### PR TITLE
[TAN-664] Add simple Reject button to cookie banner

### DIFF
--- a/front/app/components/ConsentManager/Banner.tsx
+++ b/front/app/components/ConsentManager/Banner.tsx
@@ -104,34 +104,10 @@ const StyledLink = styled(Link)`
 
 const ButtonContainer = styled.div`
   display: flex;
+  gap: 12px;
 
   ${isRtl`
     flex-direction: row-reverse;
-  `}
-`;
-
-const AcceptButton = styled(Button)`
-  margin-right: 10px;
-
-  ${media.phone`
-    margin-right: 0px;
-    order: 2;
-  `}
-
-  ${isRtl`
-    margin-right: 0px;
-    margin-left: 10px;
-
-    ${media.phone`
-      margin-left: 0px;
-    `}
-  `}
-`;
-
-const PreferencesButton = styled(Button)`
-  ${media.phone`
-    margin-right: 10px;
-    order: 1;
   `}
 `;
 
@@ -173,7 +149,7 @@ const Banner = ({ onAccept, onChangePreferences, onClose }: Props) => {
             </Line>
           </Left>
           <ButtonContainer>
-            <AcceptButton
+            <Button
               className="e2e-accept-cookies-btn"
               buttonStyle="primary-inverse"
               textColor={colors.primary}
@@ -181,16 +157,25 @@ const Banner = ({ onAccept, onChangePreferences, onClose }: Props) => {
               onClick={onAccept}
             >
               <FormattedMessage {...messages.accept} />
-            </AcceptButton>
-            <PreferencesButton
-              className="integration-open-modal"
+            </Button>
+            <Button
               buttonStyle="primary-inverse"
               textColor={colors.primary}
               textHoverColor={colors.primary}
+              onClick={onClose}
+            >
+              <FormattedMessage {...messages.reject} />
+            </Button>
+            <Button
+              className="integration-open-modal"
+              padding="0px"
+              buttonStyle="text"
+              textColor={colors.white}
+              textHoverColor={colors.white}
               onClick={onChangePreferences}
             >
               <FormattedMessage {...messages.manage} />
-            </PreferencesButton>
+            </Button>
           </ButtonContainer>
         </ContentContainerInner>
       </ContentContainer>

--- a/front/app/components/ConsentManager/messages.ts
+++ b/front/app/components/ConsentManager/messages.ts
@@ -22,6 +22,10 @@ export default defineMessages({
     id: 'app.components.ConsentManager.Banner.manage',
     defaultMessage: 'Manage',
   },
+  reject: {
+    id: 'app.components.ConsentManager.Banner.reject',
+    defaultMessage: 'Reject',
+  },
   accept: {
     id: 'app.components.ConsentManager.Banner.accept',
     defaultMessage: 'Accept',

--- a/front/app/modules/commercial/analytics/admin/containers/Visitors/VisitorsOverview.tsx
+++ b/front/app/modules/commercial/analytics/admin/containers/Visitors/VisitorsOverview.tsx
@@ -68,9 +68,7 @@ const VisitorsOverview = ({ uniqueVisitorDataDate }: Props) => {
       <Box p="10px">
         <Warning>
           <Text color="primary" m="0px">
-            {formatMessage(messages.dateInfo, {
-              date: uniqueVisitorDataDate.format('LL'),
-            })}
+            {formatMessage(messages.cookieBannerUpdatedInfo)}
           </Text>
         </Warning>
       </Box>

--- a/front/app/modules/commercial/analytics/admin/containers/Visitors/messages.ts
+++ b/front/app/modules/commercial/analytics/admin/containers/Visitors/messages.ts
@@ -1,9 +1,10 @@
 import { defineMessages } from 'react-intl';
 
 export default defineMessages({
-  dateInfo: {
-    id: 'app.modules.commercial.analytics.admin.containers.visitors.dateInfo',
-    defaultMessage: 'Unique visitor data is available from {date} onwards.',
+  cookieBannerUpdatedInfo: {
+    id: 'app.modules.commercial.analytics.admin.containers.visitors.cookieBannerUpdatedInfo',
+    defaultMessage:
+      "Since December 2023 it's easier for users to reject cookies, which has a negative effect on perceived traffic.",
   },
   noData: {
     id: 'app.modules.commercial.analytics.admin.containers.visitors.noData',

--- a/front/app/translations/admin/ar-SA.json
+++ b/front/app/translations/admin/ar-SA.json
@@ -2498,7 +2498,6 @@
   "app.modules.commercial.analytics.admin.components.VisitorsTrafficSourcesCard.visits": "الزيارات",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.title": "أنواع الزائرين",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.visitors": "زوار",
-  "app.modules.commercial.analytics.admin.containers.visitors.dateInfo": "تتوفر بيانات الزائر الفريدة بدءًا من {date} فصاعدًا.",
   "app.modules.commercial.analytics.admin.containers.visitors.noData": "لا توجد بيانات الزوار حتى الآن.",
   "app.modules.commercial.analytics.admin.hooks.useActiveUsers.timeSeries": "مستخدمون نشطون بمرور الوقت",
   "app.modules.commercial.analytics.admin.hooks.useEmailDeliveries.timeSeries": "عمليات تسليم البريد الإلكتروني بمرور الوقت",

--- a/front/app/translations/admin/da-DK.json
+++ b/front/app/translations/admin/da-DK.json
@@ -2498,7 +2498,6 @@
   "app.modules.commercial.analytics.admin.components.VisitorsTrafficSourcesCard.visits": "Besøg",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.title": "Besøgstyper",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.visitors": "Besøgende",
-  "app.modules.commercial.analytics.admin.containers.visitors.dateInfo": "Data om unikke besøgende er tilgængelige fra {date} og frem.",
   "app.modules.commercial.analytics.admin.containers.visitors.noData": "Der er endnu ingen besøgsdata.",
   "app.modules.commercial.analytics.admin.hooks.useActiveUsers.timeSeries": "Aktive brugere over tid",
   "app.modules.commercial.analytics.admin.hooks.useEmailDeliveries.timeSeries": "E-mail-leverancer over tid",

--- a/front/app/translations/admin/de-DE.json
+++ b/front/app/translations/admin/de-DE.json
@@ -2498,7 +2498,6 @@
   "app.modules.commercial.analytics.admin.components.VisitorsTrafficSourcesCard.visits": "Besuche",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.title": "Arten von Besucher*innen",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.visitors": "Besucher*innen",
-  "app.modules.commercial.analytics.admin.containers.visitors.dateInfo": "Daten zu den einzelnen Besucher*innen sind ab dem {date} verfügbar.",
   "app.modules.commercial.analytics.admin.containers.visitors.noData": "Es gibt noch keine Besucher*innendaten.",
   "app.modules.commercial.analytics.admin.hooks.useActiveUsers.timeSeries": "Aktive Nutzer*innen im Zeitverlauf",
   "app.modules.commercial.analytics.admin.hooks.useEmailDeliveries.timeSeries": "E-Mail-Zustellungen im Zeitverlauf",

--- a/front/app/translations/admin/en-CA.json
+++ b/front/app/translations/admin/en-CA.json
@@ -2498,7 +2498,6 @@
   "app.modules.commercial.analytics.admin.components.VisitorsTrafficSourcesCard.visits": "Visits",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.title": "Visitor Types",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.visitors": "Visitors",
-  "app.modules.commercial.analytics.admin.containers.visitors.dateInfo": "Unique visitor data is available from {date} onwards.",
   "app.modules.commercial.analytics.admin.containers.visitors.noData": "There is no visitor data yet.",
   "app.modules.commercial.analytics.admin.hooks.useActiveUsers.timeSeries": "Active users over time",
   "app.modules.commercial.analytics.admin.hooks.useEmailDeliveries.timeSeries": "Email deliveries over time",

--- a/front/app/translations/admin/en-GB.json
+++ b/front/app/translations/admin/en-GB.json
@@ -2498,7 +2498,6 @@
   "app.modules.commercial.analytics.admin.components.VisitorsTrafficSourcesCard.visits": "Visits",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.title": "Visitor Types",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.visitors": "Visitors",
-  "app.modules.commercial.analytics.admin.containers.visitors.dateInfo": "Unique visitor data is available from {date} onwards.",
   "app.modules.commercial.analytics.admin.containers.visitors.noData": "There is no visitor data yet.",
   "app.modules.commercial.analytics.admin.hooks.useActiveUsers.timeSeries": "Active users over time",
   "app.modules.commercial.analytics.admin.hooks.useEmailDeliveries.timeSeries": "Email deliveries over time",

--- a/front/app/translations/admin/en.json
+++ b/front/app/translations/admin/en.json
@@ -2498,7 +2498,7 @@
   "app.modules.commercial.analytics.admin.components.VisitorsTrafficSourcesCard.visits": "Visits",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.title": "Visitor Types",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.visitors": "Visitors",
-  "app.modules.commercial.analytics.admin.containers.visitors.dateInfo": "Unique visitor data is available from {date} onwards.",
+  "app.modules.commercial.analytics.admin.containers.visitors.cookieBannerUpdatedInfo": "Since December 2023 it's easier for users to reject cookies, which has a negative effect on perceived traffic.",
   "app.modules.commercial.analytics.admin.containers.visitors.noData": "There is no visitor data yet.",
   "app.modules.commercial.analytics.admin.hooks.useActiveUsers.timeSeries": "Active users over time",
   "app.modules.commercial.analytics.admin.hooks.useEmailDeliveries.timeSeries": "Email deliveries over time",

--- a/front/app/translations/admin/es-CL.json
+++ b/front/app/translations/admin/es-CL.json
@@ -2498,7 +2498,6 @@
   "app.modules.commercial.analytics.admin.components.VisitorsTrafficSourcesCard.visits": "Visitas",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.title": "Tipos de visitantes",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.visitors": "Visitantes",
-  "app.modules.commercial.analytics.admin.containers.visitors.dateInfo": "Los datos de visitantes únicos están disponibles a partir de {date} .",
   "app.modules.commercial.analytics.admin.containers.visitors.noData": "Aún no hay datos de visitantes.",
   "app.modules.commercial.analytics.admin.hooks.useActiveUsers.timeSeries": "Usuarios activos a lo largo del tiempo",
   "app.modules.commercial.analytics.admin.hooks.useEmailDeliveries.timeSeries": "Envíos de correo electrónico a lo largo del tiempo",

--- a/front/app/translations/admin/es-ES.json
+++ b/front/app/translations/admin/es-ES.json
@@ -2498,7 +2498,6 @@
   "app.modules.commercial.analytics.admin.components.VisitorsTrafficSourcesCard.visits": "Visitas",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.title": "Tipos de visitantes",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.visitors": "Visitantes",
-  "app.modules.commercial.analytics.admin.containers.visitors.dateInfo": "Los datos de visitantes únicos están disponibles a partir de {date} .",
   "app.modules.commercial.analytics.admin.containers.visitors.noData": "Aún no hay datos de visitantes.",
   "app.modules.commercial.analytics.admin.hooks.useActiveUsers.timeSeries": "Usuarios activos a lo largo del tiempo",
   "app.modules.commercial.analytics.admin.hooks.useEmailDeliveries.timeSeries": "Envíos de correo electrónico a lo largo del tiempo",

--- a/front/app/translations/admin/fr-BE.json
+++ b/front/app/translations/admin/fr-BE.json
@@ -2498,7 +2498,6 @@
   "app.modules.commercial.analytics.admin.components.VisitorsTrafficSourcesCard.visits": "Visites",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.title": "Types de visiteurs",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.visitors": "Visiteurs",
-  "app.modules.commercial.analytics.admin.containers.visitors.dateInfo": "Les données sur les visiteurs uniques sont disponibles à partir du {date} .",
   "app.modules.commercial.analytics.admin.containers.visitors.noData": "Il n'y a pas encore de données sur les visiteurs.",
   "app.modules.commercial.analytics.admin.hooks.useActiveUsers.timeSeries": "Utilisateurs actifs dans le temps",
   "app.modules.commercial.analytics.admin.hooks.useEmailDeliveries.timeSeries": "Livraisons d'e-mails dans le temps",

--- a/front/app/translations/admin/fr-FR.json
+++ b/front/app/translations/admin/fr-FR.json
@@ -2498,7 +2498,6 @@
   "app.modules.commercial.analytics.admin.components.VisitorsTrafficSourcesCard.visits": "Visites",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.title": "Types de visiteurs",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.visitors": "Visiteurs",
-  "app.modules.commercial.analytics.admin.containers.visitors.dateInfo": "Les données sur les visiteurs uniques sont disponibles à partir du {date} .",
   "app.modules.commercial.analytics.admin.containers.visitors.noData": "Il n'y a pas encore de données sur les visiteurs.",
   "app.modules.commercial.analytics.admin.hooks.useActiveUsers.timeSeries": "Utilisateurs actifs dans le temps",
   "app.modules.commercial.analytics.admin.hooks.useEmailDeliveries.timeSeries": "Livraisons d'e-mails dans le temps",

--- a/front/app/translations/admin/hr-HR.json
+++ b/front/app/translations/admin/hr-HR.json
@@ -2498,7 +2498,6 @@
   "app.modules.commercial.analytics.admin.components.VisitorsTrafficSourcesCard.visits": "Posjeti",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.title": "Vrste posjetitelja",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.visitors": "Posjetitelji",
-  "app.modules.commercial.analytics.admin.containers.visitors.dateInfo": "Podaci o jedinstvenim posjetiteljima dostupni su od {date} nadalje.",
   "app.modules.commercial.analytics.admin.containers.visitors.noData": "Još nema podataka o posjetiteljima.",
   "app.modules.commercial.analytics.admin.hooks.useActiveUsers.timeSeries": "Aktivni korisnika kroz vrijeme",
   "app.modules.commercial.analytics.admin.hooks.useEmailDeliveries.timeSeries": "Dostavljeno e-poruka kroz vrijeme",

--- a/front/app/translations/admin/lv-LV.json
+++ b/front/app/translations/admin/lv-LV.json
@@ -2498,7 +2498,6 @@
   "app.modules.commercial.analytics.admin.components.VisitorsTrafficSourcesCard.visits": "Apmeklējumi",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.title": "Apmeklētāju veidi",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.visitors": "Apmeklētāji",
-  "app.modules.commercial.analytics.admin.containers.visitors.dateInfo": "Unikālo apmeklētāju dati ir pieejami, sākot no {date} .",
   "app.modules.commercial.analytics.admin.containers.visitors.noData": "Pagaidām nav apmeklētāju datu.",
   "app.modules.commercial.analytics.admin.hooks.useActiveUsers.timeSeries": "Aktīvie lietotāji laika gaitā",
   "app.modules.commercial.analytics.admin.hooks.useEmailDeliveries.timeSeries": "E-pasta sūtījumi laika gaitā",

--- a/front/app/translations/admin/nb-NO.json
+++ b/front/app/translations/admin/nb-NO.json
@@ -2498,7 +2498,6 @@
   "app.modules.commercial.analytics.admin.components.VisitorsTrafficSourcesCard.visits": "Besøk",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.title": "Typer besøkende",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.visitors": "Besøkende",
-  "app.modules.commercial.analytics.admin.containers.visitors.dateInfo": "Unike besøksdata er tilgjengelig fra {date} og utover.",
   "app.modules.commercial.analytics.admin.containers.visitors.noData": "Det er ingen besøksdata ennå.",
   "app.modules.commercial.analytics.admin.hooks.useActiveUsers.timeSeries": "Aktive brukere over tid",
   "app.modules.commercial.analytics.admin.hooks.useEmailDeliveries.timeSeries": "E-postleveranser over tid",

--- a/front/app/translations/admin/nl-BE.json
+++ b/front/app/translations/admin/nl-BE.json
@@ -2498,7 +2498,6 @@
   "app.modules.commercial.analytics.admin.components.VisitorsTrafficSourcesCard.visits": "Bezoeken",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.title": "Bezoekerstypes",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.visitors": "Bezoekers",
-  "app.modules.commercial.analytics.admin.containers.visitors.dateInfo": "Gegevens over unieke bezoekers zijn beschikbaar vanaf {date}.",
   "app.modules.commercial.analytics.admin.containers.visitors.noData": "Er zijn nog geen bezoekersgegevens.",
   "app.modules.commercial.analytics.admin.hooks.useActiveUsers.timeSeries": "Actieve gebruikers in de loop van de tijd",
   "app.modules.commercial.analytics.admin.hooks.useEmailDeliveries.timeSeries": "E-mails geleverd in loop van tijd",

--- a/front/app/translations/admin/nl-NL.json
+++ b/front/app/translations/admin/nl-NL.json
@@ -2498,7 +2498,6 @@
   "app.modules.commercial.analytics.admin.components.VisitorsTrafficSourcesCard.visits": "Bezoeken",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.title": "Bezoekerstypes",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.visitors": "Bezoekers",
-  "app.modules.commercial.analytics.admin.containers.visitors.dateInfo": "Gegevens over unieke bezoekers zijn beschikbaar vanaf {date}.",
   "app.modules.commercial.analytics.admin.containers.visitors.noData": "Er zijn nog geen bezoekersgegevens.",
   "app.modules.commercial.analytics.admin.hooks.useActiveUsers.timeSeries": "Actieve gebruikers in de loop van de tijd",
   "app.modules.commercial.analytics.admin.hooks.useEmailDeliveries.timeSeries": "E-mails geleverd in loop van tijd",

--- a/front/app/translations/admin/pl-PL.json
+++ b/front/app/translations/admin/pl-PL.json
@@ -2498,7 +2498,6 @@
   "app.modules.commercial.analytics.admin.components.VisitorsTrafficSourcesCard.visits": "Odwiedziny",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.title": "Rodzaje odwiedzających",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.visitors": "Odwiedzający",
-  "app.modules.commercial.analytics.admin.containers.visitors.dateInfo": "Dane dotyczące unikalnych odwiedzających są dostępne od {date} .",
   "app.modules.commercial.analytics.admin.containers.visitors.noData": "Nie ma jeszcze danych dotyczących odwiedzających.",
   "app.modules.commercial.analytics.admin.hooks.useActiveUsers.timeSeries": "Aktywni użytkownicy w czasie",
   "app.modules.commercial.analytics.admin.hooks.useEmailDeliveries.timeSeries": "Dostawy wiadomości e-mail w czasie",

--- a/front/app/translations/admin/pt-BR.json
+++ b/front/app/translations/admin/pt-BR.json
@@ -2498,7 +2498,6 @@
   "app.modules.commercial.analytics.admin.components.VisitorsTrafficSourcesCard.visits": "Visitas",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.title": "Tipos de Visitantes",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.visitors": "Visitantes",
-  "app.modules.commercial.analytics.admin.containers.visitors.dateInfo": "Os dados de visitantes únicos estão disponíveis a partir de {date} .",
   "app.modules.commercial.analytics.admin.containers.visitors.noData": "Ainda não há dados de visitantes.",
   "app.modules.commercial.analytics.admin.hooks.useActiveUsers.timeSeries": "Usuários ativos ao longo do tempo",
   "app.modules.commercial.analytics.admin.hooks.useEmailDeliveries.timeSeries": "Entregas por e-mail ao longo do tempo",

--- a/front/app/translations/admin/sr-Latn.json
+++ b/front/app/translations/admin/sr-Latn.json
@@ -2498,7 +2498,6 @@
   "app.modules.commercial.analytics.admin.components.VisitorsTrafficSourcesCard.visits": "Posete",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.title": "Tipovi posetioca",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.visitors": "Posetioci",
-  "app.modules.commercial.analytics.admin.containers.visitors.dateInfo": "Unique visitor data is available from {date} onwards.",
   "app.modules.commercial.analytics.admin.containers.visitors.noData": "There is no visitor data yet.",
   "app.modules.commercial.analytics.admin.hooks.useActiveUsers.timeSeries": "Aktivni korisnici tokom vremena",
   "app.modules.commercial.analytics.admin.hooks.useEmailDeliveries.timeSeries": "Isporuka e-pošte tokom vremena",

--- a/front/app/translations/admin/sr-SP.json
+++ b/front/app/translations/admin/sr-SP.json
@@ -2498,7 +2498,6 @@
   "app.modules.commercial.analytics.admin.components.VisitorsTrafficSourcesCard.visits": "Посете",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.title": "Типови посетилаца",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.visitors": "Посетиоци",
-  "app.modules.commercial.analytics.admin.containers.visitors.dateInfo": "Јединствени подаци о посетиоцима доступни су од {date} па надаље.",
   "app.modules.commercial.analytics.admin.containers.visitors.noData": "There is no visitor data yet.",
   "app.modules.commercial.analytics.admin.hooks.useActiveUsers.timeSeries": "Активни корисници током времена",
   "app.modules.commercial.analytics.admin.hooks.useEmailDeliveries.timeSeries": "Испоруке путем е-поште током времена",

--- a/front/app/translations/admin/sv-SE.json
+++ b/front/app/translations/admin/sv-SE.json
@@ -2498,7 +2498,6 @@
   "app.modules.commercial.analytics.admin.components.VisitorsTrafficSourcesCard.visits": "Besök",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.title": "Typer av besökare",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.visitors": "Besökare",
-  "app.modules.commercial.analytics.admin.containers.visitors.dateInfo": "Unika besöksdata finns tillgängliga från {date} och framåt.",
   "app.modules.commercial.analytics.admin.containers.visitors.noData": "Det finns ännu inga besöksdata.",
   "app.modules.commercial.analytics.admin.hooks.useActiveUsers.timeSeries": "Aktiva användare över tid",
   "app.modules.commercial.analytics.admin.hooks.useEmailDeliveries.timeSeries": "E-postleveranser över tid",

--- a/front/app/translations/admin/tr-TR.json
+++ b/front/app/translations/admin/tr-TR.json
@@ -2498,7 +2498,6 @@
   "app.modules.commercial.analytics.admin.components.VisitorsTrafficSourcesCard.visits": "Ziyaretler",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.title": "Ziyaretçi Türleri",
   "app.modules.commercial.analytics.admin.components.VisitorsTypesCard.visitors": "Ziyaretçiler",
-  "app.modules.commercial.analytics.admin.containers.visitors.dateInfo": "Tekil ziyaretçi verilerine {date} adresinden ulaşılabilir.",
   "app.modules.commercial.analytics.admin.containers.visitors.noData": "Henüz ziyaretçi verisi bulunmamaktadır.",
   "app.modules.commercial.analytics.admin.hooks.useActiveUsers.timeSeries": "Zaman içinde aktif kullanıcılar",
   "app.modules.commercial.analytics.admin.hooks.useEmailDeliveries.timeSeries": "Zaman içinde e-posta teslimatları",

--- a/front/app/translations/en.json
+++ b/front/app/translations/en.json
@@ -86,6 +86,7 @@
   "app.components.ConsentManager.Banner.mainText": "This platform uses cookies in accordance with our {policyLink}.",
   "app.components.ConsentManager.Banner.manage": "Manage",
   "app.components.ConsentManager.Banner.policyLink": "Cookie policy",
+  "app.components.ConsentManager.Banner.reject": "Reject",
   "app.components.ConsentManager.Banner.subText": "Click \"Accept\" to allow cookies to be used or \"Manage\" to change your cookie settings.",
   "app.components.ConsentManager.Modal.CancelDialog.confirm": "Confirm",
   "app.components.ConsentManager.Modal.CancelDialog.confirmation": "If you cancel, your preferences will be lost.",


### PR DESCRIPTION
# Description
It was decided to just add a simple button to the existing cookie banner for "reject" for now. Also changed the styling of the manage button:
![image](https://github.com/CitizenLabDotCo/citizenlab/assets/33987955/982109ce-92c7-4e1e-b9a2-28133daa1810)
![image](https://github.com/CitizenLabDotCo/citizenlab/assets/33987955/38936b18-bb49-4189-a5b1-75afe6b66240)


# Changelog
## Added
- [[TAN-664]](https://www.notion.so/citizenlab/Cookie-policy-Reject-All-73604db75a374872a69c9aa9a5215030) Added a simple "Reject" button to the existing cookie banner
