### PR TITLE
TAN-299 Analysis bug fixes and enhancements part 2

### DIFF
--- a/back/engines/commercial/analysis/app/controllers/analysis/web_api/v1/background_tasks_controller.rb
+++ b/back/engines/commercial/analysis/app/controllers/analysis/web_api/v1/background_tasks_controller.rb
@@ -9,7 +9,14 @@ module Analysis
         before_action :set_background_task, only: [:show]
 
         def index
-          background_tasks = @analysis.background_tasks.order(created_at: :desc)
+          background_tasks = @analysis.background_tasks
+
+          background_tasks = background_tasks
+            .where(state: %w[queued in_progress])
+            .or(background_tasks.where('ended_at >= ?', 24.hours.ago))
+
+          background_tasks = background_tasks.order(created_at: :desc)
+
           render json: WebApi::V1::BackgroundTaskSerializer.new(background_tasks, params: jsonapi_serializer_params).serializable_hash
         end
 

--- a/back/engines/commercial/analysis/app/controllers/analysis/web_api/v1/insights_controller.rb
+++ b/back/engines/commercial/analysis/app/controllers/analysis/web_api/v1/insights_controller.rb
@@ -11,11 +11,11 @@ module Analysis
         def index
           insights = @analysis.insights
             .order(created_at: :desc)
-            .includes(:insightable)
+            .includes(insightable: :background_task)
           render json: WebApi::V1::InsightSerializer.new(
             insights,
             params: jsonapi_serializer_params,
-            include: [:insightable]
+            include: %i[insightable insightable.background_task]
           ).serializable_hash
         end
 

--- a/back/engines/commercial/analysis/app/controllers/analysis/web_api/v1/tags_controller.rb
+++ b/back/engines/commercial/analysis/app/controllers/analysis/web_api/v1/tags_controller.rb
@@ -10,6 +10,7 @@ module Analysis
 
         def index
           @tags = @analysis.tags
+            .order(created_at: :desc)
 
           inputs_count_by_tag = TagCounter.new(@analysis, tags: @tags).counts_by_tag
           filtered_inputs_count_by_tag = TagCounter.new(@analysis, tags: @tags, filters: filters).counts_by_tag

--- a/back/engines/commercial/analysis/app/services/analysis/inputs_finder.rb
+++ b/back/engines/commercial/analysis/app/services/analysis/inputs_finder.rb
@@ -94,6 +94,10 @@ module Analysis
 
         cf = CustomField.find(custom_field_id)
 
+        # domcile custom_field is stored differently, so we need to convert
+        # custom_field_option keys to area ids
+        value = convert_domicile_value(value) if cf.domicile?
+
         case cf.input_type
         when 'select', 'date'
           scope = if value.include?(nil)
@@ -218,6 +222,26 @@ module Analysis
         # return triplet [custom_field_id, predicate, value]
         matches && [matches[1], matches[2], value]
       end
+    end
+
+    # Domicile is a special user custom_field, which stores the area.id as the
+    # value in user.custom_field_values, instead of the key value of the
+    # custom_field option. Historically, the domicile custom_field did not have
+    # any custom_field_option database records. At some point, we added a
+    # mechanism to sync areas to custom_field_options for domicile. But the work
+    # to change the actual value stored in custom_field_values was not
+    # completed. This means that the front-end can treat the domicile field as
+    # any other field, but we need to convert the option_key to the right
+    # area_id in order for the filter to work. Also see
+    # back/engines/commercial/user_custom_fields/app/services/user_custom_fields/field_value_counter.rb:37
+    def convert_domicile_value(option_keys)
+      area_ids = CustomFieldOption.where(key: option_keys).filter_map do |option|
+        option&.area&.id
+      end
+
+      area_ids << 'outside' if option_keys.include? 'somewhere_else'
+
+      area_ids
     end
   end
 end

--- a/back/engines/commercial/analysis/spec/acceptance/background_tasks_spec.rb
+++ b/back/engines/commercial/analysis/spec/acceptance/background_tasks_spec.rb
@@ -16,6 +16,7 @@ resource 'Background tasks' do
     let(:analysis_id) { analysis.id }
     let!(:task) { create(:auto_tagging_task, analysis: analysis) }
     let!(:other_task) { create(:auto_tagging_task) }
+    let!(:old_task) { create(:q_and_a_task, analysis: analysis, state: 'completed', created_at: 26.hours.ago, ended_at: 25.hours.ago) }
 
     example_request 'List all background tasks' do
       expect(status).to eq(200)

--- a/back/engines/commercial/analysis/spec/acceptance/insights_spec.rb
+++ b/back/engines/commercial/analysis/spec/acceptance/insights_spec.rb
@@ -41,7 +41,7 @@ resource 'Insights' do
           }
         }
       })
-      expect(json_response_body[:included].pluck(:id)).to match_array([summary.id, question.id])
+      expect(json_response_body[:included].pluck(:id)).to match_array([summary.id, summary.background_task.id, question.id, question.background_task.id])
     end
   end
 

--- a/back/engines/commercial/analysis/spec/services/inputs_finder_spec.rb
+++ b/back/engines/commercial/analysis/spec/services/inputs_finder_spec.rb
@@ -197,6 +197,16 @@ describe Analysis::InputsFinder do
       @params = { "author_custom_#{cf.id}": [nil] }
       expect(output).to contain_exactly(idea2, idea3)
     end
+
+    it 'works correctly with the domicile field, when passed custom_field_options for areas' do
+      area = create(:area)
+      cf = create(:custom_field_domicile)
+      author = create(:user, custom_field_values: { cf.key => area.id })
+      idea1 = create(:idea, project: analysis.source_project, author: author)
+      _idea2 = create(:idea, project: analysis.source_project)
+      @params = { "author_custom_#{cf.id}": [cf.options[0].key] }
+      expect(output).to contain_exactly(idea1)
+    end
   end
 
   describe 'author_custom_<uuid>_from and author_custom_<uuid>_to' do

--- a/front/app/api/analysis_background_tasks/useAnalysisBackgroundTasks.ts
+++ b/front/app/api/analysis_background_tasks/useAnalysisBackgroundTasks.ts
@@ -28,7 +28,6 @@ const useAnalysisBackgroundTasks = (analysisId: string) => {
       queryClient.invalidateQueries({ queryKey: tagsKeys.lists() });
       queryClient.invalidateQueries({ queryKey: taggingKeys.lists() });
       queryClient.invalidateQueries({ queryKey: insightsKeys.lists() });
-      queryClient.invalidateQueries({ queryKey: backgroundTasksKeys.items() });
     },
     // Refetch every 2 seconds when tasks are active
     refetchInterval: (data) => {

--- a/front/app/api/analysis_inputs/types.ts
+++ b/front/app/api/analysis_inputs/types.ts
@@ -13,7 +13,7 @@ type InputCustomInFilterKey = `input_custom_${string}_in`;
 
 export type IInputsFilterParams = {
   search?: string;
-  tag_ids?: string[];
+  tag_ids?: string[] | null[];
   published_at_from?: string;
   published_at_to?: string;
   reactions_from?: string | number;

--- a/front/app/containers/Admin/projects/project/analysis/FilterItems/AuthorFieldFilterItem.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/FilterItems/AuthorFieldFilterItem.tsx
@@ -14,7 +14,7 @@ import ElipsisFilterValue from './EllipsisFilterValue';
 type Props = {
   customFieldId: string;
   filterKey: string;
-  filterValue: string | string[] | undefined | number;
+  filterValue: string | string[] | null[] | undefined | number;
   isEditable: boolean;
   predicate: '<' | '>' | '=';
 };

--- a/front/app/containers/Admin/projects/project/analysis/FilterItems/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/FilterItems/index.tsx
@@ -103,6 +103,14 @@ const FilterItems = ({ filters, isEditable }: FilterItemsProps) => {
               isEditable={isEditable}
             />
           );
+        } else if (
+          key === 'tag_ids' &&
+          (value as string[] | null[]).length === 1 &&
+          (value as string[] | null[])[0] === null
+        ) {
+          return (
+            <Tag key={null} name="Inputs without tags" tagType={'custom'} />
+          );
         } else if (key === 'tag_ids') {
           return (
             <>

--- a/front/app/containers/Admin/projects/project/analysis/InputsList/InputListItem.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/InputsList/InputListItem.tsx
@@ -35,6 +35,7 @@ const InputListItem = memo(({ input, onSelect, selected }: Props) => {
   return (
     <>
       <Box
+        id={`input-${input.id}`}
         onClick={() => onSelect(input.id)}
         bg={selected ? colors.background : colors.white}
         p="12px"

--- a/front/app/containers/Admin/projects/project/analysis/Insights/Question.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Insights/Question.tsx
@@ -73,12 +73,20 @@ const Question = ({ insight }: Props) => {
     return str.replace(/\[?[0-9a-f-]{0,35}$/, '');
   };
 
+  const handleClickInput = (inputId) => {
+    setSelectedInputId(inputId);
+    const element = document.getElementById(`input-${inputId}`);
+    if (element) {
+      element.scrollIntoView({ behavior: 'smooth' });
+    }
+  };
+
   const replaceIdRefsWithLinks = (question) => {
     return reactStringReplace(
       question,
       /\[?([0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12})\]?/g,
       (match, i) => (
-        <StyledButton onClick={() => setSelectedInputId(match)} key={i}>
+        <StyledButton onClick={() => handleClickInput(match)} key={i}>
           <Icon name="idea" />
         </StyledButton>
       )
@@ -99,7 +107,14 @@ const Question = ({ insight }: Props) => {
         : {}),
       reset_filters: 'true',
     });
-    updateSearchParams(question.data.attributes.filters);
+    const filters = question.data.attributes.filters;
+    updateSearchParams(filters);
+    if (filters.tag_ids?.length === 1) {
+      const element = document.getElementById(`tag-${filters.tag_ids[0]}`);
+      if (element) {
+        element.scrollIntoView({ behavior: 'smooth' });
+      }
+    }
   };
 
   const answer = question.data.attributes.answer;

--- a/front/app/containers/Admin/projects/project/analysis/Insights/Summary.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Insights/Summary.tsx
@@ -72,12 +72,20 @@ const Summary = ({ insight }: Props) => {
     return str.replace(/\[?[0-9a-f-]{0,35}$/, '');
   };
 
+  const handleClickInput = (inputId) => {
+    setSelectedInputId(inputId);
+    const element = document.getElementById(`input-${inputId}`);
+    if (element) {
+      element.scrollIntoView({ behavior: 'smooth' });
+    }
+  };
+
   const replaceIdRefsWithLinks = (summary) => {
     return reactStringReplace(
       summary,
       /\[?([0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12})\]?/g,
       (match, i) => (
-        <StyledButton onClick={() => setSelectedInputId(match)} key={i}>
+        <StyledButton onClick={() => handleClickInput(match)} key={i}>
           <Icon name="idea" />
         </StyledButton>
       )
@@ -99,7 +107,14 @@ const Summary = ({ insight }: Props) => {
         : {}),
       reset_filters: 'true',
     });
-    updateSearchParams(summary.data.attributes.filters);
+    const filters = summary.data.attributes.filters;
+    updateSearchParams(filters);
+    if (filters.tag_ids?.length === 1) {
+      const element = document.getElementById(`tag-${filters.tag_ids[0]}`);
+      if (element) {
+        element.scrollIntoView({ behavior: 'smooth' });
+      }
+    }
   };
 
   const summaryText = summary.data.attributes.summary;

--- a/front/app/containers/Admin/projects/project/analysis/Tags/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Tags/index.tsx
@@ -89,7 +89,10 @@ const Tags = () => {
   const inputsWithoutTags = tags?.meta.inputs_without_tags;
   const filteredInputsWithoutTags = tags?.meta.filtered_inputs_without_tags;
 
-  const selectedTags = filters.tag_ids;
+  // We need `as any[] | undefined` due to known TS limitation in various places
+  // below of code using `selectedTags`
+  // https://github.com/microsoft/TypeScript/issues/44373
+  const selectedTags = filters.tag_ids as any[] | undefined;
 
   const toggleTagContainerClick = (id: string) => {
     updateSearchParams({ tag_ids: [id] });

--- a/front/app/containers/Admin/projects/project/analysis/Tags/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Tags/index.tsx
@@ -163,6 +163,7 @@ const Tags = () => {
         )}
         {tags?.data.map((tag) => (
           <TagContainer
+            id={`tag-${tag.id}`}
             key={tag.id}
             tabIndex={0}
             onClick={() => {

--- a/front/app/containers/Admin/projects/project/analysis/components/ShortUserFieldValue.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/components/ShortUserFieldValue.tsx
@@ -8,7 +8,7 @@ import { IUserCustomField } from 'api/user_custom_fields/types';
 
 type Props = {
   customField: IUserCustomField;
-  rawValue?: string | string[] | number;
+  rawValue?: string | string[] | null[] | number;
 };
 
 const SelectOptionText = ({


### PR DESCRIPTION
# Changelog
## Fixed
- Various smaller fixes and enhancements to sensemaking (WIP, feature flagged)
  - Domicile filter works
  - Tags are always ordered by creation date
  - Background tasks older than 24 hours are no longer shown
  - When filtering for all inputs without tags, the filter value is correctly displayed in summaries/questions
  - When clicking an input or restoring a single-tag filter, the UI scrolls to these selected elements
