### PR TITLE
Opacity signed-in banner when banner layout is "fixed-ratio"

### DIFF
--- a/front/app/containers/HomePage/SignedInHeader/HeaderImage.tsx
+++ b/front/app/containers/HomePage/SignedInHeader/HeaderImage.tsx
@@ -50,11 +50,6 @@ const HeaderImage = ({
     return (
       <HeaderImageContainer>
         <HeaderImageContainerInner data-cy="e2e-signed-in-header-image-parent">
-          {/*
-            With the fixed ratio layout, the image would be pixeled so we
-            don't show it for that layout.
-            Ticket: https://citizenlab.atlassian.net/browse/CL-2215
-          */}
           {tenantHeaderImage && (
             <StyledImage
               data-cy="e2e-signed-in-header-image"

--- a/front/app/containers/HomePage/SignedInHeader/HeaderImage.tsx
+++ b/front/app/containers/HomePage/SignedInHeader/HeaderImage.tsx
@@ -70,10 +70,6 @@ const HeaderImage = ({
               homepageSettings.banner_signed_in_header_overlay_color ||
               theme.colors.tenantPrimary
             }
-            // With this fixed ratio layout, we don't have an image (see above),
-            // so we set opacity to 1.
-            // Ticket: https://citizenlab.atlassian.net/browse/CL-2215
-
             opacity={
               typeof homepageSettings.banner_signed_in_header_overlay_opacity ===
               'number'

--- a/front/app/containers/HomePage/SignedInHeader/HeaderImage.tsx
+++ b/front/app/containers/HomePage/SignedInHeader/HeaderImage.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import styled, { useTheme } from 'styled-components';
 import { Image, Box, media, isRtl } from '@citizenlab/cl2-component-library';
 import { IHomepageBannerSettings } from 'containers/Admin/pagesAndMenu/containers/ContentBuilder/components/CraftComponents/HomepageBanner';
-import { isNumber } from 'lodash-es';
 
 const HeaderImageContainer = styled.div`
   position: absolute;
@@ -48,8 +47,6 @@ const HeaderImage = ({
     const tenantHeaderImage = homepageSettings.header_bg
       ? homepageSettings.header_bg.large
       : null;
-    const isFixedBannerLayout =
-      homepageSettings.banner_layout === 'fixed_ratio_layout';
     return (
       <HeaderImageContainer>
         <HeaderImageContainerInner data-cy="e2e-signed-in-header-image-parent">
@@ -58,7 +55,7 @@ const HeaderImage = ({
             don't show it for that layout.
             Ticket: https://citizenlab.atlassian.net/browse/CL-2215
           */}
-          {tenantHeaderImage && !isFixedBannerLayout && (
+          {tenantHeaderImage && (
             <StyledImage
               data-cy="e2e-signed-in-header-image"
               alt="" // Image is decorative, so alt tag is empty
@@ -78,11 +75,8 @@ const HeaderImage = ({
             // Ticket: https://citizenlab.atlassian.net/browse/CL-2215
 
             opacity={
-              isFixedBannerLayout
-                ? 1
-                : isNumber(
-                    homepageSettings.banner_signed_in_header_overlay_opacity
-                  )
+              typeof homepageSettings.banner_signed_in_header_overlay_opacity ===
+              'number'
                 ? homepageSettings.banner_signed_in_header_overlay_opacity / 100
                 : 0.9
             }


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

# Changed
- When the signed-out banner layout is "fixed-ratio", we won't automatically set a fixed, non-transparent background on the signed-in banner image anymore.
    - [Before](https://github.com/CitizenLabDotCo/citizenlab/assets/16427929/057a1ae9-b41f-499d-84f3-f4f00892a651): when signed-out banner is "fixed-ratio", the signed-in banner automatically got the non-transparant overlay, with the 'Enable overlay' toggle's value not being respected.
    - [After](https://github.com/CitizenLabDotCo/citizenlab/assets/16427929/3ca8e296-83db-4b39-b0a7-071d37a5faef): "Enable overlay" toggle's value is respected again when signed-out banner is "fixed-ratio".
