### PR TITLE
CL-716 Send out new phase started email/notification for info contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Next release
+
+### Changed
+
+- The new phase started emails/notifications are also sent out for information phases or when it's possible to take a poll.
+
 ## 2022-05-06_3
 
 ### Changed

--- a/back/app/services/participation_context_service.rb
+++ b/back/app/services/participation_context_service.rb
@@ -65,11 +65,14 @@ class ParticipationContextService
     end
   end
 
-  def participation_possible_for_context? context, user
+  def participation_possible_for_context?(context, user)
+    return true if context.information?
+
     !(posting_idea_disabled_reason_for_context(context, user)\
     && commenting_idea_disabled_reason_for_context(context, user)\
     && idea_voting_disabled_reason_for(context, user)\
     && taking_survey_disabled_reason_for_context(context, user)\
+    && taking_poll_disabled_reason_for_context(context, user)\
     && budgeting_disabled_reason_for_context(context, user))
   end
 

--- a/back/spec/models/notifications/project_phase_started_spec.rb
+++ b/back/spec/models/notifications/project_phase_started_spec.rb
@@ -19,13 +19,13 @@ RSpec.describe Notifications::ProjectPhaseStarted, type: :model do
     it 'only creates a notification for users who can participate' do
       phase = create :phase
       activity = create :activity, item: phase, action: 'started'
-      create_list :user, 5
+      create_list :user, 2
       allow_any_instance_of(ParticipationContextService).to(
-        receive(:participation_possible_for_context?).and_return(true, false, true, false)
+        receive(:participation_possible_for_context?).and_return(true, false)
       )
 
       notifications = described_class.make_notifications_on activity
-      expect(notifications.size).to eq 2
+      expect(notifications.size).to eq 1
     end
   end
 end

--- a/back/spec/models/notifications/project_phase_started_spec.rb
+++ b/back/spec/models/notifications/project_phase_started_spec.rb
@@ -8,12 +8,24 @@ RSpec.describe Notifications::ProjectPhaseStarted, type: :model do
       phase = create(:phase)
       activity = create(:activity, item: phase, action: 'started')
 
-      notifications = Notifications::ProjectPhaseStarted.make_notifications_on activity
+      notifications = described_class.make_notifications_on activity
       expect(notifications.first).to have_attributes(
         recipient_id: user.id,
         phase_id: phase.id,
         project_id: phase.project_id
       )
+    end
+
+    it 'only creates a notification for users who can participate' do
+      phase = create :phase
+      activity = create :activity, item: phase, action: 'started'
+      create_list :user, 5
+      allow_any_instance_of(ParticipationContextService).to(
+        receive(:participation_possible_for_context?).and_return(true, false, true, false)
+      )
+
+      notifications = described_class.make_notifications_on activity
+      expect(notifications.size).to eq 2
     end
   end
 end

--- a/back/spec/services/participation_context_service_spec.rb
+++ b/back/spec/services/participation_context_service_spec.rb
@@ -4,14 +4,60 @@ describe ParticipationContextService do
   let(:service) { ParticipationContextService.new }
 
   describe 'participation_possible_for_context?' do
-    it 'returns true when participation is possible' do
-      project = create(:continuous_project, posting_enabled: true)
-      expect(service.participation_possible_for_context?(project, create(:user))).to be_truthy
+    let(:no_participation_attributes) do
+      {
+        participation_method: 'ideation',
+        posting_enabled: false,
+        voting_enabled: false,
+        commenting_enabled: false
+      }
+    end
+
+    it 'returns true when posting is possible' do
+      expect(service).to receive(:posting_idea_disabled_reason_for_context).and_return nil
+      project = create :continuous_project, no_participation_attributes
+      expect(service.participation_possible_for_context?(project, create(:user))).to eq true
+    end
+
+    it 'returns true when commenting is possible' do
+      expect(service).to receive(:commenting_idea_disabled_reason_for_context).and_return nil
+      project = create :continuous_project, no_participation_attributes
+      expect(service.participation_possible_for_context?(project, create(:user))).to eq true
+    end
+
+    it 'returns true when voting is possible' do
+      expect(service).to receive(:idea_voting_disabled_reason_for).and_return nil
+      project = create :continuous_project, no_participation_attributes
+      expect(service.participation_possible_for_context?(project, create(:user))).to eq true
+    end
+
+    it "returns true when it's possible to take a survey" do
+      expect(service).to receive(:taking_survey_disabled_reason_for_context).and_return nil
+      project = create :continuous_project, no_participation_attributes
+      expect(service.participation_possible_for_context?(project, create(:user))).to eq true
+    end
+
+    it "returns true when it's possible to take a poll" do
+      expect(service).to receive(:taking_poll_disabled_reason_for_context).and_return nil
+      project = create :continuous_project, no_participation_attributes
+      expect(service.participation_possible_for_context?(project, create(:user))).to eq true
+    end
+
+    it 'returns true when participatory budgeting is possible' do
+      expect(service).to receive(:budgeting_disabled_reason_for_context).and_return nil
+      project = create :continuous_project, no_participation_attributes
+      expect(service.participation_possible_for_context?(project, create(:user))).to eq true
+    end
+
+    it 'returns true for information contexts' do
+      no_participation_attributes[:participation_method] = 'information'
+      project = create :continuous_project, no_participation_attributes
+      expect(service.participation_possible_for_context?(project, create(:user))).to eq true
     end
 
     it 'returns false when no participation is possible' do
-      project = create(:continuous_project, posting_enabled: false, voting_enabled: false, commenting_enabled: false)
-      expect(service.participation_possible_for_context?(project, create(:user))).to be_falsey
+      project = create :continuous_project, no_participation_attributes
+      expect(service.participation_possible_for_context?(project, create(:user))).to eq false
     end
   end
 

--- a/back/spec/services/participation_context_service_spec.rb
+++ b/back/spec/services/participation_context_service_spec.rb
@@ -16,48 +16,48 @@ describe ParticipationContextService do
     it 'returns true when posting is possible' do
       expect(service).to receive(:posting_idea_disabled_reason_for_context).and_return nil
       project = create :continuous_project, no_participation_attributes
-      expect(service.participation_possible_for_context?(project, create(:user))).to eq true
+      expect(service.participation_possible_for_context?(project, create(:user))).to be true
     end
 
     it 'returns true when commenting is possible' do
       expect(service).to receive(:commenting_idea_disabled_reason_for_context).and_return nil
       project = create :continuous_project, no_participation_attributes
-      expect(service.participation_possible_for_context?(project, create(:user))).to eq true
+      expect(service.participation_possible_for_context?(project, create(:user))).to be true
     end
 
     it 'returns true when voting is possible' do
       expect(service).to receive(:idea_voting_disabled_reason_for).and_return nil
       project = create :continuous_project, no_participation_attributes
-      expect(service.participation_possible_for_context?(project, create(:user))).to eq true
+      expect(service.participation_possible_for_context?(project, create(:user))).to be true
     end
 
     it "returns true when it's possible to take a survey" do
       expect(service).to receive(:taking_survey_disabled_reason_for_context).and_return nil
       project = create :continuous_project, no_participation_attributes
-      expect(service.participation_possible_for_context?(project, create(:user))).to eq true
+      expect(service.participation_possible_for_context?(project, create(:user))).to be true
     end
 
     it "returns true when it's possible to take a poll" do
       expect(service).to receive(:taking_poll_disabled_reason_for_context).and_return nil
       project = create :continuous_project, no_participation_attributes
-      expect(service.participation_possible_for_context?(project, create(:user))).to eq true
+      expect(service.participation_possible_for_context?(project, create(:user))).to be true
     end
 
     it 'returns true when participatory budgeting is possible' do
       expect(service).to receive(:budgeting_disabled_reason_for_context).and_return nil
       project = create :continuous_project, no_participation_attributes
-      expect(service.participation_possible_for_context?(project, create(:user))).to eq true
+      expect(service.participation_possible_for_context?(project, create(:user))).to be true
     end
 
     it 'returns true for information contexts' do
       no_participation_attributes[:participation_method] = 'information'
       project = create :continuous_project, no_participation_attributes
-      expect(service.participation_possible_for_context?(project, create(:user))).to eq true
+      expect(service.participation_possible_for_context?(project, create(:user))).to be true
     end
 
     it 'returns false when no participation is possible' do
       project = create :continuous_project, no_participation_attributes
-      expect(service.participation_possible_for_context?(project, create(:user))).to eq false
+      expect(service.participation_possible_for_context?(project, create(:user))).to be false
     end
   end
 


### PR DESCRIPTION
The new phase started email is currently not sent out when an information phase starts (with no participation). According to product, consulting an information phase should also be considered to be a form of participation and it is therefore required to also receive these emails/notifications for information phases.

The email is triggered by the corresponding "notification created" activity; i.e. when a user receives a "new phase started" notification on the platform, an email is sent out as well. The notifications are only created when `participation_possible_for_context?` returns true for the phase and recipient (and the recipient must have viewing rights for the project as well).

I also propose to consider "taking a poll" as participation. As "taking a survey" is also considered as participation, I don't think the current behaviour makes sense.