### PR TITLE
TAN-1246 Deal with analyses with no fields

### DIFF
--- a/back/engines/commercial/analysis/app/services/analysis/patches/side_fx_custom_field_service.rb
+++ b/back/engines/commercial/analysis/app/services/analysis/patches/side_fx_custom_field_service.rb
@@ -6,6 +6,9 @@ module Analysis
       def before_destroy(custom_field, _user)
         super
         Analysis.where(main_custom_field_id: custom_field.id).each(&:destroy!)
+        Analysis.includes(:analyses_additional_custom_fields).where(analyses_additional_custom_fields: { custom_field_id: custom_field.id }).each do |analysis|
+          analysis.destroy! if analysis.associated_custom_fields.map(&:id) == [custom_field.id]
+        end
         Insight.delete_custom_field_references!(custom_field.id)
         AutoTaggingTask.delete_custom_field_references!(custom_field.id)
       end

--- a/back/lib/tasks/single_use/20240213_migrate_analysis_main_custom_field.rake
+++ b/back/lib/tasks/single_use/20240213_migrate_analysis_main_custom_field.rake
@@ -47,6 +47,7 @@ namespace :migrate_analysis do
             errors[tenant.host][analysis.id] = 'Could not remove main field from additional fields'
             next
           end
+          analysis.reload
 
           if !analysis.update(main_custom_field: main_field)
             errors[tenant.host] ||= {}

--- a/back/lib/tasks/single_use/20240213_migrate_analysis_main_custom_field.rake
+++ b/back/lib/tasks/single_use/20240213_migrate_analysis_main_custom_field.rake
@@ -19,9 +19,11 @@ namespace :migrate_analysis do
           next if analysis.main_custom_field.present? # Make idempotent
           next if analysis.participation_method == 'ideation'
 
-          if analysis.analyses_additional_custom_fields.count < 1 || analysis.additional_custom_fields.count < 1
-            errors[tenant.host] ||= {}
-            errors[tenant.host][analysis.id] = 'No associated custom fields'
+          if analysis.associated_custom_fields.count < 1
+            if !analysis.destroy
+              errors[tenant.host] ||= {}
+              errors[tenant.host][analysis.id] = analysis.errors.full_messages
+            end
             next
           end
 


### PR DESCRIPTION
- Delete analyses with no fields during migration, as those would be invalid
- Delete analyses when their last associated field gets deleted
