### PR TITLE
[TAN-340] Improve logo resolution in mails

### DIFF
--- a/back/app/mailers/application_mailer.rb
+++ b/back/app/mailers/application_mailer.rb
@@ -182,7 +182,8 @@ class ApplicationMailer < ActionMailer::Base
     @logo_width ||= case versions
     when versions[:medium].present? then versions[:medium].width
     when versions[:large].present?  then versions[:large].width / 2
-    else versions[:small].width * 2
+    when versions[:small].present?  then versions[:small].width * 2
+    else 160
     end
   end
 

--- a/back/app/mailers/application_mailer.rb
+++ b/back/app/mailers/application_mailer.rb
@@ -19,9 +19,9 @@ class ApplicationMailer < ActionMailer::Base
     :url_service, :multiloc_service, :organization_name,
     :loc, :localize_for_recipient, :recipient_first_name
 
-  helper_method :unsubscribe_url, :terms_conditions_url, :privacy_policy_url, :home_url, :logo_url,
-    :show_unsubscribe_link?, :show_terms_link?, :show_privacy_policy_link?, :format_message,
-    :header_logo_only?, :remove_vendor_branding?
+  helper_method :unsubscribe_url, :terms_conditions_url, :privacy_policy_url, :home_url, :logo_url, :logo_width,
+    :show_unsubscribe_link?, :show_terms_link?, :show_privacy_policy_link?, :format_message, :header_logo_only?,
+    :remove_vendor_branding?
 
   NotImplementedError = Class.new(StandardError)
 
@@ -172,7 +172,17 @@ class ApplicationMailer < ActionMailer::Base
 
   def logo_url
     @logo_url ||= app_configuration.logo.versions.then do |versions|
-      versions[:medium].url || versions[:small].url || versions[:large].url || ''
+      versions[:large].url || versions[:medium].url || versions[:small].url || ''
+    end
+  end
+
+  def logo_width
+    versions = app_configuration.logo.versions
+
+    @logo_width ||= case versions
+    when versions[:medium].present? then versions[:medium].width
+    when versions[:large].present?  then versions[:large].width / 2
+    else versions[:small].width * 2
     end
   end
 

--- a/back/app/mailers/application_mailer.rb
+++ b/back/app/mailers/application_mailer.rb
@@ -183,7 +183,7 @@ class ApplicationMailer < ActionMailer::Base
     when versions[:medium].present? then versions[:medium].width
     when versions[:large].present?  then versions[:large].width / 2
     when versions[:small].present?  then versions[:small].width * 2
-    else 160
+    else 0 # If logo_url is set to '' because no versions found, the width will be 0. Useful for tests without a logo.
     end
   end
 

--- a/back/app/mailers/application_mailer.rb
+++ b/back/app/mailers/application_mailer.rb
@@ -179,11 +179,14 @@ class ApplicationMailer < ActionMailer::Base
   def logo_width
     versions = app_configuration.logo.versions
 
-    @logo_width ||= case versions
-    when versions[:medium].present? then versions[:medium].width
-    when versions[:large].present?  then versions[:large].width / 2
-    when versions[:small].present?  then versions[:small].width * 2
-    else 0 # If logo_url is set to '' because no versions found, the width will be 0. Useful for tests without a logo.
+    @logo_width ||= if versions[:medium].present?
+      versions[:medium].width
+    elsif versions[:large].present?
+      versions[:large].width / 2
+    elsif versions[:small].present?
+      versions[:small].width * 2
+    else
+      0 # If logo_url is set to '' because no versions found, the width will be 0. Useful for tests without a logo.
     end
   end
 

--- a/back/app/views/application/_logo_medium_top.mjml
+++ b/back/app/views/application/_logo_medium_top.mjml
@@ -1,9 +1,5 @@
 <mj-section padding="20px 25px 0">
   <mj-column>
-    <mj-raw>
-      <%= link_to home_url do %>
-        <%= image_tag logo_url, alt: 'Organization logo' %>
-      <% end %>
-    </mj-raw>
+    <mj-image align="left" width=<%= "#{logo_width}px" %> src=<%= logo_url %> href=<%= home_url %> />
   </mj-column>
 </mj-section>

--- a/back/app/views/application/_logo_medium_top.mjml
+++ b/back/app/views/application/_logo_medium_top.mjml
@@ -1,5 +1,5 @@
 <mj-section padding="20px 25px 0">
   <mj-column>
-    <mj-image align="left" width=<%= "#{logo_width}px" %> src=<%= logo_url %> href=<%= home_url %> />
+    <mj-image align="left" width=<%= "#{logo_width}px" %> src=<%= logo_url %> href=<%= home_url %> alt="Organization logo"/>
   </mj-column>
 </mj-section>


### PR DESCRIPTION
After investigating [how responsive images should be defined for higher definition displays](https://medium.com/ynap-tech/how-to-cap-image-fidelity-to-2x-and-save-45-image-weight-on-high-end-mobile-phones-b27b43124a94) here, and then investigating how [MJML images](https://www.npmjs.com/package/mjml-image/v/4.9.3) might use this approach, as in [this example](https://mjml.io/try-it-live/HJTAiLEeM), I decided on a simpler/dumber approach.

In this PR, I simply prefer to pass the large version of the logo image to the MJML file (previously we preferred to pass the medium version), but then set the width of the image to that of the medium version (or calculate what this width would be if no medium version exists). This _seems_ to work (both in mail previews and in mails in local MailCatcher):

### before
<img width="761" alt="Screenshot 2023-09-04 at 17 44 41" src="https://github.com/CitizenLabDotCo/citizenlab/assets/3944042/b7856e8c-2066-4dfa-98c4-54cc4acbc06e">

### after
<img width="761" alt="Screenshot 2023-09-04 at 17 44 36" src="https://github.com/CitizenLabDotCo/citizenlab/assets/3944042/d4023ba8-9d92-4afd-80da-8a20f9a99b33">


My MJML linter complains that the ERB is illegal, but it still seems to work. I have previously noticed that many of our MJML files contain code that gives similar warnings (but also seem to work fine):

<img width="1101" alt="Screenshot 2023-09-04 at 17 28 02" src="https://github.com/CitizenLabDotCo/citizenlab/assets/3944042/b1e7d54c-bc17-4e66-a2fd-b614888761a7">

I am by no means expert at using MJML + ERB, so very open to suggestions / improvements.

# Changelog
## Changed
- [TAN-340] Improved logo resolution in mails
