### PR TITLE
[TAN-2363] Improve multiselect instructions in PDF survey forms

### DIFF
--- a/back/config/locales/en.yml
+++ b/back/config/locales/en.yml
@@ -296,6 +296,12 @@ en:
       optional: 'optional'
       permission: 'Permission'
       choose_as_many: 'Choose as many as you like'
+      choose_exactly:
+        one: 'Choose exactly %{count} option'
+        other: 'Choose exactly %{count} options'
+      choose_between: 'Choose between %{min} and %{max} options'
+      choose_at_least: 'Choose at least %{count} options'
+      choose_at_most: 'Choose at most %{count} options'
       this_answer: 'This answer will only be shared with moderators, and not to the public.'
       page: 'Page'
       date_published: 'Date Published (dd-mm-yyyy)'

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_pdf_form_exporter.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_pdf_form_exporter.rb
@@ -398,7 +398,7 @@ module BulkImportIdeas::Exporters
         min = custom_field.minimum_select_count
         max = custom_field.maximum_select_count
         min = nil if min == 0
-        max = nil if max >= custom_field.options.length
+        max = nil if max&.>= custom_field.options.length
 
         I18n.with_locale(locale) do
           if custom_field.select_count_enabled && (min || max)

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_pdf_form_exporter.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_pdf_form_exporter.rb
@@ -6,6 +6,9 @@ module BulkImportIdeas::Exporters
   class IdeaPdfFormExporter < BaseFormExporter
     attr_reader :participation_context, :form_fields, :previous_cursor
 
+    delegate :generate_multiselect_instructions, to: :class
+    private :generate_multiselect_instructions
+
     FORBIDDEN_HTML_TAGS_REGEX = %r{</?(div|span|ul|ol|li|img|a){1}[^>]*/?>}
     JUMBLING_FIELD_TYPES = %w[multiline_text html_multiloc text text_multiloc]
 
@@ -281,25 +284,21 @@ module BulkImportIdeas::Exporters
     end
 
     def write_instructions_and_disclaimers(pdf, custom_field)
-      show_multiselect_instructions = custom_field.input_type == 'multiselect'
-      show_visibility_disclaimer = @phase.pmethod.supports_idea_form? && custom_field.answer_visible_to == 'admins'
+      multiselect_instructions = generate_multiselect_instructions(custom_field, @locale)
+      visibility_disclaimer = generate_visibility_disclaimer(custom_field)
 
-      if show_multiselect_instructions || show_visibility_disclaimer
+      if multiselect_instructions || visibility_disclaimer
         pdf.move_down 2.mm
+        pdf.text("*#{multiselect_instructions}", size: 10) if multiselect_instructions
+        pdf.text("*#{visibility_disclaimer}", size: 10) if visibility_disclaimer
+      end
+    end
 
-        if show_multiselect_instructions
-          pdf.text(
-            "*#{I18n.with_locale(@locale) { I18n.t('form_builder.pdf_export.choose_as_many') }}",
-            size: 10
-          )
-        end
+    def generate_visibility_disclaimer(custom_field)
+      return unless @phase.pmethod.supports_idea_form? && custom_field.answer_visible_to == 'admins'
 
-        if show_visibility_disclaimer
-          pdf.text(
-            "*#{I18n.with_locale(@locale) { I18n.t('form_builder.pdf_export.this_answer') }}",
-            size: 10
-          )
-        end
+      I18n.with_locale(@locale) do
+        I18n.t('form_builder.pdf_export.this_answer')
       end
     end
 
@@ -390,6 +389,33 @@ module BulkImportIdeas::Exporters
         page: page,
         position: position.to_i
       }
+    end
+
+    class << self
+      def generate_multiselect_instructions(custom_field, locale)
+        return unless custom_field.input_type == 'multiselect'
+
+        min = custom_field.minimum_select_count
+        max = custom_field.maximum_select_count
+        min = nil if min == 0
+        max = nil if max >= custom_field.options.length
+
+        I18n.with_locale(locale) do
+          if custom_field.select_count_enabled && (min || max)
+            if min && max && min == max
+              I18n.t('form_builder.pdf_export.choose_exactly', count: min)
+            elsif min && max
+              I18n.t('form_builder.pdf_export.choose_between', min: min, max: max)
+            elsif min
+              I18n.t('form_builder.pdf_export.choose_at_least', count: min)
+            else
+              I18n.t('form_builder.pdf_export.choose_at_most', count: max)
+            end
+          else
+            I18n.t('form_builder.pdf_export.choose_as_many')
+          end
+        end
+      end
     end
   end
 end

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/parsers/pdf/idea_plain_text_parser_service.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/parsers/pdf/idea_plain_text_parser_service.rb
@@ -31,12 +31,9 @@ module BulkImportIdeas::Parsers::Pdf
     def parse_page(page)
       page = page.squish # Remove new lines and extra whitespace
 
-      # Remove static content from the whole page - ' eg *This answer may be shared...'
-      choose_as_many_copy = I18n.with_locale(@locale) { I18n.t('form_builder.pdf_export.choose_as_many') }
+      # Remove static content from the whole page - 'eg *This answer may be shared...'
       this_answer_copy = I18n.with_locale(@locale) { I18n.t('form_builder.pdf_export.this_answer') }
-      %W[*#{choose_as_many_copy} *#{this_answer_copy}].each do |control_content|
-        page = page.gsub(control_content, '')
-      end
+      page = page.gsub("*#{this_answer_copy}", '')
 
       # Extract each field by splitting the page by each field title
       optional_copy = I18n.with_locale(@locale) { I18n.t('form_builder.pdf_export.optional') }
@@ -58,6 +55,10 @@ module BulkImportIdeas::Parsers::Pdf
     end
 
     def process_field_value(field, value)
+      # Remove static instructions
+      instructions_copy = ::BulkImportIdeas::Exporters::IdeaPdfFormExporter.generate_multiselect_instructions(field, @locale)
+      value = value.gsub(instructions_copy, '')
+
       # Strip out unneeded generic text
       field_value = value.strip
 

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/parsers/pdf/idea_plain_text_parser_service.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/parsers/pdf/idea_plain_text_parser_service.rb
@@ -56,8 +56,8 @@ module BulkImportIdeas::Parsers::Pdf
 
     def process_field_value(field, value)
       # Remove static instructions
-      instructions_copy = ::BulkImportIdeas::Exporters::IdeaPdfFormExporter.generate_multiselect_instructions(field, @locale)
-      value = value.gsub(instructions_copy, '')
+      instructions_copy = BulkImportIdeas::Exporters::IdeaPdfFormExporter.generate_multiselect_instructions(field, @locale)
+      value = value.gsub("*#{instructions_copy}", '') if instructions_copy
 
       # Strip out unneeded generic text
       field_value = value.strip


### PR DESCRIPTION
Adapt the instructions according to the number of options that can be selected.


# Changelog
## Fixed
- [TAN-2363] Improve multiselect instructions in PDF survey forms
