### PR TITLE
Fix reaction icon and count mismatch

### DIFF
--- a/front/app/components/IdeasMap/IdeaMapCard.tsx
+++ b/front/app/components/IdeasMap/IdeaMapCard.tsx
@@ -259,12 +259,12 @@ const IdeaMapCard = memo<Props>(
             {!isParticipatoryBudgetIdea && (
               <>
                 <FooterItem>
-                  <DislikeIcon name="vote-down" />
+                  <LikeIcon name="vote-up" />
                   <FooterValue>{ideaMarker.attributes.likes_count}</FooterValue>
                 </FooterItem>
                 {showDislike && (
                   <FooterItem>
-                    <LikeIcon name="vote-up" />
+                    <DislikeIcon name="vote-down" />
                     <FooterValue>
                       {ideaMarker.attributes.dislikes_count}
                     </FooterValue>

--- a/front/app/components/IdeasMap/IdeaMapCard.tsx
+++ b/front/app/components/IdeasMap/IdeaMapCard.tsx
@@ -233,6 +233,7 @@ const IdeaMapCard = memo<Props>(
           onMouseLeave={handleOnMouseLeave}
           role="button"
           tabIndex={0}
+          id="e2e-idea-map-card"
         >
           {tablet && (
             <StyledCloseIconButton
@@ -260,12 +261,14 @@ const IdeaMapCard = memo<Props>(
               <>
                 <FooterItem>
                   <LikeIcon name="vote-up" />
-                  <FooterValue>{ideaMarker.attributes.likes_count}</FooterValue>
+                  <FooterValue id="e2e-map-card-like-count">
+                    {ideaMarker.attributes.likes_count}
+                  </FooterValue>
                 </FooterItem>
                 {showDislike && (
                   <FooterItem>
                     <DislikeIcon name="vote-down" />
-                    <FooterValue>
+                    <FooterValue id="e2e-map-card-dislike-count">
                       {ideaMarker.attributes.dislikes_count}
                     </FooterValue>
                   </FooterItem>

--- a/front/cypress/e2e/idea_page_action.cy.ts
+++ b/front/cypress/e2e/idea_page_action.cy.ts
@@ -41,6 +41,38 @@ describe('Idea show page actions', () => {
         officialFeedbackAuthor
       );
     });
+
+    describe('Map idea card', () => {
+      const ideaTitle = randomString();
+      let ideaId: string;
+      let projectId: string;
+      let projectSlug: string;
+      const ideaContent = randomString();
+
+      before(() => {
+        cy.getProjectBySlug('an-idea-bring-it-to-your-council').then(
+          (project) => {
+            projectSlug = project.body.data.attributes.slug;
+            projectId = project.body.data.id;
+            cy.apiCreateIdea(projectId, ideaTitle, ideaContent).then((idea) => {
+              ideaId = idea.body.data.id;
+            });
+          }
+        );
+      });
+
+      it('displays correct likes and dislikes on map idea card', () => {
+        cy.visit(`/projects/${projectSlug}`);
+        cy.get('#view-tab-2').should('exist');
+        cy.get('#view-tab-2').click();
+        cy.get('#e2e-idea-map-card')
+          .first()
+          .within(() => {
+            cy.get('#e2e-map-card-like-count').should('contain', '1');
+            cy.get('#e2e-map-card-dislike-count').should('contain', '0');
+          });
+      });
+    });
   });
 
   describe('logged in as normal user', () => {


### PR DESCRIPTION
## Description
Looks like these two just got a bit mixed up during the recent renaming work. We have an e2e test for the reaction buttons, but it looks like it doesn't include the map view cards. I've added to the e2e test so this is now covered.

# Changelog
### Fixed
- Fix like/dislike icon and count mismatch on map idea cards
