### PR TITLE
[CL-4246] Whitelist image file-types for uploading

### DIFF
--- a/back/app/uploaders/base_file_uploader.rb
+++ b/back/app/uploaders/base_file_uploader.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 class BaseFileUploader < BaseUploader
+  def extension_allowlist
+    %w[avi csv doc docx key mkv mp3 mp4 numbers odp ods odt pages pdf ppt pptx txt xls xlsx] +
+      BaseImageUploader::ALLOWED_TYPES
+  end
+
   def fog_attributes
     # Deleting consecutive whitespaces in filename because of
     # https://github.com/fog/fog-aws/issues/160

--- a/back/app/uploaders/event_file_uploader.rb
+++ b/back/app/uploaders/event_file_uploader.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 class EventFileUploader < BaseFileUploader
-  def extension_allowlist
-    %w[avi csv doc docx key mkv mp3 mp4 numbers odp ods odt pages pdf ppt pptx txt xls xlsx] +
-      BaseImageUploader::ALLOWED_TYPES
-  end
-
   def size_range
     (1.byte)..(50.megabytes)
   end

--- a/back/app/uploaders/event_file_uploader.rb
+++ b/back/app/uploaders/event_file_uploader.rb
@@ -2,7 +2,8 @@
 
 class EventFileUploader < BaseFileUploader
   def extension_allowlist
-    %w[avi csv doc docx key mkv mp3 mp4 numbers odp ods odt pages pdf ppt pptx txt xls xlsx]
+    %w[avi csv doc docx key mkv mp3 mp4 numbers odp ods odt pages pdf ppt pptx txt xls xlsx] +
+      BaseImageUploader::ALLOWED_TYPES
   end
 
   def size_range

--- a/back/app/uploaders/idea_file_uploader.rb
+++ b/back/app/uploaders/idea_file_uploader.rb
@@ -2,7 +2,8 @@
 
 class IdeaFileUploader < BaseFileUploader
   def extension_allowlist
-    %w[avi csv doc docx key mkv mp3 mp4 numbers odp ods odt pages pdf ppt pptx txt xls xlsx]
+    %w[avi csv doc docx key mkv mp3 mp4 numbers odp ods odt pages pdf ppt pptx txt xls xlsx] +
+      BaseImageUploader::ALLOWED_TYPES
   end
 
   def size_range

--- a/back/app/uploaders/idea_file_uploader.rb
+++ b/back/app/uploaders/idea_file_uploader.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 class IdeaFileUploader < BaseFileUploader
-  def extension_allowlist
-    %w[avi csv doc docx key mkv mp3 mp4 numbers odp ods odt pages pdf ppt pptx txt xls xlsx] +
-      BaseImageUploader::ALLOWED_TYPES
-  end
-
   def size_range
     (1.byte)..(50.megabytes)
   end

--- a/back/app/uploaders/initiative_file_uploader.rb
+++ b/back/app/uploaders/initiative_file_uploader.rb
@@ -2,7 +2,8 @@
 
 class InitiativeFileUploader < BaseFileUploader
   def extension_allowlist
-    %w[avi csv doc docx key mkv mp3 mp4 numbers odp ods odt pages pdf ppt pptx txt xls xlsx]
+    %w[avi csv doc docx key mkv mp3 mp4 numbers odp ods odt pages pdf ppt pptx txt xls xlsx] +
+      BaseImageUploader::ALLOWED_TYPES
   end
 
   def size_range

--- a/back/app/uploaders/initiative_file_uploader.rb
+++ b/back/app/uploaders/initiative_file_uploader.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 class InitiativeFileUploader < BaseFileUploader
-  def extension_allowlist
-    %w[avi csv doc docx key mkv mp3 mp4 numbers odp ods odt pages pdf ppt pptx txt xls xlsx] +
-      BaseImageUploader::ALLOWED_TYPES
-  end
-
   def size_range
     (1.byte)..(50.megabytes)
   end

--- a/back/app/uploaders/phase_file_uploader.rb
+++ b/back/app/uploaders/phase_file_uploader.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 class PhaseFileUploader < BaseFileUploader
-  def extension_allowlist
-    %w[avi csv doc docx key mkv mp3 mp4 numbers odp ods odt pages pdf ppt pptx txt xls xlsx] +
-      BaseImageUploader::ALLOWED_TYPES
-  end
-
   def size_range
     (1.byte)..(50.megabytes)
   end

--- a/back/app/uploaders/phase_file_uploader.rb
+++ b/back/app/uploaders/phase_file_uploader.rb
@@ -2,7 +2,8 @@
 
 class PhaseFileUploader < BaseFileUploader
   def extension_allowlist
-    %w[avi csv doc docx key mkv mp3 mp4 numbers odp ods odt pages pdf ppt pptx txt xls xlsx]
+    %w[avi csv doc docx key mkv mp3 mp4 numbers odp ods odt pages pdf ppt pptx txt xls xlsx] +
+      BaseImageUploader::ALLOWED_TYPES
   end
 
   def size_range

--- a/back/app/uploaders/project_file_uploader.rb
+++ b/back/app/uploaders/project_file_uploader.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 class ProjectFileUploader < BaseFileUploader
-  def extension_allowlist
-    %w[avi csv doc docx key mkv mp3 mp4 numbers odp ods odt pages pdf ppt pptx txt xls xlsx] +
-      BaseImageUploader::ALLOWED_TYPES
-  end
-
   def size_range
     (1.byte)..(50.megabytes)
   end

--- a/back/app/uploaders/project_file_uploader.rb
+++ b/back/app/uploaders/project_file_uploader.rb
@@ -2,7 +2,8 @@
 
 class ProjectFileUploader < BaseFileUploader
   def extension_allowlist
-    %w[avi csv doc docx key mkv mp3 mp4 numbers odp ods odt pages pdf ppt pptx txt xls xlsx]
+    %w[avi csv doc docx key mkv mp3 mp4 numbers odp ods odt pages pdf ppt pptx txt xls xlsx] +
+      BaseImageUploader::ALLOWED_TYPES
   end
 
   def size_range

--- a/back/app/uploaders/project_folders/file_uploader.rb
+++ b/back/app/uploaders/project_folders/file_uploader.rb
@@ -2,11 +2,6 @@
 
 module ProjectFolders
   class FileUploader < BaseFileUploader
-    def extension_allowlist
-      %w[avi csv doc docx key mkv mp3 mp4 numbers odp ods odt pages pdf ppt pptx txt xls xlsx] +
-        BaseImageUploader::ALLOWED_TYPES
-    end
-
     def size_range
       (1.byte)..(50.megabytes)
     end

--- a/back/app/uploaders/project_folders/file_uploader.rb
+++ b/back/app/uploaders/project_folders/file_uploader.rb
@@ -3,7 +3,8 @@
 module ProjectFolders
   class FileUploader < BaseFileUploader
     def extension_allowlist
-      %w[avi csv doc docx key mkv mp3 mp4 numbers odp ods odt pages pdf ppt pptx txt xls xlsx]
+      %w[avi csv doc docx key mkv mp3 mp4 numbers odp ods odt pages pdf ppt pptx txt xls xlsx] +
+        BaseImageUploader::ALLOWED_TYPES
     end
 
     def size_range

--- a/back/app/uploaders/static_page_file_uploader.rb
+++ b/back/app/uploaders/static_page_file_uploader.rb
@@ -2,7 +2,8 @@
 
 class StaticPageFileUploader < BaseFileUploader
   def extension_allowlist
-    %w[avi csv doc docx key mkv mp3 mp4 numbers odp ods odt pages pdf ppt pptx txt xls xlsx]
+    %w[avi csv doc docx key mkv mp3 mp4 numbers odp ods odt pages pdf ppt pptx txt xls xlsx] +
+      BaseImageUploader::ALLOWED_TYPES
   end
 
   def size_range

--- a/back/app/uploaders/static_page_file_uploader.rb
+++ b/back/app/uploaders/static_page_file_uploader.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 class StaticPageFileUploader < BaseFileUploader
-  def extension_allowlist
-    %w[avi csv doc docx key mkv mp3 mp4 numbers odp ods odt pages pdf ppt pptx txt xls xlsx] +
-      BaseImageUploader::ALLOWED_TYPES
-  end
-
   def size_range
     (1.byte)..(50.megabytes)
   end

--- a/front/app/components/UI/FileUploader/FileInput.tsx
+++ b/front/app/components/UI/FileUploader/FileInput.tsx
@@ -132,7 +132,6 @@ const fileAccept = [
   '.mkv',
   'video/x-matroska',
 
-  // jpg jpeg gif png webp svg
   '.jpg',
   'image/jpg',
   '.jpeg',

--- a/front/app/components/UI/FileUploader/FileInput.tsx
+++ b/front/app/components/UI/FileUploader/FileInput.tsx
@@ -132,7 +132,19 @@ const fileAccept = [
   '.mkv',
   'video/x-matroska',
 
+  // jpg jpeg gif png webp svg
   '.jpg',
+  'image/jpg',
+  '.jpeg',
+  'image/jpeg',
+  '.gif',
+  'image/gif',
+  '.png',
+  'image/png',
+  '.webp',
+  'image/webp',
+  '.svg',
+  'image/svg+xml',
 ];
 
 interface Props {


### PR DESCRIPTION
# Changelog
## Added
- [CL-4246] Image files can now be uploaded as attached files. For example, when attaching files to a project phase via the back office 'Edit phase' form.


[CL-4246]: https://citizenlab.atlassian.net/browse/CL-4246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ