### PR TITLE
[CL-1705] Improvements for custom idea form work

### DIFF
--- a/back/app/services/input_ui_schema_generator_service.rb
+++ b/back/app/services/input_ui_schema_generator_service.rb
@@ -13,6 +13,10 @@ class InputUiSchemaGeneratorService < UiSchemaGeneratorService
 
   protected
 
+  def default_options(field)
+    super.merge(isAdminField: admin_field?(field))
+  end
+
   def generate_for_current_locale(fields)
     participation_context = fields.first.resource.participation_context
     participation_method = Factory.instance.participation_method_for participation_context
@@ -40,6 +44,10 @@ class InputUiSchemaGeneratorService < UiSchemaGeneratorService
   end
 
   private
+
+  def admin_field?(field)
+    field.code == 'budget' || field.code == 'author_id'
+  end
 
   def category_for(fields, category_id, translation_key)
     return if fields.empty?

--- a/back/app/services/ui_schema_generator_service.rb
+++ b/back/app/services/ui_schema_generator_service.rb
@@ -76,9 +76,7 @@ class UiSchemaGeneratorService < FieldVisitorService
       type: 'Control',
       scope: "#/properties/#{field.key}",
       label: multiloc_service.t(field.title_multiloc),
-      options: {
-        description: multiloc_service.t(field.description_multiloc)
-      }
+      options: default_options(field)
     }
   end
 
@@ -86,6 +84,10 @@ class UiSchemaGeneratorService < FieldVisitorService
 
   def generate_for_current_locale(fields)
     raise NotImplementedError
+  end
+
+  def default_options(field)
+    { description: multiloc_service.t(field.description_multiloc) }
   end
 
   private

--- a/back/spec/services/input_ui_schema_generator_service_spec.rb
+++ b/back/spec/services/input_ui_schema_generator_service_spec.rb
@@ -55,19 +55,34 @@ RSpec.describe InputUiSchemaGeneratorService do
                         type: 'Control',
                         scope: "#/properties/#{field2.key}/properties/en",
                         label: 'Body multiloc field title',
-                        options: { description: 'Body multiloc field description', render: 'WYSIWYG', locale: 'en' }
+                        options: {
+                          description: 'Body multiloc field description',
+                          isAdminField: false,
+                          render: 'WYSIWYG',
+                          locale: 'en'
+                        }
                       },
                       {
                         type: 'Control',
                         scope: "#/properties/#{field2.key}/properties/fr-FR",
                         label: 'Body multiloc field title',
-                        options: { description: 'Body multiloc field description', render: 'WYSIWYG', locale: 'fr-FR' }
+                        options: {
+                          description: 'Body multiloc field description',
+                          isAdminField: false,
+                          render: 'WYSIWYG',
+                          locale: 'fr-FR'
+                        }
                       },
                       {
                         type: 'Control',
                         scope: "#/properties/#{field2.key}/properties/nl-NL",
                         label: 'Body multiloc field title',
-                        options: { description: 'Body multiloc field description', render: 'WYSIWYG', locale: 'nl-NL' }
+                        options: {
+                          description: 'Body multiloc field description',
+                          isAdminField: false,
+                          render: 'WYSIWYG',
+                          locale: 'nl-NL'
+                        }
                       }
                     ]
                   }
@@ -82,7 +97,11 @@ RSpec.describe InputUiSchemaGeneratorService do
                     type: 'Control',
                     scope: "#/properties/#{field1.key}",
                     label: 'Text title',
-                    options: { description: 'Text description', transform: 'trim_on_blur' }
+                    options: {
+                      description: 'Text description',
+                      isAdminField: false,
+                      transform: 'trim_on_blur'
+                    }
                   }
                 ]
               }
@@ -108,19 +127,34 @@ RSpec.describe InputUiSchemaGeneratorService do
                         type: 'Control',
                         scope: "#/properties/#{field2.key}/properties/en",
                         label: 'Body multiloc field title',
-                        options: { description: 'Body multiloc field description', render: 'WYSIWYG', locale: 'en' }
+                        options: {
+                          description: 'Body multiloc field description',
+                          isAdminField: false,
+                          render: 'WYSIWYG',
+                          locale: 'en'
+                        }
                       },
                       {
                         type: 'Control',
                         scope: "#/properties/#{field2.key}/properties/fr-FR",
                         label: 'Body multiloc field title',
-                        options: { description: 'Body multiloc field description', render: 'WYSIWYG', locale: 'fr-FR' }
+                        options: {
+                          description: 'Body multiloc field description',
+                          isAdminField: false,
+                          render: 'WYSIWYG',
+                          locale: 'fr-FR'
+                        }
                       },
                       {
                         type: 'Control',
                         scope: "#/properties/#{field2.key}/properties/nl-NL",
                         label: 'Body multiloc field title',
-                        options: { description: 'Body multiloc field description', render: 'WYSIWYG', locale: 'nl-NL' }
+                        options: {
+                          description: 'Body multiloc field description',
+                          isAdminField: false,
+                          render: 'WYSIWYG',
+                          locale: 'nl-NL'
+                        }
                       }
                     ]
                   }
@@ -135,7 +169,11 @@ RSpec.describe InputUiSchemaGeneratorService do
                     type: 'Control',
                     scope: "#/properties/#{field1.key}",
                     label: 'Text titre',
-                    options: { description: 'Text description', transform: 'trim_on_blur' }
+                    options: {
+                      description: 'Text description',
+                      isAdminField: false,
+                      transform: 'trim_on_blur'
+                    }
                   }
                 ]
               }
@@ -161,19 +199,34 @@ RSpec.describe InputUiSchemaGeneratorService do
                         type: 'Control',
                         scope: "#/properties/#{field2.key}/properties/en",
                         label: 'Body multiloc field title',
-                        options: { description: 'Body multiloc field description', render: 'WYSIWYG', locale: 'en' }
+                        options: {
+                          description: 'Body multiloc field description',
+                          isAdminField: false,
+                          render: 'WYSIWYG',
+                          locale: 'en'
+                        }
                       },
                       {
                         type: 'Control',
                         scope: "#/properties/#{field2.key}/properties/fr-FR",
                         label: 'Body multiloc field title',
-                        options: { description: 'Body multiloc field description', render: 'WYSIWYG', locale: 'fr-FR' }
+                        options: {
+                          description: 'Body multiloc field description',
+                          isAdminField: false,
+                          render: 'WYSIWYG',
+                          locale: 'fr-FR'
+                        }
                       },
                       {
                         type: 'Control',
                         scope: "#/properties/#{field2.key}/properties/nl-NL",
                         label: 'Body multiloc field title',
-                        options: { description: 'Body multiloc field description', render: 'WYSIWYG', locale: 'nl-NL' }
+                        options: {
+                          description: 'Body multiloc field description',
+                          isAdminField: false,
+                          render: 'WYSIWYG',
+                          locale: 'nl-NL'
+                        }
                       }
                     ]
                   }
@@ -188,7 +241,11 @@ RSpec.describe InputUiSchemaGeneratorService do
                     type: 'Control',
                     scope: "#/properties/#{field1.key}",
                     label: 'Text titel',
-                    options: { description: 'Text description', transform: 'trim_on_blur' }
+                    options: {
+                      description: 'Text description', 
+                      isAdminField: false,
+                      transform: 'trim_on_blur'
+                    }
                   }
                 ]
               }
@@ -274,7 +331,11 @@ RSpec.describe InputUiSchemaGeneratorService do
               type: 'Control',
               scope: "#/properties/#{field.key}",
               label: 'Did you attend',
-              options: { description: 'Which councils are you attending in our city?', transform: 'trim_on_blur' }
+              options: {
+                description: 'Which councils are you attending in our city?',
+                isAdminField: false,
+                transform: 'trim_on_blur'
+              }
             }]
           }]
         })
@@ -291,6 +352,96 @@ RSpec.describe InputUiSchemaGeneratorService do
       it 'uses the right input_term' do
         ui_schema = generator.generate_for(timeline_fields)['en']
         expect(ui_schema.dig(:options, :inputTerm)).to eq 'contribution'
+      end
+    end
+  end
+
+  describe '#visit_text' do
+    let(:code) { nil }
+    let(:field) do
+      create(
+        :custom_field,
+        input_type: 'text',
+        code: code,
+        key: field_key,
+        title_multiloc: { 'en' => 'Text field title' },
+        description_multiloc: { 'en-CA' => 'Text field description' }
+      )
+    end
+
+    context 'for author_id built-in field' do
+      let(:code) { 'author_id' }
+
+      it 'returns the schema for the author_id field with isAdminField set to true' do
+        expect(generator.visit_text(field)).to eq({
+          type: 'Control',
+          scope: "#/properties/#{field_key}",
+          label: 'Text field title',
+          options: {
+            description: 'Text field description',
+            transform: 'trim_on_blur',
+            isAdminField: true
+          }
+        })
+      end
+    end
+
+    context 'for other fields' do
+      it 'returns the schema for the given field with isAdminField set to false' do
+        expect(generator.visit_text(field)).to eq({
+          type: 'Control',
+          scope: "#/properties/#{field_key}",
+          label: 'Text field title',
+          options: {
+            description: 'Text field description',
+            transform: 'trim_on_blur',
+            isAdminField: false
+          }
+        })
+      end
+    end
+  end
+
+  describe '#visit_number' do
+    let(:code) { nil }
+    let(:field) do
+      create(
+        :custom_field,
+        input_type: 'number',
+        code: code,
+        key: field_key,
+        title_multiloc: { 'en' => 'Number field title' },
+        description_multiloc: { 'en' => 'Number field description' }
+      )
+    end
+
+    context 'for author_id built-in field' do
+      let(:code) { 'budget' }
+
+      it 'returns the schema for the budget field with isAdminField set to true' do
+        expect(generator.visit_number(field)).to eq({
+          type: 'Control',
+          scope: "#/properties/#{field_key}",
+          label: 'Number field title',
+          options: {
+            description: 'Number field description',
+            isAdminField: true
+          }
+        })
+      end
+    end
+
+    context 'for other fields' do
+      it 'returns the schema for the given field with isAdminField set to false' do
+        expect(generator.visit_number(field)).to eq({
+          type: 'Control',
+          scope: "#/properties/#{field_key}",
+          label: 'Number field title',
+          options: {
+            description: 'Number field description',
+            isAdminField: false
+          }
+        })
       end
     end
   end
@@ -317,19 +468,34 @@ RSpec.describe InputUiSchemaGeneratorService do
               type: 'Control',
               scope: "#/properties/#{field_key}/properties/en",
               label: 'Body multiloc field title',
-              options: { description: 'Body multiloc field description', render: 'WYSIWYG', locale: 'en' }
+              options: {
+                description: 'Body multiloc field description',
+                isAdminField: false,
+                render: 'WYSIWYG',
+                locale: 'en'
+              }
             },
             {
               type: 'Control',
               scope: "#/properties/#{field_key}/properties/fr-FR",
               label: 'Body multiloc field title',
-              options: { description: 'Body multiloc field description', render: 'WYSIWYG', locale: 'fr-FR' }
+              options: {
+                description: 'Body multiloc field description',
+                isAdminField: false,
+                render: 'WYSIWYG',
+                locale: 'fr-FR'
+              }
             },
             {
               type: 'Control',
               scope: "#/properties/#{field_key}/properties/nl-NL",
               label: 'Body multiloc field title',
-              options: { description: 'Body multiloc field description', render: 'WYSIWYG', locale: 'nl-NL' }
+              options: {
+                description: 'Body multiloc field description',
+                isAdminField: false,
+                render: 'WYSIWYG',
+                locale: 'nl-NL'
+              }
             }
           ]
         })
@@ -356,19 +522,37 @@ RSpec.describe InputUiSchemaGeneratorService do
               type: 'Control',
               scope: "#/properties/#{field_key}/properties/en",
               label: 'HTML multiloc field title',
-              options: { description: 'HTML multiloc field description', render: 'WYSIWYG', trim_on_blur: true, locale: 'en' }
+              options: {
+                description: 'HTML multiloc field description',
+                isAdminField: false,
+                render: 'WYSIWYG',
+                trim_on_blur: true,
+                locale: 'en'
+              }
             },
             {
               type: 'Control',
               scope: "#/properties/#{field_key}/properties/fr-FR",
               label: 'HTML multiloc field title',
-              options: { description: 'HTML multiloc field description', render: 'WYSIWYG', trim_on_blur: true, locale: 'fr-FR' }
+              options: {
+                description: 'HTML multiloc field description',
+                isAdminField: false,
+                render: 'WYSIWYG',
+                trim_on_blur: true,
+                locale: 'fr-FR'
+              }
             },
             {
               type: 'Control',
               scope: "#/properties/#{field_key}/properties/nl-NL",
               label: 'HTML multiloc field title',
-              options: { description: 'HTML multiloc field description', render: 'WYSIWYG', trim_on_blur: true, locale: 'nl-NL' }
+              options: {
+                description: 'HTML multiloc field description',
+                isAdminField: false,
+                render: 'WYSIWYG',
+                trim_on_blur: true,
+                locale: 'nl-NL'
+              }
             }
           ]
         })

--- a/back/spec/services/input_ui_schema_generator_service_spec.rb
+++ b/back/spec/services/input_ui_schema_generator_service_spec.rb
@@ -242,7 +242,7 @@ RSpec.describe InputUiSchemaGeneratorService do
                     scope: "#/properties/#{field1.key}",
                     label: 'Text titel',
                     options: {
-                      description: 'Text description', 
+                      description: 'Text description',
                       isAdminField: false,
                       transform: 'trim_on_blur'
                     }

--- a/back/spec/services/json_forms_service_spec.rb
+++ b/back/spec/services/json_forms_service_spec.rb
@@ -289,7 +289,8 @@ describe JsonFormsService do
                         scope: '#/properties/topic_ids',
                         label: build_in_required_field.title_multiloc['en'],
                         options: {
-                          description: build_in_required_field.description_multiloc['en']
+                          description: build_in_required_field.description_multiloc['en'],
+                          isAdminField: false
                         }
                       }
                     ]
@@ -304,7 +305,8 @@ describe JsonFormsService do
                         scope: '#/properties/idea_files_attributes',
                         label: build_in_optional_field.title_multiloc['en'],
                         options: {
-                          description: build_in_optional_field.description_multiloc['en']
+                          description: build_in_optional_field.description_multiloc['en'],
+                          isAdminField: false
                         }
                       }
                     ]
@@ -319,7 +321,8 @@ describe JsonFormsService do
                         scope: "#/properties/#{required_field.key}",
                         label: required_field.title_multiloc['en'],
                         options: {
-                          description: required_field.description_multiloc['en']
+                          description: required_field.description_multiloc['en'],
+                          isAdminField: false
                         }
                       },
                       {
@@ -327,7 +330,8 @@ describe JsonFormsService do
                         scope: "#/properties/#{optional_field.key}",
                         label: optional_field.title_multiloc['en'],
                         options: {
-                          description: optional_field.description_multiloc['en']
+                          description: optional_field.description_multiloc['en'],
+                          isAdminField: false
                         }
                       }
                     ]

--- a/front/app/components/Form/Components/Controls/InputControl.tsx
+++ b/front/app/components/Form/Components/Controls/InputControl.tsx
@@ -1,6 +1,7 @@
 import { withJsonFormsControlProps } from '@jsonforms/react';
 import {
   Box,
+  colors,
   IconTooltip,
   Input,
   Text,
@@ -49,7 +50,7 @@ export const InputControl = ({
         <Text>{label}</Text>
         {uischema?.options?.isAdminField && (
           <IconTooltip
-            iconColor="black"
+            iconColor={colors.grey800}
             marginLeft="4px"
             icon="shield-checkered"
             content={<FormattedMessage {...messages.adminFieldTooltip} />}

--- a/front/app/components/Form/Components/Controls/InputControl.tsx
+++ b/front/app/components/Form/Components/Controls/InputControl.tsx
@@ -1,5 +1,10 @@
 import { withJsonFormsControlProps } from '@jsonforms/react';
-import { Box, Input } from '@citizenlab/cl2-component-library';
+import {
+  Box,
+  IconTooltip,
+  Input,
+  Text,
+} from '@citizenlab/cl2-component-library';
 import {
   ControlProps,
   isControl,
@@ -12,6 +17,8 @@ import { FormLabel } from 'components/UI/FormComponents';
 import { sanitizeForClassname } from 'utils/JSONFormUtils';
 import { isString } from 'utils/helperUtils';
 import VerificationIcon from '../VerificationIcon';
+import { FormattedMessage } from 'utils/cl-intl';
+import messages from './messages';
 
 export const InputControl = ({
   data,
@@ -36,15 +43,33 @@ export const InputControl = ({
     [schema.type, handleChange, path]
   );
 
+  const FieldLabel = () => {
+    return (
+      <Box display="flex">
+        <Text>{label}</Text>
+        {uischema?.options?.isAdminField && (
+          <IconTooltip
+            iconColor="black"
+            marginLeft="4px"
+            icon="shield-checkered"
+            content={<FormattedMessage {...messages.adminFieldTooltip} />}
+          />
+        )}
+      </Box>
+    );
+  };
+
   return (
     <>
-      <FormLabel
-        htmlFor={sanitizeForClassname(id)}
-        labelValue={label}
-        optional={!required}
-        subtextValue={uischema.options?.description}
-        subtextSupportsHtml
-      />
+      <Box>
+        <FormLabel
+          htmlFor={sanitizeForClassname(id)}
+          labelValue={<FieldLabel />}
+          optional={!required}
+          subtextValue={uischema.options?.description}
+          subtextSupportsHtml
+        />
+      </Box>
       <Box display="flex" flexDirection="row">
         <Input
           data-testid="inputControl"

--- a/front/app/components/Form/Components/Controls/LinearScaleControl.tsx
+++ b/front/app/components/Form/Components/Controls/LinearScaleControl.tsx
@@ -39,11 +39,19 @@ const LinearScaleControl = ({
         gap="16px"
         overflow="visible"
       >
-        <Box pt="28px" alignSelf="center">
-          <Text mr="8px" mt="0" mb="0" color="textSecondary" textAlign="right">
-            {uischema.options?.minimum_label}
-          </Text>
-        </Box>
+        {uischema.options?.minimum_label && (
+          <Box pt="28px" alignSelf="center">
+            <Text
+              mr="8px"
+              mt="0"
+              mb="0"
+              color="textSecondary"
+              textAlign="right"
+            >
+              {uischema.options?.minimum_label}
+            </Text>
+          </Box>
+        )}
         <>
           {[...Array(maximum).keys()].map((i) => {
             const rowId = `${path}-radio-${i}`;

--- a/front/app/components/Form/Components/Controls/UserPickerControl.tsx
+++ b/front/app/components/Form/Components/Controls/UserPickerControl.tsx
@@ -14,7 +14,12 @@ import messages from '../../messages';
 import controlMessages from './messages';
 import { FormLabel } from 'components/UI/FormComponents';
 import { getLabel, sanitizeForClassname } from 'utils/JSONFormUtils';
-import { Box, Text, IconTooltip } from '@citizenlab/cl2-component-library';
+import {
+  Box,
+  Text,
+  colors,
+  IconTooltip,
+} from '@citizenlab/cl2-component-library';
 
 const UserPickerControl = ({
   data,
@@ -33,7 +38,7 @@ const UserPickerControl = ({
         <Text>{getLabel(uischema, schema, path)}</Text>
         {uischema?.options?.isAdminField && (
           <IconTooltip
-            iconColor="black"
+            iconColor={colors.grey800}
             marginLeft="4px"
             icon="shield-checkered"
             content={

--- a/front/app/components/Form/Components/Controls/UserPickerControl.tsx
+++ b/front/app/components/Form/Components/Controls/UserPickerControl.tsx
@@ -6,13 +6,15 @@ import {
   scopeEndsWith,
 } from '@jsonforms/core';
 import React from 'react';
-import { injectIntl } from 'utils/cl-intl';
+import { FormattedMessage, injectIntl } from 'utils/cl-intl';
 import { WrappedComponentProps } from 'react-intl';
 import ErrorDisplay from '../ErrorDisplay';
 import UserSelect from 'components/UI/UserSelect';
 import messages from '../../messages';
+import controlMessages from './messages';
 import { FormLabel } from 'components/UI/FormComponents';
 import { getLabel, sanitizeForClassname } from 'utils/JSONFormUtils';
+import { Box, Text, IconTooltip } from '@citizenlab/cl2-component-library';
 
 const UserPickerControl = ({
   data,
@@ -25,11 +27,29 @@ const UserPickerControl = ({
   schema,
   required,
 }: ControlProps & WrappedComponentProps) => {
+  const FieldLabel = () => {
+    return (
+      <Box display="flex">
+        <Text>{getLabel(uischema, schema, path)}</Text>
+        {uischema?.options?.isAdminField && (
+          <IconTooltip
+            iconColor="black"
+            marginLeft="4px"
+            icon="shield-checkered"
+            content={
+              <FormattedMessage {...controlMessages.adminFieldTooltip} />
+            }
+          />
+        )}
+      </Box>
+    );
+  };
+
   return (
     <>
       <FormLabel
         htmlFor={sanitizeForClassname(id)}
-        labelValue={getLabel(uischema, schema, path)}
+        labelValue={<FieldLabel />}
         optional={!required}
         subtextValue={uischema.options?.description}
         subtextSupportsHtml

--- a/front/app/components/Form/Components/Controls/messages.ts
+++ b/front/app/components/Form/Components/Controls/messages.ts
@@ -5,4 +5,8 @@ export default defineMessages({
     id: 'app.components.form.controls.selectMany',
     defaultMessage: '*Choose as many as you like',
   },
+  adminFieldTooltip: {
+    id: 'app.components.form.controls.adminFieldTooltip',
+    defaultMessage: 'Field only visible to admins',
+  },
 });

--- a/front/app/components/IdeaForm/index.tsx
+++ b/front/app/components/IdeaForm/index.tsx
@@ -746,7 +746,7 @@ class IdeaForm extends PureComponent<
 
       const AdminBudgetFieldLabel = () => {
         return (
-          <>
+          <Box display="flex">
             <FormattedMessage
               {...messages.budgetLabel}
               values={{
@@ -760,7 +760,7 @@ class IdeaForm extends PureComponent<
               icon="shield-checkered"
               content={<FormattedMessage {...messages.adminFieldTooltip} />}
             />
-          </>
+          </Box>
         );
       };
 

--- a/front/app/translations/en.json
+++ b/front/app/translations/en.json
@@ -545,6 +545,7 @@
   "app.components.form.ErrorDisplay.guidelinesLinkText": "our guidelines",
   "app.components.form.ErrorDisplay.userPickerPlaceholder": "Start typing to search by user email or name...",
   "app.components.form.blockedVerified": "You can't edit this field because it contains verified informtion",
+  "app.components.form.controls.adminFieldTooltip": "Field only visible to admins",
   "app.components.form.controls.selectMany": "*Choose as many as you like",
   "app.components.form.error": "Error",
   "app.components.form.locationGoogleUnavailable": "Couldn't load location field provided by google maps.",


### PR DESCRIPTION
See https://citizenlab.atlassian.net/browse/CL-1705

### BE

* Include `isAdminField` in UI schema returned by the `json_forms_schema` endpoint.

### FE

* Uses the new `isAdminField` in UI schema returned by the `json_forms_schema` endpoint to determine if a field should display the "admin only" shield tooltip icon when filling in forms.
* Also reviewed the custom idea form work on the FE, and although there are some areas where Sara has commented that improvements might be needed, for now it seems to work well (other than those bugs we've already identified and logged in our Jira board). Now that we've enabled native surveys/dynamic idea form for e2e tests, this also provides test coverage regarding ideation for custom idea forms, so I think this is fine for now.