### PR TITLE
TAN-611 - Restricted ideas in weekly digest to only those with activity in last week

### DIFF
--- a/back/app/models/idea.rb
+++ b/back/app/models/idea.rb
@@ -149,7 +149,7 @@ class Idea < ApplicationRecord
       .order("idea_statuses.ordering #{direction}, ideas.id")
   }
 
-  scope :activity_after, lambda { |time_ago = 7.days.ago|
+  scope :activity_after, lambda { |time_ago|
     left_joins(:comments, :reactions)
       .where('ideas.updated_at >= ? OR comments.updated_at >= ? OR reactions.created_at >= ?', time_ago, time_ago, time_ago)
   }

--- a/back/app/models/idea.rb
+++ b/back/app/models/idea.rb
@@ -149,6 +149,11 @@ class Idea < ApplicationRecord
       .order("idea_statuses.ordering #{direction}, ideas.id")
   }
 
+  scope :activity_after, lambda { |time_ago = 7.days.ago|
+    left_joins(:comments, :reactions)
+      .where('ideas.updated_at >= ? OR comments.updated_at >= ? OR reactions.created_at >= ?', time_ago, time_ago, time_ago)
+  }
+
   scope :feedback_needed, lambda {
     joins(:idea_status).where(idea_statuses: { code: 'proposed' })
       .where('ideas.id NOT IN (SELECT DISTINCT(post_id) FROM official_feedbacks)')

--- a/back/app/models/initiative.rb
+++ b/back/app/models/initiative.rb
@@ -128,6 +128,15 @@ class Initiative < ApplicationRecord
       .where(initiative_status_changes: { initiative_status: InitiativeStatus.find_by(code: 'proposed') })
   end)
 
+  scope :activity_after, lambda { |time_ago|
+    joins(:initiative_status_changes)
+      .where(
+        'initiative_status_changes.initiative_status_id IN (?) AND initiative_status_changes.created_at > ?',
+        InitiativeStatus.where(code: %w[threshold_reached proposed]).ids,
+        time_ago
+      )
+  }
+
   def self.review_required?
     app_config = AppConfiguration.instance
     require_review = app_config.settings('initiatives', 'require_review')

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/user_digest.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/user_digest.rb
@@ -104,7 +104,9 @@ module EmailCampaigns
     def content_worth_sending?(_)
       # Check positive? as fetching a non-integer env var would result in zero and this hook would return true,
       # whilst top_ideas would be limited to zero ideas, possibly resulting in no content being sent.
-      @content_worth_sending ||= recent_ideas.size >= N_TOP_IDEAS && N_TOP_IDEAS.positive?
+      @content_worth_sending ||=
+        (recent_ideas.size >= N_TOP_IDEAS && N_TOP_IDEAS.positive?) ||
+        recent_initiatives.any?
     end
 
     private
@@ -129,7 +131,7 @@ module EmailCampaigns
       ideas = IdeaPolicy::Scope.new(nil, Idea).resolve
         .published
         .includes(:comments)
-        .activity_after(7.days.ago)
+        .activity_after(1.week.ago)
 
       input_ideas = IdeasFinder.new({}, scope: ideas).find_records
       ti_service.sort_trending input_ideas
@@ -196,6 +198,12 @@ module EmailCampaigns
         url: Frontend::UrlService.new.model_to_url(project, locale: recipient.locale),
         created_at: project.created_at.iso8601
       }
+    end
+
+    def recent_initiatives
+      InitiativePolicy::Scope.new(nil, Initiative).resolve
+        .published
+        .activity_after(1.week.ago)
     end
 
     def new_initiatives(name_service, time:)

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/user_digest_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/user_digest_spec.rb
@@ -83,14 +83,22 @@ RSpec.describe EmailCampaigns::Campaigns::UserDigest do
   describe 'before_send_hooks' do
     let(:campaign) { build(:user_digest_campaign) }
 
-    it 'returns true when there are at least 3 trending ideas' do
+    it 'returns true when there are at least 3 ideas updated in the last week' do
       create_list(:idea, 3, published_at: Time.now - 1.minute)
       expect(campaign.content_worth_sending?({})).to be true
     end
 
-    it 'returns false when there are less than 3 trending ideas' do
+    it 'returns false when there are less than 3 ideas updated in the last week' do
       create_list(:idea, 2, published_at: Time.now - 1.minute)
       expect(campaign.content_worth_sending?({})).to be false
+    end
+
+    it 'returns true when there 3 ideas with comments or reactions updated in the last week' do
+      old_ideas = create_list(:idea, 3, published_at: Time.now - 30.days, updated_at: Time.now - 30.days)
+      create(:comment, post: old_ideas.first, created_at: Time.now - 1.minute)
+      create(:comment, post: old_ideas.second, created_at: Time.now - 1.minute)
+      create(:reaction, reactable: old_ideas.last, created_at: Time.now - 1.minute)
+      expect(campaign.content_worth_sending?({})).to be true
     end
   end
 

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/user_digest_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/user_digest_spec.rb
@@ -100,6 +100,18 @@ RSpec.describe EmailCampaigns::Campaigns::UserDigest do
       create(:reaction, reactable: old_ideas.last, created_at: Time.now - 1.minute)
       expect(campaign.content_worth_sending?({})).to be true
     end
+
+    it 'returns true when there are any initiatives proposed or where the threshold is reached' do
+      proposed_status = create(:initiative_status_proposed)
+      initiative = create(:initiative)
+      create(
+        :initiative_status_change,
+        initiative: initiative,
+        initiative_status: proposed_status,
+        created_at: 1.day.ago
+      )
+      expect(campaign.content_worth_sending?({})).to be true
+    end
   end
 
   describe 'apply_recipient_filters' do

--- a/back/spec/models/idea_spec.rb
+++ b/back/spec/models/idea_spec.rb
@@ -468,6 +468,29 @@ RSpec.describe Idea do
     end
   end
 
+  describe 'activity_after' do
+    let_it_be(:recent_idea) { create(:idea, updated_at: 1.day.ago) }
+    let_it_be(:old_idea) { create(:idea, updated_at: 30.days.ago) }
+
+    let(:recent_ideas) { described_class.activity_after(7.days.ago) }
+
+    it 'returns recently updated ideas' do
+      expect(recent_ideas.size).to eq 1
+      expect(recent_ideas.pluck(:id)).to include recent_idea.id
+      expect(recent_ideas.pluck(:id)).not_to include old_idea.id
+    end
+
+    it 'returns ideas with recent comments' do
+      create(:comment, post: old_idea, updated_at: 1.day.ago)
+      expect(recent_ideas.pluck(:id)).to include old_idea.id
+    end
+
+    it 'returns ideas with recent reactions' do
+      create(:reaction, reactable: old_idea, updated_at: 1.day.ago)
+      expect(recent_ideas.pluck(:id)).to include old_idea.id
+    end
+  end
+
   describe 'idea search' do
     it 'should return results with exact prefixes' do
       create(:idea, title_multiloc: { 'nl-BE' => 'Bomen in het park' })

--- a/back/spec/models/idea_spec.rb
+++ b/back/spec/models/idea_spec.rb
@@ -476,18 +476,18 @@ RSpec.describe Idea do
 
     it 'returns recently updated ideas' do
       expect(recent_ideas.size).to eq 1
-      expect(recent_ideas.pluck(:id)).to include recent_idea.id
-      expect(recent_ideas.pluck(:id)).not_to include old_idea.id
+      expect(recent_ideas).to include recent_idea
+      expect(recent_ideas).not_to include old_idea
     end
 
     it 'returns ideas with recent comments' do
       create(:comment, post: old_idea, updated_at: 1.day.ago)
-      expect(recent_ideas.pluck(:id)).to include old_idea.id
+      expect(recent_ideas).to include old_idea
     end
 
     it 'returns ideas with recent reactions' do
       create(:reaction, reactable: old_idea, updated_at: 1.day.ago)
-      expect(recent_ideas.pluck(:id)).to include old_idea.id
+      expect(recent_ideas).to include old_idea
     end
   end
 

--- a/back/spec/models/initiative_spec.rb
+++ b/back/spec/models/initiative_spec.rb
@@ -312,4 +312,52 @@ RSpec.describe Initiative do
       expect(initiative.reload.cosponsors).to be_present
     end
   end
+
+  describe 'activity after' do
+    let_it_be(:initiative) { create(:initiative) }
+    let_it_be(:proposed) { create(:initiative_status_proposed) }
+    let_it_be(:threshold_reached) { create(:initiative_status_threshold_reached) }
+
+    let(:recent_initiatives) { described_class.activity_after(7.days.ago) }
+
+    it 'returns initiatives that have been proposed since after time specified' do
+      create(
+        :initiative_status_change,
+        initiative: initiative,
+        initiative_status: proposed,
+        created_at: 1.day.ago
+      )
+      expect(recent_initiatives).to include(initiative)
+    end
+
+    it 'returns initiatives that where the threshold has been reached after the time specified' do
+      create(
+        :initiative_status_change,
+        initiative: initiative,
+        initiative_status: threshold_reached,
+        created_at: 1.day.ago
+      )
+      expect(recent_initiatives).to include(initiative)
+    end
+
+    it 'does not return initiatives that have been proposed before the time specified' do
+      create(
+        :initiative_status_change,
+        initiative: initiative,
+        initiative_status: proposed,
+        created_at: 8.days.ago
+      )
+      expect(recent_initiatives).not_to include(initiative)
+    end
+
+    it 'does not return initiatives that where the threshold has been reached before the time specified' do
+      create(
+        :initiative_status_change,
+        initiative: initiative,
+        initiative_status: threshold_reached,
+        created_at: 8.days.ago
+      )
+      expect(recent_initiatives).not_to include(initiative)
+    end
+  end
 end


### PR DESCRIPTION
The weekly email was reliant on the trending service to select which ideas to send - but this will include ideas updated in the last 30 days, so have restricted the ideas to only those with activity in the last 7 days and then used the trending service merely for ordering the ideas.

Also noticed that this email would only be sent if there were ideas. So if no ideas but there were proposals, no email would get sent. Have fixed this so that the email will still get sent if there has been proposal activity in the last week.

# Changelog
## Fixed
- TAN-611 - Stopped sending weekly emails where there is no activity in the last week
