### PR TITLE
[CL-1263] Remove search query from AdminApi TenantsController

### DIFF
--- a/back/engines/commercial/admin_api/app/controllers/admin_api/tenants_controller.rb
+++ b/back/engines/commercial/admin_api/app/controllers/admin_api/tenants_controller.rb
@@ -7,7 +7,6 @@ module AdminApi
 
     def index
       tenants = Tenant.not_deleted.order(name: :asc)
-      tenants = tenants.where('name LIKE ?', "%#{params[:search]}%") if params[:search]
       # Call #to_json explicitly, otherwise 'data' is added as root.
       render json: serialize_tenants(tenants).to_json
     end


### PR DESCRIPTION
Part of Jira Ticket: 10% - [AdminHQ: Make search filter case-insensitive](https://citizenlab.atlassian.net/browse/CL-1263)

We decided to move the search query/filtering to the `cl2-admin` repo in [this PR](https://github.com/CitizenLabDotCo/cl2-admin/pull/81), where we also make it case-insensitive.

This PR can be merged after the related `cl2-admin` change, as this current query only runs if a search parameter is passed, which it won't be after the `cl2-admin` change.