### PR TITLE
[NO-TICKET] Resolve homepage crash when image prop is missing

### DIFF
--- a/front/app/containers/App/Meta.tsx
+++ b/front/app/containers/App/Meta.tsx
@@ -39,7 +39,7 @@ const Meta = () => {
     const headerBg = homepageLayout.data.attributes.craftjs_json
       ? Object.values(homepageLayout.data.attributes.craftjs_json).find(
           (node) => node.displayName === 'HomepageBanner'
-        )?.props.image.imageUrl
+        )?.props.image?.imageUrl
       : '';
 
     const organizationNameMultiLoc =


### PR DESCRIPTION
# Changelog
## Fixed
- Homepage no longer crashes on platform creation when the homepage banner image attribute is missing
