### PR TITLE
OS-280 Dont fail on seeding essential wo app_configuration

### DIFF
--- a/back/app/models/common_password.rb
+++ b/back/app/models/common_password.rb
@@ -4,7 +4,7 @@ class CommonPassword < ApplicationRecord
 
 
   def self.initialize!
-    CommonPassword.destroy_all
+    CommonPassword.delete_all
     pwds = open(COMMON_PASSWORDS_FILE).readlines.map do |password|
       CommonPassword.new password: password.strip
     end

--- a/back/config/initializers/reload_cl_settings.rb
+++ b/back/config/initializers/reload_cl_settings.rb
@@ -35,4 +35,6 @@ begin
   end
 rescue ActiveRecord::NoDatabaseError
   # rescue case where initializer is executed within db:create rake task
+rescue ActiveRecord::RecordNotFound
+  # rescue case where app_configuration doesn't exist yet in db:seed rake task
 end


### PR DESCRIPTION
`reload_cl_settings` initializer assumes an app_configuration record already exists, which is not always the case. db:seed succeeds when it is executed together with db:migrate, as in that case the initializer is only executed once at the start, but not when it runs in isolation.

Also, the seeding is very slow because of the destroy_all on the CommonPassword table. The `delete_all` solves this.