### PR TITLE
CL-1075 Report data inconsistencies instead of failing hard

### DIFF
--- a/back/engines/commercial/user_custom_fields/app/services/user_custom_fields/field_value_counter.rb
+++ b/back/engines/commercial/user_custom_fields/app/services/user_custom_fields/field_value_counter.rb
@@ -75,7 +75,11 @@ module UserCustomFields
     # It only adds missing options when they are explicitly defined (as
     # +CustomFieldOption+ records). This is not the case for number and checkbox
     # custom fields whose options are implicitly defined.
-    private_class_method def self.add_missing_options(counts, custom_field)
+    #
+    # @raise [ArgumentError] if the custom field values are not consistent with the
+    #   custom field options. That is if the custom field values reference options that
+    #   do not exist.
+    private_class_method def self.add_missing_options!(counts, custom_field)
       return counts if custom_field.options.empty?
 
       option_keys = custom_field.options.pluck(:key)
@@ -86,6 +90,16 @@ module UserCustomFields
       MSG
 
       option_keys.index_with { 0 }.merge(counts)
+    end
+
+    # Same as +add_missing_options!+ but does not raise an error when it detects data
+    # inconsistencies. Instead, it returns the counts unchanged and reports the error
+    # without failing.
+    private_class_method def self.add_missing_options(counts, custom_field)
+      add_missing_options!(counts, custom_field)
+    rescue ArgumentError => e
+      ErrorReporter.report(e)
+      counts
     end
   end
 end

--- a/back/engines/commercial/user_custom_fields/spec/services/user_custom_fields/field_value_counter_spec.rb
+++ b/back/engines/commercial/user_custom_fields/spec/services/user_custom_fields/field_value_counter_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UserCustomFields::FieldValueCounter do
+  describe '.counts_by_field_option' do
+    context 'when custom field values are inconsistent with custom field options' do
+      let(:gender_custom_field) { create(:custom_field_gender, :with_options) }
+
+      before do
+        # Create user with invalid value for gender custom field.
+        user = build(:user, gender: 'unicorn')
+        user.save!(validate: false)
+      end
+
+      it 'compute counts without raising an error', :aggregate_failures do
+        expect(ErrorReporter).to receive(:report).with(kind_of(ArgumentError))
+
+        counts = nil
+        expect { counts = described_class.counts_by_field_option(User.active, gender_custom_field) }
+          .not_to raise_error(ArgumentError)
+
+        expect(counts).to match('unicorn' => 1, described_class::UNKNOWN_VALUE_LABEL => 0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Taking a lighter approach to defensive programming after `UserCustomFields::FieldValueCounter.counts_by_field_option` spotted inconsistent data in production and caused the Users dashboard to fail to render on some platforms. The root cause of those inconsistent data has yet to be addressed independently.

The new implementation just logs the issue and reports it to Sentry.