### PR TITLE
CL-3329 - Stop custom fields being enabled globally by default

### DIFF
--- a/front/app/modules/commercial/granular_permissions/admin/components/UserFieldSelection/screens/AddFieldScreen.tsx
+++ b/front/app/modules/commercial/granular_permissions/admin/components/UserFieldSelection/screens/AddFieldScreen.tsx
@@ -88,6 +88,7 @@ export const AddFieldScreen = ({
         try {
           const newField = await addCustomFieldForUsers({
             ...formValues,
+            enabled: false,
           });
           if (
             (newField.data.id && formValues?.input_type === 'multi_select') ||


### PR DESCRIPTION
Tiny change, but as I've not done much react lately thought I should get it reviewed
