### PR TITLE
CL-3065 store npm debug logs as artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -515,6 +515,8 @@ jobs:
           path: ./citizenlab/front/reports/
       - store_artifacts:
           path: ./citizenlab/front/reports/
+      - store_artifacts:
+          path: /root/.npm/_logs/
 
   front-trigger-deploy:
     resource_class: small


### PR DESCRIPTION
## Changelog
### Technical
- npm debug logs are now stored as CircleCI artifacts for the `front-test` job
