### PR TITLE
CL-3585 - Show access permissions for surveys even if posting disabled

### DIFF
--- a/back/app/models/concerns/participation_context.rb
+++ b/back/app/models/concerns/participation_context.rb
@@ -130,6 +130,10 @@ module ParticipationContext
     participation_method == 'native_survey'
   end
 
+  def hide_disabled_permissions?
+    !native_survey?
+  end
+
   private
 
   def timeline_project?

--- a/back/app/models/concerns/participation_context.rb
+++ b/back/app/models/concerns/participation_context.rb
@@ -130,10 +130,6 @@ module ParticipationContext
     participation_method == 'native_survey'
   end
 
-  def hide_disabled_permissions?
-    !native_survey?
-  end
-
   private
 
   def timeline_project?

--- a/back/app/models/permission.rb
+++ b/back/app/models/permission.rb
@@ -60,7 +60,7 @@ class Permission < ApplicationRecord
     # Remove any actions that are not enabled on the project
     available_actions(permission_scope).filter_map do |action|
       next if
-        (action == 'posting_idea' && !permission_scope&.posting_enabled?) ||
+        (action == 'posting_idea' && !permission_scope&.posting_enabled? && !permission_scope&.native_survey?) ||
         (action == 'voting_idea' && !permission_scope&.voting_enabled?) ||
         (action == 'commenting_idea' && !permission_scope&.commenting_enabled?)
 

--- a/back/app/models/permission.rb
+++ b/back/app/models/permission.rb
@@ -60,7 +60,7 @@ class Permission < ApplicationRecord
     # Remove any actions that are not enabled on the project
     available_actions(permission_scope).filter_map do |action|
       next if
-        (action == 'posting_idea' && !permission_scope&.posting_enabled? && !permission_scope&.native_survey?) ||
+        (action == 'posting_idea' && !permission_scope&.posting_enabled? && permission_scope&.hide_disabled_permissions?) ||
         (action == 'voting_idea' && !permission_scope&.voting_enabled?) ||
         (action == 'commenting_idea' && !permission_scope&.commenting_enabled?)
 

--- a/back/app/models/permission.rb
+++ b/back/app/models/permission.rb
@@ -56,11 +56,13 @@ class Permission < ApplicationRecord
     ACTIONS[permission_scope&.participation_method]
   end
 
+  # Remove any actions that are not enabled on the project
   def self.enabled_actions(permission_scope)
-    # Remove any actions that are not enabled on the project
+    return available_actions(permission_scope) unless permission_scope&.hide_disabled_permissions?
+
     available_actions(permission_scope).filter_map do |action|
       next if
-        (action == 'posting_idea' && !permission_scope&.posting_enabled? && permission_scope&.hide_disabled_permissions?) ||
+        (action == 'posting_idea' && !permission_scope&.posting_enabled?) ||
         (action == 'voting_idea' && !permission_scope&.voting_enabled?) ||
         (action == 'commenting_idea' && !permission_scope&.commenting_enabled?)
 

--- a/back/app/models/permission.rb
+++ b/back/app/models/permission.rb
@@ -58,7 +58,8 @@ class Permission < ApplicationRecord
 
   # Remove any actions that are not enabled on the project
   def self.enabled_actions(permission_scope)
-    return available_actions(permission_scope) unless permission_scope&.hide_disabled_permissions?
+    participation_method = Factory.instance.participation_method_for(permission_scope)
+    return available_actions(permission_scope) if participation_method&.return_disabled_actions?
 
     available_actions(permission_scope).filter_map do |action|
       next if

--- a/back/lib/participation_method/base.rb
+++ b/back/lib/participation_method/base.rb
@@ -113,6 +113,11 @@ module ParticipationMethod
       false
     end
 
+    # Should an admin be able to set permissions for disabled actions?
+    def return_disabled_actions?
+      false
+    end
+
     private
 
     attr_reader :participation_context

--- a/back/lib/participation_method/native_survey.rb
+++ b/back/lib/participation_method/native_survey.rb
@@ -78,6 +78,10 @@ module ParticipationMethod
       false
     end
 
+    def return_disabled_actions?
+      true
+    end
+
     # The "Additional information" category in the UI should be suppressed.
     # As long as the form builder does not support sections/categories,
     # we can suppress the heading by returning nil.

--- a/back/spec/lib/participation_method/budgeting_spec.rb
+++ b/back/spec/lib/participation_method/budgeting_spec.rb
@@ -154,4 +154,5 @@ RSpec.describe ParticipationMethod::Budgeting do
   its(:supports_budget?) { is_expected.to be true }
   its(:supports_status?) { is_expected.to be true }
   its(:supports_assignment?) { is_expected.to be true }
+  its(:return_disabled_actions?) { is_expected.to be false }
 end

--- a/back/spec/lib/participation_method/ideation_spec.rb
+++ b/back/spec/lib/participation_method/ideation_spec.rb
@@ -178,4 +178,5 @@ RSpec.describe ParticipationMethod::Ideation do
   its(:supports_budget?) { is_expected.to be true }
   its(:supports_status?) { is_expected.to be true }
   its(:supports_assignment?) { is_expected.to be true }
+  its(:return_disabled_actions?) { is_expected.to be false }
 end

--- a/back/spec/lib/participation_method/information_spec.rb
+++ b/back/spec/lib/participation_method/information_spec.rb
@@ -113,4 +113,5 @@ RSpec.describe ParticipationMethod::Information do
   its(:supports_budget?) { is_expected.to be false }
   its(:supports_status?) { is_expected.to be false }
   its(:supports_assignment?) { is_expected.to be false }
+  its(:return_disabled_actions?) { is_expected.to be false }
 end

--- a/back/spec/lib/participation_method/native_survey_spec.rb
+++ b/back/spec/lib/participation_method/native_survey_spec.rb
@@ -194,4 +194,5 @@ RSpec.describe ParticipationMethod::NativeSurvey do
   its(:supports_budget?) { is_expected.to be false }
   its(:supports_status?) { is_expected.to be false }
   its(:supports_assignment?) { is_expected.to be false }
+  its(:return_disabled_actions?) { is_expected.to be true }
 end

--- a/back/spec/lib/participation_method/none_spec.rb
+++ b/back/spec/lib/participation_method/none_spec.rb
@@ -112,4 +112,5 @@ RSpec.describe ParticipationMethod::None do
   its(:supports_budget?) { is_expected.to be false }
   its(:supports_status?) { is_expected.to be false }
   its(:supports_assignment?) { is_expected.to be false }
+  its(:return_disabled_actions?) { is_expected.to be false }
 end

--- a/back/spec/lib/participation_method/poll_spec.rb
+++ b/back/spec/lib/participation_method/poll_spec.rb
@@ -113,4 +113,5 @@ RSpec.describe ParticipationMethod::Poll do
   its(:supports_budget?) { is_expected.to be false }
   its(:supports_status?) { is_expected.to be false }
   its(:supports_assignment?) { is_expected.to be false }
+  its(:return_disabled_actions?) { is_expected.to be false }
 end

--- a/back/spec/lib/participation_method/survey_spec.rb
+++ b/back/spec/lib/participation_method/survey_spec.rb
@@ -113,4 +113,5 @@ RSpec.describe ParticipationMethod::Survey do
   its(:supports_budget?) { is_expected.to be false }
   its(:supports_status?) { is_expected.to be false }
   its(:supports_assignment?) { is_expected.to be false }
+  its(:return_disabled_actions?) { is_expected.to be false }
 end

--- a/back/spec/lib/participation_method/volunteering_spec.rb
+++ b/back/spec/lib/participation_method/volunteering_spec.rb
@@ -113,4 +113,5 @@ RSpec.describe ParticipationMethod::Volunteering do
   its(:supports_budget?) { is_expected.to be false }
   its(:supports_status?) { is_expected.to be false }
   its(:supports_assignment?) { is_expected.to be false }
+  its(:return_disabled_actions?) { is_expected.to be false }
 end

--- a/back/spec/models/permission_spec.rb
+++ b/back/spec/models/permission_spec.rb
@@ -54,5 +54,12 @@ RSpec.describe Permission do
       expect(permissions.size).to eq(2)
       expect(permissions).not_to include(permission_voting)
     end
+
+    it 'Returns all permissions for native surveys even if survey is not open to responses' do
+      project.update!(participation_method: 'native_survey', posting_enabled: false)
+      permissions = described_class.filter_enabled_actions(project)
+      expect(permissions.size).to eq(1)
+      expect(permissions).to include(permission_posting)
+    end
   end
 end


### PR DESCRIPTION
# Changelog

## Fixed
- CL-3585 - Showing access permissions for survey in back office when the survey is closed for submissions
