### PR TITLE
[TAN-893] Basic feature flag for Esri Integration

### DIFF
--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -503,7 +503,7 @@
           },
           "esri_integration": {
             "type": "boolean",
-            "default": true,
+            "default": false,
             "title": "Esri Integration",
             "description": "Enable Esri integration for maps. In development. DO NOT ENABLE ON COMMERCIAL PLATFORM!"
           }

--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -500,6 +500,12 @@
             "type": "integer",
             "title": "OSM Relation ID",
             "description": "The boundary of the municipality/organisation is specified by its Relation ID in OpenStreetMap (OSM). You can find the Relation ID at https://www.openstreetmap.org. Search for the place, click on the correct result and you'll find the Relation ID if the result is a relation (e.g. \"Relation: Knokke-Heist (4569)\"). If there is no relation defined for the place (e.g. Scheveningen), search for the next largest administrative territory (e.g. The Hague)."
+          },
+          "esri_integration": {
+            "type": "boolean",
+            "default": true,
+            "title": "Esri Integration",
+            "description": "Enable Esri integration for maps. In development. DO NOT ENABLE ON COMMERCIAL PLATFORM!"
           }
         }
       },

--- a/back/engines/commercial/multi_tenancy/db/seeds/tenants.rb
+++ b/back/engines/commercial/multi_tenancy/db/seeds/tenants.rb
@@ -101,7 +101,8 @@ module MultiTenancy
                 long: '4.3517'
               },
               zoom_level: 12,
-              osm_relation_id: 2_404_021
+              osm_relation_id: 2_404_021,
+              esri_integration: true
             },
             custom_maps: {
               enabled: true,


### PR DESCRIPTION
Very simple implementation. Added boolean flag as setting in `maps` settings (title: "Custom Maps"), in `settings.schema.json.erb`.

We may later decide we need a separate setting, with both `allowed` and `enabled` booleans, and maybe other params, but for now this should suffice as we develop the new feature.

Layout and styling not great in AdminHQ, as is the case for all such booleans not defined in `"properties"` block (e.g. `initiatives` `require_cosponsors` boolean).
<img width="1087" alt="Screenshot 2024-01-22 at 12 40 37" src="https://github.com/CitizenLabDotCo/citizenlab/assets/3944042/b4923b15-1c26-4bc7-afa5-9c5c44cb9d29">


# Changelog
## Technical
- [TAN-893] Add feature flag, as simple boolean, for Esri Integration