### PR TITLE
TAN-2050 Add google site verification meta token through tenant settings

### DIFF
--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -119,6 +119,11 @@
             "description": "The description of the platform shown in search engine results and when shared on some social media platforms.",
             "$ref": "#/definitions/multiloc_string"
           },
+          "google_search_console_meta_attribute": {
+            "title": "Google Search Console Meta Attribute",
+            "description": "Set this token to verify the ownership of the platform in Google Search Console. The value you should set is the content of the \"content\"= HTML tag attribute in meta tag Google provides.",
+            "type": ["string", "null"]
+          },
           "custom_onboarding_message": {
             "title": "Header Banner Call-to-Action Text",
             "description": "Optional Call-to-Action text for signed in users, shown on a banner on the top of the homepage. Accompanied by a Call-to-Action (CTA) button. If this field is left blank, 'Header banner non-call to action' text is shown in the banner.",

--- a/back/engines/commercial/multi_tenancy/db/seeds/tenants.rb
+++ b/back/engines/commercial/multi_tenancy/db/seeds/tenants.rb
@@ -32,7 +32,8 @@ module MultiTenancy
               maximum_moderators_number: 2,
               additional_admins_number: 1,
               additional_moderators_number: 1,
-              population: 27_500
+              population: 27_500,
+              google_search_console_meta_attribute: 'fake_meta_attribute'
             },
             password_login: {
               allowed: true,

--- a/front/app/api/app_configuration/types.ts
+++ b/front/app/api/app_configuration/types.ts
@@ -35,6 +35,7 @@ export type IAppConfigurationSettingsCore = {
     | 'not_applicable';
   meta_title?: Multiloc | null;
   meta_description?: Multiloc | null;
+  google_search_console_meta_attribute?: string | null;
   signup_helper_text?: Multiloc | null;
   custom_fields_signup_helper_text?: Multiloc | null;
   color_main: string | null;

--- a/front/app/containers/App/Meta.tsx
+++ b/front/app/containers/App/Meta.tsx
@@ -15,7 +15,7 @@ import { useIntl } from 'utils/cl-intl';
 import getAlternateLinks from 'utils/cl-router/getAlternateLinks';
 import getCanonicalLink from 'utils/cl-router/getCanonicalLink';
 import { imageSizes } from 'utils/fileUtils';
-import { isNil, isNilOrError } from 'utils/helperUtils';
+import { isNilOrError } from 'utils/helperUtils';
 
 import messages from './messages';
 
@@ -80,7 +80,7 @@ const Meta = () => {
         {getAlternateLinks(tenantLocales)}
         <meta name="title" content={metaTitle} />
         <meta name="description" content={metaDescription} />
-        {!isNil(googleSearchConsoleMetaAttribute) && (
+        {googleSearchConsoleMetaAttribute && (
           <meta
             name="google-site-verification"
             content={googleSearchConsoleMetaAttribute}

--- a/front/app/containers/App/Meta.tsx
+++ b/front/app/containers/App/Meta.tsx
@@ -15,7 +15,7 @@ import { useIntl } from 'utils/cl-intl';
 import getAlternateLinks from 'utils/cl-router/getAlternateLinks';
 import getCanonicalLink from 'utils/cl-router/getCanonicalLink';
 import { imageSizes } from 'utils/fileUtils';
-import { isNilOrError } from 'utils/helperUtils';
+import { isNil, isNilOrError } from 'utils/helperUtils';
 
 import messages from './messages';
 
@@ -57,6 +57,8 @@ const Meta = () => {
     let metaDescription = localize(metaDescriptionMultiLoc);
     metaDescription =
       metaDescription || formatMessage(messages.appMetaDescription);
+    const googleSearchConsoleMetaAttribute =
+      tenant.data.attributes.settings.core.google_search_console_meta_attribute;
 
     const lifecycleStage = tenant.data.attributes.settings.core.lifecycle_stage;
     const blockIndexing = !['active', 'churned'].includes(lifecycleStage);
@@ -78,6 +80,12 @@ const Meta = () => {
         {getAlternateLinks(tenantLocales)}
         <meta name="title" content={metaTitle} />
         <meta name="description" content={metaDescription} />
+        {!isNil(googleSearchConsoleMetaAttribute) && (
+          <meta
+            name="google-site-verification"
+            content={googleSearchConsoleMetaAttribute}
+          />
+        )}
         <meta property="og:title" content={metaTitle} />
         <meta property="og:type" content="website" />
         <meta property="og:description" content={metaDescription} />


### PR DESCRIPTION
# Changelog
## Added
- It is now possible to verify a platform in Google Search Console by manually setting the meta tag attribute Google provides in Admin HQ
