### PR TITLE
Remove unused description_multiloc of areas

### DIFF
--- a/front/app/api/areas/__mocks__/useAreas.ts
+++ b/front/app/api/areas/__mocks__/useAreas.ts
@@ -8,10 +8,7 @@ export const areasData: IAreaData[] = [
       title_multiloc: {
         en: 'Area 1',
       },
-      description_multiloc: {
-        en: 'Description of area 1',
-      },
-
+      description_multiloc: {},
       ordering: 1,
       static_page_ids: ['3'],
     },
@@ -33,9 +30,7 @@ export const areasData: IAreaData[] = [
       title_multiloc: {
         en: 'Area 2',
       },
-      description_multiloc: {
-        en: 'Description of area 2',
-      },
+      description_multiloc: {},
 
       ordering: 1,
       static_page_ids: ['4'],

--- a/front/app/api/areas/types.ts
+++ b/front/app/api/areas/types.ts
@@ -38,7 +38,6 @@ export interface IArea {
 
 export interface IAreaAdd {
   title_multiloc: Multiloc;
-  description_multiloc: Multiloc;
 }
 
 export interface IAreaUpdate {

--- a/front/app/api/areas/useAddArea.test.ts
+++ b/front/app/api/areas/useAddArea.test.ts
@@ -30,9 +30,6 @@ describe('useAddArea', () => {
         title_multiloc: {
           en: 'test',
         },
-        description_multiloc: {
-          en: 'test',
-        },
       });
     });
 
@@ -54,9 +51,6 @@ describe('useAddArea', () => {
     act(() => {
       result.current.mutate({
         title_multiloc: {
-          en: 'test',
-        },
-        description_multiloc: {
           en: 'test',
         },
       });

--- a/front/app/containers/Admin/settings/areas/AreaForm/index.tsx
+++ b/front/app/containers/Admin/settings/areas/AreaForm/index.tsx
@@ -15,7 +15,6 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { object } from 'yup';
 import validateMultilocForEveryLocale from 'utils/yup/validateMultilocForEveryLocale';
 import InputMultilocWithLocaleSwitcher from 'components/HookForm/InputMultilocWithLocaleSwitcher';
-import QuillMultilocWithLocaleSwitcher from 'components/HookForm/QuillMultilocWithLocaleSwitcher';
 import Feedback from 'components/HookForm/Feedback';
 
 // typings
@@ -24,7 +23,6 @@ import { handleHookFormSubmissionError } from 'utils/errorUtils';
 
 export interface FormValues {
   title_multiloc: Multiloc;
-  description_multiloc: Multiloc;
 }
 
 type Props = {
@@ -69,13 +67,6 @@ const AreaForm = ({
               type="text"
               name="title_multiloc"
               labelTooltipText={formatMessage(messages.fieldTitleTooltip)}
-            />
-          </SectionField>
-          <SectionField>
-            <QuillMultilocWithLocaleSwitcher
-              name="description_multiloc"
-              label={formatMessage(messages.fieldDescription)}
-              labelTooltipText={formatMessage(messages.fieldDescriptionTooltip)}
             />
           </SectionField>
           <Box display="flex">

--- a/front/app/containers/Admin/settings/areas/Edit/index.tsx
+++ b/front/app/containers/Admin/settings/areas/Edit/index.tsx
@@ -47,7 +47,6 @@ const Edit = () => {
         <AreaForm
           defaultValues={{
             title_multiloc: area.data.attributes.title_multiloc,
-            description_multiloc: area.data.attributes.description_multiloc,
           }}
           onSubmit={handleSubmit}
         />


### PR DESCRIPTION
Cleaning up the backlog and this is one of these tickets where it's faster to do it, instead of discussing or thinking about it.

TL;DR: in the front-end we let admins enter a description for an area, but this value is not used anywhere. If it's not clear to admins they can leave this open, it can make them perform unnecessary work.

We leave it in the area model in the BE so we can use it again when we want to.