### PR TITLE
Cl2 6916/registration tab erasing values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Next release
+
+### Fixed
+
+- Changing the values for Registration helper text and Account confirmation in Admin > Settings > Registration doesn't cause other values to be erased anymore.
+
 ## 2022-01-05
 
 ### Changed

--- a/front/app/containers/Admin/settings/registration/index.tsx
+++ b/front/app/containers/Admin/settings/registration/index.tsx
@@ -143,7 +143,12 @@ const SettingsRegistrationTab = (_props: Props) => {
               onCoreSettingWithMultilocChange={
                 handleCoreSettingWithMultilocOnChange
               }
-              latestAppConfigSettings={latestAppConfigSettings}
+              customFieldsSignupHelperTextMultiloc={
+                latestAppConfigSettings.core.custom_fields_signup_helper_text
+              }
+              userConfirmationSetting={
+                latestAppConfigSettings.user_confirmation
+              }
             />
             <SubmitWrapper
               loading={isFormSubmitting}

--- a/front/app/containers/Admin/settings/registration/index.tsx
+++ b/front/app/containers/Admin/settings/registration/index.tsx
@@ -62,10 +62,12 @@ const SettingsRegistrationTab = (_props: Props) => {
   useEffect(() => {
     setLatestAppConfigSettings((latestAppConfigSettings) => {
       if (!isNilOrError(latestAppConfigSettings)) {
-        return {
+        const newLatestAppConfigSettings = {
           ...latestAppConfigSettings,
           ...attributesDiff.settings,
-        } as IAppConfigurationSettings;
+        };
+
+        return newLatestAppConfigSettings as IAppConfigurationSettings;
       }
 
       return null;
@@ -80,6 +82,10 @@ const SettingsRegistrationTab = (_props: Props) => {
           ...attributesDiff.settings,
           core: {
             ...(attributesDiff.settings?.core || {}),
+            // needed because otherwise the useEffect that uses
+            // setLatestAppConfigSettings will replace the entire core
+            // setting with just our 1 setting whenever we change one of the fields
+            ...latestAppConfigSettings?.core,
             [coreSetting]: multiloc,
           },
         },

--- a/front/app/containers/Admin/settings/registration/index.tsx
+++ b/front/app/containers/Admin/settings/registration/index.tsx
@@ -101,10 +101,9 @@ const SettingsRegistrationTab = (_props: Props) => {
 
   if (!isNilOrError(appConfig)) {
     const latestAppConfigSettings = {
-      ...appConfig.data.attributes,
-      ...attributesDiff,
-    }.settings as IAppConfigurationSettings;
-    const latestAppConfigCoreSettings = latestAppConfigSettings.core;
+      ...appConfig.data.attributes.settings,
+      ...attributesDiff.settings,
+    };
 
     return (
       <>
@@ -123,7 +122,7 @@ const SettingsRegistrationTab = (_props: Props) => {
               <InputMultilocWithLocaleSwitcher
                 type="text"
                 valueMultiloc={
-                  latestAppConfigCoreSettings?.signup_helper_text || null
+                  latestAppConfigSettings?.core.signup_helper_text || null
                 }
                 onChange={handleCoreSettingWithMultilocOnChange(
                   'signup_helper_text'

--- a/front/app/modules/commercial/user_custom_fields/admin/components/RegistrationQuestions.tsx
+++ b/front/app/modules/commercial/user_custom_fields/admin/components/RegistrationQuestions.tsx
@@ -4,10 +4,7 @@ import { SectionField } from 'components/admin/Section';
 import { FormattedMessage } from 'utils/cl-intl';
 import { IconTooltip } from '@citizenlab/cl2-component-library';
 import { LabelTooltip } from 'containers/Admin/settings/registration';
-import {
-  IAppConfigurationSettings,
-  TAppConfigurationSettingCore,
-} from 'services/appConfiguration';
+import { TAppConfigurationSettingCore } from 'services/appConfiguration';
 import { Multiloc } from 'typings';
 import InputMultilocWithLocaleSwitcher from 'components/UI/InputMultilocWithLocaleSwitcher';
 import messages from './messages';
@@ -16,24 +13,18 @@ type Props = {
   onCoreSettingWithMultilocChange: (
     coreSetting: TAppConfigurationSettingCore
   ) => (multiloc: Multiloc) => void;
-  latestAppConfigSettings:
-    | IAppConfigurationSettings
-    | Partial<IAppConfigurationSettings>;
+  customFieldsSignupHelperTextMultiloc?: Multiloc | null;
 };
 
 const RegistrationQuestions = ({
   onCoreSettingWithMultilocChange,
-  latestAppConfigSettings,
+  customFieldsSignupHelperTextMultiloc,
 }: Props) => {
-  const latestAppConfigCoreSettings = latestAppConfigSettings.core;
-
   return (
     <SectionField>
       <InputMultilocWithLocaleSwitcher
         type="text"
-        valueMultiloc={
-          latestAppConfigCoreSettings?.custom_fields_signup_helper_text || null
-        }
+        valueMultiloc={customFieldsSignupHelperTextMultiloc}
         onChange={onCoreSettingWithMultilocChange(
           'custom_fields_signup_helper_text'
         )}

--- a/front/app/modules/free/user_confirmation/admin/components/ToggleUserConfirmation.tsx
+++ b/front/app/modules/free/user_confirmation/admin/components/ToggleUserConfirmation.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { IAdminSettingsRegistrationSectionEndOutletProps } from 'utils/moduleUtils';
 import {
   fontSizes,
   Toggle,
@@ -11,6 +10,10 @@ import { colors } from 'utils/styleUtils';
 import messages from './messages';
 import styled from 'styled-components';
 import { SubSectionTitle } from 'components/admin/Section';
+import {
+  TAppConfigurationSetting,
+  AppConfigurationFeature,
+} from 'services/appConfiguration';
 
 const StyledToggle = styled(Toggle)`
   flex-direction: row-reverse;
@@ -30,17 +33,21 @@ const ToggleLabel = styled.label`
   font-size: ${fontSizes.base}px;
 `;
 
+type Props = {
+  onSettingChange: (
+    setting: TAppConfigurationSetting
+  ) => (value: AppConfigurationFeature) => void;
+  userConfirmationSetting: AppConfigurationFeature;
+};
+
 const ToggleUserConfirmation = ({
   onSettingChange,
-  latestAppConfigSettings,
-}: IAdminSettingsRegistrationSectionEndOutletProps) => {
-  const isUserConfirmationEnabled =
-    !!latestAppConfigSettings?.user_confirmation?.enabled;
-
+  userConfirmationSetting,
+}: Props) => {
   function handleToggleOnChange() {
     const newUserConfirmationSetting = {
-      ...latestAppConfigSettings?.user_confirmation,
-      enabled: !isUserConfirmationEnabled,
+      ...userConfirmationSetting,
+      enabled: !userConfirmationSetting.enabled,
     };
     onSettingChange('user_confirmation')(newUserConfirmationSetting);
   }
@@ -59,11 +66,11 @@ const ToggleUserConfirmation = ({
       </SubSectionTitle>
       <ToggleLabel>
         <StyledToggle
-          checked={isUserConfirmationEnabled}
+          checked={userConfirmationSetting.enabled}
           onChange={handleToggleOnChange}
           labelTextColor={colors.adminTextColor}
         />
-        {isUserConfirmationEnabled ? (
+        {userConfirmationSetting.enabled ? (
           <FormattedMessage {...messages.enabled} />
         ) : (
           <FormattedMessage {...messages.disabled} />

--- a/front/app/modules/free/user_confirmation/index.tsx
+++ b/front/app/modules/free/user_confirmation/index.tsx
@@ -13,11 +13,19 @@ const configuration: ModuleConfiguration = {
         <ConfirmationSignupStep {...props} />
       </FeatureFlag>
     ),
-    'app.containers.Admin.settings.registrationSectionEnd': (props) => (
-      <FeatureFlag onlyCheckAllowed name="user_confirmation">
-        <ToggleUserConfirmation {...props} />
-      </FeatureFlag>
-    ),
+    'app.containers.Admin.settings.registrationSectionEnd': ({
+      userConfirmationSetting,
+      onSettingChange,
+    }) => {
+      return userConfirmationSetting ? (
+        <FeatureFlag onlyCheckAllowed name="user_confirmation">
+          <ToggleUserConfirmation
+            userConfirmationSetting={userConfirmationSetting}
+            onSettingChange={onSettingChange}
+          />
+        </FeatureFlag>
+      ) : null;
+    },
   },
 };
 

--- a/front/app/services/appConfiguration.ts
+++ b/front/app/services/appConfiguration.ts
@@ -5,7 +5,7 @@ import { TCategory } from 'components/ConsentManager/destinations';
 
 export const currentAppConfigurationEndpoint = `${API_PATH}/app_configuration`;
 
-interface AppConfigurationFeature {
+export interface AppConfigurationFeature {
   allowed: boolean;
   enabled: boolean;
 }

--- a/front/app/utils/moduleUtils.ts
+++ b/front/app/utils/moduleUtils.ts
@@ -37,6 +37,7 @@ import { IUserData } from 'services/users';
 import { MessageValue } from 'react-intl';
 import { NavItem } from 'containers/Admin/sideBar';
 import {
+  AppConfigurationFeature,
   IAppConfigurationSettings,
   TAppConfigurationSetting,
   TAppConfigurationSettingCore,
@@ -88,9 +89,8 @@ export type IAdminSettingsRegistrationSectionEndOutletProps = {
   onCoreSettingWithMultilocChange: (
     coreSetting: TAppConfigurationSettingCore
   ) => (multiloc: Multiloc) => void;
-  latestAppConfigSettings:
-    | IAppConfigurationSettings
-    | Partial<IAppConfigurationSettings>;
+  customFieldsSignupHelperTextMultiloc?: Multiloc | null;
+  userConfirmationSetting?: AppConfigurationFeature;
 };
 
 export type OutletsPropertyMap = {


### PR DESCRIPTION
## What has changed?

Fixed the bug where when you changed one field the registration section of the Admin > Settings > Registration tab, the others would get wiped out.

## Checklist

- [x] Added entry to changelog
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

- [x] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## Links

Link to Jira ticket added below by the bot.

## How urgent is a code review?

Would be great to have this fixed asap, so today would be great.
