### PR TITLE
EN-1646 Enforce authorization of onboarding campaigns

### DIFF
--- a/back/engines/free/onboarding/app/controllers/onboarding/web_api/v1/campaigns_controller.rb
+++ b/back/engines/free/onboarding/app/controllers/onboarding/web_api/v1/campaigns_controller.rb
@@ -2,8 +2,6 @@ module Onboarding
   module WebApi
     module V1
       class CampaignsController < OnboardingController
-        # skip_before_action :authenticate_user
-
         class Campaign < OpenStruct
           include ActiveModel::Serialization
           def id

--- a/back/engines/free/onboarding/app/controllers/onboarding/web_api/v1/campaigns_controller.rb
+++ b/back/engines/free/onboarding/app/controllers/onboarding/web_api/v1/campaigns_controller.rb
@@ -2,7 +2,7 @@ module Onboarding
   module WebApi
     module V1
       class CampaignsController < OnboardingController
-        skip_before_action :authenticate_user
+        # skip_before_action :authenticate_user
 
         class Campaign < OpenStruct
           include ActiveModel::Serialization

--- a/back/engines/free/onboarding/spec/acceptance/onboarding_campaigns_spec.rb
+++ b/back/engines/free/onboarding/spec/acceptance/onboarding_campaigns_spec.rb
@@ -48,6 +48,16 @@ resource "Onboarding campaigns" do
         expect(json_response[:data][:attributes][:cta_button_link]).to eq "/ideas"
       end
     end
+
+    context "for a not signed-in user" do
+      before do
+        header 'Authorization', nil
+      end
+
+      example_request "[error] returns 401 Unauthorized response" do
+        expect(status).to eq(401)
+      end
+    end
   end
 
   post "web_api/v1/onboarding_campaigns/:campaign_name/dismissal" do


### PR DESCRIPTION
No Changelog entry, as no visible change for user

- [x] Tests
- [x] Prepared branch for code review

In [recent work](https://github.com/CitizenLabDotCo/citizenlab/commit/be5b533f6bf3c5661669b9e1dfb80a1db951281a) on Navbar Items, the `secure_contoller` was replaced in many controller files with the line `skip_before_action :authenticate_user`, with the plan that these lines could be incrementally improved over time.

In the case of the `back/engines/free/onboarding/app/controllers/onboarding/web_api/v1/campaigns_controller.rb` this change resulted in [an error](https://sentry.hq.citizenlab.co/organizations/citizenlab/issues/32689/?project=2&referrer=jira_integration) when the `current` action was called after the user had logged out:
```
Pundit::NotDefinedError Onboarding::WebApi::V1::CampaignsController#current
unable to find policy `NilClassPolicy` for `nil`
```
This occurred because the value for `current_user` was nil at this point in the flow.

Removing the line `skip_before_action :authenticate_user` results in authentication being required, and thus the error no longer appears in the response, instead we get a `401 Unauthorized` response. A simple test is also added to detect regression on this issue.

## How urgent is a code review?

Not urgent.
