### PR TITLE
CL-3395 - Issue with confirmation code reset

### DIFF
--- a/back/app/services/side_fx_user_service.rb
+++ b/back/app/services/side_fx_user_service.rb
@@ -14,7 +14,7 @@ class SideFxUserService
       LogActivityJob.set(wait: 5.seconds).perform_later(user, 'admin_rights_given', current_user, user.created_at.to_i)
     end
     user.create_email_campaigns_unsubscription_token
-    SendConfirmationCode.call(user: user) if user.confirmation_required?
+    SendConfirmationCode.call(user: user) if user.should_send_confirmation_email?
   end
 
   def before_update(user, current_user); end
@@ -28,7 +28,7 @@ class SideFxUserService
     after_roles_changed current_user, user if user.roles_previously_changed?
 
     UpdateMemberCountJob.perform_later
-    SendConfirmationCode.call(user: user) if user.confirmation_required? && user.email_confirmation_code_sent_at.nil?
+    SendConfirmationCode.call(user: user) if user.should_send_confirmation_email?
   end
 
   def after_destroy(frozen_user, current_user)

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -289,16 +289,12 @@ resource 'Users' do
         describe 'create a user with no password' do
           example_request 'User successfully created and requires confirmation' do
             assert_status 201
-
-            json_response = json_parse(response_body)
-            expect(json_response.dig(:data, :attributes, :confirmation_required)).to be(true)
+            expect(response_data.dig(:attributes, :confirmation_required)).to be(true)
           end
 
           example_request 'Registration is not completed by default' do
             assert_status 201
-
-            json_response = json_parse(response_body)
-            expect(json_response.dig(:data, :attributes, :registration_completed_at)).to be_nil
+            expect(response_data.dig(:attributes, :registration_completed_at)).to be_nil
           end
 
           example_request 'Sends a confirmation email' do
@@ -310,50 +306,50 @@ resource 'Users' do
 
         describe 'Reusing an existing user with no password' do
           context 'when there is an existing user that has no password' do
-            before do
-              light_user = create(:user_no_password, email: email)
-              light_user.confirm!
-            end
+            example 'existing confirmed user is successfully returned, confirmation requirement is reset and email sent' do
+              existing_user = create(:user_no_password, email: email)
+              existing_user.confirm!
 
-            example_request 'existing user is successfully returned and confirmation requirement is reset and email resent' do
+              do_request
               assert_status 200
-
-              json_response = json_parse(response_body)
-              expect(json_response.dig(:data, :attributes, :confirmation_required)).to be(true)
-
-              last_email = ActionMailer::Base.deliveries.last
-              user       = User.order(:created_at).last
-              expect(last_email.body.encoded).to include user.reload.email_confirmation_code
+              expect(response_data.dig(:attributes, :confirmation_required)).to be(true)
+              expect(existing_user.email_confirmation_code_reset_count).to eq(0)
+              expect(ActionMailer::Base.deliveries.last.body.encoded).to include existing_user.reload.email_confirmation_code
             end
 
-            context 'when the request tries to pass additional changed attributes' do
+            example 'existing unconfirmed user is successfully returned, email sent, but resend stats are incremented', document: false do
+              existing_user = create(:user_no_password, email: email)
+
+              do_request
+              assert_status 200
+              expect(response_data.dig(:attributes, :confirmation_required)).to be(true)
+              expect(existing_user.reload.email_confirmation_code_reset_count).to eq(1)
+              expect(ActionMailer::Base.deliveries.last.body.encoded).to include existing_user.reload.email_confirmation_code
+            end
+
+            context 'when the request tries to pass additional changed attributes', document: false do
               let(:first_name) { Faker::Name.first_name }
 
-              example_request 'email taken error is returned and confirmation requirement is not reset' do
+              example 'email taken error is returned and confirmation requirement is not reset' do
+                existing_user = create(:user_no_password, email: email)
+                existing_user.confirm!
+
+                do_request
                 assert_status 422
-
-                json_response = json_parse(response_body)
-                expect(json_response.dig(:errors, :email, 0, :error)).to eq('taken')
-
-                user = User.order(:created_at).last
-                expect(user.confirmation_required?).to be(false)
+                expect(json_response_body.dig(:errors, :email, 0, :error)).to eq('taken')
+                expect(existing_user.confirmation_required?).to be(false)
               end
             end
           end
 
           context 'when there is an existing user WITH a password' do
-            before do
-              create(:user, email: email, password: 'gravy123')
-            end
+            example 'email taken error is returned and confirmation requirement is not reset' do
+              existing_user = create(:user, email: email, password: 'gravy123')
 
-            example_request 'email taken error is returned and confirmation requirement is not reset' do
+              do_request
               assert_status 422
-
-              json_response = json_parse(response_body)
-              expect(json_response.dig(:errors, :email, 0, :error)).to eq('taken')
-
-              user = User.order(:created_at).last
-              expect(user.confirmation_required?).to be(false)
+              expect(json_response_body.dig(:errors, :email, 0, :error)).to eq('taken')
+              expect(existing_user.confirmation_required?).to be(false)
             end
           end
         end

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -1015,17 +1015,17 @@ RSpec.describe User, type: :model do
       end
     end
 
-    describe '#reset_confirmation_required' do
-      it 'resets the confirmation required field' do
+    describe '#set_confirmation_required' do
+      it 'sets the confirmation required field' do
         user.save!
-        user.reset_confirmation_required
+        user.set_confirmation_required
         expect(user.confirmation_required?).to be true
         expect(user.email_confirmed_at).to be_nil
       end
 
       it 'does not perform a commit to the db' do
         user.save!
-        user.reset_confirmation_required
+        user.set_confirmation_required
         expect(user.saved_change_to_confirmation_required?).to be false
         expect(user.saved_change_to_email_confirmed_at?).to be false
       end

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -1045,7 +1045,7 @@ RSpec.describe User, type: :model do
         user.reset_confirmation_and_counts
 
         expect(user.confirmation_required?).to be true
-        expect(user.email_confirmed_at).to be_nil
+        expect(user.email_confirmation_code_sent_at).to be_nil
         expect(user.email_confirmation_code).to be_nil
         expect(user.email_confirmation_retry_count).to eq 0
         expect(user.email_confirmation_code_reset_count).to eq 0


### PR DESCRIPTION
For existing passwordless users, confirmation code was being reset to null, but not then setting the code and sending an email. 
