### PR TITLE
Hide event attendance elements

### DIFF
--- a/front/app/components/EventCard/EventInformation/index.tsx
+++ b/front/app/components/EventCard/EventInformation/index.tsx
@@ -51,8 +51,9 @@ const EventInformation = ({
   const { formatMessage } = useIntl();
   const theme = useTheme();
 
-  const isPastEvent = moment().isAfter(endAtMoment);
+  // const isPastEvent = moment().isAfter(endAtMoment); // TODO: Re-enable once event attendance smart group added
   const address1 = event?.attributes?.address_1;
+  const tempShowEventAttendance = false; // TODO: Replace once event attendance smart group added
 
   const eventDateTime = isMultiDayEvent
     ? `${startAtMoment.format('LLL')} - ${endAtMoment.format('LLL')}`
@@ -90,32 +91,36 @@ const EventInformation = ({
             mb="12px"
             flexDirection={theme.isRtl ? 'row-reverse' : 'row'}
           >
-            <Icon
-              my="auto"
-              fill={colors.coolGrey300}
-              name="clock"
-              ariaHidden
-              mr={theme.isRtl ? '0px' : '8px'}
-              ml={theme.isRtl ? '8px' : '0px'}
-            />
+            <Box flexShrink={0} my="auto">
+              <Icon
+                my="auto"
+                fill={colors.coolGrey300}
+                name="clock"
+                ariaHidden
+                mr={theme.isRtl ? '0px' : '8px'}
+                ml={theme.isRtl ? '8px' : '0px'}
+              />
+            </Box>
             <Text m="0px" pt="2px" color={'coolGrey700'} fontSize="s">
               {eventDateTime}
             </Text>
-          </Box>{' '}
+          </Box>
           {address1 && (
             <Box
               display="flex"
               mb="12px"
               flexDirection={theme.isRtl ? 'row-reverse' : 'row'}
             >
-              <Icon
-                my="auto"
-                fill={colors.coolGrey300}
-                name="position"
-                ariaHidden
-                mr={theme.isRtl ? '0px' : '8px'}
-                ml={theme.isRtl ? '8px' : '0px'}
-              />
+              <Box flexShrink={0} my="auto">
+                <Icon
+                  my="auto"
+                  fill={colors.coolGrey300}
+                  name="position"
+                  ariaHidden
+                  mr={theme.isRtl ? '0px' : '8px'}
+                  ml={theme.isRtl ? '8px' : '0px'}
+                />
+              </Box>
               <Text m="0px" pt="2px" color={'coolGrey700'} fontSize="s">
                 {address1?.includes(',')
                   ? address1?.slice(0, address1.indexOf(','))
@@ -129,14 +134,16 @@ const EventInformation = ({
               mb="12px"
               flexDirection={theme.isRtl ? 'row-reverse' : 'row'}
             >
-              <Icon
-                my="auto"
-                fill={colors.coolGrey300}
-                name="user"
-                ariaHidden
-                mr={theme.isRtl ? '0px' : '8px'}
-                ml={theme.isRtl ? '8px' : '0px'}
-              />
+              <Box flexShrink={0} my="auto">
+                <Icon
+                  my="auto"
+                  fill={colors.coolGrey300}
+                  name="user"
+                  ariaHidden
+                  mr={theme.isRtl ? '0px' : '8px'}
+                  ml={theme.isRtl ? '8px' : '0px'}
+                />
+              </Box>
               <Text m="0px" pt="2px" color={'coolGrey700'} fontSize="s">
                 {event.attributes.attendees_count}{' '}
                 {formatMessage(messages.attending)}
@@ -145,7 +152,7 @@ const EventInformation = ({
           )}
         </Box>
       </Box>
-      {isPastEvent ? (
+      {!tempShowEventAttendance ? ( // TODO: Replace once event attendance smart group added
         <Button
           ml="auto"
           width={'100%'}

--- a/front/app/components/EventCard/EventInformation/index.tsx
+++ b/front/app/components/EventCard/EventInformation/index.tsx
@@ -128,28 +128,29 @@ const EventInformation = ({
               </Text>
             </Box>
           )}
-          {event.attributes.attendees_count > 0 && (
-            <Box
-              display="flex"
-              mb="12px"
-              flexDirection={theme.isRtl ? 'row-reverse' : 'row'}
-            >
-              <Box flexShrink={0} my="auto">
-                <Icon
-                  my="auto"
-                  fill={colors.coolGrey300}
-                  name="user"
-                  ariaHidden
-                  mr={theme.isRtl ? '0px' : '8px'}
-                  ml={theme.isRtl ? '8px' : '0px'}
-                />
+          {tempShowEventAttendance &&
+            event.attributes.attendees_count > 0 && ( // TODO: Replace once event attendance smart group added
+              <Box
+                display="flex"
+                mb="12px"
+                flexDirection={theme.isRtl ? 'row-reverse' : 'row'}
+              >
+                <Box flexShrink={0} my="auto">
+                  <Icon
+                    my="auto"
+                    fill={colors.coolGrey300}
+                    name="user"
+                    ariaHidden
+                    mr={theme.isRtl ? '0px' : '8px'}
+                    ml={theme.isRtl ? '8px' : '0px'}
+                  />
+                </Box>
+                <Text m="0px" pt="2px" color={'coolGrey700'} fontSize="s">
+                  {event.attributes.attendees_count}{' '}
+                  {formatMessage(messages.attending)}
+                </Text>
               </Box>
-              <Text m="0px" pt="2px" color={'coolGrey700'} fontSize="s">
-                {event.attributes.attendees_count}{' '}
-                {formatMessage(messages.attending)}
-              </Text>
-            </Box>
-          )}
+            )}
         </Box>
       </Box>
       {!tempShowEventAttendance ? ( // TODO: Replace once event attendance smart group added

--- a/front/app/containers/EventsShowPage/components/InformationColumnDesktop.tsx
+++ b/front/app/containers/EventsShowPage/components/InformationColumnDesktop.tsx
@@ -26,6 +26,7 @@ interface Props {
 
 const InformationColumnDesktop = ({ event, className }: Props) => {
   const isPastEvent = moment().isAfter(moment(event.attributes.end_at));
+  const tempShowAttendance = false;
 
   return (
     <Box
@@ -54,14 +55,18 @@ const InformationColumnDesktop = ({ event, className }: Props) => {
             >
               <EventDateStylized event={event} />
               <>
-                {!isPastEvent && (
-                  <Box mt="12px">
-                    <EventAttendanceButton event={event} />
-                  </Box>
-                )}
-                {event.attributes.attendees_count > 0 && (
-                  <ParticipantsCount count={event.attributes.attendees_count} />
-                )}
+                {tempShowAttendance &&
+                  !isPastEvent && ( // TODO: Replace once event attendance smart group added
+                    <Box mt="12px">
+                      <EventAttendanceButton event={event} />
+                    </Box>
+                  )}
+                {tempShowAttendance &&
+                  event.attributes.attendees_count > 0 && ( // TODO: Replace once event attendance smart group added
+                    <ParticipantsCount
+                      count={event.attributes.attendees_count}
+                    />
+                  )}
                 <Box borderBottom={`solid 1px ${colors.divider}`} />
               </>
 

--- a/front/app/containers/EventsShowPage/components/InformationSectionMobile.tsx
+++ b/front/app/containers/EventsShowPage/components/InformationSectionMobile.tsx
@@ -24,6 +24,7 @@ interface Props {
 
 const InformationSectionMobile = ({ event }: Props) => {
   const isPastEvent = moment().isAfter(moment(event.attributes.end_at));
+  const tempShowEventAttendance = false; // TODO: Replace once event attendance smart group added
 
   return (
     <Box width={`100%`}>
@@ -44,14 +45,18 @@ const InformationSectionMobile = ({ event }: Props) => {
             >
               <EventDateStylized event={event} />
               <>
-                {!isPastEvent && (
-                  <Box mt="12px">
-                    <EventAttendanceButton event={event} />
-                  </Box>
-                )}
-                {event.attributes.attendees_count > 0 && (
-                  <ParticipantsCount count={event.attributes.attendees_count} />
-                )}
+                {tempShowEventAttendance &&
+                  !isPastEvent && ( // TODO: Replace once event attendance smart group added
+                    <Box mt="12px">
+                      <EventAttendanceButton event={event} />
+                    </Box>
+                  )}
+                {tempShowEventAttendance &&
+                  event.attributes.attendees_count > 0 && ( // TODO: Replace once event attendance smart group added
+                    <ParticipantsCount
+                      count={event.attributes.attendees_count}
+                    />
+                  )}
                 <Box borderBottom={`solid 1px ${colors.divider}`} />
               </>
 

--- a/front/app/containers/EventsShowPage/components/MobileTopBar.tsx
+++ b/front/app/containers/EventsShowPage/components/MobileTopBar.tsx
@@ -5,7 +5,8 @@ import useProjectById from 'api/projects/useProjectById';
 import { useLocation } from 'react-router-dom';
 
 // i18n
-import useLocalize from 'hooks/useLocalize';
+import { useIntl } from 'utils/cl-intl';
+import messages from '../messages';
 
 // components
 import GoBackButtonSolid from 'components/UI/GoBackButton/GoBackButtonSolid';
@@ -50,17 +51,15 @@ interface Props {
 const MobileTopBar = ({ projectId }: Props) => {
   const { data: project } = useProjectById(projectId);
   const isSmallerThanTablet = useBreakpoint('tablet');
+  const { formatMessage } = useIntl();
   const location = useLocation();
-  const localize = useLocalize();
 
   return (
     <Container>
       <TopBarInner>
         <Box height="48px" alignItems="center" display="flex">
           <GoBackButtonSolid
-            text={
-              project ? localize(project.data.attributes.title_multiloc) : ''
-            }
+            text={formatMessage(messages.goBack)}
             iconSize={isSmallerThanTablet ? '42px' : undefined}
             onClick={() => {
               const hasGoBackLink = location.key !== 'default';

--- a/front/app/containers/UsersShowPage/UserNavbar.tsx
+++ b/front/app/containers/UsersShowPage/UserNavbar.tsx
@@ -120,7 +120,8 @@ const UserNavbar = memo<Props>(({ currentTab, selectTab, userId }) => {
   const { data: authUser } = useAuthUser();
 
   const eventsCount = events?.data.length;
-  const showEventTab = authUser?.data?.id === userId;
+  // const showEventTab = authUser?.data?.id === userId; // TODO: Re-enable once event attendance smart group added
+  const showEventTab = false;
   const isFollowingEnabled = useFeatureFlag({
     name: 'follow',
   });

--- a/front/cypress/e2e/events/event_show_page.cy.ts
+++ b/front/cypress/e2e/events/event_show_page.cy.ts
@@ -74,17 +74,19 @@ describe('Event show page', () => {
     cy.get('#e2e-not-authorized').should('not.exist');
     cy.get('#e2e-event-title').should('exist');
     cy.get('#e2e-event-date-stylized').should('exist');
-    cy.get('#e2e-event-attendance-button').should('exist');
+    // cy.get('#e2e-event-attendance-button').should('exist');
     cy.get('#e2e-participants-count').should('not.exist');
     cy.get('#e2e-text-only-location').should('exist');
     cy.get('#e2e-location-with-coordinates-button').should('not.exist');
 
-    // Click attend button
-    cy.get('#e2e-event-attendance-button').click();
-    // Confirm that the button now shows "attending"
-    cy.get('#e2e-event-attendance-button').contains('Attending');
-    // Confirm that participant count is now shown
-    cy.get('#e2e-participants-count').should('exist');
+    // TODO: Re-enable attendance tests once smart group implemented
+
+    // // Click attend button
+    // cy.get('#e2e-event-attendance-button').click();
+    // // Confirm that the button now shows "attending"
+    // cy.get('#e2e-event-attendance-button').contains('Attending');
+    // // Confirm that participant count is now shown
+    // cy.get('#e2e-participants-count').should('exist');
   });
 
   it('shows map modal when location coordinates exist', () => {

--- a/front/cypress/e2e/profile_page.cy.ts
+++ b/front/cypress/e2e/profile_page.cy.ts
@@ -91,32 +91,34 @@ describe('Profile Page', () => {
     cy.get('.e2e-profile-comments').contains(commentContent);
   });
 
-  it('shows the events the user is attending', () => {
-    cy.clearCookies();
-    // Confirm that the user event tab is not visible to other users
-    cy.visit(`/profile/${newUserName}-${newUserSurname}`);
-    cy.get('#e2e-usersshowpage');
-    cy.get('.e2e-events-nav').should('not.exist');
+  // TODO: Re-enable attendance tests once smart group implemented
 
-    // Log in as the user
-    cy.setLoginCookie(newUserEmail, newUserPassword);
+  // it('shows the events the user is attending', () => {
+  //   cy.clearCookies();
+  //   // Confirm that the user event tab is not visible to other users
+  //   cy.visit(`/profile/${newUserName}-${newUserSurname}`);
+  //   cy.get('#e2e-usersshowpage');
+  //   cy.get('.e2e-events-nav').should('not.exist');
 
-    // Go to event
-    cy.visit(`/events/${eventId}`);
+  //   // Log in as the user
+  //   cy.setLoginCookie(newUserEmail, newUserPassword);
 
-    // RSVP to event
-    cy.get('#e2e-event-attendance-button').should('exist');
-    cy.get('#e2e-event-attendance-button').click();
+  //   // Go to event
+  //   cy.visit(`/events/${eventId}`);
 
-    // Go to profile
-    cy.visit(`/profile/${newUserName}-${newUserSurname}`);
-    cy.get('#e2e-usersshowpage');
+  //   // RSVP to event
+  //   cy.get('#e2e-event-attendance-button').should('exist');
+  //   cy.get('#e2e-event-attendance-button').click();
 
-    // Confirm the event is in the list
-    cy.get('.e2e-events-nav').click();
-    cy.get('.e2e-profile-events').should('exist');
-    cy.get('#e2e-event-attendance-button').should('exist');
-  });
+  //   // Go to profile
+  //   cy.visit(`/profile/${newUserName}-${newUserSurname}`);
+  //   cy.get('#e2e-usersshowpage');
+
+  //   // Confirm the event is in the list
+  //   cy.get('.e2e-events-nav').click();
+  //   cy.get('.e2e-profile-events').should('exist');
+  //   cy.get('#e2e-event-attendance-button').should('exist');
+  // });
 
   after(() => {
     cy.apiRemoveComment(commentId);


### PR DESCRIPTION
# Description
Apparently there was a lot of confusion about the attendance functionality after the release yesterday. Simon would like to just visually hide all these elements until the Smart Groups are implemented.

I didn't want to spend a lot of time making a new feature flag, since we'll re-enable these things once smart groups are in. I just used a hardcoded boolean for now, and made sure to mark everything with a TODO comment :thinking: Though if you have a different suggestion just let me know :)

Also sorry for assigning you again @IvaKop !! If you're too busy just let me know and I can assign someone else :+1: 

# Changelog
## Changed
- Hide new UI associated with event attendance button