### PR TITLE
[CL-4015] Fix lastpass client error in circleci workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,13 +92,7 @@ commands:
 
   copy_secrets_from_lastpass:
     steps:
-      - run: |
-          if command -v sudo &> /dev/null
-          then
-            sudo apt-get update && sudo apt-get install -y lastpass-cli
-          else
-            apt-get update && apt-get install -y lastpass-cli
-          fi
+      - run: .circleci/install_lpass.sh v1.3.5
       - run: echo $LASTPASS_PASSWORD | LPASS_DISABLE_PINENTRY=1 lpass login ${LASTPASS_EMAIL}
       - run: lpass show --notes 'citizenlab back-secret.env' > env_files/back-secret.env
       - run: lpass show --notes 'citizenlab front-secret.env' > env_files/front-secret.env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,11 @@ commands:
 
   copy_secrets_from_lastpass:
     steps:
-      - run: .circleci/install_lpass.sh v1.3.5
+      # Installing LastPass CLI from GitHub instead of using apt-get because the last
+      # version available in the source repositories is 1.3.3, which has been broken by
+      # a change of SSL certificate. For more information, see:
+      # https://github.com/lastpass/lastpass-cli/issues/653
+      - run: sudo .circleci/install_lpass.sh v1.3.5
       - run: echo $LASTPASS_PASSWORD | LPASS_DISABLE_PINENTRY=1 lpass login ${LASTPASS_EMAIL}
       - run: lpass show --notes 'citizenlab back-secret.env' > env_files/back-secret.env
       - run: lpass show --notes 'citizenlab front-secret.env' > env_files/front-secret.env

--- a/.circleci/install_lpass.sh
+++ b/.circleci/install_lpass.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <branch/tag>"
+  exit 1
+fi
+
+version="$1"
+repository="https://github.com/lastpass/lastpass-cli.git"
+
+# Clone the LastPass CLI repository with a shallow clone
+if ! git clone --depth 1 --branch "$version" "$repository" lastpass-cli; then
+    echo "Error: Failed to clone the repository."
+    exit 1
+fi
+
+# Install the dependencies
+apt-get update
+apt-get --no-install-recommends -yqq install \
+  build-essential=12.8ubuntu1.1 \
+  cmake=3.16.3-1ubuntu1.20.04.1 \
+  libcurl4=7.68.0-1ubuntu2.19 \
+  libcurl4-openssl-dev=7.68.0-1ubuntu2.19 \
+  libssl-dev=1.1.1f-1ubuntu2.19 \
+  libxml2=2.9.10+dfsg-5ubuntu0.20.04.6 \
+  libxml2-dev=2.9.10+dfsg-5ubuntu0.20.04.6 \
+  libssl1.1=1.1.1f-1ubuntu2.19 \
+  pkg-config=0.29.1-0ubuntu4 \
+  ca-certificates=20230311ubuntu0.20.04.1
+
+# Build and install the LastPass CLI
+cd lastpass-cli
+make
+make install
+
+# Clean up
+cd ..
+rm -rf lastpass-cli
+
+# copy permissions from another file


### PR DESCRIPTION
- CL-4015

# Changelog
## Technical
- Upgrade from broken `lpass` version 1.3.3 to 1.3.5 in CI.
