### PR TITLE
Hide avatar uploader when user_avatars is disabled

### DIFF
--- a/front/app/api/app_configuration/types.ts
+++ b/front/app/api/app_configuration/types.ts
@@ -237,6 +237,7 @@ export interface IAppConfigurationSettings {
   power_bi?: AppConfigurationFeature;
   analysis?: AppConfigurationFeature;
   import_printed_forms?: AppConfigurationFeature;
+  user_avatars?: AppConfigurationFeature;
 }
 
 export type TAppConfigurationSettingCore = keyof IAppConfigurationSettingsCore;


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

FE for #6813 ([ticket](https://www.notion.so/citizenlab/NL-or-GDPR-doesn-t-see-Avatars-as-a-required-data-field-for-residents-4f0dcf7e0cd74efbb5fb3977f7249d8e?pvs=4)).