### PR TITLE
TAN-1783 Monolingual language in prompts

### DIFF
--- a/back/config/locales/en.yml
+++ b/back/config/locales/en.yml
@@ -1,4 +1,38 @@
 en:
+  locales:
+    en: English
+    ar-MA: Arabic (Morocco)
+    ar-SA: Arabic (Saudi Arabia)
+    ca-ES: Catalan
+    cy-GB: Welsh
+    da-DK: Danish
+    de-DE: German
+    el-GR: Greek
+    en-CA: English (Canada)
+    en-GB: English (UK)
+    en-IE: English (Ireland)
+    es-CL: Spanish (Chile)
+    es-ES: Spanish (Spain)
+    fi-FI: Finnish
+    fr-BE: French (Belgium)
+    fr-FR: French
+    hr-HR: Croatian
+    hu-HU: Hungarian
+    it-IT: Italian
+    kl-GL: Greenlandic
+    lb-LU: Luxembourgish
+    lv-LV: Latvian
+    mi: Maori
+    nb-NO: Norwegian (Bokmål)
+    nl-BE: Dutch (Belgium)
+    nl-NL: Dutch
+    pl-PL: Polish
+    pt-BR: Portuguese (Brazil)
+    ro-RO: Romanian
+    sr-Latn: Serbian (Latin)
+    sr-SP: Serbian (Cyrillic)
+    sv-SE: Swedish
+    tr-TR: Turkish
   symbols:
     outside: somewhere else
   idea_statuses:

--- a/back/engines/commercial/analysis/app/lib/analysis/auto_tagging_method/nlp_topic.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/auto_tagging_method/nlp_topic.rb
@@ -41,7 +41,7 @@ module Analysis
 
     def inputs_prompt(inputs, project_title)
       inputs_text = input_to_text.format_all(inputs)
-      LLM::Prompt.new.fetch('topic_modeling', project_title: project_title, inputs_text: inputs_text, max_topics: max_topics(inputs.size))
+      LLM::Prompt.new.fetch('topic_modeling', project_title: project_title, inputs_text: inputs_text, max_topics: max_topics(inputs.size), language: Locale.monolingual&.language)
     end
 
     def parse_topic_modeling_response(response)

--- a/back/engines/commercial/analysis/app/lib/analysis/q_and_a_method/one_pass_llm.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/q_and_a_method/one_pass_llm.rb
@@ -75,17 +75,7 @@ module Analysis
 
     def prompt(project, inputs_text)
       project_title = MultilocService.new.t(project.title_multiloc)
-      @prompt = <<~GPT_PROMPT
-        At the end of this message is a list of form responses filled out by respondents in the context of an online participation project titled '#{project_title}'. The responses are separated by lines.
-        
-        Your only goal is to answer the following question about these responses, as accurately and as quantified as possible: "#{question.question}"
-        
-        You can refer to individual responses within the question where relevant as example, by adding their ID between square brackets. E.g. [52247442-b9a9-4a74-a6a1-898e9d6e2da7].
-        
-        Write your answer to the question in the same language as the question itself.
-        
-        #{inputs_text}
-      GPT_PROMPT
+      LLM::Prompt.new.fetch('q_and_a', project_title: project_title, question: question.question, inputs_text: inputs_text, language: Locale.monolingual&.language)
     end
   end
 end

--- a/back/engines/commercial/analysis/app/lib/analysis/summarization_method/one_pass_llm.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/summarization_method/one_pass_llm.rb
@@ -78,7 +78,7 @@ module Analysis
 
     def prompt(project, inputs_text)
       project_title = MultilocService.new.t(project.title_multiloc)
-      LLM::Prompt.new.fetch('summarization', project_title: project_title, inputs_text: inputs_text, locale: Locale.monolingual(AppConfiguration.instance).language)
+      LLM::Prompt.new.fetch('summarization', project_title: project_title, inputs_text: inputs_text, language: Locale.monolingual(AppConfiguration.instance)&.language)
     end
   end
 end

--- a/back/engines/commercial/analysis/app/lib/analysis/summarization_method/one_pass_llm.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/summarization_method/one_pass_llm.rb
@@ -78,7 +78,7 @@ module Analysis
 
     def prompt(project, inputs_text)
       project_title = MultilocService.new.t(project.title_multiloc)
-      LLM::Prompt.new.fetch('summarization', project_title: project_title, inputs_text: inputs_text, language: Locale.monolingual(AppConfiguration.instance)&.language)
+      LLM::Prompt.new.fetch('summarization', project_title: project_title, inputs_text: inputs_text, language: Locale.monolingual&.language)
     end
   end
 end

--- a/back/engines/commercial/analysis/app/lib/analysis/summarization_method/one_pass_llm.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/summarization_method/one_pass_llm.rb
@@ -78,12 +78,7 @@ module Analysis
 
     def prompt(project, inputs_text)
       project_title = MultilocService.new.t(project.title_multiloc)
-      LLM::Prompt.new.fetch('summarization', project_title: project_title, inputs_text: inputs_text, locale: monolingual_locale)
-    end
-
-    def monolingual_locale
-      config_locales = AppConfiguration.instance.settings('core', 'locales')
-      config_locales.size == 1 ? config_locales.first : nil
+      LLM::Prompt.new.fetch('summarization', project_title: project_title, inputs_text: inputs_text, locale: Locale.monolingual(AppConfiguration.instance))
     end
   end
 end

--- a/back/engines/commercial/analysis/app/lib/analysis/summarization_method/one_pass_llm.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/summarization_method/one_pass_llm.rb
@@ -76,20 +76,7 @@ module Analysis
 
     def prompt(project, inputs_text)
       project_title = MultilocService.new.t(project.title_multiloc)
-      @prompt = <<~GPT_PROMPT
-        At the end of this message is a list of form responses filled out by respondents in the context of an online participation project titled '#{project_title}'. The responses are separated by lines.
-
-        Summarize what respondents have said. Keep it brief. Put the most emphasis on things that were mentioned most often.
-        The goal is for the reader to get an understanding of what respondents have been talking about, without having to read through it all. Focus more on the trends across the responses, than on individual responses.
-        
-        Do NOT start your summary with any kind of introduction, start right away with the content, because the reader already knows the project context and the fact that this is a summary.
-        
-        You can refer to individual responses within the summary where relevant as example, by adding their ID between square brackets. E.g. [52247442-b9a9-4a74-a6a1-898e9d6e2da7].
-        
-        Write the summary in the same language as the majority of the responses.
-        
-        #{inputs_text}
-      GPT_PROMPT
+      LLM::Prompt.new.fetch('summarization', project_title: project_title, inputs_text: inputs_text)
     end
   end
 end

--- a/back/engines/commercial/analysis/app/lib/analysis/summarization_method/one_pass_llm.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/summarization_method/one_pass_llm.rb
@@ -74,9 +74,16 @@ module Analysis
       raise SummarizationFailedError, e
     end
 
+    private
+
     def prompt(project, inputs_text)
       project_title = MultilocService.new.t(project.title_multiloc)
-      LLM::Prompt.new.fetch('summarization', project_title: project_title, inputs_text: inputs_text)
+      LLM::Prompt.new.fetch('summarization', project_title: project_title, inputs_text: inputs_text, locale: monolingual_locale)
+    end
+
+    def monolingual_locale
+      config_locales = AppConfiguration.instance.settings('core', 'locales')
+      config_locales.size == 1 ? config_locales.first : nil
     end
   end
 end

--- a/back/engines/commercial/analysis/app/lib/analysis/summarization_method/one_pass_llm.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/summarization_method/one_pass_llm.rb
@@ -78,7 +78,7 @@ module Analysis
 
     def prompt(project, inputs_text)
       project_title = MultilocService.new.t(project.title_multiloc)
-      LLM::Prompt.new.fetch('summarization', project_title: project_title, inputs_text: inputs_text, locale: Locale.monolingual(AppConfiguration.instance))
+      LLM::Prompt.new.fetch('summarization', project_title: project_title, inputs_text: inputs_text, locale: Locale.monolingual(AppConfiguration.instance).language)
     end
   end
 end

--- a/back/engines/commercial/analysis/config/prompts/q_and_a.erb
+++ b/back/engines/commercial/analysis/config/prompts/q_and_a.erb
@@ -1,0 +1,9 @@
+At the end of this message is a list of form responses filled out by respondents in the context of an online participation project titled '<%= project_title %>'. The responses are separated by lines.
+  
+Your only goal is to answer the following question about these responses, as accurately and as quantified as possible: "<%= question %>"
+
+You can refer to individual responses within the question where relevant as example, by adding their ID between square brackets. E.g. [52247442-b9a9-4a74-a6a1-898e9d6e2da7].
+
+Write your answer to the question in <%= language || 'the same language as the question itself' %>.
+
+<%= inputs_text %>

--- a/back/engines/commercial/analysis/config/prompts/summarization.erb
+++ b/back/engines/commercial/analysis/config/prompts/summarization.erb
@@ -1,0 +1,12 @@
+At the end of this message is a list of form responses filled out by respondents in the context of an online participation project titled '<%= project_title %>'. The responses are separated by lines.
+
+Summarize what respondents have said. Keep it brief. Put the most emphasis on things that were mentioned most often.
+The goal is for the reader to get an understanding of what respondents have been talking about, without having to read through it all. Focus more on the trends across the responses, than on individual responses.
+
+Do NOT start your summary with any kind of introduction, start right away with the content, because the reader already knows the project context and the fact that this is a summary.
+
+You can refer to individual responses within the summary where relevant as example, by adding their ID between square brackets. E.g. [52247442-b9a9-4a74-a6a1-898e9d6e2da7].
+
+Write the summary in <%= locale || 'the same language as the majority of the responses' %>.
+
+<%= inputs_text %>

--- a/back/engines/commercial/analysis/config/prompts/summarization.erb
+++ b/back/engines/commercial/analysis/config/prompts/summarization.erb
@@ -7,6 +7,6 @@ Do NOT start your summary with any kind of introduction, start right away with t
 
 You can refer to individual responses within the summary where relevant as example, by adding their ID between square brackets. E.g. [52247442-b9a9-4a74-a6a1-898e9d6e2da7].
 
-Write the summary in <%= locale || 'the same language as the majority of the responses' %>.
+Write the summary in <%= language || 'the same language as the majority of the responses' %>.
 
 <%= inputs_text %>

--- a/back/engines/commercial/analysis/config/prompts/topic_modeling.erb
+++ b/back/engines/commercial/analysis/config/prompts/topic_modeling.erb
@@ -2,7 +2,7 @@ At the end of this message is a list of form responses filled out by citizens in
 
 Your goal is to generate a list of recurring topics across the responses, that can later be used to classify the responses.
 
-The topics should be written in the same language than the majority of the responses.
+The topics should be written in <%= language || 'the same language than the majority of the responses' %>.
 
 Here's a step by step process you should follow to get to the best list of topics:
 - First, go through all inputs and create a temporary, long list of potential topics

--- a/back/engines/commercial/analysis/spec/lib/q_and_a_method_spec.rb
+++ b/back/engines/commercial/analysis/spec/lib/q_and_a_method_spec.rb
@@ -43,29 +43,27 @@ RSpec.describe Analysis::QAndAMethod do
   end
 
   describe 'OnePassLLM q_and_a' do
-    it 'works' do
-      analysis = create(:analysis, main_custom_field: create(
+    let(:analysis) do
+      create(:analysis, main_custom_field: create(
         :custom_field,
         :for_custom_form,
         code: 'title_multiloc',
         key: 'title_multiloc'
       ))
-
-      q_and_a_task = create(
-        :q_and_a_task,
-        analysis: analysis,
-        state: 'queued',
-        question: create(:analysis_question, q_and_a_method: 'one_pass_llm', question: 'What is the most popular theme?', insight_attributes: { analysis: analysis, filters: { comments_from: 5 } })
-      )
-      question = q_and_a_task.question
-      inputs = with_options project: q_and_a_task.analysis.project do
+    end
+    let(:question) { create(:analysis_question, q_and_a_method: 'one_pass_llm', question: 'What is the most popular theme?', insight_attributes: { analysis: analysis, filters: { comments_from: 5 } }) }
+    let(:q_and_a_task) { create(:q_and_a_task, analysis: analysis, state: 'queued', question: question) }
+    let(:inputs) do
+      with_options project: analysis.project do
         [
           create(:idea, comments_count: 0),
           create(:idea, comments_count: 5),
           create(:idea, comments_count: 10)
         ]
       end
+    end
 
+    it 'works' do
       mock_llm = instance_double(Analysis::LLM::GPT4Turbo)
       plan = Analysis::QAndAMethod::OnePassLLM.new(question).generate_plan
 

--- a/back/engines/commercial/analysis/spec/lib/summarization_method_spec.rb
+++ b/back/engines/commercial/analysis/spec/lib/summarization_method_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Analysis::SummarizationMethod do
       ))
     end
     let(:summary) { create(:summary, summary: nil, summarization_method: 'one_pass_llm', insight_attributes: { analysis: analysis, filters: { comments_from: 5 } }) }
-    let(:summarization_task) { create( :summarization_task, analysis: analysis, state: 'queued', summary: summary) }
+    let(:summarization_task) { create(:summarization_task, analysis: analysis, state: 'queued', summary: summary) }
     let(:inputs) do
       with_options project: summarization_task.analysis.project do
         [
@@ -101,6 +101,6 @@ RSpec.describe Analysis::SummarizationMethod do
         state: 'succeeded',
         progress: nil
       })
-    end 
+    end
   end
 end

--- a/back/engines/commercial/analysis/spec/lib/summarization_method_spec.rb
+++ b/back/engines/commercial/analysis/spec/lib/summarization_method_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Analysis::SummarizationMethod do
     let(:summary) { create(:summary, summary: nil, summarization_method: 'one_pass_llm', insight_attributes: { analysis: analysis, filters: { comments_from: 5 } }) }
     let(:summarization_task) { create(:summarization_task, analysis: analysis, state: 'queued', summary: summary) }
     let(:inputs) do
-      with_options project: summarization_task.analysis.project do
+      with_options project: analysis.project do
         [
           create(:idea, comments_count: 0),
           create(:idea, comments_count: 5),

--- a/back/engines/commercial/analysis/spec/lib/summarization_method_spec.rb
+++ b/back/engines/commercial/analysis/spec/lib/summarization_method_spec.rb
@@ -43,32 +43,28 @@ RSpec.describe Analysis::SummarizationMethod do
   end
 
   describe 'OnePassLLM summarization' do
-    it 'works' do
-      analysis = create(:analysis, main_custom_field: create(
+    let(:analysis) do
+      create(:analysis, main_custom_field: create(
         :custom_field,
         :for_custom_form,
         code: 'title_multiloc',
         key: 'title_multiloc'
       ))
-
-      summarization_task = create(
-        :summarization_task,
-        analysis: analysis,
-        state: 'queued',
-        summary: create(:summary, summary: nil, summarization_method: 'one_pass_llm', insight_attributes: { analysis: analysis, filters: { comments_from: 5 } })
-      )
-      summary = summarization_task.summary
-      inputs = with_options project: summarization_task.analysis.project do
+    end
+    let(:summary) { create(:summary, summary: nil, summarization_method: 'one_pass_llm', insight_attributes: { analysis: analysis, filters: { comments_from: 5 } }) }
+    let(:summarization_task) { create( :summarization_task, analysis: analysis, state: 'queued', summary: summary) }
+    let(:inputs) do
+      with_options project: summarization_task.analysis.project do
         [
           create(:idea, comments_count: 0),
           create(:idea, comments_count: 5),
           create(:idea, comments_count: 10)
         ]
       end
+    end
 
-      mock_llm = instance_double(Analysis::LLM::GPT4Turbo)
+    it 'works' do
       plan = Analysis::SummarizationMethod::OnePassLLM.new(summary).generate_plan
-
       expect(plan).to have_attributes({
         summarization_method_class: Analysis::SummarizationMethod::OnePassLLM,
         llm: kind_of(Analysis::LLM::Base),
@@ -76,13 +72,24 @@ RSpec.describe Analysis::SummarizationMethod do
         include_id: true,
         shorten_labels: false
       })
-      plan.llm = mock_llm
 
+      mock_llm = instance_double(Analysis::LLM::GPT4Turbo)
+      plan.llm = mock_llm
       expect(mock_llm).to receive(:chat_async).with(kind_of(String)) do |prompt, &block|
         expect(prompt).to include(inputs[2].id)
         block.call 'Complete'
         block.call ' summary'
       end
+
+      mock_locale = instance_double(Locale)
+      expect(Locale)
+        .to receive(:monolingual)
+        .and_return(mock_locale)
+      expect(mock_locale).to receive(:language).and_return('High Valyrian')
+      expect_any_instance_of(Analysis::LLM::Prompt)
+        .to receive(:fetch)
+        .with('summarization', project_title: kind_of(String), inputs_text: kind_of(String), language: 'High Valyrian')
+        .and_call_original
 
       expect { plan.summarization_method_class.new(summary).execute(plan) }
         .to change { summarization_task.summary.summary }.from(nil).to('Complete summary')
@@ -94,6 +101,6 @@ RSpec.describe Analysis::SummarizationMethod do
         state: 'succeeded',
         progress: nil
       })
-    end
+    end 
   end
 end

--- a/back/lib/cl_errors/assertion_error.rb
+++ b/back/lib/cl_errors/assertion_error.rb
@@ -1,0 +1,4 @@
+module ClErrors
+  class AssertionError < StandardError
+  end
+end

--- a/back/lib/locale.rb
+++ b/back/lib/locale.rb
@@ -14,6 +14,6 @@ class Locale
   end
 
   def language
-    locale # TODO
+    I18n.t("locales.#{locale_sym}")
   end
 end

--- a/back/lib/locale.rb
+++ b/back/lib/locale.rb
@@ -10,7 +10,7 @@ class Locale
   def initialize(locale)
     @locale_sym = locale.to_sym
 
-    raise ClErrors::AssertionError 'Locale #{locale} is not supported' if !CL2_SUPPORTED_LOCALES.include?(locale)
+    raise ClErrors::AssertionError "Locale #{locale} is not supported" if CL2_SUPPORTED_LOCALES.exclude?(locale)
   end
 
   def language

--- a/back/lib/locale.rb
+++ b/back/lib/locale.rb
@@ -1,0 +1,19 @@
+class Locale
+  attr_reader :locale_sym
+
+  def self.monolingual(config)
+    config ||= AppConfiguration.instance
+    config_locales = config.settings('core', 'locales')
+    config_locales.size == 1 ? new(config_locales.first) : nil
+  end
+
+  def initialize(locale)
+    @locale_sym = locale.to_sym
+
+    raise ClErrors::AssertionError 'Locale #{locale} is not supported' if !CL2_SUPPORTED_LOCALES.include?(locale)
+  end
+
+  def language
+    locale # TODO
+  end
+end

--- a/back/lib/locale.rb
+++ b/back/lib/locale.rb
@@ -10,7 +10,7 @@ class Locale
   def initialize(locale)
     @locale_sym = locale.to_sym
 
-    raise ClErrors::AssertionError "Locale #{locale} is not supported" if CL2_SUPPORTED_LOCALES.exclude?(locale)
+    raise ClErrors::AssertionError, "Locale #{locale_sym} is not supported" if CL2_SUPPORTED_LOCALES.exclude?(locale_sym)
   end
 
   def language

--- a/back/lib/locale.rb
+++ b/back/lib/locale.rb
@@ -1,7 +1,7 @@
 class Locale
   attr_reader :locale_sym
 
-  def self.monolingual(config)
+  def self.monolingual(config: nil)
     config ||= AppConfiguration.instance
     config_locales = config.settings('core', 'locales')
     config_locales.size == 1 ? new(config_locales.first) : nil

--- a/back/spec/fixtures/locales/en.yml
+++ b/back/spec/fixtures/locales/en.yml
@@ -1,4 +1,6 @@
 en:
+  locales:
+    fr-FR: French
   symbols:
     outside: somewhere else
   nav_bar_items:

--- a/back/spec/fixtures/locales/fr-FR.yml
+++ b/back/spec/fixtures/locales/fr-FR.yml
@@ -1,4 +1,6 @@
 fr:
+  locales:
+    fr-FR: Français
   symbols:
     outside: quelque part d'autre
   nav_bar_items:

--- a/back/spec/fixtures/locales/nl-NL.yml
+++ b/back/spec/fixtures/locales/nl-NL.yml
@@ -1,4 +1,6 @@
 nl:
+  locales:
+    fr-FR: Frans
   symbols:
     outside: ergens anders
   nav_bar_items:

--- a/back/spec/lib/locale_spec.rb
+++ b/back/spec/lib/locale_spec.rb
@@ -1,6 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe Locale do
+  describe 'initialize' do
+    it 'returns a locale object when the locale is supported' do
+      locale = described_class.new('fr-FR')
+      expect(locale).to be_present
+      expect(locale.locale_sym).to eq(:'fr-FR')
+    end
+
+    it 'raises an error when the locale is not supported' do
+      expect { described_class.new('zz-XX') }.to raise_error(ClErrors::AssertionError, 'Locale zz-XX is not supported')
+    end
+  end
+
   describe 'monolingual' do
     it 'returns nil when the tenant uses multiple languages' do
       expect(described_class.monolingual).to be_nil

--- a/back/spec/lib/locale_spec.rb
+++ b/back/spec/lib/locale_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe Locale do
+  describe 'monolingual' do
+    it 'returns nil when the tenant uses multiple languages' do
+      expect(described_class.monolingual).to be_nil
+    end
+
+    it 'returns a corresponding locale when the tenant uses a single language' do
+      config = build(:app_configuration, settings: { core: { locales: ['nl-NL'] } })
+      locale = described_class.monolingual(config: config)
+      expect(locale).to be_present
+      expect(locale.locale_sym).to eq(:'nl-NL')
+    end
+  end
+end

--- a/back/spec/lib/locale_spec.rb
+++ b/back/spec/lib/locale_spec.rb
@@ -25,4 +25,14 @@ RSpec.describe Locale do
       expect(locale.locale_sym).to eq(:'nl-NL')
     end
   end
+
+  describe 'language' do
+    it 'returns the language of the locale' do
+      locale = described_class.new('fr-FR')
+      expect(locale.language).to eq('French')
+      I18n.with_locale(:'nl-NL') do
+        expect(locale.language).to eq('Frans')
+      end
+    end
+  end
 end


### PR DESCRIPTION
We could have taken this further, and also explicitly specify the language for multilingual tenants, but this would take more effort. For example, for Q&A we would probably have to change the database structure (migrations etc.) to be able to store the locale of a question.

# Changelog

### Changed

- [TAN-1783] Summarization, Q&A and fully automated tagging: Explicitly ask for response in specific language in prompt for monolingual tenants.
