### PR TITLE
[CL-903] Remove terser webpack plugin to fix page crash on Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Next release
+
+## Fixed
+
+- [CL-903] Fix admin input manager crash on Safari
+
 ## 2022-06-16
 
 ### Added

--- a/front/internals/webpack/webpack.config.js
+++ b/front/internals/webpack/webpack.config.js
@@ -9,7 +9,6 @@ const webpack = require('webpack');
 
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const TerserPlugin = require('terser-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const MomentLocalesPlugin = require('moment-locales-webpack-plugin');
@@ -92,13 +91,7 @@ const config = {
         chunks: 'all',
       },
       moduleIds: 'deterministic',
-      minimizer: [
-        new TerserPlugin({
-          parallel: false,
-          terserOptions: { sourceMap: true },
-        }),
-        new CssMinimizerPlugin(),
-      ],
+      minimizer: [new CssMinimizerPlugin()],
     },
   }),
 
@@ -194,8 +187,6 @@ const config = {
     }),
 
     // new BundleAnalyzerPlugin(),
-
-    // new webpack.ProgressPlugin(),
 
     // remove all moment locales except 'en' and the ones defined in appLocalesMomentPairs
     !isDev &&

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -186,7 +186,6 @@
         "shelljs": "0.8.5",
         "style-loader": "^3.3.1",
         "styled-components": "5.3.5",
-        "terser-webpack-plugin": "5.3.1",
         "ts-jest": "^28.0.5",
         "ts-loader": "^9.2.6",
         "ts-prune": "^0.10.1",

--- a/front/package.json
+++ b/front/package.json
@@ -224,7 +224,6 @@
     "shelljs": "0.8.5",
     "style-loader": "^3.3.1",
     "styled-components": "5.3.5",
-    "terser-webpack-plugin": "5.3.1",
     "ts-jest": "^28.0.5",
     "ts-loader": "^9.2.6",
     "ts-prune": "^0.10.1",


### PR DESCRIPTION
Not entire sure why but removing the webpack terser plugin fixed the page crash issue on Safari. I suspect it has something to do with the source maps but cannot say for sure. Webpack 5 comes out of the box with it and it only need to be installed if we want to customize its options (which we clearly don't). 
https://webpack.js.org/plugins/terser-webpack-plugin/

## Checklist

- [x] Added entry to changelog
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

- [ ] WCAG 2.1 AA proof
<details>
<summary>More info</summary>
For front-end devs only. Is your work conforming with the WCAG 2.1 AA rules? If you need more info, read the [a11y page](https://www.notion.so/citizenlab/a11y-7568f83d42ab4895ac133b89d358997b) on our Notion.
</details>

- [ ] Tests
<details>
<summary>More info</summary>

### Unit tests

Did you add relevant unit tests?

### E2E tests

Sometimes it can be more efficient to update E2E tests after CI has run them. If you know which ones to update, go ahead! E2E template cl2-back:

```bash
docker compose run --rm web bin/rails cl2_back:create_tenant[localhost,e2etests_template]
```

</details>

- [ ] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## Links

- [citizenlab-ee PR](**put URL here** or remove)
- [Specs](**put URL here** or remove)
- [Epic Deployment](**put URL here** or remove)

## How urgent is a code review?

Let the reviewer(s) know how urgent the code review is, so they can prioritize their work accordingly. Be specific (e.g. by Wednesday, end of the day/this week/... is better than 'urgent' or 'very urgent'). Optionally provide a word of explanation on your deadline.
