### PR TITLE
[CL-2716] Exclude languages from crowdin config

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -2,24 +2,61 @@ files:
   - source: /front/app/translations/en.json
     translation: /front/app/translations/%locale%.json
     update_option: update_without_changes
+    excluded_target_languages:
+      - kl
   - source: /front/app/translations/admin/en.json
     translation: /front/app/translations/admin/%locale%.json
     update_option: update_without_changes
+    excluded_target_languages:
+      - ca
+      - el
+      - kl
+      - it
+      - lb
+      - ar-MA
+      - ro
+      - sr
   - source: /back/config/locales/en.yml
     translation: /back/config/locales/%locale%.yml
     update_option: update_without_changes
+    excluded_target_languages:
+      - kl
   - source: /back/engines/free/email_campaigns/config/locales/en.yml
     translation: /back/engines/free/email_campaigns/config/locales/%locale%.yml
     update_option: update_without_changes
+    excluded_target_languages:
+      - kl
   - source: /back/engines/free/user_confirmation/config/locales/en.yml
     translation: /back/engines/free/user_confirmation/config/locales/%locale%.yml
     update_option: update_without_changes
+    excluded_target_languages:
+      - kl
   - source: /back/engines/free/smart_groups/config/locales/en.yml
     translation: /back/engines/free/smart_groups/config/locales/%locale%.yml
     update_option: update_without_changes
+    excluded_target_languages:
+      - kl
   - source: /back/engines/commercial/idea_assignment/config/locales/en.yml
     translation: /back/engines/commercial/idea_assignment/config/locales/%locale%.yml
     update_option: update_without_changes
+    excluded_target_languages:
+      - ca
+      - el
+      - kl
+      - it
+      - lb
+      - ar-MA
+      - ro
+      - sr
   - source: /back/engines/commercial/flag_inappropriate_content/config/locales/en.yml
     translation: /back/engines/commercial/flag_inappropriate_content/config/locales/%locale%.yml
     update_option: update_without_changes
+    excluded_target_languages:
+      - ca
+      - el
+      - kl
+      - it
+      - lb
+      - ar-MA
+      - ro
+      - sr


### PR DESCRIPTION
On Crowdin, master branch has a number of languages unchecked for files that are used in the back-office:
<img width="1148" alt="Screenshot 2023-01-26 at 11 29 03" src="https://user-images.githubusercontent.com/3944042/214824980-17714440-c5d7-4042-b02f-e7949ddf66a9.png">

This is not the case on Crowdin for the other branches (that we sometimes add to Crowdin):
<img width="1148" alt="Screenshot 2023-01-26 at 11 32 16" src="https://user-images.githubusercontent.com/3944042/214825457-c204720c-54e3-4f9c-89e1-ba55440dd02f.png">

Note: Greenlandic, `kl`, is the only language that is not selected for all translation files (back & front-office related), and thus has been excluded from all files in the `crowdin.yml` config file.

 This PR attempts to address this by excluding specific languages in the `crowdin.yml` file.
