### PR TITLE
TAN-1895 - Fix submit on enter for profile page

### DIFF
--- a/front/app/components/Form/index.tsx
+++ b/front/app/components/Form/index.tsx
@@ -1,4 +1,10 @@
-import React, { memo, ReactElement, useEffect, useState } from 'react';
+import React, {
+  FormEvent,
+  memo,
+  ReactElement,
+  useEffect,
+  useState,
+} from 'react';
 
 // jsonforms
 import {
@@ -78,7 +84,7 @@ interface Props {
   config?: 'default' | 'input' | 'survey';
   layout?: 'inline' | 'fullpage';
   footer?: React.ReactNode;
-  parentSubmit?: (e: any) => void;
+  onParentSubmit?: (event: FormEvent) => void;
 }
 
 const Form = memo(
@@ -96,7 +102,7 @@ const Form = memo(
     footer,
     onChange,
     onSubmit,
-    parentSubmit,
+    onParentSubmit,
   }: Props) => {
     const { formatMessage } = useIntl();
     const locale = useLocale();
@@ -156,8 +162,8 @@ const Form = memo(
       setScrollToError(true);
     };
 
-    const invisibleSubmit = (e) => {
-      parentSubmit ? parentSubmit(e) : handleSubmit();
+    const invisibleSubmit = (event: FormEvent) => {
+      onParentSubmit ? onParentSubmit(event) : handleSubmit();
     };
 
     useObserveEvent(submitOnEvent, handleSubmit);

--- a/front/app/components/Form/index.tsx
+++ b/front/app/components/Form/index.tsx
@@ -78,6 +78,7 @@ interface Props {
   config?: 'default' | 'input' | 'survey';
   layout?: 'inline' | 'fullpage';
   footer?: React.ReactNode;
+  parentSubmit?: (e: any) => void;
 }
 
 const Form = memo(
@@ -95,6 +96,7 @@ const Form = memo(
     footer,
     onChange,
     onSubmit,
+    parentSubmit,
   }: Props) => {
     const { formatMessage } = useIntl();
     const locale = useLocale();
@@ -152,6 +154,10 @@ const Form = memo(
         setLoading(false);
       }
       setScrollToError(true);
+    };
+
+    const invisibleSubmit = (e) => {
+      parentSubmit ? parentSubmit(e) : handleSubmit();
     };
 
     useObserveEvent(submitOnEvent, handleSubmit);
@@ -217,7 +223,7 @@ const Form = memo(
                 processing={loading}
               />
             ) : submitOnEvent ? (
-              <InvisibleSubmitButton onClick={handleSubmit} />
+              <InvisibleSubmitButton onClick={invisibleSubmit} />
             ) : (
               <Button onClick={handleSubmit}>
                 {formatMessage(messages.save)}

--- a/front/app/components/UI/MultipleSelect/index.tsx
+++ b/front/app/components/UI/MultipleSelect/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { KeyboardEvent } from 'react';
 
 import { Label } from '@citizenlab/cl2-component-library';
 import ReactSelect from 'react-select';
@@ -58,6 +58,10 @@ export default class MultipleSelect extends React.PureComponent<Props, State> {
     return value;
   };
 
+  preventModalCloseOnEscape = (event: KeyboardEvent) => {
+    if (event.code === 'Escape') event.stopPropagation();
+  };
+
   render() {
     const { id, className, disabled, label, isSearchable = true } = this.props;
     let { value, placeholder, options, autoBlur } = this.props;
@@ -90,6 +94,7 @@ export default class MultipleSelect extends React.PureComponent<Props, State> {
           menuPosition="fixed"
           menuPlacement="auto"
           hideSelectedOptions
+          onKeyDown={this.preventModalCloseOnEscape}
         />
       </div>
     );

--- a/front/app/components/UserCustomFieldsForm/index.tsx
+++ b/front/app/components/UserCustomFieldsForm/index.tsx
@@ -29,6 +29,7 @@ interface UserCustomFieldsFormProps {
   authenticationContext: AuthenticationContext;
   onSubmit?: (data: { key: string; formData: Record<string, any> }) => void;
   onChange?: (data: { key: string; formData: Record<string, any> }) => void;
+  parentSubmit?: (e: any) => void;
 }
 
 const UserCustomFieldsForm = ({
@@ -36,6 +37,7 @@ const UserCustomFieldsForm = ({
   authenticationContext,
   onSubmit,
   onChange,
+  parentSubmit,
 }: UserCustomFieldsFormProps) => {
   const { data: userCustomFieldsSchema } = useCustomFieldsSchema(
     authenticationContext
@@ -92,6 +94,7 @@ const UserCustomFieldsForm = ({
         getAjvErrorMessage={getAjvErrorMessage}
         submitOnEvent="customFieldsSubmitEvent"
         initialFormData={authUser.attributes.custom_field_values}
+        parentSubmit={parentSubmit}
       />
     );
   }

--- a/front/app/components/UserCustomFieldsForm/index.tsx
+++ b/front/app/components/UserCustomFieldsForm/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FormEvent } from 'react';
 
 import { ErrorObject } from 'ajv';
 import { forOwn } from 'lodash-es';
@@ -29,7 +29,7 @@ interface UserCustomFieldsFormProps {
   authenticationContext: AuthenticationContext;
   onSubmit?: (data: { key: string; formData: Record<string, any> }) => void;
   onChange?: (data: { key: string; formData: Record<string, any> }) => void;
-  parentSubmit?: (e: any) => void;
+  onParentSubmit?: (event: FormEvent) => void;
 }
 
 const UserCustomFieldsForm = ({
@@ -37,7 +37,7 @@ const UserCustomFieldsForm = ({
   authenticationContext,
   onSubmit,
   onChange,
-  parentSubmit,
+  onParentSubmit,
 }: UserCustomFieldsFormProps) => {
   const { data: userCustomFieldsSchema } = useCustomFieldsSchema(
     authenticationContext
@@ -94,7 +94,7 @@ const UserCustomFieldsForm = ({
         getAjvErrorMessage={getAjvErrorMessage}
         submitOnEvent="customFieldsSubmitEvent"
         initialFormData={authUser.attributes.custom_field_values}
-        parentSubmit={parentSubmit}
+        onParentSubmit={onParentSubmit}
       />
     );
   }

--- a/front/app/containers/Authentication/steps/CustomFields/index.tsx
+++ b/front/app/containers/Authentication/steps/CustomFields/index.tsx
@@ -85,6 +85,7 @@ const CustomFields = ({
         authUser={authUser.data}
         authenticationContext={authenticationData.context}
         onSubmit={handleSubmit}
+        onParentSubmit={handleOnSubmitButtonClick}
       />
 
       <Box

--- a/front/app/containers/UsersEditPage/ProfileForm.tsx
+++ b/front/app/containers/UsersEditPage/ProfileForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, FormEvent } from 'react';
 
 import { IconTooltip, Box, Button } from '@citizenlab/cl2-component-library';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -122,8 +122,8 @@ const ProfileForm = () => {
     label: appLocalePairs[locale],
   }));
 
-  const handleDisclaimer = (e) => {
-    e.preventDefault();
+  const handleDisclaimer = (event: FormEvent) => {
+    event.preventDefault();
     if (
       methods.formState.dirtyFields.avatar &&
       methods.getValues('avatar') &&
@@ -278,7 +278,7 @@ const ProfileForm = () => {
             authUser={authUser.data}
             authenticationContext={GLOBAL_CONTEXT}
             onChange={handleCustomFieldsChange}
-            parentSubmit={handleDisclaimer}
+            onParentSubmit={handleDisclaimer}
           />
           <Box display="flex">
             <Button type="submit" processing={methods.formState.isSubmitting}>

--- a/front/app/containers/UsersEditPage/ProfileForm.tsx
+++ b/front/app/containers/UsersEditPage/ProfileForm.tsx
@@ -122,7 +122,8 @@ const ProfileForm = () => {
     label: appLocalePairs[locale],
   }));
 
-  const handleDisclaimer = () => {
+  const handleDisclaimer = (e) => {
+    e.preventDefault();
     if (
       methods.formState.dirtyFields.avatar &&
       methods.getValues('avatar') &&
@@ -191,7 +192,7 @@ const ProfileForm = () => {
   return (
     <FormSection>
       <FormProvider {...methods}>
-        <form>
+        <form onSubmit={handleDisclaimer}>
           <FormSectionTitle
             message={messages.h1}
             subtitleMessage={messages.h1sub}
@@ -272,21 +273,19 @@ const ProfileForm = () => {
               label={formatMessage(messages.language)}
             />
           </SectionField>
+
+          <UserCustomFieldsForm
+            authUser={authUser.data}
+            authenticationContext={GLOBAL_CONTEXT}
+            onChange={handleCustomFieldsChange}
+            parentSubmit={handleDisclaimer}
+          />
+          <Box display="flex">
+            <Button type="submit" processing={methods.formState.isSubmitting}>
+              {formatMessage(messages.submit)}
+            </Button>
+          </Box>
         </form>
-        <UserCustomFieldsForm
-          authUser={authUser.data}
-          authenticationContext={GLOBAL_CONTEXT}
-          onChange={handleCustomFieldsChange}
-        />
-        <Box display="flex">
-          <Button
-            type="submit"
-            processing={methods.formState.isSubmitting}
-            onClick={handleDisclaimer}
-          >
-            {formatMessage(messages.submit)}
-          </Button>
-        </Box>
       </FormProvider>
       <ContentUploadDisclaimer
         isDisclaimerOpened={isDisclaimerOpened}


### PR DESCRIPTION
This was an issue on pressing enter for all user custom fields. Fixed this primarily by allowing `<UserCustomFields>` to use the parent form for submission instead of trying to do it's own submission on enter.

# Changelog
## Fixed
- Keyboard fix to stop enter key from closing profile form without saving and to stop escape key closing the complete profile modal within multiselect fields
