### PR TITLE
[TAN-2128] Don't send email confirmation to empty email

### DIFF
--- a/back/app/jobs/request_confirmation_code_job.rb
+++ b/back/app/jobs/request_confirmation_code_job.rb
@@ -19,11 +19,9 @@ class RequestConfirmationCodeJob < ApplicationJob
 
     ActiveRecord::Base.transaction do
       user.save!
-      if user.email.present?
-        deliver_confirmation_code! user
-        schedule_code_expiration! user
-        LogActivityJob.perform_later(user, 'received_confirmation_code', user, Time.now.to_i, payload: { new_email: new_email })
-      end
+      deliver_confirmation_code!(user)
+      schedule_code_expiration! user
+      LogActivityJob.perform_later(user, 'received_confirmation_code', user, Time.now.to_i, payload: { new_email: new_email })
     end
   end
 
@@ -36,7 +34,7 @@ class RequestConfirmationCodeJob < ApplicationJob
   end
 
   def deliver_confirmation_code!(user)
-    ConfirmationsMailer.with(user: user).send_confirmation_code.deliver_now
+    ConfirmationsMailer.with(user: user).send_confirmation_code.deliver_now if user.email.present?
     user.update!(email_confirmation_code_sent_at: Time.zone.now)
   end
 

--- a/back/app/jobs/request_confirmation_code_job.rb
+++ b/back/app/jobs/request_confirmation_code_job.rb
@@ -19,9 +19,11 @@ class RequestConfirmationCodeJob < ApplicationJob
 
     ActiveRecord::Base.transaction do
       user.save!
-      deliver_confirmation_code! user
-      schedule_code_expiration! user
-      LogActivityJob.perform_later(user, 'received_confirmation_code', user, Time.now.to_i, payload: { new_email: new_email })
+      if user.email.present?
+        deliver_confirmation_code! user
+        schedule_code_expiration! user
+        LogActivityJob.perform_later(user, 'received_confirmation_code', user, Time.now.to_i, payload: { new_email: new_email })
+      end
     end
   end
 


### PR DESCRIPTION
# Changelog
## Fixed
* [TAN-2128] Don't send email confirmation to empty email
