### PR TITLE
Fix nil returned by make_notifications_on

### DIFF
--- a/back/app/models/notifications/official_feedback_on_initiative_you_follow.rb
+++ b/back/app/models/notifications/official_feedback_on_initiative_you_follow.rb
@@ -85,6 +85,8 @@ module Notifications
             official_feedback: official_feedback
           )
         end
+      else
+        []
       end
     end
   end

--- a/back/spec/models/notifications/official_feedback_on_initiative_you_follow_spec.rb
+++ b/back/spec/models/notifications/official_feedback_on_initiative_you_follow_spec.rb
@@ -38,5 +38,14 @@ RSpec.describe Notifications::OfficialFeedbackOnInitiativeYouFollow do
       notifications = described_class.make_notifications_on(activity)
       expect(notifications).to eq []
     end
+
+    it "doesn't generate notifications when the post is an idea" do
+      idea = create(:idea)
+      official_feedback = create(:official_feedback, post: idea)
+      activity = create(:activity, item: official_feedback, action: :created)
+
+      notifications = described_class.make_notifications_on(activity)
+      expect(notifications).to eq []
+    end
   end
 end


### PR DESCRIPTION
This should fix this issue: https://sentry.hq.citizenlab.co/share/issue/13b24c9cf1714235b343e8415ca0c901/

The user experience should not be affected by this issue, so I think it might not be necessary to add to the changelog.

I checked the other notification models to see if there are other occurrences of this issue.
