### PR TITLE
Cl 2835 fe fix styling of child rows in folder rows

### DIFF
--- a/front/app/containers/Admin/pagesAndMenu/containers/ProjectsList/ProjectsListContent.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ProjectsList/ProjectsListContent.tsx
@@ -83,7 +83,11 @@ const ProjectsListContent = ({ customPage }: Props) => {
               isLastItem={index === adminPublicationsList.length - 1}
               key={adminPublication.id}
             >
-              <ProjectRow publication={adminPublication} actions={['manage']} />
+              <ProjectRow
+                publication={adminPublication}
+                actions={['manage']}
+                hideMoreActions
+              />
             </Row>
           ))}
         </>

--- a/front/app/containers/Admin/projectFolders/containers/projects/ItemsInFolder.tsx
+++ b/front/app/containers/Admin/projectFolders/containers/projects/ItemsInFolder.tsx
@@ -107,6 +107,7 @@ const ItemsInFolder = ({ projectFolderId }: Props) => {
                             ]
                           : ['manage']
                       }
+                      hideMoreActions
                     />
                   </SortableRow>
                 );

--- a/front/app/containers/Admin/projectFolders/containers/projects/ItemsNotInFolder.tsx
+++ b/front/app/containers/Admin/projectFolders/containers/projects/ItemsNotInFolder.tsx
@@ -86,6 +86,7 @@ const ItemsNotInFolder = ({ projectFolderId }: Props) => {
                       icon: 'plus-circle',
                     },
                   ]}
+                  hideMoreActions
                 />
               </Row>
             )

--- a/front/app/containers/Admin/projects/all/Lists/AdminProjectList.tsx
+++ b/front/app/containers/Admin/projects/all/Lists/AdminProjectList.tsx
@@ -102,7 +102,6 @@ const AdminProjectList = memo<Props>((_props) => {
                             <ProjectRow
                               actions={['manage']}
                               publication={item}
-                              showMoreActions
                             />
                           </StyledSortableRow>
                         )}

--- a/front/app/containers/Admin/projects/all/Lists/AdminProjectList.tsx
+++ b/front/app/containers/Admin/projects/all/Lists/AdminProjectList.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import React, { Fragment, memo } from 'react';
 
 // style
 import styled from 'styled-components';
@@ -88,7 +88,7 @@ const AdminProjectList = memo<Props>((_props) => {
                 {itemsList.map(
                   (item: IAdminPublicationContent, index: number) => {
                     return (
-                      <>
+                      <Fragment key={item.id}>
                         {item.publicationType === 'project' && (
                           <StyledSortableRow
                             key={item.id}
@@ -120,7 +120,7 @@ const AdminProjectList = memo<Props>((_props) => {
                             publication={item}
                           />
                         )}
-                      </>
+                      </Fragment>
                     );
                   }
                 )}

--- a/front/app/containers/Admin/projects/all/Lists/AdminProjectList.tsx
+++ b/front/app/containers/Admin/projects/all/Lists/AdminProjectList.tsx
@@ -91,7 +91,6 @@ const AdminProjectList = memo<Props>((_props) => {
                       <Fragment key={item.id}>
                         {item.publicationType === 'project' && (
                           <StyledSortableRow
-                            key={item.id}
                             id={item.id}
                             index={index}
                             moveRow={handleDragRow}
@@ -109,7 +108,6 @@ const AdminProjectList = memo<Props>((_props) => {
                         )}
                         {item.publicationType === 'folder' && (
                           <SortableFolderRow
-                            key={item.id}
                             id={item.id}
                             index={index}
                             moveRow={handleDragRow}

--- a/front/app/containers/Admin/projects/all/Lists/AdminProjectList.tsx
+++ b/front/app/containers/Admin/projects/all/Lists/AdminProjectList.tsx
@@ -9,10 +9,9 @@ import { isNilOrError } from 'utils/helperUtils';
 // components
 import { SortableList, SortableRow } from 'components/admin/ResourceList';
 import ProjectRow from '../../components/ProjectRow';
-import ProjectFolderRow from '../../projectFolders/components/ProjectFolderRow';
 import { ListHeader, HeaderTitle } from '../StyledComponents';
 import Button from 'components/UI/Button';
-
+import SortableFolderRow from './SortableFolderRow';
 // i18n
 import { FormattedMessage } from 'utils/cl-intl';
 import messages from '../messages';
@@ -89,27 +88,39 @@ const AdminProjectList = memo<Props>((_props) => {
                 {itemsList.map(
                   (item: IAdminPublicationContent, index: number) => {
                     return (
-                      <StyledSortableRow
-                        key={item.id}
-                        id={item.id}
-                        index={index}
-                        moveRow={handleDragRow}
-                        dropRow={handleDropRow}
-                        isLastItem={
-                          index === rootLevelAdminPublications.length - 1
-                        }
-                      >
+                      <>
                         {item.publicationType === 'project' && (
-                          <ProjectRow
-                            actions={['manage']}
-                            publication={item}
-                            showMoreActions
-                          />
+                          <StyledSortableRow
+                            key={item.id}
+                            id={item.id}
+                            index={index}
+                            moveRow={handleDragRow}
+                            dropRow={handleDropRow}
+                            isLastItem={
+                              index === rootLevelAdminPublications.length - 1
+                            }
+                          >
+                            <ProjectRow
+                              actions={['manage']}
+                              publication={item}
+                              showMoreActions
+                            />
+                          </StyledSortableRow>
                         )}
                         {item.publicationType === 'folder' && (
-                          <ProjectFolderRow publication={item} />
+                          <SortableFolderRow
+                            key={item.id}
+                            id={item.id}
+                            index={index}
+                            moveRow={handleDragRow}
+                            dropRow={handleDropRow}
+                            isLastItem={
+                              index === rootLevelAdminPublications.length - 1
+                            }
+                            publication={item}
+                          />
                         )}
-                      </StyledSortableRow>
+                      </>
                     );
                   }
                 )}

--- a/front/app/containers/Admin/projects/all/Lists/FolderChildProjects.tsx
+++ b/front/app/containers/Admin/projects/all/Lists/FolderChildProjects.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { List, Row } from 'components/admin/ResourceList';
+import { Box } from '@citizenlab/cl2-component-library';
+import { IAdminPublicationContent } from 'hooks/useAdminPublications';
+import ProjectRow from 'containers/Admin/projects/components/ProjectRow';
+import { userModeratesFolder } from 'services/permissions/rules/projectFolderPermissions';
+import { IUserData } from 'services/users';
+
+interface Props {
+  folderChildAdminPublications: IAdminPublicationContent[];
+  authUser: IUserData;
+}
+
+const FolderChildProjects = ({
+  folderChildAdminPublications,
+  authUser,
+}: Props) => {
+  return (
+    <Box pl="60px">
+      <List>
+        {folderChildAdminPublications.map((childPublication) => (
+          <Row>
+            <ProjectRow
+              publication={childPublication}
+              key={childPublication.id}
+              actions={['manage']}
+              showMoreActions={userModeratesFolder(
+                authUser,
+                childPublication.publicationId
+              )}
+            />
+          </Row>
+        ))}
+      </List>
+    </Box>
+  );
+};
+
+export default FolderChildProjects;

--- a/front/app/containers/Admin/projects/all/Lists/FolderChildProjects.tsx
+++ b/front/app/containers/Admin/projects/all/Lists/FolderChildProjects.tsx
@@ -4,7 +4,7 @@ import { Box } from '@citizenlab/cl2-component-library';
 import { IAdminPublicationContent } from 'hooks/useAdminPublications';
 import ProjectRow from 'containers/Admin/projects/components/ProjectRow';
 
-export interface Props {
+interface Props {
   folderChildAdminPublications: IAdminPublicationContent[];
 }
 

--- a/front/app/containers/Admin/projects/all/Lists/FolderChildProjects.tsx
+++ b/front/app/containers/Admin/projects/all/Lists/FolderChildProjects.tsx
@@ -19,10 +19,9 @@ const FolderChildProjects = ({
     <Box pl="60px">
       <List>
         {folderChildAdminPublications.map((childPublication) => (
-          <Row>
+          <Row key={childPublication.id}>
             <ProjectRow
               publication={childPublication}
-              key={childPublication.id}
               actions={['manage']}
               showMoreActions={userModeratesFolder(
                 authUser,

--- a/front/app/containers/Admin/projects/all/Lists/FolderChildProjects.tsx
+++ b/front/app/containers/Admin/projects/all/Lists/FolderChildProjects.tsx
@@ -3,33 +3,22 @@ import { List, Row } from 'components/admin/ResourceList';
 import { Box } from '@citizenlab/cl2-component-library';
 import { IAdminPublicationContent } from 'hooks/useAdminPublications';
 import ProjectRow from 'containers/Admin/projects/components/ProjectRow';
-import { userModeratesFolder } from 'services/permissions/rules/projectFolderPermissions';
-import { IUserData } from 'services/users';
 
-interface Props {
+export interface Props {
   folderChildAdminPublications: IAdminPublicationContent[];
-  authUser: IUserData;
 }
 
-const FolderChildProjects = ({
-  folderChildAdminPublications,
-  authUser,
-}: Props) => {
+const FolderChildProjects = ({ folderChildAdminPublications }: Props) => {
   return (
     <Box pl="60px">
       <List>
-        {folderChildAdminPublications.map((childPublication) => (
-          <Row key={childPublication.id}>
-            <ProjectRow
-              publication={childPublication}
-              actions={['manage']}
-              showMoreActions={userModeratesFolder(
-                authUser,
-                childPublication.publicationId
-              )}
-            />
-          </Row>
-        ))}
+        {folderChildAdminPublications.map((childPublication) => {
+          return (
+            <Row key={childPublication.id}>
+              <ProjectRow publication={childPublication} actions={['manage']} />
+            </Row>
+          );
+        })}
       </List>
     </Box>
   );

--- a/front/app/containers/Admin/projects/all/Lists/ModeratorProjectList.tsx
+++ b/front/app/containers/Admin/projects/all/Lists/ModeratorProjectList.tsx
@@ -4,17 +4,14 @@ import React, { memo } from 'react';
 import { isNilOrError } from 'utils/helperUtils';
 
 // hooks
-import useAdminPublications, {
-  IAdminPublicationContent,
-} from 'hooks/useAdminPublications';
+import useAdminPublications from 'hooks/useAdminPublications';
 import useFeatureFlag from 'hooks/useFeatureFlag';
 
 // components
 import { List, Row } from 'components/admin/ResourceList';
 import ProjectRow from '../../components/ProjectRow';
-import ProjectFolderRow from '../../projectFolders/components/ProjectFolderRow';
 import { ListHeader, HeaderTitle } from '../StyledComponents';
-
+import NonSortableFolderRow from './NonSortableFolderRow';
 // i18n
 import { FormattedMessage } from 'utils/cl-intl';
 import messages from '../messages';
@@ -25,22 +22,6 @@ const ModeratorProjectList = memo(() => {
     rootLevelOnly: true,
   });
   const isProjectFoldersEnabled = useFeatureFlag({ name: 'project_folders' });
-
-  const adminPublicationRow = (adminPublication: IAdminPublicationContent) => {
-    if (adminPublication.publicationType === 'project') {
-      return (
-        <ProjectRow
-          publication={adminPublication}
-          actions={['manage']}
-          showMoreActions={false}
-        />
-      );
-    }
-    if (adminPublication.publicationType === 'folder') {
-      return <ProjectFolderRow publication={adminPublication} />;
-    }
-    return null;
-  };
 
   if (
     !isNilOrError(rootLevelAdminPublications) &&
@@ -61,13 +42,33 @@ const ModeratorProjectList = memo(() => {
               return (
                 !isProjectFoldersEnabled ||
                 (!adminPublication.relationships.parent.data && (
-                  <Row
-                    key={index}
-                    id={adminPublication.id}
-                    isLastItem={index === rootLevelAdminPublications.length - 1}
-                  >
-                    {adminPublicationRow(adminPublication)}
-                  </Row>
+                  <>
+                    {adminPublication.publicationType === 'project' && (
+                      <Row
+                        key={index}
+                        id={adminPublication.id}
+                        isLastItem={
+                          index === rootLevelAdminPublications.length - 1
+                        }
+                      >
+                        <ProjectRow
+                          publication={adminPublication}
+                          actions={['manage']}
+                          showMoreActions={false}
+                        />
+                      </Row>
+                    )}
+                    {adminPublication.publicationType === 'folder' && (
+                      <NonSortableFolderRow
+                        key={index}
+                        id={adminPublication.id}
+                        isLastItem={
+                          index === rootLevelAdminPublications.length - 1
+                        }
+                        publication={adminPublication}
+                      />
+                    )}
+                  </>
                 ))
               );
             })}

--- a/front/app/containers/Admin/projects/all/Lists/ModeratorProjectList.tsx
+++ b/front/app/containers/Admin/projects/all/Lists/ModeratorProjectList.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import React, { memo, Fragment } from 'react';
 
 // utils
 import { isNilOrError } from 'utils/helperUtils';
@@ -28,54 +28,50 @@ const ModeratorProjectList = memo(() => {
     rootLevelAdminPublications &&
     rootLevelAdminPublications.length > 0
   ) {
-    if (rootLevelAdminPublications && rootLevelAdminPublications.length > 0) {
-      return (
-        <>
-          <ListHeader>
-            <HeaderTitle>
-              <FormattedMessage {...messages.existingProjects} />
-            </HeaderTitle>
-          </ListHeader>
+    return (
+      <>
+        <ListHeader>
+          <HeaderTitle>
+            <FormattedMessage {...messages.existingProjects} />
+          </HeaderTitle>
+        </ListHeader>
 
-          <List>
-            {rootLevelAdminPublications.map((adminPublication, index) => {
-              return (
-                !isProjectFoldersEnabled ||
-                (!adminPublication.relationships.parent.data && (
-                  <>
-                    {adminPublication.publicationType === 'project' && (
-                      <Row
-                        key={index}
-                        id={adminPublication.id}
-                        isLastItem={
-                          index === rootLevelAdminPublications.length - 1
-                        }
-                      >
-                        <ProjectRow
-                          publication={adminPublication}
-                          actions={['manage']}
-                          showMoreActions={false}
-                        />
-                      </Row>
-                    )}
-                    {adminPublication.publicationType === 'folder' && (
-                      <NonSortableFolderRow
-                        key={index}
-                        id={adminPublication.id}
-                        isLastItem={
-                          index === rootLevelAdminPublications.length - 1
-                        }
-                        publication={adminPublication}
-                      />
-                    )}
-                  </>
-                ))
-              );
-            })}
-          </List>
-        </>
-      );
-    }
+        <List>
+          {rootLevelAdminPublications.map((adminPublication, index) => {
+            const adminPublicationId = adminPublication.id;
+
+            return (
+              <Fragment key={adminPublicationId}>
+                {adminPublication.publicationType === 'project' && (
+                  <Row
+                    key={index}
+                    id={adminPublicationId}
+                    isLastItem={index === rootLevelAdminPublications.length - 1}
+                  >
+                    <ProjectRow
+                      publication={adminPublication}
+                      actions={['manage']}
+                      showMoreActions={false}
+                    />
+                  </Row>
+                )}
+                {isProjectFoldersEnabled &&
+                  adminPublication.publicationType === 'folder' && (
+                    <NonSortableFolderRow
+                      key={index}
+                      id={adminPublicationId}
+                      isLastItem={
+                        index === rootLevelAdminPublications.length - 1
+                      }
+                      publication={adminPublication}
+                    />
+                  )}
+              </Fragment>
+            );
+          })}
+        </List>
+      </>
+    );
   }
 
   return null;

--- a/front/app/containers/Admin/projects/all/Lists/ModeratorProjectList.tsx
+++ b/front/app/containers/Admin/projects/all/Lists/ModeratorProjectList.tsx
@@ -39,7 +39,7 @@ const ModeratorProjectList = memo(() => {
         <List>
           {rootLevelAdminPublications.map((adminPublication, index) => {
             const adminPublicationId = adminPublication.id;
-            const isLastItem = index === rootLevelAdminPublications.length - 1;
+            const isLastItem = rootLevelAdminPublications.length - 1 === index;
 
             return (
               <Fragment key={adminPublicationId}>

--- a/front/app/containers/Admin/projects/all/Lists/ModeratorProjectList.tsx
+++ b/front/app/containers/Admin/projects/all/Lists/ModeratorProjectList.tsx
@@ -39,30 +39,23 @@ const ModeratorProjectList = memo(() => {
         <List>
           {rootLevelAdminPublications.map((adminPublication, index) => {
             const adminPublicationId = adminPublication.id;
+            const isLastItem = index === rootLevelAdminPublications.length - 1;
 
             return (
               <Fragment key={adminPublicationId}>
                 {adminPublication.publicationType === 'project' && (
-                  <Row
-                    key={index}
-                    id={adminPublicationId}
-                    isLastItem={index === rootLevelAdminPublications.length - 1}
-                  >
+                  <Row id={adminPublicationId} isLastItem={isLastItem}>
                     <ProjectRow
                       publication={adminPublication}
                       actions={['manage']}
-                      showMoreActions={false}
                     />
                   </Row>
                 )}
                 {isProjectFoldersEnabled &&
                   adminPublication.publicationType === 'folder' && (
                     <NonSortableFolderRow
-                      key={index}
                       id={adminPublicationId}
-                      isLastItem={
-                        index === rootLevelAdminPublications.length - 1
-                      }
+                      isLastItem={isLastItem}
                       publication={adminPublication}
                     />
                   )}

--- a/front/app/containers/Admin/projects/all/Lists/NonSortableFolderRow.test.tsx
+++ b/front/app/containers/Admin/projects/all/Lists/NonSortableFolderRow.test.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import NonSortableFolderRow, { Props } from './NonSortableFolderRow';
+import { render, screen } from 'utils/testUtils/rtl';
+import {
+  IAdminPublicationContent,
+  IUseAdminPublicationsOutput,
+} from 'hooks/useAdminPublications';
+import { IUserData } from 'services/users';
+
+const folderId = 'folderId';
+const folderPublication: IAdminPublicationContent = {
+  id: '1',
+  publicationType: 'folder' as const,
+  publicationId: folderId,
+  attributes: {
+    ordering: 0,
+    depth: 0,
+    publication_status: 'published',
+    visible_children_count: 0,
+    publication_title_multiloc: {},
+    publication_description_multiloc: {},
+    publication_description_preview_multiloc: {},
+    publication_slug: 'folder_1',
+  },
+  relationships: {
+    children: { data: [] },
+    parent: {},
+    publication: {
+      data: {
+        id: folderId,
+        type: 'folder',
+      },
+    },
+  },
+};
+
+const projectId = 'projectId';
+const mockFolderChildAdminPublicationsList: IAdminPublicationContent[] = [
+  {
+    id: '2',
+    publicationType: 'project' as const,
+    publicationId: projectId,
+    attributes: {
+      ordering: 0,
+      depth: 0,
+      publication_status: 'published',
+      visible_children_count: 0,
+      publication_title_multiloc: {},
+      publication_description_multiloc: {},
+      publication_description_preview_multiloc: {},
+      publication_slug: 'project_1',
+    },
+    relationships: {
+      children: { data: [] },
+      parent: {
+        data: {
+          type: 'folder',
+          id: folderPublication.id,
+        },
+      },
+      publication: {
+        data: {
+          id: projectId,
+          type: 'project',
+        },
+      },
+    },
+  },
+];
+const mockFolderChildAdminPublications: IUseAdminPublicationsOutput = {
+  hasMore: false,
+  loadingInitial: false,
+  loadingMore: false,
+  list: mockFolderChildAdminPublicationsList,
+  onLoadMore: jest.fn,
+  onChangeTopics: jest.fn,
+  onChangeSearch: jest.fn,
+  onChangeAreas: jest.fn,
+  onChangePublicationStatus: jest.fn,
+};
+
+// Needed to render moreActionsMenu
+const mockUserData: IUserData = {
+  id: 'userId',
+  type: 'user',
+  attributes: {
+    first_name: 'Stewie',
+    last_name: 'McKenzie',
+    locale: 'en',
+    slug: 'stewie-mckenzie',
+    highest_role: 'admin',
+    bio_multiloc: {},
+    roles: [{ type: 'admin' }],
+    registration_completed_at: '',
+    created_at: '',
+    updated_at: '',
+    unread_notifications: 0,
+    invite_status: null,
+    confirmation_required: false,
+  },
+};
+jest.mock('hooks/useAuthUser', () => {
+  return () => mockUserData;
+});
+
+// Needed to render folder with project inside
+jest.mock('hooks/useAdminPublications', () => {
+  return () => mockFolderChildAdminPublications;
+});
+
+const props: Props = {
+  publication: folderPublication,
+  isLastItem: true,
+  id: 'SortableFolderRowId',
+};
+
+describe('NonSortableFolderRow', () => {
+  it('renders the project row inside', () => {
+    render(<NonSortableFolderRow {...props} />);
+
+    const projectRows = screen.getAllByTestId('projectRow');
+    expect(projectRows.length).toEqual(1);
+  });
+});

--- a/front/app/containers/Admin/projects/all/Lists/NonSortableFolderRow.test.tsx
+++ b/front/app/containers/Admin/projects/all/Lists/NonSortableFolderRow.test.tsx
@@ -79,7 +79,6 @@ const mockFolderChildAdminPublications: IUseAdminPublicationsOutput = {
   onChangePublicationStatus: jest.fn,
 };
 
-// Needed to render moreActionsMenu
 const mockUserData: IUserData = {
   id: 'userId',
   type: 'user',

--- a/front/app/containers/Admin/projects/all/Lists/NonSortableFolderRow.tsx
+++ b/front/app/containers/Admin/projects/all/Lists/NonSortableFolderRow.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import { isNilOrError } from 'utils/helperUtils';
+
+// style
+import useAdminPublications, {
+  IAdminPublicationContent,
+} from 'hooks/useAdminPublications';
+import ProjectFolderRow from '../../projectFolders/components/ProjectFolderRow';
+import { PublicationStatus } from 'services/projects';
+import { Row } from 'components/admin/ResourceList';
+import useAuthUser from 'hooks/useAuthUser';
+import FolderChildProjects from './FolderChildProjects';
+interface Props {
+  key: number;
+  id: string;
+  isLastItem: boolean;
+  publication: IAdminPublicationContent;
+}
+
+const publicationStatuses: PublicationStatus[] = [
+  'draft',
+  'published',
+  'archived',
+];
+
+const SortableFolderRow = ({ key, id, isLastItem, publication }: Props) => {
+  const authUser = useAuthUser();
+  const [folderOpen, setFolderOpen] = useState(true);
+
+  const toggleFolder = () => {
+    setFolderOpen((folderOpen) => !folderOpen);
+  };
+
+  const { list: folderChildAdminPublications } = useAdminPublications({
+    childrenOfId: publication.relationships.publication.data.id,
+    publicationStatusFilter: publicationStatuses,
+  });
+  const hasProjects =
+    !isNilOrError(folderChildAdminPublications) &&
+    folderChildAdminPublications.length > 0;
+
+  if (!isNilOrError(authUser)) {
+    return (
+      <>
+        <Row key={key} id={id} isLastItem={isLastItem}>
+          <ProjectFolderRow
+            publication={publication}
+            toggleFolder={toggleFolder}
+            folderOpen={folderOpen}
+            hasProjects={hasProjects}
+          />
+        </Row>
+        {hasProjects && folderOpen && (
+          <FolderChildProjects
+            folderChildAdminPublications={folderChildAdminPublications}
+            authUser={authUser}
+          />
+        )}
+      </>
+    );
+  }
+
+  return null;
+};
+
+export default SortableFolderRow;

--- a/front/app/containers/Admin/projects/all/Lists/NonSortableFolderRow.tsx
+++ b/front/app/containers/Admin/projects/all/Lists/NonSortableFolderRow.tsx
@@ -10,7 +10,8 @@ import { PublicationStatus } from 'services/projects';
 import { Row } from 'components/admin/ResourceList';
 import useAuthUser from 'hooks/useAuthUser';
 import FolderChildProjects from './FolderChildProjects';
-interface Props {
+
+export interface Props {
   id: string;
   isLastItem: boolean;
   publication: IAdminPublicationContent;

--- a/front/app/containers/Admin/projects/all/Lists/NonSortableFolderRow.tsx
+++ b/front/app/containers/Admin/projects/all/Lists/NonSortableFolderRow.tsx
@@ -24,16 +24,16 @@ const publicationStatuses: PublicationStatus[] = [
 
 const SortableFolderRow = ({ id, isLastItem, publication }: Props) => {
   const authUser = useAuthUser();
+  const { list: folderChildAdminPublications } = useAdminPublications({
+    childrenOfId: publication.relationships.publication.data.id,
+    publicationStatusFilter: publicationStatuses,
+  });
+  const [folderOpen, setFolderOpen] = useState(true);
 
   if (isNilOrError(authUser)) {
     return null;
   }
 
-  const [folderOpen, setFolderOpen] = useState(true);
-  const { list: folderChildAdminPublications } = useAdminPublications({
-    childrenOfId: publication.relationships.publication.data.id,
-    publicationStatusFilter: publicationStatuses,
-  });
   const hasProjects =
     !isNilOrError(folderChildAdminPublications) &&
     folderChildAdminPublications.length > 0;

--- a/front/app/containers/Admin/projects/all/Lists/NonSortableFolderRow.tsx
+++ b/front/app/containers/Admin/projects/all/Lists/NonSortableFolderRow.tsx
@@ -56,7 +56,6 @@ const SortableFolderRow = ({ id, isLastItem, publication }: Props) => {
       {hasProjects && folderOpen && (
         <FolderChildProjects
           folderChildAdminPublications={folderChildAdminPublications}
-          authUser={authUser}
         />
       )}
     </>

--- a/front/app/containers/Admin/projects/all/Lists/NonSortableFolderRow.tsx
+++ b/front/app/containers/Admin/projects/all/Lists/NonSortableFolderRow.tsx
@@ -11,7 +11,6 @@ import { Row } from 'components/admin/ResourceList';
 import useAuthUser from 'hooks/useAuthUser';
 import FolderChildProjects from './FolderChildProjects';
 interface Props {
-  key: number;
   id: string;
   isLastItem: boolean;
   publication: IAdminPublicationContent;
@@ -23,14 +22,14 @@ const publicationStatuses: PublicationStatus[] = [
   'archived',
 ];
 
-const SortableFolderRow = ({ key, id, isLastItem, publication }: Props) => {
+const SortableFolderRow = ({ id, isLastItem, publication }: Props) => {
   const authUser = useAuthUser();
+
+  if (isNilOrError(authUser)) {
+    return null;
+  }
+
   const [folderOpen, setFolderOpen] = useState(true);
-
-  const toggleFolder = () => {
-    setFolderOpen((folderOpen) => !folderOpen);
-  };
-
   const { list: folderChildAdminPublications } = useAdminPublications({
     childrenOfId: publication.relationships.publication.data.id,
     publicationStatusFilter: publicationStatuses,
@@ -39,28 +38,28 @@ const SortableFolderRow = ({ key, id, isLastItem, publication }: Props) => {
     !isNilOrError(folderChildAdminPublications) &&
     folderChildAdminPublications.length > 0;
 
-  if (!isNilOrError(authUser)) {
-    return (
-      <>
-        <Row key={key} id={id} isLastItem={isLastItem}>
-          <ProjectFolderRow
-            publication={publication}
-            toggleFolder={toggleFolder}
-            folderOpen={folderOpen}
-            hasProjects={hasProjects}
-          />
-        </Row>
-        {hasProjects && folderOpen && (
-          <FolderChildProjects
-            folderChildAdminPublications={folderChildAdminPublications}
-            authUser={authUser}
-          />
-        )}
-      </>
-    );
-  }
+  const toggleFolder = () => {
+    setFolderOpen((folderOpen) => !folderOpen);
+  };
 
-  return null;
+  return (
+    <>
+      <Row id={id} isLastItem={isLastItem}>
+        <ProjectFolderRow
+          publication={publication}
+          toggleFolder={toggleFolder}
+          isFolderOpen={folderOpen}
+          hasProjects={hasProjects}
+        />
+      </Row>
+      {hasProjects && folderOpen && (
+        <FolderChildProjects
+          folderChildAdminPublications={folderChildAdminPublications}
+          authUser={authUser}
+        />
+      )}
+    </>
+  );
 };
 
 export default SortableFolderRow;

--- a/front/app/containers/Admin/projects/all/Lists/SortableFolderRow.tsx
+++ b/front/app/containers/Admin/projects/all/Lists/SortableFolderRow.tsx
@@ -1,0 +1,90 @@
+import React, { useState } from 'react';
+import { isNilOrError } from 'utils/helperUtils';
+
+// style
+import styled from 'styled-components';
+import { SortableRow } from 'components/admin/ResourceList';
+import useAdminPublications, {
+  IAdminPublicationContent,
+} from 'hooks/useAdminPublications';
+import ProjectFolderRow from '../../projectFolders/components/ProjectFolderRow';
+import { PublicationStatus } from 'services/projects';
+import useAuthUser from 'hooks/useAuthUser';
+import FolderChildProjects from './FolderChildProjects';
+
+const StyledSortableRow = styled(SortableRow)`
+  & .sortablerow-draghandle {
+    align-self: flex-start;
+  }
+`;
+interface Props {
+  key: string;
+  id: string;
+  index: number;
+  moveRow: (fromIndex: number, toIndex: number) => void;
+  dropRow: (itemId: string, toIndex: number) => void;
+  isLastItem: boolean;
+  publication: IAdminPublicationContent;
+}
+
+const publicationStatuses: PublicationStatus[] = [
+  'draft',
+  'published',
+  'archived',
+];
+
+const SortableFolderRow = ({
+  key,
+  id,
+  index,
+  moveRow,
+  dropRow,
+  publication,
+}: Props) => {
+  const authUser = useAuthUser();
+
+  const [folderOpen, setFolderOpen] = useState(true);
+
+  const toggleFolder = () => {
+    setFolderOpen((folderOpen) => !folderOpen);
+  };
+
+  const { list: folderChildAdminPublications } = useAdminPublications({
+    childrenOfId: publication.relationships.publication.data.id,
+    publicationStatusFilter: publicationStatuses,
+  });
+  const hasProjects =
+    !isNilOrError(folderChildAdminPublications) &&
+    folderChildAdminPublications.length > 0;
+
+  if (!isNilOrError(authUser)) {
+    return (
+      <>
+        <StyledSortableRow
+          key={key}
+          id={id}
+          index={index}
+          moveRow={moveRow}
+          dropRow={dropRow}
+        >
+          <ProjectFolderRow
+            publication={publication}
+            toggleFolder={toggleFolder}
+            folderOpen={folderOpen}
+            hasProjects={hasProjects}
+          />
+        </StyledSortableRow>
+        {hasProjects && folderOpen && (
+          <FolderChildProjects
+            folderChildAdminPublications={folderChildAdminPublications}
+            authUser={authUser}
+          />
+        )}
+      </>
+    );
+  }
+
+  return null;
+};
+
+export default SortableFolderRow;

--- a/front/app/containers/Admin/projects/all/Lists/SortableFolderRow.tsx
+++ b/front/app/containers/Admin/projects/all/Lists/SortableFolderRow.tsx
@@ -77,7 +77,6 @@ const SortableFolderRow = ({
       {hasProjects && folderOpen && (
         <FolderChildProjects
           folderChildAdminPublications={folderChildAdminPublications}
-          authUser={authUser}
         />
       )}
     </>

--- a/front/app/containers/Admin/projects/all/Lists/SortableFolderRow.tsx
+++ b/front/app/containers/Admin/projects/all/Lists/SortableFolderRow.tsx
@@ -40,48 +40,47 @@ const SortableFolderRow = ({
   publication,
 }: Props) => {
   const authUser = useAuthUser();
-
+  const { list: folderChildAdminPublications } = useAdminPublications({
+    childrenOfId: publication.relationships.publication.data.id,
+    publicationStatusFilter: publicationStatuses,
+  });
   const [folderOpen, setFolderOpen] = useState(true);
+
+  if (isNilOrError(authUser)) {
+    return null;
+  }
 
   const toggleFolder = () => {
     setFolderOpen((folderOpen) => !folderOpen);
   };
 
-  const { list: folderChildAdminPublications } = useAdminPublications({
-    childrenOfId: publication.relationships.publication.data.id,
-    publicationStatusFilter: publicationStatuses,
-  });
   const hasProjects =
     !isNilOrError(folderChildAdminPublications) &&
     folderChildAdminPublications.length > 0;
 
-  if (!isNilOrError(authUser)) {
-    return (
-      <>
-        <StyledSortableRow
-          id={id}
-          index={index}
-          moveRow={moveRow}
-          dropRow={dropRow}
-        >
-          <ProjectFolderRow
-            publication={publication}
-            toggleFolder={toggleFolder}
-            isFolderOpen={folderOpen}
-            hasProjects={hasProjects}
-          />
-        </StyledSortableRow>
-        {hasProjects && folderOpen && (
-          <FolderChildProjects
-            folderChildAdminPublications={folderChildAdminPublications}
-            authUser={authUser}
-          />
-        )}
-      </>
-    );
-  }
-
-  return null;
+  return (
+    <>
+      <StyledSortableRow
+        id={id}
+        index={index}
+        moveRow={moveRow}
+        dropRow={dropRow}
+      >
+        <ProjectFolderRow
+          publication={publication}
+          toggleFolder={toggleFolder}
+          isFolderOpen={folderOpen}
+          hasProjects={hasProjects}
+        />
+      </StyledSortableRow>
+      {hasProjects && folderOpen && (
+        <FolderChildProjects
+          folderChildAdminPublications={folderChildAdminPublications}
+          authUser={authUser}
+        />
+      )}
+    </>
+  );
 };
 
 export default SortableFolderRow;

--- a/front/app/containers/Admin/projects/all/Lists/SortableFolderRow.tsx
+++ b/front/app/containers/Admin/projects/all/Lists/SortableFolderRow.tsx
@@ -17,6 +17,7 @@ const StyledSortableRow = styled(SortableRow)`
     align-self: flex-start;
   }
 `;
+
 interface Props {
   id: string;
   index: number;

--- a/front/app/containers/Admin/projects/all/Lists/SortableFolderRow.tsx
+++ b/front/app/containers/Admin/projects/all/Lists/SortableFolderRow.tsx
@@ -67,7 +67,7 @@ const SortableFolderRow = ({
           <ProjectFolderRow
             publication={publication}
             toggleFolder={toggleFolder}
-            folderOpen={folderOpen}
+            isFolderOpen={folderOpen}
             hasProjects={hasProjects}
           />
         </StyledSortableRow>

--- a/front/app/containers/Admin/projects/all/Lists/SortableFolderRow.tsx
+++ b/front/app/containers/Admin/projects/all/Lists/SortableFolderRow.tsx
@@ -18,7 +18,6 @@ const StyledSortableRow = styled(SortableRow)`
   }
 `;
 interface Props {
-  key: string;
   id: string;
   index: number;
   moveRow: (fromIndex: number, toIndex: number) => void;
@@ -34,7 +33,6 @@ const publicationStatuses: PublicationStatus[] = [
 ];
 
 const SortableFolderRow = ({
-  key,
   id,
   index,
   moveRow,
@@ -61,7 +59,6 @@ const SortableFolderRow = ({
     return (
       <>
         <StyledSortableRow
-          key={key}
           id={id}
           index={index}
           moveRow={moveRow}

--- a/front/app/containers/Admin/projects/components/ProjectRow/ManageButton.tsx
+++ b/front/app/containers/Admin/projects/components/ProjectRow/ManageButton.tsx
@@ -25,6 +25,7 @@ const ManageButton = ({ isDisabled, publicationId }: Props) => {
       type="button"
       key="manage"
       disabled={isDisabled}
+      data-testid="project-row-edit-button"
     >
       <FormattedMessage {...messages.editButtonLabel} />
     </RowButton>

--- a/front/app/containers/Admin/projects/components/ProjectRow/ProjectMoreActionsMenu.test.tsx
+++ b/front/app/containers/Admin/projects/components/ProjectRow/ProjectMoreActionsMenu.test.tsx
@@ -33,6 +33,16 @@ jest.mock('hooks/useAuthUser', () => {
   return () => mockUserData;
 });
 
+jest.mock('hooks/useProject', () => {
+  return jest.fn(() => ({
+    id: 'id',
+    type: 'project',
+    attributes: {
+      folder_id: 'folderId',
+    },
+  }));
+});
+
 describe('ProjectMoreActionsMenu', () => {
   describe('When user is an admin', () => {
     it('Has the buttons to copy and delete projects', async () => {

--- a/front/app/containers/Admin/projects/components/ProjectRow/ProjectMoreActionsMenu.test.tsx
+++ b/front/app/containers/Admin/projects/components/ProjectRow/ProjectMoreActionsMenu.test.tsx
@@ -66,55 +66,89 @@ describe('ProjectMoreActionsMenu', () => {
     });
   });
 
-  describe('When user is a folder moderator of folder that contains the project', () => {
-    it('Has the copy project button and not the delete project button', async () => {
-      mockUserData.attributes.roles = [
-        {
-          type: 'project_folder_moderator',
-          project_folder_id: mockProject.attributes.folder_id,
-        },
-      ];
-      render(<ProjectMoreActionsMenu {...defaultProps} />);
-      const user = userEvent.setup();
+  describe('When user is a folder moderator', () => {
+    describe('project that is inside folder that user moderates', () => {
+      it('Has a button to copy but not delete a project', async () => {
+        mockUserData.attributes.roles = [
+          {
+            type: 'project_folder_moderator',
+            project_folder_id: mockProject.attributes.folder_id,
+          },
+        ];
+        render(<ProjectMoreActionsMenu {...defaultProps} />);
+        const user = userEvent.setup();
 
-      const threeDotsButton = screen.getByTestId('moreOptionsButton');
-      await user.click(threeDotsButton);
+        const threeDotsButton = screen.getByTestId('moreOptionsButton');
+        await user.click(threeDotsButton);
 
-      const copyProjectButton = await screen.findByRole('button', {
-        name: 'Copy project',
+        const copyProjectButton = await screen.findByRole('button', {
+          name: 'Copy project',
+        });
+        const deleteProjectButton = screen.queryByRole('button', {
+          name: 'Delete project',
+        });
+
+        expect(copyProjectButton).toBeInTheDocument();
+        expect(deleteProjectButton).not.toBeInTheDocument();
       });
-      const deleteProjectButton = screen.queryByRole('button', {
-        name: 'Delete project',
-      });
+    });
 
-      expect(copyProjectButton).toBeInTheDocument();
-      expect(deleteProjectButton).not.toBeInTheDocument();
+    describe('project that is not inside folder that user moderates', () => {
+      it('Has no button to copy nor delete the project', async () => {
+        mockUserData.attributes.roles = [
+          {
+            type: 'project_folder_moderator',
+            project_folder_id: 'aDifferentFolderId',
+          },
+        ];
+        render(<ProjectMoreActionsMenu {...defaultProps} />);
+        const threeDotsButton = screen.queryByTestId('moreOptionsButton');
+
+        expect(threeDotsButton).not.toBeInTheDocument();
+      });
     });
   });
 
   describe('When user is a project moderator', () => {
-    it('Has the copy project button and not the delete project button', async () => {
-      mockUserData.attributes.roles = [
-        {
-          type: 'project_moderator',
-          project_id: mockProject.id,
-        },
-      ];
-      render(<ProjectMoreActionsMenu {...defaultProps} />);
-      const user = userEvent.setup();
+    describe('project that user moderates', () => {
+      it('Has a button to copy but not delete a project', async () => {
+        mockUserData.attributes.roles = [
+          {
+            type: 'project_moderator',
+            project_id: mockProject.id,
+          },
+        ];
+        render(<ProjectMoreActionsMenu {...defaultProps} />);
+        const user = userEvent.setup();
 
-      const threeDotsButton = screen.getByTestId('moreOptionsButton');
-      await user.click(threeDotsButton);
+        const threeDotsButton = screen.getByTestId('moreOptionsButton');
+        await user.click(threeDotsButton);
 
-      const copyProjectButton = await screen.findByRole('button', {
-        name: 'Copy project',
+        const copyProjectButton = await screen.findByRole('button', {
+          name: 'Copy project',
+        });
+        const deleteProjectButton = screen.queryByRole('button', {
+          name: 'Delete project',
+        });
+
+        expect(copyProjectButton).toBeInTheDocument();
+        expect(deleteProjectButton).not.toBeInTheDocument();
       });
-      const deleteProjectButton = screen.queryByRole('button', {
-        name: 'Delete project',
-      });
+    });
 
-      expect(copyProjectButton).toBeInTheDocument();
-      expect(deleteProjectButton).not.toBeInTheDocument();
+    describe('project that user does not moderate', () => {
+      it('Has no button to copy nor delete the project', async () => {
+        mockUserData.attributes.roles = [
+          {
+            type: 'project_moderator',
+            project_id: 'aDifferentProjectId',
+          },
+        ];
+        render(<ProjectMoreActionsMenu {...defaultProps} />);
+        const threeDotsButton = screen.queryByTestId('moreOptionsButton');
+
+        expect(threeDotsButton).not.toBeInTheDocument();
+      });
     });
   });
 });

--- a/front/app/containers/Admin/projects/components/ProjectRow/ProjectMoreActionsMenu.test.tsx
+++ b/front/app/containers/Admin/projects/components/ProjectRow/ProjectMoreActionsMenu.test.tsx
@@ -28,9 +28,24 @@ const mockUserData: IUserData = {
     confirmation_required: false,
   },
 };
+
 jest.mock('hooks/useAuthUser', () => {
   return () => mockUserData;
 });
+
+const projectId = 'projectId';
+const folderId = 'folderId';
+const mockProjectData = {
+  id: projectId,
+  type: 'project',
+  attributes: {
+    process_type: 'continuous',
+    title_multiloc: { en: 'Test Project' },
+    slug: 'test',
+    folderId: folderId,
+  },
+};
+jest.mock('hooks/useProject', () => jest.fn(() => mockProjectData));
 
 describe('ProjectMoreActionsMenu', () => {
   describe('When user is an admin', () => {

--- a/front/app/containers/Admin/projects/components/ProjectRow/ProjectMoreActionsMenu.test.tsx
+++ b/front/app/containers/Admin/projects/components/ProjectRow/ProjectMoreActionsMenu.test.tsx
@@ -55,7 +55,7 @@ describe('ProjectMoreActionsMenu', () => {
   });
 
   describe('When user is not an admin', () => {
-    it('Has the button to copy but not the delete projects', async () => {
+    it('Has the copy project button and not the delete project button', async () => {
       mockUserData.attributes.roles = [
         {
           type: 'project_folder_moderator',

--- a/front/app/containers/Admin/projects/components/ProjectRow/ProjectMoreActionsMenu.tsx
+++ b/front/app/containers/Admin/projects/components/ProjectRow/ProjectMoreActionsMenu.tsx
@@ -7,6 +7,9 @@ import { useIntl } from 'utils/cl-intl';
 import { isAdmin } from 'services/permissions/roles';
 import useAuthUser from 'hooks/useAuthUser';
 import { isNilOrError } from 'utils/helperUtils';
+import { canModerateProject } from 'services/permissions/rules/projectPermissions';
+import useProject from 'hooks/useProject';
+import { userModeratesFolder } from 'services/permissions/rules/projectFolderPermissions';
 
 export interface Props {
   projectId: string;
@@ -15,6 +18,8 @@ export interface Props {
 
 const ProjectMoreActionsMenu = ({ projectId, setError }: Props) => {
   const { formatMessage } = useIntl();
+  const project = useProject({ projectId });
+  const folderId = project?.attributes.folder_id;
   const authUser = useAuthUser();
   const [isCopying, setIsCopying] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -23,7 +28,14 @@ const ProjectMoreActionsMenu = ({ projectId, setError }: Props) => {
     return null;
   }
 
-  const isAdminUser = isAdmin({ data: authUser });
+  const userCanDeleteProject = isAdmin({ data: authUser });
+  const userCanModerateProject =
+    // This means project is in a folder
+    (typeof folderId === 'string' && userModeratesFolder(authUser, folderId)) ||
+    canModerateProject(projectId, {
+      data: authUser,
+    });
+
   const handleCallbackError = async (
     callback: () => Promise<any>,
     error: string
@@ -35,50 +47,69 @@ const ProjectMoreActionsMenu = ({ projectId, setError }: Props) => {
       setError(error);
     }
   };
-  const actions: IAction[] = [
-    {
-      handler: async () => {
-        setIsCopying(true);
-        await handleCallbackError(
-          () => copyProject(projectId),
-          formatMessage(messages.copyProjectError)
-        );
-        setIsCopying(false);
-      },
-      label: formatMessage(messages.copyProjectButton),
-      icon: 'copy' as const,
-      isLoading: isCopying,
-    },
-  ];
 
-  if (isAdminUser) {
-    actions.push({
-      handler: async () => {
-        if (window.confirm(formatMessage(messages.deleteProjectConfirmation))) {
-          setIsDeleting(true);
+  const createActions = () => {
+    const actions: IAction[] = [];
+
+    if (userCanModerateProject) {
+      actions.push({
+        handler: async () => {
+          setIsCopying(true);
           await handleCallbackError(
-            () => deleteProject(projectId),
-            formatMessage(messages.deleteProjectError)
+            () => copyProject(projectId),
+            formatMessage(messages.copyProjectError)
           );
-          setIsDeleting(false);
-        }
-      },
-      label: formatMessage(messages.deleteProjectButtonFull),
-      icon: 'delete' as const,
-      isLoading: isDeleting,
-    });
+          setIsCopying(false);
+        },
+        label: formatMessage(messages.copyProjectButton),
+        icon: 'copy' as const,
+        isLoading: isCopying,
+      });
+    }
+
+    if (userCanDeleteProject) {
+      actions.push({
+        handler: async () => {
+          if (
+            window.confirm(formatMessage(messages.deleteProjectConfirmation))
+          ) {
+            setIsDeleting(true);
+            await handleCallbackError(
+              () => deleteProject(projectId),
+              formatMessage(messages.deleteProjectError)
+            );
+            setIsDeleting(false);
+          }
+        },
+        label: formatMessage(messages.deleteProjectButtonFull),
+        icon: 'delete' as const,
+        isLoading: isDeleting,
+      });
+    }
+
+    if (actions.length > 0) {
+      return actions;
+    }
+
+    return null;
+  };
+
+  const actions = createActions();
+
+  if (actions) {
+    return (
+      <Box
+        display="flex"
+        alignItems="center"
+        ml="1rem"
+        data-testid="moreProjectActionsMenu"
+      >
+        <MoreActionsMenu showLabel={false} actions={actions} />
+      </Box>
+    );
   }
 
-  return (
-    <Box
-      display="flex"
-      alignItems="center"
-      ml="1rem"
-      data-testid="moreProjectActionsMenu"
-    >
-      <MoreActionsMenu showLabel={false} actions={actions} />
-    </Box>
-  );
+  return null;
 };
 
 export default ProjectMoreActionsMenu;

--- a/front/app/containers/Admin/projects/components/ProjectRow/ProjectMoreActionsMenu.tsx
+++ b/front/app/containers/Admin/projects/components/ProjectRow/ProjectMoreActionsMenu.tsx
@@ -7,23 +7,23 @@ import { useIntl } from 'utils/cl-intl';
 import { isAdmin } from 'services/permissions/roles';
 import useAuthUser from 'hooks/useAuthUser';
 import { isNilOrError } from 'utils/helperUtils';
-import { canModerateProject } from 'services/permissions/rules/projectPermissions';
-import { userModeratesFolder } from 'services/permissions/rules/projectFolderPermissions';
-import useProject from 'hooks/useProject';
 
 export interface Props {
   projectId: string;
   setError: (error: string | null) => void;
+  userCanModerateProject: boolean;
 }
 
-const ProjectMoreActionsMenu = ({ projectId, setError }: Props) => {
+const ProjectMoreActionsMenu = ({
+  projectId,
+  setError,
+  userCanModerateProject,
+}: Props) => {
   const { formatMessage } = useIntl();
-  const project = useProject({ projectId });
   const authUser = useAuthUser();
   const [isCopying, setIsCopying] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
-  if (isNilOrError(authUser) || isNilOrError(project)) return null;
-  const folderId = project.attributes.folder_id;
+  if (isNilOrError(authUser)) return null;
 
   const handleCallbackError = async (
     callback: () => Promise<any>,
@@ -68,13 +68,9 @@ const ProjectMoreActionsMenu = ({ projectId, setError }: Props) => {
   };
 
   const actions: IAction[] = [];
-  const canModerate =
-    (typeof folderId === 'string' && userModeratesFolder(authUser, folderId)) ||
-    canModerateProject(projectId, { data: authUser });
-
   const isAdminUser = isAdmin({ data: authUser });
 
-  if (isAdminUser || canModerate) {
+  if (isAdminUser || userCanModerateProject) {
     actions.push(copyAction);
   }
 

--- a/front/app/containers/Admin/projects/components/ProjectRow/ProjectMoreActionsMenu.tsx
+++ b/front/app/containers/Admin/projects/components/ProjectRow/ProjectMoreActionsMenu.tsx
@@ -16,15 +16,14 @@ export interface Props {
 const ProjectMoreActionsMenu = ({ projectId, setError }: Props) => {
   const { formatMessage } = useIntl();
   const authUser = useAuthUser();
+  const [isCopying, setIsCopying] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   if (isNilOrError(authUser)) {
     return null;
   }
 
   const isAdminUser = isAdmin({ data: authUser });
-  const [isCopying, setIsCopying] = useState(false);
-  const [isDeleting, setIsDeleting] = useState(false);
-
   const handleCallbackError = async (
     callback: () => Promise<any>,
     error: string
@@ -70,20 +69,16 @@ const ProjectMoreActionsMenu = ({ projectId, setError }: Props) => {
     });
   }
 
-  if (actions.length > 0) {
-    return (
-      <Box
-        display="flex"
-        alignItems="center"
-        ml="1rem"
-        data-testid="moreProjectActionsMenu"
-      >
-        <MoreActionsMenu showLabel={false} actions={actions} />
-      </Box>
-    );
-  }
-
-  return null;
+  return (
+    <Box
+      display="flex"
+      alignItems="center"
+      ml="1rem"
+      data-testid="moreProjectActionsMenu"
+    >
+      <MoreActionsMenu showLabel={false} actions={actions} />
+    </Box>
+  );
 };
 
 export default ProjectMoreActionsMenu;

--- a/front/app/containers/Admin/projects/components/ProjectRow/ProjectMoreActionsMenu.tsx
+++ b/front/app/containers/Admin/projects/components/ProjectRow/ProjectMoreActionsMenu.tsx
@@ -8,6 +8,8 @@ import { isAdmin } from 'services/permissions/roles';
 import useAuthUser from 'hooks/useAuthUser';
 import { isNilOrError } from 'utils/helperUtils';
 import { canModerateProject } from 'services/permissions/rules/projectPermissions';
+import { userModeratesFolder } from 'services/permissions/rules/projectFolderPermissions';
+import useProject from 'hooks/useProject';
 
 export interface Props {
   projectId: string;
@@ -16,10 +18,12 @@ export interface Props {
 
 const ProjectMoreActionsMenu = ({ projectId, setError }: Props) => {
   const { formatMessage } = useIntl();
+  const project = useProject({ projectId });
   const authUser = useAuthUser();
   const [isCopying, setIsCopying] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
-  if (isNilOrError(authUser)) return null;
+  if (isNilOrError(authUser) || isNilOrError(project)) return null;
+  const folderId = project.attributes.folder_id;
 
   const handleCallbackError = async (
     callback: () => Promise<any>,
@@ -64,7 +68,10 @@ const ProjectMoreActionsMenu = ({ projectId, setError }: Props) => {
   };
 
   const actions: IAction[] = [];
-  const canModerate = canModerateProject(projectId, { data: authUser });
+  const canModerate =
+    (typeof folderId === 'string' && userModeratesFolder(authUser, folderId)) ||
+    canModerateProject(projectId, { data: authUser });
+
   const isAdminUser = isAdmin({ data: authUser });
 
   if (isAdminUser || canModerate) {
@@ -75,16 +82,20 @@ const ProjectMoreActionsMenu = ({ projectId, setError }: Props) => {
     actions.push(deleteAction);
   }
 
-  return (
-    <Box
-      display="flex"
-      alignItems="center"
-      ml="1rem"
-      data-testid="moreProjectActionsMenu"
-    >
-      <MoreActionsMenu showLabel={false} actions={actions} />
-    </Box>
-  );
+  if (actions.length > 0) {
+    return (
+      <Box
+        display="flex"
+        alignItems="center"
+        ml="1rem"
+        data-testid="moreProjectActionsMenu"
+      >
+        <MoreActionsMenu showLabel={false} actions={actions} />
+      </Box>
+    );
+  }
+
+  return null;
 };
 
 export default ProjectMoreActionsMenu;

--- a/front/app/containers/Admin/projects/components/ProjectRow/ProjectRow.test.tsx
+++ b/front/app/containers/Admin/projects/components/ProjectRow/ProjectRow.test.tsx
@@ -50,14 +50,14 @@ describe('ProjectRow', () => {
   });
 
   it('shows the MoreActionsMenu when it is enabled', () => {
-    render(<ProjectRow {...props} showMoreActions={true} />);
+    render(<ProjectRow {...props} />);
 
     const moreActionsMenu = screen.getByTestId('moreProjectActionsMenu');
     expect(moreActionsMenu).toBeInTheDocument();
   });
 
   it('does not show the MoreActionsMenu when it is not enabled', () => {
-    render(<ProjectRow {...props} />);
+    render(<ProjectRow {...props} hideMoreActions />);
 
     const moreActionsMenu = screen.queryByTestId('moreProjectActionsMenu');
     expect(moreActionsMenu).toBeNull();

--- a/front/app/containers/Admin/projects/components/ProjectRow/ProjectRow.test.tsx
+++ b/front/app/containers/Admin/projects/components/ProjectRow/ProjectRow.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ProjectRow, { Props } from '.';
 import { render, screen } from 'utils/testUtils/rtl';
 import { IAdminPublicationContent } from 'hooks/useAdminPublications';
+import { IUserData } from 'services/users';
 
 const publication: IAdminPublicationContent = {
   id: '1',
@@ -30,10 +31,29 @@ const publication: IAdminPublicationContent = {
 };
 
 // Needed to render moreActionsMenu
+const mockUserData: IUserData = {
+  id: 'userId',
+  type: 'user',
+  attributes: {
+    first_name: 'Stewie',
+    last_name: 'McKenzie',
+    locale: 'en',
+    slug: 'stewie-mckenzie',
+    highest_role: 'admin',
+    bio_multiloc: {},
+    roles: [{ type: 'admin' }],
+    registration_completed_at: '',
+    created_at: '',
+    updated_at: '',
+    unread_notifications: 0,
+    invite_status: null,
+    confirmation_required: false,
+  },
+};
+
+// Needed to render moreActionsMenu
 jest.mock('hooks/useAuthUser', () => {
-  return () => ({
-    id: 'userId',
-  });
+  return () => mockUserData;
 });
 
 const props: Props = {
@@ -62,4 +82,6 @@ describe('ProjectRow', () => {
     const moreActionsMenu = screen.queryByTestId('moreProjectActionsMenu');
     expect(moreActionsMenu).toBeNull();
   });
+
+  // TODO: Could use extra tests for different user roles
 });

--- a/front/app/containers/Admin/projects/components/ProjectRow/ProjectRow.test.tsx
+++ b/front/app/containers/Admin/projects/components/ProjectRow/ProjectRow.test.tsx
@@ -65,7 +65,7 @@ describe('ProjectRow', () => {
   it('shows the edit button', () => {
     render(<ProjectRow {...props} />);
 
-    const editButton = screen.getByRole('button', { name: 'Edit' });
+    const editButton = screen.getByTestId('project-row-edit-button');
     expect(editButton).toBeInTheDocument();
   });
 

--- a/front/app/containers/Admin/projects/components/ProjectRow/index.tsx
+++ b/front/app/containers/Admin/projects/components/ProjectRow/index.tsx
@@ -134,7 +134,7 @@ const ProjectRow = ({
               );
             }
           })}
-          {!hideMoreActions && userCanModerateProject && (
+          {!hideMoreActions && (
             <ProjectMoreActionsMenu projectId={projectId} setError={setError} />
           )}
         </ActionsRowContainer>

--- a/front/app/containers/Admin/projects/components/ProjectRow/index.tsx
+++ b/front/app/containers/Admin/projects/components/ProjectRow/index.tsx
@@ -20,6 +20,7 @@ import ManageButton from './ManageButton';
 // resources
 import { canModerateProject } from 'services/permissions/rules/projectPermissions';
 import useAuthUser from 'hooks/useAuthUser';
+import useProject from 'hooks/useProject';
 import { userModeratesFolder } from 'services/permissions/rules/projectFolderPermissions';
 
 // types
@@ -63,14 +64,14 @@ const ProjectRow = ({
 }: Props) => {
   const [error, setError] = useState<string | null>(null);
   const authUser = useAuthUser();
+  const projectId = publication.publicationId;
+  const project = useProject({ projectId });
+  const publicationStatus = publication.attributes.publication_status;
+  const folderId = project?.attributes.folder_id;
 
   if (isNilOrError(authUser)) {
     return null;
   }
-
-  const projectId = publication.publicationId;
-  const publicationStatus = publication.attributes.publication_status;
-  const folderId = publication.relationships.parent.data?.id;
 
   const userCanModerateProject =
     // This means project is in a folder
@@ -135,7 +136,11 @@ const ProjectRow = ({
             }
           })}
           {!hideMoreActions && (
-            <ProjectMoreActionsMenu projectId={projectId} setError={setError} />
+            <ProjectMoreActionsMenu
+              projectId={projectId}
+              setError={setError}
+              userCanModerateProject={userCanModerateProject}
+            />
           )}
         </ActionsRowContainer>
       </RowContent>

--- a/front/app/containers/Admin/projects/components/ProjectRow/index.tsx
+++ b/front/app/containers/Admin/projects/components/ProjectRow/index.tsx
@@ -72,7 +72,6 @@ const ProjectRow = ({
   if (isNilOrError(authUser)) {
     return null;
   }
-
   const userCanModerateProject =
     // This means project is in a folder
     (typeof folderId === 'string' && userModeratesFolder(authUser, folderId)) ||
@@ -135,12 +134,8 @@ const ProjectRow = ({
               );
             }
           })}
-          {!hideMoreActions && (
-            <ProjectMoreActionsMenu
-              projectId={projectId}
-              setError={setError}
-              userCanModerateProject={userCanModerateProject}
-            />
+          {!hideMoreActions && userCanModerateProject && (
+            <ProjectMoreActionsMenu projectId={projectId} setError={setError} />
           )}
         </ActionsRowContainer>
       </RowContent>

--- a/front/app/containers/Admin/projects/components/ProjectRow/index.tsx
+++ b/front/app/containers/Admin/projects/components/ProjectRow/index.tsx
@@ -20,6 +20,7 @@ import ManageButton from './ManageButton';
 // resources
 import { canModerateProject } from 'services/permissions/rules/projectPermissions';
 import useAuthUser from 'hooks/useAuthUser';
+import { userModeratesFolder } from 'services/permissions/rules/projectFolderPermissions';
 
 // types
 import { IAdminPublicationContent } from 'hooks/useAdminPublications';
@@ -50,7 +51,7 @@ export interface Props {
   actions: ButtonAction[];
   hidePublicationStatusLabel?: boolean;
   className?: string;
-  showMoreActions?: boolean;
+  hideMoreActions?: boolean;
 }
 
 const ProjectRow = ({
@@ -58,16 +59,25 @@ const ProjectRow = ({
   actions,
   hidePublicationStatusLabel,
   className,
-  showMoreActions = false,
+  hideMoreActions = false,
 }: Props) => {
-  const [isBeingDeleted, _setIsBeingDeleted] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
   const authUser = useAuthUser();
+
+  if (isNilOrError(authUser)) {
+    return null;
+  }
+
   const projectId = publication.publicationId;
   const publicationStatus = publication.attributes.publication_status;
+  const folderId = publication.relationships.parent.data?.id;
+
   const userCanModerateProject =
-    !isNilOrError(authUser) &&
-    canModerateProject(publication.publicationId, { data: authUser });
+    // This means project is in a folder
+    (typeof folderId === 'string' && userModeratesFolder(authUser, folderId)) ||
+    canModerateProject(publication.publicationId, {
+      data: authUser,
+    });
 
   return (
     <Container className={className} data-testid="projectRow">
@@ -95,7 +105,7 @@ const ProjectRow = ({
             if (action === 'manage') {
               return (
                 <ManageButton
-                  isDisabled={isBeingDeleted || !userCanModerateProject}
+                  isDisabled={!userCanModerateProject}
                   publicationId={publication.publicationId}
                   key="manage"
                 />
@@ -118,14 +128,13 @@ const ProjectRow = ({
                   buttonStyle="secondary"
                   icon={action.icon}
                   processing={action.processing}
-                  disabled={isBeingDeleted}
                 >
                   {action.buttonContent}
                 </RowButton>
               );
             }
           })}
-          {showMoreActions && (
+          {!hideMoreActions && (
             <ProjectMoreActionsMenu projectId={projectId} setError={setError} />
           )}
         </ActionsRowContainer>

--- a/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/FolderMoreActionsMenu.tsx
+++ b/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/FolderMoreActionsMenu.tsx
@@ -18,6 +18,7 @@ const FolderMoreActionsMenu = ({ folderId, setError }: Props) => {
   const [isDeleting, setIsDeleting] = useState(false);
   const authUser = useAuthUser();
   if (isNilOrError(authUser)) return null;
+  const userCanDeleteProject = isAdmin({ data: authUser });
 
   const handleCallbackError = async (
     callback: () => Promise<any>,
@@ -31,41 +32,52 @@ const FolderMoreActionsMenu = ({ folderId, setError }: Props) => {
     }
   };
 
-  const deleteAction = {
-    handler: async () => {
-      if (window.confirm(formatMessage(messages.deleteFolderConfirmation))) {
-        setIsDeleting(true);
-        await handleCallbackError(
-          () => deleteProjectFolder(folderId),
-          formatMessage(messages.deleteFolderError)
-        );
-        setIsDeleting(false);
-      }
-    },
-    label: formatMessage(messages.deleteFolderButton),
-    icon: 'delete' as const,
-    isLoading: isDeleting,
+  const createActions = () => {
+    const actions: IAction[] = [];
+
+    if (userCanDeleteProject) {
+      actions.push({
+        handler: async () => {
+          if (
+            window.confirm(formatMessage(messages.deleteFolderConfirmation))
+          ) {
+            setIsDeleting(true);
+            await handleCallbackError(
+              () => deleteProjectFolder(folderId),
+              formatMessage(messages.deleteFolderError)
+            );
+            setIsDeleting(false);
+          }
+        },
+        label: formatMessage(messages.deleteFolderButton),
+        icon: 'delete' as const,
+        isLoading: isDeleting,
+      });
+    }
+
+    if (actions.length > 0) {
+      return actions;
+    }
+
+    return null;
   };
 
-  const actions: IAction[] = [];
-  if (isAdmin({ data: authUser })) {
-    actions.push(deleteAction);
+  const actions = createActions();
+
+  if (actions) {
+    return (
+      <Box
+        display="flex"
+        alignItems="center"
+        ml="1rem"
+        data-testid="folderMoreActionsMenu"
+      >
+        <MoreActionsMenu showLabel={false} actions={actions} />
+      </Box>
+    );
   }
 
-  if (actions.length === 0) {
-    return null;
-  }
-
-  return (
-    <Box
-      display="flex"
-      alignItems="center"
-      ml="1rem"
-      data-testid="folderMoreActionsMenu"
-    >
-      <MoreActionsMenu showLabel={false} actions={actions} />
-    </Box>
-  );
+  return null;
 };
 
 export default FolderMoreActionsMenu;

--- a/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/ProjectFolderRow.test.tsx
+++ b/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/ProjectFolderRow.test.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import ProjectFolderRow, { Props } from '.';
 import { render, screen } from 'utils/testUtils/rtl';
-import {
-  IAdminPublicationContent,
-  IUseAdminPublicationsOutput,
-} from 'hooks/useAdminPublications';
+import { IAdminPublicationContent } from 'hooks/useAdminPublications';
 import { IUserData } from 'services/users';
 
 const folderId = 'folderId';
@@ -34,51 +31,6 @@ const folderPublication: IAdminPublicationContent = {
   },
 };
 
-const projectId = 'projectId';
-const mockFolderChildAdminPublicationsList: IAdminPublicationContent[] = [
-  {
-    id: '2',
-    publicationType: 'project' as const,
-    publicationId: projectId,
-    attributes: {
-      ordering: 0,
-      depth: 0,
-      publication_status: 'published',
-      visible_children_count: 0,
-      publication_title_multiloc: {},
-      publication_description_multiloc: {},
-      publication_description_preview_multiloc: {},
-      publication_slug: 'project_1',
-    },
-    relationships: {
-      children: { data: [] },
-      parent: {
-        data: {
-          type: 'folder',
-          id: folderPublication.id,
-        },
-      },
-      publication: {
-        data: {
-          id: projectId,
-          type: 'project',
-        },
-      },
-    },
-  },
-];
-const mockFolderChildAdminPublications: IUseAdminPublicationsOutput = {
-  hasMore: false,
-  loadingInitial: false,
-  loadingMore: false,
-  list: mockFolderChildAdminPublicationsList,
-  onLoadMore: jest.fn,
-  onChangeTopics: jest.fn,
-  onChangeSearch: jest.fn,
-  onChangeAreas: jest.fn,
-  onChangePublicationStatus: jest.fn,
-};
-
 // Needed to render moreActionsMenu
 const mockUserData: IUserData = {
   id: 'userId',
@@ -103,11 +55,6 @@ jest.mock('hooks/useAuthUser', () => {
   return () => mockUserData;
 });
 
-// Needed to render folder with project inside
-jest.mock('hooks/useAdminPublications', () => {
-  return () => mockFolderChildAdminPublications;
-});
-
 const props: Props = {
   publication: folderPublication,
   toggleFolder: jest.fn,
@@ -116,13 +63,6 @@ const props: Props = {
 };
 
 describe('ProjectFolderRow', () => {
-  it('renders the project row inside', () => {
-    render(<ProjectFolderRow {...props} />);
-
-    const projectRows = screen.getAllByTestId('projectRow');
-    expect(projectRows.length).toEqual(1);
-  });
-
   describe('When user is an admin', () => {
     it('shows the edit button', () => {
       render(<ProjectFolderRow {...props} />);

--- a/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/ProjectFolderRow.test.tsx
+++ b/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/ProjectFolderRow.test.tsx
@@ -93,11 +93,11 @@ describe('ProjectFolderRow', () => {
       expect(editButton).toBeInTheDocument();
     });
 
-    it('shows the MoreActionsMenu', () => {
+    it('doest not show the MoreActionsMenu', () => {
       render(<ProjectFolderRow {...props} />);
 
-      const moreActionsMenu = screen.getByTestId('folderMoreActionsMenu');
-      expect(moreActionsMenu).toBeInTheDocument();
+      const moreActionsMenu = screen.queryByTestId('folderMoreActionsMenu');
+      expect(moreActionsMenu).not.toBeInTheDocument();
     });
   });
 
@@ -122,7 +122,7 @@ describe('ProjectFolderRow', () => {
       render(<ProjectFolderRow {...props} />);
 
       const moreOptions = screen.queryByTestId('moreOptionsButton');
-      expect(moreOptions).toBeNull();
+      expect(moreOptions).not.toBeInTheDocument();
     });
   });
 });

--- a/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/ProjectFolderRow.test.tsx
+++ b/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/ProjectFolderRow.test.tsx
@@ -56,6 +56,9 @@ jest.mock('hooks/useAuthUser', () => {
 
 const props: Props = {
   publication,
+  toggleFolder: jest.fn,
+  folderOpen: true,
+  hasProjects: true,
 };
 
 describe('ProjectFolderRow', () => {

--- a/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/ProjectFolderRow.test.tsx
+++ b/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/ProjectFolderRow.test.tsx
@@ -111,7 +111,7 @@ jest.mock('hooks/useAdminPublications', () => {
 const props: Props = {
   publication: folderPublication,
   toggleFolder: jest.fn,
-  folderOpen: true,
+  isFolderOpen: true,
   hasProjects: true,
 };
 

--- a/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/index.tsx
+++ b/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/index.tsx
@@ -59,17 +59,23 @@ const FolderRowContent = styled(RowContent)<{
 export interface Props {
   publication: IAdminPublicationContent;
   toggleFolder: () => void;
-  folderOpen: boolean;
+  isFolderOpen: boolean;
   hasProjects: boolean;
 }
 
 const ProjectFolderRow = memo<Props>(
-  ({ publication, toggleFolder, folderOpen, hasProjects }) => {
+  ({ publication, toggleFolder, isFolderOpen, hasProjects }) => {
     const authUser = useAuthUser();
 
     const [folderDeletionError, setFolderDeletionError] = useState<
       string | null
     >(null);
+
+    const handleClick = () => {
+      if (hasProjects) {
+        toggleFolder();
+      }
+    };
 
     if (!isNilOrError(authUser)) {
       return (
@@ -85,12 +91,12 @@ const ProjectFolderRow = memo<Props>(
                 className="e2e-admin-adminPublications-list-item"
                 hasProjects={hasProjects}
                 role="button"
-                onClick={toggleFolder}
+                onClick={handleClick}
               >
                 <RowContentInner className="expand primary">
                   {hasProjects && (
                     <ArrowIcon
-                      expanded={hasProjects && folderOpen}
+                      expanded={hasProjects && isFolderOpen}
                       name="chevron-right"
                     />
                   )}

--- a/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/index.tsx
+++ b/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/index.tsx
@@ -37,8 +37,8 @@ const FolderIcon = styled(Icon)`
 
 // types & services
 import ProjectRow from 'containers/Admin/projects/components/ProjectRow';
-import { colors } from 'utils/styleUtils';
 import PublicationStatusLabel from 'containers/Admin/projects/components/PublicationStatusLabel';
+import { List, Row } from 'components/admin/ResourceList';
 
 const ArrowIcon = styled(Icon)<{ expanded: boolean }>`
   flex: 0 0 24px;
@@ -53,15 +53,11 @@ const ArrowIcon = styled(Icon)<{ expanded: boolean }>`
   `}
 `;
 
-const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-`;
-
 const FolderRowContent = styled(RowContent)<{
   hasProjects: boolean;
 }>`
+  flex-grow: 1;
+
   ${({ hasProjects }) =>
     hasProjects &&
     `
@@ -69,14 +65,7 @@ const FolderRowContent = styled(RowContent)<{
   `}
 `;
 
-const ProjectRows = styled.div`
-  margin-left: 30px;
-`;
-
-const InFolderProjectRow = styled(ProjectRow)`
-  padding-top: 10px;
-  border-top: 1px solid ${colors.divider};
-`;
+const InFolderProjectRow = styled(ProjectRow)<{ isLast: boolean }>``;
 
 export interface Props {
   publication: IAdminPublicationContent;
@@ -109,74 +98,86 @@ const ProjectFolderRow = memo<Props>(({ publication }) => {
 
   if (!isNilOrError(authUser)) {
     return (
-      <Container>
+      <Box display="flex" flexDirection="column" flexGrow={1}>
         <Box
-          width="100%"
           display="flex"
-          alignItems="center"
-          pb={hasProjects && folderOpen ? '12px' : '0'}
+          flexDirection="column"
+          width="100%"
+          alignItems="flex-start"
         >
-          <FolderRowContent
-            className="e2e-admin-adminPublications-list-item"
-            hasProjects={hasProjects}
-            role="button"
-            onClick={toggleExpand}
+          <Box
+            width="100%"
+            display="flex"
+            alignItems="center"
+            pb={hasProjects && folderOpen ? '10px' : '0'}
           >
-            <RowContentInner className="expand primary">
-              {hasProjects && (
-                <ArrowIcon
-                  expanded={hasProjects && folderOpen}
-                  name="chevron-right"
-                />
-              )}
-              <FolderIcon name="folder-outline" />
-              <RowTitle
-                value={publication.attributes.publication_title_multiloc}
-              />
-              <PublicationStatusLabel
-                publicationStatus={publication.attributes.publication_status}
-              />
-            </RowContentInner>
-            <RowButton
-              className={`e2e-admin-edit-project ${
-                publication.attributes.publication_title_multiloc['en-GB'] || ''
-              }`}
-              linkTo={`/admin/projects/folders/${publication.publicationId}`}
-              buttonStyle="secondary"
-              icon="edit"
-              disabled={
-                isBeingDeleted ||
-                !userModeratesFolder(authUser, publication.publicationId)
-              }
-              data-testid="edit-button"
+            <FolderRowContent
+              className="e2e-admin-adminPublications-list-item"
+              hasProjects={hasProjects}
+              role="button"
+              onClick={toggleExpand}
             >
-              <FormattedMessage {...messages.edit} />
-            </RowButton>
-          </FolderRowContent>
-          <FolderMoreActionsMenu
-            folderId={publication.publicationId}
-            setError={setFolderDeletionError}
-          />
-        </Box>
-
-        {folderDeletionError && <Error text={folderDeletionError} />}
-
-        {hasProjects && folderOpen && (
-          <ProjectRows>
-            {folderChildAdminPublications.map((childPublication) => (
-              <InFolderProjectRow
-                publication={childPublication}
-                key={childPublication.id}
-                actions={['manage']}
-                showMoreActions={userModeratesFolder(
-                  authUser,
-                  publication.publicationId
+              <RowContentInner className="expand primary">
+                {hasProjects && (
+                  <ArrowIcon
+                    expanded={hasProjects && folderOpen}
+                    name="chevron-right"
+                  />
                 )}
-              />
-            ))}
-          </ProjectRows>
+                <FolderIcon name="folder-outline" />
+                <RowTitle
+                  value={publication.attributes.publication_title_multiloc}
+                />
+                <PublicationStatusLabel
+                  publicationStatus={publication.attributes.publication_status}
+                />
+              </RowContentInner>
+              <RowButton
+                className={`e2e-admin-edit-project ${
+                  publication.attributes.publication_title_multiloc['en-GB'] ||
+                  ''
+                }`}
+                linkTo={`/admin/projects/folders/${publication.publicationId}`}
+                buttonStyle="secondary"
+                icon="edit"
+                disabled={
+                  isBeingDeleted ||
+                  !userModeratesFolder(authUser, publication.publicationId)
+                }
+                data-testid="edit-button"
+              >
+                <FormattedMessage {...messages.edit} />
+              </RowButton>
+            </FolderRowContent>
+            <FolderMoreActionsMenu
+              folderId={publication.publicationId}
+              setError={setFolderDeletionError}
+            />
+          </Box>
+
+          {folderDeletionError && <Error text={folderDeletionError} />}
+        </Box>
+        {hasProjects && folderOpen && (
+          <Box ml="30px">
+            <List>
+              {folderChildAdminPublications.map((childPublication, index) => (
+                <Row>
+                  <InFolderProjectRow
+                    publication={childPublication}
+                    key={childPublication.id}
+                    actions={['manage']}
+                    showMoreActions={userModeratesFolder(
+                      authUser,
+                      publication.publicationId
+                    )}
+                    isLast={folderChildAdminPublications.length === index + 1}
+                  />
+                </Row>
+              ))}
+            </List>
+          </Box>
         )}
-      </Container>
+      </Box>
     );
   }
 

--- a/front/app/services/adminPublications.ts
+++ b/front/app/services/adminPublications.ts
@@ -41,6 +41,7 @@ export interface IAdminPublicationData {
       data: IRelationship[];
     };
     parent: {
+      // The id here is the parent's publication id, *not* the folder id.
       data?: IRelationship;
     };
     publication: {

--- a/front/app/services/adminPublications.ts
+++ b/front/app/services/adminPublications.ts
@@ -41,7 +41,7 @@ export interface IAdminPublicationData {
       data: IRelationship[];
     };
     parent: {
-      // The id here is the parent's publication id, *not* the folder id.
+      // The id in IRelationship is the parent's publication id, *not* the folder id.
       data?: IRelationship;
     };
     publication: {


### PR DESCRIPTION
Spent more time on this than I wanted. I took the folder child projects our of the ProjectFolderRow component. The styles of the SortableRow where messing with those of the children. This is expected because the styles like padding-bottom are only intended for the top row (the folder in this case), not for a row that has child rows (so the padding gets added under the children and there's double padding).

Anyway, we're now using the common components we're using in other lists in the admin.