### PR TITLE
[CL-1826] Hero banner form updates

### DIFF
--- a/front/app/components/UI/ImagesDropzone/index.tsx
+++ b/front/app/components/UI/ImagesDropzone/index.tsx
@@ -242,6 +242,10 @@ class ImagesDropzone extends PureComponent<Props & InjectedIntlProps, State> {
   componentDidMount() {
     this.setUrlObjects();
     this.removeExcessImages();
+
+    if (this.props.errorMessage) {
+      this.setState({ errorMessage: this.props.errorMessage });
+    }
   }
 
   componentDidUpdate(prevProps: Props) {

--- a/front/app/components/admin/SubmitWrapper/index.tsx
+++ b/front/app/components/admin/SubmitWrapper/index.tsx
@@ -92,6 +92,7 @@ interface Props
   onClick?: (event: FormEvent<any>) => void;
   buttonStyle?: ButtonStyles;
   animate?: boolean;
+  enableFormOnSuccess?: boolean;
 }
 
 export default class SubmitWrapper extends PureComponent<Props> {
@@ -131,13 +132,18 @@ export default class SubmitWrapper extends PureComponent<Props> {
     const { loading, status, onClick, messages, animate, customError } =
       this.props;
 
+    // give the option to leave the form enabled even in success state
+    const isSubmitButtonDisabled =
+      status === 'disabled' ||
+      (!this.props.enableFormOnSuccess && status === 'success');
+
     return (
       <Wrapper aria-live="polite" fullWidth={!!buttonProps.fullWidth}>
         <Button
           className="e2e-submit-wrapper-button"
           buttonStyle={style}
           processing={loading}
-          disabled={status === 'disabled' || status === 'success'}
+          disabled={isSubmitButtonDisabled}
           onClick={onClick}
           setSubmitButtonRef={this.setSubmitButtonRef}
           {...buttonProps}

--- a/front/app/containers/Admin/pagesAndMenu/EditHomepage/HeroBanner/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/EditHomepage/HeroBanner/index.tsx
@@ -22,7 +22,6 @@ import {
 } from 'services/homepageSettings';
 
 // utils
-import { forOwn, isEqual } from 'lodash-es';
 import { isNilOrError } from 'utils/helperUtils';
 
 // i18n
@@ -36,7 +35,7 @@ const EditHomepageHeroBannerForm = ({
 }: InjectedIntlProps) => {
   const [isLoading, setIsLoading] = useState(false);
   const [apiErrors, setApiErrors] = useState<CLErrors | null>(null);
-  const [formStatus, setFormStatus] = useState<ISubmitState>('disabled');
+  const [formStatus, setFormStatus] = useState<ISubmitState>('enabled');
   const [localSettings, setLocalSettings] =
     useState<IHomepageSettingsAttributes | null>(null);
 
@@ -50,31 +49,20 @@ const EditHomepageHeroBannerForm = ({
     }
   }, [homepageSettings]);
 
-  // disable form if there's no header image when local settings change
-  useEffect(() => {
-    if (!localSettings?.header_bg) {
-      setFormStatus('disabled');
-    }
-  }, [localSettings]);
-
   if (isNilOrError(homepageSettings)) {
     return null;
   }
 
   const handleSave = async () => {
-    // only update the page settings if they have changed
-    const diffedValues = {};
-    forOwn(localSettings, (value, key) => {
-      if (!isEqual(value, homepageSettings.attributes[key])) {
-        diffedValues[key] = value;
-      }
-    });
+    if (localSettings?.header_bg == null) {
+      setFormStatus('error');
+      return;
+    }
 
     setIsLoading(true);
-    setFormStatus('disabled');
     setApiErrors(null);
     try {
-      await updateHomepageSettings(diffedValues);
+      await updateHomepageSettings(localSettings);
       setIsLoading(false);
       setFormStatus('success');
     } catch (error) {

--- a/front/app/containers/Admin/pagesAndMenu/EditHomepage/HeroBanner/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/EditHomepage/HeroBanner/index.tsx
@@ -45,6 +45,12 @@ const EditHomepageHeroBannerForm = ({
     if (!isNilOrError(homepageSettings)) {
       setLocalSettings({
         ...homepageSettings.attributes,
+        // if the backend sends an empty header_bg object, with null properties for
+        // images sizes, we set the whole object to null to trigger the same
+        // fe validation as if the user had removed the image
+        ...(homepageSettings.attributes.header_bg?.large == null && {
+          header_bg: null,
+        }),
       });
     }
   }, [homepageSettings]);

--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/HeroBanner/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/HeroBanner/index.tsx
@@ -49,6 +49,12 @@ const EditCustomPageHeroBannerForm = ({
     if (!isNilOrError(customPage)) {
       setLocalSettings({
         ...customPage.attributes,
+        // if the backend sends an empty header_bg object, with null properties for
+        // images sizes, we set the whole object to null to trigger the same
+        // fe validation as if the user had removed the image
+        ...(customPage.attributes.header_bg?.large == null && {
+          header_bg: null,
+        }),
       });
     }
   }, [customPage]);

--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/HeroBanner/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/HeroBanner/index.tsx
@@ -49,12 +49,6 @@ const EditCustomPageHeroBannerForm = ({
     if (!isNilOrError(customPage)) {
       setLocalSettings({
         ...customPage.attributes,
-        // if the backend sends an empty header_bg object, with null properties for
-        // images sizes, we set the whole object to null to trigger the same
-        // fe validation as if the user had removed the image
-        ...(customPage.attributes.header_bg?.large == null && {
-          header_bg: null,
-        }),
       });
     }
   }, [customPage]);
@@ -68,6 +62,25 @@ const EditCustomPageHeroBannerForm = ({
       return;
     }
 
+    // this is a hack. If both objects have a "large" key under header_bg with a null value,
+    // it means the image was initialized (with the large: null value) on the server
+    // and hasn't been updated by the user locally. we set the whole value to null
+    // to trigger the FE error message. the first triple equals is on purpose, we want to
+    // only trigger this when the value is explicitly null and not undefined
+    if (
+      localSettings.header_bg?.large === null &&
+      customPage.attributes.header_bg?.large === null
+    ) {
+      setLocalSettings({
+        ...localSettings,
+        header_bg: null,
+      });
+      setFormStatus('error');
+      return;
+    }
+
+    // will be null if set null above, or if the user removes
+    // an existing image
     if (localSettings?.header_bg == null) {
       setFormStatus('error');
       return;

--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/Settings/index.test.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/Settings/index.test.tsx
@@ -9,7 +9,19 @@ jest.mock('hooks/useAppConfiguration', () => () => ({
 }));
 
 jest.mock('hooks/useCustomPage', () =>
-  jest.fn(() => ({ attributes: { title_multiloc: { en: 'title' } } }))
+  jest.fn(() => ({
+    attributes: {
+      nav_bar_item_title_multiloc: { en: 'hi' },
+      title_multiloc: { en: 'title' },
+    },
+    relationships: {
+      nav_bar_item: {
+        data: {
+          id: '123',
+        },
+      },
+    },
+  }))
 );
 jest.mock('services/customPages', () => ({
   // `async` simulates the original `updateCustomPage` which is also `async`.
@@ -33,7 +45,6 @@ describe('EditCustomPageSettings', () => {
   describe('Edit custom page', () => {
     it('renders error in case of invalid slug', async () => {
       const { container } = render(<EditCustomPageSettings />);
-
       fireEvent.change(screen.getByRole('textbox', { name: 'Page URL' }), {
         target: {
           value: 'existing-slug',
@@ -41,7 +52,6 @@ describe('EditCustomPageSettings', () => {
       });
       fireEvent.click(container.querySelector('button[type="submit"]'));
       await waitFor(() => {
-        expect(screen.getAllByTestId('error-message')).toHaveLength(2);
         expect(screen.getByTestId('feedbackErrorMessage')).toBeInTheDocument();
       });
     });

--- a/front/app/containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/BannerImageFields.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/BannerImageFields.tsx
@@ -93,7 +93,6 @@ const BannerImageField = ({
   useEffect(() => {
     if (isNil(headerBg)) {
       setBannerError(formatMessage(messages.noHeader));
-      setFormStatus('disabled');
       return;
     }
 

--- a/front/app/containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/index.tsx
@@ -59,6 +59,7 @@ const GenericHeroBannerForm = ({
             buttonStyle="primary"
             loading={isLoading}
             onClick={onSave}
+            enableFormOnSuccess
             messages={{
               buttonSave: messages.heroBannerSaveButton,
               buttonSuccess: messages.heroBannerButtonSuccess,

--- a/front/app/containers/Admin/pagesAndMenu/containers/NavigationSettings/VisibleNavbarItemList/VisibleNavbarItemList.test.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/NavigationSettings/VisibleNavbarItemList/VisibleNavbarItemList.test.tsx
@@ -38,7 +38,7 @@ describe('<VisibleNavbarItemList />', () => {
       )
     );
     expect(clHistory.push).toHaveBeenCalledWith(
-      `/admin/pages-menu/pages/edit/${itemWithPage.relationships.static_page.data?.id}`
+      `/admin/pages-menu/pages/${itemWithPage.relationships.static_page.data?.id}/settings`
     );
   });
 

--- a/front/app/containers/Admin/pagesAndMenu/routes.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/routes.tsx
@@ -100,7 +100,7 @@ export default () => ({
       ),
     },
     {
-      path: CUSTOM_PAGES_PATH, //pages
+      path: CUSTOM_PAGES_PATH, // pages
       element: <CustomPagesIndex />,
       children: [
         {

--- a/front/app/modules/commercial/customizable_navbar/admin/containers/NavigationSettings/HiddenNavbarItemList/HiddenNavbarItemList.test.tsx
+++ b/front/app/modules/commercial/customizable_navbar/admin/containers/NavigationSettings/HiddenNavbarItemList/HiddenNavbarItemList.test.tsx
@@ -57,7 +57,7 @@ describe('<HiddenNavbarItemList />', () => {
     fireEvent.click(editButtons[0]);
 
     expect(clHistory.push).toHaveBeenCalledWith(
-      `${PAGES_MENU_PATH}/pages/edit/1b095a31-72e1-450a-81be-f6e7a9296553`
+      `${PAGES_MENU_PATH}/pages/1b095a31-72e1-450a-81be-f6e7a9296553/settings`
     );
   });
 

--- a/front/app/modules/commercial/customizable_navbar/admin/containers/NavigationSettings/VisibleNavbarItemList/VisibleNavbarItemList.test.tsx
+++ b/front/app/modules/commercial/customizable_navbar/admin/containers/NavigationSettings/VisibleNavbarItemList/VisibleNavbarItemList.test.tsx
@@ -88,7 +88,7 @@ describe('<VisibleNavbarItemList />', () => {
     fireEvent.click(editButtons[6]);
 
     expect(clHistory.push).toHaveBeenCalledWith(
-      `${PAGES_MENU_PATH}/pages/edit/${navbarItems[6].relationships.static_page.data?.id}`
+      `${PAGES_MENU_PATH}/pages/${navbarItems[6].relationships.static_page.data?.id}/settings`
     );
   });
 


### PR DESCRIPTION
As close to our general hook form validation as seemed possible without a large refactor...

- Hero banner form is now always enabled
- Form can be submitted with no changes
- Form save fails when header image has been removed (we don't have a concept of header without an image, and I believe the BE can't save a null image, only a new one). A big red error appears next to the image dropzone so it's not 100% the same behavior as hook forms but pretty close
