### PR TITLE
[CL-1993] Introduce input_type "page" and adapt export of survey results

### DIFF
--- a/back/app/models/custom_field.rb
+++ b/back/app/models/custom_field.rb
@@ -38,7 +38,7 @@ class CustomField < ApplicationRecord
   belongs_to :resource, polymorphic: true, optional: true
 
   FIELDABLE_TYPES = %w[User CustomForm].freeze
-  INPUT_TYPES = %w[text number multiline_text html text_multiloc multiline_text_multiloc html_multiloc select multiselect checkbox date files image_files point linear_scale].freeze
+  INPUT_TYPES = %w[text number multiline_text html text_multiloc multiline_text_multiloc html_multiloc select multiselect checkbox date files image_files point linear_scale page].freeze
   CODES = %w[gender birthyear domicile education title_multiloc body_multiloc topic_ids location_description proposed_budget idea_images_attributes idea_files_attributes author_id budget].freeze
 
   validates :resource_type, presence: true, inclusion: { in: FIELDABLE_TYPES }
@@ -121,6 +121,8 @@ class CustomField < ApplicationRecord
       visitor.visit_point self
     when 'linear_scale'
       visitor.visit_linear_scale self
+    when 'page'
+      visitor.visit_page self
     else
       raise "Unsupported input type: #{input_type}"
     end

--- a/back/app/services/field_visitor_service.rb
+++ b/back/app/services/field_visitor_service.rb
@@ -65,6 +65,10 @@ class FieldVisitorService
     default(field)
   end
 
+  def visit_page(field)
+    default(field)
+  end
+
   def default(field)
     # Do nothing
   end

--- a/back/app/services/input_ui_schema_generator_service.rb
+++ b/back/app/services/input_ui_schema_generator_service.rb
@@ -56,7 +56,7 @@ class InputUiSchemaGeneratorService < UiSchemaGeneratorService
       type: 'Category',
       label: (I18n.t(translation_key) if translation_key),
       options: { id: category_id },
-      elements: fields.map { |field| visit field }
+      elements: fields.filter_map { |field| visit field }
     }
   end
 end

--- a/back/app/services/json_schema_generator_service.rb
+++ b/back/app/services/json_schema_generator_service.rb
@@ -189,7 +189,10 @@ class JsonSchemaGeneratorService < FieldVisitorService
 
   def generate_for_current_locale(fields)
     field_properties = fields.each_with_object({}) do |field, accu|
-      accu[field.key] = visit field
+      field_schema = visit field
+      next unless field_schema
+
+      accu[field.key] = field_schema
     end
     {
       type: 'object',

--- a/back/app/services/ui_schema_generator_service.rb
+++ b/back/app/services/ui_schema_generator_service.rb
@@ -80,6 +80,10 @@ class UiSchemaGeneratorService < FieldVisitorService
     }
   end
 
+  def visit_page(_field)
+    nil
+  end
+
   protected
 
   def generate_for_current_locale(fields)

--- a/back/app/services/xlsx_export/input_sheet_generator.rb
+++ b/back/app/services/xlsx_export/input_sheet_generator.rb
@@ -45,7 +45,9 @@ module XlsxExport
     attr_reader :inputs, :fields_in_form, :participation_method, :include_private_attributes
 
     def supported?(field)
-      field.code != 'idea_images_attributes' # Not supported by XlsxService
+      # idea_images_attributes is not supported by XlsxService.
+      # Page fields do not capture data, so they are excluded.
+      field.code != 'idea_images_attributes' && field.input_type != 'page'
     end
 
     def input_id_report_field

--- a/back/app/services/xlsx_export/value_visitor.rb
+++ b/back/app/services/xlsx_export/value_visitor.rb
@@ -79,6 +79,10 @@ module XlsxExport
       # Not supported yet. Field type not used in native surveys, nor in idea forms.
     end
 
+    def visit_page(field)
+      # The field does not capture data, so there is no value.
+    end
+
     private
 
     attr_reader :model, :option_index

--- a/back/spec/acceptance/phases_spec.rb
+++ b/back/spec/acceptance/phases_spec.rb
@@ -795,6 +795,9 @@ resource 'Phases' do
         let(:active_phase) { project.phases.first }
         let(:form) { create(:custom_form, participation_context: active_phase) }
         let(:id) { active_phase.id }
+
+        # Create a page to describe that it is not included in the export.
+        let!(:page_field) { create(:custom_field_page, resource: form) }
         let(:multiselect_field) do
           create(
             :custom_field_multiselect,

--- a/back/spec/acceptance/projects_spec.rb
+++ b/back/spec/acceptance/projects_spec.rb
@@ -880,6 +880,8 @@ resource 'Projects' do
         let(:active_phase_form) { create(:custom_form, participation_context: active_phase) }
         let(:future_phase_form) { create(:custom_form, participation_context: future_phase) }
         let(:id) { project.id }
+        # Create a page to describe that it is not included in the export.
+        let!(:page_field) { create(:custom_field_page, resource: active_phase_form) }
         let(:multiselect_field) do
           create(
             :custom_field_multiselect,

--- a/back/spec/factories/custom_fields.rb
+++ b/back/spec/factories/custom_fields.rb
@@ -84,6 +84,22 @@ FactoryBot.define do
       end
     end
 
+    factory :custom_field_page do
+      title_multiloc do
+        {
+          'en' => 'Cycling survey'
+        }
+      end
+      description_multiloc do
+        {
+          'en' => 'This is a survey on your cycling habits.'
+        }
+      end
+      required { false }
+      input_type { 'page' }
+      enabled { true }
+    end
+
     factory :custom_field_multiselect do
       title_multiloc do
         {

--- a/back/spec/models/custom_field_spec.rb
+++ b/back/spec/models/custom_field_spec.rb
@@ -62,6 +62,10 @@ class TestVisitor < FieldVisitorService
   def visit_linear_scale(_field)
     'linear_scale from visitor'
   end
+
+  def visit_page(_field)
+    'page from visitor'
+  end
 end
 
 RSpec.describe CustomField, type: :model do

--- a/back/spec/services/field_visitor_service_spec.rb
+++ b/back/spec/services/field_visitor_service_spec.rb
@@ -28,120 +28,15 @@ RSpec.describe FieldVisitorService do
     end
   end
 
-  describe 'each #visit_xxx method invokes #default' do
-    subject(:visitor) { TestVisitorWithDefault.new }
+  CustomField::INPUT_TYPES.each do |input_type|
+    message = "visit_#{input_type}"
+    describe "##{message}" do
+      subject(:visitor) { TestVisitorWithDefault.new }
 
-    let(:field) { instance_double CustomField, input_type: input_type }
+      let(:field) { instance_double CustomField, input_type: input_type }
 
-    describe '#visit_text' do
-      let(:input_type) { 'text' }
-
-      it 'returns the default' do
-        expect(visitor.visit_text(field)).to eq 'default value for text'
-      end
-    end
-
-    describe '#visit_number' do
-      let(:input_type) { 'number' }
-
-      it 'returns the default' do
-        expect(visitor.visit_number(field)).to eq 'default value for number'
-      end
-    end
-
-    describe '#visit_multiline_text' do
-      let(:input_type) { 'multiline_text' }
-
-      it 'returns the default' do
-        expect(visitor.visit_multiline_text(field)).to eq 'default value for multiline_text'
-      end
-    end
-
-    describe '#visit_html' do
-      let(:input_type) { 'html' }
-
-      it 'returns the default' do
-        expect(visitor.visit_html(field)).to eq 'default value for html'
-      end
-    end
-
-    describe '#visit_text_multiloc' do
-      let(:input_type) { 'text_multiloc' }
-
-      it 'returns the default' do
-        expect(visitor.visit_text_multiloc(field)).to eq 'default value for text_multiloc'
-      end
-    end
-
-    describe '#visit_multiline_text_multiloc' do
-      let(:input_type) { 'multiline_text_multiloc' }
-
-      it 'returns the default' do
-        expect(visitor.visit_multiline_text_multiloc(field)).to eq 'default value for multiline_text_multiloc'
-      end
-    end
-
-    describe '#visit_html_multiloc' do
-      let(:input_type) { 'html_multiloc' }
-
-      it 'returns the default' do
-        expect(visitor.visit_html_multiloc(field)).to eq 'default value for html_multiloc'
-      end
-    end
-
-    describe '#visit_select' do
-      let(:input_type) { 'select' }
-
-      it 'returns the default' do
-        expect(visitor.visit_select(field)).to eq 'default value for select'
-      end
-    end
-
-    describe '#visit_multiselect' do
-      let(:input_type) { 'multiselect' }
-
-      it 'returns the default' do
-        expect(visitor.visit_multiselect(field)).to eq 'default value for multiselect'
-      end
-    end
-
-    describe '#visit_checkbox' do
-      let(:input_type) { 'checkbox' }
-
-      it 'returns the default' do
-        expect(visitor.visit_checkbox(field)).to eq 'default value for checkbox'
-      end
-    end
-
-    describe '#visit_date' do
-      let(:input_type) { 'date' }
-
-      it 'returns the default' do
-        expect(visitor.visit_date(field)).to eq 'default value for date'
-      end
-    end
-
-    describe '#visit_files' do
-      let(:input_type) { 'files' }
-
-      it 'returns the default' do
-        expect(visitor.visit_files(field)).to eq 'default value for files'
-      end
-    end
-
-    describe '#visit_image_files' do
-      let(:input_type) { 'image_files' }
-
-      it 'returns the default' do
-        expect(visitor.visit_image_files(field)).to eq 'default value for image_files'
-      end
-    end
-
-    describe '#visit_point' do
-      let(:input_type) { 'point' }
-
-      it 'returns the default' do
-        expect(visitor.visit_point(field)).to eq 'default value for point'
+      it "returns the default for '#{input_type}'" do
+        expect(visitor.public_send(message, field)).to eq "default value for #{input_type}"
       end
     end
   end

--- a/back/spec/services/input_ui_schema_generator_service_spec.rb
+++ b/back/spec/services/input_ui_schema_generator_service_spec.rb
@@ -313,10 +313,12 @@ RSpec.describe InputUiSchemaGeneratorService do
     context 'for a continuous native survey project' do
       let(:project) { create(:continuous_native_survey_project) }
       let(:form) { create :custom_form, participation_context: project }
+      # Create a page to describe that it is not included in the schema.
+      let!(:page_field) { create(:custom_field_page, resource: form) }
       let!(:field) { create :custom_field, resource: form }
 
       it 'has an empty extra category label, so that the category label is suppressed in the UI' do
-        en_ui_schema = generator.generate_for([field])['en']
+        en_ui_schema = generator.generate_for([page_field, field])['en']
         expect(en_ui_schema).to eq({
           type: 'Categorization',
           options: {

--- a/back/spec/services/json_schema_generator_service_spec.rb
+++ b/back/spec/services/json_schema_generator_service_spec.rb
@@ -8,11 +8,13 @@ RSpec.describe JsonSchemaGeneratorService do
   let(:field_key) { 'field_key' }
 
   describe '#generate_for' do
+    # Create a page to describe that it is not included in the schema.
+    let!(:page_field) { create(:custom_field_page) }
     let(:field1) { create :custom_field }
     let(:field2) { create :custom_field_select, :with_options }
 
     it 'returns the schema for the given fields' do
-      expect(generator.generate_for([field1, field2])).to eq({
+      expect(generator.generate_for([page_field, field1, field2])).to eq({
         'en' => {
           type: 'object',
           additionalProperties: false,
@@ -365,6 +367,14 @@ RSpec.describe JsonSchemaGeneratorService do
         minimum: 1,
         maximum: field.maximum
       })
+    end
+  end
+
+  describe '#visit_page' do
+    let(:field) { create :custom_field_page }
+
+    it 'returns the schema for the given field' do
+      expect(generator.visit_page(field)).to be_nil
     end
   end
 end

--- a/back/spec/services/survey_results_generator_service_spec.rb
+++ b/back/spec/services/survey_results_generator_service_spec.rb
@@ -14,6 +14,8 @@ require 'rails_helper'
 RSpec.describe SurveyResultsGeneratorService, skip: !CitizenLab.ee? do
   subject(:generator) { described_class.new participation_context }
 
+  # Create a page to describe that it is not included in the survey results.
+  let!(:page_field) { create(:custom_field_page, resource: form) }
   let(:text_field) do
     create(
       :custom_field,

--- a/back/spec/services/ui_schema_generator_service_spec.rb
+++ b/back/spec/services/ui_schema_generator_service_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 class UiSchemaGeneratorServiceSubclass < UiSchemaGeneratorService
   def generate_for_current_locale(fields)
     {
-      elements: fields.map { |field| visit field }
+      elements: fields.filter_map { |field| visit field }
     }
   end
 end
@@ -16,6 +16,8 @@ RSpec.describe UiSchemaGeneratorService do
   let(:field_key) { 'field_key' }
 
   describe '#generate_for' do
+    # Create a page to describe that it is not included in the schema.
+    let!(:page_field) { create(:custom_field_page) }
     let(:field1) do
       create(
         :custom_field,
@@ -35,7 +37,7 @@ RSpec.describe UiSchemaGeneratorService do
     end
 
     it 'returns the schema for the given fields' do
-      expect(UiSchemaGeneratorServiceSubclass.new.generate_for([field1, field2])).to eq({
+      expect(UiSchemaGeneratorServiceSubclass.new.generate_for([page_field, field1, field2])).to eq({
         'en' => {
           elements: [
             {
@@ -519,6 +521,14 @@ RSpec.describe UiSchemaGeneratorService do
           maximum_label: 'Strongly agree'
         }
       })
+    end
+  end
+
+  describe '#visit_page' do
+    let(:field) { create :custom_field_page }
+
+    it 'returns the schema for the given field' do
+      expect(generator.visit_page(field)).to be_nil
     end
   end
 end

--- a/back/spec/services/xlsx_export/value_visitor_spec.rb
+++ b/back/spec/services/xlsx_export/value_visitor_spec.rb
@@ -485,5 +485,14 @@ describe XlsxExport::ValueVisitor do
         expect(visitor.visit_point(field)).to be_nil
       end
     end
+
+    describe '#visit_page' do
+      let(:input_type) { 'page' }
+      let(:model) { instance_double Idea } # The model is irrelevant for this test.
+
+      it 'returns nil, because the field does not capture data' do
+        expect(visitor.visit_page(field)).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR includes:
* I noticed that `back/spec/services/field_visitor_service_spec.rb` did not fail after adding the new input, so I changed the spec so that it fails when new input types are added. The code is much shorter now.
* Addition of the `page` input type for custom fields.
* Adapting the visitors.
* Ensuring that the "page" fields are not included in the JSON schemas. In another ticket we will have to revisit the UI schema generation, of course.

By adapting the visitors, the main requirement of the ticket was implemented.