### PR TITLE
[TAN-1859] Filter admin_publications by moderation by a given user ID

### DIFF
--- a/back/app/services/admin_publications_filtering_service.rb
+++ b/back/app/services/admin_publications_filtering_service.rb
@@ -87,12 +87,18 @@ class AdminPublicationsFilteringService
   end
 
   add_filter('remove_unmoderated_folders') do |scope, options|
-    next scope unless ['true', true, '1'].include? options[:filter_is_moderator_of]
+    next scope unless (['true', true, '1'].include? options[:filter_is_moderator_of]) ||
+                      options[:filter_user_is_moderator_of].present?
 
-    current_user = options[:current_user]
-    next scope.where(children_allowed: false) unless current_user
+    user = if options[:filter_user_is_moderator_of].present?
+      User.find_by(id: options[:filter_user_is_moderator_of])
+    else
+      options[:current_user]
+    end
 
-    moderated_folder_ids = current_user.roles.select { |r| r['type'] == 'project_folder_moderator' }.pluck('project_folder_id')
+    next scope.where(children_allowed: false) unless user
+
+    moderated_folder_ids = user.roles.select { |r| r['type'] == 'project_folder_moderator' }.pluck('project_folder_id')
     unmoderated_parents = scope.where(children_allowed: true).where.not(publication_id: moderated_folder_ids)
 
     scope.where.not(id: unmoderated_parents)

--- a/back/app/services/admin_publications_filtering_service.rb
+++ b/back/app/services/admin_publications_filtering_service.rb
@@ -90,11 +90,8 @@ class AdminPublicationsFilteringService
     next scope unless (['true', true, '1'].include? options[:filter_is_moderator_of]) ||
                       options[:filter_user_is_moderator_of].present?
 
-    user = if options[:filter_user_is_moderator_of].present?
-      User.find_by(id: options[:filter_user_is_moderator_of])
-    else
-      options[:current_user]
-    end
+    moderator = User.find_by(id: options[:filter_user_is_moderator_of])
+    user = moderator.presence || options[:current_user]
 
     next scope.where(children_allowed: false) unless user
 

--- a/back/app/services/projects_filtering_service.rb
+++ b/back/app/services/projects_filtering_service.rb
@@ -51,11 +51,8 @@ class ProjectsFilteringService
     next scope unless (['true', true, '1'].include? options[:filter_is_moderator_of]) ||
                       options[:filter_user_is_moderator_of].present?
 
-    user = if options[:filter_user_is_moderator_of].present?
-      User.find_by(id: options[:filter_user_is_moderator_of])
-    else
-      options[:current_user]
-    end
+    moderator = User.find_by(id: options[:filter_user_is_moderator_of])
+    user = moderator.presence || options[:current_user]
 
     next scope.none unless user
 

--- a/back/app/services/projects_filtering_service.rb
+++ b/back/app/services/projects_filtering_service.rb
@@ -48,12 +48,18 @@ class ProjectsFilteringService
   end
 
   add_filter('is_moderator_of') do |scope, options|
-    next scope unless ['true', true, '1'].include? options[:filter_is_moderator_of]
+    next scope unless (['true', true, '1'].include? options[:filter_is_moderator_of]) ||
+                      options[:filter_user_is_moderator_of].present?
 
-    current_user = options[:current_user]
-    next scope.none unless current_user
+    user = if options[:filter_user_is_moderator_of].present?
+      User.find_by(id: options[:filter_user_is_moderator_of])
+    else
+      options[:current_user]
+    end
 
-    moderated_project_ids = current_user.roles.select { |r| r['type'] == 'project_moderator' }.pluck('project_id')
+    next scope.none unless user
+
+    moderated_project_ids = user.roles.select { |r| r['type'] == 'project_moderator' }.pluck('project_id')
 
     scope.where(id: moderated_project_ids)
   end

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -41,9 +41,9 @@ resource 'AdminPublication' do
       parameter :folder, 'Filter by folder (project folder id)', required: false
       parameter :remove_not_allowed_parents, 'Filter out folders which contain only projects that are not visible to the user', required: false
       parameter :only_projects, 'Include projects only (no folders)', required: false
-      parameter :filter_can_moderate, 'Filter out the projects the current_user is allowed to moderate. False by default', required: false
+      parameter :filter_can_moderate, 'Filter out the projects the current_user is not allowed to moderate. False by default', required: false
       parameter :filter_is_moderator_of, 'Filter out the publications the current_user is not moderator of. False by default', required: false
-      parameter :filter_user_is_moderator_of, 'Filter out the publications the given user is moderator of', required: false
+      parameter :filter_user_is_moderator_of, 'Filter out the publications the given user is moderator of (user id)', required: false
 
       example_request 'List all admin publications' do
         expect(status).to eq(200)

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -41,8 +41,9 @@ resource 'AdminPublication' do
       parameter :folder, 'Filter by folder (project folder id)', required: false
       parameter :remove_not_allowed_parents, 'Filter out folders which contain only projects that are not visible to the user', required: false
       parameter :only_projects, 'Include projects only (no folders)', required: false
-      parameter :filter_can_moderate, 'Filter out the projects the user is allowed to moderate. False by default', required: false
-      parameter :filter_is_moderator_of, 'Filter out the publications the user is not moderator of. False by default', required: false
+      parameter :filter_can_moderate, 'Filter out the projects the current_user is allowed to moderate. False by default', required: false
+      parameter :filter_is_moderator_of, 'Filter out the publications the current_user is not moderator of. False by default', required: false
+      parameter :filter_user_is_moderator_of, 'Filter out the publications the  given user is not moderator of. False by default', required: false
 
       example_request 'List all admin publications' do
         expect(status).to eq(200)
@@ -90,6 +91,23 @@ resource 'AdminPublication' do
         json_response = json_parse(response_body)
         assert_status 200
         expect(json_response[:data].size).to eq 10
+      end
+
+      example 'List publications a specific user can moderate', document: false do
+        moderated_folder = create(:project_folder, projects: [projects[0], projects[1], projects[2]])
+        moderator = create(
+          :user,
+          roles: [
+            { type: 'project_moderator', project_id: projects[0].id },
+            { type: 'project_moderator', project_id: projects[1].id },
+            { type: 'project_moderator', project_id: projects[2].id },
+            { type: 'project_folder_moderator', project_folder_id: moderated_folder.id }
+          ]
+        )
+
+        do_request filter_user_is_moderator_of: moderator.id
+        assert_status 200
+        expect(publication_ids).to match_array [projects[0].id, projects[1].id, projects[2].id, moderated_folder.id]
       end
 
       context 'when admin is moderator of publications' do

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -43,7 +43,7 @@ resource 'AdminPublication' do
       parameter :only_projects, 'Include projects only (no folders)', required: false
       parameter :filter_can_moderate, 'Filter out the projects the current_user is allowed to moderate. False by default', required: false
       parameter :filter_is_moderator_of, 'Filter out the publications the current_user is not moderator of. False by default', required: false
-      parameter :filter_user_is_moderator_of, 'Filter out the publications the given user is not moderator of. False by default', required: false
+      parameter :filter_user_is_moderator_of, 'Filter out the publications the given user is moderator of', required: false
 
       example_request 'List all admin publications' do
         expect(status).to eq(200)

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -43,7 +43,7 @@ resource 'AdminPublication' do
       parameter :only_projects, 'Include projects only (no folders)', required: false
       parameter :filter_can_moderate, 'Filter out the projects the current_user is allowed to moderate. False by default', required: false
       parameter :filter_is_moderator_of, 'Filter out the publications the current_user is not moderator of. False by default', required: false
-      parameter :filter_user_is_moderator_of, 'Filter out the publications the  given user is not moderator of. False by default', required: false
+      parameter :filter_user_is_moderator_of, 'Filter out the publications the given user is not moderator of. False by default', required: false
 
       example_request 'List all admin publications' do
         expect(status).to eq(200)

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -94,20 +94,19 @@ resource 'AdminPublication' do
       end
 
       example 'List publications a specific user can moderate', document: false do
-        moderated_folder = create(:project_folder, projects: [projects[0], projects[1], projects[2]])
+        moderated_folder = create(:project_folder, projects: [projects[0], projects[1]])
         moderator = create(
           :user,
           roles: [
             { type: 'project_moderator', project_id: projects[0].id },
             { type: 'project_moderator', project_id: projects[1].id },
-            { type: 'project_moderator', project_id: projects[2].id },
             { type: 'project_folder_moderator', project_folder_id: moderated_folder.id }
           ]
         )
 
         do_request filter_user_is_moderator_of: moderator.id
         assert_status 200
-        expect(publication_ids).to match_array [projects[0].id, projects[1].id, projects[2].id, moderated_folder.id]
+        expect(publication_ids).to match_array [projects[0].id, projects[1].id, moderated_folder.id]
       end
 
       context 'when admin is moderator of publications' do

--- a/back/spec/acceptance/projects_spec.rb
+++ b/back/spec/acceptance/projects_spec.rb
@@ -30,7 +30,8 @@ resource 'Projects' do
 
       parameter :areas, 'Filter by areas (AND)', required: false
       parameter :publication_statuses, 'Return only projects with the specified publication statuses (i.e. given an array of publication statuses); returns all projects by default', required: false
-      parameter :filter_can_moderate, 'Filter out the projects the user is allowed to moderate. False by default', required: false
+      parameter :filter_can_moderate, 'Filter out the projects the current_user is allowed to moderate. False by default', required: false
+      parameter :filter_user_is_moderator_of, 'Filter out the publications the given user is not moderator of. False by default', required: false
       parameter :filter_ids, 'Filter out only projects with the given list of IDs', required: false
       parameter :folder, 'Filter by folder (project folder id)', required: false
 
@@ -119,6 +120,20 @@ resource 'Projects' do
         do_request filter_can_moderate: true, publication_statuses: ['published']
         assert_status 200
         expect(json_response[:data].size).to eq 4
+      end
+
+      example 'List projects a specific user can moderate', document: false do
+        moderator = create(
+          :user,
+          roles: [
+            { type: 'project_moderator', project_id: @projects[0].id },
+            { type: 'project_moderator', project_id: @projects[1].id }
+          ]
+        )
+
+        do_request filter_user_is_moderator_of: moderator.id
+        assert_status 200
+        expect(json_response[:data].pluck(:id)).to match_array [@projects[0].id, @projects[1].id]
       end
     end
 

--- a/back/spec/acceptance/projects_spec.rb
+++ b/back/spec/acceptance/projects_spec.rb
@@ -30,8 +30,8 @@ resource 'Projects' do
 
       parameter :areas, 'Filter by areas (AND)', required: false
       parameter :publication_statuses, 'Return only projects with the specified publication statuses (i.e. given an array of publication statuses); returns all projects by default', required: false
-      parameter :filter_can_moderate, 'Filter out the projects the current_user is allowed to moderate. False by default', required: false
-      parameter :filter_user_is_moderator_of, 'Filter out the projects the given user is moderator of', required: false
+      parameter :filter_can_moderate, 'Filter out the projects the current_user is not allowed to moderate. False by default', required: false
+      parameter :filter_user_is_moderator_of, 'Filter out the projects the given user is moderator of (user id)', required: false
       parameter :filter_ids, 'Filter out only projects with the given list of IDs', required: false
       parameter :folder, 'Filter by folder (project folder id)', required: false
 

--- a/back/spec/acceptance/projects_spec.rb
+++ b/back/spec/acceptance/projects_spec.rb
@@ -31,7 +31,7 @@ resource 'Projects' do
       parameter :areas, 'Filter by areas (AND)', required: false
       parameter :publication_statuses, 'Return only projects with the specified publication statuses (i.e. given an array of publication statuses); returns all projects by default', required: false
       parameter :filter_can_moderate, 'Filter out the projects the current_user is allowed to moderate. False by default', required: false
-      parameter :filter_user_is_moderator_of, 'Filter out the publications the given user is not moderator of. False by default', required: false
+      parameter :filter_user_is_moderator_of, 'Filter out the projects the given user is moderator of', required: false
       parameter :filter_ids, 'Filter out only projects with the given list of IDs', required: false
       parameter :folder, 'Filter by folder (project folder id)', required: false
 


### PR DESCRIPTION
Example request:
```
GET .../admin_publications?filter_user_is_moderator_of=<user_id>`
```

# Changelog
## Technical
- [TAN-1859] - filter admin_publications moderated by a given user
