### PR TITLE
[CL-4152] Include hidden fields in Typeform survey results export

### DIFF
--- a/back/engines/free/surveys/app/services/surveys/typeform_api_parser.rb
+++ b/back/engines/free/surveys/app/services/surveys/typeform_api_parser.rb
@@ -74,16 +74,19 @@ module Surveys
         }
       end
 
-      # get hidden fields, if any, and add to answers hash
-      (tf_response['hidden'] || []).map do |hidden|
-        answers << {
-          question_id: "#{hidden[0]}_hidden_field",
-          question_text: "#{hidden[0]} (hidden field)",
-          value: hidden[1]
-        }
-      end
+      answers += parse_hidden_fields(tf_response)
 
       answers
+    end
+
+    def parse_hidden_fields(tf_response)
+      (tf_response['hidden'] || []).map do |hidden_field|
+        {
+          question_id: "#{hidden_field[0]}_hidden_field",
+          question_text: "#{hidden_field[0]} (hidden field)",
+          value: hidden_field[1]
+        }
+      end
     end
   end
 end

--- a/back/engines/free/surveys/app/services/surveys/typeform_api_parser.rb
+++ b/back/engines/free/surveys/app/services/surveys/typeform_api_parser.rb
@@ -80,11 +80,11 @@ module Surveys
     end
 
     def parse_hidden_fields(tf_response)
-      (tf_response['hidden'] || []).map do |hidden_field|
+      (tf_response['hidden'] || []).map do |k, v|
         {
-          question_id: "#{hidden_field[0]}_hidden_field",
-          question_text: "#{hidden_field[0]} (hidden field)",
-          value: hidden_field[1]
+          question_id: "#{k}_hidden_field",
+          question_text: "#{k} (hidden field)",
+          value: v
         }
       end
     end

--- a/back/engines/free/surveys/spec/services/typeform_api_parser_spec.rb
+++ b/back/engines/free/surveys/spec/services/typeform_api_parser_spec.rb
@@ -277,4 +277,31 @@ describe Surveys::TypeformApiParser do
       expect(responses).to all(be_valid)
     end
   end
+
+  describe 'parse_answers' do
+    it 'encodes hidden fields and their values as answers' do
+      response = all_responses_return_value[0]
+      response['hidden'] = { 'email' => 'testemail@g.com' }
+      response['hidden']['user_id'] = '1234'
+
+      class_instance = described_class.new
+
+      field_id_to_title = class_instance.send(:extract_field_titles, form_response_return_value)
+      answers = class_instance.send(:parse_answers, response, field_id_to_title)
+
+      expect(answers.find { |answer| answer[:question_id] == 'email_hidden_field' })
+        .to eq({
+          question_id: 'email_hidden_field',
+          question_text: 'email (hidden field)',
+          value: 'testemail@g.com'
+        })
+
+      expect(answers.find { |answer| answer[:question_id] == 'user_id_hidden_field' })
+        .to eq({
+          question_id: 'user_id_hidden_field',
+          question_text: 'user_id (hidden field)',
+          value: '1234'
+        })
+    end
+  end
 end

--- a/back/engines/free/surveys/spec/services/typeform_api_parser_spec.rb
+++ b/back/engines/free/surveys/spec/services/typeform_api_parser_spec.rb
@@ -281,8 +281,7 @@ describe Surveys::TypeformApiParser do
   describe 'parse_answers' do
     it 'encodes hidden fields and their values as answers' do
       response = all_responses_return_value[0]
-      response['hidden'] = { 'email' => 'testemail@g.com' }
-      response['hidden']['user_id'] = '1234'
+      response['hidden'] = { 'email' => 'testemail@g.com', 'user_id' => '1234' }
 
       class_instance = described_class.new
 


### PR DESCRIPTION
Adds parsing of `email` and `user_id` Typeform hidden fields and the encoding of these fields and their values as answers, such that they are included in the XLSX export of Typeform survey results.

Tested functionally, and no issues found when exporting results of Typeform surveys with or without hidden fields.

<img width="757" alt="Screenshot 2023-10-11 at 16 49 14" src="https://github.com/CitizenLabDotCo/citizenlab/assets/3944042/f9df249f-d1f3-4d36-a294-7fc35d01d46a">

# Changelog
## Fixed
- [CL-4152] Include hidden fields in Typeform survey results export (`user_id` &/or `email`)


[CL-4152]: https://citizenlab.atlassian.net/browse/CL-4152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ