### PR TITLE
[TAN-2519] Rake task to translate project & related items to all tenant locales

### DIFF
--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/translate_project_to_all_locales.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/translate_project_to_all_locales.rake
@@ -4,7 +4,8 @@ namespace :cl2_back do
   #
   # It specifically processes all multilocs for the project, and its phases,
   # including; survey custom_fields & related custom_field_options, and report layouts.
-  # When reports are processed, it will re-publish the graph_data_units for each report.
+  # When related reports exist, it will re-publish the graph_data_units for each report to update
+  # any multilocs they may contain.
   #
   # It assumes that correct English (en) values are present in all the multilocs to be processed,
   # and machine translates these to all other multiloc keys in use by the tenant.
@@ -13,11 +14,6 @@ namespace :cl2_back do
   # It will overwrite any existing translations.
   desc 'Translate project multilocs to all tenant locales'
   task :translate_project_to_tenant_locales, %i[host project_id] => :environment do |_t, args|
-    # Temporary way to kill logging when developing (to more closely match the production environment)
-    dev_null = Logger.new('/dev/null')
-    Rails.logger = dev_null
-    ActiveRecord::Base.logger = dev_null
-
     Apartment::Tenant.switch(args[:host].tr('.', '_')) do
       project = Project.find(args[:project_id])
       locales = AppConfiguration.instance.settings['core']['locales']

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/translate_project_to_all_locales.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/translate_project_to_all_locales.rake
@@ -17,26 +17,26 @@ namespace :cl2_back do
     Apartment::Tenant.switch(args[:host].tr('.', '_')) do
       project = Project.find(args[:project_id])
       locales = AppConfiguration.instance.settings['core']['locales']
-      translate_model = TranslateProjectMethods.new
+      translate_project = TranslateProjectMethods.new
 
       puts "\nTranslating project: '#{project.title_multiloc['en']}' to all tenant locales\n\n"
 
-      translate_model.process_model(project, locales)
+      translate_project.process_model(project, locales)
 
       project.phases.each do |phase|
-        translate_model.process_model(phase, locales)
+        translate_project.process_model(phase, locales)
 
         fields = phase&.custom_form&.custom_fields
         fields&.each do |field|
-          translate_model.process_model(field, locales)
+          translate_project.process_model(field, locales)
           options = field&.options
-          options&.each { |option| translate_model.process_model(option, locales) }
+          options&.each { |option| translate_project.process_model(option, locales) }
         end
 
         report = phase&.report
         layout = report&.layout
-        translate_model.process_layout(layout, locales) if layout
-        translate_model.process_data_units(report) if report
+        translate_project.process_layout(layout, locales) if layout
+        translate_project.process_data_units(report) if report
       end
 
       puts "\n--- end ---\n\n"

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/translate_project_to_all_locales.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/translate_project_to_all_locales.rake
@@ -18,7 +18,17 @@ namespace :cl2_back do
       locales = AppConfiguration.instance.settings['core']['locales']
 
       puts "\nTranslating project #{project.title_multiloc['en']} to all tenant locales\n\n"
+
       process_all_multilocs(project, locales)
+
+      project.phases.each do |phase|
+        fields = phase&.custom_form&.custom_fields
+        fields&.each do |field|
+          process_all_multilocs(field, locales)
+          options = field&.options
+          options&.each { |option| process_all_multilocs(option, locales) }
+        end
+      end
 
       puts "--- end ---\n\n"
     end
@@ -32,6 +42,7 @@ def process_all_multilocs(model, locales)
   multiloc_attributes.each do |multiloc_attribute|
     attribute_name = multiloc_attribute[0]
     english = multiloc_attribute[1]['en']
+    next unless english
 
     locales.each do |locale|
       next if locale == 'en'

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/translate_project_to_all_locales.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/translate_project_to_all_locales.rake
@@ -1,0 +1,44 @@
+namespace :cl2_back do
+  # This task translates all the multiloc attributes of the project and many of its related records
+  # to all the tenant locales.
+  # It assumes that correct English (en) values are present in all the multilocs to be processed,
+  # and machine translates these to all other multiloc keys in use by the tenant.
+  # It will overwrite any existing translations.
+  # It specifically copies multilocs for the project, phases, survey custom_fields & related custom_field_options,
+  # and reports.
+  desc 'Translate project multilocs to all tenant locales'
+  task :translate_project_to_tenant_locales, %i[host project_id] => :environment do |_t, args|
+    # Temporary way to kill logging when developing (to more closely match the production environment)
+    dev_null = Logger.new('/dev/null')
+    Rails.logger = dev_null
+    ActiveRecord::Base.logger = dev_null
+
+    Apartment::Tenant.switch(args[:host].tr('.', '_')) do
+      project = Project.find(args[:project_id])
+      locales = AppConfiguration.instance.settings['core']['locales']
+
+      puts "\nTranslating project #{project.title_multiloc['en']} to all tenant locales\n\n"
+      process_all_multilocs(project, locales)
+
+      puts "--- end ---\n\n"
+    end
+  end
+end
+
+def process_all_multilocs(model, locales)
+  multiloc_attributes = model.attributes.select { |attribute| attribute.ends_with? '_multiloc' }
+  translator = MachineTranslations::MachineTranslationService.new
+
+  multiloc_attributes.each do |multiloc_attribute|
+    attribute_name = multiloc_attribute[0]
+    english = multiloc_attribute[1]['en']
+
+    locales.each do |locale|
+      next if locale == 'en'
+
+      model[attribute_name][locale] = translator.translate(english, 'en', locale)
+    end
+  end
+
+  pp model
+end

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/translate_project_to_all_locales.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/translate_project_to_all_locales.rake
@@ -77,7 +77,7 @@ class TranslateProjectMethods
   end
 
   def process_data_units(report)
-    user = User.find_by(email: 'moderator@citizenlab.co') || User.find_by(email: 'moderator@govocal.com')
+    user = User.admin.first
 
     if user.blank?
       puts "No moderator user found, so could not re-publish graph_data_units for Report: #{report.id}"


### PR DESCRIPTION
This is a task designed to translate all multilocs in a project, and its related items, from English (`:en`) to all tenant locales.

It is specifically designed to work with the project mentioned in the ticket, [TAN-2519](https://www.notion.so/govocal/TASK-translate-this-demo-project-for-maps-in-all-languages-f58075e8e2eb4340984e39768b9d770c?pvs=4), but could quite easily be extended to include more related models, etc.

# Changelog
## Technical
- [TAN-2519] Rake task to translate project & related items to all tenant locales
