### PR TITLE
OS-253/E2E projects index page

### DIFF
--- a/front/cypress/integration/projects_index_page.ts
+++ b/front/cypress/integration/projects_index_page.ts
@@ -1,7 +1,7 @@
 import { randomString } from '../support/commands';
 
 describe('Project overview page', () => {
-  it('show 6 project by default and load 6 more when the show more button is pressed', () => {
+  it('show 6 project by default and load more when the show more button is pressed', () => {
     cy.visit('/projects/');
     cy.get('#e2e-projects-container');
     cy.get('#e2e-projects-list');
@@ -13,6 +13,6 @@ describe('Project overview page', () => {
       'not.have.class',
       'loading'
     );
-    cy.get('.e2e-project-card').should('have.length', 12);
+    cy.get('.e2e-project-card').should('have.length.at.least', 7);
   });
 });

--- a/front/cypress/integration/projects_index_page.ts
+++ b/front/cypress/integration/projects_index_page.ts
@@ -6,13 +6,15 @@ describe('Project overview page', () => {
     cy.get('#e2e-projects-container');
     cy.get('#e2e-projects-list');
     cy.acceptCookies();
-    cy.get('.e2e-project-card').should('have.length', 6);
+    const initialCards = cy.get('.e2e-admin-publication-card');
+    initialCards.should('have.length', 6);
     cy.get('.e2e-project-cards-show-more-button').click();
     cy.wait(50);
     cy.get('.e2e-project-cards-show-more-button').should(
       'not.have.class',
       'loading'
     );
-    cy.get('.e2e-project-card').should('have.length.at.least', 7);
+    const cardsAfterShowMore = cy.get('.e2e-admin-publication-card');
+    cardsAfterShowMore.should('have.length.at.least', 7);
   });
 });


### PR DESCRIPTION
The initial test relied on the presence of only project cards, while there can also be folder cards, so used their common classname to grab cards.

Also, it tests for loading 6 cards more, while having at least 1 card more already confirms that the load more functionality works. Even better would be to not require 6 cards initially. 