### PR TITLE
[TAN-560] Replace folder title with general text in project go back button

### DIFF
--- a/front/app/containers/ProjectsShowPage/shared/header/ProjectFolderGoBackButton/ProjectFolderGoBackButton.test.tsx
+++ b/front/app/containers/ProjectsShowPage/shared/header/ProjectFolderGoBackButton/ProjectFolderGoBackButton.test.tsx
@@ -27,7 +27,7 @@ describe('ProjectFolderGoBackButton', () => {
       <ProjectFolderGoBackButton projectFolderId={projectFolderData.id} />
     );
     expect(screen.getByRole('button')).toBeInTheDocument();
-    expect(screen.getByText('TestFolder')).toBeInTheDocument();
+    expect(screen.getByText('Back to folder')).toBeInTheDocument();
   });
   it('pushes parent folder path to history when clicked', () => {
     render(

--- a/front/app/containers/ProjectsShowPage/shared/header/ProjectFolderGoBackButton/index.tsx
+++ b/front/app/containers/ProjectsShowPage/shared/header/ProjectFolderGoBackButton/index.tsx
@@ -2,8 +2,9 @@ import React, { memo } from 'react';
 import clHistory from 'utils/cl-router/history';
 import { Button } from '@citizenlab/cl2-component-library';
 import useProjectFolderById from 'api/project_folders/useProjectFolderById';
-import useLocalize from 'hooks/useLocalize';
 import { isNilOrError } from 'utils/helperUtils';
+import { useIntl } from 'utils/cl-intl';
+import messages from './messages';
 
 interface Props {
   projectFolderId: string;
@@ -12,8 +13,7 @@ interface Props {
 
 const GoBackButton = memo(({ projectFolderId, className }: Props) => {
   const { data: projectFolder } = useProjectFolderById(projectFolderId);
-  const localize = useLocalize();
-
+  const { formatMessage } = useIntl();
   const onGoBack = (event: React.MouseEvent) => {
     event.preventDefault();
 
@@ -34,7 +34,7 @@ const GoBackButton = memo(({ projectFolderId, className }: Props) => {
         whiteSpace="wrap"
         textDecorationHover="underline"
       >
-        {localize(projectFolder.data.attributes.title_multiloc)}
+        {formatMessage(messages.backToFolder)}
       </Button>
     );
   }

--- a/front/app/containers/ProjectsShowPage/shared/header/ProjectFolderGoBackButton/messages.ts
+++ b/front/app/containers/ProjectsShowPage/shared/header/ProjectFolderGoBackButton/messages.ts
@@ -1,0 +1,8 @@
+import { defineMessages } from 'react-intl';
+
+export default defineMessages({
+  backToFolder: {
+    id: 'app.containers.projectsShowPage.folderGoBackButton.backToFolder',
+    defaultMessage: 'Back to folder',
+  },
+});

--- a/front/app/translations/en.json
+++ b/front/app/translations/en.json
@@ -1648,6 +1648,7 @@
   "app.containers.landing.verifyNow": "Verify now",
   "app.containers.landing.verifyYourIdentity": "Verify your identity",
   "app.containers.landing.viewAllEventsText": "View all events",
+  "app.containers.projectsShowPage.folderGoBackButton.backToFolder": "Back to folder",
   "app.errors.after_end_at": "The start date occurs after the end date",
   "app.errors.avatar_carrierwave_download_error": "Could not download avatar file.",
   "app.errors.avatar_carrierwave_integrity_error": "Avatar file is not of an allowed type.",


### PR DESCRIPTION
# Changelog
## Fixed
- Instead of including the full folder title beside the go back arrow in the project page (which can be very long and lead to a strange UI on Mobile), now we just have "Back to folder" beside the arrow.
