### PR TITLE
Revert "[TAN-1106] Update user email when logged in with Vienna SSO"

### DIFF
--- a/back/app/controllers/omniauth_callback_controller.rb
+++ b/back/app/controllers/omniauth_callback_controller.rb
@@ -183,14 +183,21 @@ class OmniauthCallbackController < ApplicationController
   # @param [OmniauthMethods::Base] authver_method
   # @param [User] user
   def update_user!(auth, user, authver_method)
-    attrs = authver_method.updateable_user_attrs
-    return if attrs.empty?
+    return if authver_method.updateable_user_attrs.empty?
 
+    attrs = authver_method.updateable_user_attrs
     update_hash = authver_method.profile_to_user_attrs(auth).slice(*attrs).compact
     update_hash.delete(:remote_avatar_url) if user.avatar.present? # don't overwrite avatar if already present
     user.confirm! if authver_method.email_confirmed?(auth) # confirm user email if not already confirmed
 
-    user.update_merging_custom_fields!(update_hash)
+    if authver_method.overwrite_user_attrs?
+      user.update_merging_custom_fields!(update_hash)
+    else
+      update_hash.each_pair do |attr, value|
+        user.assign_attributes(attr => value) unless user.attribute_present?(attr)
+      end
+      user.save!
+    end
   end
 
   # Return locale if a locale can be parsed from pathname which matches an app locale

--- a/back/engines/commercial/id_bosa_fas/app/lib/id_bosa_fas/bosa_fas_omniauth.rb
+++ b/back/engines/commercial/id_bosa_fas/app/lib/id_bosa_fas/bosa_fas_omniauth.rb
@@ -64,7 +64,7 @@ module IdBosaFas
     end
 
     def updateable_user_attrs
-      super + %i[first_name last_name]
+      %i[first_name last_name]
     end
   end
 end

--- a/back/engines/commercial/id_clave_unica/app/lib/id_clave_unica/clave_unica_omniauth.rb
+++ b/back/engines/commercial/id_clave_unica/app/lib/id_clave_unica/clave_unica_omniauth.rb
@@ -60,7 +60,7 @@ module IdClaveUnica
     end
 
     def updateable_user_attrs
-      super + %i[first_name last_name custom_field_values]
+      %i[first_name last_name custom_field_values]
     end
 
     def locked_custom_fields

--- a/back/engines/commercial/id_criipto/app/lib/id_criipto/criipto_verification.rb
+++ b/back/engines/commercial/id_criipto/app/lib/id_criipto/criipto_verification.rb
@@ -87,7 +87,7 @@ module IdCriipto
     end
 
     def updateable_user_attrs
-      super + %i[custom_field_values birthyear]
+      %i[custom_field_values birthyear]
     end
   end
 end

--- a/back/engines/commercial/id_franceconnect/app/lib/id_franceconnect/franceconnect_omniauth.rb
+++ b/back/engines/commercial/id_franceconnect/app/lib/id_franceconnect/franceconnect_omniauth.rb
@@ -96,7 +96,7 @@ module IdFranceconnect
     end
 
     def updateable_user_attrs
-      super + %i[first_name last_name birthyear gender remote_avatar_url]
+      %i[first_name last_name birthyear gender remote_avatar_url]
     end
 
     # To make this method return false and so to reproduce merging error, you need:

--- a/back/engines/commercial/id_hoplr/app/lib/id_hoplr/hoplr_omniauth.rb
+++ b/back/engines/commercial/id_hoplr/app/lib/id_hoplr/hoplr_omniauth.rb
@@ -63,7 +63,7 @@ module IdHoplr
     end
 
     def updateable_user_attrs
-      super + %i[first_name last_name custom_field_values]
+      %i[first_name last_name custom_field_values]
     end
 
     def locked_custom_fields

--- a/back/engines/commercial/id_nemlog_in/app/lib/id_nemlog_in/nemlog_in_omniauth.rb
+++ b/back/engines/commercial/id_nemlog_in/app/lib/id_nemlog_in/nemlog_in_omniauth.rb
@@ -70,7 +70,7 @@ module IdNemlogIn
     end
 
     def updateable_user_attrs
-      super + %i[custom_field_values]
+      %i[custom_field_values]
     end
 
     def locked_custom_fields

--- a/back/engines/commercial/id_vienna_saml/app/lib/id_vienna_saml/citizen_saml_omniauth.rb
+++ b/back/engines/commercial/id_vienna_saml/app/lib/id_vienna_saml/citizen_saml_omniauth.rb
@@ -58,6 +58,16 @@ module IdViennaSaml
       env['omniauth.strategy'].options.merge!(metadata)
     end
 
+    # @return [Array<Symbol>] Returns a list of attributes that can be updated from the auth response hash
+    def updateable_user_attrs
+      %i[first_name last_name]
+    end
+
+    # @return [Boolean] If existing user attributes should be overwritten
+    def overwrite_user_attrs?
+      false
+    end
+
     # Removes the response object because it produces a Stacklevel too deep error when converting to JSON
     # @param [OmniAuth::AuthHash] auth
     # @return [Hash] The filtered hash that will be persisted in the database

--- a/back/engines/commercial/id_vienna_saml/app/lib/id_vienna_saml/employee_saml_omniauth.rb
+++ b/back/engines/commercial/id_vienna_saml/app/lib/id_vienna_saml/employee_saml_omniauth.rb
@@ -55,7 +55,7 @@ module IdViennaSaml
 
     # @return [Array<Symbol>] Returns a list of attributes that can be updated from the auth response hash
     def updateable_user_attrs
-      super + %i[first_name last_name]
+      %i[first_name last_name]
     end
 
     # Removes the response object because it produces a Stacklevel too deep error when converting to JSON

--- a/back/engines/commercial/id_vienna_saml/spec/requests/citizen_authentication_spec.rb
+++ b/back/engines/commercial/id_vienna_saml/spec/requests/citizen_authentication_spec.rb
@@ -14,29 +14,15 @@ describe 'Vienna SAML citizen authentication' do
   context 'when the user already exists' do
     before do
       create(:user, email: 'philipp.test@extern.wien.gv.at', first_name: 'Bob', last_name: 'Alice')
+      send_auth_request
     end
 
     it 'does not overwrite first name & last name with the data from the auth response' do
-      send_auth_request
       user = User.find_by(email: 'philipp.test@extern.wien.gv.at')
       expect(user).to have_attributes(first_name: 'Bob', last_name: 'Alice')
     end
 
-    context 'when the SAML response does not include first name and last name' do
-      before do
-        delete_raw_info_attribute('urn:oid:1.2.40.0.10.2.1.1.261.20')
-        delete_raw_info_attribute('urn:oid:2.5.4.42')
-      end
-
-      it 'does not overwrite first name & last name with empty data from the auth response' do
-        send_auth_request
-        user = User.find_by(email: 'philipp.test@extern.wien.gv.at')
-        expect(user).to have_attributes(first_name: 'Bob', last_name: 'Alice')
-      end
-    end
-
     it 'sets the JWT auth token and redirects to home page' do
-      send_auth_request
       expect(cookies[:cl2_jwt]).to be_present
       expect(response).to redirect_to('/en?')
     end

--- a/back/engines/commercial/id_vienna_saml/spec/requests/shared.rb
+++ b/back/engines/commercial/id_vienna_saml/spec/requests/shared.rb
@@ -3,6 +3,17 @@
 require 'rails_helper'
 
 RSpec.shared_context 'with Vienna SAML authentication enabled' do |provider_name|
+  define_method :enable_vienna_login do
+    configuration = AppConfiguration.instance
+    settings = configuration.settings
+    settings["#{provider_name}_login"] = {
+      allowed: true,
+      enabled: true,
+      environment: 'test'
+    }
+    configuration.save!
+  end
+
   define_method :send_auth_request do
     @uid = "_#{SecureRandom.hex}" # uid is unique per request, not per user
     saml_auth_response.uid = @uid # make sure it's overwritten even if saml_auth_response is cached
@@ -11,7 +22,7 @@ RSpec.shared_context 'with Vienna SAML authentication enabled' do |provider_name
   end
 
   def set_raw_info_attribute(attribute_name, value)
-    saml_auth_response.extra.raw_info[attribute_name] = Array.wrap(value)
+    saml_auth_response.extra.raw_info[attribute_name] = value
   end
 
   def delete_raw_info_attribute(attribute_name)
@@ -20,6 +31,7 @@ RSpec.shared_context 'with Vienna SAML authentication enabled' do |provider_name
     saml_auth_response.extra.raw_info = new_raw_info
   end
 
+  let(:user) { create(:user) }
   let(:saml_auth_response) do
     OmniAuth::AuthHash.new(
       {
@@ -56,15 +68,7 @@ RSpec.shared_context 'with Vienna SAML authentication enabled' do |provider_name
   before do
     OmniAuth.config.test_mode = true
     OmniAuth.config.mock_auth[provider_name.to_sym] = saml_auth_response
-
-    configuration = AppConfiguration.instance
-    settings = configuration.settings
-    settings["#{provider_name}_login"] = {
-      allowed: true,
-      enabled: true,
-      environment: 'test'
-    }
-    configuration.save!
+    enable_vienna_login
   end
 end
 
@@ -101,49 +105,13 @@ RSpec.shared_examples 'authenticates when the user was already registered with V
 
     context 'when the user changed their email address' do
       before do
-        set_raw_info_attribute('urn:oid:0.9.2342.19200300.100.1.3', 'test393@citizenlab.co')
+        set_raw_info_attribute('urn:oid:0.9.2342.19200300.100.1.3', 'test@citizenlab.co')
       end
 
       it 'does not create another identity and user account' do
         expect do
           send_auth_request
         end.not_to change { [Identity.count, User.count] }
-        expect(User.count).to eq(1)
-      end
-
-      context 'when password login is disabled' do
-        before do
-          configuration = AppConfiguration.instance
-          configuration.settings['password_login'] = { allowed: true, enabled: false }
-          configuration.save!
-        end
-
-        it "updates user's email" do
-          expect do
-            send_auth_request
-          end.to(change { User.first.email }.from('philipp.test@extern.wien.gv.at').to('test393@citizenlab.co'))
-        end
-      end
-
-      context 'when password login is enabled' do
-        before do
-          configuration = AppConfiguration.instance
-          configuration.settings['password_login'] = {
-            allowed: true,
-            enabled: true,
-            minimum_length: 8,
-            phone: false,
-            enable_signup: true
-          }
-          configuration.save!
-        end
-
-        it "doesn't update user's email" do
-          expect do
-            send_auth_request
-          end.not_to(change { User.first.email })
-          expect(User.first.email).to eq('philipp.test@extern.wien.gv.at')
-        end
       end
     end
   end

--- a/back/lib/omniauth_methods/azure_active_directory.rb
+++ b/back/lib/omniauth_methods/azure_active_directory.rb
@@ -30,6 +30,6 @@ module OmniauthMethods
   end
 
   def updateable_user_attrs
-    super + %i[remote_avatar_url]
+    [:remote_avatar_url]
   end
 end

--- a/back/lib/omniauth_methods/base.rb
+++ b/back/lib/omniauth_methods/base.rb
@@ -24,11 +24,12 @@ module OmniauthMethods
 
     # @return [Array<Symbol>] Returns a list of user attributes that can be updated from the auth response hash
     def updateable_user_attrs
-      result = []
-      # If password_login is disabled, users cannot update their emails on UI,
-      # but we still want to keep their emails up to date.
-      result << :email if !AppConfiguration.instance.feature_activated?('password_login')
-      result
+      []
+    end
+
+    # @return [Boolean] If existing user attributes should be overwritten
+    def overwrite_user_attrs?
+      true
     end
 
     def can_merge?(_user, _user_attrs, _sso_verification_param_value)

--- a/back/lib/omniauth_methods/facebook.rb
+++ b/back/lib/omniauth_methods/facebook.rb
@@ -41,6 +41,6 @@ module OmniauthMethods
   end
 
   def updateable_user_attrs
-    super + %i[remote_avatar_url]
+    [:remote_avatar_url]
   end
 end

--- a/back/lib/omniauth_methods/google.rb
+++ b/back/lib/omniauth_methods/google.rb
@@ -27,7 +27,7 @@ module OmniauthMethods
     end
 
     def updateable_user_attrs
-      super + %i[remote_avatar_url]
+      [:remote_avatar_url]
     end
 
     private


### PR DESCRIPTION
Reverts CitizenLabDotCo/citizenlab#7354

Unfortunately, it's not possible to update email when email confirmation is enabled because of this check https://github.com/CitizenLabDotCo/citizenlab/blob/884c56c6fa0dc2020907876fadb41b1be701af31/back/app/models/user.rb#L606

And we cannot disable `user_confirmation` for Vienna because it opens a vulnerability during account creation after an invite. 

So, reverting it for now. And we'll rethink it in 3 weeks when we work on authentication.