### PR TITLE
IN-541 Redirect on category reset

### DIFF
--- a/front/app/modules/commercial/insights/admin/containers/Insights/Edit/Categories/Categories.test.tsx
+++ b/front/app/modules/commercial/insights/admin/containers/Insights/Edit/Categories/Categories.test.tsx
@@ -135,6 +135,7 @@ describe('Insights Edit Categories', () => {
     );
   });
   it('resets categories', async () => {
+    const historySpy = jest.spyOn(clHistory, 'push');
     const spy = jest.spyOn(service, 'deleteInsightsCategories');
     render(<Categories />);
 
@@ -143,6 +144,10 @@ describe('Insights Edit Categories', () => {
     });
 
     expect(spy).toHaveBeenCalledWith(viewId);
+    expect(historySpy).toHaveBeenCalledWith({
+      pathname: '',
+      search: `?pageNumber=1&processed=false`,
+    });
   });
   it('shows all input category count correctly', () => {
     render(<Categories />);

--- a/front/app/modules/commercial/insights/admin/containers/Insights/Edit/Categories/index.tsx
+++ b/front/app/modules/commercial/insights/admin/containers/Insights/Edit/Categories/index.tsx
@@ -216,6 +216,7 @@ const Categories = ({
     }
     trackEventByName(tracks.resetCategories);
     setLoadingReset(false);
+    selectRecentlyPosted();
   };
 
   return (


### PR DESCRIPTION
## Checklist

- [ ] Added entry to changelog
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

- [x] Tests
<details>
<summary>More info</summary>

### Unit tests

Did you add relevant unit tests?

### E2E tests

Sometimes it can be more efficient to update E2E tests after CI has run them. If you know which ones to update, go ahead! E2E template cl2-back:

```bash
docker compose run --rm web bin/rails cl2_back:create_tenant[localhost,e2etests_template]
```

</details>

- [x] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## Links

- [Jira ticket](https://citizenlab.atlassian.net/browse/IN-541)

## What changes are in this PR?

When reseting a category, the user now gets redirected to the "Recently posted" list where all the input is.

## How urgent is a code review?

Very, last blocking item before the release!
