### PR TITLE
[TAN-1905] -last_active_at sorting of users lists nil values last

### DIFF
--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -267,7 +267,7 @@ class WebApi::V1::UsersController < ApplicationController
     when 'last_active_at'
       @users.order(last_active_at: :asc)
     when '-last_active_at'
-      @users.order(last_active_at: :desc)
+      @users.order(Arel.sql('last_active_at IS NULL, last_active_at DESC'))
     when 'last_name'
       @users.order(last_name: :asc)
     when '-last_name'

--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -265,7 +265,7 @@ class WebApi::V1::UsersController < ApplicationController
     when '-created_at'
       @users.order(created_at: :desc)
     when 'last_active_at'
-      @users.order(last_active_at: :asc)
+      @users.order(Arel.sql('last_active_at IS NOT NULL, last_active_at ASC'))
     when '-last_active_at'
       @users.order(Arel.sql('last_active_at IS NULL, last_active_at DESC'))
     when 'last_name'

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -419,6 +419,22 @@ resource 'Users' do
           expect(json_response[:data].map { |u| u.dig(:attributes, :email) }).to eq sorted_by_last_active_at_emails
         end
 
+        example 'List all users sorted by last_active_at lists nil values first', document: false do
+          User.all.each_with_index do |user, i|
+            user.update!(last_active_at: Time.now - i.days)
+          end
+
+          inactive_user = User.last
+          inactive_user.update!(last_active_at: nil)
+
+          do_request sort: 'last_active_at'
+
+          assert_status 200
+          json_response = json_parse(response_body)
+
+          expect(json_response[:data].map { |u| u.dig(:attributes, :email) }.first).to eq inactive_user.email
+        end
+
         example 'List all users sorted by -last_active_at' do
           User.all.each_with_index do |user, i|
             user.update!(last_active_at: Time.now - i.days)

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -419,6 +419,36 @@ resource 'Users' do
           expect(json_response[:data].map { |u| u.dig(:attributes, :email) }).to eq sorted_by_last_active_at_emails
         end
 
+        example 'List all users sorted by -last_active_at' do
+          User.all.each_with_index do |user, i|
+            user.update!(last_active_at: Time.now - i.days)
+          end
+
+          do_request sort: '-last_active_at'
+
+          assert_status 200
+          json_response = json_parse(response_body)
+
+          sorted_by_last_active_at_emails = User.order(last_active_at: :desc).pluck(:email)
+          expect(json_response[:data].map { |u| u.dig(:attributes, :email) }).to eq sorted_by_last_active_at_emails
+        end
+
+        example 'List all users sorted by -last_active_at lists nil values last', document: false do
+          User.all.each_with_index do |user, i|
+            user.update!(last_active_at: Time.now - i.days)
+          end
+
+          inactive_user = User.first
+          inactive_user.update!(last_active_at: nil)
+
+          do_request sort: '-last_active_at'
+
+          assert_status 200
+          json_response = json_parse(response_body)
+
+          expect(json_response[:data].map { |u| u.dig(:attributes, :email) }.last).to eq inactive_user.email
+        end
+
         example 'List all users in group' do
           group = create(:group)
           group_users = create_list(:user, 3, manual_groups: [group])


### PR DESCRIPTION
# Changelog
## Fixed
- Users with no 'last active' date value are now listed last when ordering the list by most recent date first, and first when list oldest date first.
