### PR TITLE
Last stuff report builder

### DIFF
--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Templates/PlatformTemplate/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Templates/PlatformTemplate/index.tsx
@@ -181,7 +181,11 @@ const PlatformTemplateContent = ({ startDate, endDate }: Props) => {
       {supportedEnabledFields.map((field) => (
         <Element is={Container} canvas key={field.id}>
           <DemographicsWidget
-            title={field.attributes.title_multiloc}
+            title={
+              field.attributes.code === 'birthyear'
+                ? toMultiloc(messages.age)
+                : field.attributes.title_multiloc
+            }
             {...dateRange}
             customFieldId={field.id}
           />

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Templates/PlatformTemplate/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Templates/PlatformTemplate/index.tsx
@@ -133,7 +133,9 @@ const PlatformTemplateContent = ({ startDate, endDate }: Props) => {
     });
   };
 
-  const supportedFields = userFields.data.filter(isSupportedField);
+  const supportedEnabledFields = userFields.data
+    .filter(isSupportedField)
+    .filter((field) => field.attributes.enabled);
 
   return (
     <Element id="platform-report-template" is={Box} canvas>
@@ -176,7 +178,7 @@ const PlatformTemplateContent = ({ startDate, endDate }: Props) => {
         )}
       />
       <WhiteSpace size="small" />
-      {supportedFields.map((field) => (
+      {supportedEnabledFields.map((field) => (
         <Element is={Container} canvas key={field.id}>
           <DemographicsWidget
             title={field.attributes.title_multiloc}

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Templates/PlatformTemplate/messages.ts
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Templates/PlatformTemplate/messages.ts
@@ -52,4 +52,8 @@ export default defineMessages({
     defaultMessage:
       'The following section provides an overview of publicly visible projects that overlap with the selected time range, the most used methods in these projects, and metrics concerning the total amount of participation.',
   },
+  age: {
+    id: 'app.containers.Admin.Reporting.Templates.PlatformReportTemplate.age',
+    defaultMessage: 'Age',
+  },
 });

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/DemographicsWidget/Settings.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/DemographicsWidget/Settings.tsx
@@ -80,8 +80,6 @@ const Settings = () => {
     });
   };
 
-  toMultiloc(platformTemplateMessages.age); // TODO
-
   const processedUserFields = userFields?.data
     .filter(isSupportedField)
     .map((field) => {

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/DemographicsWidget/Settings.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/DemographicsWidget/Settings.tsx
@@ -10,11 +10,19 @@ import {
 } from 'api/user_custom_fields/types';
 import useUserCustomFields from 'api/user_custom_fields/useUserCustomFields';
 
+import useAppConfigurationLocales from 'hooks/useAppConfigurationLocales';
+
 import GroupFilter from 'containers/Admin/dashboard/components/filters/GroupFilter';
 import groupFilterMessages from 'containers/Admin/dashboard/messages';
+import { createMultiloc } from 'containers/Admin/reporting/utils/multiloc';
 
-import { useIntl } from 'utils/cl-intl';
+import {
+  useIntl,
+  useFormatMessageWithLocale,
+  MessageDescriptor,
+} from 'utils/cl-intl';
 
+import platformTemplateMessages from '../../../Templates/PlatformTemplate/messages';
 import UserFieldSelect from '../../_shared/UserFieldSelect';
 import ChartWidgetSettings from '../_shared/ChartWidgetSettings';
 
@@ -32,6 +40,8 @@ export const INPUT_TYPES: IUserCustomFieldInputType[] = ['select', 'number'];
 
 const Settings = () => {
   const { formatMessage } = useIntl();
+  const formatMessageWithLocale = useFormatMessageWithLocale();
+  const appConfigurationLocales = useAppConfigurationLocales();
 
   const { data: userFields } = useUserCustomFields({
     inputTypes: INPUT_TYPES,
@@ -45,6 +55,8 @@ const Settings = () => {
     customFieldId: node.data.props.customFieldId,
     groupId: node.data.props.groupId,
   }));
+
+  if (!appConfigurationLocales) return null;
 
   const setCustomFieldId = (
     value?: string,
@@ -62,11 +74,35 @@ const Settings = () => {
     });
   };
 
+  const toMultiloc = (message: MessageDescriptor) => {
+    return createMultiloc(appConfigurationLocales, (locale) => {
+      return formatMessageWithLocale(locale, message);
+    });
+  };
+
+  toMultiloc(platformTemplateMessages.age); // TODO
+
+  const processedUserFields = userFields?.data
+    .filter(isSupportedField)
+    .map((field) => {
+      if (field.attributes.code === 'birthyear') {
+        return {
+          ...field,
+          attributes: {
+            ...field.attributes,
+            title_multiloc: toMultiloc(platformTemplateMessages.age),
+          },
+        };
+      } else {
+        return field;
+      }
+    });
+
   return (
     <>
       <UserFieldSelect
         userFieldId={customFieldId}
-        userFields={userFields?.data.filter(isSupportedField)}
+        userFields={processedUserFields}
         label={formatMessage(messages.registrationField)}
         emptyOption={false}
         onChange={setCustomFieldId}

--- a/front/app/translations/admin/en.json
+++ b/front/app/translations/admin/en.json
@@ -590,6 +590,7 @@
   "app.containers.Admin.PagesAndMenu.topInfoSaveAndEnableButton": "Save and enable top info section",
   "app.containers.Admin.PagesAndMenu.topInfoSaveButton": "Save top info section",
   "app.containers.Admin.PagesAndMenu.viewButton": "View",
+  "app.containers.Admin.Reporting.Templates.PlatformReportTemplate.age": "Age",
   "app.containers.Admin.Reporting.Templates.PlatformReportTemplate.community": "Community",
   "app.containers.Admin.Reporting.Templates.PlatformReportTemplate.executiveSummary": "Executive summary",
   "app.containers.Admin.Reporting.Templates.PlatformReportTemplate.inclusionIndicators": "Top-level inclusion indicators",


### PR DESCRIPTION
# Changelog
## Fixed
- 'Birthyear' now called 'Age' in Demographics widget
- Platform template now only includes active registration fields
