### PR TITLE
Show opacity slider for signed-in banner when layout is fixed-ratio

### DIFF
--- a/front/app/components/admin/PostManager/InputManager.tsx
+++ b/front/app/components/admin/PostManager/InputManager.tsx
@@ -76,6 +76,7 @@ const InputManager = ({
         ? projectId
         : undefined,
   });
+  console.log(projectAllowedInputTopics?.data);
 
   const getTopicsData = () => {
     const topicIds = getTopicIds(projectAllowedInputTopics?.data);

--- a/front/app/components/admin/PostManager/InputManager.tsx
+++ b/front/app/components/admin/PostManager/InputManager.tsx
@@ -76,7 +76,6 @@ const InputManager = ({
         ? projectId
         : undefined,
   });
-  console.log(projectAllowedInputTopics?.data);
 
   const getTopicsData = () => {
     const topicIds = getTopicIds(projectAllowedInputTopics?.data);

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/CraftComponents/HomepageBanner/OverlayControls.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/CraftComponents/HomepageBanner/OverlayControls.tsx
@@ -45,7 +45,6 @@ interface Props {
   bannerOverlayOpacity: number | null;
   bannerOverlayColor: string;
   onOverlayChange: (opacity: number | null, color: string | null) => void;
-  noOpacitySlider?: boolean;
 }
 
 const defaultOpacity = 90;
@@ -55,7 +54,6 @@ const OverlayControls = ({
   bannerOverlayOpacity,
   bannerOverlayColor,
   onOverlayChange,
-  noOpacitySlider,
 }: Props) => {
   const [overlayEnabled, setOverlayEnabled] = useState(
     typeof bannerOverlayOpacity === 'number' && bannerOverlayOpacity !== 0
@@ -129,20 +127,16 @@ const OverlayControls = ({
               onChange={handleOverlayColorOnChange}
             />
           </Box>
-          {!noOpacitySlider && (
-            <>
-              <Label>
-                <FormattedMessage {...messages.imageOverlayOpacity} />
-              </Label>
-              <RangeInput
-                step={1}
-                min={0}
-                max={100}
-                value={bannerOverlayOpacity}
-                onChange={debouncedHandleOverlayOpacityOnChange}
-              />
-            </>
-          )}
+          <Label>
+            <FormattedMessage {...messages.imageOverlayOpacity} />
+          </Label>
+          <RangeInput
+            step={1}
+            min={0}
+            max={100}
+            value={bannerOverlayOpacity}
+            onChange={debouncedHandleOverlayOpacityOnChange}
+          />
         </StyledBox>
       )}
     </>

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/CraftComponents/HomepageBanner/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/CraftComponents/HomepageBanner/index.tsx
@@ -560,9 +560,6 @@ const HomepageBannerSettings = () => {
             {formatMessage(messages.signedInDescription)}
           </Text>
           <OverlayControls
-            noOpacitySlider={
-              homepageSettings.banner_layout === 'fixed_ratio_layout'
-            }
             bannerOverlayColor={
               homepageSettings.banner_signed_in_header_overlay_color
             }


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Changed
- Show opacity slider for signed-in banner when layout is fixed-ratio. [Screenshot](https://github.com/CitizenLabDotCo/citizenlab/assets/16427929/59666d17-cc6d-4c48-8fbf-df135a038abb)

