### PR TITLE
[CL-2527] Fix bundle-audit failing on httparty CVE (upgrade httparty)

### DIFF
--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -223,7 +223,7 @@ PATH
   remote: engines/commercial/id_gent_rrn
   specs:
     id_gent_rrn (0.1.0)
-      httparty (~> 0.16.2)
+      httparty
       rails (~> 6.1)
       verification
 
@@ -240,7 +240,7 @@ PATH
   remote: engines/commercial/id_oostende_rrn
   specs:
     id_oostende_rrn (0.1.0)
-      httparty (~> 0.16.2)
+      httparty
       rails (~> 6.1)
       verification
 
@@ -315,7 +315,7 @@ PATH
   specs:
     nlp (0.1.0)
       bunny
-      httparty (~> 0.16.2)
+      httparty
       rails (~> 6.1)
 
 PATH
@@ -425,7 +425,7 @@ PATH
   specs:
     surveys (0.1.0)
       active_model_serializers (~> 0.10.7)
-      httparty (~> 0.16.2)
+      httparty
       kaminari (~> 1.2)
       pundit (~> 2.0)
       rails (~> 6.1)
@@ -705,8 +705,8 @@ GEM
     http-accept (1.7.0)
     http-cookie (1.0.4)
       domain_name (~> 0.5)
-    httparty (0.16.4)
-      mime-types (~> 3.0)
+    httparty (0.21.0)
+      mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
     httpclient (2.8.3)
     httpi (2.5.0)

--- a/back/engines/commercial/id_gent_rrn/id_gent_rrn.gemspec
+++ b/back/engines/commercial/id_gent_rrn/id_gent_rrn.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib}/**/*', 'Rakefile', 'README.md']
 
   s.add_dependency 'rails', '~> 6.1'
-  s.add_dependency 'httparty', '~> 0.16.2'
+  s.add_dependency 'httparty'
   s.add_dependency 'verification'
 
   s.add_development_dependency 'rspec_api_documentation'

--- a/back/engines/commercial/id_oostende_rrn/id_oostende_rrn.gemspec
+++ b/back/engines/commercial/id_oostende_rrn/id_oostende_rrn.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib}/**/*', 'Rakefile', 'README.md']
 
   s.add_dependency 'rails', '~> 6.1'
-  s.add_dependency 'httparty', '~> 0.16.2'
+  s.add_dependency 'httparty'
   s.add_dependency 'verification'
 
   s.add_development_dependency 'rspec_api_documentation'

--- a/back/engines/commercial/nlp/nlp.gemspec
+++ b/back/engines/commercial/nlp/nlp.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib}/**/*', 'Rakefile', 'README.md']
 
   s.add_dependency 'rails', '~> 6.1'
-  s.add_dependency 'httparty', '~> 0.16.2'
+  s.add_dependency 'httparty'
   s.add_dependency 'bunny'
 
   s.add_development_dependency 'rspec_api_documentation'

--- a/back/engines/free/surveys/surveys.gemspec
+++ b/back/engines/free/surveys/surveys.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'pundit', '~> 2.0'
   s.add_dependency 'kaminari', '~> 1.2'
   s.add_dependency 'active_model_serializers', '~> 0.10.7'
-  s.add_dependency 'httparty', '~> 0.16.2'
+  s.add_dependency 'httparty'
 
   s.add_development_dependency 'rspec_api_documentation'
   s.add_development_dependency 'rspec-rails'


### PR DESCRIPTION
Why don't we specify any version restrictions in engines anymore?

1) httparty has never introduced any breaking changes https://github.com/jnunemaker/httparty/blob/a2038f2/Changelog.md

2) the version is specified in Gemfile.lock anyway, so we'll check the changelog upgrading the next time
