### PR TITLE
TAN-1102 Fix scroll in create analysis modal

### DIFF
--- a/front/app/containers/Admin/projects/project/nativeSurvey/FormResults/FormResultsQuestion/TextQuestion/Analysis/CreateAnalysisModal.tsx
+++ b/front/app/containers/Admin/projects/project/nativeSurvey/FormResults/FormResultsQuestion/TextQuestion/Analysis/CreateAnalysisModal.tsx
@@ -29,6 +29,7 @@ const CreateAnalysisModal = ({ onClose }: { onClose: () => void }) => {
   const [selectdQuestions, setSelectedQuestions] = useState<string[]>(
     customFieldId ? [customFieldId] : []
   );
+  const [scrollCompleted, setScrollCompleted] = useState(false);
   const { projectId, phaseId } = useParams() as {
     projectId: string;
     phaseId: string;
@@ -41,15 +42,16 @@ const CreateAnalysisModal = ({ onClose }: { onClose: () => void }) => {
   });
 
   useEffect(() => {
-    if (customFieldId && formCustomFields) {
+    if (customFieldId && formCustomFields && !scrollCompleted) {
       const element = document.getElementById(customFieldId);
       element?.scrollIntoView({
         behavior: 'smooth',
         block: 'center',
         inline: 'nearest',
       });
+      setScrollCompleted(true);
     }
-  }, [customFieldId, formCustomFields]);
+  }, [customFieldId, formCustomFields, scrollCompleted]);
 
   const handleCreateAnalysis = () => {
     createAnalysis(


### PR DESCRIPTION
# Changelog
## Fixed
- The "create analysis" modal no longer scrolls the user to the initial question every time they select a new question to analyse. Instead, this happens only on opening the modal initially, as expected.
