### PR TITLE
CL-4163 Fix notification link

### DIFF
--- a/front/app/containers/MainHeader/NotificationMenu/components/ProjectModerationRightsReceivedNotification/index.tsx
+++ b/front/app/containers/MainHeader/NotificationMenu/components/ProjectModerationRightsReceivedNotification/index.tsx
@@ -33,7 +33,7 @@ const ProjectModerationRightsReceivedNotification = memo<Props>((props) => {
         values={{
           projectLink: (
             <Link
-              to={`admin/projects/${notification.attributes.project_id}/ideas`}
+              to={adminProjectsProjectPath(notification.attributes.project_id)}
               onClick={stopPropagation}
             >
               <T value={notification.attributes.project_title_multiloc} />


### PR DESCRIPTION
# Changelog
## Fixed
- Link for project moderation notification now links correctly to the admin project page