### PR TITLE
TAN-2526 - Fix backend locales for Welsh

### DIFF
--- a/back/config/initializers/0_locales.rb
+++ b/back/config/initializers/0_locales.rb
@@ -45,6 +45,7 @@ fallback_locales =
   %i[
     ar
     ca
+    cy
     da
     de
     el


### PR DESCRIPTION
There was no `cy` fallback locale for welsh, but `cy-GB.yml` has only `cy` as it's root element 

# Changelog
## Fixed
- TAN-2526 - Fix backend locales for Welsh
