### PR TITLE
[TAN-1946] Use more permissive regex in isValidUrl

### DIFF
--- a/front/app/utils/validate.test.ts
+++ b/front/app/utils/validate.test.ts
@@ -6,7 +6,7 @@ describe('isValidUrl', () => {
     expect(isValidUrl('http://www.example.com')).toStrictEqual(true);
     expect(isValidUrl('https://example.com')).toStrictEqual(true);
     expect(
-      isValidUrl('https://example.realyreallysuperduperlongurlsuffix')
+      isValidUrl('https://example.reallyreallysuperduperlongurlsuffix')
     ).toStrictEqual(true);
   });
   it('tests invalid URLs', () => {

--- a/front/app/utils/validate.test.ts
+++ b/front/app/utils/validate.test.ts
@@ -5,6 +5,9 @@ describe('isValidUrl', () => {
     expect(isValidUrl('https://www.example.com')).toStrictEqual(true);
     expect(isValidUrl('http://www.example.com')).toStrictEqual(true);
     expect(isValidUrl('https://example.com')).toStrictEqual(true);
+    expect(
+      isValidUrl('https://example.realyreallysuperduperlongurlsuffix')
+    ).toStrictEqual(true);
   });
   it('tests invalid URLs', () => {
     expect(isValidUrl('www.example.com')).toStrictEqual(false);

--- a/front/app/utils/validate.ts
+++ b/front/app/utils/validate.ts
@@ -6,7 +6,7 @@ export const isValidUrl = (url: string) => {
   // Used this reference for generating a valid URL regex:
   // https://tutorial.eyehunts.com/js/url-regex-validation-javascript-example-code/
   const validUrlRegex =
-    /(http(s)?:\/\/.)(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/g;
+    /(http(s)?:\/\/)(www\.)?([a-zA-Z0-9@:%_+-.~#?&//=]{1,256})/g;
 
   if (!validUrlRegex.test(url)) {
     return false;

--- a/front/app/utils/validate.ts
+++ b/front/app/utils/validate.ts
@@ -6,7 +6,7 @@ export const isValidUrl = (url: string) => {
   // Used this reference for generating a valid URL regex:
   // https://tutorial.eyehunts.com/js/url-regex-validation-javascript-example-code/
   const validUrlRegex =
-    /(http(s)?:\/\/)(www\.)?([a-zA-Z0-9@:%_+-.~#?&//=]{1,256})/g;
+    /(http(s)?:\/\/)(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,64}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/g;
 
   if (!validUrlRegex.test(url)) {
     return false;


### PR DESCRIPTION
Matches longer URL suffixes.
e.g. `https://example.reallyreallysuperduperlongurlsuffix`

Also removes (weird) match for any single character following `http(s)://`

# Changelog
## Fixed
- [TAN-1946] Permit URLs with long suffixes e.g. can now add https://jeparticipe.ajaccio.corsica/fr-FR/initiatives to Homepage custom button on banner.
