### PR TITLE
Fix broken link to project access rights

### DIFF
--- a/front/app/containers/ProjectsShowPage/shared/header/ProjectInfoSideBar/index.tsx
+++ b/front/app/containers/ProjectsShowPage/shared/header/ProjectInfoSideBar/index.tsx
@@ -49,6 +49,7 @@ import FormattedBudget from 'utils/currency/FormattedBudget';
 // style
 import styled from 'styled-components';
 import Link from 'utils/cl-router/Link';
+import { adminProjectsProjectPath } from 'containers/Admin/projects/routes';
 
 const Container = styled.div``;
 
@@ -251,7 +252,9 @@ const ProjectInfoSideBar = memo<Props>(({ projectId, className }) => {
                             values={{
                               accessRightsLink: (
                                 <Link
-                                  to={`/admin/projects/${projectId}/permissions`}
+                                  to={`${adminProjectsProjectPath(
+                                    projectId
+                                  )}/settings/access-rights`}
                                 >
                                   <FormattedMessage
                                     {...messages.accessRights}


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Link in project participants tooltip goes to project access rights again. [Ticket for details](https://www.notion.so/citizenlab/Broken-link-to-project-permissions-d0b2fe9e45fa4ed5aad25b9f446cf998?pvs=4).