### PR TITLE
Fix failing e2e tests

### DIFF
--- a/front/app/components/PostShowComponents/Comments/CommentingDisabled.tsx
+++ b/front/app/components/PostShowComponents/Comments/CommentingDisabled.tsx
@@ -131,7 +131,7 @@ const CommentingDisabled = ({
               </button>
             ),
             verifyIdentityLink: (
-              <button onClick={signUp}>
+              <button id="e2e-verify-identity-to-comment" onClick={signUp}>
                 <FormattedMessage {...messages.verifyIdentityLinkText} />
               </button>
             ),

--- a/front/cypress/e2e/idea_posting_permissions.cy.ts
+++ b/front/cypress/e2e/idea_posting_permissions.cy.ts
@@ -45,6 +45,7 @@ describe('Idea posting permissions', () => {
       cy.setLoginCookie(unverifiedEmail, unverifiedPassword);
       cy.visit('projects/verified-ideation');
       cy.acceptCookies();
+      cy.get('#e2e-idea-button').should('exist');
       cy.get('#e2e-idea-button').first().click();
       cy.get('#e2e-verification-wizard-root').should('exist');
     });
@@ -53,6 +54,7 @@ describe('Idea posting permissions', () => {
       cy.setLoginCookie(verifiedEmail, verifiedPassword);
       cy.visit('projects/verified-ideation');
       cy.acceptCookies();
+      cy.get('#e2e-idea-button').should('exist');
       cy.get('#e2e-idea-button').first().click();
       cy.get('#e2e-idea-new-page').should('exist');
     });
@@ -88,7 +90,10 @@ describe('idea posting permissions for non-active users', () => {
     cy.setLoginCookie(email, password);
     cy.visit('projects/verified-ideation');
     cy.acceptCookies();
-    cy.get('.e2e-idea-button:visible').first().click();
+    cy.get('#e2e-ideas-list').find('.e2e-idea-card').should('exist');
+    cy.get('#e2e-ideas-list').find('.e2e-idea-card').first().click();
+    cy.get('#e2e-verify-identity-to-comment').should('exist');
+    cy.get('#e2e-verify-identity-to-comment').click();
     cy.get('#e2e-authentication-modal').should('exist');
   });
 

--- a/front/cypress/e2e/survey_builder/create_and_fill_survey.cy.ts
+++ b/front/cypress/e2e/survey_builder/create_and_fill_survey.cy.ts
@@ -595,7 +595,7 @@ describe('Survey builder', () => {
     // Try filling in the survey again
     cy.visit(`/projects/${projectSlug}`);
     cy.get('#e2e-cta-button').find('button').should('have.attr', 'disabled');
-    cy.get('#e2e-project-sidebar-surveys-count').should('not.exist');
+    cy.get('#e2e-project-sidebar-surveys-count').should('exist');
   });
 
   it('shows validation errors when current page or previous pages are referenced', () => {


### PR DESCRIPTION
**create_and_fill_survey:**
- Looks like some behaviour was changed [here](https://github.com/CitizenLabDotCo/citizenlab/commit/81b5106292120ccd2e825230e22414e844a31bf7), so the # of surveys is always shown in the project info box now (but the clickable link is removed) so the e2e test just needed to be updated.

**idea_posting_permissions:**
- Just needed some additional should('exist') checks I think - it was a bit flaky without them
- The commenting test also wasn't really testing commenting, so I updated it.