### PR TITLE
Fix e2e tests

### DIFF
--- a/front/cypress.config.ts
+++ b/front/cypress.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
-  viewportWidth: 1200,
+  viewportWidth: 1201,
   viewportHeight: 800,
   video: false,
   videoUploadOnPasses: false,


### PR DESCRIPTION
Makes sure we are always using the desktop view for e2e tests, unless specified otherwise in the test itself.