### PR TITLE
Fix e2e test results not saving in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -681,7 +681,7 @@ jobs:
   e2e-tests:
     docker:
       - image: cimg/base:2021.03
-    parallelism: 3
+    parallelism: 1
     working_directory: ~/citizenlab
     resource_class: medium+
     steps:
@@ -712,18 +712,16 @@ jobs:
           docker-compose run front curl --retry 2 --retry-delay 5 --retry-connrefused -v http://e2e.front:3000
       - run: |
           cd front
+          mkdir -p reports
           TESTFILES=$(circleci tests glob "cypress/e2e/**/*.cy.ts" | circleci tests split  --split-by=timings)
           COMMA_SEPARATED_TESTFILES=$(echo $TESTFILES | sed 's/ /,/g')
           echo $COMMA_SEPARATED_TESTFILES
           cd ../e2e
-          docker-compose run --name cypress_run front npm run cypress:run -- --config baseUrl=http://e2e.front:3000 --spec ${COMMA_SEPARATED_TESTFILES}
-      # Uncomment to save XML reports
-      # docker-compose run --name cypress_run front npm run cypress:run -- --reporter junit --reporter-options "mochaFile=reports/cypress.xml,toConsole=true" --config baseUrl=http://e2e.front:3000 --spec ${COMMA_SEPARATED_TESTFILES}
+          docker-compose run --name cypress_run front npm run cypress:run -- --reporter junit --reporter-options "mochaFile=../front/reports/cypress.xml" --config baseUrl=http://e2e.front:3000 --spec cypress/e2e/about_page.cy.ts
       # We run cypress tests in container, so we need to copy the results out.
-      # ToDo: fix it. Reporting doesn't work atm.
-      # - run: |
-      #     mkdir -p front/reports
-      #     docker cp cypress_run:/front/reports/cypress.xml front/reports/cypress.xml
+      - run: |
+          mkdir -p front/reports
+          docker cp cypress_run:/front/reports/cypress.xml front/reports/cypress.xml
       - run:
           command: docker cp cypress_run:/front/cypress/screenshots .
           # If `when: always`, it fails on success with

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -681,7 +681,7 @@ jobs:
   e2e-tests:
     docker:
       - image: cimg/base:2021.03
-    parallelism: 1
+    parallelism: 3
     working_directory: ~/citizenlab
     resource_class: medium+
     steps:
@@ -717,7 +717,7 @@ jobs:
           COMMA_SEPARATED_TESTFILES=$(echo $TESTFILES | sed 's/ /,/g')
           echo $COMMA_SEPARATED_TESTFILES
           cd ../e2e
-          docker-compose run --name cypress_run front npm run cypress:run -- --reporter junit --reporter-options "mochaFile=../front/reports/cypress.xml" --config baseUrl=http://e2e.front:3000 --spec cypress/e2e/about_page.cy.ts
+          docker-compose run --name cypress_run front npm run cypress:run -- --reporter junit --reporter-options "mochaFile=../front/reports/cypress.xml" --config baseUrl=http://e2e.front:3000 --spec ${COMMA_SEPARATED_TESTFILES}
       # We run cypress tests in container, so we need to copy the results out.
       - run: |
           mkdir -p front/reports


### PR DESCRIPTION
# Description
Fixed Cypress E2E test results not saving in CircleCI.

![image](https://github.com/CitizenLabDotCo/citizenlab/assets/33987955/9569ed3a-8152-400a-90a0-7cd8c6b7718a)
