### PR TITLE
[CL2-6561] Events api changes

### DIFF
--- a/back/app/controllers/web_api/v1/events_controller.rb
+++ b/back/app/controllers/web_api/v1/events_controller.rb
@@ -2,7 +2,7 @@ class WebApi::V1::EventsController < ApplicationController
   before_action :set_event, only: [:show, :update, :destroy]
 
   def index
-    @events = EventFinder.find(params, scope: policy_scope(Event), current_user: current_user)
+    @events = EventsFinder.find(params, scope: policy_scope(Event), current_user: current_user).records
     render json: linked_json(@events, WebApi::V1::EventSerializer, params: fastjson_params)
   end
 

--- a/back/app/controllers/web_api/v1/events_controller.rb
+++ b/back/app/controllers/web_api/v1/events_controller.rb
@@ -2,9 +2,7 @@ class WebApi::V1::EventsController < ApplicationController
   before_action :set_event, only: [:show, :update, :destroy]
 
   def index
-    @events = policy_scope(Event).order(start_at: :desc)
-    @events = @events.where(project_id: params[:project_id]) if params[:project_id]
-    @events = @events.page(params.dig(:page, :number)).per(params.dig(:page, :size))
+    @events = EventFinder.find(params, scope: policy_scope(Event), current_user: current_user)
     render json: linked_json(@events, WebApi::V1::EventSerializer, params: fastjson_params)
   end
 

--- a/back/app/controllers/web_api/v1/events_controller.rb
+++ b/back/app/controllers/web_api/v1/events_controller.rb
@@ -2,8 +2,9 @@ class WebApi::V1::EventsController < ApplicationController
   before_action :set_event, only: [:show, :update, :destroy]
 
   def index
-    @events = policy_scope(Event).where(project_id: params[:project_id]).order(start_at: :desc)
-                                 .page(params.dig(:page, :number)).per(params.dig(:page, :size))
+    @events = policy_scope(Event).order(start_at: :desc)
+    @events = @events.where(project_id: params[:project_id]) if params[:project_id]
+    @events = @events.page(params.dig(:page, :number)).per(params.dig(:page, :size))
     render json: linked_json(@events, WebApi::V1::EventSerializer, params: fastjson_params)
   end
 

--- a/back/app/finders/events_finder.rb
+++ b/back/app/finders/events_finder.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+## EventsFinder.find
+class EventsFinder < ApplicationFinder
+  default_sort :start_at
+  sortable_attributes 'start_at'
+
+  private
+
+  def project_ids_condition(project_ids)
+    where(project_id: project_ids)
+  end
+
+  def start_at_lt_condition(start_at)
+    where('start_at < ?', start_at)
+  end
+
+  def start_at_gteq_condition(start_at)
+    where('start_at >= ?', start_at)
+  end
+end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -114,7 +114,7 @@ Rails.application.routes.draw do
       # to be shallow so we can determine their container class. See e.g.
       # https://github.com/rails/rails/pull/24405
 
-      resources :events, only: %i[show edit update destroy] do
+      resources :events, only: %i[index show edit update destroy] do
         resources :files, defaults: { container_type: 'Event' }, shallow: false
       end
 
@@ -123,7 +123,7 @@ Rails.application.routes.draw do
       end
 
       resources :projects do
-        resources :events, only: %i[index new create]
+        resources :events, only: %i[new create]
         resources :projects_topics, only: [:index]
         resources :topics, only: %i[index reorder] do
           patch 'reorder', on: :member

--- a/back/spec/acceptance/events_spec.rb
+++ b/back/spec/acceptance/events_spec.rb
@@ -9,21 +9,35 @@ resource "Events" do
   before do
     header "Content-Type", "application/json"
     @project = create(:project)
+    @project2 = create(:project)
     @events = create_list(:event, 2, project: @project)
+    @other_events = create_list(:event, 2, project: @project2)
   end
 
-  get "web_api/v1/projects/:project_id/events" do
+  get "web_api/v1/events" do
+    parameter :project_id, "The id of the project to filter events by", required: true
+
     with_options scope: :page do
       parameter :number, "Page number"
       parameter :size, "Number of events per page"
     end
-    
-    let(:project_id) { @project.id }
 
-    example_request "List all events of a project" do
-      expect(status).to eq(200)
-      json_response = json_parse(response_body)
-      expect(json_response[:data].size).to eq 2
+    context 'passing a project id' do
+      let(:project_id) { @project.id }
+
+      example_request "List all events of a project" do
+        expect(status).to eq(200)
+        json_response = json_parse(response_body)
+        expect(json_response[:data].size).to eq 2
+      end
+    end
+
+    context 'not passing a project id' do
+      example_request "List all events" do
+        expect(status).to eq(200)
+        json_response = json_parse(response_body)
+        expect(json_response[:data].size).to eq 4
+      end
     end
   end
 

--- a/back/spec/acceptance/events_spec.rb
+++ b/back/spec/acceptance/events_spec.rb
@@ -15,7 +15,7 @@ resource "Events" do
   end
 
   get "web_api/v1/events" do
-    parameter :project_id, "The id of the project to filter events by", required: true
+    parameter :project_ids, "The ids of the project to filter events by", required: true, type: :array
 
     with_options scope: :page do
       parameter :number, "Page number"

--- a/back/spec/acceptance/events_spec.rb
+++ b/back/spec/acceptance/events_spec.rb
@@ -15,7 +15,9 @@ resource "Events" do
   end
 
   get "web_api/v1/events" do
-    parameter :project_ids, "The ids of the project to filter events by", required: true, type: :array
+    parameter :project_ids, "The ids of the project to filter events by", type: :array
+    parameter :start_at_lt, "Filter by maximum start at", type: :string
+    parameter :start_at_gteq, "Filter by minimum start at", type: :string
 
     with_options scope: :page do
       parameter :number, "Page number"

--- a/back/spec/acceptance/events_spec.rb
+++ b/back/spec/acceptance/events_spec.rb
@@ -24,8 +24,8 @@ resource "Events" do
       parameter :size, "Number of events per page"
     end
 
-    context 'passing a project id' do
-      let(:project_id) { @project.id }
+    context 'passing project ids' do
+      let(:project_ids) { [@project.id] }
 
       example_request "List all events of a project" do
         expect(status).to eq(200)

--- a/back/spec/finders/events_finder_spec.rb
+++ b/back/spec/finders/events_finder_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe EventsFinder do
+  subject(:result) { described_class.find(params, **options) }
+
+  let(:params) { {} }
+  let(:options) { {} }
+  let(:result_record_ids) { result.records.pluck(:id) }
+  let(:past_events) {  }
+  let(:future_events) {  }
+
+  before do
+    create_list(:event, 5)
+  end
+
+  context 'when no params or options are received' do
+    it 'is successful' do
+      expect(result).to be_a_success
+    end
+
+    it 'returns all' do
+      expect(result.count).to eq Event.count
+    end
+  end
+
+  describe '#project_ids_condition' do
+    let(:project) { create(:project) }
+    let(:expected_record_ids) { Event.where(project: project).pluck(:id) }
+
+    before do
+      create_list(:event, 5)
+      create_list(:event, 2, project: project).pluck(:id)
+      params[:project_ids] = [project.id]
+    end
+
+    it 'is successful' do
+      expect(result).to be_a_success
+    end
+
+    it 'returns the correct records' do
+      expect(result_record_ids).to match_array expected_record_ids
+    end
+  end
+
+  describe '#start_at_lt_condition' do
+    let(:expected_record_ids) { Event.where('start_at < ?', Time.zone.today).pluck(:id) }
+
+    before do
+      create_list(:event, 5, start_at: Time.zone.today - 1.week, end_at: Time.zone.today - 1.week + 1.day)
+      create_list(:event, 5, start_at: Time.zone.today + 1.week, end_at: Time.zone.today + 1.week + 1.day)
+      params[:start_at_lt] = Time.zone.now
+    end
+
+    it 'is successful' do
+      expect(result).to be_a_success
+    end
+
+    it 'returns the past events' do
+      expect(result_record_ids).to match_array expected_record_ids
+    end
+  end
+
+  describe '#start_at_gteq_condition' do
+    let(:expected_record_ids) { Event.where('start_at >= ?', Time.zone.today).pluck(:id) }
+
+    before do
+      create_list(:event, 5, start_at: Time.zone.today - 1.week, end_at: Time.zone.today - 1.week + 1.day)
+      create_list(:event, 5, start_at: Time.zone.today + 1.week, end_at: Time.zone.today + 1.week + 1.day)
+      params[:start_at_gteq] = Time.zone.now
+    end
+
+    it 'is successful' do
+      expect(result).to be_a_success
+    end
+
+    it 'returns the correct records' do
+      expect(result_record_ids).to match_array expected_record_ids
+    end
+  end
+end

--- a/front/app/containers/Admin/projects/edit/events/index.tsx
+++ b/front/app/containers/Admin/projects/edit/events/index.tsx
@@ -134,7 +134,7 @@ class AdminProjectEventsIndex extends React.PureComponent<
 
 export default withRouter(
   injectIntl((inputProps: InputProps & WithRouterProps & InjectedIntlProps) => (
-    <GetEvents projectId={inputProps.params.projectId}>
+    <GetEvents projectIds={[inputProps.params.projectId]}>
       {(events) => <AdminProjectEventsIndex {...inputProps} events={events} />}
     </GetEvents>
   ))

--- a/front/app/containers/ProjectsShowPage/index.tsx
+++ b/front/app/containers/ProjectsShowPage/index.tsx
@@ -82,7 +82,7 @@ const ProjectsShowPage = memo<Props>(({ project }) => {
   const locale = useLocale();
   const tenant = useAppConfiguration();
   const phases = usePhases(projectId);
-  const events = useEvents(projectId);
+  const events = useEvents(projectId ? [projectId] : undefined);
   const user = useAuthUser();
 
   const loading = useMemo(() => {

--- a/front/app/containers/ProjectsShowPage/shared/events/index.tsx
+++ b/front/app/containers/ProjectsShowPage/shared/events/index.tsx
@@ -36,7 +36,7 @@ interface Props {
 
 const EventsContainer = memo<Props>(({ projectId, className }) => {
   const project = useProject({ projectId });
-  const events = useEvents(projectId);
+  const events = useEvents([projectId]);
 
   if (!isNilOrError(project) && !isNilOrError(events) && events.length > 0) {
     return (

--- a/front/app/containers/ProjectsShowPage/shared/header/ProjectInfoSideBar.tsx
+++ b/front/app/containers/ProjectsShowPage/shared/header/ProjectInfoSideBar.tsx
@@ -136,7 +136,7 @@ const ProjectInfoSideBar = memo<Props>(({ projectId, className }) => {
   const tenant = useAppConfiguration();
   const project = useProject({ projectId });
   const phases = usePhases(projectId);
-  const events = useEvents(projectId);
+  const events = useEvents([projectId]);
   const authUser = useAuthUser();
 
   const [currentPhase, setCurrentPhase] = useState<IPhaseData | null>(null);

--- a/front/app/containers/SiteMap/Project.tsx
+++ b/front/app/containers/SiteMap/Project.tsx
@@ -72,7 +72,9 @@ const Data = adopt<DataProps, InputProps>({
     <GetProject projectId={adminPublication.publicationId}>{render}</GetProject>
   ),
   events: ({ adminPublication, render }) => (
-    <GetEvents projectId={adminPublication.publicationId}>{render}</GetEvents>
+    <GetEvents projectIds={[adminPublication.publicationId]}>
+      {render}
+    </GetEvents>
   ),
 });
 

--- a/front/app/hooks/useEvents.ts
+++ b/front/app/hooks/useEvents.ts
@@ -3,7 +3,7 @@ import { isNilOrError } from 'utils/helperUtils';
 import { Observable, of } from 'rxjs';
 import { IEventData, IEvents, eventsStream } from 'services/events';
 
-export default function useProject(projectId: string | null | undefined) {
+export default function useProject(projectId?: string | null) {
   const [events, setEvents] = useState<IEventData[] | undefined | null | Error>(
     undefined
   );
@@ -14,7 +14,10 @@ export default function useProject(projectId: string | null | undefined) {
     let observable: Observable<IEvents | null> = of(null);
 
     if (projectId) {
-      observable = eventsStream(projectId).observable;
+      observable = eventsStream({ queryParameters: { project_id: projectId } })
+        .observable;
+    } else {
+      observable = eventsStream().observable;
     }
 
     const subscription = observable.subscribe((response) => {

--- a/front/app/hooks/useEvents.ts
+++ b/front/app/hooks/useEvents.ts
@@ -3,7 +3,7 @@ import { isNilOrError } from 'utils/helperUtils';
 import { Observable, of } from 'rxjs';
 import { IEventData, IEvents, eventsStream } from 'services/events';
 
-export default function useProject(projectId?: string | null) {
+export default function useEvents(projectId?: string | null) {
   const [events, setEvents] = useState<IEventData[] | undefined | null | Error>(
     undefined
   );

--- a/front/app/hooks/useEvents.ts
+++ b/front/app/hooks/useEvents.ts
@@ -8,8 +8,8 @@ import {
 
 export default function useEvents(
   projectIds?: string[],
-  futureOnly?: string | Date,
-  pastOnly?: string | Date
+  futureOnly?: boolean,
+  pastOnly?: boolean
 ) {
   const [events, setEvents] = useState<IEventData[] | undefined | null | Error>(
     undefined

--- a/front/app/resources/GetEvents.tsx
+++ b/front/app/resources/GetEvents.tsx
@@ -47,7 +47,10 @@ export default class GetEvents extends React.Component<Props, State> {
           distinctUntilChanged((prev, next) => shallowCompare(prev, next)),
           tap(() => resetOnChange && this.setState({ events: undefined })),
           switchMap(({ projectId }) =>
-            projectId ? eventsStream(projectId).observable : of(null)
+            projectId
+              ? eventsStream({ queryParameters: { project_id: projectId } })
+                  .observable
+              : of(null)
           )
         )
         .subscribe((events) =>

--- a/front/app/resources/GetEvents.tsx
+++ b/front/app/resources/GetEvents.tsx
@@ -1,11 +1,17 @@
 import React from 'react';
-import { Subscription, BehaviorSubject, of } from 'rxjs';
+import { Subscription, BehaviorSubject } from 'rxjs';
 import { distinctUntilChanged, tap, switchMap } from 'rxjs/operators';
 import shallowCompare from 'utils/shallowCompare';
-import { IEventData, eventsStream } from 'services/events';
+import {
+  IEventData,
+  eventsStream,
+  IProjectsStreamParams,
+} from 'services/events';
 
 interface InputProps {
-  projectId: string | null;
+  projectIds?: string[];
+  futureOnly?: boolean;
+  pastOnly?: boolean;
   resetOnChange?: boolean;
 }
 
@@ -37,21 +43,34 @@ export default class GetEvents extends React.Component<Props, State> {
   }
 
   componentDidMount() {
-    const { projectId, resetOnChange } = this.props;
+    const { projectIds, resetOnChange, futureOnly, pastOnly } = this.props;
 
-    this.inputProps$ = new BehaviorSubject({ projectId });
+    this.inputProps$ = new BehaviorSubject({
+      projectIds,
+      futureOnly,
+      pastOnly,
+    });
 
     this.subscriptions = [
       this.inputProps$
         .pipe(
           distinctUntilChanged((prev, next) => shallowCompare(prev, next)),
           tap(() => resetOnChange && this.setState({ events: undefined })),
-          switchMap(({ projectId }) =>
-            projectId
-              ? eventsStream({ queryParameters: { project_id: projectId } })
-                  .observable
-              : of(null)
-          )
+          switchMap(({ projectIds, futureOnly, pastOnly }) => {
+            const queryParameters: IProjectsStreamParams['queryParameters'] = {
+              project_ids: projectIds,
+            };
+
+            if (futureOnly) {
+              queryParameters.start_at_gteq = new Date();
+            }
+
+            if (pastOnly) {
+              queryParameters.start_at_lt = new Date();
+            }
+
+            return eventsStream({ queryParameters }).observable;
+          })
         )
         .subscribe((events) =>
           this.setState({ events: events ? events.data : null })
@@ -60,8 +79,8 @@ export default class GetEvents extends React.Component<Props, State> {
   }
 
   componentDidUpdate() {
-    const { projectId } = this.props;
-    this.inputProps$.next({ projectId });
+    const { projectIds } = this.props;
+    this.inputProps$.next({ projectIds });
   }
 
   componentWillUnmount() {

--- a/front/app/services/events.ts
+++ b/front/app/services/events.ts
@@ -43,12 +43,9 @@ export interface IUpdatedEventProperties {
   end_at?: string;
 }
 
-export function eventsStream(
-  projectId: string,
-  streamParams: IStreamParams | null = null
-) {
+export function eventsStream(streamParams: IStreamParams | null = null) {
   return streams.get<IEvents>({
-    apiEndpoint: `${API_PATH}/projects/${projectId}/events`,
+    apiEndpoint: `${API_PATH}/events`,
     ...streamParams,
   });
 }

--- a/front/app/services/events.ts
+++ b/front/app/services/events.ts
@@ -43,7 +43,17 @@ export interface IUpdatedEventProperties {
   end_at?: string;
 }
 
-export function eventsStream(streamParams: IStreamParams | null = null) {
+export type IProjectsStreamParams = IStreamParams & {
+  queryParameters: {
+    project_ids?: string[];
+    start_at_lt?: string | Date;
+    start_at_gteq?: string | Date;
+  };
+};
+
+export function eventsStream(
+  streamParams: IProjectsStreamParams | null = null
+) {
   return streams.get<IEvents>({
     apiEndpoint: `${API_PATH}/events`,
     ...streamParams,


### PR DESCRIPTION
### Changes
The Events index API endpoint is no longer nested within project resources to allow the client to retrieve all events from all projects at once.

**Before:** `/web_api/v1/project/:project_id/events`
| param | type |
|---|---|
| page[number] | number |
| page[size] | number |

**After:** `/web_api/v1/events`

| param | type |
|---|---|
| page[number] | number |
| page[size] | number |
| project_ids | string[] |
| start_at_lt | date |
| start_at_gteq | date |

Front-End api services were also changed to adapt to these api changes.


So for you @luucvanderzee , what this means, is that you'll be able to use the `useEvents` hook without passing a `projectId` to retrieve all events, or passing a `projectId` to filter them by project.