### PR TITLE
[CL-3052] Upgrade rack to solve CVE-2023-27530

### DIFF
--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -884,7 +884,7 @@ GEM
       que (~> 1.0.0.beta3)
       sinatra
     racc (1.6.2)
-    rack (2.2.6.2)
+    rack (2.2.6.3)
     rack-attack (6.6.1)
       rack (>= 1.0, < 3)
     rack-cors (1.1.1)


### PR DESCRIPTION
## Changelog
- Upgrade Rack to 2.2.6.3 to solve [CVE-2023-27530](https://discuss.rubyonrails.org/t/cve-2023-27530-possible-dos-vulnerability-in-multipart-mime-parsing/82388).