### PR TITLE
CL-3806-dont-show-reply-button-when-commenting-is-disabled

### DIFF
--- a/front/app/components/PostShowComponents/Comments/Comment/CommentReplyButton.tsx
+++ b/front/app/components/PostShowComponents/Comments/Comment/CommentReplyButton.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback } from 'react';
-import { isNilOrError } from 'utils/helperUtils';
 
 // i18n
 import { FormattedMessage } from 'utils/cl-intl';
@@ -171,12 +170,10 @@ const CommentReplyButton = ({
     idea?.attributes.action_descriptor.commenting_idea.disabled_reason;
 
   const isCommentDeleted = comment.attributes.publication_status === 'deleted';
-  const isSignedIn = !isNilOrError(authUser);
   const disabled =
     postType === 'initiative'
       ? !commentingPermissionInitiative?.enabled
-      : isSignedIn &&
-        ideaCommentingDisabledReason &&
+      : ideaCommentingDisabledReason &&
         !isFixableByAuthentication(ideaCommentingDisabledReason);
 
   if (!isCommentDeleted && !disabled) {


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Don't show reply button if signed out and commenting is not allowed