### PR TITLE
Restore template changes

### DIFF
--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/permission.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/permission.rb
@@ -5,7 +5,7 @@ module MultiTenancy
     module Serializers
       class Permission < Base
         ref_attribute :permission_scope
-        attributes %i[action permitted_by]
+        attributes %i[action permitted_by global_custom_fields]
       end
     end
   end

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/permissions_custom_field.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/permissions_custom_field.rb
@@ -3,7 +3,7 @@
 module MultiTenancy
   module Templates
     module Serializers
-      class PermissionCustomField < Base
+      class PermissionsCustomField < Base
         attribute :required
         ref_attributes %i[custom_field permission]
       end

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/permissions_custom_field.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/permissions_custom_field.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module MultiTenancy
+  module Templates
+    module Serializers
+      class PermissionCustomField < Base
+        attribute :required
+        ref_attributes %i[custom_field permission]
+      end
+    end
+  end
+end

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_serializer.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_serializer.rb
@@ -51,6 +51,7 @@ module MultiTenancy
           InitiativeStatus => serialize_records(InitiativeStatus),
           NavBarItem => serialize_records(NavBarItem),
           Permission => serialize_records(Permission),
+          PermissionsCustomField => serialize_records(PermissionsCustomField),
           Phase => serialize_records(Phase),
           PhaseFile => serialize_records(PhaseFile),
           Project => serialize_records(Project),


### PR DESCRIPTION
This PR restores the template changes that were made here https://github.com/CitizenLabDotCo/citizenlab/pull/4254/commits/6043be0a2b752709f049f433fe68653786c3b91a

I tested this manually by creating some custom field - permission associations and turning off the corresponding toggle. The output from `MultiTenancy::Templates::TenantSerializer.new(tenant).run` looks as expected. @adessy To be certain that the changes were done correctly, I also added you as reviewer.