### PR TITLE
CL-3157 Respond to all requests with 401 and error if user blocked

### DIFF
--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -120,6 +120,6 @@ class ApplicationController < ActionController::API
   end
 
   def error_if_blocked_user
-    render json: { errors: 'User is blocked' }, status: :unauthorized if current_user&.blocked?
+    raise Pundit::NotAuthorizedError, reason: 'user is blocked' if current_user&.blocked?
   end
 end


### PR DESCRIPTION

All requests made by blocked user result in a response with 401 status and response body:
```JSON
{"errors":{"base":[{"error":"user is blocked"}]}}
```

# Changelog
## Technical
- [CL-3157] Return 401 + error to any request from blocked user (User-blocking feature in development)
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

[CL-3157]: https://citizenlab.atlassian.net/browse/CL-3157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ