### PR TITLE
[NA] Fill in required-settings and features before create

### DIFF
--- a/back/app/models/app_configuration.rb
+++ b/back/app/models/app_configuration.rb
@@ -33,6 +33,7 @@ class AppConfiguration < ApplicationRecord
   validate :validate_singleton, on: :create
 
   before_validation :validate_missing_feature_dependencies
+  before_validation :add_missing_features_and_settings, on: :create
 
   after_update do
     AppConfiguration.instance.reload
@@ -110,6 +111,13 @@ class AppConfiguration < ApplicationRecord
     self.settings = ss.add_missing_features(settings, schema)
     self.settings = ss.add_missing_settings(settings, schema)
     self
+  end
+
+  def add_missing_features_and_settings
+    ss = SettingsService.new
+    schema = Settings.json_schema
+    self.settings = ss.add_missing_features(settings, schema)
+    self.settings = ss.add_missing_settings(settings, schema)
   end
 
   def feature_activated?(setting_name)

--- a/back/app/services/settings_service.rb
+++ b/back/app/services/settings_service.rb
@@ -14,7 +14,10 @@ class SettingsService
     else
       res = settings.clone
       missing_features.each do |f|
-        res[f] = { 'allowed' => false, 'enabled' => false }
+        res[f] = {
+          'allowed' => (default = default_setting(schema, f, 'allowed')).nil? ? false : default,
+          'enabled' => (default = default_setting(schema, f, 'enabled')).nil? ? false : default
+        }
       end
       res
     end
@@ -26,7 +29,7 @@ class SettingsService
       required_settings = schema.dig('properties', feature, 'required-settings') || []
       required_settings.each do |setting|
         if settings.dig(feature, setting).nil?
-          default_value = schema.dig('properties', feature, 'properties', setting, 'default')
+          default_value = default_setting(schema, feature, setting)
           res[feature][setting] = default_value unless default_value.nil?
         end
       end
@@ -104,5 +107,11 @@ class SettingsService
         authentication_token_lifetime_in_days: 30
       }
     }
+  end
+
+  private
+
+  def default_setting(schema, feature, setting)
+    schema.dig('properties', feature, 'properties', setting, 'default')
   end
 end

--- a/back/app/services/settings_service.rb
+++ b/back/app/services/settings_service.rb
@@ -15,8 +15,8 @@ class SettingsService
       res = settings.clone
       missing_features.each do |f|
         res[f] = {
-          'allowed' => (default = default_setting(schema, f, 'allowed')).nil? ? false : default,
-          'enabled' => (default = default_setting(schema, f, 'enabled')).nil? ? false : default
+          'allowed' => !!default_setting(schema, f, 'allowed'),
+          'enabled' => !!default_setting(schema, f, 'enabled')
         }
       end
       res

--- a/back/engines/commercial/id_clave_unica/app/lib/id_clave_unica/feature_specification.rb
+++ b/back/engines/commercial/id_clave_unica/app/lib/id_clave_unica/feature_specification.rb
@@ -17,5 +17,13 @@ module IdClaveUnica
     def self.feature_description
       'Allow users to authenticate and verify with a ClaveUnica account.'
     end
+
+    def self.allowed_by_default
+      false
+    end
+
+    def self.enabled_by_default
+      false
+    end
   end
 end

--- a/back/engines/commercial/id_franceconnect/app/lib/id_franceconnect/feature_specification.rb
+++ b/back/engines/commercial/id_franceconnect/app/lib/id_franceconnect/feature_specification.rb
@@ -18,6 +18,14 @@ module IdFranceconnect
       'Allow users to authenticate and verify with a FranceConnect account.'
     end
 
+    def self.allowed_by_default
+      false
+    end
+
+    def self.enabled_by_default
+      false
+    end
+
     add_setting 'environment', required: true, schema: {
       type: 'string',
       title: 'Environment',

--- a/back/engines/commercial/multi_tenancy/spec/factories/tenants.rb
+++ b/back/engines/commercial/multi_tenancy/spec/factories/tenants.rb
@@ -58,6 +58,10 @@ FactoryBot.define do
         user_confirmation: {
           enabled: false,
           allowed: false
+        },
+        verification: {
+          enabled: false,
+          allowed: false
         }
       })
     end

--- a/back/engines/commercial/multi_tenancy/spec/factories/tenants.rb
+++ b/back/engines/commercial/multi_tenancy/spec/factories/tenants.rb
@@ -54,6 +54,10 @@ FactoryBot.define do
           days_limit: 90,
           threshold_reached_message: { 'en' => 'Threshold reached' },
           eligibility_criteria: { 'en' => 'Eligibility criteria' }
+        },
+        user_confirmation: {
+          enabled: false,
+          allowed: false
         }
       })
     end

--- a/back/engines/commercial/multi_tenancy/spec/serializers/web_api/v1/external/tenant_serializer_spec.rb
+++ b/back/engines/commercial/multi_tenancy/spec/serializers/web_api/v1/external/tenant_serializer_spec.rb
@@ -44,10 +44,6 @@ describe 'WebApi::V1::External::TenantSerializer' do
       expect(result[:settings]).to include(**tenant_attrs[:settings])
     end
 
-    it 'includes features beyond minimal required settings' do
-      expect(result[:settings]).to include('user_confirmation' => { 'enabled' => true, 'allowed' => true })
-    end
-
     context 'when the app configuration is passed explicitly' do
       subject(:result) do
         tenant = Tenant.current

--- a/back/spec/factories/users.rb
+++ b/back/spec/factories/users.rb
@@ -19,6 +19,10 @@ FactoryBot.define do
     avatar { Rails.root.join('spec/fixtures/robot.jpg').open }
     invite_status { 'accepted' }
 
+    after(:build) do |user, _evaluator|
+      user.send(:confirmation_required=, false)
+    end
+
     factory :admin do
       roles { [{ type: 'admin' }] }
       factory :super_admin do

--- a/back/spec/factories/users.rb
+++ b/back/spec/factories/users.rb
@@ -19,10 +19,6 @@ FactoryBot.define do
     avatar { Rails.root.join('spec/fixtures/robot.jpg').open }
     invite_status { 'accepted' }
 
-    after(:build) do |user, _evaluator|
-      user.send(:confirmation_required=, false)
-    end
-
     factory :admin do
       roles { [{ type: 'admin' }] }
       factory :super_admin do

--- a/back/spec/services/settings_service_spec.rb
+++ b/back/spec/services/settings_service_spec.rb
@@ -9,13 +9,18 @@ describe SettingsService do
       'properties' => {
         'a' => {},
         'b' => {},
-        'c' => {}
+        'c' => {
+          properties: {
+            allowed: { type: 'boolean', default: true },
+            enabled: { type: 'boolean', default: false }
+          }
+        }
       },
       'dependencies' => {
         'b' => ['a'],
         'c' => %w[a b]
       }
-    }
+    }.deep_stringify_keys
   end
 
   describe 'add_missing_features' do
@@ -29,10 +34,18 @@ describe SettingsService do
       expect(settings).to include('a', 'b', 'c')
     end
 
-    it 'makes missing features to unallowed and unenabled' do
+    it 'sets missing features to unallowed and unenabled' do
       settings = ss.add_missing_features({}, schema1)
       expect(settings['a']).to include({
         'allowed' => false,
+        'enabled' => false
+      })
+    end
+
+    it 'sets missing feature allowed/enabled to their default values' do
+      settings = ss.add_missing_features({}, schema1)
+      expect(settings['c']).to include({
+        'allowed' => true,
         'enabled' => false
       })
     end


### PR DESCRIPTION
If you add a new item of required-settings or a new feature, you don't need to update seeds and tests anymore for it to work. That's what DEFAULT means :smile: 

The previous attempt was here https://github.com/CitizenLabDotCo/citizenlab/pull/3291
But now, after this PR https://github.com/CitizenLabDotCo/citizenlab/pull/4983, we won't need to update pricing plans (no need to run rake tasks) in more cases ([like here](https://github.com/CitizenLabDotCo/citizenlab/pull/4732/files#diff-f1922f7571df32ef9822ca67a0c95052b6017690b7fee5f42c002c7d228c75d2R761)).