### PR TITLE
CL2-6463 - Change author name

### DIFF
--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -855,6 +855,18 @@
         }
       },
 
+      "idea_author_change": {
+        "type": "object",
+        "title": "Idea Author Change",
+        "description": "Allows city admins to create ideas and assign users as their authors.",
+        "additionalProperties": false,
+        "required": ["allowed", "enabled"],
+        "properties": {
+          "allowed": { "type": "boolean", "default": false},
+          "enabled": { "type": "boolean", "default": false}
+        }
+      },
+
       "private_projects": {
         "type": "object",
         "title": "Private projects",

--- a/front/app/components/IdeaForm/index.tsx
+++ b/front/app/components/IdeaForm/index.tsx
@@ -67,7 +67,7 @@ import { FormLabelWithIcon } from 'components/UI/FormComponents/WithIcons';
 import { media } from 'utils/styleUtils';
 import { getInputTerm } from 'services/participationContexts';
 import GetAuthUser, { GetAuthUserChildProps } from 'resources/GetAuthUser';
-import { isProjectModerator } from 'services/permissions/roles';
+import { moderatesProject } from 'services/permissions/roles';
 import { IUserData } from 'services/users';
 
 const Form = styled.form`
@@ -758,12 +758,8 @@ class IdeaForm extends PureComponent<
                 autocomplete="off"
               />
             </FormElement>
-
             {ideaAuthorChangeEnabled &&
-              isProjectModerator(
-                { data: authUser as IUserData },
-                projectId
-              ) && (
+              moderatesProject({ data: authUser as IUserData }, projectId) && (
                 <FormElement id="e2e-idea-author-input">
                   <FormLabel htmlFor="author" labelMessage={messages.author} />
                   <UserSelect

--- a/front/app/components/IdeaForm/index.tsx
+++ b/front/app/components/IdeaForm/index.tsx
@@ -765,11 +765,7 @@ class IdeaForm extends PureComponent<
                 projectId
               ) && (
                 <FormElement id="e2e-idea-author-input">
-                  <FormLabel
-                    htmlFor="author"
-                    labelMessage={messages.author}
-                    subtextSupportsHtml={true}
-                  />
+                  <FormLabel htmlFor="author" labelMessage={messages.author} />
                   <UserSelect
                     id="author"
                     inputId="author-select"

--- a/front/app/components/IdeaForm/messages.ts
+++ b/front/app/components/IdeaForm/messages.ts
@@ -117,4 +117,12 @@ export default defineMessages({
     id: 'app.components.IdeaForm.otherFilesTitle',
     defaultMessage: 'Other files',
   },
+  author: {
+    id: 'app.components.IdeaForm.author',
+    defaultMessage: 'Author',
+  },
+  authorPlaceholder: {
+    id: 'app.components.IdeaForm.authorPlaceholder',
+    defaultMessage: 'Start typing to search by user email or name...',
+  },
 });

--- a/front/app/components/UI/UserSelect/index.tsx
+++ b/front/app/components/UI/UserSelect/index.tsx
@@ -4,6 +4,7 @@ import GetUsers, { GetUsersChildProps } from 'resources/GetUsers';
 import ReactSelect, { OptionTypeBase } from 'react-select';
 import { Icon } from 'cl2-component-library';
 import selectStyles from 'components/UI/MultipleSelect/styles';
+import { Spinner } from 'cl2-component-library';
 
 import styled from 'styled-components';
 
@@ -63,6 +64,14 @@ const UserSelect = ({
     onChange(option.id);
   };
 
+  const handleInputChange = (searchTerm) => {
+    users.onChangeSearchTerm(searchTerm);
+  };
+
+  const handleMenuScrollToBottom = () => {
+    users.onLoadMore();
+  };
+
   const filterByNameAndEmail = (option: OptionTypeBase, searchText: string) => {
     if (
       option.data.attributes.first_name
@@ -108,6 +117,12 @@ const UserSelect = ({
 
   const getOptionId = (option: OptionTypeBase) => option.id;
 
+  const LoadingIndicator = (props): any => (
+    <Spinner ref={props.innerRef} {...props} />
+  );
+
+  const components = { LoadingIndicator };
+
   return (
     <ReactSelect
       id={id}
@@ -124,10 +139,14 @@ const UserSelect = ({
       getOptionValue={getOptionId}
       getOptionLabel={getOptionLabel}
       onChange={handleChange}
+      onInputChange={handleInputChange}
       isDisabled={disabled}
       menuPlacement="auto"
       styles={selectStyles}
       filterOption={filterByNameAndEmail}
+      onMenuScrollToBottom={handleMenuScrollToBottom}
+      isLoading={users.isLoading}
+      components={components}
     />
   );
 };

--- a/front/app/components/UI/UserSelect/index.tsx
+++ b/front/app/components/UI/UserSelect/index.tsx
@@ -21,8 +21,6 @@ interface Props {
   inputId: string;
 }
 
-const StyledSelect = styled(ReactSelect)``;
-
 export const AvatarImage = styled.img`
   flex: 0 0 30px;
   width: 30px;
@@ -100,7 +98,7 @@ const UserSelect = ({
     );
   };
 
-  const UserOptionLabel = ({ option }: { option: OptionTypeBase }) => (
+  const getOptionLabel = (option: OptionTypeBase) => (
     <UserOption>
       <Avatar userId={option.value} />
       {option.attributes.first_name} {option.attributes.last_name} (
@@ -108,8 +106,10 @@ const UserSelect = ({
     </UserOption>
   );
 
+  const getOptionId = (option: OptionTypeBase) => option.id;
+
   return (
-    <StyledSelect
+    <ReactSelect
       id={id}
       inputId={inputId}
       className={className}
@@ -121,8 +121,8 @@ const UserSelect = ({
       value={selectedUser}
       placeholder={placeholder as string}
       options={usersList}
-      getOptionValue={(option) => option.id}
-      getOptionLabel={(option) => <UserOptionLabel option={option} />}
+      getOptionValue={getOptionId}
+      getOptionLabel={getOptionLabel}
       onChange={handleChange}
       isDisabled={disabled}
       menuPlacement="auto"

--- a/front/app/components/UI/UserSelect/index.tsx
+++ b/front/app/components/UI/UserSelect/index.tsx
@@ -1,0 +1,141 @@
+import React, { ReactElement } from 'react';
+import { adopt } from 'react-adopt';
+import GetUsers, { GetUsersChildProps } from 'resources/GetUsers';
+import ReactSelect, { OptionTypeBase } from 'react-select';
+import { Icon } from 'cl2-component-library';
+import selectStyles from 'components/UI/MultipleSelect/styles';
+
+import styled from 'styled-components';
+
+interface DataProps {
+  users: GetUsersChildProps;
+}
+
+interface Props {
+  onChange: (id: string) => void;
+  value: string;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+  id: string;
+  inputId: string;
+}
+
+const StyledSelect = styled(ReactSelect)``;
+
+export const AvatarImage = styled.img`
+  flex: 0 0 30px;
+  width: 30px;
+  height: 30px;
+  fill: #596b7a;
+  padding: 15px;
+  border-radius: 50%;
+  background: white;
+  margin-right: 0.5rem;
+`;
+
+const AvatarIcon = styled(Icon)`
+  flex: 0 0 30px;
+  width: 30px;
+  height: 30px;
+  background: white;
+  border-radius: 50%;
+  fill: #596b7a;
+  margin-right: 0.5rem;
+`;
+
+const UserOption = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const UserSelect = ({
+  users,
+  onChange,
+  value,
+  placeholder,
+  disabled = false,
+  className,
+  id,
+  inputId,
+}: DataProps & Props): ReactElement => {
+  const usersList = Array.isArray(users.usersList) ? users.usersList : [];
+
+  const handleChange = (option: OptionTypeBase) => {
+    onChange(option.id);
+  };
+
+  const filterByNameAndEmail = (option: OptionTypeBase, searchText: string) => {
+    if (
+      option.data.attributes.first_name
+        .toLowerCase()
+        .includes(searchText.toLowerCase()) ||
+      option.data.attributes.last_name
+        .toLowerCase()
+        .includes(searchText.toLowerCase()) ||
+      option.data.attributes.email
+        .toLowerCase()
+        .includes(searchText.toLowerCase())
+    ) {
+      return true;
+    } else {
+      return false;
+    }
+  };
+
+  const selectedUser = usersList.find((user) => user.id === value);
+
+  const Avatar = ({ userId }) => {
+    const user = usersList.find((user) => user.id === userId);
+    const avatarSrc =
+      user?.attributes?.avatar?.medium || user?.attributes?.avatar?.small;
+    return (
+      <>
+        {avatarSrc ? (
+          <AvatarImage className="avatarImage" src={avatarSrc} alt="" />
+        ) : (
+          <AvatarIcon className="avatarIcon" name="user" />
+        )}
+      </>
+    );
+  };
+
+  const UserOptionLabel = ({ option }: { option: OptionTypeBase }) => (
+    <UserOption>
+      <Avatar userId={option.value} />
+      {option.attributes.first_name} {option.attributes.last_name} (
+      {option.attributes.email})
+    </UserOption>
+  );
+
+  return (
+    <StyledSelect
+      id={id}
+      inputId={inputId}
+      className={className}
+      isSearchable
+      blurInputOnSelect
+      backspaceRemovesValue={false}
+      menuShouldScrollIntoView={false}
+      isClearable={false}
+      value={selectedUser}
+      placeholder={placeholder as string}
+      options={usersList}
+      getOptionValue={(option) => option.id}
+      getOptionLabel={(option) => <UserOptionLabel option={option} />}
+      onChange={handleChange}
+      isDisabled={disabled}
+      menuPlacement="auto"
+      styles={selectStyles}
+      filterOption={filterByNameAndEmail}
+    />
+  );
+};
+
+const Data = adopt<DataProps>({
+  users: <GetUsers />,
+});
+
+export default (props) => (
+  <Data>{(dataProps) => <UserSelect {...dataProps} {...props} />}</Data>
+);

--- a/front/app/components/UI/UserSelect/index.tsx
+++ b/front/app/components/UI/UserSelect/index.tsx
@@ -2,9 +2,8 @@ import React, { ReactElement } from 'react';
 import { adopt } from 'react-adopt';
 import GetUsers, { GetUsersChildProps } from 'resources/GetUsers';
 import ReactSelect, { OptionTypeBase } from 'react-select';
-import { Icon } from 'cl2-component-library';
 import selectStyles from 'components/UI/MultipleSelect/styles';
-import { Spinner } from 'cl2-component-library';
+import { Spinner, Icon } from 'cl2-component-library';
 
 import styled from 'styled-components';
 

--- a/front/app/components/UI/UserSelect/index.tsx
+++ b/front/app/components/UI/UserSelect/index.tsx
@@ -98,7 +98,7 @@ const UserSelect = ({
     );
   };
 
-  const getOptionLabel = (option: OptionTypeBase) => (
+  const getOptionLabel = (option: OptionTypeBase): any => (
     <UserOption>
       <Avatar userId={option.value} />
       {option.attributes.first_name} {option.attributes.last_name} (

--- a/front/app/components/admin/PostManager/components/LazyPostPreview/Idea/IdeaEdit.tsx
+++ b/front/app/components/admin/PostManager/components/LazyPostPreview/Idea/IdeaEdit.tsx
@@ -171,6 +171,7 @@ class IdeaEdit extends PureComponent<Props, State> {
             descriptionMultiloc: idea.data.attributes.body_multiloc,
             address: idea.data.attributes.location_description,
             budget: idea.data.attributes.budget,
+            authorId: idea.data.relationships.author.data?.id || null,
             proposedBudget: idea.data.attributes.proposed_budget,
             imageFile: ideaImage ? [ideaImage] : [],
             imageId: ideaImage && ideaImage.id ? ideaImage.id : null,

--- a/front/app/components/admin/PostManager/components/LazyPostPreview/Idea/IdeaEdit.tsx
+++ b/front/app/components/admin/PostManager/components/LazyPostPreview/Idea/IdeaEdit.tsx
@@ -82,6 +82,7 @@ interface State {
   submitError: boolean;
   loaded: boolean;
   processing: boolean;
+  authorId: string | null;
 }
 
 class IdeaEdit extends PureComponent<Props, State> {
@@ -91,6 +92,7 @@ class IdeaEdit extends PureComponent<Props, State> {
     super(props as any);
     this.state = {
       projectId: null,
+      authorId: null,
       locale: 'en',
       titleMultiloc: null,
       descriptionMultiloc: null,
@@ -196,6 +198,7 @@ class IdeaEdit extends PureComponent<Props, State> {
       descriptionMultiloc,
       imageId,
       imageFile,
+      authorId,
       address: savedAddress,
     } = this.state;
     const {
@@ -207,6 +210,7 @@ class IdeaEdit extends PureComponent<Props, State> {
       proposedBudget,
       ideaFiles,
       ideaFilesToRemove,
+      authorId: newAuthorId,
     } = ideaFormOutput;
     const oldImageId = imageId;
     const oldImage = imageFile && imageFile.length > 0 ? imageFile[0] : null;
@@ -227,6 +231,7 @@ class IdeaEdit extends PureComponent<Props, State> {
       .filter((file) => !!(file.remote && file.id))
       .map((file) => deleteIdeaFile(ideaId, file.id as string));
 
+    const finalAuthorId = newAuthorId || authorId;
     const addressDiff = {};
     if (
       isString(ideaFormAddress) &&
@@ -251,6 +256,7 @@ class IdeaEdit extends PureComponent<Props, State> {
         [locale]: description,
       },
       topic_ids: selectedTopics,
+      author_id: finalAuthorId,
       ...addressDiff,
     });
 
@@ -289,6 +295,7 @@ class IdeaEdit extends PureComponent<Props, State> {
         processing,
         budget,
         proposedBudget,
+        authorId,
       } = this.state;
       const title = locale && titleMultiloc ? titleMultiloc[locale] || '' : '';
       const description =
@@ -315,6 +322,7 @@ class IdeaEdit extends PureComponent<Props, State> {
 
             <Content className="idea-form">
               <IdeaForm
+                authorId={authorId}
                 projectId={projectId}
                 title={title}
                 description={description}

--- a/front/app/containers/IdeasEditPage/index.tsx
+++ b/front/app/containers/IdeasEditPage/index.tsx
@@ -210,6 +210,7 @@ class IdeaEditPage extends PureComponent<Props & InjectedLocalized, State> {
             descriptionMultiloc: idea.data.attributes.body_multiloc,
             address: idea.data.attributes.location_description,
             budget: idea.data.attributes.budget,
+            authorId: idea.data.relationships.author.data?.id || null,
             proposedBudget: idea.data.attributes.proposed_budget,
             imageFile: ideaImage ? [ideaImage] : [],
             imageId: ideaImage && ideaImage.id ? ideaImage.id : null,
@@ -343,6 +344,7 @@ class IdeaEditPage extends PureComponent<Props & InjectedLocalized, State> {
           project,
           phases
         );
+        console.log(authorId);
 
         return (
           <Container id="e2e-idea-edit-page">

--- a/front/app/containers/IdeasEditPage/index.tsx
+++ b/front/app/containers/IdeasEditPage/index.tsx
@@ -344,7 +344,6 @@ class IdeaEditPage extends PureComponent<Props & InjectedLocalized, State> {
           project,
           phases
         );
-        console.log(authorId);
 
         return (
           <Container id="e2e-idea-edit-page">

--- a/front/app/containers/IdeasEditPage/index.tsx
+++ b/front/app/containers/IdeasEditPage/index.tsx
@@ -123,6 +123,7 @@ interface State {
   imageFile: UploadFile[];
   imageId: string | null;
   loaded: boolean;
+  authorId: string | null;
 }
 
 class IdeaEditPage extends PureComponent<Props & InjectedLocalized, State> {
@@ -142,6 +143,7 @@ class IdeaEditPage extends PureComponent<Props & InjectedLocalized, State> {
       imageFile: [],
       imageId: null,
       loaded: false,
+      authorId: null,
     };
     this.subscriptions = [];
   }
@@ -237,6 +239,7 @@ class IdeaEditPage extends PureComponent<Props & InjectedLocalized, State> {
       imageId,
       imageFile,
       address: savedAddress,
+      authorId,
     } = this.state;
     const {
       title,
@@ -247,6 +250,7 @@ class IdeaEditPage extends PureComponent<Props & InjectedLocalized, State> {
       proposedBudget,
       ideaFiles,
       ideaFilesToRemove,
+      authorId: newAuthorId,
     } = ideaFormOutput;
     const oldImageId = imageId;
     const oldImage = imageFile && imageFile.length > 0 ? imageFile[0] : null;
@@ -266,7 +270,7 @@ class IdeaEditPage extends PureComponent<Props & InjectedLocalized, State> {
     const filesToRemovePromises = ideaFilesToRemove
       .filter((file) => !!(file.remote && file.id))
       .map((file) => deleteIdeaFile(ideaId, file.id as string));
-
+    const finalAuthorId = newAuthorId || authorId;
     const addressDiff = {};
     if (
       isString(ideaFormAddress) &&
@@ -291,6 +295,7 @@ class IdeaEditPage extends PureComponent<Props & InjectedLocalized, State> {
         [locale]: description,
       },
       topic_ids: selectedTopics,
+      author_id: finalAuthorId,
       ...addressDiff,
     });
 
@@ -322,6 +327,7 @@ class IdeaEditPage extends PureComponent<Props & InjectedLocalized, State> {
         imageFile,
         budget,
         proposedBudget,
+        authorId,
       } = this.state;
       const title = locale && titleMultiloc ? titleMultiloc[locale] || '' : '';
       const description =
@@ -356,6 +362,7 @@ class IdeaEditPage extends PureComponent<Props & InjectedLocalized, State> {
               </Title>
 
               <IdeaForm
+                authorId={authorId}
                 projectId={projectId}
                 title={title}
                 description={description}

--- a/front/app/containers/IdeasNewPage/NewIdeaForm.tsx
+++ b/front/app/containers/IdeasNewPage/NewIdeaForm.tsx
@@ -89,6 +89,7 @@ interface GlobalState {
   submitError: boolean;
   processing: boolean;
   fileOrImageError: boolean;
+  authorId: string | null;
 }
 
 interface State extends GlobalState {}
@@ -101,6 +102,7 @@ class NewIdeaForm extends PureComponent<Props, State> {
     super(props);
     this.state = {
       title: null,
+      authorId: null,
       description: null,
       selectedTopics: [],
       budget: null,
@@ -131,6 +133,7 @@ class NewIdeaForm extends PureComponent<Props, State> {
           submitError,
           processing,
           fileOrImageError,
+          authorId,
         }) => {
           const newState: State = {
             title,
@@ -143,6 +146,7 @@ class NewIdeaForm extends PureComponent<Props, State> {
             submitError,
             processing,
             fileOrImageError,
+            authorId,
           };
 
           this.setState(newState);
@@ -165,6 +169,7 @@ class NewIdeaForm extends PureComponent<Props, State> {
       address: position,
       imageFile,
       ideaFiles,
+      authorId,
     } = ideaFormOutput;
     this.globalState.set({
       title,
@@ -175,6 +180,7 @@ class NewIdeaForm extends PureComponent<Props, State> {
       position,
       imageFile,
       ideaFiles,
+      authorId,
     });
     this.props.onSubmit();
   };
@@ -188,6 +194,7 @@ class NewIdeaForm extends PureComponent<Props, State> {
       proposedBudget,
       position,
       imageFile,
+      authorId,
     } = this.state;
     const { projectId, project, phases } = this.props;
 
@@ -214,6 +221,7 @@ class NewIdeaForm extends PureComponent<Props, State> {
           </Title>
 
           <IdeaForm
+            authorId={authorId}
             projectId={projectId}
             title={title}
             description={description}

--- a/front/app/containers/IdeasNewPage/index.tsx
+++ b/front/app/containers/IdeasNewPage/index.tsx
@@ -110,6 +110,7 @@ class IdeasNewPage extends PureComponent<Props & WithRouterProps, State> {
       imageFile: [],
       imageId: null,
       ideaFiles: [],
+      authorId: null,
     };
     this.globalState = globalState.init('IdeasNewPage', initialGlobalState);
   }
@@ -190,6 +191,7 @@ class IdeasNewPage extends PureComponent<Props & WithRouterProps, State> {
           position_coordinates,
           imageFile,
           ideaFiles,
+          authorId,
         } = await this.globalState.get();
         const ideaTitle = { [locale]: title as string };
         const ideaDescription = { [locale]: description || '' };
@@ -197,10 +199,11 @@ class IdeasNewPage extends PureComponent<Props & WithRouterProps, State> {
           position_coordinates || (await convertToGeoJson(position));
         const locationDescription =
           isString(position) && !isEmpty(position) ? position : null;
+
         const ideaObject: IIdeaAdd = {
           budget,
           proposed_budget: proposedBudget,
-          author_id: authUser.id,
+          author_id: authorId,
           publication_status: 'published',
           title_multiloc: ideaTitle,
           body_multiloc: ideaDescription,

--- a/front/app/resources/GetUsers.tsx
+++ b/front/app/resources/GetUsers.tsx
@@ -58,12 +58,15 @@ type State = {
   sortDirection: SortDirection;
   currentPage: number;
   lastPage: number;
+  loadMoreCount: number;
+  isLoading: boolean;
 };
 
 export type GetUsersChildProps = State & {
   onChangeSorting: (sortAttribute: SortAttribute) => void;
   onChangeSearchTerm: (search: string) => void;
   onChangePage: (pageNumber: number) => void;
+  onLoadMore: () => void;
 };
 
 export default class GetUsers extends React.Component<Props, State> {
@@ -89,6 +92,8 @@ export default class GetUsers extends React.Component<Props, State> {
       sortAttribute: getSortAttribute<Sort, SortAttribute>(initialSort),
       sortDirection: getSortDirection<Sort>(initialSort),
       currentPage: 1,
+      loadMoreCount: 1,
+      isLoading: false,
       lastPage: 1,
     };
   }
@@ -107,7 +112,6 @@ export default class GetUsers extends React.Component<Props, State> {
             const newPageNumber = queryParameters['page[number]'];
             queryParameters['page[number]'] =
               newPageNumber !== oldPageNumber ? newPageNumber : 1;
-
             return usersStream({
               queryParameters,
             }).observable.pipe(map((users) => ({ users, queryParameters })));
@@ -116,6 +120,7 @@ export default class GetUsers extends React.Component<Props, State> {
         .subscribe(({ users, queryParameters }) => {
           this.setState({
             queryParameters,
+            isLoading: false,
             usersList: !isNilOrError(users) ? users.data : users,
             sortAttribute: getSortAttribute<Sort, SortAttribute>(
               queryParameters.sort
@@ -196,6 +201,19 @@ export default class GetUsers extends React.Component<Props, State> {
     });
   };
 
+  handleLoadMore = () => {
+    this.setState({
+      loadMoreCount: this.state.loadMoreCount + 1,
+      isLoading: true,
+    });
+    this.queryParameters$.next({
+      ...this.state.queryParameters,
+      'page[size]':
+        this.state.queryParameters['page[size]'] *
+        (this.state.loadMoreCount + 1),
+    });
+  };
+
   render() {
     const { children } = this.props;
     return (children as children)({
@@ -203,6 +221,7 @@ export default class GetUsers extends React.Component<Props, State> {
       onChangeSorting: this.handleChangeSorting,
       onChangeSearchTerm: this.handleChangeSearchTerm,
       onChangePage: this.handleChangePage,
+      onLoadMore: this.handleLoadMore,
     });
   }
 }

--- a/front/app/services/appConfiguration.ts
+++ b/front/app/services/appConfiguration.ts
@@ -166,6 +166,7 @@ export interface IAppConfigurationSettings {
   project_management?: AppConfigurationFeature;
   idea_assignment?: AppConfigurationFeature;
   custom_idea_statuses?: AppConfigurationFeature;
+  idea_author_change?: AppConfigurationFeature;
   idea_custom_copy?: AppConfigurationFeature;
   intercom?: AppConfigurationFeature;
   satismeter?: AppConfigurationFeature & {

--- a/front/app/services/globalState.ts
+++ b/front/app/services/globalState.ts
@@ -33,6 +33,7 @@ export interface IIdeasPageGlobalState {
   imageFile: UploadFile[];
   imageId: string | null;
   ideaFiles: UploadFile[];
+  authorId: string | null;
 }
 
 export interface IAdminFullWidth {

--- a/front/app/services/permissions/roles.ts
+++ b/front/app/services/permissions/roles.ts
@@ -49,3 +49,9 @@ export const isProjectModerator = (user?: IUser | null, projectId?: string) => {
       ))
   );
 };
+
+export const moderatesProject = (user?: IUser | null, projectId?: string) => {
+  return (
+    isProjectModerator(user, projectId) || isAdmin(user) || isSuperAdmin(user)
+  );
+};

--- a/front/app/translations/ar-SA.json
+++ b/front/app/translations/ar-SA.json
@@ -129,6 +129,8 @@
   "app.components.FolderFolderCard.numberOfProjectsInFolder": "{numberOfProjectsInFolder, plural, no {# من المشاريع} one {# مشروع} other {# من المشاريع}}",
   "app.components.GoBackButton.group.edit.goBack": "العودة",
   "app.components.IdeaCards.showMore": "اعرض المزيد",
+  "app.components.IdeaForm.author": "",
+  "app.components.IdeaForm.authorPlaceholder": "",
   "app.components.IdeaForm.contributionFormGeneralSectionTitle": "ما هي مساهمتك؟",
   "app.components.IdeaForm.descriptionEmptyError": "يُرجى إضافة وصف",
   "app.components.IdeaForm.descriptionLengthError": "يجب ألّا يقل طول وصف الفكرة عن 30 حرفًا",

--- a/front/app/translations/da-DK.json
+++ b/front/app/translations/da-DK.json
@@ -129,6 +129,8 @@
   "app.components.FolderFolderCard.numberOfProjectsInFolder": "{numberOfProjectsInFolder, plural, no {# projekter} one {# projekt} other {# projekter}}",
   "app.components.GoBackButton.group.edit.goBack": "Gå tilbage",
   "app.components.IdeaCards.showMore": "Vis mere ",
+  "app.components.IdeaForm.author": "",
+  "app.components.IdeaForm.authorPlaceholder": "",
   "app.components.IdeaForm.contributionFormGeneralSectionTitle": "Hvad er dit bidrag?",
   "app.components.IdeaForm.descriptionEmptyError": "Angiv venligst en beskrivelse",
   "app.components.IdeaForm.descriptionLengthError": "Idébeskrivelsen skal fylde mindst 30 tegn",

--- a/front/app/translations/de-DE.json
+++ b/front/app/translations/de-DE.json
@@ -129,6 +129,8 @@
   "app.components.FolderFolderCard.numberOfProjectsInFolder": "{numberOfProjectsInFolder, plural, no {# Projekte} one {# Projekt} other {# Projekte}}",
   "app.components.GoBackButton.group.edit.goBack": "Zurück",
   "app.components.IdeaCards.showMore": "Zeige mehr",
+  "app.components.IdeaForm.author": "",
+  "app.components.IdeaForm.authorPlaceholder": "",
   "app.components.IdeaForm.contributionFormGeneralSectionTitle": "Welchen Beitrag leisten Sie?",
   "app.components.IdeaForm.descriptionEmptyError": "Bitte gib eine Beschreibung ein",
   "app.components.IdeaForm.descriptionLengthError": "Die Ideenbeschreibung muss mindestens 30 Zeichen lang sein",

--- a/front/app/translations/en-CA.json
+++ b/front/app/translations/en-CA.json
@@ -129,6 +129,8 @@
   "app.components.FolderFolderCard.numberOfProjectsInFolder": "{numberOfProjectsInFolder, plural, no {# projects} one {# project} other {# projects}}",
   "app.components.GoBackButton.group.edit.goBack": "Go back",
   "app.components.IdeaCards.showMore": "Show more",
+  "app.components.IdeaForm.author": "",
+  "app.components.IdeaForm.authorPlaceholder": "",
   "app.components.IdeaForm.contributionFormGeneralSectionTitle": "What is your contribution?",
   "app.components.IdeaForm.descriptionEmptyError": "Please provide a description",
   "app.components.IdeaForm.descriptionLengthError": "The idea description must be at least 30 characters long",

--- a/front/app/translations/en-GB.json
+++ b/front/app/translations/en-GB.json
@@ -129,6 +129,8 @@
   "app.components.FolderFolderCard.numberOfProjectsInFolder": "{numberOfProjectsInFolder, plural, no {# projects} one {# project} other {# projects}}",
   "app.components.GoBackButton.group.edit.goBack": "Go back",
   "app.components.IdeaCards.showMore": "Show more",
+  "app.components.IdeaForm.author": "",
+  "app.components.IdeaForm.authorPlaceholder": "",
   "app.components.IdeaForm.contributionFormGeneralSectionTitle": "What is your contribution?",
   "app.components.IdeaForm.descriptionEmptyError": "Please provide a description",
   "app.components.IdeaForm.descriptionLengthError": "The idea description must be at least 30 characters long",

--- a/front/app/translations/en.json
+++ b/front/app/translations/en.json
@@ -129,6 +129,8 @@
   "app.components.FolderFolderCard.numberOfProjectsInFolder": "{numberOfProjectsInFolder, plural, no {# projects} one {# project} other {# projects}}",
   "app.components.GoBackButton.group.edit.goBack": "Go back",
   "app.components.IdeaCards.showMore": "Show more",
+  "app.components.IdeaForm.author": "Author",
+  "app.components.IdeaForm.authorPlaceholder": "Start typing to search by user email or name...",
   "app.components.IdeaForm.contributionFormGeneralSectionTitle": "What is your contribution?",
   "app.components.IdeaForm.descriptionEmptyError": "Please provide a description",
   "app.components.IdeaForm.descriptionLengthError": "The idea description must be at least 30 characters long",

--- a/front/app/translations/es-CL.json
+++ b/front/app/translations/es-CL.json
@@ -129,6 +129,8 @@
   "app.components.FolderFolderCard.numberOfProjectsInFolder": "{numberOfProjectsInFolder, plural, no {# proyectos} one {# proyecto} other {# proyectos}}",
   "app.components.GoBackButton.group.edit.goBack": "Volver",
   "app.components.IdeaCards.showMore": "Mostrar más",
+  "app.components.IdeaForm.author": "",
+  "app.components.IdeaForm.authorPlaceholder": "",
   "app.components.IdeaForm.contributionFormGeneralSectionTitle": "¿Cuál es tu contribución?",
   "app.components.IdeaForm.descriptionEmptyError": "Por favor proporcione una descripción",
   "app.components.IdeaForm.descriptionLengthError": "La idea debe ser describida en al menos 30 caracteres de extensión",

--- a/front/app/translations/es-ES.json
+++ b/front/app/translations/es-ES.json
@@ -129,6 +129,8 @@
   "app.components.FolderFolderCard.numberOfProjectsInFolder": "{numberOfProjectsInFolder, plural, no {# proyectos} one {# proyecto} other {# proyectos}}",
   "app.components.GoBackButton.group.edit.goBack": "Volver",
   "app.components.IdeaCards.showMore": "Mostrar más",
+  "app.components.IdeaForm.author": "",
+  "app.components.IdeaForm.authorPlaceholder": "",
   "app.components.IdeaForm.contributionFormGeneralSectionTitle": "¿Cuál es tu contribución?",
   "app.components.IdeaForm.descriptionEmptyError": "Por favor proporcione una descripción",
   "app.components.IdeaForm.descriptionLengthError": "La idea debe ser describida en al menos 30 caracteres de extensión",

--- a/front/app/translations/fr-BE.json
+++ b/front/app/translations/fr-BE.json
@@ -129,6 +129,8 @@
   "app.components.FolderFolderCard.numberOfProjectsInFolder": "{numberOfProjectsInFolder, plural, no {# projets} one {# projet} other {# projets}}",
   "app.components.GoBackButton.group.edit.goBack": "Retour",
   "app.components.IdeaCards.showMore": "Afficher plus d'idées",
+  "app.components.IdeaForm.author": "",
+  "app.components.IdeaForm.authorPlaceholder": "",
   "app.components.IdeaForm.contributionFormGeneralSectionTitle": "Quelle est votre suggestion ?",
   "app.components.IdeaForm.descriptionEmptyError": "Veuillez fournir une description",
   "app.components.IdeaForm.descriptionLengthError": "La description de l’idée doit comporter au moins 30 caractères",

--- a/front/app/translations/fr-FR.json
+++ b/front/app/translations/fr-FR.json
@@ -129,6 +129,8 @@
   "app.components.FolderFolderCard.numberOfProjectsInFolder": "{numberOfProjectsInFolder, plural, no {# projets} one {# projet} other {# projets}}",
   "app.components.GoBackButton.group.edit.goBack": "Retour",
   "app.components.IdeaCards.showMore": "Afficher plus d'idées",
+  "app.components.IdeaForm.author": "",
+  "app.components.IdeaForm.authorPlaceholder": "",
   "app.components.IdeaForm.contributionFormGeneralSectionTitle": "Quelle est votre suggestion ?",
   "app.components.IdeaForm.descriptionEmptyError": "Veuillez fournir une description",
   "app.components.IdeaForm.descriptionLengthError": "La description de l’idée doit comporter au moins 30 caractères",

--- a/front/app/translations/hu-HU.json
+++ b/front/app/translations/hu-HU.json
@@ -129,6 +129,8 @@
   "app.components.FolderFolderCard.numberOfProjectsInFolder": "{numberOfProjectsInFolder, plural, no {# projects} one {# project} other {# projects}}",
   "app.components.GoBackButton.group.edit.goBack": "Go back",
   "app.components.IdeaCards.showMore": "Show more",
+  "app.components.IdeaForm.author": "",
+  "app.components.IdeaForm.authorPlaceholder": "",
   "app.components.IdeaForm.contributionFormGeneralSectionTitle": "What is your contribution?",
   "app.components.IdeaForm.descriptionEmptyError": "Please provide a description",
   "app.components.IdeaForm.descriptionLengthError": "The idea description must be at least 30 characters long",

--- a/front/app/translations/kl-GL.json
+++ b/front/app/translations/kl-GL.json
@@ -129,6 +129,8 @@
   "app.components.FolderFolderCard.numberOfProjectsInFolder": "{numberOfProjectsInFolder, plural, no {Suliassaqanngilaq} one {Suliassaq ataasiuvoq} other {Suliassat #}}",
   "app.components.GoBackButton.group.edit.goBack": "Uterit",
   "app.components.IdeaCards.showMore": "Allanik takusaqarit",
+  "app.components.IdeaForm.author": "",
+  "app.components.IdeaForm.authorPlaceholder": "",
   "app.components.IdeaForm.contributionFormGeneralSectionTitle": "Sumik ilanngussassaqarpit?",
   "app.components.IdeaForm.descriptionEmptyError": "Allaatiginnilaarit ",
   "app.components.IdeaForm.descriptionLengthError": "Isumassarsiamik allaaserinninneq minnerpaamik naqinnernik 30-nik imaqassaaq",

--- a/front/app/translations/mi.json
+++ b/front/app/translations/mi.json
@@ -129,6 +129,8 @@
   "app.components.FolderFolderCard.numberOfProjectsInFolder": "{numberOfProjectsInFolder, plural, no {# projects} one {# project} other {# projects}}",
   "app.components.GoBackButton.group.edit.goBack": "Go back",
   "app.components.IdeaCards.showMore": "Show more",
+  "app.components.IdeaForm.author": "",
+  "app.components.IdeaForm.authorPlaceholder": "",
   "app.components.IdeaForm.contributionFormGeneralSectionTitle": "What is your contribution?",
   "app.components.IdeaForm.descriptionEmptyError": "Please provide a description",
   "app.components.IdeaForm.descriptionLengthError": "The idea description must be at least 30 characters long",

--- a/front/app/translations/nb-NO.json
+++ b/front/app/translations/nb-NO.json
@@ -129,6 +129,8 @@
   "app.components.FolderFolderCard.numberOfProjectsInFolder": "{numberOfProjectsInFolder, plural, no {# projects} one {# project} other {# projects}}",
   "app.components.GoBackButton.group.edit.goBack": "Gå tilbake",
   "app.components.IdeaCards.showMore": "Vis mer",
+  "app.components.IdeaForm.author": "",
+  "app.components.IdeaForm.authorPlaceholder": "",
   "app.components.IdeaForm.contributionFormGeneralSectionTitle": "Hva er bidraget ditt?",
   "app.components.IdeaForm.descriptionEmptyError": "Legg til en beskrivelse",
   "app.components.IdeaForm.descriptionLengthError": "Beskrivelse av ideen må være minst 30 tegn. ",

--- a/front/app/translations/nl-BE.json
+++ b/front/app/translations/nl-BE.json
@@ -129,6 +129,8 @@
   "app.components.FolderFolderCard.numberOfProjectsInFolder": "{numberOfProjectsInFolder, plural, no {# projecten} one {# project} other {# projecten}}",
   "app.components.GoBackButton.group.edit.goBack": "Ga terug",
   "app.components.IdeaCards.showMore": "Toon meer",
+  "app.components.IdeaForm.author": "",
+  "app.components.IdeaForm.authorPlaceholder": "",
   "app.components.IdeaForm.contributionFormGeneralSectionTitle": "Wat is je onderwerp?",
   "app.components.IdeaForm.descriptionEmptyError": "Gelieve een beschrijving te geven",
   "app.components.IdeaForm.descriptionLengthError": "De beschrijving van het idee moet minstens 30 tekens lang zijn",

--- a/front/app/translations/nl-NL.json
+++ b/front/app/translations/nl-NL.json
@@ -129,6 +129,8 @@
   "app.components.FolderFolderCard.numberOfProjectsInFolder": "{numberOfProjectsInFolder, plural, no {# projecten} one {# project} other {# projecten}}",
   "app.components.GoBackButton.group.edit.goBack": "Ga terug",
   "app.components.IdeaCards.showMore": "Toon meer",
+  "app.components.IdeaForm.author": "",
+  "app.components.IdeaForm.authorPlaceholder": "",
   "app.components.IdeaForm.contributionFormGeneralSectionTitle": "Wat is je onderwerp?",
   "app.components.IdeaForm.descriptionEmptyError": "Gelieve een beschrijving te geven",
   "app.components.IdeaForm.descriptionLengthError": "De beschrijving van het idee moet minstens 30 tekens lang zijn",

--- a/front/app/translations/pl-PL.json
+++ b/front/app/translations/pl-PL.json
@@ -129,6 +129,8 @@
   "app.components.FolderFolderCard.numberOfProjectsInFolder": "{numberOfProjectsInFolder, plural, one {# projekt} few {# projekty} many {# projektów} other {# projekty}}",
   "app.components.GoBackButton.group.edit.goBack": "Wróć",
   "app.components.IdeaCards.showMore": "Pokaż więcej",
+  "app.components.IdeaForm.author": "",
+  "app.components.IdeaForm.authorPlaceholder": "",
   "app.components.IdeaForm.contributionFormGeneralSectionTitle": "Jaki jest twój wkład?",
   "app.components.IdeaForm.descriptionEmptyError": "Proszę dodać opis",
   "app.components.IdeaForm.descriptionLengthError": "Opis pomysłu musi składać się z co najmniej 30 znaków",

--- a/front/app/translations/pt-BR.json
+++ b/front/app/translations/pt-BR.json
@@ -129,6 +129,8 @@
   "app.components.FolderFolderCard.numberOfProjectsInFolder": "{numberOfProjectsInFolder, plural, no {# projetos} one {# projeto} other {# projetos}}",
   "app.components.GoBackButton.group.edit.goBack": "Voltar",
   "app.components.IdeaCards.showMore": "Mostrar mais",
+  "app.components.IdeaForm.author": "",
+  "app.components.IdeaForm.authorPlaceholder": "",
   "app.components.IdeaForm.contributionFormGeneralSectionTitle": "Qual é a sua contribuição?",
   "app.components.IdeaForm.descriptionEmptyError": "Por favor, forneça uma descrição",
   "app.components.IdeaForm.descriptionLengthError": "A descrição da ideia deve ter pelo menos 30 caracteres",

--- a/front/app/translations/ro-RO.json
+++ b/front/app/translations/ro-RO.json
@@ -129,6 +129,8 @@
   "app.components.FolderFolderCard.numberOfProjectsInFolder": "{numberOfProjectsInFolder, plural, no {# proiecte} one {# proiect} other {# proiecte}}",
   "app.components.GoBackButton.group.edit.goBack": "Întoarce-te",
   "app.components.IdeaCards.showMore": "Afișați mai multe",
+  "app.components.IdeaForm.author": "",
+  "app.components.IdeaForm.authorPlaceholder": "",
   "app.components.IdeaForm.contributionFormGeneralSectionTitle": "Care este contribuția ta?",
   "app.components.IdeaForm.descriptionEmptyError": "Vă rugăm să furnizați o descriere",
   "app.components.IdeaForm.descriptionLengthError": "Descrierea ideii trebuie să fie de cel puțin 30 de caractere",

--- a/front/app/translations/sr-Latn.json
+++ b/front/app/translations/sr-Latn.json
@@ -129,6 +129,8 @@
   "app.components.FolderFolderCard.numberOfProjectsInFolder": "{numberOfProjectsInFolder, plural, no {# projects} one {# project} other {# projects}}",
   "app.components.GoBackButton.group.edit.goBack": "Povratak nazad",
   "app.components.IdeaCards.showMore": "Prikaži više",
+  "app.components.IdeaForm.author": "",
+  "app.components.IdeaForm.authorPlaceholder": "",
   "app.components.IdeaForm.contributionFormGeneralSectionTitle": "Šta je to čime ćete doprineti?",
   "app.components.IdeaForm.descriptionEmptyError": "Molimo vas da unesete opis",
   "app.components.IdeaForm.descriptionLengthError": "Opis ideje mora sadržati najmanje 30 karaktera",


### PR DESCRIPTION
This Pull Request allows cities to create ideas for users. This is a very frequently requested ticket in S&S and adding this feature will reduce our workload there for a few hours a month.

You can find a demo of the feature in this confluence page: https://citizenlab.atlassian.net/wiki/spaces/CL2/pages/11632682/Implementation


### Front-End Changes
- Adds a `UserSelect` component based on `react-select`.
- Adds this input to the `NewIdeaForm` and `EditIdeaForm`, this input is only shown when the feature is enabled and if the user can moderate the project the idea is being dropped on.