### PR TITLE
[CL-1242] Flexible pages final UI/UX changes

### DIFF
--- a/front/app/containers/Admin/pages-menu/EditHomepage/index.tsx
+++ b/front/app/containers/Admin/pages-menu/EditHomepage/index.tsx
@@ -115,17 +115,17 @@ const EditHomepage = ({ intl: { formatMessage } }: InjectedIntlProps) => {
           label: formatMessage(homeBreadcrumb.label),
         },
       ]}
+      rightSideCTA={
+        <AdminViewButton
+          buttonTextMessageDescriptor={messages.viewPage}
+          linkTo="/"
+        />
+      }
     >
       <Box display="flex" alignItems="center" mb="12px">
         <Title variant="h2">
           <FormattedMessage {...messages.sectionsTitle} />
         </Title>
-        <Box ml="auto">
-          <AdminViewButton
-            buttonTextMessageDescriptor={messages.viewPage}
-            linkTo="/"
-          />
-        </Box>
       </Box>
       <Box display="flex" flexDirection="column">
         <Box mb="28px">

--- a/front/app/containers/Admin/pages-menu/SectionToggle/index.tsx
+++ b/front/app/containers/Admin/pages-menu/SectionToggle/index.tsx
@@ -36,20 +36,26 @@ const SectionToggle = ({
 }: Props) => {
   return (
     <Row isLastItem={isLastItem}>
-      <Box display="flex" alignItems="center" justifyContent="center">
-        <Box visibility={hideToggle ? 'hidden' : 'visible'} mr="20px">
+      <Box
+        pt="5px"
+        pb="5px"
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+      >
+        <Box visibility={hideToggle ? 'hidden' : 'visible'} mr="20px" mt="7px">
           <Toggle
             checked={checked}
             onChange={onChangeSectionToggle}
             disabled={disabled}
           />
         </Box>
-        <Box pb="13px">
-          <Title variant="h3" mr="10px">
+        <Box>
+          <Title mr="10px">
             <FormattedMessage {...titleMessageDescriptor} />
           </Title>
         </Box>
-        <Box pb="15px">
+        <Box pb="13px">
           <IconTooltip
             content={<FormattedMessage {...tooltipMessageDescriptor} />}
           />

--- a/front/app/containers/Admin/pages-menu/components/SectionFormWrapper.tsx
+++ b/front/app/containers/Admin/pages-menu/components/SectionFormWrapper.tsx
@@ -12,6 +12,7 @@ interface Props {
   title?: string;
   children: JSX.Element | JSX.Element[];
   stickyMenuContents?: JSX.Element | JSX.Element[];
+  rightSideCTA?: JSX.Element | JSX.Element[];
 }
 
 const SectionFormWrapper = ({
@@ -19,17 +20,21 @@ const SectionFormWrapper = ({
   title,
   children,
   stickyMenuContents,
+  rightSideCTA,
 }: Props) => {
   return (
     <>
       <Box mb="16px">
         <Breadcrumbs breadcrumbs={breadcrumbs} />
       </Box>
-      {title && (
-        <Box mb="20px">
-          <PageTitle>{title}</PageTitle>
-        </Box>
-      )}
+      <Box display="flex" justifyContent="space-between">
+        {title && (
+          <Box mb="20px">
+            <PageTitle>{title}</PageTitle>
+          </Box>
+        )}
+        {rightSideCTA && <Box ml="auto">{rightSideCTA}</Box>}
+      </Box>
       <Box>
         <PageWrapper>
           {children}

--- a/front/app/containers/Admin/pages-menu/components/SectionFormWrapper.tsx
+++ b/front/app/containers/Admin/pages-menu/components/SectionFormWrapper.tsx
@@ -9,7 +9,7 @@ import PageWrapper from 'components/admin/PageWrapper';
 
 interface Props {
   breadcrumbs: { label: string; linkTo?: string }[];
-  title?: string;
+  title?: string | JSX.Element;
   children: JSX.Element | JSX.Element[];
   stickyMenuContents?: JSX.Element | JSX.Element[];
   rightSideCTA?: JSX.Element | JSX.Element[];

--- a/front/app/containers/Admin/pages-menu/components/StickyContainer.tsx
+++ b/front/app/containers/Admin/pages-menu/components/StickyContainer.tsx
@@ -12,7 +12,7 @@ const StickyContainer = styled.div`
   bottom: 0;
   margin-left: -4rem;
   margin-bottom: -4rem;
-  padding-left: 45px;
+  padding-left: 4rem;
 
   display: flex;
   align-items: center;

--- a/front/app/modules/commercial/customizable_navbar/admin/containers/EditNavbarItemForm/index.tsx
+++ b/front/app/modules/commercial/customizable_navbar/admin/containers/EditNavbarItemForm/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import styled from 'styled-components';
 import { withRouter, WithRouterProps } from 'utils/cl-router/withRouter';
 import { Formik, FormikActions, FormikProps } from 'formik';
 
@@ -8,33 +7,32 @@ import NavbarItemForm, {
   validatePageForm,
   FormValues,
 } from '../../components/NavbarItemForm';
-import GoBackButton from 'components/UI/GoBackButton';
-import T from 'components/T';
+import SectionFormWrapper from 'containers/Admin/pages-menu/components/SectionFormWrapper';
+import { pagesAndMenuBreadcrumb } from 'containers/Admin/pages-menu/breadcrumbs';
 
 // utils
 import { isNilOrError } from 'utils/helperUtils';
-import { fontSizes } from 'utils/styleUtils';
-import clHistory from 'utils/cl-router/history';
 import { getInitialFormValues, createNavbarItemUpdateData } from './utils';
-import { PAGES_MENU_PATH } from 'containers/Admin/pages-menu/routes';
 
 // services
 import { updateNavbarItem } from '../../../services/navbar';
 
+// i18n
+import { injectIntl } from 'utils/cl-intl';
+import { InjectedIntlProps } from 'react-intl';
+
 // hooks
 import useAppConfigurationLocales from 'hooks/useAppConfigurationLocales';
 import useNavbarItem from '../../../hooks/useNavbarItem';
+import useLocalize from 'hooks/useLocalize';
 
-const Title = styled.h1`
-  font-size: ${fontSizes.xxxl}px;
-  padding: 0;
-  width: 100%;
-  margin: 1rem 0 3rem 0;
-`;
-
-const EditNavbarItemForm = ({ params: { navbarItemId } }: WithRouterProps) => {
+const EditNavbarItemForm = ({
+  params: { navbarItemId },
+  intl: { formatMessage },
+}: WithRouterProps & InjectedIntlProps) => {
   const appConfigurationLocales = useAppConfigurationLocales();
   const navbarItem = useNavbarItem({ navbarItemId });
+  const localize = useLocalize();
 
   if (isNilOrError(appConfigurationLocales) || isNilOrError(navbarItem)) {
     return null;
@@ -58,20 +56,23 @@ const EditNavbarItemForm = ({ params: { navbarItemId } }: WithRouterProps) => {
     }
   };
 
-  const goBack = () => {
-    clHistory.push(PAGES_MENU_PATH);
-  };
-
   const renderFn = (props: FormikProps<FormValues>) => {
     return <NavbarItemForm {...props} />;
   };
 
   return (
-    <div>
-      <GoBackButton onClick={goBack} />
-      <Title>
-        <T value={navbarItem.attributes.title_multiloc} />
-      </Title>
+    <SectionFormWrapper
+      title={localize(navbarItem.attributes.title_multiloc)}
+      breadcrumbs={[
+        {
+          label: formatMessage(pagesAndMenuBreadcrumb.label),
+          linkTo: pagesAndMenuBreadcrumb.linkTo,
+        },
+        {
+          label: localize(navbarItem.attributes.title_multiloc),
+        },
+      ]}
+    >
       <Formik
         initialValues={getInitialFormValues(navbarItem)}
         onSubmit={handleSubmit}
@@ -80,8 +81,8 @@ const EditNavbarItemForm = ({ params: { navbarItemId } }: WithRouterProps) => {
         validateOnChange={false}
         validateOnBlur={false}
       />
-    </div>
+    </SectionFormWrapper>
   );
 };
 
-export default withRouter(EditNavbarItemForm);
+export default injectIntl(withRouter(EditNavbarItemForm));

--- a/front/app/modules/commercial/customizable_navbar/admin/containers/EditPageForm/EditPageFormNavbar.tsx
+++ b/front/app/modules/commercial/customizable_navbar/admin/containers/EditPageForm/EditPageFormNavbar.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import styled from 'styled-components';
 import { withRouter, WithRouterProps } from 'utils/cl-router/withRouter';
 import { Formik, FormikProps } from 'formik';
 
@@ -8,15 +7,16 @@ import PageFormWithNavbarNameField, {
   validatePageForm,
   FormValues,
 } from '../../components/PageFormWithNavbarNameField';
-import GoBackButton from 'components/UI/GoBackButton';
-import T from 'components/T';
+import SectionFormWrapper from 'containers/Admin/pages-menu/components/SectionFormWrapper';
+import { pagesAndMenuBreadcrumb } from 'containers/Admin/pages-menu/breadcrumbs';
 
 // utils
 import { isNilOrError } from 'utils/helperUtils';
-import { fontSizes } from 'utils/styleUtils';
-import clHistory from 'utils/cl-router/history';
 import { getInitialFormValues, createPageUpdateData } from './utils';
-import { PAGES_MENU_PATH } from 'containers/Admin/pages-menu/routes';
+
+// i18n
+import { injectIntl } from 'utils/cl-intl';
+import { InjectedIntlProps } from 'react-intl';
 
 // services
 import { updatePage } from 'services/pages';
@@ -27,16 +27,15 @@ import useAppConfigurationLocales from 'hooks/useAppConfigurationLocales';
 import useRemoteFiles from 'hooks/useRemoteFiles';
 import usePage from 'hooks/usePage';
 import usePageSlugs from 'hooks/usePageSlugs';
+import useLocalize from 'hooks/useLocalize';
 
-const Title = styled.h1`
-  font-size: ${fontSizes.xxxl}px;
-  padding: 0;
-  width: 100%;
-  margin: 1rem 0 3rem 0;
-`;
-
-const EditPageFormNavbar = ({ params: { pageId } }: WithRouterProps) => {
+const EditPageFormNavbar = ({
+  params: { pageId },
+  intl: { formatMessage },
+}: WithRouterProps & InjectedIntlProps) => {
   const appConfigurationLocales = useAppConfigurationLocales();
+  const localize = useLocalize();
+
   const page = usePage({ pageId });
   const remotePageFiles = useRemoteFiles({
     resourceType: 'page',
@@ -88,20 +87,23 @@ const EditPageFormNavbar = ({ params: { pageId } }: WithRouterProps) => {
     }
   };
 
-  const goBack = () => {
-    clHistory.push(PAGES_MENU_PATH);
-  };
-
   const renderFn = (props: FormikProps<FormValues>) => {
     return <PageFormWithNavbarNameField {...props} pageId={pageId} />;
   };
 
   return (
-    <div>
-      <GoBackButton onClick={goBack} />
-      <Title>
-        <T value={page.attributes.title_multiloc} />
-      </Title>
+    <SectionFormWrapper
+      title={localize(page.attributes.title_multiloc)}
+      breadcrumbs={[
+        {
+          label: formatMessage(pagesAndMenuBreadcrumb.label),
+          linkTo: pagesAndMenuBreadcrumb.linkTo,
+        },
+        {
+          label: localize(page.attributes.title_multiloc),
+        },
+      ]}
+    >
       <Formik
         initialValues={getInitialFormValues(page, remotePageFiles)}
         onSubmit={handleSubmit}
@@ -114,8 +116,8 @@ const EditPageFormNavbar = ({ params: { pageId } }: WithRouterProps) => {
         validateOnChange={false}
         validateOnBlur={false}
       />
-    </div>
+    </SectionFormWrapper>
   );
 };
 
-export default withRouter(EditPageFormNavbar);
+export default injectIntl(withRouter(EditPageFormNavbar));

--- a/front/app/modules/commercial/customizable_navbar/admin/containers/EditPageForm/EditPageFormNotInNavbar.tsx
+++ b/front/app/modules/commercial/customizable_navbar/admin/containers/EditPageForm/EditPageFormNotInNavbar.tsx
@@ -1,18 +1,19 @@
 import React from 'react';
-import styled from 'styled-components';
 import { withRouter, WithRouterProps } from 'utils/cl-router/withRouter';
 import { Formik, FormikProps } from 'formik';
 
 // components
 import PageForm, { validatePageForm, FormValues } from 'components/PageForm';
-import GoBackButton from 'components/UI/GoBackButton';
-import T from 'components/T';
+import SectionFormWrapper from 'containers/Admin/pages-menu/components/SectionFormWrapper';
+import { pagesAndMenuBreadcrumb } from 'containers/Admin/pages-menu/breadcrumbs';
 
 // utils
 import { isNilOrError } from 'utils/helperUtils';
-import { fontSizes } from 'utils/styleUtils';
-import clHistory from 'utils/cl-router/history';
-import { PAGES_MENU_PATH } from 'containers/Admin/pages-menu/routes';
+
+// i18n
+import { injectIntl } from 'utils/cl-intl';
+import { InjectedIntlProps } from 'react-intl';
+import useLocalize from 'hooks/useLocalize';
 
 // services
 import { updatePage } from 'services/pages';
@@ -24,15 +25,12 @@ import useRemoteFiles from 'hooks/useRemoteFiles';
 import usePage from 'hooks/usePage';
 import usePageSlugs from 'hooks/usePageSlugs';
 
-const Title = styled.h1`
-  font-size: ${fontSizes.xxxl}px;
-  padding: 0;
-  width: 100%;
-  margin: 1rem 0 3rem 0;
-`;
-
-const EditPageFormNotInNavbar = ({ params: { pageId } }: WithRouterProps) => {
+const EditPageFormNotInNavbar = ({
+  params: { pageId },
+  intl: { formatMessage },
+}: WithRouterProps & InjectedIntlProps) => {
   const appConfigurationLocales = useAppConfigurationLocales();
+  const localize = useLocalize();
   const page = usePage({ pageId });
   const remotePageFiles = useRemoteFiles({
     resourceType: 'page',
@@ -80,20 +78,23 @@ const EditPageFormNotInNavbar = ({ params: { pageId } }: WithRouterProps) => {
     }
   };
 
-  const goBack = () => {
-    clHistory.push(PAGES_MENU_PATH);
-  };
-
   const renderFn = (props: FormikProps<FormValues>) => {
     return <PageForm {...props} pageId={pageId} />;
   };
 
   return (
-    <div>
-      <GoBackButton onClick={goBack} />
-      <Title>
-        <T value={page.attributes.title_multiloc} />
-      </Title>
+    <SectionFormWrapper
+      title={localize(page.attributes.title_multiloc)}
+      breadcrumbs={[
+        {
+          label: formatMessage(pagesAndMenuBreadcrumb.label),
+          linkTo: pagesAndMenuBreadcrumb.linkTo,
+        },
+        {
+          label: localize(page.attributes.title_multiloc),
+        },
+      ]}
+    >
       <Formik
         initialValues={{
           title_multiloc: page.attributes.title_multiloc,
@@ -111,8 +112,8 @@ const EditPageFormNotInNavbar = ({ params: { pageId } }: WithRouterProps) => {
         validateOnChange={false}
         validateOnBlur={false}
       />
-    </div>
+    </SectionFormWrapper>
   );
 };
 
-export default withRouter(EditPageFormNotInNavbar);
+export default injectIntl(withRouter(EditPageFormNotInNavbar));


### PR DESCRIPTION
Other page editors and navbar item title editors are now in the new visual wrapper:
![Screen Shot 2022-07-27 at 10 00 06](https://user-images.githubusercontent.com/3614128/181194248-b5f53de6-5cb1-4051-981e-8e58f6f166bc.png)
![Screen Shot 2022-07-27 at 09 59 58](https://user-images.githubusercontent.com/3614128/181194258-a2a6d82a-9213-4beb-9721-b056d9a58975.png)
![Screen Shot 2022-07-27 at 09 59 52](https://user-images.githubusercontent.com/3614128/181194260-6d129ecf-0412-4dfd-a6f7-0f2def536c13.png)

"View Page" button is now outside the container, aligned with the title, and slight changes were made to the vertical alignment of the rows in the table:

![Screen Shot 2022-07-27 at 10 00 49](https://user-images.githubusercontent.com/3614128/181194322-041ec5b2-03cf-4740-883d-6f2fe3fe3075.png)

Sticky save button is now aligned properly on desktop and mobile:
![Screen Shot 2022-07-27 at 10 01 44](https://user-images.githubusercontent.com/3614128/181194529-598b5c92-bd55-4abe-8f11-23504490b619.png)
![Screen Shot 2022-07-27 at 10 01 36](https://user-images.githubusercontent.com/3614128/181194533-3970565f-82d5-4b6e-bb93-ef7134341c67.png)



