### PR TITLE
Cl 1699 suppress extra category label

### DIFF
--- a/back/app/services/input_ui_schema_generator_service.rb
+++ b/back/app/services/input_ui_schema_generator_service.rb
@@ -14,7 +14,9 @@ class InputUiSchemaGeneratorService < UiSchemaGeneratorService
   protected
 
   def generate_for_current_locale(fields)
-    input_term = fields.first.resource.participation_context&.input_term || ParticipationContext::DEFAULT_INPUT_TERM
+    participation_context = fields.first.resource.participation_context
+    participation_method = Factory.instance.participation_method_for participation_context
+    input_term = participation_context.input_term || ParticipationContext::DEFAULT_INPUT_TERM
     built_in_field_index = fields.select(&:built_in?).index_by(&:code)
     main_fields = built_in_field_index.slice('title_multiloc', 'author_id', 'body_multiloc').values
     details_fields = built_in_field_index.slice('proposed_budget', 'budget', 'topic_ids', 'location_description').values
@@ -25,7 +27,7 @@ class InputUiSchemaGeneratorService < UiSchemaGeneratorService
       category_for(main_fields, 'mainContent', "custom_forms.categories.main_content.#{input_term}.title"),
       category_for(details_fields, 'details', 'custom_forms.categories.details.title'),
       category_for(attachments_fields, 'attachments', 'custom_forms.categories.attachements.title'),
-      category_for(custom_fields, 'extra', 'custom_forms.categories.extra.title')
+      category_for(custom_fields, 'extra', participation_method.extra_fields_category_translation_key)
     ].compact
     {
       type: 'Categorization',
@@ -44,7 +46,7 @@ class InputUiSchemaGeneratorService < UiSchemaGeneratorService
 
     {
       type: 'Category',
-      label: I18n.t(translation_key),
+      label: (I18n.t(translation_key) if translation_key),
       options: { id: category_id },
       elements: fields.map { |field| visit field }
     }

--- a/back/lib/participation_method/base.rb
+++ b/back/lib/participation_method/base.rb
@@ -33,6 +33,10 @@ module ParticipationMethod
       false
     end
 
+    def extra_fields_category_translation_key
+      'custom_forms.categories.extra.title'
+    end
+
     private
 
     attr_reader :participation_context

--- a/back/lib/participation_method/native_survey.rb
+++ b/back/lib/participation_method/native_survey.rb
@@ -27,5 +27,12 @@ module ParticipationMethod
     def form_in_phase?
       true
     end
+
+    # The "Additional information" category in the UI should be suppressed.
+    # As long as the form builder does not support sections/categories,
+    # we can suppress the heading by returning nil.
+    def extra_fields_category_translation_key
+      nil
+    end
   end
 end

--- a/back/spec/lib/participation_method/budgeting_spec.rb
+++ b/back/spec/lib/participation_method/budgeting_spec.rb
@@ -76,4 +76,10 @@ RSpec.describe ParticipationMethod::Budgeting do
       expect(participation_method.form_in_phase?).to be false
     end
   end
+
+  describe '#extra_fields_category_translation_key' do
+    it 'returns the translation key for the extra fields category' do
+      expect(participation_method.extra_fields_category_translation_key).to eq 'custom_forms.categories.extra.title'
+    end
+  end
 end

--- a/back/spec/lib/participation_method/ideation_spec.rb
+++ b/back/spec/lib/participation_method/ideation_spec.rb
@@ -76,4 +76,10 @@ RSpec.describe ParticipationMethod::Ideation do
       expect(participation_method.form_in_phase?).to be false
     end
   end
+
+  describe '#extra_fields_category_translation_key' do
+    it 'returns the translation key for the extra fields category' do
+      expect(participation_method.extra_fields_category_translation_key).to eq 'custom_forms.categories.extra.title'
+    end
+  end
 end

--- a/back/spec/lib/participation_method/information_spec.rb
+++ b/back/spec/lib/participation_method/information_spec.rb
@@ -45,4 +45,10 @@ RSpec.describe ParticipationMethod::Information do
       expect(participation_method.form_in_phase?).to be false
     end
   end
+
+  describe '#extra_fields_category_translation_key' do
+    it 'returns the translation key for the extra fields category' do
+      expect(participation_method.extra_fields_category_translation_key).to eq 'custom_forms.categories.extra.title'
+    end
+  end
 end

--- a/back/spec/lib/participation_method/native_survey_spec.rb
+++ b/back/spec/lib/participation_method/native_survey_spec.rb
@@ -64,4 +64,10 @@ RSpec.describe ParticipationMethod::NativeSurvey do
       expect(participation_method.form_in_phase?).to be true
     end
   end
+
+  describe '#extra_fields_category_translation_key' do
+    it 'returns nil' do
+      expect(participation_method.extra_fields_category_translation_key).to be_nil
+    end
+  end
 end

--- a/back/spec/lib/participation_method/none_spec.rb
+++ b/back/spec/lib/participation_method/none_spec.rb
@@ -44,4 +44,10 @@ RSpec.describe ParticipationMethod::None do
       expect(participation_method.form_in_phase?).to be false
     end
   end
+
+  describe '#extra_fields_category_translation_key' do
+    it 'returns the translation key for the extra fields category' do
+      expect(participation_method.extra_fields_category_translation_key).to eq 'custom_forms.categories.extra.title'
+    end
+  end
 end

--- a/back/spec/lib/participation_method/poll_spec.rb
+++ b/back/spec/lib/participation_method/poll_spec.rb
@@ -45,4 +45,10 @@ RSpec.describe ParticipationMethod::Poll do
       expect(participation_method.form_in_phase?).to be false
     end
   end
+
+  describe '#extra_fields_category_translation_key' do
+    it 'returns the translation key for the extra fields category' do
+      expect(participation_method.extra_fields_category_translation_key).to eq 'custom_forms.categories.extra.title'
+    end
+  end
 end

--- a/back/spec/lib/participation_method/survey_spec.rb
+++ b/back/spec/lib/participation_method/survey_spec.rb
@@ -45,4 +45,10 @@ RSpec.describe ParticipationMethod::Survey do
       expect(participation_method.form_in_phase?).to be false
     end
   end
+
+  describe '#extra_fields_category_translation_key' do
+    it 'returns the translation key for the extra fields category' do
+      expect(participation_method.extra_fields_category_translation_key).to eq 'custom_forms.categories.extra.title'
+    end
+  end
 end

--- a/back/spec/lib/participation_method/volunteering_spec.rb
+++ b/back/spec/lib/participation_method/volunteering_spec.rb
@@ -45,4 +45,10 @@ RSpec.describe ParticipationMethod::Volunteering do
       expect(participation_method.form_in_phase?).to be false
     end
   end
+
+  describe '#extra_fields_category_translation_key' do
+    it 'returns the translation key for the extra fields category' do
+      expect(participation_method.extra_fields_category_translation_key).to eq 'custom_forms.categories.extra.title'
+    end
+  end
 end

--- a/back/spec/services/input_ui_schema_generator_service_spec.rb
+++ b/back/spec/services/input_ui_schema_generator_service_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe InputUiSchemaGeneratorService do
       end
     end
 
-    context 'for a continuous project' do
+    context 'for a continuous ideation project' do
       let(:project) { create(:continuous_project, input_term: 'option') }
       let(:continuous_fields) do
         IdeaCustomFieldsService.new(
@@ -250,6 +250,34 @@ RSpec.describe InputUiSchemaGeneratorService do
         ui_schema = generator.generate_for(continuous_fields)['en']
         expect(ui_schema[:elements].find { |e| e[:options][:id] == 'extra' }[:elements].size).to eq 1
         expect(ui_schema[:elements].find { |e| e[:options][:id] == 'extra' }[:elements].first[:scope]).to eq '#/properties/extra_field'
+      end
+    end
+
+    context 'for a continuous native survey project' do
+      let(:project) { create(:continuous_native_survey_project) }
+      let(:form) { create :custom_form, participation_context: project }
+      let!(:field) { create :custom_field, resource: form }
+
+      it 'has an empty extra category label, so that the category label is suppressed in the UI' do
+        en_ui_schema = generator.generate_for([field])['en']
+        expect(en_ui_schema).to eq({
+          type: 'Categorization',
+          options: {
+            formId: 'idea-form',
+            inputTerm: 'idea'
+          },
+          elements: [{
+            type: 'Category',
+            label: nil,
+            options: { id: 'extra' },
+            elements: [{
+              type: 'Control',
+              scope: "#/properties/#{field.key}",
+              label: 'Did you attend',
+              options: { description: 'Which councils are you attending in our city?', transform: 'trim_on_blur' }
+            }]
+          }]
+        })
       end
     end
 


### PR DESCRIPTION
This is the BE part of https://citizenlab.atlassian.net/browse/CL-1699. The "Additional information" category label in a form should not be shown in case of native surveys. Actually it is a workaround, because currently the UI schema hardcodes the categories (aka sections). As long as the form builder does not support sections, we need this change.