### PR TITLE
TAN-1765 Generate valid slugs

### DIFF
--- a/back/app/models/concerns/sluggable.rb
+++ b/back/app/models/concerns/sluggable.rb
@@ -17,7 +17,7 @@ module Sluggable
     def slug(options = {})
       @has_slug = true
       @slug_attribute = options[:attribute] || :slug
-      @slug_from ||= (options[:from] || proc { |sluggable| generate_fallback_slug(sluggable) })
+      @slug_from ||= (options[:from] || proc { |_| generate_fallback_slug })
       @slug_if = options[:if]
     end
   end
@@ -32,7 +32,7 @@ module Sluggable
 
     from_value = self.class.slug_from.call(self)
     self.slug = SlugService.new.generate_slug self, from_value
-    self.slug = generate_fallback_slug(self) if !SLUG_REGEX.match?(slug)
+    self.slug = generate_fallback_slug if !SLUG_REGEX.match?(slug)
   end
 
   private
@@ -42,6 +42,6 @@ module Sluggable
   end
 end
 
-def generate_fallback_slug(sluggable)
-  sluggable.id || SecureRandom.uuid
+def generate_fallback_slug
+  SecureRandom.uuid
 end

--- a/back/app/models/concerns/sluggable.rb
+++ b/back/app/models/concerns/sluggable.rb
@@ -12,12 +12,16 @@ module Sluggable
       !!@has_slug
     end
 
+    def generate_fallback_slug(sluggable)
+      sluggable.id || SecureRandom.uuid
+    end
+
     private
 
     def slug(options = {})
       @has_slug = true
       @slug_attribute = options[:attribute] || :slug
-      @slug_from ||= (options[:from] || proc { |sluggable| sluggable.id || SecureRandom.uuid })
+      @slug_from ||= (options[:from] || proc { |sluggable| generate_fallback_slug(sluggable) })
       @slug_if = options[:if]
     end
   end
@@ -32,6 +36,7 @@ module Sluggable
 
     from_value = self.class.slug_from.call(self)
     self.slug = SlugService.new.generate_slug self, from_value
+    self.slug = self.class.generate_fallback_slug(self) if !SLUG_REGEX.match?(slug)
   end
 
   private

--- a/back/app/models/concerns/sluggable.rb
+++ b/back/app/models/concerns/sluggable.rb
@@ -12,10 +12,6 @@ module Sluggable
       !!@has_slug
     end
 
-    def generate_fallback_slug(sluggable)
-      sluggable.id || SecureRandom.uuid
-    end
-
     private
 
     def slug(options = {})
@@ -36,7 +32,7 @@ module Sluggable
 
     from_value = self.class.slug_from.call(self)
     self.slug = SlugService.new.generate_slug self, from_value
-    self.slug = self.class.generate_fallback_slug(self) if !SLUG_REGEX.match?(slug)
+    self.slug = generate_fallback_slug(self) if !SLUG_REGEX.match?(slug)
   end
 
   private
@@ -44,4 +40,8 @@ module Sluggable
   def slug_enabled?
     self.class.slug? && (!self.class.slug_if || self.class.slug_if&.call(self))
   end
+end
+
+def generate_fallback_slug(sluggable)
+  sluggable.id || SecureRandom.uuid
 end

--- a/back/spec/models/concerns/sluggable_spec.rb
+++ b/back/spec/models/concerns/sluggable_spec.rb
@@ -47,6 +47,14 @@ RSpec.describe Sluggable do
         sluggable = create(sluggable_factories[:slug_on_publication], publication_status: 'published')
         expect(sluggable.slug).to be_present
       end
+
+      it 'generates valid slugs for various user names' do
+        titles = ['将太', 'константин', '-']
+        titles.each do |title|
+          sluggable = build(sluggable_factories[:slug_from_first_title], title_multiloc: { en: title })
+          expect(sluggable).to be_valid
+        end
+      end
     end
 
     describe 'validate' do

--- a/back/spec/services/user_slug_service_spec.rb
+++ b/back/spec/services/user_slug_service_spec.rb
@@ -5,32 +5,22 @@ require 'rails_helper'
 describe UserSlugService do
   let(:service) { described_class.new }
 
-  describe '#generate_slugs' do
-    it 'generates valid slugs for various user names' do
-      first_names = ['将太', 'константин', '-']
-      first_names.each do |first_name|
-        user = build(:user, first_name: first_name, last_name: nil)
-        expect(user).to be_valid
-      end
+  describe 'when Abbreviated User Names feature enabled' do
+    before { SettingsService.new.activate_feature! 'abbreviated_user_names' }
+
+    it 'uses uuids when bulk generating slugs' do
+      unpersisted_users = [build(:user, first_name: 'Jose', last_name: 'Moura')]
+
+      service.generate_slugs unpersisted_users
+
+      expect(unpersisted_users.map(&:slug)).not_to eq %w[jose-moura]
     end
 
-    describe 'when Abbreviated User Names feature enabled' do
-      before { SettingsService.new.activate_feature! 'abbreviated_user_names' }
-  
-      it 'uses uuids when bulk generating slugs' do
-        unpersisted_users = [build(:user, first_name: 'Jose', last_name: 'Moura')]
-  
-        service.generate_slugs unpersisted_users
-  
-        expect(unpersisted_users.map(&:slug)).not_to eq %w[jose-moura]
-      end
-  
-      it 'uses uuid for slug' do
-        unpersisted_record = build(:user, first_name: 'Jose', last_name: 'Moura')
-  
-        expect(service.generate_slug(unpersisted_record, unpersisted_record.full_name))
-          .not_to eq 'jose-moura'
-      end
+    it 'uses uuid for slug' do
+      unpersisted_record = build(:user, first_name: 'Jose', last_name: 'Moura')
+
+      expect(service.generate_slug(unpersisted_record, unpersisted_record.full_name))
+        .not_to eq 'jose-moura'
     end
   end
 end

--- a/back/spec/services/user_slug_service_spec.rb
+++ b/back/spec/services/user_slug_service_spec.rb
@@ -5,22 +5,32 @@ require 'rails_helper'
 describe UserSlugService do
   let(:service) { described_class.new }
 
-  describe 'when Abbreviated User Names feature enabled' do
-    before { SettingsService.new.activate_feature! 'abbreviated_user_names' }
-
-    it 'uses uuids when bulk generating slugs' do
-      unpersisted_users = [build(:user, first_name: 'Jose', last_name: 'Moura')]
-
-      service.generate_slugs unpersisted_users
-
-      expect(unpersisted_users.map(&:slug)).not_to eq %w[jose-moura]
+  describe '#generate_slugs' do
+    it 'generates valid slugs for various user names' do
+      first_names = ['将太', 'константин', '-']
+      first_names.each do |first_name|
+        user = build(:user, first_name: first_name, last_name: nil)
+        expect(user).to be_valid
+      end
     end
 
-    it 'uses uuid for slug' do
-      unpersisted_record = build(:user, first_name: 'Jose', last_name: 'Moura')
-
-      expect(service.generate_slug(unpersisted_record, unpersisted_record.full_name))
-        .not_to eq 'jose-moura'
+    describe 'when Abbreviated User Names feature enabled' do
+      before { SettingsService.new.activate_feature! 'abbreviated_user_names' }
+  
+      it 'uses uuids when bulk generating slugs' do
+        unpersisted_users = [build(:user, first_name: 'Jose', last_name: 'Moura')]
+  
+        service.generate_slugs unpersisted_users
+  
+        expect(unpersisted_users.map(&:slug)).not_to eq %w[jose-moura]
+      end
+  
+      it 'uses uuid for slug' do
+        unpersisted_record = build(:user, first_name: 'Jose', last_name: 'Moura')
+  
+        expect(service.generate_slug(unpersisted_record, unpersisted_record.full_name))
+          .not_to eq 'jose-moura'
+      end
     end
   end
 end


### PR DESCRIPTION
Follow up bugfix after https://github.com/CitizenLabDotCo/citizenlab/pull/7745. The generated slugs are not always valid (when only special characters are used). The proposed solution is to fallback to the instance's ID or a random UUID when no valid slug can be generated.

Run after release:
```
bundle exec rake fix_existing_tenants: fix_slugs
```

# Changelog
### Fixed
- [TAN-1765] Issues with user registration when only using special characters (like Cyrillic or Chinese characters).
