### PR TITLE
CL-578 Ideas in widget links to the wrong tenant URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added a tabIndex so the cookie consent banner will have a visual outline around it when focused, for a11y compatibility
 - Fixed accessibility issue in modal window used to report a proposal as spam
 - Fixed accessibility contrast issue for social media buttons
+- The widget no longer links to ideas with the wrong domain
 
 ## 2022-03-29
 

--- a/back/engines/commercial/admin_api/app/graphql/admin_api/types/idea_type.rb
+++ b/back/engines/commercial/admin_api/app/graphql/admin_api/types/idea_type.rb
@@ -52,9 +52,8 @@ module AdminApi
     end
 
 
-    @@frontend_service = Frontend::UrlService.new
     def href
-      @@frontend_service.model_to_url(object)
+      Frontend::UrlService.new.model_to_url(object)
     end
 
   end

--- a/back/engines/commercial/admin_api/app/graphql/admin_api/types/initiative_type.rb
+++ b/back/engines/commercial/admin_api/app/graphql/admin_api/types/initiative_type.rb
@@ -45,11 +45,8 @@ module AdminApi
       object.initiative_images
     end
 
-
-    @@frontend_service = Frontend::UrlService.new
     def href
-      @@frontend_service.model_to_url(object)
+      Frontend::UrlService.new.model_to_url(object)
     end
-
   end
 end

--- a/back/engines/commercial/admin_api/app/graphql/admin_api/types/page_type.rb
+++ b/back/engines/commercial/admin_api/app/graphql/admin_api/types/page_type.rb
@@ -10,9 +10,8 @@ module AdminApi
     field :created_at, String, null: false
     field :href, String, null: true
 
-    @@frontend_service = Frontend::UrlService.new
     def href
-      @@frontend_service.model_to_url(object)
+      Frontend::UrlService.new.model_to_url(object)
     end
   end
 end

--- a/back/engines/commercial/admin_api/app/graphql/admin_api/types/project_folder_type.rb
+++ b/back/engines/commercial/admin_api/app/graphql/admin_api/types/project_folder_type.rb
@@ -19,10 +19,8 @@ module AdminApi
     field :created_at, String, null: false
     field :href, String, null: true
 
-    @@frontend_service = Frontend::UrlService.new
     def href
-      @@frontend_service.model_to_url(object)
+      Frontend::UrlService.new.model_to_url(object)
     end
-
   end
 end

--- a/back/engines/commercial/admin_api/app/graphql/admin_api/types/project_type.rb
+++ b/back/engines/commercial/admin_api/app/graphql/admin_api/types/project_type.rb
@@ -33,10 +33,8 @@ module AdminApi
     field :created_at, String, null: false
     field :href, String, null: true
 
-    @@frontend_service = Frontend::UrlService.new
     def href
-      @@frontend_service.model_to_url(object)
+      Frontend::UrlService.new.model_to_url(object)
     end
-
   end
 end


### PR DESCRIPTION
Weird issue, which in the core is caused because a memoized service is shared between requests. The service that was memoized probably used to be stateless so this was fine, but now it bit us.

Difficult and messy to test and low regression chance, so chose not to cover.