### PR TITLE
[TAN-1325] Add Rack::Attack specs

### DIFF
--- a/back/config/environments/staging.rb
+++ b/back/config/environments/staging.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'active_support/core_ext/integer/time'
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/back/config/environments/staging.rb
+++ b/back/config/environments/staging.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'active_support/core_ext/integer/time'
-
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/back/config/initializers/rack_attack.rb
+++ b/back/config/initializers/rack_attack.rb
@@ -27,7 +27,7 @@ class Rack::Attack
   end
 
   # Signing in by IP.
-  throttle('logins/ip', limit: 10, period: 20.seconds) do |req|
+  throttle('logins/ip', limit: 5, period: 60.seconds) do |req|
     if req.path == '/web_api/v1/user_token' && req.post?
       req.remote_ip
     end
@@ -40,7 +40,7 @@ class Rack::Attack
   end
 
   # Signing in by email account.
-  throttle('logins/email', limit: 10, period: 20.seconds) do |req|
+  throttle('logins/email', limit: 5, period: 60.seconds) do |req|
     if req.path == '/web_api/v1/user_token' && req.post?
       begin
         JSON.parse(req.body.string).dig('auth', 'email')&.to_s&.downcase&.gsub(/\s+/, '')&.presence
@@ -61,28 +61,28 @@ class Rack::Attack
   end
 
   # Account creation by IP.
-  throttle('signup/ip', limit: 10, period: 20.seconds) do |req|
+  throttle('signup/ip', limit: 5, period: 60.seconds) do |req|
     if req.path == '/web_api/v1/users' && req.post?
       req.remote_ip
     end
   end
 
   # Password reset by IP.
-  throttle('password_reset/ip', limit: 10, period: 20.seconds) do |req|
+  throttle('password_reset/ip', limit: 5, period: 60.seconds) do |req|
     if req.path == '/web_api/v1/users/reset_password' && req.post?
       req.remote_ip
     end
   end
 
   # Password reset email by IP.
-  throttle('password_reset_email/ip', limit: 10, period: 20.seconds) do |req|
+  throttle('password_reset_email/ip', limit: 5, period: 60.seconds) do |req|
     if req.path == '/web_api/v1/users/reset_password_email' && req.post?
       req.remote_ip
     end
   end
 
   # Password reset email by email account.
-  throttle('password_reset_email/email', limit: 1, period: 20.seconds) do |req|
+  throttle('password_reset_email/email', limit: 5, period: 60.seconds) do |req|
     if req.path == '/web_api/v1/users/reset_password_email' && req.post?
       begin
         JSON.parse(req.body.string).dig('user', 'email')&.to_s&.downcase&.gsub(/\s+/, '')&.presence
@@ -93,7 +93,7 @@ class Rack::Attack
   end
 
   # Accept invite by IP.
-  throttle('accept_invite/ip', limit: 10, period: 20.seconds) do |req|
+  throttle('accept_invite/ip', limit: 5, period: 60.seconds) do |req|
     if req.path.starts_with?('/web_api/v1/invites/by_token') &&  req.path.ends_with?('accept') && req.post?
       req.remote_ip
     end

--- a/back/config/initializers/rack_attack.rb
+++ b/back/config/initializers/rack_attack.rb
@@ -94,7 +94,7 @@ class Rack::Attack
 
   # Accept invite by IP.
   throttle('accept_invite/ip', limit: 5, period: 60.seconds) do |req|
-    if req.path.starts_with?('/web_api/v1/invites/by_token') &&  req.path.ends_with?('accept') && req.post?
+    if req.path.starts_with?('/web_api/v1/invites/by_token') && req.path.ends_with?('accept') && req.post?
       req.remote_ip
     end
   end

--- a/back/config/initializers/rack_attack.rb
+++ b/back/config/initializers/rack_attack.rb
@@ -27,7 +27,7 @@ class Rack::Attack
   end
 
   # Signing in by IP.
-  throttle('logins/ip', limit: 5, period: 60.seconds) do |req|
+  throttle('logins/ip', limit: 10, period: 20.seconds) do |req|
     if req.path == '/web_api/v1/user_token' && req.post?
       req.remote_ip
     end
@@ -40,7 +40,7 @@ class Rack::Attack
   end
 
   # Signing in by email account.
-  throttle('logins/email', limit: 5, period: 60.seconds) do |req|
+  throttle('logins/email', limit: 10, period: 20.seconds) do |req|
     if req.path == '/web_api/v1/user_token' && req.post?
       begin
         JSON.parse(req.body.string).dig('auth', 'email')&.to_s&.downcase&.gsub(/\s+/, '')&.presence
@@ -61,28 +61,28 @@ class Rack::Attack
   end
 
   # Account creation by IP.
-  throttle('signup/ip', limit: 5, period: 60.seconds) do |req|
+  throttle('signup/ip', limit: 10, period: 20.seconds) do |req|
     if req.path == '/web_api/v1/users' && req.post?
       req.remote_ip
     end
   end
 
   # Password reset by IP.
-  throttle('password_reset/ip', limit: 5, period: 60.seconds) do |req|
+  throttle('password_reset/ip', limit: 10, period: 20.seconds) do |req|
     if req.path == '/web_api/v1/users/reset_password' && req.post?
       req.remote_ip
     end
   end
 
   # Password reset email by IP.
-  throttle('password_reset_email/ip', limit: 5, period: 60.seconds) do |req|
+  throttle('password_reset_email/ip', limit: 10, period: 20.seconds) do |req|
     if req.path == '/web_api/v1/users/reset_password_email' && req.post?
       req.remote_ip
     end
   end
 
   # Password reset email by email account.
-  throttle('password_reset_email/email', limit: 5, period: 60.seconds) do |req|
+  throttle('password_reset_email/email', limit: 1, period: 20.seconds) do |req|
     if req.path == '/web_api/v1/users/reset_password_email' && req.post?
       begin
         JSON.parse(req.body.string).dig('user', 'email')&.to_s&.downcase&.gsub(/\s+/, '')&.presence
@@ -93,7 +93,7 @@ class Rack::Attack
   end
 
   # Accept invite by IP.
-  throttle('accept_invite/ip', limit: 5, period: 60.seconds) do |req|
+  throttle('accept_invite/ip', limit: 10, period: 20.seconds) do |req|
     if req.path.starts_with?('/web_api/v1/invites/by_token') && req.path.ends_with?('accept') && req.post?
       req.remote_ip
     end

--- a/back/config/initializers/rack_attack.rb
+++ b/back/config/initializers/rack_attack.rb
@@ -107,14 +107,14 @@ class Rack::Attack
     end
   end
 
-  # For all requests.
+  # Resend code by IP.
   throttle('user/resend_code', limit: 10, period: 5.minutes) do |req|
     if req.path == '/web_api/v1/user/resend_code' && req.post?
       req.ip
     end
   end
 
-  # Signing in by IP.
+  # Confirming by IP.
   throttle('user/confirm', limit: 5, period: 20.seconds) do |req|
     if req.path == '/web_api/v1/user/confirm' && req.post?
       req.ip

--- a/back/config/initializers/rack_attack.rb
+++ b/back/config/initializers/rack_attack.rb
@@ -114,7 +114,7 @@ class Rack::Attack
     end
   end
 
-  # Confirming by IP.
+  # Confirm by IP.
   throttle('user/confirm', limit: 5, period: 20.seconds) do |req|
     if req.path == '/web_api/v1/user/confirm' && req.post?
       req.ip


### PR DESCRIPTION
We discovered `memcache` was not working on staging. We changed the staging env var to use the same value as the specified service alias and restarted the containers, which got `memcache` working again, and thus rate-limiting also.

Thus, the focus of this PR shifted to improving and adding some tests.

- Fixes test that wasn't testing what it should: `'limits password reset email requests for same email to 10 in 20 seconds'`
- Adds test `'limits resend code requests from same IP to 10 in 5 minutes'` for existing RackAttack rule
- Adds test `'limits confirmation requests from same IP to 5 in 20 seconds'` for existing RackAttack rule

# Changelog
## Tecnical
- [TAN-1325] Adds and improves some Rack::Attack specs