### PR TITLE
TAN-1995 - Fixed float values in survey answers

### DIFF
--- a/back/app/services/survey_results_generator_service.rb
+++ b/back/app/services/survey_results_generator_service.rb
@@ -188,7 +188,7 @@ class SurveyResultsGeneratorService < FieldVisitorService
     inputs
       .select("custom_field_values->'#{field_key}' as value")
       .where("custom_field_values->'#{field_key}' IS NOT NULL")
-      .map { |answer| { answer: answer.value } }
+      .map { |answer| { answer: answer.value.to_s } }
       .sort_by { |a| a[:answer] }
   end
 

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/parsers/idea_base_file_parser.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/parsers/idea_base_file_parser.rb
@@ -178,6 +178,8 @@ module BulkImportIdeas::Parsers
         end
       elsif %w[number linear_scale].include?(field[:input_type]) && field[:value].present?
         field[:value] = field[:value].to_i
+      else
+        field[:value] = field[:value].to_s
       end
 
       field

--- a/back/engines/commercial/bulk_import_ideas/spec/services/parsers/idea_xlsx_file_parser_spec.rb
+++ b/back/engines/commercial/bulk_import_ideas/spec/services/parsers/idea_xlsx_file_parser_spec.rb
@@ -215,7 +215,7 @@ describe BulkImportIdeas::Parsers::IdeaXlsxFileParser do
     it 'text fields return text values if xlsx values are integers or floats' do
       xlsx_ideas_array = [
         { pdf_pages: [1], fields: { 'Text field' => 2 } },
-        { pdf_pages: [1], fields: { 'Text field' => 2.2 } },
+        { pdf_pages: [1], fields: { 'Text field' => 2.2 } }
       ]
       idea_rows = service.send(:ideas_to_idea_rows, xlsx_ideas_array, import_file)
       expect(idea_rows.count).to eq 2

--- a/back/engines/commercial/bulk_import_ideas/spec/services/parsers/idea_xlsx_file_parser_spec.rb
+++ b/back/engines/commercial/bulk_import_ideas/spec/services/parsers/idea_xlsx_file_parser_spec.rb
@@ -211,5 +211,16 @@ describe BulkImportIdeas::Parsers::IdeaXlsxFileParser do
       expect(idea_rows.count).to eq 1
       expect(idea_rows[0][:custom_field_values][:select_integer]).to eq '2'
     end
+
+    it 'text fields return text values if xlsx values are integers or floats' do
+      xlsx_ideas_array = [
+        { pdf_pages: [1], fields: { 'Text field' => 2 } },
+        { pdf_pages: [1], fields: { 'Text field' => 2.2 } },
+      ]
+      idea_rows = service.send(:ideas_to_idea_rows, xlsx_ideas_array, import_file)
+      expect(idea_rows.count).to eq 2
+      expect(idea_rows[0][:custom_field_values][:text_field]).to eq '2'
+      expect(idea_rows[1][:custom_field_values][:text_field]).to eq '2.2'
+    end
   end
 end


### PR DESCRIPTION
Bit of a 'belt and braces' fix - firstly ensuring the import imports as a string and secondly ensuring it's output as a string.

# Changelog
## Fixed
- TAN-1995 - Fix for survey results when float values (eg 1.1) have been entered as text values 
