### PR TITLE
Fix failing e2e tests

### DIFF
--- a/front/app/components/InitiativeCards/ProposalsList.tsx
+++ b/front/app/components/InitiativeCards/ProposalsList.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { adopt } from 'react-adopt';
 import { isNilOrError } from 'utils/helperUtils';
 // tracks
 import { trackEventByName } from 'utils/analytics';
@@ -10,9 +9,7 @@ import InitiativeCard from 'components/InitiativeCard';
 import { Spinner, Button } from '@citizenlab/cl2-component-library';
 
 // resources
-import GetInitiatives, {
-  GetInitiativesChildProps,
-} from 'resources/GetInitiatives';
+import { IInitiativeData } from 'services/initiatives';
 
 // i18n
 import messages from './messages';
@@ -82,27 +79,33 @@ const StyledInitiativeCard = styled(InitiativeCard)`
   `};
 `;
 
-interface InputProps {
+interface Props {
   id: string;
   ariaLabelledBy: string;
+  querying: boolean;
+  hasMore: boolean;
+  loadingMore: boolean;
+  list: IInitiativeData[];
+  onLoadMore(): void;
 }
 
-interface DataProps {
-  initiatives: GetInitiativesChildProps;
-}
-
-interface Props extends InputProps, DataProps {}
-
-const ProposalsList = ({ initiatives, ariaLabelledBy, id }: Props) => {
+const ProposalsList = ({
+  list,
+  hasMore,
+  loadingMore,
+  ariaLabelledBy,
+  id,
+  onLoadMore,
+  querying,
+}: Props) => {
   const theme: any = useTheme();
   const locale = useLocale();
   const loadMore = () => {
     trackEventByName(tracks.loadMoreProposals);
-    initiatives.onLoadMore();
+    onLoadMore();
   };
 
-  if (!isNilOrError(initiatives) && !isNilOrError(locale)) {
-    const { querying, hasMore, loadingMore, list } = initiatives;
+  if (!isNilOrError(locale)) {
     const hasInitiatives = list && list.length > 0;
 
     return (
@@ -153,14 +156,4 @@ const ProposalsList = ({ initiatives, ariaLabelledBy, id }: Props) => {
   return null;
 };
 
-const Data = adopt<DataProps, InputProps>({
-  initiatives: (
-    <GetInitiatives type="load-more" publicationStatus="published" />
-  ),
-});
-
-export default (inputProps: InputProps) => (
-  <Data {...inputProps}>
-    {(dataProps: DataProps) => <ProposalsList {...inputProps} {...dataProps} />}
-  </Data>
-);
+export default ProposalsList;

--- a/front/app/components/InitiativeCards/index.tsx
+++ b/front/app/components/InitiativeCards/index.tsx
@@ -406,7 +406,7 @@ class InitiativeCards extends PureComponent<Props & InjectedIntlProps, State> {
       className,
       invisibleTitleMessage,
     } = this.props;
-    const { list, querying } = initiatives;
+    const { list, querying, onLoadMore, hasMore, loadingMore } = initiatives;
     const hasInitiatives = !isNilOrError(list) && list.length > 0;
     const biggerThanLargeTablet =
       windowSize && windowSize >= viewportWidths.largeTablet;
@@ -589,6 +589,11 @@ class InitiativeCards extends PureComponent<Props & InjectedIntlProps, State> {
                       <ProposalsList
                         ariaLabelledBy={'view-tab-1'}
                         id={'view-panel-1'}
+                        hasMore={hasMore}
+                        loadingMore={loadingMore}
+                        querying={querying}
+                        onLoadMore={onLoadMore}
+                        list={list}
                       />
                     )}
 

--- a/front/app/containers/InitiativesShow/VoteControl/ProposedNotVoted.tsx
+++ b/front/app/containers/InitiativesShow/VoteControl/ProposedNotVoted.tsx
@@ -163,10 +163,6 @@ const ProposedNotVoted = ({
   disabledReason,
 }: Props) => {
   const theme: any = useTheme();
-  const handleOnVote = () => {
-    onVote();
-  };
-
   const voteCount = initiative.attributes.upvotes_count;
   const voteLimit = voting_threshold;
   const daysLeft = getDaysRemainingUntil(initiative.attributes.expires_at);
@@ -263,7 +259,7 @@ const ProposedNotVoted = ({
             aria-describedby="tooltip-content"
             disabled={!!tippyContent}
             buttonStyle="primary"
-            onClick={handleOnVote}
+            onClick={onVote}
             id="e2e-initiative-upvote-button"
             ariaDisabled={false}
           >

--- a/front/app/containers/InitiativesShow/VoteControl/ProposedNotVoted.tsx
+++ b/front/app/containers/InitiativesShow/VoteControl/ProposedNotVoted.tsx
@@ -1,6 +1,6 @@
-import React, { PureComponent } from 'react';
+import React from 'react';
 
-import styled from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 import { colors, fontSizes, media } from 'utils/styleUtils';
 import { StatusExplanation } from './SharedStyles';
 import { getDaysRemainingUntil } from 'utils/dateUtils';
@@ -156,124 +156,123 @@ const disabledMessages: {
   notPermitted: messages.votingNotPermitted,
 };
 
-class ProposedNotVoted extends PureComponent<Props & { theme: any }> {
-  handleOnVote = () => {
-    this.props.onVote();
+const ProposedNotVoted = ({
+  onVote,
+  initiative,
+  initiativeSettings: { voting_threshold, threshold_reached_message },
+  disabledReason,
+}: Props) => {
+  const theme: any = useTheme();
+  const handleOnVote = () => {
+    onVote();
   };
 
-  render() {
-    const {
-      initiative,
-      initiativeSettings: { voting_threshold, threshold_reached_message },
-      disabledReason,
-    } = this.props;
-    const voteCount = initiative.attributes.upvotes_count;
-    const voteLimit = voting_threshold;
-    const daysLeft = getDaysRemainingUntil(initiative.attributes.expires_at);
+  const voteCount = initiative.attributes.upvotes_count;
+  const voteLimit = voting_threshold;
+  const daysLeft = getDaysRemainingUntil(initiative.attributes.expires_at);
 
-    const thresholdReachedTooltip = threshold_reached_message ? (
-      <IconTooltip
-        icon="info"
-        iconColor={this.props.theme.colorText}
-        theme="light"
+  const thresholdReachedTooltip = threshold_reached_message ? (
+    <IconTooltip
+      icon="info"
+      iconColor={theme.colorText}
+      theme="light"
+      placement="bottom"
+      content={<T value={threshold_reached_message} supportHtml />}
+    />
+  ) : (
+    <></>
+  );
+
+  const tippyContent = disabledReason ? (
+    <TooltipContent id="tooltip-content" className="e2e-disabled-tooltip">
+      <TooltipContentIcon name="lock-outlined" ariaHidden />
+      <TooltipContentText>
+        <FormattedMessage {...disabledMessages[disabledReason]} />
+      </TooltipContentText>
+    </TooltipContent>
+  ) : null;
+
+  return (
+    <Container>
+      <CountDownWrapper>
+        <CountDown targetTime={initiative.attributes.expires_at} />
+      </CountDownWrapper>
+      <StatusIcon ariaHidden name="bullseye" />
+      <StatusExplanation>
+        <OnDesktop>
+          <FormattedMessage
+            {...messages.proposedStatusExplanation}
+            values={{
+              votingThreshold: voting_threshold,
+              proposedStatusExplanationBold: (
+                <b>
+                  <FormattedMessage
+                    {...messages.proposedStatusExplanationBold}
+                  />
+                </b>
+              ),
+            }}
+          />
+          {thresholdReachedTooltip}
+        </OnDesktop>
+        <OnMobile>
+          <FormattedMessage
+            {...messages.proposedStatusExplanationMobile}
+            values={{
+              daysLeft,
+              votingThreshold: voting_threshold,
+              proposedStatusExplanationMobileBold: (
+                <b>
+                  <FormattedMessage
+                    {...messages.proposedStatusExplanationMobileBold}
+                  />
+                </b>
+              ),
+            }}
+          />
+          {thresholdReachedTooltip}
+        </OnMobile>
+      </StatusExplanation>
+      <VoteCounter>
+        <VoteText aria-hidden={true}>
+          <VoteTextLeft id="e2e-initiative-not-voted-vote-count">
+            <FormattedMessage
+              {...messages.xVotes}
+              values={{ count: voteCount }}
+            />
+          </VoteTextLeft>
+          <VoteTextRight>{voteLimit}</VoteTextRight>
+        </VoteText>
+        <ProposalProgressBar voteCount={voteCount} voteLimit={voteLimit} />
+      </VoteCounter>
+      <Tippy
+        disabled={!tippyContent}
         placement="bottom"
-        content={<T value={threshold_reached_message} supportHtml />}
-      />
-    ) : (
-      <></>
-    );
-
-    const tippyContent = disabledReason ? (
-      <TooltipContent id="tooltip-content" className="e2e-disabled-tooltip">
-        <TooltipContentIcon name="lock-outlined" ariaHidden />
-        <TooltipContentText>
-          <FormattedMessage {...disabledMessages[disabledReason]} />
-        </TooltipContentText>
-      </TooltipContent>
-    ) : null;
-
-    return (
-      <Container>
-        <CountDownWrapper>
-          <CountDown targetTime={initiative.attributes.expires_at} />
-        </CountDownWrapper>
-        <StatusIcon ariaHidden name="bullseye" />
-        <StatusExplanation>
-          <OnDesktop>
-            <FormattedMessage
-              {...messages.proposedStatusExplanation}
-              values={{
-                votingThreshold: voting_threshold,
-                proposedStatusExplanationBold: (
-                  <b>
-                    <FormattedMessage
-                      {...messages.proposedStatusExplanationBold}
-                    />
-                  </b>
-                ),
-              }}
-            />
-            {thresholdReachedTooltip}
-          </OnDesktop>
-          <OnMobile>
-            <FormattedMessage
-              {...messages.proposedStatusExplanationMobile}
-              values={{
-                daysLeft,
-                votingThreshold: voting_threshold,
-                proposedStatusExplanationMobileBold: (
-                  <b>
-                    <FormattedMessage
-                      {...messages.proposedStatusExplanationMobileBold}
-                    />
-                  </b>
-                ),
-              }}
-            />
-            {thresholdReachedTooltip}
-          </OnMobile>
-        </StatusExplanation>
-        <VoteCounter>
-          <VoteText aria-hidden={true}>
-            <VoteTextLeft id="e2e-initiative-not-voted-vote-count">
-              <FormattedMessage
-                {...messages.xVotes}
-                values={{ count: voteCount }}
-              />
-            </VoteTextLeft>
-            <VoteTextRight>{voteLimit}</VoteTextRight>
-          </VoteText>
-          <ProposalProgressBar voteCount={voteCount} voteLimit={voteLimit} />
-        </VoteCounter>
-        <Tippy
-          disabled={!tippyContent}
-          placement="bottom"
-          content={tippyContent || <></>}
-          theme="light"
-          hideOnClick={false}
+        content={tippyContent || <></>}
+        theme="light"
+        hideOnClick={false}
+      >
+        <div
+          tabIndex={tippyContent ? 0 : -1}
+          className={`${tippyContent ? 'disabled' : ''} ${
+            disabledReason ? disabledReason : ''
+          }`}
         >
-          <div
-            tabIndex={tippyContent ? 0 : -1}
-            className={`${tippyContent ? 'disabled' : ''} ${
-              disabledReason ? disabledReason : ''
-            }`}
+          <StyledButton
+            icon="upvote"
+            aria-describedby="tooltip-content"
+            disabled={!!tippyContent}
+            buttonStyle="primary"
+            onClick={handleOnVote}
+            id="e2e-initiative-upvote-button"
+            ariaDisabled={false}
           >
-            <StyledButton
-              icon="upvote"
-              aria-describedby="tooltip-content"
-              disabled={!!tippyContent}
-              buttonStyle="primary"
-              onClick={this.handleOnVote}
-              id="e2e-initiative-upvote-button"
-              ariaDisabled={false}
-            >
-              <FormattedMessage {...messages.vote} />
-            </StyledButton>
-          </div>
-        </Tippy>
-      </Container>
-    );
-  }
-}
+            <FormattedMessage {...messages.vote} />
+          </StyledButton>
+        </div>
+      </Tippy>
+    </Container>
+  );
+};
 
 export default ProposedNotVoted;


### PR DESCRIPTION
There was a data mismatch between InitiativeCards and its child component ProposalsList (e.g. the search function in the initiative cards doesn't affect data loading in the proposals list). A solution could have been to pass the search term, filters, etc. through to the proposals list, but just passing the resulting data to ProposalsList is the fastest solution.

The other problem was a missing theme prop.