### PR TITLE
TAN-2530: Add text alternative if there is no label

### DIFF
--- a/front/app/components/UI/MoreActionsMenu/index.tsx
+++ b/front/app/components/UI/MoreActionsMenu/index.tsx
@@ -12,7 +12,7 @@ import {
 } from '@citizenlab/cl2-component-library';
 import styled from 'styled-components';
 
-import { FormattedMessage } from 'utils/cl-intl';
+import { FormattedMessage, useIntl } from 'utils/cl-intl';
 import { removeFocusAfterMouseClick } from 'utils/helperUtils';
 
 import messages from './messages';
@@ -130,6 +130,7 @@ const MoreActionsMenu = forwardRef<HTMLButtonElement, Props>(
       id,
       onClick,
     } = props;
+    const { formatMessage } = useIntl();
     const [visible, setVisible] = useState(false);
 
     // Generate a unique ID for aria-labelledby
@@ -211,7 +212,10 @@ const MoreActionsMenu = forwardRef<HTMLButtonElement, Props>(
             data-cy={props['data-cy']}
             className="e2e-more-actions"
             data-testid="moreOptionsButton"
-            aria-labelledby={labelId}
+            aria-labelledby={showLabel ? labelId : undefined}
+            aria-label={
+              !showLabel ? formatMessage(messages.moreOptions) : undefined
+            }
           >
             <MoreOptionsIcon name="dots-horizontal" color={color} />
             {showLabel && (


### PR DESCRIPTION
# Changelog

## Fixed
- a11y: Add text alternative to more options button if there is no label
