### PR TITLE
CL-3470 Avoid flaky specs by always returning topics by ordering

### DIFF
--- a/back/app/models/idea.rb
+++ b/back/app/models/idea.rb
@@ -73,7 +73,7 @@ class Idea < ApplicationRecord
   belongs_to :assignee, class_name: 'User', optional: true
 
   has_many :ideas_topics, dependent: :destroy
-  has_many :topics, through: :ideas_topics
+  has_many :topics, -> { order(:ordering) }, through: :ideas_topics
   has_many :ideas_phases, dependent: :destroy
   has_many :phases, through: :ideas_phases, after_add: :update_phase_ideas_count, after_remove: :update_phase_ideas_count
   has_many :baskets_ideas, dependent: :destroy

--- a/back/app/models/initiative.rb
+++ b/back/app/models/initiative.rb
@@ -44,7 +44,7 @@ class Initiative < ApplicationRecord
   has_many :initiative_files, -> { order(:ordering) }, dependent: :destroy
 
   has_many :initiatives_topics, dependent: :destroy
-  has_many :topics, through: :initiatives_topics
+  has_many :topics, -> { order(:ordering) }, through: :initiatives_topics
   has_many :areas_initiatives, dependent: :destroy
   has_many :areas, through: :areas_initiatives
   has_many :initiative_status_changes, dependent: :destroy

--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -59,7 +59,7 @@ class Project < ApplicationRecord
   has_many :votes, through: :ideas
 
   has_many :projects_topics, dependent: :destroy
-  has_many :topics, through: :projects_topics
+  has_many :topics, -> { order(:ordering) }, through: :projects_topics
   has_many :projects_allowed_input_topics, dependent: :destroy
   has_many :allowed_input_topics, through: :projects_allowed_input_topics, source: :topic
   has_many :areas_projects, dependent: :destroy

--- a/back/app/models/static_page.rb
+++ b/back/app/models/static_page.rb
@@ -45,7 +45,7 @@ class StaticPage < ApplicationRecord
   has_many :text_images, as: :imageable, dependent: :destroy
 
   has_many :static_pages_topics, dependent: :destroy
-  has_many :topics, through: :static_pages_topics
+  has_many :topics, -> { order(:ordering) }, through: :static_pages_topics
 
   has_many :areas_static_pages, dependent: :destroy
   has_many :areas, through: :areas_static_pages


### PR DESCRIPTION
Should fix this flaky spec: https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/106689/workflows/b7274b63-df22-4813-8d6a-4cc5bb80b5aa/jobs/251811

Without specifying the ordering in the `has_many` relationship, the results of `.topics` are not always guaranteed to be returned in the same order.