### PR TITLE
[TAN-244] Verify user's date of birth with Nemlog-in

### DIFF
--- a/back/engines/commercial/id_nemlog_in/app/lib/id_nemlog_in/nemlog_in_omniauth.rb
+++ b/back/engines/commercial/id_nemlog_in/app/lib/id_nemlog_in/nemlog_in_omniauth.rb
@@ -58,12 +58,14 @@ module IdNemlogIn
     def profile_to_user_attrs(auth)
       first_name    = auth.extra.raw_info['https://data.gov.dk/model/core/eid/firstName']
       last_name     = auth.extra.raw_info['https://data.gov.dk/model/core/eid/lastName']
+      date_of_birth = auth.extra.raw_info['https://data.gov.dk/model/core/eid/dateOfBirth'] # "01-02-1999"
       cpr_number    = auth.extra.raw_info['https://data.gov.dk/model/core/eid/cprNumber']
 
       {
         first_name: first_name,
         last_name: last_name,
         custom_field_values: {
+          date_of_birth: date_of_birth,
           municipality_code: fetch_municipality_code(cpr_number)
         }
       }
@@ -112,7 +114,7 @@ module IdNemlogIn
     end
 
     def locked_custom_fields
-      %i[municipality_code]
+      %i[municipality_code date_of_birth]
     end
 
     def locked_attributes

--- a/back/engines/commercial/id_nemlog_in/spec/requests/nemlog_in_verification_spec.rb
+++ b/back/engines/commercial/id_nemlog_in/spec/requests/nemlog_in_verification_spec.rb
@@ -66,6 +66,7 @@ describe IdNemlogIn::NemlogInOmniauth do
       first_name: 'Rudolphi',
       last_name: 'Raindeari'
     })
+    expect(user.custom_field_values['date_of_birth']).to eq('28-08-1944')
     expect(user.custom_field_values).to have_key('municipality_code')
     uid = 'https://data.gov.dk/model/core/eid/professional/uuid/82dc2343-7f37-465d-a523-7f3e24feca46'
     expect(user.verifications.first).to have_attributes({


### PR DESCRIPTION
ToDo:
- [ ] add a new predicate like `was_x_years_ago` [here](https://github.com/CitizenLabDotCo/citizenlab/blob/master/back/engines/commercial/smart_groups/app/lib/smart_groups/rules/custom_field_date.rb#L81) 

# Changelog
## Added
* [TAN-244] Verify user's date of birth with Nemlog-in
