### PR TITLE
Merging survey result generators: small improvements and tests

### DIFF
--- a/back/app/services/survey_results_generator_service.rb
+++ b/back/app/services/survey_results_generator_service.rb
@@ -159,8 +159,9 @@ class SurveyResultsGeneratorService < FieldVisitorService
   end
 
   def build_select_response(answers, field, group_field)
-    # TODO: This is an additional query for selects so performance issue here
-    question_response_count = inputs.where("custom_field_values->'#{field.key}' IS NOT NULL").count
+    nil_answer_count = answers.detect { |answer| answer[:answer].nil? }[:count]
+    question_response_count = @inputs.count - nil_answer_count
+
     attributes = core_field_attributes(field, question_response_count).merge({
       grouped: !!group_field,
       totalPickCount: answers.pluck(:count).sum,

--- a/back/app/services/survey_results_generator_service.rb
+++ b/back/app/services/survey_results_generator_service.rb
@@ -120,7 +120,7 @@ class SurveyResultsGeneratorService < FieldVisitorService
         # Single form field grouped result
         group_field = find_question(group_field_id)
       end
-      raise "Unsupported group field type: #{group_field.input_type}" unless group_field.input_type == 'select'
+      raise "Unsupported group field type: #{group_field.input_type}" unless %w[select linear_scale].include?(group_field.input_type)
 
       query = query.select(
         select_field_query(field, as: 'answer'),

--- a/back/app/services/survey_results_generator_service.rb
+++ b/back/app/services/survey_results_generator_service.rb
@@ -245,9 +245,9 @@ class SurveyResultsGeneratorService < FieldVisitorService
       answers_row = {
         answer: answer,
         count: grouped_answer[:count],
-        groups: group_field_keys.map do |group|
-          grouped_answer[:groups][group] || { group: group, count: 0 }
-        end
+        groups: group_field_keys
+          .filter { |group| grouped_answer[:groups][group] }
+          .map { |group| grouped_answer[:groups][group] }
       }
 
       answers_row

--- a/back/app/services/survey_results_generator_service.rb
+++ b/back/app/services/survey_results_generator_service.rb
@@ -159,8 +159,8 @@ class SurveyResultsGeneratorService < FieldVisitorService
   end
 
   def build_select_response(answers, field, group_field)
-    nil_answer_count = answers.detect { |answer| answer[:answer].nil? }[:count]
-    question_response_count = @inputs.count - nil_answer_count
+    # TODO: This is an additional query for selects so performance issue here
+    question_response_count = inputs.where("custom_field_values->'#{field.key}' IS NOT NULL").count
 
     attributes = core_field_attributes(field, question_response_count).merge({
       grouped: !!group_field,

--- a/back/spec/services/survey_results_generator_service_spec.rb
+++ b/back/spec/services/survey_results_generator_service_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe SurveyResultsGeneratorService do
         multiselect_field.key => %w[cat dog],
         select_field.key => 'other',
         "#{select_field.key}_other" => 'Austin',
-        multiselect_image_field.key => ['house'],
+        multiselect_image_field.key => ['house']
       },
       author: female_user
     )
@@ -460,7 +460,7 @@ RSpec.describe SurveyResultsGeneratorService do
                 groups: [
                   { count: 1, group: 'la' },
                   { count: 1, group: 'ny' },
-                  { count: 2, group: 'other' },
+                  { count: 2, group: 'other' }
                 ]
               }, {
                 answer: 'dog',
@@ -474,13 +474,13 @@ RSpec.describe SurveyResultsGeneratorService do
                 count: 2,
                 groups: [
                   { count: 1, group: 'la' },
-                  { count: 1, group: 'other' },
+                  { count: 1, group: 'other' }
                 ]
               }, {
                 answer: 'pig',
                 count: 1,
                 groups: [
-                  { count: 1, group: 'la' },
+                  { count: 1, group: 'la' }
                 ]
               }, {
                 answer: 'no_response',
@@ -692,7 +692,7 @@ RSpec.describe SurveyResultsGeneratorService do
                 count: 2,
                 groups: [
                   { count: 1, group: 'male' },
-                  { count: 1, group: 'female' },
+                  { count: 1, group: 'female' }
                 ]
               }, {
                 answer: 'ny',
@@ -760,7 +760,7 @@ RSpec.describe SurveyResultsGeneratorService do
                 { count: 1, group: nil }
               ]
             },
-            { 
+            {
               answer: 'ny',
               count: 1,
               groups: [

--- a/back/spec/services/survey_results_generator_service_spec.rb
+++ b/back/spec/services/survey_results_generator_service_spec.rb
@@ -171,7 +171,8 @@ RSpec.describe SurveyResultsGeneratorService do
         text_field.key => 'Red',
         multiselect_field.key => %w[cat dog],
         select_field.key => 'ny',
-        file_upload_field.key => { 'id' => idea_file.id, 'name' => idea_file.name }
+        file_upload_field.key => { 'id' => idea_file.id, 'name' => idea_file.name },
+        linear_scale_field.key => 3
       },
       idea_files: [idea_file],
       author: female_user
@@ -183,7 +184,8 @@ RSpec.describe SurveyResultsGeneratorService do
       custom_field_values: {
         text_field.key => 'Blue',
         multiselect_field.key => %w[cow pig cat],
-        select_field.key => 'la'
+        select_field.key => 'la',
+        linear_scale_field.key => 4
       },
       author: male_user
     )
@@ -553,15 +555,15 @@ RSpec.describe SurveyResultsGeneratorService do
           required: true,
           grouped: false,
           totalResponseCount: 22,
-          questionResponseCount: 15,
+          questionResponseCount: 17,
           totalPickCount: 22,
           answers: [
             { answer: 5, count: 1 },
-            { answer: 4, count: 0 },
-            { answer: 3, count: 7 },
+            { answer: 4, count: 1 },
+            { answer: 3, count: 8 },
             { answer: 2, count: 5 },
             { answer: 1, count: 2 },
-            { answer: nil, count: 7 }
+            { answer: nil, count: 5 }
           ],
           multilocs: {
             answers: {
@@ -620,15 +622,15 @@ RSpec.describe SurveyResultsGeneratorService do
               { count: 0, group: 'other' },
               { count: 1, group: nil }
             ] },
-            { answer: 4, count: 0, groups: [
-              { count: 0, group: 'la' },
+            { answer: 4, count: 1, groups: [
+              { count: 1, group: 'la' },
               { count: 0, group: 'ny' },
               { count: 0, group: 'other' },
               { count: 0, group: nil }
             ] },
-            { answer: 3, count: 7, groups: [
+            { answer: 3, count: 8, groups: [
               { count: 0, group: 'la' },
-              { count: 0, group: 'ny' },
+              { count: 1, group: 'ny' },
               { count: 0, group: 'other' },
               { count: 7, group: nil }
             ] },
@@ -644,9 +646,9 @@ RSpec.describe SurveyResultsGeneratorService do
               { count: 0, group: 'other' },
               { count: 2, group: nil }
             ] },
-            { answer: nil, count: 7, groups: [
-              { count: 2, group: 'la' },
-              { count: 1, group: 'ny' },
+            { answer: nil, count: 5, groups: [
+              { count: 1, group: 'la' },
+              { count: 0, group: 'ny' },
               { count: 3, group: 'other' },
               { count: 1, group: nil }
             ] }
@@ -809,11 +811,11 @@ RSpec.describe SurveyResultsGeneratorService do
               count: 2,
               groups: [
                 { count: 0, group: 5 },
-                { count: 0, group: 4 },
+                { count: 1, group: 4 },
                 { count: 0, group: 3 },
                 { count: 0, group: 2 },
                 { count: 0, group: 1 },
-                { count: 2, group: nil }
+                { count: 1, group: nil }
               ]
             },
             { 
@@ -822,10 +824,10 @@ RSpec.describe SurveyResultsGeneratorService do
               groups: [
                 { count: 0, group: 5 },
                 { count: 0, group: 4 },
-                { count: 0, group: 3 },
+                { count: 1, group: 3 },
                 { count: 0, group: 2 },
                 { count: 0, group: 1 },
-                { count: 1, group: nil }
+                { count: 0, group: nil }
               ]
             },
             {

--- a/back/spec/services/survey_results_generator_service_spec.rb
+++ b/back/spec/services/survey_results_generator_service_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe SurveyResultsGeneratorService do
         multiselect_field.key => %w[cat dog],
         select_field.key => 'other',
         "#{select_field.key}_other" => 'Austin',
-        multiselect_image_field.key => ['house']
+        multiselect_image_field.key => ['house'],
       },
       author: female_user
     )
@@ -221,6 +221,7 @@ RSpec.describe SurveyResultsGeneratorService do
       phases: phases_of_inputs,
       custom_field_values: {
         select_field.key => 'la',
+        multiselect_field.key => ['gibberish'], # This should be ignored in the results
         multiselect_image_field.key => ['school']
       },
       author: female_user

--- a/back/spec/services/survey_results_generator_service_spec.rb
+++ b/back/spec/services/survey_results_generator_service_spec.rb
@@ -398,7 +398,6 @@ RSpec.describe SurveyResultsGeneratorService do
                 groups: [
                   { count: 1, group: 'male' },
                   { count: 2, group: 'female' },
-                  { count: 0, group: 'unspecified' },
                   { count: 15, group: nil }
                 ]
               }, {
@@ -406,46 +405,31 @@ RSpec.describe SurveyResultsGeneratorService do
                 count: 4,
                 groups: [
                   { count: 2, group: 'male' },
-                  { count: 2, group: 'female' },
-                  { count: 0, group: 'unspecified' },
-                  { count: 0, group: nil }
+                  { count: 2, group: 'female' }
                 ]
               }, {
                 answer: 'dog',
                 count: 3,
                 groups: [
                   { count: 1, group: 'male' },
-                  { count: 2, group: 'female' },
-                  { count: 0, group: 'unspecified' },
-                  { count: 0, group: nil }
+                  { count: 2, group: 'female' }
                 ]
               }, {
                 answer: 'cow',
                 count: 2,
                 groups: [
-                  { count: 2, group: 'male' },
-                  { count: 0, group: 'female' },
-                  { count: 0, group: 'unspecified' },
-                  { count: 0, group: nil }
+                  { count: 2, group: 'male' }
                 ]
               }, {
                 answer: 'pig',
                 count: 1,
                 groups: [
-                  { count: 1, group: 'male' },
-                  { count: 0, group: 'female' },
-                  { count: 0, group: 'unspecified' },
-                  { count: 0, group: nil }
+                  { count: 1, group: 'male' }
                 ]
               }, {
                 answer: 'no_response',
                 count: 0,
-                groups: [
-                  { count: 0, group: 'male' },
-                  { count: 0, group: 'female' },
-                  { count: 0, group: 'unspecified' },
-                  { count: 0, group: nil }
-                ]
+                groups: []
               }
             ]
             result[:multilocs][:group] = {
@@ -466,7 +450,6 @@ RSpec.describe SurveyResultsGeneratorService do
                 count: 18,
                 groups: [
                   { count: 1, group: 'la' },
-                  { count: 0, group: 'ny' },
                   { count: 1, group: 'other' },
                   { count: 16, group: nil }
                 ]
@@ -477,44 +460,31 @@ RSpec.describe SurveyResultsGeneratorService do
                   { count: 1, group: 'la' },
                   { count: 1, group: 'ny' },
                   { count: 2, group: 'other' },
-                  { count: 0, group: nil }
                 ]
               }, {
                 answer: 'dog',
                 count: 3,
                 groups: [
-                  { count: 0, group: 'la' },
                   { count: 1, group: 'ny' },
-                  { count: 2, group: 'other' },
-                  { count: 0, group: nil }
+                  { count: 2, group: 'other' }
                 ]
               }, {
                 answer: 'cow',
                 count: 2,
                 groups: [
                   { count: 1, group: 'la' },
-                  { count: 0, group: 'ny' },
                   { count: 1, group: 'other' },
-                  { count: 0, group: nil }
                 ]
               }, {
                 answer: 'pig',
                 count: 1,
                 groups: [
                   { count: 1, group: 'la' },
-                  { count: 0, group: 'ny' },
-                  { count: 0, group: 'other' },
-                  { count: 0, group: nil }
                 ]
               }, {
                 answer: 'no_response',
                 count: 0,
-                groups: [
-                  { count: 0, group: 'la' },
-                  { count: 0, group: 'ny' },
-                  { count: 0, group: 'other' },
-                  { count: 0, group: nil }
-                ]
+                groups: []
               }
             ]
             result[:multilocs][:group] = {
@@ -617,38 +587,23 @@ RSpec.describe SurveyResultsGeneratorService do
         let(:grouped_linear_scale_answers) do
           [
             { answer: 5, count: 1, groups: [
-              { count: 0, group: 'la' },
-              { count: 0, group: 'ny' },
-              { count: 0, group: 'other' },
               { count: 1, group: nil }
             ] },
             { answer: 4, count: 1, groups: [
-              { count: 1, group: 'la' },
-              { count: 0, group: 'ny' },
-              { count: 0, group: 'other' },
-              { count: 0, group: nil }
+              { count: 1, group: 'la' }
             ] },
             { answer: 3, count: 8, groups: [
-              { count: 0, group: 'la' },
               { count: 1, group: 'ny' },
-              { count: 0, group: 'other' },
               { count: 7, group: nil }
             ] },
             { answer: 2, count: 5, groups: [
-              { count: 0, group: 'la' },
-              { count: 0, group: 'ny' },
-              { count: 0, group: 'other' },
               { count: 5, group: nil }
             ] },
             { answer: 1, count: 2, groups: [
-              { count: 0, group: 'la' },
-              { count: 0, group: 'ny' },
-              { count: 0, group: 'other' },
               { count: 2, group: nil }
             ] },
             { answer: nil, count: 5, groups: [
               { count: 1, group: 'la' },
-              { count: 0, group: 'ny' },
               { count: 3, group: 'other' },
               { count: 1, group: nil }
             ] }
@@ -728,9 +683,7 @@ RSpec.describe SurveyResultsGeneratorService do
                 answer: nil,
                 count: 16,
                 groups: [
-                  { count: 0, group: 'male' },
                   { count: 1, group: 'female' },
-                  { count: 0, group: 'unspecified' },
                   { count: 15, group: nil }
                 ]
               }, {
@@ -739,26 +692,19 @@ RSpec.describe SurveyResultsGeneratorService do
                 groups: [
                   { count: 1, group: 'male' },
                   { count: 1, group: 'female' },
-                  { count: 0, group: 'unspecified' },
-                  { count: 0, group: nil }
                 ]
               }, {
                 answer: 'ny',
                 count: 1,
                 groups: [
-                  { count: 0, group: 'male' },
-                  { count: 1, group: 'female' },
-                  { count: 0, group: 'unspecified' },
-                  { count: 0, group: nil }
+                  { count: 1, group: 'female' }
                 ]
               }, {
                 answer: 'other',
                 count: 3,
                 groups: [
                   { count: 2, group: 'male' },
-                  { count: 1, group: 'female' },
-                  { count: 0, group: 'unspecified' },
-                  { count: 0, group: nil }
+                  { count: 1, group: 'female' }
                 ]
               }
             ]
@@ -799,7 +745,6 @@ RSpec.describe SurveyResultsGeneratorService do
               count: 16,
               groups: [
                 { count: 1, group: 5 },
-                { count: 0, group: 4 },
                 { count: 7, group: 3 },
                 { count: 5, group: 2 },
                 { count: 2, group: 1 },
@@ -810,11 +755,7 @@ RSpec.describe SurveyResultsGeneratorService do
               answer: 'la',
               count: 2,
               groups: [
-                { count: 0, group: 5 },
                 { count: 1, group: 4 },
-                { count: 0, group: 3 },
-                { count: 0, group: 2 },
-                { count: 0, group: 1 },
                 { count: 1, group: nil }
               ]
             },
@@ -822,23 +763,13 @@ RSpec.describe SurveyResultsGeneratorService do
               answer: 'ny',
               count: 1,
               groups: [
-                { count: 0, group: 5 },
-                { count: 0, group: 4 },
-                { count: 1, group: 3 },
-                { count: 0, group: 2 },
-                { count: 0, group: 1 },
-                { count: 0, group: nil }
+                { count: 1, group: 3 }
               ]
             },
             {
               answer: 'other',
               count: 3,
               groups: [
-                { count: 0, group: 5 },
-                { count: 0, group: 4 },
-                { count: 0, group: 3 },
-                { count: 0, group: 2 },
-                { count: 0, group: 1 },
                 { count: 3, group: nil }
               ]
             }

--- a/back/spec/services/survey_results_generator_service_spec.rb
+++ b/back/spec/services/survey_results_generator_service_spec.rb
@@ -826,6 +826,43 @@ RSpec.describe SurveyResultsGeneratorService do
       it 'returns the results for a multi-select image field' do
         expect(generated_results[:results][5]).to match expected_result_multiselect_image
       end
+
+      context 'with grouping' do
+        it 'groups multiselect image by survey question' do
+          result = generator.generate_results(
+            field_id: multiselect_image_field.id,
+            group_mode: 'survey_question',
+            group_field_id: select_field.id
+          )
+
+          expect(result[:answers]).to match [
+            {
+              answer: nil,
+              count: 19,
+              groups: [
+                { count: 1, group: 'la' },
+                { count: 1, group: 'ny' },
+                { count: 1, group: 'other' },
+                { count: 16, group: nil }
+              ]
+            },
+            {
+              answer: 'house',
+              count: 2,
+              groups: [
+                { count: 2, group: 'other' }
+              ]
+            },
+            {
+              answer: 'school',
+              count: 1,
+              groups: [
+                { count: 1, group: 'la' }
+              ]
+            }
+          ]
+        end
+      end
     end
 
     describe 'file upload fields' do

--- a/back/spec/services/survey_results_generator_service_spec.rb
+++ b/back/spec/services/survey_results_generator_service_spec.rb
@@ -613,7 +613,7 @@ RSpec.describe SurveyResultsGeneratorService do
         end
       end
 
-      describe 'with grouping' do
+      context 'with grouping' do
         let(:grouped_linear_scale_answers) do
           [
             { answer: 5, count: 1, groups: [

--- a/back/spec/services/survey_results_generator_service_spec.rb
+++ b/back/spec/services/survey_results_generator_service_spec.rb
@@ -610,6 +610,58 @@ RSpec.describe SurveyResultsGeneratorService do
           expect(generator.generate_results(field_id: linear_scale_field.id)).to match expected_result_linear_scale_without_min_and_max_labels
         end
       end
+
+      describe 'with grouping' do
+        let(:grouped_linear_scale_answers) do
+          [
+            { answer: 5, count: 1, groups: [
+              { count: 0, group: 'la' },
+              { count: 0, group: 'ny' },
+              { count: 0, group: 'other' },
+              { count: 1, group: nil }
+            ] },
+            { answer: 4, count: 0, groups: [
+              { count: 0, group: 'la' },
+              { count: 0, group: 'ny' },
+              { count: 0, group: 'other' },
+              { count: 0, group: nil }
+            ] },
+            { answer: 3, count: 7, groups: [
+              { count: 0, group: 'la' },
+              { count: 0, group: 'ny' },
+              { count: 0, group: 'other' },
+              { count: 7, group: nil }
+            ] },
+            { answer: 2, count: 5, groups: [
+              { count: 0, group: 'la' },
+              { count: 0, group: 'ny' },
+              { count: 0, group: 'other' },
+              { count: 5, group: nil }
+            ] },
+            { answer: 1, count: 2, groups: [
+              { count: 0, group: 'la' },
+              { count: 0, group: 'ny' },
+              { count: 0, group: 'other' },
+              { count: 2, group: nil }
+            ] },
+            { answer: nil, count: 7, groups: [
+              { count: 2, group: 'la' },
+              { count: 1, group: 'ny' },
+              { count: 3, group: 'other' },
+              { count: 1, group: nil }
+            ] }
+          ]
+        end
+
+        it 'returns a grouped result for a linear scale field' do
+          result = generator.generate_results(
+            field_id: linear_scale_field.id,
+            group_mode: 'survey_question',
+            group_field_id: select_field.id
+          )
+          expect(result[:answers]).to match grouped_linear_scale_answers
+        end
+      end
     end
 
     describe 'select field' do

--- a/back/spec/services/survey_results_generator_service_spec.rb
+++ b/back/spec/services/survey_results_generator_service_spec.rb
@@ -783,6 +783,65 @@ RSpec.describe SurveyResultsGeneratorService do
         #     group_field: food_survey_question.id
         #   )).to match {}
         # end
+
+        it 'groups by linear scale' do
+          result = generator.generate_results(
+            field_id: select_field.id,
+            group_mode: 'survey_question',
+            group_field_id: linear_scale_field.id
+          )
+
+          expect(result[:answers]).to match [
+            {
+              answer: nil,
+              count: 16,
+              groups: [
+                { count: 1, group: 5 },
+                { count: 0, group: 4 },
+                { count: 7, group: 3 },
+                { count: 5, group: 2 },
+                { count: 2, group: 1 },
+                { count: 1, group: nil }
+              ]
+            },
+            {
+              answer: 'la',
+              count: 2,
+              groups: [
+                { count: 0, group: 5 },
+                { count: 0, group: 4 },
+                { count: 0, group: 3 },
+                { count: 0, group: 2 },
+                { count: 0, group: 1 },
+                { count: 2, group: nil }
+              ]
+            },
+            { 
+              answer: 'ny',
+              count: 1,
+              groups: [
+                { count: 0, group: 5 },
+                { count: 0, group: 4 },
+                { count: 0, group: 3 },
+                { count: 0, group: 2 },
+                { count: 0, group: 1 },
+                { count: 1, group: nil }
+              ]
+            },
+            {
+              answer: 'other',
+              count: 3,
+              groups: [
+                { count: 0, group: 5 },
+                { count: 0, group: 4 },
+                { count: 0, group: 3 },
+                { count: 0, group: 2 },
+                { count: 0, group: 1 },
+                { count: 3, group: nil }
+              ]
+            }
+          ]
+        end
       end
     end
 

--- a/back/spec/services/survey_results_generator_service_spec.rb
+++ b/back/spec/services/survey_results_generator_service_spec.rb
@@ -221,7 +221,6 @@ RSpec.describe SurveyResultsGeneratorService do
       phases: phases_of_inputs,
       custom_field_values: {
         select_field.key => 'la',
-        multiselect_field.key => ['gibberish'], # This should be ignored in the results
         multiselect_image_field.key => ['school']
       },
       author: female_user


### PR DESCRIPTION
- Added functionality for slicing linear scales
- Added functionality for slicing image questions
- Added functionality for slicing by linear scales
- Groups with `count: 0` are filtered out in the BE now (was already doing this in FE)
- Invalid answer keys are counted as 'nil' responses and not counted in `questionResponseCount`

Not added yet:
- Slicing by image question (not sure if this is desirable / makes sense)