### PR TITLE
[CL-1020] Specify Client signing algorithm for Clave Unica & BOSA FAS Auth

### DIFF
--- a/back/engines/commercial/id_bosa_fas/app/lib/id_bosa_fas/bosa_fas_omniauth.rb
+++ b/back/engines/commercial/id_bosa_fas/app/lib/id_bosa_fas/bosa_fas_omniauth.rb
@@ -23,6 +23,7 @@ module IdBosaFas
       options[:issuer] = "https://#{host}"
       options[:acr_values] = 'urn:be:fedict:iam:fas:Level450'
       options[:send_scope_to_token_endpoint] = false
+      options[:client_signing_alg] = :HS256
       options[:client_options] = {
         identifier: config[:identifier],
         secret: config[:secret],

--- a/back/engines/commercial/id_clave_unica/app/lib/id_clave_unica/clave_unica_omniauth.rb
+++ b/back/engines/commercial/id_clave_unica/app/lib/id_clave_unica/clave_unica_omniauth.rb
@@ -28,6 +28,7 @@ module IdClaveUnica
       options[:nonce] = true
       options[:issuer] = issuer
       options[:send_scope_to_token_endpoint] = false
+      options[:client_signing_alg] = :HS256
       options[:client_options] = {
         identifier: config[:client_id],
         secret: config[:client_secret],


### PR DESCRIPTION
A fellow coder gave us a hint that we need to specify the client signing algorithm in the issue I posted: https://github.com/omniauth/omniauth_openid_connect/issues/118#issuecomment-1178041723

Not specifying the algorithm makes the library fall back to discovery mode, even if discovery is disabled.

Neither BOSA FAS nor Clave Unica specify which algorithm is used in their documentation though, so this is a bit of a guessing game. Looking at the implementation (https://github.com/omniauth/omniauth_openid_connect/blob/2e4e487b29c60d45cc2212b30765da15161c4607/lib/omniauth/strategies/openid_connect.rb#L271), it seems likely we use one of these three `:HS256, :HS384, :HS512`, because the other available options (`:RS256, :RS384, :RS512`) require a jwk signing key or x509 signing key to be specified, which we do not have. Let's give it a try.

We need to test this on production, because we don't have a sandbox available for these auth envs.

PS: I'm a bit sceptical if HS256 is the correct algo to use. At least BOSA FAS here says it defaults to RS256, but I'm not sure where the public key can be found. https://dtservices.bosa.be/sites/default/files/content/download/files/fas_oidc_integration_guide_v0.62.pdf
Anyway, let's give this a try. If it doesn't work, we'll try the other algos. :shrug: 
