### PR TITLE
[No-ticket] Use to_i to avoid rounding errors causing test to fail

### DIFF
--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -864,7 +864,7 @@ RSpec.describe User do
         reg_date = Time.now
         u = create(:user)
         u.update!(registration_completed_at: reg_date)
-        expect(u.registration_completed_at).to eq reg_date
+        expect(u.registration_completed_at.to_i).to eq reg_date.to_i
       end
     end
 


### PR DESCRIPTION
[Example test failure](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/116293/workflows/da6ae28e-207b-4d4f-8b8a-11cef7d9ecf3/jobs/274537/tests#failed-test-0)

# Changelog
## Technical
- Fix flaky test, where rounding error can cause failure.

