### PR TITLE
[CL-636] Fix bug in signup form where user could skip accepting terms/conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Removed unnecessary additional alt text describing city logos in header, navbar, and delete account modal. The remaining alt tags are now more concise for users who use screen readers
 - Properly disable SMS create/edit button if the message is empty
 - In the verification step of the sign-up flow, the form inputs are now connected to the correct labels, which makes it easier to select the input fields (also possible by clicking the input labels now)
+- Fixed a bug in the password signup flow where a user could skip accepting terms and conditions and privacy policy
 
 ## 2022-04-11
 

--- a/front/app/components/SignUpIn/SignUp/PasswordSignup.tsx
+++ b/front/app/components/SignUpIn/SignUp/PasswordSignup.tsx
@@ -349,6 +349,8 @@ class PasswordSignup extends PureComponent<Props & InjectedIntlProps, State> {
     const tacError = !tacAccepted;
     const privacyError = !privacyAccepted;
 
+    // set individual errors on state so the proper
+    // error messages can be shown in the UI
     this.setState({
       invitationRedeemError,
       emailOrPhoneNumberError,
@@ -359,8 +361,8 @@ class PasswordSignup extends PureComponent<Props & InjectedIntlProps, State> {
       privacyError,
     });
 
-    // temporary bug fix CL 636
-    return {
+    // compute if any errors exist on the current form
+    const hasErrors = [
       invitationRedeemError,
       emailOrPhoneNumberError,
       firstNameError,
@@ -368,7 +370,10 @@ class PasswordSignup extends PureComponent<Props & InjectedIntlProps, State> {
       hasMinimumLengthError,
       tacError,
       privacyError,
-    };
+    ].some((error) => error);
+
+    // and return validation status as a boolean
+    return hasErrors;
   };
 
   focusFirstInputWithError = () => {
@@ -409,27 +414,7 @@ class PasswordSignup extends PureComponent<Props & InjectedIntlProps, State> {
         processing,
       } = this.state;
 
-      // get these directly from the validate function
-      // rather than pulling from state, to make sure we have updated data
-      const {
-        invitationRedeemError,
-        emailOrPhoneNumberError,
-        firstNameError,
-        lastNameError,
-        hasMinimumLengthError,
-        tacError,
-        privacyError,
-      } = this.validate(isPhoneSignupEnabled);
-
-      const hasErrors = [
-        invitationRedeemError,
-        emailOrPhoneNumberError,
-        firstNameError,
-        lastNameError,
-        hasMinimumLengthError,
-        tacError,
-        privacyError,
-      ].some((error) => error);
+      const hasErrors = this.validate(isPhoneSignupEnabled);
 
       if (hasErrors) {
         this.focusFirstInputWithError();

--- a/front/app/components/SignUpIn/SignUp/PasswordSignup.tsx
+++ b/front/app/components/SignUpIn/SignUp/PasswordSignup.tsx
@@ -358,6 +358,17 @@ class PasswordSignup extends PureComponent<Props & InjectedIntlProps, State> {
       tacError,
       privacyError,
     });
+
+    // temporary bug fix CL 636
+    return {
+      invitationRedeemError,
+      emailOrPhoneNumberError,
+      firstNameError,
+      lastNameError,
+      hasMinimumLengthError,
+      tacError,
+      privacyError,
+    };
   };
 
   focusFirstInputWithError = () => {
@@ -388,6 +399,7 @@ class PasswordSignup extends PureComponent<Props & InjectedIntlProps, State> {
         intl: { formatMessage },
         locale,
       } = this.props;
+
       const {
         token,
         firstName,
@@ -395,6 +407,11 @@ class PasswordSignup extends PureComponent<Props & InjectedIntlProps, State> {
         emailOrPhoneNumber,
         password,
         processing,
+      } = this.state;
+
+      // get these directly from the validate function
+      // rather than pulling from state, to make sure we have updated data
+      const {
         invitationRedeemError,
         emailOrPhoneNumberError,
         firstNameError,
@@ -402,9 +419,7 @@ class PasswordSignup extends PureComponent<Props & InjectedIntlProps, State> {
         hasMinimumLengthError,
         tacError,
         privacyError,
-      } = this.state;
-
-      this.validate(isPhoneSignupEnabled);
+      } = this.validate(isPhoneSignupEnabled);
 
       const hasErrors = [
         invitationRedeemError,


### PR DESCRIPTION
I believe the bug came from calling `this.validate` which eventually did a `setState` call with its results, but continuing immediately after the `this.validate` call to the rest of the function. `setState` is async so the new values would not be present immediately, so the errors were not set by the time we checked them. I changed `this.validate` to return those values directly, so they'll always be accurate in the remainder of the function. It also still does `setState` so it shouldn't affect the rest of the component. 

https://user-images.githubusercontent.com/3614128/164172916-4c858d63-b41b-4545-a957-f744d64415ee.mov

