### PR TITLE
Survey form: remove centering of content when 1 element on page

### DIFF
--- a/front/app/components/Form/Components/Layouts/CLSurveyPageLayout.tsx
+++ b/front/app/components/Form/Components/Layouts/CLSurveyPageLayout.tsx
@@ -224,22 +224,7 @@ const CLSurveyPageLayout = memo(
               );
               return (
                 currentStep === index && (
-                  <Box
-                    key={index}
-                    p="24px"
-                    w="100%"
-                    /*
-                      Used to center fields vertically if there is only one field on the page.
-                      Also used to center the final "Thank you for participating" page,
-                      which has zero elements.
-                      Removing this line may not look to change anything.
-                      However, two-field pages (or any number that doesn't take the full page height)
-                      would be centered without this line, which looks odd.
-                    */
-                    alignSelf={
-                      pageElements.length <= 1 ? 'center' : 'flex-start'
-                    }
-                  >
+                  <Box key={index} p="24px" w="100%">
                     <Box display="flex" flexDirection="column">
                       {page.options.title && (
                         <Title


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Remove centering of survey form page content (for now). Form fields were overlapping with different elements of the form (such as the anonymous participation info message).