### PR TITLE
TAN-2516 - Fix complete onboarding step

### DIFF
--- a/front/app/containers/Authentication/useSteps/stepConfig/sharedSteps.ts
+++ b/front/app/containers/Authentication/useSteps/stepConfig/sharedSteps.ts
@@ -135,7 +135,8 @@ export const sharedSteps = (
         const isLightFlow = permitted_by === 'everyone_confirmed_email';
 
         const signedIn =
-          disabled_reason && disabled_reason !== 'user_not_signed_in';
+          !disabled_reason || // To allow onboarding for already signed in users
+          (disabled_reason && disabled_reason !== 'user_not_signed_in');
 
         if (isLightFlow) {
           if (!signedIn) {


### PR DESCRIPTION
The correct flow wasn't triggering because of the logic that detects if signed in by looking for a  disabled reason, but if all you need is onboarding, then nothing is disabled - it's always optional. Don't think this fix will cause any other side effects.