### PR TITLE
CL-3105 Get more permission requirements

### DIFF
--- a/back/.rubocop.yml
+++ b/back/.rubocop.yml
@@ -143,7 +143,6 @@ RSpec/ExampleLength:
 
 Metrics/MethodLength:
   CountAsOne: ['array', 'hash', 'heredoc']
-  AllowedMethods: ['included', 'prepended', 'extended']
   Exclude:
   - '**/db/migrate/**/*'
 

--- a/back/app/controllers/web_api/v1/permissions_controller.rb
+++ b/back/app/controllers/web_api/v1/permissions_controller.rb
@@ -45,7 +45,20 @@ class WebApi::V1::PermissionsController < ApplicationController
   end
 
   def set_permission
-    @permission = authorize Permission.find_by!(action: permission_action, permission_scope_id: permission_scope_id)
+    parent_param = params[:parent_param]
+    scope_id = params[parent_param]
+    scope = case parent_param
+    when nil
+      nil
+    when :project_id
+      Project.find(scope_id)
+    when :phase_id
+      Phase.find(scope_id)
+    when :idea_id
+      idea = Idea.find(scope_id)
+      ParticipationContextService.new.get_participation_context idea.project
+    end
+    @permission = authorize Permission.find_by!(action: permission_action, permission_scope: scope)
   end
 
   def permission_scope_id

--- a/back/app/controllers/web_api/v1/permissions_controller.rb
+++ b/back/app/controllers/web_api/v1/permissions_controller.rb
@@ -7,7 +7,7 @@ class WebApi::V1::PermissionsController < ApplicationController
   def index
     @permissions = policy_scope(Permission)
       .includes(:permission_scope)
-      .where(permission_scope_id: permission_scope_id)
+      .where(permission_scope: permission_scope)
       .order(created_at: :desc)
     @permissions = paginate @permissions
 
@@ -45,9 +45,13 @@ class WebApi::V1::PermissionsController < ApplicationController
   end
 
   def set_permission
+    @permission = authorize Permission.find_by!(action: permission_action, permission_scope: permission_scope)
+  end
+
+  def permission_scope
     parent_param = params[:parent_param]
     scope_id = params[parent_param]
-    scope = case parent_param
+    case parent_param
     when nil
       nil
     when :project_id
@@ -58,11 +62,6 @@ class WebApi::V1::PermissionsController < ApplicationController
       idea = Idea.find(scope_id)
       ParticipationContextService.new.get_participation_context idea.project
     end
-    @permission = authorize Permission.find_by!(action: permission_action, permission_scope: scope)
-  end
-
-  def permission_scope_id
-    params[params[:parent_param]]
   end
 
   def permission_action

--- a/back/app/models/permission.rb
+++ b/back/app/models/permission.rb
@@ -20,7 +20,7 @@
 class Permission < ApplicationRecord
   PERMITTED_BIES = %w[everyone everyone_confirmed_email users groups admins_moderators].freeze
   ACTIONS = {
-    nil => %w[posting_initiative voting_initiative commenting_initiative],
+    nil => %w[visiting posting_initiative voting_initiative commenting_initiative],
     'information' => [],
     'ideation' => %w[posting_idea voting_idea commenting_idea],
     'native_survey' => %w[posting_idea],

--- a/back/app/services/permissions_service.rb
+++ b/back/app/services/permissions_service.rb
@@ -144,7 +144,7 @@ class PermissionsService
         users[:built_in][:email] = 'require'
         required_field_keys = CustomField.registration.required.map(&:key)
         users[:custom_fields].each_key do |key|
-          users[:custom_fields][key] = required_field_keys.include? key ? 'require' : 'ask'
+          users[:custom_fields][key] = (required_field_keys.include?(key) ? 'require' : 'ask')
         end
         users[:special][:password] = 'require'
         users[:special][:confirmation] = 'require' if AppConfiguration.instance.feature_activated?('user_confirmation')

--- a/back/engines/commercial/granular_permissions/config/routes.rb
+++ b/back/engines/commercial/granular_permissions/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
       concerns :permissionable  # for the global permission scope (with parent_param = nil)
       resources :phases, only: [], concerns: :permissionable, defaults: { parent_param: :phase_id }
       resources :projects, only: [], concerns: :permissionable, defaults: { parent_param: :project_id }
+      resources :ideas, only: [], concerns: :permissionable, defaults: { parent_param: :idea_id }
     end
   end
 end

--- a/back/engines/commercial/granular_permissions/spec/acceptance/permissions_spec.rb
+++ b/back/engines/commercial/granular_permissions/spec/acceptance/permissions_spec.rb
@@ -175,7 +175,7 @@ resource 'Permissions' do
 
     get 'web_api/v1/projects/:project_id/permissions/:action/requirements' do
       before do
-        @permission = @phase.permissions.first
+        @permission = @project.permissions.first
         @permission.update!(permitted_by: 'everyone')
       end
 
@@ -273,6 +273,37 @@ resource 'Permissions' do
       let(:action) { @permission.action }
 
       example_request 'Get the participation requirements of a user in the global scope' do
+        assert_status 200
+        json_response = json_parse response_body
+        expect(json_response).to eq({
+          permitted: true,
+          requirements: {
+            built_in: {
+              first_name: 'satisfied',
+              last_name: 'satisfied',
+              email: 'satisfied'
+            },
+            custom_fields: {},
+            special: {
+              password: 'satisfied',
+              confirmation: 'satisfied'
+            }
+          }
+        })
+      end
+    end
+
+    get 'web_api/v1/ideas/:idea_id/permissions/:action/requirements' do
+      before do
+        @permission = @project.permissions.first
+        @permission.update!(permitted_by: 'users')
+      end
+
+      let(:action) { @permission.action }
+      let(:idea) { create :idea, project: @project }
+      let(:idea_id) { idea.id }
+
+      example_request 'Get the participation requirements of a user in an idea' do
         assert_status 200
         json_response = json_parse response_body
         expect(json_response).to eq({

--- a/back/engines/commercial/granular_permissions/spec/acceptance/permissions_spec.rb
+++ b/back/engines/commercial/granular_permissions/spec/acceptance/permissions_spec.rb
@@ -310,7 +310,7 @@ resource 'Permissions' do
 
       let(:action) { 'visiting' }
 
-      example_request 'Get the global registration requirements' do
+      example_request 'Get the global registration requirements when custom fields are asked' do
         assert_status 200
         json_response = json_parse response_body
         expect(json_response).to eq({

--- a/back/engines/commercial/granular_permissions/spec/acceptance/permissions_spec.rb
+++ b/back/engines/commercial/granular_permissions/spec/acceptance/permissions_spec.rb
@@ -173,6 +173,35 @@ resource 'Permissions' do
       end
     end
 
+    get 'web_api/v1/projects/:project_id/permissions/:action/requirements' do
+      before do
+        @permission = @phase.permissions.first
+        @permission.update!(permitted_by: 'everyone')
+      end
+
+      let(:action) { @permission.action }
+
+      example_request 'Get the participation requirements of a user in a continuous project' do
+        assert_status 200
+        json_response = json_parse response_body
+        expect(json_response).to eq({
+          permitted: true,
+          requirements: {
+            built_in: {
+              first_name: 'satisfied',
+              last_name: 'satisfied',
+              email: 'satisfied'
+            },
+            custom_fields: {},
+            special: {
+              password: 'satisfied',
+              confirmation: 'satisfied'
+            }
+          }
+        })
+      end
+    end
+
     get 'web_api/v1/phases/:phase_id/permissions/:action/participation_conditions' do
       before do
         @rule = { 'ruleType' => 'email', 'predicate' => 'ends_on', 'value' => 'test.com' }
@@ -210,7 +239,7 @@ resource 'Permissions' do
 
       let(:action) { @permission.action }
 
-      example_request 'Get the participation requirements of a user' do
+      example_request 'Get the participation requirements of a user in a timeline phase' do
         assert_status 200
         json_response = json_parse(response_body)
         expect(json_response).to eq({
@@ -229,6 +258,35 @@ resource 'Permissions' do
             special: {
               password: 'dont_ask',
               confirmation: 'require'
+            }
+          }
+        })
+      end
+    end
+
+    get 'web_api/v1/permissions/:action/requirements' do
+      before do
+        @permission = Permission.where(permission_scope_type: nil).first
+        @permission.update!(permitted_by: 'everyone')
+      end
+
+      let(:action) { @permission.action }
+
+      example_request 'Get the participation requirements of a user in the global scope' do
+        assert_status 200
+        json_response = json_parse response_body
+        expect(json_response).to eq({
+          permitted: true,
+          requirements: {
+            built_in: {
+              first_name: 'satisfied',
+              last_name: 'satisfied',
+              email: 'satisfied'
+            },
+            custom_fields: {},
+            special: {
+              password: 'satisfied',
+              confirmation: 'satisfied'
             }
           }
         })


### PR DESCRIPTION
- Added specs for requesting permission requirements
- Get permission requirements in an idea context
- Added "visiting" action to global context to get the global registration requirements. The `permitted_by` for this permission is set to "users" by default.
- We need to add the new global permission to all existing tenants after releasing:
```
Tenant.creation_finalized.each do |tenant|
  Apartment::Tenant.switch(tenant.schema_name) do
    PermissionsService.new.update_global_permissions
  end
end
```