### PR TITLE
CL-1053 Inconsistent data: Volunteer cause taken

### DIFF
--- a/back/db/migrate/20220707102050_add_uniqueness_constraint_to_volunteers.volunteering.rb
+++ b/back/db/migrate/20220707102050_add_uniqueness_constraint_to_volunteers.volunteering.rb
@@ -18,6 +18,6 @@ class AddUniquenessConstraintToVolunteers < ActiveRecord::Migration[6.1]
       SQL
     )
     add_index :volunteering_volunteers, %i[cause_id user_id], unique: true
-    remove_index :volunteers, :cause_id
+    remove_index :volunteers, name: :index_volunteering_volunteers_on_cause_id
   end
 end

--- a/back/db/migrate/20220707102050_add_uniqueness_constraint_to_volunteers.volunteering.rb
+++ b/back/db/migrate/20220707102050_add_uniqueness_constraint_to_volunteers.volunteering.rb
@@ -18,5 +18,6 @@ class AddUniquenessConstraintToVolunteers < ActiveRecord::Migration[6.1]
       SQL
     )
     add_index :volunteering_volunteers, %i[cause_id user_id], unique: true
+    remove_index :volunteers, :cause_id
   end
 end

--- a/back/db/migrate/20220707102050_add_uniqueness_constraint_to_volunteers.volunteering.rb
+++ b/back/db/migrate/20220707102050_add_uniqueness_constraint_to_volunteers.volunteering.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # This migration comes from volunteering (originally 20220707091502)
 
 class AddUniquenessConstraintToVolunteers < ActiveRecord::Migration[6.1]
@@ -7,13 +8,13 @@ class AddUniquenessConstraintToVolunteers < ActiveRecord::Migration[6.1]
       # After https://stackoverflow.com/a/12963112/3585671
       <<-SQL.squish
       DELETE FROM volunteering_volunteers to_delete USING (
-        SELECT MIN(id) AS id, cause_id, user_id
+        SELECT MIN(id::text) AS id, cause_id, user_id
           FROM volunteering_volunteers 
           GROUP BY (cause_id, user_id) HAVING COUNT(*) > 1
         ) keep_from_duplicates
         WHERE to_delete.cause_id = keep_from_duplicates.cause_id
         AND to_delete.user_id = keep_from_duplicates.user_id
-        AND to_delete.id <> keep_from_duplicates.id
+        AND to_delete.id::text <> keep_from_duplicates.id
       SQL
     )
     add_index :volunteering_volunteers, %i[cause_id user_id], unique: true

--- a/back/db/migrate/20220707102050_add_uniqueness_constraint_to_volunteers.volunteering.rb
+++ b/back/db/migrate/20220707102050_add_uniqueness_constraint_to_volunteers.volunteering.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+# This migration comes from volunteering (originally 20220707091502)
+
+class AddUniquenessConstraintToVolunteers < ActiveRecord::Migration[6.1]
+  def change
+    ActiveRecord::Base.connection.execute(
+      # After https://stackoverflow.com/a/12963112/3585671
+      <<-SQL.squish
+      DELETE FROM volunteering_volunteers to_delete USING (
+        SELECT MIN(id) AS id, cause_id, user_id
+          FROM volunteering_volunteers 
+          GROUP BY (cause_id, user_id) HAVING COUNT(*) > 1
+        ) keep_from_duplicates
+        WHERE to_delete.cause_id = keep_from_duplicates.cause_id
+        AND to_delete.user_id = keep_from_duplicates.user_id
+        AND to_delete.id <> keep_from_duplicates.id
+      SQL
+    )
+    add_index :volunteering_volunteers, %i[cause_id user_id], unique: true
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -1194,7 +1194,6 @@ ActiveRecord::Schema.define(version: 2022_07_07_102050) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["cause_id", "user_id"], name: "index_volunteering_volunteers_on_cause_id_and_user_id", unique: true
-    t.index ["cause_id"], name: "index_volunteering_volunteers_on_cause_id"
     t.index ["user_id"], name: "index_volunteering_volunteers_on_user_id"
   end
 

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_30_084221) do
+ActiveRecord::Schema.define(version: 2022_07_07_102050) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -1193,6 +1193,7 @@ ActiveRecord::Schema.define(version: 2022_06_30_084221) do
     t.uuid "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["cause_id", "user_id"], name: "index_volunteering_volunteers_on_cause_id_and_user_id", unique: true
     t.index ["cause_id"], name: "index_volunteering_volunteers_on_cause_id"
     t.index ["user_id"], name: "index_volunteering_volunteers_on_user_id"
   end

--- a/back/engines/free/volunteering/app/models/volunteering/volunteer.rb
+++ b/back/engines/free/volunteering/app/models/volunteering/volunteer.rb
@@ -12,7 +12,6 @@
 #
 # Indexes
 #
-#  index_volunteering_volunteers_on_cause_id              (cause_id)
 #  index_volunteering_volunteers_on_cause_id_and_user_id  (cause_id,user_id) UNIQUE
 #  index_volunteering_volunteers_on_user_id               (user_id)
 #

--- a/back/engines/free/volunteering/app/models/volunteering/volunteer.rb
+++ b/back/engines/free/volunteering/app/models/volunteering/volunteer.rb
@@ -12,8 +12,9 @@
 #
 # Indexes
 #
-#  index_volunteering_volunteers_on_cause_id  (cause_id)
-#  index_volunteering_volunteers_on_user_id   (user_id)
+#  index_volunteering_volunteers_on_cause_id              (cause_id)
+#  index_volunteering_volunteers_on_cause_id_and_user_id  (cause_id,user_id) UNIQUE
+#  index_volunteering_volunteers_on_user_id               (user_id)
 #
 # Foreign Keys
 #

--- a/back/engines/free/volunteering/db/migrate/20220707091502_add_uniqueness_constraint_to_volunteers.rb
+++ b/back/engines/free/volunteering/db/migrate/20220707091502_add_uniqueness_constraint_to_volunteers.rb
@@ -6,13 +6,13 @@ class AddUniquenessConstraintToVolunteers < ActiveRecord::Migration[6.1]
       # After https://stackoverflow.com/a/12963112/3585671
       <<-SQL.squish
       DELETE FROM volunteering_volunteers to_delete USING (
-        SELECT MIN(id) AS id, cause_id, user_id
+        SELECT MIN(id::text) AS id, cause_id, user_id
           FROM volunteering_volunteers 
           GROUP BY (cause_id, user_id) HAVING COUNT(*) > 1
         ) keep_from_duplicates
         WHERE to_delete.cause_id = keep_from_duplicates.cause_id
         AND to_delete.user_id = keep_from_duplicates.user_id
-        AND to_delete.id <> keep_from_duplicates.id
+        AND to_delete.id::text <> keep_from_duplicates.id
       SQL
     )
     add_index :volunteering_volunteers, %i[cause_id user_id], unique: true

--- a/back/engines/free/volunteering/db/migrate/20220707091502_add_uniqueness_constraint_to_volunteers.rb
+++ b/back/engines/free/volunteering/db/migrate/20220707091502_add_uniqueness_constraint_to_volunteers.rb
@@ -16,5 +16,6 @@ class AddUniquenessConstraintToVolunteers < ActiveRecord::Migration[6.1]
       SQL
     )
     add_index :volunteering_volunteers, %i[cause_id user_id], unique: true
+    remove_index :volunteers, :cause_id
   end
 end

--- a/back/engines/free/volunteering/db/migrate/20220707091502_add_uniqueness_constraint_to_volunteers.rb
+++ b/back/engines/free/volunteering/db/migrate/20220707091502_add_uniqueness_constraint_to_volunteers.rb
@@ -16,6 +16,6 @@ class AddUniquenessConstraintToVolunteers < ActiveRecord::Migration[6.1]
       SQL
     )
     add_index :volunteering_volunteers, %i[cause_id user_id], unique: true
-    remove_index :volunteers, :cause_id
+    remove_index :volunteers, name: :index_volunteering_volunteers_on_cause_id
   end
 end

--- a/back/engines/free/volunteering/db/migrate/20220707091502_add_uniqueness_constraint_to_volunteers.rb
+++ b/back/engines/free/volunteering/db/migrate/20220707091502_add_uniqueness_constraint_to_volunteers.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class AddUniquenessConstraintToVolunteers < ActiveRecord::Migration[6.1]
+  def change
+    ActiveRecord::Base.connection.execute(
+      # After https://stackoverflow.com/a/12963112/3585671
+      <<-SQL.squish
+      DELETE FROM volunteering_volunteers to_delete USING (
+        SELECT MIN(id) AS id, cause_id, user_id
+          FROM volunteering_volunteers 
+          GROUP BY (cause_id, user_id) HAVING COUNT(*) > 1
+        ) keep_from_duplicates
+        WHERE to_delete.cause_id = keep_from_duplicates.cause_id
+        AND to_delete.user_id = keep_from_duplicates.user_id
+        AND to_delete.id <> keep_from_duplicates.id
+      SQL
+    )
+    add_index :volunteering_volunteers, %i[cause_id user_id], unique: true
+  end
+end


### PR DESCRIPTION
The issue is that it is somehow possible to have the same user volunteering twice for the same cause. This is not allowed. It is not clear how this situation can happen, and so the proposed solution is to enforce this requirement with a database constraint, since model-level validations can be bypassed.

Whenever duplicates are encountered, all except one (the one with the smallest UUID) volunteer is deleted.

Since it was possible to bypass the model-level validation, I would expect a Sentry issue will pop up at some point where a 500 error is raised by the database constraint. This is how we will be able to find out how this situation can happen, allowing us to also solve the underlying issue.

## Checklist

- [ ] Added entry to changelog
Not relevant for the changelog.

- [ ] WCAG 2.1 AA proof
N/A

- [ ] Tests
This is a migration and therefore not covered by specs. I've tested the code manually by migrating the Lokeren platform (where the issue occurred) locally, running the migration and verifying if only the duplicate volunteers are removed.

## How urgent is a code review?

It would be nice if we could get it released this week, to get the inconsistent data checks green Monday morning.
