### PR TITLE
CL-3973: Close modal after redirecting to password reset page

### DIFF
--- a/front/app/containers/Authentication/Modal.tsx
+++ b/front/app/containers/Authentication/Modal.tsx
@@ -270,7 +270,7 @@ const AuthModal = ({ setModalOpen }: Props) => {
             onSwitchFlow={transition(currentStep, 'SWITCH_FLOW')}
             onGoBack={transition(currentStep, 'GO_BACK')}
             onSubmit={transition(currentStep, 'SIGN_IN')}
-            closeModal={handleClose}
+            closeModal={transition(currentStep, 'CLOSE')}
           />
         )}
 

--- a/front/app/containers/Authentication/Modal.tsx
+++ b/front/app/containers/Authentication/Modal.tsx
@@ -270,6 +270,7 @@ const AuthModal = ({ setModalOpen }: Props) => {
             onSwitchFlow={transition(currentStep, 'SWITCH_FLOW')}
             onGoBack={transition(currentStep, 'GO_BACK')}
             onSubmit={transition(currentStep, 'SIGN_IN')}
+            closeModal={handleClose}
           />
         )}
 

--- a/front/app/containers/Authentication/steps/EmailAndPassword/index.tsx
+++ b/front/app/containers/Authentication/steps/EmailAndPassword/index.tsx
@@ -47,6 +47,7 @@ interface Props {
   ) => void;
   onGoBack: () => void;
   onSwitchFlow: () => void;
+  closeModal: () => void;
 }
 
 interface FormValues {
@@ -67,6 +68,7 @@ const EmailAndPassword = ({
   onSubmit,
   onGoBack,
   onSwitchFlow,
+  closeModal,
 }: Props) => {
   const passwordLoginEnabled = useFeatureFlag({ name: 'password_login' });
   const anySSOEnabled = useAnySSOEnabled();
@@ -179,6 +181,7 @@ const EmailAndPassword = ({
           <TextLink
             to="/password-recovery"
             className="e2e-password-recovery-link"
+            onClick={closeModal}
           >
             {formatMessage(sharedMessages.forgotPassword)}
           </TextLink>


### PR DESCRIPTION
# Changelog

## Fixed
- Close modal after redirecting to password reset page
