### PR TITLE
CL2-6527 Corrected facebook idea scraping URL

### DIFF
--- a/back/app/services/side_fx_idea_service.rb
+++ b/back/app/services/side_fx_idea_service.rb
@@ -94,7 +94,7 @@ class SideFxIdeaService
 
   def scrape_facebook(idea)
     url = Frontend::UrlService.new.model_to_url(idea)
-    url_with_utm = "#{url}??utm_source=share_idea&utm_campaign=share_content&utm_medium=facebook"
+    url_with_utm = "#{url}?utm_source=share_idea&utm_campaign=share_content&utm_medium=facebook"
     Seo::ScrapeFacebookJob.perform_later(url_with_utm)
   end
 end

--- a/back/app/services/side_fx_idea_service.rb
+++ b/back/app/services/side_fx_idea_service.rb
@@ -94,7 +94,8 @@ class SideFxIdeaService
 
   def scrape_facebook(idea)
     url = Frontend::UrlService.new.model_to_url(idea)
-    Seo::ScrapeFacebookJob.perform_later(url)
+    url_with_utm = "#{url}??utm_source=share_idea&utm_campaign=share_content&utm_medium=facebook"
+    Seo::ScrapeFacebookJob.perform_later(url_with_utm)
   end
 end
 

--- a/back/engines/free/seo/app/services/seo/facebook_handler.rb
+++ b/back/engines/free/seo/app/services/seo/facebook_handler.rb
@@ -4,15 +4,24 @@ module Seo
   class FacebookHandler
     attr_reader :access_token
 
-    def initialize(app_id, app_secret)
-      oauth = ::Koala::Facebook::OAuth.new(app_id, app_secret)
-      @access_token = oauth.get_app_access_token
+    def initialize(app_id, app_secret, access_token: nil)
+      if access_token
+        @access_token = access_token
+      else
+        oauth = ::Koala::Facebook::OAuth.new(app_id, app_secret)
+        @access_token = oauth.get_app_access_token
+      end
     end
 
     def scrape(url)
       return unless access_token
 
-      ::HTTParty.post("https://graph.facebook.com?id=#{url}&scrape=true&access_token=#{access_token}")
+      ::HTTParty.post('https://graph.facebook.com',
+                      query: {
+                        'id' => ERB::Util.url_encode(url),
+                        'scrape' => true,
+                        'access_token' => access_token
+                      })
     end
   end
 end

--- a/back/engines/free/seo/spec/services/seo/facebook_handler_spec.rb
+++ b/back/engines/free/seo/spec/services/seo/facebook_handler_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe Seo::FacebookHandler do
+  let(:app_id) { 'fake_app_id' }
+  let(:app_secret) { 'fake_secret' }
+  let(:access_token) { 'fake_access_token' }
+  let(:service) { described_class.new(app_id, app_secret, access_token: access_token) }
+
+  describe '#scrape' do
+    it 'URL encodes the passed url in the API request' do
+      stub_request(
+        :post,
+        'https://graph.facebook.com'
+      )
+        .with(query: hash_including({ 'id' => 'https%3A%2F%2Fsome.platform%2Fsome-page%3Fwith%3Dparams' }))
+        .to_return(status: 200)
+
+      service.scrape('https://some.platform/some-page?with=params')
+    end
+  end
+end

--- a/back/spec/spec_helper.rb
+++ b/back/spec/spec_helper.rb
@@ -9,7 +9,7 @@ require 'simplecov'
 require 'simplecov-rcov'
 require 'webmock/rspec'
 
-WebMock.allow_net_connect!
+# WebMock.allow_net_connect!
 
 SimpleCov.formatters = [
   SimpleCov::Formatter::HTMLFormatter,

--- a/back/spec/spec_helper.rb
+++ b/back/spec/spec_helper.rb
@@ -9,7 +9,7 @@ require 'simplecov'
 require 'simplecov-rcov'
 require 'webmock/rspec'
 
-# WebMock.allow_net_connect!
+WebMock.allow_net_connect!
 
 SimpleCov.formatters = [
   SimpleCov::Formatter::HTMLFormatter,


### PR DESCRIPTION
It seems that at some point we started adding utm_tags to the URL we use for facebook sharing in the front-end.

Instead of 
```
https://some.url
```
we share
```
https://some.url?utm_source=share_idea&utm_campaign=share_content&utm_medium=facebook
```
for better analytics.

As we were still telling facebook to scrape the idea page without the url parameters, it always had to re-scrape at the moment someone wants to share, causing the longer delay. This should fix it.