### PR TITLE
Add e2e test for multi-phase ideation form builder

### DIFF
--- a/front/cypress/e2e/input_form_builder/timeline_projects/timeline_projects.cy.ts
+++ b/front/cypress/e2e/input_form_builder/timeline_projects/timeline_projects.cy.ts
@@ -11,6 +11,8 @@ describe('Input form builder timeline projects', () => {
 
   beforeEach(() => {
     cy.setAdminLoginCookie();
+
+    // Project with active ideation phase
     cy.apiCreateProject({
       type: 'timeline',
       title: projectTitle1,
@@ -43,7 +45,7 @@ describe('Input form builder timeline projects', () => {
       );
     });
 
-    // Create second project
+    // Project with no active ideation phase
     cy.apiCreateProject({
       type: 'timeline',
       title: projectTitle2,

--- a/front/cypress/e2e/input_form_builder/timeline_projects/timeline_projects.cy.ts
+++ b/front/cypress/e2e/input_form_builder/timeline_projects/timeline_projects.cy.ts
@@ -1,0 +1,111 @@
+import moment = require('moment');
+import { randomString } from '../../../support/commands';
+
+describe('Input form builder timeline projects', () => {
+  const projectTitle1 = randomString();
+  const projectTitle2 = randomString();
+  let projectID1: string;
+  let projectID2: string;
+  let phaseIDProject1: string;
+  let phaseIDProject2: string;
+
+  beforeEach(() => {
+    cy.setAdminLoginCookie();
+    cy.apiCreateProject({
+      type: 'timeline',
+      title: projectTitle1,
+      descriptionPreview: '',
+      description: '',
+      publicationStatus: 'published',
+    }).then((project) => {
+      projectID1 = project.body.data.id;
+      cy.apiCreatePhase(
+        projectID1,
+        'Ideation Phase I',
+        moment().subtract(2, 'month').format('DD/MM/YYYY'),
+        moment().add(2, 'days').format('DD/MM/YYYY'),
+        'ideation',
+        true,
+        true,
+        true
+      ).then((phase) => {
+        phaseIDProject1 = phase.body.data.id;
+      });
+      cy.apiCreatePhase(
+        projectID1,
+        'Ideation Phase II',
+        moment().add(4, 'days').format('DD/MM/YYYY'),
+        moment().add(2, 'months').format('DD/MM/YYYY'),
+        'ideation',
+        true,
+        true,
+        true
+      );
+    });
+
+    // Create second project
+    cy.apiCreateProject({
+      type: 'timeline',
+      title: projectTitle2,
+      descriptionPreview: '',
+      description: '',
+      publicationStatus: 'published',
+    }).then((project) => {
+      projectID2 = project.body.data.id;
+      cy.apiCreatePhase(
+        projectID2,
+        'Ideation Phase I',
+        moment().subtract(2, 'month').format('DD/MM/YYYY'),
+        moment().subtract(2, 'days').format('DD/MM/YYYY'),
+        'ideation',
+        true,
+        true,
+        true
+      );
+      cy.apiCreatePhase(
+        projectID2,
+        'Ideation Phase II',
+        moment().add(4, 'days').format('DD/MM/YYYY'),
+        moment().add(2, 'months').format('DD/MM/YYYY'),
+        'ideation',
+        true,
+        true,
+        true
+      ).then((phase) => {
+        phaseIDProject2 = phase.body.data.id;
+      });
+    });
+  });
+
+  afterEach(() => {
+    if (projectID1) {
+      cy.apiRemoveProject(projectID1);
+    }
+
+    if (projectID2) {
+      cy.apiRemoveProject(projectID2);
+    }
+  });
+
+  it('opens the idea form builder with correct phase ID', () => {
+    // Test that any current ideation phase is passed
+    cy.visit(`admin/projects/${projectID1}/ideaform`);
+    cy.get('[data-cy="e2e-edit-input-form"]').click();
+    // verify URL has correct phaseID parameter
+    cy.url().should('include', `${phaseIDProject1}`);
+    // verify clicking view form takes you to correct phase-specific input form
+    cy.get('[data-cy="e2e-preview-form-button"]').should('exist');
+    cy.get('[data-cy="e2e-preview-form-button"]').click({ force: true });
+    cy.url().should('include', `${phaseIDProject1}`);
+
+    // Test that last phase is used if no current ideation phase
+    cy.visit(`admin/projects/${projectID2}/ideaform`);
+    cy.get('[data-cy="e2e-edit-input-form"]').click();
+    // verify URL has correct phaseID parameter
+    cy.url().should('include', `${phaseIDProject2}`);
+    // verify clicking view form takes you to correct phase-specific input form
+    cy.get('[data-cy="e2e-preview-form-button"]').should('exist');
+    cy.get('[data-cy="e2e-preview-form-button"]').click({ force: true });
+    cy.url().should('include', `${phaseIDProject2}`);
+  });
+});


### PR DESCRIPTION
## Description
Adds a test to check that the correct phase ID is passed to the ideation form builder when in a timeline project.

## How urgent is a code review?
End of day if possible?

### Note
Since I don't want to merge a flaky test, I wanted to try running this locally using Alexander's new make file CI setup before I merge (since I'm out next week and wouldn't be able to fix it if it's flaky), but I wasn't able to get that working :thinking: I'll wait until I'm back and ask him to help me set that up.
