### PR TITLE
[TAN-2478] Do not nest user data in GeoJSON export

### DIFF
--- a/back/app/services/geojson_export/geojson_generator.rb
+++ b/back/app/services/geojson_export/geojson_generator.rb
@@ -38,7 +38,7 @@ module GeojsonExport
       }
 
       properties.merge!(generate_answers_to_questions(input))
-      properties[sanitized_translation_for('user_data')] = generate_user_data(input)
+      properties.merge!(generate_user_data(input))
 
       properties
     end
@@ -54,20 +54,23 @@ module GeojsonExport
     def generate_user_data(input)
       return nil if input&.author.nil?
 
-      basic_author_data(input).merge(user_custom_field_values_data(input))
+      user_data_key = sanitized_translation_for('user_data')
+      basic_author_data(input, user_data_key).merge(user_custom_field_values_data(input, user_data_key))
     end
 
-    def basic_author_data(input)
+    def basic_author_data(input, user_data_key)
       {
-        sanitized_translation_for('author_id') => input&.author&.id,
-        sanitized_translation_for('author_email') => input&.author&.email,
-        sanitized_translation_for('author_fullname') => input&.author_name
+        "#{user_data_key}__#{sanitized_translation_for('author_id')}" => input&.author&.id,
+        "#{user_data_key}__#{sanitized_translation_for('author_email')}" => input&.author&.email,
+        "#{user_data_key}__#{sanitized_translation_for('author_fullname')}" => input&.author_name
       }
     end
 
-    def user_custom_field_values_data(input)
+    def user_custom_field_values_data(input, user_data_key)
       registration_fields.each_with_object({}) do |field, accu|
-        accu[sanitize_key(@multiloc_service.t(field.title_multiloc))] = if field.code == 'domicile'
+        key = "#{user_data_key}__#{sanitize_key(@multiloc_service.t(field.title_multiloc))}"
+
+        accu[key] = if field.code == 'domicile'
           DomicileFieldForExport.new(field, :author).value_from(input)
         else
           CustomFieldForExport.new(field, :author).value_from(input)

--- a/back/app/services/geojson_export/geojson_generator.rb
+++ b/back/app/services/geojson_export/geojson_generator.rb
@@ -52,7 +52,7 @@ module GeojsonExport
     end
 
     def generate_user_data(input)
-      return nil if input&.author.nil?
+      return {} if input&.author.nil?
 
       user_data_key = sanitized_translation_for('user_data')
       basic_author_data(input, user_data_key).merge(user_custom_field_values_data(input, user_data_key))

--- a/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/as_geojson_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/as_geojson_spec.rb
@@ -237,13 +237,11 @@ resource 'Idea Custom Fields' do
                 type: 'Polygon',
                 coordinates: [[[1, 2], [3, 4], [5, 6], [1, 2]]]
               },
-              gebruikersgegevens: { # To be translated - will need to update this key when nl-NL translation is added
-                auteur_id: idea1.author_id,
-                e_mail_van_auteur: idea1.author.email,
-                auteur_naam: idea1.author_name,
-                geslacht: 'Vrouw',
-                woonplaats: 'Bruxelles'
-              }
+              gebruikersgegevens__auteur_id: idea1.author_id,
+              gebruikersgegevens__e_mail_van_auteur: idea1.author.email,
+              gebruikersgegevens__auteur_naam: idea1.author_name,
+              gebruikersgegevens__geslacht: 'Vrouw',
+              gebruikersgegevens__woonplaats: 'Bruxelles'
             }
           },
           {
@@ -262,8 +260,7 @@ resource 'Idea Custom Fields' do
               upload_de_foto: nil,
               markeer_de_locatie_op_de_kaart: { type: 'Point', coordinates: [3.3, 4.4] },
               teken_de_route_op_de_kaart: nil,
-              teken_het_gebied_op_de_kaart: nil,
-              gebruikersgegevens: nil # To be translated - will need to update this key when nl-NL translation is added
+              teken_het_gebied_op_de_kaart: nil
             }
           }
         ])

--- a/back/spec/services/geojson_export/geojson_generator_spec.rb
+++ b/back/spec/services/geojson_export/geojson_generator_spec.rb
@@ -72,24 +72,20 @@ describe GeojsonExport::GeojsonGenerator do
           'published_at' => idea1.published_at.strftime('%m/%d/%Y %H:%M:%S').to_s,
           'point_field_for_focus_of_export' => { 'type' => 'Point', 'coordinates' => [1.1, 2.2] },
           'field_for_text_question' => 'Text answer 1',
-          'user_data' => {
-            'author_id' => idea1.author.id,
-            'author_email' => idea1.author.email,
-            'author_name' => idea1.author_name,
-            'field_for_registration_question' => 'Registration q answer'
-          }
+          'user_data__author_id' => idea1.author.id,
+          'user_data__author_email' => idea1.author.email,
+          'user_data__author_name' => idea1.author_name,
+          'user_data__field_for_registration_question' => 'Registration q answer'
         },
         {
           'id' => idea2.id,
           'published_at' => idea2.published_at.strftime('%m/%d/%Y %H:%M:%S').to_s,
           'point_field_for_focus_of_export' => { 'type' => 'Point', 'coordinates' => [3.3, 4.4] },
           'field_for_text_question' => 'Text answer 2',
-          'user_data' => {
-            'author_id' => idea2.author.id,
-            'author_email' => idea2.author.email,
-            'author_name' => idea2.author_name,
-            'field_for_registration_question' => nil
-          }
+          'user_data__author_id' => idea2.author.id,
+          'user_data__author_email' => idea2.author.email,
+          'user_data__author_name' => idea2.author_name,
+          'user_data__field_for_registration_question' => nil
         }
       ])
     end


### PR DESCRIPTION
## Screenshots
<details>
  <summary> Screenshots [Click me]</summary>

## Using ArcGIS Online Map Viewer
### Inspecting data of a polygon
<img width="616" alt="Screenshot 2024-08-07 at 16 19 05" src="https://github.com/user-attachments/assets/27c5a4eb-760d-4325-9d19-5d95ecb19031">

### Styling by data attribute value(s)
<img width="1084" alt="Screenshot 2024-08-07 at 16 19 41" src="https://github.com/user-attachments/assets/f288d0e6-6e50-4704-b14f-ad8a0d79875b">

### Filtering by data attribute value(s)
<img width="1084" alt="Screenshot 2024-08-07 at 16 20 06" src="https://github.com/user-attachments/assets/5e98bfa1-9259-4cb2-9c0a-a1511cab8ac0">

</details>


# Changelog
## Changed
- [TAN-2478] Do not nest user data in GeoJSON export. This makes it easier to filter by the user data that's included in exported GeoJSON, when responses to a mapping question are exported to GeoJSON (video guide coming soon).
