### PR TITLE
TAN-2565 - Reduce user role information written to JWT

### DIFF
--- a/back/app/models/concerns/user_roles.rb
+++ b/back/app/models/concerns/user_roles.rb
@@ -134,7 +134,6 @@ module UserRoles # rubocop:disable Metrics/ModuleLength
       when 'project_moderator'
         project_moderator = true
       when 'project_folder_moderator'
-        project_moderator = true
         compressed_roles << role
       end
     end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -214,7 +214,7 @@ class User < ApplicationRecord
     token_lifetime = AppConfiguration.instance.settings('core', 'authentication_token_lifetime_in_days').days
     {
       sub: id,
-      roles: compacted_roles,
+      roles: compress_roles,
       exp: token_lifetime.from_now.to_i,
       cluster: CL2_CLUSTER,
       tenant: Tenant.current.id

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -1227,174 +1227,81 @@ RSpec.describe User do
     end
   end
 
-  describe '#compacted_roles' do
-    let_it_be(:user) { create(:user) }
-
-    let_it_be(:projects_in_folder) { create_list(:project, 2) }
-    let_it_be(:folder) { create(:project_folder, projects: projects_in_folder) }
-
-    # Top-level project (not in a folder)
-    let_it_be(:another_project) { create(:project) }
-
-    let_it_be(:project_in_another_folder) { create(:project) }
-    let_it_be(:another_folder) { create(:project_folder, projects: [project_in_another_folder]) }
-
-    def create_roles(projects, folders, admin: false)
-      projects = Array.wrap(projects)
-      folders = Array.wrap(folders)
-
-      [].tap do |roles|
-        roles << { 'type' => 'admin' } if admin
-        projects.each { |project| roles << { 'type' => 'project_moderator', 'project_id' => project.id } }
-        folders.each { |folder| roles << { 'type' => 'project_folder_moderator', 'project_folder_id' => folder.id } }
-      end
-    end
-
-    context 'when the roles are not redundant' do
-      where(:admin?, :projects, :folders) do
-        [
-          [true, nil, nil],
-          [true, ref(:another_project), nil],
-          [true, nil, ref(:folder)],
-          [false, ref(:another_project), ref(:folder)],
-          [false, ref(:projects_in_folder), nil],
-          [false, nil, [ref(:folder), ref(:another_folder)]],
-          [false, ref(:project_in_another_folder), ref(:folder)]
-        ]
-      end
-
-      with_them do
-        it 'does not modify the roles' do
-          user.roles = create_roles(projects, folders, admin: admin?)
-          expect(user.compacted_roles).to match(user.roles)
-        end
-      end
-    end
-
-    context 'when the roles are redundant' do
-      it 'removes redundant roles (1)' do
-        user.roles = create_roles(projects_in_folder, folder)
-        expected_roles = create_roles(nil, folder)
-        expect(user.compacted_roles).to match(expected_roles)
-      end
-
-      it 'removes redundant roles (2)' do
-        projects = projects_in_folder + [another_project]
-        user.roles = create_roles(projects, folder)
-        # only keep projects that are not in the folder
-        expected_roles = create_roles(another_project, folder)
-        expect(user.compacted_roles).to match(expected_roles)
-      end
-
-      it 'removes redundant roles (3)' do
-        folders = [folder, another_folder]
-        user.roles = create_roles(projects_in_folder, folders)
-        # only keep folder roles
-        expected_roles = create_roles(nil, folders)
-        expect(user.compacted_roles).to match(expected_roles)
-      end
-
-      it 'removes redundant roles (4)' do
-        projects = projects_in_folder + [project_in_another_folder, another_project]
-        folders = [folder, another_folder]
-        user.roles = create_roles(projects, folders)
-        expected_roles = create_roles(another_project, folders)
-        expect(user.compacted_roles).to match(expected_roles)
-      end
-    end
-  end
-
   describe '#compress_roles' do
-    it 'compresses project roles to a delimited string' do
+    it 'compresses project roles to only return IDs for project folders' do
       roles = [
-        {"type": "project_moderator", "project_id": "3498ad3e-930a-43cf-be7c-9d2c9677801f"},
-        {"type": "project_moderator", "project_id": "adba8dba-5678-45b6-a5ca-66d968dafd1"},
-        {"type": "project_folder_moderator", "project_folder_id": "188041cc-97da-4580-8edc-aa6cb8fd6958"}
+        { type: 'project_moderator', project_id: '3498ad3e-930a-43cf-be7c-9d2c9677801f' },
+        { type: 'project_moderator', project_id: 'adba8dba-5678-45b6-a5ca-66d968dafd1' },
+        { type: 'project_folder_moderator', project_folder_id: '188041cc-97da-4580-8edc-aa6cb8fd6958' }
       ]
       user = create(:user, roles: roles)
-      expect(user.compress_roles).to eq 'false|3498ad3e-930a-43cf-be7c-9d2c9677801f,adba8dba-5678-45b6-a5ca-66d968dafd1|188041cc-97da-4580-8edc-aa6cb8fd6958'
+      expect(user.compress_roles).to match_array [
+        { 'type' => 'project_moderator' },
+        { 'type' => 'project_folder_moderator', 'project_folder_id' => '188041cc-97da-4580-8edc-aa6cb8fd6958' }
+      ]
     end
 
-    it 'compresses admin role to a delimited string' do
-      user = create(:user, roles: [{ type: "admin" }])
-      expect(user.compress_roles).to eq 'true||'
+    it 'a single admin role remains the same' do
+      user = create(:user, roles: [{ 'type' => 'admin' }])
+      expect(user.compress_roles).to match_array [{ 'type' => 'admin' }]
     end
 
-    it 'reduces the string size to less than 45% of the original' do
+    it 'reduces a large set of roles to less than 20% of the original string size' do
       roles = [
-        {"type": "project_moderator", "project_id": "3498ad3e-930a-43cf-be7c-9d2c9677801f"},
-        {"type": "project_moderator", "project_id": "adba8dba-5678-45b6-a5ca-66d968dafd1"},
-        {"type": "project_moderator", "project_id": "0eadacd0-e62f-471e-a4cc-d9cd9fc0a0d2"},
-        {"type": "project_moderator", "project_id": "4a330fb2-8df8-4e81-84c2-e12903304c3c"},
-        {"type": "project_folder_moderator", "project_folder_id": "188041cc-97da-4580-8edc-aa6cb8fd6958"},
-        {"type": "project_moderator", "project_id": "ae134f80-7318-47d0-a64b-cf64e98e46ec"},
-        {"type": "project_moderator", "project_id": "c05e80c3-066a-43d1-a0bb-c49e7cf9264e"},
-        {"type": "project_moderator", "project_id": "9affe4dd-dcb1-4649-a682-cf13579bfd4f"},
-        {"type": "project_moderator", "project_id": "84d9bba4-f1fd-46d2-bbbb-7b1baa31de1b"},
-        {"type": "project_moderator", "project_id": "3a0cadea-784e-4e24-885a-2b682d57a836"},
-        {"type": "project_folder_moderator", "project_folder_id": "87411444-2ea1-4001-ba4c-e382f27bab57"},
-        {"type": "project_moderator", "project_id": "bdfb5e00-3501-4141-a949-e055aec065cd"},
-        {"type": "project_moderator", "project_id": "d7937f3a-5dd8-4b48-a34c-153e13a0eede"},
-        {"type": "project_moderator", "project_id": "e03d1f89-7ab9-48bc-8a95-9f147f8b9c22"},
-        {"type": "project_moderator", "project_id": "a9aef65b-726b-40f7-bc2c-56e2ea5d95df"},
-        {"type": "project_moderator", "project_id": "311db9ab-d878-48b5-b23d-98980a358272"},
-        {"type": "project_folder_moderator", "project_folder_id": "ab872f76-1d1c-44a9-92ea-530684f542ed"},
-        {"type": "project_moderator", "project_id": "dbf6104a-6619-4901-801e-38843aacf853"},
-        {"type": "project_moderator", "project_id": "3e79f762-8bae-479e-bc60-057e00cb4357"},
-        {"type": "project_moderator", "project_id": "aa8a29f6-36e2-4b25-98bb-1f069675d3dd"},
-        {"type": "project_moderator", "project_id": "5ea23ead-7209-40f6-95b3-1e6eeae4292f"},
-        {"type": "project_folder_moderator", "project_folder_id": "718cb17c-0a66-490d-8c5c-9c67a92f8ed6"},
-        {"type": "project_moderator", "project_id": "1d3134ea-476d-4471-8fe8-3957da40983e"},
-        {"type": "project_moderator", "project_id": "67170147-3c4e-434d-a13a-15bd8bd25107"},
-        {"type": "project_moderator", "project_id": "bbbc9bde-a82f-4495-af8d-2997dbce6c5a"},
-        {"type": "project_moderator", "project_id": "2774c15b-20c8-4aa0-bb1d-9b5c2b95d54c"},
-        {"type": "project_moderator", "project_id": "faaab0db-2e8d-4705-9fda-1869c4e83a96"},
-        {"type": "project_folder_moderator", "project_folder_id": "b2ca5e59-5c98-49f2-8889-e73390247201"},
-        {"type": "project_moderator", "project_id": "7ed94b9c-a980-4207-b65a-c8a50673621f"},
-        {"type": "project_moderator", "project_id": "cea1ee57-eebe-465d-97d7-3db85d4b23f4"},
-        {"type": "project_moderator", "project_id": "a4283319-a604-49b6-86c0-278c585a90f4"},
-        {"type": "project_moderator", "project_id": "695334d7-0d3d-4277-9b7d-b913c3b7e6a8"},
-        {"type": "project_moderator", "project_id": "07cdc4e6-ed33-4eec-8d9b-b9a8ee8aac16"},
-        {"type": "project_folder_moderator", "project_folder_id": "62c3c7e2-bfd6-48fe-800b-e0b66af7ccab"},
-        {"type": "project_moderator", "project_id": "9d1b959b-c665-478b-a489-ac40cce2ebfa"},
-        {"type": "project_moderator", "project_id": "d9a1e73e-75ee-4753-9ad6-7983c6087fb2"},
-        {"type": "project_moderator", "project_id": "b9e09956-ca18-4bf5-8b90-bcc9e6973aa9"},
-        {"type": "project_moderator", "project_id": "8100f10f-854b-43c8-aca4-9cffe39251f7"},
-        {"type": "project_moderator", "project_id": "a77aaadb-fe07-4e71-b5ca-4e77c8d3b82c"},
-        {"type": "project_folder_moderator", "project_folder_id": "b71098de-ff30-44b3-94a9-8d9b19f6c417"},
-        {"type": "project_moderator", "project_id": "d566673b-154a-482b-a314-9024ff141589"},
-        {"type": "project_moderator", "project_id": "adba8dba-0424-45b6-a5ca-44ad968dafd1"},
-        {"type": "project_moderator", "project_id": "93f091d9-14e7-4608-95ed-f20e93a96670"},
-        {"type": "project_moderator", "project_id": "983b77b6-440b-4d22-a29a-dc73ffe63357"},
-        {"type": "project_moderator", "project_id": "7ec69c50-c16d-4e86-bc21-aff18ea38d72"},
-        {"type": "project_folder_moderator", "project_folder_id": "4e889745-b1ed-4be1-a106-bb8451241f28"},
-        {"type": "project_moderator", "project_id": "a0eebd8c-edbe-48d6-9fc9-58fad82dc663"},
-        {"type": "project_moderator", "project_id": "da35b552-baff-4274-a333-e0ec24385e4e"},
-        {"type": "project_moderator", "project_id": "1874c3e1-035d-463f-8b2e-22cb26f8ef09"},
-        {"type": "project_moderator", "project_id": "e2aefb22-0a70-473e-b16c-99e4006ad632"},
-        {"type": "project_moderator", "project_id": "7e18584c-5113-4640-b6e3-87796cf88fef"},
-        {"type": "project_folder_moderator", "project_folder_id": "fd9b066c-9779-480a-ad24-7f177920d305"}
+        { type: 'project_moderator', project_id: '3498ad3e-930a-43cf-be7c-9d2c9677801f' },
+        { type: 'project_moderator', project_id: 'adba8dba-5678-45b6-a5ca-66d968dafd1' },
+        { type: 'project_moderator', project_id: '0eadacd0-e62f-471e-a4cc-d9cd9fc0a0d2' },
+        { type: 'project_moderator', project_id: '4a330fb2-8df8-4e81-84c2-e12903304c3c' },
+        { type: 'project_folder_moderator', project_folder_id: '188041cc-97da-4580-8edc-aa6cb8fd6958' },
+        { type: 'project_moderator', project_id: 'ae134f80-7318-47d0-a64b-cf64e98e46ec' },
+        { type: 'project_moderator', project_id: 'c05e80c3-066a-43d1-a0bb-c49e7cf9264e' },
+        { type: 'project_moderator', project_id: '9affe4dd-dcb1-4649-a682-cf13579bfd4f' },
+        { type: 'project_moderator', project_id: '84d9bba4-f1fd-46d2-bbbb-7b1baa31de1b' },
+        { type: 'project_moderator', project_id: '3a0cadea-784e-4e24-885a-2b682d57a836' },
+        { type: 'project_folder_moderator', project_folder_id: '87411444-2ea1-4001-ba4c-e382f27bab57' },
+        { type: 'project_moderator', project_id: 'bdfb5e00-3501-4141-a949-e055aec065cd' },
+        { type: 'project_moderator', project_id: 'd7937f3a-5dd8-4b48-a34c-153e13a0eede' },
+        { type: 'project_moderator', project_id: 'e03d1f89-7ab9-48bc-8a95-9f147f8b9c22' },
+        { type: 'project_moderator', project_id: 'a9aef65b-726b-40f7-bc2c-56e2ea5d95df' },
+        { type: 'project_moderator', project_id: '311db9ab-d878-48b5-b23d-98980a358272' },
+        { type: 'project_moderator', project_id: 'dbf6104a-6619-4901-801e-38843aacf853' },
+        { type: 'project_moderator', project_id: '3e79f762-8bae-479e-bc60-057e00cb4357' },
+        { type: 'project_moderator', project_id: 'aa8a29f6-36e2-4b25-98bb-1f069675d3dd' },
+        { type: 'project_moderator', project_id: '5ea23ead-7209-40f6-95b3-1e6eeae4292f' },
+        { type: 'project_folder_moderator', project_folder_id: '718cb17c-0a66-490d-8c5c-9c67a92f8ed6' },
+        { type: 'project_moderator', project_id: '1d3134ea-476d-4471-8fe8-3957da40983e' },
+        { type: 'project_moderator', project_id: '67170147-3c4e-434d-a13a-15bd8bd25107' },
+        { type: 'project_moderator', project_id: 'bbbc9bde-a82f-4495-af8d-2997dbce6c5a' },
+        { type: 'project_moderator', project_id: '2774c15b-20c8-4aa0-bb1d-9b5c2b95d54c' },
+        { type: 'project_moderator', project_id: 'faaab0db-2e8d-4705-9fda-1869c4e83a96' },
+        { type: 'project_folder_moderator', project_folder_id: 'b2ca5e59-5c98-49f2-8889-e73390247201' },
+        { type: 'project_moderator', project_id: '7ed94b9c-a980-4207-b65a-c8a50673621f' },
+        { type: 'project_moderator', project_id: 'cea1ee57-eebe-465d-97d7-3db85d4b23f4' },
+        { type: 'project_moderator', project_id: 'a4283319-a604-49b6-86c0-278c585a90f4' },
+        { type: 'project_moderator', project_id: '695334d7-0d3d-4277-9b7d-b913c3b7e6a8' },
+        { type: 'project_moderator', project_id: '07cdc4e6-ed33-4eec-8d9b-b9a8ee8aac16' },
+        { type: 'project_folder_moderator', project_folder_id: '62c3c7e2-bfd6-48fe-800b-e0b66af7ccab' },
+        { type: 'project_moderator', project_id: '9d1b959b-c665-478b-a489-ac40cce2ebfa' },
+        { type: 'project_moderator', project_id: 'd9a1e73e-75ee-4753-9ad6-7983c6087fb2' },
+        { type: 'project_moderator', project_id: 'b9e09956-ca18-4bf5-8b90-bcc9e6973aa9' },
+        { type: 'project_moderator', project_id: '8100f10f-854b-43c8-aca4-9cffe39251f7' },
+        { type: 'project_moderator', project_id: 'a77aaadb-fe07-4e71-b5ca-4e77c8d3b82c' },
+        { type: 'project_folder_moderator', project_folder_id: 'b71098de-ff30-44b3-94a9-8d9b19f6c417' },
+        { type: 'project_moderator', project_id: 'd566673b-154a-482b-a314-9024ff141589' },
+        { type: 'project_moderator', project_id: 'adba8dba-0424-45b6-a5ca-44ad968dafd1' },
+        { type: 'project_moderator', project_id: '93f091d9-14e7-4608-95ed-f20e93a96670' },
+        { type: 'project_moderator', project_id: '983b77b6-440b-4d22-a29a-dc73ffe63357' },
+        { type: 'project_moderator', project_id: '7ec69c50-c16d-4e86-bc21-aff18ea38d72' },
+        { type: 'project_folder_moderator', project_folder_id: '4e889745-b1ed-4be1-a106-bb8451241f28' },
+        { type: 'project_moderator', project_id: 'a0eebd8c-edbe-48d6-9fc9-58fad82dc663' },
+        { type: 'project_moderator', project_id: 'da35b552-baff-4274-a333-e0ec24385e4e' },
+        { type: 'project_moderator', project_id: '1874c3e1-035d-463f-8b2e-22cb26f8ef09' },
+        { type: 'project_moderator', project_id: 'e2aefb22-0a70-473e-b16c-99e4006ad632' },
+        { type: 'project_moderator', project_id: '7e18584c-5113-4640-b6e3-87796cf88fef' },
+        { type: 'project_folder_moderator', project_folder_id: 'fd9b066c-9779-480a-ad24-7f177920d305' }
       ]
       user = create(:user, roles: roles)
-      expect(user.compress_roles.length.to_f / user.roles.to_s.length.to_f).to be < 0.45
-    end
-  end
-
-  describe '#decompress_roles' do
-    let_it_be(:user) { create(:user) }
-
-    it 'decompresses project roles back to a normal object' do
-      role_string = "false|1874c3e1-035d-463f-8b2e-22cb26f8ef09,e2aefb22-0a70-473e-b16c-99e4006ad632|fd9b066c-9779-480a-ad24-7f177920d305"
-      expect(user.decompress_roles(role_string)).to eq [
-                                                         { "type" => "project_moderator", "project_id" => "1874c3e1-035d-463f-8b2e-22cb26f8ef09" },
-                                                         { "type" => "project_moderator", "project_id" => "e2aefb22-0a70-473e-b16c-99e4006ad632" },
-                                                         { "type" => "project_folder_moderator", "project_folder_id" => "fd9b066c-9779-480a-ad24-7f177920d305" }
-                                                       ]
-    end
-
-    it 'decompresses admin roles back to a normal object' do
-      role_string = "true||"
-      expect(user.decompress_roles(role_string)).to eq [{ "type" => "admin" }]
+      expect(user.compress_roles.to_s.length.to_f / user.roles.to_s.length).to be < 0.20
     end
   end
 

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -1304,6 +1304,100 @@ RSpec.describe User do
     end
   end
 
+  describe '#compress_roles' do
+    it 'compresses project roles to a delimited string' do
+      roles = [
+        {"type": "project_moderator", "project_id": "3498ad3e-930a-43cf-be7c-9d2c9677801f"},
+        {"type": "project_moderator", "project_id": "adba8dba-5678-45b6-a5ca-66d968dafd1"},
+        {"type": "project_folder_moderator", "project_folder_id": "188041cc-97da-4580-8edc-aa6cb8fd6958"}
+      ]
+      user = create(:user, roles: roles)
+      expect(user.compress_roles).to eq 'false|3498ad3e-930a-43cf-be7c-9d2c9677801f,adba8dba-5678-45b6-a5ca-66d968dafd1|188041cc-97da-4580-8edc-aa6cb8fd6958'
+    end
+
+    it 'compresses admin role to a delimited string' do
+      user = create(:user, roles: [{ type: "admin" }])
+      expect(user.compress_roles).to eq 'true||'
+    end
+
+    it 'reduces the string size to less than 45% of the original' do
+      roles = [
+        {"type": "project_moderator", "project_id": "3498ad3e-930a-43cf-be7c-9d2c9677801f"},
+        {"type": "project_moderator", "project_id": "adba8dba-5678-45b6-a5ca-66d968dafd1"},
+        {"type": "project_moderator", "project_id": "0eadacd0-e62f-471e-a4cc-d9cd9fc0a0d2"},
+        {"type": "project_moderator", "project_id": "4a330fb2-8df8-4e81-84c2-e12903304c3c"},
+        {"type": "project_folder_moderator", "project_folder_id": "188041cc-97da-4580-8edc-aa6cb8fd6958"},
+        {"type": "project_moderator", "project_id": "ae134f80-7318-47d0-a64b-cf64e98e46ec"},
+        {"type": "project_moderator", "project_id": "c05e80c3-066a-43d1-a0bb-c49e7cf9264e"},
+        {"type": "project_moderator", "project_id": "9affe4dd-dcb1-4649-a682-cf13579bfd4f"},
+        {"type": "project_moderator", "project_id": "84d9bba4-f1fd-46d2-bbbb-7b1baa31de1b"},
+        {"type": "project_moderator", "project_id": "3a0cadea-784e-4e24-885a-2b682d57a836"},
+        {"type": "project_folder_moderator", "project_folder_id": "87411444-2ea1-4001-ba4c-e382f27bab57"},
+        {"type": "project_moderator", "project_id": "bdfb5e00-3501-4141-a949-e055aec065cd"},
+        {"type": "project_moderator", "project_id": "d7937f3a-5dd8-4b48-a34c-153e13a0eede"},
+        {"type": "project_moderator", "project_id": "e03d1f89-7ab9-48bc-8a95-9f147f8b9c22"},
+        {"type": "project_moderator", "project_id": "a9aef65b-726b-40f7-bc2c-56e2ea5d95df"},
+        {"type": "project_moderator", "project_id": "311db9ab-d878-48b5-b23d-98980a358272"},
+        {"type": "project_folder_moderator", "project_folder_id": "ab872f76-1d1c-44a9-92ea-530684f542ed"},
+        {"type": "project_moderator", "project_id": "dbf6104a-6619-4901-801e-38843aacf853"},
+        {"type": "project_moderator", "project_id": "3e79f762-8bae-479e-bc60-057e00cb4357"},
+        {"type": "project_moderator", "project_id": "aa8a29f6-36e2-4b25-98bb-1f069675d3dd"},
+        {"type": "project_moderator", "project_id": "5ea23ead-7209-40f6-95b3-1e6eeae4292f"},
+        {"type": "project_folder_moderator", "project_folder_id": "718cb17c-0a66-490d-8c5c-9c67a92f8ed6"},
+        {"type": "project_moderator", "project_id": "1d3134ea-476d-4471-8fe8-3957da40983e"},
+        {"type": "project_moderator", "project_id": "67170147-3c4e-434d-a13a-15bd8bd25107"},
+        {"type": "project_moderator", "project_id": "bbbc9bde-a82f-4495-af8d-2997dbce6c5a"},
+        {"type": "project_moderator", "project_id": "2774c15b-20c8-4aa0-bb1d-9b5c2b95d54c"},
+        {"type": "project_moderator", "project_id": "faaab0db-2e8d-4705-9fda-1869c4e83a96"},
+        {"type": "project_folder_moderator", "project_folder_id": "b2ca5e59-5c98-49f2-8889-e73390247201"},
+        {"type": "project_moderator", "project_id": "7ed94b9c-a980-4207-b65a-c8a50673621f"},
+        {"type": "project_moderator", "project_id": "cea1ee57-eebe-465d-97d7-3db85d4b23f4"},
+        {"type": "project_moderator", "project_id": "a4283319-a604-49b6-86c0-278c585a90f4"},
+        {"type": "project_moderator", "project_id": "695334d7-0d3d-4277-9b7d-b913c3b7e6a8"},
+        {"type": "project_moderator", "project_id": "07cdc4e6-ed33-4eec-8d9b-b9a8ee8aac16"},
+        {"type": "project_folder_moderator", "project_folder_id": "62c3c7e2-bfd6-48fe-800b-e0b66af7ccab"},
+        {"type": "project_moderator", "project_id": "9d1b959b-c665-478b-a489-ac40cce2ebfa"},
+        {"type": "project_moderator", "project_id": "d9a1e73e-75ee-4753-9ad6-7983c6087fb2"},
+        {"type": "project_moderator", "project_id": "b9e09956-ca18-4bf5-8b90-bcc9e6973aa9"},
+        {"type": "project_moderator", "project_id": "8100f10f-854b-43c8-aca4-9cffe39251f7"},
+        {"type": "project_moderator", "project_id": "a77aaadb-fe07-4e71-b5ca-4e77c8d3b82c"},
+        {"type": "project_folder_moderator", "project_folder_id": "b71098de-ff30-44b3-94a9-8d9b19f6c417"},
+        {"type": "project_moderator", "project_id": "d566673b-154a-482b-a314-9024ff141589"},
+        {"type": "project_moderator", "project_id": "adba8dba-0424-45b6-a5ca-44ad968dafd1"},
+        {"type": "project_moderator", "project_id": "93f091d9-14e7-4608-95ed-f20e93a96670"},
+        {"type": "project_moderator", "project_id": "983b77b6-440b-4d22-a29a-dc73ffe63357"},
+        {"type": "project_moderator", "project_id": "7ec69c50-c16d-4e86-bc21-aff18ea38d72"},
+        {"type": "project_folder_moderator", "project_folder_id": "4e889745-b1ed-4be1-a106-bb8451241f28"},
+        {"type": "project_moderator", "project_id": "a0eebd8c-edbe-48d6-9fc9-58fad82dc663"},
+        {"type": "project_moderator", "project_id": "da35b552-baff-4274-a333-e0ec24385e4e"},
+        {"type": "project_moderator", "project_id": "1874c3e1-035d-463f-8b2e-22cb26f8ef09"},
+        {"type": "project_moderator", "project_id": "e2aefb22-0a70-473e-b16c-99e4006ad632"},
+        {"type": "project_moderator", "project_id": "7e18584c-5113-4640-b6e3-87796cf88fef"},
+        {"type": "project_folder_moderator", "project_folder_id": "fd9b066c-9779-480a-ad24-7f177920d305"}
+      ]
+      user = create(:user, roles: roles)
+      expect(user.compress_roles.length.to_f / user.roles.to_s.length.to_f).to be < 0.45
+    end
+  end
+
+  describe '#decompress_roles' do
+    let_it_be(:user) { create(:user) }
+
+    it 'decompresses project roles back to a normal object' do
+      role_string = "false|1874c3e1-035d-463f-8b2e-22cb26f8ef09,e2aefb22-0a70-473e-b16c-99e4006ad632|fd9b066c-9779-480a-ad24-7f177920d305"
+      expect(user.decompress_roles(role_string)).to eq [
+                                                         { "type" => "project_moderator", "project_id" => "1874c3e1-035d-463f-8b2e-22cb26f8ef09" },
+                                                         { "type" => "project_moderator", "project_id" => "e2aefb22-0a70-473e-b16c-99e4006ad632" },
+                                                         { "type" => "project_folder_moderator", "project_folder_id" => "fd9b066c-9779-480a-ad24-7f177920d305" }
+                                                       ]
+    end
+
+    it 'decompresses admin roles back to a normal object' do
+      role_string = "true||"
+      expect(user.decompress_roles(role_string)).to eq [{ "type" => "admin" }]
+    end
+  end
+
   context 'billed users' do
     def create_admin_moderator(factory)
       create(factory).tap do |user|


### PR DESCRIPTION
I think this is a workable solution to fixing the size of roles in the JWT as not all the data in the roles object is actually needed by the codebases that read the JWT roles:

- cl2-workshops only looks for a single instance of `type: project_moderator` to allow admin access. It does not care about the project IDs - https://github.com/CitizenLabDotCo/cl2-workshops/blob/e7f45633766c40aa0d1d93c0d5c8cd94173a8423/lib/cl2_workshops/user_service.ex#L39-L40
- cl2-admin-templates only requires `type: project_folder_moderator` and the project folder IDs. It does not look at `type: project_moderator` - https://github.com/CitizenLabDotCo/cl2-admin-templates/blob/4b28b3c8005c85f4d10880d96f43b3732e2cd2d9/app/services/roles_service.rb#L8

Therefore we can remove all the project IDs from the roles object, which reduces the space required massively, and does not require any changes to the codebases that read the roles from the JWT. 

Doing some analysis on Metabase, there are 4 platforms where there are over 40 project folders, which is about the maximum that the roles object can have before it is too big for the cookie. However, in terms of users, [the maximum number of project_folder_moderator_roles applied to any user is 9](https://metabase.hq.citizenlab.co/question/2224-long-user-role-lists), so this shouldn't be an issue. 

# Changelog
## Fixed
- TAN-2565 - Reduced user role information written to JWT to fix users with lots of project moderator roles not being able to login
