### PR TITLE
[CL-1010] Create reusable page form skeleton for sections and sticky button

### DIFF
--- a/front/app/containers/Admin/pagesAndMenu/SectionFormWrapper.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/SectionFormWrapper.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import Breadcrumbs from 'components/UI/Breadcrumbs';
+import PageTitle from 'components/admin/PageTitle';
+import { Box } from '@citizenlab/cl2-component-library';
+
+const testBreadcrumbs = [
+  { label: 'Pages & Menu', linkTo: 'test' },
+  { label: 'Home', linkTo: 'test' },
+  { label: 'Hero Banner', linkTo: 'test' },
+];
+
+const testTitle = 'Hero Banner';
+const testChildren = <div>hello</div>;
+
+const SectionFormWrapper = ({
+  breadcrumbs = testBreadcrumbs,
+  title = testTitle,
+  children = testChildren,
+}) => {
+  return (
+    <div>
+      <Box mb="16px">
+        <Breadcrumbs breadcrumbs={breadcrumbs} />
+      </Box>
+      <PageTitle>{title}</PageTitle>
+      {children}
+    </div>
+  );
+};
+
+export default SectionFormWrapper;

--- a/front/app/containers/Admin/pagesAndMenu/SectionFormWrapper.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/SectionFormWrapper.tsx
@@ -1,16 +1,32 @@
 import React from 'react';
+
+// components
+import StickyContainer from './StickyContainer';
+import { Box, Button } from '@citizenlab/cl2-component-library';
 import Breadcrumbs from 'components/UI/Breadcrumbs';
 import PageTitle from 'components/admin/PageTitle';
-import { Box } from '@citizenlab/cl2-component-library';
+import PageWrapper from 'components/admin/PageWrapper';
 
+// test props for development purposes
 const testBreadcrumbs = [
-  { label: 'Pages & Menu', linkTo: 'test' },
-  { label: 'Home', linkTo: 'test' },
-  { label: 'Hero Banner', linkTo: 'test' },
+  { label: 'Pages & Menu', linkTo: '/test' },
+  { label: 'Home', linkTo: '/test' },
+  { label: 'Hero banner', linkTo: '/test' },
 ];
-
+const TestBox = () => (
+  <Box height="100px" mb="10px" border="1px solid black">
+    Test Box
+  </Box>
+);
 const testTitle = 'Hero Banner';
-const testChildren = <div>hello</div>;
+const testChildren = (
+  <div>
+    <TestBox /> <TestBox /> <TestBox /> <TestBox /> <TestBox />
+    <TestBox />
+    <TestBox />
+    <TestBox />
+  </div>
+);
 
 const SectionFormWrapper = ({
   breadcrumbs = testBreadcrumbs,
@@ -22,8 +38,17 @@ const SectionFormWrapper = ({
       <Box mb="16px">
         <Breadcrumbs breadcrumbs={breadcrumbs} />
       </Box>
-      <PageTitle>{title}</PageTitle>
-      {children}
+      <Box mb="20px">
+        <PageTitle>{title}</PageTitle>
+      </Box>
+      <Box>
+        <PageWrapper>
+          {children}
+          <StickyContainer>
+            <Button>Save Hero Banner</Button>
+          </StickyContainer>
+        </PageWrapper>
+      </Box>
     </div>
   );
 };

--- a/front/app/containers/Admin/pagesAndMenu/SectionFormWrapper.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/SectionFormWrapper.tsx
@@ -7,32 +7,13 @@ import Breadcrumbs from 'components/UI/Breadcrumbs';
 import PageTitle from 'components/admin/PageTitle';
 import PageWrapper from 'components/admin/PageWrapper';
 
-// test props for development purposes
-const testBreadcrumbs = [
-  { label: 'Pages & Menu', linkTo: '/test' },
-  { label: 'Home', linkTo: '/test' },
-  { label: 'Hero banner', linkTo: '/test' },
-];
-const TestBox = () => (
-  <Box height="100px" mb="10px" border="1px solid black">
-    Test Box
-  </Box>
-);
-const testTitle = 'Hero Banner';
-const testChildren = (
-  <div>
-    <TestBox /> <TestBox /> <TestBox /> <TestBox /> <TestBox />
-    <TestBox />
-    <TestBox />
-    <TestBox />
-  </div>
-);
+interface Props {
+  breadcrumbs: { label: string; linkTo?: string }[];
+  title: string;
+  children: JSX.Element;
+}
 
-const SectionFormWrapper = ({
-  breadcrumbs = testBreadcrumbs,
-  title = testTitle,
-  children = testChildren,
-}) => {
+const SectionFormWrapper = ({ breadcrumbs, title, children }: Props) => {
   return (
     <div>
       <Box mb="16px">

--- a/front/app/containers/Admin/pagesAndMenu/StickyContainer.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/StickyContainer.tsx
@@ -1,0 +1,27 @@
+import styled from 'styled-components';
+import { media } from 'utils/styleUtils';
+import { colors } from 'utils/styleUtils';
+
+const StickyContainer = styled.div`
+  background-color: #fcfcfc;
+  border-top: 1px solid ${colors.separation};
+
+  height: 78px;
+  width: calc(100% + 8rem);
+
+  position: sticky;
+  bottom: 0;
+  margin-left: -4rem;
+  margin-bottom: -4rem;
+  padding-left: 45px;
+
+  display: flex;
+  align-items: center;
+
+  ${media.smallerThan1280px`
+    width: calc(100% + 4rem);
+    margin-left: -2rem;
+  `}
+`;
+
+export default StickyContainer;

--- a/front/app/containers/Admin/pagesAndMenu/StickyContainer.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/StickyContainer.tsx
@@ -1,6 +1,5 @@
 import styled from 'styled-components';
-import { media } from 'utils/styleUtils';
-import { colors } from 'utils/styleUtils';
+import { media, colors } from 'utils/styleUtils';
 
 const StickyContainer = styled.div`
   background-color: #fcfcfc;

--- a/front/app/containers/Admin/routes.tsx
+++ b/front/app/containers/Admin/routes.tsx
@@ -18,9 +18,6 @@ import { Navigate, useLocation } from 'react-router-dom';
 const AdminContainer = lazy(() => import('containers/Admin'));
 const AdminWorkshops = lazy(() => import('containers/Admin/workshops'));
 const AdminFavicon = lazy(() => import('containers/Admin/favicon'));
-const SectionFormWrapper = lazy(
-  () => import('containers/Admin/pagesAndMenu/SectionFormWrapper')
-);
 
 // hooks
 import { usePermission } from 'services/permissions';
@@ -140,14 +137,6 @@ const createAdminRoutes = () => {
         ),
       },
       ...moduleConfiguration.routes.admin,
-      {
-        path: 'pages-and-menu',
-        element: (
-          <PageLoading>
-            <SectionFormWrapper />
-          </PageLoading>
-        ),
-      },
     ],
   };
 };

--- a/front/app/containers/Admin/routes.tsx
+++ b/front/app/containers/Admin/routes.tsx
@@ -18,6 +18,9 @@ import { Navigate, useLocation } from 'react-router-dom';
 const AdminContainer = lazy(() => import('containers/Admin'));
 const AdminWorkshops = lazy(() => import('containers/Admin/workshops'));
 const AdminFavicon = lazy(() => import('containers/Admin/favicon'));
+const SectionFormWrapper = lazy(
+  () => import('containers/Admin/pagesAndMenu/SectionFormWrapper')
+);
 
 // hooks
 import { usePermission } from 'services/permissions';
@@ -137,6 +140,14 @@ const createAdminRoutes = () => {
         ),
       },
       ...moduleConfiguration.routes.admin,
+      {
+        path: 'pages-and-menu',
+        element: (
+          <PageLoading>
+            <SectionFormWrapper />
+          </PageLoading>
+        ),
+      },
     ],
   };
 };


### PR DESCRIPTION
Basic skeleton with no logic. Likely the structure of the file and the parent/child component relationship will need to change once we introduce actual functionality but it should be easy to adapt at that stage

https://user-images.githubusercontent.com/3614128/175296076-9e8d45e2-96fa-4c15-be67-5bc5eb9073ac.mov

