### PR TITLE
TAN-329 Ordered tags by input count

### DIFF
--- a/back/engines/commercial/analysis/app/controllers/analysis/web_api/v1/tags_controller.rb
+++ b/back/engines/commercial/analysis/app/controllers/analysis/web_api/v1/tags_controller.rb
@@ -20,7 +20,7 @@ module Analysis
           inputs_without_tags = TagCounter.new(@analysis, tags: @tags, filters: { tag_ids: [nil] }).total_count
           filtered_inputs_without_tags = TagCounter.new(@analysis, tags: @tags, filters: filters.merge(tag_ids: [nil])).total_count
 
-          @tags = @tags.sort_by { |tag| -filtered_inputs_count_by_tag[tag.id] }
+          @tags = @tags.sort_by { |tag| -inputs_count_by_tag[tag.id] }
           render json: WebApi::V1::TagSerializer.new(
             @tags,
             params: {

--- a/back/engines/commercial/analysis/app/controllers/analysis/web_api/v1/tags_controller.rb
+++ b/back/engines/commercial/analysis/app/controllers/analysis/web_api/v1/tags_controller.rb
@@ -10,7 +10,6 @@ module Analysis
 
         def index
           @tags = @analysis.tags
-            .order(created_at: :asc)
 
           inputs_count_by_tag = TagCounter.new(@analysis, tags: @tags).counts_by_tag
           filtered_inputs_count_by_tag = TagCounter.new(@analysis, tags: @tags, filters: filters).counts_by_tag
@@ -20,8 +19,8 @@ module Analysis
           inputs_without_tags = TagCounter.new(@analysis, tags: @tags, filters: { tag_ids: [nil] }).total_count
           filtered_inputs_without_tags = TagCounter.new(@analysis, tags: @tags, filters: filters.merge(tag_ids: [nil])).total_count
 
-         # @tags = @tags.sort_by { |tag| -inputs_count_by_tag[tag.id] }
-       
+          @tags = @tags.sort_by { |tag| -inputs_count_by_tag[tag.id] }
+
           render json: WebApi::V1::TagSerializer.new(
             @tags,
             params: {

--- a/back/engines/commercial/analysis/app/controllers/analysis/web_api/v1/tags_controller.rb
+++ b/back/engines/commercial/analysis/app/controllers/analysis/web_api/v1/tags_controller.rb
@@ -10,7 +10,7 @@ module Analysis
 
         def index
           @tags = @analysis.tags
-            .order(created_at: :desc)
+            .order(created_at: :asc)
 
           inputs_count_by_tag = TagCounter.new(@analysis, tags: @tags).counts_by_tag
           filtered_inputs_count_by_tag = TagCounter.new(@analysis, tags: @tags, filters: filters).counts_by_tag
@@ -20,7 +20,8 @@ module Analysis
           inputs_without_tags = TagCounter.new(@analysis, tags: @tags, filters: { tag_ids: [nil] }).total_count
           filtered_inputs_without_tags = TagCounter.new(@analysis, tags: @tags, filters: filters.merge(tag_ids: [nil])).total_count
 
-          @tags = @tags.sort_by { |tag| -inputs_count_by_tag[tag.id] }
+         # @tags = @tags.sort_by { |tag| -inputs_count_by_tag[tag.id] }
+       
           render json: WebApi::V1::TagSerializer.new(
             @tags,
             params: {

--- a/back/engines/commercial/analysis/app/controllers/analysis/web_api/v1/tags_controller.rb
+++ b/back/engines/commercial/analysis/app/controllers/analysis/web_api/v1/tags_controller.rb
@@ -20,6 +20,7 @@ module Analysis
           inputs_without_tags = TagCounter.new(@analysis, tags: @tags, filters: { tag_ids: [nil] }).total_count
           filtered_inputs_without_tags = TagCounter.new(@analysis, tags: @tags, filters: filters.merge(tag_ids: [nil])).total_count
 
+          @tags = @tags.sort_by { |tag| -filtered_inputs_count_by_tag[tag.id] }
           render json: WebApi::V1::TagSerializer.new(
             @tags,
             params: {

--- a/back/engines/commercial/analysis/app/controllers/analysis/web_api/v1/tags_controller.rb
+++ b/back/engines/commercial/analysis/app/controllers/analysis/web_api/v1/tags_controller.rb
@@ -19,7 +19,8 @@ module Analysis
           inputs_without_tags = TagCounter.new(@analysis, tags: @tags, filters: { tag_ids: [nil] }).total_count
           filtered_inputs_without_tags = TagCounter.new(@analysis, tags: @tags, filters: filters.merge(tag_ids: [nil])).total_count
 
-          @tags = @tags.sort_by { |tag| -inputs_count_by_tag[tag.id] }
+          # tags sorted by descending tag count, then by ascending creation time if equal
+          @tags = @tags.sort_by { |tag| - (inputs_count_by_tag[tag.id] || 0) + (tag.created_at.to_i / 1_000_000_000_0.0) }
 
           render json: WebApi::V1::TagSerializer.new(
             @tags,

--- a/back/engines/commercial/analysis/spec/acceptance/tags_spec.rb
+++ b/back/engines/commercial/analysis/spec/acceptance/tags_spec.rb
@@ -73,7 +73,8 @@ resource 'Tags' do
 
       example_request 'lists all tags of an analysis' do
         assert_status 200
-        expect(response_data.pluck(:id)).to match_array(tags.pluck(:id))
+        # tags sorted by descending tag count, then by ascending creation time if equal
+        expect(response_data.pluck(:id)).to eq([tags[1].id, tags[0].id, tags[2].id])
         expect(json_response_body[:meta]).to eq({
           inputs_total: 3,
           filtered_inputs_total: 3,

--- a/front/app/containers/Admin/projects/project/analysis/Tags/AddTag.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Tags/AddTag.tsx
@@ -11,7 +11,7 @@ import translations from './translations';
 import { trackEventByName } from 'utils/analytics';
 import tracks from '../tracks';
 
-const AddTag = () => {
+const AddTag = ({ onCreateTag }: { onCreateTag?: (tagId: string) => void }) => {
   const { analysisId } = useParams() as { analysisId: string };
 
   const [name, setName] = useState('');
@@ -30,32 +30,35 @@ const AddTag = () => {
         name,
       },
       {
-        onSuccess: () => {
+        onSuccess: async (data) => {
           trackEventByName(tracks.manualTagCreated.name, {
             extra: { analysisId, name },
           });
           setName('');
+          onCreateTag && onCreateTag(data.data.id);
         },
       }
     );
   };
 
   return (
-    <Box display="flex" alignItems="center" mb="8px" as="form">
-      <Input
-        type="text"
-        value={name}
-        onChange={onChangeName}
-        placeholder={formatMessage(translations.addTag)}
-        size="small"
-      />
-      <Button
-        ml="4px"
-        p="6px"
-        onClick={handleTagSubmit}
-        disabled={!name || isLoading}
-        icon="plus"
-      />
+    <Box mb="8px">
+      <Box display="flex" alignItems="center" as="form">
+        <Input
+          type="text"
+          value={name}
+          onChange={onChangeName}
+          placeholder={formatMessage(translations.addTag)}
+          size="small"
+        />
+        <Button
+          ml="4px"
+          p="6px"
+          onClick={handleTagSubmit}
+          disabled={!name || isLoading}
+          icon="plus"
+        />
+      </Box>
       <div>
         {error && (
           <Error apiErrors={error.errors['name']} fieldName="tag_name" />

--- a/front/app/containers/Admin/projects/project/analysis/Tags/AddTag.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Tags/AddTag.tsx
@@ -30,7 +30,7 @@ const AddTag = ({ onCreateTag }: { onCreateTag?: (tagId: string) => void }) => {
         name,
       },
       {
-        onSuccess: async (data) => {
+        onSuccess: (data) => {
           trackEventByName(tracks.manualTagCreated.name, {
             extra: { analysisId, name },
           });

--- a/front/app/containers/Admin/projects/project/analysis/Tags/TagActions.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Tags/TagActions.tsx
@@ -113,7 +113,7 @@ const TagActions = ({ tag }: { tag: ITagData }) => {
         onClickOutside={closeDropdown}
         className="dropdown"
         right="0px"
-        top="40px"
+        top="-150px"
         content={
           <>
             <DropdownListItem

--- a/front/app/containers/Admin/projects/project/analysis/Tags/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Tags/index.tsx
@@ -130,7 +130,7 @@ const Tags = () => {
           icon="flash"
           mb="12px"
           size="s"
-          buttonStyle="secondary-outlined"
+          buttonStyle="admin-dark"
         >
           {formatMessage(translations.autoTag)}
           {!tags?.data.length && (
@@ -138,7 +138,7 @@ const Tags = () => {
               name={'dot'}
               width="16px"
               height="16px"
-              fill={colors.primary}
+              fill={colors.white}
               ml="8px"
             />
           )}

--- a/front/app/containers/Admin/projects/project/analysis/Tags/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Tags/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { omit } from 'lodash-es';
 
@@ -70,6 +70,7 @@ const Tags = () => {
   const { formatMessage } = useIntl();
   const [autotaggingModalIsOpened, setAutotaggingModalIsOpened] =
     useState(false);
+  const [createdTagId, setCreatedTagId] = useState<string | null>(null);
 
   const filters = useAnalysisFilterParams();
 
@@ -80,6 +81,19 @@ const Tags = () => {
     analysisId,
     filters: omit(filters, 'tag_ids'),
   });
+
+  useEffect(() => {
+    if (
+      createdTagId &&
+      tags?.data.map((tag) => tag.id).includes(createdTagId)
+    ) {
+      const tagElement = document.getElementById(`tag-${createdTagId}`);
+      if (tagElement) {
+        tagElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+      setCreatedTagId(null);
+    }
+  }, [createdTagId, tags]);
 
   if (isLoadingTags) {
     return (
@@ -143,7 +157,7 @@ const Tags = () => {
             />
           )}
         </Button>
-        <AddTag />
+        <AddTag onCreateTag={(tagId) => setCreatedTagId(tagId)} />
       </Box>
       <Box>
         <TagContainer


### PR DESCRIPTION
# Changelog
## Changed
- Analysis tags are now ordered by input count, creating a new manual tag scrolls it into view (sense-making)
