### PR TITLE
[TAN-1217] Fix flaky test of abbreviated name in moderator_digest_spec

### DIFF
--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/moderator_digest_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/moderator_digest_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'EmailCampaigns::Campaigns::ModeratorDigest', skip: skip_reason d
 
       command = campaign.generate_commands(recipient: moderator).first
       payload_first_top_idea = command.dig(:event_payload, :top_ideas, 0)
-      first_top_idea = Idea.find(payload_first_top_idea.fetch(:id))
+      first_top_idea = Idea.find_by(id: payload_first_top_idea.fetch(:id))
       expected_author_name = "#{first_top_idea.author.first_name} #{first_top_idea.author.last_name[0]}."
 
       expect(payload_first_top_idea[:author_name]).to eq(expected_author_name)

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/moderator_digest_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/moderator_digest_spec.rb
@@ -48,12 +48,13 @@ RSpec.describe 'EmailCampaigns::Campaigns::ModeratorDigest', skip: skip_reason d
       SettingsService.new.activate_feature! 'abbreviated_user_names'
 
       expect(moderator.admin?).to be false
-      command = campaign.generate_commands(recipient: moderator).first
 
-      expected_author_name = "#{top_new_idea.author.first_name} #{top_new_idea.author.last_name[0]}."
-      expect(
-        command.dig(:event_payload, :top_ideas, 0, :author_name)
-      ).to eq(expected_author_name)
+      command = campaign.generate_commands(recipient: moderator).first
+      payload_first_top_idea = command.dig(:event_payload, :top_ideas, 0)
+      first_top_idea = Idea.find(payload_first_top_idea.fetch(:id))
+      expected_author_name = "#{first_top_idea.author.first_name} #{first_top_idea.author.last_name[0]}."
+
+      expect(payload_first_top_idea[:author_name]).to eq(expected_author_name)
     end
 
     # added to reproduce the bug and test the fix


### PR DESCRIPTION
Fix by not assuming knowledge of which idea will be first in payload.

Details of reasoning in ticket [TAN-1217](https://www.notion.so/citizenlab/Fix-flaky-test-in-moderator_digest_spec-9f9d138b4b634081aab55137988c1a1d?pvs=4) description

# Changelog
## Technical
[TAN-1217] Fix flaky test of abbreviated name in moderator_digest_spec