### PR TITLE
Collapse map legend by default for map input questions and results maps

### DIFF
--- a/front/app/components/EsriMap/config.ts
+++ b/front/app/components/EsriMap/config.ts
@@ -45,11 +45,10 @@ export const configureMapView = (
   }
 
   // Add map legend if set
+  const showLegendExpanded = initialData?.showLegendExpanded;
+
   if (initialData?.showLegend) {
-    addMapLegend(
-      mapView,
-      initialData?.showLegendExpanded ? false : isMobileOrSmaller
-    );
+    addMapLegend(mapView, isMobileOrSmaller, showLegendExpanded);
   }
 
   // Show layer visibility controls if set
@@ -85,7 +84,11 @@ export const setMapCenter = (
 
 // addMapLegend
 // Description: Adds a legend to the map
-export const addMapLegend = (mapView: MapView, isMobileOrSmaller: boolean) => {
+export const addMapLegend = (
+  mapView: MapView,
+  isMobileOrSmaller: boolean,
+  showLegendExpanded: boolean | undefined
+) => {
   const legend = new Expand({
     content: new Legend({
       view: mapView,
@@ -93,7 +96,10 @@ export const addMapLegend = (mapView: MapView, isMobileOrSmaller: boolean) => {
       style: { type: 'classic', layout: 'stack' },
     }),
     view: mapView,
-    expanded: isMobileOrSmaller ? false : true,
+    expanded:
+      showLegendExpanded === undefined
+        ? !isMobileOrSmaller // By default, show the legend expanded only on desktop
+        : showLegendExpanded,
     mode: 'floating',
   });
 

--- a/front/app/components/EsriMap/config.ts
+++ b/front/app/components/EsriMap/config.ts
@@ -45,10 +45,8 @@ export const configureMapView = (
   }
 
   // Add map legend if set
-  const showLegendExpanded = initialData?.showLegendExpanded;
-
   if (initialData?.showLegend) {
-    addMapLegend(mapView, isMobileOrSmaller, showLegendExpanded);
+    addMapLegend(mapView, isMobileOrSmaller, initialData?.showLegendExpanded);
   }
 
   // Show layer visibility controls if set

--- a/front/app/components/Form/Components/Controls/MapInput/Desktop/DesktopTabletView.tsx
+++ b/front/app/components/Form/Components/Controls/MapInput/Desktop/DesktopTabletView.tsx
@@ -179,6 +179,7 @@ const DesktopView = ({
               zoom: Number(mapConfig?.data.attributes.zoom_level),
               center: getInitialMapCenter(inputType, mapConfig, data),
               showLegend: isWebMap || layerCount > 0,
+              showLegendExpanded: false,
               showLayerVisibilityControl: isWebMap || layerCount > 0,
               onInit: onMapInit,
             }}

--- a/front/app/components/Form/Components/Controls/MapInput/Mobile/FullscreenMapInput.tsx
+++ b/front/app/components/Form/Components/Controls/MapInput/Mobile/FullscreenMapInput.tsx
@@ -203,7 +203,7 @@ const FullscreenMapInput = memo<Props>(
                   center: getInitialMapCenter(inputType, mapConfig, data),
                   showLegend: isWebMap || layerCount > 0,
                   showLayerVisibilityControl: isWebMap || layerCount > 0,
-                  showLegendExpanded: true,
+                  showLegendExpanded: false,
                   showZoomControls: true,
                   onInit: onMapInit,
                 }}

--- a/front/app/components/admin/Graphs/LineMap/index.tsx
+++ b/front/app/components/admin/Graphs/LineMap/index.tsx
@@ -82,6 +82,7 @@ const LineMap = ({ lines, mapConfig, layerTitle, layerId, onInit }: Props) => {
         onInit?.(mapView);
       },
       showLegend: true,
+      showLegendExpanded: false,
       showLayerVisibilityControl: true,
       zoom: Number(mapConfig?.data?.attributes.zoom_level),
       center: mapConfig?.data?.attributes.center_geojson,

--- a/front/app/components/admin/Graphs/PointMap/index.tsx
+++ b/front/app/components/admin/Graphs/PointMap/index.tsx
@@ -81,6 +81,7 @@ const PointMap = ({
         onInit?.(mapView);
       },
       showLegend: true,
+      showLegendExpanded: false,
       showLayerVisibilityControl: true,
       zoom: Number(mapConfig?.data?.attributes.zoom_level),
       center: mapConfig?.data?.attributes.center_geojson,

--- a/front/app/components/admin/Graphs/PolygonMap/index.tsx
+++ b/front/app/components/admin/Graphs/PolygonMap/index.tsx
@@ -91,6 +91,7 @@ const PolygonMap = ({
         onInit?.(mapView);
       },
       showLegend: true,
+      showLegendExpanded: false,
       showLayerVisibilityControl: true,
       zoom: Number(mapConfig?.data?.attributes.zoom_level),
       center: mapConfig?.data?.attributes.center_geojson,

--- a/front/cypress/e2e/form_builder/elements/point_field.cy.ts
+++ b/front/cypress/e2e/form_builder/elements/point_field.cy.ts
@@ -126,6 +126,10 @@ describe('Form builder point field', () => {
     // Check results in back office
     cy.visit(`/admin/projects/${projectId}/phases/${phaseId}/native-survey`);
     cy.contains(questionTitle).should('exist');
+    // Open the legend and check the correct data is shown
+    cy.get(
+      '.esri-ui-bottom-right > .esri-component > .esri-expand__container'
+    ).click();
     cy.contains('Lava Flow Hazard Zones').should('exist'); // Check loading the correct map config
     cy.contains('Responses').should('exist');
   });


### PR DESCRIPTION
# Changelog
## Changed
- Collapse the map legend by default for map input questions & survey results maps so it doesn't block the instruction animation ([before](https://github.com/user-attachments/assets/6500fa45-57f3-4b3f-a6aa-4831f9035d7d)/[after](https://github.com/user-attachments/assets/414e2551-e75a-4907-a4f6-f4c96874716d)).

