### PR TITLE
Make clicking container not reset selection

### DIFF
--- a/front/app/containers/Admin/projects/project/analysis/Tags/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Tags/index.tsx
@@ -138,14 +138,6 @@ const Tags = () => {
       uniq(tags.data.map((tag) => tag.attributes.tag_type))
     );
 
-  const toggleTagContainerClick = (id: string) => {
-    updateSearchParams({ tag_ids: [id] });
-    queryClient.invalidateQueries(inputsKeys.lists());
-    trackEventByName(tracks.tagFilterUsed.name, {
-      extra: { tagId: id },
-    });
-  };
-
   const toggleТаgCheckboxClick = (id: string) => {
     const nonNullSelectedTags = selectedTags?.filter((tagId) => tagId !== null);
     if (!selectedTags?.includes(id)) {
@@ -249,16 +241,10 @@ const Tags = () => {
           <TagContainer
             id={`tag-${tag.id}`}
             key={tag.id}
-            tabIndex={0}
             onClick={() => {
-              toggleTagContainerClick(tag.id);
+              toggleТаgCheckboxClick(tag.id);
             }}
             className={selectedTags?.includes(tag.id) ? 'selected' : ''}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                toggleTagContainerClick(tag.id);
-              }
-            }}
             data-cy="e2e-analysis-tag-container"
           >
             <Box


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Clicking a tag on a place that's not part of the checkbox/label does not deselect all previously selected [tags](https://github.com/CitizenLabDotCo/citizenlab/assets/16427929/e61bf2a9-90bf-403c-a03b-8e084e96a507) in the AI Analysis tool anymore. 