### PR TITLE
CL-898 Use HeaderBgUploader in HomePage model and reinstate related test

### DIFF
--- a/back/app/models/home_page.rb
+++ b/back/app/models/home_page.rb
@@ -86,7 +86,7 @@ class HomePage < ApplicationRecord
     validates :banner_cta_signed_out_url, presence: true, url: true
   end
 
-  mount_base64_uploader :header_bg, AppHeaderBgUploader
+  mount_base64_uploader :header_bg, HeaderBgUploader
 
   private
 

--- a/back/spec/models/home_page_spec.rb
+++ b/back/spec/models/home_page_spec.rb
@@ -39,19 +39,10 @@ RSpec.describe HomePage, type: :model do
     end
   end
 
-  # This currently fails as we have switched HomePage back to using AppBgHeaderUploader
-  # in an attempt to use the images files in their existing locations (to make use of originals).
-  # This caused an ee release to be blocked by CI failure, probably because we had not dealt with
-  # related code in back/engines/ee/multi_tenancy/app/serializers/web_api/v1/external/tenant_serializer.rb
-  # Thus, we reverted related changes in ee: https://github.com/CitizenLabDotCo/citizenlab-ee/pull/288
-  # Since we have not resolved this issue yet, and continue to use AppBgHeaderUploader,
-  # this test currently fails with: undefined method 'tenant' for #<HomePage:0x000055a142aea180>
-  #
-  # Currently skipped with `xit`
   describe 'image uploads' do
     subject(:home_page) { build(:home_page) }
 
-    xit 'stores a header background image' do
+    it 'stores a header background image' do
       home_page.header_bg = File.open(Rails.root.join('spec/fixtures/header.jpg'))
       home_page.save!
       expect(home_page.header_bg.url).to be_present


### PR DESCRIPTION
TL;DR - 2 lines changed to complete reversion to working `header_bg` field in `HomePage` model & related test, after failed to attempt use different (original) uploader mechanism.

# Description

Trying (and failing) to cut a long story short, I will attempt to describe what we tried in the interests of recording the little I understand at this point…

  Alex & I decided to try using AppHeaderBgUploader, because;
1. It would allow us to use existing header images in place, without needing to copy them to new s3 folders and reference / update them there
2. This would also retain access to the original uploaded file(s), which would, for example improve quality if we subsequently decided to increase the image versions sizes
3. This would avoid needing to clean up existing files (or leave unused files in place, ‘just in case’ we needed them again)

We tried using the `AppConfig.id` instead of `Tenant.id` in `AppHeaderBgUploader`, and merged these 2 PRs: https://github.com/CitizenLabDotCo/citizenlab-ee/pull/286/files
https://github.com/CitizenLabDotCo/citizenlab/pull/2249

This seemed to work fine in terms of a. we could upload (update) a header image via the platform’s Admin UI, and b. we could use the (slightly changed) data migration script to create a reference in the `HomePage.header_bg` field to the respective image files in the original folder(s) on s3.

I realised subsequently, however, that these changes broke the AdminHQ platform settings edit view - https://admin.hq.citizenlab.co/clusters/staging/tenants/-tenant-id-/edit

This seems related to the `back/engines/commercial/admin_api/app/serializers/admin_api/tenant_serializer.rb` file, which is involved in serializing tenants for AdminHQ and seems to make use of legacy Tenant related settings. I have not managed to find a solution to this yet.  

We, therefore, reverted the `ee` repo changes that were causing this issue (since breaking AdminHQ == bad)

This, left us with the changes in the `citizenlab` repo, which resulted in the `HomePage` model having a broken `header_bg` mechanism.

This PR reverts those `citizenlab` changes, returning to using `HeadeBgUploader`, which will create versions of image files in a new `home_page` folder on s3, but works (allows for updating a header image via `HomePage model`, for example). This may help smooth development work until we find a solution to the problems with the preferred approach.

This also has the benefit of being able to reinstate the related test (which was failing since we removed the `ee` related parts of the attempt to use `AppHeaderBgUploader`, but kept the `citizenlab` parts)