### PR TITLE
CL2-6813 Events landing page: going offscreen on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+### Fixes
+
+- The event cards now rearrange themselves vertically on mobile / small screens. Before they were always arranged horizontally. This fixed the issue of them going off-screen when there is not enough screen space.
+
 ## 2021-10-25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-### Fixes
+### Fixed
 
 - The event cards now rearrange themselves vertically on mobile / small screens. Before they were always arranged horizontally. This fixed the issue of them going off-screen when there is not enough screen space.
 

--- a/front/app/modules/commercial/events_widget/citizen/index.tsx
+++ b/front/app/modules/commercial/events_widget/citizen/index.tsx
@@ -16,7 +16,7 @@ import { InjectedIntlProps } from 'react-intl';
 
 // styling
 import styled from 'styled-components';
-import { colors, fontSizes } from 'utils/styleUtils';
+import { colors, fontSizes, media } from 'utils/styleUtils';
 
 // other
 import { isNilOrError, isNil, isError } from 'utils/helperUtils';
@@ -47,6 +47,20 @@ const CardsContainer = styled.div`
   > :last-child {
     margin-right: 0px;
   }
+
+  ${media.smallerThanMaxTablet`
+    flex-direction: column;
+
+    > * {
+      margin: 19px 0px;
+    }
+    > :first-child {
+      margin-top: 0px;
+    }
+    > :last-child {
+      margin-bottom: 0px;
+    }
+  `}
 `;
 
 const StyledEventCard = styled(EventCard)`


### PR DESCRIPTION
## Checklist

- [x] Added entry to changelog
<details>
<summary>More info</summary>
The event cards now rearrange themselves vertically on mobile / small screens. Before they were always arranged horizontally. This fixed the issue of them going off-screen when there is not enough screen space.
</details>

- [x] Tests
<details>
<summary>More info</summary>

### Unit tests

NA

### E2E tests

NA

</details>

- [x] Prepared branch for code review
<details>
<summary>More info</summary>
</details>

## Links

- [Jira ticket](https://citizenlab.atlassian.net/jira/software/c/projects/CL2/boards/9?modal=detail&selectedIssue=CL2-6813)
- [Epic Deployment](https://6813.epic.citizenlab.co/en/)

## What changes are in this PR?

Some simple CSS changes in the `events_widget/citizen/index.tsx` component

## How urgent is a code review?

Before the end of the week would be fine
