### PR TITLE
Make tooltip fully visible inside modal

### DIFF
--- a/front/app/components/SeatInfo/index.tsx
+++ b/front/app/components/SeatInfo/index.tsx
@@ -148,6 +148,7 @@ const SeatInfo = ({ seatType }: SeatInfoProps) => {
                     content={
                       <FormattedMessage {...messages.additionalSeatsToolTip} />
                     }
+                    placement="auto"
                   />
                 )}
               </Box>


### PR DESCRIPTION
# Changelog
## Fixed
- Most right tooltip in seat info modal is fully visible
