### PR TITLE
Fix maps request when there are special characters in the query

### DIFF
--- a/back/app/services/location/service.rb
+++ b/back/app/services/location/service.rb
@@ -2,12 +2,12 @@
 
 class Location::Service
   def autocomplete(input, language)
-    response = HTTParty.get("https://maps.googleapis.com/maps/api/place/autocomplete/json?input=#{input}&key=#{api_key}&language=#{language}")
+    response = HTTParty.get("https://maps.googleapis.com/maps/api/place/autocomplete/json?input=#{URI.escape(input)}&key=#{api_key}&language=#{language}")
     { results: response['predictions'].pluck('description') }
   end
 
   def geocode(address, language)
-    response = HTTParty.get("https://maps.googleapis.com/maps/api/geocode/json?address=#{address}&key=#{api_key}&language=#{language}")
+    response = HTTParty.get("https://maps.googleapis.com/maps/api/geocode/json?address=#{URI.escape(address)}&key=#{api_key}&language=#{language}")
     { location: response['results'].first['geometry']['location'] }
   end
 

--- a/back/app/services/location/service.rb
+++ b/back/app/services/location/service.rb
@@ -2,12 +2,12 @@
 
 class Location::Service
   def autocomplete(input, language)
-    response = HTTParty.get("https://maps.googleapis.com/maps/api/place/autocomplete/json?input=#{URI.escape(input)}&key=#{api_key}&language=#{language}")
+    response = HTTParty.get("https://maps.googleapis.com/maps/api/place/autocomplete/json?input=#{CGI.escape(input)}&key=#{api_key}&language=#{language}")
     { results: response['predictions'].pluck('description') }
   end
 
   def geocode(address, language)
-    response = HTTParty.get("https://maps.googleapis.com/maps/api/geocode/json?address=#{URI.escape(address)}&key=#{api_key}&language=#{language}")
+    response = HTTParty.get("https://maps.googleapis.com/maps/api/geocode/json?address=#{CGI.escape(address)}&key=#{api_key}&language=#{language}")
     { location: response['results'].first['geometry']['location'] }
   end
 

--- a/front/app/components/Form/Components/Controls/LocationControl.tsx
+++ b/front/app/components/Form/Components/Controls/LocationControl.tsx
@@ -45,10 +45,7 @@ const LocationControl = ({
           label: data || '',
         }}
         onChange={(location: Option) => {
-          handleChange(
-            path,
-            location.value === '' ? undefined : location.value
-          );
+          handleChange(path, location?.value ? location.value : undefined);
         }}
         placeholder={''}
         onBlur={() => setDidBlur(true)}

--- a/front/app/components/Form/Components/Controls/LocationControl.tsx
+++ b/front/app/components/Form/Components/Controls/LocationControl.tsx
@@ -40,10 +40,14 @@ const LocationControl = ({
       />
 
       <LocationInput
-        value={{
-          value: data || '',
-          label: data || '',
-        }}
+        value={
+          data
+            ? {
+                value: data,
+                label: data,
+              }
+            : null
+        }
         onChange={(location: Option) => {
           handleChange(path, location?.value ? location.value : undefined);
         }}

--- a/front/app/components/HookForm/LocationInput/index.tsx
+++ b/front/app/components/HookForm/LocationInput/index.tsx
@@ -46,8 +46,8 @@ const LocationInput = ({ name, ...rest }: Props) => {
                     }
                   : null
               }
-              onChange={(newOption: Option) => {
-                setValue(name, newOption.value);
+              onChange={(newOption: Option | null) => {
+                setValue(name, newOption?.value);
               }}
             />
           );

--- a/front/app/components/HookForm/LocationInput/index.tsx
+++ b/front/app/components/HookForm/LocationInput/index.tsx
@@ -47,7 +47,7 @@ const LocationInput = ({ name, ...rest }: Props) => {
                   : null
               }
               onChange={(newOption: Option | null) => {
-                setValue(name, newOption?.value);
+                setValue(name, newOption?.value || null);
               }}
             />
           );

--- a/front/app/components/UI/LocationInput/index.tsx
+++ b/front/app/components/UI/LocationInput/index.tsx
@@ -52,7 +52,9 @@ const LocationInput = (
       }
     };
 
-    fetchDefaultOptions();
+    if (props.value?.value) {
+      fetchDefaultOptions();
+    }
   }, [locale, props.value?.value]);
 
   const promiseOptions = async (inputValue: string) => {
@@ -83,6 +85,10 @@ const LocationInput = (
       loadOptions={promiseOptions}
       styles={selectStyles}
       noOptionsMessage={() => formatMessage(messages.noOptions)}
+      blurInputOnSelect
+      menuShouldScrollIntoView={false}
+      isClearable
+      openMenuOnClick={false}
       {...props}
     />
   );

--- a/front/app/containers/Admin/projects/project/events/edit.tsx
+++ b/front/app/containers/Admin/projects/project/events/edit.tsx
@@ -600,8 +600,8 @@ const AdminProjectEventEdit = () => {
                   value: eventAttrs.address_1 || '',
                   label: eventAttrs.address_1 || '',
                 }}
-                onChange={(option: Option) => {
-                  handleAddress1OnChange(option.value);
+                onChange={(option: Option | null) => {
+                  handleAddress1OnChange(option?.value ? option.value : '');
                 }}
                 placeholder={formatMessage(messages.searchForLocation)}
               />

--- a/front/app/containers/Admin/projects/project/events/edit.tsx
+++ b/front/app/containers/Admin/projects/project/events/edit.tsx
@@ -478,8 +478,6 @@ const AdminProjectEventEdit = () => {
     return <Spinner />;
   }
 
-  console.log(eventAttrs);
-
   return (
     <>
       <SectionTitle>

--- a/front/app/containers/Admin/projects/project/events/edit.tsx
+++ b/front/app/containers/Admin/projects/project/events/edit.tsx
@@ -478,6 +478,8 @@ const AdminProjectEventEdit = () => {
     return <Spinner />;
   }
 
+  console.log(eventAttrs);
+
   return (
     <>
       <SectionTitle>
@@ -596,10 +598,14 @@ const AdminProjectEventEdit = () => {
               <LocationInput
                 id="event-location-picker"
                 className="e2e-event-location-input"
-                value={{
-                  value: eventAttrs.address_1 || '',
-                  label: eventAttrs.address_1 || '',
-                }}
+                value={
+                  eventAttrs.address_1
+                    ? {
+                        value: eventAttrs.address_1,
+                        label: eventAttrs.address_1,
+                      }
+                    : null
+                }
                 onChange={(option: Option | null) => {
                   handleAddress1OnChange(option?.value ? option.value : '');
                 }}

--- a/front/app/containers/InitiativesEditPage/InitiativesEditFormWrapper.tsx
+++ b/front/app/containers/InitiativesEditPage/InitiativesEditFormWrapper.tsx
@@ -59,10 +59,10 @@ const InitiativesEditFormWrapper = ({
         requestBody: {
           title_multiloc,
           body_multiloc,
+          location_description: location_description || null,
+          location_point_geojson: location_point_geojson || null,
           ...(topic_ids && topic_ids.length > 0 && { topic_ids }),
           ...(cosponsor_ids && cosponsor_ids.length > 0 && { cosponsor_ids }),
-          ...(location_description && { location_description }),
-          ...(location_point_geojson && { location_point_geojson }),
           ...(header_bg?.[0]
             ? { header_bg: header_bg[0].base64 }
             : { header_bg: null }),

--- a/front/app/utils/locationTools.ts
+++ b/front/app/utils/locationTools.ts
@@ -74,22 +74,23 @@ const reverseGeocode = async (lat: number, lng: number, language: string) => {
 const parsePosition = async (position?: string) => {
   let location_point_geojson: Point | null | undefined;
   let location_description: string | null | undefined;
+  if (position) {
+    switch (position) {
+      case '':
+        location_point_geojson = null;
+        location_description = null;
+        break;
 
-  switch (position) {
-    case '':
-      location_point_geojson = null;
-      location_description = null;
-      break;
+      case undefined:
+        location_point_geojson = undefined;
+        location_description = undefined;
+        break;
 
-    case undefined:
-      location_point_geojson = undefined;
-      location_description = undefined;
-      break;
-
-    default:
-      location_point_geojson = await geocode(position);
-      location_description = position;
-      break;
+      default:
+        location_point_geojson = await geocode(position);
+        location_description = position;
+        break;
+    }
   }
   return { location_point_geojson, location_description };
 };


### PR DESCRIPTION
This solves some issues I discovered while I tested this on staging:
- Our requests did not handle special characters in the address 
- The location input is now clearable
