### PR TITLE
[TAN-2469] Check for specific error class, not has_attribute?

### DIFF
--- a/back/engines/commercial/analysis/app/lib/analysis/summarization_method/base.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/summarization_method/base.rb
@@ -47,12 +47,12 @@ module Analysis
         task.set_succeeded!
       rescue SummarizationFailedError, Faraday::BadRequestError => e
         extra = {}
-        if e.has_attribute?(:response)
+        if e.instance_of?('Faraday::BadRequestError')
           extra[:response] = e&.response
           extra[:response_headers] = e&.response&.headers
           extra[:response_body] = e&.response&.body
           extra[:response_status] = e&.response&.status
-          extra[:backtrace] = e&.backtrace if e.has_attribute?(:backtrace)
+          extra[:backtrace] = e&.backtrace
         end
 
         ErrorReporter.report(e, extra: extra)


### PR DESCRIPTION
# Changelog
## Technical
- [TAN-2469] Check for instance of Faraday error class, not has_attribute?
