### PR TITLE
[CL-3208] Fix margin on admin and managers page

### DIFF
--- a/front/app/containers/Admin/users/AdminsAndManagers.tsx
+++ b/front/app/containers/Admin/users/AdminsAndManagers.tsx
@@ -29,7 +29,7 @@ const AllUsers = () => {
         subtitle={messages.adminsAndManagersSubtitle}
       />
       <UserManager search={search} canModerate notCitizenlabMember />
-      <StyledBox>
+      <StyledBox mt="20px">
         <SeatInfo seatType="admin" width={null} />
         <SeatInfo seatType="project_manager" width={null} />
       </StyledBox>


### PR DESCRIPTION
Not using changelog here SeatInfo hasn't been released yet to avoid confusion

![image](https://user-images.githubusercontent.com/12659000/227142897-9ed815c2-2fae-447d-8abc-051d7ae353dd.png)
