### PR TITLE
IN-503 Fix polling when scanning a category

### DIFF
--- a/front/app/modules/commercial/insights/admin/containers/Insights/Edit/Categories/index.tsx
+++ b/front/app/modules/commercial/insights/admin/containers/Insights/Edit/Categories/index.tsx
@@ -293,8 +293,11 @@ const Categories = ({
           {loadingAdd ? <Spinner size="22px" /> : <StyledPlus>+</StyledPlus>}
         </Button>
       </FormContainer>
-      {errors && <Error apiErrors={errors['name']} fieldName="category_name" />}
-
+      <div>
+        {errors && (
+          <Error apiErrors={errors['name']} fieldName="category_name" />
+        )}
+      </div>
       {categories.length === 0 ? (
         <CategoryInfoBox data-testid="insightsNoCategories">
           <p>

--- a/front/app/modules/commercial/insights/admin/containers/Insights/Edit/InputsTable/ScanCategory.test.tsx
+++ b/front/app/modules/commercial/insights/admin/containers/Insights/Edit/InputsTable/ScanCategory.test.tsx
@@ -78,7 +78,7 @@ jest.mock('hooks/useLocale');
 const viewId = '1';
 const categoryId = '2';
 
-let mockLocationData = { pathname: '', query: { category: categoryId } };
+const mockLocationData = { pathname: '', query: { category: categoryId } };
 
 jest.mock('react-router', () => {
   return {
@@ -109,17 +109,9 @@ describe('Scan category', () => {
     ).toHaveBeenCalledWith(viewId, [categoryId]);
   });
   it('disables button if the selected category is already in a pending task', () => {
-    mockLocationData = {
-      pathname: '',
-      query: {
-        category:
-          mockCategoriesSuggestionsTasks[0].relationships.categories.data[0].id,
-      },
-    };
-
     render(<ScanCategory />);
 
     fireEvent.click(screen.getByRole('button'));
-    expect(insightsTriggerCategoriesSuggestionsTasks).toHaveBeenCalledTimes(0);
+    expect(screen.getByRole('button')).toBeDisabled();
   });
 });

--- a/front/app/modules/commercial/insights/admin/containers/Insights/Edit/InputsTable/ScanCategory.tsx
+++ b/front/app/modules/commercial/insights/admin/containers/Insights/Edit/InputsTable/ScanCategory.tsx
@@ -58,7 +58,8 @@ const ScanCategory = ({
 }: InjectedIntlProps & WithRouterProps) => {
   const categories = useMemo(() => [query.category], [query.category]);
   const categorySuggestionsPendingTasks = useInsightsCategoriesSuggestionsTasks(
-    viewId
+    viewId,
+    { categories }
   );
 
   const suggestCategories = async () => {

--- a/front/app/modules/commercial/insights/admin/containers/Insights/Edit/InputsTable/ScanCategory.tsx
+++ b/front/app/modules/commercial/insights/admin/containers/Insights/Edit/InputsTable/ScanCategory.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useEffect, useState } from 'react';
 import { withRouter, WithRouterProps } from 'react-router';
 
 // styles
@@ -13,7 +13,6 @@ import { isNilOrError } from 'utils/helperUtils';
 
 // components
 import Button from 'components/UI/Button';
-import { Spinner } from 'cl2-component-library';
 
 // services
 import { insightsTriggerCategoriesSuggestionsTasks } from 'modules/commercial/insights/services/insightsCategoriesSuggestionsTasks';
@@ -43,27 +42,30 @@ const ScanContainer = styled.div`
   }
 `;
 
-const ScanButtonContent = styled.div`
-  display: flex;
-  align-items: center;
-  > div:first-child {
-    margin-right: 8px;
-  }
-`;
-
 const ScanCategory = ({
   intl: { formatMessage },
   params: { viewId },
   location: { query },
 }: InjectedIntlProps & WithRouterProps) => {
+  const [loading, setLoading] = useState(false);
   const categories = useMemo(() => [query.category], [query.category]);
   const categorySuggestionsPendingTasks = useInsightsCategoriesSuggestionsTasks(
     viewId,
     { categories }
   );
 
+  useEffect(() => {
+    if (
+      !isNilOrError(categorySuggestionsPendingTasks) &&
+      categorySuggestionsPendingTasks.length === 0
+    ) {
+      setLoading(false);
+    }
+  }, [categorySuggestionsPendingTasks]);
+
   const suggestCategories = async () => {
     try {
+      setLoading(true);
       await insightsTriggerCategoriesSuggestionsTasks(viewId, categories);
     } catch {
       // Do nothing
@@ -73,14 +75,6 @@ const ScanCategory = ({
   if (isNilOrError(categorySuggestionsPendingTasks)) {
     return null;
   }
-
-  const loading = Boolean(
-    categorySuggestionsPendingTasks.find((pendingTask) =>
-      pendingTask.relationships?.categories.data
-        .map((category) => category.id)
-        .includes(query.category)
-    )
-  );
 
   return (
     <ScanContainer data-testid="insightsScanCategory">
@@ -97,11 +91,9 @@ const ScanCategory = ({
         buttonStyle="admin-dark"
         onClick={suggestCategories}
         disabled={loading}
+        processing={loading}
       >
-        <ScanButtonContent>
-          {loading && <Spinner size="22px" />}
-          {formatMessage(messages.categoriesEmptyScanButton)}
-        </ScanButtonContent>
+        {formatMessage(messages.categoriesEmptyScanButton)}
       </Button>
     </ScanContainer>
   );

--- a/front/app/modules/commercial/insights/hooks/useInsightsCategoriesSuggestionsTasks.test.tsx
+++ b/front/app/modules/commercial/insights/hooks/useInsightsCategoriesSuggestionsTasks.test.tsx
@@ -6,7 +6,6 @@ import { Observable, Subscription } from 'rxjs';
 import { delay } from 'rxjs/operators';
 import { waitFor } from 'utils/testUtils/rtl';
 import { insightsCategoriesSuggestionsTasksStream } from 'modules/commercial/insights/services/insightsCategoriesSuggestionsTasks';
-import streams from 'utils/streams';
 
 const viewId = '1';
 
@@ -86,14 +85,6 @@ jest.mock(
     };
   }
 );
-
-jest.mock('utils/streams', () => {
-  return { fetchAllWith: jest.fn() };
-});
-
-jest.mock('utils/helperUtils', () => {
-  return { isNilOrError: jest.fn(() => false) };
-});
 
 describe('useInsightsCatgeoriesSuggestionsTasks', () => {
   it('should call useInsightsCatgeoriesSuggestionsTasks with correct viewId', async () => {
@@ -204,39 +195,6 @@ describe('useInsightsCatgeoriesSuggestionsTasks', () => {
     );
   });
 
-  it('should call streams.fetchAllWith with correct arguments when data', async () => {
-    jest.useFakeTimers();
-    mockObservable = new Observable((subscriber) => {
-      subscriber.next({ data: mockCategoriesSuggestionsTasks.data });
-    });
-    const { result } = renderHook(() =>
-      useInsightsCatgeoriesSuggestionsTasks(viewId)
-    );
-    expect(result.current).toStrictEqual(mockCategoriesSuggestionsTasks.data);
-    await waitFor(() => {
-      expect(streams.fetchAllWith).toHaveBeenCalledWith({
-        partialApiEndpoint: [
-          'insights/views/1/tasks/category_suggestions',
-          'insights/views/1/inputs',
-        ],
-      });
-    });
-  });
-
-  it('should not call streams.fetchAllWith when data is empty', async () => {
-    jest.useFakeTimers();
-    mockObservable = new Observable((subscriber) => {
-      subscriber.next({ data: [] });
-    });
-    const { result } = renderHook(() =>
-      useInsightsCatgeoriesSuggestionsTasks(viewId)
-    );
-    expect(result.current).toStrictEqual([]);
-    await waitFor(() => {
-      expect(streams.fetchAllWith).not.toHaveBeenCalled();
-    });
-  });
-
   it('should return error when error', () => {
     const error = new Error();
     mockObservable = new Observable((subscriber) => {
@@ -263,9 +221,6 @@ describe('useInsightsCatgeoriesSuggestionsTasks', () => {
     );
 
     unmount();
-    expect(Subscription.prototype.unsubscribe).toHaveBeenCalledTimes(2);
-  });
-  afterEach(() => {
-    jest.useRealTimers();
+    expect(Subscription.prototype.unsubscribe).toHaveBeenCalledTimes(1);
   });
 });

--- a/front/app/modules/commercial/insights/hooks/useInsightsCategoriesSuggestionsTasks.tsx
+++ b/front/app/modules/commercial/insights/hooks/useInsightsCategoriesSuggestionsTasks.tsx
@@ -3,9 +3,6 @@ import {
   insightsCategoriesSuggestionsTasksStream,
   IInsightsCategoriesSuggestionTasksData,
 } from '../services/insightsCategoriesSuggestionsTasks';
-import { isNilOrError } from 'utils/helperUtils';
-import streams from 'utils/streams';
-import { timer } from 'rxjs';
 
 export type QueryParameters = {
   inputs: string[];
@@ -25,31 +22,14 @@ const useInsightsCatgeoriesSuggestionsTasks = (
   const inputs = queryParameters?.inputs;
 
   useEffect(() => {
-    let data:
-      | IInsightsCategoriesSuggestionTasksData[]
-      | undefined
-      | null
-      | Error;
     const subscription = insightsCategoriesSuggestionsTasksStream(viewId, {
       queryParameters: { categories, inputs },
     }).observable.subscribe((insightsCategories) => {
-      data = insightsCategories.data;
       setInsightsCategoriesSuggestions(insightsCategories.data);
     });
 
-    const pollingTimer = timer(5000, 5000).subscribe(() => {
-      if (!isNilOrError(data) && data.length > 0) {
-        streams.fetchAllWith({
-          partialApiEndpoint: [
-            `insights/views/${viewId}/tasks/category_suggestions`,
-            `insights/views/${viewId}/inputs`,
-          ],
-        });
-      }
-    });
     return () => {
       subscription.unsubscribe();
-      pollingTimer.unsubscribe();
     };
   }, [viewId, categories, inputs]);
 

--- a/front/app/modules/commercial/insights/services/insightsCategoriesSuggestionsTasks.ts
+++ b/front/app/modules/commercial/insights/services/insightsCategoriesSuggestionsTasks.ts
@@ -2,8 +2,8 @@ import { API_PATH } from 'containers/App/constants';
 import streams, { IStreamParams } from 'utils/streams';
 import { IRelationship } from 'typings';
 
-import { of } from 'rxjs';
-import { delay, repeat, takeWhile, skip, finalize } from 'rxjs/operators';
+import { interval } from 'rxjs';
+import { takeWhile, skip, finalize } from 'rxjs/operators';
 
 const getInsightsCategorySuggestionsTasksEndpoint = (viewId: string) =>
   `insights/views/${viewId}/tasks/category_suggestions`;
@@ -50,7 +50,7 @@ export async function insightsTriggerCategoriesSuggestionsTasks(
   categories?: string[],
   inputs?: string[]
 ) {
-  const pollingStream = of({}).pipe(delay(3000), repeat());
+  const pollingStream = interval(3000);
 
   const response = await streams.add(
     `${API_PATH}/${getInsightsCategorySuggestionsTasksEndpoint(
@@ -84,7 +84,10 @@ export async function insightsTriggerCategoriesSuggestionsTasks(
       // Refetch inputs when there are no pending tasks
       finalize(() => {
         streams.fetchAllWith({
-          partialApiEndpoint: [`insights/views/${insightsViewId}/inputs`],
+          partialApiEndpoint: [
+            `insights/views/${insightsViewId}/inputs`,
+            `insights/views/${insightsViewId}/categories`,
+          ],
         });
         subscription.unsubscribe();
       })

--- a/front/app/modules/commercial/insights/services/insightsCategoriesSuggestionsTasks.ts
+++ b/front/app/modules/commercial/insights/services/insightsCategoriesSuggestionsTasks.ts
@@ -3,7 +3,7 @@ import streams, { IStreamParams } from 'utils/streams';
 import { IRelationship } from 'typings';
 
 import { of } from 'rxjs';
-import { delay, repeat, takeWhile } from 'rxjs/operators';
+import { delay, repeat, takeWhile, skip } from 'rxjs/operators';
 
 const getInsightsCategorySuggestionsTasksEndpoint = (viewId: string) =>
   `insights/views/${viewId}/tasks/category_suggestions`;
@@ -50,6 +50,8 @@ export async function insightsTriggerCategoriesSuggestionsTasks(
   categories?: string[],
   inputs?: string[]
 ) {
+  const pollingStream = of({}).pipe(delay(3000), repeat());
+
   const response = await streams.add(
     `${API_PATH}/${getInsightsCategorySuggestionsTasksEndpoint(
       insightsViewId
@@ -60,28 +62,29 @@ export async function insightsTriggerCategoriesSuggestionsTasks(
     }
   );
 
-  const pollingSubscription = of({})
-    .pipe(delay(3000), repeat())
-    .subscribe(() => {
-      streams.fetchAllWith({
-        partialApiEndpoint: [
-          `insights/views/${insightsViewId}/tasks/category_suggestions`,
-        ],
-      });
+  // Refetch pending tasks at an interval
+  const subscription = pollingStream.subscribe(() => {
+    streams.fetchAllWith({
+      partialApiEndpoint: [
+        `insights/views/${insightsViewId}/tasks/category_suggestions`,
+      ],
     });
+  });
 
   insightsCategoriesSuggestionsTasksStream(insightsViewId, {
     queryParameters: { categories, inputs },
   })
     .observable.pipe(
-      // Only poll while there are remaining tasks
+      // Ignore the first emitted value coming from the hook
+      skip(1),
+      // Poll while there are pending tasks
       takeWhile((response) => {
-        // Refetch inputs when no tasks remain
         if (response.data.length === 0) {
+          // Refetch inputs when there are no pending tasks
           streams.fetchAllWith({
             partialApiEndpoint: [`insights/views/${insightsViewId}/inputs`],
           });
-          pollingSubscription.unsubscribe();
+          subscription.unsubscribe();
         }
         return response.data.length > 0;
       })


### PR DESCRIPTION
- Improves the polling logic by moving it from the `useInsightsCatgeoriesSuggestionsTasks` hook to the `insightsTriggerCategoriesSuggestionsTasks` service. This ensures polling is not tied to a component and can happen on the background while the user navigates away from the page.
- Optimizes the number of requests by ensuring we refetch only what we need 
- Improves the `ScanCategory` loading state by ensuring the button enters a pending state immediately after it's been clicked.