### PR TITLE
[CL-3518] Upgrade Que to 2.0.0 

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -86,7 +86,7 @@ gem 'pundit', '~> 2.3.0'
 gem 'active_model_serializers', '~> 0.10.12'
 
 gem 'jwt', '~> 2.7.0'
-gem 'que', '~> 1.4.1'
+gem 'que', '~> 2.0.0'
 gem 'que-web', '~> 0.10.0'
 
 gem 'activerecord-import', '~> 1.4'

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -801,7 +801,7 @@ GEM
     pundit (2.3.0)
       activesupport (>= 3.0.0)
     qonfig (0.28.0)
-    que (1.4.1)
+    que (2.0.0)
     que-web (0.10.0)
       que (>= 1)
       sinatra
@@ -1182,7 +1182,7 @@ DEPENDENCIES
   public_api!
   puma (~> 6.2.2)
   pundit (~> 2.3.0)
-  que (~> 1.4.1)
+  que (~> 2.0.0)
   que-web (~> 0.10.0)
   rack-attack (~> 6)
   rack-cors

--- a/back/db/migrate/20230526072941_fix_que_tables_version.rb
+++ b/back/db/migrate/20230526072941_fix_que_tables_version.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# This migration fixes the version of the Que tables for development and test
+# environments. The migration 'UpdateQueTablesToVersion5' ran a custom/modified version
+# of the que migration in those environments instead of using:
+#   Que.migrate!(5)
+# which would have bumped the version in the database after running the migration. As a
+# result, the version of the Que tables in the development and test environments stayed
+# at 4 instead of being bumped to 5.
+class FixQueTablesVersion < ActiveRecord::Migration[6.1]
+  def up
+    return unless Rails.env.development? || Rails.env.test?
+    return unless Que::Migrations.db_version == 4
+    raise <<~MSG.squish unless migration_context.get_all_versions.include?(20230517145937)
+      The migration 'FixQueTablesVersion' must be run after the migration
+      'UpdateQueTablesToVersion5' (20230517145937), as it fixes errors introduced by
+      that migration.
+    MSG
+
+    Que::Migrations.set_db_version(5)
+  end
+
+  private
+
+  def migration_context
+    migration_paths = ActiveRecord::Migrator.migrations_paths
+    schema_migration = ActiveRecord::Base.connection.schema_migration
+    ActiveRecord::MigrationContext.new(migration_paths, schema_migration)
+  end
+end
+

--- a/back/db/migrate/20230526072942_update_que_tables_to_version6.rb
+++ b/back/db/migrate/20230526072942_update_que_tables_to_version6.rb
@@ -1,0 +1,16 @@
+class UpdateQueTablesToVersion6 < ActiveRecord::Migration[6.1]
+  def up
+    # The "que" tables (and other database objects) are shared across tenants and are
+    # stored in the public schema. Some tenants may contain copies of those tables
+    # (from previous migrations) but they are not used.
+    return unless Apartment::Tenant.current == 'public'
+
+    Que.migrate!(version: 6)
+  end
+
+  def down
+    return unless Apartment::Tenant.current == 'public'
+
+    Que.migrate!(version: 5)
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_26_072941) do
+ActiveRecord::Schema.define(version: 2023_05_26_072942) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -1120,7 +1120,7 @@ ActiveRecord::Schema.define(version: 2023_05_26_072941) do
     t.index ["tenant_id"], name: "index_public_api_api_clients_on_tenant_id"
   end
 
-  create_table "que_jobs", comment: "5", force: :cascade do |t|
+  create_table "que_jobs", comment: "6", force: :cascade do |t|
     t.integer "priority", limit: 2, default: 100, null: false
     t.datetime "run_at", default: -> { "now()" }, null: false
     t.text "job_class", null: false
@@ -1132,11 +1132,12 @@ ActiveRecord::Schema.define(version: 2023_05_26_072941) do
     t.datetime "expired_at"
     t.jsonb "args", default: [], null: false
     t.jsonb "data", default: {}, null: false
-    t.integer "job_schema_version", default: 1
+    t.integer "job_schema_version", null: false
+    t.jsonb "kwargs", default: {}, null: false
     t.index ["args"], name: "que_jobs_args_gin_idx", opclass: :jsonb_path_ops, using: :gin
     t.index ["data"], name: "que_jobs_data_gin_idx", opclass: :jsonb_path_ops, using: :gin
-    t.index ["job_schema_version", "queue", "priority", "run_at", "id"], name: "que_poll_idx_with_job_schema_version", where: "((finished_at IS NULL) AND (expired_at IS NULL))"
-    t.index ["queue", "priority", "run_at", "id"], name: "que_poll_idx", where: "((finished_at IS NULL) AND (expired_at IS NULL))"
+    t.index ["job_schema_version", "queue", "priority", "run_at", "id"], name: "que_poll_idx", where: "((finished_at IS NULL) AND (expired_at IS NULL))"
+    t.index ["kwargs"], name: "que_jobs_kwargs_gin_idx", opclass: :jsonb_path_ops, using: :gin
   end
 
   create_table "que_lockers", primary_key: "pid", id: :integer, default: nil, force: :cascade do |t|

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_24_151508) do
+ActiveRecord::Schema.define(version: 2023_05_26_072941) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -1120,7 +1120,7 @@ ActiveRecord::Schema.define(version: 2023_05_24_151508) do
     t.index ["tenant_id"], name: "index_public_api_api_clients_on_tenant_id"
   end
 
-  create_table "que_jobs", comment: "4", force: :cascade do |t|
+  create_table "que_jobs", comment: "5", force: :cascade do |t|
     t.integer "priority", limit: 2, default: 100, null: false
     t.datetime "run_at", default: -> { "now()" }, null: false
     t.text "job_class", null: false

--- a/back/lib/active_job_que_extension.rb
+++ b/back/lib/active_job_que_extension.rb
@@ -10,6 +10,7 @@ module ActiveJobQueExtension
         def perform_retries(should_retry = true)
           self.should_retry = should_retry
         end
+
         # rubocop:enable Style/OptionalBooleanParameter
       end
     end
@@ -19,15 +20,26 @@ module ActiveJobQueExtension
     self.class.should_retry ? super : expire
   end
 
-  # Removing the freeze step from
-  # https://github.com/que-rb/que/blob/77c6b92952b821898c393239ce0e4047b17d7dae/lib/que/active_job/extensions.rb#L14
+  # Removing the freeze steps from
+  # https://github.com/que-rb/que/blob/3d452f22688558e87f71d079029d75eb09bf2203/lib/que/active_job/extensions.rb#L14
+  #
+  # Addendum: It's unclear why the freeze steps were removed when originally patching
+  # Que for multi-tenancy support. However, when upgrading to Que 2.0.0, we simply
+  # transposed the same logic to the new implementation of the +perform+ method.
+  # Ideally, we should investigate why the freeze steps were initially removed and
+  # determine if there is a less invasive way to support multi-tenancy.
   def perform(*args)
-    Que.internal_log(:active_job_perform, self) { { args: args } }
+    args, kwargs = Que.split_out_ruby2_keywords(args)
+
+    Que.internal_log(:active_job_perform, self) do
+      { args: args, kwargs: kwargs }
+    end
 
     _run(
       args: que_filter_args(
         args.map { |a| a.is_a?(Hash) ? a.deep_symbolize_keys : a }
       ),
+      kwargs: que_filter_args(kwargs.deep_symbolize_keys),
       reraise_errors: true
     )
   end


### PR DESCRIPTION
# Changelog
## Technical
- Upgrade Que to version [2.0.0](https://github.com/que-rb/que/blob/master/CHANGELOG.md#200-2022-08-25).
