### PR TITLE
[CL-1800] Toggle password login and signup individually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next release
 
+### Added
+
+- [CL-1800] It is now possible to disable email + password registration while logins are still allowed for existing users.
+
 ## 2022-10-27
 
 ### Added

--- a/back/app/policies/user_policy.rb
+++ b/back/app/policies/user_policy.rb
@@ -35,7 +35,8 @@ class UserPolicy < ApplicationPolicy
   end
 
   def create?
-    true
+    app_config = AppConfiguration.instance
+    (app_config.feature_activated?('password_login') && app_config.settings('password_login', 'enable_signup')) || (user&.active? && user&.admin?)
   end
 
   def show?

--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -208,10 +208,16 @@
         "description": "Allow users to register with an email and password.",
         "additionalProperties": false,
         "required": ["allowed", "enabled"],
-        "required-settings": ["minimum_length", "phone"],
+        "required-settings": ["minimum_length", "phone", "enable_signup"],
         "properties": {
           "allowed": { "type": "boolean", "default": true},
           "enabled": { "type": "boolean", "default": true},
+          "enable_signup": {
+            "type": "boolean",
+            "title": "Enable sign-up",
+            "description": "If unchecked, only login via password is allowed for existing users; sign-up via password is disabled for new users.",
+            "default": true
+          },
           "minimum_length": {
             "type": "number",
             "title": "Minimum password length",

--- a/back/db/seeds/citizenlab.rb
+++ b/back/db/seeds/citizenlab.rb
@@ -30,6 +30,7 @@ AppConfiguration.create!(
     password_login: {
       enabled: true,
       allowed: true,
+      enable_signup: true,
       phone: false,
       minimum_length: 8
     },

--- a/back/engines/commercial/project_folders/spec/policies/user_policy_spec.rb
+++ b/back/engines/commercial/project_folders/spec/policies/user_policy_spec.rb
@@ -18,7 +18,6 @@ describe UserPolicy do
       let(:subject_user) { current_user }
 
       it { is_expected.to     permit(:show)    }
-      it { is_expected.to     permit(:create)  }
       it { is_expected.to     permit(:update)  }
       it { is_expected.to     permit(:destroy) }
       it { is_expected.to     permit(:index) }
@@ -34,7 +33,6 @@ describe UserPolicy do
       let(:subject_user) { create :user }
 
       it { is_expected.to     permit(:show)    }
-      it { is_expected.to     permit(:create)  }
       it { is_expected.not_to permit(:update)  }
       it { is_expected.not_to permit(:destroy) }
       it { is_expected.to     permit(:index) }

--- a/back/engines/commercial/project_management/spec/policies/user_policy_spec.rb
+++ b/back/engines/commercial/project_management/spec/policies/user_policy_spec.rb
@@ -16,7 +16,6 @@ describe UserPolicy do
       let(:subject_user) { current_user }
 
       it { is_expected.to     permit(:show)    }
-      it { is_expected.to     permit(:create)  }
       it { is_expected.to     permit(:update)  }
       it { is_expected.to     permit(:destroy) }
       it { is_expected.to     permit(:index) }
@@ -32,7 +31,6 @@ describe UserPolicy do
       let(:subject_user) { create :user }
 
       it { is_expected.to     permit(:show)    }
-      it { is_expected.to     permit(:create)  }
       it { is_expected.not_to permit(:update)  }
       it { is_expected.not_to permit(:destroy) }
       it { is_expected.to     permit(:index) }

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -88,6 +88,7 @@ resource 'Users' do
           settings['password_login'] = {
             'allowed' => true,
             'enabled' => true,
+            'enable_signup' => true,
             'phone' => true,
             'phone_email_pattern' => 'phone+__PHONE__@test.com',
             'minimum_length' => 6
@@ -122,6 +123,19 @@ resource 'Users' do
     end
 
     post 'web_api/v1/users' do
+      before do
+        settings = AppConfiguration.instance.settings
+        settings['password_login'] = {
+          'allowed' => true,
+          'enabled' => true,
+          'enable_signup' => true,
+          'phone' => true,
+          'phone_email_pattern' => 'phone+__PHONE__@test.com',
+          'minimum_length' => 6
+        }
+        AppConfiguration.instance.update!(settings: settings)
+      end
+
       with_options scope: 'user' do
         parameter :first_name, 'User full name', required: true
         parameter :last_name, 'User full name', required: true
@@ -170,6 +184,18 @@ resource 'Users' do
       end
 
       describe 'Creating an admin user' do
+        before do
+          settings = AppConfiguration.instance.settings
+          settings['password_login'] = {
+            'enabled' => true,
+            'allowed' => true,
+            'enable_signup' => true,
+            'minimum_length' => 5,
+            'phone' => false
+          }
+          AppConfiguration.instance.update! settings: settings
+        end
+
         let(:roles) { [{ type: 'admin' }] }
 
         example 'creates a user, but not an admin', document: false do
@@ -187,6 +213,7 @@ resource 'Users' do
           settings['password_login'] = {
             'enabled' => true,
             'allowed' => true,
+            'enable_signup' => true,
             'minimum_length' => 5,
             'phone' => false
           }
@@ -236,6 +263,7 @@ resource 'Users' do
           settings['password_login'] = {
             'allowed' => true,
             'enabled' => true,
+            'enable_signup' => true,
             'phone' => true,
             'phone_email_pattern' => 'phone+__PHONE__@test.com',
             'minimum_length' => 6

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -103,6 +103,7 @@ RSpec.describe User, type: :model do
       settings['password_login'] = {
         'enabled' => true,
         'allowed' => true,
+        'enable_signup' => true,
         'minimum_length' => 5,
         'phone' => false
       }
@@ -117,6 +118,7 @@ RSpec.describe User, type: :model do
       settings['password_login'] = {
         'enabled' => true,
         'allowed' => true,
+        'enable_signup' => true,
         'minimum_length' => 5,
         'phone' => false
       }

--- a/back/spec/policies/user_policy_spec.rb
+++ b/back/spec/policies/user_policy_spec.rb
@@ -12,7 +12,6 @@ describe UserPolicy do
     let(:subject_user) { create :user }
 
     it { is_expected.to     permit(:show)    }
-    it { is_expected.to     permit(:create)  }
     it { is_expected.not_to permit(:update)  }
     it { is_expected.not_to permit(:destroy) }
     it { is_expected.not_to permit(:index) }
@@ -31,7 +30,6 @@ describe UserPolicy do
       let(:subject_user) { current_user }
 
       it { is_expected.to     permit(:show)    }
-      it { is_expected.to     permit(:create)  }
       it { is_expected.to     permit(:update)  }
       it { is_expected.to     permit(:destroy) }
       it { is_expected.not_to permit(:index) }
@@ -47,7 +45,6 @@ describe UserPolicy do
       let(:subject_user) { create :user }
 
       it { is_expected.to     permit(:show)    }
-      it { is_expected.to     permit(:create)  }
       it { is_expected.not_to permit(:update)  }
       it { is_expected.not_to permit(:destroy) }
       it { is_expected.not_to permit(:index) }
@@ -67,7 +64,6 @@ describe UserPolicy do
       let(:subject_user) { current_user }
 
       it { is_expected.to permit(:show)    }
-      it { is_expected.to permit(:create)  }
       it { is_expected.to permit(:update)  }
       it { is_expected.to permit(:destroy) }
       it { is_expected.to permit(:index) }
@@ -83,7 +79,6 @@ describe UserPolicy do
       let(:subject_user) { create :user }
 
       it { is_expected.to permit(:show)    }
-      it { is_expected.to permit(:create)  }
       it { is_expected.to permit(:update)  }
       it { is_expected.to permit(:destroy) }
       it { is_expected.to permit(:index) }

--- a/back/spec/requests/rack_attack_spec.rb
+++ b/back/spec/requests/rack_attack_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'rspec_api_documentation/dsl'
 
-describe 'Rack::Attack', type: :request, slow_test: true do
+describe 'Rack::Attack', type: :request do
   include ActiveSupport::Testing::TimeHelpers
 
   before do
@@ -79,6 +79,17 @@ describe 'Rack::Attack', type: :request, slow_test: true do
   end
 
   it 'limits account creation requests from same IP to 10 in 20 seconds' do
+    # enable user signup via password first
+    settings = AppConfiguration.instance.settings
+    settings['password_login'] = {
+      'enabled' => true,
+      'allowed' => true,
+      'enable_signup' => true,
+      'minimum_length' => 5,
+      'phone' => false
+    }
+    AppConfiguration.instance.update! settings: settings
+
     headers = { 'CONTENT_TYPE' => 'application/json' }
 
     # Use a different email for each request, to emulate multiple account creation attempts

--- a/back/spec/support/app_configuration_helper.rb
+++ b/back/spec/support/app_configuration_helper.rb
@@ -4,9 +4,10 @@ module AppConfigurationHelper
   def enable_phone_login
     settings = AppConfiguration.instance.settings
     settings['password_login'] = {
-      'phone' => true,
       'enabled' => true,
       'allowed' => true,
+      'enable_signup' => true,
+      'phone' => true,
       'phone_email_pattern' => 'phone+__PHONE__@test.com',
       'minimum_length' => 8
     }

--- a/front/app/components/SignUpIn/AuthProviders.tsx
+++ b/front/app/components/SignUpIn/AuthProviders.tsx
@@ -137,6 +137,13 @@ const AuthProviders = memo<Props & WrappedComponentProps>(
     const phone =
       !isNilOrError(tenant) && tenant.attributes.settings.password_login?.phone;
 
+    const isPasswordSigninOrSignupAllowed =
+      passwordLoginEnabled &&
+      (flow === 'signin' ||
+        (flow === 'signup' &&
+          !isNilOrError(tenant) &&
+          tenant.attributes.settings.password_login?.enable_signup));
+
     return (
       <Container className={className}>
         {franceconnectLoginEnabled && (
@@ -148,12 +155,12 @@ const AuthProviders = memo<Props & WrappedComponentProps>(
           />
         )}
 
-        {(passwordLoginEnabled ||
+        {(isPasswordSigninOrSignupAllowed ||
           facebookLoginEnabled ||
           azureAdLoginEnabled) &&
           franceconnectLoginEnabled && <Or />}
 
-        {passwordLoginEnabled && (
+        {isPasswordSigninOrSignupAllowed && (
           <StyledAuthProviderButton
             flow={flow}
             icon="email"

--- a/front/app/services/appConfiguration.ts
+++ b/front/app/services/appConfiguration.ts
@@ -78,6 +78,7 @@ export interface IAppConfigurationSettings {
   password_login?: {
     allowed: boolean;
     enabled: boolean;
+    enable_signup: boolean;
     phone?: boolean;
     minimum_length?: number;
     phone_email_pattern?: string;


### PR DESCRIPTION
This change introduces a new option to the existing `password_login` feature toggle that allows us to inidividually turn off password sign up.

With this setting we can control if new users are allowed sign up with email & password or if only exisiting users can login with email & password. Previously, you could only enable / disable both things at once.

EE PR: https://github.com/CitizenLabDotCo/citizenlab-ee/pull/372