### PR TITLE
CL-647 Content builder UX updates

### DIFF
--- a/front/app/modules/commercial/content_builder/admin/components/ContentBuilderSettings/index.tsx
+++ b/front/app/modules/commercial/content_builder/admin/components/ContentBuilderSettings/index.tsx
@@ -51,7 +51,7 @@ const ContentBuilderSettings = () => {
       p="20px"
       w="400px"
       h="100%"
-      background={colors.adminDarkBackground}
+      background="#ffffff"
     >
       <Title variant="h2">
         <FormattedMessage {...getComponentNameMessage(selected.name)} />

--- a/front/app/modules/commercial/content_builder/admin/components/ContentBuilderToggle/index.tsx
+++ b/front/app/modules/commercial/content_builder/admin/components/ContentBuilderToggle/index.tsx
@@ -121,12 +121,12 @@ const ContentBuilderToggle = ({
       )}
       {contentBuilderLinkVisible && (
         <>
-          <Box marginBottom="20px">
-            <Warning>{formatMessage(messages.layoutBuilderWarning)}</Warning>
-          </Box>
           <StyledLink id="e2e-content-builder-link" to={route}>
             {formatMessage(messages.linkText)}
           </StyledLink>
+          <Box mt="10px">
+            <Warning>{formatMessage(messages.layoutBuilderWarning)}</Warning>
+          </Box>
         </>
       )}
       {!contentBuilderLinkVisible && (

--- a/front/app/modules/commercial/content_builder/admin/components/ContentBuilderToolbox/ToolboxItem.tsx
+++ b/front/app/modules/commercial/content_builder/admin/components/ContentBuilderToolbox/ToolboxItem.tsx
@@ -13,6 +13,7 @@ interface Props {
 const StyledBox = styled(Box)`
   &:hover {
     background-color: ${colors.emailBg};
+    transition: background-color 80ms ease-out 0s;
   }
 `;
 

--- a/front/app/modules/commercial/content_builder/admin/components/ContentBuilderTopBar/index.tsx
+++ b/front/app/modules/commercial/content_builder/admin/components/ContentBuilderTopBar/index.tsx
@@ -30,6 +30,7 @@ import { FormattedMessage } from 'utils/cl-intl';
 // routing
 import clHistory from 'utils/cl-router/history';
 import { withRouter } from 'react-router';
+import Link from 'utils/cl-router/Link';
 
 // services
 import {
@@ -100,6 +101,18 @@ const ContentBuilderPage = ({ params: { projectId } }) => {
             </>
           )}
         </Box>
+        {!isNilOrError(project) && (
+          <Link to={`/projects/${project?.attributes.slug}`} target="_blank">
+            <Button
+              mr="16px"
+              buttonStyle="secondary"
+              icon="eye"
+              id="to-project"
+            >
+              <FormattedMessage {...messages.viewPublicProject} />
+            </Button>
+          </Link>
+        )}
         <Button
           id="e2e-content-builder-topbar-save"
           buttonStyle="primary"

--- a/front/app/modules/commercial/content_builder/admin/components/ContentBuilderTopBar/index.tsx
+++ b/front/app/modules/commercial/content_builder/admin/components/ContentBuilderTopBar/index.tsx
@@ -102,7 +102,7 @@ const ContentBuilderPage = ({ params: { projectId } }) => {
           )}
         </Box>
         {!isNilOrError(project) && (
-          <Link to={`/projects/${project?.attributes.slug}`} target="_blank">
+          <Link to={`/projects/${project.attributes.slug}`} target="_blank">
             <Button
               mr="16px"
               buttonStyle="secondary"

--- a/front/app/modules/commercial/content_builder/admin/components/ContentBuilderTopBar/messages.ts
+++ b/front/app/modules/commercial/content_builder/admin/components/ContentBuilderTopBar/messages.ts
@@ -9,4 +9,8 @@ export default defineMessages({
     id: 'app.containers.ContentBuilder.Save',
     defaultMessage: 'Save',
   },
+  viewPublicProject: {
+    id: 'app.containers.AdminPage.ProjectDescription.viewPublicProject',
+    defaultMessage: 'View project',
+  },
 });

--- a/front/app/modules/commercial/content_builder/admin/containers/index.tsx
+++ b/front/app/modules/commercial/content_builder/admin/containers/index.tsx
@@ -39,7 +39,7 @@ const ContentBuilderPage = ({ params: { projectId } }) => {
             display="flex"
             flexDirection="column"
             alignItems="center"
-            bgColor={colors.adminDarkBackground}
+            bgColor="#ffffff"
             borderRight={`1px solid ${colors.mediumGrey}`}
           >
             <ContentBuilderToolbox />

--- a/front/app/translations/admin/en.json
+++ b/front/app/translations/admin/en.json
@@ -714,6 +714,7 @@
   "app.containers.AdminPage.ProjectDescription.titleDescription": "Project description",
   "app.containers.AdminPage.ProjectDescription.toggleLabel": "Use page builder for description",
   "app.containers.AdminPage.ProjectDescription.toggleTooltip": "Using the page builder will let you use more advanced layout options.",
+  "app.containers.AdminPage.ProjectDescription.viewPublicProject": "View project",
   "app.containers.AdminPage.ProjectEdit.MapTab.cancel": "Cancel editing",
   "app.containers.AdminPage.ProjectEdit.MapTab.centerLatLabelTooltip": "The default latitude of the map center point. Accepts a value between -90 and 90.",
   "app.containers.AdminPage.ProjectEdit.MapTab.centerLngLabelTooltip": "The default longitude of the map center point. Accepts a value between -90 and 90.",


### PR DESCRIPTION
## Description
Fixed a short list of small UX requests for the content builder:
- Back office: put ‘Edit description in page builder’ link above the info/warning box
- Update background colour for toolbox and settings panels to white
- Add a ‘View project’ link in Page builder top bar with a target="_blank"
- Add transition on toolbox item hover states (same as back office  background-color 80ms ease-out 0s; )

## Checklist

- [X] WCAG 2.1 AA proof
- [X] Prepared branch for code review

## How urgent is a code review?
End of week if possible? Changes are quite small.
