### PR TITLE
[CL-387] Improve folder view layout for narrow screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [CL-181] Prevent forms from trying to save on clicking label
 - The "send" button on the email campaign send page is now disabled after a single click, to prevent users from clicking it multiple times and potentially sending a campaign more than once
+- [CL-387] The folder show page is better readable on narrow screens now
 
 ## 2022-05-06
 

--- a/front/app/modules/commercial/project_folders/citizen/containers/ProjectFolderShowPage/index.tsx
+++ b/front/app/modules/commercial/project_folders/citizen/containers/ProjectFolderShowPage/index.tsx
@@ -43,7 +43,7 @@ const Container = styled.main`
   flex-direction: column;
   background: #fff;
 
-  ${media.smallerThan1100px`
+  ${media.smallerThan1280px`
     background: ${colors.background};
   `}
 
@@ -65,7 +65,7 @@ const StyledContentContainer = styled(ContentContainer)`
   padding-top: 30px;
   background: #fff;
 
-  @media (min-width: 1100px) {
+  @media (min-width: 1280px) {
     padding-left: 60px;
     padding-right: 60px;
   }
@@ -98,7 +98,7 @@ const Content = styled.div`
   justify-content: flex-start;
   margin-bottom: 110px;
 
-  ${media.smallerThan1100px`
+  ${media.smallerThan1280px`
     flex-direction: column;
     align-items: stretch;
   `};
@@ -107,7 +107,7 @@ const Content = styled.div`
 const StyledProjectFolderDescription = styled(ProjectFolderDescription)`
   flex: 1;
 
-  ${media.smallerThan1100px`
+  ${media.smallerThan1280px`
     margin-bottom: 40px;
   `};
 `;
@@ -127,7 +127,7 @@ const StyledProjectFolderProjectCards = styled(ProjectFolderProjectCards)`
     width: 500px;
   }
 
-  ${media.smallerThan1100px`
+  ${media.smallerThan1280px`
     flex: 1;
     width: 100%;
     margin: 0;
@@ -166,7 +166,7 @@ const ProjectFolderShowPage = memo<{
     publicationStatusFilter: publicationStatuses,
   });
   const { windowWidth } = useWindowSize();
-  const smallerThan1100px = windowWidth ? windowWidth <= 1100 : false;
+  const smallerThan1280px = windowWidth ? windowWidth <= 1280 : false;
   const folderNotFound = isError(projectFolder);
 
   const loading =
@@ -199,7 +199,7 @@ const ProjectFolderShowPage = memo<{
           </Loading>
         ) : !isNilOrError(projectFolder) && !isNilOrError(locale) ? (
           <>
-            {!smallerThan1100px ? (
+            {!smallerThan1280px ? (
               <StyledContentContainer maxWidth={maxPageWidth}>
                 {userCanEditFolder && (
                   <ButtonBar>


### PR DESCRIPTION
Before this change, when your screen width was around 1100px wide, the text content on the left was very narrow, making it difficult to read.
    
With this change applied we start using the one column layout at around 1280px already, therefore preventing the issue from appearing on narrow screens.


## Before

![Screen Shot 2022-05-06 at 15 56 58](https://user-images.githubusercontent.com/866318/167147557-edf967fc-369b-4b8d-8610-80c0b908feb6.png)

## After
![Screen Shot 2022-05-06 at 15 55 55](https://user-images.githubusercontent.com/866318/167147621-6d6e878b-8b21-4844-8571-7210c8974c0c.png)

## Checklist

- [x] Added entry to changelog
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

- [x] WCAG 2.1 AA proof
<details>
<summary>More info</summary>
For front-end devs only. Is your work conforming with the WCAG 2.1 AA rules? If you need more info, read the [a11y page](https://www.notion.so/citizenlab/a11y-7568f83d42ab4895ac133b89d358997b) on our Notion.
</details>

- [x] Tests
<details>
<summary>More info</summary>

### Unit tests

Did you add relevant unit tests?

### E2E tests

Sometimes it can be more efficient to update E2E tests after CI has run them. If you know which ones to update, go ahead! E2E template cl2-back:

```bash
docker compose run --rm web bin/rails cl2_back:create_tenant[localhost,e2etests_template]
```

</details>

- [ ] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## Links

- [citizenlab-ee PR](**put URL here** or remove)
- [Specs](**put URL here** or remove)
- [Epic Deployment](**put URL here** or remove)

## How urgent is a code review?

Let the reviewer(s) know how urgent the code review is, so they can prioritize their work accordingly. Be specific (e.g. by Wednesday, end of the day/this week/... is better than 'urgent' or 'very urgent'). Optionally provide a word of explanation on your deadline.
