### PR TITLE
[CL-900] Fix feature flag check for customizable homepage banner

### DIFF
--- a/front/app/modules/commercial/customizable_homepage_banner/index.tsx
+++ b/front/app/modules/commercial/customizable_homepage_banner/index.tsx
@@ -1,40 +1,57 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { ModuleConfiguration } from 'utils/moduleUtils';
 import LayoutSetting from './admin/LayoutSetting';
 import TwoColumnLayout from './citizen/TwoColumnLayout';
 import TwoRowLayout from './citizen/TwoRowLayout';
 import CTASettings from './admin/CTASettings';
 import CTA from './citizen/CTA';
-import FeatureFlag from 'components/FeatureFlag';
+import useFeatureFlag from 'hooks/useFeatureFlag';
+
+type RenderOnFeatureFlagProps = {
+  children: ReactNode;
+};
+
+const RenderOnFeatureFlag = ({ children }: RenderOnFeatureFlagProps) => {
+  // Could be more than just a feature flag check,
+  // hence we're not using the FeatureFlag component
+  const isEnabled = useFeatureFlag({
+    name: 'customizable_homepage_banner',
+    onlyCheckAllowed: true,
+  });
+  if (isEnabled) {
+    return <>{children}</>;
+  }
+  return null;
+};
 
 const configuration: ModuleConfiguration = {
   outlets: {
     'app.containers.Admin.settings.customize.headerSectionStart': (props) => {
       return (
-        <FeatureFlag name="customizable_homepage_banner">
+        <RenderOnFeatureFlag>
           <LayoutSetting {...props} />
-        </FeatureFlag>
+        </RenderOnFeatureFlag>
       );
     },
     'app.containers.Admin.settings.customize.headerSectionEnd': (props) => {
       return (
-        <FeatureFlag name="customizable_homepage_banner">
+        <RenderOnFeatureFlag>
           <CTASettings {...props} />
-        </FeatureFlag>
+        </RenderOnFeatureFlag>
       );
     },
     'app.containers.LandingPage.SignedOutHeader.CTA': (props) => {
       return (
-        <FeatureFlag name="customizable_homepage_banner">
+        <RenderOnFeatureFlag>
           <CTA signedIn={false} {...props} />
-        </FeatureFlag>
+        </RenderOnFeatureFlag>
       );
     },
     'app.containers.LandingPage.SignedInHeader.CTA': (props) => {
       return (
-        <FeatureFlag name="customizable_homepage_banner">
+        <RenderOnFeatureFlag>
           <CTA signedIn {...props} />
-        </FeatureFlag>
+        </RenderOnFeatureFlag>
       );
     },
     'app.containers.LandingPage.SignedOutHeader.index': ({


### PR DESCRIPTION
Before this fix The FE  assumed that `customizable_homepage_banner` still has the `enabled` flag, which it does not anymore. We simply want to check if the pricing plan allows the feature to be used (`allowed`).

Lucas helped us with the code, but we thought it's a good idea to have someone take a look @brentguf.

See https://citizenlabco.slack.com/archives/CQZGXTFGD/p1664276748835389 for details.