### PR TITLE
CL-4201 - Ignore geocoding if exact co-ordinates are passed to geocoder

### DIFF
--- a/back/app/services/location/service.rb
+++ b/back/app/services/location/service.rb
@@ -7,8 +7,16 @@ class Location::Service
   end
 
   def geocode(address, language)
-    response = HTTParty.get("https://maps.googleapis.com/maps/api/geocode/json?address=#{CGI.escape(address)}&key=#{api_key}&language=#{language}")
-    { location: response['results'].first['geometry']['location'] }
+    # Pass through unaltered if valid co-ordinates are entered
+    coordinates_regex = /^[-+]?([1-8]?\d(\.\d+)?|90(\.0+)?),\s*[-+]?(180(\.0+)?|((1[0-7]\d)|([1-9]?\d))(\.\d+)?)$/
+    if coordinates_regex.match? address
+      split_coordinates = address.split(',')
+      location = { lat: split_coordinates[0].to_f, lng: split_coordinates[1].to_f }
+    else
+      response = HTTParty.get("https://maps.googleapis.com/maps/api/geocode/json?address=#{CGI.escape(address)}&key=#{api_key}&language=#{language}")
+      location = response['results'].first['geometry']['location']
+    end
+    { location: location }
   end
 
   def reverse_geocode(lat, lng, language)

--- a/back/spec/acceptance/location_spec.rb
+++ b/back/spec/acceptance/location_spec.rb
@@ -30,15 +30,26 @@ resource 'Location' do
     parameter :address, 'Address', required: true
     parameter :language, 'Language', required: false
 
-    let(:address) { 'New York' }
+    context 'an address' do
+      let(:address) { 'New York' }
 
-    before do
-      allow(HTTParty).to receive(:get).and_return({ 'results' => [{ 'geometry' => { 'location' => { lat: 40.7127753, lng: -74.0059728 } } }] })
+      before do
+        allow(HTTParty).to receive(:get).and_return({ 'results' => [{ 'geometry' => { 'location' => { lat: 40.7127753, lng: -74.0059728 } } }] })
+      end
+
+      example_request 'Address Geocoded' do
+        expect(status).to eq(200)
+        expect(response_data[:attributes][:location]).to eq({ lat: 40.7127753, lng: -74.0059728 })
+      end
     end
 
-    example_request 'Geocode' do
-      expect(status).to eq(200)
-      expect(response_data[:attributes][:location]).to eq({ lat: 40.7127753, lng: -74.0059728 })
+    context 'co-ordinates' do
+      let(:address) { '48.32895308112715,16.04415893554688' }
+
+      example_request 'Exact co-ordinates returned unaltered' do
+        expect(status).to eq(200)
+        expect(response_data[:attributes][:location]).to eq({ lat: 48.32895308112715, lng: 16.04415893554688 })
+      end
     end
   end
 


### PR DESCRIPTION
# Changelog
## Fixed
- CL-4201 - Do not try and geocode if exact co-ordinates are passed as the location to the geocoder
