### PR TITLE
Refactored events widget switch into Outlet

### DIFF
--- a/front/app/containers/Admin/settings/customize/index.tsx
+++ b/front/app/containers/Admin/settings/customize/index.tsx
@@ -67,7 +67,7 @@ const ContrastWarning = styled(Warning)`
   margin-top: 10px;
 `;
 
-const WideSectionField = styled(SectionField)`
+export const WideSectionField = styled(SectionField)`
   max-width: calc(${(props) => props.theme.maxPageWidth}px - 100px);
 `;
 
@@ -385,9 +385,12 @@ class SettingsCustomizeTab extends PureComponent<
     }
   };
 
-  getSetting = (setting) =>
-    get(this.state.attributesDiff, `settings.${setting}`) ??
-    get(this.state.tenant, `data.attributes.settings.${setting}`);
+  getSetting = (setting: string) => {
+    return (
+      get(this.state.attributesDiff, `settings.${setting}`) ??
+      get(this.state.tenant, `data.attributes.settings.${setting}`)
+    );
+  };
 
   handleColorPickerOnClick = () => {
     this.setState({ colorPickerOpened: true });
@@ -745,26 +748,15 @@ class SettingsCustomizeTab extends PureComponent<
               </WideSectionField>
 
               {tenant.data.attributes.settings?.events_widget?.allowed && (
-                <WideSectionField>
-                  <Setting>
-                    <ToggleLabel>
-                      <StyledToggle
-                        checked={this.getSetting('events_widget.enabled')}
-                        onChange={this.handleToggleEventsWidget}
-                      />
-                      <LabelContent>
-                        <LabelTitle>
-                          {formatMessage(messages.eventsWidgetSetting)}
-                        </LabelTitle>
-                        <LabelDescription>
-                          {formatMessage(
-                            messages.eventsWidgetSettingDescription
-                          )}
-                        </LabelDescription>
-                      </LabelContent>
-                    </ToggleLabel>
-                  </Setting>
-                </WideSectionField>
+                <Outlet
+                  id="app.containers.Admin.settings.customize.EventsWidgetSwitch"
+                  checked={this.getSetting('events_widget.enabled')}
+                  onChange={this.handleToggleEventsWidget}
+                  title={formatMessage(messages.eventsWidgetSetting)}
+                  description={formatMessage(
+                    messages.eventsWidgetSettingDescription
+                  )}
+                />
               )}
             </Section>
           )}

--- a/front/app/modules/commercial/events_widget/admin/EventsWidgetSwitch.tsx
+++ b/front/app/modules/commercial/events_widget/admin/EventsWidgetSwitch.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+// Components
+import { WideSectionField } from 'containers/Admin/settings/customize';
+import {
+  Setting,
+  ToggleLabel,
+  StyledToggle,
+  LabelContent,
+  LabelTitle,
+  LabelDescription,
+} from 'containers/Admin/settings/general';
+
+interface Props {
+  checked: boolean;
+  onChange: () => void;
+  title: string;
+  description: string;
+}
+
+export default ({ checked, onChange, title, description }: Props) => (
+  <>
+    <WideSectionField>
+      <Setting>
+        <ToggleLabel>
+          <StyledToggle checked={checked} onChange={onChange} />
+          <LabelContent>
+            <LabelTitle>{title}</LabelTitle>
+            <LabelDescription>{description}</LabelDescription>
+          </LabelContent>
+        </ToggleLabel>
+      </Setting>
+    </WideSectionField>
+  </>
+);

--- a/front/app/modules/commercial/events_widget/index.tsx
+++ b/front/app/modules/commercial/events_widget/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ModuleConfiguration } from 'utils/moduleUtils';
 import FeatureFlag from 'components/FeatureFlag';
 import EventsWidget from './citizen';
+import EventsWidgetSwitch from './admin/EventsWidgetSwitch';
 
 const configuration: ModuleConfiguration = {
   outlets: {
@@ -9,6 +10,9 @@ const configuration: ModuleConfiguration = {
       <FeatureFlag name="events_widget">
         <EventsWidget />
       </FeatureFlag>
+    ),
+    'app.containers.Admin.settings.customize.EventsWidgetSwitch': (props) => (
+      <EventsWidgetSwitch {...props} />
     ),
   },
 };

--- a/front/app/utils/moduleUtils.ts
+++ b/front/app/utils/moduleUtils.ts
@@ -354,6 +354,12 @@ export type OutletsPropertyMap = {
     className?: string;
   };
   'app.containers.LandingPage.EventsWidget': {};
+  'app.containers.Admin.settings.customize.EventsWidgetSwitch': {
+    checked: boolean;
+    onChange: () => void;
+    title: string;
+    description: string;
+  };
 };
 
 type Outlet<Props> = FunctionComponent<Props> | FunctionComponent<Props>[];


### PR DESCRIPTION
Since this is a commercial feature, it doesn't make sense to show the switch to users on the non-commerical plan.