### PR TITLE
Cl 4153 survey moderator permissions

### DIFF
--- a/front/app/containers/IdeasNewPage/IdeasNewForm/index.tsx
+++ b/front/app/containers/IdeasNewPage/IdeasNewForm/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useCallback, lazy, Suspense } from 'react';
 
 // api
-import { isRegularUser } from 'utils/permissions/roles';
+import { isProjectModerator } from 'utils/permissions/roles';
 import { canModerateProject } from 'utils/permissions/rules/projectPermissions';
 
 import useAuthUser from 'api/me/useAuthUser';
@@ -151,7 +151,7 @@ const IdeasNewPageWithJSONForm = () => {
       phase_ids:
         phaseId &&
         !isNilOrError(authUser) &&
-        !isRegularUser({ data: authUser.data })
+        isProjectModerator({ data: authUser.data }, project.data.id)
           ? [phaseId]
           : null,
       anonymous: postAnonymously ? true : undefined,

--- a/front/app/containers/IdeasNewPage/IdeasNewForm/index.tsx
+++ b/front/app/containers/IdeasNewPage/IdeasNewForm/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useCallback, lazy, Suspense } from 'react';
 
 // api
-import { isProjectModerator } from 'utils/permissions/roles';
+import { isAdmin, isProjectModerator } from 'utils/permissions/roles';
 import { canModerateProject } from 'utils/permissions/rules/projectPermissions';
 
 import useAuthUser from 'api/me/useAuthUser';
@@ -151,7 +151,8 @@ const IdeasNewPageWithJSONForm = () => {
       phase_ids:
         phaseId &&
         !isNilOrError(authUser) &&
-        isProjectModerator({ data: authUser.data }, project.data.id)
+        (isAdmin({ data: authUser.data }) ||
+          isProjectModerator({ data: authUser.data }, project.data.id))
           ? [phaseId]
           : null,
       anonymous: postAnonymously ? true : undefined,

--- a/front/app/utils/actionTakingRules.ts
+++ b/front/app/utils/actionTakingRules.ts
@@ -146,7 +146,8 @@ export const getIdeaPostingRules = ({
 
     if (
       signedIn &&
-      (isAdmin({ data: authUser }) || isProjectModerator({ data: authUser }))
+      (isAdmin({ data: authUser }) ||
+        isProjectModerator({ data: authUser }, project?.id))
     ) {
       return {
         show: true,


### PR DESCRIPTION
# Changelog
## Fixed
- CL-4153 - Fix to enable moderators to submit ideas/surveys on timeline projects on which they are NOT moderators
