### PR TITLE
CL-1980

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
   back-lint:
     resource_class: medium
     executor:
-      name: back-essential
+      name: back-ee
       image-tag: $CIRCLE_SHA1
     working_directory: /cl2_back
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,24 @@ executors:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
 
+  back-ee:
+    parameters:
+      image-tag:
+        type: string
+    docker:
+      - image: citizenlabdotco/back-ee:<< parameters.image-tag >>
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+        environment:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_HOST: localhost
+      - image: 'postgis/postgis:12-3.1'
+        environment:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+
 commands:
   wait-for-postgres:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ parameters:
     default: false
 
 executors:
-  cl2-back: # TODO rename to  or back-essential or back-os (avoid citizenlab name)
+  back-essential:
     parameters:
       image-tag:
         type: string
@@ -87,7 +87,7 @@ jobs:
   back-lint:
     resource_class: medium
     executor:
-      name: cl2-back
+      name: back-essential
       image-tag: $CIRCLE_SHA1
     working_directory: /cl2_back
     environment:
@@ -98,7 +98,7 @@ jobs:
   back-bundle-audit:
     resource_class: small
     executor:
-      name: cl2-back
+      name: back-essential
       image-tag: $CIRCLE_SHA1
     working_directory: /cl2_back
     environment:
@@ -113,7 +113,7 @@ jobs:
   back-test:
     resource_class: small
     executor:
-      name: cl2-back
+      name: back-essential
       image-tag: $CIRCLE_SHA1
     working_directory: /cl2_back
     parallelism: 4
@@ -135,7 +135,7 @@ jobs:
   back-license-check:
     resource_class: small
     executor:
-      name: cl2-back
+      name: back-essential
       image-tag: $CIRCLE_SHA1
     working_directory: /cl2_back
     steps:
@@ -144,7 +144,7 @@ jobs:
   back-web-api-docs:
     resource_class: small
     executor:
-      name: cl2-back
+      name: back-essential
       image-tag: $CIRCLE_SHA1
     working_directory: /cl2_back
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ jobs:
   back-bundle-audit:
     resource_class: small
     executor:
-      name: back-essential
+      name: back-ee
       image-tag: $CIRCLE_SHA1
     working_directory: /cl2_back
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ parameters:
     default: false
 
 executors:
-  cl2-back:
+  cl2-back: # TODO rename to  or back-essential or back-os (avoid citizenlab name)
     parameters:
       image-tag:
         type: string
@@ -56,15 +56,6 @@ jobs:
       - run:
           name: Trigger workflows
           command: chmod +x .circleci/monorepo.sh && .circleci/monorepo.sh
-
-  trigger-private-workflows:
-    resource_class: small
-    docker:
-      - image: cimg/base:stable
-    steps:
-      - checkout
-      - run: |
-          chmod +x .circleci/private-trigger.sh && .circleci/private-trigger.sh << pipeline.parameters.back >> << pipeline.parameters.front >>
 
   danger-check:
     resource_class: small
@@ -345,20 +336,6 @@ workflows:
                 - crowdin_master
                 - /l10n_.*/
 
-  private-ci:
-    when:
-      and:
-        - not: << pipeline.parameters.trigger >>
-        - or: [<< pipeline.parameters.back >>, << pipeline.parameters.front >>]
-    jobs:
-      - trigger-private-workflows:
-          context: circleci-api-token
-          filters:
-            branches:
-              ignore:
-                - crowdin_master
-                - /l10n_.*/
-
   global-checks:
     when: << pipeline.parameters.trigger >>
     jobs:
@@ -473,7 +450,6 @@ workflows:
                 - /l10n_.*/
                 - master
                 - production
-
 
   # *************** release ***************
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,7 +159,7 @@ jobs:
     steps:
       - run: bundle exec license_finder
 
-  back-web-api-docs:
+  back-essential-web-api-docs:
     resource_class: small
     executor:
       name: back-essential
@@ -413,7 +413,7 @@ workflows:
               ignore:
                 - crowdin_master
                 - /l10n_.*/
-      - back-web-api-docs:
+      - back-essential-web-api-docs:
           context: docker-hub-access
           requires:
             - back-essential-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ jobs:
       # See https://github.com/rubysec/bundler-audit
       - run: bundle exec bundle-audit check --update --ignore CVE-2015-9284
 
-  back-test:
+  back-essential-test:
     resource_class: small
     executor:
       name: back-essential
@@ -395,7 +395,7 @@ workflows:
               ignore:
                 - crowdin_master
                 - /l10n_.*/
-      - back-test:
+      - back-essential-test:
           context: docker-hub-access
           requires:
             - back-build-essential-docker-image
@@ -416,7 +416,7 @@ workflows:
       - back-web-api-docs:
           context: docker-hub-access
           requires:
-            - back-test
+            - back-essential-test
           filters:
             branches:
               ignore:
@@ -521,7 +521,7 @@ workflows:
             branches:
               only:
                 - production
-      - back-test:
+      - back-essential-test:
           context: docker-hub-access
           requires:
             - back-build-essential-docker-image
@@ -546,7 +546,7 @@ workflows:
             - front-detect-deadcode
             - front-lint
             - back-lint
-            - back-test
+            - back-essential-test
             - back-bundle-audit
             - back-license-check
           filters:
@@ -562,7 +562,7 @@ workflows:
             - front-detect-deadcode
             - front-lint
             - back-lint
-            - back-test
+            - back-essential-test
             - back-bundle-audit
             - back-license-check
           filters:


### PR DESCRIPTION
- [x] rename `cl2-back` to `back-essential`
- [ ] implement the different environment as (circleci) contexts
- [ ] Why is resource_class small for back-test and medium for back-lint?
- [ ] (cosmetic) rake db:create db:schema:load
- [ ] (cosmetic) Test files: ...
- [ ] (cosmetic) *************** back ***************
- [ ] (improvements) add release tags without pulling the image

# Questions
- What is the difference between a deploy>command step and a run step?
- How to adapt front-test? what are the main difference between front-test in os and ee CIs?
- `/bin/bash -lc "cd /citizenlab/front && license_finder"` why do we use `-lc` here?