### PR TITLE
[CL-2908] Reduce n of docs generated from acceptance tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,7 +257,7 @@ jobs:
           at: /tmp/workspace
       - run: rake templates:release['/tmp/workspace/failed-templates.txt']
 
-  back-web-api-docs-not-blocking:
+  back-web-api-docs:
     resource_class: small
     executor:
       name: cl2-back
@@ -709,7 +709,7 @@ workflows:
             - citizenlab-ee-environment
           requires:
             - back-build-docker-image
-      - back-web-api-docs-not-blocking:
+      - back-web-api-docs:
           context:
             - docker-hub-access
             - citizenlab-ee-environment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,7 +257,7 @@ jobs:
           at: /tmp/workspace
       - run: rake templates:release['/tmp/workspace/failed-templates.txt']
 
-  back-web-api-docs:
+  back-web-api-docs-not-blocking:
     resource_class: small
     executor:
       name: cl2-back
@@ -709,7 +709,7 @@ workflows:
             - citizenlab-ee-environment
           requires:
             - back-build-docker-image
-      - back-web-api-docs:
+      - back-web-api-docs-not-blocking:
           context:
             - docker-hub-access
             - citizenlab-ee-environment

--- a/back/engines/commercial/admin_api/spec/acceptance/tenants_spec.rb
+++ b/back/engines/commercial/admin_api/spec/acceptance/tenants_spec.rb
@@ -152,7 +152,8 @@ resource 'Tenants', admin_api: true do
   end
 
   delete 'admin_api/tenants/:tenant_id' do
-    example_request 'Deleting a tenant', document: false do
+    example 'Deleting a tenant', document: false do
+      do_request
       assert_status 200
       expect(tenant.reload.deleted_at).not_to be_nil
     end

--- a/back/engines/commercial/custom_idea_statuses/spec/acceptance/idea_statuses_spec.rb
+++ b/back/engines/commercial/custom_idea_statuses/spec/acceptance/idea_statuses_spec.rb
@@ -28,10 +28,12 @@ resource 'IdeaStatuses' do
       let(:color) { idea_status.color }
       let(:ordering) { 2 }
 
+      # rubocop:disable RSpec/RepeatedExample
       example 'Cannot create an idea status', document: false do
         do_request
         expect(status).to eq 401
       end
+      # rubocop:enable RSpec/RepeatedExample
     end
 
     patch 'web_api/v1/idea_statuses/:id' do
@@ -52,19 +54,22 @@ resource 'IdeaStatuses' do
       let(:color) { new_idea_status.color }
       let(:ordering) { 1 }
 
+      # rubocop:disable RSpec/RepeatedExample
       example 'Cannot update an idea status by id', document: false do
         do_request
         expect(status).to eq 401
       end
+      # rubocop:enable RSpec/RepeatedExample
     end
 
     delete 'web_api/v1/idea_statuses/:id' do
       let(:id) { @statuses.first.id }
-
+      # rubocop:disable RSpec/RepeatedExample
       example 'Cannot delete a idea status by id', document: false do
         do_request
         expect(status).to eq 401
       end
+      # rubocop:enable RSpec/RepeatedExample
     end
   end
 
@@ -87,10 +92,12 @@ resource 'IdeaStatuses' do
       let(:color) { idea_status.color }
       let(:ordering) { 2 }
 
+      # rubocop:disable RSpec/RepeatedExample
       example 'Cannot create an idea status', document: false do
         do_request
         expect(status).to eq 401
       end
+      # rubocop:enable RSpec/RepeatedExample
     end
 
     patch 'web_api/v1/idea_statuses/:id' do
@@ -111,19 +118,23 @@ resource 'IdeaStatuses' do
       let(:color) { new_idea_status.color }
       let(:ordering) { 1 }
 
+      # rubocop:disable RSpec/RepeatedExample
       example 'Cannot update an idea status by id', document: false do
         do_request
         expect(status).to eq 401
       end
+      # rubocop:enable RSpec/RepeatedExample
     end
 
     delete 'web_api/v1/idea_statuses/:id' do
       let(:id) { @statuses.first.id }
 
+      # rubocop:disable RSpec/RepeatedExample
       example 'Cannot delete a idea status by id', document: false do
         do_request
         expect(status).to eq 401
       end
+      # rubocop:enable RSpec/RepeatedExample
     end
   end
 

--- a/back/engines/commercial/custom_idea_statuses/spec/acceptance/idea_statuses_spec.rb
+++ b/back/engines/commercial/custom_idea_statuses/spec/acceptance/idea_statuses_spec.rb
@@ -28,7 +28,8 @@ resource 'IdeaStatuses' do
       let(:color) { idea_status.color }
       let(:ordering) { 2 }
 
-      example_request 'Cannot create an idea status', document: false do
+      example 'Cannot create an idea status', document: false do
+        do_request
         expect(status).to eq 401
       end
     end
@@ -51,7 +52,8 @@ resource 'IdeaStatuses' do
       let(:color) { new_idea_status.color }
       let(:ordering) { 1 }
 
-      example_request 'Cannot update an idea status by id', document: false do
+      example 'Cannot update an idea status by id', document: false do
+        do_request
         expect(status).to eq 401
       end
     end
@@ -59,7 +61,8 @@ resource 'IdeaStatuses' do
     delete 'web_api/v1/idea_statuses/:id' do
       let(:id) { @statuses.first.id }
 
-      example_request 'Cannot delete a idea status by id', document: false do
+      example 'Cannot delete a idea status by id', document: false do
+        do_request
         expect(status).to eq 401
       end
     end
@@ -84,7 +87,8 @@ resource 'IdeaStatuses' do
       let(:color) { idea_status.color }
       let(:ordering) { 2 }
 
-      example_request 'Cannot create an idea status', document: false do
+      example 'Cannot create an idea status', document: false do
+        do_request
         expect(status).to eq 401
       end
     end
@@ -107,7 +111,8 @@ resource 'IdeaStatuses' do
       let(:color) { new_idea_status.color }
       let(:ordering) { 1 }
 
-      example_request 'Cannot update an idea status by id', document: false do
+      example 'Cannot update an idea status by id', document: false do
+        do_request
         expect(status).to eq 401
       end
     end
@@ -115,7 +120,8 @@ resource 'IdeaStatuses' do
     delete 'web_api/v1/idea_statuses/:id' do
       let(:id) { @statuses.first.id }
 
-      example_request 'Cannot delete a idea status by id', document: false do
+      example 'Cannot delete a idea status by id', document: false do
+        do_request
         expect(status).to eq 401
       end
     end

--- a/back/engines/commercial/flag_inappropriate_content/spec/acceptance/spam_reports_spec.rb
+++ b/back/engines/commercial/flag_inappropriate_content/spec/acceptance/spam_reports_spec.rb
@@ -25,7 +25,8 @@ resource 'Spam Reports' do
     describe do
       before { idea.inappropriate_content_flag&.destroy! }
 
-      example_request 'A new flag is created when spam is reported', document: false do
+      example 'A new flag is created when spam is reported', document: false do
+        do_request
         expect(response_status).to eq 201
         expect(idea.reload.inappropriate_content_flag).to be_present
       end

--- a/back/engines/commercial/insights/spec/acceptance/categories_spec.rb
+++ b/back/engines/commercial/insights/spec/acceptance/categories_spec.rb
@@ -12,13 +12,19 @@ resource 'Categories' do
 
   shared_examples 'unauthorized requests' do
     context 'when visitor' do
-      example_request('unauthorized', document: false) { expect(status).to eq(401) }
+      example 'unauthorized', document: false do
+        do_request
+        expect(status).to eq(401)
+      end
     end
 
     context 'when resident' do
       before { resident_header_token }
 
-      example_request('unauthorized', document: false) { expect(status).to eq(401) }
+      example 'unauthorized', document: false do
+        do_request
+        expect(status).to eq(401)
+      end
     end
   end
 
@@ -26,7 +32,8 @@ resource 'Categories' do
     context 'when name is empty' do
       let(:name) { '' }
 
-      example_request 'returns unprocessable-entity error', document: false do
+      example 'returns unprocessable-entity error', document: false do
+        do_request
         assert_status 422
       end
     end

--- a/back/engines/commercial/insights/spec/acceptance/category_assignments_spec.rb
+++ b/back/engines/commercial/insights/spec/acceptance/category_assignments_spec.rb
@@ -15,13 +15,19 @@ resource 'Category suggestions for view inputs' do
 
   shared_examples 'unauthorized requests' do
     context 'when visitor' do
-      example_request('unauthorized', document: false) { expect(status).to eq(401) }
+      example 'unauthorized', document: false do
+        do_request
+        expect(status).to eq(401)
+      end
     end
 
     context 'when resident' do
       before { resident_header_token }
 
-      example_request('unauthorized', document: false) { expect(status).to eq(401) }
+      example 'unauthorized', document: false do
+        do_request
+        expect(status).to eq(401)
+      end
     end
   end
 

--- a/back/engines/commercial/insights/spec/acceptance/category_suggestions_spec.rb
+++ b/back/engines/commercial/insights/spec/acceptance/category_suggestions_spec.rb
@@ -16,13 +16,19 @@ resource 'Category suggestions for view inputs' do
 
   shared_examples 'unauthorized requests' do
     context 'when visitor' do
-      example_request('unauthorized', document: false) { expect(status).to eq(401) }
+      example 'unauthorized', document: false do
+        do_request
+        expect(status).to eq(401)
+      end
     end
 
     context 'when resident' do
       before { resident_header_token }
 
-      example_request('unauthorized', document: false) { expect(status).to eq(401) }
+      example 'unauthorized', document: false do
+        do_request
+        expect(status).to eq(401)
+      end
     end
   end
 

--- a/back/engines/commercial/insights/spec/acceptance/inputs_spec.rb
+++ b/back/engines/commercial/insights/spec/acceptance/inputs_spec.rb
@@ -12,13 +12,19 @@ resource 'Inputs' do
 
   shared_examples 'unauthorized requests' do
     context 'when visitor' do
-      example_request('unauthorized', document: false) { expect(status).to eq(401) }
+      example 'unauthorized', document: false do
+        do_request
+        expect(status).to eq(401)
+      end
     end
 
     context 'when resident' do
       before { resident_header_token }
 
-      example_request('unauthorized', document: false) { expect(status).to eq(401) }
+      example 'unauthorized', document: false do
+        do_request
+        expect(status).to eq(401)
+      end
     end
   end
 

--- a/back/engines/commercial/insights/spec/acceptance/stats_inputs_spec.rb
+++ b/back/engines/commercial/insights/spec/acceptance/stats_inputs_spec.rb
@@ -14,13 +14,19 @@ resource 'Stats - Inputs' do
 
   shared_examples 'unauthorized requests' do
     context 'when visitor' do
-      example_request('unauthorized', document: false) { expect(status).to eq(401) }
+      example 'unauthorized', document: false do
+        do_request
+        expect(status).to eq(401)
+      end
     end
 
     context 'when resident' do
       before { resident_header_token }
 
-      example_request('unauthorized', document: false) { expect(status).to eq(401) }
+      example 'unauthorized', document: false do
+        do_request
+        expect(status).to eq(401)
+      end
     end
   end
 

--- a/back/engines/commercial/insights/spec/acceptance/views_spec.rb
+++ b/back/engines/commercial/insights/spec/acceptance/views_spec.rb
@@ -39,7 +39,8 @@ resource 'Views' do
     context 'when name is empty' do
       let(:name) { '' }
 
-      example_request 'returns unprocessable-entity error', document: false do
+      example 'returns unprocessable-entity error', document: false do
+        do_request
         assert_status 422
       end
     end

--- a/back/engines/commercial/user_custom_fields/spec/acceptance/user_custom_field_options_spec.rb
+++ b/back/engines/commercial/user_custom_fields/spec/acceptance/user_custom_field_options_spec.rb
@@ -70,7 +70,8 @@ resource 'User Custom Field Options' do
         let(:key) { 'No spaces allowed' }
         let(:title_multiloc) { { 'en' => '' } }
 
-        example_request '[error] Create an invalid custom field option', document: false do
+        example '[error] Create an invalid custom field option', document: false do
+          do_request
           assert_status 422
           json_response = json_parse response_body
           expect(json_response).to include_response_error(:key, 'invalid', value: key)

--- a/back/engines/commercial/user_custom_fields/spec/acceptance/user_custom_fields_spec.rb
+++ b/back/engines/commercial/user_custom_fields/spec/acceptance/user_custom_fields_spec.rb
@@ -169,7 +169,8 @@ resource 'User Custom Fields' do
         let(:key) { 'No spaces allowed' }
         let(:title_multiloc) { { 'en' => '' } }
 
-        example_request '[error] Create an invalid custom field', document: false do
+        example '[error] Create an invalid custom field', document: false do
+          do_request
           assert_status 422
           json_response = json_parse response_body
           expect(json_response).to include_response_error(:key, 'invalid', value: key)

--- a/back/engines/free/email_campaigns/spec/acceptance/campaigns_spec.rb
+++ b/back/engines/free/email_campaigns/spec/acceptance/campaigns_spec.rb
@@ -192,7 +192,7 @@ resource 'Campaigns' do
       )
     end
 
-    example_request 'Get the delivery statistics of a sent campaing' do
+    example_request 'Get the delivery statistics of a sent campaign' do
       assert_status 200
       json_response = json_parse(response_body)
       expect(json_response).to match({

--- a/back/engines/free/email_campaigns/spec/acceptance/consents_spec.rb
+++ b/back/engines/free/email_campaigns/spec/acceptance/consents_spec.rb
@@ -66,7 +66,8 @@ resource 'Campaign consents' do
     context 'with an invalid unsubscription_token' do
       let(:unsubscription_token) { 'garbage' }
 
-      example_request 'List all campaigns with an invalid unsubscription token', document: false do
+      example 'List all campaigns with an invalid unsubscription token', document: false do
+        do_request
         expect(status).to eq 401
       end
     end

--- a/back/engines/free/polls/spec/acceptance/responses_spec.rb
+++ b/back/engines/free/polls/spec/acceptance/responses_spec.rb
@@ -73,7 +73,8 @@ resource 'Poll Responses' do
           header 'Authorization', "Bearer #{token}"
         end
 
-        example_request '[error] XLSX export by a normal user', document: false do
+        example '[error] XLSX export by a normal user', document: false do
+          do_request
           expect(status).to eq 401
         end
       end

--- a/back/engines/free/surveys/spec/acceptance/responses_spec.rb
+++ b/back/engines/free/surveys/spec/acceptance/responses_spec.rb
@@ -153,7 +153,8 @@ resource 'Survey Responses' do
         header 'Authorization', "Bearer #{token}"
       end
 
-      example_request '[error] XLSX export by a normal user', document: false do
+      example '[error] XLSX export by a normal user', document: false do
+        do_request
         expect(status).to eq 401
       end
     end

--- a/back/engines/free/volunteering/spec/acceptance/volunteers_spec.rb
+++ b/back/engines/free/volunteering/spec/acceptance/volunteers_spec.rb
@@ -114,7 +114,8 @@ resource 'Volunteering Volunteers' do
           header 'Authorization', "Bearer #{token}"
         end
 
-        example_request '[error] XLSX export by a normal user', document: false do
+        example '[error] XLSX export by a normal user', document: false do
+          do_request
           assert_status 401
         end
       end

--- a/back/lib/tasks/rspec_api_docs.rake
+++ b/back/lib/tasks/rspec_api_docs.rake
@@ -11,5 +11,5 @@ RSpec::Core::RakeTask.new('web_api:docs:generate' => :environment) do |t, _task_
   else
     '{spec,engines/free/*/spec}/acceptance/**/*_spec.rb'
   end
-  t.rspec_opts = ['--format RspecApiDocumentation::ApiFormatter --exclude-pattern="engines/{admin_api,public_api}/**/*_spec.rb" -t ~admin_api']
+  t.rspec_opts = ['--format RspecApiDocumentation::ApiFormatter --exclude-pattern="engines/commercial/{admin_api,public_api}/**/*_spec.rb" -t ~admin_api']
 end

--- a/back/lib/tasks/rspec_api_docs.rake
+++ b/back/lib/tasks/rspec_api_docs.rake
@@ -11,5 +11,5 @@ RSpec::Core::RakeTask.new('web_api:docs:generate' => :environment) do |t, _task_
   else
     '{spec,engines/free/*/spec}/acceptance/**/*_spec.rb'
   end
-  t.rspec_opts = ['--format RspecApiDocumentation::ApiFormatter --exclude-pattern="engines/commercial/{admin_api,public_api}/**/*_spec.rb" -t ~admin_api']
+  t.rspec_opts = ['--format RspecApiDocumentation::ApiFormatter --exclude-pattern="engines/{admin_api,public_api}/**/*_spec.rb" -t ~admin_api']
 end

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -315,7 +315,7 @@ resource 'AdminPublication' do
           expect(response_ids).not_to include f3.admin_publication.id
         end
 
-        example_request 'searching with query and filtering by topic', document: false do
+        example 'searching with query and filtering by topic', document: false do
           topic = create(:topic)
           project_with_topic = create(:project, topics: [topic],
             admin_publication_attributes: { publication_status: 'published' },
@@ -327,7 +327,7 @@ resource 'AdminPublication' do
           expect(response_ids).to contain_exactly(project_with_topic.admin_publication.id)
         end
 
-        example_request 'Search param should return a project within a folder', document: false do
+        example 'Search param should return a project within a folder', document: false do
           project_in_folder = create(
             :project,
             admin_publication_attributes: { publication_status: 'published' },
@@ -352,7 +352,7 @@ resource 'AdminPublication' do
           expect(response_ids).not_to include folder.admin_publication.id
         end
 
-        example_request 'Search param should return a project within a folder and folder', document: false do
+        example 'Search param should return a project within a folder and folder', document: false do
           project_in_folder = create(
             :project,
             admin_publication_attributes: { publication_status: 'published' },
@@ -381,7 +381,7 @@ resource 'AdminPublication' do
         end
 
         if CitizenLab.ee?
-          example_request 'Search project by content from content builder', document: false do
+          example 'Search project by content from content builder', document: false do
             project = create(:project, content_builder_layouts: [
               build(:layout, craftjs_jsonmultiloc: { en: { someid: { props: { text: 'sometext' } } } })
             ])

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -248,7 +248,7 @@ resource 'AdminPublication' do
       end
 
       context 'search param' do
-        example_request 'Search param should return the proper projects and folders', document: false do
+        example 'Search param should return the proper projects and folders', document: false do
           p1 = create(
             :project,
             admin_publication_attributes: { publication_status: 'published' },

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -247,7 +247,7 @@ resource 'AdminPublication' do
         expect(json_response[:data].find { |d| d.dig(:relationships, :publication, :data, :type) == 'folder' }.dig(:attributes, :visible_children_count)).to eq 1
       end
 
-      context 'search param' do
+      context 'search param', document: false do
         example_request 'Search param should return the proper projects and folders' do
           p1 = create(
             :project,

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -247,8 +247,8 @@ resource 'AdminPublication' do
         expect(json_response[:data].find { |d| d.dig(:relationships, :publication, :data, :type) == 'folder' }.dig(:attributes, :visible_children_count)).to eq 1
       end
 
-      context 'search param', document: false do
-        example_request 'Search param should return the proper projects and folders' do
+      context 'search param' do
+        example_request 'Search param should return the proper projects and folders', document: false do
           p1 = create(
             :project,
             admin_publication_attributes: { publication_status: 'published' },
@@ -327,7 +327,7 @@ resource 'AdminPublication' do
           expect(response_ids).to contain_exactly(project_with_topic.admin_publication.id)
         end
 
-        example_request 'Search param should return a project within a folder' do
+        example_request 'Search param should return a project within a folder', document: false do
           project_in_folder = create(
             :project,
             admin_publication_attributes: { publication_status: 'published' },
@@ -352,7 +352,7 @@ resource 'AdminPublication' do
           expect(response_ids).not_to include folder.admin_publication.id
         end
 
-        example_request 'Search param should return a project within a folder and folder' do
+        example_request 'Search param should return a project within a folder and folder', document: false do
           project_in_folder = create(
             :project,
             admin_publication_attributes: { publication_status: 'published' },
@@ -381,7 +381,7 @@ resource 'AdminPublication' do
         end
 
         if CitizenLab.ee?
-          example_request 'Search project by content from content builder' do
+          example_request 'Search project by content from content builder', document: false do
             project = create(:project, content_builder_layouts: [
               build(:layout, craftjs_jsonmultiloc: { en: { someid: { props: { text: 'sometext' } } } })
             ])

--- a/back/spec/acceptance/comment_votes_spec.rb
+++ b/back/spec/acceptance/comment_votes_spec.rb
@@ -74,7 +74,8 @@ resource 'Comment Votes' do
     describe do
       before { @comment.update!(post: create(:initiative)) }
 
-      example_request 'Create a vote on a comment of an initiative', document: false do
+      example 'Create a vote on a comment of an initiative', document: false do
+        do_request
         assert_status 201
       end
     end

--- a/back/spec/acceptance/folder_moderators_spec.rb
+++ b/back/spec/acceptance/folder_moderators_spec.rb
@@ -107,7 +107,8 @@ resource 'Moderators' do
       let(:user_id) { other_moderators.first.id }
       let!(:same_project_folder_moderators) { create_list(:project_folder_moderator, 2, project_folders: [project_folder]) }
 
-      example_request 'List all moderators of a project_folder', document: false do
+      example 'List all moderators of a project_folder', document: false do
+        do_request
         expect(status).to eq(200)
         json_response = json_parse(response_body)
         expect(json_response[:data].size).to eq same_project_folder_moderators.size

--- a/back/spec/acceptance/groups_spec.rb
+++ b/back/spec/acceptance/groups_spec.rb
@@ -111,7 +111,8 @@ resource 'Groups' do
           let(:membership_type) { 'rules' }
           let(:rules) { [{ ruleType: 'email', predicate: 'contains', value: 'k' }] }
 
-          example_request 'Membership count should only count active users', document: false do
+          example 'Membership count should only count active users', document: false do
+            do_request
             expect(response_status).to eq 201
             json_response = json_parse(response_body)
             group = Group.find json_response.dig(:data, :id)

--- a/back/spec/acceptance/idea_comments_spec.rb
+++ b/back/spec/acceptance/idea_comments_spec.rb
@@ -148,7 +148,8 @@ resource 'Comments' do
 
       let(:project) { @project.id }
 
-      example_request 'XLSX export by project', document: false do
+      example 'XLSX export by project', document: false do
+        do_request
         expect(status).to eq 200
         worksheet = RubyXL::Parser.parse_buffer(response_body).worksheets[0]
         expect(worksheet.count).to eq(@comments.size + 1)
@@ -162,7 +163,8 @@ resource 'Comments' do
 
       let(:ideas) { @comments.map(&:post_id) }
 
-      example_request 'XLSX export by idea ids', document: false do
+      example 'XLSX export by idea ids', document: false do
+        do_request
         expect(status).to eq 200
         worksheet = RubyXL::Parser.parse_buffer(response_body).worksheets[0]
         expect(worksheet.count).to eq(ideas.size + 1)
@@ -178,7 +180,10 @@ resource 'Comments' do
 
       let(:project) { @project.id }
 
-      example_request('XLSX export', document: false) { expect(status).to eq 200 }
+      example 'XLSX export', document: false do
+        do_request
+        expect(status).to eq 200
+      end
     end
 
     context 'when the user moderates another project' do
@@ -190,7 +195,10 @@ resource 'Comments' do
 
       let(:project) { @project.id }
 
-      example_request('[error] XLSX export', document: false) { expect(status).to eq 401 }
+      example '[error] XLSX export', document: false do
+        do_request
+        expect(status).to eq 401
+      end
     end
 
     describe do
@@ -200,7 +208,8 @@ resource 'Comments' do
         header 'Authorization', "Bearer #{token}"
       end
 
-      example_request '[error] XLSX export by a normal user', document: false do
+      example '[error] XLSX export by a normal user', document: false do
+        do_request
         expect(status).to eq 401
       end
     end

--- a/back/spec/acceptance/idea_statuses_spec.rb
+++ b/back/spec/acceptance/idea_statuses_spec.rb
@@ -35,7 +35,8 @@ resource 'IdeaStatuses' do
     before { resident_header_token }
 
     get 'web_api/v1/idea_statuses' do
-      example_request 'List all idea statuses', document: false do
+      example 'List all idea statuses', document: false do
+        do_request
         expect(status).to eq(200)
         json_response = json_parse(response_body)
         expect(json_response[:data].size).to eq 3
@@ -45,7 +46,8 @@ resource 'IdeaStatuses' do
     get 'web_api/v1/idea_statuses/:id' do
       let(:id) { @statuses.first.id }
 
-      example_request 'Get one idea status by id', document: false do
+      example 'Get one idea status by id', document: false do
+        do_request
         expect(status).to eq 200
         json_response = json_parse(response_body)
         expect(json_response.dig(:data, :id)).to eq @statuses.first.id
@@ -59,7 +61,8 @@ resource 'IdeaStatuses' do
     end
 
     get 'web_api/v1/idea_statuses' do
-      example_request 'List all idea statuses', document: false do
+      example 'List all idea statuses', document: false do
+        do_request
         expect(status).to eq(200)
         json_response = json_parse(response_body)
         expect(json_response[:data].size).to eq 3
@@ -69,7 +72,8 @@ resource 'IdeaStatuses' do
     get 'web_api/v1/idea_statuses/:id' do
       let(:id) { @statuses.first.id }
 
-      example_request 'Get one idea status by id', document: false do
+      example 'Get one idea status by id', document: false do
+        do_request
         expect(status).to eq 200
         json_response = json_parse(response_body)
         expect(json_response.dig(:data, :id)).to eq @statuses.first.id

--- a/back/spec/acceptance/ideas_spec.rb
+++ b/back/spec/acceptance/ideas_spec.rb
@@ -390,7 +390,8 @@ resource 'Ideas' do
             header 'Authorization', "Bearer #{token}"
           end
 
-          example_request '[error] XLSX export by a normal user', document: false do
+          example '[error] XLSX export by a normal user', document: false do
+            do_request
             expect(status).to eq 401
           end
         end
@@ -620,7 +621,8 @@ resource 'Ideas' do
           describe 'Values for disabled fields are ignored' do
             let(:proposed_budget) { 12_345 }
 
-            example_request 'Create an idea with values for disabled fields', document: false do
+            example 'Create an idea with values for disabled fields', document: false do
+              do_request
               expect(status).to be 201
               json_response = json_parse(response_body)
               expect(json_response.dig(:data, :attributes, :title_multiloc, :en)).to eq 'Plant more trees'
@@ -669,7 +671,8 @@ resource 'Ideas' do
             project.update_attribute(:ideas_order, nil)
           end
 
-          example_request 'Creates an idea', document: false do
+          example 'Creates an idea', document: false do
+            do_request
             assert_status 201
             json_response = json_parse(response_body)
             expect(json_response.dig(:data, :relationships, :project, :data, :id)).to eq project_id
@@ -751,7 +754,8 @@ resource 'Ideas' do
               .update!(permitted_by: 'groups', groups: [group])
           end
 
-          example_request '[error] Create an idea in a project with groups posting permission', document: false do
+          example '[error] Create an idea in a project with groups posting permission', document: false do
+            do_request
             assert_status 401
           end
 
@@ -836,7 +840,8 @@ resource 'Ideas' do
             let!(:custom_form) { create(:custom_form, participation_context: project) }
             let(:phase_ids) { [project.phases.first.id] }
 
-            example_request 'Post an idea in an ideation phase', document: false do
+            example 'Post an idea in an ideation phase', document: false do
+              do_request
               assert_status 201
               json_response = json_parse response_body
               idea = Idea.find(json_response.dig(:data, :id))
@@ -925,7 +930,8 @@ resource 'Ideas' do
         describe 'Values for disabled fields are ignored' do
           let(:proposed_budget) { 12_345 }
 
-          example_request 'Update an idea with values for disabled fields', document: false do
+          example 'Update an idea with values for disabled fields', document: false do
+            do_request
             expect(status).to be 200
             json_response = json_parse(response_body)
             expect(json_response.dig(:data, :attributes, :title_multiloc, :en)).to eq 'Changed title'

--- a/back/spec/acceptance/initiative_comments_spec.rb
+++ b/back/spec/acceptance/initiative_comments_spec.rb
@@ -151,7 +151,8 @@ resource 'Comments' do
 
       let(:initiatives) { @comments.map(&:post_id) }
 
-      example_request 'XLSX export by initiative ids', document: false do
+      example 'XLSX export by initiative ids', document: false do
+        do_request
         expect(status).to eq 200
         worksheet = RubyXL::Parser.parse_buffer(response_body).worksheets[0]
         expect(worksheet.count).to eq(initiatives.size + 1)
@@ -165,7 +166,8 @@ resource 'Comments' do
         header 'Authorization', "Bearer #{token}"
       end
 
-      example_request '[error] XLSX export by a normal user', document: false do
+      example '[error] XLSX export by a normal user', document: false do
+        do_request
         expect(status).to eq 401
       end
     end

--- a/back/spec/acceptance/initiatives_spec.rb
+++ b/back/spec/acceptance/initiatives_spec.rb
@@ -228,7 +228,8 @@ resource 'Initiatives' do
         header 'Authorization', "Bearer #{token}"
       end
 
-      example_request '[error] XLSX export by a normal user', document: false do
+      example '[error] XLSX export by a normal user', document: false do
+        do_request
         expect(status).to eq 401
       end
     end

--- a/back/spec/acceptance/initiatives_spec.rb
+++ b/back/spec/acceptance/initiatives_spec.rb
@@ -43,7 +43,7 @@ resource 'Initiatives' do
       expect(json_response[:data].size).to eq 0
     end
 
-    example 'List all initiatives which match one of the given topics' do
+    example 'List all initiatives which match one of the given topics', document: false do
       t1 = create(:topic)
       t2 = create(:topic)
 
@@ -60,7 +60,7 @@ resource 'Initiatives' do
       expect(json_response[:data].pluck(:id)).to match_array [i1.id, i2.id]
     end
 
-    example 'List all initiatives which match one of the given areas' do
+    example 'List all initiatives which match one of the given areas', document: false do
       a1 = create(:area)
       a2 = create(:area)
 
@@ -87,7 +87,7 @@ resource 'Initiatives' do
       expect(json_response[:data][0][:id]).to eq i.id
     end
 
-    example 'List all initiatives for an initiative status' do
+    example 'List all initiatives for an initiative status', document: false do
       status = create(:initiative_status)
       i = create(:initiative, initiative_status: status)
 
@@ -97,7 +97,7 @@ resource 'Initiatives' do
       expect(json_response[:data][0][:id]).to eq i.id
     end
 
-    example 'List all initiatives for an assignee' do
+    example 'List all initiatives for an assignee', document: false do
       a = create(:admin)
       i = create(:initiative, assignee: a)
 
@@ -107,7 +107,7 @@ resource 'Initiatives' do
       expect(json_response[:data][0][:id]).to eq i.id
     end
 
-    example 'List all initiatives that need feedback' do
+    example 'List all initiatives that need feedback', document: false do
       threshold_reached = create(:initiative_status_threshold_reached)
       i = create(:initiative, initiative_status: threshold_reached)
 
@@ -117,7 +117,7 @@ resource 'Initiatives' do
       expect(json_response[:data][0][:id]).to eq i.id
     end
 
-    example 'Search for initiatives' do
+    example 'Search for initiatives', document: false do
       create(:user)
       initiatives = [
         create(:initiative, title_multiloc: { en: 'This initiative is uniqque' }),
@@ -130,7 +130,7 @@ resource 'Initiatives' do
       expect(json_response[:data][0][:id]).to eq initiatives[0].id
     end
 
-    example 'List all initiatives sorted by new' do
+    example 'List all initiatives sorted by new', document: false do
       create(:user)
       i1 = create(:initiative)
 
@@ -214,7 +214,7 @@ resource 'Initiatives' do
 
       let(:initiatives) { @selected_initiatives.map(&:id) }
 
-      example_request 'XLSX export by initiative ids' do
+      example_request 'XLSX export by initiative ids', document: false do
         assert_status 200
         worksheet = RubyXL::Parser.parse_buffer(response_body).worksheets[0]
         expect(worksheet.count).to eq(@selected_initiatives.size + 1)
@@ -278,12 +278,12 @@ resource 'Initiatives' do
       expect(json_response[:total]).to eq 4
     end
 
-    example 'List initiative counts per filter option on topic' do
+    example 'List initiative counts per filter option on topic', document: false do
       do_request topics: [@t1.id]
       assert_status 200
     end
 
-    example 'List initiative counts per filter option on area' do
+    example 'List initiative counts per filter option on area', document: false do
       do_request areas: [@a1.id]
       assert_status 200
     end

--- a/back/spec/acceptance/invites_spec.rb
+++ b/back/spec/acceptance/invites_spec.rb
@@ -55,7 +55,8 @@ resource 'Invites' do
         let(:search) { 'abc' }
         let(:sort) { '-email' }
 
-        example_request 'List all invites by combining filter, sort and search', document: false do
+        example 'List all invites by combining filter, sort and search', document: false do
+          do_request
           assert_status 200
         end
       end
@@ -103,7 +104,8 @@ resource 'Invites' do
           header 'Authorization', "Bearer #{token}"
         end
 
-        example_request '[error] XLSX export by a normal user', document: false do
+        example '[error] XLSX export by a normal user', document: false do
+          do_request
           expect(status).to eq 401
         end
       end
@@ -294,7 +296,8 @@ resource 'Invites' do
       describe do
         let(:email) { 'Super.Boulette@hotmail.com' }
 
-        example_request 'Accept an invite using different capitalization for the email', document: false do
+        example 'Accept an invite using different capitalization for the email', document: false do
+          do_request
           expect(status).to eq 200
         end
       end

--- a/back/spec/acceptance/memberships_spec.rb
+++ b/back/spec/acceptance/memberships_spec.rb
@@ -146,7 +146,8 @@ resource 'Memberships' do
       let(:group_id) { @group.id }
       let(:user_id) { create(:invited_user).id }
 
-      example_request 'Add an invitee as a group member', document: false do
+      example 'Add an invitee as a group member', document: false do
+        do_request
         expect(response_status).to eq 201
         json_response = json_parse(response_body)
         expect(json_response.dig(:data, :relationships, :user, :data, :id)).to eq user_id

--- a/back/spec/acceptance/phases_spec.rb
+++ b/back/spec/acceptance/phases_spec.rb
@@ -223,7 +223,8 @@ resource 'Phases' do
       describe do
         let(:start_at) { nil }
 
-        example_request '[error] Create an invalid phase', document: false do
+        example '[error] Create an invalid phase', document: false do
+          do_request
           assert_status 422
           expect(json_response).to include_response_error(:start_at, 'blank')
         end

--- a/back/spec/acceptance/project_moderators_spec.rb
+++ b/back/spec/acceptance/project_moderators_spec.rb
@@ -50,7 +50,8 @@ resource 'Moderators' do
       let(:project_id) { @project.id }
       let!(:same_project_moderators) { create_list(:project_moderator, 2, projects: [@project]) }
 
-      example_request 'List all moderators of a project', document: false do
+      example 'List all moderators of a project', document: false do
+        do_request
         expect(status).to eq(200)
         json_response = json_parse(response_body)
         expect(json_response[:data].size).to eq same_project_moderators.size

--- a/back/spec/acceptance/static_pages_spec.rb
+++ b/back/spec/acceptance/static_pages_spec.rb
@@ -47,7 +47,8 @@ resource 'StaticPages' do
     describe nil do
       let(:slug) { 'unexisting-page' }
 
-      example_request '[error] Get an unexisting static page by slug', document: false do
+      example '[error] Get an unexisting static page by slug', document: false do
+        do_request
         expect(status).to eq 404
       end
     end
@@ -280,7 +281,8 @@ resource 'StaticPages' do
       describe nil do
         let(:slug) { '' }
 
-        example_request '[error] Create an invalid static page', document: false do
+        example '[error] Create an invalid static page', document: false do
+          do_request
           assert_status 422
           expect(json_response).to include_response_error(:slug, 'blank')
         end

--- a/back/spec/acceptance/stats_comments_spec.rb
+++ b/back/spec/acceptance/stats_comments_spec.rb
@@ -90,7 +90,8 @@ resource 'Stats - Comments' do
         create(:comment, post: create(:idea, project: create(:private_admins_project)))
       end
 
-      example_request 'Count all comments (as a moderator)', document: false do
+      example 'Count all comments (as a moderator)', document: false do
+        do_request
         assert_status 200
         expect(json_response[:count]).to eq 2
       end
@@ -203,7 +204,8 @@ resource 'Stats - Comments' do
 
         let(:project) { @project.id }
 
-        example_request 'Count all comments filtered by project', document: false do
+        example 'Count all comments filtered by project', document: false do
+          do_request
           assert_status 200
 
           expect(json_response[:series][:comments].values.last).to eq 1
@@ -305,7 +307,8 @@ resource 'Stats - Comments' do
 
         let(:project) { @project.id }
 
-        example_request 'Count all comments filtered by project', document: false do
+        example 'Count all comments filtered by project', document: false do
+          do_request
           assert_status 200
           worksheet = RubyXL::Parser.parse_buffer(response_body).worksheets[0]
           expect(worksheet[0].cells.map(&:value)).to match %w[date amount]

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -101,7 +101,8 @@ resource 'Users' do
           let(:email) { '+324 875 12 12' }
           let(:password) { 'supersecret' }
 
-          example_request 'Authenticate a registered user by phone number', document: false do
+          example 'Authenticate a registered user by phone number', document: false do
+            do_request
             assert_status 201
             json_response = json_parse(response_body)
             expect(json_response[:jwt]).to be_present
@@ -113,7 +114,8 @@ resource 'Users' do
           let(:email) { user.email }
           let(:password) { 'supersecret' }
 
-          example_request 'Authenticate a registered user by email', document: false do
+          example 'Authenticate a registered user by email', document: false do
+            do_request
             assert_status 201
             json_response = json_parse(response_body)
             expect(json_response[:jwt]).to be_present
@@ -222,7 +224,8 @@ resource 'Users' do
 
         let(:password) { 'ab' }
 
-        example_request '[error] Create an invalid user', document: false do
+        example '[error] Create an invalid user', document: false do
+          do_request
           assert_status 422
           json_response = json_parse response_body
           expect(json_response).to include_response_error(:password, 'too_short', count: 5)
@@ -252,7 +255,8 @@ resource 'Users' do
 
         let(:email) { 'jEzUs@citizenlab.co' }
 
-        example_request '[error] Registering a user with case insensitive email duplicate', document: false do
+        example '[error] Registering a user with case insensitive email duplicate', document: false do
+          do_request
           assert_status 422
         end
       end
@@ -274,7 +278,8 @@ resource 'Users' do
         describe do
           let(:email) { 'someone@citizenlab.co' }
 
-          example_request 'Register with email when an email is passed', document: false do
+          example 'Register with email when an email is passed', document: false do
+            do_request
             assert_status 201
             expect(User.find_by(email: email)).to be_present
           end
@@ -283,7 +288,8 @@ resource 'Users' do
         describe do
           let(:email) { '+32 487 36 58 98' }
 
-          example_request 'Registers a user with a phone number in the email when a phone number is passed', document: false do
+          example 'Registers a user with a phone number in the email when a phone number is passed', document: false do
+            do_request
             assert_status 201
             expect(User.find_by(email: 'phone+32487365898@test.com')).to be_present
           end
@@ -511,7 +517,8 @@ resource 'Users' do
           let(:group) { @group.id }
           let(:users) { @selected.map(&:id) }
 
-          example_request 'XLSX export all users by filtering on both group and user ids', document: false do
+          example 'XLSX export all users by filtering on both group and user ids', document: false do
+            do_request
             expect(status).to eq 200
             xlsx_hash = XlsxService.new.xlsx_to_hash_array RubyXL::Parser.parse_buffer(response_body).stream
             expect(xlsx_hash.map { |r| r['id'] }).to match_array(@members.map(&:id) & @selected.map(&:id))


### PR DESCRIPTION
We could probably mark many more tests `document: false`, but I think we should first fix the issue with [same named examples producing duplicated docs](https://citizenlab.atlassian.net/browse/CL-2908?focusedCommentId=29300), before we do more of this.

Also, I'd like to get this merged, along with #4129 & #4142, so we can at least see the combined performance benefits of the changes thus far.