### PR TITLE
TAN-1154 Visibility toggle report

### DIFF
--- a/back/app/models/que_job.rb
+++ b/back/app/models/que_job.rb
@@ -1,5 +1,30 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: public.que_jobs
+#
+#  priority             :integer          default(100), not null
+#  run_at               :timestamptz      not null
+#  id                   :bigint           not null, primary key
+#  job_class            :text             not null
+#  error_count          :integer          default(0), not null
+#  last_error_message   :text
+#  queue                :text             default("default"), not null
+#  last_error_backtrace :text
+#  finished_at          :timestamptz
+#  expired_at           :timestamptz
+#  args                 :jsonb            not null
+#  data                 :jsonb            not null
+#  job_schema_version   :integer          default(1)
+#
+# Indexes
+#
+#  que_jobs_args_gin_idx                 (args) USING gin
+#  que_jobs_data_gin_idx                 (data) USING gin
+#  que_poll_idx                          (queue,priority,run_at,id) WHERE ((finished_at IS NULL) AND (expired_at IS NULL))
+#  que_poll_idx_with_job_schema_version  (job_schema_version,queue,priority,run_at,id) WHERE ((finished_at IS NULL) AND (expired_at IS NULL))
+#
 require 'que/active_record/model'
 
 class QueJob < Que::ActiveRecord::Model

--- a/back/db/migrate/20240227092300_add_visible_to_reports.rb
+++ b/back/db/migrate/20240227092300_add_visible_to_reports.rb
@@ -2,6 +2,6 @@
 
 class AddVisibleToReports < ActiveRecord::Migration[7.0]
   def change
-    add_column :report_builder_reports, :visibile, :boolean, default: false, null: false
+    add_column :report_builder_reports, :visible, :boolean, default: false, null: false
   end
 end

--- a/back/db/migrate/20240227092300_add_visible_to_reports.rb
+++ b/back/db/migrate/20240227092300_add_visible_to_reports.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddVisibleToReports < ActiveRecord::Migration[7.0]
+  def change
+    add_column :report_builder_reports, :visibile, :boolean, default: false, null: false
+  end
+end

--- a/back/db/structure.sql
+++ b/back/db/structure.sql
@@ -3094,7 +3094,8 @@ CREATE TABLE public.report_builder_reports (
     owner_id uuid NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    phase_id uuid
+    phase_id uuid,
+    visible boolean DEFAULT false NOT NULL
 );
 
 
@@ -7430,6 +7431,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240130142750'),
 ('20240130170644'),
 ('20240206165004'),
-('20240214125557');
+('20240214125557'),
+('20240227092300');
 
 

--- a/back/engines/commercial/report_builder/app/controllers/report_builder/web_api/v1/reports_controller.rb
+++ b/back/engines/commercial/report_builder/app/controllers/report_builder/web_api/v1/reports_controller.rb
@@ -86,6 +86,7 @@ module ReportBuilder
             .permit(
               :name,
               :phase_id,
+              :visible,
               layout: [craftjs_json: {}]
             )
 

--- a/back/engines/commercial/report_builder/app/models/report_builder/report.rb
+++ b/back/engines/commercial/report_builder/app/models/report_builder/report.rb
@@ -45,9 +45,5 @@ module ReportBuilder
     def phase?
       !phase_id.nil?
     end
-
-    def visible?
-      visible
-    end
   end
 end

--- a/back/engines/commercial/report_builder/app/models/report_builder/report.rb
+++ b/back/engines/commercial/report_builder/app/models/report_builder/report.rb
@@ -45,5 +45,9 @@ module ReportBuilder
     def phase?
       !phase_id.nil?
     end
+
+    def visible?
+      visible
+    end
   end
 end

--- a/back/engines/commercial/report_builder/app/models/report_builder/report.rb
+++ b/back/engines/commercial/report_builder/app/models/report_builder/report.rb
@@ -10,6 +10,7 @@
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  phase_id   :uuid
+#  visible    :boolean          default(FALSE), not null
 #
 # Indexes
 #

--- a/back/engines/commercial/report_builder/app/policies/report_builder/report_policy.rb
+++ b/back/engines/commercial/report_builder/app/policies/report_builder/report_policy.rb
@@ -45,7 +45,7 @@ module ReportBuilder
       elsif user.present? && user.project_or_folder_moderator?
         if record.phase?
           if PhasePolicy.new(user, record.phase).show?
-            record.phase.started? || access_to_data?
+            (record.phase.started? && record.visible?) || access_to_data?
           else
             false
           end
@@ -82,7 +82,10 @@ module ReportBuilder
     end
 
     def phase_started_and_accessible?
-      record.phase? && PhasePolicy.new(user, record.phase).show? && record.phase.started?
+      record.phase? &&
+        PhasePolicy.new(user, record.phase).show? &&
+        record.phase.started? &&
+        record.visible?
     end
   end
 end

--- a/back/engines/commercial/report_builder/app/serializers/report_builder/web_api/v1/report_serializer.rb
+++ b/back/engines/commercial/report_builder/app/serializers/report_builder/web_api/v1/report_serializer.rb
@@ -4,7 +4,7 @@ module ReportBuilder
   module WebApi
     module V1
       class ReportSerializer < ::WebApi::V1::BaseSerializer
-        attributes :name, :created_at, :updated_at
+        attributes :name, :created_at, :updated_at, :visible
 
         attribute :action_descriptor do |object, params|
           @permissions_service = ReportBuilder::PermissionsService.new

--- a/back/engines/commercial/report_builder/spec/acceptance/reports_spec.rb
+++ b/back/engines/commercial/report_builder/spec/acceptance/reports_spec.rb
@@ -54,7 +54,8 @@ resource 'Reports' do
             },
             name: report.name,
             created_at: report.created_at.iso8601(3),
-            updated_at: report.updated_at.iso8601(3)
+            updated_at: report.updated_at.iso8601(3),
+            visible: false
           },
           relationships: {
             layout: { data: { id: layout.id, type: 'content_builder_layout' } },
@@ -113,7 +114,8 @@ resource 'Reports' do
             },
             name: name,
             created_at: be_a(String),
-            updated_at: be_a(String)
+            updated_at: be_a(String),
+            visible: false
           },
           relationships: {
             layout: { data: { id: be_a(String), type: 'content_builder_layout' } },

--- a/back/engines/commercial/report_builder/spec/acceptance/reports_spec.rb
+++ b/back/engines/commercial/report_builder/spec/acceptance/reports_spec.rb
@@ -55,7 +55,7 @@ resource 'Reports' do
             name: report.name,
             created_at: report.created_at.iso8601(3),
             updated_at: report.updated_at.iso8601(3),
-            visible: false
+            visible: true
           },
           relationships: {
             layout: { data: { id: layout.id, type: 'content_builder_layout' } },

--- a/back/engines/commercial/report_builder/spec/acceptance/reports_spec.rb
+++ b/back/engines/commercial/report_builder/spec/acceptance/reports_spec.rb
@@ -218,6 +218,14 @@ resource 'Reports' do
         end
       end
 
+      describe 'updating the visibility of a report' do
+        example 'Visibility successfully updates by report id' do
+          do_request(report: { visible: true })
+          assert_status 200
+          expect(report.reload.visible).to be(true)
+        end
+      end
+
       describe 'side effects', document: false do
         let(:side_fx_service) do
           instance_spy(ReportBuilder::SideFxReportService, 'side_fx_service')

--- a/back/engines/commercial/report_builder/spec/acceptance/reports_spec.rb
+++ b/back/engines/commercial/report_builder/spec/acceptance/reports_spec.rb
@@ -220,6 +220,7 @@ resource 'Reports' do
 
       describe 'updating the visibility of a report' do
         example 'Visibility successfully updates by report id' do
+          expect(report.reload.visible).to be(true)
           do_request(report: { visible: false })
           assert_status 200
           expect(report.reload.visible).to be(false)

--- a/back/engines/commercial/report_builder/spec/acceptance/reports_spec.rb
+++ b/back/engines/commercial/report_builder/spec/acceptance/reports_spec.rb
@@ -220,9 +220,9 @@ resource 'Reports' do
 
       describe 'updating the visibility of a report' do
         example 'Visibility successfully updates by report id' do
-          do_request(report: { visible: true })
+          do_request(report: { visible: false })
           assert_status 200
-          expect(report.reload.visible).to be(true)
+          expect(report.reload.visible).to be(false)
         end
       end
 

--- a/back/engines/commercial/report_builder/spec/factories/reports.rb
+++ b/back/engines/commercial/report_builder/spec/factories/reports.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     sequence(:name) { |i| "report-name-#{i}" }
     owner factory: :user
     layout { association :layout, content_buildable: instance, code: 'report' }
+    visible { true }
   end
 end

--- a/back/engines/commercial/report_builder/spec/policies/report_builder/report_policy_spec.rb
+++ b/back/engines/commercial/report_builder/spec/policies/report_builder/report_policy_spec.rb
@@ -173,12 +173,31 @@ RSpec.describe ReportBuilder::ReportPolicy do
           it { expect(scope.resolve.count).to eq(0) }
         end
 
-        context 'when user cannot moderate phase' do
+        context 'when user cannot moderate phase, and report is visible' do
           let_it_be(:user) { create(:project_moderator) }
           let_it_be(:report) { create(:report, phase: current_phase, layout: layout) }
 
           it { is_expected.not_to permit(:show) }
           it { is_expected.to permit(:layout) }
+          it { is_expected.not_to permit(:create) }
+          it { is_expected.not_to permit(:destroy) }
+          it { is_expected.not_to permit(:update) }
+          it { expect(scope.resolve.count).to eq(0) }
+        end
+
+        context 'when user cannot moderate phase, and report is not visible' do
+          let_it_be(:user) { create(:project_moderator) }
+          let_it_be(:report) do
+            create(
+              :report,
+              phase: current_phase,
+              layout: layout,
+              visible: false
+            )
+          end
+
+          it { is_expected.not_to permit(:show) }
+          it { is_expected.not_to permit(:layout) }
           it { is_expected.not_to permit(:create) }
           it { is_expected.not_to permit(:destroy) }
           it { is_expected.not_to permit(:update) }
@@ -227,11 +246,22 @@ RSpec.describe ReportBuilder::ReportPolicy do
         it { expect { scope.resolve.count }.to raise_error(Pundit::NotAuthorizedError) }
       end
 
-      context 'phase started' do
+      context 'phase started and report visible' do
         let_it_be(:report) { create(:report, phase: current_phase) }
 
         it { is_expected.not_to permit(:show) }
         it { is_expected.to permit(:layout) }
+        it { is_expected.not_to permit(:create) }
+        it { is_expected.not_to permit(:destroy) }
+        it { is_expected.not_to permit(:update) }
+        it { expect { scope.resolve.count }.to raise_error(Pundit::NotAuthorizedError) }
+      end
+
+      context 'phase started and report not visible' do
+        let_it_be(:report) { create(:report, phase: current_phase, visible: false) }
+
+        it { is_expected.not_to permit(:show) }
+        it { is_expected.not_to permit(:layout) }
         it { is_expected.not_to permit(:create) }
         it { is_expected.not_to permit(:destroy) }
         it { is_expected.not_to permit(:update) }
@@ -266,11 +296,22 @@ RSpec.describe ReportBuilder::ReportPolicy do
         it { expect { scope.resolve.count }.to raise_error(Pundit::NotAuthorizedError) }
       end
 
-      context 'phase started' do
+      context 'phase started and report visible' do
         let_it_be(:report) { create(:report, phase: current_phase) }
 
         it { is_expected.not_to permit(:show) }
         it { is_expected.to permit(:layout) }
+        it { is_expected.not_to permit(:create) }
+        it { is_expected.not_to permit(:destroy) }
+        it { is_expected.not_to permit(:update) }
+        it { expect { scope.resolve.count }.to raise_error(Pundit::NotAuthorizedError) }
+      end
+
+      context 'phase started and report not visible' do
+        let_it_be(:report) { create(:report, phase: current_phase, visible: false) }
+
+        it { is_expected.not_to permit(:show) }
+        it { is_expected.not_to permit(:layout) }
         it { is_expected.not_to permit(:create) }
         it { is_expected.not_to permit(:destroy) }
         it { is_expected.not_to permit(:update) }

--- a/front/app/api/reports/__mocks__/_mockServer.ts
+++ b/front/app/api/reports/__mocks__/_mockServer.ts
@@ -30,6 +30,7 @@ export const reportsData: Report[] = [
           disabled_reason: null,
         },
       },
+      visible: false,
     },
     relationships: {
       layout: {
@@ -59,6 +60,7 @@ export const reportsData: Report[] = [
           disabled_reason: null,
         },
       },
+      visible: false,
     },
     relationships: {
       layout: {

--- a/front/app/api/reports/types.ts
+++ b/front/app/api/reports/types.ts
@@ -25,6 +25,7 @@ export interface Report {
     action_descriptor: {
       editing_report: EditingReport;
     };
+    visible: boolean;
   };
   relationships: {
     layout: {

--- a/front/app/api/reports/useUpdateReport.test.ts
+++ b/front/app/api/reports/useUpdateReport.test.ts
@@ -1,0 +1,59 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+
+import useUpdateReport from './useUpdateReport';
+
+import { setupServer } from 'msw/node';
+import { rest } from 'msw';
+
+import createQueryClientWrapper from 'utils/testUtils/queryClientWrapper';
+import { reportsData } from './__mocks__/_mockServer';
+
+const apiPath = '*reports/:id';
+
+const server = setupServer(
+  rest.patch(apiPath, (_req, res, ctx) => {
+    return res(ctx.status(200), ctx.json({ data: reportsData[0] }));
+  })
+);
+
+describe('useUpdateReport', () => {
+  beforeAll(() => server.listen());
+  afterAll(() => server.close());
+
+  it('mutates data correctly', async () => {
+    const { result, waitFor } = renderHook(() => useUpdateReport(), {
+      wrapper: createQueryClientWrapper(),
+    });
+
+    act(() => {
+      result.current.mutate({
+        id: '1',
+        visible: false,
+      });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.data).toEqual(reportsData[0]);
+  });
+
+  it('returns error correctly', async () => {
+    server.use(
+      rest.patch(apiPath, (_req, res, ctx) => {
+        return res(ctx.status(500));
+      })
+    );
+
+    const { result, waitFor } = renderHook(() => useUpdateReport(), {
+      wrapper: createQueryClientWrapper(),
+    });
+
+    act(() => {
+      result.current.mutate({
+        id: '1',
+        visible: false,
+      });
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBeDefined();
+  });
+});

--- a/front/app/api/reports/useUpdateReport.ts
+++ b/front/app/api/reports/useUpdateReport.ts
@@ -1,0 +1,38 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { CLErrors } from 'typings';
+import fetcher from 'utils/cl-react-query/fetcher';
+import reportsKeys from './keys';
+import phasesKeys from 'api/phases/keys';
+import { ReportResponse } from './types';
+
+type UpdateReport = {
+  id: string;
+  visible: boolean;
+};
+
+const updateReport = async ({ id, visible }: UpdateReport) =>
+  fetcher<ReportResponse>({
+    path: `/reports/${id}`,
+    action: 'patch',
+    body: { report: { visible } },
+  });
+
+const useUpdateReport = () => {
+  const queryClient = useQueryClient();
+  return useMutation<ReportResponse, CLErrors, UpdateReport>({
+    mutationFn: updateReport,
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: reportsKeys.lists() });
+
+      const phaseId = data.data.relationships.phase?.data?.id;
+
+      if (phaseId) {
+        queryClient.invalidateQueries({
+          queryKey: phasesKeys.item({ phaseId }),
+        });
+      }
+    },
+  });
+};
+
+export default useUpdateReport;

--- a/front/app/containers/Admin/projects/project/information/ReportTab/index.tsx
+++ b/front/app/containers/Admin/projects/project/information/ReportTab/index.tsx
@@ -9,13 +9,14 @@ import useFeatureFlag from 'hooks/useFeatureFlag';
 import usePhase from 'api/phases/usePhase';
 import useReport from 'api/reports/useReport';
 import useDeleteReport from 'api/reports/useDeleteReport';
+import useUpdateReport from 'api/reports/useUpdateReport';
 
 // i18n
 import messages from './messages';
 import { useIntl } from 'utils/cl-intl';
 
 // components
-import { Box, Title } from '@citizenlab/cl2-component-library';
+import { Box, Title, Toggle } from '@citizenlab/cl2-component-library';
 import EmptyState from './EmptyState';
 import ReportPreview from './ReportPreview';
 import Buttons from 'containers/Admin/reporting/components/ReportBuilderPage/ReportRow/Buttons';
@@ -31,6 +32,7 @@ const ReportTab = () => {
   const { formatMessage } = useIntl();
 
   const { mutate: deleteReport, isLoading } = useDeleteReport();
+  const { mutate: updateReport } = useUpdateReport();
 
   if (!phaseReportsEnabled || !phase) return null;
 
@@ -61,13 +63,27 @@ const ReportTab = () => {
         <Title variant="h3" color="primary">
           {formatMessage(messages.report)}
         </Title>
-        {hasReport && (
-          <Buttons
-            reportId={reportId}
-            isLoading={isLoading}
-            onDelete={handleDeleteReport}
-            onEdit={handleEditReport}
-          />
+        {hasReport && report && (
+          <Box display="flex" h="100%" alignItems="center">
+            <Box mr="16px">
+              <Toggle
+                checked={report.data.attributes.visible}
+                onChange={() => {
+                  updateReport({
+                    id: report.data.id,
+                    visible: !report.data.attributes.visible,
+                  });
+                }}
+                label={'Report visible to public'}
+              />
+            </Box>
+            <Buttons
+              reportId={reportId}
+              isLoading={isLoading}
+              onDelete={handleDeleteReport}
+              onEdit={handleEditReport}
+            />
+          </Box>
         )}
       </Box>
       {hasReport ? (

--- a/front/app/containers/Admin/projects/project/information/ReportTab/index.tsx
+++ b/front/app/containers/Admin/projects/project/information/ReportTab/index.tsx
@@ -74,7 +74,7 @@ const ReportTab = () => {
                     visible: !report.data.attributes.visible,
                   });
                 }}
-                label={'Report visible to public'}
+                label={formatMessage(messages.reportVisible)}
               />
             </Box>
             <Buttons

--- a/front/app/containers/Admin/projects/project/information/ReportTab/messages.ts
+++ b/front/app/containers/Admin/projects/project/information/ReportTab/messages.ts
@@ -39,4 +39,8 @@ export default defineMessages({
     id: 'app.containers.Admin.projects.project.information.ReportTab.modalDescription',
     defaultMessage: 'Create a report for a past phase, or start from scratch.',
   },
+  reportVisible: {
+    id: 'app.containers.Admin.projects.project.information.ReportTab.reportVisible',
+    defaultMessage: 'Report visible to public',
+  },
 });

--- a/front/app/containers/Admin/reporting/components/ReportBuilderPage/ReportRow/Buttons/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilderPage/ReportRow/Buttons/index.tsx
@@ -5,7 +5,6 @@ import Tippy from '@tippyjs/react';
 import useReport from 'api/reports/useReport';
 
 // components
-import { Box } from '@citizenlab/cl2-component-library';
 import Button from 'components/UI/Button';
 import PrintReportButton from './PrintReportButton';
 
@@ -30,7 +29,7 @@ const Buttons = ({ reportId, isLoading, onDelete, onEdit }: Props) => {
     report.data.attributes.action_descriptor.editing_report.enabled;
 
   return (
-    <Box display="flex">
+    <>
       <Button
         id="e2e-delete-report-button"
         mr="8px"
@@ -63,7 +62,7 @@ const Buttons = ({ reportId, isLoading, onDelete, onEdit }: Props) => {
         </div>
       </Tippy>
       <PrintReportButton reportId={reportId} />
-    </Box>
+    </>
   );
 };
 

--- a/front/app/containers/Admin/reporting/components/ReportBuilderPage/ReportRow/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilderPage/ReportRow/index.tsx
@@ -63,12 +63,14 @@ const ReportRow = ({ report }: Props) => {
             userId={report.relationships.owner.data.id}
           />
         </Box>
-        <Buttons
-          reportId={report.id}
-          isLoading={isLoading}
-          onDelete={handleDeleteReport}
-          onEdit={handleEditReport}
-        />
+        <Box display="flex">
+          <Buttons
+            reportId={report.id}
+            isLoading={isLoading}
+            onDelete={handleDeleteReport}
+            onEdit={handleEditReport}
+          />
+        </Box>
       </Box>
     </ListItem>
   );

--- a/front/app/translations/admin/en.json
+++ b/front/app/translations/admin/en.json
@@ -764,6 +764,7 @@
   "app.containers.Admin.projects.project.information.ReportTab.modalDescription": "Create a report for a past phase, or start from scratch.",
   "app.containers.Admin.projects.project.information.ReportTab.phaseTemplate": "Start with a phase template",
   "app.containers.Admin.projects.project.information.ReportTab.report": "Report",
+  "app.containers.Admin.projects.project.information.ReportTab.reportVisible": "Report visible to public",
   "app.containers.Admin.projects.project.information.ReportTab.shareResults": "Share results of a past survey or ideation phase",
   "app.containers.Admin.projects.project.information.ReportTab.thisWillBe": "This will be publicly available to users as soon as this phase starts.",
   "app.containers.Admin.projects.project.information.areYouSureYouWantToDelete": "Are you sure you want to delete this report? This action cannot be undone.",

--- a/front/cypress/e2e/report_builder/phase_report.cy.ts
+++ b/front/cypress/e2e/report_builder/phase_report.cy.ts
@@ -122,9 +122,36 @@ describe('Phase report', () => {
     });
   });
 
-  it('is visible in current phase', () => {
+  it('is not visible in current phase if visibility toggle set to false', () => {
     cy.setAdminLoginCookie();
-    cy.apiCreateReportBuilder(currentInfoPhaseId).then((report) => {
+    cy.apiCreateReportBuilder(currentInfoPhaseId, false).then((report) => {
+      const reportId = report.body.data.id;
+
+      cy.visit(`/admin/reporting/report-builder/${reportId}/editor`);
+
+      // Add text widget
+      addTextWidget();
+
+      // Save report
+      saveReport(reportId);
+
+      // Go to phase report, ensure it doesn't exist anywhere
+      cy.visit(`/projects/${projectSlug}/3`);
+      cy.get('.e2e-phase-description').contains(futureInfoPhaseTitle);
+      cy.get('#e2e-phase-report').should('not.exist');
+
+      cy.visit(`/projects/${projectSlug}/2`);
+      cy.get('.e2e-phase-description').contains(currentInfoPhaseTitle);
+      cy.get('#e2e-phase-report').should('not.exist');
+
+      // Clean up
+      cy.apiRemoveReportBuilder(reportId);
+    });
+  });
+
+  it('is visible in current phase if visibility toggle set to true', () => {
+    cy.setAdminLoginCookie();
+    cy.apiCreateReportBuilder(currentInfoPhaseId, true).then((report) => {
       const reportId = report.body.data.id;
 
       cy.visit(`/admin/reporting/report-builder/${reportId}/editor`);

--- a/front/cypress/support/commands.ts
+++ b/front/cypress/support/commands.ts
@@ -1388,7 +1388,7 @@ function apiEnableProjectDescriptionBuilder({
   });
 }
 
-function apiCreateReportBuilder(phaseId?: string) {
+function apiCreateReportBuilder(phaseId?: string, visible: boolean = true) {
   return cy.apiLogin('admin@citizenlab.co', 'democracy2.0').then((response) => {
     const adminJwt = response.body.jwt;
 
@@ -1403,6 +1403,7 @@ function apiCreateReportBuilder(phaseId?: string) {
         report: {
           name: phaseId ? undefined : randomString(),
           phase_id: phaseId,
+          visible,
         },
       },
     });


### PR DESCRIPTION
# Changelog
## Added
- Add visibility toggle in report tab 

# Questions

1. For regular citizen: should a phase have a relationship to a report if the report it set to not visible? Right now, it does have this relationship. I guess it would make sense to remove it. An additional benefit of removing it, is that it will allow us to avoid an unnecessary request:

We render the [PhaseReport](https://github.com/CitizenLabDotCo/citizenlab/blob/dd41d08e96a85ee1862f8b4d8682186582e7a1ae/front/app/containers/ProjectsShowPage/timeline/PhaseReport/index.tsx#L30) in the front office on the [following conditions](https://github.com/CitizenLabDotCo/citizenlab/blob/dd41d08e96a85ee1862f8b4d8682186582e7a1ae/front/app/containers/ProjectsShowPage/timeline/index.tsx#L117):

- If this is an information phase
- That has a report relation
- And the phase has started
 
If these things are all true, we render the `PhaseReport` which requests the report layout. However, if `visible` is set to `false` on the report, the response will be an error. It would be cleaner to not make the request at all. But regular users don't have access to the `report` resource. We can, however, remove the report relation for regular users in this situation, which will avoid the unnecessary request. Does that make sense?

2. The copy of the toggle now says "Report visible to public". Should the copy of the toggle instead say something like "Report visible to public if phase has started", as it's more accurate? Or would this only be more confusing? Or should we handle this with the banner instead?