### PR TITLE
CL-3672 - Fix ideas being able to be changed to anonymous

### DIFF
--- a/back/app/controllers/web_api/v1/ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/ideas_controller.rb
@@ -211,7 +211,6 @@ class WebApi::V1::IdeasController < ApplicationController
     save_options[:context] = :publication if params.dig(:idea, :publication_status) == 'published'
     ActiveRecord::Base.transaction do
       if input.save save_options
-        # authorize input
         service.after_update(input, current_user)
         render json: WebApi::V1::IdeaSerializer.new(
           input.reload,

--- a/back/app/controllers/web_api/v1/ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/ideas_controller.rb
@@ -211,7 +211,7 @@ class WebApi::V1::IdeasController < ApplicationController
     save_options[:context] = :publication if params.dig(:idea, :publication_status) == 'published'
     ActiveRecord::Base.transaction do
       if input.save save_options
-        authorize input
+        # authorize input
         service.after_update(input, current_user)
         render json: WebApi::V1::IdeaSerializer.new(
           input.reload,

--- a/back/spec/acceptance/ideas_spec.rb
+++ b/back/spec/acceptance/ideas_spec.rb
@@ -1073,7 +1073,7 @@ resource 'Ideas' do
           example 'Change an idea to anonymous as a non-admin', document: false do
             do_request
             assert_status 200
-            expect(response_data.dig(:attributes, :anonymous)).to eq true
+            expect(response_data.dig(:attributes, :anonymous)).to be true
           end
         end
 

--- a/back/spec/acceptance/ideas_spec.rb
+++ b/back/spec/acceptance/ideas_spec.rb
@@ -1067,6 +1067,25 @@ resource 'Ideas' do
           end
         end
 
+        describe 'Changing an idea to anonymous' do
+          let(:anonymous) { true }
+
+          example 'Change an idea to anonymous as a non-admin', document: false do
+            do_request
+            assert_status 200
+            expect(response_data.dig(:attributes, :anonymous)).to eq true
+          end
+        end
+
+        describe 'Changing an author' do
+          let(:author_id) { create(:user).id }
+
+          example '[Error] Cannot change an author as a non-admin', document: false do
+            do_request
+            assert_status 401
+          end
+        end
+
         context 'when admin' do
           before do
             @user = create(:admin)


### PR DESCRIPTION
Same issue that we faced with initiatives where it was double authorising.
