### PR TITLE
CL-3637 email examples api

### DIFF
--- a/back/db/migrate/20230524151508_replace_campaign_type_with_campaign_id.email_campaigns.rb
+++ b/back/db/migrate/20230524151508_replace_campaign_type_with_campaign_id.email_campaigns.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# This migration comes from email_campaigns (originally 20230524162712)
+
+class ReplaceCampaignTypeWithCampaignId < ActiveRecord::Migration[6.1]
+  def change
+    add_column :email_campaigns_examples, :campaign_id, :uuid, null: true, foreign_key: { to_table: 'email_campaigns_campaigns' }
+    add_index :email_campaigns_examples, :campaign_id
+
+    ActiveRecord::Base.connection.execute <<~SQL.squish
+      UPDATE email_campaigns_examples e
+        SET campaign_id = (
+          SELECT id
+          FROM email_campaigns_campaigns
+          WHERE type = e.campaign_class
+          LIMIT 1
+        )
+    SQL
+
+    remove_column :email_campaigns_examples, :campaign_class
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_19_085843) do
+ActiveRecord::Schema.define(version: 2023_05_24_151508) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -336,14 +336,14 @@ ActiveRecord::Schema.define(version: 2023_05_19_085843) do
   end
 
   create_table "email_campaigns_examples", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "campaign_class", null: false
     t.string "mail_body_html", null: false
     t.string "locale", null: false
     t.string "subject", null: false
     t.uuid "recipient_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["campaign_class"], name: "index_email_campaigns_examples_on_campaign_class"
+    t.uuid "campaign_id"
+    t.index ["campaign_id"], name: "index_email_campaigns_examples_on_campaign_id"
   end
 
   create_table "email_campaigns_unsubscription_tokens", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/back/engines/free/email_campaigns/app/controllers/email_campaigns/web_api/v1/examples_controller.rb
+++ b/back/engines/free/email_campaigns/app/controllers/email_campaigns/web_api/v1/examples_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module EmailCampaigns
+  class WebApi::V1::ExamplesController < EmailCampaignsController
+    before_action :set_example, only: :show
+
+    def index
+      authorize Example
+
+      @examples = policy_scope(Example)
+        .where(campaign_id: params[:campaign_id])
+
+      @examples = paginate(@examples)
+
+      render json: linked_json(@examples, WebApi::V1::ExampleSerializer, params: jsonapi_serializer_params)
+    end
+
+    def show
+      render json: WebApi::V1::ExampleSerializer.new(@example, params: jsonapi_serializer_params).serializable_hash
+    end
+
+    private
+
+    def set_example
+      @example = Example.find(params[:id])
+      authorize @example
+    end
+  end
+end

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaign.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaign.rb
@@ -29,6 +29,7 @@
 module EmailCampaigns
   class Campaign < ApplicationRecord
     belongs_to :author, class_name: 'User', optional: true
+    has_many :examples, class_name: 'EmailCampaigns::Example', dependent: :destroy
 
     # accepts_nested_attributes_for does not work for concerns
     # (see https://github.com/rails/rails/issues/15253). Doing

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/example.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/example.rb
@@ -5,20 +5,21 @@
 # Table name: email_campaigns_examples
 #
 #  id             :uuid             not null, primary key
-#  campaign_class :string           not null
 #  mail_body_html :string           not null
 #  locale         :string           not null
 #  subject        :string           not null
 #  recipient_id   :uuid
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  campaign_id    :uuid
 #
 # Indexes
 #
-#  index_email_campaigns_examples_on_campaign_class  (campaign_class)
+#  index_email_campaigns_examples_on_campaign_id  (campaign_id)
 #
 module EmailCampaigns
   class Example < ApplicationRecord
     belongs_to :recipient, class_name: 'User', optional: true
+    belongs_to :campaign, class_name: 'EmailCampaigns::Campaign'
   end
 end

--- a/back/engines/free/email_campaigns/app/policies/email_campaigns/example_policy.rb
+++ b/back/engines/free/email_campaigns/app/policies/email_campaigns/example_policy.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module EmailCampaigns
+  class ExamplePolicy < EmailCampaignsPolicy
+    class Scope
+      attr_reader :user, :scope
+
+      def initialize(user, scope)
+        @user  = user
+        @scope = scope
+      end
+
+      def resolve
+        if user&.active? && user&.admin?
+          scope.all
+        else
+          scope.none
+        end
+      end
+    end
+
+    def index?
+      user&.active? && user&.admin?
+    end
+
+    def show?
+      user&.active? && user&.admin?
+    end
+  end
+end

--- a/back/engines/free/email_campaigns/app/serializers/email_campaigns/web_api/v1/example_serializer.rb
+++ b/back/engines/free/email_campaigns/app/serializers/email_campaigns/web_api/v1/example_serializer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module EmailCampaigns
+  class WebApi::V1::ExampleSerializer < ::WebApi::V1::BaseSerializer
+    attributes :mail_body_html, :locale, :subject, :created_at, :updated_at
+
+    belongs_to :campaign
+    belongs_to :recipient, serializer: ::WebApi::V1::UserSerializer
+  end
+end

--- a/back/engines/free/email_campaigns/app/services/email_campaigns/examples_service.rb
+++ b/back/engines/free/email_campaigns/app/services/email_campaigns/examples_service.rb
@@ -34,8 +34,8 @@ module EmailCampaigns
 
         next if n_lacking < 0
 
-        new_campaign_commands.each do |(command, campaign)|
-          save_example(command, campaign)
+        new_campaign_commands.each do |(command, camp)|
+          save_example(command, camp)
         end
       end
     end

--- a/back/engines/free/email_campaigns/app/services/email_campaigns/examples_service.rb
+++ b/back/engines/free/email_campaigns/app/services/email_campaigns/examples_service.rb
@@ -10,24 +10,24 @@ module EmailCampaigns
     RECENCY_THRESHOLD = 1.week
 
     def save_examples(campaigns_with_command)
-      campaign_types = campaigns_with_command.map { |(_command, campaign)| campaign.type }.uniq
+      campaigns = campaigns_with_command.map { |(_command, campaign)| campaign }.uniq
 
-      campaign_types.each do |campaign_type|
+      campaigns.each do |campaign|
         recent_examples_n = Example
-          .where(campaign_class: campaign_type)
+          .where(campaign: campaign)
           .where('created_at > ?', RECENCY_THRESHOLD.ago)
           .count
         n_lacking = EXAMPLES_PER_CAMPAIGN - recent_examples_n
 
         next if n_lacking == 0
 
-        total_examples = Example.where(campaign_class: campaign_type).count
+        total_examples = Example.where(campaign: campaign).count
 
         new_campaign_commands =
-          filter_n_campaigns_with_command_for_campaign_type(campaigns_with_command, campaign_type, n_lacking)
+          filter_n_campaigns_with_command_for_campaign(campaigns_with_command, campaign, n_lacking)
 
         Example
-          .where(campaign_class: campaign_type)
+          .where(campaign: campaign)
           .order(created_at: :asc)
           .limit([new_campaign_commands.size, n_lacking].min + [0, (total_examples - EXAMPLES_PER_CAMPAIGN)].max)
           .destroy_all
@@ -46,7 +46,7 @@ module EmailCampaigns
       ErrorReporter.handle do
         mail = campaign.mailer_class.with(campaign: campaign, command: command).campaign_mail
         EmailCampaigns::Example.create!(
-          campaign_class: campaign.type,
+          campaign: campaign,
           mail_body_html: mail.body.to_s,
           locale: command[:recipient].locale,
           subject: mail.subject,
@@ -55,9 +55,9 @@ module EmailCampaigns
       end
     end
 
-    def filter_n_campaigns_with_command_for_campaign_type(campaigns_with_command, campaign_type, n)
-      campaigns_with_command.select do |(_command, campaign)|
-        campaign.type == campaign_type
+    def filter_n_campaigns_with_command_for_campaign(campaigns_with_command, campaign, n)
+      campaigns_with_command.select do |(_command, camp)|
+        camp.id == campaign.id
       end.first(n)
     end
   end

--- a/back/engines/free/email_campaigns/config/routes.rb
+++ b/back/engines/free/email_campaigns/config/routes.rb
@@ -9,6 +9,8 @@ EmailCampaigns::Engine.routes.draw do
         get :preview, on: :member
         get :deliveries, on: :member
         get :stats, on: :member
+        resources :examples, only: %i[index]
+        get 'examples/:id', action: 'show', controller: 'examples', on: :collection
       end
 
       resources :consents, only: %i[index update] do

--- a/back/engines/free/email_campaigns/db/migrate/20230524162712_replace_campaign_type_with_campaign_id.rb
+++ b/back/engines/free/email_campaigns/db/migrate/20230524162712_replace_campaign_type_with_campaign_id.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class ReplaceCampaignTypeWithCampaignId < ActiveRecord::Migration[6.1]
+  def change
+    add_column :email_campaigns_examples, :campaign_id, :uuid, null: true, foreign_key: { to_table: 'email_campaigns_campaigns' }
+    add_index :email_campaigns_examples, :campaign_id
+
+    ActiveRecord::Base.connection.execute <<~SQL.squish
+      UPDATE email_campaigns_examples e
+        SET campaign_id = (
+          SELECT id
+          FROM email_campaigns_campaigns
+          WHERE type = e.campaign_class
+          LIMIT 1
+        )
+    SQL
+
+    remove_column :email_campaigns_examples, :campaign_class
+  end
+end

--- a/back/engines/free/email_campaigns/spec/acceptance/examples_spec.rb
+++ b/back/engines/free/email_campaigns/spec/acceptance/examples_spec.rb
@@ -40,6 +40,31 @@ resource 'Campaing examples' do
       assert_status 200
       json_response = json_parse(response_body)
       expect(json_response.dig(:data, :id)).to eq id
+      expect(json_response[:data]).to include({
+        id: id,
+        type: 'example',
+        attributes: a_hash_including({
+          mail_body_html: kind_of(String),
+          locale: 'en',
+          subject: 'You became an administrator on the platform of Liege',
+          created_at: kind_of(String),
+          updated_at: kind_of(String)
+        }),
+        relationships: {
+          campaign: {
+            data: {
+              id: example1.campaign_id,
+              type: 'campaign'
+            }
+          },
+          recipient: {
+            data: {
+              id: example1.recipient.id,
+              type: 'user'
+            }
+          }
+        }
+      })
     end
   end
 end

--- a/back/engines/free/email_campaigns/spec/acceptance/examples_spec.rb
+++ b/back/engines/free/email_campaigns/spec/acceptance/examples_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rspec_api_documentation/dsl'
+
+resource 'Campaing examples' do
+  explanation 'Examples of previously sent-out email campaigns, used to help the user understand email content.'
+
+  before do
+    header 'Content-Type', 'application/json'
+    @admin = create(:admin)
+    header_token_for @admin
+  end
+
+  get '/web_api/v1/campaigns/:campaign_id/examples' do
+    with_options scope: :page do
+      parameter :number, 'Page number'
+      parameter :size, 'Number of examples per page'
+    end
+
+    let(:campaign1) { create(:admin_rights_received_campaign) }
+    let(:campaign2) { create(:comment_deleted_by_admin_campaign) }
+    let(:examples) { create_list(:campaign_example, 3, campaign: campaign1) }
+    let!(:other_campaign_example) { create(:campaign_example, campaign: campaign2) }
+    let(:campaign_id) { examples.first.campaign_id }
+
+    example_request 'List all examples for a specific campaign' do
+      assert_status 200
+      json_response = json_parse(response_body)
+      expect(json_response[:data].size).to eq 3
+      expect(json_response[:data].pluck(:id)).not_to include(other_campaign_example.id)
+    end
+  end
+
+  get '/web_api/v1/campaigns/examples/:id' do
+    let(:example1) { create(:campaign_example) }
+    let(:id) { example1.id }
+
+    example_request 'Get one campaign example by id' do
+      assert_status 200
+      json_response = json_parse(response_body)
+      expect(json_response.dig(:data, :id)).to eq id
+    end
+  end
+end

--- a/back/engines/free/email_campaigns/spec/factories/examples.rb
+++ b/back/engines/free/email_campaigns/spec/factories/examples.rb
@@ -2,10 +2,10 @@
 
 FactoryBot.define do
   factory :campaign_example, class: EmailCampaigns::Example do
-    campaign_class { 'EmailCampaigns::Campaigns::AdminRightsReceived' }
+    association :campaign, factory: :admin_rights_received_campaign
     association :recipient, factory: :user
     locale { 'en' }
     subject { 'You became an administrator on the platform of Liege' }
-    mail_body_html { Faker::Lorem.paragraph }
+    mail_body_html { '<html><body>Faker::Lorem.paragraph</body></html>' }
   end
 end

--- a/back/engines/free/email_campaigns/spec/factories/examples.rb
+++ b/back/engines/free/email_campaigns/spec/factories/examples.rb
@@ -6,6 +6,6 @@ FactoryBot.define do
     association :recipient, factory: :user
     locale { 'en' }
     subject { 'You became an administrator on the platform of Liege' }
-    mail_body_html { '<html><body>Faker::Lorem.paragraph</body></html>' }
+    mail_body_html { "<html><body>#{Faker::Lorem.paragraph}</body></html>" }
   end
 end


### PR DESCRIPTION
This does 2 things:
- Change the `campaign_type` attribute to `campaign_id` attribute in the examples table, and all corresponding code
- Adds the API to fetch examples 

# Changelog
## Technical
- Adds the API to fetch email campaign examples, will be used in new campaign overview page