### PR TITLE
CL-48 Added CL- key to danger config

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -8,7 +8,7 @@ if (!hasChangelog) {
 
 // PR title and branch Jira key reference
 const extractJiraKeys = (str: string): string[] => {
-  const jiraIssueRegex = new RegExp(`((CL2|OS|WOR|IN|TEC|EN)-[0-9]+)`, "g");
+  const jiraIssueRegex = new RegExp(`((CL2|OS|WOR|IN|TEC|EN|CL)-[0-9]+)`, "g");
   return Array.from(str.matchAll(jiraIssueRegex)).map((m) => m[0]);
 };
 


### PR DESCRIPTION
This will get rid of the faulty messages that a reference in the branch name or PR name is missing.