### PR TITLE
[TAN-2625] Fix map layers when copying survey with project copy

### DIFF
--- a/back/app/services/project_copy_service.rb
+++ b/back/app/services/project_copy_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ProjectCopyService < TemplateService
+class ProjectCopyService < TemplateService # rubocop:disable Metrics/ClassLength
   def import(template, folder: nil, local_copy: false)
     same_template = MultiTenancy::Templates::Utils.translate_and_fix_locales(template)
 

--- a/back/app/services/project_copy_service.rb
+++ b/back/app/services/project_copy_service.rb
@@ -33,6 +33,7 @@ class ProjectCopyService < TemplateService # rubocop:disable Metrics/ClassLength
     @include_ideas = include_ideas
     @local_copy = local_copy
     @project = project
+    @project_map_configs = project_map_configs
     @template = { 'models' => {} }
     new_slug = SlugService.new.generate_slug(nil, new_slug) if new_slug
 
@@ -397,7 +398,7 @@ class ProjectCopyService < TemplateService # rubocop:disable Metrics/ClassLength
   end
 
   def yml_maps_map_configs(shift_timestamps: 0)
-    project_map_configs.map do |map_config|
+    @project_map_configs.map do |map_config|
       yml_map_config = {
         'mappable_ref' => lookup_ref(map_config.mappable_id, %i[project custom_field]),
         'center_geojson' => map_config.center_geojson,
@@ -414,7 +415,7 @@ class ProjectCopyService < TemplateService # rubocop:disable Metrics/ClassLength
   end
 
   def yml_maps_layers(shift_timestamps: 0)
-    layers = project_map_configs.map(&:layers).flatten
+    layers = @project_map_configs.map(&:layers).flatten
 
     layers.map do |layer|
       yml_layer = {

--- a/back/app/services/project_copy_service.rb
+++ b/back/app/services/project_copy_service.rb
@@ -764,10 +764,11 @@ class ProjectCopyService < TemplateService # rubocop:disable Metrics/ClassLength
   end
 
   def project_map_configs
-    custom_forms = CustomForm.where(participation_context: [@project, *@project.phases])
-    custom_fields = CustomField.where(resource: custom_forms)
-
     CustomMaps::MapConfig.where(mappable: @project)
-      .or(CustomMaps::MapConfig.where(mappable: custom_fields))
+      .or(
+        CustomMaps::MapConfig.where(
+          mappable: CustomField.where(resource: CustomForm.where(participation_context: [@project, *@project.phases]))
+        )
+      )
   end
 end

--- a/back/app/services/project_copy_service.rb
+++ b/back/app/services/project_copy_service.rb
@@ -425,6 +425,7 @@ class ProjectCopyService < TemplateService # rubocop:disable Metrics/ClassLength
         'geojson' => layer.geojson,
         'default_enabled' => layer.default_enabled,
         'marker_svg_url' => layer.marker_svg_url,
+        'ordering' => layer.ordering,
         'created_at' => shift_timestamp(layer.created_at, shift_timestamps)&.iso8601,
         'updated_at' => shift_timestamp(layer.updated_at, shift_timestamps)&.iso8601
       }

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/custom_maps/layer.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/custom_maps/layer.rb
@@ -6,7 +6,7 @@ module MultiTenancy
       module CustomMaps
         class Layer < Base
           ref_attribute :map_config
-          attributes %i[type layer_url default_enabled geojson marker_svg_url title_multiloc]
+          attributes %i[type layer_url default_enabled geojson marker_svg_url title_multiloc ordering]
         end
       end
     end

--- a/back/spec/services/project_copy_service_spec.rb
+++ b/back/spec/services/project_copy_service_spec.rb
@@ -148,68 +148,91 @@ describe ProjectCopyService do
       expect(template['models']['idea'].first['custom_field_values']).to match expected_custom_field_values
     end
 
-    it 'successfully copies map_configs associated with phase-level form custom_fields' do
+    it 'successfully copies map_configs associated with phase-level form custom_fields, and their layers' do
       open_ended_project = create(:single_phase_native_survey_project, title_multiloc: { en: 'open ended' })
       form1 = create(:custom_form, participation_context: open_ended_project.phases.first)
       page_field = create(:custom_field_page, :for_custom_form, resource: form1)
       map_config1 = create(:map_config, zoom_level: 15, mappable: page_field)
+      layer1 = create(:geojson_layer, map_config: map_config1, title_multiloc: { en: 'Layer 1' })
       point_field = create(:custom_field_point, :for_custom_form, resource: form1)
       map_config2 = create(:map_config, zoom_level: 17, mappable: point_field)
+      layer2 = create(:geojson_layer, map_config: map_config2, title_multiloc: { en: 'Layer 2' })
+      layer3 = create(:esri_feature_layer, map_config: map_config2, title_multiloc: { en: 'Layer 3' })
 
       template = service.export open_ended_project
 
       expect(template['models']['custom_field'].size).to eq 2
       expect(template['models']['custom_maps/map_config'].size).to eq 2
+      expect(template['models']['custom_maps/layer'].size).to eq 3
 
       tenant = create(:tenant)
       tenant.switch do
         expect(CustomMaps::MapConfig.count).to eq 0
+        expect(CustomMaps::Layer.count).to eq 0
 
         service.import template
 
         expect(CustomMaps::MapConfig.count).to eq 2
         expect(CustomMaps::MapConfig.all.pluck(:zoom_level))
           .to match_array [map_config1.zoom_level, map_config2.zoom_level]
+
+        expect(CustomMaps::Layer.count).to eq 3
+        expect(CustomMaps::Layer.all.pluck(:title_multiloc))
+          .to match_array [layer1.title_multiloc, layer2.title_multiloc, layer3.title_multiloc]
       end
     end
 
-    it 'successfully copies map_configs associated with project-level form custom_fields' do
+    it 'successfully copies map_configs associated with project-level form custom_fields, and their layers' do
       project = create(:project)
       form1 = create(:custom_form, participation_context: project)
       field1 = create(:custom_field_point, :for_custom_form, resource: form1)
       map_config = create(:map_config, zoom_level: 17, mappable: field1)
+      layer1 = create(:geojson_layer, map_config: map_config, title_multiloc: { en: 'Layer 1' })
+      layer2 = create(:geojson_layer, map_config: map_config, title_multiloc: { en: 'Layer 2' })
 
       template = service.export project
 
       expect(template['models']['custom_maps/map_config'].size).to eq 1
+      expect(template['models']['custom_maps/layer'].size).to eq 2
 
       tenant = create(:tenant)
       tenant.switch do
         expect(CustomMaps::MapConfig.count).to eq 0
+        expect(CustomMaps::Layer.count).to eq 0
 
         service.import template
 
         expect(CustomMaps::MapConfig.count).to eq 1
         expect(CustomMaps::MapConfig.first.zoom_level).to eq map_config.zoom_level
+
+        expect(CustomMaps::Layer.count).to eq 2
+        expect(CustomMaps::Layer.all.pluck(:title_multiloc))
+          .to match_array [layer1.title_multiloc, layer2.title_multiloc]
       end
     end
 
-    it 'successfully copies map_configs associated with projects' do
+    it 'successfully copies map_configs associated with projects, and their layers' do
       project = create(:project)
       map_config = create(:map_config, zoom_level: 17, mappable: project)
+      layer = create(:geojson_layer, map_config: map_config, title_multiloc: { en: 'Layer title' })
 
       template = service.export project
 
       expect(template['models']['custom_maps/map_config'].size).to eq 1
+      expect(template['models']['custom_maps/layer'].size).to eq 1
 
       tenant = create(:tenant)
       tenant.switch do
         expect(CustomMaps::MapConfig.count).to eq 0
+        expect(CustomMaps::Layer.count).to eq 0
 
         service.import template
 
         expect(CustomMaps::MapConfig.count).to eq 1
         expect(CustomMaps::MapConfig.first.zoom_level).to eq map_config.zoom_level
+
+        expect(CustomMaps::Layer.count).to eq 1
+        expect(CustomMaps::Layer.first.title_multiloc).to eq layer.title_multiloc
       end
     end
 


### PR DESCRIPTION
- Also adds copying of `layer.ordering`, which has never been included in project or tenant copying for any layers (even those associated with the `project.map_config`)

# Changelog
## Fixed
- [TAN-2625] Survey map layers are now included when copying a project.
