### PR TITLE
Remove useless authUser check in admin routes index

### DIFF
--- a/front/app/containers/Admin/routes.tsx
+++ b/front/app/containers/Admin/routes.tsx
@@ -5,13 +5,12 @@ import { Navigate, useLocation } from 'react-router-dom';
 
 import { IAppConfigurationData } from 'api/app_configuration/types';
 import useAppConfiguration from 'api/app_configuration/useAppConfiguration';
-import useAuthUser from 'api/me/useAuthUser';
 
 import PageLoading from 'components/UI/PageLoading';
 import Unauthorized from 'components/Unauthorized';
 
 import { removeLocale } from 'utils/cl-router/updateLocationDescriptor';
-import { isNilOrError, isUUID } from 'utils/helperUtils';
+import { isUUID } from 'utils/helperUtils';
 import { usePermission } from 'utils/permissions';
 
 import createDashboardRoutes, { dashboardRouteTypes } from './dashboard/routes';
@@ -100,9 +99,8 @@ const IndexElement = () => {
   });
 
   const { data: appConfiguration } = useAppConfiguration();
-  const { data: authUser } = useAuthUser();
 
-  if (isNilOrError(appConfiguration) || authUser === undefined) return null;
+  if (!appConfiguration) return null;
 
   const redirectURL = accessAuthorized
     ? null


### PR DESCRIPTION
This was not an important check but another reminder to [fix useAuthUser](https://www.notion.so/govocal/Fix-useAuthUser-9b1730cc68784b17bb1fda30cb70a37c?pvs=4). cc @EdwinKato, I have linked the ticket to QQ XL. Would be great to get this fixed before bad things happen.

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Technical
- Remove unmatchable `authUser` check from admin index route.