### PR TITLE
CL-3444 Ideas by basket bug

### DIFF
--- a/back/.rubocop_todo.yml
+++ b/back/.rubocop_todo.yml
@@ -70,7 +70,7 @@ Metrics/AbcSize:
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods, AllowedMethods, AllowedPatterns, IgnoredMethods, inherit_mode.
 # AllowedMethods: refine
 Metrics/BlockLength:
-  Max: 351
+  Max: 359
 
 # Offense count: 1
 # Configuration parameters: CountBlocks.

--- a/back/app/finders/ideas_finder.rb
+++ b/back/app/finders/ideas_finder.rb
@@ -56,7 +56,7 @@ class IdeasFinder < ApplicationFinder
     where(project_id: project_id)
   end
 
-  def basket_condition(basket_id)
+  def basket_id_condition(basket_id)
     records.joins(:baskets).where('baskets.id': basket_id)
   end
 

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/create_tenant.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/create_tenant.rake
@@ -33,6 +33,14 @@ namespace :cl2_back do
           enabled: true,
           allowed: true
         },
+        permission_option_email_confirmation: {
+          enabled: true,
+          allowed: true
+        },
+        permissions_custom_fields: {
+          enabled: true,
+          allowed: true
+        },
         representativeness: {
           enabled: true,
           allowed: true

--- a/back/spec/acceptance/ideas_spec.rb
+++ b/back/spec/acceptance/ideas_spec.rb
@@ -189,7 +189,7 @@ resource 'Ideas' do
           basket = create(:basket)
           [@ideas[1], @ideas[2], @ideas[5]].each { _1.baskets << basket }
 
-          do_request(basket: basket.id)
+          do_request(basket_id: basket.id)
           json_response = json_parse(response_body)
           expect(json_response[:data].size).to eq 2
           expect(json_response[:data].pluck(:id)).to match_array [@ideas[1].id, @ideas[5].id]

--- a/back/spec/acceptance/ideas_spec.rb
+++ b/back/spec/acceptance/ideas_spec.rb
@@ -66,7 +66,7 @@ resource 'Ideas' do
       parameter :topics, 'Filter by topics (OR)', required: false
       parameter :projects, 'Filter by projects (OR)', required: false
       parameter :phase, 'Filter by project phase', required: false
-      parameter :basket, 'Filter by basket', required: false
+      parameter :basket_id, 'Filter by basket', required: false
       parameter :author, 'Filter by author (user id)', required: false
       parameter :idea_status, 'Filter by status (idea status id)', required: false
       parameter :search, 'Filter by searching in title and body', required: false

--- a/back/spec/finders/ideas_finder_spec.rb
+++ b/back/spec/finders/ideas_finder_spec.rb
@@ -240,15 +240,20 @@ describe IdeasFinder do
   end
 
   describe '#basket_condition' do
-    let(:basket_id) { Basket.pick(:id) }
-    let(:expected_record_ids) { Idea.joins(:baskets).where('baskets.id': basket_id).pluck(:id) }
+    let(:idea_ids) { timeline_project.idea_ids.shuffle.take(2) }
+    let(:basket) { create :basket, idea_ids: idea_ids }
+    let(:params) { { basket_id: basket.id } }
 
-    before do
-      params[:basket] = basket_id
+    it 'filters ideas by basket' do
+      expect(result_record_ids).to match_array idea_ids
     end
 
-    it 'returns the correct records' do
-      expect(result_record_ids).to match_array expected_record_ids
+    context 'when the basket is empty' do
+      let(:idea_ids) { [] }
+
+      it 'returns no records' do
+        expect(result_record_ids).to eq []
+      end
     end
   end
 

--- a/back/spec/finders/ideas_finder_spec.rb
+++ b/back/spec/finders/ideas_finder_spec.rb
@@ -245,6 +245,7 @@ describe IdeasFinder do
     let(:params) { { basket_id: basket.id } }
 
     it 'filters ideas by basket' do
+      expect(result_record_ids).to be_present
       expect(result_record_ids).to match_array idea_ids
     end
 


### PR DESCRIPTION
- Enabled flexible registration flags for epic platforms.
- Fixed the spec for the basked filter. The original spec compared an empty collection with an empty collection.
- Fixed the parameter name. The backend spec used `basket` whereas the frontend is using `basket_id`. Changing it to `basket_id` on the backend side was the easier option for me.

# Changelog
### Fixed
- [CL-3444] Listing only ideas included in a basket instead of all ideas.


[CL-3444]: https://citizenlab.atlassian.net/browse/CL-3444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ