### PR TITLE
[CL-900] Replace currently_working_on_text attribute

### DIFF
--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -122,6 +122,11 @@
             "pattern": "^$|^/.*$",
             "private": true
           },
+          "currently_working_on_text": {
+            "title": "Project Overview Header Title",
+            "description": "Header title shown at the top of all of the projects on the homepage. If left blank, this field defaults to \"{orgName} is currently working on\".",
+            "$ref": "#/definitions/multiloc_string"
+          },
           "signup_helper_text": {
             "title": "Sign-up Helper Text (Step 1)",
             "description": "Optional short text, shown at the top of Step 1 of the sign up form (i.e., email and password). Supports HTML.",


### PR DESCRIPTION
Tested locally and removes the problem with saving the `Settings: Customize` form.

I also tested the other forms in `Settings` and none seem to have problems.