### PR TITLE
[CL-3175] Standartize query keys

### DIFF
--- a/front/app/api/event_files/keys.ts
+++ b/front/app/api/event_files/keys.ts
@@ -1,7 +1,7 @@
 import { IDeleteEventFileProperties } from './types';
 
 const eventFilesKeys = {
-  all: () => [{ type: 'file' }],
+  all: () => [{ type: 'file', variant: 'event' }],
   lists: () => [{ ...eventFilesKeys.all()[0], operation: 'list' }],
   list: (eventId?: string) => [{ ...eventFilesKeys.lists()[0], eventId }],
   items: () => [{ ...eventFilesKeys.all()[0], operation: 'item' }],

--- a/front/app/api/idea_markers/keys.ts
+++ b/front/app/api/idea_markers/keys.ts
@@ -1,7 +1,7 @@
 import { QueryParameters } from './types';
 
 const ideaMarkersKeys = {
-  all: () => [{ type: 'post_marker', postType: 'idea' }],
+  all: () => [{ type: 'post_marker', variant: 'idea' }],
   lists: () => [{ ...ideaMarkersKeys.all()[0], operation: 'list' }],
   list: (queryParameters: QueryParameters) => [
     { ...ideaMarkersKeys.all()[0], operation: 'list', ...queryParameters },

--- a/front/app/api/idea_votes/keys.ts
+++ b/front/app/api/idea_votes/keys.ts
@@ -1,5 +1,5 @@
 const ideaVotesKeys = {
-  all: () => [{ type: 'vote' }],
+  all: () => [{ type: 'vote', variant: 'idea' }],
   items: () => [{ ...ideaVotesKeys.all()[0], operation: 'item' }],
   item: (id?: string) => [{ ...ideaVotesKeys.items()[0], id }],
 };

--- a/front/app/api/ideas_filter_counts/keys.ts
+++ b/front/app/api/ideas_filter_counts/keys.ts
@@ -1,7 +1,7 @@
 import { IIdeasFilterCountsQueryParameters } from './types';
 
 const ideaFilterCountsKeys = {
-  all: () => [{ type: 'ideas_filter_counts' }],
+  all: () => [{ type: 'filter_counts', variant: 'idea' }],
   items: () => [{ ...ideaFilterCountsKeys.all()[0], operation: 'item' }],
   item: (filters: IIdeasFilterCountsQueryParameters) => [
     { ...ideaFilterCountsKeys.items()[0], ...filters },

--- a/front/app/api/initiative_action_descriptors/keys.ts
+++ b/front/app/api/initiative_action_descriptors/keys.ts
@@ -1,5 +1,5 @@
 const initiativeActionDescriptorsKeys = {
-  all: () => [{ type: 'action_descriptors', postType: 'initiative' }],
+  all: () => [{ type: 'initiatives', variant: 'action_descriptor' }],
   items: () => [
     { ...initiativeActionDescriptorsKeys.all()[0], operation: 'item' },
   ],

--- a/front/app/api/initiative_allowed_transitions/keys.ts
+++ b/front/app/api/initiative_allowed_transitions/keys.ts
@@ -1,5 +1,5 @@
 const initiativeAllowedTransitionsKeys = {
-  all: () => [{ type: 'allowed_transitions', postType: 'initiative' }],
+  all: () => [{ type: 'allowed_transitions', variant: 'initiative' }],
   items: () => [
     { ...initiativeAllowedTransitionsKeys.all()[0], operation: 'item' },
   ],

--- a/front/app/api/initiative_images/keys.ts
+++ b/front/app/api/initiative_images/keys.ts
@@ -1,5 +1,5 @@
 const initiativeImagesKeys = {
-  all: () => [{ type: 'initiative_images' }] as const,
+  all: () => [{ type: 'image', variant: 'initiative' }] as const,
   lists: () =>
     [{ ...initiativeImagesKeys.all()[0], operation: 'list' }] as const,
   list: (initiativeId: string) =>

--- a/front/app/api/initiative_markers/keys.ts
+++ b/front/app/api/initiative_markers/keys.ts
@@ -1,5 +1,5 @@
 const initiativeMarkersKeys = {
-  all: () => [{ type: 'post_marker', postType: 'initiative' }] as const,
+  all: () => [{ type: 'post_marker', variant: 'initiative' }] as const,
   lists: () =>
     [{ ...initiativeMarkersKeys.all()[0], operation: 'list' }] as const,
 };

--- a/front/app/api/initiatives_filter_counts/keys.ts
+++ b/front/app/api/initiatives_filter_counts/keys.ts
@@ -1,7 +1,7 @@
 import { IQueryParameters } from './types';
 
 const initiativeFilterCountsKeys = {
-  all: () => [{ type: 'initiatives_filter_counts' }],
+  all: () => [{ type: 'filter_counts', variant: 'initiative' }],
   items: () => [{ ...initiativeFilterCountsKeys.all()[0], operation: 'item' }],
   item: (filters: IQueryParameters) => [
     { ...initiativeFilterCountsKeys.items()[0], ...filters },

--- a/front/app/hooks/useInitiativesPermissions.ts
+++ b/front/app/hooks/useInitiativesPermissions.ts
@@ -22,7 +22,7 @@ export default function useInitiativesPermissions(action: IInitiativeAction) {
     if (appConfiguration && actionDescriptors) {
       const actionDescriptor = actionDescriptors.data.attributes[action];
 
-      if (actionDescriptor.enabled) {
+      if (actionDescriptor?.enabled) {
         setActionPermission({
           show: true,
           enabled: true,
@@ -30,7 +30,7 @@ export default function useInitiativesPermissions(action: IInitiativeAction) {
           action: null,
         });
       } else {
-        switch (actionDescriptor.disabled_reason) {
+        switch (actionDescriptor?.disabled_reason) {
           case 'not_verified':
             if (isNilOrError(authUser)) {
               setActionPermission({


### PR DESCRIPTION
Due to some Typescript limitations and the level of flexibility we still need to allow for the query keys, it became unfeasible to type their generation object strictly. What we do instead is create a standard (convention) that is [well documented ](https://www.notion.so/citizenlab/Data-fetching-WIP-b5cec3f674814aec8fccd7cc7e5229f6?pvs=4) on our Notion page and will be communicated to the team so that we make sure we are all aware of it and follow it strictly.

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Technical
- Standardise React query keys