### PR TITLE
Default comment sorting new (top) to old (bottom)

### DIFF
--- a/front/app/components/PostShowComponents/Comments/PublicComments.tsx
+++ b/front/app/components/PostShowComponents/Comments/PublicComments.tsx
@@ -81,7 +81,7 @@ const PublicComments = ({
   const { data: initiative } = useInitiativeById(initiativeId);
   const { data: idea } = useIdeaById(ideaId);
   const { pathname } = useLocation();
-  const [sortOrder, setSortOrder] = useState<CommentsSort>('-new');
+  const [sortOrder, setSortOrder] = useState<CommentsSort>('new');
   const {
     data: comments,
     isFetchingNextPage,

--- a/front/app/components/admin/InternalComments/index.tsx
+++ b/front/app/components/admin/InternalComments/index.tsx
@@ -58,7 +58,7 @@ const InternalCommentsSection = ({ postId, postType, className }: Props) => {
   const ideaId = postType === 'idea' ? postId : undefined;
   const { data: initiative } = useInitiativeById(initiativeId);
   const { data: idea } = useIdeaById(ideaId);
-  const [sortOrder, setSortOrder] = useState<InternalCommentSort>('-new');
+  const [sortOrder, setSortOrder] = useState<InternalCommentSort>('new');
   const {
     data: comments,
     isFetchingNextPage,


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Changed
- The default comment sorting is now new (top) to old (bottom)