### PR TITLE
[TAN-1825] Make possible to update profile when last name is empty

### DIFF
--- a/front/app/containers/UsersEditPage/ProfileForm.tsx
+++ b/front/app/containers/UsersEditPage/ProfileForm.tsx
@@ -71,7 +71,7 @@ const ProfileForm = () => {
   }>({});
 
   const schema = object({
-    first_name: string().when('last_name', ([last_name], schema) => {
+    first_name: string().when('last_name', (last_name, schema) => {
       return last_name
         ? schema.required(formatMessage(messages.provideFirstNameIfLastName))
         : schema;

--- a/front/cypress/e2e/profile_edition.cy.ts
+++ b/front/cypress/e2e/profile_edition.cy.ts
@@ -17,15 +17,31 @@ describe('profile edition', () => {
     cy.visit('/profile/edit');
     cy.acceptCookies();
   });
+
+  function saveChanges() {
+    cy.get('button[type="submit"]').contains('Save changes').click();
+    cy.wait('@saveUser');
+    cy.get('[data-testid="feedbackSuccessMessage"]').should('exist');
+  }
+
   it('lets user edit their profile', () => {
     cy.intercept(`**/users/${userId}`).as('saveUser');
     cy.get('input[type="file"]').attachFile('icon.png');
     cy.get('#first_name').clear().type('John');
     cy.get('#last_name').clear().type('Doe');
-    cy.get('button[type="submit"]').contains('Save changes').click();
-    cy.wait('@saveUser');
-    cy.get('[data-testid="feedbackSuccessMessage"]').should('exist');
+    saveChanges();
   });
+
+  it('lets user change their first name when last name is empty', () => {
+    cy.intercept(`**/users/${userId}`).as('saveUser');
+    cy.get('#last_name').clear();
+    saveChanges();
+
+    cy.reload(); // important to reproduce the bug
+    cy.get('#first_name').clear().type('Lackland');
+    saveChanges();
+  });
+
   after(() => {
     cy.apiRemoveUser(userId);
   });


### PR DESCRIPTION
The validation was introduced here https://github.com/CitizenLabDotCo/citizenlab/pull/4781

# Changelog
## Fixed
* [TAN-1825] Make it possible to update profile when last name is empty