### PR TITLE
[TAN-1939] Remove scientist experiment

### DIFF
--- a/back/app/models/app_configuration.rb
+++ b/back/app/models/app_configuration.rb
@@ -104,7 +104,8 @@ class AppConfiguration < ApplicationRecord
     private(
       :find_by, :find_by!, :find_or_create_by, :find_or_create_by!,
       :first, :first!,
-      :last, :last!
+      :last, :last!,
+      :update, :update!, :update_all
     )
 
     def instance

--- a/back/app/models/app_configuration.rb
+++ b/back/app/models/app_configuration.rb
@@ -91,8 +91,6 @@ class AppConfiguration < ApplicationRecord
   end
 
   class << self
-    include Scientist
-
     # We prevent the direct instantiation of AppConfiguration, because it is a singleton.
     private :new
 
@@ -110,24 +108,7 @@ class AppConfiguration < ApplicationRecord
     )
 
     def instance
-      science 'app_configuration' do |experiment|
-        experiment.use { first! }
-        experiment.try { Current.app_configuration }
-
-        experiment.compare_errors do |control, candidate|
-          next true if control.instance_of?(candidate.class) && control.message == candidate.message
-          next true if control.instance_of?(ActiveRecord::RecordNotFound) && candidate.instance_of?(ActiveRecord::RecordNotFound)
-
-          false
-        end
-
-        experiment.clean(&:attributes)
-
-        experiment.context({
-          execution_stack: caller,
-          tenant_schema: Apartment::Tenant.current
-        })
-      end
+      Current.app_configuration
     end
   end
 

--- a/back/lib/rubocop/cop/forbidden_app_configuration_method.rb
+++ b/back/lib/rubocop/cop/forbidden_app_configuration_method.rb
@@ -21,6 +21,7 @@ module Rubocop
         find_each find_in_batches in_batches
         select reselect order in_order_of reorder limit offset
         where rewhere invert_where
+        update update! update_all
       ].to_set.freeze
 
       MSG = '`AppConfiguration.instance` should be used to access the app configuration.'


### PR DESCRIPTION
# Changelog
## Technical
- [TAN-1939] Removed the scientist experiment testing the caching of the AppConfiguration, now effectively using the cached version.
