### PR TITLE
[TAN-2203] Remove hard-coded date limit in activity scope

### DIFF
--- a/back/app/models/activity.rb
+++ b/back/app/models/activity.rb
@@ -40,14 +40,7 @@ class Activity < ApplicationRecord
   validates :action, :item_type, :item_id, presence: true
 
   scope :management, lambda {
-    # We exclude activities that are older than 2024-05-20, because this is when we released the code that adds
-    # a serialized copy of the item to the payload of 'created' and 'changed' activities,
-    # and the change(s) to the payload of the 'changed' activities, when these activities are created.
-    # Without this additional info, the activities cannot display correctly in the management feed.
-    # This condition can be removed when the cutoff date is before the period used for the acted_at condition.
-    activities = where('created_at > ?', Date.new(2024, 5, 20))
-      .where('acted_at > ?', 30.days.ago)
-      .where(user: User.admin_or_moderator)
+    activities = where('acted_at > ?', 30.days.ago).where(user: User.admin_or_moderator)
 
     result = Activity.none
 

--- a/back/spec/models/activity_spec.rb
+++ b/back/spec/models/activity_spec.rb
@@ -68,16 +68,6 @@ RSpec.describe Activity do
         activity = create(:idea_created_activity, user: admin, acted_at: 31.days.ago)
         expect(described_class.management).not_to include(activity)
       end
-
-      it 'inludes activities where created_at is later than 20-05-2024' do
-        activity = create(:idea_created_activity, user: admin, created_at: Date.new(2024, 5, 21))
-        expect(described_class.management).to include(activity)
-      end
-
-      it 'excludes activities where created_at is earlier than 21-05-2024' do
-        activity = create(:idea_created_activity, user: admin, created_at: Date.new(2024, 5, 20))
-        expect(described_class.management).not_to include(activity)
-      end
     end
   end
 end


### PR DESCRIPTION
We excluded activities that are older than 2024-05-20, because this is when we released the code that adds a serialized copy of the item to the payload of 'created' and 'changed' activities, and the change(s) to the payload of the 'changed' activities, when these activities are created.
Without this additional info, the activities cannot display correctly in the management feed.

This condition can now be removed, as the cutoff date is before the period used for the `acted_at` condition.

# Changelog
## Technical
- [TAN-2203] Remove hard-coded date limit in activity scope
