### PR TITLE
TAN-177 - Register users without emails using unique code & allow blank emails in import

### DIFF
--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_28_160743) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_03_112021) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -1464,10 +1464,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_28_160743) do
     t.string "block_reason"
     t.datetime "block_end_at", precision: nil
     t.string "new_email"
+    t.string "unique_code"
     t.index "lower((email)::text)", name: "users_unique_lower_email_idx", unique: true
     t.index ["email"], name: "index_users_on_email"
     t.index ["registration_completed_at"], name: "index_users_on_registration_completed_at"
     t.index ["slug"], name: "index_users_on_slug", unique: true
+    t.index ["unique_code"], name: "index_users_on_unique_code", unique: true
   end
 
   create_table "verification_verifications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/import_ideas_service.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/import_ideas_service.rb
@@ -65,6 +65,8 @@ module BulkImportIdeas
           next unless key.include? '_'
 
           field, locale = key.split '_'
+          raise Error.new 'bulk_import_ideas_locale_not_valid', value: locale if AppConfiguration.instance.settings('core', 'locales').exclude?(locale)
+
           case field
           when 'Title'
             title_multiloc[locale] = value

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/import_ideas_service.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/import_ideas_service.rb
@@ -170,7 +170,6 @@ module BulkImportIdeas
         return
       end
 
-      published_at = nil
       invalid_date_error = Error.new(
         'bulk_import_ideas_publication_date_invalid_format',
         value: idea_row[:published_at],
@@ -200,8 +199,6 @@ module BulkImportIdeas
         raise Error.new 'bulk_import_ideas_location_point_blank_coordinate', value: "(#{idea_row[:latitude]}, #{idea_row[:longitude]})", row: idea_row[:id]
       end
 
-      lat = nil
-      lon = nil
       begin
         lat = Float idea_row[:latitude]
         lon = Float idea_row[:longitude]
@@ -219,7 +216,6 @@ module BulkImportIdeas
     def add_phase(idea_row, idea_attributes)
       return if idea_row[:phase_rank].blank?
 
-      phase_rank = nil
       begin
         phase_rank = Integer idea_row[:phase_rank]
       rescue ArgumentError => _e

--- a/back/engines/commercial/bulk_import_ideas/spec/services/import_ideas_service_spec.rb
+++ b/back/engines/commercial/bulk_import_ideas/spec/services/import_ideas_service_spec.rb
@@ -312,10 +312,10 @@ describe BulkImportIdeas::ImportIdeasService do
     it 'converts uploaded XLSX to more parseable format for the idea import method' do
       xlsx_array = [
         {
-          'Title_nl-BE' => 'Mijn idee titel',
-          'Title_fr-BE' => 'Mon idée titre',
-          'Body_nl-BE' => 'Mijn idee inhoud',
-          'Body_fr-BE' => 'Mon idée contenu',
+          'Title_nl-NL' => 'Mijn idee titel',
+          'Title_fr-FR' => 'Mon idée titre',
+          'Body_nl-NL' => 'Mijn idee inhoud',
+          'Body_fr-FR' => 'Mon idée contenu',
           'Email' => 'moderator@citizenlab.co',
           'Project' => 'Project 1',
           'Phase' => 2,
@@ -340,8 +340,8 @@ describe BulkImportIdeas::ImportIdeasService do
       expect(idea_rows).to eq [
         {
           id: nil,
-          title_multiloc: { 'nl-BE' => 'Mijn idee titel', 'fr-BE' => 'Mon idée titre' },
-          body_multiloc: { 'nl-BE' => 'Mijn idee inhoud', 'fr-BE' => 'Mon idée contenu' },
+          title_multiloc: { 'nl-NL' => 'Mijn idee titel', 'fr-FR' => 'Mon idée titre' },
+          body_multiloc: { 'nl-NL' => 'Mijn idee inhoud', 'fr-FR' => 'Mon idée contenu' },
           user_email: 'moderator@citizenlab.co',
           project_title: 'Project 1',
           phase_rank: 2,
@@ -367,6 +367,28 @@ describe BulkImportIdeas::ImportIdeasService do
           image_url: nil
         }
       ]
+    end
+
+    it 'throws an error if imported locales do not match any on the tenant' do
+      xlsx_array = [
+        {
+          'Title_nl-BE' => 'Mijn idee titel',
+          'Body_nl-BE' => 'Mijn idee inhoud',
+          'Email' => 'moderator@citizenlab.co',
+          'Project' => 'Project 1',
+          'Phase' => 2,
+          'Date (dd-mm-yyyy)' => '18-07-2022',
+          'Topics' => 'topic 1;topic 2 ; topic 3',
+          'Latitude' => 50.5035,
+          'Longitude' => 6.0944,
+          'Location Description' => 'Panorama sur les Hautes Fagnes / Hohes Venn',
+          'Image URL' => 'https://images.com/image.png'
+        }
+      ]
+
+      expect { service.xlsx_to_idea_rows xlsx_array }.to raise_error(
+        an_instance_of(BulkImportIdeas::Error).and(having_attributes(key: 'bulk_import_ideas_locale_not_valid', params: { value: 'nl-BE' }))
+      )
     end
   end
 end

--- a/back/engines/commercial/bulk_import_ideas/spec/services/import_ideas_service_spec.rb
+++ b/back/engines/commercial/bulk_import_ideas/spec/services/import_ideas_service_spec.rb
@@ -8,7 +8,7 @@ describe BulkImportIdeas::ImportIdeasService do
   describe 'import_ideas' do
     before { create(:idea_status, code: 'proposed') }
 
-    it 'imports multiple ideas' do
+    it 'imports multiple ideas to existing authors' do
       project1 = create(:project, title_multiloc: { 'fr-BE' => 'Projet un', 'en' => 'Project 1' })
       project2 = create(:project, title_multiloc: { 'nl-BE' => 'Project twee', 'en' => 'Project 2' })
       create(:idea, project: project2)
@@ -42,6 +42,56 @@ describe BulkImportIdeas::ImportIdeasService do
       expect(idea2.project_id).to eq project2.id
       expect(idea2.title_multiloc).to eq({ 'en' => 'My idea title 2' })
       expect(idea2.body_multiloc).to eq({ 'en' => 'My idea description 2' })
+    end
+
+    it 'imports multiple ideas and creates new authors - with or without email addresses' do
+      project1 = create(:project, title_multiloc: { 'fr-BE' => 'Projet un', 'en' => 'Project 1' })
+      project2 = create(:project, title_multiloc: { 'nl-BE' => 'Project twee', 'en' => 'Project 2' })
+      project3 = create(:project, title_multiloc: { 'fr-BE' => 'Projet trois', 'en' => 'Project 3' })
+
+      idea_rows = [
+        {
+          title_multiloc: { 'en' => 'My idea title' },
+          body_multiloc: { 'en' => 'My idea description' },
+          project_title: 'Project 1',
+          user_email: 'userimport1@citizenlab.co'
+        },
+        {
+          title_multiloc: { 'en' => 'My idea title 2' },
+          body_multiloc: { 'en' => 'My idea description 2' },
+          project_title: 'Project 2',
+          user_email: nil
+        },
+        {
+          title_multiloc: { 'en' => 'My idea title 3' },
+          body_multiloc: { 'en' => 'My idea description 3' },
+          project_title: 'Project 3',
+          user_email: 'userimport1@citizenlab.co'
+        }
+      ]
+      service.import_ideas idea_rows
+
+      expect(project1.reload.ideas_count).to eq 1
+      idea1 = project1.ideas.first
+      expect(idea1.project_id).to eq project1.id
+      expect(idea1.title_multiloc).to eq({ 'en' => 'My idea title' })
+      expect(idea1.body_multiloc).to eq({ 'en' => 'My idea description' })
+      expect(idea1.author[:email]).to eq 'userimport1@citizenlab.co'
+
+      expect(project2.reload.ideas_count).to eq 1
+      idea2 = project2.ideas.first
+      expect(idea2.project_id).to eq project2.id
+      expect(idea2.title_multiloc).to eq({ 'en' => 'My idea title 2' })
+      expect(idea2.body_multiloc).to eq({ 'en' => 'My idea description 2' })
+      expect(idea2.author.email).to be_nil
+      expect(idea2.author.unique_code).not_to be_nil
+
+      expect(project3.reload.ideas_count).to eq 1
+      idea3 = project3.ideas.first
+      expect(idea3.project_id).to eq project3.id
+      expect(idea3.title_multiloc).to eq({ 'en' => 'My idea title 3' })
+      expect(idea3.body_multiloc).to eq({ 'en' => 'My idea description 3' })
+      expect(idea3.author).to eq idea1.author
     end
 
     it 'imports ideas with publication info' do

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -196,6 +196,16 @@ RSpec.describe User do
       expect(u1).to be_invalid
       expect(u1.errors.details[:email]).to eq [{ error: :domain_blacklisted, value: '039b1ee.netsolhost.com' }]
     end
+
+    it 'is required when a unique code is not present' do
+      u1 = build(:user, email: nil)
+      expect(u1).to be_invalid
+    end
+
+    it 'is not required when a unique code is present' do
+      u1 = build(:user, email: nil, unique_code: '1234abcd')
+      expect(u1).to be_valid
+    end
   end
 
   describe 'new_email' do
@@ -219,6 +229,13 @@ RSpec.describe User do
       expect(user).to be_invalid
       expect(user.errors.details[:new_email]).not_to be_present
       expect(user.errors.details[:email]).to eq [{ error: :taken, value: 'kOeN@citizenlab.co' }]
+    end
+  end
+
+  describe 'unique_code' do
+    it 'returns an error if it already exists' do
+      create(:user, unique_code: '1234abcd')
+      expect { create(:user, unique_code: '1234abcd') }.to raise_error(ActiveRecord::RecordNotUnique)
     end
   end
 


### PR DESCRIPTION
# Changelog

## Updated
- Bulk importer will create users where the email address does not exist
- Bulk importer will also create entirely anonymous users with a unique code if an idea has no email at all
- Added validation to importer to ensure only valid locales can be imported

## Technical
- Users can be registered without an email using a unique code instead
