### PR TITLE
[TAN-1592] Serialize stats with campaign response if manual and sent

### DIFF
--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaign.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaign.rb
@@ -117,6 +117,10 @@ module EmailCampaigns
       CampaignPolicy
     end
 
+    def manual?
+      false
+    end
+
     protected
 
     def set_enabled

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/manual.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/manual.rb
@@ -65,6 +65,10 @@ module EmailCampaigns
       }]
     end
 
+    def manual?
+      true
+    end
+
     private
 
     def user_filter_no_invitees(users_scope, _options = {})

--- a/back/engines/free/email_campaigns/app/serializers/email_campaigns/web_api/v1/campaign_serializer.rb
+++ b/back/engines/free/email_campaigns/app/serializers/email_campaigns/web_api/v1/campaign_serializer.rb
@@ -70,6 +70,12 @@ module EmailCampaigns
       end
     end
 
+    attribute :stats, if: proc { |object|
+      object.manual? && object.sent?
+    } do |object|
+      Delivery.status_counts(object.id)
+    end
+
     attribute :sender, if: proc { |object|
       sender_configurable? object
     }

--- a/back/engines/free/email_campaigns/app/serializers/email_campaigns/web_api/v1/campaign_serializer.rb
+++ b/back/engines/free/email_campaigns/app/serializers/email_campaigns/web_api/v1/campaign_serializer.rb
@@ -70,7 +70,7 @@ module EmailCampaigns
       end
     end
 
-    attribute :stats, if: proc { |object|
+    attribute :delivery_stats, if: proc { |object|
       object.manual? && object.sent?
     } do |object|
       Delivery.status_counts(object.id)

--- a/back/engines/free/email_campaigns/spec/acceptance/campaigns_spec.rb
+++ b/back/engines/free/email_campaigns/spec/acceptance/campaigns_spec.rb
@@ -91,6 +91,23 @@ resource 'Campaigns' do
       json_response = json_parse(response_body)
       expect(json_response.dig(:data, :id)).to eq id
     end
+
+    example 'Get a manual campaign that has been sent' do
+      create_list(:delivery, 5, campaign: campaign)
+      do_request
+      assert_status 200
+      json_response = json_parse(response_body)
+      expect(json_response[:data][:attributes][:stats]).to match({
+        sent: 5,
+        bounced: 0,
+        failed: 0,
+        accepted: 0,
+        delivered: 0,
+        opened: 0,
+        clicked: 0,
+        total: 5
+      })
+    end
   end
 
   get '/web_api/v1/campaigns/:id/preview' do

--- a/back/engines/free/email_campaigns/spec/acceptance/campaigns_spec.rb
+++ b/back/engines/free/email_campaigns/spec/acceptance/campaigns_spec.rb
@@ -38,6 +38,27 @@ resource 'Campaigns' do
       expect(json_response[:data].size).to eq 3
     end
 
+    example 'List all manual campaigns when some have been sent' do
+      create_list(:delivery, 5, campaign: @campaigns.first)
+      do_request(campaign_names: ['manual'])
+      json_response = json_parse(response_body)
+      expect(json_response[:data].size).to eq 3
+
+      sent_campaign = json_response[:data].find { |c| c[:id] == @campaigns.first.id }
+      unsent_campaign = json_response[:data].find { |c| c[:id] == @campaigns.second.id }
+      expect(sent_campaign[:attributes][:stats]).to match({
+        sent: 5,
+        bounced: 0,
+        failed: 0,
+        accepted: 0,
+        delivered: 0,
+        opened: 0,
+        clicked: 0,
+        total: 5
+      })
+      expect(unsent_campaign[:attributes][:stats]).to be_nil
+    end
+
     example 'List all non-manual campaigns' do
       do_request(without_campaign_names: ['manual'])
       json_response = json_parse(response_body)

--- a/back/engines/free/email_campaigns/spec/acceptance/campaigns_spec.rb
+++ b/back/engines/free/email_campaigns/spec/acceptance/campaigns_spec.rb
@@ -46,7 +46,7 @@ resource 'Campaigns' do
 
       sent_campaign = json_response[:data].find { |c| c[:id] == @campaigns.first.id }
       unsent_campaign = json_response[:data].find { |c| c[:id] == @campaigns.second.id }
-      expect(sent_campaign[:attributes][:stats]).to match({
+      expect(sent_campaign[:attributes][:delivery_stats]).to match({
         sent: 5,
         bounced: 0,
         failed: 0,
@@ -90,7 +90,7 @@ resource 'Campaigns' do
       assert_status 200
       json_response = json_parse(response_body)
       expect(json_response.dig(:data, :id)).to eq id
-      expect(json_response[:data][:attributes][:stats]).to be_nil
+      expect(json_response[:data][:attributes][:delivery_stats]).to be_nil
     end
 
     example 'Get a manual campaign that has been sent' do
@@ -98,7 +98,7 @@ resource 'Campaigns' do
       do_request
       assert_status 200
       json_response = json_parse(response_body)
-      expect(json_response[:data][:attributes][:stats]).to match({
+      expect(json_response[:data][:attributes][:delivery_stats]).to match({
         sent: 5,
         bounced: 0,
         failed: 0,

--- a/back/engines/free/email_campaigns/spec/acceptance/campaigns_spec.rb
+++ b/back/engines/free/email_campaigns/spec/acceptance/campaigns_spec.rb
@@ -38,7 +38,7 @@ resource 'Campaigns' do
       expect(json_response[:data].size).to eq 3
     end
 
-    example 'List all manual campaigns when some have been sent' do
+    example 'List all manual campaigns when one has been sent' do
       create_list(:delivery, 5, campaign: @campaigns.first)
       do_request(campaign_names: ['manual'])
       json_response = json_parse(response_body)
@@ -90,6 +90,7 @@ resource 'Campaigns' do
       assert_status 200
       json_response = json_parse(response_body)
       expect(json_response.dig(:data, :id)).to eq id
+      expect(json_response[:data][:attributes][:stats]).to be_nil
     end
 
     example 'Get a manual campaign that has been sent' do


### PR DESCRIPTION
## Why?
Because we will be showing some stats in the list view of custom (Manual) campaigns:

<img width="1704" alt="Screenshot 2024-04-15 at 11 27 11" src="https://github.com/CitizenLabDotCo/citizenlab/assets/3944042/2d739c56-9cbb-4296-8701-91404dfcf20f">

## Release plan
1. These BE changes are merged and released.
2. FE changes to use these newly serialized stats are developed and released
3. BE `CampaignsController#stats` endpoint and route is removed, as will no longer be used.

# Changelog
## Technical
- [TAN-1592] Serialize campaign delivery stats with campaigns responses, if campaign is manual and has been sent.
