### PR TITLE
[NO-TICKET] Temporarily downgrading `rack-cors` to 2.0.0 to solve  CVE-2024-27456

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -23,7 +23,7 @@ gem 'bcrypt', '~> 3.1.7'
 # gem 'capistrano-rails', group: :development
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-gem 'rack-cors'
+gem 'rack-cors', '2.0.0'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -918,7 +918,7 @@ GEM
     rack (2.2.8.1)
     rack-attack (6.6.1)
       rack (>= 1.0, < 3)
-    rack-cors (2.0.1)
+    rack-cors (2.0.0)
       rack (>= 2.0.0)
     rack-mini-profiler (3.1.0)
       rack (>= 1.2.0)
@@ -1307,7 +1307,7 @@ DEPENDENCIES
   que (~> 1.4.1)
   que-web (~> 0.10.0)
   rack-attack (~> 6)
-  rack-cors
+  rack-cors (= 2.0.0)
   rack-mini-profiler
   rails (~> 7.0)
   rails-i18n (~> 7.0.7)


### PR DESCRIPTION
# Changelog
## Technical
- [NO-TICKET] Temporarily downgrading `rack-cors` to 2.0.0 to solve  CVE-2024-27456.
