### PR TITLE
Fix template generation so that users with no email (SSO users) are valid

### DIFF
--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/user.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/user.rb
@@ -18,8 +18,8 @@ module MultiTenancy
           verified
         ]
 
-        # To fix invalid SSO users where they have no email without having to serialize the Identity model
-        attribute(:unique_code) { |user| user.unique_code || (user.email.blank? ? SecureRandom.uuid : nil) }
+        # To fix invalid SSO users without email addresses without having to serialize the Identity model
+        attribute(:unique_code) { |user| user.unique_code || (user.sso? && user.email.blank? ? SecureRandom.uuid : nil) }
 
         attribute(:block_start_at) { |user| serialize_timestamp(user.block_start_at) }
         attribute(:registration_completed_at) { |user| serialize_timestamp(user.registration_completed_at) }

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/user.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/user.rb
@@ -16,8 +16,10 @@ module MultiTenancy
           locale
           password_digest
           verified
-          unique_code
         ]
+
+        # To fix invalid SSO users where they have no email without having to serialize the Identity model
+        attribute(:unique_code) { |user| user.unique_code || (user.email.blank? ? SecureRandom.uuid : nil) }
 
         attribute(:block_start_at) { |user| serialize_timestamp(user.block_start_at) }
         attribute(:registration_completed_at) { |user| serialize_timestamp(user.registration_completed_at) }

--- a/back/engines/commercial/multi_tenancy/spec/services/multi_tenancy/templates/tenant_serializer_spec.rb
+++ b/back/engines/commercial/multi_tenancy/spec/services/multi_tenancy/templates/tenant_serializer_spec.rb
@@ -21,7 +21,6 @@ describe MultiTenancy::Templates::TenantSerializer do
 
       tenant.switch do
         MultiTenancy::Templates::TenantDeserializer.new.deserialize(template)
-        binding.pry
         expect(ContentBuilder::Layout.where(code: 'homepage').count).to be 1
         expect(Area.count).to be > 0
         expect(Comment.count).to be > 0


### PR DESCRIPTION
The problem occurs because SSO identities are not serialized. But I really don't think identities need to be serialized, so this just adds a unique code to those users to make sure that they can be imported as valid users.

# Changelog
## Technical
- Fix to ensure that SSO users with no email are valid in templates
