### PR TITLE
[CL-3235] Handle set collaborator as normal user

### DIFF
--- a/front/app/containers/Admin/users/ChangeSeatModal.tsx
+++ b/front/app/containers/Admin/users/ChangeSeatModal.tsx
@@ -102,7 +102,7 @@ const ChangeSeatModal = ({
             />
           </Text>
           {!isChangingCollaboratorToNormalUser && (
-            <Box py="32px">
+            <Box pt="32px">
               <SeatInfo seatType="admin" width={null} />
             </Box>
           )}

--- a/front/app/containers/Admin/users/ChangeSeatModal.tsx
+++ b/front/app/containers/Admin/users/ChangeSeatModal.tsx
@@ -42,7 +42,7 @@ interface Props {
   isUserAdmin: boolean;
   isChangingToNormalUser: boolean;
   closeModal: () => void;
-  changeRoles: () => void;
+  changeRoles: (user: IUserData, changeToNormalUser: boolean) => void;
 }
 
 const ChangeSeatModal = ({
@@ -116,7 +116,7 @@ const ChangeSeatModal = ({
           <Button
             width="auto"
             onClick={() => {
-              changeRoles();
+              changeRoles(user, isChangingToNormalUser);
               closeModal();
             }}
           >

--- a/front/app/containers/Admin/users/UserTable.tsx
+++ b/front/app/containers/Admin/users/UserTable.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React from 'react';
-import { isAdmin, isCollaborator, TRole } from 'services/permissions/roles';
+import { TRole } from 'services/permissions/roles';
 import { includes, isArray } from 'lodash-es';
 import { isNilOrError } from 'utils/helperUtils';
 // Components
@@ -58,12 +58,8 @@ const SortableTh = ({ sortDirection, onClick, children }: SortableThProps) => (
   </Th>
 );
 
-const getNewRoles = (user: IUserData): TRole[] => {
-  if (
-    !user.attributes.roles ||
-    (user.attributes.roles &&
-      (isAdmin({ data: user }) || isCollaborator({ data: user })))
-  ) {
+const getNewRoles = (user: IUserData, changeToNormalUser: boolean): TRole[] => {
+  if (!user.attributes.roles || changeToNormalUser) {
     return [];
   }
 
@@ -96,7 +92,7 @@ const UsersTable = ({
     return null;
   }
 
-  const handleAdminRoleOnChange = (user: IUserData) => () => {
+  const handleChangeRoles = (user: IUserData, changeToNormalUser: boolean) => {
     trackEventByName(tracks.adminChangeRole.name);
 
     if (authUser && authUser.id === user.id) {
@@ -105,7 +101,7 @@ const UsersTable = ({
         <FormattedMessage {...messages.youCantUnadminYourself} />
       );
     } else {
-      updateUser(user.id, { roles: getNewRoles(user) });
+      updateUser(user.id, { roles: getNewRoles(user, changeToNormalUser) });
     }
   };
 
@@ -194,7 +190,7 @@ const UsersTable = ({
                   selectedUsers === 'all' || includes(selectedUsers, user.id)
                 }
                 toggleSelect={handleUserToggle(user.id)}
-                changeRoles={handleAdminRoleOnChange(user)}
+                changeRoles={handleChangeRoles}
                 authUser={authUser}
               />
             ))}

--- a/front/app/containers/Admin/users/UserTable.tsx
+++ b/front/app/containers/Admin/users/UserTable.tsx
@@ -60,15 +60,14 @@ const SortableTh = ({ sortDirection, onClick, children }: SortableThProps) => (
 
 const getNewRoles = (user: IUserData): TRole[] => {
   if (
-    user.attributes.roles &&
-    (isAdmin({ data: user }) || isCollaborator({ data: user }))
+    !user.attributes.roles ||
+    (user.attributes.roles &&
+      (isAdmin({ data: user }) || isCollaborator({ data: user })))
   ) {
     return [];
   }
 
-  return user.attributes.roles
-    ? [...user.attributes.roles, { type: 'admin' }]
-    : [];
+  return [...user.attributes.roles, { type: 'admin' }];
 };
 
 interface InputProps {

--- a/front/app/containers/Admin/users/UserTable.tsx
+++ b/front/app/containers/Admin/users/UserTable.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import React from 'react';
-import { isAdmin, TRole } from 'services/permissions/roles';
-import { includes, get, isArray } from 'lodash-es';
+import { isAdmin, isCollaborator, TRole } from 'services/permissions/roles';
+import { includes, isArray } from 'lodash-es';
 import { isNilOrError } from 'utils/helperUtils';
 // Components
 import { Table, Thead, Th, Tbody, Tr } from '@citizenlab/cl2-component-library';
@@ -58,6 +58,19 @@ const SortableTh = ({ sortDirection, onClick, children }: SortableThProps) => (
   </Th>
 );
 
+const getNewRoles = (user: IUserData): TRole[] => {
+  if (
+    user.attributes.roles &&
+    (isAdmin({ data: user }) || isCollaborator({ data: user }))
+  ) {
+    return [];
+  }
+
+  return user.attributes.roles
+    ? [...user.attributes.roles, { type: 'admin' }]
+    : [];
+};
+
 interface InputProps {
   selectedUsers: string[] | 'none' | 'all';
   handleSelect: (userId: string) => void;
@@ -85,9 +98,7 @@ const UsersTable = ({
   }
 
   const handleAdminRoleOnChange = (user: IUserData) => () => {
-    let newRoles: TRole[] = [];
-
-    trackEventByName(tracks.adminToggle.name);
+    trackEventByName(tracks.adminChangeRole.name);
 
     if (authUser && authUser.id === user.id) {
       eventEmitter.emit<JSX.Element>(
@@ -95,15 +106,7 @@ const UsersTable = ({
         <FormattedMessage {...messages.youCantUnadminYourself} />
       );
     } else {
-      if (user.attributes.roles && isAdmin({ data: user })) {
-        newRoles = user.attributes.roles.filter(
-          (role) => role.type !== 'admin'
-        );
-      } else {
-        newRoles = [...get(user, 'attributes.roles', []), { type: 'admin' }];
-      }
-
-      updateUser(user.id, { roles: newRoles });
+      updateUser(user.id, { roles: getNewRoles(user) });
     }
   };
 
@@ -192,7 +195,7 @@ const UsersTable = ({
                   selectedUsers === 'all' || includes(selectedUsers, user.id)
                 }
                 toggleSelect={handleUserToggle(user.id)}
-                toggleAdmin={handleAdminRoleOnChange(user)}
+                changeRoles={handleAdminRoleOnChange(user)}
                 authUser={authUser}
               />
             ))}

--- a/front/app/containers/Admin/users/UserTableRow.tsx
+++ b/front/app/containers/Admin/users/UserTableRow.tsx
@@ -39,7 +39,7 @@ interface Props {
   user: IUserData;
   selected: boolean;
   toggleSelect: () => void;
-  changeRoles: () => void;
+  changeRoles: (user: IUserData, changeToNormalUser: boolean) => void;
   authUser: GetAuthUserChildProps;
 }
 

--- a/front/app/containers/Admin/users/UserTableRow.tsx
+++ b/front/app/containers/Admin/users/UserTableRow.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, { useEffect, useState } from 'react';
-import { isAdmin } from 'services/permissions/roles';
+import { isAdmin, isCollaborator } from 'services/permissions/roles';
 import moment from 'moment';
 
 // Utils
@@ -39,7 +39,7 @@ interface Props {
   user: IUserData;
   selected: boolean;
   toggleSelect: () => void;
-  toggleAdmin: () => void;
+  changeRoles: () => void;
   authUser: GetAuthUserChildProps;
 }
 
@@ -60,15 +60,18 @@ const UserTableRow = ({
   user,
   selected,
   toggleSelect,
-  toggleAdmin,
+  changeRoles,
   authUser,
 }: Props) => {
   const { formatMessage } = useIntl();
   const [isUserAdmin, setUserIsAdmin] = useState(isAdmin({ data: user }));
+  const isUserCollaborator = isCollaborator({ data: user });
   const [registeredAt, setRegisteredAt] = useState(
     moment(user.attributes.registration_completed_at).format('LL')
   );
   const [showModal, setShowModal] = useState(false);
+  const [isChangingToNormalUser, setIsChangingToNormalUser] =
+    useState<boolean>(false);
   const closeModal = () => {
     setShowModal(false);
   };
@@ -103,16 +106,32 @@ const UserTableRow = ({
     }
   };
 
-  const setAsAdminAction: IAction = {
-    handler: openModal,
-    label: formatMessage(messages.setAsAdmin),
-    icon: 'shield-checkered' as const,
-  };
+  const getSeatChangeActions = () => {
+    const setAsAdminAction: IAction = {
+      handler: () => {
+        setIsChangingToNormalUser(false);
+        openModal();
+      },
+      label: formatMessage(messages.setAsAdmin),
+      icon: 'shield-checkered' as const,
+    };
 
-  const setAsNormalUserAction: IAction = {
-    handler: openModal,
-    label: formatMessage(messages.setAsNormalUser),
-    icon: 'user-circle' as const,
+    const setAsNormalUserAction: IAction = {
+      handler: () => {
+        setIsChangingToNormalUser(true);
+        openModal();
+      },
+      label: formatMessage(messages.setAsNormalUser),
+      icon: 'user-circle' as const,
+    };
+
+    if (isUserAdmin) {
+      return [setAsNormalUserAction];
+    } else if (isUserCollaborator) {
+      return [setAsNormalUserAction, setAsAdminAction];
+    } else {
+      return [setAsAdminAction];
+    }
   };
 
   const actions: IAction[] = [
@@ -123,7 +142,7 @@ const UserTableRow = ({
       label: formatMessage(messages.seeProfile),
       icon: 'eye' as const,
     },
-    ...(isUserAdmin ? [setAsNormalUserAction] : [setAsAdminAction]),
+    ...getSeatChangeActions(),
     {
       handler: () => {
         handleDeleteClick();
@@ -180,9 +199,10 @@ const UserTableRow = ({
       <ChangeSeatModal
         user={user}
         isUserAdmin={isUserAdmin}
-        toggleAdmin={toggleAdmin}
+        changeRoles={changeRoles}
         showModal={showModal}
         closeModal={closeModal}
+        isChangingToNormalUser={isChangingToNormalUser}
       />
     </Tr>
   );

--- a/front/app/containers/Admin/users/messages.ts
+++ b/front/app/containers/Admin/users/messages.ts
@@ -70,6 +70,11 @@ export default defineMessages({
     defaultMessage:
       'Are you sure you want to give {name} platform admin rights?',
   },
+  confirmSetCollaboratorAsNormalUserQuestion: {
+    id: 'app.containers.Admin.Users.confirmSetCollaboratorAsNormalUserQuestion',
+    defaultMessage:
+      'Are you sure you want to set {name} as a normal user? Please note that they will lose collaborator rights to all the projects and folders that they are assigned to on confirmation.',
+  },
   permissionToBuy: {
     id: 'app.containers.Admin.Users.permissionToBuy',
     defaultMessage:

--- a/front/app/containers/Admin/users/tracks.ts
+++ b/front/app/containers/Admin/users/tracks.ts
@@ -29,8 +29,8 @@ export default {
   toggleOneUser: {
     name: 'Selected or unselected one user',
   },
-  adminToggle: {
-    name: 'Clicked an admin toggle',
+  adminChangeRole: {
+    name: 'Clicked an action to change the user role',
   },
   sortChange: {
     name: 'Changed sorting of users in the table',

--- a/front/app/services/permissions/roles.ts
+++ b/front/app/services/permissions/roles.ts
@@ -38,6 +38,16 @@ export const isAdmin = (user?: IUser | null | undefined | Error) => {
   return false;
 };
 
+export const isCollaborator = (user?: IUser | null | undefined | Error) => {
+  if (!isNilOrError(user)) {
+    return ['project_moderator', 'project_folder_moderator'].includes(
+      user.data.attributes.highest_role
+    );
+  }
+
+  return false;
+};
+
 /*
   A super admin is an admin with @citizenlab.co email address.
   In the frontend, it doesn't have a significant meaning at the time of writing (18/1/'21).

--- a/front/app/services/users.ts
+++ b/front/app/services/users.ts
@@ -107,7 +107,11 @@ export async function updateUser(userId: string, object: IUserUpdate) {
 
   await streams.fetchAllWith({
     dataId: [userId],
-    apiEndpoint: [`${API_PATH}/groups`, `${API_PATH}/users`],
+    apiEndpoint: [
+      `${API_PATH}/groups`,
+      `${API_PATH}/users`,
+      `${API_PATH}/stats/users_count`,
+    ],
   });
 
   // Invalidate seats if the user's roles have changed

--- a/front/app/translations/admin/en.json
+++ b/front/app/translations/admin/en.json
@@ -555,6 +555,7 @@
   "app.containers.Admin.Users.confirm": "Confirm",
   "app.containers.Admin.Users.confirmAdminQuestion": "Are you sure you want to give {name} platform admin rights?",
   "app.containers.Admin.Users.confirmNormalUserQuestion": "Are you sure you want to set {name} as a normal user?",
+  "app.containers.Admin.Users.confirmSetCollaboratorAsNormalUserQuestion": "Are you sure you want to set {name} as a normal user? Please note that they will lose collaborator rights to all the projects and folders that they are assigned to on confirmation.",
   "app.containers.Admin.Users.deleteUser": "Delete user",
   "app.containers.Admin.Users.email": "Email",
   "app.containers.Admin.Users.folderManager": "Folder manager",


### PR DESCRIPTION
# Changelog

## Added
* Add option to change a collaborator(project / folder manager) to a normal user in the users page

[CL-3235]: https://citizenlab.atlassian.net/browse/CL-3158
