### PR TITLE
[TAN-1429] Fix the association of matomo actions with projects

### DIFF
--- a/front/app/modules/commercial/matomo/getProjectId.test.ts
+++ b/front/app/modules/commercial/matomo/getProjectId.test.ts
@@ -47,7 +47,7 @@ describe('getProjectId', () => {
   beforeEach(() => {
     queryClient.setQueryData(ideasKeys.item({ slug: 'some-idea' }), mockIdea);
   });
-  it('returns the project id directly when the project link is an admin link', async () => {
+  it('returns the project id when the project link is an admin link', async () => {
     const projectId = await getProjectId(
       '/en/admin/projects/e20f63ae-1fe4-49be-8bf9-599cc34e6515'
     );
@@ -56,6 +56,12 @@ describe('getProjectId', () => {
 
   it('returns the project id when a non admin project link is passed', async () => {
     const projectId = await getProjectId('/en/projects/test-slug');
+    expect(projectId).toEqual('project-id');
+  });
+
+  // Regression test
+  it('returns the project id when the slug does not contain any hyphens', async () => {
+    const projectId = await getProjectId('/en/projects/testslug');
     expect(projectId).toEqual('project-id');
   });
 

--- a/front/app/modules/commercial/matomo/getProjectId.test.ts
+++ b/front/app/modules/commercial/matomo/getProjectId.test.ts
@@ -69,4 +69,14 @@ describe('getProjectId', () => {
     const projectId = await getProjectId('/en/ideas/some-idea');
     expect(projectId).toEqual('project-id2');
   });
+
+  it.each([
+    '/en/',
+    '/en/initiatives/lorem-ipsum',
+    '/initiatives/lorem-ipsum',
+    '/en/pages/cookie-policy',
+  ])('returns null when the path is %s', async (path) => {
+    const projectId = await getProjectId(path);
+    expect(projectId).toBeNull();
+  });
 });

--- a/front/app/modules/commercial/matomo/getProjectId.test.ts
+++ b/front/app/modules/commercial/matomo/getProjectId.test.ts
@@ -2,33 +2,7 @@ import ideasKeys from 'api/ideas/keys';
 
 import { queryClient } from 'utils/cl-react-query/queryClient';
 
-import {
-  extractIdeaSlug,
-  getProjectId,
-  isOnAdminProjectPage,
-} from './getProjectId';
-
-describe('extractIdeaSlug', () => {
-  it('works for /ideas/:slug', () => {
-    expect(extractIdeaSlug('/ideas/some-slug')).toEqual('some-slug');
-  });
-});
-
-describe('isOnAdminProjectPage', () => {
-  it('returns true when the link is a project admin page', () => {
-    const isAdminLink = isOnAdminProjectPage(
-      '/en/admin/projects/e20f63ae-1fe4-49be-8bf9-599cc34e6515'
-    );
-    expect(isAdminLink).toEqual(true);
-  });
-
-  it('returns false when the link is a project admin page', () => {
-    const isAdminLink = isOnAdminProjectPage(
-      '/en/projects/e20f63ae-1fe4-49be-8bf9-599cc34e6515'
-    );
-    expect(isAdminLink).toEqual(false);
-  });
-});
+import { getProjectId } from './getProjectId';
 
 const mockProject = {
   data: { id: 'project-id' },

--- a/front/app/modules/commercial/matomo/getProjectId.ts
+++ b/front/app/modules/commercial/matomo/getProjectId.ts
@@ -30,7 +30,7 @@ export const getProjectId = async (path: string) => {
 
   return null;
 };
-const slugRegExSource = slugRegEx.source.slice(1, slugRegEx.source.length - 2);
+const slugRegExSource = slugRegEx.source.slice(1, -1);
 
 const adminProjectPageDetectRegex = RegExp(
   `admin/projects/(${slugRegExSource})`

--- a/front/app/modules/commercial/matomo/getProjectId.ts
+++ b/front/app/modules/commercial/matomo/getProjectId.ts
@@ -1,55 +1,11 @@
 import ideasKeys from 'api/ideas/keys';
 import { fetchIdea } from 'api/ideas/useIdeaBySlug';
 import getProjectbySlug from 'api/projects/getProjectBySlug';
-
 import { queryClient } from 'utils/cl-react-query/queryClient';
-import { slugRegEx } from 'utils/textUtils';
 
-export const getProjectId = async (path: string) => {
-  if (isProjectPage(path)) {
-    // We are using an id in the admin and a slug for citizens
-    if (isOnAdminProjectPage(path)) {
-      return extractProjectIdOrSlug(path);
-    } else {
-      const slug = extractProjectIdOrSlug(path);
-      if (!slug) return null;
-
-      const projectId = await getProjectIdFromProjectSlug(slug);
-      return projectId;
-    }
-  }
-
-  if (isIdeaPage(path)) {
-    const slug = extractIdeaSlug(path);
-    if (!slug) return null;
-
-    const idea = await getIdea(slug);
-    const projectId = idea?.data.relationships?.project?.data?.id;
-    return projectId;
-  }
-
-  return null;
-};
-const slugRegExSource = slugRegEx.source.slice(1, -1);
-
-const adminProjectPageDetectRegex = RegExp(
-  `admin/projects/(${slugRegExSource})`
-);
-const projectPageDetectRegex = RegExp(`/projects/(${slugRegExSource})`);
-const projectPageExtractRegex = /\/projects\/([^\s!?/.*#|]+)/;
-
-const isProjectPage = (path: string) => {
-  return projectPageDetectRegex.test(path);
-};
-
-export const isOnAdminProjectPage = (path: string) => {
-  return adminProjectPageDetectRegex.test(path);
-};
-
-const extractProjectIdOrSlug = (path: string) => {
-  const matches = path.match(projectPageExtractRegex);
-  return matches && matches[1];
-};
+const projectPathRegex =
+  /(\/(?<prefix_segment>[^/]+))?\/projects\/(?<slug_or_id>[^/?#]+)/;
+const ideasPathRegex = /\/ideas\/(?<slug>[^/?#]+)/;
 
 const getProjectIdFromProjectSlug = async (slug: string) => {
   try {
@@ -60,20 +16,39 @@ const getProjectIdFromProjectSlug = async (slug: string) => {
   }
 };
 
-const ideaPageDetectRegex = RegExp(`/ideas/(${slugRegExSource})$`);
-const ideaPageExtractRegex = /\/ideas\/([^\s!?/.*#|]+)$/;
+async function extractProjectIdFromProjectPath(path: string) {
+  const match = path.match(projectPathRegex);
 
-const isIdeaPage = (path: string) => {
-  return ideaPageDetectRegex.test(path);
-};
+  if (match?.groups) {
+    const slugOrId = match.groups.slug_or_id;
+    const prefix = match.groups.prefix_segment;
+    return prefix === 'admin'
+      ? slugOrId
+      : await getProjectIdFromProjectSlug(slugOrId);
+  } else {
+    return null;
+  }
+}
 
-export const extractIdeaSlug = (path: string) => {
-  const ideaPageMatches = path.match(ideaPageExtractRegex);
-  return ideaPageMatches && ideaPageMatches[1];
-};
-
-const getIdea = async (slug: string) => {
+async function getIdea(slug: string) {
   return queryClient.fetchQuery(ideasKeys.item({ slug }), () =>
     fetchIdea({ slug })
+  );
+}
+
+async function getProjectIdFromIdeaSlug(slug: string) {
+  const idea = await getIdea(slug);
+  return idea?.data.relationships?.project?.data?.id;
+}
+
+async function extractProjectIdFromIdeaPath(path: string) {
+  const slug = path.match(ideasPathRegex)?.groups?.slug;
+  return slug ? await getProjectIdFromIdeaSlug(slug) : null;
+}
+
+export const getProjectId = async (path: string) => {
+  return (
+    (await extractProjectIdFromProjectPath(path)) ||
+    (await extractProjectIdFromIdeaPath(path))
   );
 };


### PR DESCRIPTION
As kind of an exercise, I also wrote a complete refactoring of `getProjectId.ts` during my 10%: #7499. If you wanna take a look, but it's maybe going one step too far.

One outstanding question is: How can we limit the risk of missing matching some paths in the future?

# Changelog
## Fixed
- [TAN-1429] Fix the association of Matomo actions with projects. This should fix the by-project visit statistics.
