### PR TITLE
TAN-1554 Don't send reminder emails when phase ended

### DIFF
--- a/back/spec/services/activities_service_spec.rb
+++ b/back/spec/services/activities_service_spec.rb
@@ -177,6 +177,15 @@ describe ActivitiesService do
         expect { service.create_periodic_activities(now: now) }
           .not_to have_enqueued_job(LogActivityJob)
       end
+
+      it 'does not log an activity when a the voting phase finished' do
+        create(:activity, item: basket.phase, action: 'ended')
+        create(:baskets_idea, idea: create(:idea), basket: basket, created_at: updated_at, updated_at: updated_at)
+        now = updated_at + 1.day
+        phase = basket.phase.update!(start_at: (now - 4.days), end_at: (now - 2.days))
+        expect { service.create_periodic_activities(now: now) }
+          .not_to(have_enqueued_job(LogActivityJob))
+      end
     end
 
     describe '#create_survey_not_submitted_activities' do
@@ -201,6 +210,14 @@ describe ActivitiesService do
         now = updated_at + 5.hours
         expect { service.create_periodic_activities(now: now) }
           .not_to have_enqueued_job(LogActivityJob)
+      end
+
+      it 'does not log an activity when a the survey phase finished' do
+        create(:activity, item: idea.creation_phase, action: 'ended')
+        now = updated_at + 1.day
+        phase = idea.creation_phase.update!(start_at: (now - 4.days), end_at: (now - 2.days))
+        expect { service.create_periodic_activities(now: now) }
+          .not_to(have_enqueued_job(LogActivityJob))
       end
     end
 

--- a/back/spec/services/activities_service_spec.rb
+++ b/back/spec/services/activities_service_spec.rb
@@ -182,7 +182,7 @@ describe ActivitiesService do
         create(:activity, item: basket.phase, action: 'ended')
         create(:baskets_idea, idea: create(:idea), basket: basket, created_at: updated_at, updated_at: updated_at)
         now = updated_at + 1.day
-        phase = basket.phase.update!(start_at: (now - 4.days), end_at: (now - 2.days))
+        basket.phase.update!(start_at: (now - 4.days), end_at: (now - 2.days))
         expect { service.create_periodic_activities(now: now) }
           .not_to(have_enqueued_job(LogActivityJob))
       end
@@ -215,7 +215,7 @@ describe ActivitiesService do
       it 'does not log an activity when a the survey phase finished' do
         create(:activity, item: idea.creation_phase, action: 'ended')
         now = updated_at + 1.day
-        phase = idea.creation_phase.update!(start_at: (now - 4.days), end_at: (now - 2.days))
+        idea.creation_phase.update!(start_at: (now - 4.days), end_at: (now - 2.days))
         expect { service.create_periodic_activities(now: now) }
           .not_to(have_enqueued_job(LogActivityJob))
       end


### PR DESCRIPTION
It's possible, however, that there was no issue and that the email job just stayed in the queue for a very long time. But I don't think it hurts to add the extra check.

# Changelog
### Fixed
- [TAN-1554] Don't send voting and survey submission reminder emails when the phase is already over.
