### PR TITLE
[TAN-94] Allow removal of event locations with PATCH

### DIFF
--- a/back/app/controllers/web_api/v1/events_controller.rb
+++ b/back/app/controllers/web_api/v1/events_controller.rb
@@ -70,12 +70,17 @@ class WebApi::V1::EventsController < ApplicationController
       title_multiloc: CL2_SUPPORTED_LOCALES,
       description_multiloc: CL2_SUPPORTED_LOCALES
     ).tap do |p|
+      # Allow removing the location point.
+      if params[:event].key?(:location_point_geojson) && params.dig(:event, :location_point_geojson).nil?
+        p[:location_point_geojson] = nil
+      end
+
       # Set default location_description if not provided and location_multiloc is
       # provided. This will be removed once the location_multiloc parameter is removed.
-      next if p[:location_multiloc].blank?
-
-      p[:location_description] ||= p.dig(:location_multiloc, default_locale)
-      p[:location_description] ||= p[:location_multiloc].values.first
+      if p[:location_multiloc].present?
+        p[:location_description] ||= p.dig(:location_multiloc, default_locale)
+        p[:location_description] ||= p[:location_multiloc].values.first
+      end
     end
   end
 

--- a/back/spec/acceptance/events_spec.rb
+++ b/back/spec/acceptance/events_spec.rb
@@ -245,6 +245,19 @@ resource 'Events' do
         expect(event.location_point_geojson).to eq(geojson_point)
         expect(event.location_point.coordinates).to eq(geojson_point['coordinates'])
       end
+
+      example 'Remove event location_point_geojson', document: false do
+        event.update!(location_point_geojson: { 'type' => 'Point', 'coordinates' => [10, 20] })
+
+        do_request(event: { location_point_geojson: nil })
+
+        expect(status).to eq 200
+        expect(response_data.dig(:attributes, :location_point_geojson)).to be_nil
+
+        event.reload
+        expect(event.location_point_geojson).to be_nil
+        expect(event.location_point).to be_nil
+      end
     end
 
     delete 'web_api/v1/events/:id' do


### PR DESCRIPTION
# Changelog
## Fixed
- Allow removal of event locations via the web API.
