### PR TITLE
[CL-2021] Enable bottom info section toggle/edit, events + projects toggles for custom pages

### DIFF
--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/Content/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/Content/index.tsx
@@ -70,18 +70,17 @@ const CustomPagesEditContent = () => {
     //   titleMessageDescriptor: sectionToggleMessages.eventsList,
     //   tooltipMessageDescriptor: sectionToggleMessages.eventsListTooltip,
     // },
-    // next iteration!
-    // {
-    //   name: 'bottom_info_section_enabled',
-    //   titleMessageDescriptor: sectionToggleMessages.bottomInfoSection,
-    //   tooltipMessageDescriptor: sectionToggleMessages.bottomInfoSectionTooltip,
-    //   linkToPath: 'bottom-info-section',
-    // },
     {
       name: 'files_section_enabled',
       titleMessageDescriptor: sectionToggleMessages.attachmentsSection,
       tooltipMessageDescriptor: sectionToggleMessages.attachmentsSectionTooltip,
       linkToPath: 'attachments',
+    },
+    {
+      name: 'bottom_info_section_enabled',
+      titleMessageDescriptor: sectionToggleMessages.bottomInfoSection,
+      tooltipMessageDescriptor: sectionToggleMessages.bottomInfoSectionTooltip,
+      linkToPath: 'bottom-info-section',
     },
   ];
 

--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/Content/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/Content/index.tsx
@@ -57,24 +57,21 @@ const CustomPagesEditContent = () => {
       tooltipMessageDescriptor: sectionToggleMessages.topInfoSectionTooltip,
       linkToPath: 'top-info-section',
     },
-    // next iteration!
-    // {
-    //   name: 'projects_enabled',
-    //   titleMessageDescriptor: sectionToggleMessages.projectsList,
-    //   tooltipMessageDescriptor: sectionToggleMessages.projectsListTooltip,
-    //   linkToPath: 'projects',
-    // },
-    // next iteration!
-    // {
-    //   name: 'events_widget_enabled',
-    //   titleMessageDescriptor: sectionToggleMessages.eventsList,
-    //   tooltipMessageDescriptor: sectionToggleMessages.eventsListTooltip,
-    // },
     {
       name: 'files_section_enabled',
       titleMessageDescriptor: sectionToggleMessages.attachmentsSection,
       tooltipMessageDescriptor: sectionToggleMessages.attachmentsSectionTooltip,
       linkToPath: 'attachments',
+    },
+    {
+      name: 'projects_enabled',
+      titleMessageDescriptor: sectionToggleMessages.projectsList,
+      tooltipMessageDescriptor: sectionToggleMessages.projectsListTooltip,
+    },
+    {
+      name: 'events_widget_enabled',
+      titleMessageDescriptor: sectionToggleMessages.eventsList,
+      tooltipMessageDescriptor: sectionToggleMessages.eventsListTooltip,
     },
     {
       name: 'bottom_info_section_enabled',

--- a/front/app/hooks/fixtures/customPages.ts
+++ b/front/app/hooks/fixtures/customPages.ts
@@ -41,6 +41,7 @@ const PAGES: ICustomPageData[] = [
       top_info_section_enabled: true,
       events_widget_enabled: true,
       files_section_enabled: true,
+      projects_enabled: true,
       projects_filter_type: 'area',
       bottom_info_section_multiloc: { en: 'bottom info' },
       header_bg: {
@@ -85,6 +86,7 @@ const PAGES: ICustomPageData[] = [
       top_info_section_enabled: true,
       events_widget_enabled: true,
       files_section_enabled: true,
+      projects_enabled: true,
       projects_filter_type: 'area',
       bottom_info_section_multiloc: { en: 'bottom info' },
       header_bg: {
@@ -134,6 +136,7 @@ const PAGES: ICustomPageData[] = [
       top_info_section_enabled: true,
       events_widget_enabled: true,
       files_section_enabled: true,
+      projects_enabled: true,
       projects_filter_type: 'area',
       bottom_info_section_multiloc: { en: 'bottom info' },
       header_bg: {
@@ -186,6 +189,7 @@ const PAGES: ICustomPageData[] = [
       top_info_section_enabled: true,
       events_widget_enabled: true,
       files_section_enabled: true,
+      projects_enabled: true,
       projects_filter_type: 'area',
       bottom_info_section_multiloc: { en: 'bottom info' },
       header_bg: {
@@ -235,6 +239,7 @@ const PAGES: ICustomPageData[] = [
       top_info_section_enabled: true,
       events_widget_enabled: true,
       files_section_enabled: true,
+      projects_enabled: true,
       projects_filter_type: 'area',
       bottom_info_section_multiloc: { en: 'bottom info' },
       header_bg: {
@@ -288,6 +293,7 @@ const PAGES: ICustomPageData[] = [
       top_info_section_enabled: true,
       events_widget_enabled: true,
       files_section_enabled: true,
+      projects_enabled: true,
       projects_filter_type: 'area',
       bottom_info_section_multiloc: { en: 'bottom info' },
       header_bg: {
@@ -337,6 +343,7 @@ const PAGES: ICustomPageData[] = [
       top_info_section_enabled: true,
       events_widget_enabled: true,
       files_section_enabled: true,
+      projects_enabled: true,
       projects_filter_type: 'area',
       bottom_info_section_multiloc: { en: 'bottom info' },
       header_bg: {

--- a/front/app/services/customPages.ts
+++ b/front/app/services/customPages.ts
@@ -37,9 +37,7 @@ export interface ICustomPageEnabledSettings {
   top_info_section_enabled: boolean;
   events_widget_enabled: boolean;
   files_section_enabled: boolean;
-
-  // for a subsequent iteration
-  // projects_enabled: boolean;
+  projects_enabled: boolean;
 }
 
 export interface ICustomPageAttributes extends ICustomPageEnabledSettings {


### PR DESCRIPTION
Pretty easy PR, I had forgotten how much work we had done on this one 😅. 

I ordered the toggles in the same order as they appear on the page, from [the mockup](https://www.figma.com/proto/XD9LDCrg2wnthCU8EEDTnL/Flexible-pages?page-id=1741%3A22521&node-id=2161%3A25811&viewport=-4633%2C-983%2C0.5&scaling=scale-down-width&starting-point-node-id=2161%3A25811&show-proto-sidebar=1) it looks like files go above projects/events/bottom info section. Easy to change the order though.

The projects toggle doesn't work (backend error, I think due to no linked tag/area existing?) but we can fix that in another PR. 