### PR TITLE
[TAN-340]  Improve logo resolution in mails - v2

### DIFF
--- a/back/app/mailers/application_mailer.rb
+++ b/back/app/mailers/application_mailer.rb
@@ -172,7 +172,7 @@ class ApplicationMailer < ActionMailer::Base
 
   def logo_url
     @logo_url ||= app_configuration.logo.versions.then do |versions|
-      versions[:medium].url || versions[:small].url || versions[:large].url || ''
+      versions[:large].url || versions[:medium].url || versions[:small].url || ''
     end
   end
 

--- a/back/app/views/application/_logo_medium_top.mjml
+++ b/back/app/views/application/_logo_medium_top.mjml
@@ -1,5 +1,5 @@
 <mj-section padding="20px 25px 0">
-  <mj-column css-class="col">
+  <mj-column>
     <mj-image css-class="logo" src=<%= logo_url %> href=<%= home_url %> alt="Organization logo"/>
   </mj-column>
 </mj-section>

--- a/back/app/views/application/_logo_medium_top.mjml
+++ b/back/app/views/application/_logo_medium_top.mjml
@@ -1,9 +1,5 @@
 <mj-section padding="20px 25px 0">
-  <mj-column>
-    <mj-raw>
-      <%= link_to home_url do %>
-        <%= image_tag logo_url, alt: 'Organization logo' %>
-      <% end %>
-    </mj-raw>
+  <mj-column css-class="col">
+    <mj-image css-class="logo" src=<%= logo_url %> href=<%= home_url %> alt="Organization logo"/>
   </mj-column>
 </mj-section>

--- a/back/engines/free/email_campaigns/app/views/email_campaigns/application/_head.mjml
+++ b/back/engines/free/email_campaigns/app/views/email_campaigns/application/_head.mjml
@@ -4,7 +4,13 @@
       font-size: 25px;
       margin-bottom: 25px;
     }
+    
     a {text-decoration: none;}
+    
+    .logo img {
+      height: 80px !important;
+      width: auto !important;
+    }
 
     <%# From https://github.com/mjmlio/mjml/issues/230 %>
     <% if text_direction == "rtl" %>


### PR DESCRIPTION
Uses CSS, via `mj-style`, to set `height:80px;width:auto;`. This ,combined with preferring to use large image version when present, results in higher resolution image (when large version exists).

# Changelog
## Fixed
- [TAN-340] Improve logo resolution in mails - v2
