### PR TITLE
[TAN-374] Use Oj for JSON serialization that outperforms standard json

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -23,6 +23,7 @@ gem 'bcrypt', '~> 3.1.7'
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 gem 'rack-cors'
+gem 'oj'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -796,6 +796,7 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
+    oj (3.16.1)
     okcomputer (1.18.4)
     omniauth (1.9.2)
       hashie (>= 3.4.6)
@@ -1246,6 +1247,7 @@ DEPENDENCIES
   multi_tenancy!
   nlp!
   nokogiri (~> 1.14.3)
+  oj
   okcomputer
   omniauth (~> 1.9.1)
   omniauth-facebook

--- a/back/config/initializers/oj.rb
+++ b/back/config/initializers/oj.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Oj.optimize_rails

--- a/back/engines/commercial/analytics/app/services/analytics/query_schema.json.erb
+++ b/back/engines/commercial/analytics/app/services/analytics/query_schema.json.erb
@@ -6,13 +6,13 @@
       "anyOf" : [
         {
           "type" : "string",
-          "pattern" : "^[a-z_]*\.[a-z_]*$"
-        }, 
+          "pattern" : "^[a-z_]*.[a-z_]*$"
+        },
         {
           "type": "array",
           "items" : {
             "type" : "string",
-            "pattern" : "^[a-z_]*\.[a-z_]*$"
+            "pattern" : "^[a-z_]*.[a-z_]*$"
           },
           "minLength" : 1
         }
@@ -26,7 +26,7 @@
       "type" : "object",
       "minProperties" : 1,
       "patternProperties" : {
-        "^[a-z_]*\.[a-z_]*$" : {
+        "^[a-z_]*.[a-z_]*$" : {
           "type" : ["string", "integer", "null", "array", "object", "boolean"],
           "items" : {"type" : ["string", "integer", "null", "boolean"]},
           "properties" : {
@@ -44,13 +44,13 @@
       "anyOf" : [
         {
           "type" : "string",
-          "pattern" : "^[a-z_]*\.[a-z_]*$"
-        }, 
+          "pattern" : "^[a-z_]*.[a-z_]*$"
+        },
         {
           "type": "array",
           "items" : {
             "type" : "string",
-            "pattern" : "^[a-z_]*\.[a-z_]*$"
+            "pattern" : "^[a-z_]*.[a-z_]*$"
           },
           "minLength" : 1
         }
@@ -60,12 +60,12 @@
       "type" : "object",
       "minProperties" : 1,
       "patternProperties" : {
-        "^[a-z_]*\.[a-z_]*$" : {
+        "^[a-z_]*.[a-z_]*$" : {
           "anyOf" : [
             {
               "type" : "string",
               "enum" : ["min", "max", "avg", "sum", "count", "first"]
-            }, 
+            },
             {
               "type": "array",
               "items" : {
@@ -82,7 +82,7 @@
     "sort" : {
       "type": "object",
       "patternProperties" : {
-        "^[a-z_]*\.[a-z_]*$" : {
+        "^[a-z_]*.[a-z_]*$" : {
           "type" : "string",
           "enum" : ["ASC", "DESC"]
         }


### PR DESCRIPTION
## Benchmarks on the `admin_api/tenants` call

### Oj
to_json: 47ms
entire request: 294ms

to_json: 26ms
entire request: 281ms

to_json: 157ms
entire request: 541ms

### Standard json
to_json: 601ms
entire request: 873ms

to_json: 725ms
entire request: 1001ms

to_json: 579ms
entire request: 867ms


# Changelog
## Fixed
* [TAN-374] Improve AdminHQ tenant list page performance