### PR TITLE
Add feature flag for permissions_custom_fields

### DIFF
--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -1115,6 +1115,18 @@
           "allowed": { "type": "boolean", "default": false },
           "enabled": { "type": "boolean", "default": false }
         }
+      },
+
+      "permissions_custom_fields": {
+        "type": "object",
+        "title": "Permission custom fields on project actions",
+        "description": "Enables the option for admins to add custom questions to project action permissions.",
+        "additionalProperties": false,
+        "required": ["allowed", "enabled"],
+        "properties": {
+          "allowed": { "type": "boolean", "default": false },
+          "enabled": { "type": "boolean", "default": false }
+        }
       }
     },
   "dependencies": {

--- a/back/engines/commercial/multi_tenancy/db/seeds/tenants.rb
+++ b/back/engines/commercial/multi_tenancy/db/seeds/tenants.rb
@@ -108,6 +108,10 @@ module MultiTenancy
               enabled: true,
               allowed: true
             },
+            permissions_custom_fields: {
+              enabled: true,
+              allowed: true
+            },
             representativeness: {
               enabled: true,
               allowed: true

--- a/front/app/api/app_configuration/types.ts
+++ b/front/app/api/app_configuration/types.ts
@@ -207,6 +207,7 @@ export interface IAppConfigurationSettings {
   visitors_dashboard?: AppConfigurationFeature;
   user_confirmation?: AppConfigurationFeature;
   permission_option_email_confirmation?: AppConfigurationFeature;
+  permissions_custom_fields?: AppConfigurationFeature;
   input_form_custom_fields?: AppConfigurationFeature;
   report_builder?: AppConfigurationFeature;
   posthog_integration?: AppConfigurationFeature;

--- a/front/app/modules/commercial/granular_permissions/admin/containers/Granular/ActionsForm.tsx
+++ b/front/app/modules/commercial/granular_permissions/admin/containers/Granular/ActionsForm.tsx
@@ -20,6 +20,7 @@ import messages from './messages';
 // hooks
 import useProject from 'hooks/useProject';
 import usePhases from 'hooks/usePhases';
+import useFeatureFlag from 'hooks/useFeatureFlag';
 
 // utils
 import {
@@ -92,6 +93,9 @@ type Props = PostTypeProps & SharedProps;
 
 const ActionsForm = memo(
   ({ permissions, postType, onChange, projectId }: Props) => {
+    const includePermissionsCustomFields = useFeatureFlag({
+      name: 'permissions_custom_fields',
+    });
     const project = useProject({ projectId });
     const phases = usePhases(projectId);
     const handlePermissionChange =
@@ -156,11 +160,12 @@ const ActionsForm = memo(
                   projectType={postType}
                   onChange={handlePermissionChange(permission)}
                 />
-                {permission.attributes.permitted_by !== 'everyone' && (
-                  <Box mt="42px" mb="20px">
-                    <UserFieldSelection permission={permission} />
-                  </Box>
-                )}
+                {permission.attributes.permitted_by !== 'everyone' &&
+                  includePermissionsCustomFields && (
+                    <Box mt="42px" mb="20px">
+                      <UserFieldSelection permission={permission} />
+                    </Box>
+                  )}
               </ActionPermissionWrapper>
             );
           })}


### PR DESCRIPTION
### Description
Adds a new feature flag "permissions_custom_fields", which when enabled shows the custom fields setup in the back office:
![image](https://user-images.githubusercontent.com/33987955/228762909-8edac37d-b9a8-4a38-a3bf-973c152851e5.png)

When it's disabled, this is hidden:
![image](https://user-images.githubusercontent.com/33987955/228762835-e1d61c9f-9b52-482f-aa5e-e0b5269142b1.png)

