### PR TITLE
TAN-2051 - Fix sentry idea draft bugs

### DIFF
--- a/back/app/controllers/web_api/v1/ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/ideas_controller.rb
@@ -251,7 +251,7 @@ class WebApi::V1::IdeasController < ApplicationController
   private
 
   def render_show(input, check_auth: true)
-    authorize input if check_auth
+    authorize input if check_auth # we should usually check auth, except when we're returning an empty draft idea
     render json: WebApi::V1::IdeaSerializer.new(
       input,
       params: jsonapi_serializer_params,

--- a/back/app/policies/idea_policy.rb
+++ b/back/app/policies/idea_policy.rb
@@ -79,7 +79,7 @@ class IdeaPolicy < ApplicationPolicy
   private
 
   def owner?
-    record.author_id == user.id
+    user && record.author_id == user.id
   end
 end
 

--- a/back/spec/acceptance/ideas_spec.rb
+++ b/back/spec/acceptance/ideas_spec.rb
@@ -612,27 +612,45 @@ resource 'Ideas' do
       context 'Idea authored by another user' do
         let!(:idea) { create(:idea, project: phase.project, phases: [phase], creation_phase: phase, publication_status: 'draft') }
 
-        example '[error] No draft ideas for current user', document: false do
+        example '[empty idea] No draft ideas for current user', document: false do
           do_request
-          expect(status).to eq 404
+          expect(status).to eq 200
+          json_response = json_parse(response_body)
+          expect(json_response.dig(:data, :id)).to be_nil
         end
       end
 
       context 'Idea is not draft' do
         let!(:idea) { create(:idea, project: phase.project, phases: [phase], creation_phase: phase, author: @user) }
 
-        example '[error] No draft ideas', document: false do
+        example '[empty idea] No draft ideas', document: false do
           do_request
-          expect(status).to eq 404
+          expect(status).to eq 200
+          json_response = json_parse(response_body)
+          expect(json_response.dig(:data, :id)).to be_nil
         end
       end
 
       context 'Idea is not native survey' do
         let!(:idea) { create(:idea, project: phase.project, phases: [phase], author: @user, publication_status: 'draft') }
 
-        example '[error] No native survey idea found', document: false do
+        example '[empty idea] No native survey idea found', document: false do
           do_request
-          expect(status).to eq 404
+          expect(status).to eq 200
+          json_response = json_parse(response_body)
+          expect(json_response.dig(:data, :id)).to be_nil
+        end
+      end
+
+      context 'User is not logged in' do
+        let!(:idea) { create(:idea, project: phase.project, phases: [phase], author: @user, publication_status: 'draft') }
+
+        example '[empty idea] User not logged in', document: false do
+          header 'Authorization', nil
+          do_request
+          expect(status).to eq 200
+          json_response = json_parse(response_body)
+          expect(json_response.dig(:data, :id)).to be_nil
         end
       end
     end


### PR DESCRIPTION
Notes from ticket:

- the GET draft endpoint error I have mitigated by always returning a blank response if there is no current draft (or user not logged in) instead of a 404 - this annoyed me anyway, so this works more nicely for the front end
- the PATCH update errors, these are very much fewer and this is caused by trying to submit after your session has expired (or logged out in a different tab). So added an additional check now in the idea_policy to stop it throwing an error. Should just return unauthorized now.

Separately we might need to think about how to handle the latter situation (if at all) on the front-end as in this situation you just get a never ending spinner - this fix makes it no better or worse for the user experience.

# Changelog
## Technical
- TAN-2051 - Correctly throw 401 unauthorized if logged out user tries to update a draft idea & return blank draft idea instead of 404 when no draft idea can be found
