### PR TITLE
CL-3802: Fix deleting comments when load more is on page

### DIFF
--- a/front/app/api/comments/useMarkCommentForDeletion.ts
+++ b/front/app/api/comments/useMarkCommentForDeletion.ts
@@ -6,6 +6,7 @@ import { DeleteReason, IComment } from './types';
 import userCommentsCount from 'api/user_comments_count/keys';
 import ideasKeys from 'api/ideas/keys';
 import initiativesKeys from 'api/initiatives/keys';
+import commentsKeys from 'api/comments/keys';
 
 interface MarkForDeletion {
   commentId: string;
@@ -26,9 +27,11 @@ const markCommentForDeletion = async ({
 const useMarkCommentForDeletion = ({
   ideaId,
   initiativeId,
+  parentCommentId,
 }: {
   ideaId?: string;
   initiativeId?: string;
+  parentCommentId?: string;
 }) => {
   const queryClient = useQueryClient();
   return useMutation<IComment, CLErrors, MarkForDeletion>({
@@ -45,6 +48,12 @@ const useMarkCommentForDeletion = ({
         // We invalidate the idea because the number of comments is on the idea
         queryClient.invalidateQueries({
           queryKey: ideasKeys.item({ id: ideaId }),
+        });
+      }
+
+      if (parentCommentId) {
+        queryClient.invalidateQueries({
+          queryKey: commentsKeys.list({ commentId: parentCommentId }),
         });
       }
 

--- a/front/app/api/internal_comments/useMarkInternalCommentForDeletion.ts
+++ b/front/app/api/internal_comments/useMarkInternalCommentForDeletion.ts
@@ -6,6 +6,7 @@ import { IInternalComment } from './types';
 import userCommentsCount from 'api/user_comments_count/keys';
 import ideasKeys from 'api/ideas/keys';
 import initiativesKeys from 'api/initiatives/keys';
+import commentsKeys from 'api/comments/keys';
 
 interface MarkInternalCommentForDeletion {
   commentId: string;
@@ -23,9 +24,11 @@ const markInternalCommentForDeletion = async ({
 const useMarkInternalCommentForDeletion = ({
   ideaId,
   initiativeId,
+  parentCommentId,
 }: {
   ideaId?: string;
   initiativeId?: string;
+  parentCommentId?: string;
 }) => {
   const queryClient = useQueryClient();
   return useMutation<
@@ -46,6 +49,12 @@ const useMarkInternalCommentForDeletion = ({
         // We invalidate the idea because the number of internal comments is on the idea
         queryClient.invalidateQueries({
           queryKey: ideasKeys.item({ id: ideaId }),
+        });
+      }
+
+      if (parentCommentId) {
+        queryClient.invalidateQueries({
+          queryKey: commentsKeys.list({ commentId: parentCommentId }),
         });
       }
 

--- a/front/app/components/PostShowComponents/Comments/Comment/CommentsMoreActions.tsx
+++ b/front/app/components/PostShowComponents/Comments/Comment/CommentsMoreActions.tsx
@@ -73,9 +73,11 @@ const CommentsMoreActions = ({
   ideaId,
   initiativeId,
 }: Props) => {
+  const parentCommentId = comment.relationships?.parent?.data?.id;
   const { mutate: markForDeletion, isLoading } = useMarkCommentForDeletion({
     ideaId,
     initiativeId,
+    parentCommentId,
   });
 
   const [modalVisible_spam, setModalVisible_spam] = useState(false);

--- a/front/app/components/admin/InternalComments/InternalComment/InternalCommentsMoreActions.tsx
+++ b/front/app/components/admin/InternalComments/InternalComment/InternalCommentsMoreActions.tsx
@@ -70,9 +70,14 @@ const InternalCommentsMoreActions = ({
   ideaId,
   initiativeId,
 }: Props) => {
+  const parentCommentId = comment.relationships?.parent?.data?.id;
   const { data: authUser } = useAuthUser();
   const { mutate: markForDeletion, isLoading } =
-    useMarkInternalCommentForDeletion({ ideaId, initiativeId });
+    useMarkInternalCommentForDeletion({
+      ideaId,
+      initiativeId,
+      parentCommentId,
+    });
   const [modalVisible_delete, setModalVisible_delete] = useState(false);
 
   const authUserId = authUser?.data.id;


### PR DESCRIPTION
# Changelog

## Fixed
- Fix bug where deleting child top comments would remain visible after deletion. Specifically when you had the load more comments button
