### PR TITLE
CL-2914 Faster checkout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,6 +167,7 @@ jobs:
       # - run: git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1 -q
       - git-shallow-clone/checkout:
           depth: 1
+          path: ./citizenlab
       - setup_remote_docker:
           docker_layer_caching: true
       - run: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
       #     path: ./citizenlab
       # - run: git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1 -q
       - git-shallow-clone/checkout:
-        - depth: 1
+        depth: 1
       - setup_remote_docker:
           docker_layer_caching: true
       - run: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,7 +377,7 @@ jobs:
   front-detect-deadcode:
     docker:
       - image: citizenlabdotco/cl2-devops-front-buildenv
-    working_directory: /citizenlab/front
+    working_directory: ~/citizenlab/front
     steps:
       - shallow-clone
       # Download and cache dependencies
@@ -415,7 +415,7 @@ jobs:
   front-license-check:
     docker:
       - image: licensefinder/license_finder
-    working_directory: /citizenlab/front
+    working_directory: ~/citizenlab/front
     resource_class: small
     steps:
       - shallow-clone
@@ -431,7 +431,7 @@ jobs:
     docker:
       - image: citizenlabdotco/cl2-devops-front-buildenv
     resource_class: large
-    working_directory: /citizenlab/front
+    working_directory: ~/citizenlab/front
     steps:
       - shallow-clone
       # Download and cache dependencies
@@ -452,7 +452,7 @@ jobs:
   front-extract-intl:
     docker:
       - image: citizenlabdotco/cl2-devops-front-buildenv
-    working_directory: /citizenlab/front
+    working_directory: ~/citizenlab/front
     steps:
       - shallow-clone
       # Download and cache dependencies
@@ -547,7 +547,7 @@ jobs:
     docker:
       - image: citizenlabdotco/cl2-devops-front-buildenv
     resource_class: large
-    working_directory: /citizenlab/front
+    working_directory: ~/citizenlab/front
     steps:
       - shallow-clone
       - restore_cache:
@@ -575,7 +575,7 @@ jobs:
     docker:
       - image: citizenlabdotco/cl2-devops-front-buildenv
     resource_class: large
-    working_directory: /citizenlab/front
+    working_directory: ~/citizenlab/front
     steps:
       - shallow-clone
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -425,7 +425,7 @@ jobs:
             # fallback to using the latest cache if no exact match is found
             - v1-npm-cache-
       - run: npm ci
-      - run: /bin/bash -lc "cd /citizenlab/front && license_finder"
+      - run: /bin/bash -lc "cd ~/citizenlab/front && license_finder"
 
   front-build:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,14 +107,14 @@ commands:
     steps:
       - run: mkdir ~/.ssh
       - run: ssh-keyscan github.com >> ~/.ssh/known_hosts
-      - run: cd ~ && rm -rf * && git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1 # Would be nice to only remove working directory
+      - run: cd ~ && rm -rf ~/citizenlab && git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1
 
 jobs:
   trigger-workflows:
     docker:
       - image: cimg/base:stable
     steps:
-      - checkout # Difficult
+      - checkout
       - run:
           name: Trigger workflows
           command: chmod +x .circleci/monorepo.sh && .circleci/monorepo.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -401,6 +401,7 @@ jobs:
     steps:
       - clone
       - run: cd citizenlab/front
+      - run: ls
       # Download and cache dependencies
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,9 +122,9 @@ jobs:
   danger-check:
     resource_class: small
     docker:
-      - image: ghcr.io/danger/danger-js:10.6.6
+      - image: citizenlabdotco/cl2-devops-danger-check
     steps:
-      - checkout # Has no git installed in img
+      - shallow-clone
       - run: danger ci
 
   slack-invalid-data-success:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,11 +109,7 @@ jobs:
     docker:
       - image: cimg/base:stable
     steps:
-      - git-shallow-clone/checkout:
-          depth: 1000
-          fetch_depth: 10000
-          keyscan_github: true
-          path: ./citizenlab
+      - checkout
       - run:
           name: Trigger workflows
           command: chmod +x ./citizenlab/.circleci/monorepo.sh && ./citizenlab/.circleci/monorepo.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
           path: ./citizenlab
       - run:
           name: Trigger workflows
-          command: chmod +x ./.circleci/monorepo.sh && ./.circleci/monorepo.sh
+          command: chmod +x ../.circleci/monorepo.sh && ../.circleci/monorepo.sh
 
   danger-check:
     resource_class: small

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -400,7 +400,7 @@ jobs:
     steps:
       - clone
       # - run: echo 'export CIRCLE_WORKING_DIRECTORY="$CIRCLE_WORKING_DIRECTORY"/citizenlab/front' >> "$BASH_ENV"
-      - run: echo $CIRCLE_WORKING_DIRECTORY
+      # - run: echo $CIRCLE_WORKING_DIRECTORY
       # - run: 
       # - checkout
       #     path: /citizenlab

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,8 +124,8 @@ jobs:
     docker:
       - image: citizenlabdotco/cl2-devops-danger-check
     steps:
-      - checkout # shallow-clone
-      - run: danger ci
+      - shallow-clone
+      - run: cd citizenlab && danger ci
 
   slack-invalid-data-success:
     resource_class: small

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
           path: ./citizenlab
       - run:
           name: Trigger workflows
-          command: chmod +x ../.circleci/monorepo.sh && ../.circleci/monorepo.sh
+          command: chmod +x ./citizenlab/.circleci/monorepo.sh && ./citizenlab/.circleci/monorepo.sh
 
   danger-check:
     resource_class: small

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ commands:
       - run: mkdir ~/.ssh
       - run: ssh-keyscan github.com >> ~/.ssh/known_hosts
       - run: cd ~ && \
-             repo_dir=${"$CIRCLE_REPOSITORY_URL" | cut -d '/' -f 2 | cut -d '.' -f 1}
+             repo_var=$(echo $CIRCLE_REPOSITORY_URL | cut -d '/' -f 2 | cut -d '.' -f 1)
              rm -rf ~/$repo_dir && \
              git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ commands:
     steps:
       - run: mkdir ~/.ssh
       - run: ssh-keyscan github.com >> ~/.ssh/known_hosts
-      - run: git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1
+      - run: cd ~/project && git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1
   clone:
     steps:
       - git-shallow-clone/checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -396,11 +396,14 @@ jobs:
   front-lint:
     docker:
       - image: citizenlabdotco/cl2-devops-front-buildenv
-    working_directory: /citizenlab/front
+    # working_directory: /citizenlab/front
     steps:
-      # - clone
-      - checkout
-        path: /citizenlab
+      - clone
+      - CIRCLE_WORKING_DIRECTORY=CIRCLE_WORKING_DIRECTORY/citizenlab/front
+      - run: echo $CIRCLE_WORKING_DIRECTORY
+      # - run: 
+      # - checkout
+      #     path: /citizenlab
       - run: ls
       # Download and cache dependencies
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,8 +108,7 @@ commands:
       - run: mkdir ~/.ssh
       - run: ssh-keyscan github.com >> ~/.ssh/known_hosts
       - run: cd ~ && \
-             repo_dir=$(echo $CIRCLE_REPOSITORY_URL | cut -d '/' -f 2 | cut -d '.' -f 1) \
-             rm -rf ~/$repo_dir && \
+             rm -rf ~/$$(echo $CIRCLE_REPOSITORY_URL | cut -d '/' -f 2 | cut -d '.' -f 1) && \
              git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ commands:
       - run: mkdir ~/.ssh
       - run: ssh-keyscan github.com >> ~/.ssh/known_hosts
       - run: cd ~ && \
-             repo_var=$(echo $CIRCLE_REPOSITORY_URL | cut -d '/' -f 2 | cut -d '.' -f 1)
+             repo_var=$(echo $CIRCLE_REPOSITORY_URL | cut -d '/' -f 2 | cut -d '.' -f 1) \
              rm -rf ~/$repo_dir && \
              git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,7 @@ jobs:
     steps:
       - git-shallow-clone/checkout:
           depth: 1000
+          fetch_depth: 10000
           path: ./citizenlab
       - run:
           name: Trigger workflows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,7 @@ jobs:
       - echo_pipeline_parameters
       # - checkout:
       #     path: ./citizenlab
-      - run: git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1
+      - run: git clone -b "$CIRCLE_BRANCH" ./citizenlab --depth 1
       - setup_remote_docker:
           docker_layer_caching: true
       - run: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ commands:
     steps:
       - run: mkdir ~/.ssh
       - run: ssh-keyscan github.com >> ~/.ssh/known_hosts
-      - run: cd ~ && git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1
+      - run: cd ~ && rm -rf * && git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1
   clone:
     steps:
       - git-shallow-clone/checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
     docker:
       - image: ghcr.io/danger/danger-js:10.6.6
     steps:
-      - clone
+      - clone # Has no git installed in img
       - run: danger ci
 
   slack-invalid-data-success:
@@ -400,6 +400,7 @@ jobs:
     working_directory: /citizenlab/front
     steps:
       - clone
+      - run: cd front
       # Download and cache dependencies
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ commands:
       - run: mkdir ~/.ssh
       - run: ssh-keyscan github.com >> ~/.ssh/known_hosts
       - run: cd ~ && \
-             repo_var=$(echo $CIRCLE_REPOSITORY_URL | cut -d '/' -f 2 | cut -d '.' -f 1) \
+             repo_dir=$(echo $CIRCLE_REPOSITORY_URL | cut -d '/' -f 2 | cut -d '.' -f 1) \
              rm -rf ~/$repo_dir && \
              git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
       - image: cimg/base:stable
     steps:
       - git-shallow-clone/checkout:
-          depth: 1
+          depth: 1000
           path: ./citizenlab
       - run:
           name: Trigger workflows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,9 @@ jobs:
     docker:
       - image: ghcr.io/danger/danger-js:10.6.6
     steps:
-      - checkout
+      - git-shallow-clone/checkout:
+          depth: 1
+          path: ./citizenlab
       - run: danger ci
 
   slack-invalid-data-success:
@@ -162,9 +164,6 @@ jobs:
       - image: cimg/base:2021.03
     steps:
       - echo_pipeline_parameters
-      # - checkout:
-      #     path: ./citizenlab
-      # - run: git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1 -q
       - git-shallow-clone/checkout:
           depth: 1
           path: ./citizenlab
@@ -379,8 +378,9 @@ jobs:
       - image: citizenlabdotco/cl2-devops-front-buildenv
     working_directory: /citizenlab/front
     steps:
-      - checkout:
-          path: /citizenlab
+      - git-shallow-clone/checkout:
+          depth: 1
+          path: ./citizenlab
       # Download and cache dependencies
       - restore_cache:
           keys:
@@ -399,8 +399,9 @@ jobs:
       - image: citizenlabdotco/cl2-devops-front-buildenv
     working_directory: /citizenlab/front
     steps:
-      - checkout:
-          path: /citizenlab
+      - git-shallow-clone/checkout:
+          depth: 1
+          path: ./citizenlab
       # Download and cache dependencies
       - restore_cache:
           keys:
@@ -420,8 +421,9 @@ jobs:
     working_directory: /citizenlab/front
     resource_class: small
     steps:
-      - checkout:
-          path: /citizenlab
+      - git-shallow-clone/checkout:
+          depth: 1
+          path: ./citizenlab
       - restore_cache:
           keys:
             - v1-npm-cache-{{ checksum "package.json" }}
@@ -436,8 +438,9 @@ jobs:
     resource_class: large
     working_directory: /citizenlab/front
     steps:
-      - checkout:
-          path: /citizenlab
+      - git-shallow-clone/checkout:
+          depth: 1
+          path: ./citizenlab
       # Download and cache dependencies
       - restore_cache:
           keys:
@@ -458,8 +461,9 @@ jobs:
       - image: citizenlabdotco/cl2-devops-front-buildenv
     working_directory: /citizenlab/front
     steps:
-      - checkout:
-          path: /citizenlab
+      - git-shallow-clone/checkout:
+          depth: 1
+          path: ./citizenlab
       # Download and cache dependencies
       - restore_cache:
           keys:
@@ -503,7 +507,8 @@ jobs:
       CITIZENLAB_EE: true
     parallelism: 4
     steps:
-      - checkout:
+      - git-shallow-clone/checkout:
+          depth: 1
           path: ./citizenlab
       - restore_cache:
           keys:
@@ -555,8 +560,9 @@ jobs:
     resource_class: large
     working_directory: /citizenlab/front
     steps:
-      - checkout:
-          path: /citizenlab
+      - git-shallow-clone/checkout:
+          depth: 1
+          path: ./citizenlab
       - restore_cache:
           keys:
             - v1-npm-cache-{{ checksum "package.json" }}
@@ -584,8 +590,9 @@ jobs:
     resource_class: large
     working_directory: /citizenlab/front
     steps:
-      - checkout:
-          path: /citizenlab
+      - git-shallow-clone/checkout:
+          depth: 1
+          path: ./citizenlab
       - restore_cache:
           keys:
             - v1-npm-cache-{{ checksum "package.json" }}
@@ -631,7 +638,9 @@ jobs:
       - image: cimg/base:2021.03
     resource_class: medium+
     steps:
-      - checkout
+      - git-shallow-clone/checkout:
+          depth: 1
+          path: ./citizenlab
       - copy_secrets_from_lastpass
       - setup_remote_docker:
           version: 19.03.13 # https://support.circleci.com/hc/en-us/articles/360050934711

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,10 @@ commands:
     steps:
       - run: mkdir ~/.ssh
       - run: ssh-keyscan github.com >> ~/.ssh/known_hosts
-      - run: cd ~ && rm -rf ~/citizenlab && git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1
+      - run: cd ~ && \
+             repo_dir=${"$CIRCLE_REPOSITORY_URL" | cut -d '/' -f 2 | cut -d '.' -f 1}
+             rm -rf ~/$repo_dir && \
+             git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1
 
 jobs:
   trigger-workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ commands:
     steps:
       - run: mkdir ~/.ssh
       - run: ssh-keyscan github.com >> ~/.ssh/known_hosts
-      - run: cd ~ && rm -rf citizenlab && git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1 # Would be nice to only remove working directory
+      - run: cd ~ && rm -rf * && git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1 # Would be nice to only remove working directory
 
 jobs:
   trigger-workflows:
@@ -124,7 +124,7 @@ jobs:
     docker:
       - image: citizenlabdotco/cl2-devops-danger-check
     steps:
-      - shallow-clone
+      - checkout # shallow-clone
       - run: danger ci
 
   slack-invalid-data-success:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
       #     path: ./citizenlab
       # - run: git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1 -q
       - git-shallow-clone/checkout:
-        depth: 1
+          depth: 1
       - setup_remote_docker:
           docker_layer_caching: true
       - run: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ commands:
       - run: mkdir ~/.ssh
       - run: ssh-keyscan github.com >> ~/.ssh/known_hosts
       - run: cd ~ && \
-             rm -rf ~/$$(echo $CIRCLE_REPOSITORY_URL | cut -d '/' -f 2 | cut -d '.' -f 1) && \
+             rm -rf ~/$(echo $CIRCLE_REPOSITORY_URL | cut -d '/' -f 2 | cut -d '.' -f 1) && \
              git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,7 @@ jobs:
       - echo_pipeline_parameters
       # - checkout:
       #     path: ./citizenlab
-      - run: git clone -b "$CIRCLE_BRANCH" --depth 1
+      - run: git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1 -q
       - setup_remote_docker:
           docker_layer_caching: true
       - run: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -399,7 +399,7 @@ jobs:
     # working_directory: /citizenlab/front
     steps:
       - clone
-      - CIRCLE_WORKING_DIRECTORY=CIRCLE_WORKING_DIRECTORY/citizenlab/front
+      - run: CIRCLE_WORKING_DIRECTORY=$CIRCLE_WORKING_DIRECTORY/citizenlab/front
       - run: echo $CIRCLE_WORKING_DIRECTORY
       # - run: 
       # - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ commands:
     steps:
       - run: mkdir ~/.ssh
       - run: ssh-keyscan github.com >> ~/.ssh/known_hosts
-      - run: cd ~ && rm -rf * && git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1 # Would be nice to only remove working directory
+      - run: cd ~ && rm -rf citizenlab && git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1 # Would be nice to only remove working directory
 
 jobs:
   trigger-workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,9 +125,7 @@ jobs:
     docker:
       - image: ghcr.io/danger/danger-js:10.6.6
     steps:
-      - git-shallow-clone/checkout:
-          depth: 1
-          path: ./citizenlab
+      - clone
       - run: danger ci
 
   slack-invalid-data-success:
@@ -382,9 +380,7 @@ jobs:
       - image: citizenlabdotco/cl2-devops-front-buildenv
     working_directory: /citizenlab/front
     steps:
-      - git-shallow-clone/checkout:
-          depth: 1
-          path: ./citizenlab
+      - clone
       # Download and cache dependencies
       - restore_cache:
           keys:
@@ -403,9 +399,7 @@ jobs:
       - image: citizenlabdotco/cl2-devops-front-buildenv
     working_directory: /citizenlab/front
     steps:
-      - git-shallow-clone/checkout:
-          depth: 1
-          path: ./citizenlab
+      - clone
       # Download and cache dependencies
       - restore_cache:
           keys:
@@ -425,9 +419,7 @@ jobs:
     working_directory: /citizenlab/front
     resource_class: small
     steps:
-      - git-shallow-clone/checkout:
-          depth: 1
-          path: ./citizenlab
+      - clone
       - restore_cache:
           keys:
             - v1-npm-cache-{{ checksum "package.json" }}
@@ -442,9 +434,7 @@ jobs:
     resource_class: large
     working_directory: /citizenlab/front
     steps:
-      - git-shallow-clone/checkout:
-          depth: 1
-          path: ./citizenlab
+      - clone
       # Download and cache dependencies
       - restore_cache:
           keys:
@@ -465,9 +455,7 @@ jobs:
       - image: citizenlabdotco/cl2-devops-front-buildenv
     working_directory: /citizenlab/front
     steps:
-      - git-shallow-clone/checkout:
-          depth: 1
-          path: ./citizenlab
+      - clone
       # Download and cache dependencies
       - restore_cache:
           keys:
@@ -511,9 +499,7 @@ jobs:
       CITIZENLAB_EE: true
     parallelism: 4
     steps:
-      - git-shallow-clone/checkout:
-          depth: 1
-          path: ./citizenlab
+      - clone
       - restore_cache:
           keys:
             - v1-npm-cache-{{ checksum "citizenlab/front/package.json" }}
@@ -564,9 +550,7 @@ jobs:
     resource_class: large
     working_directory: /citizenlab/front
     steps:
-      - git-shallow-clone/checkout:
-          depth: 1
-          path: ./citizenlab
+      - clone
       - restore_cache:
           keys:
             - v1-npm-cache-{{ checksum "package.json" }}
@@ -594,9 +578,7 @@ jobs:
     resource_class: large
     working_directory: /citizenlab/front
     steps:
-      - git-shallow-clone/checkout:
-          depth: 1
-          path: ./citizenlab
+      - clone
       - restore_cache:
           keys:
             - v1-npm-cache-{{ checksum "package.json" }}
@@ -642,9 +624,7 @@ jobs:
       - image: cimg/base:2021.03
     resource_class: medium+
     steps:
-      - git-shallow-clone/checkout:
-          depth: 1
-          path: ./citizenlab
+      - clone
       - copy_secrets_from_lastpass
       - setup_remote_docker:
           version: 19.03.13 # https://support.circleci.com/hc/en-us/articles/360050934711

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,8 @@ jobs:
   danger-check:
     resource_class: small
     docker:
-      - image: citizenlabdotco/cl2-devops-danger-check
+      # - image: citizenlabdotco/cl2-devops-danger-check
+      - image: citizenlabdotco/cl2-devops-front-buildenv
     steps:
       - shallow-clone
       - run: danger ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
           path: ./citizenlab
       - run:
           name: Trigger workflows
-          command: chmod +x .circleci/monorepo.sh && .circleci/monorepo.sh
+          command: chmod +x ./.circleci/monorepo.sh && ./.circleci/monorepo.sh
 
   danger-check:
     resource_class: small

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -396,7 +396,7 @@ jobs:
   front-lint:
     docker:
       - image: citizenlabdotco/cl2-devops-front-buildenv
-    working_directory: /citizenlab/front
+    working_directory: ~/citizenlab/front
     steps:
       - run: pwd
       - clone

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,23 +103,18 @@ commands:
       - run: echo $LASTPASS_PASSWORD | LPASS_DISABLE_PINENTRY=1 lpass login ${LASTPASS_EMAIL}
       - run: lpass show --notes 'citizenlab back-secret.env' > env_files/back-secret.env
       - run: lpass show --notes 'citizenlab front-secret.env' > env_files/front-secret.env
-  shallow-checkout:
+  shallow-clone:
     steps:
       - run: mkdir ~/.ssh
       - run: ssh-keyscan github.com >> ~/.ssh/known_hosts
       - run: cd ~ && rm -rf * && git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1 # Would be nice to only remove working directory
-  clone:
-    steps:
-      - git-shallow-clone/checkout:
-          depth: 1
-          path: ~/citizenlab
 
 jobs:
   trigger-workflows:
     docker:
       - image: cimg/base:stable
     steps:
-      - checkout
+      - checkout # Difficult
       - run:
           name: Trigger workflows
           command: chmod +x .circleci/monorepo.sh && .circleci/monorepo.sh
@@ -129,7 +124,7 @@ jobs:
     docker:
       - image: ghcr.io/danger/danger-js:10.6.6
     steps:
-      - clone # Has no git installed in img
+      - checkout # Has no git installed in img
       - run: danger ci
 
   slack-invalid-data-success:
@@ -172,7 +167,7 @@ jobs:
       - image: cimg/base:2021.03
     steps:
       - echo_pipeline_parameters
-      - shallow-checkout
+      - shallow-clone
       - setup_remote_docker:
           docker_layer_caching: true
       - run: |
@@ -384,7 +379,7 @@ jobs:
       - image: citizenlabdotco/cl2-devops-front-buildenv
     working_directory: /citizenlab/front
     steps:
-      - clone
+      - shallow-clone
       # Download and cache dependencies
       - restore_cache:
           keys:
@@ -403,17 +398,7 @@ jobs:
       - image: citizenlabdotco/cl2-devops-front-buildenv
     working_directory: ~/citizenlab/front
     steps:
-      # - run: pwd
-      # - run: cd .. && rm -r front
-      - run: pwd
-      - shallow-checkout
-      # - run: echo 'export CIRCLE_WORKING_DIRECTORY="$CIRCLE_WORKING_DIRECTORY"/citizenlab/front' >> "$BASH_ENV"
-      # - run: echo $CIRCLE_WORKING_DIRECTORY
-      # - run: 
-      # - checkout
-      #     path: /citizenlab
-      - run: pwd
-      - run: ls
+      - shallow-clone
       # Download and cache dependencies
       - restore_cache:
           keys:
@@ -433,7 +418,7 @@ jobs:
     working_directory: /citizenlab/front
     resource_class: small
     steps:
-      - clone
+      - shallow-clone
       - restore_cache:
           keys:
             - v1-npm-cache-{{ checksum "package.json" }}
@@ -448,7 +433,7 @@ jobs:
     resource_class: large
     working_directory: /citizenlab/front
     steps:
-      - clone
+      - shallow-clone
       # Download and cache dependencies
       - restore_cache:
           keys:
@@ -469,7 +454,7 @@ jobs:
       - image: citizenlabdotco/cl2-devops-front-buildenv
     working_directory: /citizenlab/front
     steps:
-      - clone
+      - shallow-clone
       # Download and cache dependencies
       - restore_cache:
           keys:
@@ -513,7 +498,7 @@ jobs:
       CITIZENLAB_EE: true
     parallelism: 4
     steps:
-      - clone
+      - shallow-clone
       - restore_cache:
           keys:
             - v1-npm-cache-{{ checksum "citizenlab/front/package.json" }}
@@ -564,7 +549,7 @@ jobs:
     resource_class: large
     working_directory: /citizenlab/front
     steps:
-      - clone
+      - shallow-clone
       - restore_cache:
           keys:
             - v1-npm-cache-{{ checksum "package.json" }}
@@ -592,7 +577,7 @@ jobs:
     resource_class: large
     working_directory: /citizenlab/front
     steps:
-      - clone
+      - shallow-clone
       - restore_cache:
           keys:
             - v1-npm-cache-{{ checksum "package.json" }}
@@ -638,7 +623,7 @@ jobs:
       - image: cimg/base:2021.03
     resource_class: medium+
     steps:
-      - clone
+      - shallow-clone
       - copy_secrets_from_lastpass
       - setup_remote_docker:
           version: 19.03.13 # https://support.circleci.com/hc/en-us/articles/360050934711

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -398,7 +398,8 @@ jobs:
       - image: citizenlabdotco/cl2-devops-front-buildenv
     working_directory: /citizenlab/front
     steps:
-      - clone
+      # - clone
+      - checkout
       - run: ls
       # Download and cache dependencies
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,7 @@ jobs:
       - echo_pipeline_parameters
       # - checkout:
       #     path: ./citizenlab
-      - run: git clone -b "$CIRCLE_BRANCH" ./citizenlab --depth 1
+      - run: git clone -b "$CIRCLE_BRANCH" --depth 1
       - setup_remote_docker:
           docker_layer_caching: true
       - run: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ commands:
     steps:
       - run: mkdir ~/.ssh
       - run: ssh-keyscan github.com >> ~/.ssh/known_hosts
-      - run: cd ~ && rm -rf * && git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1
+      - run: cd ~ && rm -rf * && git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1 # Would be nice to only remove working directory
   clone:
     steps:
       - git-shallow-clone/checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,9 +107,10 @@ commands:
     steps:
       - run: mkdir ~/.ssh
       - run: ssh-keyscan github.com >> ~/.ssh/known_hosts
-      - run: cd ~ && \
-             rm -rf ~/$(echo $CIRCLE_REPOSITORY_URL | cut -d '/' -f 2 | cut -d '.' -f 1) && \
-             git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1
+      - run: |
+          cd ~
+          rm -rf ~/$(echo $CIRCLE_REPOSITORY_URL | cut -d '/' -f 2 | cut -d '.' -f 1)
+          git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1
 
 jobs:
   trigger-workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -399,7 +399,7 @@ jobs:
     # working_directory: /citizenlab/front
     steps:
       - clone
-      - run: CIRCLE_WORKING_DIRECTORY=$CIRCLE_WORKING_DIRECTORY/citizenlab/front
+      - run: export CIRCLE_WORKING_DIRECTORY=$CIRCLE_WORKING_DIRECTORY/citizenlab/front
       - run: echo $CIRCLE_WORKING_DIRECTORY
       # - run: 
       # - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -397,7 +397,7 @@ jobs:
   front-lint:
     docker:
       - image: citizenlabdotco/cl2-devops-front-buildenv
-    working_directory: /citizenlab/front
+    # working_directory: /citizenlab/front
     steps:
       - clone
       - run: cd front

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,8 +161,9 @@ jobs:
       - image: cimg/base:2021.03
     steps:
       - echo_pipeline_parameters
-      - checkout:
-          path: ./citizenlab
+      # - checkout:
+      #     path: ./citizenlab
+      - run: git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL"
       - setup_remote_docker:
           docker_layer_caching: true
       - run: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,12 @@ commands:
       - run: echo $LASTPASS_PASSWORD | LPASS_DISABLE_PINENTRY=1 lpass login ${LASTPASS_EMAIL}
       - run: lpass show --notes 'citizenlab back-secret.env' > env_files/back-secret.env
       - run: lpass show --notes 'citizenlab front-secret.env' > env_files/front-secret.env
+  clone:
+    steps:
+      - git-shallow-clone/checkout:
+          depth: 1
+          path: ./citizenlab
+      - run: cd citizenlab
 
 jobs:
   trigger-workflows:
@@ -164,9 +170,7 @@ jobs:
       - image: cimg/base:2021.03
     steps:
       - echo_pipeline_parameters
-      - git-shallow-clone/checkout:
-          depth: 1
-          path: ./citizenlab
+      - clone
       - setup_remote_docker:
           docker_layer_caching: true
       - run: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,7 @@ jobs:
       - echo_pipeline_parameters
       # - checkout:
       #     path: ./citizenlab
-      - run: git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL"
+      - run: git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1
       - setup_remote_docker:
           docker_layer_caching: true
       - run: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ commands:
     steps:
       - git-shallow-clone/checkout:
           depth: 1
-          path: /citizenlab
+          path: ~/citizenlab
 
 jobs:
   trigger-workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,8 @@ jobs:
     docker:
       - image: cimg/base:stable
     steps:
-      - checkout
+      # - checkout
+      - run: 1 + x
       - run:
           name: Trigger workflows
           command: chmod +x .circleci/monorepo.sh && .circleci/monorepo.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,8 +122,7 @@ jobs:
   danger-check:
     resource_class: small
     docker:
-      # - image: citizenlabdotco/cl2-devops-danger-check
-      - image: citizenlabdotco/cl2-devops-front-buildenv
+      - image: citizenlabdotco/cl2-devops-danger-check
     steps:
       - shallow-clone
       - run: danger ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ commands:
     steps:
       - git-shallow-clone/checkout:
           depth: 1
-          path: ./citizenlab
+          path: /citizenlab
 
 jobs:
   trigger-workflows:
@@ -400,7 +400,7 @@ jobs:
     steps:
       - clone
       # - run: echo 'export CIRCLE_WORKING_DIRECTORY="$CIRCLE_WORKING_DIRECTORY"/citizenlab/front' >> "$BASH_ENV"
-      # - run: echo $CIRCLE_WORKING_DIRECTORY
+      - run: echo $CIRCLE_WORKING_DIRECTORY
       # - run: 
       # - checkout
       #     path: /citizenlab

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,8 @@ commands:
       - run: lpass show --notes 'citizenlab front-secret.env' > env_files/front-secret.env
   shallow-checkout:
     steps:
-      - run: ssh-keyscan github.com >> /home/circleci/project/.ssh/known_hosts
+      - run: mkdir ~/.ssh
+      - run: ssh-keyscan github.com >> ~/.ssh/known_hosts
       - run: git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1
   clone:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -398,6 +398,7 @@ jobs:
       - image: citizenlabdotco/cl2-devops-front-buildenv
     working_directory: /citizenlab/front
     steps:
+      - run: pwd
       - clone
       # - run: echo 'export CIRCLE_WORKING_DIRECTORY="$CIRCLE_WORKING_DIRECTORY"/citizenlab/front' >> "$BASH_ENV"
       # - run: echo $CIRCLE_WORKING_DIRECTORY

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
       - checkout
       - run:
           name: Trigger workflows
-          command: chmod +x ./citizenlab/.circleci/monorepo.sh && ./citizenlab/.circleci/monorepo.sh
+          command: chmod +x .circleci/monorepo.sh && .circleci/monorepo.sh
 
   danger-check:
     resource_class: small

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   slack: circleci/slack@4.3.3
+  git-shallow-clone: guitarrapc/git-shallow-clone@2.4.1
 
 # REUSABLE YAML FRAGMENTS (yml anchors)
 slack-fail-post-step-templates: &slack-fail-post-step-templates
@@ -163,7 +164,9 @@ jobs:
       - echo_pipeline_parameters
       # - checkout:
       #     path: ./citizenlab
-      - run: git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1 -q
+      # - run: git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1 -q
+      - git-shallow-clone/checkout:
+        - depth: 1
       - setup_remote_docker:
           docker_layer_caching: true
       - run: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -400,6 +400,7 @@ jobs:
     steps:
       # - clone
       - checkout
+        path: /citizenlab
       - run: ls
       # Download and cache dependencies
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ commands:
       - run: lpass show --notes 'citizenlab front-secret.env' > env_files/front-secret.env
   shallow-checkout:
     steps:
-      - run: ssh-keyscan github.com >> ~/.ssh/known_hosts
+      - run: ssh-keyscan github.com >> /home/circleci/project/.ssh/known_hosts
       - run: git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1
   clone:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2.1
 
 orbs:
   slack: circleci/slack@4.3.3
-  git-shallow-clone: guitarrapc/git-shallow-clone@2.4.1
 
 # REUSABLE YAML FRAGMENTS (yml anchors)
 slack-fail-post-step-templates: &slack-fail-post-step-templates
@@ -126,9 +125,10 @@ jobs:
     resource_class: small
     docker:
       - image: citizenlabdotco/cl2-devops-danger-check
+    working_directory: ~/citizenlab
     steps:
       - shallow-clone
-      - run: cd ~/citizenlab && danger ci
+      - run: danger ci
 
   slack-invalid-data-success:
     resource_class: small

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -399,6 +399,7 @@ jobs:
     working_directory: ~/citizenlab/front
     steps:
       - run: pwd
+      - run: cd .. && rm -r front
       - clone
       # - run: echo 'export CIRCLE_WORKING_DIRECTORY="$CIRCLE_WORKING_DIRECTORY"/citizenlab/front' >> "$BASH_ENV"
       # - run: echo $CIRCLE_WORKING_DIRECTORY

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
       - image: citizenlabdotco/cl2-devops-danger-check
     steps:
       - shallow-clone
-      - run: cd citizenlab && danger ci
+      - run: cd ~/citizenlab && danger ci
 
   slack-invalid-data-success:
     resource_class: small

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,10 @@ commands:
       - run: echo $LASTPASS_PASSWORD | LPASS_DISABLE_PINENTRY=1 lpass login ${LASTPASS_EMAIL}
       - run: lpass show --notes 'citizenlab back-secret.env' > env_files/back-secret.env
       - run: lpass show --notes 'citizenlab front-secret.env' > env_files/front-secret.env
+  shallow-checkout:
+    steps:
+      - run: ssh-keyscan github.com >> ~/.ssh/known_hosts
+      - run: git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1
   clone:
     steps:
       - git-shallow-clone/checkout:
@@ -114,8 +118,7 @@ jobs:
     docker:
       - image: cimg/base:stable
     steps:
-      # - checkout
-      - run: 1 + x
+      - checkout
       - run:
           name: Trigger workflows
           command: chmod +x .circleci/monorepo.sh && .circleci/monorepo.sh
@@ -168,7 +171,7 @@ jobs:
       - image: cimg/base:2021.03
     steps:
       - echo_pipeline_parameters
-      - clone
+      - shallow-checkout
       - setup_remote_docker:
           docker_layer_caching: true
       - run: |
@@ -399,10 +402,10 @@ jobs:
       - image: citizenlabdotco/cl2-devops-front-buildenv
     working_directory: ~/citizenlab/front
     steps:
+      # - run: pwd
+      # - run: cd .. && rm -r front
       - run: pwd
-      - run: cd .. && rm -r front
-      - run: pwd
-      - clone
+      - shallow-checkout
       # - run: echo 'export CIRCLE_WORKING_DIRECTORY="$CIRCLE_WORKING_DIRECTORY"/citizenlab/front' >> "$BASH_ENV"
       # - run: echo $CIRCLE_WORKING_DIRECTORY
       # - run: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,7 @@ jobs:
       - git-shallow-clone/checkout:
           depth: 1000
           fetch_depth: 10000
+          keyscan_github: true
           path: ./citizenlab
       - run:
           name: Trigger workflows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,11 @@ commands:
     steps:
       - run: mkdir ~/.ssh
       - run: ssh-keyscan github.com >> ~/.ssh/known_hosts
+      # Git clone can fail when the repository directory exists and is not empty. This
+      # can happen when e.g. setting the working_directory to ~/citizenlab/front because
+      # CircleCI will create those directories in this case. The solution is to remove
+      # the created directories before cloning. The name of the directory to remove is
+      # inferred from the repository URL (the part between the "/" and "." characters).
       - run: |
           cd ~
           rm -rf ~/$(echo $CIRCLE_REPOSITORY_URL | cut -d '/' -f 2 | cut -d '.' -f 1)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,9 @@ jobs:
     docker:
       - image: cimg/base:stable
     steps:
-      - checkout
+      - git-shallow-clone/checkout:
+          depth: 1
+          path: ./citizenlab
       - run:
           name: Trigger workflows
           command: chmod +x .circleci/monorepo.sh && .circleci/monorepo.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -400,7 +400,7 @@ jobs:
     # working_directory: /citizenlab/front
     steps:
       - clone
-      - run: cd front
+      - run: cd citizenlab/front
       # Download and cache dependencies
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -400,12 +400,14 @@ jobs:
     steps:
       - run: pwd
       - run: cd .. && rm -r front
+      - run: pwd
       - clone
       # - run: echo 'export CIRCLE_WORKING_DIRECTORY="$CIRCLE_WORKING_DIRECTORY"/citizenlab/front' >> "$BASH_ENV"
       # - run: echo $CIRCLE_WORKING_DIRECTORY
       # - run: 
       # - checkout
       #     path: /citizenlab
+      - run: pwd
       - run: ls
       # Download and cache dependencies
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -396,12 +396,11 @@ jobs:
   front-lint:
     docker:
       - image: citizenlabdotco/cl2-devops-front-buildenv
-    # working_directory: /citizenlab/front
+    working_directory: /citizenlab/front
     steps:
       - clone
-      - run: echo 'export CIRCLE_WORKING_DIRECTORY="$CIRCLE_WORKING_DIRECTORY"/citizenlab/front' >> "$BASH_ENV"
-      # - run: export CIRCLE_WORKING_DIRECTORY=$CIRCLE_WORKING_DIRECTORY/citizenlab/front
-      - run: echo $CIRCLE_WORKING_DIRECTORY
+      # - run: echo 'export CIRCLE_WORKING_DIRECTORY="$CIRCLE_WORKING_DIRECTORY"/citizenlab/front' >> "$BASH_ENV"
+      # - run: echo $CIRCLE_WORKING_DIRECTORY
       # - run: 
       # - checkout
       #     path: /citizenlab

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,6 @@ commands:
       - git-shallow-clone/checkout:
           depth: 1
           path: ./citizenlab
-      - run: cd citizenlab
 
 jobs:
   trigger-workflows:
@@ -397,10 +396,9 @@ jobs:
   front-lint:
     docker:
       - image: citizenlabdotco/cl2-devops-front-buildenv
-    # working_directory: /citizenlab/front
+    working_directory: /citizenlab/front
     steps:
       - clone
-      - run: cd citizenlab/front
       - run: ls
       # Download and cache dependencies
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ commands:
     steps:
       - run: mkdir ~/.ssh
       - run: ssh-keyscan github.com >> ~/.ssh/known_hosts
-      - run: cd ~/project && git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1
+      - run: cd ~ && git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1
   clone:
     steps:
       - git-shallow-clone/checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -399,7 +399,8 @@ jobs:
     # working_directory: /citizenlab/front
     steps:
       - clone
-      - run: export CIRCLE_WORKING_DIRECTORY=$CIRCLE_WORKING_DIRECTORY/citizenlab/front
+      - run: echo 'export CIRCLE_WORKING_DIRECTORY="$CIRCLE_WORKING_DIRECTORY"/citizenlab/front' >> "$BASH_ENV"
+      # - run: export CIRCLE_WORKING_DIRECTORY=$CIRCLE_WORKING_DIRECTORY/citizenlab/front
       - run: echo $CIRCLE_WORKING_DIRECTORY
       # - run: 
       # - checkout

--- a/back/README.md
+++ b/back/README.md
@@ -1,4 +1,4 @@
-# cl2-back
+# cl2_back
 
 ## Getting started
 

--- a/back/README.md
+++ b/back/README.md
@@ -1,4 +1,4 @@
-# cl2__back
+# cl2___back
 
 ## Getting started
 

--- a/back/README.md
+++ b/back/README.md
@@ -1,4 +1,4 @@
-# cl2____back
+# cl2_____back
 
 ## Getting started
 

--- a/back/README.md
+++ b/back/README.md
@@ -1,4 +1,4 @@
-# cl2___back
+# cl2____back
 
 ## Getting started
 

--- a/back/README.md
+++ b/back/README.md
@@ -1,4 +1,4 @@
-# cl2__back
+# cl2_back
 
 ## Getting started
 

--- a/back/README.md
+++ b/back/README.md
@@ -1,4 +1,4 @@
-# cl2_____back
+# cl2_back
 
 ## Getting started
 

--- a/back/README.md
+++ b/back/README.md
@@ -1,4 +1,4 @@
-# cl2__back
+# cl2-back
 
 ## Getting started
 

--- a/back/README.md
+++ b/back/README.md
@@ -1,4 +1,4 @@
-# cl2_back
+# cl2__back
 
 ## Getting started
 

--- a/front/README.md
+++ b/front/README.md
@@ -1,4 +1,4 @@
-# cl2-front
+# cl2_front
 
 ## Prerequisites
 

--- a/front/README.md
+++ b/front/README.md
@@ -1,4 +1,4 @@
-# cl2_front
+# cl2\_\_front
 
 ## Prerequisites
 

--- a/front/README.md
+++ b/front/README.md
@@ -1,4 +1,4 @@
-# cl2\_\_front
+# cl2-front
 
 ## Prerequisites
 


### PR DESCRIPTION
This PR makes the CI workflows faster by using a shallow clone/checkout of the Git repository. The time of the clone/checkout step is reduced to 3s. Before this change, the checkout step varied between 30s and 10 minutes.

A few remarks:
- The frontend deployment jobs were not tested, so we need to merge and release this work carefully.
- The trigger-workflows job is the only one that has not been improved, because it needs some part of the history and possibly other branches to work. I'll look into this further in a separate branch.
- A new Docker image was created for the Danger JS job with Git pre installed. It can be found here: https://github.com/CitizenLabDotCo/cl2-devops-danger-check/blob/master/Dockerfile. Perhaps we could consider updating the Danger JS version from 10.6.6 to a more recent version (11.2.4)?