### PR TITLE
CL-1509 Bulk idea import with special date cells

### DIFF
--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/import_ideas_service.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/import_ideas_service.rb
@@ -156,6 +156,11 @@ module BulkImportIdeas
     def add_published_at(idea_row, idea_attributes)
       return if idea_row[:published_at].blank?
 
+      if idea_row[:published_at].acts_like? :date
+        idea_attributes[:published_at] = idea_row[:published_at]
+        return
+      end
+
       published_at = nil
       invalid_date_error = Error.new(
         'bulk_import_ideas_publication_date_invalid_format',

--- a/back/engines/commercial/bulk_import_ideas/spec/services/import_ideas_service_spec.rb
+++ b/back/engines/commercial/bulk_import_ideas/spec/services/import_ideas_service_spec.rb
@@ -66,6 +66,28 @@ describe BulkImportIdeas::ImportIdeasService do
       expect(idea.publication_status).to eq 'published'
     end
 
+    it 'imports ideas with special date cells' do
+      create :user, email: 'userimport@citizenlab.co'
+      create :project, title_multiloc: { 'en' => 'Project title' }
+
+      idea_rows = [
+        {
+          title_multiloc: { 'en' => 'My idea title' },
+          body_multiloc: { 'en' => 'My idea description' },
+          project_title: 'Project title',
+          user_email: 'userimport@citizenlab.co',
+          published_at: Time.zone.today
+        }
+      ]
+
+      service.import_ideas idea_rows
+
+      expect(Idea.count).to eq 1
+      idea = Idea.first
+      expect(idea.published_at).to eq Time.zone.today
+      expect(idea.publication_status).to eq 'published'
+    end
+
     it 'imports ideas with location info' do
       create :user, email: 'userimport@citizenlab.co'
       create :project, title_multiloc: { 'en' => 'Project title' }


### PR DESCRIPTION
An idea bulk import recently failed, because the date cells have some special format. The code that loads the XLSX file is clever enough to automatically convert these cells to Date or DateTime instances, but some code assumed that the values would be strings, resulting in a 500 error. This change makes it possible to deal with these special date cells. I also tested this locally with the sheet Amanda provided.


Product issue: https://citizenlabco.slack.com/archives/C01J9DHRJTE/p1661272932175069
Jira ticket: https://citizenlab.atlassian.net/browse/CL-1509

Not too urgent, since the workaround solution is to convert those cells to normal cells.