### PR TITLE
IN-563 Pre-population of categories based on inputs filters

### DIFF
--- a/back/engines/commercial/insights/app/controllers/insights/web_api/v1/categories_controller.rb
+++ b/back/engines/commercial/insights/app/controllers/insights/web_api/v1/categories_controller.rb
@@ -64,6 +64,12 @@ module Insights
                                  .merge(view_id: params.require(:view_id))
       end
 
+      def input_filter_params
+        @inputs_params ||= params.require(:category)
+                                 .permit(inputs: [:search, keywords: [], categories:[]])
+                                 .fetch(:inputs, nil)
+      end
+
       def update_params
         @update_params ||= params.require(:category).permit(:name)
       end

--- a/back/engines/commercial/insights/spec/acceptance/categories_spec.rb
+++ b/back/engines/commercial/insights/spec/acceptance/categories_spec.rb
@@ -159,11 +159,6 @@ resource 'Categories' do
         end
       end
 
-      example 'creates a pre-populated category', document: false do
-        require 'pry'; binding.pry
-        inputs = create_list(:idea, 4, project: view.scope)
-      end
-
       include_examples 'unprocessable entity'
     end
 

--- a/back/engines/commercial/insights/spec/acceptance/categories_spec.rb
+++ b/back/engines/commercial/insights/spec/acceptance/categories_spec.rb
@@ -85,9 +85,23 @@ resource 'Categories' do
   end
 
   post 'web_api/v1/insights/views/:view_id/categories' do
+    route_description <<~DESC
+      Allows to create a new category. The newly created category can be
+      (optionally) pre-populated with a set of inputs identified by filtering
+      parameters.
+    DESC
+
     with_options scope: :category do
       parameter :name, 'The name of the category.', required: true
     end
+
+    with_options scope: %w[category inputs], required: false do
+      parameter :search, 'Filter inputs by searching in title and body'
+      parameter :categories, 'Filter inputs by category (identifiers of categories)'
+      parameter :keywords, 'Filter inputs by keywords (identifiers of keyword nodes)'
+      parameter :processed, 'Filter inputs by processed status'
+    end
+
     ValidationErrorHelper.new.error_fields(self, Insights::Category)
 
     let(:name) { 'category-name' }

--- a/back/engines/commercial/insights/spec/acceptance/categories_spec.rb
+++ b/back/engines/commercial/insights/spec/acceptance/categories_spec.rb
@@ -99,7 +99,6 @@ resource 'Categories' do
       parameter :search, 'Filter inputs by searching in title and body'
       parameter :categories, 'Filter inputs by category (identifiers of categories)'
       parameter :keywords, 'Filter inputs by keywords (identifiers of keyword nodes)'
-      parameter :processed, 'Filter inputs by processed status'
     end
 
     ValidationErrorHelper.new.error_fields(self, Insights::Category)


### PR DESCRIPTION
(IN-563)

## What changes are in this PR?

This PR extends `POST .../categories` with new parameters to allow the creation of pre-populated categories. The new structure of the payload is:
```json
{
    "category": {
        "name": "Economy",
        "inputs": {   // <= NEW & OPTIONAL
            "categories": ["bd6c4918-...", "6fc462df-..."],
            "keywords": ["node-id"],
            "search": "search query"
        }
    }
}
```

All inputs that matches the filters will be assigned to the newly created category.
