### PR TITLE
[CL-3881] Link internal comments email CTA buttons to respective internal comment

### DIFF
--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/internal_comment_on_unassigned_unmoderated_idea.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/internal_comment_on_unassigned_unmoderated_idea.rb
@@ -63,7 +63,7 @@ module EmailCampaigns
     end
 
     def self.trigger_multiloc_key
-      'email_campaigns.admin_labels.trigger.internal_comment_is_made_on_unassigned_unmoderated_idea'
+      'email_campaigns.admin_labels.trigger.internal_comment_is_posted_on_unassigned_unmoderated_idea'
     end
 
     def mailer_class

--- a/back/engines/free/frontend/app/services/frontend/url_service.rb
+++ b/back/engines/free/frontend/app/services/frontend/url_service.rb
@@ -24,8 +24,14 @@ module Frontend
       when User
         subroute = 'profile'
         slug = model_instance.slug
-      when Comment, InternalComment, OfficialFeedback ### comments and official feedbacks do not have a path yet, we return the post path for now
+      when Comment, OfficialFeedback # Comments and official feedbacks do not have a path yet, we return the post path for now
         return model_to_path(model_instance.post)
+      when InternalComment # Internal comments are only implemented in the Back Office / Admin UI
+        if model_instance.post_type == 'Idea'
+          return "admin/projects/#{model_instance.post.project_id}/ideas/#{model_instance.post.id}##{model_instance.id}"
+        elsif model_instance.post_type == 'Initiative'
+          return "admin/initiatives/#{model_instance.post.id}##{model_instance.id}"
+        end
       when ProjectFolders::Folder
         subroute = 'folders'
         slug = model_instance.slug

--- a/back/engines/free/frontend/app/services/frontend/url_service.rb
+++ b/back/engines/free/frontend/app/services/frontend/url_service.rb
@@ -28,9 +28,9 @@ module Frontend
         return model_to_path(model_instance.post)
       when InternalComment # Internal comments are only implemented in the Back Office / Admin UI
         if model_instance.post_type == 'Idea'
-          return "admin/projects/#{model_instance.post.project_id}/ideas/#{model_instance.post.id}##{model_instance.id}"
+          return "/admin/projects/#{model_instance.post.project_id}/ideas/#{model_instance.post.id}##{model_instance.id}"
         elsif model_instance.post_type == 'Initiative'
-          return "admin/initiatives/#{model_instance.post.id}##{model_instance.id}"
+          return "/admin/initiatives/#{model_instance.post.id}##{model_instance.id}"
         end
       when ProjectFolders::Folder
         subroute = 'folders'

--- a/back/engines/free/frontend/spec/services/frontend/url_service_spec.rb
+++ b/back/engines/free/frontend/spec/services/frontend/url_service_spec.rb
@@ -11,10 +11,9 @@ describe Frontend::UrlService do
     let(:internal_comment1) { create(:internal_comment, post: idea) }
     let(:initiative) { create(:initiative) }
     let(:internal_comment2) { create(:internal_comment, post: initiative) }
-    let(:user) { create(:user, locale: 'en') }
 
     it 'returns the correct url for an internal comment on an idea' do
-      expect(service.model_to_url(internal_comment1, locale: user.locale))
+      expect(service.model_to_url(internal_comment1, locale: 'en'))
         .to eq(
           "#{base_uri}/en/admin/projects/#{internal_comment1.post.project_id}" \
           "/ideas/#{internal_comment1.post.id}##{internal_comment1.id}"
@@ -22,7 +21,7 @@ describe Frontend::UrlService do
     end
 
     it 'returns the correct url for an internal comment on an initiative' do
-      expect(service.model_to_url(internal_comment2, locale: user.locale))
+      expect(service.model_to_url(internal_comment2, locale: 'en'))
         .to eq("#{base_uri}/en/admin/initiatives/#{internal_comment2.post.id}##{internal_comment2.id}")
     end
   end

--- a/back/engines/free/frontend/spec/services/url_service_spec.rb
+++ b/back/engines/free/frontend/spec/services/url_service_spec.rb
@@ -10,20 +10,19 @@ describe Frontend::UrlService do
     let(:internal_comment1) { create(:internal_comment, post: idea) }
     let(:initiative) { create(:initiative) }
     let(:internal_comment2) { create(:internal_comment, post: initiative) }
+    let(:base_uri) { AppConfiguration.instance.base_frontend_uri }
 
     it 'returns the correct url for an internal comment on an idea' do
       expect(service.model_to_url(internal_comment1))
-        .to include(
-          "://#{Tenant.current.host}/admin/projects/#{internal_comment1.post.project_id}" \
+        .to eq(
+          "#{base_uri}/admin/projects/#{internal_comment1.post.project_id}" \
           "/ideas/#{internal_comment1.post.id}##{internal_comment1.id}"
         )
     end
 
     it 'returns the correct url for an internal comment on an initiative' do
       expect(service.model_to_url(internal_comment2))
-        .to include(
-          "://#{Tenant.current.host}/admin/initiatives/#{internal_comment2.post.id}##{internal_comment2.id}"
-        )
+        .to eq("#{base_uri}/admin/initiatives/#{internal_comment2.post.id}##{internal_comment2.id}")
     end
   end
 end

--- a/back/engines/free/frontend/spec/services/url_service_spec.rb
+++ b/back/engines/free/frontend/spec/services/url_service_spec.rb
@@ -4,13 +4,13 @@ require 'rails_helper'
 
 describe Frontend::UrlService do
   let(:service) { described_class.new }
+  let(:base_uri) { AppConfiguration.instance.base_frontend_uri }
 
   describe '#model_to_url' do
     let(:idea) { create(:idea) }
     let(:internal_comment1) { create(:internal_comment, post: idea) }
     let(:initiative) { create(:initiative) }
     let(:internal_comment2) { create(:internal_comment, post: initiative) }
-    let(:base_uri) { AppConfiguration.instance.base_frontend_uri }
     let(:user) { create(:user, locale: 'en') }
 
     it 'returns the correct url for an internal comment on an idea' do

--- a/back/engines/free/frontend/spec/services/url_service_spec.rb
+++ b/back/engines/free/frontend/spec/services/url_service_spec.rb
@@ -11,18 +11,19 @@ describe Frontend::UrlService do
     let(:initiative) { create(:initiative) }
     let(:internal_comment2) { create(:internal_comment, post: initiative) }
     let(:base_uri) { AppConfiguration.instance.base_frontend_uri }
+    let(:user) { create(:user, locale: 'en') }
 
     it 'returns the correct url for an internal comment on an idea' do
-      expect(service.model_to_url(internal_comment1))
+      expect(service.model_to_url(internal_comment1, locale: user.locale))
         .to eq(
-          "#{base_uri}/admin/projects/#{internal_comment1.post.project_id}" \
+          "#{base_uri}/en/admin/projects/#{internal_comment1.post.project_id}" \
           "/ideas/#{internal_comment1.post.id}##{internal_comment1.id}"
         )
     end
 
     it 'returns the correct url for an internal comment on an initiative' do
-      expect(service.model_to_url(internal_comment2))
-        .to eq("#{base_uri}/admin/initiatives/#{internal_comment2.post.id}##{internal_comment2.id}")
+      expect(service.model_to_url(internal_comment2, locale: user.locale))
+        .to eq("#{base_uri}/en/admin/initiatives/#{internal_comment2.post.id}##{internal_comment2.id}")
     end
   end
 end

--- a/back/engines/free/frontend/spec/services/url_service_spec.rb
+++ b/back/engines/free/frontend/spec/services/url_service_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Frontend::UrlService do
+  let(:service) { described_class.new }
+
+  describe '#model_to_url' do
+    let(:idea) { create(:idea) }
+    let(:internal_comment1) { create(:internal_comment, post: idea) }
+    let(:initiative) { create(:initiative) }
+    let(:internal_comment2) { create(:internal_comment, post: initiative) }
+
+    it 'returns the correct url for an internal comment on an idea' do
+      expect(service.model_to_url(internal_comment1))
+        .to include(
+          "://#{Tenant.current.host}/admin/projects/#{internal_comment1.post.project_id}" \
+          "/ideas/#{internal_comment1.post.id}##{internal_comment1.id}"
+        )
+    end
+
+    it 'returns the correct url for an internal comment on an initiative' do
+      expect(service.model_to_url(internal_comment2))
+        .to include(
+          "://#{Tenant.current.host}/admin/initiatives/#{internal_comment2.post.id}##{internal_comment2.id}"
+        )
+    end
+  end
+end


### PR DESCRIPTION
UPDATE: This is already merged to an epic deploy: https://internalcommentingwithemails.epic.citizenlab.co/ and the email CTA buttons do, indeed, link to the relevant `internal_comment` in the BO.

-------------------------------------------------------------------------------

On `internal_comments` [epic deploy](https://internalcommenting.epic.citizenlab.co/) (with new FE, from this [PR branch](https://github.com/CitizenLabDotCo/citizenlab/pull/5162)) we can already see the URL to link to internal comments when clicking on a notification related to an internal comment:

Clicking on an `internal_comment` notification takes you to the comment, using the comment's ID as an anchor, eg:
```
https://internalcommenting.epic.citizenlab.co/en/admin/projects/aec9515a-b1a2-4ef8-b6c4-b5c94f7fb585/ideas/1580e8bc-21b1-48ea-b0a7-8f0b98a42ecf#0bdfae88-61e5-470b-a1d9-58ccb47437fa
```

This is:
```Ruby
https://<host>/<recipient.locale>/admin/projects/<idea.project.id>/ideas/<idea.id>#<internal_comment_id>
```

An internal comment on a proposal is simpler (no project):
```
https://internalcommenting.epic.citizenlab.co/en/admin/initiatives/a32823d7-2f5f-4a87-9aaa-f598c57be6de#5d6dc59f-3ce6-4d92-b784-0106e9dc95ab
```

This is:
```Ruby
https://<host>/<recipient.locale>/admin/initiatives/<initiative.id>#<internal_comment_id>
```

Thus, this PR adds URL builders to `Frontend::UrlService`, which is used in the `InternalCommentCampaignCommandsBuilder` `build_commands` method.

A spec file is also added to include tests of the 2 different URL forms (`internal_comment` on `idea` vs. `internal_comment` on `initiative`).

# Changelog
## Technical
- [CL-3881] Link internal comments email CTA buttons to respective internal comment


[CL-3881]: https://citizenlab.atlassian.net/browse/CL-3881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ