### PR TITLE
[CL-3874] Temporary fix

### DIFF
--- a/back/app/models/phase.rb
+++ b/back/app/models/phase.rb
@@ -124,6 +124,8 @@ class Phase < ApplicationRecord
   # I merged BE work for this feature too soon, and we need to wait for FE part (awaiting translations).
   # This fix will be removed as soon as FE part is merged. [Simon T., 14/07/2021]
   def temporary_validation_fix
+    return if campaigns_settings.present?
+
     enabled = EmailCampaigns::Campaign.find_by(type: 'EmailCampaigns::Campaigns::ProjectPhaseStarted')&.enabled
 
     self.campaigns_settings = { project_phase_started: enabled }

--- a/back/app/models/phase.rb
+++ b/back/app/models/phase.rb
@@ -60,6 +60,7 @@ class Phase < ApplicationRecord
 
   before_validation :sanitize_description_multiloc
   before_validation :strip_title
+  before_validation :temporary_validation_fix
   before_destroy :remove_notifications # Must occur before has_many :notifications (see https://github.com/rails/rails/issues/5205)
   has_many :notifications, dependent: :nullify
 
@@ -117,6 +118,15 @@ class Phase < ApplicationRecord
     )
     self.description_multiloc = service.remove_multiloc_empty_trailing_tags(description_multiloc)
     self.description_multiloc = service.linkify_multiloc(description_multiloc)
+  end
+
+  # Temporary fix for new toggle of project_phase_started campaign at phase-level.
+  # I merged BE work for this feature too soon, and we need to wait for FE part (awaiting translations).
+  # This fix will be removed as soon as FE part is merged. [Simon T., 14/07/2021]
+  def temporary_validation_fix
+    enabled = EmailCampaigns::Campaign.find_by(type: 'EmailCampaigns::Campaigns::ProjectPhaseStarted')&.enabled
+
+    self.campaigns_settings = { project_phase_started: enabled }
   end
 
   def validate_campaigns_settings_keys_and_values


### PR DESCRIPTION
Temporary fix for new toggle of project_phase_started campaign at phase-level.
I merged BE work for this feature too soon, and we need to wait for FE part (awaiting translations).
This fix will be removed as soon as FE part is merged. [Simon T., 14/07/2023]

# Changelog
## Technical
- [CL-3874] Temporary fix of project_phase_started phase-level toggle.


[CL-3874]: https://citizenlab.atlassian.net/browse/CL-3874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ