### PR TITLE
[CL-166] Sending a campaign multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - [CL-181] Prevent forms from trying to save on clicking label
+- The "send" button on the email campaign send page is now disabled after a single click, to prevent users from clicking it multiple times and potentially sending a campaign more than once
 
 ## 2022-05-06
 

--- a/front/app/containers/Admin/messaging/CustomEmails/Show/index.tsx
+++ b/front/app/containers/Admin/messaging/CustomEmails/Show/index.tsx
@@ -148,6 +148,7 @@ interface Props
 
 interface State {
   showSendConfirmationModal: boolean;
+  isCampaignSending: boolean;
 }
 
 class Show extends React.Component<Props, State> {
@@ -155,6 +156,7 @@ class Show extends React.Component<Props, State> {
     super(props);
     this.state = {
       showSendConfirmationModal: false,
+      isCampaignSending: false,
     };
   }
 
@@ -162,7 +164,10 @@ class Show extends React.Component<Props, State> {
     if (noGroupsSelected) {
       this.openSendConfirmationModal();
     } else {
-      sendCampaign(this.props.campaign.id);
+      this.setState({ isCampaignSending: true }, async () => {
+        const result = await sendCampaign(this.props.campaign.id);
+        console.log({ result });
+      });
     }
   };
 
@@ -207,14 +212,16 @@ class Show extends React.Component<Props, State> {
   };
 
   confirmSendCampaign = (campaignId: string) => () => {
-    sendCampaign(campaignId).then(() => {
-      this.closeSendConfirmationModal();
+    this.setState({ isCampaignSending: true }, () => {
+      sendCampaign(campaignId).then(() => {
+        this.closeSendConfirmationModal();
+      });
     });
   };
 
   render() {
     const { campaign } = this.props;
-    const { showSendConfirmationModal } = this.state;
+    const { showSendConfirmationModal, isCampaignSending } = this.state;
 
     if (campaign) {
       const groupIds: string[] = campaign.relationships.groups.data.map(
@@ -256,6 +263,8 @@ class Show extends React.Component<Props, State> {
                   icon="send"
                   iconPos="right"
                   onClick={this.handleSend(noGroupsSelected)}
+                  disabled={isCampaignSending}
+                  processing={isCampaignSending}
                 >
                   <FormattedMessage {...messages.send} />
                 </Button>
@@ -353,6 +362,8 @@ class Show extends React.Component<Props, State> {
                   onClick={this.confirmSendCampaign(this.props.campaign.id)}
                   icon="send"
                   iconPos="right"
+                  disabled={isCampaignSending}
+                  processing={isCampaignSending}
                 >
                   <FormattedMessage {...messages.sendNowButton} />
                 </Button>

--- a/front/app/containers/Admin/messaging/CustomEmails/Show/index.tsx
+++ b/front/app/containers/Admin/messaging/CustomEmails/Show/index.tsx
@@ -164,9 +164,8 @@ class Show extends React.Component<Props, State> {
     if (noGroupsSelected) {
       this.openSendConfirmationModal();
     } else {
-      this.setState({ isCampaignSending: true }, async () => {
-        const result = await sendCampaign(this.props.campaign.id);
-        console.log({ result });
+      this.setState({ isCampaignSending: true }, () => {
+        sendCampaign(this.props.campaign.id);
       });
     }
   };


### PR DESCRIPTION
https://citizenlab.atlassian.net/browse/CL-166

Here's a test with my browser throttled to slow 3g, so everything takes a moment to load, but I assume slow conditions were what caused the initial bug so I wanted to test that way:

https://user-images.githubusercontent.com/3614128/167116152-0534bec8-7901-4406-a972-b776460d23b4.mov



## Checklist

- [ ] Added entry to changelog
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

- [ ] WCAG 2.1 AA proof
<details>
<summary>More info</summary>
For front-end devs only. Is your work conforming with the WCAG 2.1 AA rules? If you need more info, read the [a11y page](https://www.notion.so/citizenlab/a11y-7568f83d42ab4895ac133b89d358997b) on our Notion.
</details>

- [ ] Tests
<details>
<summary>More info</summary>

### Unit tests

Did you add relevant unit tests?

### E2E tests

Sometimes it can be more efficient to update E2E tests after CI has run them. If you know which ones to update, go ahead! E2E template cl2-back:

```bash
docker compose run --rm web bin/rails cl2_back:create_tenant[localhost,e2etests_template]
```

</details>

- [ ] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## Links

- [citizenlab-ee PR](**put URL here** or remove)
- [Specs](**put URL here** or remove)
- [Epic Deployment](**put URL here** or remove)

## How urgent is a code review?

Let the reviewer(s) know how urgent the code review is, so they can prioritize their work accordingly. Be specific (e.g. by Wednesday, end of the day/this week/... is better than 'urgent' or 'very urgent'). Optionally provide a word of explanation on your deadline.
