### PR TITLE
EN-1267 Replace dot in non-latin URL slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next release
 
+### Fixed
+
+- Remove periods from non-Latin URL slugs
+
 ### Added
 
 - Folder slugs (URLs) can now be customized
@@ -39,8 +43,6 @@
 - Projects on homepage can now be filtered by 'Active', 'Archived' or 'All' through a tab system
 
 ## 2022-02-01
-
-> > > > > > > master
 
 ### Changed
 

--- a/back/app/services/slug_service.rb
+++ b/back/app/services/slug_service.rb
@@ -22,7 +22,7 @@ class SlugService
     return [] if unpersisted_records.blank?
     # Calculate slugs for every record individually
     slugs = unpersisted_records.map do |record|
-      slugify(block.call(record)) 
+      slugify(block.call(record))
     end
 
     # Find the all the persisted duplicates
@@ -57,9 +57,16 @@ class SlugService
 
   def slugify str
     if latinish? str
-      str.downcase.parameterize.gsub('_', '-')
+      # `parametrize` transliterates (replaces ü with u) text.
+      # It's more convenient, because URL looks the same everywhere (browser, text editor).
+      # But proper transliteration is difficult (it should be configured for each language).
+      # https://apidock.com/rails/v6.1.3.1/ActiveSupport/Inflector/transliterate
+      # So, we transliterate only strings with latin characters.
+      str.downcase.parameterize.tr('_', '-')
     else
-      str.gsub('_', '-')
+      str.downcase.strip
+        .gsub(/[^\p{L}\p{N}]+/, '-') # replace all characters that are not letters or numbers
+        .gsub(/\A-+|-+\z/, '') # remove leading and trailing dashes
     end
   end
 

--- a/back/spec/services/slug_service_spec.rb
+++ b/back/spec/services/slug_service_spec.rb
@@ -2,76 +2,88 @@ require 'rails_helper'
 
 describe SlugService do
   let(:service) { SlugService.new }
-  describe "generate_slugs" do
-    it "generates unique slugs for unpersisted users with the same names" do
+  describe 'generate_slugs' do
+    it 'generates unique slugs for unpersisted users with the same names' do
       unpersisted_users = [
         build(:user, first_name: 'jose'),
-        build(:user, first_name: 'jose'),
+        build(:user, first_name: 'jose')
       ]
-      expect(service.generate_slugs(unpersisted_users, &:first_name)).to eq [
-        'jose',
-        'jose-1',
+      expect(service.generate_slugs(unpersisted_users, &:first_name)).to eq %w[
+        jose
+        jose-1
       ]
     end
 
-    it "generates unique slugs when one existing user already has the slug" do
-      persisted_user = create(:user, slug: 'jose')
+    it 'generates unique slugs when one existing user already has the slug' do
+      _persisted_user = create(:user, slug: 'jose')
       unpersisted_users = [
         build(:user, first_name: 'jose'),
-        build(:user, first_name: 'jose'),
+        build(:user, first_name: 'jose')
       ]
-      expect(service.generate_slugs(unpersisted_users, &:first_name)).to eq [
-        'jose-1',
-        'jose-2',
+      expect(service.generate_slugs(unpersisted_users, &:first_name)).to eq %w[
+        jose-1
+        jose-2
       ]
     end
 
-    it "generates unique slugs when existing users already have the slug" do
-      persisted_users = [
+    it 'generates unique slugs when existing users already have the slug' do
+      _persisted_users = [
         create(:user, slug: 'jose'),
         create(:user, slug: 'jose-1'),
-        create(:user, slug: 'paulo-18'),
+        create(:user, slug: 'paulo-18')
       ]
       unpersisted_users = [
         build(:user, first_name: 'jose'),
-        build(:user, first_name: 'paulo'),
+        build(:user, first_name: 'paulo')
       ]
-      expect(service.generate_slugs(unpersisted_users, &:first_name)).to eq [
-        'jose-2',
-        'paulo-19'
+      expect(service.generate_slugs(unpersisted_users, &:first_name)).to eq %w[
+        jose-2
+        paulo-19
       ]
     end
-
   end
 
-  describe "slugify" do
-
-    it "retains normal latin chars and numbers" do
-      expect(service.slugify("abcaz123")).to eq "abcaz123"
+  describe 'slugify' do
+    it 'retains normal chars and numbers' do
+      expect(service.slugify('abcaz123')).to eq 'abcaz123'
+      expect(service.slugify('абвгд123')).to eq 'абвгд123'
     end
 
-    it "converts uppercase to lowercase" do
-      expect(service.slugify("ABCDEabc")).to eq "abcdeabc"
+    it 'converts uppercase to lowercase' do
+      expect(service.slugify('ABCDEabc')).to eq 'abcdeabc'
+      expect(service.slugify('АБВГдеёж')).to eq 'абвгдеёж'
     end
 
-    it "replaces spaces with dashes" do
-      expect(service.slugify("this is great")).to eq "this-is-great"
+    it 'replaces spaces with dashes' do
+      expect(service.slugify('this is great')).to eq 'this-is-great'
+      expect(service.slugify('это хорошо')).to eq 'это-хорошо'
     end
 
-    it "replaces underscores with dashes" do
-      expect(service.slugify("this_is_great")).to eq "this-is-great"
+    it 'replaces underscores with dashes' do
+      expect(service.slugify('this_is_great')).to eq 'this-is-great'
+      expect(service.slugify('это_хорошо')).to eq 'это-хорошо'
     end
 
-    it "ignores prefix or postfix whitespace" do
-      expect(service.slugify(" great ")).to eq "great"
+    it 'ignores prefix or postfix whitespace' do
+      expect(service.slugify(' great ')).to eq 'great'
+      expect(service.slugify(' хорошо ')).to eq 'хорошо'
     end
 
     it "removes accents on latin characters when there's at least one normal latin character" do
-      expect(service.slugify("gáöüóáàØ")).to eq "gaouoaao"
+      expect(service.slugify('gáöüóáàØ')).to eq 'gaouoaao'
+    end
+
+    it "removes dots and other special characters" do
+      expect(service.slugify('this.is.good,?*')).to eq 'this-is-good'
+      expect(service.slugify('это.хорошо,?*')).to eq 'это-хорошо'
+    end
+
+    it "retains accents on latin characters when there's no normal latin character" do
+      expect(service.slugify('áöüóáàØ')).to eq 'áöüóáàø'
     end
 
     it "retains all non-latin characters if there's no normal latin characters" do
-      expect(service.slugify("عربى")).to eq "عربى"
+      expect(service.slugify('عربى')).to eq 'عربى'
     end
   end
 end


### PR DESCRIPTION
We could handle URLs with dots on FE, but anyway it doesn't look
nice when URLs have special characters.

## Checklist

- [x] Added entry to changelog
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

- [ ] ~~WCAG 2.1 AA proof~~
<details>
<summary>More info</summary>
For front-end devs only. Is your work conforming with the WCAG 2.1 AA rules? If you need more info, read the [a11y page](https://www.notion.so/citizenlab/a11y-7568f83d42ab4895ac133b89d358997b) on our Notion.
</details>

- [x] Tests
<details>
<summary>More info</summary>

### Unit tests

Did you add relevant unit tests?

### E2E tests

Sometimes it can be more efficient to update E2E tests after CI has run them. If you know which ones to update, go ahead! E2E template cl2-back:

```bash
docker compose run --rm web bin/rails cl2_back:create_tenant[localhost,e2etests_template]
```

</details>

- [x] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## How urgent is a code review?

Not urgent.