### PR TITLE
CL-3241 - Enable new denied logic across all action descriptors

### DIFF
--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -283,7 +283,7 @@ class WebApi::V1::UsersController < ::ApplicationController
     return false if existing_user.changed?
 
     @user = existing_user
-    @user.reset_confirmation_with_no_password
+    @user.reset_confirmation_and_counts
     return false unless @user.save
 
     SendConfirmationCode.call(user: @user)

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -467,7 +467,7 @@ class User < ApplicationRecord
     self.confirmation_required = should_require_confirmation?
   end
 
-  def reset_confirmation_with_no_password
+  def reset_confirmation_and_counts
     if !confirmation_required?
       # Only reset code and retry/reset counts if account has already been confirmed
       # To keep limits in place for retries when not confirmed

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -397,8 +397,18 @@ class User < ApplicationRecord
     end
   end
 
+  # User has no password
   def no_password?
     !password_digest && !invite_pending?
+  end
+
+  # Do we need a password for this user?
+  def should_require_password?
+    password_digest.blank? && !confirmation_required? && !sso? && !invite_pending?
+  end
+
+  def sso?
+    identities.any?
   end
 
   def member_of?(group_id)

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -402,11 +402,6 @@ class User < ApplicationRecord
     !password_digest && !invite_pending?
   end
 
-  # Do we need a password for this user?
-  def should_require_password?
-    password_digest.blank? && !confirmation_required? && !sso? && !invite_pending?
-  end
-
   def sso?
     identities.any?
   end

--- a/back/app/services/permissions_service.rb
+++ b/back/app/services/permissions_service.rb
@@ -140,11 +140,11 @@ class PermissionsService
       end,
       'groups' => everyone.deep_dup.tap do |groups|
         groups[:built_in][:email] = 'require'
-        groups[:special][:confirmation] = 'require'
+        groups[:special][:confirmation] = 'require' if AppConfiguration.instance.feature_activated?('user_confirmation')
       end,
       'admins_moderators' => everyone.deep_dup.tap do |admins|
         admins[:built_in][:email] = 'require'
-        admins[:special][:confirmation] = 'require'
+        admins[:special][:confirmation] = 'require' if AppConfiguration.instance.feature_activated?('user_confirmation')
       end
     }
   end

--- a/back/app/services/permissions_service.rb
+++ b/back/app/services/permissions_service.rb
@@ -50,6 +50,7 @@ class PermissionsService
   def requirements(permission, user)
     requirements = requirements_mapping[permission.permitted_by]
     mark_satisfied_requirements! requirements, user if user
+    ignore_password_for_sso! requirements, user if user
     permitted = requirements.values.none? do |subrequirements|
       subrequirements.value? 'require'
     end
@@ -156,6 +157,12 @@ class PermissionsService
       end
       requirements[:special][special_key] = 'satisfied' if is_satisfied
     end
+  end
+
+  def ignore_password_for_sso!(requirements, user)
+    return requirements if !user
+
+    requirements[:special][:password] = 'dont_ask' if user.sso?
   end
 end
 

--- a/back/app/services/permissions_service.rb
+++ b/back/app/services/permissions_service.rb
@@ -138,8 +138,14 @@ class PermissionsService
         users[:special][:password] = 'require'
         users[:special][:confirmation] = 'require' if AppConfiguration.instance.feature_activated?('user_confirmation')
       end,
-      'groups' => {},
-      'admins_moderators' => {}
+      'groups' => everyone.deep_dup.tap do |groups|
+        groups[:built_in][:email] = 'require'
+        groups[:special][:confirmation] = 'require'
+      end,
+      'admins_moderators' => everyone.deep_dup.tap do |admins|
+        admins[:built_in][:email] = 'require'
+        admins[:special][:confirmation] = 'require'
+      end
     }
   end
 

--- a/back/app/services/permissions_service.rb
+++ b/back/app/services/permissions_service.rb
@@ -86,10 +86,10 @@ class PermissionsService
       user ||= User.new
     else
       return DENIED_REASONS[:not_signed_in] if !user
+      return DENIED_REASONS[:blocked] if user.blocked?
 
-      if !user.confirmation_required? # Always ensure confirmation not required for all user permissions
-        return DENIED_REASONS[:not_active] if user.registration_completed_at.nil?
-        return DENIED_REASONS[:blocked] if user.blocked?
+      if !user.confirmation_required? # Ignore confirmation as this will be checked by the requirements
+        return DENIED_REASONS[:not_active] if !user.active?
         return if UserRoleService.new.can_moderate? permission.permission_scope, user
         return DENIED_REASONS[:not_permitted] if permission.permitted_by == 'admins_moderators'
 

--- a/back/engines/commercial/granular_permissions/spec/acceptance/permissions_spec.rb
+++ b/back/engines/commercial/granular_permissions/spec/acceptance/permissions_spec.rb
@@ -228,7 +228,7 @@ resource 'Permissions' do
         create :custom_field_gender, required: false
         create :custom_field_checkbox, resource_type: 'User', required: true, key: 'extra_field'
 
-        @user.reset_confirmation_with_no_password
+        @user.reset_confirmation_and_counts
         @user.update!(
           email: 'my@email.com',
           first_name: 'Jack',

--- a/back/spec/services/permissions_service_spec.rb
+++ b/back/spec/services/permissions_service_spec.rb
@@ -202,7 +202,8 @@ describe PermissionsService do
         before do
           facebook_identity = create(:facebook_identity)
           user.identities << facebook_identity
-          user.update!(password_digest: nil)
+          user.update(password_digest: nil)
+          user.save!
         end
 
         it { expect(denied_reason).to be_nil }

--- a/back/spec/services/permissions_service_spec.rb
+++ b/back/spec/services/permissions_service_spec.rb
@@ -210,7 +210,7 @@ describe PermissionsService do
         before do
           facebook_identity = create(:facebook_identity)
           user.identities << facebook_identity
-          user.update(password_digest: nil)
+          user.update!(password_digest: nil)
           user.save!
         end
 

--- a/back/spec/services/permissions_service_spec.rb
+++ b/back/spec/services/permissions_service_spec.rb
@@ -187,6 +187,7 @@ describe PermissionsService do
         it { expect(denied_reason).to eq 'not_active' }
       end
 
+      # TODO: Change this to be properly unconfirmed
       context 'when fully registered unconfirmed resident' do
         before { user.update!(email_confirmed_at: nil) }
 
@@ -194,6 +195,16 @@ describe PermissionsService do
       end
 
       context 'when fully registered confirmed resident' do
+        it { expect(denied_reason).to be_nil }
+      end
+
+      context 'when fully registered sso user' do
+        before do
+          facebook_identity = create(:facebook_identity)
+          user.identities << facebook_identity
+          user.update!(password_digest: nil)
+        end
+
         it { expect(denied_reason).to be_nil }
       end
 

--- a/back/spec/services/permissions_service_spec.rb
+++ b/back/spec/services/permissions_service_spec.rb
@@ -178,7 +178,7 @@ describe PermissionsService do
       context 'when light confirmed resident' do
         before { user.update!(password_digest: nil, identity_ids: [], first_name: nil, custom_field_values: {}) }
 
-        it { expect(denied_reason).to be_nil } # TODO: change to missing_data when applying the new implementation to all permitted_by's
+        it { expect(denied_reason).to eq 'missing_data' }
       end
 
       context 'when light confirmed inactive resident' do


### PR DESCRIPTION
Merged in logic from the old_denied_reasons into denied_reasons and removed the old functionality.
