### PR TITLE
[TAN-2554] Remove event description from mail and ics event

### DIFF
--- a/back/app/services/events/ics_generator.rb
+++ b/back/app/services/events/ics_generator.rb
@@ -82,11 +82,9 @@ module Events
       return online_link if online_link.present?
 
       tenant_locales = AppConfiguration.instance.settings('core', 'locales')
-
       locale = tenant_locales.include?(preferred_locale) ? preferred_locale : tenant_locales.first
-      locale = Locale.new(locale)
 
-      Frontend::UrlService.new.model_to_url(event, locale: locale)
+      Frontend::UrlService.new.model_to_url(event, locale: Locale.new(locale))
     end
 
     def multiloc_service

--- a/back/app/services/events/ics_generator.rb
+++ b/back/app/services/events/ics_generator.rb
@@ -59,7 +59,7 @@ module Events
         # The interpretation of the URL property seems to differ widely depending on its
         # value and the calendar app. Most of them will just ignore the property if they
         # don't recognize a well-known video conferencing service in the URL.
-        e.url = event.online_link
+        e.url = event_url(event, preferred_locale)
 
         e.geo = [event.location_point.y, event.location_point.x] if event.location_point
       end
@@ -75,6 +75,19 @@ module Events
       address += "\n(#{address_details})" if address_details.present?
 
       address.presence
+    end
+
+    def event_url(event, preferred_locale)
+      online_link = event.online_link
+      return online_link if online_link.present?
+
+      tenant_locales = AppConfiguration.instance.settings('core', 'locales')
+
+      locale = tenant_locales.include?(preferred_locale) ? preferred_locale : tenant_locales.first
+      locale = Locale.new(locale)
+
+      frontend_service = Frontend::UrlService.new
+      frontend_service.model_to_url(event, locale: locale)
     end
 
     def multiloc_service

--- a/back/app/services/events/ics_generator.rb
+++ b/back/app/services/events/ics_generator.rb
@@ -54,7 +54,7 @@ module Events
         e.dtend = Icalendar::Values::DateTime.new(end_time, tzid: tzid)
 
         e.summary = multiloc_service.t(event.title_multiloc, preferred_locale)
-        e.description = "Event details: #{event_url(event, preferred_locale)}"
+        e.description = event_description(event, preferred_locale)
         e.location = full_address(event, preferred_locale)
 
         # The interpretation of the URL property seems to differ widely depending on its
@@ -78,11 +78,14 @@ module Events
       address.presence
     end
 
-    def event_url(event, preferred_locale)
+    def event_description(event, preferred_locale)
       tenant_locales = AppConfiguration.instance.settings('core', 'locales')
       locale = tenant_locales.include?(preferred_locale) ? preferred_locale : tenant_locales.first
 
-      Frontend::UrlService.new.model_to_url(event, locale: Locale.new(locale))
+      event_details = I18n.with_locale(locale) { I18n.t('ics_calendar_event.event_details') }
+      event_url = Frontend::UrlService.new.model_to_url(event, locale: Locale.new(locale))
+
+      "#{event_details}: #{event_url}"
     end
 
     def multiloc_service

--- a/back/app/services/events/ics_generator.rb
+++ b/back/app/services/events/ics_generator.rb
@@ -86,8 +86,7 @@ module Events
       locale = tenant_locales.include?(preferred_locale) ? preferred_locale : tenant_locales.first
       locale = Locale.new(locale)
 
-      frontend_service = Frontend::UrlService.new
-      frontend_service.model_to_url(event, locale: locale)
+      Frontend::UrlService.new.model_to_url(event, locale: locale)
     end
 
     def multiloc_service

--- a/back/app/services/events/ics_generator.rb
+++ b/back/app/services/events/ics_generator.rb
@@ -54,12 +54,13 @@ module Events
         e.dtend = Icalendar::Values::DateTime.new(end_time, tzid: tzid)
 
         e.summary = multiloc_service.t(event.title_multiloc, preferred_locale)
+        e.description = "Event details: #{event_url(event, preferred_locale)}"
         e.location = full_address(event, preferred_locale)
 
         # The interpretation of the URL property seems to differ widely depending on its
         # value and the calendar app. Most of them will just ignore the property if they
         # don't recognize a well-known video conferencing service in the URL.
-        e.url = event_url(event, preferred_locale)
+        e.url = event.online_link
 
         e.geo = [event.location_point.y, event.location_point.x] if event.location_point
       end
@@ -78,9 +79,6 @@ module Events
     end
 
     def event_url(event, preferred_locale)
-      online_link = event.online_link
-      return online_link if online_link.present?
-
       tenant_locales = AppConfiguration.instance.settings('core', 'locales')
       locale = tenant_locales.include?(preferred_locale) ? preferred_locale : tenant_locales.first
 

--- a/back/app/services/events/ics_generator.rb
+++ b/back/app/services/events/ics_generator.rb
@@ -54,7 +54,6 @@ module Events
         e.dtend = Icalendar::Values::DateTime.new(end_time, tzid: tzid)
 
         e.summary = multiloc_service.t(event.title_multiloc, preferred_locale)
-        e.description = multiloc_service.t(event.description_multiloc, preferred_locale)
         e.location = full_address(event, preferred_locale)
 
         # The interpretation of the URL property seems to differ widely depending on its

--- a/back/config/locales/en.yml
+++ b/back/config/locales/en.yml
@@ -339,3 +339,5 @@ en:
   voting_method:
     default_voting_term_singular: "vote"
     default_voting_term_plural: "votes"
+  ics_calendar_event:
+    event_details: "Event details"

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/event_registration_confirmation_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/event_registration_confirmation_mailer.rb
@@ -58,11 +58,6 @@ module EmailCampaigns
       location.presence
     end
 
-    def event_description
-      description = localize_for_recipient(event.event_attributes.description_multiloc)
-      strip_tags(description).presence
-    end
-
     def project_title
       localize_for_recipient(event.project_title_multiloc)
     end

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/project_phase_started.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/project_phase_started.rb
@@ -79,7 +79,6 @@ module EmailCampaigns
         [{
           event_payload: {
             phase_title_multiloc: notification.phase.title_multiloc,
-            phase_description_multiloc: notification.phase.description_multiloc,
             phase_start_at: notification.phase.start_at.iso8601,
             phase_end_at: notification.phase.end_at&.iso8601,
             phase_url: Frontend::UrlService.new.model_to_url(notification.phase, locale: Locale.new(recipient.locale)),

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/project_phase_upcoming.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/project_phase_upcoming.rb
@@ -77,7 +77,6 @@ module EmailCampaigns
       [{
         event_payload: {
           phase_title_multiloc: notification.phase.title_multiloc,
-          phase_description_multiloc: notification.phase.description_multiloc,
           phase_start_at: notification.phase.start_at.iso8601,
           phase_end_at: notification.phase.end_at&.iso8601,
           phase_url: Frontend::UrlService.new.model_to_url(notification.phase, locale: Locale.new(recipient.locale)),

--- a/back/engines/free/email_campaigns/app/views/email_campaigns/event_registration_confirmation_mailer/campaign_mail.mjml
+++ b/back/engines/free/email_campaigns/app/views/email_campaigns/event_registration_confirmation_mailer/campaign_mail.mjml
@@ -27,14 +27,6 @@
       } %>
     <% end %>
 
-    <% if event_description.present? %>
-      <%= render partial: 'event_details_generic_item', locals: {
-        label: format_message('event_details.labels.description'),
-        text: event_description,
-        color: "#892FD3"
-      } %>
-    <% end %>
-
     <%= render partial: 'event_details_project_item' %>
   </mj-column>
 </mj-section>

--- a/back/engines/free/email_campaigns/app/views/email_campaigns/project_phase_started_mailer/campaign_mail.mjml
+++ b/back/engines/free/email_campaigns/app/views/email_campaigns/project_phase_started_mailer/campaign_mail.mjml
@@ -6,9 +6,6 @@
   <mj-column border-radius="5px" background-color="#F2F6F8" padding="25px">
     <mj-text font-size="14px">
       <%= format_message('new_phase', values: { phaseTitle: localize_for_recipient(event.phase_title_multiloc) }) %>
-      <p style="margin: 15px 0 0;">
-        <%= localize_for_recipient(event.phase_description_multiloc) %>
-      </p>
     </mj-text>
   </mj-column>
 </mj-section>

--- a/back/engines/free/email_campaigns/app/views/email_campaigns/project_phase_upcoming_mailer/campaign_mail.mjml
+++ b/back/engines/free/email_campaigns/app/views/email_campaigns/project_phase_upcoming_mailer/campaign_mail.mjml
@@ -6,9 +6,6 @@
   <mj-column border-radius="5px" background-color="#F2F6F8" padding="25px" vertical-align="middle" >
     <mj-text font-size="14px">
       <%= format_message('new_phase', values: { phaseTitle: localize_for_recipient(event.phase_title_multiloc) }) %>
-      <p style="margin: 15px 0 0;">
-        <%= localize_for_recipient(event.phase_description_multiloc) %>
-      </p>
     </mj-text>
   </mj-column>
 </mj-section>

--- a/back/engines/free/email_campaigns/spec/mailers/event_registration_confirmation_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/event_registration_confirmation_mailer_spec.rb
@@ -131,23 +131,6 @@ RSpec.describe EmailCampaigns::EventRegistrationConfirmationMailer do
         end
       end
 
-      context 'when the event has a description' do
-        include ActionView::Helpers::SanitizeHelper
-
-        it 'contains the description' do
-          # Sanity check
-          event_description = event_attributes['description_multiloc']
-          expect(event_description).to be_present
-
-          # Check for presence of:
-          # <div> Description </div>
-          # <div ...> Be there and learn everything about our future! </div>
-          label_div = page.find('div', exact_text: /\s*Description\s*/)
-          description = strip_tags(event_description[recipient.locale])
-          expect(label_div).to have_css('+ div', text: description)
-        end
-      end
-
       context 'when the event has no description' do
         before do
           event_attributes['description_multiloc'] = {}

--- a/back/engines/free/email_campaigns/spec/mailers/previews/email_campaigns/project_phase_started_mailer_preview.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/previews/email_campaigns/project_phase_started_mailer_preview.rb
@@ -12,7 +12,6 @@ module EmailCampaigns
         recipient: recipient_user,
         event_payload: {
           phase_title_multiloc: { 'en' => 'Being implemented' },
-          phase_description_multiloc: { 'en' => 'Project is now being implemented' },
           phase_start_at: Time.zone.today.prev_day.iso8601,
           phase_end_at: Time.zone.today.next_month.iso8601,
           phase_url: 'demo.stg.govocal.com',

--- a/back/spec/services/events/ics_generator_spec.rb
+++ b/back/spec/services/events/ics_generator_spec.rb
@@ -49,10 +49,11 @@ RSpec.describe Events::IcsGenerator do
         UID:%UID_PLACEHOLDER%
         DTSTART;TZID=America/New_York:20170501T160000
         DTEND;TZID=America/New_York:20170501T180000
-        DESCRIPTION:<p>Be there and learn everything about our future!</p>
         GEO:50.8465574798584;4.351710319519043
         LOCATION:Atomiumsquare 1\\, 1020 Brussels\\, Belgium\\n(Sphere 1)
         SUMMARY:Info session
+        URL;VALUE=URI:http://example.org/en/events/#{event.id[..-5]}
+         #{event.id[-4..]}
         END:VEVENT
         END:VCALENDAR
       ICS
@@ -91,7 +92,6 @@ RSpec.describe Events::IcsGenerator do
       ics_string = ics_generator.generate_ics(event, 'fa-KE')
 
       expect(ics_string).to include("SUMMARY:#{event.title_multiloc['en']}")
-      expect(ics_string).to include("DESCRIPTION:#{event.description_multiloc['en']}")
       expect(ics_string).to include(event.address_2_multiloc['en'])
     end
   end

--- a/back/spec/services/events/ics_generator_spec.rb
+++ b/back/spec/services/events/ics_generator_spec.rb
@@ -49,11 +49,11 @@ RSpec.describe Events::IcsGenerator do
         UID:%UID_PLACEHOLDER%
         DTSTART;TZID=America/New_York:20170501T160000
         DTEND;TZID=America/New_York:20170501T180000
+        DESCRIPTION:Event details: http://example.org/en/events/#{event.id[..-18]}
+         #{event.id[-17..]}
         GEO:50.8465574798584;4.351710319519043
         LOCATION:Atomiumsquare 1\\, 1020 Brussels\\, Belgium\\n(Sphere 1)
         SUMMARY:Info session
-        URL;VALUE=URI:http://example.org/en/events/#{event.id[..-5]}
-         #{event.id[-4..]}
         END:VEVENT
         END:VCALENDAR
       ICS


### PR DESCRIPTION
This PR removes descriptions, derived from WYSIWYG input, from 3 emails and the ics calendar event related to an Event.

The reasoning is that WYSIWYG input can result in relatively complex (HTML) formatting that we do not attempt to recreate in MJML, and thus it can look 'messy' and hard to understand.

Also adds the event model URL to the ics calendar event description.

## Screenshots of exported calendar ics events
<details>
  <summary> Screenshot [Click me]</summary>

<img width="304" alt="Screenshot 2024-09-20 at 09 23 58" src="https://github.com/user-attachments/assets/91a6ec50-6bdc-4a31-b872-1b4c876d8354">


</details>

# Changelog
## Fixed
- [TAN-2554] Remove event description from mail and ics event. This avoids the bad formatting of the description that would occur when formatting was added (bullets, etc.)