### PR TITLE
TAN-2289: Fix missing ids and add aria-label for Read more

### DIFF
--- a/front/app/components/EventCards/EventInformation/index.tsx
+++ b/front/app/components/EventCards/EventInformation/index.tsx
@@ -13,6 +13,8 @@ import styled, { useTheme } from 'styled-components';
 import useEventImage from 'api/event_images/useEventImage';
 import { IEventData } from 'api/events/types';
 
+import useLocalize from 'hooks/useLocalize';
+
 import EventAttendanceButton from 'components/EventAttendanceButton';
 import ScreenReadableEventDate from 'components/ScreenReadableEventDate';
 import T from 'components/T';
@@ -64,6 +66,7 @@ interface Props {
 const EventInformation = ({ event }: Props) => {
   const { formatMessage } = useIntl();
   const theme = useTheme();
+  const localize = useLocalize();
 
   // event image
   const { data: eventImage } = useEventImage(event);
@@ -239,6 +242,12 @@ const EventInformation = ({ event }: Props) => {
             bgColor={theme.colors.tenantPrimary}
             linkTo={`/events/${event.id}`}
             scrollToTop
+            // For accessibility, we need to add an aria-label to the button
+            // to provide context for screen readers. Using the same "Read more" text
+            // for multiple links/buttons is not accessible because it doesn't convey
+            // the unique purpose of each link. Screen readers will not differentiate
+            // between the links, making it difficult for users to navigate.
+            ariaLabel={localize(event.attributes.title_multiloc)}
           >
             {formatMessage(messages.readMore)}
           </Button>

--- a/front/app/components/FilterSelector/ValuesList.tsx
+++ b/front/app/components/FilterSelector/ValuesList.tsx
@@ -143,6 +143,7 @@ interface Props extends DefaultProps {
   opened: boolean;
   baseID: string;
   name: string;
+  selectorId: string;
 }
 
 const ValuesList = ({
@@ -163,6 +164,7 @@ const ValuesList = ({
   name,
   onChange,
   onClickOutside,
+  selectorId,
 }: Props) => {
   const tabsRef = useRef({});
   const invisibleRef = useRef<HTMLButtonElement | null>(null);
@@ -226,7 +228,7 @@ const ValuesList = ({
         // The id is used for aria-labelledby on the group which defines
         // the accessible name for the group. The role group identifies the
         // group container for the list items.
-        <Box role="group" aria-labelledby={`id-${name}`}>
+        <Box role="group" aria-labelledby={selectorId}>
           {/* When a user opens the dropdown, we move focus to this  invisible button.
             This is needed to make sure that the keyboard navigation using the up
             and down arrow keys works without interfering with the behavior if the

--- a/front/app/components/FilterSelector/index.tsx
+++ b/front/app/components/FilterSelector/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, KeyboardEvent } from 'react';
+import React, { useState, KeyboardEvent, useMemo } from 'react';
 
 import {
   Box,
@@ -203,6 +203,13 @@ const FilterSelector = ({
     }
   };
 
+  // We use a random id for the selectorId to ensure it doesn't conflict if multiple
+  // instances of the same filter selector are rendered on the same page.
+  const selectorId = useMemo(
+    () => `id-${name}-${Math.random().toString(36).slice(2, 11)}`,
+    [name]
+  );
+
   return (
     <Container
       id={id}
@@ -210,7 +217,7 @@ const FilterSelector = ({
         last ? 'last' : ''
       }`}
     >
-      <Box id={`id-${name}`}>
+      <Box id={selectorId}>
         {/* The id is used for aria-labelledby on the group
          which defines the accessible name for the group */}
         {filterSelectorStyle === 'button' ? (
@@ -262,6 +269,7 @@ const FilterSelector = ({
         right={right}
         mobileRight={mobileRight}
         name={name}
+        selectorId={selectorId}
       />
     </Container>
   );

--- a/front/app/components/IdeaCards/IdeasWithFiltersSidebar/index.tsx
+++ b/front/app/components/IdeaCards/IdeasWithFiltersSidebar/index.tsx
@@ -293,6 +293,7 @@ const IdeaCards = ({ ideaQueryParameters, onUpdateQuery }: Props) => {
                   smallerThanPhone
                 }
                 view="card"
+                hasMoreThanOneView={false}
               />
             </ContentLeft>
 

--- a/front/app/components/IdeaCards/shared/IdeasView/index.tsx
+++ b/front/app/components/IdeaCards/shared/IdeasView/index.tsx
@@ -13,6 +13,8 @@ import IdeasList from './IdeasList';
 
 interface Props {
   view: 'card' | 'map';
+  // This prop is used to set the aria-labelledby attribute. Set this to false if only one view is shown all the time. That is when the tabs are hidden.
+  hasMoreThanOneView?: boolean;
   defaultSortingMethod?: IdeaDefaultSortMethod;
   hideImage: boolean;
   hideImagePlaceholder: boolean;
@@ -40,6 +42,7 @@ const IdeasView = ({
   loadingMore,
   ideaMarkers,
   onLoadMore,
+  hasMoreThanOneView = true,
 }: Props) => {
   const { data: mapConfig, isLoading } = useProjectMapConfig(
     projectId || undefined
@@ -53,7 +56,7 @@ const IdeasView = ({
     <>
       {view === 'card' && list && (
         <IdeasList
-          ariaLabelledBy={'view-tab-1'}
+          ariaLabelledBy={hasMoreThanOneView ? 'view-tab-1' : undefined}
           id={'view-panel-1'}
           querying={querying}
           onLoadMore={onLoadMore}


### PR DESCRIPTION
# Changelog

## Fixed
- a11y: Fix missing tab labelled by id when tab is not shown.
- a11y: Fix duplicate ids when filter bar is rendered more than once on the same page.
- a11y: Use aria-label for Read more button in events to prevent the confusion that comes with having the same text with different links for screen reader users.
