### PR TITLE
[WIP] [CL-3327] Update RUT custom fields during verification

### DIFF
--- a/back/app/models/sso_custom_field_mapping.rb
+++ b/back/app/models/sso_custom_field_mapping.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: sso_custom_field_mappings
+#
+#  id                       :uuid             not null, primary key
+#  key_custom_field_id      :uuid
+#  key_custom_field_value   :string
+#  value_custom_field_id    :uuid
+#  value_custom_field_value :string
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#
+# Indexes
+#
+#  index_sso_custom_field_mappings_on_key                    (key_custom_field_id,key_custom_field_value)
+#  index_sso_custom_field_mappings_on_key_custom_field_id    (key_custom_field_id)
+#  index_sso_custom_field_mappings_on_value_custom_field_id  (value_custom_field_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (key_custom_field_id => custom_fields.id)
+#  fk_rails_...  (value_custom_field_id => custom_fields.id)
+#
+class SsoCustomFieldMapping < ApplicationRecord
+end

--- a/back/db/migrate/20230428140847_create_sso_custom_field_mappings.rb
+++ b/back/db/migrate/20230428140847_create_sso_custom_field_mappings.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateSsoCustomFieldMappings < ActiveRecord::Migration[6.1]
+  def change
+    create_table :sso_custom_field_mappings, id: :uuid do |t|
+      t.references :key_custom_field, foreign_key: { to_table: :custom_fields }, type: :uuid
+      t.string :key_custom_field_value
+      t.references :value_custom_field, foreign_key: { to_table: :custom_fields }, type: :uuid
+      t.string :value_custom_field_value
+
+      t.index %i[key_custom_field_id key_custom_field_value], name: :index_sso_custom_field_mappings_on_key
+
+      t.timestamps
+    end
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.0].define(version: 2023_08_25_121819) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -1386,6 +1387,18 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_25_121819) do
     t.index ["user_id"], name: "index_spam_reports_on_user_id"
   end
 
+  create_table "sso_custom_field_mappings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "key_custom_field_id"
+    t.string "key_custom_field_value"
+    t.uuid "value_custom_field_id"
+    t.string "value_custom_field_value"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["key_custom_field_id", "key_custom_field_value"], name: "index_sso_custom_field_mappings_on_key"
+    t.index ["key_custom_field_id"], name: "index_sso_custom_field_mappings_on_key_custom_field_id"
+    t.index ["value_custom_field_id"], name: "index_sso_custom_field_mappings_on_value_custom_field_id"
+  end
+
   create_table "static_page_files", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "static_page_id"
     t.string "file"
@@ -1688,6 +1701,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_25_121819) do
   add_foreign_key "reactions", "users"
   add_foreign_key "report_builder_reports", "users", column: "owner_id"
   add_foreign_key "spam_reports", "users"
+  add_foreign_key "sso_custom_field_mappings", "custom_fields", column: "key_custom_field_id"
+  add_foreign_key "sso_custom_field_mappings", "custom_fields", column: "value_custom_field_id"
   add_foreign_key "static_page_files", "static_pages"
   add_foreign_key "static_pages_topics", "static_pages"
   add_foreign_key "static_pages_topics", "topics"

--- a/back/engines/commercial/id_clave_unica/app/lib/id_clave_unica/clave_unica_omniauth.rb
+++ b/back/engines/commercial/id_clave_unica/app/lib/id_clave_unica/clave_unica_omniauth.rb
@@ -15,6 +15,11 @@ module IdClaveUnica
       if (ln = auth.dig('extra', 'raw_info', 'name', 'apellidos'))
         info[:last_name] = ln.join(' ')
       end
+
+      rut = auth.dig('extra', 'raw_info', 'sub')
+      rut_location = SsoCustomFieldMapping.find_by(key_custom_field_id: CustomField.find_by(key: 'rut').id, key_custom_field_value: rut).value_custom_field_value
+      info[:custom_field_values] = { rut: rut, rut_location: rut_location }
+
       info
     end
 
@@ -53,7 +58,7 @@ module IdClaveUnica
     end
 
     def updateable_user_attrs
-      %i[first_name last_name]
+      %i[first_name last_name custom_field_values]
     end
 
     def logout_url(_user)

--- a/back/spec/factories/sso_custom_field_mappings.rb
+++ b/back/spec/factories/sso_custom_field_mappings.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :sso_custom_field_mapping do
+    key_custom_field_id { "" }
+    key_custom_field_value { "MyString" }
+    value_custom_field_id { "" }
+    value_custom_field_value { "MyString" }
+  end
+end

--- a/back/spec/models/sso_custom_field_mapping_spec.rb
+++ b/back/spec/models/sso_custom_field_mapping_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe SsoCustomFieldMapping, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## Setup
```ruby
locale = AppConfiguration.instance.closest_locale_to('es')
rut_custom_field = CustomField.create!(resource_type: 'User', title_multiloc: { locale => 'RUT' }, description_multiloc: { locale => 'RUT' }, input_type: 'text', hidden: true)
location_custom_field = CustomField.create!(resource_type: 'User', title_multiloc: { locale => 'RUT location' }, description_multiloc: { locale => 'RUT location' }, input_type: 'text', hidden: true)
Group.create!(
  title_multiloc: { locale => "Santiago group" },
  membership_type: "rules",
  rules: [
    {"value"=>"Santiago", "ruleType"=>"custom_field_text", "predicate"=>"is", "customFieldId"=>location_custom_field.id},
    {"ruleType"=>"verified", "predicate"=>"is_verified"}
  ]
)

SsoCustomFieldMapping.create(
  key_custom_field_id: rut_custom_field.id, key_custom_field_value: '44444444',
  value_custom_field_id: location_custom_field.id, value_custom_field_value: 'Santiago')

SsoCustomFieldMapping.create(
  key_custom_field_id: rut_custom_field.id, key_custom_field_value: '55555555',
  value_custom_field_id: location_custom_field.id, value_custom_field_value: 'Valparaiso')


# Clean:
Group.order(created_at: :asc).last.destroy
SsoCustomFieldMapping.delete_all
CustomField.order(created_at: :asc).last(2).each(&:destroy!)

User.find_by(email: 'admin@citizenlab.co').verifications.destroy_all
User.find_by(email: 'admin@citizenlab.co').update!(verified: false)
```

* If we don't hide RUT and RUT location, it means they will be editable before verification. Not terrible, but weird. So, we create them as hidden.

## ToDo
- [ ] Have a 15-minute call with @kogre to check if `extra_user_attributes_sso` is really just a mapping of two fields. I gave it a more specific name and fixed columns. Is it still flexible? Do we have some bigger plans for it?
- [ ] Ask Pablo whether we should use 8 or 9 digits in RUT
- [ ] Add a rake task to parse pdf with RUTs and save them to the DB
```ruby
`sudo apt install poppler-utils`
`pdftotext -layout Padron-13-LA\ REINA-2-2\ \(1\).pdf padron.txt`
File.readlines('padron.txt').select { |line| line.match?(/\s\d{1,2}\.\d{3}\.\d{3}-[\dK]\s/) }.map { |line| line.split('   ')[0] }
```
- [x] Do not overwrite old custom fields with new ones. Use `deep_merge` in `back/app/controllers/omniauth_callback_controller.rb`
- [ ] Write tests 