### PR TITLE
[CL-1762] Bugfix: Use Swedish content for default static_pages when creating tenant with Swedish locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Changelog
 
+### Fixed
+
+- [CL-1762] Default pages titles and content, and default navbar items, now display in Swedish for newly created platforms with the Swedish locale.
+
 ## 2022-09-30
 
 ### Added
 
 - [CL-1553] Basic privacy-friendly session counting for all visitors and users, for now not exposed in the product
-
-### Fixed
 
 ## 2022-09-29
 

--- a/back/config/initializers/1_locales.rb
+++ b/back/config/initializers/1_locales.rb
@@ -53,6 +53,7 @@ fallback_locales =
     pt
     ro
     sr
+    sv
     tr
   ].freeze
 

--- a/front/app/containers/App/constants.ts
+++ b/front/app/containers/App/constants.ts
@@ -116,8 +116,8 @@ export const appGraphqlLocalePairs = {
   roRo: 'ro-RO',
   srLatn: 'sr-Latn',
   srSp: 'sr-SP',
-  svSE: 'sv-SE',
-  trTR: 'tr-TR',
+  svSe: 'sv-SE',
+  trTr: 'tr-TR',
 };
 
 export const shortenedAppLocalePairs = {


### PR DESCRIPTION
[Jira ticket CL-1762](https://citizenlab.atlassian.net/browse/CL-1762)

With this fix, newly created tenants will now show the default `static_pages` with Swedish titles & content, and the navbar items will also be displayed in Swedish:

<img width="1434" alt="Screenshot 2022-10-01 at 18 09 11" src="https://user-images.githubusercontent.com/3944042/193420491-beb63f59-e65e-485d-9077-9fbd7f6abaca.png">

<img width="1434" alt="Screenshot 2022-10-01 at 19 01 27" src="https://user-images.githubusercontent.com/3944042/193422312-862e06c4-ab6b-436b-87a5-89e8aeb7065d.png">

For existing Swedish platforms that matter (e.g. active customer platforms), we will probably also need to manually update the `static_pages` `title_multiloc` and `body_multiloc` values:

<img width="1124" alt="Screenshot 2022-10-01 at 17 09 00" src="https://user-images.githubusercontent.com/3944042/193420570-c8dda827-81a4-4aec-a7ae-eef19aa6ea7b.png">