### PR TITLE
Higher priority analysis jobs

### DIFF
--- a/back/engines/commercial/analysis/app/jobs/analysis/auto_tagging_job.rb
+++ b/back/engines/commercial/analysis/app/jobs/analysis/auto_tagging_job.rb
@@ -2,7 +2,7 @@
 
 module Analysis
   class AutoTaggingJob < ApplicationJob
-    queue_as :default
+    self.priority = 45 # Slighltly more important than emails (50)
 
     def run(auto_tagging_task)
       auto_tagging_task.execute

--- a/back/engines/commercial/analysis/app/jobs/analysis/q_and_a_job.rb
+++ b/back/engines/commercial/analysis/app/jobs/analysis/q_and_a_job.rb
@@ -2,7 +2,7 @@
 
 module Analysis
   class QAndAJob < ApplicationJob
-    queue_as :default
+    self.priority = 45 # Slighltly more important than emails (50)
 
     def run(question)
       # even though the plan was normally already generated once in

--- a/back/engines/commercial/analysis/app/jobs/analysis/summarization_job.rb
+++ b/back/engines/commercial/analysis/app/jobs/analysis/summarization_job.rb
@@ -2,7 +2,7 @@
 
 module Analysis
   class SummarizationJob < ApplicationJob
-    queue_as :default
+    self.priority = 45 # Slighltly more important than emails (50)
 
     def run(summary)
       # even though the plan was normally already generated once in


### PR DESCRIPTION
We want to make sure that analysis tasks don't remain queued while a large amount of emails is being sent out. We therefore set the priority slightly higher. 

https://citizenlabco.slack.com/archives/C05EZTFP46N/p1711346503515629
