### PR TITLE
[TAN-1736] Fix error serializing SphericalPointImpl

### DIFF
--- a/back/config/initializers/active_job.rb
+++ b/back/config/initializers/active_job.rb
@@ -1,0 +1,3 @@
+require Rails.root.join('lib/spherical_point_impl_active_job_serializer')
+
+Rails.application.config.active_job.custom_serializers << SphericalPointImplActiveJobSerializer

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/event_registration_confirmation_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/event_registration_confirmation_spec.rb
@@ -48,9 +48,9 @@ RSpec.describe EmailCampaigns::Campaigns::EventRegistrationConfirmation do
       before { event.update!(location_point: 'POINT (1.0 2.0)') }
 
       it 'can be processed by ActiveJob', :active_job_que_adapter do
-        stub_const 'TestJob', Class.new(ApplicationJob) do
+        stub_const 'TestJob', (Class.new(ApplicationJob) do
           def run(commands); end
-        end
+        end)
 
         commands = campaign.generate_commands(recipient: recipient, activity: activity)
 

--- a/back/lib/spherical_point_impl_active_job_serializer.rb
+++ b/back/lib/spherical_point_impl_active_job_serializer.rb
@@ -2,14 +2,23 @@
 # https://api.rubyonrails.org/classes/ActiveJob/Serializers/ObjectSerializer.html
 class SphericalPointImplActiveJobSerializer < ActiveJob::Serializers::ObjectSerializer
   def serialize(point)
-    super(
+    hash = {
       'x' => point.x,
       'y' => point.y
-    )
+    }
+    hash['z'] = point.z if point.z
+    hash['m'] = point.m if point.m
+
+    super(hash)
   end
 
   def deserialize(hash)
-    RGeo::Geographic.spherical_factory(srid: 4326).point(hash['x'], hash['y'])
+    factory = RGeo::Geographic.spherical_factory(srid: 4326, has_z_coordinate: !!hash['z'], has_m_coordinate: !!hash['m'])
+    attrs = [hash['x'], hash['y']]
+    attrs << hash['z'] if hash['z']
+    attrs << hash['m'] if hash['m']
+
+    factory.point(*attrs)
   end
 
   private

--- a/back/lib/spherical_point_impl_active_job_serializer.rb
+++ b/back/lib/spherical_point_impl_active_job_serializer.rb
@@ -2,10 +2,10 @@
 # https://api.rubyonrails.org/classes/ActiveJob/Serializers/ObjectSerializer.html
 class SphericalPointImplActiveJobSerializer < ActiveJob::Serializers::ObjectSerializer
   def serialize(point)
-    {
+    super(
       'x' => point.x,
       'y' => point.y
-    }
+    )
   end
 
   def deserialize(hash)

--- a/back/lib/spherical_point_impl_active_job_serializer.rb
+++ b/back/lib/spherical_point_impl_active_job_serializer.rb
@@ -1,0 +1,20 @@
+# https://blog.saeloun.com/2019/09/11/rails-6-custom-serializers-for-activejob-arguments/
+# https://api.rubyonrails.org/classes/ActiveJob/Serializers/ObjectSerializer.html
+class SphericalPointImplActiveJobSerializer < ActiveJob::Serializers::ObjectSerializer
+  def serialize(point)
+    {
+      'x' => point.x,
+      'y' => point.y
+    }
+  end
+
+  def deserialize(hash)
+    RGeo::Geographic.spherical_factory.point(hash['x'], hash['y'])
+  end
+
+  private
+
+  def klass
+    RGeo::Geographic::SphericalPointImpl
+  end
+end

--- a/back/lib/spherical_point_impl_active_job_serializer.rb
+++ b/back/lib/spherical_point_impl_active_job_serializer.rb
@@ -9,7 +9,7 @@ class SphericalPointImplActiveJobSerializer < ActiveJob::Serializers::ObjectSeri
   end
 
   def deserialize(hash)
-    RGeo::Geographic.spherical_factory.point(hash['x'], hash['y'])
+    RGeo::Geographic.spherical_factory(srid: 4326).point(hash['x'], hash['y'])
   end
 
   private

--- a/back/spec/lib/spherical_point_impl_active_job_serializer_spec.rb
+++ b/back/spec/lib/spherical_point_impl_active_job_serializer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe SphericalPointImplActiveJobSerializer do
   describe '#serialize' do
     it 'correctly serializes a RGeo::Geographic::SphericalPointImpl object' do
       serializer = described_class.send(:new)
-      expect(serializer.serialize(point)).to eq(serialized_point)
+      expect(serializer.serialize(point)).to include(serialized_point)
     end
   end
 
@@ -32,7 +32,7 @@ RSpec.describe SphericalPointImplActiveJobSerializer do
       TestJob.perform_later(point)
       jobs = QueJob.by_args({ job_class: 'TestJob' })
       expect(jobs.count).to eq 1
-      expect(jobs.first.args['arguments']).to eq([serialized_point])
+      expect(jobs.first.args['arguments'].first).to include(serialized_point)
     end
   end
 end

--- a/back/spec/lib/spherical_point_impl_active_job_serializer_spec.rb
+++ b/back/spec/lib/spherical_point_impl_active_job_serializer_spec.rb
@@ -1,50 +1,101 @@
 require 'rails_helper'
 
 RSpec.describe SphericalPointImplActiveJobSerializer do
-  let(:point) do
-    factory = Event.new(location_point: 'POINT (1.0 2.0)').location_point.factory
-    factory.point(1.0, 2.0)
-  end
-  let(:serialized_point) { { 'x' => 1.0, 'y' => 2.0 } }
+  context 'when point has only x and y' do
+    let(:point) do
+      factory = Event.new(location_point: 'POINT (1.0 2.0)').location_point.factory
+      factory.point(1.0, 2.0)
+    end
+    let(:serialized_point) { { 'x' => 1.0, 'y' => 2.0 } }
 
-  describe '#serialize' do
-    it 'correctly serializes a RGeo::Geographic::SphericalPointImpl object' do
-      serializer = described_class.send(:new)
-      expect(serializer.serialize(point).except('_aj_serialized')).to eq(serialized_point)
+    describe '#serialize' do
+      it 'correctly serializes a RGeo::Geographic::SphericalPointImpl object' do
+        serializer = described_class.send(:new)
+        expect(serializer.serialize(point).except('_aj_serialized')).to eq(serialized_point)
+      end
+    end
+
+    describe '#deserialize' do
+      it 'correctly deserializes a hash to a RGeo::Geographic::SphericalPointImpl object' do
+        serializer = described_class.send(:new)
+        deserialized_point = serializer.deserialize(serialized_point)
+
+        expect(deserialized_point).to be_a(RGeo::Geographic::SphericalPointImpl)
+
+        expect(deserialized_point.x).to eq(1.0)
+        expect(deserialized_point.x).to eq(point.x)
+        expect(deserialized_point.y).to eq(2.0)
+        expect(deserialized_point.y).to eq(point.y)
+
+        expect(deserialized_point.z).to eq(point.z)
+        expect(deserialized_point.z).to be_nil
+        expect(deserialized_point.m).to eq(point.m)
+        expect(deserialized_point.m).to be_nil
+      end
+    end
+
+    describe 'integration with ActiveJob', :active_job_que_adapter do
+      before do
+        stub_const 'TestJob', (Class.new(ApplicationJob) do
+          def run(point); end
+        end)
+      end
+
+      it 'correctly processes passed point object' do
+        TestJob.perform_later(point)
+        jobs = QueJob.by_args({ job_class: 'TestJob' })
+        expect(jobs.count).to eq 1
+        expect(jobs.first.args['arguments'].first.except('_aj_serialized')).to eq(serialized_point)
+      end
     end
   end
 
-  describe '#deserialize' do
-    it 'correctly deserializes a hash to a RGeo::Geographic::SphericalPointImpl object' do
-      serializer = described_class.send(:new)
-      deserialized_point = serializer.deserialize(serialized_point)
-
-      expect(deserialized_point).to be_a(RGeo::Geographic::SphericalPointImpl)
-
-      expect(deserialized_point.x).to eq(1.0)
-      expect(deserialized_point.x).to eq(point.x)
-      expect(deserialized_point.y).to eq(2.0)
-      expect(deserialized_point.y).to eq(point.y)
-
-      expect(deserialized_point.z).to eq(point.z)
-      expect(deserialized_point.z).to be_nil
-      expect(deserialized_point.m).to eq(point.m)
-      expect(deserialized_point.m).to be_nil
+  context 'when point has x, y, z, and m' do
+    let(:point) do
+      factory = RGeo::Geographic.spherical_factory(srid: 4326, has_z_coordinate: true, has_m_coordinate: true)
+      factory.point(1.0, 2.0, 3, 4)
     end
-  end
+    let(:serialized_point) { { 'x' => 1.0, 'y' => 2.0, 'z' => 3, 'm' => 4 } }
 
-  describe 'integration with ActiveJob', :active_job_que_adapter do
-    before do
-      stub_const 'TestJob', (Class.new(ApplicationJob) do
-        def run(point); end
-      end)
+    describe '#serialize' do
+      it 'correctly serializes a RGeo::Geographic::SphericalPointImpl object' do
+        serializer = described_class.send(:new)
+        expect(serializer.serialize(point).except('_aj_serialized')).to eq(serialized_point)
+      end
     end
 
-    it 'correctly processes passed point object' do
-      TestJob.perform_later(point)
-      jobs = QueJob.by_args({ job_class: 'TestJob' })
-      expect(jobs.count).to eq 1
-      expect(jobs.first.args['arguments'].first.except('_aj_serialized')).to eq(serialized_point)
+    describe '#deserialize' do
+      it 'correctly deserializes a hash to a RGeo::Geographic::SphericalPointImpl object' do
+        serializer = described_class.send(:new)
+        deserialized_point = serializer.deserialize(serialized_point)
+
+        expect(deserialized_point).to be_a(RGeo::Geographic::SphericalPointImpl)
+
+        expect(deserialized_point.x).to eq(1.0)
+        expect(deserialized_point.x).to eq(point.x)
+        expect(deserialized_point.y).to eq(2.0)
+        expect(deserialized_point.y).to eq(point.y)
+
+        expect(deserialized_point.z).to eq(point.z)
+        expect(deserialized_point.z).to eq(3)
+        expect(deserialized_point.m).to eq(point.m)
+        expect(deserialized_point.m).to eq(4)
+      end
+    end
+
+    describe 'integration with ActiveJob', :active_job_que_adapter do
+      before do
+        stub_const 'TestJob', (Class.new(ApplicationJob) do
+          def run(point); end
+        end)
+      end
+
+      it 'correctly processes passed point object' do
+        TestJob.perform_later(point)
+        jobs = QueJob.by_args({ job_class: 'TestJob' })
+        expect(jobs.count).to eq 1
+        expect(jobs.first.args['arguments'].first.except('_aj_serialized')).to eq(serialized_point)
+      end
     end
   end
 end

--- a/back/spec/lib/spherical_point_impl_active_job_serializer_spec.rb
+++ b/back/spec/lib/spherical_point_impl_active_job_serializer_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe SphericalPointImplActiveJobSerializer do
 
   describe 'integration with ActiveJob', :active_job_que_adapter do
     before do
-      stub_const 'TestJob', Class.new(ApplicationJob) do
+      stub_const 'TestJob', (Class.new(ApplicationJob) do
         def run(point); end
-      end
+      end)
     end
 
     it 'correctly processes passed point object' do

--- a/back/spec/lib/spherical_point_impl_active_job_serializer_spec.rb
+++ b/back/spec/lib/spherical_point_impl_active_job_serializer_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe SphericalPointImplActiveJobSerializer do
+  let(:point) { RGeo::Geographic.spherical_factory.point(1.0, 2.0) }
+  let(:serialized_point) { { 'x' => 1.0, 'y' => 2.0 } }
+
+  describe '#serialize' do
+    it 'correctly serializes a RGeo::Geographic::SphericalPointImpl object' do
+      serializer = described_class.send(:new)
+      expect(serializer.serialize(point)).to eq(serialized_point)
+    end
+  end
+
+  describe '#deserialize' do
+    it 'correctly deserializes a hash to a RGeo::Geographic::SphericalPointImpl object' do
+      serializer = described_class.send(:new)
+      deserialized_point = serializer.deserialize(serialized_point)
+      expect(deserialized_point).to be_a(RGeo::Geographic::SphericalPointImpl)
+      expect(deserialized_point.x).to eq(1.0)
+      expect(deserialized_point.y).to eq(2.0)
+    end
+  end
+
+  describe 'integration with ActiveJob', :active_job_que_adapter do
+    before do
+      stub_const 'TestJob', Class.new(ApplicationJob) do
+        def run(point); end
+      end
+    end
+
+    it 'correctly processes passed point object' do
+      TestJob.perform_later(point)
+      jobs = QueJob.by_args({ job_class: 'TestJob' })
+      expect(jobs.count).to eq 1
+      expect(jobs.first.args['arguments']).to eq([serialized_point])
+    end
+  end
+end


### PR DESCRIPTION
RGeo::Geographic::SphericalPointImpl instance, that is passed to ActiveJob
from EventRegistrationConfirmation#generate_commands in event_attributes field,
cannot be serialized and raises this error:
Unsupported argument type: RGeo::Geographic::SphericalPointImpl (ActiveJob::SerializationError) in two Sentry errors ([1](https://sentry.hq.citizenlab.co/organizations/citizenlab/issues/76573/events/0a7fd4690cc14582b3bacabc078e1e66/?cursor=0%3A600%3A0&project=2), [2](https://sentry.hq.citizenlab.co/organizations/citizenlab/issues/83033/?project=2&query=is%3Aunresolved+SerializationError&statsPeriod=14d)).

The issue exists since we introduced EventRegistrationConfirmation email.
Tested and reproduced it in https://github.com/CitizenLabDotCo/citizenlab/commit/7f8e6b0c1fa39296358cae1b150ece0ff134b321

I found only one issue related to this error, but the fix
is already used in our postgis-adapter version and it
doesn't help
https://github.com/rgeo/activerecord-postgis-adapter/issues/307


# Changelog
## Fixed
* [TAN-1736] Fix email not being sent when "Attend" event button is clicked
