### PR TITLE
[TAN-1118] Don't use SameSite protection for form post SSO providers

### DIFF
--- a/back/app/controllers/omniauth_callback_controller.rb
+++ b/back/app/controllers/omniauth_callback_controller.rb
@@ -10,8 +10,6 @@ class OmniauthCallbackController < ApplicationController
     auth_method = authentication_service.method_by_provider(auth_provider)
     verification_method = get_verification_method(auth_provider)
 
-    return if (auth_method || verification_method).redirect_callback_to_get_cookies(self)
-
     if auth_method && verification_method
       auth_or_verification_callback(verify: verification_method, authver_method: auth_method)
     elsif auth_method

--- a/back/config/application.rb
+++ b/back/config/application.rb
@@ -62,6 +62,29 @@ module Cl2Back
 
     config.action_dispatch.perform_deep_munge = false
     config.session_store :cookie_store, key: '_interslice_session'
+
+    # https://github.com/AzureAD/omniauth-azure-activedirectory/issues/22#issuecomment-1259340380
+    # It's weird that returning nil in `cookies_same_site_protection` works because `lax` is default
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#lax
+    # And this config creates this header: `Set-Cookie: _interslice_session=...; path=/; HttpOnly`
+    # So, lax should be used by default in most browsers. But it works both in Chrome and Firefox.
+    #
+    # If it stops working, we can change `session_store` config to sth like this:
+    # config.session_store :cookie_store, key: '_interslice_session', same_site: :none, secure: true
+    # (same_site also accepts a lambda)
+    config.action_dispatch.cookies_same_site_protection = lambda { |request|
+      # We use `none` SameSite attribute for SSO providers that send response using form post (and don't support redirect).
+      # Omniauth uses session cookie to send a nonce and verify it on the callback.
+      # If SameSite attribute is set to `lax` or `strict`, the session cookie is not sent
+      # with the form post. But it's sent if redirect is used instead of form post (all other SSO providers).
+      # When the cookie is not sent, the nonce verification fails.
+
+      sso_providers_with_form_post = %w[azureactivedirectory nemlog_in]
+      return if sso_providers_with_form_post.any? { request.path.starts_with?("/auth/#{_1}") }
+
+      :lax
+    }
+
     config.middleware.use ActionDispatch::Cookies # Required for all session management
     config.middleware.use ActionDispatch::Session::CookieStore, config.session_options
 

--- a/back/engines/commercial/id_nemlog_in/app/lib/id_nemlog_in/nemlog_in_omniauth.rb
+++ b/back/engines/commercial/id_nemlog_in/app/lib/id_nemlog_in/nemlog_in_omniauth.rb
@@ -49,7 +49,7 @@ module IdNemlogIn
         # Probably, because the request has a token and so the size of request is too big
         # <samlp:AuthnRequest AssertionConsumerServiceURL='https://nemlogin-k3kd.loca.lt/auth/nemlog_in/callback?token=eyJhbG
         # Nemlog-in also fails without this line.
-        assertion_consumer_service_url: callback_uri(configuration),
+        assertion_consumer_service_url: redirect_uri(configuration),
 
         # certificate: verification_config[:certificate], # not required as it's used in our SP metadata file, which is uploaded to NemLog-in
         private_key: verification_config[:private_key], # should start with "-----BEGIN PRIVATE KEY-----". "Bag Attributes" part should be removed
@@ -81,52 +81,6 @@ module IdNemlogIn
       %i[]
     end
 
-    # Why do we need cookies?
-    # The omniauth gem saves our params (token and path) to the session here
-    # https://github.com/omniauth/omniauth/blob/a13cd110beb9538ea51be6c614bf43351c3f4e95/lib/omniauth/strategy.rb#L233
-    # Then we use both params in Verification::Patches::OmniauthCallbackController.
-    #
-    # In some omniauth strategies (e.g., OIDC for ClaveUnica), the provider (ClaveUnica)
-    # redirects a user to our app via the 302 code. This way, the cookies are passed to our app.
-    #
-    # But in other strategies (e.g., SAML for Nemlog-in), the provider (Nemlog-in)
-    # "redirects" using an html POST form (see below).
-    # This way, the cookies are not passed to our app.
-    # See:
-    # - https://web.dev/samesite-cookie-recipes/#:~:text=primarily%20POST%20requests.-,Cookies%20marked%20as,-SameSite%3DLax%20will
-    # - https://citizenlabco.slack.com/archives/C65GX921W/p1695740292043389
-    #
-    def redirect_callback_to_get_cookies(controller)
-      nemlog_in_callback_uri = callback_uri(AppConfiguration.instance)
-      # If the request comes from #callback_uri, it means the form below was already submitted
-      # which means the previous nemlog_in/callback "redirected" here.
-      # It also means that the cookies are present in the current request.
-      return false if controller.request.referer.nil? || controller.request.referer.include?(nemlog_in_callback_uri)
-
-      controller.request.session_options[:skip] = true # without this line, session is overwritten with a new (almost empty) one
-
-      # We cannot use redirect_to, because SAMLResponse can be many kilobytes long,
-      # and so doesn't fit into a GET response for many web servers.
-      # Nemlog-in uses the same form to "redirect" to our app.
-      # rubocop:disable Rails/OutputSafety
-      controller.render html: <<-HTML.html_safe
-        <form action="#{nemlog_in_callback_uri}" method="post">
-          <div>
-            <input type="hidden" name="RelayState" value="#{controller.params['RelayState']}"/>
-            <input type="hidden" name="SAMLResponse" value="#{controller.params['SAMLResponse']}"/>
-          </div>
-        </form>
-        <script>
-          window.addEventListener('DOMContentLoaded', function() {
-            document.forms[0].submit()
-          })
-        </script>
-      HTML
-      # rubocop:enable Rails/OutputSafety
-
-      true
-    end
-
     def logout_url; end
 
     private
@@ -135,7 +89,7 @@ module IdNemlogIn
       IdNemlogIn::KkiLocationApi.new.municipality_code(cpr_number)
     end
 
-    def callback_uri(configuration)
+    def redirect_uri(configuration)
       "#{configuration.base_backend_uri}/auth/nemlog_in/callback"
     end
   end

--- a/back/lib/omniauth_methods/base.rb
+++ b/back/lib/omniauth_methods/base.rb
@@ -36,10 +36,6 @@ module OmniauthMethods
       true
     end
 
-    def redirect_callback_to_get_cookies(_controller)
-      false
-    end
-
     # It never runs if #can_merge? always returns true.
     # So, override only if you need to override #can_merge?
     def merging_error_code


### PR DESCRIPTION
### Why did Azure AD SSO stop working?
Likely because of new Rails defaults for `SameSite` that became `lax` (was `none` before). There's also a small chance that browser defaults have changed.

### Is this solution perfect?
No. If the browser defaults for `SameSite` change to `lax`, it'll break again. It [should be the case for Chrome now](https://caniuse.com/mdn-http_headers_set-cookie_samesite_lax_default), but in practice it's not. And I don't see how to configure it [as described here](https://www.chromium.org/updates/same-site/faq/#:~:text=In%20the%20location%20bar%2C%20enter,site%2Dmust%2Dbe%2Dsecure).

To avoid it breaking, we can explicitly set `SameSite` to `none`, but it requires setting `secure` cookie config to `true` (otherwise, browsers ignore these cookies). But if secure is true, [Rack doesn't write cookies](https://github.com/rack/rack/blob/v2.2.8/lib/rack/session/abstract/id.rb#L363-L366) if `request.ssl?` [returns](https://github.com/rack/rack/blob/v2.2.8/lib/rack/request.rb#L350-L352) `false`. First, I'm not sure `request.ssl?` is `true` on production. Second, it means it won't work on localhost (`request.ssl?` returns false on localhost).

There's a way around it, but maybe it's not that important to spend time on it this time. Maybe writing proper e2e tests for SSO would be a better investment to prevent regression.

### Why is Azure AD more similar to SAML Nemlog-in than to other OIDC providers?
Both SAML and OIDC support passing data by both redirect and form post. For Vienna, [we use redirect](https://github.com/CitizenLabDotCo/citizenlab/blob/2b0e2c9/back/engines/commercial/id_vienna_saml/config/saml/citizen/idp_metadata_production.xml#L38). But Nemlog-in [supports only form post](https://github.com/CitizenLabDotCo/citizenlab/blob/5e02cbf/back/engines/commercial/id_nemlog_in/config/saml/sp_metadata_examples/production.xml#L26). And the Azure AD gem that we use doesn't support redirect (for redirects, it should fetch `id_token`, and [there's no code related to it](https://github.com/CitizenLabDotCo/citizenlab/blob/507638a/back/lib/omni_auth/strategies/azure_active_directory.rb)). We could use another gem or just OIDC Omniauth gem, but probably it'll take some time to migrate.

# Changelog
## Fixed
* [TAN-1118] Make Azure AD (Entra ID) SSO work again. Simplify Nemlog-in SSO