### PR TITLE
[CL-3188] Set max n admins & moderators to 2 each in dev env

### DIFF
--- a/back/engines/commercial/multi_tenancy/db/seeds/tenants.rb
+++ b/back/engines/commercial/multi_tenancy/db/seeds/tenants.rb
@@ -27,7 +27,9 @@ module MultiTenancy
             core: {
               organization_type: "#{runner.seed_size}_city",
               organization_name: runner.create_for_tenant_locales { Faker::Address.city },
-              currency: CL2_SUPPORTED_CURRENCIES.sample
+              currency: CL2_SUPPORTED_CURRENCIES.sample,
+              maximum_admins_number: 2,
+              maximum_moderators_number: 2
             },
             password_login: {
               allowed: true,


### PR DESCRIPTION
localhost:

<img width="635" alt="Screenshot 2023-03-21 at 16 36 22" src="https://user-images.githubusercontent.com/3944042/226679997-3829afda-1537-4e76-8a4f-910558413f32.png">

## Changelog
### Technical
- [CL-3188] Set max n of admin & moderator seats to 2 each, in dev env


[CL-3188]: https://citizenlab.atlassian.net/browse/CL-3188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ