### PR TITLE
[CL-3645] Update Vienna SAML IDP metadata

### DIFF
--- a/back/engines/commercial/id_vienna_saml/config/saml/citizen/idp_metadata_production.xml
+++ b/back/engines/commercial/id_vienna_saml/config/saml/citizen/idp_metadata_production.xml
@@ -8,7 +8,7 @@
       <mdui:UIInfo xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui">
         <mdui:DisplayName xml:lang="de">https://mein.wien.gv.at/stdportal-idp/extern.wien.gv.at</mdui:DisplayName>
         <mdui:Description xml:lang="de">https://mein.wien.gv.at/stdportal-idp/extern.wien.gv.at</mdui:Description>
-        <mdui:Logo height="70" width="79" xml:lang="en">https://www.portalverbund.at/sites/www.portalverbund.at/img/logo.png</mdui:Logo>
+        <mdui:Logo height="70" width="79" xml:lang="en">https://www.wien.gv.at/Wien.WienAt.Customer-theme/images/logo-stadt-wien.svg</mdui:Logo>
       </mdui:UIInfo>
     </md:Extensions>
     <md:KeyDescriptor use="signing">
@@ -19,6 +19,18 @@ SubjectDN: CN=pvp.wien.gv.at, OU=MA01, O=Magistrat Wien, L=Wien, ST=Wien, C=AT
 NotBefore: Mon May 31 13:50:20 CEST 2021
 NotAfter: Thu Jun 01 13:50:20 CEST 2023
 SerialNumber: 3809416862600171027 (0x34ddc47410aa8e13)
+SigAlgName: SHA256withRSA--></ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+    <md:KeyDescriptor use="signing">
+      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:X509Data>
+          <ds:X509Certificate>MIIF7TCCA9WgAwIBAgIUDA5j7uQX1z5xcx6y9XB2oHl0YrwwDQYJKoZIhvcNAQELBQAwSjELMAkG A1UEBhMCQVQxEzARBgNVBAoMClN0YWR0IFdpZW4xJjAkBgNVBAMMHVN0YWR0IFdpZW4gUG9ydGFs dmVyYnVuZCBDQSAxMB4XDTIzMDQyNjExMTc1NFoXDTI4MDQyNDExMTc1NFowSzELMAkGA1UEBhMC QVQxEzARBgNVBAoMClN0YWR0IFdpZW4xDjAMBgNVBAsMBU1BIDAxMRcwFQYDVQQDDA5wdnAud2ll bi5ndi5hdDCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAMt+3YpuxpmEyJ7Ykvv7XkjA T+195NOpyiluh+3SwS4b+lq0KqMSejk5ka/U4HlCqpNbAL2W2DShYY9YufTrRNTLTVomSaIdbiVK FPOfvT+j5KVGGlMmbAOgHkhyC9DY0S+LEPV220p4I24vFQG8IECsoC6X/H5pB++DEbLxS22BGkAl FWpvDBaUAI67+VpOqpuxdvxPyYPROqqKXm1R5QsV2x4zrflQ4qNlPnvNn5gSDr6Gmz9Uf7aVboeU 8HbFhimK4bRleYFy0weRJn4g3XBg9CK01HaWWmQ5HCAOGAIGDlmc4O0fqZK5EWXq3SQoXaQuB7/j tWZK+/dngHZvqN5hiWOmTcup3Sgv9XlYK7F2ch/Enbk7TNhdQ1ksUhqVXHLFlA10QF5twizin1vJ gOUKSFjDEaTGSNbbVEh/cRCHuc+s5FvJdwEmCpyFAfXAEh5rlECTh8MbJgFOaDXzhFt8h17eaA6R X/KhJlbt5SIdflsvpx2vzQe+m+uY1t5VYwQqRGuHNGiM5FICy/eOjRfZJTsCoSnUAmyZ2Uk8retU hPaaFc/aQQCIuv9zI5PxsMLAhLrw7RIou8MK+OpMTrCOL3Z95Bu3K6kHLijKlShAwdk6G/dcGb+e iZgpdTOWQneKFfSqagjISXyoKrLD9dLgRa1SryjPqcgjxCO3wsYxAgMBAAGjgckwgcYwDAYDVR0T AQH/BAIwADAfBgNVHSMEGDAWgBS6Mo54oCbYbyXMPlw8Y3UYngvIsDBRBggrBgEFBQcBAQRFMEMw QQYIKwYBBQUHMAKGNWh0dHA6Ly9jcnQucGtpLndpZW4vc3RhZHRfd2llbl9wb3J0YWx2ZXJidW5k X2NhXzEuY3J0MBMGA1UdJQQMMAoGCCsGAQUFBwMCMB0GA1UdDgQWBBRioTf7IiNgwhlYhD7Uv1fT mQE/DjAOBgNVHQ8BAf8EBAMCBaAwDQYJKoZIhvcNAQELBQADggIBACYHShzGm4k80bVpqe1iuiG9 VYBs37ckwkTly48Utvq0C280j7VT4EmfDpyudoobJPDSldUCQpIils391NDxc4tPCfczkVlj9OoC d7EuRYeYZfzALWbtd3AtjGXDAlwJZUK/g0g41ct5AkMDPJkzkKcB+fQtSw/gZHiF3BXX1+zvAxU8 eTtHmZrjRGq7d1K/GSLYQU5Oz9Rp1jRWqJ2qgOiXKksbh4XVLo/dFnhTlVX4c8PnUdJj2yADtvyt Zh3YLJMe7DtyOeQV1gfUy6TK58ZJmagPnvzC/gnRb1oPgca15/hdN78GBbOy7ex2lqvRVdrvxIxd AaUoGp0g0GZybd0AbxcHKD73FI4TsJ9uyBaAb7Zz/JCWGbUeU0i9/poWEAPapLbjcZpn+98xoh4e Lr2iuc8CExWEECg3pVev5/20xnIQDM8GLgnC44oOCxZMFyPbVfKz/MZXiYuJn9677PVMdp13Cp2R Anf+a2wRGBNq24LJ2WriDoIVe5Z+xnkMtLa7nlFJFQqckE6uJiwQFfH3ZBw1bZInu4e6YWwReYmg KxronIN8Cb4wEEW+PLx/1GsYvqCcqMQGgTMCcamD1Sx5RyA50SmA9JRqF4389sjSWCZ/5l1sUDiv +K/ibdP5O+2Rlqg7T6/YIMmdpWhNyR5ybVm099MYopajUgiZtwnR<!--IssuerDN: CN=Stadt Wien Portalverbund CA 1, O=Stadt Wien, C=AT
+SubjectDN: CN=pvp.wien.gv.at, OU=MA 01, O=Stadt Wien, C=AT
+NotBefore: Wed Apr 26 13:17:54 CEST 2023
+NotAfter: Mon Apr 24 13:17:54 CEST 2028
+SerialNumber: 68828805089363845994580505240922826219019592380 (0xc0e63eee417d73e71731eb2f57076a0797462bc)
 SigAlgName: SHA256withRSA--></ds:X509Certificate>
         </ds:X509Data>
       </ds:KeyInfo>
@@ -35,12 +47,24 @@ SigAlgName: SHA256withRSA--></ds:X509Certificate>
         </ds:X509Data>
       </ds:KeyInfo>
     </md:KeyDescriptor>
+    <md:KeyDescriptor use="encryption">
+      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:X509Data>
+          <ds:X509Certificate>MIIF7TCCA9WgAwIBAgIUDA5j7uQX1z5xcx6y9XB2oHl0YrwwDQYJKoZIhvcNAQELBQAwSjELMAkG A1UEBhMCQVQxEzARBgNVBAoMClN0YWR0IFdpZW4xJjAkBgNVBAMMHVN0YWR0IFdpZW4gUG9ydGFs dmVyYnVuZCBDQSAxMB4XDTIzMDQyNjExMTc1NFoXDTI4MDQyNDExMTc1NFowSzELMAkGA1UEBhMC QVQxEzARBgNVBAoMClN0YWR0IFdpZW4xDjAMBgNVBAsMBU1BIDAxMRcwFQYDVQQDDA5wdnAud2ll bi5ndi5hdDCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAMt+3YpuxpmEyJ7Ykvv7XkjA T+195NOpyiluh+3SwS4b+lq0KqMSejk5ka/U4HlCqpNbAL2W2DShYY9YufTrRNTLTVomSaIdbiVK FPOfvT+j5KVGGlMmbAOgHkhyC9DY0S+LEPV220p4I24vFQG8IECsoC6X/H5pB++DEbLxS22BGkAl FWpvDBaUAI67+VpOqpuxdvxPyYPROqqKXm1R5QsV2x4zrflQ4qNlPnvNn5gSDr6Gmz9Uf7aVboeU 8HbFhimK4bRleYFy0weRJn4g3XBg9CK01HaWWmQ5HCAOGAIGDlmc4O0fqZK5EWXq3SQoXaQuB7/j tWZK+/dngHZvqN5hiWOmTcup3Sgv9XlYK7F2ch/Enbk7TNhdQ1ksUhqVXHLFlA10QF5twizin1vJ gOUKSFjDEaTGSNbbVEh/cRCHuc+s5FvJdwEmCpyFAfXAEh5rlECTh8MbJgFOaDXzhFt8h17eaA6R X/KhJlbt5SIdflsvpx2vzQe+m+uY1t5VYwQqRGuHNGiM5FICy/eOjRfZJTsCoSnUAmyZ2Uk8retU hPaaFc/aQQCIuv9zI5PxsMLAhLrw7RIou8MK+OpMTrCOL3Z95Bu3K6kHLijKlShAwdk6G/dcGb+e iZgpdTOWQneKFfSqagjISXyoKrLD9dLgRa1SryjPqcgjxCO3wsYxAgMBAAGjgckwgcYwDAYDVR0T AQH/BAIwADAfBgNVHSMEGDAWgBS6Mo54oCbYbyXMPlw8Y3UYngvIsDBRBggrBgEFBQcBAQRFMEMw QQYIKwYBBQUHMAKGNWh0dHA6Ly9jcnQucGtpLndpZW4vc3RhZHRfd2llbl9wb3J0YWx2ZXJidW5k X2NhXzEuY3J0MBMGA1UdJQQMMAoGCCsGAQUFBwMCMB0GA1UdDgQWBBRioTf7IiNgwhlYhD7Uv1fT mQE/DjAOBgNVHQ8BAf8EBAMCBaAwDQYJKoZIhvcNAQELBQADggIBACYHShzGm4k80bVpqe1iuiG9 VYBs37ckwkTly48Utvq0C280j7VT4EmfDpyudoobJPDSldUCQpIils391NDxc4tPCfczkVlj9OoC d7EuRYeYZfzALWbtd3AtjGXDAlwJZUK/g0g41ct5AkMDPJkzkKcB+fQtSw/gZHiF3BXX1+zvAxU8 eTtHmZrjRGq7d1K/GSLYQU5Oz9Rp1jRWqJ2qgOiXKksbh4XVLo/dFnhTlVX4c8PnUdJj2yADtvyt Zh3YLJMe7DtyOeQV1gfUy6TK58ZJmagPnvzC/gnRb1oPgca15/hdN78GBbOy7ex2lqvRVdrvxIxd AaUoGp0g0GZybd0AbxcHKD73FI4TsJ9uyBaAb7Zz/JCWGbUeU0i9/poWEAPapLbjcZpn+98xoh4e Lr2iuc8CExWEECg3pVev5/20xnIQDM8GLgnC44oOCxZMFyPbVfKz/MZXiYuJn9677PVMdp13Cp2R Anf+a2wRGBNq24LJ2WriDoIVe5Z+xnkMtLa7nlFJFQqckE6uJiwQFfH3ZBw1bZInu4e6YWwReYmg KxronIN8Cb4wEEW+PLx/1GsYvqCcqMQGgTMCcamD1Sx5RyA50SmA9JRqF4389sjSWCZ/5l1sUDiv +K/ibdP5O+2Rlqg7T6/YIMmdpWhNyR5ybVm099MYopajUgiZtwnR<!--IssuerDN: CN=Stadt Wien Portalverbund CA 1, O=Stadt Wien, C=AT
+SubjectDN: CN=pvp.wien.gv.at, OU=MA 01, O=Stadt Wien, C=AT
+NotBefore: Wed Apr 26 13:17:54 CEST 2023
+NotAfter: Mon Apr 24 13:17:54 CEST 2028
+SerialNumber: 68828805089363845994580505240922826219019592380 (0xc0e63eee417d73e71731eb2f57076a0797462bc)
+SigAlgName: SHA256withRSA--></ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
     <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://mein.wien.gv.at/stdportal-idp/extern.wien.gv.at/profile/SAML2/Redirect/SLO" ResponseLocation="https://mein.wien.gv.at/stdportal-idp/extern.wien.gv.at/profile/SAML2/Redirect/SLO"/>
     <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
     <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>
     <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://mein.wien.gv.at/stdportal-idp/extern.wien.gv.at/profile/SAML2/Redirect/SSO"/>
     <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://mein.wien.gv.at/stdportal-idp/extern.wien.gv.at/profile/SAML2/POST/SSO"/>
+    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://mein.wien.gv.at/stdportal-idp/extern.wien.gv.at/profile/SAML2/Redirect/SSO"/>
   </md:IDPSSODescriptor>
   <md:Organization>
     <md:OrganizationName xml:lang="en">Magistrat der Stadt Wien</md:OrganizationName>

--- a/back/engines/commercial/id_vienna_saml/config/saml/citizen/idp_metadata_test.xml
+++ b/back/engines/commercial/id_vienna_saml/config/saml/citizen/idp_metadata_test.xml
@@ -39,8 +39,8 @@ SigAlgName: SHA256withRSA--></ds:X509Certificate>
     <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
     <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>
     <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp-test.wien.gv.at/stdportal-idp/test.wien.gv.at/profile/SAML2/Redirect/SSO"/>
     <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp-test.wien.gv.at/stdportal-idp/test.wien.gv.at/profile/SAML2/POST/SSO"/>
+    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp-test.wien.gv.at/stdportal-idp/test.wien.gv.at/profile/SAML2/Redirect/SSO"/>
   </md:IDPSSODescriptor>
   <md:Organization>
     <md:OrganizationName xml:lang="en">Magistrat der Stadt Wien</md:OrganizationName>


### PR DESCRIPTION
### What's done?
I just ran these commands
```bash
wget https://mein.wien.gv.at/stdportal-idp/extern.wien.gv.at -O back/engines/commercial/id_vienna_saml/config/saml/citizen/idp_metadata_production.xml
wget --no-check-certificate https://idp-test.wien.gv.at/stdportal-idp/test.wien.gv.at -O back/engines/commercial/id_vienna_saml/config/saml/citizen/idp_metadata_test.xml
```
[This ticket](https://citizenlab.atlassian.net/browse/CL-1581) mentions that XML should be fixed manually, but I'm not sure how.
> Pay attention when implementing their metadata. They had a funky XML that required manual changes in their document for the employee IdP already (double entry for some kind of value)

### Testing
I'm not sure how to test it properly. On production, accessing this URL works https://mitgestalten.wien.gv.at/auth/vienna_citizen/ (the same as clicking the login button, after registering at https://mein.wien.gv.at/), but locally it fails with 500, the same as the login button.

I hoped it would work on this epic URL https://viennasaml.epic.citizenlab.co/en/ (it was tested here [before](https://citizenlabco.slack.com/archives/CQAGMHKT3/p1643364596326849)), but it also fails with `Beim Verarbeiten des Requests ist ein Fehler aufgetreten` with both `production` and `test` environment configured in the `vienna_citizen_login` feature.

I ran our tests in `engines/commercial/id_vienna_saml/spec/` with production config and they all passed.

So, the only option I see is to test it in production.

### Can we make such changes easier and more reliable?
Probably, yes.
1. We could use the `parse_remote_to_hash` [method](https://github.com/omniauth/omniauth-saml#idp-metadata) by getting metadata right here https://mein.wien.gv.at/stdportal-idp/extern.wien.gv.at. 
2. We could use federation. [Vienna's federation URL](https://citizenlabco.slack.com/archives/C02QT8TQFBL/p1684740475329499) is not accessible, but maybe it should be reached via some proxy. It seems the federation is supported by `ruby-saml` (first, it [wasn't supported](https://github.com/SAML-Toolkits/ruby-saml/issues/346), then it [was implemented](https://github.com/SAML-Toolkits/ruby-saml/pull/460)), but [not by](https://github.com/omniauth/omniauth-saml/issues/213) `omniauth-saml`.

But taking into account very limited testing capabilities, it would be really hard to implement any of it.

# Changelog
## Changed
- [CL-3645] Update Vienna SAML IDP metadata


[CL-3645]: https://citizenlab.atlassian.net/browse/CL-3645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ