### PR TITLE
[CL-2894] Preserve Acts::List ordering field source values when applying template

### DIFF
--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/tenant_template_service.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/tenant_template_service.rb
@@ -39,7 +39,6 @@ module MultiTenancy
       end
     end
 
-    # rubocop:disable Metrics/MethodLength
     def apply_template(template, validate: true, max_time: nil, local_copy: false)
       t1 = Time.zone.now
       obj_to_id_and_class = {}
@@ -127,7 +126,6 @@ module MultiTenancy
 
       created_objects_ids
     end
-    # rubocop:enable Metrics/MethodLength
 
     def restore_template_attributes(attributes, obj_to_id_and_class, app_settings, model_class: nil)
       start_of_day = Time.now.in_time_zone(app_settings.dig('core', 'timezone')).beginning_of_day

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/tenant_template_service.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/tenant_template_service.rb
@@ -80,7 +80,16 @@ module MultiTenancy
           model.skip_image_presence = true if SKIP_IMAGE_PRESENCE_VALIDATION.include?(model_class.name)
 
           begin
-            if validate
+            if model.class.method_defined?(:in_list?) && model.in_list?
+              model_class.name.constantize.acts_as_list_no_update do
+                if validate
+                  model.save!
+                else
+                  model.save # Might fail but runs before_validations
+                  model.save(validate: false)
+                end
+              end
+            elsif validate
               model.save!
             else
               model.save # Might fail but runs before_validations

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/tenant_template_service.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/tenant_template_service.rb
@@ -81,7 +81,7 @@ module MultiTenancy
 
           begin
             if model.class.method_defined?(:in_list?) && model.in_list?
-              model_class.name.constantize.acts_as_list_no_update { save_model(model, validate) }
+              model.class.acts_as_list_no_update { save_model(model, validate) }
             else
               save_model(model, validate)
             end

--- a/back/engines/commercial/multi_tenancy/spec/services/multi_tenancy/templates/serializer_spec.rb
+++ b/back/engines/commercial/multi_tenancy/spec/services/multi_tenancy/templates/serializer_spec.rb
@@ -198,5 +198,29 @@ describe MultiTenancy::Templates::Serializer do
       expect(template['models']['idea'].size).to eq 1
       expect(template['models']['idea'].first['custom_field_values']).to match expected_custom_field_values
     end
+
+    it 'copies exact :ordering values of records for models that use acts_as_list gem' do
+      project = create(:project, title_multiloc: { en: 'source project' })
+      create_list(
+        :cause,
+        5,
+        participation_context_id: project.id,
+        participation_context_type: 'Project',
+        ordering: rand(10) # Introduce some randomness, with the acts_as_list gem handling collisions & sequencing
+      )
+
+      ordering_of_source_causes = project.causes.order(:title_multiloc['en']).pluck(:ordering)
+      serializer = described_class.new Tenant.current
+      template = serializer.run
+      tenant = create :tenant, locales: AppConfiguration.instance.settings('core', 'locales')
+
+      Apartment::Tenant.switch(tenant.schema_name) do
+        MultiTenancy::TenantTemplateService.new.apply_template template
+
+        copied_project = Project.find_by(title_multiloc: project.title_multiloc)
+        expect(copied_project.causes.order(:title_multiloc['en']).pluck(:ordering))
+          .to eq(ordering_of_source_causes)
+      end
+    end
   end
 end

--- a/back/spec/services/local_project_copy_service_spec.rb
+++ b/back/spec/services/local_project_copy_service_spec.rb
@@ -144,10 +144,10 @@ describe LocalProjectCopyService do
       copied_project = service.copy(continuous_project.reload)
 
       expect(copied_project.causes.map do |record|
-        record.as_json(only: %i[participation_context_type title_multiloc description_multiloc volunteers_count])
+        record.as_json(except: %i[id participation_context_id image updated_at created_at])
       end)
         .to match_array(continuous_project.causes.map do |record|
-          record.as_json(only: %i[participation_context_type title_multiloc description_multiloc volunteers_count])
+          record.as_json(except: %i[id participation_context_id image updated_at created_at])
         end)
     end
 
@@ -161,10 +161,10 @@ describe LocalProjectCopyService do
       copied_project = service.copy(continuous_project.reload)
 
       expect(copied_project.custom_form.custom_fields.map do |record|
-        record.as_json(except: %i[id ordering resource_id updated_at created_at])
+        record.as_json(except: %i[id resource_id updated_at created_at])
       end)
         .to match_array(continuous_project.custom_form.custom_fields.map do |record|
-          record.as_json(except: %i[id ordering resource_id updated_at created_at])
+          record.as_json(except: %i[id resource_id updated_at created_at])
         end)
 
       source_custom_field = continuous_project.custom_form.custom_fields.last


### PR DESCRIPTION
## Summary

It appears that when using the `TenantTemplateService` to copy a either tenant or a project, the `acts_as_list` gem changes the values of the `:ordering` fields of records, probably to represent the ordering in which the new records are written - which may not represent the ordering of the original records by their `:ordering` values.

This PR overrides that behaviour by wrapping the saving of models, in the `TenantTemplateService#apply_template` method, in an `acts_as_list_no_update` block (see [docs](https://rubydoc.info/gems/acts_as_list/1.0.1/ActiveRecord/Acts/List/NoUpdate)), if the model being applied is acting as a list.

## Tests

I chose to add an example test of explicit copying of such `:ordering` values to both the `serializer_spec.rb` and `project_copy_service_spec.rb` files, since this seemed to offer a better test of the end-to-end process (original data -> template -> copied data), than a test in `tenant_template_service_spec.rb` would have (template -> copied data).

This PR also takes the opportunity to include `:ordering` fields in `local_project_copy_serice_spec.rb` tests, where these had been omitted due to the previously unreliable copying of `:ordering` values.