### PR TITLE
Cl 3980 vienna visitor dashboard cant be exported

### DIFF
--- a/front/app/components/UI/MentionsTextArea/index.tsx
+++ b/front/app/components/UI/MentionsTextArea/index.tsx
@@ -210,7 +210,7 @@ const MentionsTextArea = ({
         mention: query.toLowerCase(),
         post_id: postId,
         post_type: capitalize(postType) as 'Idea' | 'Initiative',
-        roles: roles,
+        roles,
       };
 
       const response = await getMentions(queryParameters);

--- a/front/app/components/admin/PostManager/components/ExportMenu/ExportIdeasButton.tsx
+++ b/front/app/components/admin/PostManager/components/ExportMenu/ExportIdeasButton.tsx
@@ -51,7 +51,7 @@ class ExportIdeasButton extends React.PureComponent<
     try {
       this.setState({ exporting: true });
       const { exportType } = this.props;
-      var blob;
+      let blob;
       if (exportType === 'project') {
         blob = await requestBlob(
           `${API_PATH}/projects/${exportQueryParameter}/as_xlsx`,

--- a/front/app/components/admin/ReportExportMenu/index.tsx
+++ b/front/app/components/admin/ReportExportMenu/index.tsx
@@ -13,8 +13,7 @@ import { fontSizes } from 'utils/styleUtils';
 import Button from 'components/UI/Button';
 import { Dropdown } from '@citizenlab/cl2-component-library';
 import { saveAs } from 'file-saver';
-import { WrappedComponentProps } from 'react-intl';
-import { injectIntl, FormattedMessage } from 'utils/cl-intl';
+import { FormattedMessage, useIntl } from 'utils/cl-intl';
 import messages from './messages';
 import { IResolution } from 'components/admin/ResolutionControl';
 
@@ -22,8 +21,6 @@ import { IResolution } from 'components/admin/ResolutionControl';
 import { requestBlob } from 'utils/request';
 import { reportError } from 'utils/loggingUtils';
 import { truncate } from 'utils/textUtils';
-
-const DropdownButton = styled(Button)``;
 
 const Container = styled.div`
   display: flex;
@@ -71,17 +68,6 @@ interface XlsxConfigOnDownload {
 
 export type XlsxData = Record<string, Record<string, any>[]>;
 
-const downloadXlsxData = (data: XlsxData, fileName: string) => {
-  const workbook = XLSX.utils.book_new();
-
-  Object.entries(data).forEach(([sheet_name, sheet_data]) => {
-    const worksheet = XLSX.utils.json_to_sheet(sheet_data);
-    XLSX.utils.book_append_sheet(workbook, worksheet, truncate(sheet_name, 31));
-  });
-
-  XLSX.writeFile(workbook, `${fileName}.xlsx`);
-};
-
 const ReportExportMenu = ({
   svgNode,
   className,
@@ -96,8 +82,8 @@ const ReportExportMenu = ({
   currentTopicFilterLabel,
   currentProjectFilterLabel,
   xlsx,
-  intl: { formatMessage, formatDate },
-}: ReportExportMenuProps & WrappedComponentProps) => {
+}: ReportExportMenuProps) => {
+  const { formatMessage, formatDate } = useIntl();
   const [dropdownOpened, setDropdownOpened] = useState(false);
   const [exportingXls, setExportingXls] = useState(false);
 
@@ -215,6 +201,21 @@ const ReportExportMenu = ({
     setDropdownOpened(value || !dropdownOpened);
   };
 
+  const downloadXlsxData = (data: XlsxData, fileName: string) => {
+    const workbook = XLSX.utils.book_new();
+
+    Object.entries(data).forEach(([sheet_name, sheet_data]) => {
+      const worksheet = XLSX.utils.json_to_sheet(sheet_data);
+      XLSX.utils.book_append_sheet(
+        workbook,
+        worksheet,
+        truncate(sheet_name, 31)
+      );
+    });
+
+    XLSX.writeFile(workbook, `${fileName}.xlsx`);
+  };
+
   const downloadXlsx = async () => {
     setExportingXls(true);
 
@@ -261,7 +262,7 @@ const ReportExportMenu = ({
 
   return (
     <Container className={`${className} intercom-admin-export-button`}>
-      <DropdownButton
+      <Button
         buttonStyle="admin-dark-text"
         onClick={toggleDropdown()}
         icon="download"
@@ -315,4 +316,4 @@ const ReportExportMenu = ({
   );
 };
 
-export default injectIntl(ReportExportMenu);
+export default ReportExportMenu;

--- a/front/app/components/admin/ReportExportMenu/index.tsx
+++ b/front/app/components/admin/ReportExportMenu/index.tsx
@@ -208,7 +208,7 @@ const ReportExportMenu = ({
       // Added after production bug.
       // Error from XLSX package: sheet names can't contain certain characters
       const sheetNameWithoutForbiddenChars = sheet_name.replace(
-        /[:[*?/\\]/g,
+        /[:\]\[*?/\\]/g,
         '_'
       );
       const worksheet = XLSX.utils.json_to_sheet(sheet_data);

--- a/front/app/components/admin/ReportExportMenu/index.tsx
+++ b/front/app/components/admin/ReportExportMenu/index.tsx
@@ -205,11 +205,17 @@ const ReportExportMenu = ({
     const workbook = XLSX.utils.book_new();
 
     Object.entries(data).forEach(([sheet_name, sheet_data]) => {
+      // Added after production bug.
+      // Error from XLSX package: sheet names can't contain certain characters
+      const sheetNameWithoutForbiddenChars = sheet_name.replace(
+        /[:[*?/\\]/g,
+        '_'
+      );
       const worksheet = XLSX.utils.json_to_sheet(sheet_data);
       XLSX.utils.book_append_sheet(
         workbook,
         worksheet,
-        truncate(sheet_name, 31)
+        truncate(sheetNameWithoutForbiddenChars, 31)
       );
     });
 

--- a/front/app/components/admin/ReportExportMenu/index.tsx
+++ b/front/app/components/admin/ReportExportMenu/index.tsx
@@ -209,7 +209,7 @@ const ReportExportMenu = ({
       // Error from XLSX package: sheet names can't contain characters from the following array:
       // [':', ']', '[', '*', '?', '/', '\\']
       const sheetNameWithoutForbiddenChars = sheet_name.replace(
-        /[:\]\[*?/\\]/g,
+        /[:\][*?/\\]/g,
         '_'
       );
       const worksheet = XLSX.utils.json_to_sheet(sheet_data);

--- a/front/app/components/admin/ReportExportMenu/index.tsx
+++ b/front/app/components/admin/ReportExportMenu/index.tsx
@@ -206,7 +206,8 @@ const ReportExportMenu = ({
 
     Object.entries(data).forEach(([sheet_name, sheet_data]) => {
       // Added after production bug.
-      // Error from XLSX package: sheet names can't contain certain characters
+      // Error from XLSX package: sheet names can't contain characters from the following array:
+      // [':', ']', '[', '*', '?', '/', '\\']
       const sheetNameWithoutForbiddenChars = sheet_name.replace(
         /[:\]\[*?/\\]/g,
         '_'

--- a/front/app/modules/commercial/project_description_builder/admin/components/ContentViewer/Viewer/Viewer.test.tsx
+++ b/front/app/modules/commercial/project_description_builder/admin/components/ContentViewer/Viewer/Viewer.test.tsx
@@ -16,7 +16,7 @@ const DEFAULT_PROJECT_DESCRIPTION_BUILDER_LAYOUT_DATA = {
   },
 };
 
-let mockProjectDescriptionBuilderLayoutData:
+const mockProjectDescriptionBuilderLayoutData:
   | typeof DEFAULT_PROJECT_DESCRIPTION_BUILDER_LAYOUT_DATA
   | undefined
   | Error = DEFAULT_PROJECT_DESCRIPTION_BUILDER_LAYOUT_DATA;


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Excel sheets with sheet names containing certain characters (':', ']', '[', '*', '?', '/', '\\') have these sheet names fixed so exporting files doesn't error anymore.