### PR TITLE
[CL-3260] Don't show generated user names in profile form

### DIFF
--- a/front/app/containers/UsersEditPage/ProfileForm.tsx
+++ b/front/app/containers/UsersEditPage/ProfileForm.tsx
@@ -110,10 +110,10 @@ const ProfileForm = ({
     mode: 'onBlur',
     defaultValues: {
       first_name: authUser?.attributes.no_name
-        ? ''
+        ? undefined
         : authUser?.attributes.first_name,
       last_name: authUser?.attributes.no_name
-        ? ''
+        ? undefined
         : authUser?.attributes.last_name || undefined,
       email: authUser?.attributes.email,
       bio_multiloc: authUser?.attributes.bio_multiloc,

--- a/front/app/containers/UsersEditPage/ProfileForm.tsx
+++ b/front/app/containers/UsersEditPage/ProfileForm.tsx
@@ -109,8 +109,12 @@ const ProfileForm = ({
   const methods = useForm<FormValues>({
     mode: 'onBlur',
     defaultValues: {
-      first_name: authUser?.attributes.first_name,
-      last_name: authUser?.attributes.last_name || undefined,
+      first_name: authUser?.attributes.no_name
+        ? ''
+        : authUser?.attributes.first_name,
+      last_name: authUser?.attributes.no_name
+        ? ''
+        : authUser?.attributes.last_name || undefined,
       email: authUser?.attributes.email,
       bio_multiloc: authUser?.attributes.bio_multiloc,
       locale: authUser?.attributes.locale,


### PR DESCRIPTION
## Description
Small fix so that if user's `no_name` attribute is false, don't use the generated name in the default data for profile settings.