### PR TITLE
IN-593 Fix network tasks polling

### DIFF
--- a/front/app/modules/commercial/insights/hooks/useInsightsNetwork.test.ts
+++ b/front/app/modules/commercial/insights/hooks/useInsightsNetwork.test.ts
@@ -134,16 +134,7 @@ describe('useInsightsNetwork', () => {
     renderHook(() => useInsightsNetwork(viewId));
     expect(insightsNetworkStream).toHaveBeenCalledWith(viewId);
   });
-  it('should return data when data', async () => {
-    const { result } = renderHook(() => useInsightsNetwork(viewId));
-    expect(result.current.network).toBe(undefined); // initially, the hook returns undefined
-    await act(
-      async () =>
-        await waitFor(() =>
-          expect(result.current.network).toStrictEqual(mockNetwork)
-        )
-    );
-  });
+
   it('should return loading=true when there are tasks', () => {
     const { result } = renderHook(() => useInsightsNetwork(viewId));
     expect(result.current.loading).toBe(true);
@@ -154,6 +145,16 @@ describe('useInsightsNetwork', () => {
     );
     const { result } = renderHook(() => useInsightsNetwork(viewId));
     expect(result.current.loading).toBe(false);
+  });
+  it('should return data when data', async () => {
+    const { result } = renderHook(() => useInsightsNetwork(viewId));
+    expect(result.current.network).toBe(undefined); // initially, the hook returns undefined
+    await act(
+      async () =>
+        await waitFor(() =>
+          expect(result.current.network).toStrictEqual(mockNetwork)
+        )
+    );
   });
   it('should return error when error', () => {
     const error = new Error();

--- a/front/app/modules/commercial/insights/hooks/useInsightsNetwork.ts
+++ b/front/app/modules/commercial/insights/hooks/useInsightsNetwork.ts
@@ -5,9 +5,8 @@ import {
 } from '../services/insightsNetwork';
 
 import { interval } from 'rxjs';
-import { takeWhile, finalize, count } from 'rxjs/operators';
+import { takeWhile, finalize } from 'rxjs/operators';
 
-import { API_PATH } from 'containers/App/constants';
 import streams from 'utils/streams';
 
 import { insightsTextNetworkAnalysisTasksStream } from 'modules/commercial/insights/services/insightsTextNetworkAnalysisTasks';
@@ -18,19 +17,21 @@ const useInsightsNetwork = (viewId: string) => {
   const [loading, setLoading] = useState(true);
   const [insightsNetwork, setInsightsNetwork] = useState<
     IInsightsNetwork | undefined | null | Error
-  >(undefined);
+  >();
 
   useEffect(() => {
     const subscription = insightsNetworkStream(viewId).observable.subscribe(
       (insightsNetwork) => {
-        setInsightsNetwork(insightsNetwork);
+        if (!loading) {
+          setInsightsNetwork(insightsNetwork);
+        }
       }
     );
 
     return () => {
       subscription.unsubscribe();
     };
-  }, [viewId]);
+  }, [viewId, loading]);
 
   useEffect(() => {
     // Refetch pending tasks at an interval
@@ -41,28 +42,23 @@ const useInsightsNetwork = (viewId: string) => {
         ],
       });
     });
-    insightsTextNetworkAnalysisTasksStream(viewId)
+    const streamSubscription = insightsTextNetworkAnalysisTasksStream(viewId)
       .observable.pipe(
         // Poll while there are pending tasks
         takeWhile((response) => {
           return response.data.length > 0;
         }),
-        count(),
         // Refetch network when there are no pending tasks
         finalize(() => {
+          subscription.unsubscribe();
           setLoading(false);
         })
       )
-      .subscribe((count) => {
-        if (count > 0) {
-          streams.fetchAllWith({
-            apiEndpoint: [`${API_PATH}/insights/views/${viewId}/network`],
-          });
-        }
-      });
+      .subscribe();
 
     return () => {
       subscription.unsubscribe();
+      streamSubscription.unsubscribe();
     };
   }, [viewId]);
 

--- a/front/app/modules/commercial/insights/services/insightsNetwork.ts
+++ b/front/app/modules/commercial/insights/services/insightsNetwork.ts
@@ -37,7 +37,6 @@ export function insightsNetworkStream(
 ) {
   return streams.get<IInsightsNetwork>({
     apiEndpoint: `${API_PATH}/${getInsightsNetworkEndpoint(insightsViewId)}`,
-    cacheStream: false,
     ...streamParams,
   });
 }


### PR DESCRIPTION
## Checklist

- [ ] Added entry to changelog
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

- [x] Tests
<details>
<summary>More info</summary>

### Unit tests

Did you add relevant unit tests?

### E2E tests

Sometimes it can be more efficient to update E2E tests after CI has run them. If you know which ones to update, go ahead! E2E template cl2-back:

```bash
docker compose run --rm web bin/rails cl2_back:create_tenant[localhost,e2etests_template]
```

</details>

- [x] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## Links

- [Jira ticket](https://citizenlab.atlassian.net/browse/IN-593)

## What changes are in this PR?

I had to rework the polling system for network tasks. Turns out the stream gets destroyed on error. But the first time we request the network it returns 404 because it doesn't exist yet. This destroys the network stream. Then, when there are no more tasks, we try to refetch the stream but it doesn't exist anymore. So this led to some buggy behaviour.

Now, to fix this, we don't rely on a refetch but instead use the loading state as an indicator of when to get the network again. Also, now we are caching the network. It doesn't change, not sure why I wasn't before.

## How urgent is a code review?

As soon as possible since the View this is already in production :)
