### PR TITLE
[CL-4035] Fix extension issues in test db upon running db:reset

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -52,30 +52,17 @@ make reset-dev-env
 ## Testing
 
 ### Unit and integration tests
-Resetting the database, with the previous command, upsets the testing database as well. Before running the tests, it's sometimes necessary to put it back in it's default shape. We can do this with the following command:
+To run the tests:
 
-```
-docker-compose run --rm --user "$(id -u):$(id -g)" -e RAILS_ENV=test web bundle exec rake db:environment:set db:drop db:create db:schema:load
-```
+- If you're on Linux, use this command:
+  ```bash
+  docker-compose run --rm --user "$(id -u):$(id -g)" web rspec
+  ```
 
-Mac or Windows:
-
-```
-docker-compose run --rm -e RAILS_ENV=test web bundle exec rake db:environment:set db:drop db:create db:schema:load
-```
-
-To actually run the tests:
-```
-docker-compose run --rm --user "$(id -u):$(id -g)" web rspec
-
-```
-
-Mac or Windows:
-
-```
-docker-compose run --rm web rspec
-
-```
+- If you're on Mac or Windows, run:
+  ```bash
+  docker-compose run --rm web rspec
+  ```
 
 For debugging random test failures, it's can be useful to run the tests multiple times, but stop as soon as one of the test runs fails (for Mac or Windows):
 


### PR DESCRIPTION
When db:reset was run in development, it used to “upset” the test db. In practice, “upset” means here that the extensions were not installed properly in the test db. This commit fixes that issue.

The issue stemmed from a combination of factors. Two important points to keep in mind:
- Postgres installs extensions into a specific schema (which is public by default), but it only does so once per database. Therefore, if, for instance, the hstore extension is already installed and you execute the following SQL command: ```sql CREATE EXTENSION IF NOT EXISTS hstore SCHEMA shared_extensions; ``` Postgres won't take any action.
- To access an extension, the schema in which it is installed must be in the search path. This is particularly important in our case because Apartment alters the search path and removes the public schema from it when switching to a tenant.

Hence, we must ensure that the extensions are installed in one of Apartment’s "persistent" schemas, which in our case is the shared_extensions schema (see config/initializers/apartment.rb). To achieve this, we had enhanced the db:create (and db:test:purge) rake task to install the extensions in the shared_extensions schema (check out lib/tasks/db_extensions.rake).

However despite the enhancements, it was still not working in some cases for the test db and the extensions were getting installed in the public schema when running db:reset. The reason lies in the fact that when we execute db:reset in development, it runs for both the development and test environments, and each step is executed twice. Our enhancement to the `db:create` task failed account for this, as it was only running for the development environment. Subsequently, when db:schema:load was executed for the test environment, the extensions were installed, but in the public schema instead.


# Changelog
## Technical
- Fix extension issues with the test DB when running the `db:reset` rake task for the development environment.
