### PR TITLE
[CL-3228] Seed additional seats values for localhost

### DIFF
--- a/back/engines/commercial/multi_tenancy/db/seeds/tenants.rb
+++ b/back/engines/commercial/multi_tenancy/db/seeds/tenants.rb
@@ -29,7 +29,9 @@ module MultiTenancy
               organization_name: runner.create_for_tenant_locales { Faker::Address.city },
               currency: CL2_SUPPORTED_CURRENCIES.sample,
               maximum_admins_number: 2,
-              maximum_moderators_number: 2
+              maximum_moderators_number: 2,
+              additional_admins_number: 1,
+              additional_moderators_number: 1
             },
             password_login: {
               allowed: true,


### PR DESCRIPTION
# Changelog
## Technical
- [CL-3228] Seed additional admin & moderator seats values for localhost (seat-usage feature, iteration 2)


[CL-3228]: https://citizenlab.atlassian.net/browse/CL-3228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ