### PR TITLE
[CL-3385] Hide slug input if page is proposals

### DIFF
--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/CustomPageSettingsForm/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/CustomPageSettingsForm/index.tsx
@@ -77,6 +77,7 @@ interface Props {
   defaultValues?: Partial<FormValues>;
   showNavBarItemTitle?: boolean;
   mode: TMode;
+  hideSlug?: boolean;
   onSubmit: (formValues: FormValues) => void | Promise<void>;
 }
 
@@ -91,6 +92,7 @@ const fieldMarginBottom = '40px';
 const CustomPageSettingsForm = ({
   showNavBarItemTitle,
   mode,
+  hideSlug,
   onSubmit,
   defaultValues,
 }: Props) => {
@@ -249,7 +251,7 @@ const CustomPageSettingsForm = ({
                 />
               </Box>
             )}
-            {slug && previewUrl && (
+            {slug && previewUrl && !hideSlug && (
               <Box mb={fieldMarginBottom}>
                 <SlugInput
                   slug={slug}

--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/Settings/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/Settings/index.tsx
@@ -58,6 +58,7 @@ const EditCustomPageSettings = () => {
         }}
         showNavBarItemTitle={hasNavbarItem}
         onSubmit={handleOnSubmit}
+        hideSlug={customPage.attributes.code === 'proposals'}
       />
     );
   }


### PR DESCRIPTION
# Changelog

## Fixed
- Hide slug input in page editor if page is proposals
