### PR TITLE
Remove volunteering from BE schema

### DIFF
--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -917,18 +917,6 @@
         }
       },
 
-      "volunteering": {
-        "type": "object",
-        "title": "Volunteering",
-        "description": "Allow volunteering.",
-        "additionalProperties": false,
-        "required": ["allowed", "enabled"],
-        "properties": {
-          "allowed": { "type": "boolean", "default": true},
-          "enabled": { "type": "boolean", "default": true}
-        }
-      },
-
       "workshops": {
         "title": "Workshops",
         "type": "object",


### PR DESCRIPTION
Seems like I missed this in https://github.com/CitizenLabDotCo/citizenlab/pull/7605/files.

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Technical
- Also remove the `volunteering` feature from the BE schema