### PR TITLE
Ignore CVE-2020-36599

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,9 +115,11 @@ jobs:
     steps:
       # CVE-2015-9284 is "CSRF vulnerability in OmniAuth's request phase"
       # Solution: upgrade to '>= 2.0.0'
-      # But we can't, due to unmaintained gems that don't work with Omniauth 2.0.
+      # CVE-2020-36599 is "OmniAuth's `lib/omniauth/failure_endpoint.rb` does not escape `message_key` value"
+      # Solution: upgrade to '>= 2.0.0'
+      # But we can't upgrade, due to unmaintained gems that don't work with Omniauth 2.0.
       # See https://github.com/rubysec/bundler-audit
-      - run: bundle exec bundle-audit check --update --ignore CVE-2015-9284
+      - run: bundle exec bundle-audit check --update --ignore CVE-2015-9284 CVE-2020-36599
 
   back-test:
     resource_class: small


### PR DESCRIPTION
Name: omniauth
Version: 1.9.1
CVE: CVE-2020-36599
GHSA: GHSA-pm55-qfxr-h247
Criticality: Critical
URL: https://github.com/omniauth/omniauth/commit/43a396f181ef7d0ed2ec8291c939c95e3ed3ff00#diff-575abda9deb9b1a77bf534e898a923029b9a61e991d626db88dc6e8b34260aa2
Title: OmniAuth's `lib/omniauth/failure_endpoint.rb` does not escape `message_key` value
Solution: upgrade to '~> 1.9.2', '>= 2.0.0'

But we cannot upgrades. See .circleci/config.yml