### PR TITLE
[No ticket] Fix admin digest mailer spec failing on CI

### DIFF
--- a/back/engines/free/email_campaigns/spec/mailers/admin_digest_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/admin_digest_mailer_spec.rb
@@ -72,9 +72,10 @@ RSpec.describe EmailCampaigns::AdminDigestMailer, type: :mailer do
       expect(mail_document.css('.idea').length).to eq 3
     end
 
-    it 'renders links to the idea URLs' do
+    it 'renders links to the top project ideas' do
+      ideas_urls = command.dig(:event_payload, :top_project_ideas).first[:top_ideas].pluck(:url)
       first_idea_link = mail_document.css('.idea a').first
-      expect(first_idea_link.attr('href')).to eq('http://example.org/ideas/plant-more-trees-1')
+      expect(first_idea_link.attr('href')).to eq(ideas_urls.first)
     end
 
     it 'shows all initiatives' do


### PR DESCRIPTION
The URL used to be hard-coded before this change. We now fetch the URL from the payload and not rely on the specific idea IDs to be present.

I introduced this myself in #1076.

## Checklist

- [x] Added entry to changelog
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

- [x] WCAG 2.1 AA proof
<details>
<summary>More info</summary>
For front-end devs only. Is your work conforming with the WCAG 2.1 AA rules? If you need more info, read the [a11y page](https://www.notion.so/citizenlab/a11y-7568f83d42ab4895ac133b89d358997b) on our Notion.
</details>

- [x] Tests
<details>
<summary>More info</summary>

### Unit tests

Did you add relevant unit tests?

### E2E tests

Sometimes it can be more efficient to update E2E tests after CI has run them. If you know which ones to update, go ahead! E2E template cl2-back:

```bash
docker compose run --rm web bin/rails cl2_back:create_tenant[localhost,e2etests_template]
```

</details>

- [x] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## Links

- [citizenlab-ee PR](**put URL here** or remove)
- [Specs](**put URL here** or remove)
- [Epic Deployment](**put URL here** or remove)

## How urgent is a code review?

Let the reviewer(s) know how urgent the code review is, so they can prioritize their work accordingly. Be specific (e.g. by Wednesday, end of the day/this week/... is better than 'urgent' or 'very urgent'). Optionally provide a word of explanation on your deadline.
