### PR TITLE
CL-1505 Set input slug when there is no current context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Next
+
+### Fixed
+- [CL-1505] Posting ideas when there is no current phase
+
 ## 2022-08-23
 
 ### Added

--- a/back/lib/factory.rb
+++ b/back/lib/factory.rb
@@ -8,7 +8,7 @@ class Factory
 
   def participation_method_for(project)
     participation_context = ::ParticipationContextService.new.get_participation_context(project)
-    return ::ParticipationMethod::None.new unless participation_context
+    return ::ParticipationMethod::Ideation.new(project) unless participation_context
 
     participation_method = participation_context.participation_method
     method_class = case participation_method

--- a/back/spec/lib/factory_spec.rb
+++ b/back/spec/lib/factory_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Factory do
       let(:project) { create :project_with_past_phases }
 
       it 'returns an instance of ParticipationMethod::None' do
-        expect(participation_method).to be_an_instance_of(ParticipationMethod::None)
+        expect(participation_method).to be_an_instance_of(ParticipationMethod::Ideation)
       end
     end
 

--- a/back/spec/models/idea_spec.rb
+++ b/back/spec/models/idea_spec.rb
@@ -71,6 +71,20 @@ RSpec.describe Idea, type: :model do
       idea = create(:idea, slug: nil)
       expect(idea.slug).to be_present
     end
+
+    it 'should generate a slug when there is no current phase' do
+      project = create :project, process_type: 'timeline'
+      create :phase, project: project, start_at: (Time.zone.today - 10), end_at: (Time.zone.today - 5)
+      create :phase, project: project, start_at: (Time.zone.today + 5), end_at: (Time.zone.today + 10)
+      idea = create :idea, slug: nil, project: project.reload
+      expect(idea.slug).to be_present
+    end
+
+    it 'should generate a slug for a timeline project with no phases' do
+      project = create :project, process_type: 'timeline'
+      idea = create :idea, slug: nil, project: project
+      expect(idea.slug).to be_present
+    end
   end
 
   context 'feedback_needed' do


### PR DESCRIPTION
The issue was introduced during a release last week, where we did a significant refactoring. It turns out that it's possible for admins to post ideas when there is no current phase, even when you have a timeline project without phases. The issue was the the slug would not be generated and set in this cases, making it impossible to view the ideas.

After releasing we need to fix existing data:
```
Idea.where(slug: nil).map{|i| i.update_column(:slug, SlugService.new.generate_slug(i, MultilocService.new.t(i.title_multiloc)))} 
```

Jira: https://citizenlab.atlassian.net/browse/CL-1505

## How urgent is a code review?

This bug is considered urgent (it would be nice to merge it today), as it can happen that ideas are created that cannot be visited.