### PR TITLE
TAN-617 - Disable notifications and therefore emails if the follow feature is turned off

### DIFF
--- a/back/app/models/notifications/comment_on_idea_you_follow.rb
+++ b/back/app/models/notifications/comment_on_idea_you_follow.rb
@@ -71,6 +71,8 @@ module Notifications
     EVENT_NAME = 'Comment on idea you follow'
 
     def self.make_notifications_on(activity)
+      return [] unless AppConfiguration.instance.feature_activated? 'follow'
+
       comment = activity.item
       initiator_id = comment&.author_id
 

--- a/back/app/models/notifications/comment_on_initiative_you_follow.rb
+++ b/back/app/models/notifications/comment_on_initiative_you_follow.rb
@@ -71,6 +71,8 @@ module Notifications
     EVENT_NAME = 'Comment on initiative you follow'
 
     def self.make_notifications_on(activity)
+      return [] unless AppConfiguration.instance.feature_activated? 'follow'
+
       comment = activity.item
       initiator_id = comment&.author_id
 

--- a/back/app/models/notifications/official_feedback_on_idea_you_follow.rb
+++ b/back/app/models/notifications/official_feedback_on_idea_you_follow.rb
@@ -71,6 +71,8 @@ module Notifications
     EVENT_NAME = 'Official feedback on idea you follow'
 
     def self.make_notifications_on(activity)
+      return [] unless AppConfiguration.instance.feature_activated? 'follow'
+
       official_feedback = activity.item
       initiator_id = official_feedback.user_id
 

--- a/back/app/models/notifications/official_feedback_on_initiative_you_follow.rb
+++ b/back/app/models/notifications/official_feedback_on_initiative_you_follow.rb
@@ -71,6 +71,8 @@ module Notifications
     EVENT_NAME = 'Official feedback on initiative you follow'
 
     def self.make_notifications_on(activity)
+      return [] unless AppConfiguration.instance.feature_activated? 'follow'
+
       official_feedback = activity.item
       initiator_id = official_feedback.user_id
 

--- a/back/app/models/notifications/status_change_on_idea_you_follow.rb
+++ b/back/app/models/notifications/status_change_on_idea_you_follow.rb
@@ -71,6 +71,8 @@ module Notifications
     EVENT_NAME = 'Status change on idea you follow'
 
     def self.make_notifications_on(activity)
+      return [] unless AppConfiguration.instance.feature_activated? 'follow'
+
       initiator_id = activity.user_id
       idea = activity.item
       return [] if !idea

--- a/back/app/models/notifications/status_change_on_initiative_you_follow.rb
+++ b/back/app/models/notifications/status_change_on_initiative_you_follow.rb
@@ -71,6 +71,8 @@ module Notifications
     EVENT_NAME = 'Status change on initiative you follow'
 
     def self.make_notifications_on(activity)
+      return [] unless AppConfiguration.instance.feature_activated? 'follow'
+
       initiator_id = activity.user_id
       initiative = activity.item
       return [] if !initiative

--- a/back/spec/models/notifications/comment_on_idea_you_follow_spec.rb
+++ b/back/spec/models/notifications/comment_on_idea_you_follow_spec.rb
@@ -19,5 +19,16 @@ RSpec.describe Notifications::CommentOnIdeaYouFollow do
         project_id: comment.post.project_id
       )
     end
+
+    it 'does not make a notification when follow feature is turned off' do
+      idea = create(:idea)
+      create(:follower, followable: idea)
+      comment = create(:comment, post: idea)
+      activity = create(:activity, item: comment, action: 'created')
+
+      SettingsService.new.deactivate_feature! 'follow'
+      notifications = described_class.make_notifications_on activity
+      expect(notifications).to be_empty
+    end
   end
 end

--- a/back/spec/models/notifications/comment_on_initiative_you_follow_spec.rb
+++ b/back/spec/models/notifications/comment_on_initiative_you_follow_spec.rb
@@ -18,5 +18,16 @@ RSpec.describe Notifications::CommentOnInitiativeYouFollow do
         comment_id: comment.id
       )
     end
+
+    it 'does not make a notification when follow feature is turned off' do
+      initiative = create(:initiative)
+      create(:follower, followable: initiative)
+      comment = create(:comment, post: initiative)
+      activity = create(:activity, item: comment, action: 'created')
+
+      SettingsService.new.deactivate_feature! 'follow'
+      notifications = described_class.make_notifications_on activity
+      expect(notifications).to be_empty
+    end
   end
 end

--- a/back/spec/models/notifications/official_feedback_on_idea_you_follow_spec.rb
+++ b/back/spec/models/notifications/official_feedback_on_idea_you_follow_spec.rb
@@ -27,5 +27,16 @@ RSpec.describe Notifications::OfficialFeedbackOnIdeaYouFollow do
       notifications = described_class.make_notifications_on(activity)
       expect(notifications).to eq []
     end
+
+    it 'does not make a notification when follow feature is turned off' do
+      idea = create(:idea)
+      create(:follower, followable: idea)
+      official_feedback = create(:official_feedback, post: idea)
+      activity = create(:activity, item: official_feedback, action: :created)
+
+      SettingsService.new.deactivate_feature! 'follow'
+      notifications = described_class.make_notifications_on activity
+      expect(notifications).to be_empty
+    end
   end
 end

--- a/back/spec/models/notifications/official_feedback_on_initiative_you_follow_spec.rb
+++ b/back/spec/models/notifications/official_feedback_on_initiative_you_follow_spec.rb
@@ -47,5 +47,16 @@ RSpec.describe Notifications::OfficialFeedbackOnInitiativeYouFollow do
       notifications = described_class.make_notifications_on(activity)
       expect(notifications).to eq []
     end
+
+    it 'does not make a notification when follow feature is turned off' do
+      initiative = create(:initiative)
+      create(:follower, followable: initiative)
+      official_feedback = create(:official_feedback, post: initiative)
+      activity = create(:activity, item: official_feedback, action: :created)
+
+      SettingsService.new.deactivate_feature! 'follow'
+      notifications = described_class.make_notifications_on activity
+      expect(notifications).to be_empty
+    end
   end
 end

--- a/back/spec/models/notifications/status_change_on_idea_you_follow_spec.rb
+++ b/back/spec/models/notifications/status_change_on_idea_you_follow_spec.rb
@@ -25,5 +25,15 @@ RSpec.describe Notifications::StatusChangeOnIdeaYouFollow do
       notifications = described_class.make_notifications_on(activity)
       expect(notifications).to eq []
     end
+
+    it 'does not make a notification when follow feature is turned off' do
+      idea = create(:idea)
+      create(:follower, followable: idea)
+      activity = create(:activity, item: idea, action: 'changed_status')
+
+      SettingsService.new.deactivate_feature! 'follow'
+      notifications = described_class.make_notifications_on activity
+      expect(notifications).to be_empty
+    end
   end
 end

--- a/back/spec/models/notifications/status_change_on_initiative_you_follow_spec.rb
+++ b/back/spec/models/notifications/status_change_on_initiative_you_follow_spec.rb
@@ -25,5 +25,15 @@ RSpec.describe Notifications::StatusChangeOnInitiativeYouFollow do
       notifications = described_class.make_notifications_on(activity)
       expect(notifications).to eq []
     end
+
+    it 'does not make a notification when follow feature is turned off' do
+      initiative = create(:initiative)
+      create(:follower, followable: initiative)
+      activity = create(:activity, item: initiative, action: 'changed_status')
+
+      SettingsService.new.deactivate_feature! 'follow'
+      notifications = described_class.make_notifications_on activity
+      expect(notifications).to be_empty
+    end
   end
 end


### PR DESCRIPTION
# Changelog
## Changed
- Turned off follow notifications and emails if the follow feature is turned off
