### PR TITLE
[CL-1216] fix too many sql queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Next release
 
+### Fixed
+
+- [CL-1216] Fix slow insights export
+
 ### Changed
 
 - [CL-1205] Change see less copy to read less in read more on project info and phase description

--- a/back/engines/commercial/insights/app/services/insights/xlsx_service.rb
+++ b/back/engines/commercial/insights/app/services/insights/xlsx_service.rb
@@ -2,23 +2,27 @@
 
 module Insights
   class XlsxService
+    def build_assignments_hash(category_assignments)
+      assignments_hash = {}
+      if category_assignments
+        assignments_hash = category_assignments.map { |assignment| [assignment.category_id, assignment.approved ? 'approved' : 'suggested'] }.to_h
+      end
+      assignments_hash
+    end
+
     def generate_inputs_xlsx(inputs, categories, view_private_attributes: false)
       columns = xlsx_service.generate_idea_xlsx_columns(inputs, view_private_attributes: view_private_attributes)
+
+      values = inputs.includes(:insights_category_assignments).select('id').map { |input| [input.id, build_assignments_hash(input.insights_category_assignments)] }.to_h
 
       category_cols = categories.map do |category|
         {
           header: category.name,
-          f: lambda do |input|
-            assignment = input.insights_category_assignments.find_by(category_id: category.id)
-            return unless assignment
-
-            assignment.approved ? 'approved' : 'suggested'
-          end
+          f: ->(input) { values[input.id][category.id] }
         }
       end
 
       columns.insert(3, *category_cols)
-      inputs = inputs.includes(:insights_category_assignments)
       xlsx_service.generate_xlsx('Inputs export', columns, inputs)
     end
 

--- a/back/engines/commercial/insights/app/services/insights/xlsx_service.rb
+++ b/back/engines/commercial/insights/app/services/insights/xlsx_service.rb
@@ -2,18 +2,18 @@
 
 module Insights
   class XlsxService
-    def build_assignments_hash(category_assignments)
-      assignments_hash = {}
-      if category_assignments
-        assignments_hash = category_assignments.map { |assignment| [assignment.category_id, assignment.approved ? 'approved' : 'suggested'] }.to_h
-      end
-      assignments_hash
-    end
-
     def generate_inputs_xlsx(inputs, categories, view_private_attributes: false)
       columns = xlsx_service.generate_idea_xlsx_columns(inputs, view_private_attributes: view_private_attributes)
 
-      values = inputs.includes(:insights_category_assignments).select('id').map { |input| [input.id, build_assignments_hash(input.insights_category_assignments)] }.to_h
+      values = inputs
+        .includes(:insights_category_assignments)
+        .select('id')
+        .to_h do |input|
+          [
+            input.id,
+            build_assignments_hash(input.insights_category_assignments)
+          ]
+        end
 
       category_cols = categories.map do |category|
         {
@@ -27,6 +27,20 @@ module Insights
     end
 
     private
+
+    def build_assignments_hash(category_assignments)
+      assignments_hash = {}
+      if category_assignments
+        assignments_hash = category_assignments
+          .to_h do |assignment|
+            [
+              assignment.category_id,
+              assignment.approved ? 'approved' : 'suggested'
+            ]
+          end
+      end
+      assignments_hash
+    end
 
     def xlsx_service
       @xlsx_service ||= ::XlsxService.new


### PR DESCRIPTION
As [James suggested](https://citizenlabco.slack.com/archives/C016C2EHURY/p1658422063301729?thread_ts=1658407194.129109&cid=C016C2EHURY) there were too many queries to the `insights_category_assignment` table. So i put all inputs and categories assignments in a hash to get faster the values for the excel table.

Here is a chart of transaction per second i was getting when i did some downloads of the excel with 1000 ideas as before this change (blue) and now (yellow):
![transactions per second](https://user-images.githubusercontent.com/9025698/180325336-719d2f21-c478-40a2-997d-c76999b4bf86.png)


## Checklist

- [x] Added entry to changelog

- [ ] Tests

- [x] Prepared branch for code review

## How urgent is a code review?
High priority
