### PR TITLE
[TAN-1853] Add feature flag for new Management Feed feature

### DIFF
--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -1357,6 +1357,18 @@
           "allowed": { "type": "boolean", "default": false },
           "enabled": { "type": "boolean", "default": false }
         }
+      },
+
+      "management_feed": {
+        "type": "object",
+        "title": "Management Feed",
+        "description": "Experimental feature: A minimal list of selected actions performed by admins or managers in the last 30 days. Not all actions are included.",
+        "additionalProperties": false,
+        "required": ["allowed", "enabled"],
+        "properties": {
+          "allowed": { "type": "boolean", "default": false },
+          "enabled": { "type": "boolean", "default": false }
+        }
       }
     },
   "dependencies": {

--- a/back/engines/commercial/multi_tenancy/db/seeds/tenants.rb
+++ b/back/engines/commercial/multi_tenancy/db/seeds/tenants.rb
@@ -476,6 +476,10 @@ module MultiTenancy
             multi_language_platform: {
               enabled: true,
               allowed: true
+            },
+            management_feed: {
+              enabled: true,
+              allowed: true
             }
           })
         )


### PR DESCRIPTION
AdminHQ platform settings:
<img width="1082" alt="Screenshot 2024-05-20 at 14 11 29" src="https://github.com/CitizenLabDotCo/citizenlab/assets/3944042/46b9bbc5-3b1a-4849-bb31-45467b85319a">

AdminHQ pricing plans:
<img width="1250" alt="Screenshot 2024-05-20 at 14 11 00" src="https://github.com/CitizenLabDotCo/citizenlab/assets/3944042/2baf2805-cd48-4728-a402-13bc244d6a3d">

# Changelog
## Technical
- [TAN-1853] Add feature flag for Management Feed feature
