### PR TITLE
[No ticket] Upgrade to bcrypt 3.1.18

### DIFF
--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -549,7 +549,7 @@ GEM
       mimemagic (~> 0.3)
       nokogiri (~> 1.8, >= 1.8.2)
       rubyzip (~> 1.2, >= 1.2.1)
-    bcrypt (3.1.17)
+    bcrypt (3.1.18)
     bindata (2.4.10)
     binding_ninja (0.2.3)
     binding_of_caller (1.0.0)


### PR DESCRIPTION
Changelog https://github.com/bcrypt-ruby/bcrypt-ruby/blob/master/CHANGELOG

3.1.18 May 16 2022
  - Unlock GVL when calculating hashes and salts [GH #260]
  - Fix compilation warnings in `ext/mri/bcrypt_ext.c` [GH #261]
