### PR TITLE
Make sure "skip for now" button is contrasting enough

### DIFF
--- a/front/app/containers/Authentication/steps/Onboarding/TopicsAndAreas/index.tsx
+++ b/front/app/containers/Authentication/steps/Onboarding/TopicsAndAreas/index.tsx
@@ -71,7 +71,7 @@ const TopicsAndAreas = ({ onSubmit, onSkip }: Props) => {
       )}
       <Box display="flex" justifyContent="flex-end">
         <Box my="20px" w="auto" display="flex" alignSelf="flex-end" gap="8px">
-          <Button onClick={onSkip} buttonStyle="secondary">
+          <Button onClick={onSkip} buttonStyle="primary-outlined">
             {formatMessage(messages.skipForNow)}
           </Button>
           <Button onClick={handleSubmit}>


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- A11y: "Skip for now" button, shown when choosing topics of preference during sign-up, has enough contrast to comply with WCAG 2.2 AA now. ([Before](https://github.com/CitizenLabDotCo/citizenlab/assets/16427929/2ae31fae-1146-4b42-b55a-89697b1d163d)/[after](https://github.com/CitizenLabDotCo/citizenlab/assets/16427929/c11cce00-5935-4773-a979-7a43256a655a))