### PR TITLE
CL-4154 - Increase default proposal image sizes

### DIFF
--- a/back/app/uploaders/initiative_image_uploader.rb
+++ b/back/app/uploaders/initiative_image_uploader.rb
@@ -3,17 +3,14 @@
 class InitiativeImageUploader < BaseImageUploader
   version :small do
     process resize_to_fill: [96, 96]
-    # process optimize: [{ quality: 90, quiet: true }]
   end
 
   version :medium do
-    process resize_to_fill: [298, 135]
-    # process optimize: [{ quality: 90, quiet: true }]
+    process resize_to_fill: [480, 217]
   end
 
   version :large do
-    process resize_to_limit: [480, nil]
-    # process optimize: [{ quality: 90, quiet: true }]
+    process resize_to_limit: [960, nil]
   end
 
   version :fb do


### PR DESCRIPTION
On deployment the following rake task needs to be  run to update the image resolution for existing proposal images:

```docker exec -it -e MODEL_CONFIGS='[{"class": "InitiativeImage", "attributes": { "image": [] } }]' "$(docker ps | awk '/web/ {print $1}' | head -1)" bin/rails carrierwave:recreate_image_versions```


# Changelog
## Fixed
- CL-4154 - Increased default image sizes for proposals to avoid blurry images on higher resolution screens - eg mobile/4k
