### PR TITLE
TAN-810: Fix page visibility issues when navigating to previous pages and then forward

### DIFF
--- a/front/app/components/Form/Components/Fields/index.tsx
+++ b/front/app/components/Form/Components/Fields/index.tsx
@@ -38,6 +38,7 @@ interface Props {
   config?: 'default' | 'input' | 'survey';
   locale: Locale;
   onChange: (formData: FormData) => void;
+  setFormData: (formData: FormData) => void;
   onSubmit?: (formData: FormData) => Promise<any>;
 }
 
@@ -56,6 +57,7 @@ const Fields = ({
   config,
   locale,
   onChange,
+  setFormData,
   onSubmit,
 }: Props) => {
   const { formatMessage } = useIntl();
@@ -99,6 +101,7 @@ const Fields = ({
           onSubmit,
           setShowAllErrors,
           formSubmitText,
+          setFormData,
           locale,
         }}
       >

--- a/front/app/components/Form/Components/Fields/index.tsx
+++ b/front/app/components/Form/Components/Fields/index.tsx
@@ -38,7 +38,7 @@ interface Props {
   config?: 'default' | 'input' | 'survey';
   locale: Locale;
   onChange: (formData: FormData) => void;
-  setFormData: (formData: FormData) => void;
+  setFormData?: (formData: FormData) => void;
   onSubmit?: (formData: FormData) => Promise<any>;
 }
 

--- a/front/app/components/Form/Components/Layouts/CLPageLayout.tsx
+++ b/front/app/components/Form/Components/Layouts/CLPageLayout.tsx
@@ -174,7 +174,7 @@ const CLPageLayout = memo(
        * We need to find a better solution for this but keeping it like this for now. I'll probably come back to it when I have more time
        * to think about it. See https://www.notion.so/citizenlab/Bug-in-survey-flow-792a72efc35e44e58e1bb10ab631ecdf
        */
-      setFormData && setFormData(dataWithoutRuleValues);
+      setFormData?.(dataWithoutRuleValues);
 
       setCurrentStep(currentStep - 1);
       userPagePath.pop();

--- a/front/app/components/Form/contexts.ts
+++ b/front/app/components/Form/contexts.ts
@@ -1,6 +1,6 @@
 import { createContext } from 'react';
 import { CLErrors, Locale } from 'typings';
-import { ApiErrorGetter } from './typings';
+import { ApiErrorGetter, FormData } from './typings';
 import { MessageDescriptor } from 'utils/cl-intl';
 
 export const APIErrorsContext = createContext<CLErrors | undefined>(undefined);
@@ -10,8 +10,8 @@ export const FormContext = createContext<{
   getApiErrorMessage: ApiErrorGetter;
   formSubmitText?: MessageDescriptor;
   inputId?: string | undefined;
-  onSubmit?: (formData?: any) => void | Promise<void>;
-  setFormData?: (formData?: any) => void;
+  onSubmit?: (formData?: FormData) => void | Promise<void>;
+  setFormData?: (formData?: FormData) => void;
   setShowAllErrors?: (showAllErrors: boolean) => void;
   locale?: Locale;
 }>({

--- a/front/app/components/Form/contexts.ts
+++ b/front/app/components/Form/contexts.ts
@@ -11,12 +11,14 @@ export const FormContext = createContext<{
   formSubmitText?: MessageDescriptor;
   inputId?: string | undefined;
   onSubmit?: (formData?: any) => void | Promise<void>;
+  setFormData?: (formData?: any) => void;
   setShowAllErrors?: (showAllErrors: boolean) => void;
   locale?: Locale;
 }>({
   showAllErrors: false,
   getApiErrorMessage: () => undefined,
   onSubmit: async () => undefined,
+  setFormData: async () => undefined,
   setShowAllErrors: () => undefined,
   inputId: undefined,
   locale: undefined,

--- a/front/app/components/Form/index.tsx
+++ b/front/app/components/Form/index.tsx
@@ -199,6 +199,7 @@ const Form = memo(
             formSubmitText={formSubmitText}
             config={config}
             locale={locale}
+            setFormData={setData}
             onChange={handleChange}
             onSubmit={handleSubmit}
           />


### PR DESCRIPTION
# Changelog

## Fixed
- Fixes a tricky page visibility issue on surveys with rules. When a user enters data for a question that has rules. For that case, navigating to a previous page and then selecting different options that would lead to hiding another previously visible page with elements with rules that had data prior to selecting previous would before lead to visibility issues since the data before was being used in the decisions to pick the page. The down side with the current solution is that it will remove the answers to the rule questions in those cases. I'll probably come back and think about a better solution but that requires more time. This should suffice for now with minimal impact since this is only on single select fields with rules
