### PR TITLE
Fix and re-enable skipped test

### DIFF
--- a/front/app/components/IdeaButton/index.tsx
+++ b/front/app/components/IdeaButton/index.tsx
@@ -340,6 +340,7 @@ const IdeaButton = memo<Props & WrappedComponentProps>(
                   onClick={onClick}
                   disabled={!enabled}
                   ariaDisabled={false}
+                  id="e2e-idea-button"
                 >
                   <FormattedMessage {...buttonMessage} />
                 </Button>

--- a/front/app/containers/Admin/messaging/CustomEmails/CampaignForm/index.tsx
+++ b/front/app/containers/Admin/messaging/CustomEmails/CampaignForm/index.tsx
@@ -194,6 +194,7 @@ const CampaignForm = ({
 
           <StyledSectionField>
             <Input
+              id="e2e-reply-to-input"
               name="reply_to"
               type="email"
               label={formatMessage(messages.fieldReplyTo)}
@@ -230,7 +231,11 @@ const CampaignForm = ({
           </SectionField>
         </StyledSection>
         <Box display="flex">
-          <Button type="submit" processing={methods.formState.isSubmitting}>
+          <Button
+            id="e2e-campaign-form-save-button"
+            type="submit"
+            processing={methods.formState.isSubmitting}
+          >
             {formatMessage(messages.formSave)}
           </Button>
         </Box>

--- a/front/cypress/e2e/email_consent.cy.ts
+++ b/front/cypress/e2e/email_consent.cy.ts
@@ -1,4 +1,4 @@
-describe.skip('email consent', () => {
+describe('email consent', () => {
   beforeEach(() => {
     cy.setAdminLoginCookie();
     cy.visit('/admin/messaging/emails/custom/new');
@@ -7,16 +7,30 @@ describe.skip('email consent', () => {
 
   it('lets admins create a custom email, this email contains a link to unsubscribe and turns off subscription', () => {
     // creates a custom email
-    cy.get('.e2e-campaign_subject_multiloc')
-      .find('input')
-      .first()
-      .type('Test subject');
-    cy.get('.e2e-campaign_body_multiloc')
-      .find('.ql-editor')
-      .first()
-      .type('Test content');
-    cy.get('.e2e-submit-wrapper-button').find('button').click();
-    cy.wait(1000);
+
+    cy.get('#e2e-reply-to-input').type('test@test.com');
+
+    cy.get('.e2e-campaign_subject_multiloc .e2e-localeswitcher').each(
+      (button) => {
+        // input
+        cy.wrap(button).click();
+        cy.get('.e2e-campaign_subject_multiloc')
+          .find('input')
+          .first()
+          .type('Test subject');
+      }
+    );
+
+    cy.get('.e2e-campaign_body_multiloc .e2e-localeswitcher').each((button) => {
+      // input
+      cy.wrap(button).click();
+      cy.get('.e2e-campaign_body_multiloc')
+        .find('.ql-editor')
+        .first()
+        .type('Test content');
+    });
+
+    cy.get('#e2e-campaign-form-save-button').click();
     cy.get('#e2e-custom-email-container');
     cy.get('#e2e-custom-email-container iframe');
 

--- a/front/cypress/e2e/idea_posting_permissions.cy.ts
+++ b/front/cypress/e2e/idea_posting_permissions.cy.ts
@@ -40,22 +40,22 @@ describe('Idea posting permissions', () => {
       });
   });
 
-  describe.skip('a project that requires verification', () => {
+  describe('a project that requires verification', () => {
     it('sends unverified users to the signup flow', () => {
       cy.setLoginCookie(unverifiedEmail, unverifiedPassword);
       cy.visit('projects/verified-ideation');
       cy.acceptCookies();
-      cy.get('.e2e-idea-button:visible').click();
+      cy.get('#e2e-idea-button').first().click();
       cy.wait(4000); // sometimes the next line fails on CI. Not sure how to properly fix it
-      cy.get('#e2e-verification-wizard-root');
+      cy.get('#e2e-verification-wizard-root').should('exist');
     });
 
     it('lets verified users post', () => {
       cy.setLoginCookie(verifiedEmail, verifiedPassword);
       cy.visit('projects/verified-ideation');
       cy.acceptCookies();
-      cy.get('.e2e-idea-button:visible').click();
-      cy.get('#e2e-new-idea-form');
+      cy.get('#e2e-idea-button').first().click();
+      cy.get('#e2e-idea-new-page').should('exist');
     });
   });
 

--- a/front/cypress/e2e/sign_up_email_password.cy.ts
+++ b/front/cypress/e2e/sign_up_email_password.cy.ts
@@ -15,11 +15,12 @@ function signUp() {
   cy.get('#e2e-signup-password-submit-button').wait(500).click().wait(500);
 }
 
-describe.skip('Sign up - Email + password step', () => {
+describe('Sign up - Email + password step', () => {
   beforeEach(() => {
     cy.goToLandingPage();
     cy.get('#e2e-navbar-signup-menu-item').click();
     cy.get('#e2e-sign-up-container');
+    cy.contains('Sign up with Email').click();
     cy.get('#e2e-sign-up-email-password-container');
   });
 
@@ -28,10 +29,13 @@ describe.skip('Sign up - Email + password step', () => {
   });
 
   it('shows an error when no first name is provided', () => {
-    cy.get('#e2e-signup-password-submit-button').wait(500).click().wait(500);
+    cy.get('#e2e-signup-password-submit-button').should('exist');
+    cy.get('#e2e-signup-password-submit-button').click();
+    cy.get('#e2e-firstName-container .e2e-error-message').should('exist');
+    cy.scrollTo('top');
     cy.get('#e2e-firstName-container .e2e-error-message').should(
       'contain',
-      'This cannot be empty'
+      'Enter your first name'
     );
   });
 
@@ -43,7 +47,7 @@ describe.skip('Sign up - Email + password step', () => {
     cy.get('#e2e-signup-password-submit-button').wait(500).click().wait(500);
     cy.get('#e2e-lastName-container .e2e-error-message').should(
       'contain',
-      'This cannot be empty'
+      'Enter your last name'
     );
   });
 
@@ -55,7 +59,7 @@ describe.skip('Sign up - Email + password step', () => {
     cy.get('#e2e-signup-password-submit-button').wait(500).click().wait(500);
     cy.get('#e2e-email-container .e2e-error-message').should(
       'contain',
-      'This cannot be empty'
+      'Enter an email address in the correct format'
     );
   });
 
@@ -64,7 +68,7 @@ describe.skip('Sign up - Email + password step', () => {
     cy.get('#e2e-signup-password-submit-button').wait(500).click().wait(500);
     cy.get('#e2e-email-container .e2e-error-message').should(
       'contain',
-      "This doesn't look like a valid email"
+      'Enter an email address in the correct format'
     );
   });
 
@@ -78,7 +82,7 @@ describe.skip('Sign up - Email + password step', () => {
     cy.get('#e2e-signup-password-submit-button').wait(500).click().wait(500);
     cy.get('#e2e-password-container .e2e-error-message').should(
       'contain',
-      'Your password needs to be at least 8 characters long.'
+      'Provide a password that is at least 8 characters long'
     );
   });
 
@@ -87,7 +91,7 @@ describe.skip('Sign up - Email + password step', () => {
     cy.get('#e2e-signup-password-submit-button').wait(500).click().wait(500);
     cy.get('#e2e-password-container .e2e-error-message').should(
       'contain',
-      'Your password needs to be at least 8 characters long.'
+      'Provide a password that is at least 8 characters long'
     );
   });
 
@@ -108,12 +112,20 @@ describe.skip('Sign up - Email + password step', () => {
     cy.get('#e2e-signup-password-submit-button').wait(500).click().wait(500);
     cy.get('#e2e-terms-and-conditions-container');
     cy.get('#e2e-terms-and-conditions-container .e2e-error-message');
+    cy.get('#e2e-terms-and-conditions-container .e2e-error-message').should(
+      'contain',
+      'Accept our terms and conditions to proceed'
+    );
   });
 
   it('shows an error when the privacy checkbox is not checked', () => {
     cy.get('#e2e-signup-password-submit-button').wait(500).click().wait(500);
     cy.get('#e2e-terms-and-conditions-container');
     cy.get('#e2e-privacy-container .e2e-error-message');
+    cy.get('#e2e-privacy-container .e2e-error-message').should(
+      'contain',
+      'Accept our privacy policy to proceed'
+    );
   });
 
   it('signs up successfully', () => {
@@ -126,6 +138,8 @@ describe.skip('Sign up - Email + password step', () => {
     signUp();
     cy.get('#e2e-confirmation-code-input').type('1234');
     cy.get('#e2e-confirmation-button').click();
+    cy.get('#e2e-signup-custom-fields-skip-btn').should('exist');
+    cy.get('#e2e-signup-custom-fields-skip-btn').click();
     cy.get('.e2e-signup-success-close-button').wait(500).click();
     cy.get('#e2e-sign-up-in-modal').should('not.exist');
     cy.get('#e2e-user-menu-container');


### PR DESCRIPTION
## Description
I only found 1 skipped test related to authentication/registration. I've re-enabled it and fixed the issues so it passes.

The main reason it failed was copy changes in the error messages, so I've updated the copy. However I'm not sure this is the most resilient approach. The content of the copy _is_ important though, since we want to make sure the copy is the correct one :thinking: @luucvanderzee do you have a suggestion? Should we just check that error messages are being shown? Or check their text content as well?