### PR TITLE
Rename projectFilter to projectId for all craft widgets default props

### DIFF
--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/ActiveUsersWidget/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/ActiveUsersWidget/index.tsx
@@ -39,7 +39,7 @@ const ActiveUsersWidget = ({
 ActiveUsersWidget.craft = {
   props: {
     title: '',
-    projectFilter: undefined,
+    projectId: undefined,
     startAtMoment: undefined,
     endAtMoment: null,
   },

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/AgeWidget/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/AgeWidget/index.tsx
@@ -24,7 +24,7 @@ const AgeWidget = ({ title, projectId, startAt, endAt }: ChartWidgetProps) => {
 AgeWidget.craft = {
   props: {
     title: '',
-    projectFilter: undefined,
+    projectId: undefined,
     startAt: undefined,
     endAt: null,
   },

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/CommentsByTimeWidget/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/CommentsByTimeWidget/index.tsx
@@ -39,7 +39,7 @@ const CommentsByTimeWidget = ({
 CommentsByTimeWidget.craft = {
   props: {
     title: '',
-    projectFilter: undefined,
+    projectId: undefined,
     startAt: undefined,
     endAt: null,
   },

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/GenderWidget/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/GenderWidget/index.tsx
@@ -33,7 +33,7 @@ const GenderWidget = ({
 GenderWidget.craft = {
   props: {
     title: '',
-    projectFilter: undefined,
+    projectId: undefined,
     startAt: undefined,
     endAt: null,
   },

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/PostsByTimeWidget/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/PostsByTimeWidget/index.tsx
@@ -39,7 +39,7 @@ const PostsByTimeWidget = ({
 PostsByTimeWidget.craft = {
   props: {
     title: '',
-    projectFilter: undefined,
+    projectId: undefined,
     startAt: undefined,
     endAt: null,
   },

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/ReactionsByTimeWidget/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/ReactionsByTimeWidget/index.tsx
@@ -39,7 +39,7 @@ const ReactionsByTimeWidget = ({
 ReactionsByTimeWidget.craft = {
   props: {
     title: '',
-    projectFilter: undefined,
+    projectId: undefined,
     startAt: undefined,
     endAt: null,
   },

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/VisitorsTrafficSourcesWidget/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/VisitorsTrafficSourcesWidget/index.tsx
@@ -42,7 +42,7 @@ const VisitorsTrafficSourcesWidget = ({
 VisitorsTrafficSourcesWidget.craft = {
   props: {
     title: '',
-    projectFilter: undefined,
+    projectId: undefined,
     startAtMoment: undefined,
     endAtMoment: null,
   },

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/VisitorsWidget/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/VisitorsWidget/index.tsx
@@ -40,7 +40,7 @@ const VisitorsWidget = ({
 VisitorsWidget.craft = {
   props: {
     title: '',
-    projectFilter: undefined,
+    projectId: undefined,
     startAt: undefined,
     endAt: undefined,
   },


### PR DESCRIPTION
This was just some weird inconsistency that was bothering me. In theory we could leave all these props with `undefined` out because that would be the same as defining them with a default value of `undefined`. But this way it's a bit more explicit that these are existing props, they just happen to be `undefined` by default.