### PR TITLE
[CL-3898] Use without_campaign_names query param to filter out consents

### DIFF
--- a/back/engines/free/email_campaigns/app/controllers/email_campaigns/web_api/v1/consents_controller.rb
+++ b/back/engines/free/email_campaigns/app/controllers/email_campaigns/web_api/v1/consents_controller.rb
@@ -10,6 +10,12 @@ module EmailCampaigns
       authorize Consent
 
       @consents = policy_scope(Consent).where(user: current_user_by_unsubscription_token)
+
+      if params[:without_campaign_names]
+        campaign_types = params[:without_campaign_names].map { |name| Campaign.from_campaign_name(name) }
+        @consents = @consents.where.not(campaign_type: campaign_types)
+      end
+
       @consents = paginate @consents
 
       render json: linked_json(@consents, WebApi::V1::ConsentSerializer, params: jsonapi_serializer_params)
@@ -62,7 +68,8 @@ module EmailCampaigns
 
     def consent_params
       params.require(:consent).permit(
-        :consented
+        :consented,
+        :without_campaign_names
       )
     end
   end


### PR DESCRIPTION
Adds ability to filter out campaign `consents` using `without_campaign_names` query param (an array of campaign names to exclude) + an acceptance test.

Example (filtering out one consent type):
```
http://localhost:3000/web_api/v1/consents?without_campaign_names[]=internal_comment_on_unassigned_unmoderated_idea
```
Alternative format of value:
```
http://localhost:3000/web_api/v1/consents?without_campaign_names[]=InternalCommentOnUnassignedUnmoderatedIdea
```

# Changelog
## Technical
- [CL-3898] Use without_campaign_names query param to filter out campaign consents


[CL-3898]: https://citizenlab.atlassian.net/browse/CL-3898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ