### PR TITLE
CL-3925 - Baskets ideas upsert endpoint

### DIFF
--- a/back/app/controllers/web_api/v1/baskets_ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/baskets_ideas_controller.rb
@@ -55,7 +55,6 @@ class WebApi::V1::BasketsIdeasController < ApplicationController
   def upsert
     # 1. Create or get basket
     idea = Idea.find(params[:idea_id])
-    # TODO: return 404 if idea not found?
     participation_context = ParticipationContextService.new.get_participation_context(idea.project)
     participation_context_type = participation_context.phase? ? 'Phase' : 'Project'
 

--- a/back/app/controllers/web_api/v1/baskets_ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/baskets_ideas_controller.rb
@@ -85,7 +85,11 @@ class WebApi::V1::BasketsIdeasController < ApplicationController
       baskets_idea.destroy
       if baskets_idea.destroyed?
         SideFxBasketsIdeaService.new.after_destroy baskets_idea, current_user
-        head :ok
+        # Returning the frozen basket as the front-end needs a response
+        render json: WebApi::V1::BasketsIdeaSerializer.new(
+          baskets_idea,
+          params: jsonapi_serializer_params,
+        ).serializable_hash, status: :ok
         return
       end
     end

--- a/back/app/policies/basket_policy.rb
+++ b/back/app/policies/basket_policy.rb
@@ -16,6 +16,10 @@ class BasketPolicy < ApplicationPolicy
     create?
   end
 
+  def upsert?
+    create?
+  end
+
   def destroy?
     update?
   end

--- a/back/app/policies/baskets_idea_policy.rb
+++ b/back/app/policies/baskets_idea_policy.rb
@@ -29,4 +29,8 @@ class BasketsIdeaPolicy < ApplicationPolicy
   def destroy?
     BasketPolicy.new(user, record.basket).update?
   end
+
+  def upsert?
+    BasketPolicy.new(user, record.basket).update?
+  end
 end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -266,6 +266,7 @@ Rails.application.routes.draw do
       resources :baskets, except: [:index] do
         resources :baskets_ideas, shallow: true
       end
+      put 'baskets_ideas/upsert/:idea_id', to: 'baskets_ideas#upsert'
 
       resources :avatars, only: %i[index show]
     end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -266,7 +266,7 @@ Rails.application.routes.draw do
       resources :baskets, except: [:index] do
         resources :baskets_ideas, shallow: true
       end
-      put 'baskets_ideas/upsert/:idea_id', to: 'baskets_ideas#upsert'
+      put 'baskets/ideas/:idea_id', to: 'baskets_ideas#upsert'
 
       resources :avatars, only: %i[index show]
     end

--- a/back/spec/acceptance/baskets_ideas_spec.rb
+++ b/back/spec/acceptance/baskets_ideas_spec.rb
@@ -176,6 +176,15 @@ resource BasketsIdea do
           end
         end
       end
+
+      context 'idea does not exist' do
+        let(:idea_id) { 'NON_EXISTENT' }
+        let(:votes) { 1 }
+
+        example_request 'Add an non existent idea to a basket' do
+          assert_status 404
+        end
+      end
     end
   end
 

--- a/back/spec/acceptance/baskets_ideas_spec.rb
+++ b/back/spec/acceptance/baskets_ideas_spec.rb
@@ -127,6 +127,26 @@ resource BasketsIdea do
     end
   end
 
+  put 'web_api/v1/baskets_ideas/upsert/:idea_id' do
+    with_options scope: :baskets_idea do
+      parameter :idea_id, 'The ID of the idea added to the basket.', required: true
+      parameter :votes, 'The number of times the idea is voted on. Defaults to 1.', required: false
+    end
+    ValidationErrorHelper.new.error_fields self, BasketsIdea
+
+    let(:basket_id) { basket.id }
+    let(:idea_id) { create(:idea, project: project).id }
+    let(:votes) { 3 }
+
+    example_request 'Add an idea to a basket' do
+      assert_status 201
+      json_response = json_parse response_body
+
+      expect(json_response.dig(:data, :attributes, :votes)).to eq 3
+      expect(json_response[:included].pluck(:id)).to include idea_id
+    end
+  end
+
   def create_baskets_ideas(basket, votes: [3, 2, 1])
     votes.map do |v|
       create(:baskets_idea, basket: basket, idea: create(:idea, project: basket.participation_context.project), votes: v).idea

--- a/back/spec/acceptance/baskets_ideas_spec.rb
+++ b/back/spec/acceptance/baskets_ideas_spec.rb
@@ -182,6 +182,7 @@ resource BasketsIdea do
 
           example_request 'Delete an idea in an existing basket' do
             assert_status 200
+            expect(response_data[:id]).to eq baskets_idea.id
             expect { baskets_idea.reload }.to raise_error(ActiveRecord::RecordNotFound)
           end
         end

--- a/back/spec/acceptance/baskets_ideas_spec.rb
+++ b/back/spec/acceptance/baskets_ideas_spec.rb
@@ -155,7 +155,6 @@ resource BasketsIdea do
 
           example_request 'Add an idea to an existing basket' do
             assert_status 200
-
             expect(response_data.dig(:attributes, :votes)).to eq 2
             expect(json_response_body[:included].pluck(:id)).to include idea_id
             expect(response_data.dig(:relationships, :basket, :data, :id)).to eq basket.id
@@ -168,7 +167,6 @@ resource BasketsIdea do
 
           example_request 'Update an idea in an existing basket' do
             assert_status 200
-
             expect(response_data.dig(:attributes, :votes)).to eq 3
             expect(json_response_body[:included].pluck(:id)).to include idea_id
             expect(response_data[:id]).to eq baskets_idea.id
@@ -183,7 +181,21 @@ resource BasketsIdea do
           example_request 'Delete an idea in an existing basket' do
             assert_status 200
             expect(response_data[:id]).to eq baskets_idea.id
+            expect(response_data.dig(:attributes, :votes)).to be_nil
+            expect(response_data.dig(:relationships, :idea, :data, :id)).to eq idea_id
             expect { baskets_idea.reload }.to raise_error(ActiveRecord::RecordNotFound)
+          end
+        end
+
+        context 'basket_idea does not exist and votes is set to nil' do
+          let(:votes) { nil }
+
+          example_request 'Return the baskets_idea that was never persisted', document: false do
+            assert_status 200
+            expect(response_data[:id]).to be_nil
+            expect(response_data.dig(:attributes, :votes)).to be_nil
+            expect(response_data.dig(:relationships, :idea, :data, :id)).to eq idea_id
+            expect(BasketsIdea.find_by(idea: idea)).to be_nil
           end
         end
       end

--- a/back/spec/acceptance/baskets_ideas_spec.rb
+++ b/back/spec/acceptance/baskets_ideas_spec.rb
@@ -125,25 +125,57 @@ resource BasketsIdea do
         expect { BasketsIdea.find(id) }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
-  end
 
-  put 'web_api/v1/baskets_ideas/upsert/:idea_id' do
-    with_options scope: :baskets_idea do
-      parameter :idea_id, 'The ID of the idea added to the basket.', required: true
-      parameter :votes, 'The number of times the idea is voted on. Defaults to 1.', required: false
-    end
-    ValidationErrorHelper.new.error_fields self, BasketsIdea
+    put 'web_api/v1/baskets/ideas/:idea_id' do
+      with_options scope: :baskets_idea do
+        parameter :idea_id, 'The ID of the idea added to the basket.', required: true
+        parameter :votes, 'The number of times the idea is voted on. Defaults to 1.', required: false
+      end
+      ValidationErrorHelper.new.error_fields self, BasketsIdea
 
-    let(:basket_id) { basket.id }
-    let(:idea_id) { create(:idea, project: project).id }
-    let(:votes) { 3 }
+      let(:idea) { create(:idea, project: project) }
+      let(:idea_id) { idea.id }
 
-    example_request 'Add an idea to a basket' do
-      assert_status 201
-      json_response = json_parse response_body
+      context 'basket and basket_idea do not exist' do
+        let(:votes) { 1 }
 
-      expect(json_response.dig(:data, :attributes, :votes)).to eq 3
-      expect(json_response[:included].pluck(:id)).to include idea_id
+        example_request 'Add an idea to a basket & create the basket' do
+          assert_status 200
+
+          expect(response_data.dig(:attributes, :votes)).to eq 1
+          expect(json_response_body[:included].pluck(:id)).to include idea_id
+        end
+      end
+
+      context 'basket already exists' do
+        let!(:basket) { create(:basket, participation_context: project, user: user) }
+
+        context 'basket_idea does not exist' do
+          let(:votes) { 2 }
+
+          example_request 'Add an idea to an existing basket' do
+            assert_status 200
+
+            expect(response_data.dig(:attributes, :votes)).to eq 2
+            expect(json_response_body[:included].pluck(:id)).to include idea_id
+            expect(response_data.dig(:relationships, :basket, :data, :id)).to eq basket.id
+          end
+        end
+
+        context 'basket_idea already exists' do
+          let!(:baskets_idea) { create(:baskets_idea, basket: basket, idea: idea) }
+          let(:votes) { 3 }
+
+          example_request 'Update an idea in an existing basket' do
+            assert_status 200
+
+            expect(response_data.dig(:attributes, :votes)).to eq 3
+            expect(json_response_body[:included].pluck(:id)).to include idea_id
+            expect(response_data[:id]).to eq baskets_idea.id
+            expect(response_data.dig(:relationships, :basket, :data, :id)).to eq basket.id
+          end
+        end
+      end
     end
   end
 

--- a/back/spec/acceptance/baskets_ideas_spec.rb
+++ b/back/spec/acceptance/baskets_ideas_spec.rb
@@ -129,7 +129,7 @@ resource BasketsIdea do
     put 'web_api/v1/baskets/ideas/:idea_id' do
       with_options scope: :baskets_idea do
         parameter :idea_id, 'The ID of the idea added to the basket.', required: true
-        parameter :votes, 'The number of times the idea is voted on. Defaults to 1.', required: false
+        parameter :votes, 'The number of times the idea is voted on. If set to nil, the relationship between basket and idea will be deleted.', required: false
       end
       ValidationErrorHelper.new.error_fields self, BasketsIdea
 
@@ -173,6 +173,16 @@ resource BasketsIdea do
             expect(json_response_body[:included].pluck(:id)).to include idea_id
             expect(response_data[:id]).to eq baskets_idea.id
             expect(response_data.dig(:relationships, :basket, :data, :id)).to eq basket.id
+          end
+        end
+
+        context 'basket_idea already exists and votes is set to nil' do
+          let!(:baskets_idea) { create(:baskets_idea, basket: basket, idea: idea) }
+          let(:votes) { nil }
+
+          example_request 'Delete an idea in an existing basket' do
+            assert_status 200
+            expect { baskets_idea.reload }.to raise_error(ActiveRecord::RecordNotFound)
           end
         end
       end


### PR DESCRIPTION
New upsert endpoint: `PUT /web_api/v1/baskets/ideas/:idea_id` - derives the basket from the current participation context of the idea passed in:

- creates the `basket` if does not exist
- creates the `baskets_idea` if does not exist
- otherwise just updates the `baskets_idea` with the new value of `votes`
- deletes the `baskets_idea` if the value of `votes` is set to `nil`

Unless there is a problem saving then the endpoint will always return a `baskets_idea` response - even if you try send votes=nil to a baskets_idea relationship that has not yet been created.
