### PR TITLE
CL2-6833 i1 BE Get admin_publications publication_status counts

### DIFF
--- a/back/app/controllers/web_api/v1/admin_publications_controller.rb
+++ b/back/app/controllers/web_api/v1/admin_publications_controller.rb
@@ -33,14 +33,14 @@ class WebApi::V1::AdminPublicationsController < ::ApplicationController
     end
   end
 
-  # Developed for use by homepage to get status counts of top-level (not in folder) admin_publications,
+  # For use by homepage to get status counts of visible top-level (not in folder) admin_publications,
   # using: .../web_api/v1/admin_publications/status_counts?remove_not_allowed_parents=true&depth=0
   def status_counts
     publication_filterer = AdminPublicationsFilteringService.new
     publications = policy_scope(AdminPublication.includes(:parent))
     publications = publication_filterer.filter(publications, params)
 
-    # publication_status: :draft count should always be zero for non-admins, and thus will not be included in the response
+    # For non-admins: publication_status: :draft count should always be zero, and thus not included in response
     counts = publications.group(:publication_status).count
 
     authorize :admin_publication, :status_counts

--- a/back/app/controllers/web_api/v1/admin_publications_controller.rb
+++ b/back/app/controllers/web_api/v1/admin_publications_controller.rb
@@ -34,13 +34,13 @@ class WebApi::V1::AdminPublicationsController < ::ApplicationController
   end
 
   def status_counts
+    authorize :admin_publication, :status_counts
+    
     publication_filterer = AdminPublicationsFilteringService.new
     publications = policy_scope(AdminPublication.includes(:parent))
     publications = publication_filterer.filter(publications, params)
 
     counts = publications.group(:publication_status).count
-
-    authorize :admin_publication, :status_counts
 
     render json: { status_counts: counts }
   end

--- a/back/app/controllers/web_api/v1/admin_publications_controller.rb
+++ b/back/app/controllers/web_api/v1/admin_publications_controller.rb
@@ -33,14 +33,11 @@ class WebApi::V1::AdminPublicationsController < ::ApplicationController
     end
   end
 
-  # For use by homepage to get status counts of visible top-level (not in folder) admin_publications,
-  # using: .../web_api/v1/admin_publications/status_counts?remove_not_allowed_parents=true&depth=0
   def status_counts
     publication_filterer = AdminPublicationsFilteringService.new
     publications = policy_scope(AdminPublication.includes(:parent))
     publications = publication_filterer.filter(publications, params)
 
-    # For non-admins: publication_status: :draft count should always be zero, and thus not included in response
     counts = publications.group(:publication_status).count
 
     authorize :admin_publication, :status_counts

--- a/back/app/controllers/web_api/v1/admin_publications_controller.rb
+++ b/back/app/controllers/web_api/v1/admin_publications_controller.rb
@@ -33,6 +33,21 @@ class WebApi::V1::AdminPublicationsController < ::ApplicationController
     end
   end
 
+  # Developed for use by homepage to get status counts of top-level (not in folder) admin_publications,
+  # using: .../web_api/v1/admin_publications/status_counts?remove_not_allowed_parents=true&depth=0
+  def status_counts
+    publication_filterer = AdminPublicationsFilteringService.new
+    publications = policy_scope(AdminPublication.includes(:parent))
+    publications = publication_filterer.filter(publications, params)
+
+    # publication_status: :draft count should always be zero for non-admins, and thus will not be included in the response
+    counts = publications.group(:publication_status).count
+
+    authorize :admin_publication, :status_counts
+
+    render json: { status_counts: counts }
+  end
+
   def show
     render json: WebApi::V1::AdminPublicationSerializer.new(
       @publication,

--- a/back/app/policies/admin_publication_policy.rb
+++ b/back/app/policies/admin_publication_policy.rb
@@ -28,7 +28,7 @@ class AdminPublicationPolicy < ApplicationPolicy
   end
 
   def status_counts
-    user&.active?
+    active?
   end
 end
 

--- a/back/app/policies/admin_publication_policy.rb
+++ b/back/app/policies/admin_publication_policy.rb
@@ -26,6 +26,10 @@ class AdminPublicationPolicy < ApplicationPolicy
   def permitted_attributes_for_reorder
     [:ordering]
   end
+
+  def status_counts
+    user&.active?
+  end
 end
 
 AdminPublicationPolicy.prepend_if_ee('ProjectFolders::Patches::AdminPublicationPolicy')

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -139,8 +139,10 @@ Rails.application.routes.draw do
 
         get 'by_slug/:slug', on: :collection, to: 'projects#by_slug'
       end
+      
       resources :admin_publications, only: %i[index show] do
         patch 'reorder', on: :member
+        get 'status_counts', on: :collection
       end
 
       resources :notifications, only: %i[index show] do

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -165,21 +165,15 @@ resource "AdminPublication" do
     end
 
     get "web_api/v1/admin_publications/status_counts" do
-      parameter :depth, 'Filter by depth (AND)', required: false
-      parameter :remove_not_allowed_parents, 'Exclude children with parent', required: false
-
       example "Get publication_status counts for top-level admin publications when folders in use" do
+        do_request(depth: 0)
 
-        # @projects = ['published','published','draft','draft','published','archived','archived','published']
-        # 3 projects ('published','published','draft') are in a published folder
-        # 5 projects are not in a folder ('draft','published','archived','archived','published')
-        # Our top-level counts should, therefore, be published: 3, draft: 1, archived: 2
-
-        do_request(remove_not_allowed_parents: true, depth: 0)
+        expect(status).to eq 200
         json_response = json_parse(response_body)
-        puts json_response.inspect
-        # => {:status_counts=>{:archived=>2, :draft=>2, :published=>3}} ... which is WRONG! It should draft: 1, not 2, as one draft project is in a folder.
-        # the :remove_not_allowed_parents option appears to not be being used, although it is in the actual implementation
+
+        expect(json_response[:status_counts][:draft]).to eq 2
+        expect(json_response[:status_counts][:published]).to eq 3
+        expect(json_response[:status_counts][:archived]).to eq 2
       end
     end
   end

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -165,9 +165,6 @@ resource "AdminPublication" do
     end
 
     get "web_api/v1/admin_publications/status_counts" do
-      parameter :depth, 'Filter by depth (AND)', required: false
-      parameter :remove_not_allowed_parents, 'Exclude children with parent', required: false
-
       example "Get publication_status counts for top-level admin publications when folders in use" do
         do_request(depth: 0)
         expect(status).to eq 200
@@ -176,6 +173,7 @@ resource "AdminPublication" do
 
         expect(json_response[:status_counts][:draft]).to eq 2
         expect(json_response[:status_counts][:archived]).to eq 2
+        
         if CitizenLab.ee?
           expect(json_response[:status_counts][:published]).to eq 3
         else

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -31,10 +31,12 @@ resource "AdminPublication" do
       parameter :depth, 'Filter by depth (AND)', required: false
       parameter :topics, 'Filter by topics (AND)', required: false
       parameter :areas, 'Filter by areas (AND)', required: false
-      parameter :folder, "Filter by folder (project folder id)", required: false
       parameter :publication_statuses, "Return only publications with the specified publication statuses (i.e. given an array of publication statuses); always includes folders; returns all publications by default", required: false
       parameter :remove_childless_parents, 'Use the visibility rules of children on the parent and remove the empty ones', required: false
       parameter :remove_not_allowed_parents, 'Exclude children with parent', required: false
+      if CitizenLab.ee?
+        parameter :folder, "Filter by folder (project folder id)", required: false
+      end
 
       example_request "List all admin publications" do
         expect(status).to eq(200)
@@ -203,9 +205,11 @@ resource "AdminPublication" do
       end
       parameter :topics, 'Filter by topics (AND)', required: false
       parameter :areas, 'Filter by areas (AND)', required: false
-      parameter :folder, "Filter by folder (project folder id)", required: false
       parameter :publication_statuses, "Return only publications with the specified publication statuses (i.e. given an array of publication statuses); always includes folders; returns all publications by default", required: false
       parameter :filter_empty_folders, "Filter out folders with no visible children for the current user", required: false
+      if CitizenLab.ee?
+        parameter :folder, "Filter by folder (project folder id)", required: false
+      end
 
       if !CitizenLab.ee?
         example "Listed admin publications have correct visible children count", document: false do

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -165,15 +165,23 @@ resource "AdminPublication" do
     end
 
     get "web_api/v1/admin_publications/status_counts" do
+      parameter :depth, 'Filter by depth (AND)', required: false
+      parameter :remove_not_allowed_parents, 'Exclude children with parent', required: false
+
       example "Get publication_status counts for top-level admin publications when folders in use" do
         do_request(depth: 0)
-
         expect(status).to eq 200
+
         json_response = json_parse(response_body)
 
-        expect(json_response[:status_counts][:draft]).to eq 2
-        expect(json_response[:status_counts][:published]).to eq 3
         expect(json_response[:status_counts][:archived]).to eq 2
+        if CitizenLab.ee?
+          expect(json_response[:status_counts][:draft]).to eq 2
+          expect(json_response[:status_counts][:published]).to eq 3
+        else
+          expect(json_response[:status_counts][:draft]).to eq 1
+          expect(json_response[:status_counts][:published]).to eq 4
+        end
       end
     end
   end

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -174,12 +174,11 @@ resource "AdminPublication" do
 
         json_response = json_parse(response_body)
 
+        expect(json_response[:status_counts][:draft]).to eq 2
         expect(json_response[:status_counts][:archived]).to eq 2
         if CitizenLab.ee?
-          expect(json_response[:status_counts][:draft]).to eq 2
           expect(json_response[:status_counts][:published]).to eq 3
         else
-          expect(json_response[:status_counts][:draft]).to eq 1
           expect(json_response[:status_counts][:published]).to eq 4
         end
       end


### PR DESCRIPTION
## Checklist

- [ ] Added entry to changelog

NO CHANGELOG ENTRY - this PR does not fully implement any new feature.

- [x] Tests
<details>
<summary>More info</summary>

### Unit tests

Did you add relevant unit tests?

### E2E tests

Sometimes it can be more efficient to update E2E tests after CI has run them. If you know which ones to update, go ahead! E2E template cl2-back:

```bash
docker compose run --rm web bin/rails cl2_back:create_tenant[localhost,e2etests_template]
```

</details>

- [x] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## Links

- [Jira ticket](https://citizenlab.atlassian.net/browse/CL2-6833)
- [Jira Epic](https://citizenlab.atlassian.net/browse/CL2-6832)

## What changes are in this PR?

A new endpoint, `status_counts`, in `AdminPublicationsController`, for use by the Homepage to get the counts of visible top-level `admin_publications` (representing folders and projects) by their `publication_status`, as part of the [Homepage Filters Epic](https://citizenlab.atlassian.net/browse/CL2-6832).  
  
The counts will be displayed on the homepage and also used in FE logic to decide whether to show related tabs.
   
<details>
  <summary>Example requests & responses - Click to expand</summary>

With these projects and folders on a platform: 
<img width="375" alt="Screenshot 2021-10-28 at 15 30 40" src="https://user-images.githubusercontent.com/3944042/139277814-7c671ed2-0d73-4e95-a190-6830b37ca71c.png">
As Admin:
<img width="1378" alt="Screenshot 2021-10-28 at 15 29 36" src="https://user-images.githubusercontent.com/3944042/139457956-d7406f49-cf8c-4f38-8dc3-c89afff0b981.png">
As non-admin User:
<img width="1378" alt="Screenshot 2021-10-28 at 15 30 03" src="https://user-images.githubusercontent.com/3944042/139457985-306de829-d8e2-4787-921a-1135f38681a5.png">
</details>
  
Why a new endpoint (and not just derive the counts from the publications data returned to FE)?
- [Faster db query when only ask for counts]( https://stackoverflow.com/questions/15912749/is-count-faster-than-pulling-the-records-and-counting-in-code)
- Smaller response size (obviously)
- More flexible: Can be used in parallel with other requests, for example enabling counts to be displayed before all related publications data is received, processed and displayed by FE. Can be used standalone if any reason arises to only get counts without related publications data.

### Filtering Service Context
[Study of `AdminPublicationsFilteringService`](https://docs.google.com/presentation/d/1bp9_EpwnvacRLjioekIEFWgjDCXhjj9echmFN6bClzA/edit?usp=sharing) - in context of `index` action, but this new endpoint will also be used with this filtering service.

## How urgent is a code review?

Within a day or two, as FE will need this endpoint in Iteration 1 of this Epic.
