### PR TITLE
CL-2722: Add displaying section description in front office

### DIFF
--- a/front/app/components/Form/Components/Layouts/CLCategoryLayout.tsx
+++ b/front/app/components/Form/Components/Layouts/CLCategoryLayout.tsx
@@ -8,8 +8,9 @@ import {
 import { JsonFormsDispatch, withJsonFormsLayoutProps } from '@jsonforms/react';
 import { Box, fontSizes, media } from '@citizenlab/cl2-component-library';
 import { FormSection } from 'components/UI/FormComponents';
-import styled from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 import { FormElement } from 'components/IdeaForm';
+import QuillEditedContent from 'components/UI/QuillEditedContent';
 
 const StyledFormSection = styled(FormSection)`
   max-width: 100%;
@@ -36,6 +37,7 @@ const FormSectionTitleStyled = styled.h2`
 const CLCategoryLayout = memo(
   // here we can cast types because the tester made sure we only get categorization layouts
   ({ schema, uischema, path, renderers, cells, enabled }: LayoutProps) => {
+    const theme = useTheme();
     return (
       <Box
         width="100%"
@@ -48,6 +50,20 @@ const CLCategoryLayout = memo(
         {(uischema as Categorization).elements.map((e, index) => (
           <StyledFormSection key={index}>
             <FormSectionTitleStyled>{e.label}</FormSectionTitleStyled>
+            {e.options && e.options.description && (
+              <Box mb={e.elements.length >= 1 ? '48px' : '28px'}>
+                <QuillEditedContent
+                  fontWeight={400}
+                  textColor={theme.colors.tenantText}
+                >
+                  <div
+                    dangerouslySetInnerHTML={{
+                      __html: e.options.description,
+                    }}
+                  />
+                </QuillEditedContent>
+              </Box>
+            )}
             {e.elements.map((e, index) => (
               <FormElement key={index}>
                 <JsonFormsDispatch


### PR DESCRIPTION
Add displaying section description in the front office. You can test this manually by setting a hard coded value. It should be similar to what we have on pages. The FE side is complete but we can leave the PR open after review. for the BE code such that it tested with it

## How urgent is a code review?

End of day if possible
