### PR TITLE
TAN-831 - Removed unused automatic creation of default forms

### DIFF
--- a/back/engines/commercial/analysis/app/controllers/analysis/web_api/v1/analyses_controller.rb
+++ b/back/engines/commercial/analysis/app/controllers/analysis/web_api/v1/analyses_controller.rb
@@ -78,9 +78,7 @@ module Analysis
 
         def detect_custom_fields
           container = @analysis.phase || @analysis.project
-          participation_method = Factory.instance.participation_method_for(container)
-          custom_form = container.custom_form || participation_method.create_default_form!
-
+          custom_form = container.custom_form
           custom_fields = IdeaCustomFieldsService.new(custom_form).all_fields
           # custom fields can be an array or a scope
           custom_fields.filter(&:support_free_text_value?).map(&:id)

--- a/back/engines/commercial/analysis/app/controllers/analysis/web_api/v1/analyses_controller.rb
+++ b/back/engines/commercial/analysis/app/controllers/analysis/web_api/v1/analyses_controller.rb
@@ -78,7 +78,9 @@ module Analysis
 
         def detect_custom_fields
           container = @analysis.phase || @analysis.project
-          custom_form = container.custom_form
+          participation_method = Factory.instance.participation_method_for(container)
+          custom_form = participation_method.custom_form
+
           custom_fields = IdeaCustomFieldsService.new(custom_form).all_fields
           # custom fields can be an array or a scope
           custom_fields.filter(&:support_free_text_value?).map(&:id)

--- a/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
+++ b/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
@@ -282,6 +282,7 @@ module IdeaCustomFields
     def set_custom_form
       container_id = params[secure_constantize(:container_id)]
       @container = secure_constantize(:container_class).find container_id
+      # TODO: JS - This doesn't seem right given the form is always now edited in phase
       @custom_form = CustomForm.find_or_initialize_by participation_context: @container
     end
 

--- a/back/lib/participation_method/base.rb
+++ b/back/lib/participation_method/base.rb
@@ -19,10 +19,6 @@ module ParticipationMethod
       # Default is to do nothing.
     end
 
-    def create_default_form!
-      # Default is to do nothing.
-    end
-
     def default_fields(_custom_form)
       []
     end

--- a/back/lib/participation_method/ideation.rb
+++ b/back/lib/participation_method/ideation.rb
@@ -269,19 +269,6 @@ module ParticipationMethod
       'section'
     end
 
-    def create_default_form!
-      form = CustomForm.create(participation_context: phase.project)
-
-      default_fields(form).reverse_each do |field|
-        field.save!
-        field.move_to_top
-      end
-
-      phase.reload
-
-      form
-    end
-
     def validate_built_in_fields?
       true
     end

--- a/back/lib/participation_method/native_survey.rb
+++ b/back/lib/participation_method/native_survey.rb
@@ -61,20 +61,6 @@ module ParticipationMethod
       ]
     end
 
-    # TODO: JS - Can we remove this method? Only used by analysis
-    def create_default_form!
-      form = CustomForm.create(participation_context: phase)
-
-      default_fields(form).reverse_each do |field|
-        field.save!
-        field.move_to_top
-      end
-
-      phase.reload
-
-      form
-    end
-
     def never_show?
       true
     end

--- a/back/spec/lib/participation_method/ideation_spec.rb
+++ b/back/spec/lib/participation_method/ideation_spec.rb
@@ -29,13 +29,6 @@ RSpec.describe ParticipationMethod::Ideation do
     end
   end
 
-  describe '#create_default_form!' do
-    it 'creates a default form' do
-      expect { participation_method.create_default_form! }.to change(CustomForm, :count)
-      expect { participation_method.create_default_form! }.to change(CustomField, :count)
-    end
-  end
-
   describe '#default_fields' do
     it 'returns the default ideation fields' do
       expect(

--- a/back/spec/lib/participation_method/information_spec.rb
+++ b/back/spec/lib/participation_method/information_spec.rb
@@ -31,12 +31,6 @@ RSpec.describe ParticipationMethod::Information do
     end
   end
 
-  describe '#create_default_form!' do
-    it 'does not create a default form' do
-      expect { participation_method.create_default_form! }.not_to change(CustomForm, :count)
-    end
-  end
-
   describe '#default_fields' do
     it 'returns an empty list' do
       expect(

--- a/back/spec/lib/participation_method/native_survey_spec.rb
+++ b/back/spec/lib/participation_method/native_survey_spec.rb
@@ -36,50 +36,6 @@ RSpec.describe ParticipationMethod::NativeSurvey do
     end
   end
 
-  # TODO: JS - probably not needed anymore
-  # describe '#create_default_form!' do
-  #   it 'persists a default form with a page for the participation context' do
-  #     expect(phase.custom_form).to be_nil
-  #
-  #     participation_method.create_default_form!
-  #     # create_default_form! does not reload associations for form/fields/options,
-  #     # so fetch the project from the database. The associations will be fetched
-  #     # when they are needed.
-  #     # Not doing this makes this test flaky, as create_default_form! creates fields
-  #     # and CustomField uses acts_as_list for ordering fields. The ordering is ok
-  #     # in the database, but not necessarily in memory.
-  #     phase_in_db = Phase.find(phase.id)
-  #
-  #     expect(phase_in_db.custom_form.custom_fields.size).to eq 2
-  #
-  #     question_page = phase_in_db.custom_form.custom_fields[0]
-  #     expect(question_page.title_multiloc).to eq({})
-  #     expect(question_page.description_multiloc).to eq({})
-  #
-  #     field = phase_in_db.custom_form.custom_fields[1]
-  #     expect(field.title_multiloc).to match({
-  #       'en' => 'Default question',
-  #       'fr-FR' => 'Question par défaut',
-  #       'nl-NL' => 'Standaardvraag'
-  #     })
-  #     expect(field.description_multiloc).to eq({})
-  #     options = field.options
-  #     expect(options.size).to eq 2
-  #     expect(options[0].key).to eq 'option1'
-  #     expect(options[1].key).to eq 'option2'
-  #     expect(options[0].title_multiloc).to match({
-  #       'en' => 'First option',
-  #       'fr-FR' => 'Première option',
-  #       'nl-NL' => 'Eerste optie'
-  #     })
-  #     expect(options[1].title_multiloc).to match({
-  #       'en' => 'Second option',
-  #       'fr-FR' => 'Deuxième option',
-  #       'nl-NL' => 'Tweede optie'
-  #     })
-  #   end
-  # end
-
   describe '#default_fields' do
     it 'returns an empty list' do
       expect(

--- a/back/spec/lib/participation_method/none_spec.rb
+++ b/back/spec/lib/participation_method/none_spec.rb
@@ -30,12 +30,6 @@ RSpec.describe ParticipationMethod::None do
     end
   end
 
-  describe '#create_default_form!' do
-    it 'does not create a default form' do
-      expect { participation_method.create_default_form! }.not_to change(CustomForm, :count)
-    end
-  end
-
   describe '#default_fields' do
     it 'returns an empty list' do
       expect(

--- a/back/spec/lib/participation_method/poll_spec.rb
+++ b/back/spec/lib/participation_method/poll_spec.rb
@@ -31,12 +31,6 @@ RSpec.describe ParticipationMethod::Poll do
     end
   end
 
-  describe '#create_default_form!' do
-    it 'does not create a default form' do
-      expect { participation_method.create_default_form! }.not_to change(CustomForm, :count)
-    end
-  end
-
   describe '#default_fields' do
     it 'returns an empty list' do
       expect(

--- a/back/spec/lib/participation_method/survey_spec.rb
+++ b/back/spec/lib/participation_method/survey_spec.rb
@@ -31,12 +31,6 @@ RSpec.describe ParticipationMethod::Survey do
     end
   end
 
-  describe '#create_default_form!' do
-    it 'does not create a default form' do
-      expect { participation_method.create_default_form! }.not_to change(CustomForm, :count)
-    end
-  end
-
   describe '#default_fields' do
     it 'returns an empty list' do
       expect(

--- a/back/spec/lib/participation_method/volunteering_spec.rb
+++ b/back/spec/lib/participation_method/volunteering_spec.rb
@@ -31,12 +31,6 @@ RSpec.describe ParticipationMethod::Volunteering do
     end
   end
 
-  describe '#create_default_form!' do
-    it 'does not create a default form' do
-      expect { participation_method.create_default_form! }.not_to change(CustomForm, :count)
-    end
-  end
-
   describe '#default_fields' do
     it 'returns an empty list' do
       expect(

--- a/back/spec/lib/participation_method/voting_spec.rb
+++ b/back/spec/lib/participation_method/voting_spec.rb
@@ -29,13 +29,6 @@ RSpec.describe ParticipationMethod::Voting do
     end
   end
 
-  describe '#create_default_form!' do
-    it 'creates a default form' do
-      expect { participation_method.create_default_form! }.to change(CustomForm, :count)
-      expect { participation_method.create_default_form! }.to change(CustomField, :count)
-    end
-  end
-
   describe '#default_fields' do
     it 'returns the default ideation fields' do
       expect(


### PR DESCRIPTION
Simplification of the participation methods - in the copy survey branch we have changed surveys to follow the same logic as input forms to only persist the custom form when edits are made and otherwise return default fields.

Therefore the only place left where `create_default_form!` was being was in the analysis controller. Put this in a separate PR just in case there is reason not to remove it here too and just return the default fields in the same way.
