### PR TITLE
[CL-1959] BulkDeleteUsersJob - Batch not found user emails into one Sentry error

### DIFF
--- a/back/engines/commercial/admin_api/app/jobs/admin_api/bulk_delete_users_job.rb
+++ b/back/engines/commercial/admin_api/app/jobs/admin_api/bulk_delete_users_job.rb
@@ -2,11 +2,23 @@
 
 class AdminApi::BulkDeleteUsersJob < ApplicationJob
   def run(emails)
+    emails_of_not_found_users = []
+
     emails.each do |email|
-      ErrorReporter.handle do
-        user = User.find_by_cimail(email) || raise("No user with email #{email} found")
+      user = User.find_by_cimail(email)
+
+      if user
         DeleteUserJob.perform_later(user)
+      else
+        emails_of_not_found_users << email
       end
+    end
+
+    if emails_of_not_found_users.count.positive?
+      ErrorReporter.report_msg(
+        'One or more users not found with given email(s). See extra for email(s).',
+        extra: { 'emails_of_not_found_users': emails_of_not_found_users.to_s }
+      )
     end
   end
 end

--- a/back/engines/commercial/admin_api/app/jobs/admin_api/bulk_delete_users_job.rb
+++ b/back/engines/commercial/admin_api/app/jobs/admin_api/bulk_delete_users_job.rb
@@ -14,11 +14,11 @@ class AdminApi::BulkDeleteUsersJob < ApplicationJob
       end
     end
 
-    if emails_of_not_found_users.count.positive?
-      ErrorReporter.report_msg(
-        'One or more users not found with given email(s). See extra for email(s).',
-        extra: { 'emails_of_not_found_users': emails_of_not_found_users.to_s }
-      )
-    end
+    return unless emails_of_not_found_users.count.positive?
+
+    ErrorReporter.report_msg(
+      'One or more users not found with given email(s). See additional data for email(s).',
+      extra: { emails_of_not_found_users: emails_of_not_found_users.to_s }
+    )
   end
 end

--- a/back/engines/commercial/admin_api/spec/acceptance/users_spec.rb
+++ b/back/engines/commercial/admin_api/spec/acceptance/users_spec.rb
@@ -55,7 +55,7 @@ resource 'User', admin_api: true do
 
     before do
       expect(DeleteUserJob).to receive(:perform_later).with(user).once
-      expect(Sentry).to receive(:capture_exception).once
+      expect(Sentry).to receive(:capture_message).once
     end
 
     example_request 'Delete users by emails' do


### PR DESCRIPTION
This seems to work (in that it sends the correct Sentry error to the local Sentry app, but also seems to raise an errors related to Sentry in the logs (see below):

<img width="2350" alt="Screenshot 2022-11-21 at 15 14 40" src="https://user-images.githubusercontent.com/3944042/203092987-a4386661-3599-42aa-ad78-94cb02aee0af.png">
<img width="1066" alt="Screenshot 2022-11-21 at 15 14 58" src="https://user-images.githubusercontent.com/3944042/203093006-18e0a212-7bf1-45fc-9d9b-1233c0fb3014.png">

Error in Rails log (nothing similar seen with original Sentry error this replaces):
```Ruby
cl-que         | 2022-11-21 15:13:24.320064 E [1:worker-1 logging_helper.rb:9] Rails -- sentry -- Event sending failed: the server responded with status 400
cl-que         | body: {"detail":"invalid event envelope","causes":["invalid item header","unknown variant `client_report`, expected one of `event`, `transaction`, `security`, `attachment`, `form_data`, `raw_security`, `unreal_report`, `user_report`, `session`, `sessions`, `metrics`, `metric_buckets` at line 2 column 23"]}
cl-que         | 2022-11-21 15:13:24.321148 I [1:worker-1] Rails -- sentry -- Unreported Event: One or more users not found with given email(s). See extra for email(s).
cl-que         | 2022-11-21 15:13:24.321274 E [1:worker-1 logging_helper.rb:9] Rails -- sentry -- exception happened in background worker: the server responded with status 400
cl-que         | body: {"detail":"invalid event envelope","causes":["invalid item header","unknown variant `client_report`, expected one of `event`, `transaction`, `security`, `attachment`, `form_data`, `raw_security`, `unreal_report`, `user_report`, `session`, `sessions`, `metrics`, `metric_buckets` at line 2 column 23"]}
```