### PR TITLE
CL-885 UI tweaks content builder sections

### DIFF
--- a/front/app/modules/commercial/content_builder/admin/components/ContentBuilderSettings/index.tsx
+++ b/front/app/modules/commercial/content_builder/admin/components/ContentBuilderSettings/index.tsx
@@ -56,7 +56,10 @@ const ContentBuilderSettings = () => {
     actions.selectNode();
   };
 
-  return selected && isEnabled && selected.id !== ROOT_NODE ? (
+  return selected &&
+    isEnabled &&
+    selected.id !== ROOT_NODE &&
+    selected.name !== 'Box' ? (
     <StyledBox
       position="fixed"
       right="0"

--- a/front/app/modules/commercial/content_builder/admin/components/ContentBuilderToolbox/index.tsx
+++ b/front/app/modules/commercial/content_builder/admin/components/ContentBuilderToolbox/index.tsx
@@ -63,7 +63,7 @@ const ContentBuilderToolbox = ({
       flexDirection="column"
       alignItems="center"
       bgColor="#ffffff"
-      overflowY="scroll"
+      overflowY="auto"
       borderRight={`1px solid ${colors.mediumGrey}`}
     >
       <Box w="100%" display="inline">

--- a/front/app/modules/commercial/content_builder/admin/components/ContentBuilderToolbox/index.tsx
+++ b/front/app/modules/commercial/content_builder/admin/components/ContentBuilderToolbox/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 // craft
-import { useEditor, Element } from '@craftjs/core';
+import { useEditor } from '@craftjs/core';
 
 // Router
 import { useParams } from 'react-router-dom';
@@ -21,7 +21,8 @@ import Iframe from '../CraftComponents/Iframe';
 import AboutBox from '../CraftComponents/AboutBox';
 import Accordion from '../CraftComponents/Accordion';
 import WhiteSpace from '../CraftComponents/WhiteSpace';
-import Container from '../CraftComponents/Container';
+import InfoWithAccordions from '../CraftSections/InfoWithAccordions';
+import ImageTextCards from '../CraftSections/ImageTextCards';
 
 // intl
 import messages from '../../messages';
@@ -72,35 +73,11 @@ const ContentBuilderToolbox = ({
           id="e2e-draggable-image-text-cards"
           ref={(ref) =>
             ref &&
-            connectors.create(
-              ref,
-              <Element id="image-text-cards" is={Box} canvas>
-                <TwoColumn columnLayout="1-2">
-                  <Element id="left" is={Container} canvas>
-                    <Image alt="" />
-                  </Element>
-                  <Element id="right" is={Container} canvas>
-                    <Text text={formatMessage(messages.textValue)} />
-                  </Element>
-                </TwoColumn>
-                <TwoColumn columnLayout="1-2">
-                  <Element id="left" is={Container} canvas>
-                    <Image alt="" />
-                  </Element>
-                  <Element id="right" is={Container} canvas>
-                    <Text text={formatMessage(messages.textValue)} />
-                  </Element>
-                </TwoColumn>
-                <TwoColumn columnLayout="1-2">
-                  <Element id="left" is={Container} canvas>
-                    <Image alt="" />
-                  </Element>
-                  <Element id="right" is={Container} canvas>
-                    <Text text={formatMessage(messages.textValue)} />
-                  </Element>
-                </TwoColumn>
-              </Element>
-            )
+            connectors.create(ref, <ImageTextCards />, {
+              onCreate: (node) => {
+                selectNode(node.rootNodeId);
+              },
+            })
           }
         >
           <ToolboxItem
@@ -114,36 +91,12 @@ const ContentBuilderToolbox = ({
             ref &&
             connectors.create(
               ref,
-              <Element id="image-text-cards" is={Box} canvas>
-                <TwoColumn columnLayout="2-1">
-                  <Element id="left" is={Container} canvas>
-                    <Text text={formatMessage(messages.textValue)} />
-                  </Element>
-                  <Element id="right" is={Container} canvas>
-                    <AboutBox projectId={projectId} />
-                  </Element>
-                </TwoColumn>
-                <WhiteSpace size="small" />
-                <TwoColumn columnLayout="2-1">
-                  <Element id="left" is={Container} canvas>
-                    <Accordion
-                      title={formatMessage(messages.accordionTitleValue)}
-                      text={formatMessage(messages.accordionTextValue)}
-                      openByDefault={false}
-                    />
-                    <Accordion
-                      title={formatMessage(messages.accordionTitleValue)}
-                      text={formatMessage(messages.accordionTextValue)}
-                      openByDefault={false}
-                    />
-                    <Accordion
-                      title={formatMessage(messages.accordionTitleValue)}
-                      text={formatMessage(messages.accordionTextValue)}
-                      openByDefault={false}
-                    />
-                  </Element>
-                </TwoColumn>
-              </Element>
+              <InfoWithAccordions projectId={projectId} />,
+              {
+                onCreate: (node) => {
+                  selectNode(node.rootNodeId);
+                },
+              }
             )
           }
         >

--- a/front/app/modules/commercial/content_builder/admin/components/ContentBuilderToolbox/index.tsx
+++ b/front/app/modules/commercial/content_builder/admin/components/ContentBuilderToolbox/index.tsx
@@ -209,7 +209,7 @@ const ContentBuilderToolbox = ({
           id="e2e-draggable-image"
           ref={(ref) => {
             ref &&
-              connectors.create(ref, <Image imageUrl="" alt="" />, {
+              connectors.create(ref, <Image alt="" />, {
                 onCreate: (node) => {
                   selectNode(node.rootNodeId);
                 },

--- a/front/app/modules/commercial/content_builder/admin/components/ContentBuilderToolbox/index.tsx
+++ b/front/app/modules/commercial/content_builder/admin/components/ContentBuilderToolbox/index.tsx
@@ -63,10 +63,19 @@ const ContentBuilderToolbox = ({
       flexDirection="column"
       alignItems="center"
       bgColor="#ffffff"
+      overflowY="scroll"
       borderRight={`1px solid ${colors.mediumGrey}`}
     >
       <Box w="100%" display="inline">
-        <Title mt="24px" ml="5px" variant="h6" as="h1" color="label">
+        <Title
+          fontWeight="normal"
+          mb="0px"
+          mt="24px"
+          ml="10px"
+          variant="h6"
+          as="h3"
+          color="label"
+        >
           <FormattedMessage {...messages.sections} />
         </Title>
         <DraggableElement
@@ -105,7 +114,15 @@ const ContentBuilderToolbox = ({
             label={formatMessage(messages.infoWithAccordions)}
           />
         </DraggableElement>
-        <Title mt="32px" ml="5px" variant="h6" as="h1" color="label">
+        <Title
+          fontWeight="normal"
+          mb="0px"
+          mt="24px"
+          ml="10px"
+          variant="h6"
+          as="h3"
+          color="label"
+        >
           <FormattedMessage {...messages.layout} />
         </Title>
         <DraggableElement
@@ -160,7 +177,15 @@ const ContentBuilderToolbox = ({
             label={formatMessage(messages.whiteSpace)}
           />
         </DraggableElement>
-        <Title mt="32px" ml="4px" variant="h6" as="h1" color="label">
+        <Title
+          fontWeight="normal"
+          mb="0px"
+          mt="24px"
+          ml="10px"
+          variant="h6"
+          as="h3"
+          color="label"
+        >
           <FormattedMessage {...messages.content} />
         </Title>
         <DraggableElement

--- a/front/app/modules/commercial/content_builder/admin/components/CraftComponents/Image/index.tsx
+++ b/front/app/modules/commercial/content_builder/admin/components/CraftComponents/Image/index.tsx
@@ -82,7 +82,7 @@ const ImageSettings = injectIntl(({ intl: { formatMessage } }) => {
 
   const handleOnRemove = () => {
     setProp((props) => {
-      props.imageUrl = undefined;
+      props.imageUrl = '';
       props.dataCode = undefined;
       props.alt = '';
     });
@@ -127,9 +127,6 @@ const ImageSettings = injectIntl(({ intl: { formatMessage } }) => {
 });
 
 Image.craft = {
-  props: {
-    imageUrl: '',
-  },
   related: {
     settings: ImageSettings,
   },

--- a/front/app/modules/commercial/content_builder/admin/components/CraftSections/ImageTextCards/index.tsx
+++ b/front/app/modules/commercial/content_builder/admin/components/CraftSections/ImageTextCards/index.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+// components
+import { Box } from '@citizenlab/cl2-component-library';
+
+// craft
+import { UserComponent, Element } from '@craftjs/core';
+import TwoColumn from '../../CraftComponents/TwoColumn';
+import Container from '../../CraftComponents/Container';
+import Image from '../../CraftComponents/Image';
+import Text from '../../CraftComponents/Text';
+
+// intl
+import messages from '../../../messages';
+import { injectIntl } from 'utils/cl-intl';
+import { InjectedIntlProps } from 'react-intl';
+
+const ImageTextCards: UserComponent = ({
+  intl: { formatMessage },
+}: InjectedIntlProps) => {
+  return (
+    <Element id="image-text-cards" is={Box} canvas>
+      <TwoColumn columnLayout="1-2">
+        <Element id="left" is={Container} canvas>
+          <Image alt="" />
+        </Element>
+        <Element id="right" is={Container} canvas>
+          <Text text={formatMessage(messages.textValue)} />
+        </Element>
+      </TwoColumn>
+      <TwoColumn columnLayout="1-2">
+        <Element id="left" is={Container} canvas>
+          <Image alt="" />
+        </Element>
+        <Element id="right" is={Container} canvas>
+          <Text text={formatMessage(messages.textValue)} />
+        </Element>
+      </TwoColumn>
+      <TwoColumn columnLayout="1-2">
+        <Element id="left" is={Container} canvas>
+          <Image alt="" />
+        </Element>
+        <Element id="right" is={Container} canvas>
+          <Text text={formatMessage(messages.textValue)} />
+        </Element>
+      </TwoColumn>
+    </Element>
+  );
+};
+
+export default injectIntl(ImageTextCards);

--- a/front/app/modules/commercial/content_builder/admin/components/CraftSections/InfoWithAccordions/index.tsx
+++ b/front/app/modules/commercial/content_builder/admin/components/CraftSections/InfoWithAccordions/index.tsx
@@ -26,7 +26,7 @@ const InfoWithAccordions: UserComponent = ({
   projectId,
 }: InfoWithAccordionsProps) => {
   return (
-    <Element id="image-text-cards" is={Box} canvas>
+    <Element id="info-with-accordions" is={Box} canvas>
       <TwoColumn columnLayout="2-1">
         <Element id="left" is={Container} canvas>
           <Text text={formatMessage(messages.textValue)} />

--- a/front/app/modules/commercial/content_builder/admin/components/CraftSections/InfoWithAccordions/index.tsx
+++ b/front/app/modules/commercial/content_builder/admin/components/CraftSections/InfoWithAccordions/index.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+// components
+import { Box } from '@citizenlab/cl2-component-library';
+
+// craft
+import { UserComponent, Element } from '@craftjs/core';
+import TwoColumn from '../../CraftComponents/TwoColumn';
+import Text from '../../CraftComponents/Text';
+import AboutBox from '../../CraftComponents/AboutBox';
+import WhiteSpace from '../../CraftComponents/WhiteSpace';
+import Accordion from '../../CraftComponents/Accordion';
+import Container from '../../CraftComponents/Container';
+
+// intl
+import messages from '../../../messages';
+import { injectIntl } from 'utils/cl-intl';
+import { InjectedIntlProps } from 'react-intl';
+
+type InfoWithAccordionsProps = {
+  projectId: string;
+} & InjectedIntlProps;
+
+const InfoWithAccordions: UserComponent = ({
+  intl: { formatMessage },
+  projectId,
+}: InfoWithAccordionsProps) => {
+  return (
+    <Element id="image-text-cards" is={Box} canvas>
+      <TwoColumn columnLayout="2-1">
+        <Element id="left" is={Container} canvas>
+          <Text text={formatMessage(messages.textValue)} />
+        </Element>
+        <Element id="right" is={Container} canvas>
+          <AboutBox projectId={projectId} />
+        </Element>
+      </TwoColumn>
+      <WhiteSpace size="small" />
+      <TwoColumn columnLayout="2-1">
+        <Element id="left" is={Container} canvas>
+          <Accordion
+            title={formatMessage(messages.accordionTitleValue)}
+            text={formatMessage(messages.accordionTextValue)}
+            openByDefault={false}
+          />
+          <Accordion
+            title={formatMessage(messages.accordionTitleValue)}
+            text={formatMessage(messages.accordionTextValue)}
+            openByDefault={false}
+          />
+          <Accordion
+            title={formatMessage(messages.accordionTitleValue)}
+            text={formatMessage(messages.accordionTextValue)}
+            openByDefault={false}
+          />
+        </Element>
+        <Element id="right" is={Container} canvas />
+      </TwoColumn>
+    </Element>
+  );
+};
+
+export default injectIntl(InfoWithAccordions);

--- a/front/app/modules/commercial/content_builder/admin/components/Editor/index.tsx
+++ b/front/app/modules/commercial/content_builder/admin/components/Editor/index.tsx
@@ -16,6 +16,8 @@ import Iframe from '../CraftComponents/Iframe';
 import AboutBox from '../CraftComponents/AboutBox';
 import Accordion from '../CraftComponents/Accordion';
 import WhiteSpace from '../CraftComponents/WhiteSpace';
+import InfoWithAccordions from '../CraftSections/InfoWithAccordions';
+import ImageTextCards from '../CraftSections/ImageTextCards';
 
 type EditorProps = {
   children?: React.ReactNode;
@@ -41,6 +43,8 @@ const Editor: React.FC<EditorProps> = ({
         AboutBox,
         Accordion,
         WhiteSpace,
+        InfoWithAccordions,
+        ImageTextCards,
       }}
       onRender={isPreview ? undefined : RenderNode}
       enabled={isPreview ? false : true}

--- a/front/app/modules/commercial/content_builder/admin/components/RenderNode/index.tsx
+++ b/front/app/modules/commercial/content_builder/admin/components/RenderNode/index.tsx
@@ -23,6 +23,8 @@ const IFRAME = 'Iframe';
 const ABOUT_BOX = 'AboutBox';
 const ACCORDION = 'Accordion';
 const WHITE_SPACE = 'WhiteSpace';
+const INFO_WITH_ACCORDIONS = 'InfoWithAccordions';
+const IMAGE_TEXT_CARDS = 'ImageTextCards';
 
 type ComponentNamesType =
   | typeof CONTAINER
@@ -33,7 +35,9 @@ type ComponentNamesType =
   | typeof IFRAME
   | typeof ABOUT_BOX
   | typeof ACCORDION
-  | typeof WHITE_SPACE;
+  | typeof WHITE_SPACE
+  | typeof INFO_WITH_ACCORDIONS
+  | typeof IMAGE_TEXT_CARDS;
 
 export const getComponentNameMessage = (name: ComponentNamesType) => {
   switch (name) {
@@ -55,6 +59,10 @@ export const getComponentNameMessage = (name: ComponentNamesType) => {
       return messages.accordion;
     case WHITE_SPACE:
       return messages.whiteSpace;
+    case INFO_WITH_ACCORDIONS:
+      return messages.infoWithAccordions;
+    case IMAGE_TEXT_CARDS:
+      return messages.imageTextCards;
     default:
       return messages.default;
   }
@@ -142,7 +150,11 @@ const RenderNode = ({ render }) => {
 
   const isSelectable = getComponentNameMessage(name) !== messages.default;
   const nodeLabelIsVisible =
-    isActive && isSelectable && id !== ROOT_NODE && isDeletable;
+    isActive &&
+    isSelectable &&
+    id !== ROOT_NODE &&
+    isDeletable &&
+    name !== CONTAINER;
   const nodeIsHovered = isHover && id !== ROOT_NODE && name !== CONTAINER;
   const solidBorderIsVisible =
     isSelectable && (nodeLabelIsVisible || nodeIsHovered || hasError);
@@ -162,7 +174,7 @@ const RenderNode = ({ render }) => {
           ? colors.clRedError
           : solidBorderIsVisible
           ? colors.adminTextColor
-          : name !== TWO_COLUMNS && name !== THREE_COLUMNS && isSelectable
+          : isSelectable
           ? colors.separation
           : 'transparent'
       }

--- a/front/app/modules/commercial/content_builder/admin/components/RenderNode/index.tsx
+++ b/front/app/modules/commercial/content_builder/admin/components/RenderNode/index.tsx
@@ -202,7 +202,8 @@ const RenderNode = ({ render }) => {
       )}
       <div
         style={{
-          pointerEvents: name === IFRAME ? 'none' : 'auto',
+          pointerEvents:
+            name === IFRAME || name === ABOUT_BOX ? 'none' : 'auto',
           display: name === IMAGE ? 'flex' : 'auto',
           width: '100%',
         }}

--- a/front/app/modules/commercial/content_builder/admin/messages.ts
+++ b/front/app/modules/commercial/content_builder/admin/messages.ts
@@ -117,7 +117,7 @@ export default defineMessages({
   },
   imageTextCards: {
     id: 'app.containers.admin.ContentBuilder.imageTextCards',
-    defaultMessage: 'Image & Text Cards',
+    defaultMessage: 'Image & text cards',
   },
   infoWithAccordions: {
     id: 'app.containers.admin.ContentBuilder.infoWithAccordions',


### PR DESCRIPTION
## Changes Include:
- About component not be clickable when in edit more
- The sidebar should have scroll-y: auto
- Component should be ‘Image & test cards’ (**needs to be done in crowd-in**)
- Give all containers a dashed border in canvas (so these new section components but also the column components)
- Ensure new section component names are reflected in edit panel (currently ‘default’)
- Update styling for section headings in toolbox 
- Solved the last saving issue on FE instead of BE

## Checklist
- [x] Prepared branch for code review

## How urgent is a code review?
End of today if possible?
