### PR TITLE
TAN-1690 Everyone external survey bug

### DIFF
--- a/back/app/services/permissions_service.rb
+++ b/back/app/services/permissions_service.rb
@@ -113,7 +113,7 @@ class PermissionsService
   end
 
   def fix_permitted_by(scope)
-    if scope && !scope.native_survey?
+    if scope && !Factory.instance.participation_method_for(scope).supports_everyone_permission?
       Permission.where(permission_scope: scope, permitted_by: 'everyone').update!(permitted_by: 'users')
     end
   end

--- a/back/app/services/permissions_service.rb
+++ b/back/app/services/permissions_service.rb
@@ -113,7 +113,7 @@ class PermissionsService
   end
 
   def fix_permitted_by(scope)
-    if scope && !Factory.instance.participation_method_for(scope).supports_everyone_permission?
+    if scope && !Factory.instance.participation_method_for(scope).supports_permitted_by_everyone?
       Permission.where(permission_scope: scope, permitted_by: 'everyone').update!(permitted_by: 'users')
     end
   end

--- a/back/lib/participation_method/base.rb
+++ b/back/lib/participation_method/base.rb
@@ -125,6 +125,10 @@ module ParticipationMethod
       false
     end
 
+    def supports_everyone_permission?
+      false
+    end
+
     def include_data_in_email?
       true
     end

--- a/back/lib/participation_method/base.rb
+++ b/back/lib/participation_method/base.rb
@@ -125,7 +125,7 @@ module ParticipationMethod
       false
     end
 
-    def supports_everyone_permission?
+    def supports_permitted_by_everyone?
       false
     end
 

--- a/back/lib/participation_method/native_survey.rb
+++ b/back/lib/participation_method/native_survey.rb
@@ -114,7 +114,7 @@ module ParticipationMethod
       true
     end
 
-    def supports_everyone_permission?
+    def supports_permitted_by_everyone?
       true
     end
 

--- a/back/lib/participation_method/native_survey.rb
+++ b/back/lib/participation_method/native_survey.rb
@@ -114,6 +114,10 @@ module ParticipationMethod
       true
     end
 
+    def supports_everyone_permission?
+      true
+    end
+
     def include_data_in_email?
       false
     end

--- a/back/lib/participation_method/survey.rb
+++ b/back/lib/participation_method/survey.rb
@@ -2,7 +2,7 @@
 
 module ParticipationMethod
   class Survey < Base
-    def supports_everyone_permission?
+    def supports_permitted_by_everyone?
       true
     end
   end

--- a/back/lib/participation_method/survey.rb
+++ b/back/lib/participation_method/survey.rb
@@ -2,5 +2,8 @@
 
 module ParticipationMethod
   class Survey < Base
+    def supports_everyone_permission?
+      true
+    end
   end
 end

--- a/back/spec/lib/participation_method/ideation_spec.rb
+++ b/back/spec/lib/participation_method/ideation_spec.rb
@@ -252,7 +252,7 @@ RSpec.describe ParticipationMethod::Ideation do
   its(:supports_reacting?) { is_expected.to be true }
   its(:supports_status?) { is_expected.to be true }
   its(:supports_assignment?) { is_expected.to be true }
-  its(:supports_everyone_permission?) { is_expected.to be false }
+  its(:supports_permitted_by_everyone?) { is_expected.to be false }
   its(:return_disabled_actions?) { is_expected.to be false }
   its(:additional_export_columns) { is_expected.to eq [] }
 end

--- a/back/spec/lib/participation_method/ideation_spec.rb
+++ b/back/spec/lib/participation_method/ideation_spec.rb
@@ -252,6 +252,7 @@ RSpec.describe ParticipationMethod::Ideation do
   its(:supports_reacting?) { is_expected.to be true }
   its(:supports_status?) { is_expected.to be true }
   its(:supports_assignment?) { is_expected.to be true }
+  its(:supports_everyone_permission?) { is_expected.to be false }
   its(:return_disabled_actions?) { is_expected.to be false }
   its(:additional_export_columns) { is_expected.to eq [] }
 end

--- a/back/spec/lib/participation_method/information_spec.rb
+++ b/back/spec/lib/participation_method/information_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe ParticipationMethod::Information do
   its(:supports_reacting?) { is_expected.to be false }
   its(:supports_status?) { is_expected.to be false }
   its(:supports_assignment?) { is_expected.to be false }
-  its(:supports_everyone_permission?) { is_expected.to be false }
+  its(:supports_permitted_by_everyone?) { is_expected.to be false }
   its(:return_disabled_actions?) { is_expected.to be false }
   its(:additional_export_columns) { is_expected.to eq [] }
 end

--- a/back/spec/lib/participation_method/information_spec.rb
+++ b/back/spec/lib/participation_method/information_spec.rb
@@ -147,6 +147,7 @@ RSpec.describe ParticipationMethod::Information do
   its(:supports_reacting?) { is_expected.to be false }
   its(:supports_status?) { is_expected.to be false }
   its(:supports_assignment?) { is_expected.to be false }
+  its(:supports_everyone_permission?) { is_expected.to be false }
   its(:return_disabled_actions?) { is_expected.to be false }
   its(:additional_export_columns) { is_expected.to eq [] }
 end

--- a/back/spec/lib/participation_method/native_survey_spec.rb
+++ b/back/spec/lib/participation_method/native_survey_spec.rb
@@ -221,7 +221,7 @@ RSpec.describe ParticipationMethod::NativeSurvey do
   its(:supports_reacting?) { is_expected.to be false }
   its(:supports_status?) { is_expected.to be false }
   its(:supports_assignment?) { is_expected.to be false }
-  its(:supports_everyone_permission?) { is_expected.to be true }
+  its(:supports_permitted_by_everyone?) { is_expected.to be true }
   its(:return_disabled_actions?) { is_expected.to be true }
   its(:additional_export_columns) { is_expected.to eq [] }
 end

--- a/back/spec/lib/participation_method/native_survey_spec.rb
+++ b/back/spec/lib/participation_method/native_survey_spec.rb
@@ -221,6 +221,7 @@ RSpec.describe ParticipationMethod::NativeSurvey do
   its(:supports_reacting?) { is_expected.to be false }
   its(:supports_status?) { is_expected.to be false }
   its(:supports_assignment?) { is_expected.to be false }
+  its(:supports_everyone_permission?) { is_expected.to be true }
   its(:return_disabled_actions?) { is_expected.to be true }
   its(:additional_export_columns) { is_expected.to eq [] }
 end

--- a/back/spec/lib/participation_method/none_spec.rb
+++ b/back/spec/lib/participation_method/none_spec.rb
@@ -136,6 +136,7 @@ RSpec.describe ParticipationMethod::None do
   its(:supports_reacting?) { is_expected.to be false }
   its(:supports_status?) { is_expected.to be false }
   its(:supports_assignment?) { is_expected.to be false }
+  its(:supports_everyone_permission?) { is_expected.to be false }
   its(:return_disabled_actions?) { is_expected.to be false }
   its(:additional_export_columns) { is_expected.to eq [] }
 end

--- a/back/spec/lib/participation_method/none_spec.rb
+++ b/back/spec/lib/participation_method/none_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe ParticipationMethod::None do
   its(:supports_reacting?) { is_expected.to be false }
   its(:supports_status?) { is_expected.to be false }
   its(:supports_assignment?) { is_expected.to be false }
-  its(:supports_everyone_permission?) { is_expected.to be false }
+  its(:supports_permitted_by_everyone?) { is_expected.to be false }
   its(:return_disabled_actions?) { is_expected.to be false }
   its(:additional_export_columns) { is_expected.to eq [] }
 end

--- a/back/spec/lib/participation_method/poll_spec.rb
+++ b/back/spec/lib/participation_method/poll_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe ParticipationMethod::Poll do
   its(:supports_reacting?) { is_expected.to be false }
   its(:supports_status?) { is_expected.to be false }
   its(:supports_assignment?) { is_expected.to be false }
-  its(:supports_everyone_permission?) { is_expected.to be false }
+  its(:supports_permitted_by_everyone?) { is_expected.to be false }
   its(:return_disabled_actions?) { is_expected.to be false }
   its(:additional_export_columns) { is_expected.to eq [] }
 end

--- a/back/spec/lib/participation_method/poll_spec.rb
+++ b/back/spec/lib/participation_method/poll_spec.rb
@@ -146,6 +146,7 @@ RSpec.describe ParticipationMethod::Poll do
   its(:supports_reacting?) { is_expected.to be false }
   its(:supports_status?) { is_expected.to be false }
   its(:supports_assignment?) { is_expected.to be false }
+  its(:supports_everyone_permission?) { is_expected.to be false }
   its(:return_disabled_actions?) { is_expected.to be false }
   its(:additional_export_columns) { is_expected.to eq [] }
 end

--- a/back/spec/lib/participation_method/survey_spec.rb
+++ b/back/spec/lib/participation_method/survey_spec.rb
@@ -147,6 +147,7 @@ RSpec.describe ParticipationMethod::Survey do
   its(:supports_reacting?) { is_expected.to be false }
   its(:supports_status?) { is_expected.to be false }
   its(:supports_assignment?) { is_expected.to be false }
+  its(:supports_everyone_permission?) { is_expected.to be true }
   its(:return_disabled_actions?) { is_expected.to be false }
   its(:additional_export_columns) { is_expected.to eq [] }
 end

--- a/back/spec/lib/participation_method/survey_spec.rb
+++ b/back/spec/lib/participation_method/survey_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe ParticipationMethod::Survey do
   its(:supports_reacting?) { is_expected.to be false }
   its(:supports_status?) { is_expected.to be false }
   its(:supports_assignment?) { is_expected.to be false }
-  its(:supports_everyone_permission?) { is_expected.to be true }
+  its(:supports_permitted_by_everyone?) { is_expected.to be true }
   its(:return_disabled_actions?) { is_expected.to be false }
   its(:additional_export_columns) { is_expected.to eq [] }
 end

--- a/back/spec/lib/participation_method/volunteering_spec.rb
+++ b/back/spec/lib/participation_method/volunteering_spec.rb
@@ -146,6 +146,7 @@ RSpec.describe ParticipationMethod::Volunteering do
   its(:supports_reacting?) { is_expected.to be false }
   its(:supports_status?) { is_expected.to be false }
   its(:supports_assignment?) { is_expected.to be false }
+  its(:supports_everyone_permission?) { is_expected.to be false }
   its(:return_disabled_actions?) { is_expected.to be false }
   its(:additional_export_columns) { is_expected.to eq [] }
 end

--- a/back/spec/lib/participation_method/volunteering_spec.rb
+++ b/back/spec/lib/participation_method/volunteering_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe ParticipationMethod::Volunteering do
   its(:supports_reacting?) { is_expected.to be false }
   its(:supports_status?) { is_expected.to be false }
   its(:supports_assignment?) { is_expected.to be false }
-  its(:supports_everyone_permission?) { is_expected.to be false }
+  its(:supports_permitted_by_everyone?) { is_expected.to be false }
   its(:return_disabled_actions?) { is_expected.to be false }
   its(:additional_export_columns) { is_expected.to eq [] }
 end

--- a/back/spec/lib/participation_method/voting_spec.rb
+++ b/back/spec/lib/participation_method/voting_spec.rb
@@ -179,5 +179,6 @@ RSpec.describe ParticipationMethod::Voting do
   its(:supports_reacting?) { is_expected.to be false }
   its(:supports_status?) { is_expected.to be true }
   its(:supports_assignment?) { is_expected.to be true }
+  its(:supports_everyone_permission?) { is_expected.to be false }
   its(:return_disabled_actions?) { is_expected.to be false }
 end

--- a/back/spec/lib/participation_method/voting_spec.rb
+++ b/back/spec/lib/participation_method/voting_spec.rb
@@ -179,6 +179,6 @@ RSpec.describe ParticipationMethod::Voting do
   its(:supports_reacting?) { is_expected.to be false }
   its(:supports_status?) { is_expected.to be true }
   its(:supports_assignment?) { is_expected.to be true }
-  its(:supports_everyone_permission?) { is_expected.to be false }
+  its(:supports_permitted_by_everyone?) { is_expected.to be false }
   its(:return_disabled_actions?) { is_expected.to be false }
 end

--- a/back/spec/services/permissions_service_spec.rb
+++ b/back/spec/services/permissions_service_spec.rb
@@ -1215,6 +1215,15 @@ describe PermissionsService do
       expect(phase.permissions.pluck(:permitted_by)).to match_array %w[users users users]
     end
 
+    it 'does not change permitted_by to "users" for external surveys permitted_by "everyone"' do
+      phase = create(:typeform_survey_phase, with_permissions: true)
+      permission = phase.permissions.first
+      permission.update!(permitted_by: 'everyone')
+      service.update_permissions_for_scope(phase)
+
+      expect(permission.reload.permitted_by).to eq 'everyone'
+    end
+
     it 'does not changes permitted_by from native_survey if permitted_by is not "everyone"' do
       phase = create(:native_survey_phase, with_permissions: true)
       phase.permissions.first.update!(permitted_by: 'groups')


### PR DESCRIPTION
# Changelog
### Fixed
- [TAN-1690] Prevent permissions from jumping from "everyone" to "registered users" for external survey phases (this happened after every release).
