### PR TITLE
TAN-345 Fix auto-tagging with 10 tags selected

### DIFF
--- a/back/engines/commercial/analysis/app/lib/analysis/auto_tagging_method/label_classification.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/auto_tagging_method/label_classification.rb
@@ -84,8 +84,10 @@ module Analysis
       labels = tags.pluck(:name)
       # When using an LLM (e.g. gpt-j or llama2) the classifier has a tendency
       # to always want to assign inputs. We include an 'other' label to give it
-      # a way out, in case 'other' is not yet one of the provided labels
-      if (labels & OTHER_TERMS).empty? && labels.size < 10
+      # a way out, in case 'other' is not yet one of the provided labels Despite
+      # the NLPCloud claiming there is a max of 10 labels, we seem to get
+      # consistent errors when we go with 10 instead of 9 as the maximum
+      if (labels & OTHER_TERMS).empty? && labels.size < 9
         labels << 'other'
       end
     end

--- a/front/app/containers/Admin/projects/project/analysis/Tags/AutoTaggingModal/Step2LabelClassification.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Tags/AutoTaggingModal/Step2LabelClassification.tsx
@@ -32,7 +32,7 @@ const Step2LabelClassification = ({ onLaunch }: Props) => {
     setSelectedTagIds((tagIds) => xor(tagIds, [tagId]));
   };
 
-  const listFull = selectedTagIds.length >= 10;
+  const listFull = selectedTagIds.length >= 9;
 
   return (
     <Box>

--- a/front/app/containers/Admin/projects/project/analysis/Tags/translations.ts
+++ b/front/app/containers/Admin/projects/project/analysis/Tags/translations.ts
@@ -185,7 +185,7 @@ export default defineMessages({
   fewShotSubtitle: {
     id: 'app.containers.AdminPage.projects.project.analysis.Tags.fewShotSubtitle',
     defaultMessage:
-      'Select maximum 10 tags you would like the inputs to be distributed between.',
+      'Select maximum 9 tags you would like the inputs to be distributed between.',
   },
   fewShotSubtitle2: {
     id: 'app.containers.AdminPage.projects.project.analysis.Tags.fewShotSubtitle2',
@@ -199,7 +199,7 @@ export default defineMessages({
   byLabelSubtitle1: {
     id: 'app.containers.AdminPage.projects.project.analysis.Tags.byLabelSubtitle1',
     defaultMessage:
-      'Select maximum 10 tags you would like the inputs to be distributed between. Inputs already associated with these tags will not be classified again.',
+      'Select maximum 9 tags you would like the inputs to be distributed between. Inputs already associated with these tags will not be classified again.',
   },
   byLabelSubtitle2: {
     id: 'app.containers.AdminPage.projects.project.analysis.Tags.byLabelSubtitle2',


### PR DESCRIPTION
# Changelog
## Fixed
- Auto-tagging no longer fails when selecting 10 tags, 9 is the new maximum
