### PR TITLE
[CL-1393] Cache smart group queries

### DIFF
--- a/back/engines/commercial/smart_groups/app/lib/smart_groups/rules/custom_field_rule.rb
+++ b/back/engines/commercial/smart_groups/app/lib/smart_groups/rules/custom_field_rule.rb
@@ -30,6 +30,11 @@ module SmartGroups::Rules
       end
     end
 
+    # All custom field filter queries access the `users` table only, so we can cache it.
+    def cachable_by_users_scope?
+      true
+    end
+
     def as_json
       json = {
         'ruleType' => rule_type,

--- a/back/engines/commercial/smart_groups/app/lib/smart_groups/rules/email.rb
+++ b/back/engines/commercial/smart_groups/app/lib/smart_groups/rules/email.rb
@@ -50,6 +50,11 @@ module SmartGroups::Rules
       self.value = value
     end
 
+    # The result of the `filter` query depends on the `users` table only, so the query can be cached.
+    def cachable_by_users_scope?
+      true
+    end
+
     def filter(users_scope)
       case predicate
       when 'is'

--- a/back/engines/commercial/smart_groups/app/lib/smart_groups/rules/lives_in.rb
+++ b/back/engines/commercial/smart_groups/app/lib/smart_groups/rules/lives_in.rb
@@ -92,6 +92,11 @@ module SmartGroups::Rules
       self.value = value
     end
 
+    # The result of the `filter` query depends on the `users` table only, so the query can be cached.
+    def cachable_by_users_scope?
+      true
+    end
+
     def filter(users_scope)
       case predicate
       when 'has_value'

--- a/back/engines/commercial/smart_groups/app/lib/smart_groups/rules/participated_in_idea_status.rb
+++ b/back/engines/commercial/smart_groups/app/lib/smart_groups/rules/participated_in_idea_status.rb
@@ -77,6 +77,11 @@ module SmartGroups::Rules
       self.value = value
     end
 
+    # The filter queries more than just the `users` table, so we cannot cache the result via the users scope.
+    def cachable_by_users_scope?
+      false
+    end
+
     def multivalue_predicate?
       MULTIVALUE_PREDICATES.include? predicate
     end

--- a/back/engines/commercial/smart_groups/app/lib/smart_groups/rules/participated_in_project.rb
+++ b/back/engines/commercial/smart_groups/app/lib/smart_groups/rules/participated_in_project.rb
@@ -77,6 +77,11 @@ module SmartGroups::Rules
       self.value = value
     end
 
+    # The filter queries more than just the `users` table, so we cannot cache the result via the users scope.
+    def cachable_by_users_scope?
+      false
+    end
+
     def multivalue_predicate?
       MULTIVALUE_PREDICATES.include? predicate
     end

--- a/back/engines/commercial/smart_groups/app/lib/smart_groups/rules/participated_in_topic.rb
+++ b/back/engines/commercial/smart_groups/app/lib/smart_groups/rules/participated_in_topic.rb
@@ -77,6 +77,11 @@ module SmartGroups::Rules
       self.value = value
     end
 
+    # The filter queries more than just the `users` table, so we cannot cache the result via the users scope.
+    def cachable_by_users_scope?
+      false
+    end
+
     def multivalue_predicate?
       MULTIVALUE_PREDICATES.include? predicate
     end

--- a/back/engines/commercial/smart_groups/app/lib/smart_groups/rules/registration_completed_at.rb
+++ b/back/engines/commercial/smart_groups/app/lib/smart_groups/rules/registration_completed_at.rb
@@ -68,6 +68,11 @@ module SmartGroups::Rules
       self.value = value
     end
 
+    # The result of the `filter` query depends on the `users` table only, so the query can be cached.
+    def cachable_by_users_scope?
+      true
+    end
+
     def filter(users_scope)
       case predicate
       when 'is_before'

--- a/back/engines/commercial/smart_groups/app/lib/smart_groups/rules/role.rb
+++ b/back/engines/commercial/smart_groups/app/lib/smart_groups/rules/role.rb
@@ -49,6 +49,11 @@ module SmartGroups::Rules
       self.predicate = predicate
     end
 
+    # The result of the `filter` query depends on the `users` table only, so the query can be cached.
+    def cachable_by_users_scope?
+      true
+    end
+
     def filter(users_scope)
       case predicate
       when 'is_admin'

--- a/back/engines/commercial/smart_groups/app/services/smart_groups/rules_service.rb
+++ b/back/engines/commercial/smart_groups/app/services/smart_groups/rules_service.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'digest'
+
 module SmartGroups
   class RulesService
     include RulableService
@@ -39,16 +41,41 @@ module SmartGroups
       }
     }.freeze
 
-    # Returns all the smart groupts the user is a member of. Accepts an
+    # Returns all the smart groups the user is a member of. Accepts an
     # optional `groups` scope to limit the groups to search in. This method
     # is very carefully written to do it all in 2 queries, so beware when
-    # editing
+    # editing.
+    # In case the groups are all easily cachable by the passed users and groups
+    # scope, we will do so.
     def groups_for_user(user, groups = ::Group.rules)
       # We're using `id: [user.id]` instead of `id: user.id` to
       # workaround this rails/arel issue:
       # https://github.com/rails/rails/issues/20077
       user_relation_object = ::User.where(id: [user.id])
-      groups_in_common_for_users(user_relation_object, groups)
+
+      cache_enabled = all_rules_cachable_by_users_scope?(groups)
+
+      if cache_enabled
+        puts '##################### CACHING ENABLED'
+        puts '##################### CACHING ENABLED'
+        puts '##################### CACHING ENABLED'
+        puts '##################### CACHING ENABLED'
+        puts '##################### CACHING ENABLED'
+        cache_key = calculate_cache_key(user_relation_object, groups)
+        group_ids = Rails.cache.fetch(cache_key) do
+          puts '################## CACHE WRITE'
+          puts '################## CACHE WRITE'
+          puts '################## CACHE WRITE'
+          puts '################## CACHE WRITE'
+          puts '################## CACHE WRITE'
+          puts '################## CACHE WRITE'
+          groups_in_common_for_users(user_relation_object, groups).pluck(:id)
+        end
+        groups.where(id: group_ids)
+      else
+        puts '################# CACHE DISABLED'
+        groups_in_common_for_users(user_relation_object, groups)
+      end
     end
 
     def filter(users_scope, group_json_rules)
@@ -100,6 +127,23 @@ module SmartGroups
     def group_if_users_included(users, group)
       ::Group.where(id: group.id)
         .where(filter(users, group.rules).arel.exists)
+    end
+
+    # Returns true if all rules of all groups are cachable by the users scope.
+    # @return [Boolean]
+    def all_rules_cachable_by_users_scope?(groups)
+      all_rules = groups.map(&:rules).flatten
+
+      parse_json_rules(all_rules).all?(&:cachable_by_users_scope?)
+    end
+
+    # Calculates the cache key based on the passed users and groups scope
+    # @return [String]
+    def calculate_cache_key(users_scope, groups_scope)
+      prefix = 'rules_service_queries'
+      digest = Digest::SHA256.hexdigest([users_scope, groups_scope].map(&:cache_key_with_version).join)
+
+      "#{prefix}/#{digest}"
     end
   end
 end

--- a/back/engines/commercial/smart_groups/spec/services/rules_service_spec.rb
+++ b/back/engines/commercial/smart_groups/spec/services/rules_service_spec.rb
@@ -94,8 +94,10 @@ describe SmartGroups::RulesService do
       expect(groups.map(&:id)).to match_array [group1.id, group2.id]
     end
 
-    it 'uses a maximun of 2 queries' do
-      expect { service.groups_for_user(user) }.not_to exceed_query_limit(2)
+    it 'uses a maximum of 3 queries' do
+      # 1 for calculating the cache key
+      # 2 for the smart group filtering
+      expect { service.groups_for_user(user) }.not_to exceed_query_limit(3)
     end
 
     it 'accepts an optional scope to limit the groups to search in' do

--- a/back/engines/commercial/verification/lib/verification/smart_groups/rules/verified.rb
+++ b/back/engines/commercial/verification/lib/verification/smart_groups/rules/verified.rb
@@ -47,6 +47,11 @@ module Verification
           self.predicate = predicate
         end
 
+        # The result of the `filter` query depends on the `users` table only, so the query can be cached.
+        def cachable_by_users_scope?
+          true
+        end
+
         def filter(users_scope)
           case predicate
           when 'is_verified'


### PR DESCRIPTION
# Background

This is my 2nd and more successful attempt to caching smart group queries, attempt #1 did not perform well (PR #2630).

This commit aims to improve the performance issues we experience for some customers that use smart groups heavily for permission checks of projects & folders.

With smart groups, we need to execute SQL queries based on the smart group rules every time we want to check whose a member of that smart group. This can get very expensive, because the rules for the smart groups are very flexible, and so are the queries generated behind the scenes. These rules are generally unoptimized, because we don't know in advance which columns a smart group is going to query (they can be set an run time in the back office).

Additionally, the front-end is requesting resources related to projects in an ineffective matter currently. When displaying projects of a folder for example, project data is fetched one by one instead of grouped in one request. Every single request triggers another query to check for permissions of the current user. This will be fixed too at a later point in time, for now we'd like to work around these slow queries by caching them.

Many of the rules are queries against the users table. We check for specific values in their email, their role, timestamp columns and similar. By leveraging Rails low level cache, we can cache the members of those smart groups instead of calculating them again and again.
We have to be smart about how to invalidate the cache. If the rules of the smart group change, we need to recalculate its members again. If user records change, we also need to invalidate the cache and recalculate again.

The caching is now part of the `RulesService`. When we want to know what groups a certain user is a member of, we check of the rules in these groups allow for caching (yes if they only query the users table, otherwise no) and conditionally enable or disable that caching.

# Results

Looking at the response time of a typical front page load with projects who use smart groups for permissions, the response times do improve a lot! In most requests we go from ~ 2000 ms to 500 ms on my naive benchmark on my local machine.

What is next? I think the logical step is to use JSON APIs `include` features and other means to reduce the number of separate requests, which would eliminate the need for the permission check completely.

### Master branch
![before_v2](https://user-images.githubusercontent.com/866318/187163782-3e8a6ac0-5a5f-49f9-8372-9e5b85e96d65.jpg)


### This feature br
![after_v2](https://user-images.githubusercontent.com/866318/187163886-02c538ea-cbc3-4db3-8d24-6f194627a514.jpg)
anch
