### PR TITLE
[NA] Fill in required-settings and features before create

### DIFF
--- a/back/app/models/app_configuration.rb
+++ b/back/app/models/app_configuration.rb
@@ -39,6 +39,7 @@ class AppConfiguration < ApplicationRecord
   validate :validate_singleton, on: :create
 
   before_validation :validate_missing_feature_dependencies
+  before_validation :add_missing_features_and_settings, on: :create
 
   after_update do
     AppConfiguration.instance.reload
@@ -116,6 +117,13 @@ class AppConfiguration < ApplicationRecord
     self.settings = ss.add_missing_features(settings, schema)
     self.settings = ss.add_missing_settings(settings, schema)
     self
+  end
+
+  def add_missing_features_and_settings
+    ss = SettingsService.new
+    schema = Settings.json_schema
+    self.settings = ss.add_missing_features(settings, schema)
+    self.settings = ss.add_missing_settings(settings, schema)
   end
 
   def feature_activated?(setting_name)

--- a/back/app/models/app_configuration.rb
+++ b/back/app/models/app_configuration.rb
@@ -39,7 +39,7 @@ class AppConfiguration < ApplicationRecord
   validate :validate_singleton, on: :create
 
   before_validation :validate_missing_feature_dependencies
-  before_validation :add_missing_features_and_settings, on: :create
+  before_validation :add_missing_settings, on: :create
 
   after_update do
     AppConfiguration.instance.reload
@@ -119,10 +119,9 @@ class AppConfiguration < ApplicationRecord
     self
   end
 
-  def add_missing_features_and_settings
+  def add_missing_settings
     ss = SettingsService.new
     schema = Settings.json_schema
-    self.settings = ss.add_missing_features(settings, schema)
     self.settings = ss.add_missing_settings(settings, schema)
   end
 


### PR DESCRIPTION
If you add a new item of required-settings or a new feature,
you don't need to update seeds anymore for it to work.

E.g., I need it for this PR https://github.com/CitizenLabDotCo/citizenlab/pull/3272/files#diff-15e4a4715537af6fcdb25e57aa88b86230d98f1ba31e65a8bd41baa2d2070ef4R245