### PR TITLE
Sentry fixes after proposals migration

### DIFF
--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/new_idea_for_admin.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/new_idea_for_admin.rb
@@ -57,7 +57,8 @@ module EmailCampaigns
     def filter_recipient(users_scope, activity:, time: nil)
       input = activity.item
       initiator = input.author
-      return users_scope.none if UserRoleService.new.moderates_something? initiator
+      return users_scope.none if !input.participation_method_on_creation.supports_public_visibility?
+      return users_scope.none if initiator && UserRoleService.new.moderates_something?(initiator)
 
       UserRoleService.new.moderators_for(input, users_scope)
     end

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/user_digest.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/user_digest.rb
@@ -102,7 +102,7 @@ module EmailCampaigns
     end
 
     # @return [Boolean]
-    def content_worth_sending?(time:)
+    def content_worth_sending?(time:, activity: nil)
       # Check positive? as fetching a non-integer env var would result in zero and this hook would return true,
       # whilst top_ideas would be limited to zero ideas, possibly resulting in no content being sent.
       @content_worth_sending ||=

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/new_idea_for_admin_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/new_idea_for_admin_spec.rb
@@ -47,6 +47,23 @@ RSpec.describe EmailCampaigns::Campaigns::NewIdeaForAdmin do
       idea_published = create(:activity, item: idea, action: 'published')
       expect(campaign.apply_recipient_filters(activity: idea_published).count).to eq 0
     end
+
+    it 'keeps moderators if the author is anonymous' do
+      idea = create(:idea, anonymous: true)
+      moderator = create(:project_moderator, projects: [idea.project])
+
+      idea_published = create(:activity, item: idea, action: 'published')
+      expect(campaign.apply_recipient_filters(activity: idea_published)).to eq([moderator])
+    end
+
+    it 'filters out everyone for a native survey response' do
+      create(:idea_status_proposed)
+      input = create(:native_survey_response)
+      create(:admin)
+
+      input_published = create(:activity, item: input, action: 'published')
+      expect(campaign.apply_recipient_filters(activity: input_published).count).to eq 0
+    end
   end
 
   describe '#generate_commands' do

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/user_digest_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/user_digest_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe EmailCampaigns::Campaigns::UserDigest do
 
   describe 'before_send_hooks' do
     let(:campaign) { build(:user_digest_campaign) }
+
     let_it_be(:activity) { create(:activity) }
 
     it 'returns true when there are at least 3 ideas updated in the last week' do

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/user_digest_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/user_digest_spec.rb
@@ -77,15 +77,16 @@ RSpec.describe EmailCampaigns::Campaigns::UserDigest do
 
   describe 'before_send_hooks' do
     let(:campaign) { build(:user_digest_campaign) }
+    let_it_be(:activity) { create(:activity) }
 
     it 'returns true when there are at least 3 ideas updated in the last week' do
       create_list(:idea, 3, published_at: Time.now - 1.minute)
-      expect(campaign.content_worth_sending?(time: Time.now)).to be true
+      expect(campaign.content_worth_sending?(time: Time.now, activity:)).to be true
     end
 
     it 'returns false when there are less than 3 ideas updated in the last week' do
       create_list(:idea, 2, published_at: Time.now - 1.minute)
-      expect(campaign.content_worth_sending?(time: Time.now)).to be false
+      expect(campaign.content_worth_sending?(time: Time.now, activity:)).to be false
     end
 
     it 'returns true when there 3 ideas with comments or reactions updated in the last week' do
@@ -93,14 +94,14 @@ RSpec.describe EmailCampaigns::Campaigns::UserDigest do
       create(:comment, post: old_ideas.first, created_at: Time.now - 1.minute)
       create(:comment, post: old_ideas.second, created_at: Time.now - 1.minute)
       create(:reaction, reactable: old_ideas.last, created_at: Time.now - 1.minute)
-      expect(campaign.content_worth_sending?(time: Time.now)).to be true
+      expect(campaign.content_worth_sending?(time: Time.now, activity:)).to be true
     end
 
     it 'returns true when there are proposals that reached the threshold' do
       threshold_reached_status = create(:proposals_status, code: 'threshold_reached')
       proposal = create(:proposal, idea_status: threshold_reached_status)
       create(:idea_changed_status_activity, item: proposal, payload: { change: [nil, threshold_reached_status.id] }, acted_at: 1.day.ago)
-      expect(campaign.content_worth_sending?(time: Time.now)).to be true
+      expect(campaign.content_worth_sending?(time: Time.now, activity:)).to be true
     end
   end
 


### PR DESCRIPTION
- New idea for admin: Deal with native survey responses and anonymous inputs.
- User digest: before send hook needed to accept the activity keyword.
- User digest: It seems like [this issue](https://sentry.hq.citizenlab.co/share/issue/8f4f26b2af184677a55698bf5a04670e/) should no longer happen (I don't think `successful_proposals` can every be `nil`). I suspect that this was an activity generated before the release when this attribute did not yet exist.