### PR TITLE
[CL-2376] Fix flaky test

### DIFF
--- a/back/spec/services/side_fx_idea_spec.rb
+++ b/back/spec/services/side_fx_idea_spec.rb
@@ -36,10 +36,10 @@ describe SideFxIdeaService do
       idea = create(:idea, publication_status: 'draft', author: user)
       idea.update(publication_status: 'published')
       expect { service.after_update(idea, user) }.to(
-        have_enqueued_job(LogActivityJob).with(idea, 'published', user, idea.created_at.to_i).exactly(1).times
+        have_enqueued_job(LogActivityJob).with(idea, 'published', user, idea.published_at.to_i).exactly(1).times
       .and(
         have_enqueued_job(LogActivityJob).with(idea, 'first_published_by_user', user,
-          idea.created_at.to_i).exactly(1).times
+          idea.published_at.to_i).exactly(1).times
       )
       )
     end


### PR DESCRIPTION
Flaky test: SideFxIdeaService after_update logs a 'published' action job when publication_state goes from draft to published, as well as a first idea published log when the idea was first published