### PR TITLE
[CL-1561] Add sentry performance tracing

### DIFF
--- a/front/app/components/ErrorBoundary/index.tsx
+++ b/front/app/components/ErrorBoundary/index.tsx
@@ -3,7 +3,7 @@
 
 import React, { Component } from 'react';
 import { FormattedMessage, injectIntl } from 'utils/cl-intl';
-import { withScope, showReportDialog } from '@sentry/browser';
+import { withScope, showReportDialog } from '@sentry/react';
 import messages from './messages';
 import styled from 'styled-components';
 import { fontSizes, colors } from 'utils/styleUtils';

--- a/front/app/containers/App/index.tsx
+++ b/front/app/containers/App/index.tsx
@@ -11,7 +11,7 @@ import 'moment-timezone';
 import 'intersection-observer';
 import 'focus-visible';
 import smoothscroll from 'smoothscroll-polyfill';
-import { configureScope } from '@sentry/browser';
+import { configureScope } from '@sentry/react';
 import GlobalStyle from 'global-styles';
 
 // constants

--- a/front/app/root.tsx
+++ b/front/app/root.tsx
@@ -40,7 +40,7 @@ Sentry.init({
       ),
     }),
   ],
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0.05,
 });
 
 const useSentryRoutes = wrapUseRoutes(useRoutes);

--- a/front/app/utils/loggingUtils.ts
+++ b/front/app/utils/loggingUtils.ts
@@ -1,4 +1,4 @@
-import { captureMessage, captureException, withScope } from '@sentry/browser';
+import { captureMessage, captureException, withScope } from '@sentry/react';
 import { isEmpty, isError, isObject } from 'lodash-es';
 
 function isErrorOrErrorEvent(wat: any) {

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -18,8 +18,9 @@
         "@jsonforms/vanilla-renderers": "3.0.0-beta.1",
         "@researchgate/react-intersection-observer": "1.3.5",
         "@segment/snippet": "4.15.3",
-        "@sentry/browser": "7.3.1",
-        "@sentry/integrations": "7.3.1",
+        "@sentry/integrations": "7.14.1",
+        "@sentry/react": "^7.14.1",
+        "@sentry/tracing": "^7.14.1",
         "@tippyjs/react": "4.2.6",
         "ajv": "^8.9.0",
         "bowser": "1.x",
@@ -3441,13 +3442,13 @@
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.3.1.tgz",
-      "integrity": "sha512-x0LhK8hnrGEBBCZVsW9h3USW93agX+axXvUPu72SJMyMnwF+92XjpgOET48OdPNzej/bU8Qv+eXTC/VDh/HXvw==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.14.1.tgz",
+      "integrity": "sha512-b9nW2+kT9Jl/tfzJmvzpnS6F8ziC62TDx04a7kZDtuaVA5rKKTTlLDg8ZamCRFjjnuwuFhLnzxO34N0KfeTqHg==",
       "dependencies": {
-        "@sentry/core": "7.3.1",
-        "@sentry/types": "7.3.1",
-        "@sentry/utils": "7.3.1",
+        "@sentry/core": "7.14.1",
+        "@sentry/types": "7.14.1",
+        "@sentry/utils": "7.14.1",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -3482,13 +3483,13 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.3.1.tgz",
-      "integrity": "sha512-UYPNDluFtj5w6alh+SjSm9p6kxReKVcKEE+EPE4o44pdowjZ1BFTUY6ipMJhtIiDPr/51eeP8TuYdOAbo0Z9Pg==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.14.1.tgz",
+      "integrity": "sha512-sjk60Gf5o9zynhWe1e0ro9uQO4OrKZ3H9xfgBf2ExgKXeMfKzYp5r2v2OKNevEde36Sr/DzlpiPj8EK67xrWPA==",
       "dependencies": {
-        "@sentry/hub": "7.3.1",
-        "@sentry/types": "7.3.1",
-        "@sentry/utils": "7.3.1",
+        "@sentry/hub": "7.14.1",
+        "@sentry/types": "7.14.1",
+        "@sentry/utils": "7.14.1",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -3501,12 +3502,12 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/hub": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.3.1.tgz",
-      "integrity": "sha512-TFewt7zDvVLLrCfKkmvJEO4GPw3oPvR2t+606Z4S2gKiekGXKFGX4YC5u0ytoPfi+NMadXz4HivfrPuxrMy1JQ==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.14.1.tgz",
+      "integrity": "sha512-BWh5jUvGmzCsJtYy6EX3qA6gTOxwGhA64IEXHbzwIAnBoG+VWao3addaL77AGR9pIgAqn6ssfkX665OZa+GPGw==",
       "dependencies": {
-        "@sentry/types": "7.3.1",
-        "@sentry/utils": "7.3.1",
+        "@sentry/types": "7.14.1",
+        "@sentry/utils": "7.14.1",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -3519,12 +3520,12 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/integrations": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.3.1.tgz",
-      "integrity": "sha512-YA3IooY+MOspcnp3LKpP0SSefE6FTpVpyr20kab30hN54LzekohnAlikNwm8TzxvMa79Nm4IjtAEnTde07JYDQ==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.14.1.tgz",
+      "integrity": "sha512-viQkOOLa6YkXV8OV98BGqFY80emEDmfxOsLKc+AJe87nrb9j5ruobovFPwlJi0DlIMHdTtsoldBb/05bbVDKwg==",
       "dependencies": {
-        "@sentry/types": "7.3.1",
-        "@sentry/utils": "7.3.1",
+        "@sentry/types": "7.14.1",
+        "@sentry/utils": "7.14.1",
         "localforage": "^1.8.1",
         "tslib": "^1.9.3"
       },
@@ -3537,20 +3538,62 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
+    "node_modules/@sentry/react": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.14.1.tgz",
+      "integrity": "sha512-KPfreZ9O63RDlryh1YjYmycDlteulqcXqeRv/OzQCZb08RcSybdho1QyhKU4LeyTc3rCQx4TNo4rSSwgWxKvdg==",
+      "dependencies": {
+        "@sentry/browser": "7.14.1",
+        "@sentry/types": "7.14.1",
+        "@sentry/utils": "7.14.1",
+        "hoist-non-react-statics": "^3.3.2",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "react": "15.x || 16.x || 17.x || 18.x"
+      }
+    },
+    "node_modules/@sentry/react/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@sentry/tracing": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.14.1.tgz",
+      "integrity": "sha512-vs/GXOu3RRT9ethdRXdiXmYF11PFViIo70Nt6RWb/vKEykHTQ0Y5IYc3GtU7aC6DKqpJ1xZkNUfgvV/q3he/Eg==",
+      "dependencies": {
+        "@sentry/hub": "7.14.1",
+        "@sentry/types": "7.14.1",
+        "@sentry/utils": "7.14.1",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/tracing/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
     "node_modules/@sentry/types": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.3.1.tgz",
-      "integrity": "sha512-EZaRLJ8G2aSb7Vlpe1TR9LRZKY5gNpufuu8OXVrnTHiEMLHNUv1NrLQevy2m1SQUkg43oLdTyMKdM+nTESIC+A==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.14.1.tgz",
+      "integrity": "sha512-PxAfrIwBci6ouHOuRsfVq1B16i92nQNV5IvlqfJIYciazVhDWJvbF52caJAPOFS1WnuQZ4zqBDMYvtnwld3JCA==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.3.1.tgz",
-      "integrity": "sha512-lrwbyajioWeG/CTFCzRh0Pu+zd/P+A+ASToEy2WIQsRbUORZrOmHSVzP0KR+TSZE0TMNrwxUwjSYZoyWCfZ1wQ==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.14.1.tgz",
+      "integrity": "sha512-CErQFbJMuhnHFKGkfIazQj5ETKoS7hG8PkoQEBt19F5QMh4+sbrJgnpIrIW8fVGtp0qKWKuIxQwD3b+1cFBozA==",
       "dependencies": {
-        "@sentry/types": "7.3.1",
+        "@sentry/types": "7.14.1",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -23402,13 +23445,13 @@
       }
     },
     "@sentry/browser": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.3.1.tgz",
-      "integrity": "sha512-x0LhK8hnrGEBBCZVsW9h3USW93agX+axXvUPu72SJMyMnwF+92XjpgOET48OdPNzej/bU8Qv+eXTC/VDh/HXvw==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.14.1.tgz",
+      "integrity": "sha512-b9nW2+kT9Jl/tfzJmvzpnS6F8ziC62TDx04a7kZDtuaVA5rKKTTlLDg8ZamCRFjjnuwuFhLnzxO34N0KfeTqHg==",
       "requires": {
-        "@sentry/core": "7.3.1",
-        "@sentry/types": "7.3.1",
-        "@sentry/utils": "7.3.1",
+        "@sentry/core": "7.14.1",
+        "@sentry/types": "7.14.1",
+        "@sentry/utils": "7.14.1",
         "tslib": "^1.9.3"
       },
       "dependencies": {
@@ -23435,13 +23478,13 @@
       }
     },
     "@sentry/core": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.3.1.tgz",
-      "integrity": "sha512-UYPNDluFtj5w6alh+SjSm9p6kxReKVcKEE+EPE4o44pdowjZ1BFTUY6ipMJhtIiDPr/51eeP8TuYdOAbo0Z9Pg==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.14.1.tgz",
+      "integrity": "sha512-sjk60Gf5o9zynhWe1e0ro9uQO4OrKZ3H9xfgBf2ExgKXeMfKzYp5r2v2OKNevEde36Sr/DzlpiPj8EK67xrWPA==",
       "requires": {
-        "@sentry/hub": "7.3.1",
-        "@sentry/types": "7.3.1",
-        "@sentry/utils": "7.3.1",
+        "@sentry/hub": "7.14.1",
+        "@sentry/types": "7.14.1",
+        "@sentry/utils": "7.14.1",
         "tslib": "^1.9.3"
       },
       "dependencies": {
@@ -23453,12 +23496,12 @@
       }
     },
     "@sentry/hub": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.3.1.tgz",
-      "integrity": "sha512-TFewt7zDvVLLrCfKkmvJEO4GPw3oPvR2t+606Z4S2gKiekGXKFGX4YC5u0ytoPfi+NMadXz4HivfrPuxrMy1JQ==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.14.1.tgz",
+      "integrity": "sha512-BWh5jUvGmzCsJtYy6EX3qA6gTOxwGhA64IEXHbzwIAnBoG+VWao3addaL77AGR9pIgAqn6ssfkX665OZa+GPGw==",
       "requires": {
-        "@sentry/types": "7.3.1",
-        "@sentry/utils": "7.3.1",
+        "@sentry/types": "7.14.1",
+        "@sentry/utils": "7.14.1",
         "tslib": "^1.9.3"
       },
       "dependencies": {
@@ -23470,12 +23513,12 @@
       }
     },
     "@sentry/integrations": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.3.1.tgz",
-      "integrity": "sha512-YA3IooY+MOspcnp3LKpP0SSefE6FTpVpyr20kab30hN54LzekohnAlikNwm8TzxvMa79Nm4IjtAEnTde07JYDQ==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.14.1.tgz",
+      "integrity": "sha512-viQkOOLa6YkXV8OV98BGqFY80emEDmfxOsLKc+AJe87nrb9j5ruobovFPwlJi0DlIMHdTtsoldBb/05bbVDKwg==",
       "requires": {
-        "@sentry/types": "7.3.1",
-        "@sentry/utils": "7.3.1",
+        "@sentry/types": "7.14.1",
+        "@sentry/utils": "7.14.1",
         "localforage": "^1.8.1",
         "tslib": "^1.9.3"
       },
@@ -23487,17 +23530,54 @@
         }
       }
     },
+    "@sentry/react": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.14.1.tgz",
+      "integrity": "sha512-KPfreZ9O63RDlryh1YjYmycDlteulqcXqeRv/OzQCZb08RcSybdho1QyhKU4LeyTc3rCQx4TNo4rSSwgWxKvdg==",
+      "requires": {
+        "@sentry/browser": "7.14.1",
+        "@sentry/types": "7.14.1",
+        "@sentry/utils": "7.14.1",
+        "hoist-non-react-statics": "^3.3.2",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@sentry/tracing": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.14.1.tgz",
+      "integrity": "sha512-vs/GXOu3RRT9ethdRXdiXmYF11PFViIo70Nt6RWb/vKEykHTQ0Y5IYc3GtU7aC6DKqpJ1xZkNUfgvV/q3he/Eg==",
+      "requires": {
+        "@sentry/hub": "7.14.1",
+        "@sentry/types": "7.14.1",
+        "@sentry/utils": "7.14.1",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
     "@sentry/types": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.3.1.tgz",
-      "integrity": "sha512-EZaRLJ8G2aSb7Vlpe1TR9LRZKY5gNpufuu8OXVrnTHiEMLHNUv1NrLQevy2m1SQUkg43oLdTyMKdM+nTESIC+A=="
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.14.1.tgz",
+      "integrity": "sha512-PxAfrIwBci6ouHOuRsfVq1B16i92nQNV5IvlqfJIYciazVhDWJvbF52caJAPOFS1WnuQZ4zqBDMYvtnwld3JCA=="
     },
     "@sentry/utils": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.3.1.tgz",
-      "integrity": "sha512-lrwbyajioWeG/CTFCzRh0Pu+zd/P+A+ASToEy2WIQsRbUORZrOmHSVzP0KR+TSZE0TMNrwxUwjSYZoyWCfZ1wQ==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.14.1.tgz",
+      "integrity": "sha512-CErQFbJMuhnHFKGkfIazQj5ETKoS7hG8PkoQEBt19F5QMh4+sbrJgnpIrIW8fVGtp0qKWKuIxQwD3b+1cFBozA==",
       "requires": {
-        "@sentry/types": "7.3.1",
+        "@sentry/types": "7.14.1",
         "tslib": "^1.9.3"
       },
       "dependencies": {

--- a/front/package.json
+++ b/front/package.json
@@ -44,10 +44,10 @@
     "base": "master",
     "tasks": {
       "app/**/*.{ts,tsx,js,jsx}": [
-      "eslint --ext .js,.jsx,.ts,.tsx app --color --max-warnings=0"
-     ]
-  }
-},
+        "eslint --ext .js,.jsx,.ts,.tsx app --color --max-warnings=0"
+      ]
+    }
+  },
   "husky": {
     "hooks": {
       "pre-commit": "pretty-quick --staged",
@@ -65,8 +65,9 @@
     "@jsonforms/vanilla-renderers": "3.0.0-beta.1",
     "@researchgate/react-intersection-observer": "1.3.5",
     "@segment/snippet": "4.15.3",
-    "@sentry/browser": "7.3.1",
-    "@sentry/integrations": "7.3.1",
+    "@sentry/integrations": "7.14.1",
+    "@sentry/react": "^7.14.1",
+    "@sentry/tracing": "^7.14.1",
     "@tippyjs/react": "4.2.6",
     "ajv": "^8.9.0",
     "bowser": "1.x",


### PR DESCRIPTION
Added Sentry performance testing and replaced the SDK from `@sentry/browser` to `@sentry/react` which is the one we should be using. They've added support for `useRoutes` since the last time we looked at this, so this was not an issue.

Here are the relevant [docs](https://docs.sentry.io/platforms/javascript/guides/react/configuration/integrations/react-router/) for reference. 

My only doubt - how do I test this works without merging it to staging? Ideas welcome but if it's complicated, it's probably fine to test on staging, as well.