### PR TITLE
Cl 247/broken aria attributes

### DIFF
--- a/front/app/components/UI/Modal/index.tsx
+++ b/front/app/components/UI/Modal/index.tsx
@@ -488,7 +488,7 @@ class Modal extends PureComponent<Props, State> {
                 }`}
                 onClickOutside={this.clickOutsideModal}
                 windowHeight={windowHeight}
-                ariaLabelledBy="modal-header"
+                ariaLabelledBy={header ? 'modal-header' : undefined}
                 aria-modal="true"
                 role="dialog"
               >

--- a/front/app/containers/SiteMap/index.tsx
+++ b/front/app/containers/SiteMap/index.tsx
@@ -163,8 +163,8 @@ const SiteMap = ({ projects, authUser }: Props) => {
                 <FormattedMessage {...messages.siteMapTitle} />
               </Title>
 
-              <TOC aria-labelledby="nav-header">
-                <Header id="nav-header">
+              <TOC>
+                <Header>
                   <FormattedMessage {...messages.pageContents} />
                 </Header>
                 <Ul>


### PR DESCRIPTION
The sometimes empty aria-labelledby was mentioned as an issue in one of the reports. On the web, I read it's not a problem. Anyway, now it's only in the modal when there's a title. :)

Also removed a redundant aria attribute.

