### PR TITLE
[No ticket] Upgrade to Puma 5.6.5

### DIFF
--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -27,4 +27,4 @@ COPY back/. .
 
 EXPOSE 4000
 
-CMD puma -C config/puma.rb
+CMD bundle exec puma -C config/puma.rb

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -864,7 +864,7 @@ GEM
       binding_of_caller (~> 1.0)
       pry (~> 0.13)
     public_suffix (4.0.7)
-    puma (5.6.4)
+    puma (5.6.5)
       nio4r (~> 2.0)
     que-web (0.9.3)
       que (~> 1.0.0.beta3)


### PR DESCRIPTION
Mostly bug fixes in this release, see https://github.com/puma/puma/releases/tag/v5.6.5 for details.

Also we now start puma via `bundle exec` in the Dockerfile, as advised in pumas README and to ensure we use the puma version specified in the Gemfile only.
