### PR TITLE
TAN-2484 - Allow user update for verified users with no email

### DIFF
--- a/back/app/models/concerns/user_confirmation.rb
+++ b/back/app/models/concerns/user_confirmation.rb
@@ -18,7 +18,8 @@ module UserConfirmation
 
   # true if the user has not yet confirmed their email address and the platform requires it
   def confirmation_required?
-    user_confirmation_enabled? && confirmation_required
+    user_confirmation_enabled? && confirmation_required &&
+      !(sso? && verified && email.nil?) # for verified SSO users without email, confirmation is not yet required
   end
 
   def confirm

--- a/back/engines/commercial/id_clave_unica/spec/requests/clave_unica_verification_spec.rb
+++ b/back/engines/commercial/id_clave_unica/spec/requests/clave_unica_verification_spec.rb
@@ -226,13 +226,13 @@ describe 'clave_unica verification' do
 
         user = User.order(created_at: :asc).last
         expect_to_create_verified_and_identified_user(user)
-        expect(user.email).to be(nil)
+        expect(user.email).to be_nil
         expect(user.active?).to be(true)
         expect(ActionMailer::Base.deliveries.count).to eq(0)
 
         headers = { 'Authorization' => authorization_header(user) }
 
-        patch "/web_api/v1/users/#{user.id}", params: { user: { email: 'newcoolemail@example.org' }}, headers: headers
+        patch "/web_api/v1/users/#{user.id}", params: { user: { email: 'newcoolemail@example.org' } }, headers: headers
         expect(response).to have_http_status(:ok)
         expect(user.reload).to have_attributes({ email: 'newcoolemail@example.org' })
         expect(user.confirmation_required?).to be(true)
@@ -278,7 +278,7 @@ describe 'clave_unica verification' do
 
         user = User.order(created_at: :asc).last
         expect_to_create_verified_and_identified_user(user)
-        expect(user.email).to be(nil)
+        expect(user.email).to be_nil
         expect(user.confirmation_required?).to be(false)
         expect(user.active?).to be(true)
       end

--- a/back/engines/commercial/id_clave_unica/spec/requests/clave_unica_verification_spec.rb
+++ b/back/engines/commercial/id_clave_unica/spec/requests/clave_unica_verification_spec.rb
@@ -220,44 +220,31 @@ describe 'clave_unica verification' do
         configuration.save!
       end
 
-      it 'creates user that can confirm her email' do
+      it 'creates user that can add & confirm her email' do
         get '/auth/clave_unica'
         follow_redirect!
 
         user = User.order(created_at: :asc).last
         expect_to_create_verified_and_identified_user(user)
-        expect(user.confirmation_required?).to be(true)
+        expect(user.email).to be(nil)
+        expect(user.active?).to be(true)
+        expect(ActionMailer::Base.deliveries.count).to eq(0)
 
         headers = { 'Authorization' => authorization_header(user) }
 
-        expect(ActionMailer::Base.deliveries.count).to eq(0)
-
-        post '/web_api/v1/user/resend_code', params: { new_email: 'newcoolemail@example.org' }, headers: headers
+        patch "/web_api/v1/users/#{user.id}", params: { user: { email: 'newcoolemail@example.org' }}, headers: headers
         expect(response).to have_http_status(:ok)
-        expect(user.reload).to have_attributes({ new_email: 'newcoolemail@example.org' })
+        expect(user.reload).to have_attributes({ email: 'newcoolemail@example.org' })
         expect(user.confirmation_required?).to be(true)
+        expect(user.active?).to be(false)
         expect(ActionMailer::Base.deliveries.count).to eq(1)
 
         post '/web_api/v1/user/confirm', params: { confirmation: { code: user.email_confirmation_code } }, headers: headers
-
         expect(response).to have_http_status(:ok)
         expect(user.reload.confirmation_required?).to be(false)
+        expect(user.active?).to be(true)
         expect(user).to have_attributes({ email: 'newcoolemail@example.org' })
         expect(user.new_email).to be_nil
-      end
-
-      it 'creates user that cannot update her email' do
-        get '/auth/clave_unica'
-        follow_redirect!
-
-        user = User.order(created_at: :asc).last
-
-        headers = { 'Authorization' => authorization_header(user) }
-        patch "/web_api/v1/users/#{user.id}", params: { user: { email: 'newcoolemail@example.org' } }, headers: headers
-
-        expect(response).not_to have_http_status(:ok)
-        expect(user.reload).to have_attributes({ email: nil })
-        expect(user.confirmation_required?).to be(true)
       end
 
       it 'creates user that can enter email, change it and then confirm it' do
@@ -282,7 +269,7 @@ describe 'clave_unica verification' do
         expect(user.new_email).to be_nil
       end
 
-      it 'prevents bypassing email confirmation by logging in when signup is partially completed' do
+      it 'allows users to be active without adding an email & confirmation' do
         get '/auth/clave_unica'
         follow_redirect!
 
@@ -290,11 +277,10 @@ describe 'clave_unica verification' do
         follow_redirect!
 
         user = User.order(created_at: :asc).last
-
-        headers = { 'Authorization' => authorization_header(user) }
-        post '/web_api/v1/user/resend_code', params: { new_email: 'newcoolemail@example.org' }, headers: headers
-
-        expect(user.confirmation_required?).to be(true)
+        expect_to_create_verified_and_identified_user(user)
+        expect(user.email).to be(nil)
+        expect(user.confirmation_required?).to be(false)
+        expect(user.active?).to be(true)
       end
     end
 

--- a/back/engines/commercial/id_criipto/spec/requests/criipto_verification_spec.rb
+++ b/back/engines/commercial/id_criipto/spec/requests/criipto_verification_spec.rb
@@ -283,31 +283,34 @@ context 'criipto verification' do
         configuration.save!
       end
 
-      it 'creates user that can confirm her email' do
+      it 'creates user that can add & confirm her email' do
         get '/auth/criipto'
         follow_redirect!
 
         user = User.order(created_at: :asc).last
         expect_to_create_verified_and_identified_user(user)
+        expect(user.email).to be(nil)
+        expect(user.active?).to be(true)
+        expect(ActionMailer::Base.deliveries.count).to eq(0)
 
         headers = { 'Authorization' => authorization_header(user) }
 
-        expect(ActionMailer::Base.deliveries.count).to eq(0)
-
-        post '/web_api/v1/user/resend_code', params: { new_email: 'newcoolemail@example.org' }, headers: headers
+        patch "/web_api/v1/users/#{user.id}", params: { user: { email: 'newcoolemail@example.org' }}, headers: headers
         expect(response).to have_http_status(:ok)
-        expect(user.reload).to have_attributes({ new_email: 'newcoolemail@example.org' })
+        expect(user.reload).to have_attributes({ email: 'newcoolemail@example.org' })
         expect(user.confirmation_required?).to be(true)
+        expect(user.active?).to be(false)
         expect(ActionMailer::Base.deliveries.count).to eq(1)
 
         post '/web_api/v1/user/confirm', params: { confirmation: { code: user.email_confirmation_code } }, headers: headers
         expect(response).to have_http_status(:ok)
         expect(user.reload.confirmation_required?).to be(false)
+        expect(user.active?).to be(true)
         expect(user).to have_attributes({ email: 'newcoolemail@example.org' })
         expect(user.new_email).to be_nil
       end
 
-      it 'prevents bypassing email confirmation by logging in when signup is partially completed' do
+      it 'allows users to be active without adding an email & confirmation' do
         get '/auth/criipto'
         follow_redirect!
 
@@ -315,12 +318,10 @@ context 'criipto verification' do
         follow_redirect!
 
         user = User.order(created_at: :asc).last
-
-        token = AuthToken::AuthToken.new(payload: user.to_token_payload).token
-        headers = { 'Authorization' => "Bearer #{token}" }
-        post '/web_api/v1/user/resend_code', params: { new_email: 'newcoolemail@example.org' }, headers: headers
-
-        expect(user.confirmation_required?).to be(true)
+        expect_to_create_verified_and_identified_user(user)
+        expect(user.email).to be(nil)
+        expect(user.confirmation_required?).to be(false)
+        expect(user.active?).to be(true)
       end
     end
 

--- a/back/engines/commercial/id_criipto/spec/requests/criipto_verification_spec.rb
+++ b/back/engines/commercial/id_criipto/spec/requests/criipto_verification_spec.rb
@@ -289,13 +289,13 @@ context 'criipto verification' do
 
         user = User.order(created_at: :asc).last
         expect_to_create_verified_and_identified_user(user)
-        expect(user.email).to be(nil)
+        expect(user.email).to be_nil
         expect(user.active?).to be(true)
         expect(ActionMailer::Base.deliveries.count).to eq(0)
 
         headers = { 'Authorization' => authorization_header(user) }
 
-        patch "/web_api/v1/users/#{user.id}", params: { user: { email: 'newcoolemail@example.org' }}, headers: headers
+        patch "/web_api/v1/users/#{user.id}", params: { user: { email: 'newcoolemail@example.org' } }, headers: headers
         expect(response).to have_http_status(:ok)
         expect(user.reload).to have_attributes({ email: 'newcoolemail@example.org' })
         expect(user.confirmation_required?).to be(true)
@@ -319,7 +319,7 @@ context 'criipto verification' do
 
         user = User.order(created_at: :asc).last
         expect_to_create_verified_and_identified_user(user)
-        expect(user.email).to be(nil)
+        expect(user.email).to be_nil
         expect(user.confirmation_required?).to be(false)
         expect(user.active?).to be(true)
       end

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -1049,6 +1049,16 @@ RSpec.describe User do
       it 'returns true if the user has not yet confirmed their account' do
         expect(user.confirmation_required?).to be true
       end
+
+      it 'returns false when the user is a verified SSO user with no email' do
+        u = build(:user, identities: [build(:franceconnect_identity)], email: nil, verified: true)
+        expect(u.confirmation_required?).to be false
+      end
+
+      it 'returns true when the user is an unverified SSO user with no email' do
+        u = build(:user, identities: [build(:facebook_identity)], email: nil)
+        expect(u.confirmation_required?).to be true
+      end
     end
 
     describe '#confirmation_required' do


### PR DESCRIPTION
Currently very specific to verified SSO users with no email - we can decide later whether to open this up further. In theory any user without an email should not require confirmation as there's no way to confirm them, nor can anyone else try to login and hijack their account.
