### PR TITLE
CL-2184 Fix project status stats card

### DIFF
--- a/back/db/migrate/20221202110054_update_fact_project_statuses_view.analytics.rb
+++ b/back/db/migrate/20221202110054_update_fact_project_statuses_view.analytics.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # This migration comes from analytics (originally 20221202105918)
 
 class UpdateFactProjectStatusesView < ActiveRecord::Migration[6.1]

--- a/back/db/migrate/20221202110054_update_fact_project_statuses_view.analytics.rb
+++ b/back/db/migrate/20221202110054_update_fact_project_statuses_view.analytics.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# This migration comes from analytics (originally 20221202105918)
+
+class UpdateFactProjectStatusesView < ActiveRecord::Migration[6.1]
+  def change
+    update_view :analytics_fact_project_statuses, version: 2, revert_to_version: 1
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_10_105544) do
+ActiveRecord::Schema.define(version: 2022_12_02_110054) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -1733,6 +1733,14 @@ ActiveRecord::Schema.define(version: 2022_11_10_105544) do
       users.invite_status
      FROM users;
   SQL
+  create_view "analytics_fact_events", sql_definition: <<-SQL
+      SELECT events.id,
+      events.project_id AS dimension_project_id,
+      (events.created_at)::date AS dimension_date_created_id,
+      (events.start_at)::date AS dimension_date_start_id,
+      (events.end_at)::date AS dimension_date_end_id
+     FROM events;
+  SQL
   create_view "analytics_fact_project_statuses", sql_definition: <<-SQL
       WITH last_project_statuses AS (
            SELECT DISTINCT ON (activities.item_id) activities.item_id AS project_id,
@@ -1772,20 +1780,24 @@ ActiveRecord::Schema.define(version: 2022_11_10_105544) do
               finished_statuses_for_continuous_projects.status,
               finished_statuses_for_continuous_projects."timestamp"
              FROM finished_statuses_for_continuous_projects
+          ), all_finished_projects AS (
+           SELECT DISTINCT afp_1.project_id
+             FROM ( SELECT finished_statuses_for_timeline_projects.project_id
+                     FROM finished_statuses_for_timeline_projects
+                  UNION
+                   SELECT finished_statuses_for_continuous_projects.project_id
+                     FROM finished_statuses_for_continuous_projects) afp_1
           )
-   SELECT project_statuses.project_id AS dimension_project_id,
-      project_statuses.status,
-      project_statuses."timestamp",
-      (project_statuses."timestamp")::date AS dimension_date_id
-     FROM project_statuses
-    ORDER BY project_statuses."timestamp" DESC;
-  SQL
-  create_view "analytics_fact_events", sql_definition: <<-SQL
-      SELECT events.id,
-      events.project_id AS dimension_project_id,
-      (events.created_at)::date AS dimension_date_created_id,
-      (events.start_at)::date AS dimension_date_start_id,
-      (events.end_at)::date AS dimension_date_end_id
-     FROM events;
+   SELECT ps.project_id AS dimension_project_id,
+      ps.status,
+          CASE
+              WHEN (afp.project_id IS NULL) THEN false
+              ELSE true
+          END AS finished,
+      ps."timestamp",
+      (ps."timestamp")::date AS dimension_date_id
+     FROM (project_statuses ps
+       LEFT JOIN all_finished_projects afp ON ((afp.project_id = ps.project_id)))
+    ORDER BY ps."timestamp" DESC;
   SQL
 end

--- a/back/db/views/analytics_fact_project_statuses_v02.sql
+++ b/back/db/views/analytics_fact_project_statuses_v02.sql
@@ -1,0 +1,54 @@
+-- This view lists the last statuses of each project.
+
+-- All statuses, except 'finished', are sourced directly from the 'activities' table.
+-- The view has one record for each project with one of those "regular" statuses. The
+-- finished on the other hand is computed based on some application logic and does not
+-- correspond to any status used in activities or admin publications. The finished
+-- status comes in addition to the regular status. Thus, the view has two records for
+-- finished projects.
+-- The additional 'finished' column is added to enable querying of projects that
+-- are currently published.
+
+WITH last_project_statuses AS -- project statuses that do not need to be calculated
+         (SELECT DISTINCT ON (item_id) item_id as project_id, action as status, acted_at as timestamp
+FROM activities
+WHERE item_type = 'Project'
+  AND action IN ('draft', 'published', 'archived', 'deleted')
+ORDER BY item_id, acted_at DESC),
+
+    finished_statuses_for_continuous_projects AS
+    (SELECT project_id, 'finished' as status, timestamp
+FROM last_project_statuses lps JOIN projects p ON lps.project_id = p.id
+where p.process_type = 'continuous' AND lps.status = 'archived'),
+
+    finished_statuses_for_timeline_projects AS
+-- The project is considered finished at the beginning of the day following the end
+-- date of the last phase.
+    (SELECT phases.project_id, 'finished' as status, (MAX(phases.end_at) + 1)::timestamp as timestamp
+FROM phases JOIN projects ON phases.project_id = projects.id
+WHERE projects.process_type != 'draft' -- a project cannot be finished if it's a draft
+GROUP BY phases.project_id
+HAVING MAX(phases.end_at) < NOW()),
+
+    project_statuses AS (
+SELECT * FROM last_project_statuses
+UNION
+SELECT * FROM finished_statuses_for_timeline_projects
+UNION
+SELECT * FROM finished_statuses_for_continuous_projects
+    ),
+
+    all_finished_projects AS (SELECT DISTINCT project_id FROM(
+    SELECT project_id FROM finished_statuses_for_timeline_projects
+    UNION
+    SELECT project_id FROM finished_statuses_for_continuous_projects
+    ) afp)
+
+SELECT ps.project_id as dimension_project_id,
+       status,
+       CASE WHEN afp.project_id IS NULL THEN false ELSE true END AS finished,
+    timestamp,
+    timestamp::DATE as dimension_date_id
+FROM project_statuses ps
+    LEFT JOIN all_finished_projects afp ON afp.project_id = ps.project_id
+ORDER BY timestamp DESC;

--- a/back/engines/commercial/analytics/app/models/analytics/fact_project_status.rb
+++ b/back/engines/commercial/analytics/app/models/analytics/fact_project_status.rb
@@ -6,6 +6,7 @@
 #
 #  dimension_project_id :uuid
 #  status               :string
+#  finished             :boolean
 #  timestamp            :datetime
 #  dimension_date_id    :date
 #

--- a/back/engines/commercial/analytics/db/migrate/20221202105918_update_fact_project_statuses_view.rb
+++ b/back/engines/commercial/analytics/db/migrate/20221202105918_update_fact_project_statuses_view.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class UpdateFactProjectStatusesView < ActiveRecord::Migration[6.1]
+  def change
+    update_view :analytics_fact_project_statuses, version: 2, revert_to_version: 1
+  end
+end

--- a/back/engines/commercial/analytics/db/views/analytics_fact_project_statuses_v02.sql
+++ b/back/engines/commercial/analytics/db/views/analytics_fact_project_statuses_v02.sql
@@ -1,0 +1,54 @@
+-- This view lists the last statuses of each project.
+
+-- All statuses, except 'finished', are sourced directly from the 'activities' table.
+-- The view has one record for each project with one of those "regular" statuses. The
+-- finished on the other hand is computed based on some application logic and does not
+-- correspond to any status used in activities or admin publications. The finished
+-- status comes in addition to the regular status. Thus, the view has two records for
+-- finished projects.
+-- The additional 'finished' column is added to enable querying of projects that
+-- are currently published.
+
+WITH last_project_statuses AS -- project statuses that do not need to be calculated
+         (SELECT DISTINCT ON (item_id) item_id as project_id, action as status, acted_at as timestamp
+FROM activities
+WHERE item_type = 'Project'
+  AND action IN ('draft', 'published', 'archived', 'deleted')
+ORDER BY item_id, acted_at DESC),
+
+    finished_statuses_for_continuous_projects AS
+    (SELECT project_id, 'finished' as status, timestamp
+FROM last_project_statuses lps JOIN projects p ON lps.project_id = p.id
+where p.process_type = 'continuous' AND lps.status = 'archived'),
+
+    finished_statuses_for_timeline_projects AS
+-- The project is considered finished at the beginning of the day following the end
+-- date of the last phase.
+    (SELECT phases.project_id, 'finished' as status, (MAX(phases.end_at) + 1)::timestamp as timestamp
+FROM phases JOIN projects ON phases.project_id = projects.id
+WHERE projects.process_type != 'draft' -- a project cannot be finished if it's a draft
+GROUP BY phases.project_id
+HAVING MAX(phases.end_at) < NOW()),
+
+    project_statuses AS (
+SELECT * FROM last_project_statuses
+UNION
+SELECT * FROM finished_statuses_for_timeline_projects
+UNION
+SELECT * FROM finished_statuses_for_continuous_projects
+    ),
+
+    all_finished_projects AS (SELECT DISTINCT project_id FROM(
+    SELECT project_id FROM finished_statuses_for_timeline_projects
+    UNION
+    SELECT project_id FROM finished_statuses_for_continuous_projects
+    ) afp)
+
+SELECT ps.project_id as dimension_project_id,
+       status,
+       CASE WHEN afp.project_id IS NULL THEN false ELSE true END AS finished,
+    timestamp,
+    timestamp::DATE as dimension_date_id
+FROM project_statuses ps
+    LEFT JOIN all_finished_projects afp ON afp.project_id = ps.project_id
+ORDER BY timestamp DESC;

--- a/back/engines/commercial/analytics/spec/acceptance/analytics_project_statuses_spec.rb
+++ b/back/engines/commercial/analytics/spec/acceptance/analytics_project_statuses_spec.rb
@@ -87,6 +87,5 @@ resource 'Analytics - ProjectStatus' do
         { count: 0 }
       ])
     end
-
   end
 end

--- a/back/engines/commercial/analytics/spec/acceptance/analytics_project_statuses_spec.rb
+++ b/back/engines/commercial/analytics/spec/acceptance/analytics_project_statuses_spec.rb
@@ -25,7 +25,7 @@ resource 'Analytics - ProjectStatus' do
       log_status_change(continuous_p2, 'published')
       log_status_change(continuous_p2, 'archived') # continuous and archived = finished
 
-      log_status_change(timeline_project, 'published')
+      log_status_change(timeline_project, 'published') # Should have a status of published but be finished
     end
 
     example 'gets counts by project status' do
@@ -47,5 +47,46 @@ resource 'Analytics - ProjectStatus' do
         { status: 'archived', count: 1 }
       ])
     end
+
+    example 'gets published projects that are finished' do
+      do_request({
+        query: {
+          fact: 'project_status',
+          filters: {
+            status: 'published',
+            finished: true
+          },
+          aggregations: {
+            all: 'count'
+          }
+        }
+      })
+
+      assert_status 200
+      expect(response_data).to eq([
+        { count: 1 }
+      ])
+    end
+
+    example 'gets published projects that NOT finished' do
+      do_request({
+        query: {
+          fact: 'project_status',
+          filters: {
+            status: 'published',
+            finished: false
+          },
+          aggregations: {
+            all: 'count'
+          }
+        }
+      })
+
+      assert_status 200
+      expect(response_data).to eq([
+        { count: 0 }
+      ])
+    end
+
   end
 end

--- a/front/app/modules/commercial/analytics/admin/components/ProjectStatusCard/config.test.ts
+++ b/front/app/modules/commercial/analytics/admin/components/ProjectStatusCard/config.test.ts
@@ -44,11 +44,11 @@ describe('Project status card data parsing', () => {
     };
 
     const responseData = [
-      [{ count: 5 }],
-      [{ count: 4 }],
-      [{ count: 3 }],
-      [{ count: 2 }],
-      [{ count: 1 }],
+      [{ count_dimension_project_id: 5 }],
+      [{ count_dimension_project_id: 4 }],
+      [{ count_dimension_project_id: 3 }],
+      [{ count_dimension_project_id: 2 }],
+      [{ count_dimension_project_id: 1 }],
     ];
 
     const labels: ProjectStatusCardLabels = {
@@ -90,7 +90,10 @@ describe('Project status card data parsing', () => {
       ],
     };
 
-    const responseData = [[{ count: 2 }], [{ count: 1 }]];
+    const responseData = [
+      [{ count_dimension_project_id: 2 }],
+      [{ count_dimension_project_id: 1 }],
+    ];
 
     const labels: ProjectStatusCardLabels = {
       projects: 'Project status',
@@ -120,22 +123,22 @@ describe('Project status card data parsing', () => {
         {
           fact: 'project_status',
           aggregations: {
-            all: 'count',
+            dimension_project_id: 'count',
           },
         },
         {
           fact: 'project_status',
           aggregations: {
-            all: 'count',
+            dimension_project_id: 'count',
           },
           filters: {
-            status: 'active',
+            status: 'published',
           },
         },
         {
           fact: 'project_status',
           aggregations: {
-            all: 'count',
+            dimension_project_id: 'count',
           },
           filters: {
             status: 'archived',
@@ -144,7 +147,7 @@ describe('Project status card data parsing', () => {
         {
           fact: 'project_status',
           aggregations: {
-            all: 'count',
+            dimension_project_id: 'count',
           },
           filters: {
             status: 'finished',
@@ -153,7 +156,7 @@ describe('Project status card data parsing', () => {
         {
           fact: 'project_status',
           aggregations: {
-            all: 'count',
+            dimension_project_id: 'count',
           },
           filters: {
             status: 'draft',
@@ -177,7 +180,7 @@ describe('Project status card data parsing', () => {
       query: [
         {
           fact: 'project_status',
-          aggregations: { all: 'count' },
+          aggregations: { dimension_project_id: 'count' },
           filters: {
             status: 'archived',
             'dimension_date.date': { from: '2020-10-31', to: '2021-10-31' },
@@ -186,7 +189,7 @@ describe('Project status card data parsing', () => {
         },
         {
           fact: 'project_status',
-          aggregations: { all: 'count' },
+          aggregations: { dimension_project_id: 'count' },
           filters: {
             status: 'finished',
             'dimension_date.date': { from: '2020-10-31', to: '2021-10-31' },

--- a/front/app/modules/commercial/analytics/admin/components/ProjectStatusCard/config.ts
+++ b/front/app/modules/commercial/analytics/admin/components/ProjectStatusCard/config.ts
@@ -91,7 +91,7 @@ export const projectStatusConfig: StatCardConfig = {
     endAtMoment,
   }: StatCardProps): Query => {
     const queryBase = (
-      status?: 'active' | 'archived' | 'finished' | 'draft'
+      status?: 'published' | 'archived' | 'finished' | 'draft'
     ): QuerySchema => {
       const querySchema: QuerySchema = {
         fact: 'project_status',
@@ -115,7 +115,7 @@ export const projectStatusConfig: StatCardConfig = {
     };
 
     const queryTotal: QuerySchema = queryBase();
-    const queryActive: QuerySchema = queryBase('active');
+    const queryActive: QuerySchema = queryBase('published');
     const queryArchived: QuerySchema = queryBase('archived');
     const queryFinished: QuerySchema = queryBase('finished');
     const queryDraft: QuerySchema = queryBase('draft');
@@ -131,6 +131,11 @@ export const projectStatusConfig: StatCardConfig = {
     if (startAtMoment && endAtMoment) {
       returnQuery = [queryArchived, queryFinished];
     }
+    console.log(
+      JSON.stringify({
+        query: returnQuery,
+      })
+    );
     return {
       query: returnQuery,
     };

--- a/front/app/modules/commercial/analytics/admin/components/ProjectStatusCard/config.ts
+++ b/front/app/modules/commercial/analytics/admin/components/ProjectStatusCard/config.ts
@@ -56,28 +56,28 @@ export const projectStatusConfig: StatCardConfig = {
     total &&
       cardData.stats.push({
         label: labels.totalProjects,
-        value: formatCountValue(total[0].count),
+        value: formatCountValue(total[0].count_dimension_project_id),
         toolTip: labels.totalProjectsToolTip,
       });
     active &&
       cardData.stats.push({
         label: labels.active,
-        value: formatCountValue(active[0].count),
+        value: formatCountValue(active[0].count_dimension_project_id),
         toolTip: labels.activeToolTip,
       });
     cardData.stats.push({
       label: labels.archived,
-      value: formatCountValue(archived[0].count),
+      value: formatCountValue(archived[0].count_dimension_project_id),
     });
     cardData.stats.push({
       label: labels.finished,
-      value: formatCountValue(finished[0].count),
+      value: formatCountValue(finished[0].count_dimension_project_id),
       toolTip: labels.finishedToolTip,
     });
     draft &&
       cardData.stats.push({
         label: labels.draftProjects,
-        value: formatCountValue(draft[0].count),
+        value: formatCountValue(draft[0].count_dimension_project_id),
         display: 'corner',
       });
 
@@ -91,19 +91,22 @@ export const projectStatusConfig: StatCardConfig = {
     endAtMoment,
   }: StatCardProps): Query => {
     const queryBase = (
-      status?: 'published' | 'archived' | 'finished' | 'draft'
+      status?: 'published' | 'archived' | 'finished' | 'draft',
+      notFinished?: boolean
     ): QuerySchema => {
       const querySchema: QuerySchema = {
         fact: 'project_status',
         aggregations: {
-          all: 'count',
+          dimension_project_id: 'count',
         },
       };
 
       const statusFilter = status === undefined ? {} : { status };
+      const finishedFilter = notFinished ? { finished: false } : {};
 
       const filters = {
         ...statusFilter,
+        ...finishedFilter,
         ...getDateFilter(`dimension_date`, startAtMoment, endAtMoment),
         ...getProjectFilter('dimension_project', projectId),
       };
@@ -115,10 +118,10 @@ export const projectStatusConfig: StatCardConfig = {
     };
 
     const queryTotal: QuerySchema = queryBase();
-    const queryActive: QuerySchema = queryBase('published');
+    const queryActive: QuerySchema = queryBase('published', false);
     const queryArchived: QuerySchema = queryBase('archived');
     const queryFinished: QuerySchema = queryBase('finished');
-    const queryDraft: QuerySchema = queryBase('draft');
+    const queryDraft: QuerySchema = queryBase('draft', false);
 
     // Remove the total and active queries if there are start and end date filters
     let returnQuery = [
@@ -131,11 +134,6 @@ export const projectStatusConfig: StatCardConfig = {
     if (startAtMoment && endAtMoment) {
       returnQuery = [queryArchived, queryFinished];
     }
-    console.log(
-      JSON.stringify({
-        query: returnQuery,
-      })
-    );
     return {
       query: returnQuery,
     };


### PR DESCRIPTION
Have made front-end and backend changes. Key change is that because there are multiple records for finished projects, we have to make sure we're counting dimension_project_ids and not all on the front end. Also on the backend I've added a column so to get the currently published projects we can ignore any published statuses that have subsequently been finished.

Think there may be further work in the future as I'm not totally happy with the solution, but I think this fixes it for now.