### PR TITLE
CL-2327 Remove customizable_homepage_banner from seeds

### DIFF
--- a/back/engines/commercial/multi_tenancy/db/seeds/tenants.rb
+++ b/back/engines/commercial/multi_tenancy/db/seeds/tenants.rb
@@ -26,10 +26,6 @@ module MultiTenancy
               organization_name: runner.create_for_tenant_locales { Faker::Address.city },
               currency: CL2_SUPPORTED_CURRENCIES.sample
             },
-            customizable_homepage_banner: {
-              allowed: true,
-              enabled: true
-            },
             password_login: {
               allowed: true,
               enabled: true,

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/create_tenant.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/create_tenant.rake
@@ -22,10 +22,6 @@ namespace :cl2_back do
             en: 'If you don\'t want to register, use hello@citizenlab.co/democrazy as email/password'
           }
         },
-        customizable_homepage_banner: {
-          enabled: true,
-          allowed: true
-        },
         private_projects: {
           enabled: true,
           allowed: true


### PR DESCRIPTION
Also remove customizable_homepage_banner from rake task.

Does not remove line from config.ee.json as in the old [ee PR](https://github.com/CitizenLabDotCo/citizenlab-ee/pull/412), as I assume this file is no longer relevant.

Template serializer changes in the old ee PR are already merged to the feature branch, in [this PR](https://github.com/CitizenLabDotCo/citizenlab/pull/3504).