### PR TITLE
CL-2769: Add tests for the folder moderator

### DIFF
--- a/front/app/containers/Admin/projects/components/ProjectRow/ProjectMoreActionsMenu.test.tsx
+++ b/front/app/containers/Admin/projects/components/ProjectRow/ProjectMoreActionsMenu.test.tsx
@@ -79,29 +79,41 @@ describe('ProjectMoreActionsMenu', () => {
     });
   });
 
-  // describe('When user is a folder moderator', () => {
-  //   beforeAll(() => {
-  //     mockUserData.attributes.roles = [
-  //       { type: 'project_folder_moderator', project_folder_id: 'folderId' },
-  //     ];
-  //   });
+  describe('When user is a folder moderator', () => {
+    it('has no copy nor delete button for project that they do not moderate', async () => {
+      mockUserData.attributes.roles = [
+        { type: 'project_folder_moderator', project_folder_id: 'folderId' },
+      ];
+      render(<ProjectMoreActionsMenu {...props} />);
+      const threeDotsButton = screen.queryByTestId('moreOptionsButton');
 
-  //   it('Has no copy nor delete button', async () => {
-  //     render(<ProjectMoreActionsMenu {...props} />);
-  //     const user = userEvent.setup();
+      expect(threeDotsButton).not.toBeInTheDocument();
+    });
 
-  //     const threeDotsButton = screen.getByTestId('moreOptionsButton');
-  //     await user.click(threeDotsButton);
+    it('has copy button but not delete button for project that the user moderates', async () => {
+      mockUserData.attributes.highest_role = 'project_moderator';
+      mockUserData.attributes.roles = [
+        {
+          type: 'project_moderator',
+          project_id: 'projectId',
+        },
+      ];
 
-  //     const copyProjectButton = screen.queryByRole('button', {
-  //       name: 'Copy project',
-  //     });
-  //     const deleteProjectButton = screen.queryByRole('button', {
-  //       name: 'Delete project',
-  //     });
+      render(<ProjectMoreActionsMenu {...props} />);
+      const user = userEvent.setup();
 
-  //     expect(copyProjectButton).toBeNull();
-  //     expect(deleteProjectButton).toBeNull();
-  //   });
-  // });
+      const threeDotsButton = screen.getByTestId('moreOptionsButton');
+      await user.click(threeDotsButton);
+
+      const copyProjectButton = await screen.findByRole('button', {
+        name: 'Copy project',
+      });
+      const deleteProjectButton = screen.queryByRole('button', {
+        name: 'Delete project',
+      });
+
+      expect(copyProjectButton).toBeInTheDocument();
+      expect(deleteProjectButton).toBeNull();
+    });
+  });
 });

--- a/front/app/containers/Admin/projects/components/ProjectRow/ProjectMoreActionsMenu.tsx
+++ b/front/app/containers/Admin/projects/components/ProjectRow/ProjectMoreActionsMenu.tsx
@@ -7,6 +7,7 @@ import { useIntl } from 'utils/cl-intl';
 import { isAdmin } from 'services/permissions/roles';
 import useAuthUser from 'hooks/useAuthUser';
 import { isNilOrError } from 'utils/helperUtils';
+import { canModerateProject } from 'services/permissions/rules/projectPermissions';
 
 export interface Props {
   projectId: string;
@@ -54,8 +55,15 @@ const ProjectMoreActionsMenu = ({ projectId, setError }: Props) => {
     icon: 'delete' as const,
   };
 
-  const actions: IAction[] = [copyAction];
-  if (isAdmin({ data: authUser })) {
+  const actions: IAction[] = [];
+  const canModerate = canModerateProject(projectId, { data: authUser });
+  const isAdminUser = isAdmin({ data: authUser });
+
+  if (isAdminUser || canModerate) {
+    actions.push(copyAction);
+  }
+
+  if (isAdminUser) {
     actions.push(deleteAction);
   }
 

--- a/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/ProjectFolderRow.test.tsx
+++ b/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/ProjectFolderRow.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ProjectFolderRow, { Props } from '.';
 import { render, screen } from 'utils/testUtils/rtl';
 import { IAdminPublicationContent } from 'hooks/useAdminPublications';
+import { IUserData } from 'services/users';
 
 const publication: IAdminPublicationContent = {
   id: '1',
@@ -30,10 +31,27 @@ const publication: IAdminPublicationContent = {
 };
 
 // Needed to render moreActionsMenu
+const mockUserData: IUserData = {
+  id: 'userId',
+  type: 'user',
+  attributes: {
+    first_name: 'Stewie',
+    last_name: 'McKenzie',
+    locale: 'en',
+    slug: 'stewie-mckenzie',
+    highest_role: 'admin',
+    bio_multiloc: {},
+    roles: [{ type: 'admin' }],
+    registration_completed_at: '',
+    created_at: '',
+    updated_at: '',
+    unread_notifications: 0,
+    invite_status: null,
+    confirmation_required: false,
+  },
+};
 jest.mock('hooks/useAuthUser', () => {
-  return () => ({
-    id: 'userId',
-  });
+  return () => mockUserData;
 });
 
 const props: Props = {
@@ -42,12 +60,12 @@ const props: Props = {
 
 describe('ProjectFolderRow', () => {
   describe('When user is an admin', () => {
-    // it('shows the edit button', () => {
-    //   render(<ProjectFolderRow {...props} />);
+    it('shows the edit button', () => {
+      render(<ProjectFolderRow {...props} />);
 
-    //   const editButton = screen.getByRole('button', { name: 'Edit' });
-    //   expect(editButton).toBeInTheDocument();
-    // });
+      const editButton = screen.getByRole('button', { name: 'Manage' });
+      expect(editButton).toBeInTheDocument();
+    });
 
     it('shows the MoreActionsMenu', () => {
       render(<ProjectFolderRow {...props} />);
@@ -58,20 +76,41 @@ describe('ProjectFolderRow', () => {
   });
 
   describe('When user is a folder moderator', () => {
-    // it('shows the edit button for a folder the user is a moderator of', () => {
-    //   render(<ProjectFolderRow {...props} />);
-    //   const editButton = screen.getByRole('button', { name: 'Edit' });
-    //   expect(editButton).toBeInTheDocument();
-    // });
-    // it('shows a disabled edit button for a folder the user is not a moderator of', () => {
-    //   render(<ProjectFolderRow {...props} />);
-    //   const editButton = screen.getByRole('button', { name: 'Edit' });
-    //   expect(editButton).toBeDisabled();
-    // });
-    // it('does not show the MoreActionsMenu', () => {
-    //   render(<ProjectFolderRow {...props} />);
-    //   const moreActionsMenu = screen.queryByTestId('folderMoreActionsMenu');
-    //   expect(moreActionsMenu).toBeNull();
-    // });
+    beforeAll(() => {
+      mockUserData.attributes.highest_role = 'project_moderator';
+    });
+
+    it('shows the edit button for a folder the user is a moderator of', () => {
+      mockUserData.attributes.roles = [
+        {
+          type: 'project_folder_moderator',
+          project_folder_id: 'publicationId',
+        },
+      ];
+
+      render(<ProjectFolderRow {...props} />);
+      const editButton = screen.getByRole('button', { name: 'Manage' });
+      expect(editButton).toBeInTheDocument();
+    });
+
+    it('shows a disabled edit button for a folder the user is not a moderator of', () => {
+      mockUserData.attributes.roles = [
+        { type: 'project_folder_moderator', project_folder_id: 'testId' },
+      ];
+
+      render(<ProjectFolderRow {...props} />);
+      const editButton = screen.getByTestId('edit-button');
+      expect(editButton).toHaveAttribute('disabled');
+    });
+
+    it('does not show the MoreActionsMenu', () => {
+      mockUserData.attributes.roles = [
+        { type: 'project_folder_moderator', project_folder_id: 'folderId' },
+      ];
+
+      render(<ProjectFolderRow {...props} />);
+      const moreOptions = screen.queryByTestId('moreOptionsButton');
+      expect(moreOptions).toBeNull();
+    });
   });
 });

--- a/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/ProjectFolderRow.test.tsx
+++ b/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/ProjectFolderRow.test.tsx
@@ -63,7 +63,7 @@ describe('ProjectFolderRow', () => {
     it('shows the edit button', () => {
       render(<ProjectFolderRow {...props} />);
 
-      const editButton = screen.getByRole('button', { name: 'Manage' });
+      const editButton = screen.getByRole('button', { name: 'Edit' });
       expect(editButton).toBeInTheDocument();
     });
 
@@ -76,10 +76,6 @@ describe('ProjectFolderRow', () => {
   });
 
   describe('When user is a folder moderator', () => {
-    beforeAll(() => {
-      mockUserData.attributes.highest_role = 'project_moderator';
-    });
-
     it('shows the edit button for a folder the user is a moderator of', () => {
       mockUserData.attributes.roles = [
         {
@@ -89,11 +85,11 @@ describe('ProjectFolderRow', () => {
       ];
 
       render(<ProjectFolderRow {...props} />);
-      const editButton = screen.getByRole('button', { name: 'Manage' });
+      const editButton = screen.getByRole('button', { name: 'Edit' });
       expect(editButton).toBeInTheDocument();
     });
 
-    it('shows a disabled edit button for a folder the user is not a moderator of', () => {
+    it('shows a disabled edit button for a folder when the user is not a moderator of', async () => {
       mockUserData.attributes.roles = [
         { type: 'project_folder_moderator', project_folder_id: 'testId' },
       ];

--- a/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/index.tsx
+++ b/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/index.tsx
@@ -156,6 +156,7 @@ const ProjectFolderRow = memo<Props>(({ publication }) => {
                 isBeingDeleted ||
                 !userModeratesFolder(authUser, publication.publicationId)
               }
+              data-testid="edit-button"
             >
               <FormattedMessage {...messages.edit} />
             </RowButton>

--- a/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/messages.ts
+++ b/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/messages.ts
@@ -3,7 +3,7 @@ import { defineMessages } from 'react-intl';
 export default defineMessages({
   edit: {
     id: 'app.containers.Admin.projects.all.components.manageButtonLabel',
-    defaultMessage: 'Manage',
+    defaultMessage: 'Edit',
   },
   deleteFolderError: {
     id: 'app.containers.Admin.projects.all.deleteFolderError',


### PR DESCRIPTION
Add tests for the folder moderator.

The messages file still has `Manage` instead of `Edit` but leaving that as is. I think that was changed in Crowdin and the default message was not changed

## How urgent is a code review?

End of Tomorrow
