### PR TITLE
Cl 1859 add edit page button for admins on custom page citizen 

### DIFF
--- a/front/app/containers/Admin/pagesAndMenu/containers/Attachments/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/Attachments/index.tsx
@@ -1,28 +1,28 @@
 import React from 'react';
 
 // components
-import SectionFormWrapper from '../../components/SectionFormWrapper';
 import {
+  Box,
+  Button,
   IconTooltip,
   Label,
-  Button,
-  Box,
 } from '@citizenlab/cl2-component-library';
 import { SectionField } from 'components/admin/Section';
+import SectionFormWrapper from '../../components/SectionFormWrapper';
 
 // i18n
-import messages from './messages';
+import HelmetIntl from 'components/HelmetIntl';
 import useLocalize from 'hooks/useLocalize';
 import { InjectedIntlProps } from 'react-intl';
-import { injectIntl, FormattedMessage } from 'utils/cl-intl';
-import HelmetIntl from 'components/HelmetIntl';
+import { FormattedMessage, injectIntl } from 'utils/cl-intl';
+import messages from './messages';
 
 // form
-import { useForm, FormProvider } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { object, mixed } from 'yup';
-import FileUploader from 'components/HookForm/FileUploader';
 import Feedback from 'components/HookForm/Feedback';
+import FileUploader from 'components/HookForm/FileUploader';
+import { FormProvider, useForm } from 'react-hook-form';
+import { mixed, object } from 'yup';
 
 // typings
 import { UploadFile } from 'typings';
@@ -31,17 +31,17 @@ import { UploadFile } from 'typings';
 import { handleAddPageFiles, handleRemovePageFiles } from 'services/pageFiles';
 
 // hooks
-import { useParams } from 'react-router-dom';
-import useRemoteFiles from 'hooks/useRemoteFiles';
 import useCustomPage from 'hooks/useCustomPage';
+import useRemoteFiles from 'hooks/useRemoteFiles';
+import { useParams } from 'react-router-dom';
 
 // constants
-import { PAGES_MENU_CUSTOM_PATH } from '../../routes';
 import { pagesAndMenuBreadcrumb } from '../../breadcrumbs';
+import { ADMIN_PAGES_MENU_CUSTOM_PAGE_PATH } from '../../routes';
 
 // utils
-import { isNilOrError } from 'utils/helperUtils';
 import { handleHookFormSubmissionError } from 'utils/errorUtils';
+import { isNilOrError } from 'utils/helperUtils';
 
 type FormValues = {
   local_page_files: UploadFile[] | null;
@@ -114,7 +114,7 @@ const AttachmentsForm = ({ intl: { formatMessage } }: InjectedIntlProps) => {
               },
               {
                 label: localize(customPage.attributes.title_multiloc),
-                linkTo: `${PAGES_MENU_CUSTOM_PATH}/${customPageId}/content`,
+                linkTo: `${ADMIN_PAGES_MENU_CUSTOM_PAGE_PATH}/${customPageId}/content`,
               },
               {
                 label: formatMessage(messages.pageTitle),

--- a/front/app/containers/Admin/pagesAndMenu/containers/Attachments/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/Attachments/index.tsx
@@ -36,8 +36,8 @@ import useRemoteFiles from 'hooks/useRemoteFiles';
 import { useParams } from 'react-router-dom';
 
 // constants
+import { adminCustomPageContentPath } from 'containers/Admin/pagesAndMenu/routes';
 import { pagesAndMenuBreadcrumb } from '../../breadcrumbs';
-import { ADMIN_PAGES_MENU_CUSTOM_PAGE_PATH } from '../../routes';
 
 // utils
 import { handleHookFormSubmissionError } from 'utils/errorUtils';
@@ -114,7 +114,7 @@ const AttachmentsForm = ({ intl: { formatMessage } }: InjectedIntlProps) => {
               },
               {
                 label: localize(customPage.attributes.title_multiloc),
-                linkTo: `${ADMIN_PAGES_MENU_CUSTOM_PAGE_PATH}/${customPageId}/content`,
+                linkTo: adminCustomPageContentPath(customPageId),
               },
               {
                 label: formatMessage(messages.pageTitle),

--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/HeroBanner/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/HeroBanner/index.tsx
@@ -4,7 +4,7 @@ import CTAButtonFields from 'containers/Admin/pagesAndMenu/containers/CustomPage
 import BannerHeaderFields from 'containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/BannerHeaderFields';
 import BannerImageFields from 'containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/BannerImageFields';
 import LayoutSettingField from 'containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/LayoutSettingField';
-import { ADMIN_PAGES_MENU_CUSTOM_PAGE_PATH } from 'containers/Admin/pagesAndMenu/routes';
+import { adminCustomPageContentPath } from 'containers/Admin/pagesAndMenu/routes';
 import useCustomPage from 'hooks/useCustomPage';
 import { forOwn, isEqual } from 'lodash-es';
 import React, { useEffect, useState } from 'react';
@@ -161,7 +161,7 @@ const EditCustomPageHeroBannerForm = ({
             },
             {
               label: localize(customPage.attributes.title_multiloc),
-              linkTo: `${ADMIN_PAGES_MENU_CUSTOM_PAGE_PATH}/${customPageId}/content`,
+              linkTo: adminCustomPageContentPath(customPageId),
             },
             { label: formatMessage(messages.heroBannerTitle) },
           ]}

--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/HeroBanner/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/HeroBanner/index.tsx
@@ -4,7 +4,7 @@ import CTAButtonFields from 'containers/Admin/pagesAndMenu/containers/CustomPage
 import BannerHeaderFields from 'containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/BannerHeaderFields';
 import BannerImageFields from 'containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/BannerImageFields';
 import LayoutSettingField from 'containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/LayoutSettingField';
-import { PAGES_MENU_CUSTOM_PATH } from 'containers/Admin/pagesAndMenu/routes';
+import { ADMIN_PAGES_MENU_CUSTOM_PAGE_PATH } from 'containers/Admin/pagesAndMenu/routes';
 import useCustomPage from 'hooks/useCustomPage';
 import { forOwn, isEqual } from 'lodash-es';
 import React, { useEffect, useState } from 'react';
@@ -161,7 +161,7 @@ const EditCustomPageHeroBannerForm = ({
             },
             {
               label: localize(customPage.attributes.title_multiloc),
-              linkTo: `${PAGES_MENU_CUSTOM_PATH}/${customPageId}/content`,
+              linkTo: `${ADMIN_PAGES_MENU_CUSTOM_PAGE_PATH}/${customPageId}/content`,
             },
             { label: formatMessage(messages.heroBannerTitle) },
           ]}

--- a/front/app/containers/Admin/pagesAndMenu/containers/NavigationSettings/VisibleNavbarItemList/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/NavigationSettings/VisibleNavbarItemList/index.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
-import useNavbarItems from 'hooks/useNavbarItems';
-import { getNavbarItemSlug, INavbarItem } from 'services/navbar';
-import NavbarItemRow from '../NavbarItemRow';
 import { List, Row } from 'components/admin/ResourceList';
-import { isNilOrError } from 'utils/helperUtils';
+import { ADMIN_PAGES_MENU_PATH } from 'containers/Admin/pagesAndMenu/routes';
+import useNavbarItems from 'hooks/useNavbarItems';
 import usePageSlugById from 'hooks/usePageSlugById';
+import { getNavbarItemSlug, INavbarItem } from 'services/navbar';
 import clHistory from 'utils/cl-router/history';
-import { PAGES_MENU_PATH } from 'containers/Admin/pagesAndMenu/routes';
+import { isNilOrError } from 'utils/helperUtils';
+import NavbarItemRow from '../NavbarItemRow';
 
 export default function VisibleNavbarItemList() {
   const navbarItems = useNavbarItems({ onlyDefault: true });
@@ -20,14 +20,16 @@ export default function VisibleNavbarItemList() {
   const handleClickEdit = (navbarItem: INavbarItem) => () => {
     // redirect to homepage toggle page
     if (navbarItem?.attributes?.code && navbarItem.attributes.code === 'home') {
-      clHistory.push(`${PAGES_MENU_PATH}/homepage/`);
+      clHistory.push(`${ADMIN_PAGES_MENU_PATH}/homepage/`);
       return;
     }
 
     const pageData = navbarItem.relationships.static_page.data;
     pageData
-      ? clHistory.push(`${PAGES_MENU_PATH}/pages/${pageData.id}/settings`)
-      : clHistory.push(`${PAGES_MENU_PATH}/navbar-items/edit/${navbarItem.id}`);
+      ? clHistory.push(`${ADMIN_PAGES_MENU_PATH}/pages/${pageData.id}/settings`)
+      : clHistory.push(
+          `${ADMIN_PAGES_MENU_PATH}/navbar-items/edit/${navbarItem.id}`
+        );
   };
 
   const getViewButtonLink = (navbarItem: INavbarItem) => {

--- a/front/app/containers/Admin/pagesAndMenu/routes.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/routes.tsx
@@ -42,7 +42,14 @@ const CustomPageHeroBannerForm = lazy(
 export const ADMIN_PAGES_MENU_PATH = `/admin/pages-menu`;
 const HOMEPAGE_PATH = 'homepage';
 const CUSTOM_PAGES_PATH = 'pages';
-export const ADMIN_PAGES_MENU_CUSTOM_PAGE_PATH = `${ADMIN_PAGES_MENU_PATH}/${CUSTOM_PAGES_PATH}`;
+const ADMIN_PAGES_MENU_CUSTOM_PAGE_PATH = `${ADMIN_PAGES_MENU_PATH}/${CUSTOM_PAGES_PATH}`;
+
+export const adminCustomPageSettingsPath = (pageId: string) => {
+  return `${ADMIN_PAGES_MENU_CUSTOM_PAGE_PATH}/${pageId}/settings`;
+};
+export const adminCustomPageContentPath = (pageId: string) => {
+  return `${ADMIN_PAGES_MENU_CUSTOM_PAGE_PATH}/${pageId}/content`;
+};
 
 export default () => ({
   path: 'pages-menu', // pages-menu

--- a/front/app/containers/Admin/pagesAndMenu/routes.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/routes.tsx
@@ -1,6 +1,6 @@
-import React, { lazy } from 'react';
 import PageLoading from 'components/UI/PageLoading';
 import moduleConfiguration from 'modules';
+import React, { lazy } from 'react';
 import { Navigate } from 'react-router-dom';
 const CustomPagesIndex = lazy(() => import('./containers/CustomPages'));
 const PagesAndMenuIndex = lazy(() => import('containers/Admin/pagesAndMenu'));
@@ -39,15 +39,13 @@ const CustomPageHeroBannerForm = lazy(
 );
 
 // path utils
-const PAGE_PATH = 'pages-menu';
-const ADMIN_PATH_PREFIX = 'admin';
-export const PAGES_MENU_PATH = `/${ADMIN_PATH_PREFIX}/${PAGE_PATH}`;
+export const ADMIN_PAGES_MENU_PATH = `/admin/pages-menu`;
 const HOMEPAGE_PATH = 'homepage';
 const CUSTOM_PAGES_PATH = 'pages';
-export const PAGES_MENU_CUSTOM_PATH = `${PAGES_MENU_PATH}/${CUSTOM_PAGES_PATH}`;
+export const ADMIN_PAGES_MENU_CUSTOM_PAGE_PATH = `${ADMIN_PAGES_MENU_PATH}/${CUSTOM_PAGES_PATH}`;
 
 export default () => ({
-  path: PAGE_PATH, // pages-menu
+  path: 'pages-menu', // pages-menu
   children: [
     {
       path: '',

--- a/front/app/containers/Admin/pagesAndMenu/routes.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/routes.tsx
@@ -44,9 +44,6 @@ const HOMEPAGE_PATH = 'homepage';
 const CUSTOM_PAGES_PATH = 'pages';
 const ADMIN_PAGES_MENU_CUSTOM_PAGE_PATH = `${ADMIN_PAGES_MENU_PATH}/${CUSTOM_PAGES_PATH}`;
 
-export const adminCustomPageSettingsPath = (pageId: string) => {
-  return `${ADMIN_PAGES_MENU_CUSTOM_PAGE_PATH}/${pageId}/settings`;
-};
 export const adminCustomPageContentPath = (pageId: string) => {
   return `${ADMIN_PAGES_MENU_CUSTOM_PAGE_PATH}/${pageId}/content`;
 };

--- a/front/app/containers/CustomPageShow/CustomPageHeader/AdminCustomPageEditButton.tsx
+++ b/front/app/containers/CustomPageShow/CustomPageHeader/AdminCustomPageEditButton.tsx
@@ -1,4 +1,5 @@
 import Button from 'components/UI/Button';
+import { ADMIN_PAGES_MENU_CUSTOM_PAGE_PATH } from 'containers/Admin/pagesAndMenu/routes';
 import useAuthUser from 'hooks/useAuthUser';
 import React from 'react';
 import { InjectedIntlProps } from 'react-intl';
@@ -6,7 +7,6 @@ import { isAdmin } from 'services/permissions/roles';
 import { injectIntl } from 'utils/cl-intl';
 import { isNilOrError } from 'utils/helperUtils';
 import messages from '../messages';
-import { ADMIN_PAGES_MENU_CUSTOM_PAGE_PATH } from 'containers/Admin/pagesAndMenu/routes';
 
 interface Props {
   pageId: string;
@@ -24,12 +24,12 @@ const AdminCustomPageEditButton = ({
   return userCanEditPage ? (
     <Button
       icon="edit"
-      linkTo={`${ADMIN_PAGES_MENU_CUSTOM_PAGE_PATH}/${pageId}`}
+      linkTo={`${ADMIN_PAGES_MENU_CUSTOM_PAGE_PATH}/${pageId}/settings`}
       buttonStyle="secondary"
       padding="5px 8px"
       position="absolute"
-      top="20px"
-      right="20px"
+      top="30px"
+      right="30px"
     >
       {formatMessage(messages.editPage)}
     </Button>

--- a/front/app/containers/CustomPageShow/CustomPageHeader/AdminCustomPageEditButton.tsx
+++ b/front/app/containers/CustomPageShow/CustomPageHeader/AdminCustomPageEditButton.tsx
@@ -6,13 +6,14 @@ import { isAdmin } from 'services/permissions/roles';
 import { injectIntl } from 'utils/cl-intl';
 import { isNilOrError } from 'utils/helperUtils';
 import messages from '../messages';
+import { ADMIN_PAGES_MENU_CUSTOM_PAGE_PATH } from 'containers/Admin/pagesAndMenu/routes';
 
 interface Props {
-  linkTo: string;
+  pageId: string;
 }
 
 const AdminCustomPageEditButton = ({
-  linkTo,
+  pageId,
   intl: { formatMessage },
 }: Props & InjectedIntlProps) => {
   const authUser = useAuthUser();
@@ -23,7 +24,7 @@ const AdminCustomPageEditButton = ({
   return userCanEditPage ? (
     <Button
       icon="edit"
-      linkTo={linkTo}
+      linkTo={`${ADMIN_PAGES_MENU_CUSTOM_PAGE_PATH}/${pageId}`}
       buttonStyle="secondary"
       padding="5px 8px"
       position="absolute"

--- a/front/app/containers/CustomPageShow/CustomPageHeader/AdminCustomPageEditButton.tsx
+++ b/front/app/containers/CustomPageShow/CustomPageHeader/AdminCustomPageEditButton.tsx
@@ -1,0 +1,38 @@
+import Button from 'components/UI/Button';
+import useAuthUser from 'hooks/useAuthUser';
+import React from 'react';
+import { InjectedIntlProps } from 'react-intl';
+import { isAdmin } from 'services/permissions/roles';
+import { injectIntl } from 'utils/cl-intl';
+import { isNilOrError } from 'utils/helperUtils';
+import messages from '../messages';
+
+interface Props {
+  linkTo: string;
+}
+
+const AdminCustomPageEditButton = ({
+  linkTo,
+  intl: { formatMessage },
+}: Props & InjectedIntlProps) => {
+  const authUser = useAuthUser();
+
+  const userCanEditPage =
+    !isNilOrError(authUser) && isAdmin({ data: authUser });
+
+  return userCanEditPage ? (
+    <Button
+      icon="edit"
+      linkTo={linkTo}
+      buttonStyle="secondary"
+      padding="5px 8px"
+      position="absolute"
+      top="20px"
+      right="20px"
+    >
+      {formatMessage(messages.editPage)}
+    </Button>
+  ) : null;
+};
+
+export default injectIntl(AdminCustomPageEditButton);

--- a/front/app/containers/CustomPageShow/CustomPageHeader/AdminCustomPageEditButton.tsx
+++ b/front/app/containers/CustomPageShow/CustomPageHeader/AdminCustomPageEditButton.tsx
@@ -1,5 +1,5 @@
 import Button from 'components/UI/Button';
-import { ADMIN_PAGES_MENU_CUSTOM_PAGE_PATH } from 'containers/Admin/pagesAndMenu/routes';
+import { adminCustomPageSettingsPath } from 'containers/Admin/pagesAndMenu/routes';
 import useAuthUser from 'hooks/useAuthUser';
 import React from 'react';
 import { InjectedIntlProps } from 'react-intl';
@@ -24,7 +24,7 @@ const AdminCustomPageEditButton = ({
   return userCanEditPage ? (
     <Button
       icon="edit"
-      linkTo={`${ADMIN_PAGES_MENU_CUSTOM_PAGE_PATH}/${pageId}/settings`}
+      linkTo={adminCustomPageSettingsPath(pageId)}
       buttonStyle="secondary"
       padding="5px 8px"
       position="absolute"

--- a/front/app/containers/CustomPageShow/CustomPageHeader/AdminCustomPageEditButton.tsx
+++ b/front/app/containers/CustomPageShow/CustomPageHeader/AdminCustomPageEditButton.tsx
@@ -1,5 +1,5 @@
 import Button from 'components/UI/Button';
-import { adminCustomPageSettingsPath } from 'containers/Admin/pagesAndMenu/routes';
+import { adminCustomPageContentPath } from 'containers/Admin/pagesAndMenu/routes';
 import useAuthUser from 'hooks/useAuthUser';
 import React from 'react';
 import { InjectedIntlProps } from 'react-intl';
@@ -24,7 +24,7 @@ const AdminCustomPageEditButton = ({
   return userCanEditPage ? (
     <Button
       icon="edit"
-      linkTo={adminCustomPageSettingsPath(pageId)}
+      linkTo={adminCustomPageContentPath(pageId)}
       buttonStyle="secondary"
       padding="5px 8px"
       position="absolute"

--- a/front/app/containers/CustomPageShow/CustomPageHeader/FullWidthBannerLayout.tsx
+++ b/front/app/containers/CustomPageShow/CustomPageHeader/FullWidthBannerLayout.tsx
@@ -1,4 +1,3 @@
-import { ADMIN_PAGES_MENU_CUSTOM_PAGE_PATH } from 'containers/Admin/pagesAndMenu/routes';
 import {
   Container,
   Header,
@@ -47,7 +46,7 @@ const FullWidthBannerLayout = ({
       <AdminCustomPageEditButton
         // check mobile version
         // check if we can use path function instead
-        linkTo={`${ADMIN_PAGES_MENU_CUSTOM_PAGE_PATH}/${pageData.id}`}
+        pageId={pageData.id}
       />
     </Container>
   );

--- a/front/app/containers/CustomPageShow/CustomPageHeader/FullWidthBannerLayout.tsx
+++ b/front/app/containers/CustomPageShow/CustomPageHeader/FullWidthBannerLayout.tsx
@@ -43,11 +43,7 @@ const FullWidthBannerLayout = ({
           pageAttributes={pageData.attributes}
         />
       </Header>
-      <AdminCustomPageEditButton
-        // check mobile version
-        // check if we can use path function instead
-        pageId={pageData.id}
-      />
+      <AdminCustomPageEditButton pageId={pageData.id} />
     </Container>
   );
 };

--- a/front/app/containers/CustomPageShow/CustomPageHeader/FullWidthBannerLayout.tsx
+++ b/front/app/containers/CustomPageShow/CustomPageHeader/FullWidthBannerLayout.tsx
@@ -1,30 +1,30 @@
-import React from 'react';
-import { ICustomPageAttributes } from 'services/customPages';
-
-// components
-import HeaderContent from './HeaderContent';
+import { ADMIN_PAGES_MENU_CUSTOM_PAGE_PATH } from 'containers/Admin/pagesAndMenu/routes';
 import {
-  HeaderImageBackground,
   Container,
   Header,
   HeaderImage,
+  HeaderImageBackground,
   HeaderImageOverlay,
 } from 'containers/LandingPage/SignedOutHeader/FullWidthBannerLayout';
-
+import React from 'react';
+import { ICustomPageData } from 'services/customPages';
+import AdminCustomPageEditButton from './AdminCustomPageEditButton';
+import HeaderContent from './HeaderContent';
 export interface Props {
   className?: string;
   imageColor?: string;
   imageOpacity?: number;
-  pageAttributes: ICustomPageAttributes;
+  pageData: ICustomPageData;
 }
 
 const FullWidthBannerLayout = ({
   className,
   imageColor,
   imageOpacity,
-  pageAttributes,
+  pageData,
 }: Props) => {
-  const imageUrl = pageAttributes.header_bg?.large;
+  const imageUrl = pageData.attributes.header_bg?.large;
+
   return (
     <Container className={`e2e-signed-out-header ${className}`}>
       <Header id="hook-header">
@@ -41,9 +41,12 @@ const FullWidthBannerLayout = ({
         <HeaderContent
           fontColors="light"
           hasHeaderBannerImage={imageUrl != null}
-          pageAttributes={pageAttributes}
+          pageAttributes={pageData.attributes}
         />
       </Header>
+      <AdminCustomPageEditButton
+        linkTo={`${ADMIN_PAGES_MENU_CUSTOM_PAGE_PATH}/${pageData.id}`}
+      />
     </Container>
   );
 };

--- a/front/app/containers/CustomPageShow/CustomPageHeader/FullWidthBannerLayout.tsx
+++ b/front/app/containers/CustomPageShow/CustomPageHeader/FullWidthBannerLayout.tsx
@@ -45,6 +45,8 @@ const FullWidthBannerLayout = ({
         />
       </Header>
       <AdminCustomPageEditButton
+        // check mobile version
+        // check if we can use path function instead
         linkTo={`${ADMIN_PAGES_MENU_CUSTOM_PAGE_PATH}/${pageData.id}`}
       />
     </Container>

--- a/front/app/containers/CustomPageShow/CustomPageHeader/TwoColumnLayout.tsx
+++ b/front/app/containers/CustomPageShow/CustomPageHeader/TwoColumnLayout.tsx
@@ -7,7 +7,7 @@ import { media } from 'utils/styleUtils';
 import AdminCustomPageEditButton from './AdminCustomPageEditButton';
 import HeaderContent from './HeaderContent';
 
-export const Container = styled.div`
+const Container = styled.div`
   width: 100%;
   display: flex;
   align-items: center;
@@ -18,7 +18,7 @@ export const Container = styled.div`
   `}
 `;
 
-export const HeaderImage = styled(Image)`
+const HeaderImage = styled(Image)`
   height: ${homepageBannerLayoutHeights.two_column_layout.desktop}px;
   max-width: 50%;
   overflow: hidden;

--- a/front/app/containers/CustomPageShow/CustomPageHeader/TwoColumnLayout.tsx
+++ b/front/app/containers/CustomPageShow/CustomPageHeader/TwoColumnLayout.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
-import HeaderContent from './HeaderContent';
-import styled from 'styled-components';
-import { media } from 'utils/styleUtils';
 import Image from 'components/UI/Image';
 import { homepageBannerLayoutHeights } from 'containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/HeaderImageDropzone';
-import { ICustomPageAttributes } from 'services/customPages';
+import React from 'react';
+import { ICustomPageData } from 'services/customPages';
+import styled from 'styled-components';
+import { media } from 'utils/styleUtils';
+import AdminCustomPageEditButton from './AdminCustomPageEditButton';
+import HeaderContent from './HeaderContent';
 
 export const Container = styled.div`
   width: 100%;
@@ -29,10 +30,11 @@ export const HeaderImage = styled(Image)`
 `;
 
 interface Props {
-  pageAttributes: ICustomPageAttributes;
+  pageData: ICustomPageData;
 }
 
-const TwoColumnLayout = ({ pageAttributes }: Props) => {
+const TwoColumnLayout = ({ pageData }: Props) => {
+  const pageAttributes = pageData.attributes;
   const imageUrl = pageAttributes.header_bg?.large;
   return (
     <Container data-cy="e2e-two-column-layout-container">
@@ -50,6 +52,11 @@ const TwoColumnLayout = ({ pageAttributes }: Props) => {
         fontColors="dark"
         hasHeaderBannerImage={imageUrl != null}
         pageAttributes={pageAttributes}
+      />
+      <AdminCustomPageEditButton
+        // check mobile version
+        // check if we can use path function instead
+        pageId={pageData.id}
       />
     </Container>
   );

--- a/front/app/containers/CustomPageShow/CustomPageHeader/TwoColumnLayout.tsx
+++ b/front/app/containers/CustomPageShow/CustomPageHeader/TwoColumnLayout.tsx
@@ -53,11 +53,7 @@ const TwoColumnLayout = ({ pageData }: Props) => {
         hasHeaderBannerImage={imageUrl != null}
         pageAttributes={pageAttributes}
       />
-      <AdminCustomPageEditButton
-        // check mobile version
-        // check if we can use path function instead
-        pageId={pageData.id}
-      />
+      <AdminCustomPageEditButton pageId={pageData.id} />
     </Container>
   );
 };

--- a/front/app/containers/CustomPageShow/CustomPageHeader/TwoRowLayout.tsx
+++ b/front/app/containers/CustomPageShow/CustomPageHeader/TwoRowLayout.tsx
@@ -44,6 +44,8 @@ const TwoRowLayout = ({ pageData }: Props) => {
       <Box
         width="100%"
         position="relative"
+        // Needed when the Hero banner is turned on, but there is no image yet
+        // Otherwise the AdminCustomPageEditButton is not clickable.
         height={
           isTablet
             ? `${homepageBannerLayoutHeights['two_row_layout'].tablet}px`

--- a/front/app/containers/CustomPageShow/CustomPageHeader/TwoRowLayout.tsx
+++ b/front/app/containers/CustomPageShow/CustomPageHeader/TwoRowLayout.tsx
@@ -1,4 +1,4 @@
-import { Box } from '@citizenlab/cl2-component-library';
+import { Box, useBreakpoint } from '@citizenlab/cl2-component-library';
 import ContentContainer from 'components/ContentContainer';
 import Image from 'components/UI/Image';
 import { homepageBannerLayoutHeights } from 'containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/HeaderImageDropzone';
@@ -37,10 +37,19 @@ interface Props {
 const TwoRowLayout = ({ pageData }: Props) => {
   const pageAttributes = pageData.attributes;
   const imageUrl = pageAttributes.header_bg?.large;
+  const isTablet = useBreakpoint('tablet');
 
   return (
     <>
-      <Box width="100%">
+      <Box
+        width="100%"
+        position="relative"
+        height={
+          isTablet
+            ? `${homepageBannerLayoutHeights['two_row_layout'].tablet}px`
+            : `${homepageBannerLayoutHeights['two_row_layout'].desktop}px`
+        }
+      >
         {imageUrl && (
           <HeaderImage
             src={imageUrl}

--- a/front/app/containers/CustomPageShow/CustomPageHeader/TwoRowLayout.tsx
+++ b/front/app/containers/CustomPageShow/CustomPageHeader/TwoRowLayout.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
-import HeaderContent from './HeaderContent';
 import ContentContainer from 'components/ContentContainer';
-import styled from 'styled-components';
 import Image from 'components/UI/Image';
-import { media } from 'utils/styleUtils';
 import { homepageBannerLayoutHeights } from 'containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/HeaderImageDropzone';
-import { ICustomPageAttributes } from 'services/customPages';
+import React from 'react';
+import { ICustomPageData } from 'services/customPages';
+import styled from 'styled-components';
+import { media } from 'utils/styleUtils';
+import HeaderContent from './HeaderContent';
+import AdminCustomPageEditButton from './AdminCustomPageEditButton';
 
 const Container = styled.div`
   display: flex;
@@ -29,10 +30,11 @@ const HeaderImage = styled(Image)`
 `;
 
 interface Props {
-  pageAttributes: ICustomPageAttributes;
+  pageData: ICustomPageData;
 }
 
-const TwoRowLayout = ({ pageAttributes }: Props) => {
+const TwoRowLayout = ({ pageData }: Props) => {
+  const pageAttributes = pageData.attributes;
   const imageUrl = pageAttributes.header_bg?.large;
   return (
     <>
@@ -52,6 +54,11 @@ const TwoRowLayout = ({ pageAttributes }: Props) => {
             hasHeaderBannerImage={imageUrl != null}
             fontColors="dark"
             pageAttributes={pageAttributes}
+          />
+          <AdminCustomPageEditButton
+            // check mobile version
+            // check if we can use path function instead
+            pageId={pageData.id}
           />
         </Container>
       </ContentContainer>

--- a/front/app/containers/CustomPageShow/CustomPageHeader/TwoRowLayout.tsx
+++ b/front/app/containers/CustomPageShow/CustomPageHeader/TwoRowLayout.tsx
@@ -1,3 +1,4 @@
+import { Box } from '@citizenlab/cl2-component-library';
 import ContentContainer from 'components/ContentContainer';
 import Image from 'components/UI/Image';
 import { homepageBannerLayoutHeights } from 'containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/HeaderImageDropzone';
@@ -5,8 +6,8 @@ import React from 'react';
 import { ICustomPageData } from 'services/customPages';
 import styled from 'styled-components';
 import { media } from 'utils/styleUtils';
-import HeaderContent from './HeaderContent';
 import AdminCustomPageEditButton from './AdminCustomPageEditButton';
+import HeaderContent from './HeaderContent';
 
 const Container = styled.div`
   display: flex;
@@ -36,29 +37,28 @@ interface Props {
 const TwoRowLayout = ({ pageData }: Props) => {
   const pageAttributes = pageData.attributes;
   const imageUrl = pageAttributes.header_bg?.large;
+
   return (
     <>
-      {imageUrl && (
-        <HeaderImage
-          src={imageUrl}
-          cover={true}
-          fadeIn={false}
-          isLazy={false}
-          placeholderBg="transparent"
-          alt=""
-        />
-      )}
+      <Box width="100%">
+        {imageUrl && (
+          <HeaderImage
+            src={imageUrl}
+            cover={true}
+            fadeIn={false}
+            isLazy={false}
+            placeholderBg="transparent"
+            alt=""
+          />
+        )}
+        <AdminCustomPageEditButton pageId={pageData.id} />
+      </Box>
       <ContentContainer mode="page">
         <Container>
           <HeaderContent
             hasHeaderBannerImage={imageUrl != null}
             fontColors="dark"
             pageAttributes={pageAttributes}
-          />
-          <AdminCustomPageEditButton
-            // check mobile version
-            // check if we can use path function instead
-            pageId={pageData.id}
           />
         </Container>
       </ContentContainer>

--- a/front/app/containers/CustomPageShow/CustomPageHeader/index.tsx
+++ b/front/app/containers/CustomPageShow/CustomPageHeader/index.tsx
@@ -1,18 +1,19 @@
 import React from 'react';
-import { ICustomPageAttributes } from 'services/customPages';
+import { ICustomPageAttributes, ICustomPageData } from 'services/customPages';
 import FullWidthBannerLayout from './FullWidthBannerLayout';
 import TwoColumnLayout from './TwoColumnLayout';
 import TwoRowLayout from './TwoRowLayout';
 
 interface Props {
   pageAttributes: ICustomPageAttributes;
+  pageData: ICustomPageData;
 }
 
-const CustomPageHeader = ({ pageAttributes }: Props) => {
+const CustomPageHeader = ({ pageAttributes, pageData }: Props) => {
   return (
     <>
       {pageAttributes.banner_layout === 'full_width_banner_layout' && (
-        <FullWidthBannerLayout pageAttributes={pageAttributes} />
+        <FullWidthBannerLayout pageData={pageData} />
       )}
       {pageAttributes.banner_layout === 'two_column_layout' && (
         <TwoColumnLayout pageAttributes={pageAttributes} />

--- a/front/app/containers/CustomPageShow/CustomPageHeader/index.tsx
+++ b/front/app/containers/CustomPageShow/CustomPageHeader/index.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
-import { ICustomPageAttributes, ICustomPageData } from 'services/customPages';
+import { ICustomPageData } from 'services/customPages';
 import FullWidthBannerLayout from './FullWidthBannerLayout';
 import TwoColumnLayout from './TwoColumnLayout';
 import TwoRowLayout from './TwoRowLayout';
 
 interface Props {
-  pageAttributes: ICustomPageAttributes;
   pageData: ICustomPageData;
 }
 
-const CustomPageHeader = ({ pageAttributes, pageData }: Props) => {
+const CustomPageHeader = ({ pageData }: Props) => {
+  const pageAttributes = pageData.attributes;
   return (
     <>
       {pageAttributes.banner_layout === 'full_width_banner_layout' && (

--- a/front/app/containers/CustomPageShow/CustomPageHeader/index.tsx
+++ b/front/app/containers/CustomPageShow/CustomPageHeader/index.tsx
@@ -16,10 +16,10 @@ const CustomPageHeader = ({ pageAttributes, pageData }: Props) => {
         <FullWidthBannerLayout pageData={pageData} />
       )}
       {pageAttributes.banner_layout === 'two_column_layout' && (
-        <TwoColumnLayout pageAttributes={pageAttributes} />
+        <TwoColumnLayout pageData={pageData} />
       )}
       {pageAttributes.banner_layout === 'two_row_layout' && (
-        <TwoRowLayout pageAttributes={pageAttributes} />
+        <TwoRowLayout pageData={pageData} />
       )}
     </>
   );

--- a/front/app/containers/CustomPageShow/index.tsx
+++ b/front/app/containers/CustomPageShow/index.tsx
@@ -72,34 +72,34 @@ const CustomPageShow = () => {
     // should return 404 here
   }
 
-  const attributes = page.attributes;
+  const pageAttributes = page.attributes;
   const localizedOrgName = localize(
     appConfiguration.attributes.settings.core.organization_name
   );
   return (
     <Container className={`e2e-custom-page`}>
       <Helmet
-        title={`${localize(attributes.title_multiloc)} | ${localizedOrgName}`}
+        title={`${localize(
+          pageAttributes.title_multiloc
+        )} | ${localizedOrgName}`}
       />
-      {attributes.banner_enabled && (
-        <CustomPageHeader pageData={page} pageAttributes={attributes} />
-      )}
+      {pageAttributes.banner_enabled && <CustomPageHeader pageData={page} />}
       <Content>
         <Fragment
           name={!isNilOrError(page) ? `pages/${page && page.id}/content` : ''}
         />
         {/* show page text title if the banner is disabled */}
-        {!attributes.banner_enabled && (
+        {!pageAttributes.banner_enabled && (
           <ContentContainer>
-            <PageTitle>{localize(attributes.title_multiloc)}</PageTitle>
+            <PageTitle>{localize(pageAttributes.title_multiloc)}</PageTitle>
           </ContentContainer>
         )}
-        {attributes.top_info_section_enabled && (
+        {pageAttributes.top_info_section_enabled && (
           <TopInfoSection
-            multilocContent={attributes.top_info_section_multiloc}
+            multilocContent={pageAttributes.top_info_section_multiloc}
           />
         )}
-        {attributes.files_section_enabled &&
+        {pageAttributes.files_section_enabled &&
           !isNilOrError(remotePageFiles) &&
           remotePageFiles.length > 0 && (
             <AttachmentsContainer>

--- a/front/app/containers/CustomPageShow/index.tsx
+++ b/front/app/containers/CustomPageShow/index.tsx
@@ -1,30 +1,30 @@
 import React from 'react';
 
 // components
-import CustomPageHeader from './CustomPageHeader';
-import TopInfoSection from './TopInfoSection';
-import { Container, Content } from 'containers/LandingPage';
-import { Helmet } from 'react-helmet';
+import ContentContainer from 'components/ContentContainer';
 import Fragment from 'components/Fragment';
 import FileAttachments from 'components/UI/FileAttachments';
-import ContentContainer from 'components/ContentContainer';
+import { Container, Content } from 'containers/LandingPage';
+import { Helmet } from 'react-helmet';
+import CustomPageHeader from './CustomPageHeader';
+import TopInfoSection from './TopInfoSection';
 
 // hooks
-import { useParams } from 'react-router-dom';
+import useAppConfiguration from 'hooks/useAppConfiguration';
 import useCustomPageBySlug from 'hooks/useCustomPageBySlug';
 import useResourceFiles from 'hooks/useResourceFiles';
-import useAppConfiguration from 'hooks/useAppConfiguration';
+import { useParams } from 'react-router-dom';
 
 // utils
 import { isNilOrError } from 'utils/helperUtils';
 
 // i18n
-import { injectIntl } from 'utils/cl-intl';
 import useLocalize from 'hooks/useLocalize';
+import { injectIntl } from 'utils/cl-intl';
 
 // styling
 import styled from 'styled-components';
-import { media, fontSizes, isRtl } from 'utils/styleUtils';
+import { fontSizes, isRtl, media } from 'utils/styleUtils';
 
 const PageTitle = styled.h1`
   color: ${({ theme }) => theme.colors.tenantText};
@@ -82,7 +82,7 @@ const CustomPageShow = () => {
         title={`${localize(attributes.title_multiloc)} | ${localizedOrgName}`}
       />
       {attributes.banner_enabled && (
-        <CustomPageHeader pageAttributes={attributes} />
+        <CustomPageHeader pageData={page} pageAttributes={attributes} />
       )}
       <Content>
         <Fragment

--- a/front/app/containers/CustomPageShow/messages.ts
+++ b/front/app/containers/CustomPageShow/messages.ts
@@ -1,0 +1,8 @@
+import { defineMessages } from 'react-intl';
+
+export default defineMessages({
+  editPage: {
+    id: 'app.containers.CustomPageShow.editPage',
+    defaultMessage: 'Edit page',
+  },
+});

--- a/front/app/containers/LandingPage/SignedOutHeader/FullWidthBannerLayout.tsx
+++ b/front/app/containers/LandingPage/SignedOutHeader/FullWidthBannerLayout.tsx
@@ -1,6 +1,6 @@
+import { homepageBannerLayoutHeights } from 'containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/HeaderImageDropzone';
 import React from 'react';
 import { isNilOrError } from 'utils/helperUtils';
-import { homepageBannerLayoutHeights } from 'containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/HeaderImageDropzone';
 
 // components
 import HeaderContent from './HeaderContent';
@@ -24,7 +24,6 @@ export const Header = styled.div`
   min-height: ${homepageBannerLayoutHeights.full_width_banner_layout.desktop}px;
   margin: 0;
   padding: 0;
-  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/front/app/containers/LandingPage/SignedOutHeader/FullWidthBannerLayout.tsx
+++ b/front/app/containers/LandingPage/SignedOutHeader/FullWidthBannerLayout.tsx
@@ -16,6 +16,7 @@ export const Container = styled.div`
   width: 100%;
   display: flex;
   flex-direction: column;
+  position: relative;
 `;
 
 export const Header = styled.div`

--- a/front/app/containers/LandingPage/SignedOutHeader/FullWidthBannerLayout.tsx
+++ b/front/app/containers/LandingPage/SignedOutHeader/FullWidthBannerLayout.tsx
@@ -16,7 +16,6 @@ export const Container = styled.div`
   width: 100%;
   display: flex;
   flex-direction: column;
-  position: relative;
 `;
 
 export const Header = styled.div`
@@ -24,6 +23,7 @@ export const Header = styled.div`
   min-height: ${homepageBannerLayoutHeights.full_width_banner_layout.desktop}px;
   margin: 0;
   padding: 0;
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/front/app/modules/commercial/customizable_homepage_banner/citizen/TwoColumnLayout.tsx
+++ b/front/app/modules/commercial/customizable_homepage_banner/citizen/TwoColumnLayout.tsx
@@ -7,7 +7,7 @@ import Image from 'components/UI/Image';
 import useHomepageSettings from 'hooks/useHomepageSettings';
 import { homepageBannerLayoutHeights } from 'containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/HeaderImageDropzone';
 
-export const Container = styled.div`
+const Container = styled.div`
   width: 100%;
   display: flex;
   align-items: center;
@@ -18,7 +18,7 @@ export const Container = styled.div`
   `}
 `;
 
-export const HeaderImage = styled(Image)`
+const HeaderImage = styled(Image)`
   height: ${homepageBannerLayoutHeights.two_column_layout.desktop}px;
   max-width: 50%;
   overflow: hidden;

--- a/front/app/modules/commercial/customizable_homepage_banner/citizen/TwoRowLayout.tsx
+++ b/front/app/modules/commercial/customizable_homepage_banner/citizen/TwoRowLayout.tsx
@@ -1,12 +1,12 @@
-import React from 'react';
-import { isNilOrError } from 'utils/helperUtils';
-import useHomepageSettings from 'hooks/useHomepageSettings';
-import HeaderContent from 'containers/LandingPage/SignedOutHeader/HeaderContent';
 import ContentContainer from 'components/ContentContainer';
-import styled from 'styled-components';
 import Image from 'components/UI/Image';
-import { media } from 'utils/styleUtils';
 import { homepageBannerLayoutHeights } from 'containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/HeaderImageDropzone';
+import HeaderContent from 'containers/LandingPage/SignedOutHeader/HeaderContent';
+import useHomepageSettings from 'hooks/useHomepageSettings';
+import React from 'react';
+import styled from 'styled-components';
+import { isNilOrError } from 'utils/helperUtils';
+import { media } from 'utils/styleUtils';
 
 const Container = styled.div`
   display: flex;

--- a/front/app/modules/commercial/customizable_navbar/admin/components/PoliciesSubtitle.tsx
+++ b/front/app/modules/commercial/customizable_navbar/admin/components/PoliciesSubtitle.tsx
@@ -11,7 +11,7 @@ import { FormattedMessage } from 'utils/cl-intl';
 import messages from './messages';
 
 // utils
-import { PAGES_MENU_PATH } from 'containers/Admin/pagesAndMenu/routes';
+import { ADMIN_PAGES_MENU_PATH } from 'containers/Admin/pagesAndMenu/routes';
 
 export default () => {
   const featureEnabled = useFeatureFlag({ name: 'customizable_navbar' });
@@ -23,7 +23,7 @@ export default () => {
       {...messages.policiesSubtitlePremium}
       values={{
         navigationLink: (
-          <StyledLink to={PAGES_MENU_PATH}>
+          <StyledLink to={ADMIN_PAGES_MENU_PATH}>
             <FormattedMessage {...messages.linkToNavigation} />
           </StyledLink>
         ),

--- a/front/app/modules/commercial/customizable_navbar/admin/containers/NavigationSettings/HiddenNavbarItemList/HiddenNavbarItemList.test.tsx
+++ b/front/app/modules/commercial/customizable_navbar/admin/containers/NavigationSettings/HiddenNavbarItemList/HiddenNavbarItemList.test.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
-import { render, screen, fireEvent } from 'utils/testUtils/rtl';
-import HiddenNavbarItemList from '.';
+import { ADMIN_PAGES_MENU_PATH } from 'containers/Admin/pagesAndMenu/routes';
 import allNavbarItems from 'hooks/fixtures/navbarItems';
-import { addNavbarItem } from '../../../../services/navbar';
+import React from 'react';
 import { deletePage } from 'services/pages';
-import { PAGES_MENU_PATH } from 'containers/Admin/pagesAndMenu/routes';
 import clHistory from 'utils/cl-router/history';
+import { fireEvent, render, screen } from 'utils/testUtils/rtl';
+import HiddenNavbarItemList from '.';
+import { addNavbarItem } from '../../../../services/navbar';
 
 jest.mock('services/locale');
 jest.mock('services/appConfiguration');
@@ -57,7 +57,7 @@ describe('<HiddenNavbarItemList />', () => {
     fireEvent.click(editButtons[0]);
 
     expect(clHistory.push).toHaveBeenCalledWith(
-      `${PAGES_MENU_PATH}/pages/edit/1b095a31-72e1-450a-81be-f6e7a9296553`
+      `${ADMIN_PAGES_MENU_PATH}/pages/edit/1b095a31-72e1-450a-81be-f6e7a9296553`
     );
   });
 

--- a/front/app/modules/commercial/customizable_navbar/admin/containers/NavigationSettings/HiddenNavbarItemList/index.tsx
+++ b/front/app/modules/commercial/customizable_navbar/admin/containers/NavigationSettings/HiddenNavbarItemList/index.tsx
@@ -22,7 +22,7 @@ import { injectIntl } from 'utils/cl-intl';
 import messages from './messages';
 
 // utils
-import { PAGES_MENU_PATH } from 'containers/Admin/pagesAndMenu/routes';
+import { ADMIN_PAGES_MENU_PATH } from 'containers/Admin/pagesAndMenu/routes';
 import clHistory from 'utils/cl-router/history';
 import { isNilOrError } from 'utils/helperUtils';
 import getItemsNotInNavbar, { IItemNotInNavbar } from './getItemsNotInNavbar';
@@ -62,7 +62,7 @@ const HiddenNavbarItemList = ({
 
   const handleClickEditButton = (item: IItemNotInNavbar) => () => {
     if (item.type !== 'page') return;
-    clHistory.push(`${PAGES_MENU_PATH}/pages/${item.pageId}/settings`);
+    clHistory.push(`${ADMIN_PAGES_MENU_PATH}/pages/${item.pageId}/settings`);
   };
 
   const handleClickAdd = (item: IItemNotInNavbar) => () => {

--- a/front/app/modules/commercial/customizable_navbar/admin/containers/NavigationSettings/VisibleNavbarItemList/VisibleNavbarItemList.test.tsx
+++ b/front/app/modules/commercial/customizable_navbar/admin/containers/NavigationSettings/VisibleNavbarItemList/VisibleNavbarItemList.test.tsx
@@ -1,14 +1,14 @@
+import { ADMIN_PAGES_MENU_PATH } from 'containers/Admin/pagesAndMenu/routes';
+import navbarItems from 'hooks/fixtures/navbarItems';
 import React from 'react';
-import { render, screen, fireEvent } from 'utils/testUtils/rtl';
+import { deletePage } from 'services/pages';
+import clHistory from 'utils/cl-router/history';
+import { fireEvent, render, screen } from 'utils/testUtils/rtl';
 import VisibleNavbarItemList from '.';
 import {
-  reorderNavbarItem,
   removeNavbarItem,
+  reorderNavbarItem,
 } from '../../../../services/navbar';
-import { deletePage } from 'services/pages';
-import { PAGES_MENU_PATH } from 'containers/Admin/pagesAndMenu/routes';
-import navbarItems from 'hooks/fixtures/navbarItems';
-import clHistory from 'utils/cl-router/history';
 
 jest.mock('services/locale');
 jest.mock('services/appConfiguration');
@@ -75,7 +75,7 @@ describe('<VisibleNavbarItemList />', () => {
     fireEvent.click(editButtons[1]);
 
     expect(clHistory.push).toHaveBeenCalledWith(
-      `${PAGES_MENU_PATH}/navbar-items/edit/${navbarItems[1].id}`
+      `${ADMIN_PAGES_MENU_PATH}/navbar-items/edit/${navbarItems[1].id}`
     );
   });
 
@@ -88,7 +88,7 @@ describe('<VisibleNavbarItemList />', () => {
     fireEvent.click(editButtons[6]);
 
     expect(clHistory.push).toHaveBeenCalledWith(
-      `${PAGES_MENU_PATH}/pages/edit/${navbarItems[6].relationships.static_page.data?.id}`
+      `${ADMIN_PAGES_MENU_PATH}/pages/edit/${navbarItems[6].relationships.static_page.data?.id}`
     );
   });
 

--- a/front/app/modules/commercial/customizable_navbar/admin/containers/NavigationSettings/VisibleNavbarItemList/index.tsx
+++ b/front/app/modules/commercial/customizable_navbar/admin/containers/NavigationSettings/VisibleNavbarItemList/index.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
 
 // services
-import {
-  reorderNavbarItem,
-  removeNavbarItem,
-} from '../../../../services/navbar';
-import { deletePage } from 'services/pages';
 import { getNavbarItemSlug, INavbarItem } from 'services/navbar';
+import { deletePage } from 'services/pages';
+import {
+  removeNavbarItem,
+  reorderNavbarItem,
+} from '../../../../services/navbar';
 
 // components
 import {
+  LockedRow,
   SortableList,
   SortableRow,
-  LockedRow,
 } from 'components/admin/ResourceList';
 import { SubSectionTitle } from 'components/admin/Section';
 import NavbarItemRow from 'containers/Admin/pagesAndMenu/containers/NavigationSettings/NavbarItemRow';
@@ -22,14 +22,14 @@ import useNavbarItems from 'hooks/useNavbarItems';
 import usePageSlugById from 'hooks/usePageSlugById';
 
 // i18n
-import { injectIntl, FormattedMessage } from 'utils/cl-intl';
 import { InjectedIntlProps } from 'react-intl';
+import { FormattedMessage, injectIntl } from 'utils/cl-intl';
 import messages from './messages';
 
 // utils
-import { isNilOrError } from 'utils/helperUtils';
+import { ADMIN_PAGES_MENU_PATH } from 'containers/Admin/pagesAndMenu/routes';
 import clHistory from 'utils/cl-router/history';
-import { PAGES_MENU_PATH } from 'containers/Admin/pagesAndMenu/routes';
+import { isNilOrError } from 'utils/helperUtils';
 
 const VisibleNavbarItemList = ({
   intl: { formatMessage },
@@ -44,15 +44,17 @@ const VisibleNavbarItemList = ({
   const handleClickEdit = (navbarItem: INavbarItem) => () => {
     // redirect to homepage toggle page
     if (navbarItem?.attributes?.code && navbarItem.attributes.code === 'home') {
-      clHistory.push(`${PAGES_MENU_PATH}/homepage/`);
+      clHistory.push(`${ADMIN_PAGES_MENU_PATH}/homepage/`);
       return;
     }
 
     const pageData = navbarItem.relationships.static_page.data;
 
     pageData
-      ? clHistory.push(`${PAGES_MENU_PATH}/pages/${pageData.id}/settings`)
-      : clHistory.push(`${PAGES_MENU_PATH}/navbar-items/edit/${navbarItem.id}`);
+      ? clHistory.push(`${ADMIN_PAGES_MENU_PATH}/pages/${pageData.id}/settings`)
+      : clHistory.push(
+          `${ADMIN_PAGES_MENU_PATH}/navbar-items/edit/${navbarItem.id}`
+        );
   };
 
   const getViewButtonLink = (navbarItem: INavbarItem) => {

--- a/front/app/modules/commercial/customizable_navbar/admin/containers/NewPageForm/index.tsx
+++ b/front/app/modules/commercial/customizable_navbar/admin/containers/NewPageForm/index.tsx
@@ -1,27 +1,27 @@
 import React from 'react';
 
 // services
-import { createPage } from 'services/pages';
 import { handleAddPageFiles } from 'services/pageFiles';
+import { createPage } from 'services/pages';
 
 // components
 import PageForm, { FormValues } from 'components/PageForm';
-import SectionFormWrapper from 'containers/Admin/pagesAndMenu/components/SectionFormWrapper';
 import { pagesAndMenuBreadcrumb } from 'containers/Admin/pagesAndMenu/breadcrumbs';
+import SectionFormWrapper from 'containers/Admin/pagesAndMenu/components/SectionFormWrapper';
 
 // i18n
 import { InjectedIntlProps } from 'react-intl';
-import { injectIntl, FormattedMessage } from 'utils/cl-intl';
+import { FormattedMessage, injectIntl } from 'utils/cl-intl';
 import messages from '../messages';
 
 // utils
+import { ADMIN_PAGES_MENU_PATH } from 'containers/Admin/pagesAndMenu/routes';
 import clHistory from 'utils/cl-router/history';
 import { isNilOrError } from 'utils/helperUtils';
-import { PAGES_MENU_PATH } from 'containers/Admin/pagesAndMenu/routes';
 
 const NewPageForm = ({ intl: { formatMessage } }: InjectedIntlProps) => {
   const goBack = () => {
-    clHistory.push(PAGES_MENU_PATH);
+    clHistory.push(ADMIN_PAGES_MENU_PATH);
   };
 
   const handleSubmit = async (values: FormValues) => {

--- a/front/app/translations/en.json
+++ b/front/app/translations/en.json
@@ -691,6 +691,7 @@
   "app.containers.CookiePolicy.viewPreferencesButtonText": "Cookie Settings",
   "app.containers.CookiePolicy.viewPreferencesText": "The below cookie categories may not apply to all visitors or platforms; view your {viewPreferencesButton} for a full list of 3rd party integrations applicable to you.",
   "app.containers.CookiePolicy.whatDoWeUseCookiesFor": "What do we use cookies for?",
+  "app.containers.CustomPageShow.editPage": "Edit page",
   "app.containers.IdeaButton.addAContribution": "Add a contribution",
   "app.containers.IdeaButton.addAProject": "Add a project",
   "app.containers.IdeaButton.addAQuestion": "Add a question",


### PR DESCRIPTION
Button for admins to go straight to a page's content settings.

<img width="1278" alt="Screenshot 2022-10-18 at 14 29 35" src="https://user-images.githubusercontent.com/16427929/196429588-a91fba84-5087-4af1-bb92-1d2119f80cb8.png">
