### PR TITLE
CL-2845 - Fix incorrect section title

### DIFF
--- a/back/app/models/custom_field.rb
+++ b/back/app/models/custom_field.rb
@@ -182,7 +182,7 @@ class CustomField < ApplicationRecord
   def title_multiloc
     if code == 'ideation_section1'
       project = resource.participation_context
-      phase = TimelineService.new.current_or_first_ideation_phase project
+      phase = TimelineService.new.current_or_last_ideation_phase project
       input_term = phase ? phase.input_term : project.input_term || ParticipationContext::DEFAULT_INPUT_TERM
 
       key = "custom_forms.categories.main_content.#{input_term}.title"

--- a/back/app/models/custom_field.rb
+++ b/back/app/models/custom_field.rb
@@ -181,20 +181,9 @@ class CustomField < ApplicationRecord
   # Special behaviour for ideation section 1
   def title_multiloc
     if code == 'ideation_section1'
-      input_term = resource.participation_context.input_term || ParticipationContext::DEFAULT_INPUT_TERM
-
-      phases = resource.participation_context.phases
-      if phases.present?
-        now = Time.zone.now
-        ideation_types = %w[ideation budgeting]
-        ideation_phases = phases.select { |phase| ideation_types.include? phase.participation_method }
-        current_phase = ideation_phases.each.detect { |phase| phase.start_at <= now && now <= phase.end_at }
-        input_term = if current_phase
-          current_phase.input_term
-        else # there is no current ideation phase, return the first phase input term by default
-          phases.first.input_term
-        end
-      end
+      project = resource.participation_context
+      phase = TimelineService.new.current_or_first_ideation_phase project
+      input_term = phase ? phase.input_term : project.input_term || ParticipationContext::DEFAULT_INPUT_TERM
 
       key = "custom_forms.categories.main_content.#{input_term}.title"
       MultilocService.new.i18n_to_multiloc key

--- a/back/app/models/custom_field.rb
+++ b/back/app/models/custom_field.rb
@@ -185,18 +185,14 @@ class CustomField < ApplicationRecord
 
       phases = resource.participation_context.phases
       if phases.present?
-        if phases.size == 1
-          input_term = phases[0].input_term
-        else
-          now = Time.zone.now
-          ideation_types = %w[ideation budgeting]
-          ideation_phases = phases.select { |phase| ideation_types.include? phase.participation_method }
-          current_phase = ideation_phases.each.detect { |phase| phase.start_at <= now && now <= phase.end_at }
-          input_term = if current_phase
-            current_phase.input_term
-          else # there is no current phase
-            current_phase.last.input_term
-          end
+        now = Time.zone.now
+        ideation_types = %w[ideation budgeting]
+        ideation_phases = phases.select { |phase| ideation_types.include? phase.participation_method }
+        current_phase = ideation_phases.each.detect { |phase| phase.start_at <= now && now <= phase.end_at }
+        input_term = if current_phase
+          current_phase.input_term
+        else # there is no current ideation phase, return the first phase input term by default
+          phases.first.input_term
         end
       end
 

--- a/back/app/services/timeline_service.rb
+++ b/back/app/services/timeline_service.rb
@@ -24,7 +24,7 @@ class TimelineService
     end
   end
 
-  def current_or_first_ideation_phase(project, time = Time.now)
+  def current_or_last_ideation_phase(project, time = Time.now)
     date = time.in_time_zone(AppConfiguration.instance.settings('core', 'timezone')).to_date
     return unless project.timeline?
 
@@ -36,7 +36,7 @@ class TimelineService
     return if ideation_phases.blank?
 
     current_phase = ideation_phases.find { |phase| phase.start_at <= date && date <= phase.end_at }
-    current_phase || ideation_phases.first
+    current_phase || ideation_phases.last
   end
 
   def current_and_future_phases(project, time = Time.now)

--- a/back/app/services/timeline_service.rb
+++ b/back/app/services/timeline_service.rb
@@ -33,8 +33,10 @@ class TimelineService
 
     ideation_types = %w[ideation budgeting]
     ideation_phases = phases.select { |phase| ideation_types.include? phase.participation_method }
+    return if ideation_phases.blank?
+
     current_phase = ideation_phases.find { |phase| phase.start_at <= date && date <= phase.end_at }
-    current_phase || phases.first
+    current_phase || ideation_phases.first
   end
 
   def current_and_future_phases(project, time = Time.now)

--- a/back/app/services/timeline_service.rb
+++ b/back/app/services/timeline_service.rb
@@ -24,6 +24,19 @@ class TimelineService
     end
   end
 
+  def current_or_first_ideation_phase(project, time = Time.now)
+    date = time.in_time_zone(AppConfiguration.instance.settings('core', 'timezone')).to_date
+    return unless project.timeline?
+
+    phases = project.phases
+    return if phases.blank?
+
+    ideation_types = %w[ideation budgeting]
+    ideation_phases = phases.select { |phase| ideation_types.include? phase.participation_method }
+    current_phase = ideation_phases.find { |phase| phase.start_at <= date && date <= phase.end_at }
+    current_phase || phases.first
+  end
+
   def current_and_future_phases(project, time = Time.now)
     date = time.in_time_zone(AppConfiguration.instance.settings('core', 'timezone')).to_date
     return unless project.timeline?

--- a/back/spec/models/custom_field_spec.rb
+++ b/back/spec/models/custom_field_spec.rb
@@ -379,9 +379,9 @@ RSpec.describe CustomField, type: :model do
         expect(section.title_multiloc['en']).to eq expected_english_title
       end
 
-      it 'returns a title containing the first phase input term if there is not a current ideation/budget phase' do
+      it 'returns a title containing the last phase input term if there is not a current ideation/budget phase' do
         project = create :project_with_future_phases
-        project.phases.first.update! input_term: 'contribution'
+        project.phases.last.update! input_term: 'contribution'
         resource = build :custom_form, participation_context: project
 
         ignored_title = { en: 'anything' }

--- a/back/spec/models/custom_field_spec.rb
+++ b/back/spec/models/custom_field_spec.rb
@@ -347,18 +347,53 @@ RSpec.describe CustomField, type: :model do
   end
 
   describe 'title_multiloc behaviour for ideation section 1' do
-    it 'returns the correct input term message regardless of what the field is set to' do
-      resource = create :custom_form
-      resource.participation_context.input_term = 'idea'
-      ignored_title = { en: 'anything' }
-      section = described_class.new(
-        resource: resource,
-        input_type: 'section',
-        code: 'ideation_section1',
-        title_multiloc: ignored_title
-      )
-      expected_english_title = 'What is your idea?'
-      expect(section.title_multiloc['en']).to eq expected_english_title
+    context 'continuous projects' do
+      it 'returns a title containing the project input term regardless of what it is set to' do
+        resource = build :custom_form
+        resource.participation_context.update! input_term: 'option'
+        ignored_title = { en: 'anything' }
+        section = described_class.new(
+          resource: resource,
+          input_type: 'section',
+          code: 'ideation_section1',
+          title_multiloc: ignored_title
+        )
+        expected_english_title = 'What is your option?'
+        expect(section.title_multiloc['en']).to eq expected_english_title
+      end
+    end
+
+    # Do budget too
+    context 'timeline projects' do
+      it 'returns a title containing the current ideation/budget phase input term if there is a current phase' do
+        project = create :project_with_current_phase, current_phase_attrs: { input_term: 'question' }
+        resource = build :custom_form, participation_context: project
+        ignored_title = { en: 'anything' }
+        section = described_class.new(
+          resource: resource,
+          input_type: 'section',
+          code: 'ideation_section1',
+          title_multiloc: ignored_title
+        )
+        expected_english_title = 'What is your question?'
+        expect(section.title_multiloc['en']).to eq expected_english_title
+      end
+
+      it 'returns a title containing the first phase input term if there is not a current ideation/budget phase' do
+        project = create :project_with_future_phases
+        project.phases.first.update! input_term: 'contribution'
+        resource = build :custom_form, participation_context: project
+
+        ignored_title = { en: 'anything' }
+        section = described_class.new(
+          resource: resource,
+          input_type: 'section',
+          code: 'ideation_section1',
+          title_multiloc: ignored_title
+        )
+        expected_english_title = 'What is your contribution?'
+        expect(section.title_multiloc['en']).to eq expected_english_title
+      end
     end
   end
 


### PR DESCRIPTION
Fixed section1 title to pull input term from phase instead of project for timeline projects