### PR TITLE
[TAN-295] Bugfix: Do not automatically add vote for initiative author who should not be able to vote

### DIFF
--- a/back/app/services/side_fx_initiative_service.rb
+++ b/back/app/services/side_fx_initiative_service.rb
@@ -109,7 +109,7 @@ class SideFxInitiativeService
   end
 
   def after_publish(initiative, user)
-    add_autoreaction initiative
+    add_autoreaction initiative, user
     log_activity_jobs_after_published initiative, user
     create_followers initiative, user
   end
@@ -122,12 +122,12 @@ class SideFxInitiativeService
     @automatic_assignment = true
   end
 
-  def add_autoreaction(initiative)
-    reaction = Reaction.new(reactable: initiative, user: initiative.author, mode: 'up')
+  def add_autoreaction(initiative, user)
+    reaction = Reaction.new(reactable: initiative, user: user, mode: 'up')
 
     begin
       Pundit.authorize(
-        initiative.author,
+        user,
         reaction,
         :create?,
         policy_class: InitiativeReactionPolicy

--- a/back/spec/services/side_fx_initiative_service_spec.rb
+++ b/back/spec/services/side_fx_initiative_service_spec.rb
@@ -171,6 +171,32 @@ describe SideFxInitiativeService do
 
       expect(user.follows.pluck(:followable_id)).to contain_exactly initiative.id
     end
+
+    it 'creates a reaction (vote) for an author who can react (vote)' do
+      initiative = create(:initiative)
+
+      expect do
+        service.after_create initiative, user
+      end.to change(Reaction, :count).from(0).to(1)
+
+      expect(initiative.reactions.pluck(:user_id)).to contain_exactly initiative.author.id
+    end
+
+    it 'does not create a reaction (vote) for an author who cannot react (vote)' do
+      initiative = create(:initiative)
+
+      create(
+        :permission,
+        permission_scope: nil,
+        action: 'reacting_initiative',
+        permitted_by: 'groups',
+        groups: [create(:group)]
+      )
+
+      expect do
+        service.after_create initiative, user
+      end.not_to change(Reaction, :count)
+    end
   end
 
   describe 'after_destroy' do


### PR DESCRIPTION
# Changelog
## Fixed
- [TAN-295] Do not automatically add vote for proposal author who should not be able to vote
