### PR TITLE
TAN-502 Add missing project_id for Reactions to activities

### DIFF
--- a/back/lib/tasks/tmp/data_migration_activities_project_id.rake
+++ b/back/lib/tasks/tmp/data_migration_activities_project_id.rake
@@ -52,20 +52,20 @@ namespace :data_migration do
     It processes all item types that are not covered by `add_project_id_to_activities_sql`,
     but it is pretty aggressive on the DB.
   DESC
-  task :add_project_id_to_activities_rails, [:tenant_id, :model_class] => [:environment] do |_task, args|
+  task :add_project_id_to_activities_rails, %i[tenant_id model_class] => [:environment] do |_task, args|
     Rails.application.eager_load!
 
     # Models without `project_id` column that support the `project_id` method.
     model_classes = if args[:model_class]
-        [args[:model_class].constantize]
-      else
-        ActiveRecord::Base.descendants.select do |klass|
-          klass.new.respond_to?(:project_id) && klass.column_names.exclude?('project_id')
-        rescue Exception # rubocop:disable Lint/RescueException
-          puts({ message: 'skipping model', model: klass.name })
-          false
-        end
+      [args[:model_class].constantize]
+    else
+      ActiveRecord::Base.descendants.select do |klass|
+        klass.new.respond_to?(:project_id) && klass.column_names.exclude?('project_id')
+      rescue Exception # rubocop:disable Lint/RescueException
+        puts({ message: 'skipping model', model: klass.name })
+        false
       end
+    end
 
     tenant_id = args[:tenant_id]
     tenants = tenant_id ? Tenant.where(id: tenant_id) : Tenant

--- a/back/lib/tasks/tmp/data_migration_activities_project_id.rake
+++ b/back/lib/tasks/tmp/data_migration_activities_project_id.rake
@@ -52,16 +52,20 @@ namespace :data_migration do
     It processes all item types that are not covered by `add_project_id_to_activities_sql`,
     but it is pretty aggressive on the DB.
   DESC
-  task :add_project_id_to_activities_rails, [:tenant_id] => [:environment] do |_task, args|
+  task :add_project_id_to_activities_rails, [:tenant_id, :model_class] => [:environment] do |_task, args|
     Rails.application.eager_load!
 
     # Models without `project_id` column that support the `project_id` method.
-    model_classes = ActiveRecord::Base.descendants.select do |klass|
-      klass.new.respond_to?(:project_id) && klass.column_names.exclude?('project_id')
-    rescue Exception # rubocop:disable Lint/RescueException
-      puts({ message: 'skipping model', model: klass.name })
-      false
-    end
+    model_classes = if args[:model_class]
+        [args[:model_class].constantize]
+      else
+        ActiveRecord::Base.descendants.select do |klass|
+          klass.new.respond_to?(:project_id) && klass.column_names.exclude?('project_id')
+        rescue Exception # rubocop:disable Lint/RescueException
+          puts({ message: 'skipping model', model: klass.name })
+          false
+        end
+      end
 
     tenant_id = args[:tenant_id]
     tenants = tenant_id ? Tenant.where(id: tenant_id) : Tenant

--- a/back/spec/services/side_fx_reaction_service_spec.rb
+++ b/back/spec/services/side_fx_reaction_service_spec.rb
@@ -16,13 +16,19 @@ describe SideFxReactionService do
     it "logs a 'liked' action when a like on an initiative is created" do
       reaction = create(:reaction, mode: 'up', reactable: create(:initiative))
       expect { service.after_create(reaction, user) }
-        .to have_enqueued_job(LogActivityJob)
+        .to(have_enqueued_job(LogActivityJob).with do |reaction_arg, action, *_args, **kwargs|
+          expect(reaction_arg).to be_a(String)
+          expect(action).to eq('initiative_liked')
+          expect(kwargs[:project_id]).to be_blank
+        end)
     end
 
     it "logs a 'disliked' action when a dislike is created" do
       reaction = create(:reaction, mode: 'down', reactable: create(:idea))
       expect { service.after_create(reaction, user) }
-        .to have_enqueued_job(LogActivityJob)
+        .to(have_enqueued_job(LogActivityJob).with do |*_args, **kwargs|
+          expect(kwargs[:project_id]).to be_present
+        end)
     end
 
     # Test for regression of bugfix to prevent case where an exception occurs due to resource being
@@ -61,21 +67,27 @@ describe SideFxReactionService do
   end
 
   describe 'after_destroy' do
-    it "logs a 'canceled_like' action job when an like is deleted" do
+    it "logs a 'canceled_idea_liked' action job when a like is deleted" do
       reaction = create(:reaction, mode: 'up')
       freeze_time do
         frozen_reaction = reaction.destroy
         expect { service.after_destroy(frozen_reaction, user) }
-          .to have_enqueued_job(LogActivityJob)
+          .to(have_enqueued_job(LogActivityJob).with do |_reaction, action, *_args, **kwargs|
+            expect(action).to eq('canceled_idea_liked')
+            expect(kwargs[:project_id]).to be_present
+          end)
       end
     end
 
-    it "logs a 'canceled_dislike' action job when a dislike is deleted" do
+    it "logs a 'canceled_idea_disliked' action job when a dislike is deleted" do
       reaction = create(:reaction, mode: 'down')
       freeze_time do
         frozen_reaction = reaction.destroy
         expect { service.after_destroy(frozen_reaction, user) }
-          .to have_enqueued_job(LogActivityJob)
+          .to(have_enqueued_job(LogActivityJob).with do |_reaction, action, *_args, **kwargs|
+                expect(action).to eq('canceled_idea_disliked')
+                expect(kwargs[:project_id]).to be_present
+              end)
       end
     end
   end


### PR DESCRIPTION
- Makes sidefx explicitely pass project_id
- Improve documentation and specs on why we're passing a String instead of a Reaction to LogActivityJob
- Repurpose the existing rake task to fill in missing project_ids for one model only