### PR TITLE
TAN-1818 Fix endpoint used to get draft survey responses

### DIFF
--- a/front/app/api/ideas/useDraftIdeaByPhaseId.ts
+++ b/front/app/api/ideas/useDraftIdeaByPhaseId.ts
@@ -8,7 +8,7 @@ import ideasKeys from './keys';
 import { IIdea, IdeasKeys } from './types';
 
 export const fetchIdea = ({ phaseId }: { phaseId?: string }) =>
-  fetcher<IIdea>({ path: `/ideas/draft_records/${phaseId}`, action: 'get' });
+  fetcher<IIdea>({ path: `/ideas/draft/${phaseId}`, action: 'get' });
 
 const useDraftIdeaByPhaseId = (phaseId?: string) => {
   return useQuery<IIdea, CLErrors, IIdea, IdeasKeys>({


### PR DESCRIPTION

<img width="1850" alt="Screenshot 2024-05-28 at 12 40 36" src="https://github.com/CitizenLabDotCo/citizenlab/assets/31925816/ce4150e7-5983-4115-8470-363487a571d2">


# Changelog
### Fixed
- [TAN-1818] Issues with finding back draft survey responses. This also fixes the issue of getting multiple survey reminder emails, as each user should only have one draft per survey.
