### PR TITLE
Tan 2069/permissions custom fields flag

### DIFF
--- a/front/app/api/app_configuration/types.ts
+++ b/front/app/api/app_configuration/types.ts
@@ -167,14 +167,12 @@ export interface IAppConfigurationSettings {
   snap_survey_surveys?: AppConfigurationFeature;
   project_folders?: AppConfigurationFeature;
   bulk_import_ideas?: AppConfigurationFeature;
-  // relevant flag
   granular_permissions?: AppConfigurationFeature;
   machine_translations?: AppConfigurationFeature;
   polls?: AppConfigurationFeature;
   moderation?: AppConfigurationFeature;
   flag_inappropriate_content?: AppConfigurationFeature;
   disable_disliking?: AppConfigurationFeature;
-  // relevant flag
   project_management?: AppConfigurationFeature;
   blocking_profanity?: AppConfigurationFeature;
   anonymous_participation?: AppConfigurationFeature;
@@ -211,9 +209,7 @@ export interface IAppConfigurationSettings {
   project_description_builder?: AppConfigurationFeature;
   remove_vendor_branding?: AppConfigurationFeature;
   user_confirmation?: AppConfigurationFeature;
-  // relevant flag
   permission_option_email_confirmation?: AppConfigurationFeature;
-  // relevant flag
   permissions_custom_fields?: AppConfigurationFeature;
   input_form_custom_fields?: AppConfigurationFeature;
   report_builder?: AppConfigurationFeature;

--- a/front/app/api/app_configuration/types.ts
+++ b/front/app/api/app_configuration/types.ts
@@ -166,12 +166,14 @@ export interface IAppConfigurationSettings {
   snap_survey_surveys?: AppConfigurationFeature;
   project_folders?: AppConfigurationFeature;
   bulk_import_ideas?: AppConfigurationFeature;
+  // relevant flag
   granular_permissions?: AppConfigurationFeature;
   machine_translations?: AppConfigurationFeature;
   polls?: AppConfigurationFeature;
   moderation?: AppConfigurationFeature;
   flag_inappropriate_content?: AppConfigurationFeature;
   disable_disliking?: AppConfigurationFeature;
+  // relevant flag
   project_management?: AppConfigurationFeature;
   blocking_profanity?: AppConfigurationFeature;
   anonymous_participation?: AppConfigurationFeature;
@@ -208,7 +210,9 @@ export interface IAppConfigurationSettings {
   project_description_builder?: AppConfigurationFeature;
   remove_vendor_branding?: AppConfigurationFeature;
   user_confirmation?: AppConfigurationFeature;
+  // relevant flag
   permission_option_email_confirmation?: AppConfigurationFeature;
+  // relevant flag
   permissions_custom_fields?: AppConfigurationFeature;
   input_form_custom_fields?: AppConfigurationFeature;
   report_builder?: AppConfigurationFeature;

--- a/front/app/containers/Admin/projects/project/permissions/granular_permissions/components/UserFieldSelection/UserFieldSelection.tsx
+++ b/front/app/containers/Admin/projects/project/permissions/granular_permissions/components/UserFieldSelection/UserFieldSelection.tsx
@@ -226,11 +226,11 @@ const UserFieldSelection = ({
                         label={
                           <Text
                             fontSize="s"
-                            style={
-                              !permissionsCustomFieldsEnabled
-                                ? { color: colors.disabled }
-                                : { color: colors.primary }
-                            }
+                            style={{
+                              color: permissionsCustomFieldsEnabled
+                                ? colors.primary
+                                : colors.disabled,
+                            }}
                           >
                             <FormattedMessage {...messages.required} />
                           </Text>

--- a/front/app/containers/Admin/projects/project/permissions/granular_permissions/components/UserFieldSelection/UserFieldSelection.tsx
+++ b/front/app/containers/Admin/projects/project/permissions/granular_permissions/components/UserFieldSelection/UserFieldSelection.tsx
@@ -56,8 +56,9 @@ const UserFieldSelection = ({
 }: UserFieldSelectionProps) => {
   const { data: authUser } = useAuthUser();
   const { formatMessage } = useIntl();
-  const permissionsCustomFieldsEnabled = useFeatureFlag({
+  const permissionsCustomFieldsAllowed = useFeatureFlag({
     name: 'permissions_custom_fields',
+    onlyCheckAllowed: true,
   });
   const { data: globalRegistrationFields } = useUserCustomFields();
   const initialFields = usePermissionsCustomFields({
@@ -133,7 +134,7 @@ const UserFieldSelection = ({
   return (
     <Tooltip
       placement={'bottom'}
-      disabled={permissionsCustomFieldsEnabled}
+      disabled={permissionsCustomFieldsAllowed}
       theme={'dark'}
       content={
         <Box style={{ cursor: 'default' }}>
@@ -161,7 +162,7 @@ const UserFieldSelection = ({
             <Box mb="10px">
               <Toggle
                 checked={permission.attributes.global_custom_fields}
-                disabled={!permissionsCustomFieldsEnabled}
+                disabled={!permissionsCustomFieldsAllowed}
                 onChange={() => {
                   onChange({
                     phaseId,
@@ -175,7 +176,7 @@ const UserFieldSelection = ({
                   <Box display="flex">
                     <span
                       style={{
-                        color: permissionsCustomFieldsEnabled
+                        color: permissionsCustomFieldsAllowed
                           ? colors.primary
                           : colors.disabled,
                       }}
@@ -184,7 +185,7 @@ const UserFieldSelection = ({
                         {...messages.useExistingRegistrationQuestions}
                       />
                     </span>
-                    {permissionsCustomFieldsEnabled && (
+                    {permissionsCustomFieldsAllowed && (
                       <IconTooltip
                         ml="4px"
                         icon="info-solid"
@@ -213,7 +214,7 @@ const UserFieldSelection = ({
                   >
                     <Text
                       style={{
-                        color: permissionsCustomFieldsEnabled
+                        color: permissionsCustomFieldsAllowed
                           ? colors.primary
                           : colors.disabled,
                       }}
@@ -223,7 +224,7 @@ const UserFieldSelection = ({
                     <Box display="flex">
                       <Toggle
                         checked={field.attributes.required}
-                        disabled={!permissionsCustomFieldsEnabled}
+                        disabled={!permissionsCustomFieldsAllowed}
                         onChange={() => {
                           updatePermissionCustomField({
                             id: field.id,
@@ -234,7 +235,7 @@ const UserFieldSelection = ({
                           <Text
                             fontSize="s"
                             style={
-                              !permissionsCustomFieldsEnabled
+                              !permissionsCustomFieldsAllowed
                                 ? { color: colors.disabled }
                                 : { color: colors.primary }
                             }
@@ -246,7 +247,7 @@ const UserFieldSelection = ({
                       <Button
                         buttonStyle="text"
                         icon="delete"
-                        disabled={!permissionsCustomFieldsEnabled}
+                        disabled={!permissionsCustomFieldsAllowed}
                         onClick={() => {
                           handleDeleteField(field.id);
                         }}
@@ -261,7 +262,7 @@ const UserFieldSelection = ({
                 <Button
                   icon="plus-circle"
                   bgColor={colors.primary}
-                  disabled={!permissionsCustomFieldsEnabled}
+                  disabled={!permissionsCustomFieldsAllowed}
                   onClick={() => {
                     setShowSelectionModal(true);
                   }}

--- a/front/app/containers/Admin/projects/project/permissions/granular_permissions/components/UserFieldSelection/UserFieldSelection.tsx
+++ b/front/app/containers/Admin/projects/project/permissions/granular_permissions/components/UserFieldSelection/UserFieldSelection.tsx
@@ -227,11 +227,7 @@ const UserFieldSelection = ({
                         label={
                           <Text
                             fontSize="s"
-                            style={{
-                              color: permissionsCustomFieldsAllowed
-                                ? colors.primary
-                                : colors.disabled,
-                            }}
+                            color={permissionsCustomFieldsAllowed ? 'primary' : 'disabled'}
                           >
                             <FormattedMessage {...messages.required} />
                           </Text>

--- a/front/app/containers/Admin/projects/project/permissions/granular_permissions/components/UserFieldSelection/UserFieldSelection.tsx
+++ b/front/app/containers/Admin/projects/project/permissions/granular_permissions/components/UserFieldSelection/UserFieldSelection.tsx
@@ -12,7 +12,6 @@ import {
 } from '@citizenlab/cl2-component-library';
 import { SupportedLocale } from 'typings';
 
-import useAuthUser from 'api/me/useAuthUser';
 import { IPermissionData } from 'api/permissions/types';
 import { IPermissionsCustomFieldData } from 'api/permissions_custom_fields/types';
 import useAddPermissionCustomField from 'api/permissions_custom_fields/useAddPermissionsCustomField';
@@ -27,7 +26,6 @@ import useLocale from 'hooks/useLocale';
 
 import { FormattedMessage, useIntl } from 'utils/cl-intl';
 import FormattedMessageComponent from 'utils/cl-intl/FormattedMessage';
-import { isNilOrError } from 'utils/helperUtils';
 
 import messages from '../../containers/Granular/messages';
 import { HandlePermissionChangeProps } from '../../containers/Granular/utils';
@@ -54,7 +52,6 @@ const UserFieldSelection = ({
   initiativeContext,
   onChange,
 }: UserFieldSelectionProps) => {
-  const { data: authUser } = useAuthUser();
   const { formatMessage } = useIntl();
   const permissionsCustomFieldsEnabled = useFeatureFlag({
     name: 'permissions_custom_fields',
@@ -118,10 +115,6 @@ const UserFieldSelection = ({
   };
 
   const groupIds = permission.relationships.groups.data.map((p) => p.id);
-
-  if (isNilOrError(locale) || isNilOrError(authUser)) {
-    return null;
-  }
 
   const showQuestionToggle =
     permission.attributes.permitted_by !== 'everyone_confirmed_email';


### PR DESCRIPTION
# Changelog

## Changed
- Disable phase-level custom registration fields and show upsell nudge when this feature (currently called `permissions_custom_fields`) is not allowed by the platform's pricing plan, instead of using the enabled value. ([Screenshot of feature when it's not enabled within pricing plan](https://github.com/CitizenLabDotCo/citizenlab/assets/16427929/55a3d3b2-4a85-4e2c-b412-4774b172108c))