### PR TITLE
TAN-2177: Hide language selector when there is one locale

### DIFF
--- a/front/app/components/Form/Components/Layouts/PageControlButtons.tsx
+++ b/front/app/components/Form/Components/Layouts/PageControlButtons.tsx
@@ -47,16 +47,18 @@ const PageControlButtons = ({
       px={isSmallerThanPhone ? '16px' : '24px'}
       py={'16px'}
     >
-      <LanguageSelector
-        dropdownClassName={'open-upwards'}
-        useDefaultTop={false}
-        mobileRight="auto"
-        mobileLeft="auto"
-        right="auto"
-        afterSelection={() => {
-          window.location.reload();
-        }}
-      />
+      <Box>
+        <LanguageSelector
+          dropdownClassName={'open-upwards'}
+          useDefaultTop={false}
+          mobileRight="auto"
+          mobileLeft="auto"
+          right="auto"
+          afterSelection={() => {
+            window.location.reload();
+          }}
+        />
+      </Box>
       <Box display="flex" justifyContent="center" alignItems="center">
         {hasPreviousPage && (
           <Button

--- a/front/app/components/Form/Components/Layouts/PageControlButtons.tsx
+++ b/front/app/components/Form/Components/Layouts/PageControlButtons.tsx
@@ -48,6 +48,8 @@ const PageControlButtons = ({
       py={'16px'}
     >
       <Box>
+        {' '}
+        {/* We wrap it in a Box here to maintain the spacing and keep the next buttons right-aligned when the language selector is empty, preventing the need to move the locale check logic here. */}
         <LanguageSelector
           dropdownClassName={'open-upwards'}
           useDefaultTop={false}

--- a/front/app/containers/MainHeader/Components/LanguageSelector/index.tsx
+++ b/front/app/containers/MainHeader/Components/LanguageSelector/index.tsx
@@ -151,6 +151,11 @@ const LanguageSelector = ({
     const tenantLocales = appConfig.data.attributes.settings.core.locales;
     const isRtl = !!locale.startsWith('ar');
 
+    // Check if the number of locales is only one and hide if there is only one since there are no langauges to select
+    if (tenantLocales.length === 1) {
+      return null;
+    }
+
     const selectedLocale = getSelectedLocale(locale);
 
     return (

--- a/front/app/containers/MainHeader/Components/NavbarContent/DesktopNavbarContent/index.tsx
+++ b/front/app/containers/MainHeader/Components/NavbarContent/DesktopNavbarContent/index.tsx
@@ -11,10 +11,7 @@ import {
 import { darken } from 'polished';
 import styled, { useTheme } from 'styled-components';
 
-import useAppConfiguration from 'api/app_configuration/useAppConfiguration';
 import useAuthUser from 'api/me/useAuthUser';
-
-import useLocale from 'hooks/useLocale';
 
 import { triggerAuthenticationFlow } from 'containers/Authentication/events';
 
@@ -101,14 +98,9 @@ const RightItem = styled.div`
 `;
 
 const DesktopNavbarContent = () => {
-  const { data: appConfiguration } = useAppConfiguration();
   const { data: authUser } = useAuthUser();
-  const locale = useLocale();
   const theme = useTheme();
   const { formatMessage } = useIntl();
-  const tenantLocales = !isNilOrError(appConfiguration)
-    ? appConfiguration.data.attributes.settings.core.locales
-    : [];
   const isEmailSettingsPage = isPage('email-settings', location.pathname);
 
   const isSmallerThanTablet = useBreakpoint('tablet');
@@ -162,11 +154,9 @@ const DesktopNavbarContent = () => {
         </>
       )}
 
-      {tenantLocales.length > 1 && locale && (
-        <RightItem className="noLeftMargin">
-          <StyledLanguageSelector />
-        </RightItem>
-      )}
+      <RightItem className="noLeftMargin">
+        <StyledLanguageSelector />
+      </RightItem>
     </Right>
   );
 };

--- a/front/app/containers/MainHeader/Components/NavbarContent/MobileNavbarContent/index.tsx
+++ b/front/app/containers/MainHeader/Components/NavbarContent/MobileNavbarContent/index.tsx
@@ -3,10 +3,7 @@ import React, { Suspense, useRef, useState } from 'react';
 import { Box, Button, media, isRtl } from '@citizenlab/cl2-component-library';
 import styled from 'styled-components';
 
-import useAppConfiguration from 'api/app_configuration/useAppConfiguration';
 import useAuthUser from 'api/me/useAuthUser';
-
-import useLocale from 'hooks/useLocale';
 
 import { triggerAuthenticationFlow } from 'containers/Authentication/events';
 
@@ -81,15 +78,10 @@ const NavItem = styled(Box)`
 `;
 
 const MobileNavbarContent = () => {
-  const { data: appConfiguration } = useAppConfiguration();
   const { data: authUser } = useAuthUser();
-  const locale = useLocale();
   const { formatMessage } = useIntl();
 
   const isEmailSettingsPage = isPage('email-settings', location.pathname);
-  const tenantLocales = !isNilOrError(appConfiguration)
-    ? appConfiguration.data.attributes.settings.core.locales
-    : [];
 
   const [isFullMenuOpened, setIsFullMenuOpened] = useState(false);
   const containerRef = useRef<HTMLElement>(null);
@@ -116,11 +108,9 @@ const MobileNavbarContent = () => {
       <RightContainer>
         {!isEmailSettingsPage && (
           <>
-            {tenantLocales.length > 1 && locale && (
-              <NavItem className="noLeftMargin">
-                <LanguageSelector />
-              </NavItem>
-            )}
+            <NavItem className="noLeftMargin">
+              <LanguageSelector />
+            </NavItem>
             {isNilOrError(authUser) ? (
               <NavItem className="login">
                 <Button


### PR DESCRIPTION
# Changelog

## Fixed
- Hide the language selector in surveys when only one language is configured on the platform.
