### PR TITLE
[CL-3956] Bugfix: Permit moderator to index any automated campaigns

### DIFF
--- a/back/engines/free/email_campaigns/app/policies/email_campaigns/campaign_policy.rb
+++ b/back/engines/free/email_campaigns/app/policies/email_campaigns/campaign_policy.rb
@@ -16,7 +16,7 @@ module EmailCampaigns
         elsif user&.active? && user&.project_moderator?
           projects = Project.where(id: user.moderatable_project_ids)
           if projects.any? { |p| p.visible_to == 'public' }
-            scope.where(type: EmailCampaigns::Campaigns::Manual.name)
+            scope.all
           else
             accessible_group_ids = GroupPolicy::Scope.new(user, Group).resolve.ids
             campaigns_with_wrong_groups = CampaignsGroup
@@ -27,7 +27,6 @@ module EmailCampaigns
               .where(email_campaigns_campaigns_groups: { id: nil })
               .ids
             scope
-              .where(type: EmailCampaigns::Campaigns::Manual.name)
               .where.not(id: [*campaigns_with_wrong_groups, *campaigns_without_groups].uniq)
           end
         else

--- a/back/engines/free/email_campaigns/spec/policies/campaign_policy_spec.rb
+++ b/back/engines/free/email_campaigns/spec/policies/campaign_policy_spec.rb
@@ -180,8 +180,21 @@ describe EmailCampaigns::CampaignPolicy do
         it { is_expected.not_to permit(:update) }
         it { is_expected.not_to permit(:destroy) }
 
-        it 'does not index the campaign' do
-          expect(scope.resolve.size).to eq 0
+        it 'indexes the campaign' do
+          expect(scope.resolve.size).to eq 1
+        end
+      end
+
+      context 'of a private groups project on a campaign without groups' do
+        let(:project) { create(:private_groups_project) }
+
+        it { is_expected.not_to permit(:show) }
+        it { is_expected.not_to permit(:create) }
+        it { is_expected.not_to permit(:update) }
+        it { is_expected.not_to permit(:destroy) }
+
+        it 'indexes the campaign' do
+          expect(scope.resolve.size).to eq 1
         end
       end
     end


### PR DESCRIPTION
This fix should permit a moderator to index all/any campaigns. This means we can always get the `project_phase-started` campaign, needed to populate the respective toggle and set the correct value, when editing a phase, thus solving the bug that the ticket [CL-3956](https://citizenlab.atlassian.net/browse/CL-3956) describes.

Theoretically, this also allows a moderator to index campaigns for projects they are _not_ moderators of (e.g. a project only visible to admins), however I can't really think of a problem with this, especially as this PR does not change create/update/delete policies.

# Changelog
## Fixed
- [CL-3956] Moderators can again create and edit phases.


[CL-3956]: https://citizenlab.atlassian.net/browse/CL-3956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ