### PR TITLE
TAN-2688 - Custom field option fallback for PDF & XLSX export and import

### DIFF
--- a/back/app/services/custom_field_service.rb
+++ b/back/app/services/custom_field_service.rb
@@ -139,19 +139,21 @@ class CustomFieldService
     idea.author_id == current_user.id || UserRoleService.new.can_moderate_project?(idea.project, current_user)
   end
 
-  private
+  # Fallback to another locale title if current locale is missing
+  def handle_title(field, locale)
+    I18n.with_locale(locale) do
+      @multiloc_service.t(field.title_multiloc)
+    end
+  end
 
+  # Fallback to another locale description if current locale is missing
   def handle_description(field, locale)
     I18n.with_locale(locale) do
       @multiloc_service.t(field.description_multiloc)
     end
   end
 
-  def handle_title(field, locale)
-    I18n.with_locale(locale) do
-      @multiloc_service.t(field.title_multiloc)
-    end
-  end
+  private
 
   def base_ui_schema_field(field, _locale)
     {}.tap do |ui_schema|

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/base_form_exporter.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/base_form_exporter.rb
@@ -29,13 +29,8 @@ module BulkImportIdeas::Exporters
 
     private
 
-    # Fallback to another locale if option in current locale is missing
-    def handle_option_title(option)
-      I18n.with_locale(@locale) { multiloc_service.t(option.title_multiloc) }
-    end
-
-    def multiloc_service
-      @multiloc_service ||= MultilocService.new app_configuration: AppConfiguration.instance
+    def custom_field_service
+      @custom_field_service ||= CustomFieldService.new
     end
   end
 end

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/base_form_exporter.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/base_form_exporter.rb
@@ -26,5 +26,16 @@ module BulkImportIdeas::Exporters
     def importer_data
       raise NotImplementedError, 'This method is not yet implemented'
     end
+
+    private
+
+    # Fallback to another locale if option in current locale is missing
+    def handle_option_title(option)
+      I18n.with_locale(@locale) { multiloc_service.t(option.title_multiloc) }
+    end
+
+    def multiloc_service
+      @multiloc_service ||= MultilocService.new app_configuration: AppConfiguration.instance
+    end
   end
 end

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_pdf_form_exporter.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_pdf_form_exporter.rb
@@ -313,7 +313,7 @@ module BulkImportIdeas::Exporters
         pdf.move_up 3.mm
 
         pdf.indent(7.mm) do
-          pdf.text option.title_multiloc[@locale]
+          pdf.text handle_option_title(option)
         end
 
         pdf.move_down 4.mm
@@ -334,7 +334,7 @@ module BulkImportIdeas::Exporters
         pdf.move_up 2.8.mm
 
         pdf.indent(7.mm) do
-          pdf.text option.title_multiloc[@locale]
+          pdf.text handle_option_title(option)
         end
 
         pdf.move_down 4.mm
@@ -373,13 +373,14 @@ module BulkImportIdeas::Exporters
       position = (810 - position) / 8.1 # Convert the position into equivalent of what form parser returns
       key = field[:key]
       parent_key = type == 'option' ? field.custom_field.key : nil
+      title = type == 'option' ? handle_option_title(option) : field[:title_multiloc][@locale]
 
       # Because of the way pdf group works we delete if value is already there and always use the last value for the field
       @importer_fields.delete_if { |f| f[:key] == key && f[:parent_key] == parent_key }
 
       # In IdeaPdfFileParser#merge_idea_with_form_fields, we add :value key to this hash.
       @importer_fields << {
-        name: field[:title_multiloc][@locale],
+        name: title,
         description: type == 'field' ? ActionView::Base.full_sanitizer.sanitize(field[:description_multiloc][@locale]) : nil,
         type: type,
         input_type: field[:input_type],

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_pdf_form_exporter.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_pdf_form_exporter.rb
@@ -266,14 +266,14 @@ module BulkImportIdeas::Exporters
       optional = I18n.with_locale(@locale) { I18n.t('form_builder.pdf_export.optional') }
 
       pdf.text(
-        "<b>#{custom_field.title_multiloc[@locale]}</b>#{custom_field.required? ? '' : " (#{optional})"}",
+        "<b>#{custom_field_service.handle_title(custom_field, @locale)}</b>#{custom_field.required? ? '' : " (#{optional})"}",
         size: 14,
         inline_format: true
       )
     end
 
     def write_description(pdf, custom_field)
-      description = custom_field.description_multiloc[@locale]
+      description = custom_field_service.handle_description(custom_field, @locale)
       if description.present?
         paragraphs = parse_html_tags(description)
 
@@ -313,7 +313,7 @@ module BulkImportIdeas::Exporters
         pdf.move_up 3.mm
 
         pdf.indent(7.mm) do
-          pdf.text handle_option_title(option)
+          pdf.text custom_field_service.handle_title(option, @locale)
         end
 
         pdf.move_down 4.mm
@@ -334,7 +334,7 @@ module BulkImportIdeas::Exporters
         pdf.move_up 2.8.mm
 
         pdf.indent(7.mm) do
-          pdf.text handle_option_title(option)
+          pdf.text custom_field_service.handle_title(option, @locale)
         end
 
         pdf.move_down 4.mm
@@ -373,14 +373,13 @@ module BulkImportIdeas::Exporters
       position = (810 - position) / 8.1 # Convert the position into equivalent of what form parser returns
       key = field[:key]
       parent_key = type == 'option' ? field.custom_field.key : nil
-      title = type == 'option' ? handle_option_title(field) : field[:title_multiloc][@locale]
 
       # Because of the way pdf group works we delete if value is already there and always use the last value for the field
       @importer_fields.delete_if { |f| f[:key] == key && f[:parent_key] == parent_key }
 
       # In IdeaPdfFileParser#merge_idea_with_form_fields, we add :value key to this hash.
       @importer_fields << {
-        name: title,
+        name: custom_field_service.handle_title(field, @locale),
         description: type == 'field' ? ActionView::Base.full_sanitizer.sanitize(field[:description_multiloc][@locale]) : nil,
         type: type,
         input_type: field[:input_type],

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_pdf_form_exporter.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_pdf_form_exporter.rb
@@ -373,7 +373,7 @@ module BulkImportIdeas::Exporters
       position = (810 - position) / 8.1 # Convert the position into equivalent of what form parser returns
       key = field[:key]
       parent_key = type == 'option' ? field.custom_field.key : nil
-      title = type == 'option' ? handle_option_title(option) : field[:title_multiloc][@locale]
+      title = type == 'option' ? handle_option_title(field) : field[:title_multiloc][@locale]
 
       # Because of the way pdf group works we delete if value is already there and always use the last value for the field
       @importer_fields.delete_if { |f| f[:key] == key && f[:parent_key] == parent_key }

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_xlsx_form_exporter.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_xlsx_form_exporter.rb
@@ -19,13 +19,13 @@ module BulkImportIdeas::Exporters
 
       xlsx_utils = Export::Xlsx::Utils.new
       @form_fields.each do |field|
-        column_name = xlsx_utils.add_duplicate_column_name_suffix(field.title_multiloc[@locale])
+        column_name = xlsx_utils.add_duplicate_column_name_suffix(custom_field_service.handle_title(field, @locale))
 
         value = case field.input_type
         when 'select'
-          handle_option_title(field.options.first)
+          custom_field_service.handle_title(field.options.first, @locale)
         when 'multiselect', 'multiselect_image'
-          field.options.map { |o| handle_option_title(o) }.join '; '
+          field.options.map { |o| custom_field_service.handle_title(o, @locale) }.join '; '
         when 'topic_ids'
           @project.allowed_input_topics.map { |t| t.title_multiloc[@locale] }.join '; '
         when 'number', 'linear_scale'
@@ -60,7 +60,7 @@ module BulkImportIdeas::Exporters
     def importer_data
       fields = @form_fields.map do |field|
         {
-          name: field[:title_multiloc][@locale],
+          name: custom_field_service.handle_title(field, @locale),
           type: 'field',
           input_type: field[:input_type],
           code: field[:code],
@@ -73,7 +73,7 @@ module BulkImportIdeas::Exporters
       options = @form_fields.map do |field|
         field.options.map do |option|
           {
-            name: handle_option_title(option),
+            name: custom_field_service.handle_title(option, @locale),
             type: 'option',
             input_type: 'option',
             code: option[:code],

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_xlsx_form_exporter.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_xlsx_form_exporter.rb
@@ -23,9 +23,9 @@ module BulkImportIdeas::Exporters
 
         value = case field.input_type
         when 'select'
-          field.options.first.title_multiloc[@locale]
+          handle_option_title(field.options.first)
         when 'multiselect', 'multiselect_image'
-          field.options.map { |o| o.title_multiloc[@locale] }.join '; '
+          field.options.map { |o| handle_option_title(o) }.join '; '
         when 'topic_ids'
           @project.allowed_input_topics.map { |t| t.title_multiloc[@locale] }.join '; '
         when 'number', 'linear_scale'
@@ -73,7 +73,7 @@ module BulkImportIdeas::Exporters
       options = @form_fields.map do |field|
         field.options.map do |option|
           {
-            name: option[:title_multiloc][@locale],
+            name: handle_option_title(option),
             type: 'option',
             input_type: 'option',
             code: option[:code],

--- a/back/spec/services/custom_field_service_spec.rb
+++ b/back/spec/services/custom_field_service_spec.rb
@@ -206,4 +206,34 @@ describe CustomFieldService do
       expect(service.keyify(str)[0..-5]).to eq '0123456789_abcdefghijklmnopqrstuvwxyz___abcdefghijklmnopqrstuvwxyz_aaaaaaaeceeeeiiiidnoooooxouuuuythssaaaaaaaeceeeeiiiidnooooo_ouuuuythy'
     end
   end
+
+  describe 'handle_title' do
+    it 'returns the title in the requested locale' do
+      field = create(:custom_field, title_multiloc: { 'en' => 'size', 'nl-NL' => 'grootte' })
+      expect(service.handle_title(field, 'en')).to eq 'size'
+      expect(service.handle_title(field, 'nl-NL')).to eq 'grootte'
+    end
+
+    it 'returns the title from the first available locale if the requested locale is not available' do
+      field = create(:custom_field, title_multiloc: { 'en' => 'size', 'fr-FR' => 'taille' })
+      expect(service.handle_title(field, 'en')).to eq 'size'
+      expect(service.handle_title(field, 'fr-FR')).to eq 'taille'
+      expect(service.handle_title(field, 'nl-NL')).to eq 'size'
+    end
+  end
+
+  describe 'handle_description' do
+    it 'returns the description in the requested locale' do
+      field = create(:custom_field, description_multiloc: { 'en' => 'carrot', 'nl-NL' => 'wortel' })
+      expect(service.handle_description(field, 'en')).to eq 'carrot'
+      expect(service.handle_description(field, 'nl-NL')).to eq 'wortel'
+    end
+
+    it 'returns the description from the first available locale if the requested locale is not available' do
+      field = create(:custom_field, description_multiloc: { 'en' => 'carrot', 'fr-FR' => 'carrotte' })
+      expect(service.handle_description(field, 'en')).to eq 'carrot'
+      expect(service.handle_description(field, 'fr-FR')).to eq 'carrotte'
+      expect(service.handle_description(field, 'nl-NL')).to eq 'carrot'
+    end
+  end
 end


### PR DESCRIPTION
# Changelog
## Fixed
- TAN-2688 - Custom field options and titles in PDF and XLSX form exports fall back to the first locale found if the requested locale is not present. This brings it in line with what happens on the web forms.
