### PR TITLE
[TAN-744] Stop silencing errors when sending confirmation codes

### DIFF
--- a/back/app/jobs/request_confirmation_code_job.rb
+++ b/back/app/jobs/request_confirmation_code_job.rb
@@ -18,7 +18,8 @@ class RequestConfirmationCodeJob < ApplicationJob
       user.email_confirmation_code_reset_count = 0
     end
     reset_user_confirmation_code user
-    return if !user.valid?
+
+    raise "User is invalid: #{user.errors.details}" unless user.valid?
 
     ActiveRecord::Base.transaction do
       user.save!


### PR DESCRIPTION
# Changelog
## Technical
- [TAN-744] Stop silencing errors when sending email confirmation codes.
