### PR TITLE
[CL-900] Replace enabled feature flags and related BE code

### DIFF
--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -190,9 +190,10 @@
         "title": "Customizable homepage banner",
         "description": "Customizable homepage banner.",
         "additionalProperties": false,
-        "required": ["allowed"],
+        "required": ["allowed", "enabled"],
         "properties": {
-          "allowed": { "type": "boolean", "default": false }
+          "allowed": { "type": "boolean", "default": false },
+          "enabled": { "type": "boolean", "default": false }
         }
       },
 
@@ -831,9 +832,10 @@
         "title": "Events Landing Page Widget",
         "description":	"Display a widget of the next upcoming events in your landing page.",
         "additionalProperties": false,
-        "required": ["allowed"],
+        "required": ["allowed", "enabled"],
         "properties": {
           "allowed": { "type": "boolean", "default": false},
+          "enabled": { "type": "boolean", "default": true},
           "widget_title": {"$ref": "#/definitions/multiloc_string"}
         }
       },

--- a/back/db/seeds/citizenlab.rb
+++ b/back/db/seeds/citizenlab.rb
@@ -23,7 +23,10 @@ AppConfiguration.create!(
       currency: ENV.fetch('CL_SETTINGS_CORE_CURRENCY', 'EUR'),
       reply_to_email: ENV.fetch('DEFAULT_FROM_EMAIL')
     },
-    customizable_homepage_banner: { allowed: true },
+    customizable_homepage_banner: {
+      allowed: true,
+      enabled: true
+    },
     password_login: {
       enabled: true,
       allowed: true,
@@ -166,6 +169,7 @@ AppConfiguration.create!(
       allowed: true
     },
     events_widget: {
+      enabled: true,
       allowed: true
     },
     native_surveys: {

--- a/back/spec/factories/app_configurations.rb
+++ b/back/spec/factories/app_configurations.rb
@@ -23,7 +23,10 @@ FactoryBot.define do
           'color_secondary' => Faker::Color.hex_color,
           'color_text' => Faker::Color.hex_color
         },
-        'customizable_homepage_banner' => { 'allowed' => true },
+        'customizable_homepage_banner' => {
+          'allowed' => true,
+          'enabled' => true
+        },
         'initiatives' => {
           'enabled' => true,
           'allowed' => true,
@@ -64,7 +67,10 @@ FactoryBot.define do
           'color_secondary' => Faker::Color.hex_color,
           'color_text' => Faker::Color.hex_color
         },
-        'customizable_homepage_banner' => { 'allowed' => true },
+        'customizable_homepage_banner' => {
+          'allowed' => true,
+          'enabled' => true
+        },
         'initiatives' => {
           'enabled' => true,
           'allowed' => true,


### PR DESCRIPTION
Fixes the loss of banner layout settings and CTA button settings from the homepage banner edit form, and the loss of related functionality on the homepage. Related [Slack thread](https://citizenlabco.slack.com/archives/C65GX921W/p1664291193063819).

Tested locally. Appears to work. As in: Now have banner layouts and CTA button settings back in homepage banner edit form + can see changes to banner layout on homepage (when logged out) + can see changes to banner CTA buttons on homepage.

[Sibling ee PR](https://github.com/CitizenLabDotCo/citizenlab-ee/pull/337)

## Urgency
High - master is currently broken without this fix. The sooner this is merged, the lower the risk of someone releasing the broken master branch to production.

## Remaining technical issues

`events_widget_enabled` remains in `Homepage.first` and is still used to toggle the widget on/off, and now this PR adds  the respective `enabled` field back into `AppConfig.first.settings['event_widget']`. So we now have the possibility of the two booleans getting out of sync (though not the end-of-the-world, since the former actually toggles the widget, the latter satisfies the various existing `feature_enabled` criteria).

We could resolve this by reverting to using the `AppConfig.first.settings['events_widget']` `enabled` value to actually toggle the widget (and remove the `HomePage` version of this field). My immediate thought is to do this afterwards, if we deem this necessary, since this PR as is should fix things for now and avoid the risk of losing the actual platform settings for this `enabled` boolean if released to production.

The `customizable_homepage_banner['enabled']` replacement does not come with such concerns, since there is no `HomePage` equivalent, so it will just be a flag that needs setting along with `allowed` in AdminHQ for the related features to be present and work.