### PR TITLE
Release 2022-02-01-2

### DIFF
--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -142,7 +142,7 @@ Rails.application.routes.draw do
         get 'by_slug/:slug', on: :collection, to: 'projects#by_slug'
       end
 
-      resources :projects_allowed_input_topics, only: [:index, :show, :create, :destroy] do
+      resources :projects_allowed_input_topics, only: [:index, :show, :reorder, :create, :destroy] do
         patch 'reorder', on: :member
       end
       


### PR DESCRIPTION
Tiny fix reverting accidental change to route resource (abandoned experimental improvement of routes).

I suspect this was the cause of the flaky test of reordering that appeared in the last release CI:
 ```
Failures:

  1) ProjectsAllowedInputTopics when admin PATCH web_api/v1/projects_allowed_input_topics/:id/reorder Reorder a project allowed input topic
     Failure/Error: expect(response_status).to eq 200
     
       expected: 200
            got: 422
```