### PR TITLE
[TAN-1594] Prevent shift_timestamps from updating que jobs timestamps

### DIFF
--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/tenant_service.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/tenant_service.rb
@@ -103,6 +103,8 @@ module MultiTenancy
       data_listing = Cl2DataListingService.new
 
       data_listing.cl2_schema_leaf_models.each do |claz|
+        next if claz == QueJob
+
         timestamp_attrs = data_listing.timestamp_attributes claz
         if [Activity.name, Tenant.name, AppConfiguration.name].include? claz.name
           timestamp_attrs.delete 'created_at'


### PR DESCRIPTION
# Changelog
## Fixed
- [TAN-1594] Prevent shift_timestamps from updating que jobs timestamps which is currently causing performance issue on production.
