### PR TITLE
[CL-3688] Fix eternal spinner

### DIFF
--- a/front/app/utils/cl-react-query/queryClient.ts
+++ b/front/app/utils/cl-react-query/queryClient.ts
@@ -5,12 +5,7 @@ export const queryClient = new QueryClient({
     queries: {
       staleTime: Infinity,
       keepPreviousData: true,
-      retry: (_, error) => {
-        if (process.env.NODE_ENV === 'test') return false;
-
-        if (typeof error !== 'string') return true;
-        return !error.includes("Couldn't find");
-      },
+      retry: false,
     },
   },
 });


### PR DESCRIPTION
Fixes the eternal spinner problem on many pages of the platform (not just projects page) by removing retries in the `queryClient.ts`. Iva and I investigated this issue and the fix was to remove the retry logic, however it's still a bit unclear why it was causing the eternal loading state issue.
