### PR TITLE
Tan 1535/unused flags fe appconfig

### DIFF
--- a/front/app/api/app_configuration/types.ts
+++ b/front/app/api/app_configuration/types.ts
@@ -183,6 +183,7 @@ export interface IAppConfigurationSettings {
   anonymous_participation?: AppConfigurationFeature;
   custom_idea_statuses?: AppConfigurationFeature;
   idea_custom_copy?: AppConfigurationFeature;
+  intercom?: AppConfigurationFeature;
   satismeter?: AppConfigurationFeature & {
     write_key: string;
   };

--- a/front/app/api/app_configuration/types.ts
+++ b/front/app/api/app_configuration/types.ts
@@ -77,14 +77,6 @@ export interface IAppConfigurationSettings {
     allowed: boolean;
     enabled: boolean;
   };
-  demographic_fields?: {
-    allowed: boolean;
-    enabled: boolean;
-    gender: boolean;
-    birthyear: boolean;
-    domicile: boolean;
-    education: boolean;
-  };
   password_login?: {
     allowed: boolean;
     enabled: boolean;
@@ -139,9 +131,7 @@ export interface IAppConfigurationSettings {
     enabled: boolean;
     url?: string;
   };
-  manual_project_sorting?: AppConfigurationFeature;
   admin_project_templates?: AppConfigurationFeature;
-  pages?: AppConfigurationFeature;
   private_projects?: AppConfigurationFeature;
   maps?: AppConfigurationMapSettings;
   initiatives: ProposalsSettings;
@@ -159,7 +149,6 @@ export interface IAppConfigurationSettings {
     verification_methods: string[];
   };
   volunteering?: AppConfigurationFeature;
-  workshops?: AppConfigurationFeature;
   smart_groups?: AppConfigurationFeature;
   manual_emailing?: AppConfigurationFeature;
   automated_emailing_control?: AppConfigurationFeature;
@@ -179,12 +168,10 @@ export interface IAppConfigurationSettings {
   snap_survey_surveys?: AppConfigurationFeature;
   project_folders?: AppConfigurationFeature;
   bulk_import_ideas?: AppConfigurationFeature;
-  widgets?: AppConfigurationFeature;
   granular_permissions?: AppConfigurationFeature;
   ideaflow_social_sharing?: AppConfigurationFeature;
   initiativeflow_social_sharing?: AppConfigurationFeature;
   machine_translations?: AppConfigurationFeature;
-  custom_maps?: AppConfigurationFeature;
   polls?: AppConfigurationFeature;
   moderation?: AppConfigurationFeature;
   flag_inappropriate_content?: AppConfigurationFeature;
@@ -195,9 +182,7 @@ export interface IAppConfigurationSettings {
   blocking_profanity?: AppConfigurationFeature;
   anonymous_participation?: AppConfigurationFeature;
   custom_idea_statuses?: AppConfigurationFeature;
-  idea_author_change?: AppConfigurationFeature;
   idea_custom_copy?: AppConfigurationFeature;
-  intercom?: AppConfigurationFeature;
   satismeter?: AppConfigurationFeature & {
     write_key: string;
   };

--- a/front/app/components/ConsentManager/destinations.ts
+++ b/front/app/components/ConsentManager/destinations.ts
@@ -12,10 +12,6 @@ export type TCategory = (typeof CATEGORIES)[number];
 
 const destinationConfigs: IDestinationConfig[] = [];
 
-export interface IConsentManagerFeatureMap {}
-export type TConsentManagerFeature =
-  IConsentManagerFeatureMap[keyof IConsentManagerFeatureMap];
-
 export interface IDestinationConfig {
   /** A unique key, used to name the destination in the stored cookie */
   key: IDestination;

--- a/front/app/components/ConsentManager/destinations.ts
+++ b/front/app/components/ConsentManager/destinations.ts
@@ -1,4 +1,7 @@
-import { IAppConfigurationData } from 'api/app_configuration/types';
+import {
+  IAppConfigurationData,
+  TAppConfigurationSetting,
+} from 'api/app_configuration/types';
 import { IUserData } from 'api/users/types';
 
 export interface IDestinationMap {}
@@ -19,7 +22,7 @@ export interface IDestinationConfig {
   /** Destinations are grouped in categories. Under which category should it be listed? */
   category: TCategory | ((tenant: IAppConfigurationData) => TCategory);
   /** The name of the feature flag that should be active for the destination to be functional */
-  feature_flag?: TConsentManagerFeature;
+  feature_flag?: TAppConfigurationSetting;
   /** Can the destination be active for the given user? */
   hasPermission?: (user?: IUserData) => boolean;
   /** Name of the destination shown in the UI */
@@ -59,7 +62,7 @@ export const isDestinationActive = (
 };
 
 function isFeatureActive(
-  featureName: TConsentManagerFeature,
+  featureName: TAppConfigurationSetting,
   appConfig: IAppConfigurationData
 ) {
   return (

--- a/front/app/modules/commercial/google_analytics/index.ts
+++ b/front/app/modules/commercial/google_analytics/index.ts
@@ -15,10 +15,6 @@ declare module 'components/ConsentManager/destinations' {
   export interface IDestinationMap {
     google_analytics: 'google_analytics';
   }
-
-  interface IConsentManagerFeatureMap {
-    google_analytics: 'google_analytics';
-  }
 }
 
 const destinationConfig: IDestinationConfig = {

--- a/front/app/modules/commercial/google_tag_manager/index.tsx
+++ b/front/app/modules/commercial/google_tag_manager/index.tsx
@@ -19,10 +19,6 @@ declare module 'components/ConsentManager/destinations' {
   export interface IDestinationMap {
     google_tag_manager: 'google_tag_manager';
   }
-
-  interface IConsentManagerFeatureMap {
-    google_tag_manager: 'google_tag_manager';
-  }
 }
 
 const destinationConfig: IDestinationConfig = {

--- a/front/app/modules/commercial/intercom/index.ts
+++ b/front/app/modules/commercial/intercom/index.ts
@@ -27,10 +27,6 @@ declare module 'components/ConsentManager/destinations' {
   export interface IDestinationMap {
     intercom: 'intercom';
   }
-
-  interface IConsentManagerFeatureMap {
-    intercom: 'intercom';
-  }
 }
 
 const destinationConfig: IDestinationConfig = {

--- a/front/app/modules/commercial/matomo/index.ts
+++ b/front/app/modules/commercial/matomo/index.ts
@@ -24,10 +24,6 @@ declare module 'components/ConsentManager/destinations' {
   export interface IDestinationMap {
     matomo: 'matomo';
   }
-
-  interface IConsentManagerFeatureMap {
-    matomo: 'matomo';
-  }
 }
 
 const destinationConfig: IDestinationConfig = {

--- a/front/app/modules/commercial/satismeter/index.ts
+++ b/front/app/modules/commercial/satismeter/index.ts
@@ -22,10 +22,6 @@ declare module 'components/ConsentManager/destinations' {
   export interface IDestinationMap {
     satismeter: 'satismeter';
   }
-
-  interface IConsentManagerFeatureMap {
-    satismeter: 'satismeter';
-  }
 }
 
 const destinationConfig: IDestinationConfig = {


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Technical
- Remove unused `IAppConfigurationSettings` setting type definitions (front-end)