### PR TITLE
CL-4058 - Allow duplicate sheet names for long volunteering cause name with similar names

### DIFF
--- a/back/engines/free/volunteering/app/services/volunteering/xlsx_service.rb
+++ b/back/engines/free/volunteering/app/services/volunteering/xlsx_service.rb
@@ -24,10 +24,12 @@ module Volunteering
       end
 
       pa = Axlsx::Package.new
+      utils = XlsxExport::Utils.new
 
       sheetnames = participation_context.causes.to_h do |cause|
-        [cause.id, @@multiloc_service.t(cause.title_multiloc)]
+        [cause.id, utils.sanitize_sheetname(@@multiloc_service.t(cause.title_multiloc))]
       end
+
       duplicate_names = (sheetnames.values.uniq.size != sheetnames.size)
       participation_context.causes.order(:ordering).each_with_index do |cause, i|
         sheetname = duplicate_names ? "#{i + 1} - " + sheetnames[cause.id] : sheetnames[cause.id]

--- a/back/engines/free/volunteering/spec/services/xlsx_service_spec.rb
+++ b/back/engines/free/volunteering/spec/services/xlsx_service_spec.rb
@@ -57,5 +57,14 @@ describe XlsxService do
         expect { workbook }.not_to raise_error
       end
     end
+
+    describe 'when there are multiple causes with different titles over 30 chars that start with same 30 chars' do
+      let!(:cause1) { create(:cause, title_multiloc: { 'en' => 'AAAAAAAAAABBBBBBBBBBCCCCCCCCC - version 1' }, participation_context: cause.participation_context) }
+      let!(:cause2) { create(:cause, title_multiloc: { 'en' => 'AAAAAAAAAABBBBBBBBBBCCCCCCCCC - number 2' }, participation_context: cause.participation_context) }
+
+      it 'exports a valid excel file' do
+        expect { workbook }.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
# Changelog

## Fixed
- CL-4058 - Fixed error where volunteering causes are over 30 characters in length and the first 30 characters are the same
