### PR TITLE
Remove text out of sync with new reject button

### DIFF
--- a/front/app/components/ConsentManager/Banner.tsx
+++ b/front/app/components/ConsentManager/Banner.tsx
@@ -72,25 +72,6 @@ const Left = styled.div`
   `}
 `;
 
-const Line = styled.div`
-  font-size: ${fontSizes.base}px;
-  font-weight: 400;
-  line-height: normal;
-  overflow-wrap: break-word;
-  word-wrap: break-word;
-  word-break: break-word;
-
-  &.first {
-    margin-bottom: 4px;
-  }
-
-  ${media.phone`
-    &.second {
-      display: none;
-    }
-  `}
-`;
-
 const StyledLink = styled(Link)`
   color: white;
   text-decoration: underline;
@@ -132,21 +113,16 @@ const Banner = ({ onAccept, onChangePreferences, onClose }: Props) => {
       <ContentContainer mode="page">
         <ContentContainerInner>
           <Left>
-            <Line className="first">
-              <FormattedMessage
-                {...messages.mainText}
-                values={{
-                  policyLink: (
-                    <StyledLink to="/pages/cookie-policy">
-                      <FormattedMessage {...messages.policyLink} />
-                    </StyledLink>
-                  ),
-                }}
-              />
-            </Line>
-            <Line className="second">
-              <FormattedMessage {...messages.subText} />
-            </Line>
+            <FormattedMessage
+              {...messages.mainText}
+              values={{
+                policyLink: (
+                  <StyledLink to="/pages/cookie-policy">
+                    <FormattedMessage {...messages.policyLink} />
+                  </StyledLink>
+                ),
+              }}
+            />
           </Left>
           <ButtonContainer>
             <Button

--- a/front/app/components/ConsentManager/messages.ts
+++ b/front/app/components/ConsentManager/messages.ts
@@ -13,11 +13,6 @@ export default defineMessages({
     id: 'app.components.ConsentManager.Banner.policyLink',
     defaultMessage: 'Cookie Policy',
   },
-  subText: {
-    id: 'app.components.ConsentManager.Banner.subText',
-    defaultMessage:
-      'Access your preferences at any time by visiting "Cookie settings" at the bottom of the page',
-  },
   manage: {
     id: 'app.components.ConsentManager.Banner.manage',
     defaultMessage: 'Manage',

--- a/front/app/translations/ar-MA.json
+++ b/front/app/translations/ar-MA.json
@@ -87,7 +87,6 @@
   "app.components.ConsentManager.Banner.manage": "إدارة",
   "app.components.ConsentManager.Banner.policyLink": "سياسة ملفات تعريف الارتباط ",
   "app.components.ConsentManager.Banner.reject": "يرفض",
-  "app.components.ConsentManager.Banner.subText": "يمكنك الوصول إلى إعدادات ملفات تعريف الارتباط في أي وقت.",
   "app.components.ConsentManager.Modal.CancelDialog.confirm": "تأكيد",
   "app.components.ConsentManager.Modal.CancelDialog.confirmation": "إذا قمت بالإلغاء، فستفقد تفضيلاتك.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "الإعلانات",

--- a/front/app/translations/ar-SA.json
+++ b/front/app/translations/ar-SA.json
@@ -87,7 +87,6 @@
   "app.components.ConsentManager.Banner.manage": "إدارة",
   "app.components.ConsentManager.Banner.policyLink": "سياسة ملفات تعريف الارتباط",
   "app.components.ConsentManager.Banner.reject": "يرفض",
-  "app.components.ConsentManager.Banner.subText": "يمكنك الوصول إلى إعدادات ملفات تعريف الارتباط في أي وقت.",
   "app.components.ConsentManager.Modal.CancelDialog.confirm": "تأكيد",
   "app.components.ConsentManager.Modal.CancelDialog.confirmation": "إذا قمت بالإلغاء، فستفقد تفضيلاتك.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "الإعلانات",

--- a/front/app/translations/ca-ES.json
+++ b/front/app/translations/ca-ES.json
@@ -87,7 +87,6 @@
   "app.components.ConsentManager.Banner.manage": "Gestionar",
   "app.components.ConsentManager.Banner.policyLink": "Política de galetes",
   "app.components.ConsentManager.Banner.reject": "Rebutjar",
-  "app.components.ConsentManager.Banner.subText": "Feu clic a \"Acceptar\" per permetre que s'utilitzin les galetes o a \"Gestiona\" per canviar la configuració de les galetes.",
   "app.components.ConsentManager.Modal.CancelDialog.confirm": "Confirmeu",
   "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Si cancel·leu, es perdran les vostres preferències.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Publicitat",

--- a/front/app/translations/da-DK.json
+++ b/front/app/translations/da-DK.json
@@ -87,7 +87,6 @@
   "app.components.ConsentManager.Banner.manage": "Administrer",
   "app.components.ConsentManager.Banner.policyLink": "Cookiepolitik",
   "app.components.ConsentManager.Banner.reject": "Afvis",
-  "app.components.ConsentManager.Banner.subText": "Klik \"Accepter\" for at tillade at der anvendes cookies, eller \"Administrer\" for at ændre dine cookie indstillinger.",
   "app.components.ConsentManager.Modal.CancelDialog.confirm": "Bekræft",
   "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Hvis du annullerer, vil dine præferencer gå tabt.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Reklamer og annoncering",

--- a/front/app/translations/de-DE.json
+++ b/front/app/translations/de-DE.json
@@ -87,7 +87,6 @@
   "app.components.ConsentManager.Banner.manage": "Bearbeiten",
   "app.components.ConsentManager.Banner.policyLink": "Cookie-Richtlinie",
   "app.components.ConsentManager.Banner.reject": "Ablehnen",
-  "app.components.ConsentManager.Banner.subText": "Klicken Sie auf \"Akzeptieren\", um die Verwendung von Cookies zuzulassen, oder auf \"Bearbeiten\", um Ihre Cookie-Einstellungen zu ändern.",
   "app.components.ConsentManager.Modal.CancelDialog.confirm": "Bestätigen",
   "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Solltest du jetzt abbrechen, gehen die Einstellungen verloren.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Werbung",

--- a/front/app/translations/el-GR.json
+++ b/front/app/translations/el-GR.json
@@ -87,7 +87,6 @@
   "app.components.ConsentManager.Banner.manage": "Διαχείριση",
   "app.components.ConsentManager.Banner.policyLink": "Πολιτική cookie",
   "app.components.ConsentManager.Banner.reject": "Απόρριψη",
-  "app.components.ConsentManager.Banner.subText": "Κάντε κλικ στο \"Αποδοχή\" για να επιτρέψετε τη χρήση cookies ή στο \"Διαχείριση\" για να αλλάξετε τις ρυθμίσεις των cookies.",
   "app.components.ConsentManager.Modal.CancelDialog.confirm": "Επιβεβαίωση",
   "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Εάν ακυρώσετε, οι προτιμήσεις σας θα χαθούν.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Διαφήμιση",

--- a/front/app/translations/en-CA.json
+++ b/front/app/translations/en-CA.json
@@ -87,7 +87,6 @@
   "app.components.ConsentManager.Banner.manage": "Manage",
   "app.components.ConsentManager.Banner.policyLink": "Cookie policy",
   "app.components.ConsentManager.Banner.reject": "Reject",
-  "app.components.ConsentManager.Banner.subText": "Click \"Accept\" to allow cookies to be used or \"Manage\" to change your cookie settings.",
   "app.components.ConsentManager.Modal.CancelDialog.confirm": "Confirm",
   "app.components.ConsentManager.Modal.CancelDialog.confirmation": "If you cancel, your preferences will be lost.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Advertising",

--- a/front/app/translations/en-GB.json
+++ b/front/app/translations/en-GB.json
@@ -87,7 +87,6 @@
   "app.components.ConsentManager.Banner.manage": "Manage",
   "app.components.ConsentManager.Banner.policyLink": "Cookie policy",
   "app.components.ConsentManager.Banner.reject": "Reject",
-  "app.components.ConsentManager.Banner.subText": "Click \"Accept\" to allow cookies to be used or \"Manage\" to change your cookie settings.",
   "app.components.ConsentManager.Modal.CancelDialog.confirm": "Confirm",
   "app.components.ConsentManager.Modal.CancelDialog.confirmation": "If you cancel, your preferences will be lost.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Advertising",

--- a/front/app/translations/en.json
+++ b/front/app/translations/en.json
@@ -87,7 +87,6 @@
   "app.components.ConsentManager.Banner.manage": "Manage",
   "app.components.ConsentManager.Banner.policyLink": "Cookie policy",
   "app.components.ConsentManager.Banner.reject": "Reject",
-  "app.components.ConsentManager.Banner.subText": "Click \"Accept\" to allow cookies to be used or \"Manage\" to change your cookie settings.",
   "app.components.ConsentManager.Modal.CancelDialog.confirm": "Confirm",
   "app.components.ConsentManager.Modal.CancelDialog.confirmation": "If you cancel, your preferences will be lost.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Advertising",

--- a/front/app/translations/es-CL.json
+++ b/front/app/translations/es-CL.json
@@ -87,7 +87,6 @@
   "app.components.ConsentManager.Banner.manage": "Administrar",
   "app.components.ConsentManager.Banner.policyLink": "Política de cookies",
   "app.components.ConsentManager.Banner.reject": "Rechaza",
-  "app.components.ConsentManager.Banner.subText": "Haga clic en \"Aceptar\" para permitir el uso de cookies o en \"Administrar\" para cambiar la configuración de las cookies.",
   "app.components.ConsentManager.Modal.CancelDialog.confirm": "Confirmar",
   "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Si cancelas, se perderán tus preferencias.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Publicidad",

--- a/front/app/translations/es-ES.json
+++ b/front/app/translations/es-ES.json
@@ -87,7 +87,6 @@
   "app.components.ConsentManager.Banner.manage": "Administrar",
   "app.components.ConsentManager.Banner.policyLink": "Política de cookies",
   "app.components.ConsentManager.Banner.reject": "Rechaza",
-  "app.components.ConsentManager.Banner.subText": "Haga clic en \"Aceptar\" para permitir el uso de cookies o en \"Administrar\" para cambiar la configuración de las cookies.",
   "app.components.ConsentManager.Modal.CancelDialog.confirm": "Confirmar",
   "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Si cancelas, se perderán tus preferencias.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Publicidad",

--- a/front/app/translations/fr-BE.json
+++ b/front/app/translations/fr-BE.json
@@ -87,7 +87,6 @@
   "app.components.ConsentManager.Banner.manage": "Gérer",
   "app.components.ConsentManager.Banner.policyLink": "Politique de cookie",
   "app.components.ConsentManager.Banner.reject": "Refuser",
-  "app.components.ConsentManager.Banner.subText": "Accéder à vos paramètres de cookie à tout moment.",
   "app.components.ConsentManager.Modal.CancelDialog.confirm": "Confirmer",
   "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Si vous annulez, vos préférences seront perdues.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Publicité",

--- a/front/app/translations/fr-FR.json
+++ b/front/app/translations/fr-FR.json
@@ -87,7 +87,6 @@
   "app.components.ConsentManager.Banner.manage": "Gérer",
   "app.components.ConsentManager.Banner.policyLink": "Politique de cookie",
   "app.components.ConsentManager.Banner.reject": "Refuser",
-  "app.components.ConsentManager.Banner.subText": "Cliquez sur “Accepter” pour autoriser l’utilisation des cookies ou sur “Gérer” pour définir vos propres paramètres.",
   "app.components.ConsentManager.Modal.CancelDialog.confirm": "Confirmer",
   "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Si vous annulez, vos préférences seront perdues.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Publicité",

--- a/front/app/translations/hr-HR.json
+++ b/front/app/translations/hr-HR.json
@@ -87,7 +87,6 @@
   "app.components.ConsentManager.Banner.manage": "Upravljanje",
   "app.components.ConsentManager.Banner.policyLink": "Pravila o kolačićima",
   "app.components.ConsentManager.Banner.reject": "Odbiti",
-  "app.components.ConsentManager.Banner.subText": "Kliknite „Prihvati kako biste dopustili korištenje kolačića ili „Upravljanje“ za promjenu postavki kolačića.",
   "app.components.ConsentManager.Modal.CancelDialog.confirm": "Potvrdi",
   "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Ukoliko odustanete, vaše postavke neće biti spremljene.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Oglašavanje",

--- a/front/app/translations/hu-HU.json
+++ b/front/app/translations/hu-HU.json
@@ -42,7 +42,6 @@
   "app.components.ConsentManager.Banner.mainText": "This platform uses cookies in accordance with our {policyLink}.",
   "app.components.ConsentManager.Banner.manage": "Manage",
   "app.components.ConsentManager.Banner.policyLink": "Cookie policy",
-  "app.components.ConsentManager.Banner.subText": "Click \"Accept\" to allow cookies to be used or \"Manage\" to change your cookie settings.",
   "app.components.ConsentManager.Modal.CancelDialog.confirm": "Confirm",
   "app.components.ConsentManager.Modal.CancelDialog.confirmation": "If you cancel, your preferences will be lost.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Advertising",

--- a/front/app/translations/it-IT.json
+++ b/front/app/translations/it-IT.json
@@ -87,7 +87,6 @@
   "app.components.ConsentManager.Banner.manage": "Gestire",
   "app.components.ConsentManager.Banner.policyLink": "Politica dei cookie",
   "app.components.ConsentManager.Banner.reject": "Rifiuta",
-  "app.components.ConsentManager.Banner.subText": "È possibile accedere alle impostazioni dei cookie in qualsiasi momento.",
   "app.components.ConsentManager.Modal.CancelDialog.confirm": "Confermare",
   "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Se ti cancelli, le tue preferenze andranno perse.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Pubblicità",

--- a/front/app/translations/kl-GL.json
+++ b/front/app/translations/kl-GL.json
@@ -79,7 +79,6 @@
   "app.components.ConsentManager.Banner.mainText": "Iliuuseqarnikkut {policyLink}-erput akuerivat.",
   "app.components.ConsentManager.Banner.manage": "Aqutsinerit",
   "app.components.ConsentManager.Banner.policyLink": "Cookiet pillugit politik",
-  "app.components.ConsentManager.Banner.subText": "Qaqugukkulluunniit cookie-mi aaqqissuussinernut isersinnaavutit.",
   "app.components.ConsentManager.Modal.CancelDialog.confirm": "Uppernarsaruk",
   "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Taamaatikkukku salliusussaanerit asuliinnassaaq.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Ussassaarutit saqqummiussinerlu",

--- a/front/app/translations/lb-LU.json
+++ b/front/app/translations/lb-LU.json
@@ -87,7 +87,6 @@
   "app.components.ConsentManager.Banner.manage": "Beaarbechten",
   "app.components.ConsentManager.Banner.policyLink": "Cookie-Richtlinnen",
   "app.components.ConsentManager.Banner.reject": "Refuséieren",
-  "app.components.ConsentManager.Banner.subText": "Klickt op “Akzeptéieren” fir Cookieën z’erlaaben oder “Beaarbechten” fir d’Cookie-Astellungen ze änneren.",
   "app.components.ConsentManager.Modal.CancelDialog.confirm": "Bestätegen",
   "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Wann Dir ofbriecht, ginn Är Preferenze verluer.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Cookië fir Publicitéit",

--- a/front/app/translations/lv-LV.json
+++ b/front/app/translations/lv-LV.json
@@ -87,7 +87,6 @@
   "app.components.ConsentManager.Banner.manage": "Pārvaldīt",
   "app.components.ConsentManager.Banner.policyLink": "Sīkdatņu politika",
   "app.components.ConsentManager.Banner.reject": "Noraidīt",
-  "app.components.ConsentManager.Banner.subText": "Noklikšķiniet uz \"Piekrist\", lai atļautu sīkdatņu izmantošanu, vai \"Pārvaldīt\", lai mainītu sīkdatņu iestatījumus.",
   "app.components.ConsentManager.Modal.CancelDialog.confirm": "Apstiprināt",
   "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Ja atcelsiet reģistrāciju, jūsu preferences tiks zaudētas.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Reklāma",

--- a/front/app/translations/mi.json
+++ b/front/app/translations/mi.json
@@ -42,7 +42,6 @@
   "app.components.ConsentManager.Banner.mainText": "This platform uses cookies in accordance with our {policyLink}.",
   "app.components.ConsentManager.Banner.manage": "Manage",
   "app.components.ConsentManager.Banner.policyLink": "Kaupapahere pihikete",
-  "app.components.ConsentManager.Banner.subText": "Click \"Accept\" to allow cookies to be used or \"Manage\" to change your cookie settings.",
   "app.components.ConsentManager.Modal.CancelDialog.confirm": "Confirm",
   "app.components.ConsentManager.Modal.CancelDialog.confirmation": "If you cancel, your preferences will be lost.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Advertising",

--- a/front/app/translations/nb-NO.json
+++ b/front/app/translations/nb-NO.json
@@ -87,7 +87,6 @@
   "app.components.ConsentManager.Banner.manage": "Administrer",
   "app.components.ConsentManager.Banner.policyLink": "Retningslinjer for informasjonskapsler",
   "app.components.ConsentManager.Banner.reject": "Avvis",
-  "app.components.ConsentManager.Banner.subText": "Du kan når som helst få tilgang til dine informasjonskapsel-innstillinger.",
   "app.components.ConsentManager.Modal.CancelDialog.confirm": "Bekreft",
   "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Dersom du avbryter vil preferansene dine gå tapt.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Reklame",

--- a/front/app/translations/nl-BE.json
+++ b/front/app/translations/nl-BE.json
@@ -87,7 +87,6 @@
   "app.components.ConsentManager.Banner.manage": "Beheren",
   "app.components.ConsentManager.Banner.policyLink": "Cookiebeleid",
   "app.components.ConsentManager.Banner.reject": "Weiger",
-  "app.components.ConsentManager.Banner.subText": "Je kan je cookie-instellingen op elk moment aanpassen.",
   "app.components.ConsentManager.Modal.CancelDialog.confirm": "Bevestigen",
   "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Als je annuleert, gaan je voorkeuren verloren.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Advertenties",

--- a/front/app/translations/nl-NL.json
+++ b/front/app/translations/nl-NL.json
@@ -87,7 +87,6 @@
   "app.components.ConsentManager.Banner.manage": "Beheren",
   "app.components.ConsentManager.Banner.policyLink": "Cookiebeleid",
   "app.components.ConsentManager.Banner.reject": "Weiger",
-  "app.components.ConsentManager.Banner.subText": "Klik op \"Aanvaarden\" om het gebruik van cookies toe te staan of op \"Beheren\" om je cookie-instellingen te wijzigen.",
   "app.components.ConsentManager.Modal.CancelDialog.confirm": "Bevestigen",
   "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Als je annuleert, gaan je voorkeuren verloren.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Advertenties",

--- a/front/app/translations/pl-PL.json
+++ b/front/app/translations/pl-PL.json
@@ -87,7 +87,6 @@
   "app.components.ConsentManager.Banner.manage": "Zarządzaj",
   "app.components.ConsentManager.Banner.policyLink": "Polityka ciasteczek",
   "app.components.ConsentManager.Banner.reject": "Odrzuć",
-  "app.components.ConsentManager.Banner.subText": "W każdej chwili możesz uzyskać dostęp do swoich ustawień dotyczących plików cookie.",
   "app.components.ConsentManager.Modal.CancelDialog.confirm": "Potwierdź",
   "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Jeśli anulujesz, Twoje preferencje zostaną utracone.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Reklama",

--- a/front/app/translations/pt-BR.json
+++ b/front/app/translations/pt-BR.json
@@ -87,7 +87,6 @@
   "app.components.ConsentManager.Banner.manage": "Gerenciar   ",
   "app.components.ConsentManager.Banner.policyLink": "Política de Cookies",
   "app.components.ConsentManager.Banner.reject": "Recusar",
-  "app.components.ConsentManager.Banner.subText": "Você pode acessar suas configurações de cookies em qualquer momento.",
   "app.components.ConsentManager.Modal.CancelDialog.confirm": "Confirmar",
   "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Se você cancelar, perderá as suas preferências.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Publicidade",

--- a/front/app/translations/ro-RO.json
+++ b/front/app/translations/ro-RO.json
@@ -57,7 +57,6 @@
   "app.components.ConsentManager.Banner.mainText": "Prin navigare, sunteți de acord cu {policyLink}.",
   "app.components.ConsentManager.Banner.manage": "Administrează",
   "app.components.ConsentManager.Banner.policyLink": "Politica Cookie",
-  "app.components.ConsentManager.Banner.subText": "Puteți accesa setările pentru cookie-uri în orice moment.",
   "app.components.ConsentManager.Modal.CancelDialog.confirm": "Confirmă",
   "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Dacă anulați, preferințele vor fi pierdute.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Reclamă",

--- a/front/app/translations/sr-Latn.json
+++ b/front/app/translations/sr-Latn.json
@@ -87,7 +87,6 @@
   "app.components.ConsentManager.Banner.manage": "Upravljajte",
   "app.components.ConsentManager.Banner.policyLink": "Deklaracija o kolačićima",
   "app.components.ConsentManager.Banner.reject": "Reject",
-  "app.components.ConsentManager.Banner.subText": "Kliknite na „Prihvati“ da biste dozvolili korišćenje kolačića ili „Upravljaj“ da biste promenili podešavanja kolačića.",
   "app.components.ConsentManager.Modal.CancelDialog.confirm": "Potvrdi",
   "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Ukoliko prekinete, vaše preferencije neće biti sačuvane.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Oglašavanje",

--- a/front/app/translations/sr-SP.json
+++ b/front/app/translations/sr-SP.json
@@ -87,7 +87,6 @@
   "app.components.ConsentManager.Banner.manage": "Управљајте",
   "app.components.ConsentManager.Banner.policyLink": "Декларација о колачићима",
   "app.components.ConsentManager.Banner.reject": "Reject",
-  "app.components.ConsentManager.Banner.subText": "Кликните на „Прихвати“ да бисте дозволили коришћење колачића или „Управљај“ да бисте променили подешавања колачића.",
   "app.components.ConsentManager.Modal.CancelDialog.confirm": "Потврди",
   "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Ако откажете, ваше поставке ће бити изгубљене.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Оглашавање",

--- a/front/app/translations/sv-SE.json
+++ b/front/app/translations/sv-SE.json
@@ -87,7 +87,6 @@
   "app.components.ConsentManager.Banner.manage": "Hantera",
   "app.components.ConsentManager.Banner.policyLink": "Policy webbkakor",
   "app.components.ConsentManager.Banner.reject": "Förkasta",
-  "app.components.ConsentManager.Banner.subText": "Du kan komma åt dina kakinställningar när som helst.",
   "app.components.ConsentManager.Modal.CancelDialog.confirm": "Bekräfta",
   "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Om du avbryter, kommer dina inställningar att gå förlorade.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Reklam",

--- a/front/app/translations/tr-TR.json
+++ b/front/app/translations/tr-TR.json
@@ -87,7 +87,6 @@
   "app.components.ConsentManager.Banner.manage": "Yönet",
   "app.components.ConsentManager.Banner.policyLink": "Çerez politikası",
   "app.components.ConsentManager.Banner.reject": "Reddet",
-  "app.components.ConsentManager.Banner.subText": "Çerez kullanımına izin vermek için \"Kabul et\"i, çerez ayarlarınızı değiştirmek için \"Yönet\"i tıklayın.",
   "app.components.ConsentManager.Modal.CancelDialog.confirm": "Onayla",
   "app.components.ConsentManager.Modal.CancelDialog.confirmation": "İptal ederseniz tercihleriniz kaydedilmez.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Reklam",


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Changed
- Removed the cookie policy banner line that described the buttons in the banner on desktop, but didn't include an explanation for the Reject button. [Before](https://github.com/CitizenLabDotCo/citizenlab/assets/16427929/be648623-36e2-440b-a2a6-e7267ed13bcc) / [After](https://github.com/CitizenLabDotCo/citizenlab/assets/16427929/66cea4dc-041c-4321-af0f-d7117fd969a4)
