### PR TITLE
[react-router] [react-router] Fix react-router index routes

### DIFF
--- a/front/app/containers/IdeasNewPage/index.tsx
+++ b/front/app/containers/IdeasNewPage/index.tsx
@@ -258,18 +258,13 @@ class IdeasNewPage extends PureComponent<Props & WithRouterProps, State> {
         }
 
         const { fileOrImageError } = await this.globalState.get();
+        const newUrl = `/ideas/${idea.data.attributes.slug}?new_idea_id=${ideaId}`;
         if (fileOrImageError) {
           setTimeout(() => {
-            clHistory.push({
-              pathname: `/ideas/${idea.data.attributes.slug}`,
-              search: `?new_idea_id=${ideaId}`,
-            });
+            clHistory.push(newUrl);
           }, 4000);
         } else {
-          clHistory.push({
-            pathname: `/ideas/${idea.data.attributes.slug}`,
-            search: `?new_idea_id=${ideaId}`,
-          });
+          clHistory.push(newUrl);
         }
       } catch (error) {
         // eslint-disable-next-line no-console

--- a/front/app/containers/IdeasShow/index.tsx
+++ b/front/app/containers/IdeasShow/index.tsx
@@ -74,6 +74,10 @@ import { getInputTermMessage } from 'utils/i18n';
 // animations
 import CSSTransition from 'react-transition-group/CSSTransition';
 
+// utils
+import clHistory from 'utils/cl-router/history';
+import { parse } from 'qs';
+
 // style
 import styled from 'styled-components';
 import { media, viewportWidths, isRtl } from 'utils/styleUtils';
@@ -249,16 +253,17 @@ export class IdeasShow extends PureComponent<
   }
 
   componentDidMount() {
-    const newIdeaId = this.props.location.query?.['new_idea_id'];
-
+    const queryParams = parse(clHistory.location.search, {
+      ignoreQueryPrefix: true,
+    });
+    const newIdeaId = queryParams.new_idea_id;
     this.setLoaded();
-
     if (isString(newIdeaId)) {
       setTimeout(() => {
         this.setState({ ideaIdForSocialSharing: newIdeaId });
       }, 1500);
 
-      window.history.replaceState(null, '', window.location.pathname);
+      clHistory.replace(window.location.pathname);
     }
   }
 

--- a/front/app/containers/InitiativesShow/index.tsx
+++ b/front/app/containers/InitiativesShow/index.tsx
@@ -59,6 +59,8 @@ import GetAppConfiguration, {
 
 // utils
 import { getAddressOrFallbackDMS } from 'utils/map';
+import clHistory from 'utils/cl-router/history';
+import { parse } from 'qs';
 
 // i18n
 import { InjectedIntlProps } from 'react-intl';
@@ -355,16 +357,17 @@ export class InitiativesShow extends PureComponent<
   }
 
   componentDidMount() {
-    const newInitiativeId = this.props.location.query?.['new_initiative_id'];
-
+    const queryParams = parse(clHistory.location.search, {
+      ignoreQueryPrefix: true,
+    });
+    const newInitiativeId = queryParams.new_initiative_id;
     this.setLoaded();
-
     if (isString(newInitiativeId)) {
       setTimeout(() => {
         this.setState({ initiativeIdForSocialSharing: newInitiativeId });
       }, 1500);
 
-      window.history.replaceState(null, '', window.location.pathname);
+      clHistory.replace(window.location.pathname);
     }
   }
 

--- a/front/app/services/locale.ts
+++ b/front/app/services/locale.ts
@@ -39,6 +39,7 @@ import { updateUser } from 'services/users';
 import { Locale } from 'typings';
 import { locales } from 'containers/App/constants';
 import { setCookieLocale, getCookieLocale } from 'utils/localeCookie';
+import clHistory from 'utils/cl-router/history';
 
 const LocaleSubject: BehaviorSubject<Locale> = new BehaviorSubject(null as any);
 const $tenantLocales = currentAppConfigurationStream().observable.pipe(
@@ -187,7 +188,7 @@ function setUrlLocale(locale: Locale): void {
     locale,
     location.search
   );
-  window.history.replaceState({ path: newLocalizedUrl }, '', newLocalizedUrl);
+  clHistory.replace(newLocalizedUrl);
 }
 
 /*  @param pathname: a string representing a pathname, without a starting locale. pathname must tart with /, and final / will not be moved
@@ -217,7 +218,7 @@ function replaceUrlLocale(locale: Locale) {
     location.search
   );
   // replaces current location with updated url
-  window.history.replaceState({ path: newLocalizedUrl }, '', newLocalizedUrl);
+  clHistory.replace(newLocalizedUrl);
 }
 
 /*  @param pathname: a string representing a pathname, with a first part we want to replace


### PR DESCRIPTION
Not sure how to handle this one, opening a WIP pr for discussion. 

The problem in the ticket is fixed by the commit below, going to `http://localhost:3000/` successfully changes to `http://localhost:3000/en/` and loads the landing page. We were accessing the history object directly (`window.history.replaceState`) and I changed this to `clHistory.replace`. 

However, I checked through the rest of the codebase for instances of `window.history.replaceState` and tried to fix them, but it broke parts of the app. Using `clHistory.replace` on `http://localhost:3000/invite` breaks the invite modal, and another bug when clicking a new idea. 

Just changing the main route (as in this commit) but leaving the others seems to work fine, but that seems a little strange versus accessing clHistory. I guess maybe there was a reason for accessing `window.history` directly before, even when we had the clHistory util, so maybe it's fine this way. 