### PR TITLE
CL-1356 Fix events/pageChanges not emiting after first event

### DIFF
--- a/front/app/utils/analytics.ts
+++ b/front/app/utils/analytics.ts
@@ -73,7 +73,7 @@ export const bufferUntilInitialized = <T>(
   o$: Observable<T>
 ): Observable<T> => {
   return concat(
-    o$.pipe(buffer(initializeFor(destination).pipe(take(1))), mergeAll()),
+    o$.pipe(buffer(initializeFor(destination)), take(1), mergeAll()),
     o$
   );
 };

--- a/front/internals/webpack/webpack.config.js
+++ b/front/internals/webpack/webpack.config.js
@@ -159,6 +159,7 @@ const config = {
         CIRCLE_SHA1: JSON.stringify(process.env.CIRCLE_SHA1),
         CIRCLE_BRANCH: JSON.stringify(process.env.CIRCLE_BRANCH),
         GOOGLE_MAPS_API_KEY: JSON.stringify(process.env.GOOGLE_MAPS_API_KEY),
+        MATOMO_HOST: JSON.stringify(process.env.MATOMO_HOST),
       },
       CL_CONFIG: JSON.stringify(clConfig),
     }),


### PR DESCRIPTION
It appears that somehow, something has changed in the rxjs semantics, or in the timing, which broke the implementation of `bufferUntilInitialized` in `analytics`, used by various tracking destinations that depend on the cookie consent.