### PR TITLE
[CL-1507] Remove BE log for project search, add FE event

### DIFF
--- a/back/app/controllers/web_api/v1/admin_publications_controller.rb
+++ b/back/app/controllers/web_api/v1/admin_publications_controller.rb
@@ -13,16 +13,6 @@ class WebApi::V1::AdminPublicationsController < ::ApplicationController
       .order(:ordering)
     @publications = paginate @publications
 
-    if params[:search].present?
-      LogActivityJob.perform_later(
-        current_user,
-        'searched_admin_publications',
-        current_user,
-        Time.now.to_i,
-        payload: { search_query: params[:search] }
-      )
-    end
-
     render json: linked_json(
       @publications,
       WebApi::V1::AdminPublicationSerializer,

--- a/front/app/components/ProjectAndFolderCards/index.tsx
+++ b/front/app/components/ProjectAndFolderCards/index.tsx
@@ -9,6 +9,8 @@ import ProjectAndFolderCardsInner from './ProjectAndFolderCardsInner';
 // utils
 import { isNilOrError } from 'utils/helperUtils';
 import { getCurrentTab } from './utils';
+import { trackEventByName } from 'utils/analytics';
+import tracks from './tracks';
 
 // typings
 import { PublicationStatus } from 'services/projects';
@@ -56,6 +58,9 @@ const ProjectAndFolderCards = ({
     setSearch(search);
     // pass search term to useAdminPublicationsStatusCount hook
     onChangeSearch(search);
+
+    // analytics event for the updated search term
+    trackEventByName(tracks.searchTermChanged, { searchTerm: search });
   };
 
   const onChangeTab = (tab: PublicationTab) => {

--- a/front/app/components/ProjectAndFolderCards/tracks.ts
+++ b/front/app/components/ProjectAndFolderCards/tracks.ts
@@ -1,4 +1,5 @@
 export default {
   clickOnProjectsAreaFilter: 'Click on projects areas filter dropdown',
   clickOnProjectsShowMoreButton: 'Click on projects show more button',
+  searchTermChanged: 'Projects list search term changed',
 };


### PR DESCRIPTION
Removes the BE log when a user adds a search query on the project index and adds a frontend Matomo event instead