### PR TITLE
[CL-2844] Handle view form button for non-active ideation phases

### DIFF
--- a/front/app/components/FormBuilder/edit/index.tsx
+++ b/front/app/components/FormBuilder/edit/index.tsx
@@ -90,6 +90,7 @@ export const FormEdit = ({
     groupingType,
     isEditPermittedAfterSubmissions,
     formSavedSuccessMessage,
+    isFormPhaseSpecific,
   } = builderConfig;
 
   const isEditingDisabled =
@@ -201,8 +202,11 @@ export const FormEdit = ({
           maximum: field.maximum.toString(),
         }),
       }));
-
-      await updateFormCustomFields(projectId, finalResponseArray, phaseId);
+      await updateFormCustomFields(
+        projectId,
+        finalResponseArray,
+        isFormPhaseSpecific ? phaseId : undefined
+      );
     } catch (error) {
       handleHookFormSubmissionError(error, setError, 'customFields');
     }

--- a/front/app/components/FormBuilder/utils.ts
+++ b/front/app/components/FormBuilder/utils.ts
@@ -30,6 +30,7 @@ export type FormBuilderConfig = {
   isLogicEnabled: boolean;
   isEditPermittedAfterSubmissions: boolean;
   alwaysShowCustomFields: boolean;
+  isFormPhaseSpecific: boolean;
 
   viewFormLink?: string;
 

--- a/front/app/containers/Admin/projects/project/inputForm/IdeaFormBuilder/index.tsx
+++ b/front/app/containers/Admin/projects/project/inputForm/IdeaFormBuilder/index.tsx
@@ -13,14 +13,12 @@ import { ideationConfig } from '../utils';
 const FormBuilder = lazy(() => import('components/FormBuilder/edit'));
 
 const IdeaFormBuilder = () => {
-  const { projectId, phaseId } = useParams() as {
+  const { projectId } = useParams() as {
     projectId: string;
-    phaseId?: string;
   };
 
   const formCustomFields = useFormCustomFields({
     projectId,
-    phaseId,
   });
 
   const goBackUrl = `/admin/projects/${projectId}/ideaform`;

--- a/front/app/containers/Admin/projects/project/inputForm/index.tsx
+++ b/front/app/containers/Admin/projects/project/inputForm/index.tsx
@@ -58,13 +58,23 @@ export const IdeaForm = () => {
   );
 };
 
+const isIdeationContext = (participationContext: string | undefined) => {
+  if (
+    participationContext === 'ideation' ||
+    participationContext === 'budgeting'
+  ) {
+    return true;
+  }
+  return false;
+};
+
 const getCurrentOrLastIdeationPhase = (phases: IPhaseData[]) => {
   const currentPhase = getCurrentPhase(phases);
-  if (currentPhase?.attributes.participation_method === 'ideation') {
+  if (isIdeationContext(currentPhase?.attributes.participation_method)) {
     return currentPhase;
   }
-  const ideationPhases = phases.filter(
-    (phase) => phase.attributes.participation_method === 'ideation'
+  const ideationPhases = phases.filter((phase) =>
+    isIdeationContext(phase.attributes.participation_method)
   );
   if (ideationPhases.length > 0) {
     return ideationPhases.pop();

--- a/front/app/containers/Admin/projects/project/inputForm/index.tsx
+++ b/front/app/containers/Admin/projects/project/inputForm/index.tsx
@@ -15,6 +15,7 @@ import { FormattedMessage } from 'utils/cl-intl';
 import { useParams } from 'react-router-dom';
 import usePhases from 'hooks/usePhases';
 import { isNilOrError } from 'utils/helperUtils';
+import { getCurrentPhase, IPhaseData } from 'services/phases';
 
 export const IdeaForm = () => {
   const { projectId } = useParams() as {
@@ -22,12 +23,10 @@ export const IdeaForm = () => {
   };
 
   const phases = usePhases(projectId);
-  const ideationPhases = !isNilOrError(phases)
-    ? phases.filter(
-        (phase) => phase.attributes.participation_method === 'ideation'
-      )
-    : [];
-  const ideationPhaseId = ideationPhases.length > 0 ? ideationPhases[0].id : '';
+  let phaseToUse;
+  if (!isNilOrError(phases)) {
+    phaseToUse = getCurrentOrLastIdeationPhase(phases);
+  }
 
   return (
     <Box gap="0px" flexWrap="wrap" width="100%" display="flex">
@@ -42,9 +41,9 @@ export const IdeaForm = () => {
       <Box>
         <Button
           onClick={() => {
-            ideationPhaseId
+            phaseToUse
               ? clHistory.push(
-                  `/admin/projects/${projectId}/phases/${ideationPhaseId}/ideaform/edit`
+                  `/admin/projects/${projectId}/phases/${phaseToUse.id}/ideaform/edit`
                 )
               : clHistory.push(`/admin/projects/${projectId}/ideaform/edit`);
           }}
@@ -57,6 +56,21 @@ export const IdeaForm = () => {
       </Box>
     </Box>
   );
+};
+
+const getCurrentOrLastIdeationPhase = (phases: IPhaseData[]) => {
+  const currentPhase = getCurrentPhase(phases);
+  if (currentPhase?.attributes.participation_method === 'ideation') {
+    return currentPhase;
+  }
+  const ideationPhases = phases.filter(
+    (phase) => phase.attributes.participation_method === 'ideation'
+  );
+  console.log({ ideationPhases });
+  if (ideationPhases.length > 0) {
+    return ideationPhases.pop();
+  }
+  return undefined;
 };
 
 export default IdeaForm;

--- a/front/app/containers/Admin/projects/project/inputForm/index.tsx
+++ b/front/app/containers/Admin/projects/project/inputForm/index.tsx
@@ -59,17 +59,11 @@ export const IdeaForm = () => {
 };
 
 const isIdeationContext = (participationContext: string | undefined) => {
-  if (
-    participationContext === 'ideation' ||
-    participationContext === 'budgeting'
-  ) {
-    return true;
-  }
-  return false;
+  return (
+    participationContext === 'ideation' || participationContext === 'budgeting'
+  );
 };
-    const isIdeationContext = (participationContext: string | undefined) => {
-      return participationContext === 'ideation' || participationContext === 'budgeting';
-    };```
+
 const getCurrentOrLastIdeationPhase = (phases: IPhaseData[]) => {
   const currentPhase = getCurrentPhase(phases);
   if (isIdeationContext(currentPhase?.attributes.participation_method)) {

--- a/front/app/containers/Admin/projects/project/inputForm/index.tsx
+++ b/front/app/containers/Admin/projects/project/inputForm/index.tsx
@@ -66,7 +66,6 @@ const getCurrentOrLastIdeationPhase = (phases: IPhaseData[]) => {
   const ideationPhases = phases.filter(
     (phase) => phase.attributes.participation_method === 'ideation'
   );
-  console.log({ ideationPhases });
   if (ideationPhases.length > 0) {
     return ideationPhases.pop();
   }

--- a/front/app/containers/Admin/projects/project/inputForm/index.tsx
+++ b/front/app/containers/Admin/projects/project/inputForm/index.tsx
@@ -13,11 +13,22 @@ import { FormattedMessage } from 'utils/cl-intl';
 
 // hooks
 import { useParams } from 'react-router-dom';
+import usePhases from 'hooks/usePhases';
+import { isNilOrError } from 'utils/helperUtils';
 
 export const IdeaForm = () => {
   const { projectId } = useParams() as {
     projectId: string;
   };
+
+  const phases = usePhases(projectId);
+  const ideationPhases = !isNilOrError(phases)
+    ? phases.filter(
+        (phase) => phase.attributes.participation_method === 'ideation'
+      )
+    : [];
+  const ideationPhaseId = ideationPhases.length > 0 ? ideationPhases[0].id : '';
+
   return (
     <Box gap="0px" flexWrap="wrap" width="100%" display="flex">
       <Box width="100%">
@@ -31,7 +42,11 @@ export const IdeaForm = () => {
       <Box>
         <Button
           onClick={() => {
-            clHistory.push(`/admin/projects/${projectId}/ideaform/edit`);
+            ideationPhaseId
+              ? clHistory.push(
+                  `/admin/projects/${projectId}/phases/${ideationPhaseId}/ideaform/edit`
+                )
+              : clHistory.push(`/admin/projects/${projectId}/ideaform/edit`);
           }}
           width="auto"
           icon="edit"

--- a/front/app/containers/Admin/projects/project/inputForm/index.tsx
+++ b/front/app/containers/Admin/projects/project/inputForm/index.tsx
@@ -67,7 +67,9 @@ const isIdeationContext = (participationContext: string | undefined) => {
   }
   return false;
 };
-
+    const isIdeationContext = (participationContext: string | undefined) => {
+      return participationContext === 'ideation' || participationContext === 'budgeting';
+    };```
 const getCurrentOrLastIdeationPhase = (phases: IPhaseData[]) => {
   const currentPhase = getCurrentPhase(phases);
   if (isIdeationContext(currentPhase?.attributes.participation_method)) {

--- a/front/app/containers/Admin/projects/project/inputForm/utils.tsx
+++ b/front/app/containers/Admin/projects/project/inputForm/utils.tsx
@@ -24,6 +24,7 @@ export const ideationConfig: FormBuilderConfig = {
   isLogicEnabled: false,
   isEditPermittedAfterSubmissions: true,
   alwaysShowCustomFields: false,
+  isFormPhaseSpecific: false,
 
   groupingType: 'section',
   getWarningNotice: () => {

--- a/front/app/containers/Admin/projects/project/nativeSurvey/utils.tsx
+++ b/front/app/containers/Admin/projects/project/nativeSurvey/utils.tsx
@@ -35,6 +35,7 @@ export const nativeSurveyConfig: FormBuilderConfig = {
   isLogicEnabled: true,
   isEditPermittedAfterSubmissions: false,
   alwaysShowCustomFields: true,
+  isFormPhaseSpecific: true,
 
   groupingType: 'page',
   getDeletionNotice: (projectId: string) => {

--- a/front/app/containers/Admin/projects/routes.tsx
+++ b/front/app/containers/Admin/projects/routes.tsx
@@ -206,6 +206,10 @@ const createAdminProjectsRoutes = () => {
             element: <IdeaFormBuilder />,
           },
           {
+            path: 'phases/:phaseId/ideaform/edit',
+            element: <IdeaFormBuilder />,
+          },
+          {
             path: 'native-survey/edit',
             element: <SurveyFormBuilder />,
           },


### PR DESCRIPTION
## Description
Passes in a phase ID to the ideation form builder so we can always view the form, but doesn't use it for loading/saving the custom fields (those are still saved on the project level).

## Note
I'll add a test after lunch :) 