### PR TITLE
CL-3411 Disable inconsistent data checker for the UK cluster 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1183,13 +1183,15 @@ workflows:
             - slack-dev-notifications-inconsistent-data
           ssh_host: $CITIZENLAB_CLUSTER_IP_ADDRESS_USW
           env_file: ".env-web"
-      - check-for-inconsistent-data:
-          <<: *slack-fail-post-step-inconsistent-data
-          name: "UK"
-          context:
-            - slack-dev-notifications-inconsistent-data
-          ssh_host: $CITIZENLAB_CLUSTER_IP_ADDRESS_UK
-          env_file: ".env-web"
+      # Disabling the check for the UK cluster for now, as it is likely the root cause of CL-3026.
+      # See: https://citizenlab.atlassian.net/browse/CL-3026
+      # - check-for-inconsistent-data:
+      #     <<: *slack-fail-post-step-inconsistent-data
+      #     name: "UK"
+      #     context:
+      #       - slack-dev-notifications-inconsistent-data
+      #     ssh_host: $CITIZENLAB_CLUSTER_IP_ADDRESS_UK
+      #     env_file: ".env-web"
       - slack-invalid-data-success:
           name: ":tada: SUCCESS: No invalid data was detected!" # Mentions are not supported for basic_success_1
           context:


### PR DESCRIPTION
# Changelog
- We are temporarily disabling the check, as it is likely what's causing aws-uk-1 to become unresponsive on a regular basis.
