### PR TITLE
[TAN-2174] Prevent removing individual project moderator rights from a folder moderator

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -28,10 +28,8 @@ if (branchKeys.length === 0) {
   warn("The branch name contains no Jira issue key (case-sensitive)");
 }
 
-new Set([...branchKeys, ...prKeys]).forEach((jiraKey) => {
-  message(
-    `Jira issue: <a href="https://citizenlab.atlassian.net/browse/${jiraKey}">${jiraKey}</a>`
-  );
+new Set([...branchKeys, ...prKeys]).forEach((key) => {
+  message(`Notion issue: <a href="https://notion.so/${key}">${key}</a>`);
 });
 
 // Link to trigger e2e tests

--- a/front/app/containers/Admin/projects/project/permissions/components/ModeratorList.tsx
+++ b/front/app/containers/Admin/projects/project/permissions/components/ModeratorList.tsx
@@ -2,6 +2,7 @@ import React, { memo } from 'react';
 
 import { Box } from '@citizenlab/cl2-component-library';
 
+import useProjectById from 'api/projects/useProjectById';
 import useProjectModerators from 'api/project_moderators/useProjectModerators';
 
 import { List } from 'components/admin/ResourceList';
@@ -17,6 +18,8 @@ interface Props {
 
 const ModeratorList = memo(({ projectId }: Props) => {
   const { data: moderators, isError } = useProjectModerators({ projectId });
+  const { data: project } = useProjectById(projectId);
+  const folderId = project?.data.attributes.folder_id ?? null;
 
   if (isError) {
     return <FormattedMessage {...messages.moderatorsNotFound} />;
@@ -34,6 +37,7 @@ const ModeratorList = memo(({ projectId }: Props) => {
                   isLastItem={index === moderators.data.length - 1}
                   moderator={moderator}
                   projectId={projectId}
+                  folderId={folderId}
                 />
               );
             })}

--- a/front/app/containers/Admin/projects/project/permissions/components/ModeratorListRow.test.tsx
+++ b/front/app/containers/Admin/projects/project/permissions/components/ModeratorListRow.test.tsx
@@ -65,6 +65,7 @@ describe('<ModeratorListRow />', () => {
         isLastItem={false}
         projectId={projectId}
         moderator={moderator}
+        folderId={null}
       />
     );
 
@@ -83,6 +84,27 @@ describe('<ModeratorListRow />', () => {
         isLastItem={false}
         projectId={projectId}
         moderator={moderator}
+        folderId={null}
+      />
+    );
+
+    const deleteButton = screen.getByRole('button', { name: /delete/i });
+    expect(deleteButton).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('disables the delete button if the user moderates the folder containing the project', () => {
+    mockAuthUserData.attributes.highest_role = 'project_folder_moderator';
+    mockAuthUserData.attributes.roles = [
+      projectModeratorRole,
+      { type: 'project_folder_moderator', project_folder_id: 'folderId' },
+    ];
+
+    render(
+      <ModeratorListRow
+        isLastItem={false}
+        projectId={projectId}
+        moderator={moderator}
+        folderId="folderId"
       />
     );
 

--- a/front/app/containers/Admin/projects/project/permissions/components/messages.ts
+++ b/front/app/containers/Admin/projects/project/permissions/components/messages.ts
@@ -33,4 +33,9 @@ export default defineMessages({
     id: 'app.modules.project_management.admin.components.permissionsTab',
     defaultMessage: 'Access rights',
   },
+  cannotDeleteFolderModerator: {
+    id: 'app.containers.AdminPage.groups.permissions.cannotDeleteFolderModerator',
+    defaultMessage:
+      'This user moderates the folder containing this project. To remove their moderator rights for this project, you can either revoke their folder rights or move the project to a different folder.',
+  },
 });

--- a/front/app/translations/admin/en.json
+++ b/front/app/translations/admin/en.json
@@ -2124,6 +2124,7 @@
   "app.containers.AdminPage.groups.permissions.answerChoices": "Answer choices",
   "app.containers.AdminPage.groups.permissions.answerFormat": "Answer format",
   "app.containers.AdminPage.groups.permissions.atLeastOneOptionError": "At least one choice must be provided",
+  "app.containers.AdminPage.groups.permissions.cannotDeleteFolderModerator": "This user moderates the folder containing this project. To remove their moderator rights for this project, you can either revoke their folder rights or move the project to a different folder.",
   "app.containers.AdminPage.groups.permissions.createANewQuestion": "Create a new question",
   "app.containers.AdminPage.groups.permissions.createAQuestion": "Create a question",
   "app.containers.AdminPage.groups.permissions.defaultField": "Default field",

--- a/front/app/utils/permissions/rules/projectFolderPermissions.ts
+++ b/front/app/utils/permissions/rules/projectFolderPermissions.ts
@@ -6,7 +6,7 @@ import {
   definePermissionRule,
   IRouteItem,
 } from 'utils/permissions/permissions';
-import { isAdmin, TRole, userHasRole } from 'utils/permissions/roles';
+import { isAdmin, TRole } from 'utils/permissions/roles';
 import {
   canAccessRoute,
   isModeratorRoute,
@@ -18,21 +18,31 @@ export function userModeratesFolder(
 ) {
   if (!user) return false;
 
-  return (
-    isAdmin(user) ||
-    !!user.data.attributes?.roles?.find((role: TRole) => {
-      return (
-        role.type === 'project_folder_moderator' &&
-        role.project_folder_id === projectFolderId
-      );
-    })
-  );
+  return isAdmin(user) || isProjectFolderModerator(user, projectFolderId);
 }
 
-export function isProjectFolderModerator(user: IUser | undefined) {
-  if (!user) return false;
+/**
+ * Checks if the user is a project folder moderator. If a folderId is provided,
+ * it checks if the user is a moderator of that folder specifically.
+ */
+export function isProjectFolderModerator(
+  user?: IUser,
+  folderId?: string
+): boolean {
+  const roles = user?.data.attributes?.roles;
+  if (!roles) return false;
 
-  return userHasRole(user, 'project_folder_moderator');
+  if (folderId) {
+    return roles.some(
+      (role: TRole) =>
+        role.type === 'project_folder_moderator' &&
+        role.project_folder_id === folderId
+    );
+  } else {
+    return roles.some(
+      (role: TRole) => role.type === 'project_folder_moderator'
+    );
+  }
 }
 
 // rules


### PR DESCRIPTION
I'm still thinking about enforcing it on the back-end, but it will depend on time constraints.

![image](https://github.com/user-attachments/assets/c2e1d7be-3db3-4fd1-b1ab-d258e1dd3a15)

# Changelog
## Fixed
- [TAN-2174] Prevent removing individual project moderator rights from a folder moderator 