### PR TITLE
[NO-TICKET] Install missing lsb_release executable

### DIFF
--- a/back/Dockerfile.development
+++ b/back/Dockerfile.development
@@ -1,6 +1,7 @@
 FROM ruby:2.7.6-slim
 
 RUN apt-get update && apt-get install -qq -y --no-install-recommends \
+      lsb-release          \
       build-essential      \
       libpq-dev            \
       file                 \


### PR DESCRIPTION
# Changelog
## Technical
- Install missing `lsb_release` executable in `Dockerfile.development`.
