### PR TITLE
[CL-1307] update localize

### DIFF
--- a/front/app/hooks/useLocalize.ts
+++ b/front/app/hooks/useLocalize.ts
@@ -2,6 +2,7 @@ import useLocale from 'hooks/useLocale';
 import useAppConfigurationLocales from 'hooks/useAppConfigurationLocales';
 import { getLocalizedWithFallback } from 'utils/i18n';
 import { Multiloc } from 'typings';
+import { useCallback } from 'react';
 
 interface ILocalizeOptions {
   maxChar?: number;
@@ -18,18 +19,18 @@ export default function useLocalize(): Localize {
   const locale = useLocale();
   const tenantLocales = useAppConfigurationLocales();
 
-  const localize = (
-    multiloc?: Multiloc,
-    { maxChar, fallback }: ILocalizeOptions = {}
-  ) => {
-    return getLocalizedWithFallback(
-      multiloc,
-      locale,
-      tenantLocales,
-      maxChar,
-      fallback
-    );
-  };
+  const localize = useCallback(
+    (multiloc?: Multiloc, { maxChar, fallback }: ILocalizeOptions = {}) => {
+      return getLocalizedWithFallback(
+        multiloc,
+        locale,
+        tenantLocales,
+        maxChar,
+        fallback
+      );
+    },
+    [locale, tenantLocales]
+  );
 
   return localize;
 }

--- a/front/app/modules/commercial/analytics/admin/hooks/usePostsFeedback/index.ts
+++ b/front/app/modules/commercial/analytics/admin/hooks/usePostsFeedback/index.ts
@@ -67,7 +67,7 @@ interface PostFeedback {
   stackedBarColumns: string[];
   statusColorById: Record<string, string>;
   stackedBarPercentages: number[];
-  stackedBarsLegendItems: LegendItem[][]; 
+  stackedBarsLegendItems: LegendItem[][];
   xlsxData: object;
 }
 
@@ -165,9 +165,9 @@ export default function usePostsWithFeedback(
         const stackedBarPercentages = parseStackedBarsPercentages(statusRows);
 
         const stackedBarsLegendItems = parseStackedBarsLegendItems(
-          statusRows, 
+          statusRows,
           localize
-        )
+        );
 
         const xlsxData = parseExcelData(feedbackRow, translations);
 
@@ -186,7 +186,7 @@ export default function usePostsWithFeedback(
         });
       }
     );
-  }, [projectId, startAt, endAt, formatMessage]);
+  }, [projectId, startAt, endAt, formatMessage, localize]);
 
   return postsWithFeedback;
 }


### PR DESCRIPTION
Make localize stable.
Still is causing the analytics request to be duplicated since locale is changing from undefined to the proper value, but we can fix that with the caching of the query object later.