### PR TITLE
Fix width of notification

### DIFF
--- a/front/app/containers/MainHeader/NotificationMenu/components/NotificationWrapper/index.tsx
+++ b/front/app/containers/MainHeader/NotificationMenu/components/NotificationWrapper/index.tsx
@@ -5,7 +5,6 @@ import { Icon, IconNames } from '@citizenlab/cl2-component-library';
 
 // utils
 import { fontSizes, colors, media } from 'utils/styleUtils';
-import clHistory from 'utils/cl-router/history';
 import { timeAgo } from 'utils/dateUtils';
 import { trackEventByName } from 'utils/analytics';
 import tracks from '../../tracks';
@@ -13,8 +12,9 @@ import tracks from '../../tracks';
 // hooks
 import useLocale from 'hooks/useLocale';
 import { isNilOrError } from 'utils/helperUtils';
+import Link from 'utils/cl-router/Link';
 
-const Container = styled.button`
+const Container = styled(Link)`
   display: flex;
   text-align: left;
   cursor: pointer;
@@ -92,7 +92,7 @@ const Timing = styled.span`
 type Props = {
   icon?: IconNames;
   timing?: string;
-  children: any;
+  children: React.ReactNode;
   linkTo: string;
   isRead: boolean;
 };
@@ -105,16 +105,13 @@ const NotificationWrapper = ({
   linkTo,
 }: Props) => {
   const locale = useLocale();
-  const navigate = () => {
-    if (linkTo) {
-      trackEventByName(tracks.clickNotification.name, { extra: { linkTo } });
-      clHistory.push(linkTo);
-    }
+  const track = () => {
+    trackEventByName(tracks.clickNotification.name, { extra: { linkTo } });
   };
 
   if (!isNilOrError(locale)) {
     return (
-      <Container role="link" onClick={navigate}>
+      <Container to={linkTo} onClick={track}>
         <IconContainer>
           {icon && <StyledIcon name={icon} isRead={isRead} />}
         </IconContainer>


### PR DESCRIPTION
Noticed that some notifications are not full width (see screenshot). While investing, I also noticed notifications are buttons with role "link", changing this also solved the faulty width. ✅
 
<img width="1247" alt="Screenshot 2023-09-10 at 18 03 50" src="https://github.com/CitizenLabDotCo/citizenlab/assets/16427929/f2154ede-221f-4b4b-9102-756d816604b6">

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Width of some notifications