### PR TITLE
[CL-586] Beta flag for SMS campaign feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changed
 
 - 'Summary' dashboard: the 'Participation per project' and 'Participation per tag' work a little bit different. Now, if a project filter is active, the former will stay the same but highlight the selected project instead of showing the differences with other projects which were hard to interpret (analogous for 'Participation per tag').
-- Added "Beta" flag to feature flagged SMS feature
+- Added property for status label to Tab component, and used this to add "Beta" flag to feature flagged SMS feature
 
 ## 2022-04-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - 'Summary' dashboard: the 'Participation per project' and 'Participation per tag' work a little bit different. Now, if a project filter is active, the former will stay the same but highlight the selected project instead of showing the differences with other projects which were hard to interpret (analogous for 'Participation per tag').
+- Added "Beta" flag to feature flagged SMS feature
 
 ## 2022-04-20
 

--- a/front/app/components/admin/TabbedResource/TabbedResource.test.tsx
+++ b/front/app/components/admin/TabbedResource/TabbedResource.test.tsx
@@ -48,12 +48,9 @@ describe('<TabbedResource />', () => {
     const routerProps = getRouterProps('continuousInformation');
 
     const { container } = render(
-      <TabbedResource
-        resource={fakeResource}
-        tabs={fakeTabs}
-        children={children}
-        {...routerProps}
-      />
+      <TabbedResource resource={fakeResource} tabs={fakeTabs} {...routerProps}>
+        {children}
+      </TabbedResource>
     );
 
     expect(container.getElementsByClassName('active')).toHaveLength(1);
@@ -80,9 +77,10 @@ describe('<TabbedResource />', () => {
       <TabbedResource
         resource={fakeResource}
         tabs={tabsIncludingOneWithStatusLabel}
-        children={children}
         {...routerProps}
-      />
+      >
+        {children}
+      </TabbedResource>
     );
     expect(screen.getByText('Beta Tag')).toBeInTheDocument();
   });

--- a/front/app/components/admin/TabbedResource/TabbedResource.test.tsx
+++ b/front/app/components/admin/TabbedResource/TabbedResource.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { render, screen } from 'utils/testUtils/rtl';
+import TabbedResource from '.';
+import { WithRouterProps } from 'react-router';
+
+const getRouterProps = (tabId, tabName?: string) =>
+  ({
+    location: {
+      pathname: `/admin/projects/${tabId}/${tabName}`,
+    },
+    params: {
+      tabId,
+    },
+  } as any as WithRouterProps);
+
+const children = (
+  <>
+    <div>hi</div>
+  </>
+);
+
+const fakeTabs = [
+  {
+    name: 'FirstTab',
+    label: 'First Tab',
+    url: '/first',
+  },
+  {
+    name: 'SecondTab',
+    label: 'Second Tab',
+    url: '/second',
+  },
+  {
+    name: 'ThirdTab',
+    label: 'Third Tab',
+    url: '/third',
+    active: true,
+  },
+];
+
+const fakeResource = {
+  title: 'Tab page',
+  subtitle: 'Fake Tab Page',
+};
+
+describe('<TabbedResource />', () => {
+  it('renders tabs and header properly including an active tab', () => {
+    const routerProps = getRouterProps('continuousInformation');
+
+    const { container } = render(
+      <TabbedResource
+        resource={fakeResource}
+        tabs={fakeTabs}
+        children={children}
+        {...routerProps}
+      />
+    );
+
+    expect(container.getElementsByClassName('active')).toHaveLength(1);
+    expect(screen.getByText('Third Tab')).toBeInTheDocument();
+    expect(screen.getByText('Tab page')).toBeInTheDocument();
+    expect(screen.getByText('Fake Tab Page')).toBeInTheDocument();
+  });
+
+  it('renders properly with an optional status label', () => {
+    const routerProps = getRouterProps('continuousInformation');
+
+    const tabsIncludingOneWithStatusLabel = [
+      ...fakeTabs,
+      {
+        name: 'FourthTab',
+        label: 'Fourth Tab',
+        url: '/fourth',
+        statusLabel: 'Beta Tag',
+      },
+    ];
+
+    render(
+      <TabbedResource
+        resource={fakeResource}
+        tabs={tabsIncludingOneWithStatusLabel}
+        children={children}
+        {...routerProps}
+      />
+    );
+    expect(screen.getByText('Beta Tag')).toBeInTheDocument();
+  });
+});

--- a/front/app/components/admin/TabbedResource/TabbedResource.test.tsx
+++ b/front/app/components/admin/TabbedResource/TabbedResource.test.tsx
@@ -15,7 +15,7 @@ const getRouterProps = (tabId, tabName?: string) =>
 
 const children = (
   <>
-    <div>hi</div>
+    <div>Child Content</div>
   </>
 );
 
@@ -60,6 +60,7 @@ describe('<TabbedResource />', () => {
     expect(screen.getByText('Third Tab')).toBeInTheDocument();
     expect(screen.getByText('Tab page')).toBeInTheDocument();
     expect(screen.getByText('Fake Tab Page')).toBeInTheDocument();
+    expect(screen.getByText('Child Content')).toBeInTheDocument();
   });
 
   it('renders properly with an optional status label', () => {

--- a/front/app/components/admin/TabbedResource/index.tsx
+++ b/front/app/components/admin/TabbedResource/index.tsx
@@ -118,23 +118,25 @@ function getRegularExpression(tabUrl: string) {
   return new RegExp(`^/([a-zA-Z]{2,3}(-[a-zA-Z]{2,3})?)(${tabUrl})(/)?$`);
 }
 
-const FormattedTabLink = ({ tab }: { tab: ITab }) => {
-  if (!isNilOrError(tab.statusLabel)) {
+const FormattedTabLink = ({
+  tab: { url, label, statusLabel },
+}: {
+  tab: ITab;
+}) => {
+  if (!isNilOrError(statusLabel)) {
     return (
-      <>
-        <Link to={tab.url}>
-          {tab.label}
-          <StatusLabelWithMargin
-            text={tab.statusLabel}
-            backgroundColor={colors.adminBackground}
-            variant="outlined"
-          />
-        </Link>
-      </>
+      <Link to={url}>
+        {label}
+        <StatusLabelWithMargin
+          text={statusLabel}
+          backgroundColor={colors.adminBackground}
+          variant="outlined"
+        />
+      </Link>
     );
   }
 
-  return <Link to={tab.url}>{tab.label}</Link>;
+  return <Link to={url}>{label}</Link>;
 };
 
 class TabbedResource extends React.PureComponent<
@@ -186,16 +188,17 @@ class TabbedResource extends React.PureComponent<
                     </Tab>
                   </FeatureFlag>
                 );
-              } else {
-                return (
-                  <Tab
-                    key={tab.url}
-                    className={`${tab.name} ${this.activeClassForTab(tab)}`}
-                  >
-                    <FormattedTabLink tab={tab} />
-                  </Tab>
-                );
               }
+
+              // no feature, just return tab with label
+              return (
+                <Tab
+                  key={tab.url}
+                  className={`${tab.name} ${this.activeClassForTab(tab)}`}
+                >
+                  <FormattedTabLink tab={tab} />
+                </Tab>
+              );
             })}
           </TabbedNav>
         )}

--- a/front/app/components/admin/TabbedResource/index.tsx
+++ b/front/app/components/admin/TabbedResource/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+// routing
 import { withRouter, WithRouterProps } from 'react-router';
 import Link from 'utils/cl-router/Link';
 
@@ -14,6 +15,10 @@ import { ITab } from 'typings';
 import FeatureFlag from 'components/FeatureFlag';
 import { SectionDescription } from 'components/admin/Section';
 import Title from 'components/admin/PageTitle';
+import { StatusLabel } from '@citizenlab/cl2-component-library';
+
+// utils
+import { isNilOrError } from 'utils/helperUtils';
 
 const ResourceHeader = styled.div`
   display: flex;
@@ -95,6 +100,10 @@ const ChildWrapper = styled.div`
   }
 `;
 
+const StatusLabelWithMargin = styled(StatusLabel)`
+  margin-left: 12px;
+`;
+
 type Props = {
   resource: {
     title: string;
@@ -108,6 +117,25 @@ interface State {}
 function getRegularExpression(tabUrl: string) {
   return new RegExp(`^/([a-zA-Z]{2,3}(-[a-zA-Z]{2,3})?)(${tabUrl})(/)?$`);
 }
+
+const FormattedTabLink = ({ tab }: { tab: ITab }) => {
+  if (!isNilOrError(tab.statusLabel)) {
+    return (
+      <>
+        <Link to={tab.url}>
+          {tab.label}
+          <StatusLabelWithMargin
+            text={tab.statusLabel}
+            backgroundColor={colors.adminBackground}
+            variant="outlined"
+          />
+        </Link>
+      </>
+    );
+  }
+
+  return <Link to={tab.url}>{tab.label}</Link>;
+};
 
 class TabbedResource extends React.PureComponent<
   Props & WithRouterProps,
@@ -154,7 +182,7 @@ class TabbedResource extends React.PureComponent<
                       key={tab.url}
                       className={`${tab.name} ${this.activeClassForTab(tab)}`}
                     >
-                      <Link to={tab.url}>{tab.label}</Link>
+                      <FormattedTabLink tab={tab} />
                     </Tab>
                   </FeatureFlag>
                 );
@@ -164,7 +192,7 @@ class TabbedResource extends React.PureComponent<
                     key={tab.url}
                     className={`${tab.name} ${this.activeClassForTab(tab)}`}
                   >
-                    <Link to={tab.url}>{tab.label}</Link>
+                    <FormattedTabLink tab={tab} />
                   </Tab>
                 );
               }

--- a/front/app/components/admin/TabbedResource/index.tsx
+++ b/front/app/components/admin/TabbedResource/index.tsx
@@ -17,9 +17,6 @@ import { SectionDescription } from 'components/admin/Section';
 import Title from 'components/admin/PageTitle';
 import { StatusLabel } from '@citizenlab/cl2-component-library';
 
-// utils
-import { isNilOrError } from 'utils/helperUtils';
-
 const ResourceHeader = styled.div`
   display: flex;
   align-items: flex-end;
@@ -123,7 +120,7 @@ const FormattedTabLink = ({
 }: {
   tab: ITab;
 }) => {
-  if (!isNilOrError(statusLabel)) {
+  if (statusLabel) {
     return (
       <Link to={url}>
         {label}

--- a/front/app/containers/Admin/messaging/index.tsx
+++ b/front/app/containers/Admin/messaging/index.tsx
@@ -45,6 +45,7 @@ class MessagingDashboard extends React.PureComponent<
       tabs.push({
         label: formatMessage(messages.tabTexting),
         url: '/admin/messaging/texting',
+        statusLabel: 'Beta',
       });
     }
     if (

--- a/front/app/typings.ts
+++ b/front/app/typings.ts
@@ -54,6 +54,7 @@ export interface ITab {
   url: string;
   active?: boolean | ((pathname: string) => boolean);
   feature?: TAppConfigurationSetting;
+  statusLabel?: string;
 }
 
 export type CellConfiguration<ComponentProps> = {

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@apollo/client": "^3.5.6",
         "@babel/runtime": "7.x",
-        "@citizenlab/cl2-component-library": "^0.9.57",
+        "@citizenlab/cl2-component-library": "^0.9.58",
         "@craftjs/core": "^0.2.0-beta.3",
         "@jsonforms/core": "3.0.0-beta.0",
         "@jsonforms/react": "3.0.0-beta.1",
@@ -2170,9 +2170,9 @@
       "dev": true
     },
     "node_modules/@citizenlab/cl2-component-library": {
-      "version": "0.9.57",
-      "resolved": "https://registry.npmjs.org/@citizenlab/cl2-component-library/-/cl2-component-library-0.9.57.tgz",
-      "integrity": "sha512-CEcFIfNbBNBTMCv10V4hweEK4Yf6oSlLhPbRa/VNmRB9OtF2VYXLdZOuagiEY94Y7nZHBoYnx4Xu8VxFjK3udQ==",
+      "version": "0.9.58",
+      "resolved": "https://registry.npmjs.org/@citizenlab/cl2-component-library/-/cl2-component-library-0.9.58.tgz",
+      "integrity": "sha512-eIEz4dtsrLaF8lr42Js2AZJ5Rh194BRSIcKIwQDEJ5EIaAj+lxrpMhFV4qKkGdIRKhxl8k/D2JXf3uW/3cLgJQ==",
       "dependencies": {
         "@tippyjs/react": "4.2.6",
         "focus-visible": "5.2.0",
@@ -23404,9 +23404,9 @@
       "dev": true
     },
     "@citizenlab/cl2-component-library": {
-      "version": "0.9.57",
-      "resolved": "https://registry.npmjs.org/@citizenlab/cl2-component-library/-/cl2-component-library-0.9.57.tgz",
-      "integrity": "sha512-CEcFIfNbBNBTMCv10V4hweEK4Yf6oSlLhPbRa/VNmRB9OtF2VYXLdZOuagiEY94Y7nZHBoYnx4Xu8VxFjK3udQ==",
+      "version": "0.9.58",
+      "resolved": "https://registry.npmjs.org/@citizenlab/cl2-component-library/-/cl2-component-library-0.9.58.tgz",
+      "integrity": "sha512-eIEz4dtsrLaF8lr42Js2AZJ5Rh194BRSIcKIwQDEJ5EIaAj+lxrpMhFV4qKkGdIRKhxl8k/D2JXf3uW/3cLgJQ==",
       "requires": {
         "@tippyjs/react": "4.2.6",
         "focus-visible": "5.2.0",

--- a/front/package.json
+++ b/front/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@apollo/client": "^3.5.6",
     "@babel/runtime": "7.x",
-    "@citizenlab/cl2-component-library": "^0.9.57",
+    "@citizenlab/cl2-component-library": "^0.9.58",
     "@craftjs/core": "^0.2.0-beta.3",
     "@jsonforms/core": "3.0.0-beta.0",
     "@jsonforms/react": "3.0.0-beta.1",


### PR DESCRIPTION
https://citizenlab.atlassian.net/browse/CL-586

Adds Beta flag to the SMS feature:

![Screen Shot 2022-04-21 at 15 17 29](https://user-images.githubusercontent.com/3614128/164466268-08658f28-a080-45fa-936f-8b638bea6b7b.png)

Notes: 
* Added some unit tests to cover the TabbedResource component and this new variation
* Broke our rules and used `margin-left` as the alternative was wrapping the label in another component. Since there is only likely to be one label on these tabs I think it's fine in this case
* The "Beta" string is not translated since it should only be seen by USA customers now, like the rest of the SMS feature

## How urgent is a code review?

Not an urgent change, next day or so would be nice
