### PR TITLE
DO NOT MERGE - Remove projects_enabled from home page model & db table

### DIFF
--- a/back/app/controllers/web_api/v1/home_pages_controller.rb
+++ b/back/app/controllers/web_api/v1/home_pages_controller.rb
@@ -35,7 +35,6 @@ class WebApi::V1::HomePagesController < ApplicationController
       :bottom_info_section_enabled,
       :bottom_info_section_multiloc,
       :events_widget_enabled,
-      :projects_enabled,
       :projects_header_multiloc,
       :banner_avatars_enabled,
       :banner_layout,

--- a/back/app/models/home_page.rb
+++ b/back/app/models/home_page.rb
@@ -11,7 +11,6 @@
 #  bottom_info_section_enabled              :boolean          default(FALSE), not null
 #  bottom_info_section_multiloc             :jsonb            not null
 #  events_widget_enabled                    :boolean          default(FALSE), not null
-#  projects_enabled                         :boolean          default(TRUE), not null
 #  projects_header_multiloc                 :jsonb            not null
 #  banner_avatars_enabled                   :boolean          default(TRUE), not null
 #  banner_layout                            :string           default("full_width_banner_layout"), not null
@@ -48,7 +47,6 @@ class HomePage < ApplicationRecord
   validates :bottom_info_section_multiloc, multiloc: { presence: false, html: true }
 
   validates :events_widget_enabled, inclusion: [true, false]
-  validates :projects_enabled, inclusion: [true, false]
 
   validates :projects_header_multiloc, multiloc: true
 

--- a/back/app/serializers/web_api/v1/home_page_serializer.rb
+++ b/back/app/serializers/web_api/v1/home_page_serializer.rb
@@ -6,7 +6,6 @@ class WebApi::V1::HomePageSerializer < WebApi::V1::BaseSerializer
     :bottom_info_section_enabled,
     :bottom_info_section_multiloc,
     :events_widget_enabled,
-    :projects_enabled,
     :projects_header_multiloc,
     :banner_avatars_enabled,
     :banner_layout,

--- a/back/db/migrate/20220801201347_remove_projects_enabled_from_home_pages.rb
+++ b/back/db/migrate/20220801201347_remove_projects_enabled_from_home_pages.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveProjectsEnabledFromHomePages < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :home_pages, :projects_enabled, :boolean, default: true, null: false
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_19_103052) do
+ActiveRecord::Schema.define(version: 2022_08_01_201347) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -339,7 +339,6 @@ ActiveRecord::Schema.define(version: 2022_07_19_103052) do
     t.boolean "bottom_info_section_enabled", default: false, null: false
     t.jsonb "bottom_info_section_multiloc", default: {}, null: false
     t.boolean "events_widget_enabled", default: false, null: false
-    t.boolean "projects_enabled", default: true, null: false
     t.jsonb "projects_header_multiloc", default: {}, null: false
     t.boolean "banner_avatars_enabled", default: true, null: false
     t.string "banner_layout", default: "full_width_banner_layout", null: false

--- a/back/spec/acceptance/home_pages_spec.rb
+++ b/back/spec/acceptance/home_pages_spec.rb
@@ -48,7 +48,6 @@ resource 'Home Page' do
         parameter :top_info_section_enabled, 'if the top info section is enabled'
         parameter :top_info_section_multiloc, 'multiloc content for the top info section'
         parameter :events_widget_enabled, 'if events are enabled'
-        parameter :projects_enabled, 'if projects are enabled'
         parameter :projects_header_multiloc, 'multiloc content for the projects header'
         parameter :pinned_admin_publication_ids, 'the IDs of admin publications that are pinned to the page', type: :array
       end


### PR DESCRIPTION
DO NOT MERGE - we decided to add the `projects_enabled` toggle to homepage UI in i2.

I noticed that we hadn't removed `projects_enabled` from the `HomePage` model nor db table, despite no longer using this boolean in i1 Flexible Pages epic. This PR removes `projects_enabled`

Related Jira ticket: [Create HomePage model CL-894](https://citizenlab.atlassian.net/browse/CL-894)