### PR TITLE
Replace non-existing icon that caused modal opening issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2022-10-13
+
+### Fixed
+
+- [CL-1835] Fixed missing verification button icon, which caused the verification modal to not open.
+
 ## 2022-10-11
 
 ### Fixed

--- a/front/app/modules/commercial/verification/citizen/components/VerificationMethodButton.tsx
+++ b/front/app/modules/commercial/verification/citizen/components/VerificationMethodButton.tsx
@@ -1,12 +1,5 @@
-import { Button, ButtonProps } from '@citizenlab/cl2-component-library';
-import useLocale from 'hooks/useLocale';
+import { Box, Button, ButtonProps } from '@citizenlab/cl2-component-library';
 import React, { ReactNode } from 'react';
-import styled from 'styled-components';
-import { isNilOrError } from 'utils/helperUtils';
-
-const MethodButton = styled(Button)<{ last: boolean }>`
-  margin-bottom: ${({ last }) => (last ? '0px' : '15px')};
-`;
 
 interface Props extends Partial<ButtonProps> {
   children: ReactNode;
@@ -14,22 +7,20 @@ interface Props extends Partial<ButtonProps> {
 }
 
 const VerificationMethodButton = (props: Props) => {
-  const locale = useLocale();
-  if (isNilOrError(locale)) return null;
-
   return (
-    <MethodButton
-      icon="shield-check"
-      iconSize="22px"
-      buttonStyle="white"
-      fullWidth={true}
-      justify="left"
-      whiteSpace="wrap"
-      locale={locale}
-      {...props}
-    >
-      {props.children}
-    </MethodButton>
+    <Box mb={props.last ? '0px' : '15px'}>
+      <Button
+        icon="shield-check"
+        iconSize="22px"
+        buttonStyle="white"
+        fullWidth={true}
+        justify="left"
+        whiteSpace="wrap"
+        {...props}
+      >
+        {props.children}
+      </Button>
+    </Box>
   );
 };
 

--- a/front/app/modules/commercial/verification/citizen/components/VerificationMethodButton.tsx
+++ b/front/app/modules/commercial/verification/citizen/components/VerificationMethodButton.tsx
@@ -1,7 +1,7 @@
 import { Button, ButtonProps } from '@citizenlab/cl2-component-library';
-import styled from 'styled-components';
-import React, { ReactNode } from 'react';
 import useLocale from 'hooks/useLocale';
+import React, { ReactNode } from 'react';
+import styled from 'styled-components';
 import { isNilOrError } from 'utils/helperUtils';
 
 const MethodButton = styled(Button)<{ last: boolean }>`
@@ -19,7 +19,7 @@ const VerificationMethodButton = (props: Props) => {
 
   return (
     <MethodButton
-      icon="shieldVerified"
+      icon="shield-check"
       iconSize="22px"
       buttonStyle="white"
       fullWidth={true}

--- a/front/app/modules/commercial/verification/citizen/components/VerificationMethodButton.tsx
+++ b/front/app/modules/commercial/verification/citizen/components/VerificationMethodButton.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, ButtonProps } from '@citizenlab/cl2-component-library';
+import { Button, ButtonProps } from '@citizenlab/cl2-component-library';
 import React, { ReactNode } from 'react';
 
 interface Props extends Partial<ButtonProps> {
@@ -8,19 +8,17 @@ interface Props extends Partial<ButtonProps> {
 
 const VerificationMethodButton = (props: Props) => {
   return (
-    <Box mb={props.last ? '0px' : '15px'}>
-      <Button
-        icon="shield-check"
-        iconSize="22px"
-        buttonStyle="white"
-        fullWidth={true}
-        justify="left"
-        whiteSpace="wrap"
-        {...props}
-      >
-        {props.children}
-      </Button>
-    </Box>
+    <Button
+      icon="shield-check"
+      buttonStyle="white"
+      fullWidth={true}
+      justify="left"
+      whiteSpace="wrap"
+      mb={props.last ? '0px' : '15px'}
+      {...props}
+    >
+      {props.children}
+    </Button>
   );
 };
 


### PR DESCRIPTION
## Checklist

- [ ] Added entry to changelog
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

- [ ] WCAG 2.1 AA proof
<details>
<summary>More info</summary>
For front-end devs only. Is your work conforming with the WCAG 2.1 AA rules? If you need more info, read the [a11y page](https://www.notion.so/citizenlab/a11y-7568f83d42ab4895ac133b89d358997b) on our Notion.
</details>

- [ ] Tests
<details>
<summary>More info</summary>

### Unit tests

Did you add relevant unit tests?

### E2E tests

Sometimes it can be more efficient to update E2E tests after CI has run them. If you know which ones to update, go ahead! E2E template cl2-back:

```bash
docker compose run --rm web bin/rails cl2_back:create_tenant[localhost,e2etests_template]
```

</details>

- [ ] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## Links

- [citizenlab-ee PR](**put URL here** or remove)
- [Specs](**put URL here** or remove)
- [Epic Deployment](**put URL here** or remove)

## How urgent is a code review?

Let the reviewer(s) know how urgent the code review is, so they can prioritize their work accordingly. Be specific (e.g. by Wednesday, end of the day/this week/... is better than 'urgent' or 'very urgent'). Optionally provide a word of explanation on your deadline.
