### PR TITLE
TAN-2684 - Fix for deleting reactions when reactions are limited

### DIFF
--- a/back/app/policies/idea_reaction_policy.rb
+++ b/back/app/policies/idea_reaction_policy.rb
@@ -42,7 +42,7 @@ class IdeaReactionPolicy < ApplicationPolicy
   def destroy?
     return false unless could_modify?
 
-    reason = permissions_service.denied_reason_for_reaction_mode record.mode
+    reason = permissions_service.denied_reason_for_reaction_mode(record.mode, delete_action: true)
     reason ? raise_not_authorized(reason) : true
   end
 

--- a/back/app/services/permissions/idea_permissions_service.rb
+++ b/back/app/services/permissions/idea_permissions_service.rb
@@ -9,7 +9,7 @@ module Permissions
       @idea ||= idea
     end
 
-    def denied_reason_for_action(action, reaction_mode: nil)
+    def denied_reason_for_action(action, reaction_mode: nil, delete_action: false)
       reason = super
       return reason if reason
 
@@ -19,8 +19,8 @@ module Permissions
       end
     end
 
-    def denied_reason_for_reaction_mode(reaction_mode)
-      denied_reason_for_action('reacting_idea', reaction_mode: reaction_mode)
+    def denied_reason_for_reaction_mode(reaction_mode, delete_action: false)
+      denied_reason_for_action('reacting_idea', reaction_mode: reaction_mode, delete_action: delete_action)
     end
 
     def action_descriptors

--- a/back/app/services/permissions/phase_permissions_service.rb
+++ b/back/app/services/permissions/phase_permissions_service.rb
@@ -52,7 +52,7 @@ module Permissions
       @phase ||= phase
     end
 
-    def denied_reason_for_action(action, reaction_mode: nil)
+    def denied_reason_for_action(action, reaction_mode: nil, delete_action: false)
       return PHASE_DENIED_REASONS[:project_inactive] unless phase || IGNORED_PHASE_ACTIONS.include?(action)
 
       phase_denied_reason = case action
@@ -61,7 +61,7 @@ module Permissions
       when 'commenting_idea'
         commenting_idea_denied_reason_for_action
       when 'reacting_idea'
-        reacting_denied_reason_for_action(reaction_mode: reaction_mode)
+        reacting_denied_reason_for_action(reaction_mode: reaction_mode, delete_action: delete_action)
       when 'voting'
         voting_denied_reason_for_action
       when 'annotating_document'
@@ -105,16 +105,17 @@ module Permissions
       end
     end
 
-    def reacting_denied_reason_for_action(reaction_mode: nil)
+    # NOTE: some reasons should not be returned if trying to delete a reaction (delete_action: true)
+    def reacting_denied_reason_for_action(reaction_mode: nil, delete_action: false)
       if !participation_method.supports_reacting?
         REACTING_DENIED_REASONS[:reacting_not_supported]
       elsif !phase.reacting_enabled
         REACTING_DENIED_REASONS[:reacting_disabled]
       elsif reaction_mode == 'down' && !phase.reacting_dislike_enabled
         REACTING_DENIED_REASONS[:reacting_dislike_disabled]
-      elsif reaction_mode == 'up' && user && liking_limit_reached?
+      elsif reaction_mode == 'up' && user && liking_limit_reached? && !delete_action
         REACTING_DENIED_REASONS[:reacting_like_limited_max_reached]
-      elsif reaction_mode == 'down' && user && disliking_limit_reached?
+      elsif reaction_mode == 'down' && user && disliking_limit_reached? && !delete_action
         REACTING_DENIED_REASONS[:reacting_dislike_limited_max_reached]
       end
     end

--- a/back/app/services/permissions/project_permissions_service.rb
+++ b/back/app/services/permissions/project_permissions_service.rb
@@ -12,7 +12,7 @@ module Permissions
       @project ||= project
     end
 
-    def denied_reason_for_action(action, reaction_mode: nil)
+    def denied_reason_for_action(action, reaction_mode: nil, delete_action: false)
       project_visible_disabled_reason || project_archived_disabled_reason || super
     end
 

--- a/back/spec/services/permissions/idea_permissions_service_spec.rb
+++ b/back/spec/services/permissions/idea_permissions_service_spec.rb
@@ -280,6 +280,11 @@ describe Permissions::IdeaPermissionsService do
         expect(service.denied_reason_for_reaction_mode('down')).to be_nil
       end
 
+      it 'does not return `reacting_like_limited_max_reached` when deleting a reaction' do
+        create(:reaction, mode: 'up', user: user, reactable: input)
+        expect(service.denied_reason_for_reaction_mode('up', delete_action: true)).to be_nil
+      end
+
       it 'returns nil if the like limit was not reached' do
         create(:reaction, mode: 'down', user: user, reactable: input)
         expect(service.denied_reason_for_reaction_mode('up')).to be_nil


### PR DESCRIPTION
# Changelog
## Fixed
- TAN-2684 - Fix for deleting reactions when reactions are limited
