### PR TITLE
[TAN-1750] Fix images not saving properly in Quill editor

### DIFF
--- a/front/app/components/UI/QuillEditor/index.tsx
+++ b/front/app/components/UI/QuillEditor/index.tsx
@@ -712,6 +712,17 @@ const QuillEditor = memo<Props>(
       .filter((className) => className)
       .join(' ');
 
+    // Function to save the latest state of the content.
+    // We call this when the mouse leaves the editor, to ensure the
+    // latest content (and image size + alt text) is proprely saved.
+    const saveLatestContent = () => {
+      if (editor) {
+        const html = editor.root.innerHTML;
+        contentRef.current = html;
+        onChange && onChange(html, locale);
+      }
+    };
+
     return (
       <Container
         maxHeight={maxHeight}
@@ -724,6 +735,7 @@ const QuillEditor = memo<Props>(
         edit={formatMessage(messages.edit)}
         remove={formatMessage(messages.remove)}
         scrollTop={scrollTop}
+        onMouseLeave={saveLatestContent}
       >
         {label && (
           <Label htmlFor={id} onClick={handleLabelOnClick}>

--- a/front/app/components/UI/QuillEditor/index.tsx
+++ b/front/app/components/UI/QuillEditor/index.tsx
@@ -719,7 +719,7 @@ const QuillEditor = memo<Props>(
       if (editor) {
         const html = editor.root.innerHTML;
         contentRef.current = html;
-        onChange && onChange(html, locale);
+        onChange?.(html, locale);
       }
     };
 

--- a/front/app/components/UI/QuillEditor/index.tsx
+++ b/front/app/components/UI/QuillEditor/index.tsx
@@ -714,7 +714,7 @@ const QuillEditor = memo<Props>(
 
     // Function to save the latest state of the content.
     // We call this when the mouse leaves the editor, to ensure the
-    // latest content (and image size + alt text) is proprely saved.
+    // latest content (and image size + alt text) is properly saved.
     const saveLatestContent = () => {
       if (editor) {
         const html = editor.root.innerHTML;


### PR DESCRIPTION
# Description
I've worked on trying to fix this issue for half a day now, and this was the best/most reliable solution I ended up finding.

The issue seems to be that the separate library we use specifically for image resizing doesn't trigger the Quill "text changed" or "selection changed" events when resizing. So if the image is resized and that's the last change a user makes to the content before saving, it doesn't actually save. I've tried to fix this in many different ways, but this ended up being the simplest solution which always seems to work.

Essentially, we just wait for a `mouseLeave` event on the Quill Editor, and when that happens we run a quick save of the content once more to make sure the latest content is saved. Once the user clicks the "Save" button, the content (including image size and alt tag) are properly saved now (even if they were the last thing to be changed).

# Changelog
## Fixed
- [TAN-1750] Fix images not saving properly in Quill editor.
