### PR TITLE
[NO-TICKET] Fix analysis filter

### DIFF
--- a/back/engines/commercial/analysis/app/services/analysis/inputs_finder.rb
+++ b/back/engines/commercial/analysis/app/services/analysis/inputs_finder.rb
@@ -49,7 +49,7 @@ module Analysis
       scope = inputs
       if params[:input_custom_field_no_empty_values]
         analysis.custom_fields.pluck(:key).each do |key|
-          scope = scope.where.not("custom_field_values->>'#{key}' IS NULL")
+          scope = scope.where.not("ideas.custom_field_values->>'#{key}' IS NULL")
         end
       end
       scope

--- a/front/app/containers/Admin/projects/project/analysis/FilterItems/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/FilterItems/index.tsx
@@ -152,7 +152,7 @@ const FilterItems = ({ filters, isEditable }: FilterItemsProps) => {
             >
               <Box>{formatMessage(translationKeys[key].translationKey)}</Box>
               <Box mx="3px">{translationKeys[key].predicate}</Box>
-              <EllipsisFilterValue>{value}</EllipsisFilterValue>
+              <EllipsisFilterValue>{value?.toString()}</EllipsisFilterValue>
               {isEditable && (
                 <IconButton
                   iconName="close"

--- a/front/app/containers/Admin/projects/project/analysis/hooks/useAnalysisFilterParams.ts
+++ b/front/app/containers/Admin/projects/project/analysis/hooks/useAnalysisFilterParams.ts
@@ -13,8 +13,9 @@ const STATIC_SCALAR_FILTERS = [
   'votes_to',
   'comments_from',
   'comments_to',
-  'input_custom_field_no_empty_values',
 ];
+
+const STATIC_BOOLEAN_FILTERS = ['input_custom_field_no_empty_values'];
 
 const STATIC_ARRAY_FILTERS = ['tag_ids'];
 
@@ -27,7 +28,9 @@ const useAnalysisFilterParams = () => {
 
   const filters = Object.entries(allParams).reduce(
     (accumulator, [key, value]) => {
-      if (
+      if (STATIC_BOOLEAN_FILTERS.includes(key)) {
+        accumulator[key] = value === 'true' ? true : false;
+      } else if (
         key.match(/^(author|input)_custom_([a-f0-9-]+)$/) ||
         STATIC_ARRAY_FILTERS.includes(key)
       ) {


### PR DESCRIPTION
# Changelog
## Fixed
- In the analysis tool, the "no answer" filter can now be combined with filters related to the input author (gender, areas, etc.) without producing an error
