### PR TITLE
Moves maptiler URL to env variable

### DIFF
--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -332,7 +332,7 @@
             "description": "The OSM compatible tile provider URL pattern (https is required).",
             "type": "string",
             "pattern": "^https:\/\/.+",
-            "default": "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+            "default": "<%= ENV.fetch('DEFAULT_MAPS_TILE_PROVIDER', 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png')%>"
           },
           "map_center": {
             "title": "Map Center",

--- a/front/app/modules/commercial/custom_maps/utils/map.ts
+++ b/front/app/modules/commercial/custom_maps/utils/map.ts
@@ -52,21 +52,19 @@ export const getZoomLevel = (
   return parseInt(mapConfigZoomLevel || '16', 10);
 };
 
+const DEFAULT_MAPS_TILE_PROVIDER =
+  process.env.DEFAULT_MAPS_TILE_PROVIDER ||
+  'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+
 export const getTileProvider = (
   appConfig: IAppConfiguration | undefined | null | Error,
   mapConfig: IMapConfig
 ): string => {
   if (isUndefinedOrError(mapConfig?.attributes?.tile_provider)) {
-    return (
-      baseGetTileProvider(appConfig) ||
-      'https://api.maptiler.com/maps/77632ac6-e168-429c-8b1b-76599ce796e3/{z}/{x}/{y}@2x.png?key=DIZiuhfkZEQ5EgsaTk6D'
-    );
+    return baseGetTileProvider(appConfig) || DEFAULT_MAPS_TILE_PROVIDER;
   }
 
-  return (
-    mapConfig?.attributes?.tile_provider ||
-    'https://api.maptiler.com/maps/77632ac6-e168-429c-8b1b-76599ce796e3/{z}/{x}/{y}@2x.png?key=DIZiuhfkZEQ5EgsaTk6D'
-  );
+  return mapConfig?.attributes?.tile_provider || DEFAULT_MAPS_TILE_PROVIDER;
 };
 
 export const getLayerType = (mapLayer: IMapLayerAttributes | undefined) => {


### PR DESCRIPTION
I'm not happy with this solution but I don't understand the intended logic well enough to fix, logging the remaining issues : 
- Sometimes maptiler will be used and not credited
- Maptiler will be the default even for essential

@kogre do you add the env variable along with yours or I am too late ? 