### PR TITLE
[no ticket] Fix TabbedResource header

### DIFF
--- a/front/app/components/admin/TabbedResource/index.tsx
+++ b/front/app/components/admin/TabbedResource/index.tsx
@@ -64,14 +64,12 @@ const TabbedResource = ({
   return (
     <>
       <Box mb="30px" className="e2e-resource-header">
-        <Box>
-          <Title color="primary">{title}</Title>
-          {subtitle && (
-            <Text maxWidth="60em" color="textSecondary">
-              {subtitle}
-            </Text>
-          )}
-        </Box>
+        <Title color="primary">{title}</Title>
+        {subtitle && (
+          <Text maxWidth="60em" color="textSecondary">
+            {subtitle}
+          </Text>
+        )}
       </Box>
 
       {tabs && tabs.length > 0 && (

--- a/front/app/components/admin/TabbedResource/index.tsx
+++ b/front/app/components/admin/TabbedResource/index.tsx
@@ -63,8 +63,8 @@ const TabbedResource = ({
 }: Props) => {
   return (
     <>
-      <Box mb="20px" className="e2e-resource-header">
-        <Box mb="20px">
+      <Box mb="30px" className="e2e-resource-header">
+        <Box>
           <Title color="primary">{title}</Title>
           {subtitle && (
             <Text maxWidth="60em" color="textSecondary">

--- a/front/app/components/admin/TabbedResource/index.tsx
+++ b/front/app/components/admin/TabbedResource/index.tsx
@@ -2,30 +2,19 @@ import React from 'react';
 
 // style
 import styled from 'styled-components';
-import { colors, isRtl } from 'utils/styleUtils';
-
+import { colors, isRtl, fontSizes } from 'utils/styleUtils';
+import { Box, Text } from '@citizenlab/cl2-component-library';
 // typings
 import { ITab } from 'typings';
 
 // components
 import FeatureFlag from 'components/FeatureFlag';
-import { SectionDescription } from 'components/admin/Section';
-import Title from 'components/admin/PageTitle';
 import Tab from './Tab';
 
-const ResourceHeader = styled.div`
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  margin-bottom: 30px;
-
-  @media print {
-    margin-bottom: 10px;
-  }
-
-  p {
-    margin-right: 40px;
-  }
+const Title = styled.h1`
+  font-size: ${fontSizes.xxxl}px;
+  line-height: 40px;
+  font-weight: 600;
 `;
 
 const TabbedNav = styled.nav`
@@ -80,12 +69,22 @@ const TabbedResource = ({
 }: Props) => {
   return (
     <>
-      <ResourceHeader className="e2e-resource-header">
+      <Box
+        display="flex"
+        justifyContent="space-between"
+        className="e2e-resource-header"
+      >
         <>
-          <Title>{title}</Title>
-          {subtitle && <SectionDescription>{subtitle}</SectionDescription>}
+          <Box mb="20px">
+            <Title>{title}</Title>
+            {subtitle && (
+              <Text maxWidth="60em" color="textSecondary">
+                {subtitle}
+              </Text>
+            )}
+          </Box>
         </>
-      </ResourceHeader>
+      </Box>
 
       {tabs && tabs.length > 0 && (
         <TabbedNav className="e2e-resource-tabs">

--- a/front/app/components/admin/TabbedResource/index.tsx
+++ b/front/app/components/admin/TabbedResource/index.tsx
@@ -2,20 +2,14 @@ import React from 'react';
 
 // style
 import styled from 'styled-components';
-import { colors, isRtl, fontSizes } from 'utils/styleUtils';
-import { Box, Text } from '@citizenlab/cl2-component-library';
+import { colors, isRtl } from 'utils/styleUtils';
+import { Box, Text, Title } from '@citizenlab/cl2-component-library';
 // typings
 import { ITab } from 'typings';
 
 // components
 import FeatureFlag from 'components/FeatureFlag';
 import Tab from './Tab';
-
-const Title = styled.h1`
-  font-size: ${fontSizes.xxxl}px;
-  line-height: 40px;
-  font-weight: 600;
-`;
 
 const TabbedNav = styled.nav`
   background: #fcfcfc;
@@ -70,16 +64,14 @@ const TabbedResource = ({
   return (
     <>
       <Box mb="20px" className="e2e-resource-header">
-        <>
-          <Box mb="20px">
-            <Title>{title}</Title>
-            {subtitle && (
-              <Text maxWidth="60em" color="textSecondary">
-                {subtitle}
-              </Text>
-            )}
-          </Box>
-        </>
+        <Box mb="20px">
+          <Title color="primary">{title}</Title>
+          {subtitle && (
+            <Text maxWidth="60em" color="textSecondary">
+              {subtitle}
+            </Text>
+          )}
+        </Box>
       </Box>
 
       {tabs && tabs.length > 0 && (

--- a/front/app/components/admin/TabbedResource/index.tsx
+++ b/front/app/components/admin/TabbedResource/index.tsx
@@ -69,11 +69,7 @@ const TabbedResource = ({
 }: Props) => {
   return (
     <>
-      <Box
-        display="flex"
-        justifyContent="space-between"
-        className="e2e-resource-header"
-      >
+      <Box mb="20px" className="e2e-resource-header">
         <>
           <Box mb="20px">
             <Title>{title}</Title>


### PR DESCRIPTION
Not sure what happened as the CSS/layouts for this component haven't been touched in a while. Updated it to look more like the pages/menu header. We're only using the subtitle prop in a few places and those seem good now:

![Screen Shot 2022-10-14 at 09 40 38](https://user-images.githubusercontent.com/3614128/195790471-676c9e2c-57e0-41e4-afbf-cc3aede1074c.png)
![Screen Shot 2022-10-14 at 09 40 32](https://user-images.githubusercontent.com/3614128/195790474-b6699772-d8e1-4b7f-819f-d698c58f3785.png)
