### PR TITLE
CL-3890 - Users thrown out of sign-up flow when content builder used for description

### DIFF
--- a/back/app/serializers/web_api/v1/project_serializer.rb
+++ b/back/app/serializers/web_api/v1/project_serializer.rb
@@ -156,3 +156,4 @@ class WebApi::V1::ProjectSerializer < WebApi::V1::BaseSerializer
 end
 
 WebApi::V1::ProjectSerializer.include(IdeaAssignment::Extensions::WebApi::V1::ProjectSerializer)
+WebApi::V1::ProjectSerializer.include(ContentBuilder::Extensions::WebApi::V1::ProjectSerializer)

--- a/back/engines/commercial/content_builder/app/models/content_builder/patches/project.rb
+++ b/back/engines/commercial/content_builder/app/models/content_builder/patches/project.rb
@@ -38,7 +38,7 @@ module ContentBuilder
         }, using: { tsearch: { prefix: true } }
 
         def uses_content_builder?
-          content_builder_layouts.present? && content_builder_layouts.pluck(:enabled).include?(true)
+          content_builder_layouts.any?(&:enabled)
         end
       end
 

--- a/back/engines/commercial/content_builder/app/models/content_builder/patches/project.rb
+++ b/back/engines/commercial/content_builder/app/models/content_builder/patches/project.rb
@@ -36,6 +36,10 @@ module ContentBuilder
         pg_search_scope :search_by_content_layouts, associated_against: {
           content_builder_layouts: [Arel.sql(CRAFTJS_TEXT_QUERY)]
         }, using: { tsearch: { prefix: true } }
+
+        def uses_content_builder?
+          content_builder_layouts.present? && content_builder_layouts.pluck(:enabled).include?(true)
+        end
       end
 
       class_methods do

--- a/back/engines/commercial/content_builder/app/serializers/content_builder/extensions/web_api/v1/project_serializer.rb
+++ b/back/engines/commercial/content_builder/app/serializers/content_builder/extensions/web_api/v1/project_serializer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module ContentBuilder
+  module Extensions
+    module WebApi
+      module V1
+        module ProjectSerializer
+          def self.included(base)
+            base.class_eval do
+              attribute :uses_content_builder do |project|
+                project.uses_content_builder?
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/back/engines/commercial/content_builder/spec/models/content_builder/patches/project_spec.rb
+++ b/back/engines/commercial/content_builder/spec/models/content_builder/patches/project_spec.rb
@@ -27,6 +27,23 @@ RSpec.describe ContentBuilder::Patches::Project do
         expect { project.destroy }.to change(ContentBuilder::Layout, :count).by(-2)
       end
     end
+
+    describe '#uses_content_builder?' do
+      it 'returns true if it has enabled layouts' do
+        expect(project.uses_content_builder?).to be true
+      end
+
+      it 'returns false if it has no enabled layouts' do
+        layout.update!(enabled: false)
+        expect(project.uses_content_builder?).to be false
+      end
+
+      it 'returns false if it has no layouts' do
+        layout.destroy!
+        another_layout.destroy!
+        expect(project.uses_content_builder?).to be false
+      end
+    end
   end
 
   describe '.search_ids_by_all_including_patches' do

--- a/front/app/api/projects/__mocks__/useProjects.ts
+++ b/front/app/api/projects/__mocks__/useProjects.ts
@@ -97,6 +97,7 @@ export const project1: IProjectData = {
     participants_count: 8,
     // MISMATCH: this attribute doesn't exist on our type
     // allocated_budget: 0
+    uses_content_builder: false,
   },
   relationships: {
     admin_publication: {
@@ -239,6 +240,7 @@ export const project2: IProjectData = {
     participants_count: 6,
     // MISMATCH: doesn't seem to exist on our type
     // allocated_budget: 0
+    uses_content_builder: false,
   },
   relationships: {
     admin_publication: {

--- a/front/app/api/projects/types.ts
+++ b/front/app/api/projects/types.ts
@@ -187,6 +187,7 @@ export interface IProjectAttributes {
     taking_poll: ActionDescriptor<PollDisabledReason>;
     annotating_document: ActionDescriptor<DocumentAnnotationDisabledReason>;
   };
+  uses_content_builder: boolean;
 }
 
 export interface IProjectData {

--- a/front/app/modules/commercial/project_description_builder/hooks/useProjectDescriptionBuilderLayout.test.ts
+++ b/front/app/modules/commercial/project_description_builder/hooks/useProjectDescriptionBuilderLayout.test.ts
@@ -38,51 +38,79 @@ jest.mock(
   }
 );
 
-describe('useProjectDescriptionBuilderLayout', () => {
-  it('should call projectDescriptionBuilderLayoutStream with correct arguments', () => {
-    renderHook(() => useProjectDescriptionBuilderLayout(projectId));
-    expect(projectDescriptionBuilderLayoutStream).toHaveBeenCalledWith(
-      projectId
-    );
-  });
-  it('should return data when data', async () => {
-    const { result } = renderHook(() =>
-      useProjectDescriptionBuilderLayout(projectId)
-    );
-    expect(result.current).toBe(undefined);
-    await act(
-      async () =>
-        await waitFor(() =>
-          expect(result.current).toBe(mockProjectDescriptionBuilderLayout)
-        )
-    );
-  });
-  it('should return error when error', () => {
-    const error = new Error();
-    mockObservable = new Observable((subscriber) => {
-      subscriber.next(new Error());
-    });
-    const { result } = renderHook(() =>
-      useProjectDescriptionBuilderLayout(projectId)
-    );
-    expect(result.current).toStrictEqual(error);
-  });
-  it('should return null when data is null', () => {
-    mockObservable = new Observable((subscriber) => {
-      subscriber.next(null);
-    });
-    const { result } = renderHook(() =>
-      useProjectDescriptionBuilderLayout(projectId)
-    );
-    expect(result.current).toBe(null);
-  });
-  it('should unsubscribe on unmount', () => {
-    jest.spyOn(Subscription.prototype, 'unsubscribe');
-    const { unmount } = renderHook(() =>
-      useProjectDescriptionBuilderLayout(projectId)
-    );
+const projectResponseEnabled = {
+  data: { data: { id: projectId, attributes: { uses_content_builder: true } } },
+};
 
-    unmount();
-    expect(Subscription.prototype.unsubscribe).toHaveBeenCalledTimes(1);
+const projectResponseDisabled = {
+  data: {
+    data: { id: projectId, attributes: { uses_content_builder: false } },
+  },
+};
+
+let mockProjectResponse = projectResponseEnabled;
+jest.mock('api/projects/useProjectById', () => () => mockProjectResponse);
+
+describe('useProjectDescriptionBuilderLayout', () => {
+  describe('layout enabled', () => {
+    beforeEach(() => {
+      mockProjectResponse = projectResponseEnabled;
+    });
+
+    it('should call projectDescriptionBuilderLayoutStream with correct arguments', () => {
+      renderHook(() => useProjectDescriptionBuilderLayout(projectId));
+      expect(projectDescriptionBuilderLayoutStream).toHaveBeenCalledWith(
+        projectId
+      );
+    });
+    it('should return data when data', async () => {
+      const { result } = renderHook(() =>
+        useProjectDescriptionBuilderLayout(projectId)
+      );
+      expect(result.current).toBe(undefined);
+      await act(
+        async () =>
+          await waitFor(() =>
+            expect(result.current).toBe(mockProjectDescriptionBuilderLayout)
+          )
+      );
+    });
+    it('should return error when error', () => {
+      const error = new Error();
+      mockObservable = new Observable((subscriber) => {
+        subscriber.next(new Error());
+      });
+      const { result } = renderHook(() =>
+        useProjectDescriptionBuilderLayout(projectId)
+      );
+      expect(result.current).toStrictEqual(error);
+    });
+    it('should return null when data is null', () => {
+      mockObservable = new Observable((subscriber) => {
+        subscriber.next(null);
+      });
+      const { result } = renderHook(() =>
+        useProjectDescriptionBuilderLayout(projectId)
+      );
+      expect(result.current).toBe(null);
+    });
+    it('should unsubscribe on unmount', () => {
+      jest.spyOn(Subscription.prototype, 'unsubscribe');
+      const { unmount } = renderHook(() =>
+        useProjectDescriptionBuilderLayout(projectId)
+      );
+
+      unmount();
+      expect(Subscription.prototype.unsubscribe).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('layout disabled', () => {
+    it('should not call projectDescriptionBuilderLayoutStream', () => {
+      mockProjectResponse = projectResponseDisabled;
+
+      renderHook(() => useProjectDescriptionBuilderLayout(projectId));
+      expect(projectDescriptionBuilderLayoutStream).not.toHaveBeenCalled();
+    });
   });
 });

--- a/front/app/modules/commercial/project_description_builder/hooks/useProjectDescriptionBuilderLayout.ts
+++ b/front/app/modules/commercial/project_description_builder/hooks/useProjectDescriptionBuilderLayout.ts
@@ -1,24 +1,33 @@
 import { useState, useEffect } from 'react';
+import useProjectById from 'api/projects/useProjectById';
 import {
   projectDescriptionBuilderLayoutStream,
   IProjectDescriptionBuilderLayout,
 } from '../services/projectDescriptionBuilder';
 
 const useProjectDescriptionBuilderLayout = (projectId: string) => {
+  const { data: project } = useProjectById(projectId);
   const [projectDescriptionBuilderLayout, setProjectDescriptionBuilderLayout] =
     useState<IProjectDescriptionBuilderLayout | undefined | null | Error>(
       undefined
     );
 
   useEffect(() => {
+    if (!project) return;
+
+    if (!project.data.attributes.uses_content_builder) {
+      setProjectDescriptionBuilderLayout(null);
+      return;
+    }
+
     const subscription = projectDescriptionBuilderLayoutStream(
-      projectId
+      project.data.id
     ).observable.subscribe((contentBuilderLayout) => {
       setProjectDescriptionBuilderLayout(contentBuilderLayout);
     });
 
     return () => subscription.unsubscribe();
-  }, [projectId]);
+  }, [project]);
 
   return projectDescriptionBuilderLayout;
 };


### PR DESCRIPTION
# Changelog

## Fixed
- CL-3890 - Users thrown out of sign-up flow when content builder used for description
