### PR TITLE
[CL-1615] Clean code reducing number of banner components parameters

### DIFF
--- a/front/app/containers/CustomPageShow/CustomPageHeader/FullWidthBannerLayout.tsx
+++ b/front/app/containers/CustomPageShow/CustomPageHeader/FullWidthBannerLayout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Multiloc } from 'typings';
+import { ICustomPageAttributes } from 'services/customPages';
 
 // components
 import HeaderContent from './HeaderContent';
@@ -13,27 +13,18 @@ import {
 
 export interface Props {
   className?: string;
-  imageUrl?: string;
   imageColor?: string;
   imageOpacity?: number;
-  headerMultiloc: Multiloc;
-  subheaderMultiloc: Multiloc;
-  ctaButtonType: 'customized_button' | 'no_button';
-  ctaButtonUrl: string | null;
-  ctaButtonMultiloc: Multiloc;
+  pageAttributes: ICustomPageAttributes;
 }
 
 const FullWidthBannerLayout = ({
   className,
-  imageUrl,
-  headerMultiloc,
-  subheaderMultiloc,
   imageColor,
   imageOpacity,
-  ctaButtonType,
-  ctaButtonUrl,
-  ctaButtonMultiloc,
+  pageAttributes,
 }: Props) => {
+  const imageUrl = pageAttributes.header_bg?.large;
   return (
     <Container className={`e2e-signed-out-header ${className}`}>
       <Header id="hook-header">
@@ -46,13 +37,9 @@ const FullWidthBannerLayout = ({
         </HeaderImage>
 
         <HeaderContent
-          headerMultiloc={headerMultiloc}
-          subheaderMultiloc={subheaderMultiloc}
-          hasHeaderBannerImage={imageUrl != null}
           fontColors="light"
-          ctaButtonUrl={ctaButtonUrl}
-          ctaButtonType={ctaButtonType}
-          ctaButtonMultiloc={ctaButtonMultiloc}
+          hasHeaderBannerImage={imageUrl != null}
+          pageAttributes={pageAttributes}
         />
       </Header>
     </Container>

--- a/front/app/containers/CustomPageShow/CustomPageHeader/HeaderContent.tsx
+++ b/front/app/containers/CustomPageShow/CustomPageHeader/HeaderContent.tsx
@@ -9,38 +9,30 @@ import {
 } from 'containers/LandingPage/SignedOutHeader/HeaderContent';
 import { InjectedIntlProps } from 'react-intl';
 import { injectIntl } from 'utils/cl-intl';
-import { Multiloc } from 'typings';
 import BannerButton from 'containers/LandingPage/BannerButton';
+import { ICustomPageAttributes } from 'services/customPages';
 
 interface Props {
   fontColors: 'light' | 'dark';
   align?: TAlign;
-  headerMultiloc: Multiloc;
-  subheaderMultiloc: Multiloc;
   hasHeaderBannerImage: boolean;
-  ctaButtonType: 'customized_button' | 'no_button';
-  ctaButtonUrl: string | null;
-  ctaButtonMultiloc: Multiloc;
+  pageAttributes: ICustomPageAttributes;
 }
 
 const HeaderContent = ({
   align = 'center',
   fontColors,
-  headerMultiloc,
-  subheaderMultiloc,
   hasHeaderBannerImage,
-  ctaButtonType,
-  ctaButtonUrl,
-  ctaButtonMultiloc,
+  pageAttributes,
 }: Props & InjectedIntlProps) => {
   const localize = useLocalize();
 
-  const formattedHeaderTitle = headerMultiloc
-    ? localize(headerMultiloc)
+  const formattedHeaderTitle = pageAttributes.banner_header_multiloc
+    ? localize(pageAttributes.banner_header_multiloc)
     : 'Placeholder: no header multiloc';
 
-  const formattedSubheaderTitle = subheaderMultiloc
-    ? localize(subheaderMultiloc)
+  const formattedSubheaderTitle = pageAttributes.banner_subheader_multiloc
+    ? localize(pageAttributes.banner_subheader_multiloc)
     : 'Placeholder: no subheader multiloc';
 
   return (
@@ -67,11 +59,11 @@ const HeaderContent = ({
       >
         {formattedSubheaderTitle}
       </HeaderSubtitle>
-      {ctaButtonType === 'customized_button' && (
+      {pageAttributes.banner_cta_button_type === 'customized_button' && (
         <BannerButton
           buttonStyle={fontColors === 'light' ? 'primary-inverse' : 'primary'}
-          text={localize(ctaButtonMultiloc)}
-          linkTo={ctaButtonUrl}
+          text={localize(pageAttributes.banner_cta_button_multiloc)}
+          linkTo={pageAttributes.banner_cta_button_url}
           openLinkInNewTab={true}
         />
       )}

--- a/front/app/containers/CustomPageShow/CustomPageHeader/TwoColumnLayout.tsx
+++ b/front/app/containers/CustomPageShow/CustomPageHeader/TwoColumnLayout.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { media } from 'utils/styleUtils';
 import Image from 'components/UI/Image';
 import { homepageBannerLayoutHeights } from 'containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/HeaderImageDropzone';
-import { Multiloc } from 'typings';
+import { ICustomPageAttributes } from 'services/customPages';
 
 export const Container = styled.div`
   width: 100%;
@@ -29,22 +29,11 @@ export const HeaderImage = styled(Image)`
 `;
 
 interface Props {
-  imageUrl?: string;
-  headerMultiloc: Multiloc;
-  subheaderMultiloc: Multiloc;
-  ctaButtonType: 'customized_button' | 'no_button';
-  ctaButtonUrl: string | null;
-  ctaButtonMultiloc: Multiloc;
+  pageAttributes: ICustomPageAttributes;
 }
 
-const TwoColumnLayout = ({
-  imageUrl,
-  headerMultiloc,
-  subheaderMultiloc,
-  ctaButtonType,
-  ctaButtonUrl,
-  ctaButtonMultiloc,
-}: Props) => {
+const TwoColumnLayout = ({ pageAttributes }: Props) => {
+  const imageUrl = pageAttributes.header_bg?.large;
   return (
     <Container data-cy="e2e-two-column-layout-container">
       {imageUrl && (
@@ -58,13 +47,9 @@ const TwoColumnLayout = ({
         />
       )}
       <HeaderContent
-        headerMultiloc={headerMultiloc}
-        subheaderMultiloc={subheaderMultiloc}
-        hasHeaderBannerImage={imageUrl != null}
         fontColors="dark"
-        ctaButtonUrl={ctaButtonUrl}
-        ctaButtonType={ctaButtonType}
-        ctaButtonMultiloc={ctaButtonMultiloc}
+        hasHeaderBannerImage={imageUrl != null}
+        pageAttributes={pageAttributes}
       />
     </Container>
   );

--- a/front/app/containers/CustomPageShow/CustomPageHeader/TwoRowLayout.tsx
+++ b/front/app/containers/CustomPageShow/CustomPageHeader/TwoRowLayout.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import Image from 'components/UI/Image';
 import { media } from 'utils/styleUtils';
 import { homepageBannerLayoutHeights } from 'containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/HeaderImageDropzone';
-import { Multiloc } from 'typings';
+import { ICustomPageAttributes } from 'services/customPages';
 
 const Container = styled.div`
   display: flex;
@@ -28,23 +28,12 @@ const HeaderImage = styled(Image)`
   `}
 `;
 
-export interface Props {
-  imageUrl?: string;
-  headerMultiloc: Multiloc;
-  subheaderMultiloc: Multiloc;
-  ctaButtonType: 'customized_button' | 'no_button';
-  ctaButtonUrl: string | null;
-  ctaButtonMultiloc: Multiloc;
+interface Props {
+  pageAttributes: ICustomPageAttributes;
 }
 
-const TwoRowLayout = ({
-  imageUrl,
-  headerMultiloc,
-  subheaderMultiloc,
-  ctaButtonType,
-  ctaButtonUrl,
-  ctaButtonMultiloc,
-}: Props) => {
+const TwoRowLayout = ({ pageAttributes }: Props) => {
+  const imageUrl = pageAttributes.header_bg?.large;
   return (
     <>
       {imageUrl && (
@@ -60,13 +49,9 @@ const TwoRowLayout = ({
       <ContentContainer mode="page">
         <Container>
           <HeaderContent
-            headerMultiloc={headerMultiloc}
-            subheaderMultiloc={subheaderMultiloc}
             hasHeaderBannerImage={imageUrl != null}
             fontColors="dark"
-            ctaButtonUrl={ctaButtonUrl}
-            ctaButtonType={ctaButtonType}
-            ctaButtonMultiloc={ctaButtonMultiloc}
+            pageAttributes={pageAttributes}
           />
         </Container>
       </ContentContainer>

--- a/front/app/containers/CustomPageShow/CustomPageHeader/index.tsx
+++ b/front/app/containers/CustomPageShow/CustomPageHeader/index.tsx
@@ -1,53 +1,24 @@
 import React from 'react';
+import { ICustomPageAttributes } from 'services/customPages';
 import FullWidthBannerLayout from './FullWidthBannerLayout';
 import TwoColumnLayout from './TwoColumnLayout';
 import TwoRowLayout from './TwoRowLayout';
 
-// to do add props
-const CustomPageHeader = ({
-  headerLayout,
-  header_bg,
-  headerMultiloc,
-  subheaderMultiloc,
-  headerColor,
-  headerOpacity,
-  ctaButtonType,
-  ctaButtonUrl,
-  ctaButtonMultiloc,
-}) => {
+interface Props {
+  pageAttributes: ICustomPageAttributes;
+}
+
+const CustomPageHeader = ({ pageAttributes }: Props) => {
   return (
     <>
-      {headerLayout === 'full_width_banner_layout' && (
-        <FullWidthBannerLayout
-          imageUrl={header_bg.large}
-          imageColor={headerColor}
-          imageOpacity={headerOpacity}
-          headerMultiloc={headerMultiloc}
-          subheaderMultiloc={subheaderMultiloc}
-          ctaButtonType={ctaButtonType}
-          ctaButtonUrl={ctaButtonUrl}
-          ctaButtonMultiloc={ctaButtonMultiloc}
-        />
+      {pageAttributes.banner_layout === 'full_width_banner_layout' && (
+        <FullWidthBannerLayout pageAttributes={pageAttributes} />
       )}
-      {headerLayout === 'two_column_layout' && (
-        <TwoColumnLayout
-          imageUrl={header_bg.large}
-          headerMultiloc={headerMultiloc}
-          subheaderMultiloc={subheaderMultiloc}
-          ctaButtonType={ctaButtonType}
-          ctaButtonUrl={ctaButtonUrl}
-          ctaButtonMultiloc={ctaButtonMultiloc}
-        />
+      {pageAttributes.banner_layout === 'two_column_layout' && (
+        <TwoColumnLayout pageAttributes={pageAttributes} />
       )}
-      {headerLayout === 'two_row_layout' && (
-        <TwoRowLayout
-          imageUrl={header_bg.large}
-          headerMultiloc={headerMultiloc}
-          subheaderMultiloc={subheaderMultiloc}
-          ctaButtonType={ctaButtonType}
-          ctaButtonUrl={ctaButtonUrl}
-          ctaButtonMultiloc={ctaButtonMultiloc}
-        />
+      {pageAttributes.banner_layout === 'two_row_layout' && (
+        <TwoRowLayout pageAttributes={pageAttributes} />
       )}
     </>
   );

--- a/front/app/containers/CustomPageShow/index.tsx
+++ b/front/app/containers/CustomPageShow/index.tsx
@@ -82,17 +82,7 @@ const CustomPageShow = () => {
         title={`${localize(attributes.title_multiloc)} | ${localizedOrgName}`}
       />
       {attributes.banner_enabled && (
-        <CustomPageHeader
-          headerLayout={attributes.banner_layout}
-          header_bg={attributes.header_bg}
-          headerMultiloc={attributes.banner_header_multiloc}
-          subheaderMultiloc={attributes.banner_subheader_multiloc}
-          headerColor={attributes.banner_overlay_color}
-          headerOpacity={attributes.banner_overlay_opacity}
-          ctaButtonType={attributes.banner_cta_button_type}
-          ctaButtonMultiloc={attributes.banner_cta_button_multiloc}
-          ctaButtonUrl={attributes.banner_cta_button_url}
-        />
+        <CustomPageHeader pageAttributes={attributes} />
       )}
       <Content>
         <Fragment


### PR DESCRIPTION
Why remove parameters?
* To make code cleaner by reducing its amount. In my opinion, we've achieved it. Some of the components (e.g., `front/app/containers/CustomPageShow/CustomPageHeader/index.tsx`) became extremely easy to read

Why attributes and not a hook in each component?
* in case we'll want to use these components for both custom and home page
* to not check `isNilOrError(page)` in every component