### PR TITLE
IN-462 Insights Views: Subscribe to zsc response messages

### DIFF
--- a/back/engines/commercial/insights/app/services/insights/category_suggestions_service.rb
+++ b/back/engines/commercial/insights/app/services/insights/category_suggestions_service.rb
@@ -11,14 +11,12 @@ module Insights
       # @param [NLP::ZeroshotClassificationResult] zsc_result zeroshot-classification result
       # @return [Array<Insights::CategoryAssignment>]
       def save_suggestion(zsc_result)
-        return unless zsc_result.success?
-
         Tenant.find(zsc_result.tenant_id).switch do
           zsc_task = ZeroshotClassificationTask.find_by(task_id: zsc_result.task_id)
           return [] unless zsc_task
 
           zsc_task.destroy!
-          save_predictions(zsc_result.predictions)
+          save_predictions(zsc_result.predictions) if zsc_result.success?
         end
       end
 

--- a/back/engines/commercial/insights/config/initializers/bunny.rb
+++ b/back/engines/commercial/insights/config/initializers/bunny.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'citizen_lab/bunny'
+require 'nlp/zeroshot_classification_result'
+require 'json'
+
+return unless (rabbitmq_uri = ENV['RABBITMQ_URI'])
+
+BUNNY_CON ||= CitizenLab::Bunny.connect(rabbitmq_uri)
+
+channel = BUNNY_CON.create_channel
+exchange = channel.topic('cl2nlp', durable: true)
+queue = channel.queue('cl2_back.zeroshot_results', durable: true)
+               .bind(exchange, routing_key: 'zeroshot.inference')
+
+queue.subscribe do |_delivery_info, _properties, payload|
+  payload = JSON.parse(payload)
+
+  # [TODO] we need a consistent approach to structured logging
+  puts({
+    time: Time.now.iso8601,
+    message: 'received rabbitmq message',
+    queue: 'cl2_back.zeroshot_results',
+    routing_key: 'zeroshot.inference',
+    payload: payload
+  }.to_json)
+
+  zsc_result = NLP::ZeroshotClassificationResult.from_json(payload)
+  Insights::CategorySuggestionsService.save_suggestion(zsc_result)
+end


### PR DESCRIPTION
Forgot the initializer to subscribe to result messages for zeroshot classification 😬 
Also fixed an issue with unsuccessful tasks not being removed from the list of pending tasks.

Already merging it bc the code is quite simple and I'm trying to speed up to unblock the FE, but your feedback is still very welcome!
 