### PR TITLE
[TAN-1259] Made analysis inputs use native_survey or ideation scope

### DIFF
--- a/back/engines/commercial/analysis/app/models/analysis/analysis.rb
+++ b/back/engines/commercial/analysis/app/models/analysis/analysis.rb
@@ -39,11 +39,10 @@ module Analysis
     # the form definition of the project or phase assigned to the analysis, that
     # also are part of the phase.
     def inputs
-      scope = Idea.published
       if phase_id
-        scope.where(creation_phase_id: phase_id)
+        phase.ideas.native_survey.published
       elsif project_id
-        scope.where(project_id: project_id, creation_phase: nil)
+        project.ideas.ideation.published
       end
     end
 

--- a/back/engines/commercial/analysis/app/services/analysis/inputs_finder.rb
+++ b/back/engines/commercial/analysis/app/services/analysis/inputs_finder.rb
@@ -10,7 +10,11 @@ module Analysis
     end
 
     def execute
-      inputs = analysis.inputs
+      inputs = if analysis.participation_method == 'native_survey'
+        analysis.inputs.native_survey
+      else
+        analysis.inputs.ideation
+      end
 
       inputs = filter_tags(inputs)
       inputs = filter_input_custom_field_no_empty_values(inputs)

--- a/back/engines/commercial/analysis/app/services/analysis/inputs_finder.rb
+++ b/back/engines/commercial/analysis/app/services/analysis/inputs_finder.rb
@@ -10,11 +10,7 @@ module Analysis
     end
 
     def execute
-      inputs = if analysis.participation_method == 'native_survey'
-        analysis.inputs.native_survey
-      else
-        analysis.inputs.ideation
-      end
+      inputs = analysis.inputs
 
       inputs = filter_tags(inputs)
       inputs = filter_input_custom_field_no_empty_values(inputs)


### PR DESCRIPTION
The important thing here is that survey results is now looking for both an ideas_phase record AND a creation_phase (to avoid issues when phase methods are switched). This change brings analysis inline with this.

Still need to track down why the analysis template is not populating ideas_phase for surveys though.

# Changelog
## Fixed
- Consistent counts between analysis and survey results
