### PR TITLE
TAN-430 - Remove continuous projects from being created in e2e tests

### DIFF
--- a/front/cypress/e2e/project_cards.cy.ts
+++ b/front/cypress/e2e/project_cards.cy.ts
@@ -1,3 +1,4 @@
+import moment = require('moment');
 import { randomString } from '../support/commands';
 
 describe('Project and folder cards on front page', () => {
@@ -97,10 +98,21 @@ describe('Native survey project card', () => {
       descriptionPreview: projectDescriptionPreview,
       description: projectDescription,
       publicationStatus: 'published',
-      participationMethod: 'native_survey',
+
     }).then((project) => {
       projectId = project.body.data.id;
       projectSlug = project.body.data.attributes.slug;
+
+      cy.apiCreatePhase({
+        projectId,
+        title: 'surveyPhaseTitle',
+        startAt: moment().subtract(9, 'month').format('DD/MM/YYYY'),
+        endAt: moment().add(1, 'month').format('DD/MM/YYYY'),
+        participationMethod: 'native_survey',
+        canPost: true,
+        canComment: true,
+        canReact: true
+      });
     });
   });
 

--- a/front/cypress/e2e/project_page_information.cy.ts
+++ b/front/cypress/e2e/project_page_information.cy.ts
@@ -20,15 +20,23 @@ describe('Information with events CTA', () => {
       })
       .then(() => {
         cy.apiCreateProject({
-          type: 'continuous',
+          type: 'timeline',
           title: projectTitle,
           descriptionPreview: projectDescriptionPreview,
-          description: projectDescription,
-          publicationStatus: 'published',
-          participationMethod: 'information',
+          description: projectDescription
         }).then((project) => {
           projectId = project.body.data.id;
           projectSlug = project.body.data.attributes.slug;
+          cy.apiCreatePhase({
+            projectId,
+            title: 'informationPhaseTitle',
+            startAt: moment().subtract(9, 'month').format('DD/MM/YYYY'),
+            endAt: moment().add(1, 'month').format('DD/MM/YYYY'),
+            participationMethod: 'information',
+            canPost: true,
+            canComment: true,
+            canReact: true
+          });
         });
       });
   });

--- a/front/cypress/e2e/project_page_volunteering.cy.ts
+++ b/front/cypress/e2e/project_page_volunteering.cy.ts
@@ -20,16 +20,23 @@ describe('Volunteering survey CTA', () => {
       })
       .then(() => {
         cy.apiCreateProject({
-          type: 'continuous',
+          type: 'timeline',
           title: projectTitle,
           descriptionPreview: projectDescriptionPreview,
           description: projectDescription,
-          publicationStatus: 'published',
-          participationMethod: 'volunteering',
+          publicationStatus: 'published'
         }).then((project) => {
           projectId = project.body.data.id;
           projectSlug = project.body.data.attributes.slug;
-
+          cy.apiCreatePhase({
+            projectId,
+            title: 'volunteerPhaseTitle',
+            startAt: moment().subtract(9, 'month').format('DD/MM/YYYY'),
+            participationMethod: 'volunteering',
+            canPost: true,
+            canComment: true,
+            canReact: true
+          });
           cy.apiCreateEvent({
             projectId,
             title: 'Event title',

--- a/front/cypress/support/commands.ts
+++ b/front/cypress/support/commands.ts
@@ -859,7 +859,6 @@ export function apiCreateProject({
       url: 'web_api/v1/projects',
       body: {
         project: {
-          process_type: type,
           admin_publication_attributes: {
             publication_status: publicationStatus,
           },
@@ -877,18 +876,7 @@ export function apiCreateProject({
             en: description,
             'nl-BE': description,
           },
-          default_assignee_id: assigneeId,
-          participation_method:
-            type === 'continuous' && !participationMethod
-              ? 'ideation'
-              : participationMethod,
-          voting_method: votingMethod,
-          survey_embed_url: surveyUrl,
-          survey_service: surveyService,
-          voting_max_total: votingMaxTotal,
-          voting_max_votes_per_idea: votingMaxVotesPerIdea,
-          posting_enabled: postingEnabled,
-          allow_anonymous_participation: allow_anonymous_participation,
+          default_assignee_id: assigneeId
         },
       },
     });


### PR DESCRIPTION
Just test changes - this only involved adding a phase in a few places and fixing the API method for projects so it always creates timeline projects. In the next PR, I will refactor the calls completely so it no longer sets the process_type and other attributes that have now gone.