### PR TITLE
CL-704 Representativeness scores – computation on-the-fly

### DIFF
--- a/back/engines/commercial/user_custom_fields/app/controllers/user_custom_fields/web_api/v1/stats_users_controller.rb
+++ b/back/engines/commercial/user_custom_fields/app/controllers/user_custom_fields/web_api/v1/stats_users_controller.rb
@@ -126,20 +126,8 @@ module UserCustomFields
 
         def find_users
           users = policy_scope(User.active, policy_scope_class: StatUserPolicy::Scope)
-            .where(registration_completed_at: @start_at..@end_at)
-
-          if params[:group]
-            group = Group.find(params[:group])
-            users = users.merge(group.members)
-          end
-
-          if params[:project]
-            project = Project.find(params[:project])
-            participants = ParticipantsService.new.project_participants(project)
-            users = users.where(id: participants)
-          end
-
-          users
+          finder_params = params.permit(:group, :project).merge(registration_date_range: @start_at..@end_at)
+          UsersFinder.new(users, finder_params).execute
         end
 
         def expected_user_counts

--- a/back/engines/commercial/user_custom_fields/app/finders/user_custom_fields/users_finder.rb
+++ b/back/engines/commercial/user_custom_fields/app/finders/user_custom_fields/users_finder.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module UserCustomFields
+  class UsersFinder
+    # @param user_scope [ActiveRecord::Relation] the scope of users to filter
+    # @param params [Hash]
+    # @option params [String] :group group identifier, only users from this group will
+    #   be returned
+    # @option params [String] :project project identifier, only participants of this
+    #   project will be returned
+    # @option params [Range] :registration_date_range date range, only users who
+    #   completed registration in this range will be returned
+    # @return [ActiveRecord::Relation]
+    def initialize(user_scope = User, params = {})
+      @user_scope = user_scope
+      @params = params
+    end
+
+    def execute
+      users = filter_by_registration_date(@user_scope)
+      users = filter_by_group(users)
+      filter_by_project(users)
+    end
+
+    def filter_by_registration_date(users)
+      return users unless @params[:registration_date_range]
+
+      users.where(registration_completed_at: @params[:registration_date_range])
+    end
+
+    def filter_by_group(users)
+      return users unless @params[:group]
+
+      group = Group.find(@params[:group])
+      users.merge(group.members)
+    end
+
+    def filter_by_project(users)
+      return users unless @params[:project]
+
+      project = Project.find(@params[:project])
+      participants = ParticipantsService.new.project_participants(project)
+      users.where(id: participants)
+    end
+  end
+end


### PR DESCRIPTION
This logic will be reused to select groups of users for the computation of representativeness scores.

## Checklist

- [ ] Added entry to changelog
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

- [ ] WCAG 2.1 AA proof
<details>
<summary>More info</summary>
For front-end devs only. Is your work conforming with the WCAG 2.1 AA rules? If you need more info, read the [a11y page](https://www.notion.so/citizenlab/a11y-7568f83d42ab4895ac133b89d358997b) on our Notion.
</details>

- [ ] Tests
<details>
<summary>More info</summary>

### Unit tests

Did you add relevant unit tests?

### E2E tests

Sometimes it can be more efficient to update E2E tests after CI has run them. If you know which ones to update, go ahead! E2E template cl2-back:

```bash
docker compose run --rm web bin/rails cl2_back:create_tenant[localhost,e2etests_template]
```

</details>

- [ ] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## Links

- [citizenlab-ee PR](**put URL here** or remove)
- [Specs](**put URL here** or remove)
- [Epic Deployment](**put URL here** or remove)

## How urgent is a code review?

Let the reviewer(s) know how urgent the code review is, so they can prioritize their work accordingly. Be specific (e.g. by Wednesday, end of the day/this week/... is better than 'urgent' or 'very urgent'). Optionally provide a word of explanation on your deadline.
