### PR TITLE
[CL-2922] Do not serialize orphaned text_images to templates

### DIFF
--- a/back/app/services/project_copy_service.rb
+++ b/back/app/services/project_copy_service.rb
@@ -216,8 +216,6 @@ class ProjectCopyService < ::TemplateService
   end
 
   def yml_projects(shift_timestamps: 0, new_slug: nil, new_title_multiloc: nil, new_publication_status: nil)
-    project_to_json = @project.to_json
-
     yml_project = yml_participation_context @project, shift_timestamps: shift_timestamps
     yml_project.merge!({
       'title_multiloc' => new_title_multiloc || @project.title_multiloc,
@@ -230,16 +228,15 @@ class ProjectCopyService < ::TemplateService
       'process_type' => @project.process_type,
       'admin_publication_attributes' =>
         { 'publication_status' => new_publication_status || @project.admin_publication.publication_status },
-      'text_images_attributes' =>
-        @project.text_images.select { |ti| project_to_json.include?(ti.text_reference) }.map do |ti|
-          {
-            'imageable_field' => ti.imageable_field,
-            'remote_image_url' => ti.image_url,
-            'text_reference' => ti.text_reference,
-            'created_at' => ti.created_at.to_s,
-            'updated_at' => ti.updated_at.to_s
-          }
-        end,
+      'text_images_attributes' => filter_text_images(@project).map do |ti|
+        {
+          'imageable_field' => ti.imageable_field,
+          'remote_image_url' => ti.image_url,
+          'text_reference' => ti.text_reference,
+          'created_at' => ti.created_at.to_s,
+          'updated_at' => ti.updated_at.to_s
+        }
+      end,
       'include_all_areas' => @project.include_all_areas
     })
     yml_project['slug'] = new_slug if new_slug.present?

--- a/back/app/services/project_copy_service.rb
+++ b/back/app/services/project_copy_service.rb
@@ -228,7 +228,7 @@ class ProjectCopyService < ::TemplateService
       'process_type' => @project.process_type,
       'admin_publication_attributes' =>
         { 'publication_status' => new_publication_status || @project.admin_publication.publication_status },
-      'text_images_attributes' => filter_text_images(@project).map do |ti|
+      'text_images_attributes' => current_text_images(@project).map do |ti|
         {
           'imageable_field' => ti.imageable_field,
           'remote_image_url' => ti.image_url,
@@ -284,7 +284,7 @@ class ProjectCopyService < ::TemplateService
         'end_at' => shift_timestamp(phase.end_at, shift_timestamps, leave_blank: false)&.iso8601,
         'created_at' => shift_timestamp(phase.created_at, shift_timestamps)&.iso8601,
         'updated_at' => shift_timestamp(phase.updated_at, shift_timestamps)&.iso8601,
-        'text_images_attributes' => phase.text_images.map do |ti|
+        'text_images_attributes' => current_text_images(phase).map do |ti|
           {
             'imageable_field' => ti.imageable_field,
             'remote_image_url' => ti.image_url,
@@ -535,7 +535,7 @@ class ProjectCopyService < ::TemplateService
         'location_description' => idea.location_description,
         'budget' => idea.budget,
         'proposed_budget' => idea.proposed_budget,
-        'text_images_attributes' => idea.text_images.map do |text_image|
+        'text_images_attributes' => current_text_images(idea).map do |text_image|
           {
             'imageable_field' => text_image.imageable_field,
             'remote_image_url' => text_image.image_url,

--- a/back/app/services/template_service.rb
+++ b/back/app/services/template_service.rb
@@ -33,4 +33,10 @@ class TemplateService
     end
     custom_field_values.slice(*supported_fields.map(&:key))
   end
+
+  def filter_text_images(parent)
+    parent_to_json = parent.to_json
+
+    parent.text_images.select { |ti| parent_to_json.include?(ti.text_reference) }
+  end
 end

--- a/back/app/services/template_service.rb
+++ b/back/app/services/template_service.rb
@@ -34,7 +34,7 @@ class TemplateService
     custom_field_values.slice(*supported_fields.map(&:key))
   end
 
-  def filter_text_images(parent)
+  def current_text_images(parent)
     parent_to_json = parent.to_json
 
     parent.text_images.select { |ti| parent_to_json.include?(ti.text_reference) }

--- a/back/app/services/template_service.rb
+++ b/back/app/services/template_service.rb
@@ -35,8 +35,6 @@ class TemplateService
   end
 
   def current_text_images(parent)
-    parent_to_json = parent.to_json
-
-    parent.text_images.select { |ti| parent_to_json.include?(ti.text_reference) }
+    parent.text_images.select { |ti| parent.to_json.include?(ti.text_reference) }
   end
 end

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializer.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializer.rb
@@ -313,6 +313,8 @@ module MultiTenancy
 
       def yml_projects
         Project.all.map do |p|
+          project_to_json = p.to_json
+
           yml_project = yml_participation_context p
           yml_project.merge!({
             'title_multiloc' => p.title_multiloc,
@@ -326,15 +328,16 @@ module MultiTenancy
             'description_preview_multiloc' => p.description_preview_multiloc,
             'process_type' => p.process_type,
             'internal_role' => p.internal_role,
-            'text_images_attributes' => p.text_images.map do |ti|
-              {
-                'imageable_field' => ti.imageable_field,
-                'remote_image_url' => ti.image_url,
-                'text_reference' => ti.text_reference,
-                'created_at' => ti.created_at.to_s,
-                'updated_at' => ti.updated_at.to_s
-              }
-            end,
+            'text_images_attributes' =>
+              p.text_images.select { |ti| project_to_json.include?(ti.text_reference) }.map do |ti|
+                {
+                  'imageable_field' => ti.imageable_field,
+                  'remote_image_url' => ti.image_url,
+                  'text_reference' => ti.text_reference,
+                  'created_at' => ti.created_at.to_s,
+                  'updated_at' => ti.updated_at.to_s
+                }
+              end,
             'include_all_areas' => p.include_all_areas
           })
           if p.admin_publication.present?

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializer.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializer.rb
@@ -313,8 +313,6 @@ module MultiTenancy
 
       def yml_projects
         Project.all.map do |p|
-          project_to_json = p.to_json
-
           yml_project = yml_participation_context p
           yml_project.merge!({
             'title_multiloc' => p.title_multiloc,
@@ -328,16 +326,15 @@ module MultiTenancy
             'description_preview_multiloc' => p.description_preview_multiloc,
             'process_type' => p.process_type,
             'internal_role' => p.internal_role,
-            'text_images_attributes' =>
-              p.text_images.select { |ti| project_to_json.include?(ti.text_reference) }.map do |ti|
-                {
-                  'imageable_field' => ti.imageable_field,
-                  'remote_image_url' => ti.image_url,
-                  'text_reference' => ti.text_reference,
-                  'created_at' => ti.created_at.to_s,
-                  'updated_at' => ti.updated_at.to_s
-                }
-              end,
+            'text_images_attributes' => filter_text_images(p).map do |ti|
+              {
+                'imageable_field' => ti.imageable_field,
+                'remote_image_url' => ti.image_url,
+                'text_reference' => ti.text_reference,
+                'created_at' => ti.created_at.to_s,
+                'updated_at' => ti.updated_at.to_s
+              }
+            end,
             'include_all_areas' => p.include_all_areas
           })
           if p.admin_publication.present?

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializer.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializer.rb
@@ -326,7 +326,7 @@ module MultiTenancy
             'description_preview_multiloc' => p.description_preview_multiloc,
             'process_type' => p.process_type,
             'internal_role' => p.internal_role,
-            'text_images_attributes' => filter_text_images(p).map do |ti|
+            'text_images_attributes' => current_text_images(p).map do |ti|
               {
                 'imageable_field' => ti.imageable_field,
                 'remote_image_url' => ti.image_url,
@@ -399,7 +399,7 @@ module MultiTenancy
             'input_term' => p.input_term,
             'created_at' => p.created_at.to_s,
             'updated_at' => p.updated_at.to_s,
-            'text_images_attributes' => p.text_images.map do |ti|
+            'text_images_attributes' => current_text_images(p).map do |ti|
               {
                 'imageable_field' => ti.imageable_field,
                 'remote_image_url' => ti.image_url,
@@ -717,7 +717,7 @@ module MultiTenancy
             'idea_status_ref' => lookup_ref(idea.idea_status_id, :idea_status),
             'budget' => idea.budget,
             'proposed_budget' => idea.proposed_budget,
-            'text_images_attributes' => idea.text_images.map do |img|
+            'text_images_attributes' => current_text_images(idea).map do |img|
               {
                 'imageable_field' => img.imageable_field,
                 'remote_image_url' => img.image_url,

--- a/back/engines/commercial/multi_tenancy/spec/services/multi_tenancy/templates/serializer_spec.rb
+++ b/back/engines/commercial/multi_tenancy/spec/services/multi_tenancy/templates/serializer_spec.rb
@@ -248,6 +248,48 @@ describe MultiTenancy::Templates::Serializer do
         expect(template['models']['project'].first['text_images_attributes'].size).to eq 1
         expect(template['models']['project'].first['text_images_attributes'].first['text_reference']).to eq(text_ref)
       end
+
+      it 'does not serialize orphaned text_images associated with phase' do
+        phase = create(
+          :phase,
+          description_multiloc: { en: "<img data-cl2-text-image-text-reference=\"#{text_ref}\">" }
+        )
+        images = create_list(
+          :text_image,
+          2,
+          imageable_id: phase.id,
+          imageable_type: 'Phase',
+          imageable_field: 'description_multiloc'
+        )
+        images[0].update(text_reference: text_ref)
+
+        serializer = described_class.new Tenant.current
+        template = serializer.run
+
+        expect(template['models']['phase'].first['text_images_attributes'].size).to eq 1
+        expect(template['models']['phase'].first['text_images_attributes'].first['text_reference']).to eq(text_ref)
+      end
+
+      it 'does not serialize orphaned text_images associated with idea' do
+        idea = create(
+          :idea,
+          body_multiloc: { en: "<img data-cl2-text-image-text-reference=\"#{text_ref}\">" }
+        )
+        images = create_list(
+          :text_image,
+          2,
+          imageable_id: idea.id,
+          imageable_type: 'Idea',
+          imageable_field: 'body_multiloc'
+        )
+        images[0].update(text_reference: text_ref)
+
+        serializer = described_class.new Tenant.current
+        template = serializer.run
+
+        expect(template['models']['idea'].first['text_images_attributes'].size).to eq 1
+        expect(template['models']['idea'].first['text_images_attributes'].first['text_reference']).to eq(text_ref)
+      end
     end
   end
 end


### PR DESCRIPTION
CLOSED: This will work, and is a useful idea to have in reserve, but on balance Alex & I feel that a job (perhaps nightly) to clean up such orphaned images is sufficient, in PR https://github.com/CitizenLabDotCo/citizenlab/pull/3928, especially as orphaned images no longer impact perfomance of LocalProjecCopyService following https://github.com/CitizenLabDotCo/citizenlab/pull/4036.

This is probably a bad idea. We should probably fix underlying issue, which is NOT that FE is re-encoding images to base64 every time a multiloc is updated (tested on production). I'll investigate and create a ticket for this.

model _________________________ field(s) that can reference `text_images`

`ProjectCopyService` & `serializer`:

- [ ] custom_fields ______________ description_multiloc - (for survey 'page')  
- [ ] events ____________________ description_multiloc
- [x] ideas ______________________ body_multiloc
- [x] phases ____________________ description_multiloc
- [x] projects ___________________ description_multiloc  - DONE for `ProjectCopyService`
- [ ] volunteering_causes_________ description_multiloc

`serializer` only:

- [ ] home_pages _______________ top_info_section_multiloc / bottom_info_section_multiloc
- [ ] email_campaigns_campaigns _ body_multiloc - (theoretically, I guess)
- [ ] initiatives __________________ body_multiloc
- [ ] static_pages _______________ top_info_section_multiloc / bottom_info_section_multiloc
- [ ] project_folders_folders ______ description_multiloc

Note: Technically, `areas` can have base64 images in their `description_multiloc`, but this doesn't seem to lead to the creation of `text_images` and I think it might just be a mistake (see [CL-2928](https://citizenlab.atlassian.net/browse/CL-2928))

[CL-2928]: https://citizenlab.atlassian.net/browse/CL-2928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ