### PR TITLE
Change sessions/upgrade response status to accepted

### DIFF
--- a/back/engines/commercial/impact_tracking/app/controllers/impact_tracking/web_api/v1/sessions_controller.rb
+++ b/back/engines/commercial/impact_tracking/app/controllers/impact_tracking/web_api/v1/sessions_controller.rb
@@ -31,7 +31,7 @@ module ImpactTracking
           highest_role: current_user&.highest_role,
           user_id: current_user.id
         )
-          head :ok
+          head :accepted
         else
           head :internal_server_error
         end

--- a/back/engines/commercial/impact_tracking/spec/acceptance/sessions_spec.rb
+++ b/back/engines/commercial/impact_tracking/spec/acceptance/sessions_spec.rb
@@ -88,7 +88,7 @@ resource 'Impact tracking session' do
 
       do_request
 
-      expect(response_status).to eq 200
+      expect(response_status).to eq 202
       expect(ImpactTracking::Session.count).to eq 1
       session = ImpactTracking::Session.first
       expect(session.highest_role).to eq('user')


### PR DESCRIPTION
Small change in the response status for the `sessions/upgrade` endpoint. Our data-fetching setup expects json data to come with a `200` response status, so I changed it to `202` to avoid confusion and reduce some Sentry noise.