### PR TITLE
[TAN-1422] Allow de-selecting a single choice answer

### DIFF
--- a/front/app/components/Form/Components/Controls/SingleSelectRadioEnumControl.tsx
+++ b/front/app/components/Form/Components/Controls/SingleSelectRadioEnumControl.tsx
@@ -84,6 +84,7 @@ const SingleSelectRadioEnumControl = ({
                 if (option.value !== data) {
                   handleChange(path, option.value);
                 } else {
+                  // User is trying to unselect the option
                   handleChange(path, undefined);
                 }
                 setDidBlur(true);

--- a/front/app/components/Form/Components/Controls/SingleSelectRadioEnumControl.tsx
+++ b/front/app/components/Form/Components/Controls/SingleSelectRadioEnumControl.tsx
@@ -81,7 +81,11 @@ const SingleSelectRadioEnumControl = ({
               currentValue={data}
               value={option.value}
               onChange={() => {
-                handleChange(path, option.value);
+                if (option.value !== data) {
+                  handleChange(path, option.value);
+                } else {
+                  handleChange(path, undefined);
+                }
                 setDidBlur(true);
               }}
             />


### PR DESCRIPTION
# Changelog
## Fixed
- [[TAN-1422](https://www.notion.so/citizenlab/For-optional-single-choice-question-in-survey-once-you-ve-selected-something-you-cannot-unselect-ad0dc62049e14f86bf5388275f8c64d6?pvs=4)] For single choice questions in surveys, once you’ve selected an option you can now also de-select it (by clicking on the currently selected option again).
