### PR TITLE
Revert "[CL-3694] Custom from email setting"

### DIFF
--- a/back/app/mailers/application_mailer.rb
+++ b/back/app/mailers/application_mailer.rb
@@ -92,8 +92,7 @@ class ApplicationMailer < ActionMailer::Base
       subject: subject,
       from: from_email,
       to: to_email,
-      reply_to: reply_to_email,
-      domain: domain
+      reply_to: reply_to_email
     }
   end
 
@@ -115,13 +114,7 @@ class ApplicationMailer < ActionMailer::Base
   end
 
   def from_email
-    email = custom_from_email.presence || ENV.fetch('DEFAULT_FROM_EMAIL')
-
-    email_address_with_name(email, organization_name)
-  end
-
-  def custom_from_email
-    app_settings.core.from_email
+    email_address_with_name(ENV.fetch('DEFAULT_FROM_EMAIL'), organization_name)
   end
 
   def to_email
@@ -130,10 +123,6 @@ class ApplicationMailer < ActionMailer::Base
 
   def reply_to_email
     app_settings.core.reply_to_email.presence || ENV.fetch('DEFAULT_FROM_EMAIL')
-  end
-
-  def domain
-    from_email&.split('@')&.last
   end
 
   def app_settings

--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -167,12 +167,6 @@
             "description": "What a tag unit should be called on this platform (e.g., department, theme, etc.). Input the singular form here with all lowercase letters. If left blank, this field defaults to 'tag'.",
             "$ref": "#/definitions/multiloc_string"
           },
-          "from_email": {
-            "title": "From email",
-            "description": "The email used in the from field when users receive emails. This should only be configured when the corresponding Second Line Support work has already happened and the customer has made the necessary DNS changes, or emails will not function at all.",
-            "type": "string",
-            "format": "email"
-          },
           "reply_to_email": {
             "title": "Reply-to email",
             "description": "The email used in the reply-to field when users receive emails from automated campaigns.",


### PR DESCRIPTION
Reverts CitizenLabDotCo/citizenlab#5008

Testing on staging, I could not see any invite mail sent to my private email (not received and nothing on mailgun from staging). Reverting to avoid releasing something that breaks emails on production.