### PR TITLE
CL-1584: fix flaky image test

### DIFF
--- a/front/cypress/e2e/content_builder/components/image_component.cy.ts
+++ b/front/cypress/e2e/content_builder/components/image_component.cy.ts
@@ -47,7 +47,11 @@ describe('Content builder Image component', () => {
 
     cy.get('#e2e-image').parent().click();
     cy.get('input[type="file"]').attachFile('icon.png');
-    cy.get('#imageAltTextInput').click().type('Image alt text.');
+    cy.get('#imageAltTextInput')
+      .click()
+      .focus()
+      .clear()
+      .type('Image alt text.');
 
     cy.get('[alt="Image alt text."]').should('exist');
     cy.get('#e2e-content-builder-topbar-save').click();


### PR DESCRIPTION
This fixes a flaky image test caused by cypress not typing the correct test in some scenarios. I have added focus and clear to help with this. 

## How urgent is a code review?

Before end of day if possible
