### PR TITLE
Signup flow last things

### DIFF
--- a/front/app/components/Mounter/index.tsx
+++ b/front/app/components/Mounter/index.tsx
@@ -8,7 +8,7 @@ export default ({ onMount }: Props) => {
   useEffect(() => {
     setTimeout(() => {
       onMount();
-    }, 200);
+    }, 1);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/front/app/components/SignUpIn/SignUp/index.tsx
+++ b/front/app/components/SignUpIn/SignUp/index.tsx
@@ -145,7 +145,7 @@ const SignUp: FC<Props & InjectedIntlProps> = memo(
     const confirmOutletsRendered = () => setOutletsRendered(true);
 
     const [activeStep, setActiveStep] = useState<TSignUpStep | null>(
-      'auth-providers'
+      metaData.isInvitation ? 'password-signup' : 'auth-providers'
     );
 
     const [enabledSteps, setEnabledSteps] = useState<TSignUpStep[]>(

--- a/front/app/components/SignUpIn/SignUp/index.tsx
+++ b/front/app/components/SignUpIn/SignUp/index.tsx
@@ -137,15 +137,16 @@ const SignUp: FC<Props & InjectedIntlProps> = memo(
     );
 
     const [outletsRendered, setOutletsRendered] = useState(false);
-    const [dataLoadedPerOutlet, setDataLoadedPerOutlet] = useState<
-      TDataLoadedPerOutlet
-    >({});
+    const [dataLoadedPerOutlet, setDataLoadedPerOutlet] =
+      useState<TDataLoadedPerOutlet>({});
     const [emailSignUpSelected, setEmailSignUpSelected] = useState(false);
     const [accountCreated, setAccountCreated] = useState(false);
 
     const confirmOutletsRendered = () => setOutletsRendered(true);
 
-    const [activeStep, setActiveStep] = useState<TSignUpStep | null>(null);
+    const [activeStep, setActiveStep] = useState<TSignUpStep | null>(
+      'auth-providers'
+    );
 
     const [enabledSteps, setEnabledSteps] = useState<TSignUpStep[]>(
       getEnabledSteps(configuration, authUser, metaData, {

--- a/front/app/components/SignUpIn/SignUpInModal.tsx
+++ b/front/app/components/SignUpIn/SignUpInModal.tsx
@@ -29,100 +29,107 @@ const Container = styled.div``;
 interface Props {
   className?: string;
   onMounted?: () => void;
+  onDeclineInvitation?: () => void;
 }
 
-const SignUpInModal = memo<Props>(({ className, onMounted }) => {
-  const isMounted = useIsMounted();
-  const [metaData, setMetaData] = useState<ISignUpInMetaData | undefined>(
-    undefined
-  );
-  const [signUpActiveStep, setSignUpActiveStep] = useState<
-    TSignUpStep | null | undefined
-  >(undefined);
+const SignUpInModal = memo<Props>(
+  ({ className, onMounted, onDeclineInvitation }) => {
+    const isMounted = useIsMounted();
+    const [metaData, setMetaData] = useState<ISignUpInMetaData | undefined>(
+      undefined
+    );
+    const [signUpActiveStep, setSignUpActiveStep] = useState<
+      TSignUpStep | null | undefined
+    >(undefined);
 
-  const authUser = useAuthUser();
-  const participationConditions = useParticipationConditions(
-    metaData?.verificationContext
-  );
+    const authUser = useAuthUser();
+    const participationConditions = useParticipationConditions(
+      metaData?.verificationContext
+    );
 
-  const opened = !!metaData?.inModal;
+    const opened = !!metaData?.inModal;
 
-  const hasParticipationConditions =
-    !isNilOrError(participationConditions) &&
-    participationConditions.length > 0;
+    const hasParticipationConditions =
+      !isNilOrError(participationConditions) &&
+      participationConditions.length > 0;
 
-  const modalWidth =
-    signUpActiveStep === 'verification' && hasParticipationConditions
-      ? 820
-      : 580;
+    const modalWidth =
+      signUpActiveStep === 'verification' && hasParticipationConditions
+        ? 820
+        : 580;
 
-  const verificationWithoutError =
-    signUpActiveStep === 'verification' && metaData?.error !== true;
+    const verificationWithoutError =
+      signUpActiveStep === 'verification' && metaData?.error !== true;
 
-  const registrationNotCompleted =
-    !isNilOrError(authUser) && !authUser.attributes.registration_completed_at;
+    const registrationNotCompleted =
+      !isNilOrError(authUser) && !authUser.attributes.registration_completed_at;
 
-  const modalCannotBeClosed =
-    verificationWithoutError || registrationNotCompleted;
+    const modalCannotBeClosed =
+      verificationWithoutError || registrationNotCompleted;
 
-  useEffect(() => {
-    if (isMounted()) {
-      onMounted?.();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [onMounted]);
+    useEffect(() => {
+      if (isMounted()) {
+        onMounted?.();
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [onMounted]);
 
-  useEffect(() => {
-    const subscriptions = [
-      openSignUpInModal$.subscribe(({ eventValue: newMetaData }) => {
-        setMetaData(newMetaData);
-      }),
-      signUpActiveStepChange$.subscribe(({ eventValue: activeStep }) => {
-        setSignUpActiveStep(activeStep);
-      }),
-    ];
+    useEffect(() => {
+      const subscriptions = [
+        openSignUpInModal$.subscribe(({ eventValue: newMetaData }) => {
+          setMetaData(newMetaData);
+        }),
+        signUpActiveStepChange$.subscribe(({ eventValue: activeStep }) => {
+          setSignUpActiveStep(activeStep);
+        }),
+      ];
 
-    return () =>
-      subscriptions.forEach((subscription) => subscription.unsubscribe());
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [authUser]);
+      return () =>
+        subscriptions.forEach((subscription) => subscription.unsubscribe());
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [authUser]);
 
-  const onClose = () => {
-    closeSignUpInModal();
-  };
+    const onClose = () => {
+      closeSignUpInModal();
 
-  const onSignUpInCompleted = useCallback(() => {
-    closeSignUpInModal();
-    const hasAction = isFunction(metaData?.action);
-    const requiresVerification = !!metaData?.verification;
+      if (onDeclineInvitation && metaData?.isInvitation) {
+        onDeclineInvitation();
+      }
+    };
 
-    const authUserIsVerified =
-      !isNilOrError(authUser) && authUser.attributes.verified;
+    const onSignUpInCompleted = useCallback(() => {
+      closeSignUpInModal();
+      const hasAction = isFunction(metaData?.action);
+      const requiresVerification = !!metaData?.verification;
 
-    if (hasAction && (!requiresVerification || authUserIsVerified)) {
-      metaData?.action?.();
-    }
-  }, [metaData, authUser]);
+      const authUserIsVerified =
+        !isNilOrError(authUser) && authUser.attributes.verified;
 
-  return (
-    <Modal
-      width={modalWidth}
-      padding="0px"
-      opened={opened}
-      close={onClose}
-      closeOnClickOutside={false}
-      noClose={modalCannotBeClosed}
-    >
-      <Container id="e2e-sign-up-in-modal" className={className}>
-        {opened && metaData && (
-          <SignUpIn
-            metaData={metaData}
-            onSignUpInCompleted={onSignUpInCompleted}
-          />
-        )}
-      </Container>
-    </Modal>
-  );
-});
+      if (hasAction && (!requiresVerification || authUserIsVerified)) {
+        metaData?.action?.();
+      }
+    }, [metaData, authUser]);
+
+    return (
+      <Modal
+        width={modalWidth}
+        padding="0px"
+        opened={opened}
+        close={onClose}
+        closeOnClickOutside={false}
+        noClose={modalCannotBeClosed}
+      >
+        <Container id="e2e-sign-up-in-modal" className={className}>
+          {opened && metaData && (
+            <SignUpIn
+              metaData={metaData}
+              onSignUpInCompleted={onSignUpInCompleted}
+            />
+          )}
+        </Container>
+      </Modal>
+    );
+  }
+);
 
 export default SignUpInModal;

--- a/front/app/containers/App/index.tsx
+++ b/front/app/containers/App/index.tsx
@@ -134,6 +134,7 @@ interface State {
   navbarRef: HTMLElement | null;
   mobileNavbarRef: HTMLElement | null;
   locale: Locale | null;
+  invitationDeclined: boolean;
 }
 
 class App extends PureComponent<Props, State> {
@@ -157,6 +158,7 @@ class App extends PureComponent<Props, State> {
       navbarRef: null,
       mobileNavbarRef: null,
       locale: null,
+      invitationDeclined: false,
     };
     this.subscriptions = [];
   }
@@ -297,9 +299,14 @@ class App extends PureComponent<Props, State> {
 
     const { pathname, search } = this.props.location;
 
+    const isAuthError = endsWith(pathname, 'authentication-error');
+    const isInvitation = endsWith(pathname, '/invite');
+    const { invitationDeclined } = this.state;
+
     openSignUpInModalIfNecessary(
-      pathname,
       authUser,
+      isAuthError,
+      isInvitation && !invitationDeclined,
       signUpInModalMounted,
       search
     );
@@ -385,6 +392,10 @@ class App extends PureComponent<Props, State> {
     this.setState({ signUpInModalMounted: true });
   };
 
+  handleDeclineInvitation = () => {
+    this.setState({ invitationDeclined: true });
+  };
+
   render() {
     const { location, children, windowSize } = this.props;
     const {
@@ -459,6 +470,7 @@ class App extends PureComponent<Props, State> {
                   <ErrorBoundary>
                     <SignUpInModal
                       onMounted={this.handleSignUpInModalMounted}
+                      onDeclineInvitation={this.handleDeclineInvitation}
                     />
                   </ErrorBoundary>
                   <Outlet

--- a/front/app/containers/App/index.tsx
+++ b/front/app/containers/App/index.tsx
@@ -444,7 +444,6 @@ class App extends PureComponent<Props, State> {
 
                 <Container>
                   <Meta />
-                  <Outlet id="app.containers.App.preload" />
                   <ErrorBoundary>
                     <Suspense fallback={null}>
                       <PostPageFullscreenModal

--- a/front/app/containers/App/index.tsx
+++ b/front/app/containers/App/index.tsx
@@ -433,6 +433,7 @@ class App extends PureComponent<Props, State> {
 
                 <Container>
                   <Meta />
+                  <Outlet id="app.containers.App.preload" />
                   <ErrorBoundary>
                     <Suspense fallback={null}>
                       <PostPageFullscreenModal

--- a/front/app/containers/App/index.tsx
+++ b/front/app/containers/App/index.tsx
@@ -276,18 +276,14 @@ class App extends PureComponent<Props, State> {
 
         setTimeout(() => {
           this.forceUpdate();
-        }, 100);
+        }, 1);
       }),
     ];
   }
 
   componentDidUpdate(prevProps: Props, prevState: State) {
-    const {
-      authUser,
-      tenant,
-      signUpInModalMounted,
-      verificationModalMounted,
-    } = this.state;
+    const { authUser, tenant, signUpInModalMounted, verificationModalMounted } =
+      this.state;
 
     const { redirectsEnabled } = this.props;
 

--- a/front/app/containers/App/openSignUpInModalIfNecessary.ts
+++ b/front/app/containers/App/openSignUpInModalIfNecessary.ts
@@ -5,14 +5,12 @@ import { SSOParams } from 'services/singleSignOn';
 import clHistory from 'utils/cl-router/history';
 
 export default function openSignUpInModalIfNecessary(
-  pathname,
   authUser,
+  isAuthError,
+  isInvitation,
   signUpInModalMounted,
   search
 ) {
-  const isAuthError = endsWith(pathname, 'authentication-error');
-  const isInvitation = endsWith(pathname, '/invite');
-
   // here we check all the possible conditions that could potentially trigger the sign-up and/or verification flow to appear
   if (
     // when the user is redirected to the '/authentication-error' url (e.g. when SSO fails)
@@ -22,17 +20,17 @@ export default function openSignUpInModalIfNecessary(
     // when -both- the signup modal component has mounted and the authUser stream has initiated
     (signUpInModalMounted && !isNilOrError(authUser))
   ) {
-    const urlSearchParams = (parse(search, {
+    const urlSearchParams = parse(search, {
       ignoreQueryPrefix: true,
-    }) as any) as SSOParams;
+    }) as any as SSOParams;
     // this constant represents the 'token' param that can optionally be included in the url
     // when a user gets sent to the platform through an invitation link (e.g. '/invite?token=123456)
     const token = urlSearchParams?.['token'] as string | undefined;
 
     // shouldCompleteRegistration is set to true when the authUser registration_completed_at attribute is not yet set.
     // when this attribute is undefined the sign-up process has not yet been completed and the user account is not yet valid!
-    const shouldCompleteRegistration = !authUser?.data?.attributes
-      ?.registration_completed_at;
+    const shouldCompleteRegistration =
+      !authUser?.data?.attributes?.registration_completed_at;
 
     // see services/singleSignOn.ts for the typed interface of all the sso related url params the url can potentially contain
     const {

--- a/front/app/containers/App/openSignUpInModalIfNecessary.ts
+++ b/front/app/containers/App/openSignUpInModalIfNecessary.ts
@@ -20,17 +20,17 @@ export default function openSignUpInModalIfNecessary(
     // when -both- the signup modal component has mounted and the authUser stream has initiated
     (signUpInModalMounted && !isNilOrError(authUser))
   ) {
-    const urlSearchParams = parse(search, {
+    const urlSearchParams = (parse(search, {
       ignoreQueryPrefix: true,
-    }) as any as SSOParams;
+    }) as any) as SSOParams;
     // this constant represents the 'token' param that can optionally be included in the url
     // when a user gets sent to the platform through an invitation link (e.g. '/invite?token=123456)
     const token = urlSearchParams?.['token'] as string | undefined;
 
     // shouldCompleteRegistration is set to true when the authUser registration_completed_at attribute is not yet set.
     // when this attribute is undefined the sign-up process has not yet been completed and the user account is not yet valid!
-    const shouldCompleteRegistration =
-      !authUser?.data?.attributes?.registration_completed_at;
+    const shouldCompleteRegistration = !authUser?.data.attributes
+      .registration_completed_at;
 
     // see services/singleSignOn.ts for the typed interface of all the sso related url params the url can potentially contain
     const {

--- a/front/app/modules/commercial/user_custom_fields/citizen/components/PreloadCustomFieldsSchema.tsx
+++ b/front/app/modules/commercial/user_custom_fields/citizen/components/PreloadCustomFieldsSchema.tsx
@@ -1,6 +1,0 @@
-import useUserCustomFieldsSchema from '../../hooks/useUserCustomFieldsSchema';
-
-export default () => {
-  useUserCustomFieldsSchema();
-  return null;
-};

--- a/front/app/modules/commercial/user_custom_fields/citizen/components/PreloadCustomFieldsSchema.tsx
+++ b/front/app/modules/commercial/user_custom_fields/citizen/components/PreloadCustomFieldsSchema.tsx
@@ -1,0 +1,6 @@
+import useUserCustomFieldsSchema from '../../hooks/useUserCustomFieldsSchema';
+
+export default () => {
+  useUserCustomFieldsSchema();
+  return null;
+};

--- a/front/app/modules/commercial/user_custom_fields/index.tsx
+++ b/front/app/modules/commercial/user_custom_fields/index.tsx
@@ -7,7 +7,6 @@ import AllCustomFields from './admin/components/CustomFields/All';
 
 import CustomFieldsStep from './citizen/components/CustomFieldsStep';
 import UserCustomFieldsForm from './citizen/components/UserCustomFieldsForm';
-import PreloadCustomFieldsSchema from './citizen/components/PreloadCustomFieldsSchema';
 import useUserCustomFieldsSchema from './hooks/useUserCustomFieldsSchema';
 import RegistrationQuestions from './admin/components/RegistrationQuestions';
 import {

--- a/front/app/modules/commercial/user_custom_fields/index.tsx
+++ b/front/app/modules/commercial/user_custom_fields/index.tsx
@@ -7,6 +7,7 @@ import AllCustomFields from './admin/components/CustomFields/All';
 
 import CustomFieldsStep from './citizen/components/CustomFieldsStep';
 import UserCustomFieldsForm from './citizen/components/UserCustomFieldsForm';
+import PreloadCustomFieldsSchema from './citizen/components/PreloadCustomFieldsSchema';
 import useUserCustomFieldsSchema from './hooks/useUserCustomFieldsSchema';
 import RegistrationQuestions from './admin/components/RegistrationQuestions';
 import {
@@ -117,14 +118,17 @@ const configuration: ModuleConfiguration = {
       metaData: _metaData,
       ...props
     }) => <CustomFieldsStep {...props} />,
-    'app.containers.Admin.dashboard.reports.ProjectReport.graphs': CustomFieldGraphs,
+    'app.containers.Admin.dashboard.reports.ProjectReport.graphs':
+      CustomFieldGraphs,
     'app.containers.UserEditPage.ProfileForm.forms': (props) => (
       <RenderOnCustomFields>
         <UserCustomFieldsForm {...props} />
       </RenderOnCustomFields>
     ),
     'app.containers.Admin.settings.registration': AllCustomFields,
-    'app.containers.Admin.settings.registrationHelperText': RegistrationQuestions,
+    'app.containers.Admin.settings.registrationHelperText':
+      RegistrationQuestions,
+    'app.containers.App.preload': PreloadCustomFieldsSchema,
   },
 };
 

--- a/front/app/modules/commercial/user_custom_fields/index.tsx
+++ b/front/app/modules/commercial/user_custom_fields/index.tsx
@@ -128,7 +128,6 @@ const configuration: ModuleConfiguration = {
     'app.containers.Admin.settings.registration': AllCustomFields,
     'app.containers.Admin.settings.registrationHelperText':
       RegistrationQuestions,
-    'app.containers.App.preload': PreloadCustomFieldsSchema,
   },
 };
 

--- a/front/app/utils/moduleUtils.ts
+++ b/front/app/utils/moduleUtils.ts
@@ -313,7 +313,6 @@ export type OutletsPropertyMap = {
   'app.containers.Navbar.UserMenu.UserNameContainer': {
     isVerified: boolean;
   };
-  'app.containers.App.preload': Record<string, any>;
   'app.containers.App.modals': { onMounted: (id: string) => void };
   'app.containers.LandingPage.onboardingCampaigns': {
     onboardingCampaigns: IOnboardingCampaigns;

--- a/front/app/utils/moduleUtils.ts
+++ b/front/app/utils/moduleUtils.ts
@@ -313,6 +313,7 @@ export type OutletsPropertyMap = {
   'app.containers.Navbar.UserMenu.UserNameContainer': {
     isVerified: boolean;
   };
+  'app.containers.App.preload': Record<string, any>;
   'app.containers.App.modals': { onMounted: (id: string) => void };
   'app.containers.LandingPage.onboardingCampaigns': {
     onboardingCampaigns: IOnboardingCampaigns;
@@ -412,16 +413,15 @@ export interface ParsedModuleConfiguration {
   streamsToReset: string[];
 }
 
-export type ModuleConfiguration = RecursivePartial<
-  ParsedModuleConfiguration
-> & {
-  /** this function triggers before the Root component is mounted */
-  beforeMountApplication?: () => void;
-  /** this function triggers after the Root component mounted */
-  afterMountApplication?: () => void;
-  /** used to reset streams created in a module */
-  streamsToReset?: string[];
-};
+export type ModuleConfiguration =
+  RecursivePartial<ParsedModuleConfiguration> & {
+    /** this function triggers before the Root component is mounted */
+    beforeMountApplication?: () => void;
+    /** this function triggers after the Root component mounted */
+    afterMountApplication?: () => void;
+    /** used to reset streams created in a module */
+    streamsToReset?: string[];
+  };
 
 type Modules = {
   configuration: ModuleConfiguration;
@@ -532,34 +532,36 @@ export const loadModules = (modules: Modules): ParsedModuleConfiguration => {
   };
 };
 
-export const insertConfiguration = <T extends { name: string }>({
-  configuration,
-  insertAfterName,
-  insertBeforeName,
-}: InsertConfigurationOptions<T>) => (items: T[]): T[] => {
-  const itemAlreadyInserted = items.some(
-    (item) => item.name === configuration.name
-  );
-  // index of item where we need to insert before/after
-  const referenceIndex = items.findIndex(
-    (item) => item.name === (insertAfterName || insertBeforeName)
-  );
-  const insertIndex = clamp(
-    // if number is outside of lower and upper, it picks
-    // the closes value. If it's inside the ranges, the
-    // number is kept
-    insertAfterName ? referenceIndex + 1 : referenceIndex - 1,
-    0,
-    items.length
-  );
-
-  if (itemAlreadyInserted) {
-    items.splice(insertIndex, 1);
-  }
-
-  return [
-    ...items.slice(0, insertIndex),
+export const insertConfiguration =
+  <T extends { name: string }>({
     configuration,
-    ...items.slice(insertIndex),
-  ];
-};
+    insertAfterName,
+    insertBeforeName,
+  }: InsertConfigurationOptions<T>) =>
+  (items: T[]): T[] => {
+    const itemAlreadyInserted = items.some(
+      (item) => item.name === configuration.name
+    );
+    // index of item where we need to insert before/after
+    const referenceIndex = items.findIndex(
+      (item) => item.name === (insertAfterName || insertBeforeName)
+    );
+    const insertIndex = clamp(
+      // if number is outside of lower and upper, it picks
+      // the closes value. If it's inside the ranges, the
+      // number is kept
+      insertAfterName ? referenceIndex + 1 : referenceIndex - 1,
+      0,
+      items.length
+    );
+
+    if (itemAlreadyInserted) {
+      items.splice(insertIndex, 1);
+    }
+
+    return [
+      ...items.slice(0, insertIndex),
+      configuration,
+      ...items.slice(insertIndex),
+    ];
+  };


### PR DESCRIPTION
- Fixed issue where sign up modal took some time to load by reducing timeouts and settings `'auth-providers'` as first step by default. Also setting `'password-signup'` as first step by default if user comes from `/invite`. Only downside of this is that if the user refreshes the page mid signup flow, the `'auth-providers'` step will flash for a second before going to the correct step. But since this will be much less common, I think this is a good solution.
- Fixed the unclosable modal when using `/invitation`

By the way, my `prettier` has been going crazy lately, making a lot of code formatting changes without me even knowing it. This is making it look like the PR has a lot of changes, even though in this case it's only a few lines. Kind of annoying, not sure what changed. The only real changes in this one are in:

- Mounter/index.tsx
- SignUp/index.tsx
- SignUpInModal, only lines 32 and 95-97
- App/index.tsx
- openSignUpInModalIfNecessary.ts