### PR TITLE
Formiksubmitwrapper isvalid

### DIFF
--- a/front/app/components/PageForm/index.tsx
+++ b/front/app/components/PageForm/index.tsx
@@ -86,7 +86,6 @@ export function validatePageForm(appConfigurationLocales: Locale[]) {
 const PageForm = ({
   isSubmitting,
   errors,
-  isValid,
   touched,
   hideTitle,
   hideSlugInput,
@@ -177,7 +176,11 @@ const PageForm = ({
         </SectionField>
       </StyledSection>
 
-      <FormikSubmitWrapper {...{ isValid, isSubmitting, status, touched }} />
+      <FormikSubmitWrapper
+        isSubmitting={isSubmitting}
+        status={status}
+        touched={touched}
+      />
     </form>
   );
 };

--- a/front/app/components/admin/FormikSubmitWrapper/index.tsx
+++ b/front/app/components/admin/FormikSubmitWrapper/index.tsx
@@ -13,6 +13,8 @@ interface Props
     OriginalButtonProps,
     'className' | 'text' | 'disabled' | 'setSubmitButtonRef' | 'processing'
   > {
+  // isValid prop doesn't work correctly in PageForm
+  // to be reviewed if it's useful/should be removed
   isValid: boolean;
   isSubmitting: boolean;
   status: any;
@@ -32,9 +34,9 @@ interface State {}
 
 class FormikSubmitWrapper extends React.PureComponent<Props, State> {
   getStatus = () => {
-    const { isValid, status, touched } = this.props;
+    const { status, touched } = this.props;
 
-    if (!isEmpty(touched)) {
+    if (status === 'enabled' && !isEmpty(touched)) {
       return 'enabled';
     } else if (status === 'error') {
       return 'error';

--- a/front/app/components/admin/FormikSubmitWrapper/index.tsx
+++ b/front/app/components/admin/FormikSubmitWrapper/index.tsx
@@ -37,7 +37,7 @@ const FormikSubmitWrapper = ({
   ...props
 }: Props) => {
   const getStatus = () => {
-    if (status === 'enabled' && !isEmpty(touched)) {
+    if (!isEmpty(touched)) {
       return 'enabled';
     } else if (status === 'error') {
       return 'error';

--- a/front/app/components/admin/FormikSubmitWrapper/index.tsx
+++ b/front/app/components/admin/FormikSubmitWrapper/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { omit, isEmpty } from 'lodash-es';
+import { isEmpty } from 'lodash-es';
 import SubmitWrapper from 'components/admin/SubmitWrapper';
 import messages from './messages';
 import {
@@ -13,9 +13,6 @@ interface Props
     OriginalButtonProps,
     'className' | 'text' | 'disabled' | 'setSubmitButtonRef' | 'processing'
   > {
-  // isValid prop doesn't work correctly in PageForm
-  // to be reviewed if it's useful/should be removed
-  isValid: boolean;
   isSubmitting: boolean;
   status: any;
   touched: any;
@@ -30,12 +27,16 @@ interface Props
   animate?: boolean;
 }
 
-interface State {}
-
-class FormikSubmitWrapper extends React.PureComponent<Props, State> {
-  getStatus = () => {
-    const { status, touched } = this.props;
-
+const FormikSubmitWrapper = ({
+  status,
+  touched,
+  isSubmitting,
+  messages: propsMessages,
+  buttonStyle,
+  animate,
+  ...props
+}: Props) => {
+  const getStatus = () => {
     if (status === 'enabled' && !isEmpty(touched)) {
       return 'enabled';
     } else if (status === 'error') {
@@ -47,29 +48,16 @@ class FormikSubmitWrapper extends React.PureComponent<Props, State> {
     }
   };
 
-  render() {
-    const { isSubmitting, buttonStyle: style, animate } = this.props;
-    const buttonProps = omit(this.props, [
-      'status',
-      'isSubmitting',
-      'isValid',
-      'messages',
-      'style',
-      'touched',
-    ]);
-    const status = this.getStatus();
-
-    return (
-      <SubmitWrapper
-        status={status}
-        loading={isSubmitting}
-        messages={this.props.messages || messages}
-        buttonStyle={style || 'primary'}
-        animate={animate}
-        {...buttonProps}
-      />
-    );
-  }
-}
+  return (
+    <SubmitWrapper
+      status={getStatus()}
+      loading={isSubmitting}
+      messages={propsMessages || messages}
+      buttonStyle={buttonStyle || 'primary'}
+      animate={animate}
+      {...props}
+    />
+  );
+};
 
 export default FormikSubmitWrapper;

--- a/front/app/containers/Admin/emails/custom/CampaignForm/index.tsx
+++ b/front/app/containers/Admin/emails/custom/CampaignForm/index.tsx
@@ -142,7 +142,7 @@ class CampaignForm extends React.Component<
   };
 
   render() {
-    const { isSubmitting, errors, isValid, touched, status } = this.props;
+    const { isSubmitting, errors, touched, status } = this.props;
     return (
       <Form>
         <StyledSection>
@@ -207,7 +207,6 @@ class CampaignForm extends React.Component<
             )}
           </StyledSectionField>
         </StyledSection>
-
         <StyledSection>
           <StyledSectionTitle>
             <FormattedMessage {...messages.fieldSubject} />
@@ -246,9 +245,10 @@ class CampaignForm extends React.Component<
             )}
           </SectionField>
         </StyledSection>
-
         <FormikSubmitWrapper
-          {...{ isValid, isSubmitting, status, touched, errors }}
+          isSubmitting={isSubmitting}
+          status={status}
+          touched={touched}
           messages={{
             buttonSave: messages.formSaveButton,
             buttonError: messages.formErrorButton,

--- a/front/app/containers/Admin/settings/areas/AreaForm/index.tsx
+++ b/front/app/containers/Admin/settings/areas/AreaForm/index.tsx
@@ -40,7 +40,6 @@ class AreaForm extends React.Component<
     const {
       isSubmitting,
       errors,
-      isValid,
       touched,
       status,
       intl: { formatMessage },
@@ -80,7 +79,11 @@ class AreaForm extends React.Component<
           </SectionField>
         </Section>
 
-        <FormikSubmitWrapper {...{ isValid, isSubmitting, status, touched }} />
+        <FormikSubmitWrapper
+          isSubmitting={isSubmitting}
+          status={status}
+          touched={touched}
+        />
       </Form>
     );
   }

--- a/front/app/containers/Admin/users/NormalGroupForm.tsx
+++ b/front/app/containers/Admin/users/NormalGroupForm.tsx
@@ -58,7 +58,7 @@ export default class NormalGroupForm extends React.Component<
   };
 
   render() {
-    const { isSubmitting, errors, isValid, touched, status } = this.props;
+    const { isSubmitting, errors, touched, status } = this.props;
 
     return (
       <Form>
@@ -81,8 +81,10 @@ export default class NormalGroupForm extends React.Component<
 
         <FooterContainer>
           <FormikSubmitWrapper
-            {...{ isValid, isSubmitting, status, touched }}
             buttonStyle="admin-dark"
+            isSubmitting={isSubmitting}
+            status={status}
+            touched={touched}
           />
         </FooterContainer>
       </Form>

--- a/front/app/modules/commercial/clusterings/admin/containers/New/ClusteringForm.tsx
+++ b/front/app/modules/commercial/clusterings/admin/containers/New/ClusteringForm.tsx
@@ -66,7 +66,7 @@ class ClusteringForm extends PureComponent<
   };
 
   render() {
-    const { isSubmitting, errors, isValid, touched, status } = this.props;
+    const { isSubmitting, errors, touched, status } = this.props;
 
     return (
       <>
@@ -209,7 +209,9 @@ class ClusteringForm extends PureComponent<
             </Section>
 
             <FormikSubmitWrapper
-              {...{ isValid, isSubmitting, status, touched }}
+              isSubmitting={isSubmitting}
+              status={status}
+              touched={touched}
             />
           </Form>
         </PageWrapper>

--- a/front/app/modules/commercial/custom_idea_statuses/admin/components/IdeaStatusForm.tsx
+++ b/front/app/modules/commercial/custom_idea_statuses/admin/components/IdeaStatusForm.tsx
@@ -92,7 +92,6 @@ export function validate(tenantLocales: Locale[]) {
 const IdeaStatusForm = ({
   isSubmitting,
   errors,
-  isValid,
   touched,
   status,
   intl: { formatMessage },
@@ -192,7 +191,11 @@ const IdeaStatusForm = ({
         </SectionField>
       </StyledSection>
 
-      <FormikSubmitWrapper {...{ isValid, isSubmitting, status, touched }} />
+      <FormikSubmitWrapper
+        isSubmitting={isSubmitting}
+        status={status}
+        touched={touched}
+      />
     </Form>
   );
 };

--- a/front/app/modules/commercial/custom_topics/admin/containers/TopicsSettings/TopicForm/index.tsx
+++ b/front/app/modules/commercial/custom_topics/admin/containers/TopicsSettings/TopicForm/index.tsx
@@ -29,7 +29,6 @@ class TopicForm extends React.Component<
     const {
       isSubmitting,
       errors,
-      isValid,
       touched,
       status,
       intl: { formatMessage },
@@ -55,7 +54,11 @@ class TopicForm extends React.Component<
           </SectionField>
         </Section>
 
-        <FormikSubmitWrapper {...{ isValid, isSubmitting, status, touched }} />
+        <FormikSubmitWrapper
+          isSubmitting={isSubmitting}
+          status={status}
+          touched={touched}
+        />
       </Form>
     );
   }

--- a/front/app/modules/commercial/smart_groups/containers/RulesGroupFormWithValidation/RulesGroupForm.tsx
+++ b/front/app/modules/commercial/smart_groups/containers/RulesGroupFormWithValidation/RulesGroupForm.tsx
@@ -38,7 +38,7 @@ export class RulesGroupForm extends React.PureComponent<
   InjectedFormikProps<Props, RulesFormValues>
 > {
   render() {
-    const { isSubmitting, errors, isValid, touched, status } = this.props;
+    const { isSubmitting, errors, touched, status } = this.props;
 
     return (
       <Form>
@@ -80,8 +80,10 @@ export class RulesGroupForm extends React.PureComponent<
 
         <FooterContainer>
           <FormikSubmitWrapper
-            {...{ isValid, isSubmitting, status, touched }}
             buttonStyle="admin-dark"
+            isSubmitting={isSubmitting}
+            status={status}
+            touched={touched}
           />
         </FooterContainer>
       </Form>

--- a/front/app/modules/commercial/user_custom_fields/admin/containers/CustomFields/RegistrationCustomFieldEdit/RegistrationCustomFieldOptionsForm.tsx
+++ b/front/app/modules/commercial/user_custom_fields/admin/containers/CustomFields/RegistrationCustomFieldEdit/RegistrationCustomFieldOptionsForm.tsx
@@ -57,7 +57,6 @@ class RegistrationCustomFieldOptionsForm extends React.Component<
     const {
       isSubmitting,
       errors,
-      isValid,
       touched,
       status,
       intl: { formatMessage },
@@ -83,7 +82,9 @@ class RegistrationCustomFieldOptionsForm extends React.Component<
 
         <Buttons>
           <FormikSubmitWrapper
-            {...{ isValid, isSubmitting, status, touched }}
+            isSubmitting={isSubmitting}
+            status={status}
+            touched={touched}
           />
           <CancelButton buttonStyle="text" onClick={this.handleCancelClick}>
             {formatMessage(messages.optionCancelButton)}

--- a/front/app/modules/commercial/user_custom_fields/admin/containers/CustomFields/RegistrationCustomFieldForm/index.tsx
+++ b/front/app/modules/commercial/user_custom_fields/admin/containers/CustomFields/RegistrationCustomFieldForm/index.tsx
@@ -71,7 +71,6 @@ class RegistrationCustomFieldForm extends React.Component<
       isSubmitting,
       mode,
       errors,
-      isValid,
       touched,
       builtInField,
       status,
@@ -149,7 +148,11 @@ class RegistrationCustomFieldForm extends React.Component<
           </SectionField>
         </Section>
 
-        <FormikSubmitWrapper {...{ isValid, isSubmitting, status, touched }} />
+        <FormikSubmitWrapper
+          isSubmitting={isSubmitting}
+          status={status}
+          touched={touched}
+        />
       </Form>
     );
   }

--- a/front/app/translations/lb-LU.json
+++ b/front/app/translations/lb-LU.json
@@ -259,7 +259,6 @@
   "app.components.InitiativesShowPage.noInitiativeFoundHere": "Keng Propositioun fonnt.",
   "app.components.Input.a11y_charactersLeft": "{currentCharCount} Zeeche benotzt vun {maxCharCount}",
   "app.components.Modal.closeModal": "Modul zoumaachen",
-  "app.components.PagesForm.dontChange": "Don't change this! (unless you really know what you're doing)",
   "app.components.PagesForm.editContent": "Inhalt",
   "app.components.PagesForm.fileUploadLabel": "Annexen (max. 50MB)",
   "app.components.PagesForm.fileUploadLabelTooltip": "Files should not be larger than 50Mb. Added files will be shown on the bottom of this page.",


### PR DESCRIPTION
https://github.com/formium/formik/issues/1133

As isValid doesn't show the correct "valid" state (isValid is often false while the form input is valid), and it's not used in the submit wrapper, I've taken it out everywhere. Also removed the passing of props in an object as that doesn't provide type checking.