### PR TITLE
[CL-800] Clean up main react-router branch

### DIFF
--- a/front/app/containers/ProjectsShowPage/index.tsx
+++ b/front/app/containers/ProjectsShowPage/index.tsx
@@ -75,7 +75,6 @@ const ContentWrapper = styled.div`
 interface Props {
   project: IProjectData | Error | null | undefined;
   scrollToEventId?: string;
-  history?: any;
 }
 
 const ProjectsShowPage = memo<Props>(({ project, scrollToEventId }) => {
@@ -184,7 +183,6 @@ const ProjectsShowPageWrapper = memo<WithRouterProps>(
     } else if (scrollToEventId) {
       // If an event id was passed as a query param, pass it on
       return (
-        // to do: remove
         <ProjectsShowPage project={project} scrollToEventId={scrollToEventId} />
       );
     } else if (urlSegments.length > 3 && urlSegments[1] === 'projects') {

--- a/front/app/modules/commercial/insights/admin/containers/Insights/Edit/InputsTable/Export.tsx
+++ b/front/app/modules/commercial/insights/admin/containers/Insights/Edit/InputsTable/Export.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { withRouter, WithRouterProps } from 'utils/withRouter';
-// import { withRouter, WithRouterProps } from 'utils/withRouter';
 import { API_PATH } from 'containers/App/constants';
 
 // components

--- a/front/app/root.tsx
+++ b/front/app/root.tsx
@@ -1,7 +1,6 @@
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 import React, { useEffect } from 'react';
-import { createBrowserHistory, BrowserHistory } from 'history';
 import { render } from 'react-dom';
 // tslint:disable-next-line:no-vanilla-routing
 
@@ -15,8 +14,7 @@ import createRoutes from './routes';
 import { init } from '@sentry/browser';
 import OutletsProvider from 'containers/OutletsProvider';
 import modules from 'modules';
-
-export const rootHistory: BrowserHistory = createBrowserHistory();
+import history from 'utils/browserHistory';
 
 import {
   unstable_HistoryRouter as HistoryRouter,
@@ -36,7 +34,7 @@ const Root = () => {
   return (
     <OutletsProvider>
       <LanguageProvider>
-        <HistoryRouter history={rootHistory}>
+        <HistoryRouter history={history}>
           <Routes />
         </HistoryRouter>
       </LanguageProvider>

--- a/front/app/root.tsx
+++ b/front/app/root.tsx
@@ -1,6 +1,7 @@
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 import React, { useEffect } from 'react';
+import { createBrowserHistory, BrowserHistory } from 'history';
 import { render } from 'react-dom';
 // tslint:disable-next-line:no-vanilla-routing
 
@@ -14,8 +15,6 @@ import createRoutes from './routes';
 import { init } from '@sentry/browser';
 import OutletsProvider from 'containers/OutletsProvider';
 import modules from 'modules';
-
-import { createBrowserHistory, BrowserHistory } from 'history';
 
 export const rootHistory: BrowserHistory = createBrowserHistory();
 

--- a/front/app/routes.tsx
+++ b/front/app/routes.tsx
@@ -56,7 +56,6 @@ export default function createRoutes() {
         },
         {
           path: 'sign-in',
-          name: 'signInPage',
           element: (
             <LoadingComponent>
               <SignUpInPage />
@@ -65,7 +64,6 @@ export default function createRoutes() {
         },
         {
           path: 'sign-up',
-          name: 'signUpPage',
           element: (
             <LoadingComponent>
               <SignUpInPage />
@@ -106,7 +104,6 @@ export default function createRoutes() {
         },
         {
           path: 'profileedit',
-          name: 'usersEditPage',
           element: (
             <LoadingComponent>
               <UsersEditPage />
@@ -115,7 +112,6 @@ export default function createRoutes() {
         },
         {
           path: 'profile/:userSlug',
-          name: 'usersShowPage',
           element: (
             <LoadingComponent>
               <UsersShowPage />
@@ -124,7 +120,6 @@ export default function createRoutes() {
         },
         {
           path: 'ideas/edit/:ideaId',
-          name: 'IdeasEditPage',
           element: (
             <LoadingComponent>
               <IdeasEditPage />
@@ -133,7 +128,6 @@ export default function createRoutes() {
         },
         {
           path: 'ideas',
-          name: 'ideasPage',
           element: (
             <LoadingComponent>
               <IdeasIndexPage />
@@ -142,7 +136,6 @@ export default function createRoutes() {
         },
         {
           path: 'ideas/:slug',
-          name: 'ideasShow',
           element: (
             <LoadingComponent>
               <IdeasShowPage />
@@ -151,7 +144,6 @@ export default function createRoutes() {
         },
         {
           path: 'initiatives',
-          name: 'initiativesPage',
           element: (
             <LoadingComponent>
               <InitiativesIndexPage />
@@ -160,7 +152,6 @@ export default function createRoutes() {
         },
         {
           path: 'initiatives/edit/:initiativeId',
-          name: 'InitiativesEditPage',
           element: (
             <LoadingComponent>
               <InitiativesEditPage />
@@ -169,7 +160,6 @@ export default function createRoutes() {
         },
         {
           path: 'initiatives/new',
-          name: 'initiativesNewPage',
           element: (
             <LoadingComponent>
               <InitiativesNewPage />
@@ -179,7 +169,6 @@ export default function createRoutes() {
         // super important that this comes AFTER initiatives/new, if it comes before, new is interpreted as a slug
         {
           path: 'initiatives/:slug',
-          name: 'initiativesShow',
           element: (
             <LoadingComponent>
               <InitiativesShowPage />
@@ -188,7 +177,6 @@ export default function createRoutes() {
         },
         {
           path: 'projects/:slug/ideas/new',
-          name: 'IdeasNewPage',
           element: (
             <LoadingComponent>
               <IdeasNewPage />
@@ -198,7 +186,6 @@ export default function createRoutes() {
         // adminRoutes(),
         {
           path: 'projects',
-          name: 'Project page',
           element: (
             <LoadingComponent>
               <ProjectsIndexPage />
@@ -207,7 +194,6 @@ export default function createRoutes() {
         },
         {
           path: 'projects/:slug',
-          name: 'Project page',
           element: (
             <LoadingComponent>
               <ProjectsShowPage />
@@ -215,7 +201,6 @@ export default function createRoutes() {
           ),
           children: [
             {
-              name: 'Project page',
               index: true,
               element: (
                 <LoadingComponent>
@@ -225,7 +210,6 @@ export default function createRoutes() {
             },
             {
               path: ':phaseNumber',
-              name: 'Project page: specific phase',
               element: (
                 <LoadingComponent>
                   <ProjectsShowPage />
@@ -234,7 +218,6 @@ export default function createRoutes() {
             },
             {
               path: '*',
-              name: 'Project page',
               element: (
                 <LoadingComponent>
                   <ProjectsShowPage />
@@ -245,7 +228,6 @@ export default function createRoutes() {
         },
         {
           path: 'events',
-          name: 'Events page',
           element: (
             <LoadingComponent>
               <EventsPage />
@@ -254,7 +236,6 @@ export default function createRoutes() {
         },
         {
           path: 'pages/cookie-policy',
-          name: 'cookiePolicy',
           element: (
             <LoadingComponent>
               <CookiePolicy />
@@ -263,7 +244,6 @@ export default function createRoutes() {
         },
         {
           path: 'pages/accessibility-statement',
-          name: 'accessibilityStatement',
           element: (
             <LoadingComponent>
               <AccessibilityStatement />
@@ -272,7 +252,6 @@ export default function createRoutes() {
         },
         {
           path: 'pages/:slug',
-          name: 'pagesShowPage',
           element: (
             <LoadingComponent>
               <PagesShowPage />
@@ -281,7 +260,6 @@ export default function createRoutes() {
         },
         {
           path: 'password-recovery',
-          name: 'passwordRecovery',
           element: (
             <LoadingComponent>
               <PasswordRecovery />
@@ -291,7 +269,6 @@ export default function createRoutes() {
         {
           // Used as link in email received for password recovery
           path: 'reset-password',
-          name: 'passwordReset',
           element: (
             <LoadingComponent>
               <PasswordReset />
@@ -300,7 +277,6 @@ export default function createRoutes() {
         },
         {
           path: 'subscription-ended',
-          name: 'subscriptionEnded',
           element: (
             <LoadingComponent>
               <SubscriptionEndedPage />
@@ -309,7 +285,6 @@ export default function createRoutes() {
         },
         {
           path: 'email-settings',
-          name: 'EmailSettingPage',
           element: (
             <LoadingComponent>
               <EmailSettingsPage />
@@ -319,7 +294,6 @@ export default function createRoutes() {
         // ...moduleConfiguration.routes.citizen,
         {
           path: '*',
-          name: 'notfound',
           element: (
             <LoadingComponent>
               <PagesShowPage />

--- a/front/app/utils/browserHistory.ts
+++ b/front/app/utils/browserHistory.ts
@@ -1,0 +1,3 @@
+import { createBrowserHistory } from 'history';
+
+export default createBrowserHistory();

--- a/front/app/utils/cl-router/history.ts
+++ b/front/app/utils/cl-router/history.ts
@@ -3,9 +3,8 @@ import { localeStream } from 'services/locale';
 import updateLocationDescriptor from 'utils/cl-router/updateLocationDescriptor';
 // tslint:disable-next-line:no-vanilla-routing
 
-import { createBrowserHistory, BrowserHistory, Location } from 'history';
-
-const browserHistory: BrowserHistory = createBrowserHistory();
+import { Location } from 'history';
+import { rootHistory } from 'root';
 
 // overrides push and replace methods so they update the location with the current locale from the locale stream
 function historyMethod(
@@ -17,15 +16,15 @@ function historyMethod(
     .observable.pipe(first())
     .subscribe((locale) => {
       // calls the vanilla react-router method with updated location
-      browserHistory[method](updateLocationDescriptor(location, locale));
+      rootHistory[method](updateLocationDescriptor(location, locale));
     });
 }
 
 export default {
-  ...browserHistory,
+  ...rootHistory,
   push: (location: Partial<Location> | string): void =>
     historyMethod('push', location),
   replace: (location: Partial<Location> | string): void =>
     historyMethod('replace', location),
-  goBack: () => browserHistory.back(),
+  goBack: () => rootHistory.back(),
 };

--- a/front/app/utils/cl-router/history.ts
+++ b/front/app/utils/cl-router/history.ts
@@ -3,9 +3,7 @@ import { localeStream } from 'services/locale';
 import updateLocationDescriptor from 'utils/cl-router/updateLocationDescriptor';
 // tslint:disable-next-line:no-vanilla-routing
 
-import { Location, BrowserHistory, createBrowserHistory } from 'history';
-
-const historyObject: BrowserHistory = createBrowserHistory();
+import history from 'utils/browserHistory';
 
 // overrides push and replace methods so they update the location with the current locale from the locale stream
 function historyMethod(
@@ -17,15 +15,15 @@ function historyMethod(
     .observable.pipe(first())
     .subscribe((locale) => {
       // calls the vanilla react-router method with updated location
-      historyObject[method](updateLocationDescriptor(location, locale));
+      history[method](updateLocationDescriptor(location, locale));
     });
 }
 
 export default {
-  ...historyObject,
+  ...history,
   push: (location: Partial<Location> | string): void =>
     historyMethod('push', location),
   replace: (location: Partial<Location> | string): void =>
     historyMethod('replace', location),
-  goBack: () => historyObject.back(),
+  goBack: () => history.back(),
 };

--- a/front/app/utils/cl-router/history.ts
+++ b/front/app/utils/cl-router/history.ts
@@ -3,8 +3,9 @@ import { localeStream } from 'services/locale';
 import updateLocationDescriptor from 'utils/cl-router/updateLocationDescriptor';
 // tslint:disable-next-line:no-vanilla-routing
 
-import { Location } from 'history';
-import { rootHistory } from 'root';
+import { Location, BrowserHistory, createBrowserHistory } from 'history';
+
+const historyObject: BrowserHistory = createBrowserHistory();
 
 // overrides push and replace methods so they update the location with the current locale from the locale stream
 function historyMethod(
@@ -16,15 +17,15 @@ function historyMethod(
     .observable.pipe(first())
     .subscribe((locale) => {
       // calls the vanilla react-router method with updated location
-      rootHistory[method](updateLocationDescriptor(location, locale));
+      historyObject[method](updateLocationDescriptor(location, locale));
     });
 }
 
 export default {
-  ...rootHistory,
+  ...historyObject,
   push: (location: Partial<Location> | string): void =>
     historyMethod('push', location),
   replace: (location: Partial<Location> | string): void =>
     historyMethod('replace', location),
-  goBack: () => rootHistory.back(),
+  goBack: () => historyObject.back(),
 };

--- a/front/package.json
+++ b/front/package.json
@@ -55,7 +55,6 @@
     "@jsonforms/core": "3.0.0-beta.0",
     "@jsonforms/react": "3.0.0-beta.1",
     "@jsonforms/vanilla-renderers": "3.0.0-beta.1",
-    "@loadable/component": "^5.15.2",
     "@researchgate/react-intersection-observer": "1.3.5",
     "@segment/snippet": "4.15.3",
     "@sentry/browser": "6.18.1",


### PR DESCRIPTION
A few style and code changes to clean up the main branch.

The `name` property isn't used in the new API for react-router 6 so I removed those from the big routes file. We aren't using `@loadable` in favor of React.lazy so that is also gone.