### PR TITLE
[TAN-1417] Log when rake tasks start and finish

### DIFF
--- a/back/engines/commercial/analytics/lib/tasks/analytics_tasks.rake
+++ b/back/engines/commercial/analytics/lib/tasks/analytics_tasks.rake
@@ -8,9 +8,11 @@ namespace :analytics do
 
   desc 'Populates the dimension tables for each tenant'
   task populate_dimensions: :environment do
+    Rails.logger.info 'analytics:populate_dimensions started'
     Tenant.not_deleted.each do |tenant|
       tenant.switch { Analytics::PopulateDimensionsService.run }
     end
+    Rails.logger.info 'analytics:populate_dimensions finished'
   end
 end
 

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/clean_tenant_settings.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/clean_tenant_settings.rake
@@ -3,13 +3,15 @@
 namespace :cl2back do
   desc 'Clean all tenant settings'
   task clean_tenant_settings: :environment do
+    Rails.logger.info 'cl2back:clean_tenant_settings started'
     Tenant.all.each do |tenant|
-      puts "Cleaning tenant settings for tenant #{tenant.name}"
+      Rails.logger.info "Cleaning tenant settings for tenant #{tenant.name}"
       Apartment::Tenant.switch(tenant.schema_name) do
         config = AppConfiguration.instance
         config.cleanup_settings
         config.save!
       end
     end
+    Rails.logger.info 'cl2back:clean_tenant_settings finished'
   end
 end

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/update_permissions.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/update_permissions.rake
@@ -3,11 +3,13 @@
 namespace :fix_existing_tenants do
   desc 'Add the missing permissions.'
   task update_permissions: [:environment] do |_t, _args|
+    Rails.logger.info 'fix_existing_tenants:update_permissions started'
     Tenant.creation_finalized.each do |tenant|
       Apartment::Tenant.switch(tenant.schema_name) do
         PermissionsService.new.update_all_permissions
       end
     end
+    Rails.logger.info 'fix_existing_tenants:update_permissions finished'
   end
 
   desc 'Migrate changes in action names'

--- a/back/engines/free/email_campaigns/lib/tasks/email_campaigns.rake
+++ b/back/engines/free/email_campaigns/lib/tasks/email_campaigns.rake
@@ -8,12 +8,16 @@ namespace :email_campaigns do
 
   desc 'Makes sure that campaign records exist for all built-in campaigns. Should run on deployment through CI'
   task assure_campaign_records: :environment do |_t, _args|
+    Rails.logger.info 'email_campaigns:assure_campaign_records started'
     EmailCampaigns::TasksService.new.assure_campaign_records
+    Rails.logger.info 'email_campaigns:assure_campaign_records finished'
   end
 
   desc 'Removes campaigns with a type that no longer exists in `EmailCampaigns::DeliveryService.new.campaign_classes`'
   task remove_deprecated: :environment do |_t, _args|
+    Rails.logger.info 'email_campaigns:remove_deprecated started'
     EmailCampaigns::TasksService.new.remove_deprecated
+    Rails.logger.info 'email_campaigns:remove_deprecated finished'
   end
 
   desc "Given a list of email addresses, remove these users' consent from all consentable campaigns"

--- a/back/lib/tasks/clear_cache.rake
+++ b/back/lib/tasks/clear_cache.rake
@@ -3,8 +3,8 @@
 namespace :cl2back do
   desc 'Clears the cache store'
   task clear_cache_store: :environment do
-    Rails.logger.debug 'Clearing the cache'
+    Rails.logger.info 'cl2back:clear_cache_store started'
     Rails.cache.clear
-    Rails.logger.debug 'Cleared the cache'
+    Rails.logger.info 'cl2back:clear_cache_store finished'
   end
 end

--- a/back/lib/tasks/db.rake
+++ b/back/lib/tasks/db.rake
@@ -3,6 +3,7 @@
 namespace :db do
   desc 'Run db:migrate only if there are pending migrations.'
   task migrate_if_pending: :environment do
+    Rails.logger.info 'db:migrate_if_pending started'
     migration_versions = ActiveRecord::Base.connection.migration_context.migrations.to_set(&:version)
 
     schemas = Tenant.all.map(&:schema_name) + ['public']
@@ -19,10 +20,11 @@ namespace :db do
       .transform_values { |run_migrations| migration_versions - run_migrations }
 
     if pending_migrations.values.all?(&:empty?)
-      puts 'Skipping db:migrate as there are no pending migrations.'
+      Rails.logger.info 'Skipping db:migrate as there are no pending migrations.'
     else
       Rake::Task['db:migrate'].invoke
     end
+    Rails.logger.info 'db:migrate_if_pending finished'
   end
 
   desc 'Postprocess db/structure.sql after db:schema:dump.'


### PR DESCRIPTION
@adessy Also, it seems our optimization to skip migrations stopped working. In the logs, every time, for every tenant we see `Migrating ... tenant` and we don't see `Skipping db:migrate as there are no pending migrations.`

# Changelog
## Technical
[TAN-1417] Log when rake tasks start and finish