### PR TITLE
[TAN-897] Prune services when deploying

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -345,7 +345,7 @@ jobs:
       - run:
           command: ssh << parameters.ssh_user >>@<< parameters.ssh_host >> -o StrictHostKeyChecking=no "docker pull citizenlabdotco/back-ee:$CIRCLE_BRANCH && docker run --env-file cl2-deployment/<< parameters.env_file >> citizenlabdotco/back-ee:$CIRCLE_BRANCH bin/rake db:migrate_if_pending cl2back:clean_tenant_settings email_campaigns:assure_campaign_records fix_existing_tenants:update_permissions cl2back:clear_cache_store email_campaigns:remove_deprecated"
       - deploy:
-          command: ssh << parameters.ssh_user >>@<< parameters.ssh_host >> -o StrictHostKeyChecking=no "cd cl2-deployment && docker stack deploy --compose-file << parameters.compose_file >> << parameters.stack_name >> --with-registry-auth"
+          command: ssh << parameters.ssh_user >>@<< parameters.ssh_host >> -o StrictHostKeyChecking=no "cd cl2-deployment && docker stack deploy --compose-file << parameters.compose_file >> << parameters.stack_name >> --with-registry-auth --prune"
 
   back-generate-tenant-templates:
     resource_class: small


### PR DESCRIPTION
Remove services that are no longer referenced in the docker-compose file when deploying the application.


# Changelog
## Technical
- Remove services that are no longer referenced in the docker-compose file when deploying the application.
