### PR TITLE
[TAN-1850] Add example coordinates to Location input tooltip

### DIFF
--- a/front/app/components/Form/Components/Controls/messages.ts
+++ b/front/app/components/Form/Components/Controls/messages.ts
@@ -28,9 +28,9 @@ export default defineMessages({
     defaultMessage: '*Select as many as you like',
   },
   validCordinatesTooltip: {
-    id: 'app.components.form.controls.validCordinatesTooltip',
+    id: 'app.components.form.controls.validCordinatesTooltip2',
     defaultMessage:
-      "If the location is not displayed among the options as you type, you can add valid coordinates in the format 'latitude, longitude' to specify a precise location.",
+      "If the location is not displayed among the options as you type, you can add valid coordinates in the format 'latitude, longitude' to specify a precise location (eg: -33.019808, -71.495676).",
   },
   tapOnMapToAdd: {
     id: 'app.components.form.controls.tapOnMapToAdd2',

--- a/front/app/translations/ar-MA.json
+++ b/front/app/translations/ar-MA.json
@@ -635,7 +635,6 @@
   "app.components.form.controls.tapOnFullscreenMapToAdd": "اضغط على الخريطة لإضافة إجابتك.",
   "app.components.form.controls.tapOnMapToAdd2": "اضغط على الخريطة أو اكتب عنوانًا أدناه لإضافة إجابتك.",
   "app.components.form.controls.tapToAddAPoint": "انقر لإضافة نقطة",
-  "app.components.form.controls.validCordinatesTooltip": "إذا لم يتم عرض الموقع بين الخيارات أثناء الكتابة، فيمكنك إضافة إحداثيات صالحة بتنسيق \"خط العرض، خط الطول\" لتحديد موقع دقيق.",
   "app.components.form.error": "خطأ",
   "app.components.form.locationGoogleUnavailable": "تعذر تعبئة حقل الموقع المتوفر من خرائط google.",
   "app.components.form.submit": "إرسال",

--- a/front/app/translations/ar-SA.json
+++ b/front/app/translations/ar-SA.json
@@ -635,7 +635,6 @@
   "app.components.form.controls.tapOnFullscreenMapToAdd": "اضغط على الخريطة لإضافة إجابتك.",
   "app.components.form.controls.tapOnMapToAdd2": "اضغط على الخريطة أو اكتب عنوانًا أدناه لإضافة إجابتك.",
   "app.components.form.controls.tapToAddAPoint": "انقر لإضافة نقطة",
-  "app.components.form.controls.validCordinatesTooltip": "إذا لم يتم عرض الموقع بين الخيارات أثناء الكتابة، فيمكنك إضافة إحداثيات صالحة بتنسيق \"خط العرض، خط الطول\" لتحديد موقع دقيق.",
   "app.components.form.error": "خطأ",
   "app.components.form.locationGoogleUnavailable": "تعذر تعبئة حقل الموقع المتوفر من خرائط google.",
   "app.components.form.submit": "إرسال",

--- a/front/app/translations/ca-ES.json
+++ b/front/app/translations/ca-ES.json
@@ -635,7 +635,6 @@
   "app.components.form.controls.tapOnFullscreenMapToAdd": "Toqueu el mapa per afegir la vostra resposta.",
   "app.components.form.controls.tapOnMapToAdd2": "Toqueu el mapa o escriviu una adreça a continuació per afegir la vostra resposta.",
   "app.components.form.controls.tapToAddAPoint": "Toqueu per afegir un punt",
-  "app.components.form.controls.validCordinatesTooltip": "Si la ubicació no es mostra entre les opcions mentre escriviu, podeu afegir coordenades vàlides en el format \"latitud, longitud\" per especificar una ubicació precisa.",
   "app.components.form.error": "Error",
   "app.components.form.locationGoogleUnavailable": "No s'ha pogut carregar el camp d'ubicació proporcionat per Google Maps.",
   "app.components.form.submit": "Presentar",

--- a/front/app/translations/da-DK.json
+++ b/front/app/translations/da-DK.json
@@ -635,7 +635,6 @@
   "app.components.form.controls.tapOnFullscreenMapToAdd": "Tryk på kortet for at tilføje dit svar.",
   "app.components.form.controls.tapOnMapToAdd2": "Tryk på kortet, eller skriv en adresse nedenfor for at tilføje dit svar.",
   "app.components.form.controls.tapToAddAPoint": "Tryk for at tilføje et punkt",
-  "app.components.form.controls.validCordinatesTooltip": "Hvis placeringen ikke vises blandt mulighederne, mens du skriver, kan du tilføje gyldige koordinater i formatet 'breddegrad, længdegrad' for at angive en præcis placering.",
   "app.components.form.error": "Fejl",
   "app.components.form.locationGoogleUnavailable": "Kunne ikke indlæse feltet for placering leveret af Google Maps.",
   "app.components.form.submit": "Indsend",

--- a/front/app/translations/de-DE.json
+++ b/front/app/translations/de-DE.json
@@ -635,7 +635,6 @@
   "app.components.form.controls.tapOnFullscreenMapToAdd": "Tippen Sie auf die Karte, um Ihre Antwort hinzuzufügen.",
   "app.components.form.controls.tapOnMapToAdd2": "Tippen Sie auf die Karte oder geben Sie unten eine Adresse ein, um Ihre Antwort hinzuzufügen.",
   "app.components.form.controls.tapToAddAPoint": "Tippen, um einen Punkt hinzuzufügen",
-  "app.components.form.controls.validCordinatesTooltip": "Wenn der Ort während der Eingabe nicht unter den Optionen angezeigt wird, können Sie gültige Koordinaten im Format 'Breitengrad, Längengrad' hinzufügen, um einen genauen Ort anzugeben.",
   "app.components.form.error": "Fehler",
   "app.components.form.locationGoogleUnavailable": "Das von Google Maps zur Verfügung gestellte Standort-Feld konnte nicht geladen werden.",
   "app.components.form.submit": "Einreichen",

--- a/front/app/translations/el-GR.json
+++ b/front/app/translations/el-GR.json
@@ -635,7 +635,6 @@
   "app.components.form.controls.tapOnFullscreenMapToAdd": "Πατήστε στο χάρτη για να προσθέσετε την απάντησή σας.",
   "app.components.form.controls.tapOnMapToAdd2": "Πατήστε στο χάρτη ή πληκτρολογήστε μια διεύθυνση παρακάτω για να προσθέσετε την απάντησή σας.",
   "app.components.form.controls.tapToAddAPoint": "Πατήστε για να προσθέσετε ένα σημείο",
-  "app.components.form.controls.validCordinatesTooltip": "Εάν η τοποθεσία δεν εμφανίζεται μεταξύ των επιλογών καθώς πληκτρολογείτε, μπορείτε να προσθέσετε έγκυρες συντεταγμένες με τη μορφή \"γεωγραφικό πλάτος, γεωγραφικό μήκος\" για να καθορίσετε μια ακριβή τοποθεσία.",
   "app.components.form.error": "Σφάλμα",
   "app.components.form.locationGoogleUnavailable": "Δεν ήταν δυνατή η φόρτωση του πεδίου τοποθεσίας που παρέχεται από τους χάρτες Google.",
   "app.components.form.submit": "Υποβολή",

--- a/front/app/translations/en-CA.json
+++ b/front/app/translations/en-CA.json
@@ -635,7 +635,6 @@
   "app.components.form.controls.tapOnFullscreenMapToAdd": "Tap on the map to add your answer.",
   "app.components.form.controls.tapOnMapToAdd2": "Tap on the map or type an address below to add your answer.",
   "app.components.form.controls.tapToAddAPoint": "Tap to add a point",
-  "app.components.form.controls.validCordinatesTooltip": "If the location is not displayed among the options as you type, you can add valid coordinates in the format 'latitude, longitude' to specify a precise location.",
   "app.components.form.error": "Error",
   "app.components.form.locationGoogleUnavailable": "Couldn't load location field provided by google maps.",
   "app.components.form.submit": "Submit",

--- a/front/app/translations/en-GB.json
+++ b/front/app/translations/en-GB.json
@@ -635,7 +635,6 @@
   "app.components.form.controls.tapOnFullscreenMapToAdd": "Tap on the map to add your answer.",
   "app.components.form.controls.tapOnMapToAdd2": "Tap on the map or type an address below to add your answer.",
   "app.components.form.controls.tapToAddAPoint": "Tap to add a point",
-  "app.components.form.controls.validCordinatesTooltip": "If the location is not displayed among the options as you type, you can add valid coordinates in the format 'latitude, longitude' to specify a precise location.",
   "app.components.form.error": "Error",
   "app.components.form.locationGoogleUnavailable": "Couldn't load location field provided by google maps.",
   "app.components.form.submit": "Submit",

--- a/front/app/translations/en-IE.json
+++ b/front/app/translations/en-IE.json
@@ -635,7 +635,6 @@
   "app.components.form.controls.tapOnFullscreenMapToAdd": "Tap on the map to add your answer.",
   "app.components.form.controls.tapOnMapToAdd2": "Tap on the map or type an address below to add your answer.",
   "app.components.form.controls.tapToAddAPoint": "Tap to add a point",
-  "app.components.form.controls.validCordinatesTooltip": "If the location is not displayed among the options as you type, you can add valid coordinates in the format 'latitude, longitude' to specify a precise location.",
   "app.components.form.error": "Error",
   "app.components.form.locationGoogleUnavailable": "Couldn't load location field provided by google maps.",
   "app.components.form.submit": "Submit",

--- a/front/app/translations/en.json
+++ b/front/app/translations/en.json
@@ -635,7 +635,7 @@
   "app.components.form.controls.tapOnFullscreenMapToAdd": "Tap on the map to add your answer.",
   "app.components.form.controls.tapOnMapToAdd2": "Tap on the map or type an address below to add your answer.",
   "app.components.form.controls.tapToAddAPoint": "Tap to add a point",
-  "app.components.form.controls.validCordinatesTooltip": "If the location is not displayed among the options as you type, you can add valid coordinates in the format 'latitude, longitude' to specify a precise location.",
+  "app.components.form.controls.validCordinatesTooltip2": "If the location is not displayed among the options as you type, you can add valid coordinates in the format 'latitude, longitude' to specify a precise location (eg: -33.019808, -71.495676).",
   "app.components.form.error": "Error",
   "app.components.form.locationGoogleUnavailable": "Couldn't load location field provided by google maps.",
   "app.components.form.submit": "Submit",

--- a/front/app/translations/es-CL.json
+++ b/front/app/translations/es-CL.json
@@ -635,7 +635,6 @@
   "app.components.form.controls.tapOnFullscreenMapToAdd": "Toca en el mapa para añadir tu respuesta.",
   "app.components.form.controls.tapOnMapToAdd2": "Toca en el mapa o escribe una dirección abajo para añadir tu respuesta.",
   "app.components.form.controls.tapToAddAPoint": "Toca para añadir un punto",
-  "app.components.form.controls.validCordinatesTooltip": "Si la ubicación no aparece entre las opciones mientras escribes, puedes añadir coordenadas válidas en el formato \"latitud, longitud\" para especificar una ubicación precisa.",
   "app.components.form.error": "Error",
   "app.components.form.locationGoogleUnavailable": "No se ha podido cargar el campo de ubicación proporcionado por google maps.",
   "app.components.form.submit": "Enviar",

--- a/front/app/translations/es-ES.json
+++ b/front/app/translations/es-ES.json
@@ -635,7 +635,6 @@
   "app.components.form.controls.tapOnFullscreenMapToAdd": "Toca en el mapa para añadir tu respuesta.",
   "app.components.form.controls.tapOnMapToAdd2": "Toca en el mapa o escribe una dirección abajo para añadir tu respuesta.",
   "app.components.form.controls.tapToAddAPoint": "Toca para añadir un punto",
-  "app.components.form.controls.validCordinatesTooltip": "Si la ubicación no aparece entre las opciones mientras escribes, puedes añadir coordenadas válidas en el formato \"latitud, longitud\" para especificar una ubicación precisa.",
   "app.components.form.error": "Error",
   "app.components.form.locationGoogleUnavailable": "No se ha podido cargar el campo de ubicación proporcionado por google maps.",
   "app.components.form.submit": "Enviar",

--- a/front/app/translations/fi-FI.json
+++ b/front/app/translations/fi-FI.json
@@ -635,7 +635,6 @@
   "app.components.form.controls.tapOnFullscreenMapToAdd": "Napauta karttaa lisätäksesi vastauksesi.",
   "app.components.form.controls.tapOnMapToAdd2": "Napauta karttaa tai kirjoita osoite alle lisätäksesi vastauksesi.",
   "app.components.form.controls.tapToAddAPoint": "Lisää piste napauttamalla",
-  "app.components.form.controls.validCordinatesTooltip": "Jos sijainti ei näy vaihtoehtojen joukossa kirjoittaessasi, voit määrittää tarkan sijainnin lisäämällä kelvollisia koordinaatteja muodossa \"leveysaste, pituusaste\".",
   "app.components.form.error": "Virhe",
   "app.components.form.locationGoogleUnavailable": "Google Mapsin toimittamaa sijaintikenttää ei voitu ladata.",
   "app.components.form.submit": "Lähetä",

--- a/front/app/translations/fr-BE.json
+++ b/front/app/translations/fr-BE.json
@@ -635,7 +635,6 @@
   "app.components.form.controls.tapOnFullscreenMapToAdd": "Cliquez sur la carte pour ajouter votre réponse.",
   "app.components.form.controls.tapOnMapToAdd2": "Cliquez sur la carte ou saisissez une adresse ci-dessous pour ajouter votre réponse.",
   "app.components.form.controls.tapToAddAPoint": "Cliquez pour ajouter un point",
-  "app.components.form.controls.validCordinatesTooltip": "Si l'emplacement n'est pas affiché parmi les options que vous saisissez, vous pouvez ajouter des coordonnées valides au format « latitude, longitude » pour spécifier un emplacement précis.",
   "app.components.form.error": "Erreur",
   "app.components.form.locationGoogleUnavailable": "Impossible de charger le champ de localisation fourni par Google Maps.",
   "app.components.form.submit": "Envoyer",

--- a/front/app/translations/fr-FR.json
+++ b/front/app/translations/fr-FR.json
@@ -635,7 +635,6 @@
   "app.components.form.controls.tapOnFullscreenMapToAdd": "Cliquez sur la carte pour ajouter votre réponse.",
   "app.components.form.controls.tapOnMapToAdd2": "Cliquez sur la carte ou saisissez une adresse ci-dessous pour ajouter votre réponse.",
   "app.components.form.controls.tapToAddAPoint": "Cliquez pour ajouter un point",
-  "app.components.form.controls.validCordinatesTooltip": "Si l'emplacement n'est pas affiché parmi les options que vous saisissez, vous pouvez ajouter des coordonnées valides au format « latitude, longitude » pour spécifier un emplacement précis.",
   "app.components.form.error": "Erreur",
   "app.components.form.locationGoogleUnavailable": "Impossible de charger le champ de localisation fourni par Google Maps.",
   "app.components.form.submit": "Envoyer",

--- a/front/app/translations/hr-HR.json
+++ b/front/app/translations/hr-HR.json
@@ -635,7 +635,6 @@
   "app.components.form.controls.tapOnFullscreenMapToAdd": "Dodirnite kartu da dodate svoj odgovor.",
   "app.components.form.controls.tapOnMapToAdd2": "Dodirnite kartu ili upišite adresu ispod kako biste dodali svoj odgovor.",
   "app.components.form.controls.tapToAddAPoint": "Dodirnite za dodavanje točke",
-  "app.components.form.controls.validCordinatesTooltip": "Ako lokacija nije prikazana među opcijama dok upisujete, možete dodati važeće koordinate u formatu 'geografska širina, dužina' kako biste odredili točnu lokaciju.",
   "app.components.form.error": "Pogreška",
   "app.components.form.locationGoogleUnavailable": "Učitavanje polja s lokacijom s Google Mapa nije uspjelo.",
   "app.components.form.submit": "Pošalji",

--- a/front/app/translations/it-IT.json
+++ b/front/app/translations/it-IT.json
@@ -635,7 +635,6 @@
   "app.components.form.controls.tapOnFullscreenMapToAdd": "Tocca la mappa per aggiungere la tua risposta.",
   "app.components.form.controls.tapOnMapToAdd2": "Tocca la mappa o digita un indirizzo qui sotto per aggiungere la tua risposta.",
   "app.components.form.controls.tapToAddAPoint": "Tocca per aggiungere un punto",
-  "app.components.form.controls.validCordinatesTooltip": "Se la posizione non viene visualizzata tra le opzioni durante la digitazione, puoi aggiungere delle coordinate valide nel formato \"latitudine, longitudine\" per specificare una posizione precisa.",
   "app.components.form.error": "Errore",
   "app.components.form.locationGoogleUnavailable": "Impossibile caricare il campo posizione fornito da google maps.",
   "app.components.form.submit": "Invia",

--- a/front/app/translations/lb-LU.json
+++ b/front/app/translations/lb-LU.json
@@ -635,7 +635,6 @@
   "app.components.form.controls.tapOnFullscreenMapToAdd": "Tippen op der Kaart fir Är Äntwert ze addéieren.",
   "app.components.form.controls.tapOnMapToAdd2": "Tippen op der Kaart oder gitt eng Adress hei ënnen fir Är Äntwert derbäi ze ginn.",
   "app.components.form.controls.tapToAddAPoint": "Tippen fir e Punkt ze addéieren",
-  "app.components.form.controls.validCordinatesTooltip": "Wann de Standort net ënnert den Optiounen ugewise gëtt wéi Dir tippt, kënnt Dir gëlteg Koordinaten am Format 'Breet, Längt' addéieren fir eng präzis Plaz ze spezifizéieren.",
   "app.components.form.error": "Feeler",
   "app.components.form.locationGoogleUnavailable": "Konnt d’Standuertfeld, dat vu Google Maps zur Verfügung gestallt gouf, net lueden.",
   "app.components.form.submit": "Schécken",

--- a/front/app/translations/lv-LV.json
+++ b/front/app/translations/lv-LV.json
@@ -635,7 +635,6 @@
   "app.components.form.controls.tapOnFullscreenMapToAdd": "Pieskarieties kartei, lai pievienotu atbildi.",
   "app.components.form.controls.tapOnMapToAdd2": "Pieskarieties kartei vai ierakstiet adresi, lai pievienotu atbildi.",
   "app.components.form.controls.tapToAddAPoint": "Pieskarieties, lai pievienotu punktu",
-  "app.components.form.controls.validCordinatesTooltip": "Ja ievadīšanas laikā atrašanās vieta nav redzama starp opcijām, varat pievienot derīgas koordinātas formātā \"platums, garums\", lai norādītu precīzu atrašanās vietu.",
   "app.components.form.error": "Kļūda",
   "app.components.form.locationGoogleUnavailable": "Nevarēja ielādēt google maps norādīto atrašanās vietas lauku.",
   "app.components.form.submit": "Iesniegt",

--- a/front/app/translations/nb-NO.json
+++ b/front/app/translations/nb-NO.json
@@ -635,7 +635,6 @@
   "app.components.form.controls.tapOnFullscreenMapToAdd": "Trykk på kartet for å legge til svaret ditt.",
   "app.components.form.controls.tapOnMapToAdd2": "Trykk på kartet eller skriv inn en adresse nedenfor for å legge til svaret ditt.",
   "app.components.form.controls.tapToAddAPoint": "Trykk for å legge til et punkt",
-  "app.components.form.controls.validCordinatesTooltip": "Hvis plasseringen ikke vises blant alternativene mens du skriver, kan du legge til gyldige koordinater i formatet 'breddegrad, lengdegrad' for å spesifisere en nøyaktig plassering.",
   "app.components.form.error": "Feil",
   "app.components.form.locationGoogleUnavailable": "Kunne ikke laste område for lokalisering basert på opplysninger fra google maps.",
   "app.components.form.submit": "Send inn",

--- a/front/app/translations/nl-BE.json
+++ b/front/app/translations/nl-BE.json
@@ -635,7 +635,6 @@
   "app.components.form.controls.tapOnFullscreenMapToAdd": "Tik op de kaart om je antwoord toe te voegen.",
   "app.components.form.controls.tapOnMapToAdd2": "Tik op de kaart of typ hieronder een adres om je antwoord toe te voegen.",
   "app.components.form.controls.tapToAddAPoint": "Tik om een punt toe te voegen",
-  "app.components.form.controls.validCordinatesTooltip": "Als de locatie niet wordt weergegeven tussen de opties terwijl je typt of als je een precieze locatie op wilt geven, kun je geldige coördinaten toevoegen in het formaat 'breedtegraad, lengtegraad'.",
   "app.components.form.error": "Fout",
   "app.components.form.locationGoogleUnavailable": "Kan locatieveld geleverd door google maps niet laden.",
   "app.components.form.submit": "Verzenden",

--- a/front/app/translations/nl-NL.json
+++ b/front/app/translations/nl-NL.json
@@ -635,7 +635,6 @@
   "app.components.form.controls.tapOnFullscreenMapToAdd": "Tik op de kaart om je antwoord toe te voegen.",
   "app.components.form.controls.tapOnMapToAdd2": "Tik op de kaart of typ hieronder een adres om je antwoord toe te voegen.",
   "app.components.form.controls.tapToAddAPoint": "Tik om een punt toe te voegen",
-  "app.components.form.controls.validCordinatesTooltip": "Als de locatie niet wordt weergegeven tussen de opties terwijl je typt of als je een precieze locatie op wilt geven, kun je geldige coördinaten toevoegen in het formaat 'breedtegraad, lengtegraad'.",
   "app.components.form.error": "Fout",
   "app.components.form.locationGoogleUnavailable": "Kan locatieveld geleverd door google maps niet laden.",
   "app.components.form.submit": "Verzenden",

--- a/front/app/translations/pl-PL.json
+++ b/front/app/translations/pl-PL.json
@@ -635,7 +635,6 @@
   "app.components.form.controls.tapOnFullscreenMapToAdd": "Dotknij mapy, aby dodać odpowiedź.",
   "app.components.form.controls.tapOnMapToAdd2": "Dotknij mapy lub wpisz adres poniżej, aby dodać odpowiedź.",
   "app.components.form.controls.tapToAddAPoint": "Stuknij, aby dodać punkt",
-  "app.components.form.controls.validCordinatesTooltip": "Jeśli lokalizacja nie jest wyświetlana wśród opcji podczas wpisywania, możesz dodać prawidłowe współrzędne w formacie \"szerokość, długość geograficzna\", aby określić dokładną lokalizację.",
   "app.components.form.error": "Błąd",
   "app.components.form.locationGoogleUnavailable": "Nie można załadować pola lokalizacji dostarczonego przez mapy google.",
   "app.components.form.submit": "Prześlij",

--- a/front/app/translations/pt-BR.json
+++ b/front/app/translations/pt-BR.json
@@ -635,7 +635,6 @@
   "app.components.form.controls.tapOnFullscreenMapToAdd": "Toque no mapa para adicionar sua resposta.",
   "app.components.form.controls.tapOnMapToAdd2": "Toque no mapa ou digite um endereço abaixo para adicionar sua resposta.",
   "app.components.form.controls.tapToAddAPoint": "Toque para adicionar um ponto",
-  "app.components.form.controls.validCordinatesTooltip": "Se a localização não for exibida entre as opções enquanto você digita, você pode adicionar coordenadas válidas no formato 'latitude, longitude' para especificar uma localização precisa.",
   "app.components.form.error": "Erro",
   "app.components.form.locationGoogleUnavailable": "Não foi possível carregar o campo de localização fornecido pelo google maps.",
   "app.components.form.submit": "Enviar",

--- a/front/app/translations/sr-Latn.json
+++ b/front/app/translations/sr-Latn.json
@@ -635,7 +635,6 @@
   "app.components.form.controls.tapOnFullscreenMapToAdd": "Tap on the map to add your answer.",
   "app.components.form.controls.tapOnMapToAdd2": "Tap on the map or type an address below to add your answer.",
   "app.components.form.controls.tapToAddAPoint": "Tap to add a point",
-  "app.components.form.controls.validCordinatesTooltip": "If the location is not displayed among the options as you type, you can add valid coordinates in the format 'latitude, longitude' to specify a precise location.",
   "app.components.form.error": "Greška",
   "app.components.form.locationGoogleUnavailable": "Učitavanje polja sa lokacijom google mape nije uspelo.",
   "app.components.form.submit": "Pošalji",

--- a/front/app/translations/sr-SP.json
+++ b/front/app/translations/sr-SP.json
@@ -635,7 +635,6 @@
   "app.components.form.controls.tapOnFullscreenMapToAdd": "Tap on the map to add your answer.",
   "app.components.form.controls.tapOnMapToAdd2": "Tap on the map or type an address below to add your answer.",
   "app.components.form.controls.tapToAddAPoint": "Tap to add a point",
-  "app.components.form.controls.validCordinatesTooltip": "Ако локација није приказана међу опцијама док куцате, можете додати важеће координате у формату „латитуде, лонгитуде“ да бисте одредили прецизну локацију.",
   "app.components.form.error": "Грешка",
   "app.components.form.locationGoogleUnavailable": "Није могуће учитати поље локације које пружају Гоогле мапе.",
   "app.components.form.submit": "прихвати",

--- a/front/app/translations/sv-SE.json
+++ b/front/app/translations/sv-SE.json
@@ -635,7 +635,6 @@
   "app.components.form.controls.tapOnFullscreenMapToAdd": "Tryck på kartan för att lägga till ditt svar.",
   "app.components.form.controls.tapOnMapToAdd2": "Klicka på kartan eller skriv en adress nedan för att lägga till ditt svar.",
   "app.components.form.controls.tapToAddAPoint": "Tryck för att lägga till en punkt",
-  "app.components.form.controls.validCordinatesTooltip": "Om platsen inte visas bland alternativen när du skriver kan du lägga till giltiga koordinater i formatet \"latitud, longitud\" för att ange en exakt plats.",
   "app.components.form.error": "Fel",
   "app.components.form.locationGoogleUnavailable": "Det gick inte att läsa in platsfältet från Google Maps.",
   "app.components.form.submit": "Skicka",

--- a/front/app/translations/tr-TR.json
+++ b/front/app/translations/tr-TR.json
@@ -635,7 +635,6 @@
   "app.components.form.controls.tapOnFullscreenMapToAdd": "Cevabınızı eklemek için haritaya dokunun.",
   "app.components.form.controls.tapOnMapToAdd2": "Cevabınızı eklemek için haritaya dokunun veya aşağıya bir adres yazın.",
   "app.components.form.controls.tapToAddAPoint": "Nokta eklemek için dokunun",
-  "app.components.form.controls.validCordinatesTooltip": "Yazarken seçenekler arasında konum görüntülenmezse, kesin bir konum belirtmek için 'enlem, boylam' biçiminde geçerli koordinatlar ekleyebilirsiniz.",
   "app.components.form.error": "Hata",
   "app.components.form.locationGoogleUnavailable": "Google Maps tarafından sağlanan konum alanı yüklenemedi.",
   "app.components.form.submit": "Gönder",


### PR DESCRIPTION
# Changelog
## Changed
- [[TAN-1850](https://www.notion.so/citizenlab/Task-adding-an-example-of-coordinate-format-in-the-tooltip-about-location-with-coordinates-in-the--76b68f95bcbb4a99abf974a13ddb6dc7?pvs=4)] Added example coordinates to Location input tooltip
