### PR TITLE
[CL-3823] Serialize internal_comment_id in responses

### DIFF
--- a/back/app/serializers/web_api/v1/notifications/internal_comment_notification_serializer.rb
+++ b/back/app/serializers/web_api/v1/notifications/internal_comment_notification_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class WebApi::V1::Notifications::InternalCommentNotificationSerializer < WebApi::V1::Notifications::NotificationSerializer
-  attributes :post_type, :post_id, :project_id
+  attributes :post_type, :post_id, :project_id, :internal_comment_id
 
   attribute :initiating_user_first_name do |object|
     object.initiating_user&.first_name


### PR DESCRIPTION
# Changelog
## Technical
- [CL-3823] Include internal_comment_id when serializing related notifications (feature in development)


[CL-3823]: https://citizenlab.atlassian.net/browse/CL-3823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ