### PR TITLE
CL-3910 Do not require verification if the user is already member of a different group

### DIFF
--- a/back/engines/commercial/verification/app/services/verification/patches/permissions_service.rb
+++ b/back/engines/commercial/verification/app/services/verification/patches/permissions_service.rb
@@ -26,9 +26,13 @@ module Verification
 
       def mark_satisfied_requirements!(requirements, permission, user)
         super
-        return unless permission.permitted_by == 'groups' && user.verified? && VerificationService.new.find_verification_group(permission.groups)
+        return unless permission.permitted_by == 'groups' && VerificationService.new.find_verification_group(permission.groups)
 
-        requirements[:special][:verification] = 'satisfied'
+        if user.verified?
+          requirements[:special][:verification] = 'satisfied'
+        elsif user.in_any_groups? permission.groups
+          requirements[:special][:verification] = 'dont_ask'
+        end
       end
     end
   end

--- a/back/engines/commercial/verification/spec/services/permissions_service_spec.rb
+++ b/back/engines/commercial/verification/spec/services/permissions_service_spec.rb
@@ -43,7 +43,7 @@ describe PermissionsService do
     context 'when unverified resident, belonging to the other group' do
       let(:user) { create(:user, verified: false, manual_groups: [groups.first]) }
 
-      it { expect(service.denied_reason_for_permission(group_permission, user)).to eq 'missing_data' }
+      it { expect(service.denied_reason_for_permission(group_permission, user)).to be_nil }
     end
   end
 


### PR DESCRIPTION
A bug was reported in https://citizenlab.atlassian.net/browse/CL-3910, where users expect to be allowed to participate when they are part of one of the groups, but did not verify their profile, while the other group requires verification.

The specs explicitly state that this is desired behaviour. However, I don't think this is very intuitive and the reported bug seems to confirm this. I therefore propose to change the requirement.


# Changelog

### Changed

- [CL-3910] Do not require verification if the user is already member of a different group


[CL-3910]: https://citizenlab.atlassian.net/browse/CL-3910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ