### PR TITLE
CL-3937 Faster xlsx export

### DIFF
--- a/back/app/services/xlsx_export/custom_field_for_report.rb
+++ b/back/app/services/xlsx_export/custom_field_for_report.rb
@@ -7,7 +7,8 @@ module XlsxExport
     def initialize(custom_field, scope = nil)
       @custom_field = custom_field
       @scope = scope
-      @multiloc_service = MultilocService.new
+      @app_configuration = AppConfiguration.instance
+      @multiloc_service = MultilocService.new(app_configuration: @app_configuration)
     end
 
     def column_header
@@ -19,7 +20,7 @@ module XlsxExport
         model = model.public_send(scope)
         return unless model
       end
-      visitor = ValueVisitor.new(model, option_index)
+      visitor = ValueVisitor.new(model, option_index, app_configuration: @app_configuration)
       visitor.visit self
     end
 

--- a/back/app/services/xlsx_export/input_sheet_generator.rb
+++ b/back/app/services/xlsx_export/input_sheet_generator.rb
@@ -10,7 +10,7 @@ module XlsxExport
       @include_private_attributes = include_private_attributes
       @participation_method = Factory.instance.participation_method_for participation_context
       @fields_in_form = IdeaCustomFieldsService.new(participation_method.custom_form).reportable_fields
-      @multiloc_service = MultilocService.new
+      @multiloc_service = MultilocService.new(app_configuration: AppConfiguration.instance)
       @url_service = Frontend::UrlService.new
     end
 

--- a/back/app/services/xlsx_export/value_visitor.rb
+++ b/back/app/services/xlsx_export/value_visitor.rb
@@ -2,11 +2,11 @@
 
 module XlsxExport
   class ValueVisitor < FieldVisitorService
-    def initialize(model, option_index)
+    def initialize(model, option_index, app_configuration: nil)
       super()
       @model = model
       @option_index = option_index
-      @multiloc_service = MultilocService.new
+      @multiloc_service = MultilocService.new(app_configuration: app_configuration)
     end
 
     def default(field)


### PR DESCRIPTION
Main cause of slowness are the `multiloc.t` calls, which call `AppConfiguration.instance`. Can be avoided by passing in the app_configuration instance when initializing the `MultilocService`, which this PR does.

# Changelog
## Fixed
- Faster excel export for surveys, solving the timeout issue for some platform with lots of responses
