### PR TITLE
[CL-4025] Fix initiatives filter counts when using search on Proposals page

### DIFF
--- a/back/app/controllers/web_api/v1/initiatives_controller.rb
+++ b/back/app/controllers/web_api/v1/initiatives_controller.rb
@@ -67,7 +67,7 @@ class WebApi::V1::InitiativesController < ApplicationController
       .joins('FULL OUTER JOIN areas_initiatives ON areas_initiatives.initiative_id = initiatives.id')
       .joins('FULL OUTER JOIN initiative_initiative_statuses ON initiative_initiative_statuses.initiative_id = initiatives.id')
       .select('initiative_initiative_statuses.initiative_status_id, areas_initiatives.area_id, initiatives_topics.topic_id, COUNT(DISTINCT(initiatives.id)) as count')
-      .reorder(nil) # Avoids SQL error on GROUP BY when a search string was used
+      .reorder(nil) # Avoids SQL error on GROUP BY when a search string is used
       .group('GROUPING SETS (initiative_initiative_statuses.initiative_status_id, areas_initiatives.area_id, initiatives_topics.topic_id)')
       .each do |record|
         attributes.each do |attribute|
@@ -75,7 +75,7 @@ class WebApi::V1::InitiativesController < ApplicationController
           counts[attribute][id] = record.count if id
         end
       end
-    counts['total'] = initiatives.distinct.count
+    counts['total'] = initiatives.reorder(nil).distinct.count # reorder(nil) avoids SQL error on SELECT DISTINCT when a search string is used
     render json: raw_json(counts)
   end
 

--- a/back/spec/acceptance/initiatives_spec.rb
+++ b/back/spec/acceptance/initiatives_spec.rb
@@ -296,7 +296,7 @@ resource 'Initiatives' do
       assert_status 200
     end
 
-    example 'List initiative counts when also using search filtering AND ordering', document: false do
+    example 'List initiative counts when also using search filtering AND sort', document: false do
       do_request(search: 'uniqque', sort: 'new')
       assert_status 200
     end

--- a/back/spec/acceptance/initiatives_spec.rb
+++ b/back/spec/acceptance/initiatives_spec.rb
@@ -295,6 +295,11 @@ resource 'Initiatives' do
       do_request areas: [@a1.id]
       assert_status 200
     end
+
+    example 'List initiative counts when also using search filtering AND ordering', document: false do
+      do_request(search: 'uniqque', sort: 'new')
+      assert_status 200
+    end
   end
 
   get 'web_api/v1/initiatives/:id' do


### PR DESCRIPTION
# Changelog
## Fixed
[CL-4025] Counts of proposal by status on Proposals page no longer break when search is used.


[CL-4025]: https://citizenlab.atlassian.net/browse/CL-4025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ