### PR TITLE
Preserve ordering of admin publications in templates

### DIFF
--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_serializer.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_serializer.rb
@@ -215,19 +215,8 @@ module MultiTenancy
       end
 
       def serialize_admin_publications(scope)
-        publications = serialize_records(scope)
-
-        # The parent publications must be listed before their children since the
-        # children publications reference their parent.
-        child_to_parent = publications.transform_values do |attributes|
-          Array.wrap(attributes[:parent_ref]&.id)
-        end
-
-        each_node = ->(&block) { child_to_parent.each_key(&block) }
-        each_child = ->(node, &block) { child_to_parent[node].each(&block) }
-        ordered_ids = TSort.tsort(each_node, each_child)
-
-        publications.slice(*ordered_ids)
+        # This code will stop working when folders can contain folders
+        serialize_records(scope.order(parent_id: :desc, ordering: :asc))
       end
 
       def serialize_comments(*post_scopes)


### PR DESCRIPTION
# Changelog
### Fixed
- [CL-4169] Fix issue with ordering in admin publications.


[CL-4169]: https://citizenlab.atlassian.net/browse/CL-4169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ