### PR TITLE
CL-3161 - Prevent email change for user with no password in resend code endpoint

### DIFF
--- a/back/app/interactors/reset_user_email.rb
+++ b/back/app/interactors/reset_user_email.rb
@@ -7,6 +7,9 @@ class ResetUserEmail < ApplicationInteractor
   def call
     return unless new_email
 
+    # Cannot allow resets if the user has no password as could allow others to hijack an existing account
+    fail_with_error! :email, message: 'Cannot change email for user with no password' if user.no_password?
+
     context.old_email = user.email
     user.reset_email!(new_email)
   rescue ActiveRecord::RecordInvalid => _e

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -509,10 +509,14 @@ class User < ApplicationRecord
   end
 
   def reset_email!(email)
-    update!(
-      email: email,
-      email_confirmation_code_reset_count: 0
-    )
+    if no_password?
+      errors.add(:email, :no_password, value: email)
+    else
+      update!(
+        email: email,
+        email_confirmation_code_reset_count: 0
+      )
+    end
   end
 
   def reset_confirmed_at

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -509,14 +509,10 @@ class User < ApplicationRecord
   end
 
   def reset_email!(email)
-    if no_password?
-      errors.add(:email, :no_password, value: email)
-    else
-      update!(
-        email: email,
-        email_confirmation_code_reset_count: 0
-      )
-    end
+    update!(
+      email: email,
+      email_confirmation_code_reset_count: 0
+    )
   end
 
   def reset_confirmed_at

--- a/back/spec/factories/users.rb
+++ b/back/spec/factories/users.rb
@@ -51,4 +51,12 @@ FactoryBot.define do
       end
     end
   end
+
+  factory :user_no_password, class: 'User' do
+    sequence(:email) do |n|
+      name, domain = Faker::Internet.email.split('@')
+      "#{name}#{n}@#{domain}"
+    end
+    locale { 'en' }
+  end
 end

--- a/back/spec/interactors/reset_user_email_spec.rb
+++ b/back/spec/interactors/reset_user_email_spec.rb
@@ -50,4 +50,19 @@ RSpec.describe ResetUserEmail do
       expect(result.errors[:email]).not_to be_empty
     end
   end
+
+  context 'when passing a new email and the account has no password' do
+    before do
+      context[:user] = create(:user_no_password)
+      context[:new_email] = 'new@email.com'
+    end
+
+    it 'does not change the user email' do
+      expect(context[:user].reload.email).not_to eq(context[:new_email])
+    end
+
+    it 'returns an error' do
+      expect(result.errors[:email]).not_to be_empty
+    end
+  end
 end


### PR DESCRIPTION
Plugs a security hole
