### PR TITLE
CL-875 Change the display name of en to en-US in admin HQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Next
+
+### Changed
+
+- [CL-875] "en" locale is shown as "en-US" in admin HQ
+
 ## Next release
 
 ### Added

--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -60,7 +60,8 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": [<%= CL2_SUPPORTED_LOCALES.map{|l| "\"#{l}\""}.join(",") %>]
+              "enum": [<%= CL2_SUPPORTED_LOCALES.map{|l| "\"#{l}\""}.join(",") %>],
+              "enumNames": [<%= CL2_SUPPORTED_LOCALES.map{ |locale| locale.to_s == 'en' ? '"en-US"' : "\"#{locale}\"" }.join(",") %>]
             },
             "uniqueItems": true,
             "minItems": 1,

--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -60,8 +60,8 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": [<%= CL2_SUPPORTED_LOCALES.map{|l| "\"#{l}\""}.join(",") %>],
-              "enumNames": [<%= CL2_SUPPORTED_LOCALES.map{ |locale| locale.to_s == 'en' ? '"en-US"' : "\"#{locale}\"" }.join(",") %>]
+              "enum": [<%= CL2_SUPPORTED_LOCALES.map { |locale| "\"#{locale}\"" }.join(",") %>],
+              "enumNames": [<%= CL2_SUPPORTED_LOCALES.map { |locale| locale.to_s == 'en' ? '"en-US"' : "\"#{locale}\"" }.join(",") %>]
             },
             "uniqueItems": true,
             "minItems": 1,


### PR DESCRIPTION
Note that the locales for the multiloc text fields are still shown as "en". I didn't consider this part of the scope of the ticket, and it's not clear how much additional effort is needed to also realize this change.

## Checklist

- [ ] Tests
There are no tests today for the tenant settings schema. I therefore didn't add any specs, but tested manually that everything works fine for different combinations of picking locales.

## Links

- [Admin HQ PR](https://github.com/CitizenLabDotCo/cl2-admin/pull/78)

## How urgent is a code review?

Not too urgent, if we're not foreseeing any important platform launches where this confusion could happen.

![Screenshot 2022-07-05 at 17 56 53](https://user-images.githubusercontent.com/31925816/177370184-3ebe9ef7-67ac-43bb-8d9f-32fb49cc6889.png)
![Screenshot 2022-07-05 at 17 57 27](https://user-images.githubusercontent.com/31925816/177370190-1cdca45c-b8fb-4aa6-95a1-108be82d11bc.png)

