### PR TITLE
[TAN-1939] Use CurrentAttributes to cache app_configuration 

### DIFF
--- a/back/app/models/app_configuration.rb
+++ b/back/app/models/app_configuration.rb
@@ -112,23 +112,15 @@ class AppConfiguration < ApplicationRecord
     def instance
       science 'app_configuration' do |experiment|
         experiment.use { first! }
-        experiment.try do
-          @instance_caller ||= caller
-          @instance ||= first!
-        end
+        experiment.try { Current.app_configuration }
 
         experiment.clean(&:attributes)
 
         experiment.context({
           execution_stack: caller,
-          tenant_schema: Apartment::Tenant.current,
-          instance_caller: @instance_caller
+          tenant_schema: Apartment::Tenant.current
         })
       end
-    end
-
-    def reset_instance
-      @instance = @instance_caller = nil
     end
   end
 

--- a/back/engines/commercial/multi_tenancy/app/controllers/multi_tenancy/patches/application_controller.rb
+++ b/back/engines/commercial/multi_tenancy/app/controllers/multi_tenancy/patches/application_controller.rb
@@ -5,16 +5,9 @@ module MultiTenancy
     module ApplicationController
       def self.prepended(base)
         base.class_eval do
-          before_action :set_current_tenant
           before_action :set_sentry_context
           rescue_from Apartment::TenantNotFound, with: :tenant_not_found
         end
-      end
-
-      def set_current_tenant
-        Current.tenant = Tenant.current
-      rescue ActiveRecord::RecordNotFound
-        # Ignored
       end
 
       def set_sentry_context

--- a/back/engines/commercial/multi_tenancy/app/models/multi_tenancy/extensions/app_configuration.rb
+++ b/back/engines/commercial/multi_tenancy/app/models/multi_tenancy/extensions/app_configuration.rb
@@ -34,7 +34,7 @@ module MultiTenancy
 
       def update_tenant
         Tenant.transaction do
-          tenant = Tenant.current
+          tenant = Tenant.current.reload
           # When computing the attributes delta, we cannot compare the tenant with:
           # - `AppConfiguration.instance` because the delta would include both, stale
           # and dirty attributes from the `AppConfiguration.instance` record. We only
@@ -44,7 +44,7 @@ module MultiTenancy
           # `AppConfiguration` side effects (`SideFxAppConfigurationService`).
           #
           # So we compare with `AppConfiguration.first` instead.
-          app_config = ::AppConfiguration.send(:first)
+          app_config = ::AppConfiguration.send(:first!)
           attrs_delta = tenant.send(:attributes_delta, app_config, tenant)
 
           next if attrs_delta.blank?

--- a/back/engines/commercial/multi_tenancy/app/models/tenant.rb
+++ b/back/engines/commercial/multi_tenancy/app/models/tenant.rb
@@ -62,6 +62,11 @@ class Tenant < ApplicationRecord
       host&.tr('.', '_')
     end
 
+    def by_schema_name!(schema_name)
+      host = schema_name_to_host(schema_name)
+      find_by!(host: host)
+    end
+
     # Reorder tenants by most important tenants (active) first
     def prioritize(tenants)
       priority_order = %w[active trial demo expired_trial churned not_applicable]
@@ -86,7 +91,7 @@ class Tenant < ApplicationRecord
   end
 
   def self.current
-    Current.tenant || find_by!(host: schema_name_to_host(Apartment::Tenant.current))
+    Current.tenant
   end
 
   def self.settings(*path)

--- a/back/engines/commercial/multi_tenancy/spec/models/tenant_spec.rb
+++ b/back/engines/commercial/multi_tenancy/spec/models/tenant_spec.rb
@@ -18,13 +18,16 @@ RSpec.describe Tenant do
       tenant.switch!
     end
 
-    it 'resets the app configuration' do
+    it 'updates the current tenant and app configuration' do
       expect(AppConfiguration.instance.name).to eq('test-tenant')
-      expect(AppConfiguration).to receive(:reset_instance).once.and_call_original
+
+      # Twice because of the second call in the :after hook defined in RSpec.configure
+      expect(Current).to receive(:reset_tenant).twice.and_call_original
 
       other_tenant.switch!
 
       expect(AppConfiguration.instance.name).to eq('other-tenant')
+      expect(described_class.current).to eq(other_tenant)
     end
 
     it 'switches successfully into the tenant' do

--- a/back/engines/commercial/report_builder/spec/services/report_builder/queries/demographics_spec.rb
+++ b/back/engines/commercial/report_builder/spec/services/report_builder/queries/demographics_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ReportBuilder::Queries::Demographics do
           create(:user, custom_field_values: { @custom_field.key => @option1.key }, manual_groups: [@group])
         end
 
-        AppConfiguration.update!(created_at: Date.new(2020, 1, 1))
+        AppConfiguration.instance.update!(created_at: Date.new(2020, 1, 1))
       end
 
       it 'returns multilocs' do
@@ -104,7 +104,7 @@ RSpec.describe ReportBuilder::Queries::Demographics do
           custom_field_values: { birthyear: 1977 }
         )
 
-        AppConfiguration.update!(created_at: Date.new(2020, 1, 1))
+        AppConfiguration.instance.update!(created_at: Date.new(2020, 1, 1))
       end
 
       it 'returns correct series data' do

--- a/back/lib/citizen_lab/scientist/experiment.rb
+++ b/back/lib/citizen_lab/scientist/experiment.rb
@@ -31,6 +31,8 @@ module CitizenLab
               candidate: observation_payload(result.candidates.first),
               execution_order: result.observations.map(&:name)
             })
+        else
+          Rails.logger.info("Experiment '#{name}' matched")
         end
       end
 

--- a/back/spec/spec_helper.rb
+++ b/back/spec/spec_helper.rb
@@ -183,7 +183,16 @@ RSpec.configure do |config|
   # rubocop:enable RSpec/BeforeAfterAll
 
   config.before do
-    Apartment::Tenant.switch!('example_org') # Switch into the default tenant
+    Apartment::Tenant.switch!('example_org')
+  end
+
+  config.after do
+    # We invalidate the cached tenant and app_configuration after each test to prevent
+    # state from leaking between tests. However, it could still occur in some edge cases,
+    # such as when an after(:context) hook accesses the tenant or app_configuration. This
+    # is unlikely to happen in practice, and if it does, it should be resolved by
+    # rewriting the test or the hook.
+    Current.reset_tenant
   end
 
   config.around(:each, use_transactional_fixtures: false) do |example|


### PR DESCRIPTION
This is our second attempt to cache app_configuration to improve application performance. The first attempt was buggy because it used a class instance variable, which is not thread-safe. This new implementation uses CurrentAttributes instead.

The tenant and app_configuration are now lazily loaded when needed, i.e., when accessing Current.tenant or Current.app_configuration. As a result, we no longer need to explicitly set the tenant or app_configuration (allowing us to remove the `set_current_tenant` callback from ApplicationController). This "lazy-caching" approach has the advantage to also work outside of the request-response cycle, e.g., in background jobs or rake tasks, without the need to set the tenant or app_configuration explicitly.

# Changelog
## Technical
- [TAN-1939] Use CurrentAttributes to cache app_configuration
