### PR TITLE
[CL-1308] Use the same nav_bar_item_title attr name for write as for read

### DIFF
--- a/back/app/controllers/web_api/v1/static_pages_controller.rb
+++ b/back/app/controllers/web_api/v1/static_pages_controller.rb
@@ -21,7 +21,8 @@ class WebApi::V1::StaticPagesController < ::ApplicationController
   end
 
   def create
-    @page = StaticPage.new permitted_attributes(StaticPage)
+    @page = StaticPage.new
+    assign_attributes
     authorize @page
 
     SideFxStaticPageService.new.before_create @page, current_user
@@ -37,7 +38,7 @@ class WebApi::V1::StaticPagesController < ::ApplicationController
   end
 
   def update
-    assign_attributes_for_update
+    assign_attributes
     authorize @page
 
     SideFxStaticPageService.new.before_update @page, current_user
@@ -62,7 +63,7 @@ class WebApi::V1::StaticPagesController < ::ApplicationController
 
   private
 
-  def assign_attributes_for_update
+  def assign_attributes
     @page.assign_attributes permitted_attributes(StaticPage)
   end
 

--- a/back/app/serializers/web_api/v1/static_page_serializer.rb
+++ b/back/app/serializers/web_api/v1/static_page_serializer.rb
@@ -12,6 +12,8 @@ class WebApi::V1::StaticPageSerializer < WebApi::V1::BaseSerializer
   # title. That way, the frontend can know what the title
   # will be when the page would be added to the navbar (and
   # show this in the list of items to add).
+  # See also back/engines/commercial/customizable_navbar/app/controllers/customizable_navbar/web_api/v1/patches/static_pages_controller.rb
+  # #assign_attributes
   attribute :nav_bar_item_title_multiloc do |object|
     current_navbaritem_title = object.nav_bar_item&.title_multiloc_with_fallback
     current_navbaritem_title || NavBarItem.new(code: 'custom', static_page: object).title_multiloc_with_fallback

--- a/back/engines/commercial/customizable_navbar/app/controllers/customizable_navbar/web_api/v1/patches/static_pages_controller.rb
+++ b/back/engines/commercial/customizable_navbar/app/controllers/customizable_navbar/web_api/v1/patches/static_pages_controller.rb
@@ -7,10 +7,14 @@ module CustomizableNavbar
         module StaticPagesController
           private
 
-          def assign_attributes_for_update
+          # See also back/app/serializers/web_api/v1/static_page_serializer.rb
+          # `attribute :nav_bar_item_title_multiloc`
+          def assign_attributes
             attributes = permitted_attributes(StaticPage).to_h
-            if attributes[:nav_bar_item_attributes].present?
+            if (nav_bar_item_title = attributes.delete(:nav_bar_item_title_multiloc)).present?
+              attributes[:nav_bar_item_attributes] ||= {}
               attributes[:nav_bar_item_attributes][:id] = @page.nav_bar_item_id
+              attributes[:nav_bar_item_attributes][:title_multiloc] = nav_bar_item_title
             end
             @page.assign_attributes attributes
           end

--- a/back/engines/commercial/customizable_navbar/app/policies/customizable_navbar/patches/static_page_policy.rb
+++ b/back/engines/commercial/customizable_navbar/app/policies/customizable_navbar/patches/static_page_policy.rb
@@ -5,7 +5,7 @@ module CustomizableNavbar
     module StaticPagePolicy
       def permitted_attributes
         super.tap do |attributes|
-          attributes.push nav_bar_item_attributes: [title_multiloc: CL2_SUPPORTED_LOCALES]
+          attributes.push nav_bar_item_title_multiloc: CL2_SUPPORTED_LOCALES
         end
       end
     end

--- a/back/engines/commercial/customizable_navbar/spec/acceptance/static_pages_spec.rb
+++ b/back/engines/commercial/customizable_navbar/spec/acceptance/static_pages_spec.rb
@@ -19,10 +19,9 @@ resource 'StaticPages' do
         parameter :title_multiloc, 'The title of the page, as a multiloc string', required: true
         parameter :body_multiloc, 'The content of the page, as a multiloc HTML string', required: true
         parameter :slug, 'The unique slug of the page. If not given, it will be auto generated'
+        parameter :nav_bar_item_title_multiloc, 'The title of the corresponding NavBarItem'
       end
-      with_options scope: %i[static_page nav_bar_item_attributes] do
-        parameter :title_multiloc, 'The title of the corresponding NavBarItem'
-      end
+
       ValidationErrorHelper.new.error_fields self, StaticPage
       ValidationErrorHelper.new.error_fields self, NavBarItem
 
@@ -34,7 +33,7 @@ resource 'StaticPages' do
           static_page: {
             title_multiloc: page.title_multiloc,
             body_multiloc: page.body_multiloc,
-            nav_bar_item_attributes: { title_multiloc: item_title_multiloc }
+            nav_bar_item_title_multiloc: item_title_multiloc
           }
         )
         expect(response_status).to eq 201
@@ -48,10 +47,9 @@ resource 'StaticPages' do
         parameter :title_multiloc, 'The title of the static page, as a multiloc string'
         parameter :body_multiloc, 'The content of the static page, as a multiloc HTML string'
         parameter :slug, 'The unique slug of the static page'
+        parameter :nav_bar_item_title_multiloc, 'The title of the corresponding NavBarItem'
       end
-      with_options scope: %i[static_page nav_bar_item_attributes] do
-        parameter :title_multiloc, 'The title of the corresponding NavBarItem'
-      end
+
       ValidationErrorHelper.new.error_fields self, StaticPage
       ValidationErrorHelper.new.error_fields self, NavBarItem
 
@@ -62,7 +60,7 @@ resource 'StaticPages' do
         title_multiloc = { 'en' => 'Awesome item' }
         item = create :nav_bar_item, static_page: page
 
-        do_request(static_page: { nav_bar_item_attributes: { title_multiloc: title_multiloc } })
+        do_request(static_page: { nav_bar_item_title_multiloc: title_multiloc })
         assert_status 200
         expect(item.reload.title_multiloc).to match title_multiloc
       end
@@ -70,7 +68,7 @@ resource 'StaticPages' do
       example 'Update the NavBarItem title of a static page with no NavBarItem' do
         title_multiloc = { 'en' => 'Awesome item' }
         page.nav_bar_item&.destroy!
-        do_request(static_page: { nav_bar_item_attributes: { title_multiloc: title_multiloc } })
+        do_request(static_page: { nav_bar_item_title_multiloc: title_multiloc })
         assert_status 200
       end
 
@@ -78,7 +76,7 @@ resource 'StaticPages' do
         title_multiloc = { 'en' => 42 }
         create :nav_bar_item, static_page: page
 
-        do_request(static_page: { nav_bar_item_attributes: { title_multiloc: title_multiloc } })
+        do_request(static_page: { nav_bar_item_title_multiloc: title_multiloc })
         assert_status 422
       end
     end

--- a/front/app/services/pages.ts
+++ b/front/app/services/pages.ts
@@ -127,14 +127,14 @@ export function pageBySlugStream(
 }
 
 export function createPage(pageData: IPageCreate) {
-  return streams.add<IPage>(`${apiEndpoint}`, pageData);
+  return streams.add<IPage>(`${apiEndpoint}`, { static_page: pageData });
 }
 
 export async function updatePage(pageId: string, pageData: IPageUpdate) {
   const response = await streams.update<IPage>(
     `${apiEndpoint}/${pageId}`,
     pageId,
-    pageData
+    { static_page: pageData }
   );
 
   await streams.fetchAllWith({


### PR DESCRIPTION
I'm currently refactoring the pages on the FE, and this change will solve one new bug and simplify some FE code.

1. Now we handle the `nav_bar_item_title_multiloc` logic completely on the BE. Before, the BE returned `nav_bar_item_title_multiloc` in the serializer, but expected to get `nav_bar_item_attributes: { title_multiloc: value }` in the `#update` request. So, the FE doesn't need to know anything about `nav_bar_item_attributes`.
2. Now the BE expects to get attributes without the `static_page` scope in the `#update` method. The same way as the FE sends it.