### PR TITLE
TAN-57 Bugfix: Add manual transitions from approval rejected status

### DIFF
--- a/back/app/services/initiative_status_service.rb
+++ b/back/app/services/initiative_status_service.rb
@@ -10,6 +10,14 @@ class InitiativeStatusService
         feedback_required: true
       }
     },
+    'approval_rejected' => {
+      'approval_pending' => {
+        feedback_required: true
+      },
+      'proposed' => {
+        feedback_required: true
+      }
+    },
     'proposed' => {
       'answered' => {
         feedback_required: true

--- a/back/spec/services/initiative_status_service_spec.rb
+++ b/back/spec/services/initiative_status_service_spec.rb
@@ -75,8 +75,8 @@ describe InitiativeStatusService do
       expect(service.transition_type(status_ineligible)).to eq 'manual'
     end
 
-    it 'labels the approval_pending status as automatic' do
-      expect(service.transition_type(status_approval_pending)).to eq 'automatic'
+    it 'labels the approval_pending status as manual' do
+      expect(service.transition_type(status_approval_pending)).to eq 'manual'
     end
 
     it 'labels the approval_rejected status as manual' do


### PR DESCRIPTION
It seems a transition _from_ each status must be possible. There can be no 'dead-ends'.

Without this fix, proposals in `approval_rejected` status will not be listed in BO Proposals table when page is refreshed, because of `allowed_transitions` 500 error.

# Changelog
## Technical
- [TAN-57] Bugfix: Add manual transitions from approval rejected status (proposal approval feature in development)
