### PR TITLE
Speed up docker build ignoring .git and node_modules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,4 @@
-front/coverage
-front/build
-front/stats.json
-front/.DS_Store
-front/npm-debug.log
-front/.idea
-front/Dockerfile
-
+/front
 
 back/.byebug_history
 back/log/*
@@ -15,3 +8,5 @@ back/secrets/*
 back/Dockerfile
 !back/secrets/*.example
 !back/secrets/*.sample
+
+.git


### PR DESCRIPTION
Build time with all images being built beforehand
(mostly sending build context to Docker daemon):
before fix - 42s
after node_modules (entire front folder) ignored - 5.5s
after .git ignored - 3.5s

## Checklist

- [ ] ~~Added entry to changelog~~
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

- [ ] ~~Tests~~
<details>
<summary>More info</summary>

### Unit tests

Did you add relevant unit tests?

### E2E tests

Sometimes it can be more efficient to update E2E tests after CI has run them. If you know which ones to update, go ahead! E2E template cl2-back:

```bash
docker compose run --rm web bin/rails cl2_back:create_tenant[localhost,e2etests_template]
```

</details>

- [x] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## How urgent is a code review?

Not urgent at all