### PR TITLE
[CL-529] Do not check GA in consent because it was disabled

### DIFF
--- a/front/cypress/integration/cookie_consent.ts
+++ b/front/cypress/integration/cookie_consent.ts
@@ -10,7 +10,7 @@ describe('Cookie consent form for not-signed-in users', () => {
   it('Shows the correct options when not signed in', () => {
     cy.get('#e2e-cookie-banner');
     cy.get('#e2e-cookie-banner').find('.integration-open-modal').click();
-    cy.get('#e2e-preference-dialog').contains('Google Analytics');
+    cy.get('#e2e-preference-dialog').contains('Matomo');
     cy.get('#e2e-preference-dialog').should('not.contain.text', 'SatisMeter');
   });
 });
@@ -34,7 +34,7 @@ describe('Cookie consent form for signed-in users', () => {
   it('Shows the correct options when signed up as normal user', () => {
     cy.get('#e2e-cookie-banner');
     cy.get('#e2e-cookie-banner').find('.integration-open-modal').click();
-    cy.get('#e2e-preference-dialog').contains('Google Analytics');
+    cy.get('#e2e-preference-dialog').contains('Matomo');
     cy.get('#e2e-preference-dialog').should('not.contain.text', 'SatisMeter');
   });
 });
@@ -51,6 +51,6 @@ describe('Cookie consent form for signed-in admins', () => {
   it('Shows the correct options when signed up as admin user', () => {
     cy.get('#e2e-cookie-banner');
     cy.get('#e2e-cookie-banner').find('.integration-open-modal').click();
-    cy.get('#e2e-preference-dialog').contains('Google Analytics');
+    cy.get('#e2e-preference-dialog').contains('Matomo');
   });
 });


### PR DESCRIPTION
It was disabled here https://github.com/CitizenLabDotCo/citizenlab-ee/commit/1c6364cb482b3e69c9714502a3d1a597cf9f9d5f
because it should be enabled only with credentials.
And it was possible to enable it without credentials because of
the bug which was fixed in CL-541
