### PR TITLE
[CL-3694] Custom from email setting

### DIFF
--- a/back/app/mailers/application_mailer.rb
+++ b/back/app/mailers/application_mailer.rb
@@ -114,7 +114,9 @@ class ApplicationMailer < ActionMailer::Base
   end
 
   def from_email
-    email_address_with_name(ENV.fetch('DEFAULT_FROM_EMAIL'), organization_name)
+    email = AppConfiguration.instance.settings.dig('core', 'from_email') || ENV.fetch('DEFAULT_FROM_EMAIL')
+
+    email_address_with_name(email, organization_name)
   end
 
   def to_email

--- a/back/app/mailers/application_mailer.rb
+++ b/back/app/mailers/application_mailer.rb
@@ -115,7 +115,7 @@ class ApplicationMailer < ActionMailer::Base
   end
 
   def from_email
-    email = custom_from_email || ENV.fetch('DEFAULT_FROM_EMAIL')
+    email = custom_from_email.presence || ENV.fetch('DEFAULT_FROM_EMAIL')
 
     email_address_with_name(email, organization_name)
   end

--- a/back/app/mailers/application_mailer.rb
+++ b/back/app/mailers/application_mailer.rb
@@ -121,7 +121,7 @@ class ApplicationMailer < ActionMailer::Base
   end
 
   def custom_from_email
-    AppConfiguration.instance.settings.dig('core', 'from_email')
+    app_settings.core.from_email
   end
 
   def to_email

--- a/back/app/mailers/application_mailer.rb
+++ b/back/app/mailers/application_mailer.rb
@@ -114,7 +114,10 @@ class ApplicationMailer < ActionMailer::Base
   end
 
   def from_email
-    email = AppConfiguration.instance.settings.dig('core', 'from_email') || ENV.fetch('DEFAULT_FROM_EMAIL')
+    custom_email = AppConfiguration.instance.settings.dig('core', 'from_email')
+    ::Rails.application.config.action_mailer.mailgun_settings[:domain] = custom_email.split('@').last if custom_email
+
+    email = custom_email || ENV.fetch('DEFAULT_FROM_EMAIL')
 
     email_address_with_name(email, organization_name)
   end

--- a/back/app/mailers/application_mailer.rb
+++ b/back/app/mailers/application_mailer.rb
@@ -133,7 +133,7 @@ class ApplicationMailer < ActionMailer::Base
   end
 
   def domain
-    custom_from_email&.split('@')&.last
+    from_email&.split('@')&.last
   end
 
   def app_settings

--- a/back/app/mailers/application_mailer.rb
+++ b/back/app/mailers/application_mailer.rb
@@ -92,7 +92,8 @@ class ApplicationMailer < ActionMailer::Base
       subject: subject,
       from: from_email,
       to: to_email,
-      reply_to: reply_to_email
+      reply_to: reply_to_email,
+      domain: domain
     }
   end
 
@@ -114,12 +115,13 @@ class ApplicationMailer < ActionMailer::Base
   end
 
   def from_email
-    custom_email = AppConfiguration.instance.settings.dig('core', 'from_email')
-    ::Rails.application.config.action_mailer.mailgun_settings[:domain] = custom_email.split('@').last if custom_email
-
-    email = custom_email || ENV.fetch('DEFAULT_FROM_EMAIL')
+    email = custom_from_email || ENV.fetch('DEFAULT_FROM_EMAIL')
 
     email_address_with_name(email, organization_name)
+  end
+
+  def custom_from_email
+    AppConfiguration.instance.settings.dig('core', 'from_email')
   end
 
   def to_email
@@ -128,6 +130,10 @@ class ApplicationMailer < ActionMailer::Base
 
   def reply_to_email
     app_settings.core.reply_to_email.presence || ENV.fetch('DEFAULT_FROM_EMAIL')
+  end
+
+  def domain
+    custom_from_email&.split('@')&.last
   end
 
   def app_settings

--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -169,7 +169,7 @@
           },
           "from_email": {
             "title": "From email",
-            "description": "The email used in the from field when users receive emails from automated campaigns.",
+            "description": "The email used in the from field when users receive emails. This should only be configured in case the corresponding Second Line Support work has already happened and the customer has made the necessary DNS changes, or emails will not function at all.",
             "type": "string",
             "format": "email"
           },

--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -167,6 +167,12 @@
             "description": "What a tag unit should be called on this platform (e.g., department, theme, etc.). Input the singular form here with all lowercase letters. If left blank, this field defaults to 'tag'.",
             "$ref": "#/definitions/multiloc_string"
           },
+          "from_email": {
+            "title": "From email",
+            "description": "The email used in the from field when users receive emails from automated campaigns.",
+            "type": "string",
+            "format": "email"
+          },
           "reply_to_email": {
             "title": "Reply-to email",
             "description": "The email used in the reply-to field when users receive emails from automated campaigns.",

--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -169,7 +169,7 @@
           },
           "from_email": {
             "title": "From email",
-            "description": "The email used in the from field when users receive emails. This should only be configured in case the corresponding Second Line Support work has already happened and the customer has made the necessary DNS changes, or emails will not function at all.",
+            "description": "The email used in the from field when users receive emails. This should only be configured when the corresponding Second Line Support work has already happened and the customer has made the necessary DNS changes, or emails will not function at all.",
             "type": "string",
             "format": "email"
           },


### PR DESCRIPTION
Adds the ability to specify a custom from email address (and set the related domain accordingly) via AdminHQ:

<img width="1057" alt="Screenshot 2023-05-31 at 11 21 08" src="https://github.com/CitizenLabDotCo/citizenlab/assets/3944042/07d38cbe-87a2-4348-93b9-4d9eb40e0daf">

  
Does not include tests. These will be added after testing on staging (if this approach proves successful).

# Changelog
## Added
- [CL-3694] Custom 'from' email address per tenant, via setting in AdminHQ Core settings.

[CL-3694]: https://citizenlab.atlassian.net/browse/CL-3694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ