### PR TITLE
[TAN-1836] Revert on: :create different from new_record?

### DIFF
--- a/back/app/models/concerns/user_confirmation.rb
+++ b/back/app/models/concerns/user_confirmation.rb
@@ -5,7 +5,7 @@ module UserConfirmation
 
   included do
     with_options if: -> { user_confirmation_enabled? } do
-      before_validation :set_confirmation_required
+      before_validation :set_confirmation_required, on: :create
       before_validation :confirm, if: ->(user) { user.invite_status_change&.last == 'accepted' }
     end
 
@@ -70,7 +70,7 @@ module UserConfirmation
   private
 
   def set_confirmation_required
-    return unless new_record? && email_changed?
+    return unless email_changed?
 
     not_ordinary_user = highest_role != :user # admin or moderator can be created only by invite or by admin API from cl2-tenant-setup
     confirmation_not_required =


### PR DESCRIPTION
new_record? works not in the same way as `on: :create`.

initiative_manager.cy.ts was failing on cy.apiConfirmUser because with `on: :create`, set_confirmation_required's body wasn't called, but with new_record? it was.
