### PR TITLE
[TAN-274] Use initiative policy in scope of initiative_comment policy

### DIFF
--- a/back/app/policies/initiative_comment_policy.rb
+++ b/back/app/policies/initiative_comment_policy.rb
@@ -10,7 +10,7 @@ class InitiativeCommentPolicy < ApplicationPolicy
     end
 
     def resolve
-      scope.where(post_type: 'Initiative')
+      scope.where(post: InitiativePolicy::Scope.new(user, Initiative).resolve)
     end
   end
 

--- a/back/spec/policies/initiative_comment_policy_spec.rb
+++ b/back/spec/policies/initiative_comment_policy_spec.rb
@@ -5,11 +5,20 @@ require 'rails_helper'
 describe InitiativeCommentPolicy do
   subject { described_class.new(user, comment) }
 
-  let(:scope) { InitiativeCommentPolicy::Scope.new(user, initiave.comments) }
+  let(:scope) { InitiativeCommentPolicy::Scope.new(user, initiative.comments) }
 
-  context 'on comment on initiave' do
-    let(:initiave) { create(:initiative) }
-    let!(:comment) { create(:comment, post: initiave) }
+  context 'on comment on initiative with proposed status' do
+    let(:initiative) { create(:initiative) }
+
+    let!(:_initiative_status_change) do
+      create(
+        :initiative_status_change,
+        initiative: initiative,
+        initiative_status: create(:initiative_status_proposed)
+      )
+    end
+
+    let!(:comment) { create(:comment, post: initiative) }
 
     context 'for a visitor' do
       let(:user) { nil }
@@ -52,7 +61,7 @@ describe InitiativeCommentPolicy do
 
     context 'for blocked comment author' do
       let(:user) { create(:user, block_end_at: 5.days.from_now) }
-      let(:comment) { create(:comment, author: user, post: initiave) }
+      let(:comment) { create(:comment, author: user, post: initiative) }
 
       it_behaves_like 'policy for blocked user'
     end
@@ -66,6 +75,100 @@ describe InitiativeCommentPolicy do
       it { is_expected.not_to permit(:destroy) }
 
       it 'indexes the comment' do
+        expect(scope.resolve.size).to eq 1
+      end
+    end
+  end
+
+  context 'on comment on initiative with review_pending status' do
+    let(:initiative) { create(:initiative) }
+
+    let!(:_initiative_status_change) do
+      create(
+        :initiative_status_change,
+        initiative: initiative,
+        initiative_status: create(:initiative_status_review_pending)
+      )
+    end
+
+    let!(:comment) { create(:comment, post: initiative, author: initiative.author) }
+
+    context 'for a visitor' do
+      let(:user) { nil }
+
+      it { is_expected.not_to permit(:show)    }
+      it { is_expected.not_to permit(:create)  }
+      it { is_expected.not_to permit(:update)  }
+      it { is_expected.not_to permit(:destroy) }
+
+      it 'does not index the comment' do
+        expect(scope.resolve.size).to eq 0
+      end
+    end
+
+    context 'for a user who is not the author of the initiative or the comment' do
+      let(:user) { create(:user) }
+
+      it { is_expected.not_to permit(:show)    }
+      it { is_expected.not_to permit(:create)  }
+      it { is_expected.not_to permit(:update)  }
+      it { is_expected.not_to permit(:destroy) }
+
+      it 'does not index the comment' do
+        expect(scope.resolve.size).to eq 0
+      end
+    end
+
+    context 'for a user who is the author of the initiative and the comment' do
+      let(:user) { initiative.author }
+
+      it { is_expected.to     permit(:show)    }
+      it { is_expected.to     permit(:create)  }
+      it { is_expected.to     permit(:update)  }
+      it { is_expected.not_to permit(:destroy) }
+
+      it 'indexes the comment' do
+        expect(scope.resolve.size).to eq 1
+      end
+    end
+
+    context 'for blocked comment author' do
+      let(:user) { create(:user, block_end_at: 5.days.from_now) }
+      let(:comment) { create(:comment, author: user, post: initiative) }
+
+      it { is_expected.not_to permit(:show)    }
+      it { is_expected.not_to permit(:create)  }
+      it { is_expected.not_to permit(:update)  }
+      it { is_expected.not_to permit(:destroy) }
+
+      it 'does not index the comment' do
+        expect(scope.resolve.size).to eq 0
+      end
+    end
+
+    context 'for an admin' do
+      let(:user) { create(:admin) }
+
+      it { is_expected.to     permit(:show)    }
+      it { is_expected.to     permit(:create)  }
+      it { is_expected.to     permit(:update)  }
+      it { is_expected.not_to permit(:destroy) }
+
+      it 'indexes the comment' do
+        expect(scope.resolve.size).to eq 1
+      end
+    end
+
+    context 'for a user who is cosponsor of the initiative' do
+      let(:user) { create(:user) }
+      let!(:cosponsors_initiative) { create(:cosponsors_initiative, user: user, initiative: initiative) }
+
+      it { is_expected.to permit(:show) }
+      it { is_expected.not_to permit(:create) }
+      it { is_expected.not_to permit(:update) }
+      it { is_expected.not_to permit(:destroy) }
+
+      it 'indexes the initiative' do
         expect(scope.resolve.size).to eq 1
       end
     end


### PR DESCRIPTION
# Changelog
## Technical
- [TAN-274] Use initiative policy in scope of initiative_comment policy
