### PR TITLE
[CL-337] Fix failure of FranceConnect test login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Can now re-use tenant host URL immediately the tenant is deleted.
 - Relevant error(s) now returned when tenant creation fails, for example due to host URL already being in use.
 - Added temporary fix for the project page without permissions error where it doesn't recover after sign in.
+- FranceConnect test login
 
 ## 2022-02-28
 

--- a/back/engines/commercial/id_franceconnect/config/initializers/httpclient_patch.rb
+++ b/back/engines/commercial/id_franceconnect/config/initializers/httpclient_patch.rb
@@ -1,0 +1,18 @@
+# Copied from https://gitlab.com/gitlab-org/gitlab-foss/-/merge_requests/30749
+
+# By default, httpclient (and hence anything that uses rack-oauth2)
+# ignores the system-wide SSL certificate configuration in favor of its
+# own cacert.pem. This makes it impossible to use custom certificates
+# without patching that file. Until
+# https://github.com/nahi/httpclient/pull/386 is merged, we work around
+# this limitation by forcing the HTTPClient SSL store to use the default
+# system configuration.
+module HTTPClient::SSLConfigDefaultPaths
+  def initialize(client)
+    super
+
+    set_default_paths
+  end
+end
+
+HTTPClient::SSLConfig.prepend HTTPClient::SSLConfigDefaultPaths


### PR DESCRIPTION
Steps to reproduce:

It works (ruby code)
`curl -XPOST https://fcp.integ01.dev-franceconnect.fr/api/v1/token`

It doesn't work (ruby code)
`gem install httpclient`
require 'httpclient'
HTTPClient.new.post('https://fcp.integ01.dev-franceconnect.fr/api/v1/token')

More details
https://citizenlabco.slack.com/archives/C015M14HYSF/p1646385968195309

## Checklist

- [x] Added entry to changelog
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

- [x] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## How urgent is a code review?

Maybe better to test it this week.
