### PR TITLE
TAN-2071 Fixes Woerden

### DIFF
--- a/front/app/components/ConsentManager/Banner.tsx
+++ b/front/app/components/ConsentManager/Banner.tsx
@@ -111,6 +111,9 @@ const Banner = ({ onAccept, onChangePreferences, onClose }: Props) => {
       tabIndex={0}
       role="dialog"
       id="e2e-cookie-banner"
+      // aria-labelledby helps screen readers find
+      // the title of the dialog
+      // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role
       aria-labelledby="cookie-banner-title"
     >
       <ContentContainer mode="page">

--- a/front/app/components/ConsentManager/Banner.tsx
+++ b/front/app/components/ConsentManager/Banner.tsx
@@ -107,10 +107,15 @@ interface Props {
 
 const Banner = ({ onAccept, onChangePreferences, onClose }: Props) => {
   return (
-    <Container tabIndex={0} role="dialog" id="e2e-cookie-banner">
+    <Container
+      tabIndex={0}
+      role="dialog"
+      id="e2e-cookie-banner"
+      aria-labelledby="cookie-banner-title"
+    >
       <ContentContainer mode="page">
         <ContentContainerInner>
-          <Left>
+          <Left id="cookie-banner-title">
             <FormattedMessage
               {...messages.mainText}
               values={{

--- a/front/app/components/ConsentManager/PreferencesModal/index.tsx
+++ b/front/app/components/ConsentManager/PreferencesModal/index.tsx
@@ -63,8 +63,12 @@ const PreferencesModal = ({
           preferences={preferences}
         />
       ) : (
-        <ContentContainer role="dialog" aria-modal>
-          <Title variant="h5" as="h1">
+        <ContentContainer
+          role="dialog"
+          aria-modal
+          aria-labelledby="consent-manager-preferences-title"
+        >
+          <Title variant="h5" as="h1" id="consent-manager-preferences-title">
             <FormattedMessage {...messages.confirmation} />
           </Title>
         </ContentContainer>

--- a/front/app/components/ConsentManager/PreferencesModal/index.tsx
+++ b/front/app/components/ConsentManager/PreferencesModal/index.tsx
@@ -66,6 +66,9 @@ const PreferencesModal = ({
         <ContentContainer
           role="dialog"
           aria-modal
+          // aria-labelledby helps screen readers find
+          // the title of the dialog
+          // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role
           aria-labelledby="consent-manager-preferences-title"
         >
           <Title variant="h5" as="h1" id="consent-manager-preferences-title">

--- a/front/app/containers/Admin/sideBar/index.tsx
+++ b/front/app/containers/Admin/sideBar/index.tsx
@@ -148,6 +148,11 @@ const Sidebar = ({ authUser }: Props) => {
       <Outlet id="app.containers.Admin.sideBar.navItems" onData={handleData} />
       <MenuInner id="sidebar">
         <Box w="100%">
+          {/* The aria-label here is used when there is no clear
+           * 'text-like' element as a child of the Link component,
+           * making it unclear for screen readers what the link point to.
+           * https://stackoverflow.com/a/53765144/7237112
+           */}
           <Link to="/" aria-label={formatMessage(messages.toPlatform)}>
             <Box
               height={

--- a/front/app/containers/Admin/sideBar/index.tsx
+++ b/front/app/containers/Admin/sideBar/index.tsx
@@ -148,7 +148,7 @@ const Sidebar = ({ authUser }: Props) => {
       <Outlet id="app.containers.Admin.sideBar.navItems" onData={handleData} />
       <MenuInner id="sidebar">
         <Box w="100%">
-          <Link to="/">
+          <Link to="/" aria-label={formatMessage(messages.toPlatform)}>
             <Box
               height={
                 isPagesAndMenuPage ? `${stylingConsts.menuHeight}px` : '60px'

--- a/front/app/containers/MainHeader/Components/TenantLogo/index.tsx
+++ b/front/app/containers/MainHeader/Components/TenantLogo/index.tsx
@@ -28,7 +28,11 @@ const TenantLogo = () => {
 
     if (tenantLogo) {
       return (
-        <Link to="/" onlyActiveOnIndex={true}>
+        <Link
+          to="/"
+          onlyActiveOnIndex={true}
+          aria-label={formatMessage(messages.logoAltText)}
+        >
           <Logo src={tenantLogo} alt={formatMessage(messages.logoAltText)} />
         </Link>
       );

--- a/front/app/containers/MainHeader/Components/TenantLogo/index.tsx
+++ b/front/app/containers/MainHeader/Components/TenantLogo/index.tsx
@@ -31,6 +31,11 @@ const TenantLogo = () => {
         <Link
           to="/"
           onlyActiveOnIndex={true}
+          /* The aria-label here is used when there is no clear
+           * 'text-like' element as a child of the Link component,
+           * making it unclear for screen readers what the link point to.
+           * https://stackoverflow.com/a/53765144/7237112
+           */
           aria-label={formatMessage(messages.logoAltText)}
         >
           <Logo src={tenantLogo} alt={formatMessage(messages.logoAltText)} />


### PR DESCRIPTION
# Changelog
## Technical
- Added `aria-labelledby` to all elements with `role="dialog"` that didn't have a label yet (https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role)
- Added `aria-label` to all `Link`s that didn't have a clear 'text'-like element as a child, making it hard for screenreaders to know what it links to (https://stackoverflow.com/questions/53761939/why-do-my-links-not-have-a-discernable-name/53765144#53765144)