### PR TITLE
[CL-1546] linear scale fix

### DIFF
--- a/back/app/services/json_schema_generator_service.rb
+++ b/back/app/services/json_schema_generator_service.rb
@@ -177,14 +177,9 @@ class JsonSchemaGeneratorService < FieldVisitorService
 
   def visit_linear_scale(field)
     {
-      type: 'object',
-      properties: {
-        rating: {
-          type: 'integer',
-          minimum: 1,
-          maximum: field.maximum
-        }
-      }
+      type: 'number',
+      minimum: 1,
+      maximum: field.maximum
     }
   end
 

--- a/back/spec/services/json_schema_generator_service_spec.rb
+++ b/back/spec/services/json_schema_generator_service_spec.rb
@@ -361,14 +361,9 @@ RSpec.describe JsonSchemaGeneratorService do
 
     it 'returns the schema for the given field' do
       expect(generator.visit_linear_scale(field)).to eq({
-        type: 'object',
-        properties: {
-          rating: {
-            type: 'integer',
-            minimum: 1,
-            maximum: field.maximum
-          }
-        }
+        type: 'number',
+        minimum: 1,
+        maximum: field.maximum
       })
     end
   end

--- a/front/app/components/Form/Components/Controls/LinearScaleControl.test.tsx
+++ b/front/app/components/Form/Components/Controls/LinearScaleControl.test.tsx
@@ -15,14 +15,9 @@ const mockJSONSchema = {
   additionalProperties: false,
   properties: {
     linear_scale: {
-      type: 'object',
-      properties: {
-        rating: {
-          type: 'integer',
-          minimum: 1,
-          maximum: 5,
-        },
-      },
+      type: 'number',
+      minimum: 1,
+      maximum: 5,
     },
   },
   required: ['linear_scale'],

--- a/front/app/components/Form/Components/Controls/LinearScaleControl.tsx
+++ b/front/app/components/Form/Components/Controls/LinearScaleControl.tsx
@@ -21,7 +21,8 @@ const LinearScaleControl = ({
   handleChange,
   id,
 }: ControlProps) => {
-  const maximum = schema?.properties?.rating?.maximum;
+  const maximum = schema?.maximum;
+
   return (
     <>
       <FormLabel
@@ -55,11 +56,11 @@ const LinearScaleControl = ({
                 <br />
                 <Radio
                   name="linear_scale"
-                  currentValue={data?.rating}
+                  currentValue={data}
                   value={visualIndex}
                   key={i}
                   id={rowId}
-                  onChange={(value) => handleChange(path, { rating: value })}
+                  onChange={(value) => handleChange(path, value)}
                 />
               </Box>
             );


### PR DESCRIPTION
This PR changes how linear scale is generated in the json schema, so that the value is a simple number, instead of an object `{rating: <number>}`.

This PR also fixes an oversight: the labels of the min and max values in the survey results should include the number and a hyphen. After checking with Ben, the hyphen is not included if the minimum label or maximum label is not configured for the field.