### PR TITLE
[Flexible pages r2] Assorted styling and layout fixes

### DIFF
--- a/front/app/containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/LayoutSettingField/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/LayoutSettingField/index.tsx
@@ -63,7 +63,8 @@ const LayoutSettingField = ({ bannerLayout, onChange }: Props) => {
       <SubSectionTitle>
         <FormattedMessage {...messages.chooseLayout} />
       </SubSectionTitle>
-      <Box display="flex">
+      {/* minwidth to allow longer i18n strings to fit on one line */}
+      <Box display="flex" minWidth="750px">
         <LayoutOption>
           <LayoutOptionTop>
             <Radio

--- a/front/app/containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/LayoutSettingField/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/LayoutSettingField/index.tsx
@@ -63,8 +63,7 @@ const LayoutSettingField = ({ bannerLayout, onChange }: Props) => {
       <SubSectionTitle>
         <FormattedMessage {...messages.chooseLayout} />
       </SubSectionTitle>
-      {/* minwidth to allow longer i18n strings to fit on one line */}
-      <Box display="flex" minWidth="750px">
+      <Box display="flex">
         <LayoutOption>
           <LayoutOptionTop>
             <Radio

--- a/front/app/containers/Admin/pagesAndMenu/containers/NavigationSettings/NavbarItemRow/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/NavigationSettings/NavbarItemRow/index.tsx
@@ -133,6 +133,8 @@ const NavbarItemRow = ({
 
         {showAddButton && (
           <Button
+            // no icon on add and remove buttons, so specify height to match the others
+            height="44px"
             buttonStyle="secondary"
             onClick={handleOnClickAddButton}
             disabled={addButtonDisabled}
@@ -144,6 +146,7 @@ const NavbarItemRow = ({
 
         {showRemoveButton && (
           <Button
+            height="44px"
             buttonStyle="secondary"
             onClick={handleOnClickRemoveButton}
             ml="10px"

--- a/front/app/containers/CustomPageShow/CustomPageHeader/TwoColumnLayout.tsx
+++ b/front/app/containers/CustomPageShow/CustomPageHeader/TwoColumnLayout.tsx
@@ -27,6 +27,7 @@ const TwoColumnLayout = ({ pageData }: Props) => {
         />
       )}
       <HeaderContent
+        align="left"
         fontColors="dark"
         hasHeaderBannerImage={imageUrl != null}
         pageAttributes={pageAttributes}

--- a/front/app/containers/CustomPageShow/index.tsx
+++ b/front/app/containers/CustomPageShow/index.tsx
@@ -8,6 +8,7 @@ import { Container, Content } from 'components/LandingPages/citizen';
 import { Helmet } from 'react-helmet';
 import CustomPageHeader from './CustomPageHeader';
 import TopInfoSection from './TopInfoSection';
+import AdminCustomPageEditButton from './CustomPageHeader/AdminCustomPageEditButton';
 
 // hooks
 import useAppConfiguration from 'hooks/useAppConfiguration';
@@ -49,6 +50,7 @@ const AttachmentsContainer = styled.div`
   max-width: calc(${(props) => props.theme.maxPageWidth}px - 100px);
   margin-left: auto;
   margin-right: auto;
+  margin-bottom: 30px;
   padding-left: 20px;
   padding-right: 20px;
 `;
@@ -83,7 +85,11 @@ const CustomPageShow = () => {
           pageAttributes.title_multiloc
         )} | ${localizedOrgName}`}
       />
-      {pageAttributes.banner_enabled && <CustomPageHeader pageData={page} />}
+      {pageAttributes.banner_enabled ? (
+        <CustomPageHeader pageData={page} />
+      ) : (
+        <AdminCustomPageEditButton pageId={page.id} />
+      )}
       <Content>
         <Fragment
           name={!isNilOrError(page) ? `pages/${page && page.id}/content` : ''}

--- a/front/app/containers/CustomPageShow/index.tsx
+++ b/front/app/containers/CustomPageShow/index.tsx
@@ -10,6 +10,7 @@ import CustomPageHeader from './CustomPageHeader';
 import TopInfoSection from './TopInfoSection';
 import AdminCustomPageEditButton from './CustomPageHeader/AdminCustomPageEditButton';
 import PageNotFound from './PageNotFound';
+import { Box } from '@citizenlab/cl2-component-library';
 
 // hooks
 import useAppConfiguration from 'hooks/useAppConfiguration';
@@ -93,7 +94,9 @@ const CustomPageShow = () => {
       {pageAttributes.banner_enabled ? (
         <CustomPageHeader pageData={page} />
       ) : (
-        <AdminCustomPageEditButton pageId={page.id} />
+        <Box zIndex="9999">
+          <AdminCustomPageEditButton pageId={page.id} />
+        </Box>
       )}
       <Content>
         <Fragment

--- a/front/app/containers/CustomPageShow/index.tsx
+++ b/front/app/containers/CustomPageShow/index.tsx
@@ -48,13 +48,8 @@ const PageTitle = styled.h1`
   `}
 `;
 
-const AttachmentsContainer = styled.div`
-  max-width: calc(${(props) => props.theme.maxPageWidth}px - 100px);
-  margin-left: auto;
-  margin-right: auto;
+const AttachmentsContainer = styled(ContentContainer)`
   margin-bottom: 30px;
-  padding-left: 20px;
-  padding-right: 20px;
 `;
 
 const CustomPageShow = () => {


### PR DESCRIPTION
edit page button without and with hero banner:
![Screen Shot 2022-10-25 at 12 43 44](https://user-images.githubusercontent.com/3614128/197754265-560c53ad-8a4b-45aa-943d-f07c4bd50b22.png)
![Screen Shot 2022-10-25 at 12 43 50](https://user-images.githubusercontent.com/3614128/197754271-43c919a7-7221-4b21-84c9-71b3e34b94b8.png)

bottom of a custom page without and with attachments section:

![Screen Shot 2022-10-25 at 12 47 04](https://user-images.githubusercontent.com/3614128/197754281-c08e75ed-c033-4c4a-a296-33e370beeb60.png)
![Screen Shot 2022-10-25 at 12 47 30](https://user-images.githubusercontent.com/3614128/197754283-8703f7be-6050-4374-9ec1-44d69e32f466.png)
