### PR TITLE
TAN-2458: fix helmet meta values on initial load

### DIFF
--- a/front/app/components/PageMeta/index.tsx
+++ b/front/app/components/PageMeta/index.tsx
@@ -43,8 +43,8 @@ const PageMeta = React.memo<Props & WrappedComponentProps>(
         {getAlternateLinks(tenantLocales)}
         {getCanonicalLink()}
         <meta name="title" content={ideasIndexTitle} />
-        <meta name="description" content={ideasIndexDescription} />
         <meta property="og:title" content={ideasIndexTitle} />
+        <meta name="description" content={ideasIndexDescription} />
         <meta property="og:description" content={ideasIndexDescription} />
         <meta property="og:url" content={location.href} />
       </Helmet>

--- a/front/app/containers/AccessibilityStatement/index.tsx
+++ b/front/app/containers/AccessibilityStatement/index.tsx
@@ -28,6 +28,12 @@ const AccessibilityStatement = () => {
           name="description"
           content={formatMessage(messages.pageDescription)}
         />
+        <meta property="og:title" content={formatMessage(messages.headTitle)} />
+        <meta name="title" content={formatMessage(messages.headTitle)} />
+        <meta
+          property="og:description"
+          content={formatMessage(messages.pageDescription)}
+        />
       </Helmet>
       <main className="e2e-page-accessibility-statement">
         <Container>

--- a/front/app/containers/App/Meta.tsx
+++ b/front/app/containers/App/Meta.tsx
@@ -69,7 +69,7 @@ const Meta = () => {
     // All other front office pages have their own title and description meta tags.
     // Ideally, we should ensure that all backoffice pages have their own meta tags and remove them from here..
     // This is necessary because on initial load, Helmet is not overriding them in child pages.
-    const showDefaultTags =
+    const showDefaultTitleAndDescTags =
       pathname.startsWith(`/${locale}/admin/`) || pathname === `/${locale}/`;
 
     return (
@@ -80,7 +80,7 @@ const Meta = () => {
         {getCanonicalLink()}
         {getAlternateLinks(tenantLocales)}
 
-        {showDefaultTags && (
+        {showDefaultTitleAndDescTags && (
           <title>
             {`${
               authUser && authUser.data.attributes.unread_notifications
@@ -89,12 +89,16 @@ const Meta = () => {
             } ${metaTitle}`}
           </title>
         )}
-        {showDefaultTags && <meta name="title" content={metaTitle} />}
-        {showDefaultTags && <meta property="og:title" content={metaTitle} />}
-        {showDefaultTags && (
+        {showDefaultTitleAndDescTags && (
+          <meta name="title" content={metaTitle} />
+        )}
+        {showDefaultTitleAndDescTags && (
+          <meta property="og:title" content={metaTitle} />
+        )}
+        {showDefaultTitleAndDescTags && (
           <meta name="description" content={metaDescription} />
         )}
-        {showDefaultTags && (
+        {showDefaultTitleAndDescTags && (
           <meta property="og:description" content={metaDescription} />
         )}
 

--- a/front/app/containers/App/Meta.tsx
+++ b/front/app/containers/App/Meta.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { Helmet } from 'react-helmet';
+import { useLocation } from 'react-router-dom';
 
 import useAppConfiguration from 'api/app_configuration/useAppConfiguration';
 import useHomepageLayout from 'api/home_page_layout/useHomepageLayout';
@@ -26,6 +27,7 @@ const Meta = () => {
   const { data: authUser } = useAuthUser();
   const { formatMessage } = useIntl();
   const localize = useLocalize();
+  const { pathname } = useLocation();
 
   if (
     !isNilOrError(locale) &&
@@ -63,32 +65,46 @@ const Meta = () => {
     const lifecycleStage = tenant.data.attributes.settings.core.lifecycle_stage;
     const blockIndexing = !['active', 'churned'].includes(lifecycleStage);
 
+    // Show default tags only on the homepage and backoffice.
+    // All other front office pages have their own title and description meta tags.
+    // Ideally, we should ensure that all backoffice pages have their own meta tags and remove them from here..
+    // This is necessary because on initial load, Helmet is not overriding them in child pages.
+    const showDefaultTags =
+      pathname.startsWith(`/${locale}/admin/`) || pathname === `/${locale}/`;
+
     return (
       <Helmet>
         <html lang={locale} />
         {blockIndexing && <meta name="robots" content="noindex" />}
-        <title>
-          {`${
-            authUser && authUser.data.attributes.unread_notifications
-              ? `(${authUser.data.attributes.unread_notifications}) `
-              : ''
-          }
-            ${metaTitle}`}
-        </title>
         {/* https://github.com/nfl/react-helmet/issues/279 href comes first! */}
         {getCanonicalLink()}
         {getAlternateLinks(tenantLocales)}
-        <meta name="title" content={metaTitle} />
-        <meta name="description" content={metaDescription} />
+
+        {showDefaultTags && (
+          <title>
+            {`${
+              authUser && authUser.data.attributes.unread_notifications
+                ? `(${authUser.data.attributes.unread_notifications}) `
+                : ''
+            } ${metaTitle}`}
+          </title>
+        )}
+        {showDefaultTags && <meta name="title" content={metaTitle} />}
+        {showDefaultTags && <meta property="og:title" content={metaTitle} />}
+        {showDefaultTags && (
+          <meta name="description" content={metaDescription} />
+        )}
+        {showDefaultTags && (
+          <meta property="og:description" content={metaDescription} />
+        )}
+
         {googleSearchConsoleMetaAttribute && (
           <meta
             name="google-site-verification"
             content={googleSearchConsoleMetaAttribute}
           />
         )}
-        <meta property="og:title" content={metaTitle} />
         <meta property="og:type" content="website" />
-        <meta property="og:description" content={metaDescription} />
         <meta property="og:image" content={headerBg} />
         <meta
           property="og:image:width"

--- a/front/app/containers/CookiePolicy/index.tsx
+++ b/front/app/containers/CookiePolicy/index.tsx
@@ -48,6 +48,22 @@ const CookiePolicy = () => {
           name="description"
           content={formatMessage(messages.cookiePolicyDescription)}
         />
+        <meta
+          name="title"
+          content={formatMessage(messages.headCookiePolicyTitle)}
+        />
+        <meta
+          property="og:title"
+          content={formatMessage(messages.headCookiePolicyTitle)}
+        />
+        <meta
+          name="description"
+          content={formatMessage(messages.cookiePolicyDescription)}
+        />
+        <meta
+          property="og:description"
+          content={formatMessage(messages.cookiePolicyDescription)}
+        />
       </Helmet>
       <main className="e2e-page-cookie-policy" data-testid="cookiePolicy">
         <Container>

--- a/front/app/containers/IdeasShow/components/IdeaMeta.tsx
+++ b/front/app/containers/IdeasShow/components/IdeaMeta.tsx
@@ -130,7 +130,7 @@ const IdeaMeta = ({ ideaId }: Props) => {
         {getAlternateLinks(appConfigurationLocales)}
         <meta name="title" content={localizedTitle} />
         <meta name="description" content={ideaDescription} />
-
+        <meta property="og:description" content={ideaDescription} />
         <meta property="og:type" content="article" />
         <meta property="og:title" content={localizedTitle} />
         <meta property="ideaOgDescription" content={ideaDescription} />

--- a/front/app/containers/SiteMap/SiteMapMeta.tsx
+++ b/front/app/containers/SiteMap/SiteMapMeta.tsx
@@ -11,8 +11,17 @@ const SiteMapMeta = () => {
   return (
     <Helmet>
       <title>{formatMessage(messages.headSiteMapTitle)}</title>
+      <meta name="title" content={formatMessage(messages.headSiteMapTitle)} />
+      <meta
+        property="og:title"
+        content={formatMessage(messages.headSiteMapTitle)}
+      />
       <meta
         name="description"
+        content={formatMessage(messages.siteMapDescription)}
+      />
+      <meta
+        property="og:description"
         content={formatMessage(messages.siteMapDescription)}
       />
     </Helmet>


### PR DESCRIPTION
# Changelog

## Fixed
- Fixed a bug where the Helmet head values assigned in the main app file were not being overridden in the child pages on the first page load.
