### PR TITLE
Add force: true to make test less flaky

### DIFF
--- a/front/cypress/e2e/verification_modal.cy.ts
+++ b/front/cypress/e2e/verification_modal.cy.ts
@@ -62,7 +62,7 @@ describe('Verification modal', () => {
     });
 
     it('verifies the user using the bogus form', () => {
-      cy.get('.e2e-idea-button:visible').first().click();
+      cy.get('.e2e-idea-button:visible').first().click({ force: true });
       cy.get('.e2e-rule-item');
       cy.get('.e2e-rule-item').should('have.length', 1);
       cy.get('.e2e-rule-item').contains('charlie');


### PR DESCRIPTION
Following the instructions from cypress in the [failing job](https://app.circleci.com/jobs/github/CitizenLabDotCo/citizenlab/257999):

```
`pointer-events: none` prevents user mouse interaction.

Fix this problem, or use {force: true} to disable error checking
```