### PR TITLE
CL-3156 Error when blocked user attempts login

### DIFF
--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -68,10 +68,14 @@ class WebApi::V1::UsersController < ::ApplicationController
   end
 
   def me
+    # binding.pry
+
     @user = current_user
     skip_authorization
 
-    if @user
+    if @user&.blocked?
+      render json: { errors: 'User is blocked' }, status: :unauthorized
+    elsif @user
       params = fastjson_params unread_notifications: @user.notifications.unread.size
       render json: WebApi::V1::UserSerializer.new(@user, params: params).serialized_json
     else

--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -68,13 +68,18 @@ class WebApi::V1::UsersController < ::ApplicationController
   end
 
   def me
-    # binding.pry
-
     @user = current_user
     skip_authorization
 
     if @user&.blocked?
-      render json: { errors: 'User is blocked' }, status: :unauthorized
+      render json: {
+        errors: {
+          user: [{
+            error: 'user is blocked',
+            details: { block_reason: @user.block_reason, block_end_at: @user.block_end_at }
+          }]
+        }
+      }, status: :unauthorized
     elsif @user
       params = fastjson_params unread_notifications: @user.notifications.unread.size
       render json: WebApi::V1::UserSerializer.new(@user, params: params).serialized_json

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -803,6 +803,17 @@ resource 'Users' do
           expect(json_response.dig(:data, :id)).to eq(@user.id)
           expect(json_response.dig(:data, :attributes, :verified)).to be false
         end
+
+        include_context 'when user_blocking duration is 90 days' do
+          example '[error] When user is blocked' do
+            @user.update(block_start_at: 5.days.ago)
+
+            do_request
+            assert_status 401
+            json_response = json_parse(response_body)
+            expect(json_response[:errors]).to eq('User is blocked')
+          end
+        end
       end
 
       get 'web_api/v1/users/blocked_count' do


### PR DESCRIPTION
# Changelog
## Technical
- [CL-3156] me endpoint responds with 401 + error when user blocked (User-blocking feature in development)
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->


[CL-3156]: https://citizenlab.atlassian.net/browse/CL-3156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ