### PR TITLE
[No ticket] Upgrade to Webmock 3.14

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -72,7 +72,7 @@ end
 group :test do
   gem 'rubyXL'
   gem 'shoulda-matchers', '~> 3.1'
-  gem 'webmock', '~> 3.12'
+  gem 'webmock', '~> 3.14'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -909,7 +909,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     retriable (3.1.2)
-    rexml (3.2.4)
+    rexml (3.2.5)
     rgeo (2.3.0)
     rgeo-activerecord (7.0.1)
       activerecord (>= 5.0)
@@ -1091,8 +1091,8 @@ GEM
     webfinger (1.1.0)
       activesupport
       httpclient (>= 2.4)
-    webmock (3.12.1)
-      addressable (>= 2.3.6)
+    webmock (3.14.0)
+      addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
@@ -1241,7 +1241,7 @@ DEPENDENCIES
   user_custom_fields!
   verification!
   volunteering!
-  webmock (~> 3.12)
+  webmock (~> 3.14)
 
 BUNDLED WITH
    1.17.3


### PR DESCRIPTION

Changelog

```

  * fixed async-http adapter on Windows

  * Bump Addressable from 2.3.6 to 2.8.0

    Thanks to [Eduardo Hernandez](https://github.com/EduardoGHdez)

  * Support http.rb 5.x

    Thanks to [Will Storey](https://github.com/horgh)

  * Fixed em-http-request adapter to avoid calling middleware twice.

    Thanks to [Alex Vondrak](https://github.com/ajvondrak)

  * Fixed handling of URIs with IPv6 addresses with square brackets when in Net::HTTP adapter.

    Thanks to [Johanna Hartmann](https://github.com/JohannaHartmann)

```





## How urgent is a code review?

Not super important
