### PR TITLE
Fix failing E2E tests

### DIFF
--- a/front/app/components/FormBuilder/components/FormBuilderSettings/FieldTypeSwitcher/index.tsx
+++ b/front/app/components/FormBuilder/components/FormBuilderSettings/FieldTypeSwitcher/index.tsx
@@ -27,7 +27,8 @@ const FieldTypeSwitcher = ({ field, surveyHasSubmissions }: Props) => {
     formatMessage
   );
 
-  if (fieldSwitchOptions.length === 0) return null;
+  // Don't show if there are no field switch options, or it's a built-in field
+  if (fieldSwitchOptions.length === 0 || field.code) return null;
 
   return (
     <Box mb="24px">

--- a/front/app/components/FormBuilder/components/FormBuilderSettings/index.tsx
+++ b/front/app/components/FormBuilder/components/FormBuilderSettings/index.tsx
@@ -36,7 +36,7 @@ import { LogicSettings } from './LogicSettings';
 
 interface Props {
   field: IFlatCustomFieldWithIndex;
-  closeSettings: () => void;
+  closeSettings: (triggerAutosave?: boolean) => void;
   builderConfig: FormBuilderConfig;
   surveyHasSubmissions: boolean;
 }
@@ -112,7 +112,7 @@ const FormBuilderSettings = ({
           a11y_buttonActionMessage={messages.close}
           onClick={() => {
             trackEventByName(tracks.formFieldSettingsCloseButtonClicked);
-            closeSettings();
+            closeSettings(true);
           }}
           iconColor={colors.textSecondary}
           iconColorOnHover={'#000'}

--- a/front/app/components/FormBuilder/components/FormFields/FormField/index.tsx
+++ b/front/app/components/FormBuilder/components/FormFields/FormField/index.tsx
@@ -50,7 +50,7 @@ type Props = {
   selectedFieldId?: string;
   builderConfig: FormBuilderConfig;
   fieldNumbers: Record<string, number>;
-  closeSettings: () => void;
+  closeSettings: (triggerAutosave?: boolean) => void;
 };
 
 export const FormField = ({
@@ -184,7 +184,7 @@ export const FormField = ({
         remove(fieldIndex);
       }
     }
-    closeSettings();
+    closeSettings(false);
     trigger();
   };
 

--- a/front/app/components/FormBuilder/components/FormFields/index.tsx
+++ b/front/app/components/FormBuilder/components/FormFields/index.tsx
@@ -34,7 +34,7 @@ interface FormFieldsProps {
   ) => void;
   selectedFieldId?: string;
   builderConfig: FormBuilderConfig;
-  closeSettings: () => void;
+  closeSettings: (triggerAutosave?: boolean) => void;
 }
 
 const FormFields = ({

--- a/front/app/components/FormBuilder/edit/index.tsx
+++ b/front/app/components/FormBuilder/edit/index.tsx
@@ -154,11 +154,11 @@ const FormEdit = ({
     }
   }, [formCustomFields, isUpdatingForm, isFetching, reset]);
 
-  const closeSettings = () => {
+  const closeSettings = (triggerAutosave?: boolean) => {
     setSelectedField(undefined);
 
     // If autosave is enabled & no submission have come in yet, save
-    if (autosaveEnabled && totalSubmissions === 0) {
+    if (triggerAutosave && autosaveEnabled && totalSubmissions === 0) {
       onFormSubmit(getValues());
     }
   };


### PR DESCRIPTION
# Description
Behaviour changed a bit when I merged the auto-saving work - this PR fixes this and only calls the autosave on the "X" button click when closing the question settings panel.