### PR TITLE
[TAN-1141] Fix content builder button not wrapping text

### DIFF
--- a/front/app/components/admin/ContentBuilder/Widgets/ButtonMultiloc/index.tsx
+++ b/front/app/components/admin/ContentBuilder/Widgets/ButtonMultiloc/index.tsx
@@ -74,8 +74,11 @@ const Button = ({ text, url, type, alignment }: ButtonProps) => {
           id="e2e-button"
           width={alignment === 'fullWidth' ? '100%' : 'auto'}
           buttonStyle={type}
-          text={localize(text)}
-        />
+        >
+          <span style={{ whiteSpace: 'normal', maxWidth: '100vw !important' }}>
+            {localize(text)}
+          </span>
+        </ButtonComponent>
       )}
     </Box>
   );

--- a/front/app/components/admin/ContentBuilder/Widgets/ButtonMultiloc/index.tsx
+++ b/front/app/components/admin/ContentBuilder/Widgets/ButtonMultiloc/index.tsx
@@ -75,9 +75,7 @@ const Button = ({ text, url, type, alignment }: ButtonProps) => {
           width={alignment === 'fullWidth' ? '100%' : 'auto'}
           buttonStyle={type}
         >
-          <span style={{ whiteSpace: 'normal', maxWidth: '100vw !important' }}>
-            {localize(text)}
-          </span>
+          <span style={{ whiteSpace: 'normal' }}>{localize(text)}</span>
         </ButtonComponent>
       )}
     </Box>


### PR DESCRIPTION
# Changelog
## Fixed
- [[TAN-1141](https://www.notion.so/citizenlab/Side-by-side-image-on-the-home-page-doesn-t-work-on-mobile-6a521e6aac034bc7bafb5b21004d3c23?pvs=4)] Fix issue where long custom button text (from Content Builder) wasn't wrapping and resulted in content appearing off the side of the screen ([before](https://github.com/CitizenLabDotCo/citizenlab/assets/33987955/0eae5a1c-423e-415c-a5eb-9d71921e59a1) / [after](https://github.com/CitizenLabDotCo/citizenlab/assets/33987955/2fd3aa22-1222-4e7a-8326-8073a8706230)).
