### PR TITLE
TAN-2699: Show loading in submit

### DIFF
--- a/front/app/components/Form/Components/ButtonBar.tsx
+++ b/front/app/components/Form/Components/ButtonBar.tsx
@@ -34,6 +34,7 @@ const ButtonBar = ({
       <Button
         className="e2e-submit-idea-form"
         processing={processing}
+        disabled={processing}
         text={buttonText}
         marginRight="10px"
         onClick={onSubmit}

--- a/front/app/components/Form/index.tsx
+++ b/front/app/components/Form/index.tsx
@@ -56,7 +56,7 @@ interface Props {
   config?: 'default' | 'input' | 'survey';
   layout?: 'inline' | 'fullpage';
   footer?: React.ReactNode;
-  // Optional loading state from parent. If set, loading state is controlled by the parent.
+  // Optional loading state from parent. If set, the loading state will be controlled by the parent.
   loading?: boolean;
 }
 
@@ -73,7 +73,7 @@ const Form = memo(
     layout,
     footer,
     onSubmit,
-    loading: externalLoading, // External loading state (optional)
+    loading: externalLoading,
   }: Props) => {
     const { formatMessage } = useIntl();
     const locale = useLocale();

--- a/front/app/containers/IdeasEditPage/IdeasEditForm.tsx
+++ b/front/app/containers/IdeasEditPage/IdeasEditForm.tsx
@@ -55,7 +55,7 @@ const IdeasEditForm = ({ ideaId }: Props) => {
   const previousPathName = useContext(PreviousPathnameContext);
   const [isDisclaimerOpened, setIsDisclaimerOpened] = useState(false);
   const [formData, setFormData] = useState<FormValues | null>(null);
-
+  const [loading, setLoading] = useState(false);
   const { data: authUser } = useAuthUser();
   const { data: idea } = useIdeaById(ideaId);
   const { mutate: deleteIdeaImage } = useDeleteIdeaImage();
@@ -170,6 +170,7 @@ const IdeasEditForm = ({ ideaId }: Props) => {
   };
 
   const onSubmit = async (data: FormValues) => {
+    setLoading(true);
     const { idea_images_attributes, ...ideaWithoutImages } = data;
 
     const location_point_geojson = await getLocationGeojson(
@@ -209,6 +210,7 @@ const IdeasEditForm = ({ ideaId }: Props) => {
       },
       { scrollToTop: true }
     );
+    setLoading(false);
   };
 
   return (
@@ -229,6 +231,7 @@ const IdeasEditForm = ({ ideaId }: Props) => {
               getAjvErrorMessage={getAjvErrorMessage}
               getApiErrorMessage={getApiErrorMessage}
               config={'input'}
+              loading={loading}
               title={
                 <Box
                   width="100%"

--- a/front/app/containers/IdeasNewPage/IdeasNewIdeationForm/index.tsx
+++ b/front/app/containers/IdeasNewPage/IdeasNewIdeationForm/index.tsx
@@ -91,7 +91,7 @@ const IdeasNewIdeationForm = ({ project, phaseId }: Props) => {
     phaseId,
   });
   const search = location.search;
-
+  const [loading, setLoading] = useState(false);
   const [showAnonymousConfirmationModal, setShowAnonymousConfirmationModal] =
     useState(false);
   const [processingLocation, setProcessingLocation] = useState(false);
@@ -157,6 +157,7 @@ const IdeasNewIdeationForm = ({ project, phaseId }: Props) => {
   };
 
   const onSubmit = async (data: FormValues) => {
+    setLoading(true);
     const location_point_geojson = await getLocationGeojson(
       initialFormData,
       data
@@ -180,6 +181,7 @@ const IdeasNewIdeationForm = ({ project, phaseId }: Props) => {
       ideaId,
       idea,
     });
+    setLoading(false);
   };
 
   const getApiErrorMessage: ApiErrorGetter = useCallback(
@@ -260,6 +262,7 @@ const IdeasNewIdeationForm = ({ project, phaseId }: Props) => {
               initialFormData={initialFormData}
               getAjvErrorMessage={getAjvErrorMessage}
               getApiErrorMessage={getApiErrorMessage}
+              loading={loading}
               title={
                 participationMethodConfig.getFormTitle ? (
                   <Box mb="40px">


### PR DESCRIPTION
# Changelog

## Fixed
- When creating or editing an idea with a large image, users could accidentally submit the form twice by clicking the submit button again before being redirected to the idea page. This has been fixed by displaying a loading indicator on the submit button, preventing duplicate submissions and informing the user that the idea is being uploaded.
