### PR TITLE
CL-3393 - Fix inconsistent styles

### DIFF
--- a/front/app/containers/Authentication/steps/AuthProviders/AuthProviderButton.tsx
+++ b/front/app/containers/Authentication/steps/AuthProviders/AuthProviderButton.tsx
@@ -14,7 +14,7 @@ import messages from './messages';
 import { trackEventByName } from 'utils/analytics';
 
 // styling
-import styled from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 import { darken } from 'polished';
 import { colors } from 'utils/styleUtils';
 
@@ -131,7 +131,7 @@ const AuthProviderButton = memo<Props>(
     const [tacError, setTacError] = useState(false);
     const [privacyAccepted, setPrivacyAccepted] = useState(false);
     const [privacyError, setPrivacyError] = useState(false);
-
+    const theme = useTheme();
     useEffect(() => {
       // reset
       setTacAccepted(false);
@@ -194,7 +194,9 @@ const AuthProviderButton = memo<Props>(
           icon={icon}
           iconSize="22px"
           iconColor={
-            authProvider === 'facebook' ? colors.facebook : colors.textPrimary
+            authProvider === 'facebook'
+              ? colors.facebook
+              : theme.colors.tenantText
           }
           buttonStyle="white"
           fullWidth={true}
@@ -202,6 +204,7 @@ const AuthProviderButton = memo<Props>(
           whiteSpace="wrap"
           onClick={handleExpandButtonClicked}
           padding="10px 18px"
+          textColor={theme.colors.tenantText}
         >
           {children}
         </Button>

--- a/front/app/containers/Authentication/steps/ChangeEmail/index.tsx
+++ b/front/app/containers/Authentication/steps/ChangeEmail/index.tsx
@@ -60,7 +60,7 @@ const ChangeEmail = ({ status, onGoBack, onChangeEmail }: Props) => {
 
   return (
     <>
-      <Text mt="0px" mb="32px">
+      <Text mt="0px" mb="32px" color="tenantText">
         {formatMessage(messages.enterNewEmail)}
       </Text>
       <FormProvider {...methods}>

--- a/front/app/containers/Authentication/steps/EmailAndPasswordSignUp/index.tsx
+++ b/front/app/containers/Authentication/steps/EmailAndPasswordSignUp/index.tsx
@@ -159,7 +159,7 @@ const EmailAndPasswordSignUp = ({
             </Button>
           </Box>
         </form>
-        <Box mt="32px">
+        <Box mt="22px">
           {anySSOEnabled ? (
             <TextButton onClick={onGoBack} className="link">
               {formatMessage(messages.backToSignUpOptions)}

--- a/front/app/containers/Authentication/steps/EmailAndPasswordSignUp/index.tsx
+++ b/front/app/containers/Authentication/steps/EmailAndPasswordSignUp/index.tsx
@@ -159,7 +159,7 @@ const EmailAndPasswordSignUp = ({
             </Button>
           </Box>
         </form>
-        <Box mt="22px">
+        <Box mt="24px">
           {anySSOEnabled ? (
             <TextButton onClick={onGoBack} className="link">
               {formatMessage(messages.backToSignUpOptions)}

--- a/front/app/containers/Authentication/steps/EmailConfirmation/FooterNotes.tsx
+++ b/front/app/containers/Authentication/steps/EmailConfirmation/FooterNotes.tsx
@@ -15,7 +15,7 @@ import { isNilOrError } from 'utils/helperUtils';
 
 export const FooterNote = styled.p`
   color: ${({ theme }) => theme.colors.tenantText};
-  font-size: ${fontSizes.s}px;
+  font-size: ${fontSizes.base}px;
   line-height: normal;
 
   &:not(:last-child) {
@@ -24,7 +24,7 @@ export const FooterNote = styled.p`
 `;
 
 export const FooterNoteLink = styled.button`
-  font-size: ${fontSizes.s}px;
+  font-size: ${fontSizes.base}px;
   padding-left: 4px;
   color: ${({ theme }) => theme.colors.tenantText};
   text-decoration: underline;

--- a/front/app/containers/Authentication/steps/LightFlowStart/index.tsx
+++ b/front/app/containers/Authentication/steps/LightFlowStart/index.tsx
@@ -78,7 +78,7 @@ const LightFlowStart = ({ onSubmit, onSwitchToSSO }: Props) => {
       {passwordLoginEnabled && (
         <FormProvider {...methods}>
           <form onSubmit={methods.handleSubmit(handleSubmit)}>
-            <Text mt="0px" mb="32px">
+            <Text mt="0px" mb="32px" color="tenantText">
               {formatMessage(sharedMessages.enterYourEmailAddress)}
             </Text>
             <Box>

--- a/front/app/containers/Authentication/steps/Password/index.tsx
+++ b/front/app/containers/Authentication/steps/Password/index.tsx
@@ -115,7 +115,7 @@ const Password = ({ state, status, onSubmit }: Props) => {
           <Checkbox
             name="rememberMe"
             label={
-              <Text mt="0" mb="0" mr="4px">
+              <Text mt="0" mb="0" mr="4px" color="tenantText">
                 {formatMessage(sharedMessages.rememberMe)}
               </Text>
             }

--- a/front/app/containers/Authentication/steps/Policies/PoliciesMarkup.tsx
+++ b/front/app/containers/Authentication/steps/Policies/PoliciesMarkup.tsx
@@ -6,7 +6,7 @@ import Link from 'utils/cl-router/Link';
 
 // styling
 import styled from 'styled-components';
-import { colors, fontSizes } from 'utils/styleUtils';
+import { fontSizes } from 'utils/styleUtils';
 
 // i18n
 import { useIntl, FormattedMessage } from 'utils/cl-intl';
@@ -17,15 +17,15 @@ import authProvidersMessages from 'containers/Authentication/steps/AuthProviders
 import Checkbox from 'components/HookForm/Checkbox';
 
 export const ConsentText = styled.div`
-  color: ${colors.textSecondary};
-  font-size: ${fontSizes.s}px;
+  color: ${({ theme }) => theme.colors.tenantText};
+  font-size: ${fontSizes.base}px;
   line-height: 21px;
   overflow-wrap: break-word;
   word-wrap: break-word;
   word-break: break-word;
 
   a {
-    color: ${colors.textSecondary};
+    color: ${({ theme }) => theme.colors.tenantText};
     font-weight: 400;
     text-decoration: underline;
     overflow-wrap: break-word;
@@ -84,7 +84,7 @@ const PoliciesMarkup = () => {
           }
         />
       </Box>
-      <Text mt="24px" mb="0px" fontSize="s" color="textSecondary">
+      <Text mt="24px" mb="0px" fontSize="base" color="tenantText">
         {formatMessage(messages.byContinuing)}
       </Text>
     </>

--- a/front/app/containers/Authentication/steps/Policies/PoliciesMarkup.tsx
+++ b/front/app/containers/Authentication/steps/Policies/PoliciesMarkup.tsx
@@ -18,7 +18,7 @@ import Checkbox from 'components/HookForm/Checkbox';
 
 export const ConsentText = styled.div`
   color: ${({ theme }) => theme.colors.tenantText};
-  font-size: ${fontSizes.base}px;
+  font-size: ${fontSizes.s}px;
   line-height: 21px;
   overflow-wrap: break-word;
   word-wrap: break-word;
@@ -84,7 +84,7 @@ const PoliciesMarkup = () => {
           }
         />
       </Box>
-      <Text mt="24px" mb="0px" fontSize="base" color="tenantText">
+      <Text mt="24px" mb="0px" fontSize="s" color="tenantText">
         {formatMessage(messages.byContinuing)}
       </Text>
     </>

--- a/front/app/containers/Authentication/steps/Success/index.tsx
+++ b/front/app/containers/Authentication/steps/Success/index.tsx
@@ -28,7 +28,7 @@ const Success = ({ status, onContinue }: Props) => {
       <Title variant="h4" as="h2" mt="24px" mb="0">
         {formatMessage(messages.allDone)}
       </Title>
-      <Text mt="8px" mb="24px">
+      <Text mt="8px" mb="24px" color="tenantText">
         {formatMessage(messages.nowContinueYourParticipation)}
       </Text>
       <Button

--- a/front/app/containers/Authentication/steps/_components/TextButton.tsx
+++ b/front/app/containers/Authentication/steps/_components/TextButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { fontSizes } from 'utils/styleUtils';
-import { darken } from 'polished';
+import { darken } from 'polished'; // TODO: Remove when we have a better system
 
 export const StyledButton = styled.button`
   font-size: ${fontSizes.base}px;
@@ -15,7 +15,7 @@ export const StyledButton = styled.button`
 
   cursor: pointer;
   padding: 0px;
-  margin-top: 10px;
+  margin-top: 12px;
 `;
 
 export default (props: React.HTMLProps<HTMLButtonElement>) => (

--- a/front/app/containers/Authentication/steps/_components/TextButton.tsx
+++ b/front/app/containers/Authentication/steps/_components/TextButton.tsx
@@ -1,19 +1,21 @@
 import React from 'react';
 import styled from 'styled-components';
-import { fontSizes, colors } from 'utils/styleUtils';
+import { fontSizes } from 'utils/styleUtils';
+import { darken } from 'polished';
 
 export const StyledButton = styled.button`
   font-size: ${fontSizes.base}px;
-  color: ${colors.textSecondary};
+  color: ${({ theme }) => theme.colors.tenantText};
   text-decoration: underline;
 
   &:hover {
-    color: ${colors.textPrimary};
+    color: ${({ theme }) => darken(0.2, theme.colors.tenantText)};
     text-decoration: underline;
   }
 
   cursor: pointer;
   padding: 0px;
+  margin-top: 10px;
 `;
 
 export default (props: React.HTMLProps<HTMLButtonElement>) => (


### PR DESCRIPTION
Should cover the tweaks that Yaesul recommended:
- All text color to be: tenantText (some things were tenantPrimary or textSecondary, on SSO buttons and secondary links under primary buttons)
- Secondary links (i.e. login/signup/forgot your password?): Text size to 16px
- (and add a bit more margin above flow switching text?)