### PR TITLE
Fix removing an image in content builder

### DIFF
--- a/front/app/components/admin/ContentBuilder/Widgets/ImageMultiloc/index.tsx
+++ b/front/app/components/admin/ContentBuilder/Widgets/ImageMultiloc/index.tsx
@@ -139,7 +139,7 @@ const ImageSettings = injectIntl(({ intl: { formatMessage } }) => {
     setProp((props: Props) => {
       props.image = {
         dataCode: undefined,
-        imageUrl: '',
+        imageUrl: undefined,
       };
       props.alt = {};
     });


### PR DESCRIPTION
# Changelog
## Fixed
- Content builder content can now be saved as expected after removing an image without deleting the image element
