### PR TITLE
Quill editor: prefix url with https protocol if missing

### DIFF
--- a/front/app/components/UI/QuillEditor/index.tsx
+++ b/front/app/components/UI/QuillEditor/index.tsx
@@ -334,6 +334,11 @@ class CustomLink extends Link {
     const node = super.create(url);
     node.setAttribute('rel', 'noreferrer noopener nofollow');
 
+    // if the href of node starts with www., add https://
+    if (url.startsWith('www.')) {
+      node.setAttribute('href', `https://${url}`);
+    }
+
     // The default behavior of the Link is to add a target="_blank" attribute
     // So for internal urls we have to remove this
     if (!isExternal(url)) {


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Changed
- When adding a link without protocol (e.g. www.citizenlab.co) via the Quill editor, we automatically prepend the https protocol. Screenshots: [1](https://github.com/CitizenLabDotCo/citizenlab/assets/16427929/5943080d-c843-4477-835c-4248ac04fe94), [2](https://github.com/CitizenLabDotCo/citizenlab/assets/16427929/274f697e-b159-44ee-a7d4-410a49fc19d4)
