### PR TITLE
[TAN-2267] Add line and polygon data to survey_results response

### DIFF
--- a/back/app/services/survey_results_generator_service.rb
+++ b/back/app/services/survey_results_generator_service.rb
@@ -69,17 +69,15 @@ class SurveyResultsGeneratorService < FieldVisitorService
   end
 
   def visit_point(field)
-    responses = inputs
-      .select("custom_field_values->'#{field.key}' as value")
-      .where("custom_field_values->'#{field.key}' IS NOT NULL")
-      .map do |response|
-        { response: response.value }
-      end
-    response_count = responses.size
+    geographic_input_type(field)
+  end
 
-    core_field_attributes(field, response_count).merge({
-      mapConfigId: field&.map_config&.id, pointResponses: responses
-    })
+  def visit_line(field)
+    geographic_input_type(field)
+  end
+
+  def visit_polygon(field)
+    geographic_input_type(field)
   end
 
   private
@@ -148,6 +146,20 @@ class SurveyResultsGeneratorService < FieldVisitorService
     else
       raise "Unsupported field type: #{field.input_type}"
     end
+  end
+
+  def geographic_input_type(field)
+    responses = inputs
+      .select("custom_field_values->'#{field.key}' as value")
+      .where("custom_field_values->'#{field.key}' IS NOT NULL")
+      .map do |response|
+        { response: response.value }
+      end
+    response_count = responses.size
+
+    core_field_attributes(field, response_count).merge({
+      mapConfigId: field&.map_config&.id, pointResponses: responses
+    })
   end
 
   def build_select_response(answers, field, group_field)

--- a/back/app/services/survey_results_generator_service.rb
+++ b/back/app/services/survey_results_generator_service.rb
@@ -69,15 +69,15 @@ class SurveyResultsGeneratorService < FieldVisitorService
   end
 
   def visit_point(field)
-    responses_for_geographic_input_type(field)
+    responses_to_geographic_input_type(field)
   end
 
   def visit_line(field)
-    responses_for_geographic_input_type(field)
+    responses_to_geographic_input_type(field)
   end
 
   def visit_polygon(field)
-    responses_for_geographic_input_type(field)
+    responses_to_geographic_input_type(field)
   end
 
   private
@@ -148,7 +148,7 @@ class SurveyResultsGeneratorService < FieldVisitorService
     end
   end
 
-  def responses_for_geographic_input_type(field)
+  def responses_to_geographic_input_type(field)
     responses = inputs
       .select("custom_field_values->'#{field.key}' as value")
       .where("custom_field_values->'#{field.key}' IS NOT NULL")

--- a/back/app/services/survey_results_generator_service.rb
+++ b/back/app/services/survey_results_generator_service.rb
@@ -158,7 +158,7 @@ class SurveyResultsGeneratorService < FieldVisitorService
     response_count = responses.size
 
     core_field_attributes(field, response_count).merge({
-      mapConfigId: field&.map_config&.id, pointResponses: responses
+      mapConfigId: field&.map_config&.id, "#{field.input_type}Responses": responses
     })
   end
 

--- a/back/app/services/survey_results_generator_service.rb
+++ b/back/app/services/survey_results_generator_service.rb
@@ -69,15 +69,15 @@ class SurveyResultsGeneratorService < FieldVisitorService
   end
 
   def visit_point(field)
-    geographic_input_type(field)
+    responses_for_geographic_input_type(field)
   end
 
   def visit_line(field)
-    geographic_input_type(field)
+    responses_for_geographic_input_type(field)
   end
 
   def visit_polygon(field)
-    geographic_input_type(field)
+    responses_for_geographic_input_type(field)
   end
 
   private
@@ -148,7 +148,7 @@ class SurveyResultsGeneratorService < FieldVisitorService
     end
   end
 
-  def geographic_input_type(field)
+  def responses_for_geographic_input_type(field)
     responses = inputs
       .select("custom_field_values->'#{field.key}' as value")
       .where("custom_field_values->'#{field.key}' IS NOT NULL")

--- a/back/spec/services/survey_results_generator_service_spec.rb
+++ b/back/spec/services/survey_results_generator_service_spec.rb
@@ -164,7 +164,33 @@ RSpec.describe SurveyResultsGeneratorService do
     )
   end
 
-  let_it_be(:map_config) { create(:map_config, mappable: point_field) }
+  let_it_be(:map_config_for_point) { create(:map_config, mappable: point_field) }
+
+  let_it_be(:line_field) do
+    create(
+      :custom_field_line,
+      resource: form,
+      title_multiloc: {
+        'en' => 'Where should we build the new bicycle path?'
+      },
+      description_multiloc: {}
+    )
+  end
+
+  let_it_be(:map_config_for_line) { create(:map_config, mappable: line_field) }
+
+  let_it_be(:polygon_field) do
+    create(
+      :custom_field_polygon,
+      resource: form,
+      title_multiloc: {
+        'en' => 'Where should we build the new housing?'
+      },
+      description_multiloc: {}
+    )
+  end
+
+  let_it_be(:map_config_for_polygon) { create(:map_config, mappable: polygon_field) }
 
   let_it_be(:user_custom_field) do
     create(:custom_field_gender, :with_options)
@@ -187,6 +213,8 @@ RSpec.describe SurveyResultsGeneratorService do
         select_field.key => 'ny',
         file_upload_field.key => { 'id' => idea_file.id, 'name' => idea_file.name },
         point_field.key => { type: 'Point', coordinates: [42.42, 24.24] },
+        line_field.key => { type: 'LineString', coordinates: [[1.1, 2.2], [3.3, 4.4]] },
+        polygon_field.key => { type: 'Polygon', coordinates: [[[1.1, 2.2], [3.3, 4.4], [5.5, 6.6], [1.1, 2.2]]] },
         linear_scale_field.key => 3
       },
       idea_files: [idea_file],
@@ -201,6 +229,8 @@ RSpec.describe SurveyResultsGeneratorService do
         multiselect_field.key => %w[cow pig cat],
         select_field.key => 'la',
         point_field.key => { type: 'Point', coordinates: [11.22, 33.44] },
+        line_field.key => { type: 'LineString', coordinates: [[1.2, 2.3], [3.4, 4.5]] },
+        polygon_field.key => { type: 'Polygon', coordinates: [[[1.2, 2.3], [3.4, 4.5], [5.6, 6.7], [1.2, 2.3]]] },
         linear_scale_field.key => 4
       },
       author: male_user
@@ -285,7 +315,7 @@ RSpec.describe SurveyResultsGeneratorService do
       end
 
       it 'returns the correct fields and structure' do
-        expect(generated_results[:results].count).to eq 9
+        expect(generated_results[:results].count).to eq 11
         expect(generated_results[:results].pluck(:customFieldId)).not_to include page_field.id
         expect(generated_results[:results].pluck(:customFieldId)).not_to include disabled_multiselect_field.id
       end
@@ -971,7 +1001,7 @@ RSpec.describe SurveyResultsGeneratorService do
           questionResponseCount: 2,
           totalResponseCount: 22,
           customFieldId: point_field.id,
-          mapConfigId: map_config.id,
+          mapConfigId: map_config_for_point.id,
           pointResponses: a_collection_containing_exactly(
             { response: { 'coordinates' => [42.42, 24.24], 'type' => 'Point' } },
             { response: { 'coordinates' => [11.22, 33.44], 'type' => 'Point' } }
@@ -981,6 +1011,52 @@ RSpec.describe SurveyResultsGeneratorService do
 
       it 'returns the results for a point field' do
         expect(generated_results[:results][8]).to match expected_result_point
+      end
+    end
+
+    describe 'line fields' do
+      let(:expected_result_line) do
+        {
+          inputType: 'line',
+          question: { 'en' => 'Where should we build the new bicycle path?' },
+          required: false,
+          grouped: false,
+          questionResponseCount: 2,
+          totalResponseCount: 22,
+          customFieldId: line_field.id,
+          mapConfigId: map_config_for_line.id,
+          lineResponses: a_collection_containing_exactly(
+            { response: { 'coordinates' => [[1.1, 2.2], [3.3, 4.4]], 'type' => 'LineString' } },
+            { response: { 'coordinates' => [[1.2, 2.3], [3.4, 4.5]], 'type' => 'LineString' } }
+          )
+        }
+      end
+
+      it 'returns the results for a line field' do
+        expect(generated_results[:results][9]).to match expected_result_line
+      end
+    end
+
+    describe 'polygon fields' do
+      let(:expected_result_polygon) do
+        {
+          inputType: 'polygon',
+          question: { 'en' => 'Where should we build the new housing?' },
+          required: false,
+          grouped: false,
+          questionResponseCount: 2,
+          totalResponseCount: 22,
+          customFieldId: polygon_field.id,
+          mapConfigId: map_config_for_polygon.id,
+          polygonResponses: a_collection_containing_exactly(
+            { response: { 'coordinates' => [[[1.1, 2.2], [3.3, 4.4], [5.5, 6.6], [1.1, 2.2]]], 'type' => 'Polygon' } },
+            { response: { 'coordinates' => [[[1.2, 2.3], [3.4, 4.5], [5.6, 6.7], [1.2, 2.3]]], 'type' => 'Polygon' } }
+          )
+        }
+      end
+
+      it 'returns the results for a polygon field' do
+        expect(generated_results[:results][10]).to match expected_result_polygon
       end
     end
   end


### PR DESCRIPTION
[Example of response to `GET .../phases/:phase_id/survey_results`](https://www.notion.so/govocal/Survey-summary-results-tab-f3ec723af0df49ab8df6c018ec90a186?pvs=4#c9243810482d45d29cd54c9ec676dda5)

# Changelog
## Technical
- [TAN-2267] Add line and polygon data to survey_results response
