### PR TITLE
[CL2-6361] Inconsistent data - Assignee cannot moderate idea

### DIFF
--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -169,6 +169,10 @@ class User < ApplicationRecord
   scope :project_moderator, ->(_project_id = nil) { User.none }
   scope :not_project_moderator, -> { User.all }
 
+  def self.oldest_admin
+    active.admin.order(:created_at).reject(&:super_admin?).first
+  end
+
   def assign_email_or_phone
     # Hack to embed phone numbers in email
     email_or_embedded_phone = PhoneService.new.emailize_email_or_phone(email)

--- a/back/engines/commercial/idea_assignment/app/services/idea_assignment/patches/side_fx_project_service.rb
+++ b/back/engines/commercial/idea_assignment/app/services/idea_assignment/patches/side_fx_project_service.rb
@@ -10,7 +10,7 @@ module IdeaAssignment
 
       def set_default_assignee(project, current_user)
         project.default_assignee ||= if current_user&.super_admin?
-                                       User.active.admin.order(:created_at).reject(&:super_admin?).first
+                                        ::User.oldest_admin
                                      else
                                        current_user
                                      end

--- a/back/engines/commercial/project_management/app/models/project_management/patches/user.rb
+++ b/back/engines/commercial/project_management/app/models/project_management/patches/user.rb
@@ -5,6 +5,7 @@ module ProjectManagement
     module User
       def self.prepended(base)
         base.singleton_class.prepend(ClassMethods)
+        base.include(IdeaAssignment)
         base.class_eval do
           scope :project_moderator, lambda { |project_id = nil|
             if project_id
@@ -24,16 +25,51 @@ module ProjectManagement
         end
       end
 
-      def project_moderator?(project_id = nil)
-        project_id ? moderatable_project_ids.include?(project_id) : moderatable_project_ids.present?
-      end
-
       def moderatable_project_ids
         roles.select { |role| role['type'] == 'project_moderator' }.pluck("project_id").compact
       end
 
+      def moderatable_project_ids_was
+        roles_was.select { |role| role['type'] == 'project_moderator' }.pluck("project_id").compact
+      end
+
       def moderatable_projects
         ::Project.where(id: moderatable_project_ids)
+      end
+
+      def moderatable_projects_was
+        ::Project.where(id: moderatable_project_ids_was)
+      end
+
+      module IdeaAssignment
+        def self.included(base)
+          base.before_save :reset_project_and_idea_assignments, if: :lost_rights_over_assigned_projects_or_ideas?
+        end
+
+        # When a user loses project management rights over a project, and is the default assignee, or assignee of some ideas,
+        # change it to the oldest admin.
+        def reset_project_and_idea_assignments
+          lost_assigned_moderatable_projects.update!(default_assignee: self.class.oldest_admin)
+          lost_assigned_moderated_ideas.update!(default_assignee: self.class.oldest_admin)
+        end
+
+        def lost_rights_over_assigned_projects_or_ideas?
+          return false if admin?
+
+          lost_assigned_moderatable_projects.any? || lost_assigned_moderated_ideas.any?
+        end
+
+        def lost_assigned_moderatable_projects
+          ::Project.where(id: moderatable_project_ids_was - moderatable_project_ids, default_assignee: self)
+        end
+
+        def lost_assigned_moderated_ideas
+          Idea.includes(:project).where(project: ::Project.where(id: moderatable_project_ids_was - moderatable_project_ids), assignee: self)
+        end
+
+        def project_moderator?(project_id = nil)
+          project_id ? moderatable_project_ids.include?(project_id) : moderatable_project_ids.present?
+        end
       end
     end
   end

--- a/back/engines/commercial/project_management/app/models/project_management/patches/user.rb
+++ b/back/engines/commercial/project_management/app/models/project_management/patches/user.rb
@@ -68,7 +68,7 @@ module ProjectManagement
         end
 
         def lost_assigned_moderated_ideas
-          Idea.includes(:project).where(project: ::Project.where(id: moderatable_project_ids_was - moderatable_project_ids), assignee: self)
+          Idea.includes(:project).where(project_id: (moderatable_project_ids_was - moderatable_project_ids), assignee: self)
         end
       end
     end

--- a/back/engines/commercial/project_management/app/models/project_management/patches/user.rb
+++ b/back/engines/commercial/project_management/app/models/project_management/patches/user.rb
@@ -53,10 +53,8 @@ module ProjectManagement
         # When a user loses project management rights over a project, and is the default assignee, or assignee of some ideas,
         # change it to the oldest admin.
         def reset_project_and_idea_assignments
-          projects = lost_assigned_moderatable_projects
-          ideas = lost_assigned_moderated_ideas
-          projects.update(default_assignee: self.class.oldest_admin)
-          ideas.update(assignee: self.class.oldest_admin)
+          lost_assigned_moderatable_projects.update(default_assignee: self.class.oldest_admin)
+          lost_assigned_moderated_ideas.update(assignee: self.class.oldest_admin)
         end
 
         def lost_rights_over_assigned_projects_or_ideas?

--- a/back/engines/commercial/project_management/spec/models/user_spec.rb
+++ b/back/engines/commercial/project_management/spec/models/user_spec.rb
@@ -58,6 +58,31 @@ RSpec.describe User, type: :model do
       expect(mod.save).to eq true
       expect(mod.project_moderator? prj.id).to eq false
     end
+
+    it "demotes the user from default_assignee of the moderated project" do
+      prj = create(:project)
+      mod = create(:moderator, project: prj)
+      prj.default_assignee = mod
+      prj.save
+
+      mod.delete_role 'project_moderator', project_id: prj.id
+      expect(mod.save).to eq true
+      byebug
+      expect(prj.default_assignee_id).not_to eq mod.id
+    end
+
+    it "demotes the user from assignee of the moderated project's ideas" do
+      prj = create(:project)
+      mod = create(:moderator, project: prj)
+      prj.default_assignee = mod
+      prj.save
+
+      project_ideas = create_list(:idea, 3, project: project, assignee: mod)
+
+      mod.delete_role 'project_moderator', project_id: prj.id
+      expect(mod.save).to eq true
+      expect(ideas.puck(:default_assignee_id)).not_to include mod.id
+    end
   end
 
   describe "highest_role" do

--- a/back/engines/commercial/project_management/spec/models/user_spec.rb
+++ b/back/engines/commercial/project_management/spec/models/user_spec.rb
@@ -67,8 +67,7 @@ RSpec.describe User, type: :model do
 
       mod.delete_role 'project_moderator', project_id: prj.id
       expect(mod.save).to eq true
-      byebug
-      expect(prj.default_assignee_id).not_to eq mod.id
+      expect(prj.reload.default_assignee_id).not_to eq mod.id
     end
 
     it "demotes the user from assignee of the moderated project's ideas" do
@@ -77,11 +76,12 @@ RSpec.describe User, type: :model do
       prj.default_assignee = mod
       prj.save
 
-      project_ideas = create_list(:idea, 3, project: project, assignee: mod)
+      ideas = create_list(:idea, 3, project: prj, assignee: mod)
 
       mod.delete_role 'project_moderator', project_id: prj.id
       expect(mod.save).to eq true
-      expect(ideas.puck(:default_assignee_id)).not_to include mod.id
+      ideas = Idea.where(id: ideas.pluck(:id)) # this is necessary to reload the objects
+      expect(ideas.pluck(:assignee_id)).not_to include mod.id
     end
   end
 


### PR DESCRIPTION
Sets the default assignee of a project and assignee of its ideas to `nil` when that assignee loses project management rights.