### PR TITLE
[CL-1483] Disable Vienna SSO by default

### DIFF
--- a/back/engines/commercial/id_vienna_saml/app/lib/id_vienna_saml/citizen_feature_specification.rb
+++ b/back/engines/commercial/id_vienna_saml/app/lib/id_vienna_saml/citizen_feature_specification.rb
@@ -18,6 +18,14 @@ module IdViennaSaml
       'Allow vienna citizens to authenticate via StandardPortal Single sign-on.'
     end
 
+    def self.allowed_by_default
+      false
+    end
+
+    def self.enabled_by_default
+      false
+    end
+
     add_setting 'environment', required: true, schema: {
       type: 'string',
       title: 'Environment',

--- a/back/engines/commercial/id_vienna_saml/app/lib/id_vienna_saml/employee_feature_specification.rb
+++ b/back/engines/commercial/id_vienna_saml/app/lib/id_vienna_saml/employee_feature_specification.rb
@@ -18,6 +18,14 @@ module IdViennaSaml
       'Allow vienna city employees to authenticate via Single sign-on.'
     end
 
+    def self.allowed_by_default
+      false
+    end
+
+    def self.enabled_by_default
+      false
+    end
+
     add_setting 'environment', required: true, schema: {
       type: 'string',
       title: 'Environment',


### PR DESCRIPTION
The tests started to fail because if Vienna SSO is enabled, the signup modal has the Vienna SSO option. And the tests don't expect it.

# Changelog
## Technical
* Fix e2e tests
