### PR TITLE
[TAN-1929] Only include activities after a specific date in management feed

### DIFF
--- a/back/spec/models/activity_spec.rb
+++ b/back/spec/models/activity_spec.rb
@@ -59,8 +59,23 @@ RSpec.describe Activity do
         expect(described_class.management).not_to include(activity)
       end
 
-      it 'excludes activities where acted_at is more than 30 days ago' do
+      it 'includes activities where acted_at is later than 30 days ago' do
+        activity = create(:idea_created_activity, user: admin, acted_at: 29.days.ago)
+        expect(described_class.management).to include(activity)
+      end
+
+      it 'excludes activities where acted_at is earlier than 30 days ago' do
         activity = create(:idea_created_activity, user: admin, acted_at: 31.days.ago)
+        expect(described_class.management).not_to include(activity)
+      end
+
+      it 'inludes activities where created_at is later than 20-05-2024' do
+        activity = create(:idea_created_activity, user: admin, created_at: Date.new(2024, 5, 21))
+        expect(described_class.management).to include(activity)
+      end
+
+      it 'excludes activities where created_at is earlier than 21-05-2024' do
+        activity = create(:idea_created_activity, user: admin, created_at: Date.new(2024, 5, 20))
         expect(described_class.management).not_to include(activity)
       end
     end


### PR DESCRIPTION
**TL;DR:** A hard-coded date limit for the Management Feed activities, that I will remove in about 30 days time.

We exclude activities that are older than 2024-05-20, because this is when we released the code that adds a serialized copy of the item to the payload of 'created' and 'changed' activities, and the change(s) to the payload of the 'changed' activities, when these activities are created.
Without this additional info, the activities cannot display correctly in the management feed.
This condition can be removed when the cutoff date is before the period used for the acted_at condition.

It would be non-trivial to migrate data to existing activities on production to provide the correct information in the respective payloads.
Since we limit the feed to only display activities for the past 30 days + we won't be enabling this for may platforms initially, we can simply wait until 2024-06-20 and then remove this hard-coded limit.

# Changelog
## Technical
- Only include activities after a specific date in management feed. This will avoid issues with displaying activities with incomplete information.
