### PR TITLE
TAN-2773 - Stopped templates from allowing permitted_by verified

### DIFF
--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/permission.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/permission.rb
@@ -5,7 +5,10 @@ module MultiTenancy
     module Serializers
       class Permission < Base
         ref_attribute :permission_scope
-        attributes %i[action permitted_by global_custom_fields]
+        attributes %i[action global_custom_fields]
+
+        # Permitted by 'verified' is only allowed if verification turned on in settings, so should fallback to 'users' when written to templates
+        attribute(:permitted_by) { |permission| permission.permitted_by == 'verified' ? 'users' : permission.permitted_by }
       end
     end
   end

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/templates.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/templates.rake
@@ -125,13 +125,6 @@ namespace :templates do
       lifecycle_stage: 'demo'
     ) }.with_indifferent_access
 
-    # Required for verified actions
-    config_attrs[:settings][:verification] = {
-      enabled: true,
-      allowed: true,
-      verification_methods: [{ name: 'fake_sso' }]
-    }
-
     _success, tenant, _app_config = MultiTenancy::TenantService.new.initialize_tenant(
       tenant_attrs, config_attrs
     )

--- a/back/engines/commercial/multi_tenancy/spec/services/multi_tenancy/templates/tenant_serializer_spec.rb
+++ b/back/engines/commercial/multi_tenancy/spec/services/multi_tenancy/templates/tenant_serializer_spec.rb
@@ -313,5 +313,14 @@ describe MultiTenancy::Templates::TenantSerializer do
       expect(template['models']['user'].last['email']).to be_nil
       expect(template['models']['user'].last['unique_code']).not_to be_nil
     end
+
+    it 'changes "verified" permissions to "user" permissions' do
+      SettingsService.new.activate_feature! 'verification', settings: { verification_methods: [{ name: 'fake_sso' }] }
+      create(:permission, :by_admins_moderators)
+      create(:permission, :by_verified)
+      template = tenant_serializer.run(deserializer_format: true)
+      expect(template['models']['permission'].first['permitted_by']).to eq 'admins_moderators' # Not changed
+      expect(template['models']['permission'].last['permitted_by']).to eq 'users' # Changed
+    end
   end
 end


### PR DESCRIPTION
# Changelog
## Fixed
- Fixed templates to stop errors with Permissions where permitted_by = verified
