### PR TITLE
[TAN-1778] Migrate deprecated "About this report" report widget

### DIFF
--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -40,6 +40,7 @@ PATH
   specs:
     content_builder (0.1.0)
       active_model_serializers (~> 0.10.7)
+      nanoid (~> 2.0)
       pundit (~> 2.0)
       rails (~> 7.0)
       ros-apartment (>= 2.9.0)
@@ -808,6 +809,7 @@ GEM
     mustache (1.1.1)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
+    nanoid (2.0.0)
     net-http (0.4.1)
       uri
     net-imap (0.4.10)

--- a/back/engines/commercial/content_builder/app/models/content_builder/layout.rb
+++ b/back/engines/commercial/content_builder/app/models/content_builder/layout.rb
@@ -26,6 +26,14 @@ module ContentBuilder
     validates :code, presence: true
     validate :validate_iframe_urls
 
+    scope :with_widget_type, lambda { |widget_type|
+      with_widget = joins('CROSS JOIN jsonb_each(content_builder_layouts.craftjs_json) AS jsonb_each')
+        .where("jsonb_each.value->'type'->>'resolvedName' = ?", widget_type)
+        .select(:id)
+
+      where(id: with_widget)
+    }
+
     def project_id
       content_buildable.try(:project_id)
     end

--- a/back/engines/commercial/content_builder/app/services/content_builder/craftjs/state.rb
+++ b/back/engines/commercial/content_builder/app/services/content_builder/craftjs/state.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require 'nanoid'
+
+module ContentBuilder
+  module Craftjs
+    class State
+      attr_reader :json
+
+      def initialize(json)
+        @json = json
+      end
+
+      # rubocop:disable Metrics/ParameterLists
+      def add_node(
+        type: nil,
+        resolved_name: nil,
+        display_name: nil,
+        parent: 'ROOT',
+        props: {},
+        custom: {},
+        hidden: false,
+        is_canvas: false,
+        nodes: [],
+        linked_nodes: {},
+        index: nil
+      )
+        if resolved_name && type
+          raise ArgumentError, 'Cannot provide both `type` and `resolved_name`'
+        end
+
+        unless type || resolved_name
+          raise ArgumentError, 'Must provide either `type` or `resolved_name`'
+        end
+
+        node = {
+          'type' => type || { 'resolvedName' => resolved_name },
+          'parent' => parent,
+          'props' => props,
+          'custom' => custom,
+          'hidden' => hidden,
+          'isCanvas' => is_canvas,
+          'displayName' => display_name || resolved_name || type,
+          'nodes' => nodes,
+          'linkedNodes' => linked_nodes
+        }
+
+        id = generate_id
+        json[id] = node
+
+        parent_node = _node(parent)
+        index ? parent_node['nodes'].insert(index, id) : parent_node['nodes'] << id
+
+        id
+      end
+      # rubocop:enable Metrics/ParameterLists
+
+      # @param [String] node_id
+      # @param [Array<String>, String] new_node_ids
+      # @return [Hash] The deleted/replaced node
+      def replace_node(node_id, new_node_ids)
+        new_node_ids = Array.wrap(new_node_ids)
+        new_node_ids.each { |id| detach_node(id) }
+
+        node_to_replace = _node(node_id)
+        parent_id = node_to_replace['parent']
+        parent_node = _node(parent_id)
+
+        child_index = parent_node['nodes'].index(node_id)
+        delete_node(node_id)
+        parent_node['nodes'].insert(child_index, *new_node_ids)
+
+        # Reattach the new nodes to the parent.
+        new_node_ids.each do |id|
+          new_node = _node(id)
+          new_node['parent'] = parent_id
+        end
+
+        node_to_replace
+      end
+
+      def nodes_by_resolved_name(resolved_name)
+        json.select do |_id, node|
+          type = node['type']
+          type.is_a?(Hash) && type['resolvedName'] == resolved_name
+        end
+      end
+
+      def delete_node(node_id)
+        deleted_nodes = {}
+        ids_to_delete = [node_id]
+
+        node = _node(node_id)
+        parent = _node(node['parent'])
+        parent['nodes'].delete(node_id)
+
+        until ids_to_delete.empty?
+          id = ids_to_delete.shift
+          deleted_node = json.delete(id) { raise KeyError, "Node with id #{id} not found" }
+          deleted_nodes[id] = deleted_node
+
+          ids_to_delete.concat(deleted_node['linkedNodes'].values)
+          ids_to_delete.concat(deleted_node['nodes'])
+        end
+
+        deleted_nodes
+      end
+
+      def node(id)
+        json.fetch(id)
+      end
+
+      alias _node node # handy for avoiding name collisions when there is a local
+      private :_node # variable named `node`
+
+      private
+
+      def detach_node(id)
+        node = _node(id)
+        parent = _node(node['parent'])
+        node['parent'] = nil
+        parent['nodes'].delete(id)
+      end
+
+      def generate_id
+        # Using a Ruby port of nanoid, the library that Craft.js uses internally to
+        # generate node IDs.
+        Nanoid.generate(size: 10)
+      end
+    end
+  end
+end

--- a/back/engines/commercial/content_builder/content_builder.gemspec
+++ b/back/engines/commercial/content_builder/content_builder.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir['{app,config,db,lib}/**/*', 'Rakefile', 'README.md']
 
   spec.add_dependency 'active_model_serializers', '~> 0.10.7'
+  spec.add_dependency 'nanoid', '~> 2.0'
   spec.add_dependency 'pundit', '~> 2.0'
   spec.add_dependency 'rails', '~> 7.0'
   spec.add_dependency 'ros-apartment', '>=2.9.0'

--- a/back/engines/commercial/content_builder/spec/factories/layouts.rb
+++ b/back/engines/commercial/content_builder/spec/factories/layouts.rb
@@ -17,9 +17,9 @@ FactoryBot.define do
     end
 
     factory :report_layout, class: 'ContentBuilder::Layout' do
-      content_buildable { association(:report, layout: instance) }
       code { 'report' }
       enabled { true }
+      content_buildable { association(:report, layout: instance) }
     end
 
     trait :with_image do

--- a/back/engines/commercial/content_builder/spec/models/content_builder/layout_spec.rb
+++ b/back/engines/commercial/content_builder/spec/models/content_builder/layout_spec.rb
@@ -14,6 +14,38 @@ RSpec.describe ContentBuilder::Layout do
     its(:updated_at) { is_expected.to be_nil }
   end
 
+  describe 'with_widget_type scope' do
+    let_it_be(:layout1) do
+      create(:layout, craftjs_json: {
+        'ROOT' => { 'type' => 'div' },
+        'node-1' => { 'type' => { 'resolvedName' => 'Widget1' } },
+        'node-2' => { 'type' => { 'resolvedName' => 'Widget2' } },
+        'node-3' => { 'type' => { 'resolvedName' => 'Widget2' } }
+      })
+    end
+
+    let_it_be(:layout2) do
+      create(:layout, craftjs_json: {
+        'ROOT' => { 'type' => 'div' },
+        'node-1' => { 'type' => { 'resolvedName' => 'Widget1' } }
+      })
+    end
+
+    it 'returns all the layouts that contain the specified widget type' do
+      expect(described_class.with_widget_type('Widget1'))
+        .to match_array([layout1, layout2])
+    end
+
+    it 'does not duplicate layouts that contain multiple instances of the widget type' do
+      expect(described_class.with_widget_type('Widget2'))
+        .to match_array([layout1])
+    end
+
+    it 'returns an empty array when no layout contains the specified widget type' do
+      expect(described_class.with_widget_type('Widget3')).to be_empty
+    end
+  end
+
   describe '#valid?' do
     it 'returns false when code is not present' do
       layout = build(:layout, code: nil)

--- a/back/engines/commercial/content_builder/spec/services/content_builder/craftjs/fixtures/about_this_report.layout.json
+++ b/back/engines/commercial/content_builder/spec/services/content_builder/craftjs/fixtures/about_this_report.layout.json
@@ -1,0 +1,102 @@
+{
+  "ROOT": {
+    "type": "div",
+    "nodes": [
+      "3h-Eizw2cD"
+    ],
+    "props": {
+      "id": "e2e-content-builder-frame"
+    },
+    "custom": {},
+    "hidden": false,
+    "isCanvas": true,
+    "displayName": "div",
+    "linkedNodes": {}
+  },
+  "3h-Eizw2cD": {
+    "type": {
+      "resolvedName": "AboutReportWidget"
+    },
+    "nodes": [],
+    "props": {
+      "reportId": "68a4aa72-8538-47ea-bbb3-04ab1cd1e286"
+    },
+    "custom": {},
+    "hidden": false,
+    "parent": "ROOT",
+    "isCanvas": false,
+    "displayName": "AboutReportWidget",
+    "linkedNodes": {
+      "about-text": "U7ecmS1hsI",
+      "about-title": "PoSwoa3Fx5"
+    }
+  },
+  "PoSwoa3Fx5": {
+    "type": {
+      "resolvedName": "Container"
+    },
+    "nodes": [
+      "x8jJUeZx0K"
+    ],
+    "props": {},
+    "custom": {},
+    "hidden": false,
+    "parent": "3h-Eizw2cD",
+    "isCanvas": true,
+    "displayName": "Container",
+    "linkedNodes": {}
+  },
+  "U7ecmS1hsI": {
+    "type": {
+      "resolvedName": "Container"
+    },
+    "nodes": [
+      "dpDtvSimWx"
+    ],
+    "props": {},
+    "custom": {},
+    "hidden": false,
+    "parent": "3h-Eizw2cD",
+    "isCanvas": true,
+    "displayName": "Container",
+    "linkedNodes": {}
+  },
+  "dpDtvSimWx": {
+    "type": {
+      "resolvedName": "TextMultiloc"
+    },
+    "nodes": [],
+    "props": {
+      "text": {
+        "en": "<ul>\n<li>Project:</li>\n<li>Project manager: Natasha Roth</li>\n</ul><p>marker-about-text</p>",
+        "fr-BE": "<ul>\n<li>Projet : </li>\n<li>Chef de projet : Natasha Roth</li>\n</ul>",
+        "nl-BE": "<ul>\n<li>Project: </li>\n<li>Projectmanager: Natasha Roth</li>\n</ul>"
+      }
+    },
+    "custom": {},
+    "hidden": false,
+    "parent": "U7ecmS1hsI",
+    "isCanvas": false,
+    "displayName": "TextMultiloc",
+    "linkedNodes": {}
+  },
+  "x8jJUeZx0K": {
+    "type": {
+      "resolvedName": "TextMultiloc"
+    },
+    "nodes": [],
+    "props": {
+      "text": {
+        "en": "<h2>marker-about-title</h2>",
+        "fr-BE": "<h2>about-this-report</h2>",
+        "nl-BE": "<h2>about-this-report</h2>"
+      }
+    },
+    "custom": {},
+    "hidden": false,
+    "parent": "PoSwoa3Fx5",
+    "isCanvas": false,
+    "displayName": "TextMultiloc",
+    "linkedNodes": {}
+  }
+}

--- a/back/engines/commercial/content_builder/spec/services/content_builder/craftjs/state_spec.rb
+++ b/back/engines/commercial/content_builder/spec/services/content_builder/craftjs/state_spec.rb
@@ -1,0 +1,192 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ContentBuilder::Craftjs::State do
+  subject(:state) { described_class.new(json) }
+
+  def load_fixture(file_name)
+    Pathname.new(File.dirname(__FILE__)).join('fixtures', file_name).read
+  end
+
+  let(:json) do
+    JSON.parse(load_fixture('about_this_report.layout.json'))
+  end
+
+  describe '#delete_node' do
+    it 'deletes a node and its children (node tree)' do
+      expect(json.size).to eq(6)
+      expect(json.keys).to include('3h-Eizw2cD')
+      expect(json['ROOT']['nodes']).to include('3h-Eizw2cD')
+
+      state.delete_node('3h-Eizw2cD')
+
+      expect(json.keys).to eq ['ROOT']
+      expect(json['ROOT']['nodes']).to eq []
+    end
+
+    it 'returns the deleted nodes' do
+      expected_results = json.slice(
+        '3h-Eizw2cD', 'PoSwoa3Fx5', 'U7ecmS1hsI', 'dpDtvSimWx', 'x8jJUeZx0K'
+      ).deep_dup
+
+      expect(state.delete_node('3h-Eizw2cD')).to match(expected_results)
+    end
+
+    it 'fails if the node does not exist' do
+      expect { state.delete_node('nonexistent') }.to raise_error(KeyError)
+    end
+  end
+
+  describe '#replace_node' do
+    it 'replaces a node with another node' do
+      expect(json['ROOT']['nodes']).to eq ['3h-Eizw2cD']
+
+      state.replace_node('3h-Eizw2cD', 'x8jJUeZx0K')
+
+      expect(json['ROOT']['nodes']).to eq ['x8jJUeZx0K']
+      expect(state.node('x8jJUeZx0K')['parent']).to eq('ROOT')
+    end
+
+    it 'keeps the replacing node unchanged except for its parent property' do
+      before_node = json['x8jJUeZx0K'].deep_dup
+
+      state.replace_node('3h-Eizw2cD', 'x8jJUeZx0K')
+
+      expect(json['x8jJUeZx0K'].except('parent')).to eq before_node.except('parent')
+    end
+
+    it 'removes nodes that are disconnected by the replacement' do
+      state.replace_node('3h-Eizw2cD', 'x8jJUeZx0K')
+      expect(json.keys).to match_array %w[ROOT x8jJUeZx0K]
+    end
+
+    it 'does not affect the sibling nodes' do
+      id1 = state.add_node(
+        type: 'DummyWidget',
+        parent: 'ROOT',
+        props: { title: 'Dummy Widget 1' },
+        index: 0
+      )
+
+      id2 = state.add_node(
+        type: 'DummyWidget',
+        parent: 'ROOT',
+        props: { title: 'Dummy Widget 2' },
+        index: -1
+      )
+
+      expect(json['ROOT']['nodes']).to eq [id1, '3h-Eizw2cD', id2] # order matters
+      state.replace_node('3h-Eizw2cD', 'x8jJUeZx0K')
+      expect(json['ROOT']['nodes']).to eq [id1, 'x8jJUeZx0K', id2] # order matters
+    end
+
+    it 'replaces a node with multiple nodes' do
+      ids = Array.new(2) { state.add_node(type: 'DummyWidget') }
+
+      state.replace_node('dpDtvSimWx', ids)
+
+      expect(json.dig('U7ecmS1hsI', 'nodes')).to eq ids
+      expect(json).not_to include('dpDtvSimWx')
+
+      ids.each do |id|
+        expect(json.dig(id, 'parent')).to eq('U7ecmS1hsI')
+        expect(json.dig('ROOT', 'nodes')).not_to include(id)
+      end
+    end
+  end
+
+  describe '#add_node' do
+    it 'returns the id of the new node' do
+      id = state.add_node(type: 'a')
+
+      expect(id).to be_a(String)
+      expect(id.length).to eq(10)
+    end
+
+    it 'adds a node to the root' do
+      id = state.add_node(resolved_name: 'DummyWidget')
+      expect(json.dig('ROOT', 'nodes', -1)).to eq(id)
+    end
+
+    it 'creates a node with the correct properties' do
+      id = state.add_node(
+        resolved_name: 'DummyWidget',
+        props: { title: 'Dummy Widget', color: 'red' },
+        custom: { custom_key: 'custom_value' },
+        hidden: true,
+        is_canvas: true,
+        display_name: 'Dummy'
+      )
+
+      # `as_json` is used to convert symbols to strings
+      expect(json[id].as_json).to include(
+        'type' => { 'resolvedName' => 'DummyWidget' },
+        'props' => { 'title' => 'Dummy Widget', 'color' => 'red' },
+        'custom' => { 'custom_key' => 'custom_value' },
+        'hidden' => true,
+        'isCanvas' => true,
+        'displayName' => 'Dummy'
+      )
+    end
+
+    it 'accepts both type and resolved_name to define the node type' do
+      id = state.add_node(type: 'div')
+      expect(json.dig(id, 'type')).to eq('div')
+
+      id = state.add_node(resolved_name: 'DummyWidget')
+      expect(json.dig(id, 'type')).to eq('resolvedName' => 'DummyWidget')
+    end
+
+    it 'fails if type and resolved_name parameters are both missing' do
+      expect { state.add_node }
+        .to raise_error(ArgumentError, 'Must provide either `type` or `resolved_name`')
+    end
+
+    it 'fails if type and resolved_name parameters are both present' do
+      expect { state.add_node(type: 'div', resolved_name: 'DummyWidget') }
+        .to raise_error(ArgumentError, 'Cannot provide both `type` and `resolved_name`')
+    end
+
+    it 'fails if the parent node does not exist' do
+      expect { state.add_node(type: 'div', parent: 'imaginary') }
+        .to raise_error(KeyError)
+    end
+
+    it 'inserts a node at the specified position among siblings' do
+      parent_id = state.add_node(resolved_name: 'Parent')
+
+      id1 = state.add_node(resolved_name: 'DummyWidget', parent: parent_id)
+      id2 = state.add_node(resolved_name: 'DummyWidget', parent: parent_id, index: 0)
+      id3 = state.add_node(resolved_name: 'DummyWidget', parent: parent_id, index: -2)
+
+      expect(json.dig(parent_id, 'nodes')).to eq [id2, id3, id1]
+    end
+  end
+
+  describe '#node' do
+    it 'returns the node with the given id' do
+      expect(state.node('3h-Eizw2cD')).to be(json['3h-Eizw2cD'])
+    end
+
+    it 'fails if the node does not exist' do
+      expect { state.node('non-existent') }.to raise_error(KeyError)
+    end
+  end
+
+  describe '#nodes_by_resolved_name' do
+    it 'returns all nodes with the given resolved_name' do
+      nodes = state.nodes_by_resolved_name('TextMultiloc')
+
+      expect(nodes.keys).to match_array %w[dpDtvSimWx x8jJUeZx0K]
+
+      # Testing for object identity
+      expect(nodes['dpDtvSimWx']).to be(json['dpDtvSimWx'])
+      expect(nodes['x8jJUeZx0K']).to be(json['x8jJUeZx0K'])
+    end
+
+    it 'returns an empty hash if no nodes have the given resolved_name' do
+      expect(state.nodes_by_resolved_name('non-existent')).to eq({})
+    end
+  end
+end

--- a/back/lib/tasks/single_use/20240527_migrate_deprecated_about_this_report_widget.rake
+++ b/back/lib/tasks/single_use/20240527_migrate_deprecated_about_this_report_widget.rake
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+namespace :single_use do
+  task migrate_deprecated_about_this_report_widget: [:environment] do |_t, _args|
+    # region HELPER METHODS
+
+    # @param [ContentBuilder::Layout] layout
+    def migrate_about_this_report_widgets!(layout)
+      json = layout.craftjs_json
+
+      ContentBuilder::Layout.transaction do
+        layout.dup.tap do |backup|
+          backup.code = "backup/#{layout.code}/#{layout.id}"
+          backup.content_buildable = nil
+        end.save!
+
+        state = ContentBuilder::Craftjs::State.new(json)
+
+        about_nodes = state.nodes_by_resolved_name('AboutReportWidget')
+
+        about_nodes.each do |node_id, about_node|
+          logo_node = create_logo_node!(state)
+          title_node = create_multiloc_node(about_node, 'about-title', state)
+          text_node = create_multiloc_node(about_node, 'about-text', state)
+
+          new_node_ids = [logo_node].compact + [title_node, text_node]
+          state.replace_node(node_id, new_node_ids)
+        end
+
+        layout.update!(craftjs_json: state.json)
+      end
+    end
+
+    # @param [ContentBuilder::Craftjs::State] state
+    # @return [String, nil]
+    def create_logo_node!(state)
+      logo = AppConfiguration.instance.logo.versions[:medium]
+      return if logo.blank?
+
+      data_code = ContentBuilder::LayoutImage.create!(image: logo).code
+
+      state.add_node(
+        resolved_name: 'ImageMultiloc',
+        display_name: 'Image',
+        props: {
+          image: { dataCode: data_code },
+          stretch: false
+        }
+      )
+    end
+
+    # @param [Hash] about_report_node
+    # @param [String] linked_node_label
+    # @param [ContentBuilder::Craftjs::State] state
+    def create_multiloc_node(about_report_node, linked_node_label, state)
+      container_node_id = about_report_node.dig('linkedNodes', linked_node_label)
+      container_node = state.node(container_node_id)
+
+      title_node_id = container_node['nodes'].first
+      title_node = state.node(title_node_id)
+
+      multiloc = title_node['props']['text']
+      raise 'Cannot find title node text' if multiloc.blank?
+
+      state.add_node(
+        resolved_name: 'TextMultiloc',
+        props: { text: multiloc }
+      )
+    end
+
+    # endregion HELPER METHODS
+
+    Tenant.prioritize(Tenant.creation_finalized).each do |tenant|
+      tenant.switch do
+        layouts = ContentBuilder::Layout
+          .where.not('code LIKE ?', 'backup/%')
+          .with_widget_type('AboutReportWidget')
+
+        layouts.each do |layout|
+          migrate_about_this_report_widgets!(layout)
+        end
+      end
+    end
+  end
+end

--- a/back/spec/tasks/single_use/fixtures/about-this-report.before.report-layout.json
+++ b/back/spec/tasks/single_use/fixtures/about-this-report.before.report-layout.json
@@ -1,0 +1,102 @@
+{
+  "ROOT": {
+    "type": "div",
+    "nodes": [
+      "3h-Eizw2cD"
+    ],
+    "props": {
+      "id": "e2e-content-builder-frame"
+    },
+    "custom": {},
+    "hidden": false,
+    "isCanvas": true,
+    "displayName": "div",
+    "linkedNodes": {}
+  },
+  "3h-Eizw2cD": {
+    "type": {
+      "resolvedName": "AboutReportWidget"
+    },
+    "nodes": [],
+    "props": {
+      "reportId": "68a4aa72-8538-47ea-bbb3-04ab1cd1e286"
+    },
+    "custom": {},
+    "hidden": false,
+    "parent": "ROOT",
+    "isCanvas": false,
+    "displayName": "AboutReportWidget",
+    "linkedNodes": {
+      "about-text": "U7ecmS1hsI",
+      "about-title": "PoSwoa3Fx5"
+    }
+  },
+  "PoSwoa3Fx5": {
+    "type": {
+      "resolvedName": "Container"
+    },
+    "nodes": [
+      "x8jJUeZx0K"
+    ],
+    "props": {},
+    "custom": {},
+    "hidden": false,
+    "parent": "3h-Eizw2cD",
+    "isCanvas": true,
+    "displayName": "Container",
+    "linkedNodes": {}
+  },
+  "U7ecmS1hsI": {
+    "type": {
+      "resolvedName": "Container"
+    },
+    "nodes": [
+      "dpDtvSimWx"
+    ],
+    "props": {},
+    "custom": {},
+    "hidden": false,
+    "parent": "3h-Eizw2cD",
+    "isCanvas": true,
+    "displayName": "Container",
+    "linkedNodes": {}
+  },
+  "dpDtvSimWx": {
+    "type": {
+      "resolvedName": "TextMultiloc"
+    },
+    "nodes": [],
+    "props": {
+      "text": {
+        "en": "<p>marker-about-text</p>",
+        "fr-BE": "<p>marker-about-text</p>" ,
+        "nl-BE": "<p>marker-about-text</p>"
+      }
+    },
+    "custom": {},
+    "hidden": false,
+    "parent": "U7ecmS1hsI",
+    "isCanvas": false,
+    "displayName": "TextMultiloc",
+    "linkedNodes": {}
+  },
+  "x8jJUeZx0K": {
+    "type": {
+      "resolvedName": "TextMultiloc"
+    },
+    "nodes": [],
+    "props": {
+      "text": {
+        "en": "<h2>marker-about-title</h2>",
+        "fr-BE": "<h2>about-this-report</h2>",
+        "nl-BE": "<h2>about-this-report</h2>"
+      }
+    },
+    "custom": {},
+    "hidden": false,
+    "parent": "PoSwoa3Fx5",
+    "isCanvas": false,
+    "displayName": "TextMultiloc",
+    "linkedNodes": {}
+  }
+}

--- a/back/spec/tasks/single_use/migrate_deprecated_about_this_report_widget_spec.rb
+++ b/back/spec/tasks/single_use/migrate_deprecated_about_this_report_widget_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'single_use:migrate_deprecated_about_this_report_widget' do # rubocop:disable RSpec/DescribeClass
+  before(:all) do # rubocop:disable RSpec/BeforeAfterAll
+    task_path = 'tasks/single_use/20240527_migrate_deprecated_about_this_report_widget'
+    Rake.application.rake_require(task_path)
+    Rake::Task.define_task(:environment)
+  end
+
+  before do
+    Rake::Task['single_use:migrate_deprecated_about_this_report_widget'].reenable
+  end
+
+  def load_fixture(file_name)
+    Pathname.new(File.dirname(__FILE__)).join('fixtures', file_name).read
+  end
+
+  def load_json(file_name)
+    JSON.parse(load_fixture(file_name))
+  end
+
+  let(:json_before) { load_json('about-this-report.before.report-layout.json') }
+  let!(:report_layout) { create(:report_layout, craftjs_json: json_before) }
+
+  context 'when the tenant has a logo' do
+    before do
+      AppConfiguration.instance.update!(logo: Rails.root.join('spec/fixtures/logo.png').open)
+    end
+
+    it "converts the 'AboutReportWidget' into an 'ImageMultiloc' and two 'TextMultiloc' nodes" do
+      Rake::Task['single_use:migrate_deprecated_about_this_report_widget'].invoke
+
+      craftjs_json = report_layout.reload.craftjs_json
+      expect(craftjs_json.size).to eq(4) # ROOT + the 3 nodes replacing the AboutReportWidget
+
+      about_nodes = craftjs_json.values.select do |node|
+        node['type']['resolvedName'] == 'AboutReportWidget'
+      end
+      expect(about_nodes).to be_empty
+
+      root_children = craftjs_json['ROOT']['nodes']
+
+      expect(craftjs_json[root_children[0]]).to match(
+        'type' => { 'resolvedName' => 'ImageMultiloc' },
+        'nodes' => [],
+        'props' => {
+          'image' => { 'dataCode' => be_a(String) },
+          'stretch' => false
+        },
+        'custom' => {},
+        'hidden' => false,
+        'parent' => 'ROOT',
+        'isCanvas' => false,
+        'displayName' => 'Image',
+        'linkedNodes' => {}
+      )
+
+      expect(craftjs_json[root_children[1]]).to match(
+        'type' => { 'resolvedName' => 'TextMultiloc' },
+        'nodes' => [],
+        'props' => {
+          'text' => {
+            'en' => '<h2>marker-about-title</h2>',
+            'fr-BE' => '<h2>about-this-report</h2>',
+            'nl-BE' => '<h2>about-this-report</h2>'
+          }
+        },
+        'custom' => {},
+        'hidden' => false,
+        'parent' => 'ROOT',
+        'isCanvas' => false,
+        'displayName' => 'TextMultiloc',
+        'linkedNodes' => {}
+      )
+
+      expect(craftjs_json[root_children[2]]).to match(
+        'type' => { 'resolvedName' => 'TextMultiloc' },
+        'nodes' => [],
+        'props' => {
+          'text' => {
+            'en' => '<p>marker-about-text</p>',
+            'fr-BE' => '<p>marker-about-text</p>',
+            'nl-BE' => '<p>marker-about-text</p>'
+          }
+        },
+        'custom' => {},
+        'hidden' => false,
+        'parent' => 'ROOT',
+        'isCanvas' => false,
+        'displayName' => 'TextMultiloc',
+        'linkedNodes' => {}
+      )
+    end
+  end
+
+  context 'when the tenant has no logo' do
+    it "converts the 'AboutReportWidget' into two 'TextMultiloc' nodes" do
+      Rake::Task['single_use:migrate_deprecated_about_this_report_widget'].invoke
+
+      craftjs_json = report_layout.reload.craftjs_json
+      expect(craftjs_json.size).to eq(3)
+
+      nb_text_multiloc_nodes = craftjs_json.count do |_, node|
+        node['type']['resolvedName'] == 'TextMultiloc'
+      end
+
+      expect(nb_text_multiloc_nodes).to eq(2)
+    end
+  end
+
+  it 'creates a backup of the layout' do
+    expect do
+      Rake::Task['single_use:migrate_deprecated_about_this_report_widget'].invoke
+    end.to change(ContentBuilder::Layout, :count).by(1)
+
+    backup = ContentBuilder::Layout.find_by!(code: "backup/#{report_layout.code}/#{report_layout.id}")
+    expect(backup.craftjs_json).to eq(json_before)
+    expect(backup.content_buildable).to be_nil
+  end
+end


### PR DESCRIPTION
# Changelog
## Technical 
- [TAN-1778] Add a single-use rake task to recompose deprecated "About this report" widget using other widgets.