### PR TITLE
Cl 2834 fe load projects inside folder row for extra robustness

### DIFF
--- a/front/app/containers/Admin/projects/components/ProjectRow/index.tsx
+++ b/front/app/containers/Admin/projects/components/ProjectRow/index.tsx
@@ -70,7 +70,7 @@ const ProjectRow = ({
     canModerateProject(publication.publicationId, { data: authUser });
 
   return (
-    <Container className={className}>
+    <Container className={className} data-testid="projectRow">
       <RowContent className="e2e-admin-projects-list-item">
         <RowContentInner className="expand primary">
           <RowTitle value={publication.attributes.publication_title_multiloc} />

--- a/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/ProjectFolderRow.test.tsx
+++ b/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/ProjectFolderRow.test.tsx
@@ -113,8 +113,8 @@ describe('ProjectFolderRow', () => {
     });
   });
 
-  describe('When user is a folder moderator', () => {
-    it('shows the edit button for a folder the user is a moderator of', () => {
+  describe('When user is a folder moderator of the folder', () => {
+    it('shows the edit button', () => {
       mockUserData.attributes.roles = [
         {
           type: 'project_folder_moderator',
@@ -127,7 +127,16 @@ describe('ProjectFolderRow', () => {
       expect(editButton).toBeInTheDocument();
     });
 
-    it('shows a disabled edit button for a folder when the user is not a moderator of', async () => {
+    it('shows the MoreActionsMenu', () => {
+      render(<ProjectFolderRow {...props} />);
+
+      const moreActionsMenu = screen.getByTestId('folderMoreActionsMenu');
+      expect(moreActionsMenu).toBeInTheDocument();
+    });
+  });
+
+  describe('When user is a folder moderator but not of the folder', () => {
+    it('shows a disabled edit button', async () => {
       mockUserData.attributes.roles = [
         { type: 'project_folder_moderator', project_folder_id: 'testId' },
       ];
@@ -139,7 +148,10 @@ describe('ProjectFolderRow', () => {
 
     it('does not show the MoreActionsMenu', () => {
       mockUserData.attributes.roles = [
-        { type: 'project_folder_moderator', project_folder_id: 'folderId' },
+        {
+          type: 'project_folder_moderator',
+          project_folder_id: folderPublication.publicationId,
+        },
       ];
 
       render(<ProjectFolderRow {...props} />);

--- a/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/ProjectFolderRow.test.tsx
+++ b/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/ProjectFolderRow.test.tsx
@@ -4,10 +4,11 @@ import { render, screen } from 'utils/testUtils/rtl';
 import { IAdminPublicationContent } from 'hooks/useAdminPublications';
 import { IUserData } from 'services/users';
 
-const publication: IAdminPublicationContent = {
+const folderId = 'folderId';
+const folderPublication: IAdminPublicationContent = {
   id: '1',
-  publicationType: 'project' as const,
-  publicationId: 'publicationId',
+  publicationType: 'folder' as const,
+  publicationId: folderId,
   attributes: {
     ordering: 0,
     depth: 0,
@@ -16,19 +17,53 @@ const publication: IAdminPublicationContent = {
     publication_title_multiloc: {},
     publication_description_multiloc: {},
     publication_description_preview_multiloc: {},
-    publication_slug: 'project_1',
+    publication_slug: 'folder_1',
   },
   relationships: {
     children: { data: [] },
     parent: {},
     publication: {
       data: {
-        id: '1',
-        type: 'project',
+        id: folderId,
+        type: 'folder',
       },
     },
   },
 };
+
+const projectId = 'projectId';
+const mockFolderChildAdminPublications: IAdminPublicationContent[] = [
+  {
+    id: '2',
+    publicationType: 'project' as const,
+    publicationId: projectId,
+    attributes: {
+      ordering: 0,
+      depth: 0,
+      publication_status: 'published',
+      visible_children_count: 0,
+      publication_title_multiloc: {},
+      publication_description_multiloc: {},
+      publication_description_preview_multiloc: {},
+      publication_slug: 'project_1',
+    },
+    relationships: {
+      children: { data: [] },
+      parent: {
+        data: {
+          type: 'folder',
+          id: folderPublication.id,
+        },
+      },
+      publication: {
+        data: {
+          id: projectId,
+          type: 'project',
+        },
+      },
+    },
+  },
+];
 
 // Needed to render moreActionsMenu
 const mockUserData: IUserData = {
@@ -53,9 +88,12 @@ const mockUserData: IUserData = {
 jest.mock('hooks/useAuthUser', () => {
   return () => mockUserData;
 });
+jest.mock('hooks/useAdminPublications', () => {
+  return () => mockFolderChildAdminPublications;
+});
 
 const props: Props = {
-  publication,
+  publication: folderPublication,
 };
 
 describe('ProjectFolderRow', () => {
@@ -80,7 +118,7 @@ describe('ProjectFolderRow', () => {
       mockUserData.attributes.roles = [
         {
           type: 'project_folder_moderator',
-          project_folder_id: publication.publicationId,
+          project_folder_id: folderPublication.publicationId,
         },
       ];
 

--- a/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/ProjectFolderRow.test.tsx
+++ b/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/ProjectFolderRow.test.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import ProjectFolderRow, { Props } from '.';
 import { render, screen } from 'utils/testUtils/rtl';
-import { IAdminPublicationContent } from 'hooks/useAdminPublications';
+import {
+  IAdminPublicationContent,
+  IUseAdminPublicationsOutput,
+} from 'hooks/useAdminPublications';
 import { IUserData } from 'services/users';
 
 const folderId = 'folderId';
@@ -32,7 +35,7 @@ const folderPublication: IAdminPublicationContent = {
 };
 
 const projectId = 'projectId';
-const mockFolderChildAdminPublications: IAdminPublicationContent[] = [
+const mockFolderChildAdminPublicationsList: IAdminPublicationContent[] = [
   {
     id: '2',
     publicationType: 'project' as const,
@@ -64,6 +67,17 @@ const mockFolderChildAdminPublications: IAdminPublicationContent[] = [
     },
   },
 ];
+const mockFolderChildAdminPublications: IUseAdminPublicationsOutput = {
+  hasMore: false,
+  loadingInitial: false,
+  loadingMore: false,
+  list: mockFolderChildAdminPublicationsList,
+  onLoadMore: jest.fn,
+  onChangeTopics: jest.fn,
+  onChangeSearch: jest.fn,
+  onChangeAreas: jest.fn,
+  onChangePublicationStatus: jest.fn,
+};
 
 // Needed to render moreActionsMenu
 const mockUserData: IUserData = {
@@ -88,6 +102,8 @@ const mockUserData: IUserData = {
 jest.mock('hooks/useAuthUser', () => {
   return () => mockUserData;
 });
+
+// Needed to render folder with project inside
 jest.mock('hooks/useAdminPublications', () => {
   return () => mockFolderChildAdminPublications;
 });
@@ -97,6 +113,13 @@ const props: Props = {
 };
 
 describe('ProjectFolderRow', () => {
+  it('renders the project row inside', () => {
+    render(<ProjectFolderRow {...props} />);
+
+    const projectRows = screen.getAllByTestId('projectRow');
+    expect(projectRows.length).toEqual(1);
+  });
+
   describe('When user is an admin', () => {
     it('shows the edit button', () => {
       render(<ProjectFolderRow {...props} />);
@@ -153,8 +176,8 @@ describe('ProjectFolderRow', () => {
           project_folder_id: folderPublication.publicationId,
         },
       ];
-
       render(<ProjectFolderRow {...props} />);
+
       const moreOptions = screen.queryByTestId('moreOptionsButton');
       expect(moreOptions).toBeNull();
     });

--- a/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/ProjectFolderRow.test.tsx
+++ b/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/ProjectFolderRow.test.tsx
@@ -101,7 +101,7 @@ describe('ProjectFolderRow', () => {
     it('shows the edit button', () => {
       render(<ProjectFolderRow {...props} />);
 
-      const editButton = screen.getByRole('button', { name: 'Edit' });
+      const editButton = screen.getByTestId('folder-row-edit-button');
       expect(editButton).toBeInTheDocument();
     });
 
@@ -123,7 +123,7 @@ describe('ProjectFolderRow', () => {
       ];
 
       render(<ProjectFolderRow {...props} />);
-      const editButton = screen.getByRole('button', { name: 'Edit' });
+      const editButton = screen.getByTestId('folder-row-edit-button');
       expect(editButton).toBeInTheDocument();
     });
 
@@ -133,7 +133,7 @@ describe('ProjectFolderRow', () => {
       ];
       render(<ProjectFolderRow {...props} />);
 
-      const editButton = screen.getByTestId('edit-button');
+      const editButton = screen.getByTestId('folder-row-edit-button');
       expect(editButton).toHaveAttribute('disabled');
     });
 

--- a/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/index.tsx
+++ b/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/index.tsx
@@ -148,7 +148,7 @@ const ProjectFolderRow = memo<Props>(({ publication }) => {
                 isBeingDeleted ||
                 !userModeratesFolder(authUser, publication.publicationId)
               }
-              data-testid="edit-button"
+              data-testid="folder-row-edit-button"
             >
               <FormattedMessage {...messages.edit} />
             </RowButton>


### PR DESCRIPTION
## Checklist

- [ ] Added entry to changelog
<details>
<summary>More info</summary>
Add a concise line to the 'Next release' section of the changelog (docs/README.md) so people other than developers can understand what has changed where. E.g. 'Added an error message to the project name field of the project edit form (Admin > Projects > Edit)'.
</details>

- [ ] WCAG 2.1 AA proof
<details>
<summary>More info</summary>
For front-end devs only. Is your work conforming with the WCAG 2.1 AA rules? If you need more info, read the [a11y page](https://www.notion.so/citizenlab/a11y-7568f83d42ab4895ac133b89d358997b) on our Notion.
</details>

- [ ] Tests
<details>
<summary>More info</summary>

### Unit tests

Did you add relevant unit tests?

### E2E tests

Sometimes it can be more efficient to update E2E tests after CI has run them. If you know which ones to update, go ahead! E2E template cl2-back:

```bash
docker compose run --rm web bin/rails cl2_back:create_tenant[localhost,e2etests_template]
```

</details>

- [ ] Prepared branch for code review
<details>
<summary>More info</summary>
Reviewed code to reduce unnecessary back and forth (removal of console.log, comments, ...)? Added comments to clarify code, emphasize what to pay attention to, etc.?
</details>

## Links

- [citizenlab-ee PR](**put URL here** or remove)
- [Specs](**put URL here** or remove)
- [Epic Deployment](**put URL here** or remove)

## How urgent is a code review?

Let the reviewer(s) know how urgent the code review is, so they can prioritize their work accordingly. Be specific (e.g. by Wednesday, end of the day/this week/... is better than 'urgent' or 'very urgent'). Optionally provide a word of explanation on your deadline.
