### PR TITLE
CL2-6708 Avoid inconsistent data check failures related to in_budgeting_participation_context validation

### DIFF
--- a/back/app/models/basket.rb
+++ b/back/app/models/basket.rb
@@ -6,7 +6,7 @@ class Basket < ApplicationRecord
   has_many :ideas, through: :baskets_ideas
 
   validates :user, :participation_context, presence: true
-  # validate :in_budgeting_participation_context
+  validate :in_budgeting_participation_context
   validate :basket_submission, on: :basket_submission
 
   scope :submitted, -> { where.not(submitted_at: nil) }

--- a/back/app/models/basket.rb
+++ b/back/app/models/basket.rb
@@ -6,7 +6,6 @@ class Basket < ApplicationRecord
   has_many :ideas, through: :baskets_ideas
 
   validates :user, :participation_context, presence: true
-  validate :in_budgeting_participation_context
   validate :basket_submission, on: :basket_submission
 
   scope :submitted, -> { where.not(submitted_at: nil) }
@@ -23,12 +22,6 @@ class Basket < ApplicationRecord
   
   def less_than_min_budget?
   	total_budget < participation_context.min_budget
-  end
-
-  def in_budgeting_participation_context
-  	if !participation_context.budgeting?
-  		errors.add(:participation_context, :is_not_budgeting, message: 'is not a in budgeting method')
-  	end
   end
 
   def basket_submission

--- a/back/app/models/basket.rb
+++ b/back/app/models/basket.rb
@@ -6,7 +6,7 @@ class Basket < ApplicationRecord
   has_many :ideas, through: :baskets_ideas
 
   validates :user, :participation_context, presence: true
-  validate :in_budgeting_participation_context
+  # validate :in_budgeting_participation_context
   validate :basket_submission, on: :basket_submission
 
   scope :submitted, -> { where.not(submitted_at: nil) }

--- a/back/spec/models/basket_spec.rb
+++ b/back/spec/models/basket_spec.rb
@@ -70,13 +70,13 @@ RSpec.describe Basket, type: :model do
   end
 
   context "when the basket's project is updated to non-budgeting participation method" do
+    let!(:basket) { create(:basket, ideas: [idea], participation_context: project, submitted_at: Time.now) }
     let(:project) { create(:continuous_budgeting_project, min_budget: 200) }
     let(:idea) { create(:idea, budget: 100, project: project) }
 
     # Check the basket remains valid and thus won't fail data consistency checks, as would be the case,
     # for example, if we enforce validation that the participation_context is budgeting.
     it "the basket remains valid" do
-      basket = create(:basket, ideas: [idea], participation_context: project, submitted_at: Time.now)
       project.update!(participation_method: "ideation")
       basket.reload
       expect(basket).to be_valid

--- a/back/spec/models/basket_spec.rb
+++ b/back/spec/models/basket_spec.rb
@@ -68,4 +68,22 @@ RSpec.describe Basket, type: :model do
       expect(basket_idea).to be_invalid
     end
   end
+
+  context "when the basket's project is updated to non-budgeting participation method" do
+    #let(:basket) { create(:basket, ideas: [idea], participation_context: project, submitted_at: Time.now) }
+    let(:project) { create(:continuous_budgeting_project, min_budget: 200) }
+    let(:idea) { create(:idea, budget: 100, project: project) }
+
+    # This checks that the basket remains valid and thus won't cause failures of data consistency checks,
+    # as would be the case, for example, if we were to enforce validation that the participation_context
+    # is budgeting.
+    it "the basket remains valid" do
+      basket = create(:basket, ideas: [idea], participation_context: project, submitted_at: Time.now)
+      project.update!(participation_method: "ideation")
+      basket.reload
+      # expect(project).to be_valid
+      # expect(idea).to be_valid
+      expect(basket).to be_valid
+    end
+  end
 end

--- a/back/spec/models/basket_spec.rb
+++ b/back/spec/models/basket_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Basket, type: :model do
     let(:project) { create(:continuous_budgeting_project, min_budget: 200) }
     let(:idea) { create(:idea, budget: 100, project: project) }
 
-    # Check the basket remains valid and thus won't fail data consistency checks, as would e the case,
+    # Check the basket remains valid and thus won't fail data consistency checks, as would be the case,
     # for example, if we enforce validation that the participation_context is budgeting.
     it "the basket remains valid" do
       basket = create(:basket, ideas: [idea], participation_context: project, submitted_at: Time.now)

--- a/back/spec/models/basket_spec.rb
+++ b/back/spec/models/basket_spec.rb
@@ -70,19 +70,15 @@ RSpec.describe Basket, type: :model do
   end
 
   context "when the basket's project is updated to non-budgeting participation method" do
-    #let(:basket) { create(:basket, ideas: [idea], participation_context: project, submitted_at: Time.now) }
     let(:project) { create(:continuous_budgeting_project, min_budget: 200) }
     let(:idea) { create(:idea, budget: 100, project: project) }
 
-    # This checks that the basket remains valid and thus won't cause failures of data consistency checks,
-    # as would be the case, for example, if we were to enforce validation that the participation_context
-    # is budgeting.
+    # Check the basket remains valid and thus won't fail data consistency checks, as would e the case,
+    # for example, if we enforce validation that the participation_context is budgeting.
     it "the basket remains valid" do
       basket = create(:basket, ideas: [idea], participation_context: project, submitted_at: Time.now)
       project.update!(participation_method: "ideation")
       basket.reload
-      # expect(project).to be_valid
-      # expect(idea).to be_valid
       expect(basket).to be_valid
     end
   end


### PR DESCRIPTION
## Checklist

- [ ] Added entry to changelog
<details>
<summary>More info</summary>
<br>
No changelog entry included, since this change aims to reduce our reporting of inconsistent data, and is thus of little direct benefit to users and difficult to explain in language that is understandable outside of our dev team.
</details>

- [x] Tests
<details>
<summary>More info</summary>
Added a single test to `spec/models/basket_spec.rb` that confirms a basket is still valid after the project it is associated with is updated to have a non-budgeting `participation_method`, e,g, 'ideation'.

</details>

- [x] Prepared branch for code review


## Links

- [Jira ticket](https://citizenlab.atlassian.net/browse/CL2-6708)

## What changes are in this PR?

We decided to remove the the `in_budgeting_participation_context` validation from the Basket model.

This should avoid the related inconsistent data check failures seen in CI, as in these examples:
```
"issues": {
    ...
    "Basket_participation_context_is_not_budgeting": {
      "count": 27,
      "hosts": {
        "denkmee.t-diel.nl": [
          "11f42fce-a49b-4502-aec4-45b7ff5b7bc1",
          "126c060b-ec46-47bc-8db6-dea24031b7bf",
          "1293cba2-0692-4177-b679-bbbaf71f0e86",
          "1655ff38-ded6-4c53-89ac-2c5a8b2d5a5f",
          "26400a29-5e61-4908-a70e-8cadcbfd10a6",
          "2898dead-b59b-4319-b1f5-0011666b8992",
          "28ae4660-4665-4245-8e09-59e7d5e2d43a",
          "2e2907c0-d1de-4d0f-876c-5e805c9ae101",
          "34bb30a6-748d-45a7-8e55-e2fe34b2159c",
          "42340fc6-c13e-4f23-91b1-4752ca82681c",
          "651a6e2d-1904-4874-af63-2f3f43b23869",
          "66cacf1c-eca0-462d-a768-6e6e7bd5a5f2",
          "82376c41-6796-46b9-baab-8bf465b7e5b0",
          "82908803-4dbc-4298-9010-9539f9f9c2b5",
          "8551b726-eb51-4c18-a67c-29f509c679ee",
          "87250fb9-e195-41b6-ab0c-5f013933d03f",
          "8755ae4b-54fc-4409-8d0e-d1af0a32ed9f",
          "96c41cd5-bb8c-47f3-82e7-7f45f32e5f99",
          "97bbdf63-5427-4fdb-ac15-f1028a2aff53",
          "a436ad59-2468-4f37-980a-3dc85762ba68",
          "a77cd06a-b7e5-48fb-ae00-a579be41c017",
          "cdfe9bb8-b43c-4c76-8780-25ad2d921838",
          "cf780ed6-35c9-4492-ba0c-b47a2154bf14",
          "e3b1fa44-80e4-441f-a653-d83929b67d68",
          "f5220e5e-5a3d-4084-a10f-bca7aba017c4",
          "fef3756d-6f24-4937-9a7e-86d8da7e1f91"
        ],
        "dialogportalen.odense.dk": [
          "c0935be6-2cf1-4bf1-bdd6-8c25d41ddd36"
        ]
      }
```
Excerpt from [this CI run](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab-ee/4935/workflows/8cc6dce1-1bc8-4506-9cde-a349aed9fbc4/jobs/16876).

## How urgent is a code review?

Medium priority. By the end-of-the week would be nice.
