### PR TITLE
[CL-510] Use HTTPS validating Twilio requests

### DIFF
--- a/back/engines/commercial/texting/app/controllers/texting/web_api/v1/campaigns_controller.rb
+++ b/back/engines/commercial/texting/app/controllers/texting/web_api/v1/campaigns_controller.rb
@@ -70,7 +70,8 @@ module Texting
     # SMS provider calls it
     def mark_as_sent
       campaign = Campaign.find(params[:id])
-      if Texting::Sms.provider.request_valid?(request)
+      url = Texting::WebhookUrlGenerator.new.mark_campaign_as_sent(campaign)
+      if Texting::Sms.provider.request_valid?(url, request)
         campaign.update!(status: Texting::Campaign.statuses.fetch(:sent), sent_at: Time.zone.now) if campaign.sending?
         head :ok
       else

--- a/back/engines/commercial/texting/app/jobs/texting/send_campaign_job.rb
+++ b/back/engines/commercial/texting/app/jobs/texting/send_campaign_job.rb
@@ -5,19 +5,13 @@ module Texting
     def run(campaign)
       provider = Texting::Sms.provider
       sent_statuses = campaign.phone_numbers.map.with_index do |number, index|
-        callback = status_callback(campaign) if index + 1 == campaign.phone_numbers.length
+        if index + 1 == campaign.phone_numbers.length
+          callback = Texting::WebhookUrlGenerator.new.mark_campaign_as_sent(campaign)
+        end
         provider.send_msg(campaign.message, number, status_callback: callback)
       end
 
       campaign.update!(status: Texting::Campaign.statuses.fetch(:failed)) if sent_statuses.none?
-    end
-
-    private
-
-    def status_callback(campaign)
-      Texting::Engine.routes.url_helpers.mark_as_sent_web_api_v1_campaign_url(
-        campaign.id, host: Tenant.current.host, protocol: :https
-      )
     end
   end
 end

--- a/back/engines/commercial/texting/app/services/texting/phone_number.rb
+++ b/back/engines/commercial/texting/app/services/texting/phone_number.rb
@@ -5,20 +5,20 @@ class Texting::PhoneNumber
   class << self
     # I tried to use phonelib and telephone_number gems, but they're super slow (1000 numbers per second).
     # Current implementation is ~100x faster.
-    # If conditions change, the error message in 
+    # If conditions change, the error message in
     # front/app/containers/Admin/messaging/texting/components/SMSCampaignForm.tsx may need to be updated.
     def valid?(number, country_codes: [])
       codes_regex =
         if country_codes.present?
           "(#{country_codes.map { |code| Regexp.escape(code) }.join('|')})"
         else
-          '\+'
+          '\+?'
         end
-      number.match?(/\A#{codes_regex}\d{#{MIN_LENGTH},#{MAX_LENGTH}}\Z/)
+      normalize(number).match?(/\A#{codes_regex}\d{#{MIN_LENGTH},#{MAX_LENGTH}}\Z/)
     end
 
     def normalize(number)
-      number.gsub(/[-\s]/, '')
+      number.gsub(/[-\s()]/, '')
     end
 
     def requirements(country_codes: [])

--- a/back/engines/commercial/texting/app/services/texting/sms/providers/twilio.rb
+++ b/back/engines/commercial/texting/app/services/texting/sms/providers/twilio.rb
@@ -19,15 +19,12 @@ class Texting::Sms::Providers::Twilio
     segments_count > SEGMENTS_QUEUE
   end
 
-  def request_valid?(request)
+  def request_valid?(url, request)
     signature = request.headers['X-Twilio-Signature']
-    puts "request.original_url #{request.original_url}, request.request_parameters #{request.request_parameters}, signature #{signature}"
-    Rails.logger.info "request.original_url #{request.original_url}, request.request_parameters #{request.request_parameters}, signature #{signature}"
-    Rails.logger.error "request.original_url #{request.original_url}, request.request_parameters #{request.request_parameters}, signature #{signature}"
     return false if signature.blank?
 
     validator = Twilio::Security::RequestValidator.new(auth_token)
-    validator.validate(request.original_url, request.request_parameters, signature)
+    validator.validate(url, request.request_parameters, signature)
   end
 
   private

--- a/back/engines/commercial/texting/app/services/texting/webhook_url_generator.rb
+++ b/back/engines/commercial/texting/app/services/texting/webhook_url_generator.rb
@@ -1,0 +1,7 @@
+class Texting::WebhookUrlGenerator
+  def mark_campaign_as_sent(campaign)
+    Texting::Engine.routes.url_helpers.mark_as_sent_web_api_v1_campaign_url(
+      campaign.id, host: Tenant.current.host, protocol: :https
+    )
+  end
+end

--- a/back/engines/commercial/texting/spec/acceptance/campaigns_spec.rb
+++ b/back/engines/commercial/texting/spec/acceptance/campaigns_spec.rb
@@ -143,7 +143,7 @@ resource 'Texting campaigns' do
   end
 
   # To test locally without stubs:
-  # 1. Run ngrok
+  # 1. ngrok http 4000
   # 2.
   <<-DOC
   Tenant.find_by(host: 'localhost').tap(&:switch!)

--- a/back/engines/commercial/texting/spec/services/texting/phone_number_spec.rb
+++ b/back/engines/commercial/texting/spec/services/texting/phone_number_spec.rb
@@ -4,8 +4,10 @@ describe Texting::PhoneNumber do
   describe '.valid?' do
     it 'returns true for valid phone numbers' do
       expect(described_class.valid?('+12345678911')).to eq(true)
+      expect(described_class.valid?('2345678911')).to eq(true)
       expect(described_class.valid?("+#{'1' * 7}")).to eq(true)
       expect(described_class.valid?("+#{'1' * 15}")).to eq(true)
+      expect(described_class.valid?("+#{'1' * 15}---")).to eq(true)
       expect(described_class.valid?('+12345678911', country_codes: ['+123'])).to eq(true)
       expect(described_class.valid?('+12345678911', country_codes: ['+111', '+123'])).to eq(true)
     end
@@ -22,6 +24,7 @@ describe Texting::PhoneNumber do
     it 'removes extra characters' do
       expect(described_class.normalize('+12345678911')).to eq('+12345678911')
       expect(described_class.normalize('+12 345-67--89  11')).to eq('+12345678911')
+      expect(described_class.normalize('+12 (345) 67--89  11')).to eq('+12345678911')
     end
   end
 end

--- a/front/app/containers/Admin/messaging/texting/components/SMSCampaignForm.tsx
+++ b/front/app/containers/Admin/messaging/texting/components/SMSCampaignForm.tsx
@@ -142,7 +142,7 @@ const SMSCampaignForm = ({
         <Label>
           {formIsLocked
             ? 'Sent to:'
-            : 'Enter a list of phone numbers. Separate each number by a comma and include the international dialing code (eg. +1).'}
+            : 'Enter a list of phone numbers. Separate each number by a comma.'}
         </Label>
         <TextArea
           rows={8}


### PR DESCRIPTION
Twilio sends request to HTTPS, but Rails knows only about HTTP in
request.original_url because of using reverse proxy.
So, now we don't rely on Rails, but use the same code we use to set
Twilio webhook.
