### PR TITLE
CL-1917: Add change to use json_forms_schema in idea edit page

### DIFF
--- a/front/app/services/ideaCustomFieldsSchemas.ts
+++ b/front/app/services/ideaCustomFieldsSchemas.ts
@@ -62,6 +62,7 @@ const getInputFormsSchemaEndpoint = (
   phaseId?: string | null,
   inputId?: string
 ) => {
+  debugger;
   if (inputId) {
     return `${API_PATH}/ideas/${inputId}/schema`;
   } else if (phaseId) {

--- a/front/app/services/ideaCustomFieldsSchemas.ts
+++ b/front/app/services/ideaCustomFieldsSchemas.ts
@@ -62,7 +62,6 @@ const getInputFormsSchemaEndpoint = (
   phaseId?: string | null,
   inputId?: string
 ) => {
-  debugger;
   if (inputId) {
     return `${API_PATH}/ideas/${inputId}/schema`;
   } else if (phaseId) {


### PR DESCRIPTION
## How to test
- Create an ideation project or phase
- Add an idea in the front office
- Edit the idea using the Input manager in the B0 
- Check that the `json_forms_schema` endpoint is being used
- Check that editing works well

## Note
I noticed that we have both `useInputSchema` and `useIdeaCustomFieldsSchema`. I think using one of this might be a better approach if possible. That way a change in one is reflected everywhere. I have not addressed it in this PR because we expect some of this code to change when we remove the feature flags. I'll just add a comment to that ticket.

## How urgent is a code review?

End of day if possible
