### PR TITLE
CL-4107: fix flaky create update custom page test

### DIFF
--- a/front/app/components/UI/FileUploader/index.tsx
+++ b/front/app/components/UI/FileUploader/index.tsx
@@ -52,7 +52,11 @@ const FileUploader = ({
   const fileNames = files ? files.map((file) => file.name).join(', ') : '';
 
   return (
-    <Container className={className} key={id}>
+    <Container
+      className={className}
+      key={id}
+      data-cy="e2e-file-uploader-container"
+    >
       <FileInput onAdd={handleFileOnAdd} id={id} />
       <Error fieldName="file" apiErrors={apiErrors?.file} />
 

--- a/front/cypress/e2e/admin/pages_and_menu/create_update_and_view_custom_page.cy.ts
+++ b/front/cypress/e2e/admin/pages_and_menu/create_update_and_view_custom_page.cy.ts
@@ -27,10 +27,7 @@ describe('Admin: can', () => {
 
       // type title in each language
 
-      cy.get('.e2e-localeswitcher').each((button) => {
-        cy.wrap(button).click();
-        cy.get('#title_multiloc').type(page1);
-      });
+      cy.clickLocaleSwitcherAndType(page1);
 
       // submit
       cy.get('[data-cy="e2e-submit-custom-page"]').click();

--- a/front/cypress/e2e/admin/pages_and_menu/create_update_and_view_custom_page.cy.ts
+++ b/front/cypress/e2e/admin/pages_and_menu/create_update_and_view_custom_page.cy.ts
@@ -26,7 +26,6 @@ describe('Admin: can', () => {
       cy.get('#create-custom-page').click();
 
       // type title in each language
-
       cy.clickLocaleSwitcherAndType(page1);
 
       // submit

--- a/front/cypress/e2e/project_topics.cy.ts
+++ b/front/cypress/e2e/project_topics.cy.ts
@@ -33,13 +33,7 @@ describe('Project topics', () => {
 
       // Add custom topic
       cy.get('#e2e-add-custom-topic-button').click();
-      cy.get('#title_multiloc').type(topicTitle);
-      cy.get('.nl-BE').click();
-      cy.get('#title_multiloc').type(topicTitle);
-      cy.get('.nl-NL').click();
-      cy.get('#title_multiloc').type(topicTitle);
-      cy.get('.fr-BE').click();
-      cy.get('#title_multiloc').type(topicTitle);
+      cy.clickLocaleSwitcherAndType(topicTitle);
       cy.get('#e2e-submit-wrapper-button').click();
       cy.wait(1000);
       cy.get('.e2e-admin-list-row').contains(topicTitle);
@@ -55,13 +49,7 @@ describe('Project topics', () => {
       // create a topic
       cy.visit('admin/settings/topics');
       cy.get('#e2e-add-custom-topic-button').click();
-      cy.get('#title_multiloc').type(topicTitle);
-      cy.get('.nl-BE').click();
-      cy.get('#title_multiloc').type(topicTitle);
-      cy.get('.nl-NL').click();
-      cy.get('#title_multiloc').type(topicTitle);
-      cy.get('.fr-BE').click();
-      cy.get('#title_multiloc').type(topicTitle);
+      cy.clickLocaleSwitcherAndType(topicTitle);
       cy.get('#e2e-submit-wrapper-button').click();
       cy.wait(1000);
       cy.get('.e2e-admin-list-row').contains(topicTitle);
@@ -95,13 +83,7 @@ describe('Project topics', () => {
       // create a topic
       cy.visit('admin/settings/topics');
       cy.get('#e2e-add-custom-topic-button').click();
-      cy.get('#title_multiloc').type(topicTitle);
-      cy.get('.nl-BE').click();
-      cy.get('#title_multiloc').type(topicTitle);
-      cy.get('.nl-NL').click();
-      cy.get('#title_multiloc').type(topicTitle);
-      cy.get('.fr-BE').click();
-      cy.get('#title_multiloc').type(topicTitle);
+      cy.clickLocaleSwitcherAndType(topicTitle);
       cy.get('#e2e-submit-wrapper-button').click();
       cy.wait(1000);
       cy.get('.e2e-admin-list-row').contains(topicTitle);
@@ -144,13 +126,7 @@ describe('Project topics', () => {
       // create a topic
       cy.visit('admin/settings/topics');
       cy.get('#e2e-add-custom-topic-button').click();
-      cy.get('#title_multiloc').type(topicTitle);
-      cy.get('.nl-BE').click();
-      cy.get('#title_multiloc').type(topicTitle);
-      cy.get('.nl-NL').click();
-      cy.get('#title_multiloc').type(topicTitle);
-      cy.get('.fr-BE').click();
-      cy.get('#title_multiloc').type(topicTitle);
+      cy.clickLocaleSwitcherAndType(topicTitle);
       cy.get('#e2e-submit-wrapper-button').click();
       cy.wait(1000);
       cy.get('.e2e-admin-list-row').contains(topicTitle);
@@ -179,13 +155,7 @@ describe('Project topics', () => {
       // create a topic
       cy.visit('admin/settings/topics');
       cy.get('#e2e-add-custom-topic-button').click();
-      cy.get('#title_multiloc').type(topicTitle);
-      cy.get('.nl-BE').click();
-      cy.get('#title_multiloc').type(topicTitle);
-      cy.get('.nl-NL').click();
-      cy.get('#title_multiloc').type(topicTitle);
-      cy.get('.fr-BE').click();
-      cy.get('#title_multiloc').type(topicTitle);
+      cy.clickLocaleSwitcherAndType(topicTitle);
       cy.get('#e2e-submit-wrapper-button').click();
       cy.wait(1000);
       cy.get('.e2e-admin-list-row').contains(topicTitle);
@@ -237,13 +207,7 @@ describe('Project topics', () => {
       // create a topic in the topic manager
       cy.visit('admin/settings/topics');
       cy.get('#e2e-add-custom-topic-button').click();
-      cy.get('#title_multiloc').type(topicTitle);
-      cy.get('.nl-BE').click();
-      cy.get('#title_multiloc').type(topicTitle);
-      cy.get('.nl-NL').click();
-      cy.get('#title_multiloc').type(topicTitle);
-      cy.get('.fr-BE').click();
-      cy.get('#title_multiloc').type(topicTitle);
+      cy.clickLocaleSwitcherAndType(topicTitle);
       cy.get('#e2e-submit-wrapper-button').click();
       cy.wait(1000);
 
@@ -273,13 +237,7 @@ describe('Project topics', () => {
       // create a topic in the topic manager
       cy.visit('admin/settings/topics');
       cy.get('#e2e-add-custom-topic-button').click();
-      cy.get('#title_multiloc').type(topicTitle);
-      cy.get('.nl-BE').click();
-      cy.get('#title_multiloc').type(topicTitle);
-      cy.get('.nl-NL').click();
-      cy.get('#title_multiloc').type(topicTitle);
-      cy.get('.fr-BE').click();
-      cy.get('#title_multiloc').type(topicTitle);
+      cy.clickLocaleSwitcherAndType(topicTitle);
       cy.get('#e2e-submit-wrapper-button').click();
       cy.wait(1000);
 

--- a/front/cypress/support/commands.ts
+++ b/front/cypress/support/commands.ts
@@ -54,6 +54,7 @@ declare global {
       apiRemoveFolder: typeof apiRemoveFolder;
       apiRemoveProject: typeof apiRemoveProject;
       apiRemoveCustomPage: typeof apiRemoveCustomPage;
+      apiCreateCustomPage: typeof apiCreateCustomPage;
       apiAddProjectsToFolder: typeof apiAddProjectsToFolder;
       apiCreatePhase: typeof apiCreatePhase;
       apiCreateCustomField: typeof apiCreateCustomField;
@@ -1060,6 +1061,32 @@ export function apiRemoveFolder(folderId: string) {
   });
 }
 
+export function apiCreateCustomPage(title: string) {
+  return cy.apiLogin('admin@citizenlab.co', 'democracy2.0').then((response) => {
+    const adminJwt = response.body.jwt;
+
+    return cy.request({
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${adminJwt}`,
+      },
+      method: 'POST',
+      url: `web_api/v1/static_pages`,
+      body: {
+        static_page: {
+          projects_filter_type: 'no_filter',
+          topic_ids: [],
+          title_multiloc: {
+            en: title,
+            'nl-BE': title,
+            'nl-NL': title,
+            'fr-BE': title,
+          },
+        },
+      },
+    });
+  });
+}
 export function apiRemoveCustomPage(customPageId: string) {
   return cy.apiLogin('admin@citizenlab.co', 'democracy2.0').then((response) => {
     const adminJwt = response.body.jwt;
@@ -1567,3 +1594,4 @@ Cypress.Commands.add(
 );
 Cypress.Commands.add('apiUpdateHomepageSettings', apiUpdateHomepageSettings);
 Cypress.Commands.add('apiRemoveCustomPage', apiRemoveCustomPage);
+Cypress.Commands.add('apiCreateCustomPage', apiCreateCustomPage);

--- a/front/cypress/support/commands.ts
+++ b/front/cypress/support/commands.ts
@@ -69,6 +69,7 @@ declare global {
       notIntersectsViewport: typeof notIntersectsViewport;
       apiUpdateHomepageSettings: typeof apiUpdateHomepageSettings;
       apiUpdateAppConfiguration: typeof apiUpdateAppConfiguration;
+      clickLocaleSwitcherAndType: typeof clickLocaleSwitcherAndType;
     }
   }
 }
@@ -1410,6 +1411,14 @@ export function apiUpdateAppConfiguration(
   });
 }
 
+export function clickLocaleSwitcherAndType(title: string) {
+  cy.get('.e2e-localeswitcher').each((button) => {
+    cy.wrap(button).click();
+    cy.get('#title_multiloc').clear().type(title);
+    // cy.get('#title_multiloc').type(title);
+  });
+}
+
 export function apiUpdateHomepageSettings({
   top_info_section_enabled,
   bottom_info_section_enabled,
@@ -1595,3 +1604,4 @@ Cypress.Commands.add(
 Cypress.Commands.add('apiUpdateHomepageSettings', apiUpdateHomepageSettings);
 Cypress.Commands.add('apiRemoveCustomPage', apiRemoveCustomPage);
 Cypress.Commands.add('apiCreateCustomPage', apiCreateCustomPage);
+Cypress.Commands.add('clickLocaleSwitcherAndType', clickLocaleSwitcherAndType);

--- a/front/cypress/support/commands.ts
+++ b/front/cypress/support/commands.ts
@@ -1415,7 +1415,6 @@ export function clickLocaleSwitcherAndType(title: string) {
   cy.get('.e2e-localeswitcher').each((button) => {
     cy.wrap(button).click();
     cy.get('#title_multiloc').clear().type(title);
-    // cy.get('#title_multiloc').type(title);
   });
 }
 


### PR DESCRIPTION
# Changelog

## Technical
- Re-enable and fix flaky create_update_and_view_custom_page end to end test

FYI
- The old flakiness appears to have been around attaching files. I have broken these tests down and simplified them a bit. In the past, we fixed the attachments flakiness with a wait but let me monitor it before going down that road.

