### PR TITLE
[CL-2992] Remove useRemoteFiles from FileUploader

### DIFF
--- a/front/app/components/HookForm/FileUploader/FileUploader.test.tsx
+++ b/front/app/components/HookForm/FileUploader/FileUploader.test.tsx
@@ -16,7 +16,7 @@ const Form = () => {
   return (
     <FormProvider {...methods}>
       <form onSubmit={methods.handleSubmit((formData) => onSubmit(formData))}>
-        <FileUploader name="input" resourceId="pageId" resourceType="page" />
+        <FileUploader name="input" />
         <button type="submit">Submit</button>
       </form>
     </FormProvider>

--- a/front/app/components/HookForm/FileUploader/index.tsx
+++ b/front/app/components/HookForm/FileUploader/index.tsx
@@ -6,8 +6,7 @@ import FileUploaderComponent, {
 import Error from 'components/UI/Error';
 import { Controller, useFormContext } from 'react-hook-form';
 import { UploadFile } from 'typings';
-import useRemoteFiles from 'hooks/useRemoteFiles';
-import { TResourceType } from 'resources/GetRemoteFiles';
+import { RemoteFiles } from 'hooks/useRemoteFiles';
 import { get } from 'lodash-es';
 
 interface Props
@@ -16,21 +15,15 @@ interface Props
     'onFileAdd' | 'onFileRemove' | 'files' | 'id'
   > {
   name: string;
-  resourceType: TResourceType;
-  resourceId: string | null;
+  remoteFiles?: RemoteFiles;
 }
 
-const FileUploader = ({ name, resourceId, resourceType, ...rest }: Props) => {
+const FileUploader = ({ name, remoteFiles, ...rest }: Props) => {
   const {
     setValue,
     formState: { errors },
     control,
   } = useFormContext();
-
-  const remoteFiles = useRemoteFiles({
-    resourceId,
-    resourceType,
-  });
 
   useEffect(() => {
     if (remoteFiles) {

--- a/front/app/components/PageForm/index.tsx
+++ b/front/app/components/PageForm/index.tsx
@@ -29,6 +29,7 @@ import { isNilOrError } from 'utils/helperUtils';
 
 // hooks
 import useCustomPage from 'hooks/useCustomPage';
+import useRemoteFiles from 'hooks/useRemoteFiles';
 
 export interface FormValues {
   nav_bar_item_title_multiloc?: Multiloc;
@@ -46,7 +47,10 @@ interface Props {
 const PageForm = ({ onSubmit, defaultValues, pageId }: Props) => {
   const { formatMessage } = useIntl();
   const page = useCustomPage({ customPageId: pageId });
-
+  const remoteFiles = useRemoteFiles({
+    resourceId: pageId,
+    resourceType: 'page',
+  });
   const schema = object({
     title_multiloc: validateAtLeastOneLocale(
       formatMessage(messages.titleMissingOneLanguageError)
@@ -116,11 +120,7 @@ const PageForm = ({ onSubmit, defaultValues, pageId }: Props) => {
               }
             />
           </Label>
-          <FileUploader
-            name="local_page_files"
-            resourceId={pageId}
-            resourceType="page"
-          />
+          <FileUploader name="local_page_files" remoteFiles={remoteFiles} />
         </SectionField>
         <Box display="flex">
           <Button type="submit" processing={methods.formState.isSubmitting}>

--- a/front/app/containers/Admin/pagesAndMenu/containers/Attachments/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/Attachments/index.tsx
@@ -164,8 +164,7 @@ const AttachmentsForm = ({
               </Label>
               <FileUploader
                 name="local_page_files"
-                resourceId={customPageId}
-                resourceType="page"
+                remoteFiles={remotePageFiles}
               />
             </SectionField>
             <Box display="flex">


### PR DESCRIPTION
@brentguf @luucvanderzee This removes the FileUploader dependency of useRemoteFiles, allowing us to split the abstraction for our respective needs. Tagging you so you know when it's merged.