### PR TITLE
[no-ticket] Made Gemfile work with stricter Gemfile interpretation for IDE tool

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -152,7 +152,18 @@ gem 'intercom', '~> 4.2'
 gem 'mjml-rails', '~> 4.9'
 gem 'cloudfront-rails', '~> 0.4'
 
-Dir.children('engines/free').each do |engine_name|
+free_engines = [
+  'document_annotation',
+  'email_campaigns',
+  'frontend',
+  'onboarding',
+  'polls',
+  'seo',
+  'surveys',
+  'volunteering'
+]
+
+free_engines.each do |engine_name|
   path = "engines/free/#{engine_name}"
   gem engine_name, path: path if File.directory?(path)
 end

--- a/back/Gemfile
+++ b/back/Gemfile
@@ -152,15 +152,15 @@ gem 'intercom', '~> 4.2'
 gem 'mjml-rails', '~> 4.9'
 gem 'cloudfront-rails', '~> 0.4'
 
-free_engines = [
-  'document_annotation',
-  'email_campaigns',
-  'frontend',
-  'onboarding',
-  'polls',
-  'seo',
-  'surveys',
-  'volunteering'
+free_engines = %w[
+  document_annotation
+  email_campaigns
+  frontend
+  onboarding
+  polls
+  seo
+  surveys
+  volunteering
 ]
 
 free_engines.each do |engine_name|


### PR DESCRIPTION
Was tired of wasting time with fixing Rubocop issues, so investigated why my vscode extension rembornix/ruby (most popular ruby extension in vscode marketplace) was no longer properly working. It seemed to choke on the `Dir` command in our Gemfile.

This fixes it, now working as expected.