### PR TITLE
TAN-430 - Submission count only from phase

### DIFF
--- a/front/app/api/submission_count/types.ts
+++ b/front/app/api/submission_count/types.ts
@@ -4,7 +4,6 @@ import { Keys } from 'utils/cl-react-query/types';
 export type SubmissionsCountKeys = Keys<typeof submissionsCountKeys>;
 
 export type IParameters = {
-  projectId: string;
   phaseId?: string;
 };
 

--- a/front/app/api/submission_count/useSubmissionCount.test.ts
+++ b/front/app/api/submission_count/useSubmissionCount.test.ts
@@ -27,25 +27,9 @@ describe('useSubmissionCount', () => {
   beforeAll(() => server.listen());
   afterAll(() => server.close());
 
-  it('returns data correctly for project', async () => {
-    const { result, waitFor } = renderHook(
-      () => useSubmissionCount({ projectId: 'projectId' }),
-      {
-        wrapper: createQueryClientWrapper(),
-      }
-    );
-
-    expect(result.current.isLoading).toBe(true);
-
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
-
-    expect(result.current.isLoading).toBe(false);
-    expect(result.current.data?.data).toEqual(statData);
-  });
-
   it('returns data correctly for phase', async () => {
     const { result, waitFor } = renderHook(
-      () => useSubmissionCount({ projectId: 'projectId' }),
+      () => useSubmissionCount({ phaseId: 'phaseId' }),
       {
         wrapper: createQueryClientWrapper(),
       }
@@ -67,7 +51,7 @@ describe('useSubmissionCount', () => {
     );
 
     const { result, waitFor } = renderHook(
-      () => useSubmissionCount({ projectId: 'projectId', phaseId: 'phaseId' }),
+      () => useSubmissionCount({ phaseId: 'phaseId' }),
       {
         wrapper: createQueryClientWrapper(),
       }

--- a/front/app/api/submission_count/useSubmissionCount.test.ts
+++ b/front/app/api/submission_count/useSubmissionCount.test.ts
@@ -7,7 +7,7 @@ import { rest } from 'msw';
 import createQueryClientWrapper from 'utils/testUtils/queryClientWrapper';
 import { IFormSubmissionCount } from 'api/submission_count/types';
 
-let apiPath = '*projects/:projectId/submission_count';
+let apiPath = '*phases/:phaseId/submission_count';
 
 const statData: IFormSubmissionCount = {
   data: {

--- a/front/app/api/submission_count/useSubmissionCount.ts
+++ b/front/app/api/submission_count/useSubmissionCount.ts
@@ -8,27 +8,25 @@ import {
   IFormSubmissionCount,
 } from './types';
 
-const getSubmissionCountEndpoint = (projectId: string, phaseId?: string) => {
-  return phaseId
-    ? `phases/${phaseId}/submission_count`
-    : `projects/${projectId}/submission_count`;
+const getSubmissionCountEndpoint = (phaseId?: string) => {
+  return `phases/${phaseId}/submission_count`;
 };
 
-const fetchSubmissionsCount = ({ projectId, phaseId }: IParameters) =>
+const fetchSubmissionsCount = ({ phaseId }: IParameters) =>
   fetcher<IFormSubmissionCount>({
-    path: `/${getSubmissionCountEndpoint(projectId, phaseId)}`,
+    path: `/${getSubmissionCountEndpoint(phaseId)}`,
     action: 'get',
   });
 
-const useSubmissionsCount = ({ projectId, phaseId }: IParameters) => {
+const useSubmissionsCount = ({ phaseId }: IParameters) => {
   return useQuery<
     IFormSubmissionCount,
     CLErrors,
     IFormSubmissionCount,
     SubmissionsCountKeys
   >({
-    queryKey: submissionsCountKeys.item({ projectId, phaseId }),
-    queryFn: () => fetchSubmissionsCount({ projectId, phaseId }),
+    queryKey: submissionsCountKeys.item({ phaseId }),
+    queryFn: () => fetchSubmissionsCount({ phaseId }),
   });
 };
 

--- a/front/app/api/submission_count/useSubmissionCount.ts
+++ b/front/app/api/submission_count/useSubmissionCount.ts
@@ -27,6 +27,7 @@ const useSubmissionsCount = ({ phaseId }: IParameters) => {
   >({
     queryKey: submissionsCountKeys.item({ phaseId }),
     queryFn: () => fetchSubmissionsCount({ phaseId }),
+    enabled: !!phaseId
   });
 };
 

--- a/front/app/api/survey_results/useDeleteSurveyResults.test.ts
+++ b/front/app/api/survey_results/useDeleteSurveyResults.test.ts
@@ -6,7 +6,7 @@ import { setupServer } from 'msw/node';
 import { rest } from 'msw';
 
 import createQueryClientWrapper from 'utils/testUtils/queryClientWrapper';
-const apiPath = '*projects/:projectId/inputs';
+const apiPath = '*phases/:phaseId/inputs';
 
 const server = setupServer(
   rest.delete(apiPath, (_req, res, ctx) => {
@@ -25,7 +25,7 @@ describe('useDeleteSurveyResults', () => {
 
     act(() => {
       result.current.mutate({
-        projectId: 'projectId',
+        phaseId: 'phaseId',
       });
     });
 
@@ -45,7 +45,7 @@ describe('useDeleteSurveyResults', () => {
 
     act(() => {
       result.current.mutate({
-        projectId: 'projectId',
+        phaseId: 'phaseId',
       });
     });
 

--- a/front/app/api/survey_results/useDeleteSurveyResults.ts
+++ b/front/app/api/survey_results/useDeleteSurveyResults.ts
@@ -4,15 +4,12 @@ import surveyResultsKeys from './keys';
 import submissionsCountKeys from 'api/submission_count/keys';
 
 const deleteSurveyResults = ({
-  projectId,
   phaseId,
 }: {
   projectId: string;
   phaseId?: string;
 }) => {
-  const deleteApiEndpoint = phaseId
-    ? `phases/${phaseId}/inputs`
-    : `projects/${projectId}/inputs`;
+  const deleteApiEndpoint = `phases/${phaseId}/inputs`;
   return fetcher({
     path: `/${deleteApiEndpoint}`,
     action: 'delete',
@@ -24,9 +21,9 @@ const useDeleteSurveyResults = () => {
 
   return useMutation({
     mutationFn: deleteSurveyResults,
-    onSuccess: (_data, { projectId, phaseId }) => {
+    onSuccess: (_data, { phaseId }) => {
       queryClient.invalidateQueries(
-        submissionsCountKeys.item({ projectId, phaseId })
+        submissionsCountKeys.item({ phaseId })
       );
       queryClient.invalidateQueries({
         queryKey: surveyResultsKeys.items(),

--- a/front/app/api/survey_results/useDeleteSurveyResults.ts
+++ b/front/app/api/survey_results/useDeleteSurveyResults.ts
@@ -4,9 +4,8 @@ import surveyResultsKeys from './keys';
 import submissionsCountKeys from 'api/submission_count/keys';
 
 const deleteSurveyResults = ({
-  phaseId,
+  phaseId
 }: {
-  projectId: string;
   phaseId?: string;
 }) => {
   const deleteApiEndpoint = `phases/${phaseId}/inputs`;

--- a/front/app/components/FormBuilder/edit/index.tsx
+++ b/front/app/components/FormBuilder/edit/index.tsx
@@ -326,8 +326,7 @@ const FormBuilderPage = ({ builderConfig }: FormBuilderPageProps) => {
     phaseId?: string;
   };
   const { data: submissionCount } = useFormSubmissionCount({
-    projectId,
-    phaseId,
+    phaseId
   });
 
   const formCustomFields = builderConfig.formCustomFields;

--- a/front/app/containers/Admin/projects/project/nativeSurvey/index.tsx
+++ b/front/app/containers/Admin/projects/project/nativeSurvey/index.tsx
@@ -134,7 +134,7 @@ const Forms = () => {
 
   const deleteResults = () => {
     deleteFormResults(
-      { projectId, phaseId },
+      { phaseId },
       {
         onSuccess: () => {
           closeDeleteModal();

--- a/front/app/containers/Admin/projects/project/nativeSurvey/index.tsx
+++ b/front/app/containers/Admin/projects/project/nativeSurvey/index.tsx
@@ -65,7 +65,6 @@ const Forms = () => {
   const locale = useLocale();
   const { mutate: updatePhase } = useUpdatePhase();
   const { data: submissionCount } = useFormSubmissionCount({
-    projectId,
     phaseId,
   });
   const { uiSchema } = useInputSchema({ projectId, phaseId });

--- a/front/app/containers/ProjectsShowPage/shared/header/ProjectInfoSideBar/index.tsx
+++ b/front/app/containers/ProjectsShowPage/shared/header/ProjectInfoSideBar/index.tsx
@@ -139,7 +139,6 @@ const ProjectInfoSideBar = memo<Props>(({ projectId, className }) => {
   const { formatMessage } = useIntl();
   const [currentPhase, setCurrentPhase] = useState<IPhaseData | undefined>();
   const [shareModalOpened, setShareModalOpened] = useState(false);
-  const { data: surveySubmissionCount } = useFormSubmissionCount({ projectId });
   const isAdminUser = !isNilOrError(authUser)
     ? isAdmin({ data: authUser.data })
     : false;
@@ -149,6 +148,9 @@ const ProjectInfoSideBar = memo<Props>(({ projectId, className }) => {
       getCurrentPhase(phases?.data) || getLastPhase(phases?.data)
     );
   }, [phases]);
+
+  const phaseId = currentPhase?.id;
+  const { data: surveySubmissionCount } = useFormSubmissionCount({ phaseId });
 
   const scrollTo = useCallback(
     (id: string, shouldSelectCurrentPhase = true) =>
@@ -366,9 +368,7 @@ const ProjectInfoSideBar = memo<Props>(({ projectId, className }) => {
                   )}
                 </ListItem>
               )}
-            {((projectType === 'continuous' &&
-              projectParticipationMethod === 'native_survey') ||
-              currentPhase?.attributes.participation_method ===
+            {(currentPhase?.attributes.participation_method ===
                 'native_survey') &&
               surveySubmissionCount && (
                 <Box>


### PR DESCRIPTION
Updated the logic here so that it will always get the count only from the phase endpoint. There is one issue that I can't resolve which is ideally I don't want the endpoint being called before the current phase is resolved and then only if it is a native survey phase. But obviously hooks cannot be called conditionally so I fear a lot of refactoring to achieve that.

Also removed project from delete survey results as they were impacting on each other.
