### PR TITLE
[CL2-6611] Equidistant timeline phases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Changed
 
 - Project moderators have access to the 'Reporting' tab of the admin panel for their projects.
+- Very short phases are now shown slightly bigger in the timeline, and projects with many phases will display the timeline correctly.
 
 ### Fixed
 

--- a/front/app/containers/ProjectsShowPage/timeline/Timeline.tsx
+++ b/front/app/containers/ProjectsShowPage/timeline/Timeline.tsx
@@ -61,6 +61,20 @@ const ContainerInner = styled.div`
   align-items: stretch;
 `;
 
+const Phases = styled.div`
+  width: 100%;
+  margin: 0;
+  margin-left: auto;
+  margin-right: auto;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+
+  ${isRtl`
+    flex-direction: row-reverse;
+  `}
+`;
+
 const phaseBarHeight = '24px';
 
 const PhaseBar = styled.button`
@@ -155,13 +169,20 @@ const currentSelectedPhaseBar = css`
   }
 `;
 
-const PhaseContainer = styled.div<{ width: number }>`
+const PhaseContainer = styled.div<{ width: number; breakpoint: number }>`
   width: ${(props) => props.width}%;
+  min-width: ${MIN_PHASE_WIDTH_PX}px;
   display: flex;
   flex-direction: column;
   position: relative;
   cursor: pointer;
   margin-right: ${(props: any) => (!props.last ? '1px' : '0px')};
+
+  @media (max-width: ${({ breakpoint }) =>
+      breakpoint + CONTAINER_PADDING_PX * 2}px) {
+    width: 100%;
+    min-width: unset;
+  }
 
   &.first ${PhaseBar} {
     border-radius: ${(props: any) => props.theme.borderRadius} 0px 0px
@@ -192,32 +213,6 @@ const PhaseContainer = styled.div<{ width: number }>`
 
   &.selectedPhase.currentPhase {
     ${currentSelectedPhaseBar}
-  }
-`;
-
-const Phases = styled.div<{ breakpoint: number }>`
-  width: 100%;
-  margin: 0;
-  margin-left: auto;
-  margin-right: auto;
-  display: flex;
-  flex-direction: row;
-  flex-wrap: nowrap;
-
-  ${isRtl`
-    flex-direction: row-reverse;
-  `}
-
-  ${PhaseContainer} {
-    min-width: ${MIN_PHASE_WIDTH_PX}px;
-  }
-
-  @media (max-width: ${({ breakpoint }) =>
-      breakpoint + CONTAINER_PADDING_PX * 2}px) {
-    ${PhaseContainer} {
-      width: 100%;
-      min-width: unset;
-    }
   }
 `;
 
@@ -277,7 +272,7 @@ const Timeline = memo<Props>(({ projectId, className }) => {
         isHidden={phases.length === 1}
       >
         <ContainerInner>
-          <Phases className="e2e-phases" breakpoint={phasesBreakpoint}>
+          <Phases className="e2e-phases">
             <ScreenReaderOnly>
               <FormattedMessage {...messages.a11y_phasesOverview} />
             </ScreenReaderOnly>
@@ -313,6 +308,7 @@ const Timeline = memo<Props>(({ projectId, className }) => {
                   className={classNames}
                   key={index}
                   width={width}
+                  breakpoint={phasesBreakpoint}
                   onMouseDown={removeFocusAfterMouseClick}
                   onClick={handleOnPhaseSelection(phase)}
                 >

--- a/front/app/containers/ProjectsShowPage/timeline/Timeline.tsx
+++ b/front/app/containers/ProjectsShowPage/timeline/Timeline.tsx
@@ -41,7 +41,7 @@ import { ScreenReaderOnly } from 'utils/a11y';
 import { darken, rgba } from 'polished';
 
 const MIN_PHASE_WIDTH_PX = 110;
-const CONTAINER_PADDING = 20;
+const CONTAINER_PADDING_PX = 20;
 
 const grey = colors.label;
 const greenTransparent = rgba(colors.clGreen, 0.15);
@@ -213,7 +213,7 @@ const Phases = styled.div<{ breakpoint: number }>`
   }
 
   @media (max-width: ${({ breakpoint }) =>
-      breakpoint + CONTAINER_PADDING * 2}px) {
+      breakpoint + CONTAINER_PADDING_PX * 2}px) {
     ${PhaseContainer} {
       width: 100%;
       min-width: unset;


### PR DESCRIPTION
## Checklist

- [x] Added entry to changelog
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

- ~~[ ] Tests~~
<details>
<summary>More info</summary>

### Unit tests

Did you add relevant unit tests?

### E2E tests

Sometimes it can be more efficient to update E2E tests after CI has run them. If you know which ones to update, go ahead! E2E template cl2-back:

```bash
docker compose run --rm web bin/rails cl2_back:create_tenant[localhost,e2etests_template]
```

</details>

- [x] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## Links

- [Jira ticket](https://citizenlab.atlassian.net/browse/CL2-6611)

## What changes are in this PR?

- Before, very short phases were shown in the timeline with a fixed minimum of 80px. This was a bit too small, so I increased it to 110px.
- With the new minimum of 110px this meant that if you had a project with 8 phases, but your screen was only 800px wide, the timeline would go offscreen. There was a break point at which all phases would become equidistant and fit the timeline, but this was fixed at `media.smallerThanMinTablet`. I made the break point dynamic based on the number of phases, so that the timeline is always shown correctly, regardless of screen size or number of phases.

## How urgent is a code review?

Not very urgent
