### PR TITLE
Fix sentry error tracking for backgroud jobs

### DIFF
--- a/back/app/jobs/application_job.rb
+++ b/back/app/jobs/application_job.rb
@@ -4,10 +4,4 @@ class ApplicationJob < ActiveJob::Base
   include ActiveJobQueExtension
 
   perform_retries true
-
-  def handle_error(error)
-    super
-    message = "#{error.class.name}: \"#{error}\". Retry count: #{error_count} (max: #{max_retries})."
-    Sentry.capture_exception(message, tags: { type: 'Job', tenant: Apartment::Tenant.current })
-  end
 end

--- a/back/config/sidekiq.yml.erb
+++ b/back/config/sidekiq.yml.erb
@@ -1,7 +1,0 @@
----
-:concurrency: 5
-:queues:
-  - default
-  - mailers
-  - image_creation
-  - image_background

--- a/back/lib/active_job_que_extension.rb
+++ b/back/lib/active_job_que_extension.rb
@@ -38,7 +38,8 @@ module ActiveJobQueExtension
     _run(
       args: que_filter_args(
         args.map { |a| a.is_a?(Hash) ? a.deep_symbolize_keys : a }
-      )
+      ),
+      reraise_errors: true
     )
   end
 end


### PR DESCRIPTION
sentry-rails's approach of sending error is better than ours at least because they send more parameters (e.g. job arguments). 

sentry-rails gem catches any active_job error, sends it to sentry
server and reraises it
https://github.com/getsentry/sentry-ruby/blob/master/sentry-rails/lib/sentry/rails/active_job.rb#L36
It worked when job is run with `perform_now`.
It seems in this case que doesn't catches errors
(maybe que is not even involved, see below).

que gem also catches any error, but reraises it only if `reraise_errors`
keyword argument is passed as true
https://github.com/que-rb/que/blob/77c6b92952b821898c393239ce0e4047b17d7dae/lib/que/job_methods.rb#L65
In this case que calls `handle_error`, and had `handle_error(error)`
with `Sentry.capture_`, but it worked only for `perform_later`,
`perform_now` ignored `handle_error`.

Sometimes `reraise_errors` is true
https://github.com/que-rb/que/blob/77c6b92952b821898c393239ce0e4047b17d7dae/lib/que/job.rb#L138
but sometimes it's false
https://github.com/que-rb/que/blob/77c6b92952b821898c393239ce0e4047b17d7dae/lib/que/active_job/extensions.rb#L19
(we have this code copied to our repo).

So the solution is to pass `reraise_errors` as true.
This way we don't need `handle_error`, sentry-rails does the job for us.

## Checklist

- [ ] ~~Added entry to changelog~~
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

- [ ] ~~Tests~~
<details>
<summary>More info</summary>

### Unit tests

Did you add relevant unit tests?

### E2E tests

Sometimes it can be more efficient to update E2E tests after CI has run them. If you know which ones to update, go ahead! E2E template cl2-back:

```bash
docker compose run --rm web bin/rails cl2_back:create_tenant[localhost,e2etests_template]
```

</details>

- [x] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## How urgent is a code review?

Average. Currently, error tracking doesn't work for background jobs.
