### PR TITLE
[CL-3927] Fix ClaveUnica and FranceConnect redirects after Rail 7 upgrade

### DIFF
--- a/back/app/controllers/omniauth_callback_controller.rb
+++ b/back/app/controllers/omniauth_callback_controller.rb
@@ -33,7 +33,7 @@ class OmniauthCallbackController < ApplicationController
 
     url = auth_service.logout_url(provider, user)
 
-    redirect_to url
+    redirect_to url, allow_other_host: true
   rescue ActiveRecord::RecordNotFound
     redirect_to Frontend::UrlService.new.home_url
   end

--- a/back/spec/acceptance/omniauth_callback_spec.rb
+++ b/back/spec/acceptance/omniauth_callback_spec.rb
@@ -12,4 +12,21 @@ resource 'Omniauth Callback', document: false do
       expect(response_headers['Location']).to include('/authentication-error')
     end
   end
+
+  context 'when the user is logged in' do
+    before do
+      @user = create(:user)
+    end
+
+    parameter :user_id, 'User ID', required: true
+
+    let(:user_id) { @user.id }
+
+    get '/auth/clave_unica/logout' do
+      example_request 'Redirect to ClaveUnica URL' do
+        expect(status).to eq(302)
+        expect(response_headers['Location']).to start_with('https://accounts.claveunica.gob.cl/api/v1/accounts/app/logout')
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Changelog
## Fixed
* [CL-3927] Fix ClaveUnica and FranceConnect redirects after Rail 7 upgrade


[CL-3927]: https://citizenlab.atlassian.net/browse/CL-3927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ