### PR TITLE
[TAN-2469] Try catching error in ActiveJobQueExtension#perform

### DIFF
--- a/back/engines/commercial/analysis/app/lib/analysis/auto_tagging_method/base.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/auto_tagging_method/base.rb
@@ -86,7 +86,7 @@ module Analysis
       chosen_topic = begin
         gpt3.chat(prompt)
       rescue Faraday::BadRequestError => e # https://go.microsoft.com/fwlink/?linkid=2198766
-        ErrorReporter.report(e, extra: { e_inspect: e.inspect })
+        ErrorReporter.report(e)
         'Other'
       end
       topics.include?(chosen_topic) ? chosen_topic : 'Other'


### PR DESCRIPTION
Still experimenting. Current theory being that this is where the [Sentry error](https://sentry.hq.citizenlab.co/organizations/citizenlab/issues/84371/events/a4c8801ef19b4e5e8a43289df5833db4/?project=2&statsPeriod=24h) is saying the error is raised, and that it's 'unhandled'.

@kogre Main Q I have is "Could this break `Que` in any general way?" (I assume this would be bad, as I would be releasing this to test it).

Testing locally, `Que` seems to continue working, even after I raise an error that gets handled by this new `rescue` block, and the Sentry error gets created (so the call to `ErrorReporter` seems to work also).

I won't release this today (Friday). I'd prefer to try on Tuesday morning (bank holiday for me on Monday).
