### PR TITLE
IN-632 Prevent Microsoft Form from auto-focusing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,18 @@
 
 ## Next
 
+### Fixed
+
+- Microsoft Form survey iframes no longer auto-focus on the form
+
 ## 2021-11-01
 
 ### Changed
 
 - The whole input card in Insight View screen is now clickable
-- Inputs list component in Insights View screen how shows active filters at all times
-- Insights Newtwork Visualisation changes:
-  - Reduced space between clusteres
+- Inputs list component in Insights View screen now shows active filters at all times
+- Insights Network Visualisation changes:
+  - Reduced space between clusters
   - Increased font size for keywords labels
   - It is now possible to de-select keywords by clicking on them twice
 

--- a/front/app/containers/ProjectsShowPage/shared/survey/MicrosoftFormsSurvey.tsx
+++ b/front/app/containers/ProjectsShowPage/shared/survey/MicrosoftFormsSurvey.tsx
@@ -1,13 +1,5 @@
-import React from 'react';
-import styled from 'styled-components';
-import { Box } from 'cl2-component-library';
-
-const StyledIframe = styled.iframe`
-  display: block;
-  height: 600px;
-  width: 100%;
-  border: 1px solid #ccc;
-`;
+import React, { useState } from 'react';
+import { Box, Spinner } from 'cl2-component-library';
 
 type Props = {
   microsoftFormsUrl: string;
@@ -15,9 +7,24 @@ type Props = {
 };
 
 const MicrosoftFormsSurvey = ({ microsoftFormsUrl, className }: Props) => {
+  const [loading, setLoading] = useState(true);
+
   return (
     <Box display="flex" justifyContent="center" className={className}>
-      <StyledIframe src={microsoftFormsUrl} />
+      <Box
+        as="iframe"
+        border="1px solid #ccc"
+        display={loading ? 'none' : 'block'}
+        h="600px"
+        w="100%"
+        src={microsoftFormsUrl}
+        onLoad={() => {
+          setTimeout(() => {
+            setLoading(false);
+          }, 3000);
+        }}
+      />
+      {loading && <Spinner />}
     </Box>
   );
 };


### PR DESCRIPTION
## Checklist

- [x] Added entry to changelog
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

- [ ] Tests
<details>
<summary>More info</summary>

### Unit tests

Did you add relevant unit tests?

### E2E tests

Sometimes it can be more efficient to update E2E tests after CI has run them. If you know which ones to update, go ahead! E2E template cl2-back:

```bash
docker compose run --rm web bin/rails cl2_back:create_tenant[localhost,e2etests_template]
```

</details>

- [x] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## Links

- [Jira ticket](https://citizenlab.atlassian.net/browse/IN-526)

## What changes are in this PR?

Microsoft Form Surveys are embedded in our platform with an iframe. The problem is that when the iframe loads, there is a bit of delay and then the focus directly goes into the first form field and the page is automatically scrolled down to the form. We want to prevent that since we want users to have time to read the project description before going to the form.

## How urgent is a code review?

Urgent! As soon as possible, please.