### PR TITLE
TAN-1942 - Fixed bug for admins submitting when there is an admin or group project permission

### DIFF
--- a/back/app/services/permissions/project_permissions_service.rb
+++ b/back/app/services/permissions/project_permissions_service.rb
@@ -82,8 +82,11 @@ module Permissions
 
     # Project methods
     def project_visible_disabled_reason(project, user)
-      if (project&.visible_to == 'admins' && !user.admin?) ||
-         (project&.visible_to == 'groups' && !user.in_any_groups?(project.groups))
+      user_can_moderate = user && UserRoleService.new.can_moderate?(project, user)
+      return if user_can_moderate
+
+      if (project&.visible_to == 'admins' && !user_can_moderate) ||
+         (project&.visible_to == 'groups' && project.groups && !user&.in_any_groups?(project.groups))
         PROJECT_DENIED_REASONS[:project_not_visible]
       end
     end

--- a/back/app/services/side_fx_idea_service.rb
+++ b/back/app/services/side_fx_idea_service.rb
@@ -105,6 +105,7 @@ class SideFxIdeaService
   end
 
   def add_autoreaction(idea)
+    return unless idea.author
     return if Permissions::IdeaPermissionsService.new.denied_reason_for_action 'reacting_idea', idea.author, idea, reaction_mode: 'up'
 
     idea.reactions.create!(mode: 'up', user: idea.author)

--- a/back/spec/acceptance/ideas_create_spec.rb
+++ b/back/spec/acceptance/ideas_create_spec.rb
@@ -187,6 +187,7 @@ resource 'Ideas' do
               project.update!(visible_to: 'groups', groups: [group])
               resident.update!(manual_groups: [group])
             end
+
             example_request 'Posting an idea anonymously to a group restricted project' do
               assert_status 201
               expect(response_data.dig(:attributes, :anonymous)).to be true

--- a/back/spec/acceptance/ideas_create_spec.rb
+++ b/back/spec/acceptance/ideas_create_spec.rb
@@ -180,6 +180,20 @@ resource 'Ideas' do
               expect(json_response).to include_response_error(:base, 'anonymous_participation_not_allowed')
             end
           end
+
+          describe 'when anonymous posting is not allowed and project is restricted to groups' do
+            before do
+              group = create(:group)
+              project.update!(visible_to: 'groups', groups: [group])
+              resident.update!(manual_groups: [group])
+            end
+            example_request 'Posting an idea anonymously to a group restricted project' do
+              assert_status 201
+              expect(response_data.dig(:attributes, :anonymous)).to be true
+              expect(response_data.dig(:attributes, :author_name)).to be_nil
+              expect(response_data.dig(:relationships, :author, :data)).to be_nil
+            end
+          end
         end
 
         describe 'For projects without ideas_order' do

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -971,13 +971,19 @@ RSpec.describe User do
   end
 
   describe 'in_any_groups?' do
-    it 'returns truety iff the user is a member of one of the given groups' do
+    it 'returns true if the user is a member of one of the given groups' do
       group1, group2 = create_list(:group, 2)
       user = create(:user, manual_groups: [group1])
       expect(user.in_any_groups?(Group.none)).to be false
       expect(user.in_any_groups?(Group.where(id: group1))).to be true
       expect(user.in_any_groups?(Group.where(id: [group1, group2]))).to be true
       expect(user).not_to be_in_any_groups(Group.where(id: group2))
+    end
+
+    it 'returns false if the user is not in any groups' do
+      group = create(:group)
+      user = create(:user)
+      expect(user.in_any_groups?([group])).to be false
     end
   end
 

--- a/back/spec/services/permissions/project_permissions_service_spec.rb
+++ b/back/spec/services/permissions/project_permissions_service_spec.rb
@@ -566,6 +566,50 @@ describe Permissions::ProjectPermissionsService do
     end
   end
 
+  describe 'project_visible_disabled_reason' do
+    it 'returns nil when a user is an admin and the project is visible to admins' do
+      project = create(:project, visible_to: 'admins')
+      user = create(:admin)
+      expect(service.send(:project_visible_disabled_reason, project, user)).to be_nil
+    end
+
+    it 'returns "project_not_visible" when a user is not admin and the project is visible to admins' do
+      project = create(:project, visible_to: 'admins')
+      user = create(:user)
+      expect(service.send(:project_visible_disabled_reason, project, user)).to eq 'project_not_visible'
+    end
+
+    it 'returns "project_not_visible" when there is no logged in user and the project is visible to admins' do
+      project = create(:project, visible_to: 'admins')
+      user = nil
+      expect(service.send(:project_visible_disabled_reason, project, user)).to eq 'project_not_visible'
+    end
+
+    it 'returns nil when a user is in a project group' do
+      project = create(:project, visible_to: 'groups', groups: [create(:group)])
+      user = create(:user, manual_groups: [project.groups.first])
+      expect(service.send(:project_visible_disabled_reason, project, user)).to be_nil
+    end
+
+    it 'returns nil when a user is a project moderator' do
+      project = create(:project, visible_to: 'groups', groups: [create(:group)])
+      user = create(:user, roles: [{ type: 'project_moderator', project_id: project.id }])
+      expect(service.send(:project_visible_disabled_reason, project, user)).to be_nil
+    end
+
+    it 'returns "project_not_visible" when a user is not in a project group' do
+      project = create(:project, visible_to: 'groups', groups: [create(:group)])
+      user = create(:user)
+      expect(service.send(:project_visible_disabled_reason, project, user)).to eq 'project_not_visible'
+    end
+
+    it 'returns "project_not_visible" when there is no logged in user and the project is visible to groups' do
+      project = create(:project, visible_to: 'groups', groups: [create(:group)])
+      user = nil
+      expect(service.send(:project_visible_disabled_reason, project, user)).to eq 'project_not_visible'
+    end
+  end
+
   describe 'action_descriptors' do
     it 'does not run more than 5 queries for 5 ideation projects with default user permissions' do
       user = create(:user)


### PR DESCRIPTION
# Changelog
## Fixed
- Fixed bug that was preventing admins or moderators submitting an idea when projects had 'admins' or 'groups' visibility 
