### PR TITLE
[CL-3874] Refactor after_update to use new method

### DIFF
--- a/back/engines/free/email_campaigns/app/services/email_campaigns/side_fx_campaign_service.rb
+++ b/back/engines/free/email_campaigns/app/services/email_campaigns/side_fx_campaign_service.rb
@@ -14,10 +14,7 @@ module EmailCampaigns
       return unless campaign.saved_change_to_enabled? &&
                     campaign.instance_of?(EmailCampaigns::Campaigns::ProjectPhaseStarted)
 
-      Phase.update_all(
-        "campaigns_settings = jsonb_set(campaigns_settings, array['project_phase_started']," \
-        "to_jsonb(#{campaign.enabled}));"
-      )
+      toggle_project_phase_started(campaign)
     end
 
     def before_send(campaign, user); end
@@ -32,6 +29,13 @@ module EmailCampaigns
 
     def resource_name
       :campaign
+    end
+
+    def toggle_project_phase_started(campaign)
+      Phase.update_all(
+        "campaigns_settings = jsonb_set(campaigns_settings, array['project_phase_started']," \
+        "to_jsonb(#{campaign.enabled}));"
+      )
     end
   end
 end


### PR DESCRIPTION
# Changelog
## Technical
- [CL-3784] Small refactor of side_fx_campaign_service `after_update` method


[CL-3784]: https://citizenlab.atlassian.net/browse/CL-3784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ