### PR TITLE
CL2-6584 Sentry: NoMethodError: "undefined method `project_moderator' for ProjectManagement::Patches::User:Module"...

### DIFF
--- a/back/engines/commercial/project_management/app/models/project_management/patches/notifications/project_phase_upcoming.rb
+++ b/back/engines/commercial/project_management/app/models/project_management/patches/notifications/project_phase_upcoming.rb
@@ -10,7 +10,7 @@ module ProjectManagement
 
         module ClassMethods
           def recipients(project_id)
-            super.or(User.project_moderator(project_id))
+            super.or(::User.project_moderator(project_id))
           end
         end
       end


### PR DESCRIPTION
This is a regression issue where `User` inside a `ProjectManagement::Patches` module resolves to `ProjectManagement::Patches::User` instead of `::User`. Found hopefully the last place where this issue occurred.