### PR TITLE
Remove reacted only users from followers

### DIFF
--- a/back/app/services/side_fx_reaction_service.rb
+++ b/back/app/services/side_fx_reaction_service.rb
@@ -51,7 +51,6 @@ class SideFxReactionService
     when 'Idea', 'Initiative'
       reaction.reactable
     end
-    Follower.find_or_create_by(followable: post, user: user)
     return if !post.is_a? Idea
 
     Follower.find_or_create_by(followable: post.project, user: user)

--- a/back/spec/services/side_fx_reaction_service_spec.rb
+++ b/back/spec/services/side_fx_reaction_service_spec.rb
@@ -43,15 +43,16 @@ describe SideFxReactionService do
 
       expect do
         service.after_create reaction.reload, user
-      end.to change(Follower, :count).from(0).to(3)
+      end.to change(Follower, :count).from(0).to(2)
 
-      expect(user.follows.pluck(:followable_id)).to contain_exactly idea.id, project.id, folder.id
+      expect(user.follows.pluck(:followable_id)).to contain_exactly project.id, folder.id
     end
 
-    it 'does not create a follower if the user already follows the post' do
-      initiative = create(:initiative)
-      reaction = create(:reaction, reactable: initiative)
-      create(:follower, followable: initiative, user: user)
+    it 'does not create a follower if the user already follows the project' do
+      project = create(:project)
+      idea = create(:idea, project: project)
+      reaction = create(:reaction, reactable: idea)
+      create(:follower, followable: project, user: user)
 
       expect do
         service.after_create reaction, user


### PR DESCRIPTION
We received the feedback that the following feature is too spammy and therefore opted to no longer let participants who only reacted automatically follower the corresponding idea/initiative. See discussion: https://citizenlabco.slack.com/archives/C05GPT39BM1/p1695895146554279

Tested locally.

Quite urgent.