### PR TITLE
Fix tests by reducing the amount of tests kept in memory

### DIFF
--- a/front/cypress.json
+++ b/front/cypress.json
@@ -4,7 +4,7 @@
   "baseUrl": "http://localhost:3000",
   "video": false,
   "chromeWebSecurity": false,
-  "numTestsKeptInMemory": 10,
+  "numTestsKeptInMemory": 0,
   "defaultCommandTimeout": 15000,
   "retries": 2
 }


### PR DESCRIPTION
This is addressing the Cypress test fail - my guess is it hangs because it is out of memory so trying to fix it by reducing the tests kept in memory. Worth a shot.