### PR TITLE
[CL-2989] Fix excel downloads from input manager

### DIFF
--- a/back/app/services/idea_custom_fields_service.rb
+++ b/back/app/services/idea_custom_fields_service.rb
@@ -8,7 +8,7 @@ class IdeaCustomFieldsService
 
   def all_fields
     if @custom_form.custom_field_ids.empty?
-      @participation_method.default_fields custom_form
+      @participation_method.default_fields @custom_form
     else
       @custom_form.custom_fields
     end

--- a/back/app/services/idea_custom_fields_service.rb
+++ b/back/app/services/idea_custom_fields_service.rb
@@ -8,7 +8,7 @@ class IdeaCustomFieldsService
 
   def all_fields
     if @custom_form.custom_field_ids.empty?
-      participation_method.default_fields custom_form
+      @participation_method.default_fields custom_form
     else
       @custom_form.custom_fields
     end

--- a/back/app/services/xlsx_service.rb
+++ b/back/app/services/xlsx_service.rb
@@ -59,7 +59,6 @@ class XlsxService
   end
 
   def generate_xlsx(sheetname, columns, instances)
-    binding.pry
     columns = columns.uniq { |c| c[:header] }
     pa = Axlsx::Package.new
     generate_sheet pa.workbook, sheetname, columns, instances

--- a/back/app/services/xlsx_service.rb
+++ b/back/app/services/xlsx_service.rb
@@ -59,6 +59,7 @@ class XlsxService
   end
 
   def generate_xlsx(sheetname, columns, instances)
+    binding.pry
     columns = columns.uniq { |c| c[:header] }
     pa = Axlsx::Package.new
     generate_sheet pa.workbook, sheetname, columns, instances

--- a/back/engines/commercial/idea_custom_fields/app/services/idea_custom_fields/patches/xlsx_service.rb
+++ b/back/engines/commercial/idea_custom_fields/app/services/idea_custom_fields/patches/xlsx_service.rb
@@ -14,7 +14,6 @@ module IdeaCustomFields
       private
 
       def custom_form_custom_field_columns(ideas)
-
         idea_custom_fields = ideas.map(&:project).flat_map do |project|
           next unless project.custom_form
 

--- a/back/engines/commercial/idea_custom_fields/app/services/idea_custom_fields/patches/xlsx_service.rb
+++ b/back/engines/commercial/idea_custom_fields/app/services/idea_custom_fields/patches/xlsx_service.rb
@@ -14,14 +14,17 @@ module IdeaCustomFields
       private
 
       def custom_form_custom_field_columns(ideas)
+
         idea_custom_fields = ideas.map(&:project).flat_map do |project|
+          next unless project.custom_form
+
           ::IdeaCustomFieldsService.new(project.custom_form).reportable_fields.reject(&:built_in?)
         end
 
         # options keys are only unique in the scope of their field, namespacing to avoid collisions
         options = CustomFieldOption.where(custom_field: idea_custom_fields).index_by { |option| namespace(option.custom_field_id, option.key) }
 
-        idea_custom_fields.map do |field|
+        idea_custom_fields.compact.map do |field|
           column_name = multiloc_service.t(field.title_multiloc)
           { header: column_name, f: value_getter_for_custom_form_custom_field_columns(field, options) }
         end


### PR DESCRIPTION
Errors were being returned for fields in projects that do not have custom_forms. Have fixed this by ignoring projects where there is no custom_form defined when generating the fields.

