### PR TITLE
Remove unnecessary test and make sure skip button works correctly

### DIFF
--- a/front/app/api/custom_fields_json_form_schema/utils.ts
+++ b/front/app/api/custom_fields_json_form_schema/utils.ts
@@ -6,6 +6,12 @@ export const hasRequiredFields = (
   schemaResponse: SchemaResponse,
   locale: SupportedLocale
 ) => {
-  return !!schemaResponse.data.attributes?.json_schema_multiloc[locale]
-    ?.required;
+  const requiredFields =
+    schemaResponse.data.attributes.json_schema_multiloc[locale]?.required;
+
+  if (!requiredFields) {
+    return false;
+  }
+
+  return requiredFields.length > 0;
 };

--- a/front/app/containers/Authentication/steps/CustomFields/index.tsx
+++ b/front/app/containers/Authentication/steps/CustomFields/index.tsx
@@ -75,8 +75,6 @@ const CustomFields = ({
     }
   };
 
-  console.log({ userCustomFieldsSchema });
-
   const formHasRequiredFields = hasRequiredFields(
     userCustomFieldsSchema,
     locale

--- a/front/app/containers/Authentication/steps/CustomFields/index.tsx
+++ b/front/app/containers/Authentication/steps/CustomFields/index.tsx
@@ -75,6 +75,8 @@ const CustomFields = ({
     }
   };
 
+  console.log({ userCustomFieldsSchema });
+
   const formHasRequiredFields = hasRequiredFields(
     userCustomFieldsSchema,
     locale

--- a/front/cypress/e2e/auth/sign_up_custom_fields.cy.ts
+++ b/front/cypress/e2e/auth/sign_up_custom_fields.cy.ts
@@ -1,26 +1,6 @@
 import { randomString, randomEmail } from '../../support/commands';
 
 describe('Sign up - custom fields step', () => {
-  describe('No custom fields', () => {
-    before(() => {
-      const firstName = randomString();
-      const lastName = randomString();
-      const email = randomEmail();
-      const password = randomString();
-      cy.apiSignup(firstName, lastName, email, password);
-      cy.setLoginCookie(email, password);
-    });
-
-    after(() => {
-      cy.logout();
-    });
-
-    it('does not show it when no custom fields are enabled', () => {
-      cy.goToLandingPage();
-      cy.get('#e2e-sign-up-in-modal').should('not.exist');
-    });
-  });
-
   describe('Optional custom field', () => {
     const randomFieldName = randomString();
     let customFieldId: string;


### PR DESCRIPTION
# Changelog
## Fixed
- Skip button being visible when 'required' array in json forms schema is an empty instead of being `undefined` for some reason
## Technical
- Remove unnecessary custom fields test