### PR TITLE
Remove width on app container

### DIFF
--- a/front/app/containers/App/index.tsx
+++ b/front/app/containers/App/index.tsx
@@ -354,7 +354,6 @@ const App = ({ children }: Props) => {
                 </ErrorBoundary>
               )}
               <Box
-                width="100vw"
                 display="flex"
                 flexDirection="column"
                 alignItems="stretch"


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- App not using the full width on narrow mobile devices