### PR TITLE
[No ticket] Upgrade to api-pagination 5

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -105,7 +105,7 @@ gem 'carrierwave', git: 'https://github.com/carrierwaveuploader/carrierwave.git'
 gem 'carrierwave-base64', '~> 2.10'
 gem 'fog-aws', '~> 3.12'
 
-gem 'api-pagination', '~> 4.8.2'
+gem 'api-pagination', '~> 5.0.0'
 gem 'kaminari', '~> 1.2'
 gem 'rails-i18n', '~> 6.0.0'
 gem 'awesome_nested_set', '~> 3.5.0'

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -530,7 +530,7 @@ GEM
     annotate (3.2.0)
       activerecord (>= 3.2, < 8.0)
       rake (>= 10.4, < 14.0)
-    api-pagination (4.8.2)
+    api-pagination (5.0.0)
     ast (2.4.2)
     attr_required (1.0.1)
     awesome_nested_set (3.5.0)
@@ -1144,7 +1144,7 @@ DEPENDENCIES
   acts_as_list (~> 1.0)
   admin_api!
   annotate
-  api-pagination (~> 4.8.2)
+  api-pagination (~> 5.0.0)
   awesome_nested_set (~> 3.5.0)
   aws-sdk-s3 (~> 1)
   axlsx (= 3.0.0.pre)


### PR DESCRIPTION
Even though this is a major version upgrade, there are no breaking changes for us:

> 5.0.0
> This release fixes issues with using newer versions of Pagy, due to them renaming Pagy::VARS to Pagy::DEFAULT. Consequently, support for older versions of Pagy is dropped.

 See https://github.com/davidcelis/api-pagination/releases for details.
