### PR TITLE
Disable index.html cache

### DIFF
--- a/front/app/index.html
+++ b/front/app/index.html
@@ -2,6 +2,11 @@
 <html>
   <head>
     <meta charset="utf-8" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta
+      http-equiv="cache-control"
+      content="no-cache, no-store, must-revalidate"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <% if (process.env.NODE_ENV==="production") { %>
     <link


### PR DESCRIPTION
Taking a look at the unhandled sentry FE errors and we seem to be having a lot of [chunk load errors](https://sentry.hq.citizenlab.co/organizations/citizenlab/issues/?cursor=1663159760000%3A0%3A0&page=5&project=3&query=is%3Aunresolved+error.unhandled%3Atrue&statsPeriod=14d). I think this might be resolved (at least partially) if we disable caching for the index.html. Wondering if adding the relevant meta tags to the `index.html` file is enough though or maybe we need to configure it elsewhere, as well?
