### PR TITLE
IN-562 GET inputs from a set of categories

### DIFF
--- a/back/engines/commercial/insights/app/controllers/insights/web_api/v1/inputs_controller.rb
+++ b/back/engines/commercial/insights/app/controllers/insights/web_api/v1/inputs_controller.rb
@@ -34,6 +34,7 @@ module Insights
           :search,
           :sort,
           :processed,
+          categories: [],
           page: %i[number size]
         )
       end

--- a/back/engines/commercial/insights/app/finders/insights/inputs_finder.rb
+++ b/back/engines/commercial/insights/app/finders/insights/inputs_finder.rb
@@ -51,19 +51,20 @@ module Insights
 
       category_ids = params[:categories].map(&:presence)
       filtered = inputs.none
-      
+
       if category_ids.compact.present?
+        view.categories.find(category_ids.compact) # raise an exception if a category does not exist
         in_categories = inputs.left_outer_joins(:insights_category_assignments)
                               .where(insights_category_assignments: { category_id: category_ids.compact })
         filtered = filtered.or(in_categories)
       end
-      
+
       if category_ids.include?(nil)
         assigned_ids = Insights::CategoryAssignment.where(category: view.categories, input: inputs).pluck(:input_id)
         without_category = inputs.where.not(id: assigned_ids)
         filtered = filtered.or(without_category)
       end
-      
+
       filtered
     end
 
@@ -75,7 +76,7 @@ module Insights
                                 .where(insights_processed_flags: { view: [view] })
 
       if params[:processed] == 'true'
-      	inputs_with_flags
+        inputs_with_flags
       else
         inputs.where.not(id: inputs_with_flags)
       end

--- a/back/engines/commercial/insights/spec/finders/insights/inputs_finder_spec.rb
+++ b/back/engines/commercial/insights/spec/finders/insights/inputs_finder_spec.rb
@@ -119,9 +119,10 @@ describe Insights::InputsFinder do
       end
 
       context 'when filtering with an unknown category' do
+        let(:unknown_category) { create(:category) }
+
         it 'raises an exception' do
-          category = create(:category)
-          finder = described_class.new(view, { categories: [category.id] })
+          finder = described_class.new(view, { categories: [unknown_category.id] })
           expect { finder.execute }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end


### PR DESCRIPTION
(IN-562)

## What changes are in this PR?

Adds `categories[]` query parameter to `GET .../inputs`. The parameter can be used to select inputs from multiple categories. Once the FE will be adapted, we'll remove support the `category`query parameter.

`GET .../inputs?categories[]=uuid-1&categories[]=uuid-2`

