### PR TITLE
CL-4198 Update ENGAGING_ACTIVITIES in ParticipantsService

### DIFF
--- a/back/app/services/participants_service.rb
+++ b/back/app/services/participants_service.rb
@@ -6,6 +6,7 @@ class ParticipantsService
     { item_type: 'Idea', action: 'published', score: 5 },
     { item_type: 'Reaction', action: 'idea_liked', score: 1 },
     { item_type: 'Reaction', action: 'idea_disliked', score: 1 },
+    { item_type: 'Initiative', action: 'published', score: 5 },
     { item_type: 'Reaction', action: 'initiative_liked', score: 1 },
     { item_type: 'Reaction', action: 'initiative_disliked', score: 1 },
     { item_type: 'Reaction', action: 'comment_liked', score: 1 },

--- a/back/app/services/participants_service.rb
+++ b/back/app/services/participants_service.rb
@@ -6,6 +6,8 @@ class ParticipantsService
     { item_type: 'Idea', action: 'published', score: 5 },
     { item_type: 'Reaction', action: 'idea_liked', score: 1 },
     { item_type: 'Reaction', action: 'idea_disliked', score: 1 },
+    { item_type: 'Reaction', action: 'initiative_liked', score: 1 },
+    { item_type: 'Reaction', action: 'initiative_disliked', score: 1 },
     { item_type: 'Reaction', action: 'comment_liked', score: 1 },
     { item_type: 'Reaction', action: 'comment_disliked', score: 1 },
     { item_type: 'Basket', action: 'created', score: 3 },

--- a/back/spec/factories/activities.rb
+++ b/back/spec/factories/activities.rb
@@ -63,6 +63,16 @@ FactoryBot.define do
       action { 'idea_disliked' }
     end
 
+    factory :initiative_liked_activity do
+      association :item, factory: :reaction
+      action { 'initiative_liked' }
+    end
+
+    factory :initiative_disliked_activity do
+      association :item, factory: :dislike
+      action { 'initiative_disliked' }
+    end
+
     factory :comment_liked_activity do
       association :item, factory: :comment_reaction
       action { 'comment_liked' }

--- a/back/spec/factories/activities.rb
+++ b/back/spec/factories/activities.rb
@@ -73,16 +73,6 @@ FactoryBot.define do
       action { 'published' }
     end
 
-    factory :initiative_liked_activity do
-      association :item, factory: :reaction
-      action { 'initiative_liked' }
-    end
-
-    factory :initiative_disliked_activity do
-      association :item, factory: :dislike
-      action { 'initiative_disliked' }
-    end
-
     factory :comment_liked_activity do
       association :item, factory: :comment_reaction
       action { 'comment_liked' }

--- a/back/spec/factories/activities.rb
+++ b/back/spec/factories/activities.rb
@@ -53,6 +53,11 @@ FactoryBot.define do
       action { 'created' }
     end
 
+    factory :idea_published_activity do
+      association :item, factory: :idea
+      action { 'published' }
+    end
+
     factory :idea_liked_activity do
       association :item, factory: :reaction
       action { 'idea_liked' }
@@ -61,6 +66,11 @@ FactoryBot.define do
     factory :idea_disliked_activity do
       association :item, factory: :dislike
       action { 'idea_disliked' }
+    end
+
+    factory :initiative_published_activity do
+      association :item, factory: :initiative
+      action { 'published' }
     end
 
     factory :initiative_liked_activity do

--- a/back/spec/services/participants_service_spec.rb
+++ b/back/spec/services/participants_service_spec.rb
@@ -260,8 +260,10 @@ describe ParticipantsService do
     it 'does not filter out likes or dislikes' do
       idea_liked_activity = create(:idea_liked_activity)
       idea_disliked_activity = create(:idea_disliked_activity)
-      initiative_liked_activity = create(:initiative_liked_activity)
-      initiative_disliked_activity = create(:initiative_disliked_activity)
+      initiative_liked_activity =
+        create(:activity, action: 'initiative_liked', item: create(:reaction2, :for_initiative, :up))
+      initiative_disliked_activity =
+        create(:activity, action: 'initiative_disliked', item: create(:reaction2, :for_initiative, :down))
 
       expect(service.filter_engaging_activities(Activity.all))
         .to match_array [

--- a/back/spec/services/participants_service_spec.rb
+++ b/back/spec/services/participants_service_spec.rb
@@ -272,6 +272,16 @@ describe ParticipantsService do
         ]
     end
 
+    it 'does not filter out publishing an idea' do
+      idea_published_activity = create(:idea_published_activity)
+      expect(service.filter_engaging_activities(Activity.all)).to eq [idea_published_activity]
+    end
+
+    it 'does not filter out publishing an initiative' do
+      initiative_published_activity = create(:initiative_published_activity)
+      expect(service.filter_engaging_activities(Activity.all)).to eq [initiative_published_activity]
+    end
+
     it 'filters out an idea changed title activity' do
       create(:changed_title_activity)
       expect(service.filter_engaging_activities(Activity.all)).to be_empty

--- a/back/spec/services/participants_service_spec.rb
+++ b/back/spec/services/participants_service_spec.rb
@@ -257,9 +257,19 @@ describe ParticipantsService do
   end
 
   describe 'filter_engaging_activities' do
-    it 'does not filter out a like' do
-      activity = create(:published_activity)
-      expect(service.filter_engaging_activities(Activity.all)).to eq [activity]
+    it 'does not filter out likes or dislikes' do
+      idea_liked_activity = create(:idea_liked_activity)
+      idea_disliked_activity = create(:idea_disliked_activity)
+      initiative_liked_activity = create(:initiative_liked_activity)
+      initiative_disliked_activity = create(:initiative_disliked_activity)
+
+      expect(service.filter_engaging_activities(Activity.all))
+        .to match_array [
+          idea_liked_activity,
+          idea_disliked_activity,
+          initiative_liked_activity,
+          initiative_disliked_activity
+        ]
     end
 
     it 'filters out an idea changed title activity' do


### PR DESCRIPTION
Possibly, there are other `activities` to include. I've [asked in Slack](https://citizenlabco.slack.com/archives/C016C2EHURY/p1699894845176389) for any ideas on this.

# Changelog
## Fixed
- [CL-4198] We now include proposal publishing, liking & disliking in our stats (e.g. In the 'Active users' graph, in the back office Dashboard 'Overview' tab) 


[CL-4198]: https://citizenlab.atlassian.net/browse/CL-4198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ