### PR TITLE
Remove closeModal stuff listening to clHistory

### DIFF
--- a/front/app/components/UI/Modal/index.tsx
+++ b/front/app/components/UI/Modal/index.tsx
@@ -3,7 +3,6 @@ import { createPortal } from 'react-dom';
 import { adopt } from 'react-adopt';
 import { Subscription, fromEvent } from 'rxjs';
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
-import clHistory from 'utils/cl-router/history';
 import eventEmitter from 'utils/eventEmitter';
 import { FocusOn } from 'react-focus-on';
 
@@ -462,7 +461,6 @@ interface State {
 }
 
 class Modal extends PureComponent<Props, State> {
-  unlisten: null | (() => void);
   subscription: Subscription | null;
 
   static defaultProps = {
@@ -475,7 +473,6 @@ class Modal extends PureComponent<Props, State> {
     this.state = {
       windowHeight: window.innerHeight,
     };
-    this.unlisten = null;
     this.subscription = null;
   }
 
@@ -507,7 +504,6 @@ class Modal extends PureComponent<Props, State> {
     window.addEventListener('popstate', this.handlePopstateEvent);
     window.addEventListener('keydown', this.handleKeypress);
     eventEmitter.emit('modalOpened');
-    this.unlisten = clHistory.listen(() => this.closeModal());
   };
 
   closeModal = () => {
@@ -529,8 +525,6 @@ class Modal extends PureComponent<Props, State> {
     window.removeEventListener('popstate', this.handlePopstateEvent);
     window.removeEventListener('keydown', this.handleKeypress);
     eventEmitter.emit('modalClosed');
-    this.unlisten && this.unlisten();
-    this.unlisten = null;
   };
 
   clickOutsideModal = () => {


### PR DESCRIPTION
Currently, on master, you get thrown out of the authentication flow sometimes when this shouldn't be possible. To reproduce, go to https://demo.stg.citizenlab.co/en/projects/continuous-ideation, click 'Submit your idea', and enter your email. During the confirmation code step the modal closes sometimes. You also get it when you use the regular 'sign up' button sometimes, but for some reason I get it more often with the idea posting button.

Anyway, after investigating I found that the modal sometimes closes itself when it detects any change to `clHistory`. I couldn't really figure out why it would do this- do you happen to remember? The code that takes care of this was last edited by David [back in 2020](https://github.com/CitizenLabDotCo/citizenlab/commit/69dea739c0f664f88f3da41515dd5cad3d3e15d7) and has been there even longer. The change them seems to have been part of some kind of authentication refactor. Is there still a reason to keep this? Because for me the behavior in our current setup seems kind of counterintuitive and I would like to get rid of it instead of make the code more complicated. Maybe it served a purpose in the old authentication setup / with the post fullscreen page that now has been removed?

# Changelog
## Fixed
Authentication modal sometimes closing randomly
