### PR TITLE
CL-1817 Initiative pages 404 (undefined checks)

### DIFF
--- a/front/app/containers/InitiativesEditPage/index.tsx
+++ b/front/app/containers/InitiativesEditPage/index.tsx
@@ -169,6 +169,7 @@ const Data = adopt<DataProps, WithRouterProps>({
 export default withRouter((withRouterProps: WithRouterProps) => {
   const initiativesEnabled = useFeatureFlag({ name: 'initiatives' });
 
+  if (initiativesEnabled === undefined) return null;
   if (!initiativesEnabled) {
     return <PageNotFound />;
   }

--- a/front/app/containers/InitiativesIndexPage/index.tsx
+++ b/front/app/containers/InitiativesIndexPage/index.tsx
@@ -77,6 +77,7 @@ const InitiativeIndexPage = () => {
   const initiativePermissions = useInitiativesPermissions('posting_initiative');
   const initiativesEnabled = useFeatureFlag({ name: 'initiatives' });
 
+  if (initiativesEnabled === undefined) return null;
   if (!initiativesEnabled) {
     return <PageNotFound />;
   }

--- a/front/app/containers/InitiativesNewPage/index.tsx
+++ b/front/app/containers/InitiativesNewPage/index.tsx
@@ -160,6 +160,7 @@ const Data = adopt<DataProps>({
 export default withRouter((inputProps: WithRouterProps) => {
   const initiativesEnabled = useFeatureFlag({ name: 'initiatives' });
 
+  if (initiativesEnabled === undefined) return null;
   if (!initiativesEnabled) {
     return <PageNotFound />;
   }

--- a/front/app/containers/InitiativesShowPage/index.tsx
+++ b/front/app/containers/InitiativesShowPage/index.tsx
@@ -80,6 +80,7 @@ const InitiativesShowPage = ({ initiative }: Props) => {
     );
   }
 
+  if (initiativesEnabled === undefined) return null;
   if (!initiativesEnabled) {
     return <PageNotFound />;
   }

--- a/front/app/hooks/useFeatureFlag.ts
+++ b/front/app/hooks/useFeatureFlag.ts
@@ -25,11 +25,8 @@ export default function useFeatureFlag({
   onlyCheckAllowed = false,
 }: Parameters) {
   const [tenantSettings, setTenantSettings] = useState<
-    | IAppConfiguration['data']['attributes']['settings']
-    | undefined
-    | null
-    | Error
-  >(undefined);
+    IAppConfiguration['data']['attributes']['settings'] | null | Error
+  >(null);
 
   useEffect(() => {
     const subscription = currentAppConfigurationStream().observable.subscribe(


### PR DESCRIPTION
Checks if the output of `useFeatureFlag` is `undefined` first. Avoid flashing of 'Page not found' when initiatives is enabled.