### PR TITLE
IN-406 Sorting (view) inputs by approval status

### DIFF
--- a/back/engines/commercial/insights/app/controllers/insights/web_api/v1/inputs_controller.rb
+++ b/back/engines/commercial/insights/app/controllers/insights/web_api/v1/inputs_controller.rb
@@ -19,8 +19,9 @@ module Insights
 
       def index_params
         @index_params ||= params.permit(
-          :search,
           :category,
+          :search,
+          :sort,
           page: %i[number size]
         )
       end

--- a/back/engines/commercial/insights/app/finders/insights/inputs_finder.rb
+++ b/back/engines/commercial/insights/app/finders/insights/inputs_finder.rb
@@ -15,6 +15,7 @@ module Insights
     def execute
       inputs = view.scope.ideas
       inputs = filter_category(inputs)
+      inputs = sort_by_approval(inputs)
       inputs = search(inputs)
       paginate(inputs)
     end
@@ -34,6 +35,14 @@ module Insights
 
       inputs.left_outer_joins(:insights_category_assignments)
             .where(insights_category_assignments: { category_id: category_id })
+    end
+
+    def sort_by_approval(inputs)
+      return inputs if params[:category].blank?
+      return inputs unless %w[approval -approval].include?(params[:sort])
+
+      order = params[:sort].start_with?('-') ? :asc : :desc
+      inputs.order('insights_category_assignments.approved': order)
     end
 
     def search(inputs)

--- a/back/engines/commercial/insights/app/models/insights/concerns/input.rb
+++ b/back/engines/commercial/insights/app/models/insights/concerns/input.rb
@@ -13,6 +13,10 @@ module Insights
           )
         end
       end
+
+      def assignments(view)
+        insights_category_assignments.where(view: view)
+      end
     end
   end
 end

--- a/back/engines/commercial/insights/spec/lib/finders/insights/inputs_finder_spec.rb
+++ b/back/engines/commercial/insights/spec/lib/finders/insights/inputs_finder_spec.rb
@@ -10,10 +10,11 @@ describe Insights::InputsFinder do
     end
 
     let(:view) { create(:view) }
-    let!(:inputs) { create_list(:idea, 5, project: view.scope) }
 
     context 'without params' do
       let(:finder) { described_class.new(view) }
+      let!(:inputs) { create_list(:idea, 2, project: view.scope) }
+
 
       it 'returns all inputs' do
         expect(finder.execute).to match(inputs)
@@ -28,6 +29,8 @@ describe Insights::InputsFinder do
     end
 
     context 'when page size is smaller than the nb of inputs' do
+      let!(:inputs) { create_list(:idea, 5, project: view.scope) }
+
       it 'trims inputs on the first page' do
         page_size = 3
         params = { page: { size: page_size, number: 1 } }
@@ -45,6 +48,8 @@ describe Insights::InputsFinder do
 
     context 'when using the category filter' do
       let(:category) { create(:category, view: view) }
+      let!(:inputs) { create_list(:idea, 3, project: view.scope) }
+
 
       before do
         inputs.take(2).each do |input|
@@ -77,6 +82,8 @@ describe Insights::InputsFinder do
 
     context 'when sorting by approval status' do
       let(:category) { create(:category, view: view) }
+      let!(:inputs) { create_list(:idea, 3, project: view.scope) }
+
 
       before do
         inputs = view.scope.ideas
@@ -99,7 +106,7 @@ describe Insights::InputsFinder do
         inputs = finder.execute
 
         aggregate_failures('checking results') do
-          expect(inputs.count).to eq(5)
+          expect(inputs.count).to eq(3)
           expect(inputs.first.insights_category_assignments.first).not_to be_approved
         end
       end
@@ -107,6 +114,7 @@ describe Insights::InputsFinder do
 
     context 'when sorting by approval status (desc)' do
       let(:category) { create(:category, view: view) }
+      let!(:inputs) { create_list(:idea, 3, project: view.scope) }
 
       before do
         inputs = view.scope.ideas
@@ -127,8 +135,9 @@ describe Insights::InputsFinder do
 
     it 'supports text search' do
       idea = create(:idea, title_multiloc: { en: 'Peace in the world ☮' }, project: view.scope)
-      params = { search: 'peace' }
-      finder = described_class.new(view, params)
+      _just_another_idea = create(:idea, project: view.scope) # to have a least two inputs
+
+      finder = described_class.new(view, { search: 'peace' })
       expect(finder.execute).to match([idea])
     end
   end


### PR DESCRIPTION
IN-406

Allows to sort inputs by approval status for a given category. 
The sort parameter is ignored if the category filter is not used.