### PR TITLE
TAN-1493 Do not filter empty values when there is no main field

### DIFF
--- a/back/engines/commercial/analysis/app/services/analysis/inputs_finder.rb
+++ b/back/engines/commercial/analysis/app/services/analysis/inputs_finder.rb
@@ -48,7 +48,7 @@ module Analysis
 
     def filter_input_custom_field_no_empty_values(inputs)
       scope = inputs
-      if params[:input_custom_field_no_empty_values]
+      if params[:input_custom_field_no_empty_values] && analysis.main_custom_field_id
         scope = scope.where.not("ideas.custom_field_values->>'#{analysis.main_custom_field.key}' IS NULL")
       end
       scope


### PR DESCRIPTION
Fix for https://sentry.hq.citizenlab.co/share/issue/cccc337ce4994de293b6e36bba7b713c.

It seems like this happens for older analyses so what I think happened is this:
1. We released the filter, but the first version was applied to additional fields as well.
2. Some platforms created insights in ideation using this filter.
3. We changed the filter to only apply on the main field. The main field is not set for ideation, and so some insights now get this error.

So I don't think the issue should happen for new insights anymore, and perhaps it's sufficient to just remove the filter for those insights, but I think it doesn't hurt to make the code more robust.
