### PR TITLE
[CL-1101] Add padding to bottom of fullscreen modal

### DIFF
--- a/front/app/components/UI/Modal/index.tsx
+++ b/front/app/components/UI/Modal/index.tsx
@@ -64,7 +64,12 @@ export const ModalContentContainer = styled.div<{
     padding: ${({ padding }) => padding || '20px'};
   `}
 
-  ${({ fullScreen }) => fullScreen && 'max-width: 580px;'}
+  ${({ fullScreen }) =>
+    fullScreen &&
+    `
+      max-width: 580px;;
+      padding-bottom: 40px !important;
+  `}
 `;
 
 const StyledCloseIconButton = styled(CloseIconButton)`


### PR DESCRIPTION
In testing on my phone, new iOS has moved the address bar to the bottom, so I added some padding only when the `fullScreen` option is active: 
![Screen Shot 2022-11-10 at 08 38 10](https://user-images.githubusercontent.com/3614128/201028900-82da72ee-b17f-454c-a9da-cfc2d5f4eb5d.png)
