### PR TITLE
Fix color contrast issue

### DIFF
--- a/front/app/components/PostCardsComponents/ViewButtons.tsx
+++ b/front/app/components/PostCardsComponents/ViewButtons.tsx
@@ -64,13 +64,6 @@ const ViewButton = styled.button<{ active: boolean }>`
         : 'rgba(132, 147, 158, 0.15)'};
     color: ${(props) =>
       props.active ? colors.white : darken(0.2, props.theme.colors.tenantText)};
-
-    ${StyledIcon} {
-      fill: ${(props) =>
-        props.active
-          ? colors.white
-          : darken(0.2, props.theme.colors.tenantText)};
-    }
   }
 `;
 

--- a/front/app/components/PostCardsComponents/ViewButtons.tsx
+++ b/front/app/components/PostCardsComponents/ViewButtons.tsx
@@ -28,7 +28,7 @@ import tracks from './tracks';
 const Container = styled.div`
   display: flex;
   padding: 4px;
-  background: ${darken(0.06, colors.grey200)};
+  background: #fff;
   border-radius: ${(props) => props.theme.borderRadius};
 `;
 
@@ -41,21 +41,32 @@ const ViewButton = styled.button<{ active: boolean }>`
   padding: 10px 12px;
   font-size: ${fontSizes.base}px;
   border-radius: 3px;
-  background-color: ${(props) => (props.active ? '#fff' : 'transparent')};
-  color: ${colors.textSecondary};
+  background-color: ${(props) =>
+    props.active ? props.theme.colors.tenantSecondary : 'transparent'};
+  color: ${(props) => (props.active ? '#fff' : props.theme.colors.tenantText)};
+  font-weight: ${(props) => (props.active ? 'bold' : 'normal')};
   border-color: transparent;
   box-shadow: ${defaultStyles.boxShadow};
   margin-right: 0;
   display: flex;
   align-items: center;
 
+  ${StyledIcon} {
+    fill: ${(props) =>
+      props.active ? '#fff' : darken(0.2, props.theme.colors.tenantText)};
+  }
+
   &:hover {
     background-color: ${(props) =>
-      props.active ? '#fff' : 'rgba(0,0,0,0.12)'};
-    color: ${darken(0.2, colors.textSecondary)};
+      props.active
+        ? darken(0.15, props.theme.colors.tenantSecondary)
+        : 'rgba(132, 147, 158, 0.15)'};
+    color: ${(props) =>
+      props.active ? '#fff' : darken(0.2, props.theme.colors.tenantText)};
 
     ${StyledIcon} {
-      color: ${darken(0.2, colors.textSecondary)};
+      fill: ${(props) =>
+        props.active ? '#fff' : darken(0.2, props.theme.colors.tenantText)};
     }
   }
 `;

--- a/front/app/components/PostCardsComponents/ViewButtons.tsx
+++ b/front/app/components/PostCardsComponents/ViewButtons.tsx
@@ -28,7 +28,7 @@ import tracks from './tracks';
 const Container = styled.div`
   display: flex;
   padding: 4px;
-  background: #fff;
+  background: ${colors.white};
   border-radius: ${(props) => props.theme.borderRadius};
 `;
 
@@ -43,7 +43,8 @@ const ViewButton = styled.button<{ active: boolean }>`
   border-radius: 3px;
   background-color: ${(props) =>
     props.active ? props.theme.colors.tenantSecondary : 'transparent'};
-  color: ${(props) => (props.active ? '#fff' : props.theme.colors.tenantText)};
+  color: ${(props) =>
+    props.active ? colors.white : props.theme.colors.tenantText};
   font-weight: ${(props) => (props.active ? 'bold' : 'normal')};
   border-color: transparent;
   box-shadow: ${defaultStyles.boxShadow};
@@ -53,7 +54,7 @@ const ViewButton = styled.button<{ active: boolean }>`
 
   ${StyledIcon} {
     fill: ${(props) =>
-      props.active ? '#fff' : darken(0.2, props.theme.colors.tenantText)};
+      props.active ? colors.white : darken(0.2, props.theme.colors.tenantText)};
   }
 
   &:hover {
@@ -62,11 +63,13 @@ const ViewButton = styled.button<{ active: boolean }>`
         ? darken(0.15, props.theme.colors.tenantSecondary)
         : 'rgba(132, 147, 158, 0.15)'};
     color: ${(props) =>
-      props.active ? '#fff' : darken(0.2, props.theme.colors.tenantText)};
+      props.active ? colors.white : darken(0.2, props.theme.colors.tenantText)};
 
     ${StyledIcon} {
       fill: ${(props) =>
-        props.active ? '#fff' : darken(0.2, props.theme.colors.tenantText)};
+        props.active
+          ? colors.white
+          : darken(0.2, props.theme.colors.tenantText)};
     }
   }
 `;

--- a/front/app/components/PostCardsComponents/ViewButtons.tsx
+++ b/front/app/components/PostCardsComponents/ViewButtons.tsx
@@ -58,8 +58,14 @@ const ViewButton = styled.button<{ active: boolean }>`
         }};
 
   ${StyledIcon} {
-    fill: ${(props) =>
-      props.active ? colors.white : darken(0.2, props.theme.colors.tenantText)};
+    ${({ active, theme }) =>
+      active
+        ? {
+            fill: colors.white,
+          }
+        : {
+            fill: darken(0.2, theme.colors.tenantText),
+          }};
   }
 
   &:hover {

--- a/front/app/components/PostCardsComponents/ViewButtons.tsx
+++ b/front/app/components/PostCardsComponents/ViewButtons.tsx
@@ -41,16 +41,23 @@ const ViewButton = styled.button<{ active: boolean }>`
   padding: 10px 12px;
   font-size: ${fontSizes.base}px;
   border-radius: 3px;
-  background-color: ${(props) =>
-    props.active ? props.theme.colors.tenantSecondary : 'transparent'};
-  color: ${(props) =>
-    props.active ? colors.white : props.theme.colors.tenantText};
-  font-weight: ${(props) => (props.active ? 'bold' : 'normal')};
   border-color: transparent;
   box-shadow: ${defaultStyles.boxShadow};
   margin-right: 0;
   display: flex;
   align-items: center;
+  ${({ active, theme }) =>
+    active
+      ? {
+          backgroundColor: theme.colors.tenantSecondary,
+          color: colors.white,
+          fontWeight: 'bold',
+        }
+      : {
+          backgroundColor: 'transparent',
+          color: theme.colors.tenantText,
+          fontWeight: 'normal',
+        }};
 
   ${StyledIcon} {
     fill: ${(props) =>
@@ -58,12 +65,16 @@ const ViewButton = styled.button<{ active: boolean }>`
   }
 
   &:hover {
-    background-color: ${(props) =>
-      props.active
-        ? darken(0.15, props.theme.colors.tenantSecondary)
-        : 'rgba(132, 147, 158, 0.15)'};
-    color: ${(props) =>
-      props.active ? colors.white : darken(0.2, props.theme.colors.tenantText)};
+    ${({ active, theme }) =>
+      active
+        ? {
+            backgroundColor: darken(0.15, theme.colors.tenantSecondary),
+            color: colors.white,
+          }
+        : {
+            backgroundColor: 'rgba(132, 147, 158, 0.15)',
+            color: darken(0.2, theme.colors.tenantText),
+          }};
   }
 `;
 

--- a/front/app/components/PostCardsComponents/ViewButtons.tsx
+++ b/front/app/components/PostCardsComponents/ViewButtons.tsx
@@ -51,12 +51,10 @@ const ViewButton = styled.button<{ active: boolean }>`
       ? {
           backgroundColor: theme.colors.tenantSecondary,
           color: colors.white,
-          fontWeight: 'bold',
         }
       : {
           backgroundColor: 'transparent',
           color: theme.colors.tenantText,
-          fontWeight: 'normal',
         }};
 
   ${StyledIcon} {


### PR DESCRIPTION
# Changelog

## Fixed
- Fix color contrast accessibility failure on proposals page when distinguishing between selected and unselected tabs for list and map. This also makes them uniform by using the values from the theme and similar styling on the statuses

![image](https://github.com/CitizenLabDotCo/citizenlab/assets/12659000/8aac1dea-9e85-4da3-bd5d-36ac7f6d55c9)

