### PR TITLE
Fix e2e test for content builder mobile toggle

### DIFF
--- a/front/cypress/e2e/content_builder/mobile_preview_toggle.cy.ts
+++ b/front/cypress/e2e/content_builder/mobile_preview_toggle.cy.ts
@@ -51,12 +51,6 @@ describe('Content builder mobile preview', () => {
   it('shows saved description if there is no draft content', () => {
     cy.visit(`/admin/content-builder/projects/${projectId}/description`);
     cy.wait(10000);
-    cy.get('#e2e-draggable-single-column').dragAndDrop(
-      '#e2e-content-builder-frame',
-      {
-        position: 'inside',
-      }
-    );
     cy.get('#e2e-draggable-text').dragAndDrop('#e2e-content-builder-frame', {
       position: 'inside',
     });


### PR DESCRIPTION
After deleting the single column elements - this e2e test that relies on it was not updated.