### PR TITLE
[CL-3994] serialize app_configuration created_at + test

### DIFF
--- a/back/app/serializers/web_api/v1/app_configuration_serializer.rb
+++ b/back/app/serializers/web_api/v1/app_configuration_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class WebApi::V1::AppConfigurationSerializer < WebApi::V1::BaseSerializer
-  attributes :name, :host, :style
+  attributes :name, :host, :style, :created_at
 
   attribute :logo do |object|
     object.logo && object.logo.versions.to_h { |k, v| [k.to_s, v.url] }

--- a/back/spec/acceptance/app_configurations_spec.rb
+++ b/back/spec/acceptance/app_configurations_spec.rb
@@ -33,6 +33,8 @@ resource 'AppConfigurations' do
       json_response = json_parse(response_body)
       expect(json_response.with_indifferent_access.dig(:data, :attributes, :host)).to eq 'example.org'
       expect(json_response.with_indifferent_access.dig(:data, :attributes, :style)).to eq({})
+      expect(json_response.with_indifferent_access.dig(:data, :attributes, :created_at))
+        .to eq(AppConfiguration.instance.created_at.iso8601(3))
     end
   end
 


### PR DESCRIPTION
So that the FE can use the `created_at` date as an approximation of when platform created, for use in checking if also have visits stats for entire lifetime of platform.

# Changelog
## Technical
[CL-3994] serialize app_configuration created_at + test


[CL-3994]: https://citizenlab.atlassian.net/browse/CL-3994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ