### PR TITLE
[TAN-151] Include consponsors_initiatives IDs in initiative serializer

### DIFF
--- a/back/app/serializers/web_api/v1/initiative_serializer.rb
+++ b/back/app/serializers/web_api/v1/initiative_serializer.rb
@@ -37,11 +37,11 @@ class WebApi::V1::InitiativeSerializer < WebApi::V1::BaseSerializer
     can_moderate?(object, params)
   }
 
-  attribute :cosponsorships do |object, params|
+  attribute :cosponsors_initiatives do |object, params|
     name_service = UserDisplayNameService.new(AppConfiguration.instance, current_user(params))
-
+  
     object.cosponsors_initiatives.includes(:user).map do |ci|
-      { user_id: ci.user_id, name: name_service.display_name!(ci.user), status: ci.status }
+      { id: ci.id, user_id: ci.user_id, name: name_service.display_name!(ci.user), status: ci.status }
     end
   end
 

--- a/back/app/serializers/web_api/v1/initiative_serializer.rb
+++ b/back/app/serializers/web_api/v1/initiative_serializer.rb
@@ -39,7 +39,7 @@ class WebApi::V1::InitiativeSerializer < WebApi::V1::BaseSerializer
 
   attribute :cosponsors_initiatives do |object, params|
     name_service = UserDisplayNameService.new(AppConfiguration.instance, current_user(params))
-  
+
     object.cosponsors_initiatives.includes(:user).map do |ci|
       { id: ci.id, user_id: ci.user_id, name: name_service.display_name!(ci.user), status: ci.status }
     end


### PR DESCRIPTION
Also renames serialized attribute to `cosponsors_initiatives`, (from `cosponsorships`), for clarity

# Changelog
## Technical
 - [TAN-151] Include consponsors_initiatives IDs in initiative serializer (cosponsors feature in development)
