### PR TITLE
[CL-501] Remove aria-live from card

### DIFF
--- a/front/app/components/AssignBudgetControl/index.tsx
+++ b/front/app/components/AssignBudgetControl/index.tsx
@@ -295,7 +295,6 @@ const AssignBudgetControl = memo(
           return (
             <IdeaCardContainer
               className={`e2e-assign-budget ${className || ''}`}
-              aria-live="polite"
             >
               {addRemoveButton}
             </IdeaCardContainer>
@@ -308,7 +307,6 @@ const AssignBudgetControl = memo(
               className={`pbAssignBudgetControlContainer e2e-assign-budget ${
                 className || ''
               }`}
-              aria-live="polite"
             >
               <BudgetWithButtonWrapper>
                 <Budget>


### PR DESCRIPTION
I managed to reproduce the issue with Mac's Voice Over and figured out that the `Card` component aria-live was causing the screen-reader to read the updates twice. Should be fixed now.