### PR TITLE
TAN-1347 project input manager do not reset project id

### DIFF
--- a/front/app/components/admin/PostManager/InputManager.tsx
+++ b/front/app/components/admin/PostManager/InputManager.tsx
@@ -226,6 +226,8 @@ const InputManager = ({
 
   const onResetParams = () => {
     setQueryParameters(
+      // Don't reset the project filter if we're in the project input manager
+      // or all ideas (including from other projects) will be visible.
       type === 'ProjectIdeas' && typeof projectId === 'string'
         ? {
             projects: [projectId],

--- a/front/app/components/admin/PostManager/InputManager.tsx
+++ b/front/app/components/admin/PostManager/InputManager.tsx
@@ -225,7 +225,13 @@ const InputManager = ({
   };
 
   const onResetParams = () => {
-    setQueryParameters({});
+    setQueryParameters(
+      type === 'ProjectIdeas' && typeof projectId === 'string'
+        ? {
+            projects: [projectId],
+          }
+        : {}
+    );
   };
 
   const onChangePage = (pageNumber: number) => {


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- If [clicking "Reset all" in the input manager](https://github.com/CitizenLabDotCo/citizenlab/assets/16427929/b8d5ee3e-dec5-4a9e-8e7c-14642c6fe40b), the project filter is not reset anymore when users are in a specific project's input manager (as opposed to the general input manager). This meant admins & moderators would see _all_ inputs, including the ones not belonging to the project, which led to bugs (e.g. when you tried to assign an idea from a different project to one of your project's phases).
