### PR TITLE
[No ticket] Upgrade to database_cleaner 2.0

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -33,7 +33,7 @@ group :development, :test do
   gem 'pry-byebug'
   gem 'pry-rails'
   gem 'pry-stack_explorer'
-  gem 'database_cleaner'
+  gem 'database_cleaner-active_record'
   gem 'factory_bot_rails'
   gem 'license_finder'
   # Use module prepend to patch NET::HTTP to avoid stack level too deep errors.

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -571,7 +571,10 @@ GEM
     css_parser (1.7.0)
       addressable
     dalli (2.7.9)
-    database_cleaner (1.7.0)
+    database_cleaner-active_record (2.0.1)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0.0)
+    database_cleaner-core (2.0.1)
     debug_inspector (1.0.0)
     declarative (0.0.20)
     diff-lcs (1.4.4)
@@ -1132,7 +1135,7 @@ DEPENDENCIES
   custom_style!
   custom_topics!
   dalli
-  database_cleaner
+  database_cleaner-active_record
   email_campaigns!
   factory_bot_rails
   faker


### PR DESCRIPTION
The library is now splitted into multiple gems, depending on the ORM / database you use.

Changes since 1.7.0:

```
== 2.0.1 2021-02-04

== Bugfixes
  * Regression: allow_remote_database_url and url_allowlist not working anymore: https://github.com/DatabaseCleaner/database_cleaner/pull/671

== 2.0.0 2021-01-31

=== Changes
  * Rename `url_whitelist` to `url_allowlist`
  * Allowlist now supports regular expressions
  * Fixed Ruby 2.7 deprecation warnings

=== Breaking changes
  * Failed checks against the allowlist now raise `UrlNotAllowed` rather than `NotWhitelistedUrl`

== 2.0.0.beta2 2020-05-30

=== Features
  * New API for ORM Adapter gems: https://github.com/DatabaseCleaner/database_cleaner/pull/644

=== Breaking changes
  * Rename :connection configuration option to :db for consistency: https://github.com/DatabaseCleaner/database_cleaner/pull/650
  * Remove all #orm= setter methods: https://github.com/DatabaseCleaner/database_cleaner/pull/643/files
  * drop support for Ruby 2.4 which is EOL as of 2020-03-31: https://github.com/DatabaseCleaner/database_cleaner/pull/635

== 2.0.0.beta 2020-04-05

=== Breaking changes
  * Replace old shared RSpec examples with new "database_cleaner adapter" example: https://github.com/DatabaseCleaner/database_cleaner/pull/629
  * split gem into database_cleaner-core and database_cleaner metagem.
  * Support Ruby versions 2.4, 2.5, 2.6, and 2.7, and drop support for older Rubies.
  * remove all deprecated code and get the specs passing again.
  * Split off all adapter gems into their own repos: https://github.com/DatabaseCleaner/database_cleaner/pull/620

== 1.99.0 2021-01-31

== Changes
  * Remove unnecessary dependency on database_cleaner-mongo from database_cleaner-mongoid: @botandrose
  * Enable the :cache_tables option for the mongo truncation strategy, and default to true: https://github.com/DatabaseCleaner/database_cleaner/pull/646"
  * Introduce deletion aliases for truncation strategies for mongo, mongoid, and redis adapters. https://github.com/DatabaseCleaner/database_cleaner/pull/654
  * Add new :db orm configuration key, for consistency with #db and #db=. https://github.com/DatabaseCleaner/database_cleaner/pull/649

== Deprecations
  * Deprecate all #orm= setter methods: https://github.com/DatabaseCleaner/database_cleaner/pull/643
  * Deprecate non-functional :reset_ids option in ActiveRecord truncation strategy: https://github.com/DatabaseCleaner/database_cleaner/issues/559
  * Deprecate mongo truncation's `:cache_tables => true` option in favor of `false`, to prep for caching removal in v2.0: https://github.com/DatabaseCleaner/database_cleaner/pull/646"
  * Deprecate redis truncation's #url method in favor of #db: @botandrose
  * Deprecate mongo, mongoid, and redis truncation strategies in favor of deletion. https://github.com/DatabaseCleaner/database_cleaner/pull/654
  * Deprecate :connection and :model configuration options in favor of :db for consistency: https://github.com/DatabaseCleaner/database_cleaner/pull/650

== Bugfixes
  * Fix deprecation warning about `DatabaseCleaner.connections` to recommend a better alternative: https://github.com/DatabaseCleaner/database_cleaner/pull/656

== 1.8.5 2020-05-04

=== Bug Fixes
  * Fix :mongo strategy: https://github.com/DatabaseCleaner/database_cleaner/pull/645

== 1.8.4 2020-04-02

=== Bug Fixes
  * Fix false positive deprecation warnings on Windows: https://github.com/DatabaseCleaner/database_cleaner/pull/633

== 1.8.3 2020-02-18

=== Bug Fixes
  * Fix performance issue of DatabaseCleaner::Base#orm_module: https://github.com/DatabaseCleaner/database_cleaner/pull/625

== 1.8.2 2020-02-01

=== Bug Fixes
  * Fix database_cleaner-ohm autodetected adapter loading: https://github.com/DatabaseCleaner/database_cleaner/pull/619
  * Fix database_cleaner-mongo_mapper autodetected adapter loading: @botandrose
  * Fix database_cleaner-mongoid autodetected adapter loading: https://github.com/DatabaseCleaner/database_cleaner/pull/617
  * Exclude ar_internal_metadata from truncation on Rails 5: https://github.com/DatabaseCleaner/database_cleaner/pull/588

=== Changes
  * Deprecate ohm adapter: https://github.com/DatabaseCleaner/database_cleaner/pull/619

== 1.8.1 2020-01-30

=== Bug Fixes
  * Remove undeclared active_support dependency: https://github.com/DatabaseCleaner/database_cleaner/pull/612

== 1.8.0 2020-01-29

=== Bug Fixes
  * Fix MySQL deprecation warnings with Rails 5: https://github.com/DatabaseCleaner/database_cleaner/pull/574
  * Fix MySQL truncation with `pre_count: true`: https://github.com/DatabaseCleaner/database_cleaner/pull/498
  * Fix primary key sequence resetting in Sequel with Postgres and SQLite: https://github.com/DatabaseCleaner/database_cleaner/pull/538/files
  * ActiveRecord truncation adapter doesn't work with Oracle: https://github.com/DatabaseCleaner/database_cleaner/pull/542

=== Changes
  * Extract ORM adapters into gems: https://github.com/DatabaseCleaner/database_cleaner/pull/560
  * Allow postgres:///dbname as a local url: https://github.com/DatabaseCleaner/database_cleaner/pull/569
  * Add an optional URL whitelist safeguard: https://github.com/DatabaseCleaner/database_cleaner/pull/526
  * Add `local` tld to safeguard check: https://github.com/DatabaseCleaner/database_cleaner/pull/547
  * Speed up ActiveRecord deletion strategy: https://github.com/DatabaseCleaner/database_cleaner/pull/534
  * Consider `sqlite:` database urls to be local: https://github.com/DatabaseCleaner/database_cleaner/pull/529
```

## Checklist

- [x] Added entry to changelog
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

- [x] WCAG 2.1 AA proof
<details>
<summary>More info</summary>
For front-end devs only. Is your work conforming with the WCAG 2.1 AA rules? If you need more info, read the [a11y page](https://www.notion.so/citizenlab/a11y-7568f83d42ab4895ac133b89d358997b) on our Notion.
</details>

- [x] Tests
<details>
<summary>More info</summary>

### Unit tests

Did you add relevant unit tests?

### E2E tests

Sometimes it can be more efficient to update E2E tests after CI has run them. If you know which ones to update, go ahead! E2E template cl2-back:

```bash
docker compose run --rm web bin/rails cl2_back:create_tenant[localhost,e2etests_template]
```

</details>

- [x] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## How urgent is a code review?

Not urgent. :)
