### PR TITLE
CL-896 Add homepage records to seeds

### DIFF
--- a/back/app/models/home_page.rb
+++ b/back/app/models/home_page.rb
@@ -37,10 +37,10 @@ class HomePage < ApplicationRecord
   validate :only_one_home_page, on: :create
 
   validates :top_info_section_enabled, inclusion: [true, false]
-  validates :top_info_section_multiloc, presence: true, multiloc: { html: true, presence: true }, if: :top_info_section_enabled
+  validates :top_info_section_multiloc, multiloc: true, if: :top_info_section_enabled
 
   validates :bottom_info_section_enabled, inclusion: [true, false]
-  validates :bottom_info_section_multiloc, presence: true, multiloc: { html: true, presence: true }, if: :bottom_info_section_enabled
+  validates :bottom_info_section_multiloc, multiloc: true, if: :bottom_info_section_enabled
 
   validates :events_enabled, inclusion: [true, false]
   validates :projects_enabled, inclusion: [true, false]
@@ -48,10 +48,10 @@ class HomePage < ApplicationRecord
   validates :banner_avatars_enabled, inclusion: [true, false]
   validates :banner_enabled, inclusion: [true, false]
   validates :banner_layout, inclusion: %w[full_width_banner_layout two_column_layout two_row_layout]
-  validates :banner_signed_in_header_multiloc, presence: true, multiloc: true
+  validates :banner_signed_in_header_multiloc, multiloc: true
 
-  validates :banner_signed_out_header_multiloc, presence: true, multiloc: true
-  validates :banner_signed_out_subheader_multiloc, presence: true, multiloc: true
+  validates :banner_signed_out_header_multiloc, multiloc: true
+  validates :banner_signed_out_subheader_multiloc, multiloc: true
   validates :banner_signed_out_header_overlay_color, css_color: true
   validates :banner_signed_out_header_overlay_opacity, numericality: { only_integer: true,
                                                                        in: [0..100],

--- a/back/app/models/home_page.rb
+++ b/back/app/models/home_page.rb
@@ -45,6 +45,8 @@ class HomePage < ApplicationRecord
   validates :events_enabled, inclusion: [true, false]
   validates :projects_enabled, inclusion: [true, false]
 
+  validates :projects_header_multiloc, multloc: true
+
   validates :banner_avatars_enabled, inclusion: [true, false]
   validates :banner_enabled, inclusion: [true, false]
   validates :banner_layout, inclusion: %w[full_width_banner_layout two_column_layout two_row_layout]

--- a/back/app/models/home_page.rb
+++ b/back/app/models/home_page.rb
@@ -45,7 +45,7 @@ class HomePage < ApplicationRecord
   validates :events_enabled, inclusion: [true, false]
   validates :projects_enabled, inclusion: [true, false]
 
-  validates :projects_header_multiloc, multloc: true
+  validates :projects_header_multiloc, multiloc: true
 
   validates :banner_avatars_enabled, inclusion: [true, false]
   validates :banner_enabled, inclusion: [true, false]

--- a/back/app/models/home_page.rb
+++ b/back/app/models/home_page.rb
@@ -6,9 +6,9 @@
 # Table name: home_pages
 #
 #  id                                       :uuid             not null, primary key
-#  top_info_section_enabled                 :boolean          default(TRUE), not null
+#  top_info_section_enabled                 :boolean          default(FALSE), not null
 #  top_info_section_multiloc                :jsonb            not null
-#  bottom_info_section_enabled              :boolean          default(TRUE), not null
+#  bottom_info_section_enabled              :boolean          default(FALSE), not null
 #  bottom_info_section_multiloc             :jsonb            not null
 #  events_enabled                           :boolean          default(FALSE), not null
 #  projects_enabled                         :boolean          default(TRUE), not null

--- a/back/app/models/home_page.rb
+++ b/back/app/models/home_page.rb
@@ -37,10 +37,10 @@ class HomePage < ApplicationRecord
   validate :only_one_home_page, on: :create
 
   validates :top_info_section_enabled, inclusion: [true, false]
-  validates :top_info_section_multiloc, multiloc: true, if: :top_info_section_enabled
+  validates :top_info_section_multiloc, presence: true, multiloc: { html: true, presence: true }, if: :top_info_section_enabled
 
   validates :bottom_info_section_enabled, inclusion: [true, false]
-  validates :bottom_info_section_multiloc, multiloc: true, if: :bottom_info_section_enabled
+  validates :bottom_info_section_multiloc, presence: true, multiloc: { html: true, presence: true }, if: :bottom_info_section_enabled
 
   validates :events_enabled, inclusion: [true, false]
   validates :projects_enabled, inclusion: [true, false]

--- a/back/config/tenant_templates/base.yml
+++ b/back/config/tenant_templates/base.yml
@@ -1,9 +1,9 @@
 models:
   home_page:
     -
-      top_info_section_enabled: true
+      top_info_section_enabled: false
       top_info_section_multiloc: {}
-      bottom_info_section_enabled: true
+      bottom_info_section_enabled: false
       bottom_info_section_multiloc: {}
       events_enabled: false
       projects_enabled: true

--- a/back/config/tenant_templates/base.yml
+++ b/back/config/tenant_templates/base.yml
@@ -1,23 +1,6 @@
 models:
   home_page:
-    -
-      top_info_section_enabled: false
-      top_info_section_multiloc: {}
-      bottom_info_section_enabled: false
-      bottom_info_section_multiloc: {}
-      events_enabled: false
-      projects_enabled: true
-      projects_header_multiloc: {}
-      banner_avatars_enabled: true
-      banner_enabled: true
-      banner_layout: "full_width_banner_layout"
-      banner_signed_in_header_multiloc: {}
-      cta_signed_in_text_multiloc: {}
-      cta_signed_in_type: "no_button"
-      banner_signed_out_header_multiloc: {}
-      banner_signed_out_subheader_multiloc: {}
-      cta_signed_out_text_multiloc: {}
-      cta_signed_out_type: "sign_up_button"
+    - {}
   idea_status:
     -
       title_multiloc: idea_statuses.proposed

--- a/back/config/tenant_templates/base.yml
+++ b/back/config/tenant_templates/base.yml
@@ -1,4 +1,23 @@
 models:
+  home_page:
+    -
+      top_info_section_enabled: true
+      top_info_section_multiloc: {}
+      bottom_info_section_enabled: true
+      bottom_info_section_multiloc: {}
+      events_enabled: false
+      projects_enabled: true
+      projects_header_multiloc: {}
+      banner_avatars_enabled: true
+      banner_enabled: true
+      banner_layout: "full_width_banner_layout"
+      banner_signed_in_header_multiloc: {}
+      cta_signed_in_text_multiloc: {}
+      cta_signed_in_type: "no_button"
+      banner_signed_out_header_multiloc: {}
+      banner_signed_out_subheader_multiloc: {}
+      cta_signed_out_text_multiloc: {}
+      cta_signed_out_type: "sign_up_button"
   idea_status:
     -
       title_multiloc: idea_statuses.proposed

--- a/back/config/tenant_templates/e2etests_template.yml
+++ b/back/config/tenant_templates/e2etests_template.yml
@@ -1,24 +1,7 @@
 ---
 models:
   home_page:
-    -
-      top_info_section_enabled: false
-      top_info_section_multiloc: {}
-      bottom_info_section_enabled: false
-      bottom_info_section_multiloc: {}
-      events_enabled: false
-      projects_enabled: true
-      projects_header_multiloc: {}
-      banner_avatars_enabled: true
-      banner_enabled: true
-      banner_layout: "full_width_banner_layout"
-      banner_signed_in_header_multiloc: {}
-      cta_signed_in_text_multiloc: {}
-      cta_signed_in_type: "no_button"
-      banner_signed_out_header_multiloc: {}
-      banner_signed_out_subheader_multiloc: {}
-      cta_signed_out_text_multiloc: {}
-      cta_signed_out_type: "sign_up_button"
+    - {}
   idea_status:
     -
       title_multiloc: idea_statuses.proposed

--- a/back/config/tenant_templates/e2etests_template.yml
+++ b/back/config/tenant_templates/e2etests_template.yml
@@ -1,5 +1,24 @@
 ---
 models:
+  home_page:
+    -
+      top_info_section_enabled: true
+      top_info_section_multiloc: {}
+      bottom_info_section_enabled: true
+      bottom_info_section_multiloc: {}
+      events_enabled: false
+      projects_enabled: true
+      projects_header_multiloc: {}
+      banner_avatars_enabled: true
+      banner_enabled: true
+      banner_layout: "full_width_banner_layout"
+      banner_signed_in_header_multiloc: {}
+      cta_signed_in_text_multiloc: {}
+      cta_signed_in_type: "no_button"
+      banner_signed_out_header_multiloc: {}
+      banner_signed_out_subheader_multiloc: {}
+      cta_signed_out_text_multiloc: {}
+      cta_signed_out_type: "sign_up_button"
   idea_status:
     -
       title_multiloc: idea_statuses.proposed

--- a/back/config/tenant_templates/e2etests_template.yml
+++ b/back/config/tenant_templates/e2etests_template.yml
@@ -2,9 +2,9 @@
 models:
   home_page:
     -
-      top_info_section_enabled: true
+      top_info_section_enabled: false
       top_info_section_multiloc: {}
-      bottom_info_section_enabled: true
+      bottom_info_section_enabled: false
       bottom_info_section_multiloc: {}
       events_enabled: false
       projects_enabled: true

--- a/back/db/migrate/20220531123916_create_home_pages.rb
+++ b/back/db/migrate/20220531123916_create_home_pages.rb
@@ -3,10 +3,10 @@
 class CreateHomePages < ActiveRecord::Migration[6.1]
   def change
     create_table :home_pages, id: :uuid do |t|
-      t.boolean :top_info_section_enabled, default: true, null: false
+      t.boolean :top_info_section_enabled, default: false, null: false
       t.jsonb :top_info_section_multiloc, default: {}, null: false
 
-      t.boolean :bottom_info_section_enabled, default: true, null: false
+      t.boolean :bottom_info_section_enabled, default: false, null: false
       t.jsonb :bottom_info_section_multiloc, default: {}, null: false
 
       t.boolean :events_enabled, default: false, null: false

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -334,9 +334,9 @@ ActiveRecord::Schema.define(version: 2022_05_31_123916) do
   end
 
   create_table "home_pages", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.boolean "top_info_section_enabled", default: true, null: false
+    t.boolean "top_info_section_enabled", default: false, null: false
     t.jsonb "top_info_section_multiloc", default: {}, null: false
-    t.boolean "bottom_info_section_enabled", default: true, null: false
+    t.boolean "bottom_info_section_enabled", default: false, null: false
     t.jsonb "bottom_info_section_multiloc", default: {}, null: false
     t.boolean "events_enabled", default: false, null: false
     t.boolean "projects_enabled", default: true, null: false
@@ -1014,6 +1014,7 @@ ActiveRecord::Schema.define(version: 2022_05_31_123916) do
 
   create_table "que_values", primary_key: "key", id: :text, force: :cascade do |t|
     t.jsonb "value", default: {}, null: false
+    t.check_constraint "jsonb_typeof(value) = 'object'::text", name: "valid_value"
   end
 
   create_table "spam_reports", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -1014,7 +1014,6 @@ ActiveRecord::Schema.define(version: 2022_05_31_123916) do
 
   create_table "que_values", primary_key: "key", id: :text, force: :cascade do |t|
     t.jsonb "value", default: {}, null: false
-    t.check_constraint "jsonb_typeof(value) = 'object'::text", name: "valid_value"
   end
 
   create_table "spam_reports", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/back/db/seeds/citizenlab.rb
+++ b/back/db/seeds/citizenlab.rb
@@ -541,9 +541,6 @@ open_idea_project = Project.create!({
 open_idea_project.project_images.create!(remote_image_url: 'https://res.cloudinary.com/citizenlabco/image/upload/v1539874546/undraw_brainstorming_49d4_iaimmn.png')
 open_idea_project.set_default_topics!
 
-# Create settings for home page.
-HomePage.create!
-
 User.find_each do |user|
   EmailCampaigns::UnsubscriptionToken.create!(user_id: user.id)
 end

--- a/back/db/seeds/citizenlab.rb
+++ b/back/db/seeds/citizenlab.rb
@@ -541,6 +541,9 @@ open_idea_project = Project.create!({
 open_idea_project.project_images.create!(remote_image_url: 'https://res.cloudinary.com/citizenlabco/image/upload/v1539874546/undraw_brainstorming_49d4_iaimmn.png')
 open_idea_project.set_default_topics!
 
+# Create settings for Home Page.
+HomePage.create!
+
 User.find_each do |user|
   EmailCampaigns::UnsubscriptionToken.create!(user_id: user.id)
 end

--- a/back/db/seeds/citizenlab.rb
+++ b/back/db/seeds/citizenlab.rb
@@ -541,6 +541,9 @@ open_idea_project = Project.create!({
 open_idea_project.project_images.create!(remote_image_url: 'https://res.cloudinary.com/citizenlabco/image/upload/v1539874546/undraw_brainstorming_49d4_iaimmn.png')
 open_idea_project.set_default_topics!
 
+# Create settings for home page.
+HomePage.create!
+
 User.find_each do |user|
   EmailCampaigns::UnsubscriptionToken.create!(user_id: user.id)
 end

--- a/back/spec/models/home_page_spec.rb
+++ b/back/spec/models/home_page_spec.rb
@@ -25,17 +25,5 @@ RSpec.describe HomePage, type: :model do
       it { is_expected.to validate_presence_of(:cta_signed_in_url) }
       it { is_expected.to validate_presence_of(:cta_signed_in_text_multiloc) }
     end
-
-    context 'when top_info_section is enabled' do
-      subject { described_class.new(top_info_section_enabled: true) }
-
-      it { is_expected.to validate_presence_of(:top_info_section_multiloc) }
-    end
-
-    context 'when bottom_info_section is enabled' do
-      subject { described_class.new(bottom_info_section_enabled: true) }
-
-      it { is_expected.to validate_presence_of(:bottom_info_section_multiloc) }
-    end
   end
 end

--- a/back/spec/models/home_page_spec.rb
+++ b/back/spec/models/home_page_spec.rb
@@ -25,5 +25,17 @@ RSpec.describe HomePage, type: :model do
       it { is_expected.to validate_presence_of(:cta_signed_in_url) }
       it { is_expected.to validate_presence_of(:cta_signed_in_text_multiloc) }
     end
+
+    context 'when top_info_section is enabled' do
+      subject { described_class.new(top_info_section_enabled: true) }
+
+      it { is_expected.to validate_presence_of(:top_info_section_multiloc) }
+    end
+
+    context 'when bottom_info_section is enabled' do
+      subject { described_class.new(bottom_info_section_enabled: true) }
+
+      it { is_expected.to validate_presence_of(:bottom_info_section_multiloc) }
+    end
   end
 end


### PR DESCRIPTION
## Checklist
- [x] Prepared branch for code review

## TL;DR
A [KISS](https://en.wikipedia.org/wiki/KISS_principle) approach to seeding a `home_pages` record, given that some aspects of the default values, model validations and related specs may change in the light of design and functionality decisions still to be clarified / developed.

## Description

The original `AppConfig.settings` that seem to relate to the HomePage seem to be limited to:
```
"customizable_homepage_banner": {
    "layout": "full_width_banner_layout",
    "allowed": true,
    "enabled": true,
    "cta_signed_in_type": "no_button",
    "cta_signed_out_type": "sign_up_button"
},
```
All these values are set as defaults (at db level) for the new `HomePage` model, _**except**_ `allowed` which may not be necessary (see this [Slack thread](https://citizenlabco.slack.com/archives/CQZGXTFGD/p1654775376311739)).

### Why remove validations of presence for 3 multilocs?
The 3 multilocs concerned are:
```
Original name                         New name

header_title                          banner_signed_out_header_multiloc
custom_onboarding_fallback_message    banner_signed_in_header_multiloc
header_slogan                         banner_signed_out_subheader_multiloc
```
None of the 3 original multilocs appear to have seeded values, nor did I find them set in a small sample of tenant templates - which makes sense to me, as this would require translations for all locales, and what would be good values to seed these with?

Leaving these presence validations gives this error on `db:reset`:
```
ActiveRecord::RecordInvalid: Validation failed: Banner signed in header multiloc can't be blank, Banner signed out header multiloc can't be blank, Banner signed out subheader multiloc can't be blank
/cl2_back/engines/ee/multi_tenancy/app/services/multi_tenancy/tenant_template_service.rb:51:in `block (2 levels) in apply_template'
/cl2_back/engines/ee/multi_tenancy/app/services/multi_tenancy/tenant_template_service.rb:34:in `each'
/cl2_back/engines/ee/multi_tenancy/app/services/multi_tenancy/tenant_template_service.rb:34:in `block in apply_template'
/cl2_back/engines/ee/multi_tenancy/app/services/multi_tenancy/tenant_template_service.rb:28:in `each'
/cl2_back/engines/ee/multi_tenancy/app/services/multi_tenancy/tenant_template_service.rb:28:in `apply_template'
/cl2_back/engines/ee/multi_tenancy/app/services/multi_tenancy/tenant_template_service.rb:22:in `resolve_and_apply_template'
/cl2_back/engines/ee/multi_tenancy/db/seeds/citizenlab-ee.rb:522:in `<main>'
/cl2_back/db/seeds.rb:4:in `<main>'
```

Thus, I have removed the `presence: true` validations for these multilocs.

Locally, this currently gives a `home_pages` record with these values:
```
top_info_section_enabled: false,
 top_info_section_multiloc: {},
 bottom_info_section_enabled: false,
 bottom_info_section_multiloc: {},
 events_enabled: false,
 projects_enabled: true,
 projects_header_multiloc: {},
 banner_avatars_enabled: true,
 banner_enabled: true,
 banner_layout: "full_width_banner_layout",
 banner_signed_in_header_multiloc: {},
 cta_signed_in_text_multiloc: {},
 cta_signed_in_type: "no_button",
 cta_signed_in_url: nil,
 banner_signed_out_header_multiloc: {},
 banner_signed_out_subheader_multiloc: {},
 banner_signed_out_header_overlay_color: nil,
 banner_signed_out_header_overlay_opacity: nil,
 cta_signed_out_text_multiloc: {},
 cta_signed_out_type: "sign_up_button",
 cta_signed_out_url: nil,
```
(Tested locally on both OS and EE versions)

## Notes
In discussion with @benfraserdesign, it seems we will probably set the info sections to `false` as initial state, and I have done this in both the db migration (with related changes to `schema.rb`) and the 2 templates local to the `citizenlab` repo. 

The validations that check for multiloc presence and content in the `bottom_info_section_multiloc` and `top_info_section_multiloc`, don't prevent seeding because they are conditional on the respective info sections being enabled (values of `true`) and these are set to `false` initially.

This may present some issues for the FE to consider, since we will have a page where home page sections can be toggled on or off, but the BE will not validate the model when an info section (top or bottom) is enabled but there is no related content for the respective `...info_section_multiloc`. Thus, I imagine the FE will either need to prevent toggling an info section on if no respective `...info_section_multiloc` value is set and give some kind of feedback to the user on the home page sections view, or automatically open the section editor form when toggling 'on' is attempted in such a case and highlight the missing `...info_section_multiloc` field content.

## Still unresolved
How to add to existing external templates, via [/templates/serializer.rb](https://github.com/CitizenLabDotCo/citizenlab-ee/blob/master/back/engines/ee/multi_tenancy/app/services/multi_tenancy/templates/serializer.rb), as mentioned [here](https://www.notion.so/citizenlab/Tenant-templates-c756c55da21e407b97a21519deb96c53#c8e6d649991f499aa240786b78e72168). 
Maybe better to move this to a separate PR/task, as will require some work to test, and may be easier to test once the migration is released and existing tenants (including template tenants) have the required record written to their `home_pages` table?
EDIT: I've added some [notes on this](https://citizenlab.atlassian.net/browse/CL-896?focusedCommentId=25362) to the Jira ticket.