### PR TITLE
[CL-1993] Improve DB query performance when fetching projects

### DIFF
--- a/back/app/models/admin_publication.rb
+++ b/back/app/models/admin_publication.rb
@@ -42,11 +42,12 @@
 #
 # Indexes
 #
-#  index_admin_publications_on_depth      (depth)
-#  index_admin_publications_on_lft        (lft)
-#  index_admin_publications_on_ordering   (ordering)
-#  index_admin_publications_on_parent_id  (parent_id)
-#  index_admin_publications_on_rgt        (rgt)
+#  index_admin_publications_on_depth                                (depth)
+#  index_admin_publications_on_lft                                  (lft)
+#  index_admin_publications_on_ordering                             (ordering)
+#  index_admin_publications_on_parent_id                            (parent_id)
+#  index_admin_publications_on_publication_type_and_publication_id  (publication_type,publication_id)
+#  index_admin_publications_on_rgt                                  (rgt)
 #
 class AdminPublication < ApplicationRecord
   PUBLICATION_STATUSES = %w[draft published archived]

--- a/back/db/migrate/20220818165037_add_admin_publication_indexes.rb
+++ b/back/db/migrate/20220818165037_add_admin_publication_indexes.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAdminPublicationIndexes < ActiveRecord::Migration[6.1]
+  def change
+    add_index(:admin_publications, %i[publication_type publication_id])
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_08_074431) do
+ActiveRecord::Schema.define(version: 2022_08_18_165037) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 2022_08_08_074431) do
     t.index ["lft"], name: "index_admin_publications_on_lft"
     t.index ["ordering"], name: "index_admin_publications_on_ordering"
     t.index ["parent_id"], name: "index_admin_publications_on_parent_id"
+    t.index ["publication_type", "publication_id"], name: "index_admin_publications_on_publication_type_and_publication_id"
     t.index ["rgt"], name: "index_admin_publications_on_rgt"
   end
 


### PR DESCRIPTION
This change adds a multi column index on `admin_publications.publication_type` and `admin_publications.publication_id`, which according AWS RDS Performance insights is the top most query that takes CPU time.

It makes sense, because we execute this query whenever we want to fetch the folder / project that belongs to an admin publication (and this query happens very often, in the BE as well as in the FE).

The query looks like this:

```
SELECT "projects"."id" FROM "projects" LEFT OUTER JOIN "admin_publications" ON "admin_publications"."publication_type" = $1 AND "admin_publications"."publication_id" = "projects"."id" WHERE ("admin_publications"."publication_status" != $2 AND ("projects"."visible_to" = $3 OR "projects"."id" IN (SELECT DISTINCT "groups_projects"."project_id" FROM "groups_projects" WHERE "groups_projects"."project_id" IN (SELECT "projects"."id" FROM "projects") AND "groups_projects"."group_id" IN (SELECT "groups"...
```

The query itself is huge, but making the join fast is a first step.

The index will also speed up queries that look for only projects / folders (e.g. when counting them), which is a nice benefit too. 