### PR TITLE
Restored running `trigger-workflows` on production branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,7 +286,6 @@ workflows:
             branches:
               ignore:
                 - crowdin_master
-                - production
 
   private-ci:
     when:


### PR DESCRIPTION
Seems like we accidentally started ignoring the `trigger-workflows` job on the production branch in a merge mistake, which means that subsequent pipelines (for example the one to trigger citizenlab-ee for deployment) no longer got triggered.