### PR TITLE
[CL-3863] Tasks to enable or disable feature for specific tenants

### DIFF
--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/tenant_settings.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/tenant_settings.rake
@@ -6,9 +6,10 @@ namespace :tenant_settings do
     failed = []
     Tenant.where.not(host: 'i18n.stg.citizenlab.co').each do |tn|
       Apartment::Tenant.switch(tn.schema_name) do
-        tn.settings[args[:feature]]['allowed'] = true
-        tn.settings[args[:feature]]['enabled'] = true
-        failed += [tn.host] unless tn.save
+        config = AppConfiguration.instance
+        config.settings[args[:feature]]['allowed'] = true
+        config.settings[args[:feature]]['enabled'] = true
+        failed += [tn.host] unless config.save
       end
     end
     if failed.present?
@@ -23,9 +24,43 @@ namespace :tenant_settings do
     failed = []
     Tenant.where.not(host: 'i18n.stg.citizenlab.co').each do |tn|
       Apartment::Tenant.switch(tn.schema_name) do
-        tn.settings[args[:feature]]['allowed'] = false
-        tn.settings[args[:feature]]['enabled'] = false
-        failed += [tn.host] unless tn.save
+        config = AppConfiguration.instance
+        config.settings[args[:feature]]['allowed'] = false
+        config.settings[args[:feature]]['enabled'] = false
+        failed += [tn.host] unless config.save
+      end
+    end
+    if failed.present?
+      puts "Failed for: #{failed.join(', ')}"
+    else
+      puts 'Success!'
+    end
+  end
+
+  # Usage:
+  #   bundle exec rake tenant_settings:enable_feature_for_tenants[feature,url]
+  # Example:
+  #   bundle exec rake tenant_settings:enable_feature_for_tenants['participatory_budgeting','/tenants.txt']
+  #   Where /tmp/tenants.txt contains a list of tenant hosts, one per line. Example line: participer.grandparissud.fr
+  desc 'Enable tenant feature for specific tenants'
+  task :enable_feature_for_tenants, %i[feature url] => [:environment] do |_t, args|
+    tenants = File.readlines(args[:url]).map(&:strip)
+
+    not_found = tenants - Tenant.all.pluck(:host)
+    puts "WARNING! The following tenants were not found: #{not_found.join(', ')}" if not_found.present?
+
+    failed = []
+    Tenant.where(host: tenants).each do |tn|
+      Apartment::Tenant.switch(tn.schema_name) do
+        config = AppConfiguration.instance
+        config.settings[args[:feature]]['allowed'] = true
+        config.settings[args[:feature]]['enabled'] = true
+
+        if config.save
+          puts "Successfully enabled #{args[:feature]} for #{tn.host}"
+        else
+          failed += [tn.host]
+        end
       end
     end
     if failed.present?

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/tenant_settings.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/tenant_settings.rake
@@ -41,7 +41,7 @@ namespace :tenant_settings do
   #   bundle exec rake tenant_settings:enable_feature_for_tenants[feature,url]
   # Example:
   #   bundle exec rake tenant_settings:enable_feature_for_tenants['participatory_budgeting','/tenants.txt']
-  #   Where /tmp/tenants.txt contains a list of tenant hosts, one per line. Example line: participer.grandparissud.fr
+  #   Where /tenants.txt contains a list of tenant hosts, one per line. Example line: participer.grandparissud.fr
   desc 'Enable tenant feature for specific tenants'
   task :enable_feature_for_tenants, %i[feature url] => [:environment] do |_t, args|
     tenants = File.readlines(args[:url]).map(&:strip)
@@ -74,7 +74,7 @@ namespace :tenant_settings do
   #   bundle exec rake tenant_settings:disable_feature_for_tenants[feature,url]
   # Example:
   #   bundle exec rake tenant_settings:disable_feature_for_tenants['participatory_budgeting','/tenants.txt']
-  #   Where /tmp/tenants.txt contains a list of tenant hosts, one per line. Example line: participer.grandparissud.fr
+  #   Where /tenants.txt contains a list of tenant hosts, one per line. Example line: participer.grandparissud.fr
   desc 'Disable tenant feature for specific tenants'
   task :disable_feature_for_tenants, %i[feature url] => [:environment] do |_t, args|
     tenants = File.readlines(args[:url]).map(&:strip)

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/tenant_settings.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/tenant_settings.rake
@@ -69,4 +69,37 @@ namespace :tenant_settings do
       puts 'Success!'
     end
   end
+
+  # Usage:
+  #   bundle exec rake tenant_settings:disable_feature_for_tenants[feature,url]
+  # Example:
+  #   bundle exec rake tenant_settings:disable_feature_for_tenants['participatory_budgeting','/tenants.txt']
+  #   Where /tmp/tenants.txt contains a list of tenant hosts, one per line. Example line: participer.grandparissud.fr
+  desc 'Disable tenant feature for specific tenants'
+  task :disable_feature_for_tenants, %i[feature url] => [:environment] do |_t, args|
+    tenants = File.readlines(args[:url]).map(&:strip)
+
+    not_found = tenants - Tenant.all.pluck(:host)
+    puts "WARNING! The following tenants were not found: #{not_found.join(', ')}" if not_found.present?
+
+    failed = []
+    Tenant.where(host: tenants).each do |tn|
+      Apartment::Tenant.switch(tn.schema_name) do
+        config = AppConfiguration.instance
+        config.settings[args[:feature]]['allowed'] = false
+        config.settings[args[:feature]]['enabled'] = false
+
+        if config.save
+          puts "Successfully disabled #{args[:feature]} for #{tn.host}"
+        else
+          failed += [tn.host]
+        end
+      end
+    end
+    if failed.present?
+      puts "Failed for: #{failed.join(', ')}"
+    else
+      puts 'Success!'
+    end
+  end
 end

--- a/back/test.txt
+++ b/back/test.txt
@@ -1,3 +1,0 @@
-something.com
-localhost
-somethingelse.com

--- a/back/test.txt
+++ b/back/test.txt
@@ -1,0 +1,3 @@
+something.com
+localhost
+somethingelse.com


### PR DESCRIPTION
2 new rake tasks, each targeting a given list of specific tenants, one to enable and one to disable, a specific feature.

Also updates 2 similar more general tasks, in the same file, to use `AppConfiguration.instance.settings`, rather than the now deprecated `Tenant.settings` (as specified [here](https://github.com/CitizenLabDotCo/citizenlab/blob/829400eefbea5acccedc073d368d1b0718aaa888/back/engines/commercial/multi_tenancy/app/models/tenant.rb#L78), in `tenant.rb`)

# Changelog
## Technical
- [CL-3863] New rake tasks to enable/disable feature settings for specific tenants

[CL-3863]: https://citizenlab.atlassian.net/browse/CL-3863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ