### PR TITLE
[TAN-2052] Add 'csv' gem rather than require 'csv'

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -18,6 +18,7 @@ gem 'puma', '~> 6.4.2'
 # gem 'redis', '~> 3.0'
 # Use ActiveModel has_secure_password
 gem 'bcrypt', '~> 3.1.20'
+gem 'csv'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development

--- a/back/Gemfile
+++ b/back/Gemfile
@@ -18,7 +18,7 @@ gem 'puma', '~> 6.4.2'
 # gem 'redis', '~> 3.0'
 # Use ActiveModel has_secure_password
 gem 'bcrypt', '~> 3.1.20'
-gem 'csv'
+gem 'csv', '~> 3.3.0'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -1264,6 +1264,7 @@ DEPENDENCIES
   combine_pdf (~> 1.0.26)
   content_builder!
   counter_culture (~> 3.5)
+  csv
   custom_idea_statuses!
   custom_maps!
   dalli (~> 3.2.8)

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -1264,7 +1264,7 @@ DEPENDENCIES
   combine_pdf (~> 1.0.26)
   content_builder!
   counter_culture (~> 3.5)
-  csv
+  csv (~> 3.3.0)
   custom_idea_statuses!
   custom_maps!
   dalli (~> 3.2.8)

--- a/back/app/services/anonymize_user_service.rb
+++ b/back/app/services/anonymize_user_service.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-# This service is invoked by cl2-admin/lib/admin_api.rb#project_template_export and it seems we need to require CSV.
-require 'csv'
-
 class AnonymizeUserService
   def initialize
     # CSV files are generated from Google Sheets found in this Google Drive folder:

--- a/back/engines/commercial/id_id_card_lookup/app/controllers/id_id_card_lookup/admin_api/id_cards_controller.rb
+++ b/back/engines/commercial/id_id_card_lookup/app/controllers/id_id_card_lookup/admin_api/id_cards_controller.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# The bulk_replace method is invoked by cl2-admin/lib/admin_api.rb#verification_id_cards_replace_all
+# and it seems we need to require CSV.
+require 'csv'
+
 module IdIdCardLookup
   module AdminApi
     class IdCardsController < ::AdminApi::AdminApiController

--- a/back/engines/commercial/id_id_card_lookup/app/controllers/id_id_card_lookup/admin_api/id_cards_controller.rb
+++ b/back/engines/commercial/id_id_card_lookup/app/controllers/id_id_card_lookup/admin_api/id_cards_controller.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-# The bulk_replace method is invoked by cl2-admin/lib/admin_api.rb#verification_id_cards_replace_all
-# and it seems we need to require CSV.
-require 'csv'
-
 module IdIdCardLookup
   module AdminApi
     class IdCardsController < ::AdminApi::AdminApiController


### PR DESCRIPTION
# Changelog
## Technical
- [TAN-2052] Add 'csv' gem, rather than requiring 'csv'
