### PR TITLE
CL-2831: Align edit button to the right if more options menu is not present

### DIFF
--- a/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/FolderMoreActionsMenu.tsx
+++ b/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/FolderMoreActionsMenu.tsx
@@ -52,7 +52,7 @@ const FolderMoreActionsMenu = ({ folderId, setError }: Props) => {
     actions.push(deleteAction);
   }
 
-  if (!actions.length) {
+  if (actions.length === 0) {
     return null;
   }
 

--- a/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/FolderMoreActionsMenu.tsx
+++ b/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/FolderMoreActionsMenu.tsx
@@ -52,7 +52,7 @@ const FolderMoreActionsMenu = ({ folderId, setError }: Props) => {
     actions.push(deleteAction);
   }
 
-  if (actions.length === 0) {
+  if (!actions.length) {
     return null;
   }
 

--- a/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/FolderMoreActionsMenu.tsx
+++ b/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/FolderMoreActionsMenu.tsx
@@ -52,6 +52,10 @@ const FolderMoreActionsMenu = ({ folderId, setError }: Props) => {
     actions.push(deleteAction);
   }
 
+  if (actions.length === 0) {
+    return null;
+  }
+
   return (
     <Box
       display="flex"

--- a/front/app/services/projects.ts
+++ b/front/app/services/projects.ts
@@ -367,7 +367,11 @@ export async function copyProject(projectId: string) {
   const response = await streams.add(`${apiEndpoint}/${projectId}/copy`, {});
 
   await streams.fetchAllWith({
-    apiEndpoint: [`${API_PATH}/projects`, `${API_PATH}/admin_publications`],
+    apiEndpoint: [
+      `${API_PATH}/projects`,
+      `${API_PATH}/admin_publications`,
+      `${API_PATH}/users/me`,
+    ],
   });
   return response;
 }


### PR DESCRIPTION
Align edit button to the right if more options menu is not present in folder row.

While working on this, I noticed that the more options menu wasn't being shown after copying a project for a moderator. I fixed that with this.

## How urgent is a code review?

End of day if possible
