### PR TITLE
TAN-2257: Show different text when there is no phase id

### DIFF
--- a/front/app/containers/Admin/projects/project/messages.ts
+++ b/front/app/containers/Admin/projects/project/messages.ts
@@ -561,6 +561,11 @@ export default defineMessages({
     id: 'app.components.app.containers.AdminPage.ProjectEdit.optionsToVoteOnDescription2',
     defaultMessage: 'Configure the voting options in the {optionsPageLink}.',
   },
+  optionsToVoteOnDescWihoutPhase: {
+    id: 'app.components.app.containers.AdminPage.ProjectEdit.optionsToVoteOnDescWihoutPhase',
+    defaultMessage:
+      'Configure the voting options in the Input manager tab after creating a phase.',
+  },
   optionsPageText: {
     id: 'app.components.app.containers.AdminPage.ProjectEdit.optionsPageText2',
     defaultMessage: 'Input Manager tab',

--- a/front/app/containers/Admin/projects/project/phase/phaseParticipationConfig/components/inputs/VotingInputs/index.tsx
+++ b/front/app/containers/Admin/projects/project/phase/phaseParticipationConfig/components/inputs/VotingInputs/index.tsx
@@ -133,19 +133,23 @@ export default ({
           <SubSectionTitleWithDescription>
             <FormattedMessage {...messages.optionsToVoteOn} />
           </SubSectionTitleWithDescription>
-          <FormattedMessage
-            {...messages.optionsToVoteOnDescription}
-            values={{
-              optionsPageLink: (
-                <Link
-                  to={`/admin/projects/${projectId}/phases/${phaseId}/ideas`}
-                  rel="noreferrer"
-                >
-                  <FormattedMessage {...messages.optionsPageText} />
-                </Link>
-              ),
-            }}
-          />
+          {phaseId ? (
+            <FormattedMessage
+              {...messages.optionsToVoteOnDescription}
+              values={{
+                optionsPageLink: (
+                  <Link
+                    to={`/admin/projects/${projectId}/phases/${phaseId}/ideas`}
+                    rel="noreferrer"
+                  >
+                    <FormattedMessage {...messages.optionsPageText} />
+                  </Link>
+                ),
+              }}
+            />
+          ) : (
+            <FormattedMessage {...messages.optionsToVoteOnDescWihoutPhase} />
+          )}
         </SectionField>
         {voting_method === 'budgeting' && (
           <BudgetingInputs

--- a/front/app/translations/admin/en.json
+++ b/front/app/translations/admin/en.json
@@ -306,6 +306,7 @@
   "app.components.app.containers.AdminPage.ProjectEdit.minVotesRequired": "A minimum number of votes is required",
   "app.components.app.containers.AdminPage.ProjectEdit.optionTerm": "Option",
   "app.components.app.containers.AdminPage.ProjectEdit.optionsPageText2": "Input Manager tab",
+  "app.components.app.containers.AdminPage.ProjectEdit.optionsToVoteOnDescWihoutPhase": "Configure the voting options in the Input manager tab after creating a phase.",
   "app.components.app.containers.AdminPage.ProjectEdit.optionsToVoteOnDescription2": "Configure the voting options in the {optionsPageLink}.",
   "app.components.app.containers.AdminPage.ProjectEdit.participationTab": "Participants",
   "app.components.app.containers.AdminPage.ProjectEdit.phaseHeader.adminsAndManagers": "Admins & managers",


### PR DESCRIPTION
# Changelog

## Fixed
- Remove broken link to input manager when creating new voting phase
