### PR TITLE
TAN-1990: Return focus to more actions button

### DIFF
--- a/front/app/components/FormBuilder/components/FormFields/FormField/index.tsx
+++ b/front/app/components/FormBuilder/components/FormFields/FormField/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 
 import {
   Box,
@@ -67,6 +67,7 @@ export const FormField = ({
     trigger,
     setValue,
   } = useFormContext();
+  const moreActionsButtonRef = useRef<HTMLButtonElement>(null);
   const { formatMessage } = useIntl();
   const lockedAttributes = field?.constraints?.locks;
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -335,11 +336,16 @@ export const FormField = ({
               actions={actions}
               onClick={(event) => event.stopPropagation()}
               data-cy="e2e-more-field-actions"
+              ref={moreActionsButtonRef}
             />
           </Box>
         </FlexibleRow>
       </FormFieldsContainer>
-      <Modal opened={showDeleteModal} close={closeModal}>
+      <Modal
+        opened={showDeleteModal}
+        close={closeModal}
+        returnFocusRef={moreActionsButtonRef}
+      >
         <Box display="flex" flexDirection="column" width="100%" p="20px">
           <Box mb="40px">
             <Title variant="h3" color="primary">

--- a/front/app/components/PostShowComponents/Comments/Comment/CommentsMoreActions.tsx
+++ b/front/app/components/PostShowComponents/Comments/Comment/CommentsMoreActions.tsx
@@ -1,4 +1,4 @@
-import React, { FormEvent, useState } from 'react';
+import React, { FormEvent, useState, useRef } from 'react';
 
 import { isRtl } from '@citizenlab/cl2-component-library';
 import styled from 'styled-components';
@@ -70,6 +70,7 @@ const CommentsMoreActions = ({
   ideaId,
   initiativeId,
 }: Props) => {
+  const moreActionsButtonRef = useRef<HTMLButtonElement>(null);
   const parentCommentId = comment.relationships?.parent?.data?.id;
   const { mutate: markForDeletion, isLoading } = useMarkCommentForDeletion({
     ideaId,
@@ -175,13 +176,18 @@ const CommentsMoreActions = ({
   return (
     <>
       <Container className={className || ''}>
-        <MoreActionsMenu showLabel={false} actions={actions} />
+        <MoreActionsMenu
+          showLabel={false}
+          actions={actions}
+          ref={moreActionsButtonRef}
+        />
       </Container>
 
       <Modal
         opened={modalVisible_delete}
         close={closeDeleteModal}
         className="e2e-comment-deletion-modal"
+        returnFocusRef={moreActionsButtonRef}
         header={<FormattedMessage {...messages.confirmCommentDeletion} />}
       >
         {needsToJustifyDeletion ? (

--- a/front/app/components/PostShowComponents/Comments/Comment/CommentsMoreActions.tsx
+++ b/front/app/components/PostShowComponents/Comments/Comment/CommentsMoreActions.tsx
@@ -215,6 +215,7 @@ const CommentsMoreActions = ({
       <Modal
         opened={modalVisible_spam}
         close={closeSpamModal}
+        returnFocusRef={moreActionsButtonRef}
         header={<FormattedMessage {...messages.reportAsSpamModalTitle} />}
       >
         <SpamReportForm targetId={comment.id} targetType="comments" />

--- a/front/app/components/UI/Modal/index.tsx
+++ b/front/app/components/UI/Modal/index.tsx
@@ -1,4 +1,4 @@
-import React, { PureComponent, ReactElement } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 
 import {
   Box,
@@ -12,7 +12,7 @@ import {
 import { createPortal } from 'react-dom';
 import { FocusOn } from 'react-focus-on';
 import CSSTransition from 'react-transition-group/CSSTransition';
-import { Subscription, fromEvent } from 'rxjs';
+import { fromEvent } from 'rxjs';
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 import styled from 'styled-components';
 
@@ -27,18 +27,15 @@ import tracks from './tracks';
 
 const desktopOpacityTimeout = 500;
 const mobileOpacityTimeout = 250;
-
 const desktopTransformTimeout = 500;
 const mobileTransformTimeout = 700;
-
 const desktopTranslateY = '-200px';
 const mobileTranslateY = '300px';
-
 const desktopEasing = 'cubic-bezier(0.19, 1, 0.22, 1)';
 const mobileEasing = 'cubic-bezier(0.19, 1, 0.22, 1)';
 
 export const ModalContentContainer = styled.div<{
-  padding?: string | undefined;
+  padding?: string;
   fullScreen?: boolean;
 }>`
   flex: 1 1 auto;
@@ -48,22 +45,20 @@ export const ModalContentContainer = styled.div<{
   -webkit-overflow-scrolling: touch;
   padding: ${({ padding }) => padding || '30px'};
 
-  ${(props) => media.phone`
-    padding: ${props.padding || '20px'};
+  ${media.phone`
+    padding: ${({ padding }) => padding || '20px'};
   `}
 
   ${({ fullScreen }) =>
     fullScreen &&
     `
-      display: flex;
-      justify-content: center;
-      padding-bottom: 40px !important;
+    display: flex;
+    justify-content: center;
+    padding-bottom: 40px !important;
   `}
 `;
 
-const StyledCloseIconButton = styled(CloseIconButton)<{
-  fullScreen?: boolean;
-}>`
+const StyledCloseIconButton = styled(CloseIconButton)<{ fullScreen?: boolean }>`
   position: absolute;
   top: 12px;
   z-index: 2000;
@@ -80,6 +75,7 @@ const StyledCloseIconButton = styled(CloseIconButton)<{
   &.focus-visible {
     ${defaultOutline};
   }
+
   ${isRtl`
     right: auto;
     left: 25px;
@@ -87,9 +83,9 @@ const StyledCloseIconButton = styled(CloseIconButton)<{
 
   ${({ fullScreen }) => (fullScreen ? 'left: 25px;' : 'right: 25px;')};
 
-  ${(props) => media.phone`
+  ${media.phone`
     top: 13px;
-    ${props.fullScreen ? 'left: auto;' : ''};
+    ${({ fullScreen }) => (fullScreen ? 'left: auto;' : '')};
     right: 15px;
   `}
 `;
@@ -116,16 +112,14 @@ const StyledCloseIconButton2 = styled(CloseIconButton)`
   &.focus-visible {
     ${defaultOutline};
   }
+
   ${isRtl`
     right: auto;
     left: 25px;
   `}
 `;
 
-// copy of the styled FocusOn container below
-const StyledNonFocusableContainer = styled.div<{
-  fullScreen?: boolean;
-}>`
+const StyledNonFocusableContainer = styled.div<{ fullScreen?: boolean }>`
   width: 100%;
   display: flex;
   justify-content: center;
@@ -133,8 +127,8 @@ const StyledNonFocusableContainer = styled.div<{
   ${({ fullScreen }) =>
     fullScreen &&
     `
-      height: calc(100vh - 78px);
-      max-width: 100%;
+    height: calc(100vh - 78px);
+    max-width: 100%;
   `}
 `;
 
@@ -144,15 +138,15 @@ const StyledFocusOn = styled(FocusOn)<{
 }>`
   width: 100%;
   max-width: ${({ width }) =>
-    width.constructor === String ? width : `${width}px`};
+    typeof width === 'string' ? width : `${width}px`};
   display: flex;
   justify-content: center;
 
   ${({ fullScreen }) =>
     fullScreen &&
     `
-      height: calc(100vh - 78px);
-      max-width: 100%;
+    height: calc(100vh - 78px);
+    max-width: 100%;
   `}
 `;
 
@@ -180,21 +174,20 @@ const ModalContainer = styled(clickOutside)<{
   ${({ fullScreen }) =>
     fullScreen &&
     `
-      margin: 0;
-      align-items: center;
-      max-height: 100%;
-      border-radius: 0;
+    margin: 0;
+    align-items: center;
+    max-height: 100%;
+    border-radius: 0;
   `}
 
-  /* tall desktops screens */
   @media (min-height: 1200px) {
     margin-top: 120px;
     ${({ fullScreen }) => fullScreen && 'margin-top: 0;'}
   }
 
-  ${(props) => media.phone`
+  ${media.phone`
     max-width: calc(100vw - 30px);
-    max-height: calc(${props.windowHeight}px - 30px);
+    max-height: calc(${({ windowHeight }) => windowHeight}px - 30px);
     margin-top: 15px;
 
     &.fixedHeight {
@@ -202,21 +195,17 @@ const ModalContainer = styled(clickOutside)<{
       max-height: 85vh;
     }
 
-    ${
-      props.fullScreen &&
+    ${({ fullScreen }) =>
+      fullScreen &&
       `
-        margin-top: 0;
-        max-height: 100%;
-        max-width: 100%;
-      `
-    }
+      margin-top: 0;
+      max-height: 100%;
+      max-width: 100%;
+    `}
   `}
 `;
 
-const Overlay = styled.div<{
-  fullScreen?: boolean;
-  zIndex?: number;
-}>`
+const Overlay = styled.div<{ fullScreen?: boolean; zIndex?: number }>`
   width: 100vw;
   height: 100vh;
   position: fixed;
@@ -233,19 +222,14 @@ const Overlay = styled.div<{
   overflow: hidden;
   will-change: opacity, transform;
 
-  z-index: ${({ fullScreen, zIndex }) => {
-    if (zIndex !== undefined) {
-      return zIndex.toString();
-    }
-
-    return fullScreen ? '400' : '1000001';
-  }};
+  z-index: ${({ fullScreen, zIndex }) =>
+    zIndex !== undefined ? zIndex.toString() : fullScreen ? '400' : '1000001'};
 
   ${({ fullScreen }) =>
     fullScreen &&
     `
-      margin-top: 78px;
-      padding: 0px;
+    margin-top: 78px;
+    padding: 0px;
   `}
 
   ${media.phone`
@@ -279,15 +263,13 @@ const Overlay = styled.div<{
           transform ${desktopTransformTimeout}ms ${desktopEasing};
 
         ${media.phone`
-          transition: opacity ${mobileOpacityTimeout}ms ${mobileEasing},
-                      transform ${mobileTransformTimeout}ms ${mobileEasing};
+          transition: opacity ${mobileOpacityTimeout}ms ${mobileEasing}, transform ${mobileTransformTimeout}ms ${mobileEasing};
         `}
 
         ${({ fullScreen }) =>
           fullScreen &&
           `
-            transition: opacity 0ms ${mobileEasing},
-            transform 0ms ${mobileEasing};
+          transition: opacity 0ms ${mobileEasing}, transform 0ms ${mobileEasing};
         `}
       }
     }
@@ -314,7 +296,7 @@ const HeaderContainer = styled.div`
 `;
 
 const HeaderTitle = styled.h1`
-  color: ${(props) => props.theme.colors.tenantText};
+  color: ${({ theme }) => theme.colors.tenantText};
   font-size: ${fontSizes.xl}px;
   font-weight: 600;
   line-height: normal;
@@ -396,7 +378,7 @@ const ModalContentContainerSwitch = ({
 }: {
   fullScreen: boolean | undefined;
   width: number | string;
-  children: ReactElement | ReactElement[];
+  children: React.ReactNode;
 }) => {
   if (fullScreen) {
     return (
@@ -432,230 +414,204 @@ interface Props {
   hideCloseButton?: boolean;
 }
 
-interface State {
-  windowWidth: number;
-  windowHeight: number;
-}
+const Modal: React.FC<Props> = ({
+  opened,
+  fixedHeight = false,
+  width = 650,
+  close,
+  className,
+  header,
+  niceHeader,
+  footer,
+  hasSkipButton,
+  skipText,
+  padding,
+  closeOnClickOutside = true,
+  children,
+  fullScreen,
+  zIndex,
+  hideCloseButton,
+}) => {
+  const [windowDimensions, setWindowDimensions] = useState({
+    windowWidth: window.innerWidth,
+    windowHeight: window.innerHeight,
+  });
 
-class Modal extends PureComponent<Props, State> {
-  subscription: Subscription | null;
+  const handleResize = useCallback((event: Event) => {
+    const target = event.target as Window;
+    setWindowDimensions({
+      windowWidth: target.innerWidth,
+      windowHeight: target.innerHeight,
+    });
+  }, []);
 
-  constructor(props: Props) {
-    super(props);
-    this.state = {
-      windowWidth: window.innerWidth,
-      windowHeight: window.innerHeight,
-    };
-    this.subscription = null;
-  }
+  const handlePopstateEvent = useCallback(() => {
+    close();
+  }, [close]);
 
-  componentDidMount() {
-    this.subscription = fromEvent(window, 'resize')
-      .pipe(debounceTime(50), distinctUntilChanged())
-      .subscribe((event) => {
-        if (event.target) {
-          const height = event.target['innerHeight'] as number;
-          const width = event.target['innerWidth'] as number;
-          this.setState({ windowWidth: width, windowHeight: height });
-        }
-      });
-  }
+  const handleKeypress = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.type === 'keydown' && event.key === 'Escape') {
+        event.preventDefault();
+        close();
+      }
+    },
+    [close]
+  );
 
-  componentDidUpdate(prevProps: Props) {
-    if (!prevProps.opened && this.props.opened) {
-      this.openModal();
-    } else if (prevProps.opened && !this.props.opened) {
-      this.cleanup();
-    }
-  }
-
-  componentWillUnmount() {
-    this.subscription?.unsubscribe();
-    this.cleanup();
-  }
-
-  openModal = () => {
-    window.addEventListener('popstate', this.handlePopstateEvent);
-    window.addEventListener('keydown', this.handleKeypress);
-    eventEmitter.emit('modalOpened');
-  };
-
-  closeModal = () => {
-    this.props.close();
-  };
-
-  handlePopstateEvent = () => {
-    this.closeModal();
-  };
-
-  handleKeypress = (event: KeyboardEvent) => {
-    if (event.type === 'keydown' && event.key === 'Escape') {
-      event.preventDefault();
-      this.closeModal();
-    }
-  };
-
-  cleanup = () => {
-    window.removeEventListener('popstate', this.handlePopstateEvent);
-    window.removeEventListener('keydown', this.handleKeypress);
+  const cleanup = useCallback(() => {
+    window.removeEventListener('popstate', handlePopstateEvent);
+    window.removeEventListener('keydown', handleKeypress);
     eventEmitter.emit('modalClosed');
-  };
+  }, [handlePopstateEvent, handleKeypress]);
 
-  clickOutsideModal = () => {
-    if (this.props.closeOnClickOutside !== false) {
+  useEffect(() => {
+    const subscription = fromEvent(window, 'resize')
+      .pipe(debounceTime(50), distinctUntilChanged())
+      .subscribe(handleResize);
+
+    if (opened) {
+      window.addEventListener('popstate', handlePopstateEvent);
+      window.addEventListener('keydown', handleKeypress);
+      eventEmitter.emit('modalOpened');
+    }
+
+    return () => {
+      subscription.unsubscribe();
+      cleanup();
+    };
+  }, [opened, handleResize, handlePopstateEvent, handleKeypress, cleanup]);
+
+  const clickOutsideModal = useCallback(() => {
+    if (closeOnClickOutside) {
       trackEventByName(tracks.clickOutsideModal);
-      this.closeModal();
+      close();
     }
-  };
+  }, [closeOnClickOutside, close]);
 
-  clickCloseButton = (event: React.MouseEvent<any>) => {
-    event.preventDefault();
-    event.stopPropagation();
-    trackEventByName(tracks.clickCloseButton);
-    this.closeModal();
-  };
+  const clickCloseButton = useCallback(
+    (event: React.MouseEvent<any>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      trackEventByName(tracks.clickCloseButton);
+      close();
+    },
+    [close]
+  );
 
-  render() {
-    const { windowHeight, windowWidth } = this.state;
-    const {
-      width = 650,
-      children,
-      opened,
-      header,
-      niceHeader,
-      footer,
-      hasSkipButton,
-      skipText,
-      fullScreen,
-      zIndex,
-      hideCloseButton,
-      fixedHeight = false,
-    } = this.props;
-    const smallerThanSmallTablet = windowWidth
-      ? windowWidth <= viewportWidths.tablet
-      : false;
-    let padding: string | undefined = undefined;
+  const { windowHeight, windowWidth } = windowDimensions;
+  const smallerThanSmallTablet = windowWidth <= viewportWidths.tablet;
+  let calculatedPadding = padding;
 
-    if (header !== undefined || footer !== undefined) {
-      padding = '0px';
-    } else if (this.props.padding) {
-      padding = this.props.padding;
-    }
-
-    if (width) {
-      return (
-        <CSSTransition
-          classNames="modal"
-          in={opened}
-          timeout={
-            smallerThanSmallTablet
-              ? mobileTransformTimeout
-              : desktopTransformTimeout
-          }
-          mountOnEnter={true}
-          unmountOnExit={true}
-          enter={true}
-          exit={false}
-        >
-          <Overlay
-            id="e2e-modal-container"
-            className={this.props.className}
-            fullScreen={fullScreen}
-            zIndex={zIndex}
-          >
-            <ModalContentContainerSwitch width={width} fullScreen={fullScreen}>
-              <ModalContainer
-                fullScreen={fullScreen}
-                className={`modalcontent ${fixedHeight ? 'fixedHeight' : ''}`}
-                onClickOutside={this.clickOutsideModal}
-                windowHeight={windowHeight}
-                ariaLabelledBy={header ? 'modal-header' : undefined}
-                aria-modal="true"
-                role="dialog"
-              >
-                {!niceHeader && (
-                  <>
-                    {!hideCloseButton && (
-                      <StyledCloseIconButton
-                        fullScreen={fullScreen}
-                        className="e2e-modal-close-button"
-                        onClick={this.clickCloseButton}
-                        iconColor={colors.textSecondary}
-                        iconColorOnHover={'#000'}
-                        a11y_buttonActionMessage={messages.closeWindow}
-                      />
-                    )}
-
-                    {header && (
-                      <HeaderContainer>
-                        <HeaderTitle id="modal-header">{header}</HeaderTitle>
-                      </HeaderContainer>
-                    )}
-                  </>
-                )}
-
-                {/* TODO: actually fix the header by always using the 'nice' header.
-                 * Didn't dare to do that yet because the modal with header is used
-                 * in so many different places, and I was scared of breaking something.
-                 * Made a task for this already: CL-2962
-                 * (Luuc)
-                 */}
-                {header && niceHeader && (
-                  <>
-                    <Box
-                      display="flex"
-                      flexDirection="row"
-                      alignItems="center"
-                      w="100%"
-                      py="8px"
-                      borderBottom={`solid 1px ${colors.divider}`}
-                    >
-                      <Box
-                        w="100%"
-                        h="100%"
-                        display="flex"
-                        alignItems="center"
-                        minHeight="66px"
-                      >
-                        {header}
-                      </Box>
-                    </Box>
-                    {!hideCloseButton && (
-                      <Box mr={smallerThanSmallTablet ? '0px' : '8px'}>
-                        <StyledCloseIconButton2
-                          className="e2e-modal-close-button"
-                          iconColor={colors.textSecondary}
-                          iconColorOnHover={colors.black}
-                          a11y_buttonActionMessage={messages.closeWindow}
-                          onClick={this.clickCloseButton}
-                        />
-                      </Box>
-                    )}
-                  </>
-                )}
-
-                <ModalContentContainer
-                  padding={padding}
-                  fullScreen={fullScreen}
-                >
-                  {children}
-                </ModalContentContainer>
-
-                {footer && <FooterContainer>{footer}</FooterContainer>}
-
-                {hasSkipButton && skipText && (
-                  <Skip onClick={this.clickCloseButton}>{skipText}</Skip>
-                )}
-              </ModalContainer>
-            </ModalContentContainerSwitch>
-          </Overlay>
-        </CSSTransition>
-      );
-    }
-
-    return null;
+  if (header !== undefined || footer !== undefined) {
+    calculatedPadding = '0px';
+  } else if (padding) {
+    calculatedPadding = padding;
   }
-}
+
+  return width ? (
+    <CSSTransition
+      classNames="modal"
+      in={opened}
+      timeout={
+        smallerThanSmallTablet
+          ? mobileTransformTimeout
+          : desktopTransformTimeout
+      }
+      mountOnEnter
+      unmountOnExit
+      enter
+      exit={false}
+    >
+      <Overlay
+        id="e2e-modal-container"
+        className={className}
+        fullScreen={fullScreen}
+        zIndex={zIndex}
+      >
+        <ModalContentContainerSwitch width={width} fullScreen={fullScreen}>
+          <ModalContainer
+            fullScreen={fullScreen}
+            className={`modalcontent ${fixedHeight ? 'fixedHeight' : ''}`}
+            onClickOutside={clickOutsideModal}
+            windowHeight={windowHeight}
+            ariaLabelledBy={header ? 'modal-header' : undefined}
+            aria-modal="true"
+            role="dialog"
+          >
+            {!niceHeader && (
+              <>
+                {!hideCloseButton && (
+                  <StyledCloseIconButton
+                    fullScreen={fullScreen}
+                    className="e2e-modal-close-button"
+                    onClick={clickCloseButton}
+                    iconColor={colors.textSecondary}
+                    iconColorOnHover="#000"
+                    a11y_buttonActionMessage={messages.closeWindow}
+                  />
+                )}
+
+                {header && (
+                  <HeaderContainer>
+                    <HeaderTitle id="modal-header">{header}</HeaderTitle>
+                  </HeaderContainer>
+                )}
+              </>
+            )}
+
+            {header && niceHeader && (
+              <>
+                <Box
+                  display="flex"
+                  flexDirection="row"
+                  alignItems="center"
+                  w="100%"
+                  py="8px"
+                  borderBottom={`solid 1px ${colors.divider}`}
+                >
+                  <Box
+                    w="100%"
+                    h="100%"
+                    display="flex"
+                    alignItems="center"
+                    minHeight="66px"
+                  >
+                    {header}
+                  </Box>
+                </Box>
+                {!hideCloseButton && (
+                  <Box mr={smallerThanSmallTablet ? '0px' : '8px'}>
+                    <StyledCloseIconButton2
+                      className="e2e-modal-close-button"
+                      iconColor={colors.textSecondary}
+                      iconColorOnHover={colors.black}
+                      a11y_buttonActionMessage={messages.closeWindow}
+                      onClick={clickCloseButton}
+                    />
+                  </Box>
+                )}
+              </>
+            )}
+
+            <ModalContentContainer
+              padding={calculatedPadding}
+              fullScreen={fullScreen}
+            >
+              {children}
+            </ModalContentContainer>
+
+            {footer && <FooterContainer>{footer}</FooterContainer>}
+
+            {hasSkipButton && skipText && (
+              <Skip onClick={clickCloseButton}>{skipText}</Skip>
+            )}
+          </ModalContainer>
+        </ModalContentContainerSwitch>
+      </Overlay>
+    </CSSTransition>
+  ) : null;
+};
 
 export default (props: Props) => {
   const modalPortalElement = document.getElementById('modal-portal');

--- a/front/app/components/UI/Modal/index.tsx
+++ b/front/app/components/UI/Modal/index.tsx
@@ -412,6 +412,12 @@ interface Props {
   fullScreen?: boolean;
   zIndex?: number;
   hideCloseButton?: boolean;
+  /**
+   * Optional ref to return focus on close.
+   * By default, focus returns to the control that opened the modal.
+   * Use this ref if you want to return focus to another ref.
+   */
+  returnFocusRef?: React.RefObject<HTMLElement>;
 }
 
 const Modal: React.FC<Props> = ({
@@ -431,6 +437,7 @@ const Modal: React.FC<Props> = ({
   fullScreen,
   zIndex,
   hideCloseButton,
+  returnFocusRef,
 }) => {
   const [windowDimensions, setWindowDimensions] = useState({
     windowWidth: window.innerWidth,
@@ -464,6 +471,23 @@ const Modal: React.FC<Props> = ({
     window.removeEventListener('keydown', handleKeypress);
     eventEmitter.emit('modalClosed');
   }, [handlePopstateEvent, handleKeypress]);
+
+  useEffect(() => {
+    let timeoutId: number | undefined;
+
+    if (!opened && returnFocusRef?.current) {
+      timeoutId = window.setTimeout(() => {
+        returnFocusRef.current?.focus();
+      }, 0);
+    }
+
+    // Cleanup function to clear the timeout on unmount
+    return () => {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
+    };
+  }, [opened, returnFocusRef]);
 
   useEffect(() => {
     const subscription = fromEvent(window, 'resize')

--- a/front/app/components/UI/MoreActionsMenu/index.tsx
+++ b/front/app/components/UI/MoreActionsMenu/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, forwardRef } from 'react';
 
 import {
   Box,
@@ -119,104 +119,106 @@ export interface Props {
   onClick?: (event: React.MouseEvent) => void;
 }
 
-const MoreActionsMenu = (props: Props) => {
-  const {
-    actions,
-    showLabel = true,
-    color,
-    labelAndTitle = <FormattedMessage {...messages.showMoreActions} />,
-    className,
-    id,
-    onClick,
-  } = props;
-  const [visible, setVisible] = useState(false);
+const MoreActionsMenu = forwardRef<HTMLButtonElement, Props>(
+  (props, moreActionsButtonRef) => {
+    const {
+      actions,
+      showLabel = true,
+      color,
+      labelAndTitle = <FormattedMessage {...messages.showMoreActions} />,
+      className,
+      id,
+      onClick,
+    } = props;
+    const [visible, setVisible] = useState(false);
 
-  const hide = () => {
-    setVisible(false);
-  };
-
-  const toggleMenu = (event: React.MouseEvent) => {
-    onClick && onClick(event);
-    event.preventDefault();
-    setVisible((current) => !current);
-  };
-
-  const handleListItemOnClick =
-    (handler: (event: React.MouseEvent) => Promise<any> | void) =>
-    async (event: React.MouseEvent) => {
-      event.preventDefault();
-      await handler(event);
-      hide();
+    const hide = () => {
+      setVisible(false);
     };
 
-  if (actions.length === 0) {
-    return <Box width="25px" />; // to keep other elements in the row in the same place as when there is actions menu
-  }
+    const toggleMenu = (event: React.MouseEvent) => {
+      onClick && onClick(event);
+      event.preventDefault();
+      setVisible((current) => !current);
+    };
 
-  return (
-    <Container className={className || ''}>
-      <Tippy
-        placement="bottom"
-        interactive={true}
-        duration={[200, 0]}
-        visible={visible}
-        onClickOutside={hide}
-        content={
-          <List className="e2e-more-actions-list">
-            {actions.map((action, index) => {
-              const { handler, label, icon, name, isLoading } = action;
+    const handleListItemOnClick =
+      (handler: (event: React.MouseEvent) => Promise<any> | void) =>
+      async (event: React.MouseEvent) => {
+        event.preventDefault();
+        await handler(event);
+        hide();
+      };
 
-              return (
-                <ListItem
-                  key={index}
-                  onMouseDown={removeFocusAfterMouseClick}
-                  onClick={handleListItemOnClick(handler)}
-                  className={name ? `e2e-action-${name}` : undefined}
-                >
-                  {label}
-                  {icon && !isLoading && (
-                    <Box
-                      width="20px"
-                      height="20px"
-                      display="flex"
-                      alignItems="center"
-                      ml="12px"
-                    >
-                      <Icon name={icon} fill="white" />
-                    </Box>
-                  )}
-                  {isLoading && (
-                    <Box ml="12px">
-                      <Spinner color="white" size="20px" />
-                    </Box>
-                  )}
-                </ListItem>
-              );
-            })}
-          </List>
-        }
-      >
-        <MoreOptionsButton
-          onMouseDown={removeFocusAfterMouseClick}
-          onClick={toggleMenu}
-          aria-expanded={visible}
-          id={id}
-          data-cy={props['data-cy']}
-          className="e2e-more-actions"
-          data-testid="moreOptionsButton"
+    if (actions.length === 0) {
+      return <Box width="25px" />; // to keep other elements in the row in the same place as when there is actions menu
+    }
+
+    return (
+      <Container className={className || ''}>
+        <Tippy
+          placement="bottom"
+          interactive={true}
+          duration={[200, 0]}
+          visible={visible}
+          onClickOutside={hide}
+          content={
+            <List className="e2e-more-actions-list">
+              {actions.map((action, index) => {
+                const { handler, label, icon, name, isLoading } = action;
+
+                return (
+                  <ListItem
+                    key={index}
+                    onMouseDown={removeFocusAfterMouseClick}
+                    onClick={handleListItemOnClick(handler)}
+                    className={name ? `e2e-action-${name}` : undefined}
+                  >
+                    {label}
+                    {icon && !isLoading && (
+                      <Box
+                        width="20px"
+                        height="20px"
+                        display="flex"
+                        alignItems="center"
+                        ml="12px"
+                      >
+                        <Icon name={icon} fill="white" />
+                      </Box>
+                    )}
+                    {isLoading && (
+                      <Box ml="12px">
+                        <Spinner color="white" size="20px" />
+                      </Box>
+                    )}
+                  </ListItem>
+                );
+              })}
+            </List>
+          }
         >
-          <MoreOptionsIcon
-            title={labelAndTitle}
-            name="dots-horizontal"
-            color={color}
-            ariaHidden={!showLabel}
-            aria-labelledby={labelAndTitle}
-          />
-          {showLabel && <MoreOptionsLabel>{labelAndTitle}</MoreOptionsLabel>}
-        </MoreOptionsButton>
-      </Tippy>
-    </Container>
-  );
-};
+          <MoreOptionsButton
+            ref={moreActionsButtonRef}
+            onMouseDown={removeFocusAfterMouseClick}
+            onClick={toggleMenu}
+            aria-expanded={visible}
+            id={id}
+            data-cy={props['data-cy']}
+            className="e2e-more-actions"
+            data-testid="moreOptionsButton"
+          >
+            <MoreOptionsIcon
+              title={labelAndTitle}
+              name="dots-horizontal"
+              color={color}
+              ariaHidden={!showLabel}
+            />
+            {showLabel && <MoreOptionsLabel>{labelAndTitle}</MoreOptionsLabel>}
+          </MoreOptionsButton>
+        </Tippy>
+      </Container>
+    );
+  }
+);
 
 export default MoreActionsMenu;

--- a/front/app/components/WarningModal/index.tsx
+++ b/front/app/components/WarningModal/index.tsx
@@ -22,6 +22,12 @@ interface Props {
   explanation?: React.ReactNode;
   onClose: () => void;
   onConfirm: () => void;
+  /**
+   * Optional ref to return focus on close.
+   * By default, focus returns to the control that opened the modal.
+   * Use this ref if you want to return focus to another ref.
+   */
+  returnFocusRef?: React.RefObject<HTMLElement>;
 }
 
 const WarningModal = ({
@@ -31,9 +37,15 @@ const WarningModal = ({
   explanation,
   onClose,
   onConfirm,
+  returnFocusRef,
 }: Props) => {
   return (
-    <Modal width="460px" opened={open} close={onClose}>
+    <Modal
+      width="460px"
+      opened={open}
+      close={onClose}
+      returnFocusRef={returnFocusRef}
+    >
       <Box
         display="flex"
         height="64px"

--- a/front/app/components/admin/InternalComments/InternalComment/InternalCommentsMoreActions.tsx
+++ b/front/app/components/admin/InternalComments/InternalComment/InternalCommentsMoreActions.tsx
@@ -1,4 +1,4 @@
-import React, { FormEvent, useState } from 'react';
+import React, { FormEvent, useState, useRef } from 'react';
 
 import { isRtl } from '@citizenlab/cl2-component-library';
 import styled from 'styled-components';
@@ -65,6 +65,7 @@ const InternalCommentsMoreActions = ({
   ideaId,
   initiativeId,
 }: Props) => {
+  const moreActionsButtonRef = useRef<HTMLButtonElement>(null);
   const parentCommentId = comment.relationships?.parent?.data?.id;
   const { data: authUser } = useAuthUser();
   const { mutate: markForDeletion, isLoading } =
@@ -135,6 +136,7 @@ const InternalCommentsMoreActions = ({
           showLabel={false}
           actions={actions}
           data-cy="e2e-internal-comments-more-actions"
+          ref={moreActionsButtonRef}
         />
       </Container>
 
@@ -142,6 +144,7 @@ const InternalCommentsMoreActions = ({
         opened={modalVisible_delete}
         close={closeDeleteModal}
         className="e2e-comment-deletion-modal"
+        returnFocusRef={moreActionsButtonRef}
         header={
           <FormattedMessage {...commentsMessages.confirmCommentDeletion} />
         }

--- a/front/app/components/admin/SeatBasedBilling/ChangeSeatModal/index.tsx
+++ b/front/app/components/admin/SeatBasedBilling/ChangeSeatModal/index.tsx
@@ -56,6 +56,12 @@ interface Props {
   isChangingToNormalUser: boolean;
   closeModal: () => void;
   changeRoles: (user: IUserData, changeToNormalUser: boolean) => void;
+  /**
+   * Optional ref to return focus on close.
+   * By default, focus returns to the control that opened the modal.
+   * Use this ref if you want to return focus to another ref.
+   */
+  returnFocusRef?: React.RefObject<HTMLElement>;
 }
 
 const ChangeSeatModal = ({
@@ -64,6 +70,7 @@ const ChangeSeatModal = ({
   userToChangeSeat,
   changeRoles,
   isChangingToNormalUser,
+  returnFocusRef,
 }: Props) => {
   const [showSuccess, setShowSuccess] = useState(false);
   const isUserToChangeSeatAdmin = isAdmin({ data: userToChangeSeat });
@@ -107,7 +114,12 @@ const ChangeSeatModal = ({
   };
 
   return (
-    <Modal opened={showModal} close={resetModal} header={header}>
+    <Modal
+      opened={showModal}
+      close={resetModal}
+      header={header}
+      returnFocusRef={returnFocusRef}
+    >
       {showSuccess ? (
         <SeatSetSuccess
           closeModal={resetModal}

--- a/front/app/components/admin/UserBlockModals/BlockUser.tsx
+++ b/front/app/components/admin/UserBlockModals/BlockUser.tsx
@@ -31,13 +31,19 @@ type Props = {
   open: boolean;
   setClose: () => void;
   user: IUserData;
+  /**
+   * Optional ref to return focus on close.
+   * By default, focus returns to the control that opened the modal.
+   * Use this ref if you want to return focus to another ref.
+   */
+  returnFocusRef?: React.RefObject<HTMLElement>;
 };
 
 type FormValues = {
   reason: string;
 };
 
-const BlockUserModal = ({ open, setClose, user }: Props) => {
+const BlockUserModal = ({ open, setClose, user, returnFocusRef }: Props) => {
   const [success, setSuccess] = useState(false);
   const [updatedUser, setUpdatedUser] = useState<IUserData | undefined>();
   const { data: appConfiguration } = useAppConfiguration();
@@ -95,6 +101,7 @@ const BlockUserModal = ({ open, setClose, user }: Props) => {
       close={setClose}
       opened={open}
       header={formatMessage(messages.header)}
+      returnFocusRef={returnFocusRef}
     >
       <Box p="30px">
         <FormProvider {...methods}>

--- a/front/app/components/admin/UserBlockModals/UnblockUser.tsx
+++ b/front/app/components/admin/UserBlockModals/UnblockUser.tsx
@@ -16,9 +16,15 @@ type Props = {
   open: boolean;
   setClose: () => void;
   user: IUserData;
+  /**
+   * Optional ref to return focus on close.
+   * By default, focus returns to the control that opened the modal.
+   * Use this ref if you want to return focus to another ref.
+   */
+  returnFocusRef?: React.RefObject<HTMLElement>;
 };
 
-export default ({ open, setClose, user }: Props) => {
+const UnblockUserModal = ({ open, setClose, user, returnFocusRef }: Props) => {
   const { formatMessage } = useIntl();
   const { mutate: unBlockUser } = useUnblockUser();
 
@@ -30,7 +36,12 @@ export default ({ open, setClose, user }: Props) => {
     });
   };
   return (
-    <Modal width={400} close={setClose} opened={open}>
+    <Modal
+      width={400}
+      close={setClose}
+      opened={open}
+      returnFocusRef={returnFocusRef}
+    >
       <Title variant="h3" m="35px 0 30px">
         {formatMessage(messages.confirmUnblock, {
           name: getFullName(user),
@@ -45,3 +56,5 @@ export default ({ open, setClose, user }: Props) => {
     </Modal>
   );
 };
+
+export default UnblockUserModal;

--- a/front/app/containers/Admin/users/UserTableRow.tsx
+++ b/front/app/containers/Admin/users/UserTableRow.tsx
@@ -1,4 +1,4 @@
-import React, { useState, lazy, Suspense } from 'react';
+import React, { useState, lazy, Suspense, useRef } from 'react';
 
 import {
   Tr,
@@ -87,6 +87,7 @@ const UserTableRow = ({
   changeRoles,
   authUser,
 }: Props) => {
+  const moreActionsButtonRef = useRef<HTMLButtonElement>(null);
   const [isAssignedItemsOpened, setIsAssignedItemsOpened] = useState(false);
   const [
     isSetSetAsProjectModeratorOpened,
@@ -315,6 +316,7 @@ const UserTableRow = ({
         <Td>
           <MoreActionsMenu
             showLabel={false}
+            ref={moreActionsButtonRef}
             actions={
               userInRowHasRegistered
                 ? [
@@ -331,11 +333,13 @@ const UserTableRow = ({
           user={userInRow}
           setClose={() => setShowBlockUserModal(false)}
           open={showBlockUserModal}
+          returnFocusRef={moreActionsButtonRef}
         />
         <UnblockUser
           user={userInRow}
           setClose={() => setShowUnblockUserModal(false)}
           open={showUnblockUserModal}
+          returnFocusRef={moreActionsButtonRef}
         />
         <Suspense fallback={null}>
           <ChangeSeatModal
@@ -344,17 +348,22 @@ const UserTableRow = ({
             showModal={showChangeSeatModal}
             closeModal={closeChangeSeatModal}
             isChangingToNormalUser={isChangingToNormalUser}
+            returnFocusRef={moreActionsButtonRef}
           />
         </Suspense>
         <Modal
           opened={isAssignedItemsOpened}
           close={() => setIsAssignedItemsOpened(false)}
+          // Return focus to the More Actions button on close
+          returnFocusRef={moreActionsButtonRef}
         >
           <UserAssignedItems user={userInRow} />
         </Modal>
         <Modal
           opened={isSetSetAsProjectModeratorOpened}
           close={() => setIsSetSetAsProjectModeratorOpened(false)}
+          // Return focus to the More Actions button on close
+          returnFocusRef={moreActionsButtonRef}
         >
           <SetSetAsProjectModerator
             user={userInRow}

--- a/front/app/containers/IdeasShow/components/IdeaMoreActions.tsx
+++ b/front/app/containers/IdeasShow/components/IdeaMoreActions.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useState } from 'react';
+import React, { memo, useState, useRef } from 'react';
 
 import styled from 'styled-components';
 
@@ -44,6 +44,8 @@ const IdeaMoreActions = memo(({ idea, className, projectId }: Props) => {
 
   const openWarningModal = () => setWarningModalOpen(true);
   const closeWarningModal = () => setWarningModalOpen(false);
+
+  const moreActionsButtonRef = useRef<HTMLButtonElement>(null);
 
   const { data: authUser } = useAuthUser();
   const { data: project } = useProjectById(projectId);
@@ -113,12 +115,15 @@ const IdeaMoreActions = memo(({ idea, className, projectId }: Props) => {
               labelAndTitle={<FormattedMessage {...messages.moreOptions} />}
               showLabel={false}
               actions={actions}
+              ref={moreActionsButtonRef}
             />
           </MoreActionsMenuWrapper>
           <Modal
             opened={isSpamModalVisible}
             close={closeSpamModal}
             header={<FormattedMessage {...messages.reportAsSpamModalTitle} />}
+            // Return focus to the More Actions button on close
+            returnFocusRef={moreActionsButtonRef}
           >
             <SpamReportForm targetId={idea.id} targetType="ideas" />
           </Modal>

--- a/front/app/containers/IdeasShow/components/IdeaMoreActions.tsx
+++ b/front/app/containers/IdeasShow/components/IdeaMoreActions.tsx
@@ -135,6 +135,7 @@ const IdeaMoreActions = memo(({ idea, className, projectId }: Props) => {
           explanation={formatMessage(warningMessages.deleteInputExplanation)}
           onClose={closeWarningModal}
           onConfirm={onDeleteIdea}
+          returnFocusRef={moreActionsButtonRef}
         />
       </>
     );

--- a/front/app/containers/InitiativesShow/ActionBar/InitiativeMoreActions.tsx
+++ b/front/app/containers/InitiativesShow/ActionBar/InitiativeMoreActions.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 
 import styled from 'styled-components';
 
@@ -35,6 +35,7 @@ interface Props {
 
 const InitiativeMoreActions = ({ initiative, className, color, id }: Props) => {
   const { formatMessage } = useIntl();
+  const moreActionsButtonRef = useRef<HTMLButtonElement>(null);
   const canEditInitiative = usePermission({
     action: 'edit',
     item: initiative,
@@ -87,6 +88,7 @@ const InitiativeMoreActions = ({ initiative, className, color, id }: Props) => {
             labelAndTitle={<FormattedMessage {...messages.moreOptions} />}
             color={color}
             id={id}
+            ref={moreActionsButtonRef}
             actions={[
               {
                 label: <FormattedMessage {...messages.reportAsSpam} />,
@@ -113,6 +115,8 @@ const InitiativeMoreActions = ({ initiative, className, color, id }: Props) => {
           opened={spamModalVisible}
           close={closeSpamModal}
           header={<FormattedMessage {...messages.reportAsSpamModalTitle} />}
+          // Return focus to the More Actions button on close
+          returnFocusRef={moreActionsButtonRef}
         >
           <SpamReportForm targetId={initiative.id} targetType="initiatives" />
         </Modal>
@@ -124,6 +128,7 @@ const InitiativeMoreActions = ({ initiative, className, color, id }: Props) => {
         explanation={formatMessage(warningMessages.deleteInitiativeExplanation)}
         onClose={closeWarningModal}
         onConfirm={onDeleteInitiative}
+        returnFocusRef={moreActionsButtonRef}
       />
     </>
   );


### PR DESCRIPTION
The modal automatically returns focus to the element that opened it. I have added ability to move that focus to a specified ref. For the more actions button, we need to handle cases differently

# Changelog

## Fixed
- a11y: When a Modal is opened by an action in the more actions options, we now return focus to the three dots that opened the options

## Technical
- a11y: Add ability for Modal to return focus to optional ref
