### PR TITLE
[CL-4257] Show all verification method names after autoreload

### DIFF
--- a/back/engines/commercial/id_auth0/lib/id_auth0/engine.rb
+++ b/back/engines/commercial/id_auth0/lib/id_auth0/engine.rb
@@ -7,7 +7,7 @@ module IdAuth0
     isolate_namespace IdAuth0
 
     config.to_prepare do
-      Verification::VerificationService.add_method(
+      Verification.add_method(
         Auth0Omniauth.new
       )
     end

--- a/back/engines/commercial/id_bogus/lib/id_bogus/engine.rb
+++ b/back/engines/commercial/id_bogus/lib/id_bogus/engine.rb
@@ -5,7 +5,7 @@ module IdBogus
     isolate_namespace IdBogus
 
     config.to_prepare do
-      Verification::VerificationService.add_method(
+      Verification.add_method(
         BogusVerification.new
       )
     end

--- a/back/engines/commercial/id_bosa_fas/lib/id_bosa_fas/engine.rb
+++ b/back/engines/commercial/id_bosa_fas/lib/id_bosa_fas/engine.rb
@@ -5,7 +5,7 @@ module IdBosaFas
     isolate_namespace IdBosaFas
 
     config.to_prepare do
-      Verification::VerificationService.add_method(
+      Verification.add_method(
         BosaFasOmniauth.new
       )
     end

--- a/back/engines/commercial/id_clave_unica/lib/id_clave_unica/engine.rb
+++ b/back/engines/commercial/id_clave_unica/lib/id_clave_unica/engine.rb
@@ -9,7 +9,7 @@ module IdClaveUnica
 
       cu = ClaveUnicaOmniauth.new
       AuthenticationService.add_method('clave_unica', cu)
-      Verification::VerificationService.add_method(cu)
+      Verification.add_method(cu)
     end
   end
 end

--- a/back/engines/commercial/id_cow/lib/id_cow/engine.rb
+++ b/back/engines/commercial/id_cow/lib/id_cow/engine.rb
@@ -5,7 +5,7 @@ module IdCow
     isolate_namespace IdCow
 
     config.to_prepare do
-      Verification::VerificationService.add_method(
+      Verification.add_method(
         CowVerification.new
       )
     end

--- a/back/engines/commercial/id_criipto/lib/id_criipto/engine.rb
+++ b/back/engines/commercial/id_criipto/lib/id_criipto/engine.rb
@@ -5,7 +5,7 @@ module IdCriipto
     isolate_namespace IdCriipto
 
     config.to_prepare do
-      Verification::VerificationService.add_method(
+      Verification.add_method(
         CriiptoOmniauth.new
       )
     end

--- a/back/engines/commercial/id_franceconnect/lib/id_franceconnect/engine.rb
+++ b/back/engines/commercial/id_franceconnect/lib/id_franceconnect/engine.rb
@@ -9,7 +9,7 @@ module IdFranceconnect
 
       fc = FranceconnectOmniauth.new
       AuthenticationService.add_method('franceconnect', fc)
-      Verification::VerificationService.add_method(fc)
+      Verification.add_method(fc)
     end
   end
 end

--- a/back/engines/commercial/id_gent_rrn/lib/id_gent_rrn/engine.rb
+++ b/back/engines/commercial/id_gent_rrn/lib/id_gent_rrn/engine.rb
@@ -5,7 +5,7 @@ module IdGentRrn
     isolate_namespace IdGentRrn
 
     config.to_prepare do
-      Verification::VerificationService.add_method(
+      Verification.add_method(
         GentRrnVerification.new
       )
     end

--- a/back/engines/commercial/id_id_card_lookup/lib/id_id_card_lookup/engine.rb
+++ b/back/engines/commercial/id_id_card_lookup/lib/id_id_card_lookup/engine.rb
@@ -16,7 +16,7 @@ module IdIdCardLookup
     config.factory_bot.definition_file_paths += [factories_path] if defined?(FactoryBotRails)
 
     config.to_prepare do
-      Verification::VerificationService.add_method(
+      Verification.add_method(
         IdCardLookupVerification.new
       )
     end

--- a/back/engines/commercial/id_nemlog_in/lib/id_nemlog_in/engine.rb
+++ b/back/engines/commercial/id_nemlog_in/lib/id_nemlog_in/engine.rb
@@ -6,7 +6,7 @@ module IdNemlogIn
 
     config.to_prepare do
       nemlog_in_omniauth = NemlogInOmniauth.new
-      Verification::VerificationService.add_method(nemlog_in_omniauth)
+      Verification.add_method(nemlog_in_omniauth)
 
       AppConfiguration::Settings.add_feature(IdNemlogIn::KkiLocationApiFeatureSpecification)
     end

--- a/back/engines/commercial/id_oostende_rrn/lib/id_oostende_rrn/engine.rb
+++ b/back/engines/commercial/id_oostende_rrn/lib/id_oostende_rrn/engine.rb
@@ -5,7 +5,7 @@ module IdOostendeRrn
     isolate_namespace IdOostendeRrn
 
     config.to_prepare do
-      Verification::VerificationService.add_method(
+      Verification.add_method(
         OostendeRrnVerification.new
       )
     end

--- a/back/engines/commercial/verification/app/services/verification/verification_service.rb
+++ b/back/engines/commercial/verification/app/services/verification/verification_service.rb
@@ -2,23 +2,12 @@
 
 module Verification
   class VerificationService
-    @all_methods = []
-
-    class << self
-      attr_reader :all_methods
-
-      def add_method(verification_method)
-        @all_methods.reject! { |m| m.id == verification_method.id }
-        @all_methods << verification_method
-      end
-    end
-
     def initialize(sfxv_service = SideFxVerificationService.new)
       @sfxv_service = sfxv_service
     end
 
     def all_methods
-      self.class.all_methods
+      ::Verification.all_methods
     end
 
     def method_by_name(name)

--- a/back/engines/commercial/verification/lib/verification.rb
+++ b/back/engines/commercial/verification/lib/verification.rb
@@ -3,5 +3,12 @@
 require 'verification/engine'
 
 module Verification
-  # Your code goes here...
+  mattr_accessor(:all_methods) { [] }
+
+  class << self
+    def add_method(verification_method)
+      all_methods.reject! { |m| m.id == verification_method.id }
+      all_methods << verification_method
+    end
+  end
 end

--- a/back/engines/commercial/verification/lib/verification.rb
+++ b/back/engines/commercial/verification/lib/verification.rb
@@ -3,6 +3,14 @@
 require 'verification/engine'
 
 module Verification
+  # This array `all_methods` is populated in `to_prepare` callbacks in Engines,
+  # and it's used to define the `VerificationMethodSerializer` attributes.
+  # When the code is autoreloaded, VerificationMethodSerializer is loaded BEFORE
+  # calling to_prepare callbacks, which means that `all_methods` is empty at the time.
+  # And so, no attributes are defined in the serializer.
+  # So, all_methods is defined here (in not-autoreloaded code), to keep it from
+  # resetting to empty when the code is autoreloaded.
+  #
   mattr_accessor(:all_methods) { [] }
 
   class << self

--- a/back/engines/commercial/verification/spec/lib/verification_spec.rb
+++ b/back/engines/commercial/verification/spec/lib/verification_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Verification do
+  describe '.add_method' do
+    it 'adds methods that are exposed through #all_methods' do
+      mthd = Struct.new(:id).new('9fb591e7-f577-40a7-8596-03e406d7eebe')
+      described_class.add_method(mthd)
+      expect(described_class.all_methods).to include(mthd)
+    end
+
+    it 'replaces duplicate methods with the same .id' do
+      mthd1 = Struct.new(:id).new('9fb591e7-f577-40a7-8596-03e406d7eebe')
+      mthd2 = Struct.new(:id).new('9fb591e7-f577-40a7-8596-03e406d7eebe')
+      described_class.add_method(mthd1)
+      described_class.add_method(mthd2)
+      expect(described_class.all_methods.select { |m| m.id == '9fb591e7-f577-40a7-8596-03e406d7eebe' }).to contain_exactly(mthd2)
+    end
+  end
+end

--- a/back/engines/commercial/verification/spec/services/verification_service_spec.rb
+++ b/back/engines/commercial/verification/spec/services/verification_service_spec.rb
@@ -188,20 +188,4 @@ describe Verification::VerificationService do
       end
     end
   end
-
-  describe 'add_method' do
-    it 'adds methods that are exposed through #all_methods' do
-      mthd = OpenStruct.new(id: '9fb591e7-f577-40a7-8596-03e406d7eebe')
-      service.class.add_method(mthd)
-      expect(service.class.all_methods).to include(mthd)
-    end
-
-    it 'replaces duplicate methods with the same .id' do
-      mthd1 = OpenStruct.new(id: '9fb591e7-f577-40a7-8596-03e406d7eebe')
-      mthd2 = OpenStruct.new(id: '9fb591e7-f577-40a7-8596-03e406d7eebe')
-      service.class.add_method(mthd1)
-      service.class.add_method(mthd2)
-      expect(service.all_methods.select { |m| m.id == '9fb591e7-f577-40a7-8596-03e406d7eebe' }).to contain_exactly(mthd2)
-    end
-  end
 end


### PR DESCRIPTION
VerificationService is autoloaded. But `all_methods` variable is populated (via `add_method`) in not-autoloaded code. And when VerificationService gets reloaded, `all_methods` is again initialized with empty array []. UPDATE: @adessy reasonably pointed out that `to_prepare` callbacks are called on every code reload. So, the real reason of an empty array is the order of running the code (the serializer is defined before calling `to_prepare` callbacks). The rest of the explanations still makes sense.

And when the attributes of the serializer are being defined, no method is used in this line
https://github.com/CitizenLabDotCo/citizenlab/blob/30bb3536e6bc813a9d96a602716165ef812b111b/back/engines/commercial/verification/app/serializers/verification/web_api/v1/verification_method_serializer.rb#L7

And so, no attribute is defined in the serializer except :name.

And on the FE, empty `method_name_multiloc` is used and so nothing is displayed.
https://github.com/CitizenLabDotCo/citizenlab/blob/30bb3536e6bc813a9d96a602716165ef812b111b/front/app/modules/commercial/id_auth0/api/verification_methods/types.ts#L14


# Changelog
## Technical
* [CL-4257] Show all verification method names after autoreload

[CL-4257]: https://citizenlab.atlassian.net/browse/CL-4257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ