### PR TITLE
[No-ticket] Disable rubocop class length warning for ProjectCopyService

### DIFF
--- a/back/app/services/project_copy_service.rb
+++ b/back/app/services/project_copy_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ProjectCopyService < TemplateService
+class ProjectCopyService < TemplateService # rubocop:disable Metrics/ClassLength
   def import(template, folder: nil, local_copy: false)
     same_template = MultiTenancy::Templates::Utils.translate_and_fix_locales(template)
 


### PR DESCRIPTION
# Changelog
## Technical
[No-ticket] Disable rubocop class length warning for ProjectCopyService
