### PR TITLE
Removing author and budget custom fields

### DIFF
--- a/back/app/controllers/web_api/v1/ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/ideas_controller.rb
@@ -13,7 +13,7 @@ class WebApi::V1::IdeasController < ApplicationController
   def json_forms_schema
     input = Idea.find params[:id]
     enabled_fields = IdeaCustomFieldsService.new(input.custom_form).enabled_fields
-    json_attributes = JsonFormsService.new.input_ui_and_json_multiloc_schemas enabled_fields, current_user, input.input_term
+    json_attributes = JsonFormsService.new.input_ui_and_json_multiloc_schemas enabled_fields, current_user, input.input_term, input.participation_method_on_creation
     render json: raw_json(json_attributes)
   end
 

--- a/back/app/controllers/web_api/v1/phase_custom_fields_controller.rb
+++ b/back/app/controllers/web_api/v1/phase_custom_fields_controller.rb
@@ -7,7 +7,7 @@ class WebApi::V1::PhaseCustomFieldsController < ApplicationController
 
   def json_forms_schema
     if phase
-      render json: raw_json(JsonFormsService.new.input_ui_and_json_multiloc_schemas(custom_fields, current_user, phase.input_term))
+      render json: raw_json(JsonFormsService.new.input_ui_and_json_multiloc_schemas(custom_fields, current_user, phase.input_term, participation_method))
     else
       send_not_found
     end
@@ -19,7 +19,11 @@ class WebApi::V1::PhaseCustomFieldsController < ApplicationController
     @phase ||= Phase.find params[:phase_id]
   end
 
+  def participation_method
+    @participation_method ||= Factory.instance.participation_method_for(phase)
+  end
+
   def custom_fields
-    IdeaCustomFieldsService.new(Factory.instance.participation_method_for(phase).custom_form).enabled_fields_with_other_options
+    IdeaCustomFieldsService.new(participation_method.custom_form).enabled_fields_with_other_options
   end
 end

--- a/back/app/controllers/web_api/v1/project_custom_fields_controller.rb
+++ b/back/app/controllers/web_api/v1/project_custom_fields_controller.rb
@@ -7,7 +7,7 @@ class WebApi::V1::ProjectCustomFieldsController < ApplicationController
 
   def json_forms_schema
     if project && phase
-      render json: raw_json(JsonFormsService.new.input_ui_and_json_multiloc_schemas(custom_fields, current_user, input_term))
+      render json: raw_json(JsonFormsService.new.input_ui_and_json_multiloc_schemas(custom_fields, current_user, input_term, participation_method))
     else
       send_not_found
     end
@@ -27,7 +27,11 @@ class WebApi::V1::ProjectCustomFieldsController < ApplicationController
     phase.input_term
   end
 
+  def participation_method
+    @participation_method ||= Factory.instance.participation_method_for(phase)
+  end
+
   def custom_fields
-    IdeaCustomFieldsService.new(Factory.instance.participation_method_for(phase).custom_form).enabled_fields
+    IdeaCustomFieldsService.new(participation_method.custom_form).enabled_fields
   end
 end

--- a/back/app/models/custom_field.rb
+++ b/back/app/models/custom_field.rb
@@ -54,7 +54,7 @@ class CustomField < ApplicationRecord
     multiselect multiselect_image number page point select select_image text text_multiloc topic_ids section
   ].freeze
   CODES = %w[
-    author_id birthyear body_multiloc budget domicile education gender idea_files_attributes idea_images_attributes
+    birthyear body_multiloc domicile education gender idea_files_attributes idea_images_attributes
     ideation_section1 ideation_section2 ideation_section3 location_description proposed_budget title_multiloc topic_ids
   ].freeze
   VISIBLE_TO_PUBLIC = 'public'

--- a/back/app/services/input_ui_schema_generator_service.rb
+++ b/back/app/services/input_ui_schema_generator_service.rb
@@ -47,7 +47,7 @@ class InputUiSchemaGeneratorService < UiSchemaGeneratorService
 
   def default_options(field)
     defaults = {
-      isAdminField: admin_field?(field),
+      isAdminField: field.admin_field?,
       hasRule: field.logic?
     }
     if @supports_answer_visible_to
@@ -142,7 +142,7 @@ class InputUiSchemaGeneratorService < UiSchemaGeneratorService
     {
       type: 'Category',
       label: (MultilocService.new.t(current_section.title_multiloc) if current_section.title_multiloc),
-      options: { id: current_section.id, description: description_option(current_section) },
+      options: { id: current_section.id, description: description_option(current_section) }, # TODO: Use key instead of id?
       elements: section_fields.filter_map { |field| visit field }
     }
   end
@@ -160,8 +160,4 @@ class InputUiSchemaGeneratorService < UiSchemaGeneratorService
   private
 
   attr_reader :input_term
-
-  def admin_field?(field)
-    field.code == 'budget' || field.code == 'author_id'
-  end
 end

--- a/back/lib/schema_field.rb
+++ b/back/lib/schema_field.rb
@@ -3,7 +3,62 @@ class SchemaField
     @custom_field = custom_field
   end
 
-  def input_type
-    @custom_field.input_type
+  delegate :input_type, :title_multiloc, :description_multiloc, :key, :code, :enabled?, :required?, :hidden?, :page?, :section?, :other_option_text_field, :id, to: :custom_field
+
+  def admin_field?
+    code == 'budget' || code == 'author_id'
   end
+
+  def accept(visitor)
+    case input_type
+    when 'checkbox'
+      visitor.visit_checkbox self
+    when 'date'
+      visitor.visit_date self
+    when 'files'
+      visitor.visit_files self
+    when 'file_upload'
+      visitor.visit_file_upload self
+    when 'html'
+      visitor.visit_html self
+    when 'html_multiloc'
+      visitor.visit_html_multiloc self
+    when 'image_files'
+      visitor.visit_image_files self
+    when 'linear_scale'
+      visitor.visit_linear_scale self
+    when 'multiline_text'
+      visitor.visit_multiline_text self
+    when 'multiline_text_multiloc'
+      visitor.visit_multiline_text_multiloc self
+    when 'multiselect'
+      visitor.visit_multiselect self
+    when 'multiselect_image'
+      visitor.visit_multiselect_image self
+    when 'number'
+      visitor.visit_number self
+    when 'page'
+      visitor.visit_page self
+    when 'point'
+      visitor.visit_point self
+    when 'section'
+      visitor.visit_section self
+    when 'select'
+      visitor.visit_select self
+    when 'select_image'
+      visitor.visit_select_image self
+    when 'text'
+      visitor.visit_text self
+    when 'text_multiloc'
+      visitor.visit_text_multiloc self
+    when 'topic_ids'
+      visitor.visit_topic_ids self
+    else
+      raise "Unsupported input type: #{input_type}"
+    end
+  end
+
+  private
+
+  attr_reader :custom_field
 end

--- a/back/lib/schema_field.rb
+++ b/back/lib/schema_field.rb
@@ -1,0 +1,9 @@
+class SchemaField
+  def initialize(custom_field)
+    @custom_field = custom_field
+  end
+
+  def input_type
+    @custom_field.input_type
+  end
+end

--- a/back/spec/services/json_forms_service_spec.rb
+++ b/back/spec/services/json_forms_service_spec.rb
@@ -244,7 +244,8 @@ describe JsonFormsService do
         end
       end
       let(:fields) { IdeaCustomFieldsService.new(custom_form).enabled_fields }
-      let(:output) { service.input_ui_and_json_multiloc_schemas fields, user, input_term }
+      let(:participation_method) { Factory.instance.participation_method_for(project) }
+      let(:output) { service.input_ui_and_json_multiloc_schemas fields, user, input_term, participation_method }
 
       context 'when resident' do
         let(:user) { create(:user) }
@@ -377,7 +378,7 @@ describe JsonFormsService do
             receive(:render_data_images_multiloc).with(field.description_multiloc, field: :description_multiloc, imageable: field).and_return({ 'en' => 'Description with text images' })
           )
 
-          ui_schema = service.input_ui_and_json_multiloc_schemas([field], nil, 'option')[:ui_schema_multiloc]
+          ui_schema = service.input_ui_and_json_multiloc_schemas([field], nil, 'option', participation_method)[:ui_schema_multiloc]
           expect(ui_schema.dig('en', :elements, 0, :elements, 0, :options, :description)).to eq 'Description with text images'
         end
 
@@ -390,7 +391,7 @@ describe JsonFormsService do
             receive(:render_data_images_multiloc).with(field.description_multiloc, field: :description_multiloc, imageable: field).and_return({ 'en' => 'Description with text images' })
           )
 
-          ui_schema = service.input_ui_and_json_multiloc_schemas([field], nil, 'question')[:ui_schema_multiloc]
+          ui_schema = service.input_ui_and_json_multiloc_schemas([field], nil, 'question', participation_method)[:ui_schema_multiloc]
           expect(ui_schema.dig('en', :elements, 0, :options, :description)).to eq 'Description with text images'
         end
       end


### PR DESCRIPTION
This was an attempt to remove the author and budget fields as custom fields, because there's nothing customizable about those fields. The idea was to instead support schemas that can work with a combination of custom fields and "normal" fields.

While doing this refactoring, we realized that the coupling between the logic in the schema's and the custom fields implementation is extremely high. For example:
- The IDs of sections are used to generate the schemas. I don't think this makes sense.
- Including the other option text fields.
- Getting the participation context and participation method.
- Using the visitor pattern.