### PR TITLE
TAN-1249  - Survey submission to phase fixes

### DIFF
--- a/back/app/controllers/web_api/v1/ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/ideas_controller.rb
@@ -119,19 +119,15 @@ class WebApi::V1::IdeasController < ApplicationController
     render_show Idea.find_by!(creation_phase_id: params[:phase_id], author: current_user, publication_status: 'draft')
   end
 
-  #   Normal users always post in an active phase. They should never provide a phase id.
+  #   Normal users always post in an active phase. Provided phase id should be ignored.
   #   Users who can moderate projects post in an active phase if no phase id is given.
   #   Users who can moderate projects post in the given phase if a phase id is given.
   def create
     project = Project.find(params.dig(:idea, :project_id))
-    phase_ids = params.dig(:idea, :phase_ids) || []
     is_moderator = current_user && UserRoleService.new.can_moderate_project?(project, current_user)
+    phase_ids = is_moderator ? params.dig(:idea, :phase_ids) || [] : []
 
-    if phase_ids.any?
-      send_error and return unless is_moderator
-
-      send_error and return if phase_ids.size != 1
-    end
+    send_error and return if phase_ids.any? && phase_ids.size != 1
 
     phase = if is_moderator && phase_ids.any?
       Phase.find(phase_ids.first)

--- a/front/app/containers/IdeasNewPage/IdeasNewSurveyForm/index.tsx
+++ b/front/app/containers/IdeasNewPage/IdeasNewSurveyForm/index.tsx
@@ -23,7 +23,6 @@ import { AjvErrorGetter, ApiErrorGetter } from 'components/Form/typings';
 import FullPageSpinner from 'components/UI/FullPageSpinner';
 import PageContainer from 'components/UI/PageContainer';
 import Warning from 'components/UI/Warning';
-import SurveyNotActiveNotice from '../components/SurveyNotActiveNotice';
 
 import { useIntl } from 'utils/cl-intl';
 import { getMethodConfig } from 'utils/configs/participationMethodConfig';
@@ -82,7 +81,6 @@ const IdeasNewSurveyForm = ({ project }: Props) => {
   const [ideaId, setIdeaId] = useState<string | undefined>();
 
   const [initialFormData, setInitialFormData] = useState({});
-  const currentPhase = getCurrentPhase(phases?.data);
   const participationMethodConfig = getConfig(phaseFromUrl?.data, phases);
   const allowAnonymousPosting =
     phaseFromUrl?.data.attributes.allow_anonymous_participation;
@@ -90,8 +88,6 @@ const IdeasNewSurveyForm = ({ project }: Props) => {
   const userIsModerator =
     !isNilOrError(authUser) &&
     canModerateProject(project.data.id, { data: authUser.data });
-
-  const canUserViewForm = userIsModerator || phaseId === currentPhase?.id;
 
   const getApiErrorMessage: ApiErrorGetter = useCallback(
     (error) => {
@@ -213,8 +209,6 @@ const IdeasNewSurveyForm = ({ project }: Props) => {
       });
     }
   };
-
-  if (!canUserViewForm) return <SurveyNotActiveNotice project={project.data} />;
 
   return (
     <PageContainer id="e2e-idea-new-page" overflow="hidden">

--- a/front/app/containers/IdeasNewPage/IdeasNewSurveyForm/index.tsx
+++ b/front/app/containers/IdeasNewPage/IdeasNewSurveyForm/index.tsx
@@ -159,7 +159,7 @@ const IdeasNewSurveyForm = ({ project }: Props) => {
     const requestBody = {
       ...data,
       project_id: project.data.id,
-      phase_ids: userIsModerator ? [phaseId] : [],
+      ...(userIsModerator ? { phase_ids: [phaseId] } : {}), // Moderators can submit survey responses for inactive phases, in which case the backend cannot infer the correct phase (the current phase).
       publication_status: data.publication_status || 'published',
     };
 

--- a/front/app/containers/IdeasNewPage/IdeasNewSurveyForm/index.tsx
+++ b/front/app/containers/IdeasNewPage/IdeasNewSurveyForm/index.tsx
@@ -87,11 +87,11 @@ const IdeasNewSurveyForm = ({ project }: Props) => {
   const allowAnonymousPosting =
     phaseFromUrl?.data.attributes.allow_anonymous_participation;
 
-  const canUserEditProject =
+  const userIsModerator =
     !isNilOrError(authUser) &&
     canModerateProject(project.data.id, { data: authUser.data });
 
-  const canUserViewForm = canUserEditProject || phaseId === currentPhase?.id;
+  const canUserViewForm = userIsModerator || phaseId === currentPhase?.id;
 
   const getApiErrorMessage: ApiErrorGetter = useCallback(
     (error) => {
@@ -163,7 +163,7 @@ const IdeasNewSurveyForm = ({ project }: Props) => {
     const requestBody = {
       ...data,
       project_id: project.data.id,
-      phase_ids: [phaseId], // Note: Backend only uses if moderator
+      phase_ids: userIsModerator ? [phaseId] : [],
       publication_status: data.publication_status || 'published',
     };
 
@@ -245,7 +245,7 @@ const IdeasNewSurveyForm = ({ project }: Props) => {
                     )
                   }
                   isSurvey={true}
-                  canUserEditProject={canUserEditProject}
+                  canUserEditProject={userIsModerator}
                   loggedIn={!isNilOrError(authUser)}
                 />
                 {allowAnonymousPosting && (

--- a/front/app/containers/IdeasNewPage/components/SurveyNotActiveNotice.tsx
+++ b/front/app/containers/IdeasNewPage/components/SurveyNotActiveNotice.tsx
@@ -8,17 +8,20 @@ import {
   Title,
   useBreakpoint,
 } from '@citizenlab/cl2-component-library';
+
+import { IProjectData } from 'api/projects/types';
+
 import PageContainer from 'components/UI/PageContainer';
 
 // intl
 import { useIntl } from 'utils/cl-intl';
+import clHistory from 'utils/cl-router/history';
+
 import messages from './messages';
 
 // util
-import clHistory from 'utils/cl-router/history';
 
 // types
-import { IProjectData } from 'api/projects/types';
 
 type Props = {
   project: IProjectData;

--- a/front/app/containers/IdeasNewPage/components/SurveyNotActiveNotice.tsx
+++ b/front/app/containers/IdeasNewPage/components/SurveyNotActiveNotice.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+// components
+import {
+  Box,
+  Button,
+  Text,
+  Title,
+  useBreakpoint,
+} from '@citizenlab/cl2-component-library';
+import PageContainer from 'components/UI/PageContainer';
+
+// intl
+import { useIntl } from 'utils/cl-intl';
+import messages from './messages';
+
+// util
+import clHistory from 'utils/cl-router/history';
+
+// types
+import { IProjectData } from 'api/projects/types';
+
+type Props = {
+  project: IProjectData;
+};
+
+const SurveyNotActiveNotice = ({ project }: Props) => {
+  const { formatMessage } = useIntl();
+  const isMobileOrSmaller = useBreakpoint('phone');
+
+  return (
+    <PageContainer>
+      <Box mx="auto">
+        <Title mt={isMobileOrSmaller ? '80px' : '160px'} textAlign="center">
+          {formatMessage(messages.surveyNotActiveTitle)}
+        </Title>
+        <Text mb="30px" textAlign="center">
+          {formatMessage(messages.surveyNotActiveDescription)}
+        </Text>
+        <Box display="flex" justifyContent="center">
+          <Button
+            icon="arrow-left"
+            pl="12px"
+            onClick={() => {
+              clHistory.push(`/projects/${project.attributes.slug}`);
+            }}
+          >
+            {formatMessage(messages.returnToProject)}
+          </Button>
+        </Box>
+      </Box>
+    </PageContainer>
+  );
+};
+
+export default SurveyNotActiveNotice;

--- a/front/app/containers/IdeasNewPage/components/messages.ts
+++ b/front/app/containers/IdeasNewPage/components/messages.ts
@@ -17,4 +17,13 @@ export default defineMessages({
     id: 'app.containers.IdeasNewPage.SurveySubmittedNotice.returnToProject',
     defaultMessage: 'Return to project',
   },
+  surveyNotActiveTitle: {
+    id: 'app.containers.IdeasNewPage.SurveyNotActiveNotice.surveyNotActiveTitle',
+    defaultMessage: 'This survey is not currently active.',
+  },
+  surveyNotActiveDescription: {
+    id: 'app.containers.IdeasNewPage.SurveyNotActiveNotice.surveyNotActiveDescription',
+    defaultMessage:
+      'This survey is not currently open for responses. Please return to the project for more information.',
+  },
 });

--- a/front/app/containers/IdeasNewPage/index.tsx
+++ b/front/app/containers/IdeasNewPage/index.tsx
@@ -20,12 +20,12 @@ import { getIdeaPostingRules } from 'utils/actionTakingRules';
 import { getParticipationMethod } from 'utils/configs/participationMethodConfig';
 import { isUnauthorizedRQ } from 'utils/errorUtils';
 import { isNilOrError } from 'utils/helperUtils';
+import { canModerateProject } from 'utils/permissions/rules/projectPermissions';
 
-import SurveySubmittedNotice from './components/SurveySubmittedNotice';
 import SurveyNotActiveNotice from './components/SurveyNotActiveNotice';
+import SurveySubmittedNotice from './components/SurveySubmittedNotice';
 import IdeasNewIdeationForm from './IdeasNewIdeationForm';
 import IdeasNewSurveyForm from './IdeasNewSurveyForm';
-import { canModerateProject } from 'utils/permissions/rules/projectPermissions';
 
 const NewIdeaPage = () => {
   const { slug } = useParams();

--- a/front/app/translations/en.json
+++ b/front/app/translations/en.json
@@ -964,6 +964,8 @@
   "app.containers.IdeasNewPage.IdeasNewForm.inputsAssociatedWithProfile1": "By default your submissions will be associated with your profile, unless you select this option.",
   "app.containers.IdeasNewPage.IdeasNewForm.postAnonymously": "Post anonymously",
   "app.containers.IdeasNewPage.IdeasNewForm.profileVisibility": "Profile visibility",
+  "app.containers.IdeasNewPage.SurveyNotActiveNotice.surveyNotActiveDescription": "This survey is not currently open for responses. Please return to the project for more information.",
+  "app.containers.IdeasNewPage.SurveyNotActiveNotice.surveyNotActiveTitle": "This survey is not currently active.",
   "app.containers.IdeasNewPage.SurveySubmittedNotice.returnToProject": "Return to project",
   "app.containers.IdeasNewPage.SurveySubmittedNotice.surveySubmittedDescription": "You have already completed this survey.",
   "app.containers.IdeasNewPage.SurveySubmittedNotice.surveySubmittedTitle": "Survey submitted",


### PR DESCRIPTION
# Changelog
## Fixed
- Residents now cannot see a survey form via a direct link if the survey phase is not active - instead they will see a notice saying the survey is not active
- Fix to allow moderators to post surveys to phases that are not active
