### PR TITLE
1.4.11: Fix Non-text Contrast (AA) failures

### DIFF
--- a/front/app/components/EventCard/EventInformation/index.tsx
+++ b/front/app/components/EventCard/EventInformation/index.tsx
@@ -103,7 +103,7 @@ const EventInformation = ({ event, titleFontSize }: Props) => {
             <Box flexShrink={0} my="auto">
               <Icon
                 my="auto"
-                fill={colors.coolGrey300}
+                fill={theme.colors.tenantPrimary}
                 name="clock"
                 ariaHidden
                 mr={theme.isRtl ? '0px' : '8px'}
@@ -123,7 +123,7 @@ const EventInformation = ({ event, titleFontSize }: Props) => {
               <Box flexShrink={0} my="auto">
                 <Icon
                   my="auto"
-                  fill={colors.coolGrey300}
+                  fill={theme.colors.tenantPrimary}
                   name="position"
                   ariaHidden
                   mr={theme.isRtl ? '0px' : '8px'}
@@ -141,7 +141,7 @@ const EventInformation = ({ event, titleFontSize }: Props) => {
             <Box display="flex" mb="12px">
               <Icon
                 my="auto"
-                fill={colors.coolGrey300}
+                fill={theme.colors.tenantPrimary}
                 name="link"
                 ariaHidden
                 mr="8px"
@@ -172,7 +172,7 @@ const EventInformation = ({ event, titleFontSize }: Props) => {
               <Box flexShrink={0} my="auto">
                 <Icon
                   my="auto"
-                  fill={colors.coolGrey300}
+                  fill={theme.colors.tenantPrimary}
                   name="user"
                   ariaHidden
                   mr={theme.isRtl ? '0px' : '8px'}


### PR DESCRIPTION
# Changelog

## Fixed
- The 4 gray icons within the event cards are informative, but lacked colour contrast: 1,6:1 when compared to their blue background (minimum 3:1). This has been fixed. Their color will now match the tenatPrimary color for a good contrast and a consistent look

Before
![image](https://github.com/CitizenLabDotCo/citizenlab/assets/12659000/65f4ed53-7163-41c5-995f-116ef9df38d5)


After
![image](https://github.com/CitizenLabDotCo/citizenlab/assets/12659000/7cbf29fe-bbb9-4e46-9405-e3c47528168d)

Colour contrast analyser for the defaults
<img width="474" alt="image" src="https://github.com/CitizenLabDotCo/citizenlab/assets/12659000/c85c515c-e7bf-4895-8142-44a500986322">


