### PR TITLE
CL-2964 - Fix Matomo visit data import when date dimensions do not exist

### DIFF
--- a/back/engines/commercial/analytics/app/services/analytics/matomo_data_importer.rb
+++ b/back/engines/commercial/analytics/app/services/analytics/matomo_data_importer.rb
@@ -31,7 +31,7 @@ module Analytics
       )
 
       enumerator.with_index(1) do |visits, index|
-        set_date_dimensions(visits)
+        update_date_dimensions(visits)
         persist_visit_data(visits)
 
         last_action_timestamp = visits.pluck('lastActionTimestamp').max
@@ -50,7 +50,7 @@ module Analytics
     private
 
     # Fix any date dimensions that don't exist for the visit data
-    def set_date_dimensions(visits)
+    def update_date_dimensions(visits)
       from = timestamp_to_date(visits.pluck('firstActionTimestamp').min)
       to = timestamp_to_date(visits.pluck('lastActionTimestamp').max)
       Analytics::PopulateDimensionsService.create_dates(from, to)

--- a/back/engines/commercial/analytics/app/services/analytics/matomo_data_importer.rb
+++ b/back/engines/commercial/analytics/app/services/analytics/matomo_data_importer.rb
@@ -31,6 +31,7 @@ module Analytics
       )
 
       enumerator.with_index(1) do |visits, index|
+        set_date_dimensions(visits)
         persist_visit_data(visits)
 
         last_action_timestamp = visits.pluck('lastActionTimestamp').max
@@ -47,6 +48,13 @@ module Analytics
     end
 
     private
+
+    # Fix any date dimensions that don't exist for the visit data
+    def set_date_dimensions(visits)
+      from = timestamp_to_date(visits.pluck('firstActionTimestamp').min)
+      to = timestamp_to_date(visits.pluck('lastActionTimestamp').max)
+      Analytics::PopulateDimensionsService.create_dates(from, to)
+    end
 
     # @return [Array<String>] the ids of the newly created +FactVisit+ in the same order
     #   as +visit_data+.
@@ -110,8 +118,7 @@ module Analytics
     def update_referrer_types(visit_data)
       referrer_types_attrs = visit_data
         .pluck('referrerType', 'referrerTypeName').uniq
-        # being extra cautious and checking that matomo doesn't return empty values
-        .select { |type_infos| type_infos.none?(&:blank?) }
+        .select { |type_infos| type_infos.none?(&:blank?) } # being extra cautious and checking that matomo doesn't return empty values
         .map { |type, type_name| { key: type, name: type_name } }
 
       return if referrer_types_attrs.blank?

--- a/back/engines/commercial/analytics/app/services/analytics/populate_dimensions_service.rb
+++ b/back/engines/commercial/analytics/app/services/analytics/populate_dimensions_service.rb
@@ -10,6 +10,19 @@ module Analytics
         populate_referrer_types
       end
 
+      def create_dates(from, to)
+        (from..to).each do |date|
+          Analytics::DimensionDate.create!(
+            date: date,
+            week: date.beginning_of_week.to_date,
+            month: "#{date.year}-#{date.strftime('%m')}",
+            year: date.year
+          )
+        rescue ActiveRecord::RecordNotUnique
+          # Ignore any that already exist
+        end
+      end
+
       private
 
       def populate_dates
@@ -33,17 +46,6 @@ module Analytics
           end
         end
         create_dates(from, to)
-      end
-
-      def create_dates(from, to)
-        (from..to).each do |date|
-          Analytics::DimensionDate.create!(
-            date: date,
-            week: date.beginning_of_week.to_date,
-            month: "#{date.year}-#{date.strftime('%m')}",
-            year: date.year
-          )
-        end
       end
 
       def populate_types


### PR DESCRIPTION
# Changelog

## Fixed 
- CL-3701 - Visit data not being populated from Matomo for some tenants 
