### PR TITLE
[TAN-1331] Permit any cross-origin requests in development environment

### DIFF
--- a/back/config/environments/development.rb
+++ b/back/config/environments/development.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
   # [] => Cross-origin requests are NOT allowed from any origin.
   # ['*'] => Cross-origin requests from any origin are allowed.
   # ['http://some-domain.com', 'https://other-domain.com'] => Cross-origin requests are allowed from specified origins.
-  config.allowed_cors_origins = []
+  config.allowed_cors_origins = ['*']
 
   # In the development environment your application's code is reloaded any time
   # it changes. This slows down response time but is perfect for development


### PR DESCRIPTION
I noticed that, since merging #7431, we get CORS errors when attempting to fetch related images in the project edit view. 

This fixes that issue, without investigating exactly why this happens only in specific cases. e.g. why in this case, but not when fetching images in the homepage view, for example.

<img width="2056" alt="Screenshot 2024-06-19 at 17 15 38" src="https://github.com/CitizenLabDotCo/citizenlab/assets/3944042/97d79d2c-6050-4349-ad52-0cb6e1a4880f">

# Changelog
## Technical
- [TAN-1331] Permit any cross-origin requests in development environment
