### PR TITLE
[CL-2462] Migrate input form custom fields

### DIFF
--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/migrate_flexible_input_forms.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/migrate_flexible_input_forms.rake
@@ -20,8 +20,6 @@ namespace :fix_existing_tenants do
   end
 end
 
-# TODO: Some fields want to update a second time
-
 class FlexibleInputFormMigrator
   def initialize
     @stats = { forms: 0, errors: 0, updated: 0, created: 0 }

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/migrate_flexible_input_forms.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/migrate_flexible_input_forms.rake
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+namespace :fix_existing_tenants do
+  desc 'Migrate ideation form custom fields to the new codes and types - to persist changes run with [persist]'
+  task :migrate_flexible_input_forms, [:persist_changes] => [:environment] do |_t, args|
+    persist_changes = args[:persist_changes] == 'persist'
+    Rails.logger.info 'DRY RUN: Changes will not be persisted' unless persist_changes
+    Tenant.all.each do |tenant|
+      Rails.logger.info "PROCESSING TENANT: #{tenant.host}..."
+      Apartment::Tenant.switch(tenant.schema_name) do
+        if tenant.host == 'localhost' # temp
+          form_migrator = FlexibleInputFormMigrator.new
+          CustomForm.all.each do |custom_form|
+            form_migrator.migrate_form(custom_form, persist_changes)
+          end
+          form_migrator.output_stats tenant.host
+        end
+      end
+    end
+  end
+end
+
+class FlexibleInputFormMigrator
+  def initialize
+    @stats = { forms: 0, errors: 0, updated: 0, created: 0 }
+  end
+
+  def output_stats(host)
+    Rails.logger.info "STATS for #{host}: #{@stats}"
+  end
+
+  def migrate_form(custom_form, persist_changes)
+    @stats[:forms] += 1
+
+    # Format the fields
+    fields = CustomField.where(resource: custom_form)
+    if custom_form.participation_context.participation_method == 'ideation'
+      fields = merge_ideation_fields fields, custom_form
+    else
+      # Only fix ordering in other forms
+      fix_ordering(fields)
+    end
+
+    # Validate that sections / pages are present
+    errors = {}
+    IdeaCustomFieldsService.new(custom_form).check_form_structure fields, errors
+    if errors.present?
+      Rails.logger.error "ERROR: Form structure does not validate #{errors}"
+      @stats[:errors] += 1
+      return
+    end
+
+    # Validate that the ordering is correct
+    ordering = fields.pluck('ordering')
+    if ordering[0] != 0 || !ordering.each_cons(2).all? { |x, y| y == x + 1 }
+      Rails.logger.error "ERROR: Ordering is not correct - #{ordering}"
+      @stats[:errors] += 1
+      return
+    end
+
+    # Save the changes
+    fields.each do |field|
+      field_id = field.code || field.key
+      if field.persisted?
+        if field.changed?
+          Rails.logger.info "FIELD EXISTS - UPDATING: #{field_id} #{field.changes.keys}"
+          field.save! if persist_changes
+          @stats[:updated] += 1
+        else
+          Rails.logger.info "FIELD EXISTS - NO CHANGES: #{field_id}"
+        end
+      else
+        Rails.logger.info "NEW FIELD - CREATING: #{field_id}"
+        field.save! if persist_changes
+        @stats[:created] += 1
+      end
+    end
+  end
+
+  def merge_ideation_fields(fields, custom_form)
+    participation_method = Factory.instance.participation_method_for custom_form.participation_context
+    default_fields = participation_method.default_fields(custom_form)
+    constraints = participation_method.constraints
+
+    updated_fields = []
+    default_fields.each do |default_field|
+      existing_field = fields.find { |field| field.code == default_field.code }
+      updated_fields << if existing_field
+        merge_attributes(existing_field, default_field, constraints)
+      else
+        default_field
+      end
+    end
+    fix_ordering(updated_fields)
+
+    updated_fields
+  end
+
+  # Fix ordering in the context of a form, not of the platform
+  def fix_ordering(fields)
+    fields.each_with_index do |field, index|
+      field.ordering = index
+    end
+  end
+
+  def merge_attributes(existing_field, default_field, form_constraints)
+    field_constraints = form_constraints[existing_field.code&.to_sym]
+    if field_constraints
+      field_constraints[:locks]&.keys.each do |attribute|
+        existing_field[attribute] = default_field[attribute]
+      end
+    end
+
+    # Input type shouldn't ever be different from default, but just in case it is
+    existing_field.input_type = default_field.input_type
+
+    existing_field
+  end
+end

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/migrate_flexible_input_forms.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/migrate_flexible_input_forms.rake
@@ -43,7 +43,7 @@ class FlexibleInputFormMigrator
     @stats[:forms] += 1
 
     # Get persisted fields by order
-    fields = CustomField.where(resource: custom_form).order(:ordering)
+    fields = custom_form.custom_fields.order(:ordering)
 
     # Do nothing if there are no fields (can this happen?)
     if fields.empty?

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/migrate_flexible_input_forms.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/migrate_flexible_input_forms.rake
@@ -115,7 +115,7 @@ class FlexibleInputFormMigrator
   def merge_attributes(existing_field, default_field, form_constraints)
     field_constraints = form_constraints[existing_field.code&.to_sym]
     if field_constraints
-      field_constraints[:locks]&.keys.each do |attribute|
+      field_constraints[:locks]&.keys&.each do |attribute|
         existing_field[attribute] = default_field[attribute]
       end
     end

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/migrate_flexible_input_forms.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/migrate_flexible_input_forms.rake
@@ -20,6 +20,8 @@ namespace :fix_existing_tenants do
   end
 end
 
+# TODO: Some fields want to update a second time
+
 class FlexibleInputFormMigrator
   def initialize
     @stats = { forms: 0, errors: 0, updated: 0, created: 0 }
@@ -33,7 +35,7 @@ class FlexibleInputFormMigrator
     @stats[:forms] += 1
 
     # Format the fields
-    fields = CustomField.where(resource: custom_form)
+    fields = CustomField.where(resource: custom_form).order(:ordering)
     if custom_form.participation_context.participation_method == 'ideation'
       fields = merge_ideation_fields fields, custom_form
     else
@@ -64,6 +66,7 @@ class FlexibleInputFormMigrator
       if field.persisted?
         if field.changed?
           Rails.logger.info "FIELD EXISTS - UPDATING: #{field_id} #{field.changes.keys}"
+          Rails.logger.info field.changes
           field.save! if persist_changes
           @stats[:updated] += 1
         else

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/migrate_flexible_input_forms.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/migrate_flexible_input_forms.rake
@@ -17,6 +17,10 @@
 # 11 with 5 - missing budget and (files or location)
 
 # 133 with 6 - missing budget - this code will create budget fields but not enabled
+#
+# For all of these - the current site behaviour is whatever is missing just displays the default
+#
+# Rest all have 7 fields
 
 # to persist changes run: fix_existing_tenants:migrate_flexible_input_forms[true]
 # to persist changes for one host run: fix_existing_tenants:migrate_flexible_input_forms[true,localhost]
@@ -127,8 +131,6 @@ class FlexibleInputFormMigrator
     default_fields = participation_method.default_fields(custom_form)
     constraints = participation_method.constraints
     updated_fields = []
-    
-    # TODO: It updated 1 on second run. title_multiloc ordering Why?? Ordering gem?
 
     # Merge existing fields with same code as defaults
     default_fields.each do |default_field|
@@ -152,7 +154,8 @@ class FlexibleInputFormMigrator
   end
 
   # Fix ordering in the context of a form, not of the platform
-  # TODO: There is a helper method somewhere to do this, but can't find it 
+  # TODO: There is a helper method somewhere to do this, but can't find it
+  #     # TODO: It updated 1 on second run for stadt_gent. title_multiloc ordering Why?? Ordering gem?
     # Others have raised concern about the ordering gem and this seems to work
   def fix_ordering(fields)
     fields.each_with_index do |field, index|

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/migrate_flexible_input_forms.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/migrate_flexible_input_forms.rake
@@ -1,20 +1,49 @@
 # frozen_string_literal: true
 
+# For non test or demo platforms:
+# 1931 total forms
+
+# 1 field
+# 118 custom forms with 1 field - title, body, or location
+# 73 are published
+# What shall we do? Assume defaults are OK
+
+# Between 2 & 5 fields
+# Only 7 of the following are published - Assume defaults are OK?
+
+# 1 with 2 fields - title & body
+# 3 with 3 - title, body & (files or images or topics)
+# 2 with 4 - title, body, files & images
+# 11 with 5 - missing budget and (files or location)
+
+# 133 with 6 - missing budget - this code will create budget fields but not enabled
+
+# to persist changes run: fix_existing_tenants:migrate_flexible_input_forms[true]
+# to persist changes for one host run: fix_existing_tenants:migrate_flexible_input_forms[true,localhost]
 namespace :fix_existing_tenants do
-  desc 'Migrate ideation form custom fields to the new codes and types - to persist changes run with [persist]'
-  task :migrate_flexible_input_forms, [:persist_changes] => [:environment] do |_t, args|
-    persist_changes = args[:persist_changes] == 'persist'
+  desc 'Migrate ideation form custom fields to the new codes and types'
+  task :migrate_flexible_input_forms, %i[persist_changes host] => [:environment] do |_t, args|
+    persist_changes = args[:persist_changes] == 'true'
+    host = args[:host]
     Rails.logger.info 'DRY RUN: Changes will not be persisted' unless persist_changes
-    Tenant.all.each do |tenant|
+    stats = {}
+    Tenant.creation_finalized.each do |tenant|
+      next unless tenant.host == host || host.blank?
+
       Rails.logger.info "PROCESSING TENANT: #{tenant.host}..."
       Apartment::Tenant.switch(tenant.schema_name) do
-        if tenant.host == 'localhost' # temp
-          form_migrator = FlexibleInputFormMigrator.new
-          CustomForm.all.each do |custom_form|
-            form_migrator.migrate_form(custom_form, persist_changes)
-          end
-          form_migrator.output_stats tenant.host
+        form_migrator = FlexibleInputFormMigrator.new
+        CustomForm.all.each do |custom_form|
+          form_migrator.migrate_form(custom_form, persist_changes)
         end
+        stats[tenant.host] = form_migrator.stats
+      end
+    end
+
+    stats.each do |host, stat|
+      Rails.logger.info "STATS: #{host} - forms:#{stat[:forms]}(#{stat[:empty]}) update:#{stat[:updated]} create:#{stat[:created]}"
+      stat[:errors].each do |error|
+        Rails.logger.info "ERROR: #{error}"
       end
     end
   end
@@ -22,12 +51,11 @@ end
 
 class FlexibleInputFormMigrator
   def initialize
-    @stats = { forms: 0, empty: 0, errors: 0, updated: 0, created: 0 }
+    @stats = { forms: 0, empty: 0, updated: 0, created: 0, errors: [] }
+    @errors = []
   end
 
-  def output_stats(host)
-    Rails.logger.info "STATS for #{host}: #{@stats}"
-  end
+  attr_reader :stats
 
   def migrate_form(custom_form, persist_changes)
     @stats[:forms] += 1
@@ -43,27 +71,26 @@ class FlexibleInputFormMigrator
     end
 
     # Format the fields
-    if custom_form.participation_context.participation_method == 'ideation'
-      fields = merge_ideation_fields fields, custom_form
+    # TODO: Test timeline projects
+    Rails.logger.info "ORDERING: #{custom_form.id}"
+    if custom_form.participation_context.participation_method == 'native_survey'
+      fix_ordering(fields) # Only fix ordering in survey forms
     else
-      # Only fix ordering in other forms
-      fix_ordering(fields)
+      fields = merge_ideation_fields fields, custom_form
     end
 
     # Validate that sections / pages are present
     errors = {}
     IdeaCustomFieldsService.new(custom_form).check_form_structure fields, errors
     if errors.present?
-      Rails.logger.error "ERROR: Form structure does not validate #{errors}"
-      @stats[:errors] += 1
+      error_handler "Form structure does not validate #{errors}"
       return
     end
 
     # Validate that the ordering is correct
     ordering = fields.pluck('ordering')
     if ordering[0] != 0 || !ordering.each_cons(2).all? { |x, y| y == x + 1 }
-      Rails.logger.error "ERROR: Ordering is not correct - #{ordering}"
-      @stats[:errors] += 1
+      error_handler "Ordering is not correct - #{ordering}"
       return
     end
 
@@ -73,31 +100,50 @@ class FlexibleInputFormMigrator
       if field.persisted?
         if field.changed?
           Rails.logger.info "FIELD EXISTS - UPDATING: #{field_id} #{field.changes.keys}"
-          field.save! if persist_changes
+          if persist_changes && !field.save
+            error_handler "Cannot update field - #{field_id} - #{field.id} - #{field.errors.errors}"
+          end
           @stats[:updated] += 1
         else
           Rails.logger.info "FIELD EXISTS - NO CHANGES: #{field_id}"
         end
       else
         Rails.logger.info "NEW FIELD - CREATING: #{field_id}"
-        field.save! if persist_changes
+        if persist_changes && !field.save
+          error_handler "Cannot create field - #{field_id} - #{field.id} - #{field.errors.errors}"
+        end
         @stats[:created] += 1
       end
     end
+  end
+
+  def error_handler(error)
+    Rails.logger.error "ERROR: #{error}"
+    @stats[:errors] << error
   end
 
   def merge_ideation_fields(fields, custom_form)
     participation_method = Factory.instance.participation_method_for custom_form.participation_context
     default_fields = participation_method.default_fields(custom_form)
     constraints = participation_method.constraints
-
     updated_fields = []
+    
+    # TODO: It updated 1 on second run. title_multiloc ordering Why?? Ordering gem?
+
+    # Merge existing fields with same code as defaults
     default_fields.each do |default_field|
       existing_field = fields.find { |field| field.code == default_field.code }
       updated_fields << if existing_field
-        merge_attributes(existing_field, default_field, constraints)
+        merge_attributes(existing_field, default_field, constraints) 
       else
         default_field
+      end
+    end
+
+    # Add any additional custom fields that don't match the defaults
+    fields.each do |field|
+      unless updated_fields.find { |f| f.id == field.id }
+        updated_fields << field
       end
     end
     fix_ordering(updated_fields)
@@ -106,6 +152,8 @@ class FlexibleInputFormMigrator
   end
 
   # Fix ordering in the context of a form, not of the platform
+  # TODO: There is a helper method somewhere to do this, but can't find it 
+    # Others have raised concern about the ordering gem and this seems to work
   def fix_ordering(fields)
     fields.each_with_index do |field, index|
       field.ordering = index


### PR DESCRIPTION
Migration to get the forms from the old list of fields into the new state with sections and also fix ordering of all custom fields

Have tested against 3 largish platforms locally with ~75 total forms and ~ 600 fields updated ~240 additional fields created. All seems good. Took about 30 seconds.

Looked at stats on Metabase:

For non test or demo platforms: 1931 total forms

1 field
118 custom forms with 1 field - title, body, or location
73 are published
What shall we do? Assume defaults are OK

Between 2 & 5 fields
Only 7 of the following are published - Assume defaults are OK?

1 with 2 fields - title & body
3 with 3 - title, body & (files or images or topics)
2 with 4 - title, body, files & images
11 with 5 - missing budget and (files or location)

133 with 6 - missing budget - this code will create budget fields but not enabled

For all of these - the current site behaviour is whatever is missing just displays the default

Rest all have 7 fields
