### PR TITLE
[CL-1374] Custom pages hero banner outlet work

### DIFF
--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/HeroBanner/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/HeroBanner/index.tsx
@@ -37,9 +37,18 @@ const EditCustomPageHeroBannerForm = ({
 
   const handleSave = async (newSettings: HeroBannerInputSettings) => {
     if (!newSettings) return;
+
+    // necessary because the CTA module uses 
+    const mappedSettings = {
+      ...newSettings,
+      ...newSettings.banner_cta_signed_out_url && { banner_cta_button_url: newSettings.banner_cta_signed_out_url },
+      ...newSettings.banner_cta_signed_out_type && { banner_cta_button_type: newSettings.banner_cta_signed_out_type },
+      ...newSettings.banner_cta_signed_out_text_multiloc && { banner_cta_button_multiloc: newSettings.banner_cta_signed_out_text_multiloc }
+    }
+
     // only update the page settings if they have changed
     const diffedValues = {};
-    forOwn(newSettings, (value, key) => {
+    forOwn(mappedSettings, (value, key) => {
       if (!isEqual(value, customPage.attributes[key])) {
         diffedValues[key] = value;
       }
@@ -64,6 +73,9 @@ const EditCustomPageHeroBannerForm = ({
     banner_header_multiloc: attributes.banner_header_multiloc,
     banner_subheader_multiloc: attributes.banner_subheader_multiloc,
     header_bg: attributes.header_bg,
+    banner_cta_signed_out_url: attributes.banner_cta_button_url,
+    banner_cta_signed_out_text_multiloc: attributes.banner_cta_button_multiloc,
+    banner_cta_signed_out_type: attributes.banner_cta_button_type
   };
 
   return (

--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/HeroBanner/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/HeroBanner/index.tsx
@@ -38,13 +38,20 @@ const EditCustomPageHeroBannerForm = ({
   const handleSave = async (newSettings: HeroBannerInputSettings) => {
     if (!newSettings) return;
 
-    // necessary because the CTA module uses 
+    // necessary because the CTA module uses
     const mappedSettings = {
       ...newSettings,
-      ...newSettings.banner_cta_signed_out_url && { banner_cta_button_url: newSettings.banner_cta_signed_out_url },
-      ...newSettings.banner_cta_signed_out_type && { banner_cta_button_type: newSettings.banner_cta_signed_out_type },
-      ...newSettings.banner_cta_signed_out_text_multiloc && { banner_cta_button_multiloc: newSettings.banner_cta_signed_out_text_multiloc }
-    }
+      ...(newSettings.banner_cta_signed_out_url && {
+        banner_cta_button_url: newSettings.banner_cta_signed_out_url,
+      }),
+      ...(newSettings.banner_cta_signed_out_type && {
+        banner_cta_button_type: newSettings.banner_cta_signed_out_type,
+      }),
+      ...(newSettings.banner_cta_signed_out_text_multiloc && {
+        banner_cta_button_multiloc:
+          newSettings.banner_cta_signed_out_text_multiloc,
+      }),
+    };
 
     // only update the page settings if they have changed
     const diffedValues = {};
@@ -75,7 +82,7 @@ const EditCustomPageHeroBannerForm = ({
     header_bg: attributes.header_bg,
     banner_cta_signed_out_url: attributes.banner_cta_button_url,
     banner_cta_signed_out_text_multiloc: attributes.banner_cta_button_multiloc,
-    banner_cta_signed_out_type: attributes.banner_cta_button_type
+    banner_cta_signed_out_type: attributes.banner_cta_button_type,
   };
 
   return (

--- a/front/app/containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/index.tsx
@@ -106,9 +106,10 @@ export type HeroBannerInputSettings = {
   banner_cta_signed_in_type?: IHomepageSettingsAttributes['banner_cta_signed_in_type'];
   banner_cta_signed_in_url?: IHomepageSettingsAttributes['banner_cta_signed_in_url'];
   // cta_signed_out
-  banner_cta_signed_out_text_multiloc?: IHomepageSettingsAttributes['banner_cta_signed_out_text_multiloc'];
-  banner_cta_signed_out_type?: IHomepageSettingsAttributes['banner_cta_signed_out_type'];
-  banner_cta_signed_out_url?: IHomepageSettingsAttributes['banner_cta_signed_out_url'];
+  // this can be retyped since it exists on custom page too
+  banner_cta_signed_out_text_multiloc: IHomepageSettingsAttributes['banner_cta_signed_out_text_multiloc'];
+  banner_cta_signed_out_type: IHomepageSettingsAttributes['banner_cta_signed_out_type'];
+  banner_cta_signed_out_url: IHomepageSettingsAttributes['banner_cta_signed_out_url'];
 };
 
 import { ISubmitState } from 'components/admin/SubmitWrapper';
@@ -293,13 +294,11 @@ const GenericHeroBannerForm = ({
           <FormattedMessage {...messages.heroBannerInfoBar} />
         </Warning>
 
-        {type === 'homePage' && (
-          <Outlet
-            id="app.containers.Admin.settings.customize.headerSectionStart"
-            bannerLayout={localSettings.banner_layout ?? 'two_column_layout'}
-            handleOnChange={updateValueInLocalState}
-          />
-        )}
+        <Outlet
+          id="app.containers.Admin.settings.customize.headerSectionStart"
+          bannerLayout={localSettings.banner_layout ?? 'two_column_layout'}
+          handleOnChange={updateValueInLocalState}
+        />
         <SubSectionTitle>
           <FormattedMessage {...messages.header_bg} />
           <IconTooltip
@@ -469,14 +468,23 @@ const GenericHeroBannerForm = ({
           </>
         )}
         {/* // CTA settings, only applicable on homepage */}
-        {type === 'homePage' && (
-          <Outlet
-            id="app.containers.Admin.settings.customize.headerSectionEnd"
-            homepageSettings={localSettings}
-            handleOnChange={updateValueInLocalState}
-            errors={apiErrors}
-          />
-        )}
+        <Outlet
+          id="app.containers.Admin.settings.customize.headerSectionEnd"
+          banner_cta_signed_in_text_multiloc={
+            localSettings.banner_cta_signed_in_text_multiloc
+          }
+          banner_cta_signed_in_url={localSettings.banner_cta_signed_in_url}
+          banner_cta_signed_in_type={localSettings.banner_cta_signed_in_type}
+          banner_cta_signed_out_text_multiloc={
+            localSettings.banner_cta_signed_out_text_multiloc
+          }
+          banner_cta_signed_out_url={localSettings.banner_cta_signed_out_url}
+          banner_cta_signed_out_type={localSettings.banner_cta_signed_out_type}
+          handleOnChange={updateValueInLocalState}
+          // signed in only applies to 
+          showSignedInSettings={type === "homePage"}
+          errors={apiErrors}
+        />
       </Section>
     </SectionFormWrapper>
   );

--- a/front/app/containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/index.tsx
@@ -481,8 +481,8 @@ const GenericHeroBannerForm = ({
           banner_cta_signed_out_url={localSettings.banner_cta_signed_out_url}
           banner_cta_signed_out_type={localSettings.banner_cta_signed_out_type}
           handleOnChange={updateValueInLocalState}
-          // signed in only applies to 
-          showSignedInSettings={type === "homePage"}
+          // signed in only applies to
+          showSignedInSettings={type === 'homePage'}
           errors={apiErrors}
         />
       </Section>

--- a/front/app/modules/commercial/customizable_homepage_banner/admin/CTASettings/index.tsx
+++ b/front/app/modules/commercial/customizable_homepage_banner/admin/CTASettings/index.tsx
@@ -9,7 +9,6 @@ import CTASignedInSettings from './CTASignedInSettings';
 import { CLErrors, Multiloc } from 'typings';
 import 'utils/moduleUtils';
 
-
 // only these keys will be used in CTA settings
 
 export type BannerSettingKeyType = Extract<
@@ -57,13 +56,15 @@ const CTASettings = ({
         handleSettingOnChange={handleOnChange}
         errors={errors}
       />
-      { showSignedInSettings && <CTASignedInSettings
-        ctaType={banner_cta_signed_in_type}
-        ctaButtonMultiloc={banner_cta_signed_in_text_multiloc}
-        ctaButtonUrl={banner_cta_signed_in_url}
-        handleSettingOnChange={handleOnChange}
-        errors={errors}
-      /> }
+      {showSignedInSettings && (
+        <CTASignedInSettings
+          ctaType={banner_cta_signed_in_type}
+          ctaButtonMultiloc={banner_cta_signed_in_text_multiloc}
+          ctaButtonUrl={banner_cta_signed_in_url}
+          handleSettingOnChange={handleOnChange}
+          errors={errors}
+        />
+      )}
     </Section>
   );
 };

--- a/front/app/modules/commercial/customizable_homepage_banner/admin/CTASettings/index.tsx
+++ b/front/app/modules/commercial/customizable_homepage_banner/admin/CTASettings/index.tsx
@@ -2,17 +2,18 @@ import { Section, SubSectionTitle } from 'components/admin/Section';
 import { FormattedMessage } from 'utils/cl-intl';
 import React from 'react';
 import messages from '../messages';
-import { IHomepageSettingsAttributes } from 'services/homepageSettings';
+
+import { CTASignedInType, CTASignedOutType } from 'services/homepageSettings';
 import CTASignedOutSettings from './CTASignedOutSettings';
 import CTASignedInSettings from './CTASignedInSettings';
-import { CLErrors } from 'typings';
+import { CLErrors, Multiloc } from 'typings';
 import 'utils/moduleUtils';
 
-import { isNilOrError } from 'utils/helperUtils';
 
 // only these keys will be used in CTA settings
+
 export type BannerSettingKeyType = Extract<
-  keyof IHomepageSettingsAttributes,
+  keyof Props,
   | 'banner_cta_signed_in_text_multiloc'
   | 'banner_cta_signed_out_text_multiloc'
   | 'banner_cta_signed_in_url'
@@ -22,35 +23,47 @@ export type BannerSettingKeyType = Extract<
 >;
 
 interface Props {
-  homepageSettings: IHomepageSettingsAttributes;
+  banner_cta_signed_in_text_multiloc: Multiloc;
+  banner_cta_signed_out_text_multiloc: Multiloc;
+  banner_cta_signed_in_url: string;
+  banner_cta_signed_out_url: string;
+  banner_cta_signed_out_type: CTASignedOutType;
+  banner_cta_signed_in_type: CTASignedInType;
   handleOnChange: (settingKey: BannerSettingKeyType, settingValue: any) => void;
+  showSignedInSettings: boolean;
   errors: CLErrors | undefined | null;
 }
 
-const CTASettings = ({ homepageSettings, handleOnChange, errors }: Props) => {
-  if (isNilOrError(homepageSettings)) {
-    return null;
-  }
-
+const CTASettings = ({
+  handleOnChange,
+  errors,
+  showSignedInSettings,
+  banner_cta_signed_in_text_multiloc,
+  banner_cta_signed_out_text_multiloc,
+  banner_cta_signed_in_url,
+  banner_cta_signed_out_url,
+  banner_cta_signed_out_type,
+  banner_cta_signed_in_type,
+}: Props) => {
   return (
     <Section>
       <SubSectionTitle>
         <FormattedMessage {...messages.ctaHeader} />
       </SubSectionTitle>
       <CTASignedOutSettings
-        ctaType={homepageSettings.banner_cta_signed_out_type}
-        ctaButtonMultiloc={homepageSettings.banner_cta_signed_out_text_multiloc}
-        ctaButtonUrl={homepageSettings.banner_cta_signed_out_url}
+        ctaType={banner_cta_signed_out_type}
+        ctaButtonMultiloc={banner_cta_signed_out_text_multiloc}
+        ctaButtonUrl={banner_cta_signed_out_url}
         handleSettingOnChange={handleOnChange}
         errors={errors}
       />
-      <CTASignedInSettings
-        ctaType={homepageSettings.banner_cta_signed_in_type}
-        ctaButtonMultiloc={homepageSettings.banner_cta_signed_in_text_multiloc}
-        ctaButtonUrl={homepageSettings.banner_cta_signed_in_url}
+      { showSignedInSettings && <CTASignedInSettings
+        ctaType={banner_cta_signed_in_type}
+        ctaButtonMultiloc={banner_cta_signed_in_text_multiloc}
+        ctaButtonUrl={banner_cta_signed_in_url}
         handleSettingOnChange={handleOnChange}
         errors={errors}
-      />
+      /> }
     </Section>
   );
 };

--- a/front/app/modules/commercial/customizable_homepage_banner/index.tsx
+++ b/front/app/modules/commercial/customizable_homepage_banner/index.tsx
@@ -10,18 +10,10 @@ import FeatureFlag from 'components/FeatureFlag';
 const configuration: ModuleConfiguration = {
   outlets: {
     'app.containers.Admin.settings.customize.headerSectionStart': (props) => {
-      return (
-        <FeatureFlag name="customizable_homepage_banner">
-          <LayoutSetting {...props} />
-        </FeatureFlag>
-      );
+      return <LayoutSetting {...props} />;
     },
     'app.containers.Admin.settings.customize.headerSectionEnd': (props) => {
-      return (
-        <FeatureFlag name="customizable_homepage_banner">
-          <CTASettings {...props} />
-        </FeatureFlag>
-      );
+      return <CTASettings {...props} />;
     },
     'app.containers.LandingPage.SignedOutHeader.CTA': (props) => {
       return (

--- a/front/app/services/customPages.ts
+++ b/front/app/services/customPages.ts
@@ -33,7 +33,8 @@ export interface ICustomPagesAttributes extends ICustomPageEnabledSettings {
   banner_overlay_color: string | null;
   banner_overlay_opacity: number | null;
   banner_cta_button_multiloc: Multiloc;
-  banner_cta_button_type: 'customized_button' | 'no_button' | null;
+  // check if this can be null
+  banner_cta_button_type: 'customized_button' | 'no_button';
   banner_cta_button_url: string | null;
   banner_header_multiloc: Multiloc;
   banner_subheader_multiloc: Multiloc;

--- a/front/app/utils/moduleUtils.tsx
+++ b/front/app/utils/moduleUtils.tsx
@@ -46,10 +46,8 @@ import {
   TAppConfigurationSettingCore,
 } from 'services/appConfiguration';
 import {
-  IHomepageSettingsAttributes,
   THomepageBannerLayout,
 } from 'services/homepageSettings';
-import { HeroBannerInputSettings } from 'containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm';
 import { ManagerType } from 'components/admin/PostManager';
 import { IdeaCellComponentProps } from 'components/admin/PostManager/components/PostTable/IdeaRow';
 import { IdeaHeaderCellComponentProps } from 'components/admin/PostManager/components/PostTable/IdeaHeaderRow';
@@ -373,12 +371,19 @@ export interface OutletsPropertyMap {
     ) => void;
   };
   'app.containers.Admin.settings.customize.headerSectionEnd': {
-    homepageSettings: Partial<IHomepageSettingsAttributes>
+    banner_cta_signed_in_text_multiloc: any;
+    banner_cta_signed_out_text_multiloc: any;
+    banner_cta_signed_in_url: any;
+    banner_cta_signed_out_url: any;
+    // todo: type these better, probably means moving CTA types to main app
+    banner_cta_signed_out_type: any;
+    banner_cta_signed_in_type: any;
+    showSignedInSettings: boolean;
     handleOnChange: (
-      settingKey: keyof HeroBannerInputSettings,
+      settingKey: any,
       settingValue: any
     ) => void;
-    errors: CLErrors | null | undefined;
+    errors: CLErrors | undefined | null;
   };
   'app.containers.LandingPage.SignedOutHeader.index': {
     homepageBannerLayout: THomepageBannerLayout;

--- a/front/app/utils/moduleUtils.tsx
+++ b/front/app/utils/moduleUtils.tsx
@@ -45,9 +45,7 @@ import {
   TAppConfigurationSetting,
   TAppConfigurationSettingCore,
 } from 'services/appConfiguration';
-import {
-  THomepageBannerLayout,
-} from 'services/homepageSettings';
+import { THomepageBannerLayout } from 'services/homepageSettings';
 import { ManagerType } from 'components/admin/PostManager';
 import { IdeaCellComponentProps } from 'components/admin/PostManager/components/PostTable/IdeaRow';
 import { IdeaHeaderCellComponentProps } from 'components/admin/PostManager/components/PostTable/IdeaHeaderRow';
@@ -379,10 +377,7 @@ export interface OutletsPropertyMap {
     banner_cta_signed_out_type: any;
     banner_cta_signed_in_type: any;
     showSignedInSettings: boolean;
-    handleOnChange: (
-      settingKey: any,
-      settingValue: any
-    ) => void;
+    handleOnChange: (settingKey: any, settingValue: any) => void;
     errors: CLErrors | undefined | null;
   };
   'app.containers.LandingPage.SignedOutHeader.index': {


### PR DESCRIPTION
A proof of concept showing how we can use the existing outlets for banner layout and page button settings for both custom pages and homepages. In testing I'm able to persist settings for both the layout and CTA button settings for custom pages and home pages.

The types are all placeholders, if the general solution looks good we can finalize them later. A few adjustments will need to be made in the module (copy, generally) and removing a field for custom pages that exists on home pages, but generally it seems like a simple solution that doesn't require a lot of code to be moved or refactored

The copy and layout need to be adjusted for custom pages (there are only two options, custom/none, no "sign up" option)
![Screen Shot 2022-09-05 at 16 31 18](https://user-images.githubusercontent.com/3614128/188472229-6c05c76f-55be-465b-b75d-3a2604a6f13d.png)

![Screen Shot 2022-09-05 at 16 31 29](https://user-images.githubusercontent.com/3614128/188472222-c22ddebf-2424-4269-aafa-e81c7ca9b8e3.png)
