### PR TITLE
[CL-2747] custom field answer visible to

### DIFF
--- a/back/app/serializers/web_api/v1/custom_field_serializer.rb
+++ b/back/app/serializers/web_api/v1/custom_field_serializer.rb
@@ -9,8 +9,12 @@ class WebApi::V1::CustomFieldSerializer < WebApi::V1::BaseSerializer
   end
 
   attribute :answer_visible_to, if: proc { |object, _params|
-    @participation_method = Factory.instance.participation_method_for object.resource.participation_context
-    @participation_method.supports_answer_visible_to?
+    if object.resource
+      @participation_method = Factory.instance.participation_method_for object.resource.participation_context
+      @participation_method.supports_answer_visible_to?
+    else
+      false
+    end
   }
 
   attribute :hidden, if: proc { |object, _params|

--- a/back/app/serializers/web_api/v1/custom_field_serializer.rb
+++ b/back/app/serializers/web_api/v1/custom_field_serializer.rb
@@ -9,7 +9,7 @@ class WebApi::V1::CustomFieldSerializer < WebApi::V1::BaseSerializer
   end
 
   attribute :answer_visible_to, if: proc { |object, _params|
-    if object.resource
+    if object.resource && object.resource_type == 'CustomForm'
       @participation_method = Factory.instance.participation_method_for object.resource.participation_context
       @participation_method.supports_answer_visible_to?
     else

--- a/back/app/serializers/web_api/v1/custom_field_serializer.rb
+++ b/back/app/serializers/web_api/v1/custom_field_serializer.rb
@@ -2,11 +2,16 @@
 
 class WebApi::V1::CustomFieldSerializer < WebApi::V1::BaseSerializer
   attributes :key, :input_type, :title_multiloc, :required, :ordering,
-    :enabled, :code, :created_at, :updated_at, :logic, :answer_visible_to
+    :enabled, :code, :created_at, :updated_at, :logic
 
   attribute :description_multiloc do |field|
     TextImageService.new.render_data_images field, :description_multiloc
   end
+
+  attribute :answer_visible_to, if: proc { |object, _params|
+    @participation_method = Factory.instance.participation_method_for object.resource.participation_context
+    @participation_method.supports_answer_visible_to?
+  }
 
   attribute :hidden, if: proc { |object, _params|
     object.resource_type == 'User'

--- a/back/app/serializers/web_api/v1/custom_field_serializer.rb
+++ b/back/app/serializers/web_api/v1/custom_field_serializer.rb
@@ -8,23 +8,17 @@ class WebApi::V1::CustomFieldSerializer < WebApi::V1::BaseSerializer
     TextImageService.new.render_data_images field, :description_multiloc
   end
 
-  attribute :answer_visible_to, if: proc { |object, _params|
-    if object.resource && object.resource_type == 'CustomForm'
-      @participation_method = Factory.instance.participation_method_for object.resource.participation_context
-      @participation_method.supports_answer_visible_to?
-    else
-      false
-    end
+  attribute :answer_visible_to, if: proc { |_object, params|
+    params[:supports_answer_visible_to]
   }
 
   attribute :hidden, if: proc { |object, _params|
     object.resource_type == 'User'
   }
 
-  attribute :constraints do |object|
-    if object.resource_type == 'CustomForm'
-      @participation_method = Factory.instance.participation_method_for object.resource.participation_context
-      @participation_method.constraints[object.code&.to_sym] || {}
+  attribute :constraints do |object, params|
+    if params[:constraints]
+      params[:constraints][object.code&.to_sym] || {}
     else
       {}
     end

--- a/back/app/services/custom_field_service.rb
+++ b/back/app/services/custom_field_service.rb
@@ -106,21 +106,21 @@ class CustomFieldService
 
   # @param [Hash<String, _>] custom_field_values
   # @return [Hash<String, _>]
-  # Think this may not be correct as you can have the same key in multiple forms - could be enabled in one and not another
+  # Note: this only works for users - custom forms can have the same key in multiple forms
   def self.remove_disabled_custom_fields(custom_field_values)
     all_disabled_keys = CustomField.disabled.pluck(:key)
     disabled_keys = all_disabled_keys & custom_field_values.keys
     custom_field_values.except(*disabled_keys)
   end
 
-  def self.remove_not_visible_answers(idea, current_user)
-    return idea.custom_field_values if can_see_admin_answers?(idea, current_user)
-
-    # Do we need to check if this is ideation? Maybe not
+  def self.remove_not_visible_fields(idea, current_user)
     @custom_form = CustomForm.find_or_initialize_by participation_context: idea.project
-    @fields = IdeaCustomFieldsService.new(@custom_form).public_answer_fields
-    public_keys = @fields.pluck(:key)
-    idea.custom_field_values.slice(*public_keys)
+    @fields = IdeaCustomFieldsService.new(@custom_form).enabled_public_fields
+    if can_see_admin_answers?(idea, current_user)
+      @fields = IdeaCustomFieldsService.new(@custom_form).enabled_fields
+    end
+    visible_keys = @fields.pluck(:key)
+    idea.custom_field_values.slice(*visible_keys)
   end
 
   def self.can_see_admin_answers?(idea, current_user)

--- a/back/app/services/custom_field_service.rb
+++ b/back/app/services/custom_field_service.rb
@@ -106,14 +106,14 @@ class CustomFieldService
 
   # @param [Hash<String, _>] custom_field_values
   # @return [Hash<String, _>]
-  # Note: this only works for users - custom forms can have the same key in multiple forms
+  # NOTE: this only works for users - custom forms can have the same key in multiple forms
   def self.remove_disabled_custom_fields(custom_field_values)
     all_disabled_keys = CustomField.disabled.pluck(:key)
     disabled_keys = all_disabled_keys & custom_field_values.keys
     custom_field_values.except(*disabled_keys)
   end
 
-  # Note: Needs refactor. This is called by idea serializer so will have an n+1 issue
+  # NOTE: Needs refactor. This is called by idea serializer so will have an n+1 issue
   def self.remove_not_visible_fields(idea, current_user)
     custom_form = CustomForm.find_or_initialize_by participation_context: idea.project
     fields = IdeaCustomFieldsService.new(custom_form).enabled_public_fields

--- a/back/app/services/custom_field_service.rb
+++ b/back/app/services/custom_field_service.rb
@@ -106,10 +106,21 @@ class CustomFieldService
 
   # @param [Hash<String, _>] custom_field_values
   # @return [Hash<String, _>]
+  # Think this may not be correct as you can have the same key in multiple forms - could be enabled in one and not another
   def self.remove_disabled_custom_fields(custom_field_values)
     all_disabled_keys = CustomField.disabled.pluck(:key)
     disabled_keys = all_disabled_keys & custom_field_values.keys
     custom_field_values.except(*disabled_keys)
+  end
+
+  def self.remove_not_visible_answers(custom_field_values, project, can_moderate)
+    return custom_field_values if can_moderate
+
+    # Do we need to check if this is ideation? Maybe not
+    @custom_form = CustomForm.find_or_initialize_by participation_context: project
+    @fields = IdeaCustomFieldsService.new(@custom_form).public_answer_fields
+    public_keys = @fields.pluck(:key)
+    custom_field_values.slice(*public_keys)
   end
 
   private

--- a/back/app/services/custom_field_service.rb
+++ b/back/app/services/custom_field_service.rb
@@ -113,13 +113,14 @@ class CustomFieldService
     custom_field_values.except(*disabled_keys)
   end
 
+  # Note: Needs refactor. This is called by idea serializer so will have an n+1 issue
   def self.remove_not_visible_fields(idea, current_user)
-    @custom_form = CustomForm.find_or_initialize_by participation_context: idea.project
-    @fields = IdeaCustomFieldsService.new(@custom_form).enabled_public_fields
+    custom_form = CustomForm.find_or_initialize_by participation_context: idea.project
+    fields = IdeaCustomFieldsService.new(custom_form).enabled_public_fields
     if can_see_admin_answers?(idea, current_user)
-      @fields = IdeaCustomFieldsService.new(@custom_form).enabled_fields
+      fields = IdeaCustomFieldsService.new(custom_form).enabled_fields
     end
-    visible_keys = @fields.pluck(:key)
+    visible_keys = fields.pluck(:key)
     idea.custom_field_values.slice(*visible_keys)
   end
 

--- a/back/app/services/idea_custom_fields_service.rb
+++ b/back/app/services/idea_custom_fields_service.rb
@@ -18,16 +18,16 @@ class IdeaCustomFieldsService
     enabled_fields.reject(&:built_in?)
   end
 
-  def public_answer_fields
-    all_fields.select { |field| field.answer_visible_to == CustomField::VISIBLE_TO_PUBLIC }
-  end
-
   def visible_fields
     enabled_fields
   end
 
   def enabled_fields
     all_fields.select(&:enabled?)
+  end
+
+  def enabled_public_fields
+    enabled_fields.select { |field| field.answer_visible_to == CustomField::VISIBLE_TO_PUBLIC }
   end
 
   def extra_visible_fields

--- a/back/app/services/idea_custom_fields_service.rb
+++ b/back/app/services/idea_custom_fields_service.rb
@@ -18,6 +18,10 @@ class IdeaCustomFieldsService
     enabled_fields.reject(&:built_in?)
   end
 
+  def public_answer_fields
+    all_fields.select { |field| field.answer_visible_to == CustomField::VISIBLE_TO_PUBLIC }
+  end
+
   def visible_fields
     enabled_fields
   end

--- a/back/app/services/input_ui_schema_generator_service.rb
+++ b/back/app/services/input_ui_schema_generator_service.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class InputUiSchemaGeneratorService < UiSchemaGeneratorService
-  def initialize(input_term)
+  def initialize(input_term, supports_answer_visible_to)
     super()
     @input_term = input_term || ParticipationContext::DEFAULT_INPUT_TERM
+    @supports_answer_visible_to = supports_answer_visible_to
   end
 
   def visit_html_multiloc(field)
@@ -50,11 +51,8 @@ class InputUiSchemaGeneratorService < UiSchemaGeneratorService
       isAdminField: admin_field?(field),
       hasRule: field.logic?
     }
-    if field.resource # Required as the budget and author fields added don't have a resource
-      @participation_method = Factory.instance.participation_method_for field.resource.participation_context
-      if @participation_method.supports_answer_visible_to?
-        defaults[:answer_visible_to] = field.answer_visible_to
-      end
+    if @supports_answer_visible_to
+      defaults[:answer_visible_to] = field.answer_visible_to
     end
     super.merge(defaults).tap do |options|
       options[:description] = description_option field

--- a/back/app/services/input_ui_schema_generator_service.rb
+++ b/back/app/services/input_ui_schema_generator_service.rb
@@ -48,9 +48,14 @@ class InputUiSchemaGeneratorService < UiSchemaGeneratorService
   def default_options(field)
     defaults = {
       isAdminField: admin_field?(field),
-      hasRule: field.logic?,
-      answer_visible_to: field.answer_visible_to
+      hasRule: field.logic?
     }
+    if field.resource # Required as the budget and author fields added don't have a resource
+      @participation_method = Factory.instance.participation_method_for field.resource.participation_context
+      if @participation_method.supports_answer_visible_to?
+        defaults[:answer_visible_to] = field.answer_visible_to
+      end
+    end
     super.merge(defaults).tap do |options|
       options[:description] = description_option field
     end

--- a/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
+++ b/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
@@ -34,7 +34,7 @@ module IdeaCustomFields
       fields = IdeaCustomFieldsService.new(@custom_form).all_fields
       render json: ::WebApi::V1::CustomFieldSerializer.new(
         fields,
-        params: fastjson_params,
+        params: serializer_params(@custom_form),
         include: [:options]
       ).serialized_json
     end
@@ -42,7 +42,7 @@ module IdeaCustomFields
     def show
       render json: ::WebApi::V1::CustomFieldSerializer.new(
         @custom_field,
-        params: fastjson_params,
+        params: serializer_params(@custom_field),
         include: [:options]
       ).serialized_json
     end
@@ -60,7 +60,7 @@ module IdeaCustomFields
       update_logic! page_temp_ids_to_ids_mapping, option_temp_ids_to_ids_mapping, errors
       render json: ::WebApi::V1::CustomFieldSerializer.new(
         IdeaCustomFieldsService.new(@custom_form).all_fields,
-        params: fastjson_params,
+        params: serializer_params(@custom_form),
         include: [:options]
       ).serialized_json
     rescue UpdateAllFailedError => e
@@ -270,6 +270,11 @@ module IdeaCustomFields
 
     def render_updating_form_with_input_error
       render json: { error: :updating_form_with_input }, status: :unauthorized
+    end
+
+    def serializer_params(object)
+      participation_method = Factory.instance.participation_method_for object.participation_context
+      fastjson_params({ constraints: participation_method.constraints, supports_answer_visible_to: participation_method.supports_answer_visible_to? })
     end
   end
 end

--- a/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
+++ b/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
@@ -42,7 +42,7 @@ module IdeaCustomFields
     def show
       render json: ::WebApi::V1::CustomFieldSerializer.new(
         @custom_field,
-        params: serializer_params(@custom_field),
+        params: fastjson_params,
         include: [:options]
       ).serialized_json
     end
@@ -272,13 +272,9 @@ module IdeaCustomFields
       render json: { error: :updating_form_with_input }, status: :unauthorized
     end
 
-    def serializer_params(object)
-      if object.participation_context
-        participation_method = Factory.instance.participation_method_for object.participation_context
-        fastjson_params({ constraints: participation_method.constraints, supports_answer_visible_to: participation_method.supports_answer_visible_to? })
-      else
-        fastjson_params
-      end
+    def serializer_params(custom_form)
+      participation_method = Factory.instance.participation_method_for custom_form.participation_context
+      fastjson_params({ constraints: participation_method.constraints, supports_answer_visible_to: participation_method.supports_answer_visible_to? })
     end
   end
 end

--- a/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
+++ b/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
@@ -273,8 +273,12 @@ module IdeaCustomFields
     end
 
     def serializer_params(object)
-      participation_method = Factory.instance.participation_method_for object.participation_context
-      fastjson_params({ constraints: participation_method.constraints, supports_answer_visible_to: participation_method.supports_answer_visible_to? })
+      if object.participation_context
+        participation_method = Factory.instance.participation_method_for object.participation_context
+        fastjson_params({ constraints: participation_method.constraints, supports_answer_visible_to: participation_method.supports_answer_visible_to? })
+      else
+        fastjson_params
+      end
     end
   end
 end

--- a/back/engines/commercial/idea_custom_fields/app/serializers/idea_custom_fields/extensions/web_api/v1/idea_serializer.rb
+++ b/back/engines/commercial/idea_custom_fields/app/serializers/idea_custom_fields/extensions/web_api/v1/idea_serializer.rb
@@ -9,8 +9,9 @@ module IdeaCustomFields
             base.class_eval do
               attribute :custom_field_values, if: proc {
                 AppConfiguration.instance.feature_activated? 'idea_custom_fields'
-              } do |idea|
+              } do |idea, params|
                 CustomFieldService.remove_disabled_custom_fields idea.custom_field_values
+                CustomFieldService.remove_not_visible_answers idea.custom_field_values, idea.project, can_moderate?(idea, params)
               end
 
               def self.attributes_hash(record, fieldset = nil, params = {})

--- a/back/engines/commercial/idea_custom_fields/app/serializers/idea_custom_fields/extensions/web_api/v1/idea_serializer.rb
+++ b/back/engines/commercial/idea_custom_fields/app/serializers/idea_custom_fields/extensions/web_api/v1/idea_serializer.rb
@@ -10,8 +10,8 @@ module IdeaCustomFields
               attribute :custom_field_values, if: proc {
                 AppConfiguration.instance.feature_activated? 'idea_custom_fields'
               } do |idea, params|
-                CustomFieldService.remove_disabled_custom_fields idea.custom_field_values
-                CustomFieldService.remove_not_visible_answers idea.custom_field_values, idea.project, can_moderate?(idea, params)
+                idea.custom_field_values = CustomFieldService.remove_disabled_custom_fields idea.custom_field_values
+                CustomFieldService.remove_not_visible_answers idea, current_user(params)
               end
 
               def self.attributes_hash(record, fieldset = nil, params = {})

--- a/back/engines/commercial/idea_custom_fields/app/serializers/idea_custom_fields/extensions/web_api/v1/idea_serializer.rb
+++ b/back/engines/commercial/idea_custom_fields/app/serializers/idea_custom_fields/extensions/web_api/v1/idea_serializer.rb
@@ -10,8 +10,7 @@ module IdeaCustomFields
               attribute :custom_field_values, if: proc {
                 AppConfiguration.instance.feature_activated? 'idea_custom_fields'
               } do |idea, params|
-                idea.custom_field_values = CustomFieldService.remove_disabled_custom_fields idea.custom_field_values
-                CustomFieldService.remove_not_visible_answers idea, current_user(params)
+                CustomFieldService.remove_not_visible_fields idea, current_user(params)
               end
 
               def self.attributes_hash(record, fieldset = nil, params = {})

--- a/back/engines/commercial/idea_custom_fields/spec/serializers/web_api/v1/idea_serializer_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/serializers/web_api/v1/idea_serializer_spec.rb
@@ -7,20 +7,54 @@ describe WebApi::V1::IdeaSerializer do
     describe '#serializable_hash' do
       let(:project) { create :project }
       let(:form) { create :custom_form, participation_context: project }
-      let(:visible_field_value) { 1 }
-      let(:visible_field) { create :custom_field, :for_custom_form, resource: form, enabled: true, input_type: 'number' }
+
+      let(:visible_public_field) { create :custom_field, :for_custom_form, resource: form, enabled: true, input_type: 'number', answer_visible_to: 'public' }
+      let(:visible_admin_field) { create :custom_field, :for_custom_form, resource: form, enabled: true, input_type: 'number', answer_visible_to: 'admins' }
       let(:disabled_field) { create :custom_field, :for_custom_form, resource: form, enabled: false, input_type: 'number' }
-      let(:custom_field_values) { { visible_field.key => visible_field_value, disabled_field.key => 2 } }
-      let(:idea) { create :idea, project: project, custom_field_values: custom_field_values }
 
-      it 'serializes all visible extra fields at the same level of the idea fields' do
+      let(:visible_public_value) { 1 }
+      let(:visible_admin_value) { 2 }
+      let(:disabled_value) { 3 }
+
+      let(:custom_field_values) do
+        {
+          visible_public_field.key => visible_public_value,
+          visible_admin_field.key => visible_admin_value,
+          disabled_field.key => disabled_value
+        }
+      end
+      let(:idea_author) { create(:user) }
+      let(:idea) { create :idea, project: project, custom_field_values: custom_field_values, author: idea_author }
+
+      before_all do
         SettingsService.new.activate_feature! 'idea_custom_fields'
+      end
 
-        output = described_class.new(idea, params: { current_user: create(:user) }).serializable_hash
-        expect(output.dig(:data, :attributes, visible_field.key.to_sym)).to eq visible_field_value
-        expect(output.dig(:data, :attributes)).not_to have_key disabled_field.key
+      it 'serializes all visible extra fields at the same level as the idea fields for the idea author' do
+        output = described_class.new(idea, params: { current_user: idea_author }).serializable_hash
+        expect(output.dig(:data, :attributes, visible_public_field.key.to_sym)).to eq visible_public_value
+        expect(output.dig(:data, :attributes, visible_admin_field.key.to_sym)).to eq visible_admin_value
+        expect(output.dig(:data, :attributes)).not_to have_key disabled_field.key.to_sym # ???????
         expect(output.dig(:data, :attributes)).not_to have_key :custom_field_values
       end
+
+      it 'serializes all visible extra fields at the same level as the idea fields for an admin user' do
+        admin_user = create(:admin)
+        output = described_class.new(idea, params: { current_user: admin_user }).serializable_hash
+        expect(output.dig(:data, :attributes, visible_public_field.key.to_sym)).to eq visible_public_value
+        expect(output.dig(:data, :attributes, visible_admin_field.key.to_sym)).to eq visible_admin_value
+        expect(output.dig(:data, :attributes)).not_to have_key disabled_field.key.to_sym
+        expect(output.dig(:data, :attributes)).not_to have_key :custom_field_values
+      end
+
+      it 'only serializes public fields for a public user' do
+        output = described_class.new(idea, params: { current_user: nil }).serializable_hash
+        expect(output.dig(:data, :attributes)).to have_key visible_public_field.key.to_sym
+        expect(output.dig(:data, :attributes)).not_to have_key visible_admin_field.key.to_sym
+        expect(output.dig(:data, :attributes)).not_to have_key disabled_field.key.to_sym
+        expect(output.dig(:data, :attributes)).not_to have_key :custom_field_values
+      end
+
     end
   end
 end

--- a/back/engines/commercial/idea_custom_fields/spec/serializers/web_api/v1/idea_serializer_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/serializers/web_api/v1/idea_serializer_spec.rb
@@ -54,7 +54,6 @@ describe WebApi::V1::IdeaSerializer do
         expect(output.dig(:data, :attributes)).not_to have_key disabled_field.key.to_sym
         expect(output.dig(:data, :attributes)).not_to have_key :custom_field_values
       end
-
     end
   end
 end

--- a/back/engines/commercial/idea_custom_fields/spec/serializers/web_api/v1/idea_serializer_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/serializers/web_api/v1/idea_serializer_spec.rb
@@ -34,7 +34,7 @@ describe WebApi::V1::IdeaSerializer do
         output = described_class.new(idea, params: { current_user: idea_author }).serializable_hash
         expect(output.dig(:data, :attributes, visible_public_field.key.to_sym)).to eq visible_public_value
         expect(output.dig(:data, :attributes, visible_admin_field.key.to_sym)).to eq visible_admin_value
-        expect(output.dig(:data, :attributes)).not_to have_key disabled_field.key.to_sym # ???????
+        expect(output.dig(:data, :attributes)).not_to have_key disabled_field.key.to_sym
         expect(output.dig(:data, :attributes)).not_to have_key :custom_field_values
       end
 
@@ -49,7 +49,7 @@ describe WebApi::V1::IdeaSerializer do
 
       it 'only serializes public fields for a public user' do
         output = described_class.new(idea, params: { current_user: nil }).serializable_hash
-        expect(output.dig(:data, :attributes)).to have_key visible_public_field.key.to_sym
+        expect(output.dig(:data, :attributes, visible_public_field.key.to_sym)).to eq visible_public_value
         expect(output.dig(:data, :attributes)).not_to have_key visible_admin_field.key.to_sym
         expect(output.dig(:data, :attributes)).not_to have_key disabled_field.key.to_sym
         expect(output.dig(:data, :attributes)).not_to have_key :custom_field_values

--- a/back/lib/participation_method/base.rb
+++ b/back/lib/participation_method/base.rb
@@ -105,6 +105,10 @@ module ParticipationMethod
       false
     end
 
+    def supports_answer_visible_to?
+      false
+    end
+
     private
 
     attr_reader :participation_context

--- a/back/lib/participation_method/ideation.rb
+++ b/back/lib/participation_method/ideation.rb
@@ -300,5 +300,9 @@ module ParticipationMethod
     def include_author_budget_in_schema?
       true
     end
+
+    def supports_answer_visible_to?
+      true
+    end
   end
 end

--- a/back/spec/models/custom_field_spec.rb
+++ b/back/spec/models/custom_field_spec.rb
@@ -413,5 +413,4 @@ RSpec.describe CustomField, type: :model do
       end
     end
   end
-
 end

--- a/back/spec/serializers/web_api/v1/custom_field_serializer_spec.rb
+++ b/back/spec/serializers/web_api/v1/custom_field_serializer_spec.rb
@@ -29,7 +29,8 @@ describe WebApi::V1::CustomFieldSerializer do
     end
 
     it 'includes the attributes of a field' do
-      serialized_field = described_class.new(field).serializable_hash
+      params = { params: { constraints: {}, supports_answer_visible_to: true } }
+      serialized_field = described_class.new(field, params).serializable_hash
       attributes = serialized_field[:data][:attributes]
       expect(attributes).to match({
         code: nil,
@@ -83,8 +84,7 @@ describe WebApi::V1::CustomFieldSerializer do
         title_multiloc: { 'en' => 'We need a swimming pool.' },
         updated_at: an_instance_of(ActiveSupport::TimeWithZone),
         logic: {},
-        constraints: {},
-        answer_visible_to: 'admins'
+        constraints: {}
       })
     end
   end
@@ -114,8 +114,7 @@ describe WebApi::V1::CustomFieldSerializer do
         title_multiloc: { 'en' => 'Cycling survey' },
         updated_at: an_instance_of(ActiveSupport::TimeWithZone),
         logic: { 'next_page_id' => 'TEMP-ID-1' },
-        constraints: {},
-        answer_visible_to: 'public'
+        constraints: {}
       })
     end
   end

--- a/back/spec/serializers/web_api/v1/custom_field_serializer_spec.rb
+++ b/back/spec/serializers/web_api/v1/custom_field_serializer_spec.rb
@@ -43,7 +43,8 @@ describe WebApi::V1::CustomFieldSerializer do
         title_multiloc: { 'en' => 'Did you attend' },
         updated_at: an_instance_of(ActiveSupport::TimeWithZone),
         logic: {},
-        constraints: {}
+        constraints: {},
+        answer_visible_to: 'admins'
       })
     end
   end
@@ -82,7 +83,8 @@ describe WebApi::V1::CustomFieldSerializer do
         title_multiloc: { 'en' => 'We need a swimming pool.' },
         updated_at: an_instance_of(ActiveSupport::TimeWithZone),
         logic: {},
-        constraints: {}
+        constraints: {},
+        answer_visible_to: 'admins'
       })
     end
   end
@@ -112,7 +114,8 @@ describe WebApi::V1::CustomFieldSerializer do
         title_multiloc: { 'en' => 'Cycling survey' },
         updated_at: an_instance_of(ActiveSupport::TimeWithZone),
         logic: { 'next_page_id' => 'TEMP-ID-1' },
-        constraints: {}
+        constraints: {},
+        answer_visible_to: 'public'
       })
     end
   end

--- a/back/spec/services/idea_custom_fields_service_spec.rb
+++ b/back/spec/services/idea_custom_fields_service_spec.rb
@@ -73,6 +73,23 @@ describe IdeaCustomFieldsService do
       end
     end
 
+    describe 'enabled_public_fields' do
+      it 'excludes disabled & answer_visible_to: admins fields' do
+        output = service.enabled_public_fields
+        expect(output.map(&:code)).to eq %w[
+          ideation_section1
+          title_multiloc
+          body_multiloc
+          ideation_section2
+          idea_images_attributes
+          idea_files_attributes
+          ideation_section3
+          topic_ids
+          location_description
+        ]
+      end
+    end
+
     describe 'extra_visible_fields' do
       it 'excludes disabled and built-in fields' do
         output = service.extra_visible_fields
@@ -174,6 +191,24 @@ describe IdeaCustomFieldsService do
           'idea_files_attributes',
           'ideation_section3',
           nil
+        ]
+      end
+    end
+
+    describe 'enabled_public_fields' do
+      it 'excludes disabled & answer_visible_to: admins fields' do
+        location_field = custom_form.custom_fields.find_by(code: 'location_description')
+        location_field.update!(answer_visible_to: 'admins')
+        output = service.enabled_public_fields
+        expect(output.map(&:code)).to eq %w[
+          ideation_section1
+          title_multiloc
+          body_multiloc
+          ideation_section2
+          idea_images_attributes
+          idea_files_attributes
+          ideation_section3
+          topic_ids
         ]
       end
     end

--- a/back/spec/services/input_ui_schema_generator_service_spec.rb
+++ b/back/spec/services/input_ui_schema_generator_service_spec.rb
@@ -9,1033 +9,1058 @@ require 'rails_helper'
 # passed when creating an instance of the described class.
 
 RSpec.describe InputUiSchemaGeneratorService do
-  subject(:generator) { described_class.new input_term }
-
   let(:input_term) { 'question' }
   let(:field_key) { 'field_key' }
-  let(:ui_schema) { generator.generate_for IdeaCustomFieldsService.new(custom_form).enabled_fields }
 
   describe '#generate_for' do
-    context 'for a continuous ideation project with a changed built-in field and an extra section and field' do
-      let(:project) { create :continuous_project, input_term: input_term }
-      let!(:custom_form) do
-        create(:custom_form, :with_default_fields, participation_context: project).tap do |form|
-          form.custom_fields.find_by(code: 'title_multiloc').update!(
-            description_multiloc: { 'en' => 'My title description', 'nl-NL' => 'Mijn titel beschrijving' }
+    context 'ideation form' do
+      subject(:generator) { described_class.new input_term, true }
+
+      let(:ui_schema) { generator.generate_for IdeaCustomFieldsService.new(custom_form).enabled_fields }
+
+      context 'for a continuous ideation project with a changed built-in field and an extra section and field' do
+        let(:project) { create :continuous_project, input_term: input_term }
+        let!(:custom_form) do
+          create(:custom_form, :with_default_fields, participation_context: project).tap do |form|
+            form.custom_fields.find_by(code: 'title_multiloc').update!(
+              description_multiloc: { 'en' => 'My title description', 'nl-NL' => 'Mijn titel beschrijving' }
+            )
+          end
+        end
+        let!(:extra_section) do
+          create(
+            :custom_field_section,
+            :for_custom_form,
+            resource: custom_form,
+            title_multiloc: {
+              'en' => 'Extra fields',
+              # No 'nl-NL' to describe that it will default to 'en'.
+              'fr-FR' => 'Extra choses'
+            },
+            description_multiloc: {
+              'en' => 'Custom stuff',
+              # No 'nl-NL' to describe that it will default to 'en'.
+              'fr-FR' => 'Des choses en plus'
+            }
+          )
+        end
+        let!(:extra_field) do
+          create(
+            :custom_field,
+            :for_custom_form,
+            resource: custom_form,
+            input_type: 'html_multiloc',
+            key: 'extra_field',
+            title_multiloc: {
+              'en' => 'Extra field title',
+              'nl-NL' => 'Extra veldtitel'
+              # No 'fr-FR' to describe that it will default to 'en'.
+            },
+            description_multiloc: {
+              'en' => 'Extra field description',
+              'nl-NL' => 'Extra veldbeschrijving'
+              # No 'fr-FR' to describe that it will default to 'en'.
+            }
+          )
+        end
+
+        it 'returns the schema for the given fields' do
+          expect(ui_schema.keys).to match_array %w[en fr-FR nl-NL]
+          # en
+          expect(ui_schema['en']).to eq(
+            type: 'Categorization',
+            options: {
+              formId: 'idea-form',
+              inputTerm: input_term
+            },
+            elements: [
+              {
+                type: 'Category',
+                label: 'What is your question?',
+                options: { id: custom_form.custom_fields.find_by(code: 'ideation_section1').id },
+                elements: [
+                  {
+                    type: 'VerticalLayout',
+                    options: { input_type: 'text_multiloc', render: 'multiloc' },
+                    elements: [
+                      {
+                        type: 'Control',
+                        scope: '#/properties/title_multiloc/properties/en',
+                        label: 'Title',
+                        options: {
+                          answer_visible_to: 'public',
+                          description: 'My title description',
+                          isAdminField: false,
+                          hasRule: false,
+                          locale: 'en',
+                          trim_on_blur: true
+                        }
+                      },
+                      {
+                        type: 'Control',
+                        scope: '#/properties/title_multiloc/properties/fr-FR',
+                        label: 'Title',
+                        options: {
+                          answer_visible_to: 'public',
+                          description: 'My title description',
+                          isAdminField: false,
+                          hasRule: false,
+                          locale: 'fr-FR',
+                          trim_on_blur: true
+                        }
+                      },
+                      {
+                        type: 'Control',
+                        scope: '#/properties/title_multiloc/properties/nl-NL',
+                        label: 'Title',
+                        options: {
+                          answer_visible_to: 'public',
+                          description: 'My title description',
+                          isAdminField: false,
+                          hasRule: false,
+                          locale: 'nl-NL',
+                          trim_on_blur: true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    type: 'VerticalLayout',
+                    options: { input_type: 'html_multiloc', render: 'multiloc' },
+                    elements: [
+                      {
+                        type: 'Control',
+                        scope: '#/properties/body_multiloc/properties/en',
+                        label: 'Description',
+                        options: {
+                          answer_visible_to: 'public',
+                          description: '',
+                          isAdminField: false,
+                          hasRule: false,
+                          render: 'WYSIWYG',
+                          locale: 'en'
+                        }
+                      },
+                      {
+                        type: 'Control',
+                        scope: '#/properties/body_multiloc/properties/fr-FR',
+                        label: 'Description',
+                        options: {
+                          answer_visible_to: 'public',
+                          description: '',
+                          isAdminField: false,
+                          hasRule: false,
+                          render: 'WYSIWYG',
+                          locale: 'fr-FR'
+                        }
+                      },
+                      {
+                        type: 'Control',
+                        scope: '#/properties/body_multiloc/properties/nl-NL',
+                        label: 'Description',
+                        options: {
+                          answer_visible_to: 'public',
+                          description: '',
+                          isAdminField: false,
+                          hasRule: false,
+                          render: 'WYSIWYG',
+                          locale: 'nl-NL'
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                type: 'Category',
+                label: 'Images and attachments',
+                options: {
+                  id: custom_form.custom_fields.find_by(code: 'ideation_section2').id,
+                  description: 'Upload your favourite files here'
+                },
+                elements: [
+                  {
+                    type: 'Control',
+                    scope: '#/properties/idea_images_attributes',
+                    label: 'Images',
+                    options: {
+                      answer_visible_to: 'public',
+                      description: '',
+                      input_type: 'image_files',
+                      isAdminField: false,
+                      hasRule: false
+                    }
+                  },
+                  {
+                    type: 'Control',
+                    scope: '#/properties/idea_files_attributes',
+                    label: 'Attachments',
+                    options: {
+                      answer_visible_to: 'public',
+                      description: '',
+                      input_type: 'files',
+                      isAdminField: false,
+                      hasRule: false
+                    }
+                  }
+                ]
+              },
+              {
+                type: 'Category',
+                label: 'Details',
+                options: {
+                  id: custom_form.custom_fields.find_by(code: 'ideation_section3').id
+                },
+                elements: [
+                  {
+                    type: 'Control',
+                    scope: '#/properties/topic_ids',
+                    label: 'Tags',
+                    options: {
+                      answer_visible_to: 'public',
+                      description: '',
+                      input_type: 'topic_ids',
+                      isAdminField: false,
+                      hasRule: false
+                    }
+                  },
+                  {
+                    type: 'Control',
+                    scope: '#/properties/location_description',
+                    label: 'Location',
+                    options: {
+                      answer_visible_to: 'public',
+                      description: '',
+                      input_type: 'text',
+                      isAdminField: false,
+                      hasRule: false,
+                      transform: 'trim_on_blur'
+                    }
+                  }
+                ]
+              },
+              {
+                type: 'Category',
+                label: 'Extra fields',
+                options: { id: extra_section.id, description: 'Custom stuff' },
+                elements: [
+                  {
+                    type: 'VerticalLayout',
+                    options: { input_type: 'html_multiloc', render: 'multiloc' },
+                    elements: [
+                      {
+                        type: 'Control',
+                        scope: '#/properties/extra_field/properties/en',
+                        label: 'Extra field title',
+                        options: {
+                          answer_visible_to: 'admins',
+                          description: 'Extra field description',
+                          isAdminField: false,
+                          hasRule: false,
+                          locale: 'en',
+                          render: 'WYSIWYG',
+                          trim_on_blur: true
+                        }
+                      },
+                      {
+                        type: 'Control',
+                        scope: '#/properties/extra_field/properties/fr-FR',
+                        label: 'Extra field title',
+                        options: {
+                          answer_visible_to: 'admins',
+                          description: 'Extra field description',
+                          isAdminField: false,
+                          hasRule: false,
+                          locale: 'fr-FR',
+                          render: 'WYSIWYG',
+                          trim_on_blur: true
+                        }
+                      },
+                      {
+                        type: 'Control',
+                        scope: '#/properties/extra_field/properties/nl-NL',
+                        label: 'Extra field title',
+                        options: {
+                          answer_visible_to: 'admins',
+                          description: 'Extra field description',
+                          isAdminField: false,
+                          hasRule: false,
+                          locale: 'nl-NL',
+                          render: 'WYSIWYG',
+                          trim_on_blur: true
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          )
+          # fr-FR
+          expect(ui_schema['fr-FR']).to match(
+            type: 'Categorization',
+            options: {
+              formId: 'idea-form',
+              inputTerm: input_term
+            },
+            elements: [
+              hash_including(
+                type: 'Category',
+                label: 'Quelle est votre question ?',
+                elements: [
+                  hash_including(
+                    type: 'VerticalLayout',
+                    options: { input_type: 'text_multiloc', render: 'multiloc' },
+                    elements: [
+                      hash_including(
+                        scope: '#/properties/title_multiloc/properties/en',
+                        label: 'Titre',
+                        options: hash_including(locale: 'en')
+                      ),
+                      hash_including(
+                        scope: '#/properties/title_multiloc/properties/fr-FR',
+                        label: 'Titre',
+                        options: hash_including(locale: 'fr-FR')
+                      ),
+                      hash_including(
+                        scope: '#/properties/title_multiloc/properties/nl-NL',
+                        label: 'Titre',
+                        options: hash_including(locale: 'nl-NL')
+                      )
+                    ]
+                  ),
+                  hash_including(
+                    type: 'VerticalLayout',
+                    options: { input_type: 'html_multiloc', render: 'multiloc' },
+                    elements: [
+                      hash_including(
+                        scope: '#/properties/body_multiloc/properties/en',
+                        label: 'Description',
+                        options: hash_including(locale: 'en', render: 'WYSIWYG')
+                      ),
+                      hash_including(
+                        scope: '#/properties/body_multiloc/properties/fr-FR',
+                        label: 'Description',
+                        options: hash_including(locale: 'fr-FR', render: 'WYSIWYG')
+                      ),
+                      hash_including(
+                        scope: '#/properties/body_multiloc/properties/nl-NL',
+                        label: 'Description',
+                        options: hash_including(locale: 'nl-NL', render: 'WYSIWYG')
+                      )
+                    ]
+                  )
+                ]
+              ),
+              hash_including(
+                type: 'Category',
+                label: 'Images et pièces jointes',
+                elements: [
+                  hash_including(
+                    type: 'Control',
+                    scope: '#/properties/idea_images_attributes',
+                    label: 'Images',
+                    options: hash_including(input_type: 'image_files')
+                  ),
+                  hash_including(
+                    type: 'Control',
+                    scope: '#/properties/idea_files_attributes',
+                    label: 'Pièces jointes',
+                    options: hash_including(input_type: 'files')
+                  )
+                ]
+              ),
+              hash_including(
+                type: 'Category',
+                label: 'Details',
+                elements: [
+                  hash_including(
+                    type: 'Control',
+                    scope: '#/properties/topic_ids',
+                    label: 'Étiquettes',
+                    options: hash_including(input_type: 'topic_ids')
+                  ),
+                  hash_including(
+                    type: 'Control',
+                    scope: '#/properties/location_description',
+                    label: 'Adresse',
+                    options: hash_including(input_type: 'text')
+                  )
+                ]
+              ),
+              hash_including(
+                type: 'Category',
+                label: 'Extra choses',
+                options: hash_including(description: 'Des choses en plus'),
+                elements: [
+                  hash_including(
+                    type: 'VerticalLayout',
+                    options: { input_type: 'html_multiloc', render: 'multiloc' },
+                    elements: [
+                      hash_including(
+                        type: 'Control',
+                        scope: '#/properties/extra_field/properties/en',
+                        label: 'Extra field title',
+                        options: hash_including(description: 'Extra field description', locale: 'en', render: 'WYSIWYG')
+                      ),
+                      hash_including(
+                        type: 'Control',
+                        scope: '#/properties/extra_field/properties/fr-FR',
+                        label: 'Extra field title',
+                        options: hash_including(description: 'Extra field description', locale: 'fr-FR', render: 'WYSIWYG')
+                      ),
+                      hash_including(
+                        type: 'Control',
+                        scope: '#/properties/extra_field/properties/nl-NL',
+                        label: 'Extra field title',
+                        options: hash_including(description: 'Extra field description', locale: 'nl-NL', render: 'WYSIWYG')
+                      )
+                    ]
+                  )
+                ]
+              )
+            ]
+          )
+          # nl-NL
+          expect(ui_schema['nl-NL']).to match(
+            type: 'Categorization',
+            options: {
+              formId: 'idea-form',
+              inputTerm: input_term
+            },
+            elements: [
+              hash_including(
+                type: 'Category',
+                label: 'Wat is je vraag?',
+                elements: [
+                  hash_including(
+                    type: 'VerticalLayout',
+                    options: { input_type: 'text_multiloc', render: 'multiloc' },
+                    elements: [
+                      hash_including(
+                        scope: '#/properties/title_multiloc/properties/en',
+                        label: 'Titel',
+                        options: hash_including(locale: 'en', description: 'Mijn titel beschrijving')
+                      ),
+                      hash_including(
+                        scope: '#/properties/title_multiloc/properties/fr-FR',
+                        label: 'Titel',
+                        options: hash_including(locale: 'fr-FR', description: 'Mijn titel beschrijving')
+                      ),
+                      hash_including(
+                        scope: '#/properties/title_multiloc/properties/nl-NL',
+                        label: 'Titel',
+                        options: hash_including(locale: 'nl-NL', description: 'Mijn titel beschrijving')
+                      )
+                    ]
+                  ),
+                  hash_including(
+                    type: 'VerticalLayout',
+                    options: { input_type: 'html_multiloc', render: 'multiloc' },
+                    elements: [
+                      hash_including(
+                        scope: '#/properties/body_multiloc/properties/en',
+                        label: 'Beschrijving',
+                        options: hash_including(locale: 'en', render: 'WYSIWYG')
+                      ),
+                      hash_including(
+                        scope: '#/properties/body_multiloc/properties/fr-FR',
+                        label: 'Beschrijving',
+                        options: hash_including(locale: 'fr-FR', render: 'WYSIWYG')
+                      ),
+                      hash_including(
+                        scope: '#/properties/body_multiloc/properties/nl-NL',
+                        label: 'Beschrijving',
+                        options: hash_including(locale: 'nl-NL', render: 'WYSIWYG')
+                      )
+                    ]
+                  )
+                ]
+              ),
+              hash_including(
+                type: 'Category',
+                label: 'Afbeeldingen en bijlagen',
+                elements: [
+                  hash_including(
+                    type: 'Control',
+                    scope: '#/properties/idea_images_attributes',
+                    label: 'Afbeeldingen',
+                    options: hash_including(input_type: 'image_files')
+                  ),
+                  hash_including(
+                    type: 'Control',
+                    scope: '#/properties/idea_files_attributes',
+                    label: 'Bijlagen',
+                    options: hash_including(input_type: 'files')
+                  )
+                ]
+              ),
+              hash_including(
+                type: 'Category',
+                label: 'Details',
+                elements: [
+                  hash_including(
+                    type: 'Control',
+                    scope: '#/properties/topic_ids',
+                    label: 'Tags',
+                    options: hash_including(input_type: 'topic_ids')
+                  ),
+                  hash_including(
+                    type: 'Control',
+                    scope: '#/properties/location_description',
+                    label: 'Locatie',
+                    options: hash_including(input_type: 'text')
+                  )
+                ]
+              ),
+              hash_including(
+                type: 'Category',
+                label: 'Extra fields',
+                options: hash_including(description: 'Custom stuff'),
+                elements: [
+                  hash_including(
+                    type: 'VerticalLayout',
+                    options: { input_type: 'html_multiloc', render: 'multiloc' },
+                    elements: [
+                      hash_including(
+                        type: 'Control',
+                        scope: '#/properties/extra_field/properties/en',
+                        label: 'Extra veldtitel',
+                        options: hash_including(description: 'Extra veldbeschrijving', locale: 'en', render: 'WYSIWYG')
+                      ),
+                      hash_including(
+                        type: 'Control',
+                        scope: '#/properties/extra_field/properties/fr-FR',
+                        label: 'Extra veldtitel',
+                        options: hash_including(description: 'Extra veldbeschrijving', locale: 'fr-FR', render: 'WYSIWYG')
+                      ),
+                      hash_including(
+                        type: 'Control',
+                        scope: '#/properties/extra_field/properties/nl-NL',
+                        label: 'Extra veldtitel',
+                        options: hash_including(description: 'Extra veldbeschrijving', locale: 'nl-NL', render: 'WYSIWYG')
+                      )
+                    ]
+                  )
+                ]
+              )
+            ]
           )
         end
       end
-      let!(:extra_section) do
-        create(
-          :custom_field_section,
-          :for_custom_form,
-          resource: custom_form,
-          title_multiloc: {
-            'en' => 'Extra fields',
-            # No 'nl-NL' to describe that it will default to 'en'.
-            'fr-FR' => 'Extra choses'
-          },
-          description_multiloc: {
-            'en' => 'Custom stuff',
-            # No 'nl-NL' to describe that it will default to 'en'.
-            'fr-FR' => 'Des choses en plus'
-          }
-        )
-      end
-      let!(:extra_field) do
-        create(
-          :custom_field,
-          :for_custom_form,
-          resource: custom_form,
-          input_type: 'html_multiloc',
-          key: 'extra_field',
-          title_multiloc: {
-            'en' => 'Extra field title',
-            'nl-NL' => 'Extra veldtitel'
-            # No 'fr-FR' to describe that it will default to 'en'.
-          },
-          description_multiloc: {
-            'en' => 'Extra field description',
-            'nl-NL' => 'Extra veldbeschrijving'
-            # No 'fr-FR' to describe that it will default to 'en'.
-          }
-        )
+
+      context 'for a continuous ideation project with an empty custom section' do
+        let(:project) { create :continuous_project, input_term: input_term }
+        let!(:custom_form) { create :custom_form, :with_default_fields, participation_context: project }
+        let!(:extra_section) do
+          create(
+            :custom_field_section,
+            :for_custom_form,
+            resource: custom_form,
+            title_multiloc: { 'en' => 'Empty custom section' }
+          )
+        end
+
+        it 'returns the schema for the given fields' do
+          expect(ui_schema.keys).to match_array %w[en fr-FR nl-NL]
+          expect(ui_schema['en']).to match(
+            type: 'Categorization',
+            options: {
+              formId: 'idea-form',
+              inputTerm: input_term
+            },
+            elements: [
+              hash_including(type: 'Category', label: 'What is your question?'),
+              hash_including(type: 'Category', label: 'Images and attachments'),
+              hash_including(type: 'Category', label: 'Details'),
+              hash_including(type: 'Category', label: 'Empty custom section', elements: [])
+            ]
+          )
+        end
       end
 
-      it 'returns the schema for the given fields' do
-        expect(ui_schema.keys).to match_array %w[en fr-FR nl-NL]
-        # en
-        expect(ui_schema['en']).to eq(
-          type: 'Categorization',
-          options: {
-            formId: 'idea-form',
-            inputTerm: input_term
-          },
-          elements: [
-            {
-              type: 'Category',
-              label: 'What is your question?',
-              options: { id: custom_form.custom_fields.find_by(code: 'ideation_section1').id },
-              elements: [
-                {
-                  type: 'VerticalLayout',
-                  options: { input_type: 'text_multiloc', render: 'multiloc' },
-                  elements: [
-                    {
-                      type: 'Control',
-                      scope: '#/properties/title_multiloc/properties/en',
-                      label: 'Title',
-                      options: {
-                        description: 'My title description',
-                        isAdminField: false,
-                        hasRule: false,
-                        locale: 'en',
-                        trim_on_blur: true
-                      }
-                    },
-                    {
-                      type: 'Control',
-                      scope: '#/properties/title_multiloc/properties/fr-FR',
-                      label: 'Title',
-                      options: {
-                        description: 'My title description',
-                        isAdminField: false,
-                        hasRule: false,
-                        locale: 'fr-FR',
-                        trim_on_blur: true
-                      }
-                    },
-                    {
-                      type: 'Control',
-                      scope: '#/properties/title_multiloc/properties/nl-NL',
-                      label: 'Title',
-                      options: {
-                        description: 'My title description',
-                        isAdminField: false,
-                        hasRule: false,
-                        locale: 'nl-NL',
-                        trim_on_blur: true
-                      }
-                    }
-                  ]
-                },
-                {
-                  type: 'VerticalLayout',
-                  options: { input_type: 'html_multiloc', render: 'multiloc' },
-                  elements: [
-                    {
-                      type: 'Control',
-                      scope: '#/properties/body_multiloc/properties/en',
-                      label: 'Description',
-                      options: {
-                        description: '',
-                        isAdminField: false,
-                        hasRule: false,
-                        render: 'WYSIWYG',
-                        locale: 'en'
-                      }
-                    },
-                    {
-                      type: 'Control',
-                      scope: '#/properties/body_multiloc/properties/fr-FR',
-                      label: 'Description',
-                      options: {
-                        description: '',
-                        isAdminField: false,
-                        hasRule: false,
-                        render: 'WYSIWYG',
-                        locale: 'fr-FR'
-                      }
-                    },
-                    {
-                      type: 'Control',
-                      scope: '#/properties/body_multiloc/properties/nl-NL',
-                      label: 'Description',
-                      options: {
-                        description: '',
-                        isAdminField: false,
-                        hasRule: false,
-                        render: 'WYSIWYG',
-                        locale: 'nl-NL'
-                      }
-                    }
-                  ]
-                }
-              ]
+      context 'for a continuous ideation project with the default form' do
+        let(:input_term) { 'option' }
+        let(:project) { create :continuous_project, input_term: input_term }
+        let(:custom_form) { create :custom_form, participation_context: project }
+
+        it 'returns the schema for the default fields' do
+          expect(ui_schema.keys).to match_array %w[en fr-FR nl-NL]
+          expect(ui_schema['en']).to match(
+            type: 'Categorization',
+            options: {
+              formId: 'idea-form',
+              inputTerm: input_term
             },
-            {
-              type: 'Category',
-              label: 'Images and attachments',
-              options: {
-                id: custom_form.custom_fields.find_by(code: 'ideation_section2').id,
-                description: 'Upload your favourite files here'
-              },
-              elements: [
-                {
-                  type: 'Control',
-                  scope: '#/properties/idea_images_attributes',
-                  label: 'Images',
-                  options: {
-                    description: '',
-                    input_type: 'image_files',
-                    isAdminField: false,
-                    hasRule: false
-                  }
-                },
-                {
-                  type: 'Control',
-                  scope: '#/properties/idea_files_attributes',
-                  label: 'Attachments',
-                  options: {
-                    description: '',
-                    input_type: 'files',
-                    isAdminField: false,
-                    hasRule: false
-                  }
-                }
-              ]
+            elements: [
+              hash_including(
+                type: 'Category',
+                label: 'What is your option?',
+                elements: [
+                  hash_including(
+                    type: 'VerticalLayout',
+                    options: { input_type: 'text_multiloc', render: 'multiloc' },
+                    elements: [
+                      hash_including(
+                        scope: '#/properties/title_multiloc/properties/en',
+                        label: 'Title',
+                        options: hash_including(locale: 'en')
+                      ),
+                      hash_including(
+                        scope: '#/properties/title_multiloc/properties/fr-FR',
+                        label: 'Title',
+                        options: hash_including(locale: 'fr-FR')
+                      ),
+                      hash_including(
+                        scope: '#/properties/title_multiloc/properties/nl-NL',
+                        label: 'Title',
+                        options: hash_including(locale: 'nl-NL')
+                      )
+                    ]
+                  ),
+                  hash_including(
+                    type: 'VerticalLayout',
+                    options: { input_type: 'html_multiloc', render: 'multiloc' },
+                    elements: [
+                      hash_including(
+                        scope: '#/properties/body_multiloc/properties/en',
+                        label: 'Description',
+                        options: hash_including(locale: 'en', render: 'WYSIWYG')
+                      ),
+                      hash_including(
+                        scope: '#/properties/body_multiloc/properties/fr-FR',
+                        label: 'Description',
+                        options: hash_including(locale: 'fr-FR', render: 'WYSIWYG')
+                      ),
+                      hash_including(
+                        scope: '#/properties/body_multiloc/properties/nl-NL',
+                        label: 'Description',
+                        options: hash_including(locale: 'nl-NL', render: 'WYSIWYG')
+                      )
+                    ]
+                  )
+                ]
+              ),
+              hash_including(
+                type: 'Category',
+                label: 'Images and attachments',
+                options: hash_including(description: 'Upload your favourite files here'),
+                elements: [
+                  hash_including(
+                    type: 'Control',
+                    scope: '#/properties/idea_images_attributes',
+                    label: 'Images',
+                    options: hash_including(input_type: 'image_files')
+                  ),
+                  hash_including(
+                    type: 'Control',
+                    scope: '#/properties/idea_files_attributes',
+                    label: 'Attachments',
+                    options: hash_including(input_type: 'files')
+                  )
+                ]
+              ),
+              hash_including(
+                type: 'Category',
+                label: 'Details',
+                elements: [
+                  hash_including(
+                    type: 'Control',
+                    scope: '#/properties/topic_ids',
+                    label: 'Tags',
+                    options: hash_including(input_type: 'topic_ids')
+                  ),
+                  hash_including(
+                    type: 'Control',
+                    scope: '#/properties/location_description',
+                    label: 'Location',
+                    options: hash_including(input_type: 'text')
+                  )
+                ]
+              )
+            ]
+          )
+        end
+
+        it 'uses the right input_term' do
+          expect(ui_schema.dig('en', :options, :inputTerm)).to eq 'option'
+        end
+
+        context 'when a nil input_term is given' do
+          let(:input_term) { nil }
+
+          it 'uses the default "idea" as input_term' do
+            expect(ui_schema.dig('en', :options, :inputTerm)).to eq 'idea'
+          end
+        end
+      end
+
+      context 'for a timeline project' do
+        let(:input_term) { 'contribution' }
+        let(:timeline_fields) do
+          project_with_current_phase = create(:project_with_current_phase, input_term: 'issue')
+          TimelineService.new.current_phase(project_with_current_phase).update!(input_term: 'option')
+          IdeaCustomFieldsService.new(create(:custom_form, participation_context: project_with_current_phase)).all_fields
+        end
+
+        it 'uses the right input_term' do
+          ui_schema = generator.generate_for(timeline_fields)['en']
+          expect(ui_schema.dig(:options, :inputTerm)).to eq 'contribution'
+        end
+      end
+    end
+
+    context 'native survey forms' do
+      subject(:generator) { described_class.new input_term, false }
+
+      let(:ui_schema) { generator.generate_for IdeaCustomFieldsService.new(custom_form).enabled_fields }
+
+      context 'for a continuous native survey project without pages' do
+        let(:project) { create(:continuous_native_survey_project) }
+        let(:custom_form) { create :custom_form, participation_context: project }
+        let!(:field) { create :custom_field, resource: custom_form }
+
+        it 'has an empty extra category label, so that the category label is suppressed in the UI' do
+          en_ui_schema = generator.generate_for([field])['en']
+          expect(en_ui_schema).to eq({
+            type: 'Categorization',
+            options: {
+              formId: 'idea-form',
+              inputTerm: input_term
             },
-            {
+            elements: [{
               type: 'Category',
-              label: 'Details',
-              options: {
-                id: custom_form.custom_fields.find_by(code: 'ideation_section3').id
-              },
-              elements: [
-                {
-                  type: 'Control',
-                  scope: '#/properties/topic_ids',
-                  label: 'Tags',
-                  options: {
-                    description: '',
-                    input_type: 'topic_ids',
-                    isAdminField: false,
-                    hasRule: false
-                  }
+              label: nil,
+              options: { id: 'extra' },
+              elements: [{
+                type: 'Control',
+                scope: "#/properties/#{field.key}",
+                label: 'Did you attend',
+                options: {
+                  input_type: field.input_type,
+                  description: 'Which councils are you attending in our city?',
+                  isAdminField: false,
+                  hasRule: false,
+                  transform: 'trim_on_blur'
+                }
+              }]
+            }]
+          })
+        end
+      end
+
+      context 'for a continuous native survey project with pages' do
+        let(:project) { create(:continuous_native_survey_project) }
+        let(:custom_form) { create :custom_form, participation_context: project }
+        let!(:page1) do
+          create(
+            :custom_field_page,
+            resource: custom_form,
+            key: 'about_you',
+            title_multiloc: { 'en' => 'About you' },
+            description_multiloc: { 'en' => 'Please fill in some <strong>personal details</strong>.' }
+          )
+        end
+        let!(:field_in_page1) do
+          create(
+            :custom_field,
+            resource: custom_form,
+            key: 'what_is_your_age',
+            title_multiloc: { 'en' => 'What is your age?' },
+            description_multiloc: { 'en' => 'Enter a number.' }
+          )
+        end
+        let!(:page2) do
+          create(
+            :custom_field_page,
+            resource: custom_form,
+            key: 'about_your_cycling_habits',
+            title_multiloc: { 'en' => 'About your cycling habits' },
+            description_multiloc: { 'en' => 'Please indicate how you use <strong>a bike</strong>.' }
+          )
+        end
+        let!(:field_in_page2) do
+          create(
+            :custom_field,
+            resource: custom_form,
+            key: 'do_you_own_a_bike',
+            title_multiloc: { 'en' => 'Do you own a bike?' },
+            description_multiloc: { 'en' => 'Enter Yes or No.' }
+          )
+        end
+        let!(:page3) do
+          create(
+            :custom_field_page,
+            resource: custom_form,
+            key: 'this_is_the_end_of_the_survey',
+            title_multiloc: { 'en' => 'This is the end of the survey' },
+            description_multiloc: { 'en' => 'Thank you for participating 🚀' }
+          )
+        end
+
+        it 'has a category for each page, including the fixed survey end page' do
+          expect(ui_schema['en']).to eq({
+            type: 'Categorization',
+            options: {
+              formId: 'idea-form',
+              inputTerm: 'idea'
+            },
+            elements: [
+              {
+                type: 'Page',
+                options: {
+                  input_type: page1.input_type,
+                  id: page1.id,
+                  title: 'About you',
+                  description: 'Please fill in some <strong>personal details</strong>.'
                 },
-                {
+                elements: [{
                   type: 'Control',
-                  scope: '#/properties/location_description',
-                  label: 'Location',
+                  scope: "#/properties/#{field_in_page1.key}",
+                  label: 'What is your age?',
                   options: {
-                    description: '',
-                    input_type: 'text',
+                    input_type: field_in_page1.input_type,
+                    description: 'Enter a number.',
                     isAdminField: false,
                     hasRule: false,
                     transform: 'trim_on_blur'
                   }
-                }
-              ]
-            },
-            {
-              type: 'Category',
-              label: 'Extra fields',
-              options: { id: extra_section.id, description: 'Custom stuff' },
-              elements: [
-                {
-                  type: 'VerticalLayout',
-                  options: { input_type: 'html_multiloc', render: 'multiloc' },
-                  elements: [
-                    {
-                      type: 'Control',
-                      scope: '#/properties/extra_field/properties/en',
-                      label: 'Extra field title',
-                      options: {
-                        description: 'Extra field description',
-                        isAdminField: false,
-                        hasRule: false,
-                        locale: 'en',
-                        render: 'WYSIWYG',
-                        trim_on_blur: true
-                      }
-                    },
-                    {
-                      type: 'Control',
-                      scope: '#/properties/extra_field/properties/fr-FR',
-                      label: 'Extra field title',
-                      options: {
-                        description: 'Extra field description',
-                        isAdminField: false,
-                        hasRule: false,
-                        locale: 'fr-FR',
-                        render: 'WYSIWYG',
-                        trim_on_blur: true
-                      }
-                    },
-                    {
-                      type: 'Control',
-                      scope: '#/properties/extra_field/properties/nl-NL',
-                      label: 'Extra field title',
-                      options: {
-                        description: 'Extra field description',
-                        isAdminField: false,
-                        hasRule: false,
-                        locale: 'nl-NL',
-                        render: 'WYSIWYG',
-                        trim_on_blur: true
-                      }
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        )
-        # fr-FR
-        expect(ui_schema['fr-FR']).to match(
-          type: 'Categorization',
-          options: {
-            formId: 'idea-form',
-            inputTerm: input_term
-          },
-          elements: [
-            hash_including(
-              type: 'Category',
-              label: 'Quelle est votre question ?',
-              elements: [
-                hash_including(
-                  type: 'VerticalLayout',
-                  options: { input_type: 'text_multiloc', render: 'multiloc' },
-                  elements: [
-                    hash_including(
-                      scope: '#/properties/title_multiloc/properties/en',
-                      label: 'Titre',
-                      options: hash_including(locale: 'en')
-                    ),
-                    hash_including(
-                      scope: '#/properties/title_multiloc/properties/fr-FR',
-                      label: 'Titre',
-                      options: hash_including(locale: 'fr-FR')
-                    ),
-                    hash_including(
-                      scope: '#/properties/title_multiloc/properties/nl-NL',
-                      label: 'Titre',
-                      options: hash_including(locale: 'nl-NL')
-                    )
-                  ]
-                ),
-                hash_including(
-                  type: 'VerticalLayout',
-                  options: { input_type: 'html_multiloc', render: 'multiloc' },
-                  elements: [
-                    hash_including(
-                      scope: '#/properties/body_multiloc/properties/en',
-                      label: 'Description',
-                      options: hash_including(locale: 'en', render: 'WYSIWYG')
-                    ),
-                    hash_including(
-                      scope: '#/properties/body_multiloc/properties/fr-FR',
-                      label: 'Description',
-                      options: hash_including(locale: 'fr-FR', render: 'WYSIWYG')
-                    ),
-                    hash_including(
-                      scope: '#/properties/body_multiloc/properties/nl-NL',
-                      label: 'Description',
-                      options: hash_including(locale: 'nl-NL', render: 'WYSIWYG')
-                    )
-                  ]
-                )
-              ]
-            ),
-            hash_including(
-              type: 'Category',
-              label: 'Images et pièces jointes',
-              elements: [
-                hash_including(
-                  type: 'Control',
-                  scope: '#/properties/idea_images_attributes',
-                  label: 'Images',
-                  options: hash_including(input_type: 'image_files')
-                ),
-                hash_including(
-                  type: 'Control',
-                  scope: '#/properties/idea_files_attributes',
-                  label: 'Pièces jointes',
-                  options: hash_including(input_type: 'files')
-                )
-              ]
-            ),
-            hash_including(
-              type: 'Category',
-              label: 'Details',
-              elements: [
-                hash_including(
-                  type: 'Control',
-                  scope: '#/properties/topic_ids',
-                  label: 'Étiquettes',
-                  options: hash_including(input_type: 'topic_ids')
-                ),
-                hash_including(
-                  type: 'Control',
-                  scope: '#/properties/location_description',
-                  label: 'Adresse',
-                  options: hash_including(input_type: 'text')
-                )
-              ]
-            ),
-            hash_including(
-              type: 'Category',
-              label: 'Extra choses',
-              options: hash_including(description: 'Des choses en plus'),
-              elements: [
-                hash_including(
-                  type: 'VerticalLayout',
-                  options: { input_type: 'html_multiloc', render: 'multiloc' },
-                  elements: [
-                    hash_including(
-                      type: 'Control',
-                      scope: '#/properties/extra_field/properties/en',
-                      label: 'Extra field title',
-                      options: hash_including(description: 'Extra field description', locale: 'en', render: 'WYSIWYG')
-                    ),
-                    hash_including(
-                      type: 'Control',
-                      scope: '#/properties/extra_field/properties/fr-FR',
-                      label: 'Extra field title',
-                      options: hash_including(description: 'Extra field description', locale: 'fr-FR', render: 'WYSIWYG')
-                    ),
-                    hash_including(
-                      type: 'Control',
-                      scope: '#/properties/extra_field/properties/nl-NL',
-                      label: 'Extra field title',
-                      options: hash_including(description: 'Extra field description', locale: 'nl-NL', render: 'WYSIWYG')
-                    )
-                  ]
-                )
-              ]
-            )
-          ]
-        )
-        # nl-NL
-        expect(ui_schema['nl-NL']).to match(
-          type: 'Categorization',
-          options: {
-            formId: 'idea-form',
-            inputTerm: input_term
-          },
-          elements: [
-            hash_including(
-              type: 'Category',
-              label: 'Wat is je vraag?',
-              elements: [
-                hash_including(
-                  type: 'VerticalLayout',
-                  options: { input_type: 'text_multiloc', render: 'multiloc' },
-                  elements: [
-                    hash_including(
-                      scope: '#/properties/title_multiloc/properties/en',
-                      label: 'Titel',
-                      options: hash_including(locale: 'en', description: 'Mijn titel beschrijving')
-                    ),
-                    hash_including(
-                      scope: '#/properties/title_multiloc/properties/fr-FR',
-                      label: 'Titel',
-                      options: hash_including(locale: 'fr-FR', description: 'Mijn titel beschrijving')
-                    ),
-                    hash_including(
-                      scope: '#/properties/title_multiloc/properties/nl-NL',
-                      label: 'Titel',
-                      options: hash_including(locale: 'nl-NL', description: 'Mijn titel beschrijving')
-                    )
-                  ]
-                ),
-                hash_including(
-                  type: 'VerticalLayout',
-                  options: { input_type: 'html_multiloc', render: 'multiloc' },
-                  elements: [
-                    hash_including(
-                      scope: '#/properties/body_multiloc/properties/en',
-                      label: 'Beschrijving',
-                      options: hash_including(locale: 'en', render: 'WYSIWYG')
-                    ),
-                    hash_including(
-                      scope: '#/properties/body_multiloc/properties/fr-FR',
-                      label: 'Beschrijving',
-                      options: hash_including(locale: 'fr-FR', render: 'WYSIWYG')
-                    ),
-                    hash_including(
-                      scope: '#/properties/body_multiloc/properties/nl-NL',
-                      label: 'Beschrijving',
-                      options: hash_including(locale: 'nl-NL', render: 'WYSIWYG')
-                    )
-                  ]
-                )
-              ]
-            ),
-            hash_including(
-              type: 'Category',
-              label: 'Afbeeldingen en bijlagen',
-              elements: [
-                hash_including(
-                  type: 'Control',
-                  scope: '#/properties/idea_images_attributes',
-                  label: 'Afbeeldingen',
-                  options: hash_including(input_type: 'image_files')
-                ),
-                hash_including(
-                  type: 'Control',
-                  scope: '#/properties/idea_files_attributes',
-                  label: 'Bijlagen',
-                  options: hash_including(input_type: 'files')
-                )
-              ]
-            ),
-            hash_including(
-              type: 'Category',
-              label: 'Details',
-              elements: [
-                hash_including(
-                  type: 'Control',
-                  scope: '#/properties/topic_ids',
-                  label: 'Tags',
-                  options: hash_including(input_type: 'topic_ids')
-                ),
-                hash_including(
-                  type: 'Control',
-                  scope: '#/properties/location_description',
-                  label: 'Locatie',
-                  options: hash_including(input_type: 'text')
-                )
-              ]
-            ),
-            hash_including(
-              type: 'Category',
-              label: 'Extra fields',
-              options: hash_including(description: 'Custom stuff'),
-              elements: [
-                hash_including(
-                  type: 'VerticalLayout',
-                  options: { input_type: 'html_multiloc', render: 'multiloc' },
-                  elements: [
-                    hash_including(
-                      type: 'Control',
-                      scope: '#/properties/extra_field/properties/en',
-                      label: 'Extra veldtitel',
-                      options: hash_including(description: 'Extra veldbeschrijving', locale: 'en', render: 'WYSIWYG')
-                    ),
-                    hash_including(
-                      type: 'Control',
-                      scope: '#/properties/extra_field/properties/fr-FR',
-                      label: 'Extra veldtitel',
-                      options: hash_including(description: 'Extra veldbeschrijving', locale: 'fr-FR', render: 'WYSIWYG')
-                    ),
-                    hash_including(
-                      type: 'Control',
-                      scope: '#/properties/extra_field/properties/nl-NL',
-                      label: 'Extra veldtitel',
-                      options: hash_including(description: 'Extra veldbeschrijving', locale: 'nl-NL', render: 'WYSIWYG')
-                    )
-                  ]
-                )
-              ]
-            )
-          ]
-        )
-      end
-    end
-
-    context 'for a continuous ideation project with an empty custom section' do
-      let(:project) { create :continuous_project, input_term: input_term }
-      let!(:custom_form) { create :custom_form, :with_default_fields, participation_context: project }
-      let!(:extra_section) do
-        create(
-          :custom_field_section,
-          :for_custom_form,
-          resource: custom_form,
-          title_multiloc: { 'en' => 'Empty custom section' }
-        )
-      end
-
-      it 'returns the schema for the given fields' do
-        expect(ui_schema.keys).to match_array %w[en fr-FR nl-NL]
-        expect(ui_schema['en']).to match(
-          type: 'Categorization',
-          options: {
-            formId: 'idea-form',
-            inputTerm: input_term
-          },
-          elements: [
-            hash_including(type: 'Category', label: 'What is your question?'),
-            hash_including(type: 'Category', label: 'Images and attachments'),
-            hash_including(type: 'Category', label: 'Details'),
-            hash_including(type: 'Category', label: 'Empty custom section', elements: [])
-          ]
-        )
-      end
-    end
-
-    context 'for a continuous ideation project with the default form' do
-      let(:input_term) { 'option' }
-      let(:project) { create :continuous_project, input_term: input_term }
-      let(:custom_form) { create :custom_form, participation_context: project }
-
-      it 'returns the schema for the default fields' do
-        expect(ui_schema.keys).to match_array %w[en fr-FR nl-NL]
-        expect(ui_schema['en']).to match(
-          type: 'Categorization',
-          options: {
-            formId: 'idea-form',
-            inputTerm: input_term
-          },
-          elements: [
-            hash_including(
-              type: 'Category',
-              label: 'What is your option?',
-              elements: [
-                hash_including(
-                  type: 'VerticalLayout',
-                  options: { input_type: 'text_multiloc', render: 'multiloc' },
-                  elements: [
-                    hash_including(
-                      scope: '#/properties/title_multiloc/properties/en',
-                      label: 'Title',
-                      options: hash_including(locale: 'en')
-                    ),
-                    hash_including(
-                      scope: '#/properties/title_multiloc/properties/fr-FR',
-                      label: 'Title',
-                      options: hash_including(locale: 'fr-FR')
-                    ),
-                    hash_including(
-                      scope: '#/properties/title_multiloc/properties/nl-NL',
-                      label: 'Title',
-                      options: hash_including(locale: 'nl-NL')
-                    )
-                  ]
-                ),
-                hash_including(
-                  type: 'VerticalLayout',
-                  options: { input_type: 'html_multiloc', render: 'multiloc' },
-                  elements: [
-                    hash_including(
-                      scope: '#/properties/body_multiloc/properties/en',
-                      label: 'Description',
-                      options: hash_including(locale: 'en', render: 'WYSIWYG')
-                    ),
-                    hash_including(
-                      scope: '#/properties/body_multiloc/properties/fr-FR',
-                      label: 'Description',
-                      options: hash_including(locale: 'fr-FR', render: 'WYSIWYG')
-                    ),
-                    hash_including(
-                      scope: '#/properties/body_multiloc/properties/nl-NL',
-                      label: 'Description',
-                      options: hash_including(locale: 'nl-NL', render: 'WYSIWYG')
-                    )
-                  ]
-                )
-              ]
-            ),
-            hash_including(
-              type: 'Category',
-              label: 'Images and attachments',
-              options: hash_including(description: 'Upload your favourite files here'),
-              elements: [
-                hash_including(
-                  type: 'Control',
-                  scope: '#/properties/idea_images_attributes',
-                  label: 'Images',
-                  options: hash_including(input_type: 'image_files')
-                ),
-                hash_including(
-                  type: 'Control',
-                  scope: '#/properties/idea_files_attributes',
-                  label: 'Attachments',
-                  options: hash_including(input_type: 'files')
-                )
-              ]
-            ),
-            hash_including(
-              type: 'Category',
-              label: 'Details',
-              elements: [
-                hash_including(
-                  type: 'Control',
-                  scope: '#/properties/topic_ids',
-                  label: 'Tags',
-                  options: hash_including(input_type: 'topic_ids')
-                ),
-                hash_including(
-                  type: 'Control',
-                  scope: '#/properties/location_description',
-                  label: 'Location',
-                  options: hash_including(input_type: 'text')
-                )
-              ]
-            )
-          ]
-        )
-      end
-
-      it 'uses the right input_term' do
-        expect(ui_schema.dig('en', :options, :inputTerm)).to eq 'option'
-      end
-
-      context 'when a nil input_term is given' do
-        let(:input_term) { nil }
-
-        it 'uses the default "idea" as input_term' do
-          expect(ui_schema.dig('en', :options, :inputTerm)).to eq 'idea'
-        end
-      end
-    end
-
-    context 'for a continuous native survey project without pages' do
-      let(:project) { create(:continuous_native_survey_project) }
-      let(:custom_form) { create :custom_form, participation_context: project }
-      let!(:field) { create :custom_field, resource: custom_form }
-
-      it 'has an empty extra category label, so that the category label is suppressed in the UI' do
-        en_ui_schema = generator.generate_for([field])['en']
-        expect(en_ui_schema).to eq({
-          type: 'Categorization',
-          options: {
-            formId: 'idea-form',
-            inputTerm: input_term
-          },
-          elements: [{
-            type: 'Category',
-            label: nil,
-            options: { id: 'extra' },
-            elements: [{
-              type: 'Control',
-              scope: "#/properties/#{field.key}",
-              label: 'Did you attend',
-              options: {
-                input_type: field.input_type,
-                description: 'Which councils are you attending in our city?',
-                isAdminField: false,
-                hasRule: false,
-                transform: 'trim_on_blur'
-              }
-            }]
-          }]
-        })
-      end
-    end
-
-    context 'for a continuous native survey project with pages' do
-      let(:project) { create(:continuous_native_survey_project) }
-      let(:custom_form) { create :custom_form, participation_context: project }
-      let!(:page1) do
-        create(
-          :custom_field_page,
-          resource: custom_form,
-          key: 'about_you',
-          title_multiloc: { 'en' => 'About you' },
-          description_multiloc: { 'en' => 'Please fill in some <strong>personal details</strong>.' }
-        )
-      end
-      let!(:field_in_page1) do
-        create(
-          :custom_field,
-          resource: custom_form,
-          key: 'what_is_your_age',
-          title_multiloc: { 'en' => 'What is your age?' },
-          description_multiloc: { 'en' => 'Enter a number.' }
-        )
-      end
-      let!(:page2) do
-        create(
-          :custom_field_page,
-          resource: custom_form,
-          key: 'about_your_cycling_habits',
-          title_multiloc: { 'en' => 'About your cycling habits' },
-          description_multiloc: { 'en' => 'Please indicate how you use <strong>a bike</strong>.' }
-        )
-      end
-      let!(:field_in_page2) do
-        create(
-          :custom_field,
-          resource: custom_form,
-          key: 'do_you_own_a_bike',
-          title_multiloc: { 'en' => 'Do you own a bike?' },
-          description_multiloc: { 'en' => 'Enter Yes or No.' }
-        )
-      end
-      let!(:page3) do
-        create(
-          :custom_field_page,
-          resource: custom_form,
-          key: 'this_is_the_end_of_the_survey',
-          title_multiloc: { 'en' => 'This is the end of the survey' },
-          description_multiloc: { 'en' => 'Thank you for participating 🚀' }
-        )
-      end
-
-      it 'has a category for each page, including the fixed survey end page' do
-        expect(ui_schema['en']).to eq({
-          type: 'Categorization',
-          options: {
-            formId: 'idea-form',
-            inputTerm: 'idea'
-          },
-          elements: [
-            {
-              type: 'Page',
-              options: {
-                input_type: page1.input_type,
-                id: page1.id,
-                title: 'About you',
-                description: 'Please fill in some <strong>personal details</strong>.'
+                }]
               },
-              elements: [{
-                type: 'Control',
-                scope: "#/properties/#{field_in_page1.key}",
-                label: 'What is your age?',
-                options: {
-                  input_type: field_in_page1.input_type,
-                  description: 'Enter a number.',
-                  isAdminField: false,
-                  hasRule: false,
-                  transform: 'trim_on_blur'
-                }
-              }]
-            },
-            {
-              type: 'Page',
-              options: {
-                input_type: page2.input_type,
-                id: page2.id,
-                title: 'About your cycling habits',
-                description: 'Please indicate how you use <strong>a bike</strong>.'
-              },
-              elements: [{
-                type: 'Control',
-                scope: "#/properties/#{field_in_page2.key}",
-                label: 'Do you own a bike?',
-                options: {
-                  input_type: field_in_page2.input_type,
-                  description: 'Enter Yes or No.',
-                  isAdminField: false,
-                  hasRule: false,
-                  transform: 'trim_on_blur'
-                }
-              }]
-            },
-            {
-              type: 'Page',
-              options: {
-                input_type: page3.input_type,
-                id: page3.id,
-                title: 'This is the end of the survey',
-                description: 'Thank you for participating 🚀'
-              },
-              elements: []
-            },
-            {
-              type: 'Page',
-              options: {
-                id: 'survey_end',
-                title: 'Survey end',
-                description: "Please submit your answers by selecting 'Submit survey' below."
-              },
-              elements: []
-            }
-          ]
-        })
-      end
-    end
-
-    context 'for a continuous native survey project with pages and logic' do
-      let(:project) { create(:continuous_native_survey_project) }
-      let(:custom_form) { create :custom_form, participation_context: project }
-      let!(:page1) do
-        create(
-          :custom_field_page,
-          resource: custom_form,
-          key: 'page1',
-          title_multiloc: { 'en' => '' },
-          description_multiloc: { 'en' => '' }
-        )
-      end
-      let!(:field_in_page1) do
-        create(
-          :custom_field,
-          resource: custom_form,
-          input_type: 'linear_scale',
-          key: 'how_old_are_you',
-          title_multiloc: { 'en' => 'Hold old are you?' },
-          description_multiloc: { 'en' => '' },
-          maximum: 7,
-          logic: {
-            rules: [
               {
-                if: 1,
-                goto_page_id: page3.id
+                type: 'Page',
+                options: {
+                  input_type: page2.input_type,
+                  id: page2.id,
+                  title: 'About your cycling habits',
+                  description: 'Please indicate how you use <strong>a bike</strong>.'
+                },
+                elements: [{
+                  type: 'Control',
+                  scope: "#/properties/#{field_in_page2.key}",
+                  label: 'Do you own a bike?',
+                  options: {
+                    input_type: field_in_page2.input_type,
+                    description: 'Enter Yes or No.',
+                    isAdminField: false,
+                    hasRule: false,
+                    transform: 'trim_on_blur'
+                  }
+                }]
+              },
+              {
+                type: 'Page',
+                options: {
+                  input_type: page3.input_type,
+                  id: page3.id,
+                  title: 'This is the end of the survey',
+                  description: 'Thank you for participating 🚀'
+                },
+                elements: []
+              },
+              {
+                type: 'Page',
+                options: {
+                  id: 'survey_end',
+                  title: 'Survey end',
+                  description: "Please submit your answers by selecting 'Submit survey' below."
+                },
+                elements: []
               }
             ]
-          }
-        )
-      end
-      let!(:page2) do
-        create(
-          :custom_field_page,
-          resource: custom_form,
-          key: 'page2',
-          title_multiloc: { 'en' => '' },
-          description_multiloc: { 'en' => '' }
-        )
-      end
-      let!(:field_in_page2) do
-        create(
-          :custom_field,
-          resource: custom_form,
-          input_type: 'select',
-          key: 'how_often_do_you_choose_to_cycle',
-          title_multiloc: { 'en' => 'When considering travel near your home, how often do you choose to CYCLE?' },
-          description_multiloc: { 'en' => '' }
-        )
-      end
-      let!(:every_day_option) do
-        create(:custom_field_option, custom_field: field_in_page2, key: 'every_day', title_multiloc: { 'en' => 'Every day' })
-      end
-      let!(:never_option) do
-        create(:custom_field_option, custom_field: field_in_page2, key: 'never', title_multiloc: { 'en' => 'Never' })
-      end
-      let!(:page3) do
-        create(
-          :custom_field_page,
-          resource: custom_form,
-          key: 'page3',
-          title_multiloc: { 'en' => '' },
-          description_multiloc: { 'en' => '' }
-        )
-      end
-      let!(:page4) do
-        create(
-          :custom_field_page,
-          resource: custom_form,
-          key: 'page4',
-          title_multiloc: { 'en' => '' },
-          description_multiloc: { 'en' => '' }
-        )
+          })
+        end
       end
 
-      before do
-        field_in_page2.update!(logic: {
-          rules: [
-            {
-              if: never_option.id,
-              goto_page_id: page4.id
-            }
-          ]
-        })
-      end
-
-      it 'includes rules for logic' do
-        ui_schema = generator.generate_for [page1, field_in_page1, page2, field_in_page2, page3] # TODO: Remove this line (include page 4)
-        expect(ui_schema['en']).to eq({
-          type: 'Categorization',
-          options: {
-            formId: 'idea-form',
-            inputTerm: 'idea'
-          },
-          elements: [
-            {
-              type: 'Page',
-              options: {
-                input_type: page1.input_type,
-                id: page1.id,
-                title: '',
-                description: ''
-              },
-              elements: [{
-                type: 'Control',
-                scope: "#/properties/#{field_in_page1.key}",
-                label: 'Hold old are you?',
-                options: {
-                  input_type: field_in_page1.input_type,
-                  description: '',
-                  isAdminField: false,
-                  hasRule: true,
-                  maximum_label: '',
-                  minimum_label: ''
-                }
-              }]
-            },
-            {
-              type: 'Page',
-              options: {
-                input_type: page2.input_type,
-                id: page2.id,
-                title: '',
-                description: ''
-              },
-              elements: [{
-                type: 'Control',
-                scope: "#/properties/#{field_in_page2.key}",
-                label: 'When considering travel near your home, how often do you choose to CYCLE?',
-                options: {
-                  input_type: field_in_page2.input_type,
-                  description: '',
-                  isAdminField: false,
-                  hasRule: true
-                }
-              }],
-              ruleArray: [
+      context 'for a continuous native survey project with pages and logic' do
+        let(:project) { create(:continuous_native_survey_project) }
+        let(:custom_form) { create :custom_form, participation_context: project }
+        let!(:page1) do
+          create(
+            :custom_field_page,
+            resource: custom_form,
+            key: 'page1',
+            title_multiloc: { 'en' => '' },
+            description_multiloc: { 'en' => '' }
+          )
+        end
+        let!(:field_in_page1) do
+          create(
+            :custom_field,
+            resource: custom_form,
+            input_type: 'linear_scale',
+            key: 'how_old_are_you',
+            title_multiloc: { 'en' => 'Hold old are you?' },
+            description_multiloc: { 'en' => '' },
+            maximum: 7,
+            logic: {
+              rules: [
                 {
-                  effect: 'HIDE',
-                  condition: {
-                    scope: "#/properties/#{field_in_page1.key}",
-                    schema: {
-                      enum: [1]
-                    }
-                  }
+                  if: 1,
+                  goto_page_id: page3.id
                 }
               ]
+            }
+          )
+        end
+        let!(:page2) do
+          create(
+            :custom_field_page,
+            resource: custom_form,
+            key: 'page2',
+            title_multiloc: { 'en' => '' },
+            description_multiloc: { 'en' => '' }
+          )
+        end
+        let!(:field_in_page2) do
+          create(
+            :custom_field,
+            resource: custom_form,
+            input_type: 'select',
+            key: 'how_often_do_you_choose_to_cycle',
+            title_multiloc: { 'en' => 'When considering travel near your home, how often do you choose to CYCLE?' },
+            description_multiloc: { 'en' => '' }
+          )
+        end
+        let!(:every_day_option) do
+          create(:custom_field_option, custom_field: field_in_page2, key: 'every_day', title_multiloc: { 'en' => 'Every day' })
+        end
+        let!(:never_option) do
+          create(:custom_field_option, custom_field: field_in_page2, key: 'never', title_multiloc: { 'en' => 'Never' })
+        end
+        let!(:page3) do
+          create(
+            :custom_field_page,
+            resource: custom_form,
+            key: 'page3',
+            title_multiloc: { 'en' => '' },
+            description_multiloc: { 'en' => '' }
+          )
+        end
+        let!(:page4) do
+          create(
+            :custom_field_page,
+            resource: custom_form,
+            key: 'page4',
+            title_multiloc: { 'en' => '' },
+            description_multiloc: { 'en' => '' }
+          )
+        end
+
+        before do
+          field_in_page2.update!(logic: {
+            rules: [
+              {
+                if: never_option.id,
+                goto_page_id: page4.id
+              }
+            ]
+          })
+        end
+
+        it 'includes rules for logic' do
+          ui_schema = generator.generate_for [page1, field_in_page1, page2, field_in_page2, page3] # TODO: Remove this line (include page 4)
+          expect(ui_schema['en']).to eq({
+            type: 'Categorization',
+            options: {
+              formId: 'idea-form',
+              inputTerm: 'idea'
             },
-            {
-              type: 'Page',
-              options: {
-                input_type: page3.input_type,
-                id: page3.id,
-                title: '',
-                description: ''
+            elements: [
+              {
+                type: 'Page',
+                options: {
+                  input_type: page1.input_type,
+                  id: page1.id,
+                  title: '',
+                  description: ''
+                },
+                elements: [{
+                  type: 'Control',
+                  scope: "#/properties/#{field_in_page1.key}",
+                  label: 'Hold old are you?',
+                  options: {
+                    input_type: field_in_page1.input_type,
+                    description: '',
+                    isAdminField: false,
+                    hasRule: true,
+                    maximum_label: '',
+                    minimum_label: ''
+                  }
+                }]
               },
-              elements: [],
-              ruleArray: [
-                {
-                  effect: 'HIDE',
-                  condition: {
-                    scope: "#/properties/#{field_in_page2.key}",
-                    schema: {
-                      enum: [never_option.key]
+              {
+                type: 'Page',
+                options: {
+                  input_type: page2.input_type,
+                  id: page2.id,
+                  title: '',
+                  description: ''
+                },
+                elements: [{
+                  type: 'Control',
+                  scope: "#/properties/#{field_in_page2.key}",
+                  label: 'When considering travel near your home, how often do you choose to CYCLE?',
+                  options: {
+                    input_type: field_in_page2.input_type,
+                    description: '',
+                    isAdminField: false,
+                    hasRule: true
+                  }
+                }],
+                ruleArray: [
+                  {
+                    effect: 'HIDE',
+                    condition: {
+                      scope: "#/properties/#{field_in_page1.key}",
+                      schema: {
+                        enum: [1]
+                      }
                     }
                   }
-                }
-              ]
-            },
-            {
-              type: 'Page',
-              options: {
-                id: 'survey_end',
-                title: 'Survey end',
-                description: "Please submit your answers by selecting 'Submit survey' below."
+                ]
               },
-              elements: []
-            }
-          ]
-        })
-      end
-    end
-
-    context 'for a timeline project' do
-      let(:input_term) { 'contribution' }
-      let(:timeline_fields) do
-        project_with_current_phase = create(:project_with_current_phase, input_term: 'issue')
-        TimelineService.new.current_phase(project_with_current_phase).update!(input_term: 'option')
-        IdeaCustomFieldsService.new(create(:custom_form, participation_context: project_with_current_phase)).all_fields
-      end
-
-      it 'uses the right input_term' do
-        ui_schema = generator.generate_for(timeline_fields)['en']
-        expect(ui_schema.dig(:options, :inputTerm)).to eq 'contribution'
+              {
+                type: 'Page',
+                options: {
+                  input_type: page3.input_type,
+                  id: page3.id,
+                  title: '',
+                  description: ''
+                },
+                elements: [],
+                ruleArray: [
+                  {
+                    effect: 'HIDE',
+                    condition: {
+                      scope: "#/properties/#{field_in_page2.key}",
+                      schema: {
+                        enum: [never_option.key]
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                type: 'Page',
+                options: {
+                  id: 'survey_end',
+                  title: 'Survey end',
+                  description: "Please submit your answers by selecting 'Submit survey' below."
+                },
+                elements: []
+              }
+            ]
+          })
+        end
       end
     end
   end
 
   describe '#visit_text' do
+    subject(:generator) { described_class.new input_term, false }
+
+    let(:ui_schema) { generator.generate_for IdeaCustomFieldsService.new(custom_form).enabled_fields }
     let(:code) { nil }
     let(:field) do
       create(
@@ -1086,6 +1111,9 @@ RSpec.describe InputUiSchemaGeneratorService do
   end
 
   describe '#visit_number' do
+    subject(:generator) { described_class.new input_term, false }
+
+    let(:ui_schema) { generator.generate_for IdeaCustomFieldsService.new(custom_form).enabled_fields }
     let(:code) { nil }
     let(:field) do
       create(
@@ -1134,6 +1162,10 @@ RSpec.describe InputUiSchemaGeneratorService do
   end
 
   describe '#visit_html_multiloc' do
+    subject(:generator) { described_class.new input_term, false }
+
+    let(:ui_schema) { generator.generate_for IdeaCustomFieldsService.new(custom_form).enabled_fields }
+
     context 'when the code is body_multiloc' do
       let(:field) do
         create(
@@ -1352,6 +1384,9 @@ RSpec.describe InputUiSchemaGeneratorService do
   end
 
   describe '#visit_page' do
+    subject(:generator) { described_class.new input_term, false }
+
+    let(:ui_schema) { generator.generate_for IdeaCustomFieldsService.new(custom_form).enabled_fields }
     let(:field) do
       create(
         :custom_field,

--- a/back/spec/services/json_forms_service_spec.rb
+++ b/back/spec/services/json_forms_service_spec.rb
@@ -425,6 +425,7 @@ describe JsonFormsService do
             scope: '#/properties/author_id',
             label: 'Author',
             options: {
+              answer_visible_to: 'public',
               input_type: 'text',
               transform: 'trim_on_blur',
               isAdminField: true,
@@ -437,6 +438,7 @@ describe JsonFormsService do
             scope: '#/properties/budget',
             label: 'Budget',
             options: {
+              answer_visible_to: 'public',
               input_type: 'number',
               isAdminField: true,
               hasRule: false,


### PR DESCRIPTION
Additional field on custom_fields for answer_visible_to.

Added to the custom_fields output and the ui_schema output - but only on the ideation forms - not survey or anything else

Field is also used to limit what is returned by the ideas end point - only returns fields flagged with answer_visible_to: admins to admins, moderators and the idea author.