### PR TITLE
TAN-2741: Fix position of quill tooltip

### DIFF
--- a/front/app/components/UI/QuillEditor/StyleContainer.tsx
+++ b/front/app/components/UI/QuillEditor/StyleContainer.tsx
@@ -109,9 +109,7 @@ const Container = styled.div<{
   }
 
   .ql-tooltip {
-    top: 20px !important;
-    left: 50% !important;
-    transform: translate(-50%);
+    left: 0 !important;
   }
 
   .ql-tooltip[data-mode='link']::before {


### PR DESCRIPTION
# Changelog

## Fixed
- This fixes the issue where the hyperlink tooltip in the Quill editor always appeared at the top of the editor instead of dynamically positioning itself near the selected text.
