### PR TITLE
Tan 954/streamline proposals uis

### DIFF
--- a/front/app/components/IdeaCard/Footer/ReadMoreButton.tsx
+++ b/front/app/components/IdeaCard/Footer/ReadMoreButton.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import Button from 'components/UI/Button';
 import { colors } from '@citizenlab/cl2-component-library';
 import messages from '../messages';

--- a/front/app/containers/InitiativesShow/ReactionControl/Status/Answered.tsx
+++ b/front/app/containers/InitiativesShow/ReactionControl/Status/Answered.tsx
@@ -16,6 +16,7 @@ import messages from '../messages';
 import { FormattedMessage } from 'utils/cl-intl';
 import ProposalProgressBar from '../ProposalProgressBar';
 import { StatusComponentProps } from '.';
+import ReadAnswerButton from './components/ReadAnswerButton';
 
 const StatusIcon = styled(Icon)`
   path {
@@ -125,14 +126,7 @@ const Answered = ({
           </Button>
         )}
       </Box>
-      <Button
-        icon="survey-long-answer-2"
-        iconSize="20px"
-        buttonStyle="secondary"
-        onClick={onScrollToOfficialFeedback}
-      >
-        <FormattedMessage {...messages.readAnswer} />
-      </Button>
+      <ReadAnswerButton onClick={onScrollToOfficialFeedback} />
     </Box>
   );
 };

--- a/front/app/containers/InitiativesShow/ReactionControl/Status/Answered.tsx
+++ b/front/app/containers/InitiativesShow/ReactionControl/Status/Answered.tsx
@@ -9,7 +9,6 @@ import {
 } from '@citizenlab/cl2-component-library';
 
 import { StatusWrapper, StatusExplanation } from '../SharedStyles';
-import Button from 'components/UI/Button';
 
 import T from 'components/T';
 import messages from '../messages';
@@ -17,6 +16,7 @@ import { FormattedMessage } from 'utils/cl-intl';
 import ProposalProgressBar from '../ProposalProgressBar';
 import { StatusComponentProps } from '.';
 import ReadAnswerButton from './components/ReadAnswerButton';
+import VoteButtons from './components/VoteButtons';
 
 const StatusIcon = styled(Icon)`
   path {
@@ -106,25 +106,11 @@ const Answered = ({
         </ReactionCounter>
       </Box>
       <Box mb="8px">
-        {userReacted ? (
-          <Button
-            buttonStyle="success"
-            iconSize="20px"
-            icon="check"
-            onClick={onCancelReaction}
-          >
-            <FormattedMessage {...messages.voted} />
-          </Button>
-        ) : (
-          <Button
-            buttonStyle="primary"
-            iconSize="20px"
-            icon="vote-ballot"
-            onClick={onReaction}
-          >
-            <FormattedMessage {...messages.vote} />
-          </Button>
-        )}
+        <VoteButtons
+          onCancelReaction={onCancelReaction}
+          onReaction={onReaction}
+          userReacted={userReacted}
+        />
       </Box>
       <ReadAnswerButton onClick={onScrollToOfficialFeedback} />
     </Box>

--- a/front/app/containers/InitiativesShow/ReactionControl/Status/Expired.tsx
+++ b/front/app/containers/InitiativesShow/ReactionControl/Status/Expired.tsx
@@ -75,23 +75,25 @@ const Expired = ({
           }}
         />
       </StatusExplanation>
-      <ReactionCounter>
-        <ReactionTexts aria-hidden={true}>
-          <ReactionText>
-            <FormattedMessage
-              {...messages.xVotes}
-              values={{ count: reactionCount }}
-            />
-          </ReactionText>
-          <ReactionText>{reactionLimit}</ReactionText>
-        </ReactionTexts>
-        <ProposalProgressBar
-          reactionCount={reactionCount}
-          reactionLimit={reactionLimit}
-          barColor="linear-gradient(270deg, #84939E 0%, #C8D0D6 100%)"
-          bgShaded
-        />
-      </ReactionCounter>
+      <Box mb="24px">
+        <ReactionCounter>
+          <ReactionTexts aria-hidden={true}>
+            <ReactionText>
+              <FormattedMessage
+                {...messages.xVotes}
+                values={{ count: reactionCount }}
+              />
+            </ReactionText>
+            <ReactionText>{reactionLimit}</ReactionText>
+          </ReactionTexts>
+          <ProposalProgressBar
+            reactionCount={reactionCount}
+            reactionLimit={reactionLimit}
+            barColor="linear-gradient(270deg, #84939E 0%, #C8D0D6 100%)"
+            bgShaded
+          />
+        </ReactionCounter>
+      </Box>
     </Container>
   );
 };

--- a/front/app/containers/InitiativesShow/ReactionControl/Status/Ineligible.tsx
+++ b/front/app/containers/InitiativesShow/ReactionControl/Status/Ineligible.tsx
@@ -15,6 +15,7 @@ import T from 'components/T';
 import messages from '../messages';
 import { FormattedMessage } from 'utils/cl-intl';
 import { StatusComponentProps } from '.';
+import ReadAnswerButton from './components/ReadAnswerButton';
 
 const StatusIcon = styled(Icon)`
   path {
@@ -95,25 +96,25 @@ const Ineligible = ({
           )}
         </FormattedMessage>
       </StatusExplanation>
-      <ReactionCounter>
-        <ReactionTexts>
-          <ReactionText>
-            <FormattedMessage
-              {...messages.xVotes}
-              values={{ count: reactionCount }}
-            />
-          </ReactionText>
-          <ReactionText>{reactionLimit}</ReactionText>
-        </ReactionTexts>
-        <ProposalProgressBar
-          reactionCount={reactionCount}
-          reactionLimit={reactionLimit}
-          barColor="linear-gradient(270deg, #84939E 0%, #C8D0D6 100%)"
-        />
-      </ReactionCounter>
-      <StyledButton onClick={onScrollToOfficialFeedback}>
-        <FormattedMessage {...messages.readAnswer} />
-      </StyledButton>
+      <Box mb="24px">
+        <ReactionCounter>
+          <ReactionTexts>
+            <ReactionText>
+              <FormattedMessage
+                {...messages.xVotes}
+                values={{ count: reactionCount }}
+              />
+            </ReactionText>
+            <ReactionText>{reactionLimit}</ReactionText>
+          </ReactionTexts>
+          <ProposalProgressBar
+            reactionCount={reactionCount}
+            reactionLimit={reactionLimit}
+            barColor="linear-gradient(270deg, #84939E 0%, #C8D0D6 100%)"
+          />
+        </ReactionCounter>
+      </Box>
+      <ReadAnswerButton onClick={onScrollToOfficialFeedback} />
     </Box>
   );
 };

--- a/front/app/containers/InitiativesShow/ReactionControl/Status/Ineligible.tsx
+++ b/front/app/containers/InitiativesShow/ReactionControl/Status/Ineligible.tsx
@@ -10,7 +10,6 @@ import {
 } from '@citizenlab/cl2-component-library';
 import { StatusWrapper, StatusExplanation } from '../SharedStyles';
 import ProposalProgressBar from '../ProposalProgressBar';
-import Button from 'components/UI/Button';
 import T from 'components/T';
 import messages from '../messages';
 import { FormattedMessage } from 'utils/cl-intl';
@@ -43,10 +42,6 @@ const ReactionTexts = styled.div`
 const ReactionText = styled.div`
   font-size: ${fontSizes.base}px;
   color: ${colors.coolGrey600};
-`;
-
-const StyledButton = styled(Button)`
-  margin-top: 20px;
 `;
 
 const Ineligible = ({

--- a/front/app/containers/InitiativesShow/ReactionControl/Status/ProposedNotReacted.tsx
+++ b/front/app/containers/InitiativesShow/ReactionControl/Status/ProposedNotReacted.tsx
@@ -12,7 +12,6 @@ import {
 import { StatusExplanation } from '../SharedStyles';
 import { getPeriodRemainingUntil } from 'utils/dateUtils';
 import CountDown from '../CountDown';
-import Button from 'components/UI/Button';
 import ProposalProgressBar from '../ProposalProgressBar';
 import { FormattedMessage, MessageDescriptor } from 'utils/cl-intl';
 import messages from '../messages';
@@ -22,12 +21,11 @@ import { darken } from 'polished';
 import Tippy from '@tippyjs/react';
 import { InitiativePermissionsDisabledReason } from 'hooks/useInitiativesPermissions';
 import { StatusComponentProps } from '.';
+import VoteButtons from './components/VoteButtons';
 
-const Container = styled.div``;
-
-const CountDownWrapper = styled.div`
+const Container = styled.div`
   display: flex;
-  flex-direction: row-reverse;
+  flex-direction: column;
 `;
 
 const StatusIcon = styled(Icon)`
@@ -61,14 +59,6 @@ const ReactionTextLeft = styled.div`
 const ReactionTextRight = styled.div`
   font-size: ${fontSizes.base}px;
   color: ${(props) => props.theme.colors.tenantText};
-`;
-
-const StyledButton = styled(Button)`
-  margin-top: 20px;
-
-  svg {
-    margin-top: -2px;
-  }
 `;
 
 const OnDesktop = styled.span`
@@ -175,9 +165,9 @@ const ProposedNotReacted = ({
 
   return (
     <Container>
-      <CountDownWrapper>
+      <Box ml="auto">
         <CountDown targetTime={initiative.attributes.expires_at} />
-      </CountDownWrapper>
+      </Box>
       <StatusIcon ariaHidden name="bullseye" />
       <StatusExplanation>
         <OnDesktop>
@@ -216,7 +206,7 @@ const ProposedNotReacted = ({
           {thresholdReachedTooltip}
         </OnMobile>
       </StatusExplanation>
-      <Box mb="24px">
+      <Box mb="16px">
         <ReactionCounter>
           <ReactionText aria-hidden={true}>
             <ReactionTextLeft id="e2e-initiative-not-reacted-reaction-count">
@@ -246,28 +236,12 @@ const ProposedNotReacted = ({
             disabledReason ? disabledReason : ''
           }`}
         >
-          <Box mb="8px">
-            {userReacted ? (
-              <Button
-                buttonStyle="success"
-                iconSize="20px"
-                icon="check"
-                onClick={onCancelReaction}
-              >
-                <FormattedMessage {...messages.voted} />
-              </Button>
-            ) : (
-              <Button
-                id="e2e-initiative-like-button"
-                buttonStyle="primary"
-                iconSize="20px"
-                icon="vote-ballot"
-                onClick={onReaction}
-              >
-                <FormattedMessage {...messages.vote} />
-              </Button>
-            )}
-          </Box>
+          <VoteButtons
+            voteButtonId="e2e-initiative-like-button"
+            onCancelReaction={onCancelReaction}
+            onReaction={onReaction}
+            userReacted={userReacted}
+          />
         </div>
       </Tippy>
     </Container>

--- a/front/app/containers/InitiativesShow/ReactionControl/Status/ProposedNotReacted.tsx
+++ b/front/app/containers/InitiativesShow/ReactionControl/Status/ProposedNotReacted.tsx
@@ -206,7 +206,7 @@ const ProposedNotReacted = ({
           {thresholdReachedTooltip}
         </OnMobile>
       </StatusExplanation>
-      <Box mb="16px">
+      <Box mb="24px">
         <ReactionCounter>
           <ReactionText aria-hidden={true}>
             <ReactionTextLeft id="e2e-initiative-not-reacted-reaction-count">

--- a/front/app/containers/InitiativesShow/ReactionControl/Status/ProposedNotReacted.tsx
+++ b/front/app/containers/InitiativesShow/ReactionControl/Status/ProposedNotReacted.tsx
@@ -7,6 +7,7 @@ import {
   media,
   Icon,
   IconTooltip,
+  Box,
 } from '@citizenlab/cl2-component-library';
 import { StatusExplanation } from '../SharedStyles';
 import { getPeriodRemainingUntil } from 'utils/dateUtils';
@@ -27,9 +28,6 @@ const Container = styled.div``;
 const CountDownWrapper = styled.div`
   display: flex;
   flex-direction: row-reverse;
-  ${media.tablet`
-    display: none;
-  `}
 `;
 
 const StatusIcon = styled(Icon)`
@@ -149,6 +147,8 @@ const ProposedNotReacted = ({
   initiative,
   initiativeSettings: { reacting_threshold, threshold_reached_message },
   disabledReason,
+  userReacted,
+  onCancelReaction,
 }: StatusComponentProps) => {
   const theme = useTheme();
   const reactionCount = initiative.attributes.likes_count;
@@ -216,21 +216,23 @@ const ProposedNotReacted = ({
           {thresholdReachedTooltip}
         </OnMobile>
       </StatusExplanation>
-      <ReactionCounter>
-        <ReactionText aria-hidden={true}>
-          <ReactionTextLeft id="e2e-initiative-not-reacted-reaction-count">
-            <FormattedMessage
-              {...messages.xVotes}
-              values={{ count: reactionCount }}
-            />
-          </ReactionTextLeft>
-          <ReactionTextRight>{reactionLimit}</ReactionTextRight>
-        </ReactionText>
-        <ProposalProgressBar
-          reactionCount={reactionCount}
-          reactionLimit={reactionLimit}
-        />
-      </ReactionCounter>
+      <Box mb="24px">
+        <ReactionCounter>
+          <ReactionText aria-hidden={true}>
+            <ReactionTextLeft id="e2e-initiative-not-reacted-reaction-count">
+              <FormattedMessage
+                {...messages.xVotes}
+                values={{ count: reactionCount }}
+              />
+            </ReactionTextLeft>
+            <ReactionTextRight>{reactionLimit}</ReactionTextRight>
+          </ReactionText>
+          <ProposalProgressBar
+            reactionCount={reactionCount}
+            reactionLimit={reactionLimit}
+          />
+        </ReactionCounter>
+      </Box>
       <Tippy
         disabled={!tippyContent}
         placement="bottom"
@@ -244,17 +246,28 @@ const ProposedNotReacted = ({
             disabledReason ? disabledReason : ''
           }`}
         >
-          <StyledButton
-            icon="vote-up"
-            aria-describedby="tooltip-content"
-            disabled={!!tippyContent}
-            buttonStyle="primary"
-            onClick={onReaction}
-            id="e2e-initiative-like-button"
-            ariaDisabled={false}
-          >
-            <FormattedMessage {...messages.vote} />
-          </StyledButton>
+          <Box mb="8px">
+            {userReacted ? (
+              <Button
+                buttonStyle="success"
+                iconSize="20px"
+                icon="check"
+                onClick={onCancelReaction}
+              >
+                <FormattedMessage {...messages.voted} />
+              </Button>
+            ) : (
+              <Button
+                id="e2e-initiative-like-button"
+                buttonStyle="primary"
+                iconSize="20px"
+                icon="vote-ballot"
+                onClick={onReaction}
+              >
+                <FormattedMessage {...messages.vote} />
+              </Button>
+            )}
+          </Box>
         </div>
       </Tippy>
     </Container>

--- a/front/app/containers/InitiativesShow/ReactionControl/Status/ProposedReacted.tsx
+++ b/front/app/containers/InitiativesShow/ReactionControl/Status/ProposedReacted.tsx
@@ -3,20 +3,21 @@ import styled, { keyframes } from 'styled-components';
 import {
   colors,
   fontSizes,
-  media,
   Icon,
+  Box,
+  Button,
+  Text,
 } from '@citizenlab/cl2-component-library';
-import { darken } from 'polished';
 import { getPeriodRemainingUntil } from 'utils/dateUtils';
 import { FormattedMessage } from 'utils/cl-intl';
 import messages from '../messages';
 import ProposalProgressbar from '../ProposalProgressBar';
 import { StatusComponentProps } from '.';
+import CountDown from '../CountDown';
 
 const Container = styled.div`
   display: flex;
   flex-direction: column;
-  align-items: center;
 `;
 
 const scaleIn = keyframes`
@@ -31,51 +32,12 @@ const scaleIn = keyframes`
 `;
 
 const StyledIcon = styled(Icon)`
-  fill: ${colors.success};
-  width: 63px;
-  height: 63px;
   animation: ${scaleIn} 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94) both;
-`;
-
-const ReactedTitle = styled.h4`
-  color: ${(props) => props.theme.colors.tenantText};
-  font-size: ${fontSizes.base}px;
-  font-weight: 600;
-  text-align: center;
-  margin: 0;
-  margin-top: 25px;
-  margin-bottom: 5px;
-  width: 100%;
-`;
-
-const ReactedText = styled.p`
-  color: ${(props) => props.theme.colors.tenantText};
-  font-size: ${fontSizes.base}px;
-  font-weight: 300;
-  line-height: 21px;
-  text-align: center;
-  margin: 0 0 20px 0;
-  width: 100%;
-`;
-
-const UnreactButton = styled.button`
-  color: ${(props) => props.theme.colors.tenantText};
-  font-size: ${fontSizes.base}px;
-  text-decoration: underline;
-
-  &:hover {
-    color: ${(props) => darken(0.12, props.theme.colors.tenantText)};
-    text-decoration: underline;
-    cursor: pointer;
-  }
 `;
 
 const ReactionCounter = styled.div`
   margin-top: 15px;
   width: 100%;
-  ${media.tablet`
-    display: none;
-  `}
 `;
 
 const ReactionText = styled.div`
@@ -99,6 +61,8 @@ const ProposedReacted = ({
   initiative,
   initiativeSettings: { reacting_threshold },
   onCancelReaction,
+  onReaction,
+  userReacted,
 }: StatusComponentProps) => {
   const reactionCount = initiative.attributes.likes_count;
   const reactionLimit = reacting_threshold;
@@ -106,11 +70,22 @@ const ProposedReacted = ({
 
   return (
     <Container>
-      <StyledIcon ariaHidden name="check-circle" />
-      <ReactedTitle>
-        <FormattedMessage {...messages.votedTitle} />
-      </ReactedTitle>
-      <ReactedText>
+      <Box ml="auto" mb="16px">
+        <CountDown targetTime={initiative.attributes.expires_at} />
+      </Box>
+      <Box mb="8px">
+        <StyledIcon
+          fill={colors.success}
+          width="31px"
+          height="31px"
+          ariaHidden
+          name="check-circle"
+        />
+      </Box>
+      <Text m="0">
+        <b>
+          <FormattedMessage {...messages.votedTitle} />
+        </b>{' '}
         <FormattedMessage
           {...messages.votedText}
           values={{
@@ -125,28 +100,46 @@ const ProposedReacted = ({
             ),
           }}
         />
-      </ReactedText>
-      <UnreactButton
-        id="e2e-initiative-cancel-like-button"
-        onClick={onCancelReaction}
-      >
-        <FormattedMessage {...messages.unvoteLink} />
-      </UnreactButton>
-      <ReactionCounter>
-        <ReactionText aria-hidden={true}>
-          <ReactionTextLeft id="e2e-initiative-reacted-reaction-count">
-            <FormattedMessage
-              {...messages.xVotes}
-              values={{ count: reactionCount }}
-            />
-          </ReactionTextLeft>
-          <ReactionTextRight>{reactionLimit}</ReactionTextRight>
-        </ReactionText>
-        <ProposalProgressbar
-          reactionCount={reactionCount}
-          reactionLimit={reactionLimit}
-        />
-      </ReactionCounter>
+      </Text>
+      <Box mb="16px">
+        <ReactionCounter>
+          <ReactionText aria-hidden={true}>
+            <ReactionTextLeft id="e2e-initiative-reacted-reaction-count">
+              <FormattedMessage
+                {...messages.xVotes}
+                values={{ count: reactionCount }}
+              />
+            </ReactionTextLeft>
+            <ReactionTextRight>{reactionLimit}</ReactionTextRight>
+          </ReactionText>
+          <ProposalProgressbar
+            reactionCount={reactionCount}
+            reactionLimit={reactionLimit}
+          />
+        </ReactionCounter>
+      </Box>
+      <Box>
+        {userReacted ? (
+          <Button
+            id="e2e-initiative-cancel-like-button"
+            buttonStyle="success"
+            iconSize="20px"
+            icon="check"
+            onClick={onCancelReaction}
+          >
+            <FormattedMessage {...messages.voted} />
+          </Button>
+        ) : (
+          <Button
+            buttonStyle="primary"
+            iconSize="20px"
+            icon="vote-ballot"
+            onClick={onReaction}
+          >
+            <FormattedMessage {...messages.vote} />
+          </Button>
+        )}
+      </Box>
     </Container>
   );
 };

--- a/front/app/containers/InitiativesShow/ReactionControl/Status/ProposedReacted.tsx
+++ b/front/app/containers/InitiativesShow/ReactionControl/Status/ProposedReacted.tsx
@@ -101,7 +101,7 @@ const ProposedReacted = ({
           }}
         />
       </Text>
-      <Box mb="16px">
+      <Box mb="24px">
         <ReactionCounter>
           <ReactionText aria-hidden={true}>
             <ReactionTextLeft id="e2e-initiative-reacted-reaction-count">

--- a/front/app/containers/InitiativesShow/ReactionControl/Status/ProposedReacted.tsx
+++ b/front/app/containers/InitiativesShow/ReactionControl/Status/ProposedReacted.tsx
@@ -5,7 +5,6 @@ import {
   fontSizes,
   Icon,
   Box,
-  Button,
   Text,
 } from '@citizenlab/cl2-component-library';
 import { getPeriodRemainingUntil } from 'utils/dateUtils';
@@ -14,6 +13,7 @@ import messages from '../messages';
 import ProposalProgressbar from '../ProposalProgressBar';
 import { StatusComponentProps } from '.';
 import CountDown from '../CountDown';
+import VoteButtons from './components/VoteButtons';
 
 const Container = styled.div`
   display: flex;
@@ -70,7 +70,7 @@ const ProposedReacted = ({
 
   return (
     <Container>
-      <Box ml="auto" mb="16px">
+      <Box ml="auto">
         <CountDown targetTime={initiative.attributes.expires_at} />
       </Box>
       <Box mb="8px">
@@ -118,28 +118,12 @@ const ProposedReacted = ({
           />
         </ReactionCounter>
       </Box>
-      <Box>
-        {userReacted ? (
-          <Button
-            id="e2e-initiative-cancel-like-button"
-            buttonStyle="success"
-            iconSize="20px"
-            icon="check"
-            onClick={onCancelReaction}
-          >
-            <FormattedMessage {...messages.voted} />
-          </Button>
-        ) : (
-          <Button
-            buttonStyle="primary"
-            iconSize="20px"
-            icon="vote-ballot"
-            onClick={onReaction}
-          >
-            <FormattedMessage {...messages.vote} />
-          </Button>
-        )}
-      </Box>
+      <VoteButtons
+        cancelVoteButtonId="e2e-initiative-cancel-like-button"
+        onCancelReaction={onCancelReaction}
+        onReaction={onReaction}
+        userReacted={userReacted}
+      />
     </Container>
   );
 };

--- a/front/app/containers/InitiativesShow/ReactionControl/Status/ThresholdReached.tsx
+++ b/front/app/containers/InitiativesShow/ReactionControl/Status/ThresholdReached.tsx
@@ -11,7 +11,6 @@ import {
 
 // components
 import { StatusWrapper, StatusExplanation } from '../SharedStyles';
-import Button from 'components/UI/Button';
 
 // i18n
 import T from 'components/T';
@@ -32,10 +31,6 @@ const StatusIcon = styled(Icon)`
   width: 30px;
   height: 30px;
   margin-bottom: 20px;
-`;
-
-const StyledButton = styled(Button)`
-  margin-top: 20px;
 `;
 
 const ReactionCounter = styled.div`
@@ -68,7 +63,6 @@ const ThresholdReached = ({
   initiativeStatus,
   userReacted,
   onReaction,
-  onCancelReaction,
 }: StatusComponentProps) => {
   const theme = useTheme();
   const reactionCount = initiative.attributes.likes_count;

--- a/front/app/containers/InitiativesShow/ReactionControl/Status/ThresholdReached.tsx
+++ b/front/app/containers/InitiativesShow/ReactionControl/Status/ThresholdReached.tsx
@@ -5,6 +5,8 @@ import {
   Box,
   Icon,
   IconTooltip,
+  media,
+  colors,
 } from '@citizenlab/cl2-component-library';
 
 // components
@@ -18,6 +20,8 @@ import { FormattedMessage } from 'utils/cl-intl';
 
 // Types
 import { StatusComponentProps } from '.';
+import ProposalProgressBar from '../ProposalProgressBar';
+import VoteButtons from './components/VoteButtons';
 
 const Container = styled.div``;
 
@@ -30,14 +34,32 @@ const StatusIcon = styled(Icon)`
   margin-bottom: 20px;
 `;
 
-const ReactionText = styled.div`
-  font-size: ${fontSizes.base}px;
-  color: ${(props) => props.theme.colors.tenantText};
+const StyledButton = styled(Button)`
   margin-top: 20px;
 `;
 
-const StyledButton = styled(Button)`
-  margin-top: 20px;
+const ReactionCounter = styled.div`
+  margin-top: 15px;
+  ${media.tablet`
+    display: none;
+  `}
+`;
+
+const ReactionText = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding-bottom: 4px;
+`;
+
+const ReactionTextLeft = styled.div`
+  font-size: ${fontSizes.base}px;
+  color: ${(props) => props.theme.colors.tenantPrimary};
+`;
+
+const ReactionTextRight = styled.div`
+  font-size: ${fontSizes.base}px;
+  color: ${(props) => props.theme.colors.tenantText};
 `;
 
 const ThresholdReached = ({
@@ -46,6 +68,7 @@ const ThresholdReached = ({
   initiativeStatus,
   userReacted,
   onReaction,
+  onCancelReaction,
 }: StatusComponentProps) => {
   const theme = useTheme();
   const reactionCount = initiative.attributes.likes_count;
@@ -80,27 +103,27 @@ const ThresholdReached = ({
           content={<T value={threshold_reached_message} supportHtml />}
         />
       </StatusExplanation>
-      <ReactionText>
-        <FormattedMessage
-          {...messages.a11y_xVotesOfRequiredY}
-          values={{
-            votingThreshold: reactionLimit,
-            xVotes: (
-              <b>
-                <FormattedMessage
-                  {...messages.xVotes}
-                  values={{ count: reactionCount }}
-                />
-              </b>
-            ),
-          }}
-        />
-      </ReactionText>
-      {!userReacted && (
-        <StyledButton icon="vote-ballot" onClick={onReaction}>
-          <FormattedMessage {...messages.vote} />
-        </StyledButton>
-      )}
+      <Box mb="24px">
+        <ReactionCounter>
+          <ReactionText aria-hidden={true}>
+            <ReactionTextLeft>
+              <FormattedMessage
+                {...messages.xVotes}
+                values={{ count: reactionCount }}
+              />
+            </ReactionTextLeft>
+            <ReactionTextRight>{reactionLimit}</ReactionTextRight>
+          </ReactionText>
+          <ProposalProgressBar
+            reactionCount={reactionCount}
+            reactionLimit={reactionLimit}
+            barColor={colors.green500}
+          />
+        </ReactionCounter>
+      </Box>
+      <Box mb="8px">
+        <VoteButtons onReaction={onReaction} userReacted={userReacted} />
+      </Box>
     </Container>
   );
 };

--- a/front/app/containers/InitiativesShow/ReactionControl/Status/ThresholdReached.tsx
+++ b/front/app/containers/InitiativesShow/ReactionControl/Status/ThresholdReached.tsx
@@ -97,7 +97,7 @@ const ThresholdReached = ({
         />
       </ReactionText>
       {!userReacted && (
-        <StyledButton icon="vote-up" onClick={onReaction}>
+        <StyledButton icon="vote-ballot" onClick={onReaction}>
           <FormattedMessage {...messages.vote} />
         </StyledButton>
       )}

--- a/front/app/containers/InitiativesShow/ReactionControl/Status/components/ReadAnswerButton.tsx
+++ b/front/app/containers/InitiativesShow/ReactionControl/Status/components/ReadAnswerButton.tsx
@@ -1,0 +1,23 @@
+import { Button } from '@citizenlab/cl2-component-library';
+import React from 'react';
+import { FormattedMessage } from 'utils/cl-intl';
+import messages from '../../messages';
+
+interface Props {
+  onClick: () => void;
+}
+
+const ReadAnswerButton = ({ onClick }: Props) => {
+  return (
+    <Button
+      icon="survey-long-answer-2"
+      iconSize="20px"
+      buttonStyle="secondary"
+      onClick={onClick}
+    >
+      <FormattedMessage {...messages.readAnswer} />
+    </Button>
+  );
+};
+
+export default ReadAnswerButton;

--- a/front/app/containers/InitiativesShow/ReactionControl/Status/components/VoteButtons.tsx
+++ b/front/app/containers/InitiativesShow/ReactionControl/Status/components/VoteButtons.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import Button from 'components/UI/Button';
+import messages from '../../messages';
+import { FormattedMessage } from 'utils/cl-intl';
+import { StatusComponentProps } from '..';
+
+interface Props {
+  userReacted: StatusComponentProps['userReacted'];
+  onCancelReaction: StatusComponentProps['onCancelReaction'];
+  onReaction: StatusComponentProps['onReaction'];
+  voteButtonId?: string;
+  cancelVoteButtonId?: string;
+}
+
+const VoteButtons = ({
+  userReacted,
+  onCancelReaction,
+  onReaction,
+  voteButtonId,
+  cancelVoteButtonId,
+}: Props) => {
+  return (
+    <>
+      {userReacted ? (
+        <Button
+          buttonStyle="success"
+          iconSize="20px"
+          icon="check"
+          onClick={onCancelReaction}
+          id={cancelVoteButtonId}
+        >
+          <FormattedMessage {...messages.voted} />
+        </Button>
+      ) : (
+        <Button
+          buttonStyle="primary"
+          iconSize="20px"
+          icon="vote-ballot"
+          onClick={onReaction}
+          id={voteButtonId}
+        >
+          <FormattedMessage {...messages.vote} />
+        </Button>
+      )}
+    </>
+  );
+};
+
+export default VoteButtons;

--- a/front/app/containers/InitiativesShow/ReactionControl/Status/components/VoteButtons.tsx
+++ b/front/app/containers/InitiativesShow/ReactionControl/Status/components/VoteButtons.tsx
@@ -6,7 +6,7 @@ import { StatusComponentProps } from '..';
 
 interface Props {
   userReacted: StatusComponentProps['userReacted'];
-  onCancelReaction: StatusComponentProps['onCancelReaction'];
+  onCancelReaction?: StatusComponentProps['onCancelReaction'];
   onReaction: StatusComponentProps['onReaction'];
   voteButtonId?: string;
   cancelVoteButtonId?: string;
@@ -28,6 +28,7 @@ const VoteButtons = ({
           icon="check"
           onClick={onCancelReaction}
           id={cancelVoteButtonId}
+          disabled={onCancelReaction === undefined}
         >
           <FormattedMessage {...messages.voted} />
         </Button>

--- a/front/app/containers/InitiativesShow/ReactionControl/Status/index.tsx
+++ b/front/app/containers/InitiativesShow/ReactionControl/Status/index.tsx
@@ -30,9 +30,9 @@ export interface StatusComponentProps {
   initiativeStatus: IInitiativeStatusData;
   initiativeSettings: ProposalsSettings;
   userReacted: boolean;
-  onReaction?: () => void;
-  onCancelReaction?: () => void;
-  onScrollToOfficialFeedback?: () => void;
+  onReaction: () => void;
+  onCancelReaction: () => void;
+  onScrollToOfficialFeedback: () => void;
   disabledReason?: InitiativePermissionsDisabledReason | null | undefined;
 }
 

--- a/front/app/containers/InitiativesShow/ReactionControl/messages.ts
+++ b/front/app/containers/InitiativesShow/ReactionControl/messages.ts
@@ -132,10 +132,6 @@ export default defineMessages({
     defaultMessage:
       '{x, plural, =0 {less than a day} one {one day} other {# days}}',
   },
-  unvoteLink: {
-    id: 'app.containers.InitiativesShow.VoteControl.unvoteLink',
-    defaultMessage: 'Cancel my vote',
-  },
   a11y_xVotesOfRequiredY: {
     id: 'app.containers.InitiativesShow.VoteControl.a11y_xVotesOfRequiredY',
     defaultMessage: '{xVotes} out of {votingThreshold} required votes',

--- a/front/app/translations/ar-MA.json
+++ b/front/app/translations/ar-MA.json
@@ -1131,7 +1131,6 @@
   "app.containers.InitiativesShow.VoteControl.reviewPendingStatusExplanationSentenceTwo": "ستتلقى بريدًا إلكترونيًا بمجرد مراجعته.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanation": "{thresholdReachedStatusExplanationBold}. تم إخطار {orgName}، وسيتم تقديم الإجابة.لا يزال التصويت مفتوحًا.\n     ",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanationBold": "تم الوصول إلى الحد المطلوب",
-  "app.containers.InitiativesShow.VoteControl.unvoteLink": "ألغِ تصويتي",
   "app.containers.InitiativesShow.VoteControl.vote": "صوّت",
   "app.containers.InitiativesShow.VoteControl.votedText": "ستتلقى إشعارًا بمجرد انتقال هذا المُقترح إلى الخطوة التالية. {x, plural, =0 {تبقى {xDays}.} one {تبقى {xDays}.} other {تبقى {xDays}.}}",
   "app.containers.InitiativesShow.VoteControl.votedTitle": "تم إرسال تصويتك!",

--- a/front/app/translations/ar-SA.json
+++ b/front/app/translations/ar-SA.json
@@ -1131,7 +1131,6 @@
   "app.containers.InitiativesShow.VoteControl.reviewPendingStatusExplanationSentenceTwo": "ستتلقى بريدًا إلكترونيًا بمجرد مراجعته.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanation": "{thresholdReachedStatusExplanationBold}. تم إخطار {orgName}، وسيتم تقديم الإجابة.\nلا يزال التصويت مفتوحًا.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanationBold": "تم الوصول إلى الحد المطلوب",
-  "app.containers.InitiativesShow.VoteControl.unvoteLink": "ألغِ تصويتي",
   "app.containers.InitiativesShow.VoteControl.vote": "صوّت",
   "app.containers.InitiativesShow.VoteControl.votedText": "ستتلقى إشعارًا بمجرد انتقال هذا المُقترح إلى الخطوة التالية. {x, plural, =0 {تبقى {xDays}.} one {تبقى {xDays}.} other {تبقى {xDays}.}}",
   "app.containers.InitiativesShow.VoteControl.votedTitle": "تم إرسال تصويتك!",

--- a/front/app/translations/ca-ES.json
+++ b/front/app/translations/ca-ES.json
@@ -1131,7 +1131,6 @@
   "app.containers.InitiativesShow.VoteControl.reviewPendingStatusExplanationSentenceTwo": "Rebràs un correu electrònic un cop revisat.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanation": "{thresholdReachedStatusExplanationBold}. S'ha notificat a {orgName}. La votació continua oberta.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanationBold": "S'ha assolit el llindar",
-  "app.containers.InitiativesShow.VoteControl.unvoteLink": "Cancel·leu el meu vot",
   "app.containers.InitiativesShow.VoteControl.vote": "Votar",
   "app.containers.InitiativesShow.VoteControl.votedText": "Rebreu una notificació quan aquesta proposta passi al pas següent. {x, plural, =0 {Queden {xDays}.} one {Queden {xDays}.} other {Queden {xDays}.}}",
   "app.containers.InitiativesShow.VoteControl.votedTitle": "S'ha enviat el vostre vot!",

--- a/front/app/translations/da-DK.json
+++ b/front/app/translations/da-DK.json
@@ -1131,7 +1131,6 @@
   "app.containers.InitiativesShow.VoteControl.reviewPendingStatusExplanationSentenceTwo": "Du vil modtage en e-mail, når det er gennemgået.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanation": "{thresholdReachedStatusExplanationBold}. {orgName} blev underrettet, og vil give et svar. Afstemning forbliver åben.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanationBold": "Grænsen er nået",
-  "app.containers.InitiativesShow.VoteControl.unvoteLink": "Annullér min stemme",
   "app.containers.InitiativesShow.VoteControl.vote": "Stem",
   "app.containers.InitiativesShow.VoteControl.votedText": "Du vil blive underrettet når dette forslag når til næste trin. {x, plural, =0 {Der er {xDays} tilbage.} one {Der er {xDays} tilbage.} other {Der er {xDays} tilbage.}}",
   "app.containers.InitiativesShow.VoteControl.votedTitle": "Din stemme blev indsendt!",

--- a/front/app/translations/de-DE.json
+++ b/front/app/translations/de-DE.json
@@ -1131,7 +1131,6 @@
   "app.containers.InitiativesShow.VoteControl.reviewPendingStatusExplanationSentenceTwo": "Sie erhalten eine E-Mail, sobald er geprüft wurde.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanation": "{thresholdReachedStatusExplanationBold}. {orgName} wurde benachrichtigt und wird eine Antwort geben. Abstimmung bleibt geöffnet.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanationBold": "Der Grenzwert wurde erreicht.",
-  "app.containers.InitiativesShow.VoteControl.unvoteLink": "Meine Stimme streichen",
   "app.containers.InitiativesShow.VoteControl.vote": "Abstimmen",
   "app.containers.InitiativesShow.VoteControl.votedText": "Du wirst benachrichtigt, sobald dein Vorschlag in die nächste Stufe kommt. {x, plural, =0 {Es sind {xDays} übrig.} one {Es ist {xDays} Tag übrig.} other {Es sind {xDays} übrig.}}",
   "app.containers.InitiativesShow.VoteControl.votedTitle": "Ihre Stimme ist abgegeben worden!",

--- a/front/app/translations/el-GR.json
+++ b/front/app/translations/el-GR.json
@@ -1131,7 +1131,6 @@
   "app.containers.InitiativesShow.VoteControl.reviewPendingStatusExplanationSentenceTwo": "Θα λάβετε ένα email μόλις επανεξεταστεί.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanation": "{thresholdReachedStatusExplanationBold}. Το {orgName} έχει ενημερωθεί. Η ψηφοφορία παραμένει ανοικτή.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanationBold": "Το όριο έχει επιτευχθεί",
-  "app.containers.InitiativesShow.VoteControl.unvoteLink": "Ακύρωση της ψήφου μου",
   "app.containers.InitiativesShow.VoteControl.vote": "Ψηφίστε",
   "app.containers.InitiativesShow.VoteControl.votedText": "Θα λάβετε ειδοποίηση όταν η πρόταση αυτή περάσει στο επόμενο βήμα. {x, plural, =0 {Απομένει {xDays}.} one {Απομένουν {xDays}.} other {Απομένουν {xDays}.}}",
   "app.containers.InitiativesShow.VoteControl.votedTitle": "Η ψήφος σας υποβλήθηκε!",

--- a/front/app/translations/en-CA.json
+++ b/front/app/translations/en-CA.json
@@ -1131,7 +1131,6 @@
   "app.containers.InitiativesShow.VoteControl.reviewPendingStatusExplanationSentenceTwo": "You will receive an email once it's reviewed.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanation": "{thresholdReachedStatusExplanationBold}. {orgName} has been notified. Voting remains open.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanationBold": "The threshold has been reached",
-  "app.containers.InitiativesShow.VoteControl.unvoteLink": "Cancel my vote",
   "app.containers.InitiativesShow.VoteControl.vote": "Vote",
   "app.containers.InitiativesShow.VoteControl.votedText": "You'll get notified when this proposal goes to the next step. {x, plural, =0 {There's {xDays} left.} one {There's {xDays} left.} other {There are {xDays} left.}}",
   "app.containers.InitiativesShow.VoteControl.votedTitle": "Your vote has been submitted!",

--- a/front/app/translations/en-GB.json
+++ b/front/app/translations/en-GB.json
@@ -1131,7 +1131,6 @@
   "app.containers.InitiativesShow.VoteControl.reviewPendingStatusExplanationSentenceTwo": "You will receive an email once it's reviewed.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanation": "{thresholdReachedStatusExplanationBold}. {orgName} has been notified. Voting remains open.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanationBold": "The threshold has been reached",
-  "app.containers.InitiativesShow.VoteControl.unvoteLink": "{tenantName, select, stirlingcouncil {Remove my signature} other {Cancel my vote}}",
   "app.containers.InitiativesShow.VoteControl.vote": "{tenantName, select, stirlingcouncil {Sign here} other {Vote}}",
   "app.containers.InitiativesShow.VoteControl.votedText": "You'll get notified when this goes to the next step. {x, plural, =0 {There's {xDays} left.} one {There's {xDays} left.} other {There are {xDays} left.}}",
   "app.containers.InitiativesShow.VoteControl.votedTitle": "{tenantName, select, stirlingcouncil {Your signature has been submitted!} other {Your vote has been submitted!}}",

--- a/front/app/translations/en.json
+++ b/front/app/translations/en.json
@@ -1132,7 +1132,6 @@
   "app.containers.InitiativesShow.VoteControl.reviewPendingStatusExplanationSentenceTwo": "You will receive an email once it's reviewed.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanation": "{thresholdReachedStatusExplanationBold}. {orgName} has been notified. Voting remains open.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanationBold": "The threshold has been reached",
-  "app.containers.InitiativesShow.VoteControl.unvoteLink": "Cancel my vote",
   "app.containers.InitiativesShow.VoteControl.vote": "Vote",
   "app.containers.InitiativesShow.VoteControl.voted": "Voted",
   "app.containers.InitiativesShow.VoteControl.votedText": "You'll get notified when this proposal goes to the next step. {x, plural, =0 {There's {xDays} left.} one {There's {xDays} left.} other {There are {xDays} left.}}",

--- a/front/app/translations/es-CL.json
+++ b/front/app/translations/es-CL.json
@@ -1131,7 +1131,6 @@
   "app.containers.InitiativesShow.VoteControl.reviewPendingStatusExplanationSentenceTwo": "Recibirás un correo electrónico una vez que sea revisado.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanation": "{thresholdReachedStatusExplanationBold}. {orgName} ha sido notificada y le dará una respuesta. La votación sigue abierta.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanationBold": "Se ha alcanzado el límite",
-  "app.containers.InitiativesShow.VoteControl.unvoteLink": "Cancelar mi voto",
   "app.containers.InitiativesShow.VoteControl.vote": "Votar",
   "app.containers.InitiativesShow.VoteControl.votedText": "Se le notificará cuando esta propuesta pase al siguiente paso. {x, plural, =0 {There's {xDays} left.} one {There's {xDays} left.} other {There are {xDays} left.}}",
   "app.containers.InitiativesShow.VoteControl.votedTitle": "Tu voto ha sido enviado!",

--- a/front/app/translations/es-ES.json
+++ b/front/app/translations/es-ES.json
@@ -1131,7 +1131,6 @@
   "app.containers.InitiativesShow.VoteControl.reviewPendingStatusExplanationSentenceTwo": "Recibirás un correo electrónico cuando se haya revisado.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanation": "{thresholdReachedStatusExplanationBold}. {orgName} ha sido notificada y le dará una respuesta. La votación sigue abierta.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanationBold": "Se ha alcanzado el límite",
-  "app.containers.InitiativesShow.VoteControl.unvoteLink": "Cancelar mi voto",
   "app.containers.InitiativesShow.VoteControl.vote": "Votar",
   "app.containers.InitiativesShow.VoteControl.votedText": "Se le notificará cuando esta propuesta pase al siguiente paso. {x, plural, =0 {There's {xDays} left.} one {There's {xDays} left.} other {There are {xDays} left.}}",
   "app.containers.InitiativesShow.VoteControl.votedTitle": "Tu voto ha sido enviado!",

--- a/front/app/translations/fi-FI.json
+++ b/front/app/translations/fi-FI.json
@@ -1131,7 +1131,6 @@
   "app.containers.InitiativesShow.VoteControl.reviewPendingStatusExplanationSentenceTwo": "Saat sähköpostin, kun se on tarkistettu.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanation": "{thresholdReachedStatusExplanationBold}. {orgName} on ilmoitettu. Äänestys on auki.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanationBold": "Kynnys on saavutettu",
-  "app.containers.InitiativesShow.VoteControl.unvoteLink": "Peruuta ääneni",
   "app.containers.InitiativesShow.VoteControl.vote": "Äänestys",
   "app.containers.InitiativesShow.VoteControl.votedText": "Saat ilmoituksen, kun tämä ehdotus siirtyy seuraavaan vaiheeseen. {x, plural, =0 {{xDays} jäljellä.} one {{xDays} jäljellä.} other {{xDays} jäljellä.}}",
   "app.containers.InitiativesShow.VoteControl.votedTitle": "Äänesi on lähetetty!",

--- a/front/app/translations/fr-BE.json
+++ b/front/app/translations/fr-BE.json
@@ -1131,7 +1131,6 @@
   "app.containers.InitiativesShow.VoteControl.reviewPendingStatusExplanationSentenceTwo": "Vous recevrez un e-mail une fois que votre proposition aura été examinée.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanation": "{thresholdReachedStatusExplanationBold}. {orgName} a été notifié et donnera une réponse. Les votes restent ouverts.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanationBold": "Le seuil a été atteint",
-  "app.containers.InitiativesShow.VoteControl.unvoteLink": "Annuler mon vote",
   "app.containers.InitiativesShow.VoteControl.vote": "Votez",
   "app.containers.InitiativesShow.VoteControl.votedText": "Vous serez notifié lorsque cette proposition passera à l'étape suivante. {x, plural, =0 {Il ne reste plus de {xDays}.} one {Il reste {xDays} jour.} other {Il reste {xDays} jours.}}",
   "app.containers.InitiativesShow.VoteControl.votedTitle": "Votre vote a été soumis !",

--- a/front/app/translations/fr-FR.json
+++ b/front/app/translations/fr-FR.json
@@ -1131,7 +1131,6 @@
   "app.containers.InitiativesShow.VoteControl.reviewPendingStatusExplanationSentenceTwo": "Vous recevrez un e-mail une fois que votre proposition aura été examinée.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanation": "{thresholdReachedStatusExplanationBold}. {orgName} a été notifié et donnera une réponse. Les votes restent ouverts.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanationBold": "Le seuil a été atteint",
-  "app.containers.InitiativesShow.VoteControl.unvoteLink": "Annuler mon vote",
   "app.containers.InitiativesShow.VoteControl.vote": "Votez",
   "app.containers.InitiativesShow.VoteControl.votedText": "Vous serez notifié lorsque cette proposition passera à l'étape suivante. {x, plural, =0 {Il ne reste plus de {xDays}.} one {Il reste {xDays} jour.} other {Il reste {xDays} jours.}}",
   "app.containers.InitiativesShow.VoteControl.votedTitle": "Votre vote a été soumis !",

--- a/front/app/translations/hr-HR.json
+++ b/front/app/translations/hr-HR.json
@@ -1131,7 +1131,6 @@
   "app.containers.InitiativesShow.VoteControl.reviewPendingStatusExplanationSentenceTwo": "Primit ćete e-poruku nakon pregleda.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanation": "{thresholdReachedStatusExplanationBold}. {orgName} je obaviješten. Glasanje je i dalje otvoreno.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanationBold": "Dosegnut je prag",
-  "app.containers.InitiativesShow.VoteControl.unvoteLink": "Poništi moj glas",
   "app.containers.InitiativesShow.VoteControl.vote": "Glas",
   "app.containers.InitiativesShow.VoteControl.votedText": "Bit ćete obaviješteni kada ovaj prijedlog prijeđe u sljedeću fazu. {x, plural, =0 {Ostalo je još {xDays}.} one {Ostao je još {xDays}.} other {Ostalo je još {xDays}.}}",
   "app.containers.InitiativesShow.VoteControl.votedTitle": "Vaš glas je predan!",

--- a/front/app/translations/hu-HU.json
+++ b/front/app/translations/hu-HU.json
@@ -707,7 +707,6 @@
   "app.containers.InitiativesShow.VoteControl.readAnswer": "Read answer",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanation": "{thresholdReachedStatusExplanationBold}. {orgName} has been notified. Voting remains open.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanationBold": "The threshold has been reached",
-  "app.containers.InitiativesShow.VoteControl.unvoteLink": "Cancel my vote",
   "app.containers.InitiativesShow.VoteControl.vote": "Vote",
   "app.containers.InitiativesShow.VoteControl.votedText": "You'll get notified when this proposal goes to the next step. {x, plural, =0 {There's {xDays} left.} one {There's {xDays} left.} other {There are {xDays} left.}}",
   "app.containers.InitiativesShow.VoteControl.votedTitle": "Your vote has been submitted!",

--- a/front/app/translations/it-IT.json
+++ b/front/app/translations/it-IT.json
@@ -1131,7 +1131,6 @@
   "app.containers.InitiativesShow.VoteControl.reviewPendingStatusExplanationSentenceTwo": "Riceverai un'e-mail una volta esaminato.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanation": "{thresholdReachedStatusExplanationBold}. {orgName} è stato notificato. Le votazioni rimangono aperte.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanationBold": "La soglia è stata raggiunta",
-  "app.containers.InitiativesShow.VoteControl.unvoteLink": "Annulla il mio voto",
   "app.containers.InitiativesShow.VoteControl.vote": "Vota",
   "app.containers.InitiativesShow.VoteControl.votedText": "Sarai avvisato quando questa proposta passerà alla fase successiva. {x, plural, =0 {Ci sono {xDays} rimasti.} one {C'è {xDays} a sinistra.} other {Ci sono {xDays} rimasti.}}",
   "app.containers.InitiativesShow.VoteControl.votedTitle": "Il tuo voto è stato presentato!",

--- a/front/app/translations/kl-GL.json
+++ b/front/app/translations/kl-GL.json
@@ -1033,7 +1033,6 @@
   "app.containers.InitiativesShow.VoteControl.reviewPendingStatusExplanationSentenceTwo": "You will receive an email once it's reviewed.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanation": "{thresholdReachedStatusExplanationBold}. {orgName} nalunaarfigineqarpoq, akissuteqarumaarporlu. Taasineq ammaannassaaq. ",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanationBold": "Killissaq anguneqarsimavoq",
-  "app.containers.InitiativesShow.VoteControl.unvoteLink": "Taasinera atorunnaarsiguk",
   "app.containers.InitiativesShow.VoteControl.vote": "{tenantName, select, DeloitteDK {Peqataagit} other {Taasigit}}",
   "app.containers.InitiativesShow.VoteControl.votedText": "Du vil blive underrettet når dette borgerforslag når til næste trin. {x, plural, =0 {Der er {xDage} tilbage.} one {Der er {xDage} tilbage.} other {Der er {xDage} tilbage.}}",
   "app.containers.InitiativesShow.VoteControl.votedTitle": "Taasinerit nassiunneqarpoq!",

--- a/front/app/translations/lb-LU.json
+++ b/front/app/translations/lb-LU.json
@@ -1131,7 +1131,6 @@
   "app.containers.InitiativesShow.VoteControl.reviewPendingStatusExplanationSentenceTwo": "Dir kritt eng E-Mail eemol et iwwerpréift ass.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanation": "{thresholdReachedStatusExplanationBold}. {orgName} gouf benoriichtegt a wäert äntweren. D'Ofstëmmen bleift op.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanationBold": "D'Schwell gouf erreecht",
-  "app.containers.InitiativesShow.VoteControl.unvoteLink": "Meng Ofstëmmung réckgängeg maachen",
   "app.containers.InitiativesShow.VoteControl.vote": "Ofstëmmen",
   "app.containers.InitiativesShow.VoteControl.votedText": "Dir gitt benoriichtegt soubal Äre Virschlag an di nächst Etapp kënnt. {x, plural, =0 {Et si(nn) {xDays} iwwereg.} one {Et si(nn) {xDays} iwwereg.} other {Et si(nn) {xDays} iwwereg.}}",
   "app.containers.InitiativesShow.VoteControl.votedTitle": "Är Stëmm gouf iwwermëttelt!",

--- a/front/app/translations/lv-LV.json
+++ b/front/app/translations/lv-LV.json
@@ -1131,7 +1131,6 @@
   "app.containers.InitiativesShow.VoteControl.reviewPendingStatusExplanationSentenceTwo": "Pēc tam, kad tas būs pārskatīts, saņemsiet e-pasta vēstuli.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanation": "{thresholdReachedStatusExplanationBold}. {orgName} ir paziņots. Balsošana joprojām ir atvērta.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanationBold": "Robežvērtība ir sasniegta",
-  "app.containers.InitiativesShow.VoteControl.unvoteLink": "Atcelt manu balsojumu",
   "app.containers.InitiativesShow.VoteControl.vote": "Balsot",
   "app.containers.InitiativesShow.VoteControl.votedText": "Jūs saņemsiet paziņojumu, kad šis priekšlikums tiks virzīts uz nākamo posmu. {x, plural, =0 {There's {xDays} left.} one {There's {xDays} left.} other {There are {xDays} left.}}",
   "app.containers.InitiativesShow.VoteControl.votedTitle": "Jūsu balsojums ir iesniegts!",

--- a/front/app/translations/mi.json
+++ b/front/app/translations/mi.json
@@ -707,7 +707,6 @@
   "app.containers.InitiativesShow.VoteControl.readAnswer": "Read answer",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanation": "{thresholdReachedStatusExplanationBold}. {orgName} has been notified. Voting remains open.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanationBold": "The threshold has been reached",
-  "app.containers.InitiativesShow.VoteControl.unvoteLink": "Cancel my vote",
   "app.containers.InitiativesShow.VoteControl.vote": "Vote",
   "app.containers.InitiativesShow.VoteControl.votedText": "You'll get notified when this proposal goes to the next step. {x, plural, =0 {There's {xDays} left.} one {There's {xDays} left.} other {There are {xDays} left.}}",
   "app.containers.InitiativesShow.VoteControl.votedTitle": "Your vote has been submitted!",

--- a/front/app/translations/nb-NO.json
+++ b/front/app/translations/nb-NO.json
@@ -1131,7 +1131,6 @@
   "app.containers.InitiativesShow.VoteControl.reviewPendingStatusExplanationSentenceTwo": "Du vil motta en e-post når den er gjennomgått.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanation": "{thresholdReachedStatusExplanationBold}. {orgName} ble informert og vil gi et svar. Avstemningen forblir åpen.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanationBold": "Grensen er nådd",
-  "app.containers.InitiativesShow.VoteControl.unvoteLink": "Trekk tilbake min stemme",
   "app.containers.InitiativesShow.VoteControl.vote": "Stem ",
   "app.containers.InitiativesShow.VoteControl.votedText": "Du vil bli informert når  forslaget går til neste fase. {x, plural, =0 {Der er {xDage} tilbage.} one {Der er {xDage} tilbage.} other {Der er {xDage} tilbage.}}",
   "app.containers.InitiativesShow.VoteControl.votedTitle": "Stemmen din har blitt sendt inn",

--- a/front/app/translations/nl-BE.json
+++ b/front/app/translations/nl-BE.json
@@ -1131,7 +1131,6 @@
   "app.containers.InitiativesShow.VoteControl.reviewPendingStatusExplanationSentenceTwo": "Je ontvangt een e-mail zodra het is beoordeeld.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanation": "{thresholdReachedStatusExplanationBold}. {orgName} is op de hoogte gebracht en zal dit voorstel beantwoorden. Stemmen blijft mogelijk.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanationBold": "Het aantal stemmen is bereikt",
-  "app.containers.InitiativesShow.VoteControl.unvoteLink": "Annuleer mijn stem",
   "app.containers.InitiativesShow.VoteControl.vote": "Stem",
   "app.containers.InitiativesShow.VoteControl.votedText": "Je wordt op de hoogte gebracht wanneer dit voorstel naar de volgende stap gaat. {x, plural, =0 {Er zijn {xDays} meer.} one {Er is nog {xDays}.} other {Er zijn nog {xDays} over.}}",
   "app.containers.InitiativesShow.VoteControl.votedTitle": "Je stem werd uitgebracht!",

--- a/front/app/translations/nl-NL.json
+++ b/front/app/translations/nl-NL.json
@@ -1131,7 +1131,6 @@
   "app.containers.InitiativesShow.VoteControl.reviewPendingStatusExplanationSentenceTwo": "Je ontvangt een e-mail zodra het is beoordeeld.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanation": "{thresholdReachedStatusExplanationBold}. {orgName} is op de hoogte gebracht en zal dit voorstel beantwoorden. Stemmen blijft mogelijk.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanationBold": "Het aantal stemmen is bereikt",
-  "app.containers.InitiativesShow.VoteControl.unvoteLink": "Annuleer mijn stem",
   "app.containers.InitiativesShow.VoteControl.vote": "Stem",
   "app.containers.InitiativesShow.VoteControl.votedText": "Je wordt op de hoogte gebracht wanneer dit voorstel naar de volgende stap gaat. {x, plural, =0 {Er zijn {xDays} meer.} one {Er is nog {xDays}.} other {Er zijn nog {xDays} over.}}",
   "app.containers.InitiativesShow.VoteControl.votedTitle": "Je stem werd uitgebracht!",

--- a/front/app/translations/pl-PL.json
+++ b/front/app/translations/pl-PL.json
@@ -1131,7 +1131,6 @@
   "app.containers.InitiativesShow.VoteControl.reviewPendingStatusExplanationSentenceTwo": "Po rozpatrzeniu otrzymasz wiadomość e-mail.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanation": "{thresholdReachedStatusExplanationBold}. {orgName} został powiadomiony i udzieli odpowiedzi. Głosowanie pozostaje otwarte.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanationBold": "Próg poparcia został osiągnięty",
-  "app.containers.InitiativesShow.VoteControl.unvoteLink": "Odwołaj mój głos",
   "app.containers.InitiativesShow.VoteControl.vote": "Głosuj",
   "app.containers.InitiativesShow.VoteControl.votedText": "Zostaniesz poinformowany, gdy ta propozycja przejdzie do następnego etapu. {x, plural, =0 {Zostało {xDays}.} one {Został {xDays}.} few {Zostało {xDays}.} many {Zostało {xDays}.} other {Zostało {xDays} left.}}",
   "app.containers.InitiativesShow.VoteControl.votedTitle": "Twój głos został oddany!",

--- a/front/app/translations/pt-BR.json
+++ b/front/app/translations/pt-BR.json
@@ -1131,7 +1131,6 @@
   "app.containers.InitiativesShow.VoteControl.reviewPendingStatusExplanationSentenceTwo": "Você receberá um e-mail assim que for revisada.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanation": "{thresholdReachedStatusExplanationBold}. {orgName} foi notificado e irá fornecer uma resposta. A votação continua em aberto.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanationBold": "O limite foi estourado",
-  "app.containers.InitiativesShow.VoteControl.unvoteLink": "Cancelar o meu voto",
   "app.containers.InitiativesShow.VoteControl.vote": "Curtir",
   "app.containers.InitiativesShow.VoteControl.votedText": "Você será notificado quando esta proposta for para o próximo passo. {x, plural, =0 {Há {xDays} à esquerda.} one {Há {xDays} à esquerda.} other {Há {xDays} à esquerda.}}",
   "app.containers.InitiativesShow.VoteControl.votedTitle": "O seu voto foi enviado com sucesso!",

--- a/front/app/translations/ro-RO.json
+++ b/front/app/translations/ro-RO.json
@@ -873,7 +873,6 @@
   "app.containers.InitiativesShow.VoteControl.readAnswer": "Citește răspunsul",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanation": "{thresholdReachedStatusExplanationBold}. {orgName} a fost notificată și vă va oferi un răspuns. Votarea rămâne deschisă.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanationBold": "Pragul a fost atins",
-  "app.containers.InitiativesShow.VoteControl.unvoteLink": "Anulează votul meu",
   "app.containers.InitiativesShow.VoteControl.vote": "Votează",
   "app.containers.InitiativesShow.VoteControl.votedText": "Veți primi o notificare atunci când această propunere va trece la pasul următor. {x, plural, =0 {There's {xDays} left.} one {Au mai rămas {xDays} left.} other {There are {xDays} zile.}}",
   "app.containers.InitiativesShow.VoteControl.votedTitle": "Votul tău a fost trimis!",

--- a/front/app/translations/sr-Latn.json
+++ b/front/app/translations/sr-Latn.json
@@ -1131,7 +1131,6 @@
   "app.containers.InitiativesShow.VoteControl.reviewPendingStatusExplanationSentenceTwo": "You will receive an email once it's reviewed.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanation": "{thresholdReachedStatusExplanationBold}. {orgName} je obavešten i pružiće odgovor. Glasanje je i dalje otvoreno.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanationBold": "Prikupljen je dovoljan broj glasova",
-  "app.containers.InitiativesShow.VoteControl.unvoteLink": "Poništi moj glas",
   "app.containers.InitiativesShow.VoteControl.vote": "Glasajte",
   "app.containers.InitiativesShow.VoteControl.votedText": "Bićete obavešteni kada ovaj predlog pređe u narednu fazu. {x, plural, =0 {Ostalo je još {xDays}.} one {Ostao je još {xDays} .} other {Ostalo je još {xDays}.}}",
   "app.containers.InitiativesShow.VoteControl.votedTitle": "Vaš glas je zabeležen!",

--- a/front/app/translations/sr-SP.json
+++ b/front/app/translations/sr-SP.json
@@ -1131,7 +1131,6 @@
   "app.containers.InitiativesShow.VoteControl.reviewPendingStatusExplanationSentenceTwo": "Добићете е-поруку када буде прегледан.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanation": "{thresholdReachedStatusExplanationBold}. {orgName} је обавештен. Гласање остаје отворено.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanationBold": "Праг је достигнут",
-  "app.containers.InitiativesShow.VoteControl.unvoteLink": "Откажи мој глас",
   "app.containers.InitiativesShow.VoteControl.vote": "Гласајте",
   "app.containers.InitiativesShow.VoteControl.votedText": "Бићете обавештени када овај предлог пређе на следећи корак. {x, plural, =0 {Ту је {xDays} лево.} one {Ту је {xDays} лево.} other {Постоје {xDays} лево.}}",
   "app.containers.InitiativesShow.VoteControl.votedTitle": "Ваш глас је послат!",

--- a/front/app/translations/sv-SE.json
+++ b/front/app/translations/sv-SE.json
@@ -1131,7 +1131,6 @@
   "app.containers.InitiativesShow.VoteControl.reviewPendingStatusExplanationSentenceTwo": "Du kommer att få ett e-postmeddelande när det har granskats.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanation": "{thresholdReachedStatusExplanationBold}. {orgName} har underrättats. Röstningen är fortfarande öppen.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanationBold": "Tröskeln har nåtts",
-  "app.containers.InitiativesShow.VoteControl.unvoteLink": "Avbryt min röst",
   "app.containers.InitiativesShow.VoteControl.vote": "Rösta",
   "app.containers.InitiativesShow.VoteControl.votedText": "Du får ett meddelande när detta förslag går till nästa steg. {x, plural, =0 {Det är {xDays} kvar.} one {Det är {xDays} kvar.} other {Det är {xDays} kvar.}}",
   "app.containers.InitiativesShow.VoteControl.votedTitle": "Din röst har skickats!",

--- a/front/app/translations/tr-TR.json
+++ b/front/app/translations/tr-TR.json
@@ -1131,7 +1131,6 @@
   "app.containers.InitiativesShow.VoteControl.reviewPendingStatusExplanationSentenceTwo": "İncelendikten sonra bir e-posta alacaksınız.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanation": "{thresholdReachedStatusExplanationBold}. {orgName} bilgilendirildi. Oylama devam ediyor.",
   "app.containers.InitiativesShow.VoteControl.thresholdReachedStatusExplanationBold": "Eşiğe ulaşan",
-  "app.containers.InitiativesShow.VoteControl.unvoteLink": "Oyumu iptal et",
   "app.containers.InitiativesShow.VoteControl.vote": "Oy verin",
   "app.containers.InitiativesShow.VoteControl.votedText": "Bu öneri bir sonraki aşamaya geçtiğinde bilgilendirileceksiniz. {x, plural, =0 {{xDays} kaldı.} one {{xDays} kaldı.} other {{xDays} kaldı.}}",
   "app.containers.InitiativesShow.VoteControl.votedTitle": "Oyunuz gönderildi!",


### PR DESCRIPTION
Different proposal statuses are using the same components vs. each their own. + adding missing components to certain statuses.

Changelog will be added to the parent PR when all work is done. All work = facelift & streamlining of all "proposal status cards".