### PR TITLE
[CL-3348] Remove fetching of env vars in mail campaigns

### DIFF
--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/admin_digest.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/admin_digest.rb
@@ -42,7 +42,7 @@ module EmailCampaigns
 
     before_send :content_worth_sending?
 
-    N_TOP_IDEAS = ENV.fetch('N_ADMIN_WEEKLY_REPORT_IDEAS', 12).to_i
+    N_TOP_IDEAS = 12
 
     def self.default_schedule
       config_timezone = Time.find_zone(AppConfiguration.instance.settings('core', 'timezone'))

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/assignee_digest.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/assignee_digest.rb
@@ -38,7 +38,7 @@ module EmailCampaigns
 
     recipient_filter :user_filter_admins_moderators_only
 
-    N_TOP_IDEAS = ENV.fetch('N_ASSIGNEE_WEEKLY_REPORT_IDEAS', 12).to_i
+    N_TOP_IDEAS = 12
 
     def self.default_schedule
       IceCube::Schedule.new(Time.find_zone(AppConfiguration.instance.settings('core', 'timezone')).local(2019)) do |s|

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/moderator_digest.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/moderator_digest.rb
@@ -40,7 +40,7 @@ module EmailCampaigns
 
     before_send :content_worth_sending?
 
-    N_TOP_IDEAS = ENV.fetch('N_MODERATOR_DIGEST_IDEAS', 12).to_i
+    N_TOP_IDEAS = 12
 
     def mailer_class
       ModeratorDigestMailer

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/user_digest.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/user_digest.rb
@@ -39,9 +39,9 @@ module EmailCampaigns
 
     before_send :content_worth_sending?
 
-    N_TOP_IDEAS = ENV.fetch('N_USER_PLATFORM_DIGEST_IDEAS', 3).to_i
-    N_TOP_COMMENTS = ENV.fetch('N_TOP_COMMENTS', 2).to_i
-    N_DISCOVER_PROJECTS = ENV.fetch('N_DISCOVER_PROJECTS', 3).to_i
+    N_TOP_IDEAS = 3
+    N_TOP_COMMENTS = 2
+    N_DISCOVER_PROJECTS = 3
 
     def self.default_schedule
       day, hour = [[:thursday, 13], [:saturday, 8]].sample


### PR DESCRIPTION
We don't have any of these env vars set on production, and leaving them includes the risk of setting a constant to zero (e.g. if env var == non-integer value), which in turn can cause some campaigns to send empty mails (no content).

# Changelog
## Technical
- [CL-3348] Don't fetch env vars to set constants in mail campaigns (we never set the env vars on production)


[CL-3348]: https://citizenlab.atlassian.net/browse/CL-3348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ