### PR TITLE
TAN-1458 Bug fix: Mismatching tenant names and hosts in Admin HQ

### DIFF
--- a/back/engines/commercial/admin_api/app/controllers/admin_api/tenants_controller.rb
+++ b/back/engines/commercial/admin_api/app/controllers/admin_api/tenants_controller.rb
@@ -70,9 +70,9 @@ module AdminApi
     #
     # @param [Enumerable<Tenant>] tenants
     def serialize_tenants(tenants)
-      configs = AppConfiguration.from_tenants(tenants).sort_by(&:host)
-      tenants.sort_by(&:host).zip(configs).map do |tenant, config|
-        AdminApi::TenantSerializer.new(tenant, app_configuration: config)
+      configs = AppConfiguration.from_tenants(tenants).index_by(&:host)
+      tenants.sort_by(&:host).map do |tenant|
+        AdminApi::TenantSerializer.new(tenant, app_configuration: config[tenant.host])
       end
     end
 

--- a/back/engines/commercial/admin_api/app/controllers/admin_api/tenants_controller.rb
+++ b/back/engines/commercial/admin_api/app/controllers/admin_api/tenants_controller.rb
@@ -72,7 +72,7 @@ module AdminApi
     def serialize_tenants(tenants)
       configs = AppConfiguration.from_tenants(tenants).index_by(&:host)
       tenants.sort_by(&:host).map do |tenant|
-        AdminApi::TenantSerializer.new(tenant, app_configuration: config[tenant.host])
+        AdminApi::TenantSerializer.new(tenant, app_configuration: configs[tenant.host])
       end
     end
 


### PR DESCRIPTION
Strangely one of the tenants had two app configurations associated to it. I manually deleted one of the app configs but the issue persists on admin HQ. But I think this should fix the issue more permanently.


# Changelog

### Fixed
- [TAN-1458] Mismatching tenant names and hosts in Admin HQ
