### PR TITLE
[No ticket] Upgrade to rspec-rails 5.1

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -44,7 +44,7 @@ group :development, :test do
   gem 'rack-mini-profiler', require: ['prepend_net_http_patch', 'rack-mini-profiler']
   gem 'rspec_api_documentation'
   gem 'rspec_junit_formatter'
-  gem 'rspec-rails', '~> 5.0.2'
+  gem 'rspec-rails', '~> 5.1.0'
   gem 'rspec-parameterized'
   gem 'rspec-sqlimit'
   gem 'rubocop-ast', '~> 0.7.1', require: false

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -573,7 +573,7 @@ GEM
     database_cleaner (1.7.0)
     debug_inspector (1.0.0)
     declarative (0.0.20)
-    diff-lcs (1.4.4)
+    diff-lcs (1.5.0)
     docile (1.4.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
@@ -725,7 +725,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.12.0)
+    loofah (2.14.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -745,7 +745,7 @@ GEM
       rake
     mini_magick (4.11.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.6.1)
+    mini_portile2 (2.8.0)
     minitest (5.15.0)
     mjml-rails (4.4.0)
     mprelude (0.1.0)
@@ -764,8 +764,8 @@ GEM
       ruby2_keywords (~> 0.0.1)
     netrc (0.11.0)
     nio4r (2.5.8)
-    nokogiri (1.12.5)
-      mini_portile2 (~> 2.6.1)
+    nokogiri (1.13.3)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     nori (2.6.0)
     oauth2 (1.4.7)
@@ -928,12 +928,12 @@ GEM
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
       rspec-mocks (~> 3.10.0)
-    rspec-core (3.10.1)
+    rspec-core (3.10.2)
       rspec-support (~> 3.10.0)
-    rspec-expectations (3.10.1)
+    rspec-expectations (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
-    rspec-mocks (3.10.2)
+    rspec-mocks (3.10.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-parameterized (0.5.0)
@@ -942,7 +942,7 @@ GEM
       proc_to_ast
       rspec (>= 2.13, < 4)
       unparser
-    rspec-rails (5.0.2)
+    rspec-rails (5.1.0)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       railties (>= 5.2)
@@ -1224,7 +1224,7 @@ DEPENDENCIES
   rinku (~> 2)
   ros-apartment
   rspec-parameterized
-  rspec-rails (~> 5.0.2)
+  rspec-rails (~> 5.1.0)
   rspec-sqlimit
   rspec_api_documentation
   rspec_junit_formatter


### PR DESCRIPTION
Changelog: https://github.com/rspec/rspec-rails/blob/main/Changelog.md

```
Development

Full Changelog
5.1.0 / 2022-01-26

Full Changelog

Enhancements:

    Make the API request scaffold template more consistent and compatible with Rails 6.1. (Naoto Hamada, #2484)
    Change the scaffold rails_helper.rb template to use require_relative. (Jon Dufresne, #2528)
```
