### PR TITLE
[CL-3547] Add filter parameters to projects endpoint (Public API)

### DIFF
--- a/back/engines/commercial/public_api/app/controllers/public_api/v2/projects_controller.rb
+++ b/back/engines/commercial/public_api/app/controllers/public_api/v2/projects_controller.rb
@@ -3,25 +3,23 @@
 module PublicApi
   class V2::ProjectsController < PublicApiController
     def index
-      projects = Project
-        .includes(:project_images)
-        .includes(:map_config)
-        .order(created_at: :desc)
-        .page(params[:page_number])
-        .per(num_per_page)
+      projects = ProjectsFinder.new(
+        Project.includes(:project_images).includes(:map_config).order(created_at: :desc),
+        **finder_params
+      ).execute
 
-      projects = common_date_filters(projects)
-
-      # TODO: Add filter by topic, status & folder_id
-
-      render json: projects,
-        each_serializer: V2::ProjectSerializer,
-        adapter: :json,
-        meta: meta_properties(projects)
+      # TODO: Add filter by topic, status
+      list_items(projects, V2::ProjectSerializer)
     end
 
     def show
       show_item Project.find(params[:id]), V2::ProjectSerializer
+    end
+
+    private
+
+    def finder_params
+      params.permit(:folder_id).to_h.symbolize_keys
     end
   end
 end

--- a/back/engines/commercial/public_api/app/controllers/public_api/v2/projects_controller.rb
+++ b/back/engines/commercial/public_api/app/controllers/public_api/v2/projects_controller.rb
@@ -8,7 +8,7 @@ module PublicApi
         **finder_params
       ).execute
 
-      # TODO: Add filter by topic, status
+      # TODO: Add filter by topic
       list_items(projects, V2::ProjectSerializer)
     end
 
@@ -19,7 +19,19 @@ module PublicApi
     private
 
     def finder_params
-      params.permit(:folder_id).to_h.symbolize_keys
+      params.permit(:folder_id, :publication_status).to_h.tap do |params|
+        if params[:publication_status]
+          validate_publication_status!(params[:publication_status])
+        end
+      end.symbolize_keys
+    end
+
+    def validate_publication_status!(status)
+      return if status.in?(AdminPublication::PUBLICATION_STATUSES)
+
+      raise InvalidEnumParameterValueError.new(
+        'publication_status', status, AdminPublication::PUBLICATION_STATUSES
+      )
     end
   end
 end

--- a/back/engines/commercial/public_api/app/controllers/public_api/v2/reactions_controller.rb
+++ b/back/engines/commercial/public_api/app/controllers/public_api/v2/reactions_controller.rb
@@ -12,7 +12,7 @@ module PublicApi
     private
 
     def finder_params
-      params.dup.permit(:reactable_type, :user_id).to_h.tap do |params|
+      params.permit(:reactable_type, :user_id).to_h.tap do |params|
         if (reactable_type = params[:reactable_type])
           validate_reactable_type!(reactable_type)
 

--- a/back/engines/commercial/public_api/app/finders/public_api/projects_finder.rb
+++ b/back/engines/commercial/public_api/app/finders/public_api/projects_finder.rb
@@ -3,14 +3,16 @@
 module PublicApi
   class ProjectsFinder
 
-    def initialize(scope, folder_id: nil)
+    def initialize(scope, folder_id: nil, publication_status: nil)
       @scope = scope
       @folder_id = folder_id
+      @publication_status = publication_status
     end
 
     def execute
       @scope
         .then { |scope| filter_by_folder_id(scope) }
+        .then { |scope| filter_by_publication_status(scope) }
     end
 
     private
@@ -24,6 +26,14 @@ module PublicApi
       scope
         .joins(:admin_publication)
         .where(admin_publication: { parent_id: folder_admin_publication.id})
+    end
+
+    def filter_by_publication_status(scope)
+      return scope unless status = @publication_status
+
+      scope
+        .joins(:admin_publication)
+        .where(admin_publication: { publication_status: @publication_status })
     end
   end
 end

--- a/back/engines/commercial/public_api/app/finders/public_api/projects_finder.rb
+++ b/back/engines/commercial/public_api/app/finders/public_api/projects_finder.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module PublicApi
+  class ProjectsFinder
+
+    def initialize(scope, folder_id: nil)
+      @scope = scope
+      @folder_id = folder_id
+    end
+
+    def execute
+      @scope
+        .then { |scope| filter_by_folder_id(scope) }
+    end
+
+    private
+
+    def filter_by_folder_id(scope)
+      return scope unless @folder_id
+
+      folder = ProjectFolders::Folder.find(@folder_id)
+      folder_admin_publication = folder.admin_publication
+
+      scope
+        .joins(:admin_publication)
+        .where(admin_publication: { parent_id: folder_admin_publication.id})
+    end
+  end
+end

--- a/back/engines/commercial/public_api/app/finders/public_api/projects_finder.rb
+++ b/back/engines/commercial/public_api/app/finders/public_api/projects_finder.rb
@@ -2,7 +2,6 @@
 
 module PublicApi
   class ProjectsFinder
-
     def initialize(scope, folder_id: nil, publication_status: nil)
       @scope = scope
       @folder_id = folder_id
@@ -25,11 +24,11 @@ module PublicApi
 
       scope
         .joins(:admin_publication)
-        .where(admin_publication: { parent_id: folder_admin_publication.id})
+        .where(admin_publication: { parent_id: folder_admin_publication.id })
     end
 
     def filter_by_publication_status(scope)
-      return scope unless status = @publication_status
+      return scope unless @publication_status
 
       scope
         .joins(:admin_publication)

--- a/back/engines/commercial/public_api/app/serializers/public_api/v2/project_serializer.rb
+++ b/back/engines/commercial/public_api/app/serializers/public_api/v2/project_serializer.rb
@@ -7,7 +7,6 @@ class PublicApi::V2::ProjectSerializer < PublicApi::V2::BaseSerializer
     :description_preview,
     :process_type,
     :participation_method,
-    :status, # Should we change this to publication_status to avoid confusion
     :slug,
     :folder_id,
     :href, # Not in spec
@@ -29,7 +28,8 @@ class PublicApi::V2::ProjectSerializer < PublicApi::V2::BaseSerializer
     :min_budget,
     :max_budget
 
-  def status
+
+  attribute :publication_status do
     object.admin_publication.publication_status
   end
 

--- a/back/engines/commercial/public_api/app/serializers/public_api/v2/project_serializer.rb
+++ b/back/engines/commercial/public_api/app/serializers/public_api/v2/project_serializer.rb
@@ -28,7 +28,6 @@ class PublicApi::V2::ProjectSerializer < PublicApi::V2::BaseSerializer
     :min_budget,
     :max_budget
 
-
   attribute :publication_status do
     object.admin_publication.publication_status
   end

--- a/back/engines/commercial/public_api/spec/acceptance/v2/projects_spec.rb
+++ b/back/engines/commercial/public_api/spec/acceptance/v2/projects_spec.rb
@@ -25,6 +25,15 @@ resource 'Projects' do
 
     include_context 'common_list_params'
 
+    parameter(
+      :folder_id, <<~DESC.squish,
+        List only the projects that are in the specified folder.
+      DESC
+      required: false,
+      in: 'query',
+      type: 'string'
+    )
+
     context 'when the page size is smaller than the total number of projects' do
       let(:page_size) { 2 }
 
@@ -62,6 +71,18 @@ resource 'Projects' do
         assert_status 200
         expect(json_response_body[:projects].pluck(:id)).to eq [project.id]
         expect(json_response_body[:meta]).to eq({ total_pages: 1, current_page: 1 })
+      end
+    end
+
+    context "when filtering by 'folder_id'" do
+      let(:projects_in_folder) { create_list(:project, 2) }
+      let(:folder) { create(:project_folder, projects: projects_in_folder) }
+      let(:folder_id) { folder.id }
+
+      example_request 'List only the projects in the specified folder', document: false do
+        assert_status 200
+        expect(json_response_body[:projects].pluck(:id))
+          .to match_array projects_in_folder.pluck(:id)
       end
     end
   end


### PR DESCRIPTION
# Changelog
## Technical
- Add new filter parameters (`publication_status` and `folder_id`) to the `projects` endpoint of the public API.

