### PR TITLE
TAN-625: Fixes following for vienna for logged out users

### DIFF
--- a/back/app/services/permissions_service.rb
+++ b/back/app/services/permissions_service.rb
@@ -176,7 +176,11 @@ class PermissionsService
     when 'everyone'
       everyone
     when 'everyone_confirmed_email'
-      AppConfiguration.instance.feature_activated?('user_confirmation') ? everyone_confirmed_email : users
+      if permission.action == 'following'
+        AppConfiguration.instance.feature_activated?('user_confirmation') && AppConfiguration.instance.feature_activated?('password_login') ? everyone_confirmed_email : users
+      else
+        AppConfiguration.instance.feature_activated?('user_confirmation') ? everyone_confirmed_email : users
+      end
     when 'groups'
       groups
     else # users | admins_moderators'


### PR DESCRIPTION
# Changelog

In looking at this and remembering the follow work. We designed it to only use the light user flow if enabled and other wise default to whatever flow is being used. This change takes into consideration the `password_login` too. 

## Fixed
- Following something when logged out should trigger the auth process. This flow was specifically not working for Vienna. It should be good now

