### PR TITLE
Make formatMessage stable reference

### DIFF
--- a/front/app/utils/cl-intl/useIntl.tsx
+++ b/front/app/utils/cl-intl/useIntl.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback } from 'react';
 import {
   // eslint-disable-next-line no-restricted-imports
   useIntl as useOriginalUseIntl,
@@ -13,25 +13,24 @@ const useIntl = () => {
   const localize = useLocalize();
   const appConfig = useAppConfiguration();
 
-  const formatMessageReplacement = useMemo(
-    () =>
-      (
-        messageDescriptor: MessageDescriptor,
-        values?: { [key: string]: string | number | boolean | Date } | undefined
-      ) => {
-        return intl.formatMessage(messageDescriptor, {
-          tenantName: !isNilOrError(appConfig)
-            ? appConfig.attributes.name
-            : undefined,
-          orgName: !isNilOrError(appConfig)
-            ? localize(appConfig.attributes.settings.core.organization_name)
-            : undefined,
-          orgType: !isNilOrError(appConfig)
-            ? appConfig.attributes.settings.core.organization_type
-            : undefined,
-          ...(values || {}),
-        });
-      },
+  const formatMessageReplacement = useCallback(
+    (
+      messageDescriptor: MessageDescriptor,
+      values?: { [key: string]: string | number | boolean | Date } | undefined
+    ) => {
+      return intl.formatMessage(messageDescriptor, {
+        tenantName: !isNilOrError(appConfig)
+          ? appConfig.attributes.name
+          : undefined,
+        orgName: !isNilOrError(appConfig)
+          ? localize(appConfig.attributes.settings.core.organization_name)
+          : undefined,
+        orgType: !isNilOrError(appConfig)
+          ? appConfig.attributes.settings.core.organization_type
+          : undefined,
+        ...(values || {}),
+      });
+    },
     [intl, localize, appConfig]
   );
 

--- a/front/app/utils/cl-intl/useIntl.tsx
+++ b/front/app/utils/cl-intl/useIntl.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import {
   // eslint-disable-next-line no-restricted-imports
   useIntl as useOriginalUseIntl,
@@ -12,23 +13,27 @@ const useIntl = () => {
   const localize = useLocalize();
   const appConfig = useAppConfiguration();
 
-  const formatMessageReplacement = (
-    messageDescriptor: MessageDescriptor,
-    values?: { [key: string]: string | number | boolean | Date } | undefined
-  ) => {
-    return intl.formatMessage(messageDescriptor, {
-      tenantName: !isNilOrError(appConfig)
-        ? appConfig.attributes.name
-        : undefined,
-      orgName: !isNilOrError(appConfig)
-        ? localize(appConfig.attributes.settings.core.organization_name)
-        : undefined,
-      orgType: !isNilOrError(appConfig)
-        ? appConfig.attributes.settings.core.organization_type
-        : undefined,
-      ...(values || {}),
-    });
-  };
+  const formatMessageReplacement = useMemo(
+    () =>
+      (
+        messageDescriptor: MessageDescriptor,
+        values?: { [key: string]: string | number | boolean | Date } | undefined
+      ) => {
+        return intl.formatMessage(messageDescriptor, {
+          tenantName: !isNilOrError(appConfig)
+            ? appConfig.attributes.name
+            : undefined,
+          orgName: !isNilOrError(appConfig)
+            ? localize(appConfig.attributes.settings.core.organization_name)
+            : undefined,
+          orgType: !isNilOrError(appConfig)
+            ? appConfig.attributes.settings.core.organization_type
+            : undefined,
+          ...(values || {}),
+        });
+      },
+    [intl, localize, appConfig]
+  );
 
   return { ...intl, formatMessage: formatMessageReplacement };
 };


### PR DESCRIPTION
If you use `const { formatMessage } = useIntl()` in a hook, and use `formatMessage` inside of `useEffect`, you need to provide it as a dependency. This currently creates an infinite loop, as the reference to `formatMessage` is not stable. This solves that