### PR TITLE
CustomPageSettingsForm unit tests init

### DIFF
--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/CustomPageSettingsForm/index.test.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/CustomPageSettingsForm/index.test.tsx
@@ -124,8 +124,8 @@ describe('CustomPageSettingsForm', () => {
 
       await waitFor(() => {
         expect(defaultProps.onSubmit).toHaveBeenCalledWith({
-          title_multiloc: { en: titleEN, 'nl-NL': titleNL },
-          slug,
+          title_multiloc: { en: editedTitleEN, 'nl-NL': editedTitleNL },
+          slug: 'new-slug',
         });
         expect(
           screen.getByTestId('feedbackSuccessMessage')

--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/CustomPageSettingsForm/index.test.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/CustomPageSettingsForm/index.test.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { screen, render, fireEvent, waitFor } from 'utils/testUtils/rtl';
+import CustomPageSettingsForm from './';
+
+const titleEN = 'title en';
+const titleNL = 'title nl';
+// Slug computation takes primary title as base
+const slug = 'title-en';
+
+const defaultProps = {
+  onSubmit: jest.fn(),
+  defaultValues: {
+    title_multiloc: { en: '', 'nl-NL': '' },
+  },
+};
+
+jest.mock('utils/cl-intl');
+jest.mock('hooks/useLocale');
+jest.mock('hooks/useAppConfigurationLocales', () =>
+  jest.fn(() => ['en', 'nl-NL'])
+);
+
+describe('CustomPageSettingsForm', () => {
+  describe('New custom page', () => {
+    const mode = 'new';
+
+    it('renders', () => {
+      render(<CustomPageSettingsForm mode={mode} {...defaultProps} />);
+      expect(screen.getByTestId('customPageSettingsForm')).toBeInTheDocument();
+    });
+
+    it('submits correct data', async () => {
+      const { container } = render(
+        <CustomPageSettingsForm mode={mode} {...defaultProps} />
+      );
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: {
+          value: titleEN,
+        },
+      });
+
+      fireEvent.click(screen.getByText(/nl-NL/i));
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: {
+          value: titleNL,
+        },
+      });
+
+      fireEvent.click(container.querySelector('button[type="submit"]'));
+
+      await waitFor(() => {
+        expect(defaultProps.onSubmit).toHaveBeenCalledWith({
+          title_multiloc: { en: titleEN, 'nl-NL': titleNL },
+        });
+        expect(
+          screen.getByTestId('feedbackSuccessMessage')
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('shows error summary and error message when title is missing', async () => {
+      const { container } = render(
+        <CustomPageSettingsForm mode={mode} {...defaultProps} />
+      );
+
+      fireEvent.click(container.querySelector('button[type="submit"]'));
+      await waitFor(() => {
+        expect(screen.getAllByTestId('error-message')).toHaveLength(2);
+        expect(screen.getByTestId('feedbackErrorMessage')).toBeInTheDocument();
+        expect(defaultProps.onSubmit).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('Edit custom page', () => {
+    const mode = 'edit';
+
+    it('renders', () => {
+      render(<CustomPageSettingsForm mode={mode} {...defaultProps} />);
+      expect(screen.getByTestId('customPageSettingsForm')).toBeInTheDocument();
+    });
+
+    it('submits correct data', async () => {
+      const { container } = render(
+        <CustomPageSettingsForm mode={mode} {...defaultProps} />
+      );
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: {
+          value: titleEN,
+        },
+      });
+
+      fireEvent.click(screen.getByText(/nl-NL/i));
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: {
+          value: titleNL,
+        },
+      });
+
+      fireEvent.click(container.querySelector('button[type="submit"]'));
+
+      await waitFor(() => {
+        expect(defaultProps.onSubmit).toHaveBeenCalledWith({
+          title_multiloc: { en: titleEN, 'nl-NL': titleNL },
+          slug,
+        });
+        expect(
+          screen.getByTestId('feedbackSuccessMessage')
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('shows error summary and error message when title is missing', async () => {
+      const { container } = render(
+        <CustomPageSettingsForm mode={mode} {...defaultProps} />
+      );
+
+      fireEvent.click(container.querySelector('button[type="submit"]'));
+      await waitFor(() => {
+        expect(screen.getAllByTestId('error-message')).toHaveLength(2);
+        expect(screen.getByTestId('feedbackErrorMessage')).toBeInTheDocument();
+        expect(defaultProps.onSubmit).not.toHaveBeenCalled();
+      });
+    });
+
+    it('shows error summary and error message when slug is not correct', async () => {
+      const { container } = render(
+        <CustomPageSettingsForm mode={mode} {...defaultProps} />
+      );
+
+      fireEvent.click(container.querySelector('button[type="submit"]'));
+      await waitFor(() => {
+        expect(screen.getAllByTestId('error-message')).toHaveLength(2);
+        expect(screen.getByTestId('feedbackErrorMessage')).toBeInTheDocument();
+        expect(defaultProps.onSubmit).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/CustomPageSettingsForm/index.test.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/CustomPageSettingsForm/index.test.tsx
@@ -14,6 +14,9 @@ jest.mock('hooks/useLocale');
 jest.mock('hooks/useAppConfigurationLocales', () =>
   jest.fn(() => ['en', 'nl-NL'])
 );
+jest.mock('hooks/useAppConfiguration', () => () => ({
+  data: { attributes: { name: 'orgName', host: 'localhost' } },
+}));
 
 describe('CustomPageSettingsForm', () => {
   describe('New custom page', () => {

--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/CustomPageSettingsForm/index.test.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/CustomPageSettingsForm/index.test.tsx
@@ -4,15 +4,10 @@ import CustomPageSettingsForm from './';
 
 const titleEN = 'title en';
 const titleNL = 'title nl';
+const editedTitleEN = 'edited title en';
+const editedTitleNL = 'edited title nl';
 // Slug computation takes primary title as base
 const slug = 'title-en';
-
-const defaultProps = {
-  onSubmit: jest.fn(),
-  defaultValues: {
-    title_multiloc: { en: '', 'nl-NL': '' },
-  },
-};
 
 jest.mock('utils/cl-intl');
 jest.mock('hooks/useLocale');
@@ -23,6 +18,12 @@ jest.mock('hooks/useAppConfigurationLocales', () =>
 describe('CustomPageSettingsForm', () => {
   describe('New custom page', () => {
     const mode = 'new';
+    const defaultProps = {
+      onSubmit: jest.fn(),
+      defaultValues: {
+        title_multiloc: { en: '', 'nl-NL': '' },
+      },
+    };
 
     it('renders', () => {
       render(<CustomPageSettingsForm mode={mode} {...defaultProps} />);
@@ -76,6 +77,13 @@ describe('CustomPageSettingsForm', () => {
 
   describe('Edit custom page', () => {
     const mode = 'edit';
+    const defaultProps = {
+      onSubmit: jest.fn(),
+      defaultValues: {
+        title_multiloc: { en: titleEN, 'nl-NL': titleNL },
+        slug,
+      },
+    };
 
     it('renders', () => {
       render(<CustomPageSettingsForm mode={mode} {...defaultProps} />);
@@ -87,20 +95,28 @@ describe('CustomPageSettingsForm', () => {
         <CustomPageSettingsForm mode={mode} {...defaultProps} />
       );
 
-      fireEvent.change(screen.getByRole('textbox'), {
+      // Set title field
+      fireEvent.change(screen.getByRole('textbox', { name: 'Title' }), {
         target: {
-          value: titleEN,
+          value: editedTitleEN,
         },
       });
 
       fireEvent.click(screen.getByText(/nl-NL/i));
-
-      fireEvent.change(screen.getByRole('textbox'), {
+      fireEvent.change(screen.getByRole('textbox', { name: 'Title' }), {
         target: {
-          value: titleNL,
+          value: editedTitleNL,
         },
       });
 
+      // Set slug field
+      fireEvent.change(screen.getByRole('textbox', { name: 'Page URL' }), {
+        target: {
+          value: 'new-slug',
+        },
+      });
+
+      // Submit form
       fireEvent.click(container.querySelector('button[type="submit"]'));
 
       await waitFor(() => {
@@ -119,6 +135,12 @@ describe('CustomPageSettingsForm', () => {
         <CustomPageSettingsForm mode={mode} {...defaultProps} />
       );
 
+      fireEvent.change(screen.getByRole('textbox', { name: 'Title' }), {
+        target: {
+          value: '',
+        },
+      });
+
       fireEvent.click(container.querySelector('button[type="submit"]'));
       await waitFor(() => {
         expect(screen.getAllByTestId('error-message')).toHaveLength(2);
@@ -131,6 +153,13 @@ describe('CustomPageSettingsForm', () => {
       const { container } = render(
         <CustomPageSettingsForm mode={mode} {...defaultProps} />
       );
+
+      fireEvent.change(screen.getByRole('textbox', { name: 'Page URL' }), {
+        target: {
+          // invalid slug
+          value: '%%%',
+        },
+      });
 
       fireEvent.click(container.querySelector('button[type="submit"]'));
       await waitFor(() => {

--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/CustomPageSettingsForm/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/CustomPageSettingsForm/index.tsx
@@ -18,7 +18,7 @@ import SlugInput from 'components/HookForm/SlugInput';
 import { Box } from '@citizenlab/cl2-component-library';
 
 // intl
-import messages from './messages';
+import messages from '../messages';
 import { InjectedIntlProps } from 'react-intl';
 import { injectIntl } from 'utils/cl-intl';
 
@@ -73,7 +73,10 @@ const CustomPageSettingsForm = ({
 
   return (
     <FormProvider {...methods}>
-      <form onSubmit={methods.handleSubmit(onFormSubmit)}>
+      <form
+        onSubmit={methods.handleSubmit(onFormSubmit)}
+        data-testid="customPageSettingsForm"
+      >
         <SectionFormWrapper
           stickyMenuContents={
             <Button type="submit" processing={methods.formState.isSubmitting}>

--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/CustomPageSettingsForm/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/CustomPageSettingsForm/index.tsx
@@ -30,9 +30,10 @@ export interface FormValues {
   slug?: string;
 }
 
+type TMode = 'new' | 'edit';
 interface Props {
   defaultValues?: FormValues;
-  mode: 'new' | 'edit';
+  mode: TMode;
   onSubmit: (formValues: FormValues) => void;
 }
 


### PR DESCRIPTION
## Checklist

- [ ] Added entry to changelog
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

- [ ] WCAG 2.1 AA proof
<details>
<summary>More info</summary>
For front-end devs only. Is your work conforming with the WCAG 2.1 AA rules? If you need more info, read the [a11y page](https://www.notion.so/citizenlab/a11y-7568f83d42ab4895ac133b89d358997b) on our Notion.
</details>

- [ ] Tests
<details>
<summary>More info</summary>

### Unit tests

Did you add relevant unit tests?

### E2E tests

Sometimes it can be more efficient to update E2E tests after CI has run them. If you know which ones to update, go ahead! E2E template cl2-back:

```bash
docker compose run --rm web bin/rails cl2_back:create_tenant[localhost,e2etests_template]
```

</details>

- [ ] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## Links

- [citizenlab-ee PR](**put URL here** or remove)
- [Specs](**put URL here** or remove)
- [Epic Deployment](**put URL here** or remove)

## How urgent is a code review?

Let the reviewer(s) know how urgent the code review is, so they can prioritize their work accordingly. Be specific (e.g. by Wednesday, end of the day/this week/... is better than 'urgent' or 'very urgent'). Optionally provide a word of explanation on your deadline.
