### PR TITLE
[TAN-1254] Include mapConfigId: in survey_results response

### DIFF
--- a/back/app/services/survey_results_generator_service.rb
+++ b/back/app/services/survey_results_generator_service.rb
@@ -131,6 +131,7 @@ class SurveyResultsGeneratorService < FieldVisitorService
       required: field.required,
       totalResponses: answer_count,
       customFieldId: field.id,
+      mapConfigId: field&.map_config&.id,
       pointResponses: answers
     }
   end

--- a/back/spec/services/survey_results_generator_service_spec.rb
+++ b/back/spec/services/survey_results_generator_service_spec.rb
@@ -222,11 +222,13 @@ RSpec.describe SurveyResultsGeneratorService do
       :custom_field_point,
       resource: form,
       title_multiloc: {
-        'en' => 'Where should the transmogrification unit be located?'
+        'en' => 'Where should the new nursery be located?'
       },
       description_multiloc: {}
     )
   end
+
+  let!(:map_config) { create(:map_config, mappable: point_field) }
 
   let(:expected_result) do
     {
@@ -368,10 +370,11 @@ RSpec.describe SurveyResultsGeneratorService do
         },
         {
           inputType: 'point',
-          question: { 'en' => 'Where should the transmogrification unit be located?' },
+          question: { 'en' => 'Where should the new nursery be located?' },
           required: false,
           totalResponses: 2,
           customFieldId: point_field.id,
+          mapConfigId: map_config.id,
           pointResponses: a_collection_containing_exactly(
             { answer: { 'coordinates' => [42.42, 24.24], 'type' => 'Point' } },
             { answer: { 'coordinates' => [11.22, 33.44], 'type' => 'Point' } }


### PR DESCRIPTION
FE needs a `mapConfigId` value for a `custom_field` of `input-type: point` in the response to the `PhasesController#survey_response`  action, as otherwise it is not easy to correlate such a  `custom_field` with its `map_config`.

Returns `mapConfigId: nil` when `custom_field` is not related to a `map_config`.

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->
