### PR TITLE
Revert "[TAN-1000] Remove two redundant map related admin_api serializers"

### DIFF
--- a/back/engines/commercial/admin_api/app/serializers/layer_serializer.rb
+++ b/back/engines/commercial/admin_api/app/serializers/layer_serializer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class LayerSerializer
+  include FastJsonapi::ObjectSerializer
+
+  attributes :title_multiloc, :geojson, :default_enabled, :marker_svg_url, :ordering, :id
+end

--- a/back/engines/commercial/admin_api/app/serializers/map_config_serializer.rb
+++ b/back/engines/commercial/admin_api/app/serializers/map_config_serializer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class MapConfigSerializer
+  include JSONAPI::Serializer
+
+  attributes :project_id, :zoom_level, :tile_provider
+  attribute :center, &:center_geojson
+
+  has_many :layers
+end


### PR DESCRIPTION
I suspect the removal of these may have broken project copy (between production platforms, via AdminHQ project copy tool): [Slack thread](https://citizenlabco.slack.com/archives/C01J9DHRJTE/p1708694035396189).

Reverts CitizenLabDotCo/citizenlab#6908

# Changelog
## Technical
- [No-ticket] Revert removal of admin-api map_config serializer, as potential fix of project copy tool