### PR TITLE
[CL-3420] Re-enable locale sensitive human-readable schedule attribute

### DIFF
--- a/back/engines/free/email_campaigns/app/serializers/email_campaigns/web_api/v1/campaign_serializer.rb
+++ b/back/engines/free/email_campaigns/app/serializers/email_campaigns/web_api/v1/campaign_serializer.rb
@@ -22,16 +22,11 @@ module EmailCampaigns
     attribute :schedule_multiloc, if: proc { |object|
       schedulable? object
     } do |object|
-      # Temporary fix until CL2-3052 is solved
       AppConfiguration.instance.settings('core', 'locales').each_with_object({}) do |locale, result|
-        I18n.with_locale('en') do
-          result[locale] = object.ic_schedule.to_s
+        I18n.with_locale(locale) do
+          result[locale] = object.ic_schedule.to_ical
         end
       end
-
-      # MultilocService.new.block_to_multiloc do |locale|
-      #   object.ic_schedule.to_s
-      # end
     end
 
     attribute :sender, if: proc { |object|


### PR DESCRIPTION
# Changelog
## Technical
- [CL-3420] Return human-readable multilocs in campaigns schedule_multiloc attribute.


[CL-3420]: https://citizenlab.atlassian.net/browse/CL-3420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ