### PR TITLE
TAN-1965: Fix focus issues in firefox

### DIFF
--- a/front/app/assets/css/reset.css
+++ b/front/app/assets/css/reset.css
@@ -374,23 +374,6 @@ button,
 }
 
 /**
-  * Remove the inner border and padding in Firefox.
-  */
-
-::-moz-focus-inner {
-  border-style: none;
-  padding: 0;
-}
-
-/**
-  * Correct the focus styles unset by the previous rule.
-  */
-
-:-moz-focusring {
-  outline: 1px dotted ButtonText;
-}
-
-/**
   * Correct the border, margin, and padding in all browsers.
   */
 

--- a/front/app/assets/css/reset.min.css
+++ b/front/app/assets/css/reset.min.css
@@ -170,13 +170,7 @@ button,
 html [type='button'] {
   -webkit-appearance: button;
 }
-::-moz-focus-inner {
-  border-style: none;
-  padding: 0;
-}
-:-moz-focusring {
-  outline: ButtonText dotted 1px;
-}
+
 fieldset {
   border: 1px solid silver;
   margin: 0 2px;

--- a/front/app/component-library/assets/css/reset.css
+++ b/front/app/component-library/assets/css/reset.css
@@ -384,23 +384,6 @@ button,
 }
 
 /**
-  * Remove the inner border and padding in Firefox.
-  */
-
-::-moz-focus-inner {
-  border-style: none;
-  padding: 0;
-}
-
-/**
-  * Correct the focus styles unset by the previous rule.
-  */
-
-:-moz-focusring {
-  outline: 1px dotted ButtonText;
-}
-
-/**
   * Correct the border, margin, and padding in all browsers.
   */
 

--- a/front/app/component-library/assets/css/reset.min.css
+++ b/front/app/component-library/assets/css/reset.min.css
@@ -170,13 +170,7 @@ button,
 html [type='button'] {
   -webkit-appearance: button;
 }
-::-moz-focus-inner {
-  border-style: none;
-  padding: 0;
-}
-:-moz-focusring {
-  outline: ButtonText dotted 1px;
-}
+
 fieldset {
   border: 1px solid silver;
   margin: 0 2px;


### PR DESCRIPTION
The custom focus that we had for Firefox was not working for all cases so I have removed it to work with the default browser defaults. It was also a fix for Firefox versions before version 53 which was released in April 2017. All versions after that don't have the problem

# Changelog

## Fixed
-a11y: Fix focus issues in Firefox. Firefox used to add padding before version 53 so developers needed to handle those cases differently. The way we were handling it was causing some focus issues were focused elements sometimes appeared unfocused
