### PR TITLE
[TAN-1880] Gracefully handle XLSX rows with all cells being blank

### DIFF
--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/patches/xlsx_service.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/patches/xlsx_service.rb
@@ -21,6 +21,8 @@ module BulkImportIdeas
             new_sheet.add_row(header.cells.map { |c| c&.value })
 
             rows.each do |row|
+              next unless row&.cells
+
               new_sheet.add_row(row.cells.map { |c| c&.value })
             end
           end


### PR DESCRIPTION
In the file that was failing, there was a row that had only blank cells.

# Changelog
## Fixed
* [TAN-1880] Gracefully handle XLSX rows with all cells being blank