### PR TITLE
Increase memory limit

### DIFF
--- a/front/internals/webpack/webpack.config.js
+++ b/front/internals/webpack/webpack.config.js
@@ -150,6 +150,7 @@ const config = {
         configFile: path.join(process.cwd(), 'app/tsconfig.json'),
       },
       logger: { infrastructure: !!argv.json ? 'silent' : 'console' }, // silent when trying to profile the chunks sizes
+      memoryLimit: 3072, // Increased to counter memoryLimit issue
     }),
 
     new CleanWebpackPlugin(),


### PR DESCRIPTION
# Changelog

## Techinical
- Increased the memoryLimit for ForkTsCheckerWebpackPlugin to 3GB to resolve intermittent out-of-memory errors during TypeScript and ESLint checks
