### PR TITLE
[TAN-1748] Add number question survey results view

### DIFF
--- a/back/app/services/survey_results_generator_service.rb
+++ b/back/app/services/survey_results_generator_service.rb
@@ -31,7 +31,7 @@ class SurveyResultsGeneratorService < FieldVisitorService
       .select("custom_field_values->'#{field.key}' as value")
       .where("custom_field_values->'#{field.key}' IS NOT NULL")
       .map do |response|
-        { response: response.value }
+        { answer: response.value }
       end
     response_count = responses.size
 

--- a/back/app/services/survey_results_generator_service.rb
+++ b/back/app/services/survey_results_generator_service.rb
@@ -27,12 +27,7 @@ class SurveyResultsGeneratorService < FieldVisitorService
   end
 
   def visit_number(field)
-    responses = inputs
-      .select("custom_field_values->'#{field.key}' as value")
-      .where("custom_field_values->'#{field.key}' IS NOT NULL")
-      .map do |response|
-        { answer: response.value }
-      end
+    responses = base_responses(field)
     response_count = responses.size
 
     core_field_attributes(field, response_count).merge({
@@ -114,6 +109,15 @@ class SurveyResultsGeneratorService < FieldVisitorService
     }
   end
 
+  def base_responses(field)
+    inputs
+      .select("custom_field_values->'#{field.key}' as value")
+      .where("custom_field_values->'#{field.key}' IS NOT NULL")
+      .map do |response|
+        { answer: response.value }
+      end
+  end
+
   def visit_select_base(field)
     query = inputs
     if group_field_id
@@ -167,12 +171,7 @@ class SurveyResultsGeneratorService < FieldVisitorService
   end
 
   def responses_to_geographic_input_type(field)
-    answers = inputs
-      .select("custom_field_values->'#{field.key}' as value")
-      .where("custom_field_values->'#{field.key}' IS NOT NULL")
-      .map do |answer|
-        { answer: answer.value }
-      end
+    answers = base_responses(field)
     response_count = answers.size
 
     core_field_attributes(field, response_count).merge({

--- a/back/app/services/survey_results_generator_service.rb
+++ b/back/app/services/survey_results_generator_service.rb
@@ -171,11 +171,11 @@ class SurveyResultsGeneratorService < FieldVisitorService
   end
 
   def responses_to_geographic_input_type(field)
-    answers = base_responses(field)
-    response_count = answers.size
+    responses = base_responses(field)
+    response_count = responses.size
 
     core_field_attributes(field, response_count).merge({
-      mapConfigId: field&.map_config&.id, "#{field.input_type}Responses": answers
+      mapConfigId: field&.map_config&.id, "#{field.input_type}Responses": responses
     })
   end
 

--- a/back/app/services/survey_results_generator_service.rb
+++ b/back/app/services/survey_results_generator_service.rb
@@ -167,16 +167,16 @@ class SurveyResultsGeneratorService < FieldVisitorService
   end
 
   def responses_to_geographic_input_type(field)
-    responses = inputs
+    answers = inputs
       .select("custom_field_values->'#{field.key}' as value")
       .where("custom_field_values->'#{field.key}' IS NOT NULL")
-      .map do |response|
-        { response: response.value }
+      .map do |answer|
+        { answer: answer.value }
       end
-    response_count = responses.size
+    response_count = answers.size
 
     core_field_attributes(field, response_count).merge({
-      mapConfigId: field&.map_config&.id, "#{field.input_type}Responses": responses
+      mapConfigId: field&.map_config&.id, "#{field.input_type}Responses": answers
     })
   end
 

--- a/back/app/services/survey_results_generator_service.rb
+++ b/back/app/services/survey_results_generator_service.rb
@@ -26,6 +26,20 @@ class SurveyResultsGeneratorService < FieldVisitorService
     end
   end
 
+  def visit_number(field)
+    responses = inputs
+      .select("custom_field_values->'#{field.key}' as value")
+      .where("custom_field_values->'#{field.key}' IS NOT NULL")
+      .map do |response|
+        { response: response.value }
+      end
+    response_count = responses.size
+
+    core_field_attributes(field, response_count).merge({
+      numberResponses: responses
+    })
+  end
+
   def visit_select(field)
     visit_select_base(field)
   end

--- a/back/spec/services/survey_results_generator_service_spec.rb
+++ b/back/spec/services/survey_results_generator_service_spec.rb
@@ -1049,8 +1049,8 @@ RSpec.describe SurveyResultsGeneratorService do
           customFieldId: point_field.id,
           mapConfigId: map_config_for_point.id,
           pointResponses: a_collection_containing_exactly(
-            { response: { 'coordinates' => [42.42, 24.24], 'type' => 'Point' } },
-            { response: { 'coordinates' => [11.22, 33.44], 'type' => 'Point' } }
+            { answer: { 'coordinates' => [42.42, 24.24], 'type' => 'Point' } },
+            { answer: { 'coordinates' => [11.22, 33.44], 'type' => 'Point' } }
           )
         }
       end
@@ -1072,8 +1072,8 @@ RSpec.describe SurveyResultsGeneratorService do
           customFieldId: line_field.id,
           mapConfigId: map_config_for_line.id,
           lineResponses: a_collection_containing_exactly(
-            { response: { 'coordinates' => [[1.1, 2.2], [3.3, 4.4]], 'type' => 'LineString' } },
-            { response: { 'coordinates' => [[1.2, 2.3], [3.4, 4.5]], 'type' => 'LineString' } }
+            { answer: { 'coordinates' => [[1.1, 2.2], [3.3, 4.4]], 'type' => 'LineString' } },
+            { answer: { 'coordinates' => [[1.2, 2.3], [3.4, 4.5]], 'type' => 'LineString' } }
           )
         }
       end
@@ -1095,8 +1095,8 @@ RSpec.describe SurveyResultsGeneratorService do
           customFieldId: polygon_field.id,
           mapConfigId: map_config_for_polygon.id,
           polygonResponses: a_collection_containing_exactly(
-            { response: { 'coordinates' => [[[1.1, 2.2], [3.3, 4.4], [5.5, 6.6], [1.1, 2.2]]], 'type' => 'Polygon' } },
-            { response: { 'coordinates' => [[[1.2, 2.3], [3.4, 4.5], [5.6, 6.7], [1.2, 2.3]]], 'type' => 'Polygon' } }
+            { answer: { 'coordinates' => [[[1.1, 2.2], [3.3, 4.4], [5.5, 6.6], [1.1, 2.2]]], 'type' => 'Polygon' } },
+            { answer: { 'coordinates' => [[[1.2, 2.3], [3.4, 4.5], [5.6, 6.7], [1.2, 2.3]]], 'type' => 'Polygon' } }
           )
         }
       end

--- a/back/spec/services/survey_results_generator_service_spec.rb
+++ b/back/spec/services/survey_results_generator_service_spec.rb
@@ -203,6 +203,17 @@ RSpec.describe SurveyResultsGeneratorService do
 
   let_it_be(:map_config_for_polygon) { create(:map_config, mappable: polygon_field) }
 
+  let_it_be(:number_field) do
+    create(
+      :custom_field_number,
+      resource: form,
+      title_multiloc: {
+        'en' => 'How many cats would you like?'
+      },
+      description_multiloc: {}
+    )
+  end
+
   let_it_be(:user_custom_field) do
     create(:custom_field_gender, :with_options)
   end
@@ -228,7 +239,8 @@ RSpec.describe SurveyResultsGeneratorService do
         point_field.key => { type: 'Point', coordinates: [42.42, 24.24] },
         line_field.key => { type: 'LineString', coordinates: [[1.1, 2.2], [3.3, 4.4]] },
         polygon_field.key => { type: 'Polygon', coordinates: [[[1.1, 2.2], [3.3, 4.4], [5.5, 6.6], [1.1, 2.2]]] },
-        linear_scale_field.key => 3
+        linear_scale_field.key => 3,
+        number_field.key => 42
       },
       idea_files: [idea_file1, idea_file2],
       author: female_user
@@ -328,7 +340,7 @@ RSpec.describe SurveyResultsGeneratorService do
       end
 
       it 'returns the correct fields and structure' do
-        expect(generated_results[:results].count).to eq 12
+        expect(generated_results[:results].count).to eq 13
         expect(generated_results[:results].pluck(:customFieldId)).not_to include page_field.id
         expect(generated_results[:results].pluck(:customFieldId)).not_to include disabled_multiselect_field.id
       end
@@ -1091,6 +1103,27 @@ RSpec.describe SurveyResultsGeneratorService do
 
       it 'returns the results for a polygon field' do
         expect(generated_results[:results][11]).to match expected_result_polygon
+      end
+    end
+
+    describe 'number fields' do
+      let(:expected_result_number) do
+        {
+          inputType: 'number',
+          question: { 'en' => 'How many cats would you like?' },
+          required: false,
+          grouped: false,
+          questionResponseCount: 1,
+          totalResponseCount: 22,
+          customFieldId: number_field.id,
+          numberResponses: a_collection_containing_exactly(
+            { answer: 42 }
+          )
+        }
+      end
+
+      it 'returns the results for a number field' do
+        expect(generated_results[:results][12]).to match expected_result_number
       end
     end
   end

--- a/front/app/api/survey_results/types.ts
+++ b/front/app/api/survey_results/types.ts
@@ -42,6 +42,7 @@ type BaseResult = {
   totalResponseCount: number;
   totalPickCount: number;
   questionResponseCount: number;
+  numberResponses?: { answer: number }[];
 
   // Defined for text questions,
   // and for select questions with "other" option

--- a/front/app/api/survey_results/types.ts
+++ b/front/app/api/survey_results/types.ts
@@ -58,9 +58,9 @@ export type ResultUngrouped = BaseResult & {
 
   // Defined map questions
   mapConfigId?: string;
-  pointResponses?: { response: GeoJSON.Point }[];
-  lineResponses?: { response: GeoJSON.LineString }[];
-  polygonResponses?: { response: GeoJSON.Polygon }[];
+  pointResponses?: { answer: GeoJSON.Point }[];
+  lineResponses?: { answer: GeoJSON.LineString }[];
+  polygonResponses?: { answer: GeoJSON.Polygon }[];
 
   // Defined for file upload questions
   files?: { name: string; url: string }[];

--- a/front/app/containers/Admin/projects/project/nativeSurvey/FormResults/FormResultsQuestion/MappingQuestions/LineLocationQuestion/index.tsx
+++ b/front/app/containers/Admin/projects/project/nativeSurvey/FormResults/FormResultsQuestion/MappingQuestions/LineLocationQuestion/index.tsx
@@ -16,7 +16,7 @@ import messages from '../../../messages';
 import ExportGeoJSONButton from '../components/ExportGeoJSONButton';
 
 type Props = {
-  lineResponses: { response: GeoJSON.LineString }[];
+  lineResponses: { answer: GeoJSON.LineString }[];
   mapConfigId?: string;
   customFieldId: string;
 };
@@ -53,7 +53,7 @@ const LineLocationQuestion = ({
     (isLoadingCustomMapConfig && mapConfigId) || isLoadingProjectMapConfig;
 
   const lines = useMemo(() => {
-    return lineResponses?.map(({ response }) => response);
+    return lineResponses?.map(({ answer }) => answer);
   }, [lineResponses]);
 
   return (

--- a/front/app/containers/Admin/projects/project/nativeSurvey/FormResults/FormResultsQuestion/MappingQuestions/PointLocationQuestion/index.tsx
+++ b/front/app/containers/Admin/projects/project/nativeSurvey/FormResults/FormResultsQuestion/MappingQuestions/PointLocationQuestion/index.tsx
@@ -18,7 +18,7 @@ import ExportGeoJSONButton from '../components/ExportGeoJSONButton';
 import HeatmapTooltipContent from './HeatmapTooltipContent';
 
 type Props = {
-  pointResponses: { response: GeoJSON.Point }[];
+  pointResponses: { answer: GeoJSON.Point }[];
   mapConfigId?: string;
   customFieldId: string;
 };
@@ -56,7 +56,7 @@ const PointLocationQuestion = ({
     (isLoadingCustomMapConfig && mapConfigId) || isLoadingProjectMapConfig;
 
   const points = useMemo(() => {
-    return pointResponses?.map(({ response }) => response);
+    return pointResponses?.map(({ answer }) => answer);
   }, [pointResponses]);
 
   return (

--- a/front/app/containers/Admin/projects/project/nativeSurvey/FormResults/FormResultsQuestion/MappingQuestions/PolygonLocationQuestion/index.tsx
+++ b/front/app/containers/Admin/projects/project/nativeSurvey/FormResults/FormResultsQuestion/MappingQuestions/PolygonLocationQuestion/index.tsx
@@ -16,7 +16,7 @@ import messages from '../../../messages';
 import ExportGeoJSONButton from '../components/ExportGeoJSONButton';
 
 type Props = {
-  polygonResponses: { response: GeoJSON.Polygon }[];
+  polygonResponses: { answer: GeoJSON.Polygon }[];
   mapConfigId?: string;
   customFieldId: string;
 };
@@ -53,7 +53,7 @@ const PolygonLocationQuestion = ({
     (isLoadingCustomMapConfig && mapConfigId) || isLoadingProjectMapConfig;
 
   const polygons = useMemo(() => {
-    return polygonResponses?.map(({ response }) => response);
+    return polygonResponses?.map(({ answer }) => answer);
   }, [polygonResponses]);
 
   return (

--- a/front/app/containers/Admin/projects/project/nativeSurvey/FormResults/FormResultsQuestion/NumberQuestion/NumberResponses.tsx
+++ b/front/app/containers/Admin/projects/project/nativeSurvey/FormResults/FormResultsQuestion/NumberQuestion/NumberResponses.tsx
@@ -6,6 +6,10 @@ import styled from 'styled-components';
 
 import Divider from 'components/admin/Divider';
 
+import { useIntl } from 'utils/cl-intl';
+
+import messages from '../../messages';
+
 const Item = styled.div<{ start: number }>`
   position: absolute;
   top: 0;
@@ -21,6 +25,7 @@ type NumberResponsesProps = {
 };
 
 const NumberResponses = ({ numberResponses }: NumberResponsesProps) => {
+  const { formatMessage } = useIntl();
   const parentRef = React.useRef(null);
 
   // The virtualizer
@@ -31,10 +36,12 @@ const NumberResponses = ({ numberResponses }: NumberResponsesProps) => {
   });
 
   return (
-    <Box bg={colors.background} height="460px">
+    <Box bg={colors.background} height="460px" width="100%" maxWidth="524px">
       <Box borderBottom={`1px solid ${colors.divider}`} p="24px" height="60px">
         <Text fontWeight="bold" m="0px">
+          {formatMessage(messages.allResponses)} {'('}
           {numberResponses.length}
+          {')'}
         </Text>
       </Box>
 

--- a/front/app/containers/Admin/projects/project/nativeSurvey/FormResults/FormResultsQuestion/NumberQuestion/NumberResponses.tsx
+++ b/front/app/containers/Admin/projects/project/nativeSurvey/FormResults/FormResultsQuestion/NumberQuestion/NumberResponses.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+
+import { Box, colors, Text } from '@citizenlab/cl2-component-library';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import styled from 'styled-components';
+
+import Divider from 'components/admin/Divider';
+
+const Item = styled.div<{ start: number }>`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  transform: translateY(${(props) => props.start}px);
+`;
+
+type NumberResponsesProps = {
+  numberResponses: {
+    answer: number;
+  }[];
+};
+
+const NumberResponses = ({ numberResponses }: NumberResponsesProps) => {
+  const parentRef = React.useRef(null);
+
+  // The virtualizer
+  const { measureElement, getTotalSize, getVirtualItems } = useVirtualizer({
+    count: numberResponses.length,
+    getScrollElement: () => parentRef?.current,
+    estimateSize: () => 100,
+  });
+
+  return (
+    <Box bg={colors.background} height="460px">
+      <Box borderBottom={`1px solid ${colors.divider}`} p="24px" height="60px">
+        <Text fontWeight="bold" m="0px">
+          {numberResponses.length}
+        </Text>
+      </Box>
+
+      <Box ref={parentRef} overflow="auto" pt="12px" height="400px">
+        <Box height={`${getTotalSize()}px`} width="100%" position="relative">
+          {getVirtualItems().map((virtualItem) => (
+            <Item
+              ref={measureElement}
+              data-index={virtualItem.index}
+              key={virtualItem.key}
+              start={virtualItem.start}
+            >
+              <Text m="0px" px="24px">
+                {numberResponses[virtualItem.index].answer}
+              </Text>
+              <Divider />
+            </Item>
+          ))}
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default NumberResponses;

--- a/front/app/containers/Admin/projects/project/nativeSurvey/FormResults/FormResultsQuestion/NumberQuestion/index.tsx
+++ b/front/app/containers/Admin/projects/project/nativeSurvey/FormResults/FormResultsQuestion/NumberQuestion/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import { Box } from '@citizenlab/cl2-component-library';
+
+import NumberResponses from './NumberResponses';
+
+interface Props {
+  numberResponses: { answer: number }[];
+}
+
+const NumberQuestion = ({ numberResponses }: Props) => {
+  return (
+    <Box display="flex" gap="24px" mt="20px">
+      <Box flex="1">
+        <NumberResponses numberResponses={numberResponses} />
+      </Box>
+    </Box>
+  );
+};
+
+export default NumberQuestion;

--- a/front/app/containers/Admin/projects/project/nativeSurvey/FormResults/FormResultsQuestion/index.tsx
+++ b/front/app/containers/Admin/projects/project/nativeSurvey/FormResults/FormResultsQuestion/index.tsx
@@ -16,6 +16,7 @@ import InputType from './InputType';
 import LineLocationQuestion from './MappingQuestions/LineLocationQuestion';
 import PointLocationQuestion from './MappingQuestions/PointLocationQuestion';
 import PolygonLocationQuestion from './MappingQuestions/PolygonLocationQuestion';
+import NumberQuestion from './NumberQuestion';
 import TextQuestion from './TextQuestion';
 
 type FormResultsQuestionProps = {
@@ -39,6 +40,7 @@ const FormResultsQuestion = ({
     pointResponses,
     lineResponses,
     polygonResponses,
+    numberResponses,
     inputType,
     question,
     required,
@@ -50,6 +52,7 @@ const FormResultsQuestion = ({
 
   const isMultipleChoiceAndHasAnswers = !!answers;
   const hasTextResponses = textResponses && textResponses.length > 0;
+  const hasNumberResponses = numberResponses && numberResponses.length > 0;
   const isPointAndHasAnswers =
     inputType === 'point' && pointResponses && pointResponses?.length > 0;
   const isLineAndHasAnswers =
@@ -78,6 +81,9 @@ const FormResultsQuestion = ({
             customFieldId={customFieldId}
             hasOtherResponses={isMultipleChoiceAndHasAnswers}
           />
+        )}
+        {hasNumberResponses && (
+          <NumberQuestion numberResponses={numberResponses} />
         )}
         {isPointAndHasAnswers && (
           <PointLocationQuestion

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/SurveyQuestionResultWidget/Question/MapQuestions/LineLocationQuestion.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/SurveyQuestionResultWidget/Question/MapQuestions/LineLocationQuestion.tsx
@@ -12,7 +12,7 @@ import LineMap from 'components/admin/Graphs/LineMap';
 import { useIntl } from 'utils/cl-intl';
 
 interface Props {
-  lineResponses: { response: GeoJSON.LineString }[];
+  lineResponses: { answer: GeoJSON.LineString }[];
   mapConfigId?: string;
   customFieldId: string;
   projectId: string;
@@ -27,7 +27,7 @@ const LineLocationQuestion = ({
   const { formatMessage } = useIntl();
 
   const lines = useMemo(() => {
-    return lineResponses.map(({ response }) => response);
+    return lineResponses.map(({ answer }) => answer);
   }, [lineResponses]);
 
   const { data: customMapConfig, isLoading: isLoadingCustomMapConfig } =

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/SurveyQuestionResultWidget/Question/MapQuestions/PointLocationQuestion.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/SurveyQuestionResultWidget/Question/MapQuestions/PointLocationQuestion.tsx
@@ -12,7 +12,7 @@ import PointMap from 'components/admin/Graphs/PointMap';
 import { useIntl } from 'utils/cl-intl';
 
 interface Props {
-  pointResponses: { response: GeoJSON.Point }[];
+  pointResponses: { answer: GeoJSON.Point }[];
   mapConfigId?: string;
   customFieldId: string;
   projectId: string;
@@ -29,7 +29,7 @@ const PointLocationQuestion = ({
   const { formatMessage } = useIntl();
 
   const points = useMemo(() => {
-    return pointResponses.map(({ response }) => response);
+    return pointResponses.map(({ answer }) => answer);
   }, [pointResponses]);
 
   const { data: customMapConfig, isLoading: isLoadingCustomMapConfig } =

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/SurveyQuestionResultWidget/Question/MapQuestions/PolygonLocationQuestion.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/SurveyQuestionResultWidget/Question/MapQuestions/PolygonLocationQuestion.tsx
@@ -12,7 +12,7 @@ import PolygonMap from 'components/admin/Graphs/PolygonMap';
 import { useIntl } from 'utils/cl-intl';
 
 interface Props {
-  polygonResponses: { response: GeoJSON.Polygon }[];
+  polygonResponses: { answer: GeoJSON.Polygon }[];
   mapConfigId?: string;
   customFieldId: string;
   projectId: string;
@@ -27,7 +27,7 @@ const PolygonLocationQuestion = ({
   const { formatMessage } = useIntl();
 
   const polygons = useMemo(() => {
-    return polygonResponses.map(({ response }) => response);
+    return polygonResponses.map(({ answer }) => answer);
   }, [polygonResponses]);
 
   const { data: customMapConfig, isLoading: isLoadingCustomMapConfig } =


### PR DESCRIPTION
- Also renames `:response` (in survey results & report builder widgets responses) to `:answer` for all 3 mapping question types, for consistency with other question types.

# Changelog
## Added
- [TAN-1748] Added number question to back-office survey results view
