### PR TITLE
[No ticket] RSpec: Run tests in all engines by default

### DIFF
--- a/back/.rspec
+++ b/back/.rspec
@@ -1,4 +1,5 @@
 --color
---require spec_helper
+--format doc
+--pattern 'spec/**/*_spec.rb,engines/*/*/spec/**/*_spec.rb'
 --profile
--fdoc
+--require spec_helper


### PR DESCRIPTION
This changes RSpec default options to run all engine specs by default. Previously, only specs in the main app were executed via `docker-compose run --rm web bundle exec rspec`.