### PR TITLE
TAN-1309 Don't allow modifying submitted baskets

### DIFF
--- a/back/app/controllers/web_api/v1/baskets_ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/baskets_ideas_controller.rb
@@ -64,7 +64,8 @@ class WebApi::V1::BasketsIdeasController < ApplicationController
     if basket.new_record?
       if basket.save
         SideFxBasketService.new.after_create basket, current_user
-      else
+      else # TODO: return 401 if no phase
+        skip_authorization
         render json: { errors: basket.errors.details }, status: :unprocessable_entity
         return
       end

--- a/back/app/controllers/web_api/v1/baskets_ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/baskets_ideas_controller.rb
@@ -62,10 +62,10 @@ class WebApi::V1::BasketsIdeasController < ApplicationController
       user: current_user
     )
     if basket.new_record?
+      authorize basket
       if basket.save
         SideFxBasketService.new.after_create basket, current_user
-      else # TODO: return 401 if no phase
-        skip_authorization
+      else
         render json: { errors: basket.errors.details }, status: :unprocessable_entity
         return
       end

--- a/back/app/policies/basket_policy.rb
+++ b/back/app/policies/basket_policy.rb
@@ -4,7 +4,8 @@ class BasketPolicy < ApplicationPolicy
   def create?
     user&.active? &&
       (record.user_id == user.id) &&
-      ProjectPolicy.new(user, record.phase&.project).show? &&
+      record.phase &&
+      ProjectPolicy.new(user, record.phase.project).show? &&
       check_voting_allowed(record, user)
   end
 

--- a/back/app/policies/baskets_idea_policy.rb
+++ b/back/app/policies/baskets_idea_policy.rb
@@ -19,18 +19,24 @@ class BasketsIdeaPolicy < ApplicationPolicy
   end
 
   def create?
-    BasketPolicy.new(user, record.basket).update?
+    modify_basket?
   end
 
   def update?
-    BasketPolicy.new(user, record.basket).update?
+    modify_basket?
   end
 
   def destroy?
-    BasketPolicy.new(user, record.basket).update?
+    modify_basket?
   end
 
   def upsert?
-    BasketPolicy.new(user, record.basket).update?
+    modify_basket?
+  end
+
+  private
+
+  def modify_basket?
+    !record.basket.submitted? && BasketPolicy.new(user, record.basket).update?
   end
 end

--- a/back/spec/acceptance/baskets_ideas_spec.rb
+++ b/back/spec/acceptance/baskets_ideas_spec.rb
@@ -194,7 +194,7 @@ resource BasketsIdea do
         end
 
         context 'voting phase is over' do
-          let(:project) { create(:single_voting_phase, start_at: (Date.today - 5.days), end_at: (Date.today - 3.days)).project }
+          let(:project) { create(:single_voting_phase, start_at: (Time.zone.today - 5.days), end_at: (Time.zone.today - 3.days)).project }
 
           example_request '[error] Add an idea to a new basket' do
             assert_status 401

--- a/back/spec/acceptance/baskets_ideas_spec.rb
+++ b/back/spec/acceptance/baskets_ideas_spec.rb
@@ -78,6 +78,14 @@ resource BasketsIdea do
           expect(json_response[:included].pluck(:id)).to include idea_id
         end
       end
+
+      context 'basket is submitted' do
+        let!(:basket) { create(:basket, phase: project.phases.first, user: user, submitted_at: Time.now) }
+
+        example_request '[error] Add an idea to a submitted basket' do
+          assert_status 401
+        end
+      end
     end
 
     patch 'web_api/v1/baskets_ideas/:id' do
@@ -114,6 +122,14 @@ resource BasketsIdea do
           expect(json_response.dig(:data, :attributes, :votes)).to eq 3
         end
       end
+
+      context 'basket is submitted' do
+        let!(:basket) { create(:basket, phase: project.phases.first, user: user, submitted_at: Time.now) }
+
+        example_request '[error] Update an idea in a submitted basket' do
+          assert_status 401
+        end
+      end
     end
 
     delete 'web_api/v1/baskets_ideas/:id' do
@@ -123,6 +139,14 @@ resource BasketsIdea do
       example_request 'Delete a baskets_idea' do
         assert_status 200
         expect { BasketsIdea.find(id) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      context 'basket is submitted' do
+        let!(:basket) { create(:basket, phase: project.phases.first, user: user, submitted_at: Time.now) }
+
+        example_request '[error] Remove an idea from a submitted basket' do
+          assert_status 401
+        end
       end
     end
 
@@ -165,6 +189,14 @@ resource BasketsIdea do
           end
 
           example_request '[error] Not authorized to add an idea to a basket & create the basket' do
+            assert_status 401
+          end
+        end
+
+        context 'voting phase is over' do
+          let(:project) { create(:single_voting_phase, start_at: (Date.today - 5.days), end_at: (Date.today - 3.days)).project }
+
+          example_request '[error] Add an idea to a new basket' do
             assert_status 401
           end
         end
@@ -232,6 +264,14 @@ resource BasketsIdea do
             expect(response_data.dig(:attributes, :votes)).to be_nil
             expect(response_data.dig(:relationships, :idea, :data, :id)).to eq idea_id
             expect(BasketsIdea.find_by(idea: idea)).to be_nil
+          end
+        end
+
+        context 'basket is submitted' do
+          let!(:basket) { create(:basket, phase: project.phases.first, user: user, submitted_at: Time.now) }
+
+          example_request '[error] Add an idea to a submitted basket' do
+            assert_status 401
           end
         end
       end

--- a/back/spec/acceptance/baskets_ideas_spec.rb
+++ b/back/spec/acceptance/baskets_ideas_spec.rb
@@ -10,7 +10,7 @@ resource BasketsIdea do
 
   let(:user) { create(:user) }
   let(:project) { create(:single_phase_multiple_voting_project) }
-  let(:basket) { create(:basket, phase: project.phases.first, user: user) }
+  let(:basket) { create(:basket, phase: project.phases.first, user: user, submitted_at: nil) }
 
   context 'when resident' do
     before { header_token_for user }
@@ -203,7 +203,7 @@ resource BasketsIdea do
       end
 
       context 'basket already exists' do
-        let!(:basket) { create(:basket, phase: project.phases.first, user: user) }
+        let!(:basket) { create(:basket, phase: project.phases.first, user: user, submitted_at: nil) }
 
         context 'basket_idea does not exist' do
           let(:votes) { 2 }

--- a/back/spec/acceptance/baskets_spec.rb
+++ b/back/spec/acceptance/baskets_spec.rb
@@ -171,7 +171,7 @@ resource 'Baskets' do
             end
 
             let(:submitted) { true }
-    
+
             example_request '[error] Submit a basket' do
               assert_status 401
             end

--- a/back/spec/acceptance/baskets_spec.rb
+++ b/back/spec/acceptance/baskets_spec.rb
@@ -83,6 +83,14 @@ resource 'Baskets' do
 
         expect(response_status).to be >= 400
       end
+
+      context 'when the voting phase is over' do
+        before { @project.phases.first.update!(start_at: (Time.now - 5.days), end_at: (Time.now - 3.days)) }
+
+        example_request '[error] Create a basket' do
+          assert_status 401
+        end
+      end
     end
   end
 
@@ -154,6 +162,19 @@ resource 'Baskets' do
             @basket.reload
             expect(@basket.baskets_ideas.map(&:votes)).to contain_exactly 7, 2, 2
             expect(@basket.total_votes).to eq 11
+          end
+
+          context 'when the voting phase is over' do
+            before do
+              @project.phases.first.update!(start_at: (Time.now - 5.days), end_at: (Time.now - 3.days))
+              @basket.update!(submitted_at: nil)
+            end
+
+            let(:submitted) { true }
+    
+            example_request '[error] Submit a basket' do
+              assert_status 401
+            end
           end
         end
       end

--- a/back/spec/policies/baskets_idea_policy_spec.rb
+++ b/back/spec/policies/baskets_idea_policy_spec.rb
@@ -6,7 +6,7 @@ describe BasketsIdeaPolicy do
   subject { described_class.new(user, baskets_idea) }
 
   let(:context) { create(:single_phase_single_voting_project).phases.first }
-  let(:basket) { create(:basket, phase: context) }
+  let(:basket) { create(:basket, phase: context, submitted_at: nil) }
   let!(:baskets_idea) { create(:baskets_idea, basket: basket) }
 
   let(:scope) { BasketsIdeaPolicy::Scope.new(user, basket.baskets_ideas) }
@@ -44,6 +44,20 @@ describe BasketsIdeaPolicy do
     it { is_expected.to permit(:create)  }
     it { is_expected.to permit(:update)  }
     it { is_expected.to permit(:destroy) }
+
+    it 'indexes the baskets_idea' do
+      expect(scope.resolve.size).to eq 1
+    end
+  end
+
+  context 'for a submitted basket' do
+    let(:basket) { create(:basket, phase: context, submitted_at: Time.now) }
+    let(:user) { basket.user }
+
+    it { is_expected.to permit(:show)    }
+    it { is_expected.not_to permit(:create)  }
+    it { is_expected.not_to permit(:update)  }
+    it { is_expected.not_to permit(:destroy) }
 
     it 'indexes the baskets_idea' do
       expect(scope.resolve.size).to eq 1

--- a/back/spec/policies/baskets_idea_policy_spec.rb
+++ b/back/spec/policies/baskets_idea_policy_spec.rb
@@ -54,7 +54,7 @@ describe BasketsIdeaPolicy do
     let(:basket) { create(:basket, phase: context, submitted_at: Time.now) }
     let(:user) { basket.user }
 
-    it { is_expected.to permit(:show)    }
+    it { is_expected.to permit(:show)        }
     it { is_expected.not_to permit(:create)  }
     it { is_expected.not_to permit(:update)  }
     it { is_expected.not_to permit(:destroy) }


### PR DESCRIPTION
- Only allow making basket changes when not submitted
- Only allow un/submitting when the voting phase is still active (not over yet)

# Changelog

### Fixed
- [TAN-1309] Residents should not be able to change their votes once the voting phase is over.