### PR TITLE
[No-ticket] Do not print empty quotes for nil GeoJSON to XLSX

### DIFF
--- a/back/app/services/xlsx_export/value_visitor.rb
+++ b/back/app/services/xlsx_export/value_visitor.rb
@@ -78,7 +78,7 @@ module XlsxExport
       value = value_for(field)
       return '' if value.blank?
 
-      JSON.generate(value_for(field))
+      JSON.generate(value)
     end
 
     def visit_line(field)

--- a/back/app/services/xlsx_export/value_visitor.rb
+++ b/back/app/services/xlsx_export/value_visitor.rb
@@ -75,15 +75,18 @@ module XlsxExport
     end
 
     def visit_point(field)
+      value = value_for(field)
+      return '' if value.blank?
+
       JSON.generate(value_for(field))
     end
 
     def visit_line(field)
-      JSON.generate(value_for(field))
+      visit_point(field)
     end
 
     def visit_polygon(field)
-      JSON.generate(value_for(field))
+      visit_point(field)
     end
 
     def visit_page(_field)

--- a/back/spec/services/xlsx_export/value_visitor_spec.rb
+++ b/back/spec/services/xlsx_export/value_visitor_spec.rb
@@ -473,44 +473,77 @@ describe XlsxExport::ValueVisitor do
 
     describe '#visit_point' do
       let(:input_type) { 'point' }
-      let(:value) do
-        {
-          'type' => 'Point',
-          'coordinates' => [11.11, 22.22]
-        }
+
+      context 'when there is no value' do
+        let(:value) { nil }
+
+        it 'returns an empty string' do
+          expect(visitor.visit_point(field)).to eq ''
+        end
       end
 
-      it 'returns the GeoJSON value as a string' do
-        expect(visitor.visit_point(field)).to eq '{"type":"Point","coordinates":[11.11,22.22]}'
+      context 'when there is a value' do
+        let(:value) do
+          {
+            'type' => 'Point',
+            'coordinates' => [11.11, 22.22]
+          }
+        end
+
+        it 'returns the GeoJSON value as a string' do
+          expect(visitor.visit_point(field)).to eq '{"type":"Point","coordinates":[11.11,22.22]}'
+        end
       end
     end
 
     describe '#visit_line' do
       let(:input_type) { 'line' }
-      let(:value) do
-        {
-          'type' => 'LineString',
-          'coordinates' => [[11.11, 22.22], [11.33, 22.44]]
-        }
+
+      context 'when there is no value' do
+        let(:value) { nil }
+
+        it 'returns an empty string' do
+          expect(visitor.visit_line(field)).to eq ''
+        end
       end
 
-      it 'returns the GeoJSON value as a string' do
-        expect(visitor.visit_line(field)).to eq '{"type":"LineString","coordinates":[[11.11,22.22],[11.33,22.44]]}'
+      context 'when there is a value' do
+        let(:value) do
+          {
+            'type' => 'LineString',
+            'coordinates' => [[11.11, 22.22], [11.33, 22.44]]
+          }
+        end
+
+        it 'returns the GeoJSON value as a string' do
+          expect(visitor.visit_line(field)).to eq '{"type":"LineString","coordinates":[[11.11,22.22],[11.33,22.44]]}'
+        end
       end
     end
 
     describe '#visit_polygon' do
       let(:input_type) { 'polygon' }
-      let(:value) do
-        {
-          'type' => 'Polygon',
-          'coordinates' => [[11.11, 22.22], [11.33, 22.44], [12.33, 23.44], [11.11, 22.22]]
-        }
+
+      context 'when there is no value' do
+        let(:value) { nil }
+
+        it 'returns an empty string' do
+          expect(visitor.visit_polygon(field)).to eq ''
+        end
       end
 
-      it 'returns the GeoJSON value as a string' do
-        expect(visitor.visit_polygon(field))
-          .to eq '{"type":"Polygon","coordinates":[[11.11,22.22],[11.33,22.44],[12.33,23.44],[11.11,22.22]]}'
+      context 'when there is a value' do
+        let(:value) do
+          {
+            'type' => 'Polygon',
+            'coordinates' => [[11.11, 22.22], [11.33, 22.44], [12.33, 23.44], [11.11, 22.22]]
+          }
+        end
+
+        it 'returns the GeoJSON value as a string' do
+          expect(visitor.visit_polygon(field))
+            .to eq '{"type":"Polygon","coordinates":[[11.11,22.22],[11.33,22.44],[12.33,23.44],[11.11,22.22]]}'
+        end
       end
     end
 


### PR DESCRIPTION
# Changelog
## Fixed
[No-ticket] Do not print empty quotes to survey results Excel, when a mapping question has not been answered.
