### PR TITLE
[TAN-164] Add ongoing_during filter parameter to the GET events endpoint

### DIFF
--- a/back/app/controllers/web_api/v1/events_controller.rb
+++ b/back/app/controllers/web_api/v1/events_controller.rb
@@ -11,7 +11,7 @@ class WebApi::V1::EventsController < ApplicationController
     skip_policy_scope
 
     events = EventsFinder
-      .new(params, scope: scope, current_user: current_user)
+      .new(finder_params, scope: scope, current_user: current_user)
       .find_records
 
     events = paginate SortByParamsService.new.sort_events(events, params)
@@ -116,6 +116,39 @@ class WebApi::V1::EventsController < ApplicationController
         p[:address_1] ||= p[:location_multiloc].values.first
       end
     end
+  end
+
+  def finder_params
+    params.tap do |p|
+      if p.key?(:ongoing_during)
+        p[:ongoing_during] = parse_date_range(p[:ongoing_during])
+      end
+    end
+  end
+
+  def parse_date_range(date_range)
+    raise ArgumentError, 'date_range must be a String' unless date_range.is_a?(String)
+
+    date_range = date_range.reverse.chomp('[').reverse.chomp(']')
+    # Ignore extra items if there are more than two. ("Be conservative in what you send,
+    # and liberal in what you accept.", Postel's law — at least for now)
+    start_str, end_str = date_range.split(',')
+
+    start_date = parse_date(start_str)
+    end_date = parse_date(end_str)
+    [start_date, end_date]
+  end
+
+  def parse_date(date_str)
+    date_str = date_str.strip
+    return nil if date_str.in?(['null', ''])
+
+    config_timezone.parse(date_str)
+  end
+
+  def config_timezone
+    timezone_str = AppConfiguration.instance.settings('core', 'timezone')
+    ActiveSupport::TimeZone[timezone_str] || (raise KeyError, timezone_str)
   end
 
   def default_locale

--- a/back/app/finders/events_finder.rb
+++ b/back/app/finders/events_finder.rb
@@ -26,4 +26,15 @@ class EventsFinder < ApplicationFinder
   def attendee_id_condition(attendee_id)
     records.joins(:attendances).where(attendances: { attendee_id: attendee_id })
   end
+
+  # Returns only the events that overlap with the given datetime range.
+  def ongoing_during_condition(datetime_range)
+    start_dt, end_dt = datetime_range
+    start_dt ||= '-infinity'
+    end_dt ||= 'infinity'
+
+    records.where(<<~SQL.squish, start_datetime: start_dt, end_datetime: end_dt)
+      (start_at, end_at) OVERLAPS (:start_datetime, :end_datetime)
+    SQL
+  end
 end

--- a/back/spec/acceptance/events_spec.rb
+++ b/back/spec/acceptance/events_spec.rb
@@ -11,8 +11,8 @@ resource 'Events' do
   before_all do
     @project = create(:project)
     @project2 = create(:project)
-    @events = create_list(:event, 2, project: @project)
-    @other_events = create_list(:event, 2, project: @project2)
+    @events = create_list(:event, 2, project: @project, start_at: '2017-05-01', end_at: '2017-05-02')
+    @other_events = create_list(:event, 2, project: @project2, start_at: '2017-05-01', end_at: '2017-05-02')
   end
 
   get 'web_api/v1/events' do
@@ -21,6 +21,13 @@ resource 'Events' do
     parameter :start_at_lt, 'Filter by maximum start at', type: :string
     parameter :start_at_gteq, 'Filter by minimum start at', type: :string
     parameter :project_publication_statuses, 'The publication statuses of the project to filter events by', type: :array
+    parameter :ongoing_during, <<~DESC, required: false, type: :string
+      Filter events by date range. Only returns events that are ongoing during the 
+      specified date range, meaning events that overlap with the given range. The date 
+      range should be provided as a string in the format "[<start_date>,<end_date>]", 
+      where <start_date> and <end_date> are ISO 8601 dates. 'null' can be used for 
+      open-ended ranges.
+    DESC
 
     with_options scope: :page do
       parameter :number, 'Page number'
@@ -61,6 +68,36 @@ resource 'Events' do
         # User attendances are always nil for visitors as they cannot register to
         # events.
         expect(user_attendances).to all(be_nil)
+      end
+    end
+
+    context 'when filtering by ongoing_during' do
+      let!(:event1) do
+        create(:event, start_at: '2020-12-31T23:00:00Z', end_at: '2021-01-01T01:00:00Z')
+      end
+
+      let!(:event2) do
+        create(:event, start_at: '2021-12-31T23:00:00Z', end_at: '2022-01-01T02:00:00Z')
+      end
+
+      example 'List events that overlap with the given range' do
+        do_request(ongoing_during: '[2020-12-31T00:00:00Z,2020-12-31T23:59:59Z]')
+        expect(response_ids).to match_array [event1.id]
+      end
+
+      example 'List events that overlap with the given range (right open-ended)', document: false do
+        do_request(ongoing_during: '[2020-12-31,null]')
+        expect(response_ids).to match_array [event1.id, event2.id]
+      end
+
+      example 'List events that overlap with the given range (left open-ended)', document: false do
+        do_request(ongoing_during: '[null,2021-06-01]')
+        expect(response_data.size).to eq(5)
+      end
+
+      example 'List events that overlap with the given range (both open-ended)', document: false do
+        do_request(ongoing_during: '[null,null]')
+        expect(response_data.size).to eq(Event.count)
       end
     end
 

--- a/back/spec/finders/events_finder_spec.rb
+++ b/back/spec/finders/events_finder_spec.rb
@@ -90,4 +90,68 @@ describe EventsFinder do
       expect(result_record_ids).to match_array expected_record_ids
     end
   end
+
+  describe '#ongoing_during_condition' do
+    let_it_be(:event1) do
+      create(
+        :event,
+        start_at: Time.zone.parse('2023-01-01T00:00:00Z'),
+        end_at: Time.zone.parse('2023-01-02T00:00:00Z')
+      )
+    end
+
+    let_it_be(:event2) do
+      create(
+        :event,
+        start_at: Time.zone.parse('2023-01-01T00:00:00Z'),
+        end_at: Time.zone.parse('2023-01-03T00:00:00Z')
+      )
+    end
+
+    let_it_be(:event3) do
+      create(
+        :event,
+        start_at: Time.zone.parse('2023-01-10T12:00:00Z'),
+        end_at: Time.zone.parse('2023-01-10T14:00:00Z')
+      )
+    end
+
+    let_it_be(:events) { Event.where(id: [event1.id, event2.id, event3.id]) }
+
+    where(:start_at, :end_at, :expected_events) do
+      [
+        ['2022-12-31T12:00:00Z', '2023-01-01T00:00:00Z', []],
+        ['2022-12-31T12:00:00Z', '2023-01-01T01:00:00Z', [ref(:event1), ref(:event2)]],
+        ['2023-01-01T12:00:00Z', '2023-01-01T14:00:00Z', [ref(:event1), ref(:event2)]],
+        ['2023-01-01T12:00:00Z', '2023-01-04T00:00:00Z', [ref(:event1), ref(:event2)]],
+        ['2023-01-02T00:00:00Z', '2023-01-03T00:00:00Z', [ref(:event2)]],
+
+        ['2023-01-10T00:00:00Z', '2023-01-10T12:00:00Z', []],
+        ['2023-01-10T00:00:00Z', '2023-01-10T11:00:00-01:00', []],
+        ['2023-01-10T00:00:00Z', '2023-01-10T12:00:01Z', [ref(:event3)]],
+        ['2023-01-10T00:00:00Z', '2023-01-10T11:00:01-01:00', [ref(:event3)]],
+
+        ['2023-01-10T14:00:00Z', '2023-01-10T23:59:59Z', []],
+        ['2023-01-10T15:00:00+01:00', '2023-01-10T23:59:59Z', []],
+        ['2023-01-10T13:59:59Z', '2023-01-10T23:59:59Z', [ref(:event3)]],
+        ['2023-01-10T14:59:59+01:00', '2023-01-10T23:59:59Z', [ref(:event3)]]
+      ]
+    end
+
+    with_them do
+      let(:finder) do
+        start_dt = Time.zone.parse(start_at)
+        end_dt = Time.zone.parse(end_at)
+
+        described_class.new(
+          { ongoing_during: [start_dt, end_dt] },
+          scope: events
+        )
+      end
+
+      it 'returns the correct records' do
+        expect(result_record_ids).to match_array expected_events.map(&:id)
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Changelog
## Technical
- Adds the `ongoing_during` query parameter to the `GET .../events` endpoint. This parameters allows retrieving all events that overlap with a given time period.
