### PR TITLE
[CL-3207] Prevent blocked user submitting survey

### DIFF
--- a/back/app/policies/application_policy.rb
+++ b/back/app/policies/application_policy.rb
@@ -62,4 +62,8 @@ class ApplicationPolicy
   def active?
     user&.active?
   end
+
+  def blocked?
+    user&.blocked?
+  end
 end

--- a/back/app/policies/idea_policy.rb
+++ b/back/app/policies/idea_policy.rb
@@ -36,6 +36,7 @@ class IdeaPolicy < ApplicationPolicy
   def create?
     return true if record.draft?
     return true if active? && UserRoleService.new.can_moderate_project?(record.project, user)
+    return false if user&.blocked?
     return false if !active? && record.participation_method_on_creation.sign_in_required_for_posting?
 
     reason = ParticipationContextService.new.posting_idea_disabled_reason_for_project(record.project, user)

--- a/back/app/policies/idea_policy.rb
+++ b/back/app/policies/idea_policy.rb
@@ -34,9 +34,9 @@ class IdeaPolicy < ApplicationPolicy
   end
 
   def create?
+    return false if blocked?
     return true if record.draft?
     return true if active? && UserRoleService.new.can_moderate_project?(record.project, user)
-    return false if user&.blocked?
     return false if !active? && record.participation_method_on_creation.sign_in_required_for_posting?
 
     reason = ParticipationContextService.new.posting_idea_disabled_reason_for_project(record.project, user)

--- a/back/engines/free/polls/spec/policies/response_policy_spec.rb
+++ b/back/engines/free/polls/spec/policies/response_policy_spec.rb
@@ -88,4 +88,10 @@ describe Polls::ResponsePolicy do
       expect(scope.resolve.size).to eq 0
     end
   end
+
+  context 'for blocked user' do
+    let(:user) { create(:user, block_end_at: 5.days.from_now) }
+
+    it_behaves_like 'policy for blocked user', show: false
+  end
 end

--- a/back/spec/policies/idea_policy_spec.rb
+++ b/back/spec/policies/idea_policy_spec.rb
@@ -449,4 +449,12 @@ describe IdeaPolicy do
 
     it_behaves_like 'policy for blocked user'
   end
+
+  # It appears we actually create an idea when a user submits a native survey
+  context 'for blocked user submitting a survey' do
+    let(:user) { create(:user, block_end_at: 5.days.from_now) }
+    let(:idea) { create(:idea, author: user, project: create(:continuous_survey_project)) }
+
+    it_behaves_like 'policy for blocked user'
+  end
 end


### PR DESCRIPTION
Bugfix: Prevent blocked user submitting native survey (+ test)

Also adds test that poll response creation is blocked when user blocked.

# Changelog
## Fixed
- [CL-3207] Blocked user cannot submit native survey (User-blocking feature in development) 


[CL-3207]: https://citizenlab.atlassian.net/browse/CL-3207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ