### PR TITLE
[TAN-1096] Do not copy Phase baskets_count or votes_count when copying a Project within a platform

### DIFF
--- a/back/app/services/project_copy_service.rb
+++ b/back/app/services/project_copy_service.rb
@@ -30,6 +30,7 @@ class ProjectCopyService < TemplateService
     new_publication_status: nil
   )
     include_ideas = false if local_copy
+    @include_ideas = include_ideas
     @local_copy = local_copy
     @project = project
     @template = { 'models' => {} }
@@ -297,8 +298,8 @@ class ProjectCopyService < TemplateService
         'poll_anonymous' => phase.poll_anonymous,
         'ideas_order' => phase.ideas_order,
         'input_term' => phase.input_term,
-        'baskets_count' => phase.baskets_count,
-        'votes_count' => phase.votes_count
+        'baskets_count' => @local_copy || !@include_ideas ? 0 : phase.baskets_count,
+        'votes_count' => @local_copy || !@include_ideas ? 0 : phase.votes_count
       }
       if yml_phase['participation_method'] == 'voting'
         yml_phase['voting_method'] = phase.voting_method

--- a/back/spec/services/local_project_copy_service_spec.rb
+++ b/back/spec/services/local_project_copy_service_spec.rb
@@ -416,5 +416,17 @@ describe LocalProjectCopyService do
         })
       end
     end
+
+    describe 'when source project has phase with non-zero baskets_count or votes_count' do
+      let(:phase) { create(:budgeting_phase, baskets_count: 42, votes_count: 53) }
+      let!(:source_project) { create(:project, phases: [phase]) }
+
+      it 'sets baskets_count and votes_count to zero' do
+        copied_project = service.copy(source_project)
+
+        expect(copied_project.phases.first.baskets_count).to eq 0
+        expect(copied_project.phases.first.votes_count).to eq 0
+      end
+    end
   end
 end


### PR DESCRIPTION
Also fixes case of copying project _between_ platforms when _not_ including participation.

# Changelog
## Fixed
- [TAN-1096] We no longer copy `baskets_count` and `votes_count` for phase(s) when copying a project within a platform, or between platforms when participation is not included. In these cases, we don't copy baskets or votes, so the corresponding counts should be set to zero.
