### PR TITLE
Fix the order of registration settings fields

### DIFF
--- a/front/app/containers/Admin/settings/registration/index.tsx
+++ b/front/app/containers/Admin/settings/registration/index.tsx
@@ -173,12 +173,6 @@ const SettingsRegistrationTab = () => {
                 }
               />
             </SectionField>
-            {userConfirmationIsAllowed && (
-              <ToggleUserConfirmation
-                onChange={handleUserConfirmationToggleChange}
-                isEnabled={userConfirmationToggleIsEnabled}
-              />
-            )}
             <CustomFieldsSignupText
               onCoreSettingWithMultilocChange={
                 handleCoreSettingWithMultilocOnChange
@@ -187,6 +181,12 @@ const SettingsRegistrationTab = () => {
                 latestAppConfigSettings.core.custom_fields_signup_helper_text
               }
             />
+            {userConfirmationIsAllowed && (
+              <ToggleUserConfirmation
+                onChange={handleUserConfirmationToggleChange}
+                isEnabled={userConfirmationToggleIsEnabled}
+              />
+            )}
             <SubmitWrapper
               loading={isFormSubmitting}
               status={getSubmitState({


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Order of registration settings fields. A registration 'helper text' field was under the 'Account confirmation' heading. ([Before](https://github.com/CitizenLabDotCo/citizenlab/assets/16427929/98fe1d3c-f938-48db-a013-1e5c60fa5420)/[after](https://github.com/CitizenLabDotCo/citizenlab/assets/16427929/ade3bcd3-5dd8-4697-b461-97ff9d50950e))
