### PR TITLE
CL-3971 - Do not send moderator emails for archived projects

### DIFF
--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/moderator_digest.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/moderator_digest.rb
@@ -77,7 +77,7 @@ module EmailCampaigns
         next unless project
 
         statistics = statistics project
-        next unless nonzero_statistics?(statistics) && !project.admin_publication.archived?
+        next if project.admin_publication.archived? || zero_statistics?(statistics)
 
         project_name = project.title_multiloc[recipient.locale] || project.title_multiloc[I18n.default_locale]
         top_ideas = top_ideas project, name_service
@@ -145,8 +145,8 @@ module EmailCampaigns
       }
     end
 
-    def nonzero_statistics?(statistics)
-      !((statistics.dig(:activities, :new_ideas, :increase) == 0) &&
+    def zero_statistics?(statistics)
+      ((statistics.dig(:activities, :new_ideas, :increase) == 0) &&
          (statistics.dig(:activities, :new_comments, :increase) == 0) &&
          (statistics.dig(:users, :new_visitors, :increase) == 0) &&
          (statistics.dig(:users, :new_users, :increase) == 0) &&

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/moderator_digest.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/moderator_digest.rb
@@ -151,7 +151,7 @@ module EmailCampaigns
          (statistics.dig(:users, :new_visitors, :increase) == 0) &&
          (statistics.dig(:users, :new_users, :increase) == 0) &&
          (statistics.dig(:users, :active_users, :increase) == 0)
-       )
+      )
     end
 
     def days_ago

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/moderator_digest.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/moderator_digest.rb
@@ -77,7 +77,7 @@ module EmailCampaigns
         next unless project
 
         statistics = statistics project
-        next unless nonzero_statistics? statistics
+        next unless nonzero_statistics?(statistics) && !project.admin_publication.archived?
 
         project_name = project.title_multiloc[recipient.locale] || project.title_multiloc[I18n.default_locale]
         top_ideas = top_ideas project, name_service

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/moderator_digest_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/moderator_digest_spec.rb
@@ -73,6 +73,12 @@ RSpec.describe 'EmailCampaigns::Campaigns::ModeratorDigest', skip: skip_reason d
         commands.flat_map { |command| command.dig(:event_payload, :top_ideas).pluck(:id) }
       ).not_to include response.id
     end
+
+    it 'does not generate a command for archived projects' do
+      project.admin_publication.update! publication_status: 'archived'
+      commands = campaign.generate_commands(recipient: moderator).first
+      expect(commands).to be_blank
+    end
   end
 
   describe 'apply_recipient_filters' do


### PR DESCRIPTION
# Changelog

## Fixed
- CL-3971 - Stopped project overview emails from sending for archived projects
