### PR TITLE
[CL-1997] Adapt UI schema generation for pages

### DIFF
--- a/back/app/models/custom_field.rb
+++ b/back/app/models/custom_field.rb
@@ -89,6 +89,10 @@ class CustomField < ApplicationRecord
     key == 'domicile' && code == 'domicile'
   end
 
+  def page?
+    input_type == 'page'
+  end
+
   def accept(visitor)
     case input_type
     when 'text'

--- a/back/app/services/input_ui_schema_generator_service.rb
+++ b/back/app/services/input_ui_schema_generator_service.rb
@@ -11,10 +11,74 @@ class InputUiSchemaGeneratorService < UiSchemaGeneratorService
     end
   end
 
+  def generate_for(fields)
+    uses_pages = fields.any?(&:page?)
+    return super(fields) unless uses_pages
+
+    generate_with_pages(fields)
+  end
+
+  def visit_page(field)
+    {
+      type: 'Page',
+      options: {
+        # No id yet. It will be set after invoking this method.
+        title: multiloc_service.t(field.title_multiloc),
+        description: multiloc_service.t(field.description_multiloc)
+      },
+      elements: [
+        # No elements yet. They will be added after invoking this method.
+      ]
+    }
+  end
+
   protected
 
   def default_options(field)
     super.merge(isAdminField: admin_field?(field))
+  end
+
+  def generate_with_pages(fields)
+    locales.index_with do |locale|
+      I18n.with_locale(locale) do
+        generate_pages_for_current_locale fields
+      end
+    end
+  end
+
+  def schema_elements_for(fields)
+    current_page_schema = nil
+    current_page_index = 0
+    fields.each_with_object([]) do |field, accu|
+      field_schema = visit field
+      if field.page?
+        current_page_index += 1
+        field_schema[:options][:id] = "page_#{current_page_index}"
+        accu << field_schema
+        current_page_schema = field_schema
+      elsif current_page_schema
+        current_page_schema[:elements] << field_schema
+      else
+        accu << field_schema
+      end
+    end
+  end
+
+  def categorization_schema_with(input_term, elements)
+    {
+      type: 'Categorization',
+      options: {
+        formId: 'idea-form',
+        inputTerm: input_term
+      },
+      elements: elements
+    }
+  end
+
+  def generate_pages_for_current_locale(fields)
+    participation_context = fields.first.resource.participation_context
+    input_term = participation_context.input_term || ParticipationContext::DEFAULT_INPUT_TERM
+    categorization_schema_with(input_term, schema_elements_for(fields))
   end
 
   def generate_for_current_locale(fields)
@@ -33,14 +97,7 @@ class InputUiSchemaGeneratorService < UiSchemaGeneratorService
       category_for(attachments_fields, 'attachments', 'custom_forms.categories.attachements.title'),
       category_for(custom_fields, 'extra', participation_method.extra_fields_category_translation_key)
     ].compact
-    {
-      type: 'Categorization',
-      options: {
-        formId: 'idea-form',
-        inputTerm: input_term
-      },
-      elements: elements
-    }
+    categorization_schema_with(input_term, elements)
   end
 
   private

--- a/back/spec/models/custom_field_spec.rb
+++ b/back/spec/models/custom_field_spec.rb
@@ -69,6 +69,18 @@ class TestVisitor < FieldVisitorService
 end
 
 RSpec.describe CustomField, type: :model do
+  describe '#page?' do
+    it 'returns true when the input_type is "page"' do
+      page_field = described_class.new input_type: 'page'
+      expect(page_field.page?).to be true
+    end
+
+    it 'returns false otherwise' do
+      other_field = described_class.new input_type: 'something_else'
+      expect(other_field.page?).to be false
+    end
+  end
+
   context 'hooks' do
     it 'generates a key on creation, if not specified' do
       cf = create(:custom_field, key: nil)


### PR DESCRIPTION
See https://citizenlab.atlassian.net/browse/CL-1997

This PR adapt the generation of the UI schema for inputs. `InputUiSchemaGeneratorService#generate_for` checks whether there are any page fields. If so, a different code path is followed to generate a UI schema with pages. `InputUiSchemaGeneratorService#schema_elements_for` does the heavy lifting. It includes the algorithm to turn a flat list of fields into a UI schema with pages and their nested fields.

Due to the different code path, there is no impact on the UI schema generation for idea forms.