### PR TITLE
[CL-3872] Show clear instructions on how to use ClaveUnica with existing email

### DIFF
--- a/back/app/controllers/omniauth_callback_controller.rb
+++ b/back/app/controllers/omniauth_callback_controller.rb
@@ -43,7 +43,7 @@ class OmniauthCallbackController < ApplicationController
   # Currently, only FranceConnect and ClaveUnica use this method (support both verification and authentication).
   def auth_or_verification_callback(verify:, authver_method:)
     # If token is present, the user is already logged in, which means they try to verify not authenticate.
-    if request.env['omniauth.params']['token'] && authver_method.verification_prioritized?
+    if request.env['omniauth.params']['token'].present? && authver_method.verification_prioritized?
       # We need it only for ClaveUnica. For FC, we never verify, only authenticate (even when user clicks "verify").
       verification_callback(verify)
       # Apart from verification, we also create an identity to be able to authenticate with this provider.

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -427,6 +427,11 @@ class User < ApplicationRecord
     registered? && !blocked? && !confirmation_required?
   end
 
+  def blank_and_can_be_deleted?
+    # atm it can be true only for users registered with ClaveUnica who haven't entered email
+    sso? && email.blank? && new_email.blank? && password_digest.blank? && identity_ids.count == 1
+  end
+
   def groups
     manual_groups
   end

--- a/back/engines/commercial/id_clave_unica/spec/requests/clave_unica_verification_spec.rb
+++ b/back/engines/commercial/id_clave_unica/spec/requests/clave_unica_verification_spec.rb
@@ -127,7 +127,7 @@ describe 'clave_unica verification' do
 
   it 'creates user when the authentication token is not passed' do
     expect(User.count).to eq(1)
-    get '/auth/clave_unica?pathname=/whatever-page'
+    get '/auth/clave_unica?pathname=/some-page'
     follow_redirect!
 
     expect(User.count).to eq(2)
@@ -141,12 +141,57 @@ describe 'clave_unica verification' do
       password_digest: nil
     })
 
-    expect(response).to redirect_to('/en/complete-signup?pathname=%2Fwhatever-page')
+    expect(response).to redirect_to('/en/complete-signup?pathname=%2Fsome-page')
   end
 
-  context 'when phone registration enabled' do
+  context 'when verification is already taken by new user' do
+    before do
+      get '/auth/clave_unica'
+      follow_redirect!
+    end
+
+    let!(:new_user) do
+      User.order(created_at: :asc).last.tap do |user|
+        expect(user).to have_attributes({ email: nil })
+        expect_to_create_verified_user(user)
+      end
+    end
+
+    context 'when verified registration is completed' do
+      before { new_user.update!(email: Faker::Internet.email) }
+
+      it 'does not verify another user and does not delete previously verified new user' do
+        get "/auth/clave_unica?token=#{@token}&pathname=/some-page"
+        follow_redirect!
+
+        expect(response).to redirect_to('/some-page?verification_error=true&error=taken')
+        expect(@user.reload).to have_attributes({
+          verified: false,
+          first_name: 'Rudolphi',
+          last_name: 'Raindeari'
+        })
+
+        expect(new_user.reload).to eq(new_user)
+      end
+    end
+
+    context 'when verified registration is not completed' do
+      it 'successfully verifies another user and deletes previously verified blank new user' do
+        get "/auth/clave_unica?token=#{@token}&pathname=/some-page"
+        follow_redirect!
+
+        expect(response).to redirect_to('/en/some-page?verification_success=true')
+        expect_to_create_verified_user(@user.reload)
+        expect { new_user.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+
+  describe 'update email after registration with ClaveUnica' do
     before do
       configuration = AppConfiguration.instance
+      # We enable phone registration, because this part is rarely used (so, can be broken) and specific for Chile.
+      # The normal email flow should work the same way as with phone registration turned off.
       configuration.settings['password_login'] = {
         'phone' => true,
         'allowed' => true,
@@ -169,7 +214,7 @@ describe 'clave_unica verification' do
       end
 
       it 'creates user that can confirm her email' do
-        get '/auth/clave_unica?pathname=/whatever-page'
+        get '/auth/clave_unica?pathname=/some-page'
         follow_redirect!
 
         user = User.order(created_at: :asc).last
@@ -199,7 +244,7 @@ describe 'clave_unica verification' do
       end
 
       it 'creates user that can update her email' do
-        get '/auth/clave_unica?pathname=/whatever-page'
+        get '/auth/clave_unica?pathname=/some-page'
         follow_redirect!
 
         user = User.order(created_at: :asc).last

--- a/back/engines/commercial/id_clave_unica/spec/requests/clave_unica_verification_spec.rb
+++ b/back/engines/commercial/id_clave_unica/spec/requests/clave_unica_verification_spec.rb
@@ -157,7 +157,7 @@ describe 'clave_unica verification' do
       end
     end
 
-    context 'when verified registration is completed' do
+    context 'when verified registration is completed by new user' do
       before { new_user.update!(email: Faker::Internet.email) }
 
       it 'does not verify another user and does not delete previously verified new user' do
@@ -175,7 +175,7 @@ describe 'clave_unica verification' do
       end
     end
 
-    context 'when verified registration is not completed' do
+    context 'when verified registration is not completed by new user' do
       it 'successfully verifies another user and deletes previously verified blank new user' do
         get "/auth/clave_unica?token=#{@token}&pathname=/some-page"
         follow_redirect!

--- a/back/engines/commercial/verification/app/services/verification/verification_service.rb
+++ b/back/engines/commercial/verification/app/services/verification/verification_service.rb
@@ -117,7 +117,16 @@ module Verification
     private
 
     def make_verification(user:, method_name:, uid:)
-      raise VerificationTakenError if taken?(user, uid, method_name)
+      existing_users = existing_verified_users(user, uid, method_name)
+      taken = existing_users.present?
+
+      if taken
+        if existing_users.all? { |u| u.email.blank? }
+          existing_users.each { |u| DeleteUserJob.perform_now(u) }
+        else
+          raise VerificationTakenError
+        end
+      end
 
       verification = ::Verification::Verification.new(
         method_name: method_name,
@@ -135,13 +144,13 @@ module Verification
       verification
     end
 
-    def taken?(user, uid, method_name)
+    def existing_verified_users(user, uid, method_name)
       ::Verification::Verification.where(
         active: true,
         hashed_uid: hashed_uid(uid, method_name)
       )
         .where.not(user: user)
-        .exists?
+        .includes(:user).map(&:user)
     end
 
     def hashed_uid(uid, method_name)

--- a/back/engines/commercial/verification/app/services/verification/verification_service.rb
+++ b/back/engines/commercial/verification/app/services/verification/verification_service.rb
@@ -121,7 +121,7 @@ module Verification
       taken = existing_users.present?
 
       if taken
-        if existing_users.all? { |u| u.email.blank? }
+        if existing_users.all?(&:blank_and_can_be_deleted?)
           existing_users.each { |u| DeleteUserJob.perform_now(u) }
         else
           raise VerificationTakenError

--- a/front/app/containers/Authentication/Modal.tsx
+++ b/front/app/containers/Authentication/Modal.tsx
@@ -92,6 +92,7 @@ export const ERROR_CODE_MESSAGES: Record<ErrorCode, MessageDescriptor> = {
   unknown: messages.unknownError,
   invitation_error: messages.invitationError,
   franceconnect_merging_failed: messages.franceConnectMergingFailed,
+  email_taken_and_user_can_be_verified: messages.emailTakenAndUserCanBeVerified,
 };
 
 type HelperTextKey = 'signup_helper_text' | 'custom_fields_signup_helper_text';

--- a/front/app/containers/Authentication/messages.ts
+++ b/front/app/containers/Authentication/messages.ts
@@ -37,6 +37,11 @@ export default defineMessages({
     id: 'app.containers.SignIn.signInError',
     defaultMessage: 'No account was found for the provided credentials',
   },
+  emailTakenAndUserCanBeVerified: {
+    id: 'app.containers.AuthProviders.emailTakenAndUserCanBeVerified',
+    defaultMessage:
+      'An account with this email already exists. You can sign out, log in with this email address and verify your account on the settings page.',
+  },
   franceConnectMergingFailed: {
     id: 'app.components.AuthProviders.franceConnectMergingFailed',
     defaultMessage:

--- a/front/app/containers/Authentication/steps/ClaveUnicaEmail/index.tsx
+++ b/front/app/containers/Authentication/steps/ClaveUnicaEmail/index.tsx
@@ -50,7 +50,11 @@ const ClaveUnicaEmail = ({ loading, setError, onSubmit }: Props) => {
         return;
       }
 
-      setError('account_creation_failed');
+      if (e.email?.[0]?.error === 'taken') {
+        setError('email_taken_and_user_can_be_verified');
+      } else {
+        setError('account_creation_failed');
+      }
     }
   };
   return (

--- a/front/app/containers/Authentication/typings.ts
+++ b/front/app/containers/Authentication/typings.ts
@@ -13,7 +13,8 @@ export type ErrorCode =
   | 'requirements_fetching_failed'
   | 'invitation_error'
   | 'unknown'
-  | 'franceconnect_merging_failed';
+  | 'franceconnect_merging_failed'
+  | 'email_taken_and_user_can_be_verified';
 
 export interface State {
   email: string | null;

--- a/front/app/translations/en.json
+++ b/front/app/translations/en.json
@@ -648,6 +648,7 @@
   "app.containers.App.appMetaDescription": "Welcome to the online participation platform of {orgName}. \nExplore local projects and engage in the discussion!",
   "app.containers.App.loading": "Loading...",
   "app.containers.App.metaTitle": "Public participation platform of {orgName} | CitizenLab",
+  "app.containers.AuthProviders.emailTakenAndUserCanBeVerified": "An account with this email already exists. You can sign out, log in with this email address and verify your account on the settings page.",
   "app.containers.Authentication.steps.Invitation.pleaseEnterAToken": "Please enter a token",
   "app.containers.Authentication.steps.Invitation.token": "Token",
   "app.containers.CampaignsConsentForm.ally_categoryLabel": "Emails in this category",


### PR DESCRIPTION
# Changelog
## Changed
* [CL-3872] Show clear instructions on how to use ClaveUnica with existing email


[CL-3872]: https://citizenlab.atlassian.net/browse/CL-3872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ