### PR TITLE
[CL-4012] Don't overwrite existing user avatar with SSO avatar

### DIFF
--- a/back/app/controllers/omniauth_callback_controller.rb
+++ b/back/app/controllers/omniauth_callback_controller.rb
@@ -194,6 +194,7 @@ class OmniauthCallbackController < ApplicationController
 
     attrs = authver_method.updateable_user_attrs
     update_hash = authver_method.profile_to_user_attrs(auth).slice(*attrs).compact
+    update_hash.delete(:remote_avatar_url) if user.avatar.present? # don't overwrite avatar if already present
     user.confirm! # confirm user email if not already confirmed
 
     if authver_method.overwrite_user_attrs?

--- a/back/spec/requests/google_authentication_spec.rb
+++ b/back/spec/requests/google_authentication_spec.rb
@@ -94,7 +94,7 @@ describe 'google authentication' do
     expect(cookies[:cl2_jwt]).to be_present
   end
 
-  it 'updates the avatar when re-authenticating an existing user without an avatar' do
+  it 'does not update the avatar when re-authenticating an existing user with an avatar' do
     user = create(
       :user,
       email: 'boris.brompton@orange.uk',
@@ -107,7 +107,7 @@ describe 'google authentication' do
     expect(user.reload.avatar.file.file).to be_present
   end
 
-  it 'does not update the avatar when re-authenticating an existing user with an avatar' do
+  it 'updates the avatar when re-authenticating an existing user without an avatar' do
     user = create(
       :user,
       email: 'boris.brompton@orange.uk',

--- a/back/spec/requests/google_authentication_spec.rb
+++ b/back/spec/requests/google_authentication_spec.rb
@@ -100,12 +100,11 @@ describe 'google authentication' do
       email: 'boris.brompton@orange.uk',
       avatar: nil
     )
-    original_file = user.avatar.file.file
 
     get '/auth/google'
     follow_redirect!
 
-    expect(user.reload.avatar.file.file).not_to eq original_file
+    expect(user.reload.avatar.file.file).to be_present
   end
 
   it 'does not update the avatar when re-authenticating an existing user with an avatar' do

--- a/back/spec/requests/google_authentication_spec.rb
+++ b/back/spec/requests/google_authentication_spec.rb
@@ -94,7 +94,21 @@ describe 'google authentication' do
     expect(cookies[:cl2_jwt]).to be_present
   end
 
-  it 'updates the avatar when re-authenticating an existing user with an avatar' do
+  it 'updates the avatar when re-authenticating an existing user without an avatar' do
+    user = create(
+      :user,
+      email: 'boris.brompton@orange.uk',
+      avatar: nil
+    )
+    original_file = user.avatar.file.file
+
+    get '/auth/google'
+    follow_redirect!
+
+    expect(user.reload.avatar.file.file).not_to eq original_file
+  end
+
+  it 'does not update the avatar when re-authenticating an existing user with an avatar' do
     user = create(
       :user,
       email: 'boris.brompton@orange.uk',
@@ -105,7 +119,7 @@ describe 'google authentication' do
     get '/auth/google'
     follow_redirect!
 
-    expect(user.reload.avatar.file.file).not_to eq original_file
+    expect(user.reload.avatar.file.file).to eq original_file
   end
 
   describe 'When registering a new user' do


### PR DESCRIPTION
Tricky to manually test locally, but safe enough to release then test.

# Changelog
## Fixed
[CL-4012] Don't overwrite existing user avatar with SSO avatar (e.g. Google avatar)


[CL-4012]: https://citizenlab.atlassian.net/browse/CL-4012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ