### PR TITLE
[TAN-2260] Do not recreate existing custom fields in rake task

### DIFF
--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/setup_and_support.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/setup_and_support.rake
@@ -128,7 +128,7 @@ namespace :setup_and_support do
       locale = args[:locale] || AppConfiguration.instance.settings.dig('core', 'locales').first
       cf = CustomField.find args[:id]
       options.each do |option|
-        cfo = cf.options.create!(title_multiloc: { locale => option })
+        cfo = cf.options.find_or_create_by!(title_multiloc: { locale => option })
         cfo.move_to_bottom
       end
     end


### PR DESCRIPTION
In [this SLS ticket](https://www.notion.so/govocal/Waddinxveen-SLS-Bulk-importing-custom-registration-fields-1b3ad993f95b4ef1a1c88909094cc7bb?d=67f0cc8407654de2981c2315211b5321#1b3ad993f95b4ef1a1c88909094cc7bb), we don't want to remove existing postal codes, we only need to add absent ones.

# Changelog
## Technical
* [TAN-2260] Do not recreate existing custom fields in Rake task
