### PR TITLE
Cl 1381 fix project custom fields controller

### DIFF
--- a/back/app/controllers/web_api/v1/project_custom_fields_controller.rb
+++ b/back/app/controllers/web_api/v1/project_custom_fields_controller.rb
@@ -28,7 +28,18 @@ class WebApi::V1::ProjectCustomFieldsController < ApplicationController
   end
 
   def participation_context
-    @participation_context ||= project && ParticipationContextService.new.get_participation_context(project)
+    @participation_context ||= determine_participation_context
+  end
+
+  def determine_participation_context
+    return unless project
+    return project if project.continuous?
+
+    phase = ParticipationContextService.new.get_participation_context(project)
+    return unless phase
+
+    participation_method = Factory.instance.participation_method_for phase
+    participation_method.form_in_phase? ? phase : project
   end
 
   def custom_fields

--- a/back/app/models/idea.rb
+++ b/back/app/models/idea.rb
@@ -166,7 +166,7 @@ class Idea < ApplicationRecord
   end
 
   def custom_form
-    if project.timeline? && participation_method_on_creation.form_in_phase?
+    if participation_method_on_creation.form_in_phase?
       creation_phase.custom_form || CustomForm.new(participation_context: creation_phase)
     else
       project.custom_form || CustomForm.new(participation_context: project)

--- a/back/lib/participation_method/native_survey.rb
+++ b/back/lib/participation_method/native_survey.rb
@@ -25,7 +25,7 @@ module ParticipationMethod
     end
 
     def form_in_phase?
-      true
+      participation_context.project.timeline?
     end
 
     # The "Additional information" category in the UI should be suppressed.

--- a/back/spec/lib/participation_method/native_survey_spec.rb
+++ b/back/spec/lib/participation_method/native_survey_spec.rb
@@ -3,9 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe ParticipationMethod::NativeSurvey do
-  subject(:participation_method) { described_class.new project }
+  subject(:participation_method) { described_class.new participation_context }
 
-  let(:project) { create :continuous_native_survey_project }
+  let(:participation_context) { create :continuous_native_survey_project }
 
   describe '#assign_slug' do
     let(:input) { create :input, slug: nil }
@@ -60,8 +60,19 @@ RSpec.describe ParticipationMethod::NativeSurvey do
   end
 
   describe '#form_in_phase?' do
-    it 'returns true' do
-      expect(participation_method.form_in_phase?).to be true
+    context 'for a timeline project' do
+      let(:project) { create :project_with_active_native_survey_phase }
+      let(:participation_context) { project.phases.first }
+
+      it 'returns true' do
+        expect(participation_method.form_in_phase?).to be true
+      end
+    end
+
+    context 'for a continuous project' do
+      it 'returns false' do
+        expect(participation_method.form_in_phase?).to be false
+      end
     end
   end
 


### PR DESCRIPTION
Amanda found a bug when posting an idea from the front office (so no phase_id given) in a timeline project with an active ideation phase.

The `ProjectCustomFieldsController` took the form from the ideation phase, and because obviously there was none, a new empty form was used to generate the schema. Determining the form is more complicated than that. The fix takes the form from the project when the form does not live at the phase level.