### PR TITLE
CL-4246 Unsupported file in phase upload error message

### DIFF
--- a/back/app/uploaders/base_file_uploader.rb
+++ b/back/app/uploaders/base_file_uploader.rb
@@ -2,8 +2,8 @@
 
 class BaseFileUploader < BaseUploader
   def extension_allowlist
-    %w[avi csv doc docx key mkv mp3 mp4 numbers odp ods odt pages pdf ppt pptx txt xls xlsx] #+
-      #BaseImageUploader::ALLOWED_TYPES
+    %w[avi csv doc docx key mkv mp3 mp4 numbers odp ods odt pages pdf ppt pptx txt xls xlsx] +
+      BaseImageUploader::ALLOWED_TYPES
   end
 
   def fog_attributes

--- a/back/app/uploaders/base_file_uploader.rb
+++ b/back/app/uploaders/base_file_uploader.rb
@@ -2,8 +2,8 @@
 
 class BaseFileUploader < BaseUploader
   def extension_allowlist
-    %w[avi csv doc docx key mkv mp3 mp4 numbers odp ods odt pages pdf ppt pptx txt xls xlsx] +
-      BaseImageUploader::ALLOWED_TYPES
+    %w[avi csv doc docx key mkv mp3 mp4 numbers odp ods odt pages pdf ppt pptx txt xls xlsx] #+
+      #BaseImageUploader::ALLOWED_TYPES
   end
 
   def fog_attributes

--- a/front/app/api/phase_files/usePhaseFiles.ts
+++ b/front/app/api/phase_files/usePhaseFiles.ts
@@ -14,6 +14,7 @@ const usePhaseFiles = (phaseId: string | null) => {
   return useQuery<IPhaseFiles, CLErrors, IPhaseFiles, PhaseFilesKeys>({
     queryKey: phaseFilesKeys.list({ phaseId }),
     queryFn: () => fetchPhaseFiles({ phaseId }),
+    enabled: !!phaseId,
   });
 };
 

--- a/front/app/containers/Admin/projects/project/timeline/edit.tsx
+++ b/front/app/containers/Admin/projects/project/timeline/edit.tsx
@@ -281,7 +281,15 @@ const AdminProjectTimelineEdit = () => {
         }
       })
       .catch(({ errors }) => {
-        setErrors({ ...errors });
+        // For some reason, the BE adds a 'blank' error
+        // to the file errors array when the real error is
+        // extension_whitelist_error. So if we get that error,
+        // we filter out the blank error and only show the
+        // extension_whitelist_error.
+        errors.file[0].error === 'extension_whitelist_error'
+          ? setErrors({ file: [errors.file[0]] })
+          : setErrors({ ...errors });
+
         setProcessing(false);
         setSubmitState('error');
       });

--- a/front/app/containers/Admin/projects/project/timeline/edit.tsx
+++ b/front/app/containers/Admin/projects/project/timeline/edit.tsx
@@ -90,7 +90,7 @@ const AdminProjectTimelineEdit = () => {
   const { mutateAsync: deletePhaseFile } = useDeletePhaseFile();
   const { projectId, id: phaseId } = useParams() as {
     projectId: string;
-    id: string;
+    id: string | null;
   };
   const { data: phaseFiles } = usePhaseFiles(phaseId);
   const { data: phase } = usePhase(phaseId || null);

--- a/front/app/containers/Admin/projects/project/timeline/edit.tsx
+++ b/front/app/containers/Admin/projects/project/timeline/edit.tsx
@@ -267,8 +267,8 @@ const AdminProjectTimelineEdit = () => {
       .filter((file) => file.remote)
       .map((file) => deletePhaseFile({ phaseId, fileId: file.id as string }));
 
-    await Promise.all([...filesToAddPromises, ...filesToRemovePromises]).then(
-      () => {
+    await Promise.all([...filesToAddPromises, ...filesToRemovePromises])
+      .then(() => {
         setPhaseFilesToRemove([]);
         setProcessing(false);
         setErrors(null);
@@ -279,8 +279,12 @@ const AdminProjectTimelineEdit = () => {
         if (redirectAfterSave) {
           clHistory.push(`/admin/projects/${projectId}/timeline/`);
         }
-      }
-    );
+      })
+      .catch(({ errors }) => {
+        setErrors({ ...errors });
+        setProcessing(false);
+        setSubmitState('error');
+      });
   };
 
   const save = async (


### PR DESCRIPTION
# Changelog
## Fixed
- Before, if you tried uploading a file that wasn't supported to the phase, the frontend would not show any error even though the upload would fail. Now, you see a message, both next to the submit button as well as under the file uploader.
![image](https://github.com/CitizenLabDotCo/citizenlab/assets/13822005/53e359a5-5e2d-4cec-9ccf-bd4de0a96e52)
(the 'This cannot be empty' part has been removed)
