### PR TITLE
[CL-3870] Add www to hoplr url to fix "Issuer mismatch"

### DIFF
--- a/back/engines/commercial/id_hoplr/app/lib/id_hoplr/hoplr_omniauth.rb
+++ b/back/engines/commercial/id_hoplr/app/lib/id_hoplr/hoplr_omniauth.rb
@@ -43,7 +43,7 @@ module IdHoplr
     def host
       case AppConfiguration.instance.settings('hoplr_login', 'environment')
       when 'test'       then 'test.hoplr.com'
-      when 'production' then 'hoplr.com'
+      when 'production' then 'www.hoplr.com'
       end
     end
 


### PR DESCRIPTION
```
[6] pry(main)> ::OpenIDConnect::Discovery::Provider::Config.discover!("https://hoplr.com/")
OpenIDConnect::Discovery::DiscoveryFailed: Issuer mismatch

[7] pry(main)> ::OpenIDConnect::Discovery::Provider::Config.discover!("https://www.hoplr.com/") 
=> #<OpenIDConnect::Discovery::Provider::Config::Response:0x000056478bfda650
 @acr_values_supported=nil,
 @authorization_endpoint="https://www.hoplr.com/connect/authorize",
 ...
```

Discussion:
https://sentry.hq.citizenlab.co/organizations/citizenlab/issues/77567/?project=2&query=is%3Aunresolved&statsPeriod=14d

Error:
https://citizenlabco.slack.com/archives/C05E3STMDNY/p1697548302402919?thread_ts=1697531306.137489&cid=C05E3STMDNY


# Changelog
## Fixed
* Fix hoplr authentication error
