### PR TITLE
CL-2809 - SSO permissions fix

### DIFF
--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -463,9 +463,9 @@ class User < ApplicationRecord
   end
 
   def reset_confirmation_with_no_password
-    if confirmation_required == false
+    if !confirmation_required?
       # Only reset code and retry/reset counts if account has already been confirmed
-      # To keep limits in place for non-legit requests
+      # To keep limits in place for retries when not confirmed
       self.email_confirmation_code = nil
       self.email_confirmation_retry_count = 0
       self.email_confirmation_code_reset_count = 0

--- a/back/app/services/permissions_service.rb
+++ b/back/app/services/permissions_service.rb
@@ -106,6 +106,8 @@ class PermissionsService
       user ||= User.new
     elsif !user
       return DENIED_REASONS[:not_signed_in]
+    elsif user.confirmation_required?
+      return DENIED_REASONS[:missing_data]
     elsif !user.active?
       return DENIED_REASONS[:not_active]
     end
@@ -168,7 +170,7 @@ class PermissionsService
       when :password
         !user.no_password?
       when :confirmation
-        user.confirmed?
+        !user.confirmation_required?
       end
       requirements[:special][special_key] = 'satisfied' if is_satisfied
     end

--- a/back/engines/commercial/granular_permissions/spec/acceptance/permissions_spec.rb
+++ b/back/engines/commercial/granular_permissions/spec/acceptance/permissions_spec.rb
@@ -221,6 +221,7 @@ resource 'Permissions' do
 
     get 'web_api/v1/phases/:phase_id/permissions/:action/requirements' do
       before do
+        SettingsService.new.activate_feature! 'user_confirmation'
         @permission = @phase.permissions.first
         @permission.update!(permitted_by: 'everyone_confirmed_email')
         create :custom_field_birthyear, required: true

--- a/back/engines/commercial/granular_permissions/spec/acceptance/permissions_spec.rb
+++ b/back/engines/commercial/granular_permissions/spec/acceptance/permissions_spec.rb
@@ -227,19 +227,19 @@ resource 'Permissions' do
         create :custom_field_gender, required: false
         create :custom_field_checkbox, resource_type: 'User', required: true, key: 'extra_field'
 
+        @user.reset_confirmation_with_no_password
         @user.update!(
           email: 'my@email.com',
           first_name: 'Jack',
           last_name: nil,
           password_digest: nil,
-          email_confirmed_at: nil,
           custom_field_values: { 'gender' => 'male' }
         )
       end
 
       let(:action) { @permission.action }
 
-      example_request 'Get the participation requirements of a user in a timeline phase' do
+      example_request 'Get the participation requirements of a user requiring confirmation in a timeline phase' do
         assert_status 200
         json_response = json_parse(response_body)
         expect(json_response.dig(:data, :attributes, :requirements)).to eq({


### PR DESCRIPTION
ON HOLD: May not be required

Manually moved over some changes from a later branch to fix SSO asking for a confirmation code:
- Changes  user.confirmed? (which only checks a date) to !user.confirmation_required?
- Gets the permissions to return 'missing_data' when user is not confirmed - it was returning 'not_active' but confirmed is now a factor in being confirmed