### PR TITLE
Task/fix condition to show billing warning

### DIFF
--- a/front/app/components/SeatInfo/BillingWarning.tsx
+++ b/front/app/components/SeatInfo/BillingWarning.tsx
@@ -2,10 +2,22 @@ import React from 'react';
 import Warning from 'components/UI/Warning';
 import { useIntl } from 'utils/cl-intl';
 import messages from './messages';
+import useFeatureFlag from 'hooks/useFeatureFlag';
+import { Box, BoxMarginProps } from '@citizenlab/cl2-component-library';
 
-const BillingWarning = () => {
+const BillingWarning = (boxMarginProps: BoxMarginProps) => {
   const { formatMessage } = useIntl();
-  return <Warning>{formatMessage(messages.billingWarning)}</Warning>;
+  const hasSeatBasedBillingEnabled = useFeatureFlag({
+    name: 'seat_based_billing',
+  });
+
+  if (!hasSeatBasedBillingEnabled) return null;
+
+  return (
+    <Box {...boxMarginProps}>
+      <Warning>{formatMessage(messages.billingWarning)}</Warning>
+    </Box>
+  );
 };
 
 export default BillingWarning;

--- a/front/app/components/admin/AddModeratorsModal/index.tsx
+++ b/front/app/components/admin/AddModeratorsModal/index.tsx
@@ -94,9 +94,7 @@ const AddModeratorsModal = ({
             <SeatInfo seatType="moderator" />
           </Box>
 
-          <Box mb="24px">
-            <BillingWarning />
-          </Box>
+          <BillingWarning mb="24px" />
 
           <Box display="flex">
             <Button

--- a/front/app/components/admin/InviteUsersWithSeatsModal/index.tsx
+++ b/front/app/components/admin/InviteUsersWithSeatsModal/index.tsx
@@ -132,9 +132,7 @@ const InviteUsersWithSeatsModal = ({
             <SeatInfo seatType={seatType} />
           </Box>
 
-          <Box mb="24px">
-            <BillingWarning />
-          </Box>
+          <BillingWarning mb="24px" />
 
           <Checkbox
             mb="24px"

--- a/front/app/containers/Admin/users/ChangeSeatModal.tsx
+++ b/front/app/containers/Admin/users/ChangeSeatModal.tsx
@@ -160,7 +160,7 @@ const ChangeSeatModal = ({
             </Box>
           )}
 
-          <BillingWarning mb="24px" />
+          {!isChangingToNormalUser && <BillingWarning mb="24px" />}
 
           <Box display="flex">
             <Button

--- a/front/app/containers/Admin/users/ChangeSeatModal.tsx
+++ b/front/app/containers/Admin/users/ChangeSeatModal.tsx
@@ -160,9 +160,7 @@ const ChangeSeatModal = ({
             </Box>
           )}
 
-          <Box mb="24px">
-            <BillingWarning />
-          </Box>
+          <BillingWarning mb="24px" />
 
           <Box display="flex">
             <Button


### PR DESCRIPTION
# Changelog

## Fixed
- Feature flag showing Billing warning when changing admin to normal user and vice-versa
- Only show Billing warning when new seat is being acquired
