### PR TITLE
Open settings on drop for image and text components

### DIFF
--- a/front/app/modules/commercial/content_builder/admin/components/ContentBuilderToolbox/index.tsx
+++ b/front/app/modules/commercial/content_builder/admin/components/ContentBuilderToolbox/index.tsx
@@ -29,7 +29,10 @@ const DraggableElement = styled.div`
 const ContentBuilderToolbox = ({
   intl: { formatMessage },
 }: InjectedIntlProps) => {
-  const { connectors } = useEditor();
+  const {
+    connectors,
+    actions: { selectNode },
+  } = useEditor();
 
   return (
     <Box w="100%" display="inline">
@@ -78,17 +81,26 @@ const ContentBuilderToolbox = ({
               is={Text}
               id="text"
               text={formatMessage(messages.textValue)}
-            />
+            />,
+            {
+              onCreate: (node) => {
+                selectNode(node.rootNodeId);
+              },
+            }
           )
         }
       >
         <ToolboxItem icon="text" label={formatMessage(messages.text)} />
       </DraggableElement>
       <DraggableElement
-        ref={(ref) =>
+        ref={(ref) => {
           ref &&
-          connectors.create(ref, <Element is={Image} id="image" alt="" />)
-        }
+            connectors.create(ref, <Element is={Image} id="image" alt="" />, {
+              onCreate: (node) => {
+                selectNode(node.rootNodeId);
+              },
+            });
+        }}
       >
         <ToolboxItem icon="image" label={formatMessage(messages.image)} />
       </DraggableElement>


### PR DESCRIPTION
A small change to open the settings in the content editor on drop (node creation). For now, it's only for the Image and Text as I think there it makes most sense but we can easily add it to the others as well, if needed.