### PR TITLE
Fix issue with 2 column banner

### DIFF
--- a/front/app/components/UI/Image/index.tsx
+++ b/front/app/components/UI/Image/index.tsx
@@ -5,6 +5,13 @@ import React, { PureComponent } from 'react';
 import styled, { css } from 'styled-components';
 import { colors } from 'utils/styleUtils';
 
+const Fallback = styled.div<{ src: string | undefined }>`
+  background-repeat: no-repeat;
+  background-position: center center;
+  background-size: cover;
+  background-image: url(${({ src }) => src});
+`;
+
 const ImageElement = styled.img<{
   cover: boolean;
   fadeIn: boolean;
@@ -80,7 +87,7 @@ export default class Image extends PureComponent<Props, State> {
     const { isLazy } = this.props;
     const { loaded } = this.state;
 
-    return (
+    let image = (
       <ImageElement
         src={src}
         alt={alt}
@@ -96,5 +103,11 @@ export default class Image extends PureComponent<Props, State> {
         loading={isLazy ? 'lazy' : 'eager'}
       />
     );
+
+    if (cover) {
+      image = <Fallback src={src} className={className} />;
+    }
+
+    return image;
   }
 }


### PR DESCRIPTION
# Description
Looks like the old 2 column banner was using the Fallback which was removed. Once I added it back in it looked correct again :thinking: I wonder if "Fallback" should rather be renamed though, since it doesn't really feel like it's a fallback?

# Changelog
## Fixed
- Fix issue with 2 column banner
