### PR TITLE
TAN-1932 update last active at every email login

### DIFF
--- a/back/engines/commercial/impact_tracking/app/controllers/impact_tracking/web_api/v1/sessions_controller.rb
+++ b/back/engines/commercial/impact_tracking/app/controllers/impact_tracking/web_api/v1/sessions_controller.rb
@@ -63,7 +63,7 @@ module ImpactTracking
         visitor_hash = SessionHashService.new.generate_for_visitor(request.remote_ip, request.user_agent)
         @session = Session.where(monthly_user_hash: visitor_hash).order(created_at: :desc)&.first
 
-        # If the visitor has no session, create one. e.g. user logs out and in again, without refreshing the page.
+        # If the visitor has no session, return a new one. e.g. user logs out and in again, without refreshing the page.
         @session = Session.new if @session.nil?
       end
 

--- a/back/engines/commercial/impact_tracking/app/controllers/impact_tracking/web_api/v1/sessions_controller.rb
+++ b/back/engines/commercial/impact_tracking/app/controllers/impact_tracking/web_api/v1/sessions_controller.rb
@@ -26,9 +26,9 @@ module ImpactTracking
       end
 
       # PATCH /sessions/current/upgrade
-      # Called after the user has authenticated to upgrade its current session
+      # Called after the user has authenticated to upgrade its current visitor session, if it exists.
       def upgrade
-        if @session.update(
+        if @session.nil? || @session.update(
           monthly_user_hash: generate_hash,
           highest_role: current_user&.highest_role,
           user_id: current_user.id
@@ -61,7 +61,7 @@ module ImpactTracking
         return head(:not_found) unless params[:id] == 'current'
 
         visitor_hash = SessionHashService.new.generate_for_visitor(request.remote_ip, request.user_agent)
-        @session = Session.where(monthly_user_hash: visitor_hash).order(created_at: :desc).first!
+        @session = Session.where(monthly_user_hash: visitor_hash).order(created_at: :desc)&.first
       end
 
       def side_fx_session_service

--- a/back/engines/commercial/impact_tracking/app/controllers/impact_tracking/web_api/v1/sessions_controller.rb
+++ b/back/engines/commercial/impact_tracking/app/controllers/impact_tracking/web_api/v1/sessions_controller.rb
@@ -26,9 +26,9 @@ module ImpactTracking
       end
 
       # PATCH /sessions/current/upgrade
-      # Called after the user has authenticated to upgrade its current visitor session, if it exists.
+      # Called after the user has authenticated to upgrade its current session
       def upgrade
-        if @session.nil? || @session.update(
+        if @session.update(
           monthly_user_hash: generate_hash,
           highest_role: current_user&.highest_role,
           user_id: current_user.id
@@ -62,6 +62,9 @@ module ImpactTracking
 
         visitor_hash = SessionHashService.new.generate_for_visitor(request.remote_ip, request.user_agent)
         @session = Session.where(monthly_user_hash: visitor_hash).order(created_at: :desc)&.first
+
+        # If the visitor has no session, create one. e.g. user logs out and in again, without refreshing the page.
+        @session = Session.new if @session.nil?
       end
 
       def side_fx_session_service

--- a/back/engines/commercial/impact_tracking/app/services/impact_tracking/side_fx_session_service.rb
+++ b/back/engines/commercial/impact_tracking/app/services/impact_tracking/side_fx_session_service.rb
@@ -6,7 +6,9 @@ module ImpactTracking
       update_user_last_active_at(user)
     end
 
-    def after_upgrade(user)
+    # Called before setting the current session, to catch cases where upgrade returns a 404 when no visitor session
+    # exists for the user. This can happen when a user logs out and in again without refreshing the page, for example.
+    def before_set_current_session(user)
       update_user_last_active_at(user)
     end
 


### PR DESCRIPTION
Uses a `before_set_current_session` side effect to update `last_active_at`, rather than an `after_upgrade` side effect.

This means we now also successfully update the `User.last_active_at` value in the cases where previously a 404 would have prevented this. E.g if no visitor session exists, as could be the case if a user logs out and in again, without refreshing the page after logging out, then the upgrade action would result in a 404.

# Changelog
## Technical
- [TAN-1932] Ensure last_active_at always updates when user logs in. Fixes case where user logs out and in again with email, without refreshing page.
