### PR TITLE
CL-3668 - Fix for moderators not being able to see ideas in other projects with group visibility

### DIFF
--- a/back/app/controllers/web_api/v1/comments_controller.rb
+++ b/back/app/controllers/web_api/v1/comments_controller.rb
@@ -89,11 +89,11 @@ class WebApi::V1::CommentsController < ApplicationController
       .where(post_type: @post_type)
       .includes(:author, :"#{@post_type.underscore}")
       .order(:lft)
-    if (@post_type == 'Idea') && params[:project].present?
-      @comments = @comments.where(ideas: { project_id: params[:project] })
-    end
-    if (@post_type == 'Idea')
+    if @post_type == 'Idea'
       @comments = @comments.where(ideas: { project_id: UserRoleService.new.moderatable_projects(current_user) })
+      if params[:project].present?
+        @comments = @comments.where(ideas: { project_id: params[:project] })
+      end
     end
     @comments = @comments.where(post_id: post_ids) if post_ids.present?
 

--- a/back/app/controllers/web_api/v1/comments_controller.rb
+++ b/back/app/controllers/web_api/v1/comments_controller.rb
@@ -92,6 +92,9 @@ class WebApi::V1::CommentsController < ApplicationController
     if (@post_type == 'Idea') && params[:project].present?
       @comments = @comments.where(ideas: { project_id: params[:project] })
     end
+    if (@post_type == 'Idea')
+      @comments = @comments.where(ideas: { project_id: UserRoleService.new.moderatable_projects(current_user) })
+    end
     @comments = @comments.where(post_id: post_ids) if post_ids.present?
 
     I18n.with_locale(current_user&.locale) do

--- a/back/app/policies/idea_policy.rb
+++ b/back/app/policies/idea_policy.rb
@@ -15,9 +15,7 @@ class IdeaPolicy < ApplicationPolicy
         scope.all
       elsif user
         projects = Pundit.policy_scope(user, Project)
-        user_scope = scope.where(project: projects, publication_status: %w[published closed])
-        user_scope = user_scope.or(scope.where(project_id: user.moderatable_project_ids)) if user&.project_moderator?
-        user_scope
+        scope.where(project: projects, publication_status: %w[published closed])
       else
         scope
           .left_outer_joins(project: [:admin_publication])

--- a/back/app/policies/idea_policy.rb
+++ b/back/app/policies/idea_policy.rb
@@ -13,11 +13,11 @@ class IdeaPolicy < ApplicationPolicy
     def resolve
       if user&.admin?
         scope.all
-      elsif user&.project_moderator?
-        scope.where(project_id: user.moderatable_project_ids)
       elsif user
         projects = Pundit.policy_scope(user, Project)
-        scope.where(project: projects, publication_status: %w[published closed])
+        user_scope = scope.where(project: projects, publication_status: %w[published closed])
+        user_scope = user_scope.or(scope.where(project_id: user.moderatable_project_ids)) if user&.project_moderator?
+        user_scope
       else
         scope
           .left_outer_joins(project: [:admin_publication])


### PR DESCRIPTION
# Changelog

## Fixed
- Moderators on one project could not see content on another project requiring a group they are a member of
