### PR TITLE
[CL-832] Remove toggle from required idea fields

### DIFF
--- a/front/app/modules/commercial/idea_custom_fields/admin/containers/projects/edit/ideaform/IdeaCustomField.tsx
+++ b/front/app/modules/commercial/idea_custom_fields/admin/containers/projects/edit/ideaform/IdeaCustomField.tsx
@@ -176,7 +176,7 @@ const disablableFields = [
   'idea_files_attributes',
   'proposed_budget',
 ];
-const alwaysRequiredFields = ['title', 'body'];
+const alwaysRequiredFields = ['title_multiloc', 'body_multiloc'];
 
 export default memo<Props>(
   ({


### PR DESCRIPTION
The logic to hide the toggle was there but the field keys have changed for some reason. Should be fixed now.