### PR TITLE
[CL-3327] Check id_cards table for verified rut numbers

### DIFF
--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -115,6 +115,7 @@ PATH
   remote: engines/commercial/id_clave_unica
   specs:
     id_clave_unica (0.1.0)
+      id_id_card_lookup
       omniauth_openid_connect
       rails (~> 7.0)
       verification

--- a/back/engines/commercial/id_clave_unica/app/lib/id_clave_unica/clave_unica_omniauth.rb
+++ b/back/engines/commercial/id_clave_unica/app/lib/id_clave_unica/clave_unica_omniauth.rb
@@ -16,7 +16,8 @@ module IdClaveUnica
         info[:last_name] = ln.join(' ')
       end
 
-      if IdIdCardLookup::IdCard.find_by_card_id(formatted_rut(auth))
+      rut = auth['uid']
+      if IdIdCardLookup::IdCard.find_by_card_id(rut)
         info[:custom_field_values] = { rut_verified: true }
       end
 
@@ -79,17 +80,6 @@ module IdClaveUnica
 
     def verification_prioritized?
       true
-    end
-
-    private
-
-    def formatted_rut(auth)
-      info = auth.dig('extra', 'raw_info')
-      dv = info.dig('RolUnico', 'DV')
-
-      return if info['sub'].blank? || dv.blank?
-
-      (info['sub'] + dv).gsub(/(\d{1,3})(\d{3})(\d{3})([\dkK])/, '\1.\2.\3-\4')
     end
   end
 end

--- a/back/engines/commercial/id_clave_unica/app/lib/id_clave_unica/clave_unica_omniauth.rb
+++ b/back/engines/commercial/id_clave_unica/app/lib/id_clave_unica/clave_unica_omniauth.rb
@@ -15,6 +15,12 @@ module IdClaveUnica
       if (ln = auth.dig('extra', 'raw_info', 'name', 'apellidos'))
         info[:last_name] = ln.join(' ')
       end
+
+      rut = auth['uid']
+      if IdIdCardLookup::IdCard.find_by_card_id(rut)
+        info[:custom_field_values] = { rut_verified: true }
+      end
+
       info
     end
 
@@ -53,7 +59,7 @@ module IdClaveUnica
     end
 
     def updateable_user_attrs
-      %i[first_name last_name]
+      %i[first_name last_name custom_field_values]
     end
 
     def logout_url(_user)

--- a/back/engines/commercial/id_clave_unica/app/lib/id_clave_unica/clave_unica_omniauth.rb
+++ b/back/engines/commercial/id_clave_unica/app/lib/id_clave_unica/clave_unica_omniauth.rb
@@ -16,8 +16,9 @@ module IdClaveUnica
         info[:last_name] = ln.join(' ')
       end
 
-      rut = auth['uid']
-      if IdIdCardLookup::IdCard.find_by_card_id(rut)
+      # We save formatted RUT in IdCard to be able to use this table for IdCard verification
+      # (so, that users enter their RUT in its usual format)
+      if IdIdCardLookup::IdCard.find_by_card_id(formatted_rut(auth))
         info[:custom_field_values] = { rut_verified: true }
       end
 
@@ -80,6 +81,17 @@ module IdClaveUnica
 
     def verification_prioritized?
       true
+    end
+
+    private
+
+    def formatted_rut(auth)
+      info = auth.dig('extra', 'raw_info')
+      dv = info.dig('RolUnico', 'DV')
+
+      return if info['sub'].blank? || dv.blank?
+
+      (info['sub'] + dv).gsub(/(\d{1,3})(\d{3})(\d{3})([\dkK])/, '\1.\2.\3-\4')
     end
   end
 end

--- a/back/engines/commercial/id_clave_unica/id_clave_unica.gemspec
+++ b/back/engines/commercial/id_clave_unica/id_clave_unica.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rails', '~> 7.0'
   s.add_dependency 'verification'
+  s.add_dependency 'id_id_card_lookup'
   s.add_dependency 'omniauth_openid_connect'
 
   s.add_development_dependency 'rspec_api_documentation'

--- a/back/engines/commercial/id_clave_unica/lib/tasks/id_clave_unica.rake
+++ b/back/engines/commercial/id_clave_unica/lib/tasks/id_clave_unica.rake
@@ -32,7 +32,7 @@ namespace :id_clave_unica do
   task :update_rut_verified_flag, %i[input_csv_file_path] => [:environment] do |_t, args|
     File.read(args[:input_csv_file_path]).split("\n").each do |rut|
       hashed_uid = Verification::VerificationService.new.send(:hashed_uid, rut, 'clave_unica')
-      verification = Verification::Verification.where(method_name: 'clave_unica', hashed_uid: hashed_uid)
+      verification = Verification::Verification.find_by(method_name: 'clave_unica', hashed_uid: hashed_uid)
       if verification.nil?
         print '.'
       else

--- a/back/engines/commercial/id_clave_unica/lib/tasks/id_clave_unica.rake
+++ b/back/engines/commercial/id_clave_unica/lib/tasks/id_clave_unica.rake
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+namespace :id_clave_unica do
+  # Run it locally first (not to install poppler-utils on production)
+  #
+  # docker cp ../clave-unica/Padron-13-LA\ REINA-1-2\ \(1\).pdf "$(docker ps | awk '/citizenlab-web/ {print $1}')":/cl2_back/ruts.pdf
+  # docker cp ../clave-unica/Padron-13-LA\ REINA-2-2\ \(1\).pdf "$(docker ps | awk '/citizenlab-web/ {print $1}')":/cl2_back/ruts2.pdf
+  # docker exec -it "$(docker ps | awk '/citizenlab-web/ {print $1}')" bin/rails 'id_clave_unica:parse_rut_pdf_to_csv[ruts.csv,ruts.pdf,ruts2.pdf]'
+  # docker cp "$(docker ps | awk '/citizenlab-web/ {print $1}')":/cl2_back/ruts.csv ./ruts.csv
+  task :parse_rut_pdf_to_csv, %i[output_csv_file_path] => [:environment] do |_t, args|
+    `apt-get install -qq -y --no-install-recommends poppler-utils`
+    # https://stackoverflow.com/questions/46770938/regex-for-chilean-rut-run-with-pcre
+    rut_format_regex = /\d{1,3}(?:\.\d{1,3}){2}-[\dkK]/
+
+    ruts = []
+    args.extras.each do |input_pdf_file_path|
+      puts "Reading #{input_pdf_file_path}"
+      tmp_file_path = Tempfile.new.path
+      `pdftotext -layout "#{input_pdf_file_path}" "#{tmp_file_path}"`
+      new_ruts = File.read(tmp_file_path).scan(rut_format_regex)
+      # plain_new_ruts = new_ruts.map { |rut| rut.split('-').first.delete('.') }
+      ruts += new_ruts
+    end
+    File.write(args[:output_csv_file_path], ruts.join("\n"))
+  end
+
+  task :update_rut_verified_flag, %i[input_csv_file_path] => [:environment] do |_t, args|
+    File.read(args[:input_csv_file_path]).split("\n").each do |rut|
+      hashed_uid = Verification::VerificationService.new.send(:hashed_uid, rut, 'clave_unica')
+      verification = Verification::Verification.where(method_name: 'clave_unica', hashed_uid: hashed_uid)
+      if verification.nil?
+        print '.'
+      else
+        user = verification.user
+        if user
+          user.update_merging_custom_fields!(custom_field_values: { rut_verified: true })
+          puts "Updated user #{user.id} (#{rut})"
+        end
+      end
+    end
+  end
+end

--- a/back/engines/commercial/id_clave_unica/lib/tasks/id_clave_unica.rake
+++ b/back/engines/commercial/id_clave_unica/lib/tasks/id_clave_unica.rake
@@ -3,12 +3,15 @@
 require 'csv'
 
 namespace :id_clave_unica do
-  # Run it locally first (not to install poppler-utils on production)
+  # Run these commands locally (not to install poppler-utils on production)
   #
   # docker cp ../clave-unica/Padron-13-LA\ REINA-1-2\ \(1\).pdf "$(docker ps | awk '/citizenlab-web/ {print $1}')":/cl2_back/ruts.pdf
   # docker cp ../clave-unica/Padron-13-LA\ REINA-2-2\ \(1\).pdf "$(docker ps | awk '/citizenlab-web/ {print $1}')":/cl2_back/ruts2.pdf
+  #
   # docker exec -it "$(docker ps | awk '/citizenlab-web/ {print $1}')" bin/rails 'id_clave_unica:parse_rut_pdf_to_csv[ruts.csv,ruts.pdf,ruts2.pdf]'
+  #
   # docker cp "$(docker ps | awk '/citizenlab-web/ {print $1}')":/cl2_back/ruts.csv ./ruts.csv
+  #
   task :parse_rut_pdf_to_csv, %i[output_csv_file_path] => [:environment] do |_t, args|
     `apt-get install -qq -y --no-install-recommends poppler-utils`
     # https://stackoverflow.com/questions/46770938/regex-for-chilean-rut-run-with-pcre

--- a/back/engines/commercial/id_clave_unica/spec/requests/clave_unica_verification_spec.rb
+++ b/back/engines/commercial/id_clave_unica/spec/requests/clave_unica_verification_spec.rb
@@ -144,6 +144,30 @@ describe 'clave_unica verification' do
     expect(response).to redirect_to('/en/complete-signup?pathname=%2Fsome-page')
   end
 
+  context 'when checking against list of verified RUTs registered in municipality' do
+    context 'when RUT is added to list' do
+      before { IdIdCardLookup::IdCard.create!(card_id: '44.444.444-4') }
+
+      it 'sets rut_verified custom field' do
+        get "/auth/clave_unica?token=#{@token}"
+        follow_redirect!
+
+        expect(@user.reload.custom_field_values).to eq({ 'rut_verified' => true })
+      end
+    end
+
+    context 'when RUT is not added to list' do
+      before { IdIdCardLookup::IdCard.create!(card_id: '55.555.555-5') }
+
+      it 'does not set rut_verified custom field' do
+        get "/auth/clave_unica?token=#{@token}"
+        follow_redirect!
+
+        expect(@user.reload.custom_field_values).to eq({})
+      end
+    end
+  end
+
   context 'when verification is already taken by new user' do
     before do
       get '/auth/clave_unica'

--- a/back/engines/commercial/id_clave_unica/spec/requests/clave_unica_verification_spec.rb
+++ b/back/engines/commercial/id_clave_unica/spec/requests/clave_unica_verification_spec.rb
@@ -146,7 +146,7 @@ describe 'clave_unica verification' do
 
   context 'when checking against list of verified RUTs registered in municipality' do
     context 'when RUT is added to list' do
-      before { IdIdCardLookup::IdCard.create!(card_id: '44444444') }
+      before { IdIdCardLookup::IdCard.create!(card_id: '44.444.444-4') }
 
       it 'sets rut_verified custom field' do
         get "/auth/clave_unica?token=#{@token}"
@@ -157,7 +157,7 @@ describe 'clave_unica verification' do
     end
 
     context 'when RUT is not added to list' do
-      before { IdIdCardLookup::IdCard.create!(card_id: '55555555') }
+      before { IdIdCardLookup::IdCard.create!(card_id: '55.555.555-5') }
 
       it 'does not set rut_verified custom field' do
         get "/auth/clave_unica?token=#{@token}"

--- a/back/engines/commercial/id_clave_unica/spec/requests/clave_unica_verification_spec.rb
+++ b/back/engines/commercial/id_clave_unica/spec/requests/clave_unica_verification_spec.rb
@@ -146,7 +146,7 @@ describe 'clave_unica verification' do
 
   context 'when checking against list of verified RUTs registered in municipality' do
     context 'when RUT is added to list' do
-      before { IdIdCardLookup::IdCard.create!(card_id: '44.444.444-4') }
+      before { IdIdCardLookup::IdCard.create!(card_id: '44444444') }
 
       it 'sets rut_verified custom field' do
         get "/auth/clave_unica?token=#{@token}"
@@ -157,7 +157,7 @@ describe 'clave_unica verification' do
     end
 
     context 'when RUT is not added to list' do
-      before { IdIdCardLookup::IdCard.create!(card_id: '55.555.555-5') }
+      before { IdIdCardLookup::IdCard.create!(card_id: '55555555') }
 
       it 'does not set rut_verified custom field' do
         get "/auth/clave_unica?token=#{@token}"

--- a/back/engines/commercial/verification/app/services/verification/verification_service.rb
+++ b/back/engines/commercial/verification/app/services/verification/verification_service.rb
@@ -119,6 +119,7 @@ module Verification
       taken = existing_users.present?
 
       if taken
+        # it means sth went wrong and user wasn't fully created (e.g., they didn't enter email)
         if existing_users.all?(&:blank_and_can_be_deleted?)
           existing_users.each { |u| DeleteUserJob.perform_now(u) }
         else


### PR DESCRIPTION
It's a simplified version of https://github.com/CitizenLabDotCo/citizenlab/pull/4742

```ruby
locale = AppConfiguration.instance.closest_locale_to('es')
rut_verified_custom_field = CustomField.create!(resource_type: 'User', title_multiloc: { locale => 'RUT verified' }, key: :rut_verified, input_type: 'checkbox', hidden: true)
Group.create!(
  title_multiloc: { locale => "Living in La Reina" },
  membership_type: "rules",
  rules: [{"ruleType"=>"custom_field_checkbox", "predicate"=>"is_checked", "customFieldId"=>rut_verified_custom_field.id}]
)
```

# Changelog
## Added
* [CL-3327] Check if RUT belongs to local inhabitant during ClaveUnica verification

[CL-3327]: https://citizenlab.atlassian.net/browse/CL-3327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ