### PR TITLE
Quick fix when deleting image from layout

### DIFF
--- a/back/app/services/content_image_service.rb
+++ b/back/app/services/content_image_service.rb
@@ -27,7 +27,7 @@ class ContentImageService
     image_elements(content).each do |img_elt|
       next if image_attributes_for_element.none? { |elt_atr| attribute? img_elt, elt_atr }
 
-      if !attribute? img_elt, code_attribute_for_element
+      if !attribute?(img_elt, code_attribute_for_element) && image_attributes(img_elt, imageable, field).present?
         content_image = content_image_class.create! image_attributes(img_elt, imageable, field)
         set_attribute! img_elt, code_attribute_for_element, content_image[code_attribute_for_model]
       end

--- a/back/engines/commercial/content_builder/app/services/content_builder/layout_image_service.rb
+++ b/back/engines/commercial/content_builder/app/services/content_builder/layout_image_service.rb
@@ -17,7 +17,7 @@ module ContentBuilder
     end
 
     def image_attributes(img_elt, _imageable, _field)
-      { remote_image_url: img_elt['imageUrl'] }
+      img_elt['imageUrl'].present? && { remote_image_url: img_elt['imageUrl'] }
     end
 
     def image_attributes_for_element


### PR DESCRIPTION
When removing an image from an image element in the content builder, the frontend sends an empty string as image URL and the backend returns a 422 because the image could not be downloaded from the URL. When the backend returns an error, the frontend does not show any error, and it looks as if the save was successful. This could cause work to be lost, which is pretty bad.

This PR is a quick fix by being able to handle the situation when the failure in saving happens.

See also: https://citizenlabco.slack.com/archives/C016C2EHURY/p1701187140337529

# Changelog
### Fixed
- Quick fix: content builder could silently fail to save when removing images. To be continued, but this fix should prevent the issue on production.
