### PR TITLE
Use author instead of authUser to determine comment moderator styles

### DIFF
--- a/front/app/components/PostShowComponents/Comments/Comment/index.tsx
+++ b/front/app/components/PostShowComponents/Comments/Comment/index.tsx
@@ -7,6 +7,8 @@ import useComment from 'api/comments/useComment';
 import useUserById from 'api/users/useUserById';
 
 import { FormattedMessage } from 'utils/cl-intl';
+import { canModerateInitiative } from 'utils/permissions/rules/initiativePermissions';
+import { canModerateProject } from 'utils/permissions/rules/projectPermissions';
 
 import messages from '../messages';
 
@@ -58,7 +60,6 @@ interface Props {
   hasChildComments?: boolean;
   last?: boolean;
   className?: string;
-  userCanModerate: boolean;
 }
 
 const Comment = ({
@@ -71,7 +72,6 @@ const Comment = ({
   hasChildComments,
   last,
   className,
-  userCanModerate,
 }: Props) => {
   const { data: comment } = useComment(commentId);
   const { data: author } = useUserById(
@@ -91,6 +91,13 @@ const Comment = ({
   const onCommentSaved = () => {
     setEditing(false);
   };
+
+  const authorCanModerate = author
+    ? {
+        idea: canModerateProject(projectId, author),
+        initiative: canModerateInitiative(author),
+      }[postType]
+    : false;
 
   if (comment) {
     const commentId = comment.data.id;
@@ -119,7 +126,7 @@ const Comment = ({
                 commentType={commentType}
                 className={commentType === 'parent' ? 'marginBottom' : ''}
                 authorId={authorId}
-                userCanModerate={userCanModerate}
+                userCanModerate={authorCanModerate}
               />
 
               <Content>

--- a/front/app/components/PostShowComponents/Comments/CommentsSection/PublicComments/Comments/ChildCommentForm.tsx
+++ b/front/app/components/PostShowComponents/Comments/CommentsSection/PublicComments/Comments/ChildCommentForm.tsx
@@ -23,6 +23,8 @@ import { trackEventByName } from 'utils/analytics';
 import { FormattedMessage, useIntl } from 'utils/cl-intl';
 import clickOutside from 'utils/containers/clickOutside';
 import { isNilOrError } from 'utils/helperUtils';
+import { canModerateInitiative } from 'utils/permissions/rules/initiativePermissions';
+import { canModerateProject } from 'utils/permissions/rules/projectPermissions';
 
 import { commentReplyButtonClicked$, commentAdded } from '../../../events';
 import messages from '../../../messages';
@@ -69,7 +71,6 @@ interface Props {
   parentId: string;
   className?: string;
   allowAnonymousParticipation?: boolean;
-  userCanModerate: boolean;
 }
 
 const ChildCommentForm = ({
@@ -80,7 +81,6 @@ const ChildCommentForm = ({
   projectId,
   className,
   allowAnonymousParticipation,
-  userCanModerate,
 }: Props) => {
   const { formatMessage } = useIntl();
   const locale = useLocale();
@@ -307,6 +307,11 @@ const ChildCommentForm = ({
       }
     }
   };
+
+  const userCanModerate = {
+    idea: canModerateProject(projectId, authUser),
+    initiative: canModerateInitiative(authUser),
+  }[postType];
 
   if (focused) {
     return (

--- a/front/app/components/PostShowComponents/Comments/CommentsSection/PublicComments/Comments/ParentComment.tsx
+++ b/front/app/components/PostShowComponents/Comments/CommentsSection/PublicComments/Comments/ParentComment.tsx
@@ -47,7 +47,6 @@ interface Props {
   childCommentIds: string[];
   className?: string;
   allowAnonymousParticipation?: boolean;
-  userCanModerate: boolean;
 }
 
 const ParentComment = ({
@@ -58,7 +57,6 @@ const ParentComment = ({
   className,
   childCommentIds,
   allowAnonymousParticipation,
-  userCanModerate,
 }: Props) => {
   const commentingPermissionInitiative = useInitiativesPermissions(
     'commenting_initiative'
@@ -114,7 +112,6 @@ const ParentComment = ({
             commentId={commentId}
             commentType="parent"
             hasChildComments={hasChildComments}
-            userCanModerate={userCanModerate}
           />
         </ParentCommentContainer>
 
@@ -150,7 +147,6 @@ const ParentComment = ({
               commentId={childCommentId}
               commentType="child"
               last={index === modifiedChildCommentIds.length - 1}
-              userCanModerate={userCanModerate}
             />
           ))}
 
@@ -162,7 +158,6 @@ const ParentComment = ({
             projectId={projectId}
             parentId={commentId}
             allowAnonymousParticipation={allowAnonymousParticipation}
-            userCanModerate={userCanModerate}
           />
         )}
       </Container>

--- a/front/app/components/PostShowComponents/Comments/CommentsSection/PublicComments/Comments/index.tsx
+++ b/front/app/components/PostShowComponents/Comments/CommentsSection/PublicComments/Comments/index.tsx
@@ -33,7 +33,6 @@ interface Props {
   loading: boolean;
   className?: string;
   allowAnonymousParticipation?: boolean;
-  userCanModerate: boolean;
 }
 
 const CommentsSection = memo<Props>(
@@ -45,7 +44,6 @@ const CommentsSection = memo<Props>(
     loading,
     className,
     allowAnonymousParticipation,
-    userCanModerate,
   }) => {
     const { formatMessage } = useIntl();
     const [commentPostedMessage, setCommentPostedMessage] = useState('');
@@ -117,7 +115,6 @@ const CommentsSection = memo<Props>(
               childCommentIds={childCommentIds}
               className={loading ? 'loading' : ''}
               allowAnonymousParticipation={allowAnonymousParticipation}
-              userCanModerate={userCanModerate}
             />
           );
         })}

--- a/front/app/components/PostShowComponents/Comments/CommentsSection/PublicComments/ParentCommentForm.tsx
+++ b/front/app/components/PostShowComponents/Comments/CommentsSection/PublicComments/ParentCommentForm.tsx
@@ -23,6 +23,8 @@ import { trackEventByName } from 'utils/analytics';
 import { FormattedMessage, MessageDescriptor, useIntl } from 'utils/cl-intl';
 import clickOutside from 'utils/containers/clickOutside';
 import { isNilOrError, isPage } from 'utils/helperUtils';
+import { canModerateInitiative } from 'utils/permissions/rules/initiativePermissions';
+import { canModerateProject } from 'utils/permissions/rules/projectPermissions';
 
 import Actions from '../../CommentForm/Actions';
 import { commentAdded } from '../../events';
@@ -78,7 +80,6 @@ interface Props {
   postingComment: (arg: boolean) => void;
   className?: string;
   allowAnonymousParticipation?: boolean;
-  userCanModerate: boolean;
 }
 
 const ParentCommentForm = ({
@@ -87,7 +88,6 @@ const ParentCommentForm = ({
   postType,
   className,
   allowAnonymousParticipation,
-  userCanModerate,
 }: Props) => {
   const locale = useLocale();
   const { data: authUser } = useAuthUser();
@@ -282,6 +282,10 @@ const ParentCommentForm = ({
     ? messages.visibleToUsersPlaceholder
     : messages[`${postType}CommentBodyPlaceholder`];
   const placeholder = formatMessage(placeholderMessage);
+  const userCanModerate = {
+    idea: canModerateProject(projectId, authUser),
+    initiative: canModerateInitiative(authUser),
+  }[postType];
 
   return (
     <Box display="flex" className={className || ''} my="12px">

--- a/front/app/components/PostShowComponents/Comments/CommentsSection/PublicComments/index.tsx
+++ b/front/app/components/PostShowComponents/Comments/CommentsSection/PublicComments/index.tsx
@@ -16,7 +16,6 @@ import { CommentsSort } from 'api/comments/types';
 import useComments from 'api/comments/useComments';
 import useIdeaById from 'api/ideas/useIdeaById';
 import useInitiativeById from 'api/initiatives/useInitiativeById';
-import useAuthUser from 'api/me/useAuthUser';
 import useProjectById from 'api/projects/useProjectById';
 
 import useInitiativesPermissions from 'hooks/useInitiativesPermissions';
@@ -24,8 +23,6 @@ import useInitiativesPermissions from 'hooks/useInitiativesPermissions';
 import { trackEventByName } from 'utils/analytics';
 import { FormattedMessage } from 'utils/cl-intl';
 import { isPage } from 'utils/helperUtils';
-import { canModerateInitiative } from 'utils/permissions/rules/initiativePermissions';
-import { canModerateProject } from 'utils/permissions/rules/projectPermissions';
 
 import messages from '../../messages';
 import tracks from '../../tracks';
@@ -80,7 +77,6 @@ const PublicComments = ({
   const ideaId = postType === 'idea' ? postId : undefined;
   const { data: initiative } = useInitiativeById(initiativeId);
   const { data: idea } = useIdeaById(ideaId);
-  const { data: authUser } = useAuthUser();
   const { pathname } = useLocation();
   const [sortOrder, setSortOrder] = useState<CommentsSort>('new');
   const {
@@ -130,12 +126,6 @@ const PublicComments = ({
       !commentingPermissionInitiative?.disabledReason &&
       !commentingPermissionInitiative?.authenticationRequirements,
   }[postType];
-  const userCanModerate = authUser
-    ? {
-        idea: canModerateProject(projectId, authUser),
-        initiative: canModerateInitiative(authUser),
-      }[postType]
-    : false;
 
   return (
     <Box className={className || ''}>
@@ -178,7 +168,6 @@ const PublicComments = ({
             postType={postType}
             postingComment={handleCommentPosting}
             allowAnonymousParticipation={allowAnonymousParticipation}
-            userCanModerate={userCanModerate}
           />
         </Box>
       )}
@@ -189,7 +178,6 @@ const PublicComments = ({
         allComments={commentsList}
         loading={isLoading}
         allowAnonymousParticipation={allowAnonymousParticipation}
-        userCanModerate={userCanModerate}
       />
 
       {hasNextPage && !isFetchingNextPage && <Box ref={ref} w="100%" />}


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Don't show red moderator styles for regular users in the comments when signed in as a admin/moderator. (Technical: use `author` instead of `authUser` to determine styles used in the comment.)
