### PR TITLE
[CL-3780] Seed some internal_comments for local dev use

### DIFF
--- a/back/engines/commercial/multi_tenancy/db/seeds/internal_comments.rb
+++ b/back/engines/commercial/multi_tenancy/db/seeds/internal_comments.rb
@@ -17,7 +17,7 @@ module MultiTenancy
             post: idea
           )
 
-          create_reply_comment(idea, internal_comment, admins) if internal_comment && admins.second
+          create_reply_comment(idea, internal_comment, admins) if admins.second
         end
 
         if initiative && admins.first
@@ -27,7 +27,7 @@ module MultiTenancy
             post: initiative
           )
 
-          create_reply_comment(initiative, internal_comment, admins) if internal_comment && admins.second
+          create_reply_comment(initiative, internal_comment, admins) if admins.second
         end
       end
 

--- a/back/engines/commercial/multi_tenancy/db/seeds/internal_comments.rb
+++ b/back/engines/commercial/multi_tenancy/db/seeds/internal_comments.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module MultiTenancy
+  module Seeds
+    class InternalComments < Base
+      def run
+        idea = Idea.first
+        initiative = Initiative.first
+        admins = User.admin
+
+        if idea && admins.first
+          internal_comment = InternalComment.create!(
+            body: 'We should bring this input to the next executive meeting.',
+            author: admins.first,
+            post: idea
+          )
+
+          create_reply_comment(idea, internal_comment, admins) if internal_comment && admins.second
+        end
+
+        if initiative && admins.first
+          internal_comment = InternalComment.create!(
+            body: 'We should bring this proposal to the next executive meeting.',
+            author: admins.first,
+            post: initiative
+          )
+
+          create_reply_comment(initiative, internal_comment, admins) if internal_comment && admins.second
+        end
+      end
+
+      def create_reply_comment(post, parent, admins)
+        InternalComment.create!(
+          body: '+1 to this!',
+          author: admins.second,
+          post: post,
+          parent: parent
+        )
+      end
+    end
+  end
+end

--- a/back/engines/commercial/multi_tenancy/db/seeds/runner.rb
+++ b/back/engines/commercial/multi_tenancy/db/seeds/runner.rb
@@ -16,6 +16,7 @@ require_relative 'groups'
 require_relative 'home_pages'
 require_relative 'ideas'
 require_relative 'iniatives'
+require_relative 'internal_comments'
 require_relative 'invites'
 require_relative 'permissions'
 require_relative 'project_folders'
@@ -111,6 +112,7 @@ module MultiTenancy
         MultiTenancy::Seeds::Projects.new(runner: self).run
         MultiTenancy::Seeds::Ideas.new(runner: self).run
         MultiTenancy::Seeds::Iniatives.new(runner: self).run
+        MultiTenancy::Seeds::InternalComments.new(runner: self).run
 
         InitiativeStatusService.new.automated_transitions!
 

--- a/back/engines/commercial/multi_tenancy/db/seeds/users.rb
+++ b/back/engines/commercial/multi_tenancy/db/seeds/users.rb
@@ -7,10 +7,15 @@ module MultiTenancy
     class Users < Base
       attr_reader :anonymizer
 
-      ADMIN_ATTRS = {
+      ADMIN_1_ATTRS = {
         id: '386d255e-2ff1-4192-8e50-b3022576be50',
         email: 'admin@citizenlab.co',
         password: 'democracy2.0',
+        roles: [{ type: 'admin' }],
+        locale: 'en'
+      }.freeze
+
+      ADMIN_2_ATTRS = {
         roles: [{ type: 'admin' }],
         locale: 'en'
       }.freeze
@@ -47,12 +52,13 @@ module MultiTenancy
 
       def run_for_empty_localhost
         random_user = anonymizer.anonymized_attributes(AppConfiguration.instance.settings('core', 'locales'))
-        User.create!(random_user.merge({ **admin_attrs, id: 'e0d698fc-5969-439f-9fe6-e74fe82b567a' }))
+        User.create!(random_user.merge({ **admin_1_attrs, id: 'e0d698fc-5969-439f-9fe6-e74fe82b567a' }))
       end
 
       def run_for_localhost
         locales = AppConfiguration.instance.settings('core', 'locales')
-        User.create! anonymizer.anonymized_attributes(locales).merge(admin_attrs)
+        User.create! anonymizer.anonymized_attributes(locales).merge(admin_1_attrs)
+        User.create! anonymizer.anonymized_attributes(locales).merge(admin_2_attrs)
         User.create! anonymizer.anonymized_attributes(locales).merge(moderator_attrs)
         User.create! anonymizer.anonymized_attributes(locales).merge(user_attrs)
 
@@ -61,8 +67,12 @@ module MultiTenancy
         end
       end
 
-      def admin_attrs
-        ADMIN_ATTRS
+      def admin_1_attrs
+        ADMIN_1_ATTRS
+      end
+
+      def admin_2_attrs
+        ADMIN_2_ATTRS
       end
 
       def moderator_attrs


### PR DESCRIPTION
Seeds 4 `internal comments`, 2 for an `Initiative`, 2 for an `Idea`.

Seeds 1 additional admin, so that 2 comments (by admin_2) can be replies to comments (by admin_1).

I decided not to use any moderators for the `Idea` `internal_comments`, as ensuring there were moderators for the `Idea` project seemed likely to make the code unnecessarily complicated (and to make following the user setup difficult)

# Changelog
## Technical
- [CL-3780] Seed some `internal_comments` for local dev use


[CL-3780]: https://citizenlab.atlassian.net/browse/CL-3780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ