### PR TITLE
[CL-4212] ClaveUnica: Require email confirmation if confirmation feature active

### DIFF
--- a/back/app/controllers/omniauth_callback_controller.rb
+++ b/back/app/controllers/omniauth_callback_controller.rb
@@ -190,7 +190,7 @@ class OmniauthCallbackController < ApplicationController
     attrs = authver_method.updateable_user_attrs
     update_hash = authver_method.profile_to_user_attrs(auth).slice(*attrs).compact
     update_hash.delete(:remote_avatar_url) if user.avatar.present? # don't overwrite avatar if already present
-    user.confirm! if authver_method.email_confirmed?(user) # confirm user email if not already confirmed
+    user.confirm! if authver_method.email_confirmed?(auth) # confirm user email if not already confirmed
 
     if authver_method.overwrite_user_attrs?
       user.update_merging_custom_fields!(update_hash)

--- a/back/app/controllers/omniauth_callback_controller.rb
+++ b/back/app/controllers/omniauth_callback_controller.rb
@@ -190,7 +190,7 @@ class OmniauthCallbackController < ApplicationController
     attrs = authver_method.updateable_user_attrs
     update_hash = authver_method.profile_to_user_attrs(auth).slice(*attrs).compact
     update_hash.delete(:remote_avatar_url) if user.avatar.present? # don't overwrite avatar if already present
-    user.confirm! # confirm user email if not already confirmed
+    user.confirm! if authver_method.email_confirmed?(user) # confirm user email if not already confirmed
 
     if authver_method.overwrite_user_attrs?
       user.update_merging_custom_fields!(update_hash)

--- a/back/app/policies/user_policy.rb
+++ b/back/app/policies/user_policy.rb
@@ -103,8 +103,14 @@ class UserPolicy < ApplicationPolicy
     !!((user && (instance&.id == user.id || user.admin?)) || instance&.invite_pending?)
   end
 
-  def permitted_attributes
+  def permitted_attributes_for_create
     [:email] + shared_permitted_attributes
+  end
+
+  def permitted_attributes_for_update
+    shared_permitted_attributes.tap do |attrs|
+      attrs.push :email if !AppConfiguration.instance.feature_activated?('user_confirmation')
+    end
   end
 
   private

--- a/back/engines/commercial/bulk_import_ideas/app/controllers/bulk_import_ideas/web_api/v1/project_users_controller.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/controllers/bulk_import_ideas/web_api/v1/project_users_controller.rb
@@ -32,7 +32,7 @@ module BulkImportIdeas
     private
 
     def user_params(user)
-      params.require(:user).permit(UserPolicy.new(current_user, user).permitted_attributes)
+      params.require(:user).permit(UserPolicy.new(current_user, user).permitted_attributes_for_create)
     end
   end
 end

--- a/back/engines/commercial/id_clave_unica/app/lib/id_clave_unica/clave_unica_omniauth.rb
+++ b/back/engines/commercial/id_clave_unica/app/lib/id_clave_unica/clave_unica_omniauth.rb
@@ -83,8 +83,8 @@ module IdClaveUnica
       true
     end
 
-    def email_confirmed?(user)
-      !user.confirmation_required?
+    def email_confirmed?(_auth)
+      false
     end
 
     private

--- a/back/engines/commercial/id_clave_unica/app/lib/id_clave_unica/clave_unica_omniauth.rb
+++ b/back/engines/commercial/id_clave_unica/app/lib/id_clave_unica/clave_unica_omniauth.rb
@@ -83,6 +83,10 @@ module IdClaveUnica
       true
     end
 
+    def email_confirmed?(user)
+      !user.confirmation_required?
+    end
+
     private
 
     def formatted_rut(auth)

--- a/back/lib/omniauth_methods/base.rb
+++ b/back/lib/omniauth_methods/base.rb
@@ -45,5 +45,9 @@ module OmniauthMethods
     def verification_prioritized?
       raise NotImplementedError
     end
+
+    def email_confirmed?(_user)
+      true
+    end
   end
 end

--- a/back/lib/omniauth_methods/base.rb
+++ b/back/lib/omniauth_methods/base.rb
@@ -46,7 +46,7 @@ module OmniauthMethods
       raise NotImplementedError
     end
 
-    def email_confirmed?(_user)
+    def email_confirmed?(_auth)
       true
     end
   end


### PR DESCRIPTION
Effectively reverts #6437 and adds a better fix, specific to the ClaveUnica case.

# Changelog
## Fixed
- [CL-4212] Activate email confirmation for ClaveUnica SSO (Single sign-on method)


[CL-4212]: https://citizenlab.atlassian.net/browse/CL-4212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ