### PR TITLE
IN-569 Add error and loading states to the visualization

### DIFF
--- a/front/app/modules/commercial/insights/admin/containers/Insights/Details/Network/index.tsx
+++ b/front/app/modules/commercial/insights/admin/containers/Insights/Details/Network/index.tsx
@@ -34,9 +34,12 @@ import { Box, Spinner } from 'cl2-component-library';
 import Button from 'components/UI/Button';
 
 // intl
-import { injectIntl } from 'utils/cl-intl';
+import { injectIntl, FormattedMessage } from 'utils/cl-intl';
 import { InjectedIntlProps } from 'react-intl';
 import messages from '../../messages';
+
+// styles
+import styled from 'styled-components';
 
 type CanvasCustomRenderMode = 'replace' | 'before' | 'after';
 type Node = NodeObject & IInsightsNetworkNode;
@@ -58,6 +61,10 @@ const nodeColors = [
   '#0DA796',
   '#934E6F',
 ];
+
+const StyledMessage = styled.h4`
+  text-align: center;
+`;
 
 const Network = ({
   params: { viewId },
@@ -256,8 +263,31 @@ const Network = ({
 
   if (isError(network)) {
     return (
-      <Box h="100%" display="flex" justifyContent="center" alignItems="center">
-        Error message
+      <Box
+        w="50%"
+        m="auto"
+        h="100%"
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        color={colors.label}
+      >
+        <StyledMessage>
+          <FormattedMessage
+            {...messages.networkError}
+            values={{
+              link: (
+                <a
+                  href="https://citizenlabco.typeform.com/to/V2cPZ0rd"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  {formatMessage(messages.networkErrorLink)}
+                </a>
+              ),
+            }}
+          />
+        </StyledMessage>
       </Box>
     );
   }

--- a/front/app/modules/commercial/insights/admin/containers/Insights/messages.ts
+++ b/front/app/modules/commercial/insights/admin/containers/Insights/messages.ts
@@ -339,6 +339,15 @@ export default defineMessages({
     id: 'app.containers.Admin.Insights.Details.network',
     defaultMessage: 'Network',
   },
+  networkError: {
+    id: 'app.containers.Admin.Insights.Details.networkError',
+    defaultMessage:
+      'Something went wrong while trying to create your visualization. Leave your details { link } and we’ll get back to you.',
+  },
+  networkErrorLink: {
+    id: 'app.containers.Admin.Insights.Details.networkErrorLink',
+    defaultMessage: 'here',
+  },
   detectCategoriesTitle: {
     id: 'app.containers.Admin.Insights.Detect.pageTitle',
     defaultMessage: 'Detect new categories',

--- a/front/app/modules/commercial/insights/hooks/useInsightsNetwork.test.ts
+++ b/front/app/modules/commercial/insights/hooks/useInsightsNetwork.test.ts
@@ -6,6 +6,7 @@ import { delay } from 'rxjs/operators';
 import { insightsNetworkStream } from 'modules/commercial/insights/services/insightsNetwork';
 
 const viewId = '1';
+
 const mockNetwork = {
   data: {
     id: '2',
@@ -74,8 +75,31 @@ const mockNetwork = {
   },
 };
 
+const mockNetworkAnalysisTasks = {
+  data: [
+    {
+      id: '58ed4a03-155b-4b60-ac9e-cf101e6d94d0',
+      type: 'network_text_analysis_task',
+      attributes: {
+        created_at: '2021-07-08T12:01:53.254Z',
+      },
+    },
+    {
+      id: '140b1468-8b49-4999-a51c-084d8e17eefa',
+      type: 'network_text_analysis_task',
+      attributes: {
+        created_at: '2021-07-08T12:01:53.330Z',
+      },
+    },
+  ],
+};
+
 let mockObservable = new Observable((subscriber) => {
   subscriber.next(mockNetwork);
+}).pipe(delay(1));
+
+const mockTasksObservable = new Observable((subscriber) => {
+  subscriber.next(mockNetworkAnalysisTasks);
 }).pipe(delay(1));
 
 jest.mock('modules/commercial/insights/services/insightsNetwork', () => {
@@ -87,6 +111,19 @@ jest.mock('modules/commercial/insights/services/insightsNetwork', () => {
     }),
   };
 });
+
+jest.mock(
+  'modules/commercial/insights/services/insightsTextNetworkAnalysisTasks',
+  () => {
+    return {
+      insightsNetworkStream: jest.fn(() => {
+        return {
+          observable: mockTasksObservable,
+        };
+      }),
+    };
+  }
+);
 
 describe('useInsightsNetwork', () => {
   it('should call insightsNetworkStream with correct arguments', async () => {

--- a/front/app/modules/commercial/insights/hooks/useInsightsNetwork.ts
+++ b/front/app/modules/commercial/insights/hooks/useInsightsNetwork.ts
@@ -1,25 +1,69 @@
 import { useState, useEffect } from 'react';
 import {
   insightsNetworkStream,
-  IInsightsNetworkData,
+  IInsightsNetwork,
 } from '../services/insightsNetwork';
 
+import { interval } from 'rxjs';
+import { takeWhile, finalize } from 'rxjs/operators';
+
+import { API_PATH } from 'containers/App/constants';
+import streams from 'utils/streams';
+
+import { insightsTextNetworkAnalysisTasksStream } from 'modules/commercial/insights/services/insightsTextNetworkAnalysisTasks';
+
+const pollingStream = interval(3000);
+
 const useInsightsNetwork = (viewId: string) => {
+  const [loading, setLoading] = useState(true);
   const [insightsNetwork, setInsightsNetwork] = useState<
-    IInsightsNetworkData | undefined | null | Error
+    IInsightsNetwork | undefined | null | Error
   >(undefined);
 
   useEffect(() => {
     const subscription = insightsNetworkStream(viewId).observable.subscribe(
       (insightsNetwork) => {
-        setInsightsNetwork(insightsNetwork.data);
+        setInsightsNetwork(insightsNetwork);
       }
     );
 
-    return () => subscription.unsubscribe();
+    return () => {
+      subscription.unsubscribe();
+    };
   }, [viewId]);
 
-  return insightsNetwork;
+  useEffect(() => {
+    // Refetch pending tasks at an interval
+    const subscription = pollingStream.subscribe(() => {
+      streams.fetchAllWith({
+        partialApiEndpoint: [
+          `insights/views/${viewId}/tasks/text_network_analysis`,
+        ],
+      });
+    });
+    insightsTextNetworkAnalysisTasksStream(viewId)
+      .observable.pipe(
+        // Poll while there are pending tasks
+        takeWhile((response) => {
+          return response.data.length > 0;
+        }),
+        // Refetch network when there are no pending tasks
+        finalize(() => {
+          streams.fetchAllWith({
+            apiEndpoint: [`${API_PATH}/insights/views/${viewId}/network`],
+          });
+          subscription.unsubscribe();
+          setLoading(false);
+        })
+      )
+      .subscribe();
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [viewId]);
+
+  return { loading, network: insightsNetwork };
 };
 
 export default useInsightsNetwork;

--- a/front/app/modules/commercial/insights/hooks/useInsightsView.test.ts
+++ b/front/app/modules/commercial/insights/hooks/useInsightsView.test.ts
@@ -59,6 +59,6 @@ describe('useInsightsView', () => {
     const { unmount } = renderHook(() => useInsightsView(viewId));
 
     unmount();
-    expect(Subscription.prototype.unsubscribe).toHaveBeenCalledTimes(1);
+    expect(Subscription.prototype.unsubscribe).toHaveBeenCalledTimes(2);
   });
 });

--- a/front/app/modules/commercial/insights/hooks/useInsightsView.test.ts
+++ b/front/app/modules/commercial/insights/hooks/useInsightsView.test.ts
@@ -59,6 +59,6 @@ describe('useInsightsView', () => {
     const { unmount } = renderHook(() => useInsightsView(viewId));
 
     unmount();
-    expect(Subscription.prototype.unsubscribe).toHaveBeenCalledTimes(2);
+    expect(Subscription.prototype.unsubscribe).toHaveBeenCalledTimes(1);
   });
 });

--- a/front/app/modules/commercial/insights/services/insightsNetwork.ts
+++ b/front/app/modules/commercial/insights/services/insightsNetwork.ts
@@ -37,6 +37,7 @@ export function insightsNetworkStream(
 ) {
   return streams.get<IInsightsNetwork>({
     apiEndpoint: `${API_PATH}/${getInsightsInputsEndpoint(insightsViewId)}`,
+    cacheStream: false,
     ...streamParams,
   });
 }

--- a/front/app/modules/commercial/insights/services/insightsTextNetworkAnalysisTasks.ts
+++ b/front/app/modules/commercial/insights/services/insightsTextNetworkAnalysisTasks.ts
@@ -1,0 +1,39 @@
+import { API_PATH } from 'containers/App/constants';
+import streams, { IStreamParams } from 'utils/streams';
+import { IRelationship } from 'typings';
+
+const getInsightsTextNetworkAnalysisTasksEndpoint = (viewId: string) =>
+  `insights/views/${viewId}/tasks/text_network_analysis`;
+
+export interface IInsightsTextNetworkAnalysisTasksData {
+  id: string;
+  type: string;
+  attributes: {
+    created_at: string;
+  };
+  relationships?: {
+    categories: {
+      data: IRelationship[];
+    };
+    inputs: {
+      data: IRelationship[];
+    };
+  };
+}
+
+export interface IInsightsTextNetworkAnalysisTasks {
+  data: IInsightsTextNetworkAnalysisTasksData[];
+}
+
+export function insightsTextNetworkAnalysisTasksStream(
+  insightsViewId: string,
+  streamParams: IStreamParams | null = null
+) {
+  return streams.get<IInsightsTextNetworkAnalysisTasks>({
+    apiEndpoint: `${API_PATH}/${getInsightsTextNetworkAnalysisTasksEndpoint(
+      insightsViewId
+    )}`,
+    ...streamParams,
+    cacheStream: false,
+  });
+}

--- a/front/app/modules/commercial/insights/services/insightsTextNetworkAnalysisTasks.ts
+++ b/front/app/modules/commercial/insights/services/insightsTextNetworkAnalysisTasks.ts
@@ -1,6 +1,5 @@
 import { API_PATH } from 'containers/App/constants';
 import streams, { IStreamParams } from 'utils/streams';
-import { IRelationship } from 'typings';
 
 const getInsightsTextNetworkAnalysisTasksEndpoint = (viewId: string) =>
   `insights/views/${viewId}/tasks/text_network_analysis`;
@@ -10,14 +9,6 @@ export interface IInsightsTextNetworkAnalysisTasksData {
   type: string;
   attributes: {
     created_at: string;
-  };
-  relationships?: {
-    categories: {
-      data: IRelationship[];
-    };
-    inputs: {
-      data: IRelationship[];
-    };
   };
 }
 

--- a/front/app/translations/en.json
+++ b/front/app/translations/en.json
@@ -742,6 +742,8 @@
   "app.containers.Admin.Insights.Details.inputsLoadMore": "Load more",
   "app.containers.Admin.Insights.Details.inputsReadMore": "Read more",
   "app.containers.Admin.Insights.Details.network": "Network",
+  "app.containers.Admin.Insights.Details.networkError": "Something went wrong while trying to create your visualization. Leave your details {link} and we’ll get back to you.",
+  "app.containers.Admin.Insights.Details.networkErrorLink": "here",
   "app.containers.Admin.Insights.Detect.addCategories": "Add tags",
   "app.containers.Admin.Insights.Detect.addCategory": "Add tag",
   "app.containers.Admin.Insights.Detect.cancel": "Cancel",


### PR DESCRIPTION
## Checklist

- [ ] Added entry to changelog
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

- [x] Tests
<details>
<summary>More info</summary>

### Unit tests

Did you add relevant unit tests?

### E2E tests

Sometimes it can be more efficient to update E2E tests after CI has run them. If you know which ones to update, go ahead! E2E template cl2-back:

```bash
docker compose run --rm web bin/rails cl2_back:create_tenant[localhost,e2etests_template]
```

</details>

- [x] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## Links

- [Jira ticket](https://citizenlab.atlassian.net/browse/IN-569)

## What changes are in this PR?

We add error and loading states to the View screen visualisation. The loading state is based on polling of the text network analysis tasks endpoint.

## How urgent is a code review?

We are in a bit of a hurry with this so end of the day would be perfect. If not possible - Thursday morning?
