### PR TITLE
[CL-4059] Serialize initiatives proposed_at

### DIFF
--- a/back/app/models/initiative.rb
+++ b/back/app/models/initiative.rb
@@ -156,11 +156,11 @@ class Initiative < ApplicationRecord
     InitiativeStatus::REVIEW_CODES.include? initiative_status&.code
   end
 
-  private
-
   def proposed_at
     initiative_status_changed_at('proposed')
   end
+
+  private
 
   def initiative_status_changed_at(initiative_status_code)
     initiative_status_changes

--- a/back/app/serializers/web_api/v1/initiative_serializer.rb
+++ b/back/app/serializers/web_api/v1/initiative_serializer.rb
@@ -19,7 +19,8 @@ class WebApi::V1::InitiativeSerializer < WebApi::V1::BaseSerializer
     :anonymous,
     :author_hash,
     :editing_locked,
-    :public
+    :public,
+    :proposed_at
 
   attribute :author_name do |object, params|
     name_service = UserDisplayNameService.new(AppConfiguration.instance, current_user(params))
@@ -48,10 +49,6 @@ class WebApi::V1::InitiativeSerializer < WebApi::V1::BaseSerializer
 
   attribute :public do |object|
     object.initiative_status ? object.initiative_status.public? : false
-  end
-
-  attribute :proposed_at do |object|
-    object.proposed_at
   end
 
   has_many :initiative_images, serializer: WebApi::V1::ImageSerializer

--- a/back/app/serializers/web_api/v1/initiative_serializer.rb
+++ b/back/app/serializers/web_api/v1/initiative_serializer.rb
@@ -50,6 +50,10 @@ class WebApi::V1::InitiativeSerializer < WebApi::V1::BaseSerializer
     object.initiative_status ? object.initiative_status.public? : false
   end
 
+  attribute :proposed_at do |object|
+    object.proposed_at
+  end
+
   has_many :initiative_images, serializer: WebApi::V1::ImageSerializer
   has_many :topics
   has_many :areas

--- a/back/spec/models/initiative_spec.rb
+++ b/back/spec/models/initiative_spec.rb
@@ -121,7 +121,14 @@ RSpec.describe Initiative do
       create(:initiative_status_proposed)
     end
 
-    let(:initiative) { create(:initiative, build_status_change: false) }
+    let(:initiative) do
+      create(
+        :initiative,
+        build_status_change: false,
+        created_at: 2.days.ago,
+        published_at: 2.days.ago
+      )
+    end
 
     it 'returns date when initiative status became proposed' do
       expect(initiative.proposed_at).to be_within(1.second).of(initiative.initiative_status_changes.first.created_at)

--- a/back/spec/models/initiative_spec.rb
+++ b/back/spec/models/initiative_spec.rb
@@ -116,10 +116,7 @@ RSpec.describe Initiative do
   end
 
   describe '#proposed_at' do
-    before do
-      allow(Time).to receive(:now).and_return(Time.now)
-      create(:initiative_status_proposed)
-    end
+    before { create(:initiative_status_proposed) }
 
     let(:initiative) do
       create(

--- a/back/spec/models/initiative_spec.rb
+++ b/back/spec/models/initiative_spec.rb
@@ -115,6 +115,19 @@ RSpec.describe Initiative do
     end
   end
 
+  describe '#proposed_at' do
+    before do
+      allow(Time).to receive(:now).and_return(Time.now)
+      create(:initiative_status_proposed)
+    end
+
+    let(:initiative) { create(:initiative, build_status_change: false) }
+
+    it 'returns date when initiative status became proposed' do
+      expect(initiative.proposed_at).to be_within(1.second).of(initiative.initiative_status_changes.first.created_at)
+    end
+  end
+
   describe '#expires_at' do
     before do
       allow(Time).to receive(:now).and_return(Time.now)

--- a/front/app/api/initiatives/__mocks__/useInitiatives.ts
+++ b/front/app/api/initiatives/__mocks__/useInitiatives.ts
@@ -25,6 +25,7 @@ export const initiativeData: IInitiativeData = {
     created_at: '2021-03-01T12:00:00.000Z',
     updated_at: '2021-03-01T12:00:00.000Z',
     expires_at: '2021-03-01T12:00:00.000Z',
+    proposed_at: '2021-03-01T12:00:00.000Z',
     header_bg: {
       small: 'http://localhost:3000/system/images/1/small/test.jpg',
       medium: 'http://localhost:3000/system/images/1/medium/test.jpg',
@@ -99,6 +100,7 @@ export const initiativesData: IInitiativeData[] = [
       created_at: '2021-03-01T12:00:00.000Z',
       updated_at: '2021-03-01T12:00:00.000Z',
       expires_at: '2021-03-01T12:00:00.000Z',
+      proposed_at: '2021-03-01T12:00:00.000Z',
       header_bg: {
         small: 'http://localhost:3000/system/images/1/small/test.jpg',
         medium: 'http://localhost:3000/system/images/1/medium/test.jpg',

--- a/front/app/api/initiatives/types.ts
+++ b/front/app/api/initiatives/types.ts
@@ -62,6 +62,7 @@ export interface IInitiativeData {
     created_at: string;
     updated_at: string;
     published_at: string;
+    proposed_at: string;
     header_bg: ImageSizes;
     expires_at: string;
     anonymous: boolean;

--- a/front/app/api/initiatives/useUpdateInitiative.test.ts
+++ b/front/app/api/initiatives/useUpdateInitiative.test.ts
@@ -34,6 +34,7 @@ export const data: IInitiativeData = {
     location_description: 'Test location',
     created_at: '2021-03-01T12:00:00.000Z',
     updated_at: '2021-03-01T12:00:00.000Z',
+    proposed_at: '2021-03-01T12:00:00.000Z',
     expires_at: '2021-03-01T12:00:00.000Z',
     header_bg: {
       small: 'http://localhost:3000/system/images/1/small/test.jpg',

--- a/front/app/components/InitiativeCard/index.tsx
+++ b/front/app/components/InitiativeCard/index.tsx
@@ -22,10 +22,6 @@ import useInitiativeImage from 'api/initiative_images/useInitiativeImage';
 import useLocalize from 'hooks/useLocalize';
 import useInitiativeById from 'api/initiatives/useInitiativeById';
 
-const StyledAuthor = styled(Author)`
-  margin-left: -4px;
-`;
-
 const FooterInner = styled.div`
   width: 100%;
   min-height: 50px;
@@ -100,12 +96,14 @@ const InitiativeCard = ({
       imageUrl={initiativeImageUrl}
       title={initiativeTitle}
       body={
-        <StyledAuthor
-          authorId={initiativeAuthorId}
-          createdAt={initiative.data.attributes.published_at}
-          size={34}
-          anonymous={initiative.data.attributes.anonymous}
-        />
+        <Box ml="-4px">
+          <Author
+            authorId={initiativeAuthorId}
+            createdAt={initiative.data.attributes.proposed_at}
+            size={34}
+            anonymous={initiative.data.attributes.anonymous}
+          />
+        </Box>
       }
       footer={
         <>

--- a/front/app/containers/InitiativesShow/InitiativeMeta.tsx
+++ b/front/app/containers/InitiativesShow/InitiativeMeta.tsx
@@ -67,7 +67,7 @@ const InitiativeMeta = ({ initiativeId }: Props) => {
       '@type': 'WebPage',
       '@id': initiativeUrl,
     },
-    datePublished: initiative.data.attributes.published_at,
+    datePublished: initiative.data.attributes.proposed_at,
   };
 
   const json = {


### PR DESCRIPTION
Serializing `Initiative.proposed_at` so the FE can use it in displaying a 'published_at' date (or time ago), because now we have the review feature the actual `published_at` date will not match the `proposed_at` date when the feature is on, and `proposed_at` is actually when it will become publiclly visible.

Note: Now that we have aligned the creation of initiatives more with that of ideas, in that we now only create the record when a new initiative form is submitted, we should probably rethink how we use publication status with initiatives. We currently don't use 'draft' status at all, and thus `published_at` is always almost the same time as `created_at`. This has been logged at platform ticket: https://citizenlab.atlassian.net/browse/CL-4066 

# Changelog
## Fixed
- [CL-4059] Use initiatives proposed_at for the publication 'time ago' on card view (now correct period when proposals review feature ON)


[CL-4059]: https://citizenlab.atlassian.net/browse/CL-4059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ