### PR TITLE
[DISP-76] Fixed timeout (N+1 query) issue during users XLSX export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixed
 
 - [CL-775] Use correct link to conditions page
+- [CL-814] Faster user XLSX export.
 
 ## 2022-05-16
 

--- a/back/app/services/multiloc_service.rb
+++ b/back/app/services/multiloc_service.rb
@@ -1,8 +1,12 @@
 class MultilocService
+  def initialize(app_configuration: nil)
+    @app_configuration = app_configuration
+  end
+
   def t(translations, user = nil)
     return nil unless translations
 
-    locales = AppConfiguration.instance.settings('core', 'locales')
+    locales = app_configuration.settings('core', 'locales')
     user_locale = user&.locale || I18n.locale.to_s
     result = ([user_locale] + locales + translations.keys).each do |locale|
       break translations[locale] if translations[locale]
@@ -11,7 +15,7 @@ class MultilocService
   end
 
   def i18n_to_multiloc(key, locales: nil)
-    (locales || AppConfiguration.instance.settings('core', 'locales')).each_with_object({}) do |locale, result|
+    (locales || app_configuration.settings('core', 'locales')).each_with_object({}) do |locale, result|
       I18n.with_locale(locale) do
         result[locale] = I18n.t(key, raise: true)
       end
@@ -19,7 +23,7 @@ class MultilocService
   end
 
   def block_to_multiloc
-    AppConfiguration.instance.settings('core', 'locales').each_with_object({}) do |locale, result|
+    app_configuration.settings('core', 'locales').each_with_object({}) do |locale, result|
       I18n.with_locale(locale) do
         result[locale] = yield(locale)
       end
@@ -28,5 +32,11 @@ class MultilocService
 
   def is_empty?(multiloc)
     !multiloc || multiloc.values.all?(&:blank?)
+  end
+
+  private
+
+  def app_configuration
+    @app_configuration || AppConfiguration.instance
   end
 end

--- a/back/app/services/xlsx_service.rb
+++ b/back/app/services/xlsx_service.rb
@@ -3,10 +3,6 @@
 class XlsxService
   include HtmlToPlainText
 
-  def multiloc_service
-    MultilocService.new
-  end
-
   def escape_formula(text)
     # After https://docs.servicenow.com/bundle/orlando-platform-administration/page/administer/security/reference/escape-excel-formula.html and http://rorsecurity.info/portfolio/excel-injection-via-rails-downloads
     if '=+-@'.include?(text.first) && !text.empty?
@@ -303,6 +299,10 @@ class XlsxService
   end
 
   private
+
+  def multiloc_service
+    @multiloc_service ||= MultilocService.new app_configuration: AppConfiguration.instance
+  end
 
   def private_attributes
     custom_field_attrs = CustomField.with_resource_type('User')&.map do |field|


### PR DESCRIPTION
While generating the final users export for the Creamos platform, I briefly took a look at where the N+1 query issues (calling `AppConfiguration.instance`) where coming from. It turns out that the `MultilocService` makes this call every time a multiloc is generated. This happens several times for every user (for each custom field value), and is therefore executed perhaps up to a million times for the Creamos platform.

The proposed solution is to allow storing the app configuration as an instance variable in the `MultilocService` such that only one `AppConfiguration.instance` call is executed for all generations of multilocs. The time spent on generating the XLSX sheet was reduced from 1-5 minutes to 10-20 seconds.