### PR TITLE
Fix map input fullscreen view crashing

### DIFF
--- a/front/app/components/Form/Components/Controls/PointControl/Mobile/FullscreenMapInput.tsx
+++ b/front/app/components/Form/Components/Controls/PointControl/Mobile/FullscreenMapInput.tsx
@@ -157,7 +157,7 @@ const FullscreenMapInput = memo<Props>(
               >
                 <Box>
                   <FormLabel
-                    htmlFor={sanitizeForClassname(id)}
+                    htmlFor={id && sanitizeForClassname(id)}
                     labelValue={getLabel(uischema, schema, path)}
                     optional={!required}
                   />


### PR DESCRIPTION
# Description
Looks like we're assuming there is an ID prop when there isn't always one. Changed this to an optional check first to fix the issue.
