### PR TITLE
CL2-6723 Support 25 neighbourhoods for Ghent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 - Smart group rules for participation in project, topic or idea status are now applied in one continuous SQL query.
 
+- Ghent now supports mapping 25 instead of 24 neighbourhouds
+
 ### Changed
 
 - The rule values for participation in project, topic or idea status, with predicates that are not a negation, are now represented as arrays of IDs in order to support specifying multiple projects, topics or idea statuses (the rule applies when satisfied for one of the values).

--- a/back/engines/commercial/id_gent_rrn/app/lib/id_gent_rrn/gent_rrn_verification.rb
+++ b/back/engines/commercial/id_gent_rrn/app/lib/id_gent_rrn/gent_rrn_verification.rb
@@ -35,7 +35,7 @@ module IdGentRrn
         wijk_mapping: {
           type: 'object',
           description: 'Maps wijknummers (see https://data.stad.gent/explore/dataset/stadswijken-gent/table/) to custom_field_value keys',
-          properties: (1..24).map do |i|
+          properties: (1..25).map do |i|
             [i.to_s, { type: 'string' }]
           end.to_h,
           additionalProperties: false,


### PR DESCRIPTION
## Checklist

- [x] Added entry to changelog
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

## What changes are in this PR?

I miscounted the amount of neighborhoods Ghent's API can return. Our mapping on the app configuration only supports 24, now 25.

## How urgent is a code review?
Pretty urgent, it's blocking them testing it