### PR TITLE
[TAN-862] Solve Psych::DisallowedClass error

### DIFF
--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/utils.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/utils.rb
@@ -267,7 +267,11 @@ module MultiTenancy
         end
 
         def parse_yml(content)
-          YAML.load(content, aliases: true, permitted_classes: [Date, Symbol, Time])
+          YAML.load(
+            content,
+            aliases: true,
+            permitted_classes: [Date, Project, Symbol, Time]
+          )
         end
         alias parse_yaml parse_yml
 


### PR DESCRIPTION
# Changelog
## Fixes
- [TAN-862] Fixes a bug in project-copy (AdminHQ) introduced by the Ruby upgrade.