### PR TITLE
Remove unneeded checks for initiatives setting

### DIFF
--- a/front/app/api/app_configuration/__mocks__/useAppConfiguration.ts
+++ b/front/app/api/app_configuration/__mocks__/useAppConfiguration.ts
@@ -1,9 +1,12 @@
-export const appConfigurationData = {
+import { IAppConfigurationData } from 'api/app_configuration/types';
+
+export const appConfigurationData: IAppConfigurationData = {
   id: 'c4b400e1-1786-5be2-af55-40730c6a843d',
   type: 'app_configuration',
   attributes: {
     name: 'wonderville',
     host: 'wonderville.com',
+    created_at: '',
     settings: {
       core: {
         allowed: true,
@@ -24,6 +27,10 @@ export const appConfigurationData = {
         segment_destinations_blacklist: null,
         reply_to_email: 'not-support@citizenlab.co',
         authentication_token_lifetime_in_days: 30,
+        maximum_admins_number: 4,
+        maximum_moderators_number: 4,
+        additional_admins_number: 4,
+        additional_moderators_number: 4,
       },
       advanced_custom_pages: {
         allowed: true,
@@ -38,6 +45,15 @@ export const appConfigurationData = {
         enabled: true,
         tenant_site_id: '13',
         product_site_id: '14',
+      },
+      initiatives: {
+        allowed: true,
+        enabled: true,
+        days_limit: 50,
+        eligibility_criteria: {},
+        posting_tips: {},
+        threshold_reached_message: {},
+        reacting_threshold: 5,
       },
     },
     logo: {

--- a/front/app/api/app_configuration/types.ts
+++ b/front/app/api/app_configuration/types.ts
@@ -134,7 +134,7 @@ export interface IAppConfigurationSettings {
   project_reports?: AppConfigurationFeature;
   private_projects?: AppConfigurationFeature;
   maps?: AppConfigurationMapSettings;
-  initiatives?: ProposalsSettings;
+  initiatives: ProposalsSettings;
   initiative_review?: AppConfigurationFeature;
   initiative_cosponsors?: AppConfigurationFeature;
   fragments?: {

--- a/front/app/api/app_configuration/useAppConfiguration.test.tsx
+++ b/front/app/api/app_configuration/useAppConfiguration.test.tsx
@@ -44,6 +44,15 @@ export const getAppConfigurationData = (
         additional_admins_number: 0,
         additional_moderators_number: 0,
       },
+      initiatives: {
+        allowed: true,
+        enabled: true,
+        days_limit: 50,
+        eligibility_criteria: {},
+        posting_tips: {},
+        threshold_reached_message: {},
+        reacting_threshold: 1,
+      },
       advanced_custom_pages: {
         allowed: true,
         enabled: true,

--- a/front/app/components/InitiativeCard/ReactionIndicator.tsx
+++ b/front/app/components/InitiativeCard/ReactionIndicator.tsx
@@ -121,8 +121,8 @@ const ReactionIndicator = ({ initiativeId }: Props) => {
   const statusCode = initiativeStatus.data.attributes.code;
   const reactionCount = initiative?.data.attributes.likes_count || 0;
   const reactionLimit: number =
-    appConfiguration?.data?.attributes?.settings.initiatives
-      ?.reacting_threshold || 1;
+    appConfiguration?.data.attributes.settings.initiatives.reacting_threshold ||
+    1;
 
   return (
     <Container className="e2e-initiative-card-reaction-indicator">

--- a/front/app/components/InitiativeForm/CollapsibleTipsAndInfo.tsx
+++ b/front/app/components/InitiativeForm/CollapsibleTipsAndInfo.tsx
@@ -23,7 +23,7 @@ const CollapsibleTipsAndInfo = ({ className }: Props) => {
   const localize = useLocalize();
 
   const postingTips = localize(
-    appConfiguration?.data.attributes.settings.initiatives?.posting_tips
+    appConfiguration?.data.attributes.settings.initiatives.posting_tips
   );
 
   if (postingTips.length === 0) return null;

--- a/front/app/components/InitiativeForm/CosponsorsFormSection.tsx
+++ b/front/app/components/InitiativeForm/CosponsorsFormSection.tsx
@@ -46,7 +46,7 @@ const CosponsorsFormSection = ({ cosponsorships }: Props) => {
   };
 
   const cosponsorsNumber =
-    appConfiguration.data.attributes.settings.initiatives?.cosponsors_number;
+    appConfiguration.data.attributes.settings.initiatives.cosponsors_number;
 
   return (
     <>

--- a/front/app/components/InitiativeForm/InitiativeForm.test.tsx
+++ b/front/app/components/InitiativeForm/InitiativeForm.test.tsx
@@ -5,6 +5,8 @@ import InitiativeForm, { Props } from '.';
 // Needed for language selector of org name multiloc input
 jest.mock('hooks/useAppConfigurationLocales', () => jest.fn(() => ['en']));
 jest.mock('api/topics/useTopics');
+jest.mock('api/app_configuration/useAppConfiguration');
+
 const submitButtonName = 'Publish your initiative';
 
 describe('InitiativeForm', () => {

--- a/front/app/components/InitiativeForm/ProfileVisibilityFormSection.tsx
+++ b/front/app/components/InitiativeForm/ProfileVisibilityFormSection.tsx
@@ -27,7 +27,7 @@ const ProfileVisibilityFormSection = ({ triggerModal }: Props) => {
   const isEditingInitiative = typeof initiativeId === 'string';
   const allowAnonymousParticipation =
     appConfiguration.data.attributes.settings.initiatives
-      ?.allow_anonymous_participation;
+      .allow_anonymous_participation;
 
   const onHandleSideEffects = () => {
     triggerModal();

--- a/front/app/components/InitiativeForm/TipsBox.tsx
+++ b/front/app/components/InitiativeForm/TipsBox.tsx
@@ -40,7 +40,7 @@ const TipsBox = memo(({ className }: Props) => {
   const localize = useLocalize();
 
   const postingTips = localize(
-    appConfiguration?.data.attributes.settings.initiatives?.posting_tips
+    appConfiguration?.data.attributes.settings.initiatives.posting_tips
   );
 
   if (postingTips.length === 0) return null;

--- a/front/app/components/InitiativeForm/TipsContent.tsx
+++ b/front/app/components/InitiativeForm/TipsContent.tsx
@@ -32,7 +32,7 @@ const TipsContent = () => {
       <QuillEditedContent textColor={theme.colors.tenantText}>
         <div
           dangerouslySetInnerHTML={{
-            __html: localize(initiativeSettings?.posting_tips),
+            __html: localize(initiativeSettings.posting_tips),
           }}
         />
       </QuillEditedContent>

--- a/front/app/components/InitiativeForm/index.tsx
+++ b/front/app/components/InitiativeForm/index.tsx
@@ -120,7 +120,7 @@ const InitiativeForm = ({
       .min(1, formatMessage(messages.topicEmptyError)),
     ...(cosponsorsRequired &&
       typeof appConfiguration?.data.attributes.settings.initiatives
-        ?.cosponsors_number === 'number' && {
+        .cosponsors_number === 'number' && {
         cosponsor_ids: array()
           .required(formatMessage(messages.cosponsorsEmptyError))
           .min(

--- a/front/app/components/PostShowComponents/Footer.tsx
+++ b/front/app/components/PostShowComponents/Footer.tsx
@@ -64,7 +64,7 @@ const Footer = memo<Props>(({ postId, postType, className }) => {
             allowAnonymousParticipation={
               postType === 'initiative'
                 ? appConfiguration?.data.attributes.settings.initiatives
-                    ?.allow_anonymous_participation
+                    .allow_anonymous_participation
                 : undefined
             }
             postId={postId}

--- a/front/app/components/ResolveTextVariables/index.tsx
+++ b/front/app/components/ResolveTextVariables/index.tsx
@@ -32,23 +32,23 @@ class ResolveTextVariables extends PureComponent<Props> {
         orgName: localize(tenant.attributes.settings.core.organization_name),
       };
 
-      const initiatives = tenant.attributes.settings.initiatives;
-      if (initiatives) {
-        if (initiatives.eligibility_criteria) {
-          textVariables.initiativesEligibilityCriteria = localize(
-            initiatives.eligibility_criteria
-          );
-        }
-        if (initiatives.threshold_reached_message) {
-          textVariables.initiativesThresholdReachedMessage = localize(
-            initiatives.threshold_reached_message
-          );
-        }
+      const initiativeSettings = tenant.attributes.settings.initiatives;
 
-        textVariables.initiativesReactingThreshold =
-          initiatives.reacting_threshold.toString();
-        textVariables.initiativesDaysLimit = initiatives.days_limit.toString();
+      if (initiativeSettings.eligibility_criteria) {
+        textVariables.initiativesEligibilityCriteria = localize(
+          initiativeSettings.eligibility_criteria
+        );
       }
+      if (initiativeSettings.threshold_reached_message) {
+        textVariables.initiativesThresholdReachedMessage = localize(
+          initiativeSettings.threshold_reached_message
+        );
+      }
+
+      textVariables.initiativesReactingThreshold =
+        initiativeSettings.reacting_threshold.toString();
+      textVariables.initiativesDaysLimit =
+        initiativeSettings.days_limit.toString();
 
       return textVariables;
     }

--- a/front/app/components/admin/PostManager/components/PostPreview/Initiative/AdminInitiativeContent.tsx
+++ b/front/app/components/admin/PostManager/components/PostPreview/Initiative/AdminInitiativeContent.tsx
@@ -211,7 +211,7 @@ const AdminInitiativeContent = ({
               <CommentsSection
                 allowAnonymousParticipation={
                   appConfiguration?.data.attributes.settings.initiatives
-                    ?.allow_anonymous_participation
+                    .allow_anonymous_participation
                 }
                 postId={initiativeId}
                 postType="initiative"

--- a/front/app/containers/Admin/initiatives/settings/Thresholds.tsx
+++ b/front/app/containers/Admin/initiatives/settings/Thresholds.tsx
@@ -5,11 +5,16 @@ import { SectionField, SubSectionTitle } from 'components/admin/Section';
 import { Input, Box } from '@citizenlab/cl2-component-library';
 import Error from 'components/UI/Error';
 import errorMessages from 'components/UI/Error/messages';
-import { StyledWarning } from '.';
 
 // i18n
 import { useIntl } from 'utils/cl-intl';
 import messages from '../messages';
+import styled from 'styled-components';
+import Warning from 'components/UI/Warning';
+
+const StyledWarning = styled(Warning)`
+  margin-bottom: 7px;
+`;
 
 interface Props {
   numberOfVotesThreshold: number;

--- a/front/app/containers/Admin/initiatives/settings/index.tsx
+++ b/front/app/containers/Admin/initiatives/settings/index.tsx
@@ -14,7 +14,6 @@ import useUpdateAppConfiguration from 'api/app_configuration/useUpdateAppConfigu
 
 // components
 import { SectionTitle, SectionDescription } from 'components/admin/Section';
-import Warning from 'components/UI/Warning';
 import ProposalsFeatureToggle from './ProposalsFeatureToggle';
 import Thresholds from './Thresholds';
 import ThresholdReachedMessage from './ThresholdReachedMessage';
@@ -37,10 +36,6 @@ import { colors } from 'utils/styleUtils';
 
 // typings
 import { Multiloc } from 'typings';
-
-export const StyledWarning = styled(Warning)`
-  margin-bottom: 7px;
-`;
 
 const StyledSectionTitle = styled(SectionTitle)`
   margin-bottom: 10px;
@@ -75,10 +70,7 @@ const InitiativesSettingsPage = () => {
   const { data: proposalsPage } = useCustomPageBySlug('initiatives');
 
   const remoteProposalsSettings = useMemo(() => {
-    if (
-      isNilOrError(appConfiguration) ||
-      !appConfiguration.data.attributes.settings.initiatives
-    ) {
+    if (isNilOrError(appConfiguration)) {
       return null;
     }
 

--- a/front/app/containers/InitiativesIndexPage/InitiativeInfoContent/index.tsx
+++ b/front/app/containers/InitiativesIndexPage/InitiativeInfoContent/index.tsx
@@ -9,8 +9,8 @@ import { fontSizes, colors } from 'utils/styleUtils';
 
 // i18n
 import { FormattedMessage } from 'utils/cl-intl';
-import injectLocalize, { InjectedLocalized } from 'utils/localize';
 import messages from '../messages';
+import useLocalize from 'hooks/useLocalize';
 
 const Content = styled.div`
   color: ${colors.textSecondary};
@@ -36,48 +36,46 @@ interface Props {
   className?: string;
 }
 
-const InitiativeInfoContent = memo<InjectedLocalized & Props>(
-  ({ className, localize }) => {
-    const { data: appConfig } = useAppConfiguration();
+const InitiativeInfoContent = memo<Props>(({ className }) => {
+  const { data: appConfig } = useAppConfiguration();
+  const localize = useLocalize();
 
-    if (!isNilOrError(appConfig)) {
-      const reactionThreshold =
-        appConfig.data.attributes.settings.initiatives?.reacting_threshold;
-      const daysLimit =
-        appConfig.data.attributes.settings.initiatives?.days_limit;
+  if (!isNilOrError(appConfig)) {
+    const reactionThreshold =
+      appConfig.data.attributes.settings.initiatives.reacting_threshold;
+    const daysLimit = appConfig.data.attributes.settings.initiatives.days_limit;
 
-      return (
-        <Content className={className}>
-          <FormattedMessage
-            {...messages.explanationContent}
-            values={{
-              constraints: (
-                <Bold>
-                  <FormattedMessage
-                    {...messages.constraints}
-                    values={{
-                      voteThreshold: reactionThreshold,
-                      daysLimit,
-                    }}
-                  />
-                </Bold>
-              ),
-              link: (
-                <Link to="/pages/initiatives">
-                  <FormattedMessage {...messages.learnMoreAboutProposals} />
-                </Link>
-              ),
-              orgName: localize(
-                appConfig.data.attributes.settings.core.organization_name
-              ),
-            }}
-          />
-        </Content>
-      );
-    }
-
-    return null;
+    return (
+      <Content className={className}>
+        <FormattedMessage
+          {...messages.explanationContent}
+          values={{
+            constraints: (
+              <Bold>
+                <FormattedMessage
+                  {...messages.constraints}
+                  values={{
+                    voteThreshold: reactionThreshold,
+                    daysLimit,
+                  }}
+                />
+              </Bold>
+            ),
+            link: (
+              <Link to="/pages/initiatives">
+                <FormattedMessage {...messages.learnMoreAboutProposals} />
+              </Link>
+            ),
+            orgName: localize(
+              appConfig.data.attributes.settings.core.organization_name
+            ),
+          }}
+        />
+      </Content>
+    );
   }
-);
 
-export default injectLocalize(InitiativeInfoContent);
+  return null;
+});
+
+export default InitiativeInfoContent;

--- a/front/app/containers/InitiativesShow/CosponsorShipReminder.tsx
+++ b/front/app/containers/InitiativesShow/CosponsorShipReminder.tsx
@@ -13,7 +13,7 @@ const CosponsorShipReminder = ({ initiativeId }: Props) => {
   const { formatMessage } = useIntl();
   const { data: appConfiguration } = useAppConfiguration();
   const requiredNumberOfCosponsors =
-    appConfiguration?.data.attributes.settings.initiatives?.cosponsors_number;
+    appConfiguration?.data.attributes.settings.initiatives.cosponsors_number;
 
   if (typeof requiredNumberOfCosponsors !== 'number') return null;
 

--- a/front/app/containers/InitiativesShow/ReactionControl/index.tsx
+++ b/front/app/containers/InitiativesShow/ReactionControl/index.tsx
@@ -121,11 +121,7 @@ const ReactionControl = ({
   const { mutate: addReaction } = useAddInitiativeReaction();
   const { mutate: deleteReaction } = useDeleteInitiativeReaction();
 
-  if (
-    !initiative ||
-    !initiativeStatus ||
-    !appConfiguration?.data.attributes.settings.initiatives
-  ) {
+  if (!initiative || !initiativeStatus || !appConfiguration) {
     return null;
   }
 

--- a/front/app/containers/InitiativesShow/RequestToCosponsor.tsx
+++ b/front/app/containers/InitiativesShow/RequestToCosponsor.tsx
@@ -57,7 +57,7 @@ const RequestToCosponsor = ({ initiativeId }: Props) => {
     initiative.data.relationships.author.data?.id === authUserId;
   const authorName = initiative.data.attributes.author_name;
   const requiredNumberOfCosponsors =
-    appConfiguration.data.attributes.settings.initiatives?.cosponsors_number;
+    appConfiguration.data.attributes.settings.initiatives.cosponsors_number;
 
   if (
     !authUserIsAuthor &&

--- a/front/app/containers/InitiativesShow/hooks/useInitiativeCosponsorsRequired.ts
+++ b/front/app/containers/InitiativesShow/hooks/useInitiativeCosponsorsRequired.ts
@@ -6,11 +6,12 @@ export default function useInitiativeCosponsorsRequired() {
     name: 'initiative_cosponsors',
   });
   const { data: appConfig } = useAppConfiguration();
-  const reviewRequired =
+
+  const cosponsorsRequired =
     appConfig?.data.attributes.settings.initiatives.require_cosponsors;
 
-  if (typeof reviewRequired === 'boolean') {
-    return initiativeCosponsorsEnabled && reviewRequired;
+  if (typeof cosponsorsRequired === 'boolean') {
+    return initiativeCosponsorsEnabled && cosponsorsRequired;
   }
 
   // setting doesn't exist (is not configured, so we don't require cosponsors)

--- a/front/app/containers/InitiativesShow/hooks/useInitiativeCosponsorsRequired.ts
+++ b/front/app/containers/InitiativesShow/hooks/useInitiativeCosponsorsRequired.ts
@@ -7,7 +7,7 @@ export default function useInitiativeCosponsorsRequired() {
   });
   const { data: appConfig } = useAppConfiguration();
   const reviewRequired =
-    appConfig?.data.attributes.settings.initiatives?.require_cosponsors;
+    appConfig?.data.attributes.settings.initiatives.require_cosponsors;
 
   if (typeof reviewRequired === 'boolean') {
     return initiativeCosponsorsEnabled && reviewRequired;

--- a/front/app/containers/InitiativesShow/hooks/useInitiativeReviewRequired.ts
+++ b/front/app/containers/InitiativesShow/hooks/useInitiativeReviewRequired.ts
@@ -7,7 +7,7 @@ export default function useInitiativeReviewRequired() {
   });
   const { data: appConfig } = useAppConfiguration();
   const reviewRequired =
-    appConfig?.data.attributes.settings.initiatives?.require_review;
+    appConfig?.data.attributes.settings.initiatives.require_review;
 
   if (initiativeReviewEnabled) {
     return typeof reviewRequired === 'boolean' ? reviewRequired : false;

--- a/front/app/containers/InitiativesShow/hooks/useShowCosponsorshipReminder.ts
+++ b/front/app/containers/InitiativesShow/hooks/useShowCosponsorshipReminder.ts
@@ -23,7 +23,7 @@ function useShowCosponsorshipReminder(initiativeId: string) {
   const signedInUserIsAuthor =
     typeof authorId === 'string' ? authorId === authUser.data.id : false;
   const requiredNumberOfCosponsors =
-    appConfiguration.data.attributes.settings.initiatives?.cosponsors_number;
+    appConfiguration.data.attributes.settings.initiatives.cosponsors_number;
   const acceptedCosponsorships =
     initiative.data.attributes.cosponsorships.filter(
       (c) => c.status === 'accepted'

--- a/front/app/containers/InitiativesShow/modals/index.tsx
+++ b/front/app/containers/InitiativesShow/modals/index.tsx
@@ -29,11 +29,11 @@ const InitiativeModals = ({
   });
   const initiativeReviewRequired = useInitiativeReviewRequired();
   const { formatMessage } = useIntl();
+
+  if (!appConfiguration) return null;
+
   const initiativeSettings =
-    appConfiguration?.data.attributes.settings.initiatives;
-
-  if (!initiativeSettings) return null;
-
+    appConfiguration.data.attributes.settings.initiatives;
   const reactingThreshold = initiativeSettings.reacting_threshold;
   const daysLimit = initiativeSettings.days_limit.toString();
 


### PR DESCRIPTION
Since `initiatives` will always be available if we successfully load appConfig, I've adjusted our types and was able to remove unnecessary code. We can do this for many more settings. I'll share how to check it during the next FE CDM.