### PR TITLE
CL-3458 Make names private attributes

### DIFF
--- a/back/app/services/xlsx_export/input_sheet_generator.rb
+++ b/back/app/services/xlsx_export/input_sheet_generator.rb
@@ -151,7 +151,7 @@ module XlsxExport
           author_id_report_field
         ]
       else
-        [author_name_report_field]
+        []
       end
     end
 

--- a/back/app/services/xlsx_export/input_sheet_generator.rb
+++ b/back/app/services/xlsx_export/input_sheet_generator.rb
@@ -170,7 +170,7 @@ module XlsxExport
         meta_fields << project_report_field
         meta_fields << status_report_field if participation_method.supports_status?
         if participation_method.supports_assignment?
-          meta_fields << assignee_fullname_report_field
+          meta_fields << assignee_fullname_report_field if include_private_attributes
           meta_fields << assignee_email_report_field if include_private_attributes
         end
       end

--- a/back/app/services/xlsx_service.rb
+++ b/back/app/services/xlsx_service.rb
@@ -125,7 +125,7 @@ class XlsxService
       { header: 'invite_status', f: ->(u) { u.invite_status }, skip_sanitization: true },
       *user_custom_field_columns(:itself)
     ]
-    columns.reject! { |c| %w[id email].include?(c[:header]) } unless view_private_attributes
+    columns.reject! { |c| %w[id email first_name last_name].include?(c[:header]) } unless view_private_attributes
 
     generate_xlsx 'Users', columns, users
   end
@@ -156,7 +156,7 @@ class XlsxService
       { header: 'attachments',          f: ->(i) { i.idea_files.map { |f| f.file.url }.join("\n") }, skip_sanitization: true, width: 2 }
     ]
     columns.concat user_custom_field_columns(:author)
-    columns.reject! { |c| %w[author_email assignee_email author_id].include?(c[:header]) } unless view_private_attributes
+    columns.reject! { |c| %w[author_name author_email assignee assignee_email author_id].include?(c[:header]) } unless view_private_attributes
     columns
   end
 
@@ -188,7 +188,7 @@ class XlsxService
       { header: 'attachmens',           f: ->(i) { i.initiative_files.map { |f| f.file.url }.join("\n") }, skip_sanitization: true, width: 2 }
     ]
     columns.concat user_custom_field_columns(:author)
-    columns.reject! { |c| %w[author_email assignee_email author_id].include?(c[:header]) } unless view_private_attributes
+    columns.reject! { |c| %w[author_name author_email assignee assignee_email author_id].include?(c[:header]) } unless view_private_attributes
     generate_xlsx 'Initiatives', columns, initiatives
   end
 
@@ -207,7 +207,7 @@ class XlsxService
       { header: 'project',            f: ->(c) { multiloc_service.t(c&.idea&.project&.title_multiloc) } }
     ]
     columns.concat user_custom_field_columns(:author)
-    columns.reject! { |c| %w[author_email author_id].include?(c[:header]) } unless view_private_attributes
+    columns.reject! { |c| %w[author_name author_email author_id].include?(c[:header]) } unless view_private_attributes
     generate_xlsx 'Comments', columns, comments
   end
 
@@ -225,7 +225,7 @@ class XlsxService
       { header: 'parent_comment_id',        f: ->(c) { c.parent_id }, skip_sanitization: true }
     ]
     columns.concat user_custom_field_columns(:author)
-    columns.reject! { |c| %w[author_email author_id].include?(c[:header]) } unless view_private_attributes
+    columns.reject! { |c| %w[author_name author_email author_id].include?(c[:header]) } unless view_private_attributes
     generate_xlsx 'Comments', columns, comments
   end
 

--- a/back/engines/commercial/idea_custom_fields/spec/services/xlsx_service_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/services/xlsx_service_spec.rb
@@ -162,7 +162,7 @@ describe XlsxService do
         headers = worksheet[0].cells.map(&:value)
         row = worksheet[1].cells.map(&:value)
         expect(headers).to match_array(
-          %w[id title description author_name proposed_budget published_at comments upvotes downvotes baskets url project topics status assignee latitude longitude location_description attachments]
+          %w[id title description proposed_budget published_at comments upvotes downvotes baskets url project topics status latitude longitude location_description attachments]
         )
         expect(row.size).to eq headers.size
       end

--- a/back/spec/acceptance/phases_spec.rb
+++ b/back/spec/acceptance/phases_spec.rb
@@ -1016,7 +1016,6 @@ resource 'Phases' do
                 'Location',
                 'Proposed Budget',
                 extra_idea_field.title_multiloc['en'],
-                'Author name',
                 'Submitted at',
                 'Published at',
                 'Comments',
@@ -1027,7 +1026,6 @@ resource 'Phases' do
                 'URL',
                 'Project',
                 'Status',
-                'Assignee',
                 custom_field.title_multiloc['en']
               ],
               rows: [
@@ -1042,7 +1040,6 @@ resource 'Phases' do
                   ideation_response.location_description,
                   ideation_response.proposed_budget,
                   'Answer',
-                  ideation_response.author_name,
                   an_instance_of(DateTime), # created_at
                   an_instance_of(DateTime), # published_at
                   0,
@@ -1053,7 +1050,6 @@ resource 'Phases' do
                   "http://example.org/ideas/#{ideation_response.slug}",
                   project.title_multiloc['en'],
                   ideation_response.idea_status.title_multiloc['en'],
-                  "#{assignee.first_name} #{assignee.last_name}",
                   ''
                 ]
               ]
@@ -1100,7 +1096,6 @@ resource 'Phases' do
               column_headers: [
                 'ID',
                 multiselect_field.title_multiloc['en'],
-                'Author name',
                 'Submitted at',
                 'Project'
               ],
@@ -1108,7 +1103,6 @@ resource 'Phases' do
                 [
                   survey_response.id,
                   'Cat, Dog',
-                  survey_response.author_name,
                   an_instance_of(DateTime), # created_at
                   project.title_multiloc['en']
                 ]

--- a/back/spec/services/xlsx_service_spec.rb
+++ b/back/spec/services/xlsx_service_spec.rb
@@ -81,6 +81,8 @@ describe XlsxService do
         custom_field = create(:custom_field)
         expect(worksheet[0].cells.map(&:value)).not_to include 'id'
         expect(worksheet[0].cells.map(&:value)).not_to include 'email'
+        expect(worksheet[0].cells.map(&:value)).not_to include 'first_name'
+        expect(worksheet[0].cells.map(&:value)).not_to include 'last_name'
         expect(worksheet[0].cells.map(&:value)).to include custom_field.title_multiloc['en']
       end
     end
@@ -111,6 +113,9 @@ describe XlsxService do
       it 'hides private attributes' do
         custom_field = create :custom_field
         expect(worksheet[0].cells.map(&:value)).not_to include 'author_email'
+        expect(worksheet[0].cells.map(&:value)).not_to include 'author_name'
+        expect(worksheet[0].cells.map(&:value)).not_to include 'assignee'
+        expect(worksheet[0].cells.map(&:value)).not_to include 'assignee_email'
         expect(worksheet[0].cells.map(&:value)).to include custom_field.title_multiloc['en']
       end
     end
@@ -165,6 +170,7 @@ describe XlsxService do
         custom_field = create :custom_field
         expect(worksheet[0].cells.map(&:value)).not_to include 'author_id'
         expect(worksheet[0].cells.map(&:value)).not_to include 'author_email'
+        expect(worksheet[0].cells.map(&:value)).not_to include 'author_name'
         expect(worksheet[0].cells.map(&:value)).to include custom_field.title_multiloc['en']
       end
     end
@@ -189,6 +195,7 @@ describe XlsxService do
         custom_field = create :custom_field
         expect(worksheet[0].cells.map(&:value)).not_to include 'author_id'
         expect(worksheet[0].cells.map(&:value)).not_to include 'author_email'
+        expect(worksheet[0].cells.map(&:value)).not_to include 'author_name'
         expect(worksheet[0].cells.map(&:value)).to include custom_field.title_multiloc['en']
       end
     end


### PR DESCRIPTION
# Changelog
### Changed
- [CL-3458] Consider user names as private attributes (hidden from moderators) in XLSX exports; with exception for volunteering exports.


[CL-3458]: https://citizenlab.atlassian.net/browse/CL-3458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ