### PR TITLE
CL-3292 - Ensure correct sso_flow param returned from SSO

### DIFF
--- a/back/app/controllers/omniauth_callback_controller.rb
+++ b/back/app/controllers/omniauth_callback_controller.rb
@@ -127,12 +127,12 @@ class OmniauthCallbackController < ApplicationController
   end
 
   def signin_success_redirect
-    request.env['omniauth.params']['sso_flow'] = 'signin' if request.env['omniauth.params']['sso_flow']
+    request.env['omniauth.params']['sso_flow'] = 'signin'
     redirect_to(add_uri_params(Frontend::UrlService.new.signin_success_url(locale: @user.locale), request.env['omniauth.params']))
   end
 
   def signup_success_redirect
-    request.env['omniauth.params']['sso_flow'] = 'signup' if request.env['omniauth.params']['sso_flow']
+    request.env['omniauth.params']['sso_flow'] = 'signup'
     redirect_to(add_uri_params(Frontend::UrlService.new.signup_success_url(locale: @user.locale), request.env['omniauth.params']))
   end
 

--- a/back/app/controllers/omniauth_callback_controller.rb
+++ b/back/app/controllers/omniauth_callback_controller.rb
@@ -127,11 +127,13 @@ class OmniauthCallbackController < ApplicationController
   end
 
   def signin_success_redirect
+    request.env['omniauth.params']['sso_flow'] = 'signin'
     redirect_to(add_uri_params(Frontend::UrlService.new.signin_success_url(locale: @user.locale), request.env['omniauth.params']))
   end
 
   def signup_success_redirect
-    redirect_to(add_uri_params(Frontend::UrlService.new.signup_success_url(locale: @user.locale), request.env['omniauth.params']))
+    request.env['omniauth.params']['sso_flow'] = 'signup'
+    redirect_to(add_uri_params(Frontend::UrlService.new.signin_success_url(locale: @user.locale), request.env['omniauth.params']))
   end
 
   def add_uri_params(uri, params = {})

--- a/back/app/controllers/omniauth_callback_controller.rb
+++ b/back/app/controllers/omniauth_callback_controller.rb
@@ -133,7 +133,7 @@ class OmniauthCallbackController < ApplicationController
 
   def signup_success_redirect
     request.env['omniauth.params']['sso_flow'] = 'signup'
-    redirect_to(add_uri_params(Frontend::UrlService.new.signin_success_url(locale: @user.locale), request.env['omniauth.params']))
+    redirect_to(add_uri_params(Frontend::UrlService.new.signup_success_url(locale: @user.locale), request.env['omniauth.params']))
   end
 
   def add_uri_params(uri, params = {})

--- a/back/app/controllers/omniauth_callback_controller.rb
+++ b/back/app/controllers/omniauth_callback_controller.rb
@@ -127,12 +127,12 @@ class OmniauthCallbackController < ApplicationController
   end
 
   def signin_success_redirect
-    request.env['omniauth.params']['sso_flow'] = 'signin'
+    request.env['omniauth.params']['sso_flow'] = 'signin' if request.env['omniauth.params']['sso_flow']
     redirect_to(add_uri_params(Frontend::UrlService.new.signin_success_url(locale: @user.locale), request.env['omniauth.params']))
   end
 
   def signup_success_redirect
-    request.env['omniauth.params']['sso_flow'] = 'signup'
+    request.env['omniauth.params']['sso_flow'] = 'signup' if request.env['omniauth.params']['sso_flow']
     redirect_to(add_uri_params(Frontend::UrlService.new.signup_success_url(locale: @user.locale), request.env['omniauth.params']))
   end
 

--- a/back/app/controllers/omniauth_callback_controller.rb
+++ b/back/app/controllers/omniauth_callback_controller.rb
@@ -126,6 +126,7 @@ class OmniauthCallbackController < ApplicationController
     redirect_to(add_uri_params(Frontend::UrlService.new.signin_failure_url, redirect_params))
   end
 
+  # NOTE: sso_flow params corrected as sometimes an sso user may start from signin but actually signup and vice versa
   def signin_success_redirect
     request.env['omniauth.params']['sso_flow'] = 'signin' if request.env['omniauth.params']['sso_flow']
     redirect_to(add_uri_params(Frontend::UrlService.new.signin_success_url(locale: @user.locale), request.env['omniauth.params']))

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_05_162820) do
+ActiveRecord::Schema.define(version: 2023_03_21_153659) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -1304,7 +1304,6 @@ ActiveRecord::Schema.define(version: 2023_04_05_162820) do
     t.boolean "confirmation_required", default: true, null: false
     t.datetime "block_start_at"
     t.string "block_reason"
-    t.string "new_email"
     t.index "lower((email)::text)", name: "users_unique_lower_email_idx", unique: true
     t.index ["email"], name: "index_users_on_email"
     t.index ["registration_completed_at"], name: "index_users_on_registration_completed_at"

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_21_153659) do
+ActiveRecord::Schema.define(version: 2023_04_05_162820) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -1304,6 +1304,7 @@ ActiveRecord::Schema.define(version: 2023_03_21_153659) do
     t.boolean "confirmation_required", default: true, null: false
     t.datetime "block_start_at"
     t.string "block_reason"
+    t.string "new_email"
     t.index "lower((email)::text)", name: "users_unique_lower_email_idx", unique: true
     t.index ["email"], name: "index_users_on_email"
     t.index ["registration_completed_at"], name: "index_users_on_registration_completed_at"

--- a/back/engines/free/frontend/app/services/frontend/url_service.rb
+++ b/back/engines/free/frontend/app/services/frontend/url_service.rb
@@ -78,6 +78,10 @@ module Frontend
       home_url(options)
     end
 
+    def signup_success_url(options = {})
+      "#{home_url(options)}/complete-signup"
+    end
+
     def signin_failure_url(options = {})
       "#{home_url(options)}/authentication-error"
     end

--- a/back/engines/free/frontend/app/services/frontend/url_service.rb
+++ b/back/engines/free/frontend/app/services/frontend/url_service.rb
@@ -78,10 +78,6 @@ module Frontend
       home_url(options)
     end
 
-    def signup_success_url(options = {})
-      "#{home_url(options)}/complete-signup"
-    end
-
     def signin_failure_url(options = {})
       "#{home_url(options)}/authentication-error"
     end


### PR DESCRIPTION
Before redirecting, we correct the sso_flow param which is passed initially to SSO, to make sure it now reflects whether this was actually a sign-in or a sign-up.

This only gets updated if the sso_flow parameter is already set.
