### PR TITLE
[CL-336] Use only user name in FranceConnect instead of full profile scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
+## New
+
 ### Changed
 
 - Fixed issue with folder page responsiveness where right hand side gets cropped.
+- Use only user name in FranceConnect instead of full profile scope
 
 ## 2022-03-04
 

--- a/back/engines/commercial/id_franceconnect/app/lib/id_franceconnect/franceconnect_omniauth.rb
+++ b/back/engines/commercial/id_franceconnect/app/lib/id_franceconnect/franceconnect_omniauth.rb
@@ -1,3 +1,5 @@
+# FranceConnect works locally with any of these identifiers
+# https://github.com/france-connect/identity-provider-example/blob/master/database.csv
 module IdFranceconnect
   class FranceconnectOmniauth
     include FranceconnectVerification
@@ -9,16 +11,8 @@ module IdFranceconnect
         email: auth.info['email'],
         last_name: auth.info['last_name'].titleize, # FC returns last names in ALL CAPITALS
         locale: AppConfiguration.instance.closest_locale_to('fr-FR'),
-        remote_avatar_url: auth.info['image'],
-      }.tap do |attrs|
-        custom_fields = CustomField.with_resource_type('User').enabled.pluck(:code)
-        if custom_fields.include?('birthyear')
-          attrs[:birthyear] = (Date.parse(auth.extra.raw_info.birthdate)&.year rescue nil)
-        end
-        if custom_fields.include?('gender')
-          attrs[:gender] = auth.extra.raw_info.gender
-        end
-      end
+        remote_avatar_url: auth.info['image']
+      }
     end
 
     # @param [AppConfiguration] configuration
@@ -26,7 +20,7 @@ module IdFranceconnect
       return unless configuration.feature_activated?('franceconnect_login')
 
       env['omniauth.strategy'].options.merge!(
-        scope: [:openid, :profile, :email],
+        scope: %i[openid given_name family_name email],
         response_type: :code,
         state: true, # required by France connect
         nonce: true, # required by France connect

--- a/back/engines/commercial/id_franceconnect/app/lib/id_franceconnect/franceconnect_verification.rb
+++ b/back/engines/commercial/id_franceconnect/app/lib/id_franceconnect/franceconnect_verification.rb
@@ -23,7 +23,7 @@ module IdFranceconnect
     end
 
     def locked_custom_fields
-      [:birthyear]
+      []
     end
   end
 end

--- a/back/engines/commercial/verification/spec/acceptance/locked_attributes_spec.rb
+++ b/back/engines/commercial/verification/spec/acceptance/locked_attributes_spec.rb
@@ -43,20 +43,15 @@ resource "Users - Locked attributes" do
 
   get "web_api/v1/users/custom_fields/json_forms_schema", document: false do
     before do
-      # Franceconnect locks the `birthyear` custom_field
-      create(:custom_field_birthyear)
+      # Bogus locks the `gender` custom_field
       create(:custom_field_gender)
-      create(:verification, method_name: 'franceconnect', user: @user)
+      create(:verification, method_name: 'bogus', user: @user)
     end
 
     example_request "Jsonforms UI schema marks the locked fields" do
       expect(status).to eq 200
       json_response = json_parse(response_body)
-      expect(json_response.dig(:ui_schema_multiloc, :en, :elements).find { |e| e[:scope] === "#/properties/birthyear"}[:options]).to include({
-        readonly: true,
-        verificationLocked: true
-      })
-      expect(json_response.dig(:ui_schema_multiloc, :en, :elements).find { |e| e[:scope] === "#/properties/gender"}[:options].to_h).not_to include({
+      expect(json_response.dig(:ui_schema_multiloc, :en, :elements).find { |e| e[:scope] === "#/properties/gender"}[:options].to_h).to include({
         readonly: true,
         verificationLocked: true
       })

--- a/back/engines/commercial/verification/spec/services/verification_service_spec.rb
+++ b/back/engines/commercial/verification/spec/services/verification_service_spec.rb
@@ -180,10 +180,10 @@ describe Verification::VerificationService do
       end
     end
 
-    context "for a user only verified with franceconnect" do
+    context "for a user only verified with bogus" do
       it "returns some locked custom field keys" do
-        verification = create(:verification, method_name: 'franceconnect')
-        expect(service.locked_custom_fields(verification.user)).to match_array [:birthyear]
+        verification = create(:verification, method_name: 'bogus')
+        expect(service.locked_custom_fields(verification.user)).to match_array [:gender]
       end
     end
   end

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -692,23 +692,15 @@ resource "Users" do
         let(:birthyear_cf) { create(:custom_field_birthyear) }
         let(:custom_field_values) {{
           cf.key => "new value",
-          birthyear_cf.key => 1969,
+          birthyear_cf.key => birthyear
         }}
         let(:first_name) { 'Raymond' }
         let(:last_name) { 'Betancourt' }
         let(:email) { 'ray.mond@rocks.com' }
         let(:locale) { 'fr-FR' }
+        let(:birthyear) { 1969 }
 
-        example "Can't change birthyear of a user verified with FranceConnect", document: false, skip: !CitizenLab.ee? do
-          create(:verification, method_name: 'franceconnect', user: @user)
-          @user.update!(custom_field_values: {cf.key => "original value", birthyear_cf.key => 1950})
-          do_request
-          expect(response_status).to eq 200
-          @user.reload
-          expect(@user.custom_field_values[cf.key]).to eq "new value"
-          expect(@user.custom_field_values[birthyear_cf.key]).to eq 1950
-        end
-  
+
         example "Can change many attributes of a user verified with FranceConnect", document: false, skip: !CitizenLab.ee? do
           create(:verification, method_name: 'franceconnect', user: @user)
           do_request
@@ -718,6 +710,26 @@ resource "Users" do
           expect(@user.last_name).to eq last_name
           expect(@user.email).to eq email
           expect(@user.locale).to eq locale
+          expect(@user.birthyear).to eq birthyear
+        end
+      end
+
+      describe do
+        let(:cf) { create(:custom_field) }
+        let(:gender_cf) { create(:custom_field_gender) }
+        let(:custom_field_values) {{
+          cf.key => "new value",
+          gender_cf.key => 'female'
+        }}
+
+        example "Can't change gender of a user verified with Bogus", document: false, skip: !CitizenLab.ee? do
+          create(:verification, method_name: 'bogus', user: @user)
+          @user.update!(custom_field_values: {cf.key => "original value", gender_cf.key => 'male'})
+          do_request
+          expect(response_status).to eq 200
+          @user.reload
+          expect(@user.custom_field_values[cf.key]).to eq "new value"
+          expect(@user.custom_field_values[gender_cf.key]).to eq 'male'
         end
       end
     end
@@ -755,23 +767,23 @@ resource "Users" do
 
       describe do
         let(:cf) { create(:custom_field) }
-        let(:birthyear_cf) { create(:custom_field_birthyear) }
+        let(:gender_cf) { create(:custom_field_gender) }
         let(:custom_field_values) {{
           cf.key => "new value",
-          birthyear_cf.key => 1969,
+          gender_cf.key => 'female',
         }}
 
-        example "Can't change some custom_field_values of a user verified with FranceConnect", document: false, skip: !CitizenLab.ee? do
+        example "Can't change some custom_field_values of a user verified with Bogus", document: false, skip: !CitizenLab.ee? do
           @user.update!(
             registration_completed_at: nil,
-            custom_field_values: {cf.key => "original value", birthyear_cf.key => 1950}
+            custom_field_values: {cf.key => "original value", gender_cf.key => 'male'}
           )
-          create(:verification, method_name: 'franceconnect', user: @user)
+          create(:verification, method_name: 'bogus', user: @user)
           do_request
           expect(response_status).to eq 200
           @user.reload
           expect(@user.custom_field_values[cf.key]).to eq "new value"
-          expect(@user.custom_field_values[birthyear_cf.key]).to eq 1950
+          expect(@user.custom_field_values[gender_cf.key]).to eq 'male'
         end
       end
     end


### PR DESCRIPTION
As we don't set automatically birthyear and gender anymore,
we do not want to lock them.

Before we removed gender from locked fields as part of this ticket
https://citizenlab.atlassian.net/browse/EN-125

## Checklist

- [x] Added entry to changelog
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

- [x] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## How urgent is a code review?

Blocking our client from launch.