### PR TITLE
Tan 1149/padding folder edit form

### DIFF
--- a/front/app/containers/Admin/projectFolders/containers/settings/ProjectFolderForm/index.tsx
+++ b/front/app/containers/Admin/projectFolders/containers/settings/ProjectFolderForm/index.tsx
@@ -60,6 +60,7 @@ type IProjectFolderSubmitState =
 
 interface Props {
   mode: 'edit' | 'new';
+  // This is wrong. Can be undefined if mode is 'new'
   projectFolderId: string;
 }
 

--- a/front/app/containers/Admin/projectFolders/containers/settings/index.tsx
+++ b/front/app/containers/Admin/projectFolders/containers/settings/index.tsx
@@ -58,7 +58,7 @@ const FolderSettings = ({ params }: WithRouterProps) => {
   }
 
   return (
-    <Box p="40px">
+    <Box p={mode === 'new' ? '40px' : '0'}>
       {mode === 'new' && <StyledGoBackButton onClick={goBack} />}
       <Container mode={mode}>
         {mode === 'edit' ? (


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Padding of folder edit form ([before](https://github.com/CitizenLabDotCo/citizenlab/assets/16427929/e4c53f65-d1bd-4742-851a-e759f85a2f06)/[after](https://github.com/CitizenLabDotCo/citizenlab/assets/16427929/ae3f66b2-39de-41b6-b8f0-f752af3a62e8))