### PR TITLE
[CL-833] Do not leave non-Latin field keys blank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [CL-835] Roll back CL-99 ("Add slight blur to logged-in header image")
 - [CL-790] Events date picker now has the correct date format for US-based tenants
+- [CL-833] Fix creating a new registration field in FR and AR-MA
 
 ### Added
 

--- a/back/app/services/custom_field_service.rb
+++ b/back/app/services/custom_field_service.rb
@@ -80,7 +80,7 @@ class CustomFieldService
   end
 
   def keyify(str)
-    str.parameterize.tr('-', '_')
+    str.parameterize.tr('-', '_').presence || '_'
   end
 
   def cleanup_custom_field_values!(custom_field_values)

--- a/back/spec/models/custom_field_spec.rb
+++ b/back/spec/models/custom_field_spec.rb
@@ -15,6 +15,16 @@ RSpec.describe CustomField, type: :model do
       cf3 = create(:custom_field)
       expect([cf1, cf2, cf3].map(&:key).uniq).to match [cf1, cf2, cf3].map(&:key)
     end
+
+    it 'generates a key made of non-Latin letters of title' do
+      cf = create(:custom_field, key: nil, title_multiloc: { 'ar-SA': 'abbaالرئيسية' })
+      expect(cf.key).to eq('abba')
+    end
+
+    it 'generates a present key from non-Latin title' do
+      cf = create(:custom_field, key: nil, title_multiloc: { 'ar-SA': 'الرئيسية' })
+      expect(cf.key).to be_present
+    end
   end
 
   describe 'description sanitizer' do


### PR DESCRIPTION
Maybe we could leave Arabic text in key, but not sure it's safe. Underscore should be safe though.
The team discussion is here https://citizenlabco.slack.com/archives/C65GX921W/p1653664624226169

## Checklist

- [x] Added entry to changelog
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

- [ ] WCAG 2.1 AA proof
<details>
<summary>More info</summary>
For front-end devs only. Is your work conforming with the WCAG 2.1 AA rules? If you need more info, read the [a11y page](https://www.notion.so/citizenlab/a11y-7568f83d42ab4895ac133b89d358997b) on our Notion.
</details>

- [x] Tests
<details>
<summary>More info</summary>

### Unit tests

Did you add relevant unit tests?

### E2E tests

Sometimes it can be more efficient to update E2E tests after CI has run them. If you know which ones to update, go ahead! E2E template cl2-back:

```bash
docker compose run --rm web bin/rails cl2_back:create_tenant[localhost,e2etests_template]
```

</details>

- [x] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>
