### PR TITLE
Password reset: prevent user enumeration

### DIFF
--- a/back/app/controllers/web_api/v1/reset_password_controller.rb
+++ b/back/app/controllers/web_api/v1/reset_password_controller.rb
@@ -16,10 +16,9 @@ class WebApi::V1::ResetPasswordController < ApplicationController
     reset_password_service.send_email_later user, token
     reset_password_service.log_activity user, token
     head :accepted
-    
-    rescue ActiveRecord::RecordNotFound
-      head :accepted
-    end
+
+  rescue ActiveRecord::RecordNotFound
+    head :accepted
   end
 
   def reset_password

--- a/back/app/controllers/web_api/v1/reset_password_controller.rb
+++ b/back/app/controllers/web_api/v1/reset_password_controller.rb
@@ -16,7 +16,6 @@ class WebApi::V1::ResetPasswordController < ApplicationController
     reset_password_service.send_email_later user, token
     reset_password_service.log_activity user, token
     head :accepted
-
   rescue ActiveRecord::RecordNotFound
     head :accepted
   end

--- a/back/app/controllers/web_api/v1/reset_password_controller.rb
+++ b/back/app/controllers/web_api/v1/reset_password_controller.rb
@@ -6,16 +6,20 @@ class WebApi::V1::ResetPasswordController < ApplicationController
 
   # Creates a password reset token and sends an email to the user with instructions.
   def reset_password_email
-    user = User.not_invited.find_by_cimail! params[:user][:email]
+    begin 
+      user = User.not_invited.find_by_cimail! params[:user][:email]
 
-    reset_password_service = ResetPasswordService.new
-    token = reset_password_service.generate_reset_password_token user
+      reset_password_service = ResetPasswordService.new
+      token = reset_password_service.generate_reset_password_token user
 
-    user.update! reset_password_token: token
+      user.update! reset_password_token: token
 
-    reset_password_service.send_email_later user, token
-    reset_password_service.log_activity user, token
-    head :accepted
+      reset_password_service.send_email_later user, token
+      reset_password_service.log_activity user, token
+      head :accepted
+    rescue ActiveRecord::RecordNotFound
+      head :accepted
+    end
   end
 
   def reset_password

--- a/back/app/controllers/web_api/v1/reset_password_controller.rb
+++ b/back/app/controllers/web_api/v1/reset_password_controller.rb
@@ -6,7 +6,7 @@ class WebApi::V1::ResetPasswordController < ApplicationController
 
   # Creates a password reset token and sends an email to the user with instructions.
   def reset_password_email
-    user = User.not_invited.find_by_cimail! params[:user][:email]
+    user = User.not_invited.find_by_cimail params[:user][:email]
     if user
       reset_password_service = ResetPasswordService.new
       token = reset_password_service.generate_reset_password_token user

--- a/back/app/controllers/web_api/v1/reset_password_controller.rb
+++ b/back/app/controllers/web_api/v1/reset_password_controller.rb
@@ -7,16 +7,15 @@ class WebApi::V1::ResetPasswordController < ApplicationController
   # Creates a password reset token and sends an email to the user with instructions.
   def reset_password_email
     user = User.not_invited.find_by_cimail! params[:user][:email]
+    if user
+      reset_password_service = ResetPasswordService.new
+      token = reset_password_service.generate_reset_password_token user
 
-    reset_password_service = ResetPasswordService.new
-    token = reset_password_service.generate_reset_password_token user
+      user.update! reset_password_token: token
 
-    user.update! reset_password_token: token
-
-    reset_password_service.send_email_later user, token
-    reset_password_service.log_activity user, token
-    head :accepted
-  rescue ActiveRecord::RecordNotFound
+      reset_password_service.send_email_later user, token
+      reset_password_service.log_activity user, token
+    end
     head :accepted
   end
 

--- a/back/app/controllers/web_api/v1/reset_password_controller.rb
+++ b/back/app/controllers/web_api/v1/reset_password_controller.rb
@@ -6,17 +6,17 @@ class WebApi::V1::ResetPasswordController < ApplicationController
 
   # Creates a password reset token and sends an email to the user with instructions.
   def reset_password_email
-    begin 
-      user = User.not_invited.find_by_cimail! params[:user][:email]
+    user = User.not_invited.find_by_cimail! params[:user][:email]
 
-      reset_password_service = ResetPasswordService.new
-      token = reset_password_service.generate_reset_password_token user
+    reset_password_service = ResetPasswordService.new
+    token = reset_password_service.generate_reset_password_token user
 
-      user.update! reset_password_token: token
+    user.update! reset_password_token: token
 
-      reset_password_service.send_email_later user, token
-      reset_password_service.log_activity user, token
-      head :accepted
+    reset_password_service.send_email_later user, token
+    reset_password_service.log_activity user, token
+    head :accepted
+    
     rescue ActiveRecord::RecordNotFound
       head :accepted
     end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -101,14 +101,6 @@ class User < ApplicationRecord
       where('lower(email) = lower(?)', email).first
     end
 
-    # Returns the user record from the database which matches the specified
-    # email address (case-insensitive) or raises `ActiveRecord::RecordNotFound`.
-    # @param email [String] The email of the user
-    # @return [User] The user record
-    def find_by_cimail!(email)
-      find_by_cimail(email) || raise(ActiveRecord::RecordNotFound)
-    end
-
     # This method is used by knock to get the user.
     # Default is by email, but we want to compare
     # case insensitively and forbid login for

--- a/back/spec/acceptance/reset_password_spec.rb
+++ b/back/spec/acceptance/reset_password_spec.rb
@@ -28,18 +28,18 @@ resource 'Users' do
 
         example 'does not use underscores in a special manner' do
           do_request(user: { email: 's_hoorens@gmail.com' })
-          expect(status).to eq 404
+          expect(status).to eq 202
         end
 
         example 'does not use percentages in a special manner' do
           do_request(user: { email: '%hoorens@gmail.com%' })
-          expect(status).to eq 404
+          expect(status).to eq 202
         end
       end
 
       example '[error] Request password reset of an invitee' do
         do_request(user: { email: create(:invited_user).email })
-        expect(status).to eq 404
+        expect(status).to eq 202
       end
     end
 


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Don't return 404 when user record is not found while performing a password reset to prevent user enumeration