### PR TITLE
[CL-4045] Revert to previous low-res email logo aproach

### DIFF
--- a/back/app/mailers/application_mailer.rb
+++ b/back/app/mailers/application_mailer.rb
@@ -171,9 +171,7 @@ class ApplicationMailer < ActionMailer::Base
   end
 
   def logo_url
-    @logo_url ||= app_configuration.logo.versions.then do |versions|
-      versions[:large].url || versions[:medium].url || versions[:small].url || ''
-    end
+    versions[:medium].url || versions[:small].url || versions[:large].url || ''
   end
 
   def formatted_todays_date

--- a/back/app/mailers/application_mailer.rb
+++ b/back/app/mailers/application_mailer.rb
@@ -171,7 +171,9 @@ class ApplicationMailer < ActionMailer::Base
   end
 
   def logo_url
-    versions[:medium].url || versions[:small].url || versions[:large].url || ''
+    @logo_url ||= app_configuration.logo.versions.then do |versions|
+      versions[:medium].url || versions[:small].url || versions[:large].url || ''
+    end
   end
 
   def formatted_todays_date

--- a/back/app/views/application/_logo_medium_top.mjml
+++ b/back/app/views/application/_logo_medium_top.mjml
@@ -1,5 +1,9 @@
 <mj-section padding="20px 25px 0">
   <mj-column>
-    <mj-image css-class="logo" src=<%= logo_url %> href=<%= home_url %> alt="Organization logo"/>
+    <mj-raw>
+      <%= link_to home_url do %>
+        <%= image_tag logo_url, alt: 'Organization logo' %>
+      <% end %>
+    </mj-raw>
   </mj-column>
 </mj-section>

--- a/back/engines/free/email_campaigns/app/views/email_campaigns/application/_head.mjml
+++ b/back/engines/free/email_campaigns/app/views/email_campaigns/application/_head.mjml
@@ -6,11 +6,6 @@
     }
     
     a {text-decoration: none;}
-    
-    .logo img {
-      height: 80px !important;
-      width: auto !important;
-    }
 
     <%# From https://github.com/mjmlio/mjml/issues/230 %>
     <% if text_direction == "rtl" %>


### PR DESCRIPTION
Using the large logo image version and CSS to set a logo image height of half the large logo image height resulted in higher resolution logos on higher resolution screens, but broke the image aspect ratio on Outlook mail clients, so here we revert to the approach used previously. Thus, this removes the higher resolution logos, but ensures they work on Outlook again.

# Changelog
## Fixed
- [CL-4045] Logos in emails on Outlook should render properly again


[CL-4045]: https://citizenlab.atlassian.net/browse/CL-4045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ