### PR TITLE
[CL-2666] Fix overflowing locales quill editor

### DIFF
--- a/front/app/components/UI/QuillEditor/QuillMultilocWithLocaleSwitcher.tsx
+++ b/front/app/components/UI/QuillEditor/QuillMultilocWithLocaleSwitcher.tsx
@@ -28,6 +28,8 @@ const LabelContainer = styled.div`
   align-items: center;
   justify-content: space-between;
   margin-bottom: 10px;
+  flex-wrap: wrap;
+  gap: 16px;
 `;
 
 const StyledLabel = styled(Label)`
@@ -42,7 +44,6 @@ const Spacer = styled.div`
 
 const StyledLocaleSwitcher = styled(LocaleSwitcher)`
   width: auto;
-  margin-left: 20px;
 `;
 
 export interface Props


### PR DESCRIPTION
Didn't realize this was actually in the main app.

Simple CSS change. I checked all the places in the app where this component is used as well to make sure it still looks good :+1: 

## How urgent is a code review?
End of day if possible?