### PR TITLE
[CL-3712] Improve save_examples in light of recent bugfix

### DIFF
--- a/back/engines/free/email_campaigns/app/services/email_campaigns/examples_service.rb
+++ b/back/engines/free/email_campaigns/app/services/email_campaigns/examples_service.rb
@@ -2,7 +2,7 @@
 
 # ExamplesService is responsible for maintaining an adequate and relevant sample
 # of email campaign examples in the database. It's called by the email campaigns
-# send pipeline on every email. It decided whether the email's html is worth
+# send pipeline on every email. It decides whether the email's html is worth
 # storing, and if so stores it and cleans up less relevant examples.
 module EmailCampaigns
   class ExamplesService

--- a/back/engines/free/email_campaigns/app/services/email_campaigns/examples_service.rb
+++ b/back/engines/free/email_campaigns/app/services/email_campaigns/examples_service.rb
@@ -13,30 +13,24 @@ module EmailCampaigns
       campaigns = campaigns_with_command.map { |(_command, campaign)| campaign }.uniq
 
       campaigns.each do |campaign|
-        recent_examples_n = Example
-          .where(campaign: campaign)
-          .where('created_at > ?', RECENCY_THRESHOLD.ago)
-          .count
+        base_scope = Example.where(campaign: campaign)
+        recent_examples_n = base_scope.where('created_at > ?', RECENCY_THRESHOLD.ago).count
         n_lacking = EXAMPLES_PER_CAMPAIGN - recent_examples_n
 
-        next if n_lacking == 0
+        if n_lacking.positive?
+          new_campaign_commands =
+            filter_n_campaigns_with_command_for_campaign(campaigns_with_command, campaign, n_lacking)
 
-        total_examples = Example.where(campaign: campaign).count
-
-        new_campaign_commands =
-          filter_n_campaigns_with_command_for_campaign(campaigns_with_command, campaign, [n_lacking, 0].max)
-
-        Example
-          .where(campaign: campaign)
-          .order(created_at: :asc)
-          .limit([new_campaign_commands.size, n_lacking].min + [0, (total_examples - EXAMPLES_PER_CAMPAIGN)].max)
-          .destroy_all
-
-        next if n_lacking < 0
-
-        new_campaign_commands.each do |(command, camp)|
-          save_example(command, camp)
+          new_campaign_commands.each do |(command, camp)|
+            save_example(command, camp)
+          end
         end
+
+        valid_examples = base_scope
+          .order(created_at: :desc)
+          .limit(EXAMPLES_PER_CAMPAIGN)
+
+        base_scope.where.not(id: valid_examples).destroy_all
       end
     end
 

--- a/back/engines/free/email_campaigns/spec/services/email_campaigns/examples_service_spec.rb
+++ b/back/engines/free/email_campaigns/spec/services/email_campaigns/examples_service_spec.rb
@@ -87,5 +87,19 @@ describe EmailCampaigns::ExamplesService do
       expect { service.save_examples([[command, campaign]]) }.to change(EmailCampaigns::Example, :count).from(6).to(5)
       expect(old_examples.map(&:id) & EmailCampaigns::Example.ids).to be_empty
     end
+
+    # Specifically testing for regression after a recent bugfix: CL-3712
+    it 'reduces the number of stored campaigns if there are more recent examples than EXAMPLES_PER_CAMPAIGN (5)' do
+      campaign = create(:admin_rights_received_campaign)
+      create_list(:campaign_example, 10, campaign: campaign)
+
+      recipient = create(:admin)
+      command = {
+        recipient: recipient,
+        event_payload: {}
+      }
+
+      expect { service.save_examples([[command, campaign]]) }.to change(EmailCampaigns::Example, :count).from(10).to(5)
+    end
   end
 end


### PR DESCRIPTION
This maintains the effect of the recent bugfix (#5041), by never calling `filter_n_campaigns_with_command_for_campaign` when `n_lacking` is not positive.

Also improves the removal of excess `examples` records, when saving new records results in more than the `EXAMPLES_PER_CAMPAIGN` limit records.

Thanks to @alexander-cit for the majority of the reworking of the code here.

# Changelog
## Technical
- [CL-3712] Improve ExamplesService.save_examples in light of recent bug


[CL-3712]: https://citizenlab.atlassian.net/browse/CL-3712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ