### PR TITLE
Fix bookmark summary title

### DIFF
--- a/front/app/containers/Admin/projects/project/analysis/Insights/Summary.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Insights/Summary.tsx
@@ -246,7 +246,7 @@ const Summary = ({ insight }: Props) => {
             }
             iconColor={colors.teal400}
             iconColorOnHover={colors.teal700}
-            a11y_buttonActionMessage={formatMessage(messages.deleteSummary)}
+            a11y_buttonActionMessage={formatMessage(messages.bookmarkSummary)}
             onClick={() => toggleBookmark({ analysisId, id: insight.id })}
           />
         </Box>

--- a/front/app/containers/Admin/projects/project/analysis/Insights/messages.ts
+++ b/front/app/containers/Admin/projects/project/analysis/Insights/messages.ts
@@ -61,6 +61,10 @@ export default defineMessages({
     id: 'app.containers.AdminPage.projects.project.analysis.Insights.deleteSummary',
     defaultMessage: 'Delete summary',
   },
+  bookmarkSummary: {
+    id: 'app.containers.AdminPage.projects.project.analysis.Insights.bookmarkSummary',
+    defaultMessage: 'Bookmark summary',
+  },
   deleteSummaryConfirmation: {
     id: 'app.containers.AdminPage.projects.project.analysis.Insights.deleteSummaryConfirmation',
     defaultMessage: 'Are you sure you want to delete these summaries?',

--- a/front/app/translations/admin/en.json
+++ b/front/app/translations/admin/en.json
@@ -1969,6 +1969,7 @@
   "app.containers.AdminPage.projects.project.analysis.Insights.appliesTo": "Applies to currently selected inputs",
   "app.containers.AdminPage.projects.project.analysis.Insights.ask": "Ask",
   "app.containers.AdminPage.projects.project.analysis.Insights.askQuestion": "Ask a question",
+  "app.containers.AdminPage.projects.project.analysis.Insights.bookmarkSummary": "Bookmark summary",
   "app.containers.AdminPage.projects.project.analysis.Insights.deleteQuestion": "Delete question",
   "app.containers.AdminPage.projects.project.analysis.Insights.deleteQuestionConfirmation": "Are you sure you want to delete this question?",
   "app.containers.AdminPage.projects.project.analysis.Insights.deleteSummary": "Delete summary",


### PR DESCRIPTION
Teeny-tiny typo I noticed when playing with AI-analysis.

# Changelog
## Fixed
* Changed bookmark summary title from "Delete summary" to "Bookmark summary"