### PR TITLE
TAN-2282: Fix heading styles not applying to links

### DIFF
--- a/front/app/component-library/utils/styleUtils.ts
+++ b/front/app/component-library/utils/styleUtils.ts
@@ -311,6 +311,12 @@ export function quillEditedContent(
       font-weight: bold;
       padding: 0;
       margin: 0 0 16px 0;
+
+      a {
+        font-size: inherit;
+        font-weight: inherit;
+        text-decoration: inherit;
+      }
     }
 
     h3 {
@@ -319,6 +325,12 @@ export function quillEditedContent(
       font-weight: bold;
       padding: 0;
       margin: 0 0 16px 0;
+
+      a {
+        font-size: inherit;
+        font-weight: inherit;
+        text-decoration: inherit;
+      }
     }
 
     p {


### PR DESCRIPTION
# Changelog

## Fixed
- Fix a bug in the Quill editor where heading styles were not applied to links.

Before:
![image](https://github.com/user-attachments/assets/95e6fbf3-8f95-4de3-8d82-a6b3437d247d)

After:
![image](https://github.com/user-attachments/assets/2c531f29-03eb-47f4-bc92-66cd1e337043)
