### PR TITLE
Fix password tooltip on mobile

### DIFF
--- a/front/app/components/ContentContainer/index.tsx
+++ b/front/app/components/ContentContainer/index.tsx
@@ -33,7 +33,7 @@ const Inner = styled.div<{ maxWidth?: string | number }>`
   }
 `;
 
-interface Props {
+export interface Props {
   children?: any;
   id?: string;
   className?: string;

--- a/front/app/components/UI/PasswordInput/PasswordInputIconTooltip.tsx
+++ b/front/app/components/UI/PasswordInput/PasswordInputIconTooltip.tsx
@@ -16,6 +16,7 @@ const PasswordInputIconTooltip = ({
 }: Props & WrappedComponentProps) => {
   return (
     <IconTooltip
+      placement="top-start"
       className={className}
       content={
         <>

--- a/front/app/components/UI/PasswordInput/PasswordInputIconTooltip.tsx
+++ b/front/app/components/UI/PasswordInput/PasswordInputIconTooltip.tsx
@@ -2,18 +2,15 @@ import React from 'react';
 import { IconTooltip } from '@citizenlab/cl2-component-library';
 
 // i18n
-import { injectIntl } from 'utils/cl-intl';
-import { WrappedComponentProps } from 'react-intl';
+import { useIntl } from 'utils/cl-intl';
 import messages from './messages';
 
 type Props = {
   className?: string;
 };
 
-const PasswordInputIconTooltip = ({
-  intl: { formatMessage },
-  className,
-}: Props & WrappedComponentProps) => {
+const PasswordInputIconTooltip = ({ className }: Props) => {
+  const { formatMessage } = useIntl();
   return (
     <IconTooltip
       placement="top-start"
@@ -32,4 +29,4 @@ const PasswordInputIconTooltip = ({
   );
 };
 
-export default injectIntl(PasswordInputIconTooltip);
+export default PasswordInputIconTooltip;


### PR DESCRIPTION
# Changelog
## Fixed
- Visibility of the password tooltip (shown when resetting/changing the password) on smaller devices