### PR TITLE
[CL-2103] Fixed flaky test - Ensured consistent order

### DIFF
--- a/back/spec/acceptance/projects_allowed_input_topics_spec.rb
+++ b/back/spec/acceptance/projects_allowed_input_topics_spec.rb
@@ -79,7 +79,7 @@ resource 'ProjectsAllowedInputTopics' do
       end
 
       let(:project) { create(:project, allowed_input_topics: create_list(:topic, 3)) }
-      let(:id) { project.projects_allowed_input_topics[1].id }
+      let(:id) { project.projects_allowed_input_topics.order(:ordering).last.id }
       let(:ordering) { 0 }
 
       example_request 'Reorder a project allowed input topic' do


### PR DESCRIPTION
Test was flaky because the ordering of the allowed topics assigned to the project was not always consistent, allowing us to test reordering to zero of a topic that already had an ordering of zero - this returns an error from the API because nothing is updated. Added consistent ordering to ensure this never happens.