### PR TITLE
Reduce users script: ignore followers

### DIFF
--- a/back/app/services/user_reduce_service.rb
+++ b/back/app/services/user_reduce_service.rb
@@ -6,6 +6,7 @@ class UserReduceService
   #
   # See: https://docs.google.com/document/d/1REUc69m2fn1vCtBOMosWjAXDPSSRB9Hgh-Lf1OmXnX0/edit?usp=sharing
 
+  # Ideally, "followers" should not be blacklisted, but there was no time to tackle the uniqueness constraint issue. This is a temporary solution.
   MERGE_TABLES_BLACKLIST = %w[
     activities email_campaigns_campaign_email_commands
     email_campaigns_campaigns email_campaigns_consents

--- a/back/app/services/user_reduce_service.rb
+++ b/back/app/services/user_reduce_service.rb
@@ -10,7 +10,7 @@ class UserReduceService
     activities email_campaigns_campaign_email_commands
     email_campaigns_campaigns email_campaigns_consents
     email_campaigns_unsubscription_tokens email_campaigns_deliveries
-    identities initiative_status_changes invites memberships
+    followers identities initiative_status_changes invites memberships
     notifications onboarding_campaign_dismissals spam_reports
     users verification_verifications
   ].freeze

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_serializer.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_serializer.rb
@@ -203,6 +203,7 @@ module MultiTenancy
 
         return {} if record_class.nil? && scope.size == 0 # rubocop:disable Style/ZeroLengthPredicate
 
+        Rails.logger.info "Serializing #{record_class.name}"
         serializer_class = MultiTenancy::Templates::Serializers.const_get(record_class.name)
         serializer = serializer_class.new(**@serialization_params)
         scope.to_h { |record| [record.id, serializer.serialize(record)] }


### PR DESCRIPTION
This is a small change to make the user reduction script work.

There was a problem where merging followers would give errors because this would result in the same user following the same thing twice, which is not allowed. I would love to spend more time to find a better fix, but this is the fastest solution that is good enough to apply it to the master template.

The reason we need to apply this, is to make the amount of data on the master template smaller. People have been copying over projects, which caused the number of users to increase. Because of this increase, the templates takes too much time to run, and this in turn causes tenant creation issues.

We also log the different classes/models that are being serialized. This logging should include timestamps. This helps with two problems:
- It should reduce the chances of the CI step to get aborted, because of "Too long without output".
- It should give us an idea on how much time is spent on each class in the template.
