### PR TITLE
CL-694 Validate and sanitize layout craftjson multiloc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Next Release
+
+### Added
+
+- Validation of content builder layouts: whitelist of URLs for video iframes.
+- Sanitization of content builder layouts: HTML of text elements.
+
 ## 2022-04-28
 
 ### Added

--- a/back/app/services/sanitization_service.rb
+++ b/back/app/services/sanitization_service.rb
@@ -24,14 +24,14 @@ class SanitizationService
   end
 
   def sanitize_multiloc(multiloc, features)
-    multiloc.each_with_object({}) do |(locale, text), output|
-      output[locale] = sanitize(text, features)
+    multiloc.transform_values do |text|
+      sanitize text, features
     end
   end
 
   def remove_multiloc_empty_trailing_tags(multiloc)
-    multiloc.each_with_object({}) do |(locale, text), output|
-      output[locale] = remove_empty_trailing_tags(text)
+    multiloc.transform_values do |text|
+      remove_empty_trailing_tags text
     end
   end
 

--- a/back/app/services/sanitization_service.rb
+++ b/back/app/services/sanitization_service.rb
@@ -163,7 +163,7 @@ class SanitizationService
     end
 
     def video_whitelisted?(url)
-      VIDEO_WHITELIST.any? { |regex| (url =~ regex)&.zero? }
+      VIDEO_WHITELIST.any? { |regex| regex.match? url }
     end
 
     private

--- a/back/app/services/sanitization_service.rb
+++ b/back/app/services/sanitization_service.rb
@@ -149,7 +149,7 @@ class SanitizationService
 
     attr_reader :tags, :attributes
 
-    def initialize(features)
+    def initialize(features = [])
       super()
       features_w_default = features.concat([:default])
       @tags = features_w_default.flat_map { |f| EDITOR_FEATURES[f][:tags] }.uniq
@@ -157,16 +157,16 @@ class SanitizationService
     end
 
     def allowed_node?(node)
-      return iframe_allowed? && video_whitelisted?(node) if node.name == 'iframe'
+      return iframe_allowed? && video_whitelisted?(node['src']) if node.name == 'iframe'
       ensure_nofollow(node) if node.name == 'a'
       tags.include? node.name
     end
 
-    private
-
-    def video_whitelisted?(node)
-      VIDEO_WHITELIST.any? { |regex| (node['src'] =~ regex)&.zero? }
+    def video_whitelisted?(url)
+      VIDEO_WHITELIST.any? { |regex| (url =~ regex)&.zero? }
     end
+
+    private
 
     def iframe_allowed?
       tags.include? 'iframe'

--- a/back/app/validators/multiloc_validator.rb
+++ b/back/app/validators/multiloc_validator.rb
@@ -4,7 +4,7 @@ class MultilocValidator < ActiveModel::EachValidator
     return if record.errors.present? || value.nil?
 
     validate_supported_locales record, attribute, value
-    validate_values_are_strings record, attribute, value
+    validate_values_types record, attribute, value
     validate_html record, attribute, value
   end
 
@@ -23,12 +23,13 @@ class MultilocValidator < ActiveModel::EachValidator
     end
   end
 
-  def validate_values_are_strings(record, attribute, value)
-    if value&.values && !value.values.all?(String)
-      locales = value.keys.reject { |l| value[l].is_a?(String) }
-      message = "non-string values (for #{locales}) cannot be accepted. Either the key should be removed, or the value should be replaced by an empty string"
-      record.errors.add attribute, :values_not_all_strings, message: message
-    end
+  def validate_values_types(record, attribute, value)
+    value_type = options[:value_type] || String
+    return if !value&.values || value.values.all?(value_type)
+
+    locales = value.keys.reject { |l| value[l].is_a?(value_type) }
+    message = "non-#{value_type} values (for #{locales}) cannot be accepted. Either the key should be removed, or the value should be replaced by an empty #{value_type}"
+    record.errors.add attribute, :values_of_wrong_type, message: message
   end
 
   def validate_supported_locales(record, attribute, value)

--- a/back/engines/commercial/content_builder/app/models/content_builder/layout.rb
+++ b/back/engines/commercial/content_builder/app/models/content_builder/layout.rb
@@ -20,5 +20,26 @@ module ContentBuilder
     belongs_to :content_buildable, polymorphic: true
 
     validates :content_buildable, :code, presence: true
+    validates :craftjs_jsonmultiloc, multiloc: { presence: false, value_type: Hash }
+    validate :validate_craftjs_jsonmultiloc
+
+    private
+
+    def validate_craftjs_jsonmultiloc
+      validate_whitelisted_iframe_urls
+    end
+
+    def validate_whitelisted_iframe_urls
+      craftjs_jsonmultiloc.each do |locale, json|
+        json.select do |key, elt|
+          key != 'ROOT' && elt.dig('type', 'resolvedName') == 'Iframe'
+        end.each_value do |elt|
+          url = elt.dig 'props', 'url'
+          if url && !::SanitizationService::IframeScrubber.new.video_whitelisted?(url)
+            errors.add :craftjs_jsonmultiloc, :iframe_url_not_whitelisted, locale: locale, url: url
+          end
+        end
+      end
+    end
   end
 end

--- a/back/engines/commercial/content_builder/app/models/content_builder/layout.rb
+++ b/back/engines/commercial/content_builder/app/models/content_builder/layout.rb
@@ -19,6 +19,8 @@ module ContentBuilder
   class Layout < ApplicationRecord
     belongs_to :content_buildable, polymorphic: true
 
+    before_validation :sanitize_craftjs_jsonmultiloc
+
     validates :content_buildable, :code, presence: true
     validates :craftjs_jsonmultiloc, multiloc: { presence: false, value_type: Hash }
     validate :validate_craftjs_jsonmultiloc
@@ -40,6 +42,11 @@ module ContentBuilder
           end
         end
       end
+    end
+
+    def sanitize_craftjs_jsonmultiloc
+      service = LayoutSanitizationService.new
+      self.craftjs_jsonmultiloc = service.sanitize_multiloc craftjs_jsonmultiloc
     end
   end
 end

--- a/back/engines/commercial/content_builder/app/services/content_builder/layout_sanitization_service.rb
+++ b/back/engines/commercial/content_builder/app/services/content_builder/layout_sanitization_service.rb
@@ -13,9 +13,9 @@ module ContentBuilder
     private
 
     def sanitize_html_in_text_elements(craftjson, features)
-      craftjson.select do |key, elt|
-        key != 'ROOT' && elt.dig('type', 'resolvedName') == 'Text'
-      end.each_value do |elt|
+      craftjson.each do |key, elt|
+        next if key == 'ROOT' || elt.dig('type', 'resolvedName') != 'Text'
+
         text = elt.dig 'props', 'text'
         elt['props']['text'] = html_sanitizer.sanitize text, features if text
       end

--- a/back/engines/commercial/content_builder/app/services/content_builder/layout_sanitization_service.rb
+++ b/back/engines/commercial/content_builder/app/services/content_builder/layout_sanitization_service.rb
@@ -1,0 +1,29 @@
+module ContentBuilder
+  class LayoutSanitizationService < ::ContentImageService
+    def sanitize(craftjson, text_features: %i[title alignment list decoration link image video])
+      sanitize_html_in_text_elements craftjson, text_features
+    end
+
+    def sanitize_multiloc(multiloc, text_features: %i[title alignment list decoration link image video])
+      multiloc.transform_values do |craftjson|
+        sanitize craftjson, text_features: text_features
+      end
+    end
+
+    private
+
+    def sanitize_html_in_text_elements(craftjson, features)
+      craftjson.select do |key, elt|
+        key != 'ROOT' && elt.dig('type', 'resolvedName') == 'Text'
+      end.each_value do |elt|
+        text = elt.dig 'props', 'text'
+        elt['props']['text'] = html_sanitizer.sanitize text, features if text
+      end
+      craftjson
+    end
+
+    def html_sanitizer
+      @html_sanitizer = ::SanitizationService.new
+    end
+  end
+end

--- a/back/engines/commercial/content_builder/app/services/content_builder/layout_sanitization_service.rb
+++ b/back/engines/commercial/content_builder/app/services/content_builder/layout_sanitization_service.rb
@@ -23,7 +23,7 @@ module ContentBuilder
     end
 
     def html_sanitizer
-      @html_sanitizer = ::SanitizationService.new
+      @html_sanitizer ||= ::SanitizationService.new
     end
   end
 end

--- a/back/engines/commercial/content_builder/spec/controllers/content_builder/web_api/v1/content_builder_layouts_controller_spec.rb
+++ b/back/engines/commercial/content_builder/spec/controllers/content_builder/web_api/v1/content_builder_layouts_controller_spec.rb
@@ -61,20 +61,19 @@ RSpec.describe ::ContentBuilder::WebApi::V1::ContentBuilderLayoutsController, ty
       end
 
       it 'sanitizes HTML inside text elements' do
-        input_craftjson = craftjson_with_text '<p>Unsanitized text</p>'
-        expected_craftjson = craftjson_with_text '<p>Sanitized text</p>'
-        allow_any_instance_of(SanitizationService).to receive(:sanitize).and_return('<p>Sanitized text</p>')
+        expected_multiloc = { 'en' => { 'sanitized_craftjson' => {} } }
+        expect_any_instance_of(ContentBuilder::LayoutSanitizationService).to receive(:sanitize_multiloc).and_return(
+          expected_multiloc
+        )
 
         params = {
           project_id: project_id,
           code: code,
-          content_builder_layout: { craftjs_jsonmultiloc: { 'en' => input_craftjson } }
+          content_builder_layout: { craftjs_jsonmultiloc: { 'en' => { 'unsanitized_craftjson' => {} } }  }
         }
         post :upsert, params: params, format: :json
         expect(response.status).to eq 201
-        expect(JSON.parse(response.body).dig('data', 'attributes', 'craftjs_jsonmultiloc')).to eq(
-          { 'en' => expected_craftjson }
-        )
+        expect(JSON.parse(response.body).dig('data', 'attributes', 'craftjs_jsonmultiloc')).to eq(expected_multiloc)
       end
     end
 
@@ -153,20 +152,20 @@ RSpec.describe ::ContentBuilder::WebApi::V1::ContentBuilderLayoutsController, ty
       end
 
       it 'sanitizes HTML inside text elements' do
-        input_craftjson = craftjson_with_text '<p>Unsanitized text</p>'
-        expected_craftjson = craftjson_with_text '<p>Sanitized text</p>'
-        allow_any_instance_of(SanitizationService).to receive(:sanitize).and_return('<p>Sanitized text</p>')
+        expected_multiloc = { 'en' => { 'sanitized_craftjson' => {} } }
+        layout # also calls sanitize_multiloc (to make the expectation below work)
+        expect_any_instance_of(ContentBuilder::LayoutSanitizationService).to receive(:sanitize_multiloc).and_return(
+          expected_multiloc
+        )
 
         params = {
           project_id: project_id,
           code: code,
-          content_builder_layout: { craftjs_jsonmultiloc: { 'en' => input_craftjson } }
+          content_builder_layout: { craftjs_jsonmultiloc: { 'en' => { 'unsanitized_craftjson' => {} } } }
         }
         post :upsert, params: params, format: :json
         expect(response.status).to eq 200
-        expect(JSON.parse(response.body).dig('data', 'attributes', 'craftjs_jsonmultiloc')).to eq(
-          { 'en' => expected_craftjson }
-        )
+        expect(JSON.parse(response.body).dig('data', 'attributes', 'craftjs_jsonmultiloc')).to eq(expected_multiloc)
       end
     end
 
@@ -261,43 +260,5 @@ RSpec.describe ::ContentBuilder::WebApi::V1::ContentBuilderLayoutsController, ty
         expect(response.content_type).to eq 'application/json'
       end
     end
-  end
-
-  def craftjson_with_text(text)
-    {
-      'ROOT' => {
-        'type' => 'div',
-        'isCanvas' => true,
-        'props' => {
-          'id' => 'e2e-content-builder-frame',
-          'style' => {
-            'padding' => '4px',
-            'minHeight' => '160px',
-            'backgroundColor' => '#fff'
-          }
-        },
-        'displayName' => 'div',
-        'custom' => {},
-        'hidden' => false,
-        'nodes' => ['XGtvXcaUr3'],
-        'linkedNodes' => {}
-      },
-      'XGtvXcaUr3' => {
-        'type' => {
-          'resolvedName' => 'Text'
-        },
-        'isCanvas' => false,
-        'props' => {
-          'text' => text,
-          'id' => 'text'
-        },
-        'displayName' => 'Text',
-        'custom' => {},
-        'parent' => 'ROOT',
-        'hidden' => false,
-        'nodes' => [],
-        'linkedNodes' => {}
-      }
-    }
   end
 end

--- a/back/engines/commercial/content_builder/spec/models/content_builder/layout_spec.rb
+++ b/back/engines/commercial/content_builder/spec/models/content_builder/layout_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe ContentBuilder::Layout, type: :model do
       expect(layout.errors.details).to eq({ code: [{ error: :blank }] })
     end
 
-    it 'returns false when an iframe with url not from the whitelist is present' do
+    it 'returns false for an iframe with a non-whitelisted url' do
       url = 'http://malicious.com/my-video'
       craftjs_jsonmultiloc = { 'en' => craftjson_with_iframe_url(url) }
       layout = build(:layout, craftjs_jsonmultiloc: craftjs_jsonmultiloc)

--- a/back/engines/commercial/content_builder/spec/models/content_builder/layout_spec.rb
+++ b/back/engines/commercial/content_builder/spec/models/content_builder/layout_spec.rb
@@ -26,8 +26,21 @@ RSpec.describe ContentBuilder::Layout, type: :model do
       expect(layout.errors.details).to eq({ code: [{ error: :blank }] })
     end
 
+    it 'returns false when an iframe with url not from the whitelist is present' do
+      url = 'http://malicious.com/my-video'
+      craftjs_jsonmultiloc = { 'en' => craftjson_with_iframe_url(url) }
+      layout = build(:layout, craftjs_jsonmultiloc: craftjs_jsonmultiloc)
+      expect(layout).to be_invalid
+      expect(layout.errors.details).to eq({ craftjs_jsonmultiloc: [{
+        error: :iframe_url_not_whitelisted,
+        locale: 'en',
+        url: url
+      }] })
+    end
+
     it 'returns true otherwise' do
-      expect(build(:layout)).to be_valid
+      craftjs_jsonmultiloc = { 'en' => craftjson_with_iframe_url('https://www.youtube.com/embed/gdfWFDcXut4') }
+      expect(build(:layout, craftjs_jsonmultiloc: craftjs_jsonmultiloc)).to be_valid
     end
   end
 
@@ -68,5 +81,46 @@ RSpec.describe ContentBuilder::Layout, type: :model do
         expect { layout.content_buildable }.to raise_error NameError
       end
     end
+  end
+
+  def craftjson_with_iframe_url(url)
+    {
+      'ROOT' => {
+        'type' => 'div',
+        'isCanvas' => true,
+        'props' => {
+          'style' => {
+            'padding' => '4px',
+            'minHeight' => '160px',
+            'backgroundColor' => '#fff'
+          }
+        },
+        'displayName' => 'div',
+        'custom' => {},
+        'hidden' => false,
+        'nodes' => [
+          'sLvtGHTAha'
+        ],
+        'linkedNodes' => {}
+      },
+      'sLvtGHTAha' => {
+        'type' => {
+          'resolvedName' => 'Iframe'
+        },
+        'isCanvas' => false,
+        'props' => {
+          'url' => url,
+          'height' => '400',
+          'id' => 'Iframe',
+          'hasError' => false
+        },
+        'displayName' => 'CraftIframe',
+        'custom' => {},
+        'parent' => 'ROOT',
+        'hidden' => false,
+        'nodes' => [],
+        'linkedNodes' => {}
+      }
+    }
   end
 end

--- a/back/engines/commercial/content_builder/spec/services/content_builder/layout_sanitization_service_spec.rb
+++ b/back/engines/commercial/content_builder/spec/services/content_builder/layout_sanitization_service_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+describe ContentBuilder::LayoutSanitizationService do
+  let(:service) { described_class.new }
+
+  describe 'sanitize_multiloc' do
+    it 'sanitizes the HTML in text elements' do
+      input_craftjson = craftjson_with_text '<p>Unsanitized text</p>'
+      expected_craftjson = craftjson_with_text '<p>Sanitized text</p>'
+      allow(service.send(:html_sanitizer)).to receive(:sanitize).and_return('<p>Sanitized text</p>')
+
+      output = service.sanitize_multiloc({ 'fr-BE' => input_craftjson })
+      expect(service.send(:html_sanitizer)).to have_received(:sanitize)
+      expect(output).to eq({ 'fr-BE' => expected_craftjson })
+    end
+  end
+
+  def craftjson_with_text(text)
+    {
+      'ROOT' => {
+        'type' => 'div',
+        'isCanvas' => true,
+        'props' => {
+          'id' => 'e2e-content-builder-frame',
+          'style' => {
+            'padding' => '4px',
+            'minHeight' => '160px',
+            'backgroundColor' => '#fff'
+          }
+        },
+        'displayName' => 'div',
+        'custom' => {},
+        'hidden' => false,
+        'nodes' => ['XGtvXcaUr3'],
+        'linkedNodes' => {}
+      },
+      'XGtvXcaUr3' => {
+        'type' => {
+          'resolvedName' => 'Text'
+        },
+        'isCanvas' => false,
+        'props' => {
+          'text' => text,
+          'id' => 'text'
+        },
+        'displayName' => 'Text',
+        'custom' => {},
+        'parent' => 'ROOT',
+        'hidden' => false,
+        'nodes' => [],
+        'linkedNodes' => {}
+      }
+    }
+  end
+end

--- a/back/spec/validators/multiloc_validator_spec.rb
+++ b/back/spec/validators/multiloc_validator_spec.rb
@@ -18,6 +18,12 @@ class Validatable3
   attr_accessor :multiloc_field
 end
 
+class Validatable4
+  include ActiveModel::Validations
+  validates :multiloc_field, multiloc: { value_type: Hash }
+  attr_accessor :multiloc_field
+end
+
 describe MultilocValidator do
   let(:presence_subject) { Validatable.new }
   let(:nonpresence_subject) { Validatable2.new }
@@ -72,6 +78,42 @@ describe MultilocValidator do
     it 'is invalid' do
       presence_subject.multiloc_field = { 'smalltalk' => 'Hey how are you?' }
       expect(presence_subject).to be_invalid
+    end
+  end
+
+  context 'with string values' do
+    it 'is invalid some values are not strings' do
+      nonpresence_subject.multiloc_field = { 'en' => 'My value', 'nl-BE' => false }
+      expect(nonpresence_subject).to be_invalid
+    end
+
+    it 'is invalid some values are nil' do
+      nonpresence_subject.multiloc_field = { 'en' => 'My value', 'nl-BE' => nil }
+      expect(nonpresence_subject).to be_invalid
+    end
+
+    it 'is valid when all values are strings' do
+      nonpresence_subject.multiloc_field = { 'en' => 'My value', 'nl-BE' => '' }
+      expect(nonpresence_subject).to be_valid
+    end
+  end
+
+  context 'with hash values' do
+    let(:hashed_multiloc_subject) { Validatable4.new }
+
+    it 'is invalid some values are not hashes' do
+      hashed_multiloc_subject.multiloc_field = { 'en' => { my_value: 53 }, 'nl-BE' => 'test' }
+      expect(hashed_multiloc_subject).to be_invalid
+    end
+
+    it 'is invalid some values are nil' do
+      hashed_multiloc_subject.multiloc_field = { 'en' => { my_value: 53 }, 'fr-BE' => nil }
+      expect(hashed_multiloc_subject).to be_invalid
+    end
+
+    it 'is valid when all values are strings' do
+      hashed_multiloc_subject.multiloc_field = { 'en' => { my_value: 53 }, 'de-DE' => {} }
+      expect(hashed_multiloc_subject).to be_valid
     end
   end
 

--- a/back/spec/validators/multiloc_validator_spec.rb
+++ b/back/spec/validators/multiloc_validator_spec.rb
@@ -101,7 +101,7 @@ describe MultilocValidator do
   context 'with hash values' do
     let(:hashed_multiloc_subject) { Validatable4.new }
 
-    it 'is invalid some values are not hashes' do
+    it 'is invalid when some values are not hashes' do
       hashed_multiloc_subject.multiloc_field = { 'en' => { my_value: 53 }, 'nl-BE' => 'test' }
       expect(hashed_multiloc_subject).to be_invalid
     end

--- a/back/spec/validators/multiloc_validator_spec.rb
+++ b/back/spec/validators/multiloc_validator_spec.rb
@@ -87,7 +87,7 @@ describe MultilocValidator do
       expect(nonpresence_subject).to be_invalid
     end
 
-    it 'is invalid some values are nil' do
+    it 'is invalid when some values are nil' do
       nonpresence_subject.multiloc_field = { 'en' => 'My value', 'nl-BE' => nil }
       expect(nonpresence_subject).to be_invalid
     end

--- a/back/spec/validators/multiloc_validator_spec.rb
+++ b/back/spec/validators/multiloc_validator_spec.rb
@@ -106,7 +106,7 @@ describe MultilocValidator do
       expect(hashed_multiloc_subject).to be_invalid
     end
 
-    it 'is invalid some values are nil' do
+    it 'is invalid when some values are nil' do
       hashed_multiloc_subject.multiloc_field = { 'en' => { my_value: 53 }, 'fr-BE' => nil }
       expect(hashed_multiloc_subject).to be_invalid
     end

--- a/back/spec/validators/multiloc_validator_spec.rb
+++ b/back/spec/validators/multiloc_validator_spec.rb
@@ -82,7 +82,7 @@ describe MultilocValidator do
   end
 
   context 'with string values' do
-    it 'is invalid some values are not strings' do
+    it 'is invalid when some values are not strings' do
       nonpresence_subject.multiloc_field = { 'en' => 'My value', 'nl-BE' => false }
       expect(nonpresence_subject).to be_invalid
     end


### PR DESCRIPTION
- Multiloc validator now supports other types of values than strings.
- Validate that crafjson iframes have URLs from the whitelist.
- Sanitize HTML in text elements in craftjson.