### PR TITLE
Revert accidental docker network change

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,5 +99,5 @@ volumes:
   bundle_path:
 
 networks:
-  citizenlab:
+  default:
     name: citizenlab


### PR DESCRIPTION
It reverts this change in docker-compose.yml
https://github.com/CitizenLabDotCo/citizenlab/pull/5622/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3

See this discussion for details https://citizenlabco.slack.com/archives/C03RE3XFN65/p1699280354184699

# Changelog
## Technical
* Fix cl2-admin local network failures