### PR TITLE
CL-3400 - Disable global registration fields toggle for moderators

### DIFF
--- a/front/app/modules/commercial/granular_permissions/admin/components/UserFieldSelection/UserFieldSelection.tsx
+++ b/front/app/modules/commercial/granular_permissions/admin/components/UserFieldSelection/UserFieldSelection.tsx
@@ -168,7 +168,9 @@ const UserFieldSelection = ({
                     ml="4px"
                     icon="info-solid"
                     content={formatMessage(
-                      messages.useExistingRegistrationQuestionsDescription
+                      userIsAdmin
+                        ? messages.useExistingRegistrationQuestionsDescription
+                        : messages.onlyAdmins
                     )}
                   />
                 </Box>

--- a/front/app/modules/commercial/granular_permissions/admin/components/UserFieldSelection/UserFieldSelection.tsx
+++ b/front/app/modules/commercial/granular_permissions/admin/components/UserFieldSelection/UserFieldSelection.tsx
@@ -32,10 +32,12 @@ import { IPermissionData } from 'services/actionPermissions';
 import { IUserCustomFieldData } from 'services/userCustomFields';
 import { IPermissionsCustomFieldData } from 'api/permissions_custom_fields/types';
 import { HandlePermissionChangeProps } from '../../containers/Granular/utils';
+import { isAdmin } from 'services/permissions/roles';
 
 // hooks
 import useUserCustomFields from 'hooks/useUserCustomFields';
 import useLocale from 'hooks/useLocale';
+import useAuthUser from 'hooks/useAuthUser';
 
 type UserFieldSelectionProps = {
   permission: IPermissionData;
@@ -57,6 +59,7 @@ const UserFieldSelection = ({
   initiativeContext,
   onChange,
 }: UserFieldSelectionProps) => {
+  const authUser = useAuthUser();
   const { formatMessage } = useIntl();
   const globalRegistrationFields = useUserCustomFields();
   const initialFields = usePermissionsCustomFields({
@@ -118,9 +121,11 @@ const UserFieldSelection = ({
 
   const groupIds = permission.relationships.groups.data.map((p) => p.id);
 
-  if (isNilOrError(locale)) {
+  if (isNilOrError(locale) || isNilOrError(authUser)) {
     return null;
   }
+
+  const userIsAdmin = authUser && isAdmin({ data: authUser });
 
   const showQuestionToggle =
     permission.attributes.permitted_by !== 'everyone_confirmed_email';
@@ -142,6 +147,7 @@ const UserFieldSelection = ({
           <Box mb="10px">
             <Toggle
               checked={permission.attributes.global_custom_fields}
+              disabled={!userIsAdmin}
               onChange={() => {
                 onChange({
                   permission,

--- a/front/app/modules/commercial/granular_permissions/admin/containers/Granular/ActionsForm.tsx
+++ b/front/app/modules/commercial/granular_permissions/admin/containers/Granular/ActionsForm.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import React, { memo, useState } from 'react';
 import styled from 'styled-components';
 import { isEmpty } from 'lodash-es';
 
@@ -74,6 +74,14 @@ const ActionsForm = memo(
       name: 'permissions_custom_fields',
     });
     const project = useProject({ projectId });
+    const [
+      previousUsersGlobalCustomFields,
+      setPreviousUsersGlobalCustomFields,
+    ] = useState(true);
+    const [
+      previousGroupsGlobalCustomFields,
+      setPreviousGroupsGlobalCustomFields,
+    ] = useState(true);
 
     const handlePermissionChange =
       (permission: IPermissionData) =>
@@ -81,7 +89,27 @@ const ActionsForm = memo(
         permittedBy: IPermissionData['attributes']['permitted_by'],
         groupIds: string[]
       ) => {
-        onChange({ permission, permittedBy, groupIds });
+        // Remember what the last values of global custom fields toggles were for 'users' & 'groups'
+        const previousPermittedBy = permission.attributes.permitted_by;
+        if (previousPermittedBy === 'users') {
+          setPreviousUsersGlobalCustomFields(
+            permission.attributes.global_custom_fields
+          );
+        } else if (previousPermittedBy === 'groups') {
+          setPreviousGroupsGlobalCustomFields(
+            permission.attributes.global_custom_fields
+          );
+        }
+
+        // Set global custom fields toggle back to the old value when switching back to 'users' & 'groups'
+        let globalCustomFields = false;
+        if (permittedBy === 'users') {
+          globalCustomFields = previousUsersGlobalCustomFields;
+        } else if (permittedBy === 'groups') {
+          globalCustomFields = previousGroupsGlobalCustomFields;
+        }
+
+        onChange({ permission, permittedBy, groupIds, globalCustomFields });
       };
 
     if (isEmpty(permissions)) {

--- a/front/app/modules/commercial/granular_permissions/admin/containers/Granular/messages.ts
+++ b/front/app/modules/commercial/granular_permissions/admin/containers/Granular/messages.ts
@@ -73,7 +73,7 @@ export default defineMessages({
     defaultMessage: 'Phase ',
   },
   userFieldsSelectionDescription: {
-    id: 'app.containers.AdminPage.groups.permissions.userFieldsSelectionDescription',
+    id: 'app.containers.AdminPage.groups.permissions.userFieldsSelectionDescription2',
     defaultMessage:
       'Responses to demographic questions will get stored in user profiles. Answers to these questions will be accessible to both admins and moderators to easy participation analysis. Questions will only be asked to users who have not answered them before.',
   },

--- a/front/app/modules/commercial/granular_permissions/admin/containers/Granular/messages.ts
+++ b/front/app/modules/commercial/granular_permissions/admin/containers/Granular/messages.ts
@@ -186,4 +186,8 @@ export default defineMessages({
     id: 'app.containers.AdminPage.groups.permissions.option1',
     defaultMessage: 'Option 1',
   },
+  onlyAdmins: {
+    id: 'app.containers.AdminPage.groups.permissions.onlyAdmins',
+    defaultMessage: 'Only admins can change this setting.',
+  },
 });

--- a/front/app/translations/admin/en.json
+++ b/front/app/translations/admin/en.json
@@ -1650,7 +1650,7 @@
   "app.containers.AdminPage.groups.permissions.selectValueError": "Please select an answer type",
   "app.containers.AdminPage.groups.permissions.useExistingRegistrationQuestions": "Ask platform level registration questions",
   "app.containers.AdminPage.groups.permissions.useExistingRegistrationQuestionsDescription": "Use this setting if collecting name, last name, and answers to platform level demographic questions is important to you. It may increase the barrier for participation.",
-  "app.containers.AdminPage.groups.permissions.userFieldsSelectionDescription": "Responses to demographic questions will get stored in user profiles. Answers to these questions will be accessible to both admins and moderators to easy participation analysis. Questions will only be asked to users who have not answered them before.",
+  "app.containers.AdminPage.groups.permissions.userFieldsSelectionDescription2": "Responses to demographic questions will get stored in user profiles. Answers to these questions will be accessible to both admins and moderators to easy participation analysis. Questions will only be asked to users who have not answered them before.",
   "app.containers.AdminPage.groups.permissions.userQuestionTitle": "Ask questions to participants",
   "app.containers.AdminPage.projects.all.existingProjects": "Existing projects",
   "app.containers.AdminPage.projects.all.newProjectFolder": "Create a project folder",

--- a/front/app/translations/admin/en.json
+++ b/front/app/translations/admin/en.json
@@ -1649,7 +1649,7 @@
   "app.containers.AdminPage.groups.permissions.selectValueError": "Please select an answer type",
   "app.containers.AdminPage.groups.permissions.useExistingRegistrationQuestions": "Ask platform level registration questions",
   "app.containers.AdminPage.groups.permissions.useExistingRegistrationQuestionsDescription": "Use this setting if collecting name, last name, and answers to platform level demographic questions is important to you. It may increase the barrier for participation.",
-  "app.containers.AdminPage.groups.permissions.userFieldsSelectionDescription": "You can ask the existing registration question(s) or create new ones. If a user hasn’t answered to the question(s), they will be asked to answer it before taking the action. Answers to these questions will be stored in user profiles, and will be only accessible to admins.",
+  "app.containers.AdminPage.groups.permissions.userFieldsSelectionDescription": "Responses to demographic questions will get stored in user profiles. Answers to these questions will be accessible to both admins and moderators to easy participation analysis. Questions will only be asked to users who have not answered them before.",
   "app.containers.AdminPage.groups.permissions.userQuestionTitle": "Ask questions to participants",
   "app.containers.AdminPage.projects.all.existingProjects": "Existing projects",
   "app.containers.AdminPage.projects.all.newProjectFolder": "Create a project folder",

--- a/front/app/translations/admin/en.json
+++ b/front/app/translations/admin/en.json
@@ -1625,6 +1625,7 @@
   "app.containers.AdminPage.groups.permissions.moderatorDeletionConfirmation": "Are you sure?",
   "app.containers.AdminPage.groups.permissions.moderatorsNotFound": "Project managers not found",
   "app.containers.AdminPage.groups.permissions.noActionsCanBeTakenInThisProject": "Nothing is shown, because there are no actions the user can take in this project.",
+  "app.containers.AdminPage.groups.permissions.onlyAdmins": "Only admins can change this setting.",
   "app.containers.AdminPage.groups.permissions.option1": "Option 1",
   "app.containers.AdminPage.groups.permissions.pendingInvitation": "Pending invitation",
   "app.containers.AdminPage.groups.permissions.permissionAction_budgeting_subtitle": "Who can spend the budget?",


### PR DESCRIPTION
- Disabled the toggle for non-admin users 
- Had to also add logic to remember what the previous state of that toggle was when moving to a different permitted_by given that moderators will still be able to change these settings.
