### PR TITLE
Restrict direct imports from `@testing-library/react`

### DIFF
--- a/front/.eslintrc.js
+++ b/front/.eslintrc.js
@@ -108,7 +108,7 @@ module.exports = {
           {
             name: '@testing-library/react',
             message:
-              "Import react testing library exports from 'utils/testUtils/rtl' instead",
+              "Import React testing library exports from 'utils/testUtils/rtl' instead",
           },
         ],
       },

--- a/front/.eslintrc.js
+++ b/front/.eslintrc.js
@@ -105,6 +105,11 @@ module.exports = {
             message:
               "Import lodash functions from 'lodash-es' instead of 'lodash'",
           },
+          {
+            name: '@testing-library/react',
+            message:
+              "Import react testing library exports from 'utils/testUtils/rtl' instead",
+          },
         ],
       },
     ],

--- a/front/app/components/admin/SlugInput/SlugInput.test.tsx
+++ b/front/app/components/admin/SlugInput/SlugInput.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen } from 'utils/testUtils/rtl';
 import SlugInput, { Props } from '.';
 
 jest.mock('utils/cl-intl');

--- a/front/app/utils/testUtils/rtl.tsx
+++ b/front/app/utils/testUtils/rtl.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { render, RenderOptions } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ThemeProvider } from 'styled-components';
@@ -56,6 +57,7 @@ const customRender: any = (ui: React.ReactElement, options?: RenderOptions) =>
   render(ui, { wrapper: AllTheProviders, ...options });
 
 // re-export everything
+// eslint-disable-next-line no-restricted-imports
 export * from '@testing-library/react';
 
 // override render method


### PR DESCRIPTION
Restricts direct react testing library imports and enforced the use of our `utils/testUtils/rtl` wrapper via an eslint rule.