### PR TITLE
[CL-2268] Fix mistake in memoizing description translations while generating UI schema

### DIFF
--- a/back/app/services/input_ui_schema_generator_service.rb
+++ b/back/app/services/input_ui_schema_generator_service.rb
@@ -47,7 +47,9 @@ class InputUiSchemaGeneratorService < UiSchemaGeneratorService
 
   def description_option(field)
     @descriptions ||= {}
-    @descriptions[field] ||= multiloc_service.t TextImageService.new.render_data_images(field, :description_multiloc)
+    locale = I18n.locale.to_s
+    @descriptions[locale] ||= {}
+    @descriptions[locale][field] ||= multiloc_service.t TextImageService.new.render_data_images(field, :description_multiloc)
   end
 
   def generate_with_pages(fields)

--- a/back/spec/services/input_ui_schema_generator_service_spec.rb
+++ b/back/spec/services/input_ui_schema_generator_service_spec.rb
@@ -36,8 +36,16 @@ RSpec.describe InputUiSchemaGeneratorService do
           resource: custom_form,
           input_type: 'html_multiloc',
           code: 'body_multiloc',
-          title_multiloc: { 'en' => 'Body multiloc field title' },
-          description_multiloc: { 'en' => 'Body multiloc field description' }
+          title_multiloc: {
+            'en' => 'Body multiloc field title',
+            'nl-NL' => 'Body multiloc veldtitel'
+            # No 'fr-FR' to describe that it will default to 'en'.
+          },
+          description_multiloc: {
+            'en' => 'Body multiloc field description',
+            'nl-NL' => 'Body multiloc veldbeschrijving'
+            # No 'fr-FR' to describe that it will default to 'en'.
+          }
         )
       end
 
@@ -206,9 +214,9 @@ RSpec.describe InputUiSchemaGeneratorService do
                       {
                         type: 'Control',
                         scope: "#/properties/#{field2.key}/properties/en",
-                        label: 'Body multiloc field title',
+                        label: 'Body multiloc veldtitel',
                         options: {
-                          description: 'Body multiloc field description',
+                          description: 'Body multiloc veldbeschrijving',
                           isAdminField: false,
                           render: 'WYSIWYG',
                           locale: 'en'
@@ -217,9 +225,9 @@ RSpec.describe InputUiSchemaGeneratorService do
                       {
                         type: 'Control',
                         scope: "#/properties/#{field2.key}/properties/fr-FR",
-                        label: 'Body multiloc field title',
+                        label: 'Body multiloc veldtitel',
                         options: {
-                          description: 'Body multiloc field description',
+                          description: 'Body multiloc veldbeschrijving',
                           isAdminField: false,
                           render: 'WYSIWYG',
                           locale: 'fr-FR'
@@ -228,9 +236,9 @@ RSpec.describe InputUiSchemaGeneratorService do
                       {
                         type: 'Control',
                         scope: "#/properties/#{field2.key}/properties/nl-NL",
-                        label: 'Body multiloc field title',
+                        label: 'Body multiloc veldtitel',
                         options: {
-                          description: 'Body multiloc field description',
+                          description: 'Body multiloc veldbeschrijving',
                           isAdminField: false,
                           render: 'WYSIWYG',
                           locale: 'nl-NL'
@@ -581,51 +589,143 @@ RSpec.describe InputUiSchemaGeneratorService do
           input_type: 'html_multiloc',
           code: 'body_multiloc',
           key: field_key,
-          title_multiloc: { 'en' => 'Body multiloc field title' },
-          description_multiloc: { 'en' => 'Body multiloc field description' }
+          title_multiloc: {
+            'en' => 'Body multiloc field title',
+            'nl-NL' => 'Body multiloc veldtitel'
+            # No 'fr-FR' to describe that it will default to 'en'.
+          },
+          description_multiloc: {
+            'en' => 'Body multiloc field description',
+            'nl-NL' => 'Body multiloc veldbeschrijving'
+            # No 'fr-FR' to describe that it will default to 'en'.
+          }
         )
       end
 
-      it 'returns the schema for the given built-in field' do
-        expect(generator.visit_html_multiloc(field)).to eq({
-          type: 'VerticalLayout',
-          options: { render: 'multiloc' },
-          elements: [
-            {
-              type: 'Control',
-              scope: "#/properties/#{field_key}/properties/en",
-              label: 'Body multiloc field title',
-              options: {
-                description: 'Body multiloc field description',
-                isAdminField: false,
-                render: 'WYSIWYG',
-                locale: 'en'
+      it 'returns the schema for the given built-in field with translations in the current locale' do
+        I18n.with_locale('en') do
+          expect(generator.visit_html_multiloc(field)).to eq({
+            type: 'VerticalLayout',
+            options: { render: 'multiloc' },
+            elements: [
+              {
+                type: 'Control',
+                scope: "#/properties/#{field_key}/properties/en",
+                label: 'Body multiloc field title',
+                options: {
+                  description: 'Body multiloc field description',
+                  isAdminField: false,
+                  render: 'WYSIWYG',
+                  locale: 'en'
+                }
+              },
+              {
+                type: 'Control',
+                scope: "#/properties/#{field_key}/properties/fr-FR",
+                label: 'Body multiloc field title',
+                options: {
+                  description: 'Body multiloc field description',
+                  isAdminField: false,
+                  render: 'WYSIWYG',
+                  locale: 'fr-FR'
+                }
+              },
+              {
+                type: 'Control',
+                scope: "#/properties/#{field_key}/properties/nl-NL",
+                label: 'Body multiloc field title',
+                options: {
+                  description: 'Body multiloc field description',
+                  isAdminField: false,
+                  render: 'WYSIWYG',
+                  locale: 'nl-NL'
+                }
               }
-            },
-            {
-              type: 'Control',
-              scope: "#/properties/#{field_key}/properties/fr-FR",
-              label: 'Body multiloc field title',
-              options: {
-                description: 'Body multiloc field description',
-                isAdminField: false,
-                render: 'WYSIWYG',
-                locale: 'fr-FR'
+            ]
+          })
+        end
+        I18n.with_locale('fr-FR') do
+          expect(generator.visit_html_multiloc(field)).to eq({
+            type: 'VerticalLayout',
+            options: { render: 'multiloc' },
+            elements: [
+              {
+                type: 'Control',
+                scope: "#/properties/#{field_key}/properties/en",
+                label: 'Body multiloc field title',
+                options: {
+                  description: 'Body multiloc field description',
+                  isAdminField: false,
+                  render: 'WYSIWYG',
+                  locale: 'en'
+                }
+              },
+              {
+                type: 'Control',
+                scope: "#/properties/#{field_key}/properties/fr-FR",
+                label: 'Body multiloc field title',
+                options: {
+                  description: 'Body multiloc field description',
+                  isAdminField: false,
+                  render: 'WYSIWYG',
+                  locale: 'fr-FR'
+                }
+              },
+              {
+                type: 'Control',
+                scope: "#/properties/#{field_key}/properties/nl-NL",
+                label: 'Body multiloc field title',
+                options: {
+                  description: 'Body multiloc field description',
+                  isAdminField: false,
+                  render: 'WYSIWYG',
+                  locale: 'nl-NL'
+                }
               }
-            },
-            {
-              type: 'Control',
-              scope: "#/properties/#{field_key}/properties/nl-NL",
-              label: 'Body multiloc field title',
-              options: {
-                description: 'Body multiloc field description',
-                isAdminField: false,
-                render: 'WYSIWYG',
-                locale: 'nl-NL'
+            ]
+          })
+        end
+        I18n.with_locale('nl-NL') do
+          expect(generator.visit_html_multiloc(field)).to eq({
+            type: 'VerticalLayout',
+            options: { render: 'multiloc' },
+            elements: [
+              {
+                type: 'Control',
+                scope: "#/properties/#{field_key}/properties/en",
+                label: 'Body multiloc veldtitel',
+                options: {
+                  description: 'Body multiloc veldbeschrijving',
+                  isAdminField: false,
+                  render: 'WYSIWYG',
+                  locale: 'en'
+                }
+              },
+              {
+                type: 'Control',
+                scope: "#/properties/#{field_key}/properties/fr-FR",
+                label: 'Body multiloc veldtitel',
+                options: {
+                  description: 'Body multiloc veldbeschrijving',
+                  isAdminField: false,
+                  render: 'WYSIWYG',
+                  locale: 'fr-FR'
+                }
+              },
+              {
+                type: 'Control',
+                scope: "#/properties/#{field_key}/properties/nl-NL",
+                label: 'Body multiloc veldtitel',
+                options: {
+                  description: 'Body multiloc veldbeschrijving',
+                  isAdminField: false,
+                  render: 'WYSIWYG',
+                  locale: 'nl-NL'
+                }
               }
-            }
-          ]
-        })
+            ]
+          })
+        end
       end
     end
 

--- a/back/spec/services/json_forms_service_spec.rb
+++ b/back/spec/services/json_forms_service_spec.rb
@@ -348,7 +348,7 @@ describe JsonFormsService do
           'en' => '<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" />'
         }
         field = create :custom_field, :for_custom_form, input_type: 'text', description_multiloc: description_multiloc
-        expect_any_instance_of(TextImageService).to(
+        allow_any_instance_of(TextImageService).to(
           receive(:render_data_images).with(field, :description_multiloc).and_return({ 'en' => 'Description with text images' })
         )
 
@@ -361,7 +361,7 @@ describe JsonFormsService do
           'en' => '<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" />'
         }
         field = create :custom_field, :for_custom_form, input_type: 'page', description_multiloc: description_multiloc
-        expect_any_instance_of(TextImageService).to(
+        allow_any_instance_of(TextImageService).to(
           receive(:render_data_images).with(field, :description_multiloc).and_return({ 'en' => 'Description with text images' })
         )
 


### PR DESCRIPTION
Fix for https://citizenlab.atlassian.net/browse/CL-2268

There was a mistake in memoizing description translations. Memoizing happened per field, while it should have happened per locale and field.

Added extra tests. Performed manual tests with idea forms and native survey forms.