### PR TITLE
[CL-4212] Fix ClaveUnica signup bug

### DIFF
--- a/back/app/policies/user_policy.rb
+++ b/back/app/policies/user_policy.rb
@@ -103,15 +103,8 @@ class UserPolicy < ApplicationPolicy
     !!((user && (instance&.id == user.id || user.admin?)) || instance&.invite_pending?)
   end
 
-  def permitted_attributes_for_create
+  def permitted_attributes
     [:email] + shared_permitted_attributes
-  end
-
-  def permitted_attributes_for_update
-    # shared_permitted_attributes.tap do |attrs|
-    #   attrs.push :email if !AppConfiguration.instance.feature_activated?('user_confirmation')
-    # end
-    permitted_attributes_for_create
   end
 
   private

--- a/back/app/policies/user_policy.rb
+++ b/back/app/policies/user_policy.rb
@@ -108,9 +108,10 @@ class UserPolicy < ApplicationPolicy
   end
 
   def permitted_attributes_for_update
-    shared_permitted_attributes.tap do |attrs|
-      attrs.push :email if !AppConfiguration.instance.feature_activated?('user_confirmation')
-    end
+    # shared_permitted_attributes.tap do |attrs|
+    #   attrs.push :email if !AppConfiguration.instance.feature_activated?('user_confirmation')
+    # end
+    permitted_attributes_for_create
   end
 
   private

--- a/back/app/policies/user_policy.rb
+++ b/back/app/policies/user_policy.rb
@@ -104,15 +104,11 @@ class UserPolicy < ApplicationPolicy
   end
 
   def permitted_attributes
-    [:email] + shared_permitted_attributes
+    shared = [:email, :first_name, :last_name, :password, :avatar, :locale, { onboarding: [:topics_and_areas], custom_field_values: allowed_custom_field_keys, bio_multiloc: CL2_SUPPORTED_LOCALES }]
+    admin? ? shared + [roles: %i[type project_id project_folder_id]] : shared
   end
 
   private
-
-  def shared_permitted_attributes
-    shared = [:first_name, :last_name, :password, :avatar, :locale, { onboarding: [:topics_and_areas], custom_field_values: allowed_custom_field_keys, bio_multiloc: CL2_SUPPORTED_LOCALES }]
-    admin? ? shared + [roles: %i[type project_id project_folder_id]] : shared
-  end
 
   def allowed_custom_field_keys
     allowed_fields = allowed_custom_fields

--- a/back/app/policies/user_policy.rb
+++ b/back/app/policies/user_policy.rb
@@ -104,11 +104,15 @@ class UserPolicy < ApplicationPolicy
   end
 
   def permitted_attributes
-    shared = [:email, :first_name, :last_name, :password, :avatar, :locale, { onboarding: [:topics_and_areas], custom_field_values: allowed_custom_field_keys, bio_multiloc: CL2_SUPPORTED_LOCALES }]
-    admin? ? shared + [roles: %i[type project_id project_folder_id]] : shared
+    [:email] + shared_permitted_attributes
   end
 
   private
+
+  def shared_permitted_attributes
+    shared = [:email, :first_name, :last_name, :password, :avatar, :locale, { onboarding: [:topics_and_areas], custom_field_values: allowed_custom_field_keys, bio_multiloc: CL2_SUPPORTED_LOCALES }]
+    admin? ? shared + [roles: %i[type project_id project_folder_id]] : shared
+  end
 
   def allowed_custom_field_keys
     allowed_fields = allowed_custom_fields

--- a/back/engines/commercial/bulk_import_ideas/app/controllers/bulk_import_ideas/web_api/v1/project_users_controller.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/controllers/bulk_import_ideas/web_api/v1/project_users_controller.rb
@@ -32,7 +32,7 @@ module BulkImportIdeas
     private
 
     def user_params(user)
-      params.require(:user).permit(UserPolicy.new(current_user, user).permitted_attributes_for_create)
+      params.require(:user).permit(UserPolicy.new(current_user, user).permitted_attributes)
     end
   end
 end


### PR DESCRIPTION
Bug was almost certainly introduced by [this change]( https://github.com/CitizenLabDotCo/citizenlab/pull/6142/files#diff-17330ff3519690e4dc94c56816987e56755d9be7e42c96bf6f45de39dc8b1cf9R112).

Though, actually that change really just revealed a more specific bug with ClaveUnica, which is fixed by #6440 (and the changes made here are reverted)

I have not created regression tests, since this would involve some rather complex stubbing of ClaveUnica responses (if it's really possible at all to test this specific case), and I would rather get this bugfix out as the customer has been dealing with this issue for a while now.

# Changelog
## Fixed
- [CL-4212] Bug with ClaveUnica signup: Users who sign up with ClaveUnica, but then sign out (or get signed out) before submitting their email, no longer get stuck infinite loop of being asked for email when they sign in, getting a success message when they provide an email, and then being asked for their email again, etc.


[CL-4212]: https://citizenlab.atlassian.net/browse/CL-4212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ