### PR TITLE
[TAN-133] Set submit button copy conditionally

### DIFF
--- a/front/app/components/InitiativeForm/index.tsx
+++ b/front/app/components/InitiativeForm/index.tsx
@@ -22,6 +22,9 @@ import FileUploader from 'components/UI/FileUploader';
 import Error from 'components/UI/Error';
 import ProfileVisiblity from 'components/ProfileVisibility';
 
+// hooks
+import useInitiativeReviewRequired from 'hooks/useInitiativeReviewRequired';
+
 // intl
 import messages from './messages';
 import { MessageDescriptor, FormattedMessage, useIntl } from 'utils/cl-intl';
@@ -255,6 +258,7 @@ const InitiativeForm = ({
     appConfiguration.data?.data.attributes.settings.initiatives
       ?.allow_anonymous_participation;
   const mapsLoaded = window.googleMaps;
+  const initiativeReviewRequired = useInitiativeReviewRequired();
 
   if (!isNilOrError(topics)) {
     const availableTopics = topics.filter((topic) => !isNilOrError(topic));
@@ -469,7 +473,11 @@ const InitiativeForm = ({
 
         <FormSubmitFooter
           className="e2e-initiative-publish-button"
-          message={messages.publishButton}
+          message={
+            initiativeReviewRequired
+              ? messages.submitButton
+              : messages.publishButton
+          }
           error={publishError}
           errorMessage={messages.submitApiError}
           processing={publishing}

--- a/front/app/components/InitiativeForm/messages.ts
+++ b/front/app/components/InitiativeForm/messages.ts
@@ -169,6 +169,10 @@ export default defineMessages({
     id: 'app.components.InitiativeForm.publishButton',
     defaultMessage: 'Publish your initiative',
   },
+  submitButton: {
+    id: 'app.components.InitiativeForm.submitButton',
+    defaultMessage: 'Submit your proposal',
+  },
   submitApiError: {
     id: 'app.components.InitiativeForm.submitApiError',
     defaultMessage:

--- a/front/app/translations/en.json
+++ b/front/app/translations/en.json
@@ -197,6 +197,7 @@
   "app.components.InitiativeForm.profanityError": "Oops! It looks like your post contains some language that doesn’t meet {guidelinesLink}. We try to keep this a safe space for everyone. Please edit your input and try again.",
   "app.components.InitiativeForm.publishButton": "Publish your proposal",
   "app.components.InitiativeForm.submitApiError": "There was an issue submitting the form. Please check for any errors and try again.",
+  "app.components.InitiativeForm.submitButton": "Submit your proposal",
   "app.components.InitiativeForm.titleEmptyError": "Please provide a title",
   "app.components.InitiativeForm.titleLabel": "Title",
   "app.components.InitiativeForm.titleLabelSubtext2": "Choose a descriptive, yet concise title (min. 10 characters, max. 72 characters)",


### PR DESCRIPTION
When review feature is active, we change the button copy to 'Submit your proposal'. When off, we use the original copy 'Publish your proposal'.

I chose 'Submit your proposal' as this can also be used when/if the planned new co-sponsorship feature is active.

# Changelog
## Technical
- [TAN-133] Set proposal submit button copy conditionally on review feature state