### PR TITLE
[TAN-2254] Fix copy of map_config in project copy

### DIFF
--- a/back/.rubocop_todo.yml
+++ b/back/.rubocop_todo.yml
@@ -187,7 +187,7 @@ Metrics/BlockNesting:
 # Offense count: 92
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 689
+  Max: 700
 
 Metrics/ModuleLength:
   Max: 120

--- a/back/app/services/project_copy_service.rb
+++ b/back/app/services/project_copy_service.rb
@@ -389,9 +389,10 @@ class ProjectCopyService < TemplateService
   end
 
   def yml_maps_map_configs(shift_timestamps: 0)
+    custom_forms = CustomForm.where(participation_context: [@project, *@project.phases])
+    custom_fields = CustomField.where(resource: custom_forms)
     map_configs = CustomMaps::MapConfig.where(mappable: @project)
-      .or(CustomMaps::MapConfig.where(mappable: @project&.custom_form&.custom_fields))
-      .or(CustomMaps::MapConfig.where(mappable: @project&.phases&.map(&:custom_form)&.compact&.map(&:custom_fields)))
+      .or(CustomMaps::MapConfig.where(mappable: custom_fields))
 
     map_configs.map do |map_config|
       yml_map_config = {


### PR DESCRIPTION
# Changelog
## Fixes
- [TAN-2254] Fix copy of map_config in project copy. he project copy was (unnecessarily) copying config maps without mappable (mappable: nil) due to a faulty SQL query. This caused the number of such map configs to grow exponentially on some platforms.
