### PR TITLE
[CL-3200] Delete 'idea_custom_fields' and 'dynamic_idea_form' feature flags

### DIFF
--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -215,18 +215,6 @@
         }
       },
 
-      "dynamic_idea_form": {
-        "type": "object",
-        "title": "Dynamic idea form",
-        "description": "Changes the idea form from the hard-coded version to the generated version.",
-        "additionalProperties": false,
-        "required": ["allowed", "enabled"],
-        "properties": {
-          "allowed": { "type": "boolean", "default": true},
-          "enabled": { "type": "boolean", "default": true}
-        }
-      },
-
       "jsonforms_custom_fields": {
         "type": "object",
         "title": "Rework of user custom fields (experimental)",

--- a/back/engines/commercial/granular_permissions/spec/acceptance/ideas_spec.rb
+++ b/back/engines/commercial/granular_permissions/spec/acceptance/ideas_spec.rb
@@ -6,12 +6,7 @@ require 'rspec_api_documentation/dsl'
 resource 'Ideas' do
   explanation 'Proposals from citizens to the city.'
 
-  before do
-    header 'Content-Type', 'application/json'
-
-    SettingsService.new.activate_feature! 'idea_custom_fields'
-    SettingsService.new.activate_feature! 'dynamic_idea_form'
-  end
+  before { header 'Content-Type', 'application/json' }
 
   context 'when visitor' do
     describe 'Create' do

--- a/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
+++ b/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
@@ -23,7 +23,6 @@ module IdeaCustomFields
       }
     }
 
-    before_action :verify_feature_flag
     before_action :set_custom_field, only: %i[show]
     before_action :set_custom_form, only: %i[index update_all]
     skip_after_action :verify_policy_scoped
@@ -254,12 +253,6 @@ module IdeaCustomFields
     def set_custom_field
       @custom_field = CustomField.find params[:id]
       authorize @custom_field, policy_class: IdeaCustomFieldPolicy
-    end
-
-    def verify_feature_flag
-      return if AppConfiguration.instance.feature_activated? 'idea_custom_fields'
-
-      render json: { errors: { base: [{ error: '"idea_custom_fields" feature is not activated' }] } }, status: :unauthorized
     end
 
     def secure_constantize(key)

--- a/back/engines/commercial/idea_custom_fields/app/models/idea_custom_fields/extensions/idea.rb
+++ b/back/engines/commercial/idea_custom_fields/app/models/idea_custom_fields/extensions/idea.rb
@@ -33,16 +33,11 @@ module IdeaCustomFields
       private
 
       def validate_extra_fields_on_publication?
-        dynamic_form_activated? && project.custom_form
+        project.custom_form
       end
 
       def validate_extra_fields_on_update?
-        custom_field_values_changed? && persisted? && dynamic_form_activated? && project.custom_form
-      end
-
-      def dynamic_form_activated?
-        AppConfiguration.instance.feature_activated?('idea_custom_fields') &&
-          AppConfiguration.instance.feature_activated?('dynamic_idea_form')
+        custom_field_values_changed? && persisted? && project.custom_form
       end
 
       def extra_idea_fields_schema

--- a/back/engines/commercial/idea_custom_fields/app/serializers/idea_custom_fields/extensions/web_api/v1/idea_serializer.rb
+++ b/back/engines/commercial/idea_custom_fields/app/serializers/idea_custom_fields/extensions/web_api/v1/idea_serializer.rb
@@ -7,9 +7,7 @@ module IdeaCustomFields
         module IdeaSerializer
           def self.included(base)
             base.class_eval do
-              attribute :custom_field_values, if: proc {
-                AppConfiguration.instance.feature_activated? 'idea_custom_fields'
-              } do |idea, params|
+              attribute(:custom_field_values) do |idea, params|
                 CustomFieldService.remove_not_visible_fields idea, current_user(params)
               end
 

--- a/back/engines/commercial/idea_custom_fields/app/services/idea_custom_fields/patches/xlsx_service.rb
+++ b/back/engines/commercial/idea_custom_fields/app/services/idea_custom_fields/patches/xlsx_service.rb
@@ -4,11 +4,7 @@ module IdeaCustomFields
   module Patches
     module XlsxService
       def generate_idea_xlsx_columns(ideas, view_private_attributes: false, with_tags: false)
-        if AppConfiguration.instance.feature_activated? 'idea_custom_fields'
-          super + custom_form_custom_field_columns(ideas)
-        else
-          super
-        end
+        super + custom_form_custom_field_columns(ideas)
       end
 
       private

--- a/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/index_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/index_spec.rb
@@ -5,10 +5,8 @@ require 'rspec_api_documentation/dsl'
 
 resource 'Idea Custom Fields' do
   explanation 'Fields in idea forms which are customized by the city, scoped on the project level.'
-  before do
-    header 'Content-Type', 'application/json'
-    SettingsService.new.activate_feature! 'idea_custom_fields'
-  end
+
+  before { header 'Content-Type', 'application/json' }
 
   get 'web_api/v1/admin/phases/:phase_id/custom_fields' do
     let(:context) { create :phase, participation_method: 'native_survey' }

--- a/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/update_all_native_survey_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/update_all_native_survey_spec.rb
@@ -5,10 +5,7 @@ require 'rspec_api_documentation/dsl'
 
 resource 'Idea Custom Fields' do
   explanation 'Fields in idea forms which are customized by the city, scoped on the project level.'
-  before do
-    header 'Content-Type', 'application/json'
-    SettingsService.new.activate_feature! 'idea_custom_fields'
-  end
+  before { header 'Content-Type', 'application/json' }
 
   patch 'web_api/v1/admin/phases/:phase_id/custom_fields/update_all' do
     parameter :custom_fields, type: :array

--- a/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/project_context/index_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/project_context/index_spec.rb
@@ -5,10 +5,7 @@ require 'rspec_api_documentation/dsl'
 
 resource 'Idea Custom Fields' do
   explanation 'Fields in idea forms which are customized by the city, scoped on the project level.'
-  before do
-    header 'Content-Type', 'application/json'
-    SettingsService.new.activate_feature! 'idea_custom_fields'
-  end
+  before { header 'Content-Type', 'application/json' }
 
   get 'web_api/v1/admin/projects/:project_id/custom_fields' do
     let(:context) { create :project }

--- a/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/project_context/show_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/project_context/show_spec.rb
@@ -5,10 +5,8 @@ require 'rspec_api_documentation/dsl'
 
 resource 'Idea Custom Fields' do
   explanation 'Fields in idea forms which are customized by the city, scoped on the project level.'
-  before do
-    header 'Content-Type', 'application/json'
-    SettingsService.new.activate_feature! 'idea_custom_fields'
-  end
+
+  before { header 'Content-Type', 'application/json' }
 
   get 'web_api/v1/admin/projects/:project_id/custom_fields/:id' do
     # let(:context) { create :project }

--- a/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/project_context/update_all_ideation_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/project_context/update_all_ideation_spec.rb
@@ -5,10 +5,8 @@ require 'rspec_api_documentation/dsl'
 
 resource 'Idea Custom Fields' do
   explanation 'Fields in idea forms which are customized by the city, scoped on the project level.'
-  before do
-    header 'Content-Type', 'application/json'
-    SettingsService.new.activate_feature! 'idea_custom_fields'
-  end
+
+  before { header 'Content-Type', 'application/json' }
 
   patch 'web_api/v1/admin/projects/:project_id/custom_fields/update_all' do
     parameter :custom_fields, type: :array

--- a/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/project_context/update_all_native_survey_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/project_context/update_all_native_survey_spec.rb
@@ -5,10 +5,8 @@ require 'rspec_api_documentation/dsl'
 
 resource 'Idea Custom Fields' do
   explanation 'Fields in idea forms which are customized by the city, scoped on the project level.'
-  before do
-    header 'Content-Type', 'application/json'
-    SettingsService.new.activate_feature! 'idea_custom_fields'
-  end
+
+  before { header 'Content-Type', 'application/json' }
 
   patch 'web_api/v1/admin/projects/:project_id/custom_fields/update_all' do
     parameter :custom_fields, type: :array

--- a/back/engines/commercial/idea_custom_fields/spec/acceptance/ideas_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/acceptance/ideas_spec.rb
@@ -12,9 +12,6 @@ resource 'Ideas' do
     header 'Content-Type', 'application/json'
     token = Knock::AuthToken.new(payload: user.to_token_payload).token
     header 'Authorization', "Bearer #{token}"
-
-    SettingsService.new.activate_feature! 'idea_custom_fields'
-    SettingsService.new.activate_feature! 'dynamic_idea_form'
   end
 
   describe 'Create' do

--- a/back/engines/commercial/idea_custom_fields/spec/models/idea_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/models/idea_spec.rb
@@ -4,11 +4,6 @@ require 'rails_helper'
 
 RSpec.describe Idea, type: :model do
   context 'with custom fields' do
-    before do
-      SettingsService.new.activate_feature! 'idea_custom_fields'
-      SettingsService.new.activate_feature! 'dynamic_idea_form'
-    end
-
     let(:project) { create :project }
     let(:form) { create :custom_form, participation_context: project }
     let!(:required_field) { create :custom_field, :for_custom_form, resource: form, required: true, input_type: 'number' }

--- a/back/engines/commercial/idea_custom_fields/spec/serializers/web_api/v1/idea_serializer_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/serializers/web_api/v1/idea_serializer_spec.rb
@@ -26,10 +26,6 @@ describe WebApi::V1::IdeaSerializer do
       let(:idea_author) { create(:user) }
       let(:idea) { create :idea, project: project, custom_field_values: custom_field_values, author: idea_author }
 
-      before_all do
-        SettingsService.new.activate_feature! 'idea_custom_fields'
-      end
-
       it 'serializes all visible extra fields at the same level as the idea fields for the idea author' do
         output = described_class.new(idea, params: { current_user: idea_author }).serializable_hash
         expect(output.dig(:data, :attributes, visible_public_field.key.to_sym)).to eq visible_public_value

--- a/back/engines/commercial/idea_custom_fields/spec/services/xlsx_service_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/services/xlsx_service_spec.rb
@@ -8,8 +8,9 @@ describe XlsxService do
 
   describe 'generate_ideas_xlsx' do
     before do
-      @project = create :project
-      @form = create :custom_form, participation_context: @project
+      @project = create(:project)
+      @form = create(:custom_form, participation_context: @project)
+
       create(
         :custom_field,
         :for_custom_form,
@@ -19,157 +20,136 @@ describe XlsxService do
         key: 'number_field',
         title_multiloc: { 'en' => 'How many times did it rain this year?' }
       )
+
+      create(
+        :custom_field,
+        :for_custom_form,
+        resource: @form,
+        required: false,
+        input_type: 'date',
+        key: 'date_field',
+        title_multiloc: { 'en' => 'When was the last time it rained?' }
+      )
+
+      select_field = create(
+        :custom_field_select,
+        :for_custom_form,
+        resource: @form,
+        required: false,
+        key: 'select_field',
+        title_multiloc: { 'en' => 'Which of these animals is more common in your neighbourhood?' }
+      )
+      create(
+        :custom_field_option,
+        custom_field: select_field,
+        key: 'hippopotamus',
+        title_multiloc: { 'en' => 'Hippopotamus' }
+      )
+      create(
+        :custom_field_option,
+        custom_field: select_field,
+        key: 'fruitfly',
+        title_multiloc: { 'en' => 'Fruit fly' }
+      )
+
+      multiselect_field = create(
+        :custom_field_multiselect,
+        :for_custom_form,
+        resource: @form,
+        required: false,
+        key: 'multiselect_field',
+        title_multiloc: { 'en' => 'Which option names sound good to you?' }
+      )
+      create(
+        :custom_field_option,
+        custom_field: multiselect_field,
+        key: 'option1',
+        title_multiloc: { 'en' => 'Option 1' }
+      )
+      create(
+        :custom_field_option,
+        custom_field: multiselect_field,
+        key: 'option2',
+        title_multiloc: { 'en' => 'Option 2' }
+      )
+
+      fields1 = { 'number_field' => 9, 'multiselect_field' => %w[option1 option2] }
+      fields2 = { 'number_field' => 22, 'date_field' => '19-05-2022', 'select_field' => 'hippopotamus' }
+      fields3 = { 'select_field' => 'fruitfly', 'multiselect_field' => %w[option1] }
+      @idea1 = create(:idea, project: @project, custom_field_values: fields1)
+      @idea2 = create(:idea, project: @project, custom_field_values: fields2)
+      @idea3 = create(:idea, project: @project, custom_field_values: fields3)
     end
 
-    context 'when idea_custom_fields is deactivated' do
-      before do
-        SettingsService.new.deactivate_feature! 'idea_custom_fields'
-        @idea1 = create(:idea, project: @project, custom_field_values: { 'number_field' => 4 })
-      end
+    let(:xlsx) { service.generate_ideas_xlsx([@idea1, @idea2, @idea3], view_private_attributes: false) }
+    let(:workbook) { RubyXL::Parser.parse_buffer(xlsx) }
+    let(:worksheet) { workbook.worksheets[0] }
 
-      let(:xlsx) { service.generate_ideas_xlsx([@idea1], view_private_attributes: false) }
-      let(:workbook) { RubyXL::Parser.parse_buffer(xlsx) }
-      let(:worksheet) { workbook.worksheets[0] }
-
-      it 'excludes custom field values' do
-        headers = worksheet[0].cells.map(&:value)
-        number_field_idx = headers.find_index 'How many times did it rain this year?'
-        expect(number_field_idx).to be_nil
-      end
+    it 'includes custom field values' do
+      # TODO: verify that hidden fields are left out
+      headers = worksheet[0].cells.map(&:value)
+      number_field_idx = headers.find_index 'How many times did it rain this year?'
+      date_field_idx = headers.find_index 'When was the last time it rained?'
+      select_field_idx = headers.find_index 'Which of these animals is more common in your neighbourhood?'
+      multiselect_field_idx = headers.find_index 'Which option names sound good to you?'
+      expect([number_field_idx, date_field_idx, select_field_idx, multiselect_field_idx]).to all(be_present)
+      idea1_row = worksheet[1].cells.map(&:value)
+      expect(
+        [
+          idea1_row[number_field_idx],
+          idea1_row[date_field_idx],
+          idea1_row[select_field_idx],
+          idea1_row[multiselect_field_idx]
+        ]
+      ).to eq [9, '', '', 'Option 1, Option 2']
+      idea2_row = worksheet[2].cells.map(&:value)
+      expect(
+        [
+          idea2_row[number_field_idx],
+          idea2_row[date_field_idx],
+          idea2_row[select_field_idx],
+          idea2_row[multiselect_field_idx]
+        ]
+      ).to eq [22, '19-05-2022', 'Hippopotamus', '']
+      idea3_row = worksheet[3].cells.map(&:value)
+      expect(
+        [
+          idea3_row[number_field_idx],
+          idea3_row[date_field_idx],
+          idea3_row[select_field_idx],
+          idea3_row[multiselect_field_idx]
+        ]
+      ).to eq ['', '', 'Fruit fly', 'Option 1']
     end
 
-    context 'when idea_custom_fields is activated' do
-      before do
-        SettingsService.new.activate_feature! 'idea_custom_fields'
+    it 'includes hidden custom fields' do
+      create(
+        :custom_field,
+        :for_custom_form,
+        resource: @form,
+        hidden: true,
+        title_multiloc: { 'en' => 'Hidden field' }
+      )
+      headers = worksheet[0].cells.map(&:value)
+      field_idx = headers.find_index 'Hidden field'
+      expect(field_idx).to be_present
+    end
 
-        create(
-          :custom_field,
-          :for_custom_form,
-          resource: @form,
-          required: false,
-          input_type: 'date',
-          key: 'date_field',
-          title_multiloc: { 'en' => 'When was the last time it rained?' }
-        )
-        select_field = create(
-          :custom_field_select,
-          :for_custom_form,
-          resource: @form,
-          required: false,
-          key: 'select_field',
-          title_multiloc: { 'en' => 'Which of these animals is more common in your neighbourhood?' }
-        )
-        create(
-          :custom_field_option,
-          custom_field: select_field,
-          key: 'hippopotamus',
-          title_multiloc: { 'en' => 'Hippopotamus' }
-        )
-        create(
-          :custom_field_option,
-          custom_field: select_field,
-          key: 'fruitfly',
-          title_multiloc: { 'en' => 'Fruit fly' }
-        )
-        multiselect_field = create(
-          :custom_field_multiselect,
-          :for_custom_form,
-          resource: @form,
-          required: false,
-          key: 'multiselect_field',
-          title_multiloc: { 'en' => 'Which option names sound good to you?' }
-        )
-        create(
-          :custom_field_option,
-          custom_field: multiselect_field,
-          key: 'option1',
-          title_multiloc: { 'en' => 'Option 1' }
-        )
-        create(
-          :custom_field_option,
-          custom_field: multiselect_field,
-          key: 'option2',
-          title_multiloc: { 'en' => 'Option 2' }
-        )
-
-        fields1 = { 'number_field' => 9, 'multiselect_field' => %w[option1 option2] }
-        fields2 = { 'number_field' => 22, 'date_field' => '19-05-2022', 'select_field' => 'hippopotamus' }
-        fields3 = { 'select_field' => 'fruitfly', 'multiselect_field' => %w[option1] }
-        @idea1 = create :idea, project: @project, custom_field_values: fields1
-        @idea2 = create :idea, project: @project, custom_field_values: fields2
-        @idea3 = create :idea, project: @project, custom_field_values: fields3
-      end
-
-      let(:xlsx) { service.generate_ideas_xlsx([@idea1, @idea2, @idea3], view_private_attributes: false) }
-      let(:workbook) { RubyXL::Parser.parse_buffer(xlsx) }
-      let(:worksheet) { workbook.worksheets[0] }
-
-      it 'includes custom field values' do # TODO: verify that hidden fields are left out
-        headers = worksheet[0].cells.map(&:value)
-        number_field_idx      = headers.find_index 'How many times did it rain this year?'
-        date_field_idx        = headers.find_index 'When was the last time it rained?'
-        select_field_idx      = headers.find_index 'Which of these animals is more common in your neighbourhood?'
-        multiselect_field_idx = headers.find_index 'Which option names sound good to you?'
-        expect([number_field_idx, date_field_idx, select_field_idx, multiselect_field_idx]).to all(be_present)
-        idea1_row = worksheet[1].cells.map(&:value)
-        expect(
-          [
-            idea1_row[number_field_idx],
-            idea1_row[date_field_idx],
-            idea1_row[select_field_idx],
-            idea1_row[multiselect_field_idx]
-          ]
-        ).to eq [9, '', '', 'Option 1, Option 2']
-        idea2_row = worksheet[2].cells.map(&:value)
-        expect(
-          [
-            idea2_row[number_field_idx],
-            idea2_row[date_field_idx],
-            idea2_row[select_field_idx],
-            idea2_row[multiselect_field_idx]
-          ]
-        ).to eq [22, '19-05-2022', 'Hippopotamus', '']
-        idea3_row = worksheet[3].cells.map(&:value)
-        expect(
-          [
-            idea3_row[number_field_idx],
-            idea3_row[date_field_idx],
-            idea3_row[select_field_idx],
-            idea3_row[multiselect_field_idx]
-          ]
-        ).to eq ['', '', 'Fruit fly', 'Option 1']
-      end
-
-      it 'includes hidden custom fields' do
-        create(
-          :custom_field,
-          :for_custom_form,
-          resource: @form,
-          hidden: true,
-          title_multiloc: { 'en' => 'Hidden field' }
-        )
-        headers = worksheet[0].cells.map(&:value)
-        field_idx = headers.find_index 'Hidden field'
-        expect(field_idx).to be_present
-      end
-
-      it 'includes disabled custom fields' do
-        create(
-          :custom_field,
-          :for_custom_form,
-          resource: @form,
-          enabled: false,
-          title_multiloc: { 'en' => 'Disabled field' }
-        )
-        headers = worksheet[0].cells.map(&:value)
-        field_idx = headers.find_index 'Disabled field'
-        expect(field_idx).to be_present
-      end
+    it 'includes disabled custom fields' do
+      create(
+        :custom_field,
+        :for_custom_form,
+        resource: @form,
+        enabled: false,
+        title_multiloc: { 'en' => 'Disabled field' }
+      )
+      headers = worksheet[0].cells.map(&:value)
+      field_idx = headers.find_index 'Disabled field'
+      expect(field_idx).to be_present
     end
 
     context 'when a project has no custom form - and therefore no fields' do
       before do
-        SettingsService.new.activate_feature! 'idea_custom_fields'
         @project_no_form = create :project
         @idea = create :idea, project: @project_no_form
       end
@@ -190,7 +170,6 @@ describe XlsxService do
 
     context 'when there is a mix of projects with custom fields and without' do
       before do
-        SettingsService.new.activate_feature! 'idea_custom_fields'
         @project_no_form = create :project
         @project_with_form = create :project
         @form = create :custom_form, participation_context: @project_with_form

--- a/back/engines/commercial/multi_tenancy/db/seeds/tenants.rb
+++ b/back/engines/commercial/multi_tenancy/db/seeds/tenants.rb
@@ -124,14 +124,6 @@ module MultiTenancy
               enabled: true,
               allowed: true
             },
-            idea_custom_fields: {
-              enabled: true,
-              allowed: true
-            },
-            dynamic_idea_form: {
-              enabled: true,
-              allowed: true
-            },
             idea_author_change: {
               enabled: true,
               allowed: true

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/create_tenant.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/create_tenant.rake
@@ -41,14 +41,6 @@ namespace :cl2_back do
           enabled: true,
           allowed: true
         },
-        idea_custom_fields: {
-          enabled: true,
-          allowed: true
-        },
-        dynamic_idea_form: {
-          enabled: true,
-          allowed: true
-        },
         idea_author_change: {
           enabled: true,
           allowed: true


### PR DESCRIPTION
# Changelog

- Remove the `idea_custom_fields` and `dynamic_idea_form` feature flags. These features are no longer in use and must be enabled on all platforms, as the legacy hardcoded idea form has been removed.
