### PR TITLE
CL-1365 Fix error when searching for projects by query and tags

### DIFF
--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -108,7 +108,7 @@ class Project < ApplicationRecord
   end)
 
   scope :with_some_topics, (proc do |topic_ids|
-    joins(:projects_topics).where(projects_topics: { topic_id: topic_ids }).distinct
+    joins(:projects_topics).where(projects_topics: { topic_id: topic_ids })
   end)
 
   scope :is_participation_context, lambda {

--- a/back/app/services/admin_publications_filtering_service.rb
+++ b/back/app/services/admin_publications_filtering_service.rb
@@ -85,4 +85,10 @@ class AdminPublicationsFilteringService
   add_filter('top_level_only') do |scope, options|
     [0, '0'].include?(options[:depth]) ? scope.where(depth: 0) : scope
   end
+
+  # Keep that as the last filter, this acts as a failsafe.
+  # If any of the filters before return duplicate admin publications, we remove them at the last step
+  add_filter('distinct') do |scope, _options|
+    scope.distinct
+  end
 end

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -356,6 +356,18 @@ resource 'AdminPublication' do
             expect(response_ids).not_to include f3.admin_publication.id
           end
 
+          example_request 'searching with query and filtering by topic', document: false do
+            topic = create(:topic)
+            project_with_topic = create(:project, topics: [topic],
+              admin_publication_attributes: { publication_status: 'published' },
+              title_multiloc: {
+                en: 'fancy title'
+              })
+            do_request search: 'fancy title', topics: [topic.id]
+            expect(response_data.size).to eq 1
+            expect(response_ids).to contain_exactly(project_with_topic.admin_publication.id)
+          end
+
           example_request 'Search param should return a project within a folder' do
             project_in_folder = create(
               :project,


### PR DESCRIPTION
Previously this would respond with an exception because the distinct in `Project#with_some_topics` and the pg_search `ORDER BY` don't play nice with each other:

```
PG::InvalidColumnReference: ERROR:  for SELECT DISTINCT, ORDER BY expressions must appear in select list
LINE 1: ...) AND "projects_topics"."topic_id" = $35 ORDER BY pg_search_...
```

We can workaround this by removing the distinct on the scope and add it to the very end of the admin publication filtering service.