### PR TITLE
Tan 1062 Fix user types for definePermission rule functions

### DIFF
--- a/front/app/utils/permissions/permissions.ts
+++ b/front/app/utils/permissions/permissions.ts
@@ -16,14 +16,12 @@ interface IResourceData {
   [key: string]: any;
 }
 
-interface IPermissionRule {
-  (
-    resource: TPermissionItem | null,
-    user: IUser | null,
-    tenant: IAppConfigurationData,
-    context?: any
-  ): boolean;
-}
+type IPermissionRule = (
+  resource: TPermissionItem | null,
+  user: IUser | undefined,
+  tenant: IAppConfigurationData,
+  context?: any
+) => boolean;
 
 interface IPermissionRules {
   [key: string]: {
@@ -75,7 +73,7 @@ const usePermission = ({
   const rule = getPermissionRule(resourceType, action);
 
   if (rule && appConfig) {
-    return rule(item, user || null, appConfig.data, context);
+    return rule(item, user, appConfig.data, context);
   } else {
     throw `No permission rule is specified on resource '${resourceType}' for action '${action}'`;
   }

--- a/front/app/utils/permissions/permissions.ts
+++ b/front/app/utils/permissions/permissions.ts
@@ -16,7 +16,7 @@ interface IResourceData {
   [key: string]: any;
 }
 
-type IPermissionRule = (
+type PermissionRule = (
   resource: TPermissionItem | null,
   user: IUser | undefined,
   tenant: IAppConfigurationData,
@@ -25,7 +25,7 @@ type IPermissionRule = (
 
 interface IPermissionRules {
   [key: string]: {
-    [key: string]: IPermissionRule;
+    [key: string]: PermissionRule;
   };
 }
 
@@ -41,7 +41,7 @@ const isResource = (object: any): object is IResourceData => {
 const definePermissionRule = (
   resourceType: TResourceType,
   action: TAction,
-  rule: IPermissionRule
+  rule: PermissionRule
 ) => {
   permissionRules[resourceType] = {
     ...(permissionRules[resourceType] || {}),

--- a/front/app/utils/permissions/permissions.ts
+++ b/front/app/utils/permissions/permissions.ts
@@ -23,16 +23,13 @@ type PermissionRule = (
   context?: any
 ) => boolean;
 
-interface IPermissionRules {
-  [key: string]: {
-    [key: string]: PermissionRule;
-  };
-}
-
 type TResourceType = string;
 type TAction = string;
 
-const permissionRules: IPermissionRules = {};
+const permissionRules: Record<
+  TResourceType,
+  Record<TAction, PermissionRule>
+> = {};
 
 const isResource = (object: any): object is IResourceData => {
   return isObject(object) && 'type' in object;

--- a/front/app/utils/permissions/rules/campaignPermissions.ts
+++ b/front/app/utils/permissions/rules/campaignPermissions.ts
@@ -7,7 +7,7 @@ import { isAdmin, isProjectModerator } from '../roles';
 definePermissionRule(
   'automatedCampaign',
   'manage',
-  (_campaign: string, user: IUser) => {
+  (_campaign: string, user: IUser | undefined) => {
     return isAdmin(user);
   }
 );
@@ -15,7 +15,7 @@ definePermissionRule(
 definePermissionRule(
   'manualCampaign',
   'manage',
-  (_campaign: string, user: IUser) => {
+  (_campaign: string, user: IUser | undefined) => {
     return isAdmin(user) || isProjectModerator(user);
   }
 );

--- a/front/app/utils/permissions/rules/campaignPermissions.ts
+++ b/front/app/utils/permissions/rules/campaignPermissions.ts
@@ -1,5 +1,3 @@
-import { IUser } from 'api/users/types';
-
 import { definePermissionRule } from 'utils/permissions/permissions';
 
 import { isAdmin, isProjectModerator } from '../roles';
@@ -7,15 +5,11 @@ import { isAdmin, isProjectModerator } from '../roles';
 definePermissionRule(
   'automatedCampaign',
   'manage',
-  (_campaign: string, user: IUser | undefined) => {
+  (_campaign: string, user) => {
     return isAdmin(user);
   }
 );
 
-definePermissionRule(
-  'manualCampaign',
-  'manage',
-  (_campaign: string, user: IUser | undefined) => {
-    return isAdmin(user) || isProjectModerator(user);
-  }
-);
+definePermissionRule('manualCampaign', 'manage', (_campaign: string, user) => {
+  return isAdmin(user) || isProjectModerator(user);
+});

--- a/front/app/utils/permissions/rules/commentPermissions.ts
+++ b/front/app/utils/permissions/rules/commentPermissions.ts
@@ -16,7 +16,7 @@ const isAuthor = (comment: ICommentData, user?: IUser) => {
 definePermissionRule(
   'comment',
   'create',
-  (_comment: ICommentData, user: IUser) => {
+  (_comment: ICommentData, user: IUser | undefined) => {
     return !!user;
   }
 );
@@ -24,7 +24,7 @@ definePermissionRule(
 definePermissionRule(
   'comment',
   'edit',
-  (comment: ICommentData, user: IUser) => {
+  (comment: ICommentData, user: IUser | undefined) => {
     return !!isAuthor(comment, user);
   }
 );
@@ -32,7 +32,7 @@ definePermissionRule(
 definePermissionRule(
   'comment',
   'delete',
-  (comment: ICommentData, user: IUser, _tenant, { projectId }) => {
+  (comment: ICommentData, user: IUser | undefined, _tenant, { projectId }) => {
     return !!(
       isAuthor(comment, user) ||
       isAdmin(user) ||
@@ -44,7 +44,7 @@ definePermissionRule(
 definePermissionRule(
   'comment',
   'justifyDeletion',
-  (comment: ICommentData, user: IUser, _tenant, { projectId }) => {
+  (comment: ICommentData, user: IUser | undefined, _tenant, { projectId }) => {
     return (
       !isAuthor(comment, user) &&
       (isAdmin(user) || isProjectModerator(user, projectId))
@@ -55,14 +55,13 @@ definePermissionRule(
 definePermissionRule(
   'comment',
   'markAsSpam',
-  (comment: ICommentData, user: IUser, _tenant, { projectId }) => {
-    return (
-      user &&
-      !(
-        isAuthor(comment, user) ||
-        isAdmin(user) ||
-        isProjectModerator(user, projectId)
-      )
-    );
+  (comment: ICommentData, user: IUser | undefined, _tenant, { projectId }) => {
+    return user
+      ? !(
+          isAuthor(comment, user) ||
+          isAdmin(user) ||
+          (typeof projectId === 'string' && isProjectModerator(user, projectId))
+        )
+      : false;
   }
 );

--- a/front/app/utils/permissions/rules/commentPermissions.ts
+++ b/front/app/utils/permissions/rules/commentPermissions.ts
@@ -13,26 +13,18 @@ const isAuthor = (comment: ICommentData, user?: IUser) => {
   );
 };
 
-definePermissionRule(
-  'comment',
-  'create',
-  (_comment: ICommentData, user: IUser | undefined) => {
-    return !!user;
-  }
-);
+definePermissionRule('comment', 'create', (_comment: ICommentData, user) => {
+  return !!user;
+});
 
-definePermissionRule(
-  'comment',
-  'edit',
-  (comment: ICommentData, user: IUser | undefined) => {
-    return !!isAuthor(comment, user);
-  }
-);
+definePermissionRule('comment', 'edit', (comment: ICommentData, user) => {
+  return !!isAuthor(comment, user);
+});
 
 definePermissionRule(
   'comment',
   'delete',
-  (comment: ICommentData, user: IUser | undefined, _tenant, { projectId }) => {
+  (comment: ICommentData, user, _tenant, { projectId }) => {
     return !!(
       isAuthor(comment, user) ||
       isAdmin(user) ||
@@ -44,7 +36,7 @@ definePermissionRule(
 definePermissionRule(
   'comment',
   'justifyDeletion',
-  (comment: ICommentData, user: IUser | undefined, _tenant, { projectId }) => {
+  (comment: ICommentData, user, _tenant, { projectId }) => {
     return (
       !isAuthor(comment, user) &&
       (isAdmin(user) || isProjectModerator(user, projectId))
@@ -55,7 +47,7 @@ definePermissionRule(
 definePermissionRule(
   'comment',
   'markAsSpam',
-  (comment: ICommentData, user: IUser | undefined, _tenant, { projectId }) => {
+  (comment: ICommentData, user, _tenant, { projectId }) => {
     return user
       ? !(
           isAuthor(comment, user) ||

--- a/front/app/utils/permissions/rules/ideaPermissions.ts
+++ b/front/app/utils/permissions/rules/ideaPermissions.ts
@@ -5,7 +5,7 @@ import { definePermissionRule } from 'utils/permissions/permissions';
 
 import { isAdmin, isProjectModerator } from '../roles';
 
-const isAuthor = (idea: IIdeaData, user?: IUser) => {
+const isAuthor = (idea: IIdeaData, user: IUser | undefined) => {
   return (
     user &&
     idea.relationships.author?.data &&
@@ -13,14 +13,14 @@ const isAuthor = (idea: IIdeaData, user?: IUser) => {
   );
 };
 
-const isIdeaProjectModerator = (idea: IIdeaData, user?: IUser) => {
+const isIdeaProjectModerator = (idea: IIdeaData, user: IUser | undefined) => {
   return user && isProjectModerator(user, idea.relationships.project.data.id);
 };
 
 definePermissionRule(
   'idea',
   'create',
-  (_idea: IIdeaData, user: IUser, _tenant, { project = null }) => {
+  (_idea: IIdeaData, user: IUser | undefined, _tenant, { project = null }) => {
     if (project) {
       return (
         project.attributes.action_descriptor.posting_idea.enabled ||
@@ -32,13 +32,17 @@ definePermissionRule(
   }
 );
 
-definePermissionRule('idea', 'edit', (idea: IIdeaData, user: IUser) => {
-  return !!(
-    isAuthor(idea, user) ||
-    isAdmin(user) ||
-    isIdeaProjectModerator(idea, user)
-  );
-});
+definePermissionRule(
+  'idea',
+  'edit',
+  (idea: IIdeaData, user: IUser | undefined) => {
+    return !!(
+      isAuthor(idea, user) ||
+      isAdmin(user) ||
+      isIdeaProjectModerator(idea, user)
+    );
+  }
+);
 
 definePermissionRule('idea', 'markAsSpam', () => {
   return true;
@@ -47,7 +51,7 @@ definePermissionRule('idea', 'markAsSpam', () => {
 definePermissionRule(
   'idea',
   'assignBudget',
-  (idea: IIdeaData | null, user: IUser, _tenant, { projectId }) => {
+  (idea: IIdeaData | null, user: IUser | undefined, _tenant, { projectId }) => {
     return !!isAdmin(user) || (!!idea && !!isProjectModerator(user, projectId));
   }
 );

--- a/front/app/utils/permissions/rules/ideaPermissions.ts
+++ b/front/app/utils/permissions/rules/ideaPermissions.ts
@@ -20,7 +20,7 @@ const isIdeaProjectModerator = (idea: IIdeaData, user: IUser | undefined) => {
 definePermissionRule(
   'idea',
   'create',
-  (_idea: IIdeaData, user: IUser | undefined, _tenant, { project = null }) => {
+  (_idea: IIdeaData, user, _tenant, { project = null }) => {
     if (project) {
       return (
         project.attributes.action_descriptor.posting_idea.enabled ||
@@ -32,17 +32,13 @@ definePermissionRule(
   }
 );
 
-definePermissionRule(
-  'idea',
-  'edit',
-  (idea: IIdeaData, user: IUser | undefined) => {
-    return !!(
-      isAuthor(idea, user) ||
-      isAdmin(user) ||
-      isIdeaProjectModerator(idea, user)
-    );
-  }
-);
+definePermissionRule('idea', 'edit', (idea: IIdeaData, user) => {
+  return !!(
+    isAuthor(idea, user) ||
+    isAdmin(user) ||
+    isIdeaProjectModerator(idea, user)
+  );
+});
 
 definePermissionRule('idea', 'markAsSpam', () => {
   return true;
@@ -51,7 +47,7 @@ definePermissionRule('idea', 'markAsSpam', () => {
 definePermissionRule(
   'idea',
   'assignBudget',
-  (idea: IIdeaData | null, user: IUser | undefined, _tenant, { projectId }) => {
+  (idea: IIdeaData | null, user, _tenant, { projectId }) => {
     return !!isAdmin(user) || (!!idea && !!isProjectModerator(user, projectId));
   }
 );

--- a/front/app/utils/permissions/rules/initiativePermissions.ts
+++ b/front/app/utils/permissions/rules/initiativePermissions.ts
@@ -24,7 +24,7 @@ export const canModerateInitiative = (user: IUser) => {
 definePermissionRule(
   'initiative',
   'edit',
-  (initiative: IInitiativeData, user: IUser | undefined) => {
+  (initiative: IInitiativeData, user) => {
     return !!(isAuthor(initiative, user) || isAdmin(user));
   }
 );
@@ -36,7 +36,7 @@ definePermissionRule('initiative', 'markAsSpam', () => {
 definePermissionRule(
   'initiative',
   'moderate',
-  (_initiative: IInitiativeData, user: IUser | undefined) => {
+  (_initiative: IInitiativeData, user) => {
     return isAdmin(user);
   }
 );

--- a/front/app/utils/permissions/rules/initiativePermissions.ts
+++ b/front/app/utils/permissions/rules/initiativePermissions.ts
@@ -5,7 +5,7 @@ import { definePermissionRule } from 'utils/permissions/permissions';
 
 import { isAdmin } from '../roles';
 
-const isAuthor = (initiative: IInitiativeData, user?: IUser) => {
+const isAuthor = (initiative: IInitiativeData, user: IUser | undefined) => {
   return (
     user &&
     initiative.relationships.author.data &&
@@ -24,7 +24,7 @@ export const canModerateInitiative = (user: IUser) => {
 definePermissionRule(
   'initiative',
   'edit',
-  (initiative: IInitiativeData, user: IUser) => {
+  (initiative: IInitiativeData, user: IUser | undefined) => {
     return !!(isAuthor(initiative, user) || isAdmin(user));
   }
 );
@@ -36,7 +36,7 @@ definePermissionRule('initiative', 'markAsSpam', () => {
 definePermissionRule(
   'initiative',
   'moderate',
-  (_initiative: IInitiativeData, user: IUser) => {
+  (_initiative: IInitiativeData, user: IUser | undefined) => {
     return isAdmin(user);
   }
 );

--- a/front/app/utils/permissions/rules/projectFolderPermissions.ts
+++ b/front/app/utils/permissions/rules/projectFolderPermissions.ts
@@ -60,7 +60,7 @@ definePermissionRule('route', 'access', canUserAccessAdminFolderRoute);
 definePermissionRule(
   'project_folder',
   'create',
-  (_folder: IProjectFolderData, user: IUser | undefined) => {
+  (_folder: IProjectFolderData, user) => {
     return isAdmin(user);
   }
 );
@@ -68,7 +68,7 @@ definePermissionRule(
 definePermissionRule(
   'project_folder',
   'delete',
-  (_folder: IProjectFolderData, user: IUser | undefined) => {
+  (_folder: IProjectFolderData, user) => {
     return isAdmin(user);
   }
 );
@@ -76,7 +76,7 @@ definePermissionRule(
 definePermissionRule(
   'project_folder',
   'reorder',
-  (_folder: IProjectFolderData, user: IUser | undefined) => {
+  (_folder: IProjectFolderData, user) => {
     return isAdmin(user);
   }
 );
@@ -84,7 +84,7 @@ definePermissionRule(
 definePermissionRule(
   'project_folder',
   'moderate',
-  (folder: IProjectFolderData, user: IUser | undefined) => {
+  (folder: IProjectFolderData, user) => {
     return user ? userModeratesFolder(user.data, folder.id) : false;
   }
 );
@@ -92,7 +92,7 @@ definePermissionRule(
 definePermissionRule(
   'project_folder',
   'create_project_in_folder_only',
-  (_folder, user: IUser | undefined) => {
+  (_folder, user) => {
     return user ? !isAdmin(user) && isProjectFolderModerator(user.data) : false;
   }
 );

--- a/front/app/utils/permissions/rules/projectFolderPermissions.ts
+++ b/front/app/utils/permissions/rules/projectFolderPermissions.ts
@@ -14,7 +14,7 @@ import {
 } from 'utils/permissions/rules/routePermissions';
 
 export function userModeratesFolder(
-  user: IUserData | null,
+  user: IUserData | undefined,
   projectFolderId: string
 ) {
   if (isNilOrError(user)) {
@@ -32,8 +32,8 @@ export function userModeratesFolder(
   );
 }
 
-export function isProjectFolderModerator(user: IUserData) {
-  return !!user.attributes?.roles?.find((role: TRole) => {
+export function isProjectFolderModerator(user: IUserData | undefined) {
+  return !!user?.attributes?.roles?.find((role: TRole) => {
     return role.type === 'project_folder_moderator';
   });
 }
@@ -41,7 +41,7 @@ export function isProjectFolderModerator(user: IUserData) {
 // rules
 const canUserAccessAdminFolderRoute = (
   item: IRouteItem,
-  user: IUser | null,
+  user: IUser | undefined,
   tenant: IAppConfigurationData
 ) => {
   const hasAdminFolderRouteAccess =
@@ -60,7 +60,7 @@ definePermissionRule('route', 'access', canUserAccessAdminFolderRoute);
 definePermissionRule(
   'project_folder',
   'create',
-  (_folder: IProjectFolderData, user: IUser) => {
+  (_folder: IProjectFolderData, user: IUser | undefined) => {
     return isAdmin(user);
   }
 );
@@ -68,7 +68,7 @@ definePermissionRule(
 definePermissionRule(
   'project_folder',
   'delete',
-  (_folder: IProjectFolderData, user: IUser) => {
+  (_folder: IProjectFolderData, user: IUser | undefined) => {
     return isAdmin(user);
   }
 );
@@ -76,7 +76,7 @@ definePermissionRule(
 definePermissionRule(
   'project_folder',
   'reorder',
-  (_folder: IProjectFolderData, user: IUser) => {
+  (_folder: IProjectFolderData, user: IUser | undefined) => {
     return isAdmin(user);
   }
 );
@@ -84,15 +84,15 @@ definePermissionRule(
 definePermissionRule(
   'project_folder',
   'moderate',
-  (folder: IProjectFolderData, user: IUser) => {
-    return userModeratesFolder(user.data, folder.id);
+  (folder: IProjectFolderData, user: IUser | undefined) => {
+    return user ? userModeratesFolder(user.data, folder.id) : false;
   }
 );
 
 definePermissionRule(
   'project_folder',
   'create_project_in_folder_only',
-  (_folder, user: IUser) => {
-    return !isAdmin(user) && isProjectFolderModerator(user.data);
+  (_folder, user: IUser | undefined) => {
+    return user ? !isAdmin(user) && isProjectFolderModerator(user.data) : false;
   }
 );

--- a/front/app/utils/permissions/rules/projectPermissions.ts
+++ b/front/app/utils/permissions/rules/projectPermissions.ts
@@ -8,7 +8,7 @@ import { isAdmin, isProjectModerator } from '../roles';
 definePermissionRule(
   'project',
   'create',
-  (_project: IProjectData, user: IUser) => {
+  (_project: IProjectData, user: IUser | undefined) => {
     return isAdmin(user);
   }
 );
@@ -16,7 +16,7 @@ definePermissionRule(
 definePermissionRule(
   'project',
   'delete',
-  (_project: IProjectData, user: IUser) => {
+  (_project: IProjectData, user: IUser | undefined) => {
     return isAdmin(user);
   }
 );
@@ -24,14 +24,14 @@ definePermissionRule(
 definePermissionRule(
   'project',
   'reorder',
-  (_project: IProjectData, user: IUser) => {
+  (_project: IProjectData, user: IUser | undefined) => {
     return isAdmin(user);
   }
 );
 
 export function canModerateProject(
   projectId: string | null | undefined,
-  user: IUser
+  user: IUser | undefined
 ) {
   if (projectId) {
     return isAdmin(user) || isProjectModerator(user, projectId);
@@ -43,7 +43,7 @@ export function canModerateProject(
 definePermissionRule(
   'project',
   'moderate',
-  (project: IProjectData, user: IUser) => {
+  (project: IProjectData, user: IUser | undefined) => {
     return canModerateProject(project.id, user);
   }
 );

--- a/front/app/utils/permissions/rules/projectPermissions.ts
+++ b/front/app/utils/permissions/rules/projectPermissions.ts
@@ -5,29 +5,17 @@ import { definePermissionRule } from 'utils/permissions/permissions';
 
 import { isAdmin, isProjectModerator } from '../roles';
 
-definePermissionRule(
-  'project',
-  'create',
-  (_project: IProjectData, user: IUser | undefined) => {
-    return isAdmin(user);
-  }
-);
+definePermissionRule('project', 'create', (_project: IProjectData, user) => {
+  return isAdmin(user);
+});
 
-definePermissionRule(
-  'project',
-  'delete',
-  (_project: IProjectData, user: IUser | undefined) => {
-    return isAdmin(user);
-  }
-);
+definePermissionRule('project', 'delete', (_project: IProjectData, user) => {
+  return isAdmin(user);
+});
 
-definePermissionRule(
-  'project',
-  'reorder',
-  (_project: IProjectData, user: IUser | undefined) => {
-    return isAdmin(user);
-  }
-);
+definePermissionRule('project', 'reorder', (_project: IProjectData, user) => {
+  return isAdmin(user);
+});
 
 export function canModerateProject(
   projectId: string | null | undefined,
@@ -40,10 +28,6 @@ export function canModerateProject(
   return isAdmin(user);
 }
 
-definePermissionRule(
-  'project',
-  'moderate',
-  (project: IProjectData, user: IUser | undefined) => {
-    return canModerateProject(project.id, user);
-  }
-);
+definePermissionRule('project', 'moderate', (project: IProjectData, user) => {
+  return canModerateProject(project.id, user);
+});

--- a/front/app/utils/permissions/rules/routePermissions.ts
+++ b/front/app/utils/permissions/rules/routePermissions.ts
@@ -47,7 +47,7 @@ export const isAdminRoute = (path: string) => {
   return /^\/admin/.test(path);
 };
 
-const isModeratedProjectRoute = (item: IRouteItem, user: IUser | null) => {
+const isModeratedProjectRoute = (item: IRouteItem, user: IUser | undefined) => {
   const idRegexp = /^\/admin\/projects\/([a-z0-9-]+)\/?/;
   const matches = idRegexp.exec(item.path);
   const pathProjectId = matches && matches[1];
@@ -60,7 +60,7 @@ const tenantIsChurned = (tenant: IAppConfigurationData) => {
 
 export const canAccessRoute = (
   item: IRouteItem,
-  user: IUser | null,
+  user: IUser | undefined,
   tenant: IAppConfigurationData
 ) => {
   if (isAdminRoute(item.path)) {


### PR DESCRIPTION
Mostly removal of wrong type definitions. Needed to change implementation of some rules, indicated with "Implementation change" to make sure it's not missed.

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Technical
- Remove faulty `user` param type definitions for `definePermissionRule` calls