### PR TITLE
[TAN-1802] Limit activities index to admins only

### DIFF
--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
         resources :followers, only: [:create]
       end
       concern :post do
-        resources :activities, only: [:index]
+        # resources :activities, only: [:index]
         resources :comments, shallow: true,
           concerns: %i[reactable spam_reportable],
           defaults: { reactable: 'Comment', spam_reportable: 'Comment' } do

--- a/back/spec/acceptance/idea_activities_spec.rb
+++ b/back/spec/acceptance/idea_activities_spec.rb
@@ -6,26 +6,26 @@ require 'rspec_api_documentation/dsl'
 resource 'Activities' do
   explanation 'Activities capture interactions throughout the platform, like posting ideas, reacting or editing/deleting content.'
 
-  get 'web_api/v1/ideas/:idea_id/activities' do
-    before do
-      @idea = create(:idea)
-      create(:published_activity, item: @idea)
-      create(:changed_title_activity, item: @idea)
-      create(:changed_body_activity, item: @idea)
-      create(:changed_status_activity, item: @idea)
-    end
+  # get 'web_api/v1/ideas/:idea_id/activities' do
+  #   before do
+  #     @idea = create(:idea)
+  #     create(:published_activity, item: @idea)
+  #     create(:changed_title_activity, item: @idea)
+  #     create(:changed_body_activity, item: @idea)
+  #     create(:changed_status_activity, item: @idea)
+  #   end
 
-    with_options scope: :page do
-      parameter :number, 'Page number'
-      parameter :size, 'Number of activities per page'
-    end
+  #   with_options scope: :page do
+  #     parameter :number, 'Page number'
+  #     parameter :size, 'Number of activities per page'
+  #   end
 
-    let(:idea_id) { @idea.id }
+  #   let(:idea_id) { @idea.id }
 
-    example_request 'List all activities' do
-      expect(status).to eq(200)
-      json_response = json_parse(response_body)
-      expect(json_response[:data].size).to eq 4
-    end
-  end
+  #   example_request 'List all activities' do
+  #     expect(status).to eq(200)
+  #     json_response = json_parse(response_body)
+  #     expect(json_response[:data].size).to eq 4
+  #   end
+  # end
 end

--- a/back/spec/acceptance/initiative_activities_spec.rb
+++ b/back/spec/acceptance/initiative_activities_spec.rb
@@ -6,26 +6,26 @@ require 'rspec_api_documentation/dsl'
 resource 'Activities' do
   explanation 'Activities capture interactions throughout the platform, like posting initiatives, reacting or editing/deleting content.'
 
-  get 'web_api/v1/initiatives/:initiative_id/activities' do
-    before do
-      @initiative = create(:initiative)
-      create(:published_activity, item: @initiative)
-      create(:changed_title_activity, item: @initiative)
-      create(:changed_body_activity, item: @initiative)
-      create(:changed_status_activity, item: @initiative)
-    end
+  # get 'web_api/v1/initiatives/:initiative_id/activities' do
+  #   before do
+  #     @initiative = create(:initiative)
+  #     create(:published_activity, item: @initiative)
+  #     create(:changed_title_activity, item: @initiative)
+  #     create(:changed_body_activity, item: @initiative)
+  #     create(:changed_status_activity, item: @initiative)
+  #   end
 
-    with_options scope: :page do
-      parameter :number, 'Page number'
-      parameter :size, 'Number of activities per page'
-    end
+  #   with_options scope: :page do
+  #     parameter :number, 'Page number'
+  #     parameter :size, 'Number of activities per page'
+  #   end
 
-    let(:initiative_id) { @initiative.id }
+  #   let(:initiative_id) { @initiative.id }
 
-    example_request 'List all activities' do
-      expect(status).to eq(200)
-      json_response = json_parse(response_body)
-      expect(json_response[:data].size).to eq 4
-    end
-  end
+  #   example_request 'List all activities' do
+  #     expect(status).to eq(200)
+  #     json_response = json_parse(response_body)
+  #     expect(json_response[:data].size).to eq 4
+  #   end
+  # end
 end


### PR DESCRIPTION
WIP (experimental, at this point)

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->
