### PR TITLE
CL2-6778 User deletion broken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Next release
 
-/
+### Fixed
+
+- Issue with user deletion
 
 ## 2021-10-06
 

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/user_decorator.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/user_decorator.rb
@@ -10,7 +10,7 @@ module EmailCampaigns::UserDecorator
     before_destroy :fix_authored_campaigns
 
     def fix_authored_campaigns
-      authored_campaigns.where(sender: 'author').update_all(author_id: nil, sender: 'organization')
+      authored_campaigns.update_all(author_id: nil, sender: 'organization')
     end
   end
 

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/user_decorator.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/user_decorator.rb
@@ -10,7 +10,8 @@ module EmailCampaigns::UserDecorator
     before_destroy :fix_authored_campaigns
 
     def fix_authored_campaigns
-      authored_campaigns.update_all(author_id: nil, sender: 'organization')
+      authored_campaigns.where(sender: 'author').update_all(sender: 'organization')
+      authored_campaigns.update_all(author_id: nil)
     end
   end
 


### PR DESCRIPTION
Also when the sender is "organization" (even though the campaign would keep working in this case), the user ID needs to be cleared out from the campaign author to not violate the database foreign key constraint. See: https://sentry.hq.citizenlab.co/share/issue/68efea44b4a444a9bf6a7a7ebea8d4f7/