### PR TITLE
[TAN-222] Add two new cosponsorship email campaigns

### DIFF
--- a/back/app/models/cosponsors_initiative.rb
+++ b/back/app/models/cosponsors_initiative.rb
@@ -27,6 +27,19 @@ class CosponsorsInitiative < ApplicationRecord
   belongs_to :user
   belongs_to :initiative
 
+  before_destroy :remove_notifications # Must occur before has_many :notifications (see https://github.com/rails/rails/issues/5205)
+  has_many :notifications, dependent: :nullify
+
   validates :user, :initiative, presence: true
   validates :status, inclusion: { in: STATUSES }
+
+  private
+
+  def remove_notifications
+    notifications.each do |notification|
+      unless notification.update cosponsors_initiative: nil
+        notification.destroy!
+      end
+    end
+  end
 end

--- a/back/app/models/initiative.rb
+++ b/back/app/models/initiative.rb
@@ -119,6 +119,8 @@ class Initiative < ApplicationRecord
 
     cosponsors_initiatives.where.not(user_id: ids).destroy_all
     (ids - current_ids).each { |id| cosponsors_initiatives.create(user_id: id) }
+
+    # super(ids.uniq)
   end
 
   def reactions_needed(configuration = AppConfiguration.instance)

--- a/back/app/models/initiative.rb
+++ b/back/app/models/initiative.rb
@@ -119,8 +119,6 @@ class Initiative < ApplicationRecord
 
     cosponsors_initiatives.where.not(user_id: ids).destroy_all
     (ids - current_ids).each { |id| cosponsors_initiatives.create(user_id: id) }
-
-    # super(ids.uniq)
   end
 
   def reactions_needed(configuration = AppConfiguration.instance)

--- a/back/app/models/initiative.rb
+++ b/back/app/models/initiative.rb
@@ -113,7 +113,15 @@ class Initiative < ApplicationRecord
   def cosponsor_ids=(ids)
     return unless ids
 
-    super(ids.uniq)
+    ids = ids.uniq
+    current_ids = cosponsors.pluck(:id).uniq
+    return if current_ids.sort == ids.sort
+
+    cosponsors_initiatives.where.not(user_id: ids).destroy_all
+
+    (ids - current_ids).each do |id|
+      cosponsors_initiatives.create(user_id: id)
+    end
   end
 
   def reactions_needed(configuration = AppConfiguration.instance)

--- a/back/app/models/initiative.rb
+++ b/back/app/models/initiative.rb
@@ -118,10 +118,7 @@ class Initiative < ApplicationRecord
     return if current_ids.sort == ids.sort
 
     cosponsors_initiatives.where.not(user_id: ids).destroy_all
-
-    (ids - current_ids).each do |id|
-      cosponsors_initiatives.create(user_id: id)
-    end
+    (ids - current_ids).each { |id| cosponsors_initiatives.create(user_id: id) }
   end
 
   def reactions_needed(configuration = AppConfiguration.instance)

--- a/back/app/services/side_fx_initiative_service.rb
+++ b/back/app/services/side_fx_initiative_service.rb
@@ -71,7 +71,8 @@ class SideFxInitiativeService
   private
 
   def log_activities_if_cosponsors_added(initiative, user, old_cosponsor_ids)
-    added_ids = initiative.cosponsors.map(&:id) - old_cosponsor_ids
+    new_cosponsor_ids = Initiative.find(initiative.id).cosponsors.map(&:id)
+    added_ids = new_cosponsor_ids - old_cosponsor_ids
 
     if added_ids.present?
       new_cosponsors_initiatives = initiative.cosponsors_initiatives.where(user_id: added_ids)

--- a/back/app/services/side_fx_initiative_service.rb
+++ b/back/app/services/side_fx_initiative_service.rb
@@ -26,7 +26,6 @@ class SideFxInitiativeService
   end
 
   def after_update(initiative, user, old_cosponsor_ids)
-    log_activities_if_cosponsors_added(initiative, user, old_cosponsor_ids)
     transition_to_review_pending_if_required(initiative, user)
     remove_user_from_past_activities_with_item(initiative, user) if initiative.anonymous_previously_changed?(to: true)
 
@@ -44,6 +43,8 @@ class SideFxInitiativeService
     if initiative.title_multiloc_previously_changed?
       LogActivityJob.perform_later(initiative, 'changed_title', user_for_activity_on_anonymizable_item(initiative, user), initiative.updated_at.to_i, payload: { change: initiative.title_multiloc_previous_change })
     end
+
+    log_activities_if_cosponsors_added(initiative, user, old_cosponsor_ids)
 
     return unless initiative.body_multiloc_previously_changed?
 

--- a/back/app/services/side_fx_initiative_service.rb
+++ b/back/app/services/side_fx_initiative_service.rb
@@ -71,8 +71,7 @@ class SideFxInitiativeService
   private
 
   def log_activities_if_cosponsors_added(initiative, user, old_cosponsor_ids)
-    new_cosponsor_ids = Initiative.find(initiative.id).cosponsors.map(&:id)
-    added_ids = new_cosponsor_ids - old_cosponsor_ids
+    added_ids = initiative.reload.cosponsors.map(&:id) - old_cosponsor_ids
 
     if added_ids.present?
       new_cosponsors_initiatives = initiative.cosponsors_initiatives.where(user_id: added_ids)

--- a/back/app/services/side_fx_initiative_service.rb
+++ b/back/app/services/side_fx_initiative_service.rb
@@ -81,7 +81,7 @@ class SideFxInitiativeService
           cosponsors_initiative,
           'created',
           user, # We don't want anonymized authors when cosponsors feature in use
-          cosponsors_initiative.updated_at.to_i
+          cosponsors_initiative.created_at.to_i
         )
       end
     end

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/cosponsor_of_your_initiative_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/cosponsor_of_your_initiative_mailer.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module EmailCampaigns
+  class CosponsorOfYourInitiativeMailer < ApplicationMailer
+    protected
+
+    def subject
+      format_message('subject', values: { cosponsorName: event.post_cosponsor_name })
+    end
+
+    def header_title
+      format_message('main_header', values: { cosponsorName: event.post_cosponsor_name })
+    end
+
+    private
+
+    def header_message
+      format_message('event_description_initiative', values: { cosponsorName: event.post_cosponsor_name })
+    end
+
+    def preheader
+      format_message('preheader_initiative', values: { cosponsorName: event.post_cosponsor_name })
+    end
+  end
+end

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/invitation_to_cosponsor_initiative_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/invitation_to_cosponsor_initiative_mailer.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module EmailCampaigns
+  class InvitationToCosponsorInitiativeMailer < ApplicationMailer
+    protected
+
+    def subject
+      format_message('subject')
+    end
+
+    def header_title
+      format_message('main_header')
+    end
+
+    private
+
+    def header_message
+      format_message('event_description_initiative', values: { authorName: event.post_author_name })
+    end
+
+    def preheader
+      format_message('preheader_initiative', values: { authorName: event.post_author_name })
+    end
+  end
+end

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/cosponsor_of_your_initiative.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/cosponsor_of_your_initiative.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: email_campaigns_campaigns
+#
+#  id               :uuid             not null, primary key
+#  type             :string           not null
+#  author_id        :uuid
+#  enabled          :boolean
+#  sender           :string
+#  reply_to         :string
+#  schedule         :jsonb
+#  subject_multiloc :jsonb
+#  body_multiloc    :jsonb
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  deliveries_count :integer          default(0), not null
+#
+# Indexes
+#
+#  index_email_campaigns_campaigns_on_author_id  (author_id)
+#  index_email_campaigns_campaigns_on_type       (type)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (author_id => users.id)
+#
+module EmailCampaigns
+  class Campaigns::CosponsorOfYourInitiative < Campaign
+    include Consentable
+    include ActivityTriggerable
+    include RecipientConfigurable
+    include Disableable
+    include Trackable
+    include LifecycleStageRestrictable
+    allow_lifecycle_stages only: %w[trial active]
+
+    recipient_filter :filter_notification_recipient
+
+    def mailer_class
+      CosponsorOfYourInitiativeMailer
+    end
+
+    def activity_triggers
+      { 'Notifications::CosponsorOfYourInitiative' => { 'created' => true } }
+    end
+
+    def filter_notification_recipient(users_scope, activity:, time: nil)
+      users_scope.where(id: activity.item.recipient.id)
+    end
+
+    def self.recipient_role_multiloc_key
+      'email_campaigns.admin_labels.recipient_role.registered_users'
+    end
+
+    def self.recipient_segment_multiloc_key
+      'email_campaigns.admin_labels.recipient_segment.user_who_published_the_proposal'
+    end
+
+    def self.content_type_multiloc_key
+      'email_campaigns.admin_labels.content_type.proposals'
+    end
+
+    def self.trigger_multiloc_key
+      'email_campaigns.admin_labels.trigger.user_accepts_invitation_to_cosponsor_a_proposal'
+    end
+
+    def generate_commands(recipient:, activity:)
+      initiative = activity.item.post
+      cosponsor = activity.user
+      name_service = UserDisplayNameService.new(AppConfiguration.instance, recipient)
+
+      [{
+        event_payload: {
+          post_title_multiloc: initiative.title_multiloc,
+          post_body_multiloc: initiative.body_multiloc,
+          post_cosponsor_name: name_service.display_name!(cosponsor),
+          post_url: Frontend::UrlService.new.model_to_url(initiative, locale: recipient.locale),
+          post_image_medium_url: post_image_medium_url(initiative)
+        }
+      }]
+    end
+
+    private
+
+    def post_image_medium_url(initiative)
+      image = initiative&.initiative_images&.first
+      image.image.versions[:medium].url if image&.image&.versions
+    end
+  end
+end

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/cosponsor_of_your_initiative.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/cosponsor_of_your_initiative.rb
@@ -75,6 +75,7 @@ module EmailCampaigns
         event_payload: {
           post_title_multiloc: initiative.title_multiloc,
           post_body_multiloc: initiative.body_multiloc,
+          post_author_name: name_service.display_name!(initiative.author),
           post_cosponsor_name: name_service.display_name!(cosponsor),
           post_url: Frontend::UrlService.new.model_to_url(initiative, locale: recipient.locale),
           post_image_medium_url: post_image_medium_url(initiative)

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/invitation_to_cosponsor_initiative.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/invitation_to_cosponsor_initiative.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: email_campaigns_campaigns
+#
+#  id               :uuid             not null, primary key
+#  type             :string           not null
+#  author_id        :uuid
+#  enabled          :boolean
+#  sender           :string
+#  reply_to         :string
+#  schedule         :jsonb
+#  subject_multiloc :jsonb
+#  body_multiloc    :jsonb
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  deliveries_count :integer          default(0), not null
+#
+# Indexes
+#
+#  index_email_campaigns_campaigns_on_author_id  (author_id)
+#  index_email_campaigns_campaigns_on_type       (type)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (author_id => users.id)
+#
+module EmailCampaigns
+  class Campaigns::InvitationToCosponsorInitiative < Campaign
+    include Consentable
+    include ActivityTriggerable
+    include RecipientConfigurable
+    include Disableable
+    include Trackable
+    include LifecycleStageRestrictable
+    allow_lifecycle_stages only: %w[trial active]
+
+    recipient_filter :filter_notification_recipient
+
+    def mailer_class
+      InvitationToCosponsorInitiativeMailer
+    end
+
+    def activity_triggers
+      { 'Notifications::InvitationToCosponsorInitiative' => { 'created' => true } }
+    end
+
+    def filter_notification_recipient(users_scope, activity:, time: nil)
+      users_scope.where(id: activity.item.recipient.id)
+    end
+
+    def self.recipient_role_multiloc_key
+      'email_campaigns.admin_labels.recipient_role.registered_users'
+    end
+
+    def self.recipient_segment_multiloc_key
+      'email_campaigns.admin_labels.recipient_segment.user_who_is_invited_to_cosponsor_a_proposal'
+    end
+
+    def self.content_type_multiloc_key
+      'email_campaigns.admin_labels.content_type.proposals'
+    end
+
+    def self.trigger_multiloc_key
+      'email_campaigns.admin_labels.trigger.user_is_invited_to_cosponsor_a_proposal'
+    end
+
+    def generate_commands(recipient:, activity:)
+      notification = activity.item
+      initiative = notification.post
+      name_service = UserDisplayNameService.new(AppConfiguration.instance, recipient)
+
+      [{
+        event_payload: {
+          post_title_multiloc: initiative.title_multiloc,
+          post_body_multiloc: initiative.body_multiloc,
+          post_author_name: name_service.display_name!(initiative.author),
+          post_url: Frontend::UrlService.new.model_to_url(notification.post, locale: recipient.locale),
+          post_image_medium_url: post_image_medium_url(notification)
+        }
+      }]
+    end
+
+    def serialize_medium_image(image)
+      image.image.versions[:medium].url if image&.image&.versions
+    end
+
+    private
+
+    def post_image_medium_url(notification)
+      serialize_medium_image(notification&.post&.initiative_images&.first)
+    end
+  end
+end

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/invitation_to_cosponsor_initiative.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/invitation_to_cosponsor_initiative.rb
@@ -67,8 +67,7 @@ module EmailCampaigns
     end
 
     def generate_commands(recipient:, activity:)
-      notification = activity.item
-      initiative = notification.post
+      initiative = activity.item.post
       name_service = UserDisplayNameService.new(AppConfiguration.instance, recipient)
 
       [{
@@ -76,8 +75,8 @@ module EmailCampaigns
           post_title_multiloc: initiative.title_multiloc,
           post_body_multiloc: initiative.body_multiloc,
           post_author_name: name_service.display_name!(initiative.author),
-          post_url: Frontend::UrlService.new.model_to_url(notification.post, locale: recipient.locale),
-          post_image_medium_url: post_image_medium_url(notification)
+          post_url: Frontend::UrlService.new.model_to_url(initiative, locale: recipient.locale),
+          post_image_medium_url: post_image_medium_url(initiative)
         }
       }]
     end
@@ -88,8 +87,8 @@ module EmailCampaigns
 
     private
 
-    def post_image_medium_url(notification)
-      serialize_medium_image(notification&.post&.initiative_images&.first)
+    def post_image_medium_url(initiative)
+      serialize_medium_image(initiative&.initiative_images&.first)
     end
   end
 end

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/invitation_to_cosponsor_initiative.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/invitation_to_cosponsor_initiative.rb
@@ -81,14 +81,11 @@ module EmailCampaigns
       }]
     end
 
-    def serialize_medium_image(image)
-      image.image.versions[:medium].url if image&.image&.versions
-    end
-
     private
 
     def post_image_medium_url(initiative)
-      serialize_medium_image(initiative&.initiative_images&.first)
+      image = initiative&.initiative_images&.first
+      image.image.versions[:medium].url if image&.image&.versions
     end
   end
 end

--- a/back/engines/free/email_campaigns/app/services/email_campaigns/delivery_service.rb
+++ b/back/engines/free/email_campaigns/app/services/email_campaigns/delivery_service.rb
@@ -11,6 +11,7 @@ module EmailCampaigns
       Campaigns::CommentOnYourComment,
       Campaigns::CommentOnYourIdea,
       Campaigns::CommentOnYourInitiative,
+      Campaigns::CosponsorOfYourInitiative,
       Campaigns::IdeaMarkedAsSpam,
       Campaigns::IdeaPublished,
       Campaigns::InitiativeAssignedToYou,

--- a/back/engines/free/email_campaigns/app/services/email_campaigns/delivery_service.rb
+++ b/back/engines/free/email_campaigns/app/services/email_campaigns/delivery_service.rb
@@ -16,6 +16,7 @@ module EmailCampaigns
       Campaigns::InitiativeAssignedToYou,
       Campaigns::InitiativeMarkedAsSpam,
       Campaigns::InitiativePublished,
+      Campaigns::InvitationToCosponsorInitiative,
       Campaigns::InitiativeResubmittedForReview,
       Campaigns::InternalCommentOnIdeaAssignedToYou,
       Campaigns::InternalCommentOnIdeaYouCommentedInternallyOn,

--- a/back/engines/free/email_campaigns/app/views/email_campaigns/cosponsor_of_your_initiative_mailer/campaign_mail.mjml
+++ b/back/engines/free/email_campaigns/app/views/email_campaigns/cosponsor_of_your_initiative_mailer/campaign_mail.mjml
@@ -1,0 +1,2 @@
+<%= render 'email_campaigns/posts/post_with_image', post_image_url: event&.post_image_medium_url, post_title_multiloc: event.post_title_multiloc, post_body_multiloc: event.post_body_multiloc %>
+<%= render partial: 'application/cta_button', locals: { href: event.post_url, message: format_message('cta_reply_to', values: { authorName: event.post_author_name }) } %>

--- a/back/engines/free/email_campaigns/app/views/email_campaigns/invitation_to_cosponsor_initiative_mailer/campaign_mail.mjml
+++ b/back/engines/free/email_campaigns/app/views/email_campaigns/invitation_to_cosponsor_initiative_mailer/campaign_mail.mjml
@@ -1,0 +1,18 @@
+<mj-section padding="0 25px 0 25px">
+  <mj-column>
+    <mj-text>
+      <p><%= format_message('event_description_cosponsoring', escape_html: false) %></p>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<mj-section padding="0 25px 0 25px">
+  <mj-column>
+    <mj-text>
+      <p><%= format_message('event_description_action') %></p>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%= render 'email_campaigns/posts/post_with_image', post_image_url: event&.post_image_medium_url, post_title_multiloc: event.post_title_multiloc, post_body_multiloc: event.post_body_multiloc %>
+<%= render partial: 'application/cta_button', locals: { href: event.post_url, message: format_message('cta_reply_to', values: { authorName: event.post_author_name }) } %>

--- a/back/engines/free/email_campaigns/app/views/email_campaigns/posts/_post_with_image.mjml
+++ b/back/engines/free/email_campaigns/app/views/email_campaigns/posts/_post_with_image.mjml
@@ -18,6 +18,9 @@
       <p style="margin-top: 10px; color: #84939E;">
         <%= localize_for_recipient(post_body_multiloc)&.html_safe %>
       </p>
+      <% if event.post_author_name %>
+        <p style="color:#8D8D8D;"><%= "by #{event.post_author_name}" %></p>
+      <% end %>
     </mj-text>
   </mj-column>
 </mj-section>

--- a/back/engines/free/email_campaigns/config/locales/en.yml
+++ b/back/engines/free/email_campaigns/config/locales/en.yml
@@ -14,6 +14,7 @@ en:
       "initiative_assigned_to_you": Assignment of a proposal to me
       "initiative_marked_as_spam": Proposal spam report
       "initiative_published": Publication of my proposal
+      "invitation_to_cosponsor_initiative": Invitation to cosponsor a proposal
       "initiative_resubmitted_for_review": Proposal resubmitted for review
       "invite_received": Invitation
       "invite_reminder": Invitation reminder
@@ -179,6 +180,15 @@ en:
       main_header: '%{firstName}, you have a new assignment'
       subject: 'You have an assignment on the platform of %{organizationName}'
       preheader_initiative: 'The proposal of %{authorName} has been assigned to you'
+    invitation_to_cosponsor_initiative:
+      by_author: 'by %{authorName}'
+      cta_reply_to: 'Co-sponsor this proposal'
+      event_description_initiative: '%{authorName} has created a new proposal and would like you to co-sponsor it.'
+      event_description_cosponsoring: 'Co-sponsoring a proposal means that <strong>your name will be displayed</strong> with the names of other co-sponsors of the proposal.'
+      event_description_action: 'Click below to read the proposal.'
+      main_header: 'You have been invited to co-sponsor a proposal'
+      subject: 'You have been invited to co-sponsor a proposal'
+      preheader_initiative: 'You have been invited to cosponsor the proposal of %{authorName}'
     initiative_resubmitted_for_review:
       by_author: 'by %{authorName}'
       cta_reply_to: 'Give feedback to %{authorName}'
@@ -641,6 +651,7 @@ en:
         managers: 'Managers'
         admins_assigned_to_a_proposal: 'Admins assigned to a proposal'
         admins_and_managers_assigned_to_the_input: 'Admins & managers assigned to the input'
+        user_who_is_invited_to_cosponsor_a_proposal: 'User who is invited to cosponsor a proposal'
         user_who_is_receiving_admin_rights: 'User who is receiving admin rights'
         user_who_is_receiving_folder_moderator_rights: 'User who is receiving folder moderator rights'
         user_who_is_receiving_project_moderator_rights: 'User who is receiving project moderator rights'
@@ -675,6 +686,7 @@ en:
         input_is_flagged_as_spam: 'Input is flagged as spam'
         input_is_updated: 'Input is updated'
         input_status_changes: 'Input status changes'
+        new_test_campaign: 'Proposal resubmitted for review'
         initiative_resubmitted_for_review: 'Proposal resubmitted for review'
         internal_comment_is_posted_on_idea_assigned_to_user: 'Internal comment is posted on input assigned to user'
         internal_comment_is_posted_on_initiative_assigned_to_user: 'Internal comment is posted on proposal assigned to user'
@@ -684,6 +696,7 @@ en:
         internal_comment_is_posted_on_initiative_user_has_commented_internally_on: 'Internal comment is posted on proposal user commented internally on'
         internal_comment_is_posted_on_unassigned_initiative: 'Internal comment is posted on unassigned proposal'
         internal_comment_is_posted_on_unassigned_unmoderated_idea: 'Internal comment is posted on unassigned input in unmanaged project'
+        user_is_invited_to_cosponsor_a_proposal: 'User is invited to cosponsor a proposal'
         user_is_mentioned_in_internal_comment: 'User is mentioned in internal comment'
         new_input_is_published: 'New input is published'
         new_proposal_is_posted: 'New proposal is posted'

--- a/back/engines/free/email_campaigns/config/locales/en.yml
+++ b/back/engines/free/email_campaigns/config/locales/en.yml
@@ -15,7 +15,7 @@ en:
       "initiative_assigned_to_you": Assignment of a proposal to me
       "initiative_marked_as_spam": Proposal spam report
       "initiative_published": Publication of my proposal
-      "invitation_to_cosponsor_initiative": Invitation to cosponsor a proposal
+      "invitation_to_cosponsor_initiative": Invitation to co-sponsor a proposal
       "initiative_resubmitted_for_review": Proposal resubmitted for review
       "invite_received": Invitation
       "invite_reminder": Invitation reminder
@@ -195,7 +195,7 @@ en:
       event_description_action: 'Click below to read the proposal.'
       main_header: 'You have been invited to co-sponsor a proposal'
       subject: 'You have been invited to co-sponsor a proposal'
-      preheader_initiative: 'You have been invited to cosponsor the proposal of %{authorName}'
+      preheader_initiative: 'You have been invited to co-sponsor the proposal of %{authorName}'
     initiative_resubmitted_for_review:
       by_author: 'by %{authorName}'
       cta_reply_to: 'Give feedback to %{authorName}'
@@ -658,7 +658,7 @@ en:
         managers: 'Managers'
         admins_assigned_to_a_proposal: 'Admins assigned to a proposal'
         admins_and_managers_assigned_to_the_input: 'Admins & managers assigned to the input'
-        user_who_is_invited_to_cosponsor_a_proposal: 'User who is invited to cosponsor a proposal'
+        user_who_is_invited_to_cosponsor_a_proposal: 'User who is invited to co-sponsor a proposal'
         user_who_is_receiving_admin_rights: 'User who is receiving admin rights'
         user_who_is_receiving_folder_moderator_rights: 'User who is receiving folder moderator rights'
         user_who_is_receiving_project_moderator_rights: 'User who is receiving project moderator rights'
@@ -693,7 +693,6 @@ en:
         input_is_flagged_as_spam: 'Input is flagged as spam'
         input_is_updated: 'Input is updated'
         input_status_changes: 'Input status changes'
-        new_test_campaign: 'Proposal resubmitted for review'
         initiative_resubmitted_for_review: 'Proposal resubmitted for review'
         internal_comment_is_posted_on_idea_assigned_to_user: 'Internal comment is posted on input assigned to user'
         internal_comment_is_posted_on_initiative_assigned_to_user: 'Internal comment is posted on proposal assigned to user'

--- a/back/engines/free/email_campaigns/config/locales/en.yml
+++ b/back/engines/free/email_campaigns/config/locales/en.yml
@@ -189,7 +189,6 @@ en:
       subject: 'You have an assignment on the platform of %{organizationName}'
       preheader_initiative: 'The proposal of %{authorName} has been assigned to you'
     invitation_to_cosponsor_initiative:
-      by_author: 'by %{authorName}'
       cta_reply_to: 'Co-sponsor this proposal'
       event_description_initiative: '%{authorName} has created a new proposal and would like you to co-sponsor it.'
       event_description_cosponsoring: 'Co-sponsoring a proposal means that <strong>your name will be displayed</strong> with the names of other co-sponsors of the proposal.'

--- a/back/engines/free/email_campaigns/config/locales/en.yml
+++ b/back/engines/free/email_campaigns/config/locales/en.yml
@@ -8,6 +8,7 @@ en:
       "comment_on_your_comment": A reply on my comment
       "comment_on_your_idea": A comment on my idea
       "comment_on_your_initiative": A comment on my proposal
+      "cosponsor_of_your_initiative": A user accepts my invitation to co-sponsor my proposal
       "first_idea_published": Publication of my first idea
       "idea_marked_as_spam": Idea spam report
       "idea_published": Publication of my idea
@@ -140,6 +141,13 @@ en:
       main_header: '%{commentAuthor} commented on your initiative'
       subject: 'You''ve received a comment on %{organizationName}''s platform'
       preheader: '%{authorName} left a comment on your initiative for %{organizationName}'
+    cosponsor_of_your_initiative:
+      cta_reply_to: 'View your proposal'
+      event_description_initiative: 'Congratulations! %{cosponsorName} has accepted your invitation to co-sponsor your proposal.'
+      event_description_cosponsoring: 'Co-sponsoring a proposal means that <strong>your name will be displayed</strong> with the names of other co-sponsors of the proposal.'
+      main_header: '%{cosponsorName} has accepted your invitation to co-sponsor your proposal'
+      subject: '%{cosponsorName} has accepted your invitation to co-sponsor your proposal'
+      preheader_initiative: '%{cosponsorName} has accepted your invitation to co-sponsor your proposal'
     assignee_digest:
       subject: 'Ideas requiring your feedback: %{numberIdeas}'
       preheader: 'Assignee digest of %{organizationName}'
@@ -696,7 +704,8 @@ en:
         internal_comment_is_posted_on_initiative_user_has_commented_internally_on: 'Internal comment is posted on proposal user commented internally on'
         internal_comment_is_posted_on_unassigned_initiative: 'Internal comment is posted on unassigned proposal'
         internal_comment_is_posted_on_unassigned_unmoderated_idea: 'Internal comment is posted on unassigned input in unmanaged project'
-        user_is_invited_to_cosponsor_a_proposal: 'User is invited to cosponsor a proposal'
+        user_accepts_invitation_to_cosponsor_a_proposal: 'User accepts invitation to co-sponsor a proposal'
+        user_is_invited_to_cosponsor_a_proposal: 'User is invited to co-sponsor a proposal'
         user_is_mentioned_in_internal_comment: 'User is mentioned in internal comment'
         new_input_is_published: 'New input is published'
         new_proposal_is_posted: 'New proposal is posted'

--- a/back/engines/free/email_campaigns/spec/factories/campaigns.rb
+++ b/back/engines/free/email_campaigns/spec/factories/campaigns.rb
@@ -106,6 +106,10 @@ FactoryBot.define do
     enabled { true }
   end
 
+  factory :invitation_to_cosponsor_initiative_campaign, class: EmailCampaigns::Campaigns::InvitationToCosponsorInitiative do
+    enabled { true }
+  end
+
   factory :mention_in_internal_comment_campaign, class: EmailCampaigns::Campaigns::MentionInInternalComment do
     enabled { true }
   end

--- a/back/engines/free/email_campaigns/spec/factories/campaigns.rb
+++ b/back/engines/free/email_campaigns/spec/factories/campaigns.rb
@@ -42,6 +42,10 @@ FactoryBot.define do
     enabled { true }
   end
 
+  factory :cosponsor_of_your_initiative_campaign, class: EmailCampaigns::Campaigns::CosponsorOfYourInitiative do
+    enabled { true }
+  end
+
   factory :idea_marked_as_spam_campaign, class: EmailCampaigns::Campaigns::IdeaMarkedAsSpam do
     enabled { true }
   end

--- a/back/engines/free/email_campaigns/spec/fixtures/locales/mailers.en.yml
+++ b/back/engines/free/email_campaigns/spec/fixtures/locales/mailers.en.yml
@@ -25,7 +25,7 @@ en:
       "internal_comment_on_your_internal_comment": Internal comment on my internal comment
       "invite_received": Invitation
       "invite_reminder": Invitation reminder
-      "invitation_to_cosponsor_initiative": Invitation to cosponsor a proposal
+      "invitation_to_cosponsor_initiative": Invitation to co-sponsor a proposal
       "mention_in_internal_comment": Mention in an internal comment
       "mention_in_official_feedback": Mention in an update
       "new_comment_for_admin": New comment in a project I moderate
@@ -67,7 +67,7 @@ en:
       "comment_on_your_comment": Reply on your comment - all users
       "comment_on_your_idea": Comment on your idea - all users
       "comment_on_your_initiative": Comment on your proposal - all users
-      "cosponsor_of_your_initiative": A user accepts your invitation to co-sponor yourmy proposal - all users
+      "cosponsor_of_your_initiative": A user accepts your invitation to co-sponor your proposal - all users
       "first_idea_published": Publication of your first idea - all users
       "idea_marked_as_spam": Idea spam report - admins and project managers
       "idea_published": Publication of your idea - all users
@@ -84,7 +84,7 @@ en:
       "internal_comment_on_your_internal_comment": Internal comment on your internal comment - admins and project managers
       "invite_received": Invitation - all users
       "invite_reminder": Invitation reminder - all users
-      "invitation_to_cosponsor_initiative": Invitation to cosponsor a proposal - all users
+      "invitation_to_cosponsor_initiative": Invitation to co-sponsor a proposal - all users
       "mention_in_comment": Mention in a comment - all users
       "mention_in_internal_comment": Mention in an internal comment - admins and project managers
       "mention_in_official_feedback": Mention in an update - all users
@@ -253,7 +253,7 @@ en:
       event_description_action: 'Click below to read the proposal'
       main_header: 'You have been invited to co-sponsor a proposal'
       subject: 'You have been invited to co-sponsor a proposal'
-      preheader_initiative: 'You have been invited to cosponsor the proposal of %{authorName}'
+      preheader_initiative: 'You have been invited to co-sponsor the proposal of %{authorName}'
     initiative_published:
       action_add_image: '%{addImageLink} to increase visibility'
       action_published_initiative: 'Published proposal'

--- a/back/engines/free/email_campaigns/spec/fixtures/locales/mailers.en.yml
+++ b/back/engines/free/email_campaigns/spec/fixtures/locales/mailers.en.yml
@@ -24,6 +24,7 @@ en:
       "internal_comment_on_your_internal_comment": Internal comment on my internal comment
       "invite_received": Invitation
       "invite_reminder": Invitation reminder
+      "invitation_to_cosponsor_initiative": Invitation to cosponsor a proposal
       "mention_in_internal_comment": Mention in an internal comment
       "mention_in_official_feedback": Mention in an update
       "new_comment_for_admin": New comment in a project I moderate
@@ -81,6 +82,7 @@ en:
       "internal_comment_on_your_internal_comment": Internal comment on your internal comment - admins and project managers
       "invite_received": Invitation - all users
       "invite_reminder": Invitation reminder - all users
+      "invitation_to_cosponsor_initiative": Invitation to cosponsor a proposal - all users
       "mention_in_comment": Mention in a comment - all users
       "mention_in_internal_comment": Mention in an internal comment - admins and project managers
       "mention_in_official_feedback": Mention in an update - all users
@@ -235,6 +237,15 @@ en:
       invitation_header_message: '%{organizationName} invited you to their participation platform.'
       preheader: '%{organizationName} sent you an invite to join their participation platform.'
       subject: 'You are invited to join the platform of %{organizationName}'
+    invitation_to_cosponsor_initative:
+      by_author: 'by %{authorName}'
+      cta_reply_to: 'Co-sponsor this proposal'
+      event_description_initiative: '%{authorName} has created a new proposal and would like you to co-sponsor it.'
+      event_description_cosponsoring: 'Co-sponsoring a proposal means that <strong>your name will be displayed</strong> with the names of other co-sponsors of the proposal'
+      event_description_action: 'Click below to read the proposal'
+      main_header: 'You have been invited to co-sponsor a proposal'
+      subject: 'You have been invited to co-sponsor a proposal'
+      preheader_initiative: 'You have been invited to cosponsor the proposal of %{authorName}'
     initiative_published:
       action_add_image: '%{addImageLink} to increase visibility'
       action_published_initiative: 'Published proposal'

--- a/back/engines/free/email_campaigns/spec/fixtures/locales/mailers.en.yml
+++ b/back/engines/free/email_campaigns/spec/fixtures/locales/mailers.en.yml
@@ -8,6 +8,7 @@ en:
       "comment_on_your_comment": A reply on my comment
       "comment_on_your_idea": A comment on my idea
       "comment_on_your_initiative": A comment on my proposal
+      "cosponsor_of_your_initiative": A user accepts my invitation to co-sponor my proposal
       "first_idea_published": Publication of my first idea
       "idea_marked_as_spam": Idea spam report
       "idea_published": Publication of my idea
@@ -66,6 +67,7 @@ en:
       "comment_on_your_comment": Reply on your comment - all users
       "comment_on_your_idea": Comment on your idea - all users
       "comment_on_your_initiative": Comment on your proposal - all users
+      "cosponsor_of_your_initiative": A user accepts your invitation to co-sponor yourmy proposal - all users
       "first_idea_published": Publication of your first idea - all users
       "idea_marked_as_spam": Idea spam report - admins and project managers
       "idea_published": Publication of your idea - all users
@@ -185,6 +187,13 @@ en:
       main_header: '%{commentAuthor} commented on your initiative'
       subject: 'You''ve received a comment on %{organizationName}''s platform'
       preheader: '%{authorName} left a comment on your initiative for %{organizationName}'
+    cosponsor_of_your_initiative:
+      cta_reply_to: 'View your proposal'
+      event_description_initiative: 'Congratulations! %{cosponsorName} has accepted your invitation to co-sponsor your proposal.'
+      event_description_cosponsoring: 'Co-sponsoring a proposal means that <strong>your name will be displayed</strong> with the names of other co-sponsors of the proposal.'
+      main_header: '%{cosponsorName} has accepted your invitation to co-sponsor your proposal'
+      subject: '%{cosponsorName} has accepted your invitation to co-sponsor your proposal'
+      preheader_initiative: '%{cosponsorName} has accepted your invitation to co-sponsor your proposal'
     assignee_digest:
       subject: 'Ideas requiring your feedback: %{numberIdeas}'
       preheader: 'Assignee digest of %{organizationName}'

--- a/back/engines/free/email_campaigns/spec/fixtures/locales/mailers.en.yml
+++ b/back/engines/free/email_campaigns/spec/fixtures/locales/mailers.en.yml
@@ -247,7 +247,6 @@ en:
       preheader: '%{organizationName} sent you an invite to join their participation platform.'
       subject: 'You are invited to join the platform of %{organizationName}'
     invitation_to_cosponsor_initative:
-      by_author: 'by %{authorName}'
       cta_reply_to: 'Co-sponsor this proposal'
       event_description_initiative: '%{authorName} has created a new proposal and would like you to co-sponsor it.'
       event_description_cosponsoring: 'Co-sponsoring a proposal means that <strong>your name will be displayed</strong> with the names of other co-sponsors of the proposal'

--- a/back/engines/free/email_campaigns/spec/mailers/cosponsor_of_your_initiative_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/cosponsor_of_your_initiative_mailer_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EmailCampaigns::CosponsorOfYourInitiativeMailer do
+  describe 'campaign_mail' do
+    let_it_be(:recipient) { create(:user, locale: 'en') }
+    let_it_be(:author) { create(:user) }
+    let_it_be(:cosponsor) { create(:user) }
+    let_it_be(:initiative) { create(:initiative, author: author) }
+    let_it_be(:campaign) { EmailCampaigns::Campaigns::CosponsorOfYourInitiative.create! }
+    let_it_be(:cosponsor_name) { UserDisplayNameService.new(AppConfiguration.instance, cosponsor).display_name!(cosponsor) }
+    let_it_be(:command) do
+      item = Notifications::CosponsorOfYourInitiative.new(post: initiative)
+      activity = Activity.new(item: item, user: cosponsor)
+      commands = EmailCampaigns::Campaigns::CosponsorOfYourInitiative.new.generate_commands(recipient: recipient, activity: activity)
+      commands[0].merge({ recipient: recipient })
+    end
+
+    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+
+    before_all { EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id) }
+
+    it 'renders the subject' do
+      expect(mail.subject).to match('has accepted your invitation to co-sponsor your proposal')
+    end
+
+    it 'renders the receiver email' do
+      expect(mail.to).to eq([recipient.email])
+    end
+
+    it 'renders the sender email' do
+      expect(mail.from).to all(end_with('@citizenlab.co'))
+    end
+
+    it 'assigns initiative cosponsor name' do
+      expect(mail.body.encoded).to match(cosponsor_name)
+    end
+
+    it 'assigns cta url' do
+      post_url = Frontend::UrlService.new.model_to_url(initiative, locale: recipient.locale)
+      expect(mail.body.encoded).to match(post_url)
+    end
+  end
+end

--- a/back/engines/free/email_campaigns/spec/mailers/invitation_to_cosponsor_initiative_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/invitation_to_cosponsor_initiative_mailer_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EmailCampaigns::InvitationToCosponsorInitiativeMailer do
+  describe 'campaign_mail' do
+    let_it_be(:recipient) { create(:user, locale: 'en') }
+    let_it_be(:author) { create(:user) }
+    let_it_be(:initiative) { create(:initiative, author: author) }
+    let_it_be(:campaign) { EmailCampaigns::Campaigns::InvitationToCosponsorInitiative.create! }
+    let_it_be(:author_name) { UserDisplayNameService.new(AppConfiguration.instance, author).display_name!(initiative.author) }
+    let_it_be(:command) do
+      item = Notifications::InvitationToCosponsorInitiative.new(post: initiative)
+      activity = Activity.new(item: item)
+      commands = EmailCampaigns::Campaigns::InvitationToCosponsorInitiative.new.generate_commands(recipient: recipient, activity: activity)
+      commands[0].merge({ recipient: recipient })
+    end
+
+    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+
+    before_all { EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id) }
+
+    it 'renders the subject' do
+      expect(mail.subject).to start_with('You have been invited to co-sponsor a proposal')
+    end
+
+    it 'renders the receiver email' do
+      expect(mail.to).to eq([recipient.email])
+    end
+
+    it 'renders the sender email' do
+      expect(mail.from).to all(end_with('@citizenlab.co'))
+    end
+
+    it 'assigns initiative author name' do
+      expect(mail.body.encoded).to match(author_name)
+    end
+
+    it 'assigns cta url' do
+      post_url = Frontend::UrlService.new.model_to_url(initiative, locale: recipient.locale)
+      expect(mail.body.encoded).to match(post_url)
+    end
+  end
+end

--- a/back/engines/free/email_campaigns/spec/mailers/previews/email_campaigns/cosponsor_of_your_initiative_preview.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/previews/email_campaigns/cosponsor_of_your_initiative_preview.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module EmailCampaigns
+  class CosponsorOfYourInitiativeMailerPreview < ActionMailer::Preview
+    include EmailCampaigns::MailerPreviewRecipient
+
+    def campaign_mail
+      campaign = EmailCampaigns::Campaigns::CosponsorOfYourInitiative.first
+      initiative = Initiative.order(created_at: :asc).first
+      user = User.order(created_at: :asc).first
+      item = Notifications::CosponsorOfYourInitiative.new(post: initiative)
+      activity = Activity.new(item: item, user: user)
+      commands = EmailCampaigns::Campaigns::CosponsorOfYourInitiative.new.generate_commands(recipient: user, activity: activity)
+      command = commands[0].merge({ recipient: user })
+
+      campaign.mailer_class.with(campaign: campaign, command: command).campaign_mail
+    end
+  end
+end

--- a/back/engines/free/email_campaigns/spec/mailers/previews/email_campaigns/invitation_to_cosponsor_initiative_mailer_preview.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/previews/email_campaigns/invitation_to_cosponsor_initiative_mailer_preview.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module EmailCampaigns
+  class InvitationToCosponsorInitiativeMailerPreview < ActionMailer::Preview
+    include EmailCampaigns::MailerPreviewRecipient
+
+    def campaign_mail
+      campaign = EmailCampaigns::Campaigns::InvitationToCosponsorInitiative.first
+      initiative = Initiative.order(created_at: :asc).first
+      user = User.order(created_at: :asc).first
+      item = Notifications::InvitationToCosponsorInitiative.new(post: initiative)
+      activity = Activity.new(item: item)
+      commands = EmailCampaigns::Campaigns::InvitationToCosponsorInitiative.new.generate_commands(recipient: user, activity: activity)
+      command = commands[0].merge({ recipient: user })
+
+      campaign.mailer_class.with(campaign: campaign, command: command).campaign_mail
+    end
+  end
+end

--- a/back/spec/acceptance/initiatives_spec.rb
+++ b/back/spec/acceptance/initiatives_spec.rb
@@ -685,6 +685,11 @@ resource 'Initiatives' do
 
           expect(json_response.dig(:data, :relationships, :cosponsors, :data).pluck(:id)).to match_array cosponsor_ids
         end
+
+        example 'Update the cosponsors of an initiative 2' do
+          expect { do_request }.to have_enqueued_job(LogActivityJob).with(instance_of(CosponsorsInitiative), 'created', @user, instance_of(Integer)).exactly(1).times
+          assert_status 200
+        end
       end
     end
   end

--- a/back/spec/acceptance/initiatives_spec.rb
+++ b/back/spec/acceptance/initiatives_spec.rb
@@ -679,16 +679,16 @@ resource 'Initiatives' do
         let(:cosponsor) { create(:user) }
         let(:cosponsor_ids) { [cosponsor.id] }
 
-        example_request 'Update the cosponsors of an initiative' do
+        example 'Update the cosponsors of an initiative' do
+          expect { do_request }
+            .to have_enqueued_job(LogActivityJob)
+            .with(instance_of(CosponsorsInitiative), 'created', @user, instance_of(Integer))
+            .exactly(1).times
+
           assert_status 200
           json_response = json_parse(response_body)
 
           expect(json_response.dig(:data, :relationships, :cosponsors, :data).pluck(:id)).to match_array cosponsor_ids
-        end
-
-        example 'Update the cosponsors of an initiative 2' do
-          expect { do_request }.to have_enqueued_job(LogActivityJob).with(instance_of(CosponsorsInitiative), 'created', @user, instance_of(Integer)).exactly(1).times
-          assert_status 200
         end
       end
     end

--- a/back/spec/models/initiative_spec.rb
+++ b/back/spec/models/initiative_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe Initiative do
       expect(initiative.reload.cosponsors).to match_array [cosponsor1, cosponsor2]
     end
 
-    it 'removes cosponsors_initiative when given array of user IDs excluding ID of existing cosponsor' do
+    it 'removes cosponsors_initiative when given array of user IDs excluding ID of existing co-sponsor' do
       cosponsor2 = create(:user)
       initiative.update!(cosponsor_ids: [cosponsor2.id])
 

--- a/back/spec/models/initiative_spec.rb
+++ b/back/spec/models/initiative_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe Initiative do
     let(:cosponsor1) { create(:user) }
     let!(:cosponsors_initiative) { create(:cosponsors_initiative, user_id: cosponsor1.id, initiative_id: initiative.id) }
 
-    it 'adds cosponsor when given array of user IDs including new ID' do
+    it 'adds cosponsors_initiative when given array of user IDs including new ID' do
       expect(initiative.reload.cosponsors).to match_array [cosponsor1]
 
       cosponsor2 = create(:user)
@@ -218,14 +218,22 @@ RSpec.describe Initiative do
       expect(initiative.reload.cosponsors).to match_array [cosponsor1, cosponsor2]
     end
 
-    it 'removes cosponsor when given array of user IDs excluding ID of existing cosponsor' do
+    it 'removes cosponsors_initiative when given array of user IDs excluding ID of existing cosponsor' do
       cosponsor2 = create(:user)
       initiative.update!(cosponsor_ids: [cosponsor2.id])
 
       expect(initiative.reload.cosponsors).to match_array [cosponsor2]
     end
 
-    it 'can add and remove cosponsors at the same time' do
+    it 'removes cosponsors_initiative even when an associated notifcation exists' do
+      cosponsor2 = create(:user)
+      create(:invitation_to_cosponsor_initiative, cosponsors_initiative: cosponsors_initiative)
+      initiative.update!(cosponsor_ids: [cosponsor2.id])
+
+      expect(initiative.reload.cosponsors).to match_array [cosponsor2]
+    end
+
+    it 'can add and remove cosponsors_initiatives at the same time' do
       cosponsor2 = create(:user)
       cosponsor3 = create(:user)
       initiative.update!(cosponsor_ids: [cosponsor2.id, cosponsor3.id])
@@ -233,7 +241,7 @@ RSpec.describe Initiative do
       expect(initiative.reload.cosponsors).to match_array [cosponsor2, cosponsor3]
     end
 
-    it 'removes all cosponsors when given empty array' do
+    it 'removes all cosponsors_initiatives when given empty array' do
       initiative.update!(cosponsor_ids: [])
 
       expect(initiative.reload.cosponsors).to be_empty


### PR DESCRIPTION
Adds 2 new campaigns + previews + tests:
- `InvitationToCosponsorInitiative`
- `CosponsorOfYourInitiative`

Fixes bug whereby `cosponsors_initiatives` could not be destroyed if they had an associated `notification` (see comments in code for details).

<details>
  <summary>CLICK ME for screenshots of mails</summary>
  
  ### `InvitationToCosponsorInitiative`
<img width="1116" alt="Screenshot 2023-08-17 at 12 30 54" src="https://github.com/CitizenLabDotCo/citizenlab/assets/3944042/5229469d-f7b3-4357-8df1-72771f4fb6d7">

  ### `CosponsorOfYourInitiative`
  <img width="1116" alt="Screenshot 2023-08-17 at 11 26 02" src="https://github.com/CitizenLabDotCo/citizenlab/assets/3944042/17db4f88-bc3f-4457-9790-7b5597d54a1d">

</details>

# Changelog
## Technical
 - [TAN-222] Add two new cosponsorship email campaigns (cosponsors feature in development)
