### PR TITLE
[CL-3983] New rake task to update custom_field_option title_multiloc for specific locale, regardless of existing value

### DIFF
--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/update_custom_field_option.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/update_custom_field_option.rake
@@ -42,4 +42,37 @@ namespace :cl2back do
 
     puts "Updated custom field option value (for specific locale) for #{n} tenants"
   end
+
+  # This task will update ANY existing value for a specific locale, for all tenants.
+  desc 'Update a specific custom field option title_multiloc, from ANY VALUE, for one specific locale, for all tenants'
+  # Examples of usage:
+  # Dry run (no changes): rake cl2back:update_custom_field_option['unspecified','de-DE','Divers']
+  # Execute (updates records!):
+  #  rake cl2back:update_custom_field_option_from_any_value['unspecified','de-DE','Divers','execute']
+  task :update_custom_field_option_from_any_value, %i[option_key locale new_value execute] => [:environment] do |_t, args|
+    live_run = true if args[:execute] == 'execute'
+    option_key = args[:option_key]
+    locale = args[:locale]
+    new_value = args[:new_value]
+    n = 0
+
+    puts "live_run: #{live_run ? 'true' : 'false'}"
+
+    Tenant.switch_each do |tenant|
+      puts "Processing tenant: #{tenant.name}..."
+
+      option = CustomFieldOption.find_by(key: option_key)
+
+      if option&.title_multiloc&.key?(locale) && option.title_multiloc[locale] != new_value
+        old_value = option.title_multiloc[locale]
+        option.title_multiloc[locale] = new_value
+        option.save! if live_run
+        n += 1
+        puts "Updated option with key: #{option_key}, title_multiloc value for locale: #{locale}; " \
+             "#{old_value}, to be: #{new_value}"
+      end
+    end
+
+    puts "Updated custom field option value (for specific locale) for #{n} tenants"
+  end
 end


### PR DESCRIPTION
New rake task, to facilitate task in related ticket.

I chose not to implement this via the new AdminHQ rake task UI, as simply producing a different version of an existing rake task is quicker, and this task should not be used often (and only when we are quite confident that we will not be changing any custom values that customers actually want).

# Changelog
## Technical
- [CL-3983] New rake task to update custom_field_option title_multiloc for specific locale, regardless of existing value


[CL-3983]: https://citizenlab.atlassian.net/browse/CL-3983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ