### PR TITLE
TAN-593: Hide take the survey when conditions are not met

### DIFF
--- a/front/app/containers/ProjectsShowPage/shared/header/ProjectActionButtons.tsx
+++ b/front/app/containers/ProjectsShowPage/shared/header/ProjectActionButtons.tsx
@@ -88,6 +88,9 @@ const ProjectActionButtons = memo<Props>(({ projectId, className }) => {
     scrollTo(scrollParams)();
   };
 
+  const { disabled_reason } =
+    project.data.attributes.action_descriptor.taking_survey;
+
   const handleTakeSurveyClick = () => {
     const { enabled, disabled_reason } =
       project.data.attributes.action_descriptor.taking_survey;
@@ -179,6 +182,7 @@ const ProjectActionButtons = memo<Props>(({ projectId, className }) => {
   const showTakeNativeSurveyButton =
     generalShowCTAButtonCondition && participationMethod === 'native_survey';
   const showTakeSurveyButton =
+    !disabled_reason &&
     !generalShowCTAButtonCondition &&
     participationMethod === 'survey' &&
     !hasCurrentPhaseEnded;


### PR DESCRIPTION
# Changelog

## Fixed
- Hides the take the survey button on mobile when the user does not meet the criteria to take the survey. Before the button was shown but nothing would happen when clicked
