### PR TITLE
Revert "[TAN-340] Improve logo resolution in mails"

### DIFF
--- a/back/app/mailers/application_mailer.rb
+++ b/back/app/mailers/application_mailer.rb
@@ -19,9 +19,9 @@ class ApplicationMailer < ActionMailer::Base
     :url_service, :multiloc_service, :organization_name,
     :loc, :localize_for_recipient, :recipient_first_name
 
-  helper_method :unsubscribe_url, :terms_conditions_url, :privacy_policy_url, :home_url, :logo_url, :logo_width,
-    :show_unsubscribe_link?, :show_terms_link?, :show_privacy_policy_link?, :format_message, :header_logo_only?,
-    :remove_vendor_branding?
+  helper_method :unsubscribe_url, :terms_conditions_url, :privacy_policy_url, :home_url, :logo_url,
+    :show_unsubscribe_link?, :show_terms_link?, :show_privacy_policy_link?, :format_message,
+    :header_logo_only?, :remove_vendor_branding?
 
   NotImplementedError = Class.new(StandardError)
 
@@ -172,21 +172,7 @@ class ApplicationMailer < ActionMailer::Base
 
   def logo_url
     @logo_url ||= app_configuration.logo.versions.then do |versions|
-      versions[:large].url || versions[:medium].url || versions[:small].url || ''
-    end
-  end
-
-  def logo_width
-    versions = app_configuration.logo.versions
-
-    @logo_width ||= if versions[:medium].present?
-      versions[:medium].width
-    elsif versions[:large].present?
-      versions[:large].width / 2
-    elsif versions[:small].present?
-      versions[:small].width * 2
-    else
-      0 # If logo_url is set to '' because no versions found, the width will be 0. Useful for tests without a logo.
+      versions[:medium].url || versions[:small].url || versions[:large].url || ''
     end
   end
 

--- a/back/app/views/application/_logo_medium_top.mjml
+++ b/back/app/views/application/_logo_medium_top.mjml
@@ -1,5 +1,9 @@
 <mj-section padding="20px 25px 0">
   <mj-column>
-    <mj-image align="left" width=<%= "#{logo_width}px" %> src=<%= logo_url %> href=<%= home_url %> alt="Organization logo"/>
+    <mj-raw>
+      <%= link_to home_url do %>
+        <%= image_tag logo_url, alt: 'Organization logo' %>
+      <% end %>
+    </mj-raw>
   </mj-column>
 </mj-section>


### PR DESCRIPTION
Reverts CitizenLabDotCo/citizenlab#5796

Unfortunately we cannot read the width of images from the AWS Fog items. This needs more work/thought.

# Changelog
## Fixed
- [CL-3971] Revert attempt to improve logo resolution in mails

[CL-3971]: https://citizenlab.atlassian.net/browse/CL-3971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ