### PR TITLE
CL-3433 native survey e2e

### DIFF
--- a/back/app/interactors/confirm_user.rb
+++ b/back/app/interactors/confirm_user.rb
@@ -5,9 +5,9 @@ class ConfirmUser < ApplicationInteractor
 
   def call
     validate_user
-    validate_code_expiration
     validate_retry_count
     validate_code_value
+    validate_code_expiration
     confirm_user
   end
 

--- a/back/config/tenant_templates/e2etests_template.yml
+++ b/back/config/tenant_templates/e2etests_template.yml
@@ -1139,7 +1139,7 @@ models:
       nl-BE: Test idea custom fields. Laten we het park op de grens van de stad vernieuwen en er een aangename
         plek van maken, voor jong en oud.
     presentation_mode: card
-    participation_method: ideation
+    participation_method: native_survey
     process_type: continuous
     admin_publication_attributes:
       publication_status: published

--- a/back/spec/interactors/confirm_user_spec.rb
+++ b/back/spec/interactors/confirm_user_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe ConfirmUser do
     end
 
     it 'returns a code invalid error' do
-      expect(result.errors.details).to eq(code: [{ error: :expired }])
+      expect(result.errors.details).to eq(code: [{ error: :invalid }])
     end
   end
 end


### PR DESCRIPTION
- The data in the e2etest template was fixed. I checked other epic deployments and the project doesn't work there either (even worse, it crashes with a 500 error).
- When asking for a confirmation code, but no confirmation code was sent, we had a 500 error. This is now replaced by a "invalid confirmation code" error.
![Screenshot 2023-04-25 at 18 31 23](https://user-images.githubusercontent.com/31925816/234344119-65624f47-0706-4769-936d-3519eb27ccd7.png)

![Screenshot 2023-04-25 at 17 44 19](https://user-images.githubusercontent.com/31925816/234344139-2c9e598d-ccbd-49a6-b298-abd9d04c1e33.png)


# Changelog
### Fixed
- [CL-3433] Invalid project in e2etest template.

[CL-3433]: https://citizenlab.atlassian.net/browse/CL-3433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ