### PR TITLE
[CL-3971] Do not send digests when no significant stats (activity)

### DIFF
--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/admin_digest.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/admin_digest.rb
@@ -108,21 +108,17 @@ module EmailCampaigns
 
     def content_worth_sending?(_)
       [
-        statistics.dig(:activities, :new_ideas_increase),
-        statistics.dig(:activities, :new_comments_increase),
-        statistics.dig(:users, :new_users_increase)
+        statistics[:new_ideas_increase],
+        statistics[:new_comments_increase],
+        statistics[:new_users_increase]
       ].any?(&:positive?)
     end
 
     def statistics
       @statistics ||= {
-        activities: {
-          new_ideas_increase: stat_increase(Idea.pluck(:published_at).compact),
-          new_comments_increase: stat_increase(Comment.pluck(:created_at))
-        },
-        users: {
-          new_users_increase: stat_increase(User.pluck(:registration_completed_at).compact)
-        }
+        new_ideas_increase: stat_increase(Idea.pluck(:published_at).compact),
+        new_comments_increase: stat_increase(Comment.pluck(:created_at)),
+        new_users_increase: stat_increase(User.pluck(:registration_completed_at).compact)
       }
     end
 

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/admin_digest.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/admin_digest.rb
@@ -108,12 +108,12 @@ module EmailCampaigns
 
     def content_worth_sending?(_)
       [
-        statistics.dig(:activities, :new_ideas, :increase),
-        statistics.dig(:activities, :new_initiatives, :increase),
-        statistics.dig(:activities, :new_comments, :increase),
-        statistics.dig(:users, :new_visitors, :increase),
-        statistics.dig(:users, :new_users, :increase),
-        statistics.dig(:users, :active_users, :increase)
+        statistics.dig(:activities, :new_ideas),
+        statistics.dig(:activities, :new_initiatives),
+        statistics.dig(:activities, :new_comments),
+        statistics.dig(:users, :new_visitors),
+        statistics.dig(:users, :new_users),
+        statistics.dig(:users, :active_users)
       ].any?(&:positive?)
     end
 
@@ -145,10 +145,8 @@ module EmailCampaigns
     def stat_increase(stats = [])
       second_last_agos = stats.select { |t| t > (Time.now - (days_ago * 2)) }
       last_agos = second_last_agos.select { |t| t > (Time.now - days_ago) }
-      {
-        increase: last_agos.size,
-        past_increase: second_last_agos.size
-      }
+
+      last_agos.size
     end
 
     def top_project_ideas

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/admin_digest.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/admin_digest.rb
@@ -108,30 +108,20 @@ module EmailCampaigns
 
     def content_worth_sending?(_)
       [
-        statistics.dig(:activities, :new_ideas),
-        statistics.dig(:activities, :new_initiatives),
-        statistics.dig(:activities, :new_comments),
-        statistics.dig(:users, :new_visitors),
-        statistics.dig(:users, :new_users),
-        statistics.dig(:users, :active_users)
+        statistics.dig(:activities, :new_ideas_count),
+        statistics.dig(:activities, :new_comments_count),
+        statistics.dig(:users, :new_users_count)
       ].any?(&:positive?)
     end
 
     def statistics
       @statistics ||= {
         activities: {
-          new_ideas: stat_increase(Idea.pluck(:published_at).compact),
-          new_initiatives: stat_increase(Initiative.pluck(:published_at).compact),
-          new_reactions: stat_increase(Reaction.pluck(:created_at)),
-          new_comments: stat_increase(Comment.pluck(:created_at)),
-          total_ideas: Idea.count,
-          total_initiatives: Initiative.count,
-          total_users: User.count
+          new_ideas_count: stat_increase(Idea.pluck(:published_at).compact),
+          new_comments_count: stat_increase(Comment.pluck(:created_at))
         },
         users: {
-          new_visitors: stat_increase,
-          new_users: stat_increase(User.pluck(:registration_completed_at).compact),
-          active_users: stat_increase
+          new_users_count: stat_increase(User.pluck(:registration_completed_at).compact)
         }
       }
     end
@@ -142,11 +132,8 @@ module EmailCampaigns
       ((t2 - t1) / 1.day).days
     end
 
-    def stat_increase(stats = [])
-      second_last_agos = stats.select { |t| t > (Time.now - (days_ago * 2)) }
-      last_agos = second_last_agos.select { |t| t > (Time.now - days_ago) }
-
-      last_agos.size
+    def stat_increase(dates = [])
+      dates.count { |t| t > (Time.now - days_ago) }
     end
 
     def top_project_ideas

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/admin_digest.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/admin_digest.rb
@@ -132,8 +132,8 @@ module EmailCampaigns
       ((t2 - t1) / 1.day).days
     end
 
-    def stat_increase(dates = [])
-      dates.count { |t| t > (Time.now - days_ago) }
+    def stat_increase(stat_dates = [])
+      stat_dates.count { |t| t > (Time.now - days_ago) }
     end
 
     def top_project_ideas

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/moderator_digest.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/moderator_digest.rb
@@ -117,7 +117,6 @@ module EmailCampaigns
       participants_increase = ps.projects_participants([project], since: (Time.now - days_ago)).size
       ideas = Idea.published.where(project_id: project.id).load
       comments = Comment.where(post_id: ideas.map(&:id))
-      # reactions = Reaction.where(reactable_id: (ideas.map(&:id) + comments.map(&:id)))
       {
         activities: {
           new_ideas_count: stat_increase(

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/moderator_digest.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/moderator_digest.rb
@@ -149,8 +149,7 @@ module EmailCampaigns
       ((statistics.dig(:activities, :new_ideas, :increase) == 0) &&
          (statistics.dig(:activities, :new_comments, :increase) == 0) &&
          (statistics.dig(:users, :new_visitors, :increase) == 0) &&
-         (statistics.dig(:users, :new_users, :increase) == 0) &&
-         (statistics.dig(:users, :active_users, :increase) == 0)
+         (statistics.dig(:users, :new_participants, :increase) == 0)
       )
     end
 

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/moderator_digest.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/moderator_digest.rb
@@ -119,23 +119,23 @@ module EmailCampaigns
       comments = Comment.where(post_id: ideas.map(&:id))
       {
         activities: {
-          new_ideas_count: stat_increase(
+          new_ideas_increase: stat_increase(
             ideas.filter_map(&:published_at)
           ),
-          new_comments_count: stat_increase(
+          new_comments_increase: stat_increase(
             comments.filter_map(&:created_at)
           )
         },
         users: {
-          new_participants_count: participants_increase
+          new_participants_increase: participants_increase
         }
       }
     end
 
     def zero_statistics?(statistics)
-      ((statistics.dig(:activities, :new_ideas_count) == 0) &&
-         (statistics.dig(:activities, :new_comments_count) == 0) &&
-         (statistics.dig(:users, :new_participants_count) == 0)
+      ((statistics.dig(:activities, :new_ideas_increase) == 0) &&
+         (statistics.dig(:activities, :new_comments_increase) == 0) &&
+         (statistics.dig(:users, :new_participants_increase) == 0)
       )
     end
 
@@ -181,8 +181,8 @@ module EmailCampaigns
 
     def idea_activity_count(idea)
       new_reactions_count = idea.reactions.where('created_at > ?', Time.now - days_ago).count
-      new_comments_count = idea.comments.where('created_at > ?', Time.now - days_ago).count
-      new_reactions_count + new_comments_count
+      new_comments_increase = idea.comments.where('created_at > ?', Time.now - days_ago).count
+      new_reactions_count + new_comments_increase
     end
 
     protected

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/moderator_digest.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/moderator_digest.rb
@@ -115,7 +115,6 @@ module EmailCampaigns
     def statistics(project)
       ps = ParticipantsService.new
       participants_increase = ps.projects_participants([project], since: (Time.now - days_ago)).size
-      participants_past_increase = ps.projects_participants([project], since: (Time.now - (days_ago * 2))).size - participants_increase
       ideas = Idea.published.where(project_id: project.id).load
       comments = Comment.where(post_id: ideas.map(&:id))
       reactions = Reaction.where(reactable_id: (ideas.map(&:id) + comments.map(&:id)))
@@ -132,19 +131,16 @@ module EmailCampaigns
           )
         },
         users: {
-          new_participants: {
-            increase: participants_increase,
-            past_increase: participants_past_increase
-          }
+          new_participants: participants_increase
         }
       }
     end
 
     def zero_statistics?(statistics)
-      ((statistics.dig(:activities, :new_ideas, :increase) == 0) &&
-         (statistics.dig(:activities, :new_reactions, :increase) == 0) &&
-         (statistics.dig(:activities, :new_comments, :increase) == 0) &&
-         (statistics.dig(:users, :new_participants, :increase) == 0)
+      ((statistics.dig(:activities, :new_ideas) == 0) &&
+         (statistics.dig(:activities, :new_reactions) == 0) &&
+         (statistics.dig(:activities, :new_comments) == 0) &&
+         (statistics.dig(:users, :new_participants) == 0)
       )
     end
 
@@ -157,10 +153,8 @@ module EmailCampaigns
     def stat_increase(ts)
       second_last_agos = ts.select { |t| t > (Time.now - (days_ago * 2)) }
       last_agos = second_last_agos.select { |t| t > (Time.now - days_ago) }
-      {
-        increase: last_agos.size,
-        past_increase: second_last_agos.size
-      }
+
+      last_agos.size
     end
 
     # @param [UserDisplayNameService] name_service

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/moderator_digest.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/moderator_digest.rb
@@ -145,8 +145,8 @@ module EmailCampaigns
       ((t2 - t1) / 1.day).days
     end
 
-    def stat_increase(dates = [])
-      dates.count { |t| t > (Time.now - days_ago) }
+    def stat_increase(stat_dates = [])
+      stat_dates.count { |t| t > (Time.now - days_ago) }
     end
 
     # @param [UserDisplayNameService] name_service

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/moderator_digest.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/moderator_digest.rb
@@ -146,11 +146,8 @@ module EmailCampaigns
       ((t2 - t1) / 1.day).days
     end
 
-    def stat_increase(ts)
-      second_last_agos = ts.select { |t| t > (Time.now - (days_ago * 2)) }
-      last_agos = second_last_agos.select { |t| t > (Time.now - days_ago) }
-
-      last_agos.size
+    def stat_increase(dates = [])
+      dates.count { |t| t > (Time.now - days_ago) }
     end
 
     # @param [UserDisplayNameService] name_service

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/moderator_digest.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/moderator_digest.rb
@@ -118,24 +118,16 @@ module EmailCampaigns
       ideas = Idea.published.where(project_id: project.id).load
       comments = Comment.where(post_id: ideas.map(&:id))
       {
-        activities: {
-          new_ideas_increase: stat_increase(
-            ideas.filter_map(&:published_at)
-          ),
-          new_comments_increase: stat_increase(
-            comments.filter_map(&:created_at)
-          )
-        },
-        users: {
-          new_participants_increase: participants_increase
-        }
+        new_ideas_increase: stat_increase(ideas.filter_map(&:published_at)),
+        new_comments_increase: stat_increase(comments.filter_map(&:created_at)),
+        new_participants_increase: participants_increase
       }
     end
 
     def zero_statistics?(statistics)
-      ((statistics.dig(:activities, :new_ideas_increase) == 0) &&
-         (statistics.dig(:activities, :new_comments_increase) == 0) &&
-         (statistics.dig(:users, :new_participants_increase) == 0)
+      ((statistics[:new_ideas_increase] == 0) &&
+         (statistics[:new_comments_increase] == 0) &&
+         (statistics[:new_participants_increase] == 0)
       )
     end
 

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/moderator_digest.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/moderator_digest.rb
@@ -129,26 +129,21 @@ module EmailCampaigns
           ),
           new_comments: stat_increase(
             comments.filter_map(&:created_at)
-          ),
-          total_ideas: ideas.size
+          )
         },
         users: {
-          new_visitors: stat_increase(
-            []
-          ),
           new_participants: {
             increase: participants_increase,
             past_increase: participants_past_increase
-          },
-          total_participants: ps.projects_participants([project]).size
+          }
         }
       }
     end
 
     def zero_statistics?(statistics)
       ((statistics.dig(:activities, :new_ideas, :increase) == 0) &&
+         (statistics.dig(:activities, :new_reactions, :increase) == 0) &&
          (statistics.dig(:activities, :new_comments, :increase) == 0) &&
-         (statistics.dig(:users, :new_visitors, :increase) == 0) &&
          (statistics.dig(:users, :new_participants, :increase) == 0)
       )
     end

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/moderator_digest.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/moderator_digest.rb
@@ -117,14 +117,11 @@ module EmailCampaigns
       participants_increase = ps.projects_participants([project], since: (Time.now - days_ago)).size
       ideas = Idea.published.where(project_id: project.id).load
       comments = Comment.where(post_id: ideas.map(&:id))
-      reactions = Reaction.where(reactable_id: (ideas.map(&:id) + comments.map(&:id)))
+      # reactions = Reaction.where(reactable_id: (ideas.map(&:id) + comments.map(&:id)))
       {
         activities: {
           new_ideas_count: stat_increase(
             ideas.filter_map(&:published_at)
-          ),
-          new_reactions_count: stat_increase(
-            reactions.filter_map(&:created_at)
           ),
           new_comments_count: stat_increase(
             comments.filter_map(&:created_at)
@@ -138,7 +135,6 @@ module EmailCampaigns
 
     def zero_statistics?(statistics)
       ((statistics.dig(:activities, :new_ideas_count) == 0) &&
-         (statistics.dig(:activities, :new_reactions_count) == 0) &&
          (statistics.dig(:activities, :new_comments_count) == 0) &&
          (statistics.dig(:users, :new_participants_count) == 0)
       )

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/moderator_digest.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/moderator_digest.rb
@@ -120,27 +120,27 @@ module EmailCampaigns
       reactions = Reaction.where(reactable_id: (ideas.map(&:id) + comments.map(&:id)))
       {
         activities: {
-          new_ideas: stat_increase(
+          new_ideas_count: stat_increase(
             ideas.filter_map(&:published_at)
           ),
-          new_reactions: stat_increase(
+          new_reactions_count: stat_increase(
             reactions.filter_map(&:created_at)
           ),
-          new_comments: stat_increase(
+          new_comments_count: stat_increase(
             comments.filter_map(&:created_at)
           )
         },
         users: {
-          new_participants: participants_increase
+          new_participants_count: participants_increase
         }
       }
     end
 
     def zero_statistics?(statistics)
-      ((statistics.dig(:activities, :new_ideas) == 0) &&
-         (statistics.dig(:activities, :new_reactions) == 0) &&
-         (statistics.dig(:activities, :new_comments) == 0) &&
-         (statistics.dig(:users, :new_participants) == 0)
+      ((statistics.dig(:activities, :new_ideas_count) == 0) &&
+         (statistics.dig(:activities, :new_reactions_count) == 0) &&
+         (statistics.dig(:activities, :new_comments_count) == 0) &&
+         (statistics.dig(:users, :new_participants_count) == 0)
       )
     end
 

--- a/back/engines/free/email_campaigns/app/views/email_campaigns/admin_digest_mailer/_statistics.mjml
+++ b/back/engines/free/email_campaigns/app/views/email_campaigns/admin_digest_mailer/_statistics.mjml
@@ -4,7 +4,7 @@
   <mj-section padding="25px" border="1px solid #EAEAEA" border-radius="5px">
     <mj-column>
       <mj-text font-size="28px" align="center" font-weight="700">
-        <%= count_from(event.statistics.users.new_users.increase) %>
+        <%= count_from(event.statistics.users.new_users_count) %>
         <img
           alt="User icon"
           width="29px"
@@ -18,7 +18,7 @@
 
     <mj-column>
       <mj-text font-size="28px" align="center" font-weight="700">
-        <%= count_from(event.statistics.activities.new_ideas.increase) %>
+        <%= count_from(event.statistics.activities.new_ideas_count) %>
         <img
           alt="Idea icon"
           width="24px"
@@ -32,7 +32,7 @@
 
     <mj-column>
       <mj-text font-size="28px" align="center" font-weight="700">
-        <%= count_from(event.statistics.activities.new_comments.increase) %>
+        <%= count_from(event.statistics.activities.new_comments_count) %>
         <img
           alt="Comment icon"
           width="26px"

--- a/back/engines/free/email_campaigns/app/views/email_campaigns/admin_digest_mailer/_statistics.mjml
+++ b/back/engines/free/email_campaigns/app/views/email_campaigns/admin_digest_mailer/_statistics.mjml
@@ -4,7 +4,7 @@
   <mj-section padding="25px" border="1px solid #EAEAEA" border-radius="5px">
     <mj-column>
       <mj-text font-size="28px" align="center" font-weight="700">
-        <%= count_from(event.statistics.users.new_users_count) %>
+        <%= count_from(event.statistics.users.new_users_increase) %>
         <img
           alt="User icon"
           width="29px"
@@ -18,7 +18,7 @@
 
     <mj-column>
       <mj-text font-size="28px" align="center" font-weight="700">
-        <%= count_from(event.statistics.activities.new_ideas_count) %>
+        <%= count_from(event.statistics.activities.new_ideas_increase) %>
         <img
           alt="Idea icon"
           width="24px"
@@ -32,7 +32,7 @@
 
     <mj-column>
       <mj-text font-size="28px" align="center" font-weight="700">
-        <%= count_from(event.statistics.activities.new_comments_count) %>
+        <%= count_from(event.statistics.activities.new_comments_increase) %>
         <img
           alt="Comment icon"
           width="26px"

--- a/back/engines/free/email_campaigns/app/views/email_campaigns/admin_digest_mailer/_statistics.mjml
+++ b/back/engines/free/email_campaigns/app/views/email_campaigns/admin_digest_mailer/_statistics.mjml
@@ -4,7 +4,7 @@
   <mj-section padding="25px" border="1px solid #EAEAEA" border-radius="5px">
     <mj-column>
       <mj-text font-size="28px" align="center" font-weight="700">
-        <%= count_from(event.statistics.users.new_users_increase) %>
+        <%= count_from(event.statistics.new_users_increase) %>
         <img
           alt="User icon"
           width="29px"
@@ -18,7 +18,7 @@
 
     <mj-column>
       <mj-text font-size="28px" align="center" font-weight="700">
-        <%= count_from(event.statistics.activities.new_ideas_increase) %>
+        <%= count_from(event.statistics.new_ideas_increase) %>
         <img
           alt="Idea icon"
           width="24px"
@@ -32,7 +32,7 @@
 
     <mj-column>
       <mj-text font-size="28px" align="center" font-weight="700">
-        <%= count_from(event.statistics.activities.new_comments_increase) %>
+        <%= count_from(event.statistics.new_comments_increase) %>
         <img
           alt="Comment icon"
           width="26px"

--- a/back/engines/free/email_campaigns/app/views/email_campaigns/moderator_digest_mailer/campaign_mail.mjml
+++ b/back/engines/free/email_campaigns/app/views/email_campaigns/moderator_digest_mailer/campaign_mail.mjml
@@ -35,7 +35,7 @@
 
     <mj-column>
       <mj-text font-size="28px" align="center" font-weight="700">
-        <%= event.activities.new_ideas_increase %>
+        <%= event.statistics.new_ideas_increase %>
         <img
           alt="Idea icon"
           width="24px"
@@ -49,7 +49,7 @@
 
     <mj-column>
       <mj-text font-size="28px" align="center" font-weight="700">
-        <%= event.activities.new_comments_increase %>
+        <%= event.statistics.new_comments_increase %>
         <img
           alt="Comment icon"
           width="26px"

--- a/back/engines/free/email_campaigns/app/views/email_campaigns/moderator_digest_mailer/campaign_mail.mjml
+++ b/back/engines/free/email_campaigns/app/views/email_campaigns/moderator_digest_mailer/campaign_mail.mjml
@@ -21,7 +21,7 @@
   >
     <mj-column>
       <mj-text font-size="28px" align="center" font-weight="700">
-        <%= event.statistics.users.new_participants.increase %>
+        <%= event.statistics.users.new_participants_count %>
         <img
           alt="User icon"
           width="29px"
@@ -35,7 +35,7 @@
 
     <mj-column>
       <mj-text font-size="28px" align="center" font-weight="700">
-        <%= event.statistics.activities.new_ideas.increase %>
+        <%= event.statistics.activities.new_ideas_count %>
         <img
           alt="Idea icon"
           width="24px"
@@ -49,7 +49,7 @@
 
     <mj-column>
       <mj-text font-size="28px" align="center" font-weight="700">
-        <%= event.statistics.activities.new_comments.increase %>
+        <%= event.statistics.activities.new_comments_count %>
         <img
           alt="Comment icon"
           width="26px"

--- a/back/engines/free/email_campaigns/app/views/email_campaigns/moderator_digest_mailer/campaign_mail.mjml
+++ b/back/engines/free/email_campaigns/app/views/email_campaigns/moderator_digest_mailer/campaign_mail.mjml
@@ -21,7 +21,7 @@
   >
     <mj-column>
       <mj-text font-size="28px" align="center" font-weight="700">
-        <%= event.statistics.users.new_participants_count %>
+        <%= event.statistics.users.new_participants_increase %>
         <img
           alt="User icon"
           width="29px"
@@ -35,7 +35,7 @@
 
     <mj-column>
       <mj-text font-size="28px" align="center" font-weight="700">
-        <%= event.statistics.activities.new_ideas_count %>
+        <%= event.statistics.activities.new_ideas_increase %>
         <img
           alt="Idea icon"
           width="24px"
@@ -49,7 +49,7 @@
 
     <mj-column>
       <mj-text font-size="28px" align="center" font-weight="700">
-        <%= event.statistics.activities.new_comments_count %>
+        <%= event.statistics.activities.new_comments_increase %>
         <img
           alt="Comment icon"
           width="26px"

--- a/back/engines/free/email_campaigns/app/views/email_campaigns/moderator_digest_mailer/campaign_mail.mjml
+++ b/back/engines/free/email_campaigns/app/views/email_campaigns/moderator_digest_mailer/campaign_mail.mjml
@@ -21,7 +21,7 @@
   >
     <mj-column>
       <mj-text font-size="28px" align="center" font-weight="700">
-        <%= event.statistics.users.new_participants_increase %>
+        <%= event.statistics.new_participants_increase %>
         <img
           alt="User icon"
           width="29px"
@@ -35,7 +35,7 @@
 
     <mj-column>
       <mj-text font-size="28px" align="center" font-weight="700">
-        <%= event.statistics.activities.new_ideas_increase %>
+        <%= event.activities.new_ideas_increase %>
         <img
           alt="Idea icon"
           width="24px"
@@ -49,7 +49,7 @@
 
     <mj-column>
       <mj-text font-size="28px" align="center" font-weight="700">
-        <%= event.statistics.activities.new_comments_increase %>
+        <%= event.activities.new_comments_increase %>
         <img
           alt="Comment icon"
           width="26px"

--- a/back/engines/free/email_campaigns/spec/mailers/previews/email_campaigns/admin_digest_mailer_preview.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/previews/email_campaigns/admin_digest_mailer_preview.rb
@@ -13,13 +13,9 @@ module EmailCampaigns
         recipient: recipient_user,
         event_payload: {
           statistics: {
-            activities: {
-              new_ideas_increase: 1,
-              new_comments_increase: 1
-            },
-            users: {
-              new_users_increase: 1
-            }
+            new_ideas_increase: 1,
+            new_comments_increase: 1,
+            new_users_increase: 1
           },
           top_project_ideas: [
             {

--- a/back/engines/free/email_campaigns/spec/mailers/previews/email_campaigns/admin_digest_mailer_preview.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/previews/email_campaigns/admin_digest_mailer_preview.rb
@@ -14,11 +14,11 @@ module EmailCampaigns
         event_payload: {
           statistics: {
             activities: {
-              new_ideas_count: 1,
-              new_comments_count: 1
+              new_ideas_increase: 1,
+              new_comments_increase: 1
             },
             users: {
-              new_users_count: 1
+              new_users_increase: 1
             }
           },
           top_project_ideas: [

--- a/back/engines/free/email_campaigns/spec/mailers/previews/email_campaigns/admin_digest_mailer_preview.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/previews/email_campaigns/admin_digest_mailer_preview.rb
@@ -14,11 +14,11 @@ module EmailCampaigns
         event_payload: {
           statistics: {
             activities: {
-              new_ideas_count: { increase: 1 },
-              new_comments_count: { increase: 1 }
+              new_ideas_count: 1,
+              new_comments_count: 1
             },
             users: {
-              new_users_count: { increase: 1 }
+              new_users_count: 1
             }
           },
           top_project_ideas: [

--- a/back/engines/free/email_campaigns/spec/mailers/previews/email_campaigns/admin_digest_mailer_preview.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/previews/email_campaigns/admin_digest_mailer_preview.rb
@@ -14,18 +14,11 @@ module EmailCampaigns
         event_payload: {
           statistics: {
             activities: {
-              new_ideas: { increase: 1 },
-              new_initiatives: { increase: 1 },
-              new_reactions: { increase: 1 },
-              new_comments: { increase: 1 },
-              total_ideas: 1,
-              total_initiatives: 2,
-              total_users: 3
+              new_ideas_count: { increase: 1 },
+              new_comments_count: { increase: 1 }
             },
             users: {
-              new_visitors: { increase: 1 },
-              new_users: { increase: 1 },
-              active_users: { increase: 1 }
+              new_users_count: { increase: 1 }
             }
           },
           top_project_ideas: [

--- a/back/engines/free/email_campaigns/spec/mailers/previews/email_campaigns/moderator_digest_mailer_preview.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/previews/email_campaigns/moderator_digest_mailer_preview.rb
@@ -20,7 +20,6 @@ module EmailCampaigns
           statistics: {
             activities: {
               new_ideas_count: 3,
-              new_reactions_count: 2,
               new_comments_count: 2
             },
             users: {

--- a/back/engines/free/email_campaigns/spec/mailers/previews/email_campaigns/moderator_digest_mailer_preview.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/previews/email_campaigns/moderator_digest_mailer_preview.rb
@@ -18,13 +18,9 @@ module EmailCampaigns
           project_id: project_id,
           project_name: project_name,
           statistics: {
-            activities: {
-              new_ideas_increase: 3,
-              new_comments_increase: 2
-            },
-            users: {
-              new_participants_increase: 0
-            }
+            new_ideas_increase: 3,
+            new_comments_increase: 2,
+            new_participants_increase: 0
           },
           top_ideas: top_ideas.map do |idea|
             new_reactions = idea.reactions.where('created_at > ?', Time.now - 7)

--- a/back/engines/free/email_campaigns/spec/mailers/previews/email_campaigns/moderator_digest_mailer_preview.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/previews/email_campaigns/moderator_digest_mailer_preview.rb
@@ -19,11 +19,11 @@ module EmailCampaigns
           project_name: project_name,
           statistics: {
             activities: {
-              new_ideas_count: 3,
-              new_comments_count: 2
+              new_ideas_increase: 3,
+              new_comments_increase: 2
             },
             users: {
-              new_participants_count: 0
+              new_participants_increase: 0
             }
           },
           top_ideas: top_ideas.map do |idea|

--- a/back/engines/free/email_campaigns/spec/mailers/previews/email_campaigns/moderator_digest_mailer_preview.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/previews/email_campaigns/moderator_digest_mailer_preview.rb
@@ -19,27 +19,12 @@ module EmailCampaigns
           project_name: project_name,
           statistics: {
             activities: {
-              new_ideas: {
-                increase: 3,
-                past_increase: 4
-              },
-              new_reactions: {
-                increase: 2,
-                past_increase: 4
-              },
-              new_comments: {
-                increase: 2,
-                past_increase: 3
-              },
-              total_ideas: 100
+              new_ideas_count: 3,
+              new_reactions_count: 2,
+              new_comments_count: 2
             },
             users: {
-              new_visitors: 0,
-              new_participants: {
-                increase: 0,
-                past_increase: 3
-              },
-              total_participants: 0
+              new_participants_count: 0
             }
           },
           top_ideas: top_ideas.map do |idea|

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/admin_digest_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/admin_digest_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe EmailCampaigns::Campaigns::AdminDigest do
   describe '#generate_commands' do
     let(:campaign) { create(:admin_digest_campaign) }
     let!(:admin) { create(:admin) }
-    let!(:old_ideas) { create_list(:idea, 2, published_at: 20.days.ago) }
+    let!(:old_ideas) { create_list(:idea, 2, published_at: 50.days.ago) }
     let!(:new_ideas) { create_list(:idea, 3, published_at: 1.day.ago) }
     let!(:reaction) { create(:reaction, mode: 'up', reactable: new_ideas.first) }
     let!(:draft) { create(:idea, publication_status: 'draft') }
@@ -19,11 +19,11 @@ RSpec.describe EmailCampaigns::Campaigns::AdminDigest do
       command = campaign.generate_commands(recipient: admin).first
 
       expect(
-        command.dig(:event_payload, :statistics, :activities, :new_ideas, :increase)
+        command.dig(:event_payload, :statistics, :activities, :new_ideas_count)
       ).to eq(new_ideas.size)
       expect(
-        command.dig(:event_payload, :statistics, :activities, :new_reactions, :increase)
-      ).to eq(1)
+        command.dig(:event_payload, :statistics, :activities, :new_comments_count)
+      ).to eq(0)
       expect(
         command.dig(:event_payload, :top_project_ideas).flat_map { |tpi| tpi[:top_ideas].pluck(:id) }
       ).to include(new_ideas.first.id)

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/admin_digest_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/admin_digest_spec.rb
@@ -82,4 +82,19 @@ RSpec.describe EmailCampaigns::Campaigns::AdminDigest do
       expect(campaign.apply_recipient_filters).to match([admin])
     end
   end
+
+  describe 'content_worth_sending?' do
+    let(:campaign) { build(:admin_digest_campaign) }
+    let(:project) { create(:continuous_project, participation_method: 'ideation') }
+
+    it 'returns false when no significant stats' do
+      expect(campaign.send(:content_worth_sending?, {})).to be false
+    end
+
+    it 'returns true when significant stats' do
+      create(:idea, project: project)
+
+      expect(campaign.send(:content_worth_sending?, {})).to be true
+    end
+  end
 end

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/admin_digest_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/admin_digest_spec.rb
@@ -19,10 +19,10 @@ RSpec.describe EmailCampaigns::Campaigns::AdminDigest do
       command = campaign.generate_commands(recipient: admin).first
 
       expect(
-        command.dig(:event_payload, :statistics, :activities, :new_ideas_count)
+        command.dig(:event_payload, :statistics, :activities, :new_ideas_increase)
       ).to eq(new_ideas.size)
       expect(
-        command.dig(:event_payload, :statistics, :activities, :new_comments_count)
+        command.dig(:event_payload, :statistics, :activities, :new_comments_increase)
       ).to eq(0)
       expect(
         command.dig(:event_payload, :top_project_ideas).flat_map { |tpi| tpi[:top_ideas].pluck(:id) }

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/admin_digest_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/admin_digest_spec.rb
@@ -19,10 +19,10 @@ RSpec.describe EmailCampaigns::Campaigns::AdminDigest do
       command = campaign.generate_commands(recipient: admin).first
 
       expect(
-        command.dig(:event_payload, :statistics, :activities, :new_ideas_increase)
+        command.dig(:event_payload, :statistics, :new_ideas_increase)
       ).to eq(new_ideas.size)
       expect(
-        command.dig(:event_payload, :statistics, :activities, :new_comments_increase)
+        command.dig(:event_payload, :statistics, :new_comments_increase)
       ).to eq(0)
       expect(
         command.dig(:event_payload, :top_project_ideas).flat_map { |tpi| tpi[:top_ideas].pluck(:id) }

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/admin_digest_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/admin_digest_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe EmailCampaigns::Campaigns::AdminDigest do
   describe '#generate_commands' do
     let(:campaign) { create(:admin_digest_campaign) }
     let!(:admin) { create(:admin) }
-    let!(:old_ideas) { create_list(:idea, 2, published_at: 50.days.ago) }
+    let!(:old_ideas) { create_list(:idea, 2, published_at: 20.days.ago) }
     let!(:new_ideas) { create_list(:idea, 3, published_at: 1.day.ago) }
     let!(:reaction) { create(:reaction, mode: 'up', reactable: new_ideas.first) }
     let!(:draft) { create(:idea, publication_status: 'draft') }

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/moderator_digest_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/moderator_digest_spec.rb
@@ -99,4 +99,23 @@ RSpec.describe 'EmailCampaigns::Campaigns::ModeratorDigest', skip: skip_reason d
       expect(campaign.apply_recipient_filters).to match([moderator])
     end
   end
+
+  describe 'zero_statistics?' do
+    let(:campaign) { build(:moderator_digest_campaign) }
+    let(:project) { create(:project) }
+
+    it 'returns true when no significant stats' do
+      stats = { activities:
+                { new_ideas: { increase: 0, past_increase: 0 },
+                  new_reactions: { increase: 0, past_increase: 0 },
+                  new_comments: { increase: 0, past_increase: 0 },
+                  total_ideas: 0 },
+                users:
+                { new_visitors: { increase: 0, past_increase: 0 },
+                  new_participants: { increase: 0, past_increase: 0 },
+                  total_participants: 0 } }
+      pp stats
+      expect(campaign.send(:zero_statistics?, stats)).to be true
+    end
+  end
 end

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/moderator_digest_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/moderator_digest_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe 'EmailCampaigns::Campaigns::ModeratorDigest', skip: skip_reason d
     let!(:old_ideas) { create_list(:idea, 2, project: project, published_at: 20.days.ago) }
     let!(:new_ideas) { create_list(:idea, 3, project: project, published_at: 1.day.ago) }
     let!(:reaction) { create(:reaction, mode: 'up', reactable: new_ideas.first) }
+    let!(:comment) { create(:comment, idea: old_ideas[0]) }
     let!(:other_idea) { create(:idea, project: create(:project)) }
     let!(:draft) { create(:idea, project: project, publication_status: 'draft') }
 
@@ -28,7 +29,7 @@ RSpec.describe 'EmailCampaigns::Campaigns::ModeratorDigest', skip: skip_reason d
         command.dig(:event_payload, :statistics, :activities, :new_ideas_count)
       ).to eq(new_ideas.size)
       expect(
-        command.dig(:event_payload, :statistics, :activities, :new_reactions_count)
+        command.dig(:event_payload, :statistics, :activities, :new_comments_count)
       ).to eq(1)
       expect(
         command.dig(:event_payload, :top_ideas).pluck(:id)
@@ -108,22 +109,20 @@ RSpec.describe 'EmailCampaigns::Campaigns::ModeratorDigest', skip: skip_reason d
       pp campaign.send(:statistics, project)
 
       stats = { activities:
-                { new_ideas: 0,
-                  new_reactions: 0,
-                  new_comments: 0 },
+                { new_ideas_count: 0,
+                  new_comments_count: 0 },
                 users:
-                { new_participants: 0 } }
+                { new_participants_count: 0 } }
 
       expect(campaign.send(:zero_statistics?, stats)).to be true
     end
 
     it 'returns false when significant stats' do
       stats = { activities:
-                { new_ideas: 1,
-                  new_reactions: 0,
-                  new_comments: 0 },
+                { new_ideas_count: 1,
+                  new_comments_count: 0 },
                 users:
-                { new_participants: 0 } }
+                { new_participants_count: 0 } }
 
       expect(campaign.send(:zero_statistics?, stats)).to be false
     end

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/moderator_digest_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/moderator_digest_spec.rb
@@ -25,10 +25,10 @@ RSpec.describe 'EmailCampaigns::Campaigns::ModeratorDigest', skip: skip_reason d
       command = campaign.generate_commands(recipient: moderator).first
 
       expect(
-        command.dig(:event_payload, :statistics, :activities, :new_ideas, :increase)
+        command.dig(:event_payload, :statistics, :activities, :new_ideas_count)
       ).to eq(new_ideas.size)
       expect(
-        command.dig(:event_payload, :statistics, :activities, :new_reactions, :increase)
+        command.dig(:event_payload, :statistics, :activities, :new_reactions_count)
       ).to eq(1)
       expect(
         command.dig(:event_payload, :top_ideas).pluck(:id)

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/moderator_digest_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/moderator_digest_spec.rb
@@ -26,10 +26,10 @@ RSpec.describe 'EmailCampaigns::Campaigns::ModeratorDigest', skip: skip_reason d
       command = campaign.generate_commands(recipient: moderator).first
 
       expect(
-        command.dig(:event_payload, :statistics, :activities, :new_ideas_increase)
+        command.dig(:event_payload, :statistics, :new_ideas_increase)
       ).to eq(new_ideas.size)
       expect(
-        command.dig(:event_payload, :statistics, :activities, :new_comments_increase)
+        command.dig(:event_payload, :statistics, :new_comments_increase)
       ).to eq(1)
       expect(
         command.dig(:event_payload, :top_ideas).pluck(:id)
@@ -108,21 +108,17 @@ RSpec.describe 'EmailCampaigns::Campaigns::ModeratorDigest', skip: skip_reason d
     it 'returns true when no significant stats' do
       pp campaign.send(:statistics, project)
 
-      stats = { activities:
-                { new_ideas_increase: 0,
-                  new_comments_increase: 0 },
-                users:
-                { new_participants_increase: 0 } }
+      stats = { new_ideas_increase: 0,
+                new_comments_increase: 0,
+                new_participants_increase: 0 }
 
       expect(campaign.send(:zero_statistics?, stats)).to be true
     end
 
     it 'returns false when significant stats' do
-      stats = { activities:
-                { new_ideas_increase: 1,
-                  new_comments_increase: 0 },
-                users:
-                { new_participants_increase: 0 } }
+      stats = { new_ideas_increase: 1,
+                new_comments_increase: 0,
+                new_participants_increase: 0 }
 
       expect(campaign.send(:zero_statistics?, stats)).to be false
     end

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/moderator_digest_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/moderator_digest_spec.rb
@@ -108,14 +108,22 @@ RSpec.describe 'EmailCampaigns::Campaigns::ModeratorDigest', skip: skip_reason d
       stats = { activities:
                 { new_ideas: { increase: 0, past_increase: 0 },
                   new_reactions: { increase: 0, past_increase: 0 },
-                  new_comments: { increase: 0, past_increase: 0 },
-                  total_ideas: 0 },
+                  new_comments: { increase: 0, past_increase: 0 } },
                 users:
-                { new_visitors: { increase: 0, past_increase: 0 },
-                  new_participants: { increase: 0, past_increase: 0 },
-                  total_participants: 0 } }
-      pp stats
+                { new_participants: { increase: 0, past_increase: 0 } } }
+
       expect(campaign.send(:zero_statistics?, stats)).to be true
+    end
+
+    it 'returns false when significant stats' do
+      stats = { activities:
+                { new_ideas: { increase: 1, past_increase: 0 },
+                  new_reactions: { increase: 0, past_increase: 0 },
+                  new_comments: { increase: 0, past_increase: 0 } },
+                users:
+                { new_participants: { increase: 0, past_increase: 0 } } }
+
+      expect(campaign.send(:zero_statistics?, stats)).to be false
     end
   end
 end

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/moderator_digest_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/moderator_digest_spec.rb
@@ -105,23 +105,25 @@ RSpec.describe 'EmailCampaigns::Campaigns::ModeratorDigest', skip: skip_reason d
     let(:project) { create(:project) }
 
     it 'returns true when no significant stats' do
+      pp campaign.send(:statistics, project)
+
       stats = { activities:
-                { new_ideas: { increase: 0, past_increase: 0 },
-                  new_reactions: { increase: 0, past_increase: 0 },
-                  new_comments: { increase: 0, past_increase: 0 } },
+                { new_ideas: 0,
+                  new_reactions: 0,
+                  new_comments: 0 },
                 users:
-                { new_participants: { increase: 0, past_increase: 0 } } }
+                { new_participants: 0 } }
 
       expect(campaign.send(:zero_statistics?, stats)).to be true
     end
 
     it 'returns false when significant stats' do
       stats = { activities:
-                { new_ideas: { increase: 1, past_increase: 0 },
-                  new_reactions: { increase: 0, past_increase: 0 },
-                  new_comments: { increase: 0, past_increase: 0 } },
+                { new_ideas: 1,
+                  new_reactions: 0,
+                  new_comments: 0 },
                 users:
-                { new_participants: { increase: 0, past_increase: 0 } } }
+                { new_participants: 0 } }
 
       expect(campaign.send(:zero_statistics?, stats)).to be false
     end

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/moderator_digest_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/moderator_digest_spec.rb
@@ -26,10 +26,10 @@ RSpec.describe 'EmailCampaigns::Campaigns::ModeratorDigest', skip: skip_reason d
       command = campaign.generate_commands(recipient: moderator).first
 
       expect(
-        command.dig(:event_payload, :statistics, :activities, :new_ideas_count)
+        command.dig(:event_payload, :statistics, :activities, :new_ideas_increase)
       ).to eq(new_ideas.size)
       expect(
-        command.dig(:event_payload, :statistics, :activities, :new_comments_count)
+        command.dig(:event_payload, :statistics, :activities, :new_comments_increase)
       ).to eq(1)
       expect(
         command.dig(:event_payload, :top_ideas).pluck(:id)
@@ -109,20 +109,20 @@ RSpec.describe 'EmailCampaigns::Campaigns::ModeratorDigest', skip: skip_reason d
       pp campaign.send(:statistics, project)
 
       stats = { activities:
-                { new_ideas_count: 0,
-                  new_comments_count: 0 },
+                { new_ideas_increase: 0,
+                  new_comments_increase: 0 },
                 users:
-                { new_participants_count: 0 } }
+                { new_participants_increase: 0 } }
 
       expect(campaign.send(:zero_statistics?, stats)).to be true
     end
 
     it 'returns false when significant stats' do
       stats = { activities:
-                { new_ideas_count: 1,
-                  new_comments_count: 0 },
+                { new_ideas_increase: 1,
+                  new_comments_increase: 0 },
                 users:
-                { new_participants_count: 0 } }
+                { new_participants_increase: 0 } }
 
       expect(campaign.send(:zero_statistics?, stats)).to be false
     end


### PR DESCRIPTION
## `ModeratorDigest`

The `zero_statistics?` method was checking a non-existent statistic, in this line:
```
(statistics.dig(:users, :new_users, :increase) == 0) &&
``` 
and thus would always return `false`, resulting in the possibility of sending mails with zero significant stats to display.

It now checks the relevant statistic, `:new_participants_count` (renamed from `:new_participants`), and I've added a test to catch regression.

Tested manually locally: Does not send digest for ideation project with no new ideas/comments/participants. Does send digest for ideation project with 1 new idea (and thus also 1 new participant).

## `AdminDigest`

I couldn't find any similar bug to that found in `ModeratorDigest`, or any evidence that mails can be sent when no significant stats exist. I added tests to catch regression anyway.

## General notes

We were creating waaaaay more stats than were used in the mails, so I removed all unused stats + renamed them to make their integer nature more obvious.

# Changelog
## Fixed
- [CL-3971] Do not send moderator digest mail for projects with no significant activity


[CL-3971]: https://citizenlab.atlassian.net/browse/CL-3971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ