### PR TITLE
CL-754 Set nlp api access token

### DIFF
--- a/back/engines/commercial/nlp/app/services/nlp/api.rb
+++ b/back/engines/commercial/nlp/app/services/nlp/api.rb
@@ -181,7 +181,7 @@ module NLP
     end
 
     def authorization_header
-      { 'Authorization' => "Token #{@authorization_token}" }
+      { 'access_token' => @authorization_token }
     end
   end
 end

--- a/back/engines/commercial/nlp/app/services/nlp/api.rb
+++ b/back/engines/commercial/nlp/app/services/nlp/api.rb
@@ -181,7 +181,7 @@ module NLP
     end
 
     def authorization_header
-      { 'access_token' => @authorization_token }
+      { 'Authorization' => @authorization_token }
     end
   end
 end

--- a/back/engines/commercial/nlp/spec/services/nlp/api_spec.rb
+++ b/back/engines/commercial/nlp/spec/services/nlp/api_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe NLP::Api do
       service.text_network_analysis_for_project('tenant-id', 'project-id', 'en')
 
       expect(HTTParty).to have_received(:post) do |_path, options|
-        authorization_header = options.dig(:headers, 'access_token')
+        authorization_header = options.dig(:headers, 'Authorization')
         expect(authorization_header).to eq(authorization_token)
       end
     end
@@ -92,7 +92,7 @@ RSpec.describe NLP::Api do
         expect(path).to eq('/v2/tenants/tenant-id/text_network_analysis')
 
         expected_headers = {
-          'access_token' => 'authorization-token',
+          'Authorization' => 'authorization-token',
           'Content-Type' => 'application/json'
         }
         expect(options[:headers]).to eq(expected_headers)
@@ -119,7 +119,7 @@ RSpec.describe NLP::Api do
 
       expect(HTTParty).to have_received(:post) do |path, options|
         expected_headers = {
-          'access_token' => 'authorization-token',
+          'Authorization' => 'authorization-token',
           'Content-Type' => 'application/json'
         }
         expect(options[:headers]).to eq(expected_headers)

--- a/back/engines/commercial/nlp/spec/services/nlp/api_spec.rb
+++ b/back/engines/commercial/nlp/spec/services/nlp/api_spec.rb
@@ -60,8 +60,8 @@ RSpec.describe NLP::Api do
       service.text_network_analysis_for_project('tenant-id', 'project-id', 'en')
 
       expect(HTTParty).to have_received(:post) do |_path, options|
-        authorization_header = options.dig(:headers, 'Authorization')
-        expect(authorization_header).to eq("Token #{authorization_token}")
+        authorization_header = options.dig(:headers, 'access_token')
+        expect(authorization_header).to eq("#{authorization_token}")
       end
     end
   end
@@ -92,7 +92,7 @@ RSpec.describe NLP::Api do
         expect(path).to eq('/v2/tenants/tenant-id/text_network_analysis')
 
         expected_headers = {
-          'Authorization' => 'Token authorization-token',
+          'access_token' => 'authorization-token',
           'Content-Type' => 'application/json'
         }
         expect(options[:headers]).to eq(expected_headers)
@@ -119,7 +119,7 @@ RSpec.describe NLP::Api do
 
       expect(HTTParty).to have_received(:post) do |path, options|
         expected_headers = {
-          'Authorization' => 'Token authorization-token',
+          'access_token' => 'authorization-token',
           'Content-Type' => 'application/json'
         }
         expect(options[:headers]).to eq(expected_headers)

--- a/back/engines/commercial/nlp/spec/services/nlp/api_spec.rb
+++ b/back/engines/commercial/nlp/spec/services/nlp/api_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe NLP::Api do
 
       expect(HTTParty).to have_received(:post) do |_path, options|
         authorization_header = options.dig(:headers, 'access_token')
-        expect(authorization_header).to eq("#{authorization_token}")
+        expect(authorization_header).to eq(authorization_token)
       end
     end
   end


### PR DESCRIPTION
This PR provides a small necessary change in the header of every nlp-api request.

## Checklist

- [ ] Added entry to changelog
cl2-nlp will have an interactive documentation interface with OpenAPI.

Related Ticket
https://citizenlab.atlassian.net/browse/CL-754

- [ ] Tests
- [ ] Prepared branch for code review

Review code for cl2-nlp api requests.
api.rb and tests at specs.rb

## Links

- [cl2-nlp PR](https://github.com/CitizenLabDotCo/cl2-nlp/pull/155)

## How urgent is a code review?

Not urgent.
