### PR TITLE
upgrade nokogiri to '>= 1.13.9'

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -122,6 +122,7 @@ gem 'premailer-rails', '~> 1.10.3'
 gem 'rest-client'
 gem 'rgeo-geojson'
 gem 'rubyzip', '~> 1.3.0'
+gem 'nokogiri', '>= 1.13.9'
 
 gem 'okcomputer'
 gem 'omniauth', '~> 1.9.1'

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -802,11 +802,11 @@ GEM
       ruby2_keywords (~> 0.0.1)
     netrc (0.11.0)
     nio4r (2.5.8)
-    nokogiri (1.13.8-aarch64-linux)
+    nokogiri (1.13.9-aarch64-linux)
       racc (~> 1.4)
-    nokogiri (1.13.8-arm64-darwin)
+    nokogiri (1.13.9-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.8-x86_64-linux)
+    nokogiri (1.13.9-x86_64-linux)
       racc (~> 1.4)
     nori (2.6.0)
     oauth2 (1.4.9)
@@ -1233,6 +1233,7 @@ DEPENDENCIES
   moderation!
   multi_tenancy!
   nlp!
+  nokogiri (>= 1.13.9)
   okcomputer
   omniauth (~> 1.9.1)
   omniauth-azure-activedirectory!


### PR DESCRIPTION
`bundle-audit` on CI failed with:
```
ruby-advisory-db:
  advisories:	611 advisories
  last updated:	2022-10-18 16:48:59 -0700
  commit:	137a425b9f4f30f895df8765b0e773400170803d
Name: nokogiri
Version: 1.13.8
GHSA: GHSA-2qc6-mcvw-92cw
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-2qc6-mcvw-92cw
Title: Update bundled libxml2 to v2.10.3 to resolve multiple CVEs
Solution: upgrade to '>= 1.13.9'

Name: nokogiri
Version: 1.13.8
GHSA: GHSA-2qc6-mcvw-92cw
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-2qc6-mcvw-92cw
Title: Update bundled libxml2 to v2.10.3 to resolve multiple CVEs
Solution: upgrade to '>= 1.13.9'

Name: nokogiri
Version: 1.13.8
GHSA: GHSA-2qc6-mcvw-92cw
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-2qc6-mcvw-92cw
Title: Update bundled libxml2 to v2.10.3 to resolve multiple CVEs
Solution: upgrade to '>= 1.13.9'

Vulnerabilities found!
```

See https://github.com/advisories/GHSA-2qc6-mcvw-92cw

This PR changes what `bundle-audit` proposes.