### PR TITLE
CL-3714 Remove guard clause cop

### DIFF
--- a/back/.rubocop.yml
+++ b/back/.rubocop.yml
@@ -29,6 +29,9 @@ Style/Documentation:
   # Most classes are not documented, so turn off this Cop.
   Enabled: false
 
+Style/GuardClause:
+  Enabled: false
+
 Style/SymbolProc:
   Enabled: true
   AllowedMethods:

--- a/back/app/services/side_fx_idea_service.rb
+++ b/back/app/services/side_fx_idea_service.rb
@@ -51,15 +51,15 @@ class SideFxIdeaService
       )
     end
 
-    return unless idea.body_multiloc_previously_changed?
-
-    LogActivityJob.perform_later(
-      idea,
-      'changed_body',
-      user_for_activity_on_anonymizable_item(idea, user),
-      idea.updated_at.to_i,
-      payload: { change: idea.body_multiloc_previous_change }
-    )
+    if idea.body_multiloc_previously_changed?
+      LogActivityJob.perform_later(
+        idea,
+        'changed_body',
+        user_for_activity_on_anonymizable_item(idea, user),
+        idea.updated_at.to_i,
+        payload: { change: idea.body_multiloc_previous_change }
+      )
+    end
   end
 
   def before_destroy(idea, _user); end

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/tenant_service.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/tenant_service.rb
@@ -142,7 +142,7 @@ module MultiTenancy
     def validate_locales(template_name, config_locales)
       required_locales = ::MultiTenancy::Templates::Utils.new.required_locales(template_name)
 
-      unless required_locales.to_set <= config_locales.to_set # rubocop:disable Style/GuardClause
+      if required_locales.to_set > config_locales.to_set
         raise ClErrors::TransactionError.new(error_key: :missing_locales)
       end
     end


### PR DESCRIPTION
As decided during the CDM, this PR disables the `Style/GuardClause` cop. An example change is included that was previously not allowed by the cop.

Alternatively, we could have set `AllowConsecutiveConditionals` to `true`. However, we discussed that guard clauses behave like goto statements from other languages, which are often considered bad practice as they make it harder to follow the flow of the code. It therefore seems better to never force the developer to use a guard clause.