### PR TITLE
IN-382 Add pagination and search to view inputs

### DIFF
--- a/back/app/models/idea.rb
+++ b/back/app/models/idea.rb
@@ -142,6 +142,7 @@ class Idea < ApplicationRecord
   end
 end
 
+Idea.include_if_ee 'Insights::Concerns::Input'
 Idea.include_if_ee 'Moderation::Concerns::Moderatable'
 Idea.include_if_ee 'MachineTranslations::Concerns::Translatable'
 Idea.include_if_ee 'IdeaAssignment::Extensions::Idea'

--- a/back/engines/commercial/insights/app/controllers/insights/web_api/v1/category_suggestions_controller.rb
+++ b/back/engines/commercial/insights/app/controllers/insights/web_api/v1/category_suggestions_controller.rb
@@ -6,7 +6,6 @@ module Insights
       skip_after_action :verify_policy_scoped, only: :index # The view is authorized instead.
 
       def index
-        require 'pry' ; binding.pry
         render json: serialize_suggestions(input), status: :ok
       end
 

--- a/back/engines/commercial/insights/app/controllers/insights/web_api/v1/inputs_controller.rb
+++ b/back/engines/commercial/insights/app/controllers/insights/web_api/v1/inputs_controller.rb
@@ -18,7 +18,7 @@ module Insights
       private
 
       def index_params
-        params.permit(
+        @index_params ||= params.permit(
           :search,
           page: %i[number size]
         )

--- a/back/engines/commercial/insights/app/controllers/insights/web_api/v1/inputs_controller.rb
+++ b/back/engines/commercial/insights/app/controllers/insights/web_api/v1/inputs_controller.rb
@@ -20,6 +20,7 @@ module Insights
       def index_params
         @index_params ||= params.permit(
           :search,
+          :category,
           page: %i[number size]
         )
       end

--- a/back/engines/commercial/insights/app/controllers/insights/web_api/v1/inputs_controller.rb
+++ b/back/engines/commercial/insights/app/controllers/insights/web_api/v1/inputs_controller.rb
@@ -3,16 +3,26 @@
 module Insights
   module WebApi::V1
     class InputsController < ::ApplicationController
+      skip_after_action :verify_policy_scoped, only: :index # The view is authorized instead.
 
       def show
         render json: serialize(input), status: :ok
       end
 
       def index
+        # index is not policy scoped, instead the view is authorized.
+        inputs = Insights::InputsFinder.new(view, index_params).execute
         render json: serialize(inputs)
       end
 
       private
+
+      def index_params
+        params.permit(
+          :search,
+          page: %i[number size]
+        )
+      end
 
       def assignment_service
         @assignment_service ||= Insights::CategoryAssignmentsService.new
@@ -26,12 +36,10 @@ module Insights
         )
       end
 
-      def inputs
-        @inputs ||= policy_scope(view.scope.ideas)
-      end
-
       def input
-        @input ||= inputs.find(params.require(:id))
+        @input ||= authorize(
+          view.scope.ideas.find(params.require(:id))
+        )
       end
 
       def serialize(inputs)

--- a/back/engines/commercial/insights/app/finders/insights/inputs_finder.rb
+++ b/back/engines/commercial/insights/app/finders/insights/inputs_finder.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Insights
+  class InputsFinder
+
+    MAX_PER_PAGE = 100
+
+    attr_reader :view, :params
+
+    def initialize(view, params = {})
+      @view = view
+      @params = params
+    end
+
+    def execute
+      inputs = view.scope.ideas
+      inputs = search(inputs)
+      paginate(inputs)
+    end
+
+    def search(inputs)
+      return inputs unless (search = params[:search])
+
+      inputs.search_by_all(search)
+    end
+
+    def paginate(inputs)
+      inputs.page(page).per(per_page)
+    end
+
+    def per_page
+      return MAX_PER_PAGE unless params[:per_page]
+
+      [params.dig(:page, :size), MAX_PER_PAGE].min
+    end
+
+    def page
+      params.dig(:page, :number) || 1
+    end
+  end
+end

--- a/back/engines/commercial/insights/app/finders/insights/inputs_finder.rb
+++ b/back/engines/commercial/insights/app/finders/insights/inputs_finder.rb
@@ -24,8 +24,9 @@ module Insights
     # or +''+.
     # @raise [ActiveRecord::RecordNotFound]
     def filter_category(inputs)
-      return inputs unless (category_id = params[:category])
+      return inputs unless params.key?(:category)
 
+      category_id = params[:category]
       category_id = category_id == '' ? nil : category_id
 
       # raise error if the category does not exist

--- a/back/engines/commercial/insights/app/finders/insights/inputs_finder.rb
+++ b/back/engines/commercial/insights/app/finders/insights/inputs_finder.rb
@@ -29,13 +29,13 @@ module Insights
     end
 
     def per_page
-      return MAX_PER_PAGE unless params[:per_page]
+      return MAX_PER_PAGE unless (size = params.dig(:page, :size))
 
-      [params.dig(:page, :size), MAX_PER_PAGE].min
+      [size.to_i, MAX_PER_PAGE].min
     end
 
     def page
-      params.dig(:page, :number) || 1
+      params.dig(:page, :number).to_i || 1
     end
   end
 end

--- a/back/engines/commercial/insights/app/finders/insights/inputs_finder.rb
+++ b/back/engines/commercial/insights/app/finders/insights/inputs_finder.rb
@@ -14,8 +14,25 @@ module Insights
 
     def execute
       inputs = view.scope.ideas
+      inputs = filter_category(inputs)
       inputs = search(inputs)
       paginate(inputs)
+    end
+
+    # Takes into account, both, actual and suggested categories.
+    # Keep only inputs without categories if +params[:category]+ is +nil+ 
+    # or +''+.
+    # @raise [ActiveRecord::RecordNotFound]
+    def filter_category(inputs)
+      return inputs unless (category_id = params[:category])
+
+      category_id = category_id == '' ? nil : category_id
+
+      # raise error if the category does not exist
+      view.categories.find(category_id) if category_id
+
+      inputs.left_outer_joins(:insights_category_assignments)
+            .where(insights_category_assignments: { category_id: category_id })
     end
 
     def search(inputs)

--- a/back/engines/commercial/insights/app/models/insights/concerns/input.rb
+++ b/back/engines/commercial/insights/app/models/insights/concerns/input.rb
@@ -8,7 +8,7 @@ module Insights
           has_many(
             :insights_category_assignments,
             class_name: 'Insights::CategoryAssignment',
-            foreign_key: 'input',
+            as: :input,  # polymorphic *association*
             dependent: :destroy
           )
         end

--- a/back/engines/commercial/insights/app/models/insights/concerns/input.rb
+++ b/back/engines/commercial/insights/app/models/insights/concerns/input.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Insights
+  module Concerns
+    module Input
+      def self.included(base)
+        base.class_eval do
+          has_many(
+            :insights_category_assignments,
+            class_name: 'Insights::CategoryAssignment',
+            foreign_key: 'input',
+            dependent: :destroy
+          )
+        end
+      end
+    end
+  end
+end

--- a/back/engines/commercial/insights/spec/lib/finders/insights/inputs_finder_spec.rb
+++ b/back/engines/commercial/insights/spec/lib/finders/insights/inputs_finder_spec.rb
@@ -15,7 +15,7 @@ describe Insights::InputsFinder do
       end
     end
 
-    context 'when view scope has not input' do
+    context 'when view scope has no input' do
       it 'returns 0 input' do
         finder = described_class.new(create(:view))
         expect(finder.execute.count).to eq(0)

--- a/back/engines/commercial/insights/spec/lib/finders/insights/inputs_finder_spec.rb
+++ b/back/engines/commercial/insights/spec/lib/finders/insights/inputs_finder_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Insights::InputsFinder do
+  describe '#execute' do
+    let(:view) { create(:view) }
+    let!(:inputs) { create_list(:idea, 5, project: view.scope) }
+
+    context 'without params' do
+      let(:finder) { described_class.new(view) }
+
+      it 'returns all inputs' do
+        expect(finder.execute).to match(inputs)
+      end
+    end
+
+    context 'when view scope has not input' do
+      it 'returns 0 input' do
+        finder = described_class.new(create(:view))
+        expect(finder.execute.count).to eq(0)
+      end
+    end
+
+    context 'when page size is smaller than the nb of inputs' do
+      it 'trims inputs on the first page' do
+        page_size = 3
+        params = { page: { size: page_size, number: 1 } }
+        finder = described_class.new(view, params)
+        expect(finder.execute.count).to eq(page_size)
+      end
+
+      it 'returns the rest on the last page' do
+        page_size = 3
+        params = { page: { size: 3, number: 2 } }
+        finder = described_class.new(view, params)
+        expect(finder.execute.count).to eq(inputs.count % page_size)
+      end
+    end
+
+    it 'supports text search' do
+      idea = create(:idea, title_multiloc: { en: 'Peace in the world ☮' }, project: view.scope)
+      params = { search: 'peace' }
+      finder = described_class.new(view, params)
+      expect(finder.execute).to match([idea])
+    end
+  end
+
+  describe '#per_page' do
+    subject(:finder) { described_class.new(nil, params) }
+
+    let(:params) { {} }
+
+    context 'when page size is above the limit' do
+      let(:params) do
+        { page: { size: 2 * described_class::MAX_PER_PAGE } }
+      end
+
+      it { expect(finder.per_page).to eq(described_class::MAX_PER_PAGE) }
+    end
+
+    context 'when page size is a string' do
+      let(:params) { { page: { size: '20' } } }
+
+      it 'converts it to an integer' do
+        expect(finder.per_page).to eq(20)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a query parameters to `GET ...views/:view_id/inputs`:

- for pagination (page>size & page>number)
- for full-text search
- to select a single category (or inputs without category)

It also fixes the dependency between ideas and idea-assignment. Assignments associated with an input get deleted when the input is deleted.