### PR TITLE
CL-4190 Upgrade Node.js to version 18

### DIFF
--- a/back/Dockerfile.development
+++ b/back/Dockerfile.development
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get install -qq -y --no-install-recommends \
       build-essential libpq-dev file imagemagick curl git optipng jpegoptim pngquant libgeos-dev libgmp3-dev netcat shared-mime-info \
       less clang
 
-RUN curl -sL https://deb.nodesource.com/setup_15.x  | bash -
+RUN curl -sL https://deb.nodesource.com/setup_18.x  | bash -
 RUN apt-get -y install nodejs
 
 # Install MJML parser required by email engine.


### PR DESCRIPTION
Node.js 15 is no longer supported. To encourage people to migrate to a newer version, the installation script waits (suspends the execution) for 20 + 60 seconds.


# Changelog
## Technical
- Upgrade Node.js to version 18 in `Dockerfile.development`.
