### PR TITLE
CL-3960 Fix flaky trending spec

### DIFF
--- a/back/spec/services/sort_by_params_service_spec.rb
+++ b/back/spec/services/sort_by_params_service_spec.rb
@@ -47,7 +47,8 @@ describe SortByParamsService do
         create(:idea, project: timeline_project, **attributes)
       end
     end
-    let(:result_record_ids) { service.sort_ideas(Idea.where(id: ideas.map(&:id)), params, user).pluck(:id) }
+    let(:idea_scope) { Idea.where(id: ideas) }
+    let(:result_record_ids) { service.sort_ideas(idea_scope, params, user).pluck(:id) }
 
     describe 'new' do
       let(:sort) { 'new' }
@@ -105,19 +106,23 @@ describe SortByParamsService do
 
     describe 'trending' do
       let(:sort) { 'trending' }
-      let(:expected_record_ids) { [ideas[0].id, ideas[2].id, ideas[1].id] }
 
       it 'returns the ids in trending order' do
-        expect(result_record_ids).to eq expected_record_ids
+        sorted_scope = idea_scope.order(created_at: :desc)
+        expect_any_instance_of(TrendingIdeaService)
+          .to receive(:sort_trending).with(idea_scope).and_return(sorted_scope)
+        expect(result_record_ids).to eq(sorted_scope.ids)
       end
     end
 
     describe '-trending' do
       let(:sort) { '-trending' }
-      let(:expected_record_ids) { [ideas[1].id, ideas[2].id, ideas[0].id] }
 
       it 'returns the ids in reverse trending order' do
-        expect(result_record_ids).to eq expected_record_ids
+        sorted_scope = idea_scope.order(created_at: :desc)
+        expect_any_instance_of(TrendingIdeaService)
+          .to receive(:sort_trending).with(idea_scope).and_return(sorted_scope)
+        expect(result_record_ids).to eq(sorted_scope.ids.reverse)
       end
     end
 

--- a/back/spec/services/sort_by_params_service_spec.rb
+++ b/back/spec/services/sort_by_params_service_spec.rb
@@ -105,19 +105,19 @@ describe SortByParamsService do
 
     describe 'trending' do
       let(:sort) { 'trending' }
+      let(:expected_record_ids) { [ideas[0].id, ideas[2].id, ideas[1].id] }
 
       it 'returns the ids in trending order' do
-        allow_any_instance_of(TrendingIdeaService).to receive(:sort_trending).with(ideas).and_return ideas
-        expect(result_record_ids).to eq ideas.map(&:id)
+        expect(result_record_ids).to eq expected_record_ids
       end
     end
 
     describe '-trending' do
       let(:sort) { '-trending' }
+      let(:expected_record_ids) { [ideas[1].id, ideas[2].id, ideas[0].id] }
 
       it 'returns the ids in reverse trending order' do
-        allow_any_instance_of(TrendingIdeaService).to receive(:sort_trending).with(ideas).and_return ideas
-        expect(result_record_ids).to eq ideas.map(&:id).reverse
+        expect(result_record_ids).to eq expected_record_ids
       end
     end
 


### PR DESCRIPTION
See e.g. https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/123647/workflows/b03c9fc4-ce27-4964-a274-473070c8a4b2/jobs/294917

It seems that sometimes `ideas` is a scope and sometimes it's an array, determined by randomness. I don't understand how, but to fix, I changed the spec so it's consistent with the other specs in the file. Sadly I also removed the expectation that `sort_trending` is called, as this is probably where randomly different types of ideas are being returned.