### PR TITLE
CL2-6622 Bugfix: Maintain language selection during/after SSO registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Next
 
+## 2021-08-06
+
+### Fixed
+
+- Locale not updating, when possible, to reflect locale returned from SSO sign-in in registration process
+
 ### Added
 
 - Added message logging to monitor tenant creation status (shown in admin HQ).

--- a/back/app/controllers/omniauth_callback_controller.rb
+++ b/back/app/controllers/omniauth_callback_controller.rb
@@ -64,6 +64,7 @@ class OmniauthCallbackController < ApplicationController
 
     else # New user
       @user = User.new(authver_method.profile_to_user_attrs(auth))
+      @user.locale = omniauth_params['locale'] if omniauth_params['locale']
       SideFxUserService.new.before_create(@user, nil)
       @user.identities << @identity
       begin

--- a/back/app/controllers/omniauth_callback_controller.rb
+++ b/back/app/controllers/omniauth_callback_controller.rb
@@ -64,7 +64,6 @@ class OmniauthCallbackController < ApplicationController
 
     else # New user
       @user = User.new(authver_method.profile_to_user_attrs(auth))
-      @user.locale = omniauth_params['locale'] if omniauth_params['locale']
       SideFxUserService.new.before_create(@user, nil)
       @user.identities << @identity
       begin

--- a/back/app/models/app_configuration.rb
+++ b/back/app/models/app_configuration.rb
@@ -109,7 +109,7 @@ class AppConfiguration < ApplicationRecord
   def closest_locale_to(locale)
     locale = locale.to_s
     locales = settings.dig('core', 'locales') || []
-    locales.include?(locale) ? locale : locales.first
+    locales.any? { |l| l.include?(locale) } ? locales.find { |l| l.include?(locale) } : locales.first
   end
 
   def public_settings

--- a/back/spec/lib/omniauth_methods/azure_active_directory_spec.rb
+++ b/back/spec/lib/omniauth_methods/azure_active_directory_spec.rb
@@ -25,7 +25,7 @@ describe OmniauthMethods::AzureActiveDirectory do
         last_name: 'Jossens',
         email: 'jos@josnet.com',
         remote_avatar_url: 'http://www.josnet.com/my-picture',
-        locale: 'en'
+        locale: 'fr-FR'
       })
     end
   end

--- a/back/spec/requests/google_authentication_spec.rb
+++ b/back/spec/requests/google_authentication_spec.rb
@@ -121,7 +121,7 @@ describe "google authentication" do
       first_name: 'Boris',
       last_name: 'Brompton',
       email: 'boris.brompton@orange.uk',
-      locale: 'nl-NL',
+      locale: 'nl-NL'
     })
     expect(user.identities.first).to have_attributes({
       provider: "google",
@@ -137,7 +137,7 @@ describe "google authentication" do
     follow_redirect!
 
     # Expect the redirect url to include the locale ('nl-NL') from Tenant locales that includes
-    # the locale code in the mock omniauth response ('nl') 
+    # the locale code in the mock omniauth response ('nl')
     expect(response).to redirect_to("/nl-NL/complete-signup?random-passthrough-param=somevalue")
 
     expect(user.reload).to have_attributes({

--- a/back/spec/requests/google_authentication_spec.rb
+++ b/back/spec/requests/google_authentication_spec.rb
@@ -128,6 +128,17 @@ describe "google authentication" do
     expect(cookies[:cl2_jwt]).to be_present
   end
 
+  it "maintains a prior locale selection during/after registration" do
+    get "/auth/google?random-passthrough-param=somevalue&locale=fr-FR"
+    follow_redirect!
+
+    expect(response).to redirect_to("/fr-FR/complete-signup?random-passthrough-param=somevalue&locale=fr-FR")
+
+    user = User.find_by(email: 'boris.brompton@orange.uk')
+
+    expect(user).to have_attributes({ locale: 'fr-FR' })
+  end
+
   it "successfully registers an invitee" do
     user = create(:invited_user, email: 'boris.brompton@orange.uk')
 

--- a/back/spec/requests/google_authentication_spec.rb
+++ b/back/spec/requests/google_authentication_spec.rb
@@ -111,7 +111,9 @@ describe "google authentication" do
     get "/auth/google?random-passthrough-param=somevalue"
     follow_redirect!
 
-    expect(response).to redirect_to("/en/complete-signup?random-passthrough-param=somevalue")
+    # Expect the redirect url to include the locale ('nl-NL') from Tenant locales that includes
+    # the locale code in the mock omniauth response ('nl')
+    expect(response).to redirect_to("/nl-NL/complete-signup?random-passthrough-param=somevalue")
 
     user = User.find_by(email: 'boris.brompton@orange.uk')
 
@@ -119,7 +121,7 @@ describe "google authentication" do
       first_name: 'Boris',
       last_name: 'Brompton',
       email: 'boris.brompton@orange.uk',
-      locale: 'en',
+      locale: 'nl-NL',
     })
     expect(user.identities.first).to have_attributes({
       provider: "google",
@@ -128,30 +130,21 @@ describe "google authentication" do
     expect(cookies[:cl2_jwt]).to be_present
   end
 
-  it "maintains a prior locale selection during/after registration" do
-    get "/auth/google?random-passthrough-param=somevalue&locale=fr-FR"
-    follow_redirect!
-
-    expect(response).to redirect_to("/fr-FR/complete-signup?random-passthrough-param=somevalue&locale=fr-FR")
-
-    user = User.find_by(email: 'boris.brompton@orange.uk')
-
-    expect(user).to have_attributes({ locale: 'fr-FR' })
-  end
-
   it "successfully registers an invitee" do
     user = create(:invited_user, email: 'boris.brompton@orange.uk')
 
     get "/auth/google?random-passthrough-param=somevalue"
     follow_redirect!
 
-    expect(response).to redirect_to("/en/complete-signup?random-passthrough-param=somevalue")
+    # Expect the redirect url to include the locale ('nl-NL') from Tenant locales that includes
+    # the locale code in the mock omniauth response ('nl') 
+    expect(response).to redirect_to("/nl-NL/complete-signup?random-passthrough-param=somevalue")
 
     expect(user.reload).to have_attributes({
       first_name: 'Boris',
       last_name: 'Brompton',
       email: 'boris.brompton@orange.uk',
-      locale: 'en',
+      locale: 'nl-NL',
       invite_status: 'accepted'
     })
     expect(user.identities.first).to have_attributes({


### PR DESCRIPTION
[Jira Ticket CL-6622](https://citizenlab.atlassian.net/browse/CL2-6622)
[Confluence discussion](https://citizenlab.atlassian.net/wiki/spaces/CL2/pages/125108225/Solve+CL2-6622+Platform+returns+to+default+language+after+SSO)
Related PR: [#69](https://github.com/CitizenLabDotCo/citizenlab-ee/pull/69)

**Description:**

Using SSO (currently only tested using Google) during registration (signup) seems to cause app to reset to default (1st) available language when exiting the SSO and returning to app. At this point, the user is presented with a 2nd part of the signup and cannot access the menu to switch language. This could at worst prevent user form understanding the app, and form completing signup process (though this will not cancel the already created registration), and at best is mildly annoying.

**Notes:**

After first considering using the OmniAuth url params passthrough to fix this issue, we eventually returned to the idea of setting the app locale to the best match with the locale returned in the OmniAuth response  (best match with a Tenant `locales` element), following the SSO (or using the default locale in Tenant locales, if no match).

If this approach proves inadequate, then we could consider using the OmniAuth url params passthrough approach. Note that this would also require some FE changes, however.

This fix also includes a new unit test in the EE repo - see PR: [#69](https://github.com/CitizenLabDotCo/citizenlab-ee/pull/69)