### PR TITLE
CL-3045 Add feature settings (User banning)

### DIFF
--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -188,7 +188,7 @@
       "user_blocking": {
       "type": "object",
       "title": "User blocking",
-      "description":	"User blocking and unblocking features.",
+      "description": "User blocking and unblocking features.",
       "additionalProperties": false,
       "required": ["allowed", "enabled"],
       "required-settings": ["duration"],

--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -188,20 +188,12 @@
       "user_banning": {
         "type": "object",
         "title": "User banning",
-        "description":	"User banning features.",
+        "description": "User banning features.",
         "additionalProperties": false,
-        "required-settings": ["duration"],
         "required": ["allowed", "enabled"],
         "properties": {
           "allowed": { "type": "boolean", "default": false },
-          "enabled": { "type": "boolean", "default": false },
-          "duration": {
-            "title": "Duration of ban period (in days)",
-            "description": "Default value for how many days a user will be banned for. This value can be changed in the admin panel on the platform. Changing this value only changes the duration of subsequent bans.",
-            "type": "integer",
-            "minimum": 1,
-            "default": 90
-          }
+          "enabled": { "type": "boolean", "default": false }
         }
       },
 

--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -188,7 +188,7 @@
       "user_blocking": {
       "type": "object",
       "title": "User blocking",
-      "description":	"User blocking features.",
+      "description":	"User blocking and unblocking features.",
       "additionalProperties": false,
       "required": ["allowed", "enabled"],
       "required-settings": ["duration"],
@@ -196,8 +196,8 @@
         "allowed": { "type": "boolean", "default": false },
         "enabled": { "type": "boolean", "default": false },
         "duration": {
-          "title": "Duration of ban period (in days)",
-          "description": "Default value for how many days a user will be banned for. This value can be changed in the admin panel on the platform. Changing this value only changes the duration of subsequent bans.",
+          "title": "Duration of block (in days)",
+          "description": "How many days a user will be blocked for. The user will remain blocked until this period expires, or an admin manually removes the block on the user. Changing this value changes the duration of subsequent blocks only.",
           "type": "integer",
           "minimum": 1,
           "default": 90

--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -188,7 +188,7 @@
       "user_blocking": {
       "type": "object",
       "title": "User blocking",
-      "description": "User blocking and unblocking features.",
+      "description": "User blocking and unblocking features. WIP - Don't enable for customer platforms",
       "additionalProperties": false,
       "required": ["allowed", "enabled"],
       "required-settings": ["duration"],

--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -186,16 +186,24 @@
       },
 
       "user_blocking": {
-        "type": "object",
-        "title": "User blocking",
-        "description": "User blocking features.",
-        "additionalProperties": false,
-        "required": ["allowed", "enabled"],
-        "properties": {
-          "allowed": { "type": "boolean", "default": false },
-          "enabled": { "type": "boolean", "default": false }
+      "type": "object",
+      "title": "User blocking",
+      "description":	"User blocking features.",
+      "additionalProperties": false,
+      "required": ["allowed", "enabled"],
+      "required-settings": ["duration"],
+      "properties": {
+        "allowed": { "type": "boolean", "default": false },
+        "enabled": { "type": "boolean", "default": false },
+        "duration": {
+          "title": "Duration of ban period (in days)",
+          "description": "Default value for how many days a user will be banned for. This value can be changed in the admin panel on the platform. Changing this value only changes the duration of subsequent bans.",
+          "type": "integer",
+          "minimum": 1,
+          "default": 90
         }
-      },
+      }
+    },
 
       "dynamic_idea_form": {
         "type": "object",

--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -185,6 +185,26 @@
         }
       },
 
+      "user_banning": {
+        "type": "object",
+        "title": "User banning",
+        "description":	"User banning features.",
+        "additionalProperties": false,
+        "required-settings": ["duration"],
+        "required": ["allowed", "enabled"],
+        "properties": {
+          "allowed": { "type": "boolean", "default": false },
+          "enabled": { "type": "boolean", "default": false },
+          "duration": {
+            "title": "Duration of ban period (in days)",
+            "description": "Default value for how many days a user will be banned for. This value can be changed in the admin panel on the platform. Changing this value only changes the duration of subsequent bans.",
+            "type": "integer",
+            "minimum": 1,
+            "default": 90
+          }
+        }
+      },
+
       "dynamic_idea_form": {
         "type": "object",
         "title": "Dynamic idea form",

--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -197,9 +197,9 @@
         "enabled": { "type": "boolean", "default": false },
         "duration": {
           "title": "Duration of block (in days)",
-          "description": "How many days a user will be blocked for. The user will remain blocked until this period expires, or an admin manually removes the block on the user. Changing this value changes the duration of subsequent blocks only.",
+          "description": "How many days a user will be blocked for. The user will remain blocked until this period expires, or an admin manually removes the block on the user. Setting this value to zero effectively unblocks all blocked users.",
           "type": "integer",
-          "minimum": 1,
+          "minimum": 0,
           "default": 90
         }
       }

--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -185,10 +185,10 @@
         }
       },
 
-      "user_banning": {
+      "user_blocking": {
         "type": "object",
-        "title": "User banning",
-        "description": "User banning features.",
+        "title": "User blocking",
+        "description": "User blocking features.",
         "additionalProperties": false,
         "required": ["allowed", "enabled"],
         "properties": {

--- a/back/db/seeds/citizenlab.rb
+++ b/back/db/seeds/citizenlab.rb
@@ -172,6 +172,11 @@ AppConfiguration.create!(
     user_confirmation: {
       allowed: true,
       enabled: false
+    },
+    user_blocking: {
+      allowed: true,
+      enabled: false,
+      duration: 90
     }
   })
 )

--- a/back/db/seeds/citizenlab.rb
+++ b/back/db/seeds/citizenlab.rb
@@ -172,11 +172,6 @@ AppConfiguration.create!(
     user_confirmation: {
       allowed: true,
       enabled: false
-    },
-    user_blocking: {
-      allowed: true,
-      enabled: false,
-      duration: 90
     }
   })
 )

--- a/back/engines/commercial/multi_tenancy/db/seeds/tenants.rb
+++ b/back/engines/commercial/multi_tenancy/db/seeds/tenants.rb
@@ -391,6 +391,10 @@ module MultiTenancy
             posthog_integration: {
               enabled: true,
               allowed: true
+            },
+            user_banning: {
+              enabled: true,
+              allowed: true
             }
           })
         )

--- a/back/engines/commercial/multi_tenancy/db/seeds/tenants.rb
+++ b/back/engines/commercial/multi_tenancy/db/seeds/tenants.rb
@@ -394,7 +394,8 @@ module MultiTenancy
             },
             user_blocking: {
               enabled: true,
-              allowed: true
+              allowed: true,
+              duration: 90
             }
           })
         )

--- a/back/engines/commercial/multi_tenancy/db/seeds/tenants.rb
+++ b/back/engines/commercial/multi_tenancy/db/seeds/tenants.rb
@@ -392,7 +392,7 @@ module MultiTenancy
               enabled: true,
               allowed: true
             },
-            user_banning: {
+            user_blocking: {
               enabled: true,
               allowed: true
             }

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/create_tenant.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/create_tenant.rake
@@ -322,7 +322,8 @@ namespace :cl2_back do
         },
         user_blocking: {
           enabled: false,
-          allowed: false
+          allowed: false,
+          duration: 90
         }
       }
     )

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/create_tenant.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/create_tenant.rake
@@ -319,6 +319,10 @@ namespace :cl2_back do
         posthog_integration: {
           enabled: false,
           allowed: false
+        },
+        user_banning: {
+          enabled: false,
+          allowed: false
         }
       }
     )

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/create_tenant.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/create_tenant.rake
@@ -320,7 +320,7 @@ namespace :cl2_back do
           enabled: false,
           allowed: false
         },
-        user_banning: {
+        user_blocking: {
           enabled: false,
           allowed: false
         }


### PR DESCRIPTION
This adds the regular `allowed` & `enabled` toggles, even though this will be available to all pricing plans. See [Slack thread](https://citizenlabco.slack.com/archives/C04SGJJR63X/p1678128648536039).

Also adds a setting for the `duration` a user will remain blocked, with default value of 90 (days).

AdminHQ, tenant settings:

<img width="1207" alt="Screenshot 2023-03-07 at 17 11 42" src="https://user-images.githubusercontent.com/3944042/223497211-220ec23e-1be2-4a35-a559-3068edd1757e.png">

## Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->
