### PR TITLE
[TAN-2512] Drop table areas_ideas

### DIFF
--- a/back/db/migrate/20240829185625_drop_areas_ideas.rb
+++ b/back/db/migrate/20240829185625_drop_areas_ideas.rb
@@ -1,0 +1,5 @@
+class DropAreasIdeas < ActiveRecord::Migration[7.0]
+  def change
+    drop_table :areas_ideas
+  end
+end

--- a/back/db/structure.sql
+++ b/back/db/structure.sql
@@ -16,7 +16,6 @@ ALTER TABLE IF EXISTS ONLY public.comments DROP CONSTRAINT IF EXISTS fk_rails_f4
 ALTER TABLE IF EXISTS ONLY public.report_builder_published_graph_data_units DROP CONSTRAINT IF EXISTS fk_rails_f21a19c203;
 ALTER TABLE IF EXISTS ONLY public.idea_files DROP CONSTRAINT IF EXISTS fk_rails_efb12f53ad;
 ALTER TABLE IF EXISTS ONLY public.static_pages_topics DROP CONSTRAINT IF EXISTS fk_rails_edc8786515;
-ALTER TABLE IF EXISTS ONLY public.areas_ideas DROP CONSTRAINT IF EXISTS fk_rails_e96a71e39f;
 ALTER TABLE IF EXISTS ONLY public.polls_response_options DROP CONSTRAINT IF EXISTS fk_rails_e871bf6e26;
 ALTER TABLE IF EXISTS ONLY public.nav_bar_items DROP CONSTRAINT IF EXISTS fk_rails_e8076fb9f6;
 ALTER TABLE IF EXISTS ONLY public.cosponsors_initiatives DROP CONSTRAINT IF EXISTS fk_rails_e48253715f;
@@ -75,7 +74,6 @@ ALTER TABLE IF EXISTS ONLY public.analysis_additional_custom_fields DROP CONSTRA
 ALTER TABLE IF EXISTS ONLY public.notifications DROP CONSTRAINT IF EXISTS fk_rails_849e0c7eb7;
 ALTER TABLE IF EXISTS ONLY public.ideas_phases DROP CONSTRAINT IF EXISTS fk_rails_845d7ca944;
 ALTER TABLE IF EXISTS ONLY public.notifications DROP CONSTRAINT IF EXISTS fk_rails_828a073a04;
-ALTER TABLE IF EXISTS ONLY public.areas_ideas DROP CONSTRAINT IF EXISTS fk_rails_81e27f10eb;
 ALTER TABLE IF EXISTS ONLY public.notifications DROP CONSTRAINT IF EXISTS fk_rails_81c11ef894;
 ALTER TABLE IF EXISTS ONLY public.areas_initiatives DROP CONSTRAINT IF EXISTS fk_rails_81a9922de4;
 ALTER TABLE IF EXISTS ONLY public.projects_topics DROP CONSTRAINT IF EXISTS fk_rails_812b6d9149;
@@ -338,9 +336,6 @@ DROP INDEX IF EXISTS public.index_areas_on_custom_field_option_id;
 DROP INDEX IF EXISTS public.index_areas_initiatives_on_initiative_id_and_area_id;
 DROP INDEX IF EXISTS public.index_areas_initiatives_on_initiative_id;
 DROP INDEX IF EXISTS public.index_areas_initiatives_on_area_id;
-DROP INDEX IF EXISTS public.index_areas_ideas_on_idea_id_and_area_id;
-DROP INDEX IF EXISTS public.index_areas_ideas_on_idea_id;
-DROP INDEX IF EXISTS public.index_areas_ideas_on_area_id;
 DROP INDEX IF EXISTS public.index_analytics_dimension_types_on_name_and_parent;
 DROP INDEX IF EXISTS public.index_analytics_dimension_locales_on_name;
 DROP INDEX IF EXISTS public.index_analysis_tags_on_analysis_id_and_name;
@@ -483,7 +478,6 @@ ALTER TABLE IF EXISTS ONLY public.areas_static_pages DROP CONSTRAINT IF EXISTS a
 ALTER TABLE IF EXISTS ONLY public.areas_projects DROP CONSTRAINT IF EXISTS areas_projects_pkey;
 ALTER TABLE IF EXISTS ONLY public.areas DROP CONSTRAINT IF EXISTS areas_pkey;
 ALTER TABLE IF EXISTS ONLY public.areas_initiatives DROP CONSTRAINT IF EXISTS areas_initiatives_pkey;
-ALTER TABLE IF EXISTS ONLY public.areas_ideas DROP CONSTRAINT IF EXISTS areas_ideas_pkey;
 ALTER TABLE IF EXISTS ONLY public.ar_internal_metadata DROP CONSTRAINT IF EXISTS ar_internal_metadata_pkey;
 ALTER TABLE IF EXISTS ONLY public.app_configurations DROP CONSTRAINT IF EXISTS app_configurations_pkey;
 ALTER TABLE IF EXISTS ONLY public.analytics_fact_visits DROP CONSTRAINT IF EXISTS analytics_fact_visits_pkey;
@@ -583,7 +577,6 @@ DROP SEQUENCE IF EXISTS public.areas_static_pages_id_seq;
 DROP TABLE IF EXISTS public.areas_static_pages;
 DROP TABLE IF EXISTS public.areas_projects;
 DROP TABLE IF EXISTS public.areas_initiatives;
-DROP TABLE IF EXISTS public.areas_ideas;
 DROP TABLE IF EXISTS public.areas;
 DROP TABLE IF EXISTS public.ar_internal_metadata;
 DROP TABLE IF EXISTS public.app_configurations;
@@ -2033,17 +2026,6 @@ CREATE TABLE public.areas (
     custom_field_option_id uuid,
     followers_count integer DEFAULT 0 NOT NULL,
     include_in_onboarding boolean DEFAULT false NOT NULL
-);
-
-
---
--- Name: areas_ideas; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.areas_ideas (
-    area_id uuid,
-    idea_id uuid,
-    id uuid DEFAULT shared_extensions.uuid_generate_v4() NOT NULL
 );
 
 
@@ -3534,14 +3516,6 @@ ALTER TABLE ONLY public.ar_internal_metadata
 
 
 --
--- Name: areas_ideas areas_ideas_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.areas_ideas
-    ADD CONSTRAINT areas_ideas_pkey PRIMARY KEY (id);
-
-
---
 -- Name: areas_initiatives areas_initiatives_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -4632,27 +4606,6 @@ CREATE UNIQUE INDEX index_analytics_dimension_locales_on_name ON public.analytic
 --
 
 CREATE UNIQUE INDEX index_analytics_dimension_types_on_name_and_parent ON public.analytics_dimension_types USING btree (name, parent);
-
-
---
--- Name: index_areas_ideas_on_area_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_areas_ideas_on_area_id ON public.areas_ideas USING btree (area_id);
-
-
---
--- Name: index_areas_ideas_on_idea_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_areas_ideas_on_idea_id ON public.areas_ideas USING btree (idea_id);
-
-
---
--- Name: index_areas_ideas_on_idea_id_and_area_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_areas_ideas_on_idea_id_and_area_id ON public.areas_ideas USING btree (idea_id, area_id);
 
 
 --
@@ -6544,14 +6497,6 @@ ALTER TABLE ONLY public.notifications
 
 
 --
--- Name: areas_ideas fk_rails_81e27f10eb; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.areas_ideas
-    ADD CONSTRAINT fk_rails_81e27f10eb FOREIGN KEY (area_id) REFERENCES public.areas(id);
-
-
---
 -- Name: notifications fk_rails_828a073a04; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7013,14 +6958,6 @@ ALTER TABLE ONLY public.nav_bar_items
 
 ALTER TABLE ONLY public.polls_response_options
     ADD CONSTRAINT fk_rails_e871bf6e26 FOREIGN KEY (response_id) REFERENCES public.polls_responses(id);
-
-
---
--- Name: areas_ideas fk_rails_e96a71e39f; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.areas_ideas
-    ADD CONSTRAINT fk_rails_e96a71e39f FOREIGN KEY (idea_id) REFERENCES public.ideas(id);
 
 
 --
@@ -7531,4 +7468,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240806161121'),
 ('20240812115140'),
 ('20240814133336'),
-('20240814163522');
+('20240814163522'),
+('20240829185625');
+
+


### PR DESCRIPTION
It seems we removed the code related to `areas_ideas` in May 2022 in [CL-839](https://citizenlab.atlassian.net/browse/CL-839), in 2 PRs:
1. [CL-839 Remove unused area_ideas code #246](https://github.com/CitizenLabDotCo/citizenlab-ee/pull/246)
2. [CL-839 Remove unused area_ideas code #2023](https://github.com/CitizenLabDotCo/citizenlab/pull/2023)

In [a comment](https://github.com/CitizenLabDotCo/citizenlab/pull/2023/files#r879133518) in one of those PRs there is a plan to drop the table in a month or two, but I assume this was forgotten.

If an idea is referenced in the table's `idea_id` column, then deletion of the idea, and any project containing such an idea, is prevented.

In the meantime, a workaround when such a problem with project deletion is encountered is to:
1. pull a copy of the tenant db locally
2. run the tenant locally & try to delete the project via the FO
3. check the rails logs for the error to confirm it is, indeed, a fk restraint on `areas_ideas` table (there are other possible reasons)
4. stub the model in the rails console
5. find the offending `areas_ideas` records and destroy them
6. Deletion via the FO should now succeed
7. Repeat 4-6 on production

# Changelog
## Technical
- [TAN-2512] Drop table areas_ideas
## Fixed
- [TAN-2512] Fixed a situation which prevented deletion of some inputs, and projects containing such inputs


[CL-839]: https://citizenlab.atlassian.net/browse/CL-839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CL-839]: https://citizenlab.atlassian.net/browse/CL-839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CL-839]: https://citizenlab.atlassian.net/browse/CL-839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ