### PR TITLE
[TAN-2052] Fix project copy service

### DIFF
--- a/back/app/services/anonymize_user_service.rb
+++ b/back/app/services/anonymize_user_service.rb
@@ -1,52 +1,9 @@
 # frozen_string_literal: true
 
+# This service is invoked by cl2-admin/lib/admin_api.rb#project_template_export and it seems we need to require CSV.
+require 'csv'
+
 class AnonymizeUserService
-  # Commented out so we can restore later. Feel free to delete if
-  # this is still here after May 2022.
-
-  # MALE_AVATAR_URLS = [
-  #   'https://cl2-seed-and-template-assets.s3.eu-central-1.amazonaws.com/images/avatars/avatar01_male.jpeg',
-  #   'https://cl2-seed-and-template-assets.s3.eu-central-1.amazonaws.com/images/avatars/avatar26_male.jpeg',
-  #   'https://cl2-tenant-template-content.s3.amazonaws.com/fr2_tenant_template/user/avatar/7ca644b8-4ebf-4e74-a266-c8f9f945fc28/profile-1474295964-7c5694e2fc409f9ba430e094fee7f906.jpg',
-  #   'https://cl2-tenant-template-content.s3.amazonaws.com/fr2_tenant_template/user/avatar/7937ab55-2985-4d6e-a4ab-db25d605ef72/66c297f1dcd085d2304f63c5ed612c0a--beauty-portrait-male-portraits.jpg',
-  #   'https://cl2-tenant-template-content.s3.amazonaws.com/fr2_tenant_template/user/avatar/84184598-6aac-408a-a49b-26ec0176a94b/49cd4c44d562e92d90a3a4c81ced02dc.jpg',
-  #   'https://cl2-tenant-template-content.s3.amazonaws.com/fr2_tenant_template/user/avatar/f34ad5d9-c337-4f12-a084-9027ee484cb6/16992834140_99815ee4ac_m.jpg',
-  #   'https://cl2-tenant-template-content.s3.amazonaws.com/fr2_tenant_template/user/avatar/d6684b22-b759-4e3e-8793-5029ff27ba25/bryan_cranston_0095.jpg',
-  #   'https://cl2-tenant-template-content.s3.amazonaws.com/fr2_tenant_template/user/avatar/90095a74-7993-4bff-b47f-154faf3efebe/dof2.jpg',
-  #   'https://cl2-tenant-template-content.s3.amazonaws.com/fr2_tenant_template/user/avatar/fc984a52-9e03-4407-a87c-75c956535a99/51DLRByNOXL._UX250_.jpg',
-  #   'https://cl2-tenant-template-content.s3.amazonaws.com/fr2_tenant_template/user/avatar/e4a62fcc-498f-49d5-a374-f625a3075659/461482218-594x367.jpg',
-  #   'https://cl2-tenant-template-content.s3.amazonaws.com/fr2_tenant_template/user/avatar/31bf5bfa-9cb8-49e6-a067-6dff9d1231fe/Prof_Ertl-Portrait.jpg',
-  #   'https://cl2-tenant-template-content.s3.amazonaws.com/fr2_tenant_template/user/avatar/c969dc8b-a29a-4758-b38c-9c3a209aad50/500.jpg',
-  #   'https://cl2-tenant-template-content.s3.amazonaws.com/fr2_tenant_template/user/avatar/241f271a-f5d5-47ec-a07f-17624e604e23/pexels-photo-247917.jpeg',
-  #   'https://cl2-tenant-template-content.s3.amazonaws.com/fr2_tenant_template/user/avatar/3a0daa4e-25b3-4087-b0a0-74681741f468/00d6436d2d9283f7ce61f87b07ae378e--portrait-men-male-portrait-photography.jpg',
-  #   'https://cl2-tenant-template-content.s3.amazonaws.com/fr2_tenant_template/user/avatar/12831742-dc2c-4dd7-8896-d9ddb29a997a/017840b7be8c4a19c57fd213eb8377a0--portrait-photography-men-face-photography.jpg',
-  #   'https://cl2-tenant-template-content.s3.amazonaws.com/fr2_tenant_template/user/avatar/54245944-8135-462a-b98f-24a75ed7c9b8/3df459479af007fed226ae39b9464af8--portrait-photography-men-photography-photos.jpg',
-  #   'https://cl2-tenant-template-content.s3.amazonaws.com/fr2_tenant_template/user/avatar/25f8652e-62d1-4651-9ed3-449ba3174be2/black-white-portrait2.jpg',
-  #   'https://cl2-tenant-template-content.s3.amazonaws.com/fr2_tenant_template/user/avatar/75616256-0236-4f3e-9027-66a0d40f46f5/csm_Karakasoglu_Yasemin1_360cb6e01f.jpg',
-  #   'https://cl2-tenant-template-content.s3.amazonaws.com/fr2_tenant_template/user/avatar/8c5928c1-89b6-4b48-92d5-d751c1c13643/5607404f-fb91-4e9f-9522-9e3363f404a6-mahmoud-benazzouk-dentiste-.jpg',
-  #   'https://cl2-tenant-template-content.s3.amazonaws.com/fr2_tenant_template/user/avatar/0e52873d-26ac-4716-9654-3c4257b613d1/70971_portrait-benjamin-dhardemare.jpg'
-  # ]
-
-  # FEMALE_AVATAR_URLS = [
-  #   'https://cl2-seed-and-template-assets.s3.eu-central-1.amazonaws.com/images/avatars/avatar18_female.jpeg',
-  #   'https://cl2-seed-and-template-assets.s3.eu-central-1.amazonaws.com/images/avatars/avatar27_female.jpeg',
-  #   'https://cl2-tenant-template-content.s3.amazonaws.com/fr2_tenant_template/user/avatar/1ded0d3c-a50f-4b68-b7ff-f1ca23dc185a/Portrait-8.jpg',
-  #   'https://cl2-tenant-template-content.s3.amazonaws.com/fr2_tenant_template/user/avatar/c6896f8d-2128-403a-82f0-fa04647173c6/popin_2016.jpg',
-  #   'https://cl2-tenant-template-content.s3.amazonaws.com/fr2_tenant_template/user/avatar/ffdc4756-2a6e-4f3d-b147-b259ea519e4c/89c81ca5da657d45d323eff5b8ad7c69.jpg',
-  #   'https://cl2-tenant-template-content.s3.amazonaws.com/fr2_tenant_template/user/avatar/9327615c-0dcd-4b72-bc1d-d7d821bbcf89/5dcf2c739263eb1e32ca1ef35d2664a8.jpg',
-  #   'https://cl2-tenant-template-content.s3.amazonaws.com/fr2_tenant_template/user/avatar/851a2bdb-ef19-4d9a-a56b-75256cf855eb/BethanyR.jpg',
-  #   'https://cl2-tenant-template-content.s3.amazonaws.com/fr2_tenant_template/user/avatar/4c7ab5ab-fc25-470a-81fa-c1c984759c3a/83857__portrait-tips2.jpg',
-  #   'https://cl2-tenant-template-content.s3.amazonaws.com/fr2_tenant_template/user/avatar/7550ac4f-fc07-4898-9e31-7e6ecb925d87/6c44f9503011a7dd186449bd25f49f4b--painting-portraits-portrait-art.jpg',
-  #   'https://cl2-tenant-template-content.s3.amazonaws.com/fr2_tenant_template/user/avatar/d1100534-2d07-41c8-b68c-f6b005e96ba8/leia-princess-leia-organa-solo-skywalker-9301321-576-1010.jpg',
-  #   'https://cl2-tenant-template-content.s3.amazonaws.com/fr2_tenant_template/user/avatar/496fe56e-0f4f-4596-b0fe-f7d6709b481e/4164298-miranda-kerr-4.jpg',
-  #   'https://cl2-tenant-template-content.s3.amazonaws.com/fr2_tenant_template/user/avatar/2de4f773-4f92-4aa6-a4ae-92f690bf111c/20170601183357-5506a2c2-cu_e355.jpg',
-  #   'https://cl2-tenant-template-content.s3.amazonaws.com/fr2_tenant_template/user/avatar/dfbd3eac-84eb-424f-8589-64f87b1c98a0/c644c101aad7a5b28f74526a50a2d7c1--rankin-photography-light-photography.jpg',
-  #   'https://cl2-tenant-template-content.s3.amazonaws.com/fr2_tenant_template/user/avatar/43b629dc-762d-4c28-9478-4a6145c7a0c1/simoneveil1.jpg',
-  #   'https://cl2-tenant-template-content.s3.amazonaws.com/fr2_tenant_template/user/avatar/6a2c3645-929f-45c0-aab5-02b196c18b56/1_JvrUroQL_0QkqBqlY7Wb0A.jpeg',
-  #   'https://cl2-tenant-template-content.s3.amazonaws.com/fr2_tenant_template/user/avatar/9eb7a4fa-b750-4d84-a10f-0a29f7b8cd59/juror-ford.jpg',
-  #   'https://cl2-tenant-template-content.s3.amazonaws.com/fr2_tenant_template/user/avatar/1b9903c9-5bda-47ff-b085-e4f33a6dacb5/portrait-camera-mode-e.jpg'
-  # ]
-
   def initialize
     # CSV files are generated from Google Sheets found in this Google Drive folder:
     # https://drive.google.com/drive/folders/10LnSF5kzONn8cgFuCj37E3zzhBK8V120?usp=sharing


### PR DESCRIPTION
Requesting review after merging, as I wanted to test on staging, and it seems it works + issue is reasonably urgent.

Not sure my 'fix' is the best, but it seems to work (open to suggestions to improve, ofc)

- Adds `require 'csv'` to `AnonymizeUserService` (the fix)

## The issue:
Project copy between platforms (using AdminHQ) was broken when including user data (anonymized).
It seems that [`CSV.read`](https://github.com/CitizenLabDotCo/citizenlab/blob/f46477a07a47f8a5966f9a6d66c2add0a800dc58/back/app/services/anonymize_user_service.rb#L22) in `AnonymizeUserService#load_csv` was being interpreted as a non-existent constant, when the method was invoked from the use of `cl2-admin/lib/admin_api.rb#project_template_export`.

## The solution
Explicitly `require 'csv'` in the `citizenlab` file(s) that can be invoked from `cl2-admin` via the admin_api.

Tested by first confirming that copying within same tenant, with anonymized user data, via AdminHQ project copy tool would fail on `demo.stg`. Then checking that the same copying process succeeded after merging this to `master`.

## But why now?
Given project copy had been working for some time (I assume), then why now?
- Maybe related to the [switch to async copying in February](https://github.com/CitizenLabDotCo/cl2-admin/pull/122), and nobody had tried project copy between tenants with anonymized users since? (seems unlikely)
- Maybe related to a recent (3 weeks ago) dependabot [PR merge](https://github.com/CitizenLabDotCo/citizenlab/pull/7942/files) that set a higher version of `csv`?

## Will other CSV stuff break?
Not entirely sure.

Searching `citizenlab` repo for "CSV.", I find only one other file that is not a rake task: `back/.../admin_api/id_cards_controller.rb` that uses `CSV.parse` and can be invoked by `cl2-admin/lib/admin_api.rb#verification_id_cards_replace_all`, so I will also add a `require 'csv'` to the former file as a precaution (in a separate PR: #8179).

The only other hits for "CSV." are rake tasks. Many, but not all, already have `require 'csv'` in the respective file. Those that do not seem not be likley to be invoked from `cl2-admin`, and will therefore most likely be used manually when any such need to require 'csv' would be discovered.

# Changelog
## Fixed
- [TAN-2052] Fixes project copy, via AdminHQ, when including anonymized user data
