### PR TITLE
Don't set additional seats value in front-end

### DIFF
--- a/front/app/components/admin/SeatBasedBilling/SeatInfo/BillingInfo.tsx
+++ b/front/app/components/admin/SeatBasedBilling/SeatInfo/BillingInfo.tsx
@@ -58,7 +58,7 @@ const BillingInfo = ({ seatType }: SeatInfoProps) => {
       appConfiguration?.data.attributes.settings.core
         .additional_moderators_number,
   };
-  const additionalSeats = additionalSeatNumbers[seatType] || 0;
+  const additionalSeats = additionalSeatNumbers[seatType];
 
   // Maximum seat number being null means that there are unlimited seats so we don't show the seat info
   if (isNil(maximumSeatNumber) || !seats) {
@@ -79,11 +79,14 @@ const BillingInfo = ({ seatType }: SeatInfoProps) => {
     moderator: messages.managerSeatsTooltip,
   };
   const seatTypeTooltipMessage = seatTypeTooltipMessages[seatType];
-  const totalSeats = additionalSeats + maximumSeatNumber;
+  const totalSeats =
+    typeof additionalSeats === 'number'
+      ? additionalSeats + maximumSeatNumber
+      : maximumSeatNumber;
   const remainingSeats = totalSeats - usedSeats;
 
   let totalSeatsBreakdownMessage = formatMessage(messages.seatsWithinPlanText);
-  if (additionalSeats > 0) {
+  if (typeof additionalSeats === 'number' && additionalSeats > 0) {
     totalSeatsBreakdownMessage = formatMessage(messages.seatsExceededPlanText, {
       noOfSeatsInPlan: maximumSeatNumber,
       noOfAdditionalSeats: additionalSeats,

--- a/front/app/components/admin/SeatBasedBilling/SeatInfo/BillingInfo.tsx
+++ b/front/app/components/admin/SeatBasedBilling/SeatInfo/BillingInfo.tsx
@@ -81,7 +81,7 @@ const BillingInfo = ({ seatType }: SeatInfoProps) => {
   const seatTypeTooltipMessage = seatTypeTooltipMessages[seatType];
   const totalSeats =
     typeof additionalSeats === 'number'
-      ? additionalSeats + maximumSeatNumber
+      ? maximumSeatNumber + additionalSeats
       : maximumSeatNumber;
   const remainingSeats = totalSeats - usedSeats;
 


### PR DESCRIPTION
How about this instead? Something feels off setting this value to a number in the front-end, when the source of truth sits in the database.