### PR TITLE
[react-router] update getAllPathsFromRoutes for new routing setup

### DIFF
--- a/front/app/modules/commercial/matomo/matchPath.test.ts
+++ b/front/app/modules/commercial/matomo/matchPath.test.ts
@@ -4,8 +4,7 @@ describe('getAllPathsFromRoutes', () => {
   it('should return all paths from routes', () => {
     const mockRoutes = {
       path: '/:locale',
-      indexRoute: {},
-      childRoutes: [
+      children: [
         {
           path: 'sign-in',
         },
@@ -20,12 +19,10 @@ describe('getAllPathsFromRoutes', () => {
         },
         {
           path: 'admin',
-          indexRoute: {},
-          childRoutes: [
+          children: [
             {
               path: 'dashboard',
-              indexRoute: {},
-              childRoutes: [
+              children: [
                 {
                   path: 'users',
                 },

--- a/front/app/modules/commercial/matomo/matchPath.ts
+++ b/front/app/modules/commercial/matomo/matchPath.ts
@@ -82,14 +82,13 @@ export function getAllPathsFromRoutes(route) {
   function paths(route: RouteConfiguration, head: string) {
     // to do: check into this vs. master
     if (route.children) {
-      if (route.children[0].index) {
-        res.push(makeRoute(head, route.path));
-      }
+      res.push(makeRoute(head, route.path));
       route.children.forEach((r) => paths(r, makeRoute(head, route.path)));
     } else {
       res.push(makeRoute(head, route.path));
     }
   }
+
   paths(route, '');
   return res.map((path) => path.replaceAll('/*', ''));
 }


### PR DESCRIPTION
I think we'll need to review the whole matomo setup with the new router upgrade but at least this function should be working as before now