### PR TITLE
CL-3690 Constraint duplicate allowed topics

### DIFF
--- a/back/app/models/comment.rb
+++ b/back/app/models/comment.rb
@@ -19,6 +19,8 @@
 #  body_updated_at    :datetime
 #  children_count     :integer          default(0), not null
 #  post_type          :string
+#  author_hash        :string
+#  anonymous          :boolean          default(FALSE), not null
 #
 # Indexes
 #

--- a/back/app/models/idea.rb
+++ b/back/app/models/idea.rb
@@ -28,9 +28,12 @@
 #  proposed_budget          :integer
 #  custom_field_values      :jsonb            not null
 #  creation_phase_id        :uuid
+#  author_hash              :string
+#  anonymous                :boolean          default(FALSE), not null
 #
 # Indexes
 #
+#  index_ideas_on_author_hash     (author_hash)
 #  index_ideas_on_author_id       (author_id)
 #  index_ideas_on_idea_status_id  (idea_status_id)
 #  index_ideas_on_location_point  (location_point) USING gist

--- a/back/app/models/initiative.rb
+++ b/back/app/models/initiative.rb
@@ -22,6 +22,8 @@
 #  assignee_id              :uuid
 #  official_feedbacks_count :integer          default(0), not null
 #  assigned_at              :datetime
+#  author_hash              :string
+#  anonymous                :boolean          default(FALSE), not null
 #
 # Indexes
 #

--- a/back/app/models/phase.rb
+++ b/back/app/models/phase.rb
@@ -4,34 +4,35 @@
 #
 # Table name: phases
 #
-#  id                     :uuid             not null, primary key
-#  project_id             :uuid
-#  title_multiloc         :jsonb
-#  description_multiloc   :jsonb
-#  start_at               :date
-#  end_at                 :date
-#  created_at             :datetime         not null
-#  updated_at             :datetime         not null
-#  participation_method   :string           default("ideation"), not null
-#  posting_enabled        :boolean          default(TRUE)
-#  commenting_enabled     :boolean          default(TRUE)
-#  voting_enabled         :boolean          default(TRUE), not null
-#  upvoting_method        :string           default("unlimited"), not null
-#  upvoting_limited_max   :integer          default(10)
-#  survey_embed_url       :string
-#  survey_service         :string
-#  presentation_mode      :string           default("card")
-#  max_budget             :integer
-#  poll_anonymous         :boolean          default(FALSE), not null
-#  downvoting_enabled     :boolean          default(TRUE), not null
-#  ideas_count            :integer          default(0), not null
-#  ideas_order            :string
-#  input_term             :string           default("idea")
-#  min_budget             :integer          default(0)
-#  downvoting_method      :string           default("unlimited"), not null
-#  downvoting_limited_max :integer          default(10)
-#  posting_method         :string           default("unlimited"), not null
-#  posting_limited_max    :integer          default(1)
+#  id                            :uuid             not null, primary key
+#  project_id                    :uuid
+#  title_multiloc                :jsonb
+#  description_multiloc          :jsonb
+#  start_at                      :date
+#  end_at                        :date
+#  created_at                    :datetime         not null
+#  updated_at                    :datetime         not null
+#  participation_method          :string           default("ideation"), not null
+#  posting_enabled               :boolean          default(TRUE)
+#  commenting_enabled            :boolean          default(TRUE)
+#  voting_enabled                :boolean          default(TRUE), not null
+#  upvoting_method               :string           default("unlimited"), not null
+#  upvoting_limited_max          :integer          default(10)
+#  survey_embed_url              :string
+#  survey_service                :string
+#  presentation_mode             :string           default("card")
+#  max_budget                    :integer
+#  poll_anonymous                :boolean          default(FALSE), not null
+#  downvoting_enabled            :boolean          default(TRUE), not null
+#  ideas_count                   :integer          default(0), not null
+#  ideas_order                   :string
+#  input_term                    :string           default("idea")
+#  min_budget                    :integer          default(0)
+#  downvoting_method             :string           default("unlimited"), not null
+#  downvoting_limited_max        :integer          default(10)
+#  posting_method                :string           default("unlimited"), not null
+#  posting_limited_max           :integer          default(1)
+#  allow_anonymous_participation :boolean          default(FALSE), not null
 #
 # Indexes
 #

--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -4,40 +4,41 @@
 #
 # Table name: projects
 #
-#  id                           :uuid             not null, primary key
-#  title_multiloc               :jsonb
-#  description_multiloc         :jsonb
-#  slug                         :string
-#  created_at                   :datetime         not null
-#  updated_at                   :datetime         not null
-#  header_bg                    :string
-#  ideas_count                  :integer          default(0), not null
-#  visible_to                   :string           default("public"), not null
-#  description_preview_multiloc :jsonb
-#  presentation_mode            :string           default("card")
-#  participation_method         :string           default("ideation")
-#  posting_enabled              :boolean          default(TRUE)
-#  commenting_enabled           :boolean          default(TRUE)
-#  voting_enabled               :boolean          default(TRUE), not null
-#  upvoting_method              :string           default("unlimited"), not null
-#  upvoting_limited_max         :integer          default(10)
-#  process_type                 :string           default("timeline"), not null
-#  internal_role                :string
-#  survey_embed_url             :string
-#  survey_service               :string
-#  max_budget                   :integer
-#  comments_count               :integer          default(0), not null
-#  default_assignee_id          :uuid
-#  poll_anonymous               :boolean          default(FALSE), not null
-#  downvoting_enabled           :boolean          default(TRUE), not null
-#  ideas_order                  :string
-#  input_term                   :string           default("idea")
-#  min_budget                   :integer          default(0)
-#  downvoting_method            :string           default("unlimited"), not null
-#  downvoting_limited_max       :integer          default(10)
-#  include_all_areas            :boolean          default(FALSE), not null
-#  posting_method               :string           default("unlimited"), not null
-#  posting_limited_max          :integer          default(1)
+#  id                            :uuid             not null, primary key
+#  title_multiloc                :jsonb
+#  description_multiloc          :jsonb
+#  slug                          :string
+#  created_at                    :datetime         not null
+#  updated_at                    :datetime         not null
+#  header_bg                     :string
+#  ideas_count                   :integer          default(0), not null
+#  visible_to                    :string           default("public"), not null
+#  description_preview_multiloc  :jsonb
+#  presentation_mode             :string           default("card")
+#  participation_method          :string           default("ideation")
+#  posting_enabled               :boolean          default(TRUE)
+#  commenting_enabled            :boolean          default(TRUE)
+#  voting_enabled                :boolean          default(TRUE), not null
+#  upvoting_method               :string           default("unlimited"), not null
+#  upvoting_limited_max          :integer          default(10)
+#  process_type                  :string           default("timeline"), not null
+#  internal_role                 :string
+#  survey_embed_url              :string
+#  survey_service                :string
+#  max_budget                    :integer
+#  comments_count                :integer          default(0), not null
+#  default_assignee_id           :uuid
+#  poll_anonymous                :boolean          default(FALSE), not null
+#  downvoting_enabled            :boolean          default(TRUE), not null
+#  ideas_order                   :string
+#  input_term                    :string           default("idea")
+#  min_budget                    :integer          default(0)
+#  downvoting_method             :string           default("unlimited"), not null
+#  downvoting_limited_max        :integer          default(10)
+#  include_all_areas             :boolean          default(FALSE), not null
+#  posting_method                :string           default("unlimited"), not null
+#  posting_limited_max           :integer          default(1)
+#  allow_anonymous_participation :boolean          default(FALSE), not null
 #
 # Indexes
 #

--- a/back/app/models/projects_allowed_input_topic.rb
+++ b/back/app/models/projects_allowed_input_topic.rb
@@ -13,8 +13,8 @@
 #
 # Indexes
 #
-#  index_projects_allowed_input_topics_on_project_id  (project_id)
-#  index_projects_allowed_input_topics_on_topic_id    (topic_id)
+#  index_projects_allowed_input_topics_on_project_id               (project_id)
+#  index_projects_allowed_input_topics_on_topic_id_and_project_id  (topic_id,project_id) UNIQUE
 #
 # Foreign Keys
 #

--- a/back/app/models/projects_allowed_input_topic.rb
+++ b/back/app/models/projects_allowed_input_topic.rb
@@ -28,4 +28,5 @@ class ProjectsAllowedInputTopic < ApplicationRecord
   belongs_to :topic
 
   validates :project, :topic, presence: true
+  validates :topic_id, uniqueness: { scope: :project_id }
 end

--- a/back/db/migrate/20230601085753_add_uniqueness_constraint_to_projects_allowed_input_topics.rb
+++ b/back/db/migrate/20230601085753_add_uniqueness_constraint_to_projects_allowed_input_topics.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class AddUniquenessConstraintToProjectsAllowedInputTopics < ActiveRecord::Migration[6.1]
+  def change
+    execute(
+      # After https://stackoverflow.com/a/12963112/3585671
+      <<-SQL.squish
+      DELETE FROM projects_allowed_input_topics to_delete USING (
+        SELECT MIN(id::text) AS id, topic_id, project_id
+          FROM projects_allowed_input_topics 
+          GROUP BY (topic_id, project_id) HAVING COUNT(*) > 1
+        ) keep_from_duplicates
+        WHERE to_delete.topic_id = keep_from_duplicates.topic_id
+        AND to_delete.project_id = keep_from_duplicates.project_id
+        AND to_delete.id::text <> keep_from_duplicates.id
+      SQL
+    )
+    remove_index :projects_allowed_input_topics, name: :index_projects_allowed_input_topics_on_topic_id
+    add_index :projects_allowed_input_topics, %i[topic_id project_id], unique: true
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_24_151508) do
+ActiveRecord::Schema.define(version: 2023_06_01_085753) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -202,6 +202,8 @@ ActiveRecord::Schema.define(version: 2023_05_24_151508) do
     t.datetime "body_updated_at"
     t.integer "children_count", default: 0, null: false
     t.string "post_type"
+    t.string "author_hash"
+    t.boolean "anonymous", default: false, null: false
     t.index ["author_id"], name: "index_comments_on_author_id"
     t.index ["created_at"], name: "index_comments_on_created_at"
     t.index ["lft"], name: "index_comments_on_lft"
@@ -511,7 +513,10 @@ ActiveRecord::Schema.define(version: 2023_05_24_151508) do
     t.integer "proposed_budget"
     t.jsonb "custom_field_values", default: {}, null: false
     t.uuid "creation_phase_id"
+    t.string "author_hash"
+    t.boolean "anonymous", default: false, null: false
     t.index "((to_tsvector('simple'::regconfig, COALESCE((title_multiloc)::text, ''::text)) || to_tsvector('simple'::regconfig, COALESCE((body_multiloc)::text, ''::text))))", name: "index_ideas_search", using: :gin
+    t.index ["author_hash"], name: "index_ideas_on_author_hash"
     t.index ["author_id"], name: "index_ideas_on_author_id"
     t.index ["idea_status_id"], name: "index_ideas_on_idea_status_id"
     t.index ["location_point"], name: "index_ideas_on_location_point", using: :gist
@@ -622,6 +627,8 @@ ActiveRecord::Schema.define(version: 2023_05_24_151508) do
     t.uuid "assignee_id"
     t.integer "official_feedbacks_count", default: 0, null: false
     t.datetime "assigned_at"
+    t.string "author_hash"
+    t.boolean "anonymous", default: false, null: false
     t.index "((to_tsvector('simple'::regconfig, COALESCE((title_multiloc)::text, ''::text)) || to_tsvector('simple'::regconfig, COALESCE((body_multiloc)::text, ''::text))))", name: "index_initiatives_search", using: :gin
     t.index ["author_id"], name: "index_initiatives_on_author_id"
     t.index ["location_point"], name: "index_initiatives_on_location_point", using: :gist
@@ -953,6 +960,7 @@ ActiveRecord::Schema.define(version: 2023_05_24_151508) do
     t.integer "downvoting_limited_max", default: 10
     t.string "posting_method", default: "unlimited", null: false
     t.integer "posting_limited_max", default: 1
+    t.boolean "allow_anonymous_participation", default: false, null: false
     t.index ["project_id"], name: "index_phases_on_project_id"
   end
 
@@ -1090,6 +1098,7 @@ ActiveRecord::Schema.define(version: 2023_05_24_151508) do
     t.boolean "include_all_areas", default: false, null: false
     t.string "posting_method", default: "unlimited", null: false
     t.integer "posting_limited_max", default: 1
+    t.boolean "allow_anonymous_participation", default: false, null: false
     t.index ["slug"], name: "index_projects_on_slug", unique: true
   end
 
@@ -1100,7 +1109,7 @@ ActiveRecord::Schema.define(version: 2023_05_24_151508) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "ordering"
     t.index ["project_id"], name: "index_projects_allowed_input_topics_on_project_id"
-    t.index ["topic_id"], name: "index_projects_allowed_input_topics_on_topic_id"
+    t.index ["topic_id", "project_id"], name: "index_projects_allowed_input_topics_on_topic_id_and_project_id", unique: true
   end
 
   create_table "projects_topics", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1320,8 +1329,8 @@ ActiveRecord::Schema.define(version: 2023_05_24_151508) do
     t.boolean "confirmation_required", default: true, null: false
     t.datetime "block_start_at"
     t.string "block_reason"
-    t.string "new_email"
     t.datetime "block_end_at"
+    t.string "new_email"
     t.index "lower((email)::text)", name: "users_unique_lower_email_idx", unique: true
     t.index ["email"], name: "index_users_on_email"
     t.index ["registration_completed_at"], name: "index_users_on_registration_completed_at"

--- a/back/spec/models/project_spec.rb
+++ b/back/spec/models/project_spec.rb
@@ -149,4 +149,11 @@ RSpec.describe Project do
       create(:continuous_project)
     end
   end
+
+  describe 'allowed_input_topics' do
+    it 'cannot have duplicate topics' do
+      project = create(:project_with_allowed_input_topics)
+      expect(project.projects_allowed_input_topics.create(topic: project.allowed_input_topics.first)).not_to be_valid
+    end
+  end
 end


### PR DESCRIPTION
This change is very similar to the solution we did for volunteering (see e.g. `AddUniquenessConstraintToVolunteers`).

# Changelog
### Fixed
- [CL-3690] Prevent duplicates in associated allowed input topics within the same project.


[CL-3690]: https://citizenlab.atlassian.net/browse/CL-3690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ