### PR TITLE
TAN-1668 - Fix moderator disclaimer text appearing as questions

### DIFF
--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_pdf_form_exporter.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_pdf_form_exporter.rb
@@ -99,7 +99,7 @@ module BulkImportIdeas::Exporters
       return if logo.blank? || logo.url&.include?('.gif')
 
       pdf.image URI.open logo.to_s
-      pdf.move_down 10.mm
+      pdf.move_down 5.mm
     end
 
     def write_form_title(pdf)
@@ -112,7 +112,7 @@ module BulkImportIdeas::Exporters
         inline_format: true
       )
 
-      pdf.move_down 9.mm
+      pdf.move_down 5.mm
     end
 
     def write_instructions(pdf)
@@ -156,7 +156,7 @@ module BulkImportIdeas::Exporters
         inline_format: true
       )
 
-      pdf.move_down 4.mm
+      pdf.move_down 2.mm
 
       # Personal data explanation
       participation_method = @phase.participation_method
@@ -237,7 +237,7 @@ module BulkImportIdeas::Exporters
         # if necessary
         write_instructions_and_disclaimers(pdf_group, custom_field)
 
-        pdf_group.move_down 7.mm
+        pdf_group.move_down 5.mm
 
         case field_type
         when 'select'
@@ -267,7 +267,6 @@ module BulkImportIdeas::Exporters
     def write_description(pdf, custom_field)
       description = custom_field.description_multiloc[@locale]
       if description.present?
-        pdf.move_down 3.mm
         paragraphs = parse_html_tags(description)
 
         paragraphs.each do |paragraph|
@@ -282,7 +281,7 @@ module BulkImportIdeas::Exporters
       show_visibility_disclaimer = participation_method.supports_idea_form? && custom_field.answer_visible_to == 'admins'
 
       if show_multiselect_instructions || show_visibility_disclaimer
-        pdf.move_down 5.mm
+        pdf.move_down 2.mm
 
         if show_multiselect_instructions
           pdf.text(
@@ -316,6 +315,7 @@ module BulkImportIdeas::Exporters
 
         pdf.move_down 5.mm
       end
+      pdf.move_up 2.mm
     end
 
     def render_multiple_choice(pdf, custom_field)
@@ -336,67 +336,14 @@ module BulkImportIdeas::Exporters
 
         pdf.move_down 5.mm
       end
+      pdf.move_up 2.mm
     end
 
     def render_text_lines(pdf, lines)
       lines.times do
-        pdf.text '_' * 59, color: '666666', size: 20, leading: 15
+        pdf.text '_' * 59, color: '666666', size: 20, leading: 5
       end
     end
-
-    # TODO: More advanced rendering of linear scale fields not used currently in favour of simple number field
-    # def render_linear_scale(pdf, custom_field)
-    #   max_index = custom_field.maximum - 1
-    #   width = 80.mm
-    #
-    #   if custom_field.maximum > 3
-    #     width = 100.mm
-    #   end
-    #
-    #   if custom_field.maximum > 5
-    #     width = 120.mm
-    #   end
-    #
-    #   # Draw number labels
-    #   (0..max_index).each do |i|
-    #     pdf.indent(((i.to_f / max_index) * width) + 1.8.mm) do
-    #       save_cursor pdf
-    #
-    #       pdf.text((i + 1).to_s)
-    #
-    #       reset_cursor pdf
-    #     end
-    #   end
-    #
-    #   pdf.move_down 7.mm
-    #
-    #   # Draw checkboxes
-    #   (0..max_index).each do |i|
-    #     pdf.stroke_color '000000'
-    #     pdf.stroke_circle(
-    #       [
-    #         3.mm + ((i.to_f / max_index) * width),
-    #         pdf.cursor
-    #       ],
-    #       5
-    #     )
-    #   end
-    #
-    #   pdf.move_down 7.mm
-    #
-    #   # Draw min and max labels
-    #   save_cursor pdf
-    #
-    #   pdf.indent(1.8.mm) do
-    #     pdf.text custom_field.minimum_label_multiloc[@locale]
-    #   end
-    #
-    #   reset_cursor pdf
-    #
-    #   pdf.indent(width + 1.mm) do
-    #     pdf.text custom_field.maximum_label_multiloc[@locale]
-    #   end
-    # end
 
     def parse_html_tags(string)
       string

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_pdf_form_exporter.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_pdf_form_exporter.rb
@@ -313,7 +313,7 @@ module BulkImportIdeas::Exporters
           pdf.text option.title_multiloc[@locale]
         end
 
-        pdf.move_down 5.mm
+        pdf.move_down 4.mm
       end
       pdf.move_up 2.mm
     end
@@ -334,7 +334,7 @@ module BulkImportIdeas::Exporters
           pdf.text option.title_multiloc[@locale]
         end
 
-        pdf.move_down 5.mm
+        pdf.move_down 4.mm
       end
       pdf.move_up 2.mm
     end

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_pdf_form_exporter.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_pdf_form_exporter.rb
@@ -108,7 +108,7 @@ module BulkImportIdeas::Exporters
 
       pdf.text(
         "<b>#{project_title} - #{phase_title}</b>",
-        size: 20,
+        size: 18,
         inline_format: true
       )
 
@@ -118,7 +118,7 @@ module BulkImportIdeas::Exporters
     def write_instructions(pdf)
       pdf.text(
         "<b>#{I18n.with_locale(@locale) { I18n.t('form_builder.pdf_export.instructions') }}</b>",
-        size: 16,
+        size: 14,
         inline_format: true
       )
 
@@ -152,7 +152,7 @@ module BulkImportIdeas::Exporters
       # Personal data header
       pdf.text(
         "<b>#{I18n.with_locale(@locale) { I18n.t('form_builder.pdf_export.personal_data') }}</b>",
-        size: 16,
+        size: 14,
         inline_format: true
       )
 
@@ -259,7 +259,7 @@ module BulkImportIdeas::Exporters
 
       pdf.text(
         "<b>#{custom_field.title_multiloc[@locale]}</b>#{custom_field.required? ? '' : " (#{optional})"}",
-        size: 16,
+        size: 14,
         inline_format: true
       )
     end

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/parsers/idea_pdf_file_parser.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/parsers/idea_pdf_file_parser.rb
@@ -172,6 +172,11 @@ module BulkImportIdeas::Parsers
         if next_question && next_question[:name].split.count > 4
           field[:value] = field[:value].gsub(/#{next_question[:name]}*/, '')
         end
+
+        # Strip out 'this answer may be shared with moderators...' text
+        this_answer_copy = I18n.with_locale(@locale) { I18n.t('form_builder.pdf_export.this_answer') }
+        field[:value] = field[:value].gsub(/\*#{this_answer_copy}/, '')
+
         field[:value] = field[:value].strip
       end
 

--- a/back/engines/commercial/bulk_import_ideas/spec/services/exporters/idea_pdf_form_exporter_spec.rb
+++ b/back/engines/commercial/bulk_import_ideas/spec/services/exporters/idea_pdf_form_exporter_spec.rb
@@ -39,7 +39,7 @@ describe BulkImportIdeas::Exporters::IdeaPdfFormExporter do
   describe 'importer_data' do
     it 'returns form meta data for importer - page count, fields, options and positions' do
       importer_data = service.importer_data
-      expect(importer_data[:page_count]).to eq 2
+      expect(importer_data[:page_count]).to eq 1
       expect(importer_data[:fields].pluck(:key)).to eq %w[
         a_text_field
         number_field

--- a/back/engines/commercial/bulk_import_ideas/spec/services/parsers/idea_pdf_file_parser_spec.rb
+++ b/back/engines/commercial/bulk_import_ideas/spec/services/parsers/idea_pdf_file_parser_spec.rb
@@ -512,6 +512,12 @@ describe BulkImportIdeas::Parsers::IdeaPdfFileParser do
       expect(field[:value]).to eq 'This is the text that we really want.'
     end
 
+    it 'removes moderator disclaimer text' do
+      form_fields[1][:value] = '*This answer will only be shared with moderators, and not to the public. This is the text that we really want.'
+      field = service.send(:process_field_value, form_fields[1], form_fields)
+      expect(field[:value]).to eq 'This is the text that we really want.'
+    end
+
     it 'does not remove text if the next field title has fewer than five words in it' do
       form_fields[1][:value] = 'This is the text that we really want. Four word field title'
       form_fields[2][:name] = 'Four word field title'

--- a/front/app/containers/Admin/projects/project/inputImporter/ReviewSection/IdeaList.tsx
+++ b/front/app/containers/Admin/projects/project/inputImporter/ReviewSection/IdeaList.tsx
@@ -1,6 +1,12 @@
-import React from 'react';
+import React, { useState } from 'react';
 
-import { Box, Text, Button, colors } from '@citizenlab/cl2-component-library';
+import {
+  Box,
+  Text,
+  Button,
+  colors,
+  Spinner,
+} from '@citizenlab/cl2-component-library';
 import moment from 'moment';
 import styled from 'styled-components';
 
@@ -73,6 +79,8 @@ const Idea = ({
     id: idea.relationships.idea_import?.data?.id,
   });
 
+  const [deletingIdea, setDeletingIdea] = useState<string | null>(null);
+
   if (!ideaMetadata) return null;
 
   const { locale } = ideaMetadata.data.attributes;
@@ -81,6 +89,7 @@ const Idea = ({
   const handleDeleteIdea = (ideaId: string) => (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
+    setDeletingIdea(ideaId);
     onDeleteIdea(ideaId);
   };
 
@@ -120,15 +129,21 @@ const Idea = ({
         justifyContent="flex-end"
         alignItems="center"
       >
-        <StyledButton
-          icon="close"
-          iconSize="12px"
-          padding="2px"
-          borderRadius="10px"
-          marginRight="8px"
-          bgColor={colors.teal200}
-          onClick={handleDeleteIdea(idea.id)}
-        />
+        {deletingIdea === idea.id ? (
+          <Box marginRight="8px">
+            <Spinner size="15px" />
+          </Box>
+        ) : (
+          <StyledButton
+            icon="close"
+            iconSize="12px"
+            padding="2px"
+            borderRadius="10px"
+            marginRight="8px"
+            bgColor={colors.teal200}
+            onClick={handleDeleteIdea(idea.id)}
+          />
+        )}
       </Box>
     </StyledBox>
   );


### PR DESCRIPTION
- Similar fix to the last PR - removing text of a known string from the parsed value of the field.
- Also added a small FE change - added a spinner that gets shown when an idea is being deleted. Before there was no real feedback that something was happening
