### PR TITLE
[CL-728] Stubbing images bug

### DIFF
--- a/back/spec/services/text_image_service_spec.rb
+++ b/back/spec/services/text_image_service_spec.rb
@@ -5,7 +5,7 @@ describe TextImageService do
 
   describe 'swap_data_images' do
     before do
-      stub_request(:any, 'res.cloudinary.com').with(
+      stub_request(:any, 'res.cloudinary.com').to_return(
         body: png_image_as_base64('image10.png')
       )
     end


### PR DESCRIPTION
`to_return` needs to be used to specify the return body of the stubbed request, instead of with. We still couldn't make it work for non-existing URLs.