### PR TITLE
TAN-1487 Fix overlapping phases

### DIFF
--- a/back/app/services/timeline_service.rb
+++ b/back/app/services/timeline_service.rb
@@ -52,9 +52,9 @@ class TimelineService
   end
 
   def overlaps?(phase1, phase2)
-    return true if (phase1.start_at.blank? && phase1.end_at.blank?) || (phase2.start_at.blank? && phase2.end_at.blank?)
-    return (phase1.start_at <= phase2.start_at) if phase1.end_at.blank?
-    return (phase2.start_at <= phase1.start_at) if phase2.end_at.blank?
+    return true if (phase1.start_at.blank? && phase1.end_at.blank?) || (phase2.start_at.blank? && phase2.end_at.blank?) || (phase1.end_at.blank? && phase2.end_at.blank?)
+    return (phase2.end_at > phase1.start_at) if phase1.end_at.blank?
+    return (phase1.end_at > phase2.start_at) if phase2.end_at.blank?
 
     !((phase1.end_at.to_date < phase2.start_at.to_date) || (phase2.end_at.to_date < phase1.start_at.to_date))
   end

--- a/back/spec/models/phase_spec.rb
+++ b/back/spec/models/phase_spec.rb
@@ -164,6 +164,14 @@ RSpec.describe Phase do
       phase_right = build(:phase, project: project.reload, start_at: (Time.now + 6.days), end_at: (Time.now + 10.days))
       expect(phase_right).to be_valid
     end
+
+    it 'fails when inserting a phase in-between two phases, where then next phase has no end date' do
+      project = create(:project)
+      create(:phase, project: project, start_at: (Time.now - 5.days), end_at: (Time.now - 2.days))
+      create(:phase, project: project, start_at: (Time.now + 5.days), end_at: nil)
+      phase = build(:phase, project: project, start_at: (Time.now + 2.days), end_at: (Time.now + 12.days))
+      expect(phase).not_to be_valid
+    end
   end
 
   describe 'voting_max_total' do

--- a/back/spec/services/timeline_service_spec.rb
+++ b/back/spec/services/timeline_service_spec.rb
@@ -285,6 +285,60 @@ describe TimelineService do
     end
   end
 
+  describe 'overlaps?' do
+    it 'returns false when a phase ends before the next starts' do
+      project = build(:project)
+
+      phase1 = build(:phase, project: project, start_at: (Time.now - 5.days), end_at: (Time.now + 2.days))
+      phase2 = build(:phase, project: project, start_at: (Time.now + 5.days), end_at: (Time.now + 12.days))
+      expect(service.overlaps?(phase1, phase2)).to be false
+      expect(service.overlaps?(phase2, phase1)).to be false
+    end
+
+    it 'returns true when a phase ends on the same date that next starts' do
+      project = build(:project)
+
+      phase1 = build(:phase, project: project, start_at: (Time.now - 5.days), end_at: (Time.now + 2.days))
+      phase2 = build(:phase, project: project, start_at: (Time.now + 2.days), end_at: (Time.now + 12.days))
+      expect(service.overlaps?(phase1, phase2)).to be true
+      expect(service.overlaps?(phase2, phase1)).to be true
+    end
+
+    it 'returns true when a phase ends in between start and end of the next phase' do
+      project = build(:project)
+
+      phase1 = build(:phase, project: project, start_at: (Time.now - 5.days), end_at: (Time.now + 5.days))
+      phase2 = build(:phase, project: project, start_at: (Time.now + 2.days), end_at: (Time.now + 12.days))
+      expect(service.overlaps?(phase1, phase2)).to be true
+      expect(service.overlaps?(phase2, phase1)).to be true
+    end
+
+    it 'returns true when a phase starts and ends inside the start-end period of the other phase' do
+      project = build(:project)
+
+      phase1 = build(:phase, project: project, start_at: (Time.now - 5.days), end_at: (Time.now + 12.days))
+      phase2 = build(:phase, project: project, start_at: (Time.now + 2.days), end_at: (Time.now + 5.days))
+      expect(service.overlaps?(phase1, phase2)).to be true
+      expect(service.overlaps?(phase2, phase1)).to be true
+    end
+
+    it 'returns false for a phase ending before a phase with no end date starts' do
+      project = build(:project)
+      phase1 = build(:phase, project: project, start_at: (Time.now + 5.days), end_at: nil)
+      phase2 = build(:phase, project: project, start_at: (Time.now - 2.days), end_at: (Time.now + 2.days))
+      expect(service.overlaps?(phase1, phase2)).to be false
+      expect(service.overlaps?(phase2, phase1)).to be false
+    end
+
+    it 'returns true for a phase ending after a phase with no end date starts' do
+      project = build(:project)
+      phase1 = build(:phase, project: project, start_at: (Time.now + 5.days), end_at: nil)
+      phase2 = build(:phase, project: project, start_at: (Time.now + 2.days), end_at: (Time.now + 12.days))
+      expect(service.overlaps?(phase1, phase2)).to be true
+      expect(service.overlaps?(phase2, phase1)).to be true
+    end
+  end
+
   describe 'phase_number' do
     it 'returns the phase number' do
       project = create(:project)


### PR DESCRIPTION
# Changelog
### Fixed
- [TAN-1487] Preventing phases from overlapping when one phase is open-ended.
