### PR TITLE
Remove unnecessary logic from widget hooks

### DIFF
--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/CommentsByTimeWidget/useCommentsByTime/index.ts
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/CommentsByTimeWidget/useCommentsByTime/index.ts
@@ -1,19 +1,9 @@
-// i18n
-import { useIntl } from 'utils/cl-intl';
-import { getTranslations } from 'components/admin/GraphCards/CommentsByTimeCard/useCommentsByTime/translations';
-
 // hooks
 import { useMemo, useState } from 'react';
 import useGraphDataUnits from 'api/graph_data_units/useGraphDataUnits';
 
 // parse
-import {
-  parseTimeSeries,
-  parseExcelData,
-} from 'components/admin/GraphCards/CommentsByTimeCard/useCommentsByTime/parse';
-
-// utils
-import { getFormattedNumbers } from 'components/admin/GraphCards/_utils/parse';
+import { parseTimeSeries } from 'components/admin/GraphCards/CommentsByTimeCard/useCommentsByTime/parse';
 
 // typings
 import {
@@ -27,8 +17,7 @@ export default function useCommentsByTime({
   endAtMoment,
   resolution,
 }: QueryParameters) {
-  const { formatMessage } = useIntl();
-  const [currentResolution] = useState(resolution);
+  const [currentResolution, setCurrentResolution] = useState(resolution);
 
   const analytics = useGraphDataUnits<Response>({
     resolvedName: 'CommentsByTimeWidget',
@@ -38,6 +27,7 @@ export default function useCommentsByTime({
       endAtMoment,
       resolution,
     },
+    onSuccess: () => setCurrentResolution(resolution),
   });
 
   const timeSeries = useMemo(
@@ -54,21 +44,5 @@ export default function useCommentsByTime({
     [analytics?.data, startAtMoment, endAtMoment, currentResolution]
   );
 
-  const xlsxData = useMemo(
-    () =>
-      analytics?.data && timeSeries
-        ? parseExcelData(timeSeries, getTranslations(formatMessage))
-        : null,
-    [analytics?.data, timeSeries, formatMessage]
-  );
-
-  const formattedNumbers = timeSeries
-    ? getFormattedNumbers(timeSeries, timeSeries[0].comments)
-    : {
-        totalNumber: null,
-        formattedSerieChange: null,
-        typeOfChange: '',
-      };
-
-  return { currentResolution, timeSeries, xlsxData, formattedNumbers };
+  return { currentResolution, timeSeries };
 }

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/PostsByTimeWidget/usePostsByTime/index.ts
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/PostsByTimeWidget/usePostsByTime/index.ts
@@ -2,19 +2,8 @@ import { useMemo, useState } from 'react';
 
 // hooks
 import useGraphDataUnits from 'api/graph_data_units/useGraphDataUnits';
-
-// i18n
-import { useIntl } from 'utils/cl-intl';
-import { getTranslations } from 'components/admin/GraphCards/PostsByTimeCard/usePostsByTime/translations';
-
 // parse
-import {
-  parseTimeSeries,
-  parseExcelData,
-} from 'components/admin/GraphCards/PostsByTimeCard/usePostsByTime/parse';
-
-// utils
-import { getFormattedNumbers } from 'components/admin/GraphCards/_utils/parse';
+import { parseTimeSeries } from 'components/admin/GraphCards/PostsByTimeCard/usePostsByTime/parse';
 
 // typings
 import {
@@ -28,7 +17,6 @@ export default function usePostsByTime({
   endAtMoment,
   resolution,
 }: QueryParameters) {
-  const { formatMessage } = useIntl();
   const [currentResolution] = useState(resolution);
 
   const analytics = useGraphDataUnits<Response>({
@@ -55,21 +43,5 @@ export default function usePostsByTime({
     [analytics?.data, startAtMoment, endAtMoment, currentResolution]
   );
 
-  const xlsxData = useMemo(
-    () =>
-      analytics?.data && timeSeries
-        ? parseExcelData(timeSeries, getTranslations(formatMessage))
-        : null,
-    [analytics?.data, timeSeries, formatMessage]
-  );
-
-  const formattedNumbers = timeSeries
-    ? getFormattedNumbers(timeSeries, timeSeries[0].inputs)
-    : {
-        totalNumber: null,
-        formattedSerieChange: null,
-        typeOfChange: '',
-      };
-
-  return { currentResolution, timeSeries, xlsxData, formattedNumbers };
+  return { currentResolution, timeSeries };
 }

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/ReactionsByTimeWidget/useReactionsByTime/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/ReactionsByTimeWidget/useReactionsByTime/index.tsx
@@ -3,18 +3,8 @@ import { useMemo, useState } from 'react';
 // hooks
 import useGraphDataUnits from 'api/graph_data_units/useGraphDataUnits';
 
-// i18n
-import { useIntl } from 'utils/cl-intl';
-import { getTranslations } from 'components/admin/GraphCards/ReactionsByTimeCard/useReactionsByTime/translations';
-
 // parse
-import {
-  parseTimeSeries,
-  parseExcelData,
-} from 'components/admin/GraphCards/ReactionsByTimeCard/useReactionsByTime/parse';
-
-// utils
-import { getFormattedNumbers } from 'components/admin/GraphCards/_utils/parse';
+import { parseTimeSeries } from 'components/admin/GraphCards/ReactionsByTimeCard/useReactionsByTime/parse';
 
 // typings
 import {
@@ -28,7 +18,6 @@ export default function useReactionsByTime({
   endAtMoment,
   resolution,
 }: QueryParameters) {
-  const { formatMessage } = useIntl();
   const [currentResolution] = useState(resolution);
 
   const analytics = useGraphDataUnits<Response>({
@@ -55,26 +44,5 @@ export default function useReactionsByTime({
     [analytics?.data, startAtMoment, endAtMoment, currentResolution]
   );
 
-  const xlsxData = useMemo(
-    () =>
-      analytics?.data && timeSeries
-        ? parseExcelData(timeSeries, getTranslations(formatMessage))
-        : null,
-    [analytics?.data, timeSeries, formatMessage]
-  );
-
-  const firstSerieBar =
-    timeSeries && timeSeries.length > 0
-      ? timeSeries[0].likes + timeSeries[0].dislikes
-      : 0;
-
-  const formattedNumbers = timeSeries
-    ? getFormattedNumbers(timeSeries, firstSerieBar)
-    : {
-        totalNumber: null,
-        formattedSerieChange: null,
-        typeOfChange: '',
-      };
-
-  return { currentResolution, timeSeries, xlsxData, formattedNumbers };
+  return { currentResolution, timeSeries };
 }

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/VisitorsTrafficSourcesWidget/useVisitorReferrerTypes/index.ts
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/VisitorsTrafficSourcesWidget/useVisitorReferrerTypes/index.ts
@@ -3,10 +3,7 @@ import { useIntl } from 'utils/cl-intl';
 import { getTranslations } from 'components/admin/GraphCards/VisitorsTrafficSourcesCard/useVisitorReferrerTypes/translations';
 
 // parse
-import {
-  parsePieData,
-  parseExcelData,
-} from 'components/admin/GraphCards/VisitorsTrafficSourcesCard/useVisitorReferrerTypes/parse';
+import { parsePieData } from 'components/admin/GraphCards/VisitorsTrafficSourcesCard/useVisitorReferrerTypes/parse';
 
 // typings
 import {
@@ -36,7 +33,6 @@ export default function useVisitorsReferrerTypes({
   const pieData = analytics
     ? parsePieData(analytics.data.attributes, translations)
     : null;
-  const xlsxData = pieData ? parseExcelData(pieData, translations) : null;
 
-  return { pieData, xlsxData };
+  return { pieData };
 }

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/VisitorsWidget/useVisitors/index.ts
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/VisitorsWidget/useVisitors/index.ts
@@ -16,6 +16,7 @@ export default function useVisitorsData({
 }: QueryParameters) {
   const [currentResolution, setCurrentResolution] =
     useState<IResolution>(resolution);
+
   const analytics = useGraphDataUnits<Response>({
     resolvedName: 'VisitorsWidget',
     queryParameters: {


### PR DESCRIPTION
To improve folder structure, one thing we could still think about is:

Right now we have e.g. two `usePostsByTime` hooks, one nested in the `GraphCards` folder, and one nested in the `ReportBuilder` folder, with the one in the `GraphCards` folder containing stuff like `typings` and `parse` functions. The one in the `ReportBuilder` folder imports those.

Maybe we could instead, in the `api/graph_data_units` folder, create a sub-folder called `graphs` or something, and in there put all of these hooks and shared logic?

Or maybe better to decide on this later, after we finish converting all graph endpoints (and maybe even add some new ones)?