### PR TITLE
CL-390 List users for moderators

### DIFF
--- a/back/app/controllers/web_api/v1/avatars_controller.rb
+++ b/back/app/controllers/web_api/v1/avatars_controller.rb
@@ -7,7 +7,7 @@ class WebApi::V1::AvatarsController < ApplicationController
     avatars_service = AvatarsService.new
 
     limit = [params[:limit]&.to_i || 5, 10].min
-    users = policy_scope(User).active
+    users = User.active
 
     avatars = case params[:context_type]
     when 'project'

--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -1,6 +1,6 @@
 class WebApi::V1::UsersController < ::ApplicationController
   before_action :set_user, only: %i[show update destroy ideas_count initiatives_count comments_count]
-  skip_before_action :authenticate_user, only: %i[create? show? by_slug? by_invite? ideas_count? initiatives_count? comments_count?]
+  skip_before_action :authenticate_user, only: %i[create show by_slug by_invite ideas_count initiatives_count comments_count]
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 

--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -1,6 +1,6 @@
 class WebApi::V1::UsersController < ::ApplicationController
   before_action :set_user, only: %i[show update destroy ideas_count initiatives_count comments_count]
-  skip_before_action :authenticate_user, only: %i[create show by_slug by_invite ideas_count initiatives_count comments_count]
+  skip_before_action :authenticate_user # TODO: temp fix to pass tests
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 

--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -1,6 +1,6 @@
 class WebApi::V1::UsersController < ::ApplicationController
   before_action :set_user, only: %i[show update destroy ideas_count initiatives_count comments_count]
-  skip_before_action :authenticate_user # TODO: temp fix to pass tests
+  skip_before_action :authenticate_user, only: %i[create show by_slug by_invite ideas_count initiatives_count comments_count]
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 

--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -1,13 +1,13 @@
 class WebApi::V1::UsersController < ::ApplicationController
   before_action :set_user, only: %i[show update destroy ideas_count initiatives_count comments_count]
-  skip_after_action :verify_authorized, only: :index_xlsx
   skip_before_action :authenticate_user # TODO: temp fix to pass tests
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   def index
     authorize :user, :index?
-    @users = policy_scope(User)
+
+    @users = policy_scope User
 
     @users = @users.search_by_all(params[:search]) if params[:search].present?
 
@@ -51,7 +51,8 @@ class WebApi::V1::UsersController < ::ApplicationController
 
   def index_xlsx
     authorize :user, :index_xlsx?
-    @users = policy_scope(User).all
+
+    @users = policy_scope User
     @users = @users.active unless params[:include_inactive]
 
     @users = @users.in_group(Group.find(params[:group])) if params[:group]

--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -1,6 +1,6 @@
 class WebApi::V1::UsersController < ::ApplicationController
   before_action :set_user, only: %i[show update destroy ideas_count initiatives_count comments_count]
-  skip_before_action :authenticate_user # TODO: temp fix to pass tests
+  skip_before_action :authenticate_user, only: %i[create? show? by_slug? by_invite? ideas_count? initiatives_count? comments_count?]
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -299,21 +299,25 @@ class User < ApplicationRecord
     false
   end
 
-  def admin_or_moderator?(project_id)
-    admin? || (project_id && project_moderator?(project_id))
+  def normal_user?
+    !admin?
   end
 
-  def active_admin_or_moderator?(project_id)
-    active? && admin_or_moderator?(project_id)
-  end
+  # def admin_or_moderator?(project_id)
+  #   admin? || (project_id && project_moderator?(project_id))
+  # end
+
+  # def active_admin_or_moderator?(project_id)
+  #   active? && admin_or_moderator?(project_id)
+  # end
 
   def moderatable_project_ids # TODO include folders?
     []
   end
 
-  def moderatable_projects
-    Project.none
-  end
+  # def moderatable_projects
+  #   Project.none
+  # end
 
   def add_role(type, options = {})
     roles << { 'type' => type.to_s }.merge(options.stringify_keys)

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -303,21 +303,9 @@ class User < ApplicationRecord
     !admin?
   end
 
-  # def admin_or_moderator?(project_id)
-  #   admin? || (project_id && project_moderator?(project_id))
-  # end
-
-  # def active_admin_or_moderator?(project_id)
-  #   active? && admin_or_moderator?(project_id)
-  # end
-
   def moderatable_project_ids # TODO include folders?
     []
   end
-
-  # def moderatable_projects
-  #   Project.none
-  # end
 
   def add_role(type, options = {})
     roles << { 'type' => type.to_s }.merge(options.stringify_keys)

--- a/back/app/policies/basket_policy.rb
+++ b/back/app/policies/basket_policy.rb
@@ -1,16 +1,19 @@
 class BasketPolicy < ApplicationPolicy
   def create?
     (
-      user&.active? && 
+      user&.active? &&
       (record.user_id == user.id) &&
       ProjectPolicy.new(user, record.participation_context.project).show? &&
       check_budgeting_allowed(record, user)
-    ) || 
-    user&.active_admin_or_moderator?(record.participation_context.project.id)
+    ) || (
+      user&.active? && UserRoleService.new.can_moderate?(record.participation_context, user)
+    )
   end
 
   def show?
-    user&.active? && (record.user_id == user.id || user&.active_admin_or_moderator?(record.participation_context.project.id))
+    user&.active? && (
+      record.user_id == user.id || UserRoleService.new.can_moderate?(record.participation_context, user)
+    )
   end
 
   def update?
@@ -21,10 +24,9 @@ class BasketPolicy < ApplicationPolicy
     update?
   end
 
-
   private
 
-  def check_budgeting_allowed basket, user
+  def check_budgeting_allowed(basket, user)
     pcs = ParticipationContextService.new
     !pcs.budgeting_disabled_reason_for_context pcs.get_participation_context(basket.participation_context.project), user
   end

--- a/back/app/policies/idea_comment_policy.rb
+++ b/back/app/policies/idea_comment_policy.rb
@@ -18,12 +18,13 @@ class IdeaCommentPolicy < ApplicationPolicy
 
   def create?
     (
-      user&.active? && 
+      user&.active? &&
       (record.author_id == user.id) &&
       ProjectPolicy.new(user, record.post.project).show? &&
       check_commenting_allowed(record, user)
-    ) || 
-    user&.active_admin_or_moderator?(record.post.project.id)
+    ) || (
+      user&.active? && UserRoleService.new.can_moderate?(record.post, user)
+    )
   end
 
   def children?
@@ -46,12 +47,10 @@ class IdeaCommentPolicy < ApplicationPolicy
     false
   end
 
-
   private
 
-  def check_commenting_allowed comment, user
+  def check_commenting_allowed(comment, user)
     pcs = ParticipationContextService.new
     !pcs.commenting_disabled_reason_for_idea comment.post, user
   end
-
 end

--- a/back/app/policies/idea_official_feedback_policy.rb
+++ b/back/app/policies/idea_official_feedback_policy.rb
@@ -12,8 +12,8 @@ class IdeaOfficialFeedbackPolicy < ApplicationPolicy
     end
   end
 
-  def create? 
-    user&.active_admin_or_moderator?(record.post.project.id)
+  def create?
+    user&.active? && UserRoleService.new.can_moderate?(record, user)
   end
 
   def show?
@@ -27,5 +27,4 @@ class IdeaOfficialFeedbackPolicy < ApplicationPolicy
   def destroy?
     create?
   end
-
 end

--- a/back/app/policies/initiative_official_feedback_policy.rb
+++ b/back/app/policies/initiative_official_feedback_policy.rb
@@ -12,7 +12,7 @@ class InitiativeOfficialFeedbackPolicy < ApplicationPolicy
     end
   end
 
-  def create? 
+  def create?
     user&.admin?
   end
 
@@ -27,5 +27,4 @@ class InitiativeOfficialFeedbackPolicy < ApplicationPolicy
   def destroy?
     create?
   end
-
 end

--- a/back/app/policies/permission_policy.rb
+++ b/back/app/policies/permission_policy.rb
@@ -13,11 +13,11 @@ class PermissionPolicy < ApplicationPolicy
   end
 
   def show?
-    user && UserRoleService.new.can_moderate?(record.permission_scope, user)
+    user&.active? && UserRoleService.new.can_moderate?(record.permission_scope, user)
   end
 
   def update?
-    user && UserRoleService.new.can_moderate?(record.permission_scope, user)
+    user&.active? && UserRoleService.new.can_moderate?(record.permission_scope, user)
   end
 
   def participation_conditions?

--- a/back/app/policies/permission_policy.rb
+++ b/back/app/policies/permission_policy.rb
@@ -13,11 +13,11 @@ class PermissionPolicy < ApplicationPolicy
   end
 
   def show?
-    user&.active_admin_or_moderator? record.permission_scope&.project&.id
+    user && UserRoleService.new.can_moderate?(record.permission_scope, user)
   end
 
   def update?
-    user&.active_admin_or_moderator? record.permission_scope&.project&.id
+    user && UserRoleService.new.can_moderate?(record.permission_scope, user)
   end
 
   def participation_conditions?

--- a/back/app/policies/projects_allowed_input_topic_policy.rb
+++ b/back/app/policies/projects_allowed_input_topic_policy.rb
@@ -6,28 +6,26 @@ class ProjectsAllowedInputTopicPolicy < ApplicationPolicy
       @user  = user
       @scope = scope
     end
+
     def resolve
       scope.where(project: Pundit.policy_scope(user, Project))
     end
   end
 
   def create?
-    user&.active? && user&.active_admin_or_moderator?(record.project_id)
+    user&.active? && UserRoleService.new.can_moderate_project?(record.project, user)
   end
 
   def reorder?
-    user&.active? && user&.active_admin_or_moderator?(record.project_id)
+    user&.active? && UserRoleService.new.can_moderate_project?(record.project, user)
   end
 
   def destroy?
-    user&.active? && user&.active_admin_or_moderator?(record.project_id)
+    user&.active? && UserRoleService.new.can_moderate_project?(record.project, user)
   end
 
   def permitted_attributes_for_create
-    [
-      :topic_id,
-      :project_id
-    ]
+    %i[topic_id project_id]
   end
 
   def permitted_attributes_for_reorder

--- a/back/app/policies/user_policy.rb
+++ b/back/app/policies/user_policy.rb
@@ -17,7 +17,7 @@ class UserPolicy < ApplicationPolicy
         projects.each do |project|
           scope_for_moderator = scope_for_moderator.or role_service.moderators_for_project(project, scope)
         end
-        scope_for_moderator.or ParticipantsService.new.projects_participants(projects)
+        scope_for_moderator.or scope.where(id: ParticipantsService.new.projects_participants(projects))
       else
         scope.none
       end

--- a/back/app/policies/user_policy.rb
+++ b/back/app/policies/user_policy.rb
@@ -8,9 +8,9 @@ class UserPolicy < ApplicationPolicy
     end
 
     def resolve
-      if user.admin?
+      if user&.admin?
         scope.all
-      else
+      elsif user && !user.normal_user?
         role_service = UserRoleService.new
         scope_for_moderator = scope.none
         projects = role_service.moderatable_projects user
@@ -18,6 +18,8 @@ class UserPolicy < ApplicationPolicy
           scope_for_moderator = scope_for_moderator.or role_service.moderators_for_project(project, scope)
         end
         scope_for_moderator.or ParticipantsService.new.projects_participants(projects)
+      else
+        scope.none
       end
     end
   end

--- a/back/app/services/user_role_service.rb
+++ b/back/app/services/user_role_service.rb
@@ -1,5 +1,7 @@
 class UserRoleService
   def can_moderate?(object, user)
+    return true if user.admin?
+
     case object.class.name
     when 'Idea'
       can_moderate? object.project, user
@@ -9,6 +11,8 @@ class UserRoleService
       can_moderate? object.post, user
     when 'Project'
       can_moderate_project? object, user
+    when 'Phase'
+      can_moderate_project? object.project, user
     end
   end
 

--- a/back/app/services/user_role_service.rb
+++ b/back/app/services/user_role_service.rb
@@ -9,6 +9,10 @@ class UserRoleService
       can_moderate_initiatives? user
     when 'Comment'
       can_moderate? object.post, user
+    when 'OfficialFeedback'
+      can_moderate? object.post, user
+    when 'Vote'
+      can_moderate? object.votable, user
     when 'Project'
       can_moderate_project? object, user
     when 'Phase'

--- a/back/engines/commercial/project_folders/app/models/project_folders/patches/user.rb
+++ b/back/engines/commercial/project_folders/app/models/project_folders/patches/user.rb
@@ -38,14 +38,6 @@ module ProjectFolders
         super && moderated_project_folder_ids.blank?
       end
 
-      # def active_admin_or_folder_moderator?(project_folder_id = nil)
-      #   active? && admin_or_folder_moderator?(project_folder_id)
-      # end
-
-      # def moderated_project_folders
-      #   ProjectFolders::Folder.where(id: moderated_project_folder_ids)
-      # end
-
       def moderates_parent_folder?(project)
         project.folder && project_folder_moderator?(project.folder.id)
       end

--- a/back/engines/commercial/project_folders/app/models/project_folders/patches/user.rb
+++ b/back/engines/commercial/project_folders/app/models/project_folders/patches/user.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module ProjectFolders
   module Patches
     module User
@@ -36,20 +34,24 @@ module ProjectFolders
         admin? || (project_folder_id && project_folder_moderator?(project_folder_id))
       end
 
-      def active_admin_or_folder_moderator?(project_folder_id = nil)
-        active? && admin_or_folder_moderator?(project_folder_id)
+      def normal_user?
+        super && moderated_project_folder_ids.blank?
       end
 
-      def moderated_project_folders
-        ProjectFolders::Folder.where(id: moderated_project_folder_ids)
-      end
+      # def active_admin_or_folder_moderator?(project_folder_id = nil)
+      #   active? && admin_or_folder_moderator?(project_folder_id)
+      # end
 
-      def moderated_project_folder_ids
-        roles.select { |role| role['type'] == 'project_folder_moderator' }.pluck("project_folder_id").compact
-      end
+      # def moderated_project_folders
+      #   ProjectFolders::Folder.where(id: moderated_project_folder_ids)
+      # end
 
       def moderates_parent_folder?(project)
         project.folder && project_folder_moderator?(project.folder.id)
+      end
+
+      def moderated_project_folder_ids
+        roles.select { |role| role['type'] == 'project_folder_moderator' }.pluck('project_folder_id').compact
       end
     end
   end

--- a/back/engines/commercial/project_folders/app/policies/project_folders/patches/project_policy.rb
+++ b/back/engines/commercial/project_folders/app/policies/project_folders/patches/project_policy.rb
@@ -9,10 +9,10 @@ module ProjectFolders
 
       module Scope
         def resolve
-          if user&.project_folder_moderator? && !user&.admin?
-            folder_publication_ids = user.moderated_project_folders
-                                         .includes(:admin_publication)
-                                         .pluck('admin_publications.id')
+          if user&.project_folder_moderator? && !user.admin?
+            folder_publication_ids = ProjectFolders::Folder.where(id: user.moderated_project_folder_ids)
+                                      .includes(:admin_publication)
+                                      .pluck('admin_publications.id')
 
             all_ids = user.moderatable_project_ids + scope.user_groups_visible(user).not_draft.or(scope.publicly_visible.not_draft)
 

--- a/back/engines/commercial/project_folders/spec/policies/user_policy_spec.rb
+++ b/back/engines/commercial/project_folders/spec/policies/user_policy_spec.rb
@@ -8,7 +8,9 @@ describe UserPolicy do
   context 'for a moderator' do
     let(:project1) { create :project }
     let(:project2) { create :project }
-    let(:current_user) { create :project_moderator, projects: [project1, project2] }
+    let(:folder1) { create :project_folder, projects: [project1] }
+    let(:folder2) { create :project_folder, projects: [project2] }
+    let(:current_user) { create :project_folder_moderator, project_folders: [folder1, folder2] }
 
     context 'on theirself' do
       let(:subject_user) { current_user }
@@ -44,9 +46,10 @@ describe UserPolicy do
 
     it 'only indexes admins and moderators of the same projects' do
       moderator1 = create :project_moderator, projects: [create(:project), project1]
-      moderator2 = create :project_moderator, projects: [create(:project)]
-      moderator3 = create :project_moderator, projects: [project2]
-      user = create(:idea).author
+      moderator2 = create :project_folder_moderator, project_folders: [create(:project_folder)]
+      moderator3 = create :project_folder_moderator, project_folders: [folder2]
+      moderator4 = create :project_moderator, projects: [create(:project)]
+      user = create(:comment).author
       participant = create(:idea, project: project2).author
       admin = create :admin
       expect(scope.resolve.ids).to match_array [participant.id, current_user.id, moderator1.id, moderator3.id, admin.id]

--- a/back/engines/commercial/project_management/app/models/project_management/patches/user.rb
+++ b/back/engines/commercial/project_management/app/models/project_management/patches/user.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module ProjectManagement
   module Patches
     module User
@@ -24,21 +22,25 @@ module ProjectManagement
         end
       end
 
-      def moderatable_project_ids
-        roles.select { |role| role['type'] == 'project_moderator' }.pluck("project_id").compact
-      end
-
-      def moderatable_project_ids_was
-        roles_was.select { |role| role['type'] == 'project_moderator' }.pluck("project_id").compact
-      end
-
-      def moderatable_projects
-        ::Project.where(id: moderatable_project_ids)
-      end
-
       def project_moderator?(project_id = nil)
         project_id ? moderatable_project_ids.include?(project_id) : moderatable_project_ids.present?
       end
+
+      def normal_user?
+        super && moderatable_project_ids.blank?
+      end
+
+      def moderatable_project_ids
+        roles.select { |role| role['type'] == 'project_moderator' }.pluck('project_id').compact
+      end
+
+      # def moderatable_project_ids_was
+      #   roles_was.select { |role| role['type'] == 'project_moderator' }.pluck('project_id').compact
+      # end
+
+      # def moderatable_projects
+      #   ::Project.where(id: moderatable_project_ids)
+      # end
     end
   end
 end

--- a/back/engines/commercial/project_management/app/models/project_management/patches/user.rb
+++ b/back/engines/commercial/project_management/app/models/project_management/patches/user.rb
@@ -33,14 +33,6 @@ module ProjectManagement
       def moderatable_project_ids
         roles.select { |role| role['type'] == 'project_moderator' }.pluck('project_id').compact
       end
-
-      # def moderatable_project_ids_was
-      #   roles_was.select { |role| role['type'] == 'project_moderator' }.pluck('project_id').compact
-      # end
-
-      # def moderatable_projects
-      #   ::Project.where(id: moderatable_project_ids)
-      # end
     end
   end
 end

--- a/back/engines/commercial/project_management/app/policies/project_management/patches/stat_user_policy.rb
+++ b/back/engines/commercial/project_management/app/policies/project_management/patches/stat_user_policy.rb
@@ -15,7 +15,7 @@ module ProjectManagement
         def resolve_for_project_moderator
           return scope.none unless user.project_moderator?
 
-          UserRoleService.new.moderatable_projects(user)
+          ::UserRoleService.new.moderatable_projects(user)
               .map { |project| ::ProjectPolicy::InverseScope.new(project, scope).resolve }
               .reduce(:or)
         end

--- a/back/engines/commercial/project_management/app/policies/project_management/patches/stat_user_policy.rb
+++ b/back/engines/commercial/project_management/app/policies/project_management/patches/stat_user_policy.rb
@@ -15,7 +15,7 @@ module ProjectManagement
         def resolve_for_project_moderator
           return scope.none unless user.project_moderator?
 
-          user.moderatable_projects
+          UserRoleService.new.moderatable_projects(user)
               .map { |project| ::ProjectPolicy::InverseScope.new(project, scope).resolve }
               .reduce(:or)
         end

--- a/back/engines/commercial/project_management/spec/policies/user_policy_spec.rb
+++ b/back/engines/commercial/project_management/spec/policies/user_policy_spec.rb
@@ -1,15 +1,14 @@
-# frozen_string_literal: true
-
 require 'rails_helper'
 
 describe UserPolicy do
-  subject { described_class.new(current_user, subject_user) }
+  subject { described_class.new current_user, subject_user }
 
-  let(:scope) { UserPolicy::Scope.new(current_user, User) }
+  let(:scope) { UserPolicy::Scope.new current_user, User }
 
   context 'for a moderator' do
-    let(:project) { create(:project) }
-    let(:current_user) { create(:project_moderator, projects: [project]) }
+    let(:project1) { create :project }
+    let(:project2) { create :project }
+    let(:current_user) { create :project_moderator, projects: [project1, project2] }
 
     context 'on theirself' do
       let(:subject_user) { current_user }
@@ -18,29 +17,38 @@ describe UserPolicy do
       it { is_expected.to     permit(:create)  }
       it { is_expected.to     permit(:update)  }
       it { is_expected.to     permit(:destroy) }
-      it { is_expected.not_to permit(:index) }
+      it { is_expected.to     permit(:index) }
       it { is_expected.not_to permit(:index_xlsx) }
 
       it 'indexes the user through the scope' do
-        subject_user.save
+        subject_user.save!
         expect(scope.resolve.size).to eq 1
       end
     end
 
     context 'on someone else' do
-      let(:subject_user) { create(:user) }
+      let(:subject_user) { create :user }
 
       it { is_expected.to     permit(:show)    }
       it { is_expected.to     permit(:create)  }
       it { is_expected.not_to permit(:update)  }
       it { is_expected.not_to permit(:destroy) }
-      it { is_expected.not_to permit(:index) }
+      it { is_expected.to     permit(:index) }
       it { is_expected.not_to permit(:index_xlsx) }
 
-      it 'indexes the users through the scope' do
-        subject_user.save
-        expect(scope.resolve.size).to eq 2
+      it 'does not index the user through the scope' do
+        subject_user.save!
+        expect(scope.resolve.size).to eq 1
       end
+    end
+
+    it 'only indexes admins and moderators of the same projects' do
+      moderator1 = create :project_moderator, projects: [create(:project), project1]
+      moderator2 = create :project_moderator, projects: [create(:project)]
+      moderator3 = create :project_moderator, projects: [project2]
+      user = create :user
+      admin = create :admin
+      expect(scope.resolve.ids).to match_array [current_user.id, moderator1.id, moderator3.id, admin.id]
     end
   end
 end

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -1,20 +1,17 @@
 require 'rails_helper'
 require 'rspec_api_documentation/dsl'
 
-
-resource "Users" do
-
-  explanation "Citizens and city administrators."
+resource 'Users' do
+  explanation 'Citizens and city administrators.'
 
   before do
-    header "Content-Type", "application/json"
+    header 'Content-Type', 'application/json'
   end
 
-  context "when not authenticated" do
-
-    get "web_api/v1/users/me" do
-      example_request "[error] Get the authenticated user" do
-        expect(status).to eq(404)
+  context 'when not authenticated' do
+    get 'web_api/v1/users/me' do
+      example_request '[error] Get the authenticated user' do
+        expect(status).to eq 401
       end
     end
 

--- a/back/spec/policies/user_policy_spec.rb
+++ b/back/spec/policies/user_policy_spec.rb
@@ -1,12 +1,13 @@
 require 'rails_helper'
 
 describe UserPolicy do
-  subject { UserPolicy.new(current_user, subject_user) }
-  let(:scope) { UserPolicy::Scope.new(current_user, User) }
+  subject { described_class.new current_user, subject_user }
 
-  context "for a visitor" do
+  let(:scope) { UserPolicy::Scope.new current_user, User }
+
+  context 'for a visitor' do
     let(:current_user) { nil }
-    let(:subject_user) { create(:user) }
+    let(:subject_user) { create :user }
 
     it { should     permit(:show)    }
     it { should     permit(:create)  }
@@ -15,16 +16,16 @@ describe UserPolicy do
     it { should_not permit(:index) }
     it { should_not permit(:index_xlsx) }
 
-    it "should index the user through the scope" do
-      subject_user.save
-      expect(scope.resolve.size).to eq 1
+    it 'should not index the user through the scope' do
+      subject_user.save!
+      expect(scope.resolve.size).to eq 0
     end
   end
 
-  context "for a user" do
-    let(:current_user) { create(:user) }
+  context 'for a user' do
+    let(:current_user) { create :user }
 
-    context "on theirself" do
+    context 'on theirself' do
       let(:subject_user) { current_user }
 
       it { should     permit(:show)    }
@@ -34,14 +35,14 @@ describe UserPolicy do
       it { should_not permit(:index) }
       it { should_not permit(:index_xlsx) }
 
-      it "should index the user through the scope" do
-        subject_user.save
-        expect(scope.resolve.size).to eq 1
+      it 'should not index the user through the scope' do
+        subject_user.save!
+        expect(scope.resolve.size).to eq 0
       end
     end
 
-    context "on someone else" do
-      let(:subject_user) { create(:user) }
+    context 'on someone else' do
+      let(:subject_user) { create :user }
 
       it { should     permit(:show)    }
       it { should     permit(:create)  }
@@ -50,17 +51,17 @@ describe UserPolicy do
       it { should_not permit(:index) }
       it { should_not permit(:index_xlsx) }
 
-      it "should index the users through the scope" do
-        subject_user.save
-        expect(scope.resolve.size).to eq 2
+      it 'should index the users through the scope' do
+        subject_user.save!
+        expect(scope.resolve.size).to eq 0
       end
     end
   end
 
-  context "for an admin" do
-    let(:current_user) { create(:admin) }
+  context 'for an admin' do
+    let(:current_user) { create :admin }
 
-    context "on theirself" do
+    context 'on theirself' do
       let(:subject_user) { current_user }
 
       it { should permit(:show)    }
@@ -70,14 +71,14 @@ describe UserPolicy do
       it { should permit(:index) }
       it { should permit(:index_xlsx) }
 
-      it "should index the user through the scope" do
-        subject_user.save
+      it 'should index the user through the scope' do
+        subject_user.save!
         expect(scope.resolve.size).to eq 1
       end
     end
 
-    context "on someone else" do
-      let(:subject_user) { create(:user) }
+    context 'on someone else' do
+      let(:subject_user) { create :user }
 
       it { should permit(:show)    }
       it { should permit(:create)  }
@@ -86,11 +87,10 @@ describe UserPolicy do
       it { should permit(:index) }
       it { should permit(:index_xlsx) }
 
-      it "should index the users through the scope" do
-        subject_user.save
+      it 'should index the users through the scope' do
+        subject_user.save!
         expect(scope.resolve.size).to eq 2
       end
     end
   end
-
 end


### PR DESCRIPTION
- Allow project and folder moderators to list users: They are only allowed to see people who moderate one of the projects they moderate and participants of one of the projects they moderate. This was necessary to allow moderators to assign assignees to ideas.
- Took the opportunity to do a little bit more refactoring: Moving logic about moderation roles out of the user model and into the user role service.

Hard to estimate urgency. Considered urgent by product (Gent is asking this), but the bug has been there for 2 years.