### PR TITLE
Reset gemfile.lock

### DIFF
--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -237,6 +237,14 @@ PATH
       verification
 
 PATH
+  remote: engines/commercial/id_oostende_rrn
+  specs:
+    id_oostende_rrn (0.1.0)
+      httparty (~> 0.16.2)
+      rails (~> 6.1)
+      verification
+
+PATH
   remote: engines/commercial/id_vienna_saml
   specs:
     id_vienna_saml (1.0.0)
@@ -1212,6 +1220,7 @@ DEPENDENCIES
   id_franceconnect!
   id_gent_rrn!
   id_id_card_lookup!
+  id_oostende_rrn!
   id_vienna_saml!
   idea_assignment!
   idea_custom_fields!


### PR DESCRIPTION
Reinserting engine in Gemfile.lock after having it accidentally removed.