### PR TITLE
useModerations pageNumber/currentPage

### DIFF
--- a/front/app/modules/commercial/moderation/admin/containers/index.tsx
+++ b/front/app/modules/commercial/moderation/admin/containers/index.tsx
@@ -240,8 +240,8 @@ const Moderation = memo<Props & InjectedIntlProps>(({ className, intl }) => {
   const {
     list: moderations,
     pageSize,
+    pageNumber,
     moderationStatus,
-    currentPage,
     lastPage,
     onModerationStatusChange,
     onPageNumberChange,
@@ -433,7 +433,7 @@ const Moderation = memo<Props & InjectedIntlProps>(({ className, intl }) => {
     if (!processing) {
       setSelectedModerations([]);
     }
-  }, [currentPage, moderationStatus, pageSize, processing]);
+  }, [pageNumber, moderationStatus, pageSize, processing]);
 
   if (!isNilOrError(moderations)) {
     return (
@@ -574,7 +574,7 @@ const Moderation = memo<Props & InjectedIntlProps>(({ className, intl }) => {
         {moderations.length > 0 && (
           <Footer>
             <StyledPagination
-              currentPage={currentPage}
+              currentPage={pageNumber}
               totalPages={lastPage}
               loadPage={handePageNumberChange}
             />

--- a/front/app/modules/commercial/moderation/hooks/useModerations.ts
+++ b/front/app/modules/commercial/moderation/hooks/useModerations.ts
@@ -28,7 +28,6 @@ export default function useModerations(props: InputProps) {
   const [list, setList] = useState<
     IModerationData[] | undefined | null | Error
   >(undefined);
-  const [currentPage, setCurrentPage] = useState(1);
   const [lastPage, setLastPage] = useState(1);
   const [moderatableTypes, setModeratableTypes] = useState(
     props.moderatableTypes || []
@@ -85,10 +84,10 @@ export default function useModerations(props: InputProps) {
       },
     }).observable.subscribe((response) => {
       const list = !isNilOrError(response) ? response.data : response;
-      const currentPage = getPageNumberFromUrl(response?.links?.self) || 1;
+      const pageNumber = getPageNumberFromUrl(response?.links?.self) || 1;
       const lastPage = getPageNumberFromUrl(response?.links?.last) || 1;
       setList(list);
-      setCurrentPage(currentPage);
+      setPageNumber(pageNumber);
       setLastPage(lastPage);
     });
 
@@ -104,7 +103,6 @@ export default function useModerations(props: InputProps) {
 
   return {
     list,
-    currentPage,
     lastPage,
     pageSize,
     moderationStatus,

--- a/front/app/modules/commercial/moderation/hooks/useModerations.ts
+++ b/front/app/modules/commercial/moderation/hooks/useModerations.ts
@@ -105,6 +105,7 @@ export default function useModerations(props: InputProps) {
     list,
     lastPage,
     pageSize,
+    pageNumber,
     moderationStatus,
     onPageNumberChange,
     onPageSizeChange,


### PR DESCRIPTION
Both currentPage and pageNumber were intended to do the same thing, but have been mixed up. Using pageNumber now like we do in other resources.