### PR TITLE
[No-ticket] Fix CVE-2024-47720

### DIFF
--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -619,15 +619,14 @@ GEM
     google-api-client (0.53.0)
       google-apis-core (~> 0.1)
       google-apis-generator (~> 0.1)
-    google-apis-core (0.4.2)
+    google-apis-core (0.15.1)
       addressable (~> 2.5, >= 2.5.1)
-      googleauth (>= 0.16.2, < 2.a)
-      httpclient (>= 2.8.1, < 3.a)
+      googleauth (~> 1.9)
+      httpclient (>= 2.8.3, < 3.a)
       mini_mime (~> 1.0)
+      mutex_m
       representable (~> 3.0)
       retriable (>= 2.0, < 4.a)
-      rexml
-      webrick
     google-apis-discovery_v1 (0.8.0)
       google-apis-core (>= 0.4, < 2.a)
     google-apis-generator (0.4.1)
@@ -1215,7 +1214,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)


### PR DESCRIPTION
Fix for [back-bundle-audit failure](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/209714/workflows/9c31d2b1-1a28-4721-8f6b-5de870a10f4c/jobs/480692)

Current theory:
There's no fix for `webrick`, and it should not be used ([ref](https://nvd.nist.gov/vuln/detail/CVE-2024-47220))
Only `google-apis-core` seems to use `webrick` as a dependency, and this seems to have been made 'optional' ([ref](https://github.com/googleapis/google-api-ruby-client/pull/16574/files))
A conservative update of `google-apis-core` seems to remove the `webrick` dependency, but also removes the `rexml` dependency.

# Changelog
## Technical
- [No-ticket] Fix CVE-2024-47720
