### PR TITLE
Fix failing input form E2E tests

### DIFF
--- a/front/cypress/e2e/input_form_builder/built-in-fields/attachments.cy.ts
+++ b/front/cypress/e2e/input_form_builder/built-in-fields/attachments.cy.ts
@@ -64,7 +64,7 @@ describe('Input form builder', () => {
     // Title should not be present or editable
     cy.get('#e2e-title-multiloc').should('not.exist');
 
-    cy.get('[data-cy="e2e-more-field-actions"]').eq(4).click({ force: true });
+    cy.get('[data-cy="e2e-more-field-actions"]').eq(1).click({ force: true });
     cy.get('.e2e-more-actions-list button').contains('Delete').click();
 
     // The Attachments tool box item should be enabled as it has been removed from the canvas

--- a/front/cypress/e2e/input_form_builder/built-in-fields/description.cy.ts
+++ b/front/cypress/e2e/input_form_builder/built-in-fields/description.cy.ts
@@ -48,10 +48,11 @@ describe('Input form builder', () => {
       cy.contains('Description').click();
     });
 
-    cy.get('[data-cy="e2e-more-field-actions"]').eq(1).click({ force: true });
-    cy.get('.e2e-more-actions-list button')
-      .contains('Delete')
-      .should('not.exist');
+    cy.get('[data-cy="e2e-field-row"]')
+      .eq(1)
+      .within(() => {
+        cy.get('[data-cy="e2e-more-field-actions"]').should('not.exist');
+      });
 
     cy.get('#e2e-title-multiloc').should('not.exist');
   });

--- a/front/cypress/e2e/input_form_builder/built-in-fields/images.cy.ts
+++ b/front/cypress/e2e/input_form_builder/built-in-fields/images.cy.ts
@@ -49,10 +49,11 @@ describe('Input form builder', () => {
       cy.contains('Image upload').click();
     });
 
-    cy.get('[data-cy="e2e-more-field-actions"]').eq(3).click({ force: true });
-    cy.get('.e2e-more-actions-list button')
-      .contains('Delete')
-      .should('not.exist');
+    cy.get('[data-cy="e2e-field-row"]')
+      .eq(2)
+      .within(() => {
+        cy.get('[data-cy="e2e-more-field-actions"]').should('not.exist');
+      });
 
     cy.get('#e2e-title-multiloc').should('not.exist');
   });

--- a/front/cypress/e2e/input_form_builder/built-in-fields/location.cy.ts
+++ b/front/cypress/e2e/input_form_builder/built-in-fields/location.cy.ts
@@ -64,7 +64,7 @@ describe('Input form builder', () => {
     // Title should not be present or editable
     cy.get('#e2e-title-multiloc').should('not.exist');
 
-    cy.get('[data-cy="e2e-more-field-actions"]').eq(7).click({ force: true });
+    cy.get('[data-cy="e2e-more-field-actions"]').eq(4).click({ force: true });
     cy.get('.e2e-more-actions-list button').contains('Delete').click();
 
     // The location tool box item should be enabled as it has been removed from the canvas

--- a/front/cypress/e2e/input_form_builder/built-in-fields/tags.cy.ts
+++ b/front/cypress/e2e/input_form_builder/built-in-fields/tags.cy.ts
@@ -64,7 +64,7 @@ describe('Input form builder', () => {
     // Title should not be present or editable
     cy.get('#e2e-title-multiloc').should('not.exist');
 
-    cy.get('[data-cy="e2e-more-field-actions"]').eq(6).click({ force: true });
+    cy.get('[data-cy="e2e-more-field-actions"]').eq(3).click({ force: true });
     cy.get('.e2e-more-actions-list button').contains('Delete').click();
 
     // The tags tool box item should be enabled as it has been removed from the canvas

--- a/front/cypress/e2e/input_form_builder/built-in-fields/title.cy.ts
+++ b/front/cypress/e2e/input_form_builder/built-in-fields/title.cy.ts
@@ -48,10 +48,11 @@ describe('Input form builder', () => {
       cy.contains('Title').click();
     });
 
-    cy.get('[data-cy="e2e-more-field-actions"]').eq(0).click({ force: true });
-    cy.get('.e2e-more-actions-list button')
-      .contains('Delete')
-      .should('not.exist');
+    cy.get('[data-cy="e2e-field-row"]')
+      .eq(0)
+      .within(() => {
+        cy.get('[data-cy="e2e-more-field-actions"]').should('not.exist');
+      });
 
     cy.get('#e2e-title-multiloc').should('not.exist');
   });


### PR DESCRIPTION
Fixes the 6 failing E2E tests for the input form builder. The problem was that the "..." options were removed for default fields last week, but we were still assuming they were present in the tests when calculating the correct index to use to click the options for certain fields.

Running E2E tests [here](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/183294).