### PR TITLE
OS-158 Tenant templates (part 1: specs)

### DIFF
--- a/back/engines/commercial/verification/spec/services/participation_context_service_spec.rb
+++ b/back/engines/commercial/verification/spec/services/participation_context_service_spec.rb
@@ -33,7 +33,7 @@ describe ParticipationContextService do
     it 'returns `not_permitted` when not permitted and a permitted group requires verification, while the user is verified' do
       project = create(:continuous_project)
       permission = project.permissions.find_by(action: 'posting_idea')
-      birthyear = create(:birthyear_custom_field)
+      birthyear = create(:custom_field_birthyear)
       verified_members = create(:smart_group, rules: [
         {ruleType: 'verified', predicate: 'is_verified'},
         {value: 2002, ruleType: "custom_field_number", predicate: "is_smaller_than_or_equal", customFieldId: birthyear.id}

--- a/back/spec/acceptance/ideas_spec.rb
+++ b/back/spec/acceptance/ideas_spec.rb
@@ -205,8 +205,8 @@ resource "Ideas" do
     end
 
     example "List all ideas that need feedback" do
-      TenantTemplateService.new.resolve_and_apply_template('base')
-      i = create(:idea, idea_status: IdeaStatus.find_by(code: 'proposed'))
+      proposed = create(:idea_status_proposed)
+      i = create(:idea, idea_status: proposed)
 
       do_request feedback_needed: true
       json_response = json_parse(response_body)

--- a/back/spec/acceptance/initiative_status_changes_spec.rb
+++ b/back/spec/acceptance/initiative_status_changes_spec.rb
@@ -56,10 +56,15 @@ resource "InitiativeStatusChange" do
       token = Knock::AuthToken.new(payload: { sub: @user.id }).token
       header 'Authorization', "Bearer #{token}"
 
-      TenantTemplateService.new.resolve_and_apply_template 'base', external_subfolder: false
+      @status_proposed = create(:initiative_status_proposed)
+      @status_expired = create(:initiative_status_expired)
+      @status_threshold_reached = create(:initiative_status_threshold_reached)
+      @status_answered = create(:initiative_status_answered)
+      @status_ineligible = create(:initiative_status_ineligible)
+
       create(
         :initiative_status_change, 
-        initiative: @initiative, initiative_status: InitiativeStatus.find_by(code: 'threshold_reached')
+        initiative: @initiative, initiative_status: @status_threshold_reached
         )
     end
 
@@ -76,7 +81,7 @@ resource "InitiativeStatusChange" do
       ValidationErrorHelper.new.error_fields(self, InitiativeStatusChange)
 
       let(:initiative_id) { @initiative.id }
-      let(:initiative_status_id) { InitiativeStatus.find_by(code: 'answered').id }
+      let(:initiative_status_id) { @status_answered.id }
       let(:feedback) { build(:official_feedback) }
       let(:body_multiloc) { feedback.body_multiloc }
       let(:author_multiloc) { feedback.author_multiloc }
@@ -109,7 +114,7 @@ resource "InitiativeStatusChange" do
       end
 
       describe do
-        let(:initiative_status_id) { InitiativeStatus.find_by(code: 'expired').id }
+        let(:initiative_status_id) { @status_expired.id }
 
         example_request "[error] Create a status change through an invalid transition" do
           expect(response_status).to eq 422
@@ -119,7 +124,7 @@ resource "InitiativeStatusChange" do
       end
 
       describe do
-        let(:initiative_status_id) { InitiativeStatus.find_by(code: 'threshold_reached').id }
+        let(:initiative_status_id) { @status_threshold_reached.id }
 
         example_request "[error] Create a status change to the same status" do
           expect(response_status).to eq 422
@@ -136,10 +141,15 @@ resource "InitiativeStatusChange" do
       token = Knock::AuthToken.new(payload: { sub: @user.id }).token
       header 'Authorization', "Bearer #{token}"
 
-      TenantTemplateService.new.resolve_and_apply_template 'base', external_subfolder: false
+      @status_proposed = create(:initiative_status_proposed)
+      @status_expired = create(:initiative_status_expired)
+      @status_threshold_reached = create(:initiative_status_threshold_reached)
+      @status_answered = create(:initiative_status_answered)
+      @status_ineligible = create(:initiative_status_ineligible)
+
       create(
         :initiative_status_change, 
-        initiative: @initiative, initiative_status: InitiativeStatus.find_by(code: 'threshold_reached')
+        initiative: @initiative, initiative_status: @status_threshold_reached
         )
     end
 
@@ -156,7 +166,7 @@ resource "InitiativeStatusChange" do
       ValidationErrorHelper.new.error_fields(self, InitiativeStatusChange)
 
       let(:initiative_id) { @initiative.id }
-      let(:initiative_status_id) { InitiativeStatus.find_by(code: 'answered').id }
+      let(:initiative_status_id) { @status_answered.id }
       let(:feedback) { build(:official_feedback) }
       let(:body_multiloc) { feedback.body_multiloc }
       let(:author_multiloc) { feedback.author_multiloc }

--- a/back/spec/acceptance/initiative_votes_spec.rb
+++ b/back/spec/acceptance/initiative_votes_spec.rb
@@ -11,10 +11,17 @@ resource 'Votes' do
     token = Knock::AuthToken.new(payload: @user.to_token_payload).token
     header 'Authorization', "Bearer #{token}"
     header 'Content-Type', 'application/json'
+
+    @status_proposed = create(:initiative_status_proposed)
+    @status_expired = create(:initiative_status_expired)
+    @status_threshold_reached = create(:initiative_status_threshold_reached)
+    @status_answered = create(:initiative_status_answered)
+    @status_ineligible = create(:initiative_status_ineligible)
+
     @initiative = create(:initiative)
-    TenantTemplateService.new.resolve_and_apply_template 'base', external_subfolder: false
+
     @initiative.initiative_status_changes.create!(
-      initiative_status: InitiativeStatus.find_by(code: 'proposed')
+      initiative_status: @status_proposed
     )
     @votes = create_list(:vote, 2, votable: @initiative, mode: 'up')
   end
@@ -68,7 +75,7 @@ resource 'Votes' do
 
       do_request
       expect(response_status).to eq 201
-      expect(@initiative.reload.initiative_status.code).to eq 'threshold_reached'
+      expect(@initiative.reload.initiative_status).to eq @status_threshold_reached
     end
   end
 

--- a/back/spec/acceptance/initiatives_spec.rb
+++ b/back/spec/acceptance/initiatives_spec.rb
@@ -108,8 +108,8 @@ resource "Initiatives" do
     end
 
     example "List all initiatives that need feedback" do
-      TenantTemplateService.new.resolve_and_apply_template('base')
-      i = create(:initiative, initiative_status: InitiativeStatus.find_by(code: 'threshold_reached'))
+      threshold_reached = create(:initiative_status_threshold_reached)
+      i = create(:initiative, initiative_status: threshold_reached)
 
       do_request feedback_needed: true
       json_response = json_parse(response_body)
@@ -547,10 +547,10 @@ resource "Initiatives" do
       header 'Authorization', "Bearer #{token}"
 
       @initiative = create(:initiative)
-      TenantTemplateService.new.resolve_and_apply_template 'base', external_subfolder: false
+      threshold_reached = create(:initiative_status_threshold_reached)
       create(
         :initiative_status_change, 
-        initiative: @initiative, initiative_status: InitiativeStatus.find_by(code: 'threshold_reached')
+        initiative: @initiative, initiative_status: threshold_reached
         )
     end
     let(:id) { @initiative.id }

--- a/back/spec/acceptance/stats_users_spec.rb
+++ b/back/spec/acceptance/stats_users_spec.rb
@@ -900,7 +900,12 @@ resource "Stats - Users" do
 
     before(:all) do
       Apartment::Tenant.switch!('example_org')
-      TenantTemplateService.new.resolve_and_apply_template('base', external_subfolder: false)
+
+      create(:custom_field_birthyear)
+      create(:custom_field_gender, :with_options)
+      create(:custom_field_domicile)
+      create(:custom_field_education, :with_options)
+
       CustomField.find_by(code: 'education').update(enabled: true)
     end
 

--- a/back/spec/acceptance/stats_votes_spec.rb
+++ b/back/spec/acceptance/stats_votes_spec.rb
@@ -62,7 +62,12 @@ resource "Stats - Votes" do
   context "with dependency on custom_fields" do
     before(:all) do
       Apartment::Tenant.switch!('example_org')
-      TenantTemplateService.new.resolve_and_apply_template('base', external_subfolder: false)
+
+      create(:custom_field_birthyear)
+      create(:custom_field_gender, :with_options)
+      create(:custom_field_domicile)
+      create(:custom_field_education, :with_options)
+
       CustomField.find_by(code: 'education').update(enabled: true)
     end
 

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -653,7 +653,7 @@ resource "Users" do
 
       describe do
         let(:cf) { create(:custom_field) }
-        let(:birthyear_cf) { create(:birthyear_custom_field) }
+        let(:birthyear_cf) { create(:custom_field_birthyear) }
         let(:custom_field_values) {{
           cf.key => "new value",
           birthyear_cf.key => 1969,
@@ -715,7 +715,7 @@ resource "Users" do
 
       describe do
         let(:cf) { create(:custom_field) }
-        let(:birthyear_cf) { create(:birthyear_custom_field) }
+        let(:birthyear_cf) { create(:custom_field_birthyear) }
 
         let(:custom_field_values) {{
           cf.key => "new value",

--- a/back/spec/factories/custom_fields.rb
+++ b/back/spec/factories/custom_fields.rb
@@ -63,11 +63,53 @@ FactoryBot.define do
       enabled { true }
     end
 
-    factory :birthyear_custom_field do
+    factory :custom_field_birthyear do
       key { 'birthyear' }
       title_multiloc { {en: 'birthyear' } }
       input_type { 'number' }
       code { 'birthyear' }
+    end
+
+    factory :custom_field_gender do
+      key { 'gender' }
+      title_multiloc { {'en' => 'gender'} }
+      code { 'gender' }
+      input_type { 'select' }
+
+      trait :with_options do
+        after(:create) do |cf|
+          create(:custom_field_option, custom_field: cf, key: 'male')
+          create(:custom_field_option, custom_field: cf, key: 'female')
+          create(:custom_field_option, custom_field: cf, key: 'unspecified')
+        end
+      end
+    end
+
+    factory :custom_field_domicile do
+      key { 'domicile' }
+      title_multiloc { {'en' => 'domicile'} }
+      code { 'domicile' }
+      input_type { 'select' }
+    end
+
+    factory :custom_field_education do
+      key { 'education' }
+      title_multiloc { {'en' => 'education'} }
+      code { 'education' }
+      input_type { 'select' }
+      enabled { false }
+
+      trait :with_options do
+        after(:create) do |cf|
+          create(:custom_field_option, custom_field: cf, key: '2')
+          create(:custom_field_option, custom_field: cf, key: '3')
+          create(:custom_field_option, custom_field: cf, key: '4')
+          create(:custom_field_option, custom_field: cf, key: '5')
+          create(:custom_field_option, custom_field: cf, key: '6')
+          create(:custom_field_option, custom_field: cf, key: '7')
+          create(:custom_field_option, custom_field: cf, key: '8')
+        end
+      end
     end
 
   end

--- a/back/spec/factories/idea_statuses.rb
+++ b/back/spec/factories/idea_statuses.rb
@@ -11,5 +11,15 @@ FactoryBot.define do
       "en" => "This idea has been presented to the mayor",
       "nl-BE" => "Het idee werd voorgesteld aan de burgemeester"
     }}
+
+    factory :idea_status_proposed do
+      code { 'proposed' }
+      title_multiloc { {'en' => 'proposed'} }
+    end
+
+    factory :idea_status_accepted do
+      code { 'accepted' }
+      title_multiloc { {'en' => 'accepted'} }
+    end
   end
 end

--- a/back/spec/factories/idea_statuses.rb
+++ b/back/spec/factories/idea_statuses.rb
@@ -17,9 +17,29 @@ FactoryBot.define do
       title_multiloc { {'en' => 'proposed'} }
     end
 
+    factory :idea_status_viewed do
+      code { 'viewed' }
+      title_multiloc { {'en' => 'viewed'} }
+    end
+
+    factory :idea_status_under_consideration do
+      code { 'under_consideration' }
+      title_multiloc { {'en' => 'under_consideration'} }
+    end
+
     factory :idea_status_accepted do
       code { 'accepted' }
       title_multiloc { {'en' => 'accepted'} }
+    end
+
+    factory :idea_status_rejected do
+      code { 'rejected' }
+      title_multiloc { {'en' => 'rejected'} }
+    end
+
+    factory :idea_status_implemented do
+      code { 'implemented' }
+      title_multiloc { {'en' => 'implemented'} }
     end
   end
 end

--- a/back/spec/factories/initiative_statuses.rb
+++ b/back/spec/factories/initiative_statuses.rb
@@ -11,5 +11,30 @@ FactoryBot.define do
       "en" => "This initiative has made Joke cry",
       "nl-BE" => "Het initiatief heeft Joke doen wenen"
     }}
+
+    factory :initiative_status_proposed do
+      code { 'proposed' }
+      title_multiloc { {'en' => 'proposed'} }
+    end
+
+    factory :initiative_status_expired do
+      code { 'expired' }
+      title_multiloc { {'en' => 'expired'} }
+    end
+
+    factory :initiative_status_threshold_reached do
+      code { 'threshold_reached' }
+      title_multiloc { {'en' => 'threshold_reached'} }
+    end
+
+    factory :initiative_status_answered do
+      code { 'answered' }
+      title_multiloc { {'en' => 'answered'} }
+    end
+
+    factory :initiative_status_ineligible do
+      code { 'ineligible' }
+      title_multiloc { {'en' => 'ineligible'} }
+    end
   end
 end

--- a/back/spec/factories/topics.rb
+++ b/back/spec/factories/topics.rb
@@ -9,5 +9,30 @@ FactoryBot.define do
       "nl-BE" => "<p>Hoe voelen de mensen zich?</p><p>Wat is de levensverwachting?</p>"
     }}
     icon { "medical" }
+
+    factory :topic_nature do
+      title_multiloc {{ 'en' => 'Nature' }}
+    end
+
+    factory :topic_waste do
+      title_multiloc {{ 'en' => 'Waste' }}
+    end
+
+    factory :topic_sustainability do
+      title_multiloc {{ 'en' => 'Sustainability' }}
+    end
+
+    factory :topic_mobility do
+      title_multiloc {{ 'en' => 'Mobility' }}
+    end
+
+    factory :topic_technology do
+      title_multiloc {{ 'en' => 'Technology' }}
+    end
+
+    factory :topic_economy do
+      title_multiloc {{ 'en' => 'Economy' }}
+    end
   end
+
 end

--- a/back/spec/models/idea_spec.rb
+++ b/back/spec/models/idea_spec.rb
@@ -26,12 +26,12 @@ RSpec.describe Idea, type: :model do
 
   context "feedback_needed" do
     it "should select ideas with no official feedback or no idea status change" do
-      TenantTemplateService.new.resolve_and_apply_template('base')
-      i1 = create(:idea, idea_status: IdeaStatus.find_by(code: 'proposed'))
+
+      i1 = create(:idea, idea_status: create(:idea_status_proposed))
       create(:official_feedback, post: i1)
-      i2 = create(:idea, idea_status: IdeaStatus.find_by(code: 'accepted'))
-      i3 = create(:idea, idea_status: IdeaStatus.find_by(code: 'proposed'))
-      i4 = create(:idea, idea_status: IdeaStatus.find_by(code: 'viewed'))
+      i2 = create(:idea, idea_status: create(:idea_status_accepted))
+      i3 = create(:idea, idea_status: create(:idea_status_proposed))
+      i4 = create(:idea, idea_status: create(:idea_status_viewed))
 
       expect(Idea.feedback_needed.ids).to match_array [i3.id]
     end

--- a/back/spec/models/initiative_spec.rb
+++ b/back/spec/models/initiative_spec.rb
@@ -93,20 +93,21 @@ RSpec.describe Initiative, type: :model do
 
   describe "order_status" do
     it "shows proposed initiatives first, where the ones which will soon expire are shown at the top" do
-      TenantTemplateService.new.resolve_and_apply_template 'base', external_subfolder: false
+      proposed = create(:initiative_status_proposed)
+      threshold_reached = create(:initiative_status_threshold_reached)
       i1, i2, i3 = create_list(:initiative, 3)
       i1.update! published_at: (Time.now - 3.minutes)
       create(
         :initiative_status_change, 
-        initiative: i1, initiative_status: InitiativeStatus.find_by(code: 'proposed')
+        initiative: i1, initiative_status: proposed
         )
       create(
         :initiative_status_change, 
-        initiative: i2, initiative_status: InitiativeStatus.find_by(code: 'proposed')
+        initiative: i2, initiative_status: proposed
         )
       create(
         :initiative_status_change, 
-        initiative: i3, initiative_status: InitiativeStatus.find_by(code: 'threshold_reached')
+        initiative: i3, initiative_status: threshold_reached
         )
       expect(Initiative.order_status.ids).to eq [i1.id, i2.id, i3.id]
     end

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -67,9 +67,6 @@ RSpec.describe User, type: :model do
   end
 
   describe 'password' do
-    before do
-      CommonPassword.initialize!
-    end
 
     it 'is invalid when set to empty string' do
       u = build(:user, password: '')
@@ -77,6 +74,7 @@ RSpec.describe User, type: :model do
     end
 
     it 'is invalid if its a common password' do
+      CommonPassword.initialize!
       u = build(:user, password: 'batman')
       expect(u).to be_invalid
     end
@@ -85,9 +83,7 @@ RSpec.describe User, type: :model do
       u = build(:user, password: '9x6TUuzSfkzyQrQFhxN9')
       expect(u).to be_valid
     end
-  end
 
-  describe 'password' do
     it 'is valid when longer than minimum length' do
       settings = AppConfiguration.instance.settings
       settings['password_login'] = {
@@ -271,7 +267,10 @@ RSpec.describe User, type: :model do
 
   describe "demographic fields", slow_test: true do
     before do
-      TenantTemplateService.new.resolve_and_apply_template 'base', external_subfolder: false
+      create(:custom_field_birthyear)
+      create(:custom_field_gender, :with_options)
+      create(:custom_field_domicile)
+      create(:custom_field_education, :with_options)
     end
 
     it "(gender) is valid when male, female or unspecified" do

--- a/back/spec/services/anonymize_user_service_spec.rb
+++ b/back/spec/services/anonymize_user_service_spec.rb
@@ -4,16 +4,11 @@ describe AnonymizeUserService do
   let(:service) { AnonymizeUserService.new }
 
   describe "#anonymized_attributes" do
-    before(:all) do
-      Apartment::Tenant.switch!('example_org')
-      TenantTemplateService.new.resolve_and_apply_template('base', external_subfolder: false)
-      CustomField.with_resource_type('User').find_by(code: 'education').update(enabled: true)
-    end
-
-    after(:all) do
-      Apartment::Tenant.reset
-      Tenant.find_by(host: 'example.org').destroy
-      create(:test_tenant)
+    before do
+      create(:custom_field_birthyear)
+      create(:custom_field_gender, :with_options)
+      create(:custom_field_domicile)
+      education = create(:custom_field_education, :with_options, enabled: true)
     end
 
     it "anonymizes confidential parts of the user's attributes" do 

--- a/back/spec/services/import_ideas_service_spec.rb
+++ b/back/spec/services/import_ideas_service_spec.rb
@@ -6,7 +6,13 @@ describe ImportIdeasService do
   let(:project_without_phases) { create(:project) }
 
   before do
-    TenantTemplateService.new.resolve_and_apply_template 'base', external_subfolder: false
+    create(:idea_status_proposed)
+    create(:topic_nature)
+    create(:topic_waste)
+    create(:topic_sustainability)
+    create(:topic_mobility)
+    create(:topic_technology)
+    create(:topic_economy)
     create_list(:user, 5)
   end
 
@@ -22,7 +28,7 @@ describe ImportIdeasService do
     it "aborts successfully" do
       idea_data = generate_idea_data(6)
       idea_data[3][:user_email] = 'nonexistinguser@citizenlab.co'
-      expect { service.import_ideas(idea_data) }.to raise_error
+      expect { service.import_ideas(idea_data) }.to raise_error(RuntimeError)
       expect(Idea.count).to eq(0)
     end
 

--- a/back/spec/services/initiative_status_service_spec.rb
+++ b/back/spec/services/initiative_status_service_spec.rb
@@ -17,13 +17,18 @@ describe InitiativeStatusService do
         success_stories: []
       }
       configuration.save!
-      TenantTemplateService.new.resolve_and_apply_template 'base', external_subfolder: false
+
+      @status_proposed = create(:initiative_status_proposed)
+      @status_expired = create(:initiative_status_expired)
+      @status_threshold_reached = create(:initiative_status_threshold_reached)
+      @status_answered = create(:initiative_status_answered)
+      @status_ineligible = create(:initiative_status_ineligible)
     end
 
     it "transitions when voting threshold was reached" do 
       create(
         :initiative_status_change, 
-        initiative: @initiative, initiative_status: InitiativeStatus.find_by(code: 'proposed')
+        initiative: @initiative, initiative_status: @status_proposed
         )
       create_list(:vote, 3, votable: @initiative, mode: 'up')
 
@@ -35,7 +40,7 @@ describe InitiativeStatusService do
     it "transitions when expired" do 
       create(
         :initiative_status_change, 
-        initiative: @initiative, initiative_status: InitiativeStatus.find_by(code: 'proposed')
+        initiative: @initiative, initiative_status: @status_proposed
         )
 
       travel_to (Time.now + 22.days) do
@@ -47,7 +52,7 @@ describe InitiativeStatusService do
     it "remains proposed if not expired nor threshold reached" do 
       create(
         :initiative_status_change, 
-        initiative: @initiative, initiative_status: InitiativeStatus.find_by(code: 'proposed')
+        initiative: @initiative, initiative_status: @status_proposed
         )
       create_list(:vote, 1, votable: @initiative, mode: 'up')
 
@@ -61,15 +66,19 @@ describe InitiativeStatusService do
 
   describe "transition_type" do
     before do
-      TenantTemplateService.new.resolve_and_apply_template 'base', external_subfolder: false
+      @status_proposed = create(:initiative_status_proposed)
+      @status_expired = create(:initiative_status_expired)
+      @status_threshold_reached = create(:initiative_status_threshold_reached)
+      @status_answered = create(:initiative_status_answered)
+      @status_ineligible = create(:initiative_status_ineligible)
     end
 
     it "labels the threshold_reached status as automatic" do
-      expect(service.transition_type(InitiativeStatus.find_by(code: 'threshold_reached'))).to eq 'automatic'
+      expect(service.transition_type(@status_threshold_reached)).to eq 'automatic'
     end
 
     it "labels the ineligible status as manual" do
-      expect(service.transition_type(InitiativeStatus.find_by(code: 'ineligible'))).to eq 'manual'
+      expect(service.transition_type(@status_ineligible)).to eq 'manual'
     end
   end
 end


### PR DESCRIPTION
This removes all references to TenantTemplateService from the specs, by simply replacing the required data with factories.

As a nice bonus, this causes a significant speedup, as every call added about 6s to the tests on my machine.