### PR TITLE
[TAN-2434] Fix failing project updates

### DIFF
--- a/back/app/controllers/web_api/v1/projects_controller.rb
+++ b/back/app/controllers/web_api/v1/projects_controller.rb
@@ -200,8 +200,8 @@ class WebApi::V1::ProjectsController < ApplicationController
 
   def check_publication_inconsistencies!
     # This code is meant to be temporary to find the cause of the disappearing admin publication bugs
-    if Project.all.any? { |project| !project.valid? }
-      raise 'Project change would lead to inconsistencies!'
+    if Project.all.any? { |project| project.admin_publication.blank? }
+      raise 'Project has no admin_publication!'
     end
   end
 end

--- a/back/app/controllers/web_api/v1/projects_controller.rb
+++ b/back/app/controllers/web_api/v1/projects_controller.rb
@@ -211,7 +211,7 @@ class WebApi::V1::ProjectsController < ApplicationController
       next if assignee_error_only && moved_folder
 
       # Errors will appear in the Sentry error 'Additional Data'
-      ErrorReporter.report_msg('Project change would lead to inconsistencies!', extra: errors || {})
+      ErrorReporter.report_msg("Project (id: #{project.id}) change would lead to inconsistencies!", extra: errors || {})
     end
   end
 end

--- a/back/app/controllers/web_api/v1/projects_controller.rb
+++ b/back/app/controllers/web_api/v1/projects_controller.rb
@@ -178,9 +178,13 @@ class WebApi::V1::ProjectsController < ApplicationController
   end
 
   def save_project
-    set_folder
-    authorize @project
-    @project.save
+    ActiveRecord::Base.transaction do
+      set_folder
+      authorize @project
+      saved = @project.save
+      check_publication_inconsistencies! if saved
+      saved
+    end
   end
 
   def set_folder
@@ -192,5 +196,12 @@ class WebApi::V1::ProjectsController < ApplicationController
   def set_project
     @project = Project.find(params[:id])
     authorize @project
+  end
+
+  def check_publication_inconsistencies!
+    # This code is meant to be temporary to find the cause of the disappearing admin publication bugs
+    if Project.all.any? { |project| !project.valid? }
+      raise 'Project change would lead to inconsistencies!'
+    end
   end
 end

--- a/back/app/controllers/web_api/v1/projects_controller.rb
+++ b/back/app/controllers/web_api/v1/projects_controller.rb
@@ -207,8 +207,8 @@ class WebApi::V1::ProjectsController < ApplicationController
 
       # Skip a known case where we expect project to be invalid at this point
       moved_folder = project.admin_publication&.parent_id_was == project.folder_id
-      assignee_error = errors&.first == [:default_assignee_id, [{ :error => :assignee_can_not_moderate_project }]]
-      next if assignee_error && moved_folder
+      assignee_error_only = errors == { :default_assignee_id => [{ :error => :assignee_can_not_moderate_project }] }
+      next if assignee_error_only && moved_folder
 
       # Errors will appear in the Sentry error 'Additional Data'
       ErrorReporter.report_msg('Project change would lead to inconsistencies!', extra: errors || {})

--- a/back/app/controllers/web_api/v1/projects_controller.rb
+++ b/back/app/controllers/web_api/v1/projects_controller.rb
@@ -210,8 +210,8 @@ class WebApi::V1::ProjectsController < ApplicationController
       assignee_error_only = errors == { :default_assignee_id => [{ :error => :assignee_can_not_moderate_project }] }
       next if assignee_error_only && moved_folder
 
-      # Errors will appear in the Sentry error 'Additional Data'
-      ErrorReporter.report_msg("Project (id: #{project.id}) change would lead to inconsistencies!", extra: errors || {})
+      # Validation errors will appear in the Sentry error 'Additional Data'
+      ErrorReporter.report_msg("Project change would lead to inconsistencies! (id: #{project.id})", extra: errors || {})
     end
   end
 end

--- a/back/app/controllers/web_api/v1/projects_controller.rb
+++ b/back/app/controllers/web_api/v1/projects_controller.rb
@@ -201,7 +201,7 @@ class WebApi::V1::ProjectsController < ApplicationController
   def check_publication_inconsistencies!
     # This code is meant to be temporary to find the cause of the disappearing admin publication bugs
     if Project.all.any? { |project| project.admin_publication.blank? }
-      raise 'Project has no admin_publication!'
+      raise "Project with id #{project.id} has no admin_publication!"
     end
   end
 end

--- a/back/app/controllers/web_api/v1/projects_controller.rb
+++ b/back/app/controllers/web_api/v1/projects_controller.rb
@@ -178,13 +178,9 @@ class WebApi::V1::ProjectsController < ApplicationController
   end
 
   def save_project
-    ActiveRecord::Base.transaction do
-      set_folder
-      authorize @project
-      saved = @project.save
-      check_publication_inconsistencies! if saved
-      saved
-    end
+    set_folder
+    authorize @project
+    @project.save
   end
 
   def set_folder
@@ -196,12 +192,5 @@ class WebApi::V1::ProjectsController < ApplicationController
   def set_project
     @project = Project.find(params[:id])
     authorize @project
-  end
-
-  def check_publication_inconsistencies!
-    # This code is meant to be temporary to find the cause of the disappearing admin publication bugs
-    if Project.all.any? { |project| !project.valid? }
-      raise 'Project change would lead to inconsistencies!'
-    end
   end
 end

--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -263,7 +263,6 @@ class Project < ApplicationRecord
     old_folder_moderators.each do |moderator|
       next unless moderator.moderatable_project_ids.include?(id)
 
-      project.update(default_assignee_id: nil) if default_assignee_id == moderator.id
       moderator.delete_role('project_moderator', project_id: id)
       moderator.save
     end

--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -263,6 +263,7 @@ class Project < ApplicationRecord
     old_folder_moderators.each do |moderator|
       next unless moderator.moderatable_project_ids.include?(id)
 
+      project.update(default_assignee_id: nil) if default_assignee_id == moderator.id
       moderator.delete_role('project_moderator', project_id: id)
       moderator.save
     end

--- a/back/engines/commercial/idea_assignment/spec/acceptance/ideas_spec.rb
+++ b/back/engines/commercial/idea_assignment/spec/acceptance/ideas_spec.rb
@@ -176,7 +176,7 @@ resource 'Ideas' do
         expect(json_response.dig(:data, :relationships, :assignee, :data, :id)).to eq assignee_id
       end
 
-      example 'Changing the project keeps the assignee valid', document: false, if: defined?(ProjectManagement::Engine) do
+      example 'Changing the project keeps the assignee valid', document: false do
         @idea.update! assignee: create(:project_moderator, projects: [@project])
         do_request project_id: create(:project).id
 
@@ -186,7 +186,7 @@ resource 'Ideas' do
       end
     end
 
-    context 'when moderator', if: defined?(ProjectManagement::Engine) do
+    context 'when moderator' do
       before { header_token_for create(:project_moderator, projects: [@project]) }
 
       let(:assignee_id) { create(:admin).id }

--- a/back/engines/commercial/idea_assignment/spec/acceptance/moderators_spec.rb
+++ b/back/engines/commercial/idea_assignment/spec/acceptance/moderators_spec.rb
@@ -48,7 +48,7 @@ resource 'Moderators' do
       end
     end
 
-    delete 'web_api/v1/project_folders/:project_folder_id/moderators/:user_id', if: defined?(ProjectFolders::Engine) do
+    delete 'web_api/v1/project_folders/:project_folder_id/moderators/:user_id' do
       ValidationErrorHelper.new.error_fields self, User
 
       let(:project1) { create(:project) }

--- a/back/engines/commercial/idea_assignment/spec/acceptance/moderators_spec.rb
+++ b/back/engines/commercial/idea_assignment/spec/acceptance/moderators_spec.rb
@@ -11,7 +11,7 @@ resource 'Moderators' do
   context 'when admin' do
     before { admin_header_token }
 
-    delete 'web_api/v1/projects/:project_id/moderators/:user_id', if: defined?(ProjectManagement::Engine) do
+    delete 'web_api/v1/projects/:project_id/moderators/:user_id' do
       ValidationErrorHelper.new.error_fields self, User
 
       let(:project1) { create(:project) }

--- a/back/engines/commercial/idea_assignment/spec/acceptance/projects_spec.rb
+++ b/back/engines/commercial/idea_assignment/spec/acceptance/projects_spec.rb
@@ -26,7 +26,7 @@ resource 'Projects' do
       let(:project2) { create(:project, folder: folder, default_assignee: assignee) }
       let(:id) { project1.id }
 
-      example 'Assignees of moved project remain valid', document: false, skip: 'It will be fixed in TAN-2434' do
+      example 'Assignees of moved project remain valid', document: false do
         idea1 = create(:idea, project: project1, assignee: assignee)
         idea2 = create(:idea, project: project2, assignee: assignee)
 

--- a/back/engines/commercial/idea_assignment/spec/acceptance/projects_spec.rb
+++ b/back/engines/commercial/idea_assignment/spec/acceptance/projects_spec.rb
@@ -26,7 +26,7 @@ resource 'Projects' do
       let(:project2) { create(:project, folder: folder, default_assignee: assignee) }
       let(:id) { project1.id }
 
-      example 'Assignees of moved project remain valid', document: false, if: defined?(ProjectFolders::Engine) do
+      example 'Assignees of moved project remain valid', document: false, skip: 'It will be fixed in TAN-2434' do
         idea1 = create(:idea, project: project1, assignee: assignee)
         idea2 = create(:idea, project: project2, assignee: assignee)
 

--- a/back/engines/commercial/idea_assignment/spec/acceptance/users_spec.rb
+++ b/back/engines/commercial/idea_assignment/spec/acceptance/users_spec.rb
@@ -46,7 +46,7 @@ resource 'Users' do
         end
       end
 
-      describe 'when removing project moderator rights', if: defined?(ProjectManagement::Engine) do
+      describe 'when removing project moderator rights' do
         let(:project) { create(:project) }
         let(:assignee) { create(:project_moderator, projects: [project]) }
 
@@ -92,7 +92,7 @@ resource 'Users' do
         end
       end
 
-      describe 'when admin becomes project moderator', if: defined?(ProjectManagement::Engine) do
+      describe 'when admin becomes project moderator' do
         let(:project1) { create(:project) }
         let(:project2) { create(:project) }
         let(:assignee) { create(:admin) }
@@ -156,7 +156,7 @@ resource 'Users' do
         end
       end
 
-      describe 'when folder moderator becomes project moderator', if: defined?(ProjectManagement::Engine) do
+      describe 'when folder moderator becomes project moderator' do
         let(:folder) { create(:project_folder) }
         let(:project1) { create(:project, folder: folder) }
         let(:project2) { create(:project, folder: folder) }

--- a/back/engines/commercial/idea_assignment/spec/acceptance/users_spec.rb
+++ b/back/engines/commercial/idea_assignment/spec/acceptance/users_spec.rb
@@ -69,7 +69,7 @@ resource 'Users' do
         end
       end
 
-      describe 'when removing folder moderator rights', if: defined?(ProjectFolders::Engine) do
+      describe 'when removing folder moderator rights' do
         let(:folder) { create(:project_folder) }
         let(:assignee) { create(:project_folder_moderator, project_folders: [folder]) }
 
@@ -124,7 +124,7 @@ resource 'Users' do
         end
       end
 
-      describe 'when admin becomes folder moderator', if: defined?(ProjectFolders::Engine) do
+      describe 'when admin becomes folder moderator' do
         let(:folder1) { create(:project_folder) }
         let(:folder2) { create(:project_folder) }
         let(:assignee) { create(:admin) }
@@ -156,7 +156,7 @@ resource 'Users' do
         end
       end
 
-      describe 'when folder moderator becomes project moderator', if: defined?(ProjectManagement::Engine) && defined?(ProjectFolders::Engine) do
+      describe 'when folder moderator becomes project moderator', if: defined?(ProjectManagement::Engine) do
         let(:folder) { create(:project_folder) }
         let(:project1) { create(:project, folder: folder) }
         let(:project2) { create(:project, folder: folder) }

--- a/back/engines/commercial/idea_assignment/spec/services/idea_assignment/idea_assignment_service_spec.rb
+++ b/back/engines/commercial/idea_assignment/spec/services/idea_assignment/idea_assignment_service_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe IdeaAssignment::IdeaAssignmentService do
   let(:service) { described_class.new }
 
-  describe 'clean_idea_assignees_for_user!', if: defined?(ProjectManagement::Engine) && defined?(ProjectFolders::Engine) do
+  describe 'clean_idea_assignees_for_user!', if: defined?(ProjectManagement::Engine) do
     it 'clears the assignee where they no longer moderate the ideas' do
       assignee = create(:admin)
       folder1 = create(:project_folder)
@@ -36,7 +36,7 @@ describe IdeaAssignment::IdeaAssignmentService do
     end
   end
 
-  describe 'clean_assignees_for_project!', if: defined?(ProjectManagement::Engine) && defined?(ProjectFolders::Engine) do
+  describe 'clean_assignees_for_project!', if: defined?(ProjectManagement::Engine) do
     it 'clears the assignee where they no longer moderate the ideas' do
       folder = create(:project_folder)
       project = create(:project, folder: folder)

--- a/back/engines/commercial/idea_assignment/spec/services/idea_assignment/idea_assignment_service_spec.rb
+++ b/back/engines/commercial/idea_assignment/spec/services/idea_assignment/idea_assignment_service_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe IdeaAssignment::IdeaAssignmentService do
   let(:service) { described_class.new }
 
-  describe 'clean_idea_assignees_for_user!', if: defined?(ProjectManagement::Engine) do
+  describe 'clean_idea_assignees_for_user!' do
     it 'clears the assignee where they no longer moderate the ideas' do
       assignee = create(:admin)
       folder1 = create(:project_folder)
@@ -36,7 +36,7 @@ describe IdeaAssignment::IdeaAssignmentService do
     end
   end
 
-  describe 'clean_assignees_for_project!', if: defined?(ProjectManagement::Engine) do
+  describe 'clean_assignees_for_project!' do
     it 'clears the assignee where they no longer moderate the ideas' do
       folder = create(:project_folder)
       project = create(:project, folder: folder)


### PR DESCRIPTION
- Send a sentry error rather than raising an exception when the `check_publication_inconsistencies!` method detects an invalid project.
- Ignore case where we expect a project to be invalid in `check_publication_inconsistencies!` (project moved out of folder + folder moderator == `project.default_assignee`)

# Changelog
## Fixed
- [TAN-2434] Resolved an issue preventing project updates when moving a project out of a folder if the folder moderator was also the project default assignee. This could make it impossible to move a project out of folder, and in such cases would show an infinite spinner until the page was refreshed.
