### PR TITLE
[CL2-6528] Sign up modal can no longer be closed in the confirmation step

### DIFF
--- a/front/app/components/SignUpIn/SignUpInModal.tsx
+++ b/front/app/components/SignUpIn/SignUpInModal.tsx
@@ -60,7 +60,8 @@ const SignUpInModal = memo<Props>(({ className, onMounted }) => {
     : 580;
 
   const modalNoClose = !!(
-    metaData?.error !== true && signUpActiveStep === 'verification'
+    (metaData?.error !== true && signUpActiveStep === 'verification') ||
+    metaData?.modalNoClose
   );
 
   useEffect(() => {

--- a/front/app/components/SignUpIn/SignUpInModal.tsx
+++ b/front/app/components/SignUpIn/SignUpInModal.tsx
@@ -61,7 +61,8 @@ const SignUpInModal = memo<Props>(({ className, onMounted }) => {
 
   const modalNoClose = !!(
     (metaData?.error !== true && signUpActiveStep === 'verification') ||
-    metaData?.modalNoClose
+    (signUpActiveStep &&
+      metaData?.modalNoCloseSteps?.includes(signUpActiveStep))
   );
 
   useEffect(() => {

--- a/front/app/components/SignUpIn/events.ts
+++ b/front/app/components/SignUpIn/events.ts
@@ -22,6 +22,7 @@ export function openSignUpInModal(metaData?: Partial<ISignUpInMetaData>) {
     isInvitation: !!metaData?.isInvitation,
     token: metaData?.token,
     inModal: true,
+    modalNoCloseSteps: [],
     action: metaData?.action || undefined,
   };
 
@@ -53,6 +54,7 @@ export function modifyMetaData(
     token: undefined,
     inModal: undefined,
     action: undefined,
+    modalNoCloseSteps: [],
     ...overridenMetaData,
   };
 

--- a/front/app/components/SignUpIn/index.tsx
+++ b/front/app/components/SignUpIn/index.tsx
@@ -36,7 +36,7 @@ export interface ISignUpInMetaData {
   isInvitation?: boolean;
   token?: string;
   inModal?: boolean;
-  modalNoClose?: boolean;
+  modalNoCloseSteps?: string[];
   noPushLinks?: boolean;
   noAutofocus?: boolean;
   action?: () => void;

--- a/front/app/components/SignUpIn/index.tsx
+++ b/front/app/components/SignUpIn/index.tsx
@@ -36,6 +36,7 @@ export interface ISignUpInMetaData {
   isInvitation?: boolean;
   token?: string;
   inModal?: boolean;
+  modalNoClose?: boolean;
   noPushLinks?: boolean;
   noAutofocus?: boolean;
   action?: () => void;

--- a/front/app/containers/App/index.tsx
+++ b/front/app/containers/App/index.tsx
@@ -372,6 +372,7 @@ class App extends PureComponent<Props, State> {
             error: isAuthError,
             verification: !!sso_verification,
             requiresConfirmation: shouldConfirm,
+            modalNoCloseSteps: ['confirmation'],
             verificationContext: !!(
               sso_verification &&
               sso_verification_action &&

--- a/front/app/containers/ProjectsShowPage/shared/survey/index.tsx
+++ b/front/app/containers/ProjectsShowPage/shared/survey/index.tsx
@@ -218,6 +218,7 @@ class Survey extends PureComponent<Props, State> {
                   requiresConfirmation,
                   flow: 'signup',
                   pathname: window.location.pathname,
+                  modalNoCloseSteps: 'confirmation',
                   inModal: true,
                   verification: shouldVerify,
                   noPushLinks: true,

--- a/front/app/containers/ProjectsShowPage/shared/survey/index.tsx
+++ b/front/app/containers/ProjectsShowPage/shared/survey/index.tsx
@@ -218,7 +218,7 @@ class Survey extends PureComponent<Props, State> {
                   requiresConfirmation,
                   flow: 'signup',
                   pathname: window.location.pathname,
-                  modalNoCloseSteps: 'confirmation',
+                  modalNoCloseSteps: ['confirmation'],
                   inModal: true,
                   verification: shouldVerify,
                   noPushLinks: true,

--- a/front/app/modules/commercial/user_custom_fields/citizen/components/UserCustomFieldsSignUpInModal.tsx
+++ b/front/app/modules/commercial/user_custom_fields/citizen/components/UserCustomFieldsSignUpInModal.tsx
@@ -65,11 +65,12 @@ const UserCustomFieldsSignUpInModal = memo<Props>(
       ? 820
       : 580;
     const modalNoClose = !!(
-      metaData?.error !== true &&
-      (signUpActiveStep === 'verification' ||
-        signUpActiveStep === 'custom-fields') &&
-      !isNilOrError(customFieldsSchema) &&
-      customFieldsSchema?.hasRequiredFields
+      (metaData?.error !== true &&
+        (signUpActiveStep === 'verification' ||
+          (signUpActiveStep === 'custom-fields' &&
+            !isNilOrError(customFieldsSchema) &&
+            customFieldsSchema?.hasRequiredFields))) ||
+      metaData?.modalNoClose
     );
 
     useEffect(() => {

--- a/front/app/modules/commercial/user_custom_fields/citizen/components/UserCustomFieldsSignUpInModal.tsx
+++ b/front/app/modules/commercial/user_custom_fields/citizen/components/UserCustomFieldsSignUpInModal.tsx
@@ -64,13 +64,16 @@ const UserCustomFieldsSignUpInModal = memo<Props>(
     )
       ? 820
       : 580;
+
+    console.log(signUpActiveStep, metaData);
     const modalNoClose = !!(
       (metaData?.error !== true &&
         (signUpActiveStep === 'verification' ||
           (signUpActiveStep === 'custom-fields' &&
             !isNilOrError(customFieldsSchema) &&
             customFieldsSchema?.hasRequiredFields))) ||
-      metaData?.modalNoClose
+      (signUpActiveStep &&
+        metaData?.modalNoCloseSteps?.includes(signUpActiveStep))
     );
 
     useEffect(() => {

--- a/front/app/modules/free/user_confirmation/citizen/components/ConfirmationSignupStep.tsx
+++ b/front/app/modules/free/user_confirmation/citizen/components/ConfirmationSignupStep.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { CONFIRMATION_STEP_NAME } from '../../index';
 import { SignUpStepOutletProps } from 'utils/moduleUtils';
 import { injectIntl, FormattedMessage } from 'utils/cl-intl';
 import { InjectedIntlProps } from 'react-intl';
@@ -171,7 +172,7 @@ const ConfirmationSignupStep = ({
 
   useEffect(() => {
     props.onData({
-      key: 'confirmation',
+      key: CONFIRMATION_STEP_NAME,
       configuration: {
         position: 2.1,
         stepName: formatMessage(messages.confirmYourAccount),
@@ -185,7 +186,7 @@ const ConfirmationSignupStep = ({
     });
   }, []);
 
-  if (props.step !== 'confirmation' || isNilOrError(user)) {
+  if (props.step !== CONFIRMATION_STEP_NAME || isNilOrError(user)) {
     return null;
   }
 

--- a/front/app/modules/free/user_confirmation/index.tsx
+++ b/front/app/modules/free/user_confirmation/index.tsx
@@ -65,7 +65,10 @@ const configuration: ModuleConfiguration = {
         isUserConfirmationEnabled &&
         !metaData.requiresConfirmation
       ) {
-        modifyMetaData(metaData, { requiresConfirmation: true });
+        modifyMetaData(metaData, {
+          requiresConfirmation: true,
+          modalNoClose: true,
+        });
       }
 
       return null;

--- a/front/app/modules/free/user_confirmation/index.tsx
+++ b/front/app/modules/free/user_confirmation/index.tsx
@@ -8,6 +8,8 @@ import useAuthUser from 'hooks/useAuthUser';
 import { isNilOrError } from 'utils/helperUtils';
 import useAppConfiguration from 'hooks/useAppConfiguration';
 
+export const CONFIRMATION_STEP_NAME = 'confirmation';
+
 type RenderOnFeatureFlagProps = {
   children: ReactNode;
 };
@@ -59,7 +61,6 @@ const configuration: ModuleConfiguration = {
         // When we allow users to reconfirm their emails, we should stop checking for registration_completed_at.
         user?.attributes?.confirmation_required &&
         !user?.attributes?.registration_completed_at;
-
       if (
         confirmationRequired &&
         isUserConfirmationEnabled &&
@@ -67,7 +68,7 @@ const configuration: ModuleConfiguration = {
       ) {
         modifyMetaData(metaData, {
           requiresConfirmation: true,
-          modalNoClose: true,
+          modalNoCloseSteps: [CONFIRMATION_STEP_NAME],
         });
       }
 


### PR DESCRIPTION
Adds a `modalNoCloseSteps` property to the metadata used in signup