### PR TITLE
useEvents: increased pageSize under project/in back office

### DIFF
--- a/front/app/containers/Admin/projects/edit/events/index.tsx
+++ b/front/app/containers/Admin/projects/edit/events/index.tsx
@@ -38,7 +38,10 @@ const AdminProjectEventsIndex = ({
   params,
 }: WithRouterProps & InjectedIntlProps) => {
   const { projectId } = params;
-  const { events } = useEvents({ projectIds: [projectId] });
+  const { events } = useEvents({
+    projectIds: [projectId],
+    pageSize: 1000,
+  });
 
   const createDeleteClickHandler = (eventId: string) => (
     event: React.FormEvent<any>

--- a/front/app/containers/ProjectsShowPage/shared/events/index.tsx
+++ b/front/app/containers/ProjectsShowPage/shared/events/index.tsx
@@ -67,6 +67,7 @@ const EventsContainer = memo<Props>(
     const { events } = useEvents({
       projectIds: [projectId],
       sort: 'newest',
+      pageSize: 1000,
     });
 
     const locale = useLocale();


### PR DESCRIPTION
Under each project, and in admin view, the number of events was limited to 10- an uninteded outcome of the changes to the backend, which now implements an events route with pagination, with a default of 10 events per page. Since no pagination was implemented under each project and in admin view, it was not possible to see more than 10 events in those places. This is a quick and dirty fix for that- added a Jira ticket to come up with a better solution in the future.