### PR TITLE
[TAN-2252] Do not create VotingLastChance notification for users who have voted

### DIFF
--- a/back/app/models/notifications/voting_last_chance.rb
+++ b/back/app/models/notifications/voting_last_chance.rb
@@ -75,6 +75,8 @@ module Notifications
 
       if phase.voting?
         user_scope = ParticipantsService.new.projects_participants(Project.where(id: phase.project_id))
+          .where.not(id: Basket.where(phase: phase).submitted.select(:user_id))
+
         ProjectPolicy::InverseScope.new(phase.project, user_scope).resolve.filter_map do |recipient|
           next if Permissions::PhasePermissionsService.new(phase, recipient).denied_reason_for_action 'voting'
 

--- a/back/spec/models/notifications/voting_last_chance_spec.rb
+++ b/back/spec/models/notifications/voting_last_chance_spec.rb
@@ -6,16 +6,25 @@ RSpec.describe Notifications::VotingLastChance do
   describe 'make_notifications_on' do
     let(:participant) { create(:user) }
 
-    it 'makes a notification when a voting phase is ending soon' do
-      phase = create(:budgeting_phase)
-      create(:idea, project_id: phase.project.id, author_id: participant.id)
-      activity = create(:activity, item: phase, action: 'ending_soon')
+    context 'when the phase is a voting phase' do
+      let(:phase) { create(:budgeting_phase) }
+      let!(:idea) { create(:idea, project_id: phase.project.id, author_id: participant.id) }
+      let(:activity) { create(:activity, item: phase, action: 'ending_soon') }
 
-      notifications = described_class.make_notifications_on activity
-      expect(notifications.first).to have_attributes(
-        recipient_id: participant.id,
-        phase: phase
-      )
+      it 'makes a notification when a voting phase is ending soon' do
+        notifications = described_class.make_notifications_on activity
+        expect(notifications.first).to have_attributes(
+          recipient_id: participant.id,
+          phase: phase
+        )
+      end
+
+      it 'does not make a notification for a participant who has already voted' do
+        create(:basket, user: participant, phase: phase, submitted_at: 1.week.ago)
+
+        notifications = described_class.make_notifications_on activity
+        expect(notifications).to eq []
+      end
     end
 
     it 'does not make a notification when a non-voting phase is ending soon' do


### PR DESCRIPTION
# Changelog
## Fixed
- [TAN-2252] Do not create VotingLastChance notification for users who have voted. Also avoids sending VotingLastChance mail to users who have voted.
