### PR TITLE
TAN-2218 Feedback needed

### DIFF
--- a/back/app/finders/ideas_finder.rb
+++ b/back/app/finders/ideas_finder.rb
@@ -54,7 +54,7 @@ class IdeasFinder < ApplicationFinder
   end
 
   def feedback_needed_condition(feedback_needed)
-    feedback_needed ? scope(:feedback_needed) : scope(:no_feedback_needed)
+    scope(:feedback_needed) if feedback_needed
   end
 
   def search_condition(search)

--- a/back/app/models/idea.rb
+++ b/back/app/models/idea.rb
@@ -162,8 +162,10 @@ class Idea < ApplicationRecord
   }
 
   scope :feedback_needed, lambda {
-    joins(:idea_status).where(idea_statuses: { code: 'proposed' })
+    scope = joins(:idea_status)
+    scope.where(idea_statuses: { code: 'proposed' })
       .where('ideas.id NOT IN (SELECT DISTINCT(post_id) FROM official_feedbacks)')
+      .or(scope.where(idea_statuses: { code: 'threshold_reached' }))
   }
 
   scope :publicly_visible, lambda {

--- a/back/spec/models/idea_spec.rb
+++ b/back/spec/models/idea_spec.rb
@@ -438,11 +438,11 @@ RSpec.describe Idea do
         create(:idea, idea_status: create(:idea_status_proposed)),
         create(:idea, idea_status: create(:idea_status, code: 'accepted')),
         create(:idea, idea_status: create(:idea_status_proposed)),
-        create(:idea, idea_status: create(:idea_status, code: 'viewed'))
+        create(:idea, idea_status: create(:idea_status, code: 'threshold_reached'))
       ]
       create(:official_feedback, post: ideas[0])
 
-      expect(described_class.feedback_needed.ids).to match_array [ideas[2].id]
+      expect(described_class.feedback_needed.ids).to match_array [ideas[2].id, ideas[3].id]
     end
   end
 


### PR DESCRIPTION
Implements the new requirement for feedback needed:  Inputs in proposed without official feedback OR inputs in threshold_reached.