### PR TITLE
TAN-236 Support all custom field types in analysis

### DIFF
--- a/front/app/api/idea_custom_fields/keys.ts
+++ b/front/app/api/idea_custom_fields/keys.ts
@@ -11,7 +11,7 @@ const ideaCustomFieldsKeys = {
   ],
   items: () => [{ ...baseKey, operation: 'item' }],
   item: ({ customFieldId }: { customFieldId?: string }) => [
-    { ...baseKey, operation: 'item', parameters: { customFieldId } },
+    { ...baseKey, operation: 'item', parameters: { id: customFieldId } },
   ],
 } satisfies QueryKeys;
 

--- a/front/app/api/idea_custom_fields/types.ts
+++ b/front/app/api/idea_custom_fields/types.ts
@@ -11,7 +11,9 @@ export type IIdeaCustomFieldInputType =
   | 'select'
   | 'multiselect'
   | 'checkbox'
-  | 'date';
+  | 'date'
+  | 'linear_scale'
+  | 'file_upload';
 
 export type TCustomFieldCode =
   | 'gender'

--- a/front/app/api/user_custom_fields_options/keys.ts
+++ b/front/app/api/user_custom_fields_options/keys.ts
@@ -9,14 +9,8 @@ const userCustomFieldsOptionsKeys = {
     { ...baseKey, operation: 'list', parameters: { customFieldId } },
   ],
   items: () => [{ ...baseKey, operation: 'item' }],
-  item: ({
-    customFieldId,
-    optionId,
-  }: {
-    customFieldId?: string;
-    optionId: string;
-  }) => [
-    { ...baseKey, operation: 'item', parameters: { customFieldId, optionId } },
+  item: ({ optionId }: { customFieldId?: string; optionId: string }) => [
+    { ...baseKey, operation: 'item', parameters: { id: optionId } },
   ],
 } satisfies QueryKeys;
 

--- a/front/app/containers/Admin/projects/project/analysis/InputPreview/LongFieldValue.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/InputPreview/LongFieldValue.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { IInput } from 'api/analysis_inputs/types';
+import { IInputsData } from 'api/analysis_inputs/types';
 import useIdeaCustomField from 'api/idea_custom_fields/useIdeaCustomField';
 
 import { Box, Title, Text, Checkbox } from '@citizenlab/cl2-component-library';
@@ -11,7 +11,7 @@ import { FormattedDate } from 'react-intl';
 
 type Props = {
   customFieldId: string;
-  input: IInput;
+  input: IInputsData;
   projectId?: string;
   phaseId?: string;
 };
@@ -31,8 +31,8 @@ const SelectOptionText = ({
 };
 
 /**
- * Given a custom_field definition and an input, render a textual representation
- * of the value of the custom field for that input
+ * Given a custom_field definition and an input, render a multiline
+ * representation of the value of the custom field for that input
  */
 const FieldValue = ({ projectId, phaseId, customFieldId, input }: Props) => {
   const containerId: { projectId?: string; phaseId?: string } = {};
@@ -54,7 +54,7 @@ const FieldValue = ({ projectId, phaseId, customFieldId, input }: Props) => {
         <Box>
           <Title variant="h3">
             <T
-              value={input.data.attributes[customField.data.attributes.key]}
+              value={input.attributes[customField.data.attributes.key]}
               supportHtml={true}
             />
           </Title>
@@ -64,19 +64,19 @@ const FieldValue = ({ projectId, phaseId, customFieldId, input }: Props) => {
       return (
         <Text>
           <T
-            value={input.data.attributes[customField.data.attributes.key]}
+            value={input.attributes[customField.data.attributes.key]}
             supportHtml={true}
           />
         </Text>
       );
     case 'location_description':
-      if (input.data.attributes.location_description) {
+      if (input.attributes.location_description) {
         return (
           <Box>
             <Title variant="h5">
               <T value={customField.data.attributes.title_multiloc} />
             </Title>
-            <Text>{input.data.attributes.location_description}</Text>
+            <Text>{input.attributes.location_description}</Text>
           </Box>
         );
       } else {
@@ -84,9 +84,7 @@ const FieldValue = ({ projectId, phaseId, customFieldId, input }: Props) => {
       }
     case null: {
       const rawValue =
-        input.data.attributes.custom_field_values[
-          customField.data.attributes.key
-        ];
+        input.attributes.custom_field_values[customField.data.attributes.key];
       switch (customField.data.attributes.input_type) {
         case 'text':
         case 'number':
@@ -97,7 +95,7 @@ const FieldValue = ({ projectId, phaseId, customFieldId, input }: Props) => {
                 <T value={customField.data.attributes.title_multiloc} />
               </Title>
               <Text>
-                {input.data.attributes.custom_field_values[
+                {input.attributes.custom_field_values[
                   customField.data.attributes.key
                 ] || 'No answer'}
               </Text>
@@ -111,7 +109,7 @@ const FieldValue = ({ projectId, phaseId, customFieldId, input }: Props) => {
                 <T value={customField.data.attributes.title_multiloc} />
               </Title>
               <Text whiteSpace="pre-line">
-                {input.data.attributes.custom_field_values[
+                {input.attributes.custom_field_values[
                   customField.data.attributes.key
                 ] || 'No answer'}
               </Text>

--- a/front/app/containers/Admin/projects/project/analysis/InputPreview/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/InputPreview/index.tsx
@@ -7,7 +7,7 @@ import useAnalysisInput from 'api/analysis_inputs/useAnalysisInput';
 
 import Divider from 'components/admin/Divider';
 import Taggings from '../Taggings';
-import FieldValue from './FieldValue';
+import LongFieldValue from './LongFieldValue';
 import Avatar from 'components/Avatar';
 import useUserById from 'api/users/useUserById';
 import { getFullName } from 'utils/textUtils';
@@ -29,10 +29,10 @@ const InputListItem = ({ inputId }: Props) => {
   return (
     <Box>
       {analysis.data.relationships.custom_fields.data.map((customField) => (
-        <FieldValue
+        <LongFieldValue
           key={customField.id}
           customFieldId={customField.id}
-          input={input}
+          input={input.data}
           projectId={analysis.data.relationships.project?.data?.id}
           phaseId={analysis.data.relationships.phase?.data?.id}
         />

--- a/front/app/containers/Admin/projects/project/analysis/InputsList/InputListItem.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/InputsList/InputListItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo } from 'react';
 import { isEmpty } from 'lodash-es';
 
 import { IInputsData } from 'api/analysis_inputs/types';
@@ -18,11 +18,11 @@ import ShortFieldValue from './ShortFieldValue';
 
 interface Props {
   input: IInputsData;
-  onSelect: () => void;
+  onSelect: (id: string) => void;
   selected: boolean;
 }
 
-const InputListItem = ({ input, onSelect, selected }: Props) => {
+const InputListItem = memo(({ input, onSelect, selected }: Props) => {
   const { analysisId } = useParams() as { analysisId: string };
   const { data: analysis } = useAnalysis(analysisId);
   const { data: author } = useUserById(input.relationships.author.data?.id);
@@ -35,7 +35,7 @@ const InputListItem = ({ input, onSelect, selected }: Props) => {
   return (
     <>
       <Box
-        onClick={() => onSelect()}
+        onClick={() => onSelect(input.id)}
         bg={selected ? colors.background : colors.white}
         p="12px"
         display="flex"
@@ -95,27 +95,30 @@ const InputListItem = ({ input, onSelect, selected }: Props) => {
               <span> {input.attributes.comments_count}</span>
             </Box>
           )}
-          <Box>
-            {analysis.data.relationships.custom_fields.data.map(
-              (customField) => (
-                <Text
-                  key={customField.id}
-                  fontSize="s"
-                  m="0px"
-                  textOverflow="ellipsis"
-                  overflow="hidden"
-                  whiteSpace="nowrap"
-                >
-                  <ShortFieldValue
-                    customFieldId={customField.id}
-                    input={input}
-                    projectId={analysis.data.relationships.project?.data?.id}
-                    phaseId={analysis.data.relationships.phase?.data?.id}
-                  />
-                </Text>
-              )
-            )}
-          </Box>
+          {(!title_multiloc || isEmpty(title_multiloc)) && (
+            <Box flex="1">
+              {analysis.data.relationships.custom_fields.data
+                .slice(0, 3)
+                .map((customField) => (
+                  <Text
+                    key={customField.id}
+                    fontSize="s"
+                    color="textSecondary"
+                    m="0px"
+                    textOverflow="ellipsis"
+                    overflow="hidden"
+                    whiteSpace="nowrap"
+                  >
+                    <ShortFieldValue
+                      customFieldId={customField.id}
+                      input={input}
+                      projectId={analysis.data.relationships.project?.data?.id}
+                      phaseId={analysis.data.relationships.phase?.data?.id}
+                    />
+                  </Text>
+                ))}
+            </Box>
+          )}
         </Box>
 
         <Taggings inputId={input.id} />
@@ -123,6 +126,6 @@ const InputListItem = ({ input, onSelect, selected }: Props) => {
       <Divider m="0px" />
     </>
   );
-};
+});
 
 export default InputListItem;

--- a/front/app/containers/Admin/projects/project/analysis/InputsList/InputListItem.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/InputsList/InputListItem.tsx
@@ -14,7 +14,7 @@ import Avatar from 'components/Avatar';
 import { getFullName } from 'utils/textUtils';
 import { useParams } from 'react-router-dom';
 import useAnalysis from 'api/analyses/useAnalysis';
-import useIdeaCustomField from 'api/idea_custom_fields/useIdeaCustomField';
+import ShortFieldValue from './ShortFieldValue';
 
 interface Props {
   input: IInputsData;
@@ -26,19 +26,11 @@ const InputListItem = ({ input, onSelect, selected }: Props) => {
   const { analysisId } = useParams() as { analysisId: string };
   const { data: analysis } = useAnalysis(analysisId);
   const { data: author } = useUserById(input.relationships.author.data?.id);
-  const { data: customField } = useIdeaCustomField({
-    customFieldId: analysis?.data.relationships.custom_fields.data[0].id,
-    projectId: analysis?.data.relationships.project?.data?.id,
-    phaseId: analysis?.data.relationships.phase?.data?.id,
-  });
   const { formatDate } = useIntl();
 
-  if (!input) return null;
+  if (!analysis || !input) return null;
 
-  const { title_multiloc, custom_field_values } = input.attributes;
-  const customFieldValue =
-    (customField && custom_field_values[customField.data.attributes.key]) ||
-    'No answer';
+  const { title_multiloc } = input.attributes;
 
   return (
     <>
@@ -103,19 +95,27 @@ const InputListItem = ({ input, onSelect, selected }: Props) => {
               <span> {input.attributes.comments_count}</span>
             </Box>
           )}
-          {!!customFieldValue &&
-            analysis?.data.attributes.participation_method ===
-              'native_survey' && (
-              <Text
-                fontSize="s"
-                m="0px"
-                textOverflow="ellipsis"
-                overflow="hidden"
-                whiteSpace="nowrap"
-              >
-                {customFieldValue}
-              </Text>
+          <Box>
+            {analysis.data.relationships.custom_fields.data.map(
+              (customField) => (
+                <Text
+                  key={customField.id}
+                  fontSize="s"
+                  m="0px"
+                  textOverflow="ellipsis"
+                  overflow="hidden"
+                  whiteSpace="nowrap"
+                >
+                  <ShortFieldValue
+                    customFieldId={customField.id}
+                    input={input}
+                    projectId={analysis.data.relationships.project?.data?.id}
+                    phaseId={analysis.data.relationships.phase?.data?.id}
+                  />
+                </Text>
+              )
             )}
+          </Box>
         </Box>
 
         <Taggings inputId={input.id} />

--- a/front/app/containers/Admin/projects/project/analysis/InputsList/ShortFieldValue.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/InputsList/ShortFieldValue.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+
+import { IInputsData } from 'api/analysis_inputs/types';
+import useIdeaCustomField from 'api/idea_custom_fields/useIdeaCustomField';
+
+import { Checkbox } from '@citizenlab/cl2-component-library';
+
+import T from 'components/T';
+import useUserCustomFieldsOptions from 'api/user_custom_fields_options/useUserCustomFieldsOptions';
+import { FormattedDate } from 'react-intl';
+import { isNil } from 'lodash-es';
+
+type Props = {
+  customFieldId: string;
+  input: IInputsData;
+  projectId?: string;
+  phaseId?: string;
+};
+
+const SelectOptionText = ({
+  customFieldId,
+  selectedOptionKey,
+}: {
+  customFieldId: string;
+  selectedOptionKey: string;
+}) => {
+  const { data: options } = useUserCustomFieldsOptions(customFieldId);
+  const option = options?.data.find(
+    (option) => option.attributes.key === selectedOptionKey
+  );
+  return option ? <T value={option.attributes.title_multiloc} /> : null;
+};
+
+/**
+ * Given a custom_field definition and an input, render a one-line textual
+ * representation of the value of the custom field for that input. Only renders
+ * anything for non-built-in custom fields
+ */
+const ShortFieldValue = ({
+  projectId,
+  phaseId,
+  customFieldId,
+  input,
+}: Props) => {
+  const containerId: { projectId?: string; phaseId?: string } = {};
+  if (projectId) {
+    containerId.projectId = projectId;
+  } else {
+    containerId.phaseId = phaseId;
+  }
+  const { data: customField } = useIdeaCustomField({
+    customFieldId,
+    ...containerId,
+  });
+
+  if (!customField) return null;
+  // We only render non-built-in custom fields, assuming the parent has
+  // dedicated logic to render the built-in fields
+  if (customField.data.attributes.code) return null;
+
+  const rawValue =
+    input.attributes.custom_field_values[customField.data.attributes.key];
+
+  if (isNil(rawValue)) {
+    return <>No answer</>;
+  }
+
+  switch (customField.data.attributes.input_type) {
+    case 'text':
+    case 'multiline_text':
+    case 'number':
+    case 'linear_scale': {
+      return <>{rawValue}</>;
+    }
+    case 'select': {
+      return (
+        <SelectOptionText
+          customFieldId={customField.data.id}
+          selectedOptionKey={rawValue}
+        />
+      );
+    }
+    case 'multiselect': {
+      return (
+        <>
+          {(rawValue as string[]).map((optionKey, index) => (
+            <>
+              {index !== 0 && ', '}
+              <SelectOptionText
+                key={`${optionKey}-${index}`}
+                customFieldId={customField.data.id}
+                selectedOptionKey={optionKey}
+              />
+            </>
+          ))}
+        </>
+      );
+    }
+    case 'checkbox': {
+      return <Checkbox disabled checked={rawValue} onChange={() => {}} />;
+    }
+    case 'date': {
+      return <FormattedDate value={rawValue} />;
+    }
+    case 'file_upload': {
+      // We don't support file upload fields in an analysis at the moment
+      return null;
+    }
+    default: {
+      // Makes TS throw a compile error in case we're not covering for an input_type
+      const exhaustiveCheck: never = customField.data.attributes.input_type;
+      return exhaustiveCheck;
+    }
+  }
+};
+
+export default ShortFieldValue;

--- a/front/app/containers/Admin/projects/project/analysis/InputsList/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/InputsList/index.tsx
@@ -76,6 +76,13 @@ const InputsList = ({ onSelectInput, selectedInputId }: Props) => {
     }
   }, [downArrow, inputs, onSelectInput]);
 
+  const handleOnSelect = useCallback(
+    (inputId) => {
+      onSelectInput(inputId);
+    },
+    [onSelectInput]
+  );
+
   return (
     <Box bg={colors.white} w="100%">
       <SummarizeButton inputsCount={inputs?.length} />
@@ -93,7 +100,7 @@ const InputsList = ({ onSelectInput, selectedInputId }: Props) => {
             <InputListItem
               key={input.id}
               input={input}
-              onSelect={() => onSelectInput(input.id)}
+              onSelect={handleOnSelect}
               selected={input.id === selectedInputId}
             />
           ))}

--- a/front/app/containers/Admin/projects/project/nativeSurvey/FormResults/AnalysisBanner.tsx
+++ b/front/app/containers/Admin/projects/project/nativeSurvey/FormResults/AnalysisBanner.tsx
@@ -19,7 +19,6 @@ import useFormCustomFields from 'hooks/useFormCustomFields';
 import Modal from 'components/UI/Modal';
 import { isNilOrError } from 'utils/helperUtils';
 import useLocalize from 'hooks/useLocalize';
-import T from 'components/T';
 
 const CreateAnalysisModal = ({ onClose }: { onClose: () => void }) => {
   const { formatMessage } = useIntl();
@@ -50,6 +49,17 @@ const CreateAnalysisModal = ({ onClose }: { onClose: () => void }) => {
     );
   };
 
+  const handleOnChangeCheck =
+    (customFieldId: string) => (event: React.ChangeEvent<HTMLInputElement>) => {
+      if (event.target.checked) {
+        setSelectedQuestions([...selectdQuestions, customFieldId]);
+      } else {
+        setSelectedQuestions(
+          selectdQuestions.filter((id) => id !== customFieldId)
+        );
+      }
+    };
+
   if (isNilOrError(formCustomFields)) return null;
 
   return (
@@ -63,7 +73,7 @@ const CreateAnalysisModal = ({ onClose }: { onClose: () => void }) => {
         if (field.input_type === 'page') {
           return (
             <Title variant="h5" key={field.id}>
-              <T value={field.title_multiloc} />
+              {localize(field.title_multiloc)}
             </Title>
           );
         } else if (field.input_type === 'section') {
@@ -76,15 +86,7 @@ const CreateAnalysisModal = ({ onClose }: { onClose: () => void }) => {
               <Checkbox
                 label={localize(field.title_multiloc)}
                 checked={selectdQuestions.includes(field.id)}
-                onChange={(e) => {
-                  if (e.target.checked) {
-                    setSelectedQuestions([...selectdQuestions, field.id]);
-                  } else {
-                    setSelectedQuestions(
-                      selectdQuestions.filter((id) => id !== field.id)
-                    );
-                  }
-                }}
+                onChange={handleOnChangeCheck(field.id)}
               />
             </ListItem>
           );

--- a/front/app/containers/Admin/projects/project/nativeSurvey/FormResults/AnalysisBanner.tsx
+++ b/front/app/containers/Admin/projects/project/nativeSurvey/FormResults/AnalysisBanner.tsx
@@ -68,6 +68,8 @@ const CreateAnalysisModal = ({ onClose }: { onClose: () => void }) => {
           );
         } else if (field.input_type === 'section') {
           return null;
+        } else if (field.input_type === 'file_upload') {
+          return null;
         } else {
           return (
             <ListItem key={field.id} py="16px">

--- a/front/app/containers/Admin/projects/project/nativeSurvey/FormResults/AnalysisBanner.tsx
+++ b/front/app/containers/Admin/projects/project/nativeSurvey/FormResults/AnalysisBanner.tsx
@@ -19,6 +19,7 @@ import useFormCustomFields from 'hooks/useFormCustomFields';
 import Modal from 'components/UI/Modal';
 import { isNilOrError } from 'utils/helperUtils';
 import useLocalize from 'hooks/useLocalize';
+import T from 'components/T';
 
 const CreateAnalysisModal = ({ onClose }: { onClose: () => void }) => {
   const { formatMessage } = useIntl();
@@ -33,12 +34,6 @@ const CreateAnalysisModal = ({ onClose }: { onClose: () => void }) => {
     projectId,
     phaseId,
   });
-  const textCustomFields = !isNilOrError(formCustomFields)
-    ? formCustomFields.filter(
-        (field) =>
-          field.input_type === 'text' || field.input_type === 'multiline_text'
-      )
-    : [];
 
   const handleCreateAnalysis = () => {
     createAnalysis(
@@ -55,27 +50,43 @@ const CreateAnalysisModal = ({ onClose }: { onClose: () => void }) => {
     );
   };
 
+  if (isNilOrError(formCustomFields)) return null;
+
   return (
     <Box px="48px">
-      <Title mb="48px">{formatMessage(messages.analysisSelectQuestions)}</Title>
-      {textCustomFields?.map((field) => {
-        return (
-          <ListItem key={field.id} py="16px">
-            <Checkbox
-              label={localize(field.title_multiloc)}
-              checked={selectdQuestions.includes(field.id)}
-              onChange={(e) => {
-                if (e.target.checked) {
-                  setSelectedQuestions([...selectdQuestions, field.id]);
-                } else {
-                  setSelectedQuestions(
-                    selectdQuestions.filter((id) => id !== field.id)
-                  );
-                }
-              }}
-            />
-          </ListItem>
-        );
+      <Title>{formatMessage(messages.analysisSelectQuestions)}</Title>
+      <Text>
+        Which questions do you want to analyze simultaneously? You can always
+        create a new analysis with different questions later.
+      </Text>
+      {formCustomFields?.map((field) => {
+        if (field.input_type === 'page') {
+          return (
+            <Title variant="h5" key={field.id}>
+              <T value={field.title_multiloc} />
+            </Title>
+          );
+        } else if (field.input_type === 'section') {
+          return null;
+        } else {
+          return (
+            <ListItem key={field.id} py="16px">
+              <Checkbox
+                label={localize(field.title_multiloc)}
+                checked={selectdQuestions.includes(field.id)}
+                onChange={(e) => {
+                  if (e.target.checked) {
+                    setSelectedQuestions([...selectdQuestions, field.id]);
+                  } else {
+                    setSelectedQuestions(
+                      selectdQuestions.filter((id) => id !== field.id)
+                    );
+                  }
+                }}
+              />
+            </ListItem>
+          );
+        }
       })}
       <Box display="flex" justifyContent="flex-end" mt="48px" gap="24px">
         <Button buttonStyle="secondary" onClick={onClose}>


### PR DESCRIPTION
# Changelog
## Added
- A survey analsyis now supports displaying all question types, as opposed to only textual questions (WIP sensemaking, feature flagged)