### PR TITLE
[TAN-1412] Correctly refresh project description when selecting from nav bar

### DIFF
--- a/front/app/modules/commercial/project_description_builder/admin/components/ContentViewer/Viewer/Viewer.test.tsx
+++ b/front/app/modules/commercial/project_description_builder/admin/components/ContentViewer/Viewer/Viewer.test.tsx
@@ -31,6 +31,17 @@ const DEFAULT_PROJECT_DESCRIPTION_BUILDER_LAYOUT_DATA = {
   },
 };
 
+const mockProjectData = {
+  id: '2',
+  type: 'project',
+  attributes: {
+    title_multiloc: { en: 'Test Project' },
+    slug: 'test',
+    input_term: 'idea',
+    uses_content_builder: true,
+  },
+};
+
 const mockProjectDescriptionBuilderLayoutData:
   | typeof DEFAULT_PROJECT_DESCRIPTION_BUILDER_LAYOUT_DATA
   | undefined
@@ -43,6 +54,10 @@ jest.mock(
       data: mockProjectDescriptionBuilderLayoutData,
     };
   }
+);
+
+jest.mock('api/projects/useProjectById', () =>
+  jest.fn(() => ({ data: { data: mockProjectData } }))
 );
 
 describe('Preview', () => {

--- a/front/app/modules/commercial/project_description_builder/admin/components/ContentViewer/Viewer/index.tsx
+++ b/front/app/modules/commercial/project_description_builder/admin/components/ContentViewer/Viewer/index.tsx
@@ -6,6 +6,7 @@ import useProjectDescriptionBuilderLayout from 'modules/commercial/project_descr
 import { Multiloc } from 'typings';
 
 import useProjectFiles from 'api/project_files/useProjectFiles';
+import useProjectById from 'api/projects/useProjectById';
 
 import useLocalize from 'hooks/useLocalize';
 
@@ -32,12 +33,13 @@ const handleLoadImages = () => {
 const Preview = ({ projectId, projectTitle }: PreviewProps) => {
   const localize = useLocalize();
   const { data: projectFiles } = useProjectFiles(projectId);
-
+  const { data: project } = useProjectById(projectId);
   const { data: projectDescriptionBuilderLayout, isInitialLoading } =
     useProjectDescriptionBuilderLayout(projectId);
 
   const projectDescriptionBuilderContent =
     projectDescriptionBuilderLayout &&
+    project?.data.attributes.uses_content_builder &&
     projectDescriptionBuilderLayout.data.attributes.enabled &&
     !isEmpty(projectDescriptionBuilderLayout.data.attributes.craftjs_json);
 


### PR DESCRIPTION
# Changelog
## Fixed
- [[TAN-1412](https://www.notion.so/citizenlab/Video-is-transferred-from-project-to-project-on-the-front-end-only-a67f5cd2ff3948e69fecd09e6f35f3e9?pvs=4)] Show correct project description when selecting from top nav bar.
