### PR TITLE
[TAN-747] Fix: Changing the order of geographical areas is not working. 

### DIFF
--- a/back/app/controllers/web_api/v1/areas_controller.rb
+++ b/back/app/controllers/web_api/v1/areas_controller.rb
@@ -106,6 +106,7 @@ class WebApi::V1::AreasController < ApplicationController
   def area_params
     params.require(:area).permit(
       :include_in_onboarding,
+      :ordering,
       title_multiloc: CL2_SUPPORTED_LOCALES,
       description_multiloc: CL2_SUPPORTED_LOCALES
     )

--- a/back/app/controllers/web_api/v1/areas_controller.rb
+++ b/back/app/controllers/web_api/v1/areas_controller.rb
@@ -2,7 +2,7 @@
 
 class WebApi::V1::AreasController < ApplicationController
   before_action :set_area, except: %i[index create]
-  before_action :set_side_effects_service, only: %i[create update reorder destroy]
+  before_action :set_side_effects_service, only: %i[create update destroy]
   skip_before_action :authenticate_user, only: %i[index show]
 
   def index
@@ -81,16 +81,6 @@ class WebApi::V1::AreasController < ApplicationController
     if @area.destroy
       @side_fx_service.after_destroy(@area, current_user)
       head :ok
-    else
-      render json: { errors: @area.errors.details }, status: :unprocessable_entity
-    end
-  end
-
-  def reorder
-    @side_fx_service.before_update(@area, current_user)
-    if @area.insert_at(permitted_attributes(@area)[:ordering])
-      @side_fx_service.after_update(@area, current_user)
-      render json: WebApi::V1::AreaSerializer.new(@area.reload, params: jsonapi_serializer_params).serializable_hash, status: :ok
     else
       render json: { errors: @area.errors.details }, status: :unprocessable_entity
     end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -131,8 +131,6 @@ Rails.application.routes.draw do
       end
 
       resources :areas do
-        patch 'reorder', on: :member
-
         resources :followers, only: [:create], defaults: { followable: 'Area' }
       end
 

--- a/back/spec/acceptance/areas_spec.rb
+++ b/back/spec/acceptance/areas_spec.rb
@@ -43,7 +43,7 @@ resource 'Areas' do
   end
 
   get 'web_api/v1/areas/:id' do
-    let(:areas) { create_list(:area, 2)}
+    let(:areas) { create_list(:area, 2) }
     let(:id) { areas.first.id }
 
     example_request 'Get one area by id' do
@@ -169,25 +169,6 @@ resource 'Areas' do
         expect(response_status).to eq 200
         expect { Area.find(id) }.to raise_error(ActiveRecord::RecordNotFound)
         expect(user.reload.custom_field_values).to eq({})
-      end
-    end
-
-    patch 'web_api/v1/areas/:id/reorder' do
-      with_options scope: :area do
-        parameter :ordering, 'The position, starting from 0, where the area should be at. Publications after will move down.', required: true
-      end
-
-      let!(:id) { create_list(:area, 3).last.id }
-      let(:ordering) { 1 }
-
-      example 'Reorder an Area' do
-        area = Area.find_by(ordering: ordering)
-        do_request
-        assert_status 200
-        json_response = json_parse(response_body)
-        expect(json_response.dig(:data, :attributes, :ordering)).to match ordering
-        expect(Area.find(id).ordering).to eq(ordering)
-        expect(area.reload.ordering).to eq 2 # previous second is now third
       end
     end
   end


### PR DESCRIPTION
# Changelog
## Fix
- [TAN-747] Geographical areas can now be reordered as expected in the back office.
