### PR TITLE
[CL-208] Add map layer ordering attribute

### DIFF
--- a/back/engines/commercial/admin_api/app/serializers/layer_serializer.rb
+++ b/back/engines/commercial/admin_api/app/serializers/layer_serializer.rb
@@ -1,0 +1,5 @@
+class LayerSerializer
+  include FastJsonapi::ObjectSerializer
+
+  attributes :title_multiloc, :geojson, :default_enabled, :marker_svg_url, :ordering, :id
+end

--- a/back/engines/commercial/admin_api/app/serializers/layer_serializer.rb
+++ b/back/engines/commercial/admin_api/app/serializers/layer_serializer.rb
@@ -1,5 +1,0 @@
-class LayerSerializer
-  include FastJsonapi::ObjectSerializer
-
-  attributes :title_multiloc, :geojson, :default_enabled, :marker_svg_url, :ordering, :id
-end

--- a/back/engines/commercial/admin_api/app/serializers/map_config_serializer.rb
+++ b/back/engines/commercial/admin_api/app/serializers/map_config_serializer.rb
@@ -1,8 +1,0 @@
-class MapConfigSerializer
-  include FastJsonapi::ObjectSerializer
-
-  attributes :project_id, :zoom_level, :tile_provider
-  attribute :center, &:center_geojson
-
-  has_many :layers
-end

--- a/back/engines/commercial/custom_maps/app/controllers/custom_maps/web_api/v1/map_configs_controller.rb
+++ b/back/engines/commercial/custom_maps/app/controllers/custom_maps/web_api/v1/map_configs_controller.rb
@@ -46,8 +46,8 @@ module CustomMaps
         end
 
         def serialized_map_config
-          CustomMaps::WebApi::V1::MapConfigSerializer.new(@map_config, params: fastjson_params)
-                                               .serialized_json
+          CustomMaps::WebApi::V1::MapConfigSerializer.new(@map_config, params: fastjson_params, include: [:layers, :legend_items])
+            .serialized_json
         end
 
         def map_config_params

--- a/back/engines/commercial/custom_maps/app/controllers/custom_maps/web_api/v1/map_configs_controller.rb
+++ b/back/engines/commercial/custom_maps/app/controllers/custom_maps/web_api/v1/map_configs_controller.rb
@@ -46,8 +46,8 @@ module CustomMaps
         end
 
         def serialized_map_config
-          CustomMaps::WebApi::V1::MapConfigSerializer.new(@map_config, params: fastjson_params, include: [:layers, :legend_items])
-            .serialized_json
+          CustomMaps::WebApi::V1::MapConfigSerializer.new(@map_config, params: fastjson_params, include: %i[layers legend_items])
+                                                     .serialized_json
         end
 
         def map_config_params

--- a/back/engines/commercial/custom_maps/app/serializers/custom_maps/web_api/v1/legend_item_serializer.rb
+++ b/back/engines/commercial/custom_maps/app/serializers/custom_maps/web_api/v1/legend_item_serializer.rb
@@ -1,0 +1,10 @@
+module CustomMaps
+  module WebApi
+    module V1
+      class LegendItemSerializer
+        include FastJsonapi::ObjectSerializer
+        attributes :title_multiloc, :color
+      end
+    end
+  end
+end

--- a/back/engines/commercial/custom_maps/app/serializers/custom_maps/web_api/v1/map_config_serializer.rb
+++ b/back/engines/commercial/custom_maps/app/serializers/custom_maps/web_api/v1/map_config_serializer.rb
@@ -2,24 +2,6 @@ class CustomMaps::WebApi::V1::MapConfigSerializer < ::WebApi::V1::BaseSerializer
   attributes :zoom_level, :tile_provider, :center_geojson
   belongs_to :project
 
-  attribute :layers do |map_config, params|
-    map_config.layers.map do |layer|
-      {
-        title_multiloc: layer.title_multiloc,
-        geojson: layer.geojson,
-        default_enabled: layer.default_enabled,
-        marker_svg_url: layer.marker_svg_url,
-        id: layer.id
-      }
-    end
-  end
-
-  attribute :legend do |map_config|
-    map_config.legend_items.map do |legend_item|
-      {
-        title_multiloc: legend_item.title_multiloc,
-        color: legend_item.color
-      }
-    end
-  end
+  has_many :layers
+  has_many :legend_items
 end

--- a/back/engines/commercial/custom_maps/spec/acceptance/map_configs_spec.rb
+++ b/back/engines/commercial/custom_maps/spec/acceptance/map_configs_spec.rb
@@ -29,15 +29,20 @@ resource 'Map Configs' do
       example_request 'Get the map config of a project' do
         expect(status).to eq 200
 
-        expect(attributes['center_geojson']).to eq(map_config.center_geojson)
         expect(attributes['tile_provider']).to eq map_config.tile_provider
         expect(attributes['zoom_level']).to eq map_config.zoom_level.to_s
-        expect(attributes['layers'][0]['title_multiloc']).to eq map_config.layers.first.title_multiloc
-        expect(attributes['layers'][0]['geojson']).to eq map_config.layers.first.geojson
-        expect(attributes['layers'][0]['default_enabled']).to eq map_config.layers.first.default_enabled
-        expect(attributes['layers'][0]['marker_svg_url']).to eq map_config.layers.first.marker_svg_url
-        expect(attributes['legend'][0]['title_multiloc']).to eq map_config.legend_items.first.title_multiloc
-        expect(attributes['legend'][0]['color']).to eq map_config.legend_items.first.color
+
+        first_layer = json_response.fetch("included").select{ |inc| inc.fetch("type") == "layer" }.first
+        first_legend_item = json_response.fetch("included").select{|inc| inc.fetch("type") == "legend_item" }.first
+
+        expect(first_layer.dig('attributes', 'default_enabled')).to eq map_config.layers.first.default_enabled
+        expect(first_layer.dig('attributes', 'geojson')).to eq map_config.layers.first.geojson
+        expect(first_layer.dig('attributes', 'marker_svg_url')).to eq map_config.layers.first.marker_svg_url
+        expect(first_layer.dig('attributes', 'ordering')).to eq map_config.layers.first.ordering
+        expect(first_layer.dig('attributes', 'title_multiloc')).to eq map_config.layers.first.title_multiloc
+
+        expect(first_legend_item.dig('attributes', 'color')).to eq map_config.legend_items.first.color
+        expect(first_legend_item.dig('attributes', 'title_multiloc')).to eq map_config.legend_items.first.title_multiloc
       end
     end
   end

--- a/back/engines/commercial/custom_maps/spec/acceptance/map_configs_spec.rb
+++ b/back/engines/commercial/custom_maps/spec/acceptance/map_configs_spec.rb
@@ -32,8 +32,8 @@ resource 'Map Configs' do
         expect(attributes['tile_provider']).to eq map_config.tile_provider
         expect(attributes['zoom_level']).to eq map_config.zoom_level.to_s
 
-        first_layer = json_response.fetch("included").select{ |inc| inc.fetch("type") == "layer" }.first
-        first_legend_item = json_response.fetch("included").select{|inc| inc.fetch("type") == "legend_item" }.first
+        first_layer = json_response.fetch('included').find { |inc| inc.fetch('type') == 'layer' }
+        first_legend_item = json_response.fetch('included').find { |inc| inc.fetch('type') == 'legend_item' }
 
         expect(first_layer.dig('attributes', 'default_enabled')).to eq map_config.layers.first.default_enabled
         expect(first_layer.dig('attributes', 'geojson')).to eq map_config.layers.first.geojson

--- a/back/engines/commercial/custom_maps/spec/acceptance/map_layers_spec.rb
+++ b/back/engines/commercial/custom_maps/spec/acceptance/map_layers_spec.rb
@@ -299,7 +299,6 @@ resource 'Map Layers' do
     end
   end
 
-
   context 'when logged in as a project manager' do
     before do
       header_token_for(create(:user, roles: [{ 'type' => 'project_moderator', 'project_id' => project.id }]))

--- a/back/engines/commercial/custom_maps/spec/models/map_config_spec.rb
+++ b/back/engines/commercial/custom_maps/spec/models/map_config_spec.rb
@@ -9,5 +9,4 @@ RSpec.describe CustomMaps::MapConfig, type: :model do
       expect(map_config).to be_valid
     end
   end
-
 end


### PR DESCRIPTION
This PR adds the `ordering` attribute to the `layers`association when fetching a `map_config` via it's designated endpoint.

@luucvanderzee The `layers` and `legends` used to be included as normal attributes, but they are actual relationships which I took the liberty to improve as well. This means that they have to be fetched like a proper relation in the API response now.

## Checklist

- [ ] Added entry to changelog
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

- [x] Tests
<details>
<summary>More info</summary>

### Unit tests

Did you add relevant unit tests?

### E2E tests

Sometimes it can be more efficient to update E2E tests after CI has run them. If you know which ones to update, go ahead! E2E template cl2-back:

```bash
docker compose run --rm web bin/rails cl2_back:create_tenant[localhost,e2etests_template]
```

</details>

- [ ] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## Links

- [citizenlab-ee PR](**put URL here** or remove)
- [Specs](**put URL here** or remove)
- [Epic Deployment](**put URL here** or remove)

## How urgent is a code review?

Let the reviewer(s) know how urgent the code review is, so they can prioritize their work accordingly. Be specific (e.g. by Wednesday, end of the day/this week/... is better than 'urgent' or 'very urgent'). Optionally provide a word of explanation on your deadline.
