### PR TITLE
CL2-6503 Norwegian broken

### DIFF
--- a/back/config/locales/nb-NO.yml
+++ b/back/config/locales/nb-NO.yml
@@ -1,4 +1,4 @@
-"no":
+nb:
   symbols:
     outside: annet sted
   idea_statuses:


### PR DESCRIPTION
This fixes the issue where I18n couldn't load the Norwegian translations from the YML file.

Possibly we also need to fix the multilocs for tenants that were created since the introduction of this issue?