### PR TITLE
Fix missing lifecycle stage assignment in seeds

### DIFF
--- a/back/db/seeds/citizenlab.rb
+++ b/back/db/seeds/citizenlab.rb
@@ -25,7 +25,8 @@ AppConfiguration.create!(
       color_main: '#163A7D',
       color_secondary: '#CF4040',
       color_text: '#163A7D',
-      reply_to_email: ENV.fetch('DEFAULT_FROM_EMAIL')
+      reply_to_email: ENV.fetch('DEFAULT_FROM_EMAIL'),
+      lifecycle_stage: 'active'
     },
     password_login: {
       enabled: true,


### PR DESCRIPTION
## Checklist

- [ ] Added entry to changelog
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

- [ ] Tests
<details>
<summary>More info</summary>

### Unit tests

Did you add relevant unit tests?

### E2E tests

Sometimes it can be more efficient to update E2E tests after CI has run them. If you know which ones to update, go ahead! E2E template cl2-back:

```bash
docker compose run --rm web bin/rails cl2_back:create_tenant[localhost,e2etests_template]
```

</details>

- [x] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## Links

## What changes are in this PR?

Spun up a quick Codespace to check out the app and had some trouble setting up a new dev environment by following [this guide](https://developers.citizenlab.co/start-dev-environment/). Rails seeds would fail with:

```
Rails -- Validation failed: Settings {:fragment=>"#/core", :error=>"Required", :human_message=>"The property '#/core' did not contain a required property of 'lifecycle_stage' in schema 8da1a11a-ee9f-514a-a806-0676181c5ed5"} excluded from capture: DSN not set
ActiveRecord::RecordInvalid: Validation failed: Settings {:fragment=>"#/core", :error=>"Required", :human_message=>"The property '#/core' did not contain a required property of 'lifecycle_stage' in schema 8da1a11a-ee9f-514a-a806-0676181c5ed5"}
```

I believe this fixes it. Probably introduced in https://github.com/CitizenLabDotCo/citizenlab/commit/41e5dc269befc16d1d0189de4718c28b5cc22c16.

## How urgent is a code review?

Just FYI.
