### PR TITLE
Remove non-implemented InfoSidebar for ProposalsManager

### DIFF
--- a/front/app/components/admin/PostManager/ProposalsManager.tsx
+++ b/front/app/components/admin/PostManager/ProposalsManager.tsx
@@ -20,7 +20,6 @@ import {
 import ActionBar from './components/ActionBar';
 import FilterSidebar from './components/FilterSidebar';
 import PostTable from './components/PostTable';
-import InfoSidebar from './components/InfoSidebar';
 import InitiativesCount from './components/InitiativesCount';
 import FeedbackToggle from './components/TopLevelFilters/FeedbackToggle';
 const LazyPostPreview = lazy(
@@ -236,7 +235,6 @@ const ProposalsManager = ({ defaultFilterMenu, visibleFilterMenus }: Props) => {
             openPreview={openPreview}
           />
         </MiddleColumn>
-        <InfoSidebar postIds={[...selection]} openPreview={openPreview} />
       </ThreeColumns>
       <Suspense fallback={null}>
         <LazyPostPreview


### PR DESCRIPTION
This is not implemented for proposals, only for ideas, resulting in an empty square in the UI: 
<img width="1437" alt="Screenshot 2023-11-23 at 09 08 44" src="https://github.com/CitizenLabDotCo/citizenlab/assets/16427929/06c10afe-0cd5-459d-85c1-888ae7faf6c7">
