### PR TITLE
[TAN-1412] Fix issue where description wasn't changing when browsing projects from dropdown

### DIFF
--- a/front/app/modules/commercial/project_description_builder/admin/components/ContentViewer/Viewer/Viewer.test.tsx
+++ b/front/app/modules/commercial/project_description_builder/admin/components/ContentViewer/Viewer/Viewer.test.tsx
@@ -47,7 +47,13 @@ jest.mock(
 
 describe('Preview', () => {
   it('should shows project description builder content when project description builder is enabled', () => {
-    render(<Preview projectId={projectId} projectTitle={projectTitle} />);
+    render(
+      <Preview
+        projectId={projectId}
+        projectTitle={projectTitle}
+        usesContentBuilder={true}
+      />
+    );
     expect(
       screen.getByTestId('projectDescriptionBuilderPreviewContent')
     ).toBeInTheDocument();

--- a/front/app/modules/commercial/project_description_builder/admin/components/ContentViewer/Viewer/index.tsx
+++ b/front/app/modules/commercial/project_description_builder/admin/components/ContentViewer/Viewer/index.tsx
@@ -23,13 +23,18 @@ import Editor from '../../Editor';
 type PreviewProps = {
   projectId: string;
   projectTitle: Multiloc;
+  usesContentBuilder?: boolean;
 };
 
 const handleLoadImages = () => {
   eventEmitter.emit(IMAGES_LOADED_EVENT);
 };
 
-const Preview = ({ projectId, projectTitle }: PreviewProps) => {
+const Preview = ({
+  projectId,
+  projectTitle,
+  usesContentBuilder,
+}: PreviewProps) => {
   const localize = useLocalize();
   const { data: projectFiles } = useProjectFiles(projectId);
 
@@ -48,29 +53,32 @@ const Preview = ({ projectId, projectTitle }: PreviewProps) => {
   return (
     <Box data-testid="projectDescriptionBuilderPreview">
       {isInitialLoading && <Spinner />}
-      {!isInitialLoading && projectDescriptionBuilderContent && (
-        <Box data-testid="projectDescriptionBuilderPreviewContent">
-          <Title color="tenantText" variant="h1">
-            {localize(projectTitle)}
-          </Title>
-          <Editor isPreview={true}>
-            <ContentBuilderFrame
-              editorData={editorData}
-              onLoadImages={handleLoadImages}
-            />
-          </Editor>
-          {projectFiles && (
-            <Box maxWidth="750px" mb="25px">
-              <FileAttachments files={projectFiles.data} />
-            </Box>
-          )}
-        </Box>
-      )}
-      {!isInitialLoading && !projectDescriptionBuilderContent && (
-        <Box data-testid="projectDescriptionBuilderProjectDescription">
-          <ProjectInfo projectId={projectId} />
-        </Box>
-      )}
+      {!isInitialLoading &&
+        projectDescriptionBuilderContent &&
+        usesContentBuilder && (
+          <Box data-testid="projectDescriptionBuilderPreviewContent">
+            <Title color="tenantText" variant="h1">
+              {localize(projectTitle)}
+            </Title>
+            <Editor isPreview={true}>
+              <ContentBuilderFrame
+                editorData={editorData}
+                onLoadImages={handleLoadImages}
+              />
+            </Editor>
+            {projectFiles && (
+              <Box maxWidth="750px" mb="25px">
+                <FileAttachments files={projectFiles.data} />
+              </Box>
+            )}
+          </Box>
+        )}
+      {!isInitialLoading &&
+        (!usesContentBuilder || !projectDescriptionBuilderContent) && (
+          <Box data-testid="projectDescriptionBuilderProjectDescription">
+            <ProjectInfo projectId={projectId} />
+          </Box>
+        )}
     </Box>
   );
 };

--- a/front/app/modules/commercial/project_description_builder/admin/components/ContentViewer/index.tsx
+++ b/front/app/modules/commercial/project_description_builder/admin/components/ContentViewer/index.tsx
@@ -22,6 +22,7 @@ const ContentViewer = ({ params: { slug } }: WithRouterProps) => {
     <Viewer
       projectId={project.data.id}
       projectTitle={project.data.attributes.title_multiloc}
+      usesContentBuilder={project.data.attributes.uses_content_builder}
     />
   );
 };


### PR DESCRIPTION
# Changelog
## Fixed
- [[TAN-1412](https://www.notion.so/citizenlab/Video-is-transferred-from-project-to-project-on-the-front-end-only-a67f5cd2ff3948e69fecd09e6f35f3e9?pvs=4)] Fixed issue where the project description wasn't updating properly when browsing projects from the navbar dropdown.