### PR TITLE
TAN-1650 - Allow blank email addresses in PDF imports

### DIFF
--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/parsers/idea_base_file_parser.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/parsers/idea_base_file_parser.rb
@@ -104,7 +104,7 @@ module BulkImportIdeas::Parsers
         email = fields.find { |f| f[:name] == locale_email_label }
         email_value = email ? email[:value].gsub(/\s+/, '') : nil # Remove any spaces
         # Remove the email if it does not validate
-        email_value = email_value&.match(User::EMAIL_REGEX) ? email_value : nil
+        email_value = nil unless email_value&.match(User::EMAIL_REGEX)
 
         locale_first_name_label = I18n.with_locale(@locale) { I18n.t('form_builder.pdf_export.first_name') }
         first_name = fields.find { |f| f[:name] == locale_first_name_label }

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/parsers/idea_base_file_parser.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/parsers/idea_base_file_parser.rb
@@ -99,15 +99,13 @@ module BulkImportIdeas::Parsers
       permission = fields.find { |f| f[:name] == locale_permission_label }
       idea_row[:user_consent] = permission && permission[:value].present?
 
-      # Remove consent if any email does not validate
       if idea_row[:user_consent]
         locale_email_label = I18n.with_locale(@locale) { I18n.t('form_builder.pdf_export.email_address') }
         email = fields.find { |f| f[:name] == locale_email_label }
         email_value = email ? email[:value].gsub(/\s+/, '') : nil # Remove any spaces
-        idea_row[:user_consent] = email_value ? email_value.match(User::EMAIL_REGEX) : false
-      end
+        # Remove the email if it does not validate
+        email_value = email_value&.match(User::EMAIL_REGEX) ? email_value : nil
 
-      if idea_row[:user_consent]
         locale_first_name_label = I18n.with_locale(@locale) { I18n.t('form_builder.pdf_export.first_name') }
         first_name = fields.find { |f| f[:name] == locale_first_name_label }
         idea_row[:user_first_name] = first_name[:value] if first_name

--- a/back/engines/commercial/bulk_import_ideas/spec/services/parsers/idea_pdf_file_parser_spec.rb
+++ b/back/engines/commercial/bulk_import_ideas/spec/services/parsers/idea_pdf_file_parser_spec.rb
@@ -151,22 +151,22 @@ describe BulkImportIdeas::Parsers::IdeaPdfFileParser do
       expect(rows[1][:pdf_pages]).to eq [3, 4]
     end
 
-    it 'does not return any personal data if email does not validate' do
+    it 'does not return an email address if email does not validate' do
       ideas = [{
         pdf_pages: [1, 2],
-        fields: { 'First name' => 'John', 'Last name' => 'Rambo', 'Email address' => 'john_rambo.com', 'Permission' => 'X' }
+        fields: { 'First name(s)' => 'John', 'Last name' => 'Rambo', 'Email address' => 'john_rambo.com', 'Permission' => 'X' }
       }]
       rows = service.send(:ideas_to_idea_rows, ideas, import_file)
-      expect(rows[0][:permission]).to be_nil
-      expect(rows[0].keys).not_to include :user_email
-      expect(rows[0].keys).not_to include :user_first_name
-      expect(rows[0].keys).not_to include :user_last_name
+      expect(rows[0][:user_consent]).to be true
+      expect(rows[0][:user_email]).to be_nil
+      expect(rows[0][:user_first_name]).to eq 'John'
+      expect(rows[0][:user_last_name]).to eq 'Rambo'
     end
 
     it 'corrects the email if it has spaces in it' do
       ideas = [{
         pdf_pages: [1, 2],
-        fields: { 'First name' => 'John', 'Last name' => 'Rambo', 'Email address' => 'john  @rambo.com', 'Permission' => 'X' }
+        fields: { 'First name(s)' => 'John', 'Last name' => 'Rambo', 'Email address' => 'john  @rambo.com', 'Permission' => 'X' }
       }]
       rows = service.send(:ideas_to_idea_rows, ideas, import_file)
       expect(rows[0][:user_email]).to eq 'john@rambo.com'


### PR DESCRIPTION
Email address is optional on the PDF, but there was logic that didn't import any users (even if they had given permission for their personal details to be imported) if they didn't have a valid email address.  Have now allowed this as the user model does allow users with just a unique ID. 

Ignore the failing test. This is fixed in one of the other PRs.
