### PR TITLE
CL-3715 - Phase voting counts

### DIFF
--- a/back/app/controllers/web_api/v1/ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/ideas_controller.rb
@@ -91,11 +91,11 @@ class WebApi::V1::IdeasController < ApplicationController
     }
     attributes = %w[idea_status_id topic_id]
     all_ideas.published
-             .joins('FULL OUTER JOIN ideas_topics ON ideas_topics.idea_id = ideas.id')
-             .select('idea_status_id, ideas_topics.topic_id, COUNT(DISTINCT(ideas.id)) as count')
-             .reorder(nil) # Avoids SQL error on GROUP BY when a search string was used
-             .group('GROUPING SETS (idea_status_id, ideas_topics.topic_id)')
-             .each do |record|
+      .joins('FULL OUTER JOIN ideas_topics ON ideas_topics.idea_id = ideas.id')
+      .select('idea_status_id, ideas_topics.topic_id, COUNT(DISTINCT(ideas.id)) as count')
+      .reorder(nil) # Avoids SQL error on GROUP BY when a search string was used
+      .group('GROUPING SETS (idea_status_id, ideas_topics.topic_id)')
+      .each do |record|
       attributes.each do |attribute|
         id = record.send attribute
         counts[attribute][id] = record.count if id
@@ -130,10 +130,10 @@ class WebApi::V1::IdeasController < ApplicationController
     end
 
     participation_context = if is_moderator && phase_ids.any?
-                              Phase.find(phase_ids.first)
-                            else
-                              ParticipationContextService.new.get_participation_context(project)
-                            end
+      Phase.find(phase_ids.first)
+    else
+      ParticipationContextService.new.get_participation_context(project)
+    end
     send_error and return unless participation_context
 
     participation_method = Factory.instance.participation_method_for(participation_context)

--- a/back/app/services/sort_by_params_service.rb
+++ b/back/app/services/sort_by_params_service.rb
@@ -28,10 +28,10 @@ class SortByParamsService
     when '-likes_count' then scope.order(likes_count: :asc)
     when 'dislikes_count' then scope.order(dislikes_count: :desc)
     when '-dislikes_count' then scope.order(dislikes_count: :asc)
-    when 'baskets_count' then scope.order(baskets_count: :desc)
-    when '-baskets_count' then scope.order(baskets_count: :asc)
-    when 'votes_count' then scope.order(votes_count: :desc)
-    when '-votes_count' then scope.order(votes_count: :asc)
+    when 'baskets_count' then idea_voting_count_sort(scope, 'baskets_count', params[:phase], 'desc')
+    when '-baskets_count' then idea_voting_count_sort(scope, 'baskets_count', params[:phase], 'asc')
+    when 'votes_count' then idea_voting_count_sort(scope, 'votes_count', params[:phase], 'desc')
+    when '-votes_count' then idea_voting_count_sort(scope, 'votes_count', params[:phase], 'asc')
     when 'comments_count' then scope.order(comments_count: :desc)
     when '-comments_count' then scope.order(comments_count: :asc)
     when 'budget' then scope.order(budget: :desc)
@@ -73,6 +73,17 @@ class SortByParamsService
     when '-acted_at' then scope.order(acted_at: :asc)
     else
       raise "Unsupported sorting parameter #{params[:sort]}"
+    end
+  end
+
+  private
+
+  def idea_voting_count_sort(scope, sort, phase_id, direction)
+    if phase_id
+      ids = IdeasPhase.where(phase_id: phase_id).order("#{sort} #{direction}").pluck(:idea_id)
+      Idea.unscoped.where(id: ids).order_as_specified(id: ids)
+    else
+      scope.order("#{sort} #{direction}")
     end
   end
 end

--- a/back/spec/acceptance/ideas_spec.rb
+++ b/back/spec/acceptance/ideas_spec.rb
@@ -285,7 +285,7 @@ resource 'Ideas' do
           expect(status).to eq(200)
         end
 
-        example 'List all ideas in a phase of a project - ideas_phase baskets_count and votes_count is returned' do
+        example 'List all ideas in a phase of a project - baskets_count and votes_count are overwritten with values from ideas_phase' do
           pr = create(:project_with_active_budgeting_phase)
           phase = pr.phases.first
           ideas = create_list(:idea, 2, phases: [phase], project: pr)
@@ -312,7 +312,7 @@ resource 'Ideas' do
           expect(ideas_phases[0][:attributes][:baskets_count]).to eq 2
           expect(ideas_phases[1][:attributes][:baskets_count]).to eq 2
 
-          # Check the value in idea has also changed
+          # Check the value in idea has also been overwritten
           expect(ideas[0].reload[:baskets_count]).to eq 3
           expect(response_data[0][:attributes][:baskets_count]).to eq 2
         end
@@ -563,49 +563,49 @@ resource 'Ideas' do
         expect(json_response.dig(:data, :id)).to eq idea.id
         expect(json_response.dig(:data, :type)).to eq 'idea'
         expect(json_response.dig(:data, :attributes)).to include(
-          slug: idea.slug,
-          budget: idea.budget,
-          action_descriptor: {
-            commenting_idea: {
-              enabled: true,
-              disabled_reason: nil,
-              future_enabled: nil
-            },
-            reacting_idea: {
-              enabled: true,
-              disabled_reason: nil,
-              cancelling_enabled: true,
-              up: {
-                enabled: true,
-                disabled_reason: nil,
-                future_enabled: nil
-              },
-              down: {
-                enabled: true,
-                disabled_reason: nil,
-                future_enabled: nil
-              }
-            },
-            comment_reacting_idea: {
-              enabled: true,
-              disabled_reason: nil,
-              future_enabled: nil
-            },
-            voting: {
-              enabled: false,
-              disabled_reason: 'not_voting',
-              future_enabled: nil
-            }
-          }
-        )
+                                                           slug: idea.slug,
+                                                           budget: idea.budget,
+                                                           action_descriptor: {
+                                                             commenting_idea: {
+                                                               enabled: true,
+                                                               disabled_reason: nil,
+                                                               future_enabled: nil
+                                                             },
+                                                             reacting_idea: {
+                                                               enabled: true,
+                                                               disabled_reason: nil,
+                                                               cancelling_enabled: true,
+                                                               up: {
+                                                                 enabled: true,
+                                                                 disabled_reason: nil,
+                                                                 future_enabled: nil
+                                                               },
+                                                               down: {
+                                                                 enabled: true,
+                                                                 disabled_reason: nil,
+                                                                 future_enabled: nil
+                                                               }
+                                                             },
+                                                             comment_reacting_idea: {
+                                                               enabled: true,
+                                                               disabled_reason: nil,
+                                                               future_enabled: nil
+                                                             },
+                                                             voting: {
+                                                               enabled: false,
+                                                               disabled_reason: 'not_voting',
+                                                               future_enabled: nil
+                                                             }
+                                                           }
+                                                         )
         expect(json_response.dig(:data, :relationships)).to include(
-          topics: {
-            data: [{ id: topic.id, type: 'topic' }]
-          },
-          author: { data: { id: idea.author_id, type: 'user' } },
-          idea_status: { data: { id: idea.idea_status_id, type: 'idea_status' } },
-          user_reaction: { data: { id: user_reaction.id, type: 'reaction' } }
-        )
+                                                              topics: {
+                                                                data: [{ id: topic.id, type: 'topic' }]
+                                                              },
+                                                              author: { data: { id: idea.author_id, type: 'user' } },
+                                                              idea_status: { data: { id: idea.idea_status_id, type: 'idea_status' } },
+                                                              user_reaction: { data: { id: user_reaction.id, type: 'reaction' } }
+                                                            )
       end
     end
 
@@ -911,7 +911,7 @@ resource 'Ideas' do
 
           before do
             project.permissions.find_by(action: 'posting_idea')
-              .update!(permitted_by: 'groups', groups: [group])
+                   .update!(permitted_by: 'groups', groups: [group])
           end
 
           example '[error] Create an idea in a project with groups posting permission', document: false do

--- a/back/spec/acceptance/ideas_spec.rb
+++ b/back/spec/acceptance/ideas_spec.rb
@@ -563,49 +563,49 @@ resource 'Ideas' do
         expect(json_response.dig(:data, :id)).to eq idea.id
         expect(json_response.dig(:data, :type)).to eq 'idea'
         expect(json_response.dig(:data, :attributes)).to include(
-                                                           slug: idea.slug,
-                                                           budget: idea.budget,
-                                                           action_descriptor: {
-                                                             commenting_idea: {
-                                                               enabled: true,
-                                                               disabled_reason: nil,
-                                                               future_enabled: nil
-                                                             },
-                                                             reacting_idea: {
-                                                               enabled: true,
-                                                               disabled_reason: nil,
-                                                               cancelling_enabled: true,
-                                                               up: {
-                                                                 enabled: true,
-                                                                 disabled_reason: nil,
-                                                                 future_enabled: nil
-                                                               },
-                                                               down: {
-                                                                 enabled: true,
-                                                                 disabled_reason: nil,
-                                                                 future_enabled: nil
-                                                               }
-                                                             },
-                                                             comment_reacting_idea: {
-                                                               enabled: true,
-                                                               disabled_reason: nil,
-                                                               future_enabled: nil
-                                                             },
-                                                             voting: {
-                                                               enabled: false,
-                                                               disabled_reason: 'not_voting',
-                                                               future_enabled: nil
-                                                             }
-                                                           }
-                                                         )
+          slug: idea.slug,
+          budget: idea.budget,
+          action_descriptor: {
+            commenting_idea: {
+              enabled: true,
+              disabled_reason: nil,
+              future_enabled: nil
+            },
+            reacting_idea: {
+              enabled: true,
+              disabled_reason: nil,
+              cancelling_enabled: true,
+              up: {
+                enabled: true,
+                disabled_reason: nil,
+                future_enabled: nil
+              },
+              down: {
+                enabled: true,
+                disabled_reason: nil,
+                future_enabled: nil
+              }
+            },
+            comment_reacting_idea: {
+              enabled: true,
+              disabled_reason: nil,
+              future_enabled: nil
+            },
+            voting: {
+              enabled: false,
+              disabled_reason: 'not_voting',
+              future_enabled: nil
+            }
+          }
+        )
         expect(json_response.dig(:data, :relationships)).to include(
-                                                              topics: {
-                                                                data: [{ id: topic.id, type: 'topic' }]
-                                                              },
-                                                              author: { data: { id: idea.author_id, type: 'user' } },
-                                                              idea_status: { data: { id: idea.idea_status_id, type: 'idea_status' } },
-                                                              user_reaction: { data: { id: user_reaction.id, type: 'reaction' } }
-                                                            )
+          topics: {
+            data: [{ id: topic.id, type: 'topic' }]
+          },
+          author: { data: { id: idea.author_id, type: 'user' } },
+          idea_status: { data: { id: idea.idea_status_id, type: 'idea_status' } },
+          user_reaction: { data: { id: user_reaction.id, type: 'reaction' } }
+        )
       end
     end
 
@@ -911,7 +911,7 @@ resource 'Ideas' do
 
           before do
             project.permissions.find_by(action: 'posting_idea')
-                   .update!(permitted_by: 'groups', groups: [group])
+              .update!(permitted_by: 'groups', groups: [group])
           end
 
           example '[error] Create an idea in a project with groups posting permission', document: false do

--- a/back/spec/factories/ideas_phases.rb
+++ b/back/spec/factories/ideas_phases.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :ideas_phase do
+    idea
+    phase
+    votes_count { 0 }
+    baskets_count { 0 }
+  end
+end


### PR DESCRIPTION
Two changes:
- If ideas are filtered by a phase then overwrite the baskets_count and votes_count with the counts from the ideas_phase. This massively simplifies what we need to do in the front end
- When sorting by baskets and votes counts, use the value in ideas_phase for this too
