### PR TITLE
[CL-3190] Return error with actions blocked by policies

### DIFF
--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -43,7 +43,7 @@ class ApplicationController < ActionController::API
   # @param [Pundit::NotAuthorized] exception
   def user_not_authorized(exception)
     reason = exception.reason || 'Unauthorized!'
-    reason = 'user is blocked' if current_user.blocked?
+    reason = 'user is blocked' if current_user&.blocked?
     render json: { errors: { base: [{ error: reason }] } }, status: :unauthorized
   end
 

--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -5,7 +5,6 @@ class ApplicationController < ActionController::API
   include Pundit
 
   before_action :authenticate_user
-  before_action :error_if_blocked_user
 
   after_action :verify_authorized, except: :index
   after_action :verify_policy_scoped, only: :index
@@ -44,6 +43,7 @@ class ApplicationController < ActionController::API
   # @param [Pundit::NotAuthorized] exception
   def user_not_authorized(exception)
     reason = exception.reason || 'Unauthorized!'
+    reason = 'user is blocked' if current_user.blocked?
     render json: { errors: { base: [{ error: reason }] } }, status: :unauthorized
   end
 
@@ -117,9 +117,5 @@ class ApplicationController < ActionController::API
 
     # setting the image attribute to nil will not remove the image
     resource.public_send("remove_#{image_field_name}!")
-  end
-
-  def error_if_blocked_user
-    raise Pundit::NotAuthorizedError, reason: 'user is blocked' if current_user&.blocked?
   end
 end


### PR DESCRIPTION
Return error reason for actions blocked by policies, when user is blocked.

Also removes application-wide 401 + error for any action by blocked user.

We return to simply using the fact we consider a user inactive (`user.active? == false`) if they are blocked, which means they cannot do anything an inactive user cannot do, but now we also pass that reason, `'user is blocked'`, in the resulting 401 error responses.

So, for example, a blocked user tries to create an idea; `user.active?` will be `false` and gets a 401 with response body:
```
{"errors":{"base":[{"error":"user is blocked"}]}}
```

Actions an inactive user can take, like viewing a project page, will still result in a 200 OK, as for any user with `user.active?` `false`.

# Changelog
## Technical
- [CL-3190] Include error reason in response when action raises 401 for blocked user (User-blocking feature in development)

[CL-3190]: https://citizenlab.atlassian.net/browse/CL-3190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ