### PR TITLE
[TAN-2647] Improve sorting by table header in BO posts tables

### DIFF
--- a/back/app/services/sort_by_params_service.rb
+++ b/back/app/services/sort_by_params_service.rb
@@ -53,6 +53,8 @@ class SortByParamsService
     when '-status' then scope.order_status(:asc)
     when 'likes_count' then scope.order(likes_count: :desc)
     when '-likes_count' then scope.order(likes_count: :asc)
+    when 'comments_count' then scope.order(comments_count: :desc)
+    when '-comments_count' then scope.order(comments_count: :asc)
     else
       raise "Unsupported sorting parameter #{params[:sort]}"
     end

--- a/front/app/api/initiatives/types.ts
+++ b/front/app/api/initiatives/types.ts
@@ -14,6 +14,8 @@ export type Sort =
   | '-author_name'
   | 'likes_count'
   | '-likes_count'
+  | 'comments_count'
+  | '-comments_count'
   | 'status'
   | '-status'
   | 'random';

--- a/front/app/components/admin/PostManager/components/PostTable/Row/IdeaRow.tsx
+++ b/front/app/components/admin/PostManager/components/PostTable/Row/IdeaRow.tsx
@@ -243,7 +243,9 @@ const IdeaRow = ({
       name: 'published_on',
       Component: ({ idea }) => {
         if (!isNilOrError(locale)) {
-          return <>{timeAgo(Date.parse(idea.attributes.created_at), locale)}</>;
+          return (
+            <>{timeAgo(Date.parse(idea.attributes.published_at), locale)}</>
+          );
         }
         return null;
       },

--- a/front/app/components/admin/PostManager/components/PostTable/header/InitiativesHeaderRow.tsx
+++ b/front/app/components/admin/PostManager/components/PostTable/header/InitiativesHeaderRow.tsx
@@ -64,8 +64,16 @@ const InitiativesHeaderRow = ({
         >
           <FormattedMessage {...messages.votes} />
         </SortableHeaderCell>
-        <Th width={getWidth(1)}>
-          <FormattedMessage {...messages.comments} />
+        <Th>
+          <SortableHeaderCell
+            width={getWidth(1)}
+            sortAttribute={sortAttribute}
+            sortDirection={sortDirection}
+            sortAttributeName="comments_count"
+            onChange={handleSortClick('comments_count')}
+          >
+            <FormattedMessage {...messages.comments} />
+          </SortableHeaderCell>
         </Th>
         {cosponsorsRequired && (
           <Th width={getWidth(1)}>

--- a/front/app/components/admin/PostManager/components/PostTable/header/SortableHeaderCell.tsx
+++ b/front/app/components/admin/PostManager/components/PostTable/header/SortableHeaderCell.tsx
@@ -18,7 +18,6 @@ const SortableHeaderCell = ({
   sortAttribute,
   sortDirection,
   sortAttributeName,
-  width,
   infoTooltip,
   onChange,
   children,
@@ -26,9 +25,10 @@ const SortableHeaderCell = ({
   return (
     <Th
       clickable
-      width={width}
       sortDirection={
-        sortAttribute === sortAttributeName && sortDirection
+        sortAttribute &&
+        sortDirection &&
+        sortAttributeName === sortAttribute.replace(/^-/, '')
           ? sortDirection
           : undefined
       }

--- a/front/app/components/admin/PostManager/components/PostTable/index.tsx
+++ b/front/app/components/admin/PostManager/components/PostTable/index.tsx
@@ -120,10 +120,8 @@ const PostTable = ({
   const handleSortClick =
     (newSortAttribute: IdeasSort | InitiativesSort) => () => {
       if (isFunction(onChangeSort)) {
-        let newSortSign = '-';
-        if (newSortAttribute === sortAttribute) {
-          newSortSign = sortDirection === 'ascending' ? '-' : '';
-        }
+        const newSortSign = sortDirection === 'ascending' ? '-' : '';
+
         onChangeSort(
           `${newSortSign}${newSortAttribute}` as IdeasSort | InitiativesSort
         );


### PR DESCRIPTION
# Changelog
## Fixed
- [TAN-2647] It is now possible to sort by table headings in the BO idea and initiatives tables.
