### PR TITLE
CL-3453 fix session tracking

### DIFF
--- a/front/app/containers/Authentication/useSteps/stepConfig/newLightFlow.ts
+++ b/front/app/containers/Authentication/useSteps/stepConfig/newLightFlow.ts
@@ -9,6 +9,10 @@ import { handleOnSSOClick } from 'services/singleSignOn';
 import streams from 'utils/streams';
 import { resetQueryCache } from 'utils/cl-react-query/resetQueryCache';
 
+// tracks
+import tracks from '../../tracks';
+import { trackEventByName } from 'utils/analytics';
+
 // events
 import { triggerSuccessAction } from 'containers/Authentication/SuccessActions';
 
@@ -38,6 +42,8 @@ export const newLightFlow = (
 
     setStatus('ok');
     setCurrentStep('closed');
+
+    trackEventByName(tracks.signUpFlowCompleted);
 
     const { successAction } = getAuthenticationData();
     if (successAction) {

--- a/front/app/modules/commercial/impact_tracking/index.ts
+++ b/front/app/modules/commercial/impact_tracking/index.ts
@@ -7,7 +7,7 @@ import { events$ } from 'utils/analytics';
 import { API_PATH } from 'containers/App/constants';
 
 const signUpInTracks = {
-  signInFlowCompleted: 'Sign in flow completed',
+  signInEmailPasswordCompleted: 'Sign in - email & password sign-in completed',
   signUpFlowCompleted: 'Sign up flow completed',
 };
 
@@ -30,7 +30,7 @@ const configuration: ModuleConfiguration = {
 
     events$.subscribe((event) => {
       if (
-        event.name === signUpInTracks.signInFlowCompleted ||
+        event.name === signUpInTracks.signInEmailPasswordCompleted ||
         event.name === signUpInTracks.signUpFlowCompleted
       ) {
         upgradeSession();


### PR DESCRIPTION
This fixes 2 issues wrt [session tracking](https://github.com/CitizenLabDotCo/citizenlab/tree/master/back/engines/commercial/impact_tracking#session-tracking), where "upgrades" to the session where not working when
- using the light user flow
- logging in

The issue was that session tracking relies on certain `track` events, which were no longer fired in all cases.

Also added some comments to the useSteps code while studying it.
