### PR TITLE
[CL-894] Remove some validations for info sections multilocs

### DIFF
--- a/back/app/models/home_page.rb
+++ b/back/app/models/home_page.rb
@@ -36,16 +36,16 @@ class HomePage < ApplicationRecord
 
   accepts_nested_attributes_for :pinned_admin_publications, allow_destroy: true
 
-  before_validation :sanitize_top_info_section_multiloc, if: :top_info_section_enabled
-  before_validation :sanitize_bottom_info_section_multiloc, if: :bottom_info_section_enabled
+  before_validation :sanitize_top_info_section_multiloc
+  before_validation :sanitize_bottom_info_section_multiloc
 
   validate :only_one_home_page, on: :create
 
   validates :top_info_section_enabled, inclusion: [true, false]
-  validates :top_info_section_multiloc, presence: true, multiloc: { html: true, presence: true }, if: :top_info_section_enabled
+  validates :top_info_section_multiloc, multiloc: { presence: false, html: true }
 
   validates :bottom_info_section_enabled, inclusion: [true, false]
-  validates :bottom_info_section_multiloc, presence: true, multiloc: { html: true, presence: true }, if: :bottom_info_section_enabled
+  validates :bottom_info_section_multiloc, multiloc: { presence: false, html: true }
 
   validates :events_widget_enabled, inclusion: [true, false]
   validates :projects_enabled, inclusion: [true, false]

--- a/back/spec/models/home_page_spec.rb
+++ b/back/spec/models/home_page_spec.rb
@@ -25,18 +25,6 @@ RSpec.describe HomePage, type: :model do
       it { is_expected.to validate_presence_of(:banner_cta_signed_in_url) }
       it { is_expected.to validate_presence_of(:banner_cta_signed_in_text_multiloc) }
     end
-
-    context 'when top_info_section is enabled' do
-      subject { described_class.new(top_info_section_enabled: true) }
-
-      it { is_expected.to validate_presence_of(:top_info_section_multiloc) }
-    end
-
-    context 'when bottom_info_section is enabled' do
-      subject { described_class.new(bottom_info_section_enabled: true) }
-
-      it { is_expected.to validate_presence_of(:bottom_info_section_multiloc) }
-    end
   end
 
   describe 'image uploads' do


### PR DESCRIPTION
When performing a dry-run of the [HomePage data migration Rake task](https://github.com/CitizenLabDotCo/citizenlab-ee/blob/master/back/engines/ee/multi_tenancy/lib/tasks/core/migrate_home_page_data.rake) on a production cluster, we noticed that some validations of the `HomePage` model failed when existing `homepage_info_section_multiloc` (in `AppConfiguration`) values were used for the `HomePage.bottom_info_section_multiloc` field.

This was because we were using much stricter (and more) validations than are used in the `AppConfiguration` model [for this multiloc field](https://github.com/CitizenLabDotCo/citizenlab/blob/0c513a6d0c12cfcbe9e0a8c002841b7369c08507/back/app/models/app_configuration.rb#L44).

This PR changes the validations used on the 2 info multilocs in `HomePage` to match that used for the info multiloc in `AppConfiguration`.  It also removes two tests relating to the removed validations.
