### PR TITLE
Tan 1579/1.3.1 events page headings

### DIFF
--- a/front/app/components/EventCard/EventInformation/index.tsx
+++ b/front/app/components/EventCard/EventInformation/index.tsx
@@ -75,7 +75,7 @@ const EventInformation = ({ event, goToEvent, titleFontSize }: Props) => {
         >
           <Title
             variant="h4"
-            as="h2"
+            as="h3"
             style={{ fontSize: titleFontSize, fontWeight: '600' }}
             pr="8px"
             color="tenantText"

--- a/front/app/containers/EventsPage/CurrentAndUpcomingEvents.tsx
+++ b/front/app/containers/EventsPage/CurrentAndUpcomingEvents.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 
 import { Box, useBreakpoint } from '@citizenlab/cl2-component-library';
-import { WrappedComponentProps } from 'react-intl';
 
-import { injectIntl } from 'utils/cl-intl';
+import { useIntl } from 'utils/cl-intl';
 
 import EventsViewer from './EventsViewer';
 import messages from './messages';
@@ -11,10 +10,8 @@ import messages from './messages';
 type Props = {
   attendeeId?: string;
 };
-const CurrentAndUpcomingEvents = ({
-  intl: { formatMessage },
-  attendeeId,
-}: Props & WrappedComponentProps) => {
+const CurrentAndUpcomingEvents = ({ attendeeId }: Props) => {
+  const { formatMessage } = useIntl();
   const isPhoneOrSmaller = useBreakpoint('phone');
 
   return (
@@ -33,4 +30,4 @@ const CurrentAndUpcomingEvents = ({
   );
 };
 
-export default injectIntl(CurrentAndUpcomingEvents);
+export default CurrentAndUpcomingEvents;

--- a/front/app/containers/EventsPage/EventsViewer/TopBar.tsx
+++ b/front/app/containers/EventsPage/EventsViewer/TopBar.tsx
@@ -52,7 +52,7 @@ const TopBar = memo<Props>(
         mb="28px"
         flexDirection={theme.isRtl ? 'row-reverse' : 'row'}
       >
-        <Title color={'tenantText'} m="0px" my="auto" variant="h3" as="h1">
+        <Title color="tenantText" m="0px" my="auto" as="h2">
           {title}
         </Title>
         <ProjectFilterDropdownPositioner>

--- a/front/app/containers/EventsPage/EventsViewer/TopBar.tsx
+++ b/front/app/containers/EventsPage/EventsViewer/TopBar.tsx
@@ -39,34 +39,40 @@ const TopBar = memo<Props>(
   }) => {
     const { formatMessage } = useIntl();
     const theme = useTheme();
-    const isPhoneOrSmaller = useBreakpoint('phone');
+    const isSmallerThanPhone = useBreakpoint('phone');
 
-    const mobileLeft = isPhoneOrSmaller && !theme.isRtl ? '-70px' : 'auto';
+    const mobileLeft = isSmallerThanPhone && !theme.isRtl ? '-70px' : 'auto';
 
     return (
       <Box
-        display={isPhoneOrSmaller ? 'block' : 'flex'}
+        display={isSmallerThanPhone ? 'block' : 'flex'}
         justifyContent="space-between"
         pb="14px"
         borderBottom="solid 1px #ccc"
         mb="28px"
         flexDirection={theme.isRtl ? 'row-reverse' : 'row'}
       >
-        <Title color="tenantText" m="0px" my="auto" as="h2">
+        <Title
+          color="tenantText"
+          m="0px"
+          my="auto"
+          as="h2"
+          variant={isSmallerThanPhone ? 'h3' : 'h2'}
+        >
           {title}
         </Title>
         <ProjectFilterDropdownPositioner>
           <Box
             display="flex"
             flexWrap="wrap"
-            flexDirection={isPhoneOrSmaller ? 'row-reverse' : 'row'}
+            flexDirection={isSmallerThanPhone ? 'row-reverse' : 'row'}
             gap="8px"
             mt="8px"
             ml="auto"
           >
             {showDateFilter && (
               <Box
-                width={isPhoneOrSmaller ? '100%' : 'auto'}
+                width={isSmallerThanPhone ? '100%' : 'auto'}
                 flexShrink={0}
                 style={{ textAlign: 'right' }}
               >
@@ -74,7 +80,7 @@ const TopBar = memo<Props>(
                   onChange={setDateFilter}
                   textColor={theme.colors.tenantText}
                   listTop="44px"
-                  mobileLeft={isPhoneOrSmaller ? '-70px' : mobileLeft}
+                  mobileLeft={isSmallerThanPhone ? '-70px' : mobileLeft}
                 />
               </Box>
             )}
@@ -85,7 +91,9 @@ const TopBar = memo<Props>(
                 textColor={theme.colors.tenantText}
                 filterSelectorStyle="button"
                 listTop="44px"
-                mobileLeft={isPhoneOrSmaller && !theme.isRtl ? '-70px' : 'auto'}
+                mobileLeft={
+                  isSmallerThanPhone && !theme.isRtl ? '-70px' : 'auto'
+                }
                 eventsTime={eventsTime}
               />
             )}

--- a/front/app/containers/EventsPage/index.tsx
+++ b/front/app/containers/EventsPage/index.tsx
@@ -24,6 +24,7 @@ const EventsPage = () => {
             <Title
               color="tenantPrimary"
               style={{ fontSize: isTabletOrSmaller ? '40px' : '80px' }}
+              as="h1"
             >
               {formatMessage(messages.events)}
             </Title>


### PR DESCRIPTION
Remark id: 18829. Also fixes 18911, 18920.

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- A11y: title structure on events page: correct usage of h1, h2, etc.