### PR TITLE
[TAN-2807] Serialize navbar_item slug, if any

### DIFF
--- a/back/app/models/nav_bar_item.rb
+++ b/back/app/models/nav_bar_item.rb
@@ -69,6 +69,12 @@ class NavBarItem < ApplicationRecord
     fallback_title_multiloc.merge(title_multiloc || {})
   end
 
+  def item_slug
+    return project.slug if project?
+
+    static_page.slug if page?
+  end
+
   private
 
   def set_code

--- a/back/app/serializers/web_api/v1/nav_bar_item_serializer.rb
+++ b/back/app/serializers/web_api/v1/nav_bar_item_serializer.rb
@@ -7,6 +7,10 @@ class WebApi::V1::NavBarItemSerializer < WebApi::V1::BaseSerializer
     item.title_multiloc_with_fallback
   end
 
+  attribute :slug do |item|
+    item.item_slug
+  end
+
   belongs_to :static_page, serializer: WebApi::V1::StaticPageSerializer
   belongs_to :project, serializer: ::WebApi::V1::ProjectSerializer
 end

--- a/back/spec/acceptance/nav_bar_items_spec.rb
+++ b/back/spec/acceptance/nav_bar_items_spec.rb
@@ -10,8 +10,11 @@ resource 'NavBarItems' do
 
   get 'web_api/v1/nav_bar_items' do
     before do
+      @static_page = create(:static_page, slug: 'static-page')
+      @project = create(:project, slug: 'project')
       @items = [
-        create(:nav_bar_item, code: 'custom'),
+        create(:nav_bar_item, code: 'custom', project: nil, static_page: @static_page),
+        create(:nav_bar_item, code: 'custom', project: @project, static_page: nil),
         create(:nav_bar_item, code: 'proposals'),
         create(:nav_bar_item, code: 'events'),
         create(:nav_bar_item, code: 'home')
@@ -21,9 +24,13 @@ resource 'NavBarItems' do
 
     example_request 'List all NavBarItems' do
       assert_status 200
-      expect(json_response_body[:data].size).to eq 4
-      expect(json_response_body[:data].map { |d| d.dig(:attributes, :ordering) }).to eq [0, 1, 2, 3]
-      expect(json_response_body[:data].map { |d| d.dig(:attributes, :code) }).to eq %w[home custom proposals events]
+      expect(json_response_body[:data].size).to eq 5
+      expect(json_response_body[:data].map { |d| d.dig(:attributes, :ordering) }).to eq [0, 1, 2, 3, 4]
+      expect(json_response_body[:data].map { |d| d.dig(:attributes, :slug) })
+        .to eq [nil, @static_page.slug, @project.slug, nil, nil]
+
+      expect(json_response_body[:data].map { |d| d.dig(:attributes, :code) })
+        .to eq %w[home custom custom proposals events]
     end
 
     context 'when NavBarItem is disabled by corresponding disabled feature' do
@@ -32,7 +39,7 @@ resource 'NavBarItems' do
       end
 
       example_request 'Does not list feature-disabled NavBarItems' do
-        expect(json_response_body[:data].map { |d| d.dig(:attributes, :code) }).to eq %w[home custom events]
+        expect(json_response_body[:data].map { |d| d.dig(:attributes, :code) }).to eq %w[home custom custom events]
       end
     end
   end


### PR DESCRIPTION
# Changelog
## Technical
- [TAN-2807] Serialize `nav_bar_item` item slug, if any. First step towards simplifying & improving homepage queries.
