### PR TITLE
[NO-TICKET] Pin ruby version in Gemfile

### DIFF
--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -7,7 +7,7 @@ SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 WORKDIR /app
 
-COPY back/Gemfile back/Gemfile.* ./
+COPY back/Gemfile back/Gemfile.* back/.ruby-version ./
 COPY back/engines ./engines
 
 # `version.rb` files are also kept as they are required by gemspec files.

--- a/back/Dockerfile.development
+++ b/back/Dockerfile.development
@@ -38,7 +38,7 @@ WORKDIR $INSTALL_PATH
 
 ENV PATH="$PATH:/cl2_back/bin"
 
-COPY back/Gemfile back/Gemfile.* ./
+COPY back/Gemfile back/Gemfile.* back/.ruby-version ./
 COPY back/engines ./engines
 COPY back/lib/citizen_lab.rb ./lib/
 

--- a/back/Gemfile
+++ b/back/Gemfile
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
+ruby file: '.ruby-version'
 
 git_source(:github) do |repo_name|
   repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?('/')

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -1374,5 +1374,8 @@ DEPENDENCIES
   volunteering!
   webmock (~> 3.18)
 
+RUBY VERSION
+   ruby 2.7.6p219
+
 BUNDLED WITH
    2.4.20


### PR DESCRIPTION
Hopefully, this will provide more guidance to dependabot as to which version of ruby to use when updating dependencies.


# Changelog
## Technical
- Pin the Ruby version in the `Gemfile`.
