### PR TITLE
[TAN-2103] Remove `disable_downvoting` feature flag

### DIFF
--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -932,18 +932,6 @@
         }
       },
 
-      "disable_downvoting": {
-        "type": "object",
-        "title": "Downvoting Toggle",
-        "description": "Display toggle in Project settings or Project’s timeline phase settings, that permits the disabling and re-enabling of downvoting. By default, downvoting is enabled.",
-        "additionalProperties": false,
-        "required": ["allowed", "enabled"],
-        "properties": {
-          "allowed": { "type": "boolean", "default": false},
-          "enabled": { "type": "boolean", "default": false}
-        }
-      },
-
       "disable_disliking": {
         "type": "object",
         "title": "Disliking Toggle",


### PR DESCRIPTION



# Changelog
## Technical
- [TAN-2103] Remove `disable_downvoting` feature flag. This feature flag has been renamed to `disable_disliking` (see CL-3787) and is no longer used.
