### PR TITLE
TAN-63 Filter idea_custom_fields for fields that support a textual answer

### DIFF
--- a/back/app/models/custom_field.rb
+++ b/back/app/models/custom_field.rb
@@ -80,6 +80,7 @@ class CustomField < ApplicationRecord
   scope :hidden, -> { where(hidden: true) }
   scope :support_multiple_values, -> { where(input_type: 'multiselect') }
   scope :support_single_value, -> { where.not(input_type: 'multiselect') }
+  scope :support_free_text_value, -> { where(input_type: %w[text multiline_text text_multiloc multiline_text_multiloc html_multiloc]) }
 
   def logic?
     logic.present? && logic != { 'rules' => [] }

--- a/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
+++ b/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
@@ -31,6 +31,9 @@ module IdeaCustomFields
     def index
       authorize CustomField.new(resource: @custom_form), :index?, policy_class: IdeaCustomFieldPolicy
       fields = IdeaCustomFieldsService.new(@custom_form).all_fields
+
+      fields = fields.support_free_text_value if params[:support_free_text_value].present?
+
       render json: ::WebApi::V1::CustomFieldSerializer.new(
         fields,
         params: serializer_params(@custom_form),

--- a/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/index_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/index_spec.rb
@@ -9,11 +9,14 @@ resource 'Idea Custom Fields' do
   before { header 'Content-Type', 'application/json' }
 
   get 'web_api/v1/admin/phases/:phase_id/custom_fields' do
+
+    parameter :support_free_text_value, 'Only return custom fields that have a freely written textual answer', type: :boolean, required: false
+
     let(:context) { create(:phase, participation_method: 'native_survey') }
     let(:phase_id) { context.id }
     let(:form) { create(:custom_form, participation_context: context) }
-    let!(:custom_field1) { create(:custom_field, resource: form, key: 'extra_field1') }
-    let!(:custom_field2) { create(:custom_field, resource: form, key: 'extra_field2') }
+    let!(:custom_field1) { create(:custom_field_text, resource: form, key: 'extra_field1') }
+    let!(:custom_field2) { create(:custom_field_number, resource: form, key: 'extra_field2') }
 
     context 'when admin' do
       before { admin_header_token }
@@ -25,6 +28,16 @@ resource 'Idea Custom Fields' do
         expect(json_response[:data].map { |d| d.dig(:attributes, :key) }).to eq [
           custom_field1.key,
           custom_field2.key
+        ]
+      end
+
+      example 'List all allowed custom fields for a phase with a textual answer', document: false do
+        do_request(support_free_text_value: true)
+        assert_status 200
+        json_response = json_parse response_body
+        expect(json_response[:data].size).to eq 1
+        expect(json_response[:data].map { |d| d.dig(:attributes, :key) }).to eq [
+          custom_field1.key
         ]
       end
     end

--- a/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/project_context/index_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/project_context/index_spec.rb
@@ -8,10 +8,12 @@ resource 'Idea Custom Fields' do
   before { header 'Content-Type', 'application/json' }
 
   get 'web_api/v1/admin/projects/:project_id/custom_fields' do
+    parameter :support_free_text_value, 'Only return custom fields that have a freely written textual answer', type: :boolean, required: false
+
     let(:context) { create(:project) }
     let(:project_id) { context.id }
     let!(:form) { create(:custom_form, :with_default_fields, participation_context: context) }
-    let!(:custom_field) { create(:custom_field, resource: form, key: 'extra_field1') }
+    let!(:custom_field) { create(:custom_field_text, resource: form, key: 'extra_field1') }
 
     context 'when admin' do
       before { admin_header_token }
@@ -39,6 +41,15 @@ resource 'Idea Custom Fields' do
           nil, 'topic_ids', 'location_description', 'proposed_budget',
           'extra_field1', 'extra_field2'
         ]
+      end
+
+      example 'List all allowed custom fields for a project with a textual answer', document: false do
+        cf_number = create(:custom_field_date, resource: form, key: 'extra_field2')
+        do_request(support_free_text_value: true)
+        assert_status 200
+        json_response = json_parse response_body
+        expect(json_response[:data].map { |d| d.dig(:attributes, :key) }).to include custom_field.key
+        expect(json_response[:data].map { |d| d.dig(:attributes, :key) }).not_to include cf_number.key
       end
     end
   end

--- a/back/spec/factories/custom_fields.rb
+++ b/back/spec/factories/custom_fields.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :custom_field do
+  factory :custom_field, aliases: [:custom_field_text] do
     resource_type { 'User' }
     sequence(:key) { |n| "field_#{n}" }
     title_multiloc do


### PR DESCRIPTION
# Changelog
## Technical
- Idea custom fields can be filtered to only return fields that have a textual answer (WIP sensemaking)