### PR TITLE
TAN-2427: Fix punctuation in warning message shown to screen reader users about potential a11y issues in embedded surveys

### DIFF
--- a/front/app/containers/ProjectsShowPage/shared/survey/index.tsx
+++ b/front/app/containers/ProjectsShowPage/shared/survey/index.tsx
@@ -76,7 +76,7 @@ const Survey = ({
         </ProjectPageSectionTitle>
 
         <ScreenReaderOnly>
-          <FormattedMessage {...messages.embeddedSurveyScreenReaderWarning} />
+          <FormattedMessage {...messages.embeddedSurveyScreenReaderWarning1} />
         </ScreenReaderOnly>
 
         {surveyService === 'typeform' && (

--- a/front/app/containers/ProjectsShowPage/shared/survey/messages.ts
+++ b/front/app/containers/ProjectsShowPage/shared/survey/messages.ts
@@ -5,9 +5,9 @@ export default defineMessages({
     id: 'app.containers.ProjectsShowPage.process.survey.survey',
     defaultMessage: 'Survey',
   },
-  embeddedSurveyScreenReaderWarning: {
-    id: 'app.containers.ProjectsShowPage.process.survey.embeddedSurveyScreenReaderWarning',
+  embeddedSurveyScreenReaderWarning1: {
+    id: 'app.containers.ProjectsShowPage.process.survey.embeddedSurveyScreenReaderWarning1',
     defaultMessage:
-      ', Warning: The embedded survey may have accessibility issues for screenreader users. If you experience any challenges, please reach out to the platform admin to receive a link to the survey from the original platform. Alternatively, you can request other ways to fill out the survey.',
+      'Warning: The embedded survey may have accessibility issues for screenreader users. If you experience any challenges, please reach out to the platform admin to receive a link to the survey from the original platform. Alternatively, you can request other ways to fill out the survey.',
   },
 });

--- a/front/app/translations/ar-MA.json
+++ b/front/app/translations/ar-MA.json
@@ -1640,7 +1640,6 @@
   "app.containers.ProjectsShowPage.VolunteeringSection.signUpLinkText": "التسجيل",
   "app.containers.ProjectsShowPage.VolunteeringSection.withdrawVolunteerButton": "أنا أسحب عرضي للتطوع",
   "app.containers.ProjectsShowPage.VolunteeringSection.xVolunteers": "{x, plural, =0 {لا يوجد متطوعين} one {# متطوع} other {# من المتطوعين}}",
-  "app.containers.ProjectsShowPage.process.survey.embeddedSurveyScreenReaderWarning": "، تحذير: قد يكون للاستطلاع المضمن مشكلات في إمكانية الوصول لمستخدمي قارئ الشاشة. إذا واجهت أي تحديات، يرجى التواصل مع مسؤول المنصة للحصول على رابط للاستبيان من المنصة الأصلية. وبدلاً من ذلك، يمكنك طلب طرق أخرى لملء الاستبيان.",
   "app.containers.ProjectsShowPage.process.survey.survey": "الاستبيان",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotPermitted": "لتعرف إن كان بإمكانك المشاركة في هذا الاستبيان، يُرجى {logInLink} إلى المنصة أولًا.",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotVerified": "يمكن للمستخدمين الذين تم التحقق من هوياتهم فقط المشاركة في هذا الاستبيان. يُرجى {signUpLink} أو {logInLink} أولًا.",

--- a/front/app/translations/ar-SA.json
+++ b/front/app/translations/ar-SA.json
@@ -1640,7 +1640,6 @@
   "app.containers.ProjectsShowPage.VolunteeringSection.signUpLinkText": "التسجيل",
   "app.containers.ProjectsShowPage.VolunteeringSection.withdrawVolunteerButton": "أنا أسحب عرضي للتطوع",
   "app.containers.ProjectsShowPage.VolunteeringSection.xVolunteers": "{x, plural, =0 {لا يوجد متطوعين} one {# متطوع} other {# من المتطوعين}}",
-  "app.containers.ProjectsShowPage.process.survey.embeddedSurveyScreenReaderWarning": "، تحذير: قد يكون للاستطلاع المضمن مشكلات في إمكانية الوصول لمستخدمي قارئ الشاشة. إذا واجهت أي تحديات، يرجى التواصل مع مسؤول المنصة للحصول على رابط للاستبيان من المنصة الأصلية. وبدلاً من ذلك، يمكنك طلب طرق أخرى لملء الاستبيان.",
   "app.containers.ProjectsShowPage.process.survey.survey": "الاستبيان",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotPermitted": "لتعرف إن كان بإمكانك المشاركة في هذا الاستبيان، يُرجى {logInLink} إلى المنصة أولًا.",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotVerified": "يمكن للمستخدمين الذين تم التحقق من هوياتهم فقط المشاركة في هذا الاستبيان. يُرجى {signUpLink} أو {logInLink} أولًا.",

--- a/front/app/translations/ca-ES.json
+++ b/front/app/translations/ca-ES.json
@@ -1640,7 +1640,6 @@
   "app.containers.ProjectsShowPage.VolunteeringSection.signUpLinkText": "Registreu-vos",
   "app.containers.ProjectsShowPage.VolunteeringSection.withdrawVolunteerButton": "Retiro la meva oferta de voluntariat",
   "app.containers.ProjectsShowPage.VolunteeringSection.xVolunteers": "{x, plural, =0 {sense voluntaris} one {# voluntari} other {# voluntaris}}",
-  "app.containers.ProjectsShowPage.process.survey.embeddedSurveyScreenReaderWarning": ", Advertència: l'enquesta incrustada pot tenir problemes d'accessibilitat per als usuaris de lectors de pantalla. Si teniu cap repte, poseu-vos en contacte amb l'administrador de la plataforma per rebre un enllaç a l'enquesta des de la plataforma original. Alternativament, podeu sol·licitar altres maneres d'omplir l'enquesta.",
   "app.containers.ProjectsShowPage.process.survey.survey": "Enquesta",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotPermitted": "Per saber si podeu participar en aquesta enquesta, {logInLink} primer a la plataforma.",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotVerified": "Només els participants verificats poden participar en aquesta enquesta. Primer {signUpLink} o {logInLink}.",

--- a/front/app/translations/da-DK.json
+++ b/front/app/translations/da-DK.json
@@ -1640,7 +1640,6 @@
   "app.containers.ProjectsShowPage.VolunteeringSection.signUpLinkText": "tilmeld dig ",
   "app.containers.ProjectsShowPage.VolunteeringSection.withdrawVolunteerButton": "Jeg fortryder mit tilbud om at være frivillig ",
   "app.containers.ProjectsShowPage.VolunteeringSection.xVolunteers": "{x, plural, =0 {ingen frivillige} one {# frivillig} other {# frivillige}}",
-  "app.containers.ProjectsShowPage.process.survey.embeddedSurveyScreenReaderWarning": "Advarsel: Den indlejrede undersøgelse kan have tilgængelighedsproblemer for brugere af skærmlæsere. Hvis du oplever udfordringer, bedes du kontakte platformens administrator for at modtage et link til undersøgelsen fra den oprindelige platform. Alternativt kan du anmode om andre måder at udfylde undersøgelsen på.",
   "app.containers.ProjectsShowPage.process.survey.survey": "Spørgeundersøgelse",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotPermitted": "For at finde ud af, om du kan deltage i denne undersøgelse, skal du først {logInLink} på platformen.",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotVerified": "Kun registrerede brugere kan deltage i denne survey. Venligst {signUpLink} eller {logInLink} først.",

--- a/front/app/translations/de-DE.json
+++ b/front/app/translations/de-DE.json
@@ -1640,7 +1640,6 @@
   "app.containers.ProjectsShowPage.VolunteeringSection.signUpLinkText": "registrieren Sie sich",
   "app.containers.ProjectsShowPage.VolunteeringSection.withdrawVolunteerButton": "Ich ziehe meine Teilnahme zurück",
   "app.containers.ProjectsShowPage.VolunteeringSection.xVolunteers": "{x, plural, =0 {keine Teilnehmenden} one {# Teilnehmende:r} other {# Teilnehmende}}",
-  "app.containers.ProjectsShowPage.process.survey.embeddedSurveyScreenReaderWarning": ", Warnung: Die eingebettete Umfrage kann Probleme mit der Zugänglichkeit für Screenreader-Nutzer haben. Wenn Sie auf Probleme stoßen, wenden Sie sich bitte an den Administrator der Plattform, um einen Link zur Umfrage von der ursprünglichen Plattform zu erhalten. Alternativ können Sie auch andere Möglichkeiten zum Ausfüllen der Umfrage anfordern.",
   "app.containers.ProjectsShowPage.process.survey.survey": "Umfrage",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotPermitted": "Um zu erfahren, ob Sie an dieser Umfrage teilnehmen können, besuchen Sie bitte zuerst {logInLink} die Plattform.",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotVerified": "Nur verifizierte Nutzer*innen können an dieser Umfrage teilnehmen. Bitte {signUpLink} oder {logInLink} zuerst.",

--- a/front/app/translations/el-GR.json
+++ b/front/app/translations/el-GR.json
@@ -1640,7 +1640,6 @@
   "app.containers.ProjectsShowPage.VolunteeringSection.signUpLinkText": "εγγραφείτε",
   "app.containers.ProjectsShowPage.VolunteeringSection.withdrawVolunteerButton": "Αποσύρω την προσφορά μου ως εθελοντής",
   "app.containers.ProjectsShowPage.VolunteeringSection.xVolunteers": "{x, plural, =0 {δεν υπάρχουν εθελοντές} one {# εθελοντής} other {# εθελοντές}}",
-  "app.containers.ProjectsShowPage.process.survey.embeddedSurveyScreenReaderWarning": ", Προειδοποίηση: Η ενσωματωμένη έρευνα μπορεί να έχει προβλήματα προσβασιμότητας για τους χρήστες προγραμμάτων ανάγνωσης οθόνης. Εάν αντιμετωπίζετε προβλήματα, παρακαλούμε επικοινωνήστε με τον διαχειριστή της πλατφόρμας για να λάβετε έναν σύνδεσμο για την έρευνα από την αρχική πλατφόρμα. Εναλλακτικά, μπορείτε να ζητήσετε άλλους τρόπους συμπλήρωσης της έρευνας.",
   "app.containers.ProjectsShowPage.process.survey.survey": "Έρευνα",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotPermitted": "Για να μάθετε αν μπορείτε να λάβετε μέρος σε αυτή την έρευνα, παρακαλούμε {logInLink} στην πλατφόρμα πρώτα.",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotVerified": "Μόνο επαληθευμένοι συμμετέχοντες μπορούν να λάβουν μέρος σε αυτή την έρευνα. Παρακαλούμε {signUpLink} ή {logInLink} πρώτα.",

--- a/front/app/translations/en-CA.json
+++ b/front/app/translations/en-CA.json
@@ -1640,7 +1640,6 @@
   "app.containers.ProjectsShowPage.VolunteeringSection.signUpLinkText": "sign up",
   "app.containers.ProjectsShowPage.VolunteeringSection.withdrawVolunteerButton": "I withdraw my offer to volunteer",
   "app.containers.ProjectsShowPage.VolunteeringSection.xVolunteers": "{x, plural, =0 {no participants} one {# participant} other {# participants}}",
-  "app.containers.ProjectsShowPage.process.survey.embeddedSurveyScreenReaderWarning": ", Warning: The embedded survey may have accessibility issues for screenreader users. If you experience any challenges, please reach out to the platform admin to receive a link to the survey from the original platform. Alternatively, you can request other ways to fill out the survey.",
   "app.containers.ProjectsShowPage.process.survey.survey": "Survey",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotPermitted": "To know if you can take part in this survey, please {logInLink} to the platform first.",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotVerified": "Only verified participants can take this survey. Please {signUpLink} or {logInLink} first.",

--- a/front/app/translations/en-GB.json
+++ b/front/app/translations/en-GB.json
@@ -1640,7 +1640,6 @@
   "app.containers.ProjectsShowPage.VolunteeringSection.signUpLinkText": "sign up",
   "app.containers.ProjectsShowPage.VolunteeringSection.withdrawVolunteerButton": "I withdraw my offer to volunteer",
   "app.containers.ProjectsShowPage.VolunteeringSection.xVolunteers": "{x, plural, =0 {no volunteers} one {# volunteer} other {# volunteers}}",
-  "app.containers.ProjectsShowPage.process.survey.embeddedSurveyScreenReaderWarning": ", Warning: The embedded survey may have accessibility issues for screenreader users. If you experience any challenges, please reach out to the platform admin to receive a link to the survey from the original platform. Alternatively, you can request other ways to fill out the survey.",
   "app.containers.ProjectsShowPage.process.survey.survey": "{tenantName, select, westminster {Westminster’s Innovation Challenge - Your idea} other {Survey}}",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotPermitted": "Please {logInLink} to the platform to see how you can participate.",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotVerified": "Only verified participants can take this survey. Please {signUpLink} or {logInLink} first.",

--- a/front/app/translations/en-IE.json
+++ b/front/app/translations/en-IE.json
@@ -1640,7 +1640,6 @@
   "app.containers.ProjectsShowPage.VolunteeringSection.signUpLinkText": "sign up",
   "app.containers.ProjectsShowPage.VolunteeringSection.withdrawVolunteerButton": "I withdraw my offer to volunteer",
   "app.containers.ProjectsShowPage.VolunteeringSection.xVolunteers": "{x, plural, =0 {no participants} one {# participant} other {# participants}}",
-  "app.containers.ProjectsShowPage.process.survey.embeddedSurveyScreenReaderWarning": ", Warning: The embedded survey may have accessibility issues for screenreader users. If you experience any challenges, please reach out to the platform admin to receive a link to the survey from the original platform. Alternatively, you can request other ways to fill out the survey.",
   "app.containers.ProjectsShowPage.process.survey.survey": "Survey",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotPermitted": "To know if you can take part in this survey, please {logInLink} to the platform first.",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotVerified": "Only verified participants can take this survey. Please {signUpLink} or {logInLink} first.",

--- a/front/app/translations/en.json
+++ b/front/app/translations/en.json
@@ -1641,7 +1641,7 @@
   "app.containers.ProjectsShowPage.VolunteeringSection.signUpLinkText": "sign up",
   "app.containers.ProjectsShowPage.VolunteeringSection.withdrawVolunteerButton": "I withdraw my offer to volunteer",
   "app.containers.ProjectsShowPage.VolunteeringSection.xVolunteers": "{x, plural, =0 {no participants} one {# participant} other {# participants}}",
-  "app.containers.ProjectsShowPage.process.survey.embeddedSurveyScreenReaderWarning": ", Warning: The embedded survey may have accessibility issues for screenreader users. If you experience any challenges, please reach out to the platform admin to receive a link to the survey from the original platform. Alternatively, you can request other ways to fill out the survey.",
+  "app.containers.ProjectsShowPage.process.survey.embeddedSurveyScreenReaderWarning1": "Warning: The embedded survey may have accessibility issues for screenreader users. If you experience any challenges, please reach out to the platform admin to receive a link to the survey from the original platform. Alternatively, you can request other ways to fill out the survey.",
   "app.containers.ProjectsShowPage.process.survey.survey": "Survey",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotPermitted": "To know if you can take part in this survey, please {logInLink} to the platform first.",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotVerified": "Only verified participants can take this survey. Please {signUpLink} or {logInLink} first.",

--- a/front/app/translations/es-CL.json
+++ b/front/app/translations/es-CL.json
@@ -1640,7 +1640,6 @@
   "app.containers.ProjectsShowPage.VolunteeringSection.signUpLinkText": "inscríbete",
   "app.containers.ProjectsShowPage.VolunteeringSection.withdrawVolunteerButton": "Dejar de participar",
   "app.containers.ProjectsShowPage.VolunteeringSection.xVolunteers": "{x, plural, =0 {ningún participante} one {# participante} other {# participantes}}",
-  "app.containers.ProjectsShowPage.process.survey.embeddedSurveyScreenReaderWarning": "Advertencia: La encuesta incrustada puede tener problemas de accesibilidad para los usuarios de lectores de pantalla. Si tienes algún problema, ponte en contacto con el administrador de la plataforma para recibir un enlace a la encuesta desde la plataforma original. Alternativamente, puedes solicitar otras formas de rellenar la encuesta.",
   "app.containers.ProjectsShowPage.process.survey.survey": "Consulta",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotPermitted": "Para saber si puedes participar en esta consulta, por favor {logInLink} a la plataforma primero.",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotVerified": "Sólo los usuarios verificados pueden responder esta consulta. Por favor {signUpLink} o {logInLink} primero.",

--- a/front/app/translations/es-ES.json
+++ b/front/app/translations/es-ES.json
@@ -1640,7 +1640,6 @@
   "app.containers.ProjectsShowPage.VolunteeringSection.signUpLinkText": "inscríbete",
   "app.containers.ProjectsShowPage.VolunteeringSection.withdrawVolunteerButton": "Dejar de participar",
   "app.containers.ProjectsShowPage.VolunteeringSection.xVolunteers": "{x, plural, =0 {ningún participante} one {# participante} other {# participantes}}",
-  "app.containers.ProjectsShowPage.process.survey.embeddedSurveyScreenReaderWarning": "Advertencia: La encuesta incrustada puede tener problemas de accesibilidad para los usuarios de lectores de pantalla. Si tienes algún problema, ponte en contacto con el administrador de la plataforma para recibir un enlace a la encuesta desde la plataforma original. Alternativamente, puedes solicitar otras formas de rellenar la encuesta.",
   "app.containers.ProjectsShowPage.process.survey.survey": "Consulta",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotPermitted": "Para saber si puedes participar en esta encuesta, primero debes {logInLink} a la plataforma.",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotVerified": "Sólo los usuarios verificados pueden responder esta consulta. Por favor {signUpLink} o {logInLink} primero.",

--- a/front/app/translations/fi-FI.json
+++ b/front/app/translations/fi-FI.json
@@ -1640,7 +1640,6 @@
   "app.containers.ProjectsShowPage.VolunteeringSection.signUpLinkText": "Kirjaudu",
   "app.containers.ProjectsShowPage.VolunteeringSection.withdrawVolunteerButton": "Peruutan tarjoukseni vapaaehtoiseksi",
   "app.containers.ProjectsShowPage.VolunteeringSection.xVolunteers": "{x, plural, =0 {ei osallistujia} one {# osallistuja} other {# osallistujaa}}",
-  "app.containers.ProjectsShowPage.process.survey.embeddedSurveyScreenReaderWarning": ", Varoitus: upotetussa kyselyssä voi olla esteettömyysongelmia näytönlukulaitteiden käyttäjille. Jos kohtaat haasteita, ota yhteyttä alustan järjestelmänvalvojaan saadaksesi linkin kyselyyn alkuperäiseltä alustalta. Vaihtoehtoisesti voit pyytää muita tapoja täyttää kysely.",
   "app.containers.ProjectsShowPage.process.survey.survey": "Kysely",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotPermitted": "Jos haluat tietää, voitko osallistua tähän kyselyyn, siirry ensin alustalle {logInLink} .",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotVerified": "Vain vahvistetut osallistujat voivat osallistua tähän kyselyyn. Ole hyvä ja {signUpLink} tai {logInLink} ensin.",

--- a/front/app/translations/fr-BE.json
+++ b/front/app/translations/fr-BE.json
@@ -1640,7 +1640,6 @@
   "app.containers.ProjectsShowPage.VolunteeringSection.signUpLinkText": "s'inscrire",
   "app.containers.ProjectsShowPage.VolunteeringSection.withdrawVolunteerButton": "Je retire ma proposition d'aide",
   "app.containers.ProjectsShowPage.VolunteeringSection.xVolunteers": "{x, plural, =0 {pas de volontaires} one {# volontaire} other {# volontaires}}",
-  "app.containers.ProjectsShowPage.process.survey.embeddedSurveyScreenReaderWarning": ", Attention : Les enquêtes intégrées peuvent poser des problèmes d'accessibilité pour les utilisateurs de lecteurs d'écran. Si vous rencontrez des difficultés, veuillez contacter l'administrateur de la plateforme pour obtenir un lien vers l'enquête sur la plateforme d'origine. Vous pouvez également demander d'autres moyens pour répondre à l'enquête.",
   "app.containers.ProjectsShowPage.process.survey.survey": "Enquête",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotPermitted": "Pour savoir si vous pouvez participer à cette enquête, vous devez d'abord {logInLink} à la plateforme.",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotVerified": "Seuls les utilisateurs vérifiés peuvent répondre à cette enquête. Veuillez commencer par {signUpLink} ou {logInLink}.",

--- a/front/app/translations/fr-FR.json
+++ b/front/app/translations/fr-FR.json
@@ -1640,7 +1640,6 @@
   "app.containers.ProjectsShowPage.VolunteeringSection.signUpLinkText": "m'inscris",
   "app.containers.ProjectsShowPage.VolunteeringSection.withdrawVolunteerButton": "Je ne souhaite plus participer",
   "app.containers.ProjectsShowPage.VolunteeringSection.xVolunteers": "{x, plural, =0 {pas de volontaires} one {# volontaire} other {# volontaires}}",
-  "app.containers.ProjectsShowPage.process.survey.embeddedSurveyScreenReaderWarning": ", Attention : Les enquêtes intégrées peuvent poser des problèmes d'accessibilité pour les utilisateurs de lecteurs d'écran. Si vous rencontrez des difficultés, veuillez contacter l'administrateur de la plateforme pour obtenir un lien vers l'enquête sur la plateforme d'origine. Vous pouvez également demander d'autres moyens pour répondre à l'enquête.",
   "app.containers.ProjectsShowPage.process.survey.survey": "Enquête",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotPermitted": "Pour savoir si vous pouvez participer à cette enquête, {logInLink}.",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotVerified": "Seuls les utilisateurs vérifiés peuvent répondre à cette enquête. Veuillez commencer par {signUpLink} ou {logInLink}.",

--- a/front/app/translations/hr-HR.json
+++ b/front/app/translations/hr-HR.json
@@ -1640,7 +1640,6 @@
   "app.containers.ProjectsShowPage.VolunteeringSection.signUpLinkText": "registracija",
   "app.containers.ProjectsShowPage.VolunteeringSection.withdrawVolunteerButton": "Povlačim svoju ponudu za volontiranje",
   "app.containers.ProjectsShowPage.VolunteeringSection.xVolunteers": "{x, plural, =0 {nema volontera} one {# volonter} other {# volontera}}",
-  "app.containers.ProjectsShowPage.process.survey.embeddedSurveyScreenReaderWarning": ", Upozorenje: ugrađena anketa može imati problema s pristupačnošću za korisnike čitača zaslona. Ako naiđete na bilo kakve izazove, obratite se administratoru platforme kako biste dobili poveznicu na anketu s izvorne platforme. Alternativno, možete zatražiti druge načine ispunjavanja ankete.",
   "app.containers.ProjectsShowPage.process.survey.survey": "Upitnik",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotPermitted": "Kako biste znali možete li sudjelovati u ovom upitniku, molimo vas da se prvo prijavite {logInLink} na platformu.",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotVerified": "Samo potvrđeni sudionici mogu pristupiti ovom upitniku. Molimo vas da se prvo registrirate {signUpLink} ili prijavite {logInLink}.",

--- a/front/app/translations/it-IT.json
+++ b/front/app/translations/it-IT.json
@@ -1640,7 +1640,6 @@
   "app.containers.ProjectsShowPage.VolunteeringSection.signUpLinkText": "iscriversi",
   "app.containers.ProjectsShowPage.VolunteeringSection.withdrawVolunteerButton": "Ritiro la mia offerta di volontariato",
   "app.containers.ProjectsShowPage.VolunteeringSection.xVolunteers": "{x, plural, =0 {nessun volontario} one {# volontario} other {# volontari}}",
-  "app.containers.ProjectsShowPage.process.survey.embeddedSurveyScreenReaderWarning": ", Attenzione: L'indagine incorporata potrebbe presentare problemi di accessibilità per gli utenti di screenreader. In caso di problemi, contatta l'amministratore della piattaforma per ricevere un link all'indagine dalla piattaforma originale. In alternativa, puoi richiedere altri modi per compilare l'indagine.",
   "app.containers.ProjectsShowPage.process.survey.survey": "Sondaggio",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotPermitted": "Per sapere se puoi partecipare a questo sondaggio, ti preghiamo di {logInLink} accedere prima alla piattaforma.",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotVerified": "Solo i partecipanti verificati possono partecipare a questo sondaggio. Si prega di {signUpLink} o {logInLink} prima.",

--- a/front/app/translations/lb-LU.json
+++ b/front/app/translations/lb-LU.json
@@ -1640,7 +1640,6 @@
   "app.containers.ProjectsShowPage.VolunteeringSection.signUpLinkText": "aschreiwen",
   "app.containers.ProjectsShowPage.VolunteeringSection.withdrawVolunteerButton": "Ech ka net méi hëllefen",
   "app.containers.ProjectsShowPage.VolunteeringSection.xVolunteers": "{x, plural, one {# Volontaire} other {# Volontairen}}",
-  "app.containers.ProjectsShowPage.process.survey.embeddedSurveyScreenReaderWarning": ", Opgepasst: Déi embedded Ëmfro kann Accessibilitéitsprobleemer fir Screenreader Benotzer hunn. Wann Dir Erausfuerderunge erliewt, kontaktéiert w.e.g. den Plattformadministrator fir e Link op d'Ëmfro vun der ursprénglecher Plattform ze kréien. Alternativ kënnt Dir aner Weeër ufroen fir d'Ëmfro auszefëllen.",
   "app.containers.ProjectsShowPage.process.survey.survey": "Ëmfro",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotPermitted": "Fir gewuer ze ginn, ob Dir un dëser Ëmfro deelhuele kënnt, wgl. {logInLink} fir d’éischt op d’Plattform.",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotVerified": "Nëmmen iwwerpréiwte Benotzer kënnen un dëser Ëmfro deelhuelen. Wgl. fir d’éischt. {signUpLink} oder {logInLink}.",

--- a/front/app/translations/lv-LV.json
+++ b/front/app/translations/lv-LV.json
@@ -1640,7 +1640,6 @@
   "app.containers.ProjectsShowPage.VolunteeringSection.signUpLinkText": "reģistrēties",
   "app.containers.ProjectsShowPage.VolunteeringSection.withdrawVolunteerButton": "Es atsaucu savu brīvprātīgā darba piedāvājumu",
   "app.containers.ProjectsShowPage.VolunteeringSection.xVolunteers": "{x, plural, =0 {nav brīvprātīgo} one {# brīvprātīgais} other {# brīvprātīgie}}",
-  "app.containers.ProjectsShowPage.process.survey.embeddedSurveyScreenReaderWarning": ", Brīdinājums: V iestrādātajā aptaujā var būt problēmas ar ekrānlasītāju lietotāju piekļuvi. Ja rodas problēmas, lūdzu, sazinieties ar platformas administratoru, lai saņemtu saiti uz aptauju no sākotnējās platformas. Varat arī pieprasīt citus veidus, kā aizpildīt aptauju.",
   "app.containers.ProjectsShowPage.process.survey.survey": "Aptauja",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotPermitted": "Lai uzzinātu, vai varat piedalīties šajā pētījumā, vispirms lūdzu, {logInLink} platformai.",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotVerified": "Šo pētījumu var veikt tikai pārbaudīti dalībnieki. Lūdzu, vispirms {signUpLink} vai {logInLink}.",

--- a/front/app/translations/nb-NO.json
+++ b/front/app/translations/nb-NO.json
@@ -1640,7 +1640,6 @@
   "app.containers.ProjectsShowPage.VolunteeringSection.signUpLinkText": "registrer deg",
   "app.containers.ProjectsShowPage.VolunteeringSection.withdrawVolunteerButton": "Jeg trekker tilbake mitt tilbud om å være frivillig",
   "app.containers.ProjectsShowPage.VolunteeringSection.xVolunteers": "{x, plural, =0 {ingen frivillige} one {# frivillig} other {# frivillige}}",
-  "app.containers.ProjectsShowPage.process.survey.embeddedSurveyScreenReaderWarning": ", Advarsel: Den innebygde undersøkelsen kan ha tilgjengelighetsproblemer for skjermleserbrukere. Hvis du opplever noen utfordringer, ta kontakt med plattformadministratoren for å motta en lenke til undersøkelsen fra den opprinnelige plattformen. Alternativt kan du be om andre måter å fylle ut undersøkelsen på.",
   "app.containers.ProjectsShowPage.process.survey.survey": "Spørreundersøkelse",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotPermitted": "Logg inn for å finne ut om kan svare på undersøkelsen {logInLink}.",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotVerified": "Bare registrerte brukere kan delta i denne undersøkelse. Vennligst {signUpLink} eller {logInLink} først.",

--- a/front/app/translations/nl-BE.json
+++ b/front/app/translations/nl-BE.json
@@ -1640,7 +1640,6 @@
   "app.containers.ProjectsShowPage.VolunteeringSection.signUpLinkText": "aan te melden",
   "app.containers.ProjectsShowPage.VolunteeringSection.withdrawVolunteerButton": "{tenantName, select, Almere {Ik wil me uitschrijven} other {Ik wil mijn aanmelding intrekken}}",
   "app.containers.ProjectsShowPage.VolunteeringSection.xVolunteers": "{x, plural, =0 {nog geen aanmeldingen} one {# aanmelding} other {# aanmeldingen}}",
-  "app.containers.ProjectsShowPage.process.survey.embeddedSurveyScreenReaderWarning": "Waarschuwing: De ingesloten enquête kan toegankelijkheidsproblemen hebben voor gebruikers van screenreaders. Als je problemen ondervindt, neem dan contact op met de platformbeheerder om een koppeling naar de enquête van het oorspronkelijke platform te ontvangen. Je kunt ook andere manieren aanvragen om de enquête in te vullen.",
   "app.containers.ProjectsShowPage.process.survey.survey": "Enquête",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotPermitted": "Om te weten of je kunt deelnemen aan deze enquête, moet je eerst even {logInLink} op het platform.",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotVerified": "Enkel geverifieerde gebruikers kunnen deelnemen aan deze enquête. Gelieve eerst te {signUpLink} of te {logInLink}.",

--- a/front/app/translations/nl-NL.json
+++ b/front/app/translations/nl-NL.json
@@ -1640,7 +1640,6 @@
   "app.containers.ProjectsShowPage.VolunteeringSection.signUpLinkText": "registreren",
   "app.containers.ProjectsShowPage.VolunteeringSection.withdrawVolunteerButton": "{tenantName, select, Almere {Ik wil me uitschrijven} other {Ik wil mijn aanmelding intrekken}}",
   "app.containers.ProjectsShowPage.VolunteeringSection.xVolunteers": "{x, plural, =0 {nog geen aanmeldingen} one {# aanmelding} other {# aanmeldingen}}",
-  "app.containers.ProjectsShowPage.process.survey.embeddedSurveyScreenReaderWarning": "Waarschuwing: De ingesloten enquête kan toegankelijkheidsproblemen hebben voor gebruikers van screenreaders. Als je problemen ondervindt, neem dan contact op met de platformbeheerder om een koppeling naar de enquête van het oorspronkelijke platform te ontvangen. Je kunt ook andere manieren aanvragen om de enquête in te vullen.",
   "app.containers.ProjectsShowPage.process.survey.survey": "Vragenlijst",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotPermitted": "Om te weten of je kunt deelnemen aan deze vragenlijst, moet je eerst even {logInLink} op het platform.",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotVerified": "Alleen geverifieerde gebruikers kunnen deelnemen aan deze vragenlijst. Gelieve eerst te {signUpLink} of te {logInLink}.",

--- a/front/app/translations/pl-PL.json
+++ b/front/app/translations/pl-PL.json
@@ -1640,7 +1640,6 @@
   "app.containers.ProjectsShowPage.VolunteeringSection.signUpLinkText": "zarejestruj się",
   "app.containers.ProjectsShowPage.VolunteeringSection.withdrawVolunteerButton": "Wycofuję moją ofertę na wolontariusza",
   "app.containers.ProjectsShowPage.VolunteeringSection.xVolunteers": "{x, plural, =0 {brak wolontariuszy} one {# wolontariusz} few {# wolontariuszy} many {# wolontariuszy} other {# wolontariuszy}}",
-  "app.containers.ProjectsShowPage.process.survey.embeddedSurveyScreenReaderWarning": "Ostrzeżenie: Wbudowana ankieta może mieć problemy z dostępnością dla użytkowników czytników ekranu. Jeśli napotkasz jakiekolwiek trudności, skontaktuj się z administratorem platformy, aby otrzymać link do ankiety z oryginalnej platformy. Możesz również poprosić o inne sposoby wypełnienia ankiety.",
   "app.containers.ProjectsShowPage.process.survey.survey": "Ankieta",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotPermitted": "Aby dowiedzieć się, czy możesz wziąć udział w tej ankiecie, proszę najpierw {logInLink} do platformy.",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotVerified": "Tylko zweryfikowani użytkownicy mogą wypełnić tą ankietę. Proszę najpierw {signUpLink} lub {logInLink}.",

--- a/front/app/translations/pt-BR.json
+++ b/front/app/translations/pt-BR.json
@@ -1640,7 +1640,6 @@
   "app.containers.ProjectsShowPage.VolunteeringSection.signUpLinkText": "cadastrar-se",
   "app.containers.ProjectsShowPage.VolunteeringSection.withdrawVolunteerButton": "Descadastrar-se",
   "app.containers.ProjectsShowPage.VolunteeringSection.xVolunteers": "{x, plural, =0 {nenhum voluntário} one {# voluntário} other {# voluntários}}",
-  "app.containers.ProjectsShowPage.process.survey.embeddedSurveyScreenReaderWarning": "Aviso: A pesquisa incorporada pode ter problemas de acessibilidade para usuários de leitores de tela. Se você tiver algum problema, entre em contato com o administrador da plataforma para receber um link para a pesquisa da plataforma original. Como alternativa, você pode solicitar outras maneiras de preencher a pesquisa.",
   "app.containers.ProjectsShowPage.process.survey.survey": "Pesquisa",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotPermitted": "Para saber se você pode participar desta pesquisa, por favor {logInLink} à plataforma primeiro.",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotVerified": "Apenas usuários verificados podem participar desta pesquisa. Por favor {signUpLink} ou {logInLink} primeiro.",

--- a/front/app/translations/sr-Latn.json
+++ b/front/app/translations/sr-Latn.json
@@ -1640,7 +1640,6 @@
   "app.containers.ProjectsShowPage.VolunteeringSection.signUpLinkText": "registrujte se",
   "app.containers.ProjectsShowPage.VolunteeringSection.withdrawVolunteerButton": "Povlačim svoju ponudu za volontiranje",
   "app.containers.ProjectsShowPage.VolunteeringSection.xVolunteers": "{x, plural, =0 {nema volontera} one {# volonter} other {#volontera}}",
-  "app.containers.ProjectsShowPage.process.survey.embeddedSurveyScreenReaderWarning": ", Warning: The embedded survey may have accessibility issues for screenreader users. If you experience any challenges, please reach out to the platform admin to receive a link to the survey from the original platform. Alternatively, you can request other ways to fill out the survey.",
   "app.containers.ProjectsShowPage.process.survey.survey": "Upitnik",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotPermitted": "Da biste znali da li možete da učestvujete u ovom upitniku, molimo vas {logInLink} na platformu.",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotVerified": "Samo verifikovani učesnici mogu da pristupe ovom upitniku. Molimo vas {signUpLink} ili {logInLink}.",

--- a/front/app/translations/sr-SP.json
+++ b/front/app/translations/sr-SP.json
@@ -1640,7 +1640,6 @@
   "app.containers.ProjectsShowPage.VolunteeringSection.signUpLinkText": "пријави се",
   "app.containers.ProjectsShowPage.VolunteeringSection.withdrawVolunteerButton": "Повлачим своју понуду за волонтирање",
   "app.containers.ProjectsShowPage.VolunteeringSection.xVolunteers": "{x, plural, =0 {нема волонтера} one {#добровољац} other {# волонтера}}",
-  "app.containers.ProjectsShowPage.process.survey.embeddedSurveyScreenReaderWarning": ", Warning: The embedded survey may have accessibility issues for screenreader users. If you experience any challenges, please reach out to the platform admin to receive a link to the survey from the original platform. Alternatively, you can request other ways to fill out the survey.",
   "app.containers.ProjectsShowPage.process.survey.survey": "Анкета",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotPermitted": "Да бисте сазнали да ли можете да учествујете у овој анкети, прво {logInLink} на платформи.",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotVerified": "Само верификовани учесници могу попунити ову анкету. Молимо прво {signUpLink} или {logInLink}.",

--- a/front/app/translations/sv-SE.json
+++ b/front/app/translations/sv-SE.json
@@ -1640,7 +1640,6 @@
   "app.containers.ProjectsShowPage.VolunteeringSection.signUpLinkText": "registrera dig",
   "app.containers.ProjectsShowPage.VolunteeringSection.withdrawVolunteerButton": "Jag drar tillbaka mitt erbjudande om att anmäla mig frivilligt",
   "app.containers.ProjectsShowPage.VolunteeringSection.xVolunteers": "{x, plural, =0 {inga anmälde sig frivilligt} one {# anmälde sig frivilligt} other {# anmälde sig frivilligt}}",
-  "app.containers.ProjectsShowPage.process.survey.embeddedSurveyScreenReaderWarning": ", Varning: Den inbäddade enkäten kan ha tillgänglighetsproblem för användare av skärmläsare. Om du upplever några utmaningar, vänligen kontakta plattformsadministratören för att få en länk till undersökningen från den ursprungliga plattformen. Alternativt kan du begära andra sätt att fylla i enkäten.",
   "app.containers.ProjectsShowPage.process.survey.survey": "Undersökning",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotPermitted": "{logInLink} på plattformen först för att få veta om du kan delta i den här undersökningen.",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotVerified": "Endast verifierade deltagare kan delta i den här undersökningen. {signUpLink} eller {logInLink} först.",

--- a/front/app/translations/tr-TR.json
+++ b/front/app/translations/tr-TR.json
@@ -1640,7 +1640,6 @@
   "app.containers.ProjectsShowPage.VolunteeringSection.signUpLinkText": "kaydolun",
   "app.containers.ProjectsShowPage.VolunteeringSection.withdrawVolunteerButton": "Gönüllülük teklifimi geri alıyorum",
   "app.containers.ProjectsShowPage.VolunteeringSection.xVolunteers": "{x, plural, =0 {gönüllü yok} one {# gönüllü} other {# gönüllü}}",
-  "app.containers.ProjectsShowPage.process.survey.embeddedSurveyScreenReaderWarning": ", Uyarı: Gömülü anket, ekran okuyucu kullanıcıları için erişilebilirlik sorunları içerebilir. Herhangi bir sorunla karşılaşırsanız, orijinal platformdan ankete bir bağlantı almak için lütfen platform yöneticisine ulaşın. Alternatif olarak, anketi doldurmak için başka yollar da talep edebilirsiniz.",
   "app.containers.ProjectsShowPage.process.survey.survey": "Anket",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotPermitted": "Bu ankete katılıp katılamayacağınızı öğrenmek için lütfen önce platformda {logInLink}.",
   "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotVerified": "Bu ankete yalnızca doğrulanmış kullanıcılar katılabilir. Lütfen önce {signUpLink} veya {logInLink}.",


### PR DESCRIPTION
# Changelog

## Fixed
- a11y: Fix punctuation in warning message shown to screen reader users about potential a11y issues in embedded surveys