### PR TITLE
[CL-683] Add rake task to update user custom fields title copies

### DIFF
--- a/back/app/services/copies_updating_service.rb
+++ b/back/app/services/copies_updating_service.rb
@@ -1,0 +1,39 @@
+class CopiesUpdatingService
+  def update_custom_fields
+    scope = CustomField.where(resource_type: User.name)
+    %w[gender birthyear domicile education].each do |code|
+      scope.where(code: code).find_each do |record|
+        update_multiloc_value(record, :title_multiloc, "custom_fields.users.#{code}.title")
+      end
+    end
+  end
+
+  private
+
+  def update_multiloc_value(record, attr_name, copy_path)
+    old_multiloc_value = record.public_send(attr_name)
+    new_multiloc_value = latest_multiloc_value(copy_path)
+
+    old_multiloc_value.each do |(locale, value)|
+      english = locale.starts_with?('en')
+      value_translated = value != old_multiloc_value['en']
+
+      new_multiloc_value[locale] = value if english || value_translated
+    end
+
+    return if new_multiloc_value == old_multiloc_value
+
+    msg = "#{record.class.name} #{record.id} #{attr_name} from #{old_multiloc_value} to #{new_multiloc_value}"
+    if record.update(attr_name => new_multiloc_value)
+      Rails.logger.info("Updated #{msg}")
+    else
+      Rails.logger.error("Failed to update #{msg}")
+    end
+  end
+
+  def latest_multiloc_value(copy_path)
+    CL2_SUPPORTED_LOCALES.each_with_object({}) do |locale, obj|
+      obj[locale.to_s] = I18n.with_locale(locale) { I18n.t!(copy_path) }
+    end
+  end
+end

--- a/back/lib/tasks/copies.rake
+++ b/back/lib/tasks/copies.rake
@@ -1,0 +1,17 @@
+namespace :copies do
+  # If a custom field (a platform) is created without a copy for the specific language,
+  # and then we add this language to CitizenLab (or to the platform),
+  # the copy isn't added to the already existing custom field.
+  # So, the Spanish copy can be in English though it was translated recently.
+
+  # This task doesn't solve the problem fundamentally, but it updates the copies,
+  # which can be a fine trade-off between spent time and the result.
+  task :update_custom_fields, [:host] => :environment do |_t, args|
+    tenants = args[:host].present? ? Tenant.where(host: args[:host]) : Tenant.all
+    tenants.each do |tenant|
+      tenant.switch do
+        CopiesUpdatingService.new.update_custom_fields
+      end
+    end
+  end
+end

--- a/back/spec/services/copies_updating_service.rb
+++ b/back/spec/services/copies_updating_service.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+describe CopiesUpdatingService do
+  subject(:service) { described_class.new }
+
+  describe '#update_custom_fields' do
+    it 'updates default custom fields' do
+      field = create(:custom_field_domicile, title_multiloc: {
+        'en' => 'domicile',
+        'en-CA' => 'Canadian domicile',
+        'en-GB' => 'domicile',
+        'es-ES' => 'domicile',
+        'es-CL' => 'Hola'
+      })
+
+      expect(Rails.logger).to receive(:info)
+      service.update_custom_fields
+
+      expect(field.reload.title_multiloc).to include({
+        'en' => 'domicile',
+        'en-CA' => 'Canadian domicile',
+        'en-GB' => 'domicile',
+        'es-ES' => 'Lugar de residencia',
+        'es-CL' => 'Hola',
+        'pl-PL' => 'Miejsce zamieszkania'
+      })
+    end
+
+    it 'does not update non-default custom fields' do
+      field = create(:custom_field, title_multiloc: { 'en' => 'field' })
+
+      expect(Rails.logger).not_to receive(:info)
+      service.update_custom_fields
+
+      expect(field.reload.title_multiloc).to eq({ 'en' => 'field' })
+    end
+  end
+end


### PR DESCRIPTION
```bash
bin/rake "copies:update_custom_fields[demo.stg.citizenlab.co]"
bin/rake copies:update_custom_fields
```

How it looks on staging before running the script
![image](https://user-images.githubusercontent.com/91883434/165739987-eaa96b4d-6119-4016-8eca-9885398dd39c.png)
