### PR TITLE
TAN-821 - Add users for anonymous posts

### DIFF
--- a/back/app/controllers/web_api/v1/ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/ideas_controller.rb
@@ -145,6 +145,7 @@ class WebApi::V1::IdeasController < ApplicationController
     input.phase_ids = [phase.id] if phase_ids.empty?
 
     # NOTE: Needs refactor allow_anonymous_participation? so anonymous_participation can be allow or force
+    # TODO: JS - not saving anonymous correctly?
     if (phase.native_survey? && phase.allow_anonymous_participation?) || current_user.nil?
       input.anonymous = true
     end

--- a/back/app/controllers/web_api/v1/ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/ideas_controller.rb
@@ -145,7 +145,7 @@ class WebApi::V1::IdeasController < ApplicationController
     input.phase_ids = [phase.id] if phase_ids.empty?
 
     # NOTE: Needs refactor allow_anonymous_participation? so anonymous_participation can be allow or force
-    if phase.native_survey? && phase.allow_anonymous_participation?
+    if (phase.native_survey? && phase.allow_anonymous_participation?) || current_user.nil?
       input.anonymous = true
     end
     input.author ||= current_user

--- a/back/app/models/concerns/anonymous_participation.rb
+++ b/back/app/models/concerns/anonymous_participation.rb
@@ -27,28 +27,16 @@ module AnonymousParticipation
 
     private
 
-    # # Create a placeholder user record if anonymous is set and ensure anonymous is false if author is already present
+    # Create or use a placeholder user by author_hash if anonymous is set and ensure anonymous is false if author is already present
     def set_anonymous_values
       set_author_hash if author_id_changed? || anonymous_changed?
       if anonymous_changed?(to: true)
         # TODO: JS - This is Changing the behaviour of the anonymous avatars
-        user_source = case self.class.name
-        when 'Idea'
-          native_survey? ? 'SURVEY' : 'IDEA'
-        when 'Initiative'
-          'INITIATIVE'
-        when 'Comment'
-          'COMMENT'
-        else
-          'USER'
-        end
-        user_unique_code = "#{user_source}-#{SecureRandom.uuid}"
-        self.author = User.create!(
-          unique_code: user_unique_code,
-          locale: AppConfiguration.instance.settings('core', 'locales').first
+        anon_user = User.find_by(unique_code: author_hash)
+        self.author = anon_user || User.create!(
+          unique_code: author_hash || SecureRandom.uuid,
+          locale: author.locale || AppConfiguration.instance.settings('core', 'locales').first
         )
-      elsif author_id.present?
-        self.anonymous = false
       end
     end
 

--- a/back/app/models/concerns/anonymous_participation.rb
+++ b/back/app/models/concerns/anonymous_participation.rb
@@ -35,6 +35,7 @@ module AnonymousParticipation
         anon_user = User.find_by(unique_code: author_hash)
         self.author = anon_user || User.create!(
           unique_code: author_hash || SecureRandom.uuid,
+          anonymous: true,
           locale: author.locale || AppConfiguration.instance.settings('core', 'locales').first
         )
       end

--- a/back/app/models/idea.rb
+++ b/back/app/models/idea.rb
@@ -167,6 +167,10 @@ class Idea < ApplicationRecord
     publication_status_change == %w[draft published] || publication_status_change == [nil, 'published']
   end
 
+  def native_survey?
+    creation_phase_id.present?
+  end
+
   def custom_form
     participation_context = creation_phase || project
     participation_context.custom_form || CustomForm.new(participation_context: participation_context)

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -35,6 +35,7 @@
 #  followings_count                    :integer          default(0), not null
 #  onboarding                          :jsonb            not null
 #  unique_code                         :string
+#  anonymous                           :boolean          default(FALSE), not null
 #
 # Indexes
 #
@@ -144,6 +145,8 @@ class User < ApplicationRecord
   scope :from_follows, (proc do |follows|
     where(id: joins(:follows).where(follows: follows))
   end)
+
+  scope :not_anonymous, -> { where anonymous: false }
 
   has_many :ideas, foreign_key: :author_id, dependent: :nullify
   has_many :initiatives, foreign_key: :author_id, dependent: :nullify

--- a/back/db/migrate/20240229211021_add_anonymous_to_users.rb
+++ b/back/db/migrate/20240229211021_add_anonymous_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAnonymousToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :anonymous, :boolean, null: false, default: false
+  end
+end

--- a/back/db/structure.sql
+++ b/back/db/structure.sql
@@ -1339,7 +1339,8 @@ CREATE TABLE public.users (
     new_email character varying,
     followings_count integer DEFAULT 0 NOT NULL,
     onboarding jsonb DEFAULT '{}'::jsonb NOT NULL,
-    unique_code character varying
+    unique_code character varying,
+    anonymous boolean DEFAULT false NOT NULL
 );
 
 
@@ -7432,6 +7433,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240130170644'),
 ('20240206165004'),
 ('20240214125557'),
-('20240226170510');
+('20240226170510'),
+('20240229211021');
 
 

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/import_ideas_service.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/import_ideas_service.rb
@@ -163,7 +163,7 @@ module BulkImportIdeas
           if idea_row[:user_email].present?
             author.email = idea_row[:user_email]
           else
-            author.unique_code = SecureRandom.uuid
+            author.unique_code = "IMPORT-#{SecureRandom.uuid}"
           end
 
           if author.save

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/import_ideas_service.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/import_ideas_service.rb
@@ -163,7 +163,7 @@ module BulkImportIdeas
           if idea_row[:user_email].present?
             author.email = idea_row[:user_email]
           else
-            author.unique_code = "IMPORT-#{SecureRandom.uuid}"
+            author.unique_code = SecureRandom.uuid
           end
 
           if author.save
@@ -174,6 +174,7 @@ module BulkImportIdeas
         end
       end
 
+      idea_attributes[:anonymous] = !idea_row[:user_consent]
       idea_attributes[:author] = author
       @imported_users.include? author # Was the user created in this import
     end

--- a/back/engines/commercial/user_custom_fields/app/finders/user_custom_fields/users_finder.rb
+++ b/back/engines/commercial/user_custom_fields/app/finders/user_custom_fields/users_finder.rb
@@ -10,7 +10,7 @@ module UserCustomFields
     #   users who participated in this project
     # @option params [Range] :registration_date_range date range, the finder will only
     #   return users who completed registration within this date range
-    def initialize(user_scope = User, params = {})
+    def initialize(user_scope = User.not_anonymous, params = {})
       @user_scope = user_scope
       @params = params
     end


### PR DESCRIPTION
# Background
- This brings this in line with the bulk importer that creates anonymous users where permission has not been given
- This means that the stats for participants in a phase / project are more accurate as a user is logged for every anonymous idea, comment or native survey
- Each user is created with just a unique code instead of email - the unique code is prefixed by where the user was created from - IDEA, COMMENT, SURVEY, INITIATIVE
- Ultimately this adds consistency to all data collection so that we are able in the future to collect demographic information against non-logged in users and anonymous users

## Questions
- Should we log an activity - User - anonymous_created?
- The users still won't be 100% accurate as a single user could post anonymously and create a new user several times - can't get round this as if we use browser finger printing, then the same user can be tied to multiple posts - which we do already actually so it could be OK


# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->
