### PR TITLE
[TAN-331] Don't include current_user in mentions, even if post author

### DIFF
--- a/back/app/controllers/web_api/v1/mentions_controller.rb
+++ b/back/app/controllers/web_api/v1/mentions_controller.rb
@@ -13,16 +13,11 @@ class WebApi::V1::MentionsController < ApplicationController
     post = find_post(params[:post_type], params[:post_id])
 
     @users = []
-    @users = MentionService.new.users_from_post(query, post, limit, current_user) if post && params[:roles].nil?
+    @users = MentionService.new.users_from_post(query, post, limit) if post && params[:roles].nil?
 
     nb_missing_users = limit - @users.size
-    if nb_missing_users.positive?
-      @users += if current_user
-        find_users_by_query(query, post).where.not(id: current_user.id).limit(nb_missing_users)
-      else
-        find_users_by_query(query, post).limit(nb_missing_users)
-      end
-    end
+    @users += find_users_by_query(query, post).limit(nb_missing_users) if nb_missing_users.positive?
+    @users = @users.excluding(current_user)
 
     render json: WebApi::V1::UserSerializer.new(
       @users,

--- a/back/app/models/initiative.rb
+++ b/back/app/models/initiative.rb
@@ -131,7 +131,7 @@ class Initiative < ApplicationRecord
   end
 
   def cosponsor_ids=(ids)
-    super(ids.uniq)
+    super(ids.uniq.excluding(author_id))
   end
 
   def reactions_needed(configuration = AppConfiguration.instance)

--- a/back/app/services/mention_service.rb
+++ b/back/app/services/mention_service.rb
@@ -66,10 +66,9 @@ class MentionService
   # @param [Post] post
   # @param [Integer] limit
   # @return [Array<User>]
-  def users_from_post(query, post, limit, current_user)
+  def users_from_post(query, post, limit)
     user_ids = User.joins(:comments).where(comments: { post_id: post.id }).ids.uniq # Commenters' IDs
     user_ids << post.author_id if post.author_id
-    user_ids.reject! { |id| id == current_user.id } if current_user
     User.where(id: user_ids).by_username(query).limit(limit).to_a
   end
 

--- a/back/app/services/mention_service.rb
+++ b/back/app/services/mention_service.rb
@@ -66,9 +66,10 @@ class MentionService
   # @param [Post] post
   # @param [Integer] limit
   # @return [Array<User>]
-  def users_from_post(query, post, limit)
+  def users_from_post(query, post, limit, current_user)
     user_ids = User.joins(:comments).where(comments: { post_id: post.id }).ids.uniq # Commenters' IDs
     user_ids << post.author_id if post.author_id
+    user_ids.reject! { |id| id == current_user.id }
     User.where(id: user_ids).by_username(query).limit(limit).to_a
   end
 

--- a/back/app/services/mention_service.rb
+++ b/back/app/services/mention_service.rb
@@ -69,7 +69,7 @@ class MentionService
   def users_from_post(query, post, limit, current_user)
     user_ids = User.joins(:comments).where(comments: { post_id: post.id }).ids.uniq # Commenters' IDs
     user_ids << post.author_id if post.author_id
-    user_ids.reject! { |id| id == current_user.id }
+    user_ids.reject! { |id| id == current_user.id } if current_user
     User.where(id: user_ids).by_username(query).limit(limit).to_a
   end
 

--- a/back/spec/acceptance/mentions_spec.rb
+++ b/back/spec/acceptance/mentions_spec.rb
@@ -7,7 +7,6 @@ resource 'Mentions' do
   explanation 'Part of a text that explicitly references a user.'
 
   before do
-    # resident_header_token
     @current_user = create(:user)
     header_token_for(@current_user)
     header 'Content-Type', 'application/json'

--- a/back/spec/acceptance/mentions_spec.rb
+++ b/back/spec/acceptance/mentions_spec.rb
@@ -175,19 +175,4 @@ resource 'Mentions' do
       end
     end
   end
-
-  # context 'when logged in' do
-  #   before do
-  #     header 'Content-Type', 'application/json'
-  #     @user = create(:user)
-  #     header_token_for @user
-  #   end
-
-  #   example 'does not return current user' do
-  #     do_request mention: @user.first_name[0..3]
-  #     assert_status 200
-  #     json_response = json_parse(response_body)
-  #     expect(json_response[:data].pluck(:id)).not_to include @user.id
-  #   end
-  # end
 end

--- a/back/spec/acceptance/mentions_spec.rb
+++ b/back/spec/acceptance/mentions_spec.rb
@@ -7,7 +7,9 @@ resource 'Mentions' do
   explanation 'Part of a text that explicitly references a user.'
 
   before do
-    resident_header_token
+    # resident_header_token
+    @current_user = create(:user)
+    header_token_for(@current_user)
     header 'Content-Type', 'application/json'
   end
 
@@ -47,6 +49,34 @@ resource 'Mentions' do
       expect(json_response[:data].size).to eq idea_related.size
       expect(json_response[:data].pluck(:id)).to match_array idea_related.map(&:id)
       expect(json_response[:data].all? { |u| u[:attributes][:first_name][0..(first_name.size)] == first_name }).to be true
+    end
+
+    context 'when current user is author of post' do
+      let(:initiative) { create(:initiative, author: @current_user) }
+      let(:base_query_params) do
+        { post_id: initiative.id, post_type: 'Initiative', mention: @current_user.first_name[0..3] }
+      end
+
+      example 'does not return current user' do
+        do_request base_query_params
+        assert_status 200
+        json_response = json_parse(response_body)
+        expect(json_response[:data].pluck(:id)).not_to include @current_user.id
+      end
+    end
+
+    context 'when current user is not author of post' do
+      let(:initiative) { create(:initiative, author: create(:user)) }
+      let(:base_query_params) do
+        { post_id: initiative.id, post_type: 'Initiative', mention: @current_user.first_name[0..3] }
+      end
+
+      example 'does not return current user' do
+        do_request base_query_params
+        assert_status 200
+        json_response = json_parse(response_body)
+        expect(json_response[:data].pluck(:id)).not_to include @current_user.id
+      end
     end
 
     example 'Does not return unregistered user by (partial) mention', document: false do
@@ -145,4 +175,19 @@ resource 'Mentions' do
       end
     end
   end
+
+  # context 'when logged in' do
+  #   before do
+  #     header 'Content-Type', 'application/json'
+  #     @user = create(:user)
+  #     header_token_for @user
+  #   end
+
+  #   example 'does not return current user' do
+  #     do_request mention: @user.first_name[0..3]
+  #     assert_status 200
+  #     json_response = json_parse(response_body)
+  #     expect(json_response[:data].pluck(:id)).not_to include @user.id
+  #   end
+  # end
 end

--- a/back/spec/models/initiative_spec.rb
+++ b/back/spec/models/initiative_spec.rb
@@ -283,6 +283,12 @@ RSpec.describe Initiative do
       expect(initiative.reload.cosponsors).to match_array [cosponsor1]
     end
 
+    it 'will not add initiative author as cosponsor' do
+      initiative.update!(cosponsor_ids: [initiative.author_id])
+
+      expect(initiative.reload.cosponsors).to be_empty
+    end
+
     it 'does nothing if update validation fails' do
       saved = initiative.update(cosponsor_ids: [], title_multiloc: {})
       expect(saved).to be false

--- a/back/spec/services/mention_service_spec.rb
+++ b/back/spec/services/mention_service_spec.rb
@@ -100,13 +100,13 @@ describe MentionService do
     end
 
     it 'return the users from the idea that match the slug' do
-      result = service.users_from_post('ja', @idea, 5)
+      result = service.users_from_post('ja', @idea, 5, _current_user = nil)
       expect(result.size).to eq 2
       expect(result).to match_array [@u1, @u2]
     end
 
-    it 'handles case gracefully' do
-      result = service.users_from_post('Ja', @idea, 5)
+    it 'handles character case gracefully' do
+      result = service.users_from_post('Ja', @idea, 5, _current_user = nil)
       expect(result.size).to eq 2
       expect(result).to match_array [@u1, @u2]
     end

--- a/back/spec/services/mention_service_spec.rb
+++ b/back/spec/services/mention_service_spec.rb
@@ -100,13 +100,13 @@ describe MentionService do
     end
 
     it 'return the users from the idea that match the slug' do
-      result = service.users_from_post('ja', @idea, 5, _current_user = nil)
+      result = service.users_from_post('ja', @idea, 5)
       expect(result.size).to eq 2
       expect(result).to match_array [@u1, @u2]
     end
 
     it 'handles character case gracefully' do
-      result = service.users_from_post('Ja', @idea, 5, _current_user = nil)
+      result = service.users_from_post('Ja', @idea, 5)
       expect(result.size).to eq 2
       expect(result).to match_array [@u1, @u2]
     end


### PR DESCRIPTION
# Changelog
## Changed
- [TAN-331] Don't include current_user in mentions, even if post author.
- [TAN-331] Don't permit initiative author to be cosponsor of initiative.
