### PR TITLE
[CL-2102] Remove customizable_navbar module from OS config

### DIFF
--- a/citizenlab.config.json
+++ b/citizenlab.config.json
@@ -6,7 +6,6 @@
   ],
   "modules": {
     "free/email_campaigns": true,
-    "free/customizable_navbar": true,
     "free/frontend": true,
     "free/onboarding": true,
     "free/polls": true,


### PR DESCRIPTION
Any rails command fails with `Could not find gem 'customizable_navbar' in source at engines/free/customizable_navbar.` for me.