### PR TITLE
[DISP-72] Fix sorting in Ideas Map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Next release
 
-/
+### Fixed
+
+- Fixed bug in Ideas Map view that caused an infinite loop of requests when Idea sort order was changed
 
 ## 2022-03-29
 

--- a/front/app/hooks/useIdeaMarkers.ts
+++ b/front/app/hooks/useIdeaMarkers.ts
@@ -23,6 +23,10 @@ export default function useIdeaMarkers({
     IIdeaMarkerData[] | undefined | null
   >(undefined);
 
+  // Stringifying the project IDs and topics to make useEffect dependency array happy
+  const stringifiedProjectIds = JSON.stringify(projectIds);
+  const stringifiedTopics = JSON.stringify(topics);
+
   useEffect(() => {
     setIdeaMarkers(undefined);
 
@@ -30,24 +34,18 @@ export default function useIdeaMarkers({
       queryParameters: {
         'page[size]': 2000,
         location_required: true,
-        projects: projectIds,
+        projects: JSON.parse(stringifiedProjectIds),
         phase: phaseId,
         sort: sort || ideaDefaultSortMethodFallback,
         search: search || undefined,
-        topics: topics || undefined,
+        topics: JSON.parse(stringifiedTopics) || undefined,
       },
     }).observable.subscribe((response) => {
       setIdeaMarkers(!isNilOrError(response) ? response.data : null);
     });
 
     return () => subscription.unsubscribe();
-  }, [
-    phaseId,
-    JSON.stringify(projectIds),
-    sort,
-    search,
-    JSON.stringify(topics),
-  ]);
+  }, [phaseId, stringifiedProjectIds, sort, search, stringifiedTopics]);
 
   return ideaMarkers;
 }

--- a/front/app/hooks/useIdeaMarkers.ts
+++ b/front/app/hooks/useIdeaMarkers.ts
@@ -41,7 +41,13 @@ export default function useIdeaMarkers({
     });
 
     return () => subscription.unsubscribe();
-  }, [phaseId, projectIds, sort, search, topics]);
+  }, [
+    phaseId,
+    JSON.stringify(projectIds),
+    sort,
+    search,
+    JSON.stringify(topics),
+  ]);
 
   return ideaMarkers;
 }


### PR DESCRIPTION
Bug here: https://citizenlab.atlassian.net/browse/DISP-72
To reproduce on master, the window must be larger than a certain breakpoint (not exactly sure which but full width on my laptop is big enough to reproduce). Changing the sorting here causes an infinite loop of requests:

<img width="1381" alt="Screenshot 2022-04-01 at 14 48 12" src="https://user-images.githubusercontent.com/3614128/161266667-46c3a67b-b81b-4b82-8697-4298551a69ca.png">
 
I believe the bug was due to passing arrays into the dependency array, which made React freak out when trying to reconcile the contents. This PR changes the dependency array for the `useEffect` function to use `JSON.stringify` on the arrays we were passing in, which makes them normal strings and therefore easy for React to reconcile. This fixes the bug on my local machine but please test before/after 

I don't think there are many downsides using this fix, Dan Abramov of the React team recommends it here: https://github.com/facebook/react/issues/14476 and it might be a little slower but likely not noticeable on this component