### PR TITLE
[CL-1483] Fix random spec failures

### DIFF
--- a/back/app/models/app_configuration.rb
+++ b/back/app/models/app_configuration.rb
@@ -43,7 +43,7 @@ class AppConfiguration < ApplicationRecord
     extend CitizenLab::Mixins::SettingsSpecification
 
     def self.json_schema
-      settings_schema = core_settings_json_schema
+      settings_schema = core_settings_json_schema.deep_dup # deep_dup to avoid modifying core schema
 
       extension_features_specs.each do |spec|
         settings_schema['properties'][spec.feature_name] = spec.json_schema


### PR DESCRIPTION
Before this commit, this spec run was failing:
```bash
bin/rspec spec/models/app_configuration/settings_spec.rb engines/commercial/multi_tenancy/spec/services/multi_tenancy/churned_tenant_service_spec.rb
```


# Changelog
## Technical
* Fix random BE spec failures
