### PR TITLE
[TAN-1769] Don't make machine translation API call if localeTo not provided

### DIFF
--- a/front/app/modules/commercial/machine_translations/hooks/useTranslation.ts
+++ b/front/app/modules/commercial/machine_translations/hooks/useTranslation.ts
@@ -7,7 +7,7 @@ import useFeatureFlag from 'hooks/useFeatureFlag';
 
 interface Parameters {
   attributeName: 'body_multiloc' | 'title_multiloc';
-  localeTo?: SupportedLocale;
+  localeTo: SupportedLocale;
   id: string;
   context: 'idea' | 'initiative' | 'comment';
   machineTranslationButtonClicked: boolean;
@@ -33,6 +33,7 @@ export default function useTranslation({
     enabled:
       machineTranslationButtonClicked &&
       isMachineTranslationsEnabled &&
+      localeTo &&
       context === 'initiative',
   });
   const { data: ideaTranslation } = useMachineTranslationByIdeaId({
@@ -44,6 +45,7 @@ export default function useTranslation({
     enabled:
       machineTranslationButtonClicked &&
       isMachineTranslationsEnabled &&
+      localeTo &&
       context === 'idea',
   });
   const { data: commentTranslation } = useMachineTranslationByCommentId({
@@ -55,6 +57,7 @@ export default function useTranslation({
     enabled:
       machineTranslationButtonClicked &&
       isMachineTranslationsEnabled &&
+      localeTo &&
       context === 'comment',
   });
 


### PR DESCRIPTION
# Description
Don't make machine translation API call if localeTo not provided. Added the localeTo to the "enabled" check to make sure we only make the API request if localeTo is indeed provided.

Hopefully this should fix the last remaining Sentry error we've seen :crossed_fingers: 