### PR TITLE
Make it easier to use seeds runner in Rails console

### DIFF
--- a/back/db/seeds.rb
+++ b/back/db/seeds.rb
@@ -2,6 +2,8 @@
 
 if CitizenLab.ee?
   load Rails.root.join('engines/commercial/multi_tenancy/db/seeds/runner.rb')
+  seeds_runner = MultiTenancy::Seeds::Runner.new
+  seeds_runner.execute
 else
   load Rails.root.join('db/seeds/citizenlab.rb')
 end

--- a/back/db/seeds.rb
+++ b/back/db/seeds.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 if CitizenLab.ee?
-  load Rails.root.join('engines/commercial/multi_tenancy/db/seeds/runner.rb')
+  require Rails.root.join('engines/commercial/multi_tenancy/db/seeds/runner')
   seeds_runner = MultiTenancy::Seeds::Runner.new
   seeds_runner.execute
 else

--- a/back/engines/commercial/multi_tenancy/db/seeds/runner.rb
+++ b/back/engines/commercial/multi_tenancy/db/seeds/runner.rb
@@ -231,6 +231,3 @@ module MultiTenancy
     end
   end
 end
-
-seeds_runner = MultiTenancy::Seeds::Runner.new
-seeds_runner.execute


### PR DESCRIPTION
So, it's possible to use this code to create only projects without the rest
`MultiTenancy::Seeds::Projects.new(runner: MultiTenancy::Seeds::Runner.new).run`