### PR TITLE
[TAN-1827] Use uncached project participants in new campaign recipients

### DIFF
--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/manual_project_participants.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/manual_project_participants.rb
@@ -53,7 +53,7 @@ module EmailCampaigns
     end
 
     def project_participants(users_scope, _options = {})
-      users_scope.where(id: ParticipantsService.new.project_participants(project))
+      users_scope.where(id: ParticipantsService.new.projects_participants(project))
     end
   end
 end


### PR DESCRIPTION
Might well want to undo this in the near future, but for now this allows us to test the email campaign works on production.

If we are OK with the project_participants used for recipients lagging with the caching, then we can revert this change.

# Changelog
## Technical
- [TAN-1827] Use uncached project participants in new campaign recipients
