### PR TITLE
Webpack minimization

### DIFF
--- a/front/internals/webpack/webpack.config.js
+++ b/front/internals/webpack/webpack.config.js
@@ -52,8 +52,10 @@ const config = {
     path: path.join(process.cwd(), 'build'),
     pathinfo: false,
     publicPath: '/',
-    filename: isDev ? '[name].js' : '[name].[contenthash].js',
-    chunkFilename: isDev ? '[name].chunk.js' : '[name].[contenthash].chunk.js',
+    filename: isDev ? '[name].js' : '[name].[contenthash].min.js',
+    chunkFilename: isDev
+      ? '[name].chunk.js'
+      : '[name].[contenthash].chunk.min.js',
   },
 
   mode: isDev ? 'development' : 'production',
@@ -87,11 +89,7 @@ const config = {
     optimization: {
       runtimeChunk: 'single',
       minimize: true,
-      splitChunks: {
-        chunks: 'all',
-      },
-      moduleIds: 'deterministic',
-      minimizer: [new CssMinimizerPlugin()],
+      minimizer: ['...', new CssMinimizerPlugin()],
     },
   }),
 
@@ -203,8 +201,8 @@ const config = {
 
     !isDev &&
       new MiniCssExtractPlugin({
-        filename: '[name].[contenthash].css',
-        chunkFilename: '[name].[contenthash].chunk.css',
+        filename: '[name].[contenthash].min.css',
+        chunkFilename: '[name].[contenthash].chunk.min.css',
       }),
 
     sourceMapToSentry &&


### PR DESCRIPTION
While looking at our build output I realized we are not minifying our javascript. Maybe it was the result of the webpack upgrade (or perhaps we never did? 🤔 )

Tweaked the webpack config to make sure we do now. We can see some significant gains (-7 sec in time to interactive) as a result. 

Before
<img width="896" alt="Pasted Graphic 1" src="https://user-images.githubusercontent.com/25869467/192998424-5537440f-550c-44e7-b742-a72748a5a209.png">

After:
<img width="956" alt="1,990 ms" src="https://user-images.githubusercontent.com/25869467/192998465-ae4f3401-c6a9-403e-9998-97e775d5d922.png">

