### PR TITLE
[CL-4247] Remove related logic when survey select option is deleted

### DIFF
--- a/back/app/services/form_logic_service.rb
+++ b/back/app/services/form_logic_service.rb
@@ -39,7 +39,7 @@ class FormLogicService
   end
 
   def remove_select_logic_option_from_custom_fields(frozen_custom_field_option)
-    custom_field = fields.first
+    custom_field = frozen_custom_field_option.custom_field
 
     return unless custom_field&.logic.present? &&
                   custom_field.logic['rules'].pluck('if').include?(frozen_custom_field_option.id)

--- a/back/app/services/form_logic_service.rb
+++ b/back/app/services/form_logic_service.rb
@@ -38,6 +38,16 @@ class FormLogicService
     end
   end
 
+  def remove_select_logic_option_from_custom_fields(frozen_custom_field_option)
+    custom_field = fields.first
+
+    return unless custom_field&.logic.present? &&
+                  custom_field.logic['rules'].pluck('if').include?(frozen_custom_field_option.id)
+
+    custom_field.logic['rules'].reject! { |rule| rule['if'] == frozen_custom_field_option.id }
+    custom_field.save!
+  end
+
   private
 
   attr_reader :fields, :field_index, :option_index

--- a/back/app/services/side_fx_custom_field_option_service.rb
+++ b/back/app/services/side_fx_custom_field_option_service.rb
@@ -20,7 +20,11 @@ class SideFxCustomFieldOptionService
   end
 
   def after_destroy(frozen_custom_field_option, current_user)
-    remove_logic_option_from_custom_fields(frozen_custom_field_option)
+    custom_field = frozen_custom_field_option.custom_field
+    if custom_field&.resource_type == 'CustomForm' && custom_field&.input_type == 'select'
+      FormLogicService.new([frozen_custom_field_option.custom_field])
+        .remove_select_logic_option_from_custom_fields(frozen_custom_field_option)
+    end
 
     serialized_custom_field_option = clean_time_attributes(frozen_custom_field_option.attributes)
     LogActivityJob.perform_later(
@@ -30,15 +34,5 @@ class SideFxCustomFieldOptionService
       Time.now.to_i,
       payload: { custom_field_option: serialized_custom_field_option }
     )
-  end
-
-  def remove_logic_option_from_custom_fields(frozen_custom_field_option)
-    custom_field = frozen_custom_field_option.custom_field
-
-    return unless custom_field&.input_type == 'select' && custom_field&.logic.present? &&
-                  custom_field.logic['rules'].pluck('if').include?(frozen_custom_field_option.id)
-
-    custom_field.logic['rules'].reject! { |rule| rule['if'] == frozen_custom_field_option.id }
-    custom_field.save!
   end
 end

--- a/back/spec/services/side_fx_custom_field_option_service_spec.rb
+++ b/back/spec/services/side_fx_custom_field_option_service_spec.rb
@@ -6,7 +6,7 @@ describe SideFxCustomFieldOptionService do
   let(:service) { described_class.new }
   let(:user) { create(:user) }
 
-  describe 'before_delete' do
+  describe 'before_destroy' do
     let(:custom_field) { create(:custom_field, :for_custom_form, input_type: 'select') }
     let(:option1) { create(:custom_field_option, custom_field: custom_field, key: 'option_1') }
     let!(:user1) { create(:user, custom_field_values: { custom_field.key => 'option_1' }) }
@@ -16,6 +16,33 @@ describe SideFxCustomFieldOptionService do
         service.before_destroy(option1, user)
 
         expect(user1.reload.custom_field_values).to eq({ custom_field.key => 'option_1' })
+      end
+    end
+  end
+
+  describe 'after_destroy' do
+    let(:custom_field1) { create(:custom_field, :for_custom_form, input_type: 'select') }
+    let(:custom_field2) { create(:custom_field, :for_custom_form, input_type: 'page') }
+    let(:custom_field3) { create(:custom_field, :for_custom_form, input_type: 'page') }
+    let(:option1) { create(:custom_field_option, custom_field: custom_field1, key: 'option_1') }
+    let(:option2) { create(:custom_field_option, custom_field: custom_field1, key: 'option_2') }
+    let(:logic) do
+      { rules: [
+        { if: option1.id, goto_page_id: custom_field2.id },
+        { if: option2.id, goto_page_id: custom_field3.id }
+      ] }
+    end
+
+    before do
+      custom_field1.update!(logic: logic)
+    end
+
+    context 'when custom field option that is a survey logic option is destroyed' do
+      it 'removes the logic option from custom fields that contain it' do
+        service.after_destroy(option1, user)
+
+        expect(custom_field1.reload.logic['rules'].count).to eq 1
+        expect(custom_field1.reload.logic['rules'].pluck('if')).to eq [option2.id]
       end
     end
   end


### PR DESCRIPTION
No model or acceptance tests added, as the test I added of the `after_destroy` action seems sufficient.

Also functionally tested, locally.

# Changelog
# Fixed
- [CL-4247] Remove related survey logic when a select option is destroyed. This should help prevent problems whereby a survey could fail to load because a single-select question still contained logic that pointed to a deleted option.


[CL-4247]: https://citizenlab.atlassian.net/browse/CL-4247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ