### PR TITLE
TAN-1863 Fix flaky spec for invalid slug

### DIFF
--- a/back/app/services/project_copy_service.rb
+++ b/back/app/services/project_copy_service.rb
@@ -34,6 +34,7 @@ class ProjectCopyService < TemplateService
     @local_copy = local_copy
     @project = project
     @template = { 'models' => {} }
+    new_slug = SlugService.new.generate_slug(nil, new_slug) if new_slug
 
     # TODO: deal with linking idea_statuses, topics, custom field values and maybe areas and groups
     @template['models']['project']                    = yml_projects new_slug: new_slug, new_publication_status: new_publication_status, new_title_multiloc: new_title_multiloc, shift_timestamps: shift_timestamps

--- a/back/app/services/slug_service.rb
+++ b/back/app/services/slug_service.rb
@@ -7,7 +7,7 @@ class SlugService
     slug = slugify(string)
     indexed_slug = nil
     i = 0
-    while record.class.find_by(slug: indexed_slug || slug)
+    while record&.class&.find_by(slug: indexed_slug || slug)
       i += 1
       indexed_slug = [slug, '-', i].join
     end


### PR DESCRIPTION
This fixes the flaky spec. The solution is to generate a valid slug during export, before the project is created (which is when the error randomly occurred). It still makes sense to also keep regenerating the slug during import, in case the slug was taken (adding a number at the end to make the slug unique).

We've had some reports of project copy issues and this might also fix some of those cases. I would have liked a more robust solution (for example, if the slug is taken on the target platform and there are images, this will still fail), but that would take more time.

But the flaky spec itself should be fixed now :) 