### PR TITLE
Avoid Posthog throttling (part 2)

### DIFF
--- a/back/engines/commercial/posthog_integration/config/initializers/posthog.rb
+++ b/back/engines/commercial/posthog_integration/config/initializers/posthog.rb
@@ -33,7 +33,6 @@ POSTHOG_CLIENT = PostHog::Client.new({
 # Our own client for all the other PostHog API calls.
 POSTHOG_CUSTOM_CLIENT = PosthogIntegration::PostHog::Client.new(
   base_uri: config['POSTHOG_HOST'],
-  api_key: config['POSTHOG_API_KEY']
-).tap do |client|
-  client.default_project_id = config['POSTHOG_PROJECT_ID']
-end
+  api_key: config['POSTHOG_API_KEY'],
+  project_id: config['POSTHOG_PROJECT_ID']
+)

--- a/back/engines/commercial/posthog_integration/lib/posthog_integration/post_hog/client.rb
+++ b/back/engines/commercial/posthog_integration/lib/posthog_integration/post_hog/client.rb
@@ -7,8 +7,6 @@ module PosthogIntegration
     class Client
       DEFAULT_BASE_URI = 'https://eu.posthog.com'
 
-      attr_accessor :default_project_id
-
       def initialize(base_uri: nil, api_key: nil, project_id: nil)
         @base_uri = base_uri || ENV.fetch('POSTHOG_HOST', DEFAULT_BASE_URI)
         @base_uri = @base_uri.chomp('/')
@@ -37,7 +35,7 @@ module PosthogIntegration
 
       def delete_person_by_distinct_id(distinct_id, retries: 0)
         response = persons(distinct_id: distinct_id)
-        raise_if_error(response)
+        raise_if_error!(response)
 
         results = response.parse['results']
 
@@ -47,7 +45,7 @@ module PosthogIntegration
         when 1
           person_id = results.first['id']
           delete_response = delete_person(person_id, retries: retries)
-          raise_if_error(delete_response)
+          raise_if_error!(delete_response)
 
           person_id
         else
@@ -56,13 +54,6 @@ module PosthogIntegration
             Expected 0 or 1, got #{results.size}.
           MSG
         end
-      end
-
-      def raise_if_error(response)
-        status = response.status
-        return if !status.client_error? && !status.server_error?
-
-        raise ApiError, response.to_s
       end
 
       private
@@ -86,6 +77,12 @@ module PosthogIntegration
           
           > client.default_project_id = '123'
         MSG
+      end
+
+      def raise_if_error!(response)
+        return if !response.status.client_error? && !response.status.server_error?
+
+        raise ApiError, response.to_s
       end
 
       class ApiError < RuntimeError; end

--- a/back/engines/commercial/posthog_integration/lib/posthog_integration/post_hog/client.rb
+++ b/back/engines/commercial/posthog_integration/lib/posthog_integration/post_hog/client.rb
@@ -19,14 +19,12 @@ module PosthogIntegration
       end
 
       def persons(project_id: default_project_id, **params)
-        return 'test-posthog-specs'
         missing_project_id! unless project_id
 
         http.get("#{@base_uri}/api/projects/#{project_id}/persons", params: params)
       end
 
       def delete_person(id, project_id: default_project_id, retries: 0)
-        return 'test-posthog-specs'
         missing_project_id! unless project_id
 
         response = http.delete("#{@base_uri}/api/projects/#{project_id}/persons/#{id}")

--- a/back/engines/commercial/posthog_integration/lib/posthog_integration/post_hog/client.rb
+++ b/back/engines/commercial/posthog_integration/lib/posthog_integration/post_hog/client.rb
@@ -19,12 +19,14 @@ module PosthogIntegration
       end
 
       def persons(project_id: default_project_id, **params)
+        return 'test-posthog-specs'
         missing_project_id! unless project_id
 
         http.get("#{@base_uri}/api/projects/#{project_id}/persons", params: params)
       end
 
       def delete_person(id, project_id: default_project_id, retries: 0)
+        return 'test-posthog-specs'
         missing_project_id! unless project_id
 
         response = http.delete("#{@base_uri}/api/projects/#{project_id}/persons/#{id}")

--- a/back/engines/commercial/posthog_integration/lib/posthog_integration/post_hog/client.rb
+++ b/back/engines/commercial/posthog_integration/lib/posthog_integration/post_hog/client.rb
@@ -9,8 +9,6 @@ module PosthogIntegration
 
       attr_accessor :default_project_id
 
-      delegate :raise_if_error, to: :class  ###
-
       def initialize(base_uri: nil, api_key: nil)
         @base_uri = base_uri || ENV.fetch('POSTHOG_HOST', DEFAULT_BASE_URI)
         @base_uri = @base_uri.chomp('/')
@@ -63,9 +61,9 @@ module PosthogIntegration
         end
       end
 
-      def self.raise_if_error(response)
+      def raise_if_error(response)
         status = response.status
-        return unless status.client_error? || status.server_error? ###
+        return if !status.client_error? && !status.server_error?
 
         raise ApiError, response.to_s
       end

--- a/back/engines/commercial/posthog_integration/lib/posthog_integration/post_hog/client.rb
+++ b/back/engines/commercial/posthog_integration/lib/posthog_integration/post_hog/client.rb
@@ -9,7 +9,7 @@ module PosthogIntegration
 
       attr_accessor :default_project_id
 
-      delegate :raise_if_error, to: :class
+      delegate :raise_if_error, to: :class  ###
 
       def initialize(base_uri: nil, api_key: nil)
         @base_uri = base_uri || ENV.fetch('POSTHOG_HOST', DEFAULT_BASE_URI)
@@ -65,7 +65,7 @@ module PosthogIntegration
 
       def self.raise_if_error(response)
         status = response.status
-        return unless status.client_error? || status.server_error?
+        return unless status.client_error? || status.server_error? ###
 
         raise ApiError, response.to_s
       end

--- a/back/engines/commercial/posthog_integration/spec/lib/posthog_integration/post_hog/client_spec.rb
+++ b/back/engines/commercial/posthog_integration/spec/lib/posthog_integration/post_hog/client_spec.rb
@@ -23,7 +23,7 @@ describe PosthogIntegration::PostHog::Client do
     it 'sends a delete request' do
       allow(posthog).to receive(:delete_person).and_call_original
       expect { posthog.delete_person_by_distinct_id(user.id) }.not_to raise_error
-      expect(posthog).to have_received(:delete_person).once
+      expect(posthog).to have_received(:delete_person).with(person_id, retries: anything).once
     end
 
     it 'raises error when response is 429 (GET persons) and retries is 0' do
@@ -52,7 +52,7 @@ describe PosthogIntegration::PostHog::Client do
 
       posthog.delete_person_by_distinct_id(user.id, retries: 3)
 
-      expect(posthog).to have_received(:retry_request).thrice # Once for persons, twice for delete_person
+      expect(posthog).to have_received(:retry_request).thrice # Twice for persons, once for delete_person
     end
 
     it 'retries when response is 429 (DELETE persons) and retries > 0' do

--- a/back/engines/commercial/posthog_integration/spec/lib/posthog_integration/post_hog/client_spec.rb
+++ b/back/engines/commercial/posthog_integration/spec/lib/posthog_integration/post_hog/client_spec.rb
@@ -1,9 +1,5 @@
 require 'rails_helper'
 
-# TODO
-# Refactoring
-# Add retry for persons + wait less long + reusable method
-
 describe PosthogIntegration::PostHog::Client do
   let(:base_uri) { 'https://example.com' }
   let(:api_key) { 'fake_api_key' }
@@ -13,93 +9,32 @@ describe PosthogIntegration::PostHog::Client do
   let(:person_id) { 0 }
 
   describe 'delete_person_by_distinct_id' do
-    before { allow(posthog).to receive(:sleep) } # Don't sleep while testing
+    before do
+      allow(posthog).to receive(:sleep) # Don't sleep while testing
+
+      stub_request(:get, "https://example.com/api/projects/#{project_id}/persons?distinct_id=#{user.id}")
+        .with(headers: { 'Authorization' => "Bearer #{api_key}" })
+        .to_return(status: 200, body: persons_response(person_id), headers: { 'Content-Type' => 'application/json' })
+      stub_request(:delete, "https://example.com/api/projects/#{project_id}/persons/#{person_id}")
+        .with(headers: { 'Authorization' => "Bearer #{api_key}" })
+        .to_return(status: 204)
+    end
 
     it 'sends a delete request' do
-
-      # TODO fixture json file
-      persons_response = <<~JSON_RESPONSE
-        {
-          "next": "https://app.posthog.com/api/projects/{project_id}/accounts/?offset=400&limit=100",
-          "previous": "https://app.posthog.com/api/projects/{project_id}/accounts/?offset=400&limit=100",
-          "count": 400,
-          "results": [
-            {
-              "id": #{person_id},
-              "name": "string",
-              "distinct_ids": [
-                "string"
-              ],
-              "properties": null,
-              "created_at": "2019-08-24T14:15:22Z",
-              "uuid": "095be615-a8ad-4c33-8e9c-c7612fbf6c9f"
-            }
-          ]
-        }
-      JSON_RESPONSE
-      stub_request(:get, "https://example.com/api/projects/#{project_id}/persons?distinct_id=#{user.id}")
-        .with(headers: { 'Authorization' => "Bearer #{api_key}" })
-        .to_return(status: 200, body: persons_response, headers: { 'Content-Type' => 'application/json' })
-      stub_request(:delete, "https://example.com/api/projects/#{project_id}/persons/#{person_id}")
-        .with(headers: { 'Authorization' => "Bearer #{api_key}" })
-        .to_return(status: 204)
-
+      allow(posthog).to receive(:delete_person).and_call_original
       expect { posthog.delete_person_by_distinct_id(user.id) }.not_to raise_error
+      expect(posthog).to have_received(:delete_person).once
     end
 
-    it 'reports error when response is 429 (GET person) and retries is 0' do
-      persons_response = <<~JSON_RESPONSE
-        {
-          "next": "https://app.posthog.com/api/projects/{project_id}/accounts/?offset=400&limit=100",
-          "previous": "https://app.posthog.com/api/projects/{project_id}/accounts/?offset=400&limit=100",
-          "count": 400,
-          "results": [
-            {
-              "id": #{person_id},
-              "name": "string",
-              "distinct_ids": [
-                "string"
-              ],
-              "properties": null,
-              "created_at": "2019-08-24T14:15:22Z",
-              "uuid": "095be615-a8ad-4c33-8e9c-c7612fbf6c9f"
-            }
-          ]
-        }
-      JSON_RESPONSE
+    it 'raises error when response is 429 (GET persons) and retries is 0' do
       stub_request(:get, "https://example.com/api/projects/#{project_id}/persons?distinct_id=#{user.id}")
         .with(headers: { 'Authorization' => "Bearer #{api_key}" })
         .to_return(status: 429)
-      stub_request(:delete, "https://example.com/api/projects/#{project_id}/persons/#{person_id}")
-        .with(headers: { 'Authorization' => "Bearer #{api_key}" })
-        .to_return(status: 204)
 
       expect { posthog.delete_person_by_distinct_id(user.id, retries: 0) }.to raise_error(PosthogIntegration::PostHog::Client::ApiError)
     end
 
-    it 'reports error when response is 429 (DELETE person) and retries is 0' do
-      persons_response = <<~JSON_RESPONSE
-        {
-          "next": "https://app.posthog.com/api/projects/{project_id}/accounts/?offset=400&limit=100",
-          "previous": "https://app.posthog.com/api/projects/{project_id}/accounts/?offset=400&limit=100",
-          "count": 400,
-          "results": [
-            {
-              "id": #{person_id},
-              "name": "string",
-              "distinct_ids": [
-                "string"
-              ],
-              "properties": null,
-              "created_at": "2019-08-24T14:15:22Z",
-              "uuid": "095be615-a8ad-4c33-8e9c-c7612fbf6c9f"
-            }
-          ]
-        }
-      JSON_RESPONSE
-      stub_request(:get, "https://example.com/api/projects/#{project_id}/persons?distinct_id=#{user.id}")
-        .with(headers: { 'Authorization' => "Bearer #{api_key}" })
-        .to_return(status: 200, body: persons_response, headers: { 'Content-Type' => 'application/json' })
+    it 'raises error when response is 429 (DELETE persons) and retries is 0' do
       stub_request(:delete, "https://example.com/api/projects/#{project_id}/persons/#{person_id}")
         .with(headers: { 'Authorization' => "Bearer #{api_key}" })
         .to_return(status: 429)
@@ -107,49 +42,83 @@ describe PosthogIntegration::PostHog::Client do
       expect { posthog.delete_person_by_distinct_id(user.id, retries: 0) }.to raise_error(PosthogIntegration::PostHog::Client::ApiError)
     end
 
-    it 'retries when response is 429 (DELETE person) and retries > 0' do
-      persons_response = <<~JSON_RESPONSE
-        {
-          "next": "https://app.posthog.com/api/projects/{project_id}/accounts/?offset=400&limit=100",
-          "previous": "https://app.posthog.com/api/projects/{project_id}/accounts/?offset=400&limit=100",
-          "count": 400,
-          "results": [
-            {
-              "id": #{person_id},
-              "name": "string",
-              "distinct_ids": [
-                "string"
-              ],
-              "properties": null,
-              "created_at": "2019-08-24T14:15:22Z",
-              "uuid": "095be615-a8ad-4c33-8e9c-c7612fbf6c9f"
-            }
-          ]
-        }
-      JSON_RESPONSE
+    it 'retries when response is 429 (GET persons) and retries > 0' do
       stub_request(:get, "https://example.com/api/projects/#{project_id}/persons?distinct_id=#{user.id}")
         .with(headers: { 'Authorization' => "Bearer #{api_key}" })
-        .to_return(status: 200, body: persons_response, headers: { 'Content-Type' => 'application/json' })
+        .to_return(status: 429)
+      allow(posthog).to receive(:persons).with(distinct_id: user.id, retries: 3).and_call_original
+      allow(posthog).to receive(:retry_request).with(retries: 3).and_call_original
+      allow(posthog).to receive(:retry_request).with(retries: 2).and_return(stub_response)
+
+      posthog.delete_person_by_distinct_id(user.id, retries: 3)
+
+      expect(posthog).to have_received(:retry_request).thrice # Once for persons, twice for delete_person
+    end
+
+    it 'retries when response is 429 (DELETE persons) and retries > 0' do
       stub_request(:delete, "https://example.com/api/projects/#{project_id}/persons/#{person_id}")
         .with(headers: { 'Authorization' => "Bearer #{api_key}" })
         .to_return(status: 429)
       allow(posthog).to receive(:delete_person).with(person_id, retries: 3).and_call_original
       allow(posthog).to receive(:retry_request).with(retries: 3).and_call_original
-      status = double()
-      status.stub(:client_error?).and_return(false)
-      status.stub(:server_error?).and_return(false)
-      response = double()
-      response.stub(:status).and_return(status)
-      allow(posthog).to receive(:retry_request).with(retries: 2).and_return(response)
+      allow(posthog).to receive(:retry_request).with(retries: 2).and_return(stub_response)
+
       posthog.delete_person_by_distinct_id(user.id, retries: 3)
+
       expect(posthog).to have_received(:retry_request).thrice # Once for persons, twice for delete_person
     end
 
-    it 'reports error when response is not 429 and retries > 0' do
+    it 'raises error when response is not 429 (GET persons) and retries > 0' do
       stub_request(:get, "https://example.com/api/projects/#{project_id}/persons?distinct_id=#{user.id}")
         .with(headers: { 'Authorization' => "Bearer #{api_key}" })
         .to_return(status: 401)
-        expect { posthog.delete_person_by_distinct_id(user.id, retries: 3) }.to raise_error(PosthogIntegration::PostHog::Client::ApiError)
+      allow(posthog).to receive(:retry_request).and_call_original
+
+      expect { posthog.delete_person_by_distinct_id(user.id, retries: 3) }.to raise_error(PosthogIntegration::PostHog::Client::ApiError)
+      expect(posthog).to have_received(:retry_request).once
     end
+
+    it 'raises error when response is not 429 (DELETE persons) and retries > 0' do
+      stub_request(:delete, "https://example.com/api/projects/#{project_id}/persons/#{person_id}")
+        .with(headers: { 'Authorization' => "Bearer #{api_key}" })
+        .to_return(status: 401)
+      allow(posthog).to receive(:retry_request).and_call_original
+
+      expect { posthog.delete_person_by_distinct_id(user.id, retries: 3) }.to raise_error(PosthogIntegration::PostHog::Client::ApiError)
+      expect(posthog).to have_received(:retry_request).twice
+    end
+  end
+
+  def stub_response
+    status = double()
+    status.stub(:client_error?).and_return(false)
+    status.stub(:server_error?).and_return(false)
+    
+    double().tap do |response|
+      response.stub(:status).and_return(status)
+      response.stub(:parse).and_return(JSON.parse(persons_response))
+    end
+  end
+
+  def persons_response(person_id = 0)
+    <<~JSON_RESPONSE
+      {
+        "next": "https://app.posthog.com/api/projects/{project_id}/accounts/?offset=400&limit=100",
+        "previous": "https://app.posthog.com/api/projects/{project_id}/accounts/?offset=400&limit=100",
+        "count": 400,
+        "results": [
+          {
+            "id": #{person_id},
+            "name": "string",
+            "distinct_ids": [
+              "string"
+            ],
+            "properties": null,
+            "created_at": "2019-08-24T14:15:22Z",
+            "uuid": "095be615-a8ad-4c33-8e9c-c7612fbf6c9f"
+          }
+        ]
+      }
+    JSON_RESPONSE
   end
 end

--- a/back/engines/commercial/posthog_integration/spec/lib/posthog_integration/post_hog/client_spec.rb
+++ b/back/engines/commercial/posthog_integration/spec/lib/posthog_integration/post_hog/client_spec.rb
@@ -37,7 +37,7 @@ describe PosthogIntegration::PostHog::Client do
           ]
         }
       JSON_RESPONSE
-      stub_request(:get, /example\.com\/api\/projects\/#{project_id}\/persons\?distinct_id\=#{user.id}/)
+      stub_request(:get, "https://example.com/api/projects/#{project_id}/persons?distinct_id=#{user.id}")
         .to_return(status: 200, body: persons_response, headers: { 'Content-Type' => 'application/json' })
 
 

--- a/back/engines/commercial/posthog_integration/spec/lib/posthog_integration/post_hog/client_spec.rb
+++ b/back/engines/commercial/posthog_integration/spec/lib/posthog_integration/post_hog/client_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 # TODO
-# Spec exact request matches + headers
 # Spec throttling and retry
 # Refactoring
 # Add retry for persons + wait less long + reusable method
@@ -38,16 +37,11 @@ describe PosthogIntegration::PostHog::Client do
         }
       JSON_RESPONSE
       stub_request(:get, "https://example.com/api/projects/#{project_id}/persons?distinct_id=#{user.id}")
+        .with(headers: { 'Authorization' => "Bearer #{api_key}" })
         .to_return(status: 200, body: persons_response, headers: { 'Content-Type' => 'application/json' })
-
-
       stub_request(:delete, "https://example.com/api/projects/#{project_id}/persons/0")
+        .with(headers: { 'Authorization' => "Bearer #{api_key}" })
         .to_return(status: 204)
-      
-
-      # stub_request(:any, "example.com") ### Does not work
-      # stub_request(:get, "https://something.com/api/projects/fake_project_id/persons?distinct_id=\"#{user.id}\"") ### Does not work
-
 
       expect { posthog.delete_person_by_distinct_id(user.id) }.not_to raise_error
     end

--- a/back/engines/commercial/posthog_integration/spec/lib/posthog_integration/post_hog/client_spec.rb
+++ b/back/engines/commercial/posthog_integration/spec/lib/posthog_integration/post_hog/client_spec.rb
@@ -8,7 +8,7 @@ describe PosthogIntegration::PostHog::Client do
   let(:base_uri) { 'https://example.com' }
   let(:api_key) { 'fake_api_key' }
   let(:project_id) { 'fake_project_id' }
-  let(:posthog) { described_class.new(base_uri: base_uri, api_key: api_key).tap { |client| client.default_project_id = project_id } }
+  let(:posthog) { described_class.new(base_uri: base_uri, api_key: api_key, project_id: project_id) }
   let(:user) { create(:user) }
   let(:person_id) { 0 }
 
@@ -133,13 +133,13 @@ describe PosthogIntegration::PostHog::Client do
       stub_request(:delete, "https://example.com/api/projects/#{project_id}/persons/#{person_id}")
         .with(headers: { 'Authorization' => "Bearer #{api_key}" })
         .to_return(status: 429)
-      allow(posthog).to receive(:delete_person).with(person_id, project_id: project_id, retries: 3).and_call_original
+      allow(posthog).to receive(:delete_person).with(person_id, retries: 3).and_call_original
       status = double()
       status.stub(:client_error?).and_return(false)
       status.stub(:server_error?).and_return(false)
       response = double()
       response.stub(:status).and_return(status)
-      allow(posthog).to receive(:delete_person).with(person_id, project_id: project_id, retries: 2).and_return(response) # HTTP::Response.new(status: 429, request: nil, connection: nil, version: '1.1'))
+      allow(posthog).to receive(:delete_person).with(person_id, retries: 2).and_return(response) # HTTP::Response.new(status: 429, request: nil, connection: nil, version: '1.1'))
       posthog.delete_person_by_distinct_id(user.id, retries: 3)
       expect(posthog).to have_received(:delete_person).twice
     end

--- a/back/engines/commercial/posthog_integration/spec/lib/posthog_integration/post_hog/client_spec.rb
+++ b/back/engines/commercial/posthog_integration/spec/lib/posthog_integration/post_hog/client_spec.rb
@@ -90,11 +90,11 @@ describe PosthogIntegration::PostHog::Client do
   end
 
   def stub_response
-    status = double()
+    status = double
     status.stub(:client_error?).and_return(false)
     status.stub(:server_error?).and_return(false)
-    
-    double().tap do |response|
+
+    double.tap do |response|
       response.stub(:status).and_return(status)
       response.stub(:parse).and_return(JSON.parse(persons_response))
     end

--- a/back/engines/commercial/posthog_integration/spec/lib/posthog_integration/post_hog/client_spec.rb
+++ b/back/engines/commercial/posthog_integration/spec/lib/posthog_integration/post_hog/client_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+# TODO
+# Spec exact request matches + headers
+# Spec throttling and retry
+# Refactoring
+# Add retry for persons + wait less long + reusable method
+
+describe PosthogIntegration::PostHog::Client do
+
+  let(:base_uri) { 'https://example.com' }
+  let(:api_key) { 'fake_api_key' }
+  let(:project_id) { 'fake_project_id' }
+  let(:posthog) { described_class.new(base_uri: base_uri, api_key: api_key).tap { |client| client.default_project_id = project_id } }
+
+  describe 'delete_person_by_distinct_id' do
+    it 'sends a delete request' do
+      user = create(:user)
+
+      # TODO fixture json file
+      persons_response = <<~JSON_RESPONSE
+        {
+          "next": "https://app.posthog.com/api/projects/{project_id}/accounts/?offset=400&limit=100",
+          "previous": "https://app.posthog.com/api/projects/{project_id}/accounts/?offset=400&limit=100",
+          "count": 400,
+          "results": [
+            {
+              "id": 0,
+              "name": "string",
+              "distinct_ids": [
+                "string"
+              ],
+              "properties": null,
+              "created_at": "2019-08-24T14:15:22Z",
+              "uuid": "095be615-a8ad-4c33-8e9c-c7612fbf6c9f"
+            }
+          ]
+        }
+      JSON_RESPONSE
+      stub_request(:get, /example\.com\/api\/projects\/#{project_id}\/persons\?distinct_id\=#{user.id}/)
+        .to_return(status: 200, body: persons_response, headers: { 'Content-Type' => 'application/json' })
+
+
+      stub_request(:delete, /example/)
+        .to_return(status: 204)
+      
+
+      # stub_request(:any, "example.com") ### Does not work
+      # stub_request(:get, "https://something.com/api/projects/fake_project_id/persons?distinct_id=\"#{user.id}\"") ### Does not work
+
+
+      expect { posthog.delete_person_by_distinct_id(user.id) }.not_to raise_error
+    end
+  end
+end

--- a/back/engines/commercial/posthog_integration/spec/lib/posthog_integration/post_hog/client_spec.rb
+++ b/back/engines/commercial/posthog_integration/spec/lib/posthog_integration/post_hog/client_spec.rb
@@ -41,7 +41,7 @@ describe PosthogIntegration::PostHog::Client do
         .to_return(status: 200, body: persons_response, headers: { 'Content-Type' => 'application/json' })
 
 
-      stub_request(:delete, /example/)
+      stub_request(:delete, "https://example.com/api/projects/#{project_id}/persons/0")
         .to_return(status: 204)
       
 

--- a/back/engines/commercial/posthog_integration/spec/lib/posthog_integration/post_hog/client_spec.rb
+++ b/back/engines/commercial/posthog_integration/spec/lib/posthog_integration/post_hog/client_spec.rb
@@ -6,15 +6,17 @@ require 'rails_helper'
 # Add retry for persons + wait less long + reusable method
 
 describe PosthogIntegration::PostHog::Client do
-
   let(:base_uri) { 'https://example.com' }
   let(:api_key) { 'fake_api_key' }
   let(:project_id) { 'fake_project_id' }
   let(:posthog) { described_class.new(base_uri: base_uri, api_key: api_key).tap { |client| client.default_project_id = project_id } }
+  let(:user) { create(:user) }
+  let(:person_id) { 0 }
 
   describe 'delete_person_by_distinct_id' do
+    before { allow(posthog).to receive(:sleep) } # Don't sleep while testing
+
     it 'sends a delete request' do
-      user = create(:user)
 
       # TODO fixture json file
       persons_response = <<~JSON_RESPONSE
@@ -24,7 +26,7 @@ describe PosthogIntegration::PostHog::Client do
           "count": 400,
           "results": [
             {
-              "id": 0,
+              "id": #{person_id},
               "name": "string",
               "distinct_ids": [
                 "string"
@@ -39,11 +41,115 @@ describe PosthogIntegration::PostHog::Client do
       stub_request(:get, "https://example.com/api/projects/#{project_id}/persons?distinct_id=#{user.id}")
         .with(headers: { 'Authorization' => "Bearer #{api_key}" })
         .to_return(status: 200, body: persons_response, headers: { 'Content-Type' => 'application/json' })
-      stub_request(:delete, "https://example.com/api/projects/#{project_id}/persons/0")
+      stub_request(:delete, "https://example.com/api/projects/#{project_id}/persons/#{person_id}")
         .with(headers: { 'Authorization' => "Bearer #{api_key}" })
         .to_return(status: 204)
 
       expect { posthog.delete_person_by_distinct_id(user.id) }.not_to raise_error
+    end
+
+    it 'reports error when response is 429 (GET person) and retries is 0' do
+      persons_response = <<~JSON_RESPONSE
+        {
+          "next": "https://app.posthog.com/api/projects/{project_id}/accounts/?offset=400&limit=100",
+          "previous": "https://app.posthog.com/api/projects/{project_id}/accounts/?offset=400&limit=100",
+          "count": 400,
+          "results": [
+            {
+              "id": #{person_id},
+              "name": "string",
+              "distinct_ids": [
+                "string"
+              ],
+              "properties": null,
+              "created_at": "2019-08-24T14:15:22Z",
+              "uuid": "095be615-a8ad-4c33-8e9c-c7612fbf6c9f"
+            }
+          ]
+        }
+      JSON_RESPONSE
+      stub_request(:get, "https://example.com/api/projects/#{project_id}/persons?distinct_id=#{user.id}")
+        .with(headers: { 'Authorization' => "Bearer #{api_key}" })
+        .to_return(status: 429)
+      stub_request(:delete, "https://example.com/api/projects/#{project_id}/persons/#{person_id}")
+        .with(headers: { 'Authorization' => "Bearer #{api_key}" })
+        .to_return(status: 204)
+
+      expect { posthog.delete_person_by_distinct_id(user.id, retries: 0) }.to raise_error(PosthogIntegration::PostHog::Client::ApiError)
+    end
+
+    it 'reports error when response is 429 (DELETE person) and retries is 0' do
+      persons_response = <<~JSON_RESPONSE
+        {
+          "next": "https://app.posthog.com/api/projects/{project_id}/accounts/?offset=400&limit=100",
+          "previous": "https://app.posthog.com/api/projects/{project_id}/accounts/?offset=400&limit=100",
+          "count": 400,
+          "results": [
+            {
+              "id": #{person_id},
+              "name": "string",
+              "distinct_ids": [
+                "string"
+              ],
+              "properties": null,
+              "created_at": "2019-08-24T14:15:22Z",
+              "uuid": "095be615-a8ad-4c33-8e9c-c7612fbf6c9f"
+            }
+          ]
+        }
+      JSON_RESPONSE
+      stub_request(:get, "https://example.com/api/projects/#{project_id}/persons?distinct_id=#{user.id}")
+        .with(headers: { 'Authorization' => "Bearer #{api_key}" })
+        .to_return(status: 200, body: persons_response, headers: { 'Content-Type' => 'application/json' })
+      stub_request(:delete, "https://example.com/api/projects/#{project_id}/persons/#{person_id}")
+        .with(headers: { 'Authorization' => "Bearer #{api_key}" })
+        .to_return(status: 429)
+
+      expect { posthog.delete_person_by_distinct_id(user.id, retries: 0) }.to raise_error(PosthogIntegration::PostHog::Client::ApiError)
+    end
+
+    it 'retries when response is 429 (DELETE person) and retries > 0' do
+      persons_response = <<~JSON_RESPONSE
+        {
+          "next": "https://app.posthog.com/api/projects/{project_id}/accounts/?offset=400&limit=100",
+          "previous": "https://app.posthog.com/api/projects/{project_id}/accounts/?offset=400&limit=100",
+          "count": 400,
+          "results": [
+            {
+              "id": #{person_id},
+              "name": "string",
+              "distinct_ids": [
+                "string"
+              ],
+              "properties": null,
+              "created_at": "2019-08-24T14:15:22Z",
+              "uuid": "095be615-a8ad-4c33-8e9c-c7612fbf6c9f"
+            }
+          ]
+        }
+      JSON_RESPONSE
+      stub_request(:get, "https://example.com/api/projects/#{project_id}/persons?distinct_id=#{user.id}")
+        .with(headers: { 'Authorization' => "Bearer #{api_key}" })
+        .to_return(status: 200, body: persons_response, headers: { 'Content-Type' => 'application/json' })
+      stub_request(:delete, "https://example.com/api/projects/#{project_id}/persons/#{person_id}")
+        .with(headers: { 'Authorization' => "Bearer #{api_key}" })
+        .to_return(status: 429)
+      allow(posthog).to receive(:delete_person).with(person_id, project_id: project_id, retries: 3).and_call_original
+      status = double()
+      status.stub(:client_error?).and_return(false)
+      status.stub(:server_error?).and_return(false)
+      response = double()
+      response.stub(:status).and_return(status)
+      allow(posthog).to receive(:delete_person).with(person_id, project_id: project_id, retries: 2).and_return(response) # HTTP::Response.new(status: 429, request: nil, connection: nil, version: '1.1'))
+      posthog.delete_person_by_distinct_id(user.id, retries: 3)
+      expect(posthog).to have_received(:delete_person).twice
+    end
+
+    it 'reports error when response is not 429 and retries > 0' do
+      stub_request(:get, "https://example.com/api/projects/#{project_id}/persons?distinct_id=#{user.id}")
+        .with(headers: { 'Authorization' => "Bearer #{api_key}" })
+        .to_return(status: 401)
+        expect { posthog.delete_person_by_distinct_id(user.id, retries: 3) }.to raise_error(PosthogIntegration::PostHog::Client::ApiError)
     end
   end
 end

--- a/back/engines/commercial/posthog_integration/spec/lib/posthog_integration/post_hog/client_spec.rb
+++ b/back/engines/commercial/posthog_integration/spec/lib/posthog_integration/post_hog/client_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 # TODO
-# Spec throttling and retry
 # Refactoring
 # Add retry for persons + wait less long + reusable method
 


### PR DESCRIPTION
- We still receive the throttling exceptions. I forgot to add a retry mechanism for the GET persons endpoint as well, so I suspect that's the issue (I can't see where the error comes from in Sentry).
- There were no specs for the Posthog client, so I added some.
- As the retry mechanism would make the code more messy, I tried to apply the "camping rule": _"Always leave the code base healthier than when you found it."_
