### PR TITLE
CL-3798 - votes -> reactions rake tasks

### DIFF
--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/migrate_votes_to_reactions.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/migrate_votes_to_reactions.rake
@@ -101,5 +101,4 @@ class VotesToReactionMigrator
     end
     Rails.logger.info("SAVED: #{count} 'Notifications::' & 'EmailCampaigns::'  activities")
   end
-
 end

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/migrate_votes_to_reactions.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/migrate_votes_to_reactions.rake
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+namespace :fix_existing_tenants do
+  desc 'Migrate permitted_by values to new users value for some existing permissions'
+  task migrate_votes_to_reactions: [:environment] do |_t, _args|
+    Tenant.all.each do |tenant|
+      puts "Processing tenant #{tenant.host}..."
+      Apartment::Tenant.switch(tenant.schema_name) do
+        migrator = VotesToReactionMigrator.new(tenant)
+        migrator.update_smart_groups
+        migrator.update_initiatives_voting_threshold
+        migrator.update_downvoting_feature_flag
+      end
+    end
+  end
+  task migrate_votes_activities: [:environment] do |_t, _args|
+    Tenant.all.each do |tenant|
+      puts "Processing tenant #{tenant.host}..."
+      Apartment::Tenant.switch(tenant.schema_name) do
+        migrator = VotesToReactionMigrator.new(tenant)
+        migrator.update_activities
+      end
+    end
+  end
+end
+
+class VotesToReactionMigrator
+  def initialize(tenant)
+    @tenant = tenant
+  end
+
+  def update_smart_groups
+    Rails.logger.info("UPDATING: Smart groups for #{@tenant.host}")
+
+    count = 0
+    Group.where(membership_type: 'rules').each do |group|
+      next unless group.rules.to_s.include? 'voted'
+
+      group.rules.each do |rule|
+        rule['predicate'].sub!('voted', 'reacted')
+      end
+      group.save!
+      count += 1
+    end
+    Rails.logger.info("SAVED: #{count} groups")
+  end
+
+  # Can be done later - this is a large update
+  def update_activities
+    Rails.logger.info("UPDATING: Activities for #{@tenant.host}")
+
+    count = 0
+    Activity.where(item_type: 'Vote').each do |activity|
+      activity.item_type = 'Reaction'
+      activity.action.sub!('upvote', 'like') # matches: idea_upvoted, comment_upvoted, initiative_upvoted, canceled_idea_upvote, canceled_comment_upvote, canceled_initiative_upvote
+      activity.action.sub!('downvote', 'dislike') # matches: idea_downvoted, canceled_idea_downvote, canceled_comment_downvote
+      activity.payload = activity.payload.deep_transform_keys do |key|
+        case key
+        when 'vote'
+          'reaction'
+        when 'votable_id'
+          'reactable_id'
+        when 'votable_type'
+          'reactable_type'
+        else
+          key
+        end
+      end
+      activity.save!
+      count += 1
+    end
+    Rails.logger.info("SAVED: #{count} 'Vote' activities")
+
+    count = 0
+    Activity.where('item_type like ?', '%Voted%').each do |activity|
+      activity.item_type = 'Reaction'.sub!('Voted', 'Reacted')
+      activity.save!
+      count += 1
+    end
+    Rails.logger.info("SAVED: #{count} 'Notifications::' & 'EmailCampaigns::'  activities")
+  end
+
+  def update_initiatives_voting_threshold
+    Rails.logger.info("SETTING: initiatives->reacting_threshold for #{@tenant.host}")
+    settings = AppConfiguration.instance.settings
+    settings['initiatives']['reacting_threshold'] = settings['initiatives']['voting_threshold']
+    AppConfiguration.instance.update! settings: settings
+    Rails.logger.info("SAVED: Downvoting feature flag for #{@tenant.host}")
+  end
+
+  def update_downvoting_feature_flag
+    Rails.logger.info("SETTING: Disliking feature flag for #{@tenant.host}")
+    settings = AppConfiguration.instance.settings
+    settings['disliking'] = settings['downvoting']
+    AppConfiguration.instance.update! settings: settings
+  end
+
+  def update_notifications
+    Rails.logger.info("UPDATING: Activities for #{@tenant.host}")
+    # TODO: What do we need to do with notifications?
+  end
+
+end

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/migrate_votes_to_reactions.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/migrate_votes_to_reactions.rake
@@ -2,19 +2,19 @@
 
 # NOTE: Only to be used for release that migrates Votes -> Reactions
 namespace :fix_existing_tenants do
-  desc 'Migrate permitted_by values to new users value for some existing permissions'
+  desc 'Migrate all data relating to votes to reactions'
   task migrate_votes_to_reactions: [:environment] do |_t, _args|
     Tenant.all.each do |tenant|
       puts "Processing tenant #{tenant.host}..."
       Apartment::Tenant.switch(tenant.schema_name) do
         migrator = VotesToReactionMigrator.new(tenant)
-
         migrator.update_downvoting_feature_flag
-        # migrator.update_initiatives_voting_threshold
-        # migrator.update_smart_groups
+        migrator.update_initiatives_voting_threshold
+        migrator.update_smart_groups
       end
     end
   end
+
   task migrate_votes_activities: [:environment] do |_t, _args|
     Tenant.all.each do |tenant|
       puts "Processing tenant #{tenant.host}..."

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/migrate_votes_to_reactions.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/migrate_votes_to_reactions.rake
@@ -9,7 +9,8 @@ namespace :fix_existing_tenants do
               Tenant.creation_finalized.with_lifecycle('trial') +
               Tenant.creation_finalized.with_lifecycle('demo') +
               Tenant.creation_finalized.with_lifecycle('expired_trial') +
-              Tenant.creation_finalized.with_lifecycle('churned')
+              Tenant.creation_finalized.with_lifecycle('churned') +
+              Tenant.creation_finalized.with_lifecycle('not_applicable')
     vote_migrator = VotesToReactionMigrator.new
     tenants.each do |tenant|
       Apartment::Tenant.switch(tenant.schema_name) do


### PR DESCRIPTION
There are two rake tasks here:

`migrate_votes_core` Update the data that will cause the system to break - to be run immediately after release:

- add new disable_disliking feature flag & populate with value from disable_downvoting flag
- add new reacting_threshold setting & populate with value from voting_threshold setting
- update voting smart groups
- update permission action names
- update notification types
- update email campaign types
- tested on samen.schagen.nl - took 1.3 secs - no errors
- tested on denkmee.lokren.be - took 6.9 secs - inc 22,000 notifications - no errors

NOTE: There will be a future release to remove the old feature flag and settings

`migrate_votes_activities` Update the activities table 

- this will be slow as looking at Metabase there are about 1.5 million rows across all tenants that will need updating
- tested on samen.schagen.nl - 13,000 out of 260,000 activities were updated - Took 40 secs - no errors
- tested on denkmee.lokren.be - 40,000 out of 440,000 activities were updated - Took 2 mins - no errors
- Extrapolating these numbers - the whole migration may take just over an hour to run

