### PR TITLE
en-30 revert auth and policies changes

### DIFF
--- a/back/app/controllers/web_api/v1/projects_allowed_input_topics_controller.rb
+++ b/back/app/controllers/web_api/v1/projects_allowed_input_topics_controller.rb
@@ -1,5 +1,6 @@
 class WebApi::V1::ProjectsAllowedInputTopicsController < ApplicationController
   before_action :set_projects_allowed_input_topic, only: %i[show reorder destroy]
+  skip_before_action :authenticate_user
 
   def index
     @projects_allowed_input_topics = policy_scope(ProjectsAllowedInputTopic)

--- a/back/app/policies/projects_allowed_input_topic_policy.rb
+++ b/back/app/policies/projects_allowed_input_topic_policy.rb
@@ -6,30 +6,21 @@ class ProjectsAllowedInputTopicPolicy < ApplicationPolicy
       @user  = user
       @scope = scope
     end
-
     def resolve
       scope.where(project: Pundit.policy_scope(user, Project))
     end
   end
 
-  def index?
-    active_admin_or_moderator?
-  end
-
-  def show?
-    active_admin_or_moderator?
-  end
-
   def create?
-    active_admin_or_moderator?
+    user&.active? && user&.active_admin_or_moderator?(record.project_id)
   end
 
   def reorder?
-    active_admin_or_moderator?
+    user&.active? && user&.active_admin_or_moderator?(record.project_id)
   end
 
   def destroy?
-    active_admin_or_moderator?
+    user&.active? && user&.active_admin_or_moderator?(record.project_id)
   end
 
   def permitted_attributes_for_create
@@ -41,11 +32,5 @@ class ProjectsAllowedInputTopicPolicy < ApplicationPolicy
 
   def permitted_attributes_for_reorder
     [:ordering]
-  end
-
-  private
-
-  def active_admin_or_moderator?
-    user&.active? && user&.active_admin_or_moderator?(record.project_id)
   end
 end


### PR DESCRIPTION
Reverting changes to auth and policies that broke `projects_allowed_input_topics` for non-signed in user (not the focus of this Epic related work, in any case)
