### PR TITLE
[TAN-650] Fix proposal vote bar UI bug when vote requirement exceeded

### DIFF
--- a/front/app/components/UI/ProgressBar/index.tsx
+++ b/front/app/components/UI/ProgressBar/index.tsx
@@ -58,7 +58,7 @@ const ProgressBar = ({
         background={bgShaded === true ? `url("${warningPattern}")` : bgColor}
       >
         <ProgressBarInner
-          progress={progress}
+          progress={progress > 1 ? 1 : progress}
           className={visible ? 'visible' : ''}
           color={color}
         />

--- a/front/app/components/UI/ProgressBar/index.tsx
+++ b/front/app/components/UI/ProgressBar/index.tsx
@@ -26,7 +26,6 @@ const ProgressBarInner: any = styled.div<{ progress: number; color: string }>`
 `;
 
 interface Props {
-  /** Number between 0 and 1 */
   progress: number;
   color: string;
   bgColor: string;

--- a/front/app/containers/InitiativesShow/ReactionControl/ProposalProgressBar.tsx
+++ b/front/app/containers/InitiativesShow/ReactionControl/ProposalProgressBar.tsx
@@ -31,9 +31,7 @@ const ProposalProgressBar = ({
   return (
     <div className={className}>
       <StyledProgressBar
-        progress={
-          reactionCount > reactionLimit ? 1 : reactionCount / reactionLimit
-        } // If the limit is surpassed, set progress bar to 100% to prevent overflow
+        progress={reactionCount / reactionLimit}
         color={barColor || theme.colors.tenantText}
         bgColor={colors.grey200}
         bgShaded={bgShaded}

--- a/front/app/containers/InitiativesShow/ReactionControl/ProposalProgressBar.tsx
+++ b/front/app/containers/InitiativesShow/ReactionControl/ProposalProgressBar.tsx
@@ -27,10 +27,13 @@ const ProposalProgressBar = ({
   className,
 }: Props) => {
   const theme = useTheme();
+
   return (
     <div className={className}>
       <StyledProgressBar
-        progress={reactionCount / reactionLimit}
+        progress={
+          reactionCount > reactionLimit ? 1 : reactionCount / reactionLimit
+        } // If the limit is surpassed, set progress bar to 100% to prevent overflow
         color={barColor || theme.colors.tenantText}
         bgColor={colors.grey200}
         bgShaded={bgShaded}


### PR DESCRIPTION
# Changelog
## Fixed
- Fixed the UI bug where when a proposal received more votes than what was required the bar in the proposal card overflowed outside of the card. Now if a proposal has more votes than what was required, the bar just stays at 100% filled.
