### PR TITLE
CL-3076 - Fixed search within user groups

### DIFF
--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -11,11 +11,11 @@ class WebApi::V1::UsersController < ::ApplicationController
 
     @users = policy_scope User
 
-    @users = @users.search_by_all(params[:search]) if params[:search].present?
-
+    @users = @users.in_group(Group.find(params[:group])) if params[:group]
     @users = @users.active unless params[:include_inactive]
     @users = @users.blocked if params[:only_blocked]
-    @users = @users.in_group(Group.find(params[:group])) if params[:group]
+    @users = @users.search_by_all(params[:search]) if params[:search].present?
+
     @users = @users.admin.or(@users.project_moderator(params[:can_moderate_project])) if params[:can_moderate_project].present?
     @users = @users.admin.or(@users.project_moderator).or(@users.project_folder_moderator) if params[:can_moderate].present?
     @users = @users.not_citizenlab_member if params[:not_citizenlab_member].present?

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -390,6 +390,21 @@ resource 'Users' do
           expect(json_response[:data].pluck(:id)).to match_array group_users.map(&:id)
         end
 
+        example 'Search for users in group' do
+          group = create(:group)
+
+          group_users = [
+            create(:user, first_name: 'Joskelala', manual_groups: [group]),
+            create(:user, last_name: 'Rudolf', manual_groups: [group])
+          ]
+
+          do_request(group: group.id, search: 'joskela')
+          json_response = json_parse(response_body)
+
+          expect(json_response[:data].size).to eq 1
+          expect(json_response[:data][0][:id]).to eq group_users[0].id
+        end
+
         example 'List all users in group, ordered by role' do
           group = create(:group)
 


### PR DESCRIPTION
Changed ordering of filters as group filtering replaced the whole query (as it is a join) instead of adding clauses to the existing query.

## Changelog
- Fixed user search within groups
