### PR TITLE
[CL-3695] Add back beta label next to Texting tab in messaging

### DIFF
--- a/front/app/components/admin/NavigationTabs/Tab.tsx
+++ b/front/app/components/admin/NavigationTabs/Tab.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import { StatusLabel } from '@citizenlab/cl2-component-library';
+import { Box, StatusLabel } from '@citizenlab/cl2-component-library';
+import Link from 'utils/cl-router/Link';
 
 // style
 import styled, { css } from 'styled-components';
@@ -14,9 +15,13 @@ import {
 
 export const darkSkyBlue = '#7FBBCA'; // TODO: Use color from component library.
 
+type ContainerProps = {
+  active: boolean;
+};
+
 // very similar to front/app/components/admin/TabbedResource/Tab.tsx
 const Container = styled.div`
-  ${({ active }: TabProps) => css`
+  ${({ active }: ContainerProps) => css`
     list-style: none;
     cursor: pointer;
     display: flex;
@@ -62,25 +67,27 @@ const Container = styled.div`
   `}
 `;
 
-const StatusLabelWithMargin = styled(StatusLabel)`
-  margin-left: 12px;
-`;
-
 type TabProps = {
+  label: string;
+  url: string;
   active: boolean;
   statusLabel?: string;
 } & React.HTMLAttributes<HTMLDivElement>;
 
-const Tab = ({ active, statusLabel, children, ...props }: TabProps) => (
+const Tab = ({ label, url, active, statusLabel, ...props }: TabProps) => (
   <Container active={active} {...props}>
-    {children}
-    {statusLabel && (
-      <StatusLabelWithMargin
-        text={statusLabel}
-        backgroundColor={colors.background}
-        variant="outlined"
-      />
-    )}
+    <Link to={url}>
+      {label}
+      {statusLabel && (
+        <Box ml="12px" display="inline">
+          <StatusLabel
+            text={statusLabel}
+            backgroundColor={colors.background}
+            variant="outlined"
+          />
+        </Box>
+      )}
+    </Link>
   </Container>
 );
 

--- a/front/app/components/admin/NavigationTabs/Tab.tsx
+++ b/front/app/components/admin/NavigationTabs/Tab.tsx
@@ -1,3 +1,7 @@
+import React from 'react';
+
+import { StatusLabel } from '@citizenlab/cl2-component-library';
+
 // style
 import styled, { css } from 'styled-components';
 import { colors, fontSizes } from 'utils/styleUtils';
@@ -10,7 +14,8 @@ import {
 
 export const darkSkyBlue = '#7FBBCA'; // TODO: Use color from component library.
 
-const Tab = styled.div`
+// very similar to front/app/components/admin/TabbedResource/Tab.tsx
+const Container = styled.div`
   ${({ active }: TabProps) => css`
     list-style: none;
     cursor: pointer;
@@ -27,7 +32,7 @@ const Tab = styled.div`
       margin-right: 40px;
     }
 
-    > * {
+    a {
       color: ${colors.textSecondary};
       font-size: ${fontSizes.base}px;
       font-weight: 400;
@@ -38,7 +43,7 @@ const Tab = styled.div`
       transition: all 100ms ease-out;
     }
 
-    &:hover > * {
+    &:hover a {
       color: ${colors.primary};
     }
 
@@ -51,12 +56,32 @@ const Tab = styled.div`
     `border-color: ${darkSkyBlue};
     // border-color: ${colors.primary}; TODO : set accent color in component library
 
-    > * {
+    a {
         color: ${colors.primary};
     }`}
   `}
 `;
 
-type TabProps = { active: boolean } & React.HTMLAttributes<HTMLDivElement>;
+const StatusLabelWithMargin = styled(StatusLabel)`
+  margin-left: 12px;
+`;
+
+type TabProps = {
+  active: boolean;
+  statusLabel?: string;
+} & React.HTMLAttributes<HTMLDivElement>;
+
+const Tab = ({ active, statusLabel, children, ...props }: TabProps) => (
+  <Container active={active} {...props}>
+    {children}
+    {statusLabel && (
+      <StatusLabelWithMargin
+        text={statusLabel}
+        backgroundColor={colors.background}
+        variant="outlined"
+      />
+    )}
+  </Container>
+);
 
 export default Tab;

--- a/front/app/components/admin/TabbedResource/Tab.tsx
+++ b/front/app/components/admin/TabbedResource/Tab.tsx
@@ -1,4 +1,4 @@
-import { StatusLabel } from '@citizenlab/cl2-component-library';
+import { Box, StatusLabel } from '@citizenlab/cl2-component-library';
 import React from 'react';
 import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
@@ -44,10 +44,6 @@ const Container = styled.div`
   }
 `;
 
-const StatusLabelWithMargin = styled(StatusLabel)`
-  margin-left: 12px;
-`;
-
 interface Props {
   tab: ITab;
   className?: string;
@@ -79,11 +75,13 @@ const Tab = ({
       <Link to={url}>
         {label}
         {statusLabel && (
-          <StatusLabelWithMargin
-            text={statusLabel}
-            backgroundColor={colors.background}
-            variant="outlined"
-          />
+          <Box ml="12px" display="inline">
+            <StatusLabel
+              text={statusLabel}
+              backgroundColor={colors.background}
+              variant="outlined"
+            />
+          </Box>
         )}
       </Link>
     </Container>

--- a/front/app/components/admin/TabbedResource/Tab.tsx
+++ b/front/app/components/admin/TabbedResource/Tab.tsx
@@ -6,6 +6,7 @@ import { ITab } from 'typings';
 import Link from 'utils/cl-router/Link';
 import { colors, fontSizes } from 'utils/styleUtils';
 
+// very similar to front/app/components/admin/NavigationTabs/Tab.tsx
 const Container = styled.div`
   list-style: none;
   cursor: pointer;

--- a/front/app/containers/Admin/dashboard/components/DashboardTabs.tsx
+++ b/front/app/containers/Admin/dashboard/components/DashboardTabs.tsx
@@ -1,7 +1,6 @@
 import React, { memo, useMemo } from 'react';
 
 import { withRouter, WithRouterProps } from 'utils/cl-router/withRouter';
-import Link from 'utils/cl-router/Link';
 
 // typings
 import { ITab } from 'typings';
@@ -47,23 +46,23 @@ const DashboardTabs = memo<Props & WithRouterProps>(
                     return (
                       <FeatureFlag key={tab.url} name={tab.feature}>
                         <Tab
+                          label={tab.label}
+                          url={tab.url}
                           key={tab.url}
                           active={active}
                           className={`${classes} intercom-admin-dashboard-tab-${tab.name}`}
-                        >
-                          <Link to={tab.url}>{tab.label}</Link>
-                        </Tab>
+                        />
                       </FeatureFlag>
                     );
                   } else {
                     return (
                       <Tab
+                        label={tab.label}
+                        url={tab.url}
                         key={tab.url}
                         active={active}
                         className={`${classes} intercom-admin-dashboard-tab-${tab.name}`}
-                      >
-                        <Link to={tab.url}>{tab.label}</Link>
-                      </Tab>
+                      />
                     );
                   }
                 })}

--- a/front/app/containers/Admin/initiatives/index.tsx
+++ b/front/app/containers/Admin/initiatives/index.tsx
@@ -8,7 +8,6 @@ import NavigationTabs, {
   Tab,
   TabsPageLayout,
 } from 'components/admin/NavigationTabs';
-import Link from 'utils/cl-router/Link';
 
 // i18n
 import messages from './messages';
@@ -58,11 +57,11 @@ const InitiativesPage = memo<WrappedComponentProps & WithRouterProps>(
         <NavigationTabs>
           {tabs.map(({ url, label }) => (
             <Tab
+              label={label}
+              url={url}
               key={url}
               active={isTopBarNavActive('/admin/initiatives', pathname, url)}
-            >
-              <Link to={url}>{label}</Link>
-            </Tab>
+            />
           ))}
         </NavigationTabs>
 

--- a/front/app/containers/Admin/messaging/index.tsx
+++ b/front/app/containers/Admin/messaging/index.tsx
@@ -17,7 +17,6 @@ import NavigationTabs, {
   Tab,
   TabsPageLayout,
 } from 'components/admin/NavigationTabs';
-import Link from 'utils/cl-router/Link';
 import { isTopBarNavActive } from 'utils/helperUtils';
 
 interface DataProps {
@@ -89,12 +88,12 @@ const MessagingDashboard = ({
       <NavigationTabs>
         {tabs.map(({ url, label, statusLabel }) => (
           <Tab
+            label={label}
+            url={url}
             key={url}
             active={isTopBarNavActive('/admin/messaging', pathname, url)}
             statusLabel={statusLabel}
-          >
-            <Link to={url}>{label}</Link>
-          </Tab>
+          />
         ))}
       </NavigationTabs>
 

--- a/front/app/containers/Admin/messaging/index.tsx
+++ b/front/app/containers/Admin/messaging/index.tsx
@@ -87,10 +87,11 @@ const MessagingDashboard = ({
   return (
     <>
       <NavigationTabs>
-        {tabs.map(({ url, label }) => (
+        {tabs.map(({ url, label, statusLabel }) => (
           <Tab
             key={url}
             active={isTopBarNavActive('/admin/messaging', pathname, url)}
+            statusLabel={statusLabel}
           >
             <Link to={url}>{label}</Link>
           </Tab>

--- a/front/app/containers/Admin/reporting/components/Tabs.tsx
+++ b/front/app/containers/Admin/reporting/components/Tabs.tsx
@@ -10,7 +10,6 @@ import NavigationTabs, {
   Tab,
   TabsPageLayout,
 } from 'components/admin/NavigationTabs';
-import Link from 'utils/cl-router/Link';
 import Outlet from 'components/Outlet';
 
 // i18n
@@ -72,11 +71,11 @@ const DashboardTabs = ({ showReportBuilderTab, children }: Props) => {
       <NavigationTabs>
         {tabs.map(({ url, label }) => (
           <Tab
+            label={label}
+            url={url}
             key={url}
             active={isTopBarNavActive('/admin/reporting', pathname, url)}
-          >
-            <Link to={url}>{label}</Link>
-          </Tab>
+          />
         ))}
       </NavigationTabs>
       <TabsPageLayout>{children}</TabsPageLayout>

--- a/front/app/containers/Admin/settings/index.tsx
+++ b/front/app/containers/Admin/settings/index.tsx
@@ -10,7 +10,6 @@ import NavigationTabs, {
   Tab,
   TabsPageLayout,
 } from 'components/admin/NavigationTabs';
-import Link from 'utils/cl-router/Link';
 
 // i18n
 import messages from './messages';
@@ -69,11 +68,11 @@ const SettingsPage = () => {
       <NavigationTabs>
         {tabs.map(({ url, label }) => (
           <Tab
+            label={label}
+            url={url}
             key={url}
             active={isTopBarNavActive('/admin/settings', pathname, url)}
-          >
-            <Link to={url}>{label}</Link>
-          </Tab>
+          />
         ))}
       </NavigationTabs>
 


### PR DESCRIPTION
# Changelog
## Fixed
* [CL-3695] Add back beta label next to Texting tab in messaging

[CL-3695]: https://citizenlab.atlassian.net/browse/CL-3695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ