### PR TITLE
CL2-6872 Use correct IP with Rack::Attack

### DIFF
--- a/back/config/initializers/rack_attack.rb
+++ b/back/config/initializers/rack_attack.rb
@@ -1,5 +1,19 @@
 Rack::Attack.enabled = ENV.fetch('RACK_ATTACK_DISABLED', false) != 'true'
 
+# Rack::Attack uses rack's request object by default. This doesn't have a
+# properly built-in mechanism to detect the users real IP, in case the
+# application is behind a reverse proxy (cdn, load balancer, ...).
+# ActionDispatch `remote_ip` method supports it, if it has the IPs of those
+# proxies configured in `config.action_dispatch.trusted_proxies`
+# from https://github.com/rack/rack-attack/issues/145
+class Rack::Attack
+  class Request < ::Rack::Request
+    def remote_ip
+      @remote_ip ||= ActionDispatch::Request.new(env).remote_ip
+    end
+  end
+end
+
 class Rack::Attack
   # After https://github.com/rack/rack-attack/blob/master/docs/example_configuration.md
 
@@ -7,13 +21,13 @@ class Rack::Attack
 
   # For all requests.
   throttle('req/ip', limit: 1000, period: 3.minutes) do |req|
-    req.ip
+    req.remote_ip
   end
 
   # Signing in by IP.
   throttle('logins/ip', limit: 10, period: 20.seconds) do |req|
     if req.path == '/web_api/v1/user_token' && req.post?
-      req.ip
+      req.remote_ip
     end
   end
 
@@ -27,21 +41,21 @@ class Rack::Attack
   # Account creation by IP.
   throttle('signup/ip', limit: 10, period: 20.seconds) do |req|
     if req.path == '/web_api/v1/users' && req.post?
-      req.ip
+      req.remote_ip
     end
   end
 
   # Password reset by IP.
   throttle('password_reset/ip', limit: 10, period: 20.seconds) do |req|
     if req.path == '/web_api/v1/users/reset_password' && req.post?
-      req.ip
+      req.remote_ip
     end
   end
 
   # Password reset email by IP.
   throttle('password_reset_email/ip', limit: 10, period: 20.seconds) do |req|
     if req.path == '/web_api/v1/users/reset_password_email' && req.post?
-      req.ip
+      req.remote_ip
     end
   end
 
@@ -55,7 +69,7 @@ class Rack::Attack
   # Accept invite by IP.
   throttle('accept_invite/ip', limit: 10, period: 20.seconds) do |req|
     if req.path.starts_with?('/web_api/v1/invites/by_token') &&  req.path.ends_with?('accept') && req.post?
-      req.ip
+      req.remote_ip
     end
   end
 
@@ -63,7 +77,7 @@ class Rack::Attack
   # Search parameters are used for ideas, initiatives, users, invites, moderation and tags.
   throttle('search/ip', limit: 15, period: 20.seconds) do |req|
     if req.params['search'].present?
-      req.ip
+      req.remote_ip
     end
   end
 end


### PR DESCRIPTION
Rack::Attack doesn't use the right IP, for our AWS setup it's using the IP of the CDN instead of the user's IP. This probably fixes it. Testing it will need to happen on staging.

## Links
[citizenlab-ee PR](https://github.com/CitizenLabDotCo/citizenlab-ee/pull/113)
