### PR TITLE
[TAN-1647] Fix issue where incorrect input term used on project card

### DIFF
--- a/front/app/components/ProjectCard/index.tsx
+++ b/front/app/components/ProjectCard/index.tsx
@@ -452,7 +452,7 @@ const ProjectCard = memo<InputProps>(
         ? moment.duration(moment(endAt).endOf('day').diff(moment())).humanize()
         : null;
       let countdown: JSX.Element | null = null;
-      const inputTerm = getInputTerm(phases?.data);
+      const inputTerm = getInputTerm(phases?.data, phase?.data);
 
       if (isArchived) {
         countdown = (


### PR DESCRIPTION
# Changelog
## Fixed
- Fixed issue where "Submit your idea" was always shown on project card regardless of selected input term ([before](https://github.com/CitizenLabDotCo/citizenlab/assets/33987955/e611c543-c73a-40a5-88af-c693a1e5e3fa)/[after](https://github.com/CitizenLabDotCo/citizenlab/assets/33987955/30749aea-31d8-4576-93eb-cee4fcc4045d)).
