### PR TITLE
Generate templates without notifying product

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ ci-regenerate-templates:
 		-u ${CIRCLE_CI_TOKEN}: \
 		--url https://circleci.com/api/v2/project/github/CitizenLabDotCo/citizenlab/pipeline \
 		--header 'content-type: application/json' \
-		--data '{"branch": "production", "parameters": {"templates": true}}'
+		--data '{"branch": "production", "parameters": {"templates": true, "trigger": false }}'
 
 # Triggers a build for the current branch.
 # Also, builds images for the Epic platform.


### PR DESCRIPTION
Just tried it out, and seems to be doing what it should be doing https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/174443/workflows/e823d7e0-3f1b-4fe1-9489-d229dd335c7b
