### PR TITLE
Change front API_HOST to localhost

### DIFF
--- a/.env-front.example
+++ b/.env-front.example
@@ -1,2 +1,2 @@
-API_HOST=cl-back-web
+API_HOST=localhost
 GOOGLE_MAPS_API_KEY=


### PR DESCRIPTION
## Checklist

- [x] Added entry to changelog
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

- [ ] ~~Tests~~
<details>
<summary>More info</summary>

### Unit tests

Did you add relevant unit tests?

### E2E tests

Sometimes it can be more efficient to update E2E tests after CI has run them. If you know which ones to update, go ahead! E2E template cl2-back:

```bash
docker compose run --rm web bin/rails cl2_back:create_tenant[localhost,e2etests_template]
```

</details>

- [x] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## What changes are in this PR?

Default `.env-front.example` doesn't work on clean setup.
`API_HOST=cl-back-web` should be `API_HOST=localhost` instead,
because docker-compose doesn't create `cl-back-web` hostname
globally (on host machine), but only for docker instances
https://docs.docker.com/compose/networking/

It stopped working after this commit
https://github.com/CitizenLabDotCo/citizenlab/commit/2da75b8,
where we removed front service from docker-compose.yml.

## How urgent is a code review?

Not urgent at all.
