### PR TITLE
Normalize geojson data on upload

### DIFF
--- a/front/app/components/EsriMap/utils.tsx
+++ b/front/app/components/EsriMap/utils.tsx
@@ -399,7 +399,7 @@ export const createEsriFeatureLayers = (
       const title = localize(layer.title_multiloc);
 
       // Extract number of sublayers if present
-      const titleSplit = title.indexOf('(');
+      const titleSplit = title.lastIndexOf('(');
       const subLayerCount =
         titleSplit >= 0
           ? parseInt(title.substring(titleSplit + 1, title.length - 1), 10)

--- a/front/app/containers/Admin/CustomMapConfigPage/DataImportOptions/GeoJsonImportButton.tsx
+++ b/front/app/containers/Admin/CustomMapConfigPage/DataImportOptions/GeoJsonImportButton.tsx
@@ -107,10 +107,9 @@ const GeoJsonImportButton = memo<Props>(({ mapConfig, className }) => {
             },
             {
               onError: () => {
-                setIsLoading(false);
                 setImportError(true);
               },
-              onSuccess: () => {
+              onSettled: () => {
                 setIsLoading(false);
               },
             }

--- a/front/app/containers/Admin/CustomMapConfigPage/DataImportOptions/GeoJsonImportButton.tsx
+++ b/front/app/containers/Admin/CustomMapConfigPage/DataImportOptions/GeoJsonImportButton.tsx
@@ -1,6 +1,7 @@
 import React, { memo, useState } from 'react';
 
 import Tippy from '@tippyjs/react';
+import flatten from 'geojson-flatten';
 import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -62,6 +63,8 @@ interface Props {
 }
 
 const GeoJsonImportButton = memo<Props>(({ mapConfig, className }) => {
+  const [isLoading, setIsLoading] = useState(false);
+
   const { projectId } = useParams() as {
     projectId: string;
   };
@@ -82,26 +85,40 @@ const GeoJsonImportButton = memo<Props>(({ mapConfig, className }) => {
     fileReader.readAsText(event.target.files[0], 'UTF-8');
     event.target.value = null;
     fileReader.onload = (event: any) => {
-      const geojson = JSON.parse(event.target.result);
+      const rawGeojson = JSON.parse(event.target.result);
 
       setImportError(false);
 
       if (mapConfig.data.id && !isNilOrError(tenantLocales)) {
-        createProjectMapLayer(
-          {
-            type: 'CustomMaps::GeojsonLayer',
-            geojson,
-            mapConfigId: mapConfig.data.id,
-            title_multiloc: getUnnamedLayerTitleMultiloc(tenantLocales),
-            default_enabled: true,
-            id: mapConfig.data.id,
-          },
-          {
-            onError: () => {
-              setImportError(true);
+        try {
+          setIsLoading(true);
+
+          // Normalize the geojson
+          const geojson = flatten(rawGeojson);
+
+          createProjectMapLayer(
+            {
+              type: 'CustomMaps::GeojsonLayer',
+              geojson,
+              mapConfigId: mapConfig.data.id,
+              title_multiloc: getUnnamedLayerTitleMultiloc(tenantLocales),
+              default_enabled: true,
+              id: mapConfig.data.id,
             },
-          }
-        );
+            {
+              onError: () => {
+                setIsLoading(false);
+                setImportError(true);
+              },
+              onSuccess: () => {
+                setIsLoading(false);
+              },
+            }
+          );
+        } catch (e) {
+          setIsLoading(false);
+          setImportError(true);
+        }
       }
     };
   };
@@ -130,6 +147,7 @@ const GeoJsonImportButton = memo<Props>(({ mapConfig, className }) => {
               icon="upload-file"
               buttonStyle="secondary"
               disabled={geoJsonImportDisabled}
+              processing={isLoading}
             >
               <StyledLabel aria-hidden htmlFor="file-attachment-uploader" />
               <FormattedMessage {...messages.import} />

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -40,6 +40,7 @@
         "file-saver": "^2.0.5",
         "focus-visible": "5.2.0",
         "formatcoords": "1.1.3",
+        "geojson-flatten": "^1.1.1",
         "graphql": "^16.8.1",
         "history": "^5.3.0",
         "https-browserify": "^1.0.0",
@@ -19550,6 +19551,11 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/geojson-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/geojson-flatten/-/geojson-flatten-1.1.1.tgz",
+      "integrity": "sha512-k/6BCd0qAt7vdqdM1LkLfAy72EsLDy0laNwX0x2h49vfYCiQkRc4PSra8DNEdJ10EKRpwEvDXMb0dBknTJuWpQ=="
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -45407,6 +45413,11 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
+    },
+    "geojson-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/geojson-flatten/-/geojson-flatten-1.1.1.tgz",
+      "integrity": "sha512-k/6BCd0qAt7vdqdM1LkLfAy72EsLDy0laNwX0x2h49vfYCiQkRc4PSra8DNEdJ10EKRpwEvDXMb0dBknTJuWpQ=="
     },
     "get-caller-file": {
       "version": "2.0.5",

--- a/front/package.json
+++ b/front/package.json
@@ -57,8 +57,8 @@
     "@babel/runtime": "7.x",
     "@citizenlab/cl2-component-library": "file:../cl2-component-library/dist",
     "@craftjs/core": "^0.2.0-beta.5",
-    "@esri/arcgis-rest-request": "^4.2.0",
     "@craftjs/utils": "^0.2.0-beta.5",
+    "@esri/arcgis-rest-request": "^4.2.0",
     "@hookform/resolvers": "^3.1.0",
     "@jsonforms/core": "3.0.0-beta.0",
     "@jsonforms/react": "3.0.0-beta.1",
@@ -84,6 +84,7 @@
     "file-saver": "^2.0.5",
     "focus-visible": "5.2.0",
     "formatcoords": "1.1.3",
+    "geojson-flatten": "^1.1.1",
     "graphql": "^16.8.1",
     "history": "^5.3.0",
     "https-browserify": "^1.0.0",
@@ -143,8 +144,7 @@
     "util": "^0.12.5",
     "webfontloader": "1.6.28",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.18.10/xlsx-0.18.10.tgz",
-    "yup": "^0.32.11",
-    "fsevents": "^2"
+    "yup": "^0.32.11"
   },
   "devDependencies": {
     "@babel/cli": "7.x",


### PR DESCRIPTION
## Technical
- Introduce [geojson-flatten](https://www.npmjs.com/package/geojson-flatten/v/1.1.1) library to normalize & flatten geojson data on upload. Results in simpler & cleaner geojson which works well with Esri Maps.
