### PR TITLE
CL-479 Accessibility: Autocomplete attribute

### DIFF
--- a/front/app/containers/PasswordRecovery/index.tsx
+++ b/front/app/containers/PasswordRecovery/index.tsx
@@ -203,7 +203,8 @@ class PasswordRecovery extends React.PureComponent<
               <FormLabel htmlFor="email" labelMessage={messages.emailLabel} />
               <StyledInput
                 id="email"
-                type="text"
+                type="email"
+                autocomplete="email"
                 value={email}
                 error={errorMessage}
                 placeholder={emailPlaceholder}

--- a/front/app/containers/UsersEditPage/ProfileForm.tsx
+++ b/front/app/containers/UsersEditPage/ProfileForm.tsx
@@ -374,6 +374,7 @@ class ProfileForm extends PureComponent<Props, State> {
             <InputContainer>
               <Input
                 type="email"
+                autocomplete="email"
                 name="email"
                 id="email"
                 value={values.email}

--- a/front/app/modules/free/user_confirmation/citizen/components/ConfirmationSignupStep.tsx
+++ b/front/app/modules/free/user_confirmation/citizen/components/ConfirmationSignupStep.tsx
@@ -238,6 +238,7 @@ const ConfirmationSignupStep = ({
             </StyledLabel>
             <Input
               type="email"
+              autocomplete="email"
               value={newEmail}
               onChange={handleEmailChange}
               placeholder={formatMessage(messages.emailPlaceholder)}


### PR DESCRIPTION
Accessibility fix:

on page [Reset password](https://accessibility-audit.citizenlab.co/en/password-recovery)
Id: 13173
Most forms have correct [autocomplete attributes](https://www.w3.org/TR/WCAG21/#input-purposes). The e-mail field on this page is still missing one. Add autocomplete="email" to fix this problem.

Note: I am really not convinced this change did anything. For me, autocomplete always worked in FFox (with or without `autocomplete="email"`, or at least the browser suggested previously used email addresses in a dialogue below the input field), and never worked in Chrome.
