### PR TITLE
CL2-6707 Fixed setting DNS on host change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Next release
 
-/
+### Fixed
+
+- Setting DNS records when the host is changed
 
 ## 2021-09-01
 

--- a/back/app/services/side_fx_app_configuration_service.rb
+++ b/back/app/services/side_fx_app_configuration_service.rb
@@ -14,7 +14,6 @@ class SideFxAppConfigurationService
     if app_config.host_previously_changed?
       log_activity(app_config, 'changed_host', current_user, { changes: app_config.host_previous_change }) 
     end
-    # LogActivityJob.perform_later(tenant, 'changed_host', current_user, tenant.updated_at.to_i, payload: { changes: tenant.host_previous_change })
 
     # TODO_MT to be removed after the lifecycle stage has been move to Tenant
     if (lifecycle_change = get_lifecycle_change(app_config))

--- a/back/app/services/side_fx_app_configuration_service.rb
+++ b/back/app/services/side_fx_app_configuration_service.rb
@@ -11,7 +11,10 @@ class SideFxAppConfigurationService
 
   def after_update(app_config, current_user = nil)
     log_activity(app_config, 'changed', current_user)
-    log_activity(app_config, 'changed_host', current_user) if app_config.host_previously_changed?
+    if app_config.host_previously_changed?
+      log_activity(app_config, 'changed_host', current_user, { changes: app_config.host_previous_change }) 
+    end
+    # LogActivityJob.perform_later(tenant, 'changed_host', current_user, tenant.updated_at.to_i, payload: { changes: tenant.host_previous_change })
 
     # TODO_MT to be removed after the lifecycle stage has been move to Tenant
     if (lifecycle_change = get_lifecycle_change(app_config))


### PR DESCRIPTION
## Checklist

The change of host was no longer present in the payload, making it impossible for the tenant-setup service to set the DNS accordingly.

### Unit tests

See citizenlab-ee

## How urgent is a code review?

It's a big issue, but we've been having it for more than half a year, so probably not that urgent.
