### PR TITLE
[CL-3464] Reset success modal when closed not by button

### DIFF
--- a/front/app/components/admin/SeatBasedBilling/AddModeratorsModal/index.tsx
+++ b/front/app/components/admin/SeatBasedBilling/AddModeratorsModal/index.tsx
@@ -42,14 +42,16 @@ const AddModeratorsModal = ({
     </Text>
   ) : undefined;
 
+  const resetModal = () => {
+    closeModal();
+    setShowSuccess(false);
+  };
+
   return (
-    <Modal opened={showModal} close={closeModal} header={header}>
+    <Modal opened={showModal} close={resetModal} header={header}>
       {showSuccess ? (
         <SeatSetSuccess
-          closeModal={() => {
-            setShowSuccess(false);
-            closeModal();
-          }}
+          closeModal={resetModal}
           seatType="moderator"
           hasExceededPlanSeatLimit={exceedsSeats.moderator}
         />

--- a/front/app/components/admin/SeatBasedBilling/ChangeSeatModal/index.tsx
+++ b/front/app/components/admin/SeatBasedBilling/ChangeSeatModal/index.tsx
@@ -102,14 +102,16 @@ const ChangeSeatModal = ({
     </Box>
   ) : undefined;
 
+  const resetModal = () => {
+    closeModal();
+    setShowSuccess(false);
+  };
+
   return (
-    <Modal opened={showModal} close={closeModal} header={header}>
+    <Modal opened={showModal} close={resetModal} header={header}>
       {showSuccess ? (
         <SeatSetSuccess
-          closeModal={() => {
-            closeModal();
-            setShowSuccess(false);
-          }}
+          closeModal={resetModal}
           hasExceededPlanSeatLimit={exceedsSeats.admin}
           seatType="admin"
         />

--- a/front/app/components/admin/SeatBasedBilling/InviteUsersWithSeatsModal/index.tsx
+++ b/front/app/components/admin/SeatBasedBilling/InviteUsersWithSeatsModal/index.tsx
@@ -84,14 +84,16 @@ const InviteUsersWithSeatsModal = ({
     });
   }
 
+  const resetModal = () => {
+    closeModal();
+    setShowSuccess(false);
+  };
+
   return (
-    <Modal opened={showModal} close={closeModal} header={header}>
+    <Modal opened={showModal} close={resetModal} header={header}>
       {showSuccess ? (
         <SeatSetSuccess
-          closeModal={() => {
-            closeModal();
-            setShowSuccess(false);
-          }}
+          closeModal={resetModal}
           seatType="moderator"
           hasExceededPlanSeatLimit={exceedsSeats.any}
         />


### PR DESCRIPTION
# Changelog
## Fix
- [CL-3464] Reset success modal when closed not by button

[CL-3464]: https://citizenlab.atlassian.net/browse/CL-3464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ