### PR TITLE
Add missing email campaign types in FE

### DIFF
--- a/front/app/api/campaigns/types.ts
+++ b/front/app/api/campaigns/types.ts
@@ -75,8 +75,12 @@ type RegisterUserCampaignName =
   | 'comment_on_your_comment'
   | 'comment_on_idea_you_follow'
   | 'comment_on_initiative_you_follow'
+  | 'cosponsor_of_your_initiative'
+  | 'event_registration_confirmation'
   | 'idea_published'
+  | 'invite_received'
   | 'invite_reminder'
+  | 'invitation_to_cosponsor'
   | 'initiative_published'
   | 'mention_in_official_feedback'
   | 'official_feedback_on_idea_you_follow'
@@ -86,7 +90,12 @@ type RegisterUserCampaignName =
   | 'project_published'
   | 'status_change_on_idea_you_follow'
   | 'status_change_on_initiative_you_follow'
-  | 'user_digest';
+  | 'user_digest'
+  | 'voting_basket_not_submitted'
+  | 'voting_basket_submitted'
+  | 'voting_last_chance'
+  | 'voting_phase_started'
+  | 'voting_results';
 
 export const internalCommentNotificationTypes = [
   'mention_in_internal_comment',
@@ -109,6 +118,7 @@ type AdminModeratorCampaignName =
   | 'idea_marked_as_spam'
   | 'initiative_assigned_to_you'
   | 'initiative_marked_as_spam'
+  | 'initiative_resubmitted_for_review'
   | 'new_comment_for_admin'
   | 'new_idea_for_admin'
   | 'new_initiative_for_admin'
@@ -123,7 +133,6 @@ type AdminModeratorCampaignName =
 
 export type CampaignName =
   | 'manual'
-  | 'invite_received'
   | RegisterUserCampaignName
   | AdminModeratorCampaignName;
 

--- a/front/app/api/campaigns/types.ts
+++ b/front/app/api/campaigns/types.ts
@@ -70,16 +70,13 @@ export interface ICampaign {
 }
 
 type RegisterUserCampaignName =
-  | 'welcome'
   | 'comment_deleted_by_admin'
-  | 'comment_on_your_comment'
   | 'comment_on_idea_you_follow'
   | 'comment_on_initiative_you_follow'
+  | 'comment_on_your_comment'
   | 'cosponsor_of_your_initiative'
   | 'event_registration_confirmation'
   | 'idea_published'
-  | 'invite_received'
-  | 'invite_reminder'
   | 'invitation_to_cosponsor'
   | 'initiative_published'
   | 'mention_in_official_feedback'
@@ -95,44 +92,49 @@ type RegisterUserCampaignName =
   | 'voting_basket_submitted'
   | 'voting_last_chance'
   | 'voting_phase_started'
-  | 'voting_results';
+  | 'voting_results'
+  | 'welcome';
 
 export const internalCommentNotificationTypes = [
-  'mention_in_internal_comment',
-  'internal_comment_on_your_internal_comment',
   'internal_comment_on_idea_assigned_to_you',
-  'internal_comment_on_initiative_assigned_to_you',
-  'internal_comment_on_idea_you_moderate',
   'internal_comment_on_idea_you_commented_internally_on',
+  'internal_comment_on_idea_you_moderate',
+  'internal_comment_on_initiative_assigned_to_you',
   'internal_comment_on_initiative_you_commented_internally_on',
-  'internal_comment_on_unassigned_unmoderated_idea',
   'internal_comment_on_unassigned_initiative',
+  'internal_comment_on_unassigned_unmoderated_idea',
+  'internal_comment_on_your_internal_comment',
+  'mention_in_internal_comment',
 ] as const;
 
 export type InternalCommentType =
   (typeof internalCommentNotificationTypes)[number];
 
 type AdminModeratorCampaignName =
+  | 'admin_digest'
   | 'admin_rights_received'
+  | 'assignee_digest'
   | 'comment_marked_as_spam'
+  | 'idea_assigned_to_you'
   | 'idea_marked_as_spam'
+  | 'inappropriate_content_flagged'
   | 'initiative_assigned_to_you'
   | 'initiative_marked_as_spam'
   | 'initiative_resubmitted_for_review'
+  | 'moderator_digest'
   | 'new_comment_for_admin'
   | 'new_idea_for_admin'
   | 'new_initiative_for_admin'
   | 'project_folder_moderation_rights_received'
   | 'project_moderation_rights_received'
   | 'threshold_reached_for_admin'
-  | 'admin_digest'
-  | 'moderator_digest'
-  | 'assignee_digest'
   | 'your_proposed_initiatives_digest'
   | InternalCommentType;
 
 export type CampaignName =
   | 'manual'
+  | 'invite_received'
+  | 'invite_reminder'
   | RegisterUserCampaignName
   | AdminModeratorCampaignName;
 


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Technical
- Add missing email campaign types in FE