### PR TITLE
Temporarily disable Sentry client reports

### DIFF
--- a/back/engines/commercial/multi_tenancy/config/initializers/sentry.rb
+++ b/back/engines/commercial/multi_tenancy/config/initializers/sentry.rb
@@ -17,6 +17,10 @@ Sentry.init do |config|
   # the user and it's harder to find bugs there.
   Que::Job # make sure it will raise error if we change background processing library
   config.excluded_exceptions = [] if $PROGRAM_NAME.include?('que')
+  # Client reports are supported by Sentry 21.9.0 and above.
+  # At the moment, we use 21.6.3, so we disable it to avoid confusion and logs pollution.
+  # https://develop.sentry.dev/sdk/client-reports/
+  config.send_client_reports = false
 end
 
 Sentry.set_tags(cluster: CL2_CLUSTER)


### PR DESCRIPTION
Currently, our logs have these lines
```json
{
  "host": "a7fef22b2577",
  "application": "Semantic Logger",
  "environment": "production",
  "timestamp": "2023-10-06T10:33:10.201214Z",
  "level": "error",
  "level_index": 4,
  "pid": 51,
  "thread": "worker-19",
  "file": "/cl2_back/vendor/bundle/ruby/2.7.0/gems/sentry-ruby-5.8.0/lib/sentry/utils/logging_helper.rb",
  "line": 9,
  "name": "Rails",
  "message": "sentry -- Transaction sending failed: the server responded with status 400\nbody: {\"detail\":\"invalid event envelope\",\"causes\":[\"invalid item header\",\"unknown variant `client_report`, expected one of `event`, `transaction`, `security`, `attachment`, `form_data`, `raw_security`, `unreal_report`, `user_report`, `session`, `sessions`, `metrics`, `metric_buckets` at line 2 column 23\"]}"
}
```
This PR will hopefully get rid of them.