### PR TITLE
TAN-2444: Fix width of idea details on map

### DIFF
--- a/front/app/component-library/components/LocaleSwitcher/index.tsx
+++ b/front/app/component-library/components/LocaleSwitcher/index.tsx
@@ -11,6 +11,8 @@ import Box from '../Box';
 const Container = styled(Box)`
   width: 100%;
   display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
 `;
 
 const StyledButton = styled.button`
@@ -22,7 +24,6 @@ const StyledButton = styled.button`
   font-weight: 500;
   white-space: nowrap;
   padding: 7px 8px;
-  margin-right: 6px;
   border-radius: ${(props) => props.theme.borderRadius};
   background: ${colors.grey200};
   cursor: pointer;

--- a/front/app/containers/IdeasShow/index.tsx
+++ b/front/app/containers/IdeasShow/index.tsx
@@ -97,7 +97,7 @@ export const IdeasShow = ({
       handleContainerRef={handleContainerRef}
     >
       <Box display="flex" id="e2e-idea-show-page-content">
-        <Box flex="1 1 100%">
+        <Box flex="1 1 100%" w="100%">
           {wasImported && (
             <Box display="flex">
               <Tooltip


### PR DESCRIPTION
# Changelog

## Fixed
- Fix zoomed layout when viewing idea details on the map
- Wrap locales shown in the Locale switcher when there is no more space
