### PR TITLE
[TAN-157] Rename endpoint to accept_cosponsorship_invite

### DIFF
--- a/back/app/controllers/web_api/v1/initiatives_controller.rb
+++ b/back/app/controllers/web_api/v1/initiatives_controller.rb
@@ -3,7 +3,7 @@
 class WebApi::V1::InitiativesController < ApplicationController
   include BlockingProfanity
 
-  before_action :set_initiative, only: %i[show update destroy allowed_transitions accept_invite]
+  before_action :set_initiative, only: %i[show update destroy allowed_transitions accept_cosponsorship_invite]
   skip_before_action :authenticate_user
   skip_after_action :verify_authorized, only: %i[index_xlsx index_initiative_markers filter_counts]
 
@@ -178,7 +178,7 @@ class WebApi::V1::InitiativesController < ApplicationController
     end
   end
 
-  def accept_invite
+  def accept_cosponsorship_invite
     @cosponsors_initiative = @initiative.cosponsors_initiatives.find_by(user_id: current_user.id)
     @cosponsors_initiative.update!(status: 'accepted')
   end

--- a/back/app/policies/initiative_policy.rb
+++ b/back/app/policies/initiative_policy.rb
@@ -56,7 +56,7 @@ class InitiativePolicy < ApplicationPolicy
     create?
   end
 
-  def accept_invite?
+  def accept_cosponsorship_invite?
     cosponsor?
   end
 

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -69,7 +69,7 @@ Rails.application.routes.draw do
         get :as_markers, on: :collection, action: 'index_initiative_markers'
         get :filter_counts, on: :collection
         get :allowed_transitions, on: :member
-        patch :accept_invite, on: :member
+        patch :accept_cosponsorship_invite, on: :member
       end
 
       resources :idea_statuses, only: %i[index show]

--- a/back/spec/acceptance/initiatives_spec.rb
+++ b/back/spec/acceptance/initiatives_spec.rb
@@ -689,7 +689,7 @@ resource 'Initiatives' do
     end
   end
 
-  patch 'web_api/v1/initiatives/:id/accept_invite' do
+  patch 'web_api/v1/initiatives/:id/accept_cosponsorship_invite' do
     before do
       @initiative = create(:initiative)
       @cosponsors_initiative = create(:cosponsors_initiative, initiative: @initiative, user: @user)

--- a/back/spec/policies/initiative_policy_spec.rb
+++ b/back/spec/policies/initiative_policy_spec.rb
@@ -38,7 +38,7 @@ describe InitiativePolicy do
         it { is_expected.to permit(:create) }
         it { is_expected.to permit(:update)  }
         it { is_expected.to permit(:destroy) }
-        it { is_expected.not_to permit(:accept_invite) }
+        it { is_expected.not_to permit(:accept_cosponsorship_invite) }
 
         it 'indexes the initiative' do
           expect(scope.resolve.size).to eq 1
@@ -53,7 +53,7 @@ describe InitiativePolicy do
         it { is_expected.not_to permit(:create) }
         it { is_expected.not_to permit(:update) }
         it { is_expected.not_to permit(:destroy) }
-        it { is_expected.not_to permit(:accept_invite) }
+        it { is_expected.not_to permit(:accept_cosponsorship_invite) }
 
         it 'does not index the initiative' do
           expect(scope.resolve.size).to eq 0
@@ -68,7 +68,7 @@ describe InitiativePolicy do
         it { is_expected.to permit(:create) }
         it { is_expected.to permit(:update) }
         it { is_expected.to permit(:destroy) }
-        it { is_expected.not_to permit(:accept_invite) }
+        it { is_expected.not_to permit(:accept_cosponsorship_invite) }
 
         it 'indexes the initiative' do
           expect(scope.resolve.size).to eq 1
@@ -84,7 +84,7 @@ describe InitiativePolicy do
         it { is_expected.not_to permit(:create) }
         it { is_expected.not_to permit(:update) }
         it { is_expected.not_to permit(:destroy) }
-        it { is_expected.to permit(:accept_invite) }
+        it { is_expected.to permit(:accept_cosponsorship_invite) }
 
         it 'indexes the initiative' do
           expect(scope.resolve.size).to eq 1
@@ -99,7 +99,7 @@ describe InitiativePolicy do
         it { expect { policy.create? }.to raise_error(Pundit::NotAuthorizedError) }
         it { expect { policy.update? }.to raise_error(Pundit::NotAuthorizedError) }
         it { expect { policy.destroy? }.to raise_error(Pundit::NotAuthorizedError) }
-        it { is_expected.not_to permit(:accept_invite) }
+        it { is_expected.not_to permit(:accept_cosponsorship_invite) }
 
         it 'does not index the initiative' do
           expect(scope.resolve.size).to eq 0
@@ -120,7 +120,7 @@ describe InitiativePolicy do
         it { is_expected.to permit(:create) }
         it { is_expected.to permit(:update) }
         it { is_expected.to permit(:destroy) }
-        it { is_expected.not_to permit(:accept_invite) }
+        it { is_expected.not_to permit(:accept_cosponsorship_invite) }
 
         it 'indexes the initiative' do
           expect(scope.resolve.size).to eq 1
@@ -135,7 +135,7 @@ describe InitiativePolicy do
         it { is_expected.not_to permit(:create) }
         it { is_expected.not_to permit(:update) }
         it { is_expected.not_to permit(:destroy) }
-        it { is_expected.not_to permit(:accept_invite) }
+        it { is_expected.not_to permit(:accept_cosponsorship_invite) }
 
         it 'indexes the initiative' do
           expect(scope.resolve.size).to eq 1
@@ -150,7 +150,7 @@ describe InitiativePolicy do
         it { is_expected.to permit(:create) }
         it { is_expected.to permit(:update) }
         it { is_expected.to permit(:destroy) }
-        it { is_expected.not_to permit(:accept_invite) }
+        it { is_expected.not_to permit(:accept_cosponsorship_invite) }
 
         it 'indexes the initiative' do
           expect(scope.resolve.size).to eq 1
@@ -166,7 +166,7 @@ describe InitiativePolicy do
         it { is_expected.not_to permit(:create) }
         it { is_expected.not_to permit(:update) }
         it { is_expected.not_to permit(:destroy) }
-        it { is_expected.to permit(:accept_invite) }
+        it { is_expected.to permit(:accept_cosponsorship_invite) }
 
         it 'indexes the initiative' do
           expect(scope.resolve.size).to eq 1
@@ -181,7 +181,7 @@ describe InitiativePolicy do
         it { expect { policy.create? }.to raise_error(Pundit::NotAuthorizedError) }
         it { expect { policy.update? }.to raise_error(Pundit::NotAuthorizedError) }
         it { expect { policy.destroy? }.to raise_error(Pundit::NotAuthorizedError) }
-        it { is_expected.not_to permit(:accept_invite) }
+        it { is_expected.not_to permit(:accept_cosponsorship_invite) }
 
         it 'indexes the initiative' do
           expect(scope.resolve.size).to eq 1
@@ -219,7 +219,7 @@ describe InitiativePolicy do
         it { is_expected.to permit(:create) }
         it { is_expected.to permit(:update) }
         it { is_expected.to permit(:destroy) }
-        it { is_expected.not_to permit(:accept_invite) }
+        it { is_expected.not_to permit(:accept_cosponsorship_invite) }
 
         it 'indexes the initiative' do
           expect(scope.resolve.size).to eq 1
@@ -234,7 +234,7 @@ describe InitiativePolicy do
         it { is_expected.not_to permit(:create) }
         it { is_expected.not_to permit(:update) }
         it { is_expected.not_to permit(:destroy) }
-        it { is_expected.not_to permit(:accept_invite) }
+        it { is_expected.not_to permit(:accept_cosponsorship_invite) }
 
         it 'does not index the initiative' do
           expect(scope.resolve.size).to eq 0
@@ -251,7 +251,7 @@ describe InitiativePolicy do
         it { is_expected.to permit(:create) }
         it { is_expected.to permit(:update) }
         it { is_expected.to permit(:destroy) }
-        it { is_expected.not_to permit(:accept_invite) }
+        it { is_expected.not_to permit(:accept_cosponsorship_invite) }
 
         it 'indexes the initiative' do
           expect(scope.resolve.size).to eq 1
@@ -269,7 +269,7 @@ describe InitiativePolicy do
         it { is_expected.not_to permit(:create) }
         it { is_expected.not_to permit(:update) }
         it { is_expected.not_to permit(:destroy) }
-        it { is_expected.to permit(:accept_invite) }
+        it { is_expected.to permit(:accept_cosponsorship_invite) }
 
         it 'indexes the initiative' do
           expect(scope.resolve.size).to eq 1
@@ -284,7 +284,7 @@ describe InitiativePolicy do
         it { expect { policy.create? }.to raise_error(Pundit::NotAuthorizedError) }
         it { expect { policy.update? }.to raise_error(Pundit::NotAuthorizedError) }
         it { expect { policy.destroy? }.to raise_error(Pundit::NotAuthorizedError) }
-        it { is_expected.not_to permit(:accept_invite) }
+        it { is_expected.not_to permit(:accept_cosponsorship_invite) }
 
         it 'does not index the initiative' do
           expect(scope.resolve.size).to eq 0
@@ -305,7 +305,7 @@ describe InitiativePolicy do
         it { is_expected.to permit(:create) }
         it { is_expected.to permit(:update) }
         it { is_expected.to permit(:destroy) }
-        it { is_expected.not_to permit(:accept_invite) }
+        it { is_expected.not_to permit(:accept_cosponsorship_invite) }
 
         it 'indexes the initiative' do
           expect(scope.resolve.size).to eq 1
@@ -320,7 +320,7 @@ describe InitiativePolicy do
         it { is_expected.not_to permit(:create) }
         it { is_expected.not_to permit(:update) }
         it { is_expected.not_to permit(:destroy) }
-        it { is_expected.not_to permit(:accept_invite) }
+        it { is_expected.not_to permit(:accept_cosponsorship_invite) }
 
         it 'does not index the initiative' do
           expect(scope.resolve.size).to eq 1
@@ -337,7 +337,7 @@ describe InitiativePolicy do
         it { is_expected.to permit(:create) }
         it { is_expected.to permit(:update) } # TODO: This is confusing, as editing_locked should be true when status proposed!
         it { is_expected.to permit(:destroy) }
-        it { is_expected.not_to permit(:accept_invite) }
+        it { is_expected.not_to permit(:accept_cosponsorship_invite) }
 
         it 'indexes the initiative' do
           expect(scope.resolve.size).to eq 1
@@ -353,7 +353,7 @@ describe InitiativePolicy do
         it { is_expected.not_to permit(:create) }
         it { is_expected.not_to permit(:update) }
         it { is_expected.not_to permit(:destroy) }
-        it { is_expected.to permit(:accept_invite) }
+        it { is_expected.to permit(:accept_cosponsorship_invite) }
 
         it 'indexes the initiative' do
           expect(scope.resolve.size).to eq 1
@@ -368,7 +368,7 @@ describe InitiativePolicy do
         it { expect { policy.create? }.to raise_error(Pundit::NotAuthorizedError) }
         it { expect { policy.update? }.to raise_error(Pundit::NotAuthorizedError) }
         it { expect { policy.destroy? }.to raise_error(Pundit::NotAuthorizedError) }
-        it { is_expected.not_to permit(:accept_invite) }
+        it { is_expected.not_to permit(:accept_cosponsorship_invite) }
 
         it 'does not index the initiative' do
           expect(scope.resolve.size).to eq 1
@@ -391,7 +391,7 @@ describe InitiativePolicy do
       it { is_expected.to permit(:create) }
       it { is_expected.not_to permit(:update) }
       it { is_expected.to permit(:destroy) }
-      it { is_expected.not_to permit(:accept_invite) }
+      it { is_expected.not_to permit(:accept_cosponsorship_invite) }
 
       it 'indexes the initiative' do
         expect(scope.resolve.size).to eq 1
@@ -406,7 +406,7 @@ describe InitiativePolicy do
       it { is_expected.to permit(:create) }
       it { is_expected.not_to permit(:update) }
       it { is_expected.to permit(:destroy) }
-      it { is_expected.not_to permit(:accept_invite) }
+      it { is_expected.not_to permit(:accept_cosponsorship_invite) }
 
       it 'indexes the initiative' do
         expect(scope.resolve.size).to eq 1


### PR DESCRIPTION
# Changelog
## Technical
 - [TAN-157] Rename endpoint to accept_cosponsorship_invite (cosponsors feature in development)
