### PR TITLE
[TAN-760] Cancel other pending email-change flows once one change is confirmed

### DIFF
--- a/back/app/models/concerns/user_confirmation.rb
+++ b/back/app/models/concerns/user_confirmation.rb
@@ -27,11 +27,17 @@ module UserConfirmation
   end
 
   def confirm!
-    return if !confirmation_required? && !new_email
+    return unless confirmation_required? || new_email
 
     confirm_new_email if new_email.present?
     confirm
     save!
+
+    # Cancel any other pending email changes initiated with the same email to prevent
+    # those users from becoming invalid due to email validations.
+    User
+      .where(new_email: email)
+      .update_all(new_email: nil, email_confirmation_code: nil, updated_at: Time.zone.now)
   end
 
   def reset_confirmation_and_counts

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -1181,6 +1181,17 @@ RSpec.describe User do
         user.save!
         expect { user.confirm! }.to change(user, :saved_change_to_email_confirmed_at?)
       end
+
+      it 'cancels any pending email change initiated with the same email' do
+        new_email = 'new-email@provider.org'
+        user1, user2 = create_list(:user, 2, new_email: new_email, email_confirmation_code: 9999)
+
+        user1.confirm!
+
+        user2.reload
+        expect(user2.new_email).to be_nil
+        expect(user2.email_confirmation_code).to be_nil
+      end
     end
   end
 


### PR DESCRIPTION
# Changelog
## Fixed 
- [TAN-760] Prevent users with a pending email change to become invalid if another account confirms the same email address. Multiple accounts can initiate a change to the same email. However, once one account confirms it, all other pending changes must be cancelled.
