### PR TITLE
[TAN-2655] Remove "Rename" tooltip from `ReportTitle` component

### DIFF
--- a/front/app/containers/Admin/reporting/components/ReportBuilder/TopBar/ReportTitle.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/TopBar/ReportTitle.tsx
@@ -6,7 +6,6 @@ import {
   fontSizes,
   Input,
   Title,
-  Tooltip,
 } from '@citizenlab/cl2-component-library';
 import styled from 'styled-components';
 
@@ -128,22 +127,16 @@ const ReportTitle = ({ reportId }) => {
       alignItems="center"
       justifyContent="flex-start"
     >
-      <Tooltip
-        content={formatMessage(messages.reportTitleTooltip)}
-        zIndex={99999}
-        placement="right"
-      >
-        <div>
-          <StyledInput
-            type="text"
-            value={newTitle}
-            onChange={setNewTitle}
-            onBlur={handleOnBlur}
-            onKeyDown={handleOnKeyDown}
-            setRef={setInputRef}
-          />
-        </div>
-      </Tooltip>
+      <div>
+        <StyledInput
+          type="text"
+          value={newTitle}
+          onChange={setNewTitle}
+          onBlur={handleOnBlur}
+          onKeyDown={handleOnKeyDown}
+          setRef={setInputRef}
+        />
+      </div>
 
       {errorMessage && <StyledError text={errorMessage} />}
     </Box>

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/TopBar/messages.ts
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/TopBar/messages.ts
@@ -34,8 +34,4 @@ export default defineMessages({
     id: 'app.containers.Admin.reporting.components.ReportBuilder.TopBar.titleTaken',
     defaultMessage: 'Title is already taken',
   },
-  reportTitleTooltip: {
-    id: 'app.containers.Admin.reporting.components.ReportBuilder.TopBar.reportTitleTooltip',
-    defaultMessage: 'Rename',
-  },
 });

--- a/front/app/translations/admin/ar-MA.json
+++ b/front/app/translations/admin/ar-MA.json
@@ -426,7 +426,6 @@
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummary": "ملخص التقرير",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummaryDescription": "أضف هدف المشروع وطرق المشاركة المتبعة والنتيجة",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.visitors": "زوار",
-  "app.containers.Admin.reporting.components.ReportBuilder.TopBar.reportTitleTooltip": "إعادة تسمية",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.titleTaken": "العنوان مأخوذ بالفعل",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.noProject": "لا يوجد مشروع",
   "app.containers.Admin.reporting.components.ReportBuilderPage.ReportRow.cannotDuplicateReport": "لا يمكنك تكرار هذا التقرير لأنه يحتوي على بيانات لا يمكنك الوصول إليها.",

--- a/front/app/translations/admin/ar-SA.json
+++ b/front/app/translations/admin/ar-SA.json
@@ -1078,7 +1078,6 @@
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummaryDescription": "أضف هدف المشروع وطرق المشاركة المتبعة والنتيجة",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.visitors": "زوار",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.cannotPrint": "يحتوي هذا التقرير على تغييرات غير محفوظة. يرجى الحفظ قبل الطباعة.",
-  "app.containers.Admin.reporting.components.ReportBuilder.TopBar.reportTitleTooltip": "إعادة تسمية",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.titleTaken": "العنوان مأخوذ بالفعل",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.comparedToPreviousXDays": "مقارنة بالأيام {days} السابقة",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.hideStatistics": "إخفاء الإحصائيات",

--- a/front/app/translations/admin/ca-ES.json
+++ b/front/app/translations/admin/ca-ES.json
@@ -598,7 +598,6 @@
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummary": "Report summary",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummaryDescription": "Add the goal of the project, participation methods used, and the outcome",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.visitors": "Visitors",
-  "app.containers.Admin.reporting.components.ReportBuilder.TopBar.reportTitleTooltip": "Canvia el nom",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.titleTaken": "El títol ja està agafat",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.noProject": "No project",
   "app.containers.Admin.reporting.components.ReportBuilderPage.ReportRow.cannotDuplicateReport": "No podeu duplicar aquest informe perquè conté dades a les quals no teniu accés.",

--- a/front/app/translations/admin/cy-GB.json
+++ b/front/app/translations/admin/cy-GB.json
@@ -1078,7 +1078,6 @@
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummaryDescription": "Ychwanegwch nod y prosiect, y dulliau cyfranogiad a ddefnyddiwyd, a'r canlyniad",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.visitors": "Ymwelwyr",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.cannotPrint": "Mae'r adroddiad hwn yn cynnwys newidiadau heb eu cadw. Arbedwch cyn argraffu.",
-  "app.containers.Admin.reporting.components.ReportBuilder.TopBar.reportTitleTooltip": "Ailenwi",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.titleTaken": "Mae'r teitl eisoes wedi'i gymryd",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.comparedToPreviousXDays": "O'i gymharu â {days} diwrnodau blaenorol",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.hideStatistics": "Cuddio ystadegau",

--- a/front/app/translations/admin/da-DK.json
+++ b/front/app/translations/admin/da-DK.json
@@ -1078,7 +1078,6 @@
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummaryDescription": "Tilføj projektets mål, de anvendte deltagelsesmetoder og resultatet",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.visitors": "Besøgende",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.cannotPrint": "Denne rapport indeholder ændringer, der ikke er gemt. Gem venligst før udskrivning.",
-  "app.containers.Admin.reporting.components.ReportBuilder.TopBar.reportTitleTooltip": "Omdøb",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.titleTaken": "Titlen er allerede taget",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.comparedToPreviousXDays": "Sammenlignet med tidligere {days} dage",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.hideStatistics": "Skjul statistik",

--- a/front/app/translations/admin/de-DE.json
+++ b/front/app/translations/admin/de-DE.json
@@ -1078,7 +1078,6 @@
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummaryDescription": "Fügen Sie das Projektziel, die verwendeten Beteiligungsmethoden und das Ergebnis hinzu",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.visitors": "Besucher*innen",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.cannotPrint": "Dieser Bericht enthält ungesicherte Änderungen. Bitte speichern Sie ihn vor dem Drucken.",
-  "app.containers.Admin.reporting.components.ReportBuilder.TopBar.reportTitleTooltip": "Umbenennen",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.titleTaken": "Titel ist bereits vergeben",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.comparedToPreviousXDays": "Verglichen mit den vorherigen {days} Tagen",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.hideStatistics": "Statistik ausblenden",

--- a/front/app/translations/admin/el-GR.json
+++ b/front/app/translations/admin/el-GR.json
@@ -598,7 +598,6 @@
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummary": "Report summary",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummaryDescription": "Add the goal of the project, participation methods used, and the outcome",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.visitors": "Visitors",
-  "app.containers.Admin.reporting.components.ReportBuilder.TopBar.reportTitleTooltip": "Μετονομασία",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.titleTaken": "Ο τίτλος είναι ήδη κατειλημμένος",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.noProject": "No project",
   "app.containers.Admin.reporting.components.ReportBuilderPage.ReportRow.cannotDuplicateReport": "Δεν μπορείτε να αντιγράψετε αυτή την έκθεση, επειδή περιέχει δεδομένα στα οποία δεν έχετε πρόσβαση.",

--- a/front/app/translations/admin/en-CA.json
+++ b/front/app/translations/admin/en-CA.json
@@ -1078,7 +1078,6 @@
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummaryDescription": "Add the goal of the project, participation methods used, and the outcome",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.visitors": "Visitors",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.cannotPrint": "This report contains unsaved changes. Please save before printing.",
-  "app.containers.Admin.reporting.components.ReportBuilder.TopBar.reportTitleTooltip": "Rename",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.titleTaken": "Title is already taken",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.comparedToPreviousXDays": "Compared to previous {days} days",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.hideStatistics": "Hide statistics",

--- a/front/app/translations/admin/en-GB.json
+++ b/front/app/translations/admin/en-GB.json
@@ -1078,7 +1078,6 @@
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummaryDescription": "Add the goal of the project, participation methods used, and the outcome",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.visitors": "Visitors",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.cannotPrint": "This report contains unsaved changes. Please save before printing.",
-  "app.containers.Admin.reporting.components.ReportBuilder.TopBar.reportTitleTooltip": "Rename",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.titleTaken": "Title is already taken",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.comparedToPreviousXDays": "Compared to previous {days} days",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.hideStatistics": "Hide statistics",

--- a/front/app/translations/admin/en-IE.json
+++ b/front/app/translations/admin/en-IE.json
@@ -1078,7 +1078,6 @@
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummaryDescription": "Add the goal of the project, participation methods used, and the outcome",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.visitors": "Visitors",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.cannotPrint": "This report contains unsaved changes. Please save before printing.",
-  "app.containers.Admin.reporting.components.ReportBuilder.TopBar.reportTitleTooltip": "Rename",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.titleTaken": "Title is already taken",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.comparedToPreviousXDays": "Compared to previous {days} days",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.hideStatistics": "Hide statistics",

--- a/front/app/translations/admin/en.json
+++ b/front/app/translations/admin/en.json
@@ -1078,7 +1078,6 @@
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummaryDescription": "Add the goal of the project, participation methods used, and the outcome",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.visitors": "Visitors",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.cannotPrint": "This report contains unsaved changes. Please save before printing.",
-  "app.containers.Admin.reporting.components.ReportBuilder.TopBar.reportTitleTooltip": "Rename",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.titleTaken": "Title is already taken",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.comparedToPreviousXDays": "Compared to previous {days} days",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.hideStatistics": "Hide statistics",

--- a/front/app/translations/admin/es-CL.json
+++ b/front/app/translations/admin/es-CL.json
@@ -1078,7 +1078,6 @@
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummaryDescription": "Añada el objetivo del proyecto, los métodos de participación utilizados y el resultado",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.visitors": "Visitantes",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.cannotPrint": "Este informe contiene cambios no guardados. Por favor, guárdalos antes de imprimirlos.",
-  "app.containers.Admin.reporting.components.ReportBuilder.TopBar.reportTitleTooltip": "Renombrar",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.titleTaken": "El título ya está ocupado",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.comparedToPreviousXDays": "En comparación con los días anteriores {days}",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.hideStatistics": "Ocultar estadísticas",

--- a/front/app/translations/admin/es-ES.json
+++ b/front/app/translations/admin/es-ES.json
@@ -1078,7 +1078,6 @@
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummaryDescription": "Añada el objetivo del proyecto, los métodos de participación utilizados y el resultado",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.visitors": "Visitantes",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.cannotPrint": "Este informe contiene cambios no guardados. Por favor, guárdalos antes de imprimirlos.",
-  "app.containers.Admin.reporting.components.ReportBuilder.TopBar.reportTitleTooltip": "Renombrar",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.titleTaken": "El título ya está ocupado",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.comparedToPreviousXDays": "En comparación con los días anteriores {days}",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.hideStatistics": "Ocultar estadísticas",

--- a/front/app/translations/admin/fi-FI.json
+++ b/front/app/translations/admin/fi-FI.json
@@ -1078,7 +1078,6 @@
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummaryDescription": "Lisää projektin tavoite, käytetyt osallistumismenetelmät ja tulos",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.visitors": "Vierailijat",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.cannotPrint": "Tämä raportti sisältää tallentamattomia muutoksia. Tallenna ennen tulostusta.",
-  "app.containers.Admin.reporting.components.ReportBuilder.TopBar.reportTitleTooltip": "Nimeä uudelleen",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.titleTaken": "Otsikko on jo varattu",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.comparedToPreviousXDays": "Verrattuna edelliseen {days} päivään",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.hideStatistics": "Piilota tilastot",

--- a/front/app/translations/admin/fr-BE.json
+++ b/front/app/translations/admin/fr-BE.json
@@ -1078,7 +1078,6 @@
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummaryDescription": "Ajoutez le but du projet, les méthodes de participation utilisées et le résultat",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.visitors": "Visiteurs",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.cannotPrint": "Ce rapport contient des modifications non enregistrées. Veuillez le sauvegarder avant de l'imprimer.",
-  "app.containers.Admin.reporting.components.ReportBuilder.TopBar.reportTitleTooltip": "Renommer",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.titleTaken": "Ce titre est déjà utilisé",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.comparedToPreviousXDays": "comparé aux {days} jours précédents",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.hideStatistics": "Masquer les statistiques",

--- a/front/app/translations/admin/fr-FR.json
+++ b/front/app/translations/admin/fr-FR.json
@@ -1078,7 +1078,6 @@
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummaryDescription": "Ajoutez le but du projet, les méthodes de participation utilisées et le résultat",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.visitors": "Visiteurs",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.cannotPrint": "Ce rapport contient des modifications non enregistrées. Veuillez le sauvegarder avant de l'imprimer.",
-  "app.containers.Admin.reporting.components.ReportBuilder.TopBar.reportTitleTooltip": "Renommer",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.titleTaken": "Ce titre est déjà utilisé",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.comparedToPreviousXDays": "comparé aux {days} jours précédents",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.hideStatistics": "Masquer les statistiques",

--- a/front/app/translations/admin/hr-HR.json
+++ b/front/app/translations/admin/hr-HR.json
@@ -1078,7 +1078,6 @@
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummaryDescription": "Dodajte cilj projekta, upotrijebljene načine sudjelovanja i ishod",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.visitors": "Posjetitelji",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.cannotPrint": "Ovo izvješće sadrži nespremljene promjene. Molimo spremite prije ispisa.",
-  "app.containers.Admin.reporting.components.ReportBuilder.TopBar.reportTitleTooltip": "Preimenovati",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.titleTaken": "Naslov je već zauzet",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.comparedToPreviousXDays": "U usporedbi s prethodnih {days} dana",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.hideStatistics": "Sakrij statistiku",

--- a/front/app/translations/admin/it-IT.json
+++ b/front/app/translations/admin/it-IT.json
@@ -598,7 +598,6 @@
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummary": "Report summary",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummaryDescription": "Add the goal of the project, participation methods used, and the outcome",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.visitors": "Visitors",
-  "app.containers.Admin.reporting.components.ReportBuilder.TopBar.reportTitleTooltip": "Rinomina",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.titleTaken": "Il titolo è già stato preso",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.noProject": "No project",
   "app.containers.Admin.reporting.components.ReportBuilderPage.ReportRow.cannotDuplicateReport": "Non puoi duplicare questo report perché contiene dati a cui non hai accesso.",

--- a/front/app/translations/admin/kl-GL.json
+++ b/front/app/translations/admin/kl-GL.json
@@ -465,7 +465,6 @@
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummary": "Report summary",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummaryDescription": "Add the goal of the project, participation methods used, and the outcome",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.visitors": "Visitors",
-  "app.containers.Admin.reporting.components.ReportBuilder.TopBar.reportTitleTooltip": "Rename",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.titleTaken": "Title is already taken",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.noProject": "No project",
   "app.containers.Admin.reporting.components.ReportBuilderPage.ReportRow.cannotDuplicateReport": "You cannot duplicate this report because it contains data that you don't have access to.",

--- a/front/app/translations/admin/lb-LU.json
+++ b/front/app/translations/admin/lb-LU.json
@@ -465,7 +465,6 @@
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummary": "Rapportszesummefaassung",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummaryDescription": "Füügt d’Projetszil, genotzte Bedeelegungsmethoden an d’Resultat bäi",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.visitors": "Visitors",
-  "app.containers.Admin.reporting.components.ReportBuilder.TopBar.reportTitleTooltip": "ëmbenennen",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.titleTaken": "Den Titel ass scho geholl",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.noProject": "No project",
   "app.containers.Admin.reporting.components.ReportBuilderPage.ReportRow.cannotDuplicateReport": "Dir kënnt dëse Rapport net duplizéieren, well en Daten enthält op déi Dir keen Zougang hutt.",

--- a/front/app/translations/admin/lv-LV.json
+++ b/front/app/translations/admin/lv-LV.json
@@ -1078,7 +1078,6 @@
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummaryDescription": "Pievienojiet projekta mērķi, izmantotās līdzdalības metodes un rezultātu",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.visitors": "Apmeklētāji",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.cannotPrint": "Šajā ziņojumā ir iekļautas nesaglabātas izmaiņas. Pirms drukāšanas lūdzu, saglabājiet to.",
-  "app.containers.Admin.reporting.components.ReportBuilder.TopBar.reportTitleTooltip": "Pārdēvēt",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.titleTaken": "Nosaukums jau ir aizņemts",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.comparedToPreviousXDays": "Salīdzinot ar iepriekšējām {days} dienām",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.hideStatistics": "Paslēpt statistiku",

--- a/front/app/translations/admin/nb-NO.json
+++ b/front/app/translations/admin/nb-NO.json
@@ -1078,7 +1078,6 @@
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummaryDescription": "Legg til målet med prosjektet, deltakermetoder som brukes og utfallet",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.visitors": "Besøkende",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.cannotPrint": "Denne rapporten inneholder ulagrede endringer. Vennligst lagre før utskrift.",
-  "app.containers.Admin.reporting.components.ReportBuilder.TopBar.reportTitleTooltip": "Gi nytt navn",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.titleTaken": "Tittelen er allerede tatt",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.comparedToPreviousXDays": "Sammenlignet med tidligere {days} dager",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.hideStatistics": "Skjul statistikk",

--- a/front/app/translations/admin/nl-BE.json
+++ b/front/app/translations/admin/nl-BE.json
@@ -1078,7 +1078,6 @@
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummaryDescription": "Voeg het doel van het project, de gebruikte participatiemethoden en het resultaat toe",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.visitors": "Bezoekers",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.cannotPrint": "Dit rapport bevat niet-opgeslagen wijzigingen. Sla het op voordat je het afdrukt.",
-  "app.containers.Admin.reporting.components.ReportBuilder.TopBar.reportTitleTooltip": "Hernoemen",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.titleTaken": "Deze titel is al in gebruik",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.comparedToPreviousXDays": "Vergeleken met vorige {days} dagen",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.hideStatistics": "Verberg statistieken",

--- a/front/app/translations/admin/nl-NL.json
+++ b/front/app/translations/admin/nl-NL.json
@@ -1078,7 +1078,6 @@
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummaryDescription": "Voeg het doel van het project, de gebruikte participatiemethoden en het resultaat toe",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.visitors": "Bezoekers",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.cannotPrint": "Dit rapport bevat niet-opgeslagen wijzigingen. Sla het op voordat je het afdrukt.",
-  "app.containers.Admin.reporting.components.ReportBuilder.TopBar.reportTitleTooltip": "Hernoemen",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.titleTaken": "Deze titel is al in gebruik",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.comparedToPreviousXDays": "Vergeleken met vorige {days} dagen",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.hideStatistics": "Verberg statistieken",

--- a/front/app/translations/admin/pl-PL.json
+++ b/front/app/translations/admin/pl-PL.json
@@ -1078,7 +1078,6 @@
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummaryDescription": "Dodaj cel projektu, zastosowane metody uczestnictwa oraz wynik.",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.visitors": "Odwiedzający",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.cannotPrint": "Ten raport zawiera niezapisane zmiany. Zapisz go przed wydrukowaniem.",
-  "app.containers.Admin.reporting.components.ReportBuilder.TopBar.reportTitleTooltip": "Zmień nazwę",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.titleTaken": "Tytuł jest już zajęty",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.comparedToPreviousXDays": "W porównaniu do poprzednich dni {days}",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.hideStatistics": "Ukryj statystyki",

--- a/front/app/translations/admin/pt-BR.json
+++ b/front/app/translations/admin/pt-BR.json
@@ -1078,7 +1078,6 @@
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummaryDescription": "Acrescentar o objectivo do projeto, os métodos de participação utilizados, e o resultado",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.visitors": "Visitantes",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.cannotPrint": "Este relatório contém alterações não salvas. Por favor, salve-o antes de imprimir.",
-  "app.containers.Admin.reporting.components.ReportBuilder.TopBar.reportTitleTooltip": "Renomear",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.titleTaken": "O título já está sendo usado",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.comparedToPreviousXDays": "Em comparação com os dias anteriores {days}",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.hideStatistics": "Ocultar estatísticas",

--- a/front/app/translations/admin/sr-Latn.json
+++ b/front/app/translations/admin/sr-Latn.json
@@ -1078,7 +1078,6 @@
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummaryDescription": "Dodaj cilj projekta, korišćene metode učešća i ishod",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.visitors": "Posetioci",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.cannotPrint": "This report contains unsaved changes. Please save before printing.",
-  "app.containers.Admin.reporting.components.ReportBuilder.TopBar.reportTitleTooltip": "Rename",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.titleTaken": "Title is already taken",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.comparedToPreviousXDays": "Compared to previous {days} days",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.hideStatistics": "Hide statistics",

--- a/front/app/translations/admin/sr-SP.json
+++ b/front/app/translations/admin/sr-SP.json
@@ -1078,7 +1078,6 @@
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummaryDescription": "Додајте циљ пројекта, коришћене методе учешћа и исход",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.visitors": "Посетиоци",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.cannotPrint": "This report contains unsaved changes. Please save before printing.",
-  "app.containers.Admin.reporting.components.ReportBuilder.TopBar.reportTitleTooltip": "Rename",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.titleTaken": "Title is already taken",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.comparedToPreviousXDays": "Compared to previous {days} days",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.hideStatistics": "Hide statistics",

--- a/front/app/translations/admin/sv-SE.json
+++ b/front/app/translations/admin/sv-SE.json
@@ -1078,7 +1078,6 @@
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummaryDescription": "Lägg till projektets mål, metoder som använts för deltagande och resultatet",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.visitors": "Besökare",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.cannotPrint": "Denna rapport innehåller osparade ändringar. Spara innan du skriver ut.",
-  "app.containers.Admin.reporting.components.ReportBuilder.TopBar.reportTitleTooltip": "Byt namn på",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.titleTaken": "Titeln är redan upptagen",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.comparedToPreviousXDays": "Jämfört med tidigare {days} dagar",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.hideStatistics": "Dölj statistik",

--- a/front/app/translations/admin/tr-TR.json
+++ b/front/app/translations/admin/tr-TR.json
@@ -1078,7 +1078,6 @@
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.reportSummaryDescription": "Projenin amacını, kullanılan katılım yöntemlerini ve sonucu ekleyin",
   "app.containers.Admin.reporting.components.ReportBuilder.Templates.visitors": "Ziyaretçiler",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.cannotPrint": "Bu rapor kaydedilmemiş değişiklikler içermektedir. Lütfen yazdırmadan önce kaydedin.",
-  "app.containers.Admin.reporting.components.ReportBuilder.TopBar.reportTitleTooltip": "Yeniden Adlandır",
   "app.containers.Admin.reporting.components.ReportBuilder.TopBar.titleTaken": "Başlık zaten alınmış",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.comparedToPreviousXDays": "Önceki {days} günleriyle karşılaştırıldığında",
   "app.containers.Admin.reporting.components.ReportBuilder.Widgets.ChartWidgets.ActiveUsersWidget.ChartWidgetSettings.hideStatistics": "İstatistikleri gizle",


### PR DESCRIPTION
# Changelog
## Fixed
- [TAN-2655] Renaming of report titles

