### PR TITLE
Remove modal no close prop

### DIFF
--- a/front/app/components/SignUpIn/SignUpInModal.tsx
+++ b/front/app/components/SignUpIn/SignUpInModal.tsx
@@ -120,7 +120,6 @@ const SignUpInModal = memo<Props>(
         opened={opened}
         close={onClose}
         closeOnClickOutside={false}
-        noClose={false}
       >
         <Container id="e2e-sign-up-in-modal" className={className}>
           {opened && metaData && (

--- a/front/app/components/UI/Modal/index.tsx
+++ b/front/app/components/UI/Modal/index.tsx
@@ -324,7 +324,6 @@ export interface InputProps {
   hasSkipButton?: boolean;
   skipText?: JSX.Element;
   padding?: string;
-  noClose?: boolean;
   closeOnClickOutside?: boolean;
   children: React.ReactNode;
 }
@@ -385,9 +384,7 @@ class Modal extends PureComponent<Props, State> {
   };
 
   closeModal = () => {
-    if (!this.props.noClose) {
-      this.props.close();
-    }
+    this.props.close();
   };
 
   handlePopstateEvent = () => {
@@ -434,7 +431,6 @@ class Modal extends PureComponent<Props, State> {
       footer,
       hasSkipButton,
       skipText,
-      noClose,
     } = this.props;
     const hasFixedHeight = this.props.fixedHeight;
     const smallerThanSmallTablet = windowSize
@@ -476,15 +472,13 @@ class Modal extends PureComponent<Props, State> {
                 aria-modal="true"
                 role="dialog"
               >
-                {!noClose && (
-                  <StyledCloseIconButton
-                    className="e2e-modal-close-button"
-                    onClick={this.clickCloseButton}
-                    iconColor={colors.label}
-                    iconColorOnHover={'#000'}
-                    a11y_buttonActionMessage={messages.closeModal}
-                  />
-                )}
+                <StyledCloseIconButton
+                  className="e2e-modal-close-button"
+                  onClick={this.clickCloseButton}
+                  iconColor={colors.label}
+                  iconColorOnHover={'#000'}
+                  a11y_buttonActionMessage={messages.closeModal}
+                />
 
                 {header && (
                   <HeaderContainer>

--- a/front/app/containers/ProjectsShowPage/shared/header/ProjectSharingModal.tsx
+++ b/front/app/containers/ProjectsShowPage/shared/header/ProjectSharingModal.tsx
@@ -61,7 +61,6 @@ const ProjectSharingModal = memo<Props & InjectedIntlProps>(
           opened={opened}
           close={onClose}
           closeOnClickOutside={true}
-          noClose={false}
           header={<T value={project.attributes.title_multiloc} />}
         >
           <Container className={className}>

--- a/front/app/modules/commercial/project_folders/citizen/components/ProjectFolderSharingModal/index.tsx
+++ b/front/app/modules/commercial/project_folders/citizen/components/ProjectFolderSharingModal/index.tsx
@@ -63,7 +63,6 @@ const ProjectFolderSharingModal = memo<
         opened={opened}
         close={onClose}
         closeOnClickOutside={true}
-        noClose={false}
         header={<T value={projectFolder.attributes.title_multiloc} />}
       >
         <Container className={className || ''}>


### PR DESCRIPTION
Only `false` as used value. The default is `undefined`, which also converses to false. Then to actually use the value, we did a double negation (!noClose) on an undefined or false value, which is the same as true aka doing nothing.

(After the work on "stuck in sign up form", before we actually used it.)