### PR TITLE
CL-3925 - Minor changes to baskets_idea upsert endpoint

### DIFF
--- a/back/app/controllers/web_api/v1/baskets_ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/baskets_ideas_controller.rb
@@ -62,7 +62,6 @@ class WebApi::V1::BasketsIdeasController < ApplicationController
       user: current_user
     )
     if basket.new_record?
-      basket.participation_context_type = participation_context.phase? ? 'Phase' : 'Project'
       if basket.save
         SideFxBasketService.new.after_create basket, current_user
       else

--- a/back/app/controllers/web_api/v1/baskets_ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/baskets_ideas_controller.rb
@@ -56,18 +56,17 @@ class WebApi::V1::BasketsIdeasController < ApplicationController
     # 1. Create or get basket
     idea = Idea.find(params[:idea_id])
     participation_context = ParticipationContextService.new.get_participation_context(idea.project)
-    participation_context_type = participation_context.phase? ? 'Phase' : 'Project'
 
     basket = Basket.find_or_initialize_by(
       participation_context: participation_context,
-      participation_context_type: participation_context_type,
       user: current_user
     )
     if basket.new_record?
+      basket.participation_context_type = participation_context.phase? ? 'Phase' : 'Project'
       if basket.save
         SideFxBasketService.new.after_create basket, current_user
       else
-        render json: { errors: baskets_idea.errors.details }, status: :unprocessable_entity
+        render json: { errors: basket.errors.details }, status: :unprocessable_entity
         return
       end
     end
@@ -81,7 +80,7 @@ class WebApi::V1::BasketsIdeasController < ApplicationController
     authorize baskets_idea
     baskets_idea.assign_attributes baskets_idea_params_for_update
 
-    if baskets_idea.votes.nil?
+    if baskets_idea.votes.nil? || baskets_idea.votes == 0
       baskets_idea.destroy
       if baskets_idea.destroyed?
         SideFxBasketsIdeaService.new.after_destroy baskets_idea, current_user

--- a/back/app/policies/basket_policy.rb
+++ b/back/app/policies/basket_policy.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class BasketPolicy < ApplicationPolicy
+  # NOTE: If we change any of these, we also need to change BasketsIdeaPolicy
   def create?
     user&.active? &&
       (record.user_id == user.id) &&
@@ -21,7 +22,7 @@ class BasketPolicy < ApplicationPolicy
   end
 
   def destroy?
-    update?
+    create?
   end
 
   private

--- a/back/app/policies/basket_policy.rb
+++ b/back/app/policies/basket_policy.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class BasketPolicy < ApplicationPolicy
-  # NOTE: If we change any of these, we also need to change BasketsIdeaPolicy
   def create?
     user&.active? &&
       (record.user_id == user.id) &&
@@ -13,16 +12,17 @@ class BasketPolicy < ApplicationPolicy
     user&.active? && record.user_id == user.id
   end
 
+  # NOTE: If we change any of these, we also need to change BasketsIdeaPolicy
   def update?
     create?
   end
 
   def upsert?
-    create?
+    update?
   end
 
   def destroy?
-    create?
+    update?
   end
 
   private

--- a/back/app/policies/baskets_idea_policy.rb
+++ b/back/app/policies/baskets_idea_policy.rb
@@ -19,7 +19,7 @@ class BasketsIdeaPolicy < ApplicationPolicy
   end
 
   def create?
-    BasketPolicy.new(user, record.basket).update?
+    BasketPolicy.new(user, record.basket).create?
   end
 
   def update?
@@ -27,10 +27,10 @@ class BasketsIdeaPolicy < ApplicationPolicy
   end
 
   def destroy?
-    BasketPolicy.new(user, record.basket).update?
+    BasketPolicy.new(user, record.basket).destroy?
   end
 
   def upsert?
-    BasketPolicy.new(user, record.basket).update?
+    BasketPolicy.new(user, record.basket).upsert?
   end
 end

--- a/back/app/policies/baskets_idea_policy.rb
+++ b/back/app/policies/baskets_idea_policy.rb
@@ -19,7 +19,7 @@ class BasketsIdeaPolicy < ApplicationPolicy
   end
 
   def create?
-    BasketPolicy.new(user, record.basket).create?
+    BasketPolicy.new(user, record.basket).update?
   end
 
   def update?
@@ -27,10 +27,10 @@ class BasketsIdeaPolicy < ApplicationPolicy
   end
 
   def destroy?
-    BasketPolicy.new(user, record.basket).destroy?
+    BasketPolicy.new(user, record.basket).update?
   end
 
   def upsert?
-    BasketPolicy.new(user, record.basket).upsert?
+    BasketPolicy.new(user, record.basket).update?
   end
 end

--- a/back/spec/acceptance/baskets_ideas_spec.rb
+++ b/back/spec/acceptance/baskets_ideas_spec.rb
@@ -191,7 +191,7 @@ resource BasketsIdea do
           let!(:baskets_idea) { create(:baskets_idea, basket: basket, idea: idea) }
           let(:votes) { 0 }
 
-          example_request 'Delete an idea in an existing basket', document: false do
+          example_request 'Delete an idea in an existing basket' do
             assert_status 200
             expect(response_data[:id]).to eq baskets_idea.id
             expect(response_data.dig(:attributes, :votes)).to eq 0
@@ -203,7 +203,7 @@ resource BasketsIdea do
         context 'basket_idea does not exist and votes is set to nil' do
           let(:votes) { nil }
 
-          example_request 'Return the baskets_idea that was never persisted', document: false do
+          example_request 'Return the baskets_idea that was never persisted' do
             assert_status 200
             expect(response_data[:id]).to be_nil
             expect(response_data.dig(:attributes, :votes)).to be_nil

--- a/back/spec/acceptance/baskets_ideas_spec.rb
+++ b/back/spec/acceptance/baskets_ideas_spec.rb
@@ -187,6 +187,19 @@ resource BasketsIdea do
           end
         end
 
+        context 'basket_idea already exists and votes is set to zero' do
+          let!(:baskets_idea) { create(:baskets_idea, basket: basket, idea: idea) }
+          let(:votes) { 0 }
+
+          example_request 'Delete an idea in an existing basket', document: false do
+            assert_status 200
+            expect(response_data[:id]).to eq baskets_idea.id
+            expect(response_data.dig(:attributes, :votes)).to eq 0
+            expect(response_data.dig(:relationships, :idea, :data, :id)).to eq idea_id
+            expect { baskets_idea.reload }.to raise_error(ActiveRecord::RecordNotFound)
+          end
+        end
+
         context 'basket_idea does not exist and votes is set to nil' do
           let(:votes) { nil }
 

--- a/back/spec/factories/phases.rb
+++ b/back/spec/factories/phases.rb
@@ -20,8 +20,8 @@ FactoryBot.define do
     participation_method { 'ideation' }
     start_at { '2017-05-01' }
     end_at { Date.parse(start_at) + 60.days }
-    min_budget { 1 }
-    max_budget { 10_000 }
+    voting_min_total { 1 }
+    voting_max_total { 10_000 }
 
     transient do
       with_permissions { false }


### PR DESCRIPTION
The original PR got merged to the i1 branch before I'd finished making the review changes. This contains the small changes:

- correct error returned on basket save
- destroy on zero votes as well as nil
- comment in basket policy and updated to consistently point to the same method in each policy
