### PR TITLE
Codeless confirmation mails

### DIFF
--- a/back/app/interactors/deliver_confirmation_code.rb
+++ b/back/app/interactors/deliver_confirmation_code.rb
@@ -8,11 +8,7 @@ class DeliverConfirmationCode < ApplicationInteractor
       fail_with_error! :registration_method, :invalid, message: 'Confirmation is currently working for emails only.'
     end
 
-    if Rails.env.test?
-      ConfirmationsMailer.with(user: user).send_confirmation_code.deliver_now
-    else
-      ConfirmationsMailer.with(user: user).send_confirmation_code.deliver_later(priority: 1)
-    end
+    ConfirmationsMailer.with(user: user).send_confirmation_code.deliver_later(priority: 1)
 
     user.update!(email_confirmation_code_sent_at: Time.zone.now)
   end

--- a/back/app/interactors/reset_user_confirmation_code.rb
+++ b/back/app/interactors/reset_user_confirmation_code.rb
@@ -6,6 +6,7 @@ class ResetUserConfirmationCode < ApplicationInteractor
   def call
     validate_code
     validate_confirmation_reset_count
+    user.save!
   end
 
   def validate_code

--- a/back/spec/acceptance/resend_codes_spec.rb
+++ b/back/spec/acceptance/resend_codes_spec.rb
@@ -29,24 +29,17 @@ resource 'Code Resends' do
       end
 
       context 'when passing a valid new email' do
+        let(:success) { double }
+
         before do
+          allow(SendConfirmationCode).to receive(:call).and_return(success)
+          allow(success).to receive(:success?).and_return(true)
           do_request(new_email: 'test@test.com')
         end
 
         example 'returns an ok status when passing a valid email' do
           assert_status 200
-        end
-
-        example 'delivers an email to the user' do
-          do_request
-          last_email = ActionMailer::Base.deliveries.last
-          expect(last_email.to).to eq ['test@test.com']
-        end
-
-        example 'delivers an email with the confirmation code' do
-          do_request
-          last_email = ActionMailer::Base.deliveries.last
-          expect(last_email.body.encoded).to include user.reload.email_confirmation_code
+          expect(SendConfirmationCode).to have_received(:call).with(user: user, new_email: 'test@test.com').once
         end
       end
 
@@ -67,21 +60,15 @@ resource 'Code Resends' do
       end
 
       context 'for a normal request without params' do
+        let(:success) { double }
+
         example 'returns an ok status when performing the request without params' do
+          allow(SendConfirmationCode).to receive(:call).and_return(success)
+          allow(success).to receive(:success?).and_return(true)
+
           do_request
           assert_status 200
-        end
-
-        example 'delivers an email to the user' do
-          do_request
-          last_email = ActionMailer::Base.deliveries.last
-          expect(last_email.to).to eq [user.email]
-        end
-
-        example 'delivers an email with the confirmation code' do
-          do_request
-          last_email = ActionMailer::Base.deliveries.last
-          expect(last_email.body.encoded).to include user.reload.email_confirmation_code
+          expect(SendConfirmationCode).to have_received(:call).with(user: user, new_email: nil).once
         end
       end
     end

--- a/back/spec/interactors/deliver_confirmation_code_spec.rb
+++ b/back/spec/interactors/deliver_confirmation_code_spec.rb
@@ -27,28 +27,8 @@ RSpec.describe DeliverConfirmationCode do
       context[:user] = create(:user_with_confirmation, email: 'some_email@email.com')
     end
 
-    it 'enqueues email delivery job' do
-      result
-      last_email = ActionMailer::Base.deliveries.last
-      expect(last_email.to).to include context[:user].reload.email
-    end
-
-    it 'enqueues email with the confirmation' do
-      result
-      last_email = ActionMailer::Base.deliveries.last
-      expect(last_email.body.encoded).to include context[:user].reload.email_confirmation_code
-    end
-  end
-
-  context 'when the user has changed their email' do
-    before do
-      context[:user] = create(:user_with_confirmation, email: 'some_email@email.com', new_email: 'new@email.com')
-    end
-
-    it 'enqueues email delivery job to the changed email address' do
-      result
-      last_email = ActionMailer::Base.deliveries.last
-      expect(last_email.to).to include context[:user].reload.new_email
+    it 'enqueues the confirmation email' do
+      expect { result }.to have_enqueued_mail(ConfirmationsMailer, :send_confirmation_code).with(params: { user: context[:user] }, args: [])
     end
   end
 end

--- a/back/spec/interactors/send_confirmation_code_spec.rb
+++ b/back/spec/interactors/send_confirmation_code_spec.rb
@@ -31,16 +31,8 @@ RSpec.describe SendConfirmationCode do
       expect { result }.to change(context[:user], :email_confirmation_code_sent_at)
     end
 
-    it 'enqueues email delivery job' do
-      result
-      last_email = ActionMailer::Base.deliveries.last
-      expect(last_email.to).to eq [context[:user].email]
-    end
-
-    it 'enqueues email with the confirmation' do
-      result
-      last_email = ActionMailer::Base.deliveries.last
-      expect(last_email.body.encoded).to include context[:user].reload.email_confirmation_code
+    it 'enqueues the confirmation email' do
+      expect { result }.to have_enqueued_mail(ConfirmationsMailer, :send_confirmation_code).with(params: { user: context[:user] }, args: [])
     end
   end
 end

--- a/back/spec/mailers/confirmations_mailer_spec.rb
+++ b/back/spec/mailers/confirmations_mailer_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe ConfirmationsMailer do
   describe 'send_confirmation_code' do
-    let!(:user) { create(:user_with_confirmation) }
+    let!(:user) { create :user_with_confirmation, email: 'some_email@email.com' }
     let(:message) { described_class.with(user: user).send_confirmation_code.deliver_now }
 
     before do
@@ -15,11 +15,16 @@ RSpec.describe ConfirmationsMailer do
       expect(message.subject).to start_with('Confirm your email address')
     end
 
-    it 'renders the receiver message' do
-      expect(message.to).to eq([user.email])
+    it 'renders the receiver email address' do
+      expect(message.to).to eq(['some_email@email.com'])
     end
 
-    it 'renders the sender message' do
+    it "renders the receiver's new email address when present" do
+      user.update!(new_email: 'new@email.com')
+      expect(message.to).to eq(['new@email.com'])
+    end
+
+    it 'renders the sender address' do
       expect(message.from).to all(end_with('@citizenlab.co'))
     end
 


### PR DESCRIPTION
This PR makes two changes to avoid non-deterministic issues with the email confirmation:
- `user.save!` is called to ensure that the confirmation code is persisted before enqueueing the mail job.
- Test code does not belong in application code and has been removed. This ensures that the behaviour of the confirmation email is the same throughout all environments. It is not necessary to keep testing the reset and email behaviour in e.g. acceptance tests. If we know that the acceptance tests etc. call the `SendConfirmationCode` with the right parameters and know that `SendConfirmationCode` behaves as intended (confirmation mailer specs and reset code specs) for different parameters, then we can infer that those acceptance tests do the reset and email correctly.