### PR TITLE
CL2-6617 Avoid inconsistent data check failures related to IdeasPhase validity

### DIFF
--- a/back/app/models/ideas_phase.rb
+++ b/back/app/models/ideas_phase.rb
@@ -6,7 +6,7 @@ class IdeasPhase < ApplicationRecord
   validates :idea, :phase, presence: true
   validates :phase_id, uniqueness: {scope: :idea_id}
   validate :idea_and_phase_same_project
-  validate :phase_is_ideation
+  # validate :phase_is_ideation
 
   private
 
@@ -20,13 +20,13 @@ class IdeasPhase < ApplicationRecord
     end
   end
 
-  def phase_is_ideation
-    unless phase.can_contain_ideas?
-      self.errors.add(
-        :phase_id,
-        :phase_not_ideation,
-        message: 'You can\'t add an idea to a non-ideation phase'
-      )
-    end
-  end
+  # def phase_is_ideation
+  #   unless phase.can_contain_ideas?
+  #     self.errors.add(
+  #       :phase_id,
+  #       :phase_not_ideation,
+  #       message: 'You can\'t add an idea to a non-ideation phase'
+  #     )
+  #   end
+  # end
 end

--- a/back/app/models/ideas_phase.rb
+++ b/back/app/models/ideas_phase.rb
@@ -6,7 +6,6 @@ class IdeasPhase < ApplicationRecord
   validates :idea, :phase, presence: true
   validates :phase_id, uniqueness: {scope: :idea_id}
   validate :idea_and_phase_same_project
-  # validate :phase_is_ideation
 
   private
 
@@ -19,14 +18,4 @@ class IdeasPhase < ApplicationRecord
       )
     end
   end
-
-  # def phase_is_ideation
-  #   unless phase.can_contain_ideas?
-  #     self.errors.add(
-  #       :phase_id,
-  #       :phase_not_ideation,
-  #       message: 'You can\'t add an idea to a non-ideation phase'
-  #     )
-  #   end
-  # end
 end

--- a/back/spec/acceptance/phases_spec.rb
+++ b/back/spec/acceptance/phases_spec.rb
@@ -277,20 +277,21 @@ resource "Phases" do
 
       describe "When updating ideation phase with ideas to a poll phase" do
         before do
-          @project.phases.first.update(
+          phase.update(
             participation_method: 'ideation',
             ideas: create_list(:idea, 2, project: @project)
           )
         end
        
-        let(:id) { @project.phases.first.id }
+        let(:ideas_phase) { phase.ideas[0].ideas_phases.first }
         let(:participation_method) { 'poll' }
 
         example "Existing related ideas_phase remains valid" do
-          expect(@project.ideas[0].ideas_phases.first.valid?).to eq true
+          expect(ideas_phase.valid?).to eq true
           do_request
+          ideas_phase.reload
           expect(response_status).to eq 200
-          expect(@project.ideas[0].ideas_phases.first.valid?).to eq true
+          expect(ideas_phase.valid?).to eq true
         end
       end
     end

--- a/back/spec/acceptance/phases_spec.rb
+++ b/back/spec/acceptance/phases_spec.rb
@@ -275,26 +275,23 @@ resource "Phases" do
         end
       end
 
-      describe do
-        let(:ideas) { create_list(:idea, 2, project: @project) }
-
+      describe "When updating ideation phase with ideas to a poll phase" do
         before do
           @project.phases.first.update(
             participation_method: 'ideation',
-            ideas: ideas
+            ideas: create_list(:idea, 2, project: @project)
           )
         end
-        
+       
+        let(:phase) { create(:phase, project: @project) }
+        let(:id) { @project.phases.first.id }
         let(:participation_method) { 'poll' }
-        let(:phase) { create(:phase, project: @project, participation_method: participation_method, ideas: ideas) }
 
-        example "Update phase with ideas to a poll" do
-          # puts @project.phases.first.participation_method.inspect
+        example "Existing related ideas_phase remains valid" do
+          expect(@project.ideas[0].ideas_phases.first.valid?).to eq true
           do_request
-          # puts @project.phases.first.participation_method.inspect
-          # puts @project.phases.first.ideas[0].valid?
           expect(response_status).to eq 200
-          expect(@project.phases.first.ideas[0].valid?).to eq true
+          expect(@project.ideas[0].ideas_phases.first.valid?).to eq false
         end
       end
     end

--- a/back/spec/acceptance/phases_spec.rb
+++ b/back/spec/acceptance/phases_spec.rb
@@ -283,7 +283,6 @@ resource "Phases" do
           )
         end
        
-        let(:phase) { create(:phase, project: @project) }
         let(:id) { @project.phases.first.id }
         let(:participation_method) { 'poll' }
 

--- a/back/spec/acceptance/phases_spec.rb
+++ b/back/spec/acceptance/phases_spec.rb
@@ -291,7 +291,7 @@ resource "Phases" do
           expect(@project.ideas[0].ideas_phases.first.valid?).to eq true
           do_request
           expect(response_status).to eq 200
-          expect(@project.ideas[0].ideas_phases.first.valid?).to eq false
+          expect(@project.ideas[0].ideas_phases.first.valid?).to eq true
         end
       end
     end

--- a/back/spec/acceptance/phases_spec.rb
+++ b/back/spec/acceptance/phases_spec.rb
@@ -277,7 +277,7 @@ resource "Phases" do
 
       describe "When updating ideation phase with ideas to a poll phase" do
         before do
-          phase.update(
+          phase.update!(
             participation_method: 'ideation',
             ideas: create_list(:idea, 2, project: @project)
           )

--- a/back/spec/acceptance/phases_spec.rb
+++ b/back/spec/acceptance/phases_spec.rb
@@ -274,6 +274,29 @@ resource "Phases" do
           expect(response_status).to eq 200
         end
       end
+
+      describe do
+        let(:ideas) { create_list(:idea, 2, project: @project) }
+
+        before do
+          @project.phases.first.update(
+            participation_method: 'ideation',
+            ideas: ideas
+          )
+        end
+        
+        let(:participation_method) { 'poll' }
+        let(:phase) { create(:phase, project: @project, participation_method: participation_method, ideas: ideas) }
+
+        example "Update phase with ideas to a poll" do
+          # puts @project.phases.first.participation_method.inspect
+          do_request
+          # puts @project.phases.first.participation_method.inspect
+          # puts @project.phases.first.ideas[0].valid?
+          expect(response_status).to eq 200
+          expect(@project.phases.first.ideas[0].valid?).to eq true
+        end
+      end
     end
 
     delete "web_api/v1/phases/:id" do


### PR DESCRIPTION
## Checklist

- [ ] Added entry to changelog
<details>
<summary>More info</summary>
<br>
No changelog entry included, since this change aims to reduce our reporting of inconsistent data, and is thus of little direct benefit to users and difficult to explain in language that is understandable outside of our dev team. 
</details>

- [x] Tests
<details>
<summary>More info</summary>

### Acceptance test
Added test that asserts a related `IdeasPhase` remains valid after updating an ideation phase with ideas to a poll phase
(see changes in `back/spec/acceptance/phases_spec.rb`)

</details>

- [x] Prepared branch for code review
<details>
<summary>More info</summary>
</details>

## Links

- [Jira ticket](https://citizenlab.atlassian.net/browse/CL2-6617)

## What changes are in this PR?

We decided to remove the the `phase_is_ideation` validation from the `IdeasPhase` model.

This should avoid the related inconsistent data check failures seen in CI, as in these examples:
```
"issues": {
    "IdeasPhase_phase_id_phase_not_ideation": {
      "count": 45,
      "hosts": {
        "rijswijk-buiten.citizenlab.co": [
          "xxxxxxxxx-cbf0-47bb-a416-b7d82e876859",
          "xxxxxxxxx-553d-44b5-81d3-793e80707b1e",
          "xxxxxxxxx-474f-443e-b499-72c53f4cf648",
          "xxxxxxxxx-799f-44f8-af3b-270771cba317",
          "xxxxxxxxx-ad38-4026-ac7c-7e0ebec46b15"
        ],
        "denkmee.katwijk.nl": [
          "xxxxxxxxx-7274-45f9-b59d-698be01254c0"
        ], ...
```
Excerpt from [this CI run](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab-ee/4767/workflows/1047a799-8912-49bc-81ce-0d6b19e76b97/jobs/16194).

## How urgent is a code review?

Medium priority. By the end-of-the week would be nice, as if this works I could then use a similar approach to avoid similar failures related to other validations.
