### PR TITLE
Handle success actions for MFA

### DIFF
--- a/front/app/api/authentication/singleSignOn.ts
+++ b/front/app/api/authentication/singleSignOn.ts
@@ -28,6 +28,8 @@ export interface SSOParams {
   sso_verification_id?: string;
   sso_verification_type?: string;
   error_code?: SignUpInError;
+  // TODO: Refactoring + bettre integration of verification into new
+  // registration flow when there is BE support
   verification_success?: string;
 }
 

--- a/front/app/api/authentication/singleSignOn.ts
+++ b/front/app/api/authentication/singleSignOn.ts
@@ -28,6 +28,7 @@ export interface SSOParams {
   sso_verification_id?: string;
   sso_verification_type?: string;
   error_code?: SignUpInError;
+  verification_success?: string;
 }
 
 const setHrefVienna = () => {

--- a/front/app/api/authentication/singleSignOn.ts
+++ b/front/app/api/authentication/singleSignOn.ts
@@ -28,7 +28,7 @@ export interface SSOParams {
   sso_verification_id?: string;
   sso_verification_type?: string;
   error_code?: SignUpInError;
-  // TODO: Refactoring + bettre integration of verification into new
+  // TODO: Refactoring + better integration of verification into new
   // registration flow when there is BE support
   verification_success?: string;
 }

--- a/front/app/api/verification_methods/types.ts
+++ b/front/app/api/verification_methods/types.ts
@@ -3,6 +3,15 @@ import verificationMethodsKeys from './keys';
 
 export type VerificationMethodsKeys = Keys<typeof verificationMethodsKeys>;
 
+export const verificationTypesLeavingPlatform = [
+  'auth0',
+  'criipto',
+  'bosa_fas',
+  'clave_unica',
+  'franceconnect',
+  'nemlog_in',
+];
+
 export interface IVerificationMethodNamesMap {}
 
 export type TVerificationMethodName =

--- a/front/app/containers/Authentication/Modal.tsx
+++ b/front/app/containers/Authentication/Modal.tsx
@@ -193,8 +193,14 @@ const AuthModal = ({ setModalOpen }: ModalProps) => {
   ) {
     if (authenticationData?.successAction) {
       localStorage.setItem(
-        'sso_success_action',
+        'auth_success_action',
         JSON.stringify(authenticationData.successAction)
+      );
+    }
+    if (authenticationData?.context) {
+      localStorage.setItem(
+        'auth_context',
+        JSON.stringify(authenticationData.context)
       );
     }
   }

--- a/front/app/containers/Authentication/Modal.tsx
+++ b/front/app/containers/Authentication/Modal.tsx
@@ -184,8 +184,8 @@ const AuthModal = ({ setModalOpen }: ModalProps) => {
     ? appConfiguration?.data.attributes.settings.core[helperTextKey]
     : undefined;
 
-  // If the user is verifying their identity, save the successAction in
-  // local storage for when they return.
+  // If the user is verifying their identity, save the successAction and
+  // the current context in local storage for when they return.
   if (
     currentStep === 'missing-data:verification' ||
     currentStep === 'verification-only' ||

--- a/front/app/containers/Authentication/Modal.tsx
+++ b/front/app/containers/Authentication/Modal.tsx
@@ -184,6 +184,21 @@ const AuthModal = ({ setModalOpen }: ModalProps) => {
     ? appConfiguration?.data.attributes.settings.core[helperTextKey]
     : undefined;
 
+  // If the user is verifying their identity, save the successAction in
+  // local storage for when they return.
+  if (
+    currentStep === 'missing-data:verification' ||
+    currentStep === 'verification-only' ||
+    currentStep === 'sign-up:verification'
+  ) {
+    if (authenticationData?.successAction) {
+      localStorage.setItem(
+        'sso_success_action',
+        JSON.stringify(authenticationData.successAction)
+      );
+    }
+  }
+
   return (
     <Modal
       fullScreen={fullscreenModalEnabled}

--- a/front/app/containers/Authentication/Modal.tsx
+++ b/front/app/containers/Authentication/Modal.tsx
@@ -184,27 +184,6 @@ const AuthModal = ({ setModalOpen }: ModalProps) => {
     ? appConfiguration?.data.attributes.settings.core[helperTextKey]
     : undefined;
 
-  // If the user is verifying their identity, save the successAction and
-  // the current context in local storage for when they return.
-  if (
-    currentStep === 'missing-data:verification' ||
-    currentStep === 'verification-only' ||
-    currentStep === 'sign-up:verification'
-  ) {
-    if (authenticationData?.successAction) {
-      localStorage.setItem(
-        'auth_success_action',
-        JSON.stringify(authenticationData.successAction)
-      );
-    }
-    if (authenticationData?.context) {
-      localStorage.setItem(
-        'auth_context',
-        JSON.stringify(authenticationData.context)
-      );
-    }
-  }
-
   return (
     <Modal
       fullScreen={fullscreenModalEnabled}
@@ -437,6 +416,7 @@ const AuthModal = ({ setModalOpen }: ModalProps) => {
           <Verification
             setError={setError}
             onCompleted={transition(currentStep, 'CONTINUE')}
+            authenticationData={authenticationData}
           />
         )}
 

--- a/front/app/containers/Authentication/steps/Verification/VerificationSteps.tsx
+++ b/front/app/containers/Authentication/steps/Verification/VerificationSteps.tsx
@@ -56,7 +56,7 @@ const VerificationSteps = memo<Props>(
 
     const onMethodSelected = (selectedMethod: TVerificationMethod) => {
       // Save the successAction and the current context in local
-      // storage for when user returns from verification.
+      // storage for when user returns from verification which leaves platform.
       if (
         verificationTypesLeavingPlatform.includes(
           selectedMethod.attributes.name

--- a/front/app/containers/Authentication/steps/Verification/VerificationSteps.tsx
+++ b/front/app/containers/Authentication/steps/Verification/VerificationSteps.tsx
@@ -13,9 +13,11 @@ import styled from 'styled-components';
 
 // typings
 import { TVerificationMethod } from 'api/verification_methods/types';
-import { isNilOrError } from 'utils/helperUtils';
 import { TVerificationStep } from 'containers/Authentication/steps/Verification/utils';
+import { AuthenticationData } from 'containers/Authentication/typings';
 
+// utils
+import { isNilOrError } from 'utils/helperUtils';
 import { invalidateQueryCache } from 'utils/cl-react-query/resetQueryCache';
 
 const Container = styled.div`
@@ -27,67 +29,84 @@ const Container = styled.div`
 export interface Props {
   onCompleted?: () => void;
   onError?: () => void;
+  authenticationData: AuthenticationData;
 }
 
-const VerificationSteps = memo<Props>(({ onCompleted, onError }) => {
-  const [activeStep, setActiveStep] =
-    useState<TVerificationStep>('method-selection');
-  const [method, setMethod] = useState<TVerificationMethod | null>(null);
+const VerificationSteps = memo<Props>(
+  ({ onCompleted, onError, authenticationData }) => {
+    const [activeStep, setActiveStep] =
+      useState<TVerificationStep>('method-selection');
+    const [method, setMethod] = useState<TVerificationMethod | null>(null);
 
-  const { data: authUser } = useAuthUser();
-  const { data: verificationMethods } = useVerificationMethods();
+    const { data: authUser } = useAuthUser();
+    const { data: verificationMethods } = useVerificationMethods();
 
-  useEffect(() => {
-    if (activeStep === 'success' && onCompleted) {
-      onCompleted();
-    }
+    useEffect(() => {
+      if (activeStep === 'success' && onCompleted) {
+        onCompleted();
+      }
 
-    if (activeStep === 'error' && onError) {
-      onError();
-    }
-  }, [onCompleted, onError, activeStep]);
+      if (activeStep === 'error' && onError) {
+        onError();
+      }
+    }, [onCompleted, onError, activeStep]);
 
-  const onMethodSelected = (selectedMethod: TVerificationMethod) => {
-    setMethod(selectedMethod);
-    setActiveStep('method-step');
-  };
+    const onMethodSelected = (selectedMethod: TVerificationMethod) => {
+      // Save the successAction and the current context in local
+      // storage for when user returns from verification.
+      if (authenticationData?.successAction) {
+        localStorage.setItem(
+          'auth_success_action',
+          JSON.stringify(authenticationData.successAction)
+        );
+      }
+      if (authenticationData?.context) {
+        localStorage.setItem(
+          'auth_context',
+          JSON.stringify(authenticationData.context)
+        );
+      }
+      setMethod(selectedMethod);
+      setActiveStep('method-step');
+    };
 
-  const goToSuccessStep = useCallback(() => {
-    if (!isNilOrError(authUser)) {
-      invalidateQueryCache();
-      setActiveStep('success');
+    const goToSuccessStep = useCallback(() => {
+      if (!isNilOrError(authUser)) {
+        invalidateQueryCache();
+        setActiveStep('success');
+        setMethod(null);
+      }
+    }, [authUser]);
+
+    const onStepCancel = useCallback(() => {
+      setActiveStep('method-selection');
       setMethod(null);
+    }, []);
+
+    const onStepVerified = useCallback(() => {
+      goToSuccessStep();
+    }, [goToSuccessStep]);
+
+    if (verificationMethods) {
+      return (
+        <Container id="e2e-verification-wizard-root">
+          {activeStep === 'method-selection' && (
+            <VerificationMethods onMethodSelected={onMethodSelected} />
+          )}
+
+          <Outlet
+            id="app.components.VerificationModal.methodSteps"
+            method={method}
+            onCancel={onStepCancel}
+            onVerified={onStepVerified}
+            activeStep={activeStep}
+          />
+        </Container>
+      );
     }
-  }, [authUser]);
 
-  const onStepCancel = useCallback(() => {
-    setActiveStep('method-selection');
-    setMethod(null);
-  }, []);
-
-  const onStepVerified = useCallback(() => {
-    goToSuccessStep();
-  }, [goToSuccessStep]);
-
-  if (verificationMethods) {
-    return (
-      <Container id="e2e-verification-wizard-root">
-        {activeStep === 'method-selection' && (
-          <VerificationMethods onMethodSelected={onMethodSelected} />
-        )}
-
-        <Outlet
-          id="app.components.VerificationModal.methodSteps"
-          method={method}
-          onCancel={onStepCancel}
-          onVerified={onStepVerified}
-          activeStep={activeStep}
-        />
-      </Container>
-    );
+    return null;
   }
-
-  return null;
-});
+);
 
 export default VerificationSteps;

--- a/front/app/containers/Authentication/steps/Verification/VerificationSteps.tsx
+++ b/front/app/containers/Authentication/steps/Verification/VerificationSteps.tsx
@@ -12,7 +12,10 @@ import useVerificationMethods from 'api/verification_methods/useVerificationMeth
 import styled from 'styled-components';
 
 // typings
-import { TVerificationMethod } from 'api/verification_methods/types';
+import {
+  TVerificationMethod,
+  verificationTypesLeavingPlatform,
+} from 'api/verification_methods/types';
 import { TVerificationStep } from 'containers/Authentication/steps/Verification/utils';
 import { AuthenticationData } from 'containers/Authentication/typings';
 
@@ -54,18 +57,25 @@ const VerificationSteps = memo<Props>(
     const onMethodSelected = (selectedMethod: TVerificationMethod) => {
       // Save the successAction and the current context in local
       // storage for when user returns from verification.
-      if (authenticationData?.successAction) {
-        localStorage.setItem(
-          'auth_success_action',
-          JSON.stringify(authenticationData.successAction)
-        );
+      if (
+        verificationTypesLeavingPlatform.includes(
+          selectedMethod.attributes.name
+        )
+      ) {
+        if (authenticationData?.successAction) {
+          localStorage.setItem(
+            'auth_success_action',
+            JSON.stringify(authenticationData.successAction)
+          );
+        }
+        if (authenticationData?.context) {
+          localStorage.setItem(
+            'auth_context',
+            JSON.stringify(authenticationData.context)
+          );
+        }
       }
-      if (authenticationData?.context) {
-        localStorage.setItem(
-          'auth_context',
-          JSON.stringify(authenticationData.context)
-        );
-      }
+
       setMethod(selectedMethod);
       setActiveStep('method-step');
     };

--- a/front/app/containers/Authentication/steps/Verification/index.tsx
+++ b/front/app/containers/Authentication/steps/Verification/index.tsx
@@ -2,14 +2,22 @@ import React from 'react';
 import VerificationSteps from './VerificationSteps';
 import { trackEventByName } from 'utils/analytics';
 import tracks from './tracks';
-import { SetError } from 'containers/Authentication/typings';
+import {
+  AuthenticationData,
+  SetError,
+} from 'containers/Authentication/typings';
 
 interface Props {
   setError: SetError;
   onCompleted: () => void;
+  authenticationData: AuthenticationData;
 }
 
-const VerificationSignUpStep = ({ setError, onCompleted }: Props) => {
+const VerificationSignUpStep = ({
+  setError,
+  onCompleted,
+  authenticationData,
+}: Props) => {
   const handleOnCompleted = () => {
     trackEventByName(tracks.signUpVerificationStepCompleted);
     onCompleted();
@@ -24,6 +32,7 @@ const VerificationSignUpStep = ({ setError, onCompleted }: Props) => {
     <VerificationSteps
       onCompleted={handleOnCompleted}
       onError={handleOnError}
+      authenticationData={authenticationData}
     />
   );
 };

--- a/front/app/containers/Authentication/useSteps/index.ts
+++ b/front/app/containers/Authentication/useSteps/index.ts
@@ -314,15 +314,7 @@ export default function useSteps() {
 
       transition(currentStep, 'RESUME_FLOW_AFTER_SSO')(enterClaveUnicaEmail);
     }
-  }, [
-    pathname,
-    search,
-    currentStep,
-    transition,
-    authUser,
-    setError,
-    getAuthenticationData,
-  ]);
+  }, [pathname, search, currentStep, transition, authUser, setError]);
 
   // always show ClaveUnica modal to user
   useEffect(() => {

--- a/front/app/containers/Authentication/useSteps/index.ts
+++ b/front/app/containers/Authentication/useSteps/index.ts
@@ -266,22 +266,27 @@ export default function useSteps() {
         sso_verification_id,
         sso_verification_type,
         error_code,
+        verification_success,
       } = urlSearchParams as SSOParams;
 
-      const actionFromLocalStorage = localStorage.getItem('sso_success_action');
-      localStorage.removeItem('sso_success_action');
+      const actionFromLocalStorage = localStorage.getItem(
+        'auth_success_action'
+      );
+      localStorage.removeItem('auth_success_action');
 
-      const context =
-        sso_verification_type && sso_verification_action && sso_verification_id
-          ? {
-              type: sso_verification_type,
-              action: sso_verification_action,
-              id: sso_verification_id,
-            }
-          : GLOBAL_CONTEXT;
+      const contextFromLocalStorage = localStorage.getItem('auth_context');
+      localStorage.removeItem('auth_context');
+
+      const context = contextFromLocalStorage
+        ? JSON.parse(contextFromLocalStorage)
+        : {
+            type: sso_verification_type,
+            action: sso_verification_action,
+            id: sso_verification_id,
+          };
 
       authenticationDataRef.current = {
-        flow: sso_flow || 'signup',
+        flow: sso_flow || 'signin',
         successAction:
           actionFromLocalStorage && JSON.parse(actionFromLocalStorage),
         context: context as AuthenticationContext,
@@ -297,7 +302,7 @@ export default function useSteps() {
 
       if (sso_pathname) {
         clHistory.replace(sso_pathname);
-      } else {
+      } else if (!verification_success) {
         // Remove all parameters from URL as they've already been captured
         window.history.replaceState(null, '', '/');
       }

--- a/front/app/containers/Authentication/useSteps/index.ts
+++ b/front/app/containers/Authentication/useSteps/index.ts
@@ -269,11 +269,13 @@ export default function useSteps() {
         verification_success,
       } = urlSearchParams as SSOParams;
 
+      // Check if there is a success action in local storage (from SSO or verification)
       const actionFromLocalStorage = localStorage.getItem(
         'auth_success_action'
       );
       localStorage.removeItem('auth_success_action');
 
+      // Check if there is a context in local storage (from verification)
       const contextFromLocalStorage = localStorage.getItem('auth_context');
       localStorage.removeItem('auth_context');
 

--- a/front/app/containers/Authentication/useSteps/stepConfig/sharedSteps.ts
+++ b/front/app/containers/Authentication/useSteps/stepConfig/sharedSteps.ts
@@ -113,7 +113,10 @@ export const sharedSteps = (
             return;
           }
 
-          setCurrentStep('success');
+          const { successAction } = getAuthenticationData();
+          if (successAction) {
+            triggerSuccessAction(successAction);
+          }
         }
       },
 


### PR DESCRIPTION
# Description
Making the success actions work properly with MFA as well. 

# Changelog
## Added
- User actions (E.g. Casting a vote) are now correctly taken when returning to the platform after 3rd party verification
