### PR TITLE
Use phase_id from params

### DIFF
--- a/front/app/components/Form/Components/Layouts/CLSurveyPageLayout.tsx
+++ b/front/app/components/Form/Components/Layouts/CLSurveyPageLayout.tsx
@@ -12,10 +12,7 @@ import {
   withJsonFormsLayoutProps,
   useJsonForms,
 } from '@jsonforms/react';
-import { useSearchParams } from 'react-router-dom';
 import { useTheme } from 'styled-components';
-
-import usePhase from 'api/phases/usePhase';
 
 import {
   getSanitizedFormData,
@@ -29,9 +26,6 @@ import {
 import { FormContext } from 'components/Form/contexts';
 import { customAjv } from 'components/Form/utils';
 import QuillEditedContent from 'components/UI/QuillEditedContent';
-import Warning from 'components/UI/Warning';
-
-import { useIntl } from 'utils/cl-intl';
 
 import {
   extractElementsByOtherOptionLogic,
@@ -39,7 +33,6 @@ import {
   isVisible,
 } from '../Controls/visibilityUtils';
 
-import messages from './messages';
 import PageControlButtons from './PageControlButtons';
 
 // Handling survey pages in here. The more things that we have added to it,
@@ -57,7 +50,6 @@ const CLSurveyPageLayout = memo(
     data,
   }: LayoutProps) => {
     const { onSubmit, setShowAllErrors, setFormData } = useContext(FormContext);
-    const { formatMessage } = useIntl();
     const [currentStep, setCurrentStep] = useState<number>(0);
     const [isLoading, setIsLoading] = useState(false);
 
@@ -74,11 +66,6 @@ const CLSurveyPageLayout = memo(
     const dataCyValue = showSubmit ? 'e2e-submit-form' : 'e2e-next-page';
     const hasPreviousPage = currentStep !== 0;
     const pagesRef = useRef<HTMLDivElement>(null);
-    const [queryParams] = useSearchParams();
-    const phaseId = queryParams.get('phase_id') || undefined;
-    const { data: phase } = usePhase(phaseId);
-    const allowAnonymousPosting =
-      phase?.data.attributes.allow_anonymous_participation;
     const [percentageAnswered, setPercentageAnswered] = useState<number>(1);
 
     useEffect(() => {
@@ -211,13 +198,6 @@ const CLSurveyPageLayout = memo(
     return (
       <>
         <Box display="flex" flexDirection="column" height="100%">
-          {allowAnonymousPosting && (
-            <Box w="100%" px={isSmallerThanPhone ? '16px' : '24px'} mt="12px">
-              <Warning icon="shield-checkered">
-                {formatMessage(messages.anonymousSurveyMessage)}
-              </Warning>
-            </Box>
-          )}
           <Box h="100%" display="flex" ref={pagesRef}>
             {uiPages.map((page, index) => {
               const pageElements = extractElementsByOtherOptionLogic(

--- a/front/app/components/Form/Components/Layouts/messages.ts
+++ b/front/app/components/Form/Components/Layouts/messages.ts
@@ -1,8 +1,0 @@
-import { defineMessages } from 'react-intl';
-
-export default defineMessages({
-  anonymousSurveyMessage: {
-    id: 'app.components.form.anonymousSurveyMessage',
-    defaultMessage: 'All responses to this survey are anonymized',
-  },
-});

--- a/front/app/components/IdeaButton/index.tsx
+++ b/front/app/components/IdeaButton/index.tsx
@@ -130,7 +130,7 @@ const IdeaButton = memo<Props>(
           name: 'redirectToIdeaForm',
           params: {
             projectSlug: project.data.attributes.slug,
-            phaseId: phase?.id,
+            phaseId: phase.id,
           },
         };
 

--- a/front/app/components/IdeaButton/index.tsx
+++ b/front/app/components/IdeaButton/index.tsx
@@ -93,7 +93,7 @@ const IdeaButton = memo<Props>(
           search: stringify(
             {
               ...positionParams,
-              phase_id: phase?.id,
+              phase_id: phase.id,
             },
             { addQueryPrefix: true }
           ),

--- a/front/app/containers/IdeasNewPage/IdeasNewIdeationForm/index.tsx
+++ b/front/app/containers/IdeasNewPage/IdeasNewIdeationForm/index.tsx
@@ -68,7 +68,7 @@ interface FormValues {
 
 interface Props {
   project: IProject;
-  phaseId: string;
+  phaseId: string | undefined;
 }
 
 const IdeasNewIdeationForm = ({ project, phaseId }: Props) => {

--- a/front/app/containers/IdeasNewPage/IdeasNewIdeationForm/index.tsx
+++ b/front/app/containers/IdeasNewPage/IdeasNewIdeationForm/index.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState, useCallback, lazy, Suspense } from 'react';
 
 import { Box, colors } from '@citizenlab/cl2-component-library';
 import { parse } from 'qs';
-import { useSearchParams } from 'react-router-dom';
 import { Multiloc } from 'typings';
 
 import { IdeaPublicationStatus } from 'api/ideas/types';
@@ -69,17 +68,16 @@ interface FormValues {
 
 interface Props {
   project: IProject;
+  phaseId: string;
 }
 
-const IdeasNewIdeationForm = ({ project }: Props) => {
+const IdeasNewIdeationForm = ({ project, phaseId }: Props) => {
   const localize = useLocalize();
   const locale = useLocale();
   const [isDisclaimerOpened, setIsDisclaimerOpened] = useState(false);
   const [formData, setFormData] = useState<FormValues | null>(null);
   const { mutateAsync: addIdea } = useAddIdea();
   const { data: authUser } = useAuthUser();
-  const [queryParams] = useSearchParams();
-  const phaseId = queryParams.get('phase_id') || undefined;
   const { data: phases } = usePhases(project.data.id);
   const { data: phaseFromUrl } = usePhase(phaseId);
   const {

--- a/front/app/containers/IdeasNewPage/index.tsx
+++ b/front/app/containers/IdeasNewPage/index.tsx
@@ -58,7 +58,7 @@ const IdeasNewPage = () => {
     return <PageNotFound />;
   }
 
-  if (!phases || !phaseId) {
+  if (!phases) {
     return null;
   }
 
@@ -82,7 +82,7 @@ const IdeasNewPage = () => {
         context: {
           type: 'phase',
           action: 'posting_idea',
-          id: phaseId,
+          id: phaseId || '',
         },
       });
     };
@@ -105,7 +105,7 @@ const IdeasNewPage = () => {
     we are redirecting /ideas/new requests to the new /surveys/new URL. This code can be removed
     once we've verified all surveys started before the date this got merged have been completed.
   */
-  if (participationMethod === 'native_survey') {
+  if (participationMethod === 'native_survey' && typeof phaseId === 'string') {
     return (
       <Navigate
         to={`/projects/${slug}/surveys/new?phase_id=${phaseId}`}

--- a/front/app/containers/IdeasNewPage/index.tsx
+++ b/front/app/containers/IdeasNewPage/index.tsx
@@ -35,7 +35,7 @@ const IdeasNewPage = () => {
   const [searchParams] = useSearchParams();
   // If we reach this component by hitting ideas/new directly, without a phase_id,
   // we'll still get to this component, so we try to get the phase id from getCurrentPhase.
-  const currentPhaseId =
+  const phaseId =
     searchParams.get('phase_id') || getCurrentPhase(phases?.data)?.id;
 
   /*
@@ -58,7 +58,7 @@ const IdeasNewPage = () => {
     return <PageNotFound />;
   }
 
-  if (!phases || !currentPhaseId) {
+  if (!phases || !phaseId) {
     return null;
   }
 
@@ -66,7 +66,7 @@ const IdeasNewPage = () => {
   const participationMethod = getParticipationMethod(
     project.data,
     phases.data,
-    currentPhaseId
+    phaseId
   );
   const { enabled, disabledReason, authenticationRequirements } =
     getIdeaPostingRules({
@@ -82,7 +82,7 @@ const IdeasNewPage = () => {
         context: {
           type: 'phase',
           action: 'posting_idea',
-          id: currentPhaseId,
+          id: phaseId,
         },
       });
     };
@@ -108,7 +108,7 @@ const IdeasNewPage = () => {
   if (participationMethod === 'native_survey') {
     return (
       <Navigate
-        to={`/projects/${slug}/surveys/new?phase_id=${currentPhaseId}`}
+        to={`/projects/${slug}/surveys/new?phase_id=${phaseId}`}
         replace
       />
     );

--- a/front/app/containers/IdeasNewPage/index.tsx
+++ b/front/app/containers/IdeasNewPage/index.tsx
@@ -33,10 +33,10 @@ const IdeasNewPage = () => {
   const { data: authUser } = useAuthUser();
   const { data: phases, status: phasesStatus } = usePhases(project?.data.id);
   const [searchParams] = useSearchParams();
+  const phaseIdFromSearchParams = searchParams.get('phase_id');
   // If we reach this component by hitting ideas/new directly, without a phase_id,
   // we'll still get to this component, so we try to get the phase id from getCurrentPhase.
-  const phaseId =
-    searchParams.get('phase_id') || getCurrentPhase(phases?.data)?.id;
+  const phaseId = phaseIdFromSearchParams || getCurrentPhase(phases?.data)?.id;
 
   /*
     TO DO: simplify these loading & auth checks, then if possible abstract and use the same the IdeasNewSurveyPage
@@ -66,7 +66,10 @@ const IdeasNewPage = () => {
   const participationMethod = getParticipationMethod(
     project.data,
     phases.data,
-    phaseId
+    // No particular reason why this needs to be phaseIdFromSearchParams,
+    // I just wanted to keep this part as it was while refactoring some other parts
+    // to reduce the chances of introducing bugs. But it could probably be phaseId instead.
+    phaseIdFromSearchParams || undefined
   );
   const { enabled, disabledReason, authenticationRequirements } =
     getIdeaPostingRules({

--- a/front/app/containers/IdeasNewPage/index.tsx
+++ b/front/app/containers/IdeasNewPage/index.tsx
@@ -114,7 +114,7 @@ const IdeasNewPage = () => {
     );
   }
 
-  return <IdeasNewIdeationForm project={project} />;
+  return <IdeasNewIdeationForm project={project} phaseId={phaseId} />;
 };
 
 export default IdeasNewPage;

--- a/front/app/containers/IdeasNewPage/index.tsx
+++ b/front/app/containers/IdeasNewPage/index.tsx
@@ -81,7 +81,7 @@ const IdeasNewPage = () => {
         context: {
           type: 'phase',
           action: 'posting_idea',
-          id: phase_id || getCurrentPhase(phases?.data)?.id || '',
+          id: phase_id,
         },
       });
     };
@@ -104,10 +104,10 @@ const IdeasNewPage = () => {
     we are redirecting /ideas/new requests to the new /surveys/new URL. This code can be removed
     once we've verified all surveys started before the date this got merged have been completed.
   */
-  if (currentPhase && participationMethod === 'native_survey') {
+  if (participationMethod === 'native_survey') {
     return (
       <Navigate
-        to={`/projects/${slug}/surveys/new?phase_id=${currentPhase.id}`}
+        to={`/projects/${slug}/surveys/new?phase_id=${phase_id}`}
         replace
       />
     );

--- a/front/app/containers/IdeasNewSurveyPage/IdeasNewSurveyForm/SurveyHeading/index.tsx
+++ b/front/app/containers/IdeasNewSurveyPage/IdeasNewSurveyForm/SurveyHeading/index.tsx
@@ -9,7 +9,7 @@ import {
   stylingConsts,
   Title,
 } from '@citizenlab/cl2-component-library';
-import { useSearchParams, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { RouteType } from 'routes';
 import styled from 'styled-components';
 
@@ -37,15 +37,15 @@ const StyledSurveyTitle = styled(Text)`
 
 type Props = {
   titleText: string | React.ReactNode;
+  phaseId: string;
 };
 
-const SurveyHeading = ({ titleText }: Props) => {
+const SurveyHeading = ({ titleText, phaseId }: Props) => {
   const { slug: projectSlug } = useParams();
   const { data: project } = useProjectBySlug(projectSlug);
   const { data: authUser } = useAuthUser();
 
   const { formatMessage } = useIntl();
-  const [searchParams] = useSearchParams();
   const isSmallerThanPhone = useBreakpoint('phone');
   const [showLeaveModal, setShowLeaveModal] = useState(false);
   const openModal = () => {
@@ -59,9 +59,6 @@ const SurveyHeading = ({ titleText }: Props) => {
 
   const showEditSurveyButton =
     !isSmallerThanPhone && canModerateProject(project.data.id, authUser);
-  const phaseId =
-    searchParams.get('phase_id') ||
-    project.data.relationships.current_phase?.data?.id;
   const linkToSurveyBuilder: RouteType = `/admin/projects/${project.data.id}/phases/${phaseId}/native-survey/edit`;
 
   return (

--- a/front/app/containers/IdeasNewSurveyPage/IdeasNewSurveyForm/index.tsx
+++ b/front/app/containers/IdeasNewSurveyPage/IdeasNewSurveyForm/index.tsx
@@ -66,7 +66,7 @@ interface FormValues {
 
 interface Props {
   project: IProject;
-  phaseId: string;
+  phaseId: string | undefined;
 }
 
 const IdeasNewSurveyForm = ({ project, phaseId }: Props) => {
@@ -158,6 +158,7 @@ const IdeasNewSurveyForm = ({ project, phaseId }: Props) => {
     // inputSchemaError should display an error page instead
     inputSchemaError ||
     !participationMethodConfig ||
+    !phaseId ||
     !schema ||
     !uiSchema
   ) {

--- a/front/app/containers/IdeasNewSurveyPage/IdeasNewSurveyForm/index.tsx
+++ b/front/app/containers/IdeasNewSurveyPage/IdeasNewSurveyForm/index.tsx
@@ -7,7 +7,6 @@ import {
   useBreakpoint,
   useWindowSize,
 } from '@citizenlab/cl2-component-library';
-import { useSearchParams } from 'react-router-dom';
 
 import { IdeaPublicationStatus } from 'api/ideas/types';
 import useAddIdea from 'api/ideas/useAddIdea';
@@ -30,14 +29,16 @@ import ideaFormMessages from 'containers/IdeasNewPage/messages';
 import Form from 'components/Form';
 import { AjvErrorGetter, ApiErrorGetter } from 'components/Form/typings';
 import FullPageSpinner from 'components/UI/FullPageSpinner';
+import Warning from 'components/UI/Warning';
 
+import { useIntl } from 'utils/cl-intl';
 import { getMethodConfig } from 'utils/configs/participationMethodConfig';
-import { isNilOrError } from 'utils/helperUtils';
 import { getElementType, getFieldNameFromPath } from 'utils/JSONFormUtils';
 import { canModerateProject } from 'utils/permissions/rules/projectPermissions';
 
 import { getFormValues } from '../../IdeasEditPage/utils';
 import IdeasNewSurveyMeta from '../IdeasNewSurveyMeta';
+import messages from '../messages';
 
 import SurveyHeading from './SurveyHeading';
 
@@ -65,16 +66,16 @@ interface FormValues {
 
 interface Props {
   project: IProject;
+  phaseId: string;
 }
 
-const IdeasNewSurveyForm = ({ project }: Props) => {
+const IdeasNewSurveyForm = ({ project, phaseId }: Props) => {
+  const { formatMessage } = useIntl();
   const localize = useLocalize();
   const isSmallerThanPhone = useBreakpoint('phone');
   const { mutateAsync: addIdea } = useAddIdea();
   const { mutateAsync: updateIdea } = useUpdateIdea();
   const { data: authUser } = useAuthUser();
-  const [queryParams] = useSearchParams();
-  const phaseId = queryParams.get('phase_id') || undefined;
   const { data: phases } = usePhases(project.data.id);
   const { data: phaseFromUrl } = usePhase(phaseId);
   const {
@@ -157,7 +158,6 @@ const IdeasNewSurveyForm = ({ project }: Props) => {
     // inputSchemaError should display an error page instead
     inputSchemaError ||
     !participationMethodConfig ||
-    !phaseId ||
     !schema ||
     !uiSchema
   ) {
@@ -166,7 +166,7 @@ const IdeasNewSurveyForm = ({ project }: Props) => {
 
   const handleDraftIdeas = async (data: FormValues) => {
     if (data.publication_status === 'draft') {
-      if (allowAnonymousPosting || isNilOrError(authUser)) {
+      if (allowAnonymousPosting || !authUser) {
         // Anonymous or not logged in surveys should not save drafts
         return;
       }
@@ -266,6 +266,7 @@ const IdeasNewSurveyForm = ({ project }: Props) => {
         >
           <SurveyHeading
             titleText={localize(phase?.attributes.native_survey_title_multiloc)}
+            phaseId={phaseId}
           />
         </Box>
         <main id="e2e-idea-new-page">
@@ -282,6 +283,17 @@ const IdeasNewSurveyForm = ({ project }: Props) => {
               h={calculateDynamicHeight()}
               pb={isSmallerThanPhone ? '0' : '80px'}
             >
+              {allowAnonymousPosting && (
+                <Box
+                  w="100%"
+                  px={isSmallerThanPhone ? '16px' : '24px'}
+                  mt="12px"
+                >
+                  <Warning icon="shield-checkered">
+                    {formatMessage(messages.anonymousSurveyMessage)}
+                  </Warning>
+                </Box>
+              )}
               <Form
                 schema={schema}
                 uiSchema={uiSchema}

--- a/front/app/containers/IdeasNewSurveyPage/index.tsx
+++ b/front/app/containers/IdeasNewSurveyPage/index.tsx
@@ -79,8 +79,12 @@ const IdeasNewSurveyPage = () => {
     /* Something I could deduct: when this code was added, we made the (wrong) 
     assumption that `phase_id` was always a string (we were type casting the phase_id param). 
     So I _think_ we are checking here whether phase_id from the search params is differnet from
-    currentPhase?.id when both are strings.*/
-    phaseIdFromSearchParams !== currentPhase?.id;
+    currentPhase?.id when both are strings.
+    
+    I've added back undefined as a fallback, so the check remains the same as when we were using parse
+    to get the phase_id from the search params.
+    */
+    (phaseIdFromSearchParams || undefined) !== currentPhase?.id;
 
   if (disabledReason === 'postingLimitedMaxReached') {
     return <SurveySubmittedNotice project={project.data} />;

--- a/front/app/containers/IdeasNewSurveyPage/index.tsx
+++ b/front/app/containers/IdeasNewSurveyPage/index.tsx
@@ -58,7 +58,7 @@ const IdeasNewSurveyPage = () => {
     return <PageNotFound />;
   }
 
-  if (!phases || !phaseId) {
+  if (!phases) {
     return null;
   }
 
@@ -99,7 +99,7 @@ const IdeasNewSurveyPage = () => {
         context: {
           type: 'phase',
           action: 'posting_idea',
-          id: phaseId,
+          id: phaseId || '',
         },
       });
     };

--- a/front/app/containers/IdeasNewSurveyPage/index.tsx
+++ b/front/app/containers/IdeasNewSurveyPage/index.tsx
@@ -116,7 +116,7 @@ const IdeasNewSurveyPage = () => {
     );
   }
 
-  return <IdeasNewSurveyForm project={project} />;
+  return <IdeasNewSurveyForm project={project} phaseId={phaseId} />;
 };
 
 export default IdeasNewSurveyPage;

--- a/front/app/containers/IdeasNewSurveyPage/index.tsx
+++ b/front/app/containers/IdeasNewSurveyPage/index.tsx
@@ -76,6 +76,10 @@ const IdeasNewSurveyPage = () => {
   // Please replace this text and add a comment if you know.
   const userCannotViewSurvey =
     !canModerateProject(project.data.id, authUser) &&
+    /* Something I could deduct: when this code was added, we made the (wrong) 
+    assumption that `phase_id` was always a string (we were type casting the phase_id param). 
+    So I _think_ we are checking here whether the phase_id from the search params is the same
+    as currentPhase?.id, when both are strings.*/
     phaseIdFromSearchParams !== currentPhase?.id;
 
   if (disabledReason === 'postingLimitedMaxReached') {

--- a/front/app/containers/IdeasNewSurveyPage/index.tsx
+++ b/front/app/containers/IdeasNewSurveyPage/index.tsx
@@ -37,8 +37,7 @@ const IdeasNewSurveyPage = () => {
   // If we reach this component by hitting surveys/new directly, without a phase_id,
   // we'll still get to this component, so we try to get the phase id from getCurrentPhase.
   const phaseIdFromSearchParams = searchParams.get('phase_id');
-  const currentPhaseId =
-    phaseIdFromSearchParams || getCurrentPhase(phases?.data)?.id;
+  const phaseId = phaseIdFromSearchParams || getCurrentPhase(phases?.data)?.id;
 
   /*
     TO DO: simplify these loading & auth checks, then if possible abstract and use the same the IdeasNewPage
@@ -59,7 +58,7 @@ const IdeasNewSurveyPage = () => {
     return <PageNotFound />;
   }
 
-  if (!phases || !currentPhaseId) {
+  if (!phases || !phaseId) {
     return null;
   }
 
@@ -89,7 +88,7 @@ const IdeasNewSurveyPage = () => {
         context: {
           type: 'phase',
           action: 'posting_idea',
-          id: currentPhaseId,
+          id: phaseId,
         },
       });
     };

--- a/front/app/containers/IdeasNewSurveyPage/index.tsx
+++ b/front/app/containers/IdeasNewSurveyPage/index.tsx
@@ -73,7 +73,7 @@ const IdeasNewSurveyPage = () => {
 
   const userCannotViewSurvey =
     // Hard to understand why we do this check without context.
-    // Please replace this text and add a comment explaining this when you know.
+    // Please replace this text and add a comment if you know.
     !canModerateProject(project.data.id, authUser) &&
     phaseIdFromSearchParams !== currentPhase?.id;
 

--- a/front/app/containers/IdeasNewSurveyPage/index.tsx
+++ b/front/app/containers/IdeasNewSurveyPage/index.tsx
@@ -78,8 +78,8 @@ const IdeasNewSurveyPage = () => {
     !canModerateProject(project.data.id, authUser) &&
     /* Something I could deduct: when this code was added, we made the (wrong) 
     assumption that `phase_id` was always a string (we were type casting the phase_id param). 
-    So I _think_ we are checking here whether the phase_id from the search params is the same
-    as currentPhase?.id, when both are strings.*/
+    So I _think_ we are checking here whether phase_id from the search params is differnet from
+    currentPhase?.id when both are strings.*/
     phaseIdFromSearchParams !== currentPhase?.id;
 
   if (disabledReason === 'postingLimitedMaxReached') {

--- a/front/app/containers/IdeasNewSurveyPage/index.tsx
+++ b/front/app/containers/IdeasNewSurveyPage/index.tsx
@@ -71,9 +71,10 @@ const IdeasNewSurveyPage = () => {
       authUser: authUser?.data,
     });
 
+  // Hard to understand why this is needed without context.
+  // The phase id checks are also unclear.
+  // Please replace this text and add a comment if you know.
   const userCannotViewSurvey =
-    // Hard to understand why we do this check without context.
-    // Please replace this text and add a comment if you know.
     !canModerateProject(project.data.id, authUser) &&
     phaseIdFromSearchParams !== currentPhase?.id;
 

--- a/front/app/containers/IdeasNewSurveyPage/index.tsx
+++ b/front/app/containers/IdeasNewSurveyPage/index.tsx
@@ -72,6 +72,8 @@ const IdeasNewSurveyPage = () => {
     });
 
   const userCannotViewSurvey =
+    // Hard to understand why we do this check without context.
+    // Please replace this text and add a comment explaining this when you know.
     !canModerateProject(project.data.id, authUser) &&
     phaseIdFromSearchParams !== currentPhase?.id;
 

--- a/front/app/containers/IdeasNewSurveyPage/messages.ts
+++ b/front/app/containers/IdeasNewSurveyPage/messages.ts
@@ -30,4 +30,8 @@ export default defineMessages({
     defaultMessage:
       'This survey is not currently open for responses. Please return to the project for more information.',
   },
+  anonymousSurveyMessage: {
+    id: 'app.components.form.anonymousSurveyMessage',
+    defaultMessage: 'All responses to this survey are anonymized',
+  },
 });

--- a/front/app/containers/ProjectsShowPage/SucessModal.tsx
+++ b/front/app/containers/ProjectsShowPage/SucessModal.tsx
@@ -27,8 +27,8 @@ const SuccessModal = ({ projectId }: Props) => {
   const { data: phases } = usePhases(projectId);
 
   const [queryParams] = useSearchParams();
-  const [showModalParam] = useState<boolean>(!!queryParams.get('show_modal'));
-  const [phaseIdParam] = useState<string | null>(queryParams.get('phase_id'));
+  const showModalParam = !!queryParams.get('show_modal');
+  const phaseIdParam = queryParams.get('phase_id');
 
   const [showModal, setShowModal] = useState<boolean>(false);
 


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Old, "hard-coded" links to the survey form (using `/ideas/new` instead of `/surveys/new`) would lead to a broken form if the survey's phase were in the past (such as the "Vul de vragenlijst in" button/link [here](https://participatie.stad.gent/nl-BE/projects/pioenstraat)). In practice, seeing such a broken form could only happen to admins, since others can not access the form if its containing phase is over.