### PR TITLE
[CL-3535] Remove direct dependency to Sinatra

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -87,7 +87,6 @@ gem 'active_model_serializers', '~> 0.10.12'
 
 gem 'jwt', '~> 2.7.0'
 gem 'que', git: 'https://github.com/que-rb/que', branch: 'master', ref: '77c6b92952b821898c393239ce0e4047b17d7dae'
-gem 'sinatra', '~> 3.0.6' # Fixes CVE-2022-45442. Sinatra is a dependency of que-web, but que-web depends on sinatra >= 0.
 gem 'que-web'
 
 gem 'activerecord-import', '~> 1.4'

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -1218,7 +1218,6 @@ DEPENDENCIES
   simple_segment (~> 1.5)
   simplecov
   simplecov-rcov
-  sinatra (~> 3.0.6)
   smart_groups!
   spring
   spring-commands-rspec


### PR DESCRIPTION
To address the CVEs, it is sufficient to ensure that the correct version is specified in the Gemfile.lock. There is no need to include Sinatra as a direct dependency.

