### PR TITLE
Add platform "aarch64-linux " to Gemflile.lock

### DIFF
--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -801,6 +801,10 @@ GEM
       ruby2_keywords (~> 0.0.1)
     netrc (0.11.0)
     nio4r (2.5.8)
+    nokogiri (1.13.8-aarch64-linux)
+      racc (~> 1.4)
+    nokogiri (1.13.8-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.8-x86_64-linux)
       racc (~> 1.4)
     nori (2.6.0)
@@ -1149,7 +1153,8 @@ GEM
     zeitwerk (2.6.0)
 
 PLATFORMS
-  ruby
+  aarch64-linux
+  arm64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
@@ -1301,4 +1306,4 @@ DEPENDENCIES
   webmock (~> 3.14)
 
 BUNDLED WITH
-   2.3.20
+   2.3.22


### PR DESCRIPTION
See https://citizenlabco.slack.com/archives/C65GX921W/p1664873893369649?thread_ts=1664797466.708959&cid=C65GX921W and the conversation that follows.

See the Bundler documentation: https://bundler.io/man/bundle-lock.1.html#:~:text=If%20you%20want%20your%20bundle,that%20matches%20PLATFORM%20handy%20to

This PR is the result of running `bundle lock --add-platform aarch64-linux`. It adds that platform, so that M1 Mac users can build correctly.