### PR TITLE
CL-4123: Improve loading experience of input manager

### DIFF
--- a/front/app/containers/Admin/ideas/all/index.tsx
+++ b/front/app/containers/Admin/ideas/all/index.tsx
@@ -35,7 +35,11 @@ const IdeasTab = () => {
         <FormattedMessage {...messages.inputManagerPageSubtitle} />
       </SectionDescription>
       <Box background={colors.white} p="40px">
-        {isLoading && <Spinner />}
+        {isLoading && (
+          <Box mb="28px">
+            <Spinner />
+          </Box>
+        )}
         <PostManager
           type="AllIdeas"
           defaultFilterMenu={defaultFilterMenu}

--- a/front/app/containers/Admin/ideas/all/index.tsx
+++ b/front/app/containers/Admin/ideas/all/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 // components
 import PostManager, { TFilterMenu } from 'components/admin/PostManager';
-import { Box, Title, colors } from '@citizenlab/cl2-component-library';
+import { Box, Title, colors, Spinner } from '@citizenlab/cl2-component-library';
 import { SectionDescription } from 'components/admin/Section';
 
 // resources
@@ -19,35 +19,32 @@ const IdeasTab = () => {
     'topics',
     'statuses',
   ];
-  const { data: projects } = useProjects({
+  const { data: projects, isLoading } = useProjects({
     pageSize: 250,
     sort: 'new',
     publicationStatuses,
     canModerate: true,
   });
 
-  if (projects) {
-    return (
-      <>
-        <Title color="primary">
-          <FormattedMessage {...messages.inputManagerPageTitle} />
-        </Title>
-        <SectionDescription>
-          <FormattedMessage {...messages.inputManagerPageSubtitle} />
-        </SectionDescription>
-        <Box background={colors.white} p="40px">
-          <PostManager
-            type="AllIdeas"
-            defaultFilterMenu={defaultFilterMenu}
-            visibleFilterMenus={visibleFilterMenus}
-            projects={projects.data}
-          />
-        </Box>
-      </>
-    );
-  }
-
-  return null;
+  return (
+    <>
+      <Title color="primary">
+        <FormattedMessage {...messages.inputManagerPageTitle} />
+      </Title>
+      <SectionDescription>
+        <FormattedMessage {...messages.inputManagerPageSubtitle} />
+      </SectionDescription>
+      <Box background={colors.white} p="40px">
+        {isLoading && <Spinner />}
+        <PostManager
+          type="AllIdeas"
+          defaultFilterMenu={defaultFilterMenu}
+          visibleFilterMenus={visibleFilterMenus}
+          projects={projects?.data}
+        />
+      </Box>
+    </>
+  );
 };
 
 const publicationStatuses: PublicationStatus[] = [


### PR DESCRIPTION
# Changelog

## Fixed
- Improves loading experience of input manager on ideas page. It shows a spinner and loads data incrementally.

The slow loading is because of the projects endpoint that takes some time when there are many projects. I have added a spinner and allowed to display the input manager as data is being fetched. The user will know that data is being fetched and will also be able to see some data even before
