### PR TITLE
TAN-683 TAN-748 Fix homepage builder bugs

### DIFF
--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/CraftComponents/HomepageBanner/OverlayControls.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/CraftComponents/HomepageBanner/OverlayControls.tsx
@@ -48,7 +48,8 @@ interface Props {
   noOpacitySlider?: boolean;
 }
 
-const defaultOpacity = 0.9;
+const defaultOpacity = 90;
+const defaultOverlayColor = colors.primary;
 
 const OverlayControls = ({
   bannerOverlayOpacity,
@@ -67,8 +68,8 @@ const OverlayControls = ({
       onOverlayChange(0, theme.colors.tenantPrimary);
     } else {
       onOverlayChange(
-        bannerOverlayOpacity || defaultOpacity,
-        bannerOverlayColor || theme.colors.tenantPrimary
+        defaultOpacity,
+        bannerOverlayColor || theme.colors.tenantPrimary || defaultOverlayColor
       );
     }
 
@@ -78,7 +79,10 @@ const OverlayControls = ({
   const handleOverlayOpacityOnChange = (
     opacity: Props['bannerOverlayOpacity']
   ) => {
-    onOverlayChange(opacity, bannerOverlayColor || theme.colors.tenantPrimary);
+    onOverlayChange(
+      opacity,
+      bannerOverlayColor || theme.colors.tenantPrimary || defaultOverlayColor
+    );
   };
 
   const handleOverlayColorOnChange = (color: Props['bannerOverlayColor']) => {
@@ -121,7 +125,7 @@ const OverlayControls = ({
               id="image-overlay-color"
               label={formatMessage(messages.imageOverlayColor)}
               type="text"
-              value={bannerOverlayColor}
+              value={bannerOverlayColor || defaultOverlayColor}
               onChange={handleOverlayColorOnChange}
             />
           </Box>

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/CraftComponents/HomepageBanner/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/CraftComponents/HomepageBanner/index.tsx
@@ -404,34 +404,29 @@ const HomepageBannerSettings = () => {
         p="4px"
         background={colors.grey400}
       >
-        <Box flex="1">
-          <Button
-            onClick={() => {
-              setSearchParams({ variant: 'signedOut' });
-            }}
-            buttonStyle={
-              search.get('variant') !== 'signedIn' ? 'white' : 'text'
-            }
-            fontSize="14px"
-            id="e2e-signed-out-button"
-          >
-            {formatMessage(messages.nonRegistedredUsersView)}
-          </Button>
-        </Box>
-        <Box flex="1">
-          <Button
-            onClick={() => {
-              setSearchParams({ variant: 'signedIn' });
-            }}
-            buttonStyle={
-              search.get('variant') === 'signedIn' ? 'white' : 'text'
-            }
-            fontSize="14px"
-            id="e2e-signed-in-button"
-          >
-            {formatMessage(messages.registeredUsersView)}
-          </Button>
-        </Box>
+        <Button
+          onClick={() => {
+            setSearchParams({ variant: 'signedOut' });
+          }}
+          buttonStyle={search.get('variant') !== 'signedIn' ? 'white' : 'text'}
+          fontSize="14px"
+          id="e2e-signed-out-button"
+          whiteSpace="wrap"
+        >
+          {formatMessage(messages.nonRegistedredUsersView)}
+        </Button>
+
+        <Button
+          onClick={() => {
+            setSearchParams({ variant: 'signedIn' });
+          }}
+          buttonStyle={search.get('variant') === 'signedIn' ? 'white' : 'text'}
+          fontSize="14px"
+          id="e2e-signed-in-button"
+          whiteSpace="wrap"
+        >
+          {formatMessage(messages.registeredUsersView)}
+        </Button>
       </Box>
 
       {search.get('variant') !== 'signedIn' && (

--- a/front/cypress/e2e/admin/homepage_builder.cy.ts
+++ b/front/cypress/e2e/admin/homepage_builder.cy.ts
@@ -225,7 +225,6 @@ describe('Homepage builder', () => {
     cy.intercept('GET', '**/home_pages/content_builder_layouts/homepage').as(
       'getHomePage'
     );
-    cy.intercept('GET', '**/home_page').as('getOriginalHomePage');
     cy.intercept('GET', '**/pages-menu').as('getPages');
     cy.intercept('GET', '**/nav_bar_items').as('getNavbarItems');
     cy.intercept('POST', '**/content_builder_layout_images').as('postImage');
@@ -302,7 +301,6 @@ describe('Homepage builder', () => {
     cy.visit('/admin/pages-menu/homepage-builder');
 
     cy.wait('@getHomePage');
-    cy.wait('@getOriginalHomePage');
     cy.wait('@getNavbarItems');
     cy.wait(6000);
 


### PR DESCRIPTION
# Changelog
## Fixed
- The homepage builder no longer crashes when a new overlay color is set if there was no overlay color previously. We have also introduced a default overlay color which is the tenant's primary color.
- The buttons that toggle between the signed-in and signed-out view for the homepage builder preview now look as expected for all languages
