### PR TITLE
[CL2-6407] remove isSuperAdmin check to test feature in production

### DIFF
--- a/front/app/modules/commercial/intercom/index.ts
+++ b/front/app/modules/commercial/intercom/index.ts
@@ -14,7 +14,7 @@ import {
   IDestinationConfig,
   registerDestination,
 } from 'components/ConsentManager/destinations';
-import { isAdmin, isModerator, isSuperAdmin } from 'services/permissions/roles';
+import { isAdmin, isModerator } from 'services/permissions/roles';
 import { ModuleConfiguration } from 'utils/moduleUtils';
 
 export const INTERCOM_APP_ID = process.env.INTERCOM_APP_ID;
@@ -30,9 +30,7 @@ const destinationConfig: IDestinationConfig = {
   category: 'functional',
   feature_flag: 'intercom',
   hasPermission: (user) =>
-    !!user &&
-    (isAdmin({ data: user }) || isModerator({ data: user })) &&
-    !isSuperAdmin({ data: user }),
+    !!user && (isAdmin({ data: user }) || isModerator({ data: user })),
   name: () => 'Intercom',
 };
 


### PR DESCRIPTION
I tested this locally, and everything seems to be working perfectly fine as it was. 

This change doesn't really do much but alert us (citizenlab admins) when intercom is not available for our users.