### PR TITLE
CL-1646 Link to community guide is wrong in some languages

### DIFF
--- a/front/app/translations/admin/da-DK.json
+++ b/front/app/translations/admin/da-DK.json
@@ -1363,7 +1363,7 @@
   "app.containers.AdminPage.SideBar.insights": "Indsigt",
   "app.containers.AdminPage.SideBar.invitations": "Invitationer",
   "app.containers.AdminPage.SideBar.linkToAcademy": "https://academy.citizenlab.co/",
-  "app.containers.AdminPage.SideBar.linkToGuide": "https://community.citizenlab.co/folders/guide",
+  "app.containers.AdminPage.SideBar.linkToGuide": "https://community.citizenlab.co/da-DK/folders/guide",
   "app.containers.AdminPage.SideBar.menu": "Sider og menu",
   "app.containers.AdminPage.SideBar.messaging": "Meddelelser",
   "app.containers.AdminPage.SideBar.moderation": "Aktivitet",

--- a/front/app/translations/admin/de-DE.json
+++ b/front/app/translations/admin/de-DE.json
@@ -1363,7 +1363,7 @@
   "app.containers.AdminPage.SideBar.insights": "Berichterstattung",
   "app.containers.AdminPage.SideBar.invitations": "Einladungen",
   "app.containers.AdminPage.SideBar.linkToAcademy": "https://academy.citizenlab.co/",
-  "app.containers.AdminPage.SideBar.linkToGuide": "https://community.citizenlab.co/de-De/folders/guide",
+  "app.containers.AdminPage.SideBar.linkToGuide": "https://community.citizenlab.co/de-DE/folders/guide",
   "app.containers.AdminPage.SideBar.menu": "Navigation",
   "app.containers.AdminPage.SideBar.messaging": "Nachrichten",
   "app.containers.AdminPage.SideBar.moderation": "Aktivität",

--- a/front/app/translations/admin/en-CA.json
+++ b/front/app/translations/admin/en-CA.json
@@ -1363,7 +1363,7 @@
   "app.containers.AdminPage.SideBar.insights": "Reporting",
   "app.containers.AdminPage.SideBar.invitations": "Invitations",
   "app.containers.AdminPage.SideBar.linkToAcademy": "https://academy.citizenlab.co/",
-  "app.containers.AdminPage.SideBar.linkToGuide": "https://community.citizenlab.co/folders/guide",
+  "app.containers.AdminPage.SideBar.linkToGuide": "https://community.citizenlab.co/en/folders/guide",
   "app.containers.AdminPage.SideBar.menu": "Pages & menu",
   "app.containers.AdminPage.SideBar.messaging": "Messaging",
   "app.containers.AdminPage.SideBar.moderation": "Activity",

--- a/front/app/translations/admin/en-GB.json
+++ b/front/app/translations/admin/en-GB.json
@@ -1363,7 +1363,7 @@
   "app.containers.AdminPage.SideBar.insights": "Reporting",
   "app.containers.AdminPage.SideBar.invitations": "Invitations",
   "app.containers.AdminPage.SideBar.linkToAcademy": "https://academy.citizenlab.co/",
-  "app.containers.AdminPage.SideBar.linkToGuide": "https://community.citizenlab.co/folders/guide",
+  "app.containers.AdminPage.SideBar.linkToGuide": "https://community.citizenlab.co/en/folders/guide",
   "app.containers.AdminPage.SideBar.menu": "Pages & menu",
   "app.containers.AdminPage.SideBar.messaging": "Messaging",
   "app.containers.AdminPage.SideBar.moderation": "Activity",

--- a/front/app/translations/admin/en.json
+++ b/front/app/translations/admin/en.json
@@ -1363,7 +1363,7 @@
   "app.containers.AdminPage.SideBar.insights": "Reporting",
   "app.containers.AdminPage.SideBar.invitations": "Invitations",
   "app.containers.AdminPage.SideBar.linkToAcademy": "https://academy.citizenlab.co/",
-  "app.containers.AdminPage.SideBar.linkToGuide": "https://community.citizenlab.co/folders/guide",
+  "app.containers.AdminPage.SideBar.linkToGuide": "https://community.citizenlab.co/en/folders/guide",
   "app.containers.AdminPage.SideBar.menu": "Pages & menu",
   "app.containers.AdminPage.SideBar.messaging": "Messaging",
   "app.containers.AdminPage.SideBar.moderation": "Activity",

--- a/front/app/translations/admin/es-CL.json
+++ b/front/app/translations/admin/es-CL.json
@@ -1363,7 +1363,7 @@
   "app.containers.AdminPage.SideBar.insights": "Reportar",
   "app.containers.AdminPage.SideBar.invitations": "Invitaciones",
   "app.containers.AdminPage.SideBar.linkToAcademy": "https://academy.citizenlab.co/",
-  "app.containers.AdminPage.SideBar.linkToGuide": "https://community.citizenlab.co/folders/guide",
+  "app.containers.AdminPage.SideBar.linkToGuide": "https://community.citizenlab.co/es-CL/folders/guide",
   "app.containers.AdminPage.SideBar.menu": "Páginas y menú",
   "app.containers.AdminPage.SideBar.messaging": "Mensajería ",
   "app.containers.AdminPage.SideBar.moderation": "Actividad",

--- a/front/app/translations/admin/es-ES.json
+++ b/front/app/translations/admin/es-ES.json
@@ -1363,7 +1363,7 @@
   "app.containers.AdminPage.SideBar.insights": "Reportar",
   "app.containers.AdminPage.SideBar.invitations": "Invitaciones",
   "app.containers.AdminPage.SideBar.linkToAcademy": "https://academy.citizenlab.co/",
-  "app.containers.AdminPage.SideBar.linkToGuide": "https://community.citizenlab.co/en/folders/guide",
+  "app.containers.AdminPage.SideBar.linkToGuide": "https://community.citizenlab.co/es-CL/folders/guide",
   "app.containers.AdminPage.SideBar.menu": "Páginas y menú",
   "app.containers.AdminPage.SideBar.messaging": "Mensajería",
   "app.containers.AdminPage.SideBar.moderation": "Actividad",

--- a/front/app/translations/admin/fr-BE.json
+++ b/front/app/translations/admin/fr-BE.json
@@ -1363,7 +1363,7 @@
   "app.containers.AdminPage.SideBar.insights": "Reporting",
   "app.containers.AdminPage.SideBar.invitations": "Invitations",
   "app.containers.AdminPage.SideBar.linkToAcademy": "https://academy.citizenlab.co/",
-  "app.containers.AdminPage.SideBar.linkToGuide": "https://community.citizenlab.co/folders/guide",
+  "app.containers.AdminPage.SideBar.linkToGuide": "https://community.citizenlab.co/fr-BE/folders/guide",
   "app.containers.AdminPage.SideBar.menu": "Pages et menu",
   "app.containers.AdminPage.SideBar.messaging": "Messagerie",
   "app.containers.AdminPage.SideBar.moderation": "Activité",

--- a/front/app/translations/admin/fr-FR.json
+++ b/front/app/translations/admin/fr-FR.json
@@ -1363,7 +1363,7 @@
   "app.containers.AdminPage.SideBar.insights": "Reporting",
   "app.containers.AdminPage.SideBar.invitations": "Invitations",
   "app.containers.AdminPage.SideBar.linkToAcademy": "https://academy.citizenlab.co/",
-  "app.containers.AdminPage.SideBar.linkToGuide": "https://community.citizenlab.co/folders/guide",
+  "app.containers.AdminPage.SideBar.linkToGuide": "https://community.citizenlab.co/fr-BE/folders/guide",
   "app.containers.AdminPage.SideBar.menu": "Pages et menu",
   "app.containers.AdminPage.SideBar.messaging": "Messagerie",
   "app.containers.AdminPage.SideBar.moderation": "Activité",

--- a/front/app/translations/admin/nl-BE.json
+++ b/front/app/translations/admin/nl-BE.json
@@ -1363,7 +1363,7 @@
   "app.containers.AdminPage.SideBar.insights": "Rapportering",
   "app.containers.AdminPage.SideBar.invitations": "Uitnodigingen",
   "app.containers.AdminPage.SideBar.linkToAcademy": "https://academy.citizenlab.co/nl",
-  "app.containers.AdminPage.SideBar.linkToGuide": "https://community.citizenlab.co/nl-Be/folders/guide",
+  "app.containers.AdminPage.SideBar.linkToGuide": "https://community.citizenlab.co/nl-BE/folders/guide",
   "app.containers.AdminPage.SideBar.menu": "Pagina's en menu",
   "app.containers.AdminPage.SideBar.messaging": "Berichten",
   "app.containers.AdminPage.SideBar.moderation": "Activiteit",

--- a/front/app/translations/admin/nl-NL.json
+++ b/front/app/translations/admin/nl-NL.json
@@ -1363,7 +1363,7 @@
   "app.containers.AdminPage.SideBar.insights": "Rapportering",
   "app.containers.AdminPage.SideBar.invitations": "Uitnodigingen",
   "app.containers.AdminPage.SideBar.linkToAcademy": "https://academy.citizenlab.co/nl",
-  "app.containers.AdminPage.SideBar.linkToGuide": "https://community.citizenlab.co/folders/guide",
+  "app.containers.AdminPage.SideBar.linkToGuide": "https://community.citizenlab.co/nl-BE/folders/guide",
   "app.containers.AdminPage.SideBar.menu": "Pagina's en menu",
   "app.containers.AdminPage.SideBar.messaging": "Berichten",
   "app.containers.AdminPage.SideBar.moderation": "Activiteit",


### PR DESCRIPTION
Fixed links to community guide. In some languages, it contained a typo, in others, it was the default link without language code, which could cause them to see the platform in a different language, if previously, they visited that platform in a different language.