### PR TITLE
Migrate auto followers script: deal with errors

### DIFF
--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/migrate_auto_followers.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/migrate_auto_followers.rake
@@ -11,6 +11,8 @@ namespace :fix_existing_tenants do
         migrate_initiative_followers!
         migrate_folder_followers!
         migrate_area_followers!
+      rescue StandardError => e
+        puts "An error occurred: #{e.message}"
       end
     end
   end


### PR DESCRIPTION
Yesterday, the script failed on Benelux due to inconsistent data (a project without admin publication in a demo platform). The proposed solution is to skip when an error occurred in a tenant, so we can migrate as many tenants as possible.