### PR TITLE
Increase Go Vocal footer logo width

### DIFF
--- a/front/app/containers/PlatformFooter/index.tsx
+++ b/front/app/containers/PlatformFooter/index.tsx
@@ -182,7 +182,7 @@ const PoweredByText = styled.span`
 `;
 
 const GoVocalLink = styled.a`
-  width: 120px;
+  width: 140px;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
# Changelog
## Fixed
- Fixed Go Vocal logo in platform footer being cut off if wider than 120px
