### PR TITLE
TAN-1584: Make sure animation before submit is under 5 seconds

### DIFF
--- a/front/app/components/ParticipationCTABars/VotingCTABar/CTAButton.tsx
+++ b/front/app/components/ParticipationCTABars/VotingCTABar/CTAButton.tsx
@@ -27,9 +27,10 @@ const confetti = new JSConfetti();
 const StyledButton = styled(Button)`
   &.pulse {
     animation-name: pulse;
-    animation-duration: 1s;
     animation-timing-function: ease;
-    animation-iteration-count: 4; /* Run the animation fout times be below 5 seconds. See https://www.w3.org/WAI/WCAG21/Understanding/pause-stop-hide.html */
+    /* We set 1 second for the animation and run it 4 times to make sure we are a11y compliant (Under 5 seconds) */
+    animation-iteration-count: 4;
+    animation-duration: 1s;
     animation-delay: 0.3s;
     animation-fill-mode: forwards;
   }

--- a/front/app/components/ParticipationCTABars/VotingCTABar/CTAButton.tsx
+++ b/front/app/components/ParticipationCTABars/VotingCTABar/CTAButton.tsx
@@ -27,10 +27,11 @@ const confetti = new JSConfetti();
 const StyledButton = styled(Button)`
   &.pulse {
     animation-name: pulse;
-    animation-duration: 1.3s;
+    animation-duration: 1s;
     animation-timing-function: ease;
+    animation-iteration-count: 4; /* Run the animation fout times be below 5 seconds. See https://www.w3.org/WAI/WCAG21/Understanding/pause-stop-hide.html */
     animation-delay: 0.3s;
-    animation-iteration-count: infinite;
+    animation-fill-mode: forwards;
   }
 
   /* border-radius */


### PR DESCRIPTION
# Changelog

## Changed
- Restrict animation time on adding budget to below 5 seconds to align with the pause, stop and hide standard for WCAG 2.1. [See](https://www.w3.org/WAI/WCAG21/Understanding/pause-stop-hide.html)
