### PR TITLE
[CL-3101] Disable email confirmation toggle if email-only permissions allowed

### DIFF
--- a/front/app/containers/Admin/settings/registration/ToggleUserConfirmation/index.tsx
+++ b/front/app/containers/Admin/settings/registration/ToggleUserConfirmation/index.tsx
@@ -45,33 +45,35 @@ const ToggleUserConfirmation = ({ isEnabled, onChange }: Props) => {
     onChange(!isEnabled);
   };
 
+  if (!showEmailConfirmationToggle) {
+    return null;
+  }
+
   return (
-    showEmailConfirmationToggle && (
-      <Box mb="35px">
-        <SubSectionTitle>
-          <FormattedMessage {...messages.accountConfirmation} />
-          <IconTooltip
-            content={
-              <FormattedMessage
-                {...messages.whenTurnedOnUsersWillHaveToConfirm}
-              />
-            }
-          />
-        </SubSectionTitle>
-        <ToggleLabel>
-          <StyledToggle
-            checked={isEnabled}
-            onChange={handleChange}
-            labelTextColor={colors.primary}
-          />
-          {isEnabled ? (
-            <FormattedMessage {...messages.enabled} />
-          ) : (
-            <FormattedMessage {...messages.disabled} />
-          )}
-        </ToggleLabel>
-      </Box>
-    )
+    <Box mb="35px">
+      <SubSectionTitle>
+        <FormattedMessage {...messages.accountConfirmation} />
+        <IconTooltip
+          content={
+            <FormattedMessage
+              {...messages.whenTurnedOnUsersWillHaveToConfirm}
+            />
+          }
+        />
+      </SubSectionTitle>
+      <ToggleLabel>
+        <StyledToggle
+          checked={isEnabled}
+          onChange={handleChange}
+          labelTextColor={colors.primary}
+        />
+        {isEnabled ? (
+          <FormattedMessage {...messages.enabled} />
+        ) : (
+          <FormattedMessage {...messages.disabled} />
+        )}
+      </ToggleLabel>
+    </Box>
   );
 };
 

--- a/front/app/containers/Admin/settings/registration/ToggleUserConfirmation/index.tsx
+++ b/front/app/containers/Admin/settings/registration/ToggleUserConfirmation/index.tsx
@@ -45,39 +45,32 @@ const ToggleUserConfirmation = ({ isEnabled, onChange }: Props) => {
   };
 
   return (
-    <Box mb="35px">
-      <SubSectionTitle>
-        <FormattedMessage {...messages.accountConfirmation} />
-        <IconTooltip
-          content={
-            <FormattedMessage
-              {...messages.whenTurnedOnUsersWillHaveToConfirm}
-            />
-          }
-        />
-      </SubSectionTitle>
-      <ToggleLabel>
-        <StyledToggle
-          checked={isEnabled}
-          onChange={handleChange}
-          labelTextColor={colors.primary}
-          disabled={includeEmailConfirmedOption}
-        />
-        {isEnabled ? (
-          <FormattedMessage {...messages.enabled} />
-        ) : (
-          <FormattedMessage {...messages.disabled} />
-        )}
-        {includeEmailConfirmedOption && (
+    !includeEmailConfirmedOption && (
+      <Box mb="35px">
+        <SubSectionTitle>
+          <FormattedMessage {...messages.accountConfirmation} />
           <IconTooltip
-            icon="info-outline"
-            content={'Cannot disable this due to tenant settings.'}
-            ml="8px"
-            mb="4px"
+            content={
+              <FormattedMessage
+                {...messages.whenTurnedOnUsersWillHaveToConfirm}
+              />
+            }
           />
-        )}
-      </ToggleLabel>
-    </Box>
+        </SubSectionTitle>
+        <ToggleLabel>
+          <StyledToggle
+            checked={isEnabled}
+            onChange={handleChange}
+            labelTextColor={colors.primary}
+          />
+          {isEnabled ? (
+            <FormattedMessage {...messages.enabled} />
+          ) : (
+            <FormattedMessage {...messages.disabled} />
+          )}
+        </ToggleLabel>
+      </Box>
+    )
   );
 };
 

--- a/front/app/containers/Admin/settings/registration/ToggleUserConfirmation/index.tsx
+++ b/front/app/containers/Admin/settings/registration/ToggleUserConfirmation/index.tsx
@@ -10,6 +10,7 @@ import { colors } from 'utils/styleUtils';
 import messages from './messages';
 import styled from 'styled-components';
 import { SubSectionTitle } from 'components/admin/Section';
+import useFeatureFlag from 'hooks/useFeatureFlag';
 
 const StyledToggle = styled(Toggle)`
   flex-direction: row-reverse;
@@ -35,6 +36,10 @@ type Props = {
 };
 
 const ToggleUserConfirmation = ({ isEnabled, onChange }: Props) => {
+  const includeEmailConfirmedOption = useFeatureFlag({
+    name: 'permission_option_email_confirmation',
+  });
+
   const handleChange = () => {
     onChange(!isEnabled);
   };
@@ -56,11 +61,19 @@ const ToggleUserConfirmation = ({ isEnabled, onChange }: Props) => {
           checked={isEnabled}
           onChange={handleChange}
           labelTextColor={colors.primary}
+          disabled={includeEmailConfirmedOption}
         />
         {isEnabled ? (
           <FormattedMessage {...messages.enabled} />
         ) : (
           <FormattedMessage {...messages.disabled} />
+        )}
+        {includeEmailConfirmedOption && (
+          <IconTooltip
+            content={'Cannot disable this due to tenante settings.'}
+            ml="8px"
+            mb="4px"
+          />
         )}
       </ToggleLabel>
     </Box>

--- a/front/app/containers/Admin/settings/registration/ToggleUserConfirmation/index.tsx
+++ b/front/app/containers/Admin/settings/registration/ToggleUserConfirmation/index.tsx
@@ -70,7 +70,8 @@ const ToggleUserConfirmation = ({ isEnabled, onChange }: Props) => {
         )}
         {includeEmailConfirmedOption && (
           <IconTooltip
-            content={'Cannot disable this due to tenante settings.'}
+            icon="info-outline"
+            content={'Cannot disable this due to tenant settings.'}
             ml="8px"
             mb="4px"
           />

--- a/front/app/containers/Admin/settings/registration/ToggleUserConfirmation/index.tsx
+++ b/front/app/containers/Admin/settings/registration/ToggleUserConfirmation/index.tsx
@@ -36,16 +36,17 @@ type Props = {
 };
 
 const ToggleUserConfirmation = ({ isEnabled, onChange }: Props) => {
-  const includeEmailConfirmedOption = useFeatureFlag({
+  const emailConfirmPermissionEnabled = useFeatureFlag({
     name: 'permission_option_email_confirmation',
   });
+  const showEmailConfirmationToggle = !emailConfirmPermissionEnabled;
 
   const handleChange = () => {
     onChange(!isEnabled);
   };
 
   return (
-    !includeEmailConfirmedOption && (
+    showEmailConfirmationToggle && (
       <Box mb="35px">
         <SubSectionTitle>
           <FormattedMessage {...messages.accountConfirmation} />

--- a/front/app/containers/Admin/settings/registration/index.tsx
+++ b/front/app/containers/Admin/settings/registration/index.tsx
@@ -51,6 +51,11 @@ const SettingsRegistrationTab = () => {
     isSuccess: isFormSaved,
   } = useUpdateAppConfiguration();
 
+  const userConfirmationIsAllowed = useFeatureFlag({
+    name: 'user_confirmation',
+    onlyCheckAllowed: true,
+  });
+
   const [attributesDiff, setAttributesDiff] =
     useState<IUpdatedAppConfigurationProperties>({});
   const [latestAppConfigSettings, setLatestAppConfigSettings] =
@@ -152,10 +157,12 @@ const SettingsRegistrationTab = () => {
                 }
               />
             </SectionField>
-            <ToggleUserConfirmation
-              onChange={handleUserConfirmationToggleChange}
-              isEnabled={userConfirmationToggleIsEnabled}
-            />
+            {userConfirmationIsAllowed && (
+              <ToggleUserConfirmation
+                onChange={handleUserConfirmationToggleChange}
+                isEnabled={userConfirmationToggleIsEnabled}
+              />
+            )}
             <CustomFieldsSignupText
               onCoreSettingWithMultilocChange={
                 handleCoreSettingWithMultilocOnChange

--- a/front/app/containers/Admin/settings/registration/index.tsx
+++ b/front/app/containers/Admin/settings/registration/index.tsx
@@ -50,10 +50,6 @@ const SettingsRegistrationTab = () => {
     isLoading: isFormSubmitting,
     isSuccess: isFormSaved,
   } = useUpdateAppConfiguration();
-  const userConfirmationIsAllowed = useFeatureFlag({
-    name: 'user_confirmation',
-    onlyCheckAllowed: true,
-  });
 
   const [attributesDiff, setAttributesDiff] =
     useState<IUpdatedAppConfigurationProperties>({});
@@ -156,12 +152,10 @@ const SettingsRegistrationTab = () => {
                 }
               />
             </SectionField>
-            {userConfirmationIsAllowed && (
-              <ToggleUserConfirmation
-                onChange={handleUserConfirmationToggleChange}
-                isEnabled={userConfirmationToggleIsEnabled}
-              />
-            )}
+            <ToggleUserConfirmation
+              onChange={handleUserConfirmationToggleChange}
+              isEnabled={userConfirmationToggleIsEnabled}
+            />
             <CustomFieldsSignupText
               onCoreSettingWithMultilocChange={
                 handleCoreSettingWithMultilocOnChange

--- a/front/app/modules/commercial/granular_permissions/admin/containers/Granular/ActionForm.tsx
+++ b/front/app/modules/commercial/granular_permissions/admin/containers/Granular/ActionForm.tsx
@@ -52,7 +52,6 @@ const ActionForm = ({
   const emailConfirmPermissionEnabled = useFeatureFlag({
     name: 'permission_option_email_confirmation',
   });
-  const hideEmailConfirmationToggle = emailConfirmPermissionEnabled;
 
   const groupsOptions = () => {
     if (isNilOrError(groupsList)) {
@@ -100,7 +99,7 @@ const ActionForm = ({
             id={`participation-permission-everyone-${permissionId}`}
           />
         )}
-        {hideEmailConfirmationToggle && (
+        {emailConfirmPermissionEnabled && (
           <Radio
             name={`permittedBy-${permissionId}`}
             value="everyone_confirmed_email"

--- a/front/app/modules/commercial/granular_permissions/admin/containers/Granular/ActionForm.tsx
+++ b/front/app/modules/commercial/granular_permissions/admin/containers/Granular/ActionForm.tsx
@@ -49,9 +49,11 @@ const ActionForm = ({
   localize,
 }: Props) => {
   const { formatMessage } = useIntl();
-  const includeEmailConfirmedOption = useFeatureFlag({
+  const emailConfirmPermissionEnabled = useFeatureFlag({
     name: 'permission_option_email_confirmation',
   });
+  const hideEmailConfirmationToggle = emailConfirmPermissionEnabled;
+
   const groupsOptions = () => {
     if (isNilOrError(groupsList)) {
       return [];
@@ -98,7 +100,7 @@ const ActionForm = ({
             id={`participation-permission-everyone-${permissionId}`}
           />
         )}
-        {includeEmailConfirmedOption && (
+        {hideEmailConfirmationToggle && (
           <Radio
             name={`permittedBy-${permissionId}`}
             value="everyone_confirmed_email"


### PR DESCRIPTION
## Description
Completely hides the email confirmation toggle in the back office if the email-only permission feature flag is on (as email confirmation must be on for that feature flag).

## Note
We can't really test feature flag on/off behaviour in e2e, so not sure if this can be covered? It would be possible to write a unit test I think, but is this even behaviour we'd want to test that way? :thinking: 