### PR TITLE
[CL-3466] Use allowed/enabled defaults from schema

### DIFF
--- a/back/app/services/settings_service.rb
+++ b/back/app/services/settings_service.rb
@@ -14,7 +14,10 @@ class SettingsService
     else
       res = settings.clone
       missing_features.each do |f|
-        res[f] = { 'allowed' => false, 'enabled' => false }
+        res[f] = {
+          'allowed' => (default = default_setting(schema, f, 'allowed')).nil? ? false : default,
+          'enabled' => (default = default_setting(schema, f, 'enabled')).nil? ? false : default
+        }
       end
       res
     end
@@ -26,7 +29,7 @@ class SettingsService
       required_settings = schema.dig('properties', feature, 'required-settings') || []
       required_settings.each do |setting|
         if settings.dig(feature, setting).nil?
-          default_value = schema.dig('properties', feature, 'properties', setting, 'default')
+          default_value = default_setting(schema, feature, setting)
           res[feature][setting] = default_value unless default_value.nil?
         end
       end
@@ -104,5 +107,11 @@ class SettingsService
         authentication_token_lifetime_in_days: 30
       }
     }
+  end
+
+  private
+
+  def default_setting(schema, feature, setting)
+    schema.dig('properties', feature, 'properties', setting, 'default')
   end
 end

--- a/back/spec/services/settings_service_spec.rb
+++ b/back/spec/services/settings_service_spec.rb
@@ -9,13 +9,18 @@ describe SettingsService do
       'properties' => {
         'a' => {},
         'b' => {},
-        'c' => {}
+        'c' => {
+          properties: {
+            allowed: { type: 'boolean', default: true },
+            enabled: { type: 'boolean', default: false }
+          }
+        }
       },
       'dependencies' => {
         'b' => ['a'],
         'c' => %w[a b]
       }
-    }
+    }.deep_stringify_keys
   end
 
   describe 'add_missing_features' do
@@ -29,10 +34,18 @@ describe SettingsService do
       expect(settings).to include('a', 'b', 'c')
     end
 
-    it 'makes missing features to unallowed and unenabled' do
+    it 'sets missing features to unallowed and unenabled' do
       settings = ss.add_missing_features({}, schema1)
       expect(settings['a']).to include({
         'allowed' => false,
+        'enabled' => false
+      })
+    end
+
+    it 'sets missing feature allowed/enabled to their default values' do
+      settings = ss.add_missing_features({}, schema1)
+      expect(settings['c']).to include({
+        'allowed' => true,
         'enabled' => false
       })
     end


### PR DESCRIPTION
https://citizenlabco.slack.com/archives/C016C2EHURY/p1685094315840389

# Changelog
## Technical
* [CL-3466] Use allowed/enabled defaults from schema. With this change, we don't need to run rake tasks anymore to set default values for allowed/enabled.


[CL-3466]: https://citizenlab.atlassian.net/browse/CL-3466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ