### PR TITLE
Tan 1579/1.3.1 project page title structure

### DIFF
--- a/front/app/components/StatusModule/index.tsx
+++ b/front/app/components/StatusModule/index.tsx
@@ -20,6 +20,8 @@ import { IProjectData } from 'api/projects/types';
 
 import useLocalize from 'hooks/useLocalize';
 
+import { ProjectPageSectionTitle } from 'containers/ProjectsShowPage/styles';
+
 import Warning from 'components/UI/Warning';
 
 import { FormattedMessage, useIntl } from 'utils/cl-intl';
@@ -83,10 +85,10 @@ const StatusModule = ({ votingMethod, phase, project }: StatusModuleProps) => {
           </Warning>
         </Box>
       )}
-      <Title variant="h2" style={{ fontWeight: 500 }}>
+      <ProjectPageSectionTitle>
         {config?.getStatusTitle &&
           formatMessage(config.getStatusHeader(basketStatus))}
-      </Title>
+      </ProjectPageSectionTitle>
       <Box
         mb="16px"
         p="20px"

--- a/front/app/containers/ProjectsShowPage/timeline/PhaseTitle.tsx
+++ b/front/app/containers/ProjectsShowPage/timeline/PhaseTitle.tsx
@@ -72,7 +72,7 @@ const HeaderTitleWrapper = styled.div`
   `}
 `;
 
-const HeaderTitle = styled.h2`
+const HeaderTitle = styled.h3`
   color: ${colors.textSecondary};
   font-size: ${fontSizes.l + 1}px;
   line-height: normal;


### PR DESCRIPTION
Remark id: 18962
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
A11y: title structure on project page: correct usage of h1, h2, etc.