### PR TITLE
TAN-2416/proposal statuses leftover work

### DIFF
--- a/back/app/controllers/web_api/v1/idea_statuses_controller.rb
+++ b/back/app/controllers/web_api/v1/idea_statuses_controller.rb
@@ -107,6 +107,6 @@ class WebApi::V1::IdeaStatusesController < ApplicationController
   end
 
   def max_ordering
-    IdeaStatus.where(code: IdeaStatus::AUTOMATIC_STATUS_CODES).maximum(:ordering) || -1
+    IdeaStatus.where(code: IdeaStatus::AUTOMATIC_STATUS_CODES, participation_method: @idea_status.participation_method).maximum(:ordering) || -1
   end
 end

--- a/back/spec/acceptance/idea_statuses_spec.rb
+++ b/back/spec/acceptance/idea_statuses_spec.rb
@@ -268,7 +268,7 @@ resource 'IdeaStatuses' do
         before do
           IdeaStatus.all.zip(%w[proposed threshold_reached expired]).each { |status, code| status.update!(code: code, participation_method: 'proposals') }
         end
-        
+
         let(:idea_status) { create(:proposals_status) }
 
         example '[Error] Cannot reorder a proposals status into the automated status section', document: false do

--- a/back/spec/acceptance/idea_statuses_spec.rb
+++ b/back/spec/acceptance/idea_statuses_spec.rb
@@ -216,7 +216,7 @@ resource 'IdeaStatuses' do
 
     let(:idea_status) { create(:idea_status) }
     let(:id) { idea_status.id }
-    let(:ordering) { 0 }
+    let(:ordering) { 1 }
 
     context 'when resident' do
       before { resident_header_token }
@@ -266,9 +266,8 @@ resource 'IdeaStatuses' do
 
       describe do
         before do
-          IdeaStatus.all.zip(%w[proposed threshold_reached expired]).each { |status, code| status.update!(code: code) }
+          IdeaStatus.all.zip(%w[proposed threshold_reached expired]).each { |status, code| status.update!(code: code, participation_method: 'proposals') }
         end
-
         let(:idea_status) { create(:proposals_status) }
 
         example '[Error] Cannot reorder a proposals status into the automated status section', document: false do

--- a/back/spec/acceptance/idea_statuses_spec.rb
+++ b/back/spec/acceptance/idea_statuses_spec.rb
@@ -216,7 +216,7 @@ resource 'IdeaStatuses' do
 
     let(:idea_status) { create(:idea_status) }
     let(:id) { idea_status.id }
-    let(:ordering) { 1 }
+    let(:ordering) { 0 }
 
     context 'when resident' do
       before { resident_header_token }

--- a/back/spec/acceptance/idea_statuses_spec.rb
+++ b/back/spec/acceptance/idea_statuses_spec.rb
@@ -268,6 +268,7 @@ resource 'IdeaStatuses' do
         before do
           IdeaStatus.all.zip(%w[proposed threshold_reached expired]).each { |status, code| status.update!(code: code, participation_method: 'proposals') }
         end
+        
         let(:idea_status) { create(:proposals_status) }
 
         example '[Error] Cannot reorder a proposals status into the automated status section', document: false do

--- a/front/app/api/idea_statuses/useReorderIdeaStatus.test.ts
+++ b/front/app/api/idea_statuses/useReorderIdeaStatus.test.ts
@@ -1,0 +1,56 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+
+import createQueryClientWrapper from 'utils/testUtils/queryClientWrapper';
+
+import { ideaStatusesData } from './__mocks__/_mockServer';
+import useReorderIdeaStatus from './useReorderIdeaStatus';
+
+const apiPath = '*idea_statuses/:id/reorder';
+const server = setupServer(
+  http.patch(apiPath, () => {
+    return HttpResponse.json({ data: ideaStatusesData[0] }, { status: 200 });
+  })
+);
+
+describe('useReorderIdeaStatus', () => {
+  beforeAll(() => server.listen());
+  afterAll(() => server.close());
+
+  it('mutates data correctly', async () => {
+    const { result, waitFor } = renderHook(() => useReorderIdeaStatus(), {
+      wrapper: createQueryClientWrapper(),
+    });
+
+    act(() => {
+      result.current.mutate({
+        id: 'id',
+        ordering: 1,
+      });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.data).toEqual(ideaStatusesData[0]);
+  });
+
+  it('returns error correctly', async () => {
+    server.use(
+      http.patch(apiPath, () => {
+        return HttpResponse.json(null, { status: 500 });
+      })
+    );
+
+    const { result, waitFor } = renderHook(() => useReorderIdeaStatus(), {
+      wrapper: createQueryClientWrapper(),
+    });
+    act(() => {
+      result.current.mutate({
+        id: 'id',
+        ordering: 1,
+      });
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBeDefined();
+  });
+});

--- a/front/app/api/idea_statuses/useReorderIdeaStatus.ts
+++ b/front/app/api/idea_statuses/useReorderIdeaStatus.ts
@@ -1,0 +1,31 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { CLErrors } from 'typings';
+
+import fetcher from 'utils/cl-react-query/fetcher';
+
+import causesKeys from './keys';
+import { IIdeaStatus } from './types';
+
+type IReorderIdeaStatus = {
+  id: string;
+  ordering: number;
+};
+
+const reorderIdeaStatus = ({ id, ordering }: IReorderIdeaStatus) =>
+  fetcher<IIdeaStatus>({
+    path: `/idea_statuses/${id}/reorder`,
+    action: 'patch',
+    body: { idea_status: { ordering } },
+  });
+
+const useReorderIdeaStatus = () => {
+  const queryClient = useQueryClient();
+  return useMutation<IIdeaStatus, CLErrors, IReorderIdeaStatus>({
+    mutationFn: reorderIdeaStatus,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: causesKeys.lists() });
+    },
+  });
+};
+
+export default useReorderIdeaStatus;

--- a/front/app/components/admin/PostManager/components/FilterSidebar/FilterSidebarStatuses.tsx
+++ b/front/app/components/admin/PostManager/components/FilterSidebar/FilterSidebarStatuses.tsx
@@ -56,30 +56,41 @@ const FilterSidebarStatuses = ({
           <FormattedMessage {...messages.allStatuses} />
         </Menu.Item>
         <Divider />
-        {/* Only input statuses can be edited and only admins can do this */}
+        {/* Input statuses can be edited and only admins can do this */}
         {isAdmin(authUser) &&
-          (type === 'AllIdeas' ||
-            (type === 'ProjectIdeas' && (
-              <Box display="inline-flex">
-                <Button
-                  buttonStyle="text"
-                  icon="edit"
-                  pl="12px"
-                  linkTo="/admin/settings/ideation/statuses"
-                  iconPos="right"
-                  iconSize="14px"
-                >
-                  <Text
-                    m="0px"
-                    color="coolGrey600"
-                    fontSize="s"
-                    textAlign="left"
-                  >
-                    <FormattedMessage {...messages.editStatuses} />
-                  </Text>
-                </Button>
-              </Box>
-            )))}
+          (type === 'AllIdeas' || type === 'ProjectIdeas') && (
+            <Box display="inline-flex">
+              <Button
+                buttonStyle="text"
+                icon="edit"
+                pl="12px"
+                linkTo="/admin/settings/ideation/statuses"
+                iconPos="right"
+                iconSize="14px"
+              >
+                <Text m="0px" color="coolGrey600" fontSize="s" textAlign="left">
+                  <FormattedMessage {...messages.editStatuses} />
+                </Text>
+              </Button>
+            </Box>
+          )}
+        {/* Proposal statuses can be edited and only admins can do this */}
+        {isAdmin(authUser) && type === 'ProjectProposals' && (
+          <Box display="inline-flex">
+            <Button
+              buttonStyle="text"
+              icon="edit"
+              pl="12px"
+              linkTo="/admin/settings/proposals/statuses"
+              iconPos="right"
+              iconSize="14px"
+            >
+              <Text m="0px" color="coolGrey600" fontSize="s" textAlign="left">
+                <FormattedMessage {...messages.editStatuses} />
+              </Text>
+            </Button>
+          </Box>
+        )}
         {(statuses as (IIdeaStatusData | IInitiativeStatusData)[]).map(
           (status) => (
             <FilterSidebarStatusesItem

--- a/front/app/components/admin/PostManager/components/FilterSidebar/FilterSidebarStatuses.tsx
+++ b/front/app/components/admin/PostManager/components/FilterSidebar/FilterSidebarStatuses.tsx
@@ -49,6 +49,11 @@ const FilterSidebarStatuses = ({
     return selectedStatus === id;
   };
 
+  const linkToStatusSettings =
+    type === 'AllIdeas' || type === 'ProjectIdeas'
+      ? '/admin/settings/ideation/statuses'
+      : '/admin/settings/proposals/statuses';
+
   if (!isNilOrError(statuses)) {
     return (
       <Menu secondary={true} vertical={true} fluid={true}>
@@ -58,13 +63,15 @@ const FilterSidebarStatuses = ({
         <Divider />
         {/* Input statuses can be edited and only admins can do this */}
         {isAdmin(authUser) &&
-          (type === 'AllIdeas' || type === 'ProjectIdeas') && (
+          (type === 'AllIdeas' ||
+            type === 'ProjectIdeas' ||
+            type === 'ProjectProposals') && (
             <Box display="inline-flex">
               <Button
                 buttonStyle="text"
                 icon="edit"
                 pl="12px"
-                linkTo="/admin/settings/ideation/statuses"
+                linkTo={linkToStatusSettings}
                 iconPos="right"
                 iconSize="14px"
               >
@@ -74,23 +81,6 @@ const FilterSidebarStatuses = ({
               </Button>
             </Box>
           )}
-        {/* Proposal statuses can be edited and only admins can do this */}
-        {isAdmin(authUser) && type === 'ProjectProposals' && (
-          <Box display="inline-flex">
-            <Button
-              buttonStyle="text"
-              icon="edit"
-              pl="12px"
-              linkTo="/admin/settings/proposals/statuses"
-              iconPos="right"
-              iconSize="14px"
-            >
-              <Text m="0px" color="coolGrey600" fontSize="s" textAlign="left">
-                <FormattedMessage {...messages.editStatuses} />
-              </Text>
-            </Button>
-          </Box>
-        )}
         {(statuses as (IIdeaStatusData | IInitiativeStatusData)[]).map(
           (status) => (
             <FilterSidebarStatusesItem

--- a/front/app/components/admin/PostManager/components/PostPreview/Idea/FeedbackSettings.tsx
+++ b/front/app/components/admin/PostManager/components/PostPreview/Idea/FeedbackSettings.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { Select, Label } from '@citizenlab/cl2-component-library';
+import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import { IOption } from 'typings';
 
@@ -11,6 +12,7 @@ import { IIdea } from 'api/ideas/types';
 import useIdeaById from 'api/ideas/useIdeaById';
 import useUpdateIdea from 'api/ideas/useUpdateIdea';
 import useAuthUser from 'api/me/useAuthUser';
+import usePhase from 'api/phases/usePhase';
 import useUsers from 'api/users/useUsers';
 
 import useLocalize from 'hooks/useLocalize';
@@ -36,13 +38,18 @@ interface Props {
 }
 
 const FeedbackSettings = ({ projectId, ideaId, className }: Props) => {
+  const { phaseId } = useParams() as { phaseId: string };
+  const { data: phase } = usePhase(phaseId);
   const { formatMessage } = useIntl();
   const localize = useLocalize();
   const { data: authUser } = useAuthUser();
   const { data: idea } = useIdeaById(ideaId);
   const { data: appConfig } = useAppConfiguration();
   const { data: statuses } = useIdeaStatuses({
-    participation_method: 'ideation',
+    participation_method:
+      phase?.data.attributes.participation_method === 'proposals'
+        ? 'proposals'
+        : 'ideation',
   });
   const { mutate: updateIdea } = useUpdateIdea();
   const { data: prospectAssignees } = useUsers({

--- a/front/app/components/admin/ResourceList/LockedRow.tsx
+++ b/front/app/components/admin/ResourceList/LockedRow.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 
-import { Icon } from '@citizenlab/cl2-component-library';
+import { Icon, colors } from '@citizenlab/cl2-component-library';
 import styled from 'styled-components';
 
 import { Row } from 'components/admin/ResourceList';
@@ -32,7 +32,12 @@ export default ({
   <div className={className} data-testid={dataTestId}>
     <Row isLastItem={isLastItem}>
       <LockedDragHandle className="sortablerow-draghandle">
-        <LockIcon name="lock" />
+        <LockIcon
+          name="lock"
+          width="20px"
+          height="20px"
+          fill={colors.textSecondary}
+        />
       </LockedDragHandle>
       {children}
     </Row>

--- a/front/app/containers/Admin/ideas/routes.tsx
+++ b/front/app/containers/Admin/ideas/routes.tsx
@@ -2,7 +2,6 @@ import React, { lazy } from 'react';
 
 import moduleConfiguration from 'modules';
 
-import IdeaPreviewIndex from 'components/admin/PostManager/components/IdeaPreviewIndex';
 import PageLoading from 'components/UI/PageLoading';
 
 import { AdminRoute } from '../routes';
@@ -35,14 +34,7 @@ export default () => ({
         </PageLoading>
       ),
     },
-    {
-      path: ideaRoutes.ideaId,
-      element: (
-        <PageLoading>
-          <IdeaPreviewIndex goBackUrl="/admin/ideas" />
-        </PageLoading>
-      ),
-    },
+
     ...moduleConfiguration.routes['admin.ideas'],
   ],
 });

--- a/front/app/containers/Admin/settings/statuses/components/IdeaStatusForm.tsx
+++ b/front/app/containers/Admin/settings/statuses/components/IdeaStatusForm.tsx
@@ -115,6 +115,7 @@ const IdeaStatusForm = ({
   const allowedCodes = codes.filter(
     (code) => !automatedInputStatusCodes.has(code)
   );
+  const dedupedCodes = [...new Set(allowedCodes)];
 
   return (
     <FormProvider {...methods}>
@@ -159,7 +160,7 @@ const IdeaStatusForm = ({
                 />
               </StyledLabel>
               <RadioGroup name="code">
-                {allowedCodes.map((code, i) => (
+                {dedupedCodes.map((code, i) => (
                   <Radio
                     key={`code-input-${i}`}
                     label={

--- a/front/app/containers/Admin/settings/statuses/containers/edit.tsx
+++ b/front/app/containers/Admin/settings/statuses/containers/edit.tsx
@@ -33,19 +33,17 @@ const Edit = ({ variant }: { variant: 'ideation' | 'proposals' }) => {
   });
   const { statusId } = useParams() as { statusId: string };
   const { data: ideaStatus } = useIdeaStatus(statusId);
-  const { mutate: updateIdeaStatus } = useUpdateIdeaStatus();
+  const { mutateAsync: updateIdeaStatus } = useUpdateIdeaStatus();
   const tenantLocales = useAppConfigurationLocales();
 
   const handleSubmit = async (values: FormValues) => {
     const { ...params } = values;
 
-    updateIdeaStatus(
-      {
-        id: statusId,
-        requestBody: { ...params, participation_method: variant },
-      },
-      { onSuccess: goBack }
-    );
+    await updateIdeaStatus({
+      id: statusId,
+      requestBody: { ...params, participation_method: variant },
+    });
+    goBack();
   };
 
   const goBack = () => {

--- a/front/app/containers/Admin/settings/statuses/containers/index.tsx
+++ b/front/app/containers/Admin/settings/statuses/containers/index.tsx
@@ -70,7 +70,7 @@ const IdeaStatuses = ({ variant }: { variant: 'ideation' | 'proposals' }) => {
     onlyCheckAllowed: true,
   });
 
-  const handleReorder = (id: string, ordering: number) => () => {
+  const handleReorder = (id: string, ordering: number) => {
     updateIdeaStatus({
       id,
       requestBody: { participation_method: variant, ordering },

--- a/front/app/containers/Admin/settings/statuses/containers/index.tsx
+++ b/front/app/containers/Admin/settings/statuses/containers/index.tsx
@@ -1,21 +1,17 @@
 import React from 'react';
 
-import {
-  IconTooltip,
-  Spinner,
-  Tooltip,
-} from '@citizenlab/cl2-component-library';
+import { Spinner, Tooltip } from '@citizenlab/cl2-component-library';
 import styled from 'styled-components';
 
 import { IIdeaStatusData } from 'api/idea_statuses/types';
 import useIdeaStatuses from 'api/idea_statuses/useIdeaStatuses';
-import useUpdateIdeaStatus from 'api/idea_statuses/useUpdateIdeaStatus';
+import useReorderIdeaStatus from 'api/idea_statuses/useReorderIdeaStatus';
 
 import useFeatureFlag from 'hooks/useFeatureFlag';
 
 import { ButtonWrapper } from 'components/admin/PageWrapper';
 import {
-  Row,
+  LockedRow,
   SortableList,
   SortableRow,
   TextCell,
@@ -55,25 +51,20 @@ const FlexTextCell = styled(TextCell)`
   align-items: center;
 `;
 
-const StyledIconTooltip = styled(IconTooltip)`
-  margin-right: 20px;
-  padding: 0 16px;
-`;
-
 const IdeaStatuses = ({ variant }: { variant: 'ideation' | 'proposals' }) => {
   const { data: ideaStatuses, isLoading } = useIdeaStatuses({
     participation_method: variant,
   });
-  const { mutate: updateIdeaStatus } = useUpdateIdeaStatus();
+  const { mutate: reorderIdeaStatus } = useReorderIdeaStatus();
   const customIdeaStatusesAllowed = useFeatureFlag({
     name: 'custom_idea_statuses',
     onlyCheckAllowed: true,
   });
 
   const handleReorder = (id: string, ordering: number) => {
-    updateIdeaStatus({
+    reorderIdeaStatus({
       id,
-      requestBody: { participation_method: variant, ordering },
+      ordering,
     });
   };
 
@@ -98,9 +89,6 @@ const IdeaStatuses = ({ variant }: { variant: 'ideation' | 'proposals' }) => {
       (ideaStatus) => ideaStatus.attributes.can_reorder === false
     );
 
-    const sortableStatuses = ideaStatuses?.data.filter(
-      (ideaStatus) => ideaStatus.attributes.can_reorder
-    );
     return (
       <Section>
         {!customIdeaStatusesAllowed && (
@@ -132,48 +120,49 @@ const IdeaStatuses = ({ variant }: { variant: 'ideation' | 'proposals' }) => {
             </Button>
           </Tooltip>
         </ButtonWrapper>
-        {defaultStatuses.map((defaultStatus) => (
-          <Row key={defaultStatus.id}>
-            <FlexTextCell className="expand">
-              <StyledIconTooltip
-                content={<FormattedMessage {...messages.lockedStatusTooltip} />}
-                iconSize="16px"
-                placement="top"
-                icon="lock"
-              />
-              <ColorLabel color={defaultStatus.attributes.color} />
-              <T value={defaultStatus.attributes.title_multiloc} />
-            </FlexTextCell>
-            <Buttons>
-              {/* This DeleteStatusButton is a dummy button. The default status can never be deleted, 
-            so it's always disabled. */}
-              <DeleteStatusButton
-                buttonDisabled
-                tooltipContent={
-                  customIdeaStatusesAllowed ? (
-                    <FormattedMessage
-                      {...messages.defaultStatusDeleteButtonTooltip}
-                    />
-                  ) : (
-                    <FormattedMessage {...messages.pricingPlanUpgrade} />
-                  )
-                }
-                ideaStatusId={defaultStatus.id}
-              />
-              <EditStatusButton
-                buttonDisabled={!customIdeaStatusesAllowed}
-                tooltipContent={
-                  <FormattedMessage {...messages.pricingPlanUpgrade} />
-                }
-                linkTo={`/admin/settings/${variant}/statuses/${defaultStatus.id}`}
-              />
-            </Buttons>
-          </Row>
-        ))}
 
-        <SortableList items={sortableStatuses} onReorder={handleReorder}>
-          {({ itemsList, handleDragRow, handleDropRow }) => (
+        <SortableList
+          items={ideaStatuses.data}
+          lockFirstNItems={defaultStatuses.length}
+          onReorder={handleReorder}
+        >
+          {({ lockedItemsList, itemsList, handleDragRow, handleDropRow }) => (
             <>
+              {lockedItemsList?.map((defaultStatus, i) => (
+                <LockedRow
+                  key={defaultStatus.id}
+                  isLastItem={i === itemsList.length - 1}
+                >
+                  <FlexTextCell className="expand">
+                    <ColorLabel color={defaultStatus.attributes.color} />
+                    <T value={defaultStatus.attributes.title_multiloc} />
+                  </FlexTextCell>
+                  <Buttons>
+                    {/* This DeleteStatusButton is a dummy button. The default status can never be deleted, 
+            so it's always disabled. */}
+                    <DeleteStatusButton
+                      buttonDisabled
+                      tooltipContent={
+                        customIdeaStatusesAllowed ? (
+                          <FormattedMessage
+                            {...messages.defaultStatusDeleteButtonTooltip}
+                          />
+                        ) : (
+                          <FormattedMessage {...messages.pricingPlanUpgrade} />
+                        )
+                      }
+                      ideaStatusId={defaultStatus.id}
+                    />
+                    <EditStatusButton
+                      buttonDisabled={!customIdeaStatusesAllowed}
+                      tooltipContent={
+                        <FormattedMessage {...messages.pricingPlanUpgrade} />
+                      }
+                      linkTo={`/admin/settings/${variant}/statuses/${defaultStatus.id}`}
+                    />
+                  </Buttons>
+                </LockedRow>
+              ))}
               {itemsList.map((ideaStatus: IIdeaStatusData, index: number) => (
                 <SortableRow
                   key={ideaStatus.id}

--- a/front/app/containers/Admin/settings/statuses/containers/new.tsx
+++ b/front/app/containers/Admin/settings/statuses/containers/new.tsx
@@ -25,13 +25,11 @@ const NewIdeaStatus = ({ variant }: { variant: 'ideation' | 'proposals' }) => {
   const { data: ideaStatuses } = useIdeaStatuses({
     participation_method: variant,
   });
-  const { mutate: addIdeaStatus } = useAddIdeaStatus();
+  const { mutateAsync: addIdeaStatus } = useAddIdeaStatus();
   const tenantLocales = useAppConfigurationLocales();
-  const handleSubmit = (values: FormValues) => {
-    addIdeaStatus(
-      { ...values, participation_method: variant },
-      { onSuccess: goBack }
-    );
+  const handleSubmit = async (values: FormValues) => {
+    await addIdeaStatus({ ...values, participation_method: variant });
+    goBack();
   };
 
   const goBack = () => {
@@ -48,7 +46,7 @@ const NewIdeaStatus = ({ variant }: { variant: 'ideation' | 'proposals' }) => {
         <IdeaStatusForm
           defaultValues={{
             color: '#b5b5b5',
-            code: 'proposed',
+            code: 'custom',
           }}
           onSubmit={handleSubmit}
           showCategorySelector


### PR DESCRIPTION
@sebastienhoorens In this PR I am addressing some of the issues from the statuses PR that was merged when I was away.:
- Button to edit idea statuses is added
- The status form now works as expected (better error handling, no duplicate statuses, sensible defaults)
- Fix status display on admin proposal preview
- Fix reordering of idea and proposal statuses
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->
