### PR TITLE
Release 2022-06-23_3

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -4,7 +4,7 @@
 
 First you have the latest docker and docker-compose installed.
 
-Build the docker compose images
+Build the docker compose images 
 ```
 docker-compose up --build -d
 ```

--- a/back/README.md
+++ b/back/README.md
@@ -2,7 +2,7 @@
  
 # Getting started
 
-First you have the latest docker and docker-compose installed.
+First, you need the latest docker and docker-compose installed.
 
 Build the docker compose images 
 ```


### PR DESCRIPTION
Release 2022-06-23_3

A change to one line of `back/readme` just to trigger the back-deploy CI, to pick up the latest `ee` release, which I somehow forgot to release before releasing `Release 2022-06-23_2` for `citizenlab`.
