### PR TITLE
[No ticket] Don't define blocked? at application_policy level

### DIFF
--- a/back/app/policies/application_policy.rb
+++ b/back/app/policies/application_policy.rb
@@ -62,8 +62,4 @@ class ApplicationPolicy
   def active?
     user&.active?
   end
-
-  def blocked?
-    user&.blocked?
-  end
 end

--- a/back/app/policies/idea_policy.rb
+++ b/back/app/policies/idea_policy.rb
@@ -34,7 +34,7 @@ class IdeaPolicy < ApplicationPolicy
   end
 
   def create?
-    return false if blocked?
+    return false if user&.blocked?
     return true if record.draft?
     return true if active? && UserRoleService.new.can_moderate_project?(record.project, user)
     return false if !active? && record.participation_method_on_creation.sign_in_required_for_posting?


### PR DESCRIPTION
Partially fixes weird behaviour - setting projects to inactive when blocked user views them. Now we more often get the 'you are blocked' view when attempting to create a resource (idea, proposal, etc.)