### PR TITLE
[react-router] Fix tab selection of general in Admin -> Projects

### DIFF
--- a/front/app/containers/Admin/projects/project/index.tsx
+++ b/front/app/containers/Admin/projects/project/index.tsx
@@ -264,10 +264,16 @@ export class AdminProjectsProjectIndex extends PureComponent<
       }
     });
 
-    return cleanedTabs.map((tab) => ({
-      ...tab,
-      url: `${baseTabsUrl}/${tab.url}`,
-    }));
+    return cleanedTabs.map((tab) => {
+      // the "general" tab url is an empty string, so we don't want to add
+      // a slash to the end of the URL
+      const url =
+        tab.url === '' ? `${baseTabsUrl}` : `${baseTabsUrl}/${tab.url}`;
+      return {
+        ...tab,
+        url,
+      };
+    });
   };
 
   goBack = () => {
@@ -303,7 +309,6 @@ export class AdminProjectsProjectIndex extends PureComponent<
       },
       tabs: !isNilOrError(project) ? this.getTabs(project.id, project) : [],
     };
-
     if (!isNilOrError(project) && phases !== undefined) {
       const inputTerm = getInputTerm(
         project?.attributes.process_type,


### PR DESCRIPTION
I think this was a simple fix.

We define the tabs like this: 

```
 this.state = {
      tabs: [
        {
          label: formatMessage(messages.generalTab),
          url: '',
          name: 'general',
 },
```

And then in `TabbedResource` we check for active tabs like this:

```
return (
      typeof tab.active === 'function'
        ? tab.active(pathname)
        : tab.active ||
          (pathname && getRegularExpression(tab.url).test(location.pathname))
```

In this case `tab.active` is not a function, so the second part triggers, which does this:

```pathname && getRegularExpression(tab.url).test(location.pathname))```

The previous way had "${baseTabsUrl}/${tab.url}" which, with a tab.url of `''`, created "baseUrl/" which wasn't triggered by the test of tab.url, which was "". Now the baseUrl is without a trailing slash on the general tab, so the tab.url of (for example) '/admin/projects/7bf3a6ef-e7f4-4f92-b565-75d5e0da43bc' matches the pathname, while before the tab url was computed to '/admin/projects/7bf3a6ef-e7f4-4f92-b565-75d5e0da43bc/' which is why it only matched when the pathname was ''/admin/projects/7bf3a6ef-e7f4-4f92-b565-75d5e0da43bc/'