### PR TITLE
CL-3398 Custom fields validation

### DIFF
--- a/back/app/controllers/web_api/v1/invites_controller.rb
+++ b/back/app/controllers/web_api/v1/invites_controller.rb
@@ -136,7 +136,7 @@ class WebApi::V1::InvitesController < ApplicationController
         invitee.assign_attributes accept_params
         SideFxInviteService.new.before_accept @invite
         invitee.invite_status = 'accepted'
-        unless invitee.save
+        unless invitee.save(context: :form_submission)
           raise ClErrors::TransactionError.new(error_key: :unprocessable_invitee)
         end
         unless @invite.save

--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -160,7 +160,7 @@ class WebApi::V1::UsersController < ::ApplicationController
     remove_image_if_requested!(@user, user_params, :avatar)
 
     authorize @user
-    if @user.save
+    if @user.save(context: :form_submission)
       SideFxUserService.new.after_update(@user, current_user)
       render json: WebApi::V1::UserSerializer.new(
         @user,

--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -160,7 +160,8 @@ class WebApi::V1::UsersController < ::ApplicationController
     remove_image_if_requested!(@user, user_params, :avatar)
 
     authorize @user
-    if @user.save(context: :form_submission)
+    save_params = user_params.key?(:custom_field_values) ? { context: :form_submission } : {}
+    if @user.save save_params
       SideFxUserService.new.after_update(@user, current_user)
       render json: WebApi::V1::UserSerializer.new(
         @user,

--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -132,7 +132,7 @@ class WebApi::V1::UsersController < ::ApplicationController
 
     SideFxUserService.new.before_create(@user, current_user)
 
-    if @user.save
+    if @user.save(context: :form_submission)
       SideFxUserService.new.after_create(@user, current_user)
       render json: WebApi::V1::UserSerializer.new(
         @user,

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -204,7 +204,7 @@ class User < ApplicationRecord
     end
   end
 
-  validate :validate_can_update_email, on: :update
+  validate :validate_can_update_email
 
   validate :validate_email_domains_blacklist
 
@@ -528,7 +528,7 @@ class User < ApplicationRecord
   private
 
   def validate_can_update_email
-    return unless new_email_changed? || email_changed?
+    return unless persisted? && (new_email_changed? || email_changed?)
 
     if no_password? && confirmation_required?
       # Avoid security hole where passwordless user can change when they are authenticated without confirmation

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -173,7 +173,7 @@ class User < ApplicationRecord
   validates :custom_field_values, json: {
     schema: -> { CustomFieldService.new.fields_to_json_schema_ignore_required(CustomField.with_resource_type('User')) },
     message: ->(errors) { errors }
-  }, if: %i[custom_field_values_changed? active?]
+  }, on: :form_submission
 
   validates :password, length: { maximum: 72 }, allow_nil: true
   # Custom validation is required to deal with the

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -775,10 +775,14 @@ RSpec.describe User, type: :model do
     #   expect { u.save }.to(change { u.errors[:custom_field_values] })
     # end
 
-    it "doesn't validate when custom_field_values hasn't changed" do
+    it "doesn't validate on creation without form submission" do
       u = build(:user, custom_field_values: { somekey: 'somevalue' })
-      u.save(validate: false)
       expect { u.save }.not_to(change { u.errors[:custom_field_values] })
+    end
+
+    it 'validates on form submission' do
+      u = build(:user, custom_field_values: { somekey: 'somevalue' })
+      expect { u.save(context: :form_submission) }.to(change { u.errors[:custom_field_values] })
     end
   end
 


### PR DESCRIPTION
The main issue with the validation of the custom field values is that tenant creation could regularly fail, as we sometimes allow invalid custom field values. Custom field values should only be validated when the user makes changes to their profile, not when the e.g. the custom fields have been changed.

Using contexts seemed to be the better tradeoff between effort and quality, because the current gem we use for schema validation (activerecord_json_validator) only works on the model level, while we actually want the validation to happen on the application level.

I feel that, in the long run, we might want to split up e.g. the users#update endpoints to separate locale or email changes from custom field value changes.