### PR TITLE
Fix flaky text cards e2e test

### DIFF
--- a/front/cypress/e2e/content_builder/sections/image_text_cards_section.cy.ts
+++ b/front/cypress/e2e/content_builder/sections/image_text_cards_section.cy.ts
@@ -56,17 +56,17 @@ describe('Content builder Image Text Cards section', () => {
     // Edit image components
     cy.get('div#e2e-image').eq(0).parent().click();
     cy.get('input[type="file"]').attachFile('icon.png');
-    cy.get('#imageAltTextInput').click().type('Image alt text.');
+    cy.get('#imageAltTextInput').click().clear().type('Image alt text.');
     cy.get('[alt="Image alt text."]').should('exist');
 
     cy.get('div#e2e-image').eq(1).parent().click();
     cy.get('input[type="file"]').attachFile('icon.png');
-    cy.get('#imageAltTextInput').click().type('Image alt text.');
+    cy.get('#imageAltTextInput').click().clear().type('Image alt text.');
     cy.get('[alt="Image alt text."]').should('exist');
 
     cy.get('div#e2e-image').eq(2).parent().click();
     cy.get('input[type="file"]').attachFile('icon.png');
-    cy.get('#imageAltTextInput').click().type('Image alt text.');
+    cy.get('#imageAltTextInput').click().clear().type('Image alt text.');
     cy.get('[alt="Image alt text."]').should('exist');
 
     cy.get('#e2e-content-builder-topbar-save').click();

--- a/front/cypress/e2e/content_builder/sections/image_text_cards_section.cy.ts
+++ b/front/cypress/e2e/content_builder/sections/image_text_cards_section.cy.ts
@@ -69,6 +69,7 @@ describe('Content builder Image Text Cards section', () => {
     cy.get('#imageAltTextInput').click().clear().type('Image alt text.');
     cy.get('[alt="Image alt text."]').should('exist');
 
+    // Save
     cy.get('#e2e-content-builder-topbar-save').click();
     cy.wait('@saveContentBuilder');
 


### PR DESCRIPTION
## Description
This was hard to reproduce, and didn't happen often locally. It looks like sometimes the typing in the alt text field happens too quickly, leading to a few missing letters (and then causing the check later to fail). I've added a ".clear()" first before typing, which seems to fix the issue.

## How urgent is a code review?
End of today if possible?
