### PR TITLE
[CL-4281] Make the template release fail explicitly

### DIFF
--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/templates.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/templates.rake
@@ -79,7 +79,7 @@ namespace :templates do
 
     if failed_templates.present?
       puts({ event: 'templates_release', status: 'failed', failed_templates: failed_templates }.to_json)
-      next
+      exit(1)
     end
 
     release_prefix = MultiTenancy::Templates::Utils.new.release_templates


### PR DESCRIPTION
Ensure the release task explicitly fails when certain templates are broken. This way, the CI will go red instead of quietly stopping the release process.


# Changelog
## Technical
- Ensure the release task for tenant templates explicitly fails when certain templates are broken.
