### PR TITLE
[TAN-1444] Add LogActivityJobs for new XLSX exports

### DIFF
--- a/back/app/controllers/web_api/v1/events_controller.rb
+++ b/back/app/controllers/web_api/v1/events_controller.rb
@@ -45,6 +45,8 @@ class WebApi::V1::EventsController < ApplicationController
       xlsx = XlsxExport::AttendeesGenerator.new.generate_attendees_xlsx attendees, view_private_attributes: true
       send_data xlsx, type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', filename: 'attendees.xlsx'
     end
+
+    side_fx_event_service.after_attendees_xlsx(event, current_user)
   end
 
   def show
@@ -69,12 +71,12 @@ class WebApi::V1::EventsController < ApplicationController
     event = Event.new(event_params)
     event.project_id = params[:project_id]
 
-    SideFxEventService.new.before_create(event, current_user)
+    side_fx_event_service.before_create(event, current_user)
 
     authorize(event)
 
     if event.save
-      SideFxEventService.new.after_create(event, current_user)
+      side_fx_event_service.after_create(event, current_user)
       render json: WebApi::V1::EventSerializer.new(event, params: jsonapi_serializer_params, include: %i[event_images]).serializable_hash, status: :created
     else
       render json: { errors: event.errors.details }, status: :unprocessable_entity
@@ -84,9 +86,9 @@ class WebApi::V1::EventsController < ApplicationController
   def update
     @event.assign_attributes event_params
     authorize @event
-    SideFxEventService.new.before_update(@event, current_user)
+    side_fx_event_service.before_update(@event, current_user)
     if @event.save
-      SideFxEventService.new.after_update(@event, current_user)
+      side_fx_event_service.after_update(@event, current_user)
       render json: WebApi::V1::EventSerializer.new(@event, params: jsonapi_serializer_params, include: %i[event_images]).serializable_hash, status: :ok
     else
       render json: { errors: @event.errors.details }, status: :unprocessable_entity
@@ -96,7 +98,7 @@ class WebApi::V1::EventsController < ApplicationController
   def destroy
     event = @event.destroy
     if event.destroyed?
-      SideFxEventService.new.after_destroy(@event, current_user)
+      side_fx_event_service.after_destroy(@event, current_user)
       head :ok
     else
       head :internal_server_error
@@ -189,5 +191,9 @@ class WebApi::V1::EventsController < ApplicationController
 
   def default_locale
     AppConfiguration.instance.settings('core', 'locales').first
+  end
+
+  def side_fx_event_service
+    @side_fx_event_service ||= SideFxEventService.new
   end
 end

--- a/back/app/controllers/web_api/v1/events_controller.rb
+++ b/back/app/controllers/web_api/v1/events_controller.rb
@@ -46,7 +46,7 @@ class WebApi::V1::EventsController < ApplicationController
       send_data xlsx, type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', filename: 'attendees.xlsx'
     end
 
-    side_fx_event_service.after_attendees_xlsx(event, current_user)
+    side_fx.after_attendees_xlsx(event, current_user)
   end
 
   def show
@@ -71,12 +71,12 @@ class WebApi::V1::EventsController < ApplicationController
     event = Event.new(event_params)
     event.project_id = params[:project_id]
 
-    side_fx_event_service.before_create(event, current_user)
+    side_fx.before_create(event, current_user)
 
     authorize(event)
 
     if event.save
-      side_fx_event_service.after_create(event, current_user)
+      side_fx.after_create(event, current_user)
       render json: WebApi::V1::EventSerializer.new(event, params: jsonapi_serializer_params, include: %i[event_images]).serializable_hash, status: :created
     else
       render json: { errors: event.errors.details }, status: :unprocessable_entity
@@ -86,9 +86,9 @@ class WebApi::V1::EventsController < ApplicationController
   def update
     @event.assign_attributes event_params
     authorize @event
-    side_fx_event_service.before_update(@event, current_user)
+    side_fx.before_update(@event, current_user)
     if @event.save
-      side_fx_event_service.after_update(@event, current_user)
+      side_fx.after_update(@event, current_user)
       render json: WebApi::V1::EventSerializer.new(@event, params: jsonapi_serializer_params, include: %i[event_images]).serializable_hash, status: :ok
     else
       render json: { errors: @event.errors.details }, status: :unprocessable_entity
@@ -98,7 +98,7 @@ class WebApi::V1::EventsController < ApplicationController
   def destroy
     event = @event.destroy
     if event.destroyed?
-      side_fx_event_service.after_destroy(@event, current_user)
+      side_fx.after_destroy(@event, current_user)
       head :ok
     else
       head :internal_server_error
@@ -193,7 +193,7 @@ class WebApi::V1::EventsController < ApplicationController
     AppConfiguration.instance.settings('core', 'locales').first
   end
 
-  def side_fx_event_service
-    @side_fx_event_service ||= SideFxEventService.new
+  def side_fx
+    @side_fx ||= SideFxEventService.new
   end
 end

--- a/back/app/controllers/web_api/v1/events_controller.rb
+++ b/back/app/controllers/web_api/v1/events_controller.rb
@@ -46,7 +46,7 @@ class WebApi::V1::EventsController < ApplicationController
       send_data xlsx, type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', filename: 'attendees.xlsx'
     end
 
-    side_fx.after_attendees_xlsx(event, current_user)
+    sidefx.after_attendees_xlsx(event, current_user)
   end
 
   def show
@@ -71,12 +71,12 @@ class WebApi::V1::EventsController < ApplicationController
     event = Event.new(event_params)
     event.project_id = params[:project_id]
 
-    side_fx.before_create(event, current_user)
+    sidefx.before_create(event, current_user)
 
     authorize(event)
 
     if event.save
-      side_fx.after_create(event, current_user)
+      sidefx.after_create(event, current_user)
       render json: WebApi::V1::EventSerializer.new(event, params: jsonapi_serializer_params, include: %i[event_images]).serializable_hash, status: :created
     else
       render json: { errors: event.errors.details }, status: :unprocessable_entity
@@ -86,9 +86,9 @@ class WebApi::V1::EventsController < ApplicationController
   def update
     @event.assign_attributes event_params
     authorize @event
-    side_fx.before_update(@event, current_user)
+    sidefx.before_update(@event, current_user)
     if @event.save
-      side_fx.after_update(@event, current_user)
+      sidefx.after_update(@event, current_user)
       render json: WebApi::V1::EventSerializer.new(@event, params: jsonapi_serializer_params, include: %i[event_images]).serializable_hash, status: :ok
     else
       render json: { errors: @event.errors.details }, status: :unprocessable_entity
@@ -98,7 +98,7 @@ class WebApi::V1::EventsController < ApplicationController
   def destroy
     event = @event.destroy
     if event.destroyed?
-      side_fx.after_destroy(@event, current_user)
+      sidefx.after_destroy(@event, current_user)
       head :ok
     else
       head :internal_server_error
@@ -193,7 +193,7 @@ class WebApi::V1::EventsController < ApplicationController
     AppConfiguration.instance.settings('core', 'locales').first
   end
 
-  def side_fx
-    @side_fx ||= SideFxEventService.new
+  def sidefx
+    @sidefx ||= SideFxEventService.new
   end
 end

--- a/back/app/controllers/web_api/v1/projects_controller.rb
+++ b/back/app/controllers/web_api/v1/projects_controller.rb
@@ -150,6 +150,8 @@ class WebApi::V1::ProjectsController < ApplicationController
         send_data xlsx, type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
           filename: 'votes_by_user.xlsx'
       end
+
+      after_votes_by_user_xlsx(project, user)
     else
       raise 'Project has no voting phase.'
     end
@@ -162,6 +164,8 @@ class WebApi::V1::ProjectsController < ApplicationController
         send_data xlsx, type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
           filename: 'votes_by_input.xlsx'
       end
+
+      after_votes_by_input_xlsx(project, user)
     else
       raise 'Project has no voting phase.'
     end

--- a/back/app/controllers/web_api/v1/projects_controller.rb
+++ b/back/app/controllers/web_api/v1/projects_controller.rb
@@ -151,7 +151,7 @@ class WebApi::V1::ProjectsController < ApplicationController
           filename: 'votes_by_user.xlsx'
       end
 
-      after_votes_by_user_xlsx(project, user)
+      sidefx.after_votes_by_user_xlsx(@project, current_user)
     else
       raise 'Project has no voting phase.'
     end
@@ -165,7 +165,7 @@ class WebApi::V1::ProjectsController < ApplicationController
           filename: 'votes_by_input.xlsx'
       end
 
-      after_votes_by_input_xlsx(project, user)
+      sidefx.after_votes_by_input_xlsx(@project, current_user)
     else
       raise 'Project has no voting phase.'
     end

--- a/back/app/services/side_fx_event_service.rb
+++ b/back/app/services/side_fx_event_service.rb
@@ -30,4 +30,8 @@ class SideFxEventService
       payload: { event: serialized_event }
     )
   end
+
+  def after_attendees_xlsx(event, current_user)
+    LogActivityJob.perform_later(event, 'exported_attendees', current_user, Time.now.to_i)
+  end
 end

--- a/back/app/services/side_fx_project_service.rb
+++ b/back/app/services/side_fx_project_service.rb
@@ -82,7 +82,7 @@ class SideFxProjectService
       project,
       'exported_votes_by_user',
       user,
-      project.updated_at.to_i,
+      Time.now.to_i,
       project_id: project.id
     )
   end
@@ -92,7 +92,7 @@ class SideFxProjectService
       project,
       'exported_votes_by_input',
       user,
-      project.updated_at.to_i,
+      Time.now.to_i,
       project_id: project.id
     )
   end

--- a/back/app/services/side_fx_project_service.rb
+++ b/back/app/services/side_fx_project_service.rb
@@ -77,6 +77,26 @@ class SideFxProjectService
     LogActivityJob.perform_later project, 'inputs_deleted', user, Time.now.to_i
   end
 
+  def after_votes_by_user_xlsx(project, user)
+    LogActivityJob.perform_later(
+      project,
+      'exported_votes_by_user',
+      user,
+      project.updated_at.to_i,
+      project_id: project.id
+    )
+  end
+
+  def after_votes_by_input_xlsx(project, user)
+    LogActivityJob.perform_later(
+      project,
+      'exported_votes_by_input',
+      user,
+      project.updated_at.to_i,
+      project_id: project.id
+    )
+  end
+
   private
 
   def after_publish(project, user)

--- a/back/spec/services/side_fx_event_spec.rb
+++ b/back/spec/services/side_fx_event_spec.rb
@@ -45,4 +45,12 @@ describe SideFxEventService do
       end
     end
   end
+
+  describe 'after_attendees_xlsx' do
+    it "logs an 'exported_attendees' action job when the attendess are exported" do
+      expect { service.after_attendees_xlsx(event, user) }
+        .to enqueue_job(LogActivityJob)
+        .with(event, 'exported_attendees', user, event.updated_at.to_i, project_id: event.project_id)
+    end
+  end
 end

--- a/back/spec/services/side_fx_event_spec.rb
+++ b/back/spec/services/side_fx_event_spec.rb
@@ -50,7 +50,7 @@ describe SideFxEventService do
     it "logs an 'exported_attendees' action job when the attendess are exported" do
       expect { service.after_attendees_xlsx(event, user) }
         .to enqueue_job(LogActivityJob)
-        .with(event, 'exported_attendees', user, event.updated_at.to_i, project_id: event.project_id)
+        .with(event, 'exported_attendees', user, anything, project_id: event.project_id)
     end
   end
 end

--- a/back/spec/services/side_fx_project_service_spec.rb
+++ b/back/spec/services/side_fx_project_service_spec.rb
@@ -127,4 +127,30 @@ describe SideFxProjectService do
       service.after_delete_inputs project, user
     end
   end
+
+  describe 'after_votes_by_user_xlsx' do
+    it 'logs "exported_votes_by_user" activity' do
+      expect(LogActivityJob).to receive(:perform_later).with(
+        project,
+        'exported_votes_by_user',
+        user,
+        project.updated_at.to_i,
+        project_id: project.id
+      )
+      service.after_votes_by_user_xlsx project, user
+    end
+  end
+
+  describe 'after_votes_by_input_xlsx' do
+    it 'logs "exported_votes_by_input" activity' do
+      expect(LogActivityJob).to receive(:perform_later).with(
+        project,
+        'exported_votes_by_input',
+        user,
+        project.updated_at.to_i,
+        project_id: project.id
+      )
+      service.after_votes_by_input_xlsx project, user
+    end
+  end
 end

--- a/back/spec/services/side_fx_project_service_spec.rb
+++ b/back/spec/services/side_fx_project_service_spec.rb
@@ -134,7 +134,7 @@ describe SideFxProjectService do
         project,
         'exported_votes_by_user',
         user,
-        project.updated_at.to_i,
+        anything,
         project_id: project.id
       )
       service.after_votes_by_user_xlsx project, user
@@ -147,7 +147,7 @@ describe SideFxProjectService do
         project,
         'exported_votes_by_input',
         user,
-        project.updated_at.to_i,
+        anything,
         project_id: project.id
       )
       service.after_votes_by_input_xlsx project, user


### PR DESCRIPTION
Adds LogActivityJobs for the three new XLSX exports, to be used in the adoption dashboard for the Project manager Autonomy tandem.

Also memoizes `SideFxEventService` in events controller.

# Changelog
## Technical
- [TAN-1444] Log activity jobs for the three new XLSX exports: event_attendees, votes_by_input and votes_by_user
