### PR TITLE
Upgrade dalli due to failing `bundle-audit check`

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -156,7 +156,7 @@ gem 'ice_cube', github: 'CitizenLabDotCo/ice_cube'
 # exception.
 gem 'aws-sdk-s3', '~> 1'
 gem 'bootsnap', '~> 1', require: false
-gem 'dalli', '~> 2.7'
+gem 'dalli', '~> 3.2.3'
 gem 'mailgun-ruby', '~>1.2.0'
 gem 'rails_semantic_logger'
 gem 'rinku', '~> 2'

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -618,7 +618,7 @@ GEM
       qonfig (~> 0.24)
     css_parser (1.11.0)
       addressable
-    dalli (2.7.11)
+    dalli (3.2.3)
     database_cleaner (2.0.1)
       database_cleaner-active_record (~> 2.0.0)
     database_cleaner-active_record (2.0.1)
@@ -1201,7 +1201,7 @@ DEPENDENCIES
   custom_maps!
   custom_topics!
   customizable_navbar!
-  dalli (~> 2.7)
+  dalli (~> 3.2.3)
   database_cleaner (~> 2.0.1)
   email_campaigns!
   factory_bot_rails


### PR DESCRIPTION
It seems we're not affected by the breaking changes https://github.com/petergoldstein/dalli/blob/main/CHANGELOG.md

https://github.com/petergoldstein/dalli/issues/932 

https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/70922/workflows/16c44c8a-c645-40dc-9729-1e7d4e731260/jobs/156153

Tested with this command `Rails.cache.fetch('1231', expires_in: 3.seconds) { sleep 1; 123 }`