### PR TITLE
[No-ticket] disable rubocop rule for users index

### DIFF
--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -6,7 +6,7 @@ class WebApi::V1::UsersController < ApplicationController
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
-  def index
+  def index # rubocop:disable Metrics/CyclomaticComplexity
     authorize :user, :index?
 
     @users = policy_scope User


### PR DESCRIPTION
Temporary fix to get linting green, while I refactor to reduce complexity of method, following merging 2 PRs that each slightly increased the complexity.