### PR TITLE
TAN-2711: fix changing participation method

### DIFF
--- a/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/ParticipationMethodPicker.tsx
+++ b/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/ParticipationMethodPicker.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 import {
   IconTooltip,
@@ -97,6 +97,15 @@ const ParticipationMethodPicker = ({
   const proposalsParticipationMethodEnabled = useFeatureFlag({
     name: 'proposals_participation_method',
   });
+
+  useEffect(() => {
+    setSelectedMethod(participation_method);
+    setShowSurveyOptions(
+      participation_method === 'native_survey' ||
+        participation_method === 'survey' ||
+        participation_method === 'poll'
+    );
+  }, [participation_method]);
 
   const changeMethod = (newMethod?: ParticipationMethod) => {
     const method = newMethod || methodToChangeTo;

--- a/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/ParticipationMethodPicker.tsx
+++ b/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/ParticipationMethodPicker.tsx
@@ -116,6 +116,11 @@ const ParticipationMethodPicker = ({
   const handleMethodSelect = (event, method: ParticipationMethod) => {
     event.preventDefault();
 
+    // We don't want to change the method if it is the same
+    if (selectedMethod === method) {
+      return;
+    }
+
     if (phase) {
       setMethodToChangeTo(method);
       setShowChangeMethodModal(true);


### PR DESCRIPTION
# Changelog

## Fixed
- Switching to a different phase on the timeline in the back office now correctly updates the selected phase in the method picker
