### PR TITLE
[TAN-1665] Throttle user confirmation requests by user ID from JWT

### DIFF
--- a/back/config/initializers/rack_attack.rb
+++ b/back/config/initializers/rack_attack.rb
@@ -115,9 +115,21 @@ class Rack::Attack
   end
 
   # Confirm by IP.
-  throttle('user/confirm', limit: 5, period: 20.seconds) do |req|
+  throttle('user/confirm/ip', limit: 5, period: 20.seconds) do |req|
     if req.path == '/web_api/v1/user/confirm' && req.post?
       req.ip
+    end
+  end
+
+  # Confirm by user ID from JWT.
+  throttle('user/confirm/id', limit: 10, period: 24.hours) do |req|
+    if req.path == '/web_api/v1/user/confirm' && req.post?
+      begin
+        jwt = req.env['HTTP_AUTHORIZATION']&.split&.last
+        JWT.decode(jwt, nil, false, algorithm: 'RS256').first['sub'] # sub is the user ID
+      rescue JWT::DecodeError
+        # do nothing
+      end
     end
   end
 end

--- a/back/config/initializers/rack_attack.rb
+++ b/back/config/initializers/rack_attack.rb
@@ -110,14 +110,14 @@ class Rack::Attack
   # Resend code by IP.
   throttle('user/resend_code', limit: 10, period: 5.minutes) do |req|
     if req.path == '/web_api/v1/user/resend_code' && req.post?
-      req.ip
+      req.remote_ip
     end
   end
 
   # Confirm by IP.
   throttle('user/confirm/ip', limit: 5, period: 20.seconds) do |req|
     if req.path == '/web_api/v1/user/confirm' && req.post?
-      req.ip
+      req.remote_ip
     end
   end
 

--- a/back/config/initializers/rack_attack.rb
+++ b/back/config/initializers/rack_attack.rb
@@ -108,21 +108,21 @@ class Rack::Attack
   end
 
   # Resend code by IP.
-  throttle('user/resend_code', limit: 10, period: 5.minutes) do |req|
+  throttle('resend_code/ip', limit: 10, period: 5.minutes) do |req|
     if req.path == '/web_api/v1/user/resend_code' && req.post?
       req.remote_ip
     end
   end
 
   # Confirm by IP.
-  throttle('user/confirm/ip', limit: 5, period: 20.seconds) do |req|
+  throttle('confirm/ip', limit: 5, period: 20.seconds) do |req|
     if req.path == '/web_api/v1/user/confirm' && req.post?
       req.remote_ip
     end
   end
 
   # Confirm by user ID from JWT.
-  throttle('user/confirm/id', limit: 10, period: 24.hours) do |req|
+  throttle('confirm/id', limit: 10, period: 24.hours) do |req|
     if req.path == '/web_api/v1/user/confirm' && req.post?
       begin
         jwt = req.env['HTTP_AUTHORIZATION']&.split&.last

--- a/back/spec/requests/rack_attack_spec.rb
+++ b/back/spec/requests/rack_attack_spec.rb
@@ -369,6 +369,7 @@ describe 'Rack::Attack' do
     end
 
     travel_to(start_time + 23.hours) do
+      headers['REMOTE_ADDR'] = '1.2.3.12'
       post(
         '/web_api/v1/user/confirm',
         params: '{ "confirmation": { "code": "12345" } }',
@@ -378,6 +379,7 @@ describe 'Rack::Attack' do
     end
 
     travel_to(start_time + 25.hours) do
+      headers['REMOTE_ADDR'] = '1.2.3.13'
       post(
         '/web_api/v1/user/confirm',
         params: '{ "confirmation": { "code": "12345" } }',

--- a/back/spec/requests/rack_attack_spec.rb
+++ b/back/spec/requests/rack_attack_spec.rb
@@ -342,6 +342,51 @@ describe 'Rack::Attack' do
     end
   end
 
+  it 'limits confirmation requests from same user to 10 in 24 hours' do
+    # Use a different IP for each request, to avoid testing limit by IP
+    token = AuthToken::AuthToken.new(payload: user.to_token_payload).token
+    headers = { 'CONTENT_TYPE' => 'application/json', 'Authorization' => "Bearer #{token}" }
+    start_time = Time.zone.now.midnight # Avoid testing 24-hour period that spans midnight
+
+    travel_to(start_time) do
+      10.times do |i|
+        headers['REMOTE_ADDR'] = "1.2.3.#{i + 1}"
+        post(
+          '/web_api/v1/user/confirm',
+          params: '{ "confirmation": { "code": "12345" } }',
+          headers: headers
+        )
+      end
+      expect(status).to eq(422) # Unprocessable entity == given confirmation code is not correct
+
+      headers['REMOTE_ADDR'] = '1.2.3.11'
+      post(
+        '/web_api/v1/user/confirm',
+        params: '{ "confirmation": { "code": "12345" } }',
+        headers: headers
+      )
+      expect(status).to eq(429) # Too many requests
+    end
+
+    travel_to(start_time + 23.hours) do
+      post(
+        '/web_api/v1/user/confirm',
+        params: '{ "confirmation": { "code": "12345" } }',
+        headers: headers
+      )
+      expect(status).to eq(429) # Too many requests
+    end
+
+    travel_to(start_time + 25.hours) do
+      post(
+        '/web_api/v1/user/confirm',
+        params: '{ "confirmation": { "code": "12345" } }',
+        headers: headers
+      )
+      expect(status).to eq(422) # Unprocessable entity == given confirmation code is not correct
+    end
+  end
+
   # ==================================================================================================================
   # These tests are too slow to include in the CI, due to the number of requests they make, and are therefore skipped.
   # Remove skip statement to run in local dev environment, but do not push/merge that change to master.

--- a/back/spec/requests/rack_attack_spec.rb
+++ b/back/spec/requests/rack_attack_spec.rb
@@ -432,7 +432,7 @@ describe 'Rack::Attack' do
     end
   end
 
-  it 'limits login requests for same email to 100 in 1 day' do # , skip: 'Too slow to include in CI' do
+  it 'limits login requests for same email to 100 in 1 day', skip: 'Too slow to include in CI' do
     # Use a different IP for each request, to avoid testing limit by IP
     10.times do |i|
       # Move time forward, each 10 requests, to avoid testing shorter time-limited rule


### PR DESCRIPTION
Also changes 2 uses of `env.ip` to `env.remote_ip`

# Changelog
## Technical
- [TAN-1665] Throttle user confirmation requests by user ID from JWT token
