### PR TITLE
[TAN-887] Fix specification of query params for /consents

### DIFF
--- a/front/app/api/campaign_consents/useCampaignConsents.ts
+++ b/front/app/api/campaign_consents/useCampaignConsents.ts
@@ -10,14 +10,11 @@ import {
 
 const fetchCampaignConsents = (consentsRequestData?: IConsentsRequestData) => {
   return fetcher<ICampaignConsents>({
-    path: `/consents${
-      typeof consentsRequestData?.unsubscriptionToken === 'string'
-        ? `?unsubscription_token=${consentsRequestData.unsubscriptionToken}`
-        : ''
-    }`,
+    path: `/consents`,
     action: 'get',
     queryParams: {
       without_campaign_names: consentsRequestData?.withoutCampaignNames,
+      unsubscription_token: consentsRequestData?.unsubscriptionToken,
     },
   });
 };


### PR DESCRIPTION
I'm not sure this will fix TAN-887 on its own, but in any case, the back-end receives ill-formed requests where the value of the unsubscription_token contains the rest of the query string. For example:
```
C2WTWGNSLuv3ddLPk816BeUtYE426vfHgDlYu6YI5PLzeEioIYiYsLVro6Kksv7w?without_campaign_names[]=mention_in_internal_comment
```

# Changelog
## Fixed
- [TAN-887] Fix the email consent form that could not be rendered in some cases.
