### PR TITLE
Don't show slug input field when creating a new custom page

### DIFF
--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/CustomPageSettingsForm/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/CustomPageSettingsForm/index.tsx
@@ -251,7 +251,7 @@ const CustomPageSettingsForm = ({
                 />
               </Box>
             )}
-            {!hideSlug && mode === 'edit' && (
+            {!hideSlug && (
               <Box mb={fieldMarginBottom}>
                 <SlugInput
                   slug={slug}

--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/CustomPageSettingsForm/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/CustomPageSettingsForm/index.tsx
@@ -251,7 +251,7 @@ const CustomPageSettingsForm = ({
                 />
               </Box>
             )}
-            {!hideSlug && (
+            {!hideSlug && mode === 'edit' && (
               <Box mb={fieldMarginBottom}>
                 <SlugInput
                   slug={slug}

--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/New/NewCustomPage.test.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/New/NewCustomPage.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import NewCustomPage from './NewCustomPage';
+import { render, screen } from 'utils/testUtils/rtl';
+
+jest.mock('api/topics/useTopics');
+jest.mock('api/areas/useAreas');
+jest.mock('hooks/useLocale');
+jest.mock('api/app_configuration/useAppConfiguration');
+
+describe('NewCustomPage', () => {
+  it('does not show the slug input field', () => {
+    render(<NewCustomPage />);
+    expect(screen.queryByLabelText('Slug')).not.toBeInTheDocument();
+  });
+});

--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/New/NewCustomPage.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/New/NewCustomPage.tsx
@@ -35,6 +35,7 @@ const NewCustomPage = () => {
         area_id: null,
         topic_ids: [],
       }}
+      hideSlug
     />
   );
 };


### PR DESCRIPTION
Fixes regression introduced in https://github.com/CitizenLabDotCo/citizenlab/commit/ae3dbfa09826954fb8e33a7951de1c8e9f7c9d9d. 

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Slug input field is not shown when creating a new custom page (only when editing a page).