### PR TITLE
[CL-1645] results endpoints

### DIFF
--- a/back/.rubocop_todo.yml
+++ b/back/.rubocop_todo.yml
@@ -172,7 +172,7 @@ RSpec/MissingExampleGroupArgument:
 # Offense count: 380
 # Configuration parameters: AllowSubject.
 RSpec/MultipleMemoizedHelpers:
-  Max: 24
+  Max: 30
 
 # Offense count: 29
 # Configuration parameters: IgnoreSharedExamples.

--- a/back/app/controllers/web_api/v1/phases_controller.rb
+++ b/back/app/controllers/web_api/v1/phases_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class WebApi::V1::PhasesController < ApplicationController
-  before_action :set_phase, only: %i[show update destroy]
+  before_action :set_phase, only: %i[show update destroy survey_results]
   skip_before_action :authenticate_user
 
   def index
@@ -51,6 +51,11 @@ class WebApi::V1::PhasesController < ApplicationController
     else
       head :internal_server_error
     end
+  end
+
+  def survey_results
+    results = SurveyResultsGeneratorService.new(@phase).generate
+    render json: results
   end
 
   private

--- a/back/app/controllers/web_api/v1/projects_controller.rb
+++ b/back/app/controllers/web_api/v1/projects_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class WebApi::V1::ProjectsController < ::ApplicationController
-  before_action :set_project, only: %i[show update reorder destroy]
+  before_action :set_project, only: %i[show update reorder destroy survey_results]
   skip_before_action :authenticate_user
   skip_after_action :verify_policy_scoped, only: :index
 
@@ -110,6 +110,11 @@ class WebApi::V1::ProjectsController < ::ApplicationController
     else
       head :internal_server_error
     end
+  end
+
+  def survey_results
+    results = SurveyResultsGeneratorService.new(@project).generate
+    render json: results
   end
 
   private

--- a/back/app/policies/phase_policy.rb
+++ b/back/app/policies/phase_policy.rb
@@ -30,4 +30,8 @@ class PhasePolicy < ApplicationPolicy
   def destroy?
     ProjectPolicy.new(user, record.project).update?
   end
+
+  def survey_results?
+    ProjectPolicy.new(user, record.project).survey_results?
+  end
 end

--- a/back/app/policies/project_policy.rb
+++ b/back/app/policies/project_policy.rb
@@ -62,6 +62,10 @@ class ProjectPolicy < ApplicationPolicy
     active_moderator?
   end
 
+  def survey_results?
+    active_moderator?
+  end
+
   def create?
     active? && admin?
   end

--- a/back/app/services/survey_results_generator_service.rb
+++ b/back/app/services/survey_results_generator_service.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class SurveyResultsGeneratorService < FieldVisitorService
+  def initialize(participation_context)
+    super()
+    form = participation_context.custom_form || CustomForm.new(participation_context: participation_context)
+    @fields = IdeaCustomFieldsService.new(form).reportable_fields
+    @inputs = participation_context.ideas
+  end
+
+  def generate
+    results = fields.filter_map do |field|
+      visit field
+    end
+    {
+      data: { results: results },
+      totalSubmissions: inputs.size
+    }
+  end
+
+  def visit_multiselect(field)
+    flattened_values = inputs.select(:id, "jsonb_array_elements(custom_field_values->'#{field.key}') as value")
+    distribution = Idea.select(:value).from(flattened_values).group(:value).order(Arel.sql('COUNT(value) DESC')).count.to_a
+    option_titles = field.options.each_with_object({}) do |option, accu|
+      accu[option.key] = option.title_multiloc
+    end
+    answers = distribution.map do |(value, count)|
+      {
+        answer: option_titles[value],
+        responses: count
+      }
+    end
+    answer_count = distribution.sum { |(_value, count)| count }
+    {
+      inputType: field.input_type,
+      question: field.title_multiloc,
+      totalResponses: answer_count,
+      answers: answers
+    }
+  end
+
+  private
+
+  attr_reader :fields, :inputs
+end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -120,6 +120,7 @@ Rails.application.routes.draw do
 
       resources :phases, only: %i[show edit update destroy] do
         resources :files, defaults: { container_type: 'Phase' }, shallow: false
+        get 'survey_results', on: :member
       end
 
       resources :projects do
@@ -136,6 +137,7 @@ Rails.application.routes.draw do
         end
 
         get 'by_slug/:slug', on: :collection, to: 'projects#by_slug'
+        get 'survey_results', on: :member
       end
 
       resources :projects_allowed_input_topics, only: %i[show create destroy] do

--- a/back/spec/acceptance/phases_spec.rb
+++ b/back/spec/acceptance/phases_spec.rb
@@ -353,7 +353,8 @@ resource 'Phases' do
         )
       end
 
-      example_request 'Get survey results' do
+      example 'Get survey results', skip: !CitizenLab.ee? do
+        do_request
         expect(status).to eq 200
 
         json_response = json_parse(response_body)

--- a/back/spec/acceptance/phases_spec.rb
+++ b/back/spec/acceptance/phases_spec.rb
@@ -53,7 +53,7 @@ resource 'Phases' do
     end
   end
 
-  context 'when authenticated' do
+  context 'when authenticated as admin' do
     before do
       @user = create(:admin)
       token = Knock::AuthToken.new(payload: @user.to_token_payload).token
@@ -314,6 +314,67 @@ resource 'Phases' do
       example_request 'Delete a phase' do
         expect(response_status).to eq 200
         expect { Comment.find(id) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    get 'web_api/v1/phases/:id/survey_results' do
+      let(:project) { create(:project_with_active_native_survey_phase) }
+      let(:active_phase) { project.phases.first }
+      let(:form) { create(:custom_form, participation_context: active_phase) }
+      let(:id) { active_phase.id }
+      let(:multiselect_field) do
+        create(
+          :custom_field_multiselect,
+          resource: form,
+          title_multiloc: { 'en' => 'What are your favourite pets?' },
+          description_multiloc: {}
+        )
+      end
+      let!(:cat_option) do
+        create(:custom_field_option, custom_field: multiselect_field, key: 'cat', title_multiloc: { 'en' => 'Cat' })
+      end
+      let!(:dog_option) do
+        create(:custom_field_option, custom_field: multiselect_field, key: 'dog', title_multiloc: { 'en' => 'Dog' })
+      end
+      let!(:survey_response1) do
+        create(
+          :idea,
+          project: project,
+          phases: [active_phase],
+          custom_field_values: { multiselect_field.key => %w[cat dog] }
+        )
+      end
+      let!(:survey_response2) do
+        create(
+          :idea,
+          project: project,
+          phases: [active_phase],
+          custom_field_values: { multiselect_field.key => %w[cat] }
+        )
+      end
+
+      example_request 'Get survey results' do
+        expect(status).to eq 200
+
+        json_response = json_parse(response_body)
+        expect(json_response).to eq(
+          {
+            data: {
+              results: [
+                {
+                  inputType: 'multiselect',
+                  question: { en: 'What are your favourite pets?' },
+                  totalResponses: 3,
+                  answers: [
+                    { answer: { en: 'Cat' }, responses: 2 },
+                    { answer: { en: 'Dog' }, responses: 1 }
+                  ]
+                }
+              ]
+            },
+            totalSubmissions: 2
+          }
+        )
       end
     end
   end

--- a/back/spec/acceptance/projects_spec.rb
+++ b/back/spec/acceptance/projects_spec.rb
@@ -548,6 +548,54 @@ resource 'Projects' do
         expect(moderator.reload.project_moderator?(id)).to be false
       end
     end
+
+    get 'web_api/v1/projects/:id/survey_results' do
+      let(:project) { create(:continuous_native_survey_project) }
+      let(:form) { create(:custom_form, participation_context: project) }
+      let(:id) { project.id }
+      let(:multiselect_field) do
+        create(
+          :custom_field_multiselect,
+          resource: form,
+          title_multiloc: { 'en' => 'What are your favourite pets?' },
+          description_multiloc: {}
+        )
+      end
+      let!(:cat_option) do
+        create(:custom_field_option, custom_field: multiselect_field, key: 'cat', title_multiloc: { 'en' => 'Cat' })
+      end
+      let!(:dog_option) do
+        create(:custom_field_option, custom_field: multiselect_field, key: 'dog', title_multiloc: { 'en' => 'Dog' })
+      end
+
+      before do
+        create(:idea, project: project, custom_field_values: { multiselect_field.key => %w[cat dog] })
+        create(:idea, project: project, custom_field_values: { multiselect_field.key => %w[cat] })
+      end
+
+      example_request 'Get survey results' do
+        expect(status).to eq 200
+
+        expect(json_response).to eq(
+          {
+            data: {
+              results: [
+                {
+                  inputType: 'multiselect',
+                  question: { en: 'What are your favourite pets?' },
+                  totalResponses: 3,
+                  answers: [
+                    { answer: { en: 'Cat' }, responses: 2 },
+                    { answer: { en: 'Dog' }, responses: 1 }
+                  ]
+                }
+              ]
+            },
+            totalSubmissions: 2
+          }
+        )
+      end
+    end
   end
 
   get 'web_api/v1/projects' do

--- a/back/spec/acceptance/projects_spec.rb
+++ b/back/spec/acceptance/projects_spec.rb
@@ -573,7 +573,8 @@ resource 'Projects' do
         create(:idea, project: project, custom_field_values: { multiselect_field.key => %w[cat] })
       end
 
-      example_request 'Get survey results' do
+      example 'Get survey results', skip: !CitizenLab.ee? do
+        do_request
         expect(status).to eq 200
 
         expect(json_response).to eq(

--- a/back/spec/factories/projects.rb
+++ b/back/spec/factories/projects.rb
@@ -75,6 +75,12 @@ FactoryBot.define do
       end
     end
 
+    factory :project_with_active_native_survey_phase do
+      after(:create) do |project, _evaluator|
+        project.phases << create(:active_phase, project: project, participation_method: 'native_survey')
+      end
+    end
+
     factory :project_with_past_phases do
       transient do
         phases_count { 5 }

--- a/back/spec/policies/phase_policy_spec.rb
+++ b/back/spec/policies/phase_policy_spec.rb
@@ -18,6 +18,7 @@ describe PhasePolicy do
       it { is_expected.not_to permit(:create)  }
       it { is_expected.not_to permit(:update)  }
       it { is_expected.not_to permit(:destroy) }
+      it { is_expected.not_to permit(:survey_results) }
 
       it 'should index the phase' do
         expect(scope.resolve.size).to eq 1
@@ -31,6 +32,7 @@ describe PhasePolicy do
       it { is_expected.not_to permit(:create)  }
       it { is_expected.not_to permit(:update)  }
       it { is_expected.not_to permit(:destroy) }
+      it { is_expected.not_to permit(:survey_results) }
 
       it 'should index the phase' do
         expect(scope.resolve.size).to eq 1
@@ -44,6 +46,7 @@ describe PhasePolicy do
       it { is_expected.to    permit(:create)  }
       it { is_expected.to    permit(:update)  }
       it { is_expected.to    permit(:destroy) }
+      it { is_expected.to    permit(:survey_results) }
 
       it 'should index the phase' do
         expect(scope.resolve.size).to eq 1
@@ -60,6 +63,7 @@ describe PhasePolicy do
     it { is_expected.not_to permit(:create)  }
     it { is_expected.not_to permit(:update)  }
     it { is_expected.not_to permit(:destroy) }
+    it { is_expected.not_to permit(:survey_results) }
 
     it 'should not index the phase' do
       expect(scope.resolve.size).to eq 0
@@ -75,6 +79,7 @@ describe PhasePolicy do
     it { is_expected.not_to permit(:create)  }
     it { is_expected.not_to permit(:update)  }
     it { is_expected.not_to permit(:destroy) }
+    it { is_expected.not_to permit(:survey_results) }
 
     it 'should not index the phase' do
       expect(scope.resolve.size).to eq 0
@@ -90,6 +95,7 @@ describe PhasePolicy do
     it { is_expected.not_to permit(:create)  }
     it { is_expected.not_to permit(:update)  }
     it { is_expected.not_to permit(:destroy) }
+    it { is_expected.not_to permit(:survey_results) }
 
     it 'should index the phase' do
       expect(scope.resolve.size).to eq 1

--- a/back/spec/policies/project_policy_spec.rb
+++ b/back/spec/policies/project_policy_spec.rb
@@ -19,6 +19,8 @@ describe ProjectPolicy do
       it { is_expected.not_to permit(:update)  }
       it { is_expected.not_to permit(:reorder) }
       it { is_expected.not_to permit(:destroy) }
+      it { is_expected.not_to permit(:index_xlsx) }
+      it { is_expected.not_to permit(:survey_results) }
 
       it 'should index the project' do
         expect(scope.resolve.size).to eq 1
@@ -33,6 +35,8 @@ describe ProjectPolicy do
       it { is_expected.not_to permit(:update)  }
       it { is_expected.not_to permit(:reorder) }
       it { is_expected.not_to permit(:destroy) }
+      it { is_expected.not_to permit(:index_xlsx) }
+      it { is_expected.not_to permit(:survey_results) }
 
       it 'should index the project' do
         expect(scope.resolve.size).to eq 1
@@ -51,6 +55,8 @@ describe ProjectPolicy do
       it { is_expected.to permit(:update)  }
       it { is_expected.to permit(:reorder) }
       it { is_expected.to permit(:destroy) }
+      it { is_expected.to permit(:index_xlsx) }
+      it { is_expected.to permit(:survey_results) }
 
       it 'should index the project' do
         expect(scope.resolve.size).to eq 1
@@ -73,6 +79,8 @@ describe ProjectPolicy do
       it { is_expected.not_to permit(:update)  }
       it { is_expected.not_to permit(:reorder) }
       it { is_expected.not_to permit(:destroy) }
+      it { is_expected.not_to permit(:index_xlsx) }
+      it { is_expected.not_to permit(:survey_results) }
 
       it 'should not index the project'  do
         expect(scope.resolve.size).to eq 0
@@ -87,6 +95,8 @@ describe ProjectPolicy do
       it { is_expected.not_to permit(:update)  }
       it { is_expected.not_to permit(:reorder) }
       it { is_expected.not_to permit(:destroy) }
+      it { is_expected.not_to permit(:index_xlsx) }
+      it { is_expected.not_to permit(:survey_results) }
 
       it 'should not index the project'  do
         expect(scope.resolve.size).to eq 0
@@ -105,6 +115,8 @@ describe ProjectPolicy do
       it { is_expected.to permit(:update)  }
       it { is_expected.to permit(:reorder) }
       it { is_expected.to permit(:destroy) }
+      it { is_expected.to permit(:index_xlsx) }
+      it { is_expected.to permit(:survey_results) }
 
       it 'should index the project' do
         expect(scope.resolve.size).to eq 1
@@ -125,6 +137,8 @@ describe ProjectPolicy do
     it { is_expected.not_to permit(:update)  }
     it { is_expected.not_to permit(:reorder) }
     it { is_expected.not_to permit(:destroy) }
+    it { is_expected.not_to permit(:index_xlsx) }
+    it { is_expected.not_to permit(:survey_results) }
 
     it 'should not index the project'  do
       expect(scope.resolve.size).to eq 0
@@ -140,6 +154,8 @@ describe ProjectPolicy do
     it { is_expected.not_to permit(:update)  }
     it { is_expected.not_to permit(:reorder) }
     it { is_expected.not_to permit(:destroy) }
+    it { is_expected.not_to permit(:index_xlsx) }
+    it { is_expected.not_to permit(:survey_results) }
 
     it 'should not index the project'  do
       expect(scope.resolve.size).to eq 0
@@ -159,6 +175,8 @@ describe ProjectPolicy do
     it { is_expected.not_to permit(:update)  }
     it { is_expected.not_to permit(:reorder) }
     it { is_expected.not_to permit(:destroy) }
+    it { is_expected.not_to permit(:index_xlsx) }
+    it { is_expected.not_to permit(:survey_results) }
 
     it 'should index the project' do
       expect(scope.resolve.size).to eq 1
@@ -178,6 +196,8 @@ describe ProjectPolicy do
     it { is_expected.to permit(:update)  }
     it { is_expected.to permit(:reorder) }
     it { is_expected.to permit(:destroy) }
+    it { is_expected.to permit(:index_xlsx) }
+    it { is_expected.to permit(:survey_results) }
 
     it 'should index the project' do
       expect(scope.resolve.size).to eq 1
@@ -199,6 +219,8 @@ describe ProjectPolicy do
       it { is_expected.not_to permit(:update)  }
       it { is_expected.not_to permit(:reorder) }
       it { is_expected.not_to permit(:destroy) }
+      it { is_expected.not_to permit(:index_xlsx) }
+      it { is_expected.not_to permit(:survey_results) }
 
       it 'should not index the project'  do
         expect(scope.resolve.size).to eq 0
@@ -213,6 +235,8 @@ describe ProjectPolicy do
       it { is_expected.not_to permit(:update)  }
       it { is_expected.not_to permit(:reorder) }
       it { is_expected.not_to permit(:destroy) }
+      it { is_expected.not_to permit(:index_xlsx) }
+      it { is_expected.not_to permit(:survey_results) }
 
       it 'should not index the project'  do
         expect(scope.resolve.size).to eq 0
@@ -231,6 +255,8 @@ describe ProjectPolicy do
       it { is_expected.to permit(:update)  }
       it { is_expected.to permit(:reorder) }
       it { is_expected.to permit(:destroy) }
+      it { is_expected.to permit(:index_xlsx) }
+      it { is_expected.to permit(:survey_results) }
 
       it 'should index the project' do
         expect(scope.resolve.size).to eq 1

--- a/back/spec/services/survey_results_generator_service_spec.rb
+++ b/back/spec/services/survey_results_generator_service_spec.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# This spec describes:
+#   * Unsupported fields are not considered. Unsupported means that we do
+#     not have a visit_xxx method on the described class.
+#   * Results are generated only for reportable fields (i.e. enabled).
+#   * Missing values for fields are not counted.
+#   * Results are ordered in descending order.
+#   * Result generation is supported for projects and phases.
+
+RSpec.describe SurveyResultsGeneratorService do
+  subject(:generator) { described_class.new participation_context }
+
+  let(:text_field) do
+    create(
+      :custom_field,
+      resource: form,
+      title_multiloc: {
+        'en' => 'What is your favourite colour?'
+      },
+      description_multiloc: {}
+    )
+  end
+  let!(:disabled_multiselect_field) do
+    create(
+      :custom_field_multiselect,
+      resource: form,
+      title_multiloc: { 'en' => 'What are your favourite colours?' },
+      description_multiloc: {},
+      enabled: false
+    )
+  end
+  let(:multiselect_field) do
+    create(
+      :custom_field_multiselect,
+      resource: form,
+      title_multiloc: {
+        'en' => 'What are your favourite pets?',
+        'fr-BE' => 'Quels sont vos animaux de compagnie préférés ?',
+        'nl-BE' => 'Wat zijn je favoriete huisdieren?'
+      },
+      description_multiloc: {}
+    )
+  end
+  let!(:cat_option) do
+    create(
+      :custom_field_option,
+      custom_field: multiselect_field,
+      key: 'cat',
+      title_multiloc: { 'en' => 'Cat', 'fr-BE' => 'Chat', 'nl-BE' => 'Kat' }
+    )
+  end
+  let!(:dog_option) do
+    create(
+      :custom_field_option,
+      custom_field: multiselect_field,
+      key: 'dog',
+      title_multiloc: { 'en' => 'Dog', 'fr-BE' => 'Chien', 'nl-BE' => 'Hond' }
+    )
+  end
+  let!(:cow_option) do
+    create(
+      :custom_field_option,
+      custom_field: multiselect_field,
+      key: 'cow',
+      title_multiloc: { 'en' => 'Cow', 'fr-BE' => 'Vache', 'nl-BE' => 'Koe' }
+    )
+  end
+  let!(:pig_option) do
+    create(
+      :custom_field_option,
+      custom_field: multiselect_field,
+      key: 'pig',
+      title_multiloc: { 'en' => 'Pig', 'fr-BE' => 'Porc', 'nl-BE' => 'Varken' }
+    )
+  end
+
+  before do
+    create(
+      :idea,
+      project: project,
+      phases: phases_of_inputs,
+      custom_field_values: { text_field.key => 'Red', multiselect_field.key => %w[cat dog] }
+    )
+    create(
+      :idea,
+      project: project,
+      phases: phases_of_inputs,
+      custom_field_values: { text_field.key => 'Blue', multiselect_field.key => %w[cow pig cat] }
+    )
+    create(
+      :idea,
+      project: project,
+      phases: phases_of_inputs,
+      custom_field_values: { text_field.key => 'Green', multiselect_field.key => %w[cat dog] }
+    )
+    create(
+      :idea,
+      project: project,
+      phases: phases_of_inputs,
+      custom_field_values: { text_field.key => 'Pink', multiselect_field.key => %w[dog cat cow] }
+    )
+    create(:idea, project: project, phases: phases_of_inputs, custom_field_values: {})
+  end
+
+  describe '#generate' do
+    let(:expected_result) do
+      {
+        data: {
+          results: [
+            {
+              inputType: 'multiselect',
+              question: {
+                'en' => 'What are your favourite pets?',
+                'fr-BE' => 'Quels sont vos animaux de compagnie préférés ?',
+                'nl-BE' => 'Wat zijn je favoriete huisdieren?'
+              },
+              totalResponses: 10,
+              answers: [
+                { answer: { 'en' => 'Cat', 'fr-BE' => 'Chat', 'nl-BE' => 'Kat' }, responses: 4 },
+                { answer: { 'en' => 'Dog', 'fr-BE' => 'Chien', 'nl-BE' => 'Hond' }, responses: 3 },
+                { answer: { 'en' => 'Cow', 'fr-BE' => 'Vache', 'nl-BE' => 'Koe' }, responses: 2 },
+                { answer: { 'en' => 'Pig', 'fr-BE' => 'Porc', 'nl-BE' => 'Varken' }, responses: 1 }
+              ]
+            }
+          ]
+        },
+        totalSubmissions: 5
+      }
+    end
+
+    context 'for a project' do
+      let(:project) { create(:continuous_native_survey_project) }
+      let(:form) { create(:custom_form, participation_context: project) }
+      let(:participation_context) { project }
+      let(:phases_of_inputs) { [] }
+
+      it 'returns the results' do
+        expect(generator.generate).to eq expected_result
+      end
+    end
+
+    context 'for a phase' do
+      let(:project) { create(:project_with_active_native_survey_phase) }
+      let(:active_phase) { project.phases.first }
+      let(:form) { create(:custom_form, participation_context: active_phase) }
+      let(:participation_context) { active_phase }
+      let(:phases_of_inputs) { [active_phase] }
+
+      it 'returns the results' do
+        expect(generator.generate).to eq expected_result
+      end
+    end
+  end
+end

--- a/back/spec/services/survey_results_generator_service_spec.rb
+++ b/back/spec/services/survey_results_generator_service_spec.rb
@@ -10,7 +10,7 @@ require 'rails_helper'
 #   * Results are ordered in descending order.
 #   * Result generation is supported for projects and phases.
 
-RSpec.describe SurveyResultsGeneratorService do
+RSpec.describe SurveyResultsGeneratorService, skip: !CitizenLab.ee? do
   subject(:generator) { described_class.new participation_context }
 
   let(:text_field) do
@@ -78,7 +78,6 @@ RSpec.describe SurveyResultsGeneratorService do
   end
 
   before do
-    SettingsService.new.activate_feature! 'dynamic_idea_form'
     create(
       :idea,
       project: project,

--- a/back/spec/services/survey_results_generator_service_spec.rb
+++ b/back/spec/services/survey_results_generator_service_spec.rb
@@ -78,7 +78,6 @@ RSpec.describe SurveyResultsGeneratorService do
   end
 
   before do
-    SettingsService.new.activate_feature! 'idea_custom_fields'
     SettingsService.new.activate_feature! 'dynamic_idea_form'
     create(
       :idea,

--- a/back/spec/services/survey_results_generator_service_spec.rb
+++ b/back/spec/services/survey_results_generator_service_spec.rb
@@ -78,6 +78,8 @@ RSpec.describe SurveyResultsGeneratorService do
   end
 
   before do
+    SettingsService.new.activate_feature! 'idea_custom_fields'
+    SettingsService.new.activate_feature! 'dynamic_idea_form'
     create(
       :idea,
       project: project,


### PR DESCRIPTION
This PR adds the endpoints as described in https://www.notion.so/citizenlab/Proposed-response-structure-to-be-used-with-survey-results-a6e88e2183af424ea340bbb500207236.

In the context of the UDM, I am not sure whether having the word `survey` in the endpoints (and the results generator class) is a good idea. Maybe it is better to use `web_api/v1/phases/<phase_id>/results`.

## Checklist

- [x] Added entry to changelog
No, because this branch will be merged in the iteration 3 branch.

- [x] WCAG 2.1 AA proof
N/A

- [x] Tests
Included.

### Unit tests

Included.

### E2E tests

N/A

- [x] Prepared branch for code review
Yes

## Links

- [citizenlab-ee PR](**put URL here** or remove)
- [Specs](**put URL here** or remove)
- [Epic Deployment](**put URL here** or remove)

## How urgent is a code review?

Let the reviewer(s) know how urgent the code review is, so they can prioritize their work accordingly. Be specific (e.g. by Wednesday, end of the day/this week/... is better than 'urgent' or 'very urgent'). Optionally provide a word of explanation on your deadline.
