### PR TITLE
[TAN-1166] Fix input manager crashing when using search input

### DIFF
--- a/front/app/components/admin/PostManager/InputManager.tsx
+++ b/front/app/components/admin/PostManager/InputManager.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, Suspense, lazy, useEffect, useState } from 'react';
+import React, { Suspense, lazy, useEffect, useState } from 'react';
 
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
@@ -14,6 +14,7 @@ import { IProjectData } from 'api/projects/types';
 import useTopics from 'api/topics/useTopics';
 
 import Outlet from 'components/Outlet';
+import SearchInput from 'components/UI/SearchInput';
 
 import { removeSearchParams } from 'utils/cl-router/removeSearchParams';
 import { isNilOrError } from 'utils/helperUtils';
@@ -33,7 +34,6 @@ import {
   PreviewMode,
   Sticky,
   StyledExportMenu,
-  StyledInput,
   ThreeColumns,
   TopActionBar,
 } from '.';
@@ -240,11 +240,11 @@ const InputManager = ({
     setQueryParameters({ ...queryParameters, 'page[number]': pageNumber });
   };
 
-  const onChangeSearchTerm = (event: ChangeEvent<HTMLInputElement>) => {
+  const onChangeSearchTerm = (value: string | null) => {
     setQueryParameters({
       ...queryParameters,
       'page[number]': 1,
-      search: event.target.value,
+      search: value || undefined,
     });
   };
 
@@ -294,7 +294,11 @@ const InputManager = ({
             project={selectedProjectId}
             queryParameters={queryParameters}
           />
-          <StyledInput icon="search" onChange={onChangeSearchTerm} />
+          <SearchInput
+            debounce={1500}
+            onChange={onChangeSearchTerm}
+            a11y_numberOfSearchResults={ideas?.data.length}
+          />
         </MiddleColumnTop>
       </ThreeColumns>
       <ThreeColumns>


### PR DESCRIPTION
# Description
Looks like we sometimes get a 429 error (too many requests) when using the search bar in the input manager.

![Screenshot from 2024-05-02 12-17-01](https://github.com/CitizenLabDotCo/citizenlab/assets/33987955/7c41349d-e049-4286-89c8-6856a05878ed)

Seems to occur since we aren't debouncing the request when changing the search term. I've swapped the Input component for our "SearchInput" component instead and added a debounce, so this should fix the issue :)

# Changelog
## Fixed
- [[TAN-1166](https://www.notion.so/Houten-Page-goes-blank-when-searching-in-input-manager-7e0bfa78a281468eb065e51ec50c3ba2?pvs=4)] Fix input manager sometimes crashing when using the search input.
