### PR TITLE
[CL-3984] Fix accessibility page not showing on Vienna platform

### DIFF
--- a/front/app/containers/AccessibilityStatement/index.tsx
+++ b/front/app/containers/AccessibilityStatement/index.tsx
@@ -34,7 +34,7 @@ const CookiePolicy = memo((props: WrappedComponentProps) => {
 
       <PageContent>
         <StyledContentContainer>
-          <Fragment name="pages/cookie-policy/content">
+          <Fragment name="pages/accessibility-statement">
             <PageTitle>
               <FormattedMessage {...messages.title} />
             </PageTitle>


### PR DESCRIPTION
# Description
Looks like there were two fragments with the same name:
![image](https://github.com/CitizenLabDotCo/citizenlab/assets/33987955/b6b0c0da-04b4-4535-9004-c688c2415849)

Vienna had enabled the cookie policy fragment, so this seems to cause the problem.

# Note
I've recreated the same issue on the Product staging platform: https://product.stg.citizenlab.co/en/pages/accessibility-statement
Once I merge this I'll confirm that the issue is fixed :) 

I've also looked in the s3 bucket, and there are no tenants using a custom accessibility fragment at this time, so there should be no issue changing the name.

# Changelog
## Fixed
- Fixed accessibility page not showing on Vienna platform
