### PR TITLE
CL-1907: Allow creation of projects from templates in a folder fe

### DIFF
--- a/front/app/modules/commercial/admin_project_templates/admin/components/UseTemplateModal.tsx
+++ b/front/app/modules/commercial/admin_project_templates/admin/components/UseTemplateModal.tsx
@@ -17,9 +17,13 @@ import { client } from '../../utils/apolloUtils';
 // hooks
 import useAppConfigurationLocales from 'hooks/useAppConfigurationLocales';
 import useGraphqlTenantLocales from 'hooks/useGraphqlTenantLocales';
+import useAuthUser from 'hooks/useAuthUser';
+import { useProjectFolders } from 'modules/commercial/project_folders/hooks';
+import { userModeratesFolder } from 'modules/commercial/project_folders/permissions/roles';
+import useLocalize from 'hooks/useLocalize';
 
 // components
-import { Input, Icon } from '@citizenlab/cl2-component-library';
+import { Input, Icon, Select, Box } from '@citizenlab/cl2-component-library';
 import Button from 'components/UI/Button';
 import InputMultilocWithLocaleSwitcher from 'components/UI/InputMultilocWithLocaleSwitcher';
 import Modal from 'components/UI/Modal';
@@ -42,19 +46,13 @@ import { colors, fontSizes } from 'utils/styleUtils';
 import { darken } from 'polished';
 
 // typings
-import { Locale, Multiloc } from 'typings';
+import { Locale, Multiloc, IOption } from 'typings';
 
 const Content = styled.div`
   padding-left: 30px;
   padding-right: 30px;
   padding-top: 35px;
   padding-bottom: 50px;
-`;
-
-const StyledInputMultilocWithLocaleSwitcher = styled(
-  InputMultilocWithLocaleSwitcher
-)`
-  margin-bottom: 35px;
 `;
 
 const Success = styled.div`
@@ -119,6 +117,7 @@ interface IVariables {
   projectTemplateId: string | undefined;
   titleMultiloc: Multiloc;
   timelineStartAt: string;
+  folderId: string | null;
 }
 
 const UseTemplateModal = memo<Props & WithRouterProps & WrappedComponentProps>(
@@ -136,9 +135,13 @@ const UseTemplateModal = memo<Props & WithRouterProps & WrappedComponentProps>(
 
     const tenantLocales = useAppConfigurationLocales();
     const graphqlTenantLocales = useGraphqlTenantLocales();
+    const { projectFolders } = useProjectFolders({});
+    const authUser = useAuthUser();
+    const localize = useLocalize();
 
     const [titleMultiloc, setTitleMultiloc] = useState<Multiloc | null>(null);
     const [startDate, setStartDate] = useState<string | null>(null);
+    const [folderId, setFolderId] = useState<string | null>(null);
     const [selectedLocale, setSelectedLocale] = useState<Locale | null>(null);
     const [titleError, setTitleError] = useState<string | null>(null);
     const [startDateError, setStartDateError] = useState<string | null>(null);
@@ -161,11 +164,13 @@ const UseTemplateModal = memo<Props & WithRouterProps & WrappedComponentProps>(
         $projectTemplateId: ID!
         $titleMultiloc: MultilocAttributes!
         $timelineStartAt: String
+        $folderId: String
       ) {
         applyProjectTemplate(
           projectTemplateId: $projectTemplateId
           titleMultiloc: $titleMultiloc
           timelineStartAt: $timelineStartAt
+          folderId: $folderId
         ) {
           errors
         }
@@ -230,6 +235,7 @@ const UseTemplateModal = memo<Props & WithRouterProps & WrappedComponentProps>(
               ),
               projectTemplateId: templateId,
               timelineStartAt: startDate,
+              folderId,
             },
           });
           await streams.fetchAllWith({
@@ -282,9 +288,34 @@ const UseTemplateModal = memo<Props & WithRouterProps & WrappedComponentProps>(
       setResponseError(null);
     }, [opened]);
 
+    if (isNilOrError(authUser)) {
+      return null;
+    }
+
     const templateTitle = (
       <T value={get(data, 'projectTemplate.titleMultiloc')} />
     );
+
+    const folderOptions: IOption[] = !isNilOrError(projectFolders)
+      ? [
+          {
+            value: '',
+            label: '',
+          },
+          ...projectFolders
+            .filter((folder) => userModeratesFolder(authUser, folder.id))
+            .map((folder) => {
+              return {
+                value: folder.id,
+                label: localize(folder.attributes.title_multiloc),
+              };
+            }),
+        ]
+      : [];
+
+    const handleSelectFolderChange = ({ value: folderId }) => {
+      setFolderId(folderId);
+    };
 
     return (
       <Modal
@@ -329,7 +360,7 @@ const UseTemplateModal = memo<Props & WithRouterProps & WrappedComponentProps>(
         <Content>
           {!success ? (
             <>
-              <StyledInputMultilocWithLocaleSwitcher
+              <InputMultilocWithLocaleSwitcher
                 id="project-title"
                 label={intl.formatMessage(messages.projectTitle)}
                 placeholder={intl.formatMessage(messages.typeProjectName)}
@@ -340,15 +371,22 @@ const UseTemplateModal = memo<Props & WithRouterProps & WrappedComponentProps>(
                 error={titleError}
                 autoFocus={true}
               />
-
-              <Input
-                id="project-start-date"
-                label={intl.formatMessage(messages.projectStartDate)}
-                type="date"
-                onChange={onStartDateChange}
-                value={startDate}
-                error={startDateError}
-                placeholder={bowser.msie ? 'YYYY-MM-DD' : undefined}
+              <Box my="36px">
+                <Input
+                  id="project-start-date"
+                  label={intl.formatMessage(messages.projectStartDate)}
+                  type="date"
+                  onChange={onStartDateChange}
+                  value={startDate}
+                  error={startDateError}
+                  placeholder={bowser.msie ? 'YYYY-MM-DD' : undefined}
+                />
+              </Box>
+              <Select
+                value={folderId}
+                label={intl.formatMessage(messages.projectFolder)}
+                options={folderOptions}
+                onChange={handleSelectFolderChange}
               />
             </>
           ) : (

--- a/front/app/modules/commercial/admin_project_templates/admin/components/messages.ts
+++ b/front/app/modules/commercial/admin_project_templates/admin/components/messages.ts
@@ -49,6 +49,10 @@ export default defineMessages({
     id: 'app.components.ProjectTemplatePreview.projectStartDate',
     defaultMessage: 'The start date of your project',
   },
+  projectFolder: {
+    id: 'app.components.ProjectTemplatePreview.projectFolder',
+    defaultMessage: 'Project folder',
+  },
   projectTitleError: {
     id: 'app.components.ProjectTemplatePreview.projectTitleError',
     defaultMessage: 'Please type a project title',

--- a/front/app/translations/admin/en.json
+++ b/front/app/translations/admin/en.json
@@ -21,6 +21,7 @@
   "app.components.ProjectTemplatePreview.goBackTo": "Go back to the {goBackLink}.",
   "app.components.ProjectTemplatePreview.infoboxLine1": "Want to use this template for your participation project?",
   "app.components.ProjectTemplatePreview.infoboxLine2": "Reach out to the responsible person in your city administration, or contact a {link}.",
+  "app.components.ProjectTemplatePreview.projectFolder": "Project folder",
   "app.components.ProjectTemplatePreview.projectInvalidStartDateError": "The selected date is invalid. Please provide a date in the following format: YYYY-MM-DD",
   "app.components.ProjectTemplatePreview.projectNoStartDateError": "Please select a start date for the project",
   "app.components.ProjectTemplatePreview.projectStartDate": "The start date of your project",


### PR DESCRIPTION
## Checklist

This PR adds the folder to the template modal used when creating a project from a template

Please note that we don't have e2e tests here because this requires the app to work with the admin templates [repo](https://github.com/CitizenLabDotCo/cl2-admin-templates). This also only contains the FE work for this

## Screenshots
![image](https://user-images.githubusercontent.com/12659000/197742791-f159dbf1-0c1e-46cc-b5de-57ef28790080.png)


## How urgent is a code review?

End of tomorrow if possible
