### PR TITLE
[TAN-2347] BE for new shapefile_upload

### DIFF
--- a/back/app/controllers/web_api/v1/ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/ideas_controller.rb
@@ -281,12 +281,17 @@ class WebApi::V1::IdeasController < ApplicationController
     params_for_file_upload_fields = extract_params_for_file_upload_fields custom_form, params
     params_for_file_upload_fields.each do |key, params_for_files_field|
       if params_for_files_field['id']
+        puts 'params_for_file_upload_fields (patch):'
+        pp params_for_file_upload_fields
         idea_file = FileUpload.find(params_for_files_field['id'])
         if idea_file
           input.custom_field_values[key] = { id: idea_file.id, name: idea_file.name }
           file_uploads_exist = true
         end
       elsif params_for_files_field['content']
+        puts 'params_for_file_upload_fields:'
+        pp params_for_file_upload_fields
+
         idea_file = FileUpload.create!(
           idea: input,
           file_by_content: {

--- a/back/app/controllers/web_api/v1/ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/ideas_controller.rb
@@ -281,17 +281,12 @@ class WebApi::V1::IdeasController < ApplicationController
     params_for_file_upload_fields = extract_params_for_file_upload_fields custom_form, params
     params_for_file_upload_fields.each do |key, params_for_files_field|
       if params_for_files_field['id']
-        puts 'params_for_file_upload_fields (patch):'
-        pp params_for_file_upload_fields
         idea_file = FileUpload.find(params_for_files_field['id'])
         if idea_file
           input.custom_field_values[key] = { id: idea_file.id, name: idea_file.name }
           file_uploads_exist = true
         end
       elsif params_for_files_field['content']
-        puts 'params_for_file_upload_fields:'
-        pp params_for_file_upload_fields
-
         idea_file = FileUpload.create!(
           idea: input,
           file_by_content: {

--- a/back/app/models/custom_field.rb
+++ b/back/app/models/custom_field.rb
@@ -51,7 +51,8 @@ class CustomField < ApplicationRecord
   FIELDABLE_TYPES = %w[User CustomForm].freeze
   INPUT_TYPES = %w[
     checkbox date file_upload files html html_multiloc image_files linear_scale multiline_text multiline_text_multiloc
-    multiselect multiselect_image number page point line polygon select select_image text text_multiloc topic_ids section
+    multiselect multiselect_image number page point line polygon select select_image shapefile_upload text text_multiloc
+    topic_ids section
   ].freeze
   CODES = %w[
     author_id birthyear body_multiloc budget domicile education gender idea_files_attributes idea_images_attributes
@@ -131,7 +132,7 @@ class CustomField < ApplicationRecord
   end
 
   def file_upload?
-    input_type == 'file_upload'
+    input_type == 'file_upload' || input_type == 'shapefile_upload'
   end
 
   def page?
@@ -212,6 +213,8 @@ class CustomField < ApplicationRecord
       visitor.visit_select self
     when 'select_image'
       visitor.visit_select_image self
+    when 'shapefile_upload'
+      visitor.visit_shapefile_upload self
     when 'text'
       visitor.visit_text self
     when 'text_multiloc'

--- a/back/app/services/custom_field_params_service.rb
+++ b/back/app/services/custom_field_params_service.rb
@@ -7,7 +7,7 @@ class CustomFieldParamsService
       case field.input_type
       when 'multiselect', 'multiselect_image'
         fields_with_array_keys[field.key.to_sym] = []
-      when 'file_upload'
+      when 'file_upload', 'shapefile_upload'
         fields_with_array_keys[field.key.to_sym] = %i[id content name]
       when 'html_multiloc', 'multiline_text_multiloc', 'text_multiloc'
         fields_with_array_keys[field.key.to_sym] = CL2_SUPPORTED_LOCALES

--- a/back/app/services/field_visitor_service.rb
+++ b/back/app/services/field_visitor_service.rb
@@ -85,6 +85,10 @@ class FieldVisitorService
     default(field)
   end
 
+  def visit_shapefile_upload(field)
+    default(field)
+  end
+
   def visit_topic_ids(field)
     default(field)
   end

--- a/back/app/services/idea_custom_fields_service.rb
+++ b/back/app/services/idea_custom_fields_service.rb
@@ -39,13 +39,13 @@ class IdeaCustomFieldsService
 
   # Used in the printable PDF export
   def printable_fields
-    ignore_field_types = %w[section page date files image_files point file_upload topic_ids]
+    ignore_field_types = %w[section page date files image_files point file_upload shapefile_upload topic_ids]
     fields = enabled_fields.reject { |field| ignore_field_types.include? field.input_type }
     insert_other_option_text_fields(fields)
   end
 
   def importable_fields
-    ignore_field_types = %w[page section date files image_files file_upload point line polygon]
+    ignore_field_types = %w[page section date files image_files file_upload shapefile_upload point line polygon]
     enabled_fields_with_other_options.reject { |field| ignore_field_types.include? field.input_type }
   end
 

--- a/back/app/services/json_schema_generator_service.rb
+++ b/back/app/services/json_schema_generator_service.rb
@@ -272,6 +272,23 @@ class JsonSchemaGeneratorService < FieldVisitorService
     }
   end
 
+  def visit_shapefile_upload(_field)
+    {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string'
+        },
+        content: {
+          type: 'string'
+        },
+        name: {
+          type: 'string'
+        }
+      }
+    }
+  end
+
   private
 
   attr_reader :locales, :multiloc_service

--- a/back/app/services/json_schema_generator_service.rb
+++ b/back/app/services/json_schema_generator_service.rb
@@ -272,21 +272,8 @@ class JsonSchemaGeneratorService < FieldVisitorService
     }
   end
 
-  def visit_shapefile_upload(_field)
-    {
-      type: 'object',
-      properties: {
-        id: {
-          type: 'string'
-        },
-        content: {
-          type: 'string'
-        },
-        name: {
-          type: 'string'
-        }
-      }
-    }
+  def visit_shapefile_upload(field)
+    visit_file_upload(field)
   end
 
   private

--- a/back/app/services/survey_results_generator_service.rb
+++ b/back/app/services/survey_results_generator_service.rb
@@ -68,6 +68,10 @@ class SurveyResultsGeneratorService < FieldVisitorService
     })
   end
 
+  def visit_shapefile_upload(field)
+    visit_file_upload(field)
+  end
+
   def visit_point(field)
     responses_to_geographic_input_type(field)
   end

--- a/back/app/services/template_service.rb
+++ b/back/app/services/template_service.rb
@@ -29,7 +29,7 @@ class TemplateService
     # Templates do not support ID references.
 
     supported_fields = custom_fields.select do |field|
-      %w[file_upload].exclude? field.input_type
+      %w[file_upload shapefile_upload].exclude? field.input_type
     end
     custom_field_values.slice(*supported_fields.map(&:key))
   end

--- a/back/app/services/xlsx_export/custom_field_for_report.rb
+++ b/back/app/services/xlsx_export/custom_field_for_report.rb
@@ -25,7 +25,7 @@ module XlsxExport
     end
 
     def hyperlink?
-      custom_field.input_type == 'file_upload'
+      custom_field.file_upload?
     end
 
     private

--- a/back/app/services/xlsx_export/value_visitor.rb
+++ b/back/app/services/xlsx_export/value_visitor.rb
@@ -104,6 +104,10 @@ module XlsxExport
       idea_file.file.url
     end
 
+    def visit_shapefile_upload(field)
+      visit_file_upload(field)
+    end
+
     def visit_topic_ids(_field)
       return '' if model.topics.empty?
 

--- a/back/engines/commercial/analysis/app/controllers/analysis/web_api/v1/inputs_controller.rb
+++ b/back/engines/commercial/analysis/app/controllers/analysis/web_api/v1/inputs_controller.rb
@@ -13,7 +13,7 @@ module Analysis
           @inputs = InputsFinder.new(@analysis, filters).execute
           filtered_count = @inputs.count
           @inputs = @inputs.order(published_at: :asc)
-          @inputs = @inputs.includes(:author)
+          @inputs = @inputs.includes(:author, :idea_files)
           @inputs = paginate @inputs
 
           render json: linked_json(
@@ -23,7 +23,7 @@ module Analysis
               app_configuration: AppConfiguration.instance,
               **jsonapi_serializer_params
             },
-            include: %i[author],
+            include: %i[author idea_files],
             meta: {
               filtered_count: filtered_count
             }

--- a/back/engines/commercial/analysis/app/controllers/analysis/web_api/v1/inputs_controller.rb
+++ b/back/engines/commercial/analysis/app/controllers/analysis/web_api/v1/inputs_controller.rb
@@ -23,7 +23,7 @@ module Analysis
               app_configuration: AppConfiguration.instance,
               **jsonapi_serializer_params
             },
-            include: [:author],
+            include: %i[author],
             meta: {
               filtered_count: filtered_count
             }

--- a/back/engines/commercial/analysis/app/serializers/analysis/web_api/v1/input_serializer.rb
+++ b/back/engines/commercial/analysis/app/serializers/analysis/web_api/v1/input_serializer.rb
@@ -8,6 +8,18 @@ module Analysis
 
         attributes :title_multiloc, :body_multiloc, :custom_field_values, :published_at, :updated_at, :likes_count, :dislikes_count, :comments_count, :votes_count, :location_description
 
+        attribute(:custom_field_values) do |input, _params|
+          idea_files = input.idea_files
+
+          cf_values = input.custom_field_values
+          cf_values.each do |k, v|
+            next unless v.is_a?(Hash) && v.key?('id')
+
+            idea_file = idea_files.find { |file| file.id == v['id'] }
+            cf_values[k][:url] = idea_file.present? ? idea_file.file.url : nil
+          end
+        end
+
         belongs_to :author, serializer: ::Analysis::WebApi::V1::AnalysisUserSerializer
         belongs_to :idea, serializer: ::WebApi::V1::IdeaSerializer do |input|
           input

--- a/back/engines/commercial/analysis/app/serializers/analysis/web_api/v1/input_serializer.rb
+++ b/back/engines/commercial/analysis/app/serializers/analysis/web_api/v1/input_serializer.rb
@@ -8,18 +8,7 @@ module Analysis
 
         attributes :title_multiloc, :body_multiloc, :custom_field_values, :published_at, :updated_at, :likes_count, :dislikes_count, :comments_count, :votes_count, :location_description
 
-        attribute(:custom_field_values) do |input, _params|
-          idea_files = input.idea_files
-
-          cf_values = input.custom_field_values
-          cf_values.each do |k, v|
-            next unless v.is_a?(Hash) && v.key?('id')
-
-            idea_file = idea_files.find { |file| file.id == v['id'] }
-            cf_values[k][:url] = idea_file.present? ? idea_file.file.url : nil
-          end
-        end
-
+        has_many :idea_files, serializer: ::WebApi::V1::FileSerializer
         belongs_to :author, serializer: ::Analysis::WebApi::V1::AnalysisUserSerializer
         belongs_to :idea, serializer: ::WebApi::V1::IdeaSerializer do |input|
           input

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/idea.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/idea.rb
@@ -32,7 +32,7 @@ module MultiTenancy
         end
 
         def self.filter_custom_field_values(custom_field_values, custom_fields)
-          supported_fields = custom_fields.reject { |field| field.input_type == 'file_upload' }
+          supported_fields = custom_fields.reject(&:file_upload?)
           custom_field_values.slice(*supported_fields.map(&:key))
         end
       end

--- a/back/lib/participation_method/native_survey.rb
+++ b/back/lib/participation_method/native_survey.rb
@@ -60,7 +60,8 @@ module ParticipationMethod
     end
 
     def allowed_extra_field_input_types
-      %w[page number linear_scale text multiline_text select multiselect multiselect_image file_upload point line polygon]
+      %w[page number linear_scale text multiline_text select multiselect
+        multiselect_image file_upload shapefile_upload point line polygon]
     end
 
     # NOTE: This is only ever used by the analyses controller - otherwise the front-end always persists the form

--- a/back/spec/factories/custom_fields.rb
+++ b/back/spec/factories/custom_fields.rb
@@ -213,6 +213,15 @@ FactoryBot.define do
       input_type { 'file_upload' }
     end
 
+    factory :custom_field_shapefile_upload do
+      title_multiloc do
+        {
+          'en' => 'Upload a zipfile containing your shapefiles'
+        }
+      end
+      input_type { 'shapefile_upload' }
+    end
+
     factory :custom_field_checkbox do
       title_multiloc do
         {

--- a/back/spec/models/custom_field_spec.rb
+++ b/back/spec/models/custom_field_spec.rb
@@ -130,6 +130,11 @@ RSpec.describe CustomField do
       expect(files_field.file_upload?).to be true
     end
 
+    it 'returns true when the input_type is "shapefile_upload"' do
+      files_field = described_class.new input_type: 'shapefile_upload'
+      expect(files_field.file_upload?).to be true
+    end
+
     it 'returns false otherwise' do
       other_field = described_class.new input_type: 'something_else'
       expect(other_field.file_upload?).to be false

--- a/back/spec/models/custom_field_spec.rb
+++ b/back/spec/models/custom_field_spec.rb
@@ -94,6 +94,10 @@ class TestVisitor < FieldVisitorService
   def visit_file_upload(_field)
     'file_upload from visitor'
   end
+
+  def visit_shapefile_upload(_field)
+    'shapefile_upload from visitor'
+  end
 end
 
 RSpec.describe CustomField do

--- a/back/spec/services/custom_field_params_service_spec.rb
+++ b/back/spec/services/custom_field_params_service_spec.rb
@@ -10,6 +10,7 @@ describe CustomFieldParamsService do
       create(:custom_field_line, key: 'line_field'),
       create(:custom_field_polygon, key: 'polygon_field'),
       create(:custom_field_file_upload, key: 'file_upload_field'),
+      create(:custom_field_shapefile_upload, key: 'shapefile_upload_field'),
       create(:custom_field_html_multiloc, key: 'html_multiloc_field'),
       create(:custom_field_linear_scale, key: 'linear_scale_field')
     ]
@@ -27,6 +28,7 @@ describe CustomFieldParamsService do
         {
           multiselect_field: [],
           file_upload_field: %i[id content name],
+          shapefile_upload_field: %i[id content name],
           html_multiloc_field: CL2_SUPPORTED_LOCALES
         }
       ]

--- a/back/spec/services/json_schema_generator_service_spec.rb
+++ b/back/spec/services/json_schema_generator_service_spec.rb
@@ -567,4 +567,25 @@ RSpec.describe JsonSchemaGeneratorService do
       })
     end
   end
+
+  describe '#visit_shapefile_upload' do
+    let(:field) { create(:custom_field, input_type: 'shapefile_upload', key: field_key) }
+
+    it 'returns the schema for the given field' do
+      expect(generator.visit_shapefile_upload(field)).to eq({
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string'
+          },
+          content: {
+            type: 'string'
+          },
+          name: {
+            type: 'string'
+          }
+        }
+      })
+    end
+  end
 end

--- a/back/spec/services/project_copy_service_spec.rb
+++ b/back/spec/services/project_copy_service_spec.rb
@@ -124,12 +124,14 @@ describe ProjectCopyService do
       supported_fields = %i[custom_field_number custom_field_linear_scale custom_field_checkbox].map do |factory|
         create(factory, :for_custom_form, resource: custom_form)
       end
-      unsupported_field = create(:custom_field, :for_custom_form, input_type: 'file_upload', resource: custom_form)
+      unsupported_field1 = create(:custom_field, :for_custom_form, input_type: 'file_upload', resource: custom_form)
+      unsupported_field2 = create(:custom_field, :for_custom_form, input_type: 'shapefile_upload', resource: custom_form)
       response = create(:native_survey_response, project: project)
       custom_field_values = {
         supported_fields[0].key => 7,
         supported_fields[1].key => 1,
-        unsupported_field.key => create(:file_upload, idea: response).id,
+        unsupported_field1.key => create(:file_upload, idea: response).id,
+        unsupported_field2.key => create(:file_upload, idea: response).id,
         supported_fields[2].key => false
       }
       response.update! custom_field_values: custom_field_values

--- a/back/spec/services/ui_schema_generator_service_spec.rb
+++ b/back/spec/services/ui_schema_generator_service_spec.rb
@@ -657,4 +657,25 @@ RSpec.describe UiSchemaGeneratorService do
       })
     end
   end
+
+  describe '#visit_shapefile_upload' do
+    let(:field) do
+      create(
+        :custom_field,
+        input_type: 'shapefile_upload',
+        key: field_key,
+        title_multiloc: { 'en' => 'Shapefile upload field title' },
+        description_multiloc: { 'en' => 'Shapefile upload field description' }
+      )
+    end
+
+    it 'returns the schema for the given field' do
+      expect(generator.visit_shapefile_upload(field)).to eq({
+        type: 'Control',
+        scope: "#/properties/#{field_key}",
+        label: 'Shapefile upload field title',
+        options: { input_type: field.input_type, description: 'Shapefile upload field description' }
+      })
+    end
+  end
 end

--- a/back/spec/services/xlsx_export/value_visitor_spec.rb
+++ b/back/spec/services/xlsx_export/value_visitor_spec.rb
@@ -559,6 +559,33 @@ describe XlsxExport::ValueVisitor do
       end
     end
 
+    describe '#visit_shapefile_upload' do
+      let(:input_type) { 'shapefile_upload' }
+
+      context 'when there is no value' do
+        let(:value) { nil }
+
+        it 'returns the empty string' do
+          I18n.with_locale('nl-NL') do
+            expect(visitor.visit_shapefile_upload(field)).to eq ''
+          end
+        end
+      end
+
+      context 'when there is a value' do
+        let(:model) { create(:native_survey_response) }
+        let!(:file) { create(:idea_file, name: 'File1.pdf', idea: model) }
+
+        before do
+          model.update!(custom_field_values: { field_key => { 'id' => file.id, 'name' => file.name } })
+        end
+
+        it 'returns the value for the report' do
+          expect(visitor.visit_shapefile_upload(field)).to eq file.file.url
+        end
+      end
+    end
+
     describe '#visit_topic_ids' do
       let(:input_type) { 'topic_ids' }
       let(:model) { create(:idea, topics: topics, custom_field_values: { field_key => value }) }


### PR DESCRIPTION
Basic BE implementation. Possibly needs some more work, but we can add that to the base branch later.

[API specs](https://www.notion.so/govocal/Mapping-Specs-Front-Office-API-Alignment-a1ff73a2f8d741d686caf2e6eade496a?pvs=4#337b2a3e4bfd45f7b29de795bad7315f)

- [x] basics of new `custom_field` with `input_type: 'shapefile_upload'`
- [x] add basic tests of new shapefile_upload & related functionality
- [x] incude idea_files in `analyses/:analysis_id/inputs` response

**N.B.** Check for comments beginning `# Dev note: TAN-2347-BE-for-new-shapefile-upload`, as they need addressing and then removing!
