### PR TITLE
[TAN-657] Fix problematic composite voting string

### DIFF
--- a/front/app/components/StatusModule/index.tsx
+++ b/front/app/components/StatusModule/index.tsx
@@ -125,8 +125,6 @@ const StatusModule = ({ votingMethod, phase, project }: StatusModuleProps) => {
           </Box>
           {phase && showDate && phase.attributes.end_at && (
             <Text>
-              {config?.getSubmissionTerm &&
-                formatMessage(config.getSubmissionTerm('plural'))}{' '}
               {formatMessage(messages.submittedUntil)}{' '}
               <b>{getLocalisedDateString(phase?.attributes.end_at)}</b>.
             </Text>

--- a/front/app/components/StatusModule/messages.ts
+++ b/front/app/components/StatusModule/messages.ts
@@ -2,8 +2,8 @@ import { defineMessages } from 'react-intl';
 
 export default defineMessages({
   submittedUntil: {
-    id: 'app.components.StatusModule.submittedUntil2',
-    defaultMessage: 'may be submitted until',
+    id: 'app.components.StatusModule.submittedUntil3',
+    defaultMessage: 'Your vote may be submitted until',
   },
   modifyYourSubmission: {
     id: 'app.components.StatusModule.modifyYourSubmission',

--- a/front/app/translations/ar-MA.json
+++ b/front/app/translations/ar-MA.json
@@ -469,7 +469,6 @@
   "app.components.SideModal.closeButtonAria": "إغلاق ",
   "app.components.StatusModule.futurePhase": "أنت تشاهد مرحلة لم تبدأ بعد. ستتمكن من المشاركة عندما تبدأ المرحلة.",
   "app.components.StatusModule.modifyYourSubmission": "تعديل الخاص بك {submissionTerm}",
-  "app.components.StatusModule.submittedUntil2": "يمكن تقديمها حتى",
   "app.components.TopicsPicker.numberOfSelectedTopics": "تم تحديد {numberOfSelectedTopics, plural, =0 {لا يوجد موضوعات} one {موضوع واحد} other {# موضوعات}}. {selectedTopicNames}",
   "app.components.UI.MoreActionsMenu.showMoreActions": "عرض المزيد من الإجراءات",
   "app.components.UI.RemoveImageButton.a11y_removeImage": "إزالة",

--- a/front/app/translations/ar-SA.json
+++ b/front/app/translations/ar-SA.json
@@ -469,7 +469,6 @@
   "app.components.SideModal.closeButtonAria": "إغلاق",
   "app.components.StatusModule.futurePhase": "أنت تشاهد مرحلة لم تبدأ بعد. ستتمكن من المشاركة عندما تبدأ المرحلة.",
   "app.components.StatusModule.modifyYourSubmission": "تعديل الخاص بك {submissionTerm}",
-  "app.components.StatusModule.submittedUntil2": "يمكن تقديمها حتى",
   "app.components.TopicsPicker.numberOfSelectedTopics": "تم تحديد {numberOfSelectedTopics, plural, =0 {لا يوجد موضوعات} one {موضوع واحد} other {# موضوعات}}. {selectedTopicNames}",
   "app.components.UI.MoreActionsMenu.showMoreActions": "إظهار مزيد من الإجراءات",
   "app.components.UI.RemoveImageButton.a11y_removeImage": "إزالة",

--- a/front/app/translations/ca-ES.json
+++ b/front/app/translations/ca-ES.json
@@ -469,7 +469,6 @@
   "app.components.SideModal.closeButtonAria": "Tancar",
   "app.components.StatusModule.futurePhase": "Esteu veient una fase que encara no ha començat. Podreu participar quan comenci la fase.",
   "app.components.StatusModule.modifyYourSubmission": "Modifica el teu {submissionTerm}",
-  "app.components.StatusModule.submittedUntil2": "es podrà presentar fins a",
   "app.components.TopicsPicker.numberOfSelectedTopics": "S'han seleccionat {numberOfSelectedTopics, plural, =0 {zero etiquetes} one {una etiqueta} other {# etiquetes}}. {selectedTopicNames}",
   "app.components.UI.MoreActionsMenu.showMoreActions": "Mostra més accions",
   "app.components.UI.RemoveImageButton.a11y_removeImage": "Eliminar",

--- a/front/app/translations/da-DK.json
+++ b/front/app/translations/da-DK.json
@@ -469,7 +469,6 @@
   "app.components.SideModal.closeButtonAria": "Luk",
   "app.components.StatusModule.futurePhase": "Du ser på en fase, der ikke er startet endnu. Du vil kunne deltage, når fasen starter.",
   "app.components.StatusModule.modifyYourSubmission": "Ændre din {submissionTerm}",
-  "app.components.StatusModule.submittedUntil2": "kan indsendes indtil",
   "app.components.TopicsPicker.numberOfSelectedTopics": "Valgt {numberOfSelectedTopics, plural, =0 {zero topics} et {zero topics} andet {# topics}}.{selectedTopicNames}",
   "app.components.UI.MoreActionsMenu.showMoreActions": "Vis flere handlinger",
   "app.components.UI.RemoveImageButton.a11y_removeImage": "Fjern",

--- a/front/app/translations/de-DE.json
+++ b/front/app/translations/de-DE.json
@@ -469,7 +469,6 @@
   "app.components.SideModal.closeButtonAria": "Schließen",
   "app.components.StatusModule.futurePhase": "Sie befinden sich in einer Phase, die noch nicht begonnen hat. Sie werden teilnehmen können, wenn die Phase beginnt.",
   "app.components.StatusModule.modifyYourSubmission": "Ändern Sie Ihre {submissionTerm}",
-  "app.components.StatusModule.submittedUntil2": "können eingereicht werden bis",
   "app.components.TopicsPicker.numberOfSelectedTopics": "Ausgewählt {numberOfSelectedTopics, plural, =0 {Null Themenfilter} ein { ein Themenfilter} other {# Themenfilter}}. {selectedTopicNames}",
   "app.components.UI.MoreActionsMenu.showMoreActions": "Weitere Aktionen anzeigen",
   "app.components.UI.RemoveImageButton.a11y_removeImage": "Entfernen",

--- a/front/app/translations/el-GR.json
+++ b/front/app/translations/el-GR.json
@@ -469,7 +469,6 @@
   "app.components.SideModal.closeButtonAria": "Κλείσιμο",
   "app.components.StatusModule.futurePhase": "Βλέπετε μια φάση που δεν έχει ξεκινήσει ακόμα. Θα μπορέσετε να συμμετάσχετε όταν ξεκινήσει η φάση.",
   "app.components.StatusModule.modifyYourSubmission": "Τροποποιήστε το {submissionTerm}",
-  "app.components.StatusModule.submittedUntil2": "μπορούν να υποβληθούν μέχρι",
   "app.components.TopicsPicker.numberOfSelectedTopics": "Επιλεγμένα {numberOfSelectedTopics, plural, =0 {μηδενικές ετικέτες} one {μια ετικέτα} other {# ετικέτες}}. {selectedTopicNames}",
   "app.components.UI.MoreActionsMenu.showMoreActions": "Εμφάνιση περισσότερων ενεργειών",
   "app.components.UI.RemoveImageButton.a11y_removeImage": "Κατάργηση",

--- a/front/app/translations/en-CA.json
+++ b/front/app/translations/en-CA.json
@@ -469,7 +469,6 @@
   "app.components.SideModal.closeButtonAria": "Close",
   "app.components.StatusModule.futurePhase": "You are viewing a phase that has not started yet. You will be able to participate when the phase starts.",
   "app.components.StatusModule.modifyYourSubmission": "Modify your {submissionTerm}",
-  "app.components.StatusModule.submittedUntil2": "may be submitted until",
   "app.components.TopicsPicker.numberOfSelectedTopics": "Selected {numberOfSelectedTopics, plural, =0 {zero tags} one {one tag} other {# tags}}. {selectedTopicNames}",
   "app.components.UI.MoreActionsMenu.showMoreActions": "Show more actions",
   "app.components.UI.RemoveImageButton.a11y_removeImage": "Remove",

--- a/front/app/translations/en-GB.json
+++ b/front/app/translations/en-GB.json
@@ -469,7 +469,6 @@
   "app.components.SideModal.closeButtonAria": "Close",
   "app.components.StatusModule.futurePhase": "You are viewing a phase that has not started yet. You will be able to participate when the phase starts.",
   "app.components.StatusModule.modifyYourSubmission": "Modify your {submissionTerm}",
-  "app.components.StatusModule.submittedUntil2": "may be submitted until",
   "app.components.TopicsPicker.numberOfSelectedTopics": "Selected {numberOfSelectedTopics, plural, =0 {zero tags} one {one tag} other {# tags}}. {selectedTopicNames}",
   "app.components.UI.MoreActionsMenu.showMoreActions": "Show more actions",
   "app.components.UI.RemoveImageButton.a11y_removeImage": "Remove",

--- a/front/app/translations/en.json
+++ b/front/app/translations/en.json
@@ -469,7 +469,7 @@
   "app.components.SideModal.closeButtonAria": "Close",
   "app.components.StatusModule.futurePhase": "You are viewing a phase that has not started yet. You will be able to participate when the phase starts.",
   "app.components.StatusModule.modifyYourSubmission": "Modify your {submissionTerm}",
-  "app.components.StatusModule.submittedUntil2": "may be submitted until",
+  "app.components.StatusModule.submittedUntil3": "Your vote may be submitted until",
   "app.components.TopicsPicker.numberOfSelectedTopics": "Selected {numberOfSelectedTopics, plural, =0 {zero tags} one {one tag} other {# tags}}. {selectedTopicNames}",
   "app.components.UI.MoreActionsMenu.showMoreActions": "Show more actions",
   "app.components.UI.RemoveImageButton.a11y_removeImage": "Remove",

--- a/front/app/translations/es-CL.json
+++ b/front/app/translations/es-CL.json
@@ -469,7 +469,6 @@
   "app.components.SideModal.closeButtonAria": "Cerrar",
   "app.components.StatusModule.futurePhase": "Estás viendo una fase que aún no ha comenzado. Podrás participar cuando comience la fase.",
   "app.components.StatusModule.modifyYourSubmission": "Modifica tu {submissionTerm}",
-  "app.components.StatusModule.submittedUntil2": "pueden presentarse hasta",
   "app.components.TopicsPicker.numberOfSelectedTopics": "Seleccionado/s {numberOfSelectedTopics, plural, =0 {zero topics} one {one topic} other {# topics}}. {selectedTopicNames}",
   "app.components.UI.MoreActionsMenu.showMoreActions": "Mostrar más acciones",
   "app.components.UI.RemoveImageButton.a11y_removeImage": "Eliminar",

--- a/front/app/translations/es-ES.json
+++ b/front/app/translations/es-ES.json
@@ -469,7 +469,6 @@
   "app.components.SideModal.closeButtonAria": "Cerrar",
   "app.components.StatusModule.futurePhase": "Estás viendo una fase que aún no ha comenzado. Podrás participar cuando comience la fase.",
   "app.components.StatusModule.modifyYourSubmission": "Modifica tu {submissionTerm}",
-  "app.components.StatusModule.submittedUntil2": "pueden presentarse hasta",
   "app.components.TopicsPicker.numberOfSelectedTopics": "Seleccionado/s {numberOfSelectedTopics, plural, =0 {zero topics} one {one topic} other {# topics}}. {selectedTopicNames}",
   "app.components.UI.MoreActionsMenu.showMoreActions": "Mostrar más acciones",
   "app.components.UI.RemoveImageButton.a11y_removeImage": "Eliminar",

--- a/front/app/translations/fr-BE.json
+++ b/front/app/translations/fr-BE.json
@@ -469,7 +469,6 @@
   "app.components.SideModal.closeButtonAria": "Fermer",
   "app.components.StatusModule.futurePhase": "Vous visualisez une phase qui n'a pas encore débuté. Vous pourrez participer lorsque celle-ci aura commencé.",
   "app.components.StatusModule.modifyYourSubmission": "Modifiez votre {submissionTerm}",
-  "app.components.StatusModule.submittedUntil2": "peuvent être soumises jusqu'au",
   "app.components.TopicsPicker.numberOfSelectedTopics": "Sélectionné {numberOfSelectedTopics, plural, =0 {zéro sujet} one {un sujet} other {# topics}}. {selectedTopicNames}> <notr",
   "app.components.UI.MoreActionsMenu.showMoreActions": "Afficher plus d'actions",
   "app.components.UI.RemoveImageButton.a11y_removeImage": "Supprimer",

--- a/front/app/translations/fr-FR.json
+++ b/front/app/translations/fr-FR.json
@@ -469,7 +469,6 @@
   "app.components.SideModal.closeButtonAria": "Fermer",
   "app.components.StatusModule.futurePhase": "Vous visualisez une phase qui n'a pas encore débuté. Vous pourrez participer lorsque celle-ci aura commencé.",
   "app.components.StatusModule.modifyYourSubmission": "Modifiez votre {submissionTerm}",
-  "app.components.StatusModule.submittedUntil2": "peuvent être soumis jusqu'au",
   "app.components.TopicsPicker.numberOfSelectedTopics": "Sélectionné {numberOfSelectedTopics, plural, =0 {zéro sujet} one {un sujet} other {# topics}}. {selectedTopicNames}> <notr",
   "app.components.UI.MoreActionsMenu.showMoreActions": "Afficher d'autres actions",
   "app.components.UI.RemoveImageButton.a11y_removeImage": "Supprimer",

--- a/front/app/translations/hr-HR.json
+++ b/front/app/translations/hr-HR.json
@@ -469,7 +469,6 @@
   "app.components.SideModal.closeButtonAria": "Zatvori",
   "app.components.StatusModule.futurePhase": "Gledate fazu koja još nije započela. Moći ćete sudjelovati kada faza počne.",
   "app.components.StatusModule.modifyYourSubmission": "Izmijenite svoju {submissionTerm}",
-  "app.components.StatusModule.submittedUntil2": "može se podnijeti do",
   "app.components.TopicsPicker.numberOfSelectedTopics": "Odabrani {numberOfSelectedTopics, plural, =0 {nula oznaka} one {jedna oznaka} other {# oznaka}}. {selectedTopicNames}",
   "app.components.UI.MoreActionsMenu.showMoreActions": "Prikaži više radnji",
   "app.components.UI.RemoveImageButton.a11y_removeImage": "Ukloni",

--- a/front/app/translations/it-IT.json
+++ b/front/app/translations/it-IT.json
@@ -469,7 +469,6 @@
   "app.components.SideModal.closeButtonAria": "Chiudere",
   "app.components.StatusModule.futurePhase": "Stai visualizzando una fase che non è ancora iniziata. Potrai partecipare quando la fase inizierà.",
   "app.components.StatusModule.modifyYourSubmission": "Modifica il tuo {submissionTerm}",
-  "app.components.StatusModule.submittedUntil2": "possono essere presentati fino a",
   "app.components.TopicsPicker.numberOfSelectedTopics": "Selezionato {numberOfSelectedTopics, plural, =0 {zero argomenti} one {un argomento} other {# argomenti}}. {selectedTopicNames}",
   "app.components.UI.MoreActionsMenu.showMoreActions": "Mostra più azioni",
   "app.components.UI.RemoveImageButton.a11y_removeImage": "Rimuovi",

--- a/front/app/translations/kl-GL.json
+++ b/front/app/translations/kl-GL.json
@@ -439,7 +439,6 @@
   "app.components.SideModal.closeButtonAria": "Matujuk",
   "app.components.StatusModule.futurePhase": "You are viewing a phase that has not started yet. You will be able to participate when the phase starts.",
   "app.components.StatusModule.modifyYourSubmission": "Modify your {submissionTerm}",
-  "app.components.StatusModule.submittedUntil2": "may be submitted until",
   "app.components.TopicsPicker.numberOfSelectedTopics": "Selected {numberOfSelectedTopics, plural, =0 {zero topics} one {one topic} other {# topics}}. {selectedTopicNames}",
   "app.components.UI.MoreActionsMenu.showMoreActions": "Show more actions",
   "app.components.UI.RemoveImageButton.a11y_removeImage": "Remove",

--- a/front/app/translations/lb-LU.json
+++ b/front/app/translations/lb-LU.json
@@ -469,7 +469,6 @@
   "app.components.SideModal.closeButtonAria": "Zoumaachen",
   "app.components.StatusModule.futurePhase": "Dir kuckt eng Phase déi nach net ugefaang huet. Dir kënnt matmaachen wann d'Phase ufänkt.",
   "app.components.StatusModule.modifyYourSubmission": "Änneren Är {submissionTerm}",
-  "app.components.StatusModule.submittedUntil2": "kënne bis",
   "app.components.TopicsPicker.numberOfSelectedTopics": "Ausgewielt {numberOfSelectedTopics, plural, =0 {null Sujeten} one {ee Sujet} other {# Sujet'en}}. {selectedTopicNames}",
   "app.components.UI.MoreActionsMenu.showMoreActions": "Méi Aktioune weisen",
   "app.components.UI.RemoveImageButton.a11y_removeImage": "Ewechhuelen",

--- a/front/app/translations/lv-LV.json
+++ b/front/app/translations/lv-LV.json
@@ -469,7 +469,6 @@
   "app.components.SideModal.closeButtonAria": "Aizvērt",
   "app.components.StatusModule.futurePhase": "Jūs skatāties fāzi, kas vēl nav sākusies. Jūs varēsiet piedalīties, kad posms sāksies.",
   "app.components.StatusModule.modifyYourSubmission": "Mainiet savu {submissionTerm}",
-  "app.components.StatusModule.submittedUntil2": "var iesniegt līdz",
   "app.components.TopicsPicker.numberOfSelectedTopics": "Izvēlēts {numberOfSelectedTopics, plural, =0 {zero tags} one {one tag} other {# tags}}. {selectedTopicNames}",
   "app.components.UI.MoreActionsMenu.showMoreActions": "Rādīt vairāk darbību",
   "app.components.UI.RemoveImageButton.a11y_removeImage": "Noņemt",

--- a/front/app/translations/nb-NO.json
+++ b/front/app/translations/nb-NO.json
@@ -469,7 +469,6 @@
   "app.components.SideModal.closeButtonAria": "Lukk",
   "app.components.StatusModule.futurePhase": "Du ser på en fase som ikke har startet ennå. Du vil kunne delta når fasen starter.",
   "app.components.StatusModule.modifyYourSubmission": "Endre din {submissionTerm}",
-  "app.components.StatusModule.submittedUntil2": "kan sendes inn til",
   "app.components.TopicsPicker.numberOfSelectedTopics": "Valgte {numberOfSelectedTopics, plural, =0 {zero topics} one {one topic} other {# topics}}. {selectedTopicNames}",
   "app.components.UI.MoreActionsMenu.showMoreActions": "Vis flere handlinger",
   "app.components.UI.RemoveImageButton.a11y_removeImage": "Fjern",

--- a/front/app/translations/nl-BE.json
+++ b/front/app/translations/nl-BE.json
@@ -469,7 +469,6 @@
   "app.components.SideModal.closeButtonAria": "Sluiten",
   "app.components.StatusModule.futurePhase": "Je bekijkt een fase die nog niet is begonnen. Je kunt deelnemen wanneer de fase begint.",
   "app.components.StatusModule.modifyYourSubmission": "Pas je {submissionTerm} aan",
-  "app.components.StatusModule.submittedUntil2": "kunnen worden ingediend tot en met",
   "app.components.TopicsPicker.numberOfSelectedTopics": "{numberOfSelectedTopics, plural,=0 {Geen tags} one {Eén tag} other {# tags}} geselecteerd. {selectedTopicNames}",
   "app.components.UI.MoreActionsMenu.showMoreActions": "Meer acties tonen",
   "app.components.UI.RemoveImageButton.a11y_removeImage": "Verwijder",

--- a/front/app/translations/nl-NL.json
+++ b/front/app/translations/nl-NL.json
@@ -469,7 +469,6 @@
   "app.components.SideModal.closeButtonAria": "Sluiten",
   "app.components.StatusModule.futurePhase": "Je bekijkt een fase die nog niet is begonnen. Je kunt deelnemen wanneer de fase begint.",
   "app.components.StatusModule.modifyYourSubmission": "Pas je {submissionTerm} aan",
-  "app.components.StatusModule.submittedUntil2": "kunnen worden ingediend tot en met",
   "app.components.TopicsPicker.numberOfSelectedTopics": "{numberOfSelectedTopics, plural,=0 {Geen tags} one {Eén tag} other {# tags}} geselecteerd. {selectedTopicNames}",
   "app.components.UI.MoreActionsMenu.showMoreActions": "Meer acties tonen",
   "app.components.UI.RemoveImageButton.a11y_removeImage": "Verwijder",

--- a/front/app/translations/pl-PL.json
+++ b/front/app/translations/pl-PL.json
@@ -469,7 +469,6 @@
   "app.components.SideModal.closeButtonAria": "Zamknij",
   "app.components.StatusModule.futurePhase": "Oglądasz fazę, która jeszcze się nie rozpoczęła. Będziesz mógł wziąć w niej udział po jej rozpoczęciu.",
   "app.components.StatusModule.modifyYourSubmission": "Zmodyfikuj swoją stronę {submissionTerm}",
-  "app.components.StatusModule.submittedUntil2": "mogą być składane do",
   "app.components.TopicsPicker.numberOfSelectedTopics": "Zaznaczono {numberOfSelectedTopics, plural, =0 {zero tematów} one {jeden temat} few {# tematy} many {# tematów} other {# tematy}}. {selectedTopicNames}",
   "app.components.UI.MoreActionsMenu.showMoreActions": "Pokaż więcej działań",
   "app.components.UI.RemoveImageButton.a11y_removeImage": "Usuń",

--- a/front/app/translations/pt-BR.json
+++ b/front/app/translations/pt-BR.json
@@ -469,7 +469,6 @@
   "app.components.SideModal.closeButtonAria": "Fechar",
   "app.components.StatusModule.futurePhase": "Você está visualizando uma fase que ainda não começou. Você poderá participar quando a fase começar.",
   "app.components.StatusModule.modifyYourSubmission": "Modifique seu {submissionTerm}",
-  "app.components.StatusModule.submittedUntil2": "pode ser enviado até",
   "app.components.TopicsPicker.numberOfSelectedTopics": "Selecionado {numberOfSelectedTopics, plural, =0 {zero tópicos} one {um tópico} other {# tópicos}}. {selectedTopicNames}",
   "app.components.UI.MoreActionsMenu.showMoreActions": "Mostrar mais acções",
   "app.components.UI.RemoveImageButton.a11y_removeImage": "Remover",

--- a/front/app/translations/sr-Latn.json
+++ b/front/app/translations/sr-Latn.json
@@ -469,7 +469,6 @@
   "app.components.SideModal.closeButtonAria": "Zatvori",
   "app.components.StatusModule.futurePhase": "You are viewing a phase that has not started yet. You will be able to participate when the phase starts.",
   "app.components.StatusModule.modifyYourSubmission": "Modify your {submissionTerm}",
-  "app.components.StatusModule.submittedUntil2": "може се поднети до",
   "app.components.TopicsPicker.numberOfSelectedTopics": "Selected {numberOfSelectedTopics, plural, =0 {zero topics} one {one topic} other {# topics}}. {selectedTopicNames}",
   "app.components.UI.MoreActionsMenu.showMoreActions": "Prikaži još radnji",
   "app.components.UI.RemoveImageButton.a11y_removeImage": "Ukloni",

--- a/front/app/translations/sr-SP.json
+++ b/front/app/translations/sr-SP.json
@@ -469,7 +469,6 @@
   "app.components.SideModal.closeButtonAria": "Близу",
   "app.components.StatusModule.futurePhase": "Гледате фазу која још није почела. Моћи ћете да учествујете када фаза почне.",
   "app.components.StatusModule.modifyYourSubmission": "Измените своју {submissionTerm}",
-  "app.components.StatusModule.submittedUntil2": "може се поднети до",
   "app.components.TopicsPicker.numberOfSelectedTopics": "Изабрано {numberOfSelectedTopics, plural, =0 {зеро тагс} one {једна ознака} other {# ознаке}}. {selectedTopicNames}",
   "app.components.UI.MoreActionsMenu.showMoreActions": "Прикажи још радњи",
   "app.components.UI.RemoveImageButton.a11y_removeImage": "Уклони",

--- a/front/app/translations/sv-SE.json
+++ b/front/app/translations/sv-SE.json
@@ -469,7 +469,6 @@
   "app.components.SideModal.closeButtonAria": "Stäng",
   "app.components.StatusModule.futurePhase": "Du tittar på en fas som inte har startat ännu. Du kommer att kunna delta när fasen startar.",
   "app.components.StatusModule.modifyYourSubmission": "Ändra din {submissionTerm}",
-  "app.components.StatusModule.submittedUntil2": "får lämnas in fram till",
   "app.components.TopicsPicker.numberOfSelectedTopics": "Valde {numberOfSelectedTopics, plural, =0 {noll ämnen} one {ett ämne} other {# ämnen}}. {selectedTopicNames}",
   "app.components.UI.MoreActionsMenu.showMoreActions": "Visa fler åtgärder",
   "app.components.UI.RemoveImageButton.a11y_removeImage": "Ta bort",

--- a/front/app/translations/tr-TR.json
+++ b/front/app/translations/tr-TR.json
@@ -469,7 +469,6 @@
   "app.components.SideModal.closeButtonAria": "Kapat",
   "app.components.StatusModule.futurePhase": "Henüz başlamamış bir aşamayı görüntülüyorsunuz. Aşama başladığında katılabileceksiniz.",
   "app.components.StatusModule.modifyYourSubmission": "{submissionTerm}adresinizi değiştirin",
-  "app.components.StatusModule.submittedUntil2": "kadar sunulabilir",
   "app.components.TopicsPicker.numberOfSelectedTopics": "{numberOfSelectedTopics, plural, =0 {Sıfır etiket} one {bir etiket} other {# etiket}} seçildi. {selectedTopicNames}",
   "app.components.UI.MoreActionsMenu.showMoreActions": "Daha fazla eylem göster",
   "app.components.UI.RemoveImageButton.a11y_removeImage": "Kaldır",


### PR DESCRIPTION
# Changelog
## Fixed
- [[TAN-657]](https://www.notion.so/citizenlab/Interpolated-composite-string-cannot-be-localized-properly-in-French-61fe1ee70223427f9d38e33f6530d56f) Fixed a problematic composite string in voting projects which couldn't be translated in some languages. The string "{VotingTermPlural} may be submitted until...." in the vote instructions is now "Your vote may be submitted until..." and should be properly translated in all languages.

