### PR TITLE
[TAN-1062] Remove redundant roles from the JWT token

### DIFF
--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -331,9 +331,23 @@ class User < ApplicationRecord
     token_lifetime = AppConfiguration.instance.settings('core', 'authentication_token_lifetime_in_days').days
     {
       sub: id,
-      roles: roles,
+      roles: compacted_roles,
       exp: token_lifetime.from_now.to_i
     }
+  end
+
+  # Returns roles excluding the `project_moderator` roles that are redundant with
+  # `project_folder_moderator` roles (i.e. the user is a project moderator for a
+  # project that is in a folder that they moderate).
+  def compacted_roles
+    redundant_project_ids = AdminPublication
+      .joins(:parent)
+      .where(parent: { publication_id: moderated_project_folder_ids })
+      .pluck(:publication_id)
+
+    roles.reject do |role|
+      role['type'] == 'project_moderator' && role['project_id'].in?(redundant_project_ids)
+    end
   end
 
   def avatar_blank?

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -1257,6 +1257,83 @@ RSpec.describe User do
     end
   end
 
+  describe '#compacted_roles' do
+    let_it_be(:user) { create(:user) }
+
+    let_it_be(:projects_in_folder) { create_list(:project, 2) }
+    let_it_be(:folder) { create(:project_folder, projects: projects_in_folder) }
+
+    # Top-level project (not in a folder)
+    let_it_be(:another_project) { create(:project) }
+
+    let_it_be(:project_in_another_folder) { create(:project) }
+    let_it_be(:another_folder) { create(:project_folder, projects: [project_in_another_folder]) }
+
+    def create_roles(projects, folders, admin: false)
+      projects = Array.wrap(projects)
+      folders = Array.wrap(folders)
+
+      [].tap do |roles|
+        roles << { 'type' => 'admin' } if admin
+        projects.each { |project| roles << { 'type' => 'project_moderator', 'project_id' => project.id } }
+        folders.each { |folder| roles << { 'type' => 'project_folder_moderator', 'project_folder_id' => folder.id } }
+      end
+    end
+
+    context 'when the roles are not redundant' do
+      where(:admin?, :projects, :folders) do
+        [
+          [true, nil, nil],
+          [true, ref(:another_project), nil],
+          [true, nil, ref(:folder)],
+          [false, ref(:another_project), ref(:folder)],
+          [false, ref(:projects_in_folder), nil],
+          [false, nil, [ref(:folder), ref(:another_folder)]],
+          [false, ref(:project_in_another_folder), ref(:folder)]
+        ]
+      end
+
+      with_them do
+        it 'does not modify the roles' do
+          user.roles = create_roles(projects, folders, admin: admin?)
+          expect(user.compacted_roles).to match(user.roles)
+        end
+      end
+    end
+
+    context 'when the roles are redundant' do
+      it 'removes redundant roles (1)' do
+        user.roles = create_roles(projects_in_folder, folder)
+        expected_roles = create_roles(nil, folder)
+        expect(user.compacted_roles).to match(expected_roles)
+      end
+
+      it 'removes redundant roles (2)' do
+        projects = projects_in_folder + [another_project]
+        user.roles = create_roles(projects, folder)
+        # only keep projects that are not in the folder
+        expected_roles = create_roles(another_project, folder)
+        expect(user.compacted_roles).to match(expected_roles)
+      end
+
+      it 'removes redundant roles (3)' do
+        folders = [folder, another_folder]
+        user.roles = create_roles(projects_in_folder, folders)
+        # only keep folder roles
+        expected_roles = create_roles(nil, folders)
+        expect(user.compacted_roles).to match(expected_roles)
+      end
+
+      it 'removes redundant roles (4)' do
+        projects = projects_in_folder + [project_in_another_folder, another_project]
+        folders = [folder, another_folder]
+        user.roles = create_roles(projects, folders)
+        expected_roles = create_roles(another_project, folders)
+        expect(user.compacted_roles).to match(expected_roles)
+      end
+    end
+  end
+
   context 'billed users' do
     def create_admin_moderator(factory)
       create(factory).tap do |user|


### PR DESCRIPTION
# Changelog
## Technical
- [TAN-1062] Remove redundant roles from the JWT token. When a user is granted folder-moderator rights, individual project-moderator roles are automatically added to the `roles` attribute for all projects within the folder. This can result in a large array of roles that can cause the JWT token to exceed the maximum size of a cookie. To mitigate this issue, this commit removes the redundant roles from the JWT token. Although there is still a possibility that the token will exceed the maximum size, this is less likely to happen.
