### PR TITLE
Remove permissions check for admin folders

### DIFF
--- a/front/app/components/UI/Button/index.tsx
+++ b/front/app/components/UI/Button/index.tsx
@@ -18,10 +18,19 @@ interface ButtonContainerProps extends ComponentLibraryButtonContainerProps {
   'data-testid'?: string;
 }
 
-const ButtonWrapper = ({ linkTo, openLinkInNewTab, ...rest }: Props) => {
+const ButtonWrapper = ({
+  linkTo,
+  openLinkInNewTab,
+  disabled,
+  ...rest
+}: Props) => {
   const locale = useLocale();
   const isExternalLink =
     linkTo && (linkTo.startsWith('http') || linkTo.startsWith('www'));
+
+  if (disabled) {
+    return <Button disabled {...rest} />;
+  }
 
   const link = linkTo
     ? isExternalLink

--- a/front/app/modules/commercial/project_folders/permissions/rules.ts
+++ b/front/app/modules/commercial/project_folders/permissions/rules.ts
@@ -1,32 +1,9 @@
 import { IProjectFolderData } from './../services/projectFolders';
-import {
-  definePermissionRule,
-  IRouteItem,
-} from 'services/permissions/permissions';
-import { isProjectFolderModerator, moderatesFolder } from './roles';
+import { definePermissionRule } from 'services/permissions/permissions';
+import { moderatesFolder } from './roles';
 import { isAdmin } from 'services/permissions/roles';
-import {
-  canAccessRoute,
-  isAdminRoute,
-  MODERATOR_ROUTES,
-} from 'services/permissions/rules/routePermissions';
+
 import { IUser } from 'services/users';
-import { IAppConfigurationData } from 'services/appConfiguration';
-
-const canUserAccessAdminFolderRoute = (
-  item: IRouteItem,
-  user: IUser | null,
-  tenant: IAppConfigurationData
-) => {
-  return (
-    canAccessRoute(item, user, tenant) ||
-    (isAdminRoute(item.path) &&
-      (user ? isProjectFolderModerator(user.data) : false) &&
-      MODERATOR_ROUTES.includes(item.path))
-  );
-};
-
-definePermissionRule('route', 'access', canUserAccessAdminFolderRoute);
 
 definePermissionRule(
   'project_folder',

--- a/front/app/services/permissions/rules/routePermissions.ts
+++ b/front/app/services/permissions/rules/routePermissions.ts
@@ -30,7 +30,7 @@ export const isModeratedProjectRoute = (
   item: IRouteItem,
   user: IUser | null
 ) => {
-  const idRegexp = /^\/admin\/projects\/([a-z0-9-]+)\//;
+  const idRegexp = /^\/admin\/projects\/([a-z0-9-]+)\/?/;
   const matches = idRegexp.exec(item.path);
   const pathProjectId = matches && matches[1];
   return (pathProjectId && isProjectModerator(user, pathProjectId)) || false;
@@ -63,6 +63,10 @@ export const canAccessRoute = (
     }
 
     if (isModerator(user) && isModeratorRoute(item)) {
+      return true;
+    }
+
+    if (item.path.includes('folders')) {
       return true;
     }
 


### PR DESCRIPTION
So this basically reverts the functionality to the pre-router changes, where we just say “true” if the user is trying to edit a folder. This was happening before as we were passing the locale in to isAdminRoute which always fails due to the regex, regardless of the route, so this function hits the first boolean, `isAdminRoute(item)` is false, and it goes to the `else`, which always just returns true:

```
export const canAccessRoute = (
  item: IRouteItem,
  user: IUser | null,
  tenant: IAppConfigurationData
) => {
  if (isAdminRoute(item)) {
    if (isSuperAdmin(user)) {
      return true;
    }

    if (tenantIsChurned(tenant)) {
      return false;
    }

    if (isAdmin(user)) {
      return true;
    }

    if (isModerator(user) && isModeratorRoute(item)) {
      return true;
    }

    return isModeratedProjectRoute(item, user);
  } else {
    return true;
  }
};
```

It's broken after the router upgrade because we are doing it right now, somehow, and passing the url without the locale. So now `isAdminRoute` correctly returns true, but then the actual logic for checking permissions is broken.