### PR TITLE
[CL-4070] Introduce the AppConfiguration.timezone helper

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -157,6 +157,11 @@ gem 'combine_pdf', '~> 1.0.26'
 
 # Temporarily add nkf and mutex_m to the Gemfile to clear the following warnings:
 #   .../.rbenv/versions/3.3.1/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:
+#   warning: .../.rbenv/versions/3.3.1/lib/ruby/3.3.0/drb.rb was loaded from the standard
+#   library, but will no longer be part of the default gems since Ruby 3.4.0. Add drb to
+#   your Gemfile or gemspec. Also contact author of activesupport-7.0.8.4 to add drb into
+#   its gemspec.
+#   .../.rbenv/versions/3.3.1/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:
 #   warning: .../.rbenv/versions/3.3.1/lib/ruby/3.3.0/mutex_m.rb was loaded from
 #   the standard library, but will no longer be part of the default gems since Ruby 3.4.0.
 #   Add mutex_m to your Gemfile or gemspec. Also contact author of activesupport-7.0.8.4
@@ -166,8 +171,9 @@ gem 'combine_pdf', '~> 1.0.26'
 #   which will no longer be part of the default gems since Ruby 3.4.0. Add nkf to your
 #   Gemfile or gemspec. Also contact author of httpi-3.0.1 to add nkf into its gemspec.
 #
-# They are likely not direct dependencies, hence we can remove them once the dependent
-# gems are updated.
+# They are not direct dependencies, hence we can remove them once the dependent gems are
+# updated.
+gem 'drb'
 gem 'nkf'
 gem 'mutex_m'
 

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -555,6 +555,8 @@ GEM
     diff-lcs (1.5.1)
     docile (1.4.0)
     domain_name (0.6.20240107)
+    drb (2.2.0)
+      ruby2_keywords
     easy_translate (0.5.1)
       thread
       thread_safe
@@ -1268,6 +1270,7 @@ DEPENDENCIES
   dalli (~> 3.2.8)
   database_cleaner (~> 2.0.2)
   document_annotation!
+  drb
   email_campaigns!
   factory_bot_rails
   faker

--- a/back/app/controllers/web_api/v1/events_controller.rb
+++ b/back/app/controllers/web_api/v1/events_controller.rb
@@ -181,12 +181,7 @@ class WebApi::V1::EventsController < ApplicationController
     date_str = date_str.strip
     return nil if date_str.in?(['null', ''])
 
-    config_timezone.parse(date_str)
-  end
-
-  def config_timezone
-    timezone_str = AppConfiguration.instance.settings('core', 'timezone')
-    ActiveSupport::TimeZone[timezone_str] || (raise KeyError, timezone_str)
+    AppConfiguration.timezone.parse(date_str)
   end
 
   def default_locale

--- a/back/app/models/app_configuration.rb
+++ b/back/app/models/app_configuration.rb
@@ -129,6 +129,11 @@ class AppConfiguration < ApplicationRecord
         })
       end
     end
+
+    def timezone
+      timezone_str = instance.settings.dig('core', 'timezone')
+      ActiveSupport::TimeZone[timezone_str] or raise KeyError, timezone_str
+    end
   end
 
   # @return [AppConfiguration] self

--- a/back/app/services/activities_service.rb
+++ b/back/app/services/activities_service.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 class ActivitiesService
-  def create_periodic_activities(now: Time.zone.now, since: 1.hour)
-    now = Time.zone.at(now)
-    now = now.in_time_zone(AppConfiguration.instance.settings('core', 'timezone'))
+  def create_periodic_activities(now: Time.current, since: 1.hour)
+    now = AppConfiguration.timezone.at(now)
     last_time = now - since
 
     create_phase_started_activities now, last_time

--- a/back/app/services/events/ics_generator.rb
+++ b/back/app/services/events/ics_generator.rb
@@ -31,6 +31,7 @@ module Events
     end
 
     def add_event_to_calendar(cal, event, preferred_locale)
+      timezone = AppConfiguration.timezone
       start_time = event.start_at.in_time_zone(timezone)
       end_time = event.end_at.in_time_zone(timezone)
 
@@ -79,13 +80,6 @@ module Events
 
     def multiloc_service
       @multiloc_service ||= MultilocService.new
-    end
-
-    def timezone
-      @timezone ||= begin
-        timezone_name = AppConfiguration.instance.settings.dig('core', 'timezone')
-        ActiveSupport::TimeZone[timezone_name] || (raise KeyError, timezone_name)
-      end
     end
   end
 end

--- a/back/engines/commercial/analytics/app/services/analytics/matomo_data_importer.rb
+++ b/back/engines/commercial/analytics/app/services/analytics/matomo_data_importer.rb
@@ -9,10 +9,10 @@ module Analytics
     }
 
     # @param [Matomo::Client] matomo_client
-    # @param [String] timezone
+    # @param [ActiveSupport::TimeZone] timezone
     def initialize(matomo_client: nil, timezone: nil)
       @matomo_client = matomo_client || Matomo::Client.new
-      @timezone = timezone || AppConfiguration.instance.settings.dig('core', 'timezone')
+      @timezone = timezone || AppConfiguration.timezone
     end
 
     # @param [String] site_id Matomo site id
@@ -211,7 +211,7 @@ module Analytics
     end
 
     def timestamp_to_date(timestamp)
-      Time.at(timestamp).in_time_zone(@timezone).to_date
+      @timezone.at(timestamp).to_date
     end
   end
 end

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_deserializer.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_deserializer.rb
@@ -122,7 +122,7 @@ module MultiTenancy
       end
 
       def restore_template_attributes(attributes, obj_to_id_and_class, app_settings, model_class: nil)
-        start_of_day = Time.now.in_time_zone(app_settings.dig('core', 'timezone')).beginning_of_day
+        start_of_day = AppConfiguration.timezone.now.beginning_of_day
         locales = USER_INPUT_CLASSES.include?(model_class) ? app_settings.dig('core', 'locales') : all_supported_locales
 
         new_attributes = {}

--- a/back/engines/commercial/report_builder/spec/services/report_builder/queries/demographics_spec.rb
+++ b/back/engines/commercial/report_builder/spec/services/report_builder/queries/demographics_spec.rb
@@ -5,10 +5,9 @@ require 'rails_helper'
 RSpec.describe ReportBuilder::Queries::Demographics do
   subject(:query) { described_class.new(build(:admin)) }
 
-  let_it_be(:timezone) { AppConfiguration.instance.settings('core', 'timezone') }
-  let_it_be(:now) { Time.now.in_time_zone(timezone) }
-  let_it_be(:start_at) { (now - 1.year).in_time_zone(timezone).beginning_of_year }
-  let_it_be(:end_at) { (now - 1.year).in_time_zone(timezone).end_of_year }
+  let_it_be(:now) { AppConfiguration.timezone.now }
+  let_it_be(:start_at) { (now - 1.year).beginning_of_year }
+  let_it_be(:end_at) { (now - 1.year).end_of_year }
 
   describe '#run_query' do
     context 'select field' do

--- a/back/engines/commercial/user_custom_fields/spec/acceptance/stats_users_spec.rb
+++ b/back/engines/commercial/user_custom_fields/spec/acceptance/stats_users_spec.rb
@@ -37,10 +37,9 @@ end
 resource 'Stats - Users' do
   header 'Content-Type', 'application/json'
 
-  let_it_be(:timezone) { AppConfiguration.instance.settings('core', 'timezone') }
-  let_it_be(:now) { Time.now.in_time_zone(timezone) }
-  let_it_be(:start_at) { (now - 1.year).in_time_zone(timezone).beginning_of_year }
-  let_it_be(:end_at) { (now - 1.year).in_time_zone(timezone).end_of_year }
+  let_it_be(:now) { AppConfiguration.timezone.now }
+  let_it_be(:start_at) { (now - 1.year).beginning_of_year }
+  let_it_be(:end_at) { (now - 1.year).end_of_year }
 
   before_all do
     Tenant.current.update!(created_at: now - 2.years)

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/event_registration_confirmation_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/event_registration_confirmation_mailer.rb
@@ -32,11 +32,17 @@ module EmailCampaigns
     end
 
     def event_time
-      timezone_name = AppConfiguration.instance.settings.dig('core', 'timezone')
-      timezone = ActiveSupport::TimeZone[timezone_name] || (raise KeyError, timezone_name)
+      timezone = AppConfiguration.timezone
 
-      start_at = I18n.l(event.event_attributes.start_at.in_time_zone(timezone), format: :short, locale: locale.locale_sym)
-      end_at = I18n.l(event.event_attributes.end_at.in_time_zone(timezone), format: :short, locale: locale.locale_sym)
+      start_at = I18n.l(
+        timezone.at(event.event_attributes.start_at),
+        format: :short, locale: locale.locale_sym
+      )
+
+      end_at = I18n.l(
+        timezone.at(event.event_attributes.end_at),
+        format: :short, locale: locale.locale_sym
+      )
 
       "#{start_at} – #{end_at}"
     end

--- a/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/schedulable.rb
+++ b/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/schedulable.rb
@@ -14,8 +14,10 @@ module EmailCampaigns
     def filter_campaign_scheduled(time:, activity: nil)
       # TODO: prevent being here when time is nil
       # This happened when triggering comment on your comment notification
-      time = time&.in_time_zone(AppConfiguration.instance.settings('core', 'timezone'))
-      time && ic_schedule.occurs_between?(time - 30.minutes, time + 30.minutes)
+      return unless time
+
+      time = AppConfiguration.timezone.at(time)
+      ic_schedule.occurs_between?(time - 30.minutes, time + 30.minutes)
     end
 
     def ic_schedule
@@ -34,7 +36,7 @@ module EmailCampaigns
     # start_time, so we force it to be in the timezone from settings.
     def force_schedule_start_in_config_timezone
       ics = ic_schedule
-      ics.start_time = ics.start_time.in_time_zone(AppConfiguration.instance.settings('core', 'timezone'))
+      ics.start_time = AppConfiguration.timezone.at(ics.start_time)
       self.ic_schedule = ics
     end
 

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/admin_digest.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/admin_digest.rb
@@ -47,10 +47,14 @@ module EmailCampaigns
     N_TOP_IDEAS = 12
 
     def self.default_schedule
-      config_timezone = Time.find_zone(AppConfiguration.instance.settings('core', 'timezone'))
+      start_time = AppConfiguration.timezone.local(2019)
 
-      IceCube::Schedule.new(config_timezone.local(2019)) do |schedule|
-        every_monday_at10_am = IceCube::Rule.weekly(1).day(:monday).hour_of_day(10)
+      IceCube::Schedule.new(start_time) do |schedule|
+        every_monday_at10_am = IceCube::Rule
+          .weekly(1)
+          .day(:monday)
+          .hour_of_day(10)
+
         schedule.add_recurrence_rule(every_monday_at10_am)
       end
     end

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/assignee_digest.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/assignee_digest.rb
@@ -43,7 +43,9 @@ module EmailCampaigns
     N_TOP_IDEAS = 12
 
     def self.default_schedule
-      IceCube::Schedule.new(Time.find_zone(AppConfiguration.instance.settings('core', 'timezone')).local(2019)) do |s|
+      start_time = AppConfiguration.timezone.local(2019)
+
+      IceCube::Schedule.new(start_time) do |s|
         s.add_recurrence_rule(
           IceCube::Rule.weekly(1).day(:tuesday).hour_of_day(8)
         )

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/moderator_digest.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/moderator_digest.rb
@@ -49,7 +49,9 @@ module EmailCampaigns
     end
 
     def self.default_schedule
-      IceCube::Schedule.new(Time.find_zone(AppConfiguration.instance.settings('core', 'timezone')).local(2019)) do |s|
+      start_time = AppConfiguration.timezone.local(2019)
+
+      IceCube::Schedule.new(start_time) do |s|
         s.add_recurrence_rule(
           IceCube::Rule.weekly(1).day(:monday).hour_of_day(10)
         )

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/user_digest.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/user_digest.rb
@@ -47,7 +47,9 @@ module EmailCampaigns
 
     def self.default_schedule
       day, hour = [[:thursday, 13], [:saturday, 8]].sample
-      IceCube::Schedule.new(Time.find_zone(AppConfiguration.instance.settings('core', 'timezone')).local(2020)) do |s|
+      start_time = AppConfiguration.timezone.local(2020)
+
+      IceCube::Schedule.new(start_time) do |s|
         rule = IceCube::Rule.weekly(1).day(day).hour_of_day(hour)
         s.add_recurrence_rule(rule)
       end

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/your_proposed_initiatives_digest.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/your_proposed_initiatives_digest.rb
@@ -41,7 +41,9 @@ module EmailCampaigns
     recipient_filter :filter_authors_of_proposed_initiatives
 
     def self.default_schedule
-      IceCube::Schedule.new(Time.find_zone(AppConfiguration.instance.settings('core', 'timezone')).local(2019)) do |s|
+      start_time = AppConfiguration.timezone.local(2019)
+
+      IceCube::Schedule.new(start_time) do |s|
         s.add_recurrence_rule(
           IceCube::Rule.weekly(1).day(:wednesday).hour_of_day(14)
         )

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/concerns/schedulable_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/concerns/schedulable_spec.rb
@@ -7,19 +7,19 @@ class SchedulableCampaignForTest < EmailCampaigns::Campaign
 end
 
 RSpec.describe EmailCampaigns::Schedulable do
-  let(:config_timezone) { AppConfiguration.instance.settings('core', 'timezone') }
-  let :schedule do
-    IceCube::Schedule.new(Time.find_zone(config_timezone).local(2018)) do |s|
+  let(:campaign) { SchedulableCampaignForTest.create!(ic_schedule: schedule) }
+  let(:config_timezone) { AppConfiguration.timezone }
+  let(:schedule) do
+    IceCube::Schedule.new(config_timezone.local(2018)) do |s|
       s.add_recurrence_rule(
         IceCube::Rule.weekly(1).day(:monday).hour_of_day(10)
       )
     end
   end
-  let(:campaign) { SchedulableCampaignForTest.create!(ic_schedule: schedule) }
 
   describe 'run_before_send_hooks' do
     it 'allows sending when and only when the passed time is within half an hour of the scheduled target' do
-      time = Time.find_zone(config_timezone).local(2018, 8, 13, 10)
+      time = config_timezone.local(2018, 8, 13, 10)
       expect(campaign.run_before_send_hooks(time: time)).to be true
       expect(campaign.run_before_send_hooks(time: time - 30.minutes)).to be true
       expect(campaign.run_before_send_hooks(time: time + 30.minutes)).to be true
@@ -33,7 +33,8 @@ RSpec.describe EmailCampaigns::Schedulable do
       schedule.start_time = Time.find_zone('US/Arizona').local(2018, 8, 13, 10)
       campaign.ic_schedule = schedule
       campaign.save!
-      expect(campaign.reload.ic_schedule.start_time.utc_offset).to eq Time.find_zone(config_timezone).local(2018, 8, 13).utc_offset
+      expect(campaign.reload.ic_schedule.start_time.utc_offset)
+        .to eq(config_timezone.local(2018, 8, 13).utc_offset)
     end
   end
 end

--- a/back/lib/time_boundaries_parser.rb
+++ b/back/lib/time_boundaries_parser.rb
@@ -5,8 +5,7 @@ class TimeBoundariesParser
   end
 
   def parse
-    timezone = AppConfiguration.instance.settings('core', 'timezone')
-    platform_range = AppConfiguration.instance.created_at..Time.now.in_time_zone(timezone).end_of_day
+    platform_range = AppConfiguration.instance.created_at..AppConfiguration.timezone.now.end_of_day
     start_range = @start_at.present? ? @start_at.to_date : platform_range.begin
     end_range = @end_at.present? ? @end_at.to_date : platform_range.end
     requested_range = start_range...end_range

--- a/back/spec/acceptance/stats_comments_spec.rb
+++ b/back/spec/acceptance/stats_comments_spec.rb
@@ -52,20 +52,21 @@ resource 'Stats - Comments' do
 
   explanation 'The various stats endpoints can be used to show certain properties of comments.'
 
-  let!(:now) { Time.now.in_time_zone(@timezone) }
+  let(:timezone) { AppConfiguration.timezone }
+  let!(:now) { timezone.now }
 
   before do
-    @timezone = AppConfiguration.instance.settings('core', 'timezone')
     AppConfiguration.instance.update!(created_at: now - 3.months)
     create(:comment, publication_status: 'deleted')
   end
 
   get 'web_api/v1/stats/comments_count' do
     before do
-      travel_to((now - 1.month).in_time_zone(@timezone).beginning_of_month - 1.day) do
+      travel_to(timezone.at(now - 1.month).beginning_of_month - 1.day) do
         create_list(:comment, 2)
       end
-      travel_to((now - 5.months).in_time_zone(@timezone).beginning_of_month + 1.day) do
+
+      travel_to(timezone.at(now - 5.months).beginning_of_month + 1.day) do
         create(:comment)
       end
     end
@@ -115,8 +116,8 @@ resource 'Stats - Comments' do
       end
 
       describe 'with time filtering only' do
-        let(:start_at) { (now - 1.month).in_time_zone(@timezone).beginning_of_month }
-        let(:end_at) { (now - 1.month).in_time_zone(@timezone).end_of_month }
+        let(:start_at) { timezone.at(now - 1.month).beginning_of_month }
+        let(:end_at) { timezone.at(now - 1.month).end_of_month }
 
         before do
           travel_to start_at + 1.day do
@@ -159,8 +160,9 @@ resource 'Stats - Comments' do
           end
         end
 
-        let(:start_at) { (now - 1.month).in_time_zone(@timezone).beginning_of_month }
-        let(:end_at) { (now - 1.month).in_time_zone(@timezone).end_of_month }
+        let(:start_at) { timezone.at(now - 1.month).beginning_of_month }
+
+        let(:end_at) { timezone.at(now - 1.month).end_of_month }
         let(:project) { @project.id }
 
         example_request 'Comments by topic filtered by project' do
@@ -173,9 +175,9 @@ resource 'Stats - Comments' do
       end
 
       describe 'filtered by group' do
-        let(:start_at) { (now - 1.month).in_time_zone(@timezone).beginning_of_month }
         let(:group) { @group.id }
-        let(:end_at) { (now - 1.month).in_time_zone(@timezone).end_of_month }
+        let(:start_at) { timezone.at(now - 1.month).beginning_of_month }
+        let(:end_at) { timezone.at(now - 1.month).end_of_month }
 
         before do
           travel_to start_at + 3.days do
@@ -215,8 +217,8 @@ resource 'Stats - Comments' do
       end
 
       describe 'with time filtering only' do
-        let(:start_at) { (now - 1.month).in_time_zone(@timezone).beginning_of_month }
-        let(:end_at) { (now - 1.month).in_time_zone(@timezone).end_of_month }
+        let(:start_at) { timezone.at(now - 1.month).beginning_of_month }
+        let(:end_at) { timezone.at(now - 1.month).end_of_month }
 
         before do
           travel_to start_at + 1.day do
@@ -261,8 +263,8 @@ resource 'Stats - Comments' do
           end
         end
 
-        let(:start_at) { (now - 1.month).in_time_zone(@timezone).beginning_of_month }
-        let(:end_at) { (now - 1.month).in_time_zone(@timezone).end_of_month }
+        let(:start_at) { timezone.at(now - 1.month).beginning_of_month }
+        let(:end_at) { timezone.at(now - 1.month).end_of_month }
         let(:project) { @project.id }
 
         example_request 'Comments by topic filtered by project' do
@@ -277,9 +279,9 @@ resource 'Stats - Comments' do
       end
 
       describe 'filtered by group' do
-        let(:start_at) { (now - 1.month).in_time_zone(@timezone).beginning_of_month }
         let(:group) { @group.id }
-        let(:end_at) { (now - 1.month).in_time_zone(@timezone).end_of_month }
+        let(:start_at) { timezone.at(now - 1.month).beginning_of_month }
+        let(:end_at) { timezone.at(now - 1.month).end_of_month }
 
         before do
           travel_to start_at + 3.days do
@@ -314,8 +316,8 @@ resource 'Stats - Comments' do
       before { admin_header_token }
 
       describe 'with time filtering only' do
-        let(:start_at) { (now - 1.month).in_time_zone(@timezone).beginning_of_month }
-        let(:end_at) { (now - 1.month).in_time_zone(@timezone).end_of_month }
+        let(:start_at) { timezone.at(now - 1.month).beginning_of_month }
+        let(:end_at) { timezone.at(now - 1.month).end_of_month }
 
         before do
           travel_to start_at + 14.days do
@@ -345,9 +347,9 @@ resource 'Stats - Comments' do
       end
 
       describe 'filtered by topic' do
-        let(:start_at) { (now - 1.month).in_time_zone(@timezone).beginning_of_month }
         let(:topic) { @topic.id }
-        let(:end_at) { (now - 1.month).in_time_zone(@timezone).end_of_month }
+        let(:start_at) { timezone.at(now - 1.month).beginning_of_month }
+        let(:end_at) { timezone.at(now - 1.month).end_of_month }
 
         before do
           travel_to start_at + 17.days do
@@ -370,9 +372,9 @@ resource 'Stats - Comments' do
       end
 
       describe 'filtered by group' do
-        let(:start_at) { (now - 1.month).in_time_zone(@timezone).beginning_of_month }
         let(:group) { @group.id }
-        let(:end_at) { (now - 1.month).in_time_zone(@timezone).end_of_month }
+        let(:start_at) { timezone.at(now - 1.month).beginning_of_month }
+        let(:end_at) { timezone.at(now - 1.month).end_of_month }
 
         before do
           travel_to start_at + 12.days do
@@ -406,8 +408,8 @@ resource 'Stats - Comments' do
       before { admin_header_token }
 
       describe 'with time filtering only' do
-        let(:start_at) { (now - 1.month).in_time_zone(@timezone).beginning_of_month }
-        let(:end_at) { (now - 1.month).in_time_zone(@timezone).end_of_month }
+        let(:start_at) { timezone.at(now - 1.month).beginning_of_month }
+        let(:end_at) { timezone.at(now - 1.month).end_of_month }
 
         before do
           travel_to start_at + 14.days do
@@ -443,9 +445,9 @@ resource 'Stats - Comments' do
       end
 
       describe 'filtered by topic' do
-        let(:start_at) { (now - 1.month).in_time_zone(@timezone).beginning_of_month }
         let(:topic) { @topic.id }
-        let(:end_at) { (now - 1.month).in_time_zone(@timezone).end_of_month }
+        let(:start_at) { timezone.at(now - 1.month).beginning_of_month }
+        let(:end_at) { timezone.at(now - 1.month).end_of_month }
 
         before do
           travel_to start_at + 17.days do
@@ -470,9 +472,9 @@ resource 'Stats - Comments' do
       end
 
       describe 'filtered by group' do
-        let(:start_at) { (now - 1.month).in_time_zone(@timezone).beginning_of_month }
         let(:group) { @group.id }
-        let(:end_at) { (now - 1.month).in_time_zone(@timezone).end_of_month }
+        let(:start_at) { timezone.at(now - 1.month).beginning_of_month }
+        let(:end_at) { timezone.at(now - 1.month).end_of_month }
 
         before do
           travel_to start_at + 12.days do

--- a/back/spec/acceptance/stats_initiatives_spec.rb
+++ b/back/spec/acceptance/stats_initiatives_spec.rb
@@ -27,31 +27,32 @@ end
 
 resource 'Stats - Initiatives' do
   explanation 'The various stats endpoints can be used to show certain properties of initiatives.'
+  header 'Content-Type', 'application/json'
 
-  let_it_be(:now) { Time.now.in_time_zone(@timezone) }
+  let_it_be(:now) { AppConfiguration.timezone.now }
 
-  before do
-    header 'Content-Type', 'application/json'
-    admin_header_token
+  before { admin_header_token }
 
+  before_all do
     AppConfiguration.instance.update!(created_at: now - 3.years)
-    @timezone = AppConfiguration.instance.settings('core', 'timezone')
 
     @threshold_reached = create(:initiative_status, code: 'threshold_reached')
     @initiatives_with_topics = []
     @initiatives_with_areas = []
 
-    travel_to (now - 1.year).in_time_zone(@timezone).beginning_of_year - 1.month do
+    begin_of_last_year = AppConfiguration.timezone.now.beginning_of_year - 1.year
+
+    travel_to(begin_of_last_year - 1.month) do
       i = create(:initiative, initiative_status: @threshold_reached)
       create(:official_feedback, post: i)
     end
 
-    travel_to (now - 1.year).in_time_zone(@timezone).beginning_of_year + 2.months do
+    travel_to(begin_of_last_year + 2.months) do
       @initiatives_with_topics += create_list(:initiative_with_topics, 2, initiative_status: @threshold_reached)
       @initiatives_with_areas += create_list(:initiative_with_areas, 3, initiative_status: @threshold_reached)
     end
 
-    travel_to (now - 1.year).in_time_zone(@timezone).beginning_of_year + 5.months do
+    travel_to(begin_of_last_year + 5.months) do
       @initiatives_with_topics += create_list(:initiative_with_topics, 3, initiative_status: @threshold_reached)
       @initiatives_with_areas += create_list(:initiative_with_areas, 2, initiative_status: @threshold_reached)
       create(:initiative, initiative_status: @threshold_reached)

--- a/back/spec/acceptance/stats_reactions_spec.rb
+++ b/back/spec/acceptance/stats_reactions_spec.rb
@@ -27,14 +27,14 @@ end
 
 resource 'Stats - Reactions' do
   explanation 'The various stats endpoints can be used to show how certain properties of reactions.'
+  header 'Content-Type', 'application/json'
 
-  let!(:now) { Time.now.in_time_zone(@timezone) }
+  let(:timezone) { AppConfiguration.timezone }
+  let(:now) { timezone.now }
 
   before do
     admin_header_token
-    header 'Content-Type', 'application/json'
     AppConfiguration.instance.update!(created_at: now - 3.months)
-    @timezone = AppConfiguration.instance.settings('core', 'timezone')
     @idea_status = create(:idea_status)
   end
 
@@ -63,8 +63,8 @@ resource 'Stats - Reactions' do
     group_filter_parameter self
 
     describe 'with time filtering only' do
-      let(:start_at) { now.in_time_zone(@timezone).beginning_of_week }
-      let(:end_at) { now.in_time_zone(@timezone).end_of_week }
+      let(:start_at) { now.beginning_of_week }
+      let(:end_at) { now.end_of_week }
 
       let!(:topic1) { create(:topic) }
       let!(:topic2) { create(:topic) }
@@ -100,8 +100,8 @@ resource 'Stats - Reactions' do
         create(:reaction, reactable: create(:idea_with_topics, idea_status: @idea_status))
       end
 
-      let(:start_at) { now.in_time_zone(@timezone).beginning_of_month }
-      let(:end_at) { now.in_time_zone(@timezone).end_of_month }
+      let(:start_at) { now.beginning_of_month }
+      let(:end_at) { now.end_of_month }
       let(:project) { @project.id }
 
       example_request 'Reactions by topic filtered by project' do
@@ -121,8 +121,8 @@ resource 'Stats - Reactions' do
         create(:reaction, reactable: create(:idea_with_topics, idea_status: @idea_status))
       end
 
-      let(:start_at) { now.in_time_zone(@timezone).beginning_of_month }
-      let(:end_at) { now.in_time_zone(@timezone).end_of_month }
+      let(:start_at) { now.beginning_of_month }
+      let(:end_at) { now.end_of_month }
       let(:group) { @group.id }
 
       example_request 'Reactions by topic filtered by group' do
@@ -141,8 +141,8 @@ resource 'Stats - Reactions' do
     group_filter_parameter self
 
     describe 'with time filtering only' do
-      let(:start_at) { now.in_time_zone(@timezone).beginning_of_week }
-      let(:end_at) { now.in_time_zone(@timezone).end_of_week }
+      let(:start_at) { now.beginning_of_week }
+      let(:end_at) { now.end_of_week }
 
       let!(:topic1) { create(:topic) }
       let!(:topic2) { create(:topic) }
@@ -180,8 +180,8 @@ resource 'Stats - Reactions' do
         create(:reaction, reactable: create(:idea_with_topics, idea_status: @idea_status))
       end
 
-      let(:start_at) { now.in_time_zone(@timezone).beginning_of_month }
-      let(:end_at) { now.in_time_zone(@timezone).end_of_month }
+      let(:start_at) { now.beginning_of_month }
+      let(:end_at) { now.end_of_month }
       let(:project) { @project.id }
 
       example_request 'Reactions by topic filtered by project' do
@@ -203,8 +203,8 @@ resource 'Stats - Reactions' do
         create(:reaction, reactable: create(:idea_with_topics, idea_status: @idea_status))
       end
 
-      let(:start_at) { now.in_time_zone(@timezone).beginning_of_month }
-      let(:end_at) { now.in_time_zone(@timezone).end_of_month }
+      let(:start_at) { now.beginning_of_month }
+      let(:end_at) { now.end_of_month }
       let(:group) { @group.id }
 
       example_request 'Reactions by topic filtered by group' do
@@ -225,8 +225,8 @@ resource 'Stats - Reactions' do
     group_filter_parameter self
 
     describe 'with time filtering only' do
-      let(:start_at) { now.in_time_zone(@timezone).beginning_of_month }
-      let(:end_at) { now.in_time_zone(@timezone).end_of_month }
+      let(:start_at) { now.beginning_of_month }
+      let(:end_at) { now.end_of_month }
 
       let!(:project1) { create(:project) }
       let!(:project2) { create(:project) }
@@ -262,8 +262,8 @@ resource 'Stats - Reactions' do
         create(:reaction, reactable: idea2)
       end
 
-      let(:start_at) { now.in_time_zone(@timezone).beginning_of_month }
-      let(:end_at) { now.in_time_zone(@timezone).end_of_month }
+      let(:start_at) { now.beginning_of_month }
+      let(:end_at) { now.end_of_month }
       let(:topic) { @topic.id }
 
       example_request 'Reactions by project filtered by topic' do
@@ -284,8 +284,8 @@ resource 'Stats - Reactions' do
         create(:reaction, reactable: idea)
       end
 
-      let(:start_at) { now.in_time_zone(@timezone).beginning_of_month }
-      let(:end_at) { now.in_time_zone(@timezone).end_of_month }
+      let(:start_at) { now.beginning_of_month }
+      let(:end_at) { now.end_of_month }
       let(:group) { @group.id }
 
       example_request 'Reactions by project filtered by group' do
@@ -304,8 +304,8 @@ resource 'Stats - Reactions' do
     group_filter_parameter self
 
     describe 'with time filtering only' do
-      let(:start_at) { now.in_time_zone(@timezone).beginning_of_month }
-      let(:end_at) { now.in_time_zone(@timezone).end_of_month }
+      let(:start_at) { now.beginning_of_month }
+      let(:end_at) { now.end_of_month }
 
       let!(:project1) { create(:project) }
       let!(:project2) { create(:project) }
@@ -343,8 +343,8 @@ resource 'Stats - Reactions' do
         create(:reaction, reactable: idea2)
       end
 
-      let(:start_at) { now.in_time_zone(@timezone).beginning_of_month }
-      let(:end_at) { now.in_time_zone(@timezone).end_of_month }
+      let(:start_at) { now.beginning_of_month }
+      let(:end_at) { now.end_of_month }
       let(:topic) { @topic.id }
 
       example_request 'Reactions by project filtered by topic' do
@@ -367,8 +367,8 @@ resource 'Stats - Reactions' do
         create(:reaction, reactable: idea)
       end
 
-      let(:start_at) { now.in_time_zone(@timezone).beginning_of_month }
-      let(:end_at) { now.in_time_zone(@timezone).end_of_month }
+      let(:start_at) { now.beginning_of_month }
+      let(:end_at) { now.end_of_month }
       let(:group) { @group.id }
 
       example_request 'Reactions by project filtered by group' do

--- a/back/spec/acceptance/stats_users_spec.rb
+++ b/back/spec/acceptance/stats_users_spec.rb
@@ -10,27 +10,29 @@ end
 
 resource 'Stats - Users' do
   explanation 'The various stats endpoints can be used to show how certain properties of users.'
+  header 'Content-Type', 'application/json'
 
-  let!(:now) { Time.now.in_time_zone(@timezone) }
+  let(:timezone) { AppConfiguration.timezone }
+  let!(:now) { timezone.now }
 
   before do
     admin_header_token
-    header 'Content-Type', 'application/json'
     AppConfiguration.instance.update!(created_at: now - 2.years)
-    @timezone = AppConfiguration.instance.settings('core', 'timezone')
+    begin_of_last_month = (now - 1.month).beginning_of_month
 
-    travel_to((now - 1.month).in_time_zone(@timezone).beginning_of_month - 1.day) do
+    travel_to(begin_of_last_month - 1.day) do
       create(:user)
     end
 
-    travel_to((now - 1.month).in_time_zone(@timezone).beginning_of_month + 10.days) do
+    travel_to(begin_of_last_month + 10.days) do
       create(:user)
       create(:user)
       create(:admin)
       create(:user)
       create(:invited_user)
     end
-    travel_to((now - 1.month).in_time_zone(@timezone).beginning_of_month + 25.days) do
+
+    travel_to(begin_of_last_month + 25.days) do
       create_list(:user, 4)
     end
   end

--- a/back/spec/models/app_configuration_spec.rb
+++ b/back/spec/models/app_configuration_spec.rb
@@ -16,17 +16,28 @@ RSpec.describe AppConfiguration do
   end
 
   describe '.timezone' do
-    let(:timezone_name) { 'Europe/Amsterdam' }
-
     before do
       app_config = described_class.instance
       app_config.settings['core']['timezone'] = timezone_name
-      app_config.save!
+      # We skip validation to be able to test invalid timezones.
+      app_config.save!(validate: false)
     end
 
-    it 'returns the correct timezone object' do
-      expected_timezone = Time.find_zone(timezone_name)
-      expect(described_class.timezone).to eq(expected_timezone)
+    context 'when the timezone name is valid' do
+      let(:timezone_name) { 'Europe/Amsterdam' }
+
+      it 'returns the correct timezone object' do
+        expected_timezone = Time.find_zone(timezone_name)
+        expect(described_class.timezone).to eq(expected_timezone)
+      end
+    end
+
+    context 'when the timezone name is invalid' do
+      let(:timezone_name) { 'Invalid/Timezone' }
+
+      it 'raises a KeyError' do
+        expect { described_class.timezone }.to raise_error(KeyError, timezone_name)
+      end
     end
   end
 end

--- a/back/spec/models/app_configuration_spec.rb
+++ b/back/spec/models/app_configuration_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe AppConfiguration do
-  describe '#instance' do
+  describe '.instance' do
     it 'is reset when the tenant is reset' do
       tenant = Tenant.current
 
@@ -12,6 +12,21 @@ RSpec.describe AppConfiguration do
       expect { described_class.instance }.to raise_error(ActiveRecord::RecordNotFound)
     ensure
       tenant.switch!
+    end
+  end
+
+  describe '.timezone' do
+    let(:timezone_name) { 'Europe/Amsterdam' }
+
+    before do
+      app_config = described_class.instance
+      app_config.settings['core']['timezone'] = timezone_name
+      app_config.save!
+    end
+
+    it 'returns the correct timezone object' do
+      expected_timezone = Time.find_zone(timezone_name)
+      expect(described_class.timezone).to eq(expected_timezone)
     end
   end
 end

--- a/back/spec/services/timeline_service_spec.rb
+++ b/back/spec/services/timeline_service_spec.rb
@@ -34,8 +34,8 @@ describe TimelineService do
     end
 
     it "returns the active phase when we're in the last day of the phase" do
-      now = Time.now.in_time_zone(AppConfiguration.instance.settings('core', 'timezone')).to_date
-      phase = create(:phase, start_at: now - 1.week, end_at: now, project: project)
+      today = AppConfiguration.timezone.now.to_date
+      phase = create(:phase, start_at: today - 1.week, end_at: today, project: project)
       expect(service.current_phase(project)&.id).to eq(phase.id)
     end
 
@@ -409,8 +409,8 @@ describe TimelineService do
   end
 
   def create_active_phase(project, factory: :phase)
-    now = Time.now.in_time_zone(AppConfiguration.instance.settings('core', 'timezone')).to_date
-    create(factory, project: project, start_at: now - 2.weeks, end_at: now)
+    today = AppConfiguration.timezone.now.to_date
+    create(factory, project: project, start_at: today - 2.weeks, end_at: today)
   end
 
   def create_inactive_phase(project, phase_options = {})


### PR DESCRIPTION
This PR just introduce a small (and hopefully convenient) helper to access the timezone of a platform (instead of digging in the settings hash to get the timezone as a string). It's been stuck for a while because we wanted to improve the performance of the `AppConfiguration.instance` method, which is now done.

# Changelog
## Technical 
- [CL-4070] Introduce the AppConfiguration.timezone helper to access the timezone of the current tenant.

[CL-4070]: https://citizenlab.atlassian.net/browse/CL-4070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ