### PR TITLE
TAN-515 - Add migration task translations to crowdin.yml

### DIFF
--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/rake/continuous_project_migration_service.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/rake/continuous_project_migration_service.rb
@@ -63,7 +63,7 @@ class MultiTenancy::Rake::ContinuousProjectMigrationService
 
   def create_phase(project)
     phase = Phase.new(
-      title_multiloc: MultilocService.new.i18n_to_multiloc("default_phase_title.#{project.participation_method}"),
+      title_multiloc: MultilocService.new.i18n_to_multiloc("phase_title_default.#{project.participation_method}"),
       project: project,
       created_at: project.created_at,
       start_at: project.created_at,

--- a/back/engines/commercial/multi_tenancy/config/locales/en.yml
+++ b/back/engines/commercial/multi_tenancy/config/locales/en.yml
@@ -1,6 +1,6 @@
 # Translations for continuous to timeline migration
 en:
-  default_phase_title:
+  phase_title_default:
     ideation: Collect input
     voting: Voting
     poll: Poll

--- a/back/engines/commercial/multi_tenancy/spec/fixtures/locales/en.yml
+++ b/back/engines/commercial/multi_tenancy/spec/fixtures/locales/en.yml
@@ -1,6 +1,6 @@
 # Translations for continuous to timeline migration
 en:
-  default_phase_title:
+  phase_title_default:
     ideation: Collect input
     voting: Voting
     poll: Poll

--- a/back/engines/commercial/multi_tenancy/spec/fixtures/locales/fr-FR.yml
+++ b/back/engines/commercial/multi_tenancy/spec/fixtures/locales/fr-FR.yml
@@ -1,6 +1,6 @@
 # Translations for continuous to timeline migration
 fr-FR:
-  default_phase_title:
+  phase_title_default:
     ideation: Collect input - FR
     voting: Voting - FR
     poll: Poll - FR

--- a/back/engines/commercial/multi_tenancy/spec/fixtures/locales/nl-NL.yml
+++ b/back/engines/commercial/multi_tenancy/spec/fixtures/locales/nl-NL.yml
@@ -1,6 +1,6 @@
 # Translations for continuous to timeline migration
 nl-NL:
-  default_phase_title:
+  phase_title_default:
     ideation: Collect input - NL
     voting: Voting - NL
     poll: Poll - NL

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -26,6 +26,6 @@ files:
   - source: /back/engines/commercial/analysis/config/locales/en.yml
     translation: /back/engines/commercial/analysis/config/locales/%locale%.yml
     update_option: update_without_changes
-  - source: /back/engines/multi_tenancy/config/locales/en.yml
-    translation: /back/engines/multi_tenancy/config/locales/%locale%.yml
+  - source: /back/engines/commercial/multi_tenancy/config/locales/en.yml
+    translation: /back/engines/commercial/multi_tenancy/config/locales/%locale%.yml
     update_option: update_without_changes

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -26,3 +26,6 @@ files:
   - source: /back/engines/commercial/analysis/config/locales/en.yml
     translation: /back/engines/commercial/analysis/config/locales/%locale%.yml
     update_option: update_without_changes
+  - source: /back/engines/multi_tenancy/config/locales/en.yml
+    translation: /back/engines/multi_tenancy/config/locales/%locale%.yml
+    update_option: update_without_changes


### PR DESCRIPTION
Only needed because crowdin wasn't aware of the new translations I had added to my migration task (now merged to master)
