### PR TITLE
Take out FocusOn (temporarily) to ensure we can interact with consent…

### DIFF
--- a/front/app/containers/IdeasNewPage/IdeasNewSurveyForm/index.tsx
+++ b/front/app/containers/IdeasNewPage/IdeasNewSurveyForm/index.tsx
@@ -7,7 +7,6 @@ import {
   useBreakpoint,
 } from '@citizenlab/cl2-component-library';
 import { createPortal } from 'react-dom';
-import { FocusOn } from 'react-focus-on';
 import { useSearchParams } from 'react-router-dom';
 
 import { IdeaPublicationStatus } from 'api/ideas/types';
@@ -297,14 +296,7 @@ const IdeasNewSurveyFormWrapperModal = (props: Props) => {
           bgColor={colors.grey100}
           h="100vh"
         >
-          <FocusOn>
-            {/*
-              FocusOn is used to trap focus within the modal.
-              Otherwise the focus would escape the modal and go to the background page.
-              This impedes the user experience for screen reader users and keyboard users.
-            */}
-            <IdeasNewSurveyForm {...props} />
-          </FocusOn>
+          <IdeasNewSurveyForm {...props} />
         </Box>,
         modalPortalElement
       )


### PR DESCRIPTION
Take out FocusOn (temporarily) to ensure we can interact with the consent manager when user is linked directly to the survey form.