### PR TITLE
CL-149 Bugfix: Enforce authorization of call to locked_attributes index action

### DIFF
--- a/back/engines/commercial/verification/app/controllers/verification/web_api/v1/locked_attributes_controller.rb
+++ b/back/engines/commercial/verification/app/controllers/verification/web_api/v1/locked_attributes_controller.rb
@@ -2,7 +2,6 @@ module Verification
   module WebApi
     module V1
       class LockedAttributesController < VerificationController
-        skip_before_action :authenticate_user
         skip_after_action :verify_policy_scoped
 
         def index

--- a/back/engines/commercial/verification/spec/acceptance/locked_attributes_spec.rb
+++ b/back/engines/commercial/verification/spec/acceptance/locked_attributes_spec.rb
@@ -19,10 +19,22 @@ resource "Users - Locked attributes" do
       parameter :size, "Number of verification methods per page"
     end
 
-    example_request "List locked built-in attributes for authenticated user" do
-      expect(status).to eq(200)
-      json_response = json_parse(response_body)
-      expect(json_response[:data].map{|d| d[:attributes][:name]}).to eq ['first_name', 'last_name']
+    context 'for an authenticated user' do
+      example_request "List locked built-in attributes" do
+        expect(status).to eq(200)
+        json_response = json_parse(response_body)
+        expect(json_response[:data].map{|d| d[:attributes][:name]}).to eq ['first_name', 'last_name']
+      end
+    end
+
+    context "for an unauthenticated user" do
+      before do
+        header 'Authorization', nil
+      end
+
+      example_request "[error] returns 401 Unauthorized response" do
+        expect(status).to eq(401)
+      end
     end
   end
 end


### PR DESCRIPTION
No Changelog entry, as no visible change for user

- [x] Tests
- [x] Prepared branch for code review

In [recent work](https://github.com/CitizenLabDotCo/citizenlab/commit/be5b533f6bf3c5661669b9e1dfb80a1db951281a) on Navbar Items, the `secure_contoller` was replaced in many controller files with the line `skip_before_action :authenticate_user`, with the plan that these lines could be incrementally improved over time.

In the case of the [`locked_attributes` controller](https://github.com/CitizenLabDotCo/citizenlab/blob/master/back/engines/commercial/verification/app/controllers/verification/web_api/v1/locked_attributes_controller.rb) this change resulted in [an error](https://sentry.hq.citizenlab.co/organizations/citizenlab/issues/32690/events/02bb5dda0cd64c10a1a775f84af04e1d/?project=2) when the `index` action was called after the user had logged out:
```
NoMethodError
undefined method 'verifications' for nil:NilClass
```
This occurred because the value for `current_user` was nil at this point in the flow.

Removing the line `skip_before_action :authenticate_user` results in authentication being required, and thus the error no longer appears in the response, instead we get a `401 Unauthorized` response. A simple test is also added to detect regression on this issue.

For reasoning as to why I have not attempted to optimize by removing the FE call to this endpoint when the user logs out, and why this `401 Unauthorised` response is acceptable, see this [Slack thread](https://citizenlabco.slack.com/archives/CQAGMHKT3/p1644941674052069).

This fix is very similar to the recent fix in [EN-1646 Enforce authorization of onboarding campaigns](https://github.com/CitizenLabDotCo/citizenlab/pull/1491).

## How urgent is a code review?

Not urgent.
