### PR TITLE
[CL-2114] Use medium resource_class for back-lint CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
           docker push citizenlabdotco/back-essential:$CIRCLE_SHA1
 
   back-lint:
-    resource_class: small
+    resource_class: medium
     executor:
       name: cl2-back
       image-tag: $CIRCLE_SHA1


### PR DESCRIPTION
I couldn't see any `back-lint` failures on `citizenlab_ee`, so I didn't change the `resource_class` there.