### PR TITLE
[CL-3041] Add feature flag for new email confirmation permissions option

### DIFF
--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -1083,6 +1083,18 @@
           "allowed": { "type": "boolean", "default": true },
           "enabled": { "type": "boolean", "default": true }
         }
+      },
+
+      "permission_option_email_confirmation": {
+        "type": "object",
+        "title": "Registration via email confirmation",
+        "description": "Enables a light registration flow where users enter just an email address and a confirmation code.",
+        "additionalProperties": false,
+        "required": ["allowed", "enabled"],
+        "properties": {
+          "allowed": { "type": "boolean", "default": false },
+          "enabled": { "type": "boolean", "default": false }
+        }
       }
     },
   "dependencies": {
@@ -1106,7 +1118,9 @@
     "id_franceconnect": ["verification"],
     "id_gent_rrn": ["verification"],
     "id_oostende_rrn": ["verification"],
-    "id_id_card_lookup": ["verification"]
+    "id_id_card_lookup": ["verification"],
+
+    "permission_option_email_confirmation": ["user_confirmation"]
   },
   "definitions": {
     "multiloc_string": {

--- a/back/engines/commercial/multi_tenancy/db/seeds/tenants.rb
+++ b/back/engines/commercial/multi_tenancy/db/seeds/tenants.rb
@@ -104,6 +104,10 @@ module MultiTenancy
               enabled: true,
               allowed: true
             },
+            permission_option_email_confirmation: {
+              enabled: true,
+              allowed: true
+            },
             representativeness: {
               enabled: true,
               allowed: true

--- a/front/app/api/app_configuration/types.ts
+++ b/front/app/api/app_configuration/types.ts
@@ -206,6 +206,7 @@ export interface IAppConfigurationSettings {
   analytics?: AppConfigurationFeature;
   visitors_dashboard?: AppConfigurationFeature;
   user_confirmation?: AppConfigurationFeature;
+  permission_option_email_confirmation?: AppConfigurationFeature;
   input_form_custom_fields?: AppConfigurationFeature;
   report_builder?: AppConfigurationFeature;
   posthog_integration?: AppConfigurationFeature;

--- a/front/app/modules/commercial/granular_permissions/admin/containers/Granular/ActionForm.tsx
+++ b/front/app/modules/commercial/granular_permissions/admin/containers/Granular/ActionForm.tsx
@@ -13,6 +13,7 @@ import messages from './messages';
 import permissionsMessages from 'containers/Admin/projects/project/permissions/messages';
 import { IPermissionData } from 'services/actionPermissions';
 import Warning from 'components/UI/Warning';
+import useFeatureFlag from 'hooks/useFeatureFlag';
 
 const StyledFieldset = styled.fieldset`
   border: none;
@@ -48,6 +49,9 @@ const ActionForm = ({
   localize,
 }: Props) => {
   const { formatMessage } = useIntl();
+  const includeEmailConfirmedOption = useFeatureFlag({
+    name: 'permission_option_email_confirmation',
+  });
   const groupsOptions = () => {
     if (isNilOrError(groupsList)) {
       return [];
@@ -94,16 +98,18 @@ const ActionForm = ({
             id={`participation-permission-everyone-${permissionId}`}
           />
         )}
-        <Radio
-          name={`permittedBy-${permissionId}`}
-          value="everyone_confirmed_email"
-          currentValue={permittedBy}
-          label={
-            <FormattedMessage {...messages.permissionsEveryoneEmailLabel} />
-          }
-          onChange={handlePermittedByUpdate('everyone_confirmed_email')}
-          id={`participation-permission-users-${permissionId}`}
-        />
+        {includeEmailConfirmedOption && (
+          <Radio
+            name={`permittedBy-${permissionId}`}
+            value="everyone_confirmed_email"
+            currentValue={permittedBy}
+            label={
+              <FormattedMessage {...messages.permissionsEveryoneEmailLabel} />
+            }
+            onChange={handlePermittedByUpdate('everyone_confirmed_email')}
+            id={`participation-permission-users-${permissionId}`}
+          />
+        )}
         <Radio
           name={`permittedBy-${permissionId}`}
           value="users"


### PR DESCRIPTION
## Description
Adds feature flag FE work for hiding the "Anyone with email confirmation" radio option.

## Note
After chatting with the squad, I confirmed that the only functionality needed was to hide the radio button. Checking for the feature flag will also automatically hide the option on platforms that don't have any email confirmation, since email confirmation is needed in order for this feature flag to be turned on.