### PR TITLE
Fix behaviour when survey is empty

### DIFF
--- a/front/app/hooks/useFormCustomFields.ts
+++ b/front/app/hooks/useFormCustomFields.ts
@@ -82,7 +82,9 @@ export default function useFormCustomFields({
             }
           );
 
-          return combineLatest(fieldsWithOptions$);
+          return fieldsWithOptions$.length
+            ? combineLatest(fieldsWithOptions$)
+            : of([]);
         })
       )
       .subscribe((formCustomFields) => {


### PR DESCRIPTION
This fixes the behaviour when the survey builder edit page can't be accessed for new or empty projects
