### PR TITLE
[TAN-1414] Fix scrolling issue across survey pages

### DIFF
--- a/front/app/components/Form/Components/Layouts/CLSurveyPageLayout.tsx
+++ b/front/app/components/Form/Components/Layouts/CLSurveyPageLayout.tsx
@@ -136,7 +136,9 @@ const CLSurveyPageLayout = memo(
     const scrollToTop = () => {
       // Scroll inner container to top
       if (pagesRef?.current) {
-        pagesRef.current.scrollTop = 0;
+        pagesRef.current.scrollIntoView({
+          block: 'start',
+        });
       }
     };
 


### PR DESCRIPTION
# Description
Fixes scrolling issue across survey pages where it doesn't load at the top of the next page.

# Changelog
## Fixed
* [[TAN-1414](https://www.notion.so/citizenlab/When-switching-between-pages-in-a-survey-the-user-lands-at-random-positions-instead-of-on-top-d4bd37ae1c92404596008f5af4ec3ddd?d=77a0fc60d738429a957c9a4141b1c916)] Fix issue for surveys where going to next page didn't scroll the user to the top of the page.
