### PR TITLE
[TAN-1798] Fix issue with new input status route type

### DIFF
--- a/front/app/modules/commercial/custom_idea_statuses/index.tsx
+++ b/front/app/modules/commercial/custom_idea_statuses/index.tsx
@@ -12,14 +12,14 @@ const StatusShowComponent = React.lazy(() => import('./admin/containers/edit'));
 
 export enum customIdeaStatusesRoutes {
   statuses = 'statuses',
-  new = 'new',
+  new = 'statuses/new',
   id = `statuses/:id`,
 }
 
 // TODO: Replace "settings" with link to route in main app once converted.
 export type customIdeaStatusesRouteTypes =
   | AdminRoute<`settings/${customIdeaStatusesRoutes.statuses}`>
-  | AdminRoute<`settings/${customIdeaStatusesRoutes.new}`>
+  | AdminRoute<`settings/${customIdeaStatusesRoutes.statuses}/${customIdeaStatusesRoutes.new}`>
   | AdminRoute<`settings/${customIdeaStatusesRoutes.statuses}/${string}`>;
 
 const configuration: ModuleConfiguration = {


### PR DESCRIPTION
# Changelog
## Fixed
- [[TAN-1798](https://www.notion.so/citizenlab/Adding-new-statuses-page-is-not-working-338c1997f4e741cdb43f20060d409a86)] Fix broken new input status page.
