### PR TITLE
[CL-2908] Improve back-web-api-docs CI job - Part 1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,7 +257,7 @@ jobs:
           at: /tmp/workspace
       - run: rake templates:release['/tmp/workspace/failed-templates.txt']
 
-  back-web-api-docs-not-blocking:
+  back-docs-not-blocking:
     resource_class: small
     executor:
       name: cl2-back
@@ -709,7 +709,7 @@ workflows:
             - citizenlab-ee-environment
           requires:
             - back-build-docker-image
-      - back-web-api-docs-not-blocking:
+      - back-docs-not-blocking:
           context:
             - docker-hub-access
             - citizenlab-ee-environment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,7 +257,7 @@ jobs:
           at: /tmp/workspace
       - run: rake templates:release['/tmp/workspace/failed-templates.txt']
 
-  back-web-api-docs:
+  back-web-api-docs-not-blocking:
     resource_class: small
     executor:
       name: cl2-back
@@ -709,7 +709,7 @@ workflows:
             - citizenlab-ee-environment
           requires:
             - back-build-docker-image
-      - back-web-api-docs:
+      - back-web-api-docs-not-blocking:
           context:
             - docker-hub-access
             - citizenlab-ee-environment

--- a/back/lib/tasks/rspec_api_docs.rake
+++ b/back/lib/tasks/rspec_api_docs.rake
@@ -11,5 +11,5 @@ RSpec::Core::RakeTask.new('web_api:docs:generate' => :environment) do |t, _task_
   else
     '{spec,engines/free/*/spec}/acceptance/**/*_spec.rb'
   end
-  t.rspec_opts = ['--format RspecApiDocumentation::ApiFormatter --exclude-pattern="engines/{admin_api,public_api}/**/*_spec.rb" -t ~admin_api']
+  t.rspec_opts = ['--format RspecApiDocumentation::ApiFormatter --exclude-pattern="engines/commercial/{admin_api,public_api}/**/*_spec.rb" -t ~admin_api']
 end


### PR DESCRIPTION
See also [CL-2908] Improve back-web-api-docs CI job - Part 2 #4142

- [x] Rename CI job to `back-docs-not-blocking`
- [x] Fix failure to exclude `public_api` docs from `web_api` docs

[CL-2908]: https://citizenlab.atlassian.net/browse/CL-2908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ