### PR TITLE
IN-594 Redirect to main screen when there is an error in the view

### DIFF
--- a/front/app/modules/commercial/insights/admin/components/TopBar/TopBar.test.tsx
+++ b/front/app/modules/commercial/insights/admin/components/TopBar/TopBar.test.tsx
@@ -1,19 +1,22 @@
 import React from 'react';
 import { render, screen, fireEvent } from 'utils/testUtils/rtl';
-import * as service from 'modules/commercial/insights/services/insightsViews';
+import { deleteInsightsView } from 'modules/commercial/insights/services/insightsViews';
+import clHistory from 'utils/cl-router/history';
 
 import TopBar from './';
 
-const mockViewData = {
-  id: '1',
-  type: 'view',
-  attributes: {
-    name: 'Test View',
-    updated_at: '2021-05-31T11:02:44.608Z',
-  },
-  relationships: {
-    scope: {
-      data: { id: '2', type: 'project' },
+let mockViewData: any = {
+  data: {
+    id: '1',
+    type: 'view',
+    attributes: {
+      name: 'Test View',
+      updated_at: '2021-05-31T11:02:44.608Z',
+    },
+    relationships: {
+      scope: {
+        data: { id: '2', type: 'project' },
+      },
     },
   },
 };
@@ -60,6 +63,8 @@ jest.mock('react-router', () => {
   };
 });
 
+jest.mock('utils/cl-router/history');
+
 describe('Insights Top Bar', () => {
   it('renders Top Bar', () => {
     render(<TopBar />);
@@ -67,7 +72,9 @@ describe('Insights Top Bar', () => {
   });
   it('renders View name correctly', () => {
     render(<TopBar />);
-    expect(screen.getByText(mockViewData.attributes.name)).toBeInTheDocument();
+    expect(
+      screen.getByText(mockViewData.data.attributes.name)
+    ).toBeInTheDocument();
   });
   it('renders Project button with correct slug', () => {
     render(<TopBar />);
@@ -79,9 +86,14 @@ describe('Insights Top Bar', () => {
   });
   it('deletes view on menu item click', () => {
     render(<TopBar />);
-    const spy = jest.spyOn(service, 'deleteInsightsView');
     fireEvent.click(screen.getByRole('button'));
     fireEvent.click(screen.getByText('Delete'));
-    expect(spy).toHaveBeenCalledWith(mockViewData.id);
+    expect(deleteInsightsView).toHaveBeenCalledWith(mockViewData.data.id);
+  });
+  it('redirects to main screen there is view error', () => {
+    mockViewData = new Error();
+    render(<TopBar />);
+
+    expect(clHistory.push).toHaveBeenCalledWith('/admin/insights');
   });
 });

--- a/front/app/modules/commercial/insights/admin/components/TopBar/index.tsx
+++ b/front/app/modules/commercial/insights/admin/components/TopBar/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { withRouter, WithRouterProps } from 'react-router';
 
 // styles
@@ -18,7 +18,7 @@ import messages from './messages';
 // utils
 import clHistory from 'utils/cl-router/history';
 import { injectIntl } from 'utils/cl-intl';
-import { isNilOrError } from 'utils/helperUtils';
+import { isNilOrError, isError } from 'utils/helperUtils';
 
 // services
 import { deleteInsightsView } from '../../../services/insightsViews';
@@ -74,10 +74,17 @@ const TopBar = ({
   const viewId = params.viewId;
   const view = useInsightsView(viewId);
 
+  useEffect(() => {
+    if (isError(view)) {
+      clHistory.push('/admin/insights');
+    }
+  }, [view]);
+
   if (isNilOrError(view) || isNilOrError(locale)) {
     return null;
   }
-  const projectId = view.relationships?.scope.data.id;
+
+  const projectId = view?.data.relationships?.scope.data.id;
   const toggleDropdown = () => {
     setDropdownOpened(!isDropdownOpened);
   };
@@ -101,7 +108,7 @@ const TopBar = ({
   return (
     <Container data-testid="insightsTopBar">
       <TitleContainer>
-        <h1>{view.attributes.name}</h1>
+        <h1>{view?.data.attributes.name}</h1>
         {projectId && <ProjectButton projectId={projectId} />}
       </TitleContainer>
       <DropdownWrapper>
@@ -140,7 +147,7 @@ const TopBar = ({
         <RenameInsightsView
           closeRenameModal={closeRenameModal}
           insightsViewId={viewId}
-          originalViewName={view.attributes.name}
+          originalViewName={view.data.attributes.name}
         />
       </Modal>
     </Container>

--- a/front/app/modules/commercial/insights/admin/containers/Insights/Details/Network/index.tsx
+++ b/front/app/modules/commercial/insights/admin/containers/Insights/Details/Network/index.tsx
@@ -262,7 +262,7 @@ const Network = ({
         saveAs(
           blob,
           `${formatMessage(messages.network)}_${
-            view.attributes.name
+            view.data.attributes.name
           }_${formatDate(Date.now())}.png`
         );
       });

--- a/front/app/modules/commercial/insights/admin/containers/Insights/Details/index.tsx
+++ b/front/app/modules/commercial/insights/admin/containers/Insights/Details/index.tsx
@@ -41,7 +41,7 @@ const Container = styled.div`
 
 const Left = styled.div`
   position: relative;
-  width: 100%;
+  width: calc(100% - 420px);
 `;
 
 const DetailsInsightsView = ({

--- a/front/app/modules/commercial/insights/admin/containers/Insights/Details/index.tsx
+++ b/front/app/modules/commercial/insights/admin/containers/Insights/Details/index.tsx
@@ -133,12 +133,8 @@ const DetailsInsightsView = ({
     setMovedUpDown(true);
   }, []);
 
-  if (isNilOrError(inputs)) {
-    return null;
-  }
-
   const onPreviewInput = (input: IInsightsInputData) => {
-    setPreviewedInputIndex(inputs.indexOf(input));
+    !isNilOrError(inputs) && setPreviewedInputIndex(inputs.indexOf(input));
     clHistory.replace({
       pathname,
       search: stringify(
@@ -151,31 +147,33 @@ const DetailsInsightsView = ({
   return (
     <>
       <TopBar />
-      <Container data-testid="insightsDetails">
-        <Left>
-          {query.previewedInputId && (
-            <>
-              <Preview />
-              <Navigation
-                moveUp={moveUp}
-                moveDown={moveDown}
-                isMoveUpDisabled={previewedInputIndex === 0}
-                isMoveDownDisabled={isMoveDownDisabled}
-              />
-            </>
-          )}
-          <Categories>
-            <Network />
-          </Categories>
-        </Left>
-        <Inputs
-          hasMore={hasMore}
-          inputs={inputs}
-          loading={loading}
-          onLoadMore={onLoadMore}
-          onPreviewInput={onPreviewInput}
-        />
-      </Container>
+      {!isNilOrError(inputs) && (
+        <Container data-testid="insightsDetails">
+          <Left>
+            {query.previewedInputId && (
+              <>
+                <Preview />
+                <Navigation
+                  moveUp={moveUp}
+                  moveDown={moveDown}
+                  isMoveUpDisabled={previewedInputIndex === 0}
+                  isMoveDownDisabled={isMoveDownDisabled}
+                />
+              </>
+            )}
+            <Categories>
+              <Network />
+            </Categories>
+          </Left>
+          <Inputs
+            hasMore={hasMore}
+            inputs={inputs}
+            loading={loading}
+            onLoadMore={onLoadMore}
+            onPreviewInput={onPreviewInput}
+          />
+        </Container>
+      )}
     </>
   );
 };

--- a/front/app/modules/commercial/insights/admin/containers/Insights/Edit/InputsTable/Export.tsx
+++ b/front/app/modules/commercial/insights/admin/containers/Insights/Edit/InputsTable/Export.tsx
@@ -52,7 +52,7 @@ const Export = ({
       saveAs(
         blob,
         `${formatMessage(messages.inputsTableExportFileName)}_${
-          view.attributes.name
+          view.data.attributes.name
         }_${formatDate(Date.now())}.xlsx`
       );
     } catch {

--- a/front/app/modules/commercial/insights/hooks/useInsightsView.test.ts
+++ b/front/app/modules/commercial/insights/hooks/useInsightsView.test.ts
@@ -35,21 +35,20 @@ describe('useInsightsView', () => {
     const { result } = renderHook(() => useInsightsView(viewId));
     expect(result.current).toBe(undefined); // initially, the hook returns undefined
     await act(
-      async () =>
-        await waitFor(() => expect(result.current).toBe(mockView.data))
+      async () => await waitFor(() => expect(result.current).toBe(mockView))
     );
   });
   it('should return error when error', () => {
     const error = new Error();
     mockObservable = new Observable((subscriber) => {
-      subscriber.next({ data: new Error() });
+      subscriber.next(new Error());
     });
     const { result } = renderHook(() => useInsightsView(viewId));
     expect(result.current).toStrictEqual(error);
   });
   it('should return null when data is null', () => {
     mockObservable = new Observable((subscriber) => {
-      subscriber.next({ data: null });
+      subscriber.next(null);
     });
     const { result } = renderHook(() => useInsightsView(viewId));
     expect(result.current).toBe(null);

--- a/front/app/modules/commercial/insights/hooks/useInsightsView.ts
+++ b/front/app/modules/commercial/insights/hooks/useInsightsView.ts
@@ -1,18 +1,15 @@
 import { useState, useEffect } from 'react';
-import {
-  insightsViewStream,
-  IInsightsViewData,
-} from '../services/insightsViews';
+import { insightsViewStream, IInsightsView } from '../services/insightsViews';
 
 const useInsightsView = (id: string) => {
   const [insightsView, setInsightsView] = useState<
-    IInsightsViewData | undefined | null | Error
+    IInsightsView | undefined | null | Error
   >(undefined);
 
   useEffect(() => {
     const subscription = insightsViewStream(id).observable.subscribe(
       (insightsView) => {
-        setInsightsView(insightsView.data);
+        setInsightsView(insightsView);
       }
     );
 


### PR DESCRIPTION
## Checklist

- [ ] Added entry to changelog
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

- [x] Tests
<details>
<summary>More info</summary>

### Unit tests

Did you add relevant unit tests?

### E2E tests

Sometimes it can be more efficient to update E2E tests after CI has run them. If you know which ones to update, go ahead! E2E template cl2-back:

```bash
docker compose run --rm web bin/rails cl2_back:create_tenant[localhost,e2etests_template]
```

</details>

- [x] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## Links

- [Jira ticket](https://citizenlab.atlassian.net/browse/IN-594)

## What changes are in this PR?

Whenever the view is deleted and the user visits an url that is no longer valid, they get redirected to the main insights screen.

## How urgent is a code review?

Not super urgent.
