### PR TITLE
[CL-3313] update gem version

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -124,7 +124,7 @@ gem 'rest-client'
 gem 'rgeo-geojson'
 gem 'rubyzip', '~> 1.3.0'
 gem 'stackprof', '~> 0.2.24'
-gem 'nokogiri', '~> 1.14.2'
+gem 'nokogiri', '~> 1.14.3'
 
 gem 'okcomputer'
 gem 'omniauth', '~> 1.9.1'

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -796,13 +796,13 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.5.8)
-    nokogiri (1.14.2-aarch64-linux)
+    nokogiri (1.14.3-aarch64-linux)
       racc (~> 1.4)
-    nokogiri (1.14.2-arm64-darwin)
+    nokogiri (1.14.3-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.14.2-x86_64-darwin)
+    nokogiri (1.14.3-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.14.2-x86_64-linux)
+    nokogiri (1.14.3-x86_64-linux)
       racc (~> 1.4)
     nori (2.6.0)
     oauth2 (1.4.9)
@@ -1230,7 +1230,7 @@ DEPENDENCIES
   moderation!
   multi_tenancy!
   nlp!
-  nokogiri (~> 1.14.2)
+  nokogiri (~> 1.14.3)
   okcomputer
   omniauth (~> 1.9.1)
   omniauth-azure-activedirectory!


### PR DESCRIPTION
change due to a [vulnerability](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-pxvg-2qj5-37jq) found