### PR TITLE
[TAN-157] Return initiative data in response to accept_cosponsorship_i…

### DIFF
--- a/back/app/controllers/web_api/v1/initiatives_controller.rb
+++ b/back/app/controllers/web_api/v1/initiatives_controller.rb
@@ -184,6 +184,14 @@ class WebApi::V1::InitiativesController < ApplicationController
 
     if @cosponsors_initiative.update!(status: 'accepted')
       SideFxInitiativeService.new.after_accept_cosponsorship_invite(@cosponsors_initiative, current_user)
+
+      render json: WebApi::V1::InitiativeSerializer.new(
+        @initiative.reload,
+        params: jsonapi_serializer_params,
+        include: %i[author cosponsors topics areas user_reaction initiative_images]
+      ).serializable_hash, status: :ok
+    else
+      render json: { errors: @initiative.errors.details }, status: :unprocessable_entity
     end
   end
 

--- a/back/spec/acceptance/initiatives_spec.rb
+++ b/back/spec/acceptance/initiatives_spec.rb
@@ -700,7 +700,9 @@ resource 'Initiatives' do
 
       example 'cosponsor accepts invitation' do
         expect { do_request }.to change { @cosponsors_initiative.reload.status }.from('pending').to('accepted')
-        assert_status 204
+        assert_status 200
+        json_response = json_parse(response_body)
+        expect(json_response.dig(:data, :attributes, :slug)).to eq @initiative.slug
       end
     end
   end


### PR DESCRIPTION
# Changelog
## Technical
- [TAN-157] Return initiative data in response to `accept_cosponsorship_invite` (cosponsors feature in development)
