### PR TITLE
TAN-1696 Quickfix: Random options survey bug

### DIFF
--- a/back/app/models/custom_field.rb
+++ b/back/app/models/custom_field.rb
@@ -283,9 +283,7 @@ class CustomField < ApplicationRecord
   end
 
   def ordered_options
-    return [] unless options.any?
-
-    if random_option_ordering
+    @ordered_options ||= if random_option_ordering
       options.shuffle.sort_by { |o| o.other ? 1 : 0 }
     else
       options.order(:ordering)

--- a/back/spec/acceptance/phase_custom_fields_spec.rb
+++ b/back/spec/acceptance/phase_custom_fields_spec.rb
@@ -73,6 +73,49 @@ resource 'Phase level Custom Fields' do
         expect(ui_schema[:options]).to eq({ formId: 'idea-form', inputTerm: 'question' })
         expect(ui_schema[:elements].size).to eq 3
       end
+
+      describe 'Random ordering' do
+        let(:field_key) { :my_field_key }
+        let(:options_mapping) do
+          20.times.map.to_h do |i|
+            multiloc = {
+              en: "My en option #{i}",
+              'fr-FR': "My fr option #{i}",
+              'nl-NL': "My nl option #{i}"
+            }
+            ["my_option_#{i}", multiloc]
+          end
+        end
+        let!(:custom_field) do 
+          create(:custom_field_select, resource: custom_form, random_option_ordering: true, key: field_key).tap do |field|
+            options_mapping.each do |key, multiloc|
+              create(:custom_field_option, custom_field: field, key: key, title_multiloc: multiloc)
+            end
+          end
+        end
+
+        # TODO
+        # List affected surveys
+        # Check if this also happens for multiselect
+        # Apply to other endpoints (projects, users?)
+        example_request 'returns the options in the same random order in the JSON and UI schemas' do
+          assert_status 200
+          json_response = json_parse response_body
+          json_schemas = json_response.dig(:data, :attributes, :json_schema_multiloc)
+          ui_schemas = json_response.dig(:data, :attributes, :ui_schema_multiloc)
+          %i[en fr-FR nl-NL].each do |locale|
+            json_keys = json_schemas.dig(locale, :properties, field_key, :enum)
+            ui_details = ui_schemas.dig(locale, :elements).find{|elt| elt[:label] == 'Details'}
+            ui_names = ui_details[:elements].find{|elt| elt[:scope] == "#/properties/#{field_key}"}.dig(:options, :enumNames)
+
+            expect(json_keys.size).to eq 20
+            expect(ui_names.size).to eq 20
+            json_keys.zip(ui_names).each do |json_key, ui_name|
+              expect(ui_name).to eq options_mapping[json_key][locale]
+            end
+          end
+        end
+      end
     end
   end
 

--- a/back/spec/acceptance/phase_custom_fields_spec.rb
+++ b/back/spec/acceptance/phase_custom_fields_spec.rb
@@ -97,7 +97,6 @@ resource 'Phase level Custom Fields' do
         # TODO
         # List affected surveys
         # Check if this also happens for multiselect
-        # Apply to other endpoints (projects, users?)
         example_request 'returns the options in the same random order in the JSON and UI schemas' do
           assert_status 200
           json_response = json_parse response_body

--- a/back/spec/acceptance/phase_custom_fields_spec.rb
+++ b/back/spec/acceptance/phase_custom_fields_spec.rb
@@ -86,7 +86,7 @@ resource 'Phase level Custom Fields' do
             ["my_option_#{i}", multiloc]
           end
         end
-        let!(:custom_field) do 
+        let!(:custom_field) do
           create(:custom_field_select, resource: custom_form, random_option_ordering: true, key: field_key).tap do |field|
             options_mapping.each do |key, multiloc|
               create(:custom_field_option, custom_field: field, key: key, title_multiloc: multiloc)
@@ -105,8 +105,8 @@ resource 'Phase level Custom Fields' do
           ui_schemas = json_response.dig(:data, :attributes, :ui_schema_multiloc)
           %i[en fr-FR nl-NL].each do |locale|
             json_keys = json_schemas.dig(locale, :properties, field_key, :enum)
-            ui_details = ui_schemas.dig(locale, :elements).find{|elt| elt[:label] == 'Details'}
-            ui_names = ui_details[:elements].find{|elt| elt[:scope] == "#/properties/#{field_key}"}.dig(:options, :enumNames)
+            ui_details = ui_schemas.dig(locale, :elements).find { |elt| elt[:label] == 'Details' }
+            ui_names = ui_details[:elements].find { |elt| elt[:scope] == "#/properties/#{field_key}" }.dig(:options, :enumNames)
 
             expect(json_keys.size).to eq 20
             expect(ui_names.size).to eq 20

--- a/back/spec/services/json_schema_generator_service_spec.rb
+++ b/back/spec/services/json_schema_generator_service_spec.rb
@@ -266,7 +266,7 @@ RSpec.describe JsonSchemaGeneratorService do
         # NOTE: Checking 10 loops to make sure the chance of a flaky test here is very very low
         attempts = []
         10.times do
-          options = generator.visit_multiselect(field).dig(:items, :oneOf).pluck(:const)
+          options = generator.visit_multiselect(CustomField.find(field.id)).dig(:items, :oneOf).pluck(:const)
           expect(options.last).to eq 'other'
           attempts << options
         end

--- a/back/spec/services/ui_schema_generator_service_spec.rb
+++ b/back/spec/services/ui_schema_generator_service_spec.rb
@@ -384,7 +384,7 @@ RSpec.describe UiSchemaGeneratorService do
         # NOTE: Checking 10 loops to make sure the chance of a flaky test here is very very low
         attempts = []
         10.times do
-          options = generator.visit_select(field).dig(:options, :enumNames)
+          options = generator.visit_select(CustomField.find(field.id)).dig(:options, :enumNames)
           expect(options.last).to eq 'Other'
           attempts << options
         end


### PR DESCRIPTION
This should fix the issue where both the JSON and UI schemas are returned in one same request. If at some point, we would use different endpoints to get the two schema's, the bug would come back. So, my proposal is to write down to look into a more robust solution in the [tech debt list](https://www.notion.so/citizenlab/Tech-Issues-Debt-b107ec91cb1b455088f4d83f0212450d) and merge this quickfix for now.

# Changelog

### Fixed
- [TAN-1696] Picking an option in a randomly ordered select field, results in that option being submitted in reality. We had an issue where a random option, likely different from the chosen option, would turn out to be the submitted option instead.
