### PR TITLE
Add scripts to dump/restore e2e DB to simplify flaky test debugging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,8 +121,9 @@ e2e-ci-env-db-restore:
 	cat dump.sql | docker compose exec -T postgres psql --quiet -U postgres 1> /dev/null 2> /dev/null
 
 e2e-ci-env-reproduce-flaky-test:
-	for i in {1..10}; do \
-		make e2e-ci-env-db-restore && make e2e-ci-env-run-test spec="${spec}"; \
+	for i in $(shell seq 1 10); do \
+		make e2e-ci-env-db-restore && \
+		make e2e-ci-env-run-test spec="${spec}"; \
 	done
 
 # =================

--- a/Makefile
+++ b/Makefile
@@ -115,10 +115,10 @@ e2e-ci-env-db-dump:
 
 e2e-ci-env-db-restore:
 	cd e2e && \
-	docker compose exec postgres psql -U postgres -d cl2_back_development -c "DROP SCHEMA IF EXISTS e2e_front,public CASCADE;" && \
-	docker compose exec postgres psql -U postgres -d cl2_back_development -c "CREATE SCHEMA public;" && \
-	cat dump.sql | docker compose exec -T postgres psql --quiet -U postgres && \
-	echo "\033[0;32mDatabase restored successfully!\033[0m"
+	docker compose exec postgres psql -U postgres -d cl2_back_development -c "SELECT 1" 1> /dev/null && \
+	docker compose exec postgres psql -U postgres -d cl2_back_development -c "DROP SCHEMA IF EXISTS e2e_front,public CASCADE" 1> /dev/null 2> /dev/null && \
+	docker compose exec postgres psql -U postgres -d cl2_back_development -c "CREATE SCHEMA public" && \
+	cat dump.sql | docker compose exec -T postgres psql --quiet -U postgres 1> /dev/null 2> /dev/null
 
 # =================
 # CircleCI

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,11 @@ e2e-ci-env-db-restore:
 	docker compose exec postgres psql -U postgres -d cl2_back_development -c "CREATE SCHEMA public" && \
 	cat dump.sql | docker compose exec -T postgres psql --quiet -U postgres 1> /dev/null 2> /dev/null
 
+e2e-ci-env-reproduce-flaky-test:
+	for i in {1..10}; do \
+		make e2e-ci-env-db-restore && make e2e-ci-env-run-test spec="${spec}"; \
+	done
+
 # =================
 # CircleCI
 # =================

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,17 @@ e2e-ci-env-run-test:
 	cd e2e && \
 	docker-compose run --rm --name cypress_run front npm run cypress:run -- --config baseUrl=http://e2e.front:3000 --spec ${spec}
 
+e2e-ci-env-db-dump:
+	cd e2e && \
+	docker compose exec postgres pg_dumpall -c -U postgres > dump.sql
+
+e2e-ci-env-db-restore:
+	cd e2e && \
+	docker compose exec postgres psql -U postgres -d cl2_back_development -c "DROP SCHEMA IF EXISTS e2e_front,public CASCADE;" && \
+	docker compose exec postgres psql -U postgres -d cl2_back_development -c "CREATE SCHEMA public;" && \
+	cat dump.sql | docker compose exec -T postgres psql --quiet -U postgres && \
+	echo "\033[0;32mDatabase restored successfully!\033[0m"
+
 # =================
 # CircleCI
 # =================

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     build:
       context: ..
       dockerfile: back/Dockerfile
-    # To easily test locally. For unknow reason it doesn't work on CI
+    # To easily test locally. Volumes are not supported on CircleCI
     # volumes:
     #   - "../back:/cl2_back"
     env_file:
@@ -38,7 +38,7 @@ services:
     build:
       context: ..
       dockerfile: front/Dockerfile
-    # To easily test locally. For unknow reason it doesn't work on CI
+    # To easily test locally. Volumes are not supported on CircleCI
     # volumes:
     #   - "../front:/front"
     ports:


### PR DESCRIPTION
Also added the docs here https://www.notion.so/citizenlab/Testing-253d0c3cd99841a59929f7f615179935?pvs=4#0cc3358f99474cdcadc3a70300ee237b

# Changelog
## Technical
* Add scripts to dump/restore e2e DB to simplify flaky test debugging
