### PR TITLE
[TAN-1518] Make report title editable in report builder

### DIFF
--- a/front/app/api/reports/useUpdateReport.ts
+++ b/front/app/api/reports/useUpdateReport.ts
@@ -11,14 +11,15 @@ import { ReportResponse } from './types';
 
 type UpdateReport = {
   id: string;
-  visible: boolean;
+  visible?: boolean;
+  name?: string;
 };
 
-const updateReport = async ({ id, visible }: UpdateReport) =>
+const updateReport = async ({ id, ...requestBody }: UpdateReport) =>
   fetcher<ReportResponse>({
     path: `/reports/${id}`,
     action: 'patch',
-    body: { report: { visible } },
+    body: { report: requestBody },
   });
 
 const useUpdateReport = () => {

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/TopBar/ReportTitle.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/TopBar/ReportTitle.tsx
@@ -95,11 +95,12 @@ const ReportTitle = ({ reportId }) => {
   };
 
   const handleOnBlur = async () => {
-    try {
-      if (!updateTitleOnBlurRef.current) return;
-      newTitle ? await updateTitle() : resetTitle();
-    } catch {
-      // Do nothing
+    if (updateTitleOnBlurRef.current) {
+      try {
+        newTitle ? await updateTitle() : resetTitle();
+      } catch {
+        // Do nothing
+      }
     }
 
     // Reset the cursor position to the beginning of the input in order to show the

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/TopBar/ReportTitle.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/TopBar/ReportTitle.tsx
@@ -1,0 +1,136 @@
+import React, { useState } from 'react';
+
+import styled from 'styled-components';
+
+import {
+  Box,
+  colors,
+  fontSizes,
+  Input,
+  Title,
+} from '@citizenlab/cl2-component-library';
+
+import Error from 'components/UI/Error';
+
+import useReport from 'api/reports/useReport';
+import useUpdateReport from 'api/reports/useUpdateReport';
+
+import { useIntl } from 'utils/cl-intl';
+
+import messages from './messages';
+import reportTitleIsTaken from '../../../utils/reportTitleIsTaken';
+
+const StyledInput = styled(Input)<{ errorBorder?: boolean }>`
+  width: 500px;
+  margin-right: 10px;
+
+  input {
+    border: none;
+    padding: 2px;
+    text-overflow: ellipsis;
+
+    // Reproducing roughly the same style as: <Title variant="h3">
+    // which is used for nameless reports (e.g. photo reports).
+    font-size: ${fontSizes.xl}px;
+    font-weight: bold;
+    font-style: normal;
+  }
+
+  input.error,
+  input:hover,
+  input:focus {
+    border: 1px solid;
+  }
+
+  input:focus,
+  input:hover {
+    border-color: ${colors.primary};
+  }
+`;
+
+const StyledError = styled(Error)`
+  height: 27px; // Same height as the input
+`;
+
+const ReportTitle = ({ reportId }) => {
+  const { formatMessage } = useIntl();
+  const { data: report } = useReport(reportId);
+  const { mutateAsync: updateReport } = useUpdateReport();
+
+  const reportTitle = report?.data.attributes.name;
+  const [newTitle, setNewTitle] = useState(reportTitle);
+
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [inputRef, setInputRef] = useState<HTMLInputElement | null>(null);
+
+  const updateTitle = async () => {
+    clearError();
+    if (!newTitle || newTitle.trim() === reportTitle?.trim()) return;
+
+    try {
+      await updateReport({ id: reportId, name: newTitle });
+    } catch (error) {
+      if (reportTitleIsTaken(error)) {
+        showError(formatMessage(messages.titleTaken));
+      }
+    }
+  };
+
+  const handleOnKeyDown = (e) => {
+    if (e.key === 'Enter') {
+      // To save the new title, we just remove focus from the input. The onBlur event
+      // will handle the rest. However, if the title is empty, enter does nothing.
+      //
+      // TODO: Ideally, we should find a way to keep the focus in the input if there is an error.
+      // However, I could not find a elegant way to do it that does not send multiple
+      // patch requests (one on enter, one on blur).
+      if (newTitle) inputRef?.blur();
+    }
+  };
+
+  const handleOnBlur = async () => {
+    newTitle ? await updateTitle() : resetTitle();
+
+    // Reset the cursor position to the beginning of the input in order to show the
+    // beginning of the title in case it's too long to fit in the input.
+    inputRef?.setSelectionRange(0, 0);
+  };
+
+  const resetTitle = () => setNewTitle(reportTitle);
+
+  const showError = (message: string) => {
+    setErrorMessage(message);
+    inputRef?.classList.add('error');
+  };
+
+  const clearError = () => {
+    setErrorMessage(null);
+    inputRef?.classList.remove('error');
+  };
+
+  return reportTitle ? (
+    <Box
+      flexDirection="row"
+      display="flex"
+      alignItems="center"
+      justifyContent="flex-start"
+    >
+      <StyledInput
+        type="text"
+        value={newTitle}
+        onChange={setNewTitle}
+        onBlur={handleOnBlur}
+        onKeyDown={handleOnKeyDown}
+        setRef={setInputRef}
+      />
+
+      {errorMessage && <StyledError text={errorMessage} />}
+    </Box>
+  ) : (
+    <Title variant="h3" as="h1" mb="0px" mt="0px">
+      {formatMessage(messages.reportBuilder)}
+    </Title>
+  );
+};
+
+export default ReportTitle;

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/TopBar/ReportTitle.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/TopBar/ReportTitle.tsx
@@ -1,6 +1,4 @@
-import React, { useState } from 'react';
-
-import styled from 'styled-components';
+import React, { useState, useRef } from 'react';
 
 import {
   Box,
@@ -9,16 +7,18 @@ import {
   Input,
   Title,
 } from '@citizenlab/cl2-component-library';
-
-import Error from 'components/UI/Error';
+import styled from 'styled-components';
 
 import useReport from 'api/reports/useReport';
 import useUpdateReport from 'api/reports/useUpdateReport';
 
+import Error from 'components/UI/Error';
+
 import { useIntl } from 'utils/cl-intl';
 
-import messages from './messages';
 import reportTitleIsTaken from '../../../utils/reportTitleIsTaken';
+
+import messages from './messages';
 
 const StyledInput = styled(Input)<{ errorBorder?: boolean }>`
   width: 500px;
@@ -63,6 +63,8 @@ const ReportTitle = ({ reportId }) => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [inputRef, setInputRef] = useState<HTMLInputElement | null>(null);
 
+  const updateTitleOnBlurRef = useRef(true);
+
   const updateTitle = async () => {
     clearError();
     if (!newTitle || newTitle.trim() === reportTitle?.trim()) return;
@@ -73,23 +75,32 @@ const ReportTitle = ({ reportId }) => {
       if (reportTitleIsTaken(error)) {
         showError(formatMessage(messages.titleTaken));
       }
+
+      throw error;
     }
   };
 
-  const handleOnKeyDown = (e) => {
-    if (e.key === 'Enter') {
-      // To save the new title, we just remove focus from the input. The onBlur event
-      // will handle the rest. However, if the title is empty, enter does nothing.
-      //
-      // TODO: Ideally, we should find a way to keep the focus in the input if there is an error.
-      // However, I could not find a elegant way to do it that does not send multiple
-      // patch requests (one on enter, one on blur).
-      if (newTitle) inputRef?.blur();
+  const handleOnKeyDown = async (e) => {
+    if (e.key === 'Enter' && newTitle) {
+      try {
+        await updateTitle();
+
+        updateTitleOnBlurRef.current = false;
+        inputRef?.blur();
+        updateTitleOnBlurRef.current = true;
+      } catch {
+        // Do nothing
+      }
     }
   };
 
   const handleOnBlur = async () => {
-    newTitle ? await updateTitle() : resetTitle();
+    try {
+      if (!updateTitleOnBlurRef.current) return;
+      newTitle ? await updateTitle() : resetTitle();
+    } catch {
+      // Do nothing
+    }
 
     // Reset the cursor position to the beginning of the input in order to show the
     // beginning of the title in case it's too long to fit in the input.

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/TopBar/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/TopBar/index.tsx
@@ -3,7 +3,6 @@ import React, { useState, useEffect } from 'react';
 import {
   Box,
   Text,
-  Title,
   colors,
   IconButton,
   TooltipContentWrapper,
@@ -26,7 +25,7 @@ import Container from 'components/admin/ContentBuilder/TopBar/Container';
 import SaveButton from 'components/admin/ContentBuilder/TopBar/SaveButton';
 import Button from 'components/UI/Button';
 
-import { FormattedMessage, useIntl } from 'utils/cl-intl';
+import { useIntl } from 'utils/cl-intl';
 import clHistory from 'utils/cl-router/history';
 
 import { View } from '../ViewContainer/typings';
@@ -35,6 +34,7 @@ import ViewPicker from '../ViewContainer/ViewPicker';
 import LocaleSelect from './LocaleSelect';
 import messages from './messages';
 import QuitModal from './QuitModal';
+import ReportTitle from './ReportTitle';
 
 type ContentBuilderTopBarProps = {
   hasPendingState: boolean;
@@ -70,8 +70,8 @@ const ContentBuilderTopBar = ({
   const localize = useLocalize();
   const { formatMessage } = useIntl();
 
-  const disableSave = !!hasPendingState || saved;
-  const disablePrint = !!hasPendingState || !saved;
+  const disableSave = hasPendingState || saved;
+  const disablePrint = hasPendingState || !saved;
 
   const closeModal = () => {
     setShowQuitModal(false);
@@ -195,9 +195,8 @@ const ContentBuilderTopBar = ({
       />
       <Box display="flex" p="15px" pl="8px" flexGrow={1} alignItems="center">
         <Box flexGrow={2}>
-          <Title variant="h3" as="h1" mb="0px" mt="0px">
-            <FormattedMessage {...messages.reportBuilder} />
-          </Title>
+          <ReportTitle reportId={reportId} />
+
           {project && phase && (
             <Text m="0" color="textSecondary">
               {localize(project.data.attributes.title_multiloc)}{' '}

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/TopBar/messages.ts
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/TopBar/messages.ts
@@ -30,4 +30,8 @@ export default defineMessages({
     defaultMessage:
       'This report contains unsaved changes. Please save before printing.',
   },
+  titleTaken: {
+    id: 'app.containers.Admin.reporting.components.ReportBuilder.TopBar.titleTaken',
+    defaultMessage: 'Title is already taken',
+  },
 });

--- a/front/app/containers/Admin/reporting/components/ReportBuilderPage/CreateReportModal.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilderPage/CreateReportModal.tsx
@@ -23,6 +23,7 @@ import { FormattedMessage, MessageDescriptor, useIntl } from 'utils/cl-intl';
 import clHistory from 'utils/cl-router/history';
 
 import messages from './messages';
+import reportTitleIsTaken from '../../utils/reportTitleIsTaken';
 
 interface Props {
   open: boolean;
@@ -40,10 +41,6 @@ const RadioLabel = ({ message }: RadioLabelProps) => (
     <FormattedMessage {...message} />
   </Text>
 );
-
-const reportTitleIsTaken = (error: any) => {
-  return error?.errors?.name?.[0]?.error === 'taken';
-};
 
 const CreateReportModal = ({ open, onClose }: Props) => {
   const { mutate: createReport, isLoading } = useAddReport();

--- a/front/app/containers/Admin/reporting/utils/reportTitleIsTaken.ts
+++ b/front/app/containers/Admin/reporting/utils/reportTitleIsTaken.ts
@@ -1,0 +1,3 @@
+export default function reportTitleIsTaken(error: any) {
+  return error?.errors?.name?.[0]?.error === 'taken';
+}

--- a/front/app/translations/admin/en.json
+++ b/front/app/translations/admin/en.json
@@ -895,6 +895,7 @@
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummaryDescription": "Add the goal of the project, participation methods used, and the outcome",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.visitors": "Visitors",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.cannotPrint": "This report contains unsaved changes. Please save before printing.",
+  "app.containers.Admin.reporting.components.ReportBuilder.TopBar.titleTaken": "Title is already taken",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets._shared.missingData": "The data for this widget is missing. Reconfigure or delete it to be able to save the report.",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.noAppropriatePhases": "No appropriate phases found in this project",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.noPhaseSelected": "No phase selected. Please select a phase first.",


### PR DESCRIPTION
# Changelog
## Added
- [[TAN-1518](https://notion.so/TAN-1518)] Make report title editable in report builder.

# TODO
- [ ] show generic message when update fails
