### PR TITLE
[TAN-123] Add initiative editing_locked functionality

### DIFF
--- a/back/app/services/side_fx_initiative_status_change_service.rb
+++ b/back/app/services/side_fx_initiative_status_change_service.rb
@@ -6,6 +6,16 @@ class SideFxInitiativeStatusChangeService
   def before_create(change, user); end
 
   def after_create(change, user)
+    lock_initiative_editing_if_required(change)
+
     InitiativeStatusService.new.log_status_change change, user: user
+  end
+
+  private
+
+  def lock_initiative_editing_if_required(change)
+    return unless change.initiative_status.code == 'proposed' && Initiative.review_required?
+
+    change.initiative.update!(editing_locked: true)
   end
 end

--- a/back/app/services/side_fx_reaction_service.rb
+++ b/back/app/services/side_fx_reaction_service.rb
@@ -8,6 +8,8 @@ class SideFxReactionService
   def after_create(reaction, current_user)
     if reaction.reactable_type == 'Initiative'
       AutomatedTransitionJob.perform_now
+
+      lock_initiative_editing_if_required(reaction)
     end
 
     action = "#{reactable_type(reaction)}_#{reaction.mode == 'up' ? 'liked' : 'disliked'}" # TODO: Action name
@@ -22,6 +24,12 @@ class SideFxReactionService
   end
 
   private
+
+  def lock_initiative_editing_if_required(reaction)
+    return if reaction.reactable.editing_locked || reaction.user_id == reaction.reactable.author_id
+
+    reaction.reactable.update!(editing_locked: true)
+  end
 
   def reactable_type(reaction)
     reaction.reactable_type.underscore

--- a/back/spec/acceptance/initiative_reactions_spec.rb
+++ b/back/spec/acceptance/initiative_reactions_spec.rb
@@ -75,6 +75,13 @@ resource 'Reactions' do
       assert_status 201
       expect(@initiative.reload.initiative_status).to eq @status_threshold_reached
     end
+
+    example 'The first non-author reaction create action will set editing_locked to true', document: false do
+      expect(@initiative.reload.editing_locked).to be false
+      do_request
+      assert_status 201
+      expect(@initiative.reload.editing_locked).to be true
+    end
   end
 
   post 'web_api/v1/initiatives/:initiative_id/reactions/up' do


### PR DESCRIPTION
Sets `editing_locked: true` if...
1. `initiative_status` is changed to `proposed` && review feature is active
2. review feature is inactive && first non-author reaction is created for initiative

# Changelog
## Technical
- [TAN-123] initiative editing_locked functionality (proposal review feature in development)
