### PR TITLE
[TAN-272] Use new proposed_from_time_ago Initiative scope in digest campaigns

### DIFF
--- a/back/app/models/initiative.rb
+++ b/back/app/models/initiative.rb
@@ -112,6 +112,10 @@ class Initiative < ApplicationRecord
   scope :no_feedback_needed, -> { with_status_code(InitiativeStatus::CODES - ['threshold_reached']) }
   scope :proposed, -> { with_status_code('proposed') }
 
+  scope :proposed_from_time_ago, (proc do |time_ago|
+    with_status_code('proposed').where(initiative_status: { created_at: time_ago..Time.now })
+  end)
+
   def cosponsor_ids=(ids)
     return unless ids
 

--- a/back/app/models/initiative.rb
+++ b/back/app/models/initiative.rb
@@ -113,7 +113,9 @@ class Initiative < ApplicationRecord
   scope :proposed, -> { with_status_code('proposed') }
 
   scope :proposed_from_time_ago, (proc do |time_ago|
-    with_status_code('proposed').where(initiative_status: { created_at: time_ago..Time.now })
+    joins(:initiative_status_changes)
+      .where(initiative_status_changes: { initiative_status: InitiativeStatus.find_by(code: 'proposed') })
+      .where('initiative_status_changes.created_at > ?', time_ago)
   end)
 
   def cosponsor_ids=(ids)

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/admin_digest.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/admin_digest.rb
@@ -211,7 +211,7 @@ module EmailCampaigns
     end
 
     def new_initiatives(time: Time.zone.today)
-      @new_initiatives ||= Initiative.published.where('published_at > ?', (time - 1.week))
+      @new_initiatives ||= Initiative.published.proposed_from_time_ago(1.week.ago)
         .order(published_at: :desc)
         .includes(:initiative_images)
         .map { |initiative| serialize_initiative(initiative) }

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/user_digest.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/user_digest.rb
@@ -201,7 +201,7 @@ module EmailCampaigns
     def new_initiatives(name_service, time:)
       InitiativePolicy::Scope.new(nil, Initiative).resolve
         .published
-        .where('published_at > ?', (time - 1.week))
+        .proposed_from_time_ago(1.week.ago)
         .includes(:initiative_images)
         .map do |initiative|
         {


### PR DESCRIPTION
WIP

# Changelog
## Technical
- [TAN-272] Use Initiative 'proposed' status_change created_at date in digest campaigns (proposals review feature in development)
