### PR TITLE
Fix cy.apiCreatePhase

### DIFF
--- a/front/cypress/e2e/admin/admin_ideation_tab_and_button.cy.ts
+++ b/front/cypress/e2e/admin/admin_ideation_tab_and_button.cy.ts
@@ -27,35 +27,32 @@ describe('Idea button and tab behaviour in timeline project with multiple ideati
       .then((project) => {
         projectId = project.body.data.id;
         projectSlug = project.body.data.attributes.slug;
-        return cy.apiCreatePhase(
+        return cy.apiCreatePhase({
           projectId,
-          'Ideation phase 1',
-          '2018-03-01',
-          '2025-01-01',
-          'ideation',
-          true,
-          true,
-          true
-        );
+          title: 'Ideation phase 1',
+          startAt: '2018-03-01',
+          endAt: '2025-01-01',
+          participationMethod: 'ideation',
+          canComment: true,
+          canPost: true,
+          canReact: true,
+        });
       })
       .then((phase) => {
         firstPhaseId = phase.body.data.id;
-        return cy.apiCreatePhase(
+        return cy.apiCreatePhase({
           projectId,
-          'Budgeting phase 1',
-          '2025-01-02',
-          '2025-01-25',
-          'voting',
-          true,
-          true,
-          true,
-          'description',
-          undefined,
-          undefined,
-          400,
-          undefined,
-          'budgeting'
-        );
+          title: 'Budgeting phase 1',
+          startAt: '2025-01-02',
+          endAt: '2025-01-25',
+          participationMethod: 'voting',
+          canComment: true,
+          canPost: true,
+          canReact: true,
+          description: 'description',
+          votingMaxTotal: 400,
+          votingMethod: 'budgeting',
+        });
       });
   });
 
@@ -117,16 +114,16 @@ describe('Idea button and tab behaviour in timeline project with one ideation ph
       .then((project) => {
         projectId = project.body.data.id;
         projectSlug = project.body.data.attributes.slug;
-        return cy.apiCreatePhase(
+        return cy.apiCreatePhase({
           projectId,
-          'Ideation phase 1',
-          '2018-03-01',
-          '2025-01-01',
-          'ideation',
-          true,
-          true,
-          true
-        );
+          title: 'Ideation phase 1',
+          startAt: '2018-03-01',
+          endAt: '2025-01-01',
+          participationMethod: 'ideation',
+          canComment: true,
+          canPost: true,
+          canReact: true,
+        });
       })
       .then((phase) => {
         phaseId = phase.body.data.id;
@@ -180,16 +177,16 @@ describe('Idea button and tab behaviour in timeline project with no ideation pha
       })
       .then((project) => {
         projectId = project.body.data.id;
-        return cy.apiCreatePhase(
+        return cy.apiCreatePhase({
           projectId,
-          'Poll phase 1',
-          '2018-03-01',
-          '2025-01-01',
-          'poll',
-          true,
-          true,
-          true
-        );
+          title: 'Poll phase 1',
+          startAt: '2018-03-01',
+          endAt: '2025-01-01',
+          participationMethod: 'poll',
+          canComment: true,
+          canPost: true,
+          canReact: true,
+        });
       });
   });
 

--- a/front/cypress/e2e/admin/projects/edit_project_timeline.cy.ts
+++ b/front/cypress/e2e/admin/projects/edit_project_timeline.cy.ts
@@ -29,35 +29,33 @@ describe('Project timeline page', () => {
       .then((project) => {
         projectId = project.body.data.id;
         projectSlug = project.body.data.attributes.slug;
-        return cy.apiCreatePhase(
+        return cy.apiCreatePhase({
           projectId,
-          phaseOneTitle,
-          '2018-03-01',
-          '2025-01-01',
-          'ideation',
-          true,
-          true,
-          true
-        );
+          title: phaseOneTitle,
+          startAt: '2018-03-01',
+          endAt: '2025-01-01',
+          participationMethod: 'ideation',
+          canComment: true,
+          canPost: true,
+          canReact: true,
+        });
       })
       .then((phase) => {
         firstPhaseId = phase.body.data.id;
-        return cy.apiCreatePhase(
+        return cy.apiCreatePhase({
           projectId,
-          phaseTwoTitle,
-          '2025-01-02',
-          '2025-01-25',
-          'voting',
-          true,
-          true,
-          true,
-          'description',
-          undefined,
-          undefined,
-          400,
-          false,
-          'budgeting'
-        );
+          title: phaseTwoTitle,
+          startAt: '2025-01-02',
+          endAt: '2025-01-25',
+          participationMethod: 'voting',
+          canComment: true,
+          canPost: true,
+          canReact: true,
+          description: 'description',
+          votingMaxTotal: 400,
+          allow_anonymous_participation: false,
+          votingMethod: 'budgeting',
+        });
       });
   });
 

--- a/front/cypress/e2e/create_idea_in_any_phase.cy.ts
+++ b/front/cypress/e2e/create_idea_in_any_phase.cy.ts
@@ -21,27 +21,27 @@ describe('Idea creation', () => {
         projectId = project.body.data.id;
         projectSlug = project.body.data.attributes.slug;
 
-        cy.apiCreatePhase(
+        cy.apiCreatePhase({
           projectId,
-          'secondPhaseTitle',
-          moment().subtract(2, 'month').format('DD/MM/YYYY'),
-          moment().add(1, 'month').format('DD/MM/YYYY'),
-          'ideation',
-          true,
-          true,
-          true
-        );
+          title: 'secondPhaseTitle',
+          startAt: moment().subtract(2, 'month').format('DD/MM/YYYY'),
+          endAt: moment().add(1, 'month').format('DD/MM/YYYY'),
+          participationMethod: 'ideation',
+          canPost: true,
+          canReact: true,
+          canComment: true,
+        });
 
-        return cy.apiCreatePhase(
+        return cy.apiCreatePhase({
           projectId,
-          'firstPhaseTitle',
-          moment().subtract(9, 'month').format('DD/MM/YYYY'),
-          moment().subtract(3, 'month').format('DD/MM/YYYY'),
-          'ideation',
-          true,
-          true,
-          true
-        );
+          title: 'firstPhaseTitle',
+          startAt: moment().subtract(9, 'month').format('DD/MM/YYYY'),
+          endAt: moment().subtract(3, 'month').format('DD/MM/YYYY'),
+          participationMethod: 'ideation',
+          canPost: true,
+          canComment: true,
+          canReact: true,
+        });
       })
       .then((phase) => {
         phaseId = phase.body.data.id;

--- a/front/cypress/e2e/idea_form_settings.cy.ts
+++ b/front/cypress/e2e/idea_form_settings.cy.ts
@@ -60,16 +60,16 @@ describe('Idea form settings', () => {
         publicationStatus: 'published',
       }).then((project) => {
         timelineWithIdeationProjectId = project.body.data.id;
-        cy.apiCreatePhase(
-          timelineWithIdeationProjectId,
-          'phaseTitle',
-          moment().subtract(2, 'month').format('DD/MM/YYYY'),
-          moment().add(2, 'days').format('DD/MM/YYYY'),
-          'ideation',
-          true,
-          true,
-          true
-        );
+        cy.apiCreatePhase({
+          projectId: timelineWithIdeationProjectId,
+          title: 'phaseTitle',
+          startAt: moment().subtract(2, 'month').format('DD/MM/YYYY'),
+          endAt: moment().add(2, 'days').format('DD/MM/YYYY'),
+          participationMethod: 'ideation',
+          canPost: true,
+          canReact: true,
+          canComment: true,
+        });
       });
       // Timeline project with budget phase
       cy.apiCreateProject({
@@ -80,22 +80,23 @@ describe('Idea form settings', () => {
         publicationStatus: 'published',
       }).then((project) => {
         timelineWithBudgetProjectId = project.body.data.id;
-        cy.apiCreatePhase(
-          timelineWithBudgetProjectId,
-          'phaseTitle',
-          moment().add(5, 'month').format('DD/MM/YYYY'),
-          moment().add(7, 'month').format('DD/MM/YYYY'),
-          'voting',
-          true,
-          true,
-          true,
+        cy.apiCreatePhase({
+          projectId: timelineWithBudgetProjectId,
+          title: 'phaseTitle',
+          startAt: moment().add(5, 'month').format('DD/MM/YYYY'),
+          endAt: moment().add(7, 'month').format('DD/MM/YYYY'),
+          participationMethod: 'voting',
+          canComment: true,
+          canPost: true,
+          canReact: true,
           description,
-          'https://lifeship.typeform.com/to/YWeOlPu7?typeform-source=clickydrip.com',
-          'typeform',
-          400,
-          undefined,
-          'budgeting'
-        );
+          surveyUrl:
+            'https://lifeship.typeform.com/to/YWeOlPu7?typeform-source=clickydrip.com',
+          surveyService: 'typeform',
+          votingMaxTotal: 400,
+          allow_anonymous_participation: undefined,
+          votingMethod: 'budgeting',
+        });
       });
 
       // Timeline project with native_survey phase
@@ -107,20 +108,21 @@ describe('Idea form settings', () => {
         publicationStatus: 'published',
       }).then((project) => {
         timelineWithNativeSurveyProjectId = project.body.data.id;
-        cy.apiCreatePhase(
-          timelineWithNativeSurveyProjectId,
-          'phaseTitle',
-          moment().add(5, 'month').format('DD/MM/YYYY'),
-          moment().add(7, 'month').format('DD/MM/YYYY'),
-          'native_survey',
-          true,
-          true,
-          true,
+        cy.apiCreatePhase({
+          projectId: timelineWithNativeSurveyProjectId,
+          title: 'phaseTitle',
+          startAt: moment().add(5, 'month').format('DD/MM/YYYY'),
+          endAt: moment().add(7, 'month').format('DD/MM/YYYY'),
+          participationMethod: 'native_survey',
+          canComment: true,
+          canPost: true,
+          canReact: true,
           description,
-          'https://lifeship.typeform.com/to/YWeOlPu7?typeform-source=clickydrip.com',
-          'typeform',
-          400
-        );
+          surveyUrl:
+            'https://lifeship.typeform.com/to/YWeOlPu7?typeform-source=clickydrip.com',
+          surveyService: 'typeform',
+          votingMaxTotal: 400,
+        });
       });
 
       // Continuous poll project
@@ -160,29 +162,30 @@ describe('Idea form settings', () => {
         publicationStatus: 'published',
       }).then((project) => {
         timelineWithoutIdeationOrBudgetProjectId = project.body.data.id;
-        cy.apiCreatePhase(
-          timelineWithoutIdeationOrBudgetProjectId,
-          'phaseTitle',
-          moment().subtract(2, 'month').format('DD/MM/YYYY'),
-          moment().add(2, 'days').format('DD/MM/YYYY'),
-          'poll',
-          true,
-          true,
-          true
-        );
-        cy.apiCreatePhase(
-          timelineWithoutIdeationOrBudgetProjectId,
-          'phaseTitle',
-          moment().add(3, 'days').format('DD/MM/YYYY'),
-          moment().add(2, 'month').format('DD/MM/YYYY'),
-          'survey',
-          true,
-          true,
-          true,
+        cy.apiCreatePhase({
+          projectId: timelineWithoutIdeationOrBudgetProjectId,
+          title: 'phaseTitle',
+          startAt: moment().subtract(2, 'month').format('DD/MM/YYYY'),
+          endAt: moment().add(2, 'days').format('DD/MM/YYYY'),
+          participationMethod: 'poll',
+          canComment: true,
+          canPost: true,
+          canReact: true,
+        });
+        cy.apiCreatePhase({
+          projectId: timelineWithoutIdeationOrBudgetProjectId,
+          title: 'phaseTitle',
+          startAt: moment().add(3, 'days').format('DD/MM/YYYY'),
+          endAt: moment().add(2, 'month').format('DD/MM/YYYY'),
+          participationMethod: 'survey',
+          canComment: true,
+          canPost: true,
+          canReact: true,
           description,
-          'https://lifeship.typeform.com/to/YWeOlPu7?typeform-source=clickydrip.com',
-          'typeform'
-        );
+          surveyUrl:
+            'https://lifeship.typeform.com/to/YWeOlPu7?typeform-source=clickydrip.com',
+          surveyService: 'typeform',
+        });
       });
 
       cy.setAdminLoginCookie();

--- a/front/cypress/e2e/idea_new_page.cy.ts
+++ b/front/cypress/e2e/idea_new_page.cy.ts
@@ -203,17 +203,17 @@ describe('Idea new page for timeline project', () => {
       projectId = project.body.data.id;
       projectSlug = project.body.data.attributes.slug;
       // create active ideation phase
-      cy.apiCreatePhase(
+      cy.apiCreatePhase({
         projectId,
-        phasePastTitle,
-        twoMonthsAgo,
-        inTwoMonths,
-        'ideation',
-        true,
-        true,
-        true,
-        `description ${phasePastTitle}`
-      );
+        title: phasePastTitle,
+        startAt: twoMonthsAgo,
+        endAt: inTwoMonths,
+        participationMethod: 'ideation',
+        canComment: true,
+        canPost: true,
+        canReact: true,
+        description: `description ${phasePastTitle}`,
+      });
     });
   });
 

--- a/front/cypress/e2e/idea_posting_anonymous.cy.ts
+++ b/front/cypress/e2e/idea_posting_anonymous.cy.ts
@@ -137,21 +137,17 @@ describe('Timeline ideation with anonymous participation allowed', () => {
       }).then((project) => {
         projectId = project.body.data.id;
         projectSlug = project.body.data.attributes.slug;
-        cy.apiCreatePhase(
+        cy.apiCreatePhase({
           projectId,
-          'phaseTitle',
-          moment().subtract(2, 'month').format('DD/MM/YYYY'),
-          moment().add(2, 'days').format('DD/MM/YYYY'),
-          'ideation',
-          true,
-          true,
-          true,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          true
-        );
+          title: 'phaseTitle',
+          startAt: moment().subtract(2, 'month').format('DD/MM/YYYY'),
+          endAt: moment().add(2, 'days').format('DD/MM/YYYY'),
+          participationMethod: 'ideation',
+          canComment: true,
+          canPost: true,
+          canReact: true,
+          allow_anonymous_participation: true,
+        });
       });
     });
   });

--- a/front/cypress/e2e/native_survey_page_action.cy.ts
+++ b/front/cypress/e2e/native_survey_page_action.cy.ts
@@ -71,17 +71,17 @@ describe('Native survey project page actions', () => {
     }).then((project) => {
       projectIdTimeline = project.body.data.id;
       projectSlugTimeline = project.body.data.attributes.slug;
-      cy.apiCreatePhase(
-        projectIdTimeline,
-        'Future ',
-        inTwoDays,
-        inTwoMonths,
-        'native_survey',
-        true,
-        true,
-        true,
-        `description ${phaseFutureTitle}`
-      );
+      cy.apiCreatePhase({
+        projectId: projectIdTimeline,
+        title: 'Future ',
+        startAt: inTwoDays,
+        endAt: inTwoMonths,
+        participationMethod: 'native_survey',
+        canComment: true,
+        canPost: true,
+        canReact: true,
+        description: `description ${phaseFutureTitle}`,
+      });
     });
 
     // create a regular user

--- a/front/cypress/e2e/project_card.cy.ts
+++ b/front/cypress/e2e/project_card.cy.ts
@@ -16,16 +16,16 @@ describe('Project card component', () => {
       publicationStatus: 'published',
     }).then((project) => {
       projectId = project.body.data.id;
-      cy.apiCreatePhase(
+      cy.apiCreatePhase({
         projectId,
-        'phaseTitle',
-        moment().subtract(2, 'month').format('DD/MM/YYYY'),
-        moment().add(2, 'days').format('DD/MM/YYYY'),
-        'ideation',
-        true,
-        true,
-        true
-      );
+        title: 'phaseTitle',
+        startAt: moment().subtract(2, 'month').format('DD/MM/YYYY'),
+        endAt: moment().add(2, 'days').format('DD/MM/YYYY'),
+        participationMethod: 'ideation',
+        canComment: true,
+        canPost: true,
+        canReact: true,
+      });
       cy.goToLandingPage();
     });
   });

--- a/front/cypress/e2e/project_page_ideas.cy.ts
+++ b/front/cypress/e2e/project_page_ideas.cy.ts
@@ -128,28 +128,28 @@ describe('New timeline project with active ideation phase', () => {
       })
       .then((project) => {
         projectId = project.body.data.id;
-        return cy.apiCreatePhase(
+        return cy.apiCreatePhase({
           projectId,
-          'phaseTitle',
-          '2018-03-01',
-          '2025-01-01',
-          'ideation',
-          true,
-          true,
-          true
-        );
+          title: 'phaseTitle',
+          startAt: '2018-03-01',
+          endAt: '2025-01-01',
+          participationMethod: 'ideation',
+          canComment: true,
+          canPost: true,
+          canReact: true,
+        });
       })
       .then(() => {
-        return cy.apiCreatePhase(
+        return cy.apiCreatePhase({
           projectId,
-          'phaseTitle',
-          '2025-01-02',
-          '2025-01-25',
-          'ideation',
-          true,
-          true,
-          true
-        );
+          title: 'phaseTitle',
+          startAt: '2025-01-02',
+          endAt: '2025-01-25',
+          participationMethod: 'ideation',
+          canComment: true,
+          canPost: true,
+          canReact: true,
+        });
       })
       .then(() => {
         return cy.apiCreateIdea(projectId, ideaTitle, ideaContent);
@@ -229,28 +229,28 @@ describe('Archived timeline project with ideation phase', () => {
       })
       .then((project) => {
         projectId = project.body.data.id;
-        return cy.apiCreatePhase(
+        return cy.apiCreatePhase({
           projectId,
-          'phaseTitle',
-          '2018-03-01',
-          '2025-01-01',
-          'ideation',
-          true,
-          true,
-          true
-        );
+          title: 'phaseTitle',
+          startAt: '2018-03-01',
+          endAt: '2025-01-01',
+          participationMethod: 'ideation',
+          canComment: true,
+          canPost: true,
+          canReact: true,
+        });
       })
       .then(() => {
-        return cy.apiCreatePhase(
+        return cy.apiCreatePhase({
           projectId,
-          'phaseTitle',
-          '2025-01-02',
-          '2025-01-25',
-          'ideation',
-          true,
-          true,
-          true
-        );
+          title: 'phaseTitle',
+          startAt: '2025-01-02',
+          endAt: '2025-01-25',
+          participationMethod: 'ideation',
+          canComment: true,
+          canPost: true,
+          canReact: true,
+        });
       })
       .then(() => {
         return cy.apiCreateIdea(projectId, ideaTitle, ideaContent);
@@ -304,16 +304,16 @@ describe('timeline project with no active ideation phase', () => {
       })
       .then((project) => {
         projectId = project.body.data.id;
-        return cy.apiCreatePhase(
+        return cy.apiCreatePhase({
           projectId,
-          'phaseTitle',
-          '2018-03-01',
-          '2019-01-01',
-          'ideation',
-          true,
-          true,
-          true
-        );
+          title: 'phaseTitle',
+          startAt: '2018-03-01',
+          endAt: '2019-01-01',
+          participationMethod: 'ideation',
+          canComment: true,
+          canPost: true,
+          canReact: true,
+        });
       })
       .then(() => {
         cy.setAdminLoginCookie();

--- a/front/cypress/e2e/project_page_native_survey.cy.ts
+++ b/front/cypress/e2e/project_page_native_survey.cy.ts
@@ -62,17 +62,17 @@ describe('Timeline project with native survey phase', () => {
       projectId = project.body.data.id;
       projectSlug = project.body.data.attributes.slug;
 
-      return cy.apiCreatePhase(
+      return cy.apiCreatePhase({
         projectId,
-        phaseTitle,
-        '2018-03-01',
-        '5025-01-01',
-        'native_survey',
-        true,
-        true,
-        true,
-        'description'
-      );
+        title: phaseTitle,
+        startAt: '2018-03-01',
+        endAt: '5025-01-01',
+        participationMethod: 'native_survey',
+        canComment: true,
+        canPost: true,
+        canReact: true,
+        description: 'description',
+      });
     });
   });
 
@@ -111,17 +111,17 @@ describe('Timeline project with native survey phase but not active', () => {
       projectId = project.body.data.id;
       projectSlug = project.body.data.attributes.slug;
 
-      return cy.apiCreatePhase(
+      return cy.apiCreatePhase({
         projectId,
-        phaseTitle,
-        '2018-03-01',
-        '2019-01-01',
-        'native_survey',
-        true,
-        true,
-        true,
-        'description'
-      );
+        title: phaseTitle,
+        startAt: '2018-03-01',
+        endAt: '2019-01-01',
+        participationMethod: 'native_survey',
+        canComment: true,
+        canPost: true,
+        canReact: true,
+        description: 'description',
+      });
     });
   });
 

--- a/front/cypress/e2e/project_page_poll.cy.ts
+++ b/front/cypress/e2e/project_page_poll.cy.ts
@@ -121,17 +121,17 @@ describe('Timeline project with poll phase', () => {
         projectId = project.body.data.id;
         projectSlug = project.body.data.attributes.slug;
 
-        return cy.apiCreatePhase(
+        return cy.apiCreatePhase({
           projectId,
-          phaseTitle,
-          '2018-03-01',
-          '2025-01-01',
-          'poll',
-          true,
-          true,
-          true,
-          'description'
-        );
+          title: phaseTitle,
+          startAt: '2018-03-01',
+          endAt: '2025-01-01',
+          participationMethod: 'poll',
+          canComment: true,
+          canPost: true,
+          canReact: true,
+          description: 'description',
+        });
       })
       .then((phase) => {
         phaseId = phase.body.data.id;

--- a/front/cypress/e2e/project_page_survey.cy.ts
+++ b/front/cypress/e2e/project_page_survey.cy.ts
@@ -106,19 +106,19 @@ describe('Timeline project with survey phase', () => {
       projectId = project.body.data.id;
       projectSlug = project.body.data.attributes.slug;
 
-      return cy.apiCreatePhase(
+      return cy.apiCreatePhase({
         projectId,
-        phaseTitle,
-        '2018-03-01',
-        '2025-01-01',
-        'survey',
-        true,
-        true,
-        true,
-        'description',
-        'https://citizenlabco.typeform.com/to/Yv6B7V',
-        'typeform'
-      );
+        title: phaseTitle,
+        startAt: '2018-03-01',
+        endAt: '2025-01-01',
+        participationMethod: 'survey',
+        canComment: true,
+        canPost: true,
+        canReact: true,
+        description: 'description',
+        surveyUrl: 'https://citizenlabco.typeform.com/to/Yv6B7V',
+        surveyService: 'typeform',
+      });
     });
   });
 
@@ -165,19 +165,19 @@ describe('Timeline project with survey phase but not active', () => {
       projectId = project.body.data.id;
       projectSlug = project.body.data.attributes.slug;
 
-      return cy.apiCreatePhase(
+      return cy.apiCreatePhase({
         projectId,
-        phaseTitle,
-        '2018-03-01',
-        '2019-01-01',
-        'survey',
-        true,
-        true,
-        true,
-        'description',
-        'https://citizenlabco.typeform.com/to/Yv6B7V',
-        'typeform'
-      );
+        title: phaseTitle,
+        startAt: '2018-03-01',
+        endAt: '2019-01-01',
+        participationMethod: 'survey',
+        canComment: true,
+        canPost: true,
+        canReact: true,
+        description: 'description',
+        surveyUrl: 'https://citizenlabco.typeform.com/to/Yv6B7V',
+        surveyService: 'typeform',
+      });
     });
   });
 

--- a/front/cypress/e2e/project_page_timeline.cy.ts
+++ b/front/cypress/e2e/project_page_timeline.cy.ts
@@ -79,39 +79,39 @@ describe('New timeline project', () => {
       projectId = project.body.data.id;
       projectSlug = project.body.data.attributes.slug;
       // create new phases
-      cy.apiCreatePhase(
+      cy.apiCreatePhase({
         projectId,
-        phasePastTitle,
-        twoMonthsAgo,
-        twoDaysAgo,
-        'ideation',
-        true,
-        true,
-        true,
-        `description ${phasePastTitle}`
-      );
-      cy.apiCreatePhase(
+        title: phasePastTitle,
+        startAt: twoMonthsAgo,
+        endAt: twoDaysAgo,
+        participationMethod: 'ideation',
+        canComment: true,
+        canPost: true,
+        canReact: true,
+        description: `description ${phasePastTitle}`,
+      });
+      cy.apiCreatePhase({
         projectId,
-        phaseCurrentTitle,
-        today,
-        today,
-        'ideation',
-        true,
-        true,
-        true,
-        phaseLongDescription
-      );
-      cy.apiCreatePhase(
+        title: phaseCurrentTitle,
+        startAt: today,
+        endAt: today,
+        participationMethod: 'ideation',
+        canComment: true,
+        canPost: true,
+        canReact: true,
+        description: phaseLongDescription,
+      });
+      cy.apiCreatePhase({
         projectId,
-        phaseFutureTitle,
-        inTwoDays,
-        inTwoMonths,
-        'ideation',
-        true,
-        true,
-        true,
-        `description ${phaseFutureTitle}`
-      );
+        title: phaseFutureTitle,
+        startAt: inTwoDays,
+        endAt: inTwoMonths,
+        participationMethod: 'ideation',
+        canComment: true,
+        canPost: true,
+        canReact: true,
+        description: `description ${phaseFutureTitle}`,
+      });
       return cy.apiCreateEvent({
         projectId,
         title: 'Some event',

--- a/front/cypress/e2e/project_scroll_to_event_param.cy.ts
+++ b/front/cypress/e2e/project_scroll_to_event_param.cy.ts
@@ -31,28 +31,28 @@ describe('?scrollToEventId parameter on project page', () => {
         projectId = project.body.data.id;
         projectSlug = project.body.data.attributes.slug;
 
-        return cy.apiCreatePhase(
+        return cy.apiCreatePhase({
           projectId,
-          'phaseTitle',
-          '2018-03-01',
-          '2025-01-01',
-          'ideation',
-          true,
-          true,
-          true
-        );
+          title: 'phaseTitle',
+          startAt: '2018-03-01',
+          endAt: '2025-01-01',
+          participationMethod: 'ideation',
+          canComment: true,
+          canPost: true,
+          canReact: true,
+        });
       })
       .then(() => {
-        return cy.apiCreatePhase(
+        return cy.apiCreatePhase({
           projectId,
-          'phaseTitle',
-          '2025-01-02',
-          '2025-01-25',
-          'ideation',
-          true,
-          true,
-          true
-        );
+          title: 'phaseTitle',
+          startAt: '2025-01-02',
+          endAt: '2025-01-25',
+          participationMethod: 'ideation',
+          canComment: true,
+          canPost: true,
+          canReact: true,
+        });
       })
       .then(() => {
         return cy.apiCreateIdea(projectId, ideaTitle, ideaContent);

--- a/front/cypress/support/commands.ts
+++ b/front/cypress/support/commands.ts
@@ -1116,22 +1116,37 @@ export function apiAddPoll(
   });
 }
 
-export function apiCreatePhase(
-  projectId: string,
-  title: string,
-  startAt: string,
-  endAt: string,
-  participationMethod: ParticipationMethod,
-  canPost: boolean,
-  canReact: boolean,
-  canComment: boolean,
-  description?: string,
-  surveyUrl?: string,
-  surveyService?: 'typeform' | 'survey_monkey' | 'google_forms',
-  votingMaxTotal?: number,
-  allow_anonymous_participation?: boolean,
-  votingMethod?: VotingMethod
-) {
+export function apiCreatePhase({
+  projectId,
+  title,
+  startAt,
+  endAt,
+  participationMethod,
+  canPost,
+  canReact,
+  canComment,
+  description,
+  surveyUrl,
+  surveyService,
+  votingMaxTotal,
+  allow_anonymous_participation,
+  votingMethod,
+}: {
+  projectId: string;
+  title: string;
+  startAt: string;
+  endAt: string;
+  participationMethod: ParticipationMethod;
+  canPost: boolean;
+  canReact: boolean;
+  canComment: boolean;
+  description?: string;
+  surveyUrl?: string;
+  surveyService?: 'typeform' | 'survey_monkey' | 'google_forms';
+  votingMaxTotal?: number;
+  allow_anonymous_participation?: boolean;
+  votingMethod?: VotingMethod;
+}) {
   return cy.apiLogin('admin@citizenlab.co', 'democracy2.0').then((response) => {
     const adminJwt = response.body.jwt;
 


### PR DESCRIPTION
# Description
I refactored the `cy.apiCreatePhase` so it uses named params instead. It was getting a bit annoying to use especially with the new parameters we've been adding the last few months :) I'll add it to the FE discussion meeting as well :+1: 


Before:
```
return cy.apiCreatePhase(
projectId,
'Budgeting phase 1',
'2025-01-02',
'2025-01-25',
'voting',
true,
true,
true,
'description',
undefined,
undefined,
400,
undefined,
'budgeting'
);
```

After:
```
return cy.apiCreatePhase({
projectId,
title: 'Budgeting phase 1',
startAt: '2025-01-02',
endAt: '2025-01-25',
participationMethod: 'voting',
description: 'description',
voting_max_total: 400,
voting_method: 'budgeting'
});
```

# Changelog
## Technical
- Refactored cy.apiCreatePhase so it uses named params
