### PR TITLE
[No ticket] Fix styling regression in Auth consent message

### DIFF
--- a/front/app/components/SignUpIn/SignUp/Consent.tsx
+++ b/front/app/components/SignUpIn/SignUp/Consent.tsx
@@ -5,7 +5,7 @@ import Link from 'utils/cl-router/Link';
 import Checkbox from 'components/UI/Checkbox';
 import Error from 'components/UI/Error';
 import { AuthProvider } from '../AuthProviders';
-import { Box, Text } from '@citizenlab/cl2-component-library';
+import { Box } from '@citizenlab/cl2-component-library';
 
 // i18n
 import { WrappedComponentProps } from 'react-intl';
@@ -23,11 +23,11 @@ const Container = styled.div`
   align-items: stretch;
 `;
 
-const ConsentText = styled(Text)`
+const ConsentText = styled.div`
   color: ${(props: any) => props.theme.colors.tenantText};
   font-size: ${fontSizes.s}px;
   line-height: 21px;
-  font-weight: ${(props: any) => props.fontWeight || 300};
+  font-weight: ${(props: any) => props.fontWeight};
   overflow-wrap: break-word;
   word-wrap: break-word;
   word-break: break-word;
@@ -45,6 +45,10 @@ const ConsentText = styled(Text)`
       text-decoration: underline;
     }
   }
+`;
+
+const BoldConsentText = styled(ConsentText)`
+  font-weight: bold;
 `;
 
 interface Props {
@@ -95,7 +99,7 @@ const Consent = memo(
             <FormattedMessage {...messages.viennaConsentFooter} />
           </ConsentText>
 
-          <ConsentText fontWeight="bold">
+          <BoldConsentText>
             <FormattedMessage
               {...messages.iHaveReadAndAgreeToVienna}
               values={{
@@ -106,7 +110,7 @@ const Consent = memo(
                 ),
               }}
             />
-          </ConsentText>
+          </BoldConsentText>
         </Container>
       );
     } else {


### PR DESCRIPTION
This fixes a regression I accidentally introduced. Iva was suggesting to make the ConsentText inherit from the `Text` component, but that completely breaks the layout. So I revert that change.


Broken

![image](https://user-images.githubusercontent.com/866318/202693885-6b654886-8f99-4d71-b18e-a98450dfe91e.png)


Fixed

![image](https://user-images.githubusercontent.com/866318/202693806-caa024c2-05b5-4758-bf43-0a75791df0c2.png)
