### PR TITLE
IN-673 Stats endpoint for classification tasks

### DIFF
--- a/back/engines/commercial/insights/app/controllers/insights/web_api/v1/classification_tasks_controller.rb
+++ b/back/engines/commercial/insights/app/controllers/insights/web_api/v1/classification_tasks_controller.rb
@@ -16,6 +16,15 @@ module Insights
           render json: ZeroshotClassificationTaskSerializer.new(tasks, params: fastjson_params), status: :ok
         end
 
+        def count
+          count = ZeroshotClassificationTasksFinder.new(
+            categories || view.categories, # use all the categories if the query parameter is not provided
+            inputs: inputs
+          ).execute.count
+
+          render json: { count: count }, status: :ok
+        end
+
         def create
           Insights::CreateClassificationTasksJob.perform_now(
             view,

--- a/back/engines/commercial/insights/app/finders/insights/zeroshot_classification_tasks_finder.rb
+++ b/back/engines/commercial/insights/app/finders/insights/zeroshot_classification_tasks_finder.rb
@@ -15,6 +15,7 @@ module Insights
 
     def tasks_of_categories(categories)
       Insights::ZeroshotClassificationTask
+        .distinct
         .joins(:categories)
         .where('insights_zeroshot_classification_tasks_categories.category_id' => [categories])
     end

--- a/back/engines/commercial/insights/app/finders/insights/zeroshot_classification_tasks_finder.rb
+++ b/back/engines/commercial/insights/app/finders/insights/zeroshot_classification_tasks_finder.rb
@@ -20,7 +20,7 @@ module Insights
     end
 
     def filter_inputs(tasks)
-      return tasks unless inputs.present?
+      return tasks if inputs.nil?
 
       tasks.joins(:tasks_inputs)
            .where('insights_zeroshot_classification_tasks_inputs.input_id' => [inputs])

--- a/back/engines/commercial/insights/config/routes.rb
+++ b/back/engines/commercial/insights/config/routes.rb
@@ -50,6 +50,9 @@ Insights::Engine.routes.draw do
 
             scope '/stats' do
               get :inputs_count, controller: 'stats_inputs', action: :inputs_count
+              scope '/tasks' do
+                get :category_suggestions, controller: 'classification_tasks', action: :count
+              end
             end
           end
         end

--- a/back/engines/commercial/insights/spec/factories/zeroshot_classification_tasks.rb
+++ b/back/engines/commercial/insights/spec/factories/zeroshot_classification_tasks.rb
@@ -10,16 +10,21 @@ FactoryBot.define do
       inputs_count { 1 }
     end
 
+    # Watch-out: there is some inter-dependency between tasks_inputs and categories
+    # attributes to make sure the created tasks are coherent (inputs belong to the 
+    # scope of the view associated with the categories). Be careful to maintain that
+    # coherence when editing this code.
     tasks_inputs do
-      if inputs
-        inputs.map { |i| association(:zsc_task_input, task: instance, input: i) }
-      else
-        Array.new(inputs_count) { association(:zsc_task_input, task: instance) }
+      inputs_ = inputs || Array.new(inputs_count) do
+        association(:idea, project: categories.first.view.scope)
       end
+
+      inputs_.map { |i| association(:zsc_task_input, task: instance, input: i) }
     end
 
     categories do
-      Array.new(categories_count) { association(:category) }
+      view = inputs ? association(:view, scope: inputs.first.project) : association(:view)
+      Array.new(categories_count) { association(:category, view: view) }
     end
   end
 

--- a/back/engines/commercial/insights/spec/finders/insights/zeroshot_classification_tasks_finder_spec.rb
+++ b/back/engines/commercial/insights/spec/finders/insights/zeroshot_classification_tasks_finder_spec.rb
@@ -5,13 +5,47 @@ require 'rails_helper'
 describe Insights::ZeroshotClassificationTasksFinder do
   describe '#execute' do
 
-    context 'when inputs is empty (not nil)' do
-      let(:task) { create(:zsc_task) }
+    before_all do
+      view = create(:view)
+      @c1, @c2 = create_list(:category, 2, view: view)
 
-      it 'returns no tasks' do
-        finder = described_class.new(task.categories, inputs: [])
-        expect(finder.execute).to be_empty
-      end
+      @c1_tasks = create_list(:zsc_task, 1, categories: [@c1], inputs_count: 2)
+      @c2_tasks = create_list(:zsc_task, 2, categories: [@c2])
+      @c1c2_tasks = [create(:zsc_task, categories: [@c1, @c2])]
+      create(:zsc_task) # some unrelated task
+    end
+
+    it 'returns tasks for a single category' do
+      finder = described_class.new([@c1])
+      expect(finder.execute).to match_array(@c1_tasks + @c1c2_tasks)
+    end
+
+    it 'returns tasks for multiple categories' do
+      finder = described_class.new([@c1, @c2])
+      expect(finder.execute).to match_array(@c1_tasks + @c1c2_tasks + @c2_tasks)
+    end
+
+    it 'returns nothing if inputs is empty' do
+      finder = described_class.new([@c1, @c2], inputs: [])
+      expect(finder.execute.count).to eq(0)
+    end
+
+    it 'returns tasks associated to inputs' do
+      task = @c1_tasks.first
+      finder = described_class.new([@c1, @c2], inputs: task.inputs)
+      expect(finder.execute).to eq([task])
+    end
+
+    it 'returns tasks associated to inputs (across multiple categories)' do
+      inputs = @c2_tasks.flat_map(&:inputs)
+      finder = described_class.new([@c1, @c2], inputs: inputs)
+      expect(finder.execute).to match_array(@c2_tasks)
+    end
+
+    it 'returns nothing if there is no task with the right category-input combination' do
+      inputs = @c1_tasks.first.inputs
+      finder = described_class.new([@c2], inputs: inputs)
+      expect(finder.execute.count).to eq(0)
     end
   end
 end

--- a/back/engines/commercial/insights/spec/finders/insights/zeroshot_classification_tasks_finder_spec.rb
+++ b/back/engines/commercial/insights/spec/finders/insights/zeroshot_classification_tasks_finder_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Insights::ZeroshotClassificationTasksFinder do
+  describe '#execute' do
+
+    context 'when inputs is empty (not nil)' do
+      let(:task) { create(:zsc_task) }
+
+      it 'returns no tasks' do
+        finder = described_class.new(task.categories, inputs: [])
+        expect(finder.execute).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
(IN-673)

New endpoint that returns the count of ongoing classification tasks: 
```
GET .../views/:view_id/stats/tasks/category_suggestions
# => { "count": 666 }
```

It supports the same filters as `GET .../views/:view_id/tasks/category_suggestions` (which returns the list of tasks). 

### How urgent?

It would be nice by tomorrow morning, but not pressure. (We are just trying to release a few stuffs before holidays.)