### PR TITLE
[CL-3158] Show pending users on "Admins & managers" page

### DIFF
--- a/front/app/containers/Admin/users/AdminsAndManagers.tsx
+++ b/front/app/containers/Admin/users/AdminsAndManagers.tsx
@@ -28,7 +28,12 @@ const AllUsers = () => {
         title={messages.adminsAndManagers}
         subtitle={messages.adminsAndManagersSubtitle}
       />
-      <UserManager search={search} canModerate notCitizenlabMember />
+      <UserManager
+        search={search}
+        canModerate
+        notCitizenlabMember
+        includeInactive
+      />
       <StyledBox mt="20px">
         <SeatInfo seatType="admin" width={null} />
         <SeatInfo seatType="project_manager" width={null} />

--- a/front/app/containers/Admin/users/UserManager.tsx
+++ b/front/app/containers/Admin/users/UserManager.tsx
@@ -28,6 +28,7 @@ interface InputProps {
   // These are used in the inputProps for GetUsers
   canModerate?: boolean;
   notCitizenlabMember?: boolean;
+  includeInactive?: boolean;
 }
 
 interface DataProps {

--- a/front/app/resources/GetUsers.tsx
+++ b/front/app/resources/GetUsers.tsx
@@ -33,6 +33,7 @@ export interface InputProps {
   canModerate?: boolean;
   canAdmin?: boolean;
   notCitizenlabMember?: boolean;
+  includeInactive?: boolean;
 }
 
 interface IQueryParameters {
@@ -45,6 +46,7 @@ interface IQueryParameters {
   can_moderate?: boolean;
   can_admin?: boolean;
   not_citizenlab_member?: boolean;
+  include_inactive?: boolean;
 }
 
 type children = (obj: GetUsersChildProps) => JSX.Element | null;
@@ -90,6 +92,7 @@ export default class GetUsers extends React.Component<Props, State> {
         can_moderate: undefined,
         can_admin: undefined,
         not_citizenlab_member: undefined,
+        include_inactive: undefined,
       },
       usersList: undefined,
       sortAttribute: getSortAttribute<Sort, SortAttribute>(initialSort),
@@ -169,6 +172,7 @@ export default class GetUsers extends React.Component<Props, State> {
           can_moderate: props.canModerate,
           can_admin: props.canAdmin,
           not_citizenlab_member: props.notCitizenlabMember,
+          include_inactive: props.includeInactive,
         },
         isNil
       ),


### PR DESCRIPTION
# Changelog
## Fixes
* [CL-3158] Show pending users on "Admins & managers" page

[CL-3158]: https://citizenlab.atlassian.net/browse/CL-3158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ