### PR TITLE
IN-635 Add missing filters to the input-count endpoint

### DIFF
--- a/back/engines/commercial/insights/app/controllers/insights/web_api/v1/stats_inputs_controller.rb
+++ b/back/engines/commercial/insights/app/controllers/insights/web_api/v1/stats_inputs_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Insights
   module WebApi::V1
     class StatsInputsController < ::ApplicationController
@@ -20,7 +22,9 @@ module Insights
         @counts_params ||= params.permit(
           :category,
           :search,
-          :processed
+          :processed,
+          categories: [],
+          keywords: []
         )
       end
     end

--- a/back/engines/commercial/insights/spec/acceptance/stats_inputs_spec.rb
+++ b/back/engines/commercial/insights/spec/acceptance/stats_inputs_spec.rb
@@ -6,7 +6,7 @@ resource "Stats - Inputs" do
 
   before { header 'Content-Type', 'application/json' }
 
-  let(:view) { create(:view) }
+  let_it_be(:view) { create(:view) }
   let(:view_id) { view.id }
   let(:assignment_service) { Insights::CategoryAssignmentsService.new }
 
@@ -34,8 +34,8 @@ resource "Stats - Inputs" do
     context 'when admin' do
       before { admin_header_token }
 
-      let!(:ideas) { create_list(:idea, 3, project: view.scope) }
-      let!(:other_ideas) { create_list(:idea, 2) }
+      let_it_be(:ideas) { create_list(:idea, 3, project: view.scope) }
+      let_it_be(:other_ideas) { create_list(:idea, 2) }
 
       example_request "Count all inputs" do
         expect(response_status).to eq 200
@@ -56,7 +56,9 @@ resource "Stats - Inputs" do
 
       example 'supports processed filter', document: false do
         create(:processed_flag, input: ideas.first, view: view)
+
         do_request(processed: true)
+
         expect(status).to eq(200)
         expect(json_response_body[:count]).to eq(1)
       end

--- a/back/engines/commercial/insights/spec/acceptance/stats_inputs_spec.rb
+++ b/back/engines/commercial/insights/spec/acceptance/stats_inputs_spec.rb
@@ -8,8 +8,6 @@ resource "Stats - Inputs" do
 
   let(:view) { create(:view) }
   let(:view_id) { view.id }
-
-  let(:json_response) { json_parse(response_body) }
   let(:assignment_service) { Insights::CategoryAssignmentsService.new }
 
   shared_examples 'unauthorized requests' do
@@ -25,47 +23,54 @@ resource "Stats - Inputs" do
   end
 
   get "web_api/v1/insights/views/:view_id/stats/inputs_count" do
-    parameter :category, 'Filter by category', required: false
-    parameter :processed, 'Filter by category', required: false
-    parameter :search, 'Filter by search', required: false
+    with_options required: false do
+      parameter :search, 'Filter by searching in title and body'
+      parameter :category, 'Filter by category'
+      parameter :categories, 'Filter inputs by categories (union)'
+      parameter :keywords, 'Filter by keywords (identifiers of keyword nodes)'
+      parameter :processed, 'Filter by processed status'
+    end
 
     context 'when admin' do
       before { admin_header_token }
+
       let!(:ideas) { create_list(:idea, 3, project: view.scope) }
       let!(:other_ideas) { create_list(:idea, 2) }
 
       example_request "Count all inputs" do
         expect(response_status).to eq 200
-        expect(json_response[:count]).to eq ideas.length
+        expect(json_response_body[:count]).to eq ideas.length
       end
+
 
       example 'supports processed filter', document: false do
         create(:processed_flag, input: ideas.first, view: view)
         do_request(processed: true)
         expect(status).to eq(200)
-        expect(json_response[:count]).to eq(1) # bc there are 3 inputs in total
+        expect(json_response_body[:count]).to eq(1) # bc there are 3 inputs in total
       end
 
       context 'with categories filter' do
         let(:category) { create(:category, view: view) }
+
         before { assignment_service.add_assignments_batch(ideas.take(2), [category]) }
 
         example 'Count for one category', document: false do
           do_request(category: category.id)
 
           expect(response_status).to eq 200
-          expect(json_response[:count]).to eq 2
+          expect(json_response_body[:count]).to eq 2
         end
 
         example 'Count uncategorized', document: false do
           do_request(category: '')
 
           expect(response_status).to eq 200
-          expect(json_response[:count]).to eq 1
+          expect(json_response_body[:count]).to eq 1
         end
       end
-
     end
+
     include_examples 'unauthorized requests'
   end
 end


### PR DESCRIPTION
(IN-635)

This PR adds two new query parameters (filters) to the `.../insights/views/:view_id/stats/inputs_count` endpoint:
- `keywords[]`
- `categories[]`

### TODO (post review)

- [ ] rubocop `stats_inputs_spec.rb`

