### PR TITLE
[TAN-1700] Remove unsubscribe links from non-consentable emails

### DIFF
--- a/back/app/mailers/application_mailer.rb
+++ b/back/app/mailers/application_mailer.rb
@@ -17,8 +17,8 @@ class ApplicationMailer < ActionMailer::Base
   helper_method :organization_name, :recipient_name, :url_service, :multiloc_service, :organization_name,
     :loc, :localize_for_recipient, :localize_for_recipient_and_truncate, :recipient_first_name
 
-  helper_method :unsubscribe_url, :terms_conditions_url, :privacy_policy_url, :gv_gray_logo_url, :home_url, :tenant_logo_url,
-    :show_unsubscribe_link?, :show_terms_link?, :show_privacy_policy_link?, :format_message,
+  helper_method :unsubscribe_url, :terms_conditions_url, :privacy_policy_url, :gv_gray_logo_url,
+    :home_url, :tenant_logo_url, :show_terms_link?, :show_privacy_policy_link?, :format_message,
     :header_logo_only?, :remove_vendor_branding?
 
   NotImplementedError = Class.new(StandardError)
@@ -150,10 +150,6 @@ class ApplicationMailer < ActionMailer::Base
 
   def app_settings
     to_deep_struct(app_configuration.settings)
-  end
-
-  def show_unsubscribe_link?
-    true
   end
 
   def show_terms_link?

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/application_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/application_mailer.rb
@@ -27,7 +27,7 @@ module EmailCampaigns
     private
 
     def show_unsubscribe_link?
-      true
+      user && campaign.class.try(:consentable_for?, user)
     end
 
     def show_terms_link?

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/application_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/application_mailer.rb
@@ -4,6 +4,8 @@ module EmailCampaigns
   class ApplicationMailer < ApplicationMailer
     layout 'campaign_mailer'
 
+    helper_method :show_unsubscribe_link?
+
     before_action do
       @command, @campaign = params.values_at(:command, :campaign)
 

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/welcome_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/welcome_mailer.rb
@@ -17,9 +17,5 @@ module EmailCampaigns
     def header_message
       format_message('message_welcome', values: { organizationName: organization_name })
     end
-
-    def show_unsubscribe_link?
-      false
-    end
   end
 end

--- a/back/engines/free/email_campaigns/app/views/email_campaigns/application/_footer.mjml
+++ b/back/engines/free/email_campaigns/app/views/email_campaigns/application/_footer.mjml
@@ -36,13 +36,19 @@
 
     <mj-text color="#84939E" padding-bottom="20px">
       <p style="font-size: 12px;">
-        <%= format_message('statement', component: 'footer', escape_html: false, values: {
+        <%= format_message('recipient_statement', component: 'footer', escape_html: false, values: {
           organizationName: organization_name,
-          organizationLink: "<a href='#{home_url}' style='color: #84939E; text-decoration: underline;'>#{app_configuration.host}</a>",
-          unsubscribeLink: "<a href='#{unsubscribe_url(app_configuration, campaign.id, user.id)}' style='color: #84939E; text-decoration: underline;'>#{format_message('unsubscribe_text', component: 'footer')}</a>"
+          organizationLink: "<a href='#{home_url}' style='color: #84939E; text-decoration: underline;'>#{app_configuration.host}</a>"
         }) %>
+
+        <% if show_unsubscribe_link? %>
+          <%= format_message('unsubscribe_statement', component: 'footer', escape_html: false, values: {
+            unsubscribeLink: "<a href='#{unsubscribe_url(app_configuration, campaign.id, user.id)}' style='color: #84939E; text-decoration: underline;'>#{format_message('unsubscribe_text', component: 'footer')}</a>"
+          }) %>
+        <% end %>
       </p>
     </mj-text>
+
     <% unless remove_vendor_branding? %>
       <mj-text color="#84939E">
         <span style="font-style: italic;

--- a/back/engines/free/email_campaigns/app/views/email_campaigns/application/_footer.mjml
+++ b/back/engines/free/email_campaigns/app/views/email_campaigns/application/_footer.mjml
@@ -5,28 +5,28 @@
       <% if show_unsubscribe_link? %>
         <a
           href="<%= unsubscribe_url(app_configuration, campaign.id, user.id) %>"
-          style="color: #84939E; text-decoration: none; margin-right: 10px;"
+          style="color: #84939E; text-decoration: none;"
         >
           <%= format_message('link_unsubscribe', component: 'footer') %>
         </a>
-        |
+        <span style="margin: 0 10px;">|</span>
       <% end %>
 
       <% if show_terms_link? %>
         <a
           href="<%= terms_conditions_url(app_configuration) %>"
-          style="color: #84939E; text-decoration: none; margin: 0 10px;"
+          style="color: #84939E; text-decoration: none;"
         >
           <%= format_message('link_terms_conditions', component: 'footer') %>
         </a>
-        |
+      <span style="margin: 0 10px;">|</span>
       <% end %>
 
 
       <% if show_privacy_policy_link? %>
         <a
           href="<%= privacy_policy_url(app_configuration) %>"
-          style="color: #84939E; text-decoration: none; margin-left: 10px;"
+          style="color: #84939E; text-decoration: none;"
         >
           <%= format_message('link_privacy_policy', component: 'footer') %>
         </a>

--- a/back/engines/free/email_campaigns/config/locales/en.yml
+++ b/back/engines/free/email_campaigns/config/locales/en.yml
@@ -77,7 +77,8 @@ en:
       "link_terms_conditions": "Terms & Conditions"
       "link_unsubscribe": "Unsubscribe"
       "powered_by": "Powered by"
-      "statement": "This e-mail was sent to you by Go Vocal on behalf of %{organizationName}, because you are a registered user of %{organizationLink}. You can %{unsubscribeLink} if you do not want to receive these e-mails in the future."
+      "recipient_statement": "This e-mail was sent to you by Go Vocal on behalf of %{organizationName}, because you are a registered user of %{organizationLink}."
+      "unsubscribe_statement": "You can %{unsubscribeLink} if you do not want to receive these e-mails in the future."
       "unsubscribe_text": "unsubscribe"
     follow:
       "unfollow_here": "You have received this notification because of an item that you follow. <a href=\"%{unfollow_url}\">You can unfollow it here.</a>"


### PR DESCRIPTION
# Changelog
## Fixes
- [TAN-1700] Remove unsubscribe links from non-consentable email campaigns. These links are not relevant (and non-functional) in emails where users cannot give or withdraw their consent (e.g., welcome emails, rights notification emails, or invites).