### PR TITLE
[CL-3048] BE Return blocked user related data in user related responses

### DIFF
--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -34,6 +34,14 @@ class WebApi::V1::UsersController < ::ApplicationController
         @users.order(email: :asc) if view_private_attributes?
       when '-email'
         @users.order(email: :desc) if view_private_attributes?
+      when 'block_start_at'
+        @users.order(block_start_at: :asc) if view_private_attributes?
+      when '-block_start_at'
+        @users.order(block_start_at: :desc) if view_private_attributes?
+      when 'block_reason'
+        @users.order(block_reason: :asc) if view_private_attributes?
+      when '-block_reason'
+        @users.order(block_reason: :desc) if view_private_attributes?
       when 'role'
         @users.order_role(:asc)
       when '-role'

--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -165,15 +165,6 @@ class WebApi::V1::UsersController < ::ApplicationController
     head :ok
   end
 
-  def block
-    puts '========= user_block_test ======='
-    puts @user.inspect
-    puts '================================='
-
-    authorize :user, :test
-    render json: { data: { test: 'success' } }, status: :ok
-  end
-
   def ideas_count
     ideas = policy_scope(IdeasFinder.new({}, scope: @user.ideas.published, current_user: current_user).find_records)
     render json: { count: ideas.count }, status: :ok

--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -6,6 +6,7 @@ class WebApi::V1::UsersController < ::ApplicationController
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def index
     authorize :user, :index?
 
@@ -59,6 +60,7 @@ class WebApi::V1::UsersController < ::ApplicationController
 
     render json: linked_json(@users, WebApi::V1::UserSerializer, params: fastjson_params)
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def index_xlsx
     authorize :user, :index_xlsx?

--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -15,7 +15,7 @@ class WebApi::V1::UsersController < ::ApplicationController
     @users = @users.search_by_all(params[:search]) if params[:search].present?
 
     @users = @users.active unless params[:include_inactive]
-    @users = @users.blocked if params[:blocked]
+    @users = @users.blocked if params[:only_blocked]
     @users = @users.in_group(Group.find(params[:group])) if params[:group]
     @users = @users.admin.or(@users.project_moderator(params[:can_moderate_project])) if params[:can_moderate_project].present?
     @users = @users.admin.or(@users.project_moderator) if params[:can_moderate].present?

--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -165,6 +165,15 @@ class WebApi::V1::UsersController < ::ApplicationController
     head :ok
   end
 
+  def block
+    puts '========= user_block_test ======='
+    puts @user.inspect
+    puts '================================='
+
+    authorize :user, :test
+    render json: { data: { test: 'success' } }, status: :ok
+  end
+
   def ideas_count
     ideas = policy_scope(IdeasFinder.new({}, scope: @user.ideas.published, current_user: current_user).find_records)
     render json: { count: ideas.count }, status: :ok

--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -14,6 +14,7 @@ class WebApi::V1::UsersController < ::ApplicationController
     @users = @users.search_by_all(params[:search]) if params[:search].present?
 
     @users = @users.active unless params[:include_inactive]
+    @users = @users.blocked if params[:blocked]
     @users = @users.in_group(Group.find(params[:group])) if params[:group]
     @users = @users.admin.or(@users.project_moderator(params[:can_moderate_project])) if params[:can_moderate_project].present?
     @users = @users.admin.or(@users.project_moderator) if params[:can_moderate].present?

--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -6,7 +6,6 @@ class WebApi::V1::UsersController < ::ApplicationController
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
-  # rubocop:disable Metrics/CyclomaticComplexity
   def index
     authorize :user, :index?
 
@@ -35,14 +34,6 @@ class WebApi::V1::UsersController < ::ApplicationController
         @users.order(email: :asc) if view_private_attributes?
       when '-email'
         @users.order(email: :desc) if view_private_attributes?
-      when 'block_start_at'
-        @users.order(block_start_at: :asc) if view_private_attributes?
-      when '-block_start_at'
-        @users.order(block_start_at: :desc) if view_private_attributes?
-      when 'block_reason'
-        @users.order(block_reason: :asc) if view_private_attributes?
-      when '-block_reason'
-        @users.order(block_reason: :desc) if view_private_attributes?
       when 'role'
         @users.order_role(:asc)
       when '-role'
@@ -60,7 +51,6 @@ class WebApi::V1::UsersController < ::ApplicationController
 
     render json: linked_json(@users, WebApi::V1::UserSerializer, params: fastjson_params)
   end
-  # rubocop:enable Metrics/CyclomaticComplexity
 
   def index_xlsx
     authorize :user, :index_xlsx?

--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -180,6 +180,13 @@ class WebApi::V1::UsersController < ::ApplicationController
     render json: { count: ideas.count }, status: :ok
   end
 
+  def blocked_count
+    authorize :user, :blocked_count
+    count = User.all.blocked.count
+
+    render json: { data: { blocked_users_count: count } }, status: :ok
+  end
+
   def initiatives_count
     render json: raw_json({ count: policy_scope(@user.initiatives.published).count }), status: :ok
   end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -380,21 +380,13 @@ class User < ApplicationRecord
   end
 
   def blocked?
-    if block_start_at.present?
-      duration = AppConfiguration.instance.settings('user_blocking', 'duration')
-
-      return true if block_start_at.between?(duration.days.ago, Time.zone.now)
-    end
-
-    false
+    block_start_at.present? && block_start_at.between?(block_duration.days.ago, Time.zone.now)
   end
 
   def block_end_at
     return nil unless blocked?
 
-    duration = AppConfiguration.instance.settings('user_blocking', 'duration')
-
-    block_start_at + duration.days
+    block_start_at + block_duration.days
   end
 
   def groups
@@ -577,6 +569,10 @@ class User < ApplicationRecord
 
   def use_fake_code?
     Rails.env.development?
+  end
+
+  def block_duration
+    AppConfiguration.instance.settings('user_blocking', 'duration')
   end
 end
 

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -389,6 +389,14 @@ class User < ApplicationRecord
     false
   end
 
+  def block_end_at
+    return nil unless blocked?
+
+    duration = AppConfiguration.instance.settings('user_blocking', 'duration')
+
+    block_start_at + duration.days
+  end
+
   def groups
     manual_groups
   end

--- a/back/app/policies/user_policy.rb
+++ b/back/app/policies/user_policy.rb
@@ -63,6 +63,10 @@ class UserPolicy < ApplicationPolicy
     record.id == user&.id || (user&.active? && user&.admin?)
   end
 
+  def blocked_count
+    index?
+  end
+
   def ideas_count?
     true
   end

--- a/back/app/policies/user_policy.rb
+++ b/back/app/policies/user_policy.rb
@@ -63,6 +63,10 @@ class UserPolicy < ApplicationPolicy
     record.id == user&.id || (user&.active? && user&.admin?)
   end
 
+  def block
+    index?
+  end
+
   def blocked_count
     index?
   end

--- a/back/app/policies/user_policy.rb
+++ b/back/app/policies/user_policy.rb
@@ -96,7 +96,7 @@ class UserPolicy < ApplicationPolicy
   end
 
   def permitted_attributes
-    shared = [:first_name, :last_name, :email, :password, :avatar, :locale, { custom_field_values: allowed_custom_field_keys, bio_multiloc: CL2_SUPPORTED_LOCALES }]
+    shared = [:first_name, :last_name, :email, :password, :avatar, :block_reason, :block_start_at, :locale, { custom_field_values: allowed_custom_field_keys, bio_multiloc: CL2_SUPPORTED_LOCALES }]
     admin? ? shared + role_permitted_params : shared
   end
 

--- a/back/app/policies/user_policy.rb
+++ b/back/app/policies/user_policy.rb
@@ -63,10 +63,6 @@ class UserPolicy < ApplicationPolicy
     record.id == user&.id || (user&.active? && user&.admin?)
   end
 
-  def block
-    index?
-  end
-
   def blocked_count
     index?
   end

--- a/back/app/serializers/web_api/v1/user_serializer.rb
+++ b/back/app/serializers/web_api/v1/user_serializer.rb
@@ -9,6 +9,7 @@ class WebApi::V1::UserSerializer < WebApi::V1::BaseSerializer
     :bio_multiloc,
     :registration_completed_at,
     :invite_status,
+    :blocked,
     :block_start_at,
     :block_end_at,
     :block_reason,
@@ -43,6 +44,12 @@ class WebApi::V1::UserSerializer < WebApi::V1::BaseSerializer
 
   attribute :confirmation_required do |user|
     user.confirmation_required?
+  end
+
+  attribute :blocked, if: proc { |object, params|
+    view_private_attributes? object, params
+  } do |object|
+    object.blocked?
   end
 
   attribute :block_start_at, if: proc { |object, params|

--- a/back/app/serializers/web_api/v1/user_serializer.rb
+++ b/back/app/serializers/web_api/v1/user_serializer.rb
@@ -1,7 +1,19 @@
 # frozen_string_literal: true
 
 class WebApi::V1::UserSerializer < WebApi::V1::BaseSerializer
-  attributes :first_name, :slug, :locale, :roles, :highest_role, :bio_multiloc, :registration_completed_at, :invite_status, :created_at, :updated_at
+  attributes :first_name,
+    :slug,
+    :locale,
+    :roles,
+    :highest_role,
+    :bio_multiloc,
+    :registration_completed_at,
+    :invite_status,
+    :block_start_at,
+    :block_end_at,
+    :block_reason,
+    :created_at,
+    :updated_at
 
   attribute :last_name do |object, params|
     name_service = UserDisplayNameService.new(AppConfiguration.instance, current_user(params))
@@ -32,6 +44,20 @@ class WebApi::V1::UserSerializer < WebApi::V1::BaseSerializer
   attribute :confirmation_required do |user|
     user.confirmation_required?
   end
+
+  attribute :block_start_at, if: proc { |object, params|
+    view_private_attributes? object, params
+  }
+
+  attribute :block_end_at, if: proc { |object, params|
+    view_private_attributes? object, params
+  } do |object|
+    object.block_end_at
+  end
+
+  attribute :block_reason, if: proc { |object, params|
+    view_private_attributes? object, params
+  }
 
   has_many :granted_permissions, record_type: :permission, serializer: WebApi::V1::PermissionSerializer do |_object, params|
     params[:granted_permissions]

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -85,6 +85,7 @@ Rails.application.routes.draw do
         get 'ideas_count', on: :member
         get 'initiatives_count', on: :member
         get 'comments_count', on: :member
+        get 'blocked_count', on: :collection
 
         resources :comments, only: [:index], controller: 'user_comments'
       end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -80,7 +80,6 @@ Rails.application.routes.draw do
         post 'reset_password_email' => 'reset_password#reset_password_email', on: :collection
         post 'reset_password' => 'reset_password#reset_password', on: :collection
         post 'update_password', on: :collection
-        patch 'block', on: :member
         get 'by_slug/:slug', on: :collection, to: 'users#by_slug'
         get 'by_invite/:token', on: :collection, to: 'users#by_invite'
         get 'ideas_count', on: :member

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -80,6 +80,7 @@ Rails.application.routes.draw do
         post 'reset_password_email' => 'reset_password#reset_password_email', on: :collection
         post 'reset_password' => 'reset_password#reset_password', on: :collection
         post 'update_password', on: :collection
+        patch 'block', on: :member
         get 'by_slug/:slug', on: :collection, to: 'users#by_slug'
         get 'by_invite/:token', on: :collection, to: 'users#by_invite'
         get 'ideas_count', on: :member

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -561,7 +561,8 @@ resource 'Users' do
       end
 
       get 'web_api/v1/users/:id' do
-        let(:id) { @user.id }
+        let(:user) { create :user }
+        let(:id) { user.id }
 
         example_request 'Get a user by id includes user block data' do
           expect(status).to eq 200

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -320,6 +320,7 @@ resource 'Users' do
         parameter :sort, "Sort user by 'created_at', '-created_at', 'last_name', '-last_name', 'email', '-email', 'role', '-role'", required: false
         parameter :group, 'Filter by group_id', required: false
         parameter :can_moderate_project, 'Filter by users (and admins) who can moderate the project (by id)', required: false
+        parameter :can_moderate, 'Filter out admins and moderators', required: false
         parameter :blocked, 'Return only blocked users', required: false
 
         example_request 'List all users' do

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -573,6 +573,26 @@ resource 'Users' do
         end
       end
 
+      get 'web_api/v1/users/blocked_count' do
+        example 'Get count of blocked users' do
+          create_list(:user, 2, block_start_at: 30.days.ago)
+
+          settings = AppConfiguration.instance.settings
+          settings['user_blocking'] = {
+            'enabled' => true,
+            'allowed' => true,
+            'duration' => 90
+          }
+          AppConfiguration.instance.update!(settings: settings)
+
+          do_request
+
+          expect(status).to eq 200
+          json_response = json_parse(response_body)
+          expect(json_response.dig(:data, :blocked_users_count)).to eq 2
+        end
+      end
+
       put 'web_api/v1/users/:id' do
         with_options scope: 'user' do
           parameter :first_name, 'User full name'
@@ -738,6 +758,12 @@ resource 'Users' do
           json_response = json_parse(response_body)
           expect(json_response.dig(:data, :id)).to eq(@user.id)
           expect(json_response.dig(:data, :attributes, :verified)).to be false if CitizenLab.ee?
+        end
+      end
+
+      get 'web_api/v1/users/blocked_count' do
+        example_request 'Get count of blocked users' do
+          expect(status).to eq 401
         end
       end
 

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -329,6 +329,15 @@ resource 'Users' do
           expect(json_response[:data].size).to eq 6
         end
 
+        example_request 'List all users includes user blocking related data' do
+          expect(status).to eq 200
+          json_response = json_parse(response_body)
+          expect(json_response[:data][0][:attributes]).to have_key(:blocked)
+          expect(json_response[:data][0][:attributes]).to have_key(:block_start_at)
+          expect(json_response[:data][0][:attributes]).to have_key(:block_end_at)
+          expect(json_response[:data][0][:attributes]).to have_key(:block_reason)
+        end
+
         example 'Get all users on the second page with fixed page size' do
           do_request({ 'page[number]' => 2, 'page[size]' => 2 })
           expect(status).to eq 200

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -572,488 +572,525 @@ resource 'Users' do
           expect(json_response.dig(:data, :attributes)).to have_key(:block_reason)
         end
       end
-    end
 
-    get 'web_api/v1/users' do
-      with_options scope: :page do
-        parameter :number, 'Page number'
-        parameter :size, 'Number of users per page'
-      end
-      example 'Get all users as non-admin', document: false do
-        do_request
-        assert_status 401
-      end
-    end
+      put 'web_api/v1/users/:id' do
+        with_options scope: 'user' do
+          parameter :first_name, 'User full name'
+          parameter :last_name, 'User full name'
+          parameter :email, 'E-mail address'
+          parameter :password, 'Password'
+          parameter :locale, 'Locale. Should be one of the tenants locales'
+          parameter :avatar, 'Base64 encoded avatar image'
+          parameter :roles, 'Roles array, only allowed when admin'
+          parameter :bio_multiloc, 'A little text, allowing the user to describe herself. Multiloc and non-html'
+          parameter :custom_field_values, 'An object that can only contain keys for custom fields for users'
+        end
+        ValidationErrorHelper.new.error_fields(self, User)
 
-    get 'web_api/v1/users/:id' do
-      let(:id) { @user.id }
+        let(:id) { @user.id }
+        let(:first_name) { 'Edmond' }
 
-      example_request 'Get one user by id' do
-        do_request
-        expect(status).to eq 200
-        json_response = json_parse response_body
-        expect(json_response.dig(:data, :attributes, :highest_role)).to eq 'user'
-      end
-    end
+        describe do
+          let(:custom_field_values) { { birthyear: 1984 } }
+          let(:project) { create(:continuous_project) }
 
-    get 'web_api/v1/users/:id' do
-      let(:user) { create :user }
-      let(:id) { user.id }
+          before do
+            if CitizenLab.ee?
+              old_timers = create(:smart_group, rules: [
+                {
+                  ruleType: 'custom_field_number',
+                  customFieldId: create(:custom_field_number, title_multiloc: { 'en' => 'Birthyear?' }, key: 'birthyear', code: 'birthyear').id,
+                  predicate: 'is_smaller_than_or_equal',
+                  value: 1988
+                }
+              ])
 
-      example_request 'Get a user by id as non-admin does not include user block data' do
-        expect(status).to eq 200
-        json_response = json_parse response_body
-        expect(json_response.dig(:data, :attributes)).not_to have_key(:blocked)
-        expect(json_response.dig(:data, :attributes)).not_to have_key(:block_start_at)
-        expect(json_response.dig(:data, :attributes)).not_to have_key(:block_end_at)
-        expect(json_response.dig(:data, :attributes)).not_to have_key(:block_reason)
-      end
-    end
+              project.permissions.find_by(action: 'posting_idea')
+                .update!(permitted_by: 'groups', groups: [old_timers])
+            end
+          end
 
-    get 'web_api/v1/users/:id' do
-      let(:id) { @user.id }
+          context 'on a resident' do
+            let(:resident) { create :user }
+            let(:id) { resident.id }
+            let(:roles) { [type: 'admin'] }
 
-      example 'Get the authenticated user exposes the email field', document: false do
-        do_request
-        json_response = json_parse response_body
-        expect(json_response.dig(:data, :attributes, :email)).to eq @user.email
-      end
-    end
+            example_request 'Make the user (resident) admin' do
+              assert_status 200
+              json_response = json_parse response_body
+              expect(json_response.dig(:data, :id)).to eq id
+              expect(json_response.dig(:data, :attributes, :roles)).to eq [{ type: 'admin' }]
+            end
+          end
 
-    get 'web_api/v1/users/by_slug/:slug' do
-      let(:user) { create :user }
-      let(:slug) { user.slug }
+          context 'on a folder moderator' do
+            let(:folder) { create :project_folder }
+            let(:moderator) { create :project_folder_moderator, project_folders: [folder] }
+            let(:id) { moderator.id }
+            let(:roles) { moderator.roles + [{ 'type' => 'admin' }] }
 
-      example_request 'Get one user by slug' do
-        expect(status).to eq 200
-        json_response = json_parse response_body
-        expect(json_response.dig(:data, :id)).to eq user.id
-      end
-
-      example '[error] Get an unexisting user by slug', document: false do
-        do_request slug: 'unexisting-user'
-        expect(status).to eq 404
-      end
-
-      example_request 'Get a user by slug as non-admin does not include user block data' do
-        expect(status).to eq 200
-        json_response = json_parse response_body
-        expect(json_response.dig(:data, :attributes)).not_to have_key(:blocked)
-        expect(json_response.dig(:data, :attributes)).not_to have_key(:block_start_at)
-        expect(json_response.dig(:data, :attributes)).not_to have_key(:block_end_at)
-        expect(json_response.dig(:data, :attributes)).not_to have_key(:block_reason)
+            example_request 'Make the user (folder moderator) admin' do
+              assert_status 200
+              json_response = json_parse response_body
+              expect(json_response.dig(:data, :id)).to eq id
+              expect(json_response.dig(:data, :attributes, :roles)).to include({ type: 'admin' })
+            end
+          end
+        end
       end
     end
 
-    get 'web_api/v1/users/by_invite/:token' do
-      let!(:invite) { create(:invite) }
-      let(:token) { invite.token }
-
-      example_request 'Get a user by invite' do
-        expect(status).to eq 200
-        json_response = json_parse(response_body)
-        expect(json_response.dig(:data, :id)).to eq invite.invitee.id
-        expect(json_response.dig(:data, :attributes, :email)).to eq invite.invitee.email
-      end
-
-      describe do
-        let(:token) { 'n0ns3ns3' }
-
-        example '[error] Get an unexisting user by invite token', document: false do
+    context 'when non-admin' do
+      get 'web_api/v1/users' do
+        with_options scope: :page do
+          parameter :number, 'Page number'
+          parameter :size, 'Number of users per page'
+        end
+        example 'Get all users as non-admin', document: false do
           do_request
+          assert_status 401
+        end
+      end
+
+      get 'web_api/v1/users/:id' do
+        let(:id) { @user.id }
+
+        example_request 'Get one user by id' do
+          do_request
+          expect(status).to eq 200
+          json_response = json_parse response_body
+          expect(json_response.dig(:data, :attributes, :highest_role)).to eq 'user'
+        end
+      end
+
+      get 'web_api/v1/users/:id' do
+        let(:user) { create :user }
+        let(:id) { user.id }
+
+        example_request 'Get a user by id does not include user block data' do
+          expect(status).to eq 200
+          json_response = json_parse response_body
+          expect(json_response.dig(:data, :attributes)).not_to have_key(:blocked)
+          expect(json_response.dig(:data, :attributes)).not_to have_key(:block_start_at)
+          expect(json_response.dig(:data, :attributes)).not_to have_key(:block_end_at)
+          expect(json_response.dig(:data, :attributes)).not_to have_key(:block_reason)
+        end
+      end
+
+      get 'web_api/v1/users/:id' do
+        let(:id) { @user.id }
+
+        example 'Get the authenticated user exposes the email field', document: false do
+          do_request
+          json_response = json_parse response_body
+          expect(json_response.dig(:data, :attributes, :email)).to eq @user.email
+        end
+      end
+
+      get 'web_api/v1/users/by_slug/:slug' do
+        let(:user) { create :user }
+        let(:slug) { user.slug }
+
+        example_request 'Get one user by slug' do
+          expect(status).to eq 200
+          json_response = json_parse response_body
+          expect(json_response.dig(:data, :id)).to eq user.id
+        end
+
+        example '[error] Get an unexisting user by slug', document: false do
+          do_request slug: 'unexisting-user'
           expect(status).to eq 404
         end
+
+        example_request 'Get a user by slug does not include user block data' do
+          expect(status).to eq 200
+          json_response = json_parse response_body
+          expect(json_response.dig(:data, :attributes)).not_to have_key(:blocked)
+          expect(json_response.dig(:data, :attributes)).not_to have_key(:block_start_at)
+          expect(json_response.dig(:data, :attributes)).not_to have_key(:block_end_at)
+          expect(json_response.dig(:data, :attributes)).not_to have_key(:block_reason)
+        end
       end
-    end
 
-    get 'web_api/v1/users/me' do
-      example_request 'Get the authenticated user' do
-        json_response = json_parse(response_body)
-        expect(json_response.dig(:data, :id)).to eq(@user.id)
-        expect(json_response.dig(:data, :attributes, :verified)).to be false if CitizenLab.ee?
+      get 'web_api/v1/users/by_invite/:token' do
+        let!(:invite) { create(:invite) }
+        let(:token) { invite.token }
+
+        example_request 'Get a user by invite' do
+          expect(status).to eq 200
+          json_response = json_parse(response_body)
+          expect(json_response.dig(:data, :id)).to eq invite.invitee.id
+          expect(json_response.dig(:data, :attributes, :email)).to eq invite.invitee.email
+        end
+
+        describe do
+          let(:token) { 'n0ns3ns3' }
+
+          example '[error] Get an unexisting user by invite token', document: false do
+            do_request
+            expect(status).to eq 404
+          end
+        end
       end
-    end
 
-    put 'web_api/v1/users/:id' do
-      with_options scope: 'user' do
-        parameter :first_name, 'User full name'
-        parameter :last_name, 'User full name'
-        parameter :email, 'E-mail address'
-        parameter :password, 'Password'
-        parameter :locale, 'Locale. Should be one of the tenants locales'
-        parameter :avatar, 'Base64 encoded avatar image'
-        parameter :roles, 'Roles array, only allowed when admin'
-        parameter :bio_multiloc, 'A little text, allowing the user to describe herself. Multiloc and non-html'
-        parameter :custom_field_values, 'An object that can only contain keys for custom fields for users'
+      get 'web_api/v1/users/me' do
+        example_request 'Get the authenticated user' do
+          json_response = json_parse(response_body)
+          expect(json_response.dig(:data, :id)).to eq(@user.id)
+          expect(json_response.dig(:data, :attributes, :verified)).to be false if CitizenLab.ee?
+        end
       end
-      ValidationErrorHelper.new.error_fields(self, User)
 
-      let(:id) { @user.id }
-      let(:first_name) { 'Edmond' }
+      put 'web_api/v1/users/:id' do
+        with_options scope: 'user' do
+          parameter :first_name, 'User full name'
+          parameter :last_name, 'User full name'
+          parameter :email, 'E-mail address'
+          parameter :password, 'Password'
+          parameter :locale, 'Locale. Should be one of the tenants locales'
+          parameter :avatar, 'Base64 encoded avatar image'
+          parameter :roles, 'Roles array, only allowed when admin'
+          parameter :bio_multiloc, 'A little text, allowing the user to describe herself. Multiloc and non-html'
+          parameter :custom_field_values, 'An object that can only contain keys for custom fields for users'
+        end
+        ValidationErrorHelper.new.error_fields(self, User)
 
-      describe do
-        let(:custom_field_values) { { birthyear: 1984 } }
-        let(:project) { create(:continuous_project) }
+        let(:id) { @user.id }
+        let(:first_name) { 'Edmond' }
 
+        describe do
+          let(:custom_field_values) { { birthyear: 1984 } }
+          let(:project) { create(:continuous_project) }
+
+          before do
+            if CitizenLab.ee?
+              old_timers = create(:smart_group, rules: [
+                {
+                  ruleType: 'custom_field_number',
+                  customFieldId: create(:custom_field_number, title_multiloc: { 'en' => 'Birthyear?' }, key: 'birthyear', code: 'birthyear').id,
+                  predicate: 'is_smaller_than_or_equal',
+                  value: 1988
+                }
+              ])
+
+              project.permissions.find_by(action: 'posting_idea')
+                .update!(permitted_by: 'groups', groups: [old_timers])
+            end
+          end
+
+          example_request 'Update a user' do
+            expect(response_status).to eq 200
+            expect(response_data.dig(:attributes, :first_name)).to eq(first_name)
+
+            if CitizenLab.ee?
+              expect(json_response_body[:included].find { |i| i[:type] == 'project' }&.dig(:attributes, :slug)).to eq project.slug
+              expect(json_response_body[:included].find { |i| i[:type] == 'permission' }&.dig(:attributes, :permitted_by)).to eq 'groups'
+              expect(response_data.dig(:relationships, :granted_permissions, :data).size).to eq(1)
+            end
+          end
+        end
+
+        # NOTE: To be included in an upcoming iteration
+        # context 'when the user_confirmation module is active' do
+        #   before do
+        #     SettingsService.new.activate_feature! 'user_confirmation'
+        #   end
+
+        #   describe 'Changing the email' do
+        #     let(:email) { 'new-email@email.com' }
+
+        #     example_request 'Requires confirmation' do
+        #       json_response = json_parse(response_body)
+        #       expect(json_response.dig(:data, :attributes, :confirmation_required)).to be true
+        #     end
+
+        #     example_request 'Sends a confirmation email' do
+        #       last_email = ActionMailer::Base.deliveries.last
+        #       user       = User.find(id)
+        #       expect(last_email.to).to include user.reload.email
+        #     end
+        #   end
+        # end
+
+        describe do
+          example "Update a user's custom field values" do
+            cf = create(:custom_field)
+            do_request(user: { custom_field_values: { cf.key => 'somevalue' } })
+            json_response = json_parse(response_body)
+            expect(json_response.dig(:data, :attributes, :custom_field_values, cf.key.to_sym)).to eq 'somevalue'
+          end
+
+          example "Clear out a user's custom field value" do
+            cf = create(:custom_field)
+            @user.update!(custom_field_values: { cf.key => 'somevalue' })
+
+            do_request(user: { custom_field_values: {} })
+            expect(response_status).to eq 200
+            expect(@user.reload.custom_field_values).to eq({})
+          end
+
+          example 'Cannot modify values of hidden custom fields' do
+            cf = create(:custom_field, hidden: true, enabled: true)
+            some_value = 'some_value'
+            @user.update!(custom_field_values: { cf.key => some_value })
+
+            do_request(user: { custom_field_values: { cf.key => 'another_value' } })
+            json_response = json_parse(response_body)
+
+            expect(json_response.dig(:data, :attributes, :custom_field_values)).not_to include(cf.key.to_sym)
+            expect(@user.custom_field_values[cf.key]).to eq(some_value)
+          end
+
+          example 'Cannot modify values of disabled custom fields' do
+            cf = create(:custom_field, hidden: false, enabled: false)
+            some_value = 'some_value'
+            @user.update!(custom_field_values: { cf.key => some_value })
+
+            do_request(user: { custom_field_values: { cf.key => 'another_value' } })
+            json_response = json_parse(response_body)
+
+            expect(json_response.dig(:data, :attributes, :custom_field_values)).not_to include(cf.key.to_sym)
+            expect(@user.custom_field_values[cf.key]).to eq(some_value)
+          end
+        end
+
+        describe do
+          example 'The user avatar can be removed' do
+            @user.update!(avatar: Rails.root.join('spec/fixtures/male_avatar_1.jpg').open)
+            expect(@user.reload.avatar_url).to be_present
+            do_request user: { avatar: nil }
+            expect(@user.reload.avatar_url).to be_nil
+          end
+        end
+
+        describe do
+          let(:cf) { create(:custom_field) }
+          let(:birthyear_cf) { create(:custom_field_birthyear) }
+          let(:custom_field_values) do
+            {
+              cf.key => 'new value',
+              birthyear_cf.key => birthyear
+            }
+          end
+          let(:first_name) { 'Raymond' }
+          let(:last_name) { 'Betancourt' }
+          let(:email) { 'ray.mond@rocks.com' }
+          let(:locale) { 'fr-FR' }
+          let(:birthyear) { 1969 }
+
+          example "Can't change some attributes of a user verified with FranceConnect", document: false, skip: !CitizenLab.ee? do
+            create(:verification, method_name: 'franceconnect', user: @user)
+            @user.update!(custom_field_values: { cf.key => 'original value', birthyear_cf.key => 1950 })
+            do_request
+            expect(response_status).to eq 200
+            @user.reload
+            expect(@user.custom_field_values[cf.key]).to eq 'new value'
+            expect(@user.first_name).not_to eq first_name
+            expect(@user.last_name).not_to eq last_name
+            expect(@user.email).to eq email
+          end
+
+          example 'Can change many attributes of a user verified with FranceConnect', document: false, skip: !CitizenLab.ee? do
+            create(:verification, method_name: 'franceconnect', user: @user)
+            do_request
+            expect(response_status).to eq 200
+            @user.reload
+            expect(@user.email).to eq email
+            expect(@user.locale).to eq locale
+            expect(@user.birthyear).to eq birthyear
+          end
+        end
+
+        describe do
+          let(:cf) { create(:custom_field) }
+          let(:gender_cf) { create(:custom_field_gender) }
+          let(:custom_field_values) do
+            {
+              cf.key => 'new value',
+              gender_cf.key => 'female'
+            }
+          end
+
+          example "Can't change gender of a user verified with Bogus", document: false, skip: !CitizenLab.ee? do
+            create(:verification, method_name: 'bogus', user: @user)
+            @user.update!(custom_field_values: { cf.key => 'original value', gender_cf.key => 'male' })
+            do_request
+            expect(response_status).to eq 200
+            @user.reload
+            expect(@user.custom_field_values[cf.key]).to eq 'new value'
+            expect(@user.custom_field_values[gender_cf.key]).to eq 'male'
+          end
+        end
+      end
+
+      post 'web_api/v1/users/complete_registration' do
+        with_options scope: :user do
+          parameter :custom_field_values, 'An object that can only contain keys for custom fields for users', required: true
+        end
+
+        let(:cf1) { create(:custom_field) }
+        let(:cf2) { create(:custom_field_multiselect, required: true) }
+        let(:cf2_options) { create_list(:custom_field_option, 2, custom_field: cf2) }
+        let(:custom_field_values) { { cf1.key => 'somevalue', cf2.key => [cf2_options.first.key] } }
+
+        example 'Complete the registration of a user' do
+          @user.update! registration_completed_at: nil
+          do_request
+          expect(response_status).to eq 200
+          json_response = json_parse(response_body)
+          expect(json_response.dig(:data, :attributes, :registration_completed_at)).to be_present
+          expect(json_response.dig(:data, :attributes, :custom_field_values, cf1.key.to_sym)).to eq 'somevalue'
+          expect(json_response.dig(:data, :attributes, :custom_field_values, cf2.key.to_sym)).to eq [cf2_options.first.key]
+        end
+
+        example '[error] Complete the registration of a user fails if not all required fields are provided' do
+          @user.update! registration_completed_at: nil
+          do_request(user: { custom_field_values: { cf2.key => nil } })
+          assert_status 422
+        end
+
+        example '[error] Complete the registration of a user fails if the user has already completed signup' do
+          do_request
+          expect(response_status).to eq 401
+        end
+
+        describe do
+          let(:cf) { create(:custom_field) }
+          let(:gender_cf) { create(:custom_field_gender) }
+          let(:custom_field_values) do
+            {
+              cf.key => 'new value',
+              gender_cf.key => 'female'
+            }
+          end
+
+          example "Can't change some custom_field_values of a user verified with Bogus", document: false, skip: !CitizenLab.ee? do
+            @user.update!(
+              registration_completed_at: nil,
+              custom_field_values: { cf.key => 'original value', gender_cf.key => 'male' }
+            )
+            create(:verification, method_name: 'bogus', user: @user)
+            do_request
+            expect(response_status).to eq 200
+            @user.reload
+            expect(@user.custom_field_values[cf.key]).to eq 'new value'
+            expect(@user.custom_field_values[gender_cf.key]).to eq 'male'
+          end
+        end
+      end
+
+      post 'web_api/v1/users/update_password' do
+        with_options scope: :user do
+          parameter :current_password, required: true
+          parameter :new_password, required: true
+        end
+        describe do
+          let(:current_password) { 'test_current_password' }
+          let(:new_password) { 'test_new_password' }
+
+          example_request 'update password with wrong current password' do
+            expect(response_status).to eq 422
+            json_response = json_parse(response_body)
+            expect(json_response[:errors][:current_password][0][:error]).to eq 'invalid'
+          end
+        end
+
+        describe do
+          let(:current_password) { 'democracy2.0' }
+          let(:new_password) { 'test_new_password' }
+
+          example_request 'update password with correct current password' do
+            @user.reload
+            expect(response_status).to eq 200
+            expect(BCrypt::Password.new(@user.password_digest)).to be_is_password('test_new_password')
+          end
+        end
+      end
+
+      delete 'web_api/v1/users/:id' do
         before do
-          if CitizenLab.ee?
-            old_timers = create(:smart_group, rules: [
-              {
-                ruleType: 'custom_field_number',
-                customFieldId: create(:custom_field_number, title_multiloc: { 'en' => 'Birthyear?' }, key: 'birthyear', code: 'birthyear').id,
-                predicate: 'is_smaller_than_or_equal',
-                value: 1988
-              }
-            ])
-
-            project.permissions.find_by(action: 'posting_idea')
-              .update!(permitted_by: 'groups', groups: [old_timers])
-          end
+          @user.update!(roles: [{ type: 'admin' }])
+          @subject_user = create :admin
         end
 
-        example_request 'Update a user' do
+        let(:id) { @subject_user.id }
+
+        example_request 'Delete a user' do
           expect(response_status).to eq 200
-          expect(response_data.dig(:attributes, :first_name)).to eq(first_name)
-
-          if CitizenLab.ee?
-            expect(json_response_body[:included].find { |i| i[:type] == 'project' }&.dig(:attributes, :slug)).to eq project.slug
-            expect(json_response_body[:included].find { |i| i[:type] == 'permission' }&.dig(:attributes, :permitted_by)).to eq 'groups'
-            expect(response_data.dig(:relationships, :granted_permissions, :data).size).to eq(1)
-          end
+          expect { User.find(id) }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
 
-      # NOTE: To be included in an upcoming iteration
-      # context 'when the user_confirmation module is active' do
-      #   before do
-      #     SettingsService.new.activate_feature! 'user_confirmation'
-      #   end
+      get 'web_api/v1/users/:id/ideas_count' do
+        let(:id) { @user.id }
 
-      #   describe 'Changing the email' do
-      #     let(:email) { 'new-email@email.com' }
-
-      #     example_request 'Requires confirmation' do
-      #       json_response = json_parse(response_body)
-      #       expect(json_response.dig(:data, :attributes, :confirmation_required)).to be true
-      #     end
-
-      #     example_request 'Sends a confirmation email' do
-      #       last_email = ActionMailer::Base.deliveries.last
-      #       user       = User.find(id)
-      #       expect(last_email.to).to include user.reload.email
-      #     end
-      #   end
-      # end
-
-      context 'when admin' do
-        before { @user.update! roles: [{ type: 'admin' }] }
-
-        context 'on a resident' do
-          let(:resident) { create :user }
-          let(:id) { resident.id }
-          let(:roles) { [type: 'admin'] }
-
-          example_request 'Make the user admin' do
-            assert_status 200
-            json_response = json_parse response_body
-            expect(json_response.dig(:data, :id)).to eq id
-            expect(json_response.dig(:data, :attributes, :roles)).to eq [{ type: 'admin' }]
-          end
-        end
-
-        context 'on a folder moderator' do
-          let(:folder) { create :project_folder }
-          let(:moderator) { create :project_folder_moderator, project_folders: [folder] }
-          let(:id) { moderator.id }
-          let(:roles) { moderator.roles + [{ 'type' => 'admin' }] }
-
-          example_request 'Make the user admin' do
-            assert_status 200
-            json_response = json_parse response_body
-            expect(json_response.dig(:data, :id)).to eq id
-            expect(json_response.dig(:data, :attributes, :roles)).to include({ type: 'admin' })
-          end
-        end
-      end
-
-      describe do
-        example "Update a user's custom field values" do
-          cf = create(:custom_field)
-          do_request(user: { custom_field_values: { cf.key => 'somevalue' } })
-          json_response = json_parse(response_body)
-          expect(json_response.dig(:data, :attributes, :custom_field_values, cf.key.to_sym)).to eq 'somevalue'
-        end
-
-        example "Clear out a user's custom field value" do
-          cf = create(:custom_field)
-          @user.update!(custom_field_values: { cf.key => 'somevalue' })
-
-          do_request(user: { custom_field_values: {} })
-          expect(response_status).to eq 200
-          expect(@user.reload.custom_field_values).to eq({})
-        end
-
-        example 'Cannot modify values of hidden custom fields' do
-          cf = create(:custom_field, hidden: true, enabled: true)
-          some_value = 'some_value'
-          @user.update!(custom_field_values: { cf.key => some_value })
-
-          do_request(user: { custom_field_values: { cf.key => 'another_value' } })
-          json_response = json_parse(response_body)
-
-          expect(json_response.dig(:data, :attributes, :custom_field_values)).not_to include(cf.key.to_sym)
-          expect(@user.custom_field_values[cf.key]).to eq(some_value)
-        end
-
-        example 'Cannot modify values of disabled custom fields' do
-          cf = create(:custom_field, hidden: false, enabled: false)
-          some_value = 'some_value'
-          @user.update!(custom_field_values: { cf.key => some_value })
-
-          do_request(user: { custom_field_values: { cf.key => 'another_value' } })
-          json_response = json_parse(response_body)
-
-          expect(json_response.dig(:data, :attributes, :custom_field_values)).not_to include(cf.key.to_sym)
-          expect(@user.custom_field_values[cf.key]).to eq(some_value)
-        end
-      end
-
-      describe do
-        example 'The user avatar can be removed' do
-          @user.update!(avatar: Rails.root.join('spec/fixtures/male_avatar_1.jpg').open)
-          expect(@user.reload.avatar_url).to be_present
-          do_request user: { avatar: nil }
-          expect(@user.reload.avatar_url).to be_nil
-        end
-      end
-
-      describe do
-        let(:cf) { create(:custom_field) }
-        let(:birthyear_cf) { create(:custom_field_birthyear) }
-        let(:custom_field_values) do
-          {
-            cf.key => 'new value',
-            birthyear_cf.key => birthyear
-          }
-        end
-        let(:first_name) { 'Raymond' }
-        let(:last_name) { 'Betancourt' }
-        let(:email) { 'ray.mond@rocks.com' }
-        let(:locale) { 'fr-FR' }
-        let(:birthyear) { 1969 }
-
-        example "Can't change some attributes of a user verified with FranceConnect", document: false, skip: !CitizenLab.ee? do
-          create(:verification, method_name: 'franceconnect', user: @user)
-          @user.update!(custom_field_values: { cf.key => 'original value', birthyear_cf.key => 1950 })
+        example 'Get the number of ideas published by one user' do
+          IdeaStatus.create_defaults
+          create(:idea, author: @user)
+          create(:idea)
+          create(:idea, author: @user, publication_status: 'draft')
+          create(:idea, author: @user, project: create(:continuous_native_survey_project))
           do_request
-          expect(response_status).to eq 200
-          @user.reload
-          expect(@user.custom_field_values[cf.key]).to eq 'new value'
-          expect(@user.first_name).not_to eq first_name
-          expect(@user.last_name).not_to eq last_name
-          expect(@user.email).to eq email
-        end
-
-        example 'Can change many attributes of a user verified with FranceConnect', document: false, skip: !CitizenLab.ee? do
-          create(:verification, method_name: 'franceconnect', user: @user)
-          do_request
-          expect(response_status).to eq 200
-          @user.reload
-          expect(@user.email).to eq email
-          expect(@user.locale).to eq locale
-          expect(@user.birthyear).to eq birthyear
-        end
-      end
-
-      describe do
-        let(:cf) { create(:custom_field) }
-        let(:gender_cf) { create(:custom_field_gender) }
-        let(:custom_field_values) do
-          {
-            cf.key => 'new value',
-            gender_cf.key => 'female'
-          }
-        end
-
-        example "Can't change gender of a user verified with Bogus", document: false, skip: !CitizenLab.ee? do
-          create(:verification, method_name: 'bogus', user: @user)
-          @user.update!(custom_field_values: { cf.key => 'original value', gender_cf.key => 'male' })
-          do_request
-          expect(response_status).to eq 200
-          @user.reload
-          expect(@user.custom_field_values[cf.key]).to eq 'new value'
-          expect(@user.custom_field_values[gender_cf.key]).to eq 'male'
-        end
-      end
-    end
-
-    post 'web_api/v1/users/complete_registration' do
-      with_options scope: :user do
-        parameter :custom_field_values, 'An object that can only contain keys for custom fields for users', required: true
-      end
-
-      let(:cf1) { create(:custom_field) }
-      let(:cf2) { create(:custom_field_multiselect, required: true) }
-      let(:cf2_options) { create_list(:custom_field_option, 2, custom_field: cf2) }
-      let(:custom_field_values) { { cf1.key => 'somevalue', cf2.key => [cf2_options.first.key] } }
-
-      example 'Complete the registration of a user' do
-        @user.update! registration_completed_at: nil
-        do_request
-        expect(response_status).to eq 200
-        json_response = json_parse(response_body)
-        expect(json_response.dig(:data, :attributes, :registration_completed_at)).to be_present
-        expect(json_response.dig(:data, :attributes, :custom_field_values, cf1.key.to_sym)).to eq 'somevalue'
-        expect(json_response.dig(:data, :attributes, :custom_field_values, cf2.key.to_sym)).to eq [cf2_options.first.key]
-      end
-
-      example '[error] Complete the registration of a user fails if not all required fields are provided' do
-        @user.update! registration_completed_at: nil
-        do_request(user: { custom_field_values: { cf2.key => nil } })
-        assert_status 422
-      end
-
-      example '[error] Complete the registration of a user fails if the user has already completed signup' do
-        do_request
-        expect(response_status).to eq 401
-      end
-
-      describe do
-        let(:cf) { create(:custom_field) }
-        let(:gender_cf) { create(:custom_field_gender) }
-        let(:custom_field_values) do
-          {
-            cf.key => 'new value',
-            gender_cf.key => 'female'
-          }
-        end
-
-        example "Can't change some custom_field_values of a user verified with Bogus", document: false, skip: !CitizenLab.ee? do
-          @user.update!(
-            registration_completed_at: nil,
-            custom_field_values: { cf.key => 'original value', gender_cf.key => 'male' }
-          )
-          create(:verification, method_name: 'bogus', user: @user)
-          do_request
-          expect(response_status).to eq 200
-          @user.reload
-          expect(@user.custom_field_values[cf.key]).to eq 'new value'
-          expect(@user.custom_field_values[gender_cf.key]).to eq 'male'
-        end
-      end
-    end
-
-    post 'web_api/v1/users/update_password' do
-      with_options scope: :user do
-        parameter :current_password, required: true
-        parameter :new_password, required: true
-      end
-      describe do
-        let(:current_password) { 'test_current_password' }
-        let(:new_password) { 'test_new_password' }
-
-        example_request 'update password with wrong current password' do
-          expect(response_status).to eq 422
+          expect(status).to eq 200
           json_response = json_parse(response_body)
-          expect(json_response[:errors][:current_password][0][:error]).to eq 'invalid'
+          expect(json_response[:count]).to eq 1
         end
       end
 
-      describe do
-        let(:current_password) { 'democracy2.0' }
-        let(:new_password) { 'test_new_password' }
+      get 'web_api/v1/users/:id/initiatives_count' do
+        let(:id) { @user.id }
 
-        example_request 'update password with correct current password' do
-          @user.reload
-          expect(response_status).to eq 200
-          expect(BCrypt::Password.new(@user.password_digest)).to be_is_password('test_new_password')
+        example 'Get the number of initiatives published by one user' do
+          create(:initiative, author: @user)
+          create(:initiative)
+          create(:initiative, author: @user, publication_status: 'draft')
+          do_request
+          assert_status 200
+          json_response = json_parse response_body
+          expect(json_response.dig(:data, :type)).to eq 'initiatives_count'
+          expect(json_response.dig(:data, :attributes, :count)).to eq 1
         end
       end
-    end
 
-    delete 'web_api/v1/users/:id' do
-      before do
-        @user.update!(roles: [{ type: 'admin' }])
-        @subject_user = create :admin
-      end
+      get 'web_api/v1/users/:id/comments_count' do
+        parameter :post_type, "Count only comments of one post type. Either 'Idea' or 'Initiative'.", required: false
 
-      let(:id) { @subject_user.id }
+        let(:id) { @user.id }
 
-      example_request 'Delete a user' do
-        expect(response_status).to eq 200
-        expect { User.find(id) }.to raise_error(ActiveRecord::RecordNotFound)
-      end
-    end
+        example 'Get the number of comments posted by one user' do
+          create(:comment, author: @user, post: create(:initiative))
+          create(:comment)
+          create(:comment, author: @user, post: create(:idea))
+          create(:comment, author: @user, publication_status: 'deleted')
+          do_request
+          expect(status).to eq 200
+          json_response = json_parse(response_body)
+          expect(json_response[:count]).to eq 2
+        end
 
-    get 'web_api/v1/users/:id/ideas_count' do
-      let(:id) { @user.id }
+        example 'Get the number of comments on ideas posted by one user' do
+          create(:comment, author: @user, post: create(:initiative))
+          create(:comment, post: create(:initiative))
+          create(:comment, author: @user, post: create(:idea))
+          create(:comment, author: @user, post: create(:idea))
+          create(:comment, author: @user, publication_status: 'deleted', post: create(:idea))
+          do_request post_type: 'Idea'
+          expect(status).to eq 200
+          json_response = json_parse(response_body)
+          expect(json_response[:count]).to eq 2
+        end
 
-      example 'Get the number of ideas published by one user' do
-        IdeaStatus.create_defaults
-        create(:idea, author: @user)
-        create(:idea)
-        create(:idea, author: @user, publication_status: 'draft')
-        create(:idea, author: @user, project: create(:continuous_native_survey_project))
-        do_request
-        expect(status).to eq 200
-        json_response = json_parse(response_body)
-        expect(json_response[:count]).to eq 1
-      end
-    end
-
-    get 'web_api/v1/users/:id/initiatives_count' do
-      let(:id) { @user.id }
-
-      example 'Get the number of initiatives published by one user' do
-        create(:initiative, author: @user)
-        create(:initiative)
-        create(:initiative, author: @user, publication_status: 'draft')
-        do_request
-        assert_status 200
-        json_response = json_parse response_body
-        expect(json_response.dig(:data, :type)).to eq 'initiatives_count'
-        expect(json_response.dig(:data, :attributes, :count)).to eq 1
-      end
-    end
-
-    get 'web_api/v1/users/:id/comments_count' do
-      parameter :post_type, "Count only comments of one post type. Either 'Idea' or 'Initiative'.", required: false
-
-      let(:id) { @user.id }
-
-      example 'Get the number of comments posted by one user' do
-        create(:comment, author: @user, post: create(:initiative))
-        create(:comment)
-        create(:comment, author: @user, post: create(:idea))
-        create(:comment, author: @user, publication_status: 'deleted')
-        do_request
-        expect(status).to eq 200
-        json_response = json_parse(response_body)
-        expect(json_response[:count]).to eq 2
-      end
-
-      example 'Get the number of comments on ideas posted by one user' do
-        create(:comment, author: @user, post: create(:initiative))
-        create(:comment, post: create(:initiative))
-        create(:comment, author: @user, post: create(:idea))
-        create(:comment, author: @user, post: create(:idea))
-        create(:comment, author: @user, publication_status: 'deleted', post: create(:idea))
-        do_request post_type: 'Idea'
-        expect(status).to eq 200
-        json_response = json_parse(response_body)
-        expect(json_response[:count]).to eq 2
-      end
-
-      example 'Get the number of comments on initiatives posted by one user' do
-        create(:comment, author: @user, post: create(:initiative))
-        create(:comment, author: @user, post: create(:initiative))
-        create(:comment, post: create(:idea))
-        create(:comment, author: @user, post: create(:idea))
-        create(:comment, author: @user, publication_status: 'deleted', post: create(:initiative))
-        do_request post_type: 'Initiative'
-        expect(status).to eq 200
-        json_response = json_parse(response_body)
-        expect(json_response[:count]).to eq 2
+        example 'Get the number of comments on initiatives posted by one user' do
+          create(:comment, author: @user, post: create(:initiative))
+          create(:comment, author: @user, post: create(:initiative))
+          create(:comment, post: create(:idea))
+          create(:comment, author: @user, post: create(:idea))
+          create(:comment, author: @user, publication_status: 'deleted', post: create(:initiative))
+          do_request post_type: 'Initiative'
+          expect(status).to eq 200
+          json_response = json_parse(response_body)
+          expect(json_response[:count]).to eq 2
+        end
       end
     end
   end

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -470,7 +470,7 @@ resource 'Users' do
           }
           AppConfiguration.instance.update!(settings: settings)
 
-          do_request blocked: true
+          do_request only_blocked: true
 
           expect(status).to eq 200
           json_response = json_parse(response_body)

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -545,6 +545,33 @@ resource 'Users' do
           end
         end
       end
+
+      get 'web_api/v1/users/by_slug/:slug' do
+        let(:user) { create :user }
+        let(:slug) { user.slug }
+
+        example_request 'Get one user by slug includes user block data' do
+          expect(status).to eq 200
+          json_response = json_parse response_body
+          expect(json_response.dig(:data, :attributes)).to have_key(:blocked)
+          expect(json_response.dig(:data, :attributes)).to have_key(:block_start_at)
+          expect(json_response.dig(:data, :attributes)).to have_key(:block_end_at)
+          expect(json_response.dig(:data, :attributes)).to have_key(:block_reason)
+        end
+      end
+
+      get 'web_api/v1/users/:id' do
+        let(:id) { @user.id }
+
+        example_request 'Get a user by id includes user block data' do
+          expect(status).to eq 200
+          json_response = json_parse response_body
+          expect(json_response.dig(:data, :attributes)).to have_key(:blocked)
+          expect(json_response.dig(:data, :attributes)).to have_key(:block_start_at)
+          expect(json_response.dig(:data, :attributes)).to have_key(:block_end_at)
+          expect(json_response.dig(:data, :attributes)).to have_key(:block_reason)
+        end
+      end
     end
 
     get 'web_api/v1/users' do
@@ -566,6 +593,20 @@ resource 'Users' do
         expect(status).to eq 200
         json_response = json_parse response_body
         expect(json_response.dig(:data, :attributes, :highest_role)).to eq 'user'
+      end
+    end
+
+    get 'web_api/v1/users/:id' do
+      let(:user) { create :user }
+      let(:id) { user.id }
+
+      example_request 'Get a user by id as non-admin does not include user block data' do
+        expect(status).to eq 200
+        json_response = json_parse response_body
+        expect(json_response.dig(:data, :attributes)).not_to have_key(:blocked)
+        expect(json_response.dig(:data, :attributes)).not_to have_key(:block_start_at)
+        expect(json_response.dig(:data, :attributes)).not_to have_key(:block_end_at)
+        expect(json_response.dig(:data, :attributes)).not_to have_key(:block_reason)
       end
     end
 
@@ -592,6 +633,15 @@ resource 'Users' do
       example '[error] Get an unexisting user by slug', document: false do
         do_request slug: 'unexisting-user'
         expect(status).to eq 404
+      end
+
+      example_request 'Get a user by slug as non-admin does not include user block data' do
+        expect(status).to eq 200
+        json_response = json_parse response_body
+        expect(json_response.dig(:data, :attributes)).not_to have_key(:blocked)
+        expect(json_response.dig(:data, :attributes)).not_to have_key(:block_start_at)
+        expect(json_response.dig(:data, :attributes)).not_to have_key(:block_end_at)
+        expect(json_response.dig(:data, :attributes)).not_to have_key(:block_reason)
       end
     end
 


### PR DESCRIPTION
Adds index parameter `only_blocked` to list only blocked users. Only admins can get data from the user index endpoint.

`GET http://localhost:3000/web_api/v1/users?only_blocked=true`

-------------------------

Adds `blocked_count` endpoint (only Admins are authorised):

`GET http://localhost:3000/web_api/v1/users/blocked_count`
```JSON
{
    "data": {
        "blocked_users_count": 5
    }
}
```
-----------------------------
Adds `blocked` (boolean), `block_start_at`, `block_end_at` and `block_reason` to `UserSerializer`.

None are included in responses to regular users.

`blocked` & `block_end_at` are computed when serializing the response data. They are not attributes that are saved to the user record or any other persistent record. This is because they depend on the duration that is set for `user_blocking`, and this can be changed.

Example:

Admin requests `GET http://localhost:3000/web_api/v1/users/by_slug/jonah-lauaki`
```JSON
{
    "data": {
        "id": "386d255e-2ff1-4192-8e50-b3022576be50",
        "type": "user",
        "attributes": {
            "first_name": "Jonah",
            "slug": "jonah-lauaki",
            ...
            "blocked": "true",
            "block_start_at": "2023-02-06T10:21:36.865Z",
            "block_end_at": "2023-05-07T10:21:36.865Z",
            "block_reason": "Did a bad thing!",
            "created_at": "2023-02-20T00:00:00.000Z",
            "updated_at": "2023-03-08T16:25:13.085Z",
            ...
     }
}
```
--------------------------------

## Changelog
- [CL-3048] Return blocked user related data in user related responses, for user blocking feature (feature in development)


[CL-3048]: https://citizenlab.atlassian.net/browse/CL-3048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ