### PR TITLE
IN-506 Fix unprocessed input display in category

### DIFF
--- a/front/app/modules/commercial/insights/admin/containers/Insights/Edit/Categories/Categories.test.tsx
+++ b/front/app/modules/commercial/insights/admin/containers/Insights/Edit/Categories/Categories.test.tsx
@@ -85,7 +85,7 @@ describe('Insights Edit Categories', () => {
     fireEvent.click(screen.getByText(mockData[0].attributes.name));
     expect(spy).toHaveBeenCalledWith({
       pathname: '',
-      search: `?pageNumber=1&category=${mockData[0].id}&processed=true`,
+      search: `?pageNumber=1&category=${mockData[0].id}`,
     });
   });
 
@@ -108,6 +108,7 @@ describe('Insights Edit Categories', () => {
       search: `?pageNumber=1&category=&processed=true`,
     });
   });
+
   it('shows category count correctly', () => {
     render(<Categories />);
 

--- a/front/app/modules/commercial/insights/admin/containers/Insights/Edit/Categories/index.tsx
+++ b/front/app/modules/commercial/insights/admin/containers/Insights/Edit/Categories/index.tsx
@@ -152,11 +152,31 @@ const Categories = ({
     }
   };
 
+  const selectAllInput = () => {
+    clHistory.push({
+      pathname,
+      search: stringify(
+        { ...query, pageNumber: 1, category: undefined, processed: true },
+        { addQueryPrefix: true }
+      ),
+    });
+  };
+
+  const selectUncategorizedInput = () => {
+    clHistory.push({
+      pathname,
+      search: stringify(
+        { ...query, pageNumber: 1, category: '', processed: true },
+        { addQueryPrefix: true }
+      ),
+    });
+  };
+
   const selectCategory = (categoryId?: string) => () => {
     clHistory.push({
       pathname,
       search: stringify(
-        { ...query, pageNumber: 1, category: categoryId, processed: true },
+        { ...query, pageNumber: 1, category: categoryId, processed: undefined },
         { addQueryPrefix: true }
       ),
     });
@@ -224,7 +244,7 @@ const Categories = ({
           textColor={colors.label}
           textHoverColor={colors.adminTextColor}
           bgHoverColor={darken(0.05, colors.lightGreyishBlue)}
-          onClick={selectCategory()}
+          onClick={selectAllInput}
         >
           <div> {formatMessage(messages.allInput)}</div>
           {!isNilOrError(allInputsCount) && (
@@ -262,7 +282,7 @@ const Categories = ({
           textColor={colors.label}
           textHoverColor={colors.adminTextColor}
           bgHoverColor={darken(0.05, colors.lightGreyishBlue)}
-          onClick={selectCategory('')}
+          onClick={selectUncategorizedInput}
         >
           <div>{formatMessage(messages.notCategorized)}</div>
           {!isNilOrError(uncategorizedInputsCount) && (

--- a/front/app/modules/commercial/insights/admin/containers/Insights/Edit/InputsTable/InputsTable.test.tsx
+++ b/front/app/modules/commercial/insights/admin/containers/Insights/Edit/InputsTable/InputsTable.test.tsx
@@ -553,7 +553,7 @@ describe('Insights Input Table', () => {
       render(<InputsTable />);
       expect(useInsightsInputs).toHaveBeenCalledWith(viewId, {
         category: 'category',
-        processed: true,
+        processed: undefined,
         search: undefined,
         pageNumber: 1,
       });
@@ -593,6 +593,7 @@ describe('Insights Input Table', () => {
         processed: true,
       });
     });
+
     it('adds search query to url', () => {
       const spy = jest.spyOn(clHistory, 'replace');
       render(<InputsTable />);

--- a/front/app/modules/commercial/insights/admin/containers/Insights/Edit/InputsTable/index.tsx
+++ b/front/app/modules/commercial/insights/admin/containers/Insights/Edit/InputsTable/index.tsx
@@ -151,7 +151,16 @@ const InputsTable = ({
     pageNumber,
     search,
     sort,
-    processed: !(inputsCategoryFilter === 'recentlyPosted'),
+    processed:
+      // Include non-processed input in recently posted
+      inputsCategoryFilter === 'recentlyPosted'
+        ? false
+        : // Include both processed and unprocessed input in category
+        inputsCategoryFilter === 'category'
+        ? undefined
+        : // Include only processed input everywhere else
+          true,
+
     category: selectedCategory,
   });
 
@@ -203,40 +212,42 @@ const InputsTable = ({
   // Side Modal Preview
   // Use callback to keep references for moveUp and moveDown stable
   const moveUp = useCallback(() => {
-    let index: number | null = null;
-
     setPreviewedInputIndex((prevSelectedIndex) => {
-      index = !isNilOrError(prevSelectedIndex)
+      return !isNilOrError(prevSelectedIndex)
         ? prevSelectedIndex - 1
         : prevSelectedIndex;
-
-      return index;
     });
     setMovedUpDown(true);
   }, []);
 
   const moveDown = useCallback(() => {
-    let index: number | null = null;
-
     setPreviewedInputIndex((prevSelectedIndex) => {
-      index =
-        !isNilOrError(prevSelectedIndex) && isPreviewedInputInTable.current
-          ? prevSelectedIndex + 1
-          : prevSelectedIndex;
-
-      return index;
+      return !isNilOrError(prevSelectedIndex) && isPreviewedInputInTable.current
+        ? prevSelectedIndex + 1
+        : prevSelectedIndex;
     });
 
     setMovedUpDown(true);
   }, []);
 
   // Search
-  const onSearch = useCallback((search: string) => {
-    clHistory.replace({
-      pathname,
-      search: stringify({ ...query, search }, { addQueryPrefix: true }),
-    });
-  }, []);
+  const onSearch = useCallback(
+    (search: string) => {
+      if (search && search !== query.search) {
+        clHistory.replace({
+          pathname,
+          search: stringify(
+            {
+              ...query,
+              search,
+            },
+            { addQueryPrefix: true }
+          ),
+        });
+      }
+    },
+    [pathname, query]
+  );
 
   // From this point we need data ----------------------------------------------
   if (isNilOrError(inputs)) {


### PR DESCRIPTION
There was a small bug when scanning a category. If the input that was suggested was in the "Recently posted" category, it did not display in the category itself when the suggestion matches, even though it should.

This PR fixes the issue by ensuring that when selecting a category, all input for this category is shown, not only the one with `processed=true` flag!