### PR TITLE
Turn on homepage_builder for new tenants

### DIFF
--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -1325,12 +1325,12 @@
       "homepage_builder": {
         "type": "object",
         "title": "Homepage builder",
-        "description": "Experimental! Do not turn this on for now.",
+        "description": "Use the new homepage builder. Do not turn this on/off if you're not sure what you're doing.",
         "additionalProperties": false,
         "required": ["allowed", "enabled"],
         "properties": {
-          "allowed": { "type": "boolean", "default": false },
-          "enabled": { "type": "boolean", "default": false }
+          "allowed": { "type": "boolean", "default": true },
+          "enabled": { "type": "boolean", "default": true }
         }
       }
     },


### PR DESCRIPTION
This PR should be released as soon as the new craftjs_json is migrated and fixed for external template platforms (and regenerating the external templates).

```
bin/rails admin:pricing_plans:update['premium','homepage_builder','true','true']
bin/rails admin:pricing_plans:update['standard','homepage_builder','true','true']
bin/rails admin:pricing_plans:update['essential','homepage_builder','true','true']
```