### PR TITLE
[No ticket] Upgrade json gem to 2.6.2

### DIFF
--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -719,7 +719,7 @@ GEM
     interception (0.5)
     intercom (4.1.3)
     jmespath (1.6.1)
-    json (2.6.1)
+    json (2.6.2)
     json-jwt (1.13.0)
       activesupport (>= 4.2)
       aes_key_wrap


### PR DESCRIPTION
This helps me with an error I'm getting when bundling the Gemfile locally to execute Rubocop in my editor:

Changes seem to be minor in the parser: https://my.diffend.io/gems/json/2.6.1/2.6.2

```
/home/ntraum/.asdf/installs/ruby/2.7.6/lib/ruby/gems/2.7.0/gems/bundler-2.3.20/lib/bundler/runtime.rb:308:in `check_for_activated_spec!': You have already activated json 2.6.2, but your Gemfile requires json 2.6.1. Prepending `bundle exec` to your command may solve this. (Gem::LoadError)
```