### PR TITLE
[CL-359] Create unique issuer strings for each Vienna Login environment

### DIFF
--- a/back/engines/commercial/id_vienna_saml/app/lib/id_vienna_saml/id_vienna_saml_omniauth.rb
+++ b/back/engines/commercial/id_vienna_saml/app/lib/id_vienna_saml/id_vienna_saml_omniauth.rb
@@ -8,7 +8,7 @@ module IdViennaSaml
         metadata_xml_file: File.join(IdViennaSaml::Engine.root, 'config', 'idp_metadata_test.xml')
       },
       production: {
-        issuer: 'CitizenLab Wien',
+        issuer: 'CitizenLabWien',
         metadata_xml_file: File.join(IdViennaSaml::Engine.root, 'config', 'idp_metadata_production.xml')
       }
     }.freeze

--- a/back/engines/commercial/id_vienna_saml/app/lib/id_vienna_saml/id_vienna_saml_omniauth.rb
+++ b/back/engines/commercial/id_vienna_saml/app/lib/id_vienna_saml/id_vienna_saml_omniauth.rb
@@ -1,7 +1,17 @@
 module IdViennaSaml
   # Provides a SAML Omniauth configuration for Vienna's StandardPortal.
   class IdViennaSamlOmniauth
-    FIXED_METADATA = { issuer: 'CitizenLab' }.freeze
+    # The Issuer is hardcoded on Vienna's side and needs to match exactly.
+    ENVIRONMENTS = {
+      test: {
+        issuer: 'CitizenLab',
+        metadata_xml_file: File.join(IdViennaSaml::Engine.root, 'config', 'idp_metadata_test.xml')
+      },
+      production: {
+        issuer: 'CitizenLab Wien',
+        metadata_xml_file: File.join(IdViennaSaml::Engine.root, 'config', 'idp_metadata_production.xml')
+      }
+    }.freeze
 
     # Extracts user attributes from the Omniauth response auth.
     # @param [OmniAuth::AuthHash] auth
@@ -20,14 +30,17 @@ module IdViennaSaml
     # Configures the SAML endpoint to authenticate with Vienna's StandardPortal
     # if the feature is enabled.
     # Most of the settings are read from the XML file that Vienna shared with us.
-    # The issuer though needs to be hard-coded to 'CitizenLab'.
     # @param [AppConfiguration] configuration
     def omniauth_setup(configuration, env)
       return unless configuration.feature_activated?('vienna_login')
 
+      metadata_file = ENVIRONMENTS.dig(vienna_login_env, :metadata_xml_file)
+      issuer = ENVIRONMENTS.dig(vienna_login_env, :issuer)
+
       idp_metadata_parser = OneLogin::RubySaml::IdpMetadataParser.new
-      idp_metadata = idp_metadata_parser.parse_to_hash(idp_metadata_xml)
-      metadata = idp_metadata.merge(FIXED_METADATA)
+      idp_metadata = idp_metadata_parser.parse_to_hash(File.read(metadata_file))
+
+      metadata = idp_metadata.merge({ issuer: issuer })
 
       env['omniauth.strategy'].options.merge!(metadata)
     end
@@ -53,22 +66,9 @@ module IdViennaSaml
       "#{configuration.base_backend_uri}/auth/saml/callback"
     end
 
-    def idp_metadata_xml
-      File.read(idp_metadata_xml_file)
-    end
-
-    # Returns the XML file that contains the Metatdata of the SAML IdP based
-    # on the configured environment
-    def idp_metadata_xml_file
-      env = AppConfiguration.instance.settings('vienna_login', 'environment')
-      case env
-      when 'test'
-        File.join(IdViennaSaml::Engine.root, 'config', 'idp_metadata_test.xml')
-      when 'production'
-        File.join(IdViennaSaml::Engine.root, 'config', 'idp_metadata_production.xml')
-      else
-        raise "No Idp metadata known for vienna_login env: #{env}"
-      end
+    # @return [Symbol] The configured Vienna Login environment as a symbol
+    def vienna_login_env
+      AppConfiguration.instance.settings('vienna_login', 'environment').to_sym
     end
   end
 end


### PR DESCRIPTION
Using the same issuer name for multiple endpoints / environments will generate an error in the auth process on Vienna's side.

They need to be unique, so we settled on 'CitizenLabWien' for the current production deployment and 'CitizenLab' for test env.

## Checklist

- [ ] Added entry to changelog
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

- [ ] WCAG 2.1 AA proof
<details>
<summary>More info</summary>
For front-end devs only. Is your work conforming with the WCAG 2.1 AA rules? If you need more info, read the [a11y page](https://www.notion.so/citizenlab/a11y-7568f83d42ab4895ac133b89d358997b) on our Notion.
</details>

- [ ] Tests
<details>
<summary>More info</summary>

### Unit tests

Did you add relevant unit tests?

### E2E tests

Sometimes it can be more efficient to update E2E tests after CI has run them. If you know which ones to update, go ahead! E2E template cl2-back:

```bash
docker compose run --rm web bin/rails cl2_back:create_tenant[localhost,e2etests_template]
```

</details>

- [ ] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## Links

- [citizenlab-ee PR](**put URL here** or remove)
- [Specs](**put URL here** or remove)
- [Epic Deployment](**put URL here** or remove)

## How urgent is a code review?

Let the reviewer(s) know how urgent the code review is, so they can prioritize their work accordingly. Be specific (e.g. by Wednesday, end of the day/this week/... is better than 'urgent' or 'very urgent'). Optionally provide a word of explanation on your deadline.
