### PR TITLE
CL2-6575 HTML support for blocked words

### DIFF
--- a/back/app/services/profanity_service.rb
+++ b/back/app/services/profanity_service.rb
@@ -46,7 +46,7 @@ class ProfanityService
   def normalize_text text
     # We could also consider removing accents and
     # substituting digits by resembling letters.
-    text.downcase
+    Nokogiri::HTML(text).text.downcase
   end
 
   def without_special_chars text

--- a/back/spec/services/profanity_service_spec.rb
+++ b/back/spec/services/profanity_service_spec.rb
@@ -73,7 +73,6 @@ describe ProfanityService do
       text = 'Il est un peu déBiLE.'
       expect(service.search_blocked_words(text)).to match_array([{
         word: 'débile',
-        # position: 14,
         language: 'fr'
       }])
     end
@@ -82,6 +81,16 @@ describe ProfanityService do
       text = 'Il est un peu debile et id1ot.'
       expect(service.search_blocked_words(text)).to be_blank
     end
+
+    it "matches with HTML" do
+      text = '<p>Je suis tombé dans une pute</p>'
+      expect(service.search_blocked_words(text)).to match_array([{
+        word: 'pute',
+        language: 'fr'
+      }])
+    end
+
+    # Nokogiri::HTML('<p>test test test tes test pute </p>').text
   end
 
   private
@@ -93,7 +102,8 @@ describe ProfanityService do
         [
           'con',
           'débile',
-          'idiot'
+          'idiot',
+          'pute'
         ]
       when 'nl'
         [

--- a/back/spec/services/profanity_service_spec.rb
+++ b/back/spec/services/profanity_service_spec.rb
@@ -89,8 +89,6 @@ describe ProfanityService do
         language: 'fr'
       }])
     end
-
-    # Nokogiri::HTML('<p>test test test tes test pute </p>').text
   end
 
   private


### PR DESCRIPTION
This also works when the text does not contain HTML or contains invalid HTML.