### PR TITLE
[TAN-1388] Do not call geocode if eventAttrs.address_1 is null for event

### DIFF
--- a/front/app/containers/Admin/projects/project/events/edit.tsx
+++ b/front/app/containers/Admin/projects/project/events/edit.tsx
@@ -176,12 +176,11 @@ const AdminProjectEventEdit = () => {
 
   // When address 1 is updated, geocode the location point to match
   useEffect(() => {
-    if (
-      eventAttrs.address_1 &&
-      eventAttrs.address_1 !== event?.data.attributes.address_1
-    ) {
+    if (eventAttrs.address_1 !== event?.data.attributes.address_1) {
       const delayDebounceFn = setTimeout(async () => {
-        const point = await geocode(eventAttrs.address_1);
+        const point = eventAttrs.address_1
+          ? await geocode(eventAttrs.address_1)
+          : null;
         setGeocodedPoint(point);
         setLocationPoint(point);
         setSuccessfulGeocode(!!point);

--- a/front/app/containers/Admin/projects/project/events/edit.tsx
+++ b/front/app/containers/Admin/projects/project/events/edit.tsx
@@ -176,7 +176,10 @@ const AdminProjectEventEdit = () => {
 
   // When address 1 is updated, geocode the location point to match
   useEffect(() => {
-    if (eventAttrs.address_1 !== event?.data.attributes.address_1) {
+    if (
+      eventAttrs.address_1 &&
+      eventAttrs.address_1 !== event?.data.attributes.address_1
+    ) {
       const delayDebounceFn = setTimeout(async () => {
         const point = await geocode(eventAttrs.address_1);
         setGeocodedPoint(point);


### PR DESCRIPTION
Fixes an error where clicking the 'x' on the geocode location field ('Address 1') on the Events form, to remove a previously selected location, would send a request to `http://localhost:3000/web_api/v1/location/geocode` for a `null` address, resulting in a `500 Server error` response, and Sentry errors, for example [this one](https://sentry.hq.citizenlab.co/organizations/citizenlab/issues/77615/events/d205f4de96d44dd2aa700123885c1647/?project=2);
```
no implicit conversion of nil into String
```
e.g. When 'x' is clicked here, after selecting an address:
<img width="459" alt="Screenshot 2024-03-18 at 13 19 59" src="https://github.com/CitizenLabDotCo/citizenlab/assets/3944042/3700e0f7-762b-47d7-95e7-ea24136732e8">



# Changelog
## Technical
- [TAN-1388] Prevent sending a `null` address value to location/geocode endpoint, when 'x' is clicked to remove a selected address in the Event form.
