### PR TITLE
CL-3473 - Fall back to normal signup if email confirmation has been turned off

### DIFF
--- a/back/app/services/permissions_service.rb
+++ b/back/app/services/permissions_service.rb
@@ -168,7 +168,7 @@ class PermissionsService
     when 'everyone'
       everyone
     when 'everyone_confirmed_email'
-      everyone_confirmed_email
+      AppConfiguration.instance.feature_activated?('user_confirmation') ? everyone_confirmed_email : users
     else # users | groups | admins_moderators'
       users
     end


### PR DESCRIPTION
Added a line to make sure that if email confirmation is turned off, the light registration requirements can never be returned even if they have previously been set when confirmation was turned on
