### PR TITLE
[TAN-1792] Use boolean of can_admin query param to filter only admins OR only NOT admins

### DIFF
--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -21,7 +21,11 @@ class WebApi::V1::UsersController < ApplicationController
     @users = @users.admin.or(@users.project_moderator).or(@users.project_folder_moderator) if params[:can_moderate].present?
     @users = @users.not_project_folder_moderator(params[:is_not_folder_moderator]) if params[:is_not_folder_moderator].present?
     @users = @users.not_citizenlab_member if params[:not_citizenlab_member].present?
-    @users = @users.admin if params[:can_admin].present?
+
+    case params[:can_admin]&.downcase
+    when 'true' then @users = @users.admin
+    when 'false' then @users = @users.not_admin
+    end
 
     if params[:search].blank?
       @users = case params[:sort]

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -384,7 +384,7 @@ resource 'Users' do
         parameter :group, 'Filter by group_id', required: false
         parameter :can_moderate_project, 'Filter by users (and admins) who can moderate the project (by id)', required: false
         parameter :can_moderate, 'Return only admins and moderators', required: false
-        parameter :can_admin, 'Return only admins', required: false
+        parameter :can_admin, 'Return only admins if value is true, only non-admins if value is false', required: false
         parameter :blocked, 'Return only blocked users', required: false
 
         example_request 'List all users' do
@@ -568,6 +568,19 @@ resource 'Users' do
           do_request(can_moderate: true)
           json_response = json_parse(response_body)
           expect(json_response[:data].pluck(:id)).to match_array [a.id, m1.id, m2.id, @user.id]
+        end
+
+        example 'List all moderators who are not admins' do
+          p = create(:project)
+          m1 = create(:project_moderator, projects: [p])
+          m2 = create(:project_moderator)
+          f = create(:project_folder_moderator, project_folders: [create(:project_folder)])
+          create(:admin, roles: [{ type: 'admin' }, { type: 'project_moderator', project_id: p.id }])
+          create(:user)
+
+          do_request(can_moderate: true, can_admin: false)
+          json_response = json_parse(response_body)
+          expect(json_response[:data].pluck(:id)).to match_array [m1.id, m2.id, f.id]
         end
 
         example 'List all admins' do


### PR DESCRIPTION
Should not break any existing user filtering, since FE seems to consistently pass `?can_admin=true`, even though BE was previously only checking for presence of param value.

With these changes, the FE can now request a list of users who are project AND/OR folder moderators, _without_ including admins who may have been assigned as a project and/or folder moderator, as will be required in the new user listings of 'Admins' vs 'Project managers'. (see [designs](https://www.figma.com/file/HxJ6CL98BHbNxAtOboiJrZ/Project-Manager-Autonomy?type=design&node-id=4820-14923&mode=design&t=SrDXzavf8WnzKwhc-0)), using;

`.../users?can_moderate=true&can_admin=false`

Note: Although the copy says 'Project managers' in the designs, we actually want this list to include folder managers also.

# Changelog
## Technical
- [TAN-1792] Use boolean of can_admin query param to filter only admins OR only NOT admins.
