### PR TITLE
[CL-497] Add primary and secondary aria-labels to header and footer nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Fixed bug in Ideas Map view that caused an infinite loop of requests when Idea sort order was changed
 - Fixed SurveyMonkey container height so survey questions are visible
 - Added a tabIndex so the cookie consent banner will have a visual outline around it when focused, for a11y compatibility
-- Added primary and secondary aria-labels to header and footer navigation elements to more clearly differentiate them
+- Added primary and secondary aria-labels to header and footer navigation elements to more clearly differentiate them to screen readers and other accessability tools
 
 ## 2022-03-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed bug in Ideas Map view that caused an infinite loop of requests when Idea sort order was changed
 - Fixed SurveyMonkey container height so survey questions are visible
 - Added a tabIndex so the cookie consent banner will have a visual outline around it when focused, for a11y compatibility
+- Added primary and secondary aria-labels to header and footer navigation elements to more clearly differentiate them
 
 ## 2022-03-29
 

--- a/front/app/containers/MainHeader/DesktopNavbar/index.tsx
+++ b/front/app/containers/MainHeader/DesktopNavbar/index.tsx
@@ -16,6 +16,11 @@ import { media, isRtl } from 'utils/styleUtils';
 import { isNilOrError } from 'utils/helperUtils';
 import getNavbarItemPropsArray from './getNavbarItemPropsArray';
 
+// i18n
+import { injectIntl } from 'utils/cl-intl';
+import messages from '../messages';
+import { InjectedIntlProps } from 'react-intl';
+
 const Container = styled.nav`
   height: 100%;
   margin-left: 35px;
@@ -40,7 +45,7 @@ const NavbarItems = styled.ul`
   `};
 `;
 
-const DesktopNavbar = () => {
+const DesktopNavbar = ({ intl: { formatMessage } }: InjectedIntlProps) => {
   const navbarItems = useNavbarItems();
   const pageSlugById = usePageSlugById();
 
@@ -52,7 +57,7 @@ const DesktopNavbar = () => {
   );
 
   return (
-    <Container>
+    <Container aria-label={formatMessage(messages.ariaLabel)}>
       <NavbarItems>
         {navbarItemPropsArray.map((navbarItemProps, i) => {
           const { linkTo, onlyActiveOnIndex, navigationItemTitle } =
@@ -82,4 +87,4 @@ const DesktopNavbar = () => {
   );
 };
 
-export default DesktopNavbar;
+export default injectIntl(DesktopNavbar);

--- a/front/app/containers/MainHeader/messages.ts
+++ b/front/app/containers/MainHeader/messages.ts
@@ -26,4 +26,8 @@ export default defineMessages({
     id: 'app.containers.app.navbar.allProjects',
     defaultMessage: 'All projects',
   },
+  ariaLabel: {
+    id: 'app.containers.app.navbar.ariaLabel',
+    defaultMessage: 'Primary',
+  },
 });

--- a/front/app/containers/PlatformFooter/index.tsx
+++ b/front/app/containers/PlatformFooter/index.tsx
@@ -11,7 +11,8 @@ import SendFeedback from 'components/SendFeedback';
 import { Icon, useWindowSize } from '@citizenlab/cl2-component-library';
 
 // i18n
-import { FormattedMessage, MessageDescriptor } from 'utils/cl-intl';
+import { FormattedMessage, MessageDescriptor, injectIntl } from 'utils/cl-intl';
+import { InjectedIntlProps } from 'react-intl';
 import messages from './messages';
 
 // services
@@ -228,7 +229,11 @@ const MESSAGES_MAP: TMessagesMap = {
   'accessibility-statement': messages.accessibilityStatement,
 };
 
-const PlatformFooter = ({ className, insideModal }: Props) => {
+const PlatformFooter = ({
+  className,
+  insideModal,
+  intl: { formatMessage },
+}: Props & InjectedIntlProps) => {
   const appConfiguration = useAppConfiguration();
   const windowSize = useWindowSize();
   const customizedA11yHrefEnabled = useFeatureFlag({
@@ -267,7 +272,7 @@ const PlatformFooter = ({ className, insideModal }: Props) => {
   return (
     <Container insideModal={insideModal} id="hook-footer" className={className}>
       <FooterContainer>
-        <PagesNav>
+        <PagesNav aria-label={formatMessage(messages.ariaLabel)}>
           <PagesNavList>
             {FOOTER_PAGES.map((slug: TFooterPage, index) => {
               return (
@@ -328,4 +333,4 @@ const PlatformFooter = ({ className, insideModal }: Props) => {
   );
 };
 
-export default PlatformFooter;
+export default injectIntl(PlatformFooter);

--- a/front/app/containers/PlatformFooter/messages.ts
+++ b/front/app/containers/PlatformFooter/messages.ts
@@ -33,4 +33,8 @@ export default defineMessages({
     id: 'app.containers.footer.feedbackEmptyError',
     defaultMessage: 'The feedback field cannot be empty.',
   },
+  ariaLabel: {
+    id: 'app.containers.footer.ariaLabel',
+    defaultMessage: 'Secondary',
+  },
 });


### PR DESCRIPTION
From the a11y audit, which says:

> The website has two nav elements: one in the header and one in the footer.
> 
> It's fine to use [multiple nav elements](https://www.aditus.io/patterns/multiple-navigation-landmarks/), but when repeating a landmark multiple times on a page each landmark needs an accessible label to signify the difference between each iteration to the user.
> 
> Use an [aria-label](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) or [aria-labelledby](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) to indicate to screenreader users which navigation serves which purpose.

I added a `Primary` aria-label to the header and a `Secondary` aria-label to the footer, per [this example linked in the audit](https://www.aditus.io/patterns/multiple-navigation-landmarks/). I believe that's correct since they're applied to `nav` elements, we just need to mention which is the primary nav and which is secondary, and I think it should be clear on a screen reader which is in the header and which is the footer.
