### PR TITLE
[TAN-610] Re-enable project copy for folder moderators

### DIFF
--- a/front/app/containers/Admin/projects/components/ProjectRow/index.tsx
+++ b/front/app/containers/Admin/projects/components/ProjectRow/index.tsx
@@ -160,6 +160,7 @@ const ProjectRow = ({
           {!hideMoreActions && (
             <ProjectMoreActionsMenu
               projectId={projectId}
+              folderId={folderId ? folderId : undefined}
               setError={setError}
               setIsRunningAction={handleActionLoading}
             />


### PR DESCRIPTION
# Changelog
## Fixed
- [[TAN-610]](https://www.notion.so/citizenlab/Folder-managers-cannot-copy-or-delete-projects-b7488ed62b1b4a089ab9ab88b58083ba) Folder moderators now see the option to copy projects again in the back office.
