### PR TITLE
[CL-3941] Add filter parameters to the ideas endpoint (public API)

### DIFF
--- a/back/engines/commercial/public_api/app/controllers/public_api/public_api_controller.rb
+++ b/back/engines/commercial/public_api/app/controllers/public_api/public_api_controller.rb
@@ -66,7 +66,7 @@ module PublicApi
       "#{date_field} BETWEEN '#{start_date}' AND '#{end_date}'"
     end
 
-    # Default per page is 12, maximum is 24
+    # Default per page is 25, maximum is 100
     def num_per_page
       [params[:page_size]&.to_i || 25, 100].min
     end

--- a/back/engines/commercial/public_api/app/controllers/public_api/v1/ideas_controller.rb
+++ b/back/engines/commercial/public_api/app/controllers/public_api/v1/ideas_controller.rb
@@ -6,7 +6,7 @@ module PublicApi
 
     def index
       ideas = PublicApi::IdeaPolicy::Scope.new(current_public_api_api_client, Idea).resolve
-      ideas = IdeasFinder.new({}, scope: ideas, includes: %i[idea_trending_info]).find_records
+      ideas = ::IdeasFinder.new({}, scope: ideas, includes: %i[idea_trending_info]).find_records
       ideas = ideas
         .page(params[:page_number])
         .per([params[:page_size]&.to_i || 12, 24].min) # default is 12, maximum is 24

--- a/back/engines/commercial/public_api/app/controllers/public_api/v2/ideas_controller.rb
+++ b/back/engines/commercial/public_api/app/controllers/public_api/v2/ideas_controller.rb
@@ -3,25 +3,28 @@
 module PublicApi
   class V2::IdeasController < PublicApiController
     def index
-      ideas = Idea
-        .order(created_at: :desc)
-        .includes(:idea_images, :project, :idea_status)
-        .page(params[:page_number])
-        .per(num_per_page)
+      ideas = IdeasFinder.new(
+        Idea.includes(:idea_images, :project, :idea_status).order(created_at: :desc),
+        **finder_params
+      ).execute
 
-      ideas = common_date_filters(ideas)
-
-      # TODO: Add filter by project_id, user_id, topic_name
+      # TODO: Add filter by project_id, topic_name
       # TODO: Only return ideas, separate endpoint for survey responses
 
-      render json: ideas,
-        each_serializer: V2::IdeaSerializer,
-        adapter: :json,
-        meta: meta_properties(ideas)
+      list_items(ideas, V2::IdeaSerializer)
     end
 
     def show
       show_item Idea.find(params[:id]), V2::IdeaSerializer
+    end
+
+    private
+
+    def finder_params
+      params
+        .permit(:user_id)
+        .to_h
+        .symbolize_keys
     end
   end
 end

--- a/back/engines/commercial/public_api/app/controllers/public_api/v2/ideas_controller.rb
+++ b/back/engines/commercial/public_api/app/controllers/public_api/v2/ideas_controller.rb
@@ -21,7 +21,7 @@ module PublicApi
 
     def finder_params
       params
-        .permit(:user_id, :project_id, topic_ids: [])
+        .permit(:author_id, :project_id, topic_ids: [])
         .to_h
         .symbolize_keys
     end

--- a/back/engines/commercial/public_api/app/controllers/public_api/v2/ideas_controller.rb
+++ b/back/engines/commercial/public_api/app/controllers/public_api/v2/ideas_controller.rb
@@ -8,7 +8,6 @@ module PublicApi
         **finder_params
       ).execute
 
-      # TODO: Add filter by project_id, topic_name
       # TODO: Only return ideas, separate endpoint for survey responses
 
       list_items(ideas, V2::IdeaSerializer)

--- a/back/engines/commercial/public_api/app/controllers/public_api/v2/ideas_controller.rb
+++ b/back/engines/commercial/public_api/app/controllers/public_api/v2/ideas_controller.rb
@@ -22,7 +22,7 @@ module PublicApi
 
     def finder_params
       params
-        .permit(:user_id, :project_id)
+        .permit(:user_id, :project_id, topic_ids: [])
         .to_h
         .symbolize_keys
     end

--- a/back/engines/commercial/public_api/app/controllers/public_api/v2/ideas_controller.rb
+++ b/back/engines/commercial/public_api/app/controllers/public_api/v2/ideas_controller.rb
@@ -22,7 +22,7 @@ module PublicApi
 
     def finder_params
       params
-        .permit(:user_id)
+        .permit(:user_id, :project_id)
         .to_h
         .symbolize_keys
     end

--- a/back/engines/commercial/public_api/app/finders/public_api/ideas_finder.rb
+++ b/back/engines/commercial/public_api/app/finders/public_api/ideas_finder.rb
@@ -2,13 +2,16 @@
 
 module PublicApi
   class IdeasFinder
-    def initialize(scope, user_id: nil)
+    def initialize(scope, user_id: nil, project_id: nil)
       @scope = scope
       @user_id = user_id
+      @project_id = project_id
     end
 
     def execute
-      @scope.then { |scope| filter_by_user_id(scope) }
+      @scope
+        .then { |scope| filter_by_user_id(scope) }
+        .then { |scope| filter_by_project_id(scope) }
     end
 
     private
@@ -17,6 +20,12 @@ module PublicApi
       return scope unless @user_id
 
       scope.where(author_id: @user_id)
+    end
+
+    def filter_by_project_id(scope)
+      return scope unless @project_id
+
+      scope.where(project_id: @project_id)
     end
   end
 end

--- a/back/engines/commercial/public_api/app/finders/public_api/ideas_finder.rb
+++ b/back/engines/commercial/public_api/app/finders/public_api/ideas_finder.rb
@@ -30,6 +30,7 @@ module PublicApi
       scope.where(project_id: @project_id)
     end
 
+    # Select only ideas that have all the topics
     def filter_by_topic_ids(scope)
       return scope unless @topic_ids
 

--- a/back/engines/commercial/public_api/app/finders/public_api/ideas_finder.rb
+++ b/back/engines/commercial/public_api/app/finders/public_api/ideas_finder.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module PublicApi
+  class IdeasFinder
+    def initialize(scope, user_id: nil)
+      @scope = scope
+      @user_id = user_id
+    end
+
+    def execute
+      @scope.then { |scope| filter_by_user_id(scope) }
+    end
+
+    private
+
+    def filter_by_user_id(scope)
+      return scope unless @user_id
+
+      scope.where(author_id: @user_id)
+    end
+  end
+end

--- a/back/engines/commercial/public_api/app/finders/public_api/ideas_finder.rb
+++ b/back/engines/commercial/public_api/app/finders/public_api/ideas_finder.rb
@@ -2,26 +2,26 @@
 
 module PublicApi
   class IdeasFinder
-    def initialize(scope, user_id: nil, project_id: nil, topic_ids: nil)
+    def initialize(scope, author_id: nil, project_id: nil, topic_ids: nil)
       @scope = scope
-      @user_id = user_id
+      @author_id = author_id
       @project_id = project_id
       @topic_ids = topic_ids
     end
 
     def execute
       @scope
-        .then { |scope| filter_by_user_id(scope) }
+        .then { |scope| filter_by_author_id(scope) }
         .then { |scope| filter_by_project_id(scope) }
         .then { |scope| filter_by_topic_ids(scope) }
     end
 
     private
 
-    def filter_by_user_id(scope)
-      return scope unless @user_id
+    def filter_by_author_id(scope)
+      return scope unless @author_id
 
-      scope.where(author_id: @user_id)
+      scope.where(author_id: @author_id)
     end
 
     def filter_by_project_id(scope)

--- a/back/engines/commercial/public_api/app/finders/public_api/ideas_finder.rb
+++ b/back/engines/commercial/public_api/app/finders/public_api/ideas_finder.rb
@@ -2,16 +2,18 @@
 
 module PublicApi
   class IdeasFinder
-    def initialize(scope, user_id: nil, project_id: nil)
+    def initialize(scope, user_id: nil, project_id: nil, topic_ids: nil)
       @scope = scope
       @user_id = user_id
       @project_id = project_id
+      @topic_ids = topic_ids
     end
 
     def execute
       @scope
         .then { |scope| filter_by_user_id(scope) }
         .then { |scope| filter_by_project_id(scope) }
+        .then { |scope| filter_by_topic_ids(scope) }
     end
 
     private
@@ -26,6 +28,16 @@ module PublicApi
       return scope unless @project_id
 
       scope.where(project_id: @project_id)
+    end
+
+    def filter_by_topic_ids(scope)
+      return scope unless @topic_ids
+
+      scope
+        .joins(:idea_topics)
+        .where(idea_topics: { topic_id: @topic_ids })
+        .group(:id)
+        .having('COUNT(idea_topics.topic_id) = ?', @topic_ids.size)
     end
   end
 end

--- a/back/engines/commercial/public_api/app/finders/public_api/ideas_finder.rb
+++ b/back/engines/commercial/public_api/app/finders/public_api/ideas_finder.rb
@@ -34,10 +34,10 @@ module PublicApi
       return scope unless @topic_ids
 
       scope
-        .joins(:idea_topics)
-        .where(idea_topics: { topic_id: @topic_ids })
-        .group(:id)
-        .having('COUNT(idea_topics.topic_id) = ?', @topic_ids.size)
+        .joins(:topics)
+        .where(topics: { id: @topic_ids })
+        .group('ideas.id')
+        .having('COUNT(topics.id) = ?', @topic_ids.size)
     end
   end
 end

--- a/back/engines/commercial/public_api/spec/acceptance/v2/ideas_spec.rb
+++ b/back/engines/commercial/public_api/spec/acceptance/v2/ideas_spec.rb
@@ -37,7 +37,7 @@ resource 'Posts' do
     include_context 'common_list_params'
 
     parameter(
-      :user_id,
+      :author_id,
       'Filter by author ID',
       required: false,
       type: :string,
@@ -73,13 +73,13 @@ resource 'Posts' do
       end
     end
 
-    context 'when filtering by user id' do
-      let(:user_id) { ideas.first.author_id }
+    context 'when filtering by author id' do
+      let(:author_id) { ideas.first.author_id }
 
       example_request 'List only the ideas of the specified user' do
         assert_status 200
         expect(json_response_body[:ideas].size).to eq(1)
-        expect(json_response_body[:ideas].first[:author_id]).to eq(user_id)
+        expect(json_response_body[:ideas].first[:author_id]).to eq(author_id)
       end
     end
 

--- a/back/engines/commercial/public_api/spec/acceptance/v2/ideas_spec.rb
+++ b/back/engines/commercial/public_api/spec/acceptance/v2/ideas_spec.rb
@@ -36,6 +36,14 @@ resource 'Posts' do
 
     include_context 'common_list_params'
 
+    parameter(
+      :user_id,
+      'Filter by author ID',
+      required: false,
+      type: :string,
+      in: :query
+    )
+
     context 'when the page size is smaller than the total number of ideas' do
       let(:page_size) { 2 }
 
@@ -45,6 +53,16 @@ resource 'Posts' do
 
         total_pages = (ideas.size.to_f / page_size).ceil
         expect(json_response_body[:meta]).to eq({ total_pages: total_pages, current_page: 1 })
+      end
+    end
+
+    context 'when filtering by user id' do
+      let(:user_id) { ideas.first.author_id }
+
+      example_request 'List only the ideas of the specified user' do
+        assert_status 200
+        expect(json_response_body[:ideas].size).to eq(1)
+        expect(json_response_body[:ideas].first[:author_id]).to eq(user_id)
       end
     end
 

--- a/back/engines/commercial/public_api/spec/acceptance/v2/ideas_spec.rb
+++ b/back/engines/commercial/public_api/spec/acceptance/v2/ideas_spec.rb
@@ -44,6 +44,14 @@ resource 'Posts' do
       in: :query
     )
 
+    parameter(
+      :project_id,
+      'Filter by project ID',
+      required: false,
+      type: :string,
+      in: :query
+    )
+
     context 'when the page size is smaller than the total number of ideas' do
       let(:page_size) { 2 }
 
@@ -63,6 +71,16 @@ resource 'Posts' do
         assert_status 200
         expect(json_response_body[:ideas].size).to eq(1)
         expect(json_response_body[:ideas].first[:author_id]).to eq(user_id)
+      end
+    end
+
+    context 'when filtering by project id' do
+      let(:project_id) { ideas.first.project_id }
+
+      example_request 'List only the ideas of the specified project' do
+        assert_status 200
+        expect(json_response_body[:ideas].size).to eq(1)
+        expect(json_response_body[:ideas].first[:project_id]).to eq(project_id)
       end
     end
 


### PR DESCRIPTION
# Changelog
## Technical
- Add filter query parameters (`user_id`, `project_id`, `topic_ids`) to the ideas endpoint in the public API.
