### PR TITLE
TAN-630: Hide reports list when report-builder is off

### DIFF
--- a/front/app/containers/Admin/reporting/containers/ReportBuilderPage/index.tsx
+++ b/front/app/containers/Admin/reporting/containers/ReportBuilderPage/index.tsx
@@ -88,21 +88,23 @@ const ReportBuilderPage = () => {
               </Tippy>
             </Box>
           </Box>
-          <Box background="white" px="56px" py="40px" mt="20px">
-            <Title
-              variant="h3"
-              as="h2"
-              color="primary"
-              mt="0px"
-              mb="32px"
-              fontWeight="normal"
-            >
-              <FormattedMessage {...messages.viewReports} />
-            </Title>
-            {reports.data.map((report) => (
-              <ReportRow key={report.id} report={report} />
-            ))}
-          </Box>
+          {isReportBuilderAllowed && (
+            <Box background="white" px="56px" py="40px" mt="20px">
+              <Title
+                variant="h3"
+                as="h2"
+                color="primary"
+                mt="0px"
+                mb="32px"
+                fontWeight="normal"
+              >
+                <FormattedMessage {...messages.viewReports} />
+              </Title>
+              {reports.data.map((report) => (
+                <ReportRow key={report.id} report={report} />
+              ))}
+            </Box>
+          )}
         </>
       )}
       <CreateReportModal open={modalOpen} onClose={closeModal} />


### PR DESCRIPTION
# Changelog

## Fixed
- When report builder is not allowed in the feature flags, we now also hide the list of reports. This means that If the client previously had reports and then downgrades, they won't be able to see the reports.
