### PR TITLE
TAN-2426: move check box out of button in notifications

### DIFF
--- a/front/app/component-library/components/Accordion/index.tsx
+++ b/front/app/component-library/components/Accordion/index.tsx
@@ -12,6 +12,7 @@ import ListItem from '../ListItem';
 type AccordionProps = {
   title: ReactNode;
   children: ReactNode;
+  prefix?: ReactNode;
   isOpenByDefault?: boolean;
   className?: string;
   onChange?: (isOpen: boolean) => void;
@@ -104,6 +105,7 @@ const CollapseContainer = styled(Box)<{
 const Accordion = ({
   isOpenByDefault,
   title,
+  prefix,
   className,
   onChange,
   children,
@@ -125,18 +127,21 @@ const Accordion = ({
 
   return (
     <ListItem className={className} {...rest}>
-      <TitleButton
-        as="button"
-        padding="0"
-        aria-expanded={isExpanded}
-        aria-controls={`collapsed-section-${uuid}`}
-        id={`accordion-title-${uuid}`}
-        className={isExpanded ? 'expanded' : 'collapsed'}
-        onClick={handleChange}
-      >
-        {title}
-        <ChevronIcon name="chevron-right" />
-      </TitleButton>
+      <Box display="flex" alignItems="center">
+        {prefix}
+        <TitleButton
+          as="button"
+          padding="0"
+          aria-expanded={isExpanded}
+          aria-controls={`collapsed-section-${uuid}`}
+          id={`accordion-title-${uuid}`}
+          className={isExpanded ? 'expanded' : 'collapsed'}
+          onClick={handleChange}
+        >
+          {title}
+          <ChevronIcon name="chevron-right" />
+        </TitleButton>
+      </Box>
       <CSSTransition
         in={isExpanded}
         timeout={timeoutMilliseconds}

--- a/front/app/components/CampaignConsentForm/index.tsx
+++ b/front/app/components/CampaignConsentForm/index.tsx
@@ -5,6 +5,7 @@ import {
   Box,
   Button,
   CheckboxWithLabel,
+  Text,
 } from '@citizenlab/cl2-component-library';
 
 import {
@@ -196,12 +197,12 @@ const CampaignConsentForm = ({
           ) => (
             <Accordion
               key={i}
-              title={
+              title={<Text m="12px">{contentType}</Text>}
+              prefix={
                 <CheckboxWithPartialCheck
                   id={contentType}
                   checked={group_consented}
                   onChange={toggleGroup(contentType)}
-                  label={<Box m="14px 0">{contentType}</Box>}
                 />
               }
             >


### PR DESCRIPTION
# Changelog

## Fixed
-a11y: Resolved issues with having a checkbox inside a button on the notifications section of the profile edit page. The checkbox is now positioned first, followed by the disclosure button
