### PR TITLE
CL-3291 - Fix volunteering causes reordering

### DIFF
--- a/front/app/api/causes/useReorderCause.test.ts
+++ b/front/app/api/causes/useReorderCause.test.ts
@@ -8,7 +8,7 @@ import { rest } from 'msw';
 
 import createQueryClientWrapper from 'utils/testUtils/queryClientWrapper';
 
-const apiPath = '*causes/:id';
+const apiPath = '*causes/:id/reorder';
 const server = setupServer(
   rest.patch(apiPath, (_req, res, ctx) => {
     return res(ctx.status(200), ctx.json({ data: causesData[0] }));

--- a/front/app/api/causes/useReorderCause.ts
+++ b/front/app/api/causes/useReorderCause.ts
@@ -11,7 +11,7 @@ type IReorderCause = {
 
 const reorderCause = ({ id, ordering }: IReorderCause) =>
   fetcher<ICause>({
-    path: `/causes/${id}`,
+    path: `/causes/${id}/reorder`,
     action: 'patch',
     body: { cause: { ordering } },
   });


### PR DESCRIPTION
Hook was using the update endpoint instead of the reorder endpoint

# Changelog

## Fixed
- Reordering of volunteering causes
