### PR TITLE
[No ticket] Revert sorting CL2_SUPPORTED_LOCALES alphabetically

### DIFF
--- a/back/config/initializers/1_locales.rb
+++ b/back/config/initializers/1_locales.rb
@@ -2,12 +2,15 @@
 
 require 'i18n/backend/fallbacks'
 
+# Unfortunately we implicitly require the first supported locale to be `:en` in some places in the code,
+# which is why this list is not in alphabetical order.
+# CL-1069 is supposed to fix it.
 CL2_SUPPORTED_LOCALES = %i[
+  en
   ar-MA
   ar-SA
   da-DK
   de-DE
-  en
   en-CA
   en-GB
   es-CL


### PR DESCRIPTION
In some places of the code we have implicit dependencies of the order of locales in `CL2_SUPPORTED_LOCALES`.

One of them makes the current e2e tests fail, which is why I'm reverting my change that sorts the locales in alphabetical order. In order to fix this properly, we should think about introducing a primary locale for tenants and get rid of the implicit dependency that currently exists for the `CL2_SUPPORTED_LOCALES` array. We can track our effort in https://citizenlab.atlassian.net/browse/CL-1069.

I think it's okay to have English to be the first item and have the rest still ordered alphabetically.

Places where we depend on the order of locales are for example:
- When creating slugs, we usually just the first value in the title_multiloc translations hash (`Project#generate_slug`)
- When selecting the nearest locale fur users, we fallback to the first platform locale in alphabetical order(`AppConfiguration#closest_locale_to`)

