### PR TITLE
CL2-6809 i1 Move project search to projects_filtering_service

### DIFF
--- a/back/app/controllers/web_api/v1/projects_controller.rb
+++ b/back/app/controllers/web_api/v1/projects_controller.rb
@@ -21,11 +21,8 @@ class WebApi::V1::ProjectsController < ::ApplicationController
                        .page(params.dig(:page, :number))
                        .per(params.dig(:page, :size))
 
-    if params[:search].present?
-      @projects = @projects.search_by_all(params[:search])
-    else 
-      @projects = @projects.ordered
-    end
+    @projects = @projects.ordered unless params[:search].present?
+
 
     LogActivityJob.perform_later(current_user, 'searched_pojects', current_user, Time.now.to_i, payload: {search_query: params[:search]}) if params[:search].present?
 

--- a/back/app/services/projects_filtering_service.rb
+++ b/back/app/services/projects_filtering_service.rb
@@ -14,6 +14,14 @@ class ProjectsFilteringService
     end
   end
 
+  add_filter("by_search") do |scope, options|
+    if (search = options[:search])
+      scope.search_by_all(search)
+    else
+      scope
+    end
+  end
+
   add_filter("filter_ids") do |scope, options|
     keep_ids = options[:filter_ids]
     keep_ids ? scope.where(id: keep_ids) : scope


### PR DESCRIPTION
## Checklist

- [ ] Added entry to changelog
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

- [ ] Tests
<details>
<summary>More info</summary>

### Unit tests

Did you add relevant unit tests?

### E2E tests

Sometimes it can be more efficient to update E2E tests after CI has run them. If you know which ones to update, go ahead! E2E template cl2-back:

```bash
docker compose run --rm web bin/rails cl2_back:create_tenant[localhost,e2etests_template]
```

</details>

- [x] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## Links

- [Jira ticket](https://citizenlab.atlassian.net/browse/CL2-6811)
- [Jira Epic](https://citizenlab.atlassian.net/browse/CL2-6805)

## What changes are in this PR?

This PR moves the search filter into the `projects_filtering_service` where it probably always should have been, building on the [recently merged PR](https://github.com/CitizenLabDotCo/citizenlab/pull/943/files) to add the search functionality.

This has the added benefit of enable filtering of projects referenced in the response to a query of `admin_publications` , such as 
```
http://localhost:3000/web_api/v1/admin_publications?search=search-term&publication_statuses%5B%5D=published&publication_statuses%5B%5D=archived&page%5Bnumber%5D=1&page%5Bsize%5D=1000&remove_not_allowed_parents=true&depth=0
```

The homepage FE uses such a request to begin building the data needed to populate the page with items. Unfortunately, this search functionality currently will not filter folders by their titles or descriptions (matching them agains the search term), and thus all (non-draft) folders will always be included in the data returned by such FE queries.

At the moment, I can't see how we could filter both folders and projects by a search term, since we don't seem to have a folders controller (nor `projects_folders_folders` to include such a filter pathway in). I imagine we would need to an `add_filter('filter_folders')` method to the `admin_publications_filtering_service`, but am currently unsure how to integrate such an approach.

## How urgent is a code review?

The sooner the better, as the FE work will soon need to make use of this functionality.
