### PR TITLE
IN-610 Service for mass deletion of users

### DIFF
--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -163,9 +163,6 @@ class WebApi::V1::UsersController < ::ApplicationController
 
   def destroy
     DeleteUserJob.perform_now(@user.id, current_user)
-  rescue ActiveRecord::RecordNotDestroyed
-    head 500
-  else
     head :ok
   end
 

--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -6,7 +6,6 @@ class WebApi::V1::UsersController < ::ApplicationController
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
-
   def index
     authorize :user, :index?
     @users = policy_scope(User)
@@ -18,7 +17,6 @@ class WebApi::V1::UsersController < ::ApplicationController
     @users = @users.admin.or(@users.project_moderator(params[:can_moderate_project])) if params[:can_moderate_project].present?
     @users = @users.admin.or(@users.project_moderator) if params[:can_moderate].present?
     @users = @users.admin if params[:can_admin].present?
-
 
     if !params[:search].present?
       @users = case params[:sort]
@@ -157,28 +155,26 @@ class WebApi::V1::UsersController < ::ApplicationController
       render json: WebApi::V1::UserSerializer.new(
         @user,
         params: fastjson_params
-        ).serialized_json, status: :ok
+      ).serialized_json, status: :ok
     else
       render json: { errors: @user.errors.details }, status: :unprocessable_entity
     end
   end
 
   def destroy
-    user = @user.destroy
-    if user.destroyed?
-      SideFxUserService.new.after_destroy(user, current_user)
-      head :ok
-    else
-      head 500
-    end
+    DeleteUserJob.perform_now(@user.id, current_user)
+  rescue ActiveRecord::RecordNotDestroyed
+    head 500
+  else
+    head :ok
   end
 
   def ideas_count
-    render json: {count: policy_scope(@user.ideas.published).count}, status: :ok
+    render json: { count: policy_scope(@user.ideas.published).count }, status: :ok
   end
 
   def initiatives_count
-    render json: {count: policy_scope(@user.initiatives.published).count}, status: :ok
+    render json: { count: policy_scope(@user.initiatives.published).count }, status: :ok
   end
 
   def comments_count
@@ -188,18 +184,19 @@ class WebApi::V1::UsersController < ::ApplicationController
       count += policy_scope(
         published_comments.where(post_type: 'Idea'),
         policy_scope_class: IdeaCommentPolicy::Scope
-        ).count
+      ).count
     end
     if !params[:post_type] || params[:post_type] == 'Initiative'
       count += policy_scope(
         published_comments.where(post_type: 'Initiative'),
         policy_scope_class: InitiativeCommentPolicy::Scope
-        ).count
+      ).count
     end
-    render json: {count: count}, status: :ok
+    render json: { count: count }, status: :ok
   end
 
   private
+
   # TODO: temp fix to pass tests
   def secure_controller?
     false

--- a/back/app/jobs/application_job.rb
+++ b/back/app/jobs/application_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationJob < ActiveJob::Base
   include Bullet::ActiveJob if Rails.env.development?
   include Que::ActiveJob::JobExtensions

--- a/back/app/jobs/application_job.rb
+++ b/back/app/jobs/application_job.rb
@@ -4,4 +4,7 @@ class ApplicationJob < ActiveJob::Base
   include ActiveJobQueExtension
 
   perform_retries true
+
+  # Otherwise the default priority would be 100, which is the lowest priority.
+  self.priority = 50
 end

--- a/back/app/jobs/delete_user_job.rb
+++ b/back/app/jobs/delete_user_job.rb
@@ -4,7 +4,7 @@ class DeleteUserJob < ApplicationJob
   self.priority = 90 # pretty low priority (lowest is 100)
 
   # @param [User,String] user user or user identifier
-  # @param [User,NilClass] current_user 
+  # @param [User,NilClass] current_user
   def run(user, current_user = nil)
     user = User.find(user) unless user.respond_to?(:id)
     user.destroy!

--- a/back/app/jobs/delete_user_job.rb
+++ b/back/app/jobs/delete_user_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class DeleteUserJob < ApplicationJob
+  self.priority = 90 # pretty low priority (lowest is 100)
+
+  # @param [User,String] user user or user identifier
+  # @param [User,NilClass] current_user 
+  def run(user, current_user = nil)
+    user = User.find(user) unless user.respond_to?(:id)
+    user.destroy!
+    SideFxUserService.new.after_destroy(user, current_user)
+  end
+end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -79,7 +79,6 @@ class User < ApplicationRecord
   has_many :official_feedbacks, dependent: :nullify
   has_many :votes, dependent: :nullify
 
-  before_destroy do 1/0 end
   before_destroy :remove_initiated_notifications # Must occur before has_many :notifications (see https://github.com/rails/rails/issues/5205)
   has_many :notifications, foreign_key: :recipient_id, dependent: :destroy
   has_many :unread_notifications, -> { where read_at: nil }, class_name: 'Notification', foreign_key: :recipient_id

--- a/back/app/services/side_fx_user_service.rb
+++ b/back/app/services/side_fx_user_service.rb
@@ -35,9 +35,7 @@ class SideFxUserService
   end
 
   def after_destroy(frozen_user, current_user)
-    serialized_user = clean_time_attributes(frozen_user.attributes)
-    LogActivityJob.perform_later(encode_frozen_resource(frozen_user), 'deleted', current_user, Time.now.to_i,
-                                 payload: { user: serialized_user })
+    LogActivityJob.perform_later(encode_frozen_resource(frozen_user), 'deleted', current_user, Time.now.to_i)
     UpdateMemberCountJob.perform_later
     RemoveUserFromIntercomJob.perform_later(frozen_user.id)
     RemoveUsersFromSegmentJob.perform_later([frozen_user.id])

--- a/back/spec/jobs/delete_user_job_spec.rb
+++ b/back/spec/jobs/delete_user_job_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DeleteUserJob do
+  describe '.perform_now' do
+    let(:user) { create(:user) }
+
+    it 'deletes the user record' do
+      described_class.perform_now(user)
+      expect { user.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it 'deletes the user record from user identifier' do
+      described_class.perform_now(user.id)
+      expect { user.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it 'triggers after_destroy side effects' do
+      sidefx_service = instance_spy(SideFxUserService, 'sidefx_service')
+      allow(SideFxUserService).to receive(:new).and_return(sidefx_service)
+
+      current_user = build_stubbed(:user)
+      described_class.perform_now(user.id, current_user)
+
+      expect(sidefx_service).to have_received(:after_destroy).with(user, current_user)
+    end
+
+    context 'when the user does not exist' do
+      before do
+        user.destroy!
+      end
+
+      it 'raise an error' do
+        expect { described_class.perform_now(user.id) }
+          .to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -9,13 +9,12 @@ RSpec.describe User, type: :model do
   end
 
   describe '.destroy_all_async' do
-    let(:user) { create_list(:user, 2) }
+    before { create_list(:user, 2) }
 
     it 'enqueues a user-deletion job for each user' do
       expect { described_class.destroy_all_async }
-        .to have_enqueued_job(DeleteUserJob).exactly(user.count).times
+        .to have_enqueued_job(DeleteUserJob).exactly(User.count).times
     end
-
   end
 
   describe "creating a user" do

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe User, type: :model do
 
     it 'enqueues a user-deletion job for each user' do
       expect { described_class.destroy_all_async }
-        .to have_enqueued_job(DeleteUserJob).exactly(User.count).times
+        .to have_enqueued_job(DeleteUserJob).exactly(described_class.count).times
     end
   end
 

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -8,6 +8,16 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '.destroy_all_async' do
+    let(:user) { create_list(:user, 2) }
+
+    it 'enqueues a user-deletion job for each user' do
+      expect { described_class.destroy_all_async }
+        .to have_enqueued_job(DeleteUserJob).exactly(user.count).times
+    end
+
+  end
+
   describe "creating a user" do
     it "generates a slug" do
       u = build(:user)
@@ -286,7 +296,6 @@ RSpec.describe User, type: :model do
     end
 
   end
-
 
   describe "order_role" do
 


### PR DESCRIPTION
IN-610 

## What changes are in this PR?

In the end, the solution triggers a DeleteUserJob for each user instead of implementing a bulk delete. The main reasons are:
- The APIs of some third parties (e.g. Intercom) does not support bulk delete.
- We need a retry mechanism at the level of the request.
- We can reuse the same logic in the `UsersController` and `User.destroy_all_async`.
- Que prefers small jobs.

> Long-running jobs aren't necessarily a problem for the database, since the overhead of an individual job is very small (just an advisory lock held in memory). But jobs that hang indefinitely can tie up a worker and block the Ruby process from exiting gracefully, which is a pain.

`DeleteUserJob` jobs have a very low priority to limit the impact on the rest of the background jobs. They also have a lower priority than the jobs that they are themselves triggering to mitigate the grow of the task queue.

## Annoying stuffs
- The `UpdateMemberCountJob.perform_later` side effect is run for each user.