### PR TITLE
Add custom error handling for content builder layout

### DIFF
--- a/front/app/modules/commercial/content_builder/services/contentBuilder.ts
+++ b/front/app/modules/commercial/content_builder/services/contentBuilder.ts
@@ -2,6 +2,7 @@ import { SerializedNode } from '@craftjs/core';
 import { API_PATH } from 'containers/App/constants';
 import { Locale } from 'typings';
 import streams from 'utils/streams';
+import { reportError } from 'utils/loggingUtils';
 
 export const PROJECT_DESCRIPTION_CODE = 'project_description';
 
@@ -31,6 +32,12 @@ export interface IContentBuilderLayoutObject {
 export function contentBuilderLayoutStream({ projectId, code }) {
   return streams.get<IContentBuilderLayout>({
     apiEndpoint: `${API_PATH}/projects/${projectId}/content_builder_layouts/${code}`,
+    handleErrorLogging: (error) => {
+      // A 404 error is expected when the content builder layout is not found so we don't want to log it
+      if (error.statusCode !== 404) {
+        reportError(error);
+      }
+    },
   });
 }
 

--- a/front/app/utils/request.ts
+++ b/front/app/utils/request.ts
@@ -4,6 +4,7 @@ import { getJwt } from 'utils/auth/jwt';
 import { isString } from 'lodash-es';
 import { IHttpMethod } from 'typings';
 import { IObject } from 'utils/streams';
+import { RequestError } from 'utils/requestError';
 
 export default function request<T>(
   url: string,
@@ -53,7 +54,10 @@ export default function request<T>(
       const errorMessage = isString(json?.error)
         ? json.error
         : response.statusText || 'unknown error';
-      const error = new Error(`error for ${urlWithParams}: ${errorMessage}`);
+      const error = new RequestError(
+        `error for ${urlWithParams}: ${errorMessage}`
+      );
+      error.statusCode = response.status;
       if (json) {
         // The error reasons may be encoded in the
         // json content (this happens e.g. for

--- a/front/app/utils/requestError.ts
+++ b/front/app/utils/requestError.ts
@@ -1,0 +1,10 @@
+export class RequestError extends Error {
+  statusCode?: number;
+
+  constructor(message: string) {
+    super(message);
+
+    // 👇️ because we are extending a built-in class
+    Object.setPrototypeOf(this, RequestError.prototype);
+  }
+}

--- a/front/app/utils/streams/index.ts
+++ b/front/app/utils/streams/index.ts
@@ -27,6 +27,7 @@ import {
 } from 'lodash-es';
 import request from 'utils/request';
 import { reportError } from 'utils/loggingUtils';
+import { RequestError } from 'utils/requestError';
 import {
   deepFreeze,
   sanitizeQueryParameters,
@@ -62,6 +63,7 @@ export interface IStreamParams {
 
 export interface IInputStreamParams extends Omit<IStreamParams, 'bodyData'> {
   apiEndpoint: string;
+  handleErrorLogging?(error: RequestError): void;
 }
 
 interface IExtendedStreamParams {
@@ -351,6 +353,7 @@ class Streams {
       ...inputParams,
     };
     const apiEndpoint = removeTrailingSlash(params.apiEndpoint);
+    const logError = inputParams.handleErrorLogging ?? reportError;
 
     const queryParameters = sanitizeQueryParameters(
       params.queryParameters,
@@ -432,7 +435,7 @@ class Streams {
             this.streams[streamId].observer.next(error);
             // destroy the stream
             this.deleteStream(streamId, apiEndpoint);
-            reportError(error);
+            logError(error);
           } else if (streamId === authApiEndpoint) {
             this.streams[streamId].observer.next(null);
           }

--- a/front/app/utils/streams/index.ts
+++ b/front/app/utils/streams/index.ts
@@ -874,7 +874,10 @@ class Streams {
     }
 
     uniq(mergedStreamIds).forEach((streamId) => {
-      if (!onlyFetchActiveStreams || this.isActiveStream(streamId)) {
+      if (
+        (!onlyFetchActiveStreams || this.isActiveStream(streamId)) &&
+        this.streams[streamId]
+      ) {
         promises.push(this.streams[streamId].fetch());
       }
     });

--- a/front/app/utils/streams/streams.test.ts
+++ b/front/app/utils/streams/streams.test.ts
@@ -162,6 +162,19 @@ describe('streams.get', () => {
       expect(request).toHaveBeenCalledTimes(2);
     });
   });
+
+  it('calls a custom log function when one is passed through', async () => {
+    const log = jest.fn();
+    request.mockRejectedValueOnce(new Error('Async error'));
+
+    streams.get({
+      apiEndpoint: '/web_api/v1/error',
+      handleErrorLogging: (error) => {
+        log(error);
+        expect(log).toHaveBeenCalledTimes(1);
+      },
+    });
+  });
 });
 
 describe('streams.reset', () => {


### PR DESCRIPTION
This makes sure that a 404 isn't logged to Sentry when trying to get the content builder layout since a 404 is the expected behaviour. I also added a way for other services to provide their own custom logic and defaulting to the normal logging

## How urgent is a code review?

End of day if possible
