### PR TITLE
[TAN-1779] Use axlsx gem to write files (fixes dates)

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -73,7 +73,6 @@ group :development do
 end
 
 group :test do
-  gem 'rubyXL'
   gem 'shoulda-matchers', '~> 6.2.0'
   gem 'webmock', '~> 3.23'
 
@@ -105,7 +104,8 @@ gem 'kaminari', '~> 1.2'
 gem 'rails-i18n', '~> 7.0.9'
 
 gem 'awesome_nested_set', '~> 3.5.0'
-gem 'axlsx', '3.0.0.pre'
+gem 'axlsx', '3.0.0.pre' # write xlsx files
+gem 'rubyXL' # read xlsx files. Has issues with writing files https://github.com/CitizenLabDotCo/citizenlab/pull/7834
 gem 'counter_culture', '~> 3.5'
 gem 'groupdate', '~> 4.1'
 gem 'icalendar', '~> 2.10'

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/patches/xlsx_service.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/patches/xlsx_service.rb
@@ -15,20 +15,16 @@ module BulkImportIdeas
         data_rows = worksheet.drop(1)
 
         data_rows.each_slice(max_rows).map do |rows|
-          # Create new package
           new_package = Axlsx::Package.new
           new_workbook = new_package.workbook
           new_workbook.add_worksheet(name: worksheet.sheet_name) do |new_sheet|
-            # Add header
             new_sheet.add_row(header.cells.map { |c| c&.value })
 
-            # Add data rows
             rows.each do |row|
               new_sheet.add_row(row.cells.map { |c| c&.value })
             end
           end
 
-          # Serialize to stream
           new_package.to_stream
         end
       end

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/patches/xlsx_service.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/patches/xlsx_service.rb
@@ -15,23 +15,21 @@ module BulkImportIdeas
         data_rows = worksheet.drop(1)
 
         data_rows.each_slice(max_rows).map do |rows|
-          # Create new workbook
-          new_workbook = RubyXL::Workbook.new
-          new_worksheet = new_workbook[0]
-          new_worksheet.sheet_name = worksheet.sheet_name
+          # Create new package
+          new_package = Axlsx::Package.new
+          new_workbook = new_package.workbook
+          new_workbook.add_worksheet(name: worksheet.sheet_name) do |new_sheet|
+            # Add header
+            new_sheet.add_row(header.cells.map { |c| c&.value })
 
-          # Add header
-          header.cells.each_with_index do |cell, i|
-            new_worksheet.add_cell(0, i, cell.value)
-          end
-
-          # Add data rows
-          rows.each_with_index do |row, i|
-            row.cells.each_with_index do |cell, j|
-              new_worksheet.add_cell(i + 1, j, cell.value) unless cell.nil?
+            # Add data rows
+            rows.each do |row|
+              new_sheet.add_row(row.cells.map { |c| c&.value })
             end
           end
-          new_workbook.stream
+
+          # Serialize to stream
+          new_package.to_stream
         end
       end
     end


### PR DESCRIPTION
RubyXL gem does not write dates correctly (the old code):

```ruby
[1] pry(#<XlsxService>)> cell
=> #<RubyXL::Cell(1,4): "45415", datatype=nil, style_index=3>
[2] pry(#<XlsxService>)> cell.value
=> Fri, 03 May 2024 00:00:00 +0000
[3] pry(#<XlsxService>)> new_worksheet.sheet_data[i+1][j].value
=> 45415.0
[4] pry(#<XlsxService>)> new_worksheet.sheet_data[i+1][j]
=> #<RubyXL::Cell(1,4): 45415.0, datatype=nil, style_index=0>
```

In the line [3], the value is a float, not a date.

Axlsx gem does write dates correctly (the new code):

```ruby
[1] pry(#<XlsxService>)> rows[1][4]
=> #<RubyXL::Cell(2,4): "45415", datatype=nil, style_index=3>
[2] pry(#<XlsxService>)> rows[1][4].value
=> Fri, 03 May 2024 00:00:00 +0000
[3] pry(#<XlsxService>)> new_sheet.rows[1][4].value
=> Fri, 03 May 2024 00:00:00 +0000
```

In the line [3], the value is a date.

Maybe it's possible to make RubyXL work, but I didn't want to spend time on it. Probably, we should always use Axlsx gem to write files and RubyXL gem to read files (Axlsx cannot read).

# Changelog
## Fixed
* [TAN-1779] Fix number (date) parsing in input XLSX import