### PR TITLE
CL-953: Fix expand and collapse logic after update

### DIFF
--- a/front/app/modules/commercial/idea_custom_fields/admin/containers/projects/edit/ideaform/IdeaCustomField.tsx
+++ b/front/app/modules/commercial/idea_custom_fields/admin/containers/projects/edit/ideaform/IdeaCustomField.tsx
@@ -52,7 +52,7 @@ const CustomFieldTitle = styled.div`
 `;
 
 const StyledAccordion = styled(Accordion)`
-  border-bottom: solid 0px ${colors.separation};
+  border-bottom: none;
 `;
 
 const HeadingContainer = styled.div`
@@ -165,7 +165,7 @@ export default memo<Props>(
     const handleCollapseExpand = useCallback(() => {
       onCollapseExpand(id);
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [ideaCustomField]);
+    }, [id]);
 
     if (!isNilOrError(ideaCustomField)) {
       return (
@@ -174,7 +174,6 @@ export default memo<Props>(
             title={
               <HeadingContainer
                 onMouseDown={removeFocusAfterMouseClick}
-                onClick={handleCollapseExpand}
                 className={`
                 e2e-${ideaCustomField.attributes.code}-setting-collapsed
               `}
@@ -185,6 +184,7 @@ export default memo<Props>(
               </HeadingContainer>
             }
             isOpenByDefault={!collapsed}
+            onChange={handleCollapseExpand}
           >
             <CollapsedContainer>
               <Toggles>

--- a/front/app/modules/commercial/idea_custom_fields/admin/containers/projects/edit/ideaform/IdeaCustomField.tsx
+++ b/front/app/modules/commercial/idea_custom_fields/admin/containers/projects/edit/ideaform/IdeaCustomField.tsx
@@ -1,12 +1,5 @@
-import React, {
-  memo,
-  useCallback,
-  useEffect,
-  useState,
-  lazy,
-  Suspense,
-} from 'react';
-import { isNilOrError, removeFocusAfterMouseClick } from 'utils/helperUtils';
+import React, { memo, useCallback, useEffect, useState } from 'react';
+import { isNilOrError } from 'utils/helperUtils';
 
 // services
 import {
@@ -17,13 +10,13 @@ import {
 // components
 import {
   IconTooltip,
-  Spinner,
   Toggle,
   Accordion,
+  Box,
+  Title,
 } from '@citizenlab/cl2-component-library';
-const QuillMutilocWithLocaleSwitcher = lazy(
-  () => import('components/UI/QuillEditor/QuillMultilocWithLocaleSwitcher')
-);
+
+import QuillMutilocWithLocaleSwitcher from 'components/UI/QuillEditor/QuillMultilocWithLocaleSwitcher';
 
 // i18n
 import T from 'components/T';
@@ -36,35 +29,6 @@ import { colors, fontSizes } from 'utils/styleUtils';
 
 // typings
 import { Multiloc } from 'typings';
-
-const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-`;
-
-const CustomFieldTitle = styled.div`
-  flex: 1;
-  color: ${colors.adminTextColor};
-  font-size: ${fontSizes.l}px;
-  line-height: normal;
-  font-weight: 500;
-`;
-
-const StyledAccordion = styled(Accordion)`
-  border-bottom: none;
-`;
-
-const HeadingContainer = styled.div`
-  padding-top: 15px;
-  padding-bottom: 15px;
-`;
-
-const CollapsedContainer = styled.div`
-  padding-top: 10px;
-  margin-bottom: 25px;
-  width: 100%;
-`;
 
 const Toggles = styled.div`
   margin-bottom: 30px;
@@ -162,92 +126,85 @@ export default memo<Props>(
       onChange(ideaCustomField.id, { required: fieldRequired });
     }, [fieldRequired, ideaCustomField, onChange]);
 
-    const handleCollapseExpand = useCallback(() => {
+    const handleCollapseExpand = () => {
       onCollapseExpand(id);
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [id]);
+    };
 
     if (!isNilOrError(ideaCustomField)) {
       return (
-        <Container className={`${className || ''}`}>
-          <StyledAccordion
-            title={
-              <HeadingContainer
-                onMouseDown={removeFocusAfterMouseClick}
-                className={`
-                e2e-${ideaCustomField.attributes.code}-setting-collapsed
-              `}
-              >
-                <CustomFieldTitle>
-                  <T value={ideaCustomField.attributes.title_multiloc} />
-                </CustomFieldTitle>
-              </HeadingContainer>
-            }
-            isOpenByDefault={!collapsed}
-            onChange={handleCollapseExpand}
-          >
-            <CollapsedContainer>
-              <Toggles>
-                {canSetEnabled && (
-                  <ToggleContainer>
-                    <StyledToggle
-                      checked={fieldEnabled}
-                      onChange={handleEnabledOnChange}
-                      label={<FormattedMessage {...messages.enabled} />}
-                      labelTextColor={colors.adminTextColor}
-                      className={`
-                        e2e-${ideaCustomField.attributes.code}-enabled-toggle-label
-                      `}
-                    />
-                    <IconTooltip
-                      content={
-                        <FormattedMessage {...messages.enabledTooltipContent} />
-                      }
-                    />
-                  </ToggleContainer>
-                )}
-                {fieldEnabled && canSetRequired && (
-                  <ToggleContainer>
-                    <StyledToggle
-                      checked={fieldRequired}
-                      onChange={handleRequiredOnChange}
-                      label={<FormattedMessage {...messages.required} />}
-                      labelTextColor={colors.adminTextColor}
-                      className={`
-                          e2e-${ideaCustomField.attributes.code}-required-toggle-label
-                      `}
-                    />
-                    <IconTooltip
-                      content={
-                        <FormattedMessage
-                          {...messages.requiredTooltipContent}
-                        />
-                      }
-                    />
-                  </ToggleContainer>
-                )}
-              </Toggles>
-
-              {fieldEnabled && (
-                <Suspense fallback={<Spinner />}>
-                  <QuillMutilocWithLocaleSwitcher
-                    id={`${ideaCustomField.id}-description`}
-                    noImages={true}
-                    noVideos={true}
-                    noAlign={true}
-                    valueMultiloc={descriptionMultiloc}
-                    onChange={handleDescriptionOnChange}
-                    label={
-                      <LocaleSwitcherLabelText>
-                        <FormattedMessage {...messages.descriptionLabel} />
-                      </LocaleSwitcherLabelText>
+        <Accordion
+          title={
+            <Box
+              className={`
+              e2e-${ideaCustomField.attributes.code}-setting-collapsed
+            `}
+            >
+              <Title variant="h3">
+                <T value={ideaCustomField.attributes.title_multiloc} />
+              </Title>
+            </Box>
+          }
+          isOpenByDefault={!collapsed}
+          onChange={handleCollapseExpand}
+          className={`${className || ''}`}
+        >
+          <Box pt="10px" mb="25px" w="100%">
+            <Toggles>
+              {canSetEnabled && (
+                <ToggleContainer>
+                  <StyledToggle
+                    checked={fieldEnabled}
+                    onChange={handleEnabledOnChange}
+                    label={<FormattedMessage {...messages.enabled} />}
+                    labelTextColor={colors.adminTextColor}
+                    className={`
+                      e2e-${ideaCustomField.attributes.code}-enabled-toggle-label
+                    `}
+                  />
+                  <IconTooltip
+                    content={
+                      <FormattedMessage {...messages.enabledTooltipContent} />
                     }
                   />
-                </Suspense>
+                </ToggleContainer>
               )}
-            </CollapsedContainer>
-          </StyledAccordion>
-        </Container>
+              {fieldEnabled && canSetRequired && (
+                <ToggleContainer>
+                  <StyledToggle
+                    checked={fieldRequired}
+                    onChange={handleRequiredOnChange}
+                    label={<FormattedMessage {...messages.required} />}
+                    labelTextColor={colors.adminTextColor}
+                    className={`
+                        e2e-${ideaCustomField.attributes.code}-required-toggle-label
+                    `}
+                  />
+                  <IconTooltip
+                    content={
+                      <FormattedMessage {...messages.requiredTooltipContent} />
+                    }
+                  />
+                </ToggleContainer>
+              )}
+            </Toggles>
+
+            {fieldEnabled && (
+              <QuillMutilocWithLocaleSwitcher
+                id={`${ideaCustomField.id}-description`}
+                noImages={true}
+                noVideos={true}
+                noAlign={true}
+                valueMultiloc={descriptionMultiloc}
+                onChange={handleDescriptionOnChange}
+                label={
+                  <LocaleSwitcherLabelText>
+                    <FormattedMessage {...messages.descriptionLabel} />
+                  </LocaleSwitcherLabelText>
+                }
+              />
+            )}
+          </Box>
+        </Accordion>
       );
     }
 

--- a/front/app/modules/commercial/idea_custom_fields/admin/containers/projects/edit/ideaform/IdeaCustomField.tsx
+++ b/front/app/modules/commercial/idea_custom_fields/admin/containers/projects/edit/ideaform/IdeaCustomField.tsx
@@ -168,6 +168,7 @@ interface Props {
     updatedProperties: IUpdatedIdeaCustomFieldProperties
   ) => void;
   className?: string;
+  id: string;
 }
 
 const disablableFields = [
@@ -186,6 +187,7 @@ export default memo<Props>(
     onChange,
     onCollapseExpand,
     className,
+    id,
   }) => {
     const canSetEnabled = disablableFields.find(
       (field) => field === ideaCustomField.attributes.key
@@ -234,7 +236,7 @@ export default memo<Props>(
     }, [fieldRequired, ideaCustomField, onChange]);
 
     const handleCollapseExpand = useCallback(() => {
-      onCollapseExpand(ideaCustomField.id);
+      onCollapseExpand(id);
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [ideaCustomField]);
 

--- a/front/app/modules/commercial/idea_custom_fields/admin/containers/projects/edit/ideaform/IdeaCustomField.tsx
+++ b/front/app/modules/commercial/idea_custom_fields/admin/containers/projects/edit/ideaform/IdeaCustomField.tsx
@@ -41,11 +41,6 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  border-bottom: solid 1px ${colors.separation};
-
-  &.first {
-    border-top: solid 1px ${colors.separation};
-  }
 `;
 
 const CustomFieldTitle = styled.div`
@@ -54,6 +49,10 @@ const CustomFieldTitle = styled.div`
   font-size: ${fontSizes.l}px;
   line-height: normal;
   font-weight: 500;
+`;
+
+const StyledAccordion = styled(Accordion)`
+  border-bottom: solid 0px ${colors.separation};
 `;
 
 const HeadingContainer = styled.div`
@@ -112,7 +111,6 @@ export default memo<Props>(
   ({
     ideaCustomField,
     collapsed,
-    first,
     onChange,
     onCollapseExpand,
     className,
@@ -171,8 +169,8 @@ export default memo<Props>(
 
     if (!isNilOrError(ideaCustomField)) {
       return (
-        <Container className={`${className || ''} ${first ? 'first' : ''}`}>
-          <Accordion
+        <Container className={`${className || ''}`}>
+          <StyledAccordion
             title={
               <HeadingContainer
                 onMouseDown={removeFocusAfterMouseClick}
@@ -248,7 +246,7 @@ export default memo<Props>(
                 </Suspense>
               )}
             </CollapsedContainer>
-          </Accordion>
+          </StyledAccordion>
         </Container>
       );
     }

--- a/front/app/modules/commercial/idea_custom_fields/admin/containers/projects/edit/ideaform/IdeaCustomField.tsx
+++ b/front/app/modules/commercial/idea_custom_fields/admin/containers/projects/edit/ideaform/IdeaCustomField.tsx
@@ -56,12 +56,12 @@ const CustomFieldTitle = styled.div`
   font-weight: 500;
 `;
 
-const CollapsedContent = styled.div`
+const HeadingContainer = styled.div`
   padding-top: 15px;
   padding-bottom: 15px;
 `;
 
-const CollapseContainerInner = styled.div`
+const CollapsedContainer = styled.div`
   padding-top: 10px;
   margin-bottom: 25px;
   width: 100%;
@@ -174,22 +174,21 @@ export default memo<Props>(
         <Container className={`${className || ''} ${first ? 'first' : ''}`}>
           <Accordion
             title={
-              <CollapsedContent
+              <HeadingContainer
                 onMouseDown={removeFocusAfterMouseClick}
                 onClick={handleCollapseExpand}
                 className={`
-                ${collapsed ? 'collapsed' : 'expanded'}
                 e2e-${ideaCustomField.attributes.code}-setting-collapsed
               `}
               >
                 <CustomFieldTitle>
                   <T value={ideaCustomField.attributes.title_multiloc} />
                 </CustomFieldTitle>
-              </CollapsedContent>
+              </HeadingContainer>
             }
             isOpenByDefault={!collapsed}
           >
-            <CollapseContainerInner>
+            <CollapsedContainer>
               <Toggles>
                 {canSetEnabled && (
                   <ToggleContainer>
@@ -248,7 +247,7 @@ export default memo<Props>(
                   />
                 </Suspense>
               )}
-            </CollapseContainerInner>
+            </CollapsedContainer>
           </Accordion>
         </Container>
       );

--- a/front/app/modules/commercial/idea_custom_fields/admin/containers/projects/edit/ideaform/index.tsx
+++ b/front/app/modules/commercial/idea_custom_fields/admin/containers/projects/edit/ideaform/index.tsx
@@ -35,6 +35,8 @@ import styled from 'styled-components';
 // typings
 import { Multiloc } from 'typings';
 
+import { IIdeaCustomFieldData } from '../../../../../services/ideaCustomFields';
+
 const Container = styled.div``;
 
 const Header = styled.div`
@@ -105,11 +107,15 @@ const IdeaForm = memo<Props & WithRouterProps & InjectedIntlProps>(
       (key) => collapsed[key] === false
     );
 
+    // We are using a custom created id because the ids on the backend change on initial update
+    const getCustomFieldId = (ideaCustomField: IIdeaCustomFieldData) =>
+      `${ideaCustomField.type}${ideaCustomField.attributes.key}`;
+
     useEffect(() => {
       if (!isNilOrError(ideaCustomFields) && isEmpty(collapsed)) {
         const newCollapsed = {};
         ideaCustomFields.data.forEach((ideaCustomField) => {
-          newCollapsed[ideaCustomField.id] = true;
+          newCollapsed[getCustomFieldId(ideaCustomField)] = true;
         });
         setCollapsed(newCollapsed);
       }
@@ -231,14 +237,16 @@ const IdeaForm = memo<Props & WithRouterProps & InjectedIntlProps>(
                 />
               </StyledSubSectionTitle>
               {ideaCustomFields.data.map((ideaCustomField, index) => {
+                const id = getCustomFieldId(ideaCustomField);
                 return (
                   <IdeaCustomField
-                    key={ideaCustomField.id}
-                    collapsed={collapsed[ideaCustomField.id]}
+                    key={id}
+                    collapsed={collapsed[id]}
                     first={index === 0}
                     ideaCustomField={ideaCustomField}
                     onCollapseExpand={handleIdeaCustomFieldOnCollapseExpand}
                     onChange={handleIdeaCustomFieldOnChange}
+                    id={id}
                   />
                 );
               })}

--- a/front/app/modules/commercial/idea_custom_fields/admin/containers/projects/edit/ideaform/index.tsx
+++ b/front/app/modules/commercial/idea_custom_fields/admin/containers/projects/edit/ideaform/index.tsx
@@ -109,7 +109,7 @@ const IdeaForm = memo<Props & WithRouterProps & InjectedIntlProps>(
 
     // We are using a custom created id because the ids on the backend change on initial update
     const getCustomFieldId = (ideaCustomField: IIdeaCustomFieldData) =>
-      `${ideaCustomField.type}${ideaCustomField.attributes.key}`;
+      `${ideaCustomField.type}_${ideaCustomField.attributes.key}`;
 
     useEffect(() => {
       if (!isNilOrError(ideaCustomFields) && isEmpty(collapsed)) {


### PR DESCRIPTION
## How to test

- Create a new continuous ideation project.
- Edit the location custom field's description and toggle it to required.
- Click "save". You might already notice the behaviour is different than usual (the location entry collapsed, while normally it would remain expanded).
- Click on the location entry. It should collapse
- Click on another field, for example "tags", and check to see that it works well

## Links

- [CL-953](https://citizenlab.atlassian.net/browse/CL-953)

## How urgent is a code review?

End of day tomorrow

## Screenshots
![image](https://user-images.githubusercontent.com/12659000/173336808-2d28409b-b5b0-467a-a8e7-9b1efcd06052.png)

