### PR TITLE
[CL-2670] Use find because element can appear a bit later

### DIFF
--- a/front/app/containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/BannerImageFields/BannerImageFields.test.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/BannerImageFields/BannerImageFields.test.tsx
@@ -35,7 +35,7 @@ describe('BannerImageFields', () => {
       render(<BannerImageFields {...props} />);
 
       await uploadLocalImageForHeroBanner();
-      const select = screen.getByLabelText('Show preview for');
+      const select = await screen.findByLabelText('Show preview for');
       expect(select).toBeInTheDocument();
     });
 
@@ -63,11 +63,13 @@ describe('BannerImageFields', () => {
         expect(overlayInput).not.toBeInTheDocument();
       });
 
-      it.skip('shows when there is an unsaved image', async () => {
+      it('shows when there is an unsaved image', async () => {
         render(<BannerImageFields {...props} />);
 
         await uploadLocalImageForHeroBanner();
-        expect(screen.getByLabelText('Enable overlay')).toBeInTheDocument();
+        expect(
+          await screen.findByLabelText('Enable overlay')
+        ).toBeInTheDocument();
       });
     });
 
@@ -115,12 +117,11 @@ describe('BannerImageFields', () => {
     describe('when layout is fixed-ratio', () => {
       const bannerLayout = 'fixed_ratio_layout';
 
-      it('shows when there is an unsaved image', () => {
+      it('shows when there is an unsaved image', async () => {
         render(<BannerImageFields {...props} bannerLayout={bannerLayout} />);
 
-        uploadLocalImageForHeroBanner().then(() => {
-          expect(screen.getByTestId('image-cropper')).toBeInTheDocument();
-        });
+        await uploadLocalImageForHeroBanner();
+        expect(await screen.findByTestId('image-cropper')).toBeInTheDocument();
       });
     });
 


### PR DESCRIPTION
https://kentcdodds.com/blog/common-mistakes-with-react-testing-library#using-waitfor-to-wait-for-elements-that-can-be-queried-with-find

**Before the fix,**
tested 3 times with
```bash
for i in `seq 100`; do npm run test app/containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/BannerImageFields/BannerImageFields.test.tsx; [[ ! $? = 0 ]] && break ; done
```
Every time it failed after 61, 41, 47 runs.
Sometimes it failed on line 38, sometimes on line 70.

**After the fix,** 
it didn't fail after running the test `for` command 3 times.