### PR TITLE
CL2-6532 Memoize user custom fields schema in invites service

### DIFF
--- a/back/app/services/invites_service.rb
+++ b/back/app/services/invites_service.rb
@@ -59,7 +59,6 @@ class InvitesService
 
   def initialize
     @errors = []
-    @custom_field_schema = CustomFieldService.new.fields_to_json_schema(CustomField.with_resource_type('User'))
   end
 
   def generate_token
@@ -121,16 +120,20 @@ class InvitesService
 
   private
 
+  def custom_field_schema
+    @custom_field_schema ||= CustomFieldService.new.fields_to_json_schema(CustomField.with_resource_type('User'))
+  end
+
   # Returns type information of custom fields.
   #
   # @return [Hash<String, String>] Mapping from field key to field type
   def custom_field_types
-    @custom_field_schema[:properties].transform_values do |field_schema| field_schema[:type] end
+    custom_field_schema[:properties].transform_values do |field_schema| field_schema[:type] end
   end
 
   # @return [Array<String>]
   def custom_field_keys
-    @custom_field_schema[:properties].keys
+    custom_field_schema[:properties].keys
   end
 
   def postprocess_xlsx_hash_array hash_array

--- a/front/docs/README.md
+++ b/front/docs/README.md
@@ -2,6 +2,11 @@
 
 ## Next Release
 
+## 2021-06-10
+
+### Fixed
+- Creating invites on a platform with many heavy custom registration fields is no longer unworkably slow
+
 ## 2021-06-09
 
 ### Added


### PR DESCRIPTION
Creating invites generates the json schema for the user custom fields indirectly in it's internal iteration loop, through a new instantion of the service in the `Invite` class. If there are a lot of registration fields, or there are a lot of options within, generating that schema can be very slow and grind the invites service almost to a halt.

This memoizes the schema lazily, instead of generating it at initialize.