### PR TITLE
CL-3884 - Remove reaction config

### DIFF
--- a/front/app/containers/Admin/projects/project/participationContext/components/inputs/IdeationInputs/index.tsx
+++ b/front/app/containers/Admin/projects/project/participationContext/components/inputs/IdeationInputs/index.tsx
@@ -111,13 +111,10 @@ export default ({
     name: 'anonymous_participation',
   });
 
-  const reactingConfigNotDefault = useRef(
-    !reacting_dislike_enabled ||
-      reacting_like_method === 'limited' ||
-      reacting_dislike_method === 'limited'
+  const reactingLimited = useRef(
+    reacting_like_method === 'limited' || reacting_dislike_method === 'limited'
   );
-  const showReactingConfig =
-    reacting_enabled && reactingConfigNotDefault.current;
+  const showReactingLimits = reactingLimited.current;
 
   return (
     <>
@@ -171,54 +168,56 @@ export default ({
           <Error apiErrors={apiErrors && apiErrors.reacting_enabled} />
         </ToggleRow>
       </StyledSectionField>
-      {showReactingConfig && (
+      {reacting_enabled && (
         <>
-          <SectionField>
-            <SubSectionTitle>
-              <FormattedMessage {...messages.likingMethodTitle} />
-            </SubSectionTitle>
-            <Radio
-              onChange={handleReactingLikeMethodOnChange}
-              currentValue={reacting_like_method}
-              value="unlimited"
-              name="likingmethod"
-              id="likingmethod-unlimited"
-              label={<FormattedMessage {...messages.unlimited} />}
-            />
-            <Radio
-              onChange={handleReactingLikeMethodOnChange}
-              currentValue={reacting_like_method}
-              value="limited"
-              name="likingmethod"
-              id="likingmethod-limited"
-              label={<FormattedMessage {...messages.limited} />}
-            />
-            <Error apiErrors={apiErrors && apiErrors.reacting_method} />
+          {showReactingLimits && (
+            <SectionField>
+              <SubSectionTitle>
+                <FormattedMessage {...messages.likingMethodTitle} />
+              </SubSectionTitle>
+              <Radio
+                onChange={handleReactingLikeMethodOnChange}
+                currentValue={reacting_like_method}
+                value="unlimited"
+                name="likingmethod"
+                id="likingmethod-unlimited"
+                label={<FormattedMessage {...messages.unlimited} />}
+              />
+              <Radio
+                onChange={handleReactingLikeMethodOnChange}
+                currentValue={reacting_like_method}
+                value="limited"
+                name="likingmethod"
+                id="likingmethod-limited"
+                label={<FormattedMessage {...messages.limited} />}
+              />
+              <Error apiErrors={apiErrors && apiErrors.reacting_method} />
 
-            {reacting_like_method === 'limited' && (
-              <>
-                <SubSectionTitle>
-                  <FormattedMessage {...messages.maxLikes} />
-                </SubSectionTitle>
-                <ReactingLimitInput
-                  id="liking-limit"
-                  type="number"
-                  min="1"
-                  placeholder=""
-                  value={
-                    reacting_like_limited_max
-                      ? reacting_like_limited_max.toString()
-                      : null
-                  }
-                  onChange={handleLikingLimitOnChange}
-                />
-                <Error
-                  text={noLikingLimitError}
-                  apiErrors={apiErrors && apiErrors.reacting_limit}
-                />
-              </>
-            )}
-          </SectionField>
+              {reacting_like_method === 'limited' && (
+                <>
+                  <SubSectionTitle>
+                    <FormattedMessage {...messages.maxLikes} />
+                  </SubSectionTitle>
+                  <ReactingLimitInput
+                    id="liking-limit"
+                    type="number"
+                    min="1"
+                    placeholder=""
+                    value={
+                      reacting_like_limited_max
+                        ? reacting_like_limited_max.toString()
+                        : null
+                    }
+                    onChange={handleLikingLimitOnChange}
+                  />
+                  <Error
+                    text={noLikingLimitError}
+                    apiErrors={apiErrors && apiErrors.reacting_limit}
+                  />
+                </>
+              )}
+            </SectionField>
+          )}
           <FeatureFlag name="disable_disliking">
             <SectionField>
               <SubSectionTitle>
@@ -249,7 +248,7 @@ export default ({
                 apiErrors={apiErrors && apiErrors.reacting_dislike_enabled}
               />
             </SectionField>
-            {reacting_dislike_enabled && (
+            {reacting_dislike_enabled && showReactingLimits && (
               <SectionField>
                 <SubSectionTitle>
                   <FormattedMessage {...messages.dislikingMethodTitle} />

--- a/front/app/containers/Admin/projects/project/participationContext/components/inputs/IdeationInputs/index.tsx
+++ b/front/app/containers/Admin/projects/project/participationContext/components/inputs/IdeationInputs/index.tsx
@@ -119,8 +119,6 @@ export default ({
   const showReactingConfig =
     reacting_enabled && reactingConfigNotDefault.current;
 
-  console.log(reacting_enabled, reactingConfigNotDefault.current);
-
   return (
     <>
       {hasAnonymousParticipationEnabled && (

--- a/front/app/containers/Admin/projects/project/participationContext/components/inputs/IdeationInputs/index.tsx
+++ b/front/app/containers/Admin/projects/project/participationContext/components/inputs/IdeationInputs/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 
 // components
 import {
@@ -110,6 +110,17 @@ export default ({
   const hasAnonymousParticipationEnabled = useFeatureFlag({
     name: 'anonymous_participation',
   });
+
+  const reactingConfigNotDefault = useRef(
+    !reacting_dislike_enabled ||
+      reacting_like_method === 'limited' ||
+      reacting_dislike_method === 'limited'
+  );
+  const showReactingConfig =
+    reacting_enabled && reactingConfigNotDefault.current;
+
+  console.log(reacting_enabled, reactingConfigNotDefault.current);
+
   return (
     <>
       {hasAnonymousParticipationEnabled && (
@@ -162,7 +173,7 @@ export default ({
           <Error apiErrors={apiErrors && apiErrors.reacting_enabled} />
         </ToggleRow>
       </StyledSectionField>
-      {reacting_enabled && (
+      {showReactingConfig && (
         <>
           <SectionField>
             <SubSectionTitle>


### PR DESCRIPTION
The configurations for liking/disliking should not show for new projects and existing projects where the default values are set.
