### PR TITLE
Fix flaky idea_voting_permissions E2E test

### DIFF
--- a/front/cypress/e2e/idea_voting_permissions.cy.ts
+++ b/front/cypress/e2e/idea_voting_permissions.cy.ts
@@ -134,10 +134,10 @@ describe('Idea reacting permissions', () => {
       const email = randomEmail();
       const password = randomString();
 
-      // Go to an idea of a project that doesn't require verification
-      // and try to reaction
-      cy.visit('ideas/very-new-idea');
-      cy.get('.e2e-ideacard-like-button').click();
+      // Go to an ideation project that doesn't require verification
+      // and try to react
+      cy.visit('/projects/an-idea-bring-it-to-your-council');
+      cy.get('.e2e-ideacard-like-button').first().click();
 
       // Sign up flow
       cy.get('#e2e-authentication-modal');


### PR DESCRIPTION
Looks like all of the _"Did not find element: e2e-authentication-modal"_ E2E failures were coming from a single test this last tandem cycle. This change should fix the test. The selectors for the reaction controls on the idea page just aren't playing nicely with Cypress. Instead I've just changed the test to use the ones on the idea card instead. We're testing the same functionality, but just through a slightly different flow.

Ran this a number of times locally using the CI setup, and it's passing now.