### PR TITLE
OS-277 Fix reload_cl_ settings initializer on rake tasks

### DIFF
--- a/back/config/initializers/reload_cl_settings.rb
+++ b/back/config/initializers/reload_cl_settings.rb
@@ -1,34 +1,38 @@
 # Reloads the CL_SETTING_* environment variables
 # into the current app configuration.
 
-if !CitizenLab.ee? && !Rails.env.test?
-  config = AppConfiguration.instance
-  settings = config.settings
+begin
+  if !CitizenLab.ee? && !Rails.env.test? && ActiveRecord::Base.connection.table_exists?(AppConfiguration.table_name)
+    config = AppConfiguration.instance
+    settings = config.settings
 
-  config.host = ENV.fetch('CL_SETTINGS_HOST') if ENV.fetch('CL_SETTINGS_HOST', false)
-  
-  settings['core']['timezone'] = ENV.fetch('CL_SETTINGS_CORE_TIMEZONE') if ENV.fetch('CL_SETTINGS_CORE_TIMEZONE', false)
-  settings['core']['currency'] = ENV.fetch('CL_SETTINGS_CORE_CURRENCY') if ENV.fetch('CL_SETTINGS_CORE_CURRENCY', false)
-  settings['core']['reply_to_email'] = ENV.fetch('DEFAULT_FROM_EMAIL') if ENV.fetch('DEFAULT_FROM_EMAIL', false)
+    config.host = ENV.fetch('CL_SETTINGS_HOST') if ENV.fetch('CL_SETTINGS_HOST', false)
+    
+    settings['core']['timezone'] = ENV.fetch('CL_SETTINGS_CORE_TIMEZONE') if ENV.fetch('CL_SETTINGS_CORE_TIMEZONE', false)
+    settings['core']['currency'] = ENV.fetch('CL_SETTINGS_CORE_CURRENCY') if ENV.fetch('CL_SETTINGS_CORE_CURRENCY', false)
+    settings['core']['reply_to_email'] = ENV.fetch('DEFAULT_FROM_EMAIL') if ENV.fetch('DEFAULT_FROM_EMAIL', false)
 
-  settings['facebook_login']['enabled'] = (ENV.fetch('CL_SETTINGS_FACEBOOK_LOGIN_ENABLED') == 'true') if ENV.fetch('CL_SETTINGS_FACEBOOK_LOGIN_ENABLED', false)
-  settings['facebook_login']['app_id'] = ENV.fetch('CL_SETTINGS_FACEBOOK_LOGIN_APP_ID') if ENV.fetch('CL_SETTINGS_FACEBOOK_LOGIN_APP_ID', false)
-  settings['facebook_login']['app_secret'] = ENV.fetch('CL_SETTINGS_FACEBOOK_LOGIN_APP_SECRET') if ENV.fetch('CL_SETTINGS_FACEBOOK_LOGIN_APP_SECRET', false)
+    settings['facebook_login']['enabled'] = (ENV.fetch('CL_SETTINGS_FACEBOOK_LOGIN_ENABLED') == 'true') if ENV.fetch('CL_SETTINGS_FACEBOOK_LOGIN_ENABLED', false)
+    settings['facebook_login']['app_id'] = ENV.fetch('CL_SETTINGS_FACEBOOK_LOGIN_APP_ID') if ENV.fetch('CL_SETTINGS_FACEBOOK_LOGIN_APP_ID', false)
+    settings['facebook_login']['app_secret'] = ENV.fetch('CL_SETTINGS_FACEBOOK_LOGIN_APP_SECRET') if ENV.fetch('CL_SETTINGS_FACEBOOK_LOGIN_APP_SECRET', false)
 
-  settings['google_login']['enabled'] = (ENV.fetch('CL_SETTINGS_GOOGLE_LOGIN_ENABLED') == 'true') if ENV.fetch('CL_SETTINGS_GOOGLE_LOGIN_ENABLED', false)
-  settings['google_login']['client_id'] = ENV.fetch('CL_SETTINGS_GOOGLE_LOGIN_CLIENT_ID') if ENV.fetch('CL_SETTINGS_GOOGLE_LOGIN_CLIENT_ID', false)
-  settings['google_login']['client_secret'] = ENV.fetch('CL_SETTINGS_GOOGLE_LOGIN_CLIENT_SECRET') if ENV.fetch('CL_SETTINGS_GOOGLE_LOGIN_CLIENT_SECRET', false)
+    settings['google_login']['enabled'] = (ENV.fetch('CL_SETTINGS_GOOGLE_LOGIN_ENABLED') == 'true') if ENV.fetch('CL_SETTINGS_GOOGLE_LOGIN_ENABLED', false)
+    settings['google_login']['client_id'] = ENV.fetch('CL_SETTINGS_GOOGLE_LOGIN_CLIENT_ID') if ENV.fetch('CL_SETTINGS_GOOGLE_LOGIN_CLIENT_ID', false)
+    settings['google_login']['client_secret'] = ENV.fetch('CL_SETTINGS_GOOGLE_LOGIN_CLIENT_SECRET') if ENV.fetch('CL_SETTINGS_GOOGLE_LOGIN_CLIENT_SECRET', false)
 
-  settings['maps']['map_center']['lat'] = ENV.fetch('CL_SETTINGS_MAPS_MAP_CENTER_LAT') if ENV.fetch('CL_SETTINGS_MAPS_MAP_CENTER_LAT', false)
-  settings['maps']['map_center']['long'] = ENV.fetch('CL_SETTINGS_MAPS_MAP_CENTER_LONG') if ENV.fetch('CL_SETTINGS_MAPS_MAP_CENTER_LONG', false)
-  settings['maps']['zoom_level'] = ENV.fetch('CL_SETTINGS_MAPS_ZOOM_LEVEL').to_i if ENV.fetch('CL_SETTINGS_MAPS_ZOOM_LEVEL', false)
+    settings['maps']['map_center']['lat'] = ENV.fetch('CL_SETTINGS_MAPS_MAP_CENTER_LAT') if ENV.fetch('CL_SETTINGS_MAPS_MAP_CENTER_LAT', false)
+    settings['maps']['map_center']['long'] = ENV.fetch('CL_SETTINGS_MAPS_MAP_CENTER_LONG') if ENV.fetch('CL_SETTINGS_MAPS_MAP_CENTER_LONG', false)
+    settings['maps']['zoom_level'] = ENV.fetch('CL_SETTINGS_MAPS_ZOOM_LEVEL').to_i if ENV.fetch('CL_SETTINGS_MAPS_ZOOM_LEVEL', false)
 
-  begin
-    config.save!
-  rescue Exception => e
-    logger = Rails.logger
-    logger.error 'Failed to reload environment variables into the seeded data.'
-    logger.error e.message
-    e.backtrace.each { |line| logger.error line }
+    begin
+      config.save!
+    rescue Exception => e
+      logger = Rails.logger
+      logger.error 'Failed to reload environment variables into the seeded data.'
+      logger.error e.message
+      e.backtrace.each { |line| logger.error line }
+    end
   end
+rescue ActiveRecord::NoDatabaseError
+  # rescue case where initializer is executed within db:create rake task
 end


### PR DESCRIPTION
The initalizer to update the app_configuration from env variables is also executed on rake tasks, and because and table in db:create and db:migrate/load/reset is still missing, the code fails.

Reported here:
https://github.com/CitizenLabDotCo/citizenlab-docker/issues/7
