### PR TITLE
CL2-6600 Move sanitize_sheetname to the more generally shared xlsx_service.rb

### DIFF
--- a/back/app/services/xlsx_service.rb
+++ b/back/app/services/xlsx_service.rb
@@ -306,7 +306,7 @@ class XlsxService
   # and cannot contain the characters \ , / , * , ? , : , [ , ].
   # We are being strict and removing any character that is not alphanumeric or a space.
   def sanitize_sheetname(sheetname)
-    sheetname[0..30].gsub(/[^A-Za-z0-9 ]/, '')
+    sheetname.gsub(/[^A-Za-z0-9 ]/, '')[0..30]
   end
 end
 

--- a/back/app/services/xlsx_service.rb
+++ b/back/app/services/xlsx_service.rb
@@ -64,6 +64,7 @@ class XlsxService
   end
 
   def generate_sheet(workbook, sheetname, columns, instances)
+    sheetname = sanitize_sheetname sheetname
     columns = columns.uniq { |c| c[:header] }
     workbook.styles do |s|
       workbook.add_worksheet(name: sheetname) do |sheet|
@@ -299,6 +300,13 @@ class XlsxService
 
   def convert_to_text_long_lines html
     convert_to_text(html).gsub(/\n/, ' ')
+  end
+
+  # Sheet names, derived from Cause titles for example, can only be 31 characters long,
+  # and cannot contain the characters \ , / , * , ? , : , [ , ].
+  # We are being strict and removing any character that is not alphanumeric or a space.
+  def sanitize_sheetname(sheetname)
+    sheetname[0..30].gsub(/[^A-Za-z0-9 ]/, '')
   end
 end
 

--- a/back/engines/free/volunteering/app/services/volunteering/xlsx_service.rb
+++ b/back/engines/free/volunteering/app/services/volunteering/xlsx_service.rb
@@ -32,14 +32,5 @@ module Volunteering
 
       pa.to_stream
     end
-
-    private
-
-    # Sheet names, derived from Cause titles, can only be 31 characters long,
-    # and cannot contain the characters \ , / , * , ? , : , [ , ].
-    # We are being strict and removing any character that is not alphanumeric or a space.
-    # def sanitize_title(title)
-    #   title[0..30].gsub(/[^A-Za-z0-9 ]/, '')
-    # end
   end
 end

--- a/back/engines/free/volunteering/app/services/volunteering/xlsx_service.rb
+++ b/back/engines/free/volunteering/app/services/volunteering/xlsx_service.rb
@@ -26,7 +26,7 @@ module Volunteering
       pa = Axlsx::Package.new
 
       participation_context.causes.order(:ordering).each do |cause|
-        sheetname = sanitize_title @@multiloc_service.t(cause.title_multiloc)
+        sheetname = @@multiloc_service.t(cause.title_multiloc)
         xlsx_service.generate_sheet pa.workbook, sheetname, columns, volunteers.where(cause: cause)
       end
 
@@ -38,8 +38,8 @@ module Volunteering
     # Sheet names, derived from Cause titles, can only be 31 characters long,
     # and cannot contain the characters \ , / , * , ? , : , [ , ].
     # We are being strict and removing any character that is not alphanumeric or a space.
-    def sanitize_title(title)
-      title[0..30].gsub(/[^A-Za-z0-9 ]/, '')
-    end
+    # def sanitize_title(title)
+    #   title[0..30].gsub(/[^A-Za-z0-9 ]/, '')
+    # end
   end
 end

--- a/back/engines/free/volunteering/spec/services/xlsx_service_spec.rb
+++ b/back/engines/free/volunteering/spec/services/xlsx_service_spec.rb
@@ -46,6 +46,7 @@ describe XlsxService do
       end
 
       it 'exports a valid excel file' do
+        puts cause.inspect
         expect { workbook }.not_to raise_error
       end
     end

--- a/back/engines/free/volunteering/spec/services/xlsx_service_spec.rb
+++ b/back/engines/free/volunteering/spec/services/xlsx_service_spec.rb
@@ -46,7 +46,6 @@ describe XlsxService do
       end
 
       it 'exports a valid excel file' do
-        puts cause.inspect
         expect { workbook }.not_to raise_error
       end
     end

--- a/back/engines/free/volunteering/spec/services/xlsx_service_spec.rb
+++ b/back/engines/free/volunteering/spec/services/xlsx_service_spec.rb
@@ -36,7 +36,7 @@ describe XlsxService do
     end
 
     describe 'when cause title includes illegal characters for excel sheet name' do
-      let(:cause) { create(:cause, title_multiloc: { 'en' => 'title with illegal characters \/*?:[]' }) }
+      let(:cause) { create(:cause, title_multiloc: { 'en' => 'With illegal characters \/*?:[]' }) }
       let(:xlsx) do
         service.generate_xlsx(
           cause.participation_context,

--- a/back/spec/services/xlsx_service_spec.rb
+++ b/back/spec/services/xlsx_service_spec.rb
@@ -212,4 +212,12 @@ describe XlsxService do
        expect(round_trip_hash_array).to eq hash_array
     end
   end
+
+  describe "sanitize_sheetname" do
+    let(:sheetname) { 'With illegal characters \/*?:[]' }
+
+    it "removes illegal characters" do
+      expect(service.send(:sanitize_sheetname, sheetname)).to eq('With illegal characters ')  
+    end
+  end
 end


### PR DESCRIPTION
## Checklist

- [ ] Added entry to changelog
<details>
<summary>More info</summary>
Not done, as adds no new feature or fix.
</details>

- [x] Tests
<details>
<summary>More info</summary>
### Unit tests
Adds unit test of `sanitize_sheetname`
</details>

- [x] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## Links

- [Jira ticket](https://citizenlab.atlassian.net/browse/CL2-6600)
- Related PR [#505](https://github.com/CitizenLabDotCo/citizenlab/pull/505)

## What changes are in this PR?

As advised by @SaraBCL and @sebastienhoorens, `sanitize_sheetname` is moved to `back/app/services/xlsx_service.rb`, where it is called by `generate_sheet`, ensuring that any future development that perhaps uses a value derived from user input for an xlsx sheet name will have illegal characters removed from the value before it can cause an error.

Apologies for forgetting to use the original Jira ticket ref in the branch name.

## How urgent is a code review?

Not urgent.
