### PR TITLE
[CL-3157] 401 includes block_end_at

### DIFF
--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -120,6 +120,11 @@ class ApplicationController < ActionController::API
   end
 
   def error_if_blocked_user
-    raise Pundit::NotAuthorizedError, reason: 'user is blocked' if current_user&.blocked?
+    return true unless current_user&.blocked?
+
+    render json: { errors: { base: [{ error: 'blocked', details: { block_end_at: current_user.block_end_at } }] } },
+      status: :unauthorized
+
+    false
   end
 end


### PR DESCRIPTION
Changing the response to include `block_end_at`

Note, the error message has also changed, to simply `blocked`, at the advice of Koen G.
```JSON
{"errors":{"base":[{"error":"blocked","details":{"block_end_at":"2023-06-19T14:07:56.652Z"}}]}}
```

## Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->
