### PR TITLE
Fix small events UI issues

### DIFF
--- a/front/app/components/EventCard/DateBlocks/index.tsx
+++ b/front/app/components/EventCard/DateBlocks/index.tsx
@@ -27,18 +27,18 @@ interface Props {
   startAtMoment: moment.Moment;
   endAtMoment: moment.Moment;
   isMultiDayEvent: boolean;
+  showOnlyStartDate?: boolean;
 }
 
 export default memo<Props>(
-  ({ startAtMoment, endAtMoment, isMultiDayEvent }) => {
+  ({ startAtMoment, endAtMoment, isMultiDayEvent, showOnlyStartDate }) => {
     const startAtDay = startAtMoment.format('DD');
     const endAtDay = endAtMoment.format('DD');
     const startAtMonth = startAtMoment.format('MMM');
     const endAtMonth = endAtMoment.format('MMM');
     const startAtYear = startAtMoment.format('YYYY');
     const endAtYear = endAtMoment.format('YYYY');
-
-    const isMultiYearEvent = startAtYear !== endAtYear;
+    const isMultiYearEvent = !showOnlyStartDate && startAtYear !== endAtYear;
 
     return (
       <EventDateBlocks aria-hidden>

--- a/front/app/components/EventCard/EventInformation/index.tsx
+++ b/front/app/components/EventCard/EventInformation/index.tsx
@@ -81,6 +81,7 @@ const EventInformation = ({
             startAtMoment={startAtMoment}
             endAtMoment={endAtMoment}
             isMultiDayEvent={false}
+            showOnlyStartDate={true}
           />
         </Box>
       </Box>

--- a/front/app/components/LandingPages/citizen/EventsWidget.tsx
+++ b/front/app/components/LandingPages/citizen/EventsWidget.tsx
@@ -87,7 +87,7 @@ const EventsWidget = ({ staticPageId }: Props) => {
     projectPublicationStatuses: ['published'],
     currentAndFutureOnly: true,
     pageSize: 3,
-    sort: 'start_at',
+    sort: '-start_at',
     ...(staticPageId && { staticPageId }),
   });
 

--- a/front/app/containers/Admin/projects/project/events/index.tsx
+++ b/front/app/containers/Admin/projects/project/events/index.tsx
@@ -39,6 +39,7 @@ const AdminProjectEventsIndex = ({
   const { data: events } = useEvents({
     projectIds: [projectId],
     pageSize: 1000,
+    sort: 'start_at',
   });
 
   const { mutate: deleteEvent, isLoading } = useDeleteEvent();


### PR DESCRIPTION
# Changelog
## Fixed
- Events on homepage widget now in correct order
- Event cards now only ever show starting date in right corner
- Project events list in back office now show events furthest in the future at the top