### PR TITLE
[CL-1715] Do not return a frozen empty string as translation, because it may be manipulated later on

### DIFF
--- a/back/app/services/multiloc_service.rb
+++ b/back/app/services/multiloc_service.rb
@@ -13,7 +13,7 @@ class MultilocService
     result = ([user_locale] + locales + translations.keys).each do |locale|
       break translations[locale] if translations[locale]
     end
-    result.is_a?(String) ? result : ''
+    result.is_a?(String) ? result : +'' # return a non-frozen empty string
   end
 
   def i18n_to_multiloc(key, locales: nil)

--- a/back/spec/services/multiloc_service_spec.rb
+++ b/back/spec/services/multiloc_service_spec.rb
@@ -48,8 +48,10 @@ describe MultilocService do
       expect(service.t(translations, user)).to eq 'wort'
     end
 
-    it 'returns an empty string when no translation is defined' do
-      expect(service.t({}, user)).to eq ''
+    it 'returns an empty unfrozen string when no translation is defined' do
+      translation = service.t({}, user)
+      expect(translation).to eq ''
+      expect(translation).not_to be_frozen
     end
 
     it "returns an empty string when that's what the translations define" do


### PR DESCRIPTION
See https://citizenlab.atlassian.net/browse/CL-1715 for a description of the problem.

## How urgent is a code review?

This bug is an issue for native surveys, and probably for custom fields in general. Reviewing is not urgent, but the sooner the better 😃 
