### PR TITLE
TAN-1513 Allow project moderators to manage phase custom fields

### DIFF
--- a/front/app/containers/Admin/projects/project/permissions/granular_permissions/components/UserFieldSelection/UserFieldSelection.tsx
+++ b/front/app/containers/Admin/projects/project/permissions/granular_permissions/components/UserFieldSelection/UserFieldSelection.tsx
@@ -175,11 +175,11 @@ const UserFieldSelection = ({
                 label={
                   <Box display="flex">
                     <span
-                      style={
-                        !permissionsCustomFieldsEnabled
-                          ? { color: colors.disabled }
-                          : { color: colors.primary }
-                      }
+                      style={{
+                        color: permissionsCustomFieldsEnabled
+                          ? colors.primary
+                          : colors.disabled,
+                      }}
                     >
                       <FormattedMessage
                         {...messages.useExistingRegistrationQuestions}
@@ -213,11 +213,11 @@ const UserFieldSelection = ({
                     borderColor={colors.grey300}
                   >
                     <Text
-                      style={
-                        !permissionsCustomFieldsEnabled
-                          ? { color: colors.disabled }
-                          : { color: colors.primary }
-                      }
+                      style={{
+                        color: permissionsCustomFieldsEnabled
+                          ? colors.primary
+                          : colors.disabled,
+                      }}
                     >
                       {getTitleFromGlobalFieldId(field, locale)}
                     </Text>

--- a/front/app/containers/Admin/projects/project/permissions/granular_permissions/components/UserFieldSelection/UserFieldSelection.tsx
+++ b/front/app/containers/Admin/projects/project/permissions/granular_permissions/components/UserFieldSelection/UserFieldSelection.tsx
@@ -28,7 +28,6 @@ import useLocale from 'hooks/useLocale';
 import { FormattedMessage, useIntl } from 'utils/cl-intl';
 import FormattedMessageComponent from 'utils/cl-intl/FormattedMessage';
 import { isNilOrError } from 'utils/helperUtils';
-import { isAdmin } from 'utils/permissions/roles';
 
 import messages from '../../containers/Granular/messages';
 import { HandlePermissionChangeProps } from '../../containers/Granular/utils';
@@ -124,8 +123,6 @@ const UserFieldSelection = ({
     return null;
   }
 
-  const userIsAdmin = authUser && isAdmin(authUser);
-
   const showQuestionToggle =
     permission.attributes.permitted_by !== 'everyone_confirmed_email';
 
@@ -162,59 +159,45 @@ const UserFieldSelection = ({
 
         <Box>
           {showQuestionToggle && (
-            <Tippy
-              interactive={true}
-              placement={'bottom'}
-              disabled={userIsAdmin}
-              theme={'dark'}
-              content={
-                <Box style={{ cursor: 'default' }}>
-                  <Text my="8px" color="white" fontSize="s">
-                    {formatMessage(messages.onlyAdmins)}
-                  </Text>
-                </Box>
-              }
-            >
-              <Box mb="10px">
-                <Toggle
-                  checked={permission.attributes.global_custom_fields}
-                  disabled={!permissionsCustomFieldsEnabled || !userIsAdmin}
-                  onChange={() => {
-                    onChange({
-                      phaseId,
-                      permission,
-                      groupIds,
-                      globalCustomFields:
-                        !permission.attributes.global_custom_fields,
-                    });
-                  }}
-                  label={
-                    <Box display="flex">
-                      <span
-                        style={
-                          !permissionsCustomFieldsEnabled || !userIsAdmin
-                            ? { color: colors.disabled }
-                            : { color: colors.primary }
-                        }
-                      >
-                        <FormattedMessage
-                          {...messages.useExistingRegistrationQuestions}
-                        />
-                      </span>
-                      {permissionsCustomFieldsEnabled && (
-                        <IconTooltip
-                          ml="4px"
-                          icon="info-solid"
-                          content={formatMessage(
-                            messages.useExistingRegistrationQuestionsDescription
-                          )}
-                        />
-                      )}
-                    </Box>
-                  }
-                />
-              </Box>
-            </Tippy>
+            <Box mb="10px">
+              <Toggle
+                checked={permission.attributes.global_custom_fields}
+                disabled={!permissionsCustomFieldsEnabled}
+                onChange={() => {
+                  onChange({
+                    phaseId,
+                    permission,
+                    groupIds,
+                    globalCustomFields:
+                      !permission.attributes.global_custom_fields,
+                  });
+                }}
+                label={
+                  <Box display="flex">
+                    <span
+                      style={
+                        !permissionsCustomFieldsEnabled
+                          ? { color: colors.disabled }
+                          : { color: colors.primary }
+                      }
+                    >
+                      <FormattedMessage
+                        {...messages.useExistingRegistrationQuestions}
+                      />
+                    </span>
+                    {permissionsCustomFieldsEnabled && (
+                      <IconTooltip
+                        ml="4px"
+                        icon="info-solid"
+                        content={formatMessage(
+                          messages.useExistingRegistrationQuestionsDescription
+                        )}
+                      />
+                    )}
+                  </Box>
+                }
+              />
+            </Box>
           )}
           {showQuestions && (
             <>

--- a/front/app/containers/Admin/projects/project/permissions/granular_permissions/components/UserFieldSelection/screens/SelectionScreen.tsx
+++ b/front/app/containers/Admin/projects/project/permissions/granular_permissions/components/UserFieldSelection/screens/SelectionScreen.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 
 import { Box, Text, Button, colors } from '@citizenlab/cl2-component-library';
+import Tippy from '@tippyjs/react';
 
+import useAuthUser from 'api/me/useAuthUser';
 import { IPermissionsCustomFieldData } from 'api/permissions_custom_fields/types';
 import { IUserCustomFieldData } from 'api/user_custom_fields/types';
 import { isBuiltInField } from 'api/user_custom_fields/util';
 
-import { FormattedMessage } from 'utils/cl-intl';
+import { FormattedMessage, useIntl } from 'utils/cl-intl';
+import { isAdmin } from 'utils/permissions/roles';
 
 import messages from '../../../containers/Granular/messages';
 
@@ -27,9 +30,12 @@ export const SelectionScreen = ({
   setShowAddFieldPage,
   isLoading,
 }: SelectionScreenProps) => {
+  const { formatMessage } = useIntl();
   const selectedFieldIds = new Set(
     selectedFields?.map((field) => field.relationships.custom_field.data.id)
   );
+  const { data: authUser } = useAuthUser();
+  const userIsAdmin = authUser && isAdmin(authUser);
 
   return (
     <>
@@ -72,20 +78,32 @@ export const SelectionScreen = ({
             </Box>
           ))}
       </Box>
-      <Box display="flex">
-        <Button
-          ml="20px"
-          mb="20px"
-          icon="plus-circle"
-          buttonStyle="secondary"
-          onClick={() => {
-            setShowAddFieldPage(true);
-          }}
-          type="button"
-        >
-          <FormattedMessage {...messages.createANewQuestion} />
-        </Button>
-      </Box>
+      <Tippy
+        disabled={userIsAdmin}
+        content={
+          <Box style={{ cursor: 'default' }}>
+            <Text my="8px" color="white" fontSize="s">
+              {formatMessage(messages.onlyAdminsCreateQuestion)}
+            </Text>
+          </Box>
+        }
+      >
+        <Box display="flex" w="fit-content">
+          <Button
+            ml="20px"
+            mb="20px"
+            icon="plus-circle"
+            buttonStyle="secondary"
+            onClick={() => {
+              setShowAddFieldPage(true);
+            }}
+            type="button"
+            disabled={!userIsAdmin}
+          >
+            <FormattedMessage {...messages.createANewQuestion} />
+          </Button>
+        </Box>
+      </Tippy>
     </>
   );
 };

--- a/front/app/containers/Admin/projects/project/permissions/granular_permissions/containers/Granular/messages.ts
+++ b/front/app/containers/Admin/projects/project/permissions/granular_permissions/containers/Granular/messages.ts
@@ -194,9 +194,9 @@ export default defineMessages({
     id: 'app.containers.AdminPage.groups.permissions.option1',
     defaultMessage: 'Option 1',
   },
-  onlyAdmins: {
-    id: 'app.containers.AdminPage.groups.permissions.onlyAdmins',
-    defaultMessage: 'Only admins can change this setting.',
+  onlyAdminsCreateQuestion: {
+    id: 'app.containers.AdminPage.groups.permissions.onlyAdminsCreateQuestion',
+    defaultMessage: 'Only admins can create a new question.',
   },
   premiumUsersOnly: {
     id: 'app.containers.AdminPage.groups.permissions.premiumUsersOnly',

--- a/front/app/translations/admin/ar-SA.json
+++ b/front/app/translations/admin/ar-SA.json
@@ -1950,7 +1950,6 @@
   "app.containers.AdminPage.groups.permissions.moderatorDeletionConfirmation": "هل أنت متأكد؟",
   "app.containers.AdminPage.groups.permissions.moderatorsNotFound": "لم يتم العثور على مديري المشاريع",
   "app.containers.AdminPage.groups.permissions.noActionsCanBeTakenInThisProject": "لم يُعرض شيء، إذ لا توجد إجراءات يمكن للمستخدم اتخاذها في هذا المشروع.",
-  "app.containers.AdminPage.groups.permissions.onlyAdmins": "يمكن للمسؤولين فقط تغيير هذا الإعداد.",
   "app.containers.AdminPage.groups.permissions.option1": "الخيار 1",
   "app.containers.AdminPage.groups.permissions.pendingInvitation": "دعوة قيد الانتظار",
   "app.containers.AdminPage.groups.permissions.permissionAction_annotating_document_subtitle": "من يمكنه إضافة تعليق توضيحي على المستند؟",

--- a/front/app/translations/admin/ca-ES.json
+++ b/front/app/translations/admin/ca-ES.json
@@ -1574,7 +1574,6 @@
   "app.containers.AdminPage.groups.permissions.moderatorDeletionConfirmation": "Are you sure?",
   "app.containers.AdminPage.groups.permissions.moderatorsNotFound": "No s'han trobat caps de projecte",
   "app.containers.AdminPage.groups.permissions.noActionsCanBeTakenInThisProject": "No es mostra res, perquè no hi ha accions que l'usuari pugui dur a terme en aquest projecte.",
-  "app.containers.AdminPage.groups.permissions.onlyAdmins": "Només els administradors poden canviar aquesta configuració.",
   "app.containers.AdminPage.groups.permissions.option1": "opció 1",
   "app.containers.AdminPage.groups.permissions.pendingInvitation": "Invitació pendent",
   "app.containers.AdminPage.groups.permissions.permissionAction_annotating_document_subtitle": "Qui pot anotar el document?",

--- a/front/app/translations/admin/da-DK.json
+++ b/front/app/translations/admin/da-DK.json
@@ -1950,7 +1950,6 @@
   "app.containers.AdminPage.groups.permissions.moderatorDeletionConfirmation": "Er du sikker?",
   "app.containers.AdminPage.groups.permissions.moderatorsNotFound": "Projektledere ikke fundet",
   "app.containers.AdminPage.groups.permissions.noActionsCanBeTakenInThisProject": "Der vises intet, fordi der ikke er nogen handlinger, som brugeren kan foretage i dette projekt.",
-  "app.containers.AdminPage.groups.permissions.onlyAdmins": "Kun administratorer kan ændre denne indstilling.",
   "app.containers.AdminPage.groups.permissions.option1": "Mulighed 1",
   "app.containers.AdminPage.groups.permissions.pendingInvitation": "Afventende invitation",
   "app.containers.AdminPage.groups.permissions.permissionAction_annotating_document_subtitle": "Hvem kan kommentere dokumentet?",

--- a/front/app/translations/admin/de-DE.json
+++ b/front/app/translations/admin/de-DE.json
@@ -1950,7 +1950,6 @@
   "app.containers.AdminPage.groups.permissions.moderatorDeletionConfirmation": "Sind Sie sicher?",
   "app.containers.AdminPage.groups.permissions.moderatorsNotFound": "Projektmanager*in nicht gefunden",
   "app.containers.AdminPage.groups.permissions.noActionsCanBeTakenInThisProject": "Diese Phase enthält keine aktive Beteiligungsmöglichkeit.",
-  "app.containers.AdminPage.groups.permissions.onlyAdmins": "Nur Admins können diese Einstellung ändern.",
   "app.containers.AdminPage.groups.permissions.option1": "Option 1",
   "app.containers.AdminPage.groups.permissions.pendingInvitation": "Ausstehende Einladung",
   "app.containers.AdminPage.groups.permissions.permissionAction_annotating_document_subtitle": "Wer kann das Dokument mit Anmerkungen versehen?",

--- a/front/app/translations/admin/el-GR.json
+++ b/front/app/translations/admin/el-GR.json
@@ -1574,7 +1574,6 @@
   "app.containers.AdminPage.groups.permissions.moderatorDeletionConfirmation": "Are you sure?",
   "app.containers.AdminPage.groups.permissions.moderatorsNotFound": "Δεν βρέθηκαν οι διαχειριστές του έργου",
   "app.containers.AdminPage.groups.permissions.noActionsCanBeTakenInThisProject": "Δεν εμφανίζεται τίποτα, επειδή δεν υπάρχουν ενέργειες που μπορεί να κάνει ο χρήστης σε αυτό το έργο.",
-  "app.containers.AdminPage.groups.permissions.onlyAdmins": "Μόνο οι διαχειριστές μπορούν να αλλάξουν αυτή τη ρύθμιση.",
   "app.containers.AdminPage.groups.permissions.option1": "Επιλογή 1",
   "app.containers.AdminPage.groups.permissions.pendingInvitation": "Πρόσκληση σε εκκρεμότητα",
   "app.containers.AdminPage.groups.permissions.permissionAction_annotating_document_subtitle": "Ποιος μπορεί να σχολιάσει το έγγραφο;",

--- a/front/app/translations/admin/en-CA.json
+++ b/front/app/translations/admin/en-CA.json
@@ -1950,7 +1950,6 @@
   "app.containers.AdminPage.groups.permissions.moderatorDeletionConfirmation": "Are you sure?",
   "app.containers.AdminPage.groups.permissions.moderatorsNotFound": "Project managers not found",
   "app.containers.AdminPage.groups.permissions.noActionsCanBeTakenInThisProject": "Nothing is shown, because there are no actions the user can take in this project.",
-  "app.containers.AdminPage.groups.permissions.onlyAdmins": "Only admins can change this setting.",
   "app.containers.AdminPage.groups.permissions.option1": "Option 1",
   "app.containers.AdminPage.groups.permissions.pendingInvitation": "Pending invitation",
   "app.containers.AdminPage.groups.permissions.permissionAction_annotating_document_subtitle": "Who can annotate the document?",

--- a/front/app/translations/admin/en-GB.json
+++ b/front/app/translations/admin/en-GB.json
@@ -1950,7 +1950,6 @@
   "app.containers.AdminPage.groups.permissions.moderatorDeletionConfirmation": "Are you sure?",
   "app.containers.AdminPage.groups.permissions.moderatorsNotFound": "Project managers not found",
   "app.containers.AdminPage.groups.permissions.noActionsCanBeTakenInThisProject": "Nothing is shown, because there are no actions the user can take in this project.",
-  "app.containers.AdminPage.groups.permissions.onlyAdmins": "Only admins can change this setting.",
   "app.containers.AdminPage.groups.permissions.option1": "Option 1",
   "app.containers.AdminPage.groups.permissions.pendingInvitation": "Pending invitation",
   "app.containers.AdminPage.groups.permissions.permissionAction_annotating_document_subtitle": "Who can annotate the document?",

--- a/front/app/translations/admin/en-IE.json
+++ b/front/app/translations/admin/en-IE.json
@@ -1950,7 +1950,6 @@
   "app.containers.AdminPage.groups.permissions.moderatorDeletionConfirmation": "Are you sure?",
   "app.containers.AdminPage.groups.permissions.moderatorsNotFound": "Project managers not found",
   "app.containers.AdminPage.groups.permissions.noActionsCanBeTakenInThisProject": "Nothing is shown, because there are no actions the user can take in this project.",
-  "app.containers.AdminPage.groups.permissions.onlyAdmins": "Only admins can change this setting.",
   "app.containers.AdminPage.groups.permissions.option1": "Option 1",
   "app.containers.AdminPage.groups.permissions.pendingInvitation": "Pending invitation",
   "app.containers.AdminPage.groups.permissions.permissionAction_annotating_document_subtitle": "Who can annotate the document?",

--- a/front/app/translations/admin/en.json
+++ b/front/app/translations/admin/en.json
@@ -1950,7 +1950,7 @@
   "app.containers.AdminPage.groups.permissions.moderatorDeletionConfirmation": "Are you sure?",
   "app.containers.AdminPage.groups.permissions.moderatorsNotFound": "Project managers not found",
   "app.containers.AdminPage.groups.permissions.noActionsCanBeTakenInThisProject": "Nothing is shown, because there are no actions the user can take in this project.",
-  "app.containers.AdminPage.groups.permissions.onlyAdmins": "Only admins can change this setting.",
+  "app.containers.AdminPage.groups.permissions.onlyAdminsCreateQuestion": "Only admins can create a new question.",
   "app.containers.AdminPage.groups.permissions.option1": "Option 1",
   "app.containers.AdminPage.groups.permissions.pendingInvitation": "Pending invitation",
   "app.containers.AdminPage.groups.permissions.permissionAction_annotating_document_subtitle": "Who can annotate the document?",

--- a/front/app/translations/admin/es-CL.json
+++ b/front/app/translations/admin/es-CL.json
@@ -1950,7 +1950,6 @@
   "app.containers.AdminPage.groups.permissions.moderatorDeletionConfirmation": "¿Estás seguro?",
   "app.containers.AdminPage.groups.permissions.moderatorsNotFound": "No encontramos administradores de proyecto",
   "app.containers.AdminPage.groups.permissions.noActionsCanBeTakenInThisProject": "No se despliega información, debido a que no puedes realizar acciones en este proyecto.",
-  "app.containers.AdminPage.groups.permissions.onlyAdmins": "Sólo los administradores pueden cambiar esta configuración.",
   "app.containers.AdminPage.groups.permissions.option1": "Opción 1",
   "app.containers.AdminPage.groups.permissions.pendingInvitation": "Invitación pendiente",
   "app.containers.AdminPage.groups.permissions.permissionAction_annotating_document_subtitle": "¿Quién puede anotar el documento?",

--- a/front/app/translations/admin/es-ES.json
+++ b/front/app/translations/admin/es-ES.json
@@ -1950,7 +1950,6 @@
   "app.containers.AdminPage.groups.permissions.moderatorDeletionConfirmation": "¿Estás seguro?",
   "app.containers.AdminPage.groups.permissions.moderatorsNotFound": "No encontramos administradores de proyecto",
   "app.containers.AdminPage.groups.permissions.noActionsCanBeTakenInThisProject": "No se despliega información, debido a que no puedes realizar acciones en este proyecto.",
-  "app.containers.AdminPage.groups.permissions.onlyAdmins": "Sólo los administradores pueden cambiar esta configuración.",
   "app.containers.AdminPage.groups.permissions.option1": "Opción 1",
   "app.containers.AdminPage.groups.permissions.pendingInvitation": "Invitación pendiente",
   "app.containers.AdminPage.groups.permissions.permissionAction_annotating_document_subtitle": "¿Quién puede comentar en el documento?",

--- a/front/app/translations/admin/fi-FI.json
+++ b/front/app/translations/admin/fi-FI.json
@@ -1950,7 +1950,6 @@
   "app.containers.AdminPage.groups.permissions.moderatorDeletionConfirmation": "Oletko varma?",
   "app.containers.AdminPage.groups.permissions.moderatorsNotFound": "Projektipäälliköitä ei löydy",
   "app.containers.AdminPage.groups.permissions.noActionsCanBeTakenInThisProject": "Mitään ei näytetä, koska käyttäjä ei voi tehdä toimintoja tässä projektissa.",
-  "app.containers.AdminPage.groups.permissions.onlyAdmins": "Vain järjestelmänvalvojat voivat muuttaa tätä asetusta.",
   "app.containers.AdminPage.groups.permissions.option1": "Vaihtoehto 1",
   "app.containers.AdminPage.groups.permissions.pendingInvitation": "Odottaa kutsua",
   "app.containers.AdminPage.groups.permissions.permissionAction_annotating_document_subtitle": "Kuka voi merkitä asiakirjaan?",

--- a/front/app/translations/admin/fr-BE.json
+++ b/front/app/translations/admin/fr-BE.json
@@ -1950,7 +1950,6 @@
   "app.containers.AdminPage.groups.permissions.moderatorDeletionConfirmation": "Etes-vous sûr ?",
   "app.containers.AdminPage.groups.permissions.moderatorsNotFound": "Administrateurs projet introuvables",
   "app.containers.AdminPage.groups.permissions.noActionsCanBeTakenInThisProject": "Rien n'est montré, car il n'y a pas d'actions que l'utilisateur peut entreprendre dans ce projet.",
-  "app.containers.AdminPage.groups.permissions.onlyAdmins": "Seuls les administrateurs peuvent modifier ce paramètre.",
   "app.containers.AdminPage.groups.permissions.option1": "Option 1",
   "app.containers.AdminPage.groups.permissions.pendingInvitation": "Invitation en attente",
   "app.containers.AdminPage.groups.permissions.permissionAction_annotating_document_subtitle": "Qui peut annoter le document ?",

--- a/front/app/translations/admin/fr-FR.json
+++ b/front/app/translations/admin/fr-FR.json
@@ -1950,7 +1950,6 @@
   "app.containers.AdminPage.groups.permissions.moderatorDeletionConfirmation": "Etes-vous sûr ?",
   "app.containers.AdminPage.groups.permissions.moderatorsNotFound": "Administrateurs projet introuvables",
   "app.containers.AdminPage.groups.permissions.noActionsCanBeTakenInThisProject": "Rien n'est montré, car il n'y a pas d'actions que l'utilisateur peut entreprendre dans ce projet.",
-  "app.containers.AdminPage.groups.permissions.onlyAdmins": "Seuls les administrateurs peuvent modifier ce paramètre.",
   "app.containers.AdminPage.groups.permissions.option1": "Option 1",
   "app.containers.AdminPage.groups.permissions.pendingInvitation": "Invitation en attente",
   "app.containers.AdminPage.groups.permissions.permissionAction_annotating_document_subtitle": "Qui peut annoter le document ?",

--- a/front/app/translations/admin/hr-HR.json
+++ b/front/app/translations/admin/hr-HR.json
@@ -1950,7 +1950,6 @@
   "app.containers.AdminPage.groups.permissions.moderatorDeletionConfirmation": "Jeste li sigurni?",
   "app.containers.AdminPage.groups.permissions.moderatorsNotFound": "Nisu pronađeni voditelji projekata",
   "app.containers.AdminPage.groups.permissions.noActionsCanBeTakenInThisProject": "Ništa nije prikazano jer nema radnji koje korisnici mogu obaviti u ovom projektu.",
-  "app.containers.AdminPage.groups.permissions.onlyAdmins": "Samo administratori mogu promijeniti ovu postavku.",
   "app.containers.AdminPage.groups.permissions.option1": "opcija 1",
   "app.containers.AdminPage.groups.permissions.pendingInvitation": "Pozivnica na čekanju",
   "app.containers.AdminPage.groups.permissions.permissionAction_annotating_document_subtitle": "Tko može označiti dokument?",

--- a/front/app/translations/admin/it-IT.json
+++ b/front/app/translations/admin/it-IT.json
@@ -1574,7 +1574,6 @@
   "app.containers.AdminPage.groups.permissions.moderatorDeletionConfirmation": "Are you sure?",
   "app.containers.AdminPage.groups.permissions.moderatorsNotFound": "Project managers not found",
   "app.containers.AdminPage.groups.permissions.noActionsCanBeTakenInThisProject": "Nothing is shown, because there are no actions the user can take in this project.",
-  "app.containers.AdminPage.groups.permissions.onlyAdmins": "Solo gli amministratori possono modificare questa impostazione.",
   "app.containers.AdminPage.groups.permissions.option1": "Opzione 1",
   "app.containers.AdminPage.groups.permissions.pendingInvitation": "Pending invitation",
   "app.containers.AdminPage.groups.permissions.permissionAction_annotating_document_subtitle": "Chi può annotare il documento?",

--- a/front/app/translations/admin/lv-LV.json
+++ b/front/app/translations/admin/lv-LV.json
@@ -1950,7 +1950,6 @@
   "app.containers.AdminPage.groups.permissions.moderatorDeletionConfirmation": "Vai esat pārliecināts?",
   "app.containers.AdminPage.groups.permissions.moderatorsNotFound": "Projektu vadītāji nav atrasti",
   "app.containers.AdminPage.groups.permissions.noActionsCanBeTakenInThisProject": "Nekas nav redzams, jo šajā projektā lietotājs nevar veikt nekādas darbības.",
-  "app.containers.AdminPage.groups.permissions.onlyAdmins": "Šo iestatījumu var mainīt tikai administratori.",
   "app.containers.AdminPage.groups.permissions.option1": "1. iespēja",
   "app.containers.AdminPage.groups.permissions.pendingInvitation": "Neapstiprināts uzaicinājums",
   "app.containers.AdminPage.groups.permissions.permissionAction_annotating_document_subtitle": "Kas var pievienot anotācijas dokumentam?",

--- a/front/app/translations/admin/nb-NO.json
+++ b/front/app/translations/admin/nb-NO.json
@@ -1950,7 +1950,6 @@
   "app.containers.AdminPage.groups.permissions.moderatorDeletionConfirmation": "Er du sikker?",
   "app.containers.AdminPage.groups.permissions.moderatorsNotFound": "Fant ikke prosjektledere",
   "app.containers.AdminPage.groups.permissions.noActionsCanBeTakenInThisProject": "Ingenting vises, fordi det ikke er noen handlinger brukeren kan gjøre i dette prosjektet.",
-  "app.containers.AdminPage.groups.permissions.onlyAdmins": "Bare administratorer kan endre denne innstillingen.",
   "app.containers.AdminPage.groups.permissions.option1": "valg 1",
   "app.containers.AdminPage.groups.permissions.pendingInvitation": "Ventende invitasjon",
   "app.containers.AdminPage.groups.permissions.permissionAction_annotating_document_subtitle": "Hvem kan kommentere dokumentet?",

--- a/front/app/translations/admin/nl-BE.json
+++ b/front/app/translations/admin/nl-BE.json
@@ -1950,7 +1950,6 @@
   "app.containers.AdminPage.groups.permissions.moderatorDeletionConfirmation": "Zeker weten?",
   "app.containers.AdminPage.groups.permissions.moderatorsNotFound": "Geen projectbeheerders gevonden",
   "app.containers.AdminPage.groups.permissions.noActionsCanBeTakenInThisProject": "Er wordt niets getoond, want er zijn geen acties die de gebruiker kan nemen in dit project.",
-  "app.containers.AdminPage.groups.permissions.onlyAdmins": "Alleen platformbeheerders kunnen deze instelling wijzigen.",
   "app.containers.AdminPage.groups.permissions.option1": "Optie 1",
   "app.containers.AdminPage.groups.permissions.pendingInvitation": "Uitnodiging in behandeling",
   "app.containers.AdminPage.groups.permissions.permissionAction_annotating_document_subtitle": "Wie kan het document annoteren?",

--- a/front/app/translations/admin/nl-NL.json
+++ b/front/app/translations/admin/nl-NL.json
@@ -1950,7 +1950,6 @@
   "app.containers.AdminPage.groups.permissions.moderatorDeletionConfirmation": "Zeker weten?",
   "app.containers.AdminPage.groups.permissions.moderatorsNotFound": "Geen projectbeheerders gevonden",
   "app.containers.AdminPage.groups.permissions.noActionsCanBeTakenInThisProject": "Er wordt niets getoond, want er zijn geen acties die de gebruiker kan nemen in dit project.",
-  "app.containers.AdminPage.groups.permissions.onlyAdmins": "Alleen platformbeheerders kunnen deze instelling wijzigen.",
   "app.containers.AdminPage.groups.permissions.option1": "Optie 1",
   "app.containers.AdminPage.groups.permissions.pendingInvitation": "Uitnodiging in behandeling",
   "app.containers.AdminPage.groups.permissions.permissionAction_annotating_document_subtitle": "Wie kan het document annoteren?",

--- a/front/app/translations/admin/pl-PL.json
+++ b/front/app/translations/admin/pl-PL.json
@@ -1950,7 +1950,6 @@
   "app.containers.AdminPage.groups.permissions.moderatorDeletionConfirmation": "Czy na pewno?",
   "app.containers.AdminPage.groups.permissions.moderatorsNotFound": "Nie znaleziono menadżerów projektu",
   "app.containers.AdminPage.groups.permissions.noActionsCanBeTakenInThisProject": "Nic nie jest pokazane, ponieważ nie ma żadnych spraw, do których użytkownik może się zgłosić w tym projekcie.",
-  "app.containers.AdminPage.groups.permissions.onlyAdmins": "Tylko administratorzy mogą zmienić to ustawienie.",
   "app.containers.AdminPage.groups.permissions.option1": "Opcja 1",
   "app.containers.AdminPage.groups.permissions.pendingInvitation": "Zaproszenie oczekujące",
   "app.containers.AdminPage.groups.permissions.permissionAction_annotating_document_subtitle": "Kto może dodawać adnotacje do dokumentu?",

--- a/front/app/translations/admin/pt-BR.json
+++ b/front/app/translations/admin/pt-BR.json
@@ -1950,7 +1950,6 @@
   "app.containers.AdminPage.groups.permissions.moderatorDeletionConfirmation": "Você tem certeza?",
   "app.containers.AdminPage.groups.permissions.moderatorsNotFound": "Administradores de projetos não encontrados",
   "app.containers.AdminPage.groups.permissions.noActionsCanBeTakenInThisProject": "Nada há informações, porque não há ações que o usuário possa realizar neste projeto.",
-  "app.containers.AdminPage.groups.permissions.onlyAdmins": "Apenas os administradores podem alterar esta definição.",
   "app.containers.AdminPage.groups.permissions.option1": "Opção 1",
   "app.containers.AdminPage.groups.permissions.pendingInvitation": "Convite pendente",
   "app.containers.AdminPage.groups.permissions.permissionAction_annotating_document_subtitle": "Quem pode fazer anotações no documento?",

--- a/front/app/translations/admin/sr-Latn.json
+++ b/front/app/translations/admin/sr-Latn.json
@@ -1950,7 +1950,6 @@
   "app.containers.AdminPage.groups.permissions.moderatorDeletionConfirmation": "Da li ste sigurni",
   "app.containers.AdminPage.groups.permissions.moderatorsNotFound": "Nisu pronađeni projektni menadžeri",
   "app.containers.AdminPage.groups.permissions.noActionsCanBeTakenInThisProject": "Ništa nije prikazano, jer nema akcija koje korisnici mogu preduzeti u ovom projektu.",
-  "app.containers.AdminPage.groups.permissions.onlyAdmins": "Само администратори могу да промене ово подешавање.",
   "app.containers.AdminPage.groups.permissions.option1": "Опција 1",
   "app.containers.AdminPage.groups.permissions.pendingInvitation": "Pozivnica na čekanju",
   "app.containers.AdminPage.groups.permissions.permissionAction_annotating_document_subtitle": "Ко може да дода коментаре на документ?",

--- a/front/app/translations/admin/sr-SP.json
+++ b/front/app/translations/admin/sr-SP.json
@@ -1950,7 +1950,6 @@
   "app.containers.AdminPage.groups.permissions.moderatorDeletionConfirmation": "Јеси ли сигуран?",
   "app.containers.AdminPage.groups.permissions.moderatorsNotFound": "Менаџери пројекта нису пронађени",
   "app.containers.AdminPage.groups.permissions.noActionsCanBeTakenInThisProject": "Ништа се не приказује, јер нема радњи које корисник може да предузме у овом пројекту.",
-  "app.containers.AdminPage.groups.permissions.onlyAdmins": "Само администратори могу да промене ово подешавање.",
   "app.containers.AdminPage.groups.permissions.option1": "Опција 1",
   "app.containers.AdminPage.groups.permissions.pendingInvitation": "Позив на чекању",
   "app.containers.AdminPage.groups.permissions.permissionAction_annotating_document_subtitle": "Ко може да дода коментаре на документ?",

--- a/front/app/translations/admin/sv-SE.json
+++ b/front/app/translations/admin/sv-SE.json
@@ -1950,7 +1950,6 @@
   "app.containers.AdminPage.groups.permissions.moderatorDeletionConfirmation": "Är du säker?",
   "app.containers.AdminPage.groups.permissions.moderatorsNotFound": "Projektledare hittades inte",
   "app.containers.AdminPage.groups.permissions.noActionsCanBeTakenInThisProject": "Ingenting visas eftersom det inte finns några åtgärder som användaren kan vidta i det här projektet.",
-  "app.containers.AdminPage.groups.permissions.onlyAdmins": "Endast administratörer kan ändra den här inställningen.",
   "app.containers.AdminPage.groups.permissions.option1": "Alternativ 1",
   "app.containers.AdminPage.groups.permissions.pendingInvitation": "Väntande inbjudan",
   "app.containers.AdminPage.groups.permissions.permissionAction_annotating_document_subtitle": "Vem kan kommentera dokumentet?",

--- a/front/app/translations/admin/tr-TR.json
+++ b/front/app/translations/admin/tr-TR.json
@@ -1950,7 +1950,6 @@
   "app.containers.AdminPage.groups.permissions.moderatorDeletionConfirmation": "Emin misiniz?",
   "app.containers.AdminPage.groups.permissions.moderatorsNotFound": "Proje yöneticileri bulunamadı",
   "app.containers.AdminPage.groups.permissions.noActionsCanBeTakenInThisProject": "Bu projede kullanıcının gerçekleştirebileceği hiçbir eylem olmadığından herhangi bir şey gösterilmiyor.",
-  "app.containers.AdminPage.groups.permissions.onlyAdmins": "Bu ayarı yalnızca yöneticiler değiştirebilir.",
   "app.containers.AdminPage.groups.permissions.option1": "Seçenek 1",
   "app.containers.AdminPage.groups.permissions.pendingInvitation": "Bekleyen davetiye",
   "app.containers.AdminPage.groups.permissions.permissionAction_annotating_document_subtitle": "Belgeye kim açıklama ekleyebilir?",


### PR DESCRIPTION
# Changelog
## Changed
- Project moderators can now manage the demographic questions that are available at the action / phase level of certain participation methods. Project moderator cannot create new questions, this can only be done by a platform admin.