### PR TITLE
[TAN-288] Bugfix: Always permit editing proposal by admins

### DIFF
--- a/back/app/policies/initiative_policy.rb
+++ b/back/app/policies/initiative_policy.rb
@@ -49,6 +49,8 @@ class InitiativePolicy < ApplicationPolicy
   end
 
   def update?
+    return true if active? && can_moderate?
+
     create? && !record.editing_locked
   end
 

--- a/back/spec/policies/initiative_policy_spec.rb
+++ b/back/spec/policies/initiative_policy_spec.rb
@@ -389,7 +389,7 @@ describe InitiativePolicy do
       it { is_expected.to permit(:show) }
       it { is_expected.to permit(:by_slug) }
       it { is_expected.to permit(:create) }
-      it { is_expected.not_to permit(:update) }
+      it { is_expected.to permit(:update) }
       it { is_expected.to permit(:destroy) }
       it { is_expected.not_to permit(:accept_cosponsorship_invite) }
 

--- a/front/app/components/admin/PostManager/components/PostPreview/Initiative/AdminInitiativeContent.tsx
+++ b/front/app/components/admin/PostManager/components/PostPreview/Initiative/AdminInitiativeContent.tsx
@@ -145,16 +145,14 @@ const AdminInitiativeContent = ({
     return (
       <Container>
         <Top>
-          {!initiative.data.attributes.editing_locked && (
-            <Button
-              mr="8px"
-              icon="edit"
-              buttonStyle="secondary"
-              onClick={handleClickEdit}
-            >
-              <FormattedMessage {...messages.edit} />
-            </Button>
-          )}
+          <Button
+            mr="8px"
+            icon="edit"
+            buttonStyle="secondary"
+            onClick={handleClickEdit}
+          >
+            <FormattedMessage {...messages.edit} />
+          </Button>
           <Button
             icon="delete"
             buttonStyle="delete"


### PR DESCRIPTION
# Changelog
## Fixed
[TAN-288] Bugfix: Always permit editing proposal by admins (bug introduced in TAN-50 review/cosponsorship feature)
