### PR TITLE
CL-3496: Inconsistent data fix: Blank initiative status change for draft initiatives

### DIFF
--- a/back/app/models/initiative.rb
+++ b/back/app/models/initiative.rb
@@ -71,7 +71,7 @@ class Initiative < ApplicationRecord
   with_options unless: :draft? do
     # Problem is that this validation happens too soon, as the first idea status change is created after create.
     # initiative.validates :initiative_status, presence: true
-    validates :initiative_status_changes, presence: true, unless: proc { Current.loading_tenant_template }
+    validates :initiative_status_changes, presence: true, if: proc { |initiative| !initiative.draft? && !Current.loading_tenant_template }
     validate :assignee_can_moderate_initiatives
 
     before_validation :initialize_initiative_status_changes


### PR DESCRIPTION
A lot of invalid data was detected this week. It looks like all draft initiatives became invalid, I suspect due to a recent change to the validation, where probably the dubble usage of `unless`, caused one of them (the draft? condition) to be ignored by Rails.

I couldn't test it with the production data, because I cannot access the database anymore. But I tested it by creating a draft initiative without initiative status changes and in the original case it was considered as invalid, while with the proposed change it's no longer considered invalid.
