### PR TITLE
[CL-4038] Email for content flagged as spam is confusing

### DIFF
--- a/back/engines/commercial/flag_inappropriate_content/app/models/flag_inappropriate_content/email_campaigns/campaigns/inappropriate_content_flagged.rb
+++ b/back/engines/commercial/flag_inappropriate_content/app/models/flag_inappropriate_content/email_campaigns/campaigns/inappropriate_content_flagged.rb
@@ -81,12 +81,14 @@ module FlagInappropriateContent
           {
             flaggable_author: flaggable.author,
             flaggable: flaggable,
-            flaggable_type: flag.flaggable_type
+            flaggable_type: flag.flaggable_type,
+            flag_automatically_detected: flag.automatically_detected?
           }
         end
 
         payload = {
           flaggable_type: data[:flaggable_type],
+          flag_automatically_detected: data[:flag_automatically_detected],
           flaggable_author_name: UserDisplayNameService.new(AppConfiguration.instance, recipient).display_name!(data[:flaggable_author]),
           flaggable_url: Frontend::UrlService.new.model_to_url(data[:flaggable], locale: recipient.locale)
         }

--- a/back/engines/commercial/flag_inappropriate_content/app/models/flag_inappropriate_content/email_campaigns/campaigns/inappropriate_content_flagged.rb
+++ b/back/engines/commercial/flag_inappropriate_content/app/models/flag_inappropriate_content/email_campaigns/campaigns/inappropriate_content_flagged.rb
@@ -72,31 +72,36 @@ module FlagInappropriateContent
       end
 
       def generate_commands(recipient:, activity:, time: nil)
-        data = Rails.cache.fetch("campaigns/inappropriate_content_flagged/#{activity.item.inappropriate_content_flag_id}", expires_in: 5.minutes) do
-          flag = activity.item.inappropriate_content_flag
+        notification = activity.item
+
+        data = Rails.cache.fetch("campaigns/inappropriate_content_flagged/#{notification.inappropriate_content_flag_id}", expires_in: 5.minutes) do
+          flag = notification.inappropriate_content_flag
           flaggable = flag.flaggable
-          d = {
+
+          {
             flaggable_author: flaggable.author,
             flaggable: flaggable,
             flaggable_type: flag.flaggable_type
           }
-          d
         end
+
         payload = {
           flaggable_type: data[:flaggable_type],
           flaggable_author_name: UserDisplayNameService.new(AppConfiguration.instance, recipient).display_name!(data[:flaggable_author]),
           flaggable_url: Frontend::UrlService.new.model_to_url(data[:flaggable], locale: recipient.locale)
         }
+
         case data[:flaggable_type]
         when Idea.name, Initiative.name
           payload[:flaggable_title_multiloc] = data[:flaggable].title_multiloc
           payload[:flaggable_body_multiloc] = data[:flaggable].body_multiloc
         when Comment.name
           payload[:flaggable_body_multiloc] = data[:flaggable].body_multiloc
+        else
+          raise "Unsupported flaggable type: #{data[:flaggable_type]}"
         end
-        [{
-          event_payload: payload
-        }]
+
+        [{ event_payload: payload }]
       end
     end
   end

--- a/back/engines/commercial/flag_inappropriate_content/app/models/flag_inappropriate_content/inappropriate_content_flag.rb
+++ b/back/engines/commercial/flag_inappropriate_content/app/models/flag_inappropriate_content/inappropriate_content_flag.rb
@@ -29,6 +29,12 @@ module FlagInappropriateContent
       !!deleted_at
     end
 
+    # We use `toxicity_label` as a proxy to determine whether the flag was automatically
+    # detected as it's currently only set when using NLP detection.
+    def automatically_detected?
+      toxicity_label.present?
+    end
+
     def reason_code
       return 'inappropriate' if toxicity_label
 

--- a/back/engines/commercial/flag_inappropriate_content/app/views/flag_inappropriate_content/email_campaigns/inappropriate_content_flagged_mailer/campaign_mail.mjml
+++ b/back/engines/commercial/flag_inappropriate_content/app/views/flag_inappropriate_content/email_campaigns/inappropriate_content_flagged_mailer/campaign_mail.mjml
@@ -39,13 +39,16 @@
   </mj-column>
 </mj-section>
 
-<mj-section padding="20px 25px" text-align="left">
-  <mj-column>
-    <mj-text font-size="14px" color="#84939E">
-      <%= format_message('this_post_was_flagged', escape_html: false) %>
-    </mj-text>
-  </mj-column>
-</mj-section>
 
+  <mj-section padding="20px 25px" text-align="left">
+    <mj-column>
+      <mj-text font-size="14px" color="#84939E">
+        <% if event.flag_automatically_detected %>
+        <p><%= format_message('automatically_flagged') %></p>
+        <% end %>
+        <p><%= format_message('how_to_review') %></p>
+      </mj-text>
+    </mj-column>
+  </mj-section>
 
 <%= render partial: 'application/cta_button', locals: { href: event.flaggable_url, message: format_message('cta_review_post') } %>

--- a/back/engines/commercial/flag_inappropriate_content/config/locales/en.yml
+++ b/back/engines/commercial/flag_inappropriate_content/config/locales/en.yml
@@ -10,6 +10,11 @@ en:
       comment_author: '%{authorName} commented:'
       idea_author: '%{authorName} submitted a post:'
       initiative_author: '%{authorName} submitted a proposal:'
-      this_post_was_flagged: >
-        <p>This post was automatically detected as potentially containing inappropriate content. We’re sending you this notification so that you can review the post in accordance with your own moderation guidelines.</p><p>If the post does not contain inappropriate content, you can remove the warning via your platform in the Activity tab in the admin panel.</p>
+      automatically_flagged: >
+        This post was automatically detected as potentially containing inappropriate
+        content. We’re sending you this notification so that you can review the post in
+        accordance with your own moderation guidelines.
+      how_to_review: >
+        If the post does not contain inappropriate content, you can remove the warning 
+        via your platform in the Activity tab in the admin panel.
       cta_review_post: 'Review post'

--- a/back/engines/commercial/flag_inappropriate_content/spec/mailers/inappropriate_content_flagged_mailer_spec.rb
+++ b/back/engines/commercial/flag_inappropriate_content/spec/mailers/inappropriate_content_flagged_mailer_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe FlagInappropriateContent::EmailCampaigns::InappropriateContentFla
         recipient: recipient,
         event_payload: {
           flaggable_type: flaggable.class.name,
+          flag_automatically_detected: false,
           flaggable_author_name: UserDisplayNameService.new(AppConfiguration.instance, recipient).display_name!(flaggable.author),
           flaggable_url: Frontend::UrlService.new.model_to_url(flaggable, locale: recipient.locale),
           flaggable_title_multiloc: flaggable.title_multiloc,
@@ -46,6 +47,20 @@ RSpec.describe FlagInappropriateContent::EmailCampaigns::InappropriateContentFla
     it 'assigns review post CTA' do
       flaggable_url = command.dig(:event_payload, :flaggable_url)
       expect(mail.body.encoded).to match(flaggable_url)
+    end
+
+    it 'does not include the explanation note about automatic flagging' do
+      expect(mail.body.encoded).not_to include('This post was automatically detected')
+    end
+
+    context 'when the flag was automatically detected' do
+      before do
+        command[:event_payload][:flag_automatically_detected] = true
+      end
+
+      it 'includes the explanation note about automatic flagging' do
+        expect(mail.body.encoded).to include('This post was automatically detected')
+      end
     end
   end
 end

--- a/back/engines/commercial/flag_inappropriate_content/spec/mailers/previews/email_campaigns/inappropriate_content_flagged_mailer_preview.rb
+++ b/back/engines/commercial/flag_inappropriate_content/spec/mailers/previews/email_campaigns/inappropriate_content_flagged_mailer_preview.rb
@@ -10,6 +10,7 @@ module EmailCampaigns
       command = {
         recipient: recipient_user,
         event_payload: {
+          flag_automatically_detected: automatically_detected?,
           flaggable_type: flaggable.class.name,
           flaggable_author_name: UserDisplayNameService.new(AppConfiguration.instance, recipient_user).display_name!(flaggable.author),
           flaggable_url: Frontend::UrlService.new.model_to_url(flaggable, locale: recipient_user.locale),
@@ -17,9 +18,15 @@ module EmailCampaigns
           flaggable_body_multiloc: flaggable.body_multiloc
         }
       }
-      campaign = FlagInappropriateContent::EmailCampaigns::Campaigns::InappropriateContentFlagged.first
 
+      campaign = FlagInappropriateContent::EmailCampaigns::Campaigns::InappropriateContentFlagged.sole
       campaign.mailer_class.with(campaign: campaign, command: command).campaign_mail
+    end
+
+    private
+
+    def automatically_detected?
+      params[:automatically_detected] == 'true'
     end
   end
 end


### PR DESCRIPTION
# Changelog
## Fixed
- [CL-4038] Remove mentions of "automatic detection" in email about inappropriate content when the content is reported by a human/user.


[CL-4038]: https://citizenlab.atlassian.net/browse/CL-4038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ