### PR TITLE
[TAN-1176] Remove redundant maps feature flag and improve maps settings copy

### DIFF
--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -470,8 +470,8 @@
 
       "maps": {
         "type": "object",
-        "title": "CustomMaps",
-        "description":  "Enable maps for all projects.",
+        "title": "Default Maps Settings",
+        "description":  "Default settings for maps.",
         "additionalProperties": false,
         "required": ["allowed", "enabled"],
         "properties": {

--- a/back/engines/commercial/custom_maps/lib/custom_maps/feature_specification.rb
+++ b/back/engines/commercial/custom_maps/lib/custom_maps/feature_specification.rb
@@ -11,11 +11,11 @@ module CustomMaps
     end
 
     def self.feature_title
-      'Custom Map Configuration'
+      'GeoJSON Map Layers'
     end
 
     def self.feature_description
-      'Adds an extra tab to the project settings where admins can customize the project map.'
+      'Adds the ability to use GeoJSON layers on maps.'
     end
   end
 end


### PR DESCRIPTION
CLOSING as branch name is misleading, following change of plans.

## `maps`
- AdminHQ title changed from: “CustomMaps”
- AdminHQ description changed from: “Enable maps for all projects.”

(feature flag not yet removed)

<img width="1081" alt="Screenshot 2024-02-27 at 16 54 06" src="https://github.com/CitizenLabDotCo/citizenlab/assets/3944042/2fc41cbc-5a7d-4227-aba7-141b546d879f">

## `custom_maps`
- AdminHQ title changed from: “Custom Map Configuration”
- AdminHQ description changed from: “Adds an extra tab to the project settings where admins can customize the project map.”

<img width="1081" alt="Screenshot 2024-02-27 at 16 53 40" src="https://github.com/CitizenLabDotCo/citizenlab/assets/3944042/256134be-bed6-4b89-ac2f-4b365940f762">

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->
## Changed
- [TAN-1176] Improves copy for map-related settings (titles & descriptions visible in AdminHQ)
