### PR TITLE
[CL-4160] Show clearer folder error message if tenant has only one locale

### DIFF
--- a/front/app/containers/Admin/projectFolders/containers/messages.ts
+++ b/front/app/containers/Admin/projectFolders/containers/messages.ts
@@ -63,6 +63,10 @@ export default defineMessages({
     id: 'app.containers.AdminPage.FoldersEdit.multilocError',
     defaultMessage: 'All text fields must be fully filled in.',
   },
+  textFieldsError: {
+    id: 'app.containers.AdminPage.FoldersEdit.textFieldsError',
+    defaultMessage: 'All text fields must be filled in.',
+  },
   saveSuccessMessage: {
     id: 'app.containers.AdminPage.FoldersEdit.saveSuccessMessage',
     defaultMessage: 'Your changes have been saved.',

--- a/front/app/containers/Admin/projectFolders/containers/settings/ProjectFolderForm/index.tsx
+++ b/front/app/containers/Admin/projectFolders/containers/settings/ProjectFolderForm/index.tsx
@@ -634,7 +634,9 @@ const ProjectFolderForm = ({ mode, projectFolderId }: Props) => {
             messageError:
               submitState === 'apiError'
                 ? messages.saveErrorMessage
-                : messages.multilocError,
+                : tenantLocales && tenantLocales.length > 1
+                ? messages.multilocError
+                : messages.textFieldsError,
             messageSuccess: messages.saveSuccessMessage,
           }}
         />

--- a/front/app/translations/admin/en.json
+++ b/front/app/translations/admin/en.json
@@ -1176,6 +1176,7 @@
   "app.containers.AdminPage.FoldersEdit.statusLabel": "Publication status",
   "app.containers.AdminPage.FoldersEdit.subtitleNewFolder": "Explain why the projects belong together, define a visual identity and share information.",
   "app.containers.AdminPage.FoldersEdit.subtitleSettingsTab": "Explain why the projects belong together, define a visual identity and share information.",
+  "app.containers.AdminPage.FoldersEdit.textFieldsError": "All text fields must be filled in.",
   "app.containers.AdminPage.FoldersEdit.titleInputLabel": "Title",
   "app.containers.AdminPage.FoldersEdit.titleNewFolder": "Create a new folder",
   "app.containers.AdminPage.FoldersEdit.titleSettingsTab": "Settings",


### PR DESCRIPTION
# Changelog
## Fixed
* [CL-4160] Show clearer folder error message if tenant has only one locale


[CL-4160]: https://citizenlab.atlassian.net/browse/CL-4160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ