### PR TITLE
[TAN-131] Consider review feature when setting transition types

### DIFF
--- a/back/app/services/initiative_status_service.rb
+++ b/back/app/services/initiative_status_service.rb
@@ -123,7 +123,9 @@ class InitiativeStatusService
 
   def manual_status_ids
     statuses = InitiativeStatus.where(code: MANUAL_TRANSITIONS.values.map(&:keys).flatten.uniq)
-    statuses = statuses.where.not(code: 'proposed') unless Initiative.review_required?
+
+    status_when_published = Initiative.review_required? ? 'review_pending' : 'proposed'
+    statuses = statuses.where.not(code: status_when_published)
 
     statuses.ids
   end

--- a/back/spec/services/initiative_status_service_spec.rb
+++ b/back/spec/services/initiative_status_service_spec.rb
@@ -100,14 +100,29 @@ describe InitiativeStatusService do
         configuration.save!
       end
 
+      it 'is active' do
+        expect(Initiative.review_required?).to be true
+      end
+
+      it 'labels the review_pending status as automatic' do
+        expect(service.transition_type(status_review_pending)).to eq 'automatic'
+      end
+
       it 'labels the proposed status as manual' do
         expect(service.transition_type(status_proposed)).to eq 'manual'
       end
     end
 
     context 'when review feature is not fully activated' do
-      it 'labels the proposed status as automatic' do
+      it 'is not active' do
         expect(Initiative.review_required?).to be false
+      end
+
+      it 'labels the review_pending status as manual' do
+        expect(service.transition_type(status_review_pending)).to eq 'manual'
+      end
+
+      it 'labels the proposed status as automatic' do
         expect(service.transition_type(status_proposed)).to eq 'automatic'
       end
     end


### PR DESCRIPTION
Fixes an obvious oversight by me. See [ticket](https://www.notion.so/citizenlab/BE-Fix-manual_status_ids-should-properly-consider-review-feature-in-activity-589def40ccdb41dfb28e598a7d080af4?pvs=4) for details.

We'll need to also consider the co-sponsorship feature in this regard when we implement it.

![transition_types](https://github.com/CitizenLabDotCo/citizenlab/assets/3944042/e61852e3-1f70-46f0-b77c-fa1bf7cfa537)

# Changelog
## Tecnhical
- [TAN-131] Adjust `intitiative_statuses` `transition_types` when review feature active
