### PR TITLE
[CL-3712] Rake task to count or remove excess examples

### DIFF
--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/destroy_excess_email_campaigns_examples.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/destroy_excess_email_campaigns_examples.rake
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Task to remove excess email campaign examples over a given limit (via an argument) of n examples per campaign.
+#
+# The oldest examples are removed first.
+# The task can be run in dry run mode (no changes) or execute mode (destroys records).
+# The task is run for all email campaigns and for all tenants.
+#
+# Useful when the EXAMPLES_PER_CAMPAIGN value has been decreased in the email_campaigns/examples_service.rb file,
+# and you want to remove the excess examples that were created before the change.
+# Also useful if a bug has caused too many examples to be created, and you want to remove the excess examples,
+# though this should resolve over time, as the ExamplesService also prunes old examples when campaigns are sent.
+# Also useful in dry_run mode to see how many excess examples there are per campaign.
+
+namespace :cl2_back do
+  desc 'Destroy excess email campaigns examples'
+  # Usage:
+  # Dry run (no changes): rake cl2_back:destroy_excess_examples['3']
+  # Execute (destroys records!): rake cl2_back:destroy_excess_examples['3','execute']
+  task :destroy_excess_examples, %i[limit execute] => [:environment] do |_t, args|
+    args.with_defaults(execute: false)
+
+    dry_run = args[:execute] != 'execute'
+    limit = if args[:limit].to_i.positive?
+      args[:limit].to_i
+    else
+      abort("Aborted! Failed to parse a positive integer from the 'limit' argument")
+    end
+
+    puts "Destroying excess email campaign examples (dry run: #{dry_run})"
+    puts "Using the provided limit of #{limit} examples per campaign"
+
+    Tenant.all.each_with_index do |tenant, i|
+      puts "#{i + 1} / #{Tenant.count}: #{tenant.name}"
+      tenant.switch do
+        EmailCampaigns::Campaign.all.each do |campaign|
+          examples = EmailCampaigns::Example.where(campaign: campaign)
+          next if examples.count <= limit
+
+          puts "  #{campaign.class.name} (#{campaign.id}): #{examples.count} examples (#{examples.count - limit} excess)"
+          next if dry_run
+
+          valid_examples = examples
+            .order(created_at: :desc)
+            .limit(limit)
+
+          examples.where.not(id: valid_examples).destroy_all
+
+          print '... destroyed excess examples.'
+        end
+      end
+    end
+  end
+end

--- a/back/engines/commercial/multi_tenancy/spec/tasks/destroy_excess_email_campaigns_examples_spec.rb
+++ b/back/engines/commercial/multi_tenancy/spec/tasks/destroy_excess_email_campaigns_examples_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'rake cl2_back:destroy_excess_examples' do # rubocop:disable RSpec/DescribeClass
+  before { load_rake_tasks_if_not_loaded }
+
+  after { Rake::Task['cl2_back:destroy_excess_examples'].reenable }
+
+  let(:task) { Rake::Task['cl2_back:destroy_excess_examples'] }
+
+  it 'only destroys excess campaign examples' do
+    campaign1 = create(:admin_rights_received_campaign)
+    create_list(:campaign_example, 5, campaign: campaign1)
+    campaign2 = create(:comment_deleted_by_admin_campaign)
+    create_list(:campaign_example, 3, campaign: campaign2)
+
+    task.invoke('3', 'execute')
+
+    expect(EmailCampaigns::Example.where(campaign: campaign1).count).to eq 3
+    expect(EmailCampaigns::Example.where(campaign: campaign2).count).to eq 3
+  end
+
+  it 'only destroys the oldest examples of a campaign' do
+    campaign = create(:admin_rights_received_campaign)
+    younger_examples = create_list(:campaign_example, 3, campaign: campaign, created_at: Time.now)
+    _older_examples = create_list(:campaign_example, 2, campaign: campaign, created_at: 1.week.ago)
+
+    task.invoke('3', 'execute')
+
+    expect(EmailCampaigns::Example.where(campaign: campaign).pluck(:id)).to match_array(younger_examples.pluck(:id))
+  end
+
+  it 'does not destroy campaign examples in dry_run mode' do
+    campaign = create(:comment_deleted_by_admin_campaign)
+    create_list(:campaign_example, 5, campaign: campaign)
+
+    task.invoke('3')
+
+    expect(EmailCampaigns::Example.where(campaign: campaign).count).to eq 5
+  end
+end


### PR DESCRIPTION
I'd like to run this to see how many excess examples exist, then agian to remove the excess examples, then occasionally thereafter to count any excess examples just to get an idea of whether excess examples occur again.

# Changelog
## Technical
- [CL-3712] rake task to count or destroy excess email campaign examples 


[CL-3712]: https://citizenlab.atlassian.net/browse/CL-3712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ