### PR TITLE
CL-3180 Add email only permission to e2e

### DIFF
--- a/back/config/tenant_templates/e2etests_template.yml
+++ b/back/config/tenant_templates/e2etests_template.yml
@@ -8026,11 +8026,11 @@ models:
       permission_scope_ref: *charliesIdeation
     - &1112
       action: voting_idea
-      permitted_by: everyone_confirmed_email
+      permitted_by: groups
       permission_scope_ref: *charliesIdeation
     - &1113
       action: commenting_idea
-      permitted_by: groups
+      permitted_by: everyone_confirmed_email
       permission_scope_ref: *charliesIdeation
     - &1114
       action: budgeting

--- a/back/config/tenant_templates/e2etests_template.yml
+++ b/back/config/tenant_templates/e2etests_template.yml
@@ -8026,7 +8026,7 @@ models:
       permission_scope_ref: *charliesIdeation
     - &1112
       action: voting_idea
-      permitted_by: groups
+      permitted_by: everyone_confirmed_email
       permission_scope_ref: *charliesIdeation
     - &1113
       action: commenting_idea


### PR DESCRIPTION
The e2e tests succeeded after manual run. The light user option was set on the "commenting_idea" permission of the "Charlie Crew Ideation" project

![Screenshot 2023-04-19 at 11 22 56](https://user-images.githubusercontent.com/31925816/233030812-fa6b3a2b-9794-4c15-baca-36e10244eed0.png)
