### PR TITLE
Fix filter selector icon alignment

### DIFF
--- a/front/app/components/FilterSelector/title.tsx
+++ b/front/app/components/FilterSelector/title.tsx
@@ -27,6 +27,8 @@ const DropdownIcon = styled(Icon)<{ textColor?: string }>`
 const Container = styled.button<{ textColor?: string }>`
   height: 24px;
   cursor: pointer;
+  display: flex;
+  align-items: center;
 
   &.adminpage {
     ${Text} {

--- a/front/app/components/VoteControl/VoteButton.tsx
+++ b/front/app/components/VoteControl/VoteButton.tsx
@@ -53,6 +53,7 @@ const VoteIconContainer = styled.div<{
     return (
       styleType === 'border' &&
       `
+      padding: 8px;
       border: solid 1px ${lighten(0.2, colors.textSecondary)};
       `
     );


### PR DESCRIPTION
The filter selector icon was slightly misaligned.
Slack [discussion](https://citizenlabco.slack.com/archives/C6TQJ27L1/p1666184210569689) for context.