### PR TITLE
Fix bug with phase editing

### DIFF
--- a/front/app/containers/Admin/projects/project/timeline/edit.tsx
+++ b/front/app/containers/Admin/projects/project/timeline/edit.tsx
@@ -320,12 +320,22 @@ const AdminProjectTimelineEdit = () => {
             <Error apiErrors={errors && errors.title_multiloc} />
           </SectionField>
           <SectionField>
-            <ParticipationContext
-              phase={!isNilOrError(phase) ? { data: phase } : undefined}
-              onSubmit={handleParticipationContextOnSubmit}
-              onChange={handleParticipationContextOnChange}
-              apiErrors={errors}
-            />
+            {!isNilOrError(phase) && (
+              <ParticipationContext
+                phase={{ data: phase }}
+                onSubmit={handleParticipationContextOnSubmit}
+                onChange={handleParticipationContextOnChange}
+                apiErrors={errors}
+              />
+            )}
+            {!phase && (
+              <ParticipationContext
+                phase={undefined}
+                onSubmit={handleParticipationContextOnSubmit}
+                onChange={handleParticipationContextOnChange}
+                apiErrors={errors}
+              />
+            )}
           </SectionField>
           <SectionField>
             <Label>

--- a/front/app/containers/Admin/projects/project/timeline/edit.tsx
+++ b/front/app/containers/Admin/projects/project/timeline/edit.tsx
@@ -320,6 +320,9 @@ const AdminProjectTimelineEdit = () => {
             <Error apiErrors={errors && errors.title_multiloc} />
           </SectionField>
           <SectionField>
+            {/* TODO: After ParticipationContext refactor, it doesn't refetch phase service anymore
+            This caused a bug where phase data was not being used after fetching. This is a temporary fix.
+            ParticipationContext needs to be refactored to functional component. */}
             {!isNilOrError(phase) && (
               <ParticipationContext
                 phase={{ data: phase }}


### PR DESCRIPTION
# Description
Bug with phase editing - doesn't rerender when phase is loaded, so editing a phase loads in default data.

This bug wasn't on production yet (just staging) - so I haven't included it in the changelog.
