### PR TITLE
CL2-6811 i1 add project search

### DIFF
--- a/back/app/controllers/web_api/v1/projects_controller.rb
+++ b/back/app/controllers/web_api/v1/projects_controller.rb
@@ -22,10 +22,10 @@ class WebApi::V1::ProjectsController < ::ApplicationController
                        .per(params.dig(:page, :size))
 
     if params[:search].present?
-	    @projects = @projects.search_by_all(params[:search])
-	  else 
-	    @projects = @projects.ordered
-	  end
+      @projects = @projects.search_by_all(params[:search])
+    else 
+      @projects = @projects.ordered
+    end
 
     LogActivityJob.perform_later(current_user, 'searched_pojects', current_user, Time.now.to_i, payload: {search_query: params[:search]}) if params[:search].present?
 

--- a/back/app/controllers/web_api/v1/projects_controller.rb
+++ b/back/app/controllers/web_api/v1/projects_controller.rb
@@ -17,11 +17,11 @@ class WebApi::V1::ProjectsController < ::ApplicationController
     # scope.
 
     @projects = Project.where(id:publications.select(:publication_id))
-                       .ordered
                        .includes(:project_images, :phases, :areas, projects_topics: [:topic], admin_publication: [:children])
                        .page(params.dig(:page, :number))
                        .per(params.dig(:page, :size))
 
+    @projects = @projects.ordered unless params[:search].present?
     @projects = @projects.search_by_all(params[:search]) if params[:search].present?
 
     LogActivityJob.perform_later(current_user, 'searched_pojects', current_user, Time.now.to_i, payload: {search_query: params[:search]}) if params[:search].present?

--- a/back/app/controllers/web_api/v1/projects_controller.rb
+++ b/back/app/controllers/web_api/v1/projects_controller.rb
@@ -21,8 +21,11 @@ class WebApi::V1::ProjectsController < ::ApplicationController
                        .page(params.dig(:page, :number))
                        .per(params.dig(:page, :size))
 
-    @projects = @projects.ordered unless params[:search].present?
-    @projects = @projects.search_by_all(params[:search]) if params[:search].present?
+    if params[:search].present?
+	    @projects = @projects.search_by_all(params[:search])
+	  else 
+	    @projects = @projects.ordered
+	  end
 
     LogActivityJob.perform_later(current_user, 'searched_pojects', current_user, Time.now.to_i, payload: {search_query: params[:search]}) if params[:search].present?
 

--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -1,5 +1,7 @@
 class Project < ApplicationRecord
   include ParticipationContext
+  include PgSearch::Model
+  
   mount_base64_uploader :header_bg, ProjectHeaderBgUploader
 
   DESCRIPTION_PREVIEW_JSON_SCHEMA = ERB.new(File.read(Rails.root.join('config', 'schemas', 'project_description_preview.json_schema.erb'))).result(binding)
@@ -53,6 +55,10 @@ class Project < ApplicationRecord
   before_validation :sanitize_description_multiloc, if: :description_multiloc
   before_validation :strip_title
   before_validation :set_admin_publication
+
+  pg_search_scope :search_by_all,
+                  against: %i[title_multiloc description_multiloc],
+                  using: { tsearch: { prefix: true } }
 
   scope :with_all_areas, (Proc.new do |area_ids|
     uniq_area_ids = area_ids.uniq

--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -1,7 +1,7 @@
 class Project < ApplicationRecord
   include ParticipationContext
   include PgSearch::Model
-  
+
   mount_base64_uploader :header_bg, ProjectHeaderBgUploader
 
   DESCRIPTION_PREVIEW_JSON_SCHEMA = ERB.new(File.read(Rails.root.join('config', 'schemas', 'project_description_preview.json_schema.erb'))).result(binding)
@@ -57,7 +57,7 @@ class Project < ApplicationRecord
   before_validation :set_admin_publication
 
   pg_search_scope :search_by_all,
-                  against: %i[title_multiloc description_multiloc],
+                  against: %i[title_multiloc description_multiloc description_preview_multiloc],
                   using: { tsearch: { prefix: true } }
 
   scope :with_all_areas, (Proc.new do |area_ids|

--- a/back/spec/acceptance/projects_spec.rb
+++ b/back/spec/acceptance/projects_spec.rb
@@ -154,12 +154,6 @@ resource 'Projects' do
                 "fr-BE": "a title",
                 "nl-BE": "a title"
               })
-
-        p2 = create(:project, title_multiloc: {
-                "en": "a title",
-                "fr-BE": "a title",
-                "nl-BE": "a title"
-              })
   
         do_request search: "super-specific-title-string"
         json_response = json_parse(response_body)

--- a/back/spec/acceptance/projects_spec.rb
+++ b/back/spec/acceptance/projects_spec.rb
@@ -33,6 +33,7 @@ resource 'Projects' do
       parameter :publication_statuses, "Return only projects with the specified publication statuses (i.e. given an array of publication statuses); returns all projects by default", required: false
       parameter :filter_can_moderate, "Filter out the projects the user is allowed to moderate. False by default", required: false
       parameter :filter_ids, "Filter out only projects with the given list of IDs", required: false
+      parameter :search, 'Filter by searching in title_multiloc, description_multiloc and description_preview_multiloc', required: false
 
       parameter :folder, 'Filter by folder (project folder id)', required: false if CitizenLab.ee?
 
@@ -145,6 +146,24 @@ resource 'Projects' do
         do_request filter_can_moderate: true, publication_statuses: ['published']
         expect(status).to eq(200)
         expect(json_response[:data].size).to eq 4
+      end
+
+      example "Search for projects" do
+        p1 = create(:project, title_multiloc: {
+                "en": "super-specific-title-string",
+                "fr-BE": "a title",
+                "nl-BE": "a title"
+              })
+        p2 = create(:project, title_multiloc: {
+                "en": "a title",
+                "fr-BE": "a title",
+                "nl-BE": "a title"
+              })
+  
+        do_request search: "super-specific-title-string"
+        json_response = json_parse(response_body)
+        expect(json_response[:data].size).to eq 1
+        expect(json_response[:data][0][:id]).to eq p1.id
       end
     end
 

--- a/back/spec/acceptance/projects_spec.rb
+++ b/back/spec/acceptance/projects_spec.rb
@@ -154,6 +154,7 @@ resource 'Projects' do
                 "fr-BE": "a title",
                 "nl-BE": "a title"
               })
+              
         p2 = create(:project, title_multiloc: {
                 "en": "a title",
                 "fr-BE": "a title",
@@ -624,6 +625,29 @@ resource 'Projects' do
         do_request
         expect(status).to eq(200)
         expect(json_response[:data].size).to eq 1
+      end
+
+      example "Search for project does not return projects with draft status" do
+        p1 = create(:project,
+              admin_publication_attributes: { publication_status: "published" },
+              title_multiloc: {
+                "en": "super-specific-title-string-1",
+                "fr-BE": "a title",
+                "nl-BE": "a title"
+              })
+
+        p2 = create(:project,
+          admin_publication_attributes: { publication_status: "draft" },
+          title_multiloc: {
+            "en": "super-specific-title-string-2",
+            "fr-BE": "a title",
+            "nl-BE": "a title"
+          })
+
+        do_request search: "super-specific-title-string"
+        json_response = json_parse(response_body)
+        expect(json_response[:data].size).to eq 1
+        expect(json_response[:data][0][:id]).to eq p1.id
       end
 
       example 'Normal users cannot moderate any projects', document: false, skip: !CitizenLab.ee? do

--- a/back/spec/acceptance/projects_spec.rb
+++ b/back/spec/acceptance/projects_spec.rb
@@ -157,8 +157,8 @@ resource 'Projects' do
   
         do_request search: "super-specific-title-string"
         json_response = json_parse(response_body)
-        expect(json_response[:data].size).to eq 1
-        expect(json_response[:data][0][:id]).to eq p1.id
+        expect(response_data.size).to eq 1
+        expect(response_ids).to eq [p1.id]
       end
     end
 
@@ -640,8 +640,8 @@ resource 'Projects' do
 
         do_request search: "super-specific-title-string"
         json_response = json_parse(response_body)
-        expect(json_response[:data].size).to eq 1
-        expect(json_response[:data][0][:id]).to eq p1.id
+        expect(response_data.size).to eq 1
+        expect(response_ids).to eq [p1.id]
       end
 
       example 'Normal users cannot moderate any projects', document: false, skip: !CitizenLab.ee? do

--- a/back/spec/acceptance/projects_spec.rb
+++ b/back/spec/acceptance/projects_spec.rb
@@ -630,7 +630,7 @@ resource 'Projects' do
                 "nl-BE": "a title"
               })
 
-        p2 = create(:project,
+        create(:project,
           admin_publication_attributes: { publication_status: "draft" },
           title_multiloc: {
             "en": "super-specific-title-string-2",

--- a/back/spec/acceptance/projects_spec.rb
+++ b/back/spec/acceptance/projects_spec.rb
@@ -154,7 +154,7 @@ resource 'Projects' do
                 "fr-BE": "a title",
                 "nl-BE": "a title"
               })
-              
+
         p2 = create(:project, title_multiloc: {
                 "en": "a title",
                 "fr-BE": "a title",
@@ -627,7 +627,7 @@ resource 'Projects' do
         expect(json_response[:data].size).to eq 1
       end
 
-      example "Search for project does not return projects with draft status" do
+      example "Search for projects does not return projects with draft status" do
         p1 = create(:project,
               admin_publication_attributes: { publication_status: "published" },
               title_multiloc: {


### PR DESCRIPTION
## Checklist

- [ ] Added entry to changelog
  
Changelog NOT updated, as feature not fully implemented until FE work completed.

- [x] Tests
<details>
<summary>More info</summary>

### Acceptance tests

2 acceptance tests added.

### E2E tests

Sometimes it can be more efficient to update E2E tests after CI has run them. If you know which ones to update, go ahead! E2E template cl2-back:

```bash
docker compose run --rm web bin/rails cl2_back:create_tenant[localhost,e2etests_template]
```

</details>

- [x] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## Links

- [Jira ticket](https://citizenlab.atlassian.net/browse/CL2-6811)
- [Jira Epic](https://citizenlab.atlassian.net/browse/CL2-6805)
- [Epic Deployment](https://6805.epic.citizenlab.co)

## What changes are in this PR?

Add BE search projects functionality:

Using `search` parameter in URL query, for example;  
  http://localhost:3000/web_api/v1/projects?search=somestring  
will return the data for any projects that include the search string provided in their `title_multiloc`, `description_multiloc`, or `description_preview_multiloc`.

Note, this will return false-positives (matches with multiloc values for languages the user cannot see), but on balance it was felt that this is unlikely to present problems, since in most cases a user will keep typing to create a specific enough search string to filter out any false-positives. If this does prove to be an issue for customers, we can add the complexity needed to avoid such false-positives in a further iteration.

## How urgent is a code review?

ALREADY REVIEWED - This PR is a duplicate of [#933](https://github.com/CitizenLabDotCo/citizenlab/pull/933) - created to create a new branch to match name of [Jira task](https://citizenlab.atlassian.net/browse/CL2-6811) on [Jira Epic](https://citizenlab.atlassian.net/browse/CL2-6805). 