### PR TITLE
[TAN-2646] Use mj-preview for mail preheaders

### DIFF
--- a/back/app/mailers/application_mailer.rb
+++ b/back/app/mailers/application_mailer.rb
@@ -24,7 +24,7 @@ class ApplicationMailer < ActionMailer::Base
   NotImplementedError = Class.new(StandardError)
 
   def format_message(key, component: nil, escape_html: true, values: {})
-    msg = t(".#{key}", values)
+    msg = t(".#{key}", **values)
     escape_html ? msg : msg.html_safe
   end
 

--- a/back/app/mailers/confirmations_mailer.rb
+++ b/back/app/mailers/confirmations_mailer.rb
@@ -11,17 +11,17 @@ class ConfirmationsMailer < ApplicationMailer
     end
   end
 
+  def preheader
+    format_message('preheader', values: { organizationName: organization_name })
+  end
+
   def to_email
     email = recipient.new_email.presence || recipient.email
     email_address_with_name(email, "#{recipient.first_name} #{recipient.last_name}")
   end
 
   def subject
-    t('.subject', organizationName: organization_name)
-  end
-
-  def preheader
-    t('.preheader', organizationName: organization_name)
+    format_message('subject', values: { organizationName: organization_name })
   end
 
   def header_logo_only?

--- a/back/app/mailers/confirmations_mailer.rb
+++ b/back/app/mailers/confirmations_mailer.rb
@@ -11,10 +11,6 @@ class ConfirmationsMailer < ApplicationMailer
     end
   end
 
-  def preheader
-    t('.preheader', organizationName: organization_name)
-  end
-
   def to_email
     email = recipient.new_email.presence || recipient.email
     email_address_with_name(email, "#{recipient.first_name} #{recipient.last_name}")

--- a/back/app/mailers/confirmations_mailer.rb
+++ b/back/app/mailers/confirmations_mailer.rb
@@ -20,6 +20,10 @@ class ConfirmationsMailer < ApplicationMailer
     t('.subject', organizationName: organization_name)
   end
 
+  def preheader
+    t('.preheader', organizationName: organization_name)
+  end
+
   def header_logo_only?
     true
   end

--- a/back/app/mailers/reset_password_mailer.rb
+++ b/back/app/mailers/reset_password_mailer.rb
@@ -13,11 +13,11 @@ class ResetPasswordMailer < ApplicationMailer
   end
 
   def preheader
-    t('.preheader', organizationName: organization_name)
+    format_message('preheader', values: { organizationName: organization_name })
   end
 
   def subject
-    t('.subject', organizationName: organization_name)
+    format_message('subject', values: { organizationName: organization_name })
   end
 
   def header_logo_only?

--- a/back/app/mailers/reset_password_mailer.rb
+++ b/back/app/mailers/reset_password_mailer.rb
@@ -12,10 +12,6 @@ class ResetPasswordMailer < ApplicationMailer
     end
   end
 
-  def preheader
-    t('.preheader', organizationName: organization_name)
-  end
-
   def subject
     t('.subject', organizationName: organization_name)
   end

--- a/back/app/mailers/reset_password_mailer.rb
+++ b/back/app/mailers/reset_password_mailer.rb
@@ -12,6 +12,10 @@ class ResetPasswordMailer < ApplicationMailer
     end
   end
 
+  def preheader
+    t('.preheader', organizationName: organization_name)
+  end
+
   def subject
     t('.subject', organizationName: organization_name)
   end

--- a/back/app/mailers/user_blocked_mailer.rb
+++ b/back/app/mailers/user_blocked_mailer.rb
@@ -12,11 +12,11 @@ class UserBlockedMailer < ApplicationMailer
   end
 
   def preheader
-    t('.preheader', organizationName: organization_name)
+    format_message('preheader', values: { organizationName: organization_name })
   end
 
   def subject
-    t('.subject', organizationName: organization_name)
+    format_message('subject', values: { organizationName: organization_name })
   end
 
   def header_logo_only?

--- a/back/app/mailers/user_blocked_mailer.rb
+++ b/back/app/mailers/user_blocked_mailer.rb
@@ -11,10 +11,6 @@ class UserBlockedMailer < ApplicationMailer
     end
   end
 
-  def preheader
-    t('.preheader', organizationName: organization_name)
-  end
-
   def subject
     t('.subject', organizationName: organization_name)
   end

--- a/back/app/mailers/user_blocked_mailer.rb
+++ b/back/app/mailers/user_blocked_mailer.rb
@@ -11,6 +11,10 @@ class UserBlockedMailer < ApplicationMailer
     end
   end
 
+  def preheader
+    t('.preheader', organizationName: organization_name)
+  end
+
   def subject
     t('.subject', organizationName: organization_name)
   end

--- a/back/config/locales/en.yml
+++ b/back/config/locales/en.yml
@@ -233,6 +233,7 @@ en:
       <ul><li>Take the time to elaborate on your proposal. If necessary, type a draft first and then copy-paste it here.</li><li>Choose a meaningful title that explains clearly what your proposal entails.</li><li>Visualize your proposal with a fitting image to help it stand out!</li><li>Add relevant attachments, such as videos, inspiring examples, technical details or plans.</li><li>Share your idea on social media and other channels to gather support from others.</li></ul>
   reset_password_mailer:
     send_reset_password:
+      preheader: 'Reset your password for %{organizationName}'
       cta_reset_password: 'Reset your password'
       message_you_reset_your_password: 'You requested a password reset for the participation platform of %{organizationName}. Click the button below to choose a new, safe password. The link expires in 1 hour.'
       subject: '%{organizationName}: Reset your password'
@@ -310,6 +311,7 @@ en:
   confirmations_mailer:
     send_confirmation_code:
       subject: "Confirm your email address for %{organizationName}'s participation platform"
+      preheader: 'Confirm your email address for %{organizationName}'
       header: "Your Confirmation Code"
       header_message: "Hi %{firstName}!"
       confirm_email_address: "Confirm your email address"
@@ -324,6 +326,7 @@ en:
   user_blocked_mailer:
     send_user_blocked_email:
       subject: 'Your account has been temporarily disabled'
+      preheader: 'Your account on the participation platform of %{organizationName} has been temporarily disabled'
       title_user_blocked: 'Your account has been temporarily disabled'
       paragraph_1_without_reason: "Your account on the participation platform of %{organizationName} has been temporarily disabled for a violation of the community guidelines."
       paragraph_1_with_reason: "Your account on the participation platform of %{organizationName} has been temporarily disabled for the following reason:"

--- a/back/config/locales/en.yml
+++ b/back/config/locales/en.yml
@@ -233,7 +233,6 @@ en:
       <ul><li>Take the time to elaborate on your proposal. If necessary, type a draft first and then copy-paste it here.</li><li>Choose a meaningful title that explains clearly what your proposal entails.</li><li>Visualize your proposal with a fitting image to help it stand out!</li><li>Add relevant attachments, such as videos, inspiring examples, technical details or plans.</li><li>Share your idea on social media and other channels to gather support from others.</li></ul>
   reset_password_mailer:
     send_reset_password:
-      preheader: 'Reset your password for %{organizationName}'
       cta_reset_password: 'Reset your password'
       message_you_reset_your_password: 'You requested a password reset for the participation platform of %{organizationName}. Click the button below to choose a new, safe password. The link expires in 1 hour.'
       subject: '%{organizationName}: Reset your password'
@@ -311,7 +310,6 @@ en:
   confirmations_mailer:
     send_confirmation_code:
       subject: "Confirm your email address for %{organizationName}'s participation platform"
-      preheader: 'Confirm your email address for %{organizationName}'
       header: "Your Confirmation Code"
       header_message: "Hi %{firstName}!"
       confirm_email_address: "Confirm your email address"
@@ -326,7 +324,6 @@ en:
   user_blocked_mailer:
     send_user_blocked_email:
       subject: 'Your account has been temporarily disabled'
-      preheader: 'Your account on the participation platform of %{organizationName} has been temporarily disabled'
       title_user_blocked: 'Your account has been temporarily disabled'
       paragraph_1_without_reason: "Your account on the participation platform of %{organizationName} has been temporarily disabled for a violation of the community guidelines."
       paragraph_1_with_reason: "Your account on the participation platform of %{organizationName} has been temporarily disabled for the following reason:"

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/event_registration_confirmation_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/event_registration_confirmation_mailer.rb
@@ -20,10 +20,6 @@ module EmailCampaigns
 
     private
 
-    def preheader
-      format_message('preheader', values: { firstName: recipient.first_name, eventTitle: event_title })
-    end
-
     def subject
       format_message('subject', values: {
         organizationName: organization_name,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/invite_received_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/invite_received_mailer.rb
@@ -6,10 +6,6 @@ module EmailCampaigns
 
     protected
 
-    def preheader
-      format_message('preheader', values: { organizationName: organization_name })
-    end
-
     def subject
       format_message('subject', values: { organizationName: organization_name })
     end

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/official_feedback_on_idea_you_follow_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/official_feedback_on_idea_you_follow_mailer.rb
@@ -10,10 +10,6 @@ module EmailCampaigns
       localize_for_recipient(event.official_feedback_author_multiloc)
     end
 
-    def preheader
-      format_message('preheader')
-    end
-
     def subject
       format_message('subject', values: { organizationName: organization_name })
     end

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/official_feedback_on_initiative_you_follow_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/official_feedback_on_initiative_you_follow_mailer.rb
@@ -10,10 +10,6 @@ module EmailCampaigns
       localize_for_recipient(event.official_feedback_author_multiloc)
     end
 
-    def preheader
-      format_message('preheader')
-    end
-
     def subject
       format_message('subject', values: { organizationName: organization_name })
     end

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/project_moderation_rights_received_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/project_moderation_rights_received_mailer.rb
@@ -4,10 +4,6 @@ module EmailCampaigns
   class ProjectModerationRightsReceivedMailer < ApplicationMailer
     protected
 
-    def preheader
-      format_message('preheader', values: { organizationName: organization_name })
-    end
-
     def subject
       format_message('subject', values: { organizationName: organization_name })
     end

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/project_published_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/project_published_mailer.rb
@@ -4,10 +4,6 @@ module EmailCampaigns
   class ProjectPublishedMailer < ApplicationMailer
     private
 
-    def preheader
-      format_message('preheader')
-    end
-
     def subject
       format_message('subject', values: { organizationName: organization_name })
     end

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/status_change_on_idea_you_follow_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/status_change_on_idea_you_follow_mailer.rb
@@ -4,10 +4,6 @@ module EmailCampaigns
   class StatusChangeOnIdeaYouFollowMailer < ApplicationMailer
     private
 
-    def preheader
-      format_message('preheader')
-    end
-
     def subject
       format_message('subject')
     end

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/status_change_on_initiative_you_follow_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/status_change_on_initiative_you_follow_mailer.rb
@@ -4,10 +4,6 @@ module EmailCampaigns
   class StatusChangeOnInitiativeYouFollowMailer < ApplicationMailer
     private
 
-    def preheader
-      format_message('preheader')
-    end
-
     def subject
       format_message('subject')
     end

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/user_digest_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/user_digest_mailer.rb
@@ -4,10 +4,6 @@ module EmailCampaigns
   class UserDigestMailer < ApplicationMailer
     private
 
-    def preheader
-      format_message('preheader', values: { organizationName: organization_name })
-    end
-
     def subject
       format_message('subject', values: { organizationName: organization_name })
     end

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/welcome_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/welcome_mailer.rb
@@ -4,10 +4,6 @@ module EmailCampaigns
   class WelcomeMailer < ApplicationMailer
     protected
 
-    def preheader
-      format_message('preheader', values: { organizationName: organization_name })
-    end
-
     def subject
       format_message('subject', values: { organizationName: organization_name })
     end

--- a/back/engines/free/email_campaigns/config/locales/en.yml
+++ b/back/engines/free/email_campaigns/config/locales/en.yml
@@ -82,8 +82,6 @@ en:
       "unsubscribe_text": "unsubscribe"
     follow:
       "unfollow_here": "You have received this notification because of an item that you follow. <a href=\"%{unfollow_url}\">You can unfollow it here.</a>"
-    manual:
-      preheader: 'You have mail from %{organizationName}' 
     comment_deleted_by_admin:
       reason: 'The reason why your comment was deleted:'
       cta_view: 'View this idea'
@@ -542,7 +540,6 @@ en:
       cta_see_results: 'See results in the platform'
     event_registration_confirmation:
       subject: "You're in! Your registration for \"%{eventTitle}\" is confirmed"
-      preheader: "%{firstName}, thanks for registering for %{eventTitle}"
       header_message: "%{firstName}, thanks for registering for"
       event_details:
         labels:


### PR DESCRIPTION
RELEASE AFTER #8918 IS RELEASED

- Switches to using the `mj-preview` tag, since that is what it is specifically designed for.
- Adds preheaders to 3 core campaigns, as also seen in #8918, just to get specs passing in this PR. Otherwise, they would fail with
```
Failure/Error: msg = t(".#{key}", values)
     
     ActionView::Template::Error:
       wrong number of arguments (given 2, expected 1)
```

https://documentation.mjml.io/#mj-preview

The documentation doesn't say so, but the tag must be used within the `mj-head` element.

I think the original approach worked by setting the text to transparent and the `<span>` to hidden and of zero size, and maybe we don't need to try using `mj-preview` if that works (though it is quite hacky).

## Notes on testing
It's hard to find a way to really test this without releasing it and seeing what happens (via a temporary active platform).

I cannot find a way to test the preheader in our mailer specs, and in any case that wouldn't prove the preheader is shown in mail client email lists.

# Changelog
## Technical
- [TAN-2646] Use mj-preview tag inside mj-head
