### PR TITLE
Fix scroll to official feedback

### DIFF
--- a/front/app/components/PostShowComponents/OfficialFeedback/OfficialFeedbackFeed.tsx
+++ b/front/app/components/PostShowComponents/OfficialFeedback/OfficialFeedbackFeed.tsx
@@ -154,7 +154,7 @@ const OfficialFeedbackFeed = ({
       <Container
         aria-live="polite"
         className={`${className} ${editingAllowed ? 'hasTopMargin' : ''}`}
-        data-testid="official-feedback-feed"
+        id="official-feedback-feed"
       >
         <FeedbackHeader>
           <FeedbackTitle>

--- a/front/app/containers/InitiativesShow/index.tsx
+++ b/front/app/containers/InitiativesShow/index.tsx
@@ -36,7 +36,6 @@ const InitiativesShow = ({ initiativeId, className }: Props) => {
     setA11y_pronounceLatestOfficialFeedbackPost,
   ] = useState(false);
 
-  const officialFeedbackElement = useRef<HTMLDivElement>(null);
   const timeoutRef = useRef<NodeJS.Timeout>();
 
   useEffect(() => {
@@ -76,13 +75,9 @@ const InitiativesShow = ({ initiativeId, className }: Props) => {
   };
 
   const onScrollToOfficialFeedback = () => {
-    if (officialFeedbackElement.current) {
-      officialFeedbackElement.current.scrollIntoView({
-        behavior: 'smooth',
-        block: 'center',
-        inline: 'center',
-      });
-    }
+    document.getElementById('official-feedback-feed')?.scrollIntoView({
+      behavior: 'smooth',
+    });
 
     setA11y_pronounceLatestOfficialFeedbackPost(true);
   };


### PR DESCRIPTION
# Changelog

## Fixed
- Fix scroll behaviour to official feedback on proposals. Before, clicking the read answer on button to answered proposals would do nothing. After this fix, the page will scroll to the feedback section after clicking the button
