### PR TITLE
TAN-1826 - Fix for iCal timezones in outlook

### DIFF
--- a/back/app/services/events/ics_generator.rb
+++ b/back/app/services/events/ics_generator.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'icalendar/tzinfo'
+
 module Events
   class IcsGenerator
     # @param [Event, #to_ary] events one or multiple events
@@ -24,7 +26,7 @@ module Events
 
     def empty_calendar
       Icalendar::Calendar.new.tap do |cal|
-        cal.prodid = 'CitizenLab'
+        cal.prodid = 'GoVocal'
       end
     end
 
@@ -43,6 +45,8 @@ module Events
       # Therefore, we have decided to use the timezone identifier without the `/` prefix,
       # even though it deviates from the ICS specification.
       tzid = timezone.tzinfo.identifier
+      ical_timezone = timezone.tzinfo.ical_timezone start_time
+      cal.add_timezone ical_timezone
 
       cal.event do |e|
         e.dtstart = Icalendar::Values::DateTime.new(start_time, tzid: tzid)

--- a/back/lib/tasks/single_use/20240124_rename_most_voted_ideas_widget.rake
+++ b/back/lib/tasks/single_use/20240124_rename_most_voted_ideas_widget.rake
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-MULTILOC_TYPES = {
+MOST_VOTED_MULTILOC_TYPES = {
   'MostVotedIdeasWidget' => 'MostReactedIdeasWidget'
 }
-TEXT_PROPS = %w[text alt title]
+MOST_VOTED_MOST_VOTED_TEXT_PROPS = %w[text alt title]
 
 namespace :single_use do
   desc 'Fix existing layouts'
@@ -37,7 +37,7 @@ namespace :single_use do
 end
 
 def multiloc_element?(elt)
-  MULTILOC_TYPES.key? node_type(elt)
+  MOST_VOTED_MULTILOC_TYPES.key? node_type(elt)
 end
 
 def node_type(elt)
@@ -52,9 +52,9 @@ def migrate_monolingual(craftjs_json, primary_locale, other_locales)
   craftjs_json.transform_values do |elt|
     new_elt = elt.deep_dup
     if multiloc_element?(elt)
-      new_elt['type']['resolvedName'] = MULTILOC_TYPES[elt.dig('type', 'resolvedName')] if MULTILOC_TYPES.key? elt.dig('type', 'resolvedName')
-      new_elt['displayName'] = MULTILOC_TYPES[elt['displayName']] if MULTILOC_TYPES.key? elt['displayName']
-      TEXT_PROPS.each do |text_prop|
+      new_elt['type']['resolvedName'] = MOST_VOTED_MULTILOC_TYPES[elt.dig('type', 'resolvedName')] if MOST_VOTED_MULTILOC_TYPES.key? elt.dig('type', 'resolvedName')
+      new_elt['displayName'] = MOST_VOTED_MULTILOC_TYPES[elt['displayName']] if MOST_VOTED_MULTILOC_TYPES.key? elt['displayName']
+      MOST_VOTED_TEXT_PROPS.each do |text_prop|
         if elt['props'].key? text_prop
           new_elt['props'][text_prop] = { primary_locale => elt.dig('props', text_prop) }
           other_locales.each do |other_locale|

--- a/back/spec/services/events/ics_generator_spec.rb
+++ b/back/spec/services/events/ics_generator_spec.rb
@@ -25,8 +25,25 @@ RSpec.describe Events::IcsGenerator do
       expected_ics = <<~ICS.gsub("\n", "\r\n")
         BEGIN:VCALENDAR
         VERSION:2.0
-        PRODID:CitizenLab
+        PRODID:GoVocal
         CALSCALE:GREGORIAN
+        BEGIN:VTIMEZONE
+        TZID:America/New_York
+        BEGIN:DAYLIGHT
+        DTSTART:20170312T030000
+        TZOFFSETFROM:-0500
+        TZOFFSETTO:-0400
+        RRULE:FREQ=YEARLY;BYDAY=2SU;BYMONTH=3
+        TZNAME:EDT
+        END:DAYLIGHT
+        BEGIN:STANDARD
+        DTSTART:20171105T010000
+        TZOFFSETFROM:-0400
+        TZOFFSETTO:-0500
+        RRULE:FREQ=YEARLY;BYDAY=1SU;BYMONTH=11
+        TZNAME:EST
+        END:STANDARD
+        END:VTIMEZONE
         BEGIN:VEVENT
         DTSTAMP:%DTSTAMP_PLACEHOLDER%
         UID:%UID_PLACEHOLDER%


### PR DESCRIPTION
Looks like the issue was because Outlook didn't recognise the timezone as one of it's internal timezones, looking at our output in a [validator](https://icalendar.org/validator.html) it showed that it was missing the `VTIMEZONE` element to marry the timezone ID with with the data for that timezone. I don't know for sure that this will fix it as I can't reproduce locally with the latest mac version of outlook, but this feels like it should fix it based on [this](https://learn.microsoft.com/en-us/answers/questions/813150/outlook-desktop-not-reading-standards-compliant-ic)

# Changelog
## Fixed
- TAN-1826 - Fix for timezone being out by an hour when importing into outlook
