### PR TITLE
[TAN-867] Use persistent Vienna USERID as our identity UID

### DIFF
--- a/back/app/models/identity.rb
+++ b/back/app/models/identity.rb
@@ -33,11 +33,7 @@ class Identity < ApplicationRecord
         auth
       end
 
-      uid = if authver_method.respond_to?(:profile_to_uid)
-        authver_method.profile_to_uid(auth)
-      else
-        auth['uid']
-      end
+      uid = authver_method.profile_to_uid(auth)
       find_with_omniauth(uid, auth) || build_with_omniauth(uid, auth_to_persist)
     end
 

--- a/back/app/models/identity.rb
+++ b/back/app/models/identity.rb
@@ -27,11 +27,7 @@ class Identity < ApplicationRecord
 
   class << self
     def find_or_build_with_omniauth(auth, authver_method)
-      auth_to_persist = if authver_method.respond_to?(:filter_auth_to_persist)
-        authver_method.filter_auth_to_persist(auth)
-      else
-        auth
-      end
+      auth_to_persist = authver_method.filter_auth_to_persist(auth)
 
       uid = authver_method.profile_to_uid(auth)
       find_with_omniauth(uid, auth) || build_with_omniauth(uid, auth_to_persist)

--- a/back/app/models/identity.rb
+++ b/back/app/models/identity.rb
@@ -25,22 +25,31 @@ class Identity < ApplicationRecord
 
   validates :uid, :provider, presence: true
 
-  def self.find_with_omniauth(auth)
-    find_by(uid: auth['uid'], provider: auth['provider'])
-  end
+  class << self
+    def find_or_build_with_omniauth(auth, authver_method)
+      auth_to_persist = if authver_method.respond_to?(:filter_auth_to_persist)
+        authver_method.filter_auth_to_persist(auth)
+      else
+        auth
+      end
 
-  def self.build_with_omniauth(auth)
-    new(uid: auth['uid'], provider: auth['provider'], auth_hash: auth)
-  end
-
-  def self.find_or_build_with_omniauth(auth, authver_method)
-    auth_to_persist = if authver_method.respond_to?(:filter_auth_to_persist)
-      authver_method.filter_auth_to_persist(auth)
-    else
-      auth
+      uid = if authver_method.respond_to?(:profile_to_uid)
+        authver_method.profile_to_uid(auth)
+      else
+        auth['uid']
+      end
+      find_with_omniauth(uid, auth) || build_with_omniauth(uid, auth_to_persist)
     end
 
-    find_with_omniauth(auth) || build_with_omniauth(auth_to_persist)
+    private
+
+    def find_with_omniauth(uid, auth)
+      find_by(uid: uid, provider: auth['provider'])
+    end
+
+    def build_with_omniauth(uid, auth)
+      new(uid: uid, provider: auth['provider'], auth_hash: auth)
+    end
   end
 
   def email_always_present?

--- a/back/engines/commercial/id_vienna_saml/app/lib/id_vienna_saml/citizen_saml_omniauth.rb
+++ b/back/engines/commercial/id_vienna_saml/app/lib/id_vienna_saml/citizen_saml_omniauth.rb
@@ -15,6 +15,8 @@ module IdViennaSaml
       }
     }.freeze
 
+    USERID_KEY = 'urn:oid:0.9.2342.19200300.100.1.1'
+
     # Extracts user attributes from the Omniauth response auth.
     # @param [OmniAuth::AuthHash] auth
     # @return [Hash] The user attributes
@@ -32,6 +34,10 @@ module IdViennaSaml
         last_name: last_name,
         locale: locale
       }
+    end
+
+    def profile_to_uid(auth)
+      auth.dig('extra', 'raw_info', USERID_KEY)&.first
     end
 
     # Configures the SAML endpoint to authenticate with Vienna's StandardPortal

--- a/back/engines/commercial/id_vienna_saml/app/lib/id_vienna_saml/citizen_saml_omniauth.rb
+++ b/back/engines/commercial/id_vienna_saml/app/lib/id_vienna_saml/citizen_saml_omniauth.rb
@@ -37,7 +37,7 @@ module IdViennaSaml
     end
 
     def profile_to_uid(auth)
-      auth.dig('extra', 'raw_info', USERID_KEY)&.first
+      auth.dig(:extra, :raw_info).to_h[USERID_KEY]&.first
     end
 
     # Configures the SAML endpoint to authenticate with Vienna's StandardPortal

--- a/back/engines/commercial/id_vienna_saml/app/lib/id_vienna_saml/citizen_saml_omniauth.rb
+++ b/back/engines/commercial/id_vienna_saml/app/lib/id_vienna_saml/citizen_saml_omniauth.rb
@@ -37,7 +37,7 @@ module IdViennaSaml
     end
 
     def profile_to_uid(auth)
-      auth.dig(:extra, :raw_info).to_h[USERID_KEY]&.first
+      auth.dig(:extra, :raw_info).to_h[USERID_KEY].first
     end
 
     # Configures the SAML endpoint to authenticate with Vienna's StandardPortal

--- a/back/engines/commercial/id_vienna_saml/app/lib/id_vienna_saml/employee_saml_omniauth.rb
+++ b/back/engines/commercial/id_vienna_saml/app/lib/id_vienna_saml/employee_saml_omniauth.rb
@@ -32,7 +32,7 @@ module IdViennaSaml
     end
 
     def profile_to_uid(auth)
-      auth.dig(:extra, :raw_info).to_h[USERID_KEY]&.first
+      auth.dig(:extra, :raw_info).to_h[USERID_KEY].first
     end
 
     # Configures the SAML endpoint to authenticate with Vienna's IdP for employees

--- a/back/engines/commercial/id_vienna_saml/app/lib/id_vienna_saml/employee_saml_omniauth.rb
+++ b/back/engines/commercial/id_vienna_saml/app/lib/id_vienna_saml/employee_saml_omniauth.rb
@@ -32,7 +32,7 @@ module IdViennaSaml
     end
 
     def profile_to_uid(auth)
-      auth.dig('extra', 'raw_info', USERID_KEY)&.first
+      auth.dig(:extra, :raw_info).to_h[USERID_KEY]&.first
     end
 
     # Configures the SAML endpoint to authenticate with Vienna's IdP for employees

--- a/back/engines/commercial/id_vienna_saml/app/lib/id_vienna_saml/employee_saml_omniauth.rb
+++ b/back/engines/commercial/id_vienna_saml/app/lib/id_vienna_saml/employee_saml_omniauth.rb
@@ -15,6 +15,8 @@ module IdViennaSaml
       }
     }.freeze
 
+    USERID_KEY = 'urn:oid:0.9.2342.19200300.100.1.1'
+
     # Extracts user attributes from the Omniauth response auth.
     # @param [OmniAuth::AuthHash] auth
     # @return [Hash] The user attributes
@@ -27,6 +29,10 @@ module IdViennaSaml
         last_name: attrs.fetch('urn:oid:1.2.40.0.10.2.1.1.261.20').first,
         locale: AppConfiguration.instance.settings.dig('core', 'locales').first
       }
+    end
+
+    def profile_to_uid(auth)
+      auth.dig('extra', 'raw_info', USERID_KEY)&.first
     end
 
     # Configures the SAML endpoint to authenticate with Vienna's IdP for employees

--- a/back/engines/commercial/id_vienna_saml/spec/requests/citizen_authentication_spec.rb
+++ b/back/engines/commercial/id_vienna_saml/spec/requests/citizen_authentication_spec.rb
@@ -15,12 +15,19 @@ describe 'Vienna SAML citizen authentication' do
     configuration.save!
   end
 
+  def send_auth_request
+    @uid = "_#{SecureRandom.hex}" # uid is unique per request, not per user
+    saml_auth_response.uid = @uid # make sure it's overwritten even if saml_auth_response is cached
+    get '/auth/vienna_citizen'
+    follow_redirect!
+  end
+
   let(:user) { create(:user) }
   let(:saml_auth_response) do
     OmniAuth::AuthHash.new(
       {
         'provider' => 'vienna_citizen',
-        'uid' => '_254e789de8e21e632c8ca2c71aacc980',
+        'uid' => @uid,
         'info' => { 'name' => nil, 'email' => nil, 'first_name' => nil, 'last_name' => nil },
         'credentials' => {},
         'extra' =>
@@ -29,7 +36,7 @@ describe 'Vienna SAML citizen authentication' do
            'http://lfrz.at/stdportal/names/pvp2/txid' => ['101840$tkhx@7009p1'],
            'urn:oid:2.5.4.11' => ['MA 01'],
            'urn:oid:1.2.40.0.10.2.1.1.261.20' => ['Preß'],
-           'urn:oid:0.9.2342.19200300.100.1.3' => ['philipp.press@extern.wien.gv.at'],
+           'urn:oid:0.9.2342.19200300.100.1.3' => ['philipp.test@extern.wien.gv.at'],
            'urn:oid:1.2.40.0.10.2.1.1.261.10' => ['2.1'],
            'urn:oid:1.2.40.0.10.2.1.1.153' => ['L9-M01'],
            'urn:oid:0.9.2342.19200300.100.1.1' => ['wien1.prp9002@wien.gv.at'],
@@ -55,8 +62,7 @@ describe 'Vienna SAML citizen authentication' do
 
   context 'when the user does not exist yet' do
     before do
-      get '/auth/vienna_citizen'
-      follow_redirect!
+      send_auth_request
     end
 
     it 'redirects to complete signup path' do
@@ -64,9 +70,9 @@ describe 'Vienna SAML citizen authentication' do
     end
 
     it 'creates the user and identity' do
-      user = User.find_by(email: 'philipp.press@extern.wien.gv.at', first_name: 'Philipp', last_name: 'Preß')
+      user = User.find_by(email: 'philipp.test@extern.wien.gv.at', first_name: 'Philipp', last_name: 'Preß')
       expect(user).to be_present
-      expect(user.identities.first).to have_attributes(provider: 'vienna_citizen', uid: '_254e789de8e21e632c8ca2c71aacc980')
+      expect(user.identities.first).to have_attributes(provider: 'vienna_citizen', uid: 'wien1.prp9002@wien.gv.at')
     end
 
     it 'sets the JWT auth token' do
@@ -76,13 +82,12 @@ describe 'Vienna SAML citizen authentication' do
 
   context 'when the user already exists' do
     before do
-      create(:user, email: 'philipp.press@extern.wien.gv.at', first_name: 'Bob', last_name: 'Alice')
-      get '/auth/vienna_citizen'
-      follow_redirect!
+      create(:user, email: 'philipp.test@extern.wien.gv.at', first_name: 'Bob', last_name: 'Alice')
+      send_auth_request
     end
 
     it 'does not overwrite first name & last name with the data from the auth response' do
-      user = User.find_by(email: 'philipp.press@extern.wien.gv.at')
+      user = User.find_by(email: 'philipp.test@extern.wien.gv.at')
       expect(user).to have_attributes(first_name: 'Bob', last_name: 'Alice')
     end
 
@@ -95,45 +100,41 @@ describe 'Vienna SAML citizen authentication' do
     end
   end
 
-  context 'when the SAML response does not include first name and laste name' do
+  context 'when the user was already registered with Vienna SAML' do
     before do
-      get '/auth/vienna_citizen'
-      follow_redirect!
+      send_auth_request
     end
 
-    let(:saml_auth_response) do
-      OmniAuth::AuthHash.new(
-        {
-          'provider' => 'vienna_citizen',
-          'uid' => '_254e789de8e21e632c8ca2c71aacc980',
-          'info' => { 'name' => nil, 'email' => nil, 'first_name' => nil, 'last_name' => nil },
-          'credentials' => {},
-          'extra' =>
-          { 'raw_info' =>
-            { 'urn:oid:1.2.40.0.10.2.1.1.71' => ['AT:VKZ:L9'],
-              'http://lfrz.at/stdportal/names/pvp2/txid' => ['101840$tkhx@7009p1'],
-              'urn:oid:2.5.4.11' => ['MA 01'],
-              'urn:oid:0.9.2342.19200300.100.1.3' => ['philipp.test@extern.wien.gv.at'],
-              'urn:oid:1.2.40.0.10.2.1.1.261.10' => ['2.1'],
-              'urn:oid:1.2.40.0.10.2.1.1.153' => ['L9-M01'],
-              'urn:oid:0.9.2342.19200300.100.1.1' => ['wien1.prp9002@wien.gv.at'],
-              'urn:oid:1.2.40.0.10.2.1.1.261.30' => ['access()'],
-              'urn:oid:1.2.40.0.10.2.1.1.261.24' => ['L9'],
-              'urn:oid:1.2.40.0.10.2.1.1.261.110' => ['1'],
-              'urn:oid:1.2.40.0.10.2.1.1.3' => ['AT:VKZ:L9-M01'],
-              'urn:oid:1.2.40.0.10.2.1.1.1' => ['AT:L9:1:magwien.gv.at/prp9002'],
-              'http://lfrz.at/stdportal/names/pvp/gvoudomain' => ['magwien.gv.at'],
-              'fingerprint' => '09:ED:23:7D:BC:95:A7:37:15:F6:76:4B:0A:AF:D5:CB:36:0D:47:14' },
-            'session_index' => '_45ff99f6f7b2bc6553cd9a7868b96e33',
-            'response_object' => OneLogin::RubySaml::Response.new('fakeresponse') }
-        }
-      )
+    it 'does not create second identity' do
+      expect do
+        send_auth_request
+      end.not_to change(Identity, :count)
+    end
+
+    context 'when the user changed their email address' do
+      before do
+        saml_auth_response.extra.raw_info['urn:oid:0.9.2342.19200300.100.1.3'] = ['alex@citizenlab.co']
+      end
+
+      it 'does not create another identity and user account' do
+        expect do
+          send_auth_request
+        end.not_to change { [Identity.count, User.count] }
+      end
+    end
+  end
+
+  context 'when the SAML response does not include first name and last name' do
+    before do
+      saml_auth_response.extra.raw_info.delete('urn:oid:1.2.40.0.10.2.1.1.261.20')
+      saml_auth_response.extra.raw_info.delete('urn:oid:2.5.4.42')
+      send_auth_request
     end
 
     it 'creates the user and identity with initials based on the email' do
       user = User.find_by(email: 'philipp.test@extern.wien.gv.at', first_name: 'P', last_name: 'T')
       expect(user).to be_present
-      expect(user.identities.first).to have_attributes(provider: 'vienna_citizen', uid: '_254e789de8e21e632c8ca2c71aacc980')
+      expect(user.identities.first).to have_attributes(provider: 'vienna_citizen', uid: 'wien1.prp9002@wien.gv.at')
     end
   end
 end

--- a/back/engines/commercial/id_vienna_saml/spec/requests/citizen_authentication_spec.rb
+++ b/back/engines/commercial/id_vienna_saml/spec/requests/citizen_authentication_spec.rb
@@ -3,82 +3,13 @@
 require 'rails_helper'
 require 'rspec_api_documentation/dsl'
 
+require_relative 'shared'
+
 describe 'Vienna SAML citizen authentication' do
-  def enable_vienna_citizen_login
-    configuration = AppConfiguration.instance
-    settings = configuration.settings
-    settings['vienna_citizen_login'] = {
-      allowed: true,
-      enabled: true,
-      environment: 'test'
-    }
-    configuration.save!
-  end
+  include_context 'with Vienna SAML authentication enabled', 'vienna_citizen'
 
-  def send_auth_request
-    @uid = "_#{SecureRandom.hex}" # uid is unique per request, not per user
-    saml_auth_response.uid = @uid # make sure it's overwritten even if saml_auth_response is cached
-    get '/auth/vienna_citizen'
-    follow_redirect!
-  end
-
-  let(:user) { create(:user) }
-  let(:saml_auth_response) do
-    OmniAuth::AuthHash.new(
-      {
-        'provider' => 'vienna_citizen',
-        'uid' => @uid,
-        'info' => { 'name' => nil, 'email' => nil, 'first_name' => nil, 'last_name' => nil },
-        'credentials' => {},
-        'extra' =>
-        { 'raw_info' =>
-         { 'urn:oid:1.2.40.0.10.2.1.1.71' => ['AT:VKZ:L9'],
-           'http://lfrz.at/stdportal/names/pvp2/txid' => ['101840$tkhx@7009p1'],
-           'urn:oid:2.5.4.11' => ['MA 01'],
-           'urn:oid:1.2.40.0.10.2.1.1.261.20' => ['Preß'],
-           'urn:oid:0.9.2342.19200300.100.1.3' => ['philipp.test@extern.wien.gv.at'],
-           'urn:oid:1.2.40.0.10.2.1.1.261.10' => ['2.1'],
-           'urn:oid:1.2.40.0.10.2.1.1.153' => ['L9-M01'],
-           'urn:oid:0.9.2342.19200300.100.1.1' => ['wien1.prp9002@wien.gv.at'],
-           'urn:oid:1.2.40.0.10.2.1.1.261.30' => ['access()'],
-           'urn:oid:1.2.40.0.10.2.1.1.261.24' => ['L9'],
-           'urn:oid:1.2.40.0.10.2.1.1.261.110' => ['1'],
-           'urn:oid:2.5.4.42' => ['Philipp'],
-           'urn:oid:1.2.40.0.10.2.1.1.3' => ['AT:VKZ:L9-M01'],
-           'urn:oid:1.2.40.0.10.2.1.1.1' => ['AT:L9:1:magwien.gv.at/prp9002'],
-           'http://lfrz.at/stdportal/names/pvp/gvoudomain' => ['magwien.gv.at'],
-           'fingerprint' => '09:ED:23:7D:BC:95:A7:37:15:F6:76:4B:0A:AF:D5:CB:36:0D:47:14' },
-          'session_index' => '_45ff99f6f7b2bc6553cd9a7868b96e33',
-          'response_object' => OneLogin::RubySaml::Response.new('fakeresponse') }
-      }
-    )
-  end
-
-  before do
-    OmniAuth.config.test_mode = true
-    OmniAuth.config.mock_auth[:vienna_citizen] = saml_auth_response
-    enable_vienna_citizen_login
-  end
-
-  context 'when the user does not exist yet' do
-    before do
-      send_auth_request
-    end
-
-    it 'redirects to complete signup path' do
-      expect(response).to redirect_to('/en/complete-signup?')
-    end
-
-    it 'creates the user and identity' do
-      user = User.find_by(email: 'philipp.test@extern.wien.gv.at', first_name: 'Philipp', last_name: 'Preß')
-      expect(user).to be_present
-      expect(user.identities.first).to have_attributes(provider: 'vienna_citizen', uid: 'wien1.prp9002@wien.gv.at')
-    end
-
-    it 'sets the JWT auth token' do
-      expect(cookies[:cl2_jwt]).to be_present
-    end
-  end
+  include_examples 'authenticates when the user does not exist yet', 'vienna_citizen'
+  include_examples 'authenticates when the user was already registered with Vienna SAML'
 
   context 'when the user already exists' do
     before do
@@ -91,36 +22,9 @@ describe 'Vienna SAML citizen authentication' do
       expect(user).to have_attributes(first_name: 'Bob', last_name: 'Alice')
     end
 
-    it 'sets the JWT auth token' do
+    it 'sets the JWT auth token and redirects to home page' do
       expect(cookies[:cl2_jwt]).to be_present
-    end
-
-    it 'redirects to home page' do
       expect(response).to redirect_to('/en?')
-    end
-  end
-
-  context 'when the user was already registered with Vienna SAML' do
-    before do
-      send_auth_request
-    end
-
-    it 'does not create second identity' do
-      expect do
-        send_auth_request
-      end.not_to change(Identity, :count)
-    end
-
-    context 'when the user changed their email address' do
-      before do
-        saml_auth_response.extra.raw_info['urn:oid:0.9.2342.19200300.100.1.3'] = ['alex@citizenlab.co']
-      end
-
-      it 'does not create another identity and user account' do
-        expect do
-          send_auth_request
-        end.not_to change { [Identity.count, User.count] }
-      end
     end
   end
 

--- a/back/engines/commercial/id_vienna_saml/spec/requests/citizen_authentication_spec.rb
+++ b/back/engines/commercial/id_vienna_saml/spec/requests/citizen_authentication_spec.rb
@@ -30,8 +30,8 @@ describe 'Vienna SAML citizen authentication' do
 
   context 'when the SAML response does not include first name and last name' do
     before do
-      saml_auth_response.extra.raw_info.delete('urn:oid:1.2.40.0.10.2.1.1.261.20')
-      saml_auth_response.extra.raw_info.delete('urn:oid:2.5.4.42')
+      delete_raw_info_attribute('urn:oid:1.2.40.0.10.2.1.1.261.20')
+      delete_raw_info_attribute('urn:oid:2.5.4.42')
       send_auth_request
     end
 

--- a/back/engines/commercial/id_vienna_saml/spec/requests/employee_authentication_spec.rb
+++ b/back/engines/commercial/id_vienna_saml/spec/requests/employee_authentication_spec.rb
@@ -3,94 +3,27 @@
 require 'rails_helper'
 require 'rspec_api_documentation/dsl'
 
+require_relative 'shared'
+
 describe 'Vienna SAML employee authentication' do
-  def enable_vienna_employee_login
-    configuration = AppConfiguration.instance
-    settings = configuration.settings
-    settings['vienna_employee_login'] = {
-      allowed: true,
-      enabled: true,
-      environment: 'test'
-    }
-    configuration.save!
-  end
+  include_context 'with Vienna SAML authentication enabled', 'vienna_employee'
 
-  let(:user) { create(:user) }
-  let(:saml_auth_response) do
-    OmniAuth::AuthHash.new(
-      {
-        'provider' => 'vienna_employee',
-        'uid' => '_254e789de8e21e632c8ca2c71aacc980',
-        'info' => { 'name' => nil, 'email' => nil, 'first_name' => nil, 'last_name' => nil },
-        'credentials' => {},
-        'extra' =>
-        { 'raw_info' =>
-         { 'urn:oid:1.2.40.0.10.2.1.1.71' => ['AT:VKZ:L9'],
-           'http://lfrz.at/stdportal/names/pvp2/txid' => ['101840$tkhx@7009p1'],
-           'urn:oid:2.5.4.11' => ['MA 01'],
-           'urn:oid:1.2.40.0.10.2.1.1.261.20' => ['Preß'],
-           'urn:oid:0.9.2342.19200300.100.1.3' => ['philipp.press@extern.wien.gv.at'],
-           'urn:oid:1.2.40.0.10.2.1.1.261.10' => ['2.1'],
-           'urn:oid:1.2.40.0.10.2.1.1.153' => ['L9-M01'],
-           'urn:oid:0.9.2342.19200300.100.1.1' => ['wien1.prp9002@wien.gv.at'],
-           'urn:oid:1.2.40.0.10.2.1.1.261.30' => ['access()'],
-           'urn:oid:1.2.40.0.10.2.1.1.261.24' => ['L9'],
-           'urn:oid:1.2.40.0.10.2.1.1.261.110' => ['1'],
-           'urn:oid:2.5.4.42' => ['Philipp'],
-           'urn:oid:1.2.40.0.10.2.1.1.3' => ['AT:VKZ:L9-M01'],
-           'urn:oid:1.2.40.0.10.2.1.1.1' => ['AT:L9:1:magwien.gv.at/prp9002'],
-           'http://lfrz.at/stdportal/names/pvp/gvoudomain' => ['magwien.gv.at'],
-           'fingerprint' => '09:ED:23:7D:BC:95:A7:37:15:F6:76:4B:0A:AF:D5:CB:36:0D:47:14' },
-          'session_index' => '_45ff99f6f7b2bc6553cd9a7868b96e33',
-          'response_object' => OneLogin::RubySaml::Response.new('fakeresponse') }
-      }
-    )
-  end
-
-  before do
-    OmniAuth.config.test_mode = true
-    OmniAuth.config.mock_auth[:vienna_employee] = saml_auth_response
-    enable_vienna_employee_login
-  end
-
-  context 'when the user does not exist yet' do
-    before do
-      get '/auth/vienna_employee'
-      follow_redirect!
-    end
-
-    it 'redirects to complete signup path' do
-      expect(response).to redirect_to('/en/complete-signup?')
-    end
-
-    it 'creates the user and identity' do
-      user = User.find_by(email: 'philipp.press@extern.wien.gv.at', first_name: 'Philipp', last_name: 'Preß')
-      expect(user).to be_present
-      expect(user.identities.first).to have_attributes(provider: 'vienna_employee', uid: '_254e789de8e21e632c8ca2c71aacc980')
-    end
-
-    it 'sets the JWT auth token' do
-      expect(cookies[:cl2_jwt]).to be_present
-    end
-  end
+  include_examples 'authenticates when the user does not exist yet', 'vienna_employee'
+  include_examples 'authenticates when the user was already registered with Vienna SAML'
 
   context 'when the user already exists' do
     before do
-      create(:user, email: 'philipp.press@extern.wien.gv.at')
-      get '/auth/vienna_employee'
-      follow_redirect!
+      create(:user, email: 'philipp.test@extern.wien.gv.at')
+      send_auth_request
     end
 
     it 'updates the user attributes with the data from the auth response' do
-      user = User.find_by(email: 'philipp.press@extern.wien.gv.at')
+      user = User.find_by(email: 'philipp.test@extern.wien.gv.at')
       expect(user).to have_attributes(first_name: 'Philipp', last_name: 'Preß')
     end
 
-    it 'sets the JWT auth token' do
+    it 'sets the JWT auth token and redirects to home page' do
       expect(cookies[:cl2_jwt]).to be_present
-    end
-
-    it 'redirects to home page' do
       expect(response).to redirect_to('/en?')
     end
   end

--- a/back/engines/commercial/id_vienna_saml/spec/requests/shared.rb
+++ b/back/engines/commercial/id_vienna_saml/spec/requests/shared.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.shared_context 'with Vienna SAML authentication enabled' do |provider_name|
+  define_method :enable_vienna_login do
+    configuration = AppConfiguration.instance
+    settings = configuration.settings
+    settings["#{provider_name}_login"] = {
+      allowed: true,
+      enabled: true,
+      environment: 'test'
+    }
+    configuration.save!
+  end
+
+  define_method :send_auth_request do
+    @uid = "_#{SecureRandom.hex}" # uid is unique per request, not per user
+    saml_auth_response.uid = @uid # make sure it's overwritten even if saml_auth_response is cached
+    get "/auth/#{provider_name}"
+    follow_redirect!
+  end
+
+  let(:user) { create(:user) }
+  let(:saml_auth_response) do
+    OmniAuth::AuthHash.new(
+      {
+        'provider' => provider_name,
+        'uid' => @uid,
+        'info' => { 'name' => nil, 'email' => nil, 'first_name' => nil, 'last_name' => nil },
+        'credentials' => {},
+        'extra' =>
+        { 'raw_info' =>
+         { 'urn:oid:1.2.40.0.10.2.1.1.71' => ['AT:VKZ:L9'],
+           'http://lfrz.at/stdportal/names/pvp2/txid' => ['101840$tkhx@7009p1'],
+           'urn:oid:2.5.4.11' => ['MA 01'],
+           'urn:oid:1.2.40.0.10.2.1.1.261.20' => ['Preß'],
+           'urn:oid:0.9.2342.19200300.100.1.3' => ['philipp.test@extern.wien.gv.at'],
+           'urn:oid:1.2.40.0.10.2.1.1.261.10' => ['2.1'],
+           'urn:oid:1.2.40.0.10.2.1.1.153' => ['L9-M01'],
+           'urn:oid:0.9.2342.19200300.100.1.1' => ['wien1.prp9002@wien.gv.at'],
+           'urn:oid:1.2.40.0.10.2.1.1.261.30' => ['access()'],
+           'urn:oid:1.2.40.0.10.2.1.1.261.24' => ['L9'],
+           'urn:oid:1.2.40.0.10.2.1.1.261.110' => ['1'],
+           'urn:oid:2.5.4.42' => ['Philipp'],
+           'urn:oid:1.2.40.0.10.2.1.1.3' => ['AT:VKZ:L9-M01'],
+           'urn:oid:1.2.40.0.10.2.1.1.1' => ['AT:L9:1:magwien.gv.at/prp9002'],
+           'http://lfrz.at/stdportal/names/pvp/gvoudomain' => ['magwien.gv.at'],
+           'fingerprint' => '09:ED:23:7D:BC:95:A7:37:15:F6:76:4B:0A:AF:D5:CB:36:0D:47:14' },
+          'session_index' => '_45ff99f6f7b2bc6553cd9a7868b96e33',
+          'response_object' => OneLogin::RubySaml::Response.new('fakeresponse') }
+      }
+    )
+  end
+
+  before do
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[provider_name.to_sym] = saml_auth_response
+    enable_vienna_login
+  end
+end
+
+RSpec.shared_examples 'authenticates when the user does not exist yet' do |provider_name|
+  context 'when the user does not exist yet' do
+    before do
+      send_auth_request
+    end
+
+    it 'creates the user and identity' do
+      user = User.find_by(email: 'philipp.test@extern.wien.gv.at', first_name: 'Philipp', last_name: 'Preß')
+      expect(user).to be_present
+      expect(user.identities.first).to have_attributes(provider: provider_name, uid: 'wien1.prp9002@wien.gv.at')
+    end
+
+    it 'sets the JWT auth token and redirects to complete signup path' do
+      expect(cookies[:cl2_jwt]).to be_present
+      expect(response).to redirect_to('/en/complete-signup?')
+    end
+  end
+end
+
+RSpec.shared_examples 'authenticates when the user was already registered with Vienna SAML' do
+  context 'when the user was already registered with Vienna SAML' do
+    before do
+      send_auth_request
+    end
+
+    it 'does not create second identity' do
+      expect do
+        send_auth_request
+      end.not_to change(Identity, :count)
+    end
+
+    context 'when the user changed their email address' do
+      before do
+        saml_auth_response.extra.raw_info['urn:oid:0.9.2342.19200300.100.1.3'] = ['test@citizenlab.co']
+      end
+
+      it 'does not create another identity and user account' do
+        expect do
+          send_auth_request
+        end.not_to change { [Identity.count, User.count] }
+      end
+    end
+  end
+end

--- a/back/engines/commercial/verification/app/services/verification/verification_service.rb
+++ b/back/engines/commercial/verification/app/services/verification/verification_service.rb
@@ -67,11 +67,7 @@ module Verification
       method = method_by_name(auth.provider)
       raise NotEntitledError if method.respond_to?(:entitled?) && !method.entitled?(auth)
 
-      uid = if method.respond_to?(:profile_to_uid)
-        method.profile_to_uid(auth)
-      else
-        auth['uid']
-      end
+      uid = method.profile_to_uid(auth)
       make_verification(user: user, method_name: method.name, uid: uid)
     end
 

--- a/back/lib/omniauth_methods/base.rb
+++ b/back/lib/omniauth_methods/base.rb
@@ -18,6 +18,10 @@ module OmniauthMethods
       auth['uid']
     end
 
+    def filter_auth_to_persist(auth)
+      auth
+    end
+
     # @return [Array<Symbol>] Returns a list of user attributes that can be updated from the auth response hash
     def updateable_user_attrs
       []

--- a/back/lib/omniauth_methods/base.rb
+++ b/back/lib/omniauth_methods/base.rb
@@ -14,6 +14,10 @@ module OmniauthMethods
       {}
     end
 
+    def profile_to_uid(auth)
+      auth['uid']
+    end
+
     # @return [Array<Symbol>] Returns a list of user attributes that can be updated from the auth response hash
     def updateable_user_attrs
       []

--- a/back/lib/tasks/single_use/20240124_rename_most_voted_ideas_widget.rake
+++ b/back/lib/tasks/single_use/20240124_rename_most_voted_ideas_widget.rake
@@ -5,9 +5,9 @@ MULTILOC_TYPES = {
 }
 TEXT_PROPS = %w[text alt title]
 
-namespace :rename_most_voted_ideas_widget do
+namespace :single_use do
   desc 'Fix existing layouts'
-  task :run, %i[content_buildable_type] => [:environment] do |_t, args|
+  task :rename_most_voted_ideas_widget, %i[content_buildable_type] => [:environment] do |_t, args|
     errors = {}
     Tenant.prioritize(Tenant.creation_finalized).each do |tenant|
       Rails.logger.info tenant.host

--- a/back/lib/tasks/single_use/20240125_convert_vienna_uid_to_userid.rake
+++ b/back/lib/tasks/single_use/20240125_convert_vienna_uid_to_userid.rake
@@ -4,7 +4,7 @@ namespace :single_use do
   task convert_vienna_uid_to_userid: [:environment] do |_t, _args|
     Tenant.find_by(host: 'mitgestalten.wien.gv.at').switch do
       Identity.all.find_each do |identity|
-        new_uid = identity.auth_hash.dig('extra', 'raw_info').to_h['urn:oid:0.9.2342.19200300.100.1.1']
+        new_uid = identity.auth_hash.dig('extra', 'raw_info').to_h['urn:oid:0.9.2342.19200300.100.1.1'].first
         identity.update!(uid: new_uid)
       end
     end

--- a/back/lib/tasks/single_use/20240125_convert_vienna_uid_to_userid.rake
+++ b/back/lib/tasks/single_use/20240125_convert_vienna_uid_to_userid.rake
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+namespace :single_use do
+  task convert_vienna_uid_to_userid: [:environment] do |_t, _args|
+    Tenant.find_by(host: 'mitgestalten.wien.gv.at').switch do
+      Identity.all.find_each do |identity|
+        new_uid = identity.auth_hash.dig('extra', 'raw_info').to_h['urn:oid:0.9.2342.19200300.100.1.1']
+        identity.update!(uid: new_uid)
+      end
+    end
+  end
+end


### PR DESCRIPTION
See [the docs](https://www.notion.so/citizenlab/SSO-ID-set-up-locally-and-test-a176dd3e335f47c28f949e5962d32a26?pvs=4#8104d22eeb10448ba71a2925745ecc10) on how to test it e2e.

# Changelog
## Fixed
* [TAN-867] Prevent auto-creating a new CL account when a Vienna citizen changes their email and logs in to CL again