### PR TITLE
Cl 1381 fix bugs in ideas controller

### DIFF
--- a/back/app/controllers/web_api/v1/ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/ideas_controller.rb
@@ -127,6 +127,8 @@ class WebApi::V1::IdeasController < ApplicationController
         send_error and return if project.continuous? || phase_ids.size != 1
 
         participation_context = Phase.find(phase_ids.first)
+        participation_method = Factory.instance.participation_method_for(participation_context)
+        participation_context = project unless participation_method.form_in_phase?
       end
     elsif phase_ids.any?
       send_error and return

--- a/back/spec/acceptance/admin_native_survey_responses_spec.rb
+++ b/back/spec/acceptance/admin_native_survey_responses_spec.rb
@@ -94,6 +94,7 @@ resource 'Ideas' do
           input = inputs.first
           expect(input.phase_ids).to eq []
           expect(input.custom_field_values).to eq({ 'custom_field_name1' => 'Cat' })
+          expect(input.creation_phase).to be_nil
         end
       end
 
@@ -111,6 +112,7 @@ resource 'Ideas' do
           input = inputs.first
           expect(inputs.first.phase_ids).to eq [active_phase.id]
           expect(input.custom_field_values).to eq({ 'custom_field_name1' => 'Cat' })
+          expect(input.creation_phase_id).to eq active_phase.id
         end
       end
 
@@ -151,7 +153,7 @@ resource 'Ideas' do
         end
       end
 
-      context 'in an active native survey phase' do
+      context 'with an active native survey phase' do
         let(:project) { create :project_with_active_and_future_native_survey_phase }
         let(:active_phase) { project.phases.first }
         let(:future_phase) { project.phases.last }
@@ -168,6 +170,7 @@ resource 'Ideas' do
           input = inputs.first
           expect(inputs.first.phase_ids).to eq [future_phase.id]
           expect(input.custom_field_values).to eq({ 'custom_field_name1' => 'Cat' })
+          expect(input.creation_phase_id).to eq future_phase.id
         end
       end
 
@@ -186,6 +189,7 @@ resource 'Ideas' do
           input = inputs.first
           expect(inputs.first.phase_ids).to eq [future_phase.id]
           expect(input.custom_field_values).to eq({ 'custom_field_name1' => 'Cat' })
+          expect(input.creation_phase_id).to eq future_phase.id
         end
       end
     end

--- a/back/spec/acceptance/ideas_spec.rb
+++ b/back/spec/acceptance/ideas_spec.rb
@@ -757,7 +757,7 @@ resource 'Ideas' do
         end
       end
 
-      describe 'when posting an idea in an ideation phase, the form of the project is used for accepting the input' do
+      describe 'when posting an idea in an ideation phase, the form of the project is used for accepting the input', skip: !CitizenLab.ee? do
         let(:project) { create(:project_with_active_ideation_phase) }
         let!(:custom_form) do
           create(:custom_form, participation_context: project).tap do |form|

--- a/back/spec/acceptance/ideas_spec.rb
+++ b/back/spec/acceptance/ideas_spec.rb
@@ -745,6 +745,42 @@ resource 'Ideas' do
         end
       end
 
+      describe 'when posting an idea in an ideation phase, the form of the project is used for accepting the input' do
+        let(:project) { create(:project_with_active_ideation_phase) }
+        let!(:custom_form) do
+          create(:custom_form, participation_context: project).tap do |form|
+            fields = IdeaCustomFieldsService.new(form).all_fields
+            # proposed_budget is disabled by default
+            enabled_field_keys = %w[title_multiloc body_multiloc proposed_budget]
+            fields.each do |field|
+              field.enabled = enabled_field_keys.include? field.code
+              field.save
+            end
+          end
+        end
+        let(:phase_ids) { [project.phases.first.id] }
+        let(:title_multiloc) { { 'nl-BE' => 'An idea with a proposed budget' } }
+        let(:body_multiloc) { { 'nl-BE' => 'An idea with a proposed budget for testing' } }
+        let(:proposed_budget) { 1234 }
+
+        example_request 'Post an idea in an ideation phase' do
+          assert_status 201
+          json_response = json_parse response_body
+          # Enabled fields have a value
+          expect(json_response.dig(:data, :attributes, :title_multiloc)).to eq({ 'nl-BE': 'An idea with a proposed budget' })
+          expect(json_response.dig(:data, :attributes, :body_multiloc)).to eq({ 'nl-BE': 'An idea with a proposed budget for testing' })
+          expect(json_response.dig(:data, :attributes, :proposed_budget)).to eq proposed_budget
+          # Disabled fields do not have a value
+          expect(json_response.dig(:data, :attributes, :budget)).to be_nil
+          expect(json_response.dig(:data, :attributes, :location_description)).to be_nil
+          expect(json_response.dig(:data, :attributes)).not_to have_key :topic_ids
+          expect(json_response.dig(:data, :attributes)).not_to have_key :idea_images_attributes
+          expect(json_response.dig(:data, :attributes)).not_to have_key :idea_files_attributes
+          # location_point_geojson is not a field and cannot be disabled, so it has a value
+          expect(json_response.dig(:data, :attributes, :location_point_geojson)).to eq location_point_geojson
+        end
+      end
+
       describe do
         let(:project) { create(:project_with_active_ideation_phase) }
         let(:other_project) { create(:project_with_active_ideation_phase) }

--- a/back/spec/acceptance/ideas_spec.rb
+++ b/back/spec/acceptance/ideas_spec.rb
@@ -623,6 +623,18 @@ resource 'Ideas' do
       end
     end
 
+    describe 'when posting an idea in an active ideation phase, the creation_phase is not set' do
+      let(:project) { create(:project_with_active_ideation_phase) }
+      let!(:custom_form) { create(:custom_form, participation_context: project) }
+
+      example_request 'Post an idea in an ideation phase', document: false do
+        assert_status 201
+        json_response = json_parse response_body
+        idea = Idea.find(json_response.dig(:data, :id))
+        expect(idea.creation_phase).to be_nil
+      end
+    end
+
     describe 'For projects without ideas_order' do
       let(:project) { create(:continuous_project) }
 
@@ -778,6 +790,19 @@ resource 'Ideas' do
           expect(json_response.dig(:data, :attributes)).not_to have_key :idea_files_attributes
           # location_point_geojson is not a field and cannot be disabled, so it has a value
           expect(json_response.dig(:data, :attributes, :location_point_geojson)).to eq location_point_geojson
+        end
+      end
+
+      describe 'when posting an idea in an ideation phase, the creation_phase is not set' do
+        let(:project) { create(:project_with_active_ideation_phase) }
+        let!(:custom_form) { create(:custom_form, participation_context: project) }
+        let(:phase_ids) { [project.phases.first.id] }
+
+        example_request 'Post an idea in an ideation phase', document: false do
+          assert_status 201
+          json_response = json_parse response_body
+          idea = Idea.find(json_response.dig(:data, :id))
+          expect(idea.creation_phase).to be_nil
         end
       end
 

--- a/back/spec/acceptance/resident_native_survey_responses_spec.rb
+++ b/back/spec/acceptance/resident_native_survey_responses_spec.rb
@@ -95,10 +95,11 @@ resource 'Ideas' do
             input = inputs.first
             expect(input.phase_ids).to eq []
             expect(input.custom_field_values).to eq({ 'custom_field_name1' => 'Cat' })
+            expect(input.creation_phase).to be_nil
           end
         end
 
-        describe 'in an active native survey phase' do
+        describe 'with an active native survey phase' do
           let(:project) { create :project_with_active_native_survey_phase }
           let(:active_phase) { project.phases.first }
           let(:custom_form) { create(:custom_form, participation_context: active_phase) }
@@ -112,6 +113,7 @@ resource 'Ideas' do
             input = inputs.first
             expect(inputs.first.phase_ids).to eq [active_phase.id]
             expect(input.custom_field_values).to eq({ 'custom_field_name1' => 'Cat' })
+            expect(input.creation_phase_id).to eq active_phase.id
           end
         end
       end


### PR DESCRIPTION
This PR fixes:
* When the phase’s participation method does not allow a form at the phase level, the form to use for accepting and validating new input should come from the project, not the phase.
* Set the creation_phase only for timeline projects when a phase has a form