### PR TITLE
[CL-2913] Parallelize migrations

### DIFF
--- a/back/lib/gem_extensions/active_record/connection_adapters/abstract_adapter.rb
+++ b/back/lib/gem_extensions/active_record/connection_adapters/abstract_adapter.rb
@@ -4,7 +4,15 @@ module GemExtensions
   module ActiveRecord
     module ConnectionAdapters
       module AbstractAdapter
-        def generate_advisory_lock_id; end
+        def generate_advisory_lock_id
+          # Each connection adapter must provide its own implementation.
+          # For instance, this could look like to:
+          #   def generate_advisory_lock_id
+          #     db_name_hash = Zlib.crc32(current_database)
+          #     Migrator::MIGRATOR_SALT * db_name_hash
+          #   end
+          raise NotImplementedError
+        end
       end
     end
   end

--- a/back/lib/gem_extensions/active_record/connection_adapters/abstract_adapter.rb
+++ b/back/lib/gem_extensions/active_record/connection_adapters/abstract_adapter.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module GemExtensions
+  module ActiveRecord
+    module ConnectionAdapters
+      module AbstractAdapter
+        def generate_advisory_lock_id; end
+      end
+    end
+  end
+end

--- a/back/lib/gem_extensions/active_record/connection_adapters/postgre_sql_adapter.rb
+++ b/back/lib/gem_extensions/active_record/connection_adapters/postgre_sql_adapter.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'zlib'
+
+module GemExtensions
+  module ActiveRecord
+    module ConnectionAdapters
+      module PostgreSqlAdapter
+        def generate_advisory_lock_id
+          db_name_hash = Zlib.crc32("#{current_schema}:#{current_database}")
+          ::ActiveRecord::Migrator::MIGRATOR_SALT * db_name_hash
+        end
+      end
+    end
+  end
+end

--- a/back/lib/gem_extensions/active_record/migrator.rb
+++ b/back/lib/gem_extensions/active_record/migrator.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module GemExtensions
+  module ActiveRecord
+    module Migrator
+      def generate_migrator_advisory_lock_id
+        ::ActiveRecord::Base.connection.generate_advisory_lock_id
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request patches ActiveRecord to allow parallel execution of migrations that modify different postgres schemas.

# Next steps
- [ ] test on staging
- [ ] test on production
- [ ] increase instance size (CircleCI) on production
- [ ] Create new tickets for the remaining strategies described in the Jira ticket