### PR TITLE
CL-1094 Content builder UX tweaks

### DIFF
--- a/back/app/services/url_validation_service.rb
+++ b/back/app/services/url_validation_service.rb
@@ -23,7 +23,8 @@ class UrlValidationService
     %r{\A(https?)://docs\.google\.com/(document|spreadsheets|forms|presentation)/d/(.*?)/.*?},
     %r{\A(https?)://(www\.)?google\.com/maps(/[a-z])?/embed\?([^&]*)=([-A-Z0-9+&@#/%=~_|!:,.;]+)}i,
     %r{\A(https?)://([-A-Z0-9.]+)\.slideshare(\.(net|com))/slideshow/embed_code/key/([-A-Z0-9+&@#/%=~_|!:,.;]+)}i,
-    %r{\A(https?)://(www\.)?onedrive\.live\.([-A-Z0-9+&@#/%=~_|!:,.;?]+)}i
+    %r{\A(https?)://(www\.)?onedrive\.live\.([-A-Z0-9+&@#/%=~_|!:,.;?]+)}i,
+    %r{\A(https?)://.*pdf$}
   ].freeze
 
   VIDEO_WHITELIST = [

--- a/back/spec/services/url_validation_service_spec.rb
+++ b/back/spec/services/url_validation_service_spec.rb
@@ -44,8 +44,8 @@ describe UrlValidationService do
       'https://arcg.is/1jiOj',
       'https://onedrive.live.com/embed?cid=ECDDF98AA79FDEDB&resid=ECDDF98AA79FDEDB%21145&authkey=AIRY6_880wuOdDc&em=2',
       'http://www.slideshare.net/slideshow/embed_code/key/AYBogCfDlXkgMi',
-      'https://online1.snapsurveys.com/interview/deff624d-0604-45bb-a072-0c6da45b22e6'
-      'https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf',
+      'https://online1.snapsurveys.com/interview/deff624d-0604-45bb-a072-0c6da45b22e6',
+      'https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf'
     ]
 
     invalid_urls = [

--- a/back/spec/services/url_validation_service_spec.rb
+++ b/back/spec/services/url_validation_service_spec.rb
@@ -45,6 +45,7 @@ describe UrlValidationService do
       'https://onedrive.live.com/embed?cid=ECDDF98AA79FDEDB&resid=ECDDF98AA79FDEDB%21145&authkey=AIRY6_880wuOdDc&em=2',
       'http://www.slideshare.net/slideshow/embed_code/key/AYBogCfDlXkgMi',
       'https://online1.snapsurveys.com/interview/deff624d-0604-45bb-a072-0c6da45b22e6'
+      'https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf',
     ]
 
     invalid_urls = [
@@ -67,7 +68,8 @@ describe UrlValidationService do
       'https://platform.twitter.com',
       'https://facebook.com',
       'https://konveio.com/something',
-      'https://subdomain.arcgis.com'
+      'https://subdomain.arcgis.com',
+      'https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pd'
     ]
 
     valid_urls.each do |url|

--- a/front/app/modules/commercial/content_builder/admin/components/ContentBuilderEditModePreview/index.tsx
+++ b/front/app/modules/commercial/content_builder/admin/components/ContentBuilderEditModePreview/index.tsx
@@ -77,7 +77,7 @@ const ContentBuilderEditModePreview = React.forwardRef<
           zIndex="1"
           mb="12px"
           width={isMobile ? '360px' : '1140px'}
-          borderRadius="33px"
+          borderRadius="20px"
         >
           {/* Iframe */}
           <Box

--- a/front/app/modules/commercial/content_builder/admin/components/ContentBuilderEditModePreview/index.tsx
+++ b/front/app/modules/commercial/content_builder/admin/components/ContentBuilderEditModePreview/index.tsx
@@ -29,7 +29,6 @@ const ContentBuilderEditModePreview = React.forwardRef<
     height: '40px',
     width: '92px',
   };
-
   return (
     <Box
       mt={`${stylingConsts.menuHeight + 20}px`}
@@ -37,17 +36,15 @@ const ContentBuilderEditModePreview = React.forwardRef<
       justifyContent="center"
     >
       <Box display="flex" flexDirection="column" alignItems="center">
-        <Box
-          display="flex"
-          mb="16px"
-          border={`1px solid ${colors.adminTextColor}`}
-          borderRadius="4px"
-        >
+        <Box display="flex" mb="16px">
           <Button
             bgColor={colorIfMobileView}
             onClick={() => {
               !isMobile && setIsMobile(true);
             }}
+            borderRadius="4px 0px 0px 4px"
+            bgHoverColor={colorIfMobileView}
+            borderColor={`${colors.adminTextColor}`}
             id="e2e-mobile-preview"
             {...buttonProps}
           >
@@ -64,6 +61,9 @@ const ContentBuilderEditModePreview = React.forwardRef<
               isMobile && setIsMobile(false);
             }}
             id="e2e-desktop-preview"
+            borderRadius="0px 4px 4px 0px"
+            bgHoverColor={colorIfDesktopView}
+            borderColor={`${colors.adminTextColor}`}
             {...buttonProps}
           >
             <Icon name="desktop" width="20px" fill={colorIfMobileView} />

--- a/front/app/modules/commercial/content_builder/admin/components/ContentBuilderToolbox/ToolboxItem.tsx
+++ b/front/app/modules/commercial/content_builder/admin/components/ContentBuilderToolbox/ToolboxItem.tsx
@@ -32,7 +32,9 @@ const ToolboxItem = ({ icon, label }: Props) => {
         fill={colors.adminTextColor}
         name={icon}
       />
-      <Text color="text">{label}</Text>
+      <Text color="text" style={{ lineHeight: '1' }}>
+        {label}
+      </Text>
     </StyledBox>
   );
 };

--- a/front/app/modules/commercial/content_builder/admin/components/ContentBuilderToolbox/index.tsx
+++ b/front/app/modules/commercial/content_builder/admin/components/ContentBuilderToolbox/index.tsx
@@ -70,7 +70,7 @@ const ContentBuilderToolbox = ({
       <Box w="100%" display="inline">
         <Title
           fontWeight="normal"
-          mb="0px"
+          mb="4px"
           mt="24px"
           ml="10px"
           variant="h6"
@@ -117,7 +117,7 @@ const ContentBuilderToolbox = ({
         </DraggableElement>
         <Title
           fontWeight="normal"
-          mb="0px"
+          mb="4px"
           mt="24px"
           ml="10px"
           variant="h6"
@@ -180,7 +180,7 @@ const ContentBuilderToolbox = ({
         </DraggableElement>
         <Title
           fontWeight="normal"
-          mb="0px"
+          mb="4px"
           mt="24px"
           ml="10px"
           variant="h6"

--- a/front/app/modules/commercial/content_builder/admin/components/ContentBuilderToolbox/index.tsx
+++ b/front/app/modules/commercial/content_builder/admin/components/ContentBuilderToolbox/index.tsx
@@ -75,7 +75,7 @@ const ContentBuilderToolbox = ({
           ml="10px"
           variant="h6"
           as="h3"
-          color="label"
+          color="secondaryText"
         >
           <FormattedMessage {...messages.sections} />
         </Title>
@@ -122,7 +122,7 @@ const ContentBuilderToolbox = ({
           ml="10px"
           variant="h6"
           as="h3"
-          color="label"
+          color="secondaryText"
         >
           <FormattedMessage {...messages.layout} />
         </Title>
@@ -185,7 +185,7 @@ const ContentBuilderToolbox = ({
           ml="10px"
           variant="h6"
           as="h3"
-          color="label"
+          color="secondaryText"
         >
           <FormattedMessage {...messages.content} />
         </Title>

--- a/front/app/modules/commercial/content_builder/admin/components/CraftComponents/Button/index.tsx
+++ b/front/app/modules/commercial/content_builder/admin/components/CraftComponents/Button/index.tsx
@@ -31,6 +31,17 @@ const Button = ({ text, url, type, alignment }: ButtonProps) => {
       enabled: state.options.enabled,
     };
   });
+
+  // Links that are relative or of same hostname should open in same window
+  let openInNewTab;
+  if (url.includes(window.location.hostname)) {
+    openInNewTab = false;
+  } else if (!url.includes('.')) {
+    openInNewTab = false;
+  } else {
+    openInNewTab = true;
+  }
+
   return (
     <Box
       display="flex"
@@ -48,13 +59,7 @@ const Button = ({ text, url, type, alignment }: ButtonProps) => {
       {((enabled && text) || (text && url)) && (
         <ButtonComponent
           linkTo={url}
-          openLinkInNewTab={
-            url.includes(window.location.hostname)
-              ? false
-              : url.includes('.')
-              ? true
-              : false
-          }
+          openLinkInNewTab={openInNewTab}
           id="e2e-button"
           width={alignment === 'fullWidth' ? '100%' : 'auto'}
           buttonStyle={type}

--- a/front/app/modules/commercial/content_builder/admin/components/CraftComponents/Button/index.tsx
+++ b/front/app/modules/commercial/content_builder/admin/components/CraftComponents/Button/index.tsx
@@ -48,7 +48,13 @@ const Button = ({ text, url, type, alignment }: ButtonProps) => {
       {((enabled && text) || (text && url)) && (
         <ButtonComponent
           linkTo={url}
-          openLinkInNewTab={!url.includes(window.location.hostname)}
+          openLinkInNewTab={
+            url.includes(window.location.hostname)
+              ? false
+              : url.includes('.')
+              ? true
+              : false
+          }
           id="e2e-button"
           width={alignment === 'fullWidth' ? '100%' : 'auto'}
           buttonStyle={type}

--- a/front/app/modules/commercial/content_builder/admin/components/CraftComponents/Iframe/utils.test.ts
+++ b/front/app/modules/commercial/content_builder/admin/components/CraftComponents/Iframe/utils.test.ts
@@ -123,6 +123,12 @@ const validPlatformLinks = [
     platform: 'Survey Monkey',
     urls: ['https://www.surveymonkey.co.uk/r/ZF632GH'],
   },
+  {
+    platform: 'PDF Files',
+    urls: [
+      'https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf',
+    ],
+  },
 ];
 
 describe('isValidUrl', () => {

--- a/front/app/modules/commercial/content_builder/admin/components/CraftComponents/Iframe/utils.ts
+++ b/front/app/modules/commercial/content_builder/admin/components/CraftComponents/Iframe/utils.ts
@@ -27,6 +27,7 @@ const urlWhiteList = [
   /^(https?):\/\/(www\.)?google\.com\/maps(\/[a-z])?\/embed\?([^&]*)=([-A-Z0-9+&@#/%=~_|!:,.;]+)/i,
   /^(https?):\/\/([-A-Z0-9.]+)\.slideshare(\.(net|com))\/slideshow\/embed_code\/key\/([-A-Z0-9+&@#/%=~_|!:,.;]+)/i,
   /^(https?):\/\/(www\.)?onedrive\.live\.([-A-Z0-9+&@#/%=~_|!:,.;?]+)/i,
+  /^(https?):\/\/.*pdf$/,
 ];
 
 /*

--- a/front/app/modules/commercial/content_builder/admin/components/CraftSections/ImageTextCards/index.tsx
+++ b/front/app/modules/commercial/content_builder/admin/components/CraftSections/ImageTextCards/index.tsx
@@ -14,6 +14,7 @@ import Text from '../../CraftComponents/Text';
 import messages from '../../../messages';
 import { injectIntl } from 'utils/cl-intl';
 import { InjectedIntlProps } from 'react-intl';
+import WhiteSpace from '../../CraftComponents/WhiteSpace';
 
 const ImageTextCards: UserComponent = ({
   intl: { formatMessage },
@@ -28,6 +29,7 @@ const ImageTextCards: UserComponent = ({
           <Text text={formatMessage(messages.textValue)} />
         </Element>
       </TwoColumn>
+      <WhiteSpace size="small" />
       <TwoColumn columnLayout="1-2">
         <Element id="left" is={Container} canvas>
           <Image alt="" />
@@ -36,6 +38,7 @@ const ImageTextCards: UserComponent = ({
           <Text text={formatMessage(messages.textValue)} />
         </Element>
       </TwoColumn>
+      <WhiteSpace size="small" />
       <TwoColumn columnLayout="1-2">
         <Element id="left" is={Container} canvas>
           <Image alt="" />

--- a/front/app/modules/commercial/content_builder/admin/components/Editor/index.tsx
+++ b/front/app/modules/commercial/content_builder/admin/components/Editor/index.tsx
@@ -48,6 +48,11 @@ const Editor: React.FC<EditorProps> = ({
         ImageTextCards,
         Button,
       }}
+      indicator={{
+        success: 'rgb(98, 196, 98)',
+        error: 'red',
+        transition: 'none',
+      }}
       onRender={isPreview ? undefined : RenderNode}
       enabled={isPreview ? false : true}
       onNodesChange={(data) =>

--- a/front/app/modules/commercial/content_builder/admin/messages.ts
+++ b/front/app/modules/commercial/content_builder/admin/messages.ts
@@ -185,21 +185,21 @@ export default defineMessages({
   },
   toggleLabel: {
     id: 'app.containers.AdminPage.ProjectDescription.toggleLabel',
-    defaultMessage: 'Use page builder for description',
+    defaultMessage: 'Use Content Builder for description',
   },
   toggleTooltip: {
     id: 'app.containers.AdminPage.ProjectDescription.toggleTooltip',
     defaultMessage:
-      'Using the page builder will let you use more advanced layout options.',
+      'Using the Content Builder will let you use more advanced layout options.',
   },
   linkText: {
     id: 'app.containers.AdminPage.ProjectDescription.linkText',
-    defaultMessage: 'Edit description in page builder',
+    defaultMessage: 'Edit description in Content Builder',
   },
   layoutBuilderWarning: {
     id: 'app.containers.AdminPage.ProjectDescription.layoutBuilderWarning',
     defaultMessage:
-      'Using the page builder will let you use more advanced layout options. For languages where no content is available in the page builder, the regular project description content will be displayed instead.',
+      'Using the Content Builder will let you use more advanced layout options. For languages where no content is available in the content builder, the regular project description content will be displayed instead.',
   },
   columnLayoutRadioLabel: {
     id: 'app.containers.AdminPage.ProjectDescription.columnLayoutRadioLabel',


### PR DESCRIPTION
## Changes Include
- Support pdf files in iframe **[Done]**
- If simple: remove “blob” transition when moving components around.  **[Done]**
- Button component: allow anything but update ‘open in new tab’ logic so that relative links open in same window/tab **[Done]**
- Sidenav component paragraph: make their height smaller by updating this property line-height: 1 **[Done]**
- Preview mobile-desktop button toggle needs some minor style tweaks: should match pattern seen on /admin/invitations pattern in back office (mainly a question of tweaking border radii I think) **[Done]**
- Update copy to "Content Builder" - done on CrowdIn **[Done]**
- Reduce border-radius for preview ‘box’ for mobile and desktop to 20px **[Done]**
- Sidenav h3 headings: use secondaryText color  **[Done]**
## Checklist
- [X] Tests (updated whitelist tests, but rest are small ux tweaks so just did a functional test myself)
- [X] Prepared branch for code review

## How urgent is a code review?

