### PR TITLE
CL-3081 - Remove custom field required validation

### DIFF
--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -163,11 +163,11 @@ class User < ApplicationRecord
 
   validates :invite_status, inclusion: { in: INVITE_STATUSES }, allow_nil: true
 
-  # TODO: Allow light users without required fields
-  # validates :custom_field_values, json: {
-  #   schema: -> { CustomFieldService.new.fields_to_json_schema(CustomField.with_resource_type('User')) },
-  #   message: ->(errors) { errors }
-  # }, if: %i[custom_field_values_changed? active?]
+  # NOTE: All validation except for required
+  validates :custom_field_values, json: {
+    schema: -> { CustomFieldService.new.fields_to_json_schema_ignore_required(CustomField.with_resource_type('User')) },
+    message: ->(errors) { errors }
+  }, if: %i[custom_field_values_changed? active?]
 
   validates :password, length: { maximum: 72 }, allow_nil: true
   # Custom validation is required to deal with the

--- a/back/app/services/custom_field_service.rb
+++ b/back/app/services/custom_field_service.rb
@@ -22,7 +22,7 @@ class CustomFieldService
     end
   end
 
-  def fields_to_json_schema(fields, locale = 'en', ignore_required = false)
+  def fields_to_json_schema(fields, locale = 'en')
     {
       type: 'object',
       additionalProperties: false,
@@ -40,13 +40,17 @@ class CustomFieldService
       end
     }.tap do |output|
       required = fields.select(&:enabled?).select(&:required?).map(&:key)
-      output[:required] = required unless required.empty? || ignore_required
+      output[:required] = required unless required.empty?
     end
   end
 
-  # To allow schema validation whilst ignoring 'required' requirements
+  # To allow schema validation whilst ignoring 'required' requirements by setting all required attributes to false
   def fields_to_json_schema_ignore_required(fields)
-    fields_to_json_schema(fields, locale = 'en', true)
+    optional_fields = fields.map do |field|
+      field[:required] = false
+      field
+    end
+    fields_to_json_schema(optional_fields)
   end
 
   # @param [AppConfiguration] configuration

--- a/back/app/services/custom_field_service.rb
+++ b/back/app/services/custom_field_service.rb
@@ -22,7 +22,7 @@ class CustomFieldService
     end
   end
 
-  def fields_to_json_schema(fields, locale = 'en')
+  def fields_to_json_schema(fields, locale = 'en', ignore_required = false)
     {
       type: 'object',
       additionalProperties: false,
@@ -40,8 +40,13 @@ class CustomFieldService
       end
     }.tap do |output|
       required = fields.select(&:enabled?).select(&:required?).map(&:key)
-      output[:required] = required unless required.empty?
+      output[:required] = required unless required.empty? || ignore_required
     end
+  end
+
+  # To allow schema validation whilst ignoring 'required' requirements
+  def fields_to_json_schema_ignore_required(fields)
+    fields_to_json_schema(fields, locale = 'en', true)
   end
 
   # @param [AppConfiguration] configuration

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -932,7 +932,7 @@ resource 'Users' do
           end
 
           # To allow for custom fields to be required or not depending on the action
-          example 'Allow update if custom fields are changed but required fields are not present' do
+          example 'Allow update if custom fields are changed but required fields are not present', document: false do
             cf = create(:custom_field)
             cf_req = create(:custom_field, required: true)
 

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -930,6 +930,20 @@ resource 'Users' do
             expect(json_response.dig(:data, :attributes, :custom_field_values)).not_to include(cf.key.to_sym)
             expect(@user.custom_field_values[cf.key]).to eq(some_value)
           end
+
+          # To allow for custom fields to be required or not depending on the action
+          example 'Allow update if custom fields are changed but required fields are not present' do
+            cf = create(:custom_field)
+            cf_req = create(:custom_field, required: true)
+
+            do_request( user: { custom_field_values: { cf.key => 'some_value' } })
+            json_response = json_parse(response_body)
+
+            assert_status 200
+            expect(json_response.dig(:data, :attributes, :custom_field_values, cf.key.to_sym)).to eq 'some_value'
+            expect(json_response.dig(:data, :attributes, :custom_field_values, cf_req.key.to_sym)).to be_nil
+          end
+
         end
 
         describe do

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -936,14 +936,13 @@ resource 'Users' do
             cf = create(:custom_field)
             cf_req = create(:custom_field, required: true)
 
-            do_request( user: { custom_field_values: { cf.key => 'some_value' } })
+            do_request(user: { custom_field_values: { cf.key => 'some_value' } })
             json_response = json_parse(response_body)
 
             assert_status 200
             expect(json_response.dig(:data, :attributes, :custom_field_values, cf.key.to_sym)).to eq 'some_value'
             expect(json_response.dig(:data, :attributes, :custom_field_values, cf_req.key.to_sym)).to be_nil
           end
-
         end
 
         describe do


### PR DESCRIPTION
Have removed the required validation from custom fields when a user is updated.

Think we may have to do similar when it comes to enabled fields when we tackle custom fields against actions too. 
