### PR TITLE
Tan 1152/events disappear from project page

### DIFF
--- a/front/app/containers/EventsPage/EventsViewer/index.tsx
+++ b/front/app/containers/EventsPage/EventsViewer/index.tsx
@@ -86,7 +86,6 @@ interface Props {
   eventsTime: 'past' | 'currentAndFuture';
   className?: string;
   projectId?: string;
-  hideSectionIfNoEvents?: boolean;
   showProjectFilter: boolean;
   showDateFilter?: boolean;
   projectPublicationStatuses: PublicationStatus[];
@@ -99,7 +98,6 @@ const EventsViewer = ({
   eventsTime,
   className,
   projectId,
-  hideSectionIfNoEvents,
   showProjectFilter,
   projectPublicationStatuses,
   attendeeId,
@@ -200,15 +198,6 @@ const EventsViewer = ({
 
   const lastPageNumber =
     (events && getPageNumberFromUrl(events.links?.last)) ?? 1;
-
-  const shouldHideSection =
-    (events && events.data.length === 0 && hideSectionIfNoEvents) ||
-    (isLoading && hideSectionIfNoEvents) ||
-    (isNilOrError(events) && hideSectionIfNoEvents);
-
-  if (shouldHideSection) {
-    return null;
-  }
 
   return (
     <Box className={className} id="project-events">

--- a/front/app/containers/EventsPage/EventsViewer/index.tsx
+++ b/front/app/containers/EventsPage/EventsViewer/index.tsx
@@ -130,7 +130,7 @@ const EventsViewer = ({
   const [projectIdList, setProjectIdList] = useState<string[] | undefined>(
     projectIdsFromUrl || (projectId ? [projectId] : [])
   );
-  const [dateFilter, setDateFilter] = useState<dateFilterKey[] | undefined>(
+  const [dateFilter, setDateFilter] = useState<dateFilterKey[]>(
     dateFilterFromUrl || []
   );
 
@@ -184,7 +184,8 @@ const EventsViewer = ({
 
   // Update date filter URL params based on state, events time will not change after initial render
   useEffect(() => {
-    const hasDateFilter = dateFilter?.length && dateFilter[0] !== 'all';
+    const hasDateFilter =
+      dateFilter.length > 0 ? dateFilter[0] !== 'all' : false;
     if (eventsTime === 'currentAndFuture') {
       updateSearchParams({
         time_period: hasDateFilter ? dateFilter : null,

--- a/front/app/containers/ProjectsShowPage/index.tsx
+++ b/front/app/containers/ProjectsShowPage/index.tsx
@@ -165,7 +165,6 @@ const ProjectsShowPage = ({ project }: Props) => {
               eventsTime="currentAndFuture"
               title={formatMessage(messages.upcomingAndOngoingEvents)}
               fallbackMessage={messages.noUpcomingOrOngoingEvents}
-              hideSectionIfNoEvents={true}
               projectPublicationStatuses={['published', 'draft', 'archived']}
             />
             <EventsViewer
@@ -174,7 +173,6 @@ const ProjectsShowPage = ({ project }: Props) => {
               eventsTime="past"
               title={formatMessage(messages.pastEvents)}
               fallbackMessage={messages.noPastEvents}
-              hideSectionIfNoEvents={true}
               projectPublicationStatuses={['published', 'draft', 'archived']}
               showDateFilter={false}
             />


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- The events section on a project page doesn't disappear anymore if no events match the date filter. Instead it shows a text indicating no events exist ([screenshot](https://github.com/CitizenLabDotCo/citizenlab/assets/16427929/70992031-2720-44a5-bba3-2d15d6f5e186))
