### PR TITLE
Remove unused props TabbedResource

### DIFF
--- a/front/app/components/admin/TabbedResource/index.tsx
+++ b/front/app/components/admin/TabbedResource/index.tsx
@@ -8,7 +8,7 @@ import styled from 'styled-components';
 import { colors, fontSizes } from 'utils/styleUtils';
 
 // typings
-import { Message, ITab } from 'typings';
+import { ITab } from 'typings';
 
 // components
 import FeatureFlag from 'components/FeatureFlag';
@@ -99,9 +99,6 @@ type Props = {
   resource: {
     title: string;
     subtitle?: string;
-  };
-  messages?: {
-    viewPublicResource: Message;
   };
   tabs?: ITab[];
 };

--- a/front/app/components/admin/TabbedResource/index.tsx
+++ b/front/app/components/admin/TabbedResource/index.tsx
@@ -7,15 +7,11 @@ import Link from 'utils/cl-router/Link';
 import styled from 'styled-components';
 import { colors, fontSizes } from 'utils/styleUtils';
 
-// localisation
-import { FormattedMessage } from 'utils/cl-intl';
-
 // typings
 import { Message, ITab } from 'typings';
 
 // components
 import FeatureFlag from 'components/FeatureFlag';
-import Button from 'components/UI/Button';
 import { SectionDescription } from 'components/admin/Section';
 import Title from 'components/admin/PageTitle';
 
@@ -102,7 +98,6 @@ const ChildWrapper = styled.div`
 type Props = {
   resource: {
     title: string;
-    publicLink?: string;
     subtitle?: string;
   };
   messages?: {
@@ -139,8 +134,7 @@ class TabbedResource extends React.PureComponent<
   render() {
     const {
       children,
-      resource: { title, subtitle, publicLink },
-      messages,
+      resource: { title, subtitle },
       tabs,
     } = this.props;
 
@@ -151,12 +145,6 @@ class TabbedResource extends React.PureComponent<
             <Title>{title}</Title>
             {subtitle && <SectionDescription>{subtitle}</SectionDescription>}
           </div>
-
-          {publicLink && messages && (
-            <Button buttonStyle="cl-blue" icon="eye" linkTo={publicLink}>
-              <FormattedMessage {...messages.viewPublicResource} />
-            </Button>
-          )}
         </ResourceHeader>
 
         {tabs && tabs.length > 0 && (

--- a/front/app/containers/Admin/dashboard/components/DashboardTabs.tsx
+++ b/front/app/containers/Admin/dashboard/components/DashboardTabs.tsx
@@ -4,7 +4,7 @@ import { withRouter, WithRouterProps } from 'react-router';
 import Link from 'utils/cl-router/Link';
 
 // typings
-import { Message, ITab } from 'typings';
+import { ITab } from 'typings';
 
 // components
 import FeatureFlag from 'components/FeatureFlag';
@@ -19,11 +19,7 @@ import { matchPathToUrl } from 'utils/helperUtils';
 interface Props {
   resource: {
     title: string;
-    publicLink?: string;
     subtitle?: string;
-  };
-  messages?: {
-    viewPublicResource: Message;
   };
   tabs?: ITab[];
 }

--- a/front/app/modules/commercial/user_custom_fields/admin/containers/CustomFields/RegistrationCustomFieldEdit/index.tsx
+++ b/front/app/modules/commercial/user_custom_fields/admin/containers/CustomFields/RegistrationCustomFieldEdit/index.tsx
@@ -89,7 +89,6 @@ const RegistrationCustomFieldEdit = memo(
             tabs={getTabs(userCustomField)}
             resource={{
               title: localize(userCustomField.attributes.title_multiloc),
-              publicLink: '',
             }}
           >
             {childrenWithExtraProps}


### PR DESCRIPTION
For a different ticket I was solving why the link didn't work, checked other linkTo props for under-the-radar bugs and figured out some props weren't used along the way.