### PR TITLE
CL-1095: Fix content buidler failing tests

### DIFF
--- a/front/cypress/e2e/content_builder/components/iframe_component.cy.ts
+++ b/front/cypress/e2e/content_builder/components/iframe_component.cy.ts
@@ -83,7 +83,7 @@ describe('Content builder Iframe component', () => {
       .clear()
       .type('https://www.citizenlab.co');
     cy.contains(
-      'You cannot embed content from this website for security reasons'
+      'Sorry, this content could not be embedded. Visit our support page to learn more.'
     ).should('be.visible');
     // Check that save is disabled
     cy.contains('Save').should('be.disabled');

--- a/front/cypress/e2e/content_builder/content_builder_navigation.cy.ts
+++ b/front/cypress/e2e/content_builder/content_builder_navigation.cy.ts
@@ -73,23 +73,28 @@ describe('Content builder navigation', () => {
     );
   });
 
-  it('navigates to live project in a new tab when view project button ion content builder is clicked', () => {
+  it('navigates to live project in a new tab when view project button in content builder is clicked', () => {
+    const projectUrl = `/en/projects/${projectSlug}`;
     cy.visit(`/admin/projects/${projectId}/description`);
+
+    cy.intercept('**/content_builder_layouts/project_description/upsert').as(
+      'saveContentBuilder'
+    );
+
     cy.get('#e2e-toggle-enable-content-builder')
       .find('input')
       .click({ force: true });
+
+    cy.wait('@saveContentBuilder');
     cy.get('#e2e-content-builder-link').click();
 
-    cy.window().then((win) => {
-      cy.stub(win, 'open').as('open');
-    });
-
-    cy.get('#e2e-view-project-button').click();
-
-    cy.get('@open').should(
-      'have.been.calledOnceWithExactly',
-      `/projects/${projectSlug}`,
-      '_blank'
-    );
+    cy.get('#e2e-view-project-button > a')
+      .should(($a) => {
+        expect($a.attr('href'), 'href').to.equal(projectUrl);
+        expect($a.attr('target'), 'target').to.equal('_blank');
+        $a.attr('target', '_self');
+      })
+      .click();
+    cy.location('pathname').should('equal', projectUrl);
   });
 });


### PR DESCRIPTION
This PR fixes content builder failing tests in master. The image tests are passing locally so I think those might have failied because of time-out issues.

## How urgent is a code review?

End of Thursday
