### PR TITLE
Cl 4087 more mobile comment sorting fixes

### DIFF
--- a/front/app/components/PostShowComponents/Comments/CommentSorting.tsx
+++ b/front/app/components/PostShowComponents/Comments/CommentSorting.tsx
@@ -52,7 +52,7 @@ const CommentSorting = ({
         multipleSelectionAllowed={false}
         width="180px"
         right="-10px"
-        mobileLeft="-5px"
+        mobileRight="0"
       />
     </Box>
   );

--- a/front/app/components/PostShowComponents/Comments/PublicComments.tsx
+++ b/front/app/components/PostShowComponents/Comments/PublicComments.tsx
@@ -138,6 +138,13 @@ const PublicComments = ({
             <FormattedMessage {...messages.invisibleTitleComments} />
             {showCommentCount && <CommentCount>({commentCount})</CommentCount>}
           </Title>
+          <>
+            {postType === 'idea' && idea ? (
+              <CommentingIdeaDisabled idea={idea} phaseId={phaseId} />
+            ) : (
+              <CommentingProposalDisabled />
+            )}
+          </>
           {hasComments && (
             <Box ml="auto">
               <CommentSorting
@@ -147,12 +154,6 @@ const PublicComments = ({
             </Box>
           )}
         </Header>
-      )}
-
-      {postType === 'idea' && idea ? (
-        <CommentingIdeaDisabled idea={idea} phaseId={phaseId} />
-      ) : (
-        <CommentingProposalDisabled />
       )}
 
       <Box my="24px">

--- a/front/app/components/admin/InternalComments/InternalCommentSorting.tsx
+++ b/front/app/components/admin/InternalComments/InternalCommentSorting.tsx
@@ -52,7 +52,7 @@ const InternalCommentSorting = ({
         multipleSelectionAllowed={false}
         width="180px"
         right="-10px"
-        mobileLeft="-5px"
+        mobileRight="0"
       />
     </Box>
   );

--- a/front/app/components/admin/InternalComments/InternalCommentSorting.tsx
+++ b/front/app/components/admin/InternalComments/InternalCommentSorting.tsx
@@ -52,7 +52,6 @@ const InternalCommentSorting = ({
         multipleSelectionAllowed={false}
         width="180px"
         right="-10px"
-        mobileRight="0"
       />
     </Box>
   );


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Comment sorting dropdown is now fully visible on mobile

## Changed
- Commenting disabled reason is shown above the comment sorting component