### PR TITLE
CL-3957 Bug change participation method

### DIFF
--- a/back/app/services/side_fx_participation_context_service.rb
+++ b/back/app/services/side_fx_participation_context_service.rb
@@ -15,7 +15,12 @@ class SideFxParticipationContextService
     )
   end
 
-  def before_update(pc, user); end
+  def before_update(pc, _user)
+    method = Factory.instance.participation_method_for pc
+    if method.allowed_ideas_orders.exclude? pc.ideas_order
+      pc.ideas_order = method.allowed_ideas_orders.first
+    end
+  end
 
   def after_update(pc, _user)
     Surveys::WebhookManagerJob.perform_later(

--- a/back/spec/acceptance/phases_spec.rb
+++ b/back/spec/acceptance/phases_spec.rb
@@ -436,11 +436,10 @@ resource 'Phases' do
         let(:ideas) { create_list(:idea, 2, project: @project) }
         let(:phase) { create(:phase, project: @project, participation_method: 'ideation', ideas: ideas) }
         let(:participation_method) { 'information' }
-        let(:ideas_order) { nil }
 
         example 'Make a phase with ideas an information phase' do
           do_request
-          expect(response_status).to eq 200
+          assert_status 200
         end
       end
 
@@ -454,7 +453,6 @@ resource 'Phases' do
 
         let(:ideas_phase) { phase.ideas[0].ideas_phases.first }
         let(:participation_method) { 'poll' }
-        let(:ideas_order) { nil }
 
         example 'Existing related ideas_phase remains valid' do
           expect(ideas_phase.valid?).to be true

--- a/back/spec/acceptance/projects_spec.rb
+++ b/back/spec/acceptance/projects_spec.rb
@@ -646,6 +646,15 @@ resource 'Projects' do
           expect(json_response.dig(:data, :attributes, :voting_term_singular_multiloc, :en)).to eq 'Grocery shopping'
           expect(json_response.dig(:data, :attributes, :voting_term_plural_multiloc, :en)).to eq 'Groceries shoppings'
         end
+
+        describe do
+          let(:participation_method) { 'volunteering' }
+
+          example 'Change the participation method from voting to volunteering', document: false do
+            do_request
+            assert_status 200
+          end
+        end
       end
 
       example 'Log activities', document: false do


### PR DESCRIPTION
After the work on voting, it was no longer possible to change the participation method, if the ideas_order is no longer supported.

# Changelog
### Fixed
- [CL-3957] Change the participation method and reset the ideas order when it is no longer valid (instead of returning an error)



[CL-3957]: https://citizenlab.atlassian.net/browse/CL-3957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ