### PR TITLE
Code-split craftjs

### DIFF
--- a/front/app/modules/commercial/content_builder/index.tsx
+++ b/front/app/modules/commercial/content_builder/index.tsx
@@ -1,10 +1,27 @@
 import React from 'react';
 import { ModuleConfiguration } from 'utils/moduleUtils';
-import ContentBuilderToggle from 'modules/commercial/content_builder/admin/components/ContentBuilderToggle';
-import ContentBuilderPreview from 'modules/commercial/content_builder/admin/components/ContentBuilderPreview';
-import EditModePreview from 'modules/commercial/content_builder/admin/components/ContentBuilderEditModePreview/EditModePreview';
 
 const ContentBuilderComponent = React.lazy(() => import('./admin/containers'));
+const ContentBuilderEditModePreview = React.lazy(
+  () =>
+    import(
+      'modules/commercial/content_builder/admin/components/ContentBuilderEditModePreview/EditModePreview'
+    )
+);
+
+const ContentBuilderPreview = React.lazy(
+  () =>
+    import(
+      'modules/commercial/content_builder/admin/components/ContentBuilderPreview'
+    )
+);
+
+const ContentBuilderToggle = React.lazy(
+  () =>
+    import(
+      'modules/commercial/content_builder/admin/components/ContentBuilderToggle'
+    )
+);
 
 const configuration: ModuleConfiguration = {
   routes: {
@@ -15,7 +32,7 @@ const configuration: ModuleConfiguration = {
       },
       {
         path: 'content-builder/projects/:projectId/preview',
-        element: <EditModePreview />,
+        element: <ContentBuilderEditModePreview />,
       },
     ],
   },


### PR DESCRIPTION
Takes `craftjs` out of the main bundle by ensuring we code-split correctly the content builder code. 