### PR TITLE
[CL-3635] Add missing serializer for `ReportBuilder::Report`

### DIFF
--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/report_builder/report.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/report_builder/report.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module MultiTenancy
+  module Templates
+    module Serializers
+      module ReportBuilder
+        class Report < Base
+          ref_attribute :owner
+          attribute :name
+        end
+      end
+    end
+  end
+end

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_serializer.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_serializer.rb
@@ -149,7 +149,7 @@ module MultiTenancy
         end
 
         each_node = ->(&b) { ref_dependencies_graph.each_key(&b) }
-        each_child = ->(n, &b) { ref_dependencies_graph[n].each(&b) }
+        each_child = ->(n, &b) { ref_dependencies_graph.fetch(n).each(&b) }
 
         sorted_classes = TSort.tsort(each_node, each_child)
         models.slice(*sorted_classes)

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_serializer.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_serializer.rb
@@ -61,6 +61,7 @@ module MultiTenancy
           ProjectFolders::Image => serialize_records(ProjectFolders::Image),
           ProjectImage => serialize_records(ProjectImage),
           ProjectsAllowedInputTopic => serialize_records(ProjectsAllowedInputTopic),
+          ReportBuilder::Report => serialize_records(ReportBuilder::Report),
           StaticPage => serialize_records(StaticPage),
           StaticPageFile => serialize_records(StaticPageFile),
           Topic => serialize_records(Topic),


### PR DESCRIPTION
# Changelog
## Technical
- Add missing serializer for `ReportBuilder::Report` model for tenant templates.