### PR TITLE
TAN-1588: Set the max char count for confirmation code to 4

### DIFF
--- a/front/app/containers/Authentication/steps/EmailConfirmation/index.tsx
+++ b/front/app/containers/Authentication/steps/EmailConfirmation/index.tsx
@@ -123,6 +123,7 @@ const EmailConfirmation = ({
             name="code"
             type="text"
             label={formatMessage(messages.codeInput)}
+            maxCharCount={4}
           />
         </Box>
         <Box w="100%" display="flex" mt="32px">


### PR DESCRIPTION
# Changelog

## Fixed
- Explicitly limit the maximum character count for the confirmation code after signup to 4 characters. This doesn't change functionality but it makes it easy for users to use the confirmation code correctly.
