### PR TITLE
[CL-3518] Upgrade Que to 1.4.1

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -86,7 +86,7 @@ gem 'pundit', '~> 2.3.0'
 gem 'active_model_serializers', '~> 0.10.12'
 
 gem 'jwt', '~> 2.7.0'
-gem 'que', '~> 1.3.0'
+gem 'que', '~> 1.4.1'
 gem 'que-web', '~> 0.10.0'
 
 gem 'activerecord-import', '~> 1.4'

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -801,7 +801,7 @@ GEM
     pundit (2.3.0)
       activesupport (>= 3.0.0)
     qonfig (0.28.0)
-    que (1.3.1)
+    que (1.4.1)
     que-web (0.10.0)
       que (>= 1)
       sinatra
@@ -1182,7 +1182,7 @@ DEPENDENCIES
   public_api!
   puma (~> 6.2.2)
   pundit (~> 2.3.0)
-  que (~> 1.3.0)
+  que (~> 1.4.1)
   que-web (~> 0.10.0)
   rack-attack (~> 6)
   rack-cors


### PR DESCRIPTION
# Changelog
## Technical
- Upgrade [Que](https://github.com/que-rb/que/blob/master/CHANGELOG.md#140-2022-03-23) to version 1.4.1. 
