### PR TITLE
Quick fix for height of "users with confirmed email"

### DIFF
--- a/front/app/containers/Admin/projects/project/permissions/granular_permissions/containers/Granular/ActionForm.tsx
+++ b/front/app/containers/Admin/projects/project/permissions/granular_permissions/containers/Granular/ActionForm.tsx
@@ -127,15 +127,13 @@ const ActionForm = ({
                 selected={permittedBy === 'everyone'}
               />
             )}
-            <Tooltip
-              // user_confirmation needs to be enabled for this option to work
-              disabled={userConfirmationEnabled}
-              content={
-                <FormattedMessage
-                  {...messages.userConfirmationRequiredTooltip}
-                />
-              }
-            >
+            {/* 
+              This is a quick fix.
+              The height of the CardButton is not equal to that of other CardButtons when wrapped in a Tooltip.
+              Ideally, we should have a Tooltip component that can wrap any component and adjust its height accordingly.
+              Now, only clients with user_confirmation disabled (~1%) will see the version that's too short (the one wrapped with Tooltip).
+            */}
+            {userConfirmationEnabled ? (
               <CardButton
                 id="e2e-permission-email-confirmed-users"
                 iconName="email"
@@ -147,9 +145,32 @@ const ActionForm = ({
                 )}
                 onClick={handlePermittedByUpdate('everyone_confirmed_email')}
                 selected={permittedBy === 'everyone_confirmed_email'}
-                disabled={!userConfirmationEnabled}
               />
-            </Tooltip>
+            ) : (
+              <Tooltip
+                // user_confirmation needs to be enabled for this option to work
+                disabled={false}
+                content={
+                  <FormattedMessage
+                    {...messages.userConfirmationRequiredTooltip}
+                  />
+                }
+              >
+                <CardButton
+                  id="e2e-permission-email-confirmed-users"
+                  iconName="email"
+                  title={formatMessage(
+                    permissionsMessages.permissionsEmailConfirmLabel
+                  )}
+                  subtitle={formatMessage(
+                    permissionsMessages.permissionsEmailConfirmLabelDescription
+                  )}
+                  onClick={handlePermittedByUpdate('everyone_confirmed_email')}
+                  selected={permittedBy === 'everyone_confirmed_email'}
+                  disabled
+                />
+              </Tooltip>
+            )}
             <CardButton
               id="e2e-permission-registered-users"
               iconName="user-circle"

--- a/front/app/containers/Admin/projects/project/permissions/granular_permissions/containers/Granular/ActionForm.tsx
+++ b/front/app/containers/Admin/projects/project/permissions/granular_permissions/containers/Granular/ActionForm.tsx
@@ -127,13 +127,15 @@ const ActionForm = ({
                 selected={permittedBy === 'everyone'}
               />
             )}
-            {/* 
-              This is a quick fix.
-              The height of the CardButton is not equal to that of other CardButtons when wrapped in a Tooltip.
-              Ideally, we should have a Tooltip component that can wrap any component and adjust its height accordingly.
-              Now, only clients with user_confirmation disabled (~1%) will see the version that's too short (the one wrapped with Tooltip).
-            */}
-            {userConfirmationEnabled ? (
+            <Tooltip
+              // user_confirmation needs to be enabled for this option to work
+              disabled={userConfirmationEnabled}
+              content={
+                <FormattedMessage
+                  {...messages.userConfirmationRequiredTooltip}
+                />
+              }
+            >
               <CardButton
                 id="e2e-permission-email-confirmed-users"
                 iconName="email"
@@ -145,32 +147,9 @@ const ActionForm = ({
                 )}
                 onClick={handlePermittedByUpdate('everyone_confirmed_email')}
                 selected={permittedBy === 'everyone_confirmed_email'}
+                disabled={!userConfirmationEnabled}
               />
-            ) : (
-              <Tooltip
-                // user_confirmation needs to be enabled for this option to work
-                disabled={false}
-                content={
-                  <FormattedMessage
-                    {...messages.userConfirmationRequiredTooltip}
-                  />
-                }
-              >
-                <CardButton
-                  id="e2e-permission-email-confirmed-users"
-                  iconName="email"
-                  title={formatMessage(
-                    permissionsMessages.permissionsEmailConfirmLabel
-                  )}
-                  subtitle={formatMessage(
-                    permissionsMessages.permissionsEmailConfirmLabelDescription
-                  )}
-                  onClick={handlePermittedByUpdate('everyone_confirmed_email')}
-                  selected={permittedBy === 'everyone_confirmed_email'}
-                  disabled
-                />
-              </Tooltip>
-            )}
+            </Tooltip>
             <CardButton
               id="e2e-permission-registered-users"
               iconName="user-circle"

--- a/front/app/containers/Admin/projects/project/permissions/granular_permissions/containers/Granular/ActionForm.tsx
+++ b/front/app/containers/Admin/projects/project/permissions/granular_permissions/containers/Granular/ActionForm.tsx
@@ -148,6 +148,7 @@ const ActionForm = ({
                 onClick={handlePermittedByUpdate('everyone_confirmed_email')}
                 selected={permittedBy === 'everyone_confirmed_email'}
                 disabled={!userConfirmationEnabled}
+                height="100%"
               />
             </Tooltip>
             <CardButton


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed 
- Height of "users with confirmed email" phase-level access rights option ([before](https://github.com/CitizenLabDotCo/citizenlab/assets/16427929/f73dab12-71df-47f7-a52e-e7d1f18b67e0)/[after](https://github.com/CitizenLabDotCo/citizenlab/assets/16427929/af543e9f-4277-451e-91ec-4de4c9f24fff))
