### PR TITLE
CL-764 NavBarItem titles bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Next release
+
+### Fixed
+
+- [CL-764] Empty navbar item titles in backoffice.
+
 ## 2022-05-10_2
 
 ### Changed

--- a/back/app/serializers/web_api/v1/static_page_serializer.rb
+++ b/back/app/serializers/web_api/v1/static_page_serializer.rb
@@ -11,7 +11,8 @@ class WebApi::V1::StaticPageSerializer < WebApi::V1::BaseSerializer
   # will be when the page would be added to the navbar (and
   # show this in the list of items to add).
   attribute :nav_bar_item_title_multiloc do |object|
-    object.nav_bar_item&.title_multiloc || NavBarItem.new(code: 'custom', static_page: object).title_multiloc
+    current_navbaritem_title = object.nav_bar_item&.title_multiloc_with_fallback
+    current_navbaritem_title || NavBarItem.new(code: 'custom', static_page: object).title_multiloc_with_fallback
   end
 
   has_one :nav_bar_item

--- a/back/spec/serializers/web_api/v1/static_page_serializer_spec.rb
+++ b/back/spec/serializers/web_api/v1/static_page_serializer_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe WebApi::V1::StaticPageSerializer do
+  context 'nav_bar_item_title_multiloc' do
+    it 'corresponds to the nav bar item title, if the nav bar item exists' do
+      expected_title = { 'en' => 'Fallback title', 'fr-FR' => 'Titre de remplacement' }
+      page = create :static_page
+      create :nav_bar_item, code: 'custom', static_page: page
+      expect(page.reload.nav_bar_item).to receive(:title_multiloc_with_fallback).and_return(expected_title)
+
+      serialized_output = described_class.new(page).serializable_hash
+      expect(serialized_output.dig(:data, :attributes, :nav_bar_item_title_multiloc)).to match expected_title
+    end
+
+    it 'corresponds to what the nav bar item title will look like, if no nav bar item exists' do
+      expected_title = { 'en' => 'Fallback title', 'nl-NL' => 'Vervangingstitel' }
+      page = create :static_page, code: 'custom', title_multiloc: expected_title
+
+      serialized_output = described_class.new(page).serializable_hash
+      expect(serialized_output.dig(:data, :attributes, :nav_bar_item_title_multiloc)).to match expected_title
+    end
+  end
+end


### PR DESCRIPTION
Working on another issue, `title_multiloc` was renamed to `title_multiloc_with_fallback` in order not to overwrite the original method (which is the one we want to use to generate the templates). This introduced a bug becauose `title_multiloc` in the static page serializer was not replaced by `title_multiloc_with_fallback`. 

This part of the logic was not covered by specs, which allowed this bug to slip through. Some specs were added to cover this.

The issue was also reproduced on localhost and looks good now with the fixed code.

![Screenshot 2022-05-10 at 16 15 53](https://user-images.githubusercontent.com/31925816/167656299-012272e3-c72c-4f32-beee-bb6ebb8ae0a1.png)
