### PR TITLE
[CL-1199] UI/UX fixes for Flexible Pages

### DIFF
--- a/front/app/containers/Admin/pagesAndMenu/SectionToggle/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/SectionToggle/index.tsx
@@ -55,7 +55,7 @@ const SectionToggle = ({
             <FormattedMessage {...titleMessageDescriptor} />
           </Title>
         </Box>
-        <Box pb="13px">
+        <Box>
           <IconTooltip
             content={<FormattedMessage {...tooltipMessageDescriptor} />}
           />

--- a/front/app/modules/commercial/customizable_navbar/admin/containers/NewPageForm/index.tsx
+++ b/front/app/modules/commercial/customizable_navbar/admin/containers/NewPageForm/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import styled from 'styled-components';
 
 // services
 import { createPage } from 'services/pages';
@@ -11,11 +10,13 @@ import usePageSlugs from 'hooks/usePageSlugs';
 
 // components
 import { Formik, FormikProps } from 'formik';
-import GoBackButton from 'components/UI/GoBackButton';
 import PageForm, { FormValues, validatePageForm } from 'components/PageForm';
+import SectionFormWrapper from 'containers/Admin/pagesAndMenu/components/SectionFormWrapper';
+import { pagesAndMenuBreadcrumb } from 'containers/Admin/pagesAndMenu/breadcrumbs';
 
 // i18n
-import { FormattedMessage } from 'utils/cl-intl';
+import { InjectedIntlProps } from 'react-intl';
+import { injectIntl, FormattedMessage } from 'utils/cl-intl';
 import messages from '../messages';
 
 // utils
@@ -24,13 +25,7 @@ import { isNilOrError } from 'utils/helperUtils';
 import getInitialValues from './getInitialValues';
 import { PAGES_MENU_PATH } from 'containers/Admin/pagesAndMenu/routes';
 
-const PageTitle = styled.h1`
-  width: 100%;
-  font-size: 2rem;
-  margin: 1rem 0 3rem 0;
-`;
-
-const NewPageForm = () => {
+const NewPageForm = ({ intl: { formatMessage } }: InjectedIntlProps) => {
   const appConfigurationLocales = useAppConfigurationLocales();
   const pageSlugs = usePageSlugs();
 
@@ -67,11 +62,18 @@ const NewPageForm = () => {
   };
 
   return (
-    <div>
-      <GoBackButton onClick={goBack} />
-      <PageTitle>
-        <FormattedMessage {...messages.addPageButton} />
-      </PageTitle>
+    <SectionFormWrapper
+      breadcrumbs={[
+        {
+          label: formatMessage(pagesAndMenuBreadcrumb.label),
+          linkTo: pagesAndMenuBreadcrumb.linkTo,
+        },
+        {
+          label: formatMessage(messages.addPageButton),
+        },
+      ]}
+      title={<FormattedMessage {...messages.addPageButton} />}
+    >
       <Formik
         initialValues={getInitialValues(appConfigurationLocales)}
         onSubmit={handleSubmit}
@@ -80,8 +82,8 @@ const NewPageForm = () => {
         validateOnChange={false}
         validateOnBlur={false}
       />
-    </div>
+    </SectionFormWrapper>
   );
 };
 
-export default NewPageForm;
+export default injectIntl(NewPageForm);


### PR DESCRIPTION
Wrap "add page" form in the new wrapper:

![Screen Shot 2022-07-28 at 09 51 16](https://user-images.githubusercontent.com/3614128/181451955-e46c7c69-0c18-430b-a4a5-cc7c3e9ecd2c.png)

Remove vertical padding on the icon to align it with the other items on the same line:
![Screen Shot 2022-07-28 at 09 51 09](https://user-images.githubusercontent.com/3614128/181451964-be99d51a-0a26-4ce6-a7a7-62d48859ec42.png)
