### PR TITLE
[CL-3587] Bugfix & tests for regression

### DIFF
--- a/back/app/policies/project_folders/folder_policy.rb
+++ b/back/app/policies/project_folders/folder_policy.rb
@@ -25,7 +25,8 @@ module ProjectFolders
 
     def show?
       return true if user && UserRoleService.new.can_moderate?(record, user)
-      return false if %w[published archived].exclude?(record.admin_publication.publication_status)
+      return false if record.admin_publication.publication_status == 'draft'
+      return true if record.projects.empty?
 
       ProjectPolicy::Scope.new(user, record.projects).resolve.exists?
     end

--- a/back/spec/policies/project_folders/folder_policy_spec.rb
+++ b/back/spec/policies/project_folders/folder_policy_spec.rb
@@ -257,4 +257,32 @@ describe ProjectFolders::FolderPolicy do
       it { is_expected.to permit(:show) }
     end
   end
+
+  context 'when a published folder is empty' do
+    let(:subject_folder) { create(:project_folder, projects: []) }
+
+    context 'when visitor' do
+      let(:user) { nil }
+
+      it { is_expected.to     permit(:show)    }
+      it { is_expected.not_to permit(:create)  }
+      it { is_expected.not_to permit(:update)  }
+      it { is_expected.not_to permit(:destroy) }
+    end
+  end
+
+  context 'when an archived folder is empty' do
+    let(:subject_folder) { create(:project_folder, projects: []) }
+
+    before { subject_folder.admin_publication.update! publication_status: 'archived' }
+
+    context 'when visitor' do
+      let(:user) { nil }
+
+      it { is_expected.to     permit(:show)    }
+      it { is_expected.not_to permit(:create)  }
+      it { is_expected.not_to permit(:update)  }
+      it { is_expected.not_to permit(:destroy) }
+    end
+  end
 end


### PR DESCRIPTION
We changed permissions to see a folder to be dependant on permissions to see the projects within. This meant that if a folder contained no projects, a logged out user would not be able to see the folder.

This PR changes this such that a logged out user can now see empty published and archived folders. This behaviour is desired by some customers.

# Changelog
## Fixed
- [CL-3587] Logged out user can now view empty folder.


[CL-3587]: https://citizenlab.atlassian.net/browse/CL-3587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ