### PR TITLE
[CL-669] Send Bunny errors to Sentry

### DIFF
--- a/back/engines/commercial/insights/config/initializers/bunny.rb
+++ b/back/engines/commercial/insights/config/initializers/bunny.rb
@@ -27,4 +27,6 @@ queue.subscribe do |_delivery_info, _properties, payload|
 
   zsc_result = NLP::ZeroshotClassificationResult.from_json(payload)
   Insights::CategorySuggestionsService.save_suggestion(zsc_result)
+rescue StandardError => e
+  ErrorReporter.report e
 end

--- a/back/engines/commercial/nlp/config/initializers/bunny.rb
+++ b/back/engines/commercial/nlp/config/initializers/bunny.rb
@@ -32,4 +32,6 @@ queue.subscribe do |_delivery_info, _properties, payload|
 
   tna_result = NLP::TextNetworkAnalysisResult.from_json(payload)
   NLP::TextNetworkAnalysisService.handle_result(tna_result)
+rescue StandardError => e
+  ErrorReporter.report e
 end


### PR DESCRIPTION
### Unit tests

No tests were added, because the changed initializers cannot be tested. Messages are added to a queue in a different thread and we cannot control that. However, we tested manually to verify that an error is logged in Sentry. See https://sentry.hq.citizenlab.co/share/issue/fee84cc75aea4d889627d0fbbfc9420e/ and https://sentry.hq.citizenlab.co/share/issue/d029c4889fa5435297ed369170a440a7/
