### PR TITLE
[CL-1532] Fix flaky users spec

### DIFF
--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -266,7 +266,7 @@ resource 'Users' do
 
   context 'when authenticated' do
     before do
-      @user = create :user
+      @user = create(:user, last_name: 'Smith')
       token = Knock::AuthToken.new(payload: @user.to_token_payload).token
       header 'Authorization', "Bearer #{token}"
     end


### PR DESCRIPTION
This spec randomly fails if the auto-generated name of the `@user` contains a special character, presumingly because Rubys `sort` method works differently than Postgres in that special case.

```ruby
expected: ["Bednar", "Cole", "Hagenes", "MacGyver", "O'Hara", "Oberbrunner"]
     got: ["Bednar", "Cole", "Hagenes", "MacGyver", "Oberbrunner", "O'Hara"]
```

We fix it by manually assigning fixed last name to the test user record.
