### PR TITLE
[TAN-504] Use 'eu' for cluster name in AWS logs group

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -880,7 +880,7 @@ workflows:
           compose_file: docker-compose-production-benelux.yml
           stack_name: cl2-prd-bnlx-stack
           env_file: ".env-production-benelux"
-          cluster_name: "prd"
+          cluster_name: "eu"
       - back-deploy-to-swarm:
           name: Deploy to Canada
           requires:


### PR DESCRIPTION
I noticed we use the code `eu` in many places for the benelux cluster, and this seems more descriptive than `prd` and in-line with the other names we are using for AWS logs groups (`usw`, `uk`, `can`, `sam`, & `stg`).

I have also created an appropriately named logs group on CloudWatch; `/web/eu`.

# Changelog
## Technical
- [TAN-504] Use 'eu' for cluster name in AWS logs group, not 'prd'
