### PR TITLE
EN-652 Authorize status_counts endpoint for not-signed-in user

### DIFF
--- a/back/app/policies/admin_publication_policy.rb
+++ b/back/app/policies/admin_publication_policy.rb
@@ -28,7 +28,7 @@ class AdminPublicationPolicy < ApplicationPolicy
   end
 
   def status_counts
-    active?
+    true
   end
 end
 

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -298,12 +298,11 @@ resource "AdminPublication" do
 
         json_response = json_parse(response_body)
         expect(json_response[:status_counts][:draft]).to eq nil
+        expect(json_response[:status_counts][:published]).to eq 2
          
         if CitizenLab.ee?
-          expect(json_response[:status_counts][:published]).to eq 2
           expect(json_response[:status_counts][:archived]).to eq 1
         else
-          expect(json_response[:status_counts][:published]).to eq 1
           expect(json_response[:status_counts][:archived]).to eq 2
         end
       end

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -193,7 +193,7 @@ resource "AdminPublication" do
     end
 
     get "web_api/v1/admin_publications/status_counts" do
-      example "Get publication_status counts for top-level admin publications when folders in use" do
+      example "Get publication_status counts for top-level admin publications" do
         do_request(depth: 0)
         expect(status).to eq 200
 
@@ -276,6 +276,36 @@ resource "AdminPublication" do
         expect(status).to eq(200)
         json_response = json_parse(response_body)
         expect(json_response[:data].size).to eq 0
+      end
+    end
+  end
+
+  context 'not logged in' do
+    before do
+      @projects = ['published','archived','draft','published','archived']
+        .map { |ps|  create(:project, admin_publication_attributes: {publication_status: ps})}
+
+      next unless CitizenLab.ee?
+
+      @folder = create(:project_folder, projects: @projects.take(2))
+      @empty_draft_folder = create(:project_folder, admin_publication_attributes: {publication_status: 'draft'})
+    end
+
+    get "web_api/v1/admin_publications/status_counts" do
+      example "Get publication_status counts for top-level admin publications" do
+        do_request(depth: 0)
+        expect(status).to eq 200
+
+        json_response = json_parse(response_body)
+
+        expect(json_response[:status_counts][:draft]).to eq nil
+        expect(json_response[:status_counts][:archived]).to eq 1
+        
+        if CitizenLab.ee?
+          expect(json_response[:status_counts][:published]).to eq 2
+        else
+          expect(json_response[:status_counts][:published]).to eq 1
+        end
       end
     end
   end

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -14,8 +14,8 @@ resource "AdminPublication" do
     before do
       admin_header_token
 
-      @projects = ['published','published','draft','draft','published','archived','archived','published']
-        .map { |ps|  create(:project, admin_publication_attributes: {publication_status: ps})}
+      @projects = %w[published published draft draft published archived archived published]
+                  .map { |ps|  create(:project, admin_publication_attributes: { publication_status: ps }) }
 
       next unless CitizenLab.ee?
 
@@ -192,8 +192,8 @@ resource "AdminPublication" do
       end
     end
 
-    get "web_api/v1/admin_publications/status_counts" do
-      example "Get publication_status counts for top-level admin publications" do
+    get 'web_api/v1/admin_publications/status_counts' do
+      example 'Get publication_status counts for top-level admin publications' do
         do_request(depth: 0)
         expect(status).to eq 200
 
@@ -201,7 +201,7 @@ resource "AdminPublication" do
 
         expect(json_response[:status_counts][:draft]).to eq 2
         expect(json_response[:status_counts][:archived]).to eq 2
-        
+
         if CitizenLab.ee?
           expect(json_response[:status_counts][:published]).to eq 3
         else
@@ -280,26 +280,26 @@ resource "AdminPublication" do
     end
   end
 
-  context 'not logged in' do
+  context 'when not logged in' do
     before do
-      @projects = ['published','archived','draft','published','archived']
-        .map { |ps|  create(:project, admin_publication_attributes: {publication_status: ps})}
+      @projects = %w[published archived draft published archived]
+                  .map { |ps|  create(:project, admin_publication_attributes: { publication_status: ps }) }
 
       next unless CitizenLab.ee?
 
       @folder = create(:project_folder, projects: @projects.take(2))
-      @empty_draft_folder = create(:project_folder, admin_publication_attributes: {publication_status: 'draft'})
+      @empty_draft_folder = create(:project_folder, admin_publication_attributes: { publication_status: 'draft' })
     end
 
-    get "web_api/v1/admin_publications/status_counts" do
-      example "Get publication_status counts for top-level admin publications" do
+    get 'web_api/v1/admin_publications/status_counts' do
+      example 'Get publication_status counts for top-level admin publications' do
         do_request(depth: 0)
         expect(status).to eq 200
 
         json_response = json_parse(response_body)
         expect(json_response[:status_counts][:draft]).to eq nil
         expect(json_response[:status_counts][:published]).to eq 2
-         
+
         if CitizenLab.ee?
           expect(json_response[:status_counts][:archived]).to eq 1
         else

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -297,14 +297,14 @@ resource "AdminPublication" do
         expect(status).to eq 200
 
         json_response = json_parse(response_body)
-
         expect(json_response[:status_counts][:draft]).to eq nil
-        expect(json_response[:status_counts][:archived]).to eq 1
-        
+         
         if CitizenLab.ee?
           expect(json_response[:status_counts][:published]).to eq 2
+          expect(json_response[:status_counts][:archived]).to eq 1
         else
           expect(json_response[:status_counts][:published]).to eq 1
+          expect(json_response[:status_counts][:archived]).to eq 2
         end
       end
     end


### PR DESCRIPTION
~~Added entry to changelog~~
  
~~WCAG 2.1 AA proof~~

- [x] Tests

- [x] Prepared branch for code review

We need to authorize `status_counts` action for non-logged in users.

## How urgent is a code review?

ASAP - Luuc is close to releasing the 1st iteration of Homepage Filters epic, and this is blocking that.
