### PR TITLE
[CL-3239] Improve scopes and controller filters for not project / folder mods

### DIFF
--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -17,7 +17,9 @@ class WebApi::V1::UsersController < ::ApplicationController
     @users = @users.search_by_all(params[:search]) if params[:search].present?
 
     @users = @users.admin.or(@users.project_moderator(params[:can_moderate_project])) if params[:can_moderate_project].present?
+    @users = @users.not_admin.and(@users.not_project_moderator(params[:is_not_project_moderator])) if params[:is_not_project_moderator].present?
     @users = @users.admin.or(@users.project_moderator).or(@users.project_folder_moderator) if params[:can_moderate].present?
+    @users = @users.not_admin.and(@users.not_project_folder_moderator(params[:is_not_folder_moderator])) if params[:is_not_folder_moderator].present?
     @users = @users.not_citizenlab_member if params[:not_citizenlab_member].present?
     @users = @users.admin if params[:can_admin].present?
 

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -221,7 +221,18 @@ class User < ApplicationRecord
       where("roles @> '[{\"type\":\"project_moderator\"}]'")
     end
   }
-  scope :not_project_moderator, -> { where.not(id: project_moderator) }
+  scope :not_project_moderator, lambda { |project_id = nil|
+    if project_id
+      project = Project.find(project_id)
+      if project.folder.id
+        where.not(id: project_moderator(project_id)).and(where(id: not_project_folder_moderator(project.folder.id)))
+      else
+        where.not(id: project_moderator(project_id))
+      end
+    else
+      where.not(id: project_moderator)
+    end
+  }
   scope :project_folder_moderator, lambda { |*project_folder_ids|
     return where("roles @> '[{\"type\":\"project_folder_moderator\"}]'") if project_folder_ids.empty?
 

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -222,15 +222,13 @@ class User < ApplicationRecord
     end
   }
   scope :not_project_moderator, lambda { |project_id = nil|
-    if project_id
-      project = Project.find(project_id)
-      if project.folder
-        where.not(id: project_moderator(project_id)).and(where(id: not_project_folder_moderator(project.folder.id)))
-      else
-        where.not(id: project_moderator(project_id))
-      end
+    return where.not(id: project_moderator) if project_id.nil?
+
+    project = Project.find(project_id)
+    if project.folder
+      where.not(id: project_moderator(project_id)).and(where(id: not_project_folder_moderator(project.folder.id)))
     else
-      where.not(id: project_moderator)
+      where.not(id: project_moderator(project_id))
     end
   }
   scope :project_folder_moderator, lambda { |*project_folder_ids|

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -224,7 +224,7 @@ class User < ApplicationRecord
   scope :not_project_moderator, lambda { |project_id = nil|
     if project_id
       project = Project.find(project_id)
-      if project.folder.id
+      if project.folder
         where.not(id: project_moderator(project_id)).and(where(id: not_project_folder_moderator(project.folder.id)))
       else
         where.not(id: project_moderator(project_id))

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -487,6 +487,31 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '.not_project_moderator' do
+    let(:admin) { create(:admin) }
+    let!(:project) { create(:project) }
+    let!(:project_folder) { create(:project_folder, projects: [project]) }
+    let(:project_moderator) { create(:user, roles: [{ type: 'project_moderator', project_id: project.id }]) }
+    let(:project_folder_moderator) { create(:user, roles: [{ type: 'project_folder_moderator', project_folder_id: project_folder.id }]) }
+
+    # before do
+    #   # The after create hook for project_folder changes records, so reload.
+    #   folder.reload
+    #   project.reload
+    #   user.reload
+    # end
+
+    context 'when a project ID is provided' do
+      it 'does not include project moderator of project' do
+        expect(described_class.not_project_moderator(project.id)).not_to include(project_moderator)
+      end
+
+      it 'does not include folder moderator of project folder' do
+        expect(described_class.not_project_moderator(project.id)).not_to include(project_folder_moderator)
+      end
+    end
+  end
+
   describe 'add_role' do
     it 'gives a user moderator rights for a project' do
       usr = create(:user, roles: [])

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -531,6 +531,38 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '.not_project_folder_moderator' do
+    let(:user) { create(:user) }
+    let(:admin) { create(:admin) }
+    let!(:project_folder) { create(:project_folder, projects: [create(:project)]) }
+    let(:project_folder_moderator) { create(:project_folder_moderator, project_folders: [project_folder]) }
+    let(:moderator_of_other_folder) { create(:project_folder_moderator, project_folders: [create(:project_folder)]) }
+
+    context 'when a folder ID is provided' do
+      it 'includes regular user with no roles' do
+        expect(described_class.not_project_folder_moderator(project_folder.id)).to include(user)
+      end
+
+      it 'includes admins' do
+        expect(described_class.not_project_folder_moderator(project_folder.id)).to include(admin)
+      end
+
+      it 'excludes folder moderators of folder' do
+        expect(described_class.not_project_folder_moderator(project_folder.id)).not_to include(project_folder_moderator)
+      end
+
+      it 'includes folder moderators of other folders' do
+        expect(described_class.not_project_folder_moderator(project_folder.id)).to include(moderator_of_other_folder)
+      end
+    end
+
+    context 'when a folder ID is not provided' do
+      it 'includes all users without a folder moderator role' do
+        expect(described_class.not_project_moderator).to match_array([user, admin])
+      end
+    end
+  end
+
   describe 'add_role' do
     it 'gives a user moderator rights for a project' do
       usr = create(:user, roles: [])

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -488,26 +488,45 @@ RSpec.describe User, type: :model do
   end
 
   describe '.not_project_moderator' do
+    let(:user) { create(:user) }
     let(:admin) { create(:admin) }
     let!(:project) { create(:project) }
     let!(:project_folder) { create(:project_folder, projects: [project]) }
-    let(:project_moderator) { create(:user, roles: [{ type: 'project_moderator', project_id: project.id }]) }
-    let(:project_folder_moderator) { create(:user, roles: [{ type: 'project_folder_moderator', project_folder_id: project_folder.id }]) }
-
-    # before do
-    #   # The after create hook for project_folder changes records, so reload.
-    #   folder.reload
-    #   project.reload
-    #   user.reload
-    # end
+    let(:project_moderator) { create(:project_moderator, projects: [project]) }
+    let(:moderator_of_other_project) { create(:project_moderator, projects: [create(:project)]) }
+    let(:project_folder_moderator) { create(:project_folder_moderator, project_folders: [project_folder]) }
+    let(:moderator_of_other_folder) { create(:project_folder_moderator, project_folders: [create(:project_folder)]) }
 
     context 'when a project ID is provided' do
-      it 'does not include project moderator of project' do
+      it 'includes regular user with no roles' do
+        expect(described_class.not_project_moderator(project.id)).to include(user)
+      end
+
+      it 'includes admins' do
+        expect(described_class.not_project_moderator(project.id)).to include(admin)
+      end
+
+      it 'excludes project moderators of project' do
         expect(described_class.not_project_moderator(project.id)).not_to include(project_moderator)
       end
 
-      it 'does not include folder moderator of project folder' do
+      it 'includes project moderators of other projects' do
+        expect(described_class.not_project_moderator(project.id)).to include(moderator_of_other_project)
+      end
+
+      it 'excludes folder moderators of project folder' do
         expect(described_class.not_project_moderator(project.id)).not_to include(project_folder_moderator)
+      end
+
+      it 'includes folder moderators of other folders' do
+        expect(described_class.not_project_moderator(project.id)).to include(moderator_of_other_folder)
+      end
+    end
+
+    context 'when a project ID is not provided' do
+      it 'includes all users without a project moderator role' do
+        expect(described_class.not_project_moderator)
+          .to match_array([user, admin, project_folder_moderator, moderator_of_other_folder])
       end
     end
   end

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -487,7 +487,7 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe do
+  describe 'not moderator scopes' do
     let(:user) { create(:user) }
     let(:admin) { create(:admin) }
     let!(:project) { create(:project) }

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -487,7 +487,7 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe '.not_project_moderator' do
+  describe do
     let(:user) { create(:user) }
     let(:admin) { create(:admin) }
     let!(:project) { create(:project) }
@@ -497,68 +497,75 @@ RSpec.describe User, type: :model do
     let(:project_folder_moderator) { create(:project_folder_moderator, project_folders: [project_folder]) }
     let(:moderator_of_other_folder) { create(:project_folder_moderator, project_folders: [create(:project_folder)]) }
 
-    context 'when a project ID is provided' do
-      it 'includes regular user with no roles' do
-        expect(described_class.not_project_moderator(project.id)).to include(user)
+    describe '.not_project_moderator' do
+      context 'when a project ID is provided' do
+        it 'includes regular user with no roles' do
+          expect(described_class.not_project_moderator(project.id)).to include(user)
+        end
+
+        it 'includes admins' do
+          expect(described_class.not_project_moderator(project.id)).to include(admin)
+        end
+
+        it 'excludes project moderators of project' do
+          expect(described_class.not_project_moderator(project.id)).not_to include(project_moderator)
+        end
+
+        it 'includes project moderators of other projects' do
+          expect(described_class.not_project_moderator(project.id)).to include(moderator_of_other_project)
+        end
+
+        it 'excludes folder moderators of project folder' do
+          expect(described_class.not_project_moderator(project.id)).not_to include(project_folder_moderator)
+        end
+
+        it 'includes folder moderators of other folders' do
+          expect(described_class.not_project_moderator(project.id)).to include(moderator_of_other_folder)
+        end
       end
 
-      it 'includes admins' do
-        expect(described_class.not_project_moderator(project.id)).to include(admin)
-      end
-
-      it 'excludes project moderators of project' do
-        expect(described_class.not_project_moderator(project.id)).not_to include(project_moderator)
-      end
-
-      it 'includes project moderators of other projects' do
-        expect(described_class.not_project_moderator(project.id)).to include(moderator_of_other_project)
-      end
-
-      it 'excludes folder moderators of project folder' do
-        expect(described_class.not_project_moderator(project.id)).not_to include(project_folder_moderator)
-      end
-
-      it 'includes folder moderators of other folders' do
-        expect(described_class.not_project_moderator(project.id)).to include(moderator_of_other_folder)
-      end
-    end
-
-    context 'when a project ID is not provided' do
-      it 'includes only users without a project moderator role' do
-        expect(described_class.not_project_moderator)
-          .to match_array([user, admin, project_folder_moderator, moderator_of_other_folder])
-      end
-    end
-  end
-
-  describe '.not_project_folder_moderator' do
-    let(:user) { create(:user) }
-    let(:admin) { create(:admin) }
-    let!(:project_folder) { create(:project_folder, projects: [create(:project)]) }
-    let(:project_folder_moderator) { create(:project_folder_moderator, project_folders: [project_folder]) }
-    let(:moderator_of_other_folder) { create(:project_folder_moderator, project_folders: [create(:project_folder)]) }
-
-    context 'when a folder ID is provided' do
-      it 'includes regular user with no roles' do
-        expect(described_class.not_project_folder_moderator(project_folder.id)).to include(user)
-      end
-
-      it 'includes admins' do
-        expect(described_class.not_project_folder_moderator(project_folder.id)).to include(admin)
-      end
-
-      it 'excludes folder moderators of folder' do
-        expect(described_class.not_project_folder_moderator(project_folder.id)).not_to include(project_folder_moderator)
-      end
-
-      it 'includes folder moderators of other folders' do
-        expect(described_class.not_project_folder_moderator(project_folder.id)).to include(moderator_of_other_folder)
+      context 'when a project ID is not provided' do
+        it 'includes only users without a project moderator role' do
+          expect(described_class.not_project_moderator)
+            .to match_array([user, admin, project_folder_moderator, moderator_of_other_folder])
+        end
       end
     end
 
-    context 'when a folder ID is not provided' do
-      it 'includes only users without a folder moderator role' do
-        expect(described_class.not_project_moderator).to match_array([user, admin])
+    describe '.not_project_folder_moderator' do
+      context 'when a folder ID is provided' do
+        it 'includes regular user with no roles' do
+          expect(described_class.not_project_folder_moderator(project_folder.id)).to include(user)
+        end
+
+        it 'includes admins' do
+          expect(described_class.not_project_folder_moderator(project_folder.id)).to include(admin)
+        end
+
+        it 'excludes folder moderators of folder' do
+          expect(described_class.not_project_folder_moderator(project_folder.id))
+            .not_to include(project_folder_moderator)
+        end
+
+        it 'includes folder moderators of other folders' do
+          expect(described_class.not_project_folder_moderator(project_folder.id)).to include(moderator_of_other_folder)
+        end
+
+        it 'includes project moderators of projects in folder' do
+          expect(described_class.not_project_folder_moderator(project_folder.id)).to include(project_moderator)
+        end
+
+        it 'includes project moderators of projects not in folder' do
+          expect(described_class.not_project_folder_moderator(project_folder.id))
+            .to include(moderator_of_other_project)
+        end
+      end
+
+      context 'when a folder ID is not provided' do
+        it 'includes only users without a folder moderator role' do
+          expect(described_class.not_project_folder_moderator)
+            .to match_array([user, admin, project_moderator, moderator_of_other_project])
+        end
       end
     end
   end

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -524,7 +524,7 @@ RSpec.describe User, type: :model do
     end
 
     context 'when a project ID is not provided' do
-      it 'includes all users without a project moderator role' do
+      it 'includes only users without a project moderator role' do
         expect(described_class.not_project_moderator)
           .to match_array([user, admin, project_folder_moderator, moderator_of_other_folder])
       end
@@ -557,7 +557,7 @@ RSpec.describe User, type: :model do
     end
 
     context 'when a folder ID is not provided' do
-      it 'includes all users without a folder moderator role' do
+      it 'includes only users without a folder moderator role' do
         expect(described_class.not_project_moderator).to match_array([user, admin])
       end
     end


### PR DESCRIPTION
Extends `not_project_moderator` scope to also exclude folder moderators of project folder, if `project_id` specified and project is in a folder.

Adds `:is_not_project_moderator` and `:is_not_folder_moderator` query-parameter-based filters to `Users#index`

# Changelog
## Technical
- [CL-3239] Improve scope & add index filters for not project moderator & not folder moderator


[CL-3239]: https://citizenlab.atlassian.net/browse/CL-3239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ