### PR TITLE
CL-4006 Handle duplicate user custom field titles in XLSX export

### DIFF
--- a/back/app/services/xlsx_service.rb
+++ b/back/app/services/xlsx_service.rb
@@ -309,7 +309,7 @@ class XlsxService
     titles_to_fields.each do |title, field_ids|
       if field_ids.size == 1
         fields_to_columns[field_ids.first] = title
-      else
+      else # add suffix to titles to distinguish between fields with same title
         field_ids.each_with_index { |field_id, i| fields_to_columns[field_id] = "#{title} (#{i + 1})" }
       end
     end

--- a/back/app/services/xlsx_service.rb
+++ b/back/app/services/xlsx_service.rb
@@ -297,20 +297,13 @@ class XlsxService
   end
 
   def map_user_custom_fields_to_columns(user_custom_fields)
-    titles_to_fields = {}
-
-    user_custom_fields.each do |field|
-      title = multiloc_service.t(field.title_multiloc)
-      titles_to_fields.key?(title) ? titles_to_fields[title] << field.id : titles_to_fields[title] = [field.id]
-    end
-
     fields_to_columns = {}
 
-    titles_to_fields.each do |title, field_ids|
-      if field_ids.size == 1
-        fields_to_columns[field_ids.first] = title
+    user_custom_fields.group_by { |field| multiloc_service.t(field.title_multiloc) }.each do |title, fields|
+      if fields.size == 1
+        fields_to_columns[fields.first.id] = title
       else # add suffix to titles to distinguish between fields with same title
-        field_ids.each_with_index { |field_id, i| fields_to_columns[field_id] = "#{title} (#{i + 1})" }
+        fields.each_with_index { |field, i| fields_to_columns[field.id] = "#{title} (#{i + 1})" }
       end
     end
 

--- a/back/spec/services/xlsx_service_spec.rb
+++ b/back/spec/services/xlsx_service_spec.rb
@@ -82,6 +82,7 @@ describe XlsxService do
 
       title_row = worksheet[0].cells.map(&:value)
       expect(title_row).to include('gender (1)', 'gender (2)')
+      expect(title_row).not_to include('gender')
     end
 
     describe do

--- a/back/spec/services/xlsx_service_spec.rb
+++ b/back/spec/services/xlsx_service_spec.rb
@@ -83,6 +83,12 @@ describe XlsxService do
       title_row = worksheet[0].cells.map(&:value)
       expect(title_row).to include('gender (1)', 'gender (2)')
       expect(title_row).not_to include('gender')
+
+      column1 = title_row.find_index 'gender (1)'
+      column2 = title_row.find_index 'gender (2)'
+      user_rows = worksheet.map { |row| row.cells.map(&:value) }
+      user_row = user_rows.find { |values| values.include? users.first.id }
+      expect([user_row[column1], user_row[column2]]).to eq ['Option 1', 'Option 2']
     end
 
     describe do

--- a/back/spec/services/xlsx_service_spec.rb
+++ b/back/spec/services/xlsx_service_spec.rb
@@ -67,6 +67,23 @@ describe XlsxService do
       expect(field_idx).to be_present
     end
 
+    it 'handles duplicate user custom field titles' do
+      select1 = create(:custom_field_select, title_multiloc: { 'en' => 'gender' })
+      select2 = create(:custom_field_select, title_multiloc: { 'en' => 'gender' })
+      option1 = create(:custom_field_option, custom_field: select1, title_multiloc: { 'en' => 'Option 1' })
+      option2 = create(:custom_field_option, custom_field: select2, title_multiloc: { 'en' => 'Option 2' })
+
+      users.first.update!(
+        custom_field_values: {
+          select1.key => option1.key,
+          select2.key => option2.key
+        }
+      )
+
+      title_row = worksheet[0].cells.map(&:value)
+      expect(title_row).to include('gender (1)', 'gender (2)')
+    end
+
     describe do
       let(:xlsx) { service.generate_users_xlsx(users, view_private_attributes: false) }
 


### PR DESCRIPTION
# Changelog
## Fixed
- [CL-4006] Export of answers to user registration questions with duplicate titles - previously we only exported to Excel the answers to one of questions with the same title. For example, if there are 2 registration questions with title 'Gender',  Excel exports will now include columns 'Gender (1)' and 'Gender (2)'.


[CL-4006]: https://citizenlab.atlassian.net/browse/CL-4006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ