### PR TITLE
[CL-3941] Add query parameter to filter projects by topics (public API)

### DIFF
--- a/back/engines/commercial/public_api/app/controllers/public_api/v2/projects_controller.rb
+++ b/back/engines/commercial/public_api/app/controllers/public_api/v2/projects_controller.rb
@@ -19,7 +19,7 @@ module PublicApi
     private
 
     def finder_params
-      params.permit(:folder_id, :publication_status).to_h.tap do |params|
+      params.permit(:folder_id, :publication_status, topic_ids: []).to_h.tap do |params|
         if params[:publication_status]
           validate_publication_status!(params[:publication_status])
         end

--- a/back/engines/commercial/public_api/app/finders/public_api/projects_finder.rb
+++ b/back/engines/commercial/public_api/app/finders/public_api/projects_finder.rb
@@ -15,7 +15,6 @@ module PublicApi
     end
 
     def execute
-
       @scope
         .then { |scope| filter_by_folder_id(scope) }
         .then { |scope| filter_by_publication_status(scope) }

--- a/back/engines/commercial/public_api/app/finders/public_api/projects_finder.rb
+++ b/back/engines/commercial/public_api/app/finders/public_api/projects_finder.rb
@@ -2,16 +2,24 @@
 
 module PublicApi
   class ProjectsFinder
-    def initialize(scope, folder_id: nil, publication_status: nil)
+    def initialize(
+      scope,
+      folder_id: nil,
+      publication_status: nil,
+      topic_ids: nil
+    )
       @scope = scope
       @folder_id = folder_id
       @publication_status = publication_status
+      @topic_ids = topic_ids
     end
 
     def execute
+
       @scope
         .then { |scope| filter_by_folder_id(scope) }
         .then { |scope| filter_by_publication_status(scope) }
+        .then { |scope| filter_by_topic_ids(scope) }
     end
 
     private
@@ -33,6 +41,17 @@ module PublicApi
       scope
         .joins(:admin_publication)
         .where(admin_publication: { publication_status: @publication_status })
+    end
+
+    # Select only the projects that have all the specified topics.
+    def filter_by_topic_ids(scope)
+      return scope unless @topic_ids
+
+      scope
+        .joins(:topics)
+        .where(topics: { id: @topic_ids })
+        .group('projects.id')
+        .having('COUNT(topics.id) = ?', @topic_ids.size)
     end
   end
 end


### PR DESCRIPTION
# Changelog
## Technical
- Introduce a new query parameter to enable filtering of projects based on topics in the public API.
