### PR TITLE
[CL-3422] Log out from FC when user deletes their account

### DIFF
--- a/back/app/controllers/omniauth_callback_controller.rb
+++ b/back/app/controllers/omniauth_callback_controller.rb
@@ -27,17 +27,12 @@ class OmniauthCallbackController < ApplicationController
     failure_redirect
   end
 
-  def logout
+  def logout_data
     provider = params[:provider]
     user_id = params[:user_id]
-    user = User.find(user_id)
-    auth_service = AuthenticationService.new
-
-    url = auth_service.logout_url(provider, user)
-
-    redirect_to url, allow_other_host: true
-  rescue ActiveRecord::RecordNotFound
-    redirect_to Frontend::UrlService.new.home_url
+    user = User.find_by(id: user_id)
+    url = user ? AuthenticationService.new.logout_url(provider, user) : Frontend::UrlService.new.home_url
+    render json: { url: url }
   end
 
   private

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -293,7 +293,7 @@ Rails.application.routes.draw do
   post '/auth/:provider/callback', to: 'omniauth_callback#create'
   get '/auth/failure', to: 'omniauth_callback#failure'
   post '/auth/failure', to: 'omniauth_callback#failure'
-  get '/auth/:provider/logout', to: 'omniauth_callback#logout'
+  get '/auth/:provider/logout_data', to: 'omniauth_callback#logout_data'
 
   if Rails.env.development?
     require 'que/web'

--- a/back/spec/acceptance/omniauth_callback_spec.rb
+++ b/back/spec/acceptance/omniauth_callback_spec.rb
@@ -22,10 +22,10 @@ resource 'Omniauth Callback', document: false do
 
     let(:user_id) { @user.id }
 
-    get '/auth/clave_unica/logout' do
-      example_request 'Redirect to ClaveUnica URL' do
-        expect(status).to eq(302)
-        expect(response_headers['Location']).to start_with('https://accounts.claveunica.gob.cl/api/v1/accounts/app/logout')
+    get '/auth/clave_unica/logout_data' do
+      example_request 'Returns ClaveUnica redirect URL' do
+        expect(status).to eq(200)
+        expect(json_response_body[:url]).to start_with('https://accounts.claveunica.gob.cl/api/v1/accounts/app/logout')
       end
     end
   end

--- a/front/app/api/authentication/sign_in_out/logoutUrl.ts
+++ b/front/app/api/authentication/sign_in_out/logoutUrl.ts
@@ -1,0 +1,14 @@
+import { IDecodedJwt } from 'utils/auth/jwt';
+
+import { AUTH_PATH } from 'containers/App/constants';
+
+export default async function logoutUrl(decodedJwt: IDecodedJwt | null) {
+  if (decodedJwt?.logout_supported) {
+    const { provider, sub } = decodedJwt;
+    const logoutDataUrl = `${AUTH_PATH}/${provider}/logout_data?user_id=${sub}`;
+    const logoutUrl = (await (await fetch(logoutDataUrl)).json()).url;
+    return logoutUrl;
+  } else {
+    return null;
+  }
+}

--- a/front/app/api/authentication/sign_in_out/signOut.ts
+++ b/front/app/api/authentication/sign_in_out/signOut.ts
@@ -1,4 +1,3 @@
-import { AUTH_PATH } from 'containers/App/constants';
 import { getJwt, removeJwt, decode } from 'utils/auth/jwt';
 import { endsWith } from 'utils/helperUtils';
 import clHistory from 'utils/cl-router/history';
@@ -7,6 +6,7 @@ import {
   invalidateQueryCache,
   resetMeQuery,
 } from 'utils/cl-react-query/resetQueryCache';
+import logoutUrl from './logoutUrl';
 
 export default async function signOut() {
   const jwt = getJwt();
@@ -17,8 +17,7 @@ export default async function signOut() {
     removeJwt();
 
     if (decodedJwt.logout_supported) {
-      const { provider, sub } = decodedJwt;
-      const url = `${AUTH_PATH}/${provider}/logout?user_id=${sub}`;
+      const url = await logoutUrl(decodedJwt);
       window.location.href = url;
     } else {
       await resetMeQuery();

--- a/front/app/utils/auth/jwt.ts
+++ b/front/app/utils/auth/jwt.ts
@@ -4,7 +4,7 @@ import { SECURE_COOKIE } from '../cookie';
 
 const COOKIE_NAME = 'cl2_jwt';
 
-interface IDecodedJwt {
+export interface IDecodedJwt {
   sub: string;
   provider?: string;
   logout_supported?: boolean;


### PR DESCRIPTION
Point 11 from the PDF file in the ticket.

Previously, we deleted a user account and only then tried to redirect to
the logout url. But at the time of redirect, the user was already deleted
and so we couldn't build a FranceConnect logout URL, because it required
`id_token_hint` stored in the database record associated with the user.

Now, first, we fetch the FranceConnect logout URL and only then delete
the user account.