### PR TITLE
TAN-1464 Tenant deletion issue

### DIFF
--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -717,6 +717,7 @@ class User < ApplicationRecord
 end
 
 User.include(IdeaAssignment::Extensions::User)
+User.include(ReportBuilder::Patches::User)
 User.include(Verification::Patches::User)
 
 User.prepend(MultiTenancy::Patches::User)

--- a/back/db/migrate/20240328141200_allow_null_in_reports_owner.report_builder.rb
+++ b/back/db/migrate/20240328141200_allow_null_in_reports_owner.report_builder.rb
@@ -1,0 +1,6 @@
+# This migration comes from report_builder (originally 20240328140826)
+class AllowNullInReportsOwner < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :report_builder_reports, :owner_id, true
+  end
+end

--- a/back/db/structure.sql
+++ b/back/db/structure.sql
@@ -3085,7 +3085,7 @@ CREATE TABLE public.report_builder_published_graph_data_units (
 CREATE TABLE public.report_builder_reports (
     id uuid DEFAULT shared_extensions.gen_random_uuid() NOT NULL,
     name character varying,
-    owner_id uuid NOT NULL,
+    owner_id uuid,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     phase_id uuid,
@@ -7435,6 +7435,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240228145938'),
 ('20240229195843'),
 ('20240301120023'),
-('20240305122502');
+('20240305122502'),
+('20240328141200');
 
 

--- a/back/engines/commercial/report_builder/app/models/report_builder/patches/user.rb
+++ b/back/engines/commercial/report_builder/app/models/report_builder/patches/user.rb
@@ -3,7 +3,7 @@
 module ReportBuilder::Patches::User
   def self.included(base)
     base.class_eval do
-      has_many :reports, class_name: 'ReportBuilder::Report', foreign_key: 'owner_id', dependent: :destroy
+      has_many :reports, class_name: 'ReportBuilder::Report', foreign_key: 'owner_id', dependent: :nullify
     end
   end
 end

--- a/back/engines/commercial/report_builder/app/models/report_builder/patches/user.rb
+++ b/back/engines/commercial/report_builder/app/models/report_builder/patches/user.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module ReportBuilder::Patches::User
+  def self.included(base)
+    base.class_eval do
+      has_many :reports, class_name: 'ReportBuilder::Report', foreign_key: 'owner_id', dependent: :destroy
+    end
+  end
+end

--- a/back/engines/commercial/report_builder/app/models/report_builder/report.rb
+++ b/back/engines/commercial/report_builder/app/models/report_builder/report.rb
@@ -6,7 +6,7 @@
 #
 #  id         :uuid             not null, primary key
 #  name       :string
-#  owner_id   :uuid             not null
+#  owner_id   :uuid
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  phase_id   :uuid
@@ -25,7 +25,7 @@
 #
 module ReportBuilder
   class Report < ::ApplicationRecord
-    belongs_to :owner, class_name: 'User'
+    belongs_to :owner, class_name: 'User', optional: true
     belongs_to :phase, class_name: 'Phase', optional: true
 
     has_one(

--- a/back/engines/commercial/report_builder/db/migrate/20240328140826_allow_null_in_reports_owner.rb
+++ b/back/engines/commercial/report_builder/db/migrate/20240328140826_allow_null_in_reports_owner.rb
@@ -1,0 +1,5 @@
+class AllowNullInReportsOwner < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :report_builder_reports, :owner_id, true
+  end
+end

--- a/back/engines/commercial/report_builder/spec/models/report_builder/report_spec.rb
+++ b/back/engines/commercial/report_builder/spec/models/report_builder/report_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ReportBuilder::Report do
       report = create(:report)
       user = report.owner
       expect(user.destroy).to be_truthy
-      expect(ReportBuilder::Report.find_by(id: report.id)).to be_nil
+      expect(described_class.find_by(id: report.id)).to be_nil
     end
   end
 end

--- a/back/engines/commercial/report_builder/spec/models/report_builder/report_spec.rb
+++ b/back/engines/commercial/report_builder/spec/models/report_builder/report_spec.rb
@@ -8,4 +8,13 @@ RSpec.describe ReportBuilder::Report do
   it { is_expected.to validate_uniqueness_of(:name) }
   it { is_expected.to belong_to(:owner).class_name('User') }
   it { is_expected.to have_one(:layout).class_name('ContentBuilder::Layout').dependent(:destroy) }
+
+  describe 'user deletion' do
+    it 'deletes reports that the user owns' do
+      report = create(:report)
+      user = report.owner
+      expect(user.destroy).to be_truthy
+      expect(ReportBuilder::Report.find_by(id: report.id)).to be_nil
+    end
+  end
 end

--- a/back/engines/commercial/report_builder/spec/models/report_builder/report_spec.rb
+++ b/back/engines/commercial/report_builder/spec/models/report_builder/report_spec.rb
@@ -6,15 +6,15 @@ RSpec.describe ReportBuilder::Report do
   subject(:report) { build(:report) }
 
   it { is_expected.to validate_uniqueness_of(:name) }
-  it { is_expected.to belong_to(:owner).class_name('User') }
+  it { is_expected.to belong_to(:owner).class_name('User').optional }
   it { is_expected.to have_one(:layout).class_name('ContentBuilder::Layout').dependent(:destroy) }
 
   describe 'user deletion' do
-    it 'deletes reports that the user owns' do
+    it 'keeps reports that the user owned' do
       report = create(:report)
       user = report.owner
       expect(user.destroy).to be_truthy
-      expect(described_class.find_by(id: report.id)).to be_nil
+      expect(report.reload.owner).to be_nil
     end
   end
 end

--- a/front/app/api/reports/types.ts
+++ b/front/app/api/reports/types.ts
@@ -35,12 +35,12 @@ export interface Report {
         type: 'content-builder-layout';
       };
     };
-    owner: {
+    owner?: {
       data: {
         id: string;
         type: 'user';
       };
-    };
+    } | null;
     phase?: {
       data: {
         id: string;

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/AboutReportWidget/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/AboutReportWidget/index.tsx
@@ -41,7 +41,7 @@ const AboutReportWidget = ({ reportId, projectId, startAt, endAt }: Props) => {
   const { data: report } = useReport(reportId);
 
   // Project mod
-  const userId = report?.data.relationships.owner.data.id;
+  const userId = report?.data.relationships.owner?.data.id;
   const { data: user } = useUserById(userId);
   const projectModerator = !user ? null : getFullName(user.data);
 

--- a/front/app/containers/Admin/reporting/components/ReportBuilderPage/ReportRow/EditedText.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilderPage/ReportRow/EditedText.tsx
@@ -19,19 +19,17 @@ const EditedText = ({ createdAt, updatedAt, userId }: Props) => {
   const { data: user } = useUserById(userId);
   const { formatMessage } = useIntl();
 
-  if (!user) return null;
-
   const createdOn = moment(createdAt).format('DD/MM/YYYY');
   const lastUpdateDaysAgo = moment().diff(moment(updatedAt), 'days');
 
   return (
     <Text fontSize="s" color="textSecondary" mb="0px" mt="0px">
       {formatMessage(messages.createdOn, { date: createdOn })}
-      {' • '}
-      {formatMessage(messages.lastUpdate, {
-        days: lastUpdateDaysAgo,
-        author: user.data.attributes.first_name ?? '',
-      })}
+        {user && ' • '}
+        {user && formatMessage(messages.lastUpdate, {
+          days: lastUpdateDaysAgo,
+          author: user.data.attributes.first_name ?? '',
+        })}
     </Text>
   );
 };

--- a/front/app/containers/Admin/reporting/components/ReportBuilderPage/ReportRow/EditedText.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilderPage/ReportRow/EditedText.tsx
@@ -12,7 +12,7 @@ import messages from './messages';
 interface Props {
   createdAt: string;
   updatedAt: string;
-  userId: string;
+  userId: string | undefined;
 }
 
 const EditedText = ({ createdAt, updatedAt, userId }: Props) => {

--- a/front/app/containers/Admin/reporting/components/ReportBuilderPage/ReportRow/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilderPage/ReportRow/index.tsx
@@ -50,7 +50,7 @@ const ReportRow = ({ report }: Props) => {
           <EditedText
             createdAt={report.attributes.created_at}
             updatedAt={report.attributes.updated_at}
-            userId={report.relationships.owner?.data.id}
+            userId={report.relationships.owner?.data?.id}
           />
         </Box>
         <Box display="flex">

--- a/front/app/containers/Admin/reporting/components/ReportBuilderPage/ReportRow/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilderPage/ReportRow/index.tsx
@@ -50,7 +50,7 @@ const ReportRow = ({ report }: Props) => {
           <EditedText
             createdAt={report.attributes.created_at}
             updatedAt={report.attributes.updated_at}
-            userId={report.relationships.owner.data.id}
+            userId={report.relationships.owner?.data.id}
           />
         </Box>
         <Box display="flex">


### PR DESCRIPTION
When deleting a tenant, the users also need to successfully get deleted, which is not always the case today. The main reason for user deletion to fail that appears in Sentry happens for users who are owner of a report, as we didn't tell Rails what to do in this case. We opted to make the owner optional and keep the reports without owner when deleting the owner.

<img width="1350" alt="Screenshot 2024-03-29 at 10 53 46" src="https://github.com/CitizenLabDotCo/citizenlab/assets/31925816/686cc20d-9bb1-43f3-b91a-259dc5881001">



# Changelog
## Fixed
- [TAN-1464] Deleting a tenant when user own a report works again. This is probably the main cause behind the "host taken" tenant creation issue.