### PR TITLE
Update tenant settings rake to use the non deprecated way of updating…

### DIFF
--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/tenant_settings.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/tenant_settings.rake
@@ -3,12 +3,14 @@
 namespace :tenant_settings do
   desc 'Enable tenant feature'
   task :enable_feature, [:feature] => [:environment] do |_t, args|
+    feature = args[:feature]
     failed = []
     Tenant.where.not(host: 'i18n.stg.citizenlab.co').each do |tn|
       Apartment::Tenant.switch(tn.schema_name) do
-        tn.settings[args[:feature]]['allowed'] = true
-        tn.settings[args[:feature]]['enabled'] = true
-        failed += [tn.host] unless tn.save
+        app_config = AppConfiguration.instance
+        app_config.settings[feature]['allowed'] = true
+        app_config.settings[feature]['enabled'] = true
+        failed += [tn.host] unless app_config.save
       end
     end
     if failed.present?
@@ -20,12 +22,14 @@ namespace :tenant_settings do
 
   desc 'Disable tenant feature'
   task :disable_feature, [:feature] => [:environment] do |_t, args|
+    feature = args[:feature]
     failed = []
     Tenant.where.not(host: 'i18n.stg.citizenlab.co').each do |tn|
       Apartment::Tenant.switch(tn.schema_name) do
-        tn.settings[args[:feature]]['allowed'] = false
-        tn.settings[args[:feature]]['enabled'] = false
-        failed += [tn.host] unless tn.save
+        app_config = AppConfiguration.instance
+        app_config.settings[feature]['allowed'] = false
+        app_config.settings[feature]['enabled'] = false
+        failed += [tn.host] unless app_config.save
       end
     end
     if failed.present?

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/tenant_settings.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/tenant_settings.rake
@@ -6,7 +6,7 @@ namespace :tenant_settings do
     feature = args[:feature]
     failed = []
     Tenant.where.not(host: 'i18n.stg.citizenlab.co').each do |tn|
-      Apartment::Tenant.switch(tn.schema_name) do
+      tn.switch do
         app_config = AppConfiguration.instance
         app_config.settings[feature]['allowed'] = true
         app_config.settings[feature]['enabled'] = true
@@ -25,7 +25,7 @@ namespace :tenant_settings do
     feature = args[:feature]
     failed = []
     Tenant.where.not(host: 'i18n.stg.citizenlab.co').each do |tn|
-      Apartment::Tenant.switch(tn.schema_name) do
+      tn.switch do
         app_config = AppConfiguration.instance
         app_config.settings[feature]['allowed'] = false
         app_config.settings[feature]['enabled'] = false


### PR DESCRIPTION
Rake task doesn't seem to work at the moment - and is throwing all [these errors](https://sentry.hq.citizenlab.co/organizations/citizenlab/issues/85602/?project=2&query=is%3Aunresolved) to Sentry, so updated

# Changelog
## Technical
- remove deprecated method from tenant_settings rake
