### PR TITLE
[CL-1961] Handle Bad language pair error from EasyTranslate

### DIFF
--- a/back/engines/commercial/machine_translations/app/controllers/machine_translations/web_api/v1/machine_translations_controller.rb
+++ b/back/engines/commercial/machine_translations/app/controllers/machine_translations/web_api/v1/machine_translations_controller.rb
@@ -44,6 +44,12 @@ module MachineTranslations
 
               render json: { errors: { base: [{ error: 'translatable_blank' }] } }, status: :unprocessable_entity
               return
+            rescue EasyTranslate::EasyTranslateException => e
+              raise e unless e.message.include?('Bad language pair')
+
+              render json: { errors: { base: [{ error: 'bad_language_pair' }] } }, status: :unprocessable_entity
+              skip_authorization
+              return
             end
             unless @translation.save
               render json: { errors: @translation.errors.details }, status: :unprocessable_entity

--- a/back/engines/commercial/machine_translations/app/services/machine_translations/machine_translation_service.rb
+++ b/back/engines/commercial/machine_translations/app/services/machine_translations/machine_translation_service.rb
@@ -46,8 +46,6 @@ module MachineTranslations
         translation = EasyTranslate.translate text_or_html, from: from, to: to
         break
       rescue EasyTranslate::EasyTranslateException => e
-        raise e if e.message.include?('Bad language pair')
-
         exception = e
         sleep rand(max_sleep + 1) if i < retries
       end

--- a/back/engines/commercial/machine_translations/app/services/machine_translations/machine_translation_service.rb
+++ b/back/engines/commercial/machine_translations/app/services/machine_translations/machine_translation_service.rb
@@ -46,6 +46,8 @@ module MachineTranslations
         translation = EasyTranslate.translate text_or_html, from: from, to: to
         break
       rescue EasyTranslate::EasyTranslateException => e
+        raise e if e.message.include?('Bad language pair')
+
         exception = e
         sleep rand(max_sleep + 1) if i < retries
       end


### PR DESCRIPTION
This simply handles the error and provides a 422 response with a useful error message included. This prevents the Sentry error.

We should also log a FE ticket to either hide the 'Translate' button or grey it out and add a suitable message, etc.