### PR TITLE
CL-253 Remove "category" filter from GET .../insights/views/inputs

### DIFF
--- a/back/engines/commercial/insights/app/controllers/insights/web_api/v1/inputs_controller.rb
+++ b/back/engines/commercial/insights/app/controllers/insights/web_api/v1/inputs_controller.rb
@@ -30,7 +30,6 @@ module Insights
 
       def index_params
         @index_params ||= params.permit(
-          :category,
           :search,
           :sort,
           :processed,
@@ -42,7 +41,6 @@ module Insights
 
       def index_xlsx_params
         @index_xlsx_params ||= params.permit(
-          :category,
           :search,
           :processed,
           categories: [],

--- a/back/engines/commercial/insights/app/finders/insights/inputs_finder.rb
+++ b/back/engines/commercial/insights/app/finders/insights/inputs_finder.rb
@@ -126,9 +126,8 @@ module Insights
     private
 
     def category_ids
-      @category_ids ||= params[:categories].to_a.tap do |ids|
-        ids << params[:category] if params.key?(:category)
-      end.map(&:presence).uniq
+      # Empty strings are converted to nil and allow to select inputs without categories.
+      @category_ids ||= params.fetch(:categories, []).map(&:presence).uniq
     end
   end
 end

--- a/back/engines/commercial/insights/spec/acceptance/inputs_spec.rb
+++ b/back/engines/commercial/insights/spec/acceptance/inputs_spec.rb
@@ -30,7 +30,6 @@ resource 'Inputs' do
 
     with_options required: false do
       parameter :search, 'Filter by searching in title and body'
-      parameter :category, 'Filter by category'
       parameter :categories, 'Filter inputs by categories (union)'
       parameter :keywords, 'Filter by keywords (identifiers of keyword nodes)'
       parameter :processed, 'Filter by processed status'
@@ -112,7 +111,6 @@ resource 'Inputs' do
   get 'web_api/v1/insights/views/:view_id/inputs/as_xlsx' do
     with_options required: false do
       parameter :search, 'Filter by searching in title and body'
-      parameter :category, 'Filter by category'
       parameter :categories, 'Filter inputs by categories (union)'
       parameter :keywords, 'Filter by keywords (identifiers of keyword nodes)'
       parameter :processed, 'Filter by processed status'

--- a/front/app/modules/commercial/insights/admin/containers/Insights/Edit/InputsTable/Export.test.tsx
+++ b/front/app/modules/commercial/insights/admin/containers/Insights/Edit/InputsTable/Export.test.tsx
@@ -48,7 +48,7 @@ describe('Insights Export', () => {
     fireEvent.click(screen.getByRole('button'));
 
     expect(requestBlob).toHaveBeenCalledWith(apiPath, application, {
-      category: 'category',
+      categories: ['category'],
       processed: true,
     });
   });
@@ -59,7 +59,7 @@ describe('Insights Export', () => {
     fireEvent.click(screen.getByRole('button'));
 
     expect(requestBlob).toHaveBeenCalledWith(apiPath, application, {
-      category: 'category',
+      categories: ['category'],
       processed: false,
     });
   });
@@ -69,7 +69,7 @@ describe('Insights Export', () => {
     fireEvent.click(screen.getByRole('button'));
 
     expect(requestBlob).toHaveBeenCalledWith(apiPath, application, {
-      category: 'category',
+      categories: ['category'],
     });
   });
 });

--- a/front/app/modules/commercial/insights/admin/containers/Insights/Edit/InputsTable/Export.tsx
+++ b/front/app/modules/commercial/insights/admin/containers/Insights/Edit/InputsTable/Export.tsx
@@ -41,7 +41,8 @@ const Export = ({
         `${API_PATH}/${getInsightsInputsEndpoint(viewId)}/as_xlsx`,
         'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
         {
-          category: query.category,
+          categories:
+            typeof query.category === 'string' ? [query.category] : undefined,
           processed:
             query.processed === 'true'
               ? true

--- a/front/app/modules/commercial/insights/hooks/useInsightsInputsLoadMore.test.ts
+++ b/front/app/modules/commercial/insights/hooks/useInsightsInputsLoadMore.test.ts
@@ -26,18 +26,16 @@ const mockInputs: IInsightsInputs = {
 };
 
 const queryParameters: QueryParameters = {
-  category: '3',
   search: 'search',
-  categories: [],
+  categories: ['3'],
   keywords: [],
 };
 
 const expectedQueryParameters = {
-  category: queryParameters.category,
   'page[number]': 1,
   'page[size]': 20,
   search: queryParameters.search,
-  categories: [],
+  categories: queryParameters.categories,
   keywords: [],
 };
 
@@ -60,7 +58,7 @@ describe('useInsightsInputsLoadMore', () => {
     renderHook(() => useInsightsInputsLoadMore(viewId));
     expect(insightsInputsStream).toHaveBeenCalledWith(viewId, {
       queryParameters: {
-        category: undefined,
+        categories: undefined,
         'page[number]': 1,
         'page[size]': 20,
         search: undefined,
@@ -86,21 +84,21 @@ describe('useInsightsInputsLoadMore', () => {
   });
 
   it('should call useInsightsInputsLoadMore with correct arguments on category change', async () => {
-    let category = '5';
+    let categories = ['5'];
     const { rerender } = renderHook(() =>
-      useInsightsInputsLoadMore(viewId, { ...queryParameters, category })
+      useInsightsInputsLoadMore(viewId, { ...queryParameters, categories })
     );
 
     expect(insightsInputsStream).toHaveBeenCalledWith(viewId, {
-      queryParameters: { ...expectedQueryParameters, category },
+      queryParameters: { ...expectedQueryParameters, categories },
     });
 
     // Category change
-    category = '6';
+    categories = ['6'];
     rerender();
 
     expect(insightsInputsStream).toHaveBeenCalledWith(viewId, {
-      queryParameters: { ...expectedQueryParameters, category },
+      queryParameters: { ...expectedQueryParameters, categories },
     });
     expect(insightsInputsStream).toHaveBeenCalledTimes(2);
   });

--- a/front/app/modules/commercial/insights/hooks/useInsightsInputsLoadMore.ts
+++ b/front/app/modules/commercial/insights/hooks/useInsightsInputsLoadMore.ts
@@ -11,7 +11,6 @@ import tracks from 'modules/commercial/insights/admin/containers/Insights/tracks
 const defaultPageSize = 20;
 
 export type QueryParameters = {
-  category: string;
   search: string;
   categories: string[];
   keywords: string[];
@@ -28,7 +27,6 @@ const useInsightsInputsLoadMore = (
   const [loading, setLoading] = useState<boolean>(true);
   const [pageNumber, setPageNumber] = useState(1);
 
-  const category = queryParameters?.category;
   const search = queryParameters?.search;
 
   // Stringifying the keywords and categories array to avoid non-primary values in the useEffect dependencies
@@ -40,13 +38,12 @@ const useInsightsInputsLoadMore = (
   // Reset page number on search and category change
   useEffect(() => {
     setPageNumber(1);
-  }, [category, search, categories, keywords]);
+  }, [search, categories, keywords]);
 
   useEffect(() => {
     setLoading(true);
     const subscription = insightsInputsStream(viewId, {
       queryParameters: {
-        category,
         search,
         ...JSON.parse(categories),
         ...JSON.parse(keywords),
@@ -75,7 +72,7 @@ const useInsightsInputsLoadMore = (
     });
 
     return () => subscription.unsubscribe();
-  }, [viewId, pageNumber, category, search, categories, keywords]);
+  }, [viewId, pageNumber, search, categories, keywords]);
 
   const onLoadMore = () => {
     setPageNumber(pageNumber + 1);


### PR DESCRIPTION
The `category` query parameter has been deprecated for some time and has been replaced by `categories`. Normally, it should not be used by the front-end anymore, but one last check is still probably worth it.