### PR TITLE
Remove xlsx from the main bundle

### DIFF
--- a/front/app/modules/commercial/analytics/index.tsx
+++ b/front/app/modules/commercial/analytics/index.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { ModuleConfiguration } from 'utils/moduleUtils';
-import PostFeedback from './admin/containers/PostFeedback';
 import Tab from './admin/components/Tab';
 
+const PostFeedback = React.lazy(
+  () => import('./admin/containers/PostFeedback')
+);
 const VisitorsContainer = React.lazy(
   () => import('./admin/containers/Visitors')
 );

--- a/front/app/modules/commercial/user_custom_fields/index.tsx
+++ b/front/app/modules/commercial/user_custom_fields/index.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import { isNilOrError } from 'utils/helperUtils';
 import { ModuleConfiguration } from 'utils/moduleUtils';
-import CustomFieldGraphs from './admin/components/CustomFieldGraphs';
-import RegistrationFieldsToGraphs from './admin/components/RegistrationFieldsToGraphs';
-import AllCustomFields from './admin/components/CustomFields/All';
 
 import CustomFieldsStep from './citizen/components/CustomFieldsStep';
 import UserCustomFieldsForm from './citizen/components/UserCustomFieldsForm';
@@ -17,6 +14,16 @@ import {
 import useFeatureFlag from 'hooks/useFeatureFlag';
 import UserCustomFieldsFormMigrated from './citizen/components/UserCustomFieldsFormMigrated';
 
+// lazy components for outlets
+const CustomFieldGraphs = React.lazy(
+  () => import('./admin/components/CustomFieldGraphs')
+);
+const RegistrationFieldsToGraphs = React.lazy(
+  () => import('./admin/components/RegistrationFieldsToGraphs')
+);
+const AllCustomFields = React.lazy(
+  () => import('./admin/components/CustomFields/All')
+);
 // lazy components for routes
 const AdminCustomFieldsContainer = React.lazy(
   () => import('./admin/containers/CustomFields/')


### PR DESCRIPTION
Makes sure we don't include xlsx in the main bundle as it's not needed there and it's quite large.

Before:
<img width="461" alt="image" src="https://user-images.githubusercontent.com/25869467/196204099-545edefe-6658-45f8-9abb-82615613c2cf.png">

After:
<img width="450" alt="image" src="https://user-images.githubusercontent.com/25869467/196203917-0d51ab0c-d7c7-4d67-a4f6-f512c70ef11d.png">
