### PR TITLE
TAN-50 Add initiative policy scope for new statuses

### DIFF
--- a/back/app/models/initiative_status.rb
+++ b/back/app/models/initiative_status.rb
@@ -15,6 +15,7 @@
 #
 class InitiativeStatus < ApplicationRecord
   CODES = %w[approval_pending approval_rejected proposed expired threshold_reached answered ineligible custom]
+  NOT_PUBLICLY_VISIBLE_CODES = %w[approval_pending approval_rejected].freeze
 
   has_many :initiative_status_changes, dependent: :nullify
   has_many :initiative_initiative_statuses

--- a/back/app/policies/initiative_policy.rb
+++ b/back/app/policies/initiative_policy.rb
@@ -17,7 +17,7 @@ class InitiativePolicy < ApplicationPolicy
       else
         not_draft.left_outer_joins(:initiative_initiative_status)
           .where.not(initiative_initiative_statuses: {
-            initiative_status_id: InitiativeStatus.where(code: %w[approval_pending approval_rejected]).select(:id)
+            initiative_status_id: InitiativeStatus.where(code: InitiativeStatus::NOT_PUBLICLY_VISIBLE_CODES).select(:id)
           })
           .or(not_draft.where(author: user))
       end


### PR DESCRIPTION
Needs some tests. I suggest we add tests in a separate PR.

# Changelog
## Technical
- [TAN-50] Initiative policy scope accommodates new statuses (proposal approval feature in development)
