### PR TITLE
TAN-34 Adjust ordering of initiative statuses

### DIFF
--- a/back/app/services/initiative_status_service.rb
+++ b/back/app/services/initiative_status_service.rb
@@ -4,7 +4,7 @@ class InitiativeStatusService
   MANUAL_TRANSITIONS = {
     'approval_pending' => {
       'proposed' => {
-        feedback_required: false
+        feedback_required: true
       },
       'approval_rejected' => {
         feedback_required: true

--- a/back/config/tenant_templates/base.yml
+++ b/back/config/tenant_templates/base.yml
@@ -44,7 +44,7 @@ models:
   initiative_status:
     -
       title_multiloc: initiative_statuses.approval_pending
-      ordering: 100
+      ordering: 50
       code: approval_pending
       color: '#CC9331'
       description_multiloc: initiative_statuses.approval_pending_description
@@ -56,7 +56,7 @@ models:
       description_multiloc: initiative_statuses.approval_rejected_description
     -
       title_multiloc: initiative_statuses.proposed
-      ordering: 100
+      ordering: 150
       code: proposed
       color: '#687782'
       description_multiloc: initiative_statuses.proposed_description

--- a/back/config/tenant_templates/e2etests_template.yml
+++ b/back/config/tenant_templates/e2etests_template.yml
@@ -45,7 +45,7 @@ models:
   initiative_status:
     - &approval_pending
       title_multiloc: initiative_statuses.approval_pending
-      ordering: 100
+      ordering: 50
       code: approval_pending
       color: '#CC9331'
       description_multiloc: initiative_statuses.approval_pending_description
@@ -57,7 +57,7 @@ models:
       description_multiloc: initiative_statuses.approval_rejected_description
     - &initiative_proposed
       title_multiloc: initiative_statuses.proposed
-      ordering: 100
+      ordering: 150
       code: proposed
       color: '#687782'
       description_multiloc: initiative_statuses.proposed_description

--- a/back/db/seeds/citizenlab.rb
+++ b/back/db/seeds/citizenlab.rb
@@ -253,7 +253,7 @@ end
 [
   {
     title_multiloc: 'initiative_statuses.approval_pending',
-    ordering: 100,
+    ordering: 50,
     code: 'approval_pending',
     color: '#CC9331',
     description_multiloc: 'initiative_statuses.approval_pending_description'
@@ -267,7 +267,7 @@ end
   },
   {
     title_multiloc: 'initiative_statuses.proposed',
-    ordering: 100,
+    ordering: 150,
     code: 'proposed',
     color: '#687782',
     description_multiloc: 'initiative_statuses.proposed_description'


### PR DESCRIPTION
# Changelog
## Technical
- [TAN-34]  Adjust ordering of initiative_statuses (proposal approval feature in development)
