### PR TITLE
TAN-797 Fix report builder widget paddings

### DIFF
--- a/front/app/components/admin/ContentBuilder/Widgets/ImageMultiloc/index.tsx
+++ b/front/app/components/admin/ContentBuilder/Widgets/ImageMultiloc/index.tsx
@@ -94,7 +94,7 @@ const Image = ({ alt = {}, image }: Props) => {
   );
 };
 
-const ImageSettings = injectIntl(({ intl: { formatMessage } }) => {
+export const ImageSettings = injectIntl(({ intl: { formatMessage } }) => {
   const [imageFiles, setImageFiles] = useState<UploadFile[]>([]);
   const { mutateAsync: addContentBuilderImage } = useAddContentBuilderImage();
   const {

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Editor/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Editor/index.tsx
@@ -9,12 +9,12 @@ import RenderNode from './RenderNode';
 
 // shared widgets
 import Container from 'components/admin/ContentBuilder/Widgets/Container';
-import ImageMultiloc from 'components/admin/ContentBuilder/Widgets/ImageMultiloc';
 import WhiteSpace from 'components/admin/ContentBuilder/Widgets/WhiteSpace';
 
 // report builder widgets
 import TitleMultiloc from '../Widgets/TitleMultiloc';
 import TextMultiloc from '../Widgets/TextMultiloc';
+import ImageMultiloc from '../Widgets/ImageMultiloc';
 import TwoColumn from '../Widgets/TwoColumn';
 import AboutReportWidget from '../Widgets/AboutReportWidget';
 import SurveyResultsWidget from '../Widgets/SurveyResultsWidget';

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Toolbox/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Toolbox/index.tsx
@@ -7,12 +7,12 @@ import { Box, Title, Accordion } from '@citizenlab/cl2-component-library';
 
 // shared widgets
 import WhiteSpace from 'components/admin/ContentBuilder/Widgets/WhiteSpace';
-import ImageMultiloc from 'components/admin/ContentBuilder/Widgets/ImageMultiloc';
 
 // widgets
 import TextMultiloc from '../Widgets/TextMultiloc';
 import TwoColumn from '../Widgets/TwoColumn';
 import TitleMultiloc from '../Widgets/TitleMultiloc';
+import ImageMultiloc from '../Widgets/ImageMultiloc';
 import AboutReportWidget from '../Widgets/AboutReportWidget';
 import SurveyResultsWidget from '../Widgets/SurveyResultsWidget';
 import VisitorsWidget from '../Widgets/ChartWidgets/VisitorsWidget';

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ImageMultiloc/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ImageMultiloc/index.tsx
@@ -1,0 +1,96 @@
+import React, { useCallback } from 'react';
+
+// components
+import {
+  Image as ImageComponent,
+  colors,
+  Icon,
+} from '@citizenlab/cl2-component-library';
+import { ImageSettings } from 'components/admin/ContentBuilder/Widgets/ImageMultiloc';
+import PageBreakBox from 'components/admin/ContentBuilder/Widgets/PageBreakBox';
+
+// image upload
+import { Multiloc } from 'typings';
+
+// craft
+import { useEditor } from '@craftjs/core';
+import useReportDefaultPadding from 'containers/Admin/reporting/hooks/useReportDefaultPadding';
+
+// i18n
+import messages from 'components/admin/ContentBuilder/Widgets/ImageMultiloc/messages';
+
+// events
+import eventEmitter from 'utils/eventEmitter';
+import { IMAGE_LOADED_EVENT } from 'components/admin/ContentBuilder/constants';
+
+// hooks
+import useLocalize from 'hooks/useLocalize';
+
+interface Props {
+  image?: {
+    dataCode?: string;
+    imageUrl?: string;
+  };
+  alt?: Multiloc;
+}
+
+const Image = ({ alt = {}, image }: Props) => {
+  const componentDefaultPadding = useReportDefaultPadding();
+
+  const localize = useLocalize();
+  const { enabled } = useEditor((state) => {
+    return {
+      enabled: state.options.enabled,
+    };
+  });
+
+  const emitImageLoaded = useCallback(() => {
+    if (!image?.imageUrl) return;
+    eventEmitter.emit(IMAGE_LOADED_EVENT, image?.imageUrl);
+  }, [image?.imageUrl]);
+
+  return (
+    <PageBreakBox
+      width="100%"
+      display="flex"
+      id="e2e-image"
+      style={{ pointerEvents: 'none' }}
+      minHeight="26px"
+      maxWidth="1200px"
+      margin="0 auto"
+      px={componentDefaultPadding}
+    >
+      {image?.imageUrl && (
+        <ImageComponent
+          width="100%"
+          src={image?.imageUrl}
+          alt={localize(alt) || ''}
+          data-code={image?.dataCode}
+          onLoad={emitImageLoaded}
+        />
+      )}
+      {/* In edit view, show an image placeholder if image is not set. */}
+      {!image?.imageUrl && enabled && (
+        <Icon
+          margin="auto"
+          padding="24px"
+          width="100px"
+          height="100px"
+          fill={colors.grey500}
+          name="image"
+        />
+      )}
+    </PageBreakBox>
+  );
+};
+
+Image.craft = {
+  related: {
+    settings: ImageSettings,
+  },
+  custom: {
+    title: messages.imageMultiloc,
+  },
+};
+
+export default Image;

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/MostReactedIdeasWidget/Ideas/IdeaCard.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/MostReactedIdeasWidget/Ideas/IdeaCard.tsx
@@ -4,11 +4,10 @@ import React, { useState, useRef, useEffect } from 'react';
 import useIdeaImages from 'api/idea_images/useIdeaImages';
 
 // styling
-import styled from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 import {
   colors,
   stylingConsts,
-  fontSizes,
   Box,
   Text,
   Title,
@@ -21,6 +20,7 @@ import { BORDER } from '../../constants';
 import Link from 'utils/cl-router/Link';
 import PageBreakBox from 'components/admin/ContentBuilder/Widgets/PageBreakBox';
 import GradientSrc from './gradient.svg';
+import QuillEditedContent from 'components/UI/QuillEditedContent';
 
 // i18n
 import messages from '../messages';
@@ -42,8 +42,6 @@ interface Props {
 }
 
 const IdeaText = styled.div`
-  font-size: ${fontSizes.m}px;
-  color: ${colors.primary};
   line-height: ${MEDIUM_LINE_HEIGHT}px;
 `;
 
@@ -61,6 +59,8 @@ const IdeaCard = ({
   const textContainerRef = useRef<HTMLDivElement | null>(null);
   const [textOverflow, setTextOverflow] = useState(false);
   const { data: images } = useIdeaImages(id);
+  const theme = useTheme();
+
   const image = images?.data[0]?.attributes?.versions?.medium;
 
   useEffect(() => {
@@ -129,10 +129,17 @@ const IdeaCard = ({
           >
             <Image src={GradientSrc} alt="" width="100%" height="100%" />
           </Box>
-          <IdeaText
-            dangerouslySetInnerHTML={{ __html: body }}
-            ref={textContainerRef}
-          />
+          <Box mt="12px">
+            <QuillEditedContent
+              textColor={theme.colors.tenantText}
+              fontSize="m"
+            >
+              <IdeaText
+                dangerouslySetInnerHTML={{ __html: body }}
+                ref={textContainerRef}
+              />
+            </QuillEditedContent>
+          </Box>
         </Box>
       </Box>
       {hideTextOverflow && (


### PR DESCRIPTION
# Changelog
## Fixed
- Report builder: image widget now always has correct padding
- Report builder: before, images inside of the description of ideas shown in the 'most reacted ideas' widget, were shown full-width. This means that large images would be sticking out of the widget and look really messed up. This is now fixed- images will stay nicely inside of the widget.