### PR TITLE
E2E -fix failing and flaky idea_page_action tests

### DIFF
--- a/front/cypress/e2e/idea_page_action.cy.ts
+++ b/front/cypress/e2e/idea_page_action.cy.ts
@@ -188,7 +188,6 @@ describe('Idea show page actions', () => {
       describe('Comment', () => {
         it('lets a logged in user reply to a parent comment', () => {
           const commentBody = randomString();
-          // cy.get('#submit-comment').focus();
           cy.get('.e2e-comment-reply-button').first().click({ force: true });
           cy.wait(1000);
           cy.get('.e2e-childcomment-form textarea').first().type(commentBody);

--- a/front/cypress/e2e/idea_page_action.cy.ts
+++ b/front/cypress/e2e/idea_page_action.cy.ts
@@ -1,9 +1,40 @@
 import { randomString, randomEmail } from '../support/commands';
 
 describe('Idea show page actions', () => {
+  let projectId = '';
+  let projectSlug = '';
+  let ideaId = '';
+  let ideaSlug = '';
+
+  before(() => {
+    cy.apiCreateProject({
+      type: 'continuous',
+      title: randomString(20),
+      descriptionPreview: randomString(),
+      description: randomString(),
+      publicationStatus: 'published',
+      participationMethod: 'ideation',
+    }).then((project) => {
+      projectId = project.body.data.id;
+      projectSlug = project.body.data.attributes.slug;
+
+      cy.apiCreateIdea(projectId, randomString(20), randomString()).then(
+        (idea) => {
+          ideaId = idea.body.data.id;
+          ideaSlug = idea.body.data.attributes.slug;
+        }
+      );
+    });
+  });
+
+  after(() => {
+    cy.apiRemoveIdea(ideaId);
+    cy.apiRemoveProject(projectId);
+  });
+
   describe('not logged in', () => {
     before(() => {
-      cy.visit('/ideas/controversial-idea');
+      cy.visit(`/ideas/${ideaSlug}`);
       cy.get('#e2e-idea-show');
       cy.acceptCookies();
     });
@@ -15,9 +46,13 @@ describe('Idea show page actions', () => {
   });
 
   describe('logged in as admin', () => {
-    before(() => {
+    beforeEach(() => {
       cy.setAdminLoginCookie();
-      cy.visit('/ideas/controversial-idea');
+      cy.reload();
+    });
+
+    before(() => {
+      cy.visit(`/ideas/${ideaSlug}`);
       cy.get('#e2e-idea-show');
       cy.acceptCookies();
     });
@@ -43,29 +78,6 @@ describe('Idea show page actions', () => {
     });
 
     describe('Map idea card', () => {
-      const ideaTitle = randomString();
-      let ideaId: string;
-      let projectId: string;
-      let projectSlug: string;
-      const ideaContent = randomString();
-
-      before(() => {
-        cy.getProjectBySlug('an-idea-bring-it-to-your-council').then(
-          (project) => {
-            projectSlug = project.body.data.attributes.slug;
-            projectId = project.body.data.id;
-            cy.apiCreateIdea(projectId, ideaTitle, ideaContent).then((idea) => {
-              ideaId = idea.body.data.id;
-            });
-          }
-        );
-      });
-
-      it('is an ideation project', () => {
-        cy.visit(`/admin/projects/${projectId}`);
-        cy.get('#participationmethod-ideation').should('be.checked');
-      });
-
       it('displays correct likes and dislikes on map idea card', () => {
         cy.visit(`/projects/${projectSlug}`);
         cy.get('#view-tab-2').should('exist');
@@ -82,38 +94,20 @@ describe('Idea show page actions', () => {
 
   describe('logged in as normal user', () => {
     describe('Reaction', () => {
-      const ideaTitle = randomString();
-      let ideaId: string;
-      let projectId: string;
-      const ideaContent = randomString();
-
-      before(() => {
+      beforeEach(() => {
         const firstName = randomString();
         const lastName = randomString();
         const email = randomEmail();
         const password = randomString();
 
-        cy.getProjectBySlug('an-idea-bring-it-to-your-council').then(
-          (project) => {
-            projectId = project.body.data.id;
-            cy.apiCreateIdea(projectId, ideaTitle, ideaContent).then((idea) => {
-              ideaId = idea.body.data.id;
-            });
-            cy.apiSignup(firstName, lastName, email, password);
-            cy.setLoginCookie(email, password);
-          }
-        );
-      });
-
-      after(() => {
-        if (ideaId) {
-          cy.apiRemoveIdea(ideaId);
-        }
+        cy.apiSignup(firstName, lastName, email, password);
+        cy.setLoginCookie(email, password);
+        cy.reload();
       });
 
       it('has working up and dislike buttons', () => {
-        cy.visit(`/ideas/${ideaTitle}`);
-        cy.intercept(`**/ideas/by_slug/${ideaTitle}`).as('ideaRequest');
+        cy.visit(`/ideas/${ideaSlug}`);
+        cy.intercept(`**/ideas/by_slug/${ideaSlug}`).as('ideaRequest');
 
         cy.wait('@ideaRequest');
         cy.get('#e2e-idea-show').should('exist');
@@ -158,15 +152,28 @@ describe('Idea show page actions', () => {
       const email = randomEmail();
       const password = randomString();
 
+      let ideaId2 = '';
+      let ideaSlug2 = '';
+
       before(() => {
         const firstName = randomString();
         const lastName = randomString();
         cy.apiSignup(firstName, lastName, email, password);
+
+        cy.apiCreateIdea(projectId, randomString(20), randomString()).then(
+          (idea) => {
+            ideaId2 = idea.body.data.id;
+            ideaSlug2 = idea.body.data.attributes.slug;
+
+            cy.apiAddComment(ideaId2, 'idea', randomString());
+          }
+        );
       });
 
       beforeEach(() => {
         cy.setLoginCookie(email, password);
-        cy.visit('/ideas/controversial-idea');
+        cy.reload();
+        cy.visit(`/ideas/${ideaSlug2}`);
         cy.acceptCookies();
         cy.get('#e2e-idea-show');
       });
@@ -181,7 +188,8 @@ describe('Idea show page actions', () => {
       describe('Comment', () => {
         it('lets a logged in user reply to a parent comment', () => {
           const commentBody = randomString();
-          cy.get('.e2e-comment-reply-button').first().click();
+          // cy.get('#submit-comment').focus();
+          cy.get('.e2e-comment-reply-button').first().click({ force: true });
           cy.wait(1000);
           cy.get('.e2e-childcomment-form textarea').first().type(commentBody);
           cy.get('.e2e-submit-childcomment').first().click();

--- a/front/cypress/e2e/idea_page_action.cy.ts
+++ b/front/cypress/e2e/idea_page_action.cy.ts
@@ -170,6 +170,10 @@ describe('Idea show page actions', () => {
         );
       });
 
+      after(() => {
+        cy.apiRemoveIdea(ideaId2);
+      });
+
       beforeEach(() => {
         cy.setLoginCookie(email, password);
         cy.reload();

--- a/front/cypress/e2e/idea_page_action.cy.ts
+++ b/front/cypress/e2e/idea_page_action.cy.ts
@@ -61,6 +61,11 @@ describe('Idea show page actions', () => {
         );
       });
 
+      it('is an ideation project', () => {
+        cy.visit(`/admin/projects/${projectId}`);
+        cy.get('#participationmethod-ideation').should('be.checked');
+      });
+
       it('displays correct likes and dislikes on map idea card', () => {
         cy.visit(`/projects/${projectSlug}`);
         cy.get('#view-tab-2').should('exist');


### PR DESCRIPTION
See https://app.circleci.com/jobs/github/CitizenLabDotCo/citizenlab/295266

The `idea_page_action` suite was failing, specifically the `displays correct likes and dislikes on map idea card` test. I couldn't reproduce it locally so I rewrote the test to start from a fresh new ideation project rather than the existing `an-idea-bring-it-to-your-council` project. That solved the problem.

There was also a lot of flakiness with setting the login cookies: often you would set the cookie but then you would still appear logged out until you actually reloaded the page. So I switched to setting the cookies and reloading the page before each test. Shouldn't be necessary I feel, but also not sure how else to solve it- let me know if you've seen this issue before!

Oh and slightly improved the alignment of these icons

Before
![image](https://github.com/CitizenLabDotCo/citizenlab/assets/13822005/100ad52a-e566-4d16-adaf-4b2e737bb115)

After
![image](https://github.com/CitizenLabDotCo/citizenlab/assets/13822005/6dac8ab7-8613-48b9-b07f-9a6e280f7c7d)