### PR TITLE
[no ticket] Fix navbar item bug on flexi pages r2

### DIFF
--- a/back/engines/free/customizable_navbar/app/controllers/customizable_navbar/web_api/v1/patches/static_pages_controller.rb
+++ b/back/engines/free/customizable_navbar/app/controllers/customizable_navbar/web_api/v1/patches/static_pages_controller.rb
@@ -11,7 +11,8 @@ module CustomizableNavbar
           # `attribute :nav_bar_item_title_multiloc`
           def assign_attributes
             attributes = permitted_attributes(StaticPage).to_h
-            if (nav_bar_item_title = attributes.delete(:nav_bar_item_title_multiloc)).present?
+            nav_bar_item_title = attributes.delete(:nav_bar_item_title_multiloc)
+            if nav_bar_item_title.present? && @page.nav_bar_item_id.present?
               attributes[:nav_bar_item_attributes] ||= {}
               attributes[:nav_bar_item_attributes][:id] = @page.nav_bar_item_id
               attributes[:nav_bar_item_attributes][:title_multiloc] = nav_bar_item_title

--- a/back/engines/free/customizable_navbar/spec/acceptance/static_pages_spec.rb
+++ b/back/engines/free/customizable_navbar/spec/acceptance/static_pages_spec.rb
@@ -25,7 +25,7 @@ resource 'StaticPages' do
       ValidationErrorHelper.new.error_fields self, StaticPage
       ValidationErrorHelper.new.error_fields self, NavBarItem
 
-      example 'Create a static page with NavBarItem' do
+      example 'Does not create a NavBarItem' do
         page = build :static_page
         item_title_multiloc = { 'en' => 'Awesome item' }
 
@@ -38,7 +38,7 @@ resource 'StaticPages' do
         )
         expect(response_status).to eq 201
         json_response = json_parse response_body
-        expect(StaticPage.find(json_response.dig(:data, :id)).nav_bar_item&.title_multiloc).to match item_title_multiloc
+        expect(StaticPage.find(json_response.dig(:data, :id)).nav_bar_item).to be_nil
       end
     end
 

--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/Settings/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/Settings/index.tsx
@@ -5,26 +5,39 @@ import { useParams } from 'react-router-dom';
 import { isNilOrError } from 'utils/helperUtils';
 import { updateCustomPage } from 'services/customPages';
 import { FormValues } from 'containers/Admin/pagesAndMenu/containers/CustomPages/CustomPageSettingsForm';
+import streams from 'utils/streams';
+import { apiEndpoint as navbarItemsEndpoint } from 'services/navbar';
 
 const EditCustomPageSettings = () => {
   const { customPageId } = useParams() as { customPageId: string };
   const customPage = useCustomPage({ customPageId });
 
-  const handleOnSubmit = async (formValues: FormValues) => {
-    await updateCustomPage(customPageId, formValues);
-  };
-
   if (!isNilOrError(customPage)) {
+    const hasNavbarItem = !!customPage.relationships.nav_bar_item.data?.id;
+
+    const handleOnSubmit = async (formValues: FormValues) => {
+      await updateCustomPage(customPageId, formValues);
+      // navbar items are a separate stream, so manually refresh on title update
+      // to reflect changes in the user's navbar
+      if (hasNavbarItem) {
+        streams.fetchAllWith({
+          apiEndpoint: [navbarItemsEndpoint],
+        });
+      }
+    };
+
     return (
       <CustomPageSettingsForm
         mode="edit"
         defaultValues={{
           title_multiloc: customPage.attributes.title_multiloc,
-          nav_bar_item_title_multiloc:
-            customPage.attributes.nav_bar_item_title_multiloc,
+          ...(hasNavbarItem && {
+            nav_bar_item_title_multiloc:
+              customPage.attributes.nav_bar_item_title_multiloc,
+          }),
           slug: customPage.attributes.slug,
         }}
-        showNavBarItemTitle={!!customPage.relationships.nav_bar_item.data?.id}
+        showNavBarItemTitle={hasNavbarItem}
         onSubmit={handleOnSubmit}
       />
     );


### PR DESCRIPTION
FE validation that only shows/sends the navbar item title for a custom page if the page is in the navbar, and a backend change that makes it so changing the navbar item title of the custom page doesn't enable the page. Seems to be fixed in @alexander-cit and my testing