### PR TITLE
EN-1869 Add topic(s)_term to settings.schema.json.erb

### DIFF
--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -165,6 +165,16 @@
             "description": "What a geographic unit should be called on this platform (e.g., neighbourhood, district, etc.)? Input the singular form here with all lowercase letters. If left blank, this field defaults to 'area'.",
             "$ref": "#/definitions/multiloc_string"
           },
+          “topics_term”: {
+            “title”: “Tag Units”,
+            “description”: “What tags should be called on this platform (e.g., departments, themes, etc.). Input the plural form here with all lowercase letters. If left blank, this field defaults to ‘tags’.“,
+            “$ref”: “#/definitions/multiloc_string”
+          },
+          “topic_term”: {
+            “title”: “Tag Unit”,
+            “description”: “What a tag should be called on this platform (e.g., department, theme, etc.)? Input the singular form here with all lowercase letters. If left blank, this field defaults to ‘tag’.“,
+            “$ref”: “#/definitions/multiloc_string”
+          },
           "reply_to_email": {
             "title": "Reply-to email",
             "description": "The email used in the reply-to field when users receive emails from automated campaigns.",

--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -166,7 +166,7 @@
             "$ref": "#/definitions/multiloc_string"
           },
           "topic_term": {
-            "title": "Term for tag (singular)",
+            "title": "Tag Unit",
             "description": "What a tag unit should be called on this platform (e.g., department, theme, etc.). Input the singular form here with all lowercase letters. If left blank, this field defaults to 'tag'.",
             "$ref": "#/definitions/multiloc_string"
           },

--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -165,14 +165,9 @@
             "description": "What a geographic unit should be called on this platform (e.g., neighbourhood, district, etc.)? Input the singular form here with all lowercase letters. If left blank, this field defaults to 'area'.",
             "$ref": "#/definitions/multiloc_string"
           },
-          "topics_term": {
-            "title": "Tag Units",
-            "description": "What tag units should be called on this platform (e.g., departments, themes, etc.). Input the plural form here with all lowercase letters. If left blank, this field defaults to 'areas'.",
-            "$ref": "#/definitions/multiloc_string"
-          },
           "topic_term": {
-            "title": "Topic Unit",
-            "description": "What a tag unit should be called on this platform (e.g., departments, themes, etc.)? Input the singular form here with all lowercase letters. If left blank, this field defaults to 'area'.",
+            "title": "Term for tag (singular)",
+            "description": "What a tag unit should be called on this platform (e.g., department, theme, etc.). Input the singular form here with all lowercase letters. If left blank, this field defaults to 'tag'.",
             "$ref": "#/definitions/multiloc_string"
           },
           "reply_to_email": {

--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -165,15 +165,15 @@
             "description": "What a geographic unit should be called on this platform (e.g., neighbourhood, district, etc.)? Input the singular form here with all lowercase letters. If left blank, this field defaults to 'area'.",
             "$ref": "#/definitions/multiloc_string"
           },
-          “topics_term”: {
-            “title”: “Tag Units”,
-            “description”: “What tags should be called on this platform (e.g., departments, themes, etc.). Input the plural form here with all lowercase letters. If left blank, this field defaults to ‘tags’.“,
-            “$ref”: “#/definitions/multiloc_string”
+          "topics_term": {
+            "title": "Tag Units",
+            "description": "What tags should be called on this platform (e.g., departments, themes, etc.). Input the plural form here with all lowercase letters. If left blank, this field defaults to 'areas'.",
+            "$ref": "#/definitions/multiloc_string"
           },
-          “topic_term”: {
-            “title”: “Tag Unit”,
-            “description”: “What a tag should be called on this platform (e.g., department, theme, etc.)? Input the singular form here with all lowercase letters. If left blank, this field defaults to ‘tag’.“,
-            “$ref”: “#/definitions/multiloc_string”
+          "topic_term": {
+            "title": "Topic Unit",
+            "description": "What a tag should be called on this platform (e.g., departments, themes, etc.)? Input the singular form here with all lowercase letters. If left blank, this field defaults to 'area'.",
+            "$ref": "#/definitions/multiloc_string"
           },
           "reply_to_email": {
             "title": "Reply-to email",

--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -167,12 +167,12 @@
           },
           "topics_term": {
             "title": "Tag Units",
-            "description": "What tags should be called on this platform (e.g., departments, themes, etc.). Input the plural form here with all lowercase letters. If left blank, this field defaults to 'areas'.",
+            "description": "What tag units should be called on this platform (e.g., departments, themes, etc.). Input the plural form here with all lowercase letters. If left blank, this field defaults to 'areas'.",
             "$ref": "#/definitions/multiloc_string"
           },
           "topic_term": {
             "title": "Topic Unit",
-            "description": "What a tag should be called on this platform (e.g., departments, themes, etc.)? Input the singular form here with all lowercase letters. If left blank, this field defaults to 'area'.",
+            "description": "What a tag unit should be called on this platform (e.g., departments, themes, etc.)? Input the singular form here with all lowercase letters. If left blank, this field defaults to 'area'.",
             "$ref": "#/definitions/multiloc_string"
           },
           "reply_to_email": {


### PR DESCRIPTION
- [x] Prepared branch for code review

With regard to a default label value, in the FE I can see:
`"app.containers.AdminPage.ProjectEdit.areasLabel": "Geographic areas",`
in [front/app/translations/admin/en.json](https://github.com/CitizenLabDotCo/citizenlab/blob/6a1c575392659bbc1489468b2ff31ea787f24049/front/app/translations/admin/en.json#L792)
But nothing like that in BE.

In discussion with @luucvanderzee , we decided to use the same pattern as for areas (no default value specified in `settings.schema.json.erb`), but that this is also a good topic for discussion in a CDM (do we have/need an agreed pattern for when and how to use default values?)

## Links

- [Homepage Filters Epic](https://citizenlab.atlassian.net/browse/EN-1757)

## How urgent is a code review?

A.S.A.P - FE needs this to implement adding / removing topics (tags) of Project
