### PR TITLE
[CL-3671] Run the Que migration only in the public schema

### DIFF
--- a/back/db/migrate/20230517145937_update_que_tables_to_version5.rb
+++ b/back/db/migrate/20230517145937_update_que_tables_to_version5.rb
@@ -2,11 +2,15 @@
 
 class UpdateQueTablesToVersion5 < ActiveRecord::Migration[6.1]
   def up
+    return unless Apartment::Tenant.current == 'public'
+
     # See the comment on DEV_QUE_SQL_MIGRATION_5 for why we need to do this.
     Que.execute(DEV_QUE_SQL_MIGRATION_5)
   end
 
   def down
+    return unless Apartment::Tenant.current == 'public'
+
     Que.migrate!(version: 4)
   end
 


### PR DESCRIPTION
Prevent Apartment from running this migration for each schema. It seems that the "que" tables are missing in some of the schemas, which leads to the following error:
  ERROR:  relation "que_jobs" does not exist

We don't need "Que" tables (or Que objects in general — triggers, or functions) in the tenant schemas. Only the tables in the public schema are used.