### PR TITLE
[TAN-2455] Don't report ZERO_RESULTS from Google Maps API as an error

### DIFF
--- a/back/app/services/location/service.rb
+++ b/back/app/services/location/service.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Location::Service
+  OK_STATUSES = %w[OK ZERO_RESULTS]
+
   def autocomplete(input, language)
     response = http_get("https://maps.googleapis.com/maps/api/place/autocomplete/json?input=#{CGI.escape(input)}&key=#{api_key}&language=#{language}")
     { results: response['predictions'].pluck('description') }
@@ -28,7 +30,7 @@ class Location::Service
 
   def http_get(url)
     HTTParty.get(url).tap do |response|
-      if !response.success? || response['status'] != 'OK'
+      if !response.success? || OK_STATUSES.exclude?(response['status'])
         ErrorReporter.report(GoogleMapsApiError.new, extra: { url: url, response: response })
       end
     end


### PR DESCRIPTION
# Changelog
## Fixed
- [TAN-2455] Stop reporting requests with `ZERO_RESULTS` status from the Google Maps API as errors to Sentry.