### PR TITLE
TAN-231 Cosponsor also receives initiative status change notification and mail

### DIFF
--- a/back/app/models/notifications/status_change_of_your_initiative.rb
+++ b/back/app/models/notifications/status_change_of_your_initiative.rb
@@ -69,7 +69,8 @@ module Notifications
 
     def self.make_notifications_on(activity)
       initiative = activity.item
-      recipient_ids = [initiative&.author_id] + initiative&.cosponsor_ids
+      cosponsors_ids = initiative.cosponsors_initiatives.where(status: 'accepted').pluck(:user_id)
+      recipient_ids = [initiative&.author_id] + cosponsors_ids
 
       if initiative && recipient_ids
         recipient_ids.map do |recipient_id|

--- a/back/app/models/notifications/status_change_of_your_initiative.rb
+++ b/back/app/models/notifications/status_change_of_your_initiative.rb
@@ -69,15 +69,17 @@ module Notifications
 
     def self.make_notifications_on(activity)
       initiative = activity.item
-      recipient_id = initiative&.author_id
+      recipient_ids = [initiative&.author_id] + initiative&.cosponsor_ids
 
-      if initiative && recipient_id
-        [new(
-          recipient_id: recipient_id,
-          initiating_user_id: activity.user_id,
-          post: initiative,
-          post_status: initiative.initiative_status
-        )]
+      if initiative && recipient_ids
+        recipient_ids.map do |recipient_id|
+          new(
+            recipient_id: recipient_id,
+            initiating_user_id: activity.user_id,
+            post: initiative,
+            post_status: initiative.initiative_status
+          )
+        end
       else
         []
       end

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/status_change_of_your_initiative_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/status_change_of_your_initiative_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EmailCampaigns::Campaigns::StatusChangeOfYourInitiative do
+  describe 'StatusChangeOfYourInitiative Campaign default factory' do
+    it 'is valid' do
+      expect(build(:status_change_of_your_initiative_campaign)).to be_valid
+    end
+  end
+
+  describe '#generate_commands' do
+    let(:campaign) { create(:status_change_of_your_initiative_campaign) }
+    let(:notification) { create(:status_change_of_your_initiative) }
+    let(:notification_activity) { create(:activity, item: notification, action: 'created') }
+
+    it 'generates a command with the desired payload and tracked content' do
+      command = campaign.generate_commands(
+        recipient: notification_activity.item.recipient,
+        activity: notification_activity
+      ).first
+
+      expect(
+        command.dig(:event_payload, :initiative_status_id)
+      ).to eq(notification.post_status.id)
+    end
+  end
+end


### PR DESCRIPTION
I note that we don't seem to test the recipient filter(s) of notifications, but I tested it manually and it seems to only notify the author + confirmed cosponsors & only mail the same people.

A nice to have might be to add a sentence to the mail: "You are a co-sponsor of this proposal", but we can do this later if we have time.

# Changelog
## Technical
 - [TAN-231] Cosponsor also receives initiative status change notification and mail (cosponsors feature in development)
