### PR TITLE
TAN-2433 - Add locked fields to permissions custom fields schema

### DIFF
--- a/back/app/controllers/web_api/v1/permissions_controller.rb
+++ b/back/app/controllers/web_api/v1/permissions_controller.rb
@@ -38,7 +38,7 @@ class WebApi::V1::PermissionsController < ApplicationController
   def schema
     authorize @permission
     fields = user_requirements_service.requirements_fields @permission
-    render json: raw_json(JsonFormsService.new.user_ui_and_json_multiloc_schemas(fields))
+    render json: raw_json(user_ui_and_json_multiloc_schemas(fields))
   end
 
   private
@@ -49,6 +49,11 @@ class WebApi::V1::PermissionsController < ApplicationController
       params: jsonapi_serializer_params,
       include: %i[permissions_custom_fields custom_fields]
     ).serializable_hash
+  end
+
+  # NOTE: Extended by verification
+  def user_ui_and_json_multiloc_schemas(fields)
+    JsonFormsService.new.user_ui_and_json_multiloc_schemas(fields)
   end
 
   def permissions_update_service
@@ -75,3 +80,5 @@ class WebApi::V1::PermissionsController < ApplicationController
     params.require(:permission).permit(:permitted_by, :global_custom_fields, group_ids: [])
   end
 end
+
+WebApi::V1::PermissionsController.prepend(Verification::Patches::WebApi::V1::PermissionsController)

--- a/back/app/models/permissions_custom_field.rb
+++ b/back/app/models/permissions_custom_field.rb
@@ -10,6 +10,7 @@
 #  required        :boolean          default(TRUE), not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#  ordering        :integer          default(0)
 #
 # Indexes
 #

--- a/back/app/models/permissions_custom_field.rb
+++ b/back/app/models/permissions_custom_field.rb
@@ -10,7 +10,6 @@
 #  required        :boolean          default(TRUE), not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
-#  ordering        :integer          default(0)
 #
 # Indexes
 #

--- a/back/engines/commercial/verification/app/controllers/verification/patches/web_api/v1/permissions_controller.rb
+++ b/back/engines/commercial/verification/app/controllers/verification/patches/web_api/v1/permissions_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Verification
+  module Patches
+    module WebApi
+      module V1
+        module PermissionsController
+
+          private
+
+          def user_ui_and_json_multiloc_schemas(fields)
+            super.tap do |schemas_multiloc|
+              mark_locked_json_forms_fields(schemas_multiloc) if current_user
+            end
+          end
+
+          def mark_locked_json_forms_fields(schemas_multiloc)
+            locked_custom_fields = verification_service.locked_custom_fields(current_user).map(&:to_s)
+            schemas_multiloc[:ui_schema_multiloc].each do |_locale, ui_schema|
+              ui_schema[:elements]
+                .select { |e| locked_custom_fields.any? { |field| e[:scope].end_with?(field) } }
+                .each_with_index do |element, index|
+                ui_schema[:elements][index] = element.merge(options: element[:options].to_h.merge(readonly: true, verificationLocked: true))
+              end
+            end
+          end
+
+          def verification_service
+            @verification_service ||= VerificationService.new
+          end
+        end
+      end
+    end
+  end
+end

--- a/back/engines/commercial/verification/app/controllers/verification/patches/web_api/v1/permissions_controller.rb
+++ b/back/engines/commercial/verification/app/controllers/verification/patches/web_api/v1/permissions_controller.rb
@@ -5,7 +5,6 @@ module Verification
     module WebApi
       module V1
         module PermissionsController
-
           private
 
           def user_ui_and_json_multiloc_schemas(fields)

--- a/back/engines/commercial/verification/spec/acceptance/permissions_spec.rb
+++ b/back/engines/commercial/verification/spec/acceptance/permissions_spec.rb
@@ -21,10 +21,9 @@ resource 'Permissions custom field schema - Locked attributes' do
       assert_status 200
       expect(response_data[:type]).to eq 'schema'
       expect(response_data.dig(:attributes, :ui_schema_multiloc, :en, :elements).find { |e| e[:scope] == '#/properties/gender' }[:options].to_h).to include({
-         readonly: true,
-         verificationLocked: true
-                                                                                                                                                                   })
+        readonly: true,
+        verificationLocked: true
+      })
     end
   end
-
 end

--- a/back/engines/commercial/verification/spec/acceptance/permissions_spec.rb
+++ b/back/engines/commercial/verification/spec/acceptance/permissions_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rspec_api_documentation/dsl'
+
+resource 'Users - Locked attributes' do
+  explanation "List the attributes the user can't change in their profile, since they're controlled by a verification method"
+
+  before do
+    header 'Content-Type', 'application/json'
+    @user = create(:user)
+    header_token_for @user
+  end
+
+  get 'web_api/v1/users/me/locked_attributes' do
+    with_options scope: :page do
+      parameter :number, 'Page number'
+      parameter :size, 'Number of verification methods per page'
+    end
+
+    before do
+      create(:verification, method_name: 'clave_unica', user: @user)
+    end
+
+    context 'for an authenticated user' do
+      example_request 'List locked built-in attributes' do
+        assert_status 200
+        json_response = json_parse(response_body)
+        expect(json_response[:data].map { |d| d[:attributes][:name] }).to eq %w[first_name last_name]
+      end
+    end
+
+    context 'for an unauthenticated user' do
+      before do
+        header 'Authorization', nil
+      end
+
+      example_request '[error] returns 401 Unauthorized response' do
+        assert_status 401
+      end
+    end
+  end
+
+  get 'web_api/v1/users/custom_fields/json_forms_schema', document: false do
+    before do
+      # Bogus locks the `gender` custom_field
+      create(:custom_field_gender)
+      create(:verification, method_name: 'bogus', user: @user)
+    end
+
+    example_request 'Jsonforms UI schema marks the locked fields' do
+      assert_status 200
+      json_response = json_parse response_body
+      binding.pry
+
+      expect(json_response.dig(:data, :type)).to eq 'json_forms_schema'
+      expect(json_response.dig(:data, :attributes, :ui_schema_multiloc, :en, :elements).find { |e| e[:scope] == '#/properties/gender' }[:options].to_h).to include({
+        readonly: true,
+        verificationLocked: true
+      })
+    end
+  end
+
+  get 'web_api/v1/permissions/visiting/schema', document: false do
+    before do
+      # Bogus locks the `gender` custom_field
+      create(:custom_field_gender)
+      create(:verification, method_name: 'bogus', user: @user)
+      Permissions::PermissionsUpdateService.new.update_all_permissions
+    end
+
+    example_request 'Jsonforms UI schema marks the locked fields' do
+      assert_status 200
+      expect(response_data[:type]).to eq 'schema'
+      expect(response_data.dig(:attributes, :ui_schema_multiloc, :en, :elements).find { |e| e[:scope] == '#/properties/gender' }[:options].to_h).to include({
+         readonly: true,
+         verificationLocked: true
+                                                                                                                                                                   })
+    end
+  end
+
+end

--- a/back/engines/commercial/verification/spec/acceptance/permissions_spec.rb
+++ b/back/engines/commercial/verification/spec/acceptance/permissions_spec.rb
@@ -3,73 +3,21 @@
 require 'rails_helper'
 require 'rspec_api_documentation/dsl'
 
-resource 'Users - Locked attributes' do
-  explanation "List the attributes the user can't change in their profile, since they're controlled by a verification method"
-
+resource 'Permissions custom field schema - Locked attributes' do
   before do
     header 'Content-Type', 'application/json'
     @user = create(:user)
     header_token_for @user
   end
 
-  get 'web_api/v1/users/me/locked_attributes' do
-    with_options scope: :page do
-      parameter :number, 'Page number'
-      parameter :size, 'Number of verification methods per page'
-    end
-
-    before do
-      create(:verification, method_name: 'clave_unica', user: @user)
-    end
-
-    context 'for an authenticated user' do
-      example_request 'List locked built-in attributes' do
-        assert_status 200
-        json_response = json_parse(response_body)
-        expect(json_response[:data].map { |d| d[:attributes][:name] }).to eq %w[first_name last_name]
-      end
-    end
-
-    context 'for an unauthenticated user' do
-      before do
-        header 'Authorization', nil
-      end
-
-      example_request '[error] returns 401 Unauthorized response' do
-        assert_status 401
-      end
-    end
-  end
-
-  get 'web_api/v1/users/custom_fields/json_forms_schema', document: false do
-    before do
-      # Bogus locks the `gender` custom_field
-      create(:custom_field_gender)
-      create(:verification, method_name: 'bogus', user: @user)
-    end
-
-    example_request 'Jsonforms UI schema marks the locked fields' do
-      assert_status 200
-      json_response = json_parse response_body
-      binding.pry
-
-      expect(json_response.dig(:data, :type)).to eq 'json_forms_schema'
-      expect(json_response.dig(:data, :attributes, :ui_schema_multiloc, :en, :elements).find { |e| e[:scope] == '#/properties/gender' }[:options].to_h).to include({
-        readonly: true,
-        verificationLocked: true
-      })
-    end
-  end
-
   get 'web_api/v1/permissions/visiting/schema', document: false do
     before do
       # Bogus locks the `gender` custom_field
       create(:custom_field_gender)
-      create(:verification, method_name: 'bogus', user: @user)
       Permissions::PermissionsUpdateService.new.update_all_permissions
     end
 
-    example_request 'Jsonforms UI schema marks the locked fields' do
+    example_request 'Locked fields are marked in the UI schema' do
       assert_status 200
       expect(response_data[:type]).to eq 'schema'
       expect(response_data.dig(:attributes, :ui_schema_multiloc, :en, :elements).find { |e| e[:scope] == '#/properties/gender' }[:options].to_h).to include({

--- a/back/engines/commercial/verification/spec/acceptance/permissions_spec.rb
+++ b/back/engines/commercial/verification/spec/acceptance/permissions_spec.rb
@@ -3,24 +3,23 @@
 require 'rails_helper'
 require 'rspec_api_documentation/dsl'
 
-resource 'Permissions custom field schema - Locked attributes' do
-  before do
-    header 'Content-Type', 'application/json'
-    @user = create(:user)
-    header_token_for @user
-  end
-
+resource 'Permissions user custom field schemas - Locked attributes' do
   get 'web_api/v1/permissions/visiting/schema', document: false do
     before do
-      # Bogus locks the `gender` custom_field
-      create(:custom_field_gender)
-      create(:verification, method_name: 'bogus', user: @user)
+      create(:custom_field_gender, required: false)
       Permissions::PermissionsUpdateService.new.update_all_permissions
+
+      user = create(:user)
+      create(:verification, method_name: 'bogus', user: user) # Bogus locks the `gender` custom_field
+
+      header 'Content-Type', 'application/json'
+      header_token_for user
     end
 
     example_request 'Locked fields are marked in the UI schema' do
       assert_status 200
       expect(response_data[:type]).to eq 'schema'
+      expect(response_data.dig(:attributes, :json_schema_multiloc, :en, :required)).to eq ['gender']
       expect(response_data.dig(:attributes, :ui_schema_multiloc, :en, :elements).find { |e| e[:scope] == '#/properties/gender' }[:options].to_h).to include({
         readonly: true,
         verificationLocked: true

--- a/back/engines/commercial/verification/spec/acceptance/permissions_spec.rb
+++ b/back/engines/commercial/verification/spec/acceptance/permissions_spec.rb
@@ -14,6 +14,7 @@ resource 'Permissions custom field schema - Locked attributes' do
     before do
       # Bogus locks the `gender` custom_field
       create(:custom_field_gender)
+      create(:verification, method_name: 'bogus', user: @user)
       Permissions::PermissionsUpdateService.new.update_all_permissions
     end
 


### PR DESCRIPTION
# Changelog
## Fixed
- TAN-2433 - When users are verified, fields are correctly locked in user forms
