### PR TITLE
Makes google maps key optional

### DIFF
--- a/front/app/containers/App/constants.js
+++ b/front/app/containers/App/constants.js
@@ -3,7 +3,7 @@ exports.__esModule = true;
 exports.appLocalesMomentPairs = exports.shortenedAppLocalePairs = exports.appGraphqlLocalePairs = exports.appLocalePairs = exports.graphqlLocales = exports.locales = exports.DEFAULT_LOCALE = exports.GRAPHQL_PORT = exports.GRAPHQL_HOST = exports.API_PORT = exports.API_HOST = exports.GOOGLE_MAPS_API_KEY = exports.API_PATH = exports.AUTH_PATH = void 0;
 exports.AUTH_PATH = '/auth';
 exports.API_PATH = '/web_api/v1';
-exports.GOOGLE_MAPS_API_KEY = process.env.GOOGLE_MAPS_API_KEY;
+exports.GOOGLE_MAPS_API_KEY = process.env.GOOGLE_MAPS_API_KEY || '';
 exports.API_HOST =
   process.env.API_HOST ||
   (typeof window === 'undefined' ? 'localhost' : window.location.hostname);

--- a/front/app/containers/App/constants.ts
+++ b/front/app/containers/App/constants.ts
@@ -1,6 +1,6 @@
 export const AUTH_PATH = '/auth';
 export const API_PATH = '/web_api/v1';
-export const GOOGLE_MAPS_API_KEY = process.env.GOOGLE_MAPS_API_KEY;
+export const GOOGLE_MAPS_API_KEY = process.env.GOOGLE_MAPS_API_KEY || '';
 export const API_HOST =
   process.env.API_HOST ||
   (typeof window === 'undefined' ? 'localhost' : window.location.hostname);

--- a/front/internals/webpack/webpack.config.js
+++ b/front/internals/webpack/webpack.config.js
@@ -129,9 +129,6 @@ const config = {
 
   plugins: [
     new webpack.DefinePlugin({
-            "process.env": dotenv.parsed
-        }),
-    new webpack.DefinePlugin({
       'process.env': {
         NODE_ENV: JSON.stringify(process.env.NODE_ENV),
         API_HOST: JSON.stringify(process.env.API_HOST),


### PR DESCRIPTION
The small change in webpack is about removing a redundancy, otherwise this PR just gives a fallback to GOOGLE_MAPS_API_KEY, can you try pulling this on your local and see it fixes it ? Instructions for running slightly changed too, you can use docker-compose build for the back-end instead of the service ports, but you should set API_HOST=localhost in your .env-front. 