### PR TITLE
CL2-6873 Fix Rack::Attack IP detection (attempt 2)

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -169,6 +169,11 @@ if File.exists?('../citizenlab.config.ee.json')
   # This branch must be used because the latest version (2.1.1)
   # requires activerecord < 6.0.
   gem 'ros-apartment', require: 'apartment'
+
+  # Upstream actionpack-cloudfront depends on ActionController::Helpers, which
+  # is not enabled for a rails api project, so we run on a fork.
+  # PR to merge to upstream: https://github.com/customink/actionpack-cloudfront/pull/18
+  gem 'actionpack-cloudfront', github: 'CitizenLabDotCo/actionpack-cloudfront'
 end
 
 require './lib/citizen_lab.rb'

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/CitizenLabDotCo/actionpack-cloudfront.git
+  revision: 210a03d2e6bee69a2bc922bf367453fd5b17fb0d
+  specs:
+    actionpack-cloudfront (1.2.0)
+      actionpack (>= 4.2)
+      railties (>= 4.2)
+
+GIT
   remote: https://github.com/CitizenLabDotCo/ice_cube.git
   revision: 4671442d581d185a40933fa06a9c773f22f6070f
   specs:
@@ -330,7 +338,7 @@ PATH
   remote: engines/ee/multi_tenancy
   specs:
     multi_tenancy (0.1.0)
-      actionpack-cloudfront (~> 1.0.2)
+      actionpack-cloudfront (~> 1.2.0)
       rails (~> 6.1)
       ros-apartment (>= 2.9.0)
 
@@ -441,8 +449,6 @@ GEM
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actionpack-cloudfront (1.0.8)
-      rails (>= 4.2)
     actiontext (6.1.4.1)
       actionpack (= 6.1.4.1)
       activerecord (= 6.1.4.1)
@@ -1107,6 +1113,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  actionpack-cloudfront!
   active_model_serializers (~> 0.10.12)
   activerecord-import (~> 1.0)
   activerecord-postgis-adapter (~> 7.0.0)


### PR DESCRIPTION
Update in line with the [EE branch](https://github.com/CitizenLabDotCo/citizenlab-ee/pull/120).

We need to use the fork in order to avoid adding ActionController::Helpers to our rails API project, still hope we can get this fixed in upstream. More explanation in the PR o upstream, link found in the comments.