### PR TITLE
[TAN-2248] Some emails mix different locales

### DIFF
--- a/back/app/mailers/application_mailer.rb
+++ b/back/app/mailers/application_mailer.rb
@@ -66,7 +66,7 @@ class ApplicationMailer < ActionMailer::Base
     when OpenStruct then multiloc_or_struct.to_h.stringify_keys
     end
 
-    multiloc_service.t(multiloc, locale.locale_sym).html_safe if multiloc
+    multiloc_service.t(multiloc, locale.to_s).html_safe if multiloc
   end
 
   # Truncates localized multiloc string, avoiding cutting string in the middle of HTML link and breaking the mail view.

--- a/back/app/services/multiloc_service.rb
+++ b/back/app/services/multiloc_service.rb
@@ -8,6 +8,17 @@ class MultilocService
   def t(translations, preferred_locale = nil)
     return nil unless translations
 
+    ErrorReporter.handle(ArgumentError) do
+      bad_keys = translations.keys.reject { |key| key.is_a?(String) }
+      raise ArgumentError, <<~MSG.squish if bad_keys.any?
+        translations keys must be strings, but found: #{bad_keys.map(&:inspect)}
+      MSG
+
+      raise ArgumentError, <<~MSG.squish unless preferred_locale.nil? || preferred_locale.is_a?(String)
+        preferred_locale must be a string, but found: #{preferred_locale.inspect} (#{preferred_locale.class})
+      MSG
+    end
+
     # Optimization: return early if we can to avoid instantiating the AppConfiguration.
     preferred_locale ||= I18n.locale.to_s
     return translations[preferred_locale] if translations[preferred_locale]

--- a/back/engines/commercial/smart_groups/app/lib/smart_groups/rules/event_attendance.rb
+++ b/back/engines/commercial/smart_groups/app/lib/smart_groups/rules/event_attendance.rb
@@ -116,7 +116,7 @@ module SmartGroups::Rules
         .pluck(:id, :title_multiloc)
         # Ensure the titles are ordered in the same way as the event_ids
         .sort_by { |id, _| event_ids.index(id) }
-        .map { |_, title_multiloc| multiloc_service.t(title_multiloc, locale: locale) }
+        .map { |_, title_multiloc| multiloc_service.t(title_multiloc, locale) }
         .join(', ')
     end
 

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/event_registration_confirmation_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/event_registration_confirmation_mailer.rb
@@ -12,7 +12,7 @@ module EmailCampaigns
     def campaign_mail
       attachments['event.ics'] = Events::IcsGenerator.new.generate_ics(
         Event.find(event.event_attributes.id),
-        locale.locale_sym
+        locale.to_s
       )
 
       super

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/manual_campaign_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/manual_campaign_mailer.rb
@@ -10,7 +10,7 @@ module EmailCampaigns
       multiloc_service = MultilocService.new
       @app_configuration = AppConfiguration.instance
 
-      body_html_with_liquid = multiloc_service.t(command[:body_multiloc], locale.locale_sym)
+      body_html_with_liquid = multiloc_service.t(command[:body_multiloc], locale.to_s)
       template = Liquid::Template.parse(body_html_with_liquid)
       template.render(liquid_params(recipient))
     end
@@ -26,7 +26,7 @@ module EmailCampaigns
     end
 
     def subject
-      multiloc_service.t(command[:subject_multiloc], locale.locale_sym)
+      multiloc_service.t(command[:subject_multiloc], locale.to_s)
     end
 
     def from_email
@@ -40,7 +40,7 @@ module EmailCampaigns
       when 'author'
         "#{author.first_name} #{author.last_name}"
       when 'organization'
-        MultilocService.new.t(AppConfiguration.instance.settings('core', 'organization_name'), locale.locale_sym)
+        MultilocService.new.t(AppConfiguration.instance.settings('core', 'organization_name'), locale.to_s)
       end
     end
 

--- a/back/engines/free/email_campaigns/spec/services/email_campaigns/examples_service_spec.rb
+++ b/back/engines/free/email_campaigns/spec/services/email_campaigns/examples_service_spec.rb
@@ -67,7 +67,14 @@ describe EmailCampaigns::ExamplesService do
       recipient = create(:admin)
       command = {
         recipient: recipient,
-        event_payload: {}
+        event_payload: {
+          comment_created_at: Time.now.iso8601,
+          comment_body_multiloc: { en: 'comment body' },
+          reason_code: 'inappropriate',
+          other_reason: nil,
+          post_type: 'Comment',
+          post_url: 'http://example.com/posts/1'
+        }
       }
 
       expect { service.save_examples([[command, campaign2]]) }.not_to change { EmailCampaigns::Example.where(campaign: campaign1).count }

--- a/back/lib/error_reporter.rb
+++ b/back/lib/error_reporter.rb
@@ -4,17 +4,25 @@
 # https://github.com/rails/rails/pull/43625/files
 class ErrorReporter
   class << self
-    # Report any unhandled exception, and swallow it.
-    #
-    #  ErrorReporter.handle do
-    #    1 + '1'
-    #  end
-    #
-    def handle(error_class = StandardError)
-      yield
-    rescue error_class => e
-      report(e)
-      nil
+    # Do not swallow exceptions in the test environment.
+    # Ideally, we should not rely on `Rails` constant since this file is in the lib folder.
+    if Rails.env.test?
+      def handle(_error_class = nil)
+        yield
+      end
+    else
+      # Report any unhandled exception, and swallow it.
+      #
+      #  ErrorReporter.handle do
+      #    1 + '1'
+      #  end
+      #
+      def handle(error_class = StandardError)
+        yield
+      rescue error_class => e
+        report(e)
+        nil
+      end
     end
 
     # Uncomment and write tests if you need it.

--- a/back/lib/locale.rb
+++ b/back/lib/locale.rb
@@ -1,6 +1,8 @@
 class Locale
   attr_reader :locale_sym
 
+  delegate :to_s, to: :locale_sym
+
   def self.default(config: nil)
     config ||= AppConfiguration.instance
     monolingual(config: config) || new(config.settings('core', 'locales').first)

--- a/back/spec/lib/error_reporter_spec.rb
+++ b/back/spec/lib/error_reporter_spec.rb
@@ -4,10 +4,33 @@ require 'rails_helper'
 
 RSpec.describe ErrorReporter do
   describe '.handle' do
-    it 'captures and reports errors' do
-      expect(described_class).to receive(:report).with(instance_of(TypeError)).and_call_original
-      described_class.handle do
-        1 + nil
+    context 'when in test environment' do
+      it 'does not capture and report errors' do
+        expect(described_class).not_to receive(:report)
+        expect do
+          described_class.handle { 1 + nil }
+        end.to raise_error(TypeError)
+      end
+    end
+
+    context 'when in production environment' do
+      # rubocop:disable RSpec/BeforeAfterAll
+      before(:all) do
+        Rails.env = 'production'
+        load 'lib/error_reporter.rb'
+      end
+
+      after(:all) do
+        Rails.env = 'test'
+        load 'lib/error_reporter.rb'
+      end
+      # rubocop:enable RSpec/BeforeAfterAll
+
+      it 'captures and reports errors' do
+        expect(described_class).to receive(:report).with(instance_of(TypeError)).and_call_original
+        expect do
+          described_class.handle { 1 + nil }
+        end.not_to raise_error
       end
     end
   end

--- a/back/spec/lib/error_reporter_spec.rb
+++ b/back/spec/lib/error_reporter_spec.rb
@@ -56,13 +56,13 @@ RSpec.describe ErrorReporter do
       expect(Rails.logger).to receive(:error).with(instance_of(String), {}).and_call_original
     end
 
-    it 'repors in-line created errors which do not have backtrace' do
+    it 'reports in-line created errors which do not have backtrace' do
       error = StandardError.new('test')
       expect_report(error)
       described_class.report(error)
     end
 
-    it 'repors runtime errors' do
+    it 'reports runtime errors' do
       expect_report(instance_of(TypeError))
       begin
         1 + nil

--- a/back/spec/services/multiloc_service_spec.rb
+++ b/back/spec/services/multiloc_service_spec.rb
@@ -41,8 +41,8 @@ describe MultilocService do
 
     it 'falls back to the first available translation when no tenant locale is available' do
       translations = {
-        'de-DE': 'wort',
-        pt: 'worto'
+        'de-DE' => 'wort',
+        'pt' => 'worto'
       }
       expect(service.t(translations, preferred_locale)).to eq 'wort'
     end


### PR DESCRIPTION
I still have to fix one test. The other ones are time-sensitive (around midnight utc) flaky tests, I think.

# Changelog
## Fixes
- [TAN-2248] Some emails mix different locales.
