### PR TITLE
[DISP-92] Fix budget field not showing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next Release
 
+### Fixed
+
+- Fixed issue with budget field not showing in input form
+
 ## 2022-05-02
 
 ### Added

--- a/front/app/components/IdeaForm/index.tsx
+++ b/front/app/components/IdeaForm/index.tsx
@@ -718,7 +718,7 @@ class IdeaForm extends PureComponent<
       const showTopics =
         topicsEnabled && allowedTopics && allowedTopics.length > 0;
       const showLocation = locationEnabled;
-      const showproposedBudget = proposedBudgetEnabled;
+      const showProposedBudget = proposedBudgetEnabled;
       const inputTerm = getInputTerm(
         project.attributes.process_type,
         project,
@@ -846,7 +846,10 @@ class IdeaForm extends PureComponent<
             </FormElement>
           </StyledFormSection>
 
-          {(showPBBudget || showTopics || showLocation) && (
+          {(showPBBudget ||
+            showTopics ||
+            showLocation ||
+            showProposedBudget) && (
             <StyledFormSection>
               <FormSectionTitle message={messages.formDetailsSectionTitle} />
               {showPBBudget && (
@@ -876,7 +879,7 @@ class IdeaForm extends PureComponent<
                 </HasPermission>
               )}
 
-              {showproposedBudget && (
+              {showProposedBudget && (
                 <FormElement>
                   <FormLabel
                     htmlFor="estimated-budget"


### PR DESCRIPTION
[This issue](https://citizenlab.atlassian.net/browse/DISP-92) was reported again by the customer, and when I looked at Master, the changes made in the previous [PR](https://github.com/CitizenLabDotCo/citizenlab/pull/1807) to fix this were gone. I'm not quite sure how that happened, perhaps something went wrong with the release?

Regardless, this is a high priority fix and the changes in this PR are the same as the previous one to fix the problem. 