### PR TITLE
Add some extra checks around handleBlockedUserError

### DIFF
--- a/front/app/utils/errorUtils.ts
+++ b/front/app/utils/errorUtils.ts
@@ -229,6 +229,8 @@ export const handleHookFormSubmissionError = (
 export const handleBlockedUserError = (status: number, data: CLErrors) => {
   if (
     status === 401 &&
+    isObject(data) &&
+    isObject(data.errors) &&
     'base' in data.errors &&
     isArray(data.errors.base) &&
     data.errors.base.length >= 0 &&


### PR DESCRIPTION
Should fix https://sentry.hq.citizenlab.co/organizations/citizenlab/issues/72973/?project=3&referrer=AssignedActivityEmail

Might be related to the inconsistent error formats (`CLErrors` vs `CLErrorsJSON` vs `CLErrorsWrapper`), but I assume this was tested well by structure when they released this, so probably not

# Changelog
## Technical
- Fix sentry error in handleBlockedUserError