### PR TITLE
[CL-2790] Add tests to cover deleting and copying failure

### DIFF
--- a/front/app/containers/Admin/projects/components/ProjectRow/ProjectMoreActionsMenu.test.tsx
+++ b/front/app/containers/Admin/projects/components/ProjectRow/ProjectMoreActionsMenu.test.tsx
@@ -68,8 +68,6 @@ describe('ProjectMoreActionsMenu', () => {
       name: 'Copy project',
     });
 
-    expect(copyProjectButton).toBeInTheDocument();
-
     await user.click(copyProjectButton);
 
     expect(setErrorFn).toHaveBeenLastCalledWith(

--- a/front/app/containers/Admin/projects/components/ProjectRow/ProjectMoreActionsMenu.test.tsx
+++ b/front/app/containers/Admin/projects/components/ProjectRow/ProjectMoreActionsMenu.test.tsx
@@ -45,7 +45,60 @@ jest.mock('hooks/useProject', () => {
   return jest.fn(() => mockProject);
 });
 
+jest.mock('services/projects', () =>
+  jest.fn(() => {
+    return {
+      copyProject: jest.fn().mockImplementation(() => Promise.reject()),
+      deleteProject: jest.fn().mockImplementation(() => Promise.reject()),
+    };
+  })
+);
+
 describe('ProjectMoreActionsMenu', () => {
+  it('calls setError with an error when copying fails', async () => {
+    const setErrorFn = jest.fn();
+    defaultProps.setError = setErrorFn;
+    render(<ProjectMoreActionsMenu {...defaultProps} />);
+    const user = userEvent.setup();
+
+    const threeDotsButton = screen.getByTestId('moreOptionsButton');
+    await user.click(threeDotsButton);
+
+    const copyProjectButton = await screen.findByRole('button', {
+      name: 'Copy project',
+    });
+
+    expect(copyProjectButton).toBeInTheDocument();
+
+    await user.click(copyProjectButton);
+
+    expect(setErrorFn).toHaveBeenLastCalledWith(
+      'There was an error copying this project, please try again later.'
+    );
+  });
+
+  it('calls setError with an error when deleting fails', async () => {
+    const setErrorFn = jest.fn();
+    defaultProps.setError = setErrorFn;
+    render(<ProjectMoreActionsMenu {...defaultProps} />);
+    const user = userEvent.setup();
+
+    const threeDotsButton = screen.getByTestId('moreOptionsButton');
+    await user.click(threeDotsButton);
+
+    const deleteProjectButton = await screen.findByRole('button', {
+      name: 'Delete project',
+    });
+
+    expect(deleteProjectButton).toBeInTheDocument();
+
+    await user.click(deleteProjectButton);
+
+    expect(setErrorFn).toHaveBeenLastCalledWith(
+      'There was an error deleting this project, please try again later.'
+    );
+  });
+
   describe('When user is an admin', () => {
     it('Has the buttons to copy and delete projects', async () => {
       render(<ProjectMoreActionsMenu {...defaultProps} />);

--- a/front/app/containers/Admin/projects/components/ProjectRow/ProjectMoreActionsMenu.test.tsx
+++ b/front/app/containers/Admin/projects/components/ProjectRow/ProjectMoreActionsMenu.test.tsx
@@ -57,8 +57,11 @@ jest.mock('services/projects', () =>
 describe('ProjectMoreActionsMenu', () => {
   it('calls setError with an error when copying fails', async () => {
     const setErrorFn = jest.fn();
-    defaultProps.setError = setErrorFn;
-    render(<ProjectMoreActionsMenu {...defaultProps} />);
+    const props: Props = {
+      projectId: 'projectId',
+      setError: setErrorFn,
+    };
+    render(<ProjectMoreActionsMenu {...props} />);
     const user = userEvent.setup();
 
     const threeDotsButton = screen.getByTestId('moreOptionsButton');

--- a/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/FolderMoreActionsMenu.test.tsx
+++ b/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/FolderMoreActionsMenu.test.tsx
@@ -43,8 +43,11 @@ jest.mock('services/projectFolders', () =>
 describe('FolderMoreActionsMenu', () => {
   it('calls setError with an error when deleting fails', async () => {
     const setErrorFn = jest.fn();
-    props.setError = setErrorFn;
-    render(<FolderMoreActionsMenu {...props} />);
+    const customProps: Props = {
+      folderId: 'folderId',
+      setError: setErrorFn,
+    };
+    render(<FolderMoreActionsMenu {...customProps} />);
     const user = userEvent.setup();
 
     const threeDotsButton = screen.getByTestId('moreOptionsButton');

--- a/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/FolderMoreActionsMenu.test.tsx
+++ b/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/FolderMoreActionsMenu.test.tsx
@@ -32,7 +32,34 @@ jest.mock('hooks/useAuthUser', () => {
   return () => mockUserData;
 });
 
+jest.mock('services/projectFolders', () =>
+  jest.fn(() => {
+    return {
+      deleteProjectFolder: jest.fn().mockImplementation(() => Promise.reject()),
+    };
+  })
+);
+
 describe('FolderMoreActionsMenu', () => {
+  it('calls setError with an error when deleting fails', async () => {
+    const setErrorFn = jest.fn();
+    props.setError = setErrorFn;
+    render(<FolderMoreActionsMenu {...props} />);
+    const user = userEvent.setup();
+
+    const threeDotsButton = screen.getByTestId('moreOptionsButton');
+    await user.click(threeDotsButton);
+
+    const deleteFolderButton = await screen.findByRole('button', {
+      name: 'Delete folder',
+    });
+    await user.click(deleteFolderButton);
+
+    expect(setErrorFn).toHaveBeenLastCalledWith(
+      'There was an issue removing this folder. Please try again.'
+    );
+  });
+
   describe('When user is an admin', () => {
     it('Has the folder delete button', async () => {
       render(<FolderMoreActionsMenu {...props} />);


### PR DESCRIPTION
Adds unit tests to cover deleting and copying failure.

I tried simulating a backend failure with `forceNetworkError` in cypress but that doesn't seem to be working. In the end the request is stubbed but cypress records no calls and the UI behaves as if no response was returned. It eventually times out and shows the error message but this is not the ideal flow. I saw some issues about this in Cypress issues so it needs to investigate separately

## How urgent is a code review?

End of day if possible
