### PR TITLE
[NO-TICKET] Remove survey results info banner

### DIFF
--- a/front/app/containers/Admin/projects/project/nativeSurvey/FormResults/index.tsx
+++ b/front/app/containers/Admin/projects/project/nativeSurvey/FormResults/index.tsx
@@ -6,7 +6,7 @@ import { useParams } from 'react-router-dom';
 import useLocale from 'hooks/useLocale';
 
 // components
-import { Box, Text, Icon, colors } from '@citizenlab/cl2-component-library';
+import { Box, Text } from '@citizenlab/cl2-component-library';
 
 // i18n
 import messages from '../messages';
@@ -52,31 +52,6 @@ const FormResults = () => {
         <Text variant="bodyM" color="textSecondary">
           {surveyResponseMessage}
         </Text>
-      </Box>
-
-      <Box
-        bgColor={colors.teal100}
-        borderRadius="3px"
-        px="12px"
-        py="4px"
-        mt="0px"
-        mb="32px"
-        role="alert"
-        display="flex"
-        justifyContent="space-between"
-        alignItems="center"
-      >
-        <Box display="flex" gap="16px" alignItems="center">
-          <Icon
-            name="info-outline"
-            width="24px"
-            height="24px"
-            fill="textSecondary"
-          />
-          <Text variant="bodyM" color="textSecondary">
-            {formatMessage(messages.informationText2)}
-          </Text>
-        </Box>
       </Box>
 
       <Box>


### PR DESCRIPTION
# Changelog
## Changed
- The info banner on the survey results page that warns users that survey answers to text questions are only available via export has been removed because it is no longer needed
