### PR TITLE
Cl 2057 changes brent

### DIFF
--- a/front/app/components/HookForm/SlugInput/index.tsx
+++ b/front/app/components/HookForm/SlugInput/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Input from 'components/HookForm/Input';
 import messages from './messages';
 import { FormattedMessage } from 'utils/cl-intl';
-import { Box, Text } from '@citizenlab/cl2-component-library';
+import { Text } from '@citizenlab/cl2-component-library';
 import Warning from 'components/UI/Warning';
 import { isNilOrError } from 'utils/helperUtils';
 import useLocale from 'hooks/useLocale';
@@ -36,18 +36,16 @@ const SlugInput = ({
           name="slug"
           type="text"
         />
-        <Text>
-          <b>
+        <Text mb={showWarningMessage ? '16px' : '0'}>
+          <i>
             <FormattedMessage {...messages.resultingPageURL} />
-          </b>
+          </i>
           : {previewUrl}
         </Text>
         {showWarningMessage && (
-          <Box mb="16px">
-            <Warning>
-              <FormattedMessage {...messages.brokenURLWarning} />
-            </Warning>
-          </Box>
+          <Warning>
+            <FormattedMessage {...messages.brokenURLWarning} />
+          </Warning>
         )}
       </>
     );

--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/CustomPageSettingsForm/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/CustomPageSettingsForm/index.tsx
@@ -68,6 +68,8 @@ const projectsFilterTypesArray: ProjectsFilterTypes[] = [
   'areas',
 ];
 
+const fieldMarginBottom = '40px';
+
 const CustomPageSettingsForm = ({
   showNavBarItemTitle,
   intl: { formatMessage },
@@ -186,7 +188,7 @@ const CustomPageSettingsForm = ({
                   : formatMessage(messages.messageCreatedSuccess)
               }
             />
-            <Box mb="30px">
+            <Box mb={fieldMarginBottom}>
               <InputMultilocWithLocaleSwitcher
                 name="title_multiloc"
                 label={formatMessage(messages.titleLabel)}
@@ -194,7 +196,7 @@ const CustomPageSettingsForm = ({
               />
             </Box>
             {showNavBarItemTitle && (
-              <Box mb="30px">
+              <Box mb={fieldMarginBottom}>
                 <InputMultilocWithLocaleSwitcher
                   label={formatMessage(messages.navbarItemTitle)}
                   type="text"
@@ -203,14 +205,17 @@ const CustomPageSettingsForm = ({
               </Box>
             )}
             {mode === 'edit' && (
-              <SlugInput
-                slug={slug}
-                pathnameWithoutSlug="pages"
-                showWarningMessage={slugHasChanged}
-              />
+              <Box mb={fieldMarginBottom}>
+                <SlugInput
+                  slug={slug}
+                  pathnameWithoutSlug="pages"
+                  showWarningMessage={slugHasChanged}
+                />
+              </Box>
             )}
+
             {advancedCustomPagesEnabled && (
-              <Box>
+              <Box mb={fieldMarginBottom}>
                 <Box display="flex" justifyContent="flex-start">
                   <Label>
                     <span>{formatMessage(messages.linkedProjectsLabel)}</span>


### PR DESCRIPTION
Added larger margins between the different fields and changed the bold 'Resulting URL' to an italic version so it grabs less attention. The area where Page URL and Linked projects fields come together was too cluttered and I didn't know where to look first. 

### Before
<img width="590" alt="Screenshot 2022-11-30 at 10 20 43" src="https://user-images.githubusercontent.com/16427929/204757218-50fee42b-2bf7-4af2-8812-35a9368b94ae.png">

### After
<img width="604" alt="Screenshot 2022-11-30 at 10 16 13" src="https://user-images.githubusercontent.com/16427929/204757246-96b3c498-256f-4c68-996d-ab5014b5a202.png">

cc @benfraserdesign LMK if you have objections.