### PR TITLE
TAN-2644 WYSIWYG images in email

### DIFF
--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/manual_campaign_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/manual_campaign_mailer.rb
@@ -11,7 +11,8 @@ module EmailCampaigns
       @app_configuration = AppConfiguration.instance
 
       body_html_with_liquid = multiloc_service.t(command[:body_multiloc], locale.to_s)
-      template = Liquid::Template.parse(body_html_with_liquid)
+      body_html_with_fixed_images = fix_image_widths(body_html_with_liquid)
+      template = Liquid::Template.parse(body_html_with_fixed_images)
       template.render(liquid_params(recipient))
     end
 
@@ -56,6 +57,19 @@ module EmailCampaigns
 
     def home_url
       url_service.home_url(app_configuration: app_configuration, locale: locale)
+    end
+
+    def fix_image_widths(html)
+      doc = Nokogiri::HTML(html)
+
+      doc.css('img').each do |img|
+        # Set the width to 100% if it's not set.
+        # Otherwise, the image will be displayed at its original size.
+        # This can mess up the layout if the original image is e.g. 4000px wide.
+        img['width'] = '100%' if img['width'].blank?
+      end
+
+      doc.to_s
     end
   end
 end

--- a/front/app/components/admin/Email/PreviewFrame.tsx
+++ b/front/app/components/admin/Email/PreviewFrame.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 
 import Frame from 'react-frame-component';
 import styled from 'styled-components';
@@ -17,26 +17,15 @@ const StyledFrame = styled(Frame)`
 type Props = {
   campaignId: string;
   className?: string;
+  children?: React.ReactNode;
 };
 
-type State = {
-  previewHtml?: string;
-};
+const PreviewFrame = ({ campaignId, className, children }: Props) => {
+  const [previewHtml, setPreviewHtml] = useState<string>();
 
-class PreviewFrame extends React.Component<Props, State> {
-  iframeNode: HTMLIFrameElement | undefined;
-
-  constructor(props: Props) {
-    super(props);
-    this.state = {
-      previewHtml: undefined,
-    };
-  }
-
-  componentDidMount() {
-    // TODO: Replace with fetcher when the backend is updated
+  useEffect(() => {
     const jwt = getJwt();
-    fetch(`${API_PATH}/campaigns/${this.props.campaignId}/preview`, {
+    fetch(`${API_PATH}/campaigns/${campaignId}/preview`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
@@ -45,26 +34,21 @@ class PreviewFrame extends React.Component<Props, State> {
     })
       .then((response) => response.json())
       .then((data) => {
-        this.setState({ previewHtml: data.html });
+        setPreviewHtml(data.html);
       });
-  }
+  }, [campaignId]);
 
-  render() {
-    const { previewHtml } = this.state;
-    const { className } = this.props;
+  if (!previewHtml) return null;
 
-    if (!previewHtml) return null;
-
-    return (
-      <StyledFrame
-        id="e2e-email-preview-iframe"
-        className={className}
-        initialContent={previewHtml}
-      >
-        {this.props.children}
-      </StyledFrame>
-    );
-  }
-}
+  return (
+    <StyledFrame
+      id="e2e-email-preview-iframe"
+      className={className}
+      initialContent={previewHtml}
+    >
+      {children}
+    </StyledFrame>
+  );
+};
 
 export default PreviewFrame;


### PR DESCRIPTION
# Changelog
## Fixed
- Make sure images in manual emails campaigns are shown at 100% screen size unless they have been resized.
