### PR TITLE
CL-3911 Fix saving map zoom/position in admin map config

### DIFF
--- a/front/app/components/UI/LeafletMap/useLeaflet.ts
+++ b/front/app/components/UI/LeafletMap/useLeaflet.ts
@@ -205,6 +205,17 @@ export default function useLeaflet(
       map.on('click', (event: L.LeafletMouseEvent) => {
         setLeafletMapClicked(event.latlng);
       });
+      map.on('moveend', (event: L.LeafletEvent) => {
+        const newCenter = event.target.getCenter() as L.LatLng;
+        const newCenterLat = newCenter.lat;
+        const newCenterLng = newCenter.lng;
+        setLeafletMapCenter([newCenterLat, newCenterLng]);
+      });
+
+      map.on('zoomend', (event: L.LeafletEvent) => {
+        const newZoom = event.target.getZoom() as number;
+        setLeafletMapZoom(newZoom);
+      });
     }
 
     return () => {


### PR DESCRIPTION
This brings back the Lealet event handlers that emit an event when the state of the map changes, which was removed in e184cb9287495efac867faacb952bae9158ec4d6 The removal broke the functionality where the current map state (zoom/position) can be saved.

I'm very unsure about this, because I don't fully understand the code, nor do I understand why these handlers were removed. I'm sure this fixes the issue, but aware it might (re-)introduce other issues.

@luucvanderzee , can you shed some light? :)

# Changelog
## Fixed
- In the project map config, it's again possible to save the current map zoom/position
