### PR TITLE
IN-622 Log an activity when a view is created

### DIFF
--- a/back/engines/commercial/insights/app/services/insights/topic_import_service.rb
+++ b/back/engines/commercial/insights/app/services/insights/topic_import_service.rb
@@ -9,29 +9,30 @@ module Insights
     # @return [Array<String>] The ids of the created assignments
     def copy_assignments(view, current_user)
       locale = current_user.locale
-      topics(view).flat_map { |topic|
+      topics(view).flat_map do |topic|
         category = Category.new(name: category_name(topic, locale), view: view)
         if category.save
           ideas = IdeasFinder.find(
-            {project: view.scope, topics: [topic]},
+            { project: view.scope, topics: [topic] },
             current_user: current_user,
             paginate: false
           ).records
           assignment_service.add_assignments_batch(ideas, [category])
         end
-      }
+      end
     end
 
     private
+
     def assignment_service
       @assignment_service ||= Insights::CategoryAssignmentsService.new
     end
 
     def topics(view)
-      Topic.includes(:projects_topics).where(projects_topics: {project_id: view.scope.id})
+      Topic.includes(:projects_topics).where(projects_topics: { project_id: view.scope.id })
     end
 
-    def category_name topic, locale
+    def category_name(topic, locale)
       topic.title_multiloc[locale] || topic.title_multiloc.first
     end
   end

--- a/back/engines/commercial/insights/app/services/insights/views/create_service.rb
+++ b/back/engines/commercial/insights/app/services/insights/views/create_service.rb
@@ -3,6 +3,10 @@
 module Insights
   module Views
     class CreateService
+      include Pundit
+
+      attr_reader :current_user
+
       def initialize(current_user, params)
         @current_user = current_user
         @params = params.dup
@@ -10,7 +14,7 @@ module Insights
 
       def execute
         view = Insights::View.new(@params)
-        Pundit.policy!(@current_user, view).create?
+        authorize(view, :create?)
 
         view.save
         after_create(view)

--- a/back/engines/commercial/insights/app/services/insights/views/create_service.rb
+++ b/back/engines/commercial/insights/app/services/insights/views/create_service.rb
@@ -24,6 +24,7 @@ module Insights
         Insights::DetectCategoriesJob.perform_later(view) # [TODO] feature-flag to only detect for premium
         Insights::TopicImportService.new.copy_assignments(view, @current_user)
         Insights::ProcessedFlagsService.new.set_processed(view.scope.ideas, [view.id])
+        LogActivityJob.perform_later(view, 'created', @current_user, view.created_at.to_i)
       end
     end
   end

--- a/back/engines/commercial/insights/app/services/insights/views/create_service.rb
+++ b/back/engines/commercial/insights/app/services/insights/views/create_service.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Insights
+  module Views
+    class CreateService
+      def initialize(current_user, params)
+        @current_user = current_user
+        @params = params.dup
+      end
+
+      def execute
+        view = Insights::View.new(@params)
+        Pundit.policy!(@current_user, view).create?
+
+        view.save
+        after_create(view)
+        view
+      end
+
+      private
+
+      def after_create(view)
+        Insights::CreateTnaTasksJob.perform_later(view)
+        Insights::DetectCategoriesJob.perform_later(view) # [TODO] feature-flag to only detect for premium
+        Insights::TopicImportService.new.copy_assignments(view, @current_user)
+        Insights::ProcessedFlagsService.new.set_processed(view.scope.ideas, [view.id])
+      end
+    end
+  end
+end

--- a/back/engines/commercial/insights/app/services/insights/views/create_service.rb
+++ b/back/engines/commercial/insights/app/services/insights/views/create_service.rb
@@ -16,8 +16,7 @@ module Insights
         view = Insights::View.new(@params)
         authorize(view, :create?)
 
-        view.save
-        after_create(view)
+        after_create(view) if view.save
         view
       end
 

--- a/back/engines/commercial/insights/spec/services/insights/views/create_service_spec.rb
+++ b/back/engines/commercial/insights/spec/services/insights/views/create_service_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Insights::Views::CreateService do
 
   let(:params) { { scope_id: view_scope.id, name: view_name } }
   let(:view_name) { 'view-name' }
+
   let_it_be(:view_scope) { create(:project) }
   let_it_be(:current_user) { create(:admin) }
 
@@ -34,6 +35,16 @@ RSpec.describe Insights::Views::CreateService do
     it 'authorizes the current user' do
       service.execute
       expect(service.send(:pundit_policy_authorized?)).to eq(true)
+    end
+
+    context 'when the view is not valid' do
+      let(:view_name) { '' }
+
+      it 'does not raise an error' do
+        view = nil
+        expect { view = service.execute }.not_to raise_error
+        expect(view).not_to be_valid
+      end
     end
   end
 end

--- a/back/engines/commercial/insights/spec/services/insights/views/create_service_spec.rb
+++ b/back/engines/commercial/insights/spec/services/insights/views/create_service_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Insights::Views::CreateService do
   let_it_be(:current_user) { create(:admin) }
 
   describe '#execute' do
+    # rubocop:disable RSpec/MultipleExpectations
     it 'creates a new view' do
       view = nil
       expect { view = service.execute }.to change { Insights::View.count }.by(1)
@@ -18,7 +19,6 @@ RSpec.describe Insights::Views::CreateService do
       expect(view.scope).to eq(view_scope)
     end
 
-    # rubocop:disable RSpec/MultipleExpectations
     it 'enqueues a LogActivityJob job' do
       view = nil
       expect { view = service.execute }

--- a/back/engines/commercial/insights/spec/services/insights/views/create_service_spec.rb
+++ b/back/engines/commercial/insights/spec/services/insights/views/create_service_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Insights::Views::CreateService do
+  subject(:service) { described_class.new(current_user, params) }
+
+  let(:params) { { scope_id: view_scope.id, name: view_name } }
+  let(:view_name) { 'view-name' }
+  let_it_be(:view_scope) { create(:project) }
+  let_it_be(:current_user) { create(:admin) }
+
+  describe '#execute' do
+    it 'creates a new view' do
+      view = nil
+      expect { view = service.execute }.to change { Insights::View.count }.by(1)
+      expect(view.name).to eq(view_name)
+      expect(view.scope).to eq(view_scope)
+    end
+
+    # rubocop:disable RSpec/MultipleExpectations
+    it 'enqueues a LogActivityJob job' do
+      view = nil
+      expect { view = service.execute }
+        .to enqueue_job(LogActivityJob).with do |item, action, user, acted_at, _options|
+        expect(item).to eq(view)
+        expect(action).to eq('created')
+        expect(user).to eq(current_user)
+        expect(acted_at).to eq(view.created_at.to_i)
+      end
+    end
+    # rubocop:enable RSpec/MultipleExpectations
+
+    it 'authorizes the current user' do
+      service.execute
+      expect(service.send(:pundit_policy_authorized?)).to eq(true)
+    end
+  end
+end

--- a/back/engines/free/email_campaigns/spec/support/spec_helper.rb
+++ b/back/engines/free/email_campaigns/spec/support/spec_helper.rb
@@ -1,5 +1,5 @@
 RSpec.configure do |config|
-  config.before(:suite, type: :mailer) do
+  config.before(:suite) do
     I18n.load_path += Dir[Rails.root.join('engines/*/*/spec/fixtures/locales/mailers.*.yml')]
   end
 end


### PR DESCRIPTION
(IN-622)

This PR add an activity logging when a(n Insights) view is created. The view controller started to be a bit cluttered by too much logic so I moved everything to a new service: `Insights::Views::CreateService`. 

That's kind of an experiment bc today:
- we typically call a `SideFx***Service` directly from the controller
- the authorization is typically handled by the controller. 

In this case, both are performed directly by `Insights::Views::CreateService`. The annoying thing is that we cannot rely anymore on the `after_action` callback to check if a policy has been enforced.


