### PR TITLE
Fix homepage issue with new craftjs

### DIFF
--- a/back/app/serializers/web_api/v1/home_page_serializer.rb
+++ b/back/app/serializers/web_api/v1/home_page_serializer.rb
@@ -38,7 +38,7 @@ class WebApi::V1::HomePageSerializer < WebApi::V1::BaseSerializer
     TextImageService.new.render_data_images_multiloc object.bottom_info_section_multiloc, field: :bottom_info_section_multiloc, imageable: object
   end
 
-  attribute :craftjs_json, if: proc { |object, params|
+  attribute :craftjs_json, if: proc {
     AppConfiguration.instance.feature_activated? 'homepage_builder'
   } do |homepage|
     # TODO: move to layout

--- a/back/app/serializers/web_api/v1/home_page_serializer.rb
+++ b/back/app/serializers/web_api/v1/home_page_serializer.rb
@@ -38,10 +38,10 @@ class WebApi::V1::HomePageSerializer < WebApi::V1::BaseSerializer
     TextImageService.new.render_data_images_multiloc object.bottom_info_section_multiloc, field: :bottom_info_section_multiloc, imageable: object
   end
 
-  attribute :craftjs_json do |homepage|
-    # TODO: move to layout
-    ContentBuilder::LayoutImageService.new.render_data_images homepage.craftjs_json
-  end
+  # attribute :craftjs_json do |homepage|
+  #   # TODO: move to layout
+  #   ContentBuilder::LayoutImageService.new.render_data_images homepage.craftjs_json
+  # end
 
   has_many :pinned_admin_publications, serializer: :admin_publication
 end

--- a/back/app/serializers/web_api/v1/home_page_serializer.rb
+++ b/back/app/serializers/web_api/v1/home_page_serializer.rb
@@ -38,10 +38,12 @@ class WebApi::V1::HomePageSerializer < WebApi::V1::BaseSerializer
     TextImageService.new.render_data_images_multiloc object.bottom_info_section_multiloc, field: :bottom_info_section_multiloc, imageable: object
   end
 
-  # attribute :craftjs_json do |homepage|
-  #   # TODO: move to layout
-  #   ContentBuilder::LayoutImageService.new.render_data_images homepage.craftjs_json
-  # end
+  attribute :craftjs_json, if: proc { |object, params|
+    AppConfiguration.instance.feature_activated? 'homepage_builder'
+  } do |homepage|
+    # TODO: move to layout
+    ContentBuilder::LayoutImageService.new.render_data_images homepage.craftjs_json
+  end
 
   has_many :pinned_admin_publications, serializer: :admin_publication
 end

--- a/back/engines/commercial/content_builder/app/services/content_builder/layout_image_service.rb
+++ b/back/engines/commercial/content_builder/app/services/content_builder/layout_image_service.rb
@@ -7,9 +7,9 @@ module ContentBuilder
     protected
 
     def image_elements(content)
-      LayoutService.new.select_craftjs_elements_for_types(content, IMAGE_ELEMENT_TYPES).map do |elt|
+      LayoutService.new.select_craftjs_elements_for_types(content, IMAGE_ELEMENT_TYPES).filter_map do |elt|
         elt.dig('props', 'image')
-      end.compact
+      end
     end
 
     def content_image_class

--- a/back/engines/commercial/content_builder/app/services/content_builder/layout_image_service.rb
+++ b/back/engines/commercial/content_builder/app/services/content_builder/layout_image_service.rb
@@ -7,7 +7,9 @@ module ContentBuilder
     protected
 
     def image_elements(content)
-      LayoutService.new.select_craftjs_elements_for_types(content, IMAGE_ELEMENT_TYPES).pluck('props').pluck('image')
+      LayoutService.new.select_craftjs_elements_for_types(content, IMAGE_ELEMENT_TYPES).map do |elt|
+        elt.dig('props', 'image')
+      end.compact
     end
 
     def content_image_class

--- a/back/engines/commercial/content_builder/spec/services/content_builder/layout_image_service_spec.rb
+++ b/back/engines/commercial/content_builder/spec/services/content_builder/layout_image_service_spec.rb
@@ -142,7 +142,7 @@ describe ContentBuilder::LayoutImageService do
           'displayName' => 'div',
           'custom' => {},
           'hidden' => false,
-          'nodes' => %w[XGtvXcaUr3 nt24xY6COf],
+          'nodes' => %w[XGtvXcaUr3 B8vvp7in1B nt24xY6COf],
           'linkedNodes' => {}
         },
         'nt24xY6COf' => {
@@ -158,6 +158,23 @@ describe ContentBuilder::LayoutImageService do
             }
           },
           'displayName' => 'Image',
+          'custom' => {},
+          'parent' => 'ROOT',
+          'hidden' => false,
+          'nodes' => [],
+          'linkedNodes' => {}
+        },
+        'B8vvp7in1B' => {
+          'type' => {
+            'resolvedName' => 'HomepageBanner'
+          },
+          'isCanvas' => false,
+          'props' => {
+            'image' => {
+              'dataCode' => layout_image.code
+            }
+          },
+          'displayName' => 'HomepageBanner',
           'custom' => {},
           'parent' => 'ROOT',
           'hidden' => false,
@@ -196,7 +213,7 @@ describe ContentBuilder::LayoutImageService do
           'displayName' => 'div',
           'custom' => {},
           'hidden' => false,
-          'nodes' => %w[XGtvXcaUr3 nt24xY6COf],
+          'nodes' => %w[XGtvXcaUr3 B8vvp7in1B nt24xY6COf],
           'linkedNodes' => {}
         },
         'nt24xY6COf' => {
@@ -213,6 +230,24 @@ describe ContentBuilder::LayoutImageService do
             }
           },
           'displayName' => 'Image',
+          'custom' => {},
+          'parent' => 'ROOT',
+          'hidden' => false,
+          'nodes' => [],
+          'linkedNodes' => {}
+        },
+        'B8vvp7in1B' => {
+          'type' => {
+            'resolvedName' => 'HomepageBanner'
+          },
+          'isCanvas' => false,
+          'props' => {
+            'image' => {
+              'dataCode' => layout_image.code,
+              'imageUrl' => layout_image.image.url
+            }
+          },
+          'displayName' => 'HomepageBanner',
           'custom' => {},
           'parent' => 'ROOT',
           'hidden' => false,
@@ -240,6 +275,60 @@ describe ContentBuilder::LayoutImageService do
       imageable = build(:home_page, craftjs_json: craftjs_json)
       output = service.render_data_images imageable.craftjs_json
       expect(output).to eq expected_json
+    end
+
+    it 'adds the src attribute to the image elements' do
+      layout_image = create(:layout_image)
+      craftjs_json = {
+        'ROOT' => {
+          'type' => 'div',
+          'isCanvas' => true,
+          'props' => {
+            'id' => 'e2e-content-builder-frame',
+            'style' => {
+              'padding' => '4px',
+              'minHeight' => '160px',
+              'backgroundColor' => '#fff'
+            }
+          },
+          'displayName' => 'div',
+          'custom' => {},
+          'hidden' => false,
+          'nodes' => %w[B8vvp7in1B XGtvXcaUr3],
+          'linkedNodes' => {}
+        },
+        'B8vvp7in1B' => {
+          'type' => {
+            'resolvedName' => 'HomepageBanner'
+          },
+          'isCanvas' => false,
+          'props' => {},
+          'displayName' => 'HomepageBanner',
+          'custom' => {},
+          'parent' => 'ROOT',
+          'hidden' => false,
+          'nodes' => [],
+          'linkedNodes' => {}
+        },
+        'XGtvXcaUr3' => {
+          'badtype' => 42,
+          'isCanvas' => false,
+          'props' => {
+            'text' => '<p>This is some text.</p>',
+            'id' => 'text'
+          },
+          'displayName' => 'Text',
+          'custom' => {},
+          'parent' => 'ROOT',
+          'hidden' => false,
+          'nodes' => [],
+          'linkedNodes' => {}
+        }
+      }
+
+      imageable = build(:home_page, craftjs_json: craftjs_json)
+      output = service.render_data_images imageable.craftjs_json
+      expect(output).to eq craftjs_json
     end
   end
 end

--- a/back/engines/commercial/content_builder/spec/services/content_builder/layout_image_service_spec.rb
+++ b/back/engines/commercial/content_builder/spec/services/content_builder/layout_image_service_spec.rb
@@ -277,8 +277,7 @@ describe ContentBuilder::LayoutImageService do
       expect(output).to eq expected_json
     end
 
-    it 'adds the src attribute to the image elements' do
-      layout_image = create(:layout_image)
+    it 'can deal with craftjs_json in an unexpected format' do
       craftjs_json = {
         'ROOT' => {
           'type' => 'div',

--- a/back/engines/commercial/content_builder/spec/services/content_builder/layout_image_service_spec.rb
+++ b/back/engines/commercial/content_builder/spec/services/content_builder/layout_image_service_spec.rb
@@ -301,7 +301,7 @@ describe ContentBuilder::LayoutImageService do
             'resolvedName' => 'HomepageBanner'
           },
           'isCanvas' => false,
-          'props' => {},
+          'props' => {}, # Empty props
           'displayName' => 'HomepageBanner',
           'custom' => {},
           'parent' => 'ROOT',
@@ -310,7 +310,7 @@ describe ContentBuilder::LayoutImageService do
           'linkedNodes' => {}
         },
         'XGtvXcaUr3' => {
-          'badtype' => 42,
+          'badtype' => 42, # Bad type format
           'isCanvas' => false,
           'props' => {
             'text' => '<p>This is some text.</p>',

--- a/back/spec/acceptance/home_pages_spec.rb
+++ b/back/spec/acceptance/home_pages_spec.rb
@@ -58,7 +58,7 @@ resource 'Home Page' do
         assert_status 200
         json_response = json_parse(response_body)
         expect(json_response.dig(:data, :attributes, :events_widget_enabled)).to be true
-        expect(json_response.dig(:data, :attributes, :craftjs_json)).to eq({ test: 123 })
+        # expect(json_response.dig(:data, :attributes, :craftjs_json)).to eq({ test: 123 })
       end
 
       describe 'when banner_cta_signed_out_type: \'customized_button\' and button text and url both blank' do

--- a/back/spec/acceptance/home_pages_spec.rb
+++ b/back/spec/acceptance/home_pages_spec.rb
@@ -54,11 +54,14 @@ resource 'Home Page' do
       let(:events_widget_enabled) { true }
       let(:craftjs_json) { { 'test' => 123 } }
 
-      example_request 'Update the current home page' do
+      example 'Update the current home page' do
+        SettingsService.new.activate_feature! 'homepage_builder'
+        do_request
+
         assert_status 200
         json_response = json_parse(response_body)
         expect(json_response.dig(:data, :attributes, :events_widget_enabled)).to be true
-        # expect(json_response.dig(:data, :attributes, :craftjs_json)).to eq({ test: 123 })
+        expect(json_response.dig(:data, :attributes, :craftjs_json)).to eq({ test: 123 })
       end
 
       describe 'when banner_cta_signed_out_type: \'customized_button\' and button text and url both blank' do


### PR DESCRIPTION
There was a small incident where the homepage of the demo.stg platform no longer worked after testing out the new craftjs. This is because the new craftjs was in an unexpected format (but I think the code would also have crashed if there was a homepagebanner element with no image).

To have a better guarantee that this will never happen on an important production platform, two changes were made:

1. More robust code when searching for the image elements (+ spec).
2. Only render the craftjs_json when the experimental feature is activated.
