### PR TITLE
[CL-2597] Remove custom_topics feature flag

### DIFF
--- a/front/app/containers/Admin/projects/project/AdminProjectsProjectIndex.test.tsx
+++ b/front/app/containers/Admin/projects/project/AdminProjectsProjectIndex.test.tsx
@@ -283,6 +283,7 @@ describe('<AdminProjectEdition />', () => {
       'General',
       'Description',
       'Input manager',
+      'Allowed input tags',
       'Timeline',
       'Events',
     ];

--- a/front/app/containers/Admin/projects/project/index.tsx
+++ b/front/app/containers/Admin/projects/project/index.tsx
@@ -142,7 +142,6 @@ export class AdminProjectsProjectIndex extends PureComponent<
           label: formatMessage(messages.allowedInputTopicsTab),
           name: 'topics',
           url: 'allowed-input-topics',
-          feature: 'custom_topics',
         },
         {
           label: formatMessage(messages.phasesTab),

--- a/front/app/containers/Admin/settings/index.tsx
+++ b/front/app/containers/Admin/settings/index.tsx
@@ -54,7 +54,6 @@ class SettingsPage extends React.PureComponent<
           label: formatMessage(messages.tabTopics),
           name: 'topics',
           url: '/admin/settings/topics',
-          feature: 'custom_topics',
         },
         {
           name: 'areas',

--- a/front/app/services/appConfiguration.ts
+++ b/front/app/services/appConfiguration.ts
@@ -169,7 +169,6 @@ export interface IAppConfigurationSettings {
   ideaflow_social_sharing?: AppConfigurationFeature;
   initiativeflow_social_sharing?: AppConfigurationFeature;
   machine_translations?: AppConfigurationFeature;
-  custom_topics?: AppConfigurationFeature;
   custom_maps?: AppConfigurationFeature;
   similar_ideas?: AppConfigurationFeature;
   polls?: AppConfigurationFeature;


### PR DESCRIPTION
Removes the use of custom_topics feature flag, as it no longer exists in the back-end and should therefore not be used by the front-end.

Please review asap as this has high priority 🙏 