### PR TITLE
Faster trigger workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,7 @@ jobs:
   trigger-workflows:
     docker:
       - image: cimg/base:stable
+    working_directory: ~/citizenlab
     steps:
       - shallow-clone
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ jobs:
     docker:
       - image: cimg/base:stable
     steps:
-      - checkout
+      - shallow-clone
       - run:
           name: Trigger workflows
           command: chmod +x .circleci/monorepo.sh && .circleci/monorepo.sh

--- a/back/README.md
+++ b/back/README.md
@@ -1,4 +1,4 @@
-# cl2_back
+# cl2-back
 
 ## Getting started
 

--- a/back/README.md
+++ b/back/README.md
@@ -1,4 +1,4 @@
-# cl2-back
+# cl2_back
 
 ## Getting started
 

--- a/front/README.md
+++ b/front/README.md
@@ -1,4 +1,4 @@
-# cl2_front
+# cl2-front
 
 ## Prerequisites
 


### PR DESCRIPTION
It's very strange, but with the manual shallow clone command, the trigger workflows job seems to work. Perhaps it's able to fetch the necessary history on the fly?

It's hard to verify if the behaviour of the job is still correct because it's hard to understand what the job does exactly, and I've noticed it already behaves in a way that is different from what I would expect.