### PR TITLE
Fix CVE-2022-32209

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -168,6 +168,12 @@ gem 'rack-attack', '~> 6'
 gem 'intercom', '~> 4.1'
 gem 'mjml-rails', '~> 4.4'
 
+# Included here because of CVE-2022-32209.
+# See https://groups.google.com/g/rubyonrails-security/c/ce9PhUANQ6s
+# The gem is a dependency of Rails, but we use Rails 6.1.6 and no Rails upgrade is available yet.
+# Specifying this gem explicitly can probably be removed when the Rails upgrade is available.
+gem 'rails-html-sanitizer', '>= 1.4.3'
+
 require 'json'
 if File.exist? '../citizenlab.config.ee.json'
   gem 'ros-apartment', require: 'apartment'

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -888,7 +888,7 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.4.2)
+    rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
     rails-i18n (6.0.0)
       i18n (>= 0.7, < 2)
@@ -1224,6 +1224,7 @@ DEPENDENCIES
   rack-cors
   rack-mini-profiler
   rails (~> 6.1)
+  rails-html-sanitizer (>= 1.4.3)
   rails-i18n (~> 6.0.0)
   rails_semantic_logger
   redcarpet


### PR DESCRIPTION
Upgrade of rails-html-sanitizer to fix CVE-2022-32209. See https://groups.google.com/g/rubyonrails-security/c/ce9PhUANQ6s

I ran bundle-audit to check that it does not report the vulnerability anymore.