### PR TITLE
TAN-1971 Periodic activities aborted

### DIFF
--- a/back/app/services/activities_service.rb
+++ b/back/app/services/activities_service.rb
@@ -32,11 +32,6 @@ class ActivitiesService
       .select(:item_id)
 
     starting_phases.where.not(id: excluded_phases).each do |phase|
-      if phase.ends_before?(now + 1.day)
-        raise "Invalid phase started event would have been generated for phase\
-               #{phase.id} with now=#{now} and last_time=#{last_time}"
-      end
-
       LogActivityJob.perform_later(phase, 'started', nil, start_date.to_time)
     end
   end


### PR DESCRIPTION
The assertion never detected any real bugs, and is now going of on 1-day phases. This aborts the generation of the other periodic activities. I propose to just remove the code.

# Changelog
### Fixed
- [TAN-1971] Periodic activities (phase started emails, timestamp shifting etc.) would get aborted when a 1-day phase (same start and end date) would start.
