### PR TITLE
[TAN-674] Fixed the code that removes invalid permission scopes

### DIFF
--- a/back/app/models/permission.rb
+++ b/back/app/models/permission.rb
@@ -45,10 +45,10 @@ class Permission < ApplicationRecord
   has_many :permissions_custom_fields, -> { includes(:custom_field).order('custom_fields.ordering') }, inverse_of: :permission, dependent: :destroy
   has_many :custom_fields, -> { order(:ordering) }, through: :permissions_custom_fields
 
-  validates :permission_scope_type, inclusion: { in: SCOPE_TYPES }
   validates :action, presence: true, inclusion: { in: ->(permission) { available_actions(permission.permission_scope) } }
   validates :permitted_by, presence: true, inclusion: { in: PERMITTED_BIES }
   validates :action, uniqueness: { scope: %i[permission_scope_id permission_scope_type] }
+  validates :permission_scope_type, inclusion: { in: SCOPE_TYPES }
 
   before_validation :set_permitted_by_and_global_custom_fields, on: :create
   before_validation :update_global_custom_fields, on: :update

--- a/back/app/models/permission.rb
+++ b/back/app/models/permission.rb
@@ -45,15 +45,17 @@ class Permission < ApplicationRecord
   has_many :permissions_custom_fields, -> { includes(:custom_field).order('custom_fields.ordering') }, inverse_of: :permission, dependent: :destroy
   has_many :custom_fields, -> { order(:ordering) }, through: :permissions_custom_fields
 
+  validates :permission_scope_type, inclusion: { in: SCOPE_TYPES }
   validates :action, presence: true, inclusion: { in: ->(permission) { available_actions(permission.permission_scope) } }
   validates :permitted_by, presence: true, inclusion: { in: PERMITTED_BIES }
   validates :action, uniqueness: { scope: %i[permission_scope_id permission_scope_type] }
-  validates :permission_scope_type, inclusion: { in: SCOPE_TYPES }
 
   before_validation :set_permitted_by_and_global_custom_fields, on: :create
   before_validation :update_global_custom_fields, on: :update
 
   def self.available_actions(permission_scope)
+    return [] if permission_scope && !permission_scope.respond_to?(:participation_method)
+
     ACTIONS[permission_scope&.participation_method]
   end
 

--- a/back/app/services/permissions_service.rb
+++ b/back/app/services/permissions_service.rb
@@ -28,7 +28,7 @@ class PermissionsService
       model_class.constantize.all.each { |scope| update_permissions_for_scope(scope) }
     end
 
-    # Permission.select(&:invalid?).each(&:destroy!)
+    Permission.select(&:invalid?).each(&:destroy!)
   end
 
   def denied_reason_for_resource(user, action, resource = nil)

--- a/back/spec/services/permissions_service_spec.rb
+++ b/back/spec/services/permissions_service_spec.rb
@@ -1176,4 +1176,20 @@ describe PermissionsService do
       end
     end
   end
+
+  describe '#update_all_permissions' do
+    let(:project) { create(:project) }
+    let!(:invalid_permission) do
+      permission = build(:permission, permission_scope: project)
+      permission.save(validate: false)
+      permission
+    end
+
+    it 'deletes any project scoped permissions' do
+      expect(invalid_permission.permission_scope_type).to eq 'Project'
+
+      service.update_all_permissions
+      expect { invalid_permission.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
 end


### PR DESCRIPTION
This fixes an error that was occuring during validation when trying to remove invalid permission scopes. When deployed this should now remove **all** project scopes as they are invalid.
 
The following query shows Project scopes that have no phase scopes and they are all appear to be information / volunteering phases as expected, so the project scopes can be safely removed. https://metabase.hq.citizenlab.co/question/1740-project-permission-scopes

# Changelog
## Technical
- Fix for code that removes unneeded scopes so that it will remove project permission scopes

