### PR TITLE
Use `tty: true` again as docker logging issue was fixed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - "./back:/cl2_back"
     env_file:
       - ".env-back"
+    tty: true
     stdin_open: true
 
   que:


### PR DESCRIPTION
https://github.com/docker/compose/issues/1229#issuecomment-1112367842

Noticed and discussed here https://citizenlabco.slack.com/archives/C65GX921W/p1647876786804659

The issues without it are listed here https://citizenlabco.slack.com/archives/C65GX921W/p1648809626596629?thread_ts=1647876786.804659&cid=C65GX921W