### PR TITLE
Show 'Anyone' permission if native survey

### DIFF
--- a/front/app/components/admin/ActionForm/index.tsx
+++ b/front/app/components/admin/ActionForm/index.tsx
@@ -66,7 +66,8 @@ const ActionForm = ({ phaseId, permissionData, onChange, onReset }: Props) => {
   const participation_method = phase?.data.attributes.participation_method;
 
   const isSurveyAction =
-    participation_method === 'native_survey' && action === 'posting_idea';
+    (participation_method === 'native_survey' && action === 'posting_idea') ||
+    (participation_method === 'survey' && action === 'taking_survey');
 
   if (!permissionsCustomFields) return null;
 


### PR DESCRIPTION
# Changelog
## Fixed
- Apparently it was possible to set external surveys as open to 'Anyone'. During the permissions tandem work this got removed. Now it's back.