### PR TITLE
[No ticket] Update rinku to 2.0.6

### DIFF
--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -916,7 +916,7 @@ GEM
       rgeo (>= 1.0.0)
     rgeo-geojson (2.1.1)
       rgeo (>= 1.0.0)
-    rinku (2.0.5)
+    rinku (2.0.6)
     ros-apartment (2.10.0)
       activerecord (>= 5.0.0, < 6.2)
       parallel (< 2.0)


### PR DESCRIPTION
Rinku is used for auto-linking in our project. The gem does not feature a changelog, but according to git history at https://github.com/vmg/rinku/commits/master this version fixes a potential infinite loop when parsing characters.

## How urgent is a code review?

not urgent
