### PR TITLE
CL2-6812 i2 add project is_active and is_not_active filters

### DIFF
--- a/back/app/models/phase.rb
+++ b/back/app/models/phase.rb
@@ -58,10 +58,6 @@ class Phase < ApplicationRecord
     self
   end
 
-  def is_active?
-    start_at.present? && end_at.present? && start_at <= Time.zone.now && end_at >= Time.zone.now
-  end
-
   private
 
   def sanitize_description_multiloc

--- a/back/app/models/phase.rb
+++ b/back/app/models/phase.rb
@@ -58,6 +58,10 @@ class Phase < ApplicationRecord
     self
   end
 
+  def is_active?
+    start_at.present? && end_at.present? && start_at <= Time.zone.now && end_at >= Time.zone.now
+  end
+
   private
 
   def sanitize_description_multiloc

--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -105,26 +105,30 @@ class Project < ApplicationRecord
   }
 
   # Active = published non-timeline projects and published timeline projects with an active phase
-  scope :is_active, -> {
+  scope :is_active, lambda {
     includes(:admin_publication, :phases)
       .where.not(process_type: 'timeline')
       .where(admin_publications: { publication_status: 'published' })
-    .or(
-      where(process_type: 'timeline')
-      .where(admin_publications: { publication_status: 'published' })
-      .where('phases.start_at <= ? AND phases.end_at >= ?', today, today)
-    )
+      .or(
+        where(process_type: 'timeline')
+        .where(admin_publications: { publication_status: 'published' })
+        .where('phases.start_at <= ? AND phases.end_at >= ?', today, today)
+      )
   }
 
   # Inactive = All archived projects and any published timeline projects with no active phase.
-  scope :is_not_active, -> {
+  scope :is_not_active, lambda {
     includes(:admin_publication, :phases)
       .where(admin_publications: { publication_status: 'archived' })
-    .or(
-      where(process_type: 'timeline')
-      .where(admin_publications: { publication_status: 'published' })
-      .where.not(id: Project.includes(:phases).where('phases.start_at <= ? AND phases.end_at >= ?', today, today).pluck(:id))
-    )
+      .or(
+        where(process_type: 'timeline')
+        .where(admin_publications: { publication_status: 'published' })
+        .where.not(
+          id: Project.includes(:phases)
+          .where('phases.start_at <= ? AND phases.end_at >= ?', today, today)
+          .pluck(:id)
+        )
+      )
   }
 
   def continuous?

--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -112,7 +112,7 @@ class Project < ApplicationRecord
     .or(
       where(process_type: 'timeline')
       .where(admin_publications: { publication_status: 'published' })
-      .where('phases.start_at <= ? AND phases.end_at >= ?', Time.zone.now, Time.zone.now)
+      .where('phases.start_at <= ? AND phases.end_at >= ?', today, today)
     )
   }
 
@@ -123,8 +123,8 @@ class Project < ApplicationRecord
     .or(
       where(process_type: 'timeline').
       where(admin_publications: { publication_status: 'published' }).
-      where.not(id: Project.includes(:phases).where('phases.start_at <= ? AND phases.end_at >= ?', Time.zone.now, Time.zone.now).pluck(:id))
-      )
+      where.not(id: Project.includes(:phases).where('phases.start_at <= ? AND phases.end_at >= ?', today, today).pluck(:id))
+    )
   }
 
   def continuous?
@@ -202,6 +202,10 @@ class Project < ApplicationRecord
       end
     end
   end
+end
+
+def today
+  Time.now.in_time_zone(AppConfiguration.instance.settings('core', 'timezone')).to_date
 end
 
 Project.include(ProjectPermissions::Patches::Project)

--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -121,9 +121,9 @@ class Project < ApplicationRecord
     includes(:admin_publication, :phases)
       .where(admin_publications: { publication_status: 'archived' })
     .or(
-      where(process_type: 'timeline').
-      where(admin_publications: { publication_status: 'published' }).
-      where.not(id: Project.includes(:phases).where('phases.start_at <= ? AND phases.end_at >= ?', today, today).pluck(:id))
+      where(process_type: 'timeline')
+      .where(admin_publications: { publication_status: 'published' })
+      .where.not(id: Project.includes(:phases).where('phases.start_at <= ? AND phases.end_at >= ?', today, today).pluck(:id))
     )
   }
 

--- a/back/app/services/projects_filtering_service.rb
+++ b/back/app/services/projects_filtering_service.rb
@@ -18,6 +18,14 @@ class ProjectsFilteringService
     keep_ids = options[:filter_ids]
     keep_ids ? scope.where(id: keep_ids) : scope
   end
+
+  add_filter('is_active') do |scope, options|
+    if options[:active].present?
+      scope.is_active
+    else
+      scope
+    end
+  end
 end
 
 ProjectsFilteringService.include_if_ee('ProjectManagement::Patches::ProjectsFilteringService')

--- a/back/app/services/projects_filtering_service.rb
+++ b/back/app/services/projects_filtering_service.rb
@@ -20,9 +20,10 @@ class ProjectsFilteringService
   end
 
   add_filter('is_active') do |scope, options|
-    if options[:active] == 'true'
+    case options[:active]
+    when 'true'
       scope.is_active
-    elsif options[:active] == 'false'
+    when 'false'
       scope.is_not_active
     else
       scope

--- a/back/app/services/projects_filtering_service.rb
+++ b/back/app/services/projects_filtering_service.rb
@@ -20,8 +20,10 @@ class ProjectsFilteringService
   end
 
   add_filter('is_active') do |scope, options|
-    if options[:active].present?
+    if options[:active] == 'true'
       scope.is_active
+    elsif options[:active] == 'false'
+      scope.is_not_active
     else
       scope
     end

--- a/back/spec/acceptance/projects_spec.rb
+++ b/back/spec/acceptance/projects_spec.rb
@@ -554,9 +554,9 @@ resource 'Projects' do
 
   get 'web_api/v1/projects' do
     parameter :active,
-      '"true" = Select active (published continuous AND published timeline with active phase)'\
-      'or "false" = select inactive (archived AND published timeline with no active phase): ',
-      required: false
+              '"true" = Select active (published continuous AND published timeline with active phase)'\
+              'or "false" = select inactive (archived AND published timeline with no active phase): ',
+              required: false
 
     context 'when moderator', skip: !CitizenLab.ee? do
       before do
@@ -620,50 +620,48 @@ resource 'Projects' do
         expect(json_response[:data].size).to eq 0
       end
 
-      example "Get active projects" do
+      example 'Get active projects' do
         p1 = create(:project,
-          process_type: 'continuous',
-          admin_publication_attributes: { publication_status: 'published' })
+                    process_type: 'continuous',
+                    admin_publication_attributes: { publication_status: 'published' })
 
         p2 = create(:project_with_current_phase,
-          admin_publication_attributes: { publication_status: 'published' })
+                    admin_publication_attributes: { publication_status: 'published' })
 
         create(:project,
-          process_type: 'continuous',
-          admin_publication_attributes: { publication_status: 'archived' })
+               process_type: 'continuous',
+               admin_publication_attributes: { publication_status: 'archived' })
 
         create(:project_with_current_phase,
-          admin_publication_attributes: { publication_status: 'archived' })
+               admin_publication_attributes: { publication_status: 'archived' })
 
         create(:project_with_future_phases,
-          admin_publication_attributes: { publication_status: 'published' })
+               admin_publication_attributes: { publication_status: 'published' })
 
-        do_request active: "true"
-        json_response = json_parse(response_body)
+        do_request active: 'true'
         expect(response_data.size).to eq 2
         expect(response_ids).to eq [p2.id, p1.id]
       end
 
-      example "Get inactive projects" do
+      example 'Get inactive projects' do
         p1 = create(:project,
-          process_type: 'continuous',
-          admin_publication_attributes: { publication_status: 'archived' })
+                    process_type: 'continuous',
+                    admin_publication_attributes: { publication_status: 'archived' })
 
         p2 =  create(:project_with_current_phase,
-          admin_publication_attributes: { publication_status: 'archived' })
+                     admin_publication_attributes: { publication_status: 'archived' })
 
         p3 =  create(:project_with_future_phases,
-          admin_publication_attributes: { publication_status: 'published' })
+                     admin_publication_attributes: { publication_status: 'published' })
 
         create(:project,
-          process_type: 'continuous',
-          admin_publication_attributes: { publication_status: 'published' })
+               process_type: 'continuous',
+               admin_publication_attributes: { publication_status: 'published' })
 
         create(:project_with_current_phase,
-          admin_publication_attributes: { publication_status: 'published' })
+               admin_publication_attributes: { publication_status: 'published' })
 
-        do_request active: "false"
-        json_response = json_parse(response_body)
+        do_request active: 'false'
         expect(response_data.size).to eq 3
         expect(response_ids).to eq [p3.id, p2.id, p1.id]
       end


### PR DESCRIPTION
CLOSED WITHOUT MERGE: It seems that the FE uses a query such as `http://localhost:3000/web_api/v1/admin_publications?publication_statuses%5B%5D=published&publication_statuses%5B%5D=archived` to filter by 'active / inactive' on the homepage, and thus the filtering of projects developed in this PR is not needed.

## Checklist

- [ ] Added entry to changelog
  
Changelog NOT updated, as feature not fully implemented until FE work completed.

- [x] Tests
<details>
<summary>More info</summary>

### Unit tests

Did you add relevant unit tests?

### E2E tests

Sometimes it can be more efficient to update E2E tests after CI has run them. If you know which ones to update, go ahead! E2E template cl2-back:

```bash
docker compose run --rm web bin/rails cl2_back:create_tenant[localhost,e2etests_template]
```

</details>

- [x] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## Links

- [Jira ticket](https://citizenlab.atlassian.net/browse/CL2-6812)
- [Jira Epic](https://citizenlab.atlassian.net/browse/CL2-6805)

## What changes are in this PR?

CLOSED WITHOUT MERGE: It seems that the FE uses a query such as `http://localhost:3000/web_api/v1/admin_publications?publication_statuses%5B%5D=published&publication_statuses%5B%5D=archived` to filter by 'active / inactive' on the homepage, and thus the filtering of projects developed in this PR is not needed.

Add an `is_active` filter and `is_not_active` filters (ActiveRecord scopes) to the Projects index action, using an `active` parameter with a value of `'true'` or `'false'` respectively.

Example usages:
`http://localhost:3000/web_api/v1/projects?active=true`
`http://localhost:3000/web_api/v1/projects?active=false`

Note that if the parameter occurs more than once in the URL query params, only the last value will be used. For example, `.../projects?active=true&active=false` will return data related to inactive projects only.

## How urgent is a code review?

Within a day or two would allow FE dev(s) to move forward with the FE part of this feature.