### PR TITLE
Don't allow proposal commenting when profile not completed

### DIFF
--- a/front/app/components/PostShowComponents/Comments/PublicComments.tsx
+++ b/front/app/components/PostShowComponents/Comments/PublicComments.tsx
@@ -35,7 +35,6 @@ import CommentingIdeaDisabled from './CommentingIdeaDisabled';
 // utils
 import { isPage } from 'utils/helperUtils';
 import useInitiativesPermissions from 'hooks/useInitiativesPermissions';
-import useAuthUser from 'api/me/useAuthUser';
 
 const Header = styled(Box)`
   ${isRtl`

--- a/front/app/components/PostShowComponents/Comments/PublicComments.tsx
+++ b/front/app/components/PostShowComponents/Comments/PublicComments.tsx
@@ -126,9 +126,6 @@ const PublicComments = ({
   const canComment = {
     idea: !idea?.data.attributes.action_descriptor.commenting_idea
       .disabled_reason,
-    // authUser check is needed for proposals, because disabled reasons don't include
-    // anything related to authentication for proposals so there would be whitespace in the
-    // UI from the box that's displayed using this condition.
     initiative:
       !commentingPermissionInitiative?.disabledReason &&
       !commentingPermissionInitiative?.authenticationRequirements,

--- a/front/app/components/PostShowComponents/Comments/PublicComments.tsx
+++ b/front/app/components/PostShowComponents/Comments/PublicComments.tsx
@@ -71,7 +71,6 @@ const PublicComments = ({
   const ideaId = postType === 'idea' ? postId : undefined;
   const { data: initiative } = useInitiativeById(initiativeId);
   const { data: idea } = useIdeaById(ideaId);
-  const { data: authUser } = useAuthUser();
   const { pathname } = useLocation();
   const [sortOrder, setSortOrder] = useState<CommentsSort>('new');
   const {
@@ -131,7 +130,8 @@ const PublicComments = ({
     // anything related to authentication for proposals so there would be whitespace in the
     // UI from the box that's displayed using this condition.
     initiative:
-      !commentingPermissionInitiative?.disabledReason && authUser !== undefined,
+      !commentingPermissionInitiative?.disabledReason &&
+      !commentingPermissionInitiative?.authenticationRequirements,
   }[postType];
 
   return (


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Don't allow proposal commenting when required profile questions are not completed