### PR TITLE
Fix bug with view survey results page

### DIFF
--- a/front/app/containers/Admin/projects/project/nativeSurvey/FormResults/FormResultsQuestion.tsx
+++ b/front/app/containers/Admin/projects/project/nativeSurvey/FormResults/FormResultsQuestion.tsx
@@ -37,7 +37,8 @@ const FormResultsQuestion = ({
 }: FormResultsQuestionProps) => {
   const { formatMessage } = useIntl();
 
-  const inputTypeText = get(messages, inputType, '');
+  // TODO: Replace hardcoded '2' here. Urgent to relese to fix bug though right now.
+  const inputTypeText = get(messages, inputType.concat('2'), '');
   const requiredOrOptionalText = required
     ? formatMessage(messages.required2)
     : formatMessage(messages.optional2);


### PR DESCRIPTION
Fixes bug with view survey results page. Looks like there was a function that used input_types to match to correct messages in the messages file, but when the message keys were updated this broke.

I've updated it to use a "2" suffix so it works, but maybe there is maybe a better solution? It's fairly urgent to fix though, so maybe we can merge this now and add a ticket to replace it after platform week? :thinking: 


## How urgent is a code review?
As soon as possible