### PR TITLE
Report builder leftover issues

### DIFF
--- a/front/app/components/admin/ContentBuilder/Widgets/Text/index.tsx
+++ b/front/app/components/admin/ContentBuilder/Widgets/Text/index.tsx
@@ -23,7 +23,7 @@ const Text = ({ text }: Props) => {
   const theme = useTheme();
 
   return (
-    <PageBreakBox id="e2e-text-box" minHeight="26px">
+    <PageBreakBox className="e2e-text-box" minHeight="26px">
       <QuillEditedContent textColor={theme.colors.tenantText}>
         <div dangerouslySetInnerHTML={{ __html: text }} />
       </QuillEditedContent>

--- a/front/app/components/admin/ContentBuilder/Widgets/TextMultiloc/index.tsx
+++ b/front/app/components/admin/ContentBuilder/Widgets/TextMultiloc/index.tsx
@@ -31,7 +31,7 @@ const TextMultiloc = ({ text }: Props) => {
 
   return (
     <PageBreakBox
-      id="e2e-text-box"
+      className="e2e-text-box"
       minHeight="26px"
       maxWidth="1150px"
       margin="0 auto"

--- a/front/app/components/admin/ContentBuilder/Widgets/Title/index.tsx
+++ b/front/app/components/admin/ContentBuilder/Widgets/Title/index.tsx
@@ -26,7 +26,7 @@ interface Props {
 
 const Title = ({ text }: Props) => {
   return (
-    <PageBreakBox id="e2e-text-box" minHeight="26px" mb="12px" mt="12px">
+    <PageBreakBox className="e2e-text-box" minHeight="26px" mb="12px" mt="12px">
       <H3 color={colors.primary}>{text}</H3>
     </PageBreakBox>
   );

--- a/front/app/containers/Admin/projects/project/information/ReportSection.tsx
+++ b/front/app/containers/Admin/projects/project/information/ReportSection.tsx
@@ -12,6 +12,9 @@ import { Box, Text } from '@citizenlab/cl2-component-library';
 import Button from 'components/UI/Button';
 import ReportRow from './ReportRow';
 
+// styling
+import { colors } from 'utils/styleUtils';
+
 // i18n
 import { FormattedMessage } from 'utils/cl-intl';
 import messages from './messages';
@@ -66,6 +69,7 @@ const ReportSection = ({ phaseId }: Props) => {
             <Button
               width="auto"
               processing={isLoading}
+              bgColor={colors.primary}
               onClick={handleCreateReport}
             >
               <FormattedMessage {...messages.createAReport} />

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/Text/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/Text/index.tsx
@@ -25,7 +25,7 @@ const Text = ({ text }: Props) => {
   const px = useReportDefaultPadding();
 
   return (
-    <PageBreakBox id="e2e-text-box" minHeight="26px" px={px}>
+    <PageBreakBox className="e2e-text-box" minHeight="26px" px={px}>
       <QuillEditedContent textColor={theme.colors.tenantText}>
         <div dangerouslySetInnerHTML={{ __html: text }} />
       </QuillEditedContent>

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/Title/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/Title/index.tsx
@@ -30,7 +30,7 @@ const Title = ({ text }: Props) => {
 
   return (
     <PageBreakBox
-      id="e2e-text-box"
+      className="e2e-text-box"
       minHeight="26px"
       mb="12px"
       mt="12px"

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/TwoColumn/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/TwoColumn/index.tsx
@@ -36,12 +36,13 @@ const StyledBox = styled(Box)<{
   min-height: 40px;
   width: 100%;
 
+  display: grid;
+  grid-gap: ${DEFAULT_PADDING};
+
   ${({ layout, columnLayout }) =>
     layout === 'narrow'
       ? ''
       : `
-    display: grid;
-    grid-gap: ${DEFAULT_PADDING};
     grid-template-columns: ${COLUMN_LAYOUTS[columnLayout]};
   `}
 

--- a/front/app/containers/Admin/reporting/components/ReportBuilderPage/ReportRow/Buttons/ShareReportButton.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilderPage/ReportRow/Buttons/ShareReportButton.tsx
@@ -3,6 +3,9 @@ import React, { useState } from 'react';
 // components
 import Button from 'components/UI/Button';
 
+// styling
+import { colors } from 'utils/styleUtils';
+
 // i18n
 import messages from '../messages';
 import { FormattedMessage } from 'utils/cl-intl';
@@ -26,6 +29,7 @@ const ShareReportButton = ({ reportId, buttonStyle = 'secondary' }: Props) => {
       <Button
         icon="share"
         buttonStyle={buttonStyle}
+        bgColor={colors.primary}
         onClick={openShareModal}
         iconSize="18px"
       >

--- a/front/app/containers/Admin/reporting/components/ReportBuilderPage/ReportRow/Buttons/ShareReportButton.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilderPage/ReportRow/Buttons/ShareReportButton.tsx
@@ -17,7 +17,7 @@ interface Props {
   buttonStyle?: 'primary' | 'secondary';
 }
 
-const ShareReportButton = ({ reportId, buttonStyle = 'secondary' }: Props) => {
+const ShareReportButton = ({ reportId }: Props) => {
   const [shareModalOpen, setShareModalOpen] = useState(false);
   const openShareModal = () => setShareModalOpen(true);
   const closeShareModal = () => setShareModalOpen(false);
@@ -28,7 +28,7 @@ const ShareReportButton = ({ reportId, buttonStyle = 'secondary' }: Props) => {
     <>
       <Button
         icon="share"
-        buttonStyle={buttonStyle}
+        buttonStyle="primary"
         bgColor={colors.primary}
         onClick={openShareModal}
         iconSize="18px"

--- a/front/app/containers/Admin/reporting/components/ReportBuilderPage/ReportRow/Buttons/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilderPage/ReportRow/Buttons/index.tsx
@@ -53,7 +53,7 @@ const Buttons = ({ reportId, isLoading, onDelete, onEdit, onView }: Props) => {
       >
         {formatMessage(messages.view)}
       </Button>
-      <ShareReportButton reportId={reportId} buttonStyle="primary" />
+      <ShareReportButton reportId={reportId} />
     </Box>
   );
 };

--- a/front/app/containers/Admin/reporting/containers/FullScreenReport/index.tsx
+++ b/front/app/containers/Admin/reporting/containers/FullScreenReport/index.tsx
@@ -62,7 +62,7 @@ export const FullScreenReport = ({ reportId }: Props) => {
           {isLoadingLayout && <Spinner />}
           {!isLoadingLayout && (
             <Box w="100%" display="flex" justifyContent="center">
-              <Box maxWidth="800px">
+              <Box maxWidth="800px" w="100%">
                 <Editor isPreview={true}>
                   {editorData && (
                     <ContentBuilderFrame editorData={editorData} />

--- a/front/app/containers/ProjectsShowPage/timeline/PhaseReport/index.tsx
+++ b/front/app/containers/ProjectsShowPage/timeline/PhaseReport/index.tsx
@@ -19,7 +19,7 @@ const PhaseReport = ({ reportId }: Props) => {
 
   return (
     <Box w="100%" display="flex" justifyContent="center">
-      <Box maxWidth="800px">
+      <Box maxWidth="800px" w="100%">
         <Editor isPreview={true}>
           {editorData && <ContentBuilderFrame editorData={editorData} />}
         </Editor>

--- a/front/cypress/e2e/project_description_builder/components/text_component.cy.ts
+++ b/front/cypress/e2e/project_description_builder/components/text_component.cy.ts
@@ -48,7 +48,7 @@ describe('Project description builder Text component', () => {
       position: 'inside',
     });
 
-    cy.get('#e2e-text-box').click();
+    cy.get('.e2e-text-box').click();
     cy.get('#quill-editor').click();
     cy.get('#quill-editor').type('Edited text.', { force: true });
 
@@ -67,7 +67,7 @@ describe('Project description builder Text component', () => {
       `/admin/project-description-builder/projects/${projectId}/description`
     );
 
-    cy.get('#e2e-text-box').click();
+    cy.get('.e2e-text-box').click();
     cy.get('#e2e-delete-button').click();
     cy.get('#e2e-content-builder-topbar-save').click();
     cy.wait('@saveProjectDescriptionBuilder');

--- a/front/cypress/e2e/project_description_builder/components/three_column_component.cy.ts
+++ b/front/cypress/e2e/project_description_builder/components/three_column_component.cy.ts
@@ -59,7 +59,7 @@ describe('Project description builder Three Column component', () => {
       position: 'inside',
     });
 
-    cy.get('div#e2e-text-box').should('have.length', 3);
+    cy.get('div.e2e-text-box').should('have.length', 3);
     cy.get('div#e2e-about-box').should('have.length', 3);
 
     cy.get('#e2e-content-builder-topbar-save').click();
@@ -68,7 +68,7 @@ describe('Project description builder Three Column component', () => {
     // Check column and elements exist on page
     cy.visit(`/projects/${projectSlug}`);
     cy.get('#e2e-three-column').should('exist');
-    cy.get('div#e2e-text-box').should('have.length', 3);
+    cy.get('div.e2e-text-box').should('have.length', 3);
     cy.get('div#e2e-about-box').should('have.length', 3);
   });
 

--- a/front/cypress/e2e/project_description_builder/components/two_column_component.cy.ts
+++ b/front/cypress/e2e/project_description_builder/components/two_column_component.cy.ts
@@ -58,7 +58,7 @@ describe('Project description builder Two Column component', () => {
       position: 'inside',
     });
 
-    cy.get('div#e2e-text-box').should('have.length', 2);
+    cy.get('div.e2e-text-box').should('have.length', 2);
     cy.get('div#e2e-about-box').should('have.length', 2);
 
     cy.get('#e2e-content-builder-topbar-save').click();
@@ -66,7 +66,7 @@ describe('Project description builder Two Column component', () => {
 
     cy.visit(`/projects/${projectSlug}`);
     cy.get('#e2e-two-column').should('exist');
-    cy.get('div#e2e-text-box').should('have.length', 2);
+    cy.get('div.e2e-text-box').should('have.length', 2);
     cy.get('div#e2e-about-box').should('have.length', 2);
   });
 

--- a/front/cypress/e2e/project_description_builder/language_switch.cy.ts
+++ b/front/cypress/e2e/project_description_builder/language_switch.cy.ts
@@ -57,7 +57,7 @@ describe('Project description builder language switch', () => {
     cy.get('#e2e-draggable-text').dragAndDrop('#e2e-content-builder-frame', {
       position: 'inside',
     });
-    cy.get('#e2e-text-box').click('center');
+    cy.get('.e2e-text-box').click('center');
     cy.get('#quill-editor').click();
     cy.get('#quill-editor').type('Language 1 text.', { force: true });
     cy.get('#e2e-content-builder-topbar-save').click();
@@ -68,7 +68,7 @@ describe('Project description builder language switch', () => {
     cy.get('#e2e-draggable-text').dragAndDrop('#e2e-content-builder-frame', {
       position: 'inside',
     });
-    cy.get('#e2e-text-box').click('center');
+    cy.get('.e2e-text-box').click('center');
     cy.get('#quill-editor').click();
     cy.get('#quill-editor').type('Language 2 text.', { force: true });
     cy.get('#e2e-content-builder-topbar-save').click();
@@ -94,13 +94,13 @@ describe('Project description builder language switch', () => {
     // Delete content from languages
     // EN
     cy.get('.en').click();
-    cy.get('#e2e-text-box').click({ force: true });
+    cy.get('.e2e-text-box').click({ force: true });
     cy.get('#e2e-delete-button').click({ force: true });
 
     // NL-BE
-    cy.reload(); // without it, #e2e-text-box cannot be found. Cannot be reproduced manually.
+    cy.reload(); // without it, .e2e-text-box cannot be found. Cannot be reproduced manually.
     cy.get('.nl-BE').click();
-    cy.get('#e2e-text-box').click({ force: true });
+    cy.get('.e2e-text-box').click({ force: true });
     cy.get('#e2e-delete-button').click({ force: true });
     cy.get('#e2e-content-builder-topbar-save').click({ force: true });
     cy.wait('@saveProjectDescriptionBuilder');

--- a/front/cypress/e2e/project_description_builder/project_description_builder_preview_toggle.cy.ts
+++ b/front/cypress/e2e/project_description_builder/project_description_builder_preview_toggle.cy.ts
@@ -52,18 +52,28 @@ describe('Project description builder preview', () => {
     cy.visit(
       `/admin/project-description-builder/projects/${projectId}/description`
     );
-    cy.wait(10000);
+    cy.get('div#ROOT');
+    cy.wait(1000);
+
+    // Drag in text widget and open it
     cy.get('#e2e-draggable-text').dragAndDrop('#e2e-content-builder-frame', {
       position: 'inside',
     });
+    cy.get('div.e2e-text-box').click();
 
-    cy.get('#e2e-text-box').click();
+    // Edit text
     cy.get('#quill-editor').click();
     cy.get('#quill-editor').type('Edited text.', { force: true });
 
-    cy.get('#e2e-content-builder-topbar-save').click();
-    cy.get('#e2e-preview-toggle').click({ force: true });
+    // Make sure we see updated text on screen (seems to be some sort of delay)
+    cy.get('div.e2e-text-box').contains('Edited text.');
 
+    // Save
+    cy.get('#e2e-content-builder-topbar-save').click();
+    cy.wait(1000);
+
+    // Preview
+    cy.get('#e2e-preview-toggle').click({ force: true });
     getIframeBody().contains('Edited text.').should('be.visible');
   });
 
@@ -71,13 +81,23 @@ describe('Project description builder preview', () => {
     cy.visit(
       `/admin/project-description-builder/projects/${projectId}/description`
     );
-    cy.wait(10000);
-    cy.get('#e2e-text-box').should('exist');
-    cy.get('#e2e-text-box').click();
+    cy.get('div#ROOT');
+    cy.wait(1000);
+
+    // Open text widget
+    cy.get('.e2e-text-box').should('exist');
+    cy.get('.e2e-text-box').click();
+
+    // Edit text again
     cy.get('#quill-editor').click();
     cy.get('#quill-editor').type('Another edited text.', { force: true });
 
+    // Make sure we see updated text on screen (seems to be some sort of delay)
+    cy.get('div.e2e-text-box').contains('Edited text.Another edited text.');
+
+    // Preview
     cy.get('#e2e-preview-toggle').click({ force: true });
+    cy.wait(1000);
 
     getIframeBody()
       .contains('Edited text.Another edited text.')
@@ -88,19 +108,28 @@ describe('Project description builder preview', () => {
     cy.visit(
       `/admin/project-description-builder/projects/${projectId}/description`
     );
-    cy.get('#e2e-draggable-text').dragAndDrop('#e2e-content-builder-frame', {
-      position: 'inside',
-    });
-    cy.wait(5000);
-    cy.get('#e2e-text-box').click();
+    cy.get('div#ROOT');
+    cy.wait(1000);
+
+    // Open text widget
+    cy.get('.e2e-text-box').should('exist');
+    cy.get('.e2e-text-box').click();
+
+    // Edit text again
     cy.get('#quill-editor').click();
     cy.get('#quill-editor').type('Sample text.', { force: true });
 
+    // Make sure we see updated text on screen (seems to be some sort of delay)
+    cy.get('div.e2e-text-box').contains('Edited text.Sample text.');
+
+    // Preview on desktop
     cy.get('#e2e-preview-toggle').click({ force: true });
+    cy.wait(1000);
 
     getIframeBody().contains('Sample text.').should('be.visible');
-    cy.get('[data-cy="mobile-preview-iframe"]').should('exist');
 
+    // Preview on mobile
+    cy.get('[data-cy="mobile-preview-iframe"]').should('exist');
     cy.get('#e2e-desktop-preview').click({ force: true });
 
     getIframeBody().contains('Sample text.').should('be.visible');

--- a/front/cypress/e2e/project_description_builder/project_description_builder_settings.cy.ts
+++ b/front/cypress/e2e/project_description_builder/project_description_builder_settings.cy.ts
@@ -45,7 +45,7 @@ describe('Settings panel options', () => {
       position: 'inside',
     });
 
-    cy.get('#e2e-text-box').click();
+    cy.get('.e2e-text-box').click();
     cy.get('.e2eBuilderSettingsClose').click();
 
     cy.get('#e2e-node-label').should('not.exist');

--- a/front/cypress/e2e/project_description_builder/project_description_builder_toggle.cy.ts
+++ b/front/cypress/e2e/project_description_builder/project_description_builder_toggle.cy.ts
@@ -108,7 +108,7 @@ describe('Project description builder toggle', () => {
       position: 'inside',
     });
 
-    cy.get('#e2e-text-box').click('center');
+    cy.get('.e2e-text-box').click('center');
     cy.get('#quill-editor').click();
     cy.get('#quill-editor').type('Edited text.', { force: true });
 

--- a/front/cypress/e2e/project_description_builder/sections/image_text_cards_section.cy.ts
+++ b/front/cypress/e2e/project_description_builder/sections/image_text_cards_section.cy.ts
@@ -51,7 +51,7 @@ describe('Project description builder Image Text Cards section', () => {
     );
 
     // Edit a text component
-    cy.get('#e2e-text-box').first().click();
+    cy.get('.e2e-text-box').first().click();
     cy.get('#quill-editor').click();
     cy.get('#quill-editor').type('Edited text.', { force: true });
 

--- a/front/cypress/e2e/project_description_builder/sections/info_accordions_section.cy.ts
+++ b/front/cypress/e2e/project_description_builder/sections/info_accordions_section.cy.ts
@@ -51,7 +51,7 @@ describe('Project description builder Info & Accordions section', () => {
     );
 
     // Edit text component
-    cy.get('#e2e-text-box').click();
+    cy.get('.e2e-text-box').click();
     cy.get('#quill-editor').click();
     cy.get('#quill-editor').type('Edited text.', { force: true });
 


### PR DESCRIPTION
# Changelog
## Fixed
- Report builder: graphs sometimes not being the correct width
- Report builder: add small gap in two-column layout on mobile (when it becomes a one-column layout)
- Buttons to create or share report: now standard 'primary' back-office color, and not the 'primary' theme color
## Technical
- Fix flaky project description preview toggle e2e test