### PR TITLE
Tan 1199/visibility comment icon idea card

### DIFF
--- a/front/app/components/IdeaCard/Footer/index.tsx
+++ b/front/app/components/IdeaCard/Footer/index.tsx
@@ -26,8 +26,8 @@ const Footer = ({
 
   const commentingEnabled =
     project.data.attributes.action_descriptor.commenting_idea.enabled;
-  const projectHasComments = project.data.attributes.comments_count > 0;
-  const showCommentCount = commentingEnabled || projectHasComments;
+  const ideaHasComments = idea.attributes.comments_count > 0;
+  const showCommentCount = commentingEnabled || ideaHasComments;
 
   // the participationMethod checks ensure that the footer is not shown on
   // e.g. /ideas index page because there's no participationMethod

--- a/front/app/components/IdeaCard/Footer/index.tsx
+++ b/front/app/components/IdeaCard/Footer/index.tsx
@@ -5,23 +5,19 @@ import IdeaCardFooter from './IdeaCardFooter';
 import FooterWithReactionControl from './FooterWithReactionControl';
 
 // typings
-import { IProject } from 'api/projects/types';
 import { IIdeaData } from 'api/ideas/types';
 import { ParticipationMethod } from 'api/phases/types';
+import useProjectById from 'api/projects/useProjectById';
 
 interface Props {
-  project?: IProject;
   idea: IIdeaData;
   hideIdeaStatus: boolean;
   participationMethod: ParticipationMethod | undefined;
 }
 
-const Footer = ({
-  project,
-  idea,
-  hideIdeaStatus,
-  participationMethod,
-}: Props) => {
+const Footer = ({ idea, hideIdeaStatus, participationMethod }: Props) => {
+  const { data: project } = useProjectById(idea.relationships.project.data.id);
+
   if (!project) return null;
 
   const commentingEnabled =

--- a/front/app/components/IdeaCard/Footer/index.tsx
+++ b/front/app/components/IdeaCard/Footer/index.tsx
@@ -8,7 +8,6 @@ import FooterWithReactionControl from './FooterWithReactionControl';
 import { IProject } from 'api/projects/types';
 import { IIdeaData } from 'api/ideas/types';
 import { ParticipationMethod } from 'api/phases/types';
-import useProjectById from 'api/projects/useProjectById';
 
 interface Props {
   project?: IProject;
@@ -17,9 +16,12 @@ interface Props {
   participationMethod: ParticipationMethod | undefined;
 }
 
-const Footer = ({ idea, hideIdeaStatus, participationMethod }: Props) => {
-  const { data: project } = useProjectById(idea.relationships.project.data.id);
-
+const Footer = ({
+  project,
+  idea,
+  hideIdeaStatus,
+  participationMethod,
+}: Props) => {
   if (!project) return null;
 
   const commentingEnabled =

--- a/front/app/components/IdeaCard/Footer/index.tsx
+++ b/front/app/components/IdeaCard/Footer/index.tsx
@@ -8,6 +8,7 @@ import FooterWithReactionControl from './FooterWithReactionControl';
 import { IProject } from 'api/projects/types';
 import { IIdeaData } from 'api/ideas/types';
 import { ParticipationMethod } from 'api/phases/types';
+import useProjectById from 'api/projects/useProjectById';
 
 interface Props {
   project?: IProject;
@@ -16,12 +17,9 @@ interface Props {
   participationMethod: ParticipationMethod | undefined;
 }
 
-const Footer = ({
-  project,
-  idea,
-  hideIdeaStatus,
-  participationMethod,
-}: Props) => {
+const Footer = ({ idea, hideIdeaStatus, participationMethod }: Props) => {
+  const { data: project } = useProjectById(idea.relationships.project.data.id);
+
   if (!project) return null;
 
   const commentingEnabled =

--- a/front/app/components/IdeaCard/index.tsx
+++ b/front/app/components/IdeaCard/index.tsx
@@ -30,6 +30,7 @@ import styled from 'styled-components';
 
 // hooks
 import useIdeaById from 'api/ideas/useIdeaById';
+import useProjectById from 'api/projects/useProjectById';
 import useLocalize from 'hooks/useLocalize';
 import usePhase from 'api/phases/usePhase';
 import useIdeaImage from 'api/idea_images/useIdeaImage';
@@ -101,7 +102,9 @@ const IdeaCard = ({
   const smallerThanTablet = useBreakpoint('tablet');
 
   const localize = useLocalize();
-
+  const { data: project } = useProjectById(
+    idea.data.relationships.project.data.id
+  );
   const { data: phase } = usePhase(phaseId);
 
   const phaseData = phase?.data;
@@ -184,6 +187,7 @@ const IdeaCard = ({
         <Box>
           <Interactions idea={idea} phase={phaseData || null} />
           <Footer
+            project={project}
             idea={idea.data}
             hideIdeaStatus={hideIdeaStatus}
             participationMethod={participationMethod}

--- a/front/app/components/IdeaCard/index.tsx
+++ b/front/app/components/IdeaCard/index.tsx
@@ -30,7 +30,6 @@ import styled from 'styled-components';
 
 // hooks
 import useIdeaById from 'api/ideas/useIdeaById';
-import useProjectById from 'api/projects/useProjectById';
 import useLocalize from 'hooks/useLocalize';
 import usePhase from 'api/phases/usePhase';
 import useIdeaImage from 'api/idea_images/useIdeaImage';
@@ -102,9 +101,7 @@ const IdeaCard = ({
   const smallerThanTablet = useBreakpoint('tablet');
 
   const localize = useLocalize();
-  const { data: project } = useProjectById(
-    idea.data.relationships.project.data.id
-  );
+
   const { data: phase } = usePhase(phaseId);
 
   const phaseData = phase?.data;
@@ -187,7 +184,6 @@ const IdeaCard = ({
         <Box>
           <Interactions idea={idea} phase={phaseData || null} />
           <Footer
-            project={project}
             idea={idea.data}
             hideIdeaStatus={hideIdeaStatus}
             participationMethod={participationMethod}

--- a/front/app/components/IdeasMap/IdeaMapCard.tsx
+++ b/front/app/components/IdeasMap/IdeaMapCard.tsx
@@ -188,8 +188,8 @@ const IdeaMapCard = memo<Props>(
 
       const commentingEnabled =
         project.data.attributes.action_descriptor.commenting_idea.enabled;
-      const projectHasComments = project.data.attributes.comments_count > 0;
-      const showCommentCount = commentingEnabled || projectHasComments;
+      const ideaHasComments = idea.attributes.comments_count > 0;
+      const showCommentCount = commentingEnabled || ideaHasComments;
       const phaseButNotCurrentPhase =
         phaseData &&
         pastPresentOrFuture([

--- a/front/app/containers/ProjectsShowPage/timeline/VotingResults/VotingResultCard.tsx
+++ b/front/app/containers/ProjectsShowPage/timeline/VotingResults/VotingResultCard.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 // api
 import usePhase from 'api/phases/usePhase';
-import useProjectById from 'api/projects/useProjectById';
 import useIdeaImage from 'api/idea_images/useIdeaImage';
 
 // i18n
@@ -158,14 +157,13 @@ const VotingResultCard = ({ idea, phaseId, rank }: Props) => {
   const localize = useLocalize();
   const { formatMessage } = useIntl();
   const { data: phase } = usePhase(phaseId);
-  const { data: project } = useProjectById(idea.relationships.project.data.id);
   const { data: ideaImage } = useIdeaImage(
     idea.id,
     idea.relationships.idea_images.data?.[0]?.id
   );
   const smallerThanPhone = useBreakpoint('phone');
 
-  if (!phase || !project) return null;
+  if (!phase) return null;
 
   const budget = idea.attributes.budget;
   const ideaTitle = localize(idea.attributes.title_multiloc);
@@ -244,7 +242,6 @@ const VotingResultCard = ({ idea, phaseId, rank }: Props) => {
           </Box>
         </Body>
         <Footer
-          project={project}
           idea={idea}
           hideIdeaStatus={true}
           participationMethod="voting"


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Changed
- When commenting is disabled, the comment icon on an input card is only shown if the input has comments. Before, it was shown if the project as a whole had any comment, leading to the icon being shown even if comments for a phase were off and the input had no comments. ([Before](https://github.com/CitizenLabDotCo/citizenlab/assets/16427929/7ac884b4-47e2-4650-b0a2-a43e1a1f9e31)/[after](https://github.com/CitizenLabDotCo/citizenlab/assets/16427929/ec4bfbd7-8fc0-4755-aaf8-314e889197f0))
