### PR TITLE
[TAN-2794] Added the ability to hide verification methods from the front end (for Oslo)

### DIFF
--- a/back/app/models/app_configuration.rb
+++ b/back/app/models/app_configuration.rb
@@ -147,7 +147,7 @@ class AppConfiguration < ApplicationRecord
   end
 
   def public_settings
-    @public_settings ||= SettingsService.new.remove_private_settings(settings, Settings.json_schema)
+    @public_settings ||= SettingsService.new.format_for_front_end(settings, Settings.json_schema)
   end
 
   def location

--- a/back/app/services/settings_service.rb
+++ b/back/app/services/settings_service.rb
@@ -67,14 +67,8 @@ class SettingsService
     res
   end
 
-  def remove_private_settings(settings, schema)
-    res = settings.deep_dup
-    schema['properties'].each do |feature, feature_schema|
-      feature_schema['properties'].each do |setting, setting_schema|
-        res[feature]&.delete(setting) if setting_schema['private']
-      end
-    end
-    res
+  def format_for_front_end(settings, schema)
+    remove_private_settings(settings, schema)
   end
 
   def activate_feature!(feature, config: nil, settings: {})
@@ -112,7 +106,19 @@ class SettingsService
 
   private
 
+  def remove_private_settings(settings, schema)
+    res = settings.deep_dup
+    schema['properties'].each do |feature, feature_schema|
+      feature_schema['properties'].each do |setting, setting_schema|
+        res[feature]&.delete(setting) if setting_schema['private']
+      end
+    end
+    res
+  end
+
   def default_setting(schema, feature, setting)
     schema.dig('properties', feature, 'properties', setting, 'default')
   end
 end
+
+SettingsService.prepend(Verification::Patches::SettingsService)

--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -1368,6 +1368,8 @@
     "id_gent_rrn": ["verification"],
     "id_oostende_rrn": ["verification"],
     "id_id_card_lookup": ["verification"],
+    "id_keycloak": ["verification"],
+
     "power_bi": ["public_api_tokens"],
     "large_summaries": ["analysis"],
     "ask_a_question": ["analysis"],

--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -1368,6 +1368,7 @@
     "id_gent_rrn": ["verification"],
     "id_oostende_rrn": ["verification"],
     "id_id_card_lookup": ["verification"],
+    "id_keycloak": ["verification"],
     "power_bi": ["public_api_tokens"],
     "large_summaries": ["analysis"],
     "ask_a_question": ["analysis"],

--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -1368,7 +1368,6 @@
     "id_gent_rrn": ["verification"],
     "id_oostende_rrn": ["verification"],
     "id_id_card_lookup": ["verification"],
-    "id_keycloak": ["verification"],
     "power_bi": ["public_api_tokens"],
     "large_summaries": ["analysis"],
     "ask_a_question": ["analysis"],

--- a/back/engines/commercial/id_keycloak/app/lib/id_keycloak/keycloak_omniauth.rb
+++ b/back/engines/commercial/id_keycloak/app/lib/id_keycloak/keycloak_omniauth.rb
@@ -46,8 +46,8 @@ module IdKeycloak
     end
 
     def email_confirmed?(auth)
-      # Response will tell us if the email is verified
-      auth&.info&.email_verified
+      # Even if the response says the email is NOT verified, we assume that it is if email is present
+      auth&.info&.email.present?
     end
 
     def filter_auth_to_persist(auth)

--- a/back/engines/commercial/id_keycloak/app/lib/id_keycloak/keycloak_verification.rb
+++ b/back/engines/commercial/id_keycloak/app/lib/id_keycloak/keycloak_verification.rb
@@ -22,6 +22,7 @@ module IdKeycloak
         domain
         client_id
         client_secret
+        enabled_for_verified_actions
         hide_from_profile
       ]
     end
@@ -34,6 +35,16 @@ module IdKeycloak
           type: 'string',
           description: 'The name this verification method will have in the UI',
           default: 'ID-Porten'
+        },
+        enabled_for_verified_actions: {
+          private: true,
+          type: 'boolean',
+          description: 'Whether this verification method should be enabled for verified actions.'
+        },
+        hide_from_profile: {
+          private: true,
+          type: 'boolean',
+          description: 'Should verification be shown in the user profile and under the username?'
         }
       }
     end
@@ -58,10 +69,6 @@ module IdKeycloak
 
     def updateable_user_attrs
       super + %i[first_name last_name]
-    end
-
-    def show_in_user_profile?
-      false
     end
   end
 end

--- a/back/engines/commercial/id_keycloak/app/lib/id_keycloak/keycloak_verification.rb
+++ b/back/engines/commercial/id_keycloak/app/lib/id_keycloak/keycloak_verification.rb
@@ -44,7 +44,7 @@ module IdKeycloak
         hide_from_profile: {
           private: true,
           type: 'boolean',
-          description: 'Should verification be shown in the user profile and under the username?'
+          description: 'Should verification be hidden in the user profile and under the username?'
         }
       }
     end
@@ -69,6 +69,10 @@ module IdKeycloak
 
     def updateable_user_attrs
       super + %i[first_name last_name]
+    end
+
+    def enabled_for_verified_actions?
+      config[:enabled_for_verified_actions] || false
     end
   end
 end

--- a/back/engines/commercial/id_keycloak/app/lib/id_keycloak/keycloak_verification.rb
+++ b/back/engines/commercial/id_keycloak/app/lib/id_keycloak/keycloak_verification.rb
@@ -22,8 +22,11 @@ module IdKeycloak
         domain
         client_id
         client_secret
+        hide_from_profile
       ]
     end
+
+    # TODO: JS - Implement hide_from_profile
 
     def config_parameters_schema
       {
@@ -55,6 +58,10 @@ module IdKeycloak
 
     def updateable_user_attrs
       super + %i[first_name last_name]
+    end
+
+    def show_in_user_profile?
+      false
     end
   end
 end

--- a/back/engines/commercial/id_keycloak/app/lib/id_keycloak/keycloak_verification.rb
+++ b/back/engines/commercial/id_keycloak/app/lib/id_keycloak/keycloak_verification.rb
@@ -27,8 +27,6 @@ module IdKeycloak
       ]
     end
 
-    # TODO: JS - Implement hide_from_profile
-
     def config_parameters_schema
       {
         ui_method_name: {
@@ -73,6 +71,10 @@ module IdKeycloak
 
     def enabled_for_verified_actions?
       config[:enabled_for_verified_actions] || false
+    end
+
+    def ui_method_name
+      config[:ui_method_name] || name
     end
   end
 end

--- a/back/engines/commercial/verification/app/models/verification/verification_method.rb
+++ b/back/engines/commercial/verification/app/models/verification/verification_method.rb
@@ -17,5 +17,9 @@ module Verification
         .symbolize_keys
         .presence
     end
+
+    def show_in_user_profile?
+      false
+    end
   end
 end

--- a/back/engines/commercial/verification/app/models/verification/verification_method.rb
+++ b/back/engines/commercial/verification/app/models/verification/verification_method.rb
@@ -17,9 +17,5 @@ module Verification
         .symbolize_keys
         .presence
     end
-
-    def show_in_user_profile?
-      false
-    end
   end
 end

--- a/back/engines/commercial/verification/app/services/verification/patches/settings_service.rb
+++ b/back/engines/commercial/verification/app/services/verification/patches/settings_service.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Verification
+  module Patches
+    module SettingsService
+      def format_for_front_end(settings, schema)
+        settings = disable_verification_if_no_methods_enabled(settings)
+        super(settings, schema)
+      end
+
+      private
+
+      # Ensures the FE does not show verification if:
+      # a) There are no verification methods
+      # b) All verification methods are flagged as 'hide_from_profile'
+      def disable_verification_if_no_methods_enabled(settings)
+        return settings if settings['verification']['enabled'] == false
+
+        enabled = settings['verification']['verification_methods'].present?
+        enabled = false if settings['verification']['verification_methods']&.pluck('hide_in_profile')&.all?(true)
+
+        settings['verification']['enabled'] = enabled
+        settings
+      end
+    end
+  end
+end

--- a/back/engines/commercial/verification/app/services/verification/patches/settings_service.rb
+++ b/back/engines/commercial/verification/app/services/verification/patches/settings_service.rb
@@ -17,7 +17,7 @@ module Verification
         return settings if !settings['verification'] || settings['verification']['enabled'] == false
 
         enabled = settings['verification']['verification_methods'].present?
-        enabled = false if settings['verification']['verification_methods']&.pluck('hide_in_profile')&.all?(true)
+        enabled = false if settings['verification']['verification_methods']&.pluck('hide_from_profile')&.all?(true)
 
         settings['verification']['enabled'] = enabled
         settings

--- a/back/engines/commercial/verification/app/services/verification/patches/settings_service.rb
+++ b/back/engines/commercial/verification/app/services/verification/patches/settings_service.rb
@@ -5,7 +5,7 @@ module Verification
     module SettingsService
       def format_for_front_end(settings, schema)
         settings = disable_verification_if_no_methods_enabled(settings)
-        super(settings, schema)
+        super
       end
 
       private
@@ -14,7 +14,7 @@ module Verification
       # a) There are no verification methods
       # b) All verification methods are flagged as 'hide_from_profile'
       def disable_verification_if_no_methods_enabled(settings)
-        return settings if settings['verification']['enabled'] == false
+        return settings if !settings['verification'] || settings['verification']['enabled'] == false
 
         enabled = settings['verification']['verification_methods'].present?
         enabled = false if settings['verification']['verification_methods']&.pluck('hide_in_profile')&.all?(true)

--- a/back/engines/commercial/verification/spec/services/settings_service_spec.rb
+++ b/back/engines/commercial/verification/spec/services/settings_service_spec.rb
@@ -25,11 +25,11 @@ describe SettingsService do
           'enabled' => true,
           'verification_methods' => [
             {
-              'name' => "nemlog_in",
+              'name' => 'nemlog_in',
               'hide_in_profile' => true
             },
             {
-              'name' => "keycloak",
+              'name' => 'keycloak',
               'hide_in_profile' => true
             }
           ]
@@ -47,10 +47,10 @@ describe SettingsService do
           'enabled' => true,
           'verification_methods' => [
             {
-              'name' => "nemlog_in"
+              'name' => 'nemlog_in'
             },
             {
-              'name' => "keycloak",
+              'name' => 'keycloak',
               'hide_in_profile' => true
             }
           ]

--- a/back/engines/commercial/verification/spec/services/settings_service_spec.rb
+++ b/back/engines/commercial/verification/spec/services/settings_service_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe SettingsService do
+  let(:ss) { described_class.new }
+
+  describe 'disable_verification_if_no_methods_enabled' do
+    it 'disables verification if there are no methods enabled' do
+      settings = {
+        'verification' => {
+          'allowed' => true,
+          'enabled' => true
+        }
+      }
+
+      updated_settings = ss.send(:disable_verification_if_no_methods_enabled, settings)
+      expect(updated_settings['verification']['enabled']).to be false
+    end
+
+    it 'disables verification if all methods are hidden from the profile' do
+      settings = {
+        'verification' => {
+          'allowed' => true,
+          'enabled' => true,
+          'verification_methods' => [
+            {
+              'name' => "nemlog_in",
+              'hide_in_profile' => true
+            },
+            {
+              'name' => "keycloak",
+              'hide_in_profile' => true
+            }
+          ]
+        }
+      }
+
+      updated_settings = ss.send(:disable_verification_if_no_methods_enabled, settings)
+      expect(updated_settings['verification']['enabled']).to be false
+    end
+
+    it 'does not disable verification if at least one methods is NOT hidden from the profile' do
+      settings = {
+        'verification' => {
+          'allowed' => true,
+          'enabled' => true,
+          'verification_methods' => [
+            {
+              'name' => "nemlog_in"
+            },
+            {
+              'name' => "keycloak",
+              'hide_in_profile' => true
+            }
+          ]
+        }
+      }
+
+      updated_settings = ss.send(:disable_verification_if_no_methods_enabled, settings)
+      expect(updated_settings['verification']['enabled']).to be true
+    end
+  end
+end

--- a/back/engines/commercial/verification/spec/services/settings_service_spec.rb
+++ b/back/engines/commercial/verification/spec/services/settings_service_spec.rb
@@ -26,11 +26,11 @@ describe SettingsService do
           'verification_methods' => [
             {
               'name' => 'nemlog_in',
-              'hide_in_profile' => true
+              'hide_from_profile' => true
             },
             {
               'name' => 'keycloak',
-              'hide_in_profile' => true
+              'hide_from_profile' => true
             }
           ]
         }

--- a/back/engines/commercial/verification/spec/services/settings_service_spec.rb
+++ b/back/engines/commercial/verification/spec/services/settings_service_spec.rb
@@ -40,7 +40,7 @@ describe SettingsService do
       expect(updated_settings['verification']['enabled']).to be false
     end
 
-    it 'does not disable verification if at least one methods is NOT hidden from the profile' do
+    it 'does not disable verification if at least one method is NOT hidden from the profile' do
       settings = {
         'verification' => {
           'allowed' => true,

--- a/back/spec/services/settings_service_spec.rb
+++ b/back/spec/services/settings_service_spec.rb
@@ -194,7 +194,7 @@ describe SettingsService do
     end
   end
 
-  describe 'remove_private_settings' do
+  describe 'format_for_front_end' do
     let(:schema) do
       {
         'type' => 'object',
@@ -214,7 +214,7 @@ describe SettingsService do
       settings = {
         'a' => { 'settings1' => true }
       }
-      expect(ss.remove_private_settings(settings, schema)).to eq settings
+      expect(ss.format_for_front_end(settings, schema)).to eq settings
     end
 
     it 'removes private settings' do
@@ -224,7 +224,7 @@ describe SettingsService do
       expected_settings = {
         'a' => { 'settings1' => true }
       }
-      expect(ss.remove_private_settings(settings, schema)).to eq expected_settings
+      expect(ss.format_for_front_end(settings, schema)).to eq expected_settings
     end
   end
 end


### PR DESCRIPTION
# Changelog
## Added
- Verification can now be hidden from the user profile (and badge) by selecting the `hide_from_profile` option in the method configuration. This is useful where we only need verification via SSO. Additionally if verification has been enabled but no methods are present it will also be hidden (which was not the case before)

## Changed
- ID-Porten SSO will now always confirm an email if present and can be used with verified actions
