### PR TITLE
TAN-2705 Areas in public API for Hoplr

### DIFF
--- a/back/engines/commercial/public_api/app/controllers/public_api/v2/areas_controller.rb
+++ b/back/engines/commercial/public_api/app/controllers/public_api/v2/areas_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module PublicApi
+  class V2::AreasController < PublicApiController
+    include DeletedItemsAction
+
+    def index
+      list_items Area.all, V2::AreaSerializer
+    end
+
+    def show
+      show_item Area.find(params[:id]), V2::AreaSerializer
+    end
+  end
+end

--- a/back/engines/commercial/public_api/app/controllers/public_api/v2/projects_controller.rb
+++ b/back/engines/commercial/public_api/app/controllers/public_api/v2/projects_controller.rb
@@ -20,7 +20,7 @@ module PublicApi
     private
 
     def finder_params
-      params.permit(:folder_id, :publication_status, topic_ids: []).to_h.tap do |params|
+      params.permit(:folder_id, :publication_status, topic_ids: [], area_ids: []).to_h.tap do |params|
         if params[:publication_status]
           validate_publication_status!(params[:publication_status])
         end

--- a/back/engines/commercial/public_api/app/finders/public_api/projects_finder.rb
+++ b/back/engines/commercial/public_api/app/finders/public_api/projects_finder.rb
@@ -6,12 +6,14 @@ module PublicApi
       scope,
       folder_id: nil,
       publication_status: nil,
-      topic_ids: nil
+      topic_ids: nil,
+      area_ids: nil
     )
       @scope = scope
       @folder_id = folder_id
       @publication_status = publication_status
       @topic_ids = topic_ids
+      @area_ids = area_ids
     end
 
     def execute
@@ -19,6 +21,7 @@ module PublicApi
         .then { |scope| filter_by_folder_id(scope) }
         .then { |scope| filter_by_publication_status(scope) }
         .then { |scope| filter_by_topic_ids(scope) }
+        .then { |scope| filter_by_area_ids(scope) }
     end
 
     private
@@ -51,6 +54,16 @@ module PublicApi
         .where(topics: { id: @topic_ids })
         .group('projects.id')
         .having('COUNT(topics.id) = ?', @topic_ids.size)
+    end
+
+    def filter_by_area_ids(scope)
+      return scope unless @area_ids
+
+      scope
+        .joins(:areas)
+        .where(areas: { id: @area_ids })
+        .group('projects.id')
+        .having('COUNT(areas.id) = ?', @area_ids.size)
     end
   end
 end

--- a/back/engines/commercial/public_api/app/serializers/public_api/v2/area_serializer.rb
+++ b/back/engines/commercial/public_api/app/serializers/public_api/v2/area_serializer.rb
@@ -1,23 +1,6 @@
 # frozen_string_literal: true
 
 class PublicApi::V2::AreaSerializer < PublicApi::V2::BaseSerializer
-  attributes :id,
-    :title,
-    :description,
-    :created_at,
-    :updated_at
-
-  def title
-    multiloc_service.t(object.title_multiloc)
-  end
-
-  def description
-    multiloc_service.t(object.description_multiloc)
-  end
-
-  private
-
-  def multiloc_service
-    @multiloc_service ||= MultilocService.new
-  end
+  attributes :id, :created_at, :updated_at
+  multiloc_attributes :title_multiloc, :description_multiloc
 end

--- a/back/engines/commercial/public_api/app/serializers/public_api/v2/area_serializer.rb
+++ b/back/engines/commercial/public_api/app/serializers/public_api/v2/area_serializer.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class PublicApi::V2::AreaSerializer < PublicApi::V2::BaseSerializer
+  attributes :id,
+    :title,
+    :description,
+    :created_at,
+    :updated_at
+
+  def title
+    multiloc_service.t(object.title_multiloc)
+  end
+
+  def description
+    multiloc_service.t(object.description_multiloc)
+  end
+
+  private
+
+  def multiloc_service
+    @multiloc_service ||= MultilocService.new
+  end
+end

--- a/back/engines/commercial/public_api/config/routes.rb
+++ b/back/engines/commercial/public_api/config/routes.rb
@@ -31,6 +31,7 @@ PublicApi::Engine.routes.draw do
       route_mapper.resources :project_folders
       route_mapper.resources :reactions, only: %i[index]
       route_mapper.resources :topics
+      route_mapper.resources :areas
       route_mapper.resources :users
       route_mapper.resources :volunteering_causes
       route_mapper.resources :volunteering_volunteers

--- a/back/engines/commercial/public_api/spec/acceptance/v2/areas_spec.rb
+++ b/back/engines/commercial/public_api/spec/acceptance/v2/areas_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rspec_api_documentation/dsl'
+require './engines/commercial/public_api/spec/acceptance/v2/support/shared'
+
+resource 'Areas' do
+  explanation <<~DESC.squish
+    Areas are geogprahical regions that can be used to categorize projects, and annotate users.
+  DESC
+
+  include_context 'common_auth'
+
+  let!(:areas) { create_list(:area, 5) }
+
+  get '/api/v2/areas/' do
+    route_summary 'List areas'
+    route_description <<~DESC.squish
+      Retrieve a paginated list of all the areas in the platform, with the most recently
+      created ones first.
+    DESC
+
+    include_context 'common_list_params'
+
+    context 'when the page size is smaller than the total number of areas' do
+      let(:page_size) { 2 }
+
+      example_request 'Successful response' do
+        assert_status 200
+        expect(json_response_body[:areas].size).to eq(page_size)
+
+        total_pages = (areas.size.to_f / page_size).ceil
+        expect(json_response_body[:meta]).to eq({ total_pages: total_pages, current_page: 1 })
+      end
+    end
+
+    include_examples 'filtering_by_date', :area, :created_at
+
+    # Temporarily disable acts_as_list callbacks because they modify the updated_at
+    # attribute and break the tests. We use `it_behaves_like` to include the tests
+    # in a nested context to limit the scope of the `around` block.
+    it_behaves_like 'filtering_by_date', :area, :updated_at do
+      around do |example|
+        Area.acts_as_list_no_update { example.run }
+      end
+    end
+  end
+
+  get '/api/v2/areas/:id' do
+    route_summary 'Get area'
+    route_description 'Retrieve a single area by its ID.'
+
+    include_context 'common_item_params'
+
+    let(:area) { areas[0] }
+    let(:id) { area.id }
+
+    before do
+      # NOTE: Temp fix until locales of factories and tenants are consistent
+      # Currently, the tenant locales are ["en", "fr-FR", "nl-NL"], while the factory
+      # locales are ["en", "nl-BE"]. The following code aligns the two by replacing
+      # the "nl-BE" locale with "nl-NL" in the area.
+      title = area[:title_multiloc]
+      title['nl-NL'] = title.delete 'nl-BE'
+      area.update!(title_multiloc: title)
+    end
+
+    example_request 'Returns the area in the default locale' do
+      assert_status 200
+      # TODO: Add test condition to be sure this is the default locale
+      expect(json_response_body[:area]).to include({ id: id })
+    end
+
+    context 'when the locale is specified' do
+      let(:locale) { 'nl-NL' }
+
+      example_request 'Returns the area in the specified locale' do
+        assert_status 200
+        expect(json_response_body.dig(:area, :title))
+          .to eq area.title_multiloc['nl-NL']
+      end
+    end
+  end
+
+  include_examples '/api/v2/.../deleted', :areas
+end

--- a/back/engines/commercial/public_api/spec/acceptance/v2/projects_spec.rb
+++ b/back/engines/commercial/public_api/spec/acceptance/v2/projects_spec.rb
@@ -147,13 +147,11 @@ resource 'Projects' do
     context "when filtering by 'area_ids'" do
       let(:areas) { create_list(:area, 2) }
       let(:area_ids) { areas.pluck(:id) }
+      let!(:project) { create(:project, areas: areas) }
 
-      let!(:project) do
-        create(:project).tap { |project| project.areas << areas }
-      end
-
-      let!(:project_with_one_area) do
-        create(:project).tap { |project| project.areas << areas.first }
+      before do
+        # This project shouldn't be returned since it only has one of the requested areas.
+        create(:project, areas: areas.take(1))
       end
 
       example_request 'List only the projects that are in the specified areas' do

--- a/back/engines/commercial/public_api/spec/acceptance/v2/projects_spec.rb
+++ b/back/engines/commercial/public_api/spec/acceptance/v2/projects_spec.rb
@@ -53,6 +53,15 @@ resource 'Projects' do
       items: { type: 'string' }
     )
 
+    parameter(
+      :area_ids,
+      'List only the projects that are in the specified areas.',
+      required: false,
+      in: 'query',
+      type: 'array',
+      items: { type: 'string' }
+    )
+
     context 'when the page size is smaller than the total number of projects' do
       let(:page_size) { 2 }
 
@@ -129,6 +138,25 @@ resource 'Projects' do
       end
 
       example_request 'List only the projects that have all the specified topics' do
+        assert_status 200
+        expect(json_response_body[:projects].pluck(:id))
+          .to match_array [project.id]
+      end
+    end
+
+    context "when filtering by 'area_ids'" do
+      let(:areas) { create_list(:area, 2) }
+      let(:area_ids) { areas.pluck(:id) }
+
+      let!(:project) do
+        create(:project).tap { |project| project.areas << areas }
+      end
+
+      let!(:project_with_one_area) do
+        create(:project).tap { |project| project.areas << areas.first }
+      end
+
+      example_request 'List only the projects that are in the specified areas' do
         assert_status 200
         expect(json_response_body[:projects].pluck(:id))
           .to match_array [project.id]


### PR DESCRIPTION
This is a copy/paste of what we're doing for topics already, as the models and relations are almost the same.

# Changelog
## Technical
- Expanded the public API with project area information, in order to let Hoplr show Go Vocal projects for specific neighborhoods
