### PR TITLE
en-30 revert change to route resources

### DIFF
--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -142,7 +142,7 @@ Rails.application.routes.draw do
         get 'by_slug/:slug', on: :collection, to: 'projects#by_slug'
       end
 
-      resources :projects_allowed_input_topics, only: [:index, :show, :create, :destroy] do
+      resources :projects_allowed_input_topics, only: [:index, :show, :reorder, :create, :destroy] do
         patch 'reorder', on: :member
       end
       


### PR DESCRIPTION
We had a flakey test of reordering `projects_allowed_input_topics` when releasing the changes in [this PR](https://github.com/CitizenLabDotCo/citizenlab/pull/1389) and related [ee PR](https://github.com/CitizenLabDotCo/citizenlab-ee/pull/158).
  
I suspect a change I made to the routes resources (a leftover from an attempt to reorganise routes that I later aborted as not related to the main focus of this work) - especially since this resource is `:reorder`.
  
This PR undoes that change.
