### PR TITLE
[CL-3945] Implement project_topics and idea_topics endpoints

### DIFF
--- a/back/engines/commercial/public_api/app/controllers/public_api/v2/idea_topics_controller.rb
+++ b/back/engines/commercial/public_api/app/controllers/public_api/v2/idea_topics_controller.rb
@@ -8,6 +8,7 @@ module PublicApi
       # records (and at this point, we don't want to make the `list_items` method more
       # complex to handle this case).
       idea_topics = IdeasTopic
+        .where(query_filters)
         .order(:id)
         .page(params[:page_number])
         .per(num_per_page)
@@ -16,6 +17,12 @@ module PublicApi
         each_serializer: V2::IdeaTopicSerializer,
         adapter: :json,
         meta: meta_properties(idea_topics)
+    end
+
+    private
+
+    def query_filters
+      params.permit(:idea_id, :topic_id).to_h
     end
   end
 end

--- a/back/engines/commercial/public_api/app/controllers/public_api/v2/idea_topics_controller.rb
+++ b/back/engines/commercial/public_api/app/controllers/public_api/v2/idea_topics_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module PublicApi
+  class V2::IdeaTopicsController < PublicApiController
+    def index
+      # We can't use the `list_items` method here because `IdeasTopic` doesn't have a
+      # `created_at` column, which the `list_items` method relies on to order the
+      # records (and at this point, we don't want to make the `list_items` method more
+      # complex to handle this case).
+      idea_topics = IdeasTopic
+        .order(:id)
+        .page(params[:page_number])
+        .per(num_per_page)
+
+      render json: idea_topics,
+        each_serializer: V2::IdeaTopicSerializer,
+        adapter: :json,
+        meta: meta_properties(idea_topics)
+    end
+  end
+end

--- a/back/engines/commercial/public_api/app/controllers/public_api/v2/project_topics_controller.rb
+++ b/back/engines/commercial/public_api/app/controllers/public_api/v2/project_topics_controller.rb
@@ -3,7 +3,14 @@
 module PublicApi
   class V2::ProjectTopicsController < PublicApiController
     def index
-      list_items(ProjectsTopic.all, V2::ProjectTopicSerializer)
+      project_topics = ProjectsTopic.where(query_filters)
+      list_items(project_topics, V2::ProjectTopicSerializer)
+    end
+
+    private
+
+    def query_filters
+      params.permit(:project_id, :topic_id).to_h
     end
   end
 end

--- a/back/engines/commercial/public_api/app/controllers/public_api/v2/project_topics_controller.rb
+++ b/back/engines/commercial/public_api/app/controllers/public_api/v2/project_topics_controller.rb
@@ -3,8 +3,7 @@
 module PublicApi
   class V2::ProjectTopicsController < PublicApiController
     def index
-      project_topics = ProjectsTopic.all
-      list_items(project_topics, V2::ProjectTopicSerializer)
+      list_items(ProjectsTopic.all, V2::ProjectTopicSerializer)
     end
   end
 end

--- a/back/engines/commercial/public_api/app/controllers/public_api/v2/project_topics_controller.rb
+++ b/back/engines/commercial/public_api/app/controllers/public_api/v2/project_topics_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module PublicApi
+  class V2::ProjectTopicsController < PublicApiController
+    def index
+      project_topics = ProjectsTopic.all
+      list_items(project_topics, V2::ProjectTopicSerializer)
+    end
+  end
+end

--- a/back/engines/commercial/public_api/app/serializers/public_api/v2/idea_topic_serializer.rb
+++ b/back/engines/commercial/public_api/app/serializers/public_api/v2/idea_topic_serializer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module PublicApi
+  module V2
+    class IdeaTopicSerializer < PublicApi::V2::BaseSerializer
+      type :idea_topics
+      attributes(:idea_id, :topic_id)
+    end
+  end
+end

--- a/back/engines/commercial/public_api/app/serializers/public_api/v2/project_topic_serializer.rb
+++ b/back/engines/commercial/public_api/app/serializers/public_api/v2/project_topic_serializer.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module PublicApi
+  module V2
+    class ProjectTopicSerializer < PublicApi::V2::BaseSerializer
+      type :project_topics
+
+      attributes(
+        :project_id,
+        :topic_id,
+        :created_at,
+        :updated_at
+      )
+    end
+  end
+end

--- a/back/engines/commercial/public_api/config/routes.rb
+++ b/back/engines/commercial/public_api/config/routes.rb
@@ -31,6 +31,9 @@ PublicApi::Engine.routes.draw do
         resources :phases, only: %i[index]
       end
     end
+
+    # Association endpoints
+    resources :project_topics, only: %i[index]
   end
 end
 

--- a/back/engines/commercial/public_api/config/routes.rb
+++ b/back/engines/commercial/public_api/config/routes.rb
@@ -33,6 +33,7 @@ PublicApi::Engine.routes.draw do
     end
 
     # Association endpoints
+    resources :idea_topics, only: %i[index]
     resources :project_topics, only: %i[index]
   end
 end

--- a/back/engines/commercial/public_api/spec/acceptance/v2/idea_topics_spec.rb
+++ b/back/engines/commercial/public_api/spec/acceptance/v2/idea_topics_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rspec_api_documentation/dsl'
+require './engines/commercial/public_api/spec/acceptance/v2/support/shared'
+
+resource 'Idea topics' do
+  explanation <<~DESC.squish
+    Idea topics represent associations between ideas and topics. This is a
+    many-to-many relationship: Ideas can have multiple topics, and topics can
+    be associated with multiple ideas.
+  DESC
+
+  include_context 'common_auth'
+
+  get '/api/v2/idea_topics' do
+    let!(:idea_topics) do
+      2.times do |index|
+        create(:idea_with_topics, topics_count: index + 1)
+      end
+
+      IdeasTopic.all
+    end
+
+    example_request 'List all associations between ideas and topics' do
+      assert_status 200
+
+      expected_idea_topics = idea_topics.map do |idea_topic|
+        {
+          topic_id: idea_topic.topic_id,
+          idea_id: idea_topic.idea_id
+        }
+      end
+
+      expect(json_response_body[:idea_topics]).to match_array(expected_idea_topics)
+    end
+  end
+end

--- a/back/engines/commercial/public_api/spec/acceptance/v2/project_topics_spec.rb
+++ b/back/engines/commercial/public_api/spec/acceptance/v2/project_topics_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rspec_api_documentation/dsl'
+require './engines/commercial/public_api/spec/acceptance/v2/support/shared'
+
+resource 'Project topics' do
+  explanation <<~DESC.squish
+    Project topics represent associations between projects and topics. This is a
+    many-to-many relationship: Projects can have multiple topics, and topics can
+    be associated with multiple projects.
+  DESC
+
+  include_context 'common_auth'
+
+  get '/api/v2/project_topics' do
+    let!(:project_topics) do
+      create_list(:project, 2).each_with_index do |project, index|
+        project.topics << create_list(:topic, index + 1)
+      end
+
+      ProjectsTopic.all
+    end
+
+    example_request 'List all associations between projects and topics' do
+      assert_status 200
+
+      expected_project_topics = project_topics.map do |project_topic|
+        {
+          project_id: project_topic.project_id,
+          topic_id: project_topic.topic_id,
+          created_at: project_topic.created_at.iso8601(3),
+          updated_at: project_topic.updated_at.iso8601(3)
+        }
+      end
+
+      expect(json_response_body[:project_topics]).to match_array(expected_project_topics)
+    end
+  end
+end


### PR DESCRIPTION
# Changelog
# Technical
- Add the `idea_topics` and `project_topics` endpoints to the public API. These endpoints allow users to retrieve all associations between ideas/projects and topics.