### PR TITLE
CL-3541 Unforked ice_cube

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -147,10 +147,8 @@ gem 'order_as_specified'
 # https://github.com/nov/openid_connect/pull/48
 gem 'openid_connect', github: 'CitizenLabDotCo/openid_connect'
 gem 'scenic'
+gem 'ice_cube', '~> 0.16'
 
-# This fork was made to support the latest verions of Ruby
-# and Rails.
-gem 'ice_cube', github: 'CitizenLabDotCo/ice_cube'
 # Also required here to be able to initialize Mailgun in
 # e.g. production.rb, which would otherwise result in an
 # "undefined method 'mailgun_settings=' for ActionMailer::Base:Class"

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -7,12 +7,6 @@ GIT
       railties (>= 4.2)
 
 GIT
-  remote: https://github.com/CitizenLabDotCo/ice_cube.git
-  revision: 4671442d581d185a40933fa06a9c773f22f6070f
-  specs:
-    ice_cube (0.16.3)
-
-GIT
   remote: https://github.com/CitizenLabDotCo/omniauth-azure-activedirectory.git
   revision: ecdbac5d6ca7b4123c10b0f1d4569bfb7ba0fa8a
   specs:
@@ -707,6 +701,7 @@ GEM
       socksify
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
+    ice_cube (0.16.3)
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
@@ -1201,7 +1196,7 @@ DEPENDENCIES
   google_tag_manager!
   granular_permissions!
   groupdate (~> 4.1)
-  ice_cube!
+  ice_cube (~> 0.16)
   id_auth0!
   id_bogus!
   id_bosa_fas!


### PR DESCRIPTION
Seems like we forked only to have compatibility with a more recent Rails version, but the official repo has definitely caught up. They also added support for Ruby 3 and Rails 7 recently, but there hasn't been a Gem release yet.

# Changelog
## Technical
- Now using vanilla ice_cube Ruby gem instead of our own fork