### PR TITLE
[TAN-1723] Maintain nested ordering of admin publications 

### DIFF
--- a/back/app/controllers/web_api/v1/admin_publications_controller.rb
+++ b/back/app/controllers/web_api/v1/admin_publications_controller.rb
@@ -10,7 +10,7 @@ class WebApi::V1::AdminPublicationsController < ApplicationController
     publications = publication_filterer.filter(publications, params.merge(current_user: current_user))
 
     # A flattened ordering, such that project publications with a parent (projects in folders) are ordered
-    # first by their parent's :ordering, and then by their own :ordering (their odering within the folder).
+    # first by their parent's :ordering, and then by their own :ordering (their ordering within the folder).
     publications = publications.select(
       'admin_publications.*',
       'CASE WHEN admin_publications.parent_id IS NULL THEN admin_publications.ordering ELSE parents.ordering END
@@ -18,9 +18,9 @@ class WebApi::V1::AdminPublicationsController < ApplicationController
     )
       .joins('LEFT OUTER JOIN admin_publications AS parents ON parents.id = admin_publications.parent_id')
       .order('root_ordering, admin_publications.ordering')
+      .includes(:publication, :children)
 
-    @publications = publications.includes(:publication, :children)
-    @publications = paginate @publications
+    @publications = paginate publications
 
     render json: linked_json(
       @publications,

--- a/back/app/controllers/web_api/v1/admin_publications_controller.rb
+++ b/back/app/controllers/web_api/v1/admin_publications_controller.rb
@@ -9,8 +9,24 @@ class WebApi::V1::AdminPublicationsController < ApplicationController
     publications = policy_scope(AdminPublication.includes(:parent))
     publications = publication_filterer.filter(publications, params.merge(current_user: current_user))
 
+    publications = publications.select(
+      'admin_publications.*',
+      'CASE WHEN admin_publications.parent_id IS NOT NULL
+      THEN parents.ordering + (admin_publications.ordering / 10.0) + 0.05
+      ELSE admin_publications.ordering
+      END AS compound_ordering'
+    )
+      .joins('LEFT OUTER JOIN admin_publications AS parents ON parents.id = admin_publications.parent_id')
+      .order('compound_ordering ASC')
+
+    # Ruby non-sql version (just for testing)
+    # compound_ordering = publications.index_with { |p| p&.parent ? p.parent.ordering + (p.ordering / 10.0) + 0.05 : p.ordering }
+    # publications = compound_ordering.sort_by { |_k, v| v }.to_h.keys
+    # publications.each { |p| puts p.publication.title_multiloc['en'] } # <= 'correctly' ordered
+    # publications = AdminPublication.where(id: publications.map(&:id)) # This loses the ordering, obviously
+
     @publications = publications.includes(:publication, :children)
-      .order(:ordering)
+
     @publications = paginate @publications
 
     render json: linked_json(

--- a/back/app/controllers/web_api/v1/admin_publications_controller.rb
+++ b/back/app/controllers/web_api/v1/admin_publications_controller.rb
@@ -11,15 +11,25 @@ class WebApi::V1::AdminPublicationsController < ApplicationController
 
     # A flattened ordering of top-level and nested publications, such that project publications are always ordered as if
     # nested under their parent publication, even if their parent(s) is/are not included in the collection.
+    # publications = publications.select(
+    #   'admin_publications.*',
+    #   'CASE WHEN admin_publications.parent_id IS NOT NULL
+    #   THEN parents.ordering + (admin_publications.ordering / 10.0) + 0.05
+    #   ELSE admin_publications.ordering
+    #   END AS flattened_ordering'
+    # )
+    #   .joins('LEFT OUTER JOIN admin_publications AS parents ON parents.id = admin_publications.parent_id')
+    #   .order('flattened_ordering ASC')
+
     publications = publications.select(
       'admin_publications.*',
-      'CASE WHEN admin_publications.parent_id IS NOT NULL
-      THEN parents.ordering + (admin_publications.ordering / 10.0) + 0.05
-      ELSE admin_publications.ordering
+      'CASE WHEN admin_publications.parent_id IS NULL
+      THEN admin_publications.ordering - 0.5
+      ELSE parents.ordering
       END AS flattened_ordering'
     )
       .joins('LEFT OUTER JOIN admin_publications AS parents ON parents.id = admin_publications.parent_id')
-      .order('flattened_ordering ASC')
+      .order('flattened_ordering, admin_publications.ordering')
 
     # Ruby non-sql version (just for testing)
     # flattened_ordering = publications.index_with { |p| p&.parent ? p.parent.ordering + (p.ordering / 10.0) + 0.05 : p.ordering }

--- a/back/app/controllers/web_api/v1/admin_publications_controller.rb
+++ b/back/app/controllers/web_api/v1/admin_publications_controller.rb
@@ -9,24 +9,25 @@ class WebApi::V1::AdminPublicationsController < ApplicationController
     publications = policy_scope(AdminPublication.includes(:parent))
     publications = publication_filterer.filter(publications, params.merge(current_user: current_user))
 
+    # A flattened ordering of top-level and nested publications, such that project publications are always ordered as if
+    # nested under their parent publication, even if their parent(s) is/are not included in the collection.
     publications = publications.select(
       'admin_publications.*',
       'CASE WHEN admin_publications.parent_id IS NOT NULL
       THEN parents.ordering + (admin_publications.ordering / 10.0) + 0.05
       ELSE admin_publications.ordering
-      END AS compound_ordering'
+      END AS flattened_ordering'
     )
       .joins('LEFT OUTER JOIN admin_publications AS parents ON parents.id = admin_publications.parent_id')
-      .order('compound_ordering ASC')
+      .order('flattened_ordering ASC')
 
     # Ruby non-sql version (just for testing)
-    # compound_ordering = publications.index_with { |p| p&.parent ? p.parent.ordering + (p.ordering / 10.0) + 0.05 : p.ordering }
-    # publications = compound_ordering.sort_by { |_k, v| v }.to_h.keys
+    # flattened_ordering = publications.index_with { |p| p&.parent ? p.parent.ordering + (p.ordering / 10.0) + 0.05 : p.ordering }
+    # publications = flattened_ordering.sort_by { |_k, v| v }.to_h.keys
     # publications.each { |p| puts p.publication.title_multiloc['en'] } # <= 'correctly' ordered
     # publications = AdminPublication.where(id: publications.map(&:id)) # This loses the ordering, obviously
 
     @publications = publications.includes(:publication, :children)
-
     @publications = paginate @publications
 
     render json: linked_json(

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -224,11 +224,12 @@ resource 'AdminPublication' do
           projects[3].admin_publication.insert_at(6)
         end
 
-        example_request 'List all admin publications uses a flattened nested ordering', document: false do
+        example 'List all root-level admin publications is ordered correctly', document: false do
+          do_request(depth: 0)
           expect(status).to eq(200)
           json_response = json_parse(response_body)
           expect(json_response[:data].map { |d| d.dig(:attributes, :publication_title_multiloc, :en) })
-            .to eq(%w[P1 F1 P2 F2 P3-f2 P4-f2 P5-f2 P6 P7 P8])
+            .to eq(%w[P1 F1 P2 F2 P6 P7 P8])
         end
 
         example 'List only project publications maintains a flattened nested ordering', document: false do

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -202,25 +202,25 @@ resource 'AdminPublication' do
           # P7 (project)
           # P8 (project)
 
-          projects[7].update(title_multiloc: { en: 'P1' })
+          projects[7].update!(title_multiloc: { en: 'P1' })
           projects[7].admin_publication.insert_at(0)
-          empty_draft_folder.update(title_multiloc: { en: 'F1' })
+          empty_draft_folder.update!(title_multiloc: { en: 'F1' })
           empty_draft_folder.admin_publication.insert_at(1)
-          projects[5].update(title_multiloc: { en: 'P2' })
+          projects[5].update!(title_multiloc: { en: 'P2' })
           projects[5].admin_publication.insert_at(2)
-          custom_folder.update(title_multiloc: { en: 'F2' })
+          custom_folder.update!(title_multiloc: { en: 'F2' })
           custom_folder.admin_publication.insert_at(3)
-          projects[1].update(title_multiloc: { en: 'P3-f2' })
+          projects[1].update!(title_multiloc: { en: 'P3-f2' })
           projects[1].admin_publication.insert_at(0)
-          projects[0].update(title_multiloc: { en: 'P4-f2' })
+          projects[0].update!(title_multiloc: { en: 'P4-f2' })
           projects[0].admin_publication.insert_at(1)
-          projects[2].update(title_multiloc: { en: 'P5-f2' })
+          projects[2].update!(title_multiloc: { en: 'P5-f2' })
           projects[2].admin_publication.insert_at(2)
-          projects[6].update(title_multiloc: { en: 'P6' })
+          projects[6].update!(title_multiloc: { en: 'P6' })
           projects[6].admin_publication.insert_at(4)
-          projects[4].update(title_multiloc: { en: 'P7' })
+          projects[4].update!(title_multiloc: { en: 'P7' })
           projects[4].admin_publication.insert_at(5)
-          projects[3].update(title_multiloc: { en: 'P8' })
+          projects[3].update!(title_multiloc: { en: 'P8' })
           projects[3].admin_publication.insert_at(6)
         end
 
@@ -567,7 +567,7 @@ resource 'AdminPublication' do
       @moderator = create(:project_folder_moderator, project_folders: [project_folder, @folder])
 
       @folder.projects.each do |project|
-        @moderator.update(roles: @moderator.roles += [{ type: 'project_moderator', project_id: project.id }])
+        @moderator.update!(roles: @moderator.roles += [{ type: 'project_moderator', project_id: project.id }])
       end
 
       header_token_for(@moderator)

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -44,59 +44,6 @@ resource 'AdminPublication' do
       parameter :filter_can_moderate, 'Filter out the projects the user is allowed to moderate. False by default', required: false
       parameter :filter_is_moderator_of, 'Filter out the publications the user is not moderator of. False by default', required: false
 
-      context 'with specific publication orderings at different depths' do
-        before do
-          # Purposefully use orderings that don't reflect creation order, to avoid corect ordering due to creation order
-          #
-          # Modelling structure:
-          # P1 (project)
-          # F1 (folder)
-          # P2 (project)
-          # F2 (folder)
-          #  .. P3-f2 (project)
-          #  .. P4-f2 (project)
-          #  .. P5-f2 (project)
-          # P6 (project)
-          # P7 (project)
-
-          projects[7].update(title_multiloc: { en: 'P1' })
-          projects[7].admin_publication.insert_at(0)
-          empty_draft_folder.update(title_multiloc: { en: 'F1' })
-          empty_draft_folder.admin_publication.insert_at(1)
-          projects[5].update(title_multiloc: { en: 'P2' })
-          projects[5].admin_publication.insert_at(2)
-          custom_folder.update(title_multiloc: { en: 'F2' })
-          custom_folder.admin_publication.insert_at(3)
-          projects[1].update(title_multiloc: { en: 'P3-f2' })
-          projects[1].admin_publication.insert_at(0)
-          projects[0].update(title_multiloc: { en: 'P4-f2' })
-          projects[0].admin_publication.insert_at(1)
-          projects[2].update(title_multiloc: { en: 'P5-f2' })
-          projects[2].admin_publication.insert_at(2)
-          projects[6].update(title_multiloc: { en: 'P6' })
-          projects[6].admin_publication.insert_at(4)
-          projects[4].update(title_multiloc: { en: 'P7' })
-          projects[4].admin_publication.insert_at(5)
-          projects[3].update(title_multiloc: { en: 'P8' })
-          projects[3].admin_publication.insert_at(6)
-        end
-
-        example_request 'List all admin publications uses a flattened nested ordering', document: false do
-          expect(status).to eq(200)
-          json_response = json_parse(response_body)
-          expect(json_response[:data].map { |d| d.dig(:attributes, :publication_title_multiloc, :en) })
-            .to eq(%w[P1 F1 P2 F2 P3-f2 P4-f2 P5-f2 P6 P7 P8])
-        end
-
-        example 'List only project publications maintains a flattened nested ordering', document: false do
-          do_request(only_projects: 'true')
-          expect(status).to eq(200)
-          json_response = json_parse(response_body)
-          expect(json_response[:data].map { |d| d.dig(:attributes, :publication_title_multiloc, :en) })
-            .to eq(%w[P1 P2 P3-f2 P4-f2 P5-f2 P6 P7 P8])
-        end
-      end
-
       example_request 'List all admin publications' do
         expect(status).to eq(200)
         json_response = json_parse(response_body)
@@ -236,6 +183,60 @@ resource 'AdminPublication' do
             do_request(filter_param => ['any id'])
             expect(response_data.map { |d| d.dig(:relationships, :publication, :data, :id) }).not_to include custom_folder.id
           end
+        end
+      end
+
+      context 'with specific publication orderings at different depths' do
+        before do
+          # Purposefully use orderings that don't reflect creation order, to avoid corect ordering due to creation order
+          #
+          # Modelling the structure:
+          # P1 (project)
+          # F1 (folder)
+          # P2 (project)
+          # F2 (folder)
+          #  .. P3-f2 (project)
+          #  .. P4-f2 (project)
+          #  .. P5-f2 (project)
+          # P6 (project)
+          # P7 (project)
+          # P8 (project)
+
+          projects[7].update(title_multiloc: { en: 'P1' })
+          projects[7].admin_publication.insert_at(0)
+          empty_draft_folder.update(title_multiloc: { en: 'F1' })
+          empty_draft_folder.admin_publication.insert_at(1)
+          projects[5].update(title_multiloc: { en: 'P2' })
+          projects[5].admin_publication.insert_at(2)
+          custom_folder.update(title_multiloc: { en: 'F2' })
+          custom_folder.admin_publication.insert_at(3)
+          projects[1].update(title_multiloc: { en: 'P3-f2' })
+          projects[1].admin_publication.insert_at(0)
+          projects[0].update(title_multiloc: { en: 'P4-f2' })
+          projects[0].admin_publication.insert_at(1)
+          projects[2].update(title_multiloc: { en: 'P5-f2' })
+          projects[2].admin_publication.insert_at(2)
+          projects[6].update(title_multiloc: { en: 'P6' })
+          projects[6].admin_publication.insert_at(4)
+          projects[4].update(title_multiloc: { en: 'P7' })
+          projects[4].admin_publication.insert_at(5)
+          projects[3].update(title_multiloc: { en: 'P8' })
+          projects[3].admin_publication.insert_at(6)
+        end
+
+        example_request 'List all admin publications uses a flattened nested ordering', document: false do
+          expect(status).to eq(200)
+          json_response = json_parse(response_body)
+          expect(json_response[:data].map { |d| d.dig(:attributes, :publication_title_multiloc, :en) })
+            .to eq(%w[P1 F1 P2 F2 P3-f2 P4-f2 P5-f2 P6 P7 P8])
+        end
+
+        example 'List only project publications maintains a flattened nested ordering', document: false do
+          do_request(only_projects: 'true')
+          expect(status).to eq(200)
+          json_response = json_parse(response_body)
+          expect(json_response[:data].map { |d| d.dig(:attributes, :publication_title_multiloc, :en) })
+            .to eq(%w[P1 P2 P3-f2 P4-f2 P5-f2 P6 P7 P8])
         end
       end
     end

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -26,7 +26,7 @@ resource 'AdminPublication' do
 
     # the name of this variable shouldn't be `folder`
     # because otherwise it will be used by default in `parameter :folder`
-    let!(:custom_folder) { create(:project_folder, projects: projects.take(3)) }
+    let!(:custom_folder) { create(:project_folder, projects: [projects[0..2]]) }
 
     get 'web_api/v1/admin_publications' do
       with_options scope: :page do
@@ -43,6 +43,59 @@ resource 'AdminPublication' do
       parameter :only_projects, 'Include projects only (no folders)', required: false
       parameter :filter_can_moderate, 'Filter out the projects the user is allowed to moderate. False by default', required: false
       parameter :filter_is_moderator_of, 'Filter out the publications the user is not moderator of. False by default', required: false
+
+      context 'with specific publication orderings at different depths' do
+        before do
+          # Purposefully use orderings that don't reflect creation order, to avoid corect ordering due to creation order
+          #
+          # Modelling structure:
+          # P1 (project)
+          # F1 (folder)
+          # P2 (project)
+          # F2 (folder)
+          #  .. P3-f2 (project)
+          #  .. P4-f2 (project)
+          #  .. P5-f2 (project)
+          # P6 (project)
+          # P7 (project)
+
+          projects[7].update(title_multiloc: { en: 'P1' })
+          projects[7].admin_publication.insert_at(0)
+          empty_draft_folder.update(title_multiloc: { en: 'F1' })
+          empty_draft_folder.admin_publication.insert_at(1)
+          projects[5].update(title_multiloc: { en: 'P2' })
+          projects[5].admin_publication.insert_at(2)
+          custom_folder.update(title_multiloc: { en: 'F2' })
+          custom_folder.admin_publication.insert_at(3)
+          projects[1].update(title_multiloc: { en: 'P3-f2' })
+          projects[1].admin_publication.insert_at(0)
+          projects[0].update(title_multiloc: { en: 'P4-f2' })
+          projects[0].admin_publication.insert_at(1)
+          projects[2].update(title_multiloc: { en: 'P5-f2' })
+          projects[2].admin_publication.insert_at(2)
+          projects[6].update(title_multiloc: { en: 'P6' })
+          projects[6].admin_publication.insert_at(4)
+          projects[4].update(title_multiloc: { en: 'P7' })
+          projects[4].admin_publication.insert_at(5)
+          projects[3].update(title_multiloc: { en: 'P8' })
+          projects[3].admin_publication.insert_at(6)
+        end
+
+        example_request 'List all admin publications uses a flattened nested ordering', document: false do
+          expect(status).to eq(200)
+          json_response = json_parse(response_body)
+          expect(json_response[:data].map { |d| d.dig(:attributes, :publication_title_multiloc, :en) })
+            .to eq(%w[P1 F1 P2 F2 P3-f2 P4-f2 P5-f2 P6 P7 P8])
+        end
+
+        example 'List only project publications maintains a flattened nested ordering', document: false do
+          do_request(only_projects: 'true')
+          expect(status).to eq(200)
+          json_response = json_parse(response_body)
+          expect(json_response[:data].map { |d| d.dig(:attributes, :publication_title_multiloc, :en) })
+            .to eq(%w[P1 P2 P3-f2 P4-f2 P5-f2 P6 P7 P8])
+        end
+      end
 
       example_request 'List all admin publications' do
         expect(status).to eq(200)

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -26,7 +26,7 @@ resource 'AdminPublication' do
 
     # the name of this variable shouldn't be `folder`
     # because otherwise it will be used by default in `parameter :folder`
-    let!(:custom_folder) { create(:project_folder, projects: [projects[0..2]]) }
+    let!(:custom_folder) { create(:project_folder, projects: projects.take(3)) }
 
     get 'web_api/v1/admin_publications' do
       with_options scope: :page do


### PR DESCRIPTION
## Problem
How to maintain ordering seen in BO list of 'all' `admin_publications` (related to projects not in folders + root-level folders, and projects in folders), whether folders are, or are not, included in the collection?

## Solution
Order `admin_publications` by parent `:ordering` first (if parent exists), then by their own `:ordering`. If no parent exists, just order by their own `:ordering`.

### Screenshots
<details>
  <summary> Screenshots [Click me]</summary>
  
<img width="1381" alt="Screenshot 2024-04-29 at 23 45 49" src="https://github.com/CitizenLabDotCo/citizenlab/assets/3944042/33e49d39-8531-4bb1-882d-f80f3b9a65f3">

<img width="1381" alt="Screenshot 2024-04-29 at 23 46 01" src="https://github.com/CitizenLabDotCo/citizenlab/assets/3944042/1554f4fe-8e0a-4042-a020-9e76a063eb1b">

<img width="1373" alt="Screenshot 2024-04-29 at 23 47 34" src="https://github.com/CitizenLabDotCo/citizenlab/assets/3944042/29c05f41-564f-479a-b9e6-c416550553c3">

</details>

# Changelog
## Fixed
- [TAN-1723] Order `admin_publications` by parent `:ordering` first (if parent exists), then own `:ordering`. This fixes the issue where project lists in the BO ('your projects', 'active', 'draft', 'archived') would not display in the order they are seen in the 'all' tab view.
