### PR TITLE
[No ticket] Correct proposal vs idea feature names

### DIFF
--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -881,7 +881,7 @@
 
       "ideaflow_social_sharing": {
         "type": "object",
-        "title": "Share ideas on Social Media",
+        "title": "Share Ideas on Social Media",
         "description":  "After posting an idea, users receive a pop-up to share their idea on social media.",
         "additionalProperties": false,
         "required": ["allowed", "enabled"],
@@ -893,7 +893,7 @@
 
       "initiativeflow_social_sharing": {
         "type": "object",
-        "title": "Share Proposal on Social Media",
+        "title": "Share Proposals on Social Media",
         "description": "After posting a proposal, users receive a pop-up to share their proposal on social media.",
         "additionalProperties": false,
         "required": ["allowed", "enabled"],

--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -881,8 +881,8 @@
 
       "ideaflow_social_sharing": {
         "type": "object",
-        "title": "Share Proposals on Social Media",
-        "description":  "After posting a proposal, users receive a pop-up to share their proposal on social media.",
+        "title": "Share ideas on Social Media",
+        "description":  "After posting an idea, users receive a pop-up to share their idea on social media.",
         "additionalProperties": false,
         "required": ["allowed", "enabled"],
         "properties": {
@@ -893,8 +893,8 @@
 
       "initiativeflow_social_sharing": {
         "type": "object",
-        "title": "Share Initiative on Social Media",
-        "description": "After posting an initiative, users receive a pop-up to share their proposal on social media.",
+        "title": "Share Proposal on Social Media",
+        "description": "After posting a proposal, users receive a pop-up to share their proposal on social media.",
         "additionalProperties": false,
         "required": ["allowed", "enabled"],
         "properties": {


### PR DESCRIPTION
# Changelog
## Fixed
- Updated settings copy so that AdminHQ correctly discriminates between Proposal and Idea social sharing features.