### PR TITLE
[CL-1793] Flexible pages r2 e2e test fixes

### DIFF
--- a/front/app/containers/CustomPageShow/index.tsx
+++ b/front/app/containers/CustomPageShow/index.tsx
@@ -77,7 +77,7 @@ const CustomPageShow = () => {
     appConfiguration.attributes.settings.core.organization_name
   );
   return (
-    <Container className={`e2e-custom-page`}>
+    <Container className={`e2e-page-${slug}`}>
       <Helmet
         title={`${localize(
           pageAttributes.title_multiloc

--- a/front/cypress.config.ts
+++ b/front/cypress.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
-  viewportWidth: 1201,
+  viewportWidth: 1400,
   viewportHeight: 800,
   video: false,
   videoUploadOnPasses: false,

--- a/front/cypress/e2e/admin/pages_and_menu/create_update_and_view_custom_page.cy.ts
+++ b/front/cypress/e2e/admin/pages_and_menu/create_update_and_view_custom_page.cy.ts
@@ -145,8 +145,9 @@ describe('Admin: create, update, and view custom page', () => {
     // go to attachments section edit page
     cy.get('[data-cy="e2e-admin-edit-button-files_section_enabled"]').click();
 
-    // drop an example pdf file
+    // drop an example pdf file and wait for it to be uploaded
     cy.get('#local_page_files').selectFile('cypress/fixtures/example.pdf');
+    cy.contains('example.pdf');
 
     // submit
     cy.get('[data-cy="e2e-attachments-section-submit"]').click();

--- a/front/cypress/e2e/admin/pages_and_menu/update_hero_banner_content.cy.ts
+++ b/front/cypress/e2e/admin/pages_and_menu/update_hero_banner_content.cy.ts
@@ -113,6 +113,11 @@ describe('Admin: update Hero Banner content', () => {
     // click two-column banner layout
     cy.get('[data-cy="e2e-two-column-layout-option"]').click();
 
+    // focus the header dropzone and drop an image onto it
+    cy.get('#header-dropzone').attachFile('icon.png', {
+      subjectType: 'drag-n-drop',
+    });
+
     // fill in header and subheader
     cy.get('[data-cy="e2e-signed-out-header-section"]')
       .find('input')

--- a/front/cypress/e2e/admin/pages_and_menu/update_homepage_hero_banner_content.cy.ts
+++ b/front/cypress/e2e/admin/pages_and_menu/update_homepage_hero_banner_content.cy.ts
@@ -148,7 +148,7 @@ describe('Admin: update Hero Banner content', () => {
     cy.wait('@saveHomePage');
     cy.get('.e2e-submit-wrapper-button').contains('Success');
 
-    // log out, view page as verified user
+    // view page as verified user
     cy.goToLandingPage();
 
     // check content and url for signed in CTA button
@@ -164,9 +164,8 @@ describe('Admin: update Hero Banner content', () => {
     cy.goToLandingPage();
     cy.reload();
 
-    cy.get('[data-cy=e2e-two-column-layout-container]').should('exist');
-
     // check that the content we saved earlier is shown here
+    cy.get('[data-cy=e2e-two-column-layout-container]').should('exist');
     cy.get('#hook-header-content').should(
       'contain',
       updatedSignedOutHeaderEnglish

--- a/front/cypress/e2e/admin/pages_and_menu/update_homepage_hero_banner_content.cy.ts
+++ b/front/cypress/e2e/admin/pages_and_menu/update_homepage_hero_banner_content.cy.ts
@@ -14,6 +14,12 @@ describe('Admin: update Hero Banner content', () => {
   const updatedSignedInCTAButton = 'signedin button!';
   const updatedSignedInCTAURL = 'https://www.example.biz';
 
+  // for a fake verified user
+  const verifiedFirstName = randomString();
+  const verifiedLastName = randomString();
+  const verifiedEmail = randomEmail();
+  const verifiedPassword = randomString();
+
   const defaultHomepageSettings = {
     top_info_section_enabled: false,
     bottom_info_section_enabled: false,
@@ -36,6 +42,21 @@ describe('Admin: update Hero Banner content', () => {
     header_bg:
       'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVQYV2NgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII=',
   };
+
+  before(() => {
+    // create and verify a fake user
+    cy.apiSignup(
+      verifiedFirstName,
+      verifiedLastName,
+      verifiedEmail,
+      verifiedPassword
+    ).then(() => {
+      cy.apiLogin(verifiedEmail, verifiedPassword).then((response) => {
+        // verify the fake user
+        cy.apiVerifyBogus(response.body.jwt);
+      });
+    });
+  });
 
   beforeEach(() => {
     // set default homepage settings
@@ -148,8 +169,18 @@ describe('Admin: update Hero Banner content', () => {
     cy.wait('@saveHomePage');
     cy.get('.e2e-submit-wrapper-button').contains('Success');
 
+    // logout of admin@citizenlab account
+    cy.logout();
+
+    // login as fake verified user
+    cy.setLoginCookie(verifiedEmail, verifiedPassword);
+
     // view page as verified user
     cy.goToLandingPage();
+    cy.reload();
+
+    // click button to remove "complete your profile" banner
+    cy.get('.e2e-signed-in-header-complete-skip-btn').find('button').click();
 
     // check content and url for signed in CTA button
     cy.get('[data-cy="e2e-cta-banner-button"]')

--- a/front/cypress/e2e/admin/pages_and_menu/update_homepage_text_content_and_sections.cy.ts
+++ b/front/cypress/e2e/admin/pages_and_menu/update_homepage_text_content_and_sections.cy.ts
@@ -1,16 +1,21 @@
 import { randomString } from '../../../support/commands';
 
-describe('Admin: update HomePage content', () => {
+describe('Admin: update text content and sections', () => {
   before(() => {
     cy.apiUpdateHomepageSettings({
       top_info_section_enabled: false,
       bottom_info_section_enabled: false,
       events_widget_enabled: false,
     });
+    cy.setLoginCookie('admin@citizenlab.co', 'democracy2.0');
   });
 
-  beforeEach(() => {
-    cy.setLoginCookie('admin@citizenlab.co', 'democracy2.0');
+  after(() => {
+    cy.apiUpdateHomepageSettings({
+      top_info_section_enabled: false,
+      bottom_info_section_enabled: false,
+      events_widget_enabled: false,
+    });
   });
 
   it('updates top and bottom info section content and visibility', () => {
@@ -125,13 +130,5 @@ describe('Admin: update HomePage content', () => {
     cy.contains(topInfoContent);
     cy.contains(bottomInfoContent);
     cy.get('[data-testid="e2e-events-widget-container"]').should('exist');
-  });
-
-  after(() => {
-    cy.apiUpdateHomepageSettings({
-      top_info_section_enabled: false,
-      bottom_info_section_enabled: false,
-      events_widget_enabled: false,
-    });
   });
 });

--- a/front/cypress/e2e/profile_edition.cy.ts
+++ b/front/cypress/e2e/profile_edition.cy.ts
@@ -19,7 +19,7 @@ describe('profile edition', () => {
   });
   it('lets user edit their profile', () => {
     cy.intercept(`**/users/${userId}`).as('saveUser');
-    cy.get('input[type="file"]').attachFile('cypress/fixtures/icon.png');
+    cy.get('input[type="file"]').attachFile('icon.png');
     cy.get('#first_name').clear().type('Jane');
     cy.get('#last_name').clear().type('Doe');
     const newEmail = randomEmail();

--- a/front/cypress/support/commands.ts
+++ b/front/cypress/support/commands.ts
@@ -1178,6 +1178,7 @@ export function apiUpdateHomepageSettings({
   banner_signed_out_header_overlay_opacity,
   banner_cta_signed_out_type,
   banner_cta_signed_in_type,
+  header_bg,
 }: {
   top_info_section_enabled?: boolean;
   bottom_info_section_enabled?: boolean;
@@ -1192,6 +1193,7 @@ export function apiUpdateHomepageSettings({
   banner_signed_out_header_overlay_opacity?: number;
   banner_cta_signed_out_type?: string;
   banner_cta_signed_in_type?: string;
+  header_bg?: string;
 }) {
   return cy.apiLogin('admin@citizenlab.co', 'democracy2.0').then((response) => {
     const adminJwt = response.body.jwt;
@@ -1218,6 +1220,7 @@ export function apiUpdateHomepageSettings({
           banner_signed_out_header_overlay_opacity,
           banner_cta_signed_in_type,
           banner_cta_signed_out_type,
+          header_bg,
         },
       },
     });

--- a/front/cypress/support/commands.ts
+++ b/front/cypress/support/commands.ts
@@ -40,6 +40,7 @@ declare global {
       apiCreateFolder: typeof apiCreateFolder;
       apiRemoveFolder: typeof apiRemoveFolder;
       apiRemoveProject: typeof apiRemoveProject;
+      apiRemoveCustomPage: typeof apiRemoveCustomPage;
       apiAddProjectsToFolder: typeof apiAddProjectsToFolder;
       apiCreatePhase: typeof apiCreatePhase;
       apiCreateCustomField: typeof apiCreateCustomField;
@@ -946,6 +947,21 @@ export function apiRemoveFolder(folderId: string) {
   });
 }
 
+export function apiRemoveCustomPage(customPageId: string) {
+  return cy.apiLogin('admin@citizenlab.co', 'democracy2.0').then((response) => {
+    const adminJwt = response.body.jwt;
+
+    return cy.request({
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${adminJwt}`,
+      },
+      method: 'DELETE',
+      url: `web_api/v1/static_pages/${customPageId}`,
+    });
+  });
+}
+
 export function apiAddPoll(
   type: 'Project' | 'Phase',
   id: string,
@@ -1333,3 +1349,4 @@ Cypress.Commands.add(
   notIntersectsViewport
 );
 Cypress.Commands.add('apiUpdateHomepageSettings', apiUpdateHomepageSettings);
+Cypress.Commands.add('apiRemoveCustomPage', apiRemoveCustomPage);


### PR DESCRIPTION
All tests that failed on this run (https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab-ee/19743/workflows/4e24c913-0a10-4be9-bddc-a9377b6b00c8/jobs/72906/steps) are working for me locally. Will still need to merge and test on the CI to be sure, but I think I've addressed all the issues

Fixes:

* Some selectors broke in other tests, I've fixed those
* The homepage hero banner tests were passing locally, but had probably failed the first time and I didn't notice. Basically, the form can only be submitted if an image is present, and you can't delete the image via a backend call, so the test can either be designed for the CI (starting from a clean slate, with no image) or for local re-runs (adapts to an existing image, since once it's added, it can't be removed). I opted to add an image as part of the payload in the `before` block, so the test always assumes one's there. The full functionality of the hero banner form is tested for custom pages, since a new page is created for each test it doesn't have the same issue.
* For the hero banner test, I moved the 3rd and 4th tests into the 2nd test block, since we want to check on the changes made in the test. This is more accurate, as tests should be independent, and having the 3rd test check for changes made in the 2nd could be flaky.