### PR TITLE
CL2-6693 Restore features settings after reset in settings_spec.rb

### DIFF
--- a/back/spec/models/app_configuration/settings_spec.rb
+++ b/back/spec/models/app_configuration/settings_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe AppConfiguration::Settings do
     described_class.send(:reset)
   end
 
+  # Restore the initial state of the extension features hash.
+  # This should help avoid problems when running subsequent tests (in random orders in CI)
+  # which might depend on the descriptions of features previously registered by extensions/engines.
   after do
     described_class.instance_variable_set(:@extension_features_hash, @initial_features_hash)
   end

--- a/back/spec/models/app_configuration/settings_spec.rb
+++ b/back/spec/models/app_configuration/settings_spec.rb
@@ -3,7 +3,14 @@
 require 'rails_helper'
 
 RSpec.describe AppConfiguration::Settings do
-  before { described_class.send(:reset) }
+  before do
+    @initial_features_hash = described_class.send(:extension_features_hash)
+    described_class.send(:reset)
+  end
+
+  after do
+    described_class.instance_variable_set(:@extension_features_hash, @initial_features_hash)
+  end
 
   context 'without extension features' do
     describe '.json_schema' do

--- a/back/spec/models/app_configuration/settings_spec.rb
+++ b/back/spec/models/app_configuration/settings_spec.rb
@@ -7,8 +7,12 @@ RSpec.describe AppConfiguration::Settings do
 
   context 'without extension features' do
     describe '.json_schema' do
-      it { expect(described_class.json_schema).to match(described_class.core_settings_json_schema) }
-      it { expect(described_class.extension_features_specs).to be_empty }
+      it "uses only the core json schema settings" do
+        expect(described_class.json_schema).to match(described_class.core_settings_json_schema)
+      end
+      it "uses no extension features" do
+        expect(described_class.extension_features_specs).to be_empty
+      end
     end
   end
 
@@ -32,8 +36,12 @@ RSpec.describe AppConfiguration::Settings do
     describe '.json_schema' do
       let(:json_schema) { described_class.json_schema }
 
-      it { expect(json_schema).to include(described_class.core_settings_json_schema) }
-      it { expect(json_schema.dig('properties', feature_spec.feature_name)).to eq(feature_spec.json_schema) }
+      it "includes core json schema settings in schema" do
+        expect(json_schema).to include(described_class.core_settings_json_schema)
+      end
+      it "includes feature json schema in properties" do
+        expect(json_schema.dig('properties', feature_spec.feature_name)).to eq(feature_spec.json_schema)
+      end
     end
 
     describe '.extension_features_specs' do


### PR DESCRIPTION
## Checklist

- [ ] Added entry to changelog
Not done: Part of larger piece of work (see: [Jira ticket 6685](https://citizenlab.atlassian.net/browse/CL2-6685))
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

- [x] Tests
<details>
<summary>More info</summary>

### Unit tests

This PR is an improvement to an already existing spec.

### E2E tests

Sometimes it can be more efficient to update E2E tests after CI has run them. If you know which ones to update, go ahead! E2E template cl2-back:

```bash
docker compose run --rm web bin/rails cl2_back:create_tenant[localhost,e2etests_template]
```

</details>

- [x] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## Links

- [Jira ticket](https://citizenlab.atlassian.net/browse/CL2-6693)

## What changes are in this PR?

Restore the `@extension_features_hash` class instance variable after each time it is reset in the `before` block in the tests in `settings_spec.rb`.

This might help avoid the type of CI test failure seen in [the example](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab-ee/4018/workflows/e4ef5c01-d5eb-43c0-90c1-78d313e050be/jobs/13203/tests#failed-test-0) given by Sébastien Hoorens, since the stack-trace points to `def activate_feature!` in `settings_service.rb`, which makes use of an `AppConfiguration.instance`
## How urgent is a code review?

By the end of the week, since the over-arching ticket (see: [Jira ticket 6685](https://citizenlab.atlassian.net/browse/CL2-6685)) is marked as 'priority'.
