### PR TITLE
TAN-2054: Hide map overlay on tablets

### DIFF
--- a/front/app/components/IdeasMap/index.tsx
+++ b/front/app/components/IdeasMap/index.tsx
@@ -543,10 +543,10 @@ const IdeasMap = memo<Props>(
               width="390px"
               height={`calc(${mapHeightDesktop} - 80px)`}
               position="absolute"
-              display="flex"
               top="25px"
               left="25px"
               zIndex="900"
+              display={isTabletOrSmaller ? 'none' : 'flex'}
             >
               <IdeaMapOverlay
                 projectId={projectId}


### PR DESCRIPTION
# Changelog

## Fixed
- Hide blocking map overlay on tablets and phones on the idea map view page. This also fixes the scroll issues that were causing issues on that page
