### PR TITLE
CL-4288 - Add logic to silently reject any rules on select fields where the option ID does not exist

### DIFF
--- a/back/app/services/form_logic_service.rb
+++ b/back/app/services/form_logic_service.rb
@@ -322,8 +322,8 @@ class FormLogicService
         rule['goto_page_id'] = page_temp_ids_to_ids_mapping[target_id]
       end
 
-      # Remove any options that do not exist
-      if field.input_type == 'select' && field.options.pluck(:id).exclude?(value)
+      # Remove any select options that do not exist
+      if field.input_type == 'select' && field.options.pluck(:id).exclude?(rule['if'])
         rules.delete(rule)
       end
     end

--- a/back/app/services/form_logic_service.rb
+++ b/back/app/services/form_logic_service.rb
@@ -27,8 +27,6 @@ class FormLogicService
     fields.inject(true) do |all_valid, field|
       next all_valid unless field.logic?
 
-      remove_non_existing_options_from_logic(field)
-
       field_valid = if field.page?
         valid_page_logic_structure?(field) && valid_next_page?(field)
       elsif field.section?
@@ -38,18 +36,6 @@ class FormLogicService
       end
       all_valid && field_valid
     end
-  end
-
-  def remove_non_existing_options_from_logic(field)
-    logic = field.logic
-    rules = field.logic.fetch('rules', [])
-    rules.each do |rule|
-      value = rule['if']
-      if option_index[value].nil?
-        rules.delete(rule)
-      end
-    end
-    field.update! logic: logic
   end
 
   def remove_select_logic_option_from_custom_fields(frozen_custom_field_option)

--- a/back/app/services/form_logic_service.rb
+++ b/back/app/services/form_logic_service.rb
@@ -27,6 +27,8 @@ class FormLogicService
     fields.inject(true) do |all_valid, field|
       next all_valid unless field.logic?
 
+      remove_non_existing_options_from_logic(field)
+
       field_valid = if field.page?
         valid_page_logic_structure?(field) && valid_next_page?(field)
       elsif field.section?
@@ -36,6 +38,18 @@ class FormLogicService
       end
       all_valid && field_valid
     end
+  end
+
+  def remove_non_existing_options_from_logic(field)
+    logic = field.logic
+    rules = field.logic.fetch('rules', [])
+    rules.each do |rule|
+      value = rule['if']
+      if option_index[value].nil?
+        rules.delete(rule)
+      end
+    end
+    field.update! logic: logic
   end
 
   def remove_select_logic_option_from_custom_fields(frozen_custom_field_option)
@@ -320,6 +334,11 @@ class FormLogicService
       target_id = rule['goto_page_id']
       if page_temp_ids_to_ids_mapping.include?(target_id)
         rule['goto_page_id'] = page_temp_ids_to_ids_mapping[target_id]
+      end
+
+      # Remove any options that do not exist
+      if field.input_type == 'select' && field.options.pluck(:id).exclude?(value)
+        rules.delete(rule)
       end
     end
     field.update! logic: logic

--- a/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/project_context/update_all_native_survey_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/project_context/update_all_native_survey_spec.rb
@@ -1711,7 +1711,10 @@ resource 'Idea Custom Fields' do
                 }
               ],
               logic: {
-                rules: [{ if: 'TEMP-ID-2', goto_page_id: 'TEMP-ID-1' }]
+                rules: [
+                  { if: 'TEMP-ID-2', goto_page_id: 'TEMP-ID-1' },
+                  { if: 'TEMP-ID-NON-EXISTENT', goto_page_id: 'TEMP-ID-3' }
+                ]
               }
             },
             {

--- a/back/spec/services/form_logic_service_spec.rb
+++ b/back/spec/services/form_logic_service_spec.rb
@@ -780,4 +780,27 @@ describe FormLogicService do
       end
     end
   end
+
+  describe '#replace_temp_ids_in_field_logic!' do
+    let(:page1) { fields[2] }
+    let(:question1) { fields[3] }
+    let(:option1) { question1.options[0] }
+    let(:option2) { question1.options[1] }
+    let(:page2) { fields[4] }
+
+    before do
+      question1.update!(logic: {
+        'rules' => [
+          { 'if' => option1.id, 'goto_page_id' => page2.id },
+          { 'if' => 'NON_EXISTENT_ID', 'goto_page_id' => page2.id }
+        ]
+      })
+    end
+
+    it 'silently removes rules on select fields with option ids that do not exist' do
+      form_logic.replace_temp_ids!({}, {})
+
+      expect(question1.reload.logic).to eq('rules' => [{ 'if' => option1.id, 'goto_page_id' => page2.id }])
+    end
+  end
 end


### PR DESCRIPTION
This is a companion to [this PR](https://github.com/CitizenLabDotCo/citizenlab/pull/6427)  that removes options from the logic if an option is deleted. However, there is also an edge case that the front end could post a non-existent option ID and it would still get stored. This fixes that.

This will also fix any issues that pre-date the previous fix too.

# Changelog
## Fixed
- CL-4288 - Fix to ensure that non-existent option IDs cannot be saved in the custom field logic
