### PR TITLE
TAN-2443 - Allow event registration even when there is no current phase

### DIFF
--- a/back/app/models/permission.rb
+++ b/back/app/models/permission.rb
@@ -22,7 +22,7 @@ class Permission < ApplicationRecord
   PERMITTED_BIES = %w[everyone everyone_confirmed_email users groups admins_moderators].freeze
   ACTIONS = {
     # NOTE: Order of actions in each array is used when using :order_by_action
-    nil => %w[visiting following posting_initiative commenting_initiative reacting_initiative],
+    nil => %w[visiting following posting_initiative commenting_initiative reacting_initiative attending_event],
     'information' => %w[attending_event],
     'ideation' => %w[posting_idea commenting_idea reacting_idea attending_event],
     'proposals' => %w[posting_idea commenting_idea reacting_idea attending_event],

--- a/back/app/services/permissions/phase_permissions_service.rb
+++ b/back/app/services/permissions/phase_permissions_service.rb
@@ -44,13 +44,16 @@ module Permissions
       not_volunteering: 'not_volunteering'
     }.freeze
 
+    # Actions not to block if the project is inactive - ie no current phase
+    IGNORED_PHASE_ACTIONS = %w[attending_event].freeze
+
     def initialize(phase, user, user_requirements_service: nil)
       super(user, user_requirements_service: user_requirements_service)
       @phase ||= phase
     end
 
     def denied_reason_for_action(action, reaction_mode: nil)
-      return PHASE_DENIED_REASONS[:project_inactive] unless phase
+      return PHASE_DENIED_REASONS[:project_inactive] unless phase || IGNORED_PHASE_ACTIONS.include?(action)
 
       phase_denied_reason = case action
       when 'posting_idea'

--- a/back/app/services/permissions/project_permissions_service.rb
+++ b/back/app/services/permissions/project_permissions_service.rb
@@ -13,7 +13,7 @@ module Permissions
     end
 
     def denied_reason_for_action(action, reaction_mode: nil)
-      project_visible_disabled_reason || super
+      project_visible_disabled_reason || project_archived_disabled_reason || super
     end
 
     # Future enabled phases
@@ -104,6 +104,12 @@ module Permissions
          (project&.visible_to == 'groups' && project.groups && !user&.in_any_groups?(project.groups))
         PROJECT_DENIED_REASONS[:project_not_visible]
       end
+    end
+
+    def project_archived_disabled_reason
+      return unless project.admin_publication.archived?
+
+      PHASE_DENIED_REASONS[:project_inactive]
     end
   end
 end

--- a/back/spec/acceptance/projects_spec.rb
+++ b/back/spec/acceptance/projects_spec.rb
@@ -174,7 +174,7 @@ resource 'Projects' do
             taking_survey: { enabled: false, disabled_reason: 'project_inactive' },
             taking_poll: { enabled: false, disabled_reason: 'project_inactive' },
             voting: { enabled: false, disabled_reason: 'project_inactive' },
-            attending_event: { enabled: false, disabled_reason: 'project_inactive' },
+            attending_event: { enabled: true, disabled_reason: nil },
             volunteering: { enabled: false, disabled_reason: 'project_inactive' }
           }
         )

--- a/back/spec/services/permissions/project_permissions_service_spec.rb
+++ b/back/spec/services/permissions/project_permissions_service_spec.rb
@@ -581,13 +581,13 @@ describe Permissions::ProjectPermissionsService do
     context 'when the timeline is over' do
       let(:project) { create(:project_with_past_phases) }
 
-      it "returns 'project_inactive'" do
-        expect(service.denied_reason_for_action('attending_event')).to eq 'project_inactive'
+      it "returns nil - attending is allowed even though the phase is over" do
+        expect(service.denied_reason_for_action('attending_event')).to be_nil
       end
     end
 
     context 'when the project is archived' do
-      let(:project) { create(:single_phase_budgeting_project, admin_publication_attributes: { publication_status: 'archived' }) }
+      let(:project) { create(:project_with_current_phase, admin_publication_attributes: { publication_status: 'archived' }) }
 
       it "returns 'project_inactive'" do
         expect(service.denied_reason_for_action('attending_event')).to eq 'project_inactive'

--- a/back/spec/services/permissions/project_permissions_service_spec.rb
+++ b/back/spec/services/permissions/project_permissions_service_spec.rb
@@ -581,7 +581,7 @@ describe Permissions::ProjectPermissionsService do
     context 'when the timeline is over' do
       let(:project) { create(:project_with_past_phases) }
 
-      it "returns nil - attending is allowed even though the phase is over" do
+      it 'returns nil - attending is allowed even though the phase is over' do
         expect(service.denied_reason_for_action('attending_event')).to be_nil
       end
     end

--- a/front/app/components/EventAttendanceButton/index.tsx
+++ b/front/app/components/EventAttendanceButton/index.tsx
@@ -70,7 +70,7 @@ const EventAttendanceButton = ({ event }: EventAttendanceButtonProps) => {
   useObserveEvent('eventAttendance', handleEventAttendanceEvent);
 
   // NOTE: If the project does not have a current phase then users cannot register for events
-  if (!project || !currentPhase) return null;
+  if (!project) return null;
 
   const { enabled, disabled_reason } =
     project.data.attributes.action_descriptors.attending_event;
@@ -92,11 +92,17 @@ const EventAttendanceButton = ({ event }: EventAttendanceButtonProps) => {
     }
 
     if (disabled_reason && isFixableByAuthentication(disabled_reason)) {
-      const context = {
-        type: 'phase',
-        action: 'attending_event',
-        id: currentPhase?.id,
-      } as const;
+      // If no current phase, we still allow event registration through the default flow
+      const context = currentPhase
+        ? ({
+            type: 'phase',
+            action: 'attending_event',
+            id: currentPhase?.id,
+          } as const)
+        : ({
+            type: 'global',
+            action: 'visiting',
+          } as const);
 
       const successAction: SuccessAction = {
         name: 'attendEvent',

--- a/front/app/components/EventAttendanceButton/index.tsx
+++ b/front/app/components/EventAttendanceButton/index.tsx
@@ -91,7 +91,8 @@ const EventAttendanceButton = ({ event }: EventAttendanceButtonProps) => {
     }
 
     if (disabled_reason && isFixableByAuthentication(disabled_reason)) {
-      // If no current phase, we still allow event registration through the default flow
+      // If no current phase, we cannot use the phase context and get specific requirements for the phase
+      // BUT we still allow event registration by using the global context and triggering the default flow
       const context = currentPhase
         ? ({
             type: 'phase',

--- a/front/app/components/EventAttendanceButton/index.tsx
+++ b/front/app/components/EventAttendanceButton/index.tsx
@@ -69,7 +69,6 @@ const EventAttendanceButton = ({ event }: EventAttendanceButtonProps) => {
 
   useObserveEvent('eventAttendance', handleEventAttendanceEvent);
 
-  // NOTE: If the project does not have a current phase then users cannot register for events
   if (!project) return null;
 
   const { enabled, disabled_reason } =


### PR DESCRIPTION
# Changelog
## Fixed
- TAN-2443 - Allow event registration in a project even when there is no current phase
