### PR TITLE
TAN-1181 Add new esri_base_map_id to map_configs

### DIFF
--- a/back/app/models/que_job.rb
+++ b/back/app/models/que_job.rb
@@ -1,5 +1,30 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: public.que_jobs
+#
+#  priority             :integer          default(100), not null
+#  run_at               :timestamptz      not null
+#  id                   :bigint           not null, primary key
+#  job_class            :text             not null
+#  error_count          :integer          default(0), not null
+#  last_error_message   :text
+#  queue                :text             default("default"), not null
+#  last_error_backtrace :text
+#  finished_at          :timestamptz
+#  expired_at           :timestamptz
+#  args                 :jsonb            not null
+#  data                 :jsonb            not null
+#  job_schema_version   :integer          default(1)
+#
+# Indexes
+#
+#  que_jobs_args_gin_idx                 (args) USING gin
+#  que_jobs_data_gin_idx                 (data) USING gin
+#  que_poll_idx                          (queue,priority,run_at,id) WHERE ((finished_at IS NULL) AND (expired_at IS NULL))
+#  que_poll_idx_with_job_schema_version  (job_schema_version,queue,priority,run_at,id) WHERE ((finished_at IS NULL) AND (expired_at IS NULL))
+#
 require 'que/active_record/model'
 
 class QueJob < Que::ActiveRecord::Model

--- a/back/app/services/project_copy_service.rb
+++ b/back/app/services/project_copy_service.rb
@@ -390,6 +390,7 @@ class ProjectCopyService < TemplateService
         'zoom_level' => map_config.zoom_level&.to_f,
         'tile_provider' => map_config.tile_provider,
         'esri_web_map_id' => map_config.esri_web_map_id,
+        'esri_base_map_id' => map_config.esri_base_map_id,
         'created_at' => shift_timestamp(map_config.created_at, shift_timestamps)&.iso8601,
         'updated_at' => shift_timestamp(map_config.updated_at, shift_timestamps)&.iso8601
       }

--- a/back/db/migrate/20240226170510_add_esri_base_map_id_to_map_configs.custom_maps.rb
+++ b/back/db/migrate/20240226170510_add_esri_base_map_id_to_map_configs.custom_maps.rb
@@ -1,0 +1,6 @@
+# This migration comes from custom_maps (originally 20240226170315)
+class AddEsriBaseMapIdToMapConfigs < ActiveRecord::Migration[7.0]
+  def change
+    add_column :maps_map_configs, :esri_base_map_id, :string
+  end
+end

--- a/back/db/structure.sql
+++ b/back/db/structure.sql
@@ -2645,7 +2645,8 @@ CREATE TABLE public.maps_map_configs (
     tile_provider character varying,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    esri_web_map_id character varying
+    esri_web_map_id character varying,
+    esri_base_map_id character varying
 );
 
 
@@ -7430,6 +7431,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240130142750'),
 ('20240130170644'),
 ('20240206165004'),
-('20240214125557');
+('20240214125557'),
+('20240226170510');
 
 

--- a/back/engines/commercial/custom_maps/app/controllers/custom_maps/web_api/v1/map_configs_controller.rb
+++ b/back/engines/commercial/custom_maps/app/controllers/custom_maps/web_api/v1/map_configs_controller.rb
@@ -53,7 +53,14 @@ module CustomMaps
         end
 
         def map_config_params
-          params.require(:map_config).permit(:zoom_level, :tile_provider, :esri_web_map_id, center_geojson: {})
+          params.require(:map_config)
+            .permit(
+              :zoom_level,
+              :tile_provider,
+              :esri_web_map_id,
+              :esri_base_map_id,
+              center_geojson: {}
+            )
         end
       end
     end

--- a/back/engines/commercial/custom_maps/app/models/custom_maps/map_config.rb
+++ b/back/engines/commercial/custom_maps/app/models/custom_maps/map_config.rb
@@ -4,14 +4,15 @@
 #
 # Table name: maps_map_configs
 #
-#  id              :uuid             not null, primary key
-#  project_id      :uuid             not null
-#  center          :geography        point, 4326
-#  zoom_level      :decimal(4, 2)
-#  tile_provider   :string
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  esri_web_map_id :string
+#  id               :uuid             not null, primary key
+#  project_id       :uuid             not null
+#  center           :geography        point, 4326
+#  zoom_level       :decimal(4, 2)
+#  tile_provider    :string
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  esri_web_map_id  :string
+#  esri_base_map_id :string
 #
 # Indexes
 #

--- a/back/engines/commercial/custom_maps/app/serializers/custom_maps/web_api/v1/map_config_serializer.rb
+++ b/back/engines/commercial/custom_maps/app/serializers/custom_maps/web_api/v1/map_config_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CustomMaps::WebApi::V1::MapConfigSerializer < WebApi::V1::BaseSerializer
-  attributes :zoom_level, :tile_provider, :esri_web_map_id, :center_geojson
+  attributes :zoom_level, :tile_provider, :esri_web_map_id, :esri_base_map_id, :center_geojson
   belongs_to :project, serializer: WebApi::V1::ProjectSerializer
 
   attribute :layers do |map_config, _params|

--- a/back/engines/commercial/custom_maps/db/migrate/20240226170315_add_esri_base_map_id_to_map_configs.rb
+++ b/back/engines/commercial/custom_maps/db/migrate/20240226170315_add_esri_base_map_id_to_map_configs.rb
@@ -1,0 +1,5 @@
+class AddEsriBaseMapIdToMapConfigs < ActiveRecord::Migration[7.0]
+  def change
+    add_column :maps_map_configs, :esri_base_map_id, :string
+  end
+end

--- a/back/engines/commercial/custom_maps/spec/acceptance/map_configs_spec.rb
+++ b/back/engines/commercial/custom_maps/spec/acceptance/map_configs_spec.rb
@@ -104,11 +104,11 @@ resource 'Map Configs' do
         )
       end
 
-      let(:zoom_level)     { map_config_attributes[:zoom_level] }
-      let(:center_geojson) { RGeo::GeoJSON.encode(map_config_attributes[:center]) }
-      let(:tile_provider)  { map_config_attributes[:tile_provider] }
+      let(:zoom_level)       { map_config_attributes[:zoom_level] }
+      let(:center_geojson)   { RGeo::GeoJSON.encode(map_config_attributes[:center]) }
+      let(:tile_provider)    { map_config_attributes[:tile_provider] }
       let(:esri_web_map_id)  { map_config_attributes[:esri_web_map_id] }
-      let(:esri_base_map_id)  { map_config_attributes[:esri_base_map_id] }
+      let(:esri_base_map_id) { map_config_attributes[:esri_base_map_id] }
 
       example_request 'Creating a map config successfully' do
         expect(status).to eq 200

--- a/back/engines/commercial/custom_maps/spec/acceptance/map_configs_spec.rb
+++ b/back/engines/commercial/custom_maps/spec/acceptance/map_configs_spec.rb
@@ -22,6 +22,7 @@ resource 'Map Configs' do
           :with_positioning,
           :with_tile_provider,
           :with_esri_web_map_id,
+          :with_esri_base_map_id,
           :with_geojson_layers,
           :with_legend,
           project: project)
@@ -34,6 +35,7 @@ resource 'Map Configs' do
         expect(attributes['tile_provider']).to eq map_config.tile_provider
         expect(attributes['zoom_level']).to eq map_config.zoom_level.to_s
         expect(attributes['esri_web_map_id']).to eq map_config.esri_web_map_id
+        expect(attributes['esri_base_map_id']).to eq map_config.esri_base_map_id
         expect(attributes['layers'][0]['title_multiloc']).to eq map_config.layers.first.title_multiloc
         expect(attributes['layers'][0]['geojson']).to eq map_config.layers.first.geojson
         expect(attributes['layers'][0]['default_enabled']).to eq map_config.layers.first.default_enabled
@@ -89,16 +91,24 @@ resource 'Map Configs' do
         parameter :center_geojson,  'The coordinates of the map center as a GeoJSON object'
         parameter :tile_provider,   'The tile provider'
         parameter :esri_web_map_id, 'The ID of the Esri web map'
+        parameter :esri_base_map_id, 'The ID of the Esri base map'
       end
 
       let!(:map_config_attributes) do
-        attributes_for(:map_config, :with_tile_provider, :with_positioning, :with_esri_web_map_id)
+        attributes_for(
+          :map_config,
+          :with_tile_provider,
+          :with_positioning,
+          :with_esri_web_map_id,
+          :with_esri_base_map_id
+        )
       end
 
       let(:zoom_level)     { map_config_attributes[:zoom_level] }
       let(:center_geojson) { RGeo::GeoJSON.encode(map_config_attributes[:center]) }
       let(:tile_provider)  { map_config_attributes[:tile_provider] }
       let(:esri_web_map_id)  { map_config_attributes[:esri_web_map_id] }
+      let(:esri_base_map_id)  { map_config_attributes[:esri_base_map_id] }
 
       example_request 'Creating a map config successfully' do
         expect(status).to eq 200
@@ -106,6 +116,7 @@ resource 'Map Configs' do
         expect(attributes['zoom_level']).to      eq zoom_level.to_f.to_s
         expect(attributes['tile_provider']).to   eq tile_provider
         expect(attributes['esri_web_map_id']).to eq esri_web_map_id
+        expect(attributes['esri_base_map_id']).to eq esri_base_map_id
       end
     end
 
@@ -115,6 +126,7 @@ resource 'Map Configs' do
         parameter :center_geojson, 'The coordinates of the map center as a GeoJSON object'
         parameter :tile_provider,  'The tile provider'
         parameter :esri_web_map_id, 'The ID of the Esri web map'
+        parameter :esri_base_map_id, 'The ID of the Esri base map'
       end
 
       let!(:map_config_attributes) { attributes_for(:map_config, :with_tile_provider, :with_positioning) }
@@ -123,6 +135,7 @@ resource 'Map Configs' do
       let(:center_geojson) { { type: 'Point', coordinates: [42.42, 24.24] } }
       let(:tile_provider) { 'https://fake-tile-provider.com/tiles' }
       let(:esri_web_map_id) { 'my-fake-esri-web-map-id-4242' }
+      let(:esri_base_map_id) { 'my-fake-esri-base-map-id-9090' }
 
       context 'when the project already has a map config' do
         before do
@@ -140,6 +153,7 @@ resource 'Map Configs' do
           expect(attributes['zoom_level']).to      eq '11.0'
           expect(attributes['tile_provider']).to   eq 'https://fake-tile-provider.com/tiles'
           expect(attributes['esri_web_map_id']).to eq 'my-fake-esri-web-map-id-4242'
+          expect(attributes['esri_base_map_id']).to eq 'my-fake-esri-base-map-id-9090'
         end
       end
 
@@ -157,6 +171,7 @@ resource 'Map Configs' do
             :with_positioning,
             :with_tile_provider,
             :with_esri_web_map_id,
+            :with_esri_base_map_id,
             :with_geojson_layers,
             :with_legend,
             project: project)

--- a/back/engines/commercial/custom_maps/spec/factories/map_configs.rb
+++ b/back/engines/commercial/custom_maps/spec/factories/map_configs.rb
@@ -38,5 +38,9 @@ FactoryBot.define do
     trait :with_esri_web_map_id do
       esri_web_map_id { SecureRandom.uuid }
     end
+
+    trait :with_esri_base_map_id do
+      esri_base_map_id { SecureRandom.uuid }
+    end
   end
 end

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/custom_maps/map_config.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/custom_maps/map_config.rb
@@ -6,7 +6,7 @@ module MultiTenancy
       module CustomMaps
         class MapConfig < Base
           ref_attribute :project
-          attributes %i[center_geojson tile_provider esri_web_map_id]
+          attributes %i[center_geojson tile_provider esri_web_map_id esri_web_map_id]
           attribute(:zoom_level) { |map_config| map_config.zoom_level&.to_f }
         end
       end


### PR DESCRIPTION
Extremely similar to #7011, which added `esri_web_map_id`

With the new Esri SDK we will be / are introducing to the FE, we wish to add the option of using an Esri Base Map (a preconfigured base map).

The FE will use the id of the Esri base Map to refer to / fetch the remote web map resource (via the Esri SDK).

In discussion with Amanda, we felt model validations around this new attribute were unnecessary.

# Changelog
## Technical
- [TAN-1181] Add esri _base_map_id column to map_configs
