### PR TITLE
CL-1777 Seed static_pages with correct section toggles values

### DIFF
--- a/back/config/tenant_templates/base.yml
+++ b/back/config/tenant_templates/base.yml
@@ -156,6 +156,7 @@ models:
       slug: information
       title_multiloc: static_pages.infopage_title
       top_info_section_multiloc: static_pages.infopage_body
+      top_info_section_enabled: true
       text_images_attributes:
         - imageable_field: top_info_section_multiloc
           remote_image_url: https://res.cloudinary.com/citizenlabco/image/upload/v1548761162/image_nwmsub.png
@@ -185,21 +186,25 @@ models:
       code: privacy-policy
       title_multiloc: static_pages.privacy_policy_title
       top_info_section_multiloc: static_pages.privacy_policy_body
+      top_info_section_enabled: true
       slug: privacy-policy
     - &terms-and-conditions-page
       code: terms-and-conditions
       title_multiloc: static_pages.terms_and_conditions_title
       top_info_section_multiloc: static_pages.terms_and_conditions_body
+      top_info_section_enabled: true
       slug: terms-and-conditions
     - &faq-page
       code: faq
       slug: faq
       title_multiloc: static_pages.faq_title
       top_info_section_multiloc: static_pages.faq_body
+      top_info_section_enabled: true
     - &initiatives-page
       code: proposals
       title_multiloc: static_pages.initiatives_title
       top_info_section_multiloc: static_pages.initiatives_body
+      top_info_section_enabled: true
       slug: initiatives
       text_images_attributes:
         - imageable_field: top_info_section_multiloc

--- a/back/config/tenant_templates/base.yml
+++ b/back/config/tenant_templates/base.yml
@@ -157,6 +157,7 @@ models:
       title_multiloc: static_pages.infopage_title
       top_info_section_multiloc: static_pages.infopage_body
       top_info_section_enabled: true
+      files_section_enabled: true
       text_images_attributes:
         - imageable_field: top_info_section_multiloc
           remote_image_url: https://res.cloudinary.com/citizenlabco/image/upload/v1548761162/image_nwmsub.png
@@ -200,11 +201,13 @@ models:
       title_multiloc: static_pages.faq_title
       top_info_section_multiloc: static_pages.faq_body
       top_info_section_enabled: true
+      files_section_enabled: true
     - &initiatives-page
       code: proposals
       title_multiloc: static_pages.initiatives_title
       top_info_section_multiloc: static_pages.initiatives_body
       top_info_section_enabled: true
+      files_section_enabled: true
       slug: initiatives
       text_images_attributes:
         - imageable_field: top_info_section_multiloc

--- a/back/config/tenant_templates/e2etests_template.yml
+++ b/back/config/tenant_templates/e2etests_template.yml
@@ -156,6 +156,8 @@ models:
     code: about
     title_multiloc: static_pages.infopage_title
     top_info_section_multiloc: static_pages.infopage_body
+    top_info_section_enabled: true
+    files_section_enabled: true
     slug: information
     text_images_attributes:
       - imageable_field: top_info_section_multiloc
@@ -186,16 +188,20 @@ models:
     code: privacy-policy
     title_multiloc: static_pages.privacy_policy_title
     top_info_section_multiloc: static_pages.privacy_policy_body
+    top_info_section_enabled: true
     slug: privacy-policy
   - &terms-and-conditions-page
     code: terms-and-conditions
     title_multiloc: static_pages.terms_and_conditions_title
     top_info_section_multiloc: static_pages.terms_and_conditions_body
+    top_info_section_enabled: true
     slug: terms-and-conditions
   - &initiatives-page
     code: proposals
     title_multiloc: static_pages.initiatives_title
     top_info_section_multiloc: static_pages.initiatives_body
+    top_info_section_enabled: true
+    files_section_enabled: true
     slug: initiatives
     text_images_attributes:
       - imageable_field: top_info_section_multiloc
@@ -223,6 +229,8 @@ models:
     code: faq
     title_multiloc: static_pages.faq_title
     top_info_section_multiloc: static_pages.faq_body
+    top_info_section_enabled: true
+    files_section_enabled: true
     slug: faq
   nav_bar_item:
     -


### PR DESCRIPTION
## Description

[Jira Ticket CL-1777](https://citizenlab.atlassian.net/browse/CL-1777)
Sibling [ee PR #348](https://github.com/CitizenLabDotCo/citizenlab-ee/pull/348)

Updates internal templates to include the correct values for the two booleans which are set in the migration in Release 1:
```ruby
dir.up do
  StubStaticPage.reset_column_information
  StubStaticPage.update_all(banner_enabled: false, top_info_section_enabled: true)
  StubStaticPage.where.not(code: %w[terms-and-conditions privacy-policy]).update_all(files_section_enabled: true)
end
```
This can be added to Release 2, as Release 1 new custom page FE is hidden behind a feature flag (not activated on production platforms yet), and all pages display correctly when the feature flag is not activated.