### PR TITLE
[TAN-966] Use the common docker-compose file for Europe cluster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -877,9 +877,9 @@ workflows:
               only:
                 - production
           ssh_host: $CITIZENLAB_CLUSTER_IP_ADDRESS_EUROPE
-          compose_file: docker-compose-production-benelux.yml
+          compose_file: docker-compose-production.yml
           stack_name: cl2-prd-bnlx-stack
-          env_file: ".env-production-benelux"
+          env_file: ".env-web"
           cluster_name: "eu"
       - back-deploy-to-swarm:
           name: Deploy to Canada


### PR DESCRIPTION
Use the same docker-compose file for the Europe cluster as for the other clusters and update the env file which was moved to .env-web.


# Changelog
## Technical
- [TAN-966] Use the same docker-compose file for the Europe cluster as for the other clusters and update the env file which was moved to `.env-web`.
