### PR TITLE
[TAN-296] Bugfix: Permit destruction of user record when user is cosponsor of initiative

### DIFF
--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -142,6 +142,7 @@ class User < ApplicationRecord
   has_many :reactions, dependent: :nullify
   has_many :event_attendances, class_name: 'Events::Attendance', foreign_key: :attendee_id, dependent: :destroy
   has_many :follows, class_name: 'Follower', dependent: :destroy
+  has_many :cosponsors_initiatives, dependent: :destroy
 
   after_initialize do
     next unless has_attribute?('roles')


### PR DESCRIPTION
# Changelog
## Fixed
[TAN-296] Enable destruction of user record when user is cosponsor of initiative
