### PR TITLE
[CL-2046] Fixed discrepancy between reg numbers on overview and visit…

### DIFF
--- a/front/app/modules/commercial/analytics/admin/components/RegistrationsCard/useRegistrations/query.ts
+++ b/front/app/modules/commercial/analytics/admin/components/RegistrationsCard/useRegistrations/query.ts
@@ -8,21 +8,21 @@ import {
 // typings
 import { Query, QuerySchema } from 'services/analyticsFacts';
 import { QueryParameters } from './typings';
+import moment from 'moment';
 
 export const query = ({
   startAtMoment,
   endAtMoment,
   resolution,
 }: QueryParameters): Query => {
+  // Always set the date moments as otherwise the queries do not filter out completed registrations
+  const startAt = startAtMoment || moment('2017-01-01');
+  const endAt = endAtMoment || moment();
+
   const timeSeriesQuery: QuerySchema = {
     fact: 'registration',
     filters: {
-      'dimension_user.role': ['citizen', null],
-      ...getDateFilter(
-        'dimension_date_registration',
-        startAtMoment,
-        endAtMoment
-      ),
+      ...getDateFilter('dimension_date_registration', startAt, endAt),
     },
     groups: `dimension_date_registration.${getInterval(resolution)}`,
     aggregations: {
@@ -34,12 +34,7 @@ export const query = ({
   const registrationsWholePeriodQuery: QuerySchema = {
     fact: 'registration',
     filters: {
-      'dimension_user.role': ['citizen', null],
-      ...getDateFilter(
-        'dimension_date_registration',
-        startAtMoment,
-        endAtMoment
-      ),
+      ...getDateFilter('dimension_date_registration', startAt, endAt),
     },
     aggregations: {
       all: 'count',
@@ -49,7 +44,6 @@ export const query = ({
   const registrationsLastPeriodQuery: QuerySchema = {
     fact: 'registration',
     filters: {
-      'dimension_user.role': ['citizen', null],
       ...getDateFilterLastPeriod('dimension_date_registration', resolution),
     },
     aggregations: {
@@ -60,12 +54,7 @@ export const query = ({
   const visitsWholePeriodQuery: QuerySchema = {
     fact: 'visit',
     filters: {
-      'dimension_user.role': ['citizen', null],
-      ...getDateFilter(
-        'dimension_date_first_action',
-        startAtMoment,
-        endAtMoment
-      ),
+      ...getDateFilter('dimension_date_first_action', startAt, endAt),
     },
     aggregations: {
       visitor_id: 'count',
@@ -75,7 +64,6 @@ export const query = ({
   const visitsLastPeriodQuery: QuerySchema = {
     fact: 'visit',
     filters: {
-      'dimension_user.role': ['citizen', null],
       ...getDateFilterLastPeriod('dimension_date_first_action', resolution),
     },
     aggregations: {


### PR DESCRIPTION
Small fix to make the numbers of registrations on the overview dashboard match the numbers on the overview dashboard. 

The problem was combination of the fact that the visitors dashboard was filtering out admins/moderators but also not filtering out invited users. The solution to get the numbers to balance was to add filtering for only fully registered users and remove filter for admins/moderators. Ideally we'd keep the admin/moderator filter, and also add that to all numbers on the overview dashboard, but these are the primary numbers that admins will have been looking at so I think it would cause issues if that number changes.