### PR TITLE
CL-3240 Clarify can_moderate query params

### DIFF
--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -23,11 +23,22 @@ resource 'Users' do
         parameter :size, 'Number of users per page'
       end
       parameter :search, 'Filter by searching in first_name, last_name and email', required: false
-      parameter :sort, "Sort user by 'created_at', '-created_at', 'last_name', '-last_name', 'email', '-email', 'role', '-role'", required: false
+      parameter :sort, "Sort user by 'created_at', '-created_at', 'last_name', '-last_name', 'email', " \
+                       "'-email', 'role', '-role'", required: false
       parameter :group, 'Filter by group_id', required: false
-      parameter :can_moderate_project, 'Filter by users (and admins) who can moderate the project (by id)', required: false
-      parameter :can_moderate, 'Filter out admins and moderators', required: false
-
+      parameter :can_moderate_project, 'All admins + users who can moderate the project (by project id), ' \
+                                       'excluding folder moderators of folder containing project ' \
+                                       '(who can, in fact, moderate the project), ' \
+                                       'OR Admins & all users with project moderator role ' \
+                                       '(if no project ID provided)', required: false
+      parameter :can_moderate, 'All admins + users with either a project &/or folder moderator role', required: false
+      parameter :is_not_project_moderator, 'Users who are not admins, nor project moderator of project, ' \
+                                           'nor folder moderator of folder containing project (by project id), ' \
+                                           'OR Users who are not admins, nor have project moderator role ' \
+                                           '(if no project ID provided)', required: false
+      parameter :is_not_folder_moderator, 'Users who are not admins, nor folder moderator of folder (by folder id), ' \
+                                          'OR Users who are not admins, nor have folder moderator role ' \
+                                          '(if no folder ID provided)', required: false
       example_request '[error] List all users' do
         assert_status 401
       end

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -26,12 +26,12 @@ resource 'Users' do
       parameter :sort, "Sort user by 'created_at', '-created_at', 'last_name', '-last_name', 'email', " \
                        "'-email', 'role', '-role'", required: false
       parameter :group, 'Filter by group_id', required: false
+      parameter :can_moderate, 'All admins + users with either a project &/or folder moderator role', required: false
       parameter :can_moderate_project, 'All admins + users who can moderate the project (by project id), ' \
                                        'excluding folder moderators of folder containing project ' \
                                        '(who can, in fact, moderate the project), ' \
                                        'OR Admins & all users with project moderator role ' \
                                        '(if no project ID provided)', required: false
-      parameter :can_moderate, 'All admins + users with either a project &/or folder moderator role', required: false
       parameter :is_not_project_moderator, 'Users who are not admins, nor project moderator of project, ' \
                                            'nor folder moderator of folder containing project (by project id), ' \
                                            'OR Users who are not admins, nor have project moderator role ' \

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -30,7 +30,7 @@ resource 'Users' do
       parameter :can_moderate_project, 'All admins + users who can moderate the project (by project id), ' \
                                        'excluding folder moderators of folder containing project ' \
                                        '(who can, in fact, moderate the project), ' \
-                                       'OR Admins & all users with project moderator role ' \
+                                       'OR All admins + users with project moderator role ' \
                                        '(if no project ID provided)', required: false
       parameter :is_not_project_moderator, 'Users who are not admins, nor project moderator of project, ' \
                                            'nor folder moderator of folder containing project (by project id), ' \

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -487,7 +487,7 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe 'not moderator scopes' do
+  describe 'moderator scopes' do
     let(:user) { create(:user) }
     let(:admin) { create(:admin) }
     let!(:project) { create(:project) }
@@ -496,6 +496,80 @@ RSpec.describe User, type: :model do
     let(:moderator_of_other_project) { create(:project_moderator, projects: [create(:project)]) }
     let(:project_folder_moderator) { create(:project_folder_moderator, project_folders: [project_folder]) }
     let(:moderator_of_other_folder) { create(:project_folder_moderator, project_folders: [create(:project_folder)]) }
+
+    describe '.project_moderator' do
+      context 'when a project ID is provided' do
+        it 'excludes regular user with no roles' do
+          expect(described_class.project_moderator(project.id)).not_to include(user)
+        end
+
+        it 'excludes admins' do
+          expect(described_class.project_moderator(project.id)).not_to include(admin)
+        end
+
+        it 'includes project moderators of project' do
+          expect(described_class.project_moderator(project.id)).to include(project_moderator)
+        end
+
+        it 'excludes project moderators of other projects' do
+          expect(described_class.project_moderator(project.id)).not_to include(moderator_of_other_project)
+        end
+
+        it 'excludes folder moderators of project folder' do
+          expect(described_class.project_moderator(project.id)).not_to include(project_folder_moderator)
+        end
+
+        it 'excludes folder moderators of other folders' do
+          expect(described_class.project_moderator(project.id)).not_to include(moderator_of_other_folder)
+        end
+      end
+
+      context 'when a project ID is not provided' do
+        it 'includes only users with a project moderator role' do
+          expect(described_class.project_moderator)
+            .to match_array([project_moderator, moderator_of_other_project])
+        end
+      end
+    end
+
+    describe '.project_folder_moderator' do
+      context 'when a folder ID is provided' do
+        it 'excludes regular user with no roles' do
+          expect(described_class.project_folder_moderator(project_folder.id)).not_to include(user)
+        end
+
+        it 'excludes admins' do
+          expect(described_class.project_folder_moderator(project_folder.id)).not_to include(admin)
+        end
+
+        it 'includes folder moderators of folder' do
+          expect(described_class.project_folder_moderator(project_folder.id)).to include(project_folder_moderator)
+        end
+
+        it 'excludes folder moderators of folder' do
+          expect(described_class.project_folder_moderator(project_folder.id)).not_to include(moderator_of_other_folder)
+        end
+
+        it 'excludes project moderators who are not also moderator of the folder' do
+          expect(described_class.project_folder_moderator(project_folder.id)).not_to include(project_moderator)
+          expect(described_class.project_folder_moderator(project_folder.id)).not_to include(moderator_of_other_project)
+        end
+
+        it 'includes project moderators who are also moderator of the folder' do
+          moderator_of_other_project.roles << { type: 'project_folder_moderator', project_folder_id: project_folder.id }
+          moderator_of_other_project.save!
+
+          expect(described_class.project_folder_moderator(project_folder.id)).to include(moderator_of_other_project)
+        end
+      end
+
+      context 'when a folder ID is not provided' do
+        it 'includes only users with a folder moderator role' do
+          expect(described_class.project_folder_moderator)
+            .to match_array([project_folder_moderator, moderator_of_other_folder])
+        end
+      end
+    end
 
     describe '.not_project_moderator' do
       context 'when a project ID is provided' do


### PR DESCRIPTION
- Add model model tests for `project_moderator` & `folder_moderator` scopes, to document their behaviour.
- Improve acceptance test descriptions of query parameters related to the various moderator scopes.

Note: The behaviours documented and described here may not, in fact, be exactly what is desired. For example, we might prefer that `can_moderate_project` (by project ID) includes folder moderators of a project's parent folder (if the project is in a folder).

# Changelog
## Technical
- [CL-3240] Add model tests for moderator scopes & improve related param descriptions in acceptance spec


[CL-3240]: https://citizenlab.atlassian.net/browse/CL-3240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ