### PR TITLE
[CL-3503] Remove PII from PostHog upon the deletion of user accounts

### DIFF
--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -259,6 +259,7 @@ PATH
   remote: engines/commercial/posthog_integration
   specs:
     posthog_integration (0.1.0)
+      http (~> 5.1)
       posthog-ruby (~> 2.1)
       rails (~> 7.0)
 
@@ -593,6 +594,9 @@ GEM
       multipart-post (~> 2)
     faraday-net_http (3.0.2)
     ffi (1.15.5)
+    ffi-compiler (1.0.1)
+      ffi (>= 1.0.0)
+      rake
     fog-aws (3.19.0)
       fog-core (~> 2.1)
       fog-json (~> 1.1)
@@ -648,9 +652,15 @@ GEM
     hashdiff (1.0.1)
     hashie (5.0.0)
     htmlentities (4.3.4)
+    http (5.1.1)
+      addressable (~> 2.8)
+      http-cookie (~> 1.0)
+      http-form_data (~> 2.2)
+      llhttp-ffi (~> 0.4.0)
     http-accept (1.7.0)
     http-cookie (1.0.5)
       domain_name (~> 0.5)
+    http-form_data (2.3.0)
     httparty (0.21.0)
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
@@ -715,6 +725,9 @@ GEM
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    llhttp-ffi (0.4.0)
+      ffi-compiler (~> 1.0)
+      rake (~> 13.0)
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)

--- a/back/app/services/side_fx_user_service.rb
+++ b/back/app/services/side_fx_user_service.rb
@@ -119,3 +119,4 @@ end
 
 SideFxUserService.prepend(IdeaAssignment::Patches::SideFxUserService)
 SideFxUserService.prepend(Matomo::Patches::SideFxUserService)
+SideFxUserService.prepend(PosthogIntegration::Patches::SideFxUserService)

--- a/back/doc/dependency_decisions.yml
+++ b/back/doc/dependency_decisions.yml
@@ -169,8 +169,13 @@
 - - :approve
   - bundler-audit
   - :who:
-    :why:
-      Despite bundler-audit being a GPL utility, we're not linking against it,
+    :why: Despite bundler-audit being a GPL utility, we're not linking against it,
       but merely executing it in its distributed form as a rake task.
     :versions: []
     :when: 2022-06-17 14:33:30.806575129 Z
+- - :permit
+  - Mozilla Public License 2.0
+  - :who:
+    :why:
+    :versions: []
+    :when: 2023-09-18 09:39:49.287752000 Z

--- a/back/engines/commercial/posthog_integration/app/jobs/posthog_integration/remove_user_from_posthog_job.rb
+++ b/back/engines/commercial/posthog_integration/app/jobs/posthog_integration/remove_user_from_posthog_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module PosthogIntegration
+  class RemoveUserFromPosthogJob < ApplicationJob
+    self.priority = 70 # Lower priority than default, but still higher than DeleteUserJob.
+
+    def run(user_id)
+      return unless defined?(POSTHOG_CUSTOM_CLIENT) && POSTHOG_CUSTOM_CLIENT
+
+      POSTHOG_CUSTOM_CLIENT.delete_person_by_distinct_id(user_id)
+    end
+  end
+end

--- a/back/engines/commercial/posthog_integration/app/services/posthog_integration/patches/side_fx_user_service.rb
+++ b/back/engines/commercial/posthog_integration/app/services/posthog_integration/patches/side_fx_user_service.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module PosthogIntegration
+  module Patches
+    module SideFxUserService
+      def after_destroy(frozen_user, current_user)
+        super
+        RemoveUserFromPosthogJob.perform_later(frozen_user.id)
+      end
+    end
+  end
+end

--- a/back/engines/commercial/posthog_integration/config/initializers/posthog.rb
+++ b/back/engines/commercial/posthog_integration/config/initializers/posthog.rb
@@ -1,10 +1,39 @@
 # frozen_string_literal: true
 
-key = ENV.fetch('POSTHOG_API_KEY', nil)
+config_variables = %w[POSTHOG_PROJECT_API_KEY POSTHOG_API_KEY POSTHOG_PROJECT_ID]
+config = config_variables.index_with { |var_name| ENV.fetch(var_name, nil) }
 
-POSTHOG_CLIENT = key &&
-                 PostHog::Client.new({
-                   api_key: key,
-                   host: 'https://eu.posthog.com',
-                   on_error: proc { |status, msg| ErrorReporter.report({ status: status, msg: msg }) }
-                 })
+if config.values.none? # PostHog integration/tracking is disabled.
+  POSTHOG_CLIENT = nil
+  POSTHOG_CUSTOM_CLIENT = nil
+  return
+end
+
+missing_variables = config.select { |_, value| value.nil? }.keys
+
+# We hard fail when the configuration is partial.
+if missing_variables.present?
+  present_variables = config.keys - missing_variables
+  raise <<~ERROR
+    Some configuration env variables for the PostHog integration are missing. You can either:
+    - Specify the following missing variables: #{missing_variables.join(', ')}.
+    - Disable the PostHog integration altogether by removing the following variables: #{present_variables.join(', ')}.
+  ERROR
+end
+
+config['POSTHOG_HOST'] = ENV.fetch('POSTHOG_HOST', 'https://eu.posthog.com')
+
+# Write-only (project-specific) client for tracking events.
+POSTHOG_CLIENT = PostHog::Client.new({
+  api_key: config['POSTHOG_PROJECT_API_KEY'],
+  host: config['POSTHOG_HOST'],
+  on_error: proc { |status, msg| ErrorReporter.report({ status: status, msg: msg }) }
+})
+
+# Our own client for all the other PostHog API calls.
+POSTHOG_CUSTOM_CLIENT = PosthogIntegration::PostHog::Client.new(
+  base_uri: config['POSTHOG_HOST'],
+  api_key: config['POSTHOG_API_KEY']
+).tap do |client|
+  client.default_project_id = config['POSTHOG_PROJECT_ID']
+end

--- a/back/engines/commercial/posthog_integration/lib/posthog_integration.rb
+++ b/back/engines/commercial/posthog_integration/lib/posthog_integration.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'posthog_integration/engine'
+require 'posthog_integration/post_hog/client'
 require 'posthog-ruby'
 
 module PosthogIntegration

--- a/back/engines/commercial/posthog_integration/lib/posthog_integration/post_hog/client.rb
+++ b/back/engines/commercial/posthog_integration/lib/posthog_integration/post_hog/client.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'http'
+
+module PosthogIntegration
+  module PostHog
+    class Client
+      DEFAULT_BASE_URI = 'https://eu.posthog.com'
+
+      attr_accessor :default_project_id
+
+      delegate :raise_if_error, to: :class
+
+      def initialize(base_uri: nil, api_key: nil)
+        @base_uri = base_uri || ENV.fetch('POSTHOG_HOST', DEFAULT_BASE_URI)
+        @base_uri = @base_uri.chomp('/')
+
+        @api_key = api_key || ENV.fetch('POSTHOG_API_KEY', nil)
+      end
+
+      def persons(project_id: default_project_id, **params)
+        missing_project_id! unless project_id
+
+        http.get("#{@base_uri}/api/projects/#{project_id}/persons", params: params)
+      end
+
+      def delete_person(id, project_id: default_project_id)
+        missing_project_id! unless project_id
+
+        http.delete("#{@base_uri}/api/projects/#{project_id}/persons/#{id}")
+      end
+
+      def delete_person_by_distinct_id(distinct_id, project_id: default_project_id)
+        missing_project_id! unless project_id
+
+        response = persons(project_id: project_id, distinct_id: distinct_id)
+        raise_if_error(response)
+
+        results = response.parse['results']
+
+        case results.size
+        when 0
+          nil
+        when 1
+          person_id = results.first['id']
+          delete_response = delete_person(person_id, project_id: project_id)
+          raise_if_error(delete_response)
+
+          person_id
+        else
+          raise <<~MSG.squish
+            Unexpected number of persons with distinct_id #{distinct_id.inspect}. 
+            Expected 0 or 1, got #{results.size}.
+          MSG
+        end
+      end
+
+      def self.raise_if_error(response)
+        status = response.status
+        return unless status.client_error? || status.server_error?
+
+        raise ApiError, response.to_s
+      end
+
+      private
+
+      def http
+        HTTP
+          .auth(authorization_header)
+          .accept('application/json')
+      end
+
+      def authorization_header
+        "Bearer #{@api_key}"
+      end
+
+      def missing_project_id!
+        raise <<~MSG
+          The PostHog project ID is missing. You should either use the `project_id`
+          parameter or set a default project ID on the client: 
+          
+          > client.default_project_id = '123'
+        MSG
+      end
+
+      class ApiError < RuntimeError; end
+    end
+  end
+end

--- a/back/engines/commercial/posthog_integration/posthog_integration.gemspec
+++ b/back/engines/commercial/posthog_integration/posthog_integration.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,db,lib}/**/*', 'Rakefile', 'README.md']
 
+  s.add_dependency 'http', '~> 5.1'
   s.add_dependency 'rails', '~> 7.0'
   s.add_dependency 'posthog-ruby', '~> 2.1'
 

--- a/back/engines/commercial/posthog_integration/spec/jobs/posthog_integration/remove_user_from_posthog_job_spec.rb
+++ b/back/engines/commercial/posthog_integration/spec/jobs/posthog_integration/remove_user_from_posthog_job_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PosthogIntegration::RemoveUserFromPosthogJob do
+  subject(:job) { described_class.new }
+
+  let(:user_id) { 'user-id' }
+
+  describe '#perform' do
+    context 'when PostHog integration is configured' do
+      # PostHog integration is configured means that POSTHOG_CUSTOM_CLIENT is defined.
+      let!(:posthog_client) do
+        stub_const(
+          'POSTHOG_CUSTOM_CLIENT',
+          instance_spy(PosthogIntegration::PostHog::Client)
+        )
+      end
+
+      it 'uses PosthogIntegration::PostHog::Client to remove user data' do
+        job.perform(user_id)
+
+        expect(posthog_client)
+          .to have_received(:delete_person_by_distinct_id).with(user_id)
+      end
+    end
+
+    context 'when PostHog integration is not configured' do
+      before do
+        stub_const('POSTHOG_CUSTOM_CLIENT', nil)
+      end
+
+      it 'does not remove user data from PostHog' do
+        expect_any_instance_of(PosthogIntegration::PostHog::Client)
+          .not_to receive(:delete_person_by_distinct_id)
+
+        job.perform(user_id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Changelog
## Technical
- Remove user PII from PostHog when a user account is deleted.
