### PR TITLE
[TAN-1906] Use correct url suffix in admin_project_url method

### DIFF
--- a/back/engines/free/frontend/app/services/frontend/url_service.rb
+++ b/back/engines/free/frontend/app/services/frontend/url_service.rb
@@ -158,7 +158,7 @@ module Frontend
       if last_phase_id
         "#{configuration.base_frontend_uri}/admin/projects/#{project_id}/phases/#{last_phase_id}/ideas"
       else
-        "#{configuration.base_frontend_uri}/admin/projects/#{project_id}/setup"
+        "#{configuration.base_frontend_uri}/admin/projects/#{project_id}/settings"
       end
     end
 


### PR DESCRIPTION
# Changelog
## Fixed
- [TAN-1906] 'Manage this project' button in Project Moderation Rights Received & Moderator Digest emails now takes user to the correct page in the back office.
