### PR TITLE
[TAN-336] Include cosponsorships invite statuses in export of proposals

### DIFF
--- a/back/app/services/xlsx_service.rb
+++ b/back/app/services/xlsx_service.rb
@@ -173,7 +173,7 @@ class XlsxService
       { header: 'author_name',          f: ->(i) { format_author_name i } },
       { header: 'author_email',         f: ->(i) { i.author&.email } },
       { header: 'author_id',            f: ->(i) { i.author_id } },
-      { header: 'cosponsors',           f: ->(i) { i.cosponsors_initiatives.map { |ci| ci.user.email }.join(',') }, skip_sanitization: true },
+      { header: 'cosponsors',           f: ->(i) { i.cosponsors_initiatives.map { |ci| "#{ci.user.email} - status: #{ci.status}" }.join(', ') }, skip_sanitization: true },
       { header: 'published_at',         f: ->(i) { i.published_at },                                    skip_sanitization: true },
       { header: 'comments',             f: ->(i) { i.comments_count },                                  skip_sanitization: true },
       { header: 'likes', f: ->(i) { i.likes_count }, skip_sanitization: true },

--- a/back/app/services/xlsx_service.rb
+++ b/back/app/services/xlsx_service.rb
@@ -173,7 +173,7 @@ class XlsxService
       { header: 'author_name',          f: ->(i) { format_author_name i } },
       { header: 'author_email',         f: ->(i) { i.author&.email } },
       { header: 'author_id',            f: ->(i) { i.author_id } },
-      { header: 'cosponsors',           f: ->(i) { i.cosponsors_initiatives.map { |ci| "#{ci.user.email} - status: #{ci.status}" }.join(', ') }, skip_sanitization: true },
+      { header: 'cosponsors',           f: ->(i) { i.cosponsors_initiatives.map { |ci| "#{ci.user.email} - status: #{ci.status}" }.join("\n") }, skip_sanitization: true },
       { header: 'published_at',         f: ->(i) { i.published_at },                                    skip_sanitization: true },
       { header: 'comments',             f: ->(i) { i.comments_count },                                  skip_sanitization: true },
       { header: 'likes', f: ->(i) { i.likes_count }, skip_sanitization: true },


### PR DESCRIPTION
<img width="536" alt="Screenshot 2023-09-04 at 18 13 51" src="https://github.com/CitizenLabDotCo/citizenlab/assets/3944042/2f9c7e59-3977-4f81-bfe1-5290f4090cae">

This is the simplest approach.

Better might be to use 2 columns on excel sheet: 'cosponsors invited' & 'cosponsors accepted'.

# Changelog
## Added
- [TAN-336] Include cosponsorships invite statuses in export of proposals