### PR TITLE
Upgrade Cypress

### DIFF
--- a/front/app/modules/commercial/content_builder/admin/components/RenderNode/index.tsx
+++ b/front/app/modules/commercial/content_builder/admin/components/RenderNode/index.tsx
@@ -68,18 +68,6 @@ const StyledBox = styled(Box)`
 
 const RenderNode = ({ render }) => {
   const {
-    isActive,
-    isDeletable,
-    parentId,
-    actions: { selectNode },
-    query: { node },
-  } = useEditor((_, query) => ({
-    isActive: query.getEvent('selected').contains(id),
-    parentId: id && query.node(id).ancestors()[0],
-    isDeletable: id && query.node(id).isDeletable(),
-  }));
-
-  const {
     id,
     name,
     isHover,
@@ -90,6 +78,20 @@ const RenderNode = ({ render }) => {
     name: node.data.name as ComponentNamesType,
     hasError: node.data.props.hasError,
   }));
+
+  const {
+    isActive,
+    isDeletable,
+    parentId,
+    actions: { selectNode },
+    query: { node },
+  } = useEditor((_, query) => {
+    return {
+      isActive: id && query.getEvent('selected').contains(id),
+      parentId: id && query.node(id).ancestors()[0],
+      isDeletable: id && query.node(id).isDeletable(),
+    };
+  });
 
   const parentNode = parentId && node(parentId).get();
   const parentNodeName = parentNode && parentNode.data.name;

--- a/front/cypress.json
+++ b/front/cypress.json
@@ -6,5 +6,6 @@
   "chromeWebSecurity": false,
   "numTestsKeptInMemory": 0,
   "defaultCommandTimeout": 15000,
-  "retries": 2
+  "retries": 2,
+  "pageLoadTimeout": 15000
 }

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -157,7 +157,7 @@
         "clean-webpack-plugin": "4.0.0",
         "css-loader": "^6.5.1",
         "css-minimizer-webpack-plugin": "^3.1.1",
-        "cypress": "^9.6.0",
+        "cypress": "^9.7.0",
         "cypress-file-upload": "^5.0.8",
         "enzyme": "3.11.0",
         "enzyme-adapter-react-16": "1.15.6",
@@ -7469,9 +7469,9 @@
       "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw=="
     },
     "node_modules/cypress": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.6.0.tgz",
-      "integrity": "sha512-nNwt9eBQmSENamwa8LxvggXksfyzpyYaQ7lNBLgks3XZ6dPE/6BCQFBzeAyAPt/bNXfH3tKPkAyhiAZPYkWoEg==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.7.0.tgz",
+      "integrity": "sha512-+1EE1nuuuwIt/N1KXRR2iWHU+OiIt7H28jJDyyI4tiUftId/DrXYEwoDa5+kH2pki1zxnA0r6HrUGHV5eLbF5Q==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -25293,9 +25293,9 @@
       "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw=="
     },
     "cypress": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.6.0.tgz",
-      "integrity": "sha512-nNwt9eBQmSENamwa8LxvggXksfyzpyYaQ7lNBLgks3XZ6dPE/6BCQFBzeAyAPt/bNXfH3tKPkAyhiAZPYkWoEg==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.7.0.tgz",
+      "integrity": "sha512-+1EE1nuuuwIt/N1KXRR2iWHU+OiIt7H28jJDyyI4tiUftId/DrXYEwoDa5+kH2pki1zxnA0r6HrUGHV5eLbF5Q==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/front/package.json
+++ b/front/package.json
@@ -196,7 +196,7 @@
     "clean-webpack-plugin": "4.0.0",
     "css-loader": "^6.5.1",
     "css-minimizer-webpack-plugin": "^3.1.1",
-    "cypress": "^9.6.0",
+    "cypress": "^9.7.0",
     "cypress-file-upload": "^5.0.8",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.6",


### PR DESCRIPTION
Upgrades Cypress to the latest version to hopefully deal with the potential memory leak.
Also - fixing a bug in RenderNode in the content editor where we were using the node id before initialising it.