### PR TITLE
Handle basemap for Vienna

### DIFF
--- a/front/app/components/EsriMap/index.tsx
+++ b/front/app/components/EsriMap/index.tsx
@@ -5,7 +5,6 @@ import '@arcgis/core/assets/esri/themes/light/main.css';
 import Map from '@arcgis/core/Map';
 import MapView from '@arcgis/core/views/MapView';
 import Basemap from '@arcgis/core/Basemap';
-import WebTileLayer from '@arcgis/core/layers/WebTileLayer';
 import Layer from '@arcgis/core/layers/Layer';
 import Graphic from '@arcgis/core/Graphic';
 import { Box } from '@citizenlab/cl2-component-library';
@@ -15,9 +14,8 @@ import Fullscreen from '@arcgis/core/widgets/Fullscreen';
 import useAppConfiguration from 'api/app_configuration/useAppConfiguration';
 
 // utils
-import { getTileAttribution } from './utils';
+import { getDefaultBasemap } from './utils';
 import { isNil } from 'utils/helperUtils';
-import { DEFAULT_TILE_PROVIDER } from './constants';
 
 type Props = {
   center?: GeoJSON.Point | null;
@@ -65,13 +63,8 @@ const EsriMap = ({
     });
 
     // Set the basemap
-    const webTileLayerFromUrl = new WebTileLayer({
-      urlTemplate: globalMapSettings?.tile_provider || DEFAULT_TILE_PROVIDER,
-      copyright: getTileAttribution(globalMapSettings?.tile_provider || ''),
-    });
-
     esriMap.basemap = new Basemap({
-      baseLayers: [webTileLayerFromUrl],
+      baseLayers: [getDefaultBasemap(globalMapSettings?.tile_provider)],
     });
 
     // Add any layers that were passed in

--- a/front/app/components/EsriMap/utils.tsx
+++ b/front/app/components/EsriMap/utils.tsx
@@ -21,16 +21,17 @@ export const getDefaultBasemap = (tileProvider: string | undefined): Layer => {
   if (tileProvider?.includes('wien.gv.at/basemap')) {
     return new VectorTileLayer({
       // For Vienna's custom basemap, we fetch a vector tile layer
+      // NOTE: Currently only Vienna requires this. If we ever need to add this for other clients, we
+      // move lift this into a separate configuration somewhere.
       portalItem: {
         id: 'd607c5c98e6a4e1fbd3569e38c5c8a0c',
       },
     });
-  } else {
-    return new WebTileLayer({
-      urlTemplate: tileProvider || DEFAULT_TILE_PROVIDER,
-      copyright: getTileAttribution(tileProvider || ''),
-    });
   }
+  return new WebTileLayer({
+    urlTemplate: tileProvider || DEFAULT_TILE_PROVIDER,
+    copyright: getTileAttribution(tileProvider || ''),
+  });
 };
 
 // getTileAttribution

--- a/front/app/components/EsriMap/utils.tsx
+++ b/front/app/components/EsriMap/utils.tsx
@@ -1,14 +1,41 @@
 import { colors } from '@citizenlab/cl2-component-library';
 
+// components
+import VectorTileLayer from '@arcgis/core/layers/VectorTileLayer';
+import WebTileLayer from '@arcgis/core/layers/WebTileLayer';
+import Layer from '@arcgis/core/layers/Layer';
+
 // constants
-import { BASEMAP_AT_ATTRIBUTION, MAPTILER_ATTRIBUTION } from './constants';
+import {
+  BASEMAP_AT_ATTRIBUTION,
+  DEFAULT_TILE_PROVIDER,
+  MAPTILER_ATTRIBUTION,
+} from './constants';
 
 // components
 import SimpleMarkerSymbol from '@arcgis/core/symbols/SimpleMarkerSymbol';
 
+// getDefaultBasemap
+// Description: Gets the correct basemap given a certain tileProvider URL.
+export const getDefaultBasemap = (tileProvider: string | undefined): Layer => {
+  if (tileProvider?.includes('wien.gv.at/basemap')) {
+    return new VectorTileLayer({
+      // For Vienna's custom basemap, we fetch a vector tile layer
+      portalItem: {
+        id: 'd607c5c98e6a4e1fbd3569e38c5c8a0c',
+      },
+    });
+  } else {
+    return new WebTileLayer({
+      urlTemplate: tileProvider || DEFAULT_TILE_PROVIDER,
+      copyright: getTileAttribution(tileProvider || ''),
+    });
+  }
+};
+
 // getTileAttribution
 // Description: Gets the correct tile attribution given a certain tileProvider URL.
-export const getTileAttribution = (tileProvider: string): string => {
+const getTileAttribution = (tileProvider: string): string => {
   if (tileProvider?.includes('maptiler')) {
     return MAPTILER_ATTRIBUTION;
   }

--- a/front/app/components/EsriMap/utils.tsx
+++ b/front/app/components/EsriMap/utils.tsx
@@ -22,7 +22,7 @@ export const getDefaultBasemap = (tileProvider: string | undefined): Layer => {
     return new VectorTileLayer({
       // For Vienna's custom basemap, we fetch a vector tile layer
       // NOTE: Currently only Vienna requires this. If we ever need to add this for other clients, we
-      // move lift this into a separate configuration somewhere.
+      // should move this into a separate configuration somewhere.
       portalItem: {
         id: 'd607c5c98e6a4e1fbd3569e38c5c8a0c',
       },


### PR DESCRIPTION
# Description
Noticed on staging that Vienna's basemap wasn't working for the new Events changes. Now I fetch the data as a VectorTileLayer instead so this works.

I also added the default basemap creation into it's own util function so it was a bit cleaner.

# Context
It might help to look at my first Esri mapping PR for context, where the Esri ArcGIS SDK was introduced: https://github.com/CitizenLabDotCo/citizenlab/pull/6907
Also happy to have a meeting to discuss if that's more helpful :)