### PR TITLE
Enable voting emails that were not enabled

### DIFF
--- a/back/engines/free/email_campaigns/app/services/email_campaigns/delivery_service.rb
+++ b/back/engines/free/email_campaigns/app/services/email_campaigns/delivery_service.rb
@@ -48,10 +48,10 @@ module EmailCampaigns
       Campaigns::StatusChangeOnInitiativeYouFollow,
       Campaigns::ThresholdReachedForAdmin,
       Campaigns::UserDigest,
-      Campaigns::VotingPhaseStarted,
-      Campaigns::VotingBasketSubmitted,
       Campaigns::VotingBasketNotSubmitted,
+      Campaigns::VotingBasketSubmitted,
       Campaigns::VotingLastChance,
+      Campaigns::VotingPhaseStarted,
       Campaigns::VotingResults,
       Campaigns::Welcome,
       Campaigns::YourProposedInitiativesDigest

--- a/back/engines/free/email_campaigns/app/services/email_campaigns/delivery_service.rb
+++ b/back/engines/free/email_campaigns/app/services/email_campaigns/delivery_service.rb
@@ -49,6 +49,9 @@ module EmailCampaigns
       Campaigns::ThresholdReachedForAdmin,
       Campaigns::UserDigest,
       Campaigns::VotingPhaseStarted,
+      Campaigns::VotingBasketSubmitted,
+      Campaigns::VotingBasketNotSubmitted,
+      Campaigns::VotingLastChance,
       Campaigns::VotingResults,
       Campaigns::Welcome,
       Campaigns::YourProposedInitiativesDigest


### PR DESCRIPTION
# Changelog
## Fixed
- Voting emails enabled where they were not currently
