### PR TITLE
TA-351 Filter out qualitative questions from report builder

### DIFF
--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/SurveyResultsWidget/QuestionFilter.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/SurveyResultsWidget/QuestionFilter.tsx
@@ -32,7 +32,14 @@ const QuestionFilter = ({
     phaseId,
   });
 
-  if (isNilOrError(formResults) || formResults.results.length === 0) {
+  const fitleredResults =
+    !isNilOrError(formResults) &&
+    formResults.results.filter((result) => {
+      return (
+        result.inputType !== 'text' && result.inputType !== 'multiline_text'
+      );
+    });
+  if (!fitleredResults || fitleredResults.length === 0) {
     // This never seems to get shown
     return (
       <Text variant="bodyM" color="textSecondary">
@@ -41,14 +48,12 @@ const QuestionFilter = ({
     );
   }
 
-  const { results } = formResults;
-
   // Add/remove from selected questions
   const toggleQuestion =
     (questionIndex: number) => (event: ChangeEvent<HTMLInputElement>) => {
       event.stopPropagation();
 
-      const numberOfQuestions = results.length;
+      const numberOfQuestions = fitleredResults.length;
       onToggleQuestion(questionIndex, numberOfQuestions);
     };
 
@@ -57,7 +62,7 @@ const QuestionFilter = ({
       <Text variant="bodyM" color="textSecondary">
         {formatMessage(messages.surveyChooseQuestions)}
       </Text>
-      {results.map(({ question }, index) => (
+      {fitleredResults.map(({ question }, index) => (
         <Box key={index} mb="10px">
           <Checkbox
             checked={

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/SurveyResultsWidget/SurveyResults.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/SurveyResultsWidget/SurveyResults.tsx
@@ -44,7 +44,13 @@ const SurveyResults = ({ projectId, phaseId, shownQuestions }: Props) => {
     if (isNilOrError(formResults)) return null;
 
     const { results } = formResults;
-    return createResultRows(results, shownQuestions);
+    // Filtering out qualitative questions
+    const fitleredResults = results.filter((result) => {
+      return (
+        result.inputType !== 'text' && result.inputType !== 'multiline_text'
+      );
+    });
+    return createResultRows(fitleredResults, shownQuestions);
   }, [formResults, shownQuestions]);
 
   if (


### PR DESCRIPTION
In the process of working on sense-making, we needed to add the qualitative questions `text` and `multiline_text` to the survey results endpoint. However, we don't want them to show in the report builder (yet). This PR filters them out.

# Changelog
## Fixed
- AI analysis button no longer shows in content builder (sense-making)
