### PR TITLE
[CL-2910] Parallelize front-end tests (CircleCI)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -483,6 +483,18 @@ jobs:
   front-test:
     docker:
       - image: citizenlabdotco/cl2-devops-front-buildenv
+    # If you modify the resource_class, ensure that you also adjust the number of
+    # workers utilized by `npm run test:ci` (in package.json) to correspond with the
+    # number of vCPUs available for this instance class.
+    #
+    # Note: when running tests in parallel with Jest, the number of workers must
+    # be specified explicitly. Otherwise, Jest attempts to use all available resources
+    # of the machine instead of restricting itself to the test virtual environment.
+    # See:
+    # - https://circleci.com/docs/collect-test-data/#jest
+    # - https://github.com/facebook/jest/issues/1524#issuecomment-262366820
+    # - https://github.com/facebook/jest/issues/5239#issuecomment-355867359
+    resource_class: medium+
     working_directory: ~/
     environment:
       CITIZENLAB_EE: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -486,7 +486,7 @@ jobs:
     working_directory: ~/
     environment:
       CITIZENLAB_EE: true
-    parallelism: 2
+    parallelism: 4
     steps:
       - checkout:
           path: ./citizenlab

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -486,6 +486,7 @@ jobs:
     working_directory: ~/
     environment:
       CITIZENLAB_EE: true
+    parallelism: 2
     steps:
       - checkout:
           path: ./citizenlab
@@ -501,7 +502,11 @@ jobs:
           key: v1-npm-cache-{{ checksum "citizenlab/front/package.json" }}
       - run:
           name: Run tests with JUnit as reporter
-          command: cd citizenlab/front && npm run test:ci
+          command: |
+            cd citizenlab/front
+            TEST_FILES=$(circleci tests glob '**/*.test.{ts,tsx}' | circleci tests split --split-by=timings)
+            echo $TEST_FILES
+            npm run test:ci -- $TEST_FILES
           environment:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:

--- a/front/package.json
+++ b/front/package.json
@@ -28,7 +28,7 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "test:update-snapshots": "jest --updateSnapshot",
-    "test:ci": "jest --ci --reporters=default --reporters=jest-junit --runInBand --coverage --coverageReporters=text-summary --",
+    "test:ci": "jest --ci --reporters=default --reporters=jest-junit -w 2 --coverage --coverageReporters=text-summary --",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run --spec 'cypress/e2e/**/*.ts' --browser chrome",
     "majestic": "majestic --port 4231",

--- a/front/package.json
+++ b/front/package.json
@@ -28,7 +28,7 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "test:update-snapshots": "jest --updateSnapshot",
-    "test:ci": "jest --ci --reporters=default --reporters=jest-junit -w 2 --coverage --coverageReporters=text-summary --",
+    "test:ci": "jest --ci --reporters=default --reporters=jest-junit -w 3 --coverage --coverageReporters=text-summary --",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run --spec 'cypress/e2e/**/*.ts' --browser chrome",
     "majestic": "majestic --port 4231",

--- a/front/package.json
+++ b/front/package.json
@@ -28,7 +28,7 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "test:update-snapshots": "jest --updateSnapshot",
-    "test:ci": "jest --ci --reporters=default --reporters=jest-junit --runInBand --coverage --coverageReporters=text-summary",
+    "test:ci": "jest --ci --reporters=default --reporters=jest-junit --runInBand --coverage --coverageReporters=text-summary --",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run --spec 'cypress/e2e/**/*.ts' --browser chrome",
     "majestic": "majestic --port 4231",

--- a/front/package.json
+++ b/front/package.json
@@ -37,6 +37,9 @@
     "lint:eslint": "eslint --ext .js,.jsx,.ts,.tsx app --color --max-warnings=0 --fix",
     "detect-deadcode": "ts-prune -p app/tsconfig.json -i '(node_modules|utils/testUtils/rtl.tsx|services/permissions|i18n|/*/*/__mocks__)' | (! grep -v 'used in module')"
   },
+  "jest-junit": {
+    "addFileAttribute": "true"
+  },
   "majestic": {
     "jestScriptPath": "node_modules/jest/bin/jest.js"
   },


### PR DESCRIPTION
This PR speeds up the tests by parallelizing them in two ways:
- It splits the tests among several CircleCI instances (4 like the back-end — this way, no one gets jealous 🙂).
- It leverages the multiple (virtual) CPUs of each instance by substituting the `--runInBand` option, used by Jest, with the `--maxWorkers` (`-w`) option.

I know we had some issues in the past when removing the `--runInBand`, but I hope we can make this work this time 🤞 

With those changes, tests now run in less than 4min. (The current 95th percentile duration is 12min — could not put my hands on the average duration.)

