### PR TITLE
[NO-TICKET] Refactor NLP::Api (10%)

### DIFF
--- a/back/engines/commercial/nlp/app/services/nlp/api.rb
+++ b/back/engines/commercial/nlp/app/services/nlp/api.rb
@@ -26,11 +26,7 @@ module NLP
     end
 
     def clustering(tenant_id, locale, options = {})
-      body = { locale: locale }
-      body[:idea_ids] = options[:idea_ids] if options[:idea_ids]
-      body[:n_clusters] = options[:n_clusters] if options[:n_clusters]
-      body[:max_depth] = options[:max_depth] if options[:max_depth]
-
+      body = options.slice(:idea_ids, :n_clusters, :max_depth).merge(locale: locale)
       path = "/v1/tenants/#{tenant_id}/ideas/clustering"
       resp = post(path, body)
       raise ClErrors::TransactionError.new(error_key: resp['code']) unless resp.success?
@@ -43,12 +39,7 @@ module NLP
     end
 
     def summarize(texts, locale, options = {})
-      body = {
-        **options,
-        texts: texts,
-        locale: locale
-      }
-
+      body = options.merge(texts: texts, locale: locale)
       resp = post('/v1/summarization', body)
       raise ClErrors::TransactionError.new(error_key: resp['code']) unless resp.success?
 

--- a/back/engines/commercial/nlp/app/services/nlp/api.rb
+++ b/back/engines/commercial/nlp/app/services/nlp/api.rb
@@ -139,7 +139,7 @@ module NLP
 
       unless json.nil?
         options[:headers]['Content-Type'] = 'application/json'
-        options[:body] = json.to_json
+        options[:body] = json.is_a?(String) ? json : json.to_json
       end
 
       HTTParty.get(path, options)
@@ -147,7 +147,7 @@ module NLP
 
     def post(path, json)
       options = {
-        body: json.to_json,
+        body: json.is_a?(String) ? json : json.to_json,
         timeout: LONG_TIMEOUT,
         headers: authorization_header.merge('Content-Type' => 'application/json'),
         base_uri: base_uri

--- a/back/engines/commercial/nlp/app/services/nlp/api.rb
+++ b/back/engines/commercial/nlp/app/services/nlp/api.rb
@@ -79,7 +79,7 @@ module NLP
     end
 
     # @param [Array<String>] task_ids
-    # @return [Integer] HTTP status code
+    # @return [HTTParty::Response] HTTP status code
     def cancel_tasks(task_ids)
       body = { ids: task_ids }
       post('/v2/async_api/cancel', body)

--- a/back/engines/commercial/nlp/app/services/nlp/api.rb
+++ b/back/engines/commercial/nlp/app/services/nlp/api.rb
@@ -14,13 +14,13 @@ module NLP
     end
 
     def update_tenant(dump)
-      _post('/v1/tenants', dump)
+      post('/v1/tenants', dump)
     end
 
     def similarity(tenant_id, idea_id, locale, options = {})
       body = options.merge(locale: locale)
       path = "/v1/tenants/#{tenant_id}/ideas/#{idea_id}/similarity"
-      resp = _get(path, body)
+      resp = get(path, body)
 
       JSON.parse(resp.body)['data'] if resp.success?
     end
@@ -32,14 +32,14 @@ module NLP
       body[:max_depth] = options[:max_depth] if options[:max_depth]
 
       path = "/v1/tenants/#{tenant_id}/ideas/clustering"
-      resp = _post(path, body)
+      resp = post(path, body)
       raise ClErrors::TransactionError.new(error_key: resp['code']) unless resp.success?
 
       resp.parsed_response['data']
     end
 
     def ideas_classification(tenant_id, locale)
-      _get("/v1/tenants/#{tenant_id}/#{locale}/ideas/classification")
+      get("/v1/tenants/#{tenant_id}/#{locale}/ideas/classification")
     end
 
     def summarize(texts, locale, options = {})
@@ -49,14 +49,14 @@ module NLP
         locale: locale
       }
 
-      resp = _post('/v1/summarization', body)
+      resp = post('/v1/summarization', body)
       raise ClErrors::TransactionError.new(error_key: resp['code']) unless resp.success?
 
       resp.parsed_response['data']
     end
 
     def tag_suggestions(body)
-      resp = _post('/v2/tag_suggestions', body)
+      resp = post('/v2/tag_suggestions', body)
       raise ClErrors::TransactionError.new(error_key: resp['code']) unless resp.success?
 
       resp.parsed_response['data']
@@ -69,21 +69,21 @@ module NLP
       }
 
       path = "/v2/tenants/#{tenant_id}/project/#{project_id}/ideas/tag_suggestions"
-      resp = _post(path, body)
+      resp = post(path, body)
       raise ClErrors::TransactionError.new(error_key: resp['code']) unless resp.success?
 
       resp.parsed_response['data']
     end
 
     def zeroshot_classification(body)
-      resp = _post('/v2/zeroshot_classification', body)
+      resp = post('/v2/zeroshot_classification', body)
       raise ClErrors::TransactionError.new(error_key: resp['code']) unless resp.success?
 
       resp.parsed_response['data']
     end
 
     def cancel_task(task_id)
-      resp = _get("/v2/async_api/cancel/#{task_id}")
+      resp = get("/v2/async_api/cancel/#{task_id}")
       resp.code
     end
 
@@ -91,11 +91,11 @@ module NLP
     # @return [Integer] HTTP status code
     def cancel_tasks(task_ids)
       body = { ids: task_ids }
-      _post('/v2/async_api/cancel', body)
+      post('/v2/async_api/cancel', body)
     end
 
     def status_task(task_id)
-      resp = _get("/v2/async_api/status/#{task_id}")
+      resp = get("/v2/async_api/status/#{task_id}")
       raise ClErrors::TransactionError.new(error_key: resp['code']) unless resp.success?
 
       resp.parsed_response['data']
@@ -115,7 +115,7 @@ module NLP
       }.compact
 
       path = "/v2/tenants/#{tenant_id}/project/#{project_id}/ideas/text_network_analysis"
-      response = _post(path, body)
+      response = post(path, body)
       raise ClErrors::TransactionError.new(error_key: response['code']) unless response.success?
 
       response.parsed_response.dig('data', 'task_id')
@@ -127,7 +127,7 @@ module NLP
     # @return [Array]
     def geotag(tenant_id, text, locale, options = {})
       body = options.merge(text: text, locale: locale)
-      resp = _post("/v1/tenants/#{tenant_id}/geotagging", body)
+      resp = post("/v1/tenants/#{tenant_id}/geotagging", body)
       raise ClErrors::TransactionError.new(error_key: resp['code']) unless resp.success?
 
       resp.parsed_response['data']
@@ -135,7 +135,7 @@ module NLP
 
     def toxicity_detection(texts)
       body = { texts: texts }
-      resp = _post('/v2/toxic_classification', body)
+      resp = post('/v2/toxic_classification', body)
       raise ClErrors::TransactionError.new(error_key: resp['code']) unless resp.success?
 
       resp.parsed_response['data']
@@ -143,7 +143,7 @@ module NLP
 
     private
 
-    def _get(path, json = nil)
+    def get(path, json = nil)
       options = { timeout: LONG_TIMEOUT, headers: authorization_header, base_uri: base_uri }
 
       unless json.nil?
@@ -154,7 +154,7 @@ module NLP
       HTTParty.get(path, options)
     end
 
-    def _post(path, json)
+    def post(path, json)
       options = {
         body: json.to_json,
         timeout: LONG_TIMEOUT,

--- a/back/engines/commercial/nlp/app/services/nlp/api.rb
+++ b/back/engines/commercial/nlp/app/services/nlp/api.rb
@@ -4,17 +4,13 @@ require 'httparty'
 
 module NLP
   class Api
-    include HTTParty
-
     LONG_TIMEOUT = 2 * 60 # 2 minutes
 
-    attr_reader :authorization_token
-
-    delegate :post, :base_uri, :get, to: :class
+    attr_reader :authorization_token, :base_uri
 
     def initialize(base_uri: nil, authorization_token: nil)
       @authorization_token = authorization_token || ENV.fetch('NLP_API_TOKEN')
-      base_uri(base_uri || ENV.fetch('NLP_HOST'))
+      @base_uri = HTTParty.normalize_base_uri(base_uri || ENV.fetch('NLP_HOST'))
     end
 
     def update_tenant(dump)
@@ -52,7 +48,7 @@ module NLP
         texts: texts,
         locale: locale
       }
-      
+
       resp = _post('/v1/summarization', body)
       raise ClErrors::TransactionError.new(error_key: resp['code']) unless resp.success?
 

--- a/back/engines/commercial/nlp/spec/services/nlp/api_spec.rb
+++ b/back/engines/commercial/nlp/spec/services/nlp/api_spec.rb
@@ -56,30 +56,28 @@ RSpec.describe NLP::Api do
   end
 
   describe '#text_network_analysis' do
-    # rubocop:disable RSpec/SubjectStub
     it 'send a request with an authorization header' do
       response = instance_double(HTTParty::Response, 'success?': true, parsed_response: {})
-      allow(service).to receive(:post).and_return(response)
+      allow(HTTParty).to receive(:post).and_return(response)
       service.text_network_analysis('tenant-id', 'project-id', 'en')
 
-      expect(service).to have_received(:post) do |_path, options|
+      expect(HTTParty).to have_received(:post) do |_path, options|
         authorization_header = options.dig(:headers, 'Authorization')
         expect(authorization_header).to eq("Token #{authorization_token}")
       end
     end
-    # rubocop:enable RSpec/SubjectStub
   end
 
   describe '#cancel_tasks' do
     let(:response) { instance_double(HTTParty::Response, code: 200) }
     let(:task_ids) { %w[uuid-1 uuid-2] }
 
-    before { allow(service).to receive(:post).and_return(response) }
+    before { allow(HTTParty).to receive(:post).and_return(response) }
 
     it 'sends a well-formed request to the NLP service' do
       service.cancel_tasks(task_ids)
 
-      expect(service).to have_received(:post) do |path, options|
+      expect(HTTParty).to have_received(:post) do |path, options|
         expected_headers = {
           'Authorization' => 'Token authorization-token',
           'Content-Type' => 'application/json'


### PR DESCRIPTION
This PR reworks `NLP::Api` to:
- reduce code redundancy by introducing helper functions `NLP::Api#post` & `NLP::Api#get` to send requests with some default options;
- remove the anti-pattern of delegating `base_uri` to the class when its value is not constant (see https://github.com/CitizenLabDotCo/citizenlab/pull/1293/commits/95a88460c181551d9577a5138827b188494ec9e7).