### PR TITLE
Ruby 3 fixes for keyword arguments

### DIFF
--- a/back/engines/commercial/bulk_import_ideas/lib/tasks/bulk_import_ideas_tasks.rake
+++ b/back/engines/commercial/bulk_import_ideas/lib/tasks/bulk_import_ideas_tasks.rake
@@ -12,7 +12,7 @@ namespace :bulk_import do
     service = BulkImportIdeas::ImportIdeasService.new
 
     tenant.switch do
-      xlsx = CSV.parse open(args[:url]).read, { headers: true, col_sep: ',', converters: [] }
+      xlsx = CSV.parse open(args[:url]).read, headers: true, col_sep: ',', converters: []
       idea_rows = service.xlsx_to_idea_rows xlsx
       service.import_ideas idea_rows
     end

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/complex_migrations.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/complex_migrations.rake
@@ -24,7 +24,7 @@ namespace :complex_migrations do
   task :migrate_topic_codes, [:url] => [:environment] do |_t, args|
     errors = []
     puts 'Processing topic mapping'
-    data = CSV.parse(open(args[:url]).read, { headers: true, col_sep: ',', converters: [] })
+    data = CSV.parse(open(args[:url]).read, headers: true, col_sep: ',', converters: [])
     is_mapping = {}
     conditions = ['is', 'synonym of']
     data.each do |d|

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/create_ideas_topics.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/create_ideas_topics.rake
@@ -4,7 +4,7 @@
 namespace :demos do
   desc 'Create Ideas Topics.'
   task :create_ideas_topics, %i[url host locale] => [:environment] do |_t, args|
-    data = CSV.parse(open(args[:url]).read, { headers: true, col_sep: ',', converters: [] })
+    data = CSV.parse(open(args[:url]).read, headers: true, col_sep: ',', converters: [])
     locale = args[:locale]
     count = 0
     t_count = 0

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/insert_user_custom_field_key_values.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/insert_user_custom_field_key_values.rake
@@ -31,7 +31,7 @@ require 'open-uri'
 namespace :cl2_back do
   desc 'Insert key-value pairs to user custom_field_values hashes.'
   task :insert_user_custom_field_key_value_pairs, %i[url host key] => [:environment] do |_t, args|
-    data = CSV.parse(open(args[:url]).read, { headers: true, col_sep: ',', converters: [] })
+    data = CSV.parse(open(args[:url]).read, headers: true, col_sep: ',', converters: [])
     count = 0
     key = args[:key]
 

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/lifecycle_stage.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/lifecycle_stage.rake
@@ -42,6 +42,6 @@ namespace :fix_existing_tenants do
   end
 
   def ls_read_csv(args)
-    CSV.parse(open(args[:url]).read, { headers: true, col_sep: ',', converters: [] })
+    CSV.parse(open(args[:url]).read, headers: true, col_sep: ',', converters: [])
   end
 end

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/migrate_craftjson.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/migrate_craftjson.rake
@@ -28,7 +28,7 @@ namespace :migrate_craftjson do
   desc 'Analyze'
   task :analyze, %i[file] => [:environment] do |_t, args|
     filename = args[:file] || 'craftjsons.csv'
-    data = CSV.parse(open(filename).read, { headers: true, col_sep: ',', converters: [] })
+    data = CSV.parse(open(filename).read, headers: true, col_sep: ',', converters: [])
     good = 0
     bad = 0
     data.each do |d|

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/multiloc_gsub_by_mapping.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/multiloc_gsub_by_mapping.rake
@@ -12,7 +12,7 @@
 namespace :fix do
   desc 'Update multilocs according to mapping of old -> new substrings.'
   task :multiloc_gsub, %i[mapping] => [:environment] do |_t, args|
-    data = CSV.parse(File.read(args[:mapping]), { headers: true, col_sep: ',', converters: [] })
+    data = CSV.parse(File.read(args[:mapping]), headers: true, col_sep: ',', converters: [])
     gsubs_performed = 0
     errors = []
 

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/reformat_and_insert_user_custom_field_key_value_pairs.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/reformat_and_insert_user_custom_field_key_value_pairs.rake
@@ -34,7 +34,7 @@ require 'open-uri'
 namespace :cl2_back do
   desc 'Reformat and insert key-value pairs to user custom_field_values hashes.'
   task :reformat_and_insert_user_custom_field_key_value_pairs, %i[url host key] => [:environment] do |_t, args|
-    data = CSV.parse(open(args[:url]).read, { headers: true, col_sep: ',', converters: [] })
+    data = CSV.parse(open(args[:url]).read, headers: true, col_sep: ',', converters: [])
     count = 0
 
     Apartment::Tenant.switch(args[:host].tr('.', '_')) do

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/setup_and_support.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/setup_and_support.rake
@@ -4,7 +4,7 @@ namespace :setup_and_support do
   desc 'Mass official feedback'
   task :mass_official_feedback, %i[url host locale] => [:environment] do |_t, args|
     # ID, Feedback, Feedback Author Name, Feedback Email, New Status
-    data = CSV.parse(open(args[:url]).read, { headers: true, col_sep: ',', converters: [] })
+    data = CSV.parse(open(args[:url]).read, headers: true, col_sep: ',', converters: [])
     Apartment::Tenant.switch(args[:host].tr('.', '_')) do
       data.each do |d|
         idea = Idea.find d['ID']
@@ -99,7 +99,7 @@ namespace :setup_and_support do
   desc 'Change the slugs of the project through a provided mapping'
   task :map_project_slugs, %i[url host] => [:environment] do |_t, args|
     issues = []
-    data = CSV.parse(open(args[:url]).read, { headers: true, col_sep: ',', converters: [] })
+    data = CSV.parse(open(args[:url]).read, headers: true, col_sep: ',', converters: [])
     Apartment::Tenant.switch(args[:host].tr('.', '_')) do
       data.each do |d|
         pj = Project.find_by slug: d['old_slug'].strip
@@ -237,7 +237,7 @@ namespace :setup_and_support do
 
   desc 'Add areas'
   task :add_areas, %i[host url] => [:environment] do |_t, args|
-    data = CSV.parse(open(args[:url]).read, { headers: true, col_sep: ',', converters: [] })
+    data = CSV.parse(open(args[:url]).read, headers: true, col_sep: ',', converters: [])
     Apartment::Tenant.switch(args[:host].tr('.', '_')) do
       data.each do |d|
         Area.create!(title_multiloc: d.to_h)
@@ -257,7 +257,7 @@ namespace :setup_and_support do
 
   desc 'Add anonymous likes/dislikes to ideas'
   task :add_idea_reactions, %i[host url] => [:environment] do |_t, args|
-    data = CSV.parse(open(args[:url]).read, { headers: true, col_sep: ',', converters: [] })
+    data = CSV.parse(open(args[:url]).read, headers: true, col_sep: ',', converters: [])
     Apartment::Tenant.switch(args[:host].tr('.', '_')) do
       errors = []
       data.each do |d|

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/sync_tenants.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/sync_tenants.rake
@@ -90,7 +90,7 @@ namespace :sync_tenants do
   task :apply_updates, [:sheet] => [:environment] do |_t, args|
     template_path = Rails.root.join('config/tenant_templates/base.yml')
     template = MultiTenancy::Templates::Utils.parse_yml_file(template_path)
-    instructions = CSV.parse(open(args[:sheet]).read, { headers: true, col_sep: ',', converters: [] })
+    instructions = CSV.parse(open(args[:sheet]).read, headers: true, col_sep: ',', converters: [])
 
     Tenant.where(host: instructions.pluck('Tenant host').uniq).each do |tenant|
       Apartment::Tenant.switch(tenant.schema_name) do

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/update_authors_of_comments_or_ideas.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/update_authors_of_comments_or_ideas.rake
@@ -12,7 +12,7 @@
 namespace :demos do
   desc 'Update authors of comments or ideas'
   task :update_authors_of_comments_or_ideas, %i[type url host locale] => [:environment] do |_t, args|
-    data = CSV.parse(open(args[:url]).read, { headers: true, col_sep: ',', converters: [] })
+    data = CSV.parse(open(args[:url]).read, headers: true, col_sep: ',', converters: [])
     count = 0
 
     Apartment::Tenant.switch(args[:host].tr('.', '_')) do

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/update_comments_bodies.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/update_comments_bodies.rake
@@ -5,7 +5,7 @@
 namespace :demos do
   desc 'Update comments body multilocs.'
   task :update_comments_bodies, %i[url host locale] => [:environment] do |_t, args|
-    data = CSV.parse(open(args[:url]).read, { headers: true, col_sep: ',', converters: [] })
+    data = CSV.parse(open(args[:url]).read, headers: true, col_sep: ',', converters: [])
     locale = args[:locale]
     count = 0
 

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/update_ideas_titles_and_bodies.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/update_ideas_titles_and_bodies.rake
@@ -5,7 +5,7 @@
 namespace :demos do
   desc 'Update Ideas titles and body multilocs.'
   task :update_ideas_titles_and_bodies, %i[url host locale] => [:environment] do |_t, args|
-    data = CSV.parse(open(args[:url]).read, { headers: true, col_sep: ',', converters: [] })
+    data = CSV.parse(open(args[:url]).read, headers: true, col_sep: ',', converters: [])
     locale = args[:locale]
     count = 0
 

--- a/back/lib/tasks/single_use/20231127_update_idea_statuses_and_phases.rake
+++ b/back/lib/tasks/single_use/20231127_update_idea_statuses_and_phases.rake
@@ -6,7 +6,7 @@ namespace :data_migrate do
   task :update_idea_statuses_and_phases, %i[url host locale live] => [:environment] do |_t, args|
     live = args[:live] == 'true'
     puts "Updating idea statuses and phases. Live: #{live}"
-    data = CSV.parse(open(args[:url]).read, { headers: true, col_sep: ',', converters: [] })
+    data = CSV.parse(open(args[:url]).read, headers: true, col_sep: ',', converters: [])
 
     Apartment::Tenant.switch(args[:host].tr('.', '_')) do
       default_locale = args[:locale]

--- a/back/lib/tasks/tenant_template_csv_to_yml.rake
+++ b/back/lib/tasks/tenant_template_csv_to_yml.rake
@@ -53,7 +53,7 @@ namespace :tenant_template do
   end
 
   def read_csv(name, args)
-    CSV.read("#{args[:path]}/#{name}.csv", { headers: true, col_sep: ',' })
+    CSV.read("#{args[:path]}/#{name}.csv", headers: true, col_sep: ',')
   end
 
   def make_multiloc(value, locales)


### PR DESCRIPTION
Noticed this when trying to run `setup_and_support:mass_official_feedback`. I fixed it for that one and then searched to see if this was an issue elsewhere, which is was - [background here](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/)

# Changelog
## Technical
- Ruby 3 fixes for keyword arguments in CSV parsing in rake files
