### PR TITLE
Fix Rails cache containing whole records instead of primitive data

### DIFF
--- a/back/app/services/avatars_service.rb
+++ b/back/app/services/avatars_service.rb
@@ -1,59 +1,105 @@
 # frozen_string_literal: true
 
+# Provides avatars and total participation numbers for projects, groups, posts, ideas and other records based on their
+# participants.
 class AvatarsService
   def initialize(participants_service = ParticipantsService.new)
     @participants_service = participants_service
   end
 
+  # Returns a hash containing a list of users with avatars for a project and the total number of participants.
+  # @param project[Project] The project for which avatars of its paticipants should be fetched
+  # @param users[ActiveRecord::Relation] Scope of users to be filtered for avatars
+  # @param limit[Integer] Limit the number of users returned. Does not affect the total count
+  # @return [Hash] A hash containing the users with avatars and total count of participants
   def avatars_for_project(project, users: User.active, limit: 5)
-    Rails.cache.fetch("#{project.cache_key}/avatars", expires_in: 1.day) do
+    user_ids_and_count = Rails.cache.fetch("#{project.cache_key}/user_avatars", expires_in: 1.day) do
       participants = @participants_service.project_participants(project)
-      add_count(users.merge(participants), limit)
+      user_ids_and_count(participants, limit)
     end
+    users_and_count(user_ids_and_count)
   end
 
+  # Returns a hash containing a list of users with avatars for a group and the total member count.
+  # @param group[Group] The group for which avatars of its members should be fetched
+  # @param users[ActiveRecord::Relation] Scope of users to be filtered for avatars
+  # @param limit[Integer] Limit the number of users returned. Does not affect the total count
+  # @return [Hash] A hash containing the users with avatars and total count of participants
   def avatars_for_group(group, users: User.active, limit: 5)
-    Rails.cache.fetch("#{group.cache_key}/avatars", expires_in: 1.day) do
+    user_ids_and_count = Rails.cache.fetch("#{group.cache_key}/user_avatars", expires_in: 1.day) do
       users_in_group = users.merge(group.members)
-      add_count(users_in_group, limit)
+      user_ids_and_count(users_in_group, limit)
     end
+    users_and_count(user_ids_and_count)
   end
 
+  # Returns a hash containing a list of users with avatars for a post and the total member count.
+  # @param post[Post] The group for which avatars of its members should be fetched
+  # @param post_type
+  # @param users[ActiveRecord::Relation] Scope of users to be filtered for avatars
+  # @param limit[Integer] Limit the number of users returned. Does not affect the total count
+  # @return [Hash] A hash containing the users with avatars and total count of participants
   def avatars_for_post(post, post_type, users: User.active, limit: 5)
-    Rails.cache.fetch("#{post.cache_key}/avatars", expires_in: 1.day) do
+    user_ids_and_count = Rails.cache.fetch("#{post.cache_key}/user_avatars", expires_in: 1.day) do
       commenters = users.joins(:comments).where(comments: { post_id: post.id, post_type: post_type, publication_status: 'published' })
       users_for_post = users.where(id: post.author).or(users.where(id: commenters))
-      add_count(users_for_post, limit)
+      user_ids_and_count(users_for_post, limit)
     end
+    users_and_count(user_ids_and_count)
   end
 
+  # Returns a hash containing a list of users with avatars for an idea and the total member count.
+  # @param idea[Idea] The group for which avatars of its members should be fetched
+  # @param users[ActiveRecord::Relation] Scope of users to be filtered for avatars
+  # @param limit[Integer] Limit the number of users returned. Does not affect the total count
+  # @return [Hash] A hash containing the users with avatars and total count of participants
   def avatars_for_idea(idea, users: User.active, limit: 5)
     avatars_for_post idea, 'Idea', users: users, limit: limit
   end
 
+  # Returns a hash containing a list of users with avatars for an initiative and the total member count.
+  # @param initiative[Initiative] The group for which avatars of its members should be fetched
+  # @param users[ActiveRecord::Relation] Scope of users to be filtered for avatars
+  # @param limit[Integer] Limit the number of users returned. Does not affect the total count
+  # @return [Hash] A hash containing the users with avatars and total count of participants
   def avatars_for_initiative(initiative, users: User.active, limit: 5)
     avatars_for_post initiative, 'Initiative', users: users, limit: limit
   end
 
+  # Returns a hash containing a list of users with avatars
+  # @param users[ActiveRecord::Relation] Scope of users to be filtered for avatars
+  # @param limit[Integer] Limit the number of users returned. Does not affect the total count
+  # @return [Hash] A hash containing the users with avatars and total count of participants
   def some_avatars(users: User.active, limit: 5)
-    Rails.cache.fetch(users, expires_in: 1.day) do
-      add_count(users, limit)
+    user_ids_and_count = Rails.cache.fetch("#{users.cache_key}/user_avatars", expires_in: 1.day) do
+      user_ids_and_count(users, limit)
     end
+    users_and_count(user_ids_and_count)
   end
 
   private
 
-  def add_count(users, limit)
+  # Given a hash of user ids and count, returns a hash of users and the count.
+  def users_and_count(user_ids_and_count)
     {
-      users: with_avatars(users, limit).load,
-      total_count: users.size
+      users: User.where(id: [user_ids_and_count.fetch(:user_ids)]),
+      total_count: user_ids_and_count.fetch(:total_count)
     }
   end
 
-  def with_avatars(users, limit)
+  # Returns the user ids of users with avatars and the total count of users (with and without avatars!)
+  # Suitable for caching
+  def user_ids_and_count(users, limit)
+    {
+      user_ids: users_with_avatars(users).limit(limit).pluck(:id),
+      total_count: users.count
+    }
+  end
+
+  # Returns random users who have avatars
+  def users_with_avatars(users)
     users
       .where.not(avatar: nil)
-      .limit(limit)
       .order(Arel.sql('random()'))
   end
 end

--- a/back/app/services/participants_service.rb
+++ b/back/app/services/participants_service.rb
@@ -86,10 +86,15 @@ class ParticipantsService
     participants
   end
 
+  # Returns the participants of a project.
+  # @param project[Project]
+  # @param options[Hash]
+  # @return[ActiveRecord::Relation] List of users that participated in the project
   def project_participants(project, options = {})
-    Rails.cache.fetch("#{project.cache_key}/participants", expires_in: 1.day) do
-      projects_participants [project], options
+    participant_ids = Rails.cache.fetch("#{project.cache_key}/participant_ids", expires_in: 1.day) do
+      projects_participants([project], options).pluck(:id)
     end
+    User.where(id: participant_ids)
   end
 
   def projects_participants(projects, options = {})


### PR DESCRIPTION
which fixes a bug that can be experienced in development mode when enabling caching via `rails dev:cache`. See https://github.com/rails/rails/issues/43856 for details. Suddenly lots of endpoints start erroring with `TypeError`s as soon as you perform any code changes.

As stated in the Rails docs, the low level Rails cache should only contain primitive data structures and not whole ActiveRecord objects:

> 1.7.1 Avoid caching instances of Active Record objects
> You should avoid this pattern. Why? Because the instance could change. In production, attributes on it could differ, or the record could be deleted. And in development, it works unreliably with cache stores that reload code when you make changes.
>
> Instead, cache the ID or some other primitive data type. [...]

https://guides.rubyonrails.org/caching_with_rails.html#avoid-caching-instances-of-active-record-objects

This commit follows through with this suggestion. Where we before saved whole records in the cache, we now only cache their IDs and fetch the records from database right after so that the API of the affected methods stay the same.

The cache keys have also been changed slightly so we are not running into the issue of fetching old cache data (with whole records) where the new application code expects IDs already.
