### PR TITLE
CL-3834  - Votes count for input manager and results

### DIFF
--- a/back/app/models/idea.rb
+++ b/back/app/models/idea.rb
@@ -31,6 +31,7 @@
 #  author_hash              :string
 #  anonymous                :boolean          default(FALSE), not null
 #  internal_comments_count  :integer          default(0), not null
+#  votes_count              :integer          default(0), not null
 #
 # Indexes
 #

--- a/back/app/models/ideas_phase.rb
+++ b/back/app/models/ideas_phase.rb
@@ -10,6 +10,7 @@
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  baskets_count :integer          default(0), not null
+#  votes_count   :integer          default(0), not null
 #
 # Indexes
 #

--- a/back/app/models/phase.rb
+++ b/back/app/models/phase.rb
@@ -39,6 +39,7 @@
 #  voting_term_singular_multiloc :jsonb
 #  voting_term_plural_multiloc   :jsonb
 #  baskets_count                 :integer          default(0), not null
+#  votes_count                   :integer          default(0), not null
 #
 # Indexes
 #

--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -45,6 +45,7 @@
 #  voting_term_singular_multiloc :jsonb
 #  voting_term_plural_multiloc   :jsonb
 #  baskets_count                 :integer          default(0), not null
+#  votes_count                   :integer          default(0), not null
 #
 # Indexes
 #

--- a/back/app/serializers/web_api/v1/idea_serializer.rb
+++ b/back/app/serializers/web_api/v1/idea_serializer.rb
@@ -18,6 +18,7 @@ class WebApi::V1::IdeaSerializer < WebApi::V1::BaseSerializer
     :budget,
     :proposed_budget,
     :baskets_count,
+    :votes_count,
     :anonymous,
     :author_hash
 

--- a/back/app/serializers/web_api/v1/ideas_phase_serializer.rb
+++ b/back/app/serializers/web_api/v1/ideas_phase_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class WebApi::V1::IdeasPhaseSerializer < WebApi::V1::BaseSerializer
-  attributes :baskets_count
+  attributes :baskets_count, :votes_count
 
   has_one :idea
   has_one :phase

--- a/back/app/serializers/web_api/v1/participation_context_serializer.rb
+++ b/back/app/serializers/web_api/v1/participation_context_serializer.rb
@@ -32,6 +32,7 @@ module WebApi::V1::ParticipationContextSerializer
       attribute :voting_term_singular_multiloc, if: proc { |object| object.voting? }
       attribute :voting_term_plural_multiloc, if: proc { |object| object.voting? }
       attribute :baskets_count, if: proc { |object| object.voting? }
+      attribute :votes_count, if: proc { |object| object.voting? }
     end
   end
 end

--- a/back/app/services/side_fx_basket_service.rb
+++ b/back/app/services/side_fx_basket_service.rb
@@ -25,7 +25,6 @@ class SideFxBasketService
 
   def update_basket_counts(basket)
     # NOTE: we cannot use counter_culture because we can't trigger it from another model being updated (basket)
-    # NOTE: Think we should be able to update the votes count in the same queries in a future iteration
     project = basket.participation_context.project
 
     # Update ideas
@@ -40,7 +39,6 @@ class SideFxBasketService
       update_participation_context_counts(phase, phase)
 
       # Update the project
-      # NOTE: Is it right that we update the project counts when there are phases? Is this a useful number?
       update_participation_context_counts(project.phases, project)
     else
       # Update the project only

--- a/back/db/migrate/20230703112343_add_votes_count_to_context.rb
+++ b/back/db/migrate/20230703112343_add_votes_count_to_context.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddVotesCountToContext < ActiveRecord::Migration[6.1]
+  def change
+    %i[ideas projects phases ideas_phases].each do |tablename|
+      add_column tablename, :votes_count, :integer, null: false, default: 0
+    end
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_23_085057) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_03_112343) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -525,6 +525,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_23_085057) do
     t.string "author_hash"
     t.boolean "anonymous", default: false, null: false
     t.integer "internal_comments_count", default: 0, null: false
+    t.integer "votes_count", default: 0, null: false
     t.index "((to_tsvector('simple'::regconfig, COALESCE((title_multiloc)::text, ''::text)) || to_tsvector('simple'::regconfig, COALESCE((body_multiloc)::text, ''::text))))", name: "index_ideas_search", using: :gin
     t.index ["author_hash"], name: "index_ideas_on_author_hash"
     t.index ["author_id"], name: "index_ideas_on_author_id"
@@ -540,6 +541,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_23_085057) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.integer "baskets_count", default: 0, null: false
+    t.integer "votes_count", default: 0, null: false
     t.index ["idea_id", "phase_id"], name: "index_ideas_phases_on_idea_id_and_phase_id", unique: true
     t.index ["idea_id"], name: "index_ideas_phases_on_idea_id"
     t.index ["phase_id"], name: "index_ideas_phases_on_phase_id"
@@ -1003,6 +1005,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_23_085057) do
     t.jsonb "voting_term_singular_multiloc", default: {}
     t.jsonb "voting_term_plural_multiloc", default: {}
     t.integer "baskets_count", default: 0, null: false
+    t.integer "votes_count", default: 0, null: false
     t.index ["project_id"], name: "index_phases_on_project_id"
   end
 
@@ -1147,6 +1150,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_23_085057) do
     t.jsonb "voting_term_singular_multiloc", default: {}
     t.jsonb "voting_term_plural_multiloc", default: {}
     t.integer "baskets_count", default: 0, null: false
+    t.integer "votes_count", default: 0, null: false
     t.index ["slug"], name: "index_projects_on_slug", unique: true
   end
 


### PR DESCRIPTION
Added `votes_count` to the same queries that were already doing `baskets_count`
