### PR TITLE
TAN-114 Tag counts

### DIFF
--- a/back/engines/commercial/analysis/app/serializers/analysis/web_api/v1/tag_serializer.rb
+++ b/back/engines/commercial/analysis/app/serializers/analysis/web_api/v1/tag_serializer.rb
@@ -3,4 +3,12 @@
 class Analysis::WebApi::V1::TagSerializer < WebApi::V1::BaseSerializer
   attributes :created_at, :updated_at, :tag_type, :name
   belongs_to :analysis, class_name: 'Analysis::Analysis'
+
+  attribute :total_input_count do |tag, params|
+    params[:total_input_counts][tag.id] || 0
+  end
+
+  attribute :filtered_input_count do |tag, params|
+    params[:filtered_input_counts][tag.id] || 0
+  end
 end

--- a/back/engines/commercial/analysis/app/services/analysis/tag_counter.rb
+++ b/back/engines/commercial/analysis/app/services/analysis/tag_counter.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Analysis
+  class TagCounter
+    def initialize(analysis, filters: {}, tags: nil)
+      @tags = tags || analysis.tags
+      @analysis = analysis
+      @filters = filters
+      @inputs_finder = InputsFinder.new(analysis, filters)
+    end
+
+    def execute
+      inputs = @inputs_finder.execute
+
+      Tagging
+        .where(input: inputs, tag: @tags)
+        .group(:tag_id)
+        .count
+    end
+  end
+end

--- a/back/engines/commercial/analysis/spec/acceptance/tags_spec.rb
+++ b/back/engines/commercial/analysis/spec/acceptance/tags_spec.rb
@@ -38,16 +38,47 @@ resource 'Tags' do
   end
 
   get 'web_api/v1/analyses/:analysis_id/tags' do
+    with_options required: false do
+      parameter :search, 'Filter by searching in title and body'
+      parameter :'author_custom_<uuid>_from', 'Filter by custom field value of the author for numerical or date fields, larger than or equal to. Replace <uuid> with the custom_field id'
+      parameter :'author_custom_<uuid>_to', 'Filter by custom field value of the author for numerical or date fields, smaller than or equal to. Replace <uuid> with the custom_field id'
+      parameter :'author_custom_<uuid>', 'Filter by custom field value of the author, for select, multiselect, date and number fields (union). Replace <uuid> with the custom_field id', type: :array
+      parameter :published_at_from, 'Filter by input publication date, after or equal to', type: :date
+      parameter :published_at_to, 'Filter by input publication date, before or equal to', type: :date
+      parameter :reactions_from, 'Filter by number of reactions on the input, larger than or equal to', type: :integer
+      parameter :reactions_to, 'Filter by number of reactions on the input, smaller than or equal to', type: :integer
+      parameter :votes_from, 'Filter by number of votes on the input, larger than or equal to', type: :integer
+      parameter :votes_to, 'Filter by number of votes on the input, smaller than or equal to', type: :integer
+      parameter :comments_from, 'Filter by number of comments on the input, larger than or equal to', type: :integer
+      parameter :comments_to, 'Filter by number of comments on the input, smaller than or equal to', type: :integer
+    end
+
     let(:analysis) { create(:analysis) }
     let(:analysis_id) { analysis.id }
+    let(:comments_from) { 5 }
     let!(:tags) { create_list(:tag, 3, analysis: analysis) }
+    let!(:input1) { create(:idea, project: analysis.project, comments_count: 2) }
+    let!(:input2) { create(:idea, project: analysis.project, comments_count: 5) }
+    let!(:input3) { create(:idea, project: analysis.project, comments_count: 5) }
+    let!(:taggings) do
+      create(:tagging, input: input1, tag: tags[0])
+      create(:tagging, input: input1, tag: tags[1])
+      create(:tagging, input: input2, tag: tags[1])
+    end
 
     context 'when admin' do
       before { admin_header_token }
 
       example_request 'lists all tags of an analysis' do
         assert_status 200
-        expect(json_response_body[:data].pluck(:id)).to match_array(tags.pluck(:id))
+        expect(response_data.pluck(:id)).to match_array(tags.pluck(:id))
+        expect(response_data.find { |d| d[:id] == tags[0].id }[:attributes][:total_input_count]).to eq 1
+        expect(response_data.find { |d| d[:id] == tags[1].id }[:attributes][:total_input_count]).to eq 2
+        expect(response_data.find { |d| d[:id] == tags[2].id }[:attributes][:total_input_count]).to eq 0
+
+        expect(response_data.find { |d| d[:id] == tags[0].id }[:attributes][:filtered_input_count]).to eq 0
+        expect(response_data.find { |d| d[:id] == tags[1].id }[:attributes][:filtered_input_count]).to eq 1
+        expect(response_data.find { |d| d[:id] == tags[2].id }[:attributes][:filtered_input_count]).to eq 0
       end
 
       example 'returns 404 if the analysis does not exist', document: false do
@@ -82,7 +113,7 @@ resource 'Tags' do
           data: {
             id: kind_of(String),
             type: 'tag',
-            attributes: { name: name, tag_type: 'custom', created_at: kind_of(String), updated_at: kind_of(String) },
+            attributes: { name: name, tag_type: 'custom', total_input_count: 0, filtered_input_count: 0, created_at: kind_of(String), updated_at: kind_of(String) },
             relationships: { analysis: { data: { id: analysis_id, type: 'analysis' } } }
           }
         }
@@ -120,7 +151,7 @@ resource 'Tags' do
           data: {
             id: anything,
             type: 'tag',
-            attributes: { name: name, tag_type: 'custom', created_at: anything, updated_at: anything },
+            attributes: { name: name, tag_type: 'custom', created_at: anything, total_input_count: 0, filtered_input_count: 0, updated_at: anything },
             relationships: {
               analysis: { data: { id: analysis_id, type: 'analysis' } }
             }

--- a/back/engines/commercial/analysis/spec/acceptance/tags_spec.rb
+++ b/back/engines/commercial/analysis/spec/acceptance/tags_spec.rb
@@ -53,14 +53,13 @@ resource 'Tags' do
       parameter :comments_to, 'Filter by number of comments on the input, smaller than or equal to', type: :integer
     end
 
-    let(:analysis) { create(:analysis) }
-    let(:analysis_id) { analysis.id }
-    let(:comments_from) { 5 }
-    let!(:tags) { create_list(:tag, 3, analysis: analysis) }
-    let!(:input1) { create(:idea, project: analysis.project, comments_count: 2) }
-    let!(:input2) { create(:idea, project: analysis.project, comments_count: 5) }
-    let!(:input3) { create(:idea, project: analysis.project, comments_count: 5) }
-    let!(:taggings) do
+    let_it_be(:analysis) { create(:analysis) }
+    let_it_be(:analysis_id) { analysis.id }
+    let_it_be(:tags) { create_list(:tag, 3, analysis: analysis) }
+    let_it_be(:input1) { create(:idea, project: analysis.project, comments_count: 2) }
+    let_it_be(:input2) { create(:idea, project: analysis.project, comments_count: 5) }
+    let_it_be(:input3) { create(:idea, project: analysis.project, comments_count: 5) }
+    let_it_be(:taggings) do
       create(:tagging, input: input1, tag: tags[0])
       create(:tagging, input: input1, tag: tags[1])
       create(:tagging, input: input2, tag: tags[1])
@@ -72,6 +71,12 @@ resource 'Tags' do
       example_request 'lists all tags of an analysis' do
         assert_status 200
         expect(response_data.pluck(:id)).to match_array(tags.pluck(:id))
+      end
+
+      example 'lists filtered tags of analysis (comments > 5), with correct counts', document: false do
+        do_request(comments_from: 5)
+        assert_status 200
+
         expect(response_data.find { |d| d[:id] == tags[0].id }[:attributes][:total_input_count]).to eq 1
         expect(response_data.find { |d| d[:id] == tags[1].id }[:attributes][:total_input_count]).to eq 2
         expect(response_data.find { |d| d[:id] == tags[2].id }[:attributes][:total_input_count]).to eq 0

--- a/front/app/api/analysis_tags/__mocks__/useAnalysisTags.ts
+++ b/front/app/api/analysis_tags/__mocks__/useAnalysisTags.ts
@@ -6,6 +6,8 @@ export const tagsData: ITagData[] = [
     type: 'tag',
     attributes: {
       name: 'Tag 1',
+      total_input_count: 4,
+      filtered_input_count: 4,
       tag_type: 'custom',
       created_at: '2020-01-01T00:00:00.000Z',
       updated_at: '2020-01-01T00:00:00.000Z',

--- a/front/app/api/analysis_tags/types.ts
+++ b/front/app/api/analysis_tags/types.ts
@@ -22,6 +22,8 @@ export interface ITagData {
   type: 'tag';
   attributes: {
     name: string;
+    total_input_count: number;
+    filtered_input_count: number;
     tag_type: TagType;
     created_at: string;
     updated_at: string;

--- a/front/app/api/analysis_tags/types.ts
+++ b/front/app/api/analysis_tags/types.ts
@@ -1,10 +1,12 @@
 import { Keys } from 'utils/cl-react-query/types';
 import tagsKeys from './keys';
+import { IInputsFilterParams } from 'api/analysis_inputs/types';
 
 export type TagsKeys = Keys<typeof tagsKeys>;
 
 export interface ITagParams {
   analysisId: string;
+  filters?: Omit<IInputsFilterParams, 'tag_ids'>;
 }
 
 export const tagTypes = [

--- a/front/app/api/analysis_tags/useAnalysisTags.ts
+++ b/front/app/api/analysis_tags/useAnalysisTags.ts
@@ -4,10 +4,11 @@ import fetcher from 'utils/cl-react-query/fetcher';
 import tagsKeys from './keys';
 import { ITags, TagsKeys, ITagParams } from './types';
 
-const fetchTags = ({ analysisId }: ITagParams) => {
+const fetchTags = ({ analysisId, filters }: ITagParams) => {
   return fetcher<ITags>({
     path: `/analyses/${analysisId}/tags`,
     action: 'get',
+    queryParams: filters,
   });
 };
 

--- a/front/app/containers/Admin/projects/project/analysis/InputsList/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/InputsList/index.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import { Box, colors, Button } from '@citizenlab/cl2-component-library';
 import useInfiniteAnalysisInputs from 'api/analysis_inputs/useInfiniteAnalysisInputs';
-import { useSearchParams, useParams } from 'react-router-dom';
-import { pick } from 'lodash-es';
+import { useParams } from 'react-router-dom';
 import InputListItem from './InputListItem';
-import { handleArraySearchParam } from '../util';
 import useAddAnalysisSummary from 'api/analysis_summaries/useAddAnalysisSummary';
+import useAnalysisFilterParams from '../hooks/useAnalysisFilterParams';
 
 interface Props {
   onSelectInput: (inputId: string) => void;
@@ -14,26 +13,11 @@ interface Props {
 
 const InputsList = ({ onSelectInput, selectedInputId }: Props) => {
   const { analysisId } = useParams() as { analysisId: string };
-  const [searchParams] = useSearchParams();
-
-  const allParams = Object.fromEntries(searchParams.entries());
-  const filters = pick(allParams, [
-    'search',
-    'published_at_from',
-    'published_at_to',
-    'reactions_from',
-    'reactions_to',
-    'votes_from',
-    'votes_to',
-    'comments_from',
-    'comments_to',
-  ]);
-
-  const selectedTags = handleArraySearchParam(searchParams, 'tag_ids');
+  const filters = useAnalysisFilterParams();
 
   const { data, fetchNextPage, hasNextPage } = useInfiniteAnalysisInputs({
     analysisId,
-    queryParams: { ...filters, tag_ids: selectedTags },
+    queryParams: filters,
   });
   const { mutate: addsummary, isLoading } = useAddAnalysisSummary();
 
@@ -42,7 +26,7 @@ const InputsList = ({ onSelectInput, selectedInputId }: Props) => {
   const handleSummaryCreate = () => {
     addsummary({
       analysisId,
-      filters: { ...filters, tag_ids: selectedTags },
+      filters,
     });
   };
 

--- a/front/app/containers/Admin/projects/project/analysis/Tags/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Tags/index.tsx
@@ -1,4 +1,14 @@
 import React, { useState } from 'react';
+import styled from 'styled-components';
+import { max, omit } from 'lodash-es';
+
+import { useParams } from 'react-router-dom';
+import { removeSearchParams } from 'utils/cl-router/removeSearchParams';
+import { updateSearchParams } from 'utils/cl-router/updateSearchParams';
+import useAnalysisTags from 'api/analysis_tags/useAnalysisTags';
+import useAddAnalysisTag from 'api/analysis_tags/useAddAnalysisTag';
+import useDeleteAnalysisTag from 'api/analysis_tags/useDeleteAnalysisTag';
+import useAnalysisFilterParams from '../hooks/useAnalysisFilterParams';
 
 import {
   Box,
@@ -9,28 +19,16 @@ import {
   stylingConsts,
 } from '@citizenlab/cl2-component-library';
 import Error from 'components/UI/Error';
-
-import useAnalysisTags from 'api/analysis_tags/useAnalysisTags';
-import useAddAnalysisTag from 'api/analysis_tags/useAddAnalysisTag';
-import useDeleteAnalysisTag from 'api/analysis_tags/useDeleteAnalysisTag';
-
-import { useParams, useSearchParams } from 'react-router-dom';
-import { updateSearchParams } from 'utils/cl-router/updateSearchParams';
-
-import messages from '../messages';
-import { useIntl } from 'utils/cl-intl';
 import Modal from 'components/UI/Modal';
 import RenameTagModal from './RenameTagModal';
 import Tag from './Tag';
-import styled from 'styled-components';
-import { removeSearchParams } from 'utils/cl-router/removeSearchParams';
-import { handleArraySearchParam } from '../util';
 import AutotaggingModal from './AutotaggingModal';
+import ProgressBar from 'components/UI/ProgressBar';
+
+import { useIntl } from 'utils/cl-intl';
+import messages from '../messages';
 
 const TagContainer = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
   margin-bottom: 8px;
   padding: 8px;
   border: 1px solid transparent;
@@ -44,12 +42,18 @@ const TagContainer = styled.div`
   cursor: pointer;
 `;
 
+const StyledProgressBar = styled(ProgressBar)<{ width: number }>`
+  height: 5px;
+  width: ${({ width }) => width * 100}%;
+`;
+
 const Tags = () => {
   const [name, setName] = useState('');
   const [renameTagModalOpenedId, setRenameTagModalOpenedId] = useState('');
   const [autotaggingModalIsOpened, setAutotaggingModalIsOpened] =
     useState(false);
-  const [search] = useSearchParams();
+
+  const filters = useAnalysisFilterParams();
 
   const { formatMessage } = useIntl();
 
@@ -57,6 +61,7 @@ const Tags = () => {
 
   const { data: tags } = useAnalysisTags({
     analysisId,
+    filters: omit(filters, 'tag_ids'),
   });
   const { mutate: addTag, isLoading, error } = useAddAnalysisTag();
   const { mutate: deleteTag } = useDeleteAnalysisTag();
@@ -96,7 +101,10 @@ const Tags = () => {
     updateSearchParams({ tag_ids: [id] });
   };
 
-  const selectedTags = handleArraySearchParam(search, 'tag_ids');
+  const maxTotalCount =
+    max(tags?.data?.map((t) => t.attributes.total_input_count)) || 1;
+
+  const selectedTags = filters.tag_ids;
   return (
     <Box>
       <Box>
@@ -153,24 +161,49 @@ const Tags = () => {
             onClick={() => selectTag(tag.id)}
             className={selectedTags?.includes(tag.id) ? 'selected' : ''}
           >
-            <Tag name={tag.attributes.name} tagType={tag.attributes.tag_type} />
-            {tag.attributes.filtered_input_count}/
-            {tag.attributes.total_input_count}
-            <Box display="flex" gap="0px">
-              <IconButton
-                iconName="edit"
-                onClick={() => setRenameTagModalOpenedId(tag.id)}
-                iconColor={colors.grey700}
-                iconColorOnHover={colors.grey700}
-                a11y_buttonActionMessage={formatMessage(messages.editTag)}
+            <Box
+              display="flex"
+              alignItems="center"
+              justifyContent="space-between"
+              mb="3px"
+            >
+              <Tag
+                name={tag.attributes.name}
+                tagType={tag.attributes.tag_type}
               />
-              <IconButton
-                iconName="delete"
-                onClick={() => handleTagDelete(tag.id)}
-                iconColor={colors.red600}
-                iconColorOnHover={colors.red600}
-                a11y_buttonActionMessage={formatMessage(messages.deleteTag)}
+              <Box display="flex" gap="0px">
+                <IconButton
+                  iconName="edit"
+                  onClick={() => setRenameTagModalOpenedId(tag.id)}
+                  iconColor={colors.grey700}
+                  iconColorOnHover={colors.grey700}
+                  a11y_buttonActionMessage={formatMessage(messages.editTag)}
+                />
+                <IconButton
+                  iconName="delete"
+                  onClick={() => handleTagDelete(tag.id)}
+                  iconColor={colors.red600}
+                  iconColorOnHover={colors.red600}
+                  a11y_buttonActionMessage={formatMessage(messages.deleteTag)}
+                />
+              </Box>
+            </Box>
+            <Box display="flex" alignItems="center">
+              <StyledProgressBar
+                width={tag.attributes.total_input_count / maxTotalCount}
+                progress={
+                  tag.attributes.filtered_input_count /
+                  tag.attributes.total_input_count
+                }
+                color={colors.blue700}
+                bgColor={colors.coolGrey300}
               />
+              <Box w="50px" ml="5px">
+                {tag.attributes.filtered_input_count ===
+                tag.attributes.total_input_count
+                  ? tag.attributes.total_input_count
+                  : `${tag.attributes.filtered_input_count}/${tag.attributes.total_input_count}`}
+              </Box>
             </Box>
             <Modal
               opened={renameTagModalOpenedId === tag.id}

--- a/front/app/containers/Admin/projects/project/analysis/Tags/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Tags/index.tsx
@@ -41,6 +41,7 @@ const TagContainer = styled.div`
   &.selected {
     border: 1px solid ${colors.borderLight};
   }
+  cursor: pointer;
 `;
 
 const Tags = () => {
@@ -153,6 +154,8 @@ const Tags = () => {
             className={selectedTags?.includes(tag.id) ? 'selected' : ''}
           >
             <Tag name={tag.attributes.name} tagType={tag.attributes.tag_type} />
+            {tag.attributes.filtered_input_count}/
+            {tag.attributes.total_input_count}
             <Box display="flex" gap="0px">
               <IconButton
                 iconName="edit"

--- a/front/app/containers/Admin/projects/project/analysis/hooks/useAnalysisFilterParams.ts
+++ b/front/app/containers/Admin/projects/project/analysis/hooks/useAnalysisFilterParams.ts
@@ -1,0 +1,33 @@
+import { pick } from 'lodash-es';
+import { useSearchParams } from 'react-router-dom';
+import { handleArraySearchParam } from '../util';
+
+/** Hook that extracts and returns all filter params used in the analysis,
+ * extracted from the url */
+const useAnalysisFilterParams = () => {
+  const [searchParams] = useSearchParams();
+
+  const allParams = Object.fromEntries(searchParams.entries());
+  const scalarFilters = pick(allParams, [
+    'search',
+    'published_at_from',
+    'published_at_to',
+    'reactions_from',
+    'reactions_to',
+    'votes_from',
+    'votes_to',
+    'comments_from',
+    'comments_to',
+  ]);
+
+  const arrayFilters = {
+    tag_ids: handleArraySearchParam(searchParams, 'tag_ids'),
+  };
+
+  return {
+    ...scalarFilters,
+    ...arrayFilters,
+  };
+};
+
+export default useAnalysisFilterParams;


### PR DESCRIPTION
Review is for the BE part, @IvaKop will review/work on the FE part when she's back next week.

Some context: The pre-existing `/inputs` endpoint for an analysis returns inputs (ideas) and offers a bunch of filtering options on these ideas. This PR adds the capability to pass these same filter parameters to the `/tags` endpoint as well, in order to include the counts of these tags, meaning: How many inputs (in total, and given the current filters) are assigned to each tag?

![image](https://github.com/CitizenLabDotCo/citizenlab/assets/329308/0c4ccb76-e095-4d6f-a546-4c6115cdbc5b)

 
# Changelog
## Added
- Analysis now displays how many inputs assigned to each tag (sensemaking WIP, feature flagged)