### PR TITLE
CL-1833 Increase analytics result limit

### DIFF
--- a/back/engines/commercial/analytics/app/services/analytics/query_runner_service.rb
+++ b/back/engines/commercial/analytics/app/services/analytics/query_runner_service.rb
@@ -31,7 +31,7 @@ module Analytics
         results = query_order(results)
       end
 
-      limit = @json_query.fetch(:limit, 10)
+      limit = @json_query.fetch(:limit, 1000)
       results = results.limit(limit)
 
       query_pluck(results)


### PR DESCRIPTION
Small change to default limit from 10 to 1000 to allow the front-end to display the full range of dates when showing graphs by week or day