### PR TITLE
[CL-4250] Don't send Project Published notification to followers without access rights

### DIFF
--- a/back/app/models/notifications/project_published.rb
+++ b/back/app/models/notifications/project_published.rb
@@ -74,7 +74,9 @@ module Notifications
       project = activity.item
       followers = Follower.where(followable: project.topics).or(Follower.where(followable: project.areas))
       followers = followers.or(Follower.where(followable: project.folder)) if project.in_folder?
-      User.from_follows(followers).where.not(id: initiator_id).map do |recipient|
+      ProjectPolicy::InverseScope.new(
+        project, User.from_follows(followers).where.not(id: initiator_id)
+      ).resolve.map do |recipient|
         new(
           recipient_id: recipient.id,
           initiating_user_id: initiator_id,

--- a/back/spec/models/notifications/project_published_spec.rb
+++ b/back/spec/models/notifications/project_published_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Notifications::ProjectPublished do
       expect(notifications).to eq []
     end
 
-    it "doesn't notificaty followers who don'o't have access the project" do
+    it "doesn't notify followers who don't have access the project" do
       area = create(:area)
       project = create(:project, areas: [area], visible_to: 'groups', groups: [create(:group)])
       _follower = create(:follower, followable: area)

--- a/back/spec/models/notifications/project_published_spec.rb
+++ b/back/spec/models/notifications/project_published_spec.rb
@@ -29,5 +29,16 @@ RSpec.describe Notifications::ProjectPublished do
       notifications = described_class.make_notifications_on activity
       expect(notifications).to eq []
     end
+
+    it "doesn't notificaty followers who don'o't have access the project" do
+      area = create(:area)
+      project = create(:project, areas: [area], visible_to: 'groups', groups: [create(:group)])
+      _follower = create(:follower, followable: area)
+
+      activity = create(:activity, item: project, action: 'published')
+
+      notifications = described_class.make_notifications_on activity
+      expect(notifications).to eq []
+    end
   end
 end


### PR DESCRIPTION
# Changelog
## Fixed
- [CL-4250] Bugfix: We no longer send Project Published notifications (or the related email) to followers of a project who do not have access rights to view the project - e.g. if the user follows an area or topic associated with the project.


[CL-4250]: https://citizenlab.atlassian.net/browse/CL-4250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ