### PR TITLE
TAN-1702 Fix: Amazon made a braking change to their Anthropic API

### DIFF
--- a/back/engines/commercial/analysis/app/lib/analysis/LLM/anthropic_claude.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/LLM/anthropic_claude.rb
@@ -52,7 +52,7 @@ module Analysis
           'temperature' => 0.1,
           'top_p' => 0.9
         }
-        { model_id: model_id, body: json.to_json }
+        { model_id: model_id, body: json.to_json, content_type: 'application/json' }
       end
 
       def body_completion(body_string)


### PR DESCRIPTION
It seems that something changed in the API that the Amazon Bedrock gem is using, suddenly braking all calls to the Anthropic LLM.

Sentry: https://sentry.hq.citizenlab.co/share/issue/3d168cda379c4601aaba5f7efb45d716/

Reference: https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/BedrockRuntime/Client.html

# Changelog
### Fixed
- [TAN-1702] Toxicity detection suddenly got broken by changes from Amazon.
