### PR TITLE
[CL-2539] Use image files on s3 for anonymized user initials_avatars 

### DIFF
--- a/back/app/services/anonymize_user_service.rb
+++ b/back/app/services/anonymize_user_service.rb
@@ -161,26 +161,18 @@ class AnonymizeUserService
   end
 
   def random_avatar_assignment(first_name, last_name, gender)
+    initials_avatars_url =
+      'https://cl2-seed-and-template-assets.s3.eu-central-1.amazonaws.com/images/avatars/initials_avatars/'
     gender = mismatch_gender(gender) if rand(30) == 0
+
     if rand(5) == 0
       { 'remote_avatar_url' => random_face_avatar_url(gender) }
     else
-      { 'avatar' => random_initials_avatar_base64(first_name, last_name) }
+      { 'remote_avatar_url' => "#{initials_avatars_url}#{first_name[0]}#{last_name[0]}_avatar.png".downcase }
     end
   rescue StandardError => e
     ErrorReporter.report e
     {}
-  end
-
-  def random_initials_avatar_base64(first_name, last_name)
-    name_param = I18n.transliterate "#{first_name}+#{last_name}" # Convert to all ASCII chars
-    uri = URI "https://eu.ui-avatars.com/api/?name=#{name_param}"
-    res = Net::HTTP.get_response uri
-    unless res.is_a?(Net::HTTPSuccess)
-      raise "API request to eu.ui-avatars.com failed. Code: #{res.code}. Body: #{res.body}."
-    end
-
-    "data:image/png;base64,#{Base64.encode64 res.body}"
   end
 
   def random_face_avatar_url(gender)

--- a/back/app/services/anonymize_user_service.rb
+++ b/back/app/services/anonymize_user_service.rb
@@ -57,6 +57,8 @@ class AnonymizeUserService
     @avatars = load_csv 'avatars.csv'
     @male_avatars = @avatars.select { |d| d['gender'] == 'male' }
     @female_avatars = @avatars.select { |d| d['gender'] == 'female' }
+    @initials_avatars_url =
+      'https://cl2-seed-and-template-assets.s3.eu-central-1.amazonaws.com/images/avatars/initials_avatars/'
   end
 
   def load_csv(filename)
@@ -161,14 +163,12 @@ class AnonymizeUserService
   end
 
   def random_avatar_assignment(first_name, last_name, gender)
-    initials_avatars_url =
-      'https://cl2-seed-and-template-assets.s3.eu-central-1.amazonaws.com/images/avatars/initials_avatars/'
     gender = mismatch_gender(gender) if rand(30) == 0
 
     if rand(5) == 0
       { 'remote_avatar_url' => random_face_avatar_url(gender) }
     else
-      { 'remote_avatar_url' => "#{initials_avatars_url}#{first_name[0]}#{last_name[0]}_avatar.png".downcase }
+      { 'remote_avatar_url' => "#{@initials_avatars_url}#{(first_name[0] + last_name[0]).downcase}_avatar.png" }
     end
   rescue StandardError => e
     ErrorReporter.report e


### PR DESCRIPTION
## Problem

Currently, copying a large project with lots of user participation items, using the Project Copy Tool & including participation items, the user avatars that use the initials of the anonymized user will be created by hitting an API that creates such images and then base64 encoding the responses and writing the base64 strings to the template.

This process can make template export significantly slower than it would otherwise be. For example, when exporting the 'Leuven, maak het mee!' project, from https://participatie.leuven.be/nl-BE/, (with user participation included & user anonymization by default), locally, this takes approx. 7 minutes. (approx: 2700 users participated, 4500 participatory items; ideas, comments, etc.)

## Solution

Instead of hitting an API that produces each avatar with initials, we store all possible initials avatars on s3 (a..z, a..z = 26 * 26 = 676 PNG files), and simply insert the URLs of the desired avatar image files into the exported template. Since we know what `first_name` and `last_name` values we might use, we can be sure we only use non-accented Roman characters.

I wrote a Ruby script to download all possible two-character initials avatars, and then uploaded them all to our `cl2-seed-and-template-assets` s3 bucket, into a new `images/avatars/initials_avatars/` folder:

<img width="1230" alt="Screenshot 2023-02-25 at 17 38 41" src="https://user-images.githubusercontent.com/3944042/221376059-5a0207e1-d3cf-4f85-a940-7e851727bfe1.png">

Now, we can simply set the appropriate s3 URL value for any initials avatar we require.

Testing locally, this produces the expected order of magnitude improvement:

<img width="1097" alt="Screenshot 2023-02-25 at 19 44 17" src="https://user-images.githubusercontent.com/3944042/221376593-d101697e-fb19-4879-9332-c21e47ebecb9.png">

And produces appropriate avatars, for example:

<img width="652" alt="Screenshot 2023-02-25 at 19 59 55" src="https://user-images.githubusercontent.com/3944042/221377146-e5fa532d-3fa6-4966-abac-31b289f01abd.png">

## What about importing the template(s)?

This optimization only improves the performance of _exporting_ a template when users are anonymized. It does not improve performance when importing such a template.

When importing, the avatar images  will still be processed by Carrierwave, and then the multiple image file versions produced will be uploaded. We should also optimize this, using @alexander-cit's [optimization](https://github.com/CitizenLabDotCo/citizenlab/pull/4036) (and do likewise for any other image file-type processed by template import/application).