### PR TITLE
[CL-1143] Remove now-unused settings from admin/customize page

### DIFF
--- a/front/app/containers/Admin/settings/customize/getSubmitState.ts
+++ b/front/app/containers/Admin/settings/customize/getSubmitState.ts
@@ -9,16 +9,10 @@ interface Parameters {
 }
 
 export default function getSubmitState({ errors, saved, state }: Parameters) {
-  const {
-    attributesDiff,
-    newAllInputNavbarItemEnabled,
-    newEventsNavbarItemEnabled,
-  } = state;
+  const { attributesDiff, newAllInputNavbarItemEnabled } = state;
 
   const emptyAttributesDiff = isEmpty(attributesDiff);
-  const noNavbarUpdates =
-    newAllInputNavbarItemEnabled === null &&
-    newEventsNavbarItemEnabled === null;
+  const noNavbarUpdates = newAllInputNavbarItemEnabled === null;
 
   if (errors && (!isEmpty(errors) || isError(errors))) {
     return 'error';

--- a/front/app/containers/Admin/settings/customize/index.tsx
+++ b/front/app/containers/Admin/settings/customize/index.tsx
@@ -36,7 +36,7 @@ import {
   IUpdatedAppConfigurationProperties,
   TAppConfigurationSetting,
 } from 'services/appConfiguration';
-import { toggleEvents, toggleAllInput } from 'services/navbar';
+import { toggleAllInput } from 'services/navbar';
 
 // typings
 import { UploadFile, Locale, Multiloc, CLErrors } from 'typings';
@@ -47,9 +47,7 @@ interface Props {
 
 interface IAttributesDiff {
   settings?: Partial<IAppConfigurationSettings>;
-  homepage_info_multiloc?: Multiloc;
   logo?: UploadFile;
-  header_bg?: UploadFile;
   style?: IAppConfigurationStyle;
 }
 
@@ -58,16 +56,13 @@ export interface State {
   attributesDiff: IAttributesDiff;
   tenant: IAppConfiguration | null;
   logo: UploadFile[] | null;
-  header_bg: UploadFile[] | null;
   loading: boolean;
   errors: CLErrors;
   saved: boolean;
   logoError: string | null;
-  headerError: string | null;
   titleError: Multiloc;
   settings: Partial<IAppConfigurationSettings>;
   subtitleError: Multiloc;
-  newEventsNavbarItemEnabled: boolean | null;
   newAllInputNavbarItemEnabled: boolean | null;
 }
 
@@ -93,16 +88,13 @@ class SettingsCustomizeTab extends PureComponent<
       attributesDiff: {},
       tenant: null,
       logo: null,
-      header_bg: null,
       loading: false,
       errors: {},
       saved: false,
       logoError: null,
-      headerError: null,
       titleError: {},
       subtitleError: {},
       settings: {},
-      newEventsNavbarItemEnabled: null,
       newAllInputNavbarItemEnabled: null,
     };
     this.subscriptions = [];
@@ -117,40 +109,27 @@ class SettingsCustomizeTab extends PureComponent<
         .pipe(
           switchMap(([locale, tenant]) => {
             const logoUrl = get(tenant, 'data.attributes.logo.large', null);
-            const headerUrl = get(
-              tenant,
-              'data.attributes.header_bg.large',
-              null
-            );
             const settings = get(tenant, 'data.attributes.settings', {});
 
             const logo$ = logoUrl
               ? convertUrlToUploadFileObservable(logoUrl, null, null)
               : of(null);
-            const headerBg$ = headerUrl
-              ? convertUrlToUploadFileObservable(headerUrl, null, null)
-              : of(null);
 
-            return combineLatest([logo$, headerBg$]).pipe(
-              map(([tenantLogo, tenantHeaderBg]) => ({
+            return combineLatest([logo$]).pipe(
+              map(([tenantLogo]) => ({
                 locale,
                 tenant,
                 tenantLogo,
-                tenantHeaderBg,
                 settings,
               }))
             );
           })
         )
-        .subscribe(
-          ({ locale, tenant, tenantLogo, tenantHeaderBg, settings }) => {
-            const logo = !isNilOrError(tenantLogo) ? [tenantLogo] : [];
-            const header_bg = !isNilOrError(tenantHeaderBg)
-              ? [tenantHeaderBg]
-              : [];
-            this.setState({ locale, tenant, logo, header_bg, settings });
-          }
-        ),
+        .subscribe(({ locale, tenant, tenantLogo, settings }) => {
+          const logo = !isNilOrError(tenantLogo) ? [tenantLogo] : [];
+
+          this.setState({ locale, tenant, logo, settings });
+        }),
     ];
   }
 
@@ -193,12 +172,7 @@ class SettingsCustomizeTab extends PureComponent<
           );
         }
 
-        const { newEventsNavbarItemEnabled, newAllInputNavbarItemEnabled } =
-          this.state;
-
-        if (newEventsNavbarItemEnabled !== null) {
-          await toggleEvents({ enabled: newEventsNavbarItemEnabled });
-        }
+        const { newAllInputNavbarItemEnabled } = this.state;
 
         if (newAllInputNavbarItemEnabled !== null) {
           await toggleAllInput({ enabled: newAllInputNavbarItemEnabled });
@@ -209,7 +183,6 @@ class SettingsCustomizeTab extends PureComponent<
           saved: true,
           errors: {},
           attributesDiff: {},
-          newEventsNavbarItemEnabled: null,
           newAllInputNavbarItemEnabled: null,
         });
       } catch (error) {

--- a/front/app/modules/commercial/events_widget/index.tsx
+++ b/front/app/modules/commercial/events_widget/index.tsx
@@ -5,8 +5,21 @@ import EventsWidget from './citizen';
 import SectionToggle, {
   Props as SectionToggleProps,
 } from './admin/SectionToggle';
+import useFeatureFlag from 'hooks/useFeatureFlag';
 
-const RenderOnFeatureFlag = ({ children }) => {
+// The events section toggle should be rendered if the customer is Allowed to use the feature
+const RenderOnFeatureAllowed = ({ children }) => {
+  const allowed = useFeatureFlag({
+    name: 'events_widget',
+    onlyCheckAllowed: true,
+  });
+
+  return allowed ? <>{children}</> : null;
+};
+
+// The events section on the front page should be shown
+// if the customer is Allowed (appConfig) and if the feature is Enabled (homePageSettings)
+const RenderOnAllowedAndEnabled = ({ children }) => {
   const featureFlag = useHomepageSettingsFeatureFlag({
     sectionEnabledSettingName: 'events_widget_enabled',
     appConfigSettingName: 'events_widget',
@@ -21,16 +34,16 @@ const configuration: ModuleConfiguration = {
       props
     ) => {
       return (
-        <RenderOnFeatureFlag>
+        <RenderOnFeatureAllowed>
           <SectionToggle {...props} />
-        </RenderOnFeatureFlag>
+        </RenderOnFeatureAllowed>
       );
     },
     'app.containers.LandingPage.EventsWidget': () => {
       return (
-        <RenderOnFeatureFlag>
+        <RenderOnAllowedAndEnabled>
           <EventsWidget />
-        </RenderOnFeatureFlag>
+        </RenderOnAllowedAndEnabled>
       );
     },
   },

--- a/front/app/services/navbar.ts
+++ b/front/app/services/navbar.ts
@@ -68,14 +68,6 @@ export async function toggleProposals({ enabled }: { enabled: boolean }) {
   return response;
 }
 
-export async function toggleEvents({ enabled }: { enabled: boolean }) {
-  const response = await streams.add(`${apiEndpoint}/toggle_events`, {
-    enabled,
-  });
-  await streams.fetchAllWith({ partialApiEndpoint: [apiEndpoint] });
-  return response;
-}
-
 // utility function to get slug associated with navbar item
 export function getNavbarItemSlug(
   navbarItemCode: TNavbarItemCode,


### PR DESCRIPTION
Events toggle is now under `admin/pages-menu` so this PR removes it from the old `/customize` page. 

Also changes some logic for the Events section. We want to check if the feature is Allowed (via app config) to show the toggle in the admin page, and then on the Landing Page outlet, we want to check if the feature is Allowed (in app config) and Enabled (in HomePage settings)