### PR TITLE
[CL-1611] Remove exclamation mark from mail campaign spec fixture copy

### DIFF
--- a/back/engines/free/email_campaigns/config/locales/en.yml
+++ b/back/engines/free/email_campaigns/config/locales/en.yml
@@ -417,7 +417,7 @@ en:
       x_projects: '%{numberOfProjects} projects'
     project_phase_started:
       cta_view_phase: 'Discover this new phase'
-      event_description: 'This project entered a new phase on the platform of %{organizationName}. Click on the link below to learn more!'
+      event_description: 'This project entered a new phase on the platform of %{organizationName}. Click on the link below to learn more.'
       main_header: 'A new phase started for project ''%{projectName}'''
       subtitle: 'About ''%{projectName}'''
       new_phase: 'This project entered the phase ''%{phaseTitle}'''

--- a/back/engines/free/email_campaigns/spec/fixtures/locales/mailers.en.yml
+++ b/back/engines/free/email_campaigns/spec/fixtures/locales/mailers.en.yml
@@ -423,7 +423,7 @@ en:
       title_reset_your_password: 'Choose a new password'
     project_phase_started:
       cta_view_phase: 'Discover this new phase'
-      event_description: 'This project entered a new phase on the platform of %{organizationName}. Click on the link below to learn more!'
+      event_description: 'This project entered a new phase on the platform of %{organizationName}. Click on the link below to learn more.'
       main_header: 'A new phase started for project ''%{projectName}'''
       subtitle: 'About ''%{projectName}'''
       new_phase: 'This project entered the phase ''%{phaseTitle}'''


### PR DESCRIPTION
Closed, as we decided to make the removal of all exclamation marks from campaign emails a ticket in itself: [CL-1970](https://citizenlab.atlassian.net/browse/CL-1970)
