### PR TITLE
[TAN-688] Don't fetch the gravatar if user_avatars is disabled

### DIFF
--- a/back/app/jobs/generate_user_avatar_job.rb
+++ b/back/app/jobs/generate_user_avatar_job.rb
@@ -4,6 +4,7 @@ class GenerateUserAvatarJob < ApplicationJob
   queue_as :default
 
   def run(user)
+    return unless AppConfiguration.instance.feature_activated?('user_avatars')
     return unless user && !user.avatar? && user.email
 
     hash = Digest::MD5.hexdigest(user.email)

--- a/back/app/policies/user_policy.rb
+++ b/back/app/policies/user_policy.rb
@@ -105,7 +105,7 @@ class UserPolicy < ApplicationPolicy
 
   def permitted_attributes_for_create
     permitted_attributes_for_update.tap do |attributes|
-      attributes.delete(:avatar) unless AppConfiguration.instance.feature_activated?('user_avatar')
+      attributes.delete(:avatar) unless AppConfiguration.instance.feature_activated?('user_avatars')
     end
   end
 

--- a/back/spec/jobs/generate_user_avatar_job_spec.rb
+++ b/back/spec/jobs/generate_user_avatar_job_spec.rb
@@ -6,11 +6,27 @@ RSpec.describe GenerateUserAvatarJob do
   subject(:job) { described_class.new }
 
   describe '#perform' do
-    it 'retrieves and stores an avatar when the user has a gravatar for his email address' do
-      user = build(:user, email: 'sebastien+withgravatar@citizenlab.co', avatar: nil)
-      user.save
-      job.perform(user)
-      expect(user.reload.avatar).to be_present
+    # TODO: We should not send real requests or rely on the existence of a gravatar account.
+    let(:user) { create(:user, email: 'sebastien+withgravatar@citizenlab.co', avatar: nil) }
+
+    context 'when user_avatars is enabled' do
+      before { SettingsService.new.activate_feature!('user_avatars') }
+
+      it 'retrieves and stores an avatar when the user has a gravatar for his email address' do
+        job.perform(user)
+        expect(user.reload.avatar).to be_present
+      end
+    end
+
+    context 'when user_avatars is disabled' do
+      before { SettingsService.new.deactivate_feature!('user_avatars') }
+
+      it 'does not retrieve and store the gravatar' do
+        expect(user).not_to receive(:remote_avatar_url=)
+        expect(user).not_to receive(:save)
+
+        job.perform(user)
+      end
     end
   end
 end


### PR DESCRIPTION
# Changelog
## Fixed
- [TAN-688] Prevent Gravatar to be automatically fetched when creating a user account if avatars have been disabled on the platform.
