### PR TITLE
[TAN-1622] Extend volunteers XLSX export data

### DIFF
--- a/back/engines/free/volunteering/app/controllers/volunteering/web_api/v1/volunteers_controller.rb
+++ b/back/engines/free/volunteering/app/controllers/volunteering/web_api/v1/volunteers_controller.rb
@@ -31,7 +31,7 @@ module Volunteering
             .includes(:user, :cause)
 
           I18n.with_locale(current_user&.locale) do
-            xlsx = Volunteering::XlsxService.new.generate_xlsx @phase, @volunteers, view_private_attributes: Pundit.policy!(current_user, User).view_private_attributes?
+            xlsx = Volunteering::XlsxService.new.generate_xlsx @phase, @volunteers, view_private_attributes: true
             send_data xlsx, type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', filename: 'volunteers.xlsx'
           end
         end

--- a/back/engines/free/volunteering/app/controllers/volunteering/web_api/v1/volunteers_controller.rb
+++ b/back/engines/free/volunteering/app/controllers/volunteering/web_api/v1/volunteers_controller.rb
@@ -31,7 +31,7 @@ module Volunteering
             .includes(:user, :cause)
 
           I18n.with_locale(current_user&.locale) do
-            xlsx = Volunteering::XlsxService.new.generate_xlsx @phase, @volunteers, view_private_attributes: true
+            xlsx = Volunteering::XlsxService.new.generate_xlsx @phase, @volunteers
             send_data xlsx, type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', filename: 'volunteers.xlsx'
           end
         end

--- a/back/engines/free/volunteering/app/policies/volunteering/volunteer_policy.rb
+++ b/back/engines/free/volunteering/app/policies/volunteering/volunteer_policy.rb
@@ -21,8 +21,7 @@ module Volunteering
     end
 
     def index_xlsx?
-      # TODO: also allow folder moderators
-      user&.active? && (user&.admin? || user&.project_moderator?)
+      user&.active? && (user&.admin? || ProjectPolicy.new(user, record.cause.phase.project).update?)
     end
 
     def create?

--- a/back/engines/free/volunteering/app/policies/volunteering/volunteer_policy.rb
+++ b/back/engines/free/volunteering/app/policies/volunteering/volunteer_policy.rb
@@ -21,7 +21,7 @@ module Volunteering
     end
 
     def index_xlsx?
-      user&.active? && (user&.admin? || moderator_of_project?(record))
+      user&.active? && (user&.admin? || user&.project_moderator?)
     end
 
     def create?
@@ -32,12 +32,6 @@ module Volunteering
 
     def destroy?
       create?
-    end
-
-    private
-
-    def moderator_of_project?(record)
-      user&.project_moderator? && ProjectPolicy.new(user, record.cause.phase.project).update?
     end
   end
 end

--- a/back/engines/free/volunteering/app/policies/volunteering/volunteer_policy.rb
+++ b/back/engines/free/volunteering/app/policies/volunteering/volunteer_policy.rb
@@ -21,7 +21,7 @@ module Volunteering
     end
 
     def index_xlsx?
-      user&.active? && (user&.admin? || ProjectPolicy.new(user, record.cause.phase.project).update?)
+      user&.active? && (user&.admin? || moderator_of_project?(record))
     end
 
     def create?
@@ -32,6 +32,12 @@ module Volunteering
 
     def destroy?
       create?
+    end
+
+    private
+
+    def moderator_of_project?(record)
+      user&.project_moderator? && ProjectPolicy.new(user, record.cause.phase.project).update?
     end
   end
 end

--- a/back/engines/free/volunteering/app/services/volunteering/xlsx_service.rb
+++ b/back/engines/free/volunteering/app/services/volunteering/xlsx_service.rb
@@ -14,7 +14,8 @@ module Volunteering
         { header: 'first_name', f: ->(v) { v.user.first_name } },
         { header: 'last_name',  f: ->(v) { v.user.last_name } },
         { header: 'email',      f: ->(v) { v.user.email } },
-        { header: 'date',       f: ->(v) { v.created_at }, skip_sanitization: true }
+        { header: 'date',       f: ->(v) { v.created_at }, skip_sanitization: true },
+        *xlsx_service.user_custom_field_columns(:user)
       ]
 
       unless view_private_attributes

--- a/back/engines/free/volunteering/app/services/volunteering/xlsx_service.rb
+++ b/back/engines/free/volunteering/app/services/volunteering/xlsx_service.rb
@@ -7,7 +7,7 @@ module Volunteering
     def generate_xlsx(
       phase,
       volunteers,
-      view_private_attributes: false
+      view_private_attributes: true
     )
       xlsx_service = ::XlsxService.new
       columns = [

--- a/back/engines/free/volunteering/spec/acceptance/volunteers_spec.rb
+++ b/back/engines/free/volunteering/spec/acceptance/volunteers_spec.rb
@@ -78,7 +78,10 @@ resource 'Volunteering Volunteers' do
       before do
         @phase = create(:volunteering_phase)
         @cause1 = create(:cause, title_multiloc: { en: 'For sure works with very long titles too!!!' }, phase: @phase)
-        @volunteer1 = create(:volunteer, cause: @cause1)
+        create(:custom_field_domicile)
+        area = create(:area, title_multiloc: { 'en' => 'Center' })
+        user = create(:user, custom_field_values: { 'domicile' => area.id })
+        @volunteer1 = create(:volunteer, cause: @cause1, user: user)
         @other_volunteers = create_list(:volunteer, 2, cause: @cause1)
         @cause2 = create(:cause, phase: @phase)
         @volunteers2 = create_list(:volunteer, 3, cause: @cause2)
@@ -101,6 +104,7 @@ resource 'Volunteering Volunteers' do
         expect(worksheets[0][1][1].value).to eq @volunteer1.user.last_name
         expect(worksheets[0][1][2].value).to eq @volunteer1.user.email
         expect(worksheets[0][1][3].value.to_i).to eq @volunteer1.created_at.to_i
+        expect(worksheets[0][1][4].value).to eq 'Center'
       end
 
       describe 'when resident' do

--- a/back/engines/free/volunteering/spec/policies/volunteer_policy_spec.rb
+++ b/back/engines/free/volunteering/spec/policies/volunteer_policy_spec.rb
@@ -61,7 +61,7 @@ describe Volunteering::VolunteerPolicy do
     end
 
     context 'for a moderator NOT of the volunteering project' do
-      let(:user) { create(:user, roles: [{ type: 'project_moderator', project_id: 'fake_id' }]) }
+      let(:user) { create(:user, roles: [{ type: 'project_moderator', project_id: create(:project).id }]) }
 
       it { is_expected.not_to permit(:create) }
       it { is_expected.not_to permit(:destroy) }

--- a/back/engines/free/volunteering/spec/policies/volunteer_policy_spec.rb
+++ b/back/engines/free/volunteering/spec/policies/volunteer_policy_spec.rb
@@ -48,7 +48,7 @@ describe Volunteering::VolunteerPolicy do
       end
     end
 
-    context 'for a moderator of the volunteering project' do
+    context 'for a project moderator' do
       let(:user) { create(:user, roles: [{ type: 'project_moderator', project_id: project.id }]) }
 
       it { is_expected.not_to permit(:create) }
@@ -57,18 +57,6 @@ describe Volunteering::VolunteerPolicy do
 
       it 'indexes the volunteer' do
         expect(scope.resolve.size).to eq 1
-      end
-    end
-
-    context 'for a moderator NOT of the volunteering project' do
-      let(:user) { create(:user, roles: [{ type: 'project_moderator', project_id: create(:project).id }]) }
-
-      it { is_expected.not_to permit(:create) }
-      it { is_expected.not_to permit(:destroy) }
-      it { is_expected.not_to permit(:index_xlsx) }
-
-      it 'does not index the volunteer' do
-        expect(scope.resolve.size).to eq 0
       end
     end
 

--- a/back/engines/free/volunteering/spec/policies/volunteer_policy_spec.rb
+++ b/back/engines/free/volunteering/spec/policies/volunteer_policy_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Volunteering::VolunteerPolicy do
+  subject { described_class.new(user, volunteer) }
+
+  let(:scope) { described_class::Scope.new(user, cause.volunteers) }
+
+  context 'on volunteer in a public project' do
+    let(:project) { create(:single_phase_volunteering_project) }
+    let(:cause) { create(:cause, phase: project.phases.first) }
+    let!(:volunteer) { create(:volunteer, cause: cause) }
+
+    context 'for a visitor' do
+      let(:user) { nil }
+
+      it { is_expected.not_to permit(:create) }
+      it { is_expected.not_to permit(:destroy) }
+      it { is_expected.not_to permit(:index_xlsx) }
+
+      it 'does not index the volunteer' do
+        expect(scope.resolve.size).to eq 0
+      end
+    end
+
+    context 'for a resident' do
+      let(:user) { create(:user) }
+
+      it { is_expected.not_to permit(:create) }
+      it { is_expected.not_to permit(:destroy) }
+      it { is_expected.not_to permit(:index_xlsx) }
+
+      it 'does not index the volunteer' do
+        expect(scope.resolve.size).to eq 0
+      end
+    end
+
+    context 'for an admin' do
+      let(:user) { create(:admin) }
+
+      it { is_expected.not_to permit(:create) }
+      it { is_expected.not_to permit(:destroy) }
+      it { is_expected.to permit(:index_xlsx) }
+
+      it 'indexes the volunteer' do
+        expect(scope.resolve.size).to eq 1
+      end
+    end
+
+    context 'for a moderator of the volunteering project' do
+      let(:user) { create(:user, roles: [{ type: 'project_moderator', project_id: project.id }]) }
+
+      it { is_expected.not_to permit(:create) }
+      it { is_expected.not_to permit(:destroy) }
+      it { is_expected.to permit(:index_xlsx) }
+
+      it 'indexes the volunteer' do
+        expect(scope.resolve.size).to eq 1
+      end
+    end
+
+    context 'for a moderator NOT of the volunteering project' do
+      let(:user) { create(:user, roles: [{ type: 'project_moderator', project_id: 'fake_id' }]) }
+
+      it { is_expected.not_to permit(:create) }
+      it { is_expected.not_to permit(:destroy) }
+      it { is_expected.not_to permit(:index_xlsx) }
+
+      it 'does not index the volunteer' do
+        expect(scope.resolve.size).to eq 0
+      end
+    end
+
+    context 'for the volunteer' do
+      let(:user) { volunteer.user }
+
+      it { is_expected.to permit(:create) }
+      it { is_expected.to permit(:destroy) }
+      it { is_expected.not_to permit(:index_xlsx) }
+
+      it 'does not index the volunteer' do
+        expect(scope.resolve.size).to eq 0
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Adds user `custom_fields` to the exported XLSX.
- Aligns data in XLSX for project moderators with that for admins.

See product specs, [here](https://www.notion.so/citizenlab/Project-Manager-Autonomy-484186aba4a74be0830f6017f21e167b?pvs=4#30a2b7788ac34b5896292e0830371f3a).

# Changelog
## Changed
- [TAN-1622] Volunteer Excel export: Now includes user fields (e.g. 'Gender'). Project manager exports now contain same details as in exports by admins.
