### PR TITLE
CL-885 Layout image_elements method should deal with possible non-hash values along path

### DIFF
--- a/back/engines/commercial/content_builder/app/services/content_builder/layout_image_service.rb
+++ b/back/engines/commercial/content_builder/app/services/content_builder/layout_image_service.rb
@@ -6,7 +6,7 @@ module ContentBuilder
 
     def image_elements(content)
       content.select do |key, elt|
-        key != 'ROOT' && elt.dig('type', 'resolvedName') == 'Image'
+        key != 'ROOT' && elt.is_a?(Hash) && elt['type'].is_a?(Hash) && elt.dig('type', 'resolvedName') == 'Image'
       end.values.pluck('props')
     end
 

--- a/back/engines/commercial/content_builder/app/services/content_builder/layout_image_service.rb
+++ b/back/engines/commercial/content_builder/app/services/content_builder/layout_image_service.rb
@@ -6,7 +6,7 @@ module ContentBuilder
 
     def image_elements(content)
       content.select do |key, elt|
-        key != 'ROOT' && elt.is_a?(Hash) && elt['type'].is_a?(Hash) && elt.dig('type', 'resolvedName') == 'Image'
+        key != 'ROOT' && image_element?(elt)
       end.values.pluck('props')
     end
 
@@ -24,6 +24,12 @@ module ContentBuilder
 
     def code_attribute_for_element
       'dataCode'
+    end
+
+    private
+
+    def image_element?(element)
+      element.is_a?(Hash) && element['type'].is_a?(Hash) && element.dig('type', 'resolvedName') == 'Image'
     end
   end
 end

--- a/back/engines/commercial/content_builder/spec/services/content_builder/layout_image_service_spec.rb
+++ b/back/engines/commercial/content_builder/spec/services/content_builder/layout_image_service_spec.rb
@@ -234,4 +234,16 @@ describe ContentBuilder::LayoutImageService do
       expect(output).to eq({ 'fr-BE' => expected_json })
     end
   end
+
+  describe 'image_elements' do
+    it 'can deal with different combinations of hash structures' do
+      content = {
+        'elt1' => 'string element',
+        'elt2' => { 'type' => 'div', 'props' => 'elt2-props' },
+        'elt3' => { 'type' => { 'resolvedName' => 'Image' }, 'props' => 'elt3-props' }
+      }
+      images = service.send :image_elements, content
+      expect(images).to eq ['elt3-props']
+    end
+  end
 end


### PR DESCRIPTION
The test initially failed and turned green after the code fix. Two things bother me about the solution:
1. We're testing a protected method, using `send`.
2. The conditional looks ugly. Alternatively we could implement a method like `safe_dig` but I'm not too fond of that solution either (we don't have the habit of providing our own utility methods for built-in Ruby classes).

## Links

- [Jira](https://citizenlab.atlassian.net/browse/CL-885)