### PR TITLE
CL-3887: Allow platform admins to be a project manager or folder manager on a project

### DIFF
--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -17,9 +17,9 @@ class WebApi::V1::UsersController < ApplicationController
     @users = @users.search_by_all(params[:search]) if params[:search].present?
 
     @users = @users.admin.or(@users.project_moderator(params[:can_moderate_project])) if params[:can_moderate_project].present?
-    @users = @users.not_admin.and(@users.not_project_moderator(params[:is_not_project_moderator])) if params[:is_not_project_moderator].present?
+    @users = @users.not_project_moderator(params[:is_not_project_moderator]) if params[:is_not_project_moderator].present?
     @users = @users.admin.or(@users.project_moderator).or(@users.project_folder_moderator) if params[:can_moderate].present?
-    @users = @users.not_admin.and(@users.not_project_folder_moderator(params[:is_not_folder_moderator])) if params[:is_not_folder_moderator].present?
+    @users = @users.not_project_folder_moderator(params[:is_not_folder_moderator]) if params[:is_not_folder_moderator].present?
     @users = @users.not_citizenlab_member if params[:not_citizenlab_member].present?
     @users = @users.admin if params[:can_admin].present?
 

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -33,11 +33,11 @@ resource 'Users' do
                                        '(who can, in fact, moderate the project), ' \
                                        'OR All admins + users with project moderator role ' \
                                        '(if no project ID provided)', required: false
-      parameter :is_not_project_moderator, 'Users who are not project moderator of project, ' \
+      parameter :is_not_project_moderator, 'Users who are not project moderators of project, ' \
                                            'nor folder moderator of folder containing project (by project id), ' \
                                            'OR Users who do not have project moderator role ' \
                                            '(if no project ID provided)', required: false
-      parameter :is_not_folder_moderator, 'Users who are not folder moderator of folder (by folder id), ' \
+      parameter :is_not_folder_moderator, 'Users who are not folder moderators of folder (by folder id), ' \
                                           'OR Users who do not have folder moderator role ' \
                                           '(if no folder ID provided)', required: false
       example_request '[error] List all users' do

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -33,12 +33,12 @@ resource 'Users' do
                                        '(who can, in fact, moderate the project), ' \
                                        'OR All admins + users with project moderator role ' \
                                        '(if no project ID provided)', required: false
-      parameter :is_not_project_moderator, 'Users who are not admins, nor project moderator of project, ' \
+      parameter :is_not_project_moderator, 'Users who are not project moderator of project, ' \
                                            'nor folder moderator of folder containing project (by project id), ' \
-                                           'OR Users who are not admins, nor have project moderator role ' \
+                                           'OR Users who do not have project moderator role ' \
                                            '(if no project ID provided)', required: false
-      parameter :is_not_folder_moderator, 'Users who are not admins, nor folder moderator of folder (by folder id), ' \
-                                          'OR Users who are not admins, nor have folder moderator role ' \
+      parameter :is_not_folder_moderator, 'Users who are not folder moderator of folder (by folder id), ' \
+                                          'OR Users who do not have folder moderator role ' \
                                           '(if no folder ID provided)', required: false
       example_request '[error] List all users' do
         assert_status 401
@@ -522,7 +522,7 @@ resource 'Users' do
 
             user_ids = json_parse(response_body)[:data].pluck(:id)
             expect(user_ids).to include(@user.id, @moderator_of_other_project.id, @moderator_of_other_folder.id)
-            expect(user_ids).not_to include(@admin.id, @project_moderator.id, @project_folder_moderator.id)
+            expect(user_ids).not_to include(@project_moderator.id, @project_folder_moderator.id)
           end
 
           example 'List only users who cannot moderate a specific folder' do
@@ -533,7 +533,7 @@ resource 'Users' do
             expect(user_ids).to include(
               @user.id, @project_moderator.id, @moderator_of_other_project.id, @moderator_of_other_folder.id
             )
-            expect(user_ids).not_to include(@admin.id, @project_folder_moderator.id)
+            expect(user_ids).not_to include(@project_folder_moderator.id)
           end
         end
 

--- a/front/app/components/UI/UserSelect/index.tsx
+++ b/front/app/components/UI/UserSelect/index.tsx
@@ -78,7 +78,6 @@ const UserSelect = ({
   };
 
   const handleClear = () => {
-    console.log('clearing');
     onChange();
   };
 
@@ -118,7 +117,7 @@ const UserSelect = ({
         backspaceRemovesValue={false}
         menuShouldScrollIntoView={false}
         isClearable
-        // We check if selectedUserId is present because setting it to null won't trigger a refetch so will have old data. I'm preferring this over refetching on clear because it's faster and avoids a fetch that we techincally don't need.
+        // We check if selectedUserId is present because setting it to null won't trigger a refetch so will have old data. I'm preferring this over refetching on clear because it's faster and avoids a fetch that we technically don't need.
         value={(selectedUserId && selectedUser?.data) || null}
         placeholder={placeholder}
         options={

--- a/front/app/components/UI/UserSelect/index.tsx
+++ b/front/app/components/UI/UserSelect/index.tsx
@@ -78,6 +78,7 @@ const UserSelect = ({
   };
 
   const handleClear = () => {
+    console.log('clearing');
     onChange();
   };
 
@@ -117,7 +118,8 @@ const UserSelect = ({
         backspaceRemovesValue={false}
         menuShouldScrollIntoView={false}
         isClearable
-        value={selectedUser?.data}
+        // We check if selectedUserId is present because setting it to null won't trigger a refetch so will have old data. I'm preferring this over refetching on clear because it's faster and avoids a fetch that we techincally don't need.
+        value={(selectedUserId && selectedUser?.data) || null}
         placeholder={placeholder}
         options={
           canLoadMore ? [...usersList, { value: 'loadMore' }] : usersList


### PR DESCRIPTION
# Changelog

## Fixed
- Allow platform admins to be a project manager or folder manager on a project
- Bug where clearing the user select when setting a moderator was not possible
