### PR TITLE
[TAN-2682] Show upsell nudge for Konveio in correct cases

### DIFF
--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -914,8 +914,8 @@
         "additionalProperties": false,
         "required": ["allowed", "enabled"],
         "properties": {
-          "allowed": { "type": "boolean", "default": true },
-          "enabled": { "type": "boolean", "default": false }
+          "allowed": { "type": "boolean", "default": false },
+          "enabled": { "type": "boolean", "default": true }
         }
       },
 

--- a/front/app/containers/Admin/projects/project/phase/phaseParticipationConfig/components/ParticipationMethodChoice.tsx
+++ b/front/app/containers/Admin/projects/project/phase/phaseParticipationConfig/components/ParticipationMethodChoice.tsx
@@ -14,7 +14,7 @@ type Props = {
   title: string;
   subtitle?: string;
   image?: string;
-  onClick: (event) => void;
+  onClick?: (event) => void;
   children?: JSX.Element;
 };
 

--- a/front/app/containers/Admin/projects/project/phase/phaseParticipationConfig/components/ParticipationMethodPicker.tsx
+++ b/front/app/containers/Admin/projects/project/phase/phaseParticipationConfig/components/ParticipationMethodPicker.tsx
@@ -186,52 +186,56 @@ const ParticipationMethodPicker = ({
               image={volunteeringImage}
               selected={selectedMethod === 'volunteering'}
             />
-
-            {documentAnnotationAllowed && (
+            {documentAnnotationAllowed ? (
+              documentAnnotationEnabled && (
+                <Box position="relative">
+                  <ParticipationMethodChoice
+                    key="document"
+                    title={formatMessage(messages2.documentTitle)}
+                    subtitle={formatMessage(messages2.documentDescription)}
+                    onClick={(event) => {
+                      event.preventDefault();
+                      handleMethodSelect(event, 'document_annotation');
+                    }}
+                    image={documentImage}
+                    selected={selectedMethod === 'document_annotation'}
+                  />
+                </Box>
+              )
+            ) : (
               <Box position="relative">
                 <ParticipationMethodChoice
                   key="document"
                   title={formatMessage(messages2.documentTitle)}
                   subtitle={formatMessage(messages2.documentDescription)}
-                  onClick={(event) => {
-                    event.preventDefault();
-                    if (documentAnnotationEnabled) {
-                      handleMethodSelect(event, 'document_annotation');
-                    }
-                  }}
                   image={documentImage}
                   selected={selectedMethod === 'document_annotation'}
                 />
-                {/* Don't show tooltip and locked badge if the feature is enabled */}
-                {!documentAnnotationEnabled && (
-                  <Box
-                    style={{ transform: 'translateX(-50%)' }}
-                    position="absolute"
-                    top="20%"
-                    left="50%"
+                <Box
+                  style={{ transform: 'translateX(-50%)' }}
+                  position="absolute"
+                  top="20%"
+                  left="50%"
+                >
+                  <Tooltip
+                    maxWidth="250px"
+                    placement="bottom"
+                    content={formatMessage(messages.contactGovSuccessToAccess)}
+                    hideOnClick={false}
                   >
-                    <Tooltip
-                      maxWidth="250px"
-                      placement="bottom"
-                      content={formatMessage(
-                        messages.contactGovSuccessToAccess
-                      )}
-                      hideOnClick={false}
-                    >
-                      <Badge color={colors.coolGrey600} className="inverse">
-                        <Box
-                          display="flex"
-                          justifyContent="center"
-                          alignItems="center"
-                          gap="6px"
-                        >
-                          <Icon name="lock" fill="white" width="13px" />
-                          {formatMessage(messages2.addOn)}
-                        </Box>
-                      </Badge>
-                    </Tooltip>
-                  </Box>
-                )}
+                    <Badge color={colors.coolGrey600} className="inverse">
+                      <Box
+                        display="flex"
+                        justifyContent="center"
+                        alignItems="center"
+                        gap="6px"
+                      >
+                        <Icon name="lock" fill="white" width="13px" />
+                        {formatMessage(messages2.addOn)}
+                      </Box>
+                    </Badge>
+                  </Tooltip>
+                </Box>
               </Box>
             )}
 


### PR DESCRIPTION
### `ParticipationMethodPicker` Konevio UI element:

**Old behaviour:**
```
{ allowed: false, enabled: false } => no method shown
{ allowed: false, enabled: true }  => no method shown
{ allowed: true, enabled: false }  => upsell
{ allowed: true, enabled: true }   => method shown
```

**New behaviour:**
```
{ allowed: false, enabled: false }  => upsell
{ allowed: false, enabled: true }   => upsell
{ allowed: true, enabled: false }   => no method shown
{ allowed: true, enabled: true }    => method shown
```

In practice, { allowed: true, enabled: false }, is unlikely but possible (e.g. premium+ get this allowed && enabled in the pricing plan, but might choose to disable it)

- This PR also changes the default settings for `konveio_document_annotation` to `{allowed: false, enabled: true }` (was the inverse)



# Changelog
## Fixed
- [TAN-2682] Show upsell nudge for Konveio in correct cases
