### PR TITLE
Add -p flag to mkdir to avoid error if folder exists

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ commands:
       - run: lpass show --notes 'citizenlab front-secret.env' > env_files/front-secret.env
   shallow-clone:
     steps:
-      - run: mkdir ~/.ssh
+      - run: mkdir -p ~/.ssh
       - run: ssh-keyscan github.com >> ~/.ssh/known_hosts
       # Git clone can fail when the repository directory exists and is not empty. This
       # can happen when e.g. setting the working_directory to ~/citizenlab/front because


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/94705/workflows/aa6b4b93-235a-40cf-8960-f6f8d08c2891/jobs/223376

```
#!/bin/bash -eo pipefail
mkdir ~/.ssh
mkdir: cannot create directory ‘/home/circleci/.ssh’: File exists

Exited with code exit status 1
CircleCI received exit code 1
```