### PR TITLE
Ignore only node_modules, not entire /front

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,11 @@
-/front
+front/coverage
+front/build
+front/stats.json
+front/.DS_Store
+front/npm-debug.log
+front/.idea
+front/Dockerfile
+front/node_modules
 
 back/.byebug_history
 back/log/*


### PR DESCRIPTION
Related to https://github.com/CitizenLabDotCo/citizenlab/pull/845
`front-release-essential-image` CI task was failing with entire `front` being ignored.

## Checklist

- [ ] ~~Added entry to changelog~~
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

- [ ] ~~Tests~~
<details>
<summary>More info</summary>

### Unit tests

Did you add relevant unit tests?

### E2E tests

Sometimes it can be more efficient to update E2E tests after CI has run them. If you know which ones to update, go ahead! E2E template cl2-back:

```bash
docker compose run --rm web bin/rails cl2_back:create_tenant[localhost,e2etests_template]
```

</details>

- [x] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## How urgent is a code review?

Production release is blocked.