### PR TITLE
TAN-2520 - Fix for empty locked fields

### DIFF
--- a/back/engines/commercial/verification/app/services/verification/patches/permissions/user_requirements_service.rb
+++ b/back/engines/commercial/verification/app/services/verification/patches/permissions/user_requirements_service.rb
@@ -43,8 +43,10 @@ module Verification
             requirements[:authentication][:missing_user_attributes] = [] if permission.permitted_by == 'verified'
 
             # Remove custom fields that are locked - we should never ask them to be filled in the flow - even if they are returned empty
+            locked_fields = verification_service.locked_custom_fields(user)
+
             requirements[:custom_fields]&.each_key do |key|
-              requirements[:custom_fields].delete(key) if verification_service.locked_custom_fields(user).include?(key.to_sym)
+              requirements[:custom_fields].delete(key) if locked_fields.include?(key.to_sym)
             end
           end
 

--- a/back/engines/commercial/verification/app/services/verification/patches/permissions/user_requirements_service.rb
+++ b/back/engines/commercial/verification/app/services/verification/patches/permissions/user_requirements_service.rb
@@ -39,7 +39,15 @@ module Verification
         def mark_satisfied_requirements!(requirements, permission, user)
           super
 
-          requirements[:authentication][:missing_user_attributes] = [] if permission.permitted_by == 'verified' && user.verified?
+          if user.verified?
+            requirements[:authentication][:missing_user_attributes] = [] if permission.permitted_by == 'verified'
+
+            # Remove custom fields that are locked - we should never ask them to be filled in the flow - even if they are returned empty
+            requirements[:custom_fields]&.each_key do |key|
+              requirements[:custom_fields].delete(key) if verification_service.locked_custom_fields(user).include?(key.to_sym)
+            end
+          end
+
           return unless requirements[:verification]
 
           requirements[:verification] = requires_verification?(permission, user)

--- a/back/engines/commercial/verification/spec/services/permissions/user_requirements_service_spec.rb
+++ b/back/engines/commercial/verification/spec/services/permissions/user_requirements_service_spec.rb
@@ -117,6 +117,15 @@ describe Permissions::UserRequirementsService do
             requirements = service.requirements(verified_permission, user)
             expect(requirements[:authentication][:missing_user_attributes]).to be_empty
           end
+
+          it 'removes locked custom fields if verified' do
+            verified_permission.update!(global_custom_fields: false)
+            create(:permissions_custom_field, custom_field: create(:custom_field_gender), permission: verified_permission, required: true) # locked
+            create(:permissions_custom_field, custom_field: create(:custom_field_birthyear), permission: verified_permission, required: true) # locked
+            create(:permissions_custom_field, custom_field: create(:custom_field_domicile), permission: verified_permission, required: true) # not locked
+            requirements = service.requirements(verified_permission, user)
+            expect(requirements[:custom_fields]).to eq({ "domicile" => 'required' })
+          end
         end
 
         context 'when verification_expiry is set to 0' do
@@ -174,26 +183,5 @@ describe Permissions::UserRequirementsService do
         end
       end
     end
-
-    # context 'when permitted_by is set to "verified"' do
-    #   let(:permission) { create(:permission, permitted_by: 'verified') }
-    #
-    #   before do
-    #     # To allow permitted_by 'verified' we need to enable at least one verification method
-    #     SettingsService.new.activate_feature! 'verification', settings: { verification_methods: [{ name: 'fake_sso' }] }
-    #   end
-    #
-    #   it 'does not remove missing authentication requirements if not verified' do
-    #     user = create(:user, unique_code: '1234abcd', email: nil, password: nil)
-    #     requirements = service.requirements(permission, user)
-    #     expect(requirements[:authentication][:missing_user_attributes]).to eq %i[email password]
-    #   end
-    #
-    #   it 'removes all missing authentication requirements if verified' do
-    #     user = create(:user, unique_code: '1234abcd', email: nil, password: nil, verified: true)
-    #     requirements = service.requirements(permission, user)
-    #     expect(requirements[:authentication][:missing_user_attributes]).to be_empty
-    #   end
-    # end
   end
 end

--- a/back/engines/commercial/verification/spec/services/permissions/user_requirements_service_spec.rb
+++ b/back/engines/commercial/verification/spec/services/permissions/user_requirements_service_spec.rb
@@ -124,7 +124,7 @@ describe Permissions::UserRequirementsService do
             create(:permissions_custom_field, custom_field: create(:custom_field_birthyear), permission: verified_permission, required: true) # locked
             create(:permissions_custom_field, custom_field: create(:custom_field_domicile), permission: verified_permission, required: true) # not locked
             requirements = service.requirements(verified_permission, user)
-            expect(requirements[:custom_fields]).to eq({ "domicile" => 'required' })
+            expect(requirements[:custom_fields]).to eq({ 'domicile' => 'required' })
           end
         end
 


### PR DESCRIPTION
Removed custom fields from requirements API if they are locked and the user is verified - if they are locked then they should never get asked in the flow anyway (even if they are empty)
