### PR TITLE
[TAN-1782] Improve proposal sharing on Facebook

### DIFF
--- a/front/app/components/Sharing/utils.ts
+++ b/front/app/components/Sharing/utils.ts
@@ -18,14 +18,16 @@ export function getUrlWithUtm(
 ) {
   let resUrl = url;
 
-  resUrl += `?utm_source=${encodeURIComponent(
-    utmParams.source
-  )}&utm_campaign=${encodeURIComponent(
-    utmParams.campaign
-  )}&utm_medium=${encodeURIComponent(medium)}`;
+  if (medium !== 'facebook') {
+    resUrl += `?utm_source=${encodeURIComponent(
+      utmParams.source
+    )}&utm_campaign=${encodeURIComponent(
+      utmParams.campaign
+    )}&utm_medium=${encodeURIComponent(medium)}`;
 
-  if (utmParams.content) {
-    resUrl += `&utm_content=${encodeURIComponent(utmParams.content)}`;
+    if (utmParams.content) {
+      resUrl += `&utm_content=${encodeURIComponent(utmParams.content)}`;
+    }
   }
 
   return resUrl;

--- a/front/app/components/Sharing/utils.ts
+++ b/front/app/components/Sharing/utils.ts
@@ -19,6 +19,7 @@ export function getUrlWithUtm(
   let resUrl = url;
 
   if (medium !== 'facebook') {
+    // Only add UTM params to non-Facebook links
     resUrl += `?utm_source=${encodeURIComponent(
       utmParams.source
     )}&utm_campaign=${encodeURIComponent(


### PR DESCRIPTION
# Description
Trying to improve the chances of sharing proposals on Facebook working correctly.

# Changelog
## Fixed
- [TAN-1782] Improve the chances of a proposal sharing correctly via Facebook. We might still have some issues with sharing proposals without images due to some issues with Facebook and how they are treating our application, but I _think_ most proposals should share correctly now with this update (E.g. [This](https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fkobenhavntaler.kk.dk%2Fda-DK%2Finitiatives%2Findsats-imod-lose-hunde-i-byens-parker-og-anlaeg%3Futm_source%3Dshare_initiative%26utm_campaign%3Dshare_content%26utm_medium%3Dfacebook) was the Facebook sharing link generated before, which doesn't work. [This](https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fkobenhavntaler.kk.dk%2Fda-DK%2Finitiatives%2Findsats-imod-lose-hunde-i-byens-parker-og-anlaeg) is the new link, which does work).
