### PR TITLE
Fix idea location display

### DIFF
--- a/front/app/containers/IdeasShow/components/MetaInformation/Location.tsx
+++ b/front/app/containers/IdeasShow/components/MetaInformation/Location.tsx
@@ -6,7 +6,7 @@ import { isNilOrError } from 'utils/helperUtils';
 import { isNil } from 'lodash-es';
 
 // components
-import { Icon, colors } from '@citizenlab/cl2-component-library';
+import { Icon, Text, colors } from '@citizenlab/cl2-component-library';
 import Modal from 'components/UI/Modal';
 import Map, { Point } from 'components/Map';
 import {
@@ -122,15 +122,28 @@ const Location = memo<Props>(({ projectId, ideaId, compact, className }) => {
     setIsOpened(true);
   };
 
-  if (address && points) {
+  if (address) {
     return (
       <Item className={className || ''} compact={compact}>
         <Header>{formatMessage(messages.location)}</Header>
         <Container>
           <StyledIcon name="position" ariaHidden />
-          <OpenMapModalButton id="e2e-map-popup" onClick={openModal}>
-            {address}
-          </OpenMapModalButton>
+          {point && (
+            <OpenMapModalButton id="e2e-map-popup" onClick={openModal}>
+              {address}
+            </OpenMapModalButton>
+          )}
+          {!point && (
+            <Text
+              m="0px"
+              p="0px"
+              id="e2e-address-text-only"
+              color="coolGrey600"
+              fontSize="s"
+            >
+              {address}
+            </Text>
+          )}
         </Container>
         <Modal
           opened={isOpened}

--- a/front/cypress/e2e/idea_page_content.cy.ts
+++ b/front/cypress/e2e/idea_page_content.cy.ts
@@ -180,3 +180,78 @@ describe('Idea Page', () => {
     });
   });
 });
+
+describe('Idea location', () => {
+  let projectId: string = null as any;
+  let ideaNoLocationPointId: string = null as any;
+  let ideaWithLocationPointId: string = null as any;
+  const projectTitle = randomString();
+  const projectDescriptionPreview = randomString();
+  const projectDescription = randomString();
+  const ideaNoLocationPointTitle = randomString();
+  const ideaWithLocationPointTitle = randomString();
+  const ideaContent = randomString();
+  const locationDescription = '43 Dummy Address';
+  const locationGeojson = {
+    type: 'Point',
+    coordinates: [4.436279683196275, 50.87327010998867],
+  };
+
+  before(() => {
+    cy.apiCreateProject({
+      type: 'continuous',
+      title: projectTitle,
+      descriptionPreview: projectDescriptionPreview,
+      description: projectDescription,
+      publicationStatus: 'published',
+      participationMethod: 'ideation',
+    })
+      .then((project) => {
+        projectId = project.body.data.id;
+        return cy.apiCreateIdea(
+          projectId,
+          ideaNoLocationPointTitle,
+          ideaContent,
+          undefined,
+          locationDescription
+        );
+      })
+      .then((idea) => {
+        ideaNoLocationPointId = idea.body.data.id;
+        return cy.apiCreateIdea(
+          projectId,
+          ideaWithLocationPointTitle,
+          ideaContent,
+          locationGeojson,
+          locationDescription
+        );
+      })
+      .then((idea) => {
+        ideaWithLocationPointId = idea.body.data.id;
+      });
+  });
+
+  it('has a correct location if missing location_point attribute', () => {
+    // Shows only the text location description if location_point missing
+    cy.visit(`/ideas/${ideaNoLocationPointTitle}`);
+    cy.get('#e2e-idea-show');
+    cy.get('#e2e-idea-show-page-content');
+    cy.get('#e2e-map-popup').should('not.exist');
+    cy.get('#e2e-address-text-only').should('exist');
+  });
+
+  it('has a correct location if contains location_point attribute', () => {
+    // Shows the clickable location link when there is a location_point
+    cy.visit(`/ideas/${ideaWithLocationPointTitle}`);
+    cy.get('#e2e-idea-show');
+    cy.get('#e2e-idea-show-page-content');
+    cy.get('#e2e-map-popup').should('exist');
+    cy.get('#e2e-address-text-only').should('not.exist');
+  });
+
+  after(() => {
+    cy.apiRemoveIdea(ideaNoLocationPointId);
+    cy.apiRemoveIdea(ideaWithLocationPointId);
+    cy.apiRemoveProject(projectId);
+  });
+});


### PR DESCRIPTION
# Description
For ideas where there is no location_point_geojson, we still want to display the location_description if it exists.

# Changelog
### Fixed
- Display idea location text even if there are no location coordinates
