### PR TITLE
CL-3665 - Make avatars less similar

### DIFF
--- a/back/app/models/concerns/anonymous_participation.rb
+++ b/back/app/models/concerns/anonymous_participation.rb
@@ -27,7 +27,12 @@ module AnonymousParticipation
       return if author_id.blank?
 
       salt = anonymous? ? "#{project_string}84c168c4-a240-4f0a-8468-9e2cf714d4e1" : '335b6eb2-9e7c-405c-9221-9b8919b64b8b'
-      self.author_hash = Digest::MD5.hexdigest(author_id + salt)
+      digest = Digest::MD5.hexdigest(author_id + salt)
+      # Alter length of hash & add underscore to give more variety in avatars
+      hash_size = digest.length
+      digest += digest[0, (digest.first.ord % hash_size)]
+      digest.insert(hash_size - (digest.first.ord % hash_size), '_')
+      self.author_hash = digest
     end
 
     def project_string

--- a/back/app/models/concerns/anonymous_participation.rb
+++ b/back/app/models/concerns/anonymous_participation.rb
@@ -8,7 +8,11 @@ module AnonymousParticipation
     class << self
       def create_author_hash(author_id, project_id, anonymous)
         salt = anonymous ? "#{project_id}84c168c4-a240-4f0a-8468-9e2cf714d4e1" : '335b6eb2-9e7c-405c-9221-9b8919b64b8b'
-        Digest::MD5.hexdigest(author_id + salt)
+        digest = Digest::MD5.hexdigest(author_id + salt)
+        # Alter length of hash & add underscore to give more variety in avatars
+        hash_size = digest.length
+        digest += digest[0, (digest.first.ord % hash_size)]
+        digest.insert(hash_size - (digest.first.ord % hash_size), '_')
       end
     end
 

--- a/back/spec/models/comment_spec.rb
+++ b/back/spec/models/comment_spec.rb
@@ -68,11 +68,6 @@ RSpec.describe Comment do
   describe 'anonymous participation' do
     let(:author) { create(:user) }
 
-    it 'has an author hash of consistent length' do
-      comment = create(:comment)
-      expect(comment.author_hash.length).to eq 32
-    end
-
     context 'creating comments that are not anonymous' do
       it 'has the same author hash for comments in different projects when the author is the same' do
         comment1 = create(:comment, author: author)

--- a/back/spec/models/idea_spec.rb
+++ b/back/spec/models/idea_spec.rb
@@ -540,11 +540,6 @@ RSpec.describe Idea do
   describe 'anonymous participation' do
     let(:author) { create(:user) }
 
-    it 'has an author hash of consistent length' do
-      idea = create(:idea)
-      expect(idea.author_hash.length).to eq 32
-    end
-
     context 'ideas are not anonymous' do
       it 'has the same author hash for ideas in different projects when the author is the same' do
         idea1 = create(:idea, author: author)

--- a/back/spec/models/initiative_spec.rb
+++ b/back/spec/models/initiative_spec.rb
@@ -118,11 +118,6 @@ RSpec.describe Initiative do
   describe 'anonymous participation' do
     let(:author) { create(:user) }
 
-    it 'has an author hash of consistent length' do
-      initiative = create(:initiative)
-      expect(initiative.author_hash.length).to eq 32
-    end
-
     context 'ideas are not anonymous' do
       it 'has the same author hash on each initiative when the author is the same' do
         initiative1 = create(:initiative, author: author)


### PR DESCRIPTION
To make the boring avatars library produce more varied avatars I've changed the function so that it the avatar hash is of a varying length based on the first character of the original hash and then inserted an underscore consistently based on that same first character. Seems to produce a better variety - examples approved by Irene.
