### PR TITLE
[CL-1851] Upate homepage routes

### DIFF
--- a/front/app/containers/Admin/pagesAndMenu/containers/EditHomepage/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/EditHomepage/index.tsx
@@ -96,7 +96,7 @@ const EditHomepage = ({ intl: { formatMessage } }: InjectedIntlProps) => {
 
   const handleOnClick = (url: string) => {
     if (url) {
-      clHistory.push(`/admin/pages-menu/${url}/`);
+      clHistory.push(`/admin/pages-menu/homepage/${url}/`);
     }
   };
 

--- a/front/app/containers/Admin/pagesAndMenu/routes.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/routes.tsx
@@ -100,7 +100,7 @@ export default () => ({
       ),
     },
     {
-      path: CUSTOM_PAGES_PATH, //pages
+      path: CUSTOM_PAGES_PATH, // pages
       element: <CustomPagesIndex />,
       children: [
         {

--- a/front/app/containers/Admin/pagesAndMenu/routes.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/routes.tsx
@@ -68,7 +68,7 @@ export default () => ({
       ],
     },
     {
-      path: HOMEPAGE_PATH,
+      path: HOMEPAGE_PATH, // /homepage
       element: (
         <PageLoading>
           <EditHomepage />
@@ -76,7 +76,7 @@ export default () => ({
       ),
     },
     {
-      path: `${HOMEPAGE_PATH}/bottom-info-section`,
+      path: `${HOMEPAGE_PATH}/bottom-info-section`, // /homepage/bottom-info-section
       element: (
         <PageLoading>
           <HomepageBottomInfoForm />
@@ -84,7 +84,7 @@ export default () => ({
       ),
     },
     {
-      path: `${HOMEPAGE_PATH}/top-info-section`,
+      path: `${HOMEPAGE_PATH}/top-info-section`, // /homepage/top-info-section
       element: (
         <PageLoading>
           <HomepageTopInfoSection />
@@ -92,7 +92,7 @@ export default () => ({
       ),
     },
     {
-      path: `${HOMEPAGE_PATH}/homepage-banner`,
+      path: `${HOMEPAGE_PATH}/homepage-banner`, // /homepage/homepage-banner
       element: (
         <PageLoading>
           <HomepageHeroBannerForm />

--- a/front/app/containers/Admin/pagesAndMenu/routes.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/routes.tsx
@@ -68,7 +68,15 @@ export default () => ({
       ],
     },
     {
-      path: 'bottom-info-section',
+      path: HOMEPAGE_PATH,
+      element: (
+        <PageLoading>
+          <EditHomepage />
+        </PageLoading>
+      ),
+    },
+    {
+      path: `${HOMEPAGE_PATH}/bottom-info-section`,
       element: (
         <PageLoading>
           <HomepageBottomInfoForm />
@@ -76,7 +84,7 @@ export default () => ({
       ),
     },
     {
-      path: 'top-info-section',
+      path: `${HOMEPAGE_PATH}/top-info-section`,
       element: (
         <PageLoading>
           <HomepageTopInfoSection />
@@ -84,18 +92,10 @@ export default () => ({
       ),
     },
     {
-      path: 'homepage-banner',
+      path: `${HOMEPAGE_PATH}/homepage-banner`,
       element: (
         <PageLoading>
           <HomepageHeroBannerForm />
-        </PageLoading>
-      ),
-    },
-    {
-      path: HOMEPAGE_PATH,
-      element: (
-        <PageLoading>
-          <EditHomepage />
         </PageLoading>
       ),
     },


### PR DESCRIPTION
e2e tests don't rely on the paths so shouldn't have broke, but I'll check them with the rest of the e2e tests for this release once we're ready to merge.

The 3 edit screens for Homepage are self-contained components that handle their own breadcrumbs/title etc. so they don't need to be children of the main path, I added them as explicit URLs under the main homepage path