### PR TITLE
CL-3104: Do not show seat tracker if admins or managers are unlimited

### DIFF
--- a/front/app/api/app_configuration/types.ts
+++ b/front/app/api/app_configuration/types.ts
@@ -47,8 +47,8 @@ export type IAppConfigurationSettingsCore = {
   topics_term?: Multiloc;
   topic_term?: Multiloc;
   authentication_token_lifetime_in_days: number;
-  maximum_admins_number: number;
-  maximum_project_moderators_number: number;
+  maximum_admins_number: number | null;
+  maximum_project_moderators_number: number | null;
 };
 
 export type ProposalsSettings = {

--- a/front/app/api/app_configuration/types.ts
+++ b/front/app/api/app_configuration/types.ts
@@ -48,7 +48,7 @@ export type IAppConfigurationSettingsCore = {
   topic_term?: Multiloc;
   authentication_token_lifetime_in_days: number;
   maximum_admins_number: number | null | undefined;
-  maximum_project_moderators_number: number | null;
+  maximum_project_moderators_number: number | null | undefined;
 };
 
 export type ProposalsSettings = {

--- a/front/app/api/app_configuration/types.ts
+++ b/front/app/api/app_configuration/types.ts
@@ -47,7 +47,7 @@ export type IAppConfigurationSettingsCore = {
   topics_term?: Multiloc;
   topic_term?: Multiloc;
   authentication_token_lifetime_in_days: number;
-  maximum_admins_number: number | null;
+  maximum_admins_number: number | null | undefined;
   maximum_project_moderators_number: number | null;
 };
 

--- a/front/app/components/SeatInfo/SeatInfo.test.tsx
+++ b/front/app/components/SeatInfo/SeatInfo.test.tsx
@@ -3,7 +3,21 @@ import { render, screen } from 'utils/testUtils/rtl';
 
 import SeatInfo from './';
 
-const mockAppConfiguration = {
+type MockAppConfigurationType = {
+  data: {
+    id: string;
+    attributes: {
+      settings: {
+        core: {
+          maximum_admins_number: number | null;
+          maximum_project_moderators_number: number | null;
+        };
+      };
+    };
+  };
+};
+
+const mockAppConfiguration: MockAppConfigurationType = {
   data: {
     id: '1',
     attributes: {
@@ -62,5 +76,25 @@ describe('SeatInfo', () => {
     expect(screen.getByText('9/9')).toBeInTheDocument();
     expect(screen.getByText('6')).toBeInTheDocument();
     expect(screen.queryByText('Additional seats')).toBeInTheDocument();
+  });
+
+  it('shows nothing for admin seats when maximum_admins_number is null', () => {
+    mockUserSeatsData.data.attributes.admins_number = 15;
+    mockAppConfiguration.data.attributes.settings.core.maximum_admins_number =
+      null;
+    render(<SeatInfo seatType="admin" />);
+    expect(screen.queryByText('Current admin seats')).not.toBeInTheDocument();
+    expect(screen.queryByText('Additional seats')).not.toBeInTheDocument();
+  });
+
+  it('shows nothing for project manager seats when maximum_project_moderators_number is null', () => {
+    mockUserSeatsData.data.attributes.project_moderators_number = 15;
+    mockAppConfiguration.data.attributes.settings.core.maximum_project_moderators_number =
+      null;
+    render(<SeatInfo seatType="project_manager" />);
+    expect(
+      screen.queryByText('Current project manager seats')
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Additional seats')).not.toBeInTheDocument();
   });
 });

--- a/front/app/components/SeatInfo/index.tsx
+++ b/front/app/components/SeatInfo/index.tsx
@@ -18,6 +18,9 @@ import useSeats from 'api/seats/useSeats';
 import messages from './messages';
 import { FormattedMessage, useIntl } from 'utils/cl-intl';
 
+// Utils
+import { isNil } from 'utils/helperUtils';
+
 type SeatInfoType = {
   seatType: 'project_manager' | 'admin';
   width?: number | null;
@@ -36,12 +39,7 @@ const SeatInfo = ({ seatType, width = 516 }: SeatInfoType) => {
     seatType === 'admin' ? maximumAdmins : maximumProjectManagers;
 
   // Maximum seat number being null means that there are unlimited seats so we don't show the seat info
-  if (
-    maximumSeatNumber === null ||
-    maximumSeatNumber === undefined ||
-    !seats ||
-    !appConfiguration
-  ) {
+  if (isNil(maximumSeatNumber) || !seats || !appConfiguration) {
     return null;
   }
 

--- a/front/app/components/SeatInfo/index.tsx
+++ b/front/app/components/SeatInfo/index.tsx
@@ -27,16 +27,24 @@ const SeatInfo = ({ seatType, width = 516 }: SeatInfoType) => {
   const { formatMessage } = useIntl();
   const { data: appConfiguration } = useAppConfiguration();
   const { data: seats } = useSeats();
-
-  if (!appConfiguration || !seats) return null;
-
   const maximumAdmins =
-    appConfiguration.data.attributes.settings.core.maximum_admins_number;
+    appConfiguration?.data.attributes.settings.core.maximum_admins_number;
   const maximumProjectManagers =
-    appConfiguration.data.attributes.settings.core
+    appConfiguration?.data.attributes.settings.core
       .maximum_project_moderators_number;
   const maximumSeatNumber =
     seatType === 'admin' ? maximumAdmins : maximumProjectManagers;
+
+  // Maximum seat number being null means that there are unlimited seats so we don't show the seat info
+  if (
+    maximumSeatNumber === null ||
+    maximumSeatNumber === undefined ||
+    !seats ||
+    !appConfiguration
+  ) {
+    return null;
+  }
+
   const currentAdminSeats = seats.data.attributes.admins_number;
   const currentProjectManagerSeats =
     seats.data.attributes.project_moderators_number;

--- a/front/app/containers/Admin/users/ChangeSeatModal.tsx
+++ b/front/app/containers/Admin/users/ChangeSeatModal.tsx
@@ -13,16 +13,19 @@ import messages from './messages';
 import useAppConfiguration from 'api/app_configuration/useAppConfiguration';
 import useSeats from 'api/seats/useSeats';
 
+// Utils
+import { isNil } from 'utils/helperUtils';
+
 import { IUserData } from 'services/users';
 
 const getInfoText = (
   isUserAdmin: boolean,
-  maximumAdmins: number | null,
+  maximumAdmins: number | null | undefined,
   currentAdminSeats: number
 ): MessageDescriptor => {
   if (isUserAdmin) {
     return messages.confirmNormalUserQuestion;
-  } else if (maximumAdmins !== null && currentAdminSeats >= maximumAdmins) {
+  } else if (!isNil(maximumAdmins) && currentAdminSeats >= maximumAdmins) {
     return messages.reachedLimitMessage;
   }
 

--- a/front/app/containers/Admin/users/ChangeSeatModal.tsx
+++ b/front/app/containers/Admin/users/ChangeSeatModal.tsx
@@ -17,12 +17,12 @@ import { IUserData } from 'services/users';
 
 const getInfoText = (
   isUserAdmin: boolean,
-  maximumAdmins: number,
+  maximumAdmins: number | null,
   currentAdminSeats: number
 ): MessageDescriptor => {
   if (isUserAdmin) {
     return messages.confirmNormalUserQuestion;
-  } else if (currentAdminSeats >= maximumAdmins) {
+  } else if (maximumAdmins !== null && currentAdminSeats >= maximumAdmins) {
     return messages.reachedLimitMessage;
   }
 


### PR DESCRIPTION
Do not show seat tracker if admins or managers are unlimited
