### PR TITLE
[CL-1957] Simplify code for copying content builder layouts & images when copying project

### DIFF
--- a/back/engines/commercial/content_builder/app/services/content_builder/layout_service.rb
+++ b/back/engines/commercial/content_builder/app/services/content_builder/layout_service.rb
@@ -11,5 +11,19 @@ module ContentBuilder
     def craftjs_element_of_type?(elt, type)
       elt.is_a?(Hash) && elt['type'].is_a?(Hash) && elt.dig('type', 'resolvedName') == type
     end
+
+    def images(layout)
+      layout_image_codes = []
+
+      layout.craftjs_jsonmultiloc.each_key do |locale|
+        layout.craftjs_jsonmultiloc[locale].each_value do |node|
+          next unless craftjs_element_of_type?(node, 'Image')
+
+          layout_image_codes << node['props']['dataCode']
+        end
+      end
+
+      LayoutImage.where(code: layout_image_codes)
+    end
   end
 end


### PR DESCRIPTION
Bad idea  - this would undo our work to insert unique `:code` values for newly copied `layout_images`. But this could be solved more conventionally, for example with a `imageable_id` field in `layout_images`


I realised we can make use of the `@project` var to avoid our more complex approach to selecting only the `layout_images` used by the source project's `layouts`.

This also means our content builder related code looks and behaves far more conventionally, when compared to the existing code in the `ProjectCopyService`.