### PR TITLE
Remove texting feature flag check for messaging sidebar item

### DIFF
--- a/front/app/containers/Admin/sideBar/navItems.ts
+++ b/front/app/containers/Admin/sideBar/navItems.ts
@@ -54,7 +54,6 @@ const navItems: NavItem[] = [
     link: '/admin/messaging',
     iconName: 'messages',
     message: 'messaging',
-    featureNames: ['texting'],
   },
   {
     name: 'reporting',


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Show 'Messaging' item in admin sidebar again