### PR TITLE
TAN-630: Allow viewing, printing and editing already created reports

### DIFF
--- a/front/app/containers/Admin/reporting/containers/FullScreenReport/index.tsx
+++ b/front/app/containers/Admin/reporting/containers/FullScreenReport/index.tsx
@@ -43,10 +43,9 @@ export const FullScreenReport = ({ reportId }: Props) => {
 };
 
 const FullScreenReportWrapper = () => {
-  const reportBuilderEnabled = useFeatureFlag({ name: 'report_builder' });
   const { reportId } = useParams();
 
-  if (!reportBuilderEnabled || reportId === undefined) {
+  if (reportId === undefined) {
     return null;
   }
 

--- a/front/app/containers/Admin/reporting/containers/FullScreenReport/index.tsx
+++ b/front/app/containers/Admin/reporting/containers/FullScreenReport/index.tsx
@@ -6,7 +6,6 @@ import { ReportContextProvider } from '../../context/ReportContext';
 // hooks
 import useReportLayout from 'api/report_layout/useReportLayout';
 import { useParams } from 'react-router-dom';
-import useFeatureFlag from 'hooks/useFeatureFlag';
 
 // components
 import FullScreenWrapper from 'components/admin/ContentBuilder/FullscreenPreview/Wrapper';

--- a/front/app/containers/Admin/reporting/containers/PrintReport/index.tsx
+++ b/front/app/containers/Admin/reporting/containers/PrintReport/index.tsx
@@ -4,9 +4,6 @@ import styled from 'styled-components';
 // routing
 import { useParams } from 'react-router-dom';
 
-// hooks
-import useFeatureFlag from 'hooks/useFeatureFlag';
-
 // components
 import { Text, Spinner, Box } from '@citizenlab/cl2-component-library';
 import Report from './Report';

--- a/front/app/containers/Admin/reporting/containers/PrintReport/index.tsx
+++ b/front/app/containers/Admin/reporting/containers/PrintReport/index.tsx
@@ -96,10 +96,9 @@ export const PrintReport = ({ reportId, _print = true }: Props) => {
 };
 
 const PrintReportWrapper = () => {
-  const reportBuilderEnabled = useFeatureFlag({ name: 'report_builder' });
   const { reportId } = useParams();
 
-  if (!reportBuilderEnabled || reportId === undefined) {
+  if (reportId === undefined) {
     return null;
   }
 

--- a/front/app/containers/Admin/reporting/containers/ReportBuilder/index.tsx
+++ b/front/app/containers/Admin/reporting/containers/ReportBuilder/index.tsx
@@ -185,13 +185,11 @@ const ReportBuilder = ({ reportId, reportLayout }: Props) => {
 };
 
 const ReportBuilderWrapper = () => {
-  const reportBuilderEnabled = useFeatureFlag({ name: 'report_builder' });
   const { pathname } = useLocation();
   const { reportId } = useParams();
   const { data: reportLayout } = useReportLayout(reportId);
 
   const renderReportBuilder =
-    reportBuilderEnabled &&
     pathname.includes('admin/reporting/report-builder') &&
     reportId !== undefined &&
     reportLayout;

--- a/front/app/containers/Admin/reporting/containers/ReportBuilder/index.tsx
+++ b/front/app/containers/Admin/reporting/containers/ReportBuilder/index.tsx
@@ -2,7 +2,6 @@ import React, { useState, useCallback } from 'react';
 import { useLocation, useParams, useSearchParams } from 'react-router-dom';
 
 // hooks
-import useFeatureFlag from 'hooks/useFeatureFlag';
 import useReportLayout from 'api/report_layout/useReportLayout';
 import useLocale from 'hooks/useLocale';
 


### PR DESCRIPTION
# Changelog

## Fixed
- Allow viewing, printing and editing already created reports when client changes from premium to standard. The `Bad Dürkheim` report should now be visible
