### PR TITLE
[TAN-2125] Fix attachments not visible on voting idea page mobile

### DIFF
--- a/front/app/containers/IdeasShow/index.tsx
+++ b/front/app/containers/IdeasShow/index.tsx
@@ -140,20 +140,17 @@ export const IdeasShow = ({
               translateButtonClicked={translateButtonIsClicked}
             />
           </Box>
-          {compact &&
-            participationContext?.attributes.participation_method !==
-              'voting' && // To reduce bias we want to hide the author data during voting methods
-            statusId && (
-              <Box my="24px">
-                <MetaInformation
-                  ideaId={ideaId}
-                  projectId={project.data.id}
-                  statusId={statusId}
-                  authorId={authorId}
-                  compact={compact}
-                />
-              </Box>
-            )}
+          {compact && statusId && (
+            <Box my="24px">
+              <MetaInformation
+                ideaId={ideaId}
+                projectId={project.data.id}
+                statusId={statusId}
+                authorId={authorId}
+                compact={compact}
+              />
+            </Box>
+          )}
           <Box my={compact ? '24px' : '80px'}>
             <OfficialFeedback
               postId={ideaId}


### PR DESCRIPTION
# Changelog
## Fixed
- [[TAN-2125](https://www.notion.so/citizenlab/In-idea-cards-on-phones-the-attachments-are-not-visible-86a23448387f45e9a67cc641d2e41717?d=5d9b180c57d34ab78102b02de65e0d31#86a23448387f45e9a67cc641d2e41717)] Fixed attachments not visible on voting idea page (mobile).
