### PR TITLE
[CL-4010] Fix for official feedbacks containing links when displayed in mails

### DIFF
--- a/back/engines/free/email_campaigns/app/views/email_campaigns/official_feedbacks/_card.mjml
+++ b/back/engines/free/email_campaigns/app/views/email_campaigns/official_feedbacks/_card.mjml
@@ -26,7 +26,7 @@
     <mj-text font-size="14px">
       <%= format_message('author_wrote', component: 'general', values: { authorName: author_name }) %>
       <p style="margin: 15px 0 0;">
-        <%= localize_for_recipient(event.official_feedback_body_multiloc).first(140) %>
+        <%= localize_for_recipient(event.official_feedback_body_multiloc) %>
       </p>
     </mj-text>
   </mj-column>


### PR DESCRIPTION
Issue was caused by limiting the multiloc string to 140 characters, which in this case meant the html link was incomplete when included in the mail, causing the view rendering to fail at that point.

Fixed for official feedbacks by removing character limit, as I cannot think of an issue with including the full text of official feedbacks in mails.

This issue will still occur where links are included in other multilocs which we render in mails and limit to a specific character length (usually 140 characters). This will include the body text of comments, idea, intitiatives, project descriptions, etc. I have confirmed this is an issue with comment body multilocs in mails, for example. I have asked product if we should remove character limits on all such items, or just a subset, or no others (see ticket [CL-4010](https://citizenlab.atlassian.net/browse/CL-4010)).

Screenshot after fix (I reproduced issue before fixing):
<img width="621" alt="Screenshot 2023-10-09 at 13 17 02" src="https://github.com/CitizenLabDotCo/citizenlab/assets/3944042/c0c33503-45fc-4ae4-9a7d-5e41867aefe9">


# Changelog
## Fixed
- [CL-4010] Fix for official feedbacks containing links when displayed in mails


[CL-4010]: https://citizenlab.atlassian.net/browse/CL-4010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ