### PR TITLE
[CL-2779] Remove unused project image versions

### DIFF
--- a/back/app/uploaders/project_header_bg_uploader.rb
+++ b/back/app/uploaders/project_header_bg_uploader.rb
@@ -4,12 +4,4 @@ class ProjectHeaderBgUploader < BaseImageUploader
   version :large do
     process resize_to_fill: [1440, 360]
   end
-
-  version :medium do
-    process resize_to_fill: [720, 180]
-  end
-
-  version :small do
-    process resize_to_fill: [520, 250]
-  end
 end

--- a/back/app/uploaders/project_image_uploader.rb
+++ b/back/app/uploaders/project_image_uploader.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 class ProjectImageUploader < BaseImageUploader
-  # used for small cards on desktop
-  version :small do
-    process safe_resize_to_fill_for_gif: [400, 300]
-  end
-
   version :large do
     process safe_resize_to_fill_for_gif: [600, 450]
   end

--- a/back/engines/free/volunteering/app/uploaders/volunteering/cause_image_uploader.rb
+++ b/back/engines/free/volunteering/app/uploaders/volunteering/cause_image_uploader.rb
@@ -2,20 +2,8 @@
 
 module Volunteering
   class CauseImageUploader < BaseImageUploader
-    version :small do
-      process resize_to_fill: [96, 96]
-    end
-
     version :medium do
       process resize_to_fill: [298, 135]
-    end
-
-    version :large do
-      process resize_to_limit: [480, nil]
-    end
-
-    version :fb do
-      process resize_to_fill: [1200, 630]
     end
   end
 end

--- a/back/spec/acceptance/project_images_spec.rb
+++ b/back/spec/acceptance/project_images_spec.rb
@@ -32,7 +32,7 @@ resource 'ProjectImage' do
     example_request 'Get one image of a project' do
       assert_status 200
       json_response = json_parse(response_body)
-      expect(json_response.dig(:data, :attributes, :versions).keys).to match %i[small large]
+      expect(json_response.dig(:data, :attributes, :versions).keys).to match %i[large]
     end
   end
 
@@ -49,7 +49,7 @@ resource 'ProjectImage' do
     example_request 'Add an image to a project' do
       assert_status 201
       json_response = json_parse(response_body)
-      expect(json_response.dig(:data, :attributes, :versions).keys).to match %i[small large]
+      expect(json_response.dig(:data, :attributes, :versions).keys).to match %i[large]
       expect(json_response.dig(:data, :attributes, :ordering)).to eq(1)
     end
 
@@ -90,7 +90,7 @@ resource 'ProjectImage' do
     example_request 'Edit an image for a project' do
       expect(response_status).to eq 200
       json_response = json_parse(response_body)
-      expect(json_response.dig(:data, :attributes, :versions).keys).to match %i[small large]
+      expect(json_response.dig(:data, :attributes, :versions).keys).to match %i[large]
       expect(json_response.dig(:data, :attributes, :ordering)).to eq(2)
     end
   end

--- a/front/app/components/ProjectCard/index.tsx
+++ b/front/app/components/ProjectCard/index.tsx
@@ -10,16 +10,13 @@ import { TLayout } from 'components/ProjectAndFolderCards';
 import Link from 'utils/cl-router/Link';
 
 // components
-import { Icon, useBreakpoint } from '@citizenlab/cl2-component-library';
+import { Icon } from '@citizenlab/cl2-component-library';
 import Image from 'components/UI/Image';
 import AvatarBubbles from 'components/AvatarBubbles';
 
 // services
 import { getProjectUrl } from 'services/projects';
-import {
-  CARD_IMAGE_ASPECT_RATIO,
-  getCardImageUrl,
-} from 'services/projectImages';
+import { CARD_IMAGE_ASPECT_RATIO } from 'services/projectImages';
 import { getInputTerm } from 'services/participationContexts';
 import { getIdeaPostingRules } from 'services/actionTakingRules';
 
@@ -475,7 +472,6 @@ const ProjectCard = memo<Props>(
     const phase = usePhase(currentPhaseId);
     const phases = usePhases(projectId);
     const theme = useTheme();
-    const isPhone = useBreakpoint('phone');
 
     const [visible, setVisible] = useState(false);
 
@@ -515,13 +511,9 @@ const ProjectCard = memo<Props>(
       const canComment =
         project.attributes.action_descriptor.commenting_idea.enabled;
 
-      const imageVersions = isNilOrError(projectImages)
+      const imageUrl = isNilOrError(projectImages)
         ? null
-        : projectImages[0]?.attributes.versions;
-
-      const imageUrl = imageVersions
-        ? getCardImageUrl(imageVersions, isPhone, size)
-        : null;
+        : projectImages[0]?.attributes.versions?.large;
 
       const projectUrl = getProjectUrl(project);
       const isFinished = project.attributes.timeline_active === 'past';

--- a/front/app/containers/Admin/projects/project/volunteering/CauseForm.tsx
+++ b/front/app/containers/Admin/projects/project/volunteering/CauseForm.tsx
@@ -111,8 +111,8 @@ const CauseForm = ({ onSubmit, defaultValues, imageUrl }: PageFormProps) => {
         <SectionField>
           <ImagesDropzone
             name="image"
-            imagePreviewRatio={120 / 480}
-            maxImagePreviewWidth="500px"
+            imagePreviewRatio={135 / 298}
+            maxImagePreviewWidth="298px"
             acceptedFileTypes={{
               'image/*': ['.jpg', '.jpeg', '.png', '.gif'],
             }}

--- a/front/app/containers/Admin/projects/project/volunteering/EditCause.tsx
+++ b/front/app/containers/Admin/projects/project/volunteering/EditCause.tsx
@@ -60,7 +60,7 @@ const EditCause = () => {
           title_multiloc: cause.attributes.title_multiloc,
           description_multiloc: cause.attributes.description_multiloc,
         }}
-        imageUrl={cause.attributes.image?.large}
+        imageUrl={cause.attributes.image?.medium}
       />
     </div>
   );

--- a/front/app/services/__mocks__/projects.ts
+++ b/front/app/services/__mocks__/projects.ts
@@ -20,10 +20,7 @@ export function getProject(
       slug: `${id}_slug`,
       input_term: 'idea',
       header_bg: {
-        small: `header${id}ImageUrlSmall`,
-        medium: `header${id}ImageUrlMedium`,
         large: `header${id}ImageUrlLarge`,
-        fb: `header${id}ImageUrlFb`,
       }, // ImageSizes,
       ideas_count: 25,
       comments_count: 10,

--- a/front/app/services/causes.ts
+++ b/front/app/services/causes.ts
@@ -1,8 +1,12 @@
 import { API_PATH } from 'containers/App/constants';
 import streams, { IStreamParams } from 'utils/streams';
-import { Multiloc, ImageSizes } from 'typings';
+import { Multiloc } from 'typings';
 
 const apiEndpoint = `${API_PATH}/causes`;
+
+interface CauseImageSizes {
+  medium: string | null;
+}
 
 export interface ICauseData {
   id: string;
@@ -10,7 +14,7 @@ export interface ICauseData {
   attributes: {
     title_multiloc: Multiloc;
     description_multiloc: Multiloc;
-    image: ImageSizes;
+    image: CauseImageSizes;
     volunteers_count: number;
     ordering: number;
   };

--- a/front/app/services/projectImages.ts
+++ b/front/app/services/projectImages.ts
@@ -1,11 +1,9 @@
 import { API_PATH } from 'containers/App/constants';
 import streams, { IStreamParams } from 'utils/streams';
-import { TProjectCardSize } from 'components/ProjectCard';
 
 const apiEndpoint = `${API_PATH}/projects`;
 
 type ProjectImageSizes = {
-  small: string | null;
   large: string | null;
 };
 
@@ -13,19 +11,6 @@ export const CARD_IMAGE_ASPECT_RATIO_WIDTH = 4;
 export const CARD_IMAGE_ASPECT_RATIO_HEIGHT = 3;
 export const CARD_IMAGE_ASPECT_RATIO =
   CARD_IMAGE_ASPECT_RATIO_WIDTH / CARD_IMAGE_ASPECT_RATIO_HEIGHT;
-
-export const getCardImageUrl = (
-  imageVersions: ProjectImageSizes,
-  isPhone: boolean,
-  cardSize?: TProjectCardSize
-) => {
-  if (isPhone || cardSize !== 'small') {
-    // image size is approximately the same for both medium and large desktop card sizes
-    return imageVersions.large;
-  } else {
-    return imageVersions.small;
-  }
-};
 
 export interface IProjectImageData {
   id: string;

--- a/front/app/services/projects.ts
+++ b/front/app/services/projects.ts
@@ -3,13 +3,7 @@ import { API_PATH } from 'containers/App/constants';
 // typings
 import { ISubmitState } from 'components/admin/SubmitWrapper';
 import { Locale } from '@citizenlab/cl2-component-library';
-import {
-  IRelationship,
-  Multiloc,
-  ImageSizes,
-  UploadFile,
-  CLError,
-} from 'typings';
+import { IRelationship, Multiloc, UploadFile, CLError } from 'typings';
 import { IAreaData } from './areas';
 import { IAppConfiguration } from 'services/appConfiguration';
 
@@ -85,12 +79,16 @@ export type PollDisabledReason =
   | 'not_verified'
   | 'not_signed_in';
 
+interface ProjectHeaderBgImageSizes {
+  large: string | null;
+}
+
 export interface IProjectAttributes {
   title_multiloc: Multiloc;
   description_multiloc: Multiloc;
   description_preview_multiloc: Multiloc;
   slug: string;
-  header_bg: ImageSizes;
+  header_bg: ProjectHeaderBgImageSizes;
   ideas_count: number;
   comments_count: number;
   avatars_count: number;
@@ -197,14 +195,14 @@ export interface IProjectData {
 
 export interface IUpdatedProjectProperties {
   // header_bg is only a string or null when it's
-  // in IUpdatedProjectProperties. The ImageSizes needed
-  // to be added because we go from string here to ImageSizes
+  // in IUpdatedProjectProperties. The ProjectHeaderBgImageSizes needed
+  // to be added because we go from string here to ProjectHeaderBgImageSizes
   // in IProjectAttributes (also in this file) when we save an image
-  // selected for upload. ImageSizes needs to be here, because
+  // selected for upload. ProjectHeaderBgImageSizes needs to be here, because
   // Otherwise TS will complain about this mismatch in
   // front/app/containers/Admin/projects/general/index.tsx
   // This oddity needs to be dealt with
-  header_bg?: string | ImageSizes | null;
+  header_bg?: string | ProjectHeaderBgImageSizes | null;
   title_multiloc?: Multiloc;
   description_multiloc?: Multiloc;
   description_preview_multiloc?: Multiloc;


### PR DESCRIPTION
It would be nice to merge it to master and test copying on Production (calling the endpoint), hence this PR is separate from https://github.com/CitizenLabDotCo/citizenlab/pull/3879

See this commit description for some explanations https://github.com/CitizenLabDotCo/citizenlab/pull/3981/commits/532653303e907a86f24310417c8328d5a539a174