### PR TITLE
CL-1048 CraftJS types bug

### DIFF
--- a/back/engines/commercial/content_builder/app/models/content_builder/layout.rb
+++ b/back/engines/commercial/content_builder/app/models/content_builder/layout.rb
@@ -37,9 +37,7 @@ module ContentBuilder
       url_validation_service = ::UrlValidationService.new
 
       craftjs_jsonmultiloc.each do |locale, json|
-        json.each do |key, elt|
-          next if key == 'ROOT' || elt.dig('type', 'resolvedName') != 'Iframe'
-
+        LayoutService.new.select_craftjs_elements_for_type(json, 'Iframe').each do |elt|
           url = elt.dig 'props', 'url'
           if url && !url_validation_service.whitelisted?(url)
             errors.add :craftjs_jsonmultiloc, :iframe_url_not_whitelisted, locale: locale, url: url

--- a/back/engines/commercial/content_builder/app/services/content_builder/layout_image_service.rb
+++ b/back/engines/commercial/content_builder/app/services/content_builder/layout_image_service.rb
@@ -5,9 +5,7 @@ module ContentBuilder
     protected
 
     def image_elements(content)
-      content.select do |key, elt|
-        key != 'ROOT' && image_element?(elt)
-      end.values.pluck('props')
+      LayoutService.new.select_craftjs_elements_for_type(content, 'Image').pluck('props')
     end
 
     def content_image_class
@@ -24,12 +22,6 @@ module ContentBuilder
 
     def code_attribute_for_element
       'dataCode'
-    end
-
-    private
-
-    def image_element?(element)
-      element.is_a?(Hash) && element['type'].is_a?(Hash) && element.dig('type', 'resolvedName') == 'Image'
     end
   end
 end

--- a/back/engines/commercial/content_builder/app/services/content_builder/layout_sanitization_service.rb
+++ b/back/engines/commercial/content_builder/app/services/content_builder/layout_sanitization_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ContentBuilder
-  class LayoutSanitizationService < ::ContentImageService
+  class LayoutSanitizationService
     def sanitize(craftjson, text_features: %i[title alignment list decoration link image video])
       sanitize_html_in_text_elements craftjson, text_features
     end
@@ -15,9 +15,7 @@ module ContentBuilder
     private
 
     def sanitize_html_in_text_elements(craftjson, features)
-      craftjson.each do |key, elt|
-        next if key == 'ROOT' || elt.dig('type', 'resolvedName') != 'Text'
-
+      LayoutService.new.select_craftjs_elements_for_type(craftjson, 'Text').each do |elt|
         text = elt.dig 'props', 'text'
         elt['props']['text'] = html_sanitizer.sanitize text, features if text
       end

--- a/back/engines/commercial/content_builder/app/services/content_builder/layout_service.rb
+++ b/back/engines/commercial/content_builder/app/services/content_builder/layout_service.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ContentBuilder
+  class LayoutService
+    def select_craftjs_elements_for_type(craftjs, type)
+      craftjs.select do |key, elt|
+        key != 'ROOT' && craftjs_element_of_type?(elt, type)
+      end.values
+    end
+
+    def craftjs_element_of_type?(elt, type)
+      elt.is_a?(Hash) && elt['type'].is_a?(Hash) && elt.dig('type', 'resolvedName') == type
+    end
+  end
+end

--- a/back/engines/commercial/content_builder/spec/services/content_builder/layout_image_service_spec.rb
+++ b/back/engines/commercial/content_builder/spec/services/content_builder/layout_image_service_spec.rb
@@ -234,16 +234,4 @@ describe ContentBuilder::LayoutImageService do
       expect(output).to eq({ 'fr-BE' => expected_json })
     end
   end
-
-  describe 'image_elements' do
-    it 'can deal with different combinations of hash structures' do
-      content = {
-        'elt1' => 'string element',
-        'elt2' => { 'type' => 'div', 'props' => 'elt2-props' },
-        'elt3' => { 'type' => { 'resolvedName' => 'Image' }, 'props' => 'elt3-props' }
-      }
-      images = service.send :image_elements, content
-      expect(images).to eq ['elt3-props']
-    end
-  end
 end

--- a/back/engines/commercial/content_builder/spec/services/content_builder/layout_service_spec.rb
+++ b/back/engines/commercial/content_builder/spec/services/content_builder/layout_service_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ContentBuilder::LayoutService do
+  let(:service) { described_class.new }
+
+  describe 'select_craftjs_elements_for_type' do
+    it 'can deal with different combinations of hash structures' do
+      content = {
+        'elt1' => 'string element',
+        'elt2' => { 'type' => 'div', 'props' => 'elt2-props' },
+        'elt3' => { 'type' => { 'resolvedName' => 'Image' }, 'props' => 'elt3-props' }
+      }
+      images = service.select_craftjs_elements_for_type content, 'Image'
+      expect(images).to eq [{ 'type' => { 'resolvedName' => 'Image' }, 'props' => 'elt3-props' }]
+    end
+  end
+end


### PR DESCRIPTION
The issue from the previous PR also occurred in other places where we use other types (iframes and text). The spec is nicer now though, since we're no longer testing a private method.