### PR TITLE
[CL-3157] Error & 401 response to any request if current_user blocked

### DIFF
--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::API
   include Pundit
 
   before_action :authenticate_user
-  before_action :error_if_blocked
+  before_action :error_if_blocked_user
 
   after_action :verify_authorized, except: :index
   after_action :verify_policy_scoped, only: :index
@@ -119,7 +119,7 @@ class ApplicationController < ActionController::API
     resource.public_send("remove_#{image_field_name}!")
   end
 
-  def error_if_blocked
+  def error_if_blocked_user
     render json: { errors: 'User blocked' }, status: :unauthorized if current_user&.blocked?
   end
 end

--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::API
 
   before_action :authenticate_user
   before_action :error_if_blocked
-  
+
   after_action :verify_authorized, except: :index
   after_action :verify_policy_scoped, only: :index
 
@@ -120,6 +120,6 @@ class ApplicationController < ActionController::API
   end
 
   def error_if_blocked
-    render json: { errors: 'User blocked' }, status: :unauthorized if current_user.blocked?
+    render json: { errors: 'User blocked' }, status: :unauthorized if current_user&.blocked?
   end
 end

--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::API
 
   before_action :authenticate_user
   before_action :error_if_blocked
+  
   after_action :verify_authorized, except: :index
   after_action :verify_policy_scoped, only: :index
 
@@ -19,10 +20,6 @@ class ApplicationController < ActionController::API
   rescue_from ClErrors::TransactionError, with: :transaction_error
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
-
-  def error_if_blocked
-    render json: { errors: 'User blocked' }, status: :unauthorized if current_user.blocked?
-  end
 
   def send_error(error = nil, status = 400)
     render json: error, status: status
@@ -120,5 +117,9 @@ class ApplicationController < ActionController::API
 
     # setting the image attribute to nil will not remove the image
     resource.public_send("remove_#{image_field_name}!")
+  end
+
+  def error_if_blocked
+    render json: { errors: 'User blocked' }, status: :unauthorized if current_user.blocked?
   end
 end

--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::API
   include Pundit
 
   before_action :authenticate_user
+  before_action :error_if_blocked
   after_action :verify_authorized, except: :index
   after_action :verify_policy_scoped, only: :index
 
@@ -18,6 +19,10 @@ class ApplicationController < ActionController::API
   rescue_from ClErrors::TransactionError, with: :transaction_error
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+
+  def error_if_blocked
+    render json: { errors: 'User blocked' }, status: :unauthorized if current_user.blocked?
+  end
 
   def send_error(error = nil, status = 400)
     render json: error, status: status


### PR DESCRIPTION
All requests made by blocked user result in a response with 401 status and response body:
```JSON
{"errors":{"base":[{"error":"user is blocked"}]}}
```

# Changelog
## Technical
- [CL-3157] Return 401 + error to any request from blocked user (User-blocking feature in development)
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->


[CL-3157]: https://citizenlab.atlassian.net/browse/CL-3157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ