### PR TITLE
[TAN-446] Filter base64 encoding from production Rails logs

### DIFF
--- a/back/config/initializers/filter_parameter_logging.rb
+++ b/back/config/initializers/filter_parameter_logging.rb
@@ -9,14 +9,14 @@ Rails.application.config.filter_parameters += %i[
   password current_password passw secret token _key crypt salt certificate otp ssn import_ideas.pdf import_ideas.xlsx
 ]
 
-# Filtering out base64 image encoding. -------------------------------------------------------------------------
+# Filtering out base64 encoding. -------------------------------------------------------------------------
 #
 # Filter only exact matches of specified parameter keys. This avoids filtering false positives.
 # E.g. `image` will filter both `image` and `imageUrl`, whereas `^image$` will only filter `image`.
-Rails.application.config.filter_parameters += [/^avatar$/, /^header_bg$/, /^image$/, /^layout_image$/, /^logo$/]
+Rails.application.config.filter_parameters += [/^avatar$/, /^file$/, /^header_bg$/, /^image$/, /^layout_image$/, /^logo$/]
 
-# Custom filter to remove base64 image encoding from multiloc values,
-# as our WYSIWIG editors enable the addition of (multiple) images in the string value(s) of a mutliloc.
+# Custom filter to remove base64 image encoding from multiloc values, as our WYSIWIG editors enable the addition
+# of (multiple) images in the string value(s) of a mutliloc, which the FE encodes as base64.
 Rails.application.config.filter_parameters << lambda do |param, value|
   if CL2_SUPPORTED_LOCALES.include?(param.to_sym) && JSON.generate(value).include?(';base64,')
     value.gsub!(/;base64,[^ ]*/) { ';base64,[FILTERED]' }

--- a/back/config/initializers/filter_parameter_logging.rb
+++ b/back/config/initializers/filter_parameter_logging.rb
@@ -6,5 +6,9 @@
 # sensitive information. See the ActiveSupport::ParameterFilter documentation for supported
 # notations and behaviors.
 Rails.application.config.filter_parameters += %i[
-  image password current_password passw secret token _key crypt salt certificate otp ssn import_ideas.pdf import_ideas.xlsx
+  password current_password passw secret token _key crypt salt certificate otp ssn import_ideas.pdf import_ideas.xlsx
 ]
+
+# Filter only exact matches of specified parameter keys. This avoids filtering false positives.
+# E.g. `image` will filter both `image` and `imageUrl`, whereas `^image$` will only filter `image`.
+Rails.application.config.filter_parameters += [/^image$/]

--- a/back/config/initializers/filter_parameter_logging.rb
+++ b/back/config/initializers/filter_parameter_logging.rb
@@ -25,7 +25,9 @@ Rails.application.config.filter_parameters += [
 #      of (multiple) images in the string value(s) of mutlilocs, which the FE encodes as base64.
 #   2. Removes base64 encoding from the `file` parameter value, leaving other information intact (e.g. filename).
 Rails.application.config.filter_parameters << lambda do |param, value|
-  if param == 'file' || (CL2_SUPPORTED_LOCALES.include?(param.to_sym) && value.include?(';base64,'))
+  if param == 'file' || (
+      CL2_SUPPORTED_LOCALES.include?(param.to_sym) && value.respond_to?(:include?) && value.include?(';base64,')
+    )
     value.gsub!(/;base64,[^ ]*/) { ';base64,[FILTERED]' }
   end
 end

--- a/back/config/initializers/filter_parameter_logging.rb
+++ b/back/config/initializers/filter_parameter_logging.rb
@@ -15,16 +15,17 @@ Rails.application.config.filter_parameters += %i[
 # E.g. `image` will filter both `image` and `imageUrl`, whereas `^image$` will only filter `image`.
 Rails.application.config.filter_parameters += [
   /^avatar$/,
-  /^file$/,
   /^header_bg$/,
   /^image$/,
   /^layout_image$/,
   /^logo$/
 ]
-# Custom filter to remove base64 image encoding from multiloc values, as our WYSIWYG editors enable the addition
+# Custom filter that does 2 things:
+# 1. Removes base64 image encoding from multiloc values, as our WYSIWYG editors enable the addition
 # of (multiple) images in the string value(s) of mutlilocs, which the FE encodes as base64.
+# 2. Removes base64 encoding from the `file` parameter value, leaving other information intact (e.g. filename).
 Rails.application.config.filter_parameters << lambda do |param, value|
-  if CL2_SUPPORTED_LOCALES.include?(param.to_sym) && JSON.generate(value).include?(';base64,')
+  if param == 'file' || (CL2_SUPPORTED_LOCALES.include?(param.to_sym) && JSON.generate(value).include?(';base64,'))
     value.gsub!(/;base64,[^ ]*/) { ';base64,[FILTERED]' }
   end
 end

--- a/back/config/initializers/filter_parameter_logging.rb
+++ b/back/config/initializers/filter_parameter_logging.rb
@@ -6,5 +6,5 @@
 # sensitive information. See the ActiveSupport::ParameterFilter documentation for supported
 # notations and behaviors.
 Rails.application.config.filter_parameters += %i[
-  password current_password passw secret token _key crypt salt certificate otp ssn import_ideas.pdf import_ideas.xlsx
+  image password current_password passw secret token _key crypt salt certificate otp ssn import_ideas.pdf import_ideas.xlsx
 ]

--- a/back/config/initializers/filter_parameter_logging.rb
+++ b/back/config/initializers/filter_parameter_logging.rb
@@ -9,6 +9,17 @@ Rails.application.config.filter_parameters += %i[
   password current_password passw secret token _key crypt salt certificate otp ssn import_ideas.pdf import_ideas.xlsx
 ]
 
+# Filtering out base64 image encoding. -------------------------------------------------------------------------
+#
 # Filter only exact matches of specified parameter keys. This avoids filtering false positives.
 # E.g. `image` will filter both `image` and `imageUrl`, whereas `^image$` will only filter `image`.
-Rails.application.config.filter_parameters += [/^image$/]
+Rails.application.config.filter_parameters += [/^avatar$/, /^header_bg$/, /^image$/, /^layout_image$/, /^logo$/]
+
+# Custom filter to remove base64 image encoding from multiloc values,
+# as our WYSIWIG editors enable the addition of (multiple) images in the string value(s) of a mutliloc.
+Rails.application.config.filter_parameters << lambda do |param, value|
+  if CL2_SUPPORTED_LOCALES.include?(param.to_sym) && JSON.generate(value).include?(';base64,')
+    value.gsub!(/;base64,[^ ]*/) { ';base64,[FILTERED]' }
+  end
+end
+# ---------------------------------------------------------------------------------------------------------------

--- a/back/config/initializers/filter_parameter_logging.rb
+++ b/back/config/initializers/filter_parameter_logging.rb
@@ -9,17 +9,22 @@ Rails.application.config.filter_parameters += %i[
   password current_password passw secret token _key crypt salt certificate otp ssn import_ideas.pdf import_ideas.xlsx
 ]
 
-# Filtering out base64 encoding. -------------------------------------------------------------------------
+# Filter out base64 encoding
 #
 # Filter only exact matches of specified parameter keys. This avoids filtering false positives.
 # E.g. `image` will filter both `image` and `imageUrl`, whereas `^image$` will only filter `image`.
-Rails.application.config.filter_parameters += [/^avatar$/, /^file$/, /^header_bg$/, /^image$/, /^layout_image$/, /^logo$/]
-
-# Custom filter to remove base64 image encoding from multiloc values, as our WYSIWIG editors enable the addition
-# of (multiple) images in the string value(s) of a mutliloc, which the FE encodes as base64.
+Rails.application.config.filter_parameters += [
+  /^avatar$/,
+  /^file$/,
+  /^header_bg$/,
+  /^image$/,
+  /^layout_image$/,
+  /^logo$/
+]
+# Custom filter to remove base64 image encoding from multiloc values, as our WYSIWYG editors enable the addition
+# of (multiple) images in the string value(s) of mutlilocs, which the FE encodes as base64.
 Rails.application.config.filter_parameters << lambda do |param, value|
   if CL2_SUPPORTED_LOCALES.include?(param.to_sym) && JSON.generate(value).include?(';base64,')
     value.gsub!(/;base64,[^ ]*/) { ';base64,[FILTERED]' }
   end
 end
-# ---------------------------------------------------------------------------------------------------------------

--- a/back/config/initializers/filter_parameter_logging.rb
+++ b/back/config/initializers/filter_parameter_logging.rb
@@ -21,9 +21,9 @@ Rails.application.config.filter_parameters += [
   /^logo$/
 ]
 # Custom filter that does 2 things:
-# 1. Removes base64 image encoding from multiloc values, as our WYSIWYG editors enable the addition
-# of (multiple) images in the string value(s) of mutlilocs, which the FE encodes as base64.
-# 2. Removes base64 encoding from the `file` parameter value, leaving other information intact (e.g. filename).
+#   1. Removes base64 image encoding from multiloc values, as our WYSIWYG editors enable the addition
+#      of (multiple) images in the string value(s) of mutlilocs, which the FE encodes as base64.
+#   2. Removes base64 encoding from the `file` parameter value, leaving other information intact (e.g. filename).
 Rails.application.config.filter_parameters << lambda do |param, value|
   if param == 'file' || (CL2_SUPPORTED_LOCALES.include?(param.to_sym) && JSON.generate(value).include?(';base64,'))
     value.gsub!(/;base64,[^ ]*/) { ';base64,[FILTERED]' }

--- a/back/config/initializers/filter_parameter_logging.rb
+++ b/back/config/initializers/filter_parameter_logging.rb
@@ -25,7 +25,7 @@ Rails.application.config.filter_parameters += [
 #      of (multiple) images in the string value(s) of mutlilocs, which the FE encodes as base64.
 #   2. Removes base64 encoding from the `file` parameter value, leaving other information intact (e.g. filename).
 Rails.application.config.filter_parameters << lambda do |param, value|
-  if param == 'file' || (CL2_SUPPORTED_LOCALES.include?(param.to_sym) && JSON.generate(value).include?(';base64,'))
+  if param == 'file' || (CL2_SUPPORTED_LOCALES.include?(param.to_sym) && value.include?(';base64,'))
     value.gsub!(/;base64,[^ ]*/) { ';base64,[FILTERED]' }
   end
 end


### PR DESCRIPTION
Uses regexes to filter params, to avoid including false positives.
E.g. `image` will filter both `image` and `imageUrl`, whereas `^image$` will only filter `image`

No filtering:
```Ruby
cl-back-web    | {"host": ... {"controller":...{"image":{"image":"data:image/jpeg;base64,/9j/4AAQSkZJRgABA...<super_long_string_continues>
```

With filtering:
```Ruby
cl-back-web   | {"host":...{"controller":...{"image":"[FILTERED]", ...
```

We send base64 with the `avatar`, `file`, `image`, `layout_image`, `logo` and `header_bg` parameters.
I'm not aware of any others, except multiloc values created via WYSIWIGS (see below).

Uses a custom filter to strip base64 out of multiloc values produced using WYSIWYG editors, which can include multiple base64 strings within a single multiloc (representing multiple images).

With custom filtering of multiloc value(s):
```Ruby
cl-back-web   | {"host":... "params":{"project":{"description_multiloc":{"en":"\u003cp\u003eDolor nesciunt eaque.
... src=\"data:image/png;base64,[FILTERED] ... alt=\"\"\u003e\u003c/span\u003e\u003c/p\u003e\u003cp\u003eand
some text\u003c/p\u003e\u003cp\u003eand another
image\u003c/p\u003e\u003cp\u003e\u003cspan
... src=\"data:image/jpeg;base64,[FILTERED] ... alt=\"\"\u003e\u003c/span\u003e\u003c/p\u003e\u003cp\u003eand
some more text\u003c/p\u003e","fr-BE": ...
```

With custom filtering of `file` value:
```Ruby
cl-back-web   | 2023-10-23 18:06:23.342658 I [9:puma srv tp 005] Rails --   Parameters: {"file"=>
{"file"=>"data:application/vnd.openxmlformats-officedocument.wordprocessingml.document;base64,[FILTERED]", 
"name"=>"09-06-2021-engagement-sur-l-honneur-vert-version-anglaise.docx"}, "followable"=>"Project", 
"container_type"=>"Project", "project_id"=>"a0370acd-9936-4762-94f1-c9707dfe45ba"}
```

# Changelog
## Technical
- [TAN-446] Filter base64 image strings from production Rails logs
