### PR TITLE
CL-3536 Remove unused whenever gem

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -170,9 +170,6 @@ gem 'cloudfront-rails', '~> 0.4'
 # Specifying this gem explicitly can probably be removed when the Rails upgrade is available.
 gem 'rails-html-sanitizer', '>= 1.4.3'
 
-# Used to define CRON tasks. See back/config/schedule.rb.
-gem 'whenever', '~> 1.0'
-
 Dir.children('engines/free').each do |engine_name|
   path = "engines/free/#{engine_name}"
   gem engine_name, path: path if File.directory?(path)

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -533,7 +533,6 @@ GEM
       mime-types (~> 3.0)
     case_transform (0.2)
       activesupport
-    chronic (0.10.2)
     cloudfront-rails (0.4.0)
       railties (> 4.0)
     coderay (1.1.3)
@@ -1092,8 +1091,6 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    whenever (1.0.0)
-      chronic (>= 0.6.3)
     with_env (1.1.0)
     xml-simple (1.1.9)
       rexml
@@ -1251,7 +1248,6 @@ DEPENDENCIES
   verification!
   volunteering!
   webmock (~> 3.18)
-  whenever (~> 1.0)
 
 BUNDLED WITH
    2.3.20

--- a/back/config/schedule.rb
+++ b/back/config/schedule.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-# Use this file to easily define all of your cron jobs.
-# Learn more: http://github.com/javan/whenever
-
-every 6.hours do
-  runner 'Analytics::ImportLatestMatomoDataJob.perform_for_all_tenants'
-end


### PR DESCRIPTION
The deleted `schedule.rb` file only contained:
```
# Use this file to easily define all of your cron jobs.
# Learn more: http://github.com/javan/whenever

every 6.hours do
  runner 'Analytics::ImportLatestMatomoDataJob.perform_for_all_tenants'
end
```
And we have this job scheduled on the servers, for example in the crontab on `aws-prd-1`:
```
# Import Matomo visit data
0 0,3,6,9,12,15,18,21 * * * docker run --rm --env-file /home/ubuntu/cl2-deployment/.env-production-benelux citizenlabdotco/back-ee:production bundle exec bin/rails runner -e production 'Analytics::ImportLatestMatomoDataJob.perform_for_all_tenants'
```


# Changelog
## Technical
- [CL-3536] Remove unused whenever gem


[CL-3536]: https://citizenlab.atlassian.net/browse/CL-3536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ