### PR TITLE
[CL-2052] Handle nil omniauth.params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Fixed
+
+- [CL-2052] Fix Sentry error related to failed authentication
+
 ## 2022-11-16
 
 ### Fixed

--- a/back/app/controllers/omniauth_callback_controller.rb
+++ b/back/app/controllers/omniauth_callback_controller.rb
@@ -122,7 +122,7 @@ class OmniauthCallbackController < ApplicationController
   end
 
   def failure_redirect(params = {})
-    redirect_params = request.env['omniauth.params'].with_indifferent_access.merge(params)
+    redirect_params = (request.env['omniauth.params'] || {}).with_indifferent_access.merge(params)
     redirect_to(add_uri_params(Frontend::UrlService.new.signin_failure_url, redirect_params))
   end
 

--- a/back/spec/acceptance/omniauth_callback_spec.rb
+++ b/back/spec/acceptance/omniauth_callback_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rspec_api_documentation/dsl'
+
+resource 'Omniauth Callback', document: false do
+  before { header 'Content-Type', 'application/json' }
+
+  post '/auth/failure' do
+    example_request 'Redirect to failure URL' do
+      expect(status).to eq(302)
+      expect(response_headers['Location']).to include('/authentication-error')
+    end
+  end
+end


### PR DESCRIPTION
Not sure why, but sometimes request.env['omniauth.params'] is nil https://sentry.hq.citizenlab.co/organizations/citizenlab/issues/68343/?project=2&query=is%3Aunresolved

and so it raised

NoMethodError OmniauthCallbackController#failure
undefined method `with_indifferent_access' for nil:NilClass

app/controllers/omniauth_callback_controller.rb in failure_redirect at line 125 
app/controllers/omniauth_callback_controller.rb in failure at line 23
