### PR TITLE
TAN-80 search_by_all includes idea custom_field_values

### DIFF
--- a/back/app/models/concerns/post.rb
+++ b/back/app/models/concerns/post.rb
@@ -10,10 +10,6 @@ module Post
   PUBLICATION_STATUSES = %w[draft published].freeze
 
   included do
-    pg_search_scope :search_by_all,
-      against: %i[title_multiloc body_multiloc],
-      using: { tsearch: { prefix: true } }
-
     pg_search_scope :restricted_search,
       against: %i[title_multiloc body_multiloc],
       using: { tsearch: { prefix: true } }

--- a/back/app/models/idea.rb
+++ b/back/app/models/idea.rb
@@ -122,6 +122,10 @@ class Idea < ApplicationRecord
   after_create :assign_slug
   after_update :fix_comments_count_on_projects
 
+  pg_search_scope :search_by_all,
+    against: %i[title_multiloc body_multiloc custom_field_values],
+    using: { tsearch: { prefix: true } }
+
   scope :with_some_topics, (proc do |topics|
     ideas = joins(:ideas_topics).where(ideas_topics: { topic: topics })
     where(id: ideas)

--- a/back/app/models/initiative.rb
+++ b/back/app/models/initiative.rb
@@ -88,6 +88,10 @@ class Initiative < ApplicationRecord
     before_validation :sanitize_body_multiloc, if: :body_multiloc
   end
 
+  pg_search_scope :search_by_all,
+    against: %i[title_multiloc body_multiloc],
+    using: { tsearch: { prefix: true } }
+
   scope :with_some_topics, (proc do |topic_ids|
     with_dups = joins(:initiatives_topics)
       .where(initiatives_topics: { topic_id: topic_ids })


### PR DESCRIPTION
# Changelog
## Fixed
- Searching through a survey in an analysis now works (sensemaking, WIP)