### PR TITLE
[TAN-1424] Handle empty start/end date in custom field report widgets

### DIFF
--- a/back/app/controllers/web_api/v1/stats_controller.rb
+++ b/back/app/controllers/web_api/v1/stats_controller.rb
@@ -8,24 +8,7 @@ class WebApi::V1::StatsController < ApplicationController
 
   private
 
-  def range_intersection(r1, r2)
-    ([r1.begin, r2.begin].max)..([r1.end, r2.end].min)
-  end
-
   def parse_time_boundaries
-    timezone = AppConfiguration.instance.settings('core', 'timezone')
-    platform_range = AppConfiguration.instance.created_at..Time.now.in_time_zone(timezone).end_of_day
-    start_range = params[:start_at]&.to_date ? params[:start_at] : platform_range.begin
-    end_range = params[:end_at]&.to_date ? params[:end_at] : platform_range.end
-    requested_range = start_range...end_range
-    if requested_range.overlaps?(platform_range)
-      range = range_intersection(platform_range, requested_range)
-      @start_at = range.begin
-      @end_at = range.end
-    else
-      @no_data = true
-      @start_at = Time.now
-      @end_at = Time.now
-    end
+    @start_at, @end_at, @no_data = TimeBoundariesParser.new(params[:start_at], params[:end_at]).parse
   end
 end

--- a/back/engines/commercial/report_builder/app/services/report_builder/queries/users_by_custom_field/base.rb
+++ b/back/engines/commercial/report_builder/app/services/report_builder/queries/users_by_custom_field/base.rb
@@ -17,11 +17,13 @@ module ReportBuilder
     # Copied from UserCustomFields::...::StatsUsersController#find_users
     def find_users(start_at, end_at, project_id, group_id)
       users = StatUserPolicy::Scope.new(@current_user, User.active).resolve
+      start_date, end_date = TimeBoundariesParser.new(start_at, end_at).parse
       finder_params = {
-        registration_date_range: start_at..end_at,
+        registration_date_range: start_date..end_date,
         project: project_id,
         group: group_id
       }
+
       UserCustomFields::UsersFinder.new(users, finder_params).execute
     end
   end

--- a/back/engines/commercial/report_builder/spec/acceptance/graph_data_units_spec.rb
+++ b/back/engines/commercial/report_builder/spec/acceptance/graph_data_units_spec.rb
@@ -42,6 +42,9 @@ resource 'Graph data units' do
       project: project)
     @report = create(:report, layout: build(:layout, craftjs_json: craftjs_json), phase: phase)
 
+    # Make TimeBoundariesParser work as expected
+    AppConfiguration.instance.update!(created_at: filtered_date - 2.days)
+
     # This is used if the data query is implemented with Analytics API
     # create(:dimension_date, date: filtered_date)
     # create(:dimension_type, name: 'idea', parent: 'post')

--- a/back/engines/commercial/report_builder/spec/services/report_builder/queries/users_by_custom_field/birthyear_spec.rb
+++ b/back/engines/commercial/report_builder/spec/services/report_builder/queries/users_by_custom_field/birthyear_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe ReportBuilder::Queries::UsersByCustomField::Birthyear do
 
   describe '#run_query' do
     let(:date) { Date.new(2022, 9, 1) }
+    let(:start_at) { (date - 1.day).to_s }
+    let(:end_at) { (date + 1.day).to_s }
 
     before do
       options = []
@@ -17,9 +19,18 @@ RSpec.describe ReportBuilder::Queries::UsersByCustomField::Birthyear do
       AppConfiguration.instance.update!(created_at: date - 2.days)
     end
 
-    it 'returns users by birthyear' do
-      params = { start_at: date - 1.day, end_at: date + 1.day }
+    it 'returns users by gender' do
+      params = { start_at: start_at, end_at: end_at }
       expect(query.run_query(**params)).to eq({ '_blank' => 0, 1977 => 1 })
+    end
+
+    context 'when end_at is blank' do
+      let(:end_at) { '' }
+
+      it 'returns the same users by gender' do
+        params = { start_at: start_at, end_at: end_at }
+        expect(query.run_query(**params)).to eq({ '_blank' => 0, 1977 => 1 })
+      end
     end
   end
 end

--- a/back/engines/commercial/report_builder/spec/services/report_builder/queries/users_by_custom_field/birthyear_spec.rb
+++ b/back/engines/commercial/report_builder/spec/services/report_builder/queries/users_by_custom_field/birthyear_spec.rb
@@ -2,25 +2,24 @@
 
 require 'rails_helper'
 
-RSpec.describe ReportBuilder::Queries::UsersByCustomField::Gender do
+RSpec.describe ReportBuilder::Queries::UsersByCustomField::Birthyear do
   subject(:query) { described_class.new(build(:admin)) }
 
   describe '#run_query' do
     let(:date) { Date.new(2022, 9, 1) }
 
     before do
-      options = [
-        build(:custom_field_option, key: :female),
-        build(:custom_field_option, key: :other)
-      ]
-      create(:custom_field, key: :gender, options: options, input_type: :select)
+      options = []
+      create(:custom_field, key: :birthyear, options: options, input_type: :select)
 
-      create(:user, registration_completed_at: date, custom_field_values: { gender: :female })
+      create(:user, registration_completed_at: date, custom_field_values: { birthyear: 1977 })
+
+      AppConfiguration.instance.update!(created_at: date - 2.days)
     end
 
-    it 'returns users by gender' do
+    it 'returns users by birthyear' do
       params = { start_at: date - 1.day, end_at: date + 1.day }
-      expect(query.run_query(**params)).to eq({ '_blank' => 0, 'female' => 1, 'other' => 0 })
+      expect(query.run_query(**params)).to eq({ '_blank' => 0, 1977 => 1 })
     end
   end
 end

--- a/back/engines/commercial/report_builder/spec/services/report_builder/queries/users_by_custom_field/gender_spec.rb
+++ b/back/engines/commercial/report_builder/spec/services/report_builder/queries/users_by_custom_field/gender_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe ReportBuilder::Queries::UsersByCustomField::Gender do
 
   describe '#run_query' do
     let(:date) { Date.new(2022, 9, 1) }
+    let(:start_at) { (date - 1.day).to_s }
+    let(:end_at) { (date + 1.day).to_s }
 
     before do
       options = [
@@ -21,8 +23,17 @@ RSpec.describe ReportBuilder::Queries::UsersByCustomField::Gender do
     end
 
     it 'returns users by gender' do
-      params = { start_at: date - 1.day, end_at: date + 1.day }
+      params = { start_at: start_at, end_at: end_at }
       expect(query.run_query(**params)).to eq({ '_blank' => 0, 'female' => 1, 'other' => 0 })
+    end
+
+    context 'when end_at is blank' do
+      let(:end_at) { '' }
+
+      it 'returns the same users by gender' do
+        params = { start_at: start_at, end_at: end_at }
+        expect(query.run_query(**params)).to eq({ '_blank' => 0, 'female' => 1, 'other' => 0 })
+      end
     end
   end
 end

--- a/back/engines/commercial/report_builder/spec/services/report_builder/queries/users_by_custom_field/gender_spec.rb
+++ b/back/engines/commercial/report_builder/spec/services/report_builder/queries/users_by_custom_field/gender_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ReportBuilder::Queries::UsersByCustomField::Gender do
+  subject(:query) { described_class.new(build(:admin)) }
+
+  describe '#run_query' do
+    let(:date) { Date.new(2022, 9, 1) }
+
+    before do
+      options = [
+        build(:custom_field_option, key: :female),
+        build(:custom_field_option, key: :other)
+      ]
+      create(:custom_field, key: :gender, options: options, input_type: :select)
+
+      create(:user, registration_completed_at: date, custom_field_values: { gender: :female })
+
+      AppConfiguration.instance.update!(created_at: date - 2.days)
+    end
+
+    it 'returns users by gender' do
+      params = { start_at: date - 1.day, end_at: date + 1.day }
+      expect(query.run_query(**params)).to eq({ '_blank' => 0, 'female' => 1, 'other' => 0 })
+    end
+  end
+end

--- a/back/lib/time_boundaries_parser.rb
+++ b/back/lib/time_boundaries_parser.rb
@@ -1,0 +1,28 @@
+class TimeBoundariesParser
+  def initialize(start_at, end_at)
+    @start_at = start_at
+    @end_at = end_at
+  end
+
+  def parse
+    timezone = AppConfiguration.instance.settings('core', 'timezone')
+    platform_range = AppConfiguration.instance.created_at..Time.now.in_time_zone(timezone).end_of_day
+    start_range = @start_at&.to_date ? @start_at : platform_range.begin
+    end_range = @end_at&.to_date ? @end_at : platform_range.end
+    requested_range = start_range...end_range
+    if requested_range.overlaps?(platform_range)
+      range = range_intersection(platform_range, requested_range)
+      no_data = false
+      [range.begin, range.end, no_data]
+    else
+      no_data = true
+      [Time.now, Time.now, no_data]
+    end
+  end
+
+  private
+
+  def range_intersection(r1, r2)
+    ([r1.begin, r2.begin].max)..([r1.end, r2.end].min)
+  end
+end


### PR DESCRIPTION
# Changelog
## Fixed
* [TAN-1424] Handle empty start/end date in custom field report widgets