### PR TITLE
TAN-1949 Complete your profile issues

### DIFF
--- a/front/app/component-library/components/Select/index.tsx
+++ b/front/app/component-library/components/Select/index.tsx
@@ -197,6 +197,25 @@ class Select extends PureComponent<Props> {
             <option
               value={DEFAULT_VALUE}
               aria-selected={selectedValue === DEFAULT_VALUE}
+              // The `canBeEmpty` prop adds an 'empty' option to the select,
+              // which doesn't work very well because you can't actually select
+              // it.
+              // For this reason, usually we implement this 'empty option'
+              // in a different way, see e.g. components/UI/ProjectFilter.
+
+              // At the moment, the canBeEmpty prop is not used a lot-
+              // it's only used in the JSON form select controls
+              // (SingleSelectControl and SingleSelectEnumControl)
+              // It's NOT recommended to use it.
+              // In the two cases above, it's used because otherwise
+              // the select cannot be used with keyboard navigation
+              // in Firefox, in some cases, for some unknown reason.
+              // It's very likely this keyboard navigation is broken
+              // in other places, but at the moment of writing
+              // we don't have time to fix it everywhere else.
+              //
+              // In the future we really need to refactor this component
+              // and fix this situation, so that it works properly.
               hidden={!canBeEmpty}
               disabled={!canBeEmpty}
             />

--- a/front/app/component-library/components/Select/index.tsx
+++ b/front/app/component-library/components/Select/index.tsx
@@ -99,8 +99,8 @@ export interface Props extends DefaultProps {
   placeholder?: string;
 }
 
-const defaultValue = 'DEFAULT_SELECT_VALUE';
-const placeholderValue = 'PLACEHOLDER_SELECT_VALUE';
+const DEFAULT_VALUE = 'DEFAULT_SELECT_VALUE';
+const PLACEHOLDER_VALUE = 'PLACEHOLDER_SELECT_VALUE';
 
 const getSelectedValue = (
   options: IOption[] | null,
@@ -112,7 +112,7 @@ const getSelectedValue = (
   )?.value;
   if (selectedValue) return selectedValue;
 
-  return placeholder !== undefined ? placeholderValue : defaultValue;
+  return placeholder !== undefined ? PLACEHOLDER_VALUE : DEFAULT_VALUE;
 };
 
 class Select extends PureComponent<Props> {
@@ -148,12 +148,13 @@ class Select extends PureComponent<Props> {
       value,
       placeholder,
     } = this.props;
+
     const safeValue =
       isString(value) || isNumber(value) ? value : get(value, 'value', null);
 
     const selectedValue = getSelectedValue(options, safeValue, placeholder);
 
-    const showPlaceholder = selectedValue === placeholderValue;
+    const showPlaceholder = selectedValue === PLACEHOLDER_VALUE;
 
     return (
       <Container
@@ -184,7 +185,7 @@ class Select extends PureComponent<Props> {
           >
             {placeholder !== undefined && (
               <option
-                value={placeholderValue}
+                value={PLACEHOLDER_VALUE}
                 aria-selected={showPlaceholder}
                 hidden
                 disabled
@@ -194,8 +195,8 @@ class Select extends PureComponent<Props> {
             )}
 
             <option
-              value={defaultValue}
-              aria-selected={selectedValue === defaultValue}
+              value={DEFAULT_VALUE}
+              aria-selected={selectedValue === DEFAULT_VALUE}
               hidden={!canBeEmpty}
               disabled={!canBeEmpty}
             />

--- a/front/app/components/Form/Components/Controls/SingleSelectControl.tsx
+++ b/front/app/components/Form/Components/Controls/SingleSelectControl.tsx
@@ -61,7 +61,7 @@ const SingleSelectControl = ({
           key={sanitizeForClassname(id)}
           id={sanitizeForClassname(id)}
           aria-label={getLabel(uischema, schema, path)}
-          canBeEmpty
+          canBeEmpty // see Select component for more info
           disabled={uischema?.options?.readonly}
         />
         <VerificationIcon show={uischema?.options?.verificationLocked} />

--- a/front/app/components/Form/Components/Controls/SingleSelectControl.tsx
+++ b/front/app/components/Form/Components/Controls/SingleSelectControl.tsx
@@ -24,7 +24,6 @@ const StyledSelect = styled(Select)`
 `;
 
 const SingleSelectControl = ({
-  data,
   handleChange,
   path,
   errors,
@@ -52,10 +51,6 @@ const SingleSelectControl = ({
       />
       <Box display="flex" flexDirection="row">
         <StyledSelect
-          value={{
-            value: data,
-            label: 'any',
-          }} /* sad workaround waiting for PR in component library */
           options={options as IOption[]}
           onChange={(val) => {
             setDidBlur(true);
@@ -64,7 +59,7 @@ const SingleSelectControl = ({
           key={sanitizeForClassname(id)}
           id={sanitizeForClassname(id)}
           aria-label={getLabel(uischema, schema, path)}
-          canBeEmpty={!required}
+          canBeEmpty={true}
           disabled={uischema?.options?.readonly}
         />
         <VerificationIcon show={uischema?.options?.verificationLocked} />

--- a/front/app/components/Form/Components/Controls/SingleSelectControl.tsx
+++ b/front/app/components/Form/Components/Controls/SingleSelectControl.tsx
@@ -24,6 +24,7 @@ const StyledSelect = styled(Select)`
 `;
 
 const SingleSelectControl = ({
+  data,
   handleChange,
   path,
   errors,
@@ -51,6 +52,7 @@ const SingleSelectControl = ({
       />
       <Box display="flex" flexDirection="row">
         <StyledSelect
+          value={data}
           options={options as IOption[]}
           onChange={(val) => {
             setDidBlur(true);
@@ -59,7 +61,7 @@ const SingleSelectControl = ({
           key={sanitizeForClassname(id)}
           id={sanitizeForClassname(id)}
           aria-label={getLabel(uischema, schema, path)}
-          canBeEmpty={true}
+          canBeEmpty
           disabled={uischema?.options?.readonly}
         />
         <VerificationIcon show={uischema?.options?.verificationLocked} />

--- a/front/app/components/Form/Components/Controls/SingleSelectEnumControl.tsx
+++ b/front/app/components/Form/Components/Controls/SingleSelectEnumControl.tsx
@@ -24,7 +24,6 @@ const StyledSelect = styled(Select)`
 `;
 
 const SingleSelectEnumControl = ({
-  data,
   handleChange,
   path,
   errors,
@@ -52,10 +51,6 @@ const SingleSelectEnumControl = ({
       />
       <Box display="flex" flexDirection="row">
         <StyledSelect
-          value={{
-            value: data,
-            label: 'any',
-          }} /* sad workaround waiting for PR in component library */
           options={options as IOption[]}
           onChange={(val) => {
             setDidBlur(true);
@@ -64,7 +59,7 @@ const SingleSelectEnumControl = ({
           key={sanitizeForClassname(id)}
           id={sanitizeForClassname(id)}
           aria-label={getLabel(uischema, schema, path)}
-          canBeEmpty={!required}
+          canBeEmpty={true}
           disabled={uischema?.options?.readonly}
         />
         <VerificationIcon show={uischema?.options?.verificationLocked} />

--- a/front/app/components/Form/Components/Controls/SingleSelectEnumControl.tsx
+++ b/front/app/components/Form/Components/Controls/SingleSelectEnumControl.tsx
@@ -24,6 +24,7 @@ const StyledSelect = styled(Select)`
 `;
 
 const SingleSelectEnumControl = ({
+  data,
   handleChange,
   path,
   errors,
@@ -51,6 +52,7 @@ const SingleSelectEnumControl = ({
       />
       <Box display="flex" flexDirection="row">
         <StyledSelect
+          value={data}
           options={options as IOption[]}
           onChange={(val) => {
             setDidBlur(true);
@@ -59,7 +61,7 @@ const SingleSelectEnumControl = ({
           key={sanitizeForClassname(id)}
           id={sanitizeForClassname(id)}
           aria-label={getLabel(uischema, schema, path)}
-          canBeEmpty={true}
+          canBeEmpty
           disabled={uischema?.options?.readonly}
         />
         <VerificationIcon show={uischema?.options?.verificationLocked} />

--- a/front/app/components/Form/Components/Controls/SingleSelectEnumControl.tsx
+++ b/front/app/components/Form/Components/Controls/SingleSelectEnumControl.tsx
@@ -61,7 +61,7 @@ const SingleSelectEnumControl = ({
           key={sanitizeForClassname(id)}
           id={sanitizeForClassname(id)}
           aria-label={getLabel(uischema, schema, path)}
-          canBeEmpty
+          canBeEmpty // see Select component for more info
           disabled={uischema?.options?.readonly}
         />
         <VerificationIcon show={uischema?.options?.verificationLocked} />


### PR DESCRIPTION
To be honest, I don't really know why this works, and it's also a dodgy solution because for some reason you still cannot select the 'empty' option. But at least the keyboard navigation now works well in Firefox for any `Select` rendered inside of a JSON form. 

A proper solution would be to rewrite this ancient mess of a `Select` component, but since it's used in so many places it will be a lot of work.

# Changelog
## Fixed
- Select a11y issue in Firefox for json form select fields 
