### PR TITLE
IN-464 Insights module request hook tests

### DIFF
--- a/front/app/modules/commercial/insights/admin/containers/Insights/Edit/InputsTable/index.tsx
+++ b/front/app/modules/commercial/insights/admin/containers/Insights/Edit/InputsTable/index.tsx
@@ -126,10 +126,12 @@ const InputsTable = ({
   const pageNumber = parseInt(query?.pageNumber, 10);
   const selectedCategory = query.category;
   const search = query.search;
+  const sort = query.sort;
 
   const { list: inputs, lastPage } = useInsightsInputs(viewId, {
     pageNumber,
     search,
+    sort,
     category: selectedCategory,
   });
 

--- a/front/app/modules/commercial/insights/hooks/useInsightsCategories.test.ts
+++ b/front/app/modules/commercial/insights/hooks/useInsightsCategories.test.ts
@@ -1,0 +1,74 @@
+import { renderHook } from '@testing-library/react-hooks';
+import useInsightsCategories from './useInsightsCategories';
+import { Observable, Subscription } from 'rxjs';
+import { waitFor } from 'utils/testUtils/rtl';
+import { insightsCategoriesStream } from 'modules/commercial/insights/services/insightsCategories';
+
+const viewId = '1';
+
+const mockCategories = {
+  data: [
+    {
+      id: '1aa8a788-3aee-4ada-a581-6d934e49784b',
+      type: 'category',
+      attributes: {
+        name: 'Test',
+      },
+    },
+    {
+      id: '4b429681-1744-456f-8550-e89a2c2c74b2',
+      type: 'category',
+      attributes: {
+        name: 'Test 2',
+      },
+    },
+  ],
+};
+
+let mockObservable = new Observable((subscriber) => {
+  subscriber.next(setTimeout(() => mockCategories, 0));
+});
+
+jest.mock('modules/commercial/insights/services/insightsCategories', () => {
+  return {
+    insightsCategoriesStream: jest.fn(() => {
+      return {
+        observable: mockObservable,
+      };
+    }),
+  };
+});
+
+describe('useInsightsCategories', () => {
+  it('should call insightsCategoriesStream with correct arguments', async () => {
+    renderHook(() => useInsightsCategories(viewId));
+    expect(insightsCategoriesStream).toHaveBeenCalledWith(viewId);
+  });
+  it('should return data when data', async () => {
+    const { result } = renderHook(() => useInsightsCategories(viewId));
+    expect(result.current).toBe(undefined); // initially, the hook returns undefined
+    waitFor(() => expect(result.current).toBe(mockCategories.data));
+  });
+  it('should return error when error', () => {
+    const error = new Error();
+    mockObservable = new Observable((subscriber) => {
+      subscriber.next({ data: new Error() });
+    });
+    const { result } = renderHook(() => useInsightsCategories(viewId));
+    expect(result.current).toStrictEqual(error);
+  });
+  it('should return null when data is null', () => {
+    mockObservable = new Observable((subscriber) => {
+      subscriber.next({ data: null });
+    });
+    const { result } = renderHook(() => useInsightsCategories(viewId));
+    expect(result.current).toBe(null);
+  });
+  it('should unsubscribe on unmount', () => {
+    spyOn(Subscription.prototype, 'unsubscribe');
+    const { unmount } = renderHook(() => useInsightsCategories(viewId));
+
+    unmount();
+    expect(Subscription.prototype.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/front/app/modules/commercial/insights/hooks/useInsightsCategories.test.ts
+++ b/front/app/modules/commercial/insights/hooks/useInsightsCategories.test.ts
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import useInsightsCategories from './useInsightsCategories';
 import { Observable, Subscription } from 'rxjs';
 import { waitFor } from 'utils/testUtils/rtl';
+import { delay } from 'rxjs/operators';
 import { insightsCategoriesStream } from 'modules/commercial/insights/services/insightsCategories';
 
 const viewId = '1';
@@ -26,8 +27,8 @@ const mockCategories = {
 };
 
 let mockObservable = new Observable((subscriber) => {
-  subscriber.next(setTimeout(() => mockCategories, 0));
-});
+  subscriber.next(mockCategories);
+}).pipe(delay(1));
 
 jest.mock('modules/commercial/insights/services/insightsCategories', () => {
   return {
@@ -40,11 +41,11 @@ jest.mock('modules/commercial/insights/services/insightsCategories', () => {
 });
 
 describe('useInsightsCategories', () => {
-  it('should call insightsCategoriesStream with correct arguments', async () => {
+  it('should call insightsCategoriesStream with correct arguments', () => {
     renderHook(() => useInsightsCategories(viewId));
     expect(insightsCategoriesStream).toHaveBeenCalledWith(viewId);
   });
-  it('should return data when data', async () => {
+  it('should return data when data', () => {
     const { result } = renderHook(() => useInsightsCategories(viewId));
     expect(result.current).toBe(undefined); // initially, the hook returns undefined
     waitFor(() => expect(result.current).toBe(mockCategories.data));

--- a/front/app/modules/commercial/insights/hooks/useInsightsCategories.test.ts
+++ b/front/app/modules/commercial/insights/hooks/useInsightsCategories.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react-hooks';
 import useInsightsCategories from './useInsightsCategories';
 import { Observable, Subscription } from 'rxjs';
 import { waitFor } from 'utils/testUtils/rtl';
@@ -45,10 +45,13 @@ describe('useInsightsCategories', () => {
     renderHook(() => useInsightsCategories(viewId));
     expect(insightsCategoriesStream).toHaveBeenCalledWith(viewId);
   });
-  it('should return data when data', () => {
+  it('should return data when data', async () => {
     const { result } = renderHook(() => useInsightsCategories(viewId));
     expect(result.current).toBe(undefined); // initially, the hook returns undefined
-    waitFor(() => expect(result.current).toBe(mockCategories.data));
+    await act(
+      async () =>
+        await waitFor(() => expect(result.current).toBe(mockCategories.data))
+    );
   });
   it('should return error when error', () => {
     const error = new Error();

--- a/front/app/modules/commercial/insights/hooks/useInsightsCategory.test.ts
+++ b/front/app/modules/commercial/insights/hooks/useInsightsCategory.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react-hooks';
 import useInsightsCategory from './useInsightsCategory';
 import { Observable, Subscription } from 'rxjs';
 import { waitFor } from 'utils/testUtils/rtl';
@@ -37,12 +37,15 @@ describe('useInsightsCategory', () => {
     renderHook(() => useInsightsCategory(viewId, categoryId));
     expect(insightsCategoryStream).toHaveBeenCalledWith(viewId, categoryId);
   });
-  it('should return data when data', () => {
+  it('should return data when data', async () => {
     const { result } = renderHook(() =>
       useInsightsCategory(viewId, categoryId)
     );
     expect(result.current).toBe(undefined); // initially, the hook returns undefined
-    waitFor(() => expect(result.current).toBe(mockCategory.data));
+    await act(
+      async () =>
+        await waitFor(() => expect(result.current).toBe(mockCategory.data))
+    );
   });
   it('should return error when error', () => {
     const error = new Error();

--- a/front/app/modules/commercial/insights/hooks/useInsightsCategory.test.ts
+++ b/front/app/modules/commercial/insights/hooks/useInsightsCategory.test.ts
@@ -1,0 +1,74 @@
+import { renderHook } from '@testing-library/react-hooks';
+import useInsightsCategory from './useInsightsCategory';
+import { Observable, Subscription } from 'rxjs';
+import { waitFor } from 'utils/testUtils/rtl';
+import { insightsCategoryStream } from 'modules/commercial/insights/services/insightsCategories';
+
+const viewId = '1';
+const categoryId = '1aa8a788-3aee-4ada-a581-6d934e49784b';
+
+const mockCategory = {
+  data: {
+    id: '1aa8a788-3aee-4ada-a581-6d934e49784b',
+    type: 'category',
+    attributes: {
+      name: 'Test',
+    },
+  },
+};
+
+let mockObservable = new Observable((subscriber) => {
+  subscriber.next(setTimeout(() => mockCategory, 0));
+});
+
+jest.mock('modules/commercial/insights/services/insightsCategories', () => {
+  return {
+    insightsCategoryStream: jest.fn(() => {
+      return {
+        observable: mockObservable,
+      };
+    }),
+  };
+});
+
+describe('useInsightsCategories', () => {
+  it('should call insightsCategoryStream with correct arguments', async () => {
+    renderHook(() => useInsightsCategory(viewId, categoryId));
+    expect(insightsCategoryStream).toHaveBeenCalledWith(viewId, categoryId);
+  });
+  it('should return data when data', async () => {
+    const { result } = renderHook(() =>
+      useInsightsCategory(viewId, categoryId)
+    );
+    expect(result.current).toBe(undefined); // initially, the hook returns undefined
+    waitFor(() => expect(result.current).toBe(mockCategory.data));
+  });
+  it('should return error when error', () => {
+    const error = new Error();
+    mockObservable = new Observable((subscriber) => {
+      subscriber.next({ data: new Error() });
+    });
+    const { result } = renderHook(() =>
+      useInsightsCategory(viewId, categoryId)
+    );
+    expect(result.current).toStrictEqual(error);
+  });
+  it('should return null when data is null', () => {
+    mockObservable = new Observable((subscriber) => {
+      subscriber.next({ data: null });
+    });
+    const { result } = renderHook(() =>
+      useInsightsCategory(viewId, categoryId)
+    );
+    expect(result.current).toBe(null);
+  });
+  it('should unsubscribe on unmount', () => {
+    spyOn(Subscription.prototype, 'unsubscribe');
+    const { unmount } = renderHook(() =>
+      useInsightsCategory(viewId, categoryId)
+    );
+
+    unmount();
+    expect(Subscription.prototype.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/front/app/modules/commercial/insights/hooks/useInsightsCategory.test.ts
+++ b/front/app/modules/commercial/insights/hooks/useInsightsCategory.test.ts
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import useInsightsCategory from './useInsightsCategory';
 import { Observable, Subscription } from 'rxjs';
 import { waitFor } from 'utils/testUtils/rtl';
+import { delay } from 'rxjs/operators';
 import { insightsCategoryStream } from 'modules/commercial/insights/services/insightsCategories';
 
 const viewId = '1';
@@ -18,8 +19,8 @@ const mockCategory = {
 };
 
 let mockObservable = new Observable((subscriber) => {
-  subscriber.next(setTimeout(() => mockCategory, 0));
-});
+  subscriber.next(mockCategory);
+}).pipe(delay(1));
 
 jest.mock('modules/commercial/insights/services/insightsCategories', () => {
   return {
@@ -32,11 +33,11 @@ jest.mock('modules/commercial/insights/services/insightsCategories', () => {
 });
 
 describe('useInsightsCategory', () => {
-  it('should call insightsCategoryStream with correct arguments', async () => {
+  it('should call insightsCategoryStream with correct arguments', () => {
     renderHook(() => useInsightsCategory(viewId, categoryId));
     expect(insightsCategoryStream).toHaveBeenCalledWith(viewId, categoryId);
   });
-  it('should return data when data', async () => {
+  it('should return data when data', () => {
     const { result } = renderHook(() =>
       useInsightsCategory(viewId, categoryId)
     );

--- a/front/app/modules/commercial/insights/hooks/useInsightsCategory.test.ts
+++ b/front/app/modules/commercial/insights/hooks/useInsightsCategory.test.ts
@@ -10,7 +10,7 @@ const categoryId = '1aa8a788-3aee-4ada-a581-6d934e49784b';
 
 const mockCategory = {
   data: {
-    id: '1aa8a788-3aee-4ada-a581-6d934e49784b',
+    id: categoryId,
     type: 'category',
     attributes: {
       name: 'Test',

--- a/front/app/modules/commercial/insights/hooks/useInsightsInput.test.ts
+++ b/front/app/modules/commercial/insights/hooks/useInsightsInput.test.ts
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import useInsightsInput from './useInsightsInput';
 import { Observable, Subscription } from 'rxjs';
 import { waitFor } from 'utils/testUtils/rtl';
+import { delay } from 'rxjs/operators';
 import { insightsInputStream } from 'modules/commercial/insights/services/insightsInputs';
 
 const viewId = '1';
@@ -29,8 +30,8 @@ const mockInput = {
 };
 
 let mockObservable = new Observable((subscriber) => {
-  subscriber.next(setTimeout(() => mockInput, 0));
-});
+  subscriber.next(mockInput);
+}).pipe(delay(1));
 
 jest.mock('modules/commercial/insights/services/insightsInputs', () => {
   return {
@@ -43,11 +44,11 @@ jest.mock('modules/commercial/insights/services/insightsInputs', () => {
 });
 
 describe('useInsightsInput', () => {
-  it('should call insightsInputStream with correct arguments', async () => {
+  it('should call insightsInputStream with correct arguments', () => {
     renderHook(() => useInsightsInput(viewId, inputId));
     expect(insightsInputStream).toHaveBeenCalledWith(viewId, inputId);
   });
-  it('should return data when data', async () => {
+  it('should return data when data', () => {
     const { result } = renderHook(() => useInsightsInput(viewId, inputId));
     expect(result.current).toBe(undefined); // initially, the hook returns undefined
     waitFor(() => expect(result.current).toBe(mockInput.data));

--- a/front/app/modules/commercial/insights/hooks/useInsightsInput.test.ts
+++ b/front/app/modules/commercial/insights/hooks/useInsightsInput.test.ts
@@ -1,0 +1,77 @@
+import { renderHook } from '@testing-library/react-hooks';
+import useInsightsInput from './useInsightsInput';
+import { Observable, Subscription } from 'rxjs';
+import { waitFor } from 'utils/testUtils/rtl';
+import { insightsInputStream } from 'modules/commercial/insights/services/insightsInputs';
+
+const viewId = '1';
+const inputId = '4e9ac1f1-6928-45e9-9ac9-313e86ad636f';
+
+const mockInput = {
+  data: {
+    id: '4e9ac1f1-6928-45e9-9ac9-313e86ad636f',
+    type: 'input',
+    relationships: {
+      source: {
+        data: {
+          id: '4e9ac1f1-6928-45e9-9ac9-313e86ad636f',
+          type: 'idea',
+        },
+      },
+      categories: {
+        data: [],
+      },
+      suggested_categories: {
+        data: [],
+      },
+    },
+  },
+};
+
+let mockObservable = new Observable((subscriber) => {
+  subscriber.next(setTimeout(() => mockInput, 0));
+});
+
+jest.mock('modules/commercial/insights/services/insightsInputs', () => {
+  return {
+    insightsInputStream: jest.fn(() => {
+      return {
+        observable: mockObservable,
+      };
+    }),
+  };
+});
+
+describe('useInsightsInput', () => {
+  it('should call insightsInputStream with correct arguments', async () => {
+    renderHook(() => useInsightsInput(viewId, inputId));
+    expect(insightsInputStream).toHaveBeenCalledWith(viewId, inputId);
+  });
+  it('should return data when data', async () => {
+    const { result } = renderHook(() => useInsightsInput(viewId, inputId));
+    expect(result.current).toBe(undefined); // initially, the hook returns undefined
+    waitFor(() => expect(result.current).toBe(mockInput.data));
+  });
+  it('should return error when error', () => {
+    const error = new Error();
+    mockObservable = new Observable((subscriber) => {
+      subscriber.next({ data: new Error() });
+    });
+    const { result } = renderHook(() => useInsightsInput(viewId, inputId));
+    expect(result.current).toStrictEqual(error);
+  });
+  it('should return null when data is null', () => {
+    mockObservable = new Observable((subscriber) => {
+      subscriber.next({ data: null });
+    });
+    const { result } = renderHook(() => useInsightsInput(viewId, inputId));
+    expect(result.current).toBe(null);
+  });
+  it('should unsubscribe on unmount', () => {
+    spyOn(Subscription.prototype, 'unsubscribe');
+    const { unmount } = renderHook(() => useInsightsInput(viewId, inputId));
+
+    unmount();
+    expect(Subscription.prototype.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/front/app/modules/commercial/insights/hooks/useInsightsInput.test.ts
+++ b/front/app/modules/commercial/insights/hooks/useInsightsInput.test.ts
@@ -10,12 +10,12 @@ const inputId = '4e9ac1f1-6928-45e9-9ac9-313e86ad636f';
 
 const mockInput = {
   data: {
-    id: '4e9ac1f1-6928-45e9-9ac9-313e86ad636f',
+    id: inputId,
     type: 'input',
     relationships: {
       source: {
         data: {
-          id: '4e9ac1f1-6928-45e9-9ac9-313e86ad636f',
+          id: inputId,
           type: 'idea',
         },
       },

--- a/front/app/modules/commercial/insights/hooks/useInsightsInput.test.ts
+++ b/front/app/modules/commercial/insights/hooks/useInsightsInput.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react-hooks';
 import useInsightsInput from './useInsightsInput';
 import { Observable, Subscription } from 'rxjs';
 import { waitFor } from 'utils/testUtils/rtl';
@@ -48,10 +48,13 @@ describe('useInsightsInput', () => {
     renderHook(() => useInsightsInput(viewId, inputId));
     expect(insightsInputStream).toHaveBeenCalledWith(viewId, inputId);
   });
-  it('should return data when data', () => {
+  it('should return data when data', async () => {
     const { result } = renderHook(() => useInsightsInput(viewId, inputId));
     expect(result.current).toBe(undefined); // initially, the hook returns undefined
-    waitFor(() => expect(result.current).toBe(mockInput.data));
+    await act(
+      async () =>
+        await waitFor(() => expect(result.current).toBe(mockInput.data))
+    );
   });
   it('should return error when error', () => {
     const error = new Error();

--- a/front/app/modules/commercial/insights/hooks/useInsightsInputs.test.ts
+++ b/front/app/modules/commercial/insights/hooks/useInsightsInputs.test.ts
@@ -7,14 +7,6 @@ import { insightsInputsStream } from 'modules/commercial/insights/services/insig
 
 const viewId = '1';
 
-const queryParameters: QueryParameters = {
-  category: '3',
-  pageSize: 10,
-  pageNumber: 12,
-  search: 'search',
-  sort: '-approval',
-};
-
 const mockInputs = {
   data: [
     {
@@ -57,6 +49,22 @@ const mockInputs = {
   },
 };
 
+const queryParameters: QueryParameters = {
+  category: '3',
+  pageSize: 10,
+  pageNumber: 12,
+  search: 'search',
+  sort: '-approval',
+};
+
+const expectedQueryParameters = {
+  category: queryParameters.category,
+  'page[number]': queryParameters.pageNumber,
+  'page[size]': queryParameters.pageSize,
+  search: queryParameters.search,
+  sort: queryParameters.sort,
+};
+
 let mockObservable = new Observable((subscriber) => {
   subscriber.next(mockInputs);
 }).pipe(delay(1));
@@ -86,15 +94,111 @@ describe('useInsightsInputs', () => {
   });
   it('should call useInsightsInputs with correct non-default arguments', async () => {
     renderHook(() => useInsightsInputs(viewId, queryParameters));
+
+    expect(insightsInputsStream).toHaveBeenCalledWith(viewId, {
+      queryParameters: expectedQueryParameters,
+    });
+  });
+  it('should call useInsightsInputs with correct arguments on category change', async () => {
+    let category = '5';
+    const { rerender } = renderHook(() =>
+      useInsightsInputs(viewId, { ...queryParameters, category })
+    );
+
+    expect(insightsInputsStream).toHaveBeenCalledWith(viewId, {
+      queryParameters: { ...expectedQueryParameters, category },
+    });
+
+    // Category change
+    category = '6';
+    rerender();
+
+    expect(insightsInputsStream).toHaveBeenCalledWith(viewId, {
+      queryParameters: { ...expectedQueryParameters, category },
+    });
+    expect(insightsInputsStream).toHaveBeenCalledTimes(2);
+  });
+  it('should call useInsightsInputs with correct arguments on page number change', async () => {
+    let pageNumber = 5;
+    const { rerender } = renderHook(() =>
+      useInsightsInputs(viewId, { ...queryParameters, pageNumber })
+    );
+
     expect(insightsInputsStream).toHaveBeenCalledWith(viewId, {
       queryParameters: {
-        category: queryParameters.category,
-        'page[number]': queryParameters.pageNumber,
-        'page[size]': queryParameters.pageSize,
-        search: queryParameters.search,
-        sort: queryParameters.sort,
+        ...expectedQueryParameters,
+        'page[number]': pageNumber,
       },
     });
+
+    // Search change
+    pageNumber = 10;
+    rerender();
+
+    expect(insightsInputsStream).toHaveBeenCalledWith(viewId, {
+      queryParameters: {
+        ...expectedQueryParameters,
+        'page[number]': pageNumber,
+      },
+    });
+    expect(insightsInputsStream).toHaveBeenCalledTimes(2);
+  });
+  it('should call useInsightsInputs with correct arguments on page size change', async () => {
+    let pageSize = 5;
+    const { rerender } = renderHook(() =>
+      useInsightsInputs(viewId, { ...queryParameters, pageSize })
+    );
+
+    expect(insightsInputsStream).toHaveBeenCalledWith(viewId, {
+      queryParameters: { ...expectedQueryParameters, 'page[size]': pageSize },
+    });
+
+    // Search change
+    pageSize = 10;
+    rerender();
+
+    expect(insightsInputsStream).toHaveBeenCalledWith(viewId, {
+      queryParameters: { ...expectedQueryParameters, 'page[size]': pageSize },
+    });
+    expect(insightsInputsStream).toHaveBeenCalledTimes(2);
+  });
+  it('should call useInsightsInputs with correct arguments on search change', async () => {
+    let search = 'some search';
+    const { rerender } = renderHook(() =>
+      useInsightsInputs(viewId, { ...queryParameters, search })
+    );
+
+    expect(insightsInputsStream).toHaveBeenCalledWith(viewId, {
+      queryParameters: { ...expectedQueryParameters, search },
+    });
+
+    // Search change
+    search = 'another search';
+    rerender();
+
+    expect(insightsInputsStream).toHaveBeenCalledWith(viewId, {
+      queryParameters: { ...expectedQueryParameters, search },
+    });
+    expect(insightsInputsStream).toHaveBeenCalledTimes(2);
+  });
+  it('should call useInsightsInputs with correct arguments on sort change', async () => {
+    let sort: QueryParameters['sort'] = 'approval';
+    const { rerender } = renderHook(() =>
+      useInsightsInputs(viewId, { ...queryParameters, sort })
+    );
+
+    expect(insightsInputsStream).toHaveBeenCalledWith(viewId, {
+      queryParameters: { ...expectedQueryParameters, sort },
+    });
+
+    // Sort change
+    sort = '-approval';
+    rerender();
+
+    expect(insightsInputsStream).toHaveBeenCalledWith(viewId, {
+      queryParameters: { ...expectedQueryParameters, sort },
+    });
+    expect(insightsInputsStream).toHaveBeenCalledTimes(2);
   });
   it('should return correct data when data', async () => {
     const { result } = renderHook(() => useInsightsInputs(viewId));

--- a/front/app/modules/commercial/insights/hooks/useInsightsInputs.test.ts
+++ b/front/app/modules/commercial/insights/hooks/useInsightsInputs.test.ts
@@ -1,0 +1,152 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import useInsightsInputs, { QueryParameters } from './useInsightsInputs';
+import { Observable, Subscription } from 'rxjs';
+import { delay } from 'rxjs/operators';
+import { waitFor } from 'utils/testUtils/rtl';
+import { insightsInputsStream } from 'modules/commercial/insights/services/insightsInputs';
+
+const viewId = '1';
+
+const queryParameters: QueryParameters = {
+  category: '3',
+  pageSize: 10,
+  pageNumber: 12,
+  search: 'search',
+  sort: '-approval',
+};
+
+const mockInputs = {
+  data: {
+    currentPage: 1,
+    lastPage: 2,
+    list: [
+      {
+        id: '4e9ac1f1-6928-45e9-9ac9-313e86ad636f',
+        type: 'input',
+        relationships: {
+          source: {
+            data: {
+              id: '4e9ac1f1-6928-45e9-9ac9-313e86ad636f',
+              type: 'idea',
+            },
+          },
+          categories: {
+            data: [
+              {
+                id: '94a649b5-23fe-4d47-9165-9beceef2dcad',
+                type: 'category',
+              },
+              {
+                id: '94a649b5-23fe-4d47-9165-9becedfg45sd',
+                type: 'category',
+              },
+            ],
+          },
+          suggested_categories: {
+            data: [],
+          },
+        },
+      },
+      {
+        id: '54438f73-12f4-4b16-84f3-a55bd118de7e',
+        type: 'input',
+        relationships: {
+          source: {
+            data: {
+              id: '54438f73-12f4-4b16-84f3-a55bd118de7e',
+              type: 'idea',
+            },
+          },
+          categories: {
+            data: [],
+          },
+          suggested_categories: {
+            data: [],
+          },
+        },
+      },
+    ],
+  },
+};
+
+let mockObservable = new Observable((subscriber) => {
+  subscriber.next(mockInputs);
+}).pipe(delay(1));
+
+jest.mock('modules/commercial/insights/services/insightsInputs', () => {
+  return {
+    insightsInputsStream: jest.fn(() => {
+      return {
+        observable: mockObservable,
+      };
+    }),
+  };
+});
+
+describe('useInsightsInputs', () => {
+  it('should call useInsightsInputs with correct default arguments', async () => {
+    renderHook(() => useInsightsInputs(viewId));
+    expect(insightsInputsStream).toHaveBeenCalledWith(viewId, {
+      queryParameters: {
+        category: undefined,
+        'page[number]': 1,
+        'page[size]': 20,
+        search: undefined,
+        sort: 'approval',
+      },
+    });
+  });
+  it('should call useInsightsInputs with correct non-default arguments', async () => {
+    renderHook(() => useInsightsInputs(viewId, queryParameters));
+    expect(insightsInputsStream).toHaveBeenCalledWith(viewId, {
+      queryParameters: {
+        category: queryParameters.category,
+        'page[number]': queryParameters.pageNumber,
+        'page[size]': queryParameters.pageSize,
+        search: queryParameters.search,
+        sort: queryParameters.sort,
+      },
+    });
+  });
+  it('should return correct data when data', () => {
+    const { result } = renderHook(() => useInsightsInputs(viewId));
+    expect(result.current).toStrictEqual({
+      lastPage: null,
+      list: undefined, // initially, the hook list returns undefined
+      loading: true,
+    });
+    act(() => {
+      waitFor(() => {
+        expect(result.current.list).toBe(mockInputs.data.list);
+        expect(result.current.lastPage).toBe(mockInputs.data.lastPage);
+        expect(result.current.loading).toBe(false);
+      });
+    });
+  });
+  it('should return error when error', () => {
+    const error = new Error();
+    mockObservable = new Observable((subscriber) => {
+      subscriber.next({ data: new Error() });
+    });
+    const { result } = renderHook(() => useInsightsInputs(viewId));
+    expect(result.current.list).toStrictEqual(error);
+    expect(result.current.loading).toStrictEqual(false);
+    expect(result.current.lastPage).toStrictEqual(null);
+  });
+  it('should return null when data is null', () => {
+    mockObservable = new Observable((subscriber) => {
+      subscriber.next({ data: null });
+    });
+    const { result } = renderHook(() => useInsightsInputs(viewId));
+    expect(result.current.list).toBe(null);
+    expect(result.current.loading).toStrictEqual(false);
+    expect(result.current.lastPage).toStrictEqual(null);
+  });
+  it('should unsubscribe on unmount', () => {
+    spyOn(Subscription.prototype, 'unsubscribe');
+    const { unmount } = renderHook(() => useInsightsInputs(viewId));
+
+    unmount();
+    expect(Subscription.prototype.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/front/app/modules/commercial/insights/hooks/useInsightsInputs.test.ts
+++ b/front/app/modules/commercial/insights/hooks/useInsightsInputs.test.ts
@@ -16,56 +16,44 @@ const queryParameters: QueryParameters = {
 };
 
 const mockInputs = {
-  data: {
-    currentPage: 1,
-    lastPage: 2,
-    list: [
-      {
-        id: '4e9ac1f1-6928-45e9-9ac9-313e86ad636f',
-        type: 'input',
-        relationships: {
-          source: {
-            data: {
-              id: '4e9ac1f1-6928-45e9-9ac9-313e86ad636f',
-              type: 'idea',
-            },
-          },
-          categories: {
-            data: [
-              {
-                id: '94a649b5-23fe-4d47-9165-9beceef2dcad',
-                type: 'category',
-              },
-              {
-                id: '94a649b5-23fe-4d47-9165-9becedfg45sd',
-                type: 'category',
-              },
-            ],
-          },
-          suggested_categories: {
-            data: [],
-          },
+  data: [
+    {
+      id: 'f270e1dd-48c2-4736-912a-1aba276dcd1a',
+      type: 'input',
+      relationships: {
+        source: {
+          data: { id: 'f270e1dd-48c2-4736-912a-1aba276dcd1a', type: 'idea' },
         },
+        categories: { data: [] },
+        suggested_categories: { data: [] },
       },
-      {
-        id: '54438f73-12f4-4b16-84f3-a55bd118de7e',
-        type: 'input',
-        relationships: {
-          source: {
-            data: {
-              id: '54438f73-12f4-4b16-84f3-a55bd118de7e',
-              type: 'idea',
-            },
-          },
-          categories: {
-            data: [],
-          },
-          suggested_categories: {
-            data: [],
-          },
+    },
+    {
+      id: '49d36411-d736-4fc9-9e66-fa05d57663b7',
+      type: 'input',
+      relationships: {
+        source: {
+          data: { id: '49d36411-d736-4fc9-9e66-fa05d57663b7', type: 'idea' },
         },
+        categories: {
+          data: [
+            { id: '4e14b5b3-d95a-4925-8eba-1f57b7e87f63', type: 'category' },
+            { id: '3d0e81fb-062f-4ce2-981e-0f619cea4c4f', type: 'category' },
+          ],
+        },
+        suggested_categories: { data: [] },
       },
-    ],
+    },
+  ],
+  links: {
+    self:
+      'views/eefff7f5-957a-4b5b-816c-9278943ccde7/inputs?page%5Bnumber%5D=1\u0026page%5Bsize%5D=20\u0026sort=approval',
+    first:
+      'views/eefff7f5-957a-4b5b-816c-9278943ccde7/inputs?page%5Bnumber%5D=1\u0026page%5Bsize%5D=20\u0026sort=approval',
+    last:
+      'views/eefff7f5-957a-4b5b-816c-9278943ccde7/inputs?page%5Bnumber%5D=1\u0026page%5Bsize%5D=20\u0026sort=approval',
+    prev: null,
+    next: null,
   },
 };
 
@@ -108,18 +96,19 @@ describe('useInsightsInputs', () => {
       },
     });
   });
-  it('should return correct data when data', () => {
+  it('should return correct data when data', async () => {
     const { result } = renderHook(() => useInsightsInputs(viewId));
     expect(result.current).toStrictEqual({
       lastPage: null,
       list: undefined, // initially, the hook list returns undefined
       loading: true,
     });
-    act(() => {
-      waitFor(() => {
-        expect(result.current.list).toBe(mockInputs.data.list);
-        expect(result.current.lastPage).toBe(mockInputs.data.lastPage);
-        expect(result.current.loading).toBe(false);
+
+    await act(async () => {
+      await waitFor(() => {
+        expect(result.current.list).toStrictEqual(mockInputs.data);
+        expect(result.current.lastPage).toStrictEqual(1);
+        expect(result.current.loading).toStrictEqual(false);
       });
     });
   });

--- a/front/app/modules/commercial/insights/hooks/useInsightsInputs.ts
+++ b/front/app/modules/commercial/insights/hooks/useInsightsInputs.ts
@@ -7,7 +7,7 @@ import {
 
 const defaultPageSize = 20;
 
-type QueryParameters = {
+export type QueryParameters = {
   category: string;
   pageSize: number;
   pageNumber: number;
@@ -29,14 +29,13 @@ const useInsightsInputs = (
   const [insightsInputs, setInsightsInputs] = useState<
     IInsightsInputData[] | undefined | null | Error
   >(undefined);
+  const [lastPage, setLastPage] = useState<number | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
 
   const pageNumber = queryParameters?.pageNumber;
   const category = queryParameters?.category;
   const search = queryParameters?.search;
   const sort = queryParameters?.sort || 'approval';
-
-  const [lastPage, setLastPage] = useState<number | null>(null);
-  const [loading, setLoading] = useState<boolean>(true);
 
   useEffect(() => {
     setLoading(true);

--- a/front/app/modules/commercial/insights/hooks/useInsightsInputs.ts
+++ b/front/app/modules/commercial/insights/hooks/useInsightsInputs.ts
@@ -12,7 +12,7 @@ export type QueryParameters = {
   pageSize: number;
   pageNumber: number;
   search: string;
-  sort?: 'approval' | '-approval';
+  sort: 'approval' | '-approval';
 };
 
 export interface IUseInpightsInputsOutput {
@@ -33,9 +33,10 @@ const useInsightsInputs = (
   const [loading, setLoading] = useState<boolean>(true);
 
   const pageNumber = queryParameters?.pageNumber;
+  const pageSize = queryParameters?.pageSize;
   const category = queryParameters?.category;
   const search = queryParameters?.search;
-  const sort = queryParameters?.sort || 'approval';
+  const sort = queryParameters?.sort;
 
   useEffect(() => {
     setLoading(true);
@@ -43,7 +44,7 @@ const useInsightsInputs = (
       queryParameters: {
         category,
         search,
-        sort,
+        sort: queryParameters?.sort || 'approval',
         'page[number]': queryParameters?.pageNumber || 1,
         'page[size]': queryParameters?.pageSize || defaultPageSize,
       },
@@ -54,7 +55,7 @@ const useInsightsInputs = (
     });
 
     return () => subscription.unsubscribe();
-  }, [viewId, pageNumber, category, search, sort]);
+  }, [viewId, pageNumber, category, search, sort, pageSize]);
 
   return {
     lastPage,

--- a/front/app/modules/commercial/insights/hooks/useInsightsView.test.ts
+++ b/front/app/modules/commercial/insights/hooks/useInsightsView.test.ts
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import useInsightsView from './useInsightsView';
 import { Observable, Subscription } from 'rxjs';
 import { waitFor } from 'utils/testUtils/rtl';
+import { delay } from 'rxjs/operators';
 import { insightsViewStream } from 'modules/commercial/insights/services/insightsViews';
 
 const viewId = '1aa8a788-3aee-4ada-a581-6d934e49784b';
@@ -18,8 +19,8 @@ const mockView = {
 };
 
 let mockObservable = new Observable((subscriber) => {
-  subscriber.next(setTimeout(() => mockView, 0));
-});
+  subscriber.next(mockView);
+}).pipe(delay(1));
 
 jest.mock('modules/commercial/insights/services/insightsViews', () => {
   return {
@@ -32,11 +33,11 @@ jest.mock('modules/commercial/insights/services/insightsViews', () => {
 });
 
 describe('useInsightsView', () => {
-  it('should call insightsViewStream with correct arguments', async () => {
+  it('should call insightsViewStream with correct arguments', () => {
     renderHook(() => useInsightsView(viewId));
     expect(insightsViewStream).toHaveBeenCalledWith(viewId);
   });
-  it('should return data when data', async () => {
+  it('should return data when data', () => {
     const { result } = renderHook(() => useInsightsView(viewId));
     expect(result.current).toBe(undefined); // initially, the hook returns undefined
     waitFor(() => expect(result.current).toBe(mockView.data));

--- a/front/app/modules/commercial/insights/hooks/useInsightsView.test.ts
+++ b/front/app/modules/commercial/insights/hooks/useInsightsView.test.ts
@@ -9,7 +9,7 @@ const viewId = '1aa8a788-3aee-4ada-a581-6d934e49784b';
 
 const mockView = {
   data: {
-    id: '1aa8a788-3aee-4ada-a581-6d934e49784b',
+    id: viewId,
     type: 'view',
     attributes: {
       name: 'Test',

--- a/front/app/modules/commercial/insights/hooks/useInsightsView.test.ts
+++ b/front/app/modules/commercial/insights/hooks/useInsightsView.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react-hooks';
 import useInsightsView from './useInsightsView';
 import { Observable, Subscription } from 'rxjs';
 import { waitFor } from 'utils/testUtils/rtl';
@@ -37,10 +37,13 @@ describe('useInsightsView', () => {
     renderHook(() => useInsightsView(viewId));
     expect(insightsViewStream).toHaveBeenCalledWith(viewId);
   });
-  it('should return data when data', () => {
+  it('should return data when data', async () => {
     const { result } = renderHook(() => useInsightsView(viewId));
     expect(result.current).toBe(undefined); // initially, the hook returns undefined
-    waitFor(() => expect(result.current).toBe(mockView.data));
+    await act(
+      async () =>
+        await waitFor(() => expect(result.current).toBe(mockView.data))
+    );
   });
   it('should return error when error', () => {
     const error = new Error();

--- a/front/app/modules/commercial/insights/hooks/useInsightsView.test.ts
+++ b/front/app/modules/commercial/insights/hooks/useInsightsView.test.ts
@@ -1,29 +1,29 @@
 import { renderHook } from '@testing-library/react-hooks';
-import useInsightsCategory from './useInsightsCategory';
+import useInsightsView from './useInsightsView';
 import { Observable, Subscription } from 'rxjs';
 import { waitFor } from 'utils/testUtils/rtl';
-import { insightsCategoryStream } from 'modules/commercial/insights/services/insightsCategories';
+import { insightsViewStream } from 'modules/commercial/insights/services/insightsViews';
 
-const viewId = '1';
-const categoryId = '1aa8a788-3aee-4ada-a581-6d934e49784b';
+const viewId = '1aa8a788-3aee-4ada-a581-6d934e49784b';
 
-const mockCategory = {
+const mockView = {
   data: {
     id: '1aa8a788-3aee-4ada-a581-6d934e49784b',
-    type: 'category',
+    type: 'view',
     attributes: {
       name: 'Test',
+      updated_at: '2021-05-18T16:07:27.123Z',
     },
   },
 };
 
 let mockObservable = new Observable((subscriber) => {
-  subscriber.next(setTimeout(() => mockCategory, 0));
+  subscriber.next(setTimeout(() => mockView, 0));
 });
 
-jest.mock('modules/commercial/insights/services/insightsCategories', () => {
+jest.mock('modules/commercial/insights/services/insightsViews', () => {
   return {
-    insightsCategoryStream: jest.fn(() => {
+    insightsViewStream: jest.fn(() => {
       return {
         observable: mockObservable,
       };
@@ -31,42 +31,34 @@ jest.mock('modules/commercial/insights/services/insightsCategories', () => {
   };
 });
 
-describe('useInsightsCategory', () => {
-  it('should call insightsCategoryStream with correct arguments', async () => {
-    renderHook(() => useInsightsCategory(viewId, categoryId));
-    expect(insightsCategoryStream).toHaveBeenCalledWith(viewId, categoryId);
+describe('useInsightsView', () => {
+  it('should call insightsViewStream with correct arguments', async () => {
+    renderHook(() => useInsightsView(viewId));
+    expect(insightsViewStream).toHaveBeenCalledWith(viewId);
   });
   it('should return data when data', async () => {
-    const { result } = renderHook(() =>
-      useInsightsCategory(viewId, categoryId)
-    );
+    const { result } = renderHook(() => useInsightsView(viewId));
     expect(result.current).toBe(undefined); // initially, the hook returns undefined
-    waitFor(() => expect(result.current).toBe(mockCategory.data));
+    waitFor(() => expect(result.current).toBe(mockView.data));
   });
   it('should return error when error', () => {
     const error = new Error();
     mockObservable = new Observable((subscriber) => {
       subscriber.next({ data: new Error() });
     });
-    const { result } = renderHook(() =>
-      useInsightsCategory(viewId, categoryId)
-    );
+    const { result } = renderHook(() => useInsightsView(viewId));
     expect(result.current).toStrictEqual(error);
   });
   it('should return null when data is null', () => {
     mockObservable = new Observable((subscriber) => {
       subscriber.next({ data: null });
     });
-    const { result } = renderHook(() =>
-      useInsightsCategory(viewId, categoryId)
-    );
+    const { result } = renderHook(() => useInsightsView(viewId));
     expect(result.current).toBe(null);
   });
   it('should unsubscribe on unmount', () => {
     spyOn(Subscription.prototype, 'unsubscribe');
-    const { unmount } = renderHook(() =>
-      useInsightsCategory(viewId, categoryId)
-    );
+    const { unmount } = renderHook(() => useInsightsView(viewId));
 
     unmount();
     expect(Subscription.prototype.unsubscribe).toHaveBeenCalledTimes(1);

--- a/front/app/modules/commercial/insights/hooks/useInsightsViews.test.ts
+++ b/front/app/modules/commercial/insights/hooks/useInsightsViews.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react-hooks';
 import useInsightsViews from './useInsightsViews';
 import { Observable, Subscription } from 'rxjs';
 import { waitFor } from 'utils/testUtils/rtl';
@@ -48,7 +48,10 @@ describe('useInsightsViews', () => {
   it('should return data when data', async () => {
     const { result } = renderHook(() => useInsightsViews());
     expect(result.current).toBe(undefined); // initially, the hook returns undefined
-    waitFor(() => expect(result.current).toBe(mockViews.data));
+    await act(
+      async () =>
+        await waitFor(() => expect(result.current).toBe(mockViews.data))
+    );
   });
   it('should return error when error', () => {
     const error = new Error();

--- a/front/app/modules/commercial/insights/hooks/useInsightsViews.test.ts
+++ b/front/app/modules/commercial/insights/hooks/useInsightsViews.test.ts
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import useInsightsViews from './useInsightsViews';
 import { Observable, Subscription } from 'rxjs';
 import { waitFor } from 'utils/testUtils/rtl';
+import { delay } from 'rxjs/operators';
 import { insightsViewsStream } from 'modules/commercial/insights/services/insightsViews';
 
 const mockViews = {
@@ -26,8 +27,8 @@ const mockViews = {
 };
 
 let mockObservable = new Observable((subscriber) => {
-  subscriber.next(setTimeout(() => mockViews, 0));
-});
+  subscriber.next(mockViews);
+}).pipe(delay(1));
 
 jest.mock('modules/commercial/insights/services/insightsViews', () => {
   return {

--- a/front/app/modules/commercial/insights/hooks/useInsightsViews.test.ts
+++ b/front/app/modules/commercial/insights/hooks/useInsightsViews.test.ts
@@ -1,0 +1,74 @@
+import { renderHook } from '@testing-library/react-hooks';
+import useInsightsViews from './useInsightsViews';
+import { Observable, Subscription } from 'rxjs';
+import { waitFor } from 'utils/testUtils/rtl';
+import { insightsViewsStream } from 'modules/commercial/insights/services/insightsViews';
+
+const mockViews = {
+  data: [
+    {
+      id: '1aa8a788-3aee-4ada-a581-6d934e49784b',
+      type: 'view',
+      attributes: {
+        name: 'Test',
+        updated_at: '2021-05-18T16:07:27.123Z',
+      },
+    },
+    {
+      id: '4b429681-1744-456f-8550-e89a2c2c74b2',
+      type: 'view',
+      attributes: {
+        name: 'Test 2',
+        updated_at: '2021-05-18T16:07:49.156Z',
+      },
+    },
+  ],
+};
+
+let mockObservable = new Observable((subscriber) => {
+  subscriber.next(setTimeout(() => mockViews, 0));
+});
+
+jest.mock('modules/commercial/insights/services/insightsViews', () => {
+  return {
+    insightsViewsStream: jest.fn(() => {
+      return {
+        observable: mockObservable,
+      };
+    }),
+  };
+});
+
+describe('useInsightsViews', () => {
+  it('should call insightsViewsStream with correct arguments', async () => {
+    renderHook(() => useInsightsViews());
+    expect(insightsViewsStream).toHaveBeenCalledWith();
+  });
+  it('should return data when data', async () => {
+    const { result } = renderHook(() => useInsightsViews());
+    expect(result.current).toBe(undefined); // initially, the hook returns undefined
+    waitFor(() => expect(result.current).toBe(mockViews.data));
+  });
+  it('should return error when error', () => {
+    const error = new Error();
+    mockObservable = new Observable((subscriber) => {
+      subscriber.next({ data: new Error() });
+    });
+    const { result } = renderHook(() => useInsightsViews());
+    expect(result.current).toStrictEqual(error);
+  });
+  it('should return null when data is null', () => {
+    mockObservable = new Observable((subscriber) => {
+      subscriber.next({ data: null });
+    });
+    const { result } = renderHook(() => useInsightsViews());
+    expect(result.current).toBe(null);
+  });
+  it('should unsubscribe on unmount', () => {
+    spyOn(Subscription.prototype, 'unsubscribe');
+    const { unmount } = renderHook(() => useInsightsViews());
+
+    unmount();
+    expect(Subscription.prototype.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7033,6 +7033,19 @@
         "@testing-library/dom": "^7.28.1"
       }
     },
+    "@testing-library/react-hooks": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-7.0.1.tgz",
+      "integrity": "sha512-bpEQ2SHSBSzBmfJ437NmnP+oArQ7aVmmULiAp6Ag2rtyLBLPNFSMmgltUbFGmQOJdPWo4Ub31kpUC5T46zXNwQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@types/react": ">=16.9.0",
+        "@types/react-dom": ">=16.9.0",
+        "@types/react-test-renderer": ">=16.9.0",
+        "react-error-boundary": "^3.1.0"
+      }
+    },
     "@testing-library/user-event": {
       "version": "13.1.9",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.1.9.tgz",
@@ -7805,6 +7818,15 @@
       "version": "11.0.4",
       "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.4.tgz",
       "integrity": "sha512-9GfTo3a0PHwQeTVoqs0g5bS28KkSY48pp5659wA+Dp4MqceDEa8EHBqrllJvvtyusszyJhViUEap0FDvlk/9Zg==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-test-renderer": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz",
+      "integrity": "sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==",
       "dev": true,
       "requires": {
         "@types/react": "*"
@@ -28901,6 +28923,15 @@
           "integrity": "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==",
           "dev": true
         }
+      }
+    },
+    "react-error-boundary": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.3.tgz",
+      "integrity": "sha512-A+F9HHy9fvt9t8SNDlonq01prnU8AmkjvGKV4kk8seB9kU3xMEO8J/PQlLVmoOIDODl5U2kufSBs4vrWIqhsAA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5"
       }
     },
     "react-error-overlay": {

--- a/front/package.json
+++ b/front/package.json
@@ -154,6 +154,7 @@
     "@storybook/theming": "5.x",
     "@testing-library/jest-dom": "5.12.0",
     "@testing-library/react": "11.2.7",
+    "@testing-library/react-hooks": "^7.0.1",
     "@testing-library/user-event": "13.1.9",
     "@types/enzyme": "3.10.8",
     "@types/enzyme-adapter-react-16": "1.0.6",


### PR DESCRIPTION
Adds tests to the request hooks in our Insights module.

_Note: Assigning multiple people for the purpose of knowledge sharing. We can use the same approach to add tests to all of our request hooks!_ 