### PR TITLE
CL-3928 - Voting emails 2 - Results and phase start

### DIFF
--- a/back/app/models/notifications/voting_results.rb
+++ b/back/app/models/notifications/voting_results.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: notifications
+#
+#  id                            :uuid             not null, primary key
+#  type                          :string
+#  read_at                       :datetime
+#  recipient_id                  :uuid
+#  post_id                       :uuid
+#  comment_id                    :uuid
+#  project_id                    :uuid
+#  created_at                    :datetime         not null
+#  updated_at                    :datetime         not null
+#  initiating_user_id            :uuid
+#  spam_report_id                :uuid
+#  invite_id                     :uuid
+#  reason_code                   :string
+#  other_reason                  :string
+#  post_status_id                :uuid
+#  official_feedback_id          :uuid
+#  phase_id                      :uuid
+#  post_type                     :string
+#  post_status_type              :string
+#  project_folder_id             :uuid
+#  inappropriate_content_flag_id :uuid
+#  internal_comment_id           :uuid
+#  basket_id                     :uuid
+#
+# Indexes
+#
+#  index_notifications_on_basket_id                            (basket_id)
+#  index_notifications_on_created_at                           (created_at)
+#  index_notifications_on_inappropriate_content_flag_id        (inappropriate_content_flag_id)
+#  index_notifications_on_initiating_user_id                   (initiating_user_id)
+#  index_notifications_on_internal_comment_id                  (internal_comment_id)
+#  index_notifications_on_invite_id                            (invite_id)
+#  index_notifications_on_official_feedback_id                 (official_feedback_id)
+#  index_notifications_on_phase_id                             (phase_id)
+#  index_notifications_on_post_id_and_post_type                (post_id,post_type)
+#  index_notifications_on_post_status_id                       (post_status_id)
+#  index_notifications_on_post_status_id_and_post_status_type  (post_status_id,post_status_type)
+#  index_notifications_on_recipient_id                         (recipient_id)
+#  index_notifications_on_recipient_id_and_read_at             (recipient_id,read_at)
+#  index_notifications_on_spam_report_id                       (spam_report_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (basket_id => baskets.id)
+#  fk_rails_...  (comment_id => comments.id)
+#  fk_rails_...  (inappropriate_content_flag_id => flag_inappropriate_content_inappropriate_content_flags.id)
+#  fk_rails_...  (initiating_user_id => users.id)
+#  fk_rails_...  (internal_comment_id => internal_comments.id)
+#  fk_rails_...  (invite_id => invites.id)
+#  fk_rails_...  (official_feedback_id => official_feedbacks.id)
+#  fk_rails_...  (phase_id => phases.id)
+#  fk_rails_...  (project_id => projects.id)
+#  fk_rails_...  (recipient_id => users.id)
+#  fk_rails_...  (spam_report_id => spam_reports.id)
+#
+module Notifications
+  class VotingResults < Notification
+    validates :project, presence: true
+    validates :phase, presence: true
+
+    ACTIVITY_TRIGGERS = { 'Phase' => { 'ended' => true } }
+    EVENT_NAME = 'Phase ended'
+
+    def self.make_notifications_on(activity)
+      phase = activity.item
+
+      if phase.voting?
+        user_scope = ParticipantsService.new.projects_participants(Project.where(id: phase.project_id))
+        ProjectPolicy::InverseScope.new(phase.project, user_scope).resolve.filter_map do |recipient|
+          next unless ParticipationContextService.new.participation_possible_for_context? phase, recipient
+
+          new(
+            recipient: recipient,
+            project: phase.project,
+            phase: phase
+          )
+        end
+      else
+        []
+      end
+    end
+  end
+end

--- a/back/app/serializers/web_api/v1/notifications/voting_results_serializer.rb
+++ b/back/app/serializers/web_api/v1/notifications/voting_results_serializer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class WebApi::V1::Notifications::VotingResultsSerializer < WebApi::V1::Notifications::NotificationSerializer
+  attribute :project_slug do |object|
+    object.project&.slug
+  end
+
+  attribute :phase_title_multiloc do |object|
+    object.phase&.title_multiloc
+  end
+end

--- a/back/app/services/activities_service.rb
+++ b/back/app/services/activities_service.rb
@@ -11,6 +11,7 @@ class ActivitiesService
     create_invite_not_accepted_since_3_days_activities now, last_time
     create_phase_ending_soon_activities now
     create_basket_not_submitted_activities now
+    create_phase_ended_activities now
   end
 
   private
@@ -60,6 +61,14 @@ class ActivitiesService
     Basket.not_submitted.each do |basket|
       if Activity.find_by(item: basket, action: 'not_submitted').nil? && basket.baskets_ideas.order(:updated_at).last.updated_at <= now - 1.day
         LogActivityJob.perform_later(basket, 'not_submitted', nil, now.to_i)
+      end
+    end
+  end
+
+  def create_phase_ended_activities(now)
+    Phase.published.where(end_at: ..now).each do |phase|
+      if Activity.find_by(item: phase, action: 'ended').nil?
+        LogActivityJob.perform_later(phase, 'ended', nil, now.to_i)
       end
     end
   end

--- a/back/app/services/notification_service.rb
+++ b/back/app/services/notification_service.rb
@@ -42,7 +42,8 @@ class NotificationService
     Notifications::ThresholdReachedForAdmin,
     Notifications::VotingBasketSubmitted,
     Notifications::VotingBasketNotSubmitted,
-    Notifications::VotingLastChance
+    Notifications::VotingLastChance,
+    Notifications::VotingResults
   ].freeze
 
   def notification_classes

--- a/back/app/views/application/_voting_ideas.mjml
+++ b/back/app/views/application/_voting_ideas.mjml
@@ -1,0 +1,24 @@
+<mj-section padding="0 25px 0">
+  <mj-column>
+    <mj-raw><% ideas.each do |idea| %></mj-raw>
+    <mj-table cellpadding="10" padding-top="20px">
+      <tr style="border:1px solid #ecedee; background-color: #FFFFFF">
+        <td width="96">
+          <a style="font-size: 14px; font-weight: 700; color: #000; text-decoration: none;" href="<%= idea.url %>">
+            <mj-raw><% if idea.images.size > 0 %></mj-raw>
+            <img width="80px" src="<%= idea.images&.first&.versions&.small %>">
+            <mj-raw><% else %></mj-raw>
+            <img width="80px" src="https://cl2-seed-and-template-assets.s3.eu-central-1.amazonaws.com/images/icons/icon_idea_grey.png">
+            <mj-raw><% end %></mj-raw>
+          </a>
+        </td>
+        <td style="text-align: left; vertical-align: top;">
+          <a style="font-size: 14px; font-weight: 700; color: #000; text-decoration: none;" href="<%= idea.url %>">
+            <%= localize_for_recipient(idea.title_multiloc) %>
+          </a>
+        </td>
+      </tr>
+    </mj-table>
+    <mj-raw><% end %></mj-raw>
+  </mj-column>
+</mj-section>

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/voting_phase_started_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/voting_phase_started_mailer.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module EmailCampaigns
+  class ProjectPhaseStartedMailer < ApplicationMailer
+    private
+
+    def project_title
+      localize_for_recipient(event.project_title_multiloc)
+    end
+
+    def subject
+      format_message('subject', values: { projectName: project_title })
+    end
+
+    def header_title
+      format_message('main_header', values: { projectName: project_title })
+    end
+
+    def header_message
+      format_message('event_description', values: { organizationName: organization_name })
+    end
+
+    def preheader
+      format_message('preheader', values: { projectName: project_title })
+    end
+  end
+end

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/voting_phase_started_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/voting_phase_started_mailer.rb
@@ -9,19 +9,28 @@ module EmailCampaigns
     end
 
     def subject
-      format_message('subject', values: { projectName: project_title })
+      format_message('subject', values: {
+        organizationName: organization_name,
+        projectName: localize_for_recipient(event.project_title_multiloc)
+      })
     end
 
     def header_title
-      format_message('main_header', values: { projectName: project_title })
+      localize_for_recipient(event.project_title_multiloc)
     end
 
     def header_message
-      format_message('event_description', values: { organizationName: organization_name })
+      format_message('event_description', values: {
+        projectName: localize_for_recipient(event.project_title_multiloc),
+        numIdeas: event.ideas.size
+      })
     end
 
     def preheader
-      format_message('preheader', values: { projectName: project_title })
+      format_message('preheader', values: {
+        organizationName: organization_name,
+        projectName: localize_for_recipient(event.project_title_multiloc)
+      })
     end
   end
 end

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/voting_phase_started_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/voting_phase_started_mailer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module EmailCampaigns
-  class ProjectPhaseStartedMailer < ApplicationMailer
+  class VotingPhaseStartedMailer < ApplicationMailer
     private
 
     def project_title

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/voting_results_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/voting_results_mailer.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module EmailCampaigns
+  class VotingResultsMailer < ApplicationMailer
+    protected
+
+    def subject
+      format_message('subject', values: {
+        organizationName: organization_name,
+        phaseTitle: localize_for_recipient(event.phase_title_multiloc)
+      })
+    end
+
+    private
+
+    def header_title
+      format_message('title_results', values: { phaseTitle: localize_for_recipient(event.phase_title_multiloc) })
+    end
+
+    def header_message
+      nil
+    end
+
+    def preheader
+      format_message('preheader', values: {
+        organizationName: organization_name,
+        phaseTitle: localize_for_recipient(event.phase_title_multiloc)
+      })
+    end
+  end
+end

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/voting_basket_submitted.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/voting_basket_submitted.rb
@@ -70,23 +70,9 @@ module EmailCampaigns
       [{
         event_payload: {
           project_url: Frontend::UrlService.new.model_to_url(basket.participation_context.project, locale: recipient.locale),
-          voted_ideas: format_ideas_list(basket.ideas, recipient)
+          voted_ideas: EmailCampaigns::PayloadFormatterService.new.format_ideas_list(basket.ideas, recipient)
         }
       }]
-    end
-
-    def format_ideas_list(ideas, recipient)
-      ideas.map do |idea|
-        {
-          title_multiloc: idea.title_multiloc,
-          url: Frontend::UrlService.new.model_to_url(idea, locale: recipient.locale),
-          images: idea.idea_images.map do |image|
-            {
-              versions: image.image.versions.to_h { |k, v| [k.to_s, v.url] }
-            }
-          end
-        }
-      end
     end
   end
 end

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/voting_phase_started.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/voting_phase_started.rb
@@ -27,7 +27,7 @@
 #  fk_rails_...  (author_id => users.id)
 #
 module EmailCampaigns
-  class Campaigns::ProjectPhaseStarted < Campaign
+  class Campaigns::VotingPhaseStarted < Campaign
     include Consentable
     include ActivityTriggerable
     include RecipientConfigurable
@@ -39,7 +39,7 @@ module EmailCampaigns
     recipient_filter :filter_notification_recipient
 
     def mailer_class
-      ProjectPhaseStartedMailer
+      VotingPhaseStartedMailer
     end
 
     def activity_triggers

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/voting_phase_started.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/voting_phase_started.rb
@@ -71,13 +71,10 @@ module EmailCampaigns
       if notification.phase.voting?
         [{
           event_payload: {
+            project_url: Frontend::UrlService.new.model_to_url(notification.phase.project, locale: recipient.locale),
+            project_title_multiloc: notification.phase.project.title_multiloc,
             phase_title_multiloc: notification.phase.title_multiloc,
-            phase_description_multiloc: notification.phase.description_multiloc,
-            phase_start_at: notification.phase.start_at.iso8601,
-            phase_end_at: notification.phase.end_at.iso8601,
-            phase_url: Frontend::UrlService.new.model_to_url(notification.phase, locale: recipient.locale),
-            project_title_multiloc: notification.project.title_multiloc,
-            project_description_preview_multiloc: notification.project.description_preview_multiloc
+            ideas: EmailCampaigns::PayloadFormatterService.new.format_ideas_list(notification.phase.ideas, recipient)
           },
           delay: 8.hours.to_i
         }]

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/voting_phase_started.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/voting_phase_started.rb
@@ -69,9 +69,6 @@ module EmailCampaigns
     def generate_commands(recipient:, activity:, time: nil)
       notification = activity.item
       if notification.phase.voting?
-        # NOTE: Voting phases send a different email
-        []
-      else
         [{
           event_payload: {
             phase_title_multiloc: notification.phase.title_multiloc,
@@ -84,6 +81,8 @@ module EmailCampaigns
           },
           delay: 8.hours.to_i
         }]
+      else
+        []
       end
     end
   end

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/voting_results.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/voting_results.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: email_campaigns_campaigns
+#
+#  id               :uuid             not null, primary key
+#  type             :string           not null
+#  author_id        :uuid
+#  enabled          :boolean
+#  sender           :string
+#  reply_to         :string
+#  schedule         :jsonb
+#  subject_multiloc :jsonb
+#  body_multiloc    :jsonb
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  deliveries_count :integer          default(0), not null
+#
+# Indexes
+#
+#  index_email_campaigns_campaigns_on_author_id  (author_id)
+#  index_email_campaigns_campaigns_on_type       (type)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (author_id => users.id)
+#
+module EmailCampaigns
+  class Campaigns::VotingResults < Campaign
+    include Consentable
+    include ActivityTriggerable
+    include Disableable
+    include Trackable
+    include LifecycleStageRestrictable
+    allow_lifecycle_stages only: %w[trial active]
+
+    recipient_filter :filter_recipient
+
+    def mailer_class
+      VotingResultsMailer
+    end
+
+    def activity_triggers
+      { 'Notifications::VotingResults' => { 'created' => true } }
+    end
+
+    def filter_recipient(users_scope, activity:, time: nil)
+      users_scope.where(id: activity.item.recipient.id)
+    end
+
+    def self.recipient_role_multiloc_key
+      'email_campaigns.admin_labels.recipient_role.registered_users'
+    end
+
+    def self.recipient_segment_multiloc_key
+      'email_campaigns.admin_labels.recipient_segment.users_who_engaged_with_the_project'
+    end
+
+    def self.content_type_multiloc_key
+      'email_campaigns.admin_labels.content_type.voting'
+    end
+
+    def self.trigger_multiloc_key
+      'email_campaigns.admin_labels.trigger.voting_phase_ended'
+    end
+
+    def generate_commands(recipient:, activity:)
+      basket = activity.item
+      [{
+        event_payload: {
+          project_url: Frontend::UrlService.new.model_to_url(project, locale: recipient.locale),
+          phase_title_multiloc: basket.participation_context.title_multiloc,
+          project_title_multiloc: basket.participation_context.project.title_multiloc
+        }
+      }]
+    end
+  end
+end

--- a/back/engines/free/email_campaigns/app/services/email_campaigns/payload_formatter_service.rb
+++ b/back/engines/free/email_campaigns/app/services/email_campaigns/payload_formatter_service.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module EmailCampaigns
+  class PayloadFormatterService
+    def format_ideas_list(ideas, recipient)
+      ideas.map do |idea|
+        {
+          title_multiloc: idea.title_multiloc,
+          url: Frontend::UrlService.new.model_to_url(idea, locale: recipient.locale),
+          images: idea.idea_images.map do |image|
+            {
+              versions: image.image.versions.to_h { |k, v| [k.to_s, v.url] }
+            }
+          end
+        }
+      end
+    end
+  end
+end

--- a/back/engines/free/email_campaigns/app/views/email_campaigns/voting_basket_submitted_mailer/campaign_mail.mjml
+++ b/back/engines/free/email_campaigns/app/views/email_campaigns/voting_basket_submitted_mailer/campaign_mail.mjml
@@ -1,28 +1,5 @@
 <!-- Voted ideas -->
-<mj-section padding="0 25px 0">
-  <mj-column>
-    <mj-raw><% event.voted_ideas.each do |idea| %></mj-raw>
-    <mj-table cellpadding="10" padding-top="20px">
-      <tr style="border:1px solid #ecedee; background-color: #FFFFFF">
-        <td width="96">
-            <a style="font-size: 14px; font-weight: 700; color: #000; text-decoration: none;" href="<%= idea.url %>">
-            <mj-raw><% if idea.images.size > 0 %></mj-raw>
-              <img width="80px" src="<%= idea.images&.first&.versions&.small %>">
-            <mj-raw><% else %></mj-raw>
-              <img width="80px" src="https://cl2-seed-and-template-assets.s3.eu-central-1.amazonaws.com/images/icons/icon_idea_grey.png">
-            <mj-raw><% end %></mj-raw>
-            </a>
-        </td>
-        <td style="text-align: left; vertical-align: top;">
-          <a style="font-size: 14px; font-weight: 700; color: #000; text-decoration: none;" href="<%= idea.url %>">
-            <%= localize_for_recipient(idea.title_multiloc) %>
-          </a>
-        </td>
-      </tr>
-    </mj-table>
-    <mj-raw><% end %></mj-raw>
-  </mj-column>
-</mj-section>
+<%= render partial: 'application/voting_ideas', locals: { ideas: event.voted_ideas } %>
 
 <!-- CTA button -->
 <mj-section padding="10px 25px 0">

--- a/back/engines/free/email_campaigns/app/views/email_campaigns/voting_phase_started_mailer/campaign_mail.mjml
+++ b/back/engines/free/email_campaigns/app/views/email_campaigns/voting_phase_started_mailer/campaign_mail.mjml
@@ -1,0 +1,18 @@
+<!-- Phase -->
+<mj-section
+  padding="25px"
+  border-radius="5px"
+  text-align="left">
+  <mj-column border-radius="5px" background-color="#F2F6F8" padding="25px">
+    <mj-text font-size="14px">
+      <%= format_message('new_phase', values: { phaseTitle: localize_for_recipient(event.phase_title_multiloc) }) %>
+      <p style="margin: 15px 0 0;">
+        <%= localize_for_recipient(event.phase_description_multiloc) %>
+      </p>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%= render partial: 'application/cta_button', locals: { href: event.phase_url , message: format_message('cta_view_phase') } %>
+
+<%= render partial: 'email_campaigns/projects/about_project', locals: { homepage_description: localize_for_recipient(event.project_description_preview_multiloc), message: format_message('subtitle', values: { projectName: localize_for_recipient(event.project_title_multiloc) }) } %>

--- a/back/engines/free/email_campaigns/app/views/email_campaigns/voting_phase_started_mailer/campaign_mail.mjml
+++ b/back/engines/free/email_campaigns/app/views/email_campaigns/voting_phase_started_mailer/campaign_mail.mjml
@@ -1,18 +1,12 @@
-<!-- Phase -->
-<mj-section
-  padding="25px"
-  border-radius="5px"
-  text-align="left">
-  <mj-column border-radius="5px" background-color="#F2F6F8" padding="25px">
-    <mj-text font-size="14px">
-      <%= format_message('new_phase', values: { phaseTitle: localize_for_recipient(event.phase_title_multiloc) }) %>
-      <p style="margin: 15px 0 0;">
-        <%= localize_for_recipient(event.phase_description_multiloc) %>
-      </p>
+<!-- Ideas -->
+<%= render partial: 'application/voting_ideas', locals: { ideas: event.ideas } %>
+
+<!-- CTA button -->
+<mj-section padding="0 25px">
+  <mj-column>
+    <mj-text>
+      <p><%= format_message('cta_message') %></p>
     </mj-text>
   </mj-column>
 </mj-section>
-
-<%= render partial: 'application/cta_button', locals: { href: event.phase_url , message: format_message('cta_view_phase') } %>
-
-<%= render partial: 'email_campaigns/projects/about_project', locals: { homepage_description: localize_for_recipient(event.project_description_preview_multiloc), message: format_message('subtitle', values: { projectName: localize_for_recipient(event.project_title_multiloc) }) } %>
+<%= render partial: 'application/cta_button', locals: { href: event.project_url, message: format_message('cta_vote') } %>

--- a/back/engines/free/email_campaigns/app/views/email_campaigns/voting_results_mailer/campaign_mail.mjml
+++ b/back/engines/free/email_campaigns/app/views/email_campaigns/voting_results_mailer/campaign_mail.mjml
@@ -9,13 +9,7 @@
   </mj-column>
 </mj-section>
 
-<!-- Results -->
-<mj-section padding="0 25px">
-  <mj-column>
-    <mj-text>
-      <p>RESULTS TO APPEAR HERE.</p>
-    </mj-text>
-  </mj-column>
-</mj-section>
+<!-- TODO: RESULTS TO APPEAR HERE -->
+
 <!-- CTA button -->
 <%= render partial: 'application/cta_button', locals: { href: event.project_url, message: format_message('cta_see_results') } %>

--- a/back/engines/free/email_campaigns/app/views/email_campaigns/voting_results_mailer/campaign_mail.mjml
+++ b/back/engines/free/email_campaigns/app/views/email_campaigns/voting_results_mailer/campaign_mail.mjml
@@ -1,0 +1,21 @@
+<!-- Body text -->
+<mj-section padding="0 25px">
+  <mj-column>
+    <mj-text>
+      <p style="margin-top: 0px;"><%= format_message('body_1') %></p>
+      <p><%= format_message('body_2', values: { phaseTitle: localize_for_recipient(event.phase_title_multiloc), organizationName: organization_name }) %></p>
+      <p><%= format_message('body_3') %></p>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<!-- Results -->
+<mj-section padding="0 25px">
+  <mj-column>
+    <mj-text>
+      <p>RESULTS TO APPEAR HERE.</p>
+    </mj-text>
+  </mj-column>
+</mj-section>
+<!-- CTA button -->
+<%= render partial: 'application/cta_button', locals: { href: event.project_url, message: format_message('cta_see_results') } %>

--- a/back/engines/free/email_campaigns/config/locales/en.yml
+++ b/back/engines/free/email_campaigns/config/locales/en.yml
@@ -50,6 +50,7 @@ en:
       "voting_basket_submitted": Confirmation of voting
       "voting_basket_not_submitted": Votes not submitted
       "voting_last_chance": Last chance to vote
+      "voting_results": Voting results
       "your_proposed_initiatives_digest": Weekly overview of your proposals
     schedules:
       weekly:
@@ -539,6 +540,14 @@ en:
       body_2: 'Time is running out, and we noticed that you haven''t cast your vote yet! Act now by simply clicking the button below to participate.'
       body_3: 'By doing so, you''ll gain access to a range of options and have the chance to provide your input, which is crucial in deciding the future of this project.'
       cta_vote: 'Vote'
+    voting_results:
+      subject: '%{organizationName}: %{phaseTitle} vote results revealed!'
+      preheader: '%{phaseTitle} vote results revealed on the participation platform of %{organizationName}'
+      title_results: '%{phaseTitle} vote results revealed!'
+      body_1: 'Results are in!'
+      body_2: 'The results of the %{phaseTitle} vote in the %{organizationName} platform have been published!'
+      body_3: 'We encourage you to review the results and stay tuned for further updates on the next steps.'
+      cta_see_results: 'See results in the platform'
     admin_labels:
       recipient_role:
         admins_and_managers: 'To admins & managers'
@@ -606,6 +615,7 @@ en:
         user_replies_to_comment: 'User replies to comment'
         voting_2_days_before_phase_closes: '2 days before voting phase closes'
         voting_1_day_after_last_votes: '1 day after user last voted'
+        voting_phase_ended: 'Voting phase ended'
         voting_basket_submitted: 'Votes are submitted'
         7_days_after_invite_is_sent: '7 days after invite is sent'
         7_days_before_the_project_changes_phase: '7 days before the project changes phase'

--- a/back/engines/free/email_campaigns/config/locales/en.yml
+++ b/back/engines/free/email_campaigns/config/locales/en.yml
@@ -548,6 +548,12 @@ en:
       body_2: 'The results of the %{phaseTitle} vote in the %{organizationName} platform have been published!'
       body_3: 'We encourage you to review the results and stay tuned for further updates on the next steps.'
       cta_see_results: 'See results in the platform'
+    voting_phase_started:
+      subject: '%{organizationName}: The voting phase started for %{projectName}'
+      preheader: 'The voting phase started for %{projectName} on the participation platform of %{organizationName}'
+      event_description: 'The project "%{projectName}" is asking you to vote between %{numIdeas} options:'
+      cta_message: 'Click the button below to participate'
+      cta_vote: 'Go to the platform to vote'
     admin_labels:
       recipient_role:
         admins_and_managers: 'To admins & managers'

--- a/back/engines/free/email_campaigns/spec/factories/campaigns.rb
+++ b/back/engines/free/email_campaigns/spec/factories/campaigns.rb
@@ -210,6 +210,10 @@ FactoryBot.define do
   factory :voting_last_chance_campaign, class: EmailCampaigns::Campaigns::VotingLastChance do
     enabled { true }
   end
+
+  factory :voting_phase_started_campaign, class: EmailCampaigns::Campaigns::VotingPhaseStarted do
+    enabled { true }
+  end
 end
 
 def weekly_schedule

--- a/back/engines/free/email_campaigns/spec/fixtures/locales/mailers.en.yml
+++ b/back/engines/free/email_campaigns/spec/fixtures/locales/mailers.en.yml
@@ -590,3 +590,9 @@ en:
       body_2: 'The results of the %{phaseTitle} vote in the %{organizationName} platform have been published!'
       body_3: 'We encourage you to review the results and stay tuned for further updates on the next steps.'
       cta_see_results: 'See results in the platform'
+    voting_phase_started:
+      subject: '%{organizationName}: The voting phase started for %{projectName}'
+      preheader: 'The voting phase started for %{projectName} on the participation platform of %{organizationName}'
+      event_description: 'The project "%{projectName}" is asking you to vote between %{numIdeas} options:'
+      cta_message: 'Click the button below to participate'
+      cta_vote: 'Go to the platform to vote'

--- a/back/engines/free/email_campaigns/spec/fixtures/locales/mailers.en.yml
+++ b/back/engines/free/email_campaigns/spec/fixtures/locales/mailers.en.yml
@@ -578,6 +578,16 @@ en:
       subject: '%{organizationName}: Last chance to vote for %{phaseTitle}'
       preheader: 'Last chance to vote for %{phaseTitle} on the participation platform of %{organizationName}'
       title_last_chance: 'Last chance to vote for %{phaseTitle}'
-      event_description: 'The voting phase for the %{projectTitle} project is coming to a close tomorrow, at midnight. Time is running out, and we noticed that you haven''t cast your vote yet! Act now by simply clicking the button below to participate. By doing so, you''ll gain access to a range of options and have the chance to provide your input, which is crucial in deciding the future of this project. '
+      body_1: 'The voting phase for the %{projectTitle} project is coming to a close tomorrow, at midnight.'
+      body_2: 'Time is running out, and we noticed that you haven''t cast your vote yet! Act now by simply clicking the button below to participate.'
+      body_3: 'By doing so, you''ll gain access to a range of options and have the chance to provide your input, which is crucial in deciding the future of this project.'
       cta_vote: 'Vote'
+    voting_results:
+      subject: '%{organizationName}: %{phaseTitle} vote results revealed!'
+      preheader: '%{phaseTitle} vote results revealed on the participation platform of %{organizationName}'
+      title_results: '%{phaseTitle} vote results revealed!'
+      body_1: 'Results are in!'
+      body_2: 'The results of the %{phaseTitle} vote in the %{organizationName} platform have been published!'
+      body_3: 'We encourage you to review the results and stay tuned for further updates on the next steps.'
+      cta_see_results: 'See results in the platform'
 

--- a/back/engines/free/email_campaigns/spec/mailers/previews/email_campaigns/voting_basket_submitted_mailer_preview.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/previews/email_campaigns/voting_basket_submitted_mailer_preview.rb
@@ -11,7 +11,7 @@ module EmailCampaigns
         recipient: recipient_user,
         event_payload: {
           project_url: Frontend::UrlService.new.model_to_url(project, locale: recipient_user.locale),
-          voted_ideas: EmailCampaigns::Campaigns::VotingBasketSubmitted.new.format_ideas_list(ideas, recipient_user)
+          voted_ideas: EmailCampaigns::PayloadFormatterService.new.format_ideas_list(ideas, recipient_user)
         }
       }
       campaign = EmailCampaigns::Campaigns::VotingBasketSubmitted.first

--- a/back/engines/free/email_campaigns/spec/mailers/previews/email_campaigns/voting_phase_started_mailer_preview.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/previews/email_campaigns/voting_phase_started_mailer_preview.rb
@@ -14,7 +14,7 @@ module EmailCampaigns
           project_url: Frontend::UrlService.new.model_to_url(project, locale: recipient_user.locale),
           project_title_multiloc: project.title_multiloc,
           phase_title_multiloc: phase.title_multiloc,
-          ideas: EmailCampaigns::Campaigns::VotingBasketSubmitted.new.format_ideas_list(ideas, recipient_user)
+          ideas: EmailCampaigns::PayloadFormatterService.new.format_ideas_list(ideas, recipient_user)
         }
       }
       campaign = EmailCampaigns::Campaigns::VotingPhaseStarted.first

--- a/back/engines/free/email_campaigns/spec/mailers/previews/email_campaigns/voting_phase_started_mailer_preview.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/previews/email_campaigns/voting_phase_started_mailer_preview.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module EmailCampaigns
+  class VotingPhaseStartedMailerPreview < ActionMailer::Preview
+    include EmailCampaigns::MailerPreviewRecipient
+
+    def campaign_mail
+      phase = Phase.first
+      project = phase.project
+      ideas = project.ideas.first(3)
+      command = {
+        recipient: recipient_user,
+        event_payload: {
+          project_url: Frontend::UrlService.new.model_to_url(project, locale: recipient_user.locale),
+          project_title_multiloc: project.title_multiloc,
+          phase_title_multiloc: phase.title_multiloc,
+          ideas: EmailCampaigns::Campaigns::VotingBasketSubmitted.new.format_ideas_list(ideas, recipient_user)
+        }
+      }
+      campaign = EmailCampaigns::Campaigns::VotingPhaseStarted.first
+
+      campaign.mailer_class.with(campaign: campaign, command: command).campaign_mail
+    end
+  end
+end

--- a/back/engines/free/email_campaigns/spec/mailers/previews/email_campaigns/voting_results_mailer_preview.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/previews/email_campaigns/voting_results_mailer_preview.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module EmailCampaigns
+  class VotingResultsMailerPreview < ActionMailer::Preview
+    include EmailCampaigns::MailerPreviewRecipient
+
+    def campaign_mail
+      project = Project.is_timeline.first || Project.first
+      command = {
+        recipient: recipient_user,
+        event_payload: {
+          project_url: Frontend::UrlService.new.model_to_url(project, locale: recipient_user.locale),
+          phase_title_multiloc: project.phases.first.title_multiloc || 'PHASE TITLE',
+          project_title_multiloc: project.title_multiloc
+        }
+      }
+
+      campaign = EmailCampaigns::Campaigns::VotingResults.first
+
+      campaign.mailer_class.with(campaign: campaign, command: command).campaign_mail
+    end
+  end
+end

--- a/back/engines/free/email_campaigns/spec/mailers/voting_phase_started_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/voting_phase_started_mailer_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EmailCampaigns::VotingPhaseStartedMailer do
+  describe 'campaign_mail' do
+    let_it_be(:recipient) { create(:user, locale: 'en') }
+    let_it_be(:campaign) { EmailCampaigns::Campaigns::VotingPhaseStarted.create! }
+    let_it_be(:project) { create(:project_with_phases) }
+    let_it_be(:command) do
+      {
+        recipient: recipient,
+        event_payload: {
+          project_url: Frontend::UrlService.new.model_to_url(project, locale: recipient.locale),
+          project_title_multiloc: project.title_multiloc,
+          phase_title_multiloc: project.phases.first.title_multiloc,
+          ideas: [
+            {
+              title_multiloc: {
+                'en' => 'An idea title'
+              },
+              url: 'http://localhost:3000/en/ideas/an-idea',
+              images: [
+                {
+                  versions: {
+                    small: 'http://localhost:4000/uploads/small_image.jpeg',
+                    medium: 'http://localhost:4000/uploads/medium_image.jpeg',
+                    large: 'http://localhost:4000/uploads/large_image.jpeg',
+                    fb: 'http://localhost:4000/uploads/fb_image.jpeg'
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    end
+
+    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+
+    before_all do
+      EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id)
+    end
+
+    it 'renders the subject including project title' do
+      expect(mail.subject).to match 'The voting phase started'
+      expect(mail.subject).to match project.title_multiloc['en']
+    end
+
+    it 'renders the receiver email' do
+      expect(mail.to).to eq([recipient.email])
+    end
+
+    it 'renders the sender email' do
+      expect(mail.from).to all(end_with('@citizenlab.co'))
+    end
+
+    it 'displays the correct body - including project title and number of options' do
+      expect(mail.body.encoded).to match 'asking you to vote between'
+      expect(mail.body.encoded).to match project.title_multiloc['en']
+      expect(mail.body.encoded).to match '1' # number of ideas passed to the email
+    end
+
+    it 'lists the ideas for the phase in the body' do
+      expect(mail.body.encoded).to match('A voted idea title')
+      expect(mail.body.encoded).to match('ideas/a-voted-idea')
+      expect(mail.body.encoded).to match('uploads/small_image.jpeg')
+    end
+
+    it "displays 'Go to the platform to vote' button with correct link" do
+      project_url = Frontend::UrlService.new.model_to_url(project, locale: recipient.locale)
+      expect(mail.body.encoded).to match project_url
+      expect(mail.body.encoded).to match 'Go to the platform to vote'
+    end
+  end
+end

--- a/back/engines/free/email_campaigns/spec/mailers/voting_phase_started_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/voting_phase_started_mailer_spec.rb
@@ -30,6 +30,22 @@ RSpec.describe EmailCampaigns::VotingPhaseStartedMailer do
                   }
                 }
               ]
+            },
+            {
+              title_multiloc: {
+                'en' => 'Another idea title'
+              },
+              url: 'http://localhost:3000/en/ideas/another-idea',
+              images: [
+                {
+                  versions: {
+                    small: 'http://localhost:4000/uploads/small_image.jpeg',
+                    medium: 'http://localhost:4000/uploads/medium_image.jpeg',
+                    large: 'http://localhost:4000/uploads/large_image.jpeg',
+                    fb: 'http://localhost:4000/uploads/fb_image.jpeg'
+                  }
+                }
+              ]
             }
           ]
         }
@@ -58,12 +74,13 @@ RSpec.describe EmailCampaigns::VotingPhaseStartedMailer do
     it 'displays the correct body - including project title and number of options' do
       expect(mail.body.encoded).to match 'asking you to vote between'
       expect(mail.body.encoded).to match project.title_multiloc['en']
-      expect(mail.body.encoded).to match '1' # number of ideas passed to the email
+      expect(mail.body.encoded).to match '2 options' # number of ideas passed to the email
     end
 
     it 'lists the ideas for the phase in the body' do
-      expect(mail.body.encoded).to match('A voted idea title')
-      expect(mail.body.encoded).to match('ideas/a-voted-idea')
+      expect(mail.body.encoded).to match('An idea title')
+      expect(mail.body.encoded).to match('Another idea title')
+      expect(mail.body.encoded).to match('ideas/an-idea')
       expect(mail.body.encoded).to match('uploads/small_image.jpeg')
     end
 

--- a/back/engines/free/email_campaigns/spec/mailers/voting_results_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/voting_results_mailer_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EmailCampaigns::VotingResultsMailer do
+  describe 'campaign_mail' do
+    let_it_be(:recipient) { create(:user, locale: 'en') }
+    let_it_be(:campaign) { EmailCampaigns::Campaigns::VotingResults.create! }
+    let_it_be(:project) { create(:project_with_phases) }
+    let_it_be(:command) do
+      {
+        recipient: recipient,
+        event_payload: {
+          project_url: Frontend::UrlService.new.model_to_url(project, locale: recipient.locale),
+          project_title_multiloc: project.title_multiloc,
+          phase_title_multiloc: project.phases.first.title_multiloc
+        }
+      }
+    end
+
+    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+
+    before_all do
+      EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id)
+    end
+
+    it 'renders the subject including phase title' do
+      expect(mail.subject).to match 'vote results revealed!'
+      expect(mail.subject).to match project.phases.first.title_multiloc['en']
+    end
+
+    it 'renders the receiver email' do
+      expect(mail.to).to eq([recipient.email])
+    end
+
+    it 'renders the sender email' do
+      expect(mail.from).to all(end_with('@citizenlab.co'))
+    end
+
+    it 'displays the correct body - including phase name' do
+      expect(mail.body.encoded).to match 'Results are in!'
+      expect(mail.body.encoded).to match project.phases.first.title_multiloc['en']
+    end
+
+    it 'displays the correct results' do
+      # TODO: Check the results are correct
+      expect(mail.body.encoded).to match 'RESULTS'
+    end
+
+    it "displays 'See results in the platform' button with correct link" do
+      project_url = Frontend::UrlService.new.model_to_url(project, locale: recipient.locale)
+      expect(mail.body.encoded).to match project_url
+      expect(mail.body.encoded).to match 'See results in the platform'
+    end
+  end
+end

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/project_phase_started_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/project_phase_started_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EmailCampaigns::Campaigns::ProjectPhaseStarted do
+  describe 'VotingPhaseStarted Campaign default factory' do
+    it 'is valid' do
+      expect(build(:project_phase_started_campaign)).to be_valid
+    end
+  end
+
+  describe '#generate_commands' do
+    context 'phase is not a voting phase' do
+      let(:project) { create(:project_with_current_phase) }
+      let(:notification) { create(:project_phase_started, project: project, phase: project.phases.last) }
+      let(:notification_activity) { create(:activity, item: notification, action: 'created') }
+
+      it 'generates a command with the desired payload and tracked content' do
+        campaign = create(:project_phase_started_campaign)
+        command = campaign.generate_commands(
+          recipient: notification_activity.item.recipient,
+          activity: notification_activity
+        ).first
+
+        expect(command.dig(:event_payload, :phase_title_multiloc))
+          .to eq project.phases.last.title_multiloc
+      end
+    end
+
+    context 'phase is a voting phase' do
+      let(:project) { create(:project_with_active_budgeting_phase) }
+      let(:notification) { create(:project_phase_started, project: project, phase: project.phases.last) }
+      let(:notification_activity) { create(:activity, item: notification, action: 'created') }
+
+      it 'does not generate any payload' do
+        campaign = create(:project_phase_started_campaign)
+        command = campaign.generate_commands(
+          recipient: notification_activity.item.recipient,
+          activity: notification_activity
+        ).first
+
+        expect(command).to be_nil
+      end
+    end
+  end
+end

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/voting_phase_started_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/voting_phase_started_spec.rb
@@ -12,18 +12,24 @@ RSpec.describe EmailCampaigns::Campaigns::VotingPhaseStarted do
   describe '#generate_commands' do
     context 'phase is a voting phase' do
       let(:project) { create(:project_with_active_budgeting_phase) }
+      let(:idea) { create(:idea, project: project) }
       let(:notification) { create(:project_phase_started, project: project, phase: project.phases.last) }
       let(:notification_activity) { create(:activity, item: notification, action: 'created') }
 
       it 'generates a command with the desired payload and tracked content' do
+        project.phases.last.ideas << idea
         campaign = create(:voting_phase_started_campaign)
         command = campaign.generate_commands(
           recipient: notification_activity.item.recipient,
           activity: notification_activity
         ).first
 
+        expect(command.dig(:event_payload, :project_title_multiloc))
+          .to eq project.title_multiloc
         expect(command.dig(:event_payload, :phase_title_multiloc))
           .to eq project.phases.last.title_multiloc
+        expect(command.dig(:event_payload, :ideas, 0, :title_multiloc))
+          .to eq idea.title_multiloc
       end
     end
 

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/voting_phase_started_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/voting_phase_started_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EmailCampaigns::Campaigns::VotingPhaseStarted do
+  describe 'VotingPhaseStarted Campaign default factory' do
+    it 'is valid' do
+      expect(build(:voting_phase_started_campaign)).to be_valid
+    end
+  end
+
+  describe '#generate_commands' do
+    context 'phase is a voting phase' do
+      let(:project) { create(:project_with_active_budgeting_phase) }
+      let(:notification) { create(:project_phase_started, project: project, phase: project.phases.last) }
+      let(:notification_activity) { create(:activity, item: notification, action: 'created') }
+
+      it 'generates a command with the desired payload and tracked content' do
+        campaign = create(:voting_phase_started_campaign)
+        command = campaign.generate_commands(
+          recipient: notification_activity.item.recipient,
+          activity: notification_activity
+        ).first
+
+        expect(command.dig(:event_payload, :phase_title_multiloc))
+          .to eq project.phases.last.title_multiloc
+      end
+    end
+
+    context 'phase is not a voting phase' do
+      let(:project) { create(:project_with_current_phase) }
+      let(:notification) { create(:project_phase_started, project: project, phase: project.phases.last) }
+      let(:notification_activity) { create(:activity, item: notification, action: 'created') }
+
+      it 'does not generate any payload' do
+        campaign = create(:voting_phase_started_campaign)
+        command = campaign.generate_commands(
+          recipient: notification_activity.item.recipient,
+          activity: notification_activity
+        ).first
+
+        expect(command).to be_nil
+      end
+    end
+  end
+end

--- a/back/spec/factories/notifications.rb
+++ b/back/spec/factories/notifications.rb
@@ -282,4 +282,9 @@ FactoryBot.define do
     project
     phase
   end
+
+  factory :voting_results, parent: :notification, class: 'Notifications::VotingResults' do
+    project
+    phase
+  end
 end

--- a/front/app/api/notifications/types.ts
+++ b/front/app/api/notifications/types.ts
@@ -440,6 +440,16 @@ export interface IVotingLastChanceNotificationData
   };
 }
 
+export interface IVotingResultsNotificationData extends IBaseNotificationData {
+  attributes: {
+    type: 'voting_results';
+    read_at: string | null;
+    created_at: string;
+    project_slug: string;
+    phase_title_multiloc: Multiloc;
+  };
+}
+
 export interface INotificationDataMap {
   IAdminRightsReceivedNotificationData: IAdminRightsReceivedNotificationData;
   ICommentDeletedByAdminNotificationData: ICommentDeletedByAdminNotificationData;
@@ -474,6 +484,7 @@ export interface INotificationDataMap {
   IVotingBasketSubmittedNotificationData: IVotingBasketSubmittedNotificationData;
   IVotingBasketNotSubmittedNotificationData: IVotingBasketNotSubmittedNotificationData;
   IVotingLastChanceNotificationData: IVotingLastChanceNotificationData;
+  IVotingResultsNotificationData: IVotingResultsNotificationData;
 }
 
 export type TNotificationData =

--- a/front/app/containers/MainHeader/NotificationMenu/components/Notification/index.tsx
+++ b/front/app/containers/MainHeader/NotificationMenu/components/Notification/index.tsx
@@ -35,6 +35,7 @@ import ProjectFolderModerationRightsReceivedNotification from '../ProjectFolderM
 import VotingBasketSubmittedNotification from '../VotingBasketSubmittedNotification';
 import VotingBasketNotSubmittedNotification from '../VotingBasketNotSubmittedNotification';
 import VotingLastChanceNotification from '../VotingLastChanceNotification';
+import VotingResultsNotification from '../VotingResultsNotification';
 
 import {
   TNotificationData,
@@ -71,6 +72,7 @@ import {
   IVotingBasketSubmittedNotificationData,
   IVotingBasketNotSubmittedNotificationData,
   IVotingLastChanceNotificationData,
+  IVotingResultsNotificationData,
 } from 'api/notifications/types';
 import styled from 'styled-components';
 import Outlet from 'components/Outlet';
@@ -323,6 +325,12 @@ const Notification = ({ notification }: Props) => {
       return (
         <VotingLastChanceNotification
           notification={notification as IVotingLastChanceNotificationData}
+        />
+      );
+    case 'voting_results':
+      return (
+        <VotingResultsNotification
+          notification={notification as IVotingResultsNotificationData}
         />
       );
     default:

--- a/front/app/containers/MainHeader/NotificationMenu/components/VotingResultsNotification/index.tsx
+++ b/front/app/containers/MainHeader/NotificationMenu/components/VotingResultsNotification/index.tsx
@@ -1,0 +1,38 @@
+import React, { memo } from 'react';
+import { IVotingResultsNotificationData } from 'api/notifications/types';
+
+// i18n
+import messages from '../../messages';
+import { FormattedMessage } from 'utils/cl-intl';
+import T from 'components/T';
+
+// components
+import NotificationWrapper from '../NotificationWrapper';
+
+type Props = {
+  notification: IVotingResultsNotificationData;
+};
+
+const VotingResultsNotification = memo<Props>((props) => {
+  const { notification } = props;
+
+  return (
+    <NotificationWrapper
+      linkTo={`/projects/${notification.attributes.project_slug}`}
+      timing={notification.attributes.created_at}
+      icon="vote-ballot"
+      isRead={!!notification.attributes.read_at}
+    >
+      <FormattedMessage
+        {...messages.votingResults}
+        values={{
+          phaseTitle: (
+            <T value={notification.attributes.phase_title_multiloc} />
+          ),
+        }}
+      />
+    </NotificationWrapper>
+  );
+});
+
+export default VotingResultsNotification;

--- a/front/app/containers/MainHeader/NotificationMenu/messages.ts
+++ b/front/app/containers/MainHeader/NotificationMenu/messages.ts
@@ -312,4 +312,8 @@ export default defineMessages({
     id: 'app.containers.NotificationMenu.votingLastChance',
     defaultMessage: 'Last chance to vote for {phaseTitle}',
   },
+  votingResults: {
+    id: 'app.containers.NotificationMenu.votingResults',
+    defaultMessage: '{phaseTitle} vote results revealed',
+  },
 });

--- a/front/app/translations/en.json
+++ b/front/app/translations/en.json
@@ -1124,6 +1124,7 @@
   "app.containers.NotificationMenu.votingBasketNotSubmitted": "You didn't submit your votes",
   "app.containers.NotificationMenu.votingBasketSubmitted": "You voted successfully",
   "app.containers.NotificationMenu.votingLastChance": "Last chance to vote for {phaseTitle}",
+  "app.containers.NotificationMenu.votingResults": "{phaseTitle} vote results revealed",
   "app.containers.NotificationMenu.xAssignedPostToYou": "{name} assigned {postTitle} to you",
   "app.containers.PasswordRecovery.emailError": "This doesn't look like a valid email",
   "app.containers.PasswordRecovery.emailLabel": "Email",


### PR DESCRIPTION
This PR contains two new emails:

- Email when a voting phase starts - uses existing notification
- Email when the results are available - with a new notification

It also changes the project_phase_started email so that it does not send when the phase is a voting phase (because for a voting phase you now get the one above)

This PR does NOT contain the results in the body of the results email as the email makes sense without the results. These will be added in a separate ticket/PR.