### PR TITLE
[TAN-2528] Reduce time to export users XLSX

### DIFF
--- a/back/app/services/xlsx_service.rb
+++ b/back/app/services/xlsx_service.rb
@@ -123,7 +123,7 @@ class XlsxService
       { header: 'email', f: ->(u) { u.email } },
       { header: 'first_name', f: ->(u) { u.first_name } },
       { header: 'last_name', f: ->(u) { u.last_name } },
-      { header: 'profile_page', f: ->(u) { url_service.model_to_url(u) }, skip_sanitization: true, hyperlink: true },
+      { header: 'profile_page', f: ->(u) { url_service.model_to_url(u) }, skip_sanitization: true }, # Not hyperlinked, as approx 7x faster without this style
       { header: 'created_at', f: ->(u) { u.created_at }, skip_sanitization: true },
       { header: 'registration_completed_at', f: ->(u) { u.registration_completed_at }, skip_sanitization: true },
       { header: 'invite_status', f: ->(u) { u.invite_status }, skip_sanitization: true },

--- a/back/app/services/xlsx_service.rb
+++ b/back/app/services/xlsx_service.rb
@@ -123,7 +123,7 @@ class XlsxService
       { header: 'email', f: ->(u) { u.email } },
       { header: 'first_name', f: ->(u) { u.first_name } },
       { header: 'last_name', f: ->(u) { u.last_name } },
-      { header: 'profile_page', f: ->(u) { url_service.model_to_url(u) }, skip_sanitization: true }, # Not hyperlinked, as approx 7x faster without this style
+      { header: 'profile_page', f: ->(u) { url_service.model_to_url(u) }, skip_sanitization: true }, # Not hyperlinked, as significantly faster without this style
       { header: 'created_at', f: ->(u) { u.created_at }, skip_sanitization: true },
       { header: 'registration_completed_at', f: ->(u) { u.registration_completed_at }, skip_sanitization: true },
       { header: 'invite_status', f: ->(u) { u.invite_status }, skip_sanitization: true },


### PR DESCRIPTION
Removing the hyperlink styling from the `profile_page` values gives an approximately 7x speed improvement, testing locally (with a copy of `participacion.digital.gob.cl` with 24k users).

The URLs are still constructed and included in the export, they are just not hyperlinked from the XLSX anymore.

We could try being more nuanced, and add hyperlinks only when the n of users to export is less than some limit, but I wonder if this is YAGNI. Maybe it's just simpler to release and see if anyone notices/complains about the lack of hyperlinks?

# Changelog
## Fixed
- [TAN-2528] Reduce time to export users Excel. For platforms with large numbers of users, export would timeout and fail.
