### PR TITLE
[CL-2174] Add test of recipients for ProjectPhaseUpcoming Notifications

### DIFF
--- a/back/spec/models/notification_spec.rb
+++ b/back/spec/models/notification_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe Notification, type: :model do
       let!(:admin) { create(:admin) }
 
       it 'notifies all admins and only relevant moderators' do
-        activity = create :activity, item: project.phases[2], action: 'upcoming'
+        activity = create(:activity, item: project.phases[2], action: 'upcoming')
         notifications = Notifications::ProjectPhaseUpcoming.make_notifications_on activity
         notification_ids = notifications.pluck(:recipient_id)
 

--- a/back/spec/models/notifications/project_phase_upcoming_spec.rb
+++ b/back/spec/models/notifications/project_phase_upcoming_spec.rb
@@ -30,14 +30,14 @@ RSpec.describe Notifications::ProjectPhaseUpcoming, type: :model do
       moderator_of_other_project_folder = create(:project_folder_moderator, project_folders: [other_project_folder])
 
       notifications = described_class.make_notifications_on activity
-      notification_ids = notifications.pluck(:recipient_id)
+      recipient_ids = notifications.pluck(:recipient_id)
 
-      expect(notification_ids).to include moderator_of_project.id
-      expect(notification_ids).to include moderator_of_project_folder.id
-      expect(notification_ids).to include admin.id
-      expect(notification_ids).not_to include regular_user.id
-      expect(notification_ids).not_to include moderator_of_other_project.id
-      expect(notification_ids).not_to include moderator_of_other_project_folder.id
+      expect(recipient_ids).to include moderator_of_project.id
+      expect(recipient_ids).to include moderator_of_project_folder.id
+      expect(recipient_ids).to include admin.id
+      expect(recipient_ids).not_to include regular_user.id
+      expect(recipient_ids).not_to include moderator_of_other_project.id
+      expect(recipient_ids).not_to include moderator_of_other_project_folder.id
     end
   end
 end

--- a/back/spec/models/notifications/project_phase_upcoming_spec.rb
+++ b/back/spec/models/notifications/project_phase_upcoming_spec.rb
@@ -4,17 +4,40 @@ require 'rails_helper'
 
 RSpec.describe Notifications::ProjectPhaseUpcoming, type: :model do
   describe 'make_notifications_on' do
-    it 'makes a notification on created comment activity' do
-      admin = create :admin
-      phase = create :phase
-      activity = create :activity, item: phase, action: 'upcoming'
+    let!(:admin) { create :admin }
+    let!(:phase) { create :phase }
+    let!(:activity) { create :activity, item: phase, action: 'upcoming' }
 
+    it 'makes a notification on created comment activity' do
       notifications = described_class.make_notifications_on activity
       expect(notifications.first).to have_attributes(
         recipient_id: admin.id,
         phase_id: phase.id,
         project_id: phase.project_id
       )
+    end
+
+    it 'only notifies admins and moderators who can moderate project' do
+      project = create(:project_with_current_phase, phases: [phase])
+      other_project = create(:project_with_current_phase)
+      project_folder = create(:project_folder, projects: [project])
+      other_project_folder = create(:project_folder, projects: [other_project])
+
+      regular_user = create(:user)
+      moderator_of_project = create(:project_moderator, projects: [project])
+      moderator_of_other_project = create(:project_moderator, projects: [other_project])
+      moderator_of_project_folder = create(:project_folder_moderator, project_folders: [project_folder])
+      moderator_of_other_project_folder = create(:project_folder_moderator, project_folders: [other_project_folder])
+
+      notifications = described_class.make_notifications_on activity
+      notification_ids = notifications.pluck(:recipient_id)
+
+      expect(notification_ids).to include moderator_of_project.id
+      expect(notification_ids).to include moderator_of_project_folder.id
+      expect(notification_ids).to include admin.id
+      expect(notification_ids).not_to include regular_user.id
+      expect(notification_ids).not_to include moderator_of_other_project.id
+      expect(notification_ids).not_to include moderator_of_other_project_folder.id
     end
   end
 end


### PR DESCRIPTION
Simply adds a test of the current filtering of recipients for this `Notification` (and of the mail campaign that such notifications will trigger).
