### PR TITLE
CL-2048 add projects only filter

### DIFF
--- a/back/app/services/admin_publications_filtering_service.rb
+++ b/back/app/services/admin_publications_filtering_service.rb
@@ -14,6 +14,12 @@ class AdminPublicationsFilteringService
 
   # NOTE: This service is very fragile and the ORDER of filters matters for the Front-End, do not change it.
 
+  add_filter('only_projects') do |scope, options|
+    next scope unless ['true', true, '1'].include? options[:only_projects]
+
+    scope.where(publication_type: Project.name)
+  end
+
   add_filter('remove_not_allowed_parents') do |visible_publications, options|
     next visible_publications unless ['true', true, '1'].include? options[:remove_not_allowed_parents]
 

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -46,6 +46,7 @@ resource 'AdminPublication' do
       if CitizenLab.ee?
         parameter :folder, 'Filter by folder (project folder id)', required: false
         parameter :remove_not_allowed_parents, 'Exclude children with parent', required: false
+        parameter :only_projects, 'Include projects only (no folders)', required: false
       end
 
       example_request 'List all admin publications' do
@@ -94,6 +95,20 @@ resource 'AdminPublication' do
         else
           expect(json_response[:data].size).to eq 4
           expect(json_response[:data].map { |d| d.dig(:relationships, :publication, :data, :type) }.count('project')).to eq 4
+        end
+      end
+
+      example_request 'List projects only' do
+        do_request(only_projects: 'true')
+        expect(status).to eq(200)
+        json_response = json_parse(response_body)
+        if CitizenLab.ee?
+          expect(json_response[:data].size).to eq 8
+          expect(json_response[:data].map { |d| d.dig(:relationships, :publication, :data, :type) }.count('project')).to eq 8
+          expect(json_response[:data].map { |d| d.dig(:relationships, :publication, :data, :type) }.count('folder')).to eq 0
+        else
+          expect(json_response[:data].size).to eq 8
+          expect(json_response[:data].map { |d| d.dig(:relationships, :publication, :data, :type) }.count('project')).to eq 8
         end
       end
 


### PR DESCRIPTION
[CL-2048](https://citizenlab.atlassian.net/browse/CL-2048) add projects only filter

Manually tested with Postman, as well as the test added in this PR.
