### PR TITLE
Tan 1062 use canModerateProject

### DIFF
--- a/front/app/components/IdeasMap/InstructionMessage.tsx
+++ b/front/app/components/IdeasMap/InstructionMessage.tsx
@@ -7,7 +7,7 @@ import useAuthUser from 'api/me/useAuthUser';
 import Warning from 'components/UI/Warning';
 
 import { useIntl } from 'utils/cl-intl';
-import { isAdmin, isProjectModerator } from 'utils/permissions/roles';
+import { canModerateProject } from 'utils/permissions/rules/projectPermissions';
 
 import messages from './messages';
 
@@ -21,7 +21,7 @@ const InstructionMessage = ({ projectId }: Props) => {
   const isTabletOrSmaller = useBreakpoint('tablet');
 
   const isAdminOrModerator = authUser
-    ? isAdmin(authUser) || isProjectModerator(authUser, projectId)
+    ? canModerateProject(projectId, authUser)
     : false;
 
   const getInstructionMessage = () => {

--- a/front/app/containers/EventsShowPage/components/DesktopTopBar.tsx
+++ b/front/app/containers/EventsShowPage/components/DesktopTopBar.tsx
@@ -27,7 +27,7 @@ const Bar = styled.div`
 `;
 interface Props {
   project: IProjectData;
-  event?: IEventData;
+  event: IEventData;
 }
 
 const TopBar = ({ project, event }: Props) => {
@@ -49,7 +49,7 @@ const TopBar = ({ project, event }: Props) => {
               : clHistory.push(`/projects/${project.attributes.slug}`);
           }}
         />
-        {canModerate && event && (
+        {canModerate && (
           <Button
             buttonStyle="secondary"
             m="0px"

--- a/front/app/containers/EventsShowPage/components/DesktopTopBar.tsx
+++ b/front/app/containers/EventsShowPage/components/DesktopTopBar.tsx
@@ -12,7 +12,7 @@ import GoBackButtonSolid from 'components/UI/GoBackButton/GoBackButtonSolid';
 
 import { useIntl } from 'utils/cl-intl';
 import clHistory from 'utils/cl-router/history';
-import { isAdmin, isProjectModerator } from 'utils/permissions/roles';
+import { canModerateProject } from 'utils/permissions/rules/projectPermissions';
 
 import messages from '../messages';
 
@@ -34,8 +34,8 @@ const TopBar = ({ project, event }: Props) => {
   const location = useLocation();
   const { data: user } = useAuthUser();
   const { formatMessage } = useIntl();
-  const isAdminUser = isAdmin(user);
-  const isModerator = user ? isProjectModerator(user, project.id) : false;
+  const projectId = project.id;
+  const canModerate = user ? canModerateProject(projectId, user) : false;
 
   return (
     <Bar>
@@ -49,7 +49,7 @@ const TopBar = ({ project, event }: Props) => {
               : clHistory.push(`/projects/${project.attributes.slug}`);
           }}
         />
-        {(isAdminUser || isModerator) && event && (
+        {canModerate && event && (
           <Button
             buttonStyle="secondary"
             m="0px"
@@ -59,7 +59,7 @@ const TopBar = ({ project, event }: Props) => {
             text={formatMessage(messages.editEvent)}
             onClick={() => {
               clHistory.push(
-                `/admin/projects/${project.id}/settings/events/${event.id}`
+                `/admin/projects/${projectId}/settings/events/${event.id}`
               );
             }}
           />

--- a/front/app/containers/IdeasNewPage/IdeasNewIdeationForm/index.tsx
+++ b/front/app/containers/IdeasNewPage/IdeasNewIdeationForm/index.tsx
@@ -27,7 +27,6 @@ import { getMethodConfig } from 'utils/configs/participationMethodConfig';
 import { isNilOrError } from 'utils/helperUtils';
 import { getFieldNameFromPath } from 'utils/JSONFormUtils';
 import { geocode, reverseGeocode } from 'utils/locationTools';
-import { isAdmin, isProjectModerator } from 'utils/permissions/roles';
 import { canModerateProject } from 'utils/permissions/rules/projectPermissions';
 
 import { Heading } from '../components/Heading';
@@ -161,8 +160,7 @@ const IdeasNewIdeationForm = ({ project }: Props) => {
     const phase_ids =
       phaseId &&
       !isNilOrError(authUser) &&
-      (isAdmin({ data: authUser.data }) ||
-        isProjectModerator({ data: authUser.data }, project.data.id))
+      canModerateProject(project.data.id, { data: authUser.data })
         ? [phaseId]
         : null;
 

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/IdeaAssignedToYouNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/IdeaAssignedToYouNotification/index.tsx
@@ -1,7 +1,6 @@
 import React, { MouseEvent, KeyboardEvent } from 'react';
 
 import useIdeaBySlug from 'api/ideas/useIdeaBySlug';
-import useAuthUser from 'api/me/useAuthUser';
 import { IIdeaAssignedToYouNotificationData } from 'api/notifications/types';
 
 import T from 'components/T';
@@ -9,7 +8,6 @@ import T from 'components/T';
 import { FormattedMessage } from 'utils/cl-intl';
 import Link from 'utils/cl-router/Link';
 import { isNilOrError } from 'utils/helperUtils';
-import { isAdmin } from 'utils/permissions/roles';
 
 import messages from '../../messages';
 import NotificationWrapper from '../NotificationWrapper';
@@ -20,13 +18,12 @@ interface Props {
 
 const IdeaAssignedToYouNotification = ({ notification }: Props) => {
   const { data: idea } = useIdeaBySlug(notification.attributes.post_slug);
+
+  if (!idea) return null;
+
   const onClickUserName = (event: MouseEvent | KeyboardEvent) => {
     event.stopPropagation();
   };
-  const { data: authUser } = useAuthUser();
-  const projectId = idea ? idea.data.relationships.project.data.id : null;
-
-  if (!authUser || typeof projectId !== 'string') return null;
 
   const getNotificationMessage = (): JSX.Element => {
     const sharedValues = {
@@ -62,13 +59,12 @@ const IdeaAssignedToYouNotification = ({ notification }: Props) => {
     }
   };
 
+  const projectId = idea.data.relationships.project.data.id;
+  const ideaId = idea.data.id;
+
   return (
     <NotificationWrapper
-      linkTo={
-        isAdmin(authUser)
-          ? '/admin/ideas'
-          : `/admin/projects/${projectId}/ideas`
-      }
+      linkTo={`/admin/projects/${projectId}/ideas/${ideaId}`}
       timing={notification.attributes.created_at}
       icon="idea"
       isRead={!!notification.attributes.read_at}

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/IdeaAssignedToYouNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/IdeaAssignedToYouNotification/index.tsx
@@ -9,7 +9,7 @@ import T from 'components/T';
 import { FormattedMessage } from 'utils/cl-intl';
 import Link from 'utils/cl-router/Link';
 import { isNilOrError } from 'utils/helperUtils';
-import { isAdmin, isProjectModerator } from 'utils/permissions/roles';
+import { isAdmin } from 'utils/permissions/roles';
 
 import messages from '../../messages';
 import NotificationWrapper from '../NotificationWrapper';
@@ -25,6 +25,8 @@ const IdeaAssignedToYouNotification = ({ notification }: Props) => {
   };
   const { data: authUser } = useAuthUser();
   const projectId = idea ? idea.data.relationships.project.data.id : null;
+
+  if (!authUser || typeof projectId !== 'string') return null;
 
   const getNotificationMessage = (): JSX.Element => {
     const sharedValues = {
@@ -60,34 +62,20 @@ const IdeaAssignedToYouNotification = ({ notification }: Props) => {
     }
   };
 
-  const getLinkTo = () => {
-    if (!isNilOrError(authUser)) {
-      if (isAdmin(authUser)) {
-        return '/admin/ideas';
-      } else if (projectId && isProjectModerator(authUser, projectId)) {
-        return `/admin/projects/${projectId}/ideas`;
+  return (
+    <NotificationWrapper
+      linkTo={
+        isAdmin(authUser)
+          ? '/admin/ideas'
+          : `/admin/projects/${projectId}/ideas`
       }
-    }
-
-    return null;
-  };
-
-  const linkTo = getLinkTo();
-
-  if (linkTo) {
-    return (
-      <NotificationWrapper
-        linkTo={linkTo}
-        timing={notification.attributes.created_at}
-        icon="idea"
-        isRead={!!notification.attributes.read_at}
-      >
-        {getNotificationMessage()}
-      </NotificationWrapper>
-    );
-  }
-
-  return null;
+      timing={notification.attributes.created_at}
+      icon="idea"
+      isRead={!!notification.attributes.read_at}
+    >
+      {getNotificationMessage()}
+    </NotificationWrapper>
+  );
 };
 
 export default IdeaAssignedToYouNotification;

--- a/front/app/modules/commercial/segment/index.tsx
+++ b/front/app/modules/commercial/segment/index.tsx
@@ -10,9 +10,9 @@ import { isNilOrError } from 'utils/helperUtils';
 import { ModuleConfiguration } from 'utils/moduleUtils';
 import {
   isRegularUser,
-  isProjectModerator,
   isAdmin,
   isSuperAdmin,
+  isModerator,
 } from 'utils/permissions/roles';
 
 const CL_SEGMENT_API_KEY = process.env.SEGMENT_API_KEY;
@@ -96,7 +96,7 @@ const configuration: ModuleConfiguration = {
                 locale: user.data.attributes.locale,
                 isSuperAdmin: isSuperAdmin(user),
                 isAdmin: isAdmin(user),
-                isProjectModerator: isProjectModerator(user),
+                isProjectModerator: isModerator(user),
                 highestRole: user.data.attributes.highest_role,
               },
               {

--- a/front/app/utils/actionTakingRules.ts
+++ b/front/app/utils/actionTakingRules.ts
@@ -3,7 +3,8 @@ import { IProjectData, PostingDisabledReason } from 'api/projects/types';
 import { IUserData } from 'api/users/types';
 
 import { pastPresentOrFuture } from 'utils/dateUtils';
-import { isAdmin, isProjectModerator } from 'utils/permissions/roles';
+
+import { canModerateProject } from './permissions/rules/projectPermissions';
 
 interface ActionPermissionHide {
   show: false;
@@ -147,11 +148,7 @@ export const getIdeaPostingRules = ({
     const { disabled_reason, future_enabled, enabled } =
       project.attributes.action_descriptor.posting_idea;
 
-    if (
-      signedIn &&
-      (isAdmin({ data: authUser }) ||
-        isProjectModerator({ data: authUser }, project?.id))
-    ) {
+    if (signedIn && canModerateProject(project.id, { data: authUser })) {
       return {
         show: true,
         enabled: true,


### PR DESCRIPTION
The idea behind these changes is to not allow usage if `isProjectModerator` (and other role checks) directly anymore in the future except for in permissions files, if possible.

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Both for admins and managers, the "idea assigned to you" notification links directly to the specific idea in the admin, fixing a broken link for project/folder managers.

## Technical
- Use `canModerateProject` consistently instead of `isProjectModerator || isAdmin`.