### PR TITLE
[TAN-2170] Added security_level to token

### DIFF
--- a/back/app/controllers/web_api/v1/confirmations_controller.rb
+++ b/back/app/controllers/web_api/v1/confirmations_controller.rb
@@ -1,33 +1,31 @@
 # frozen_string_literal: true
 
 class WebApi::V1::ConfirmationsController < ApplicationController
+  include ActionController::Cookies
   skip_after_action :verify_authorized
 
   def create
     result = ConfirmUser.call(user: current_user, code: confirmation_params[:code])
 
     if result.success?
-      # Return an updated token in case others have attempted to login elsewhere with the same email
-      payload = current_user.to_token_payload
-
-      # TODO: JS Need to get the expiry from the current token
-      payload[:exp] = 1.day.from_now.to_i
-
-      # TODO: JS should we send this in the main JWT too?
-      render json: {
-        data: {
-          type: 'jwt',
-          attributes: {
-            token: AuthToken::AuthToken.new(payload: payload).token
-          }
-        }
-      }, status: :ok
+      reset_auth_cookie
+      head :ok
     else
       render json: { errors: result.errors.details }, status: :unprocessable_entity
     end
   end
 
   private
+
+  def reset_auth_cookie
+    # TODO: JS Need to get the expiry from the current token
+    payload = current_user.to_token_payload
+    payload[:exp] = 1.day.from_now.to_i
+    cookies[:cl2_jwt] = {
+      value: AuthToken::AuthToken.new(payload: payload).token,
+      expires: 1.day.from_now
+    }
+  end
 
   def confirmation_params
     params.require(:confirmation).permit(:code)

--- a/back/app/controllers/web_api/v1/confirmations_controller.rb
+++ b/back/app/controllers/web_api/v1/confirmations_controller.rb
@@ -23,7 +23,7 @@ class WebApi::V1::ConfirmationsController < ApplicationController
     payload[:exp] = 1.day.from_now.to_i
     cookies[:cl2_jwt] = {
       value: AuthToken::AuthToken.new(payload: payload).token,
-      expires: 1.day.from_now
+      expires: 1.month.from_now
     }
   end
 

--- a/back/app/controllers/web_api/v1/confirmations_controller.rb
+++ b/back/app/controllers/web_api/v1/confirmations_controller.rb
@@ -18,12 +18,17 @@ class WebApi::V1::ConfirmationsController < ApplicationController
   private
 
   def reset_auth_cookie
-    # TODO: JS Need to get the expiry from the current token
+    # get the expiry time from the current token
+    current_token = request.headers['Authorization']&.split&.last
+    current_payload = AuthToken::AuthToken.new(token: current_token).payload
+
+    # Set a new token with the same expiry time
     payload = current_user.to_token_payload
-    payload[:exp] = 1.day.from_now.to_i
+    payload[:exp] = current_payload['exp']
+
     cookies[:cl2_jwt] = {
       value: AuthToken::AuthToken.new(payload: payload).token,
-      expires: 1.month.from_now
+      expires: Time.at(current_payload['exp'])
     }
   end
 

--- a/back/app/controllers/web_api/v1/confirmations_controller.rb
+++ b/back/app/controllers/web_api/v1/confirmations_controller.rb
@@ -7,7 +7,21 @@ class WebApi::V1::ConfirmationsController < ApplicationController
     result = ConfirmUser.call(user: current_user, code: confirmation_params[:code])
 
     if result.success?
-      head :ok
+      # Return an updated token in case others have attempted to login elsewhere with the same email
+      payload = current_user.to_token_payload
+
+      # TODO: JS Need to get the expiry from the current token
+      payload[:exp] = 1.day.from_now.to_i
+
+      # TODO: JS should we send this in the main JWT too?
+      render json: {
+        data: {
+          type: 'jwt',
+          attributes: {
+            token: AuthToken::AuthToken.new(payload: payload).token
+          }
+        }
+      }, status: :ok
     else
       render json: { errors: result.errors.details }, status: :unprocessable_entity
     end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -292,6 +292,7 @@ class User < ApplicationRecord
   # Can add verification in here as a level 2 maybe
   def security_level
     return 1 unless confirmation_required?
+
     0
   end
 

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -214,6 +214,7 @@ class User < ApplicationRecord
       sub: id,
       roles: compacted_roles,
       exp: token_lifetime.from_now.to_i,
+      security_level: security_level,
       cluster: CL2_CLUSTER,
       tenant: Tenant.current.id
     }
@@ -285,6 +286,13 @@ class User < ApplicationRecord
   def blank_and_can_be_deleted?
     # atm it can be true only for users registered with ClaveUnica and MitID who haven't entered email
     sso? && email.blank? && new_email.blank? && password_digest.blank? && identity_ids.count == 1
+  end
+
+  # Used to reject auth if the security level in the token is lower than the user's security level
+  # Can add verification in here as a level 2 maybe
+  def security_level
+    return 1 unless confirmation_required?
+    0
   end
 
   private

--- a/back/lib/auth_token/auth_token.rb
+++ b/back/lib/auth_token/auth_token.rb
@@ -39,9 +39,10 @@ module AuthToken
     # Has the security level of the user changed since the token was issued?
     # eg user has now confirmed - reject if the level is now higher
     def validate_secure_attribute_changes(entity_class, entity)
-      if entity_class == User
-        return nil if @payload['security_level'] && @payload['security_level'] < entity.security_level
+      if entity_class == User && (@payload['security_level'] && @payload['security_level'] < entity.security_level)
+        return nil
       end
+
       entity
     end
 

--- a/back/lib/auth_token/auth_token.rb
+++ b/back/lib/auth_token/auth_token.rb
@@ -21,11 +21,13 @@ module AuthToken
     end
 
     def entity_for(entity_class)
-      if entity_class.respond_to? :from_token_payload
+      entity = if entity_class.respond_to? :from_token_payload
         entity_class.from_token_payload @payload
       else
         entity_class.find @payload['sub']
       end
+      entity = validate_secure_attribute_changes(entity_class, entity) if entity
+      entity
     end
 
     def to_json(_options = {})
@@ -33,6 +35,15 @@ module AuthToken
     end
 
     private
+
+    # Has the security level of the user changed since the token was issued?
+    # eg user has now confirmed - reject if the level is now higher
+    def validate_secure_attribute_changes(entity_class, entity)
+      if entity_class == User
+        return nil if @payload['security_level'] && @payload['security_level'] < entity.security_level
+      end
+      entity
+    end
 
     def decode_token_options
       {

--- a/back/spec/acceptance/confirmations_spec.rb
+++ b/back/spec/acceptance/confirmations_spec.rb
@@ -31,9 +31,10 @@ resource 'Confirmations' do
         RequestConfirmationCodeJob.perform_now user
       end
 
-      example 'returns an ok status passing the right code' do
+      example 'returns an ok status and sets a new JWT cookie when passing the right code' do
         do_request(confirmation: { code: user.email_confirmation_code })
         assert_status 200
+        expect(response_headers['Set-Cookie']).to start_with('cl2_jwt=')
       end
 
       example 'returns an unprocessable entity status passing no code' do

--- a/front/app/api/authentication/confirm_email/confirmEmail.ts
+++ b/front/app/api/authentication/confirm_email/confirmEmail.ts
@@ -4,21 +4,11 @@ import onboardingCampaignsKeys from 'api/onboarding_campaigns/keys';
 
 import fetcher from 'utils/cl-react-query/fetcher';
 import { queryClient } from 'utils/cl-react-query/queryClient';
-import { setJwt } from 'utils/auth/jwt';
 
 const confirmationApiEndpoint = `user/confirm`;
 
 export type IConfirmation = {
   code?: string | null;
-};
-
-type JwtResponse = {
-  data: {
-    type: string;
-    attributes: {
-      token: string;
-    };
-  };
 };
 
 export default async function confirmEmail(
@@ -29,14 +19,11 @@ export default async function confirmEmail(
   };
 
   try {
-    const data = await fetcher<JwtResponse>({
+    await fetcher({
       path: `/${confirmationApiEndpoint}`,
       action: 'post',
       body: bodyData,
     });
-
-    // TODO: JS Need to sort out rememberMe etc
-    setJwt(data.data.attributes.token, false);
 
     queryClient.invalidateQueries({ queryKey: requirementsKeys.all() });
     queryClient.invalidateQueries({ queryKey: meKeys.all() });

--- a/front/app/api/authentication/confirm_email/confirmEmail.ts
+++ b/front/app/api/authentication/confirm_email/confirmEmail.ts
@@ -24,7 +24,6 @@ export default async function confirmEmail(
       action: 'post',
       body: bodyData,
     });
-
     queryClient.invalidateQueries({ queryKey: requirementsKeys.all() });
     queryClient.invalidateQueries({ queryKey: meKeys.all() });
     queryClient.invalidateQueries({

--- a/front/app/api/authentication/confirm_email/confirmEmail.ts
+++ b/front/app/api/authentication/confirm_email/confirmEmail.ts
@@ -4,11 +4,21 @@ import onboardingCampaignsKeys from 'api/onboarding_campaigns/keys';
 
 import fetcher from 'utils/cl-react-query/fetcher';
 import { queryClient } from 'utils/cl-react-query/queryClient';
+import { setJwt } from 'utils/auth/jwt';
 
 const confirmationApiEndpoint = `user/confirm`;
 
 export type IConfirmation = {
   code?: string | null;
+};
+
+type JwtResponse = {
+  data: {
+    type: string;
+    attributes: {
+      token: string;
+    };
+  };
 };
 
 export default async function confirmEmail(
@@ -19,11 +29,15 @@ export default async function confirmEmail(
   };
 
   try {
-    await fetcher({
+    const data = await fetcher<JwtResponse>({
       path: `/${confirmationApiEndpoint}`,
       action: 'post',
       body: bodyData,
     });
+
+    // TODO: JS Need to sort out rememberMe etc
+    setJwt(data.data.attributes.token, false);
+
     queryClient.invalidateQueries({ queryKey: requirementsKeys.all() });
     queryClient.invalidateQueries({ queryKey: meKeys.all() });
     queryClient.invalidateQueries({


### PR DESCRIPTION
# Changelog
## Fixed
- Fixed security hole whereby a rogue user could attempt a passwordless login in one browser and then be granted full access by the real user confirming in another browser
