### PR TITLE
[CL-3784] Bugfix: Mentions endpoint no longer returns inactive users

### DIFF
--- a/back/app/controllers/web_api/v1/mentions_controller.rb
+++ b/back/app/controllers/web_api/v1/mentions_controller.rb
@@ -17,7 +17,7 @@ class WebApi::V1::MentionsController < ApplicationController
 
     nb_missing_users = limit - @users.size
     if nb_missing_users > 0
-      @users += User.not_invited.by_username(query).where.not(id: @users).limit(nb_missing_users)
+      @users += User.active.by_username(query).where.not(id: @users).limit(nb_missing_users)
     end
 
     render json: WebApi::V1::UserSerializer.new(

--- a/back/app/controllers/web_api/v1/mentions_controller.rb
+++ b/back/app/controllers/web_api/v1/mentions_controller.rb
@@ -17,7 +17,7 @@ class WebApi::V1::MentionsController < ApplicationController
 
     nb_missing_users = limit - @users.size
     if nb_missing_users > 0
-      @users += User.by_username(query).where.not(id: @users).limit(nb_missing_users)
+      @users += User.not_invited.by_username(query).where.not(id: @users).limit(nb_missing_users)
     end
 
     render json: WebApi::V1::UserSerializer.new(

--- a/back/spec/acceptance/mentions_spec.rb
+++ b/back/spec/acceptance/mentions_spec.rb
@@ -45,5 +45,15 @@ resource 'Mentions' do
       expect(json_response[:data].pluck(:id)).to match_array idea_related.map(&:id)
       expect(json_response[:data].all? { |u| u[:attributes][:first_name][0..(first_name.size)] == first_name }).to be true
     end
+
+    example 'Does not return invited user by (partial) mention', document: false do
+      users.first.update(invite_status: 'pending')
+
+      do_request
+
+      expect(response_status).to eq 200
+      json_response = json_parse(response_body)
+      expect(json_response[:data].pluck(:id)).not_to include users.first.id
+    end
   end
 end

--- a/back/spec/acceptance/mentions_spec.rb
+++ b/back/spec/acceptance/mentions_spec.rb
@@ -21,7 +21,7 @@ resource 'Mentions' do
     let(:mention) { users.first.first_name[0..3] }
 
     example_request 'Find user by (partial) mention' do
-      expect(response_status).to eq 200
+      assert_status 200
       json_response = json_parse(response_body)
       expect(json_response[:data].size).to be >= 1
       expect(json_response[:data].all? { |u| u[:attributes][:first_name][0..3] == mention }).to be true
@@ -46,12 +46,20 @@ resource 'Mentions' do
       expect(json_response[:data].all? { |u| u[:attributes][:first_name][0..(first_name.size)] == first_name }).to be true
     end
 
-    example 'Does not return invited user by (partial) mention', document: false do
-      users.first.update(invite_status: 'pending')
+    example 'Does not return unregistered user by (partial) mention', document: false do
+      users.first.update!(registration_completed_at: nil)
 
       do_request
+      assert_status 200
+      json_response = json_parse(response_body)
+      expect(json_response[:data].pluck(:id)).not_to include users.first.id
+    end
 
-      expect(response_status).to eq 200
+    example 'Does not return blocked user by (partial) mention', document: false do
+      users.first.update!(block_start_at: 1.week.ago, block_end_at: 1.week.from_now)
+
+      do_request
+      assert_status 200
       json_response = json_parse(response_body)
       expect(json_response[:data].pluck(:id)).not_to include users.first.id
     end


### PR DESCRIPTION
Please watch the short video in the [ticket description](https://citizenlab.atlassian.net/browse/CL-3784) for details of the bug this fixes.

# Changelog
## Fixed
- [CL-3784] The user mention mechanism, used when a user starts typing @some_user_name, for example in a comment, no longer returns inactive user(s) in the list used to select which user to mention. This could cause the app to become unresponsive.


[CL-3784]: https://citizenlab.atlassian.net/browse/CL-3784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ