### PR TITLE
[CL-1135] Make FE CTA validations the same as on BE

### DIFF
--- a/front/app/containers/Admin/pages-menu/containers/HeroBannerForm/index.tsx
+++ b/front/app/containers/Admin/pages-menu/containers/HeroBannerForm/index.tsx
@@ -470,8 +470,7 @@ const HeroBannerForm = ({ intl: { formatMessage } }: InjectedIntlProps) => {
           id="app.containers.Admin.settings.customize.headerSectionEnd"
           homepageSettings={localHomepageSettings}
           handleOnChange={handleSettingOnChange}
-          // testing
-          errors={{ base: [{ error: 'some error' }] }}
+          errors={apiErrors}
         />
         <Error apiErrors={apiErrors} />
       </Section>

--- a/front/app/containers/Admin/pages-menu/containers/HeroBannerForm/index.tsx
+++ b/front/app/containers/Admin/pages-menu/containers/HeroBannerForm/index.tsx
@@ -2,7 +2,6 @@ import React, { useState, useMemo, useEffect } from 'react';
 import styled, { useTheme } from 'styled-components';
 
 // components
-import Error from 'components/UI/Error';
 import SectionFormWrapper from '../../components/SectionFormWrapper';
 import {
   Section,
@@ -40,7 +39,7 @@ import { injectIntl, FormattedMessage } from 'utils/cl-intl';
 import messages from './messages';
 
 // typings
-import { UploadFile, Multiloc, CLError } from 'typings';
+import { UploadFile, Multiloc, CLErrors } from 'typings';
 type MultilocErrorType = {
   signedOutHeaderErrors: Multiloc;
   signedOutSubheaderErrors: Multiloc;
@@ -79,7 +78,7 @@ const HeroBannerForm = ({ intl: { formatMessage } }: InjectedIntlProps) => {
   const [headerLocalDisplayImage, setHeaderLocalDisplayImage] = useState<
     UploadFile[] | null
   >(null);
-  const [apiErrors, setApiErrors] = useState<CLError[] | null>(null);
+  const [apiErrors, setApiErrors] = useState<CLErrors | null>({});
   const [headerAndSubheaderErrors, setHeaderAndSubheaderErrors] =
     useState<MultilocErrorType>({
       signedOutHeaderErrors: {},
@@ -138,8 +137,11 @@ const HeroBannerForm = ({ intl: { formatMessage } }: InjectedIntlProps) => {
         setApiErrors(null);
         setIsLoading(false);
       } catch (error) {
+        setIsLoading(false);
         if (isCLErrorJSON(error)) {
           setApiErrors(error.json.errors);
+        } else {
+          setApiErrors(error);
         }
         setIsLoading(false);
       }
@@ -472,7 +474,6 @@ const HeroBannerForm = ({ intl: { formatMessage } }: InjectedIntlProps) => {
           handleOnChange={handleSettingOnChange}
           errors={apiErrors}
         />
-        <Error apiErrors={apiErrors} />
       </Section>
     </SectionFormWrapper>
   );

--- a/front/app/modules/commercial/customizable_homepage_banner/admin/CTASettings/CTASignedInSettings.tsx
+++ b/front/app/modules/commercial/customizable_homepage_banner/admin/CTASettings/CTASignedInSettings.tsx
@@ -22,7 +22,7 @@ type Props = {
     settingKey: BannerSettingKeyType,
     settingValue: any
   ) => void;
-  errors: CLErrors | undefined;
+  errors: CLErrors | undefined | null;
 };
 
 const CTASignedInSettings = ({

--- a/front/app/modules/commercial/customizable_homepage_banner/admin/CTASettings/CTASignedOutSettings.tsx
+++ b/front/app/modules/commercial/customizable_homepage_banner/admin/CTASettings/CTASignedOutSettings.tsx
@@ -22,7 +22,7 @@ type Props = {
     settingKey: BannerSettingKeyType,
     settingValue: string
   ) => void;
-  errors: CLErrors | undefined;
+  errors: CLErrors | undefined | null;
 };
 
 const CTASignedOutSettings = ({

--- a/front/app/modules/commercial/customizable_homepage_banner/admin/CTASettings/CustomizedButtonSettings.tsx
+++ b/front/app/modules/commercial/customizable_homepage_banner/admin/CTASettings/CustomizedButtonSettings.tsx
@@ -52,11 +52,11 @@ const getTextErrors = (
   }
 
   if (!isNilOrError(tenantLocales)) {
-    tenantLocales.forEach((locale) => {
-      if (isEmpty(textMultiloc?.[locale])) {
-        textErrors[locale] = formatMessage(genericMessages.blank);
-      }
-    });
+    if (tenantLocales.every((locale) => isEmpty(textMultiloc?.[locale]))) {
+      tenantLocales.forEach(
+        (locale) => (textErrors[locale] = formatMessage(genericMessages.blank))
+      );
+    }
   }
 
   return textErrors;

--- a/front/app/modules/commercial/customizable_homepage_banner/admin/CTASettings/CustomizedButtonSettings.tsx
+++ b/front/app/modules/commercial/customizable_homepage_banner/admin/CTASettings/CustomizedButtonSettings.tsx
@@ -40,7 +40,7 @@ const TextSettings = styled.div`
 // front/app/containers/Admin/projects/general/index.tsx
 const getTextErrors = (
   textMultiloc: Multiloc | undefined,
-  errors: CLErrors | undefined,
+  errors: CLErrors | undefined | null,
   formatMessage: (messageDescriptor, values?) => string,
   tenantLocales: Locale[] | undefined | null | Error
 ) => {
@@ -64,7 +64,7 @@ const getTextErrors = (
 
 const getUrlErrors = (
   url: string | undefined | null,
-  errors: CLErrors | undefined,
+  errors: CLErrors | undefined | null,
   formatMessage: (messageDescriptor, values?) => string
 ) => {
   // Prevent displaying errors on the first render.
@@ -91,7 +91,7 @@ interface Props {
     settingValue: Multiloc | string
   ) => void;
   signInStatus: 'signed_out' | 'signed_in';
-  errors: CLErrors | undefined;
+  errors: CLErrors | undefined | null;
   className?: string;
 }
 

--- a/front/app/modules/commercial/customizable_homepage_banner/admin/CTASettings/SettingRadioButtons.tsx
+++ b/front/app/modules/commercial/customizable_homepage_banner/admin/CTASettings/SettingRadioButtons.tsx
@@ -23,7 +23,7 @@ type SettingRadioButtonsProps =
         settingKey: BannerSettingKeyType,
         settingValue: any
       ) => void;
-      errors: CLErrors | undefined;
+      errors: CLErrors | undefined | null;
     }
   | {
       signInStatus: 'signed_in';
@@ -35,7 +35,7 @@ type SettingRadioButtonsProps =
         settingKey: BannerSettingKeyType,
         settingValue: any
       ) => void;
-      errors: CLErrors | undefined;
+      errors: CLErrors | undefined | null;
     };
 
 const SettingRadioButtons = ({

--- a/front/app/modules/commercial/customizable_homepage_banner/admin/CTASettings/index.tsx
+++ b/front/app/modules/commercial/customizable_homepage_banner/admin/CTASettings/index.tsx
@@ -22,7 +22,7 @@ export type BannerSettingKeyType = Extract<
 interface Props {
   homepageSettings: IHomepageSettingsAttributes;
   handleOnChange: (settingKey: BannerSettingKeyType, settingValue: any) => void;
-  errors: CLErrors | undefined;
+  errors: CLErrors | undefined | null;
 }
 
 const CTASettings = ({ homepageSettings, handleOnChange, errors }: Props) => {

--- a/front/app/utils/moduleUtils.tsx
+++ b/front/app/utils/moduleUtils.tsx
@@ -381,7 +381,7 @@ export interface OutletsPropertyMap {
       settingKey: keyof IHomepageSettingsAttributes,
       settingValue: any
     ) => void;
-    errors: CLErrors | undefined;
+    errors: CLErrors | undefined | null;
   };
   'app.containers.LandingPage.SignedOutHeader.index': {
     homepageBannerLayout: THomepageBannerLayout;

--- a/front/app/utils/moduleUtils.tsx
+++ b/front/app/utils/moduleUtils.tsx
@@ -381,7 +381,7 @@ export interface OutletsPropertyMap {
       settingKey: keyof IHomepageSettingsAttributes,
       settingValue: any
     ) => void;
-    errors: CLErrors | undefined;
+    errors: CLErrors | null;
   };
   'app.containers.LandingPage.SignedOutHeader.index': {
     homepageBannerLayout: THomepageBannerLayout;


### PR DESCRIPTION
## Checklist

- [ ] Added entry to changelog
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

- [ ] WCAG 2.1 AA proof
<details>
<summary>More info</summary>
For front-end devs only. Is your work conforming with the WCAG 2.1 AA rules? If you need more info, read the [a11y page](https://www.notion.so/citizenlab/a11y-7568f83d42ab4895ac133b89d358997b) on our Notion.
</details>

- [ ] Tests
<details>
<summary>More info</summary>

### Unit tests

Did you add relevant unit tests?

### E2E tests

Sometimes it can be more efficient to update E2E tests after CI has run them. If you know which ones to update, go ahead! E2E template cl2-back:

```bash
docker compose run --rm web bin/rails cl2_back:create_tenant[localhost,e2etests_template]
```

</details>

- [ ] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>
