### PR TITLE
[CL-3293] Rake task to insert key-values into User custom_field_values

### DIFF
--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/insert_user_custom_field_key_values.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/insert_user_custom_field_key_values.rake
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'csv'
+require 'open-uri'
+
+# This is very similar to reformat_and_insert_user_custom_field_key_value_pairs.rake, with the differences that here we
+# we don't reformat the values, and we read a specific key-value pair from the CSV custom_field_values hashes provided.
+#
+# This is designed to meet a very specific need. It is not meant to be a general purpose tool.
+#
+# This is to be used when, for example, we know that many users have 'lost' a specific key-value pair from their
+# User.custom_field_values hash, and we want to re-insert that key-value pair into the hash.
+# This might be facilitated by downloading a db dump from a production server, from before the data was 'lost',
+# saving the user ids and custom_field_values hashes from that dump to a CSV file, and then running this rake task.
+#
+# Here's an example SQL query to get the CSV data from a production db dump:
+#   SELECT id, custom_field_values FROM cqc_citizenlab_co.users
+#   WHERE (custom_field_values ? 'who_you_are')
+#   ORDER BY id ASC
+#
+# Important! This will overwrite any existing key-value with the same key. therefore, is is highly recommended to
+# first make a backup to help deal with any issues that may arise from this.
+#
+# Example:
+# Given a CSV file with the following headers: "id","custom_field_values":
+#   "id","custom_field_values"
+#   "6c43614c-025d-4d4b-8288-e8060be6b59f","{""gender_1"": ""male"", ""who_you_are"": [""7"", ""17""]}"
+#   "6c43614c-025d-4d4b-8288-e8060be6b59f","{""who_you_are"": [""9""]}"
+#
+# $ rake cl2_back:insert_user_custom_field_key_value_pairs['/cf_values.csv','cqc.citizenlab.co','who_you_are']
+#
+# Note: the specified key must be present in the custom_field_values hash for each row of data in the CSV.
+
+namespace :cl2_back do
+  desc 'Insert key-value pairs to user custom_field_values hashes.'
+  task :insert_user_custom_field_key_value_pairs, %i[url host key] => [:environment] do |_t, args|
+    data = CSV.parse(open(args[:url]).read, { headers: true, col_sep: ',', converters: [] })
+    count = 0
+    key = args[:key]
+
+    Apartment::Tenant.switch(args[:host].tr('.', '_')) do
+      errors = []
+
+      data.each do |d|
+        user = User.find_by id: d['id']
+        if user
+          cfv = user.custom_field_values
+          cfv[key] = JSON.parse(d['custom_field_values'])[key]
+          user.update!(custom_field_values: cfv)
+          count += 1
+          puts "#{count}: custom_field_value inserted for user.id #{user.id}."
+        else
+          errors += ["Couldn't find user #{d['id']}"]
+          puts "ERROR: Couldn't find user #{d['id']}"
+        end
+      end
+
+      if errors.empty?
+        puts "Success! #{count} user #{key} custom_field_values inserted."
+      else
+        puts 'Some errors occured!'
+        errors.each { |l| puts l }
+      end
+    end
+  end
+end

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/insert_user_custom_field_key_values.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/insert_user_custom_field_key_values.rake
@@ -45,6 +45,8 @@ namespace :cl2_back do
         user = User.find_by id: d['id']
         if user
           cfv = user.custom_field_values
+          next if cfv[key].present?
+
           cfv[key] = JSON.parse(d['custom_field_values'])[key]
           user.update!(custom_field_values: cfv)
           count += 1

--- a/back/test.csv
+++ b/back/test.csv
@@ -1,6 +1,0 @@
-"id","custom_field_values"
-"4a167c9b-00ab-4496-80ef-359bc81e2494","{""sector"": [""15""], ""gender_1"": ""1"", ""religion"": ""9"", ""birthyear"": 1973, ""sexuality"": ""1"", ""disability"": ""1"", ""who_you_are"": [""11""], ""ethnic_group"": ""1"", ""regional_area"": [""37""], ""additional_information"": [""1""]}"
-"70201285-6e1a-4f42-836d-0d9bef6fe1e9","{""sector"": [""11""], ""gender_1"": ""1"", ""religion"": ""1"", ""birthyear"": 1987, ""sexuality"": ""1"", ""disability"": ""2"", ""who_you_are"": [""7"", ""17""], ""ethnic_group"": ""1"", ""regional_area"": [""16""], ""additional_information"": [""2""], ""where_did_you_hear_about_this_platform"": [""8""]}"
-"6dc52cc3-ab6f-47af-b98c-e6b6e8c9264e","{""sector"": [""5""], ""gender_1"": ""1"", ""religion"": ""2"", ""birthyear"": 1973, ""sexuality"": ""1"", ""disability"": ""2"", ""who_you_are"": [""6""], ""ethnic_group"": ""1"", ""regional_area"": [""45""], ""where_did_you_hear_about_this_platform"": [""2""]}"
-"0014caed-3077-4f63-a332-5f29fec75746","{""sector"": [""1""], ""gender_1"": ""2"", ""birthyear"": 1982, ""who_you_are"": [""7"", ""17""], ""regional_area"": [""1""], ""where_did_you_hear_about_this_platform"": [""7""]}"
-"0016456d-8096-443f-97e2-9e449362440c","{}"

--- a/back/test.csv
+++ b/back/test.csv
@@ -1,0 +1,6 @@
+"id","custom_field_values"
+"4a167c9b-00ab-4496-80ef-359bc81e2494","{""sector"": [""15""], ""gender_1"": ""1"", ""religion"": ""9"", ""birthyear"": 1973, ""sexuality"": ""1"", ""disability"": ""1"", ""who_you_are"": [""11""], ""ethnic_group"": ""1"", ""regional_area"": [""37""], ""additional_information"": [""1""]}"
+"70201285-6e1a-4f42-836d-0d9bef6fe1e9","{""sector"": [""11""], ""gender_1"": ""1"", ""religion"": ""1"", ""birthyear"": 1987, ""sexuality"": ""1"", ""disability"": ""2"", ""who_you_are"": [""7"", ""17""], ""ethnic_group"": ""1"", ""regional_area"": [""16""], ""additional_information"": [""2""], ""where_did_you_hear_about_this_platform"": [""8""]}"
+"6dc52cc3-ab6f-47af-b98c-e6b6e8c9264e","{""sector"": [""5""], ""gender_1"": ""1"", ""religion"": ""2"", ""birthyear"": 1973, ""sexuality"": ""1"", ""disability"": ""2"", ""who_you_are"": [""6""], ""ethnic_group"": ""1"", ""regional_area"": [""45""], ""where_did_you_hear_about_this_platform"": [""2""]}"
+"0014caed-3077-4f63-a332-5f29fec75746","{""sector"": [""1""], ""gender_1"": ""2"", ""birthyear"": 1982, ""who_you_are"": [""7"", ""17""], ""regional_area"": [""1""], ""where_did_you_hear_about_this_platform"": [""7""]}"
+"0016456d-8096-443f-97e2-9e449362440c","{}"


### PR DESCRIPTION
High priority, as customer is unhappy about the data loss (many smart groups are now useless)

# Changelog
## Technical
- [CL-3293] Rake task for inserting key-value pairs into user custom_field_values

[CL-3293]: https://citizenlab.atlassian.net/browse/CL-3293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ