### PR TITLE
[CL-487] a11y audit 2.4.7: Focus Outline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fixed bug in Ideas Map view that caused an infinite loop of requests when Idea sort order was changed
 - Fixed SurveyMonkey container height so survey questions are visible
+- Added a tabIndex so the cookie consent banner will have a visual outline around it when focused, for a11y compatibility
 
 ## 2022-03-29
 

--- a/front/app/components/ConsentManager/Banner.tsx
+++ b/front/app/components/ConsentManager/Banner.tsx
@@ -157,7 +157,7 @@ class Banner extends PureComponent<Props> {
     );
 
     return (
-      <Container role="dialog" id="e2e-cookie-banner">
+      <Container tabIndex={0} role="dialog" id="e2e-cookie-banner">
         <ContentContainer mode="page">
           <ContentContainerInner>
             <Left>


### PR DESCRIPTION
This takes care of the first point from 2.4.7:

> The cookie banner's focus management is fine: it's one of the first elements in the source code which means keyboard users can easily close it. The contents can also be reached by keyboard.
> 
> That said, the cookie banner is still difficult to use for keyboard users as it has an [outline:none](https://www.outlinenone.com/). The browser's own outline has been hidden, but hasn't been replaced with a custom outline: a keyboard user can't tell when they've entered the cookie banner or which item currently has focus.
> 
> Remove the outline:none or replace the browser's own focus outline with a custom outline that's even more visible than the native browser one


I added `tabIndex={0}` to the cookie banner container, so the entire banner can now be focused with the tab key and then gets the normal visual outline that we apply to the focused element:

<img width="718" alt="Screenshot 2022-04-05 at 12 24 22" src="https://user-images.githubusercontent.com/3614128/161736508-3b6142ac-07f3-43cf-bc61-1c3d5c29bddc.png">

This is the second part of 2.4.7:

> When logged in, a banner appears prompting the user to complete their profile. The banner contains two buttons. These buttons like a focus outline due to the use of outline:none, making them hard to use to keyboard users. Remove the outline:none or add a custom focus outline that's even easier to see than the browser's native outline.

I'm not seeing this in my testing. Both locally and on the accessibility audit demo deployment, those two buttons are tab selectable and show the proper visual outline when each of them is selected:
<img width="1252" alt="Screenshot 2022-04-05 at 12 43 05" src="https://user-images.githubusercontent.com/3614128/161737745-22cb9480-ed9e-41bc-aa57-8a7b3c9d8738.png">
<img width="1440" alt="Screenshot 2022-04-05 at 12 44 06" src="https://user-images.githubusercontent.com/3614128/161737771-1031037f-603c-4426-80d5-6994d44f81a6.png">
<img width="1440" alt="Screenshot 2022-04-05 at 12 44 12" src="https://user-images.githubusercontent.com/3614128/161737808-b64d8a96-d5f5-4bc1-bad8-6e8c23b02067.png">

<img width="1270" alt="Screenshot 2022-04-05 at 12 43 00" src="https://user-images.githubusercontent.com/3614128/161737616-b0e443e3-4ca9-4ebd-b0c3-a4e77bf05c50.png">

