### PR TITLE
TAN-2500 nightly e2e speedup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -745,40 +745,50 @@ jobs:
       - attach_workspace:
           at: .
       - run:
+          name: Start pulling in the large cypress image in parallel to continuing with the rest of the setup
           command: |
               cd e2e
               docker compose -f docker-compose.yml -f docker-compose.test.yml pull cypress
           background: true
-      - run: |
-          cd e2e
-          docker compose -f docker-compose.yml -f docker-compose.test.yml up --no-start
-      - run: |
-          cd e2e
-          WEB_CONTAINER_ID=$(docker compose ps -a -q web)
-          FRONT_CONTAINER_ID=$(docker compose ps -a -q front)
-          POSTGRES_CONTAINER_ID=$(docker compose ps -a -q postgres)
-          docker cp ../uploads/. $WEB_CONTAINER_ID:/cl2_back/public/uploads
-          docker cp ../build $FRONT_CONTAINER_ID:/front/build
-          docker cp ../postgresql-data/. $POSTGRES_CONTAINER_ID:/var/lib/postgresql/data
-      - run: |
-          cd e2e
-          docker compose -f docker-compose.yml -f docker-compose.test.yml up -d --wait
       - run:
+          name: Pull all images and create the containers, but don't start them yet
+          command: |
+            cd e2e
+            docker compose -f docker-compose.yml -f docker-compose.test.yml up --no-start
+      - run:
+          name: Copy the pre-built e2e tenant data and front-end bundle into the containers
+          command: |
+            cd e2e
+            WEB_CONTAINER_ID=$(docker compose ps -a -q web)
+            FRONT_CONTAINER_ID=$(docker compose ps -a -q front)
+            POSTGRES_CONTAINER_ID=$(docker compose ps -a -q postgres)
+            docker cp ../uploads/. $WEB_CONTAINER_ID:/cl2_back/public/uploads
+            docker cp ../build $FRONT_CONTAINER_ID:/front/build
+            docker cp ../postgresql-data/. $POSTGRES_CONTAINER_ID:/var/lib/postgresql/data
+      - run:
+          name: Start the containers, block on them becoming healthy
+          command: |
+            cd e2e
+            docker compose -f docker-compose.yml -f docker-compose.test.yml up -d --wait
+      - run:
+          name: Output the container logs
           command: |
               cd e2e
               docker compose -f docker-compose.yml -f docker-compose.test.yml logs -f
           background: true
-      - run: |
-          cd front
-          TESTFILES=$(circleci tests glob "cypress/e2e/**/*.cy.ts" | circleci tests split --split-by=timings)
-          COMMA_SEPARATED_TESTFILES=$(echo $TESTFILES | sed 's/ /,/g')
-          echo $COMMA_SEPARATED_TESTFILES
-          cd ../e2e
-          docker compose -f docker-compose.yml -f docker-compose.test.yml --profile cypress run --name cypress_run \
-            cypress npm run cypress:run -- \
-            --reporter cypress-circleci-reporter \
-            --config baseUrl=http://e2e.front:3000 \
-            --spec ${COMMA_SEPARATED_TESTFILES}
+      - run:
+          name: Run cypress
+          command: |
+            cd front
+            TESTFILES=$(circleci tests glob "cypress/e2e/**/*.cy.ts" | circleci tests split --split-by=timings)
+            COMMA_SEPARATED_TESTFILES=$(echo $TESTFILES | sed 's/ /,/g')
+            echo $COMMA_SEPARATED_TESTFILES
+            cd ../e2e
+            docker compose -f docker-compose.yml -f docker-compose.test.yml --profile cypress run --name cypress_run \
+              cypress npm run cypress:run -- \
+              --reporter cypress-circleci-reporter \
+              --config baseUrl=http://e2e.front:3000 \
+              --spec ${COMMA_SEPARATED_TESTFILES}
       - run:
           command: |
             docker cp cypress_run:/front/test_results .
@@ -789,8 +799,6 @@ jobs:
           # Error: No such container:path: cypress_run:/front/cypress/screenshots
           when: on_fail
       - store_test_results:
-          path: test_results
-      - store_artifacts:
           path: test_results
       - store_artifacts:
           path: screenshots

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1142,7 +1142,7 @@ workflows:
             - docker-hub-access
             - lastpass
       - e2e-tests:
-          paralellism: 16
+          parallelism: 16
           context:
             - docker-hub-access
           requires:
@@ -1169,7 +1169,7 @@ workflows:
             - docker-hub-access
             - lastpass
       - e2e-tests:
-          paralellism: 4
+          parallelism: 4
           requires:
             - e2e-setup-db
             - e2e-setup-front

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1169,7 +1169,7 @@ workflows:
             - docker-hub-access
             - lastpass
       - e2e-tests:
-          parallelism: 4
+          parallelism: 6
           requires:
             - e2e-setup-db
             - e2e-setup-front

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -732,7 +732,10 @@ jobs:
   e2e-tests:
     docker:
       - image: cimg/base:2024.08
-    parallelism: 16
+    parameters:
+      parallelism:
+        type: integer
+    parallelism: << parameters.parallelism >>
     working_directory: ~/citizenlab
     resource_class: medium
     steps:
@@ -1121,9 +1124,9 @@ workflows:
             - docker-hub-access
             - lastpass
       - e2e-tests:
+          paralellism: 16
           context:
             - docker-hub-access
-            - lastpass
           requires:
             - e2e-setup-db
             - e2e-setup-front
@@ -1137,11 +1140,22 @@ workflows:
               only:
                 - master
     jobs:
+      - e2e-setup-db:
+          context:
+            - docker-hub-access
+            - lastpass
+      - e2e-setup-front:
+          context:
+            - docker-hub-access
+            - lastpass
       - e2e-tests:
+          paralellism: 4
+          requires:
+            - e2e-setup-db
+            - e2e-setup-front
           context:
             - docker-hub-access
             - slack-dev-notifications-e2e
-            - lastpass
           post-steps:
             - slack/notify:
                 event: pass

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -682,11 +682,15 @@ jobs:
       - image: cimg/base:2024.08
     working_directory: ~/citizenlab
     resource_class: medium
+    parameters:
+      docker_layer_caching:
+        type: boolean
+        description: Because docker layer caching is expensive, we make it optional so the automated nightly e2e runs can opt-out from using it.
     steps:
       - shallow-clone
       - copy_secrets_from_lastpass
       - setup_remote_docker:
-          docker_layer_caching: true
+          docker_layer_caching: << parameters.docker_layer_caching >>
       - run: docker login -u $DOCKER_USER -p $DOCKER_PASS
       - run: |
           cd e2e
@@ -710,12 +714,16 @@ jobs:
     docker:
       - image: cimg/base:2024.08
     resource_class: large
+    parameters:
+      docker_layer_caching:
+        type: boolean
+        description: Because docker layer caching is expensive, we make it optional so the automated nightly e2e runs can opt-out from using it.
     working_directory: ~/citizenlab
     steps:
       - shallow-clone
       - copy_secrets_from_lastpass
       - setup_remote_docker:
-          docker_layer_caching: true
+          docker_layer_caching: << parameters.docker_layer_caching >>
       - run: docker login -u $DOCKER_USER -p $DOCKER_PASS
       - run: |
           cd e2e
@@ -1124,10 +1132,12 @@ workflows:
     when: << pipeline.parameters.e2e >>
     jobs:
       - e2e-setup-db:
+          docker_layer_caching: true
           context:
             - docker-hub-access
             - lastpass
       - e2e-setup-front:
+          docker_layer_caching: true
           context:
             - docker-hub-access
             - lastpass
@@ -1149,10 +1159,12 @@ workflows:
                 - master
     jobs:
       - e2e-setup-db:
+          docker_layer_caching: false
           context:
             - docker-hub-access
             - lastpass
       - e2e-setup-front:
+          docker_layer_caching: false
           context:
             - docker-hub-access
             - lastpass


### PR DESCRIPTION
# Changelog
The diff in the job definition itself is only adding documentation to the job steps,  but unfortunately changing indentation which causes the larger difs.

## Technical
- Use new e2e test setup for nightly e2e tests while running them more slowly to save some costs