### PR TITLE
CL-3800 Support creation of users with confirmed email through admin API

### DIFF
--- a/back/engines/commercial/admin_api/app/controllers/admin_api/users_controller.rb
+++ b/back/engines/commercial/admin_api/app/controllers/admin_api/users_controller.rb
@@ -34,10 +34,16 @@ module AdminApi
       @user.locale ||= AppConfiguration.instance.settings('core', 'locales').first
       SideFxUserService.new.before_create @user, nil
 
-      @user.confirm if [true, 'TRUE', 'true', '1', 1].include?(params[:confirm_email])
-
       if @user.save
         SideFxUserService.new.after_create @user, nil
+
+        # The validations and hooks on the user model don't allow us to set
+        # confirm before save on creation, they'll get reset. So we're forced to
+        # do a 2nd save operation.
+        if [true, 'TRUE', 'true', '1', 1].include?(params[:confirm_email])
+          @user.confirm
+          @user.save
+        end
 
         # This uses default model serialization
         render json: @user, status: :created

--- a/back/engines/commercial/admin_api/app/controllers/admin_api/users_controller.rb
+++ b/back/engines/commercial/admin_api/app/controllers/admin_api/users_controller.rb
@@ -34,8 +34,11 @@ module AdminApi
       @user.locale ||= AppConfiguration.instance.settings('core', 'locales').first
       SideFxUserService.new.before_create @user, nil
 
+      @user.confirm if [true, 'TRUE', 'true', '1', 1].include?(params[:confirm_email])
+
       if @user.save
         SideFxUserService.new.after_create @user, nil
+
         # This uses default model serialization
         render json: @user, status: :created
       else

--- a/back/engines/commercial/admin_api/spec/acceptance/users_spec.rb
+++ b/back/engines/commercial/admin_api/spec/acceptance/users_spec.rb
@@ -115,7 +115,10 @@ resource 'User', admin_api: true do
 
       example_request 'Create a user with a confirmed email' do
         expect(response_status).to eq 201
-        expect(User.find_by(email: email).email_confirmed_at).to be_present
+        user = User.find_by(email: email)
+
+        expect(user.email_confirmed_at).to be_present
+        expect(user.confirmation_required?).to be false
       end
     end
   end

--- a/back/engines/commercial/admin_api/spec/acceptance/users_spec.rb
+++ b/back/engines/commercial/admin_api/spec/acceptance/users_spec.rb
@@ -82,6 +82,8 @@ resource 'User', admin_api: true do
       parameter :roles, 'The roles of the user'
       parameter :remote_avatar_url, 'The user avatar'
     end
+    parameter :confirm_email, 'Should the email already be verified?', required: false, default: false
+
     ValidationErrorHelper.new.error_fields(self, User)
 
     let(:first_name) { 'Jaak' }
@@ -95,6 +97,25 @@ resource 'User', admin_api: true do
         expect(response_status).to eq 201
         json_response = json_parse(response_body)
         expect(json_response[:last_name]).to eq 'Brijl'
+        expect(User.find_by(email: email).email_confirmed_at).to be_blank
+      end
+    end
+
+    describe do
+      before do
+        configuration = AppConfiguration.instance
+        configuration.settings['user_confirmation'] = {
+          allowed: true,
+          enabled: true
+        }
+        configuration.save!
+      end
+
+      let(:confirm_email) { true }
+
+      example_request 'Create a user with a confirmed email' do
+        expect(response_status).to eq 201
+        expect(User.find_by(email: email).email_confirmed_at).to be_present
       end
     end
   end


### PR DESCRIPTION
Related to https://github.com/CitizenLabDotCo/cl2-tenant-setup/pull/25

# Changelog
## Fixed
- New tenants created through Admin HQ no longer require email confirmation for the default admin account