### PR TITLE
[CL-3694] Use raw_from_email in ManualCampaignMailer

### DIFF
--- a/back/app/mailers/application_mailer.rb
+++ b/back/app/mailers/application_mailer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
-  default from: 'hello@citizenlab.co'
+  default from: -> { default_from_email }
   layout 'mailer'
 
   attr_reader :user
@@ -118,12 +118,12 @@ class ApplicationMailer < ActionMailer::Base
     email_address_with_name(raw_from_email, organization_name)
   end
 
-  def custom_from_email
-    app_settings.core.from_email
+  def default_from_email
+    ENV.fetch('DEFAULT_FROM_EMAIL', 'hello@citizenlab.co')
   end
 
   def raw_from_email
-    custom_from_email.presence || ENV.fetch('DEFAULT_FROM_EMAIL')
+    app_settings.core.from_email.presence || default_from_email
   end
 
   def to_email
@@ -131,7 +131,7 @@ class ApplicationMailer < ActionMailer::Base
   end
 
   def reply_to_email
-    app_settings.core.reply_to_email.presence || ENV.fetch('DEFAULT_FROM_EMAIL')
+    app_settings.core.reply_to_email.presence || default_from_email
   end
 
   def domain

--- a/back/app/mailers/application_mailer.rb
+++ b/back/app/mailers/application_mailer.rb
@@ -115,13 +115,15 @@ class ApplicationMailer < ActionMailer::Base
   end
 
   def from_email
-    email = raw_from_email
-
-    email_address_with_name(email, organization_name)
+    email_address_with_name(raw_from_email, organization_name)
   end
 
   def custom_from_email
     app_settings.core.from_email
+  end
+
+  def raw_from_email
+    custom_from_email.presence || ENV.fetch('DEFAULT_FROM_EMAIL')
   end
 
   def to_email
@@ -134,10 +136,6 @@ class ApplicationMailer < ActionMailer::Base
 
   def domain
     raw_from_email&.split('@')&.last
-  end
-
-  def raw_from_email
-    custom_from_email.presence || ENV.fetch('DEFAULT_FROM_EMAIL')
   end
 
   def app_settings

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/manual_campaign_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/manual_campaign_mailer.rb
@@ -30,7 +30,7 @@ module EmailCampaigns
     end
 
     def from_email
-      email_address_with_name ENV.fetch('DEFAULT_FROM_EMAIL', 'hello@citizenlab.co'), from_name(command[:sender], command[:author], recipient)
+      email_address_with_name (raw_from_email || 'hello@citizenlab.co'), from_name(command[:sender], command[:author], recipient)
     end
 
     private


### PR DESCRIPTION
<details>
  <summary>Manual Testing - Click me</summary>
  
![custom from address](https://github.com/CitizenLabDotCo/citizenlab/assets/3944042/aa1fa8ad-7201-40f3-9e35-c5baba59f71f)
![custom from address (1)](https://github.com/CitizenLabDotCo/citizenlab/assets/3944042/7435a8a0-5a41-4395-b4ab-63365272577e)

</details>

<details>
  <summary>Bugfix - handle case where no DEFAULT_FROM_EMAIL en var is set - Click me</summary>
  
On production, this bug is unlikely to be an issue , as we have the following values for DEFAULT_FROM_EMAIL env var:
```
Europe: 'notifications@mail-eu.citizenlab.co'
UK: 'notifications@mail-uk.citizenlab.co'
US: 'notifications@mail-us.citizenlab.co'
 SAM: 'notifications@mail-sam.citizenlab.co'
CAN: 'notifications@mail-can.citizenlab.co'
STG: 'notifications@mail-stg.citizenlab.co'
```

In development the value is set to `'notifications@citizenlab.co'` [here](https://github.com/CitizenLabDotCo/citizenlab/blob/baadd7a81a87e3cb704a547e2d189ed24caf41c4/env_files/back-safe.env#L16), but if this is commented out (to debug what happens in this case, then automated emails will fail silently - e.g when sending an invite, where from a UI point of view, an 'Invitation sent' confirmation occurs and the invited user is created, preventing further invites, but no invite is sent), with this error in logs:
```
cl-que         | 2023-06-24 14:44:08.600875 E [8:265560 log_subscriber.rb:130] [ActionMailer::MailDeliveryJob] [887b7451-72a6-4bb7-84fa-8dc7b4871dcd] Rails -- Error performing ActionMailer::MailDeliveryJob (Job ID: 887b7451-72a6-4bb7-84fa-8dc7b4871dcd) from Que(default) in 18.91ms: KeyError (key not found: "DEFAULT_FROM_EMAIL"
```
and manual emails similarly appear (in the UI) to be sent, but in fact raise the error:
```
cl-back-web    | 2023-06-23 14:46:53.610573 D [10:puma srv tp 002] Rails -- Unpermitted parameter: :group_ids. Context: { controller: WebApi::V1::InvitesController, action: count_new_seats, request: #<ActionDispatch::Request:0x00007f74587347f8>, params: {"invites"=>{"emails"=>["a@b.com"], "locale"=>"en", "roles"=>[], "group_ids"=>nil, "invite_text"=>nil}, "format"=>:json, "controller"=>"web_api/v1/invites", "action"=>"count_new_seats", "invite"=>{}} }
```
Now, in both cases, we fall back to an email value of `'hello@citizenlab.co'` for both the from and reply-to email addresses, and things keep working, as seemed to be the intention of the (previously failing) code in `ApplicationMailer`.

</details>

# Changelog
## Fixed
- [CL-3694] Custom from email address now works with manual campaigns (when customer has configured domain - needs testing with real example in production to confirm fully functional)
- [CL-3694] Handle case where env var DEFAULT_FROM_EMAIL is not set, by providing fallback value. 

[CL-3694]: https://citizenlab.atlassian.net/browse/CL-3694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ