### PR TITLE
[TAN-339] Align profanity API rendered errors with new format

### DIFF
--- a/back/app/controllers/concerns/blocking_profanity.rb
+++ b/back/app/controllers/concerns/blocking_profanity.rb
@@ -52,6 +52,6 @@ module BlockingProfanity
   private
 
   def render_profanity_blocked(exception)
-    render json: { errors: { base: [{ error: :includes_banned_words, blocked_words: exception.blocked_words }] } }, status: :unprocessable_entity
+    render json: { errors: { error: :includes_banned_words, blocked_words: exception.blocked_words } }, status: :unprocessable_entity
   end
 end

--- a/back/spec/acceptance/idea_comments_spec.rb
+++ b/back/spec/acceptance/idea_comments_spec.rb
@@ -371,9 +371,9 @@ resource 'Comments' do
         example_request '[error] Create a comment with blocked words' do
           assert_status 422
           json_response = json_parse(response_body)
-          blocked_error = json_response.dig(:errors, :base)&.select { |err| err[:error] == 'includes_banned_words' }&.first
-          expect(blocked_error).to be_present
-          expect(blocked_error[:blocked_words].pluck(:attribute).uniq).to eq(['body_multiloc'])
+
+          expect(json_response.dig(:errors, :error)).to eq 'includes_banned_words'
+          expect(json_response.dig(:errors, :blocked_words).pluck(:attribute).uniq).to eq(['body_multiloc'])
         end
       end
 

--- a/back/spec/acceptance/ideas_spec.rb
+++ b/back/spec/acceptance/ideas_spec.rb
@@ -937,9 +937,10 @@ resource 'Ideas' do
           example_request '[error] Create an idea with blocked words' do
             assert_status 422
             json_response = json_parse(response_body)
-            blocked_error = json_response.dig(:errors, :base)&.select { |err| err[:error] == 'includes_banned_words' }&.first
-            expect(blocked_error).to be_present
-            expect(blocked_error[:blocked_words].pluck(:attribute).uniq).to include('title_multiloc', 'body_multiloc')
+
+            expect(json_response.dig(:errors, :error)).to eq 'includes_banned_words'
+            expect(json_response.dig(:errors, :blocked_words).pluck(:attribute).uniq)
+              .to include('title_multiloc', 'body_multiloc')
           end
         end
 

--- a/back/spec/acceptance/initiatives_spec.rb
+++ b/back/spec/acceptance/initiatives_spec.rb
@@ -424,9 +424,9 @@ resource 'Initiatives' do
       example_request '[error] Create an initiative with blocked words' do
         assert_status 422
         json_response = json_parse(response_body)
-        blocked_error = json_response.dig(:errors, :base)&.select { |err| err[:error] == 'includes_banned_words' }&.first
-        expect(blocked_error).to be_present
-        expect(blocked_error[:blocked_words].pluck(:attribute).uniq).to eq(['location_description'])
+
+        expect(json_response.dig(:errors, :error)).to eq 'includes_banned_words'
+        expect(json_response.dig(:errors, :blocked_words).pluck(:attribute).uniq).to eq(['location_description'])
       end
     end
 


### PR DESCRIPTION
Not sure this is exactly what is required.

This changes, this...
```
{
    "errors": {
        "base": [
            {
                "error": "includes_banned_words",
                "blocked_words": [
                    {
                        "word": "fuck",
                        "language": "en",
                        "locale": "en",
                        "attribute": "body_multiloc"
                    },
                    {
                        "word": "fuck",
                        "language": "nl",
                        "locale": "en",
                        "attribute": "body_multiloc"
                    },
                    {
                        "word": "fuck",
                        "language": "fr",
                        "locale": "en",
                        "attribute": "body_multiloc"
                    }
                ]
            }
        ]
    }
}
```

to this ...
```
{
    "errors": {
        "error": "includes_banned_words",
        "blocked_words": [
            {
                "word": "fuck",
                "language": "en",
                "locale": "en",
                "attribute": "body_multiloc"
            },
            {
                "word": "fuck",
                "language": "nl",
                "locale": "en",
                "attribute": "body_multiloc"
            },
            {
                "word": "fuck",
                "language": "fr",
                "locale": "en",
                "attribute": "body_multiloc"
            }
        ]
    }
}
```

# Changelog
## Changed
- [TAN-339] Align profanity API rendered errors with new format
