### PR TITLE
Tan 1579/1.3.1 remark 18895 datepicker colors

### DIFF
--- a/front/app/components/admin/DateSinglePicker/index.tsx
+++ b/front/app/components/admin/DateSinglePicker/index.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import 'react-datepicker/dist/react-datepicker.css';
 
-import { colors, fontSizes } from '@citizenlab/cl2-component-library';
+import {
+  colors,
+  fontSizes,
+  stylingConsts,
+} from '@citizenlab/cl2-component-library';
 import DatePicker from 'react-datepicker';
 import styled from 'styled-components';
 
@@ -21,6 +25,16 @@ const Container = styled.div`
     color: ${colors.grey800};
     font-size: ${fontSizes.base}px;
     padding: 12px;
+  }
+
+  /*
+    Added to ensure the color contrast required to meet WCAG AA standards.
+  */
+  .react-datepicker__day--today {
+    background-color: ${colors.white};
+    color: ${colors.black};
+    border: 1px solid ${colors.black};
+    border-radius: ${stylingConsts.borderRadius};
   }
 `;
 

--- a/front/app/components/admin/DateSinglePicker/index.tsx
+++ b/front/app/components/admin/DateSinglePicker/index.tsx
@@ -20,13 +20,6 @@ const Container = styled.div`
   border-radius: ${(props) => props.theme.borderRadius};
   border: solid 1px ${colors.borderDark};
 
-  input {
-    width: 100%;
-    color: ${colors.grey800};
-    font-size: ${fontSizes.base}px;
-    padding: 12px;
-  }
-
   /*
     Added to ensure the color contrast required to meet WCAG AA standards.
   */
@@ -35,6 +28,17 @@ const Container = styled.div`
     color: ${colors.black};
     border: 1px solid ${colors.black};
     border-radius: ${stylingConsts.borderRadius};
+  }
+
+  .react-datepicker__day--keyboard-selected {
+    background-color: ${colors.white};
+  }
+
+  input {
+    width: 100%;
+    color: ${colors.grey800};
+    font-size: ${fontSizes.base}px;
+    padding: 12px;
   }
 `;
 

--- a/front/app/components/admin/DateSinglePicker/index.tsx
+++ b/front/app/components/admin/DateSinglePicker/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import 'react-datepicker/dist/react-datepicker.css';
 
 import { colors, fontSizes } from '@citizenlab/cl2-component-library';
 import DatePicker from 'react-datepicker';

--- a/front/app/components/admin/DateSinglePicker/index.tsx
+++ b/front/app/components/admin/DateSinglePicker/index.tsx
@@ -30,6 +30,11 @@ const Container = styled.div`
     border-radius: ${stylingConsts.borderRadius};
   }
 
+  /*
+    If today's date is 20/5 and you go back to the previous month, 20/4 receives the "...keyboard-selected" class,
+    also resulting in the default light-blue background that the "...today" class receives.
+    No border is needed here because on focus, the browser adds a border
+  */
   .react-datepicker__day--keyboard-selected {
     background-color: ${colors.white};
   }

--- a/front/app/components/admin/DateTimePicker/index.tsx
+++ b/front/app/components/admin/DateTimePicker/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import 'react-datepicker/dist/react-datepicker.css';
 
 import { Icon, colors, fontSizes } from '@citizenlab/cl2-component-library';
 import moment from 'moment';

--- a/front/app/components/admin/DateTimePicker/index.tsx
+++ b/front/app/components/admin/DateTimePicker/index.tsx
@@ -34,6 +34,16 @@ const Container = styled.div`
     }
   }
 
+  /*
+    Added to ensure the color contrast required to meet WCAG AA standards.
+  */
+  .react-datepicker__day--today {
+    background-color: ${colors.white};
+    color: ${colors.black};
+    border: 1px solid ${colors.black};
+    border-radius: ${stylingConsts.borderRadius};
+  }
+
   input {
     font-size: ${fontSizes.base}px;
     font-weight: 400;

--- a/front/app/components/admin/DateTimePicker/index.tsx
+++ b/front/app/components/admin/DateTimePicker/index.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import 'react-datepicker/dist/react-datepicker.css';
 
-import { Icon, colors, fontSizes } from '@citizenlab/cl2-component-library';
+import {
+  Icon,
+  colors,
+  fontSizes,
+  stylingConsts,
+} from '@citizenlab/cl2-component-library';
 import moment from 'moment';
 import DatePicker from 'react-datepicker';
 import styled from 'styled-components';
@@ -42,6 +47,10 @@ const Container = styled.div`
     color: ${colors.black};
     border: 1px solid ${colors.black};
     border-radius: ${stylingConsts.borderRadius};
+  }
+
+  .react-datepicker__day--keyboard-selected {
+    background-color: ${colors.white};
   }
 
   input {

--- a/front/app/components/admin/DateTimePicker/index.tsx
+++ b/front/app/components/admin/DateTimePicker/index.tsx
@@ -49,6 +49,11 @@ const Container = styled.div`
     border-radius: ${stylingConsts.borderRadius};
   }
 
+  /*
+    If today's date is 20/5 and you go back to the previous month, 20/4 receives the "...keyboard-selected" class,
+    also resulting in the default light-blue background that the "...today" class receives.
+    No border is needed here because on focus, the browser adds a border
+  */
   .react-datepicker__day--keyboard-selected {
     background-color: ${colors.white};
   }

--- a/front/app/root.tsx
+++ b/front/app/root.tsx
@@ -4,7 +4,6 @@ import 'assets/css/reset.min.css';
 import 'assets/fonts/fonts.css';
 import 'tippy.js/dist/tippy.css';
 import 'tippy.js/themes/light.css';
-import 'react-datepicker/dist/react-datepicker.css';
 import '@arcgis/core/assets/esri/css/main.css';
 
 import * as Sentry from '@sentry/react';


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Accessibility: indicate today's date more clearly in the date picker. Also improve color contrast for keyboard focused date. ([Before](https://github.com/CitizenLabDotCo/citizenlab/assets/16427929/207828ab-4666-42d3-b989-1b4d94551ee0)/[after](https://github.com/CitizenLabDotCo/citizenlab/assets/16427929/a305f585-9763-4903-b2fd-eb6b91b91b50))