### PR TITLE
Use pry as default rails console

### DIFF
--- a/back/.pryrc
+++ b/back/.pryrc
@@ -1,0 +1,1 @@
+Pry.config.history_file = Rails.root.join('tmp', '.pry_history')

--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -1,9 +1,9 @@
 FROM ruby:2.5.3-slim
 
 RUN apt-get update && apt-get install -qq -y --no-install-recommends \
-      build-essential nodejs libpq-dev file imagemagick curl git optipng jpegoptim pngquant libgeos-dev libgmp3-dev netcat shared-mime-info
+      build-essential libpq-dev file imagemagick curl git optipng jpegoptim pngquant libgeos-dev libgmp3-dev netcat shared-mime-info \
+      less
 
-RUN apt-get -y install curl
 RUN curl -sL https://deb.nodesource.com/setup_15.x  | bash -
 RUN apt-get -y install nodejs
 

--- a/back/Gemfile
+++ b/back/Gemfile
@@ -29,7 +29,10 @@ gem 'rack-cors'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
+  gem 'pry'
   gem 'pry-byebug'
+  gem 'pry-rails'
+  gem 'pry-stack_explorer'
   gem 'database_cleaner'
   gem 'factory_bot_rails'
   gem 'license_finder'
@@ -58,8 +61,6 @@ end
 group :development do
   gem 'bullet'
   gem 'listen', '>= 3.0.5', '< 3.2'
-  gem 'pry'
-  gem 'pry-stack_explorer'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'redcarpet'
   gem 'spring'

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -816,6 +816,8 @@ GEM
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     pry-stack_explorer (0.4.13)
       binding_of_caller (~> 0.7)
       pry (~> 0.13)
@@ -1177,6 +1179,7 @@ DEPENDENCIES
   project_permissions!
   pry
   pry-byebug
+  pry-rails
   pry-stack_explorer
   public_api!
   puma (~> 4.3.8)


### PR DESCRIPTION
irb is great and it's getting better with every ruby release,
but it still lacks multple features of pry: `ls`, `$ User`,
syntax highlighting, long output in less (added the package to
Dockerfile).

Also, commands history will be preserved in ./tmp/.pry-history.
Apart from other advantages, it's now possible to run
ctrl+r -> type "sw" -> choose `Tenant.last.switch!`

## Checklist

- [ ] ~~Added entry to changelog~~
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

- [ ] ~~Tests~~
<details>
<summary>More info</summary>

### Unit tests

Did you add relevant unit tests?

### E2E tests

Sometimes it can be more efficient to update E2E tests after CI has run them. If you know which ones to update, go ahead! E2E template cl2-back:

```bash
docker compose run --rm web bin/rails cl2_back:create_tenant[localhost,e2etests_template]
```

</details>

- [x] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## How urgent is a code review?

Not urgent.
