### PR TITLE
Standardised tenant and test locales

### DIFF
--- a/back/engines/commercial/admin_api/spec/acceptance/invites_spec.rb
+++ b/back/engines/commercial/admin_api/spec/acceptance/invites_spec.rb
@@ -28,7 +28,7 @@ resource 'Invite', admin_api: true do
     let(:email) { 'Jakky@voordevrienden.be' }
     let(:first_name) { 'Jaak' }
     let(:last_name) { 'Brijl' }
-    let(:locale) { 'nl-NL' }
+    let(:locale) { 'nl-BE' }
     let(:invite_text) { 'Welcome to the new world' }
     let(:roles) { [{ type: 'admin' }] }
     let(:group) { create(:group) }

--- a/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/project_context/update_all_ideation_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/project_context/update_all_ideation_spec.rb
@@ -103,7 +103,7 @@ resource 'Idea Custom Fields' do
                 code: 'ideation_section1',
                 key: nil,
                 input_type: 'section',
-                title_multiloc: { en: 'What is your idea?', 'fr-FR': 'Quelle est votre idée ?', 'nl-NL': 'Wat is je idee?' },
+                title_multiloc: { en: 'What is your idea?', 'fr-BE': 'Quelle est votre idée ?', 'nl-BE': 'Wat is je idee?' },
                 description_multiloc: {},
                 ordering: 0,
                 required: false,

--- a/back/engines/commercial/machine_translations/spec/services/machine_translations/machine_translation_service_spec.rb
+++ b/back/engines/commercial/machine_translations/spec/services/machine_translations/machine_translation_service_spec.rb
@@ -21,7 +21,7 @@ describe MachineTranslations::MachineTranslationService do
     end
 
     it 'propagates empty translations' do
-      text = translator.translate '', 'en', 'nl-NL'
+      text = translator.translate '', 'en', 'nl-BE'
       expect(text).to eq ''
     end
 

--- a/back/engines/commercial/multi_tenancy/spec/factories/tenants.rb
+++ b/back/engines/commercial/multi_tenancy/spec/factories/tenants.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
   factory :tenant do
     transient do
       lifecycle { 'active' }
-      locales { %w[en nl-BE fr-FR] }
+      locales { %w[en nl-BE fr-BE] }
     end
 
     name { Faker::Address.city }

--- a/back/engines/commercial/multi_tenancy/spec/serializers/web_api/v1/external/tenant_serializer_spec.rb
+++ b/back/engines/commercial/multi_tenancy/spec/serializers/web_api/v1/external/tenant_serializer_spec.rb
@@ -13,14 +13,14 @@ describe 'WebApi::V1::External::TenantSerializer' do
           {
             'allowed' => true,
             'enabled' => true,
-            'locales' => %w[en fr-FR nl-NL],
+            'locales' => %w[en fr-BE nl-BE],
             'currency' => 'EUR',
             'timezone' => 'Europe/Brussels',
             'color_main' => anything,
             'color_text' => anything,
             'color_secondary' => anything,
             'lifecycle_stage' => 'active',
-            'organization_name' => { 'en' => 'Liege', 'fr-FR' => 'Liege', 'nl-NL' => 'Luik' },
+            'organization_name' => { 'en' => 'Liege', 'fr-BE' => 'Liege', 'nl-BE' => 'Luik' },
             'organization_type' => 'medium_city',
             'authentication_token_lifetime_in_days' => 30
           },

--- a/back/engines/commercial/multi_tenancy/spec/services/track_segment_service_spec.rb
+++ b/back/engines/commercial/multi_tenancy/spec/services/track_segment_service_spec.rb
@@ -37,7 +37,7 @@ describe TrackSegmentService do
           website: 'https://example.org',
           avatar: nil,
           createdAt: Tenant.current.created_at,
-          tenantLocales: %w[en fr-FR nl-NL],
+          tenantLocales: %w[en fr-BE nl-BE],
           **expected_tenant_props
         },
         integrations: {

--- a/back/engines/commercial/smart_groups/spec/rules/custom_field_checkbox_spec.rb
+++ b/back/engines/commercial/smart_groups/spec/rules/custom_field_checkbox_spec.rb
@@ -51,8 +51,8 @@ describe SmartGroups::Rules::CustomFieldCheckbox do
     let(:checkbox) do
       create(:custom_field_checkbox, title_multiloc: {
         'en' => 'I agree to share my cookies',
-        'fr-FR' => 'J\'accepte de partager mes biscuits',
-        'nl-NL' => 'Ik ga akkoord om mijn koekjes te delen'
+        'fr-BE' => 'J\'accepte de partager mes biscuits',
+        'nl-BE' => 'Ik ga akkoord om mijn koekjes te delen'
       })
     end
 
@@ -74,13 +74,13 @@ describe SmartGroups::Rules::CustomFieldCheckbox do
     it 'successfully translates different combinations of rules' do
       expect(custom_field_checkbox_is_checked_rule.description_multiloc).to eq({
         'en' => 'Checked I agree to share my cookies',
-        'fr-FR' => 'A coché J\'accepte de partager mes biscuits',
-        'nl-NL' => 'Heeft Ik ga akkoord om mijn koekjes te delen aangevinkt'
+        'fr-BE' => 'A coché J\'accepte de partager mes biscuits',
+        'nl-BE' => 'Heeft Ik ga akkoord om mijn koekjes te delen aangevinkt'
       })
       expect(custom_field_checkbox_not_is_checked_rule.description_multiloc).to eq({
         'en' => 'Didn\'t check I agree to share my cookies',
-        'fr-FR' => 'N\'as pas coché J\'accepte de partager mes biscuits',
-        'nl-NL' => 'Heeft Ik ga akkoord om mijn koekjes te delen niet aangevinkt'
+        'fr-BE' => 'N\'as pas coché J\'accepte de partager mes biscuits',
+        'nl-BE' => 'Heeft Ik ga akkoord om mijn koekjes te delen niet aangevinkt'
       })
     end
   end

--- a/back/engines/commercial/smart_groups/spec/rules/custom_field_date_spec.rb
+++ b/back/engines/commercial/smart_groups/spec/rules/custom_field_date_spec.rb
@@ -67,8 +67,8 @@ describe SmartGroups::Rules::CustomFieldDate do
     let(:date_picker) do
       create(:custom_field_date, title_multiloc: {
         'en' => 'When will we have a new government?',
-        'fr-FR' => 'Quand est-ce que on aura un nouveau gouvernement?',
-        'nl-NL' => 'Wanneer zullen we een nieuwe regering hebben?'
+        'fr-BE' => 'Quand est-ce que on aura un nouveau gouvernement?',
+        'nl-BE' => 'Wanneer zullen we een nieuwe regering hebben?'
       })
     end
 
@@ -114,28 +114,28 @@ describe SmartGroups::Rules::CustomFieldDate do
     it 'successfully translates different combinations of rules' do
       expect(custom_field_date_is_before_rule.description_multiloc).to eq({
         'en' => 'When will we have a new government? is before 2027-11-08',
-        'fr-FR' => 'Quand est-ce que on aura un nouveau gouvernement? est avant 08/11/2027',
-        'nl-NL' => 'Wanneer zullen we een nieuwe regering hebben? is voor 08-11-2027'
+        'fr-BE' => 'Quand est-ce que on aura un nouveau gouvernement? est avant 08/11/2027',
+        'nl-BE' => 'Wanneer zullen we een nieuwe regering hebben? is voor 08-11-2027'
       })
       expect(custom_field_date_is_after_rule.description_multiloc).to eq({
         'en' => 'When will we have a new government? is after 2027-11-08',
-        'fr-FR' => 'Quand est-ce que on aura un nouveau gouvernement? est après 08/11/2027',
-        'nl-NL' => 'Wanneer zullen we een nieuwe regering hebben? is na 08-11-2027'
+        'fr-BE' => 'Quand est-ce que on aura un nouveau gouvernement? est après 08/11/2027',
+        'nl-BE' => 'Wanneer zullen we een nieuwe regering hebben? is na 08-11-2027'
       })
       expect(custom_field_date_is_exactly_rule.description_multiloc).to eq({
         'en' => 'When will we have a new government? is 2027-11-08',
-        'fr-FR' => 'Quand est-ce que on aura un nouveau gouvernement? est 08/11/2027',
-        'nl-NL' => 'Wanneer zullen we een nieuwe regering hebben? is 08-11-2027'
+        'fr-BE' => 'Quand est-ce que on aura un nouveau gouvernement? est 08/11/2027',
+        'nl-BE' => 'Wanneer zullen we een nieuwe regering hebben? is 08-11-2027'
       })
       expect(custom_field_date_is_empty_rule.description_multiloc).to eq({
         'en' => 'When will we have a new government? has no value',
-        'fr-FR' => 'Quand est-ce que on aura un nouveau gouvernement? n\'as pas de value',
-        'nl-NL' => 'Wanneer zullen we een nieuwe regering hebben? heeft geen waarde'
+        'fr-BE' => 'Quand est-ce que on aura un nouveau gouvernement? n\'as pas de value',
+        'nl-BE' => 'Wanneer zullen we een nieuwe regering hebben? heeft geen waarde'
       })
       expect(custom_field_date_not_is_empty_rule.description_multiloc).to eq({
         'en' => 'When will we have a new government? has any value',
-        'fr-FR' => 'Quand est-ce que on aura un nouveau gouvernement? peut avoir n\'importe quel value',
-        'nl-NL' => 'Wanneer zullen we een nieuwe regering hebben? heeft om het even welke waarde'
+        'fr-BE' => 'Quand est-ce que on aura un nouveau gouvernement? peut avoir n\'importe quel value',
+        'nl-BE' => 'Wanneer zullen we een nieuwe regering hebben? heeft om het even welke waarde'
       })
     end
   end

--- a/back/engines/commercial/smart_groups/spec/rules/custom_field_number_spec.rb
+++ b/back/engines/commercial/smart_groups/spec/rules/custom_field_number_spec.rb
@@ -82,8 +82,8 @@ describe SmartGroups::Rules::CustomFieldNumber do
     let(:number_picker) do
       create(:custom_field_number, title_multiloc: {
         'en' => 'How many politicians do you need to solve climate change?',
-        'fr-FR' => 'Combien de politicians faut-il pour resoudre le changement du climat?',
-        'nl-NL' => 'Hoeveel politici heb je nodig om klimaatsverandering op te lossen?'
+        'fr-BE' => 'Combien de politicians faut-il pour resoudre le changement du climat?',
+        'nl-BE' => 'Hoeveel politici heb je nodig om klimaatsverandering op te lossen?'
       })
     end
 
@@ -153,43 +153,43 @@ describe SmartGroups::Rules::CustomFieldNumber do
     it 'successfully translates different combinations of rules' do
       expect(custom_field_number_is_equal_rule.description_multiloc).to eq({
         'en' => 'How many politicians do you need to solve climate change? equals 0',
-        'fr-FR' => 'Combien de politicians faut-il pour resoudre le changement du climat? est égal à 0',
-        'nl-NL' => 'Hoeveel politici heb je nodig om klimaatsverandering op te lossen? is gelijk aan 0'
+        'fr-BE' => 'Combien de politicians faut-il pour resoudre le changement du climat? est égal à 0',
+        'nl-BE' => 'Hoeveel politici heb je nodig om klimaatsverandering op te lossen? is gelijk aan 0'
       })
       expect(custom_field_number_not_is_equal_rule.description_multiloc).to eq({
         'en' => 'How many politicians do you need to solve climate change? doesn\'t equal 0',
-        'fr-FR' => 'Combien de politicians faut-il pour resoudre le changement du climat? n\'est pas égal à 0',
-        'nl-NL' => 'Hoeveel politici heb je nodig om klimaatsverandering op te lossen? is verschillend van 0'
+        'fr-BE' => 'Combien de politicians faut-il pour resoudre le changement du climat? n\'est pas égal à 0',
+        'nl-BE' => 'Hoeveel politici heb je nodig om klimaatsverandering op te lossen? is verschillend van 0'
       })
       expect(custom_field_number_is_larger_than_rule.description_multiloc).to eq({
         'en' => 'How many politicians do you need to solve climate change? is larger than 0',
-        'fr-FR' => 'Combien de politicians faut-il pour resoudre le changement du climat? est plus grand que 0',
-        'nl-NL' => 'Hoeveel politici heb je nodig om klimaatsverandering op te lossen? is groter dan 0'
+        'fr-BE' => 'Combien de politicians faut-il pour resoudre le changement du climat? est plus grand que 0',
+        'nl-BE' => 'Hoeveel politici heb je nodig om klimaatsverandering op te lossen? is groter dan 0'
       })
       expect(custom_field_number_is_larger_than_or_equal_rule.description_multiloc).to eq({
         'en' => 'How many politicians do you need to solve climate change? is larger than or equals 0',
-        'fr-FR' => 'Combien de politicians faut-il pour resoudre le changement du climat? est plus grand ou égal à 0',
-        'nl-NL' => 'Hoeveel politici heb je nodig om klimaatsverandering op te lossen? is groter dan of gelijk aan 0'
+        'fr-BE' => 'Combien de politicians faut-il pour resoudre le changement du climat? est plus grand ou égal à 0',
+        'nl-BE' => 'Hoeveel politici heb je nodig om klimaatsverandering op te lossen? is groter dan of gelijk aan 0'
       })
       expect(custom_field_number_is_smaller_than_rule.description_multiloc).to eq({
         'en' => 'How many politicians do you need to solve climate change? is smaller than 0',
-        'fr-FR' => 'Combien de politicians faut-il pour resoudre le changement du climat? est moins que 0',
-        'nl-NL' => 'Hoeveel politici heb je nodig om klimaatsverandering op te lossen? is kleiner dan 0'
+        'fr-BE' => 'Combien de politicians faut-il pour resoudre le changement du climat? est moins que 0',
+        'nl-BE' => 'Hoeveel politici heb je nodig om klimaatsverandering op te lossen? is kleiner dan 0'
       })
       expect(custom_field_number_is_smaller_than_or_equal_rule.description_multiloc).to eq({
         'en' => 'How many politicians do you need to solve climate change? is smaller than or equals 0',
-        'fr-FR' => 'Combien de politicians faut-il pour resoudre le changement du climat? est moins ou égal à 0',
-        'nl-NL' => 'Hoeveel politici heb je nodig om klimaatsverandering op te lossen? is kleiner dan of gelijk aan 0'
+        'fr-BE' => 'Combien de politicians faut-il pour resoudre le changement du climat? est moins ou égal à 0',
+        'nl-BE' => 'Hoeveel politici heb je nodig om klimaatsverandering op te lossen? is kleiner dan of gelijk aan 0'
       })
       expect(custom_field_number_is_empty_rule.description_multiloc).to eq({
         'en' => 'How many politicians do you need to solve climate change? has no value',
-        'fr-FR' => 'Combien de politicians faut-il pour resoudre le changement du climat? n\'as pas de value',
-        'nl-NL' => 'Hoeveel politici heb je nodig om klimaatsverandering op te lossen? heeft geen waarde'
+        'fr-BE' => 'Combien de politicians faut-il pour resoudre le changement du climat? n\'as pas de value',
+        'nl-BE' => 'Hoeveel politici heb je nodig om klimaatsverandering op te lossen? heeft geen waarde'
       })
       expect(custom_field_number_not_is_empty_rule.description_multiloc).to eq({
         'en' => 'How many politicians do you need to solve climate change? has any value',
-        'fr-FR' => 'Combien de politicians faut-il pour resoudre le changement du climat? peut avoir n\'importe quel value',
-        'nl-NL' => 'Hoeveel politici heb je nodig om klimaatsverandering op te lossen? heeft om het even welke waarde'
+        'fr-BE' => 'Combien de politicians faut-il pour resoudre le changement du climat? peut avoir n\'importe quel value',
+        'nl-BE' => 'Hoeveel politici heb je nodig om klimaatsverandering op te lossen? heeft om het even welke waarde'
       })
     end
   end

--- a/back/engines/commercial/smart_groups/spec/rules/custom_field_select_spec.rb
+++ b/back/engines/commercial/smart_groups/spec/rules/custom_field_select_spec.rb
@@ -157,22 +157,22 @@ describe SmartGroups::Rules::CustomFieldSelect do
     let(:custom_field) do
       create(:custom_field_select, title_multiloc: {
         'en' => 'Where should we put the immigrants?',
-        'fr-FR' => 'Où devrions-nous placer les immigrants?',
-        'nl-NL' => 'Waar moeten we de immigraten plaatsen?'
+        'fr-BE' => 'Où devrions-nous placer les immigrants?',
+        'nl-BE' => 'Waar moeten we de immigraten plaatsen?'
       })
     end
     let(:train_station) do
       create(:custom_field_option, custom_field: custom_field, title_multiloc: {
         'en' => 'In the train station',
-        'fr-FR' => 'Dans la gare',
-        'nl-NL' => 'In het treinstation'
+        'fr-BE' => 'Dans la gare',
+        'nl-BE' => 'In het treinstation'
       })
     end
     let(:schools) do
       create(:custom_field_option, custom_field: custom_field, title_multiloc: {
         'en' => 'In schools',
-        'fr-FR' => 'Dans les écoles',
-        'nl-NL' => 'In scholen'
+        'fr-BE' => 'Dans les écoles',
+        'nl-BE' => 'In scholen'
       })
     end
 
@@ -228,33 +228,33 @@ describe SmartGroups::Rules::CustomFieldSelect do
     it 'successfully translates different combinations of rules' do
       expect(custom_field_select_has_value_rule.description_multiloc).to eq({
         'en' => 'Where should we put the immigrants? is In the train station',
-        'fr-FR' => 'Où devrions-nous placer les immigrants? est Dans la gare',
-        'nl-NL' => 'Waar moeten we de immigraten plaatsen? is In het treinstation'
+        'fr-BE' => 'Où devrions-nous placer les immigrants? est Dans la gare',
+        'nl-BE' => 'Waar moeten we de immigraten plaatsen? is In het treinstation'
       })
       expect(custom_field_select_not_has_value_rule.description_multiloc).to eq({
         'en' => 'Where should we put the immigrants? isn\'t In the train station',
-        'fr-FR' => 'Où devrions-nous placer les immigrants? n\'est pas Dans la gare',
-        'nl-NL' => 'Waar moeten we de immigraten plaatsen? is niet In het treinstation'
+        'fr-BE' => 'Où devrions-nous placer les immigrants? n\'est pas Dans la gare',
+        'nl-BE' => 'Waar moeten we de immigraten plaatsen? is niet In het treinstation'
       })
       expect(custom_field_select_is_one_of_rule.description_multiloc).to eq({
         'en' => 'Where should we put the immigrants? has one of the following values: In the train station',
-        'fr-FR' => 'Où devrions-nous placer les immigrants? est un de: Dans la gare',
-        'nl-NL' => 'Waar moeten we de immigraten plaatsen? heeft een van de volgende waarden: In het treinstation'
+        'fr-BE' => 'Où devrions-nous placer les immigrants? est un de: Dans la gare',
+        'nl-BE' => 'Waar moeten we de immigraten plaatsen? heeft een van de volgende waarden: In het treinstation'
       })
       expect(custom_field_select_not_is_one_of_rule.description_multiloc).to eq({
         'en' => 'Where should we put the immigrants? does not have any of the follow values: In the train station, In schools',
-        'fr-FR' => 'Où devrions-nous placer les immigrants? n\'est pas un de: Dans la gare, Dans les écoles',
-        'nl-NL' => 'Waar moeten we de immigraten plaatsen? heeft geen van de volgende waarden: In het treinstation, In scholen'
+        'fr-BE' => 'Où devrions-nous placer les immigrants? n\'est pas un de: Dans la gare, Dans les écoles',
+        'nl-BE' => 'Waar moeten we de immigraten plaatsen? heeft geen van de volgende waarden: In het treinstation, In scholen'
       })
       expect(custom_field_select_is_empty_rule.description_multiloc).to eq({
         'en' => 'Where should we put the immigrants? has no value',
-        'fr-FR' => 'Où devrions-nous placer les immigrants? n\'as pas de value',
-        'nl-NL' => 'Waar moeten we de immigraten plaatsen? heeft geen waarde'
+        'fr-BE' => 'Où devrions-nous placer les immigrants? n\'as pas de value',
+        'nl-BE' => 'Waar moeten we de immigraten plaatsen? heeft geen waarde'
       })
       expect(custom_field_select_not_is_empty_rule.description_multiloc).to eq({
         'en' => 'Where should we put the immigrants? has any value',
-        'fr-FR' => 'Où devrions-nous placer les immigrants? peut avoir n\'importe quel value',
-        'nl-NL' => 'Waar moeten we de immigraten plaatsen? heeft om het even welke waarde'
+        'fr-BE' => 'Où devrions-nous placer les immigrants? peut avoir n\'importe quel value',
+        'nl-BE' => 'Waar moeten we de immigraten plaatsen? heeft om het even welke waarde'
       })
     end
   end

--- a/back/engines/commercial/smart_groups/spec/rules/custom_field_text_spec.rb
+++ b/back/engines/commercial/smart_groups/spec/rules/custom_field_text_spec.rb
@@ -98,8 +98,8 @@ describe SmartGroups::Rules::CustomFieldText do
     let(:text_field) do
       create(:custom_field, title_multiloc: {
         'en' => 'What\'s your favourite Star Wars quote?',
-        'fr-FR' => 'Quelle est votre citation Star Wars préférée?',
-        'nl-NL' => 'Wat is uw favoriete Star Wars citaat?'
+        'fr-BE' => 'Quelle est votre citation Star Wars préférée?',
+        'nl-BE' => 'Wat is uw favoriete Star Wars citaat?'
       })
     end
 
@@ -185,53 +185,53 @@ describe SmartGroups::Rules::CustomFieldText do
     it 'successfully translates different combinations of rules' do
       expect(custom_field_text_is_rule.description_multiloc).to eq({
         'en' => 'What\'s your favourite Star Wars quote? is Never tell me the odds!',
-        'fr-FR' => 'Quelle est votre citation Star Wars préférée? est Never tell me the odds!',
-        'nl-NL' => 'Wat is uw favoriete Star Wars citaat? is Never tell me the odds!'
+        'fr-BE' => 'Quelle est votre citation Star Wars préférée? est Never tell me the odds!',
+        'nl-BE' => 'Wat is uw favoriete Star Wars citaat? is Never tell me the odds!'
       })
       expect(custom_field_text_not_is_rule.description_multiloc).to eq({
         'en' => 'What\'s your favourite Star Wars quote? is not Never tell me the odds!',
-        'fr-FR' => 'Quelle est votre citation Star Wars préférée? n\'est pas Never tell me the odds!',
-        'nl-NL' => 'Wat is uw favoriete Star Wars citaat? is niet Never tell me the odds!'
+        'fr-BE' => 'Quelle est votre citation Star Wars préférée? n\'est pas Never tell me the odds!',
+        'nl-BE' => 'Wat is uw favoriete Star Wars citaat? is niet Never tell me the odds!'
       })
       expect(custom_field_text_contains_rule.description_multiloc).to eq({
         'en' => 'What\'s your favourite Star Wars quote? contains Never tell me the odds!',
-        'fr-FR' => 'Quelle est votre citation Star Wars préférée? contient Never tell me the odds!',
-        'nl-NL' => 'Wat is uw favoriete Star Wars citaat? bevat Never tell me the odds!'
+        'fr-BE' => 'Quelle est votre citation Star Wars préférée? contient Never tell me the odds!',
+        'nl-BE' => 'Wat is uw favoriete Star Wars citaat? bevat Never tell me the odds!'
       })
       expect(custom_field_text_not_contains_rule.description_multiloc).to eq({
         'en' => 'What\'s your favourite Star Wars quote? doesn\'t contain Never tell me the odds!',
-        'fr-FR' => 'Quelle est votre citation Star Wars préférée? ne contient pas Never tell me the odds!',
-        'nl-NL' => 'Wat is uw favoriete Star Wars citaat? bevat niet Never tell me the odds!'
+        'fr-BE' => 'Quelle est votre citation Star Wars préférée? ne contient pas Never tell me the odds!',
+        'nl-BE' => 'Wat is uw favoriete Star Wars citaat? bevat niet Never tell me the odds!'
       })
       expect(custom_field_text_begins_with_rule.description_multiloc).to eq({
         'en' => 'What\'s your favourite Star Wars quote? begins with Never tell me the odds!',
-        'fr-FR' => 'Quelle est votre citation Star Wars préférée? commence par Never tell me the odds!',
-        'nl-NL' => 'Wat is uw favoriete Star Wars citaat? begint op Never tell me the odds!'
+        'fr-BE' => 'Quelle est votre citation Star Wars préférée? commence par Never tell me the odds!',
+        'nl-BE' => 'Wat is uw favoriete Star Wars citaat? begint op Never tell me the odds!'
       })
       expect(custom_field_text_not_begins_with_rule.description_multiloc).to eq({
         'en' => 'What\'s your favourite Star Wars quote? doesn\'t begin with Never tell me the odds!',
-        'fr-FR' => 'Quelle est votre citation Star Wars préférée? ne commence pas par Never tell me the odds!',
-        'nl-NL' => 'Wat is uw favoriete Star Wars citaat? begint niet op Never tell me the odds!'
+        'fr-BE' => 'Quelle est votre citation Star Wars préférée? ne commence pas par Never tell me the odds!',
+        'nl-BE' => 'Wat is uw favoriete Star Wars citaat? begint niet op Never tell me the odds!'
       })
       expect(custom_field_text_ends_on_rule.description_multiloc).to eq({
         'en' => 'What\'s your favourite Star Wars quote? ends on Never tell me the odds!',
-        'fr-FR' => 'Quelle est votre citation Star Wars préférée? se termine sur Never tell me the odds!',
-        'nl-NL' => 'Wat is uw favoriete Star Wars citaat? eindigt op Never tell me the odds!'
+        'fr-BE' => 'Quelle est votre citation Star Wars préférée? se termine sur Never tell me the odds!',
+        'nl-BE' => 'Wat is uw favoriete Star Wars citaat? eindigt op Never tell me the odds!'
       })
       expect(custom_field_text_not_ends_on_rule.description_multiloc).to eq({
         'en' => 'What\'s your favourite Star Wars quote? doesn\'t end on Never tell me the odds!',
-        'fr-FR' => 'Quelle est votre citation Star Wars préférée? ne se termine pas sur Never tell me the odds!',
-        'nl-NL' => 'Wat is uw favoriete Star Wars citaat? eindigt niet op Never tell me the odds!'
+        'fr-BE' => 'Quelle est votre citation Star Wars préférée? ne se termine pas sur Never tell me the odds!',
+        'nl-BE' => 'Wat is uw favoriete Star Wars citaat? eindigt niet op Never tell me the odds!'
       })
       expect(custom_field_text_is_empty_rule.description_multiloc).to eq({
         'en' => 'What\'s your favourite Star Wars quote? has no value',
-        'fr-FR' => 'Quelle est votre citation Star Wars préférée? n\'as pas de value',
-        'nl-NL' => 'Wat is uw favoriete Star Wars citaat? heeft geen waarde'
+        'fr-BE' => 'Quelle est votre citation Star Wars préférée? n\'as pas de value',
+        'nl-BE' => 'Wat is uw favoriete Star Wars citaat? heeft geen waarde'
       })
       expect(custom_field_text_not_is_empty_rule.description_multiloc).to eq({
         'en' => 'What\'s your favourite Star Wars quote? has any value',
-        'fr-FR' => 'Quelle est votre citation Star Wars préférée? peut avoir n\'importe quel value',
-        'nl-NL' => 'Wat is uw favoriete Star Wars citaat? heeft om het even welke waarde'
+        'fr-BE' => 'Quelle est votre citation Star Wars préférée? peut avoir n\'importe quel value',
+        'nl-BE' => 'Wat is uw favoriete Star Wars citaat? heeft om het even welke waarde'
       })
     end
   end

--- a/back/engines/commercial/smart_groups/spec/rules/email_spec.rb
+++ b/back/engines/commercial/smart_groups/spec/rules/email_spec.rb
@@ -139,43 +139,43 @@ describe SmartGroups::Rules::Email do
     it 'successfully translates different combinations of rules' do
       expect(email_is_rule.description_multiloc).to eq({
         'en' => 'e-mail is sebi@citizenlab.co',
-        'fr-FR' => 'adresse e-mail est sebi@citizenlab.co',
-        'nl-NL' => 'e-mail is sebi@citizenlab.co'
+        'fr-BE' => 'adresse e-mail est sebi@citizenlab.co',
+        'nl-BE' => 'e-mail is sebi@citizenlab.co'
       })
       expect(email_not_is_rule.description_multiloc).to eq({
         'en' => 'e-mail is not sebi@citizenlab.co',
-        'fr-FR' => 'adresse e-mail n\'est pas sebi@citizenlab.co',
-        'nl-NL' => 'e-mail is niet sebi@citizenlab.co'
+        'fr-BE' => 'adresse e-mail n\'est pas sebi@citizenlab.co',
+        'nl-BE' => 'e-mail is niet sebi@citizenlab.co'
       })
       expect(email_contains_rule.description_multiloc).to eq({
         'en' => 'e-mail contains @citizenlab',
-        'fr-FR' => 'adresse e-mail contient @citizenlab',
-        'nl-NL' => 'e-mail bevat @citizenlab'
+        'fr-BE' => 'adresse e-mail contient @citizenlab',
+        'nl-BE' => 'e-mail bevat @citizenlab'
       })
       expect(email_not_contains_rule.description_multiloc).to eq({
         'en' => 'e-mail doesn\'t contain @citizenlab',
-        'fr-FR' => 'adresse e-mail ne contient pas @citizenlab',
-        'nl-NL' => 'e-mail bevat niet @citizenlab'
+        'fr-BE' => 'adresse e-mail ne contient pas @citizenlab',
+        'nl-BE' => 'e-mail bevat niet @citizenlab'
       })
       expect(email_begins_with_rule.description_multiloc).to eq({
         'en' => 'e-mail begins with sebi',
-        'fr-FR' => 'adresse e-mail commence par sebi',
-        'nl-NL' => 'e-mail begint op sebi'
+        'fr-BE' => 'adresse e-mail commence par sebi',
+        'nl-BE' => 'e-mail begint op sebi'
       })
       expect(email_not_begins_with_rule.description_multiloc).to eq({
         'en' => 'e-mail doesn\'t begin with sebi',
-        'fr-FR' => 'adresse e-mail ne commence pas par sebi',
-        'nl-NL' => 'e-mail begint niet op sebi'
+        'fr-BE' => 'adresse e-mail ne commence pas par sebi',
+        'nl-BE' => 'e-mail begint niet op sebi'
       })
       expect(email_ends_on_rule.description_multiloc).to eq({
         'en' => 'e-mail ends on citizenlab.co',
-        'fr-FR' => 'adresse e-mail se termine sur citizenlab.co',
-        'nl-NL' => 'e-mail eindigt op citizenlab.co'
+        'fr-BE' => 'adresse e-mail se termine sur citizenlab.co',
+        'nl-BE' => 'e-mail eindigt op citizenlab.co'
       })
       expect(email_not_ends_on_rule.description_multiloc).to eq({
         'en' => 'e-mail doesn\'t end on citizenlab.co',
-        'fr-FR' => 'adresse e-mail ne se termine pas sur citizenlab.co',
-        'nl-NL' => 'e-mail eindigt niet op citizenlab.co'
+        'fr-BE' => 'adresse e-mail ne se termine pas sur citizenlab.co',
+        'nl-BE' => 'e-mail eindigt niet op citizenlab.co'
       })
     end
   end

--- a/back/engines/commercial/smart_groups/spec/rules/lives_in_spec.rb
+++ b/back/engines/commercial/smart_groups/spec/rules/lives_in_spec.rb
@@ -107,7 +107,7 @@ describe SmartGroups::Rules::LivesIn do
       CustomField.create!(
         resource_type: 'User',
         key: 'domicile',
-        title_multiloc: { 'en' => 'Place of residence', 'fr-FR' => 'Domicile', 'nl-NL' => 'Woonplaats' },
+        title_multiloc: { 'en' => 'Place of residence', 'fr-BE' => 'Domicile', 'nl-BE' => 'Woonplaats' },
         input_type: 'select',
         required: false,
         ordering: 2,
@@ -119,8 +119,8 @@ describe SmartGroups::Rules::LivesIn do
     let(:area) do
       create(:area, title_multiloc: {
         'en' => 'Brussels',
-        'fr-FR' => 'Bruxelles',
-        'nl-NL' => 'Brussel'
+        'fr-BE' => 'Bruxelles',
+        'nl-BE' => 'Brussel'
       })
     end
 
@@ -182,43 +182,43 @@ describe SmartGroups::Rules::LivesIn do
     it 'successfully translates different combinations of rules' do
       expect(lives_in_has_value_rule.description_multiloc).to eq({
         'en' => 'Place of residence is Brussels',
-        'fr-FR' => 'Domicile est Bruxelles',
-        'nl-NL' => 'Woonplaats is Brussel'
+        'fr-BE' => 'Domicile est Bruxelles',
+        'nl-BE' => 'Woonplaats is Brussel'
       })
       expect(lives_in_outside_rule.description_multiloc).to eq({
         'en' => 'Place of residence is somewhere else',
-        'fr-FR' => 'Domicile est ailleurs',
-        'nl-NL' => 'Woonplaats is ergens anders'
+        'fr-BE' => 'Domicile est ailleurs',
+        'nl-BE' => 'Woonplaats is ergens anders'
       })
       expect(lives_in_not_has_value_rule.description_multiloc).to eq({
         'en' => 'Place of residence isn\'t Brussels',
-        'fr-FR' => 'Domicile n\'est pas Bruxelles',
-        'nl-NL' => 'Woonplaats is niet Brussel'
+        'fr-BE' => 'Domicile n\'est pas Bruxelles',
+        'nl-BE' => 'Woonplaats is niet Brussel'
       })
       expect(lives_in_not_outside_rule.description_multiloc).to eq({
         'en' => 'Place of residence is not somewhere else',
-        'fr-FR' => 'Domicile n\'est pas ailleurs',
-        'nl-NL' => 'Woonplaats is niet ergens anders'
+        'fr-BE' => 'Domicile n\'est pas ailleurs',
+        'nl-BE' => 'Woonplaats is niet ergens anders'
       })
       expect(lives_in_is_one_of_rule.description_multiloc).to eq({
         'en' => 'Place of residence has one of the following values: Brussels, somewhere else',
-        'fr-FR' => 'Domicile est un de: Bruxelles, quelque part d\'autre',
-        'nl-NL' => 'Woonplaats heeft een van de volgende waarden: Brussel, ergens anders'
+        'fr-BE' => 'Domicile est un de: Bruxelles, quelque part d\'autre',
+        'nl-BE' => 'Woonplaats heeft een van de volgende waarden: Brussel, ergens anders'
       })
       expect(lives_in_not_is_one_of_rule.description_multiloc).to eq({
         'en' => 'Place of residence does not have any of the follow values: Brussels',
-        'fr-FR' => 'Domicile n\'est pas un de: Bruxelles',
-        'nl-NL' => 'Woonplaats heeft geen van de volgende waarden: Brussel'
+        'fr-BE' => 'Domicile n\'est pas un de: Bruxelles',
+        'nl-BE' => 'Woonplaats heeft geen van de volgende waarden: Brussel'
       })
       expect(lives_in_is_empty_rule.description_multiloc).to eq({
         'en' => 'Place of residence has no value',
-        'fr-FR' => 'Domicile n\'as pas de value',
-        'nl-NL' => 'Woonplaats heeft geen waarde'
+        'fr-BE' => 'Domicile n\'as pas de value',
+        'nl-BE' => 'Woonplaats heeft geen waarde'
       })
       expect(lives_in_not_is_empty_rule.description_multiloc).to eq({
         'en' => 'Place of residence has any value',
-        'fr-FR' => 'Domicile peut avoir n\'importe quel value',
-        'nl-NL' => 'Woonplaats heeft om het even welke waarde'
+        'fr-BE' => 'Domicile peut avoir n\'importe quel value',
+        'nl-BE' => 'Woonplaats heeft om het even welke waarde'
       })
     end
   end

--- a/back/engines/commercial/smart_groups/spec/rules/participated_in_idea_status_spec.rb
+++ b/back/engines/commercial/smart_groups/spec/rules/participated_in_idea_status_spec.rb
@@ -127,15 +127,15 @@ describe SmartGroups::Rules::ParticipatedInIdeaStatus do
     let(:garbage_status) do
       create(:idea_status, title_multiloc: {
         'en' => 'in the garbage can',
-        'fr-FR' => 'dans la poubelle',
-        'nl-NL' => 'in de prullenmand'
+        'fr-BE' => 'dans la poubelle',
+        'nl-BE' => 'in de prullenmand'
       })
     end
     let(:delayed_status) do
       create(:idea_status, title_multiloc: {
         'en' => 'delayed',
-        'fr-FR' => 'retardé',
-        'nl-NL' => 'uitgesteld'
+        'fr-BE' => 'retardé',
+        'nl-BE' => 'uitgesteld'
       })
     end
 
@@ -213,53 +213,53 @@ describe SmartGroups::Rules::ParticipatedInIdeaStatus do
     it 'successfully translates different combinations of rules' do
       expect(participated_in_idea_status_in_rule.description_multiloc).to eq({
         'en' => 'Participation in an idea with one of the following statuses in the garbage can, delayed',
-        'fr-FR' => 'Participation dans une idée avec statut est un de dans la poubelle, retardé',
-        'nl-NL' => 'Participatie in een idee met één van de volgende statussen in de prullenmand, uitgesteld'
+        'fr-BE' => 'Participation dans une idée avec statut est un de dans la poubelle, retardé',
+        'nl-BE' => 'Participatie in een idee met één van de volgende statussen in de prullenmand, uitgesteld'
       })
       expect(participated_not_in_idea_status_in_rule.description_multiloc).to eq({
         'en' => 'No participation in an idea with status in the garbage can',
-        'fr-FR' => 'Pas de participation dans une idée avec statut dans la poubelle',
-        'nl-NL' => 'Geen participatie in een idea met status in de prullenmand'
+        'fr-BE' => 'Pas de participation dans une idée avec statut dans la poubelle',
+        'nl-BE' => 'Geen participatie in een idea met status in de prullenmand'
       })
       expect(participated_posted_in_idea_status_in_rule.description_multiloc).to eq({
         'en' => 'Posted an idea with one of the following statuses in the garbage can',
-        'fr-FR' => 'Posté une idée avec statut est un de dans la poubelle',
-        'nl-NL' => 'Plaatste een idee met één van de volgende statussen in de prullenmand'
+        'fr-BE' => 'Posté une idée avec statut est un de dans la poubelle',
+        'nl-BE' => 'Plaatste een idee met één van de volgende statussen in de prullenmand'
       })
       expect(participated_not_posted_in_idea_status_in_rule.description_multiloc).to eq({
         'en' => 'Did not post an idea with status in the garbage can',
-        'fr-FR' => 'N\'as pas posté une idée avec statut dans la poubelle',
-        'nl-NL' => 'Plaatste geen idee met status in de prullenmand'
+        'fr-BE' => 'N\'as pas posté une idée avec statut dans la poubelle',
+        'nl-BE' => 'Plaatste geen idee met status in de prullenmand'
       })
       expect(participated_commented_in_idea_status_in_rule.description_multiloc).to eq({
         'en' => 'Commented on an idea with one of the following statuses in the garbage can, delayed',
-        'fr-FR' => 'Commenté sur une idée avec statut est un de dans la poubelle, retardé',
-        'nl-NL' => 'Reageerde op een idee met één van de volgende statussen in de prullenmand, uitgesteld'
+        'fr-BE' => 'Commenté sur une idée avec statut est un de dans la poubelle, retardé',
+        'nl-BE' => 'Reageerde op een idee met één van de volgende statussen in de prullenmand, uitgesteld'
       })
       expect(participated_not_commented_in_idea_status_in_rule.description_multiloc).to eq({
         'en' => 'Did not comment on an idea with status in the garbage can',
-        'fr-FR' => 'N\'as pas commenté sur une idée avec statut dans la poubelle',
-        'nl-NL' => 'Reageerde niet op een idee met status in de prullenmand'
+        'fr-BE' => 'N\'as pas commenté sur une idée avec statut dans la poubelle',
+        'nl-BE' => 'Reageerde niet op een idee met status in de prullenmand'
       })
       expect(participated_voted_idea_in_idea_status_in_rule.description_multiloc).to eq({
         'en' => 'Voted on an idea with one of the following statuses in the garbage can',
-        'fr-FR' => 'Voté pour une idée avec statut est un de dans la poubelle',
-        'nl-NL' => 'Stemde op een idee met één van de volgende statussen in de prullenmand'
+        'fr-BE' => 'Voté pour une idée avec statut est un de dans la poubelle',
+        'nl-BE' => 'Stemde op een idee met één van de volgende statussen in de prullenmand'
       })
       expect(participated_not_voted_idea_in_idea_status_in_rule.description_multiloc).to eq({
         'en' => 'Did not vote on an idea with status in the garbage can',
-        'fr-FR' => 'N\'as pas voté pour une idée avec statut dans la poubelle',
-        'nl-NL' => 'Stemde niet op een idee met status in de prullenmand'
+        'fr-BE' => 'N\'as pas voté pour une idée avec statut dans la poubelle',
+        'nl-BE' => 'Stemde niet op een idee met status in de prullenmand'
       })
       expect(participated_voted_comment_in_idea_status_in_rule.description_multiloc).to eq({
         'en' => 'Voted on a comment on an idea with one of the following statuses in the garbage can, delayed',
-        'fr-FR' => 'Voté pour un commentaire sur une idée avec statut est un de dans la poubelle, retardé',
-        'nl-NL' => 'Stemde op een reactie op een idee met één van de volgende statussen in de prullenmand, uitgesteld'
+        'fr-BE' => 'Voté pour un commentaire sur une idée avec statut est un de dans la poubelle, retardé',
+        'nl-BE' => 'Stemde op een reactie op een idee met één van de volgende statussen in de prullenmand, uitgesteld'
       })
       expect(participated_not_voted_comment_in_idea_status_in_rule.description_multiloc).to eq({
         'en' => 'Did not vote on a comment on an idea with status in the garbage can',
-        'fr-FR' => 'N\'as pas voté pour un commentaire sur une idée avec statut dans la poubelle',
-        'nl-NL' => 'Stemde niet op een reactie op een idee met status in de prullenmand'
+        'fr-BE' => 'N\'as pas voté pour un commentaire sur une idée avec statut dans la poubelle',
+        'nl-BE' => 'Stemde niet op een reactie op een idee met status in de prullenmand'
       })
     end
   end

--- a/back/engines/commercial/smart_groups/spec/rules/participated_in_project_spec.rb
+++ b/back/engines/commercial/smart_groups/spec/rules/participated_in_project_spec.rb
@@ -150,15 +150,15 @@ describe SmartGroups::Rules::ParticipatedInProject do
     let(:project1) do
       create(:project, title_multiloc: {
         'en' => 'beer',
-        'fr-FR' => 'bière',
-        'nl-NL' => 'bier'
+        'fr-BE' => 'bière',
+        'nl-BE' => 'bier'
       })
     end
     let(:project2) do
       create(:project, title_multiloc: {
         'en' => 'delayed',
-        'fr-FR' => 'retardé',
-        'nl-NL' => 'uitgesteld'
+        'fr-BE' => 'retardé',
+        'nl-BE' => 'uitgesteld'
       })
     end
 
@@ -250,63 +250,63 @@ describe SmartGroups::Rules::ParticipatedInProject do
     it 'successfully translates different combinations of rules' do
       expect(participated_in_project_in_rule.description_multiloc).to eq({
         'en' => 'Participation in an idea in one of the following projects beer, delayed',
-        'fr-FR' => "Participation à une idée dans l'un des projets bière, retardé",
-        'nl-NL' => 'Participatie in een idee in een van de volgende projecten bier, uitgesteld'
+        'fr-BE' => "Participation à une idée dans l'un des projets bière, retardé",
+        'nl-BE' => 'Participatie in een idee in een van de volgende projecten bier, uitgesteld'
       })
       expect(participated_not_in_project_in_rule.description_multiloc).to eq({
         'en' => 'No participation in an idea in the project beer',
-        'fr-FR' => 'Pas de participation dans une idée dans le projet bière',
-        'nl-NL' => 'Geen participatie in een idee in het project bier'
+        'fr-BE' => 'Pas de participation dans une idée dans le projet bière',
+        'nl-BE' => 'Geen participatie in een idee in het project bier'
       })
       expect(participated_posted_in_project_in_rule.description_multiloc).to eq({
         'en' => 'Posted an idea in one of the following projects beer, delayed',
-        'fr-FR' => 'Posté une idée dans l\'un des projets bière, retardé',
-        'nl-NL' => 'Plaatste een idee in een van de volgende projecten bier, uitgesteld'
+        'fr-BE' => 'Posté une idée dans l\'un des projets bière, retardé',
+        'nl-BE' => 'Plaatste een idee in een van de volgende projecten bier, uitgesteld'
       })
       expect(participated_not_posted_in_project_in_rule.description_multiloc).to eq({
         'en' => 'Did not post an idea in the project beer',
-        'fr-FR' => 'N\'as pas posté une idée dans le projet bière',
-        'nl-NL' => 'Plaatste geen idee in het project bier'
+        'fr-BE' => 'N\'as pas posté une idée dans le projet bière',
+        'nl-BE' => 'Plaatste geen idee in het project bier'
       })
       expect(participated_commented_in_project_in_rule.description_multiloc).to eq({
         'en' => 'Commented on an idea in one of the following projects beer, delayed',
-        'fr-FR' => 'Commenté sur une idée dans l\'un des projets bière, retardé',
-        'nl-NL' => 'Reageerde op een idee in een van de volgende projecten bier, uitgesteld'
+        'fr-BE' => 'Commenté sur une idée dans l\'un des projets bière, retardé',
+        'nl-BE' => 'Reageerde op een idee in een van de volgende projecten bier, uitgesteld'
       })
       expect(participated_not_commented_in_project_in_rule.description_multiloc).to eq({
         'en' => 'Did not comment on an idea in the project beer',
-        'fr-FR' => 'N\'as pas commenté sur une idée dans le projet bière',
-        'nl-NL' => 'Reageerde niet op een idee in het project bier'
+        'fr-BE' => 'N\'as pas commenté sur une idée dans le projet bière',
+        'nl-BE' => 'Reageerde niet op een idee in het project bier'
       })
       expect(participated_voted_idea_in_project_in_rule.description_multiloc).to eq({
         'en' => 'Voted on an idea in one of the following projects beer, delayed',
-        'fr-FR' => 'Voté pour une idée dans l\'un des projets bière, retardé',
-        'nl-NL' => 'Stemde op een idee in een van de volgende projecten bier, uitgesteld'
+        'fr-BE' => 'Voté pour une idée dans l\'un des projets bière, retardé',
+        'nl-BE' => 'Stemde op een idee in een van de volgende projecten bier, uitgesteld'
       })
       expect(participated_not_voted_idea_in_project_in_rule.description_multiloc).to eq({
         'en' => 'Did not vote on an idea in the project beer',
-        'fr-FR' => 'N\'as pas voté pour une idée dans le projet bière',
-        'nl-NL' => 'Stemde niet op een idee in het project bier'
+        'fr-BE' => 'N\'as pas voté pour une idée dans le projet bière',
+        'nl-BE' => 'Stemde niet op een idee in het project bier'
       })
       expect(participated_voted_comment_in_project_in_rule.description_multiloc).to eq({
         'en' => 'Voted on a comment on an idea in one of the following projects beer, delayed',
-        'fr-FR' => 'Voté pour un commentaire sur une idée dans l\'un des projets bière, retardé',
-        'nl-NL' => 'Stemde op een reactie op een idee in een van de volgende projecten bier, uitgesteld'
+        'fr-BE' => 'Voté pour un commentaire sur une idée dans l\'un des projets bière, retardé',
+        'nl-BE' => 'Stemde op een reactie op een idee in een van de volgende projecten bier, uitgesteld'
       })
       expect(participated_not_voted_comment_in_project_in_rule.description_multiloc).to eq({
         'en' => 'Did not vote on a comment on an idea in the project beer',
-        'fr-FR' => 'N\'as pas voté pour un commentaire sur une idée dans le projet bière',
-        'nl-NL' => 'Stemde niet op een reactie op een idee in het project bier'
+        'fr-BE' => 'N\'as pas voté pour un commentaire sur une idée dans le projet bière',
+        'nl-BE' => 'Stemde niet op een reactie op een idee in het project bier'
       })
       expect(participated_budgeted_in_project_in_rule.description_multiloc).to eq({
         'en' => 'Assigned a budget in one of the following projects beer, delayed',
-        'fr-FR' => 'Dépensé un budget dans l\'un des projets bière, retardé',
-        'nl-NL' => 'Wees een budget toe in een van de volgende projecten bier, uitgesteld'
+        'fr-BE' => 'Dépensé un budget dans l\'un des projets bière, retardé',
+        'nl-BE' => 'Wees een budget toe in een van de volgende projecten bier, uitgesteld'
       })
       expect(participated_not_budgeted_in_project_in_rule.description_multiloc).to eq({
         'en' => 'Didn\'t assign a budget in the project beer',
-        'fr-FR' => 'N\'as pas dépensé un budget dans le projet bière',
-        'nl-NL' => 'Wees geen budget toe in het project bier'
+        'fr-BE' => 'N\'as pas dépensé un budget dans le projet bière',
+        'nl-BE' => 'Wees geen budget toe in het project bier'
       })
     end
   end

--- a/back/engines/commercial/smart_groups/spec/rules/participated_in_topic_spec.rb
+++ b/back/engines/commercial/smart_groups/spec/rules/participated_in_topic_spec.rb
@@ -128,15 +128,15 @@ describe SmartGroups::Rules::ParticipatedInTopic do
     let(:topic1) do
       create(:topic, title_multiloc: {
         'en' => 'beer',
-        'fr-FR' => 'bière',
-        'nl-NL' => 'bier'
+        'fr-BE' => 'bière',
+        'nl-BE' => 'bier'
       })
     end
     let(:topic2) do
       create(:topic, title_multiloc: {
         'en' => 'delayed',
-        'fr-FR' => 'retardé',
-        'nl-NL' => 'uitgesteld'
+        'fr-BE' => 'retardé',
+        'nl-BE' => 'uitgesteld'
       })
     end
 
@@ -214,53 +214,53 @@ describe SmartGroups::Rules::ParticipatedInTopic do
     it 'successfully translates different combinations of rules' do
       expect(participated_in_topic_in_rule.description_multiloc).to eq({
         'en' => 'Participation in an idea with one of the following topics beer, delayed',
-        'fr-FR' => 'Participation dans une idée avec thème est un de bière, retardé',
-        'nl-NL' => 'Participatie in een idee met één van de volgende thema bier, uitgesteld'
+        'fr-BE' => 'Participation dans une idée avec thème est un de bière, retardé',
+        'nl-BE' => 'Participatie in een idee met één van de volgende thema bier, uitgesteld'
       })
       expect(participated_not_in_topic_in_rule.description_multiloc).to eq({
         'en' => 'No participation in an idea with topic beer',
-        'fr-FR' => 'Pas de participation dans une idée avec thème bière',
-        'nl-NL' => 'Geen participatie in een idee met thema bier'
+        'fr-BE' => 'Pas de participation dans une idée avec thème bière',
+        'nl-BE' => 'Geen participatie in een idee met thema bier'
       })
       expect(participated_posted_in_topic_in_rule.description_multiloc).to eq({
         'en' => 'Posted an idea with one of the following topics beer',
-        'fr-FR' => 'Posté une idée avec thème est un de bière',
-        'nl-NL' => 'Plaatste een idee met één van de volgende thema bier'
+        'fr-BE' => 'Posté une idée avec thème est un de bière',
+        'nl-BE' => 'Plaatste een idee met één van de volgende thema bier'
       })
       expect(participated_not_posted_in_topic_in_rule.description_multiloc).to eq({
         'en' => 'Did not post an idea with topic beer',
-        'fr-FR' => 'N\'as pas posté une idée avec thème bière',
-        'nl-NL' => 'Plaatste geen idee met thema bier'
+        'fr-BE' => 'N\'as pas posté une idée avec thème bière',
+        'nl-BE' => 'Plaatste geen idee met thema bier'
       })
       expect(participated_commented_in_topic_in_rule.description_multiloc).to eq({
         'en' => 'Commented on an idea with one of the following topics beer, delayed',
-        'fr-FR' => 'Commenté sur une idée avec thème est un de bière, retardé',
-        'nl-NL' => 'Reageerde op een idee met één van de volgende thema bier, uitgesteld'
+        'fr-BE' => 'Commenté sur une idée avec thème est un de bière, retardé',
+        'nl-BE' => 'Reageerde op een idee met één van de volgende thema bier, uitgesteld'
       })
       expect(participated_not_commented_in_topic_in_rule.description_multiloc).to eq({
         'en' => 'Did not comment on an idea with topic beer',
-        'fr-FR' => 'N\'as pas commenté sur une idée avec thème bière',
-        'nl-NL' => 'Reageerde niet op een idee met thema bier'
+        'fr-BE' => 'N\'as pas commenté sur une idée avec thème bière',
+        'nl-BE' => 'Reageerde niet op een idee met thema bier'
       })
       expect(participated_voted_idea_in_topic_in_rule.description_multiloc).to eq({
         'en' => 'Voted on an idea with one of the following topics beer',
-        'fr-FR' => 'Voté pour une idée avec thème est un de bière',
-        'nl-NL' => 'Stemde op een idee met één van de volgende thema bier'
+        'fr-BE' => 'Voté pour une idée avec thème est un de bière',
+        'nl-BE' => 'Stemde op een idee met één van de volgende thema bier'
       })
       expect(participated_not_voted_idea_in_topic_in_rule.description_multiloc).to eq({
         'en' => 'Did not vote on an idea with topic beer',
-        'fr-FR' => 'N\'as pas voté pour une idée avec thème bière',
-        'nl-NL' => 'Stemde niet op een idee met thema bier'
+        'fr-BE' => 'N\'as pas voté pour une idée avec thème bière',
+        'nl-BE' => 'Stemde niet op een idee met thema bier'
       })
       expect(participated_voted_comment_in_topic_in_rule.description_multiloc).to eq({
         'en' => 'Voted on a comment on an idea with one of the following topics beer, delayed',
-        'fr-FR' => 'Voté pour un commentaire sur une idée avec thème est un de bière, retardé',
-        'nl-NL' => 'Stemde op een reactie op een idee met één van de volgende thema bier, uitgesteld'
+        'fr-BE' => 'Voté pour un commentaire sur une idée avec thème est un de bière, retardé',
+        'nl-BE' => 'Stemde op een reactie op een idee met één van de volgende thema bier, uitgesteld'
       })
       expect(participated_not_voted_comment_in_topic_in_rule.description_multiloc).to eq({
         'en' => 'Did not vote on a comment on an idea with topic beer',
-        'fr-FR' => 'N\'as pas voté pour un commentaire sur une idée avec thème bière',
-        'nl-NL' => 'Stemde niet op een reactie op een idee met thema bier'
+        'fr-BE' => 'N\'as pas voté pour un commentaire sur une idée avec thème bière',
+        'nl-BE' => 'Stemde niet op een reactie op een idee met thema bier'
       })
     end
   end

--- a/back/engines/commercial/smart_groups/spec/rules/registration_completed_at_spec.rb
+++ b/back/engines/commercial/smart_groups/spec/rules/registration_completed_at_spec.rb
@@ -96,28 +96,28 @@ describe SmartGroups::Rules::RegistrationCompletedAt do
     it 'successfully translates different combinations of rules' do
       expect(registration_completed_at_is_before_rule.description_multiloc).to eq({
         'en' => 'registration is before 2019-11-12',
-        'fr-FR' => 'date d\'inscription est avant 12/11/2019',
-        'nl-NL' => 'registratie is voor 12-11-2019'
+        'fr-BE' => 'date d\'inscription est avant 12/11/2019',
+        'nl-BE' => 'registratie is voor 12-11-2019'
       })
       expect(registration_completed_at_is_after_rule.description_multiloc).to eq({
         'en' => 'registration is after 2019-11-12',
-        'fr-FR' => 'date d\'inscription est après 12/11/2019',
-        'nl-NL' => 'registratie is na 12-11-2019'
+        'fr-BE' => 'date d\'inscription est après 12/11/2019',
+        'nl-BE' => 'registratie is na 12-11-2019'
       })
       expect(registration_completed_at_is_exactly_rule.description_multiloc).to eq({
         'en' => 'registration is 2019-11-12',
-        'fr-FR' => 'date d\'inscription est 12/11/2019',
-        'nl-NL' => 'registratie is 12-11-2019'
+        'fr-BE' => 'date d\'inscription est 12/11/2019',
+        'nl-BE' => 'registratie is 12-11-2019'
       })
       expect(registration_completed_at_is_empty_rule.description_multiloc).to eq({
         'en' => 'registration has no value',
-        'fr-FR' => 'date d\'inscription n\'as pas de value',
-        'nl-NL' => 'registratie heeft geen waarde'
+        'fr-BE' => 'date d\'inscription n\'as pas de value',
+        'nl-BE' => 'registratie heeft geen waarde'
       })
       expect(registration_completed_at_not_is_empty_rule.description_multiloc).to eq({
         'en' => 'registration has any value',
-        'fr-FR' => 'date d\'inscription peut avoir n\'importe quel value',
-        'nl-NL' => 'registratie heeft om het even welke waarde'
+        'fr-BE' => 'date d\'inscription peut avoir n\'importe quel value',
+        'nl-BE' => 'registratie heeft om het even welke waarde'
       })
     end
   end

--- a/back/engines/commercial/smart_groups/spec/rules/role_spec.rb
+++ b/back/engines/commercial/smart_groups/spec/rules/role_spec.rb
@@ -115,33 +115,33 @@ describe SmartGroups::Rules::Role do
 
       expect(role_is_admin_rule.description_multiloc).to eq({
         'en' => 'Role is admin',
-        'fr-FR' => 'Statut est administrateur',
-        'nl-NL' => 'Rol is beheerder'
+        'fr-BE' => 'Statut est administrateur',
+        'nl-BE' => 'Rol is beheerder'
       })
       expect(role_not_is_admin_rule.description_multiloc).to eq({
         'en' => 'Role is not admin',
-        'fr-FR' => 'Statut n\'est pas administrateur',
-        'nl-NL' => 'Rol is niet beheerder'
+        'fr-BE' => 'Statut n\'est pas administrateur',
+        'nl-BE' => 'Rol is niet beheerder'
       })
       expect(role_is_project_moderator_rule.description_multiloc).to eq({
         'en' => 'Role is project moderator',
-        'fr-FR' => 'Statut est modérateur de projet',
-        'nl-NL' => 'Rol is project moderator'
+        'fr-BE' => 'Statut est modérateur de projet',
+        'nl-BE' => 'Rol is project moderator'
       })
       expect(role_not_is_project_moderator_rule.description_multiloc).to eq({
         'en' => 'Role is not project moderator',
-        'fr-FR' => 'Statut n\'est pas modérateur de projet',
-        'nl-NL' => 'Rol is niet project moderator'
+        'fr-BE' => 'Statut n\'est pas modérateur de projet',
+        'nl-BE' => 'Rol is niet project moderator'
       })
       expect(role_is_normal_user_rule.description_multiloc).to eq({
         'en' => 'Role is normal user',
-        'fr-FR' => 'Statut est utilisateur normal',
-        'nl-NL' => 'Rol is gewone gebruiker'
+        'fr-BE' => 'Statut est utilisateur normal',
+        'nl-BE' => 'Rol is gewone gebruiker'
       })
       expect(role_not_is_normal_user_rule.description_multiloc).to eq({
         'en' => 'Role is not normal user',
-        'fr-FR' => 'Statut n\'est pas utilisateur normal',
-        'nl-NL' => 'Rol is niet gewone gebruiker'
+        'fr-BE' => 'Statut n\'est pas utilisateur normal',
+        'nl-BE' => 'Rol is niet gewone gebruiker'
       })
     end
   end

--- a/back/engines/free/email_campaigns/spec/mailers/user_digest_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/user_digest_mailer_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe EmailCampaigns::UserDigestMailer do
       let_it_be(:recipient1) { create(:user, locale: 'en') }
       let_it_be(:command1) { { recipient: recipient1, event_payload: event_payload } }
 
-      let_it_be(:recipient2) { create(:user, locale: 'nl-NL') }
+      let_it_be(:recipient2) { create(:user, locale: 'nl-BE') }
       let_it_be(:command2) { { recipient: recipient2, event_payload: event_payload } }
 
       let_it_be(:mail1) { described_class.with(command: command1, campaign: campaign).campaign_mail.deliver_now }

--- a/back/spec/acceptance/app_configurations_spec.rb
+++ b/back/spec/acceptance/app_configurations_spec.rb
@@ -78,7 +78,7 @@ resource 'AppConfigurations' do
       {
         'en' => 'TestTown',
         'nl-BE' => 'TestTown',
-        'fr-FR' => 'TestTown'
+        'fr-BE' => 'TestTown'
       }
     end
 

--- a/back/spec/acceptance/idea_comments_spec.rb
+++ b/back/spec/acceptance/idea_comments_spec.rb
@@ -327,7 +327,7 @@ resource 'Comments' do
       end
 
       describe do
-        let(:body_multiloc) { { 'fr-FR' => '' } }
+        let(:body_multiloc) { { 'fr-BE' => '' } }
 
         example_request '[error] Create an invalid comment' do
           assert_status 422

--- a/back/spec/acceptance/ideas_spec.rb
+++ b/back/spec/acceptance/ideas_spec.rb
@@ -609,8 +609,8 @@ resource 'Ideas' do
         json_response = json_parse response_body
         expect(json_response.dig(:data, :type)).to eq 'json_forms_schema'
         json_attributes = json_response.dig(:data, :attributes)
-        expect(json_attributes[:json_schema_multiloc].keys).to eq %i[en fr-FR nl-NL]
-        expect(json_attributes[:ui_schema_multiloc].keys).to eq %i[en fr-FR nl-NL]
+        expect(json_attributes[:json_schema_multiloc].keys).to eq %i[en fr-BE nl-BE]
+        expect(json_attributes[:ui_schema_multiloc].keys).to eq %i[en fr-BE nl-BE]
         visible_built_in_field_keys = %i[
           title_multiloc
           body_multiloc
@@ -619,7 +619,7 @@ resource 'Ideas' do
           topic_ids
           location_description
         ]
-        %i[en fr-FR nl-NL].each do |locale|
+        %i[en fr-BE nl-BE].each do |locale|
           expect(json_attributes[:json_schema_multiloc][locale][:properties].keys).to eq(visible_built_in_field_keys + [custom_field.key.to_sym])
         end
       end
@@ -847,7 +847,7 @@ resource 'Ideas' do
           before { SettingsService.new.activate_feature! 'blocking_profanity' }
 
           let(:title_multiloc) { { 'nl-BE' => 'Fuck' } }
-          let(:body_multiloc) { { 'fr-FR' => 'cocksucker' } }
+          let(:body_multiloc) { { 'fr-BE' => 'cocksucker' } }
 
           example_request '[error] Create an idea with blocked words' do
             assert_status 422

--- a/back/spec/acceptance/invites_spec.rb
+++ b/back/spec/acceptance/invites_spec.rb
@@ -184,7 +184,7 @@ resource 'Invites' do
         let(:emails) { Array.new(5) { Faker::Internet.email }.push(nil) }
         let(:group_ids) { [create(:group).id] }
         let(:project) { create(:project) }
-        let(:locale) { 'nl-NL' }
+        let(:locale) { 'nl-BE' }
         let(:invite_text) { 'Welcome, my friend!' }
 
         let(:roles) do
@@ -257,7 +257,7 @@ resource 'Invites' do
               email: user.email,
               first_name: rand(3) == 0 ? user.first_name : nil,
               last_name: rand(3) == 0 ? user.last_name : nil,
-              language: i == 0 ? 'nl-NL' : nil,
+              language: i == 0 ? 'nl-BE' : nil,
               admin: i == 0 ? true : nil,
               groups: i == 0 ? create(:group).title_multiloc.values.first : nil
             }
@@ -274,7 +274,7 @@ resource 'Invites' do
           expect(Invite.all.map { |i| i.invitee.email }).to match_array hash_array.pluck(:email)
           expect(Invite.all.map { |i| i.invitee.groups.map(&:id) }.flatten.uniq).to match_array Group.all.map(&:id)
           expect(Invite.all.map { |i| i.invitee.admin? }.uniq).to eq [true]
-          expect(Invite.all.map { |i| i.invitee.locale }.uniq).to match_array ['nl-NL', locale]
+          expect(Invite.all.map { |i| i.invitee.locale }.uniq).to match_array ['nl-BE', locale]
         end
       end
 
@@ -336,7 +336,7 @@ resource 'Invites' do
       let(:first_name) { 'Bart' }
       let(:last_name) { 'Boulettos' }
       let(:password) { 'I<3BouletteSpecial' }
-      let(:locale) { 'nl-NL' }
+      let(:locale) { 'nl-BE' }
 
       example_request 'Accept an invite' do
         assert_status(200)

--- a/back/spec/acceptance/nav_bar_items_spec.rb
+++ b/back/spec/acceptance/nav_bar_items_spec.rb
@@ -95,7 +95,7 @@ resource 'NavBarItems' do
           expect(json_response.dig(:data, :attributes, :ordering)).to eq 0
           expect(
             json_response.dig(:data, :attributes, :title_multiloc).stringify_keys
-          ).to match({ 'en' => 'Home', 'fr-FR' => 'Accueil', 'nl-NL' => 'Home' })
+          ).to match({ 'en' => 'Home', 'fr-BE' => 'Accueil', 'nl-BE' => 'Home' })
         end
       end
 
@@ -138,7 +138,7 @@ resource 'NavBarItems' do
       end
       ValidationErrorHelper.new.error_fields self, NavBarItem
 
-      let(:page) { create(:static_page, title_multiloc: { 'nl-NL' => 'Hoe deelnemen' }) }
+      let(:page) { create(:static_page, title_multiloc: { 'nl-BE' => 'Hoe deelnemen' }) }
       let(:item) { create(:nav_bar_item, static_page: page) }
       let(:id) { item.id }
       let(:title_multiloc) { { 'en' => 'How to participate' } }
@@ -147,7 +147,7 @@ resource 'NavBarItems' do
         expect(response_status).to eq 200
         json_response = json_parse response_body
 
-        expected_title = { 'en' => 'How to participate', 'nl-NL' => 'Hoe deelnemen' }
+        expected_title = { 'en' => 'How to participate', 'nl-BE' => 'Hoe deelnemen' }
         expect(json_response.dig(:data, :attributes, :title_multiloc).stringify_keys).to match expected_title
       end
     end

--- a/back/spec/acceptance/phase_custom_fields_spec.rb
+++ b/back/spec/acceptance/phase_custom_fields_spec.rb
@@ -18,12 +18,12 @@ resource 'Phase level Custom Fields' do
           additionalProperties: false,
           properties: {}
         },
-        'fr-FR': {
+        'fr-BE': {
           type: 'object',
           additionalProperties: false,
           properties: {}
         },
-        'nl-NL': {
+        'nl-BE': {
           type: 'object',
           additionalProperties: false,
           properties: {}
@@ -31,8 +31,8 @@ resource 'Phase level Custom Fields' do
       },
       ui_schema_multiloc: {
         en: { 'ui:order': [] },
-        'fr-FR': { 'ui:order': [] },
-        'nl-NL': { 'ui:order': [] }
+        'fr-BE': { 'ui:order': [] },
+        'nl-BE': { 'ui:order': [] }
       }
     }
   end
@@ -54,8 +54,8 @@ resource 'Phase level Custom Fields' do
         json_response = json_parse response_body
         expect(json_response.dig(:data, :type)).to eq 'json_forms_schema'
         json_attributes = json_response.dig(:data, :attributes)
-        expect(json_attributes[:json_schema_multiloc].keys).to match_array %i[en fr-FR nl-NL]
-        expect(json_attributes[:ui_schema_multiloc].keys).to match_array %i[en fr-FR nl-NL]
+        expect(json_attributes[:json_schema_multiloc].keys).to match_array %i[en fr-BE nl-BE]
+        expect(json_attributes[:ui_schema_multiloc].keys).to match_array %i[en fr-BE nl-BE]
         visible_built_in_field_keys = %i[
           title_multiloc
           body_multiloc
@@ -64,7 +64,7 @@ resource 'Phase level Custom Fields' do
           idea_images_attributes
           idea_files_attributes
         ]
-        %i[en fr-FR nl-NL].each do |locale|
+        %i[en fr-BE nl-BE].each do |locale|
           expect(json_attributes[:json_schema_multiloc][locale][:properties].keys).to match_array(visible_built_in_field_keys + [custom_field.key.to_sym])
         end
         ui_schema = json_attributes[:ui_schema_multiloc][:en]
@@ -88,11 +88,11 @@ resource 'Phase level Custom Fields' do
         json_response = json_parse response_body
         expect(json_response.dig(:data, :type)).to eq 'json_forms_schema'
         json_attributes = json_response.dig(:data, :attributes)
-        expect(json_attributes[:json_schema_multiloc].keys).to match_array %i[en fr-FR nl-NL]
-        %i[en fr-FR nl-NL].each do |locale|
+        expect(json_attributes[:json_schema_multiloc].keys).to match_array %i[en fr-BE nl-BE]
+        %i[en fr-BE nl-BE].each do |locale|
           expect(json_attributes[:json_schema_multiloc][locale][:properties].keys).to match_array([custom_field.key.to_sym])
         end
-        expect(json_attributes[:ui_schema_multiloc].keys).to match_array %i[en fr-FR nl-NL]
+        expect(json_attributes[:ui_schema_multiloc].keys).to match_array %i[en fr-BE nl-BE]
       end
     end
   end

--- a/back/spec/acceptance/phases_spec.rb
+++ b/back/spec/acceptance/phases_spec.rb
@@ -177,8 +177,8 @@ resource 'Phases' do
           expect(field2.input_type).to eq 'select'
           expect(field2.title_multiloc).to match({
             'en' => an_instance_of(String),
-            'fr-FR' => an_instance_of(String),
-            'nl-NL' => an_instance_of(String)
+            'fr-BE' => an_instance_of(String),
+            'nl-BE' => an_instance_of(String)
           })
           options = field2.options
           expect(options.size).to eq 2
@@ -186,13 +186,13 @@ resource 'Phases' do
           expect(options[1].key).to eq 'option2'
           expect(options[0].title_multiloc).to match({
             'en' => an_instance_of(String),
-            'fr-FR' => an_instance_of(String),
-            'nl-NL' => an_instance_of(String)
+            'fr-BE' => an_instance_of(String),
+            'nl-BE' => an_instance_of(String)
           })
           expect(options[1].title_multiloc).to match({
             'en' => an_instance_of(String),
-            'fr-FR' => an_instance_of(String),
-            'nl-NL' => an_instance_of(String)
+            'fr-BE' => an_instance_of(String),
+            'nl-BE' => an_instance_of(String)
           })
 
           expect(phase_in_db.participation_method).to eq 'native_survey'

--- a/back/spec/acceptance/project_custom_fields_spec.rb
+++ b/back/spec/acceptance/project_custom_fields_spec.rb
@@ -18,12 +18,12 @@ resource 'Project level Custom Fields' do
           additionalProperties: false,
           properties: {}
         },
-        'fr-FR': {
+        'fr-BE': {
           type: 'object',
           additionalProperties: false,
           properties: {}
         },
-        'nl-NL': {
+        'nl-BE': {
           type: 'object',
           additionalProperties: false,
           properties: {}
@@ -31,8 +31,8 @@ resource 'Project level Custom Fields' do
       },
       ui_schema_multiloc: {
         en: { 'ui:order': [] },
-        'fr-FR': { 'ui:order': [] },
-        'nl-NL': { 'ui:order': [] }
+        'fr-BE': { 'ui:order': [] },
+        'nl-BE': { 'ui:order': [] }
       }
     }
   end
@@ -51,8 +51,8 @@ resource 'Project level Custom Fields' do
         json_response = json_parse response_body
         expect(json_response.dig(:data, :type)).to eq 'json_forms_schema'
         json_attributes = json_response.dig(:data, :attributes)
-        expect(json_attributes[:json_schema_multiloc].keys).to match_array %i[en fr-FR nl-NL]
-        %i[en fr-FR nl-NL].each do |locale|
+        expect(json_attributes[:json_schema_multiloc].keys).to match_array %i[en fr-BE nl-BE]
+        %i[en fr-BE nl-BE].each do |locale|
           expect(json_attributes[:json_schema_multiloc][locale][:properties].keys).to match_array(
             %i[title_multiloc body_multiloc topic_ids location_description idea_images_attributes idea_files_attributes]
           )
@@ -62,7 +62,7 @@ resource 'Project level Custom Fields' do
         expect(ui_schema[:type]).to eq 'Categorization'
         expect(ui_schema[:options]).to eq({ formId: 'idea-form', inputTerm: 'question' })
         expect(ui_schema[:elements].size).to eq 3
-        expect(json_attributes[:ui_schema_multiloc].keys).to match_array %i[en fr-FR nl-NL]
+        expect(json_attributes[:ui_schema_multiloc].keys).to match_array %i[en fr-BE nl-BE]
       end
     end
   end
@@ -94,11 +94,11 @@ resource 'Project level Custom Fields' do
         json_response = json_parse response_body
         expect(json_response.dig(:data, :type)).to eq 'json_forms_schema'
         json_attributes = json_response.dig(:data, :attributes)
-        expect(json_attributes[:json_schema_multiloc].keys).to match_array %i[en fr-FR nl-NL]
-        %i[en fr-FR nl-NL].each do |locale|
+        expect(json_attributes[:json_schema_multiloc].keys).to match_array %i[en fr-BE nl-BE]
+        %i[en fr-BE nl-BE].each do |locale|
           expect(json_attributes[:json_schema_multiloc][locale][:properties].keys).to match_array expected_json_forms_field_keys
         end
-        expect(json_attributes[:ui_schema_multiloc].keys).to match_array %i[en fr-FR nl-NL]
+        expect(json_attributes[:ui_schema_multiloc].keys).to match_array %i[en fr-BE nl-BE]
       end
     end
   end
@@ -130,11 +130,11 @@ resource 'Project level Custom Fields' do
         json_response = json_parse response_body
         expect(json_response.dig(:data, :type)).to eq 'json_forms_schema'
         json_attributes = json_response.dig(:data, :attributes)
-        expect(json_attributes[:json_schema_multiloc].keys).to match_array %i[en fr-FR nl-NL]
-        %i[en fr-FR nl-NL].each do |locale|
+        expect(json_attributes[:json_schema_multiloc].keys).to match_array %i[en fr-BE nl-BE]
+        %i[en fr-BE nl-BE].each do |locale|
           expect(json_attributes[:json_schema_multiloc][locale][:properties].keys).to match_array expected_json_forms_field_keys
         end
-        expect(json_attributes[:ui_schema_multiloc].keys).to match_array %i[en fr-FR nl-NL]
+        expect(json_attributes[:ui_schema_multiloc].keys).to match_array %i[en fr-BE nl-BE]
       end
     end
   end
@@ -151,11 +151,11 @@ resource 'Project level Custom Fields' do
         json_response = json_parse response_body
         expect(json_response.dig(:data, :type)).to eq 'json_forms_schema'
         json_attributes = json_response.dig(:data, :attributes)
-        expect(json_attributes[:json_schema_multiloc].keys).to match_array %i[en fr-FR nl-NL]
-        %i[en fr-FR nl-NL].each do |locale|
+        expect(json_attributes[:json_schema_multiloc].keys).to match_array %i[en fr-BE nl-BE]
+        %i[en fr-BE nl-BE].each do |locale|
           expect(json_attributes[:json_schema_multiloc][locale][:properties].keys).to match_array([custom_field.key.to_sym])
         end
-        expect(json_attributes[:ui_schema_multiloc].keys).to match_array %i[en fr-FR nl-NL]
+        expect(json_attributes[:ui_schema_multiloc].keys).to match_array %i[en fr-BE nl-BE]
       end
     end
   end

--- a/back/spec/acceptance/projects_spec.rb
+++ b/back/spec/acceptance/projects_spec.rb
@@ -432,8 +432,8 @@ resource 'Projects' do
           field2 = project_in_db.custom_form.custom_fields[1]
           expect(field2.title_multiloc).to match({
             'en' => an_instance_of(String),
-            'fr-FR' => an_instance_of(String),
-            'nl-NL' => an_instance_of(String)
+            'fr-BE' => an_instance_of(String),
+            'nl-BE' => an_instance_of(String)
           })
           options = field2.options
           expect(options.size).to eq 2
@@ -441,13 +441,13 @@ resource 'Projects' do
           expect(options[1].key).to eq 'option2'
           expect(options[0].title_multiloc).to match({
             'en' => an_instance_of(String),
-            'fr-FR' => an_instance_of(String),
-            'nl-NL' => an_instance_of(String)
+            'fr-BE' => an_instance_of(String),
+            'nl-BE' => an_instance_of(String)
           })
           expect(options[1].title_multiloc).to match({
             'en' => an_instance_of(String),
-            'fr-FR' => an_instance_of(String),
-            'nl-NL' => an_instance_of(String)
+            'fr-BE' => an_instance_of(String),
+            'nl-BE' => an_instance_of(String)
           })
 
           expect(project_in_db.process_type).to eq 'continuous'

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -1077,7 +1077,7 @@ resource 'Users' do
           let(:first_name) { 'Raymond' }
           let(:last_name) { 'Betancourt' }
           let(:email) { 'ray.mond@rocks.com' }
-          let(:locale) { 'fr-FR' }
+          let(:locale) { 'fr-BE' }
           let(:birthyear) { 1969 }
 
           example "Can't change some attributes of a user verified with FranceConnect", document: false do

--- a/back/spec/factories/app_configurations.rb
+++ b/back/spec/factories/app_configurations.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
   factory :app_configuration do
     transient do
       lifecycle { 'active' }
-      locales { %w[en nl-BE fr-FR] }
+      locales { %w[en nl-BE fr-BE] }
     end
 
     host { 'localhost' }
@@ -21,7 +21,7 @@ FactoryBot.define do
           'organization_name' => {
             'en' => Faker::Address.city,
             'nl-BE' => Faker::Address.city,
-            'fr-FR' => Faker::Address.city
+            'fr-BE' => Faker::Address.city
           },
           'lifecycle_stage' => lifecycle,
           'timezone' => 'Europe/Brussels',
@@ -39,10 +39,10 @@ FactoryBot.define do
           'days_limit' => 90,
           'threshold_reached_message' =>
             MultilocService.new.i18n_to_multiloc('initiatives.default_threshold_reached_message',
-              locales: %i[en nl-BE fr-FR]),
+              locales: %i[en nl-BE fr-BE]),
           'eligibility_criteria' =>
             MultilocService.new.i18n_to_multiloc('initiatives.default_eligibility_criteria',
-              locales: %i[en nl-BE fr-FR])
+              locales: %i[en nl-BE fr-BE])
         }
       }
     end
@@ -60,11 +60,11 @@ FactoryBot.define do
           'organization_type' => 'medium_city',
           'organization_name' => {
             'en' => 'Liege',
-            'nl-NL' => 'Luik',
-            'fr-FR' => 'Liege'
+            'nl-BE' => 'Luik',
+            'fr-BE' => 'Liege'
           },
           'lifecycle_stage' => 'active',
-          'locales' => %w[en fr-FR nl-NL],
+          'locales' => %w[en fr-BE nl-BE],
           'timezone' => 'Europe/Brussels',
           'currency' => 'EUR',
           'color_main' => '#335533',
@@ -81,10 +81,10 @@ FactoryBot.define do
           'days_limit' => 90,
           'threshold_reached_message' =>
             MultilocService.new.i18n_to_multiloc('initiatives.default_threshold_reached_message',
-              locales: %i[en nl-BE fr-FR]),
+              locales: %i[en nl-BE fr-BE]),
           'eligibility_criteria' =>
             MultilocService.new.i18n_to_multiloc('initiatives.default_eligibility_criteria',
-              locales: %i[en nl-BE fr-FR])
+              locales: %i[en nl-BE fr-BE])
         }
       }
     end

--- a/back/spec/factories/custom_field_options.rb
+++ b/back/spec/factories/custom_field_options.rb
@@ -7,8 +7,8 @@ FactoryBot.define do
     title_multiloc do
       {
         'en' => 'youth council',
-        'fr-FR' => 'conseil des jeunes',
-        'nl-NL' => 'jeugdraad'
+        'fr-BE' => 'conseil des jeunes',
+        'nl-BE' => 'jeugdraad'
       }
     end
   end

--- a/back/spec/lib/omniauth_methods/google_spec.rb
+++ b/back/spec/lib/omniauth_methods/google_spec.rb
@@ -16,7 +16,7 @@ describe OmniauthMethods::Google do
         extra: OpenStruct.new({
           raw_info: OpenStruct.new({
             gender: 'female',
-            locale: 'fr-FR'
+            locale: 'fr-BE'
           })
         })
       })
@@ -25,7 +25,7 @@ describe OmniauthMethods::Google do
       user_attrs = subject.profile_to_user_attrs(auth)
 
       expect(user_attrs).to include({
-        locale: 'fr-FR',
+        locale: 'fr-BE',
         gender: 'female',
         remote_avatar_url: 'http://www.josnet.com/my-picture'
       })

--- a/back/spec/lib/participation_method/native_survey_spec.rb
+++ b/back/spec/lib/participation_method/native_survey_spec.rb
@@ -52,8 +52,8 @@ RSpec.describe ParticipationMethod::NativeSurvey do
       field = participation_context_in_db.custom_form.custom_fields[1]
       expect(field.title_multiloc).to match({
         'en' => 'Default question',
-        'fr-FR' => 'Question par défaut',
-        'nl-NL' => 'Standaardvraag'
+        'fr-BE' => 'Question par défaut',
+        'nl-BE' => 'Standaardvraag'
       })
       expect(field.description_multiloc).to eq({})
       options = field.options
@@ -62,13 +62,13 @@ RSpec.describe ParticipationMethod::NativeSurvey do
       expect(options[1].key).to eq 'option2'
       expect(options[0].title_multiloc).to match({
         'en' => 'First option',
-        'fr-FR' => 'Première option',
-        'nl-NL' => 'Eerste optie'
+        'fr-BE' => 'Première option',
+        'nl-BE' => 'Eerste optie'
       })
       expect(options[1].title_multiloc).to match({
         'en' => 'Second option',
-        'fr-FR' => 'Deuxième option',
-        'nl-NL' => 'Tweede optie'
+        'fr-BE' => 'Deuxième option',
+        'nl-BE' => 'Tweede optie'
       })
     end
   end

--- a/back/spec/mailers/confirmations_mailer_spec.rb
+++ b/back/spec/mailers/confirmations_mailer_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe ConfirmationsMailer do
 
   describe 'when sent to users with a different locale set for each' do
     let_it_be(:recipient1) { create(:user, locale: 'en') }
-    let_it_be(:recipient2) { create(:user, locale: 'nl-NL') }
+    let_it_be(:recipient2) { create(:user, locale: 'nl-BE') }
 
     let_it_be(:mail1) { described_class.with(user: recipient1).send_confirmation_code.deliver_now }
     let_it_be(:mail2) { described_class.with(user: recipient2).send_confirmation_code.deliver_now }

--- a/back/spec/mailers/reset_password_mailer_spec.rb
+++ b/back/spec/mailers/reset_password_mailer_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe ResetPasswordMailer do
 
   describe 'when sent to users with a different locale set for each' do
     let_it_be(:recipient1) { create(:user, locale: 'en') }
-    let_it_be(:recipient2) { create(:user, locale: 'nl-NL') }
+    let_it_be(:recipient2) { create(:user, locale: 'nl-BE') }
     let_it_be(:url) { 'https://example.com' }
 
     let_it_be(:mail1) { described_class.with(user: recipient1, password_reset_url: url).send_reset_password.deliver_now }

--- a/back/spec/mailers/user_blocked_mailer_spec.rb
+++ b/back/spec/mailers/user_blocked_mailer_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe UserBlockedMailer do
 
   describe 'when sent to users with a different locale set for each' do
     let_it_be(:recipient1) { create(:user, block_end_at: 5.days.from_now, locale: 'en') }
-    let_it_be(:recipient2) { create(:user, block_end_at: 5.days.from_now, locale: 'nl-NL') }
+    let_it_be(:recipient2) { create(:user, block_end_at: 5.days.from_now, locale: 'nl-BE') }
 
     let_it_be(:mail1) { described_class.with(user: recipient1).send_user_blocked_email.deliver_now }
     let_it_be(:mail2) { described_class.with(user: recipient2).send_user_blocked_email.deliver_now }

--- a/back/spec/models/nav_bar_item_spec.rb
+++ b/back/spec/models/nav_bar_item_spec.rb
@@ -13,20 +13,20 @@ RSpec.describe NavBarItem do
     context 'with default items' do
       it "falls back to the translations when there's no title_multiloc" do
         item = create(:nav_bar_item, code: 'home', title_multiloc: nil)
-        expect(item.title_multiloc_with_fallback).to match({ 'en' => 'Home', 'fr-FR' => 'Accueil', 'nl-NL' => 'Home' })
+        expect(item.title_multiloc_with_fallback).to match({ 'en' => 'Home', 'fr-BE' => 'Accueil', 'nl-BE' => 'Home' })
       end
 
       it 'returns the custom copy for locales with custom copy and falls back to the translations for other locales' do
-        item = create(:nav_bar_item, code: 'home', title_multiloc: { 'nl-NL' => 'Thuis' })
-        expect(item.title_multiloc_with_fallback).to match({ 'en' => 'Home', 'fr-FR' => 'Accueil', 'nl-NL' => 'Thuis' })
+        item = create(:nav_bar_item, code: 'home', title_multiloc: { 'nl-BE' => 'Thuis' })
+        expect(item.title_multiloc_with_fallback).to match({ 'en' => 'Home', 'fr-BE' => 'Accueil', 'nl-BE' => 'Thuis' })
       end
     end
 
     context 'with custom items' do
       it 'returns the custom copy for locales with custom copy and falls back to the page title for other locales' do
-        page = create(:static_page, title_multiloc: { 'en' => 'How to take part', 'fr-FR' => 'Comment participer' })
+        page = create(:static_page, title_multiloc: { 'en' => 'How to take part', 'fr-BE' => 'Comment participer' })
         item = create(:nav_bar_item, static_page: page, title_multiloc: { 'en' => 'How to participate' })
-        expected_title = { 'en' => 'How to participate', 'fr-FR' => 'Comment participer' }
+        expected_title = { 'en' => 'How to participate', 'fr-BE' => 'Comment participer' }
         expect(item.title_multiloc_with_fallback).to match expected_title
       end
     end

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -318,7 +318,7 @@ RSpec.describe User do
   describe 'locale' do
     before do
       settings = AppConfiguration.instance.settings
-      settings['core']['locales'] = %w[en nl-BE fr-FR]
+      settings['core']['locales'] = %w[en nl-BE fr-BE]
       AppConfiguration.instance.update!(settings: settings)
     end
 

--- a/back/spec/requests/google_authentication_spec.rb
+++ b/back/spec/requests/google_authentication_spec.rb
@@ -113,9 +113,9 @@ describe 'google authentication' do
       get '/auth/google?random-passthrough-param=somevalue'
       follow_redirect!
 
-      # Expect the redirect URL to include the locale ('nl-NL') from Tenant locales that includes
+      # Expect the redirect URL to include the locale ('nl-BE') from Tenant locales that includes
       # the locale code in the mock omniauth response ('nl')
-      expect(response).to redirect_to('/nl-NL/complete-signup?random-passthrough-param=somevalue')
+      expect(response).to redirect_to('/nl-BE/complete-signup?random-passthrough-param=somevalue')
 
       user = User.find_by(email: 'boris.brompton@orange.uk')
 
@@ -123,7 +123,7 @@ describe 'google authentication' do
         first_name: 'Boris',
         last_name: 'Brompton',
         email: 'boris.brompton@orange.uk',
-        locale: 'nl-NL'
+        locale: 'nl-BE'
       })
       expect(user.identities.first).to have_attributes({
         provider: 'google',
@@ -133,18 +133,18 @@ describe 'google authentication' do
     end
 
     it 'uses previously selected locale appropriately' do
-      get '/auth/google?sso_pathname=/fr-FR/some-page'
+      get '/auth/google?sso_pathname=/fr-BE/some-page'
       follow_redirect!
 
-      # Expect the redirect URL to include the locale ('fr-FR') of the previously selected locale,
+      # Expect the redirect URL to include the locale ('fr-BE') of the previously selected locale,
       # which should be preferred over any locale deduced from the locale in the omniauth response ('nl')
       # Note: '%2F' is the URL-safe encoding of an ASCII '/' character
-      expect(response).to redirect_to('/fr-FR/complete-signup?sso_pathname=%2Ffr-FR%2Fsome-page')
+      expect(response).to redirect_to('/fr-BE/complete-signup?sso_pathname=%2Ffr-BE%2Fsome-page')
 
       user = User.find_by(email: 'boris.brompton@orange.uk')
 
       expect(user).to have_attributes({
-        locale: 'fr-FR'
+        locale: 'fr-BE'
       })
     end
 
@@ -152,15 +152,15 @@ describe 'google authentication' do
       get '/auth/google?sso_pathname=/en/some-page'
       follow_redirect!
 
-      # Expect the redirect URL to include the locale ('nl-NL') from Tenant locales that includes
+      # Expect the redirect URL to include the locale ('nl-BE') from Tenant locales that includes
       # the locale code in the mock omniauth response ('nl')
       # Because the 'selected' locale is the default, we cannot be sure anything was actively selected.
-      expect(response).to redirect_to('/nl-NL/complete-signup?sso_pathname=%2Fen%2Fsome-page')
+      expect(response).to redirect_to('/nl-BE/complete-signup?sso_pathname=%2Fen%2Fsome-page')
 
       user = User.find_by(email: 'boris.brompton@orange.uk')
 
       expect(user).to have_attributes({
-        locale: 'nl-NL'
+        locale: 'nl-BE'
       })
     end
   end
@@ -171,15 +171,15 @@ describe 'google authentication' do
     get '/auth/google?random-passthrough-param=somevalue'
     follow_redirect!
 
-    # Expect the redirect url to include the locale ('nl-NL') from Tenant locales that includes
+    # Expect the redirect url to include the locale ('nl-BE') from Tenant locales that includes
     # the locale code in the mock omniauth response ('nl')
-    expect(response).to redirect_to('/nl-NL/complete-signup?random-passthrough-param=somevalue')
+    expect(response).to redirect_to('/nl-BE/complete-signup?random-passthrough-param=somevalue')
 
     expect(user.reload).to have_attributes({
       first_name: 'Boris',
       last_name: 'Brompton',
       email: 'boris.brompton@orange.uk',
-      locale: 'nl-NL',
+      locale: 'nl-BE',
       invite_status: 'accepted'
     })
     expect(user.identities.first).to have_attributes({

--- a/back/spec/serializers/web_api/v1/static_page_serializer_spec.rb
+++ b/back/spec/serializers/web_api/v1/static_page_serializer_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe WebApi::V1::StaticPageSerializer do
   context 'nav_bar_item_title_multiloc' do
     it 'corresponds to the nav bar item title, if the nav bar item exists' do
-      expected_title = { 'en' => 'Fallback title', 'fr-FR' => 'Titre de remplacement' }
+      expected_title = { 'en' => 'Fallback title', 'fr-BE' => 'Titre de remplacement' }
       page = create(:static_page)
       create(:nav_bar_item, code: 'custom', static_page: page)
       expect(page.reload.nav_bar_item).to receive(:title_multiloc_with_fallback).and_return(expected_title)
@@ -15,7 +15,7 @@ describe WebApi::V1::StaticPageSerializer do
     end
 
     it 'corresponds to what the nav bar item title will look like, if no nav bar item exists' do
-      expected_title = { 'en' => 'Fallback title', 'nl-NL' => 'Vervangingstitel' }
+      expected_title = { 'en' => 'Fallback title', 'nl-BE' => 'Vervangingstitel' }
       page = create(:static_page, code: 'custom', title_multiloc: expected_title)
 
       serialized_output = described_class.new(page).serializable_hash

--- a/back/spec/services/custom_field_service_spec.rb
+++ b/back/spec/services/custom_field_service_spec.rb
@@ -18,8 +18,8 @@ describe CustomFieldService do
   end
 
   describe 'fields_to_json_schema_multiloc' do
-    let(:title_multiloc) { { 'en' => 'size', 'nl-NL' => 'grootte' } }
-    let(:description_multiloc) { { 'en' => 'How big is it?', 'nl-NL' => 'Hoe groot is het?' } }
+    let(:title_multiloc) { { 'en' => 'size', 'nl-BE' => 'grootte' } }
+    let(:description_multiloc) { { 'en' => 'How big is it?', 'nl-BE' => 'Hoe groot is het?' } }
     let(:fields) do
       [
         create(:custom_field,
@@ -33,9 +33,9 @@ describe CustomFieldService do
     it 'creates localized schemas with titles and descriptions for all languages' do
       schema = service.fields_to_json_schema_multiloc(AppConfiguration.instance, fields)
       expect(schema['en'][:properties]['field1'][:title]).to eq title_multiloc['en']
-      expect(schema['nl-NL'][:properties]['field1'][:title]).to eq title_multiloc['nl-NL']
+      expect(schema['nl-BE'][:properties]['field1'][:title]).to eq title_multiloc['nl-BE']
       expect(schema['en'][:properties]['field1'][:description]).to eq description_multiloc['en']
-      expect(schema['nl-NL'][:properties]['field1'][:description]).to eq description_multiloc['nl-NL']
+      expect(schema['nl-BE'][:properties]['field1'][:description]).to eq description_multiloc['nl-BE']
     end
   end
 

--- a/back/spec/services/input_json_schema_generator_service_spec.rb
+++ b/back/spec/services/input_json_schema_generator_service_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe InputJsonSchemaGeneratorService do
               minProperties: 1,
               properties: {
                 'en' => { type: 'string', minLength: 10, maxLength: 80 },
-                'fr-FR' => { type: 'string', minLength: 10, maxLength: 80 },
-                'nl-NL' => { type: 'string', minLength: 10, maxLength: 80 }
+                'fr-BE' => { type: 'string', minLength: 10, maxLength: 80 },
+                'nl-BE' => { type: 'string', minLength: 10, maxLength: 80 }
               }
             },
             'body_multiloc' => {
@@ -34,8 +34,8 @@ RSpec.describe InputJsonSchemaGeneratorService do
               minProperties: 1,
               properties: {
                 'en' => { type: 'string', minLength: 40 },
-                'fr-FR' => { type: 'string', minLength: 40 },
-                'nl-NL' => { type: 'string', minLength: 40 }
+                'fr-BE' => { type: 'string', minLength: 40 },
+                'nl-BE' => { type: 'string', minLength: 40 }
               }
             },
             'topic_ids' => {
@@ -86,8 +86,8 @@ RSpec.describe InputJsonSchemaGeneratorService do
               minProperties: 1,
               properties: {
                 'en' => { type: 'string', minLength: 10, maxLength: 80 },
-                'fr-FR' => { type: 'string', minLength: 10, maxLength: 80 },
-                'nl-NL' => { type: 'string', minLength: 10, maxLength: 80 }
+                'fr-BE' => { type: 'string', minLength: 10, maxLength: 80 },
+                'nl-BE' => { type: 'string', minLength: 10, maxLength: 80 }
               }
             },
             'body_multiloc' => {
@@ -95,8 +95,8 @@ RSpec.describe InputJsonSchemaGeneratorService do
               minProperties: 1,
               properties: {
                 'en' => { type: 'string', minLength: 40 },
-                'fr-FR' => { type: 'string', minLength: 40 },
-                'nl-NL' => { type: 'string', minLength: 40 }
+                'fr-BE' => { type: 'string', minLength: 40 },
+                'nl-BE' => { type: 'string', minLength: 40 }
               }
             },
             'topic_ids' => {
@@ -148,12 +148,12 @@ RSpec.describe InputJsonSchemaGeneratorService do
               minLength: 10,
               maxLength: 80
             },
-            'fr-FR' => {
+            'fr-BE' => {
               type: 'string',
               minLength: 10,
               maxLength: 80
             },
-            'nl-NL' => {
+            'nl-BE' => {
               type: 'string',
               minLength: 10,
               maxLength: 80
@@ -172,8 +172,8 @@ RSpec.describe InputJsonSchemaGeneratorService do
           minProperties: 1,
           properties: {
             'en' => { type: 'string' },
-            'fr-FR' => { type: 'string' },
-            'nl-NL' => { type: 'string' }
+            'fr-BE' => { type: 'string' },
+            'nl-BE' => { type: 'string' }
           }
         })
       end
@@ -193,11 +193,11 @@ RSpec.describe InputJsonSchemaGeneratorService do
               type: 'string',
               minLength: 40
             },
-            'fr-FR' => {
+            'fr-BE' => {
               type: 'string',
               minLength: 40
             },
-            'nl-NL' => {
+            'nl-BE' => {
               type: 'string',
               minLength: 40
             }
@@ -215,8 +215,8 @@ RSpec.describe InputJsonSchemaGeneratorService do
           minProperties: 1,
           properties: {
             'en' => { type: 'string' },
-            'fr-FR' => { type: 'string' },
-            'nl-NL' => { type: 'string' }
+            'fr-BE' => { type: 'string' },
+            'nl-BE' => { type: 'string' }
           }
         })
       end

--- a/back/spec/services/input_ui_schema_generator_service_spec.rb
+++ b/back/spec/services/input_ui_schema_generator_service_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe InputUiSchemaGeneratorService do
         let!(:custom_form) do
           create(:custom_form, :with_default_fields, participation_context: project).tap do |form|
             form.custom_fields.find_by(code: 'title_multiloc').update!(
-              description_multiloc: { 'en' => 'My title description', 'nl-NL' => 'Mijn titel beschrijving' }
+              description_multiloc: { 'en' => 'My title description', 'nl-BE' => 'Mijn titel beschrijving' }
             )
           end
         end
@@ -34,13 +34,13 @@ RSpec.describe InputUiSchemaGeneratorService do
             resource: custom_form,
             title_multiloc: {
               'en' => 'Extra fields',
-              # No 'nl-NL' to describe that it will default to 'en'.
-              'fr-FR' => 'Extra choses'
+              # No 'nl-BE' to describe that it will default to 'en'.
+              'fr-BE' => 'Extra choses'
             },
             description_multiloc: {
               'en' => 'Custom stuff',
-              # No 'nl-NL' to describe that it will default to 'en'.
-              'fr-FR' => 'Des choses en plus'
+              # No 'nl-BE' to describe that it will default to 'en'.
+              'fr-BE' => 'Des choses en plus'
             }
           )
         end
@@ -53,19 +53,19 @@ RSpec.describe InputUiSchemaGeneratorService do
             key: 'extra_field',
             title_multiloc: {
               'en' => 'Extra field title',
-              'nl-NL' => 'Extra veldtitel'
-              # No 'fr-FR' to describe that it will default to 'en'.
+              'nl-BE' => 'Extra veldtitel'
+              # No 'fr-BE' to describe that it will default to 'en'.
             },
             description_multiloc: {
               'en' => 'Extra field description',
-              'nl-NL' => 'Extra veldbeschrijving'
-              # No 'fr-FR' to describe that it will default to 'en'.
+              'nl-BE' => 'Extra veldbeschrijving'
+              # No 'fr-BE' to describe that it will default to 'en'.
             }
           )
         end
 
         it 'returns the schema for the given fields' do
-          expect(ui_schema.keys).to match_array %w[en fr-FR nl-NL]
+          expect(ui_schema.keys).to match_array %w[en fr-BE nl-BE]
           # en
           expect(ui_schema['en']).to eq(
             type: 'Categorization',
@@ -101,27 +101,27 @@ RSpec.describe InputUiSchemaGeneratorService do
                       },
                       {
                         type: 'Control',
-                        scope: '#/properties/title_multiloc/properties/fr-FR',
+                        scope: '#/properties/title_multiloc/properties/fr-BE',
                         label: 'Title',
                         options: {
                           answer_visible_to: 'public',
                           description: 'My title description',
                           isAdminField: false,
                           hasRule: false,
-                          locale: 'fr-FR',
+                          locale: 'fr-BE',
                           trim_on_blur: true
                         }
                       },
                       {
                         type: 'Control',
-                        scope: '#/properties/title_multiloc/properties/nl-NL',
+                        scope: '#/properties/title_multiloc/properties/nl-BE',
                         label: 'Title',
                         options: {
                           answer_visible_to: 'public',
                           description: 'My title description',
                           isAdminField: false,
                           hasRule: false,
-                          locale: 'nl-NL',
+                          locale: 'nl-BE',
                           trim_on_blur: true
                         }
                       }
@@ -146,7 +146,7 @@ RSpec.describe InputUiSchemaGeneratorService do
                       },
                       {
                         type: 'Control',
-                        scope: '#/properties/body_multiloc/properties/fr-FR',
+                        scope: '#/properties/body_multiloc/properties/fr-BE',
                         label: 'Description',
                         options: {
                           answer_visible_to: 'public',
@@ -154,12 +154,12 @@ RSpec.describe InputUiSchemaGeneratorService do
                           isAdminField: false,
                           hasRule: false,
                           render: 'WYSIWYG',
-                          locale: 'fr-FR'
+                          locale: 'fr-BE'
                         }
                       },
                       {
                         type: 'Control',
-                        scope: '#/properties/body_multiloc/properties/nl-NL',
+                        scope: '#/properties/body_multiloc/properties/nl-BE',
                         label: 'Description',
                         options: {
                           answer_visible_to: 'public',
@@ -167,7 +167,7 @@ RSpec.describe InputUiSchemaGeneratorService do
                           isAdminField: false,
                           hasRule: false,
                           render: 'WYSIWYG',
-                          locale: 'nl-NL'
+                          locale: 'nl-BE'
                         }
                       }
                     ]
@@ -268,28 +268,28 @@ RSpec.describe InputUiSchemaGeneratorService do
                       },
                       {
                         type: 'Control',
-                        scope: '#/properties/extra_field/properties/fr-FR',
+                        scope: '#/properties/extra_field/properties/fr-BE',
                         label: 'Extra field title',
                         options: {
                           answer_visible_to: 'admins',
                           description: 'Extra field description',
                           isAdminField: false,
                           hasRule: false,
-                          locale: 'fr-FR',
+                          locale: 'fr-BE',
                           render: 'WYSIWYG',
                           trim_on_blur: true
                         }
                       },
                       {
                         type: 'Control',
-                        scope: '#/properties/extra_field/properties/nl-NL',
+                        scope: '#/properties/extra_field/properties/nl-BE',
                         label: 'Extra field title',
                         options: {
                           answer_visible_to: 'admins',
                           description: 'Extra field description',
                           isAdminField: false,
                           hasRule: false,
-                          locale: 'nl-NL',
+                          locale: 'nl-BE',
                           render: 'WYSIWYG',
                           trim_on_blur: true
                         }
@@ -300,8 +300,8 @@ RSpec.describe InputUiSchemaGeneratorService do
               }
             ]
           )
-          # fr-FR
-          expect(ui_schema['fr-FR']).to match(
+          # fr-BE
+          expect(ui_schema['fr-BE']).to match(
             type: 'Categorization',
             options: {
               formId: 'idea-form',
@@ -322,14 +322,14 @@ RSpec.describe InputUiSchemaGeneratorService do
                         options: hash_including(locale: 'en')
                       ),
                       hash_including(
-                        scope: '#/properties/title_multiloc/properties/fr-FR',
+                        scope: '#/properties/title_multiloc/properties/fr-BE',
                         label: 'Titre',
-                        options: hash_including(locale: 'fr-FR')
+                        options: hash_including(locale: 'fr-BE')
                       ),
                       hash_including(
-                        scope: '#/properties/title_multiloc/properties/nl-NL',
+                        scope: '#/properties/title_multiloc/properties/nl-BE',
                         label: 'Titre',
-                        options: hash_including(locale: 'nl-NL')
+                        options: hash_including(locale: 'nl-BE')
                       )
                     ]
                   ),
@@ -343,14 +343,14 @@ RSpec.describe InputUiSchemaGeneratorService do
                         options: hash_including(locale: 'en', render: 'WYSIWYG')
                       ),
                       hash_including(
-                        scope: '#/properties/body_multiloc/properties/fr-FR',
+                        scope: '#/properties/body_multiloc/properties/fr-BE',
                         label: 'Description',
-                        options: hash_including(locale: 'fr-FR', render: 'WYSIWYG')
+                        options: hash_including(locale: 'fr-BE', render: 'WYSIWYG')
                       ),
                       hash_including(
-                        scope: '#/properties/body_multiloc/properties/nl-NL',
+                        scope: '#/properties/body_multiloc/properties/nl-BE',
                         label: 'Description',
-                        options: hash_including(locale: 'nl-NL', render: 'WYSIWYG')
+                        options: hash_including(locale: 'nl-BE', render: 'WYSIWYG')
                       )
                     ]
                   )
@@ -409,15 +409,15 @@ RSpec.describe InputUiSchemaGeneratorService do
                       ),
                       hash_including(
                         type: 'Control',
-                        scope: '#/properties/extra_field/properties/fr-FR',
+                        scope: '#/properties/extra_field/properties/fr-BE',
                         label: 'Extra field title',
-                        options: hash_including(description: 'Extra field description', locale: 'fr-FR', render: 'WYSIWYG')
+                        options: hash_including(description: 'Extra field description', locale: 'fr-BE', render: 'WYSIWYG')
                       ),
                       hash_including(
                         type: 'Control',
-                        scope: '#/properties/extra_field/properties/nl-NL',
+                        scope: '#/properties/extra_field/properties/nl-BE',
                         label: 'Extra field title',
-                        options: hash_including(description: 'Extra field description', locale: 'nl-NL', render: 'WYSIWYG')
+                        options: hash_including(description: 'Extra field description', locale: 'nl-BE', render: 'WYSIWYG')
                       )
                     ]
                   )
@@ -425,8 +425,8 @@ RSpec.describe InputUiSchemaGeneratorService do
               )
             ]
           )
-          # nl-NL
-          expect(ui_schema['nl-NL']).to match(
+          # nl-BE
+          expect(ui_schema['nl-BE']).to match(
             type: 'Categorization',
             options: {
               formId: 'idea-form',
@@ -447,14 +447,14 @@ RSpec.describe InputUiSchemaGeneratorService do
                         options: hash_including(locale: 'en', description: 'Mijn titel beschrijving')
                       ),
                       hash_including(
-                        scope: '#/properties/title_multiloc/properties/fr-FR',
+                        scope: '#/properties/title_multiloc/properties/fr-BE',
                         label: 'Titel',
-                        options: hash_including(locale: 'fr-FR', description: 'Mijn titel beschrijving')
+                        options: hash_including(locale: 'fr-BE', description: 'Mijn titel beschrijving')
                       ),
                       hash_including(
-                        scope: '#/properties/title_multiloc/properties/nl-NL',
+                        scope: '#/properties/title_multiloc/properties/nl-BE',
                         label: 'Titel',
-                        options: hash_including(locale: 'nl-NL', description: 'Mijn titel beschrijving')
+                        options: hash_including(locale: 'nl-BE', description: 'Mijn titel beschrijving')
                       )
                     ]
                   ),
@@ -468,14 +468,14 @@ RSpec.describe InputUiSchemaGeneratorService do
                         options: hash_including(locale: 'en', render: 'WYSIWYG')
                       ),
                       hash_including(
-                        scope: '#/properties/body_multiloc/properties/fr-FR',
+                        scope: '#/properties/body_multiloc/properties/fr-BE',
                         label: 'Beschrijving',
-                        options: hash_including(locale: 'fr-FR', render: 'WYSIWYG')
+                        options: hash_including(locale: 'fr-BE', render: 'WYSIWYG')
                       ),
                       hash_including(
-                        scope: '#/properties/body_multiloc/properties/nl-NL',
+                        scope: '#/properties/body_multiloc/properties/nl-BE',
                         label: 'Beschrijving',
-                        options: hash_including(locale: 'nl-NL', render: 'WYSIWYG')
+                        options: hash_including(locale: 'nl-BE', render: 'WYSIWYG')
                       )
                     ]
                   )
@@ -534,15 +534,15 @@ RSpec.describe InputUiSchemaGeneratorService do
                       ),
                       hash_including(
                         type: 'Control',
-                        scope: '#/properties/extra_field/properties/fr-FR',
+                        scope: '#/properties/extra_field/properties/fr-BE',
                         label: 'Extra veldtitel',
-                        options: hash_including(description: 'Extra veldbeschrijving', locale: 'fr-FR', render: 'WYSIWYG')
+                        options: hash_including(description: 'Extra veldbeschrijving', locale: 'fr-BE', render: 'WYSIWYG')
                       ),
                       hash_including(
                         type: 'Control',
-                        scope: '#/properties/extra_field/properties/nl-NL',
+                        scope: '#/properties/extra_field/properties/nl-BE',
                         label: 'Extra veldtitel',
-                        options: hash_including(description: 'Extra veldbeschrijving', locale: 'nl-NL', render: 'WYSIWYG')
+                        options: hash_including(description: 'Extra veldbeschrijving', locale: 'nl-BE', render: 'WYSIWYG')
                       )
                     ]
                   )
@@ -566,7 +566,7 @@ RSpec.describe InputUiSchemaGeneratorService do
         end
 
         it 'returns the schema for the given fields' do
-          expect(ui_schema.keys).to match_array %w[en fr-FR nl-NL]
+          expect(ui_schema.keys).to match_array %w[en fr-BE nl-BE]
           expect(ui_schema['en']).to match(
             type: 'Categorization',
             options: {
@@ -589,7 +589,7 @@ RSpec.describe InputUiSchemaGeneratorService do
         let(:custom_form) { create(:custom_form, participation_context: project) }
 
         it 'returns the schema for the default fields' do
-          expect(ui_schema.keys).to match_array %w[en fr-FR nl-NL]
+          expect(ui_schema.keys).to match_array %w[en fr-BE nl-BE]
           expect(ui_schema['en']).to match(
             type: 'Categorization',
             options: {
@@ -611,14 +611,14 @@ RSpec.describe InputUiSchemaGeneratorService do
                         options: hash_including(locale: 'en')
                       ),
                       hash_including(
-                        scope: '#/properties/title_multiloc/properties/fr-FR',
+                        scope: '#/properties/title_multiloc/properties/fr-BE',
                         label: 'Title',
-                        options: hash_including(locale: 'fr-FR')
+                        options: hash_including(locale: 'fr-BE')
                       ),
                       hash_including(
-                        scope: '#/properties/title_multiloc/properties/nl-NL',
+                        scope: '#/properties/title_multiloc/properties/nl-BE',
                         label: 'Title',
-                        options: hash_including(locale: 'nl-NL')
+                        options: hash_including(locale: 'nl-BE')
                       )
                     ]
                   ),
@@ -632,14 +632,14 @@ RSpec.describe InputUiSchemaGeneratorService do
                         options: hash_including(locale: 'en', render: 'WYSIWYG')
                       ),
                       hash_including(
-                        scope: '#/properties/body_multiloc/properties/fr-FR',
+                        scope: '#/properties/body_multiloc/properties/fr-BE',
                         label: 'Description',
-                        options: hash_including(locale: 'fr-FR', render: 'WYSIWYG')
+                        options: hash_including(locale: 'fr-BE', render: 'WYSIWYG')
                       ),
                       hash_including(
-                        scope: '#/properties/body_multiloc/properties/nl-NL',
+                        scope: '#/properties/body_multiloc/properties/nl-BE',
                         label: 'Description',
-                        options: hash_including(locale: 'nl-NL', render: 'WYSIWYG')
+                        options: hash_including(locale: 'nl-BE', render: 'WYSIWYG')
                       )
                     ]
                   )
@@ -1179,13 +1179,13 @@ RSpec.describe InputUiSchemaGeneratorService do
           key: field_key,
           title_multiloc: {
             'en' => 'Body multiloc field title',
-            'nl-NL' => 'Body multiloc veldtitel'
-            # No 'fr-FR' to describe that it will default to 'en'.
+            'nl-BE' => 'Body multiloc veldtitel'
+            # No 'fr-BE' to describe that it will default to 'en'.
           },
           description_multiloc: {
             'en' => 'Body multiloc field description',
-            'nl-NL' => 'Body multiloc veldbeschrijving'
-            # No 'fr-FR' to describe that it will default to 'en'.
+            'nl-BE' => 'Body multiloc veldbeschrijving'
+            # No 'fr-BE' to describe that it will default to 'en'.
           }
         )
       end
@@ -1210,32 +1210,32 @@ RSpec.describe InputUiSchemaGeneratorService do
               },
               {
                 type: 'Control',
-                scope: "#/properties/#{field_key}/properties/fr-FR",
+                scope: "#/properties/#{field_key}/properties/fr-BE",
                 label: 'Body multiloc field title',
                 options: {
                   description: 'Body multiloc field description',
                   isAdminField: false,
                   hasRule: false,
                   render: 'WYSIWYG',
-                  locale: 'fr-FR'
+                  locale: 'fr-BE'
                 }
               },
               {
                 type: 'Control',
-                scope: "#/properties/#{field_key}/properties/nl-NL",
+                scope: "#/properties/#{field_key}/properties/nl-BE",
                 label: 'Body multiloc field title',
                 options: {
                   description: 'Body multiloc field description',
                   isAdminField: false,
                   hasRule: false,
                   render: 'WYSIWYG',
-                  locale: 'nl-NL'
+                  locale: 'nl-BE'
                 }
               }
             ]
           })
         end
-        I18n.with_locale('fr-FR') do
+        I18n.with_locale('fr-BE') do
           expect(generator.visit_html_multiloc(field)).to eq({
             type: 'VerticalLayout',
             options: { input_type: field.input_type, render: 'multiloc' },
@@ -1254,32 +1254,32 @@ RSpec.describe InputUiSchemaGeneratorService do
               },
               {
                 type: 'Control',
-                scope: "#/properties/#{field_key}/properties/fr-FR",
+                scope: "#/properties/#{field_key}/properties/fr-BE",
                 label: 'Body multiloc field title',
                 options: {
                   description: 'Body multiloc field description',
                   isAdminField: false,
                   hasRule: false,
                   render: 'WYSIWYG',
-                  locale: 'fr-FR'
+                  locale: 'fr-BE'
                 }
               },
               {
                 type: 'Control',
-                scope: "#/properties/#{field_key}/properties/nl-NL",
+                scope: "#/properties/#{field_key}/properties/nl-BE",
                 label: 'Body multiloc field title',
                 options: {
                   description: 'Body multiloc field description',
                   isAdminField: false,
                   hasRule: false,
                   render: 'WYSIWYG',
-                  locale: 'nl-NL'
+                  locale: 'nl-BE'
                 }
               }
             ]
           })
         end
-        I18n.with_locale('nl-NL') do
+        I18n.with_locale('nl-BE') do
           expect(generator.visit_html_multiloc(field)).to eq({
             type: 'VerticalLayout',
             options: { input_type: field.input_type, render: 'multiloc' },
@@ -1298,26 +1298,26 @@ RSpec.describe InputUiSchemaGeneratorService do
               },
               {
                 type: 'Control',
-                scope: "#/properties/#{field_key}/properties/fr-FR",
+                scope: "#/properties/#{field_key}/properties/fr-BE",
                 label: 'Body multiloc veldtitel',
                 options: {
                   description: 'Body multiloc veldbeschrijving',
                   isAdminField: false,
                   hasRule: false,
                   render: 'WYSIWYG',
-                  locale: 'fr-FR'
+                  locale: 'fr-BE'
                 }
               },
               {
                 type: 'Control',
-                scope: "#/properties/#{field_key}/properties/nl-NL",
+                scope: "#/properties/#{field_key}/properties/nl-BE",
                 label: 'Body multiloc veldtitel',
                 options: {
                   description: 'Body multiloc veldbeschrijving',
                   isAdminField: false,
                   hasRule: false,
                   render: 'WYSIWYG',
-                  locale: 'nl-NL'
+                  locale: 'nl-BE'
                 }
               }
             ]
@@ -1357,7 +1357,7 @@ RSpec.describe InputUiSchemaGeneratorService do
             },
             {
               type: 'Control',
-              scope: "#/properties/#{field_key}/properties/fr-FR",
+              scope: "#/properties/#{field_key}/properties/fr-BE",
               label: 'HTML multiloc field title',
               options: {
                 description: 'HTML multiloc field description',
@@ -1365,12 +1365,12 @@ RSpec.describe InputUiSchemaGeneratorService do
                 hasRule: false,
                 render: 'WYSIWYG',
                 trim_on_blur: true,
-                locale: 'fr-FR'
+                locale: 'fr-BE'
               }
             },
             {
               type: 'Control',
-              scope: "#/properties/#{field_key}/properties/nl-NL",
+              scope: "#/properties/#{field_key}/properties/nl-BE",
               label: 'HTML multiloc field title',
               options: {
                 description: 'HTML multiloc field description',
@@ -1378,7 +1378,7 @@ RSpec.describe InputUiSchemaGeneratorService do
                 hasRule: false,
                 render: 'WYSIWYG',
                 trim_on_blur: true,
-                locale: 'nl-NL'
+                locale: 'nl-BE'
               }
             }
           ]

--- a/back/spec/services/invites/service_spec.rb
+++ b/back/spec/services/invites/service_spec.rb
@@ -243,8 +243,8 @@ describe Invites::Service do
           :custom_field,
           key: 'text_field',
           input_type: 'text',
-          title_multiloc: { 'en' => 'size', 'nl-NL' => 'grootte' },
-          description_multiloc: { 'en' => 'How big is it?', 'nl-NL' => 'Hoe groot is het?' }
+          title_multiloc: { 'en' => 'size', 'nl-BE' => 'grootte' },
+          description_multiloc: { 'en' => 'How big is it?', 'nl-BE' => 'Hoe groot is het?' }
         )
         create(
           :custom_field,

--- a/back/spec/services/json_forms_service_spec.rb
+++ b/back/spec/services/json_forms_service_spec.rb
@@ -10,8 +10,8 @@ describe JsonFormsService do
 
   context 'registration fields' do
     describe 'fields_to_ui_schema_multiloc' do
-      let(:title_multiloc) { { 'en' => 'size', 'nl-NL' => 'grootte' } }
-      let(:description_multiloc) { { 'en' => 'How big is it?', 'nl-NL' => 'Hoe groot is het?' } }
+      let(:title_multiloc) { { 'en' => 'size', 'nl-BE' => 'grootte' } }
+      let(:description_multiloc) { { 'en' => 'How big is it?', 'nl-BE' => 'Hoe groot is het?' } }
       let(:fields) do
         [
 
@@ -26,9 +26,9 @@ describe JsonFormsService do
       it 'creates localized schemas with titles and descriptions for all languages' do
         ui_schema = service.user_ui_and_json_multiloc_schemas(fields)[:ui_schema_multiloc]
         expect(ui_schema['en'][:elements][0][:label]).to eq title_multiloc['en']
-        expect(ui_schema['nl-NL'][:elements][0][:label]).to eq title_multiloc['nl-NL']
+        expect(ui_schema['nl-BE'][:elements][0][:label]).to eq title_multiloc['nl-BE']
         expect(ui_schema['en'][:elements][0][:options][:description]).to eq description_multiloc['en']
-        expect(ui_schema['nl-NL'][:elements][0][:options][:description]).to eq description_multiloc['nl-NL']
+        expect(ui_schema['nl-BE'][:elements][0][:options][:description]).to eq description_multiloc['nl-BE']
       end
     end
 

--- a/back/spec/services/json_schema_generator_service_spec.rb
+++ b/back/spec/services/json_schema_generator_service_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe JsonSchemaGeneratorService do
             }
           }
         },
-        'fr-FR' => {
+        'fr-BE' => {
           type: 'object',
           additionalProperties: false,
           properties: {
@@ -55,7 +55,7 @@ RSpec.describe JsonSchemaGeneratorService do
             }
           }
         },
-        'nl-NL' => {
+        'nl-BE' => {
           type: 'object',
           additionalProperties: false,
           properties: {
@@ -128,8 +128,8 @@ RSpec.describe JsonSchemaGeneratorService do
         minProperties: 1,
         properties: {
           'en' => { type: 'string' },
-          'fr-FR' => { type: 'string' },
-          'nl-NL' => { type: 'string' }
+          'fr-BE' => { type: 'string' },
+          'nl-BE' => { type: 'string' }
         }
       })
     end
@@ -144,8 +144,8 @@ RSpec.describe JsonSchemaGeneratorService do
         minProperties: 1,
         properties: {
           'en' => { type: 'string' },
-          'fr-FR' => { type: 'string' },
-          'nl-NL' => { type: 'string' }
+          'fr-BE' => { type: 'string' },
+          'nl-BE' => { type: 'string' }
         }
       })
     end
@@ -160,8 +160,8 @@ RSpec.describe JsonSchemaGeneratorService do
         minProperties: 1,
         properties: {
           'en' => { type: 'string' },
-          'fr-FR' => { type: 'string' },
-          'nl-NL' => { type: 'string' }
+          'fr-BE' => { type: 'string' },
+          'nl-BE' => { type: 'string' }
         }
       })
     end

--- a/back/spec/services/local_project_copy_service_spec.rb
+++ b/back/spec/services/local_project_copy_service_spec.rb
@@ -6,12 +6,12 @@ describe LocalProjectCopyService do
   let(:service) { described_class.new }
 
   describe 'project copy' do
-    # Some factories use en & nl-NL multilocs, others use en & nl-BE, but the apply_template method, invoked by the
+    # Some factories use en & nl-BE multilocs, others use en & nl-BE, but the apply_template method, invoked by the
     # LocalProjectCopyService, will only apply multiloc k-v pairs with keys that match the target tenant locale(s).
     # Thus, we specify all 3 locales to enable easier testing with factory generated multilocs.
     before_all do
       config = AppConfiguration.instance
-      config.settings['core']['locales'] = %w[en nl-BE nl-NL]
+      config.settings['core']['locales'] = %w[en nl-BE nl-BE]
       config.save!
     end
 

--- a/back/spec/services/localization_service_spec.rb
+++ b/back/spec/services/localization_service_spec.rb
@@ -18,7 +18,7 @@ describe LocalizationService do
     end
 
     it 'returns the correct format for French speaking locales' do
-      locales = %w[fr-FR fr-BE]
+      locales = %w[fr-BE fr-BE]
 
       locales.each do |locale|
         I18n.with_locale(locale) do

--- a/back/spec/services/multiloc_service_spec.rb
+++ b/back/spec/services/multiloc_service_spec.rb
@@ -7,7 +7,7 @@ describe MultilocService do
 
   before do
     settings = AppConfiguration.instance.settings
-    settings['core']['locales'] = %w[fr-FR en nl-BE]
+    settings['core']['locales'] = %w[fr-BE en nl-BE]
     AppConfiguration.instance.update(settings: settings)
   end
 
@@ -16,7 +16,7 @@ describe MultilocService do
     let(:translations) do
       {
         'nl-BE' => 'woord',
-        'fr-FR' => 'mot',
+        'fr-BE' => 'mot',
         'en' => 'word'
       }
     end
@@ -72,7 +72,7 @@ describe MultilocService do
           hello: 'hallo!'
         }
       })
-      I18n.backend.store_translations(:'fr-FR', {
+      I18n.backend.store_translations(:'fr-BE', {
         foo: {
           hello: 'bonjour!'
         }
@@ -83,7 +83,7 @@ describe MultilocService do
       expect(service.i18n_to_multiloc('foo.hello')).to eq({
         'en' => 'hello!',
         'nl-BE' => 'hallo!',
-        'fr-FR' => 'bonjour!'
+        'fr-BE' => 'bonjour!'
       })
     end
 
@@ -92,9 +92,9 @@ describe MultilocService do
     end
 
     it 'supports setting the returned locales explicitly' do
-      expect(service.i18n_to_multiloc('foo.hello', locales: %w[en fr-FR])).to eq({
+      expect(service.i18n_to_multiloc('foo.hello', locales: %w[en fr-BE])).to eq({
         'en' => 'hello!',
-        'fr-FR' => 'bonjour!'
+        'fr-BE' => 'bonjour!'
       })
     end
   end
@@ -102,7 +102,7 @@ describe MultilocService do
   describe 'block_to_multiloc' do
     it 'assembles a multiloc object with a given block' do
       expect(service.block_to_multiloc { |locale| locale }).to eq({
-        'fr-FR' => 'fr-FR',
+        'fr-BE' => 'fr-BE',
         'en' => 'en',
         'nl-BE' => 'nl-BE'
       })
@@ -110,7 +110,7 @@ describe MultilocService do
 
     it 'switches the i18n.locale in the given block' do
       expect(service.block_to_multiloc { |_locale| I18n.locale.to_s }).to eq({
-        'fr-FR' => 'fr-FR',
+        'fr-BE' => 'fr-BE',
         'en' => 'en',
         'nl-BE' => 'nl-BE'
       })
@@ -127,7 +127,7 @@ describe MultilocService do
     end
 
     it 'returns false on a multiloc with values' do
-      expect(service.empty?({ en: 'yes', 'nl-NL' => '' })).to be false
+      expect(service.empty?({ en: 'yes', 'nl-BE' => '' })).to be false
     end
   end
 end

--- a/back/spec/services/survey_results_generator_service_spec.rb
+++ b/back/spec/services/survey_results_generator_service_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe SurveyResultsGeneratorService do
       resource: form,
       title_multiloc: {
         'en' => 'What are your favourite pets?',
-        'fr-FR' => 'Quels sont vos animaux de compagnie préférés ?',
-        'nl-NL' => 'Wat zijn je favoriete huisdieren?'
+        'fr-BE' => 'Quels sont vos animaux de compagnie préférés ?',
+        'nl-BE' => 'Wat zijn je favoriete huisdieren?'
       },
       description_multiloc: {},
       required: false
@@ -53,7 +53,7 @@ RSpec.describe SurveyResultsGeneratorService do
       :custom_field_option,
       custom_field: multiselect_field,
       key: 'cat',
-      title_multiloc: { 'en' => 'Cat', 'fr-FR' => 'Chat', 'nl-NL' => 'Kat' }
+      title_multiloc: { 'en' => 'Cat', 'fr-BE' => 'Chat', 'nl-BE' => 'Kat' }
     )
   end
   let!(:dog_option) do
@@ -61,7 +61,7 @@ RSpec.describe SurveyResultsGeneratorService do
       :custom_field_option,
       custom_field: multiselect_field,
       key: 'dog',
-      title_multiloc: { 'en' => 'Dog', 'fr-FR' => 'Chien', 'nl-NL' => 'Hond' }
+      title_multiloc: { 'en' => 'Dog', 'fr-BE' => 'Chien', 'nl-BE' => 'Hond' }
     )
   end
   let!(:cow_option) do
@@ -69,7 +69,7 @@ RSpec.describe SurveyResultsGeneratorService do
       :custom_field_option,
       custom_field: multiselect_field,
       key: 'cow',
-      title_multiloc: { 'en' => 'Cow', 'fr-FR' => 'Vache', 'nl-NL' => 'Koe' }
+      title_multiloc: { 'en' => 'Cow', 'fr-BE' => 'Vache', 'nl-BE' => 'Koe' }
     )
   end
   let!(:pig_option) do
@@ -77,21 +77,21 @@ RSpec.describe SurveyResultsGeneratorService do
       :custom_field_option,
       custom_field: multiselect_field,
       key: 'pig',
-      title_multiloc: { 'en' => 'Pig', 'fr-FR' => 'Porc', 'nl-NL' => 'Varken' }
+      title_multiloc: { 'en' => 'Pig', 'fr-BE' => 'Porc', 'nl-BE' => 'Varken' }
     )
   end
   let(:minimum_label_multiloc) do
     {
       'en' => 'Strongly disagree',
-      'fr-FR' => "Pas du tout d'accord",
-      'nl-NL' => 'Helemaal niet mee eens'
+      'fr-BE' => "Pas du tout d'accord",
+      'nl-BE' => 'Helemaal niet mee eens'
     }
   end
   let(:maximum_label_multiloc) do
     {
       'en' => 'Strongly agree',
-      'fr-FR' => "Tout à fait d'accord",
-      'nl-NL' => 'Strerk mee eens'
+      'fr-BE' => "Tout à fait d'accord",
+      'nl-BE' => 'Strerk mee eens'
     }
   end
   let!(:linear_scale_field) do
@@ -100,8 +100,8 @@ RSpec.describe SurveyResultsGeneratorService do
       resource: form,
       title_multiloc: {
         'en' => 'Do you agree with the vision?',
-        'fr-FR' => "Êtes-vous d'accord avec la vision ?",
-        'nl-NL' => 'Ben je het eens met de visie?'
+        'fr-BE' => "Êtes-vous d'accord avec la vision ?",
+        'nl-BE' => 'Ben je het eens met de visie?'
       },
       maximum: 5,
       minimum_label_multiloc: minimum_label_multiloc,
@@ -115,8 +115,8 @@ RSpec.describe SurveyResultsGeneratorService do
       resource: form,
       title_multiloc: {
         'en' => 'What city do you like best?',
-        'fr-FR' => 'Quelle ville préférez-vous ?',
-        'nl-NL' => 'Welke stad vind jij het leukst?'
+        'fr-BE' => 'Quelle ville préférez-vous ?',
+        'nl-BE' => 'Welke stad vind jij het leukst?'
       },
       description_multiloc: {},
       required: true
@@ -127,7 +127,7 @@ RSpec.describe SurveyResultsGeneratorService do
       :custom_field_option,
       custom_field: select_field,
       key: 'la',
-      title_multiloc: { 'en' => 'Los Angeles', 'fr-FR' => 'Los Angeles', 'nl-NL' => 'Los Angeles' }
+      title_multiloc: { 'en' => 'Los Angeles', 'fr-BE' => 'Los Angeles', 'nl-BE' => 'Los Angeles' }
     )
   end
   let!(:ny_option) do
@@ -135,7 +135,7 @@ RSpec.describe SurveyResultsGeneratorService do
       :custom_field_option,
       custom_field: select_field,
       key: 'ny',
-      title_multiloc: { 'en' => 'New York', 'fr-FR' => 'New York', 'nl-NL' => 'New York' }
+      title_multiloc: { 'en' => 'New York', 'fr-BE' => 'New York', 'nl-BE' => 'New York' }
     )
   end
 
@@ -147,24 +147,24 @@ RSpec.describe SurveyResultsGeneratorService do
             inputType: 'multiselect',
             question: {
               'en' => 'What are your favourite pets?',
-              'fr-FR' => 'Quels sont vos animaux de compagnie préférés ?',
-              'nl-NL' => 'Wat zijn je favoriete huisdieren?'
+              'fr-BE' => 'Quels sont vos animaux de compagnie préférés ?',
+              'nl-BE' => 'Wat zijn je favoriete huisdieren?'
             },
             required: false,
             totalResponses: 10,
             answers: [
-              { answer: { 'en' => 'Cat', 'fr-FR' => 'Chat', 'nl-NL' => 'Kat' }, responses: 4 },
-              { answer: { 'en' => 'Dog', 'fr-FR' => 'Chien', 'nl-NL' => 'Hond' }, responses: 3 },
-              { answer: { 'en' => 'Cow', 'fr-FR' => 'Vache', 'nl-NL' => 'Koe' }, responses: 2 },
-              { answer: { 'en' => 'Pig', 'fr-FR' => 'Porc', 'nl-NL' => 'Varken' }, responses: 1 }
+              { answer: { 'en' => 'Cat', 'fr-BE' => 'Chat', 'nl-BE' => 'Kat' }, responses: 4 },
+              { answer: { 'en' => 'Dog', 'fr-BE' => 'Chien', 'nl-BE' => 'Hond' }, responses: 3 },
+              { answer: { 'en' => 'Cow', 'fr-BE' => 'Vache', 'nl-BE' => 'Koe' }, responses: 2 },
+              { answer: { 'en' => 'Pig', 'fr-BE' => 'Porc', 'nl-BE' => 'Varken' }, responses: 1 }
             ]
           },
           {
             inputType: 'linear_scale',
             question: {
               'en' => 'Do you agree with the vision?',
-              'fr-FR' => "Êtes-vous d'accord avec la vision ?",
-              'nl-NL' => 'Ben je het eens met de visie?'
+              'fr-BE' => "Êtes-vous d'accord avec la vision ?",
+              'nl-BE' => 'Ben je het eens met de visie?'
             },
             required: true,
             totalResponses: 15,
@@ -172,19 +172,19 @@ RSpec.describe SurveyResultsGeneratorService do
               {
                 answer: {
                   'en' => '5 - Strongly agree',
-                  'fr-FR' => "5 - Tout à fait d'accord",
-                  'nl-NL' => '5 - Strerk mee eens'
+                  'fr-BE' => "5 - Tout à fait d'accord",
+                  'nl-BE' => '5 - Strerk mee eens'
                 },
                 responses: 1
               },
-              { answer: { 'en' => '4', 'fr-FR' => '4', 'nl-NL' => '4' }, responses: 0 },
-              { answer: { 'en' => '3', 'fr-FR' => '3', 'nl-NL' => '3' }, responses: 7 },
-              { answer: { 'en' => '2', 'fr-FR' => '2', 'nl-NL' => '2' }, responses: 5 },
+              { answer: { 'en' => '4', 'fr-BE' => '4', 'nl-BE' => '4' }, responses: 0 },
+              { answer: { 'en' => '3', 'fr-BE' => '3', 'nl-BE' => '3' }, responses: 7 },
+              { answer: { 'en' => '2', 'fr-BE' => '2', 'nl-BE' => '2' }, responses: 5 },
               {
                 answer: {
                   'en' => '1 - Strongly disagree',
-                  'fr-FR' => "1 - Pas du tout d'accord",
-                  'nl-NL' => '1 - Helemaal niet mee eens'
+                  'fr-BE' => "1 - Pas du tout d'accord",
+                  'nl-BE' => '1 - Helemaal niet mee eens'
                 },
                 responses: 2
               }
@@ -194,14 +194,14 @@ RSpec.describe SurveyResultsGeneratorService do
             inputType: 'select',
             question: {
               'en' => 'What city do you like best?',
-              'fr-FR' => 'Quelle ville préférez-vous ?',
-              'nl-NL' => 'Welke stad vind jij het leukst?'
+              'fr-BE' => 'Quelle ville préférez-vous ?',
+              'nl-BE' => 'Welke stad vind jij het leukst?'
             },
             required: true,
             totalResponses: 4,
             answers: [
-              { answer: { 'en' => 'Los Angeles', 'fr-FR' => 'Los Angeles', 'nl-NL' => 'Los Angeles' }, responses: 3 },
-              { answer: { 'en' => 'New York', 'fr-FR' => 'New York', 'nl-NL' => 'New York' }, responses: 1 }
+              { answer: { 'en' => 'Los Angeles', 'fr-BE' => 'Los Angeles', 'nl-BE' => 'Los Angeles' }, responses: 3 },
+              { answer: { 'en' => 'New York', 'fr-BE' => 'New York', 'nl-BE' => 'New York' }, responses: 1 }
             ]
           }
         ],
@@ -214,13 +214,13 @@ RSpec.describe SurveyResultsGeneratorService do
     expected_result.tap do |result|
       result[:data][:results][1][:answers][0][:answer] = {
         'en' => '5 - Strongly agree',
-        'fr-FR' => '5',
-        'nl-NL' => '5'
+        'fr-BE' => '5',
+        'nl-BE' => '5'
       }
       result[:data][:results][1][:answers][4][:answer] = {
         'en' => '1',
-        'fr-FR' => "1 - Pas du tout d'accord",
-        'nl-NL' => '1'
+        'fr-BE' => "1 - Pas du tout d'accord",
+        'nl-BE' => '1'
       }
     end
   end
@@ -296,18 +296,18 @@ RSpec.describe SurveyResultsGeneratorService do
     describe '#generate_results' do
       it 'returns the results' do
         # These locales are a prerequisite for the test.
-        expect(AppConfiguration.instance.settings('core', 'locales')).to eq(%w[en fr-FR nl-NL])
+        expect(AppConfiguration.instance.settings('core', 'locales')).to eq(%w[en fr-BE nl-BE])
 
         expect(generator.generate_results).to eq expected_result
       end
 
       context 'when not all minimum and maximum labels are configured' do
-        let(:minimum_label_multiloc) { { 'fr-FR' => "Pas du tout d'accord" } }
+        let(:minimum_label_multiloc) { { 'fr-BE' => "Pas du tout d'accord" } }
         let(:maximum_label_multiloc) { { 'en' => 'Strongly agree' } }
 
         it 'returns minimum and maximum labels as numbers' do
           # These locales are a prerequisite for the test.
-          expect(AppConfiguration.instance.settings('core', 'locales')).to eq(%w[en fr-FR nl-NL])
+          expect(AppConfiguration.instance.settings('core', 'locales')).to eq(%w[en fr-BE nl-BE])
 
           expect(generator.generate_results).to eq expected_result_without_minimum_and_maximum_labels
         end
@@ -331,18 +331,18 @@ RSpec.describe SurveyResultsGeneratorService do
     describe '#generate_results' do
       it 'returns the results' do
         # These locales are a prerequisite for the test.
-        expect(AppConfiguration.instance.settings('core', 'locales')).to eq(%w[en fr-FR nl-NL])
+        expect(AppConfiguration.instance.settings('core', 'locales')).to eq(%w[en fr-BE nl-BE])
 
         expect(generator.generate_results).to eq expected_result
       end
 
       context 'when not all minimum and maximum labels are configured' do
-        let(:minimum_label_multiloc) { { 'fr-FR' => "Pas du tout d'accord" } }
+        let(:minimum_label_multiloc) { { 'fr-BE' => "Pas du tout d'accord" } }
         let(:maximum_label_multiloc) { { 'en' => 'Strongly agree' } }
 
         it 'returns minimum and maximum labels as numbers' do
           # These locales are a prerequisite for the test.
-          expect(AppConfiguration.instance.settings('core', 'locales')).to eq(%w[en fr-FR nl-NL])
+          expect(AppConfiguration.instance.settings('core', 'locales')).to eq(%w[en fr-BE nl-BE])
 
           expect(generator.generate_results).to eq expected_result_without_minimum_and_maximum_labels
         end

--- a/back/spec/services/ui_schema_generator_service_spec.rb
+++ b/back/spec/services/ui_schema_generator_service_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe UiSchemaGeneratorService do
       create(
         :custom_field,
         input_type: 'text',
-        title_multiloc: { 'en' => 'Field1 title', 'fr-FR' => 'Field1 titre', 'nl-NL' => 'Field1 titel' },
+        title_multiloc: { 'en' => 'Field1 title', 'fr-BE' => 'Field1 titre', 'nl-BE' => 'Field1 titel' },
         description_multiloc: { 'en' => 'Field1 description' }
       )
     end
@@ -31,7 +31,7 @@ RSpec.describe UiSchemaGeneratorService do
         :custom_field_select,
         :with_options,
         input_type: 'select',
-        title_multiloc: { 'en' => 'Field2 title', 'fr-FR' => 'Field2 titre', 'nl-NL' => 'Field2 titel' },
+        title_multiloc: { 'en' => 'Field2 title', 'fr-BE' => 'Field2 titre', 'nl-BE' => 'Field2 titel' },
         description_multiloc: { 'en' => 'Field2 description' }
       )
     end
@@ -54,7 +54,7 @@ RSpec.describe UiSchemaGeneratorService do
             }
           ]
         },
-        'fr-FR' => {
+        'fr-BE' => {
           elements: [
             {
               type: 'Control',
@@ -70,7 +70,7 @@ RSpec.describe UiSchemaGeneratorService do
             }
           ]
         },
-        'nl-NL' => {
+        'nl-BE' => {
           elements: [
             {
               type: 'Control',
@@ -201,7 +201,7 @@ RSpec.describe UiSchemaGeneratorService do
         :custom_field,
         input_type: 'text_multiloc',
         key: field_key,
-        title_multiloc: { 'en' => 'Text multiloc field title', 'fr-FR' => 'Titre du champ de texte multiloc' },
+        title_multiloc: { 'en' => 'Text multiloc field title', 'fr-BE' => 'Titre du champ de texte multiloc' },
         description_multiloc: { 'en' => 'Text multiloc field description' }
       )
     end
@@ -219,15 +219,15 @@ RSpec.describe UiSchemaGeneratorService do
           },
           {
             type: 'Control',
-            scope: "#/properties/#{field_key}/properties/fr-FR",
+            scope: "#/properties/#{field_key}/properties/fr-BE",
             label: 'Text multiloc field title',
-            options: { description: 'Text multiloc field description', trim_on_blur: true, locale: 'fr-FR' }
+            options: { description: 'Text multiloc field description', trim_on_blur: true, locale: 'fr-BE' }
           },
           {
             type: 'Control',
-            scope: "#/properties/#{field_key}/properties/nl-NL",
+            scope: "#/properties/#{field_key}/properties/nl-BE",
             label: 'Text multiloc field title',
-            options: { description: 'Text multiloc field description', trim_on_blur: true, locale: 'nl-NL' }
+            options: { description: 'Text multiloc field description', trim_on_blur: true, locale: 'nl-BE' }
           }
         ]
       })
@@ -258,15 +258,15 @@ RSpec.describe UiSchemaGeneratorService do
           },
           {
             type: 'Control',
-            scope: "#/properties/#{field_key}/properties/fr-FR",
+            scope: "#/properties/#{field_key}/properties/fr-BE",
             label: 'Multiline multiloc field title',
-            options: { description: 'Multiline multiloc field description', trim_on_blur: true, textarea: true, locale: 'fr-FR' }
+            options: { description: 'Multiline multiloc field description', trim_on_blur: true, textarea: true, locale: 'fr-BE' }
           },
           {
             type: 'Control',
-            scope: "#/properties/#{field_key}/properties/nl-NL",
+            scope: "#/properties/#{field_key}/properties/nl-BE",
             label: 'Multiline multiloc field title',
-            options: { description: 'Multiline multiloc field description', trim_on_blur: true, textarea: true, locale: 'nl-NL' }
+            options: { description: 'Multiline multiloc field description', trim_on_blur: true, textarea: true, locale: 'nl-BE' }
           }
         ]
       })
@@ -297,15 +297,15 @@ RSpec.describe UiSchemaGeneratorService do
           },
           {
             type: 'Control',
-            scope: "#/properties/#{field_key}/properties/fr-FR",
+            scope: "#/properties/#{field_key}/properties/fr-BE",
             label: 'HTML multiloc field title',
-            options: { description: 'HTML multiloc field description', render: 'WYSIWYG', trim_on_blur: true, locale: 'fr-FR' }
+            options: { description: 'HTML multiloc field description', render: 'WYSIWYG', trim_on_blur: true, locale: 'fr-BE' }
           },
           {
             type: 'Control',
-            scope: "#/properties/#{field_key}/properties/nl-NL",
+            scope: "#/properties/#{field_key}/properties/nl-BE",
             label: 'HTML multiloc field title',
-            options: { description: 'HTML multiloc field description', render: 'WYSIWYG', trim_on_blur: true, locale: 'nl-NL' }
+            options: { description: 'HTML multiloc field description', render: 'WYSIWYG', trim_on_blur: true, locale: 'nl-BE' }
           }
         ]
       })

--- a/back/spec/services/user_ui_schema_generator_service_spec.rb
+++ b/back/spec/services/user_ui_schema_generator_service_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe UserUiSchemaGeneratorService do
             }
           ]
         },
-        'fr-FR' => {
+        'fr-BE' => {
           type: 'VerticalLayout',
           options: {
             formId: 'user-form'
@@ -70,7 +70,7 @@ RSpec.describe UserUiSchemaGeneratorService do
             }
           ]
         },
-        'nl-NL' => {
+        'nl-BE' => {
           type: 'VerticalLayout',
           options: {
             formId: 'user-form'

--- a/back/spec/services/xlsx_export/custom_field_for_report_spec.rb
+++ b/back/spec/services/xlsx_export/custom_field_for_report_spec.rb
@@ -16,7 +16,7 @@ describe XlsxExport::CustomFieldForReport do
         key: 'name',
         title_multiloc: {
           'en' => 'Full name',
-          'nl-NL' => 'Naam'
+          'nl-BE' => 'Naam'
         }
       )
     end
@@ -49,7 +49,7 @@ describe XlsxExport::CustomFieldForReport do
             :custom_field_option,
             custom_field: custom_field,
             key: 'cat',
-            title_multiloc: { 'en' => 'Cat', 'nl-NL' => 'Kat' }
+            title_multiloc: { 'en' => 'Cat', 'nl-BE' => 'Kat' }
           )
         end
         let!(:field_option2) do
@@ -57,12 +57,12 @@ describe XlsxExport::CustomFieldForReport do
             :custom_field_option,
             custom_field: custom_field,
             key: 'dog',
-            title_multiloc: { 'en' => 'Dog', 'nl-NL' => 'Hond' }
+            title_multiloc: { 'en' => 'Dog', 'nl-BE' => 'Hond' }
           )
         end
 
         it 'returns the value for the field' do
-          I18n.with_locale('nl-NL') do
+          I18n.with_locale('nl-BE') do
             expect(report_field.value_from(model)).to eq 'Kat'
             model.custom_field_values['name'] = 'dog'
             expect(report_field.value_from(model)).to eq 'Hond'
@@ -101,7 +101,7 @@ describe XlsxExport::CustomFieldForReport do
     describe '#column_header' do
       it 'returns the translated field title' do
         expect(report_field.column_header).to eq 'Full name'
-        I18n.with_locale('nl-NL') do
+        I18n.with_locale('nl-BE') do
           expect(report_field.column_header).to eq 'Naam'
         end
       end
@@ -121,7 +121,7 @@ describe XlsxExport::CustomFieldForReport do
         resource_type: 'User',
         key: 'birthyear',
         input_type: input_type,
-        title_multiloc: { 'en' => 'Year of birth', 'nl-NL' => 'Geboortejaar' }
+        title_multiloc: { 'en' => 'Year of birth', 'nl-BE' => 'Geboortejaar' }
       )
     end
     let(:model) { instance_double Idea, author: user }
@@ -151,7 +151,7 @@ describe XlsxExport::CustomFieldForReport do
             :custom_field_option,
             custom_field: custom_field,
             key: '1990',
-            title_multiloc: { 'en' => '1990-EN', 'nl-NL' => '1990-NL' }
+            title_multiloc: { 'en' => '1990-EN', 'nl-BE' => '1990-NL' }
           )
         end
         let!(:field_option2) do
@@ -159,12 +159,12 @@ describe XlsxExport::CustomFieldForReport do
             :custom_field_option,
             custom_field: custom_field,
             key: '1991',
-            title_multiloc: { 'en' => '1991-EN', 'nl-NL' => '1991-NL' }
+            title_multiloc: { 'en' => '1991-EN', 'nl-BE' => '1991-NL' }
           )
         end
 
         it 'returns the value for the field' do
-          I18n.with_locale('nl-NL') do
+          I18n.with_locale('nl-BE') do
             expect(report_field.value_from(model)).to eq '1990-NL'
             user.custom_field_values['birthyear'] = '1991'
             expect(report_field.value_from(model)).to eq '1991-NL'
@@ -203,7 +203,7 @@ describe XlsxExport::CustomFieldForReport do
     describe '#column_header' do
       it 'returns the translated field title' do
         expect(report_field.column_header).to eq 'Year of birth'
-        I18n.with_locale('nl-NL') do
+        I18n.with_locale('nl-BE') do
           expect(report_field.column_header).to eq 'Geboortejaar'
         end
       end

--- a/back/spec/services/xlsx_export/domicile_field_for_report_spec.rb
+++ b/back/spec/services/xlsx_export/domicile_field_for_report_spec.rb
@@ -15,7 +15,7 @@ describe XlsxExport::DomicileFieldForReport do
       input_type: 'select',
       title_multiloc: {
         'en' => 'Residence',
-        'nl-NL' => 'Verblijfplaats'
+        'nl-BE' => 'Verblijfplaats'
       }
     )
   end
@@ -41,13 +41,13 @@ describe XlsxExport::DomicileFieldForReport do
       let(:area) do
         create(
           :area,
-          title_multiloc: { 'en' => 'Paris', 'nl-NL' => 'Parijs' }
+          title_multiloc: { 'en' => 'Paris', 'nl-BE' => 'Parijs' }
         )
       end
       let(:model) { create(:user, custom_field_values: { 'domicile' => area.id }) }
 
       it 'returns the area for the field' do
-        I18n.with_locale('nl-NL') do
+        I18n.with_locale('nl-BE') do
           expect(report_field.value_from(model)).to eq 'Parijs'
         end
       end

--- a/back/spec/services/xlsx_export/value_visitor_spec.rb
+++ b/back/spec/services/xlsx_export/value_visitor_spec.rb
@@ -146,10 +146,10 @@ describe XlsxExport::ValueVisitor do
       end
 
       context 'when there is a value' do
-        let(:value) { { 'en' => 'Text in EN', 'nl-NL' => 'Tekst in NL' } }
+        let(:value) { { 'en' => 'Text in EN', 'nl-BE' => 'Tekst in NL' } }
 
         it 'returns the value for the report' do
-          I18n.with_locale('nl-NL') do
+          I18n.with_locale('nl-BE') do
             expect(visitor.visit_text_multiloc(field)).to eq 'Tekst in NL'
           end
         end
@@ -168,7 +168,7 @@ describe XlsxExport::ValueVisitor do
       end
 
       context 'when there is a value' do
-        let(:value) { { 'en' => 'Line 1\nLine 2', 'nl-NL' => 'Lijn 1\nLijn2' } }
+        let(:value) { { 'en' => 'Line 1\nLine 2', 'nl-BE' => 'Lijn 1\nLijn2' } }
 
         it 'returns the empty string, because the field is not supported yet' do
           expect(visitor.visit_multiline_text_multiloc(field)).to eq ''
@@ -188,10 +188,10 @@ describe XlsxExport::ValueVisitor do
       end
 
       context 'when there is a value' do
-        let(:value) { { 'en' => +"<p>Line 1</p>\n<p>Line 2</p>", 'nl-NL' => +"<p>Lijn 1</p>\n<p>Lijn 2</p>" } }
+        let(:value) { { 'en' => +"<p>Line 1</p>\n<p>Line 2</p>", 'nl-BE' => +"<p>Lijn 1</p>\n<p>Lijn 2</p>" } }
 
         it 'returns the value for the report' do
-          I18n.with_locale('nl-NL') do
+          I18n.with_locale('nl-BE') do
             expect(visitor.visit_html_multiloc(field)).to eq 'Lijn 1  Lijn 2'
           end
         end
@@ -211,14 +211,14 @@ describe XlsxExport::ValueVisitor do
           let(:value) { nil }
 
           it 'returns the empty string' do
-            I18n.with_locale('nl-NL') do
+            I18n.with_locale('nl-BE') do
               expect(visitor.visit_select(field)).to eq ''
             end
           end
         end
 
         context 'when there is a value' do
-          let!(:area) { create(:area, title_multiloc: { 'en' => 'Paris', 'nl-NL' => 'Parijs' }) }
+          let!(:area) { create(:area, title_multiloc: { 'en' => 'Paris', 'nl-BE' => 'Parijs' }) }
           let(:value) { area.id }
           let(:option_index) do
             {
@@ -227,7 +227,7 @@ describe XlsxExport::ValueVisitor do
           end
 
           it 'returns the value for the report' do
-            I18n.with_locale('nl-NL') do
+            I18n.with_locale('nl-BE') do
               expect(visitor.visit_select(field)).to eq 'Parijs'
             end
           end
@@ -240,7 +240,7 @@ describe XlsxExport::ValueVisitor do
             :custom_field_option,
             custom_field: field,
             key: 'cat',
-            title_multiloc: { 'en' => 'Cat', 'nl-NL' => 'Kat' }
+            title_multiloc: { 'en' => 'Cat', 'nl-BE' => 'Kat' }
           )
         end
         let!(:field_option2) do
@@ -248,7 +248,7 @@ describe XlsxExport::ValueVisitor do
             :custom_field_option,
             custom_field: field,
             key: 'dog',
-            title_multiloc: { 'en' => 'Dog', 'nl-NL' => 'Hond' }
+            title_multiloc: { 'en' => 'Dog', 'nl-BE' => 'Hond' }
           )
         end
         let(:option_index) do
@@ -262,7 +262,7 @@ describe XlsxExport::ValueVisitor do
           let(:value) { nil }
 
           it 'returns the empty string' do
-            I18n.with_locale('nl-NL') do
+            I18n.with_locale('nl-BE') do
               expect(visitor.visit_select(field)).to eq ''
             end
           end
@@ -272,7 +272,7 @@ describe XlsxExport::ValueVisitor do
           let(:value) { 'cat' }
 
           it 'returns the value for the report' do
-            I18n.with_locale('nl-NL') do
+            I18n.with_locale('nl-BE') do
               expect(visitor.visit_select(field)).to eq 'Kat'
             end
           end
@@ -287,7 +287,7 @@ describe XlsxExport::ValueVisitor do
           :custom_field_option,
           custom_field: field,
           key: 'cat',
-          title_multiloc: { 'en' => 'Cat', 'nl-NL' => 'Kat' }
+          title_multiloc: { 'en' => 'Cat', 'nl-BE' => 'Kat' }
         )
       end
       let!(:field_option2) do
@@ -295,7 +295,7 @@ describe XlsxExport::ValueVisitor do
           :custom_field_option,
           custom_field: field,
           key: 'dog',
-          title_multiloc: { 'en' => 'Dog', 'nl-NL' => 'Hond' }
+          title_multiloc: { 'en' => 'Dog', 'nl-BE' => 'Hond' }
         )
       end
       let(:option_index) do
@@ -309,7 +309,7 @@ describe XlsxExport::ValueVisitor do
         let(:value) { [] }
 
         it 'returns the empty string' do
-          I18n.with_locale('nl-NL') do
+          I18n.with_locale('nl-BE') do
             expect(visitor.visit_multiselect(field)).to eq ''
           end
         end
@@ -319,7 +319,7 @@ describe XlsxExport::ValueVisitor do
         let(:value) { ['dog'] }
 
         it 'returns the value for the report' do
-          I18n.with_locale('nl-NL') do
+          I18n.with_locale('nl-BE') do
             expect(visitor.visit_multiselect(field)).to eq 'Hond'
           end
         end
@@ -329,7 +329,7 @@ describe XlsxExport::ValueVisitor do
         let(:value) { %w[cat dog] }
 
         it 'returns the value for the report' do
-          I18n.with_locale('nl-NL') do
+          I18n.with_locale('nl-BE') do
             expect(visitor.visit_multiselect(field)).to eq 'Kat, Hond'
           end
         end
@@ -364,7 +364,7 @@ describe XlsxExport::ValueVisitor do
 
         context 'when there is no value' do
           it 'returns the empty string' do
-            I18n.with_locale('nl-NL') do
+            I18n.with_locale('nl-BE') do
               expect(visitor.visit_files(field)).to eq ''
             end
           end
@@ -447,7 +447,7 @@ describe XlsxExport::ValueVisitor do
         let(:value) { nil }
 
         it 'returns the empty string' do
-          I18n.with_locale('nl-NL') do
+          I18n.with_locale('nl-BE') do
             expect(visitor.visit_file_upload(field)).to eq ''
           end
         end
@@ -478,7 +478,7 @@ describe XlsxExport::ValueVisitor do
         let(:value) { nil }
 
         it 'returns the empty string' do
-          I18n.with_locale('nl-NL') do
+          I18n.with_locale('nl-BE') do
             expect(visitor.visit_topic_ids(field)).to eq ''
           end
         end
@@ -487,13 +487,13 @@ describe XlsxExport::ValueVisitor do
       context 'when there is one topic selected' do
         let(:topics) do
           [
-            create(:topic, code: 'nature', title_multiloc: { 'en' => 'Topic 1', 'nl-NL' => 'Onderwerp 1' })
+            create(:topic, code: 'nature', title_multiloc: { 'en' => 'Topic 1', 'nl-BE' => 'Onderwerp 1' })
           ]
         end
         let(:value) { ['nature'] }
 
         it 'returns the value for the report' do
-          I18n.with_locale('nl-NL') do
+          I18n.with_locale('nl-BE') do
             expect(visitor.visit_topic_ids(field)).to eq 'Onderwerp 1'
           end
         end
@@ -502,14 +502,14 @@ describe XlsxExport::ValueVisitor do
       context 'when there are multiple topics selected' do
         let(:topics) do
           [
-            create(:topic, code: 'nature', title_multiloc: { 'en' => 'Topic 1', 'nl-NL' => 'Onderwerp 1' }),
-            create(:topic, code: 'waste', title_multiloc: { 'en' => 'Topic 2', 'nl-NL' => 'Onderwerp 2' })
+            create(:topic, code: 'nature', title_multiloc: { 'en' => 'Topic 1', 'nl-BE' => 'Onderwerp 1' }),
+            create(:topic, code: 'waste', title_multiloc: { 'en' => 'Topic 2', 'nl-BE' => 'Onderwerp 2' })
           ]
         end
         let(:value) { %w[nature waste] }
 
         it 'returns the value for the report' do
-          I18n.with_locale('nl-NL') do
+          I18n.with_locale('nl-BE') do
             expect(visitor.visit_topic_ids(field)).to eq 'Onderwerp 1, Onderwerp 2'
           end
         end

--- a/back/spec/validators/multiloc_validator_spec.rb
+++ b/back/spec/validators/multiloc_validator_spec.rb
@@ -39,10 +39,10 @@ describe MultilocValidator do
 
   context 'with nil values for some locales' do
     it 'is invalid' do
-      nonpresence_subject.multiloc_field = { 'en' => 'somevalue', 'fr-FR' => nil }
+      nonpresence_subject.multiloc_field = { 'en' => 'somevalue', 'fr-BE' => nil }
       expect(nonpresence_subject).to be_invalid
 
-      nonpresence_subject.multiloc_field = { 'en' => 'somevalue', 'fr-FR' => false, 'nl-BE' => '' }
+      nonpresence_subject.multiloc_field = { 'en' => 'somevalue', 'fr-BE' => false, 'nl-BE' => '' }
       expect(nonpresence_subject).to be_invalid
     end
   end


### PR DESCRIPTION
# Changelog

## Technical
- Changed the locales in the backend tests and factories to be consistently en, nl-BE & fr-BE - except in cases like FranceConnect where locale has to be specifically different.
