### PR TITLE
CL-4248 AI Analysis: Ask a question fixes

### DIFF
--- a/back/engines/commercial/analysis/app/lib/analysis/q_and_a_method/base.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/q_and_a_method/base.rb
@@ -11,6 +11,7 @@ module Analysis
     LLMS = [
       LLM::GPT48k.new,
       LLM::GPT432k.new,
+      LLM::GPT4Turbo.new,
       LLM::GPT3516k.new
     ]
 


### PR DESCRIPTION
# Changelog
## Added
- In AI Analysis, 'Ask a question' now also support GPT4-Turbo, just like summarization already did. Meaning it can process up to 500-1000 inputs at 70% accuracy instead of 100-200 inputs at 50% accuracy.
## Fixed
- In AI Analysis, filtering by survey answer values (e.g. all inputs where user answered 'yes' to question 5) did not have an effect on the 'ask a question' feature, and now it does
