### PR TITLE
TAN-2093 Make scheduled emails more robust

### DIFF
--- a/back/app/controllers/web_api/v1/projects_controller.rb
+++ b/back/app/controllers/web_api/v1/projects_controller.rb
@@ -181,7 +181,9 @@ class WebApi::V1::ProjectsController < ApplicationController
     ActiveRecord::Base.transaction do
       set_folder
       authorize @project
-      @project.save
+      saved = @project.save
+      check_publication_inconsistencies! if saved
+      saved
     end
   end
 
@@ -194,5 +196,12 @@ class WebApi::V1::ProjectsController < ApplicationController
   def set_project
     @project = Project.find(params[:id])
     authorize @project
+  end
+
+  def check_publication_inconsistencies!
+    # This code is meant to be temporary to find the cause of the disappearing admin publication bugs
+    if Project.all.any? { |project| !project.valid? }
+      raise 'Project change would lead to inconsistencies!'
+    end
   end
 end

--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -87,7 +87,7 @@ class Project < ApplicationRecord
   validates :description_preview_multiloc, multiloc: { presence: false }
   validates :visible_to, presence: true, inclusion: { in: VISIBLE_TOS }
   validates :internal_role, inclusion: { in: INTERNAL_ROLES, allow_nil: true }
-  validate :admin_publication_must_exist
+  validate :admin_publication_must_exist, unless: proc { Current.loading_tenant_template } # Parked - validate publications: validate :admin_publication_must_exist
 
   pg_search_scope :search_by_all,
     against: %i[title_multiloc description_multiloc description_preview_multiloc slug],

--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -64,7 +64,7 @@ class Project < ApplicationRecord
   has_many :followers, as: :followable, dependent: :destroy
 
   before_validation :sanitize_description_multiloc, if: :description_multiloc
-  before_validation :set_admin_publication, unless: proc { Current.loading_tenant_template }
+  # before_validation :set_admin_publication, unless: proc { Current.loading_tenant_template }
   before_validation :set_visible_to, on: :create
   before_validation :strip_title
   before_destroy :remove_notifications # Must occur before has_many :notifications (see https://github.com/rails/rails/issues/5205)

--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -224,10 +224,6 @@ class Project < ApplicationRecord
     end
   end
 
-  def set_admin_publication
-    self.admin_publication_attributes = {} unless admin_publication
-  end
-
   def remove_notifications
     notifications.each do |notification|
       notification.destroy! unless notification.update(project: nil)

--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -87,7 +87,7 @@ class Project < ApplicationRecord
   validates :description_preview_multiloc, multiloc: { presence: false }
   validates :visible_to, presence: true, inclusion: { in: VISIBLE_TOS }
   validates :internal_role, inclusion: { in: INTERNAL_ROLES, allow_nil: true }
-  validate :admin_publication_must_exist, unless: proc { Current.loading_tenant_template }
+  validate :admin_publication_must_exist
 
   pg_search_scope :search_by_all,
     against: %i[title_multiloc description_multiloc description_preview_multiloc slug],

--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -64,7 +64,6 @@ class Project < ApplicationRecord
   has_many :followers, as: :followable, dependent: :destroy
 
   before_validation :sanitize_description_multiloc, if: :description_multiloc
-  # before_validation :set_admin_publication, unless: proc { Current.loading_tenant_template }
   before_validation :set_visible_to, on: :create
   before_validation :strip_title
   before_destroy :remove_notifications # Must occur before has_many :notifications (see https://github.com/rails/rails/issues/5205)

--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -87,7 +87,7 @@ class Project < ApplicationRecord
   validates :description_preview_multiloc, multiloc: { presence: false }
   validates :visible_to, presence: true, inclusion: { in: VISIBLE_TOS }
   validates :internal_role, inclusion: { in: INTERNAL_ROLES, allow_nil: true }
-  validate :admin_publication_must_exist, unless: proc { Current.loading_tenant_template } # Parked - validate publications: validate :admin_publication_must_exist
+  validate :admin_publication_must_exist
 
   pg_search_scope :search_by_all,
     against: %i[title_multiloc description_multiloc description_preview_multiloc slug],

--- a/back/engines/commercial/multi_tenancy/app/models/tenant.rb
+++ b/back/engines/commercial/multi_tenancy/app/models/tenant.rb
@@ -156,12 +156,6 @@ class Tenant < ApplicationRecord
     find_by!(host: host_name).switch!
   end
 
-  def self.switch_each
-    find_each do |tenant|
-      tenant.switch { yield(tenant) }
-    end
-  end
-
   def changed_lifecycle_stage?
     return false unless settings_previously_changed?
 

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/patches/email_campaigns/tasks_service.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/patches/email_campaigns/tasks_service.rb
@@ -5,27 +5,27 @@ module MultiTenancy
     module EmailCampaigns
       module TasksService
         def schedule_email_campaigns
-          Tenant.switch_each { super }
+          Tenant.safe_switch_each { super }
         end
 
         def assure_campaign_records
-          Tenant.switch_each { super }
+          Tenant.safe_switch_each { super }
         end
 
         def remove_deprecated
-          Tenant.switch_each { super }
+          Tenant.safe_switch_each { super }
         end
 
         def remove_consents(emails_url)
-          Tenant.switch_each { super }
+          Tenant.safe_switch_each { super }
         end
 
         def ensure_unsubscription_tokens
-          Tenant.switch_each { super }
+          Tenant.safe_switch_each { super }
         end
 
         def update_user_digest_schedules
-          Tenant.switch_each do |tenant|
+          Tenant.safe_switch_each do |tenant|
             Rails.logger.info("Could not update user digest schedule for #{tenant.host}") unless super
           end
         end

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/core.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/core.rb
@@ -54,20 +54,15 @@ module MultiTenancy
           end
 
           def attributes(*attributes_list, &block)
+            self.value_attributes ||= []
+            self.nested_attributes ||= []
+
             attributes_list = attributes_list.first if attributes_list.first.is_a?(Array)
             options = attributes_list.last.is_a?(Hash) ? attributes_list.pop : {}
-            self.value_attributes = [] if value_attributes.nil?
-            self.nested_attributes = [] if nested_attributes.nil?
 
             attributes_list.each do |attr_name|
-              atr = Attribute.new(
-                attr_name.to_sym, block || attr_name, options
-              )
-              if atr.nested?
-                nested_attributes << atr
-              else
-                value_attributes << atr
-              end
+              atr = Attribute.new(attr_name.to_sym, block || attr_name, options)
+              atr.nested? ? nested_attributes << atr : value_attributes << atr
             end
           end
 

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/core/attribute.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/core/attribute.rb
@@ -19,6 +19,10 @@ module MultiTenancy
             output_hash[name] = call_proc(method, model, serialization_params)
           end
 
+          def nested?
+            !!options[:nested]
+          end
+
           private
 
           def conditional_proc

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/core/nested_attributes.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/core/nested_attributes.rb
@@ -1,0 +1,23 @@
+module MultiTenancy
+  module Templates
+    module Serializers
+      module Core
+        class NestedAttributes
+          def initialize(attrs)
+            @attrs = attrs
+          end
+
+          def resolve(context)
+            @attrs.transform_values do |value|
+              if value.is_a?(Ref)
+                value.resolve(context)
+              else
+                value
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/project.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/project.rb
@@ -15,7 +15,6 @@ module MultiTenancy
           visible_to
         ]
 
-        # Parked - validate publications:
         attribute(:admin_publication_attributes, nested: true) do |project|
           publication = project.admin_publication
           {

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/project.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/project.rb
@@ -14,6 +14,16 @@ module MultiTenancy
           title_multiloc
           visible_to
         ]
+
+        # Parked - validate publications:
+        # attribute(:admin_publication_attributes) do |project|
+        #   publication = project.admin_publication
+        #   {
+        #     'publication_status' => publication.publication_status,
+        #     'ordering' => publication.ordering,
+        #     'parent_ref' => Ref.new(publication, :parent)
+        #   }
+        # end
       end
     end
   end

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/project.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/project.rb
@@ -16,14 +16,14 @@ module MultiTenancy
         ]
 
         # Parked - validate publications:
-        # attribute(:admin_publication_attributes) do |project|
-        #   publication = project.admin_publication
-        #   {
-        #     'publication_status' => publication.publication_status,
-        #     'ordering' => publication.ordering,
-        #     'parent_ref' => Ref.new(publication, :parent)
-        #   }
-        # end
+        attribute(:admin_publication_attributes, nested: true) do |project|
+          publication = project.admin_publication
+          {
+            'publication_status' => publication.publication_status,
+            'ordering' => publication.ordering,
+            'parent_ref' => Ref.new(publication, :parent)
+          }
+        end
       end
     end
   end

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/project_folders/folder.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/project_folders/folder.rb
@@ -7,6 +7,15 @@ module MultiTenancy
         class Folder < Base
           attributes %i[description_multiloc description_preview_multiloc title_multiloc]
           upload_attribute :header_bg
+
+          # attribute(:admin_publication_attributes, nested: true) do |folder|
+          #   publication = folder.admin_publication
+          #   # The day that folders can be nested, we will need to add parent_ref and ensure that folders are serialized from top to bottom.
+          #   {
+          #     'publication_status' => publication.publication_status,
+          #     'ordering' => publication.ordering
+          #   }
+          # end
         end
       end
     end

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/project_folders/folder.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/project_folders/folder.rb
@@ -7,15 +7,6 @@ module MultiTenancy
         class Folder < Base
           attributes %i[description_multiloc description_preview_multiloc title_multiloc]
           upload_attribute :header_bg
-
-          # attribute(:admin_publication_attributes, nested: true) do |folder|
-          #   publication = folder.admin_publication
-          #   # The day that folders can be nested, we will need to add parent_ref and ensure that folders are serialized from top to bottom.
-          #   {
-          #     'publication_status' => publication.publication_status,
-          #     'ordering' => publication.ordering
-          #   }
-          # end
         end
       end
     end

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_deserializer.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_deserializer.rb
@@ -82,6 +82,8 @@ module MultiTenancy
             begin
               if model.try(:in_list?)
                 model.class.acts_as_list_no_update { save_model(model, validate) }
+              elsif model.class == Project
+                AdminPublication.acts_as_list_no_update { save_model(model, validate) }
               else
                 save_model(model, validate)
               end

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_deserializer.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_deserializer.rb
@@ -80,7 +80,7 @@ module MultiTenancy
             model.skip_image_presence = true if SKIP_IMAGE_PRESENCE_VALIDATION.include?(model_class.name)
 
             begin
-              preserve_ordering { save_model(model, validate) }
+              preserve_ordering(model) { save_model(model, validate) }
 
               # Only upload attributes that are strings are copied verbatim using
               # `update_columns` to bypass the CarrierWave uploader.
@@ -208,7 +208,7 @@ module MultiTenancy
         end
       end
 
-      def preserve_ordering
+      def preserve_ordering(model)
         if model.try(:in_list?)
           model.class.acts_as_list_no_update { yield }
         elsif model.class == Project # Support nested admin publications

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_deserializer.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_deserializer.rb
@@ -211,10 +211,10 @@ module MultiTenancy
       def preserve_ordering(model, &block)
         if model.try(:in_list?)
           model.class.acts_as_list_no_update(&block)
-        elsif model.class.instance_of?(Project) # Support nested admin publications
+        elsif model.instance_of? Project # Support nested admin publications
           AdminPublication.acts_as_list_no_update(&block)
         else
-          block.call
+          yield
         end
       end
 

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_deserializer.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_deserializer.rb
@@ -208,13 +208,13 @@ module MultiTenancy
         end
       end
 
-      def preserve_ordering(model)
+      def preserve_ordering(model, &block)
         if model.try(:in_list?)
-          model.class.acts_as_list_no_update { yield }
-        elsif model.class == Project # Support nested admin publications
-          AdminPublication.acts_as_list_no_update { yield }
+          model.class.acts_as_list_no_update(&block)
+        elsif model.class.instance_of?(Project) # Support nested admin publications
+          AdminPublication.acts_as_list_no_update(&block)
         else
-          yield
+          block.call
         end
       end
 

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_deserializer.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_deserializer.rb
@@ -141,7 +141,11 @@ module MultiTenancy
           elsif field_name.end_with?('_ref')
             ref_suffix = field_name.end_with?('_attributes_ref') ? '_attributes_ref' : '_ref' # linking attribute refs
             if field_value
-              id, ref_class = obj_to_id_and_class.fetch(field_value)
+              begin
+                id, ref_class = obj_to_id_and_class.fetch(field_value)
+              rescue KeyError
+                byebug
+              end
               new_attributes[field_name.chomp(ref_suffix)] = ref_class.find(id)
             end
 

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_deserializer.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_deserializer.rb
@@ -208,11 +208,11 @@ module MultiTenancy
         end
       end
 
-      def preserve_ordering(model, &block)
+      def preserve_ordering(model, &)
         if model.try(:in_list?)
-          model.class.acts_as_list_no_update(&block)
+          model.class.acts_as_list_no_update(&)
         elsif model.instance_of? Project # Support nested admin publications
-          AdminPublication.acts_as_list_no_update(&block)
+          AdminPublication.acts_as_list_no_update(&)
         else
           yield
         end

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_serializer.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_serializer.rb
@@ -36,7 +36,7 @@ module MultiTenancy
         users = User.where('invite_status IS NULL OR invite_status != ?', 'pending')
 
         {
-          AdminPublication => serialize_admin_publications(AdminPublication),
+          AdminPublication => serialize_admin_publications(AdminPublication), # Parked - validate publications: serialize_admin_publications(AdminPublication.where(parent_id: nil)),
           Area => serialize_records(Area),
           AreasProject => serialize_records(AreasProject),
           AreasStaticPage => serialize_records(AreasStaticPage),

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_serializer.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_serializer.rb
@@ -36,7 +36,7 @@ module MultiTenancy
         users = User.where('invite_status IS NULL OR invite_status != ?', 'pending')
 
         {
-          AdminPublication => serialize_admin_publications(AdminPublication.where(publication_type: 'ProjectFolders::Folder')),  
+          AdminPublication => serialize_admin_publications(AdminPublication.where(publication_type: 'ProjectFolders::Folder')),
           Area => serialize_records(Area),
           AreasProject => serialize_records(AreasProject),
           AreasStaticPage => serialize_records(AreasStaticPage),

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_serializer.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_serializer.rb
@@ -36,7 +36,7 @@ module MultiTenancy
         users = User.where('invite_status IS NULL OR invite_status != ?', 'pending')
 
         {
-          AdminPublication => serialize_admin_publications(AdminPublication.where(publication_type: 'ProjectFolders::Folder')),
+          AdminPublication => serialize_admin_publications(AdminPublication),
           Area => serialize_records(Area),
           AreasProject => serialize_records(AreasProject),
           AreasStaticPage => serialize_records(AreasStaticPage),
@@ -146,25 +146,10 @@ module MultiTenancy
       # @raise [TSort::Cyclic] if there is a circular dependency between the classes
       #   and the class cannot be sorted.
       def sort_by_references(models)
-        ref_dependencies_graph = extract_referential_dependencies(models)
+        graph = extract_dependencies_graph(models)
 
-        # User depends on CustomField because of the custom field values. We have to add
-        # this dependency manually because the custom field values are stored as JSON in
-        # the database, so serialized users don't hold references to CustomField.
-        if ref_dependencies_graph.key?(User) && ref_dependencies_graph.key?(CustomField)
-          ref_dependencies_graph[User] << CustomField
-        end
-
-        if ref_dependencies_graph.key?(AdminPublication)
-          ref_dependencies_graph[AdminPublication].delete Project
-        end
-
-        if ref_dependencies_graph.key?(Project) && ref_dependencies_graph.key?(AdminPublication)
-          ref_dependencies_graph[Project] << AdminPublication
-        end
-
-        each_node = ->(&b) { ref_dependencies_graph.each_key(&b) }
-        each_child = ->(n, &b) { ref_dependencies_graph.fetch(n).each(&b) }
+        each_node = ->(&process_node) { graph.each_key(&process_node) }
+        each_child = ->(node, &process_child) { graph.fetch(node).each(&process_child) }
 
         sorted_classes = TSort.tsort(each_node, each_child)
         models.slice(*sorted_classes)
@@ -180,14 +165,29 @@ module MultiTenancy
       #   }
       #
       # @return [Hash<Class, Array<Class>>]
-      def extract_referential_dependencies(models)
-        models.transform_values do |records|
+      def extract_dependencies_graph(models)
+        graph = models.transform_values do |records|
           records.flat_map do |_id, attributes|
             attributes.values.filter do |value|
               value.is_a?(Serializers::Core::Ref) && value.id
             end.map(&:klass)
           end.uniq
         end
+
+        # User depends on CustomField because of the custom field values. We have to add
+        # this dependency manually because the custom field values are stored as JSON in
+        # the database, so serialized users don't hold references to CustomField.
+        if graph.key?(User) && graph.key?(CustomField)
+          graph[User] << CustomField
+        end
+
+        # Support nested admin publications
+        if graph.key?(AdminPublication)
+          graph[AdminPublication].delete Project
+          graph[Project] << AdminPublication if graph.key?(Project)
+        end
+
+        graph
       end
 
       # Replace the Ref objects in the models hash with actual references to the
@@ -227,7 +227,10 @@ module MultiTenancy
 
       def serialize_admin_publications(scope)
         # This code will stop working when folders can contain folders
-        serialize_records(scope.order(parent_id: :desc, ordering: :asc))
+        scope = scope
+          .where(publication_type: 'ProjectFolders::Folder') # Support nested admin publications
+          .order(parent_id: :desc, ordering: :asc)
+        serialize_records scope
       end
 
       def serialize_comments(*post_scopes)

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_serializer.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_serializer.rb
@@ -36,7 +36,7 @@ module MultiTenancy
         users = User.where('invite_status IS NULL OR invite_status != ?', 'pending')
 
         {
-          AdminPublication => serialize_admin_publications(AdminPublication), # Parked - validate publications: serialize_admin_publications(AdminPublication.where(parent_id: nil)),
+          AdminPublication => serialize_admin_publications(AdminPublication.where(parent_id: nil)),
           Area => serialize_records(Area),
           AreasProject => serialize_records(AreasProject),
           AreasStaticPage => serialize_records(AreasStaticPage),
@@ -153,6 +153,10 @@ module MultiTenancy
         # the database, so serialized users don't hold references to CustomField.
         if ref_dependencies_graph.key?(User) && ref_dependencies_graph.key?(CustomField)
           ref_dependencies_graph[User] << CustomField
+        end
+
+        if ref_dependencies_graph.key?(Project) && ref_dependencies_graph.key?(ProjectFolders::Folder)
+          ref_dependencies_graph[Project] << ProjectFolders::Folder
         end
 
         each_node = ->(&b) { ref_dependencies_graph.each_key(&b) }

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_serializer.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_serializer.rb
@@ -36,7 +36,7 @@ module MultiTenancy
         users = User.where('invite_status IS NULL OR invite_status != ?', 'pending')
 
         {
-          AdminPublication => serialize_admin_publications(AdminPublication.where(parent_id: nil)),
+          AdminPublication => serialize_admin_publications(AdminPublication.where(publication_type: 'ProjectFolders::Folder')),  
           Area => serialize_records(Area),
           AreasProject => serialize_records(AreasProject),
           AreasStaticPage => serialize_records(AreasStaticPage),
@@ -155,8 +155,12 @@ module MultiTenancy
           ref_dependencies_graph[User] << CustomField
         end
 
-        if ref_dependencies_graph.key?(Project) && ref_dependencies_graph.key?(ProjectFolders::Folder)
-          ref_dependencies_graph[Project] << ProjectFolders::Folder
+        if ref_dependencies_graph.key?(AdminPublication)
+          ref_dependencies_graph[AdminPublication].delete Project
+        end
+
+        if ref_dependencies_graph.key?(Project) && ref_dependencies_graph.key?(AdminPublication)
+          ref_dependencies_graph[Project] << AdminPublication
         end
 
         each_node = ->(&b) { ref_dependencies_graph.each_key(&b) }

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/carrierwave_recreate_image_versions.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/carrierwave_recreate_image_versions.rake
@@ -24,7 +24,7 @@ namespace :carrierwave do
   # docker exec -it -e MODEL_CONFIGS='[{"class": "AppConfiguration", "attributes": { "logo": ["small", "medium"], "favicon": [] } }, {"class": "ProjectImage", "attributes": { "image": [] } }]' "$(docker ps | awk '/web/ {print $1}' | head -1)" bin/rails carrierwave:recreate_image_versions
   #
   task recreate_image_versions: :environment do
-    Tenant.switch_each do |tenant|
+    Tenant.safe_switch_each do |tenant|
       puts("Enqueueing #{tenant.host} RecreateVersionsJob")
 
       JSON.parse(ENV.fetch('MODEL_CONFIGS')).each do |model_config|

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/migrate.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/migrate.rake
@@ -3,7 +3,7 @@
 namespace :migrate do
   desc 'Define the default confirmation required value for existing users'
   task confirmation_required: %i[environment] do |_t, _args|
-    Tenant.switch_each do
+    Tenant.safe_switch_each do
       registered_users = User.registered
       user_ids = registered_users.reject(&:should_require_confirmation?).map(&:id)
 

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/setup_and_support.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/setup_and_support.rake
@@ -299,7 +299,7 @@ namespace :setup_and_support do
     old_secret = args[:old_secret]
     new_secret = args[:new_secret]
 
-    Tenant.switch_each do
+    Tenant.safe_switch_each do
       puts "Updating tenant #{Tenant.current.host}"
       settings = AppConfiguration.instance.settings
 
@@ -320,7 +320,7 @@ namespace :setup_and_support do
 
   desc 'Set custom map tile provider to null if it is the default'
   task remove_vanilla_tile_providers: [:environment] do |_t|
-    Tenant.switch_each do
+    Tenant.safe_switch_each do
       puts "Updating tenant #{Tenant.current.host}"
       settings = AppConfiguration.instance.settings
 

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/update_custom_field.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/update_custom_field.rake
@@ -26,7 +26,7 @@ namespace :cl2back do
 
     puts "live_run: #{live_run ? 'true' : 'false'}"
 
-    Tenant.switch_each do |tenant|
+    Tenant.safe_switch_each do |tenant|
       puts "Processing tenant: #{tenant.name}..."
 
       field = CustomField.find_by(key: field_key)

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/update_custom_field_option.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/update_custom_field_option.rake
@@ -26,7 +26,7 @@ namespace :cl2back do
 
     puts "live_run: #{live_run ? 'true' : 'false'}"
 
-    Tenant.switch_each do |tenant|
+    Tenant.safe_switch_each do |tenant|
       puts "Processing tenant: #{tenant.name}..."
 
       option = CustomFieldOption.find_by(key: option_key)
@@ -58,7 +58,7 @@ namespace :cl2back do
 
     puts "live_run: #{live_run ? 'true' : 'false'}"
 
-    Tenant.switch_each do |tenant|
+    Tenant.safe_switch_each do |tenant|
       puts "Processing tenant: #{tenant.name}..."
 
       option = CustomFieldOption.find_by(key: option_key)

--- a/back/engines/commercial/multi_tenancy/spec/services/multi_tenancy/templates/tenant_serializer_spec.rb
+++ b/back/engines/commercial/multi_tenancy/spec/services/multi_tenancy/templates/tenant_serializer_spec.rb
@@ -90,7 +90,7 @@ describe MultiTenancy::Templates::TenantSerializer do
         tenant.switch do
           MultiTenancy::Templates::TenantDeserializer.new.deserialize(template)
         end
-      end.to raise_error
+      end.to raise_error(NoMethodError) # Error class subject to change
     end
 
     it 'can deal with missing authors' do

--- a/back/engines/commercial/multi_tenancy/spec/services/multi_tenancy/templates/tenant_serializer_spec.rb
+++ b/back/engines/commercial/multi_tenancy/spec/services/multi_tenancy/templates/tenant_serializer_spec.rb
@@ -50,20 +50,48 @@ describe MultiTenancy::Templates::TenantSerializer do
       expect(home_attributes['title_multiloc']).to be_blank
     end
 
-    # it 'can deal with projects without admin publication' do
-    #   # The changes introduced by ticket CL-793 can be
-    #   # reverted once the issue with projects losing their
-    #   # admin publications is solved.
+    it 'can deal with nested admin publications in projects' do
+      create(:project, title_multiloc: { 'en' => 'top-project' })
+      create(
+        :project,
+        title_multiloc: { 'en' => 'nested-project' },
+        folder: create(:project_folder, title_multiloc: { 'en' => 'folder' }).tap do |folder|
+          folder.admin_publication.move_to_bottom
+        end
+      )
 
-    #   project = create(:project)
-    #   project.admin_publication.delete
-    #   expect(project.reload).to be_present
+      serializer = described_class.new(Tenant.current, uploads_full_urls: true)
+      template = serializer.run(deserializer_format: true)
 
-    #   template = tenant_serializer.run(deserializer_format: true)
+      tenant = create(:tenant, locales: AppConfiguration.instance.settings('core', 'locales'))
+      tenant.switch do
+        MultiTenancy::Templates::TenantDeserializer.new.deserialize(template)
+        expect(Project.count).to eq 2
+        expect(AdminPublication.count).to eq 3
+        expect(ProjectFolders::Folder.count).to eq 1
+        top_project = Project.find_by(title_multiloc: { 'en' => 'top-project' })
+        folder = ProjectFolders::Folder.find_by(title_multiloc: { 'en' => 'folder' })
+        nested_project = Project.find_by(title_multiloc: { 'en' => 'nested-project' })
+        expect(top_project.admin_publication.ordering).to eq 0
+        expect(folder.admin_publication.ordering).to eq 1
+        expect(nested_project.admin_publication.ordering).to eq 0
+        expect(nested_project.folder).to eq folder
+      end
+    end
 
-    #   expect(template['models']).to be_present
-    #   expect(template.dig('models', 'project', 0, 'admin_publication_attributes')).to be_nil
-    # end
+    it "fails when there's a missing publication" do
+      create(:project).admin_publication.delete
+
+      expect do
+        serializer = described_class.new(Tenant.current, uploads_full_urls: true)
+        template = serializer.run(deserializer_format: true)
+
+        tenant = create(:tenant, locales: AppConfiguration.instance.settings('core', 'locales'))
+        tenant.switch do
+          MultiTenancy::Templates::TenantDeserializer.new.deserialize(template)
+        end
+      end.to raise_error
+    end
 
     it 'can deal with missing authors' do
       idea = create(:idea, author: nil)

--- a/back/engines/commercial/multi_tenancy/spec/services/multi_tenancy/templates/tenant_serializer_spec.rb
+++ b/back/engines/commercial/multi_tenancy/spec/services/multi_tenancy/templates/tenant_serializer_spec.rb
@@ -50,20 +50,20 @@ describe MultiTenancy::Templates::TenantSerializer do
       expect(home_attributes['title_multiloc']).to be_blank
     end
 
-    it 'can deal with projects without admin publication' do
-      # The changes introduced by ticket CL-793 can be
-      # reverted once the issue with projects losing their
-      # admin publications is solved.
+    # it 'can deal with projects without admin publication' do
+    #   # The changes introduced by ticket CL-793 can be
+    #   # reverted once the issue with projects losing their
+    #   # admin publications is solved.
 
-      project = create(:project)
-      project.admin_publication.delete
-      expect(project.reload).to be_present
+    #   project = create(:project)
+    #   project.admin_publication.delete
+    #   expect(project.reload).to be_present
 
-      template = tenant_serializer.run(deserializer_format: true)
+    #   template = tenant_serializer.run(deserializer_format: true)
 
-      expect(template['models']).to be_present
-      expect(template.dig('models', 'project', 0, 'admin_publication_attributes')).to be_nil
-    end
+    #   expect(template['models']).to be_present
+    #   expect(template.dig('models', 'project', 0, 'admin_publication_attributes')).to be_nil
+    # end
 
     it 'can deal with missing authors' do
       idea = create(:idea, author: nil)

--- a/back/engines/commercial/multi_tenancy/spec/tasks/email_campaigns_task_spec.rb
+++ b/back/engines/commercial/multi_tenancy/spec/tasks/email_campaigns_task_spec.rb
@@ -15,7 +15,7 @@ describe 'rake email_campaigns' do
     it 'enqueues a TriggerOnScheduleJob for every tenant' do
       t = Time.zone.now
       travel_to(t) do
-        create(:tenant)
+        create(:test_tenant, host: 'test.govocal.com')
 
         expect { task.execute }
           .to have_enqueued_job(EmailCampaigns::TriggerOnScheduleJob)

--- a/back/lib/tasks/single_use/20220123_remove_unused_project_images.rake
+++ b/back/lib/tasks/single_use/20220123_remove_unused_project_images.rake
@@ -10,7 +10,7 @@ namespace :single_use do
     live_run = !!ActiveModel::Type::Boolean.new.cast(args[:live_run])
     puts "Live run: #{live_run}"
 
-    Tenant.switch_each do |tenant|
+    Tenant.safe_switch_each do |tenant|
       puts "Processing tenant #{tenant.host}"
 
       ids = Project.joins(:project_images).group('projects.id')

--- a/back/lib/tasks/single_use/20230828_populate_initiative_posting_tips.rake
+++ b/back/lib/tasks/single_use/20230828_populate_initiative_posting_tips.rake
@@ -7,7 +7,7 @@ namespace :single_use do
   # docker-compose run --rm web bin/rails 'single_use:populate_initiative_posting_tips'
   task populate_initiative_posting_tips: :environment do |_t, _args|
     locale_files = {}
-    Tenant.switch_each do |_tenant|
+    Tenant.safe_switch_each do |_tenant|
       posting_tips = {}
       app_config = AppConfiguration.instance
 
@@ -30,7 +30,7 @@ namespace :single_use do
 
   # We need to have this copy in the BE code for defaults.
   task populate_initiative_posting_tips_from_be_locales: :environment do |_t, _args|
-    Tenant.switch_each do |_tenant|
+    Tenant.safe_switch_each do |_tenant|
       app_config = AppConfiguration.instance
       app_config.settings['initiatives']['posting_tips'] =
         MultilocService.new.i18n_to_multiloc(

--- a/back/lib/tasks/single_use/20240220_move_ideation_custom_forms_to_project.rake
+++ b/back/lib/tasks/single_use/20240220_move_ideation_custom_forms_to_project.rake
@@ -5,7 +5,7 @@ namespace :single_use do
   # project. The ideation custom forms should always be associated with a project unlike
   # custom forms that implement native surveys.
   task move_ideation_custom_forms_to_project: :environment do
-    Tenant.switch_each do |tenant|
+    Tenant.safe_switch_each do |tenant|
       custom_forms = CustomForm.where(participation_context_type: 'Phase')
       ActiveRecord::Associations::Preloader.new(
         records: custom_forms,


### PR DESCRIPTION
- Use `safe_switch_each` so that we reduce chances of errors when sending scheduled emails (for example this can happen when a tenant was deleted while looping through the tenants)
- The issue was caused by a project without admin publication. The data issue was fixed by deleting the project and this Metabase question can be monitored (manually) to detect future occurrences: https://metabase.hq.citizenlab.co/question/2039-projects-without-admin-publications
- Add an assertion to the PATCH projects endpoint to detect if other projects lost their admin publication. Looking at the data, it seems that locally copied projects can lose their publication when updating their source project.
- I tried to have the model validations for the presence of the admin publication enabled at all time. It was disabled during template application, which caused the inconsistent data to replicate fast. We want template application to fail instead. I thereby made changes to the template code to support nested attributes (admin publication and project require each other and therefore should be created simultaneously), which got a little bit messy (especially to preserve ordering). It didn't work for folders, mainly because nested attributes (admin publications) would need to reference other nested attributes (their parent publications).

If the template changes are too messy, we could instead consider running the inconsistent data checker after templates are applied.
