### PR TITLE
Fix spacing issues in custom fields routes

### DIFF
--- a/front/app/containers/Admin/routes.tsx
+++ b/front/app/containers/Admin/routes.tsx
@@ -11,7 +11,6 @@ import settingsRoutes from './settings/routes';
 import createAdminMessagingRoutes from './messaging/routes';
 import ideasRoutes from './ideas/routes';
 import pagesAndMenuRoutes from './pagesAndMenu/routes';
-import customFieldRoutes from './settings/registration/CustomFieldRoutes/routes';
 import projectFoldersRoutes from './projectFolders/routes';
 import reportingRoutes from './reporting/routes';
 
@@ -123,7 +122,6 @@ const createAdminRoutes = () => {
       invitationsRoutes(),
       createAdminMessagingRoutes(),
       ideasRoutes(),
-      customFieldRoutes(),
       projectFoldersRoutes(),
       reportingRoutes(),
       {

--- a/front/app/containers/Admin/settings/registration/CustomFieldRoutes/routes.tsx
+++ b/front/app/containers/Admin/settings/registration/CustomFieldRoutes/routes.tsx
@@ -23,7 +23,7 @@ const AdminCustomFieldRegistrationOptionsEditComponent = React.lazy(
 );
 
 export default () => ({
-  path: 'settings/registration/custom-fields',
+  path: 'custom-fields',
   element: <AdminCustomFieldsContainer />,
   children: [
     {

--- a/front/app/containers/Admin/settings/registration/routes.tsx
+++ b/front/app/containers/Admin/settings/registration/routes.tsx
@@ -1,13 +1,22 @@
 import React, { lazy } from 'react';
 import PageLoading from 'components/UI/PageLoading';
+import customFieldRoutes from './CustomFieldRoutes/routes';
+import { Outlet } from 'react-router-dom';
 
 const AdminSettingsRegistration = lazy(() => import('.'));
 
 export default () => ({
   path: 'registration',
-  element: (
-    <PageLoading>
-      <AdminSettingsRegistration />
-    </PageLoading>
-  ),
+  element: <Outlet />,
+  children: [
+    {
+      path: '',
+      element: (
+        <PageLoading>
+          <AdminSettingsRegistration />
+        </PageLoading>
+      ),
+    },
+    customFieldRoutes(),
+  ],
 });


### PR DESCRIPTION
# Note
This moves the custom fields routes to settings such that they share context

# Changelog

## Fixed
Spacing of registration custom fields routes in the back office (`/admin/settings/registration/custom-fields/`)
