### PR TITLE
[TAN-2791] Remove areas_projects duplicates and add uniqueness index

### DIFF
--- a/back/app/models/areas_project.rb
+++ b/back/app/models/areas_project.rb
@@ -4,14 +4,15 @@
 #
 # Table name: areas_projects
 #
-#  id         :uuid             not null, primary key
 #  area_id    :uuid
 #  project_id :uuid
+#  id         :uuid             not null, primary key
 #
 # Indexes
 #
-#  index_areas_projects_on_area_id     (area_id)
-#  index_areas_projects_on_project_id  (project_id)
+#  index_areas_projects_on_area_id                 (area_id)
+#  index_areas_projects_on_project_id              (project_id)
+#  index_areas_projects_on_project_id_and_area_id  (project_id,area_id) UNIQUE
 #
 # Foreign Keys
 #

--- a/back/app/models/areas_project.rb
+++ b/back/app/models/areas_project.rb
@@ -10,8 +10,9 @@
 #
 # Indexes
 #
-#  index_areas_projects_on_area_id     (area_id)
-#  index_areas_projects_on_project_id  (project_id)
+#  index_areas_projects_on_area_id                 (area_id)
+#  index_areas_projects_on_project_id              (project_id)
+#  index_areas_projects_on_project_id_and_area_id  (project_id,area_id) UNIQUE
 #
 # Foreign Keys
 #

--- a/back/app/models/areas_project.rb
+++ b/back/app/models/areas_project.rb
@@ -10,9 +10,8 @@
 #
 # Indexes
 #
-#  index_areas_projects_on_area_id                 (area_id)
-#  index_areas_projects_on_project_id              (project_id)
-#  index_areas_projects_on_project_id_and_area_id  (project_id,area_id) UNIQUE
+#  index_areas_projects_on_area_id     (area_id)
+#  index_areas_projects_on_project_id  (project_id)
 #
 # Foreign Keys
 #

--- a/back/db/migrate/20241011101454_add_uniqueness_constraint_to_areas_projects.rb
+++ b/back/db/migrate/20241011101454_add_uniqueness_constraint_to_areas_projects.rb
@@ -1,0 +1,18 @@
+class AddUniquenessConstraintToAreasProjects < ActiveRecord::Migration[7.0]
+  def change
+    ActiveRecord::Base.connection.execute(
+      # After https://stackoverflow.com/a/12963112/3585671
+      <<-SQL.squish
+      DELETE FROM areas_projects to_delete USING (
+        SELECT MIN(id::text) AS id, project_id, area_id
+          FROM areas_projects 
+          GROUP BY (project_id, area_id) HAVING COUNT(*) > 1
+        ) keep_from_duplicates
+        WHERE to_delete.project_id = keep_from_duplicates.project_id
+        AND to_delete.area_id = keep_from_duplicates.area_id
+        AND to_delete.id::text <> keep_from_duplicates.id
+      SQL
+    )
+    add_index :areas_projects, %i[project_id area_id], unique: true
+  end
+end

--- a/back/db/migrate/20241011101454_add_uniqueness_constraint_to_areas_projects.rb
+++ b/back/db/migrate/20241011101454_add_uniqueness_constraint_to_areas_projects.rb
@@ -1,5 +1,0 @@
-class AddUniquenessConstraintToAreasProjects < ActiveRecord::Migration[7.0]
-  def change
-    add_index :areas_projects, %i[project_id area_id], unique: true
-  end
-end

--- a/back/db/migrate/20241011101454_add_uniqueness_constraint_to_areas_projects.rb
+++ b/back/db/migrate/20241011101454_add_uniqueness_constraint_to_areas_projects.rb
@@ -1,0 +1,5 @@
+class AddUniquenessConstraintToAreasProjects < ActiveRecord::Migration[7.0]
+  def change
+    add_index :areas_projects, %i[project_id area_id], unique: true
+  end
+end

--- a/back/db/structure.sql
+++ b/back/db/structure.sql
@@ -335,6 +335,7 @@ DROP INDEX IF EXISTS public.index_baskets_ideas_on_idea_id;
 DROP INDEX IF EXISTS public.index_baskets_ideas_on_basket_id_and_idea_id;
 DROP INDEX IF EXISTS public.index_areas_static_pages_on_static_page_id;
 DROP INDEX IF EXISTS public.index_areas_static_pages_on_area_id;
+DROP INDEX IF EXISTS public.index_areas_projects_on_project_id_and_area_id;
 DROP INDEX IF EXISTS public.index_areas_projects_on_project_id;
 DROP INDEX IF EXISTS public.index_areas_projects_on_area_id;
 DROP INDEX IF EXISTS public.index_areas_on_include_in_onboarding;
@@ -4678,6 +4679,13 @@ CREATE INDEX index_areas_projects_on_project_id ON public.areas_projects USING b
 
 
 --
+-- Name: index_areas_projects_on_project_id_and_area_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_areas_projects_on_project_id_and_area_id ON public.areas_projects USING btree (project_id, area_id);
+
+
+--
 -- Name: index_areas_static_pages_on_area_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7542,6 +7550,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240923112801'),
 ('20240926175000'),
 ('20241001101704'),
-('20241002200522');
+('20241002200522'),
+('20241011101454');
 
 

--- a/back/db/structure.sql
+++ b/back/db/structure.sql
@@ -335,7 +335,6 @@ DROP INDEX IF EXISTS public.index_baskets_ideas_on_idea_id;
 DROP INDEX IF EXISTS public.index_baskets_ideas_on_basket_id_and_idea_id;
 DROP INDEX IF EXISTS public.index_areas_static_pages_on_static_page_id;
 DROP INDEX IF EXISTS public.index_areas_static_pages_on_area_id;
-DROP INDEX IF EXISTS public.index_areas_projects_on_project_id_and_area_id;
 DROP INDEX IF EXISTS public.index_areas_projects_on_project_id;
 DROP INDEX IF EXISTS public.index_areas_projects_on_area_id;
 DROP INDEX IF EXISTS public.index_areas_on_include_in_onboarding;
@@ -4679,13 +4678,6 @@ CREATE INDEX index_areas_projects_on_project_id ON public.areas_projects USING b
 
 
 --
--- Name: index_areas_projects_on_project_id_and_area_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_areas_projects_on_project_id_and_area_id ON public.areas_projects USING btree (project_id, area_id);
-
-
---
 -- Name: index_areas_static_pages_on_area_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7550,7 +7542,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240923112801'),
 ('20240926175000'),
 ('20241001101704'),
-('20241002200522'),
-('20241011101454');
+('20241002200522');
 
 


### PR DESCRIPTION
Tested locally (on 2 tenants, each with one project with `areas_projects` that are not duplicated, and one project with duplicate `areas_projects`). Removes duplicates, and leaves unique records in place.

# Changelog
## Technical
[TAN-2791] Remove areas_projects duplicates and add uniqueness index
