### PR TITLE
CL-1152 Edit custom_pages db table and model

### DIFF
--- a/back/app/models/custom_page.rb
+++ b/back/app/models/custom_page.rb
@@ -18,7 +18,7 @@
 #  banner_subheader_multiloc    :jsonb            not null
 #  top_info_section_enabled     :boolean          default(FALSE), not null
 #  top_info_section_multiloc    :jsonb            not null
-#  file_section_enabled         :boolean          default(FALSE), not null
+#  files_section_enabled        :boolean          default(FALSE), not null
 #  projects_enabled             :boolean          default(FALSE), not null
 #  projects_filter_type         :string
 #  events_widget_enabled        :boolean          default(FALSE), not null
@@ -68,6 +68,8 @@ class CustomPage < ApplicationRecord
 
   validates :top_info_section_enabled, inclusion: [true, false]
   validates :top_info_section_multiloc, multiloc: { presence: false, html: true }
+
+  validates :files_section_enabled, inclusion: [true, false]
 
   validates :projects_enabled, inclusion: [true, false]
   with_options if: -> { projects_enabled == true } do

--- a/back/app/models/custom_page.rb
+++ b/back/app/models/custom_page.rb
@@ -7,7 +7,6 @@
 #  id                           :uuid             not null, primary key
 #  title_multiloc               :jsonb            not null
 #  slug                         :string
-#  code                         :string           default("custom"), not null
 #  banner_enabled               :boolean          default(TRUE), not null
 #  banner_layout                :string           default("full_width_banner_layout"), not null
 #  banner_overlay_color         :string
@@ -19,6 +18,7 @@
 #  banner_subheader_multiloc    :jsonb            not null
 #  top_info_section_enabled     :boolean          default(FALSE), not null
 #  top_info_section_multiloc    :jsonb            not null
+#  file_section_enabled         :boolean          default(FALSE), not null
 #  projects_enabled             :boolean          default(FALSE), not null
 #  projects_filter_type         :string
 #  events_widget_enabled        :boolean          default(FALSE), not null
@@ -30,7 +30,6 @@
 #
 # Indexes
 #
-#  index_custom_pages_on_code  (code)
 #  index_custom_pages_on_slug  (slug) UNIQUE
 #
 class CustomPage < ApplicationRecord

--- a/back/app/models/custom_page.rb
+++ b/back/app/models/custom_page.rb
@@ -89,6 +89,10 @@ class CustomPage < ApplicationRecord
     end
   end
 
+  def generate_slug
+    self.slug ||= SlugService.new.generate_slug self, title_multiloc.values.first
+  end
+
   def sanitize_top_info_section_multiloc
     sanitize_info_section_multiloc(:top_info_section_multiloc)
   end

--- a/back/db/migrate/20220808135654_create_custom_pages.rb
+++ b/back/db/migrate/20220808135654_create_custom_pages.rb
@@ -19,7 +19,7 @@ class CreateCustomPages < ActiveRecord::Migration[6.1]
       t.boolean :top_info_section_enabled, default: false, null: false
       t.jsonb :top_info_section_multiloc, default: {}, null: false
 
-      t.boolean :file_section_enabled, default: false, null: false
+      t.boolean :files_section_enabled, default: false, null: false
 
       t.boolean :projects_enabled, default: false, null: false
       t.string :projects_filter_type

--- a/back/db/migrate/20220808135654_create_custom_pages.rb
+++ b/back/db/migrate/20220808135654_create_custom_pages.rb
@@ -5,7 +5,6 @@ class CreateCustomPages < ActiveRecord::Migration[6.1]
     create_table :custom_pages, id: :uuid do |t|
       t.jsonb :title_multiloc, default: {}, null: false
       t.string :slug, index: { unique: true }
-      t.string :code, default: 'custom', null: false, index: true
 
       t.boolean :banner_enabled, default: true, null: false
       t.string :banner_layout, default: 'full_width_banner_layout', null: false
@@ -19,6 +18,8 @@ class CreateCustomPages < ActiveRecord::Migration[6.1]
 
       t.boolean :top_info_section_enabled, default: false, null: false
       t.jsonb :top_info_section_multiloc, default: {}, null: false
+
+      t.boolean :file_section_enabled, default: false, null: false
 
       t.boolean :projects_enabled, default: false, null: false
       t.string :projects_filter_type

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -218,7 +218,7 @@ ActiveRecord::Schema.define(version: 2022_08_09_141825) do
     t.jsonb "banner_subheader_multiloc", default: {}, null: false
     t.boolean "top_info_section_enabled", default: false, null: false
     t.jsonb "top_info_section_multiloc", default: {}, null: false
-    t.boolean "file_section_enabled", default: false, null: false
+    t.boolean "files_section_enabled", default: false, null: false
     t.boolean "projects_enabled", default: false, null: false
     t.string "projects_filter_type"
     t.boolean "events_widget_enabled", default: false, null: false

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -207,7 +207,6 @@ ActiveRecord::Schema.define(version: 2022_08_09_141825) do
   create_table "custom_pages", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.jsonb "title_multiloc", default: {}, null: false
     t.string "slug"
-    t.string "code", default: "custom", null: false
     t.boolean "banner_enabled", default: true, null: false
     t.string "banner_layout", default: "full_width_banner_layout", null: false
     t.string "banner_overlay_color"
@@ -219,6 +218,7 @@ ActiveRecord::Schema.define(version: 2022_08_09_141825) do
     t.jsonb "banner_subheader_multiloc", default: {}, null: false
     t.boolean "top_info_section_enabled", default: false, null: false
     t.jsonb "top_info_section_multiloc", default: {}, null: false
+    t.boolean "file_section_enabled", default: false, null: false
     t.boolean "projects_enabled", default: false, null: false
     t.string "projects_filter_type"
     t.boolean "events_widget_enabled", default: false, null: false
@@ -227,7 +227,6 @@ ActiveRecord::Schema.define(version: 2022_08_09_141825) do
     t.string "header_bg"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["code"], name: "index_custom_pages_on_code"
     t.index ["slug"], name: "index_custom_pages_on_slug", unique: true
   end
 

--- a/back/spec/factories/custom_pages.rb
+++ b/back/spec/factories/custom_pages.rb
@@ -2,7 +2,6 @@
 
 FactoryBot.define do
   factory :custom_page do
-    code { 'custom' }
     title_multiloc do
       {
         'en' => 'My amazing custom page',


### PR DESCRIPTION
Making some adjustments to `static_pages` db table and model in the light of [discussions](https://citizenlabco.slack.com/archives/CQZGXTFGD/p1660400961686899).

Since the db model, migrations and related code are the only things so far added to this feature branch, I feel comfortable in rolling back 2 migrations, editing the migration and re-migrating to pick up the changes to `schema.rb`

Not dealing with removing the `code: 'custom'` from `StaticPages` atm, as I think this will break current custom `static_pages`.