### PR TITLE
IN-455/allow-rel-attribute

### DIFF
--- a/back/app/services/sanitization_service.rb
+++ b/back/app/services/sanitization_service.rb
@@ -66,7 +66,7 @@ class SanitizationService
   end
 
   def linkify(html)
-    Rinku.auto_link(html, :all, 'target="_blank"', nil, Rinku::AUTOLINK_SHORT_DOMAINS)
+    Rinku.auto_link(html, :all, 'target="_blank" rel="noreferrer noopener"', nil, Rinku::AUTOLINK_SHORT_DOMAINS)
   end
 
   def html_with_content?(text_or_html)
@@ -120,7 +120,7 @@ class SanitizationService
       },
       link: {
         tags: %w[a],
-        attributes: %w[href target]
+        attributes: %w[href target rel]
       },
       image: {
         tags: %w[img],

--- a/back/spec/services/sanitization_service_spec.rb
+++ b/back/spec/services/sanitization_service_spec.rb
@@ -69,13 +69,15 @@ describe SanitizationService do
       expect(service.sanitize(input, features)).to eq input
     end
 
-    #[TODO]
-    it "still allows links to pass through with blank target and referrer when link feature is enabled" do
+    pending "fixes links blank target and referrer allowed" do
       input = <<~HTML
         <a href="https://www.google.com" target="_blank">Link</a>
       HTML
+      parsed_input = <<~HTML
+        <a href="https://www.google.com" target="_blank" rel="noreferrer noopener">Link</a>
+      HTML
       features = [:link]
-      expect(service.sanitize(input, features)).to eq input
+      expect(service.sanitize(input, features)).to eq parsed_input
     end
 
     it "allows images to pass through when title feature is enabled" do

--- a/back/spec/services/sanitization_service_spec.rb
+++ b/back/spec/services/sanitization_service_spec.rb
@@ -63,6 +63,15 @@ describe SanitizationService do
 
     it "allows links to pass through when link feature is enabled" do
       input = <<~HTML
+        <a href="https://www.google.com" target="_blank" rel="noreferrer noopener">Link</a>
+      HTML
+      features = [:link]
+      expect(service.sanitize(input, features)).to eq input
+    end
+
+    #[TODO]
+    it "still allows links to pass through with blank target and referrer when link feature is enabled" do
+      input = <<~HTML
         <a href="https://www.google.com" target="_blank">Link</a>
       HTML
       features = [:link]
@@ -164,7 +173,7 @@ describe SanitizationService do
     it "sanitizes malicious javascript" do
       input = <<~HTML
         <p>
-          test 
+          test
         <SCRIPT SRC=%(jscript)s?<B>
         <BODY onload!#$%%&()*~+-_.,:;?@[/|\]^`=javascript:alert(1)>
         <SCRIPT/SRC="%(jscript)s"></SCRIPT>
@@ -311,17 +320,17 @@ describe SanitizationService do
     it "transforms a plan-text link to an anchor" do
       html = "<p>https://www.google.com</p>"
       output = service.linkify(html)
-      expect(output).to eq '<p><a href="https://www.google.com" target="_blank">https://www.google.com</a></p>'
+      expect(output).to eq '<p><a href="https://www.google.com" target="_blank" rel="noreferrer noopener">https://www.google.com</a></p>'
     end
 
     it "transforms plain-text links with one domain segment" do
       html = "<p>http://localhost:3000/ideas</p>"
       output = service.linkify(html)
-      expect(output).to eq '<p><a href="http://localhost:3000/ideas" target="_blank">http://localhost:3000/ideas</a></p>'
+      expect(output).to eq '<p><a href="http://localhost:3000/ideas" target="_blank" rel="noreferrer noopener">http://localhost:3000/ideas</a></p>'
     end
 
     it "doesn't transforms an existing anchor" do
-      html = '<p><a href="https://www.google.com" target="_blank">https://www.google.com</a></p>'
+      html = '<p><a href="https://www.google.com" target="_blank" rel="noreferrer noopener">https://www.google.com</a></p>'
       output = service.linkify(html)
       expect(output).to eq html
     end
@@ -329,7 +338,7 @@ describe SanitizationService do
     it "transforms an email to a mailto: anchor" do
       html = "<p>hello@citizenlab.co</p>"
       output = service.linkify(html)
-      expect(output).to eq '<p><a href="mailto:hello@citizenlab.co" target="_blank">hello@citizenlab.co</a></p>'
+      expect(output).to eq '<p><a href="mailto:hello@citizenlab.co" target="_blank" rel="noreferrer noopener">hello@citizenlab.co</a></p>'
     end
   end
 


### PR DESCRIPTION
Stop removing rel attributes that the front-end is adding to links, ideally BE would enforce their usage instead but that's another magnitude of effort, so starting here. 