### PR TITLE
Make nav bar item validation only work on existing page

### DIFF
--- a/front/app/components/PageForm/index.tsx
+++ b/front/app/components/PageForm/index.tsx
@@ -42,7 +42,7 @@ import usePage from 'hooks/usePage';
 import useAppConfiguration from 'hooks/useAppConfiguration';
 
 export interface FormValues {
-  nav_bar_item_title_multiloc: Multiloc;
+  nav_bar_item_title_multiloc?: Multiloc;
   title_multiloc: Multiloc;
   body_multiloc: Multiloc;
   slug?: string;
@@ -67,14 +67,23 @@ const PageForm = ({
   const page = usePage({ pageId });
   const appConfig = useAppConfiguration();
 
-  const schema = object({
-    nav_bar_item_title_multiloc: validateMultiloc(
-      formatMessage(messages.blankTitleError)
-    ),
+  const multilocFields = {
     title_multiloc: validateMultiloc(formatMessage(messages.blankTitleError)),
     body_multiloc: validateMultiloc(
       formatMessage(messages.blankDescriptionError)
     ),
+  };
+
+  // If we're creating a new page, there is no pageId
+  // And also no slug field yet.
+  if (pageId) {
+    multilocFields['nav_bar_item_title_multiloc'] = validateMultiloc(
+      formatMessage(messages.blankTitleError)
+    );
+  }
+
+  const schema = object({
+    ...multilocFields,
     ...(!hideSlugInput && {
       slug: string()
         .matches(slugRexEx, formatMessage(messages.slugRegexError))

--- a/front/app/components/PageForm/index.tsx
+++ b/front/app/components/PageForm/index.tsx
@@ -67,23 +67,18 @@ const PageForm = ({
   const page = usePage({ pageId });
   const appConfig = useAppConfiguration();
 
-  const multilocFieldsValidation = {
+  const schema = object({
     title_multiloc: validateMultiloc(formatMessage(messages.blankTitleError)),
     body_multiloc: validateMultiloc(
       formatMessage(messages.blankDescriptionError)
     ),
-  };
-
-  // If we're creating a new page, there is no pageId
-  // And also no slug field yet.
-  if (pageId) {
-    multilocFieldsValidation['nav_bar_item_title_multiloc'] = validateMultiloc(
-      formatMessage(messages.blankTitleError)
-    );
-  }
-
-  const schema = object({
-    ...multilocFieldsValidation,
+    ...(pageId &&
+      !isNilOrError(page) &&
+      page.relationships.nav_bar_item.data && {
+        nav_bar_item_title_multiloc: validateMultiloc(
+          formatMessage(messages.blankTitleError)
+        ),
+      }),
     ...(!hideSlugInput && {
       slug: string()
         .matches(slugRexEx, formatMessage(messages.slugRegexError))

--- a/front/app/components/PageForm/index.tsx
+++ b/front/app/components/PageForm/index.tsx
@@ -67,7 +67,7 @@ const PageForm = ({
   const page = usePage({ pageId });
   const appConfig = useAppConfiguration();
 
-  const multilocFields = {
+  const multilocFieldsValidation = {
     title_multiloc: validateMultiloc(formatMessage(messages.blankTitleError)),
     body_multiloc: validateMultiloc(
       formatMessage(messages.blankDescriptionError)
@@ -77,13 +77,13 @@ const PageForm = ({
   // If we're creating a new page, there is no pageId
   // And also no slug field yet.
   if (pageId) {
-    multilocFields['nav_bar_item_title_multiloc'] = validateMultiloc(
+    multilocFieldsValidation['nav_bar_item_title_multiloc'] = validateMultiloc(
       formatMessage(messages.blankTitleError)
     );
   }
 
   const schema = object({
-    ...multilocFields,
+    ...multilocFieldsValidation,
     ...(!hideSlugInput && {
       slug: string()
         .matches(slugRexEx, formatMessage(messages.slugRegexError))

--- a/front/app/containers/Admin/pages/EditPageForm.tsx
+++ b/front/app/containers/Admin/pages/EditPageForm.tsx
@@ -37,7 +37,7 @@ const EditPageForm = ({ params: { pageId } }: WithRouterProps) => {
     resourceId: !isNilOrError(page) ? page.id : null,
   });
   const getInitialValues = (page: IPageData, remotePageFiles: RemoteFiles) => ({
-    nav_bar_item_title_multiloc: page.attributes.nav_bar_item_title_multiloc,
+    nav_bar_item_title_multiloc: undefined,
     title_multiloc: page.attributes.title_multiloc,
     body_multiloc: page.attributes.body_multiloc,
     slug: page.attributes.slug,

--- a/front/app/containers/Admin/pagesAndMenu/containers/EditPageForm/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/EditPageForm/index.tsx
@@ -89,10 +89,12 @@ const EditPageForm = ({ intl: { formatMessage } }: InjectedIntlProps) => {
           pageId={pageId}
           onSubmit={handleSubmit}
           defaultValues={{
-            nav_bar_item_title_multiloc: truncateMultiloc(
-              page.attributes.nav_bar_item_title_multiloc,
-              MAX_TITLE_LENGTH
-            ),
+            nav_bar_item_title_multiloc: page.relationships.nav_bar_item.data
+              ? truncateMultiloc(
+                  page.attributes.nav_bar_item_title_multiloc,
+                  MAX_TITLE_LENGTH
+                )
+              : undefined,
             title_multiloc: page.attributes.title_multiloc,
             body_multiloc: page.attributes.body_multiloc,
             slug: page.attributes.slug,

--- a/front/app/modules/commercial/customizable_navbar/admin/components/NavbarTitleField.tsx
+++ b/front/app/modules/commercial/customizable_navbar/admin/components/NavbarTitleField.tsx
@@ -18,7 +18,13 @@ const NavbarTitleField = ({
 }: Props & InjectedIntlProps) => {
   const page = usePage({ pageId });
 
-  if (isNilOrError(page) || isPolicyPageSlug(page.attributes.slug)) {
+  if (
+    isNilOrError(page) ||
+    isPolicyPageSlug(page.attributes.slug) ||
+    // If item is not in the navbar, we don't show the field to update the nav bar title.
+    // If a page is not in the navbar, the backend removes the nav_bar_item relationship.
+    (!isNilOrError(page) && page.relationships.nav_bar_item.data)
+  ) {
     return null;
   }
 

--- a/front/app/modules/commercial/customizable_navbar/admin/components/NavbarTitleField.tsx
+++ b/front/app/modules/commercial/customizable_navbar/admin/components/NavbarTitleField.tsx
@@ -23,7 +23,7 @@ const NavbarTitleField = ({
     isPolicyPageSlug(page.attributes.slug) ||
     // If item is not in the navbar, we don't show the field to update the nav bar title.
     // If a page is not in the navbar, the backend removes the nav_bar_item relationship.
-    (!isNilOrError(page) && page.relationships.nav_bar_item.data)
+    (!isNilOrError(page) && !page.relationships.nav_bar_item.data)
   ) {
     return null;
   }

--- a/front/app/services/pages.ts
+++ b/front/app/services/pages.ts
@@ -93,12 +93,10 @@ interface IPageCreate {
 }
 
 export interface IPageUpdate {
+  nav_bar_item_title_multiloc: Multiloc;
   title_multiloc?: Multiloc;
   body_multiloc?: Multiloc;
   slug?: string;
-  nav_bar_item_attributes?: {
-    title_multiloc?: Multiloc;
-  };
 }
 
 export interface IPage {


### PR DESCRIPTION
Is it correct that we can't add a slug when creating a new page? Then this should work.

I also don't want to spend too much time on this, because it's unclear what will happen with this page with i2.

Tagging @IvaKop to see if this is okay. Not familiar with the forms yet. We're trying to resolve the issue [here](https://github.com/CitizenLabDotCo/citizenlab/pull/2555#issuecomment-1225679812).