### PR TITLE
TAN-2630 Don't set the idea status on native survey responses

### DIFF
--- a/back/app/models/idea.rb
+++ b/back/app/models/idea.rb
@@ -120,11 +120,11 @@ class Idea < ApplicationRecord
   # }
 
   with_options unless: :draft? do
+    validates :idea_status, presence: true
     validates :project, presence: true
     before_validation :assign_defaults
     before_validation :sanitize_body_multiloc, if: :body_multiloc
   end
-  validates :idea_status, presence: true, if: :requires_idea_status?
 
   after_update :fix_comments_count_on_projects
 
@@ -218,10 +218,6 @@ class Idea < ApplicationRecord
 
   def supports_built_in_fields?
     !draft? && participation_method_on_creation.supports_built_in_fields?
-  end
-
-  def requires_idea_status?
-    !draft? && participation_method_on_creation.supports_status?
   end
 
   def assign_defaults

--- a/back/engines/commercial/analytics/spec/acceptance/analytics_posts_spec.rb
+++ b/back/engines/commercial/analytics/spec/acceptance/analytics_posts_spec.rb
@@ -54,6 +54,7 @@ resource 'Analytics - FactPosts model' do
 
     example 'does not return survey responses', document: false do
       # Create 2 posts inc 1 ignored survey
+      create(:idea_status_proposed)
       project = create(:project_with_past_ideation_and_current_native_survey_phase)
       create(:idea, created_at: @dates[0], project: project, phases: [project.phases.first])
       create(:native_survey_response, created_at: @dates[0], project: project, phases: [project.phases.last], creation_phase: project.phases.last)

--- a/back/engines/commercial/idea_assignment/spec/services/idea_assignment/idea_assignment_service_spec.rb
+++ b/back/engines/commercial/idea_assignment/spec/services/idea_assignment/idea_assignment_service_spec.rb
@@ -64,6 +64,7 @@ describe IdeaAssignment::IdeaAssignmentService do
       timeline_survey_project = create(:project_with_active_native_survey_phase, default_assignee_id: create(:admin).id)
       expect(timeline_survey_project.phases[0].participation_method).to eq('native_survey')
 
+      create(:idea_status_proposed)
       idea = create(
         :native_survey_response,
         creation_phase_id: timeline_survey_project.phases[0].id,

--- a/back/engines/commercial/multi_tenancy/spec/services/multi_tenancy/templates/tenant_serializer_spec.rb
+++ b/back/engines/commercial/multi_tenancy/spec/services/multi_tenancy/templates/tenant_serializer_spec.rb
@@ -236,6 +236,7 @@ describe MultiTenancy::Templates::TenantSerializer do
         create(factory, :for_custom_form, resource: custom_form)
       end
       unsupported_field = create(:custom_field, :for_custom_form, input_type: 'file_upload', resource: custom_form)
+      create(:idea_status_proposed)
       response = create(:native_survey_response, project: project)
       custom_field_values = {
         supported_fields[0].key => 7,

--- a/back/engines/commercial/multi_tenancy/spec/tasks/fix_assignees_task_spec.rb
+++ b/back/engines/commercial/multi_tenancy/spec/tasks/fix_assignees_task_spec.rb
@@ -8,6 +8,8 @@ describe 'rake fix_existing_tenants' do # rubocop:disable RSpec/DescribeClass
   let(:task) { Rake::Task[task_name] }
 
   describe ':remove_assignees_from_survey_responses' do
+    before { create(:idea_status_proposed) }
+
     let(:task_name) { 'fix_existing_tenants:remove_assignees_from_survey_responses' }
     let(:assignee) { create(:admin) }
     let!(:idea1) { create(:native_survey_response, assignee_id: assignee.id, assigned_at: Time.zone.now) }

--- a/back/engines/commercial/public_api/spec/acceptance/v2/ideas_spec.rb
+++ b/back/engines/commercial/public_api/spec/acceptance/v2/ideas_spec.rb
@@ -13,6 +13,8 @@ resource 'Posts' do
 
   include_context 'common_auth'
 
+  before_all { create(:idea_status_proposed) }
+
   # 3 Ideas
   let!(:ideas) do
     create_list(:idea, 3, created_at: '2020-01-01').tap do |ideas|

--- a/back/engines/commercial/report_builder/spec/services/report_builder/queries/survey_question_result_spec.rb
+++ b/back/engines/commercial/report_builder/spec/services/report_builder/queries/survey_question_result_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe ReportBuilder::Queries::SurveyQuestionResult do
     end
 
     before_all do
+      create(:idea_status_proposed)
       create(
         :native_survey_response,
         project: project,

--- a/back/engines/free/email_campaigns/spec/mailers/native_survey_not_submitted_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/native_survey_not_submitted_mailer_spec.rb
@@ -4,6 +4,8 @@ require 'rails_helper'
 
 RSpec.describe EmailCampaigns::NativeSurveyNotSubmittedMailer do
   describe 'campaign_mail' do
+    before_all { create(:idea_status_proposed) }
+
     let_it_be(:recipient) { create(:user, locale: 'en') }
     let_it_be(:campaign) { EmailCampaigns::Campaigns::NativeSurveyNotSubmitted.create! }
     let_it_be(:phase) { create(:native_survey_phase, start_at: '2022-12-01', end_at: '2022-12-31') }
@@ -20,10 +22,6 @@ RSpec.describe EmailCampaigns::NativeSurveyNotSubmittedMailer do
     end
 
     let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
-
-    before_all do
-      EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id)
-    end
 
     it 'renders the subject' do
       expect(mail.subject).to end_with 'Almost there! Submit your answers'

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/native_survey_not_submitted_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/native_survey_not_submitted_spec.rb
@@ -10,8 +10,10 @@ RSpec.describe EmailCampaigns::Campaigns::NativeSurveyNotSubmitted do
   end
 
   describe '#generate_commands' do
-    let!(:idea) { create(:native_survey_response, author: create(:user)) }
-    let(:notification) { create(:native_survey_not_submitted, post: idea, project: idea.project, phase: idea.creation_phase) }
+    before { create(:idea_status_proposed) }
+
+    let!(:input) { create(:native_survey_response, author: create(:user)) }
+    let(:notification) { create(:native_survey_not_submitted, post: input, project: input.project, phase: input.creation_phase) }
     let(:notification_activity) { create(:activity, item: notification, action: 'created') }
 
     it 'generates a command with the desired payload and tracked content' do
@@ -22,11 +24,11 @@ RSpec.describe EmailCampaigns::Campaigns::NativeSurveyNotSubmitted do
       ).first
 
       expect(command.dig(:event_payload, :survey_url))
-        .to end_with "/ideas/new?phase_id=#{idea.creation_phase.id}"
+        .to end_with "/ideas/new?phase_id=#{input.creation_phase.id}"
       expect(command.dig(:event_payload, :phase_title_multiloc))
-        .to eq idea.creation_phase.title_multiloc
+        .to eq input.creation_phase.title_multiloc
       expect(command.dig(:event_payload, :phase_end_at))
-        .to eq idea.creation_phase.end_at
+        .to eq input.creation_phase.end_at
     end
   end
 end

--- a/back/lib/participation_method/native_survey.rb
+++ b/back/lib/participation_method/native_survey.rb
@@ -13,7 +13,7 @@ module ParticipationMethod
 
     def assign_defaults(input)
       input.publication_status ||= 'published'
-      input.idea_status ||= IdeaStatus.find_by!(code: 'proposed')
+      # input.idea_status ||= IdeaStatus.find_by!(code: 'proposed')
     end
 
     # NOTE: This is only ever used by the analyses controller - otherwise the front-end always persists the form

--- a/back/lib/participation_method/native_survey.rb
+++ b/back/lib/participation_method/native_survey.rb
@@ -13,7 +13,7 @@ module ParticipationMethod
 
     def assign_defaults(input)
       input.publication_status ||= 'published'
-      # input.idea_status ||= IdeaStatus.find_by!(code: 'proposed')
+      input.idea_status ||= IdeaStatus.find_by!(code: 'proposed', participation_method: 'ideation')
     end
 
     # NOTE: This is only ever used by the analyses controller - otherwise the front-end always persists the form

--- a/back/spec/acceptance/ideas_update_spec.rb
+++ b/back/spec/acceptance/ideas_update_spec.rb
@@ -535,6 +535,8 @@ resource 'Ideas' do
     end
 
     context 'in a native survey phase' do
+      before_all { create(:idea_status_proposed) }
+
       let(:project) { create(:single_phase_native_survey_project) }
       let(:author) { create(:user) }
       let(:input) { create(:native_survey_response, project: project, author: author) }

--- a/back/spec/factories/ideas.rb
+++ b/back/spec/factories/ideas.rb
@@ -44,6 +44,7 @@ FactoryBot.define do
     factory :native_survey_response, class: 'Idea' do
       association :project, factory: :single_phase_native_survey_project
       creation_phase { project.phases.first }
+      idea_status { nil }
     end
   end
 end

--- a/back/spec/lib/participation_method/native_survey_spec.rb
+++ b/back/spec/lib/participation_method/native_survey_spec.rb
@@ -18,20 +18,18 @@ RSpec.describe ParticipationMethod::NativeSurvey do
       let!(:proposed) { create(:idea_status_proposed) }
       let(:input) { build(:idea, publication_status: nil, idea_status: nil) }
 
-      it 'sets the publication_status to "publised" and doesn\'t set the idea_status' do
+      it 'sets the publication_status to "publised" and the idea_status to "proposed"' do
         participation_method.assign_defaults input
         expect(input.publication_status).to eq 'published'
-        expect(input.idea_status).to be_nil
+        expect(input.idea_status).to eq proposed
       end
     end
 
     context 'when the proposed idea status is not available' do
       let(:input) { build(:idea, idea_status: nil) }
 
-      it 'sets the publication_status to "publised" and doesn\'t set the idea_status' do
-        participation_method.assign_defaults input
-        expect(input.publication_status).to eq 'published'
-        expect(input.idea_status).to be_nil
+      it 'raises ActiveRecord::RecordNotFound' do
+        expect { participation_method.assign_defaults input }.to raise_error ActiveRecord::RecordNotFound
       end
     end
   end

--- a/back/spec/lib/participation_method/native_survey_spec.rb
+++ b/back/spec/lib/participation_method/native_survey_spec.rb
@@ -18,18 +18,20 @@ RSpec.describe ParticipationMethod::NativeSurvey do
       let!(:proposed) { create(:idea_status_proposed) }
       let(:input) { build(:idea, publication_status: nil, idea_status: nil) }
 
-      it 'sets the publication_status to "publised" and the idea_status to "proposed"' do
+      it 'sets the publication_status to "publised" and doesn\'t set the idea_status' do
         participation_method.assign_defaults input
         expect(input.publication_status).to eq 'published'
-        expect(input.idea_status).to eq proposed
+        expect(input.idea_status).to eq nil
       end
     end
 
     context 'when the proposed idea status is not available' do
       let(:input) { build(:idea, idea_status: nil) }
 
-      it 'raises ActiveRecord::RecordNotFound' do
-        expect { participation_method.assign_defaults input }.to raise_error ActiveRecord::RecordNotFound
+      it 'sets the publication_status to "publised" and doesn\'t set the idea_status' do
+        participation_method.assign_defaults input
+        expect(input.publication_status).to eq 'published'
+        expect(input.idea_status).to eq nil
       end
     end
   end

--- a/back/spec/lib/participation_method/native_survey_spec.rb
+++ b/back/spec/lib/participation_method/native_survey_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ParticipationMethod::NativeSurvey do
       it 'sets the publication_status to "publised" and doesn\'t set the idea_status' do
         participation_method.assign_defaults input
         expect(input.publication_status).to eq 'published'
-        expect(input.idea_status).to eq nil
+        expect(input.idea_status).to be nil
       end
     end
 
@@ -31,7 +31,7 @@ RSpec.describe ParticipationMethod::NativeSurvey do
       it 'sets the publication_status to "publised" and doesn\'t set the idea_status' do
         participation_method.assign_defaults input
         expect(input.publication_status).to eq 'published'
-        expect(input.idea_status).to eq nil
+        expect(input.idea_status).to be nil
       end
     end
   end

--- a/back/spec/lib/participation_method/native_survey_spec.rb
+++ b/back/spec/lib/participation_method/native_survey_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ParticipationMethod::NativeSurvey do
       it 'sets the publication_status to "publised" and doesn\'t set the idea_status' do
         participation_method.assign_defaults input
         expect(input.publication_status).to eq 'published'
-        expect(input.idea_status).to be nil
+        expect(input.idea_status).to be_nil
       end
     end
 
@@ -31,7 +31,7 @@ RSpec.describe ParticipationMethod::NativeSurvey do
       it 'sets the publication_status to "publised" and doesn\'t set the idea_status' do
         participation_method.assign_defaults input
         expect(input.publication_status).to eq 'published'
-        expect(input.idea_status).to be nil
+        expect(input.idea_status).to be_nil
       end
     end
   end

--- a/back/spec/models/notifications/native_survey_not_submitted_spec.rb
+++ b/back/spec/models/notifications/native_survey_not_submitted_spec.rb
@@ -4,16 +4,17 @@ require 'rails_helper'
 
 RSpec.describe Notifications::NativeSurveyNotSubmitted do
   describe 'make_notifications_on' do
-    it 'makes a notification when an idea is flagged as "survey_not_submitted"' do
-      idea = create(:native_survey_response, author: create(:user))
-      activity = create(:activity, item: idea, action: 'survey_not_submitted')
+    it 'makes a notification when an input is flagged as "survey_not_submitted"' do
+      create(:idea_status_proposed)
+      input = create(:native_survey_response, author: create(:user))
+      activity = create(:activity, item: input, action: 'survey_not_submitted')
 
       notifications = described_class.make_notifications_on activity
       expect(notifications.first).to have_attributes(
-        recipient_id: idea.author_id,
-        post: idea,
-        project: idea.project,
-        phase: idea.creation_phase
+        recipient_id: input.author_id,
+        post: input,
+        project: input.project,
+        phase: input.creation_phase
       )
     end
   end

--- a/back/spec/services/export/geojson/value_visitor_spec.rb
+++ b/back/spec/services/export/geojson/value_visitor_spec.rb
@@ -374,14 +374,13 @@ describe Export::Geojson::ValueVisitor do
       end
 
       context 'when there is a value' do
+        before { create(:idea_status_proposed) }
+
         let(:model) { create(:native_survey_response) }
         let!(:file) { create(:idea_file, name: 'File1.pdf', idea: model) }
 
-        before do
-          model.update!(custom_field_values: { field_key => { 'id' => file.id, 'name' => file.name } })
-        end
-
         it 'returns the value for the report' do
+          model.update!(custom_field_values: { field_key => { 'id' => file.id, 'name' => file.name } })
           expect(visitor.visit_file_upload(field)).to eq file.file.url
         end
       end
@@ -401,14 +400,13 @@ describe Export::Geojson::ValueVisitor do
       end
 
       context 'when there is a value' do
+        before { create(:idea_status_proposed) }
+
         let(:model) { create(:native_survey_response) }
         let!(:file) { create(:idea_file, name: 'File1.pdf', idea: model) }
 
-        before do
-          model.update!(custom_field_values: { field_key => { 'id' => file.id, 'name' => file.name } })
-        end
-
         it 'returns the value for the report' do
+          model.update!(custom_field_values: { field_key => { 'id' => file.id, 'name' => file.name } })
           expect(visitor.visit_shapefile_upload(field)).to eq file.file.url
         end
       end

--- a/back/spec/services/export/xlsx/value_visitor_spec.rb
+++ b/back/spec/services/export/xlsx/value_visitor_spec.rb
@@ -579,14 +579,13 @@ describe Export::Xlsx::ValueVisitor do
       end
 
       context 'when there is a value' do
+        before { create(:idea_status_proposed) }
+
         let(:model) { create(:native_survey_response) }
         let!(:file) { create(:idea_file, name: 'File1.pdf', idea: model) }
 
-        before do
-          model.update!(custom_field_values: { field_key => { 'id' => file.id, 'name' => file.name } })
-        end
-
         it 'returns the value for the report' do
+          model.update!(custom_field_values: { field_key => { 'id' => file.id, 'name' => file.name } })
           expect(visitor.visit_file_upload(field)).to eq file.file.url
         end
       end
@@ -606,14 +605,13 @@ describe Export::Xlsx::ValueVisitor do
       end
 
       context 'when there is a value' do
+        before { create(:idea_status_proposed) }
+
         let(:model) { create(:native_survey_response) }
         let!(:file) { create(:idea_file, name: 'File1.pdf', idea: model) }
 
-        before do
-          model.update!(custom_field_values: { field_key => { 'id' => file.id, 'name' => file.name } })
-        end
-
         it 'returns the value for the report' do
+          model.update!(custom_field_values: { field_key => { 'id' => file.id, 'name' => file.name } })
           expect(visitor.visit_shapefile_upload(field)).to eq file.file.url
         end
       end

--- a/back/spec/services/participants_service_spec.rb
+++ b/back/spec/services/participants_service_spec.rb
@@ -130,6 +130,7 @@ describe ParticipantsService do
     end
 
     it 'returns total project participant count including anonymous posts & everyone surveys' do
+      create(:idea_status_proposed)
       project = create(:project)
       pp1, pp2, pp3, pp4, pp5 = create_list(:user, 5)
 

--- a/back/spec/services/participants_service_spec.rb
+++ b/back/spec/services/participants_service_spec.rb
@@ -154,8 +154,9 @@ describe ParticipantsService do
       expect(service.project_participants_count_uncached(project)).to eq 7
 
       # 'everyone' surveys +2
-      create(:native_survey_response, project: project, author: nil, title_multiloc: { 'en' => 'title' }, body_multiloc: { 'en' => 'body' })
-      create(:native_survey_response, project: project, author: nil, title_multiloc: { 'en' => 'title' }, body_multiloc: { 'en' => 'body' })
+      phase = create(:native_survey_phase, project: project)
+      create(:native_survey_response, project: project, creation_phase: phase, author: nil, title_multiloc: { 'en' => 'title' }, body_multiloc: { 'en' => 'body' })
+      create(:native_survey_response, project: project, creation_phase: phase, author: nil, title_multiloc: { 'en' => 'title' }, body_multiloc: { 'en' => 'body' })
       expect(service.project_participants_count_uncached(project)).to eq 9
     end
   end

--- a/back/spec/services/permissions/project_permissions_service_spec.rb
+++ b/back/spec/services/permissions/project_permissions_service_spec.rb
@@ -90,6 +90,7 @@ describe Permissions::ProjectPermissionsService do
       end
 
       it 'returns `posting_limited_max_reached`' do
+        create(:idea_status_proposed)
         create(:native_survey_response, project: project, author: user, anonymous: true, phases: project.phases, creation_phase: project.phases.first)
 
         expect(service.denied_reason_for_action('posting_idea')).to eq 'posting_limited_max_reached'

--- a/back/spec/services/project_copy_service_spec.rb
+++ b/back/spec/services/project_copy_service_spec.rb
@@ -120,6 +120,7 @@ describe ProjectCopyService do
     end
 
     it 'skips custom field values with ID references' do
+      create(:idea_status_proposed)
       project = create(:single_phase_native_survey_project)
       custom_form = create(:custom_form, participation_context: project)
       supported_fields = %i[custom_field_number custom_field_linear_scale custom_field_checkbox].map do |factory|


### PR DESCRIPTION
Related: https://go-vocal.slack.com/archives/C65GX921W/p1725566288147439

A bug slipped through the specs, because the specs would always assign an idea status to native survey responses created by the factory, while the web application would not assign an idea status to the native survey response (at least not the moment that we hit the bug).

We agreed that we would keep assigning native survey responses to input statuses, as this is more in line with the idea of unified input models.