### PR TITLE
Allow user_confirmation by default to avoid OS users confusion

### DIFF
--- a/back/db/seeds/citizenlab.rb
+++ b/back/db/seeds/citizenlab.rb
@@ -174,6 +174,10 @@ AppConfiguration.create!(
     events_widget: {
       enabled: true,
       allowed: true
+    },
+    user_confirmation: {
+      allowed: true,
+      enabled: false
     }
   })
 )


### PR DESCRIPTION
To avoid confusion like that https://github.com/CitizenLabDotCo/citizenlab/issues/2370

## Checklist

- [ ] Added entry to changelog
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

- [ ] WCAG 2.1 AA proof
<details>
<summary>More info</summary>
For front-end devs only. Is your work conforming with the WCAG 2.1 AA rules? If you need more info, read the [a11y page](https://www.notion.so/citizenlab/a11y-7568f83d42ab4895ac133b89d358997b) on our Notion.
</details>

- [ ] Tests
<details>
<summary>More info</summary>

### Unit tests

Did you add relevant unit tests?

### E2E tests

Sometimes it can be more efficient to update E2E tests after CI has run them. If you know which ones to update, go ahead! E2E template cl2-back:

```bash
docker compose run --rm web bin/rails cl2_back:create_tenant[localhost,e2etests_template]
```

</details>

- [x] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>
