### PR TITLE
TAN-2367 - Add reset permissions

### DIFF
--- a/back/app/controllers/web_api/v1/permissions_controller.rb
+++ b/back/app/controllers/web_api/v1/permissions_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class WebApi::V1::PermissionsController < ApplicationController
-  before_action :set_permission, only: %i[show update requirements schema]
+  before_action :set_permission, only: %i[show update reset requirements schema]
   skip_before_action :authenticate_user
 
   def index
@@ -30,11 +30,11 @@ class WebApi::V1::PermissionsController < ApplicationController
   end
 
   def reset
-    @permission.update!(global_custom_fields: true)
-    @permission.permission_custom_fields.destroy_all
-    # @permission.groups.de
-
+    authorize @permission
+    @permission.global_custom_fields = true
     if @permission.save
+      @permission.permissions_fields.destroy_all
+      @permission.groups_permissions.destroy_all
       render json: serialize(@permission), status: :ok
     else
       render json: { errors: @permission.errors.details }, status: :unprocessable_entity

--- a/back/app/controllers/web_api/v1/permissions_controller.rb
+++ b/back/app/controllers/web_api/v1/permissions_controller.rb
@@ -29,6 +29,18 @@ class WebApi::V1::PermissionsController < ApplicationController
     end
   end
 
+  def reset
+    @permission.update!(global_custom_fields: true)
+    @permission.permission_custom_fields.destroy_all
+    # @permission.groups.de
+
+    if @permission.save
+      render json: serialize(@permission), status: :ok
+    else
+      render json: { errors: @permission.errors.details }, status: :unprocessable_entity
+    end
+  end
+
   def requirements
     authorize @permission
     json_requirements = user_requirements_service.requirements @permission, current_user

--- a/back/app/policies/permission_policy.rb
+++ b/back/app/policies/permission_policy.rb
@@ -29,6 +29,10 @@ class PermissionPolicy < ApplicationPolicy
     user&.active? && UserRoleService.new.can_moderate?(record, user)
   end
 
+  def reset?
+    update?
+  end
+
   def requirements?
     true
   end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -42,7 +42,7 @@ Rails.application.routes.draw do
         resources :permissions, param: :permission_action do
           get 'requirements', on: :member
           get 'schema', on: :member
-          patch 'reset', on: member
+          patch 'reset', on: :member
           resources :permissions_fields, shallow: true do
             patch 'reorder', on: :member
           end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -42,6 +42,7 @@ Rails.application.routes.draw do
         resources :permissions, param: :permission_action do
           get 'requirements', on: :member
           get 'schema', on: :member
+          patch 'reset', on: member
           resources :permissions_fields, shallow: true do
             patch 'reorder', on: :member
           end

--- a/back/spec/acceptance/permissions_spec.rb
+++ b/back/spec/acceptance/permissions_spec.rb
@@ -189,7 +189,9 @@ resource 'Permissions' do
 
       let(:action) { 'reacting_initiative' }
 
-      example_request 'Reset a permission to use global custom fields and no groups' do
+      example 'Reset a permission to use global custom fields and no groups' do
+
+        do_request
         assert_status 200
         expect(response_data.dig(:attributes, :permitted_by)).to eq permitted_by
         expect(response_data.dig(:attributes, :global_custom_fields)).to eq true

--- a/back/spec/acceptance/permissions_spec.rb
+++ b/back/spec/acceptance/permissions_spec.rb
@@ -182,7 +182,7 @@ resource 'Permissions' do
 
         do_request
         assert_status 200
-        expect(response_data.dig(:attributes, :global_custom_fields)).to eq true
+        expect(response_data.dig(:attributes, :global_custom_fields)).to be true
         expect(permission.permissions_fields.count).to eq 0
         expect(permission.permissions_fields.count).to eq 0
       end

--- a/back/spec/acceptance/permissions_spec.rb
+++ b/back/spec/acceptance/permissions_spec.rb
@@ -183,6 +183,19 @@ resource 'Permissions' do
         expect(json_response.dig(:data, :relationships, :groups, :data).pluck(:id)).to match_array group_ids
       end
     end
+
+    patch 'web_api/v1/permissions/:action/reset' do
+      ValidationErrorHelper.new.error_fields(self, Permission)
+
+      let(:action) { 'reacting_initiative' }
+
+      example_request 'Reset a permission to use global custom fields and no groups' do
+        assert_status 200
+        expect(response_data.dig(:attributes, :permitted_by)).to eq permitted_by
+        expect(response_data.dig(:attributes, :global_custom_fields)).to eq true
+        # expect(json_response.dig(:data, :relationships, :groups, :data).pluck(:id)).to eq group_ids
+      end
+    end
   end
 
   context 'when resident' do

--- a/back/spec/acceptance/permissions_spec.rb
+++ b/back/spec/acceptance/permissions_spec.rb
@@ -164,6 +164,30 @@ resource 'Permissions' do
       end
     end
 
+    patch 'web_api/v1/phases/:phase_id/permissions/:action/reset' do
+      ValidationErrorHelper.new.error_fields(self, Permission)
+
+      let(:permission) { @phase.permissions.first }
+      let(:action) { @phase.permissions.first.action }
+
+      example 'Reset a permission to use global custom fields and no groups' do
+        # Create some groups & permission fields
+        permission.update!(global_custom_fields: false)
+        create(:permissions_field, permission: permission, custom_field: create(:custom_field), required: true)
+        permission.groups << create_list(:group, 2, projects: [@phase.project])
+
+        # Check the setup is correct
+        expect(permission.permissions_fields.count).to eq 1
+        expect(permission.groups.count).to eq 2
+
+        do_request
+        assert_status 200
+        expect(response_data.dig(:attributes, :global_custom_fields)).to eq true
+        expect(permission.permissions_fields.count).to eq 0
+        expect(permission.permissions_fields.count).to eq 0
+      end
+    end
+
     patch 'web_api/v1/permissions/:action' do
       with_options scope: :permission do
         parameter :permitted_by, "Defines who is granted permission, either #{Permission::PERMITTED_BIES.join(',')}.", required: false
@@ -181,21 +205,6 @@ resource 'Permissions' do
         json_response = json_parse response_body
         expect(json_response.dig(:data, :attributes, :permitted_by)).to eq permitted_by
         expect(json_response.dig(:data, :relationships, :groups, :data).pluck(:id)).to match_array group_ids
-      end
-    end
-
-    patch 'web_api/v1/permissions/:action/reset' do
-      ValidationErrorHelper.new.error_fields(self, Permission)
-
-      let(:action) { 'reacting_initiative' }
-
-      example 'Reset a permission to use global custom fields and no groups' do
-
-        do_request
-        assert_status 200
-        expect(response_data.dig(:attributes, :permitted_by)).to eq permitted_by
-        expect(response_data.dig(:attributes, :global_custom_fields)).to eq true
-        # expect(json_response.dig(:data, :relationships, :groups, :data).pluck(:id)).to eq group_ids
       end
     end
   end


### PR DESCRIPTION
Added a method to the permissions controller - available on the following paths:
- `/web_api/v1/phases/:phase_id/permissions/:action/reset`
- `/web_api/v1/permissions/:action/reset`

NOTE: Ignore test failures again - tests fail on parent branch too

