### PR TITLE
[TAN-1569] Allow saving single option in dashboard

### DIFF
--- a/front/app/modules/commercial/representativeness/admin/utils/form.test.ts
+++ b/front/app/modules/commercial/representativeness/admin/utils/form.test.ts
@@ -188,7 +188,7 @@ describe('getStatus', () => {
     expect(getStatus(formValues, remoteFormValues, touched)).toBe('incomplete');
   });
 
-  it("returns 'incomplete' if if only one option is enabled and filled out (remote data)", () => {
+  it("returns 'complete' if if only one option is enabled and filled out (remote data)", () => {
     const formValues: FormValues = {
       id123: 1000,
     };
@@ -197,7 +197,7 @@ describe('getStatus', () => {
 
     const touched = true;
 
-    expect(getStatus(formValues, remoteFormValues, touched)).toBe('incomplete');
+    expect(getStatus(formValues, remoteFormValues, touched)).toBe('complete');
   });
 
   it('returns null if local and remote data are both empty', () => {

--- a/front/app/modules/commercial/representativeness/admin/utils/form.test.ts
+++ b/front/app/modules/commercial/representativeness/admin/utils/form.test.ts
@@ -32,12 +32,12 @@ describe('isFormValid', () => {
     expect(isFormValid(formValues)).toBe(false);
   });
 
-  it('returns false if only one option is enabled and filled out', () => {
+  it('returns true if only one option is enabled and filled out', () => {
     const formValues: FormValues = {
       id123: 1000,
     };
 
-    expect(isFormValid(formValues)).toBe(false);
+    expect(isFormValid(formValues)).toBe(true);
   });
 });
 

--- a/front/app/modules/commercial/representativeness/admin/utils/form.test.ts
+++ b/front/app/modules/commercial/representativeness/admin/utils/form.test.ts
@@ -159,7 +159,7 @@ describe('getStatus', () => {
     expect(getStatus(formValues, remoteFormValues, touched)).toBe('incomplete');
   });
 
-  it("returns 'incomplete' if if only one option is enabled and filled out (remote data)", () => {
+  it("returns 'complete' if if only one option is enabled and filled out (remote data)", () => {
     const formValues: FormValues = {
       id123: 1000,
     };
@@ -171,7 +171,7 @@ describe('getStatus', () => {
 
     const touched = true;
 
-    expect(getStatus(formValues, remoteFormValues, touched)).toBe('incomplete');
+    expect(getStatus(formValues, remoteFormValues, touched)).toBe('complete');
   });
 
   it("returns 'incomplete' if not all enabled options are filled out (no remote data)", () => {

--- a/front/app/modules/commercial/representativeness/admin/utils/form.ts
+++ b/front/app/modules/commercial/representativeness/admin/utils/form.ts
@@ -34,7 +34,7 @@ export const isFormValid = (formValues: FormValues) => {
   const allOptionsFilledOut = areAllOptionsFilledOut(formValues);
   const numberOfOptions = Object.keys(formValues).length;
 
-  return allOptionsFilledOut && numberOfOptions > 1;
+  return allOptionsFilledOut && numberOfOptions >= 1;
 };
 
 export const getSubmitAction = (

--- a/front/app/translations/admin/ar-SA.json
+++ b/front/app/translations/admin/ar-SA.json
@@ -758,7 +758,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "يمكنك الجمع بين الاستجابات عبر الإنترنت وغير متصل. لتحميل الردود دون الاتصال بالإنترنت، انتقل إلى علامة التبويب \"استطلاع\" في هذا المشروع، ثم انقر فوق \"استيراد\".",
   "app.containers.Admin.projects.all.notIncludedInYourPlan": "ومع ذلك، هذا غير مدرج في خطتك الحالية. تواصل مع مدير النجاح الحكومي أو المسؤول لفتحه.",
   "app.containers.Admin.projects.all.notes": "ملحوظات",
-  "app.containers.Admin.projects.all.personalDataExplanation1": "إذا حددت المربع أدناه، فسنقوم بإنشاء حسابات مستخدمين للمشاركين غير المتصلين بالإنترنت.",
   "app.containers.Admin.projects.project.analysis.aiSummary": "ملخص الذكاء الاصطناعي",
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "هذا محتوى تم إنشاؤه بواسطة الذكاء الاصطناعي. وقد لا تكون دقيقة بنسبة 100%. يرجى المراجعة والإحالة المرجعية مع المدخلات الفعلية للتأكد من دقتها. انتبه إلى أنه من المرجح أن تتحسن الدقة إذا تم تقليل عدد المدخلات المحددة.",
   "app.containers.Admin.projects.project.ideas.analysisAction": "انتقل إلى تحليل الذكاء الاصطناعي",

--- a/front/app/translations/admin/da-DK.json
+++ b/front/app/translations/admin/da-DK.json
@@ -758,7 +758,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "Du kan kombinere online- og offlinebesvarelser. For at uploade offline-besvarelser skal du gå til fanen \"Survey\" i dette projekt og klikke på \"Import\".",
   "app.containers.Admin.projects.all.notIncludedInYourPlan": "Dette er dog ikke inkluderet i din nuværende plan. Kontakt din Government Success Manager eller administrator for at låse den op.",
   "app.containers.Admin.projects.all.notes": "Noter",
-  "app.containers.Admin.projects.all.personalDataExplanation1": "Hvis du markerer feltet nedenfor, opretter vi brugerkonti til offline-deltagere.",
   "app.containers.Admin.projects.project.analysis.aiSummary": "AI-opsummering",
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "Dette er AI-genereret indhold. Det er måske ikke 100% nøjagtigt. Gennemgå og krydsreferer med de faktiske input for nøjagtighed. Vær opmærksom på, at nøjagtigheden sandsynligvis forbedres, hvis antallet af valgte input reduceres.",
   "app.containers.Admin.projects.project.ideas.analysisAction": "Gå til AI-analyse",

--- a/front/app/translations/admin/de-DE.json
+++ b/front/app/translations/admin/de-DE.json
@@ -758,7 +758,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "Sie können Online- und Offline-Antworten kombinieren. Um Offline-Antworten hochzuladen, gehen Sie zur Registerkarte „Umfrage“ dieses Projekts und klicken Sie auf „Importieren“.",
   "app.containers.Admin.projects.all.notIncludedInYourPlan": "Diese Funktion ist in Ihrer aktuellen Lizenz nicht enthalten. Sprechen Sie mit Ihrer Kundenbetreuerin oder Ihrem Admin, um sie freizuschalten.",
   "app.containers.Admin.projects.all.notes": "Anmerkungen",
-  "app.containers.Admin.projects.all.personalDataExplanation1": "Wenn Sie das Kästchen unten ankreuzen, erstellen wir Accounts für Offline-Teilnehmende.",
   "app.containers.Admin.projects.project.analysis.aiSummary": "KI-Zusammenfassung",
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "Dies ist ein KI-generierter Inhalt. Dieser ist möglicherweise nicht 100%ig genau. Bitte überprüfen Sie die Genauigkeit und gleichen Sie sie mit den tatsächlichen Beiträgen ab. Beachten Sie, dass sich die Genauigkeit wahrscheinlich verbessert, wenn die Anzahl der ausgewählten Beiträge reduziert wird.",
   "app.containers.Admin.projects.project.ideas.analysisAction": "Zur KI-Analyse",

--- a/front/app/translations/admin/en-CA.json
+++ b/front/app/translations/admin/en-CA.json
@@ -758,7 +758,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "You can combine online and offline responses. To upload offline responses, go to the 'Survey' tab of this project, and click 'Import'.",
   "app.containers.Admin.projects.all.notIncludedInYourPlan": "However, this is not included in your current plan. Reach out to your Government Success Manager or admin to unlock it.",
   "app.containers.Admin.projects.all.notes": "Notes",
-  "app.containers.Admin.projects.all.personalDataExplanation1": "If you check the box below, we will create user accounts for offline participants.",
   "app.containers.Admin.projects.project.analysis.aiSummary": "AI summary",
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "This is AI-generated content. It may not be 100% accurate. Please review and cross-reference with the actual inputs for accuracy. Be aware that the accuracy is likely to improve if the number of selected inputs is reduced.",
   "app.containers.Admin.projects.project.ideas.analysisAction": "Go to AI analysis",

--- a/front/app/translations/admin/en-GB.json
+++ b/front/app/translations/admin/en-GB.json
@@ -758,7 +758,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "You can combine online and offline responses. To upload offline responses, go to the 'Survey' tab of this project, and click 'Import'.",
   "app.containers.Admin.projects.all.notIncludedInYourPlan": "However, this is not included in your current plan. Reach out to your Government Success Manager or admin to unlock it.",
   "app.containers.Admin.projects.all.notes": "Notes",
-  "app.containers.Admin.projects.all.personalDataExplanation1": "If you check the box below, we will create user accounts for offline participants.",
   "app.containers.Admin.projects.project.analysis.aiSummary": "AI summary",
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "This is AI-generated content. It may not be 100% accurate. Please review and cross-reference with the actual inputs for accuracy. Be aware that the accuracy is likely to improve if the number of selected inputs is reduced.",
   "app.containers.Admin.projects.project.ideas.analysisAction": "Go to AI analysis",

--- a/front/app/translations/admin/en-IE.json
+++ b/front/app/translations/admin/en-IE.json
@@ -758,7 +758,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "You can combine online and offline responses. To upload offline responses, go to the 'Survey' tab of this project, and click 'Import'.",
   "app.containers.Admin.projects.all.notIncludedInYourPlan": "However, this is not included in your current plan. Reach out to your Government Success Manager or admin to unlock it.",
   "app.containers.Admin.projects.all.notes": "Notes",
-  "app.containers.Admin.projects.all.personalDataExplanation1": "If you check the box below, we will create user accounts for offline participants.",
   "app.containers.Admin.projects.project.analysis.aiSummary": "AI summary",
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "This is AI-generated content. It may not be 100% accurate. Please review and cross-reference with the actual inputs for accuracy. Be aware that the accuracy is likely to improve if the number of selected inputs is reduced.",
   "app.containers.Admin.projects.project.ideas.analysisAction": "Go to AI analysis",

--- a/front/app/translations/admin/es-CL.json
+++ b/front/app/translations/admin/es-CL.json
@@ -758,7 +758,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "Puedes combinar respuestas online y offline. Para cargar respuestas sin conexión, ve a la pestaña \"Encuesta\" de este proyecto y haz clic en \"Importar\".",
   "app.containers.Admin.projects.all.notIncludedInYourPlan": "Sin embargo, esto no está incluido en tu plan actual. Ponte en contacto con tu Gestor de Éxito Gubernamental o con el administrador para desbloquearlo.",
   "app.containers.Admin.projects.all.notes": "Notas",
-  "app.containers.Admin.projects.all.personalDataExplanation1": "Si marcas la casilla de abajo, crearemos cuentas de usuario para los participantes sin conexión.",
   "app.containers.Admin.projects.project.analysis.aiSummary": "Resumen de la IA",
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "Se trata de contenido generado por IA. Puede que no sea 100% exacto. Por favor, revísalo y haz referencias cruzadas con las entradas reales para comprobar su exactitud. Ten en cuenta que es probable que la precisión mejore si se reduce el número de entradas seleccionadas.",
   "app.containers.Admin.projects.project.ideas.analysisAction": "Ir al análisis de IA",

--- a/front/app/translations/admin/es-ES.json
+++ b/front/app/translations/admin/es-ES.json
@@ -758,7 +758,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "Puedes combinar respuestas online y offline. Para cargar respuestas sin conexión, ve a la pestaña \"Encuesta\" de este proyecto y haz clic en \"Importar\".",
   "app.containers.Admin.projects.all.notIncludedInYourPlan": "Sin embargo, esto no está incluido en tu plan actual. Ponte en contacto con tu Gestor de Éxito Gubernamental o con el administrador para desbloquearlo.",
   "app.containers.Admin.projects.all.notes": "Notas",
-  "app.containers.Admin.projects.all.personalDataExplanation1": "Si marcas la casilla de abajo, crearemos cuentas de usuario para los participantes sin conexión.",
   "app.containers.Admin.projects.project.analysis.aiSummary": "Resumen de la IA",
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "Se trata de contenido generado por IA. Puede que no sea 100% exacto. Por favor, revísalo y haz referencias cruzadas con las entradas reales para comprobar su exactitud. Ten en cuenta que es probable que la precisión mejore si se reduce el número de entradas seleccionadas.",
   "app.containers.Admin.projects.project.ideas.analysisAction": "Ir al análisis de la IA",

--- a/front/app/translations/admin/fi-FI.json
+++ b/front/app/translations/admin/fi-FI.json
@@ -758,7 +758,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "Voit yhdistää online- ja offline-vastauksia. Voit ladata offline-vastauksia siirtymällä tämän projektin Kysely-välilehdelle ja napsauttamalla Tuo.",
   "app.containers.Admin.projects.all.notIncludedInYourPlan": "Tämä ei kuitenkaan sisälly nykyiseen suunnitelmaasi. Ota yhteyttä Government Success Manageriin tai järjestelmänvalvojaan avataksesi sen lukituksen.",
   "app.containers.Admin.projects.all.notes": "Huomautuksia",
-  "app.containers.Admin.projects.all.personalDataExplanation1": "Jos valitset alla olevan ruudun, luomme käyttäjätilejä offline-osallistujille.",
   "app.containers.Admin.projects.project.analysis.aiSummary": "AI yhteenveto",
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "Tämä on tekoälyn luomaa sisältöä. Se ei välttämättä ole 100 % tarkka. Tarkista ja vertaa todellisia syötteitä tarkkuuden varmistamiseksi. Huomaa, että tarkkuus todennäköisesti paranee, jos valittujen tulojen määrää vähennetään.",
   "app.containers.Admin.projects.project.ideas.analysisAction": "Siirry AI-analyysiin",

--- a/front/app/translations/admin/fr-BE.json
+++ b/front/app/translations/admin/fr-BE.json
@@ -758,7 +758,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "Vous pouvez combiner des réponses en ligne et hors ligne. Pour télécharger des réponses hors ligne, allez dans l'onglet \"Enquête\" de ce projet et cliquez sur \"Importer\".",
   "app.containers.Admin.projects.all.notIncludedInYourPlan": "Cependant, cela n'est pas inclus dans votre plan actuel. Contactez votre Government Success Manager ou votre administrateur pour le débloquer.",
   "app.containers.Admin.projects.all.notes": "Notes",
-  "app.containers.Admin.projects.all.personalDataExplanation1": "Si vous cochez la case ci-dessous, nous créerons des comptes d'utilisateur pour les participants hors ligne.",
   "app.containers.Admin.projects.project.analysis.aiSummary": "Résumé de l'IA",
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "Ce contenu a été généré par un modèle d'intelligence artificielle. Il peut ne pas être totalement exact. Nous vous recommandons de le vérifier en le recoupant avec les contributions d'origine. Notez que la précision est susceptible de s'améliorer si le nombre de contributions sélectionnées est réduit.",
   "app.containers.Admin.projects.project.ideas.analysisAction": "Accéder à l'analyse par IA",

--- a/front/app/translations/admin/fr-FR.json
+++ b/front/app/translations/admin/fr-FR.json
@@ -758,7 +758,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "Vous pouvez combiner des réponses en ligne et hors ligne. Pour télécharger des réponses hors ligne, allez dans l'onglet \"Enquête\" de ce projet et cliquez sur \"Importer\".",
   "app.containers.Admin.projects.all.notIncludedInYourPlan": "Cependant, cela n'est pas inclus dans votre plan actuel. Contactez votre Government Success Manager ou votre administrateur pour le débloquer.",
   "app.containers.Admin.projects.all.notes": "Notes",
-  "app.containers.Admin.projects.all.personalDataExplanation1": "Si vous cochez la case ci-dessous, nous créerons des comptes d'utilisateur pour les participants hors ligne.",
   "app.containers.Admin.projects.project.analysis.aiSummary": "Résumé de l'IA",
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "Ce contenu a été généré par un modèle d'intelligence artificielle. Il peut ne pas être totalement exact. Nous vous recommandons de le vérifier en le recoupant avec les contributions d'origine. Notez que la précision est susceptible de s'améliorer si le nombre de contributions sélectionnées est réduit.",
   "app.containers.Admin.projects.project.ideas.analysisAction": "Accéder à l'analyse par IA",

--- a/front/app/translations/admin/hr-HR.json
+++ b/front/app/translations/admin/hr-HR.json
@@ -758,7 +758,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "Možete kombinirati online i offline odgovore. Za prijenos izvanmrežnih odgovora idite na karticu \"Anketa\" ovog projekta i kliknite \"Uvezi\".",
   "app.containers.Admin.projects.all.notIncludedInYourPlan": "Međutim, to nije uključeno u vaš trenutni plan. Obratite se svom upravitelju uspjeha vlade ili administratoru da ga otključa.",
   "app.containers.Admin.projects.all.notes": "Bilješke",
-  "app.containers.Admin.projects.all.personalDataExplanation1": "Ako potvrdite okvir u nastavku, stvorit ćemo korisničke račune za izvanmrežne sudionike.",
   "app.containers.Admin.projects.project.analysis.aiSummary": "AI sažetak",
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "Ovo je sadržaj generiran umjetnom inteligencijom. Možda nije 100% točno. Pregledajte i usporedite sa stvarnim unosima radi točnosti. Imajte na umu da će se točnost vjerojatno poboljšati ako se smanji broj odabranih ulaza.",
   "app.containers.Admin.projects.project.ideas.analysisAction": "Idite na AI analizu",

--- a/front/app/translations/admin/lv-LV.json
+++ b/front/app/translations/admin/lv-LV.json
@@ -758,7 +758,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "Varat apvienot tiešsaistes un bezsaistes atbildes. Lai augšupielādētu bezsaistes atbildes, dodieties uz šī projekta cilni \"Aptauja\" un noklikšķiniet uz \"Importēt\".",
   "app.containers.Admin.projects.all.notIncludedInYourPlan": "Tomēr tas nav iekļauts jūsu pašreizējā plānā. Lai to atbloķētu, sazinieties ar savu valdības veiksmes menedžeri vai administratoru.",
   "app.containers.Admin.projects.all.notes": "Piezīmes",
-  "app.containers.Admin.projects.all.personalDataExplanation1": "Ja atzīmēsiet šo izvēles rūtiņu, mēs izveidosim lietotāja kontus bezsaistes dalībniekiem.",
   "app.containers.Admin.projects.project.analysis.aiSummary": "AI kopsavilkums",
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "Šis ir mākslīgā intelekta radīts saturs. Tas var nebūt 100% precīzs. Lūdzu, pārbaudiet un salīdziniet ar faktiskajiem ievades datiem, lai pārliecinātos par precizitāti. Ņemiet vērā, ka precizitāte, visticamāk, uzlabosies, ja izvēlēto ievades datu skaits tiks samazināts.",
   "app.containers.Admin.projects.project.ideas.analysisAction": "Pārejiet uz AI analīzi",

--- a/front/app/translations/admin/nb-NO.json
+++ b/front/app/translations/admin/nb-NO.json
@@ -758,7 +758,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "Du kan kombinere online og offline svar. For å laste opp frakoblede svar, gå til fanen \"Survey\" for dette prosjektet og klikk \"Importer\".",
   "app.containers.Admin.projects.all.notIncludedInYourPlan": "Dette er imidlertid ikke inkludert i din nåværende plan. Ta kontakt med Government Success Manager eller administrator for å låse den opp.",
   "app.containers.Admin.projects.all.notes": "Notater",
-  "app.containers.Admin.projects.all.personalDataExplanation1": "Hvis du merker av i boksen nedenfor, oppretter vi brukerkontoer for offline deltakere.",
   "app.containers.Admin.projects.project.analysis.aiSummary": "AI oppsummering",
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "Dette er AI-generert innhold. Det er kanskje ikke 100% nøyaktig. Se gjennom og kryssreferanse med de faktiske inngangene for nøyaktighet. Vær oppmerksom på at nøyaktigheten sannsynligvis vil forbedres hvis antall valgte innganger reduseres.",
   "app.containers.Admin.projects.project.ideas.analysisAction": "Gå til AI-analyse",

--- a/front/app/translations/admin/nl-BE.json
+++ b/front/app/translations/admin/nl-BE.json
@@ -758,7 +758,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "Je kunt online en offline reacties combineren. Als je offline reacties wilt uploaden, ga je naar het tabblad 'Vragenlijst' van dit project en klik je op 'Importeren'.",
   "app.containers.Admin.projects.all.notIncludedInYourPlan": "Dit is echter niet inbegrepen in je huidige abonnement. Neem contact op met je Government Success Manager of platformbeheerder om dit te ontgrendelen.",
   "app.containers.Admin.projects.all.notes": "Opmerkingen",
-  "app.containers.Admin.projects.all.personalDataExplanation1": "Als je het vakje hieronder aanvinkt, maken we gebruikersaccounts aan voor offline deelnemers.",
   "app.containers.Admin.projects.project.analysis.aiSummary": "AI-samenvatting",
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "Dit is AI-gegenereerde inhoud. Het is mogelijk niet 100% nauwkeurig. Controleer de nauwkeurigheid door te vergelijken met de werkelijke bijdragen. Houd er rekening mee dat de nauwkeurigheid waarschijnlijk verbetert als het aantal geselecteerde bijdragen wordt verminderd.",
   "app.containers.Admin.projects.project.ideas.analysisAction": "Ga naar AI-analyse",

--- a/front/app/translations/admin/nl-NL.json
+++ b/front/app/translations/admin/nl-NL.json
@@ -758,7 +758,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "Je kunt online en offline reacties combineren. Als je offline reacties wilt uploaden, ga je naar het tabblad 'Vragenlijst' van dit project en klik je op 'Importeren'.",
   "app.containers.Admin.projects.all.notIncludedInYourPlan": "Dit is echter niet inbegrepen in je huidige abonnement. Neem contact op met je Government Success Manager of platformbeheerder om dit te ontgrendelen.",
   "app.containers.Admin.projects.all.notes": "Opmerkingen",
-  "app.containers.Admin.projects.all.personalDataExplanation1": "Als je het vakje hieronder aanvinkt, maken we gebruikersaccounts aan voor offline deelnemers.",
   "app.containers.Admin.projects.project.analysis.aiSummary": "AI-samenvatting",
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "Dit is AI-gegenereerde inhoud. Het is mogelijk niet 100% nauwkeurig. Controleer de nauwkeurigheid door te vergelijken met de werkelijke bijdragen. Houd er rekening mee dat de nauwkeurigheid waarschijnlijk verbetert als het aantal geselecteerde bijdragen wordt verminderd.",
   "app.containers.Admin.projects.project.ideas.analysisAction": "Ga naar AI-analyse",

--- a/front/app/translations/admin/pl-PL.json
+++ b/front/app/translations/admin/pl-PL.json
@@ -758,7 +758,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "Możesz łączyć odpowiedzi online i offline. Aby przesłać odpowiedzi offline, przejdź do zakładki \"Ankieta\" tego projektu i kliknij \"Importuj\".",
   "app.containers.Admin.projects.all.notIncludedInYourPlan": "Nie jest to jednak uwzględnione w Twoim obecnym planie. Skontaktuj się ze swoim Government Success Managerem lub administratorem, aby ją odblokować.",
   "app.containers.Admin.projects.all.notes": "Uwagi",
-  "app.containers.Admin.projects.all.personalDataExplanation1": "Jeśli zaznaczysz poniższe pole, utworzymy konta użytkowników dla uczestników offline.",
   "app.containers.Admin.projects.project.analysis.aiSummary": "Podsumowanie AI",
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "To jest zawartość generowana przez sztuczną inteligencję. Może ona nie być w 100% dokładna. Sprawdź i porównaj z rzeczywistymi danymi wejściowymi pod kątem dokładności. Pamiętaj, że dokładność prawdopodobnie poprawi się, jeśli liczba wybranych danych wejściowych zostanie zmniejszona.",
   "app.containers.Admin.projects.project.ideas.analysisAction": "Przejdź do analizy AI",

--- a/front/app/translations/admin/pt-BR.json
+++ b/front/app/translations/admin/pt-BR.json
@@ -758,7 +758,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "Você pode combinar respostas on-line e off-line. Para carregar respostas off-line, vá para a guia \"Survey\" (Pesquisa) desse projeto e clique em \"Import\" (Importar).",
   "app.containers.Admin.projects.all.notIncludedInYourPlan": "No entanto, isso não está incluído em seu plano atual. Entre em contato com seu gerente de sucesso do governo ou administrador para desbloqueá-lo.",
   "app.containers.Admin.projects.all.notes": "Notas",
-  "app.containers.Admin.projects.all.personalDataExplanation1": "Se você marcar a caixa abaixo, criaremos contas de usuário para os participantes off-line.",
   "app.containers.Admin.projects.project.analysis.aiSummary": "Resumo da IA",
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "Este é um conteúdo gerado por IA. Ele pode não ser 100% preciso. Revise e faça referência cruzada com os inputs reais para verificar a precisão. Lembre-se de que a precisão provavelmente melhorará se o número de entradas selecionadas for reduzido.",
   "app.containers.Admin.projects.project.ideas.analysisAction": "Ir para a análise da IA",

--- a/front/app/translations/admin/sr-Latn.json
+++ b/front/app/translations/admin/sr-Latn.json
@@ -758,7 +758,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "You can combine online and offline responses. To upload offline responses, go to the 'Survey' tab of this project, and click 'Import'.",
   "app.containers.Admin.projects.all.notIncludedInYourPlan": "However, this is not included in your current plan. Reach out to your Government Success Manager or admin to unlock it.",
   "app.containers.Admin.projects.all.notes": "Notes",
-  "app.containers.Admin.projects.all.personalDataExplanation1": "If you check the box below, we will create user accounts for offline participants.",
   "app.containers.Admin.projects.project.analysis.aiSummary": "AI summary",
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "This is AI-generated content. It may not be 100% accurate. Please review and cross-reference with the actual inputs for accuracy. Be aware that the accuracy is likely to improve if the number of selected inputs is reduced.",
   "app.containers.Admin.projects.project.ideas.analysisAction": "Go to AI analysis",

--- a/front/app/translations/admin/sr-SP.json
+++ b/front/app/translations/admin/sr-SP.json
@@ -758,7 +758,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "You can combine online and offline responses. To upload offline responses, go to the 'Survey' tab of this project, and click 'Import'.",
   "app.containers.Admin.projects.all.notIncludedInYourPlan": "However, this is not included in your current plan. Reach out to your Government Success Manager or admin to unlock it.",
   "app.containers.Admin.projects.all.notes": "Notes",
-  "app.containers.Admin.projects.all.personalDataExplanation1": "If you check the box below, we will create user accounts for offline participants.",
   "app.containers.Admin.projects.project.analysis.aiSummary": "AI summary",
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "This is AI-generated content. It may not be 100% accurate. Please review and cross-reference with the actual inputs for accuracy. Be aware that the accuracy is likely to improve if the number of selected inputs is reduced.",
   "app.containers.Admin.projects.project.ideas.analysisAction": "Идите на АИ анализу",

--- a/front/app/translations/admin/sv-SE.json
+++ b/front/app/translations/admin/sv-SE.json
@@ -758,7 +758,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "Du kan kombinera online- och offline-svar. För att ladda upp offline-svar går du till fliken \"Survey\" i det här projektet och klickar på \"Import\".",
   "app.containers.Admin.projects.all.notIncludedInYourPlan": "Detta ingår dock inte i din nuvarande plan. Kontakta din Government Success Manager eller administratör för att låsa upp den.",
   "app.containers.Admin.projects.all.notes": "Anteckningar",
-  "app.containers.Admin.projects.all.personalDataExplanation1": "Om du markerar rutan nedan kommer vi att skapa användarkonton för offline-deltagare.",
   "app.containers.Admin.projects.project.analysis.aiSummary": "Sammanfattning av AI",
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "Detta är AI-genererat innehåll. Det kanske inte är 100% korrekt. Vänligen granska och korsreferera med de faktiska indata för noggrannhet. Observera att noggrannheten sannolikt kommer att förbättras om antalet valda indata minskas.",
   "app.containers.Admin.projects.project.ideas.analysisAction": "Gå till AI-analys",

--- a/front/app/translations/admin/tr-TR.json
+++ b/front/app/translations/admin/tr-TR.json
@@ -758,7 +758,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "Çevrimiçi ve çevrimdışı yanıtları birleştirebilirsiniz. Çevrimdışı yanıtları yüklemek için bu projenin 'Anket' sekmesine gidin ve 'İçe Aktar'a tıklayın.",
   "app.containers.Admin.projects.all.notIncludedInYourPlan": "Ancak, bu mevcut planınıza dahil değildir. Kilidi açmak için Kamu Başarı Yöneticinize veya yöneticinize ulaşın.",
   "app.containers.Admin.projects.all.notes": "Notlar",
-  "app.containers.Admin.projects.all.personalDataExplanation1": "Aşağıdaki kutuyu işaretlerseniz, çevrimdışı katılımcılar için kullanıcı hesapları oluşturacağız.",
   "app.containers.Admin.projects.project.analysis.aiSummary": "Yapay zeka özeti",
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "Bu yapay zeka tarafından oluşturulmuş bir içeriktir. 100 doğru olmayabilir. Lütfen doğruluk için gerçek girdileri gözden geçirin ve çapraz referans alın. Seçilen girdilerin sayısı azaltılırsa doğruluğun muhtemelen artacağını unutmayın.",
   "app.containers.Admin.projects.project.ideas.analysisAction": "Yapay zeka analizine git",


### PR DESCRIPTION
# Changelog
## Fixed
- [[TAN-1569](https://www.notion.so/citizenlab/The-dashboard-representation-data-upload-tool-doesn-t-allow-to-save-if-only-1-toggle-is-turned-on-a4998e7df221483bb6c7a0093b320925?pvs=4)] Allow saving dashboard representation data when only 1 toggle is turned on. 