### PR TITLE
TAN-2628 - If disabled, only show reactions control if reactions exist

### DIFF
--- a/front/app/components/IdeaCard/Footer/IdeaFooter.tsx
+++ b/front/app/components/IdeaCard/Footer/IdeaFooter.tsx
@@ -8,6 +8,8 @@ import ReactionControl from 'components/ReactionControl';
 import StatusBadge from 'components/StatusBadge';
 
 import CommentCount from './CommentCount';
+import { ParticipationMethod } from 'api/phases/types';
+import { showIdeaReactions } from 'components/ReactionControl/utils';
 
 const Container = styled.footer`
   display: flex;
@@ -36,6 +38,7 @@ const StyledReactionControl = styled(ReactionControl)`
 
 interface Props {
   idea: IIdeaData;
+  participationMethod: ParticipationMethod;
   hideIdeaStatus?: boolean;
   className?: string;
   showCommentCount: boolean;
@@ -43,16 +46,20 @@ interface Props {
 
 const IdeaFooter = ({
   idea,
+  participationMethod,
   hideIdeaStatus,
   className,
   showCommentCount,
 }: Props) => {
   const ideaStatusId = idea.relationships.idea_status.data?.id;
+  const showReactionControl = showIdeaReactions(idea, participationMethod);
 
   return (
     <Container className={className || ''}>
       <Left>
-        <StyledReactionControl styleType="border" ideaId={idea.id} size="1" />
+        {showReactionControl && (
+          <StyledReactionControl styleType="border" ideaId={idea.id} size="1" />
+        )}
 
         {showCommentCount && (
           <CommentCount commentCount={idea.attributes.comments_count} />

--- a/front/app/components/IdeaCard/Footer/index.tsx
+++ b/front/app/components/IdeaCard/Footer/index.tsx
@@ -36,6 +36,7 @@ const Footer = ({ idea, hideIdeaStatus, participationMethod }: Props) => {
     return (
       <IdeaFooter
         idea={idea}
+        participationMethod={participationMethod}
         hideIdeaStatus={hideIdeaStatus}
         showCommentCount={showCommentCount}
       />

--- a/front/app/components/ReactionControl/utils.ts
+++ b/front/app/components/ReactionControl/utils.ts
@@ -1,0 +1,28 @@
+import { IIdeaData } from 'api/ideas/types';
+import { ParticipationMethod } from 'api/phases/types';
+import { isFixableByAuthentication } from 'utils/actionDescriptors';
+
+export const showIdeaReactions = (
+  idea: IIdeaData,
+  participationMethod?: ParticipationMethod
+) => {
+  const reactingActionDescriptor =
+    idea.attributes.action_descriptors.reacting_idea;
+  const reactingFutureEnabled = !!(
+    reactingActionDescriptor.up.future_enabled_at ||
+    reactingActionDescriptor.down.future_enabled_at
+  );
+  const cancellingEnabled = reactingActionDescriptor.cancelling_enabled;
+  const likesCount = idea.attributes.likes_count;
+  const dislikesCount = idea.attributes.dislikes_count;
+  return (
+    participationMethod !== 'voting' &&
+    participationMethod !== 'proposals' &&
+    (reactingActionDescriptor.enabled ||
+      isFixableByAuthentication(reactingActionDescriptor.disabled_reason) ||
+      cancellingEnabled ||
+      reactingFutureEnabled ||
+      likesCount > 0 ||
+      dislikesCount > 0)
+  );
+};

--- a/front/app/containers/IdeasShow/components/RightColumnDesktop/index.tsx
+++ b/front/app/containers/IdeasShow/components/RightColumnDesktop/index.tsx
@@ -14,7 +14,6 @@ import useFeatureFlag from 'hooks/useFeatureFlag';
 import FollowUnfollow from 'components/FollowUnfollow';
 import ReactionControl from 'components/ReactionControl';
 
-import { isFixableByAuthentication } from 'utils/actionDescriptors';
 import { getVotingMethodConfig } from 'utils/configs/votingMethodConfig';
 
 import { rightColumnWidthDesktop } from '../../styleConstants';
@@ -24,6 +23,7 @@ import SharingButtonComponent from '../Buttons/SharingButtonComponent';
 import Cosponsorship from '../Cosponsorship';
 import MetaInformation from '../MetaInformation';
 import ProposalInfo from '../ProposalInfo';
+import { showIdeaReactions } from 'components/ReactionControl/utils';
 
 interface Props {
   ideaId: string;
@@ -59,24 +59,10 @@ const RightColumnDesktop = ({
 
   const participationMethod = phase?.attributes.participation_method;
 
-  const reactingActionDescriptor =
-    idea.data.attributes.action_descriptors.reacting_idea;
-  const reactingFutureEnabled = !!(
-    reactingActionDescriptor.up.future_enabled_at ||
-    reactingActionDescriptor.down.future_enabled_at
+  const showIdeaReactionControl = showIdeaReactions(
+    idea.data,
+    participationMethod
   );
-  const cancellingEnabled = reactingActionDescriptor.cancelling_enabled;
-  const likesCount = idea.data.attributes.likes_count;
-  const dislikesCount = idea.data.attributes.dislikes_count;
-  const showReactionControl =
-    participationMethod !== 'voting' &&
-    participationMethod !== 'proposals' &&
-    (reactingActionDescriptor.enabled ||
-      isFixableByAuthentication(reactingActionDescriptor.disabled_reason) ||
-      cancellingEnabled ||
-      reactingFutureEnabled ||
-      likesCount > 0 ||
-      dislikesCount > 0);
 
   const showInteractionsContainer =
     ideaIsInParticipationContext || commentingEnabled || followEnabled;
@@ -103,14 +89,14 @@ const RightColumnDesktop = ({
                 <ProposalInfo idea={idea} />
               </Box>
             )}
-            {showReactionControl && (
-              <Box pb="23px" mb="23px">
+            {showIdeaReactionControl && (
+              <Box pb="23px" mb="23px" borderBottom="solid 1px #ccc">
                 <ReactionControl styleType="shadow" ideaId={ideaId} size="4" />
               </Box>
             )}
-            {phase && ideaIsInParticipationContext && (
+            {phase && ideaIsInParticipationContext && votingConfig && (
               <Box pb="23px" mb="23px" borderBottom="solid 1px #ccc">
-                {votingConfig?.getIdeaPageVoteInput({
+                {votingConfig.getIdeaPageVoteInput({
                   ideaId,
                   phase,
                   compact: false,


### PR DESCRIPTION
# Changelog
## Fixed 
- TAN-2628 - If disabled, only show reactions on the ideas list page if reactions exist (now consistent with what happens on the idea page)
