### PR TITLE
[react-router] Fix admin sidebar active links

### DIFF
--- a/front/app/containers/Admin/sideBar/MenuItem.tsx
+++ b/front/app/containers/Admin/sideBar/MenuItem.tsx
@@ -49,7 +49,7 @@ const MenuItemLink = styled(Link)`
   transition: background-color 80ms ease-out;
 
   &:hover,
-  &.selected,
+  &.active,
   &.focus-visible {
     background: rgba(0, 0, 0, 0.36);
 
@@ -58,7 +58,7 @@ const MenuItemLink = styled(Link)`
     }
   }
 
-  &:not(.selected) {
+  &:not(.active) {
     .cl-icon {
       .cl-icon-primary {
         fill: ${colors.clIconPrimary};
@@ -69,7 +69,7 @@ const MenuItemLink = styled(Link)`
     }
   }
 
-  &.selected {
+  &.active {
     ${ArrowIcon} {
       opacity: 1;
     }
@@ -121,12 +121,7 @@ type Props = {
 export default ({ route }: Props) => {
   return (
     <HasPermission action="access" item={{ type: 'route', path: route.link }}>
-      <MenuItemLink
-        className={({ isActive }) =>
-          `${route.iconName} ${isActive ? 'selected' : ''}`
-        }
-        to={route.link}
-      >
+      <MenuItemLink to={route.link}>
         <IconWrapper className={route.iconName}>
           <Icon name={route.iconName} />
         </IconWrapper>

--- a/front/app/containers/Admin/sideBar/index.tsx
+++ b/front/app/containers/Admin/sideBar/index.tsx
@@ -5,7 +5,6 @@ import { get } from 'lodash-es';
 
 // router
 import { withRouter, WithRouterProps } from 'utils/withRouter';
-import { getUrlLocale } from 'services/locale';
 
 // components
 import { Icon, IconNames } from '@citizenlab/cl2-component-library';
@@ -144,9 +143,10 @@ export type NavItem = {
   iconName: IconNames;
   message: string;
   featureName?: TAppConfigurationSetting;
-  isActive: (pathname: string) => boolean;
+  isActive?: (pathname: string) => boolean;
   count?: number;
   onlyCheckAllowed?: boolean;
+  className?: ({ isActive: string }) => string | undefined;
 };
 
 type Tracks = {
@@ -167,24 +167,12 @@ class Sidebar extends PureComponent<
           link: '/admin/dashboard',
           iconName: 'stats',
           message: 'dashboard',
-          isActive: (pathName) =>
-            pathName.startsWith(
-              `${
-                getUrlLocale(pathName) ? `/${getUrlLocale(pathName)}` : ''
-              }/admin/dashboard`
-            ),
         },
         {
           name: 'projects',
           link: '/admin/projects',
           iconName: 'folder',
           message: 'projects',
-          isActive: (pathName) =>
-            pathName.startsWith(
-              `${
-                getUrlLocale(pathName) ? `/${getUrlLocale(pathName)}` : ''
-              }/admin/projects`
-            ),
         },
         {
           name: 'workshops',
@@ -192,24 +180,12 @@ class Sidebar extends PureComponent<
           iconName: 'workshops',
           message: 'workshops',
           featureName: 'workshops',
-          isActive: (pathName) =>
-            pathName.startsWith(
-              `${
-                getUrlLocale(pathName) ? `/${getUrlLocale(pathName)}` : ''
-              }/admin/workshops`
-            ),
         },
         {
           name: 'ideas',
           link: '/admin/ideas',
           iconName: 'idea2',
           message: 'inputManager',
-          isActive: (pathName) =>
-            pathName.startsWith(
-              `${
-                getUrlLocale(pathName) ? `/${getUrlLocale(pathName)}` : ''
-              }/admin/ideas`
-            ),
         },
         {
           name: 'initiatives',
@@ -218,60 +194,30 @@ class Sidebar extends PureComponent<
           message: 'initiatives',
           featureName: 'initiatives',
           onlyCheckAllowed: true,
-          isActive: (pathName) =>
-            pathName.startsWith(
-              `${
-                getUrlLocale(pathName) ? `/${getUrlLocale(pathName)}` : ''
-              }/admin/initiatives`
-            ),
         },
         {
           name: 'userinserts',
           link: '/admin/users',
           iconName: 'users',
           message: 'users',
-          isActive: (pathName) =>
-            pathName.startsWith(
-              `${
-                getUrlLocale(pathName) ? `/${getUrlLocale(pathName)}` : ''
-              }/admin/users`
-            ),
         },
         {
           name: 'invitations',
           link: '/admin/invitations',
           iconName: 'invitations',
           message: 'invitations',
-          isActive: (pathName) =>
-            pathName.startsWith(
-              `${
-                getUrlLocale(pathName) ? `/${getUrlLocale(pathName)}` : ''
-              }/admin/invitations`
-            ),
         },
         {
           name: 'messaging',
           link: '/admin/messaging',
           iconName: 'emails',
           message: 'messaging',
-          isActive: (pathName) =>
-            pathName.startsWith(
-              `${
-                getUrlLocale(pathName) ? `/${getUrlLocale(pathName)}` : ''
-              }/admin/messaging`
-            ),
         },
         {
           name: 'settings',
           link: '/admin/settings/general',
           iconName: 'setting',
           message: 'settings',
-          isActive: (pathName) =>
-            pathName.startsWith(
-              `${
-                getUrlLocale(pathName) ? `/${getUrlLocale(pathName)}` : ''
-              }/admin/settings`
-            ),
         },
       ],
     };

--- a/front/app/containers/Admin/sideBar/index.tsx
+++ b/front/app/containers/Admin/sideBar/index.tsx
@@ -143,7 +143,6 @@ export type NavItem = {
   iconName: IconNames;
   message: string;
   featureName?: TAppConfigurationSetting;
-  isActive?: (pathname: string) => boolean;
   count?: number;
   onlyCheckAllowed?: boolean;
   className?: ({ isActive: string }) => string | undefined;

--- a/front/app/containers/Admin/sideBar/index.tsx
+++ b/front/app/containers/Admin/sideBar/index.tsx
@@ -145,7 +145,6 @@ export type NavItem = {
   featureName?: TAppConfigurationSetting;
   count?: number;
   onlyCheckAllowed?: boolean;
-  className?: ({ isActive: string }) => string | undefined;
 };
 
 type Tracks = {

--- a/front/app/containers/Admin/users/GroupsListPanel.tsx
+++ b/front/app/containers/Admin/users/GroupsListPanel.tsx
@@ -215,11 +215,7 @@ export class GroupsListPanel extends React.PureComponent<
 
     return (
       <Container className={this.props.className}>
-        <MenuLink
-          to="/admin/users"
-          className={({ isActive }) => (isActive ? 'active' : undefined)}
-          onlyActiveOnIndex
-        >
+        <MenuLink to="/admin/users" onlyActiveOnIndex>
           <GroupName>
             <FormattedMessage {...messages.allUsers} />
           </GroupName>
@@ -250,10 +246,8 @@ export class GroupsListPanel extends React.PureComponent<
               <MenuLink
                 key={group.id}
                 to={`/admin/users/${group.id}`}
-                className={({ isActive }) =>
-                  `${isActive ? 'active' : ''} ${
-                    highlightedGroups.has(group.id) ? 'highlight' : ''
-                  }`
+                className={() =>
+                  `${highlightedGroups.has(group.id) ? 'highlight' : ''}`
                 }
               >
                 <Outlet

--- a/front/app/containers/MainHeader/DesktopNavbar/DesktopNavbarItem.tsx
+++ b/front/app/containers/MainHeader/DesktopNavbar/DesktopNavbarItem.tsx
@@ -75,19 +75,12 @@ interface Props {
 }
 
 const DesktopNavbarItem = ({
-  className,
   linkTo,
   navigationItemTitle,
   onlyActiveOnIndex,
 }: Props) => (
   <NavigationItem data-testid="desktop-navbar-item">
-    <StyledLink
-      to={linkTo}
-      className={({ isActive }) =>
-        isActive ? `active ${className}` : className
-      }
-      onlyActiveOnIndex={onlyActiveOnIndex}
-    >
+    <StyledLink to={linkTo} onlyActiveOnIndex={onlyActiveOnIndex}>
       <NavigationItemBorder />
       <T value={navigationItemTitle} />
     </StyledLink>

--- a/front/app/containers/MobileNavbar/FullMobileNavMenuItem.tsx
+++ b/front/app/containers/MobileNavbar/FullMobileNavMenuItem.tsx
@@ -50,7 +50,6 @@ const FullMobileNavMenuItem = ({
     <StyledLink
       onClick={onClick}
       to={linkTo}
-      className={({ isActive }) => (isActive ? 'active' : undefined)}
       onlyActiveOnIndex={onlyActiveOnIndex}
     >
       <T value={navigationItemTitle} />

--- a/front/app/modules/commercial/insights/admin/components/NavItem.tsx
+++ b/front/app/modules/commercial/insights/admin/components/NavItem.tsx
@@ -1,6 +1,5 @@
 import { NavItem } from 'containers/Admin/sideBar';
 import { FC, useEffect } from 'react';
-import { getUrlLocale } from 'services/locale';
 import { InsertConfigurationOptions } from 'typings';
 import useFeatureFlag from 'hooks/useFeatureFlag';
 
@@ -21,12 +20,6 @@ const NavItemComponent: FC<Props> = ({ onData }) => {
         featureName: insightsManualFlow
           ? 'insights_manual_flow'
           : 'project_reports',
-        isActive: (pathName) =>
-          pathName.startsWith(
-            `${
-              getUrlLocale(pathName) ? `/${getUrlLocale(pathName)}` : ''
-            }/admin/insights`
-          ),
       },
       insertAfterName: 'projects',
     });

--- a/front/app/modules/commercial/moderation/admin/components/NavItem.tsx
+++ b/front/app/modules/commercial/moderation/admin/components/NavItem.tsx
@@ -1,6 +1,5 @@
 import { NavItem } from 'containers/Admin/sideBar';
 import { FC, useEffect } from 'react';
-import { getUrlLocale } from 'services/locale';
 import { InsertConfigurationOptions } from 'typings';
 
 type Props = {
@@ -17,12 +16,6 @@ const NavItemComponent: FC<Props> = ({ onData }) => {
           iconName: 'moderation',
           message: 'moderation',
           featureName: 'moderation',
-          isActive: (pathName) =>
-            pathName.startsWith(
-              `${
-                getUrlLocale(pathName) ? `/${getUrlLocale(pathName)}` : ''
-              }/admin/moderation`
-            ),
         },
         insertAfterName: 'dashboard',
       }),


### PR DESCRIPTION
`active` class is automatically added to NavLink components that match the current path so our previous logic for determining the active sidebar/header tab has been removed

![Screen Shot 2022-05-25 at 09 23 42](https://user-images.githubusercontent.com/3614128/170204628-95cf14b6-c2e3-4952-8271-6eaf268c5a6f.png)
![Screen Shot 2022-05-25 at 09 23 39](https://user-images.githubusercontent.com/3614128/170204632-29509d9b-1e66-4f51-980a-7b9005a19a52.png)

