### PR TITLE
CL-3349 Fixed ProjectFolderModerationRightsReceived campaign

### DIFF
--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/project_folder_moderation_rights_received.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/project_folder_moderation_rights_received.rb
@@ -42,7 +42,7 @@ module EmailCampaigns
     delegate :admin_project_folder_url, to: :url_service
 
     def mailer_class
-      ProjectFolderModerationRightsReceivedMailer
+      ProjectFolders::EmailCampaigns::ProjectFolderModerationRightsReceivedMailer
     end
 
     def activity_triggers

--- a/front/app/translations/en.json
+++ b/front/app/translations/en.json
@@ -28,6 +28,7 @@
   "app.components.AuthProviders.signUpWithPhoneOrEmail": "Sign up with Phone or Email",
   "app.components.Author.a11y_postedBy": "Posted by:",
   "app.components.AvatarBubbles.numberOfUsers": "{numberOfUsers} participants",
+  "app.components.BillingWarning.billingWarning": "Once additional seats are added, your billing will be increased. Reach out to your GovSuccess Manager to learn more about it.",
   "app.components.CityLogoSection.iframeTitle": "More information about {orgName}",
   "app.components.Comments.cancel": "Cancel",
   "app.components.Comments.commentingDisabledInCurrentPhase": "Commenting is not possible in the current phase.",


### PR DESCRIPTION
Came across this while generating the admin campaigns and this one resulted in an error.

# Changelog
## Fixed
- The automated email that notifies users that they've become a folder manager works again
