### PR TITLE
[CL-3214] Remove WIP copy from feature description

### DIFF
--- a/back/engines/commercial/report_builder/lib/report_builder/feature_specification.rb
+++ b/back/engines/commercial/report_builder/lib/report_builder/feature_specification.rb
@@ -15,7 +15,6 @@ module ReportBuilder
     def self.feature_description
       <<~DESC.squish
         Create customizable reports.
-        This feature is experimental and should not be enabled yet.
       DESC
     end
   end


### PR DESCRIPTION
# Changelog
## Changed
- [CL-3214] Removed 'WIP...' comment from AdminHQ description of report builder feature.


[CL-3214]: https://citizenlab.atlassian.net/browse/CL-3214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ