### PR TITLE
[CL-2036] Fix to detect both 'returning' and 'returningCustomer' in Matomo API output

### DIFF
--- a/back/engines/commercial/analytics/app/services/analytics/matomo_data_importer.rb
+++ b/back/engines/commercial/analytics/app/services/analytics/matomo_data_importer.rb
@@ -175,7 +175,7 @@ module Analytics
         dimension_date_last_action_id: timestamp_to_date(last_action_timestamp),
         duration: visit_json['visitDuration']&.to_i,
         pages_visited: pages_visited(visit_json['actionDetails']),
-        returning_visitor: visit_json['visitorType'] == 'returningCustomer',
+        returning_visitor: visit_json['visitorType'].start_with?('returning'),
         referrer_name: visit_json['referrerName'].presence,
         referrer_url: visit_json['referrerUrl'].presence,
         matomo_visit_id: visit_json['idVisit'],

--- a/back/engines/commercial/analytics/spec/services/analytics/matomo_data_importer_spec.rb
+++ b/back/engines/commercial/analytics/spec/services/analytics/matomo_data_importer_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Analytics::MatomoDataImporter do
         'dimension_date_last_action_id' => Date.new(2022, 10, 3),
         'duration' => 672,
         'pages_visited' => 3,
-        'returning_visitor' => false,
+        'returning_visitor' => true,
         'referrer_name' => nil,
         'referrer_url' => nil,
         'matomo_visit_id' => 8,


### PR DESCRIPTION
Currently detects 'returningCustomer' in the VisitorType field as that is what is always present in the Matomo demo API docs, but usually in our output it is actually returning just 'returning'.