### PR TITLE
TAN-2383 - Allow Azure AD login to only appear on a separate admin login page

### DIFF
--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -414,6 +414,12 @@
             "title": "Login Mechanism Name",
             "type": "string",
             "description": "The Login Mechanism Name is used for user-facing copy. For instance, \"Sign up with {login_mechanism_name}.\"."
+          },
+          "admin_only": {
+            "title": "Admin only",
+            "type": "boolean",
+            "default": false,
+            "description": "Should this login mechanism be available only for admins at /sign-in/admin ?"
           }
         }
       },

--- a/back/engines/commercial/multi_tenancy/db/seeds/tenants.rb
+++ b/back/engines/commercial/multi_tenancy/db/seeds/tenants.rb
@@ -59,7 +59,8 @@ module MultiTenancy
               tenant: ENV.fetch('DEFAULT_AZURE_AD_LOGIN_TENANT_ID'),
               client_id: ENV.fetch('DEFAULT_AZURE_AD_LOGIN_CLIENT_ID'),
               logo_url: 'https://cl2-seed-and-template-assets.s3.eu-central-1.amazonaws.com/images/microsoft-azure-logo.png',
-              login_mechanism_name: 'Azure Active Directory'
+              login_mechanism_name: 'Azure Active Directory',
+              admin_only: false
             },
             azure_ad_b2c_login: {
               allowed: true,

--- a/front/app/api/app_configuration/types.ts
+++ b/front/app/api/app_configuration/types.ts
@@ -103,6 +103,7 @@ export interface IAppConfigurationSettings {
     client_id: string;
     logo_url: string;
     login_mechanism_name: string;
+    admin_only?: boolean;
   };
   azure_ad_b2c_login?: {
     allowed: boolean;

--- a/front/app/containers/Authentication/steps/AuthProviders/index.tsx
+++ b/front/app/containers/Authentication/steps/AuthProviders/index.tsx
@@ -21,6 +21,7 @@ import TextButton from '../_components/TextButton';
 import AuthProviderButton, { TOnContinueFunction } from './AuthProviderButton';
 import ClaveUnicaExpandedAuthProviderButton from './ClaveUnicaExpandedAuthProviderButton';
 import messages from './messages';
+import { useLocation } from 'react-router-dom';
 
 const Container = styled.div`
   display: flex;
@@ -53,12 +54,17 @@ const AuthProviders = memo<Props>(
   ({ flow, className, error, onSwitchFlow, onSelectAuthProvider }) => {
     const { formatMessage } = useIntl();
     const { data: tenant } = useAppConfiguration();
+    const { pathname } = useLocation();
     const tenantSettings = tenant?.data.attributes.settings;
+
+    const showAdminOnlyMethods = pathname.endsWith('/sign-in/admin');
 
     const passwordLoginEnabled = useFeatureFlag({ name: 'password_login' });
     const googleLoginEnabled = useFeatureFlag({ name: 'google_login' });
     const facebookLoginEnabled = useFeatureFlag({ name: 'facebook_login' });
-    const azureAdLoginEnabled = useFeatureFlag({ name: 'azure_ad_login' });
+    const azureAdLoginEnabled =
+      useFeatureFlag({ name: 'azure_ad_login' }) &&
+      (!tenantSettings?.azure_ad_login?.admin_only || showAdminOnlyMethods);
     const azureAdB2cLoginEnabled = useFeatureFlag({
       name: 'azure_ad_b2c_login',
     });

--- a/front/app/containers/Authentication/useSteps/index.ts
+++ b/front/app/containers/Authentication/useSteps/index.ts
@@ -203,7 +203,7 @@ export default function useSteps() {
     }
 
     // launch sign in flow, derived from route
-    if (pathname.endsWith('/sign-in')) {
+    if (pathname.endsWith('/sign-in') || pathname.endsWith('/sign-in/admin')) {
       if (isNilOrError(authUser)) {
         authenticationDataRef.current = {
           flow: 'signin',
@@ -211,8 +211,6 @@ export default function useSteps() {
         };
         transition(currentStep, 'TRIGGER_AUTHENTICATION_FLOW')();
       }
-      // Remove all parameters from URL as they've already been captured
-      window.history.replaceState(null, '', '/');
       return;
     }
 

--- a/front/app/routes.tsx
+++ b/front/app/routes.tsx
@@ -73,6 +73,7 @@ export enum citizenRoutes {
   profile = 'profile',
   signIn = 'sign-in',
   signUp = 'sign-up',
+  signInAdmin = 'sign-in/admin',
   invite = 'invite',
   completeSignUp = 'complete-signup',
   authenticationError = 'authentication-error',
@@ -112,6 +113,7 @@ export enum citizenRoutes {
 type citizenRouteTypes =
   | '/'
   | `/${string}/`
+  | `/sign-in/admin`
   | `/sign-in`
   | `/sign-up`
   | `/invite`
@@ -154,6 +156,14 @@ export default function createRoutes() {
       children: [
         {
           index: true,
+          element: (
+            <PageLoading>
+              <HomePage />
+            </PageLoading>
+          ),
+        },
+        {
+          path: citizenRoutes.signInAdmin,
           element: (
             <PageLoading>
               <HomePage />


### PR DESCRIPTION
This was a small requirement for Southwark that I thought I'd investigate in 10% as it makes sense to me not to show admin only login methods to the general public.

# Changelog
## Changed
- TAN-2383 - Added ability to only show Azure AD logins on a separate admin login path - `/sign-in/admin`
