### PR TITLE
Fix read more on vote card

### DIFF
--- a/front/app/components/IdeaCard/Footer/ReadMoreButton.tsx
+++ b/front/app/components/IdeaCard/Footer/ReadMoreButton.tsx
@@ -6,16 +6,14 @@ import messages from '../messages';
 import { useIntl } from 'utils/cl-intl';
 
 interface Props {
-  slug?: string;
   onClick?: () => void;
 }
 
-const ReadMoreButton = ({ slug, onClick }: Props) => {
+const ReadMoreButton = ({ onClick }: Props) => {
   const { formatMessage } = useIntl();
 
   return (
     <Button
-      linkTo={`/ideas/${slug}?go_back=true`}
       size="s"
       textColor={colors.coolGrey700}
       mr="8px"


### PR DESCRIPTION
# Changelog
## Fixed
- Fixed issue with the "read more" button on the vote card. When "read more" was clicked and we were redirected to the idea page this caused the back button to lead to a broken URL when clicked.
