### PR TITLE
[TAN-2346] Remove input_form_mapping_question settings

### DIFF
--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -1106,18 +1106,6 @@
         }
       },
 
-      "input_form_mapping_question": {
-        "type": "object",
-        "title": "Mapping question used in in-platform surveys",
-        "description":  "Allow mapping question(s) for use in in-platform surveys. Currently limited to one type: Select a point on a map.",
-        "additionalProperties": false,
-        "required": ["allowed", "enabled"],
-        "properties": {
-          "allowed": { "type": "boolean", "default": false },
-          "enabled": { "type": "boolean", "default": false }
-        }
-      },
-
       "form_mapping": {
         "type": "object",
         "title": "Mapping features used in in-platform surveys",

--- a/back/engines/commercial/multi_tenancy/db/seeds/tenants.rb
+++ b/back/engines/commercial/multi_tenancy/db/seeds/tenants.rb
@@ -365,10 +365,6 @@ module MultiTenancy
               enabled: true,
               allowed: true
             },
-            input_form_mapping_question: {
-              enabled: true,
-              allowed: true
-            },
             form_mapping: {
               enabled: true,
               allowed: true

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/create_tenant.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/create_tenant.rake
@@ -263,10 +263,6 @@ namespace :cl2_back do
           enabled: true,
           allowed: true
         },
-        input_form_mapping_question: {
-          enabled: true,
-          allowed: true
-        },
         form_mapping: {
           enabled: true,
           allowed: true


### PR DESCRIPTION
1. I have already deleted the `input_form_mapping_question` settings from all existing production tenants (unnecessary - see comments below)
2. I have already deleted the `input_form_mapping_question` settings from all production pricing plans
3. I will check all production tenants for the settings after I merge & release this PR, to catch new tenants created recently, if any (after step 1)

# Changelog
## Technical
- [TAN-2346] Remove redundant input_form_mapping_question settings
