### PR TITLE
Skip fact visits in invalid data checker

### DIFF
--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/invalid_data_checker.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/invalid_data_checker.rake
@@ -89,6 +89,7 @@ namespace :checks do
     return true if claz.name == 'EmailCampaigns::Delivery'
     return true if claz.name.starts_with? 'Notifications::'
     return true if claz.name == 'CommonPassword'
+    return true if claz.name == 'Analytics::FactVisit'
 
     false
   end

--- a/env_files/back-safe.env
+++ b/env_files/back-safe.env
@@ -22,7 +22,7 @@ SMTP_PORT=1025
 # ==== Development experience configuration ====
 SEED_SIZE=small
 # Tenant is fetched by this host name:
-OVERRIDE_HOST=newhamco-create.co.uk
+OVERRIDE_HOST=localhost
 # Set to `true` if you want to upload/download files to/from AWS S3:
 USE_AWS_S3_IN_DEV=false
 # If USE_AWS_S3_IN_DEV=false, this host is used in file URLs (find it in the code for details):

--- a/env_files/back-safe.env
+++ b/env_files/back-safe.env
@@ -22,7 +22,7 @@ SMTP_PORT=1025
 # ==== Development experience configuration ====
 SEED_SIZE=small
 # Tenant is fetched by this host name:
-OVERRIDE_HOST=localhost
+OVERRIDE_HOST=newhamco-create.co.uk
 # Set to `true` if you want to upload/download files to/from AWS S3:
 USE_AWS_S3_IN_DEV=false
 # If USE_AWS_S3_IN_DEV=false, this host is used in file URLs (find it in the code for details):


### PR DESCRIPTION
The invalid data checker is stopped by CI for the UK cluster after 1 hour without output (see e.g. https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/95708/workflows/1a562450-c4fc-472c-8b02-7113b56c9bcd/jobs/226798). Probably it takes too long processing the `Analytics::FactVisit` instances, so the proposed solution is to skip checking instances of this class (a solution we also applied for other classes).

There are also the idea image issues. I tried to reproduce it but couldn't. I'm planning to delete the invalid images before next week to see if they come back.

```
Tenant.creation_finalized.each do |tenant|
  Apartment::Tenant.switch(tenant.schema_name) do
    IdeaImage.where(image: nil).destroy_all
  end
end
```