### PR TITLE
Cl 868/fix admin navigation index

### DIFF
--- a/front/app/modules/commercial/customizable_navbar/index.tsx
+++ b/front/app/modules/commercial/customizable_navbar/index.tsx
@@ -26,7 +26,7 @@ const configuration: ModuleConfiguration = {
         element: <CustomNavbarContainer />,
         children: [
           {
-            index: true,
+            path: '',
             element: <CustomNavbarSettingsComponent />,
           },
           {


### PR DESCRIPTION
https://citizenlab.atlassian.net/browse/CL-868

Wanted to review the way this page is structured (I think we shouldn't have to use `path: ''` if it's not for a redirect). This is related to how we have implemented the parent index file. But then I realized we're going to move this tab to a new page and change the page structure probably by next week (for the Flexible pages epic), so I'm not going to spend more time on it for this ticket.