### PR TITLE
[CL-4268] Change invite expiry to 30 days

### DIFF
--- a/back/app/models/invite.rb
+++ b/back/app/models/invite.rb
@@ -28,7 +28,7 @@
 class Invite < ApplicationRecord
   include PgSearch::Model
 
-  EXPIRY_DAYS = 14
+  EXPIRY_DAYS = 30
   NO_EXPIRY_BEFORE_CREATED_AT = Date.new(2023, 9, 18)
 
   pg_search_scope :search_by_all, {

--- a/front/app/containers/Admin/invitations/messages.ts
+++ b/front/app/containers/Admin/invitations/messages.ts
@@ -20,7 +20,7 @@ export default defineMessages({
   invitationExpirationWarning: {
     id: 'app.containers.Admin.Invitations.invitationExpirationWarning',
     defaultMessage:
-      'Be aware that invitations expire after 14 days. After this period, you can still resend them.',
+      'Be aware that invitations expire after 30 days. After this period, you can still resend them.',
   },
   invitePeople: {
     id: 'app.containers.Admin.Invitations.invitePeople',


### PR DESCRIPTION
# Changelog
## Changed
- [CL-4268] Invitations now expire after 30 days (was 14 days)


[CL-4268]: https://citizenlab.atlassian.net/browse/CL-4268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ