### PR TITLE
[CL-3218] Sort by new admin before calculating additional seats

### DIFF
--- a/back/app/services/invites/service.rb
+++ b/back/app/services/invites/service.rb
@@ -99,8 +99,7 @@ class Invites::Service
   def prepare_invitee(params, default_params)
     email = params['email']&.strip
     group_ids = params['group_ids'] || default_params['group_ids'] || []
-    default_params_roles = default_params['roles'].presence || []
-    roles = (params['roles'] + default_params_roles).uniq
+    roles = ((params['roles'] || []) + (default_params['roles'] || [])).uniq
 
     user =
       User.find_by_cimail(email) ||

--- a/back/app/services/invites/service.rb
+++ b/back/app/services/invites/service.rb
@@ -177,7 +177,7 @@ class Invites::Service
     end
 
     invitees
-      .sort! { |i| i.roles_previously_was.any? { |r| r['type'] == 'admin' } && i.roles.none? { |r| r['type'] == 'admin' } ? 1 : 0 }
+      .sort { |i, _| i.roles_previously_was.any? { |r| r['type'] == 'admin' } && i.roles.none? { |r| r['type'] == 'admin' } ? 1 : 0 }
       .each do |invitee|
         if @run_side_fx
           if invitee.previously_new_record?

--- a/back/app/services/invites/xlsx_processor.rb
+++ b/back/app/services/invites/xlsx_processor.rb
@@ -38,9 +38,7 @@ class Invites::XlsxProcessor
       end
       hash.delete('groups')
 
-      if hash['admin'].present?
-        hash['roles'] = xlsx_admin_to_roles(hash['admin'])
-      end
+      hash['roles'] = xlsx_admin_to_roles(hash['admin'])
       hash.delete('admin')
 
       if hash['language'].present?
@@ -75,7 +73,7 @@ class Invites::XlsxProcessor
   def xlsx_admin_to_roles(admin)
     if [true, 'TRUE', 'true', '1', 1].include? admin
       [{ 'type' => 'admin' }]
-    elsif [false, 'FALSE', 'false', '0', 0].include? admin
+    elsif [false, 'FALSE', 'false', '0', 0, nil].include? admin
       []
     else
       @error_storage.add_error(:malformed_admin_value, row: @current_row, value: admin)


### PR DESCRIPTION
- sort invitees by whether they are becoming and admin to avoid incorrect calculation of additional seats by taking into account moderator seats being freed by moderators becoming admins.
- update roles setting by defaulting xlsx roles to an array and combining it with form assigned roles.