### PR TITLE
CL2-6840 Add Sentry message to create action in OmniauthCallbackController

### DIFF
--- a/back/app/controllers/omniauth_callback_controller.rb
+++ b/back/app/controllers/omniauth_callback_controller.rb
@@ -75,6 +75,7 @@ class OmniauthCallbackController < ApplicationController
         handle_verification(auth, @user) if verify
         redirect_to(add_uri_params(Frontend::UrlService.new.signup_success_url(locale: @user.locale), omniauth_params))
       rescue ActiveRecord::RecordInvalid => e
+        Sentry.capture_message("#{authver_method.class.name.demodulize} auth - ActiveRecord::RecordInvalid error: '#{e.message}' in create_def rescue block")
         Rails.logger.info "Social signup failed: #{e.message}"
         redirect_to(add_uri_params(Frontend::UrlService.new.signin_failure_url, omniauth_params))
       end


### PR DESCRIPTION
## Checklist

- [ ] Added entry to changelog
  
NO CHANGELOG ENTRY - this PR does not fully implement any new feature.

- [ ] Tests
  
NO TEST - please comment if you think test(s) are needed.

- [x] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## Links

- [Jira ticket](https://citizenlab.atlassian.net/browse/CL2-6840)


## What changes are in this PR?

Adds a Sentry comment event that records the `authver_method` class name (demodulized) and the `ActiveRecord` error when the `rescue` block in `create_def` in OmniauthcalbbackController` (new user flow) is hit.

<img width="1594" alt="Screenshot 2021-11-02 at 16 01 39" src="https://user-images.githubusercontent.com/3944042/139906660-607be842-f3f2-46af-9a19-cfc3708fc24a.png">

Interestingly, one of my FB accounts (a personal account that works fine with the FB Developer apps) hits this `rescue` block when used for SSO on our platforms, and debugging reveals a `nil` value for `email` in this `create` action, whilst returning correct values for first and last name - this would, indeed, cause an exception, as we expect an email value (model validation) when saving a User entry.

I now highly suspect that a number of FB accounts of our platform users fall into this category. Perhaps our implementation of FB auth is not correct enough to always get the email value from FB and/or sometimes the email is withheld for valid reasons (FB user wants email address kept private). In either case, this Sentry logging may well give us better insight into whether this is an issue that occurs on active platforms.

## How urgent is a code review?

By the end of the week - although this is a really simple one-liner, and the sooner this is released, the sooner we hopefully get some useful data on FB SSO failures ;)
