### PR TITLE
CL-3923 Voting terms for all

### DIFF
--- a/back/app/models/concerns/participation_context.rb
+++ b/back/app/models/concerns/participation_context.rb
@@ -144,6 +144,18 @@ module ParticipationContext
     instance_of?(Phase)
   end
 
+  def voting_term_singular_multiloc_with_fallback
+    MultilocService.new.i18n_to_multiloc('voting_method.default_voting_term_singular').merge(
+      voting_term_singular_multiloc || {}
+    )
+  end
+
+  def voting_term_plural_multiloc_with_fallback
+    MultilocService.new.i18n_to_multiloc('voting_method.default_voting_term_plural').merge(
+      voting_term_plural_multiloc || {}
+    )
+  end
+
   private
 
   def timeline_project?

--- a/back/app/serializers/web_api/v1/participation_context_serializer.rb
+++ b/back/app/serializers/web_api/v1/participation_context_serializer.rb
@@ -1,47 +1,52 @@
 # frozen_string_literal: true
 
-module WebApi::V1::ParticipationContextSerializer
-  extend ActiveSupport::Concern
+class WebApi::V1::ParticipationContextSerializer < WebApi::V1::BaseSerializer
   include DocumentAnnotation::WebApi::V1::DocumentAnnotationParticipationContextSerializer
   include Polls::WebApi::V1::PollParticipationContextSerializer
   include Surveys::WebApi::V1::SurveyParticipationContextSerializer
 
-  included do
-    with_options if: proc { |object|
-      object.participation_context?
-    } do
-      attribute :participation_method
-      attribute :posting_enabled
-      attribute :posting_method
-      attribute :posting_limited_max
-      attribute :commenting_enabled
-      attribute :reacting_enabled
-      attribute :reacting_like_method
-      attribute :reacting_like_limited_max
-      attribute :reacting_dislike_enabled
-      attribute :reacting_dislike_method
-      attribute :reacting_dislike_limited_max
-      attribute :allow_anonymous_participation
-      attribute :presentation_mode
-      attribute :ideas_order
-      attribute :input_term
-    end
+  with_options if: proc { |object|
+    object.participation_context?
+  } do
+    attribute :participation_method
+    attribute :posting_enabled
+    attribute :posting_method
+    attribute :posting_limited_max
+    attribute :commenting_enabled
+    attribute :reacting_enabled
+    attribute :reacting_like_method
+    attribute :reacting_like_limited_max
+    attribute :reacting_dislike_enabled
+    attribute :reacting_dislike_method
+    attribute :reacting_dislike_limited_max
+    attribute :allow_anonymous_participation
+    attribute :presentation_mode
+    attribute :ideas_order
+    attribute :input_term
+  end
 
-    with_options if: proc { |object|
-      object.participation_context? && object.voting?
-    } do
-      attribute :voting_method
-      attribute :voting_max_total
-      attribute :voting_min_total
-      attribute :voting_max_votes_per_idea
-      attribute :baskets_count
-      attribute :votes_count # TODO: Only show to moderators or when voting phase ended
-      attribute :voting_term_singular_multiloc do |item|
-        item.voting_term_singular_multiloc_with_fallback
-      end
-      attribute :voting_term_plural_multiloc do |item|
-        item.voting_term_plural_multiloc_with_fallback
-      end
+  with_options if: proc { |context|
+    context.participation_context? && context.voting?
+  } do
+    attribute :voting_method
+    attribute :voting_max_total
+    attribute :voting_min_total
+    attribute :voting_max_votes_per_idea
+    attribute :baskets_count
+    attribute :voting_term_singular_multiloc do |context|
+      context.voting_term_singular_multiloc_with_fallback
+    end
+    attribute :voting_term_plural_multiloc do |context|
+      context.voting_term_plural_multiloc_with_fallback
     end
   end
+
+  attribute :votes_count, if: proc { |context, params|
+    context.participation_context? \
+    && context.voting? \
+    && (
+      (current_user(params) && UserRoleService.new.can_moderate?(context, current_user(params))) \
+      || TimelineService.new.phase_is_complete?(context)
+    )
+  }
 end

--- a/back/app/serializers/web_api/v1/participation_context_serializer.rb
+++ b/back/app/serializers/web_api/v1/participation_context_serializer.rb
@@ -35,12 +35,12 @@ module WebApi::V1::ParticipationContextSerializer
       attribute :voting_min_total
       attribute :voting_max_votes_per_idea
       attribute :baskets_count
-      attribute :votes_count
+      attribute :votes_count # TODO: Only show to moderators or when voting phase ended
       attribute :voting_term_singular_multiloc do |item|
         item.voting_term_singular_multiloc_with_fallback
       end
-      attribute :voting_term_singular_multiloc do |item|
-        item.voting_term_singular_multiloc_with_fallback
+      attribute :voting_term_plural_multiloc do |item|
+        item.voting_term_plural_multiloc_with_fallback
       end
     end
   end

--- a/back/app/serializers/web_api/v1/participation_context_serializer.rb
+++ b/back/app/serializers/web_api/v1/participation_context_serializer.rb
@@ -25,14 +25,23 @@ module WebApi::V1::ParticipationContextSerializer
       attribute :presentation_mode
       attribute :ideas_order
       attribute :input_term
-      attribute :voting_method, if: proc { |object| object.voting? }
-      attribute :voting_max_total, if: proc { |object| object.voting? }
-      attribute :voting_min_total, if: proc { |object| object.voting? }
-      attribute :voting_max_votes_per_idea, if: proc { |object| object.voting? }
-      attribute :voting_term_singular_multiloc, if: proc { |object| object.voting? }
-      attribute :voting_term_plural_multiloc, if: proc { |object| object.voting? }
-      attribute :baskets_count, if: proc { |object| object.voting? }
-      attribute :votes_count, if: proc { |object| object.voting? }
+    end
+
+    with_options if: proc { |object|
+      object.participation_context? && object.voting?
+    } do
+      attribute :voting_method
+      attribute :voting_max_total
+      attribute :voting_min_total
+      attribute :voting_max_votes_per_idea
+      attribute :baskets_count
+      attribute :votes_count
+      attribute :voting_term_singular_multiloc do |item|
+        item.voting_term_singular_multiloc_with_fallback
+      end
+      attribute :voting_term_singular_multiloc do |item|
+        item.voting_term_singular_multiloc_with_fallback
+      end
     end
   end
 end

--- a/back/app/serializers/web_api/v1/phase_serializer.rb
+++ b/back/app/serializers/web_api/v1/phase_serializer.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class WebApi::V1::PhaseSerializer < WebApi::V1::BaseSerializer
-  include WebApi::V1::ParticipationContextSerializer
-
+class WebApi::V1::PhaseSerializer < WebApi::V1::ParticipationContextSerializer
   attributes :title_multiloc, :start_at, :end_at, :created_at, :updated_at, :ideas_count
 
   attribute :description_multiloc do |object|

--- a/back/app/serializers/web_api/v1/project_serializer.rb
+++ b/back/app/serializers/web_api/v1/project_serializer.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class WebApi::V1::ProjectSerializer < WebApi::V1::BaseSerializer
-  include WebApi::V1::ParticipationContextSerializer
-
+class WebApi::V1::ProjectSerializer < WebApi::V1::ParticipationContextSerializer
   attributes(
     :description_preview_multiloc,
     :title_multiloc,

--- a/back/lib/participation_method/voting.rb
+++ b/back/lib/participation_method/voting.rb
@@ -4,7 +4,7 @@ module ParticipationMethod
   class Voting < Ideation
     def assign_defaults_for_participation_context
       participation_context.ideas_order ||= 'random'
-      participation_context.voting_max_votes_per_idea = 1 if participation_context.voting_method == 'single_voting'
+      Factory.instance.voting_method_for(participation_context).assign_defaults_for_participation_context
     end
 
     def budget_in_form?(user)

--- a/back/lib/participation_method/voting.rb
+++ b/back/lib/participation_method/voting.rb
@@ -5,19 +5,6 @@ module ParticipationMethod
     def assign_defaults_for_participation_context
       participation_context.ideas_order ||= 'random'
       participation_context.voting_max_votes_per_idea = 1 if participation_context.voting_method == 'single_voting'
-
-      # Set the default voting term for multiple voting
-      if participation_context.voting_method == 'multiple_voting' &&
-         participation_context.voting_term_singular_multiloc.blank? &&
-         participation_context.voting_term_plural_multiloc.blank?
-
-        participation_context.voting_term_singular_multiloc = CL2_SUPPORTED_LOCALES.index_with do |locale|
-          I18n.t('voting_method.default_voting_term_singular', locale: locale)
-        end
-        participation_context.voting_term_plural_multiloc = CL2_SUPPORTED_LOCALES.index_with do |locale|
-          I18n.t('voting_method.default_voting_term_plural', locale: locale)
-        end
-      end
     end
 
     def budget_in_form?(user)

--- a/back/lib/voting_method/base.rb
+++ b/back/lib/voting_method/base.rb
@@ -6,6 +6,10 @@ module VotingMethod
       @participation_context = participation_context
     end
 
+    def assign_defaults_for_participation_context
+      # Default is to do nothing.
+    end
+
     def validate_participation_context
       # Default is to do nothing.
     end

--- a/back/lib/voting_method/multiple_voting.rb
+++ b/back/lib/voting_method/multiple_voting.rb
@@ -3,12 +3,6 @@
 module VotingMethod
   class MultipleVoting < Base
     def validate_participation_context
-      if participation_context.voting_term_singular_multiloc.blank? && participation_context.voting_term_plural_multiloc.present?
-        participation_context.errors.add :voting_term_singular_multiloc, :blank, message: 'singular voting term must be present with a plural voting term'
-      end
-      if participation_context.voting_term_singular_multiloc.present? && participation_context.voting_term_plural_multiloc.blank?
-        participation_context.errors.add :voting_term_plural_multiloc, :blank, message: 'plural voting term must be present with a singular voting term'
-      end
       if participation_context.voting_max_total.blank?
         participation_context.errors.add :voting_max_total, :blank, message: 'voting max total is blank'
       end

--- a/back/lib/voting_method/single_voting.rb
+++ b/back/lib/voting_method/single_voting.rb
@@ -2,6 +2,10 @@
 
 module VotingMethod
   class SingleVoting < Base
+    def assign_defaults_for_participation_context
+      participation_context.voting_max_votes_per_idea = 1
+    end
+
     def validate_participation_context
       if participation_context.voting_max_votes_per_idea != 1
         participation_context.errors.add :voting_max_votes_per_idea, :invalid, message: 'voting_max_votes_per_idea must be 1'

--- a/back/spec/acceptance/phases_spec.rb
+++ b/back/spec/acceptance/phases_spec.rb
@@ -194,8 +194,8 @@ resource 'Phases' do
             expect(response_data.dig(:attributes, :voting_max_total)).to eq 10
             expect(response_data.dig(:attributes, :voting_min_total)).to eq 0
             expect(response_data.dig(:attributes, :voting_max_votes_per_idea)).to eq 5
-            expect(response_data.dig(:attributes, :voting_term_singular_multiloc)).to eq({ en: 'bean' })
-            expect(response_data.dig(:attributes, :voting_term_plural_multiloc)).to eq({ en: 'beans' })
+            expect(response_data.dig(:attributes, :voting_term_singular_multiloc, :en)).to eq 'bean'
+            expect(response_data.dig(:attributes, :voting_term_plural_multiloc, :en)).to eq 'beans'
             expect(response_data.dig(:attributes, :ideas_order)).to eq 'random'
           end
         end
@@ -427,8 +427,8 @@ resource 'Phases' do
           expect(json_response.dig(:data, :attributes, :voting_min_total)).to eq 3
           expect(json_response.dig(:data, :attributes, :voting_max_total)).to eq 15
           expect(json_response.dig(:data, :attributes, :voting_max_votes_per_idea)).to eq 1
-          expect(json_response.dig(:data, :attributes, :voting_term_singular_multiloc)).to eq({ en: 'Grocery shopping' })
-          expect(json_response.dig(:data, :attributes, :voting_term_plural_multiloc)).to eq({ en: 'Groceries shoppings' })
+          expect(json_response.dig(:data, :attributes, :voting_term_singular_multiloc, :en)).to eq 'Grocery shopping'
+          expect(json_response.dig(:data, :attributes, :voting_term_plural_multiloc, :en)).to eq 'Groceries shoppings'
         end
       end
 

--- a/back/spec/acceptance/projects_spec.rb
+++ b/back/spec/acceptance/projects_spec.rb
@@ -412,8 +412,8 @@ resource 'Projects' do
               expect(response_data.dig(:attributes, :voting_max_total)).to eq 10
               expect(response_data.dig(:attributes, :voting_min_total)).to eq 0
               expect(response_data.dig(:attributes, :voting_max_votes_per_idea)).to eq 5
-              expect(response_data.dig(:attributes, :voting_term_singular_multiloc)).to eq({ en: 'bean' })
-              expect(response_data.dig(:attributes, :voting_term_plural_multiloc)).to eq({ en: 'beans' })
+              expect(response_data.dig(:attributes, :voting_term_singular_multiloc, :en)).to eq 'bean'
+              expect(response_data.dig(:attributes, :voting_term_plural_multiloc, :en)).to eq 'beans'
               expect(response_data.dig(:attributes, :ideas_order)).to eq 'random'
               expect(response_data.dig(:attributes, :baskets_count)).to eq 0
             end
@@ -643,8 +643,8 @@ resource 'Projects' do
           expect(json_response.dig(:data, :attributes, :voting_min_total)).to eq 3
           expect(json_response.dig(:data, :attributes, :voting_max_total)).to eq 15
           expect(json_response.dig(:data, :attributes, :voting_max_votes_per_idea)).to eq 1
-          expect(json_response.dig(:data, :attributes, :voting_term_singular_multiloc)).to eq({ en: 'Grocery shopping' })
-          expect(json_response.dig(:data, :attributes, :voting_term_plural_multiloc)).to eq({ en: 'Groceries shoppings' })
+          expect(json_response.dig(:data, :attributes, :voting_term_singular_multiloc, :en)).to eq 'Grocery shopping'
+          expect(json_response.dig(:data, :attributes, :voting_term_plural_multiloc, :en)).to eq 'Groceries shoppings'
         end
       end
 

--- a/back/spec/fixtures/locales/en.yml
+++ b/back/spec/fixtures/locales/en.yml
@@ -64,5 +64,5 @@ en:
   xlsx_export:
     anonymous: "Anonymous"
   voting_method:
-    default_voting_term_singular: "vote"
-    default_voting_term_plural: "votes"
+    default_voting_term_singular: Vote
+    default_voting_term_plural: Votes

--- a/back/spec/fixtures/locales/fr-FR.yml
+++ b/back/spec/fixtures/locales/fr-FR.yml
@@ -59,3 +59,6 @@ fr:
           title: Quel est votre problème ?
         option:
           title: Quelle est votre option ?
+  voting_method:
+    default_voting_term_singular: Vote
+    default_voting_term_plural: Votes

--- a/back/spec/fixtures/locales/nl-NL.yml
+++ b/back/spec/fixtures/locales/nl-NL.yml
@@ -59,3 +59,6 @@ nl:
           title: Wat is je probleem?
         option:
           title: Wat is je optie?
+  voting_method:
+    default_voting_term_singular: Stem
+    default_voting_term_plural: Stemmen

--- a/back/spec/lib/participation_method/voting_spec.rb
+++ b/back/spec/lib/participation_method/voting_spec.rb
@@ -17,51 +17,6 @@ RSpec.describe ParticipationMethod::Voting do
         expect(context.ideas_order).to eq 'random'
       end
     end
-
-    describe 'voting_term_singular_multiloc_with_fallback' do
-      it "falls back to the translations when there's no title_multiloc" do
-        item = create(:phase, voting_term_singular_multiloc: nil)
-        expect(item.voting_term_singular_multiloc_with_fallback).to match({ 'en' => 'Vote', 'fr-FR' => 'Vote', 'nl-NL' => 'Stem' })
-      end
-
-      it 'returns the custom copy for locales with custom copy and falls back to the translations for other locales' do
-        item = create(:phase, voting_term_singular_multiloc: { 'nl-NL' => 'Voorkeur' })
-        expect(item.voting_term_singular_multiloc_with_fallback).to match({ 'en' => 'Vote', 'fr-FR' => 'Vote', 'nl-NL' => 'Voorkeur' })
-      end
-    end
-
-    describe 'voting_term_plural_multiloc_with_fallback' do
-      it "falls back to the translations when there's no title_multiloc" do
-        item = create(:phase, voting_term_plural_multiloc: nil)
-        expect(item.voting_term_plural_multiloc_with_fallback).to match({ 'en' => 'Votes', 'fr-FR' => 'Votes', 'nl-NL' => 'Stemmen' })
-      end
-
-      it 'returns the custom copy for locales with custom copy and falls back to the translations for other locales' do
-        item = create(:phase, voting_term_plural_multiloc: { 'en' => 'Preferences' })
-        expect(item.voting_term_plural_multiloc_with_fallback).to match({ 'en' => 'Preferences', 'fr-FR' => 'Votes', 'nl-NL' => 'Stemmen' })
-      end
-    end
-
-    context 'multiple voting' do
-      let(:context) { build(:continuous_multiple_voting_project) }
-
-      it 'sets a default voting term of "vote", posting method to unlimited and ideas order to random' do
-        participation_method.assign_defaults_for_participation_context
-        expect(context.posting_method).to eq 'unlimited'
-        expect(context.ideas_order).to eq 'random'
-      end
-    end
-
-    context 'single voting' do
-      let(:context) { build(:continuous_single_voting_project) }
-
-      it 'sets voting_max_votes_per_idea to 1, posting method to unlimited and ideas order to random' do
-        participation_method.assign_defaults_for_participation_context
-        expect(context.voting_max_votes_per_idea).to eq 1
-        expect(context.posting_method).to eq 'unlimited'
-        expect(context.ideas_order).to eq 'random'
-      end
-    end
   end
 
   describe '#assign_slug' do

--- a/back/spec/lib/participation_method/voting_spec.rb
+++ b/back/spec/lib/participation_method/voting_spec.rb
@@ -18,13 +18,35 @@ RSpec.describe ParticipationMethod::Voting do
       end
     end
 
+    describe 'voting_term_singular_multiloc_with_fallback' do
+      it "falls back to the translations when there's no title_multiloc" do
+        item = create(:phase, voting_term_singular_multiloc: nil)
+        expect(item.voting_term_singular_multiloc_with_fallback).to match({ 'en' => 'Vote', 'fr-FR' => 'Vote', 'nl-NL' => 'Stem' })
+      end
+
+      it 'returns the custom copy for locales with custom copy and falls back to the translations for other locales' do
+        item = create(:phase, voting_term_singular_multiloc: { 'nl-NL' => 'Voorkeur' })
+        expect(item.voting_term_singular_multiloc_with_fallback).to match({ 'en' => 'Vote', 'fr-FR' => 'Vote', 'nl-NL' => 'Voorkeur' })
+      end
+    end
+
+    describe 'voting_term_plural_multiloc_with_fallback' do
+      it "falls back to the translations when there's no title_multiloc" do
+        item = create(:phase, voting_term_plural_multiloc: nil)
+        expect(item.voting_term_plural_multiloc_with_fallback).to match({ 'en' => 'Votes', 'fr-FR' => 'Votes', 'nl-NL' => 'Stemmen' })
+      end
+
+      it 'returns the custom copy for locales with custom copy and falls back to the translations for other locales' do
+        item = create(:phase, voting_term_plural_multiloc: { 'en' => 'Preferences' })
+        expect(item.voting_term_plural_multiloc_with_fallback).to match({ 'en' => 'Preferences', 'fr-FR' => 'Votes', 'nl-NL' => 'Stemmen' })
+      end
+    end
+
     context 'multiple voting' do
       let(:context) { build(:continuous_multiple_voting_project) }
 
       it 'sets a default voting term of "vote", posting method to unlimited and ideas order to random' do
         participation_method.assign_defaults_for_participation_context
-        expect(context.voting_term_singular_multiloc['en']).to eq 'vote'
-        expect(context.voting_term_plural_multiloc['en']).to eq 'votes'
         expect(context.posting_method).to eq 'unlimited'
         expect(context.ideas_order).to eq 'random'
       end

--- a/back/spec/lib/voting_method/budgeting_spec.rb
+++ b/back/spec/lib/voting_method/budgeting_spec.rb
@@ -7,6 +7,16 @@ RSpec.describe VotingMethod::Budgeting do
 
   let(:project) { build(:continuous_budgeting_project) }
 
+  describe '#assign_defaults_for_participation_context' do
+    let(:context) { build(:continuous_budgeting_project) }
+
+    it 'does not change voting_max_votes_per_idea' do
+      project.voting_max_votes_per_idea = 3
+      voting_method.assign_defaults_for_participation_context
+      expect(project.voting_max_votes_per_idea).to eq 3
+    end
+  end
+
   describe '#validate_participation_context' do
     it 'sets no errors when voting_max_total and voting_min_total are present' do
       project.voting_max_total = 10

--- a/back/spec/lib/voting_method/multiple_voting_spec.rb
+++ b/back/spec/lib/voting_method/multiple_voting_spec.rb
@@ -7,13 +7,6 @@ RSpec.describe VotingMethod::MultipleVoting do
 
   let(:project) { create(:continuous_multiple_voting_project) }
 
-  describe '#initialize' do
-    it 'sets a default voting term of "vote"' do
-      expect(project.voting_term_singular_multiloc['en']).to eq 'vote'
-      expect(project.voting_term_plural_multiloc['en']).to eq 'votes'
-    end
-  end
-
   describe '#validate_participation_context' do
     it 'sets no errors when voting_max_total is present' do
       project.voting_max_total = 10
@@ -26,22 +19,6 @@ RSpec.describe VotingMethod::MultipleVoting do
       voting_method.validate_participation_context
       expect(project.errors.details).to eq(
         voting_max_total: [error: :blank]
-      )
-    end
-
-    it 'sets an error when voting term singular is set and voting term plural is not' do
-      project.voting_term_plural_multiloc = nil
-      voting_method.validate_participation_context
-      expect(project.errors.details).to eq(
-        voting_term_plural_multiloc: [error: :blank]
-      )
-    end
-
-    it 'sets an error when voting term plural is set and voting term singular is not' do
-      project.voting_term_singular_multiloc = nil
-      voting_method.validate_participation_context
-      expect(project.errors.details).to eq(
-        voting_term_singular_multiloc: [error: :blank]
       )
     end
   end

--- a/back/spec/lib/voting_method/multiple_voting_spec.rb
+++ b/back/spec/lib/voting_method/multiple_voting_spec.rb
@@ -7,6 +7,16 @@ RSpec.describe VotingMethod::MultipleVoting do
 
   let(:project) { create(:continuous_multiple_voting_project) }
 
+  describe '#assign_defaults_for_participation_context' do
+    let(:context) { build(:continuous_multiple_voting_project) }
+
+    it 'does not change voting_max_votes_per_idea' do
+      project.voting_max_votes_per_idea = 3
+      voting_method.assign_defaults_for_participation_context
+      expect(project.voting_max_votes_per_idea).to eq 3
+    end
+  end
+
   describe '#validate_participation_context' do
     it 'sets no errors when voting_max_total is present' do
       project.voting_max_total = 10

--- a/back/spec/lib/voting_method/single_voting_spec.rb
+++ b/back/spec/lib/voting_method/single_voting_spec.rb
@@ -7,8 +7,12 @@ RSpec.describe VotingMethod::SingleVoting do
 
   let(:project) { create(:continuous_single_voting_project) }
 
-  describe '#initialize' do
-    it 'has max_votes_per_idea to 1' do
+  describe '#assign_defaults_for_participation_context' do
+    let(:context) { build(:continuous_single_voting_project) }
+
+    it 'sets voting_max_votes_per_idea to 1' do
+      project.voting_max_votes_per_idea = 3
+      voting_method.assign_defaults_for_participation_context
       expect(project.voting_max_votes_per_idea).to eq 1
     end
   end

--- a/back/spec/models/phase_spec.rb
+++ b/back/spec/models/phase_spec.rb
@@ -20,6 +20,30 @@ RSpec.describe Phase do
     end
   end
 
+  describe 'voting_term_singular_multiloc_with_fallback' do
+    it "falls back to the translations when there's no title_multiloc" do
+      item = create(:phase, voting_term_singular_multiloc: nil)
+      expect(item.voting_term_singular_multiloc_with_fallback).to match({ 'en' => 'Vote', 'fr-FR' => 'Vote', 'nl-NL' => 'Stem' })
+    end
+
+    it 'returns the custom copy for locales with custom copy and falls back to the translations for other locales' do
+      item = create(:phase, voting_term_singular_multiloc: { 'nl-NL' => 'Voorkeur' })
+      expect(item.voting_term_singular_multiloc_with_fallback).to match({ 'en' => 'Vote', 'fr-FR' => 'Vote', 'nl-NL' => 'Voorkeur' })
+    end
+  end
+
+  describe 'voting_term_plural_multiloc_with_fallback' do
+    it "falls back to the translations when there's no title_multiloc" do
+      item = create(:phase, voting_term_plural_multiloc: nil)
+      expect(item.voting_term_plural_multiloc_with_fallback).to match({ 'en' => 'Votes', 'fr-FR' => 'Votes', 'nl-NL' => 'Stemmen' })
+    end
+
+    it 'returns the custom copy for locales with custom copy and falls back to the translations for other locales' do
+      item = create(:phase, voting_term_plural_multiloc: { 'en' => 'Preferences' })
+      expect(item.voting_term_plural_multiloc_with_fallback).to match({ 'en' => 'Preferences', 'fr-FR' => 'Votes', 'nl-NL' => 'Stemmen' })
+    end
+  end
+
   describe 'timing validation' do
     it 'succeeds when start_at and end_at are equal' do
       phase = build(:phase)

--- a/back/spec/serializers/web_api/v1/participation_context_serializer_spec.rb
+++ b/back/spec/serializers/web_api/v1/participation_context_serializer_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe WebApi::V1::ParticipationContextSerializer do
+  let(:result) { described_class.new(context, params: { current_user: user }).serializable_hash }
+
+  context 'for a continuous voting project' do
+    let(:context) { create(:continuous_single_voting_project, baskets_count: 4, votes_count: 7) }
+
+    context 'when moderator' do
+      let(:user) { create(:project_moderator, projects: [context]) }
+
+      it 'includes the baskets_count and votes_count' do
+        expect(result.dig(:data, :attributes, :baskets_count)).to eq 4
+        expect(result.dig(:data, :attributes, :votes_count)).to eq 7
+      end
+    end
+
+    context 'when resident' do
+      let(:user) { create(:user) }
+
+      it 'includes the baskets_count but not the votes_count' do
+        expect(result.dig(:data, :attributes, :baskets_count)).to eq 4
+        expect(result.dig(:data, :attributes, :votes_count)).to be_nil
+      end
+    end
+  end
+
+  context 'for a past phase' do
+    let(:context) { create(:voting_phase, start_at: Time.zone.today - 5.days, end_at: Time.zone.today - 2.days, baskets_count: 4, votes_count: 7) }
+
+    context 'when moderator' do
+      let(:user) { create(:project_moderator, projects: [context.project]) }
+
+      it 'includes the baskets_count and votes_count' do
+        expect(result.dig(:data, :attributes, :baskets_count)).to eq 4
+        expect(result.dig(:data, :attributes, :votes_count)).to eq 7
+      end
+    end
+
+    context 'when resident' do
+      let(:user) { create(:user) }
+
+      it 'includes the baskets_count and votes_count' do
+        expect(result.dig(:data, :attributes, :baskets_count)).to eq 4
+        expect(result.dig(:data, :attributes, :votes_count)).to eq 7
+      end
+    end
+  end
+
+  context 'for an active phase' do
+    let(:context) { create(:voting_phase, start_at: Time.zone.today - 5.days, end_at: Time.zone.today + 5.days, baskets_count: 4, votes_count: 7) }
+
+    context 'when moderator' do
+      let(:user) { create(:project_moderator, projects: [context.project]) }
+
+      it 'includes the baskets_count and votes_count' do
+        expect(result.dig(:data, :attributes, :baskets_count)).to eq 4
+        expect(result.dig(:data, :attributes, :votes_count)).to eq 7
+      end
+    end
+
+    context 'when resident' do
+      let(:user) { create(:user) }
+
+      it 'includes the baskets_count but not the votes_count' do
+        expect(result.dig(:data, :attributes, :baskets_count)).to eq 4
+        expect(result.dig(:data, :attributes, :votes_count)).to be_nil
+      end
+    end
+  end
+
+  context 'for a future phase' do
+    let(:context) { create(:voting_phase, start_at: Time.zone.today + 2.days, end_at: Time.zone.today + 5.days, baskets_count: 4, votes_count: 7) }
+
+    context 'when moderator' do
+      let(:user) { create(:project_moderator, projects: [context.project]) }
+
+      it 'includes the baskets_count and votes_count' do
+        expect(result.dig(:data, :attributes, :baskets_count)).to eq 4
+        expect(result.dig(:data, :attributes, :votes_count)).to eq 7
+      end
+    end
+
+    context 'when resident' do
+      let(:user) { create(:user) }
+
+      it 'includes the baskets_count but not the votes_count' do
+        expect(result.dig(:data, :attributes, :baskets_count)).to eq 4
+        expect(result.dig(:data, :attributes, :votes_count)).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
- The default voting terms use a dynamic fallback and are available for all voting/participation methods.
- Hide the `votes_count` when the phase is not finished yet (or when continuous project) for residents. Moderators can always get the `votes_count`.