### PR TITLE
Fix flaky test

### DIFF
--- a/back/app/controllers/web_api/v1/phases_controller.rb
+++ b/back/app/controllers/web_api/v1/phases_controller.rb
@@ -24,14 +24,6 @@ class WebApi::V1::PhasesController < ApplicationController
     authorize @phase
     if @phase.save
       sidefx.after_create(@phase, current_user)
-      # When creating a native survey phase,
-      # ParticipationMethod::NativeSurvey#create_default_form! is invoked.
-      # create_default_form! does not reload associations for form/fields/options,
-      # so fetch the phase from the database. The associations will be fetched
-      # when they are needed.
-      # create_default_form! creates fields, and CustomField uses acts_as_list
-      # for ordering fields. The ordering is ok in the database, but not necessarily in memory.
-      @phase = Phase.find(@phase.id)
       render json: WebApi::V1::PhaseSerializer.new(@phase, params: fastjson_params).serialized_json, status: :created
     else
       render json: { errors: @phase.errors.details }, status: :unprocessable_entity

--- a/back/app/controllers/web_api/v1/phases_controller.rb
+++ b/back/app/controllers/web_api/v1/phases_controller.rb
@@ -24,6 +24,14 @@ class WebApi::V1::PhasesController < ApplicationController
     authorize @phase
     if @phase.save
       sidefx.after_create(@phase, current_user)
+      # When creating a native survey phase,
+      # ParticipationMethod::NativeSurvey#create_default_form! is invoked.
+      # create_default_form! does not reload associations for form/fields/options,
+      # so fetch the phase from the database. The associations will be fetched
+      # when they are needed.
+      # create_default_form! creates fields, and CustomField uses acts_as_list
+      # for ordering fields. The ordering is ok in the database, but not necessarily in memory.
+      @phase = Phase.find(@phase.id)
       render json: WebApi::V1::PhaseSerializer.new(@phase, params: fastjson_params).serialized_json, status: :created
     else
       render json: { errors: @phase.errors.details }, status: :unprocessable_entity

--- a/back/app/models/custom_form.rb
+++ b/back/app/models/custom_form.rb
@@ -16,7 +16,7 @@
 #
 class CustomForm < ApplicationRecord
   belongs_to :participation_context, polymorphic: true
-  has_many :custom_fields, as: :resource, dependent: :destroy
+  has_many :custom_fields, -> { order(:ordering) }, as: :resource, dependent: :destroy, inverse_of: :resource
 
   validates :participation_context, presence: true
   validates :participation_context_id, uniqueness: { scope: %i[participation_context_type] } # https://github.com/rails/rails/issues/34312#issuecomment-586870322

--- a/back/spec/acceptance/phases_spec.rb
+++ b/back/spec/acceptance/phases_spec.rb
@@ -172,8 +172,8 @@ resource 'Phases' do
 
           # A new native survey phase has a default form.
           fields = phase_in_db.custom_form.custom_fields
-          expect(fields.map(&:ordering)).to eq([0, 1])
           expect(fields.size).to eq 2
+          expect(fields.map(&:ordering)).to eq([0, 1])
           field1 = fields[0]
           expect(field1.input_type).to eq 'page'
           field2 = fields[1]

--- a/back/spec/acceptance/phases_spec.rb
+++ b/back/spec/acceptance/phases_spec.rb
@@ -160,18 +160,7 @@ resource 'Phases' do
       end
 
       context 'native survey' do
-        let(:phase) do
-          survey_phase = create(:native_survey_phase)
-          # When building a native survey phase,
-          # ParticipationMethod::NativeSurvey#create_default_form! is invoked.
-          # create_default_form! does not reload associations for form/fields/options,
-          # so fetch the phase from the database. The associations will be fetched
-          # when they are needed.
-          # Not doing this makes this test flaky, as create_default_form! creates fields,
-          # and CustomField uses acts_as_list for ordering fields. The ordering is ok
-          # in the database, but not necessarily in memory.
-          Phase.find(survey_phase.id)
-        end
+        let(:phase) { build(:native_survey_phase) }
         let(:min_budget) { nil }
         let(:max_budget) { nil }
 

--- a/back/spec/acceptance/phases_spec.rb
+++ b/back/spec/acceptance/phases_spec.rb
@@ -171,10 +171,12 @@ resource 'Phases' do
           phase_in_db = Phase.find(phase_id)
 
           # A new native survey phase has a default form.
-          expect(phase_in_db.custom_form.custom_fields.size).to eq 2
-          field1 = phase_in_db.custom_form.custom_fields[0]
+          fields = phase_in_db.custom_form.custom_fields
+          expect(fields.map(&:ordering)).to eq([0, 1])
+          expect(fields.size).to eq 2
+          field1 = fields[0]
           expect(field1.input_type).to eq 'page'
-          field2 = phase_in_db.custom_form.custom_fields[1]
+          field2 = fields[1]
           expect(field2.input_type).to eq 'select'
           expect(field2.title_multiloc).to match({
             'en' => an_instance_of(String),

--- a/back/spec/acceptance/phases_spec.rb
+++ b/back/spec/acceptance/phases_spec.rb
@@ -161,15 +161,16 @@ resource 'Phases' do
 
       context 'native survey' do
         let(:phase) do
-          survey_phase = build(:native_survey_phase)
+          survey_phase = create(:native_survey_phase)
           # When building a native survey phase,
           # ParticipationMethod::NativeSurvey#create_default_form! is invoked.
           # create_default_form! does not reload associations for form/fields/options,
           # so fetch the phase from the database. The associations will be fetched
           # when they are needed.
-          # Not doing this makes this test flaky, as create_default_form! creates fields
+          # Not doing this makes this test flaky, as create_default_form! creates fields,
           # and CustomField uses acts_as_list for ordering fields. The ordering is ok
           # in the database, but not necessarily in memory.
+          Phase.find(survey_phase.id)
         end
         let(:min_budget) { nil }
         let(:max_budget) { nil }


### PR DESCRIPTION
A test is flaky on CI. The failure has been [reported by Brent](https://citizenlabco.slack.com/archives/C031GG2M8BH/p1670589854657549), who saw it on a feature branch. Today Amanda and I saw the failure [on our feature branch](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/75385/workflows/9a8c96fb-8da4-451e-b6cd-b6a5eda2af2e/jobs/164319) too.

The root cause of the flakiness is a missing `order` in the query to fetch custom_fields from a CustomForm. Before, this was the query for a form with ID `db3fea02-1ab3-41b6-8f55-4da5a8593500`:
```
SELECT "custom_fields".*
FROM "custom_fields"
WHERE "custom_fields"."resource_id" = 'db3fea02-1ab3-41b6-8f55-4da5a8593500'
AND "custom_fields"."resource_type" = 'CustomForm'
```
It should be:
```
SELECT "custom_fields".*
FROM "custom_fields"
WHERE "custom_fields"."resource_id" = 'db3fea02-1ab3-41b6-8f55-4da5a859350'
AND "custom_fields"."resource_type" = 'CustomForm'
ORDER BY "custom_fields"."ordering" ASC
```
So that is what this PR does.