### PR TITLE
IN-557 Fix "stack level too deep" errors when capturing exceptions with Sentry

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -33,7 +33,13 @@ group :development, :test do
   gem 'database_cleaner'
   gem 'factory_bot_rails'
   gem 'license_finder'
-  gem 'rack-mini-profiler'
+  # Use module prepend to patch NET::HTTP to avoid stack level too deep errors.
+  # The errors are due to a conflict between patches that are using two
+  # different patching methods (method aliasing vs module prepend).
+  # Here, rack-mini-profiler conflicts with sentry-ruby which patches NET::HTTP
+  # with prepend.
+  # See https://github.com/MiniProfiler/rack-mini-profiler#nethttp-stack-level-too-deep-errors
+  gem 'rack-mini-profiler', require: ['prepend_net_http_patch', 'rack-mini-profiler']
   gem 'rspec_api_documentation'
   gem 'rspec_junit_formatter'
   gem 'rspec-rails'


### PR DESCRIPTION
See IN-557

Stack trace in `que` service:
```bash
#<Thread:0x000055ab6f1dbcb0@/usr/local/bundle/bundler/gems/que-77c6b92952b8/lib/que/worker.rb:41 run> terminated with exception (report_on_exception is true):
/usr/local/bundle/gems/rack-mini-profiler-2.3.2/lib/mini_profiler/profiler.rb:38:in `current': stack level too deep (SystemStackError)
	from /usr/local/bundle/gems/rack-mini-profiler-2.3.2/lib/mini_profiler/profiling_methods.rb:36:in `step'
	from /usr/local/bundle/gems/rack-mini-profiler-2.3.2/lib/patches/net_patches.rb:18:in `request_with_mini_profiler'
	from /usr/local/bundle/gems/sentry-ruby-core-4.7.2/lib/sentry/net/http.rb:38:in `request'
	from /usr/local/bundle/gems/rack-mini-profiler-2.3.2/lib/patches/net_patches.rb:19:in `block in request_with_mini_profiler'
	from /usr/local/bundle/gems/rack-mini-profiler-2.3.2/lib/mini_profiler/profiling_methods.rb:46:in `step'
	from /usr/local/bundle/gems/rack-mini-profiler-2.3.2/lib/patches/net_patches.rb:18:in `request_with_mini_profiler'
	from /usr/local/bundle/gems/sentry-ruby-core-4.7.2/lib/sentry/net/http.rb:38:in `request'
	from /usr/local/bundle/gems/rack-mini-profiler-2.3.2/lib/patches/net_patches.rb:19:in `block in request_with_mini_profiler'
	 ... 10685 levels...
	from (eval):11:in `run_job_middleware'
	from /usr/local/bundle/bundler/gems/que-77c6b92952b8/lib/que/worker.rb:96:in `work_job'
	from /usr/local/bundle/bundler/gems/que-77c6b92952b8/lib/que/worker.rb:69:in `work_loop'
	from /usr/local/bundle/bundler/gems/que-77c6b92952b8/lib/que/worker.rb:46:in `block in initialize'
bundler: failed to load command: que (/usr/local/bundle/bin/que)
SystemStackError: stack level too deep
  /usr/local/bundle/gems/rack-mini-profiler-2.3.2/lib/mini_profiler/profiler.rb:38:in `current'
  /usr/local/bundle/gems/rack-mini-profiler-2.3.2/lib/mini_profiler/profiling_methods.rb:36:in `step'
  /usr/local/bundle/gems/rack-mini-profiler-2.3.2/lib/patches/net_patches.rb:18:in `request_with_mini_profiler'
  /usr/local/bundle/gems/sentry-ruby-core-4.7.2/lib/sentry/net/http.rb:38:in `request'
  /usr/local/bundle/gems/rack-mini-profiler-2.3.2/lib/patches/net_patches.rb:19:in `block in request_with_mini_profiler'
  /usr/local/bundle/gems/rack-mini-profiler-2.3.2/lib/mini_profiler/profiling_methods.rb:46:in `step'
  /usr/local/bundle/gems/rack-mini-profiler-2.3.2/lib/patches/net_patches.rb:18:in `request_with_mini_profiler'
  /usr/local/bundle/gems/sentry-ruby-core-4.7.2/lib/sentry/net/http.rb:38:in `request'
  /usr/local/bundle/gems/rack-mini-profiler-2.3.2/lib/patches/net_patches.rb:19:in `block in request_with_mini_profiler'
  /usr/local/bundle/gems/rack-mini-profiler-2.3.2/lib/mini_profiler/profiling_methods.rb:46:in `step'
  /usr/local/bundle/gems/rack-mini-profiler-2.3.2/lib/patches/net_patches.rb:18:in `request_with_mini_profiler'
  /usr/local/bundle/gems/sentry-ruby-core-4.7.2/lib/sentry/net/http.rb:38:in `request'
  /usr/local/bundle/gems/rack-mini-profiler-2.3.2/lib/patches/net_patches.rb:19:in `block in request_with_mini_profiler'
  /usr/local/bundle/gems/rack-mini-profiler-2.3.2/lib/mini_profiler/profiling_methods.rb:46:in `step'
  /usr/local/bundle/gems/rack-mini-profiler-2.3.2/lib/patches/net_patches.rb:18:in `request_with_mini_profiler'
  /usr/local/bundle/gems/sentry-ruby-core-4.7.2/lib/sentry/net/http.rb:38:in `request'
  /usr/local/bundle/gems/rack-mini-profiler-2.3.2/lib/patches/net_patches.rb:19:in `block in request_with_mini_profiler'
  /usr/local/bundle/gems/rack-mini-profiler-2.3.2/lib/mini_profiler/profiling_methods.rb:46:in `step'
  /usr/local/bundle/gems/rack-mini-profiler-2.3.2/lib/patches/net_patches.rb:18:in `request_with_mini_profiler'
  /usr/local/bundle/gems/sentry-ruby-core-4.7.2/lib/sentry/net/http.rb:38:in `request'
  /usr/local/bundle/gems/rack-mini-profiler-2.3.2/lib/patches/net_patches.rb:19:in `block in request_with_mini_profiler'
  /usr/local/bundle/gems/rack-mini-profiler-2.3.2/lib/mini_profiler/profiling_methods.rb:46:in `step'
  /usr/local/bundle/gems/rack-mini-profiler-2.3.2/lib/patches/net_patches.rb:18:in `request_with_mini_profiler'
  /usr/local/bundle/gems/sentry-ruby-core-4.7.2/lib/sentry/net/http.rb:38:in `request'
  /usr/local/bundle/gems/rack-mini-profiler-2.3.2/lib/patches/net_patches.rb:19:in `block in request_with_mini_profiler'
  /usr/local/bundle/gems/rack-mini-profiler-2.3.2/lib/mini_profiler/profiling_methods.rb:46:in `step'
  /usr/local/bundle/gems/rack-mini-profiler-2.3.2/lib/patches/net_patches.rb:18:in `request_with_mini_profiler'
  /usr/local/bundle/gems/sentry-ruby-core-4.7.2/lib/sentry/net/http.rb:38:in `request'
  /usr/local/bundle/gems/rack-mini-profiler-2.3.2/lib/patches/net_patches.rb:19:in `block in request_with_mini_profiler'
  /usr/local/bundle/gems/rack-mini-profiler-2.3.2/lib/mini_profiler/profiling_methods.rb:46:in `step'
  /usr/local/bundle/gems/rack-mini-profiler-2.3.2/lib/patches/net_patches.rb:18:in `request_with_mini_profiler'
[...a few thousand lines more...]
```