### PR TITLE
[CL-3420] Enable 2 skipped tests

### DIFF
--- a/back/spec/services/localization_service_spec.rb
+++ b/back/spec/services/localization_service_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 describe LocalizationService do
   let(:service) { described_class.new }
+  let(:time_object) { Time.new(-2000, 1, 1, 18, 0, 0) }
 
   describe 'hour_of_day' do
     it 'returns the correct format for English speaking locales' do
@@ -11,27 +12,27 @@ describe LocalizationService do
 
       locales.each do |locale|
         I18n.with_locale(locale) do
-          expect(service.hour_of_day(Time.new(-2000, 1, 1, 18, 0, 0))).to eq '6 PM'
+          expect(service.hour_of_day(time_object)).to eq '6 PM'
         end
       end
     end
 
-    it 'returns the correct format for French speaking locales', skip: 'Implement when translation formats merged' do
+    it 'returns the correct format for French speaking locales' do
       locales = %w[fr-FR fr-BE]
 
       locales.each do |locale|
         I18n.with_locale(locale) do
-          expect(service.hour_of_day(Time.new(-2000, 1, 1, 18, 0, 0))).to eq '18h'
+          expect(service.hour_of_day(time_object)).to eq '18h'
         end
       end
     end
 
-    it 'returns the correct format for non-English, non-French speaking locales', skip: 'Implement when translation formats merged' do
-      locales = %w[de-DE nl-BE]
+    it 'returns the correct format for non-English, non-French speaking locales' do
+      locales = %w[it-IT nl-BE]
 
       locales.each do |locale|
         I18n.with_locale(locale) do
-          expect(service.hour_of_day(Time.new(-2000, 1, 1, 18, 0, 0))).to eq '18:00'
+          expect(service.hour_of_day(time_object)).to eq '18:00'
         end
       end
     end


### PR DESCRIPTION
# Changelog
## Technical
- [CL-3420] Enable 2 skipped tests of hour_of_day multiloc format


[CL-3420]: https://citizenlab.atlassian.net/browse/CL-3420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ