### PR TITLE
CL-4167 Fix lastpass install in CI by updating curl version

### DIFF
--- a/.circleci/install_lpass.sh
+++ b/.circleci/install_lpass.sh
@@ -19,8 +19,8 @@ apt-get update
 apt-get --no-install-recommends -yqq install \
   build-essential=12.8ubuntu1.1 \
   cmake=3.16.3-1ubuntu1.20.04.1 \
-  libcurl4=7.68.0-1ubuntu2.19 \
-  libcurl4-openssl-dev=7.68.0-1ubuntu2.19 \
+  libcurl4=7.68.0-1ubuntu2.20 \
+  libcurl4-openssl-dev=7.68.0-1ubuntu2.20 \
   libssl-dev=1.1.1f-1ubuntu2.19 \
   libxml2=2.9.10+dfsg-5ubuntu0.20.04.6 \
   libxml2-dev=2.9.10+dfsg-5ubuntu0.20.04.6 \


### PR DESCRIPTION
Fixes these `apt-get install` errors
```
E: Version '7.68.0-1ubuntu2.19' for 'libcurl4' was not found
E: Version '7.68.0-1ubuntu2.19' for 'libcurl4-openssl-dev' was not found
```

# Changelog
## Technical
- Fixed LastPass CLI install for e2e tests