### PR TITLE
CL-1922: Fix red dot in content builder

### DIFF
--- a/front/app/containers/Admin/formBuilder/components/FormBuilderSettings/ConfigMultiselectWithLocaleSwitcher/index.tsx
+++ b/front/app/containers/Admin/formBuilder/components/FormBuilderSettings/ConfigMultiselectWithLocaleSwitcher/index.tsx
@@ -26,7 +26,7 @@ import { WrappedComponentProps } from 'react-intl';
 import messages from './messages';
 
 // Typings
-import { Multiloc, Locale, CLError } from 'typings';
+import { Locale, CLError } from 'typings';
 
 // utils
 import { isNilOrError } from 'utils/helperUtils';
@@ -109,6 +109,10 @@ const ConfigMultiselectWithLocaleSwitcher = ({
           render={({ field: { ref: _ref, value: choices, onBlur } }) => {
             const canDeleteLastOption =
               allowDeletingAllOptions || choices.length > 1;
+            const validatedValues = choices.map((choice) => ({
+              title_multiloc: choice.title_multiloc,
+            }));
+            debugger;
 
             return (
               <Box
@@ -136,9 +140,7 @@ const ConfigMultiselectWithLocaleSwitcher = ({
                         onSelectedLocaleChange={handleOnSelectedLocaleChange}
                         locales={!isNilOrError(locales) ? locales : []}
                         selectedLocale={selectedLocale}
-                        values={{
-                          input_field: choices as Multiloc,
-                        }}
+                        values={validatedValues}
                       />
                     </Box>
                   </Box>

--- a/front/app/containers/Admin/formBuilder/components/FormBuilderSettings/ConfigMultiselectWithLocaleSwitcher/index.tsx
+++ b/front/app/containers/Admin/formBuilder/components/FormBuilderSettings/ConfigMultiselectWithLocaleSwitcher/index.tsx
@@ -112,7 +112,6 @@ const ConfigMultiselectWithLocaleSwitcher = ({
             const validatedValues = choices.map((choice) => ({
               title_multiloc: choice.title_multiloc,
             }));
-            debugger;
 
             return (
               <Box

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@apollo/client": "^3.5.6",
         "@babel/runtime": "7.x",
-        "@citizenlab/cl2-component-library": "^0.10.11",
+        "@citizenlab/cl2-component-library": "^0.10.13",
         "@craftjs/core": "^0.2.0-beta.5",
         "@hookform/resolvers": "^2.9.5",
         "@jsonforms/core": "3.0.0-beta.0",
@@ -2164,9 +2164,9 @@
       "dev": true
     },
     "node_modules/@citizenlab/cl2-component-library": {
-      "version": "0.10.11",
-      "resolved": "https://registry.npmjs.org/@citizenlab/cl2-component-library/-/cl2-component-library-0.10.11.tgz",
-      "integrity": "sha512-dWWLYTzJAhll9iQzw94N0PKKRu9sHVyZ6e8pZpztN/pRyfUo2mmvn+ejq1i+zo/uLaxUQkHW/oQ4M+KL8FvenA==",
+      "version": "0.10.13",
+      "resolved": "https://registry.npmjs.org/@citizenlab/cl2-component-library/-/cl2-component-library-0.10.13.tgz",
+      "integrity": "sha512-y6zvHxw138O375dsbdfb6LN/XxF08zbeXFQ2W2NeNZPu0xUCv9NEaeXU1cjgkn9OYHNu7TljBvYAZP7Pq0da8A==",
       "dependencies": {
         "@tippyjs/react": "4.2.6",
         "focus-visible": "5.2.0",
@@ -22862,9 +22862,9 @@
       "dev": true
     },
     "@citizenlab/cl2-component-library": {
-      "version": "0.10.11",
-      "resolved": "https://registry.npmjs.org/@citizenlab/cl2-component-library/-/cl2-component-library-0.10.11.tgz",
-      "integrity": "sha512-dWWLYTzJAhll9iQzw94N0PKKRu9sHVyZ6e8pZpztN/pRyfUo2mmvn+ejq1i+zo/uLaxUQkHW/oQ4M+KL8FvenA==",
+      "version": "0.10.13",
+      "resolved": "https://registry.npmjs.org/@citizenlab/cl2-component-library/-/cl2-component-library-0.10.13.tgz",
+      "integrity": "sha512-y6zvHxw138O375dsbdfb6LN/XxF08zbeXFQ2W2NeNZPu0xUCv9NEaeXU1cjgkn9OYHNu7TljBvYAZP7Pq0da8A==",
       "requires": {
         "@tippyjs/react": "4.2.6",
         "focus-visible": "5.2.0",

--- a/front/package.json
+++ b/front/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@apollo/client": "^3.5.6",
     "@babel/runtime": "7.x",
-    "@citizenlab/cl2-component-library": "^0.10.11",
+    "@citizenlab/cl2-component-library": "^0.10.13",
     "@craftjs/core": "^0.2.0-beta.5",
     "@hookform/resolvers": "^2.9.5",
     "@jsonforms/core": "3.0.0-beta.0",


### PR DESCRIPTION
Fixes the dot colour of the Locale switcher in the Multi-select options
![image](https://user-images.githubusercontent.com/12659000/200828371-7aa105d2-e67f-41c1-8bb7-913188ad2be1.png)


## How urgent is a code review?

End of day if possible
