### PR TITLE
TAN-515 - Fix for missing form logic in continuous project migration

### DIFF
--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/rake/continuous_project_migration_service.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/rake/continuous_project_migration_service.rb
@@ -68,7 +68,7 @@ class MultiTenancy::Rake::ContinuousProjectMigrationService
     end
   end
 
-  # Fix for an issue we had on staging
+  # Fix for staging - when the task was run with no logic
   def fix_survey_custom_forms
     CustomForm.where(participation_context_type: 'Project').each do |form|
       project = Project.find(form.participation_context_id)

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/rake/continuous_project_migration_service.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/rake/continuous_project_migration_service.rb
@@ -58,10 +58,24 @@ class MultiTenancy::Rake::ContinuousProjectMigrationService
       # 9. Move any native survey analysis from project to phase
       update_native_survey_analyses(project, phase)
 
-      # 10. Add a creation activity for each phase - don't think there are any other activities that need updating
+      # 10. Update the custom_form context for native surveys
+      update_survey_form_context(project, phase)
+
+      # 11. Add a creation activity for each phase - don't think there are any other activities that need updating
       add_phase_creation_activity(phase)
 
       @stats[:success] = @stats[:success] + 1
+    end
+  end
+
+  # Fix for an issue we had on staging
+  def fix_survey_custom_forms
+    CustomForm.where(participation_context_type: 'Project').each do |form|
+      project = Project.find(form.participation_context_id)
+      if project.phases.count == 1 && project.phases.first.participation_method == 'native_survey'
+        form.update!(participation_context: project.phases.first)
+        Rails.logger.info "FIXED: form for project: #{project.slug}"
+      end
     end
   end
 
@@ -191,6 +205,12 @@ class MultiTenancy::Rake::ContinuousProjectMigrationService
 
   def add_phase_creation_activity(phase)
     LogActivityJob.perform_later(phase, 'created', nil, phase.created_at.to_i, { payload: { migrated_from_continuous: true } })
+  end
+
+  def update_survey_form_context(project, phase)
+    if phase.participation_method == 'native_survey'
+      @stats[:records_updated] += CustomForm.where(participation_context: project).update!(participation_context: phase).count
+    end
   end
 
   def error_handler(error)

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/migrate_continuous_projects.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/migrate_continuous_projects.rake
@@ -33,7 +33,7 @@ namespace :fix_existing_tenants do
 end
 
 namespace :fix_existing_tenants do
-  desc 'Migrate all continuous projects to timeline projects with a single phase'
+  desc 'Fix survey forms on staging'
   task :migrate_continuous_forms_fix, %i[specify_host] => [:environment] do |_t, args|
     specify_host = args[:specify_host]
     Tenant.prioritize(Tenant.creation_finalized).each do |tenant|


### PR DESCRIPTION
When run on staging, there was a missing step to move continuous native survey forms to the project context. This PR has two elements:
1. Adding the step into the main migration
2. Adding a separate task to fix those forms that did not get migrated first time 
