### PR TITLE
CL-3028 - Reset confirmation code when email is changed

### DIFF
--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -148,13 +148,6 @@ class WebApi::V1::UsersController < ::ApplicationController
     end
   end
 
-  def email_changed?
-    return false unless @user.email_changed?
-
-    @user.reset_confirmation_and_counts
-    true
-  end
-
   def complete_registration
     # NOTE: Authorize fails if registration is already flagged as complete
     @user = current_user

--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -136,7 +136,6 @@ class WebApi::V1::UsersController < ::ApplicationController
 
     authorize @user
     if @user.save
-      SendConfirmationCode.call(user: @user)
       SideFxUserService.new.after_update(@user, current_user)
       permissions = Permission.for_user(@user).where.not(id: permissions_before.ids)
       render json: WebApi::V1::UserSerializer.new(

--- a/back/app/interactors/reset_user_email.rb
+++ b/back/app/interactors/reset_user_email.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Called only when requesting a new code but changing your email from the confirm modal
 class ResetUserEmail < ApplicationInteractor
   delegate :user, to: :context
   delegate :new_email, to: :context, allow_nil: true

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -452,7 +452,7 @@ class User < ApplicationRecord
     self.confirmation_required = should_require_confirmation?
   end
 
-  def reset_confirmation_with_no_password
+  def reset_confirmation_and_counts
     if confirmation_required == false
       # Only reset code and retry/reset counts if account has already been confirmed
       # To keep limits in place for non-legit requests
@@ -461,6 +461,7 @@ class User < ApplicationRecord
       self.email_confirmation_code_reset_count = 0
     end
     self.confirmation_required = true
+    self.email_confirmation_code_sent_at = nil
   end
 
   def confirm

--- a/back/app/services/side_fx_user_service.rb
+++ b/back/app/services/side_fx_user_service.rb
@@ -28,6 +28,7 @@ class SideFxUserService
     after_roles_changed current_user, user if user.roles_previously_changed?
 
     UpdateMemberCountJob.perform_later
+    SendConfirmationCode.call(user: user) if user.confirmation_required? && user.email_confirmation_code_sent_at.nil?
   end
 
   def after_destroy(frozen_user, current_user)

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -868,27 +868,37 @@ resource 'Users' do
           end
         end
 
-        # NOTE: To be included in an upcoming iteration
-        # context 'when the user_confirmation module is active' do
-        #   before do
-        #     SettingsService.new.activate_feature! 'user_confirmation'
-        #   end
+        context 'when the user_confirmation module is active' do
+          before do
+            SettingsService.new.activate_feature! 'user_confirmation'
+          end
 
-        #   describe 'Changing the email' do
-        #     let(:email) { 'new-email@email.com' }
+          describe 'Changing the email' do
+            let(:email) { 'new-email@email.com' }
 
-        #     example_request 'Requires confirmation' do
-        #       json_response = json_parse(response_body)
-        #       expect(json_response.dig(:data, :attributes, :confirmation_required)).to be true
-        #     end
+            example_request 'Requires confirmation' do
+              json_response = json_parse(response_body)
+              expect(json_response.dig(:data, :attributes, :confirmation_required)).to be true
+            end
 
-        #     example_request 'Sends a confirmation email' do
-        #       last_email = ActionMailer::Base.deliveries.last
-        #       user       = User.find(id)
-        #       expect(last_email.to).to include user.reload.email
-        #     end
-        #   end
-        # end
+            example_request 'Sends a confirmation email' do
+              last_email = ActionMailer::Base.deliveries.last
+              user       = User.find(id)
+              expect(last_email.to).to include user.reload.email
+              expect(user.email_confirmation_code_sent_at).not_to be_nil
+            end
+          end
+
+          describe 'Changing something else' do
+            let(:user) { create(:user) }
+
+            example_request 'Does not send a confirmation email' do
+              last_email = ActionMailer::Base.deliveries.last
+              expect(last_email.to).not_to include user.email
+            end
+          end
+
+        end
 
         describe do
           example "Update a user's custom field values" do

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -897,7 +897,6 @@ resource 'Users' do
               expect(last_email).to be_nil
             end
           end
-
         end
 
         describe do

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -894,7 +894,7 @@ resource 'Users' do
 
             example_request 'Does not send a confirmation email' do
               last_email = ActionMailer::Base.deliveries.last
-              expect(last_email.to).not_to include user.email
+              expect(last_email).to be_nil
             end
           end
 


### PR DESCRIPTION
- Reset code when email is changed in an update, then send code from the after_update side fx
- Refactored a little of the user create/update code done in i1 to move the send confirmation code to the after_update side fx service so it always happens at the same point.
