### PR TITLE
TAN-2326: Fix width of budgeting progress bar

### DIFF
--- a/front/app/containers/ProjectsShowPage/timeline/VotingResults/ProgressBar/BudgetingProgressBar.tsx
+++ b/front/app/containers/ProjectsShowPage/timeline/VotingResults/ProgressBar/BudgetingProgressBar.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { Box } from '@citizenlab/cl2-component-library';
+
 import { IIdeaData } from 'api/ideas/types';
 import { IPhase } from 'api/phases/types';
 
@@ -25,11 +27,13 @@ const BudgetingProgressBar = ({ phase, idea }: Props) => {
   );
 
   return (
-    <ProgressBarWrapper votesPercentage={basketsPercentage} tooltip={tooltip}>
-      {`${basketsPercentage}% (${formatMessage(messages.numberOfPicks, {
-        baskets: totalBasketsIdeaIsIn,
-      })})`}
-    </ProgressBarWrapper>
+    <Box w="100%">
+      <ProgressBarWrapper votesPercentage={basketsPercentage} tooltip={tooltip}>
+        {`${basketsPercentage}% (${formatMessage(messages.numberOfPicks, {
+          baskets: totalBasketsIdeaIsIn,
+        })})`}
+      </ProgressBarWrapper>
+    </Box>
   );
 };
 


### PR DESCRIPTION
# Changelog

## Fixed
- Fix width of budgeting progress bar

Before
![image](https://github.com/user-attachments/assets/265e9ecd-0c11-4fa6-b010-b7f637fe6330)

After
![image](https://github.com/user-attachments/assets/4ef3b02d-36f3-4665-b6cc-8a516d82a8f4)
