### PR TITLE
CL-1544 Fix attachment / images being removed when form is submitted via Keyboard Enter

### DIFF
--- a/front/app/components/UI/FileUploader/FileDisplay.tsx
+++ b/front/app/components/UI/FileUploader/FileDisplay.tsx
@@ -113,6 +113,7 @@ const FileDisplay = ({
         {size && <FileSize error={!!error}>({returnFileSize(size)})</FileSize>}
       </FileInfo>
       <DeleteIconButton
+        buttonType="button"
         iconName="delete"
         a11y_buttonActionMessage={formatMessage(messages.a11y_removeFile)}
         onClick={onDeleteClick}

--- a/front/app/components/UI/ImagesDropzone/index.tsx
+++ b/front/app/components/UI/ImagesDropzone/index.tsx
@@ -476,6 +476,7 @@ class ImagesDropzone extends PureComponent<Props & InjectedIntlProps, State> {
                   objectFit={objectFit}
                 >
                   <RemoveButton
+                    type="button"
                     onMouseDown={removeFocusAfterMouseClick}
                     onClick={this.removeImage(image)}
                     className="remove-button"

--- a/front/app/modules/commercial/project_folders/admin/containers/settings/ProjectFolderForm.tsx
+++ b/front/app/modules/commercial/project_folders/admin/containers/settings/ProjectFolderForm.tsx
@@ -392,6 +392,7 @@ const ProjectFolderForm = ({ mode, projectFolderId }: Props) => {
                 setStatus('apiError');
               }
             }
+            setProjectFolderFilesToRemove([]);
             setStatus('success');
           } else {
             setStatus('apiError');


### PR DESCRIPTION
Previous to this change, the button would default to type `submit` because it's rendered within a form. When a user submits the form, for example when hitting keyboard `Enter` on an input field, the buttons `onClick` handler would be executed, leading to the attachment / image being accidentally deleted.