### PR TITLE
[CL-1200] Display custom button settings

### DIFF
--- a/front/app/containers/Admin/pages-menu/EditHomepage/index.tsx
+++ b/front/app/containers/Admin/pages-menu/EditHomepage/index.tsx
@@ -28,7 +28,7 @@ import { InsertConfigurationOptions } from 'typings';
 import clHistory from 'utils/cl-router/history';
 
 export type TSectionToggleData = {
-  name: THomepageEnabledSetting;
+  name?: THomepageEnabledSetting;
   titleMessageDescriptor: MessageDescriptor;
   tooltipMessageDescriptor: MessageDescriptor;
   linkToPath?: string;
@@ -42,7 +42,6 @@ const EditHomepage = ({ intl: { formatMessage } }: InjectedIntlProps) => {
     TSectionToggleData[]
   >([
     {
-      name: 'customizable_homepage_banner_enabled',
       titleMessageDescriptor: messages.heroBanner,
       tooltipMessageDescriptor: messages.heroBannerTooltip,
       linkToPath: 'homepage-banner',

--- a/front/app/containers/Admin/pages-menu/EditHomepage/index.tsx
+++ b/front/app/containers/Admin/pages-menu/EditHomepage/index.tsx
@@ -28,7 +28,7 @@ import { InsertConfigurationOptions } from 'typings';
 import clHistory from 'utils/cl-router/history';
 
 export type TSectionToggleData = {
-  name?: THomepageEnabledSetting;
+  name: THomepageEnabledSetting | 'homepage_banner';
   titleMessageDescriptor: MessageDescriptor;
   tooltipMessageDescriptor: MessageDescriptor;
   linkToPath?: string;
@@ -42,6 +42,7 @@ const EditHomepage = ({ intl: { formatMessage } }: InjectedIntlProps) => {
     TSectionToggleData[]
   >([
     {
+      name: 'homepage_banner',
       titleMessageDescriptor: messages.heroBanner,
       tooltipMessageDescriptor: messages.heroBannerTooltip,
       linkToPath: 'homepage-banner',
@@ -68,7 +69,7 @@ const EditHomepage = ({ intl: { formatMessage } }: InjectedIntlProps) => {
   ]);
 
   const handleOnChangeToggle =
-    (sectionName: THomepageEnabledSetting) => async () => {
+    (sectionName: THomepageEnabledSetting | 'homepage_banner') => async () => {
       if (isNilOrError(homepageSettings)) {
         return;
       }

--- a/front/app/containers/Admin/pages-menu/EditHomepage/index.tsx
+++ b/front/app/containers/Admin/pages-menu/EditHomepage/index.tsx
@@ -54,11 +54,12 @@ const EditHomepage = ({ intl: { formatMessage } }: InjectedIntlProps) => {
       tooltipMessageDescriptor: messages.topInfoSectionTooltip,
       linkToPath: 'top-info-section',
     },
-    {
-      name: 'projects_enabled',
-      titleMessageDescriptor: messages.projectsList,
-      tooltipMessageDescriptor: messages.projectsListTooltip,
-    },
+    // Should be enabled and extended again in i2
+    // {
+    //   name: 'projects_enabled',
+    //   titleMessageDescriptor: messages.projectsList,
+    //   tooltipMessageDescriptor: messages.projectsListTooltip,
+    // },
     {
       name: 'bottom_info_section_enabled',
       titleMessageDescriptor: messages.bottomInfoSection,

--- a/front/app/containers/LandingPage/SignedOutHeader/HeaderContent.tsx
+++ b/front/app/containers/LandingPage/SignedOutHeader/HeaderContent.tsx
@@ -12,8 +12,8 @@ import messages from '../messages';
 import { injectIntl } from 'utils/cl-intl';
 import Outlet from 'components/Outlet';
 import SignUpButton from '../SignUpButton';
-import useHomepageSettingsFeatureFlag from 'hooks/useHomepageSettingsFeatureFlag';
 import useHomepageSettings from 'hooks/useHomepageSettings';
+import useFeatureFlag from 'hooks/useFeatureFlag';
 
 const Container = styled.div<{
   align: 'center' | 'left';
@@ -156,9 +156,8 @@ const HeaderContent = ({
   };
   const buttonStyle = getButtonStyle(fontColors);
   // Flag should not be here, but inside module.
-  const customizableHomepageBannerEnabled = useHomepageSettingsFeatureFlag({
-    sectionEnabledSettingName: 'customizable_homepage_banner_enabled',
-    appConfigSettingName: 'customizable_homepage_banner',
+  const customizableHomepageBannerEnabled = useFeatureFlag({
+    name: 'customizable_homepage_banner',
   });
 
   if (!isNilOrError(homepageSettings)) {

--- a/front/app/containers/LandingPage/SignedOutHeader/index.tsx
+++ b/front/app/containers/LandingPage/SignedOutHeader/index.tsx
@@ -1,16 +1,15 @@
-import useHomepageSettingsFeatureFlag from 'hooks/useHomepageSettingsFeatureFlag';
 import React from 'react';
 import FullWidthBannerLayout from './FullWidthBannerLayout';
 import { isNilOrError } from 'utils/helperUtils';
 import Outlet from 'components/Outlet';
 import useHomepageSettings from 'hooks/useHomepageSettings';
+import useFeatureFlag from 'hooks/useFeatureFlag';
 
 const SignedOutHeaderIndex = () => {
   const homepageSettings = useHomepageSettings();
-  // Flag should not be here, but inside module.
-  const customizableHomepageBannerEnabled = useHomepageSettingsFeatureFlag({
-    sectionEnabledSettingName: 'customizable_homepage_banner_enabled',
-    appConfigSettingName: 'customizable_homepage_banner',
+  // Flag should not be here, but inside module (not sure now)
+  const customizableHomepageBannerEnabled = useFeatureFlag({
+    name: 'customizable_homepage_banner',
   });
 
   if (!isNilOrError(homepageSettings)) {

--- a/front/app/hooks/useFeatureFlag.ts
+++ b/front/app/hooks/useFeatureFlag.ts
@@ -12,7 +12,7 @@ export type Parameters = HomepageSettingProps | AppConfigSettingProps;
 // this hook to check the allowed value, which still resides in appConfiguration
 type HomepageSettingProps = {
   name: THomepageSetting;
-  onlyCheckAllowed?: true;
+  onlyCheckAllowed: true;
 };
 
 type AppConfigSettingProps = {

--- a/front/app/hooks/useFeatureFlag.ts
+++ b/front/app/hooks/useFeatureFlag.ts
@@ -12,7 +12,7 @@ export type Parameters = HomepageSettingProps | AppConfigSettingProps;
 // this hook to check the allowed value, which still resides in appConfiguration
 type HomepageSettingProps = {
   name: THomepageSetting;
-  onlyCheckAllowed: true;
+  onlyCheckAllowed?: true;
 };
 
 type AppConfigSettingProps = {

--- a/front/app/modules/commercial/customizable_homepage_banner/admin/CTASettings/CTASettings.test.tsx
+++ b/front/app/modules/commercial/customizable_homepage_banner/admin/CTASettings/CTASettings.test.tsx
@@ -11,7 +11,6 @@ jest.mock('services/appConfiguration');
 
 const props = {
   homepageSettings: {
-    customizable_homepage_banner_enabled: true,
     banner_layout: 'full_width_banner_layout',
     banner_cta_signed_out_type: 'no_button',
     banner_cta_signed_in_type: 'no_button',

--- a/front/app/modules/commercial/customizable_homepage_banner/index.tsx
+++ b/front/app/modules/commercial/customizable_homepage_banner/index.tsx
@@ -5,45 +5,36 @@ import TwoColumnLayout from './citizen/TwoColumnLayout';
 import TwoRowLayout from './citizen/TwoRowLayout';
 import CTASettings from './admin/CTASettings';
 import CTA from './citizen/CTA';
-import useHomepageSettingsFeatureFlag from 'hooks/useHomepageSettingsFeatureFlag';
-
-const RenderOnFeatureFlag = ({ children }) => {
-  const featureFlag = useHomepageSettingsFeatureFlag({
-    sectionEnabledSettingName: 'customizable_homepage_banner_enabled',
-    appConfigSettingName: 'customizable_homepage_banner',
-  });
-
-  return featureFlag ? <>{children}</> : null;
-};
+import FeatureFlag from 'components/FeatureFlag';
 
 const configuration: ModuleConfiguration = {
   outlets: {
     'app.containers.Admin.settings.customize.headerSectionStart': (props) => {
       return (
-        <RenderOnFeatureFlag>
+        <FeatureFlag name="customizable_homepage_banner">
           <LayoutSetting {...props} />
-        </RenderOnFeatureFlag>
+        </FeatureFlag>
       );
     },
     'app.containers.Admin.settings.customize.headerSectionEnd': (props) => {
       return (
-        <RenderOnFeatureFlag>
+        <FeatureFlag name="customizable_homepage_banner">
           <CTASettings {...props} />
-        </RenderOnFeatureFlag>
+        </FeatureFlag>
       );
     },
     'app.containers.LandingPage.SignedOutHeader.CTA': (props) => {
       return (
-        <RenderOnFeatureFlag>
+        <FeatureFlag name="customizable_homepage_banner">
           <CTA signedIn={false} {...props} />
-        </RenderOnFeatureFlag>
+        </FeatureFlag>
       );
     },
     'app.containers.LandingPage.SignedInHeader.CTA': (props) => {
       return (
-        <RenderOnFeatureFlag>
+        <FeatureFlag name="customizable_homepage_banner">
           <CTA signedIn {...props} />
-        </RenderOnFeatureFlag>
+        </FeatureFlag>
       );
     },
     'app.containers.LandingPage.SignedOutHeader.index': ({

--- a/front/app/modules/commercial/customizable_homepage_banner/services/appConfiguration.ts
+++ b/front/app/modules/commercial/customizable_homepage_banner/services/appConfiguration.ts
@@ -10,8 +10,7 @@ declare module 'services/appConfiguration' {
   interface IAppConfigurationSettings {
     customizable_homepage_banner: {
       allowed: boolean;
-      cta_signed_out_customized_button?: CustomizedButtonConfig;
-      cta_signed_in_customized_button?: CustomizedButtonConfig;
+      enabled: boolean;
     };
   }
 }

--- a/front/app/modules/commercial/customizable_homepage_banner/services/homepageSettings.ts
+++ b/front/app/modules/commercial/customizable_homepage_banner/services/homepageSettings.ts
@@ -2,10 +2,6 @@ import 'services/homepageSettings';
 import { Multiloc } from 'typings';
 
 declare module 'services/homepageSettings' {
-  interface THomepageSettingKeyMap {
-    customizable_homepage_banner: 'customizable_homepage_banner';
-  }
-
   interface CTASignedOutTypeMap {
     sign_up_button: 'sign_up_button';
     customized_button: 'customized_button';
@@ -32,9 +28,5 @@ declare module 'services/homepageSettings' {
     banner_cta_signed_out_text_multiloc: Multiloc;
     banner_cta_signed_out_type: CTASignedOutType;
     banner_cta_signed_out_url: string | null;
-  }
-
-  export interface IHomepageEnabledSettings {
-    customizable_homepage_banner_enabled: boolean;
   }
 }

--- a/front/app/modules/commercial/events_widget/admin/SectionToggle.tsx
+++ b/front/app/modules/commercial/events_widget/admin/SectionToggle.tsx
@@ -16,7 +16,7 @@ const SectionToggle = ({ onData }: Props) => {
           titleMessageDescriptor: messages.eventsWidgetSetting,
           tooltipMessageDescriptor: messages.eventsWidgetSettingDescription,
         },
-        insertAfterName: 'projects_enabled',
+        insertBeforeName: 'bottom_info_section_enabled',
       }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     []

--- a/front/app/services/__mocks__/appConfiguration.ts
+++ b/front/app/services/__mocks__/appConfiguration.ts
@@ -39,14 +39,7 @@ export const getAppConfigurationData = (
       },
       customizable_homepage_banner: {
         allowed: true,
-        cta_signed_out_customized_button: {
-          text: { en: 'Click' },
-          url: 'https://www.wonder.ville/promo',
-        },
-        cta_signed_in_customized_button: {
-          text: { en: 'Click' },
-          url: 'https://www.wonder.ville/promo2',
-        },
+        enabled: true,
       },
       participatory_budgeting: {
         allowed: true,

--- a/front/app/services/appConfiguration.ts
+++ b/front/app/services/appConfiguration.ts
@@ -67,6 +67,10 @@ export type IAppConfigurationSettingsCore = {
 
 export interface IAppConfigurationSettings {
   core: IAppConfigurationSettingsCore;
+  customizable_homepage_banner: {
+    allowed: boolean;
+    enabled: boolean;
+  };
   demographic_fields?: {
     allowed: boolean;
     enabled: boolean;

--- a/front/app/services/homepageSettings.ts
+++ b/front/app/services/homepageSettings.ts
@@ -7,7 +7,7 @@ const homepageSettingsEndpoint = `${API_PATH}/home_page`;
 // setting in appConfiguration.ts
 export type TAppConfigSectionSetting = Extract<
   THomepageEnabledSetting,
-  'events_widget_enabled' | 'customizable_homepage_banner_enabled'
+  'events_widget_enabled'
 >;
 
 // Enabled values for sections that DON'T have a corresponding

--- a/front/app/utils/moduleUtils.tsx
+++ b/front/app/utils/moduleUtils.tsx
@@ -601,7 +601,7 @@ export const insertConfiguration =
       // if number is outside of lower and upper, it picks
       // the closes value. If it's inside the ranges, the
       // number is kept
-      insertAfterName ? referenceIndex + 1 : referenceIndex - 1,
+      insertAfterName ? referenceIndex + 1 : referenceIndex,
       0,
       items.length
     );


### PR DESCRIPTION
- Before, we removed `customizable_homepage_banner_enabled` from home page.
- `FeatureFlag` is deprecated but it does exactly what I need here. Using `useFeatureFlag` gives:
  > React Hook "useFeatureFlag" is called in function "'app.containers.Admin.settings.customize.headerSectionStart'" that is neither a React function component nor a custom React Hook function.

## Checklist

- [ ] Added entry to changelog
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

- [ ] WCAG 2.1 AA proof
<details>
<summary>More info</summary>
For front-end devs only. Is your work conforming with the WCAG 2.1 AA rules? If you need more info, read the [a11y page](https://www.notion.so/citizenlab/a11y-7568f83d42ab4895ac133b89d358997b) on our Notion.
</details>

- [ ] Tests
<details>
<summary>More info</summary>

### Unit tests

Did you add relevant unit tests?

### E2E tests

Sometimes it can be more efficient to update E2E tests after CI has run them. If you know which ones to update, go ahead! E2E template cl2-back:

```bash
docker compose run --rm web bin/rails cl2_back:create_tenant[localhost,e2etests_template]
```

</details>

- [ ] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>
