### PR TITLE
[CL-2618] Remove unnecessary call for slug

### DIFF
--- a/front/app/containers/Admin/projects/components/ProjectRow/ManageButton.test.tsx
+++ b/front/app/containers/Admin/projects/components/ProjectRow/ManageButton.test.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { render, screen } from 'utils/testUtils/rtl';
+import ManageButton from './ManageButton';
+
+jest.mock('utils/cl-router/Link');
+jest.mock('services/locale');
+const projectId = '1';
+
+describe('ManageButton', () => {
+  it('links to the project page with the publicationId in the URL', () => {
+    render(<ManageButton publicationId={projectId} isDisabled={false} />);
+
+    expect(screen.getByRole('link')).toHaveAttribute(
+      'href',
+      `/en/admin/projects/${projectId}`
+    );
+  });
+});

--- a/front/app/modules/commercial/matomo/getProjectId.test.ts
+++ b/front/app/modules/commercial/matomo/getProjectId.test.ts
@@ -1,4 +1,11 @@
-import { extractIdeaSlug } from './getProjectId';
+import { Observable } from 'rxjs';
+import { delay } from 'rxjs/operators';
+
+import {
+  extractIdeaSlug,
+  getProjectId,
+  isOnAdminProjectPage,
+} from './getProjectId';
 
 jest.mock('services/appConfiguration');
 jest.mock('services/auth');
@@ -6,5 +13,67 @@ jest.mock('services/auth');
 describe('extractIdeaSlug', () => {
   it('works for /ideas/:slug', () => {
     expect(extractIdeaSlug('/ideas/some-slug')).toEqual('some-slug');
+  });
+});
+
+describe('isOnAdminProjectPage', () => {
+  it('returns true when the link is a project admin page', () => {
+    const isAdminLink = isOnAdminProjectPage(
+      '/en/admin/projects/e20f63ae-1fe4-49be-8bf9-599cc34e6515'
+    );
+    expect(isAdminLink).toEqual(true);
+  });
+
+  it('returns false when the link is a project admin page', () => {
+    const isAdminLink = isOnAdminProjectPage(
+      '/en/projects/e20f63ae-1fe4-49be-8bf9-599cc34e6515'
+    );
+    expect(isAdminLink).toEqual(false);
+  });
+});
+
+const mockProject = {
+  data: { id: 'project-id' },
+};
+const mockProjectObservable = new Observable((subscriber) => {
+  subscriber.next(mockProject);
+}).pipe(delay(1));
+
+jest.mock('services/projects', () => ({
+  projectBySlugStream: jest.fn(() => ({
+    observable: mockProjectObservable,
+  })),
+}));
+
+const mockIdea = {
+  data: { relationships: { project: { data: { id: 'project-id2' } } } },
+};
+
+const mockIdeaObservable = new Observable((subscriber) => {
+  subscriber.next(mockIdea);
+}).pipe(delay(1));
+
+jest.mock('services/ideas', () => ({
+  ideaBySlugStream: jest.fn(() => ({
+    observable: mockIdeaObservable,
+  })),
+}));
+
+describe('getProjectId', () => {
+  it('returns the project id directly when the project link is an admin link', async () => {
+    const projectId = await getProjectId(
+      '/en/admin/projects/e20f63ae-1fe4-49be-8bf9-599cc34e6515'
+    );
+    expect(projectId).toEqual('e20f63ae-1fe4-49be-8bf9-599cc34e6515');
+  });
+
+  it('returns the project id when a non admin project link is passed', async () => {
+    const projectId = await getProjectId('/en/projects/test-slug');
+    expect(projectId).toEqual('project-id');
+  });
+
+  it('returns the project id when an idea link is passed', async () => {
+    const projectId = await getProjectId('/en/ideas/some-idea');
+    expect(projectId).toEqual('project-id2');
   });
 });

--- a/front/app/modules/commercial/matomo/getProjectId.ts
+++ b/front/app/modules/commercial/matomo/getProjectId.ts
@@ -11,6 +11,7 @@ import { Subscription } from 'rxjs';
 
 export const getProjectId = async (path: string) => {
   if (isProjectPage(path)) {
+    // We are using an id in the admin and a slug for citizens
     if (isOnAdminProjectPage(path)) {
       return extractProjectIdOrSlug(path);
     } else {
@@ -52,7 +53,7 @@ const isProjectPage = (path: string) => {
   return projectPageDetectRegex.test(path);
 };
 
-const isOnAdminProjectPage = (path: string) => {
+export const isOnAdminProjectPage = (path: string) => {
   return adminProjectPageDetectRegex.test(path);
 };
 

--- a/front/app/modules/commercial/matomo/getProjectId.ts
+++ b/front/app/modules/commercial/matomo/getProjectId.ts
@@ -1,5 +1,4 @@
 // services
-import { projectBySlugStream, IProject } from 'services/projects';
 import { ideaBySlugStream, IIdea } from 'services/ideas';
 
 // utils
@@ -11,16 +10,7 @@ import { Subscription } from 'rxjs';
 
 export const getProjectId = async (path: string) => {
   if (isProjectPage(path)) {
-    const slug = extractProjectSlug(path);
-    if (!slug) return null;
-
-    const projectId = await getProjectIdFromProjectSlug(slug);
-    if (projectSubscriptions[slug]) {
-      projectSubscriptions[slug].unsubscribe();
-    }
-    delete projectSubscriptions[slug];
-
-    return projectId;
+    return extractProjectId(path);
   }
 
   if (isIdeaPage(path)) {
@@ -45,27 +35,9 @@ const isProjectPage = (path: string) => {
   return projectPageDetectRegex.test(path);
 };
 
-const extractProjectSlug = (path: string) => {
+const extractProjectId = (path: string) => {
   const matches = path.match(projectPageExtractRegex);
   return matches && matches[1];
-};
-
-const projectSubscriptions: Record<string, Subscription> = {};
-
-const getProjectIdFromProjectSlug = (slug: string): Promise<string | null> => {
-  return new Promise((resolve) => {
-    const observable = projectBySlugStream(slug).observable;
-
-    projectSubscriptions[slug] = observable.subscribe(
-      (project: IProject | NilOrError) => {
-        if (isNilOrError(project)) {
-          resolve(null);
-        } else {
-          resolve(project.data.id);
-        }
-      }
-    );
-  });
 };
 
 const ideaPageDetectRegex = RegExp(`/ideas/(${slugRegExSource})$`);

--- a/front/cypress/e2e/admin/projects/edit_project.cy.ts
+++ b/front/cypress/e2e/admin/projects/edit_project.cy.ts
@@ -1,0 +1,40 @@
+import { randomString } from '../../../support/commands';
+
+describe('Admin: edit project', () => {
+  const projectTitle = randomString();
+  const projectDescription = randomString(30);
+  const projectDescriptionPreview = randomString(30);
+  let projectId: string;
+
+  beforeEach(() => {
+    if (projectId) {
+      cy.apiRemoveProject(projectId);
+    }
+
+    cy.apiCreateProject({
+      type: 'continuous',
+      title: projectTitle,
+      descriptionPreview: projectDescriptionPreview,
+      description: projectDescription,
+      publicationStatus: 'published',
+      participationMethod: 'ideation',
+    }).then((project) => {
+      projectId = project.body.data.id;
+    });
+
+    cy.setAdminLoginCookie();
+    cy.visit('/admin/projects/');
+    cy.acceptCookies();
+  });
+
+  it('navigates to the project page when the user clicks the edit page', () => {
+    // Project should appear on top of the projects list
+    cy.get('#e2e-admin-projects-list-unsortable')
+      .children()
+      .first()
+      .contains(projectTitle);
+    cy.get('.e2e-admin-edit-publication > a').first().click({ force: true });
+
+    cy.location('pathname').should('eq', `/en/admin/projects/${projectId}`);
+  });
+});


### PR DESCRIPTION
Removes unnecessary API call for the slug to get a project ID since we already have the project id in the URL

## How urgent is a code review?

End of day if possible
