### PR TITLE
Cl 1051 Fix project creation status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- [CL-1051] When a new project is published, it's default publication status is now draft
+- [CL-1051] When a new project is published, its default publication status is now draft
 
 ## 2022-06-29_2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Next release
+
+### Fixed
+
+- [CL-1051] When a new project is published, it's default publication status is now draft
+
 ## 2022-06-29_2
 
 ### Added

--- a/front/app/containers/Admin/projects/project/general/index.tsx
+++ b/front/app/containers/Admin/projects/project/general/index.tsx
@@ -86,7 +86,11 @@ const AdminProjectsProjectGeneral = ({
   const [apiErrors, setApiErrors] = useState({});
   const [projectAttributesDiff, setProjectAttributesDiff] = useState<
     IProjectFormState['projectAttributesDiff']
-  >({});
+  >({
+    admin_publication_attributes: {
+      publication_status: 'draft',
+    },
+  });
   const [titleError, setTitleError] =
     useState<IProjectFormState['titleError']>(null);
   // We should probably not have projectType, slug, publicationStatus, etc.

--- a/front/cypress/e2e/admin/projects/add_project.cy.ts
+++ b/front/cypress/e2e/admin/projects/add_project.cy.ts
@@ -13,6 +13,37 @@ describe('Admin: add project', () => {
 
   context('Type: Timeline', () => {
     context('Areas: All areas', () => {
+      it('creates a draft project by default', () => {
+        const projectTitleEN = randomString();
+        const projectTitleNLBE = randomString();
+        const projectTitleNLNL = randomString();
+        const projectTitleFRBE = randomString();
+
+        // Type random project titles for these required fields
+        cy.get('#project-title').type(projectTitleEN);
+        cy.get('.e2e-localeswitcher.nl-BE').click();
+        cy.get('#project-title').type(projectTitleNLBE);
+        cy.get('.e2e-localeswitcher.nl-NL').click();
+        cy.get('#project-title').type(projectTitleNLNL);
+        cy.get('.e2e-localeswitcher.fr-BE').click();
+        cy.get('#project-title').type(projectTitleFRBE);
+
+        // Submit project
+        cy.get('.e2e-submit-wrapper-button').click();
+
+        cy.wait(2000);
+
+        // Project should appear on top of the projects list
+        cy.get('#e2e-admin-projects-list-unsortable')
+          .children()
+          .first()
+          .contains(projectTitleEN);
+        cy.get('#e2e-admin-projects-list-unsortable')
+          .children()
+          .first()
+          .contains('Draft');
+      });
+
       it('creates a draft project', () => {
         const projectTitleEN = randomString();
         const projectTitleNLBE = randomString();
@@ -36,8 +67,15 @@ describe('Admin: add project', () => {
 
         cy.wait(2000);
 
-        // Project should appear on top of the Published projects
-        cy.get('#e2e-admin-projects-list-unsortable').contains(projectTitleEN);
+        // Project should appear on top of the projects list
+        cy.get('#e2e-admin-projects-list-unsortable')
+          .children()
+          .first()
+          .contains(projectTitleEN);
+        cy.get('#e2e-admin-projects-list-unsortable')
+          .children()
+          .first()
+          .contains('Draft');
       });
 
       it('creates a published project', () => {
@@ -47,7 +85,7 @@ describe('Admin: add project', () => {
         const projectTitleFRBE = randomString();
 
         // Select 'Draft' publication status
-        cy.get('.e2e-projecstatus-draft').click();
+        cy.get('.e2e-projecstatus-published').click();
 
         // Type random project titles for these required fields
         cy.get('#project-title').type(projectTitleEN);
@@ -63,8 +101,11 @@ describe('Admin: add project', () => {
 
         cy.wait(2000);
 
-        // Project should appear on top of the Published projects
-        cy.get('#e2e-admin-projects-list-unsortable').contains(projectTitleEN);
+        // Project should appear on top of the projects list
+        cy.get('#e2e-admin-projects-list-unsortable')
+          .children()
+          .first()
+          .contains(projectTitleEN);
       });
 
       it('creates an archived project', () => {
@@ -89,8 +130,15 @@ describe('Admin: add project', () => {
         cy.get('.e2e-submit-wrapper-button').click();
         cy.wait(2000);
 
-        // Project should appear on top of the Published projects
-        cy.get('#e2e-admin-projects-list-unsortable').contains(projectTitleEN);
+        // Project should appear on top of the projects list
+        cy.get('#e2e-admin-projects-list-unsortable')
+          .children()
+          .first()
+          .contains(projectTitleEN);
+        cy.get('#e2e-admin-projects-list-unsortable')
+          .children()
+          .first()
+          .contains('Archived');
       });
     });
 


### PR DESCRIPTION
## Checklist

- [ ] Added entry to changelog
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

- [ ] WCAG 2.1 AA proof
<details>
<summary>More info</summary>
For front-end devs only. Is your work conforming with the WCAG 2.1 AA rules? If you need more info, read the [a11y page](https://www.notion.so/citizenlab/a11y-7568f83d42ab4895ac133b89d358997b) on our Notion.
</details>

- [ ] Tests
<details>
<summary>More info</summary>

### Unit tests

Did you add relevant unit tests?

### E2E tests

Sometimes it can be more efficient to update E2E tests after CI has run them. If you know which ones to update, go ahead! E2E template cl2-back:

```bash
docker compose run --rm web bin/rails cl2_back:create_tenant[localhost,e2etests_template]
```

</details>

- [ ] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## How urgent is a code review?

Small change so today?