### PR TITLE
TAN-2813 - Ensure ManualProjectParticipants campaign gets destroyed if project is destroyed

### DIFF
--- a/back/engines/free/email_campaigns/app/models/email_campaigns/extensions/project.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/extensions/project.rb
@@ -6,7 +6,8 @@ module EmailCampaigns
       def self.included(base)
         base.has_many :email_campaigns,
           foreign_key: :context_id,
-          class_name: 'EmailCampaigns::Campaigns::ManualProjectParticipants'
+          class_name: 'EmailCampaigns::Campaigns::ManualProjectParticipants',
+          dependent: :destroy
       end
     end
   end

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/manual_project_participants_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/manual_project_participants_spec.rb
@@ -13,6 +13,14 @@ RSpec.describe EmailCampaigns::Campaigns::ManualProjectParticipants do
     it { is_expected.to validate_presence_of(:context_id) }
 
     it { is_expected.to belong_to(:project) }
+
+    it 'destroys the campaign when the project is destroyed' do
+      campaign = create(:manual_project_participants_campaign)
+      project = campaign.project
+      project.destroy!
+      expect { project.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { campaign.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
   end
 
   describe '#apply_recipient_filters' do


### PR DESCRIPTION
# Changelog
## Fixed
- Inconsistent data fix - ManualProjectParticipants campaign is deleted when a project is deleted
