### PR TITLE
IN-568 Replace deprecated "category" query parameter with "categories"

### DIFF
--- a/front/app/modules/commercial/insights/hooks/useInsightsInputs.test.ts
+++ b/front/app/modules/commercial/insights/hooks/useInsightsInputs.test.ts
@@ -35,7 +35,7 @@ const queryParameters: QueryParameters = {
 };
 
 const expectedQueryParameters = {
-  category: queryParameters.category,
+  categories: [queryParameters.category],
   'page[number]': queryParameters.pageNumber,
   'page[size]': queryParameters.pageSize,
   search: queryParameters.search,
@@ -62,7 +62,7 @@ describe('useInsightsInputs', () => {
     renderHook(() => useInsightsInputs(viewId));
     expect(insightsInputsStream).toHaveBeenCalledWith(viewId, {
       queryParameters: {
-        category: undefined,
+        categories: undefined,
         'page[number]': 1,
         'page[size]': defaultPageSize,
         search: undefined,
@@ -84,7 +84,7 @@ describe('useInsightsInputs', () => {
     );
 
     expect(insightsInputsStream).toHaveBeenCalledWith(viewId, {
-      queryParameters: { ...expectedQueryParameters, category },
+      queryParameters: { ...expectedQueryParameters, categories: [category] },
     });
 
     // Category change
@@ -92,7 +92,7 @@ describe('useInsightsInputs', () => {
     rerender();
 
     expect(insightsInputsStream).toHaveBeenCalledWith(viewId, {
-      queryParameters: { ...expectedQueryParameters, category },
+      queryParameters: { ...expectedQueryParameters, categories: [category] },
     });
     expect(insightsInputsStream).toHaveBeenCalledTimes(2);
   });

--- a/front/app/modules/commercial/insights/hooks/useInsightsInputs.ts
+++ b/front/app/modules/commercial/insights/hooks/useInsightsInputs.ts
@@ -43,9 +43,9 @@ const useInsightsInputs = (
     setLoading(true);
     const subscription = insightsInputsStream(viewId, {
       queryParameters: {
-        category,
         search,
         processed,
+        categories: category ? [category] : undefined,
         sort: sort || 'approval',
         'page[number]': pageNumber || 1,
         'page[size]': pageSize || defaultPageSize,


### PR DESCRIPTION
## Checklist

- [ ] Added entry to changelog
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

- [x] Tests
<details>
<summary>More info</summary>

### Unit tests

Did you add relevant unit tests?

### E2E tests

Sometimes it can be more efficient to update E2E tests after CI has run them. If you know which ones to update, go ahead! E2E template cl2-back:

```bash
docker compose run --rm web bin/rails cl2_back:create_tenant[localhost,e2etests_template]
```

</details>

- [x] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## Links

- [Jira ticket](**put URL here**)
- [citizenlab-ee PR](**put URL here** or remove)
- [Specs](**put URL here** or remove)
- [Epic Deployment](**put URL here** or remove)

## What changes are in this PR?

Replace deprecated "category" query parameter with "categories" in Insights Edit screen.

## How urgent is a code review?

No real urgency - end of the week would be good.
