### PR TITLE
CL-3190 Revert to blocking specific actions and add error message

### DIFF
--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -5,7 +5,6 @@ class ApplicationController < ActionController::API
   include Pundit
 
   before_action :authenticate_user
-  before_action :error_if_blocked_user
 
   after_action :verify_authorized, except: :index
   after_action :verify_policy_scoped, only: :index
@@ -43,8 +42,13 @@ class ApplicationController < ActionController::API
 
   # @param [Pundit::NotAuthorized] exception
   def user_not_authorized(exception)
-    reason = exception.reason || 'Unauthorized!'
-    render json: { errors: { base: [{ error: reason }] } }, status: :unauthorized
+    if current_user&.blocked?
+      render json: { errors: { base: [{ error: 'blocked', details: { block_end_at: current_user.block_end_at } }] } },
+        status: :unauthorized
+    else
+      reason = exception.reason || 'Unauthorized!'
+      render json: { errors: { base: [{ error: reason }] } }, status: :unauthorized
+    end
   end
 
   # Used by semantic logger to include in every log line
@@ -117,14 +121,5 @@ class ApplicationController < ActionController::API
 
     # setting the image attribute to nil will not remove the image
     resource.public_send("remove_#{image_field_name}!")
-  end
-
-  def error_if_blocked_user
-    return true unless current_user&.blocked?
-
-    render json: { errors: { base: [{ error: 'blocked', details: { block_end_at: current_user.block_end_at } }] } },
-      status: :unauthorized
-
-    false
   end
 end


### PR DESCRIPTION
Reverts to  blocking specific user actions, when user is blocked, by raising 401 response.

Adds error message to those responses, if user is blocked:
```JSON
{"errors":{"base":[{"error":"blocked","details":{"block_end_at":"2023-06-19T17:26:50.916Z"}}]}}
```

## Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->
