### PR TITLE
TAN-2820 Aggressive caching

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -199,6 +199,7 @@ commercial_engines = [
   'multi_tenancy',
 
   'admin_api',
+  'aggressive_caching',
   'analysis',
   'analytics',
   'bulk_import_ideas',

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -10,6 +10,13 @@ PATH
       ros-apartment (>= 2.9.0)
 
 PATH
+  remote: engines/commercial/aggressive_caching
+  specs:
+    aggressive_caching (0.1.0)
+      actionpack-action_caching (~> 1.2)
+      rails (~> 7.0)
+
+PATH
   remote: engines/commercial/analysis
   specs:
     analysis (0.1.0)
@@ -402,6 +409,8 @@ GEM
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
+    actionpack-action_caching (1.2.2)
+      actionpack (>= 4.0.0)
     actiontext (7.0.8.5)
       actionpack (= 7.0.8.5)
       activerecord (= 7.0.8.5)
@@ -1245,6 +1254,7 @@ DEPENDENCIES
   activerecord-postgis-adapter (~> 8.0)
   acts_as_list (~> 1.1)
   admin_api!
+  aggressive_caching!
   analysis!
   analytics!
   annotate

--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -159,3 +159,5 @@ class ApplicationController < ActionController::API
     resource.public_send(:"remove_#{image_field_name}!")
   end
 end
+
+ApplicationController.include(AggressiveCaching::Patches::ApplicationController)

--- a/back/app/controllers/web_api/v1/admin_publications_controller.rb
+++ b/back/app/controllers/web_api/v1/admin_publications_controller.rb
@@ -69,3 +69,5 @@ class WebApi::V1::AdminPublicationsController < ApplicationController
     authorize @publication
   end
 end
+
+WebApi::V1::AdminPublicationsController.include(AggressiveCaching::Patches::WebApi::V1::AdminPublicationsController)

--- a/back/app/controllers/web_api/v1/app_configurations_controller.rb
+++ b/back/app/controllers/web_api/v1/app_configurations_controller.rb
@@ -43,3 +43,5 @@ class WebApi::V1::AppConfigurationsController < ApplicationController
       .permit(:logo, :favicon, settings: {}, style: {})
   end
 end
+
+WebApi::V1::AppConfigurationsController.include(AggressiveCaching::Patches::WebApi::V1::AppConfigurationsController)

--- a/back/app/controllers/web_api/v1/areas_controller.rb
+++ b/back/app/controllers/web_api/v1/areas_controller.rb
@@ -106,3 +106,5 @@ class WebApi::V1::AreasController < ApplicationController
     @side_fx_service = SideFxAreaService.new
   end
 end
+
+WebApi::V1::AreasController.include(AggressiveCaching::Patches::WebApi::V1::AreasController)

--- a/back/app/controllers/web_api/v1/comments_controller.rb
+++ b/back/app/controllers/web_api/v1/comments_controller.rb
@@ -279,3 +279,5 @@ class WebApi::V1::CommentsController < ApplicationController
     end
   end
 end
+
+WebApi::V1::CommentsController.include(AggressiveCaching::Patches::WebApi::V1::CommentsController)

--- a/back/app/controllers/web_api/v1/events_controller.rb
+++ b/back/app/controllers/web_api/v1/events_controller.rb
@@ -192,3 +192,5 @@ class WebApi::V1::EventsController < ApplicationController
     @sidefx ||= SideFxEventService.new
   end
 end
+
+WebApi::V1::EventsController.include(AggressiveCaching::Patches::WebApi::V1::EventsController)

--- a/back/app/controllers/web_api/v1/folders_controller.rb
+++ b/back/app/controllers/web_api/v1/folders_controller.rb
@@ -126,3 +126,5 @@ class WebApi::V1::FoldersController < ApplicationController
     )
   end
 end
+
+WebApi::V1::FoldersController.include(AggressiveCaching::Patches::WebApi::V1::FoldersController)

--- a/back/app/controllers/web_api/v1/idea_statuses_controller.rb
+++ b/back/app/controllers/web_api/v1/idea_statuses_controller.rb
@@ -114,3 +114,5 @@ class WebApi::V1::IdeaStatusesController < ApplicationController
     IdeaStatus.where(code: IdeaStatus::LOCKED_CODES, participation_method: @idea_status.participation_method).maximum(:ordering) || -1
   end
 end
+
+WebApi::V1::IdeaStatusesController.include(AggressiveCaching::Patches::WebApi::V1::IdeaStatusesController)

--- a/back/app/controllers/web_api/v1/ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/ideas_controller.rb
@@ -477,3 +477,4 @@ class WebApi::V1::IdeasController < ApplicationController
 end
 
 WebApi::V1::IdeasController.prepend(IdeaAssignment::Patches::WebApi::V1::IdeasController)
+WebApi::V1::IdeasController.include(AggressiveCaching::Patches::WebApi::V1::IdeasController)

--- a/back/app/controllers/web_api/v1/nav_bar_items_controller.rb
+++ b/back/app/controllers/web_api/v1/nav_bar_items_controller.rb
@@ -72,3 +72,5 @@ class WebApi::V1::NavBarItemsController < ApplicationController
     authorize @item
   end
 end
+
+WebApi::V1::NavBarItemsController.include(AggressiveCaching::Patches::WebApi::V1::NavBarItemsController)

--- a/back/app/controllers/web_api/v1/official_feedback_controller.rb
+++ b/back/app/controllers/web_api/v1/official_feedback_controller.rb
@@ -97,3 +97,5 @@ class WebApi::V1::OfficialFeedbackController < ApplicationController
     )
   end
 end
+
+WebApi::V1::OfficialFeedbackController.include(AggressiveCaching::Patches::WebApi::V1::OfficialFeedbackController)

--- a/back/app/controllers/web_api/v1/phase_custom_fields_controller.rb
+++ b/back/app/controllers/web_api/v1/phase_custom_fields_controller.rb
@@ -23,3 +23,5 @@ class WebApi::V1::PhaseCustomFieldsController < ApplicationController
     IdeaCustomFieldsService.new(phase.pmethod.custom_form).enabled_fields_with_other_options
   end
 end
+
+WebApi::V1::PhaseCustomFieldsController.include(AggressiveCaching::Patches::WebApi::V1::PhaseCustomFieldsController)

--- a/back/app/controllers/web_api/v1/phases_controller.rb
+++ b/back/app/controllers/web_api/v1/phases_controller.rb
@@ -173,3 +173,5 @@ class WebApi::V1::PhasesController < ApplicationController
     end
   end
 end
+
+WebApi::V1::PhasesController.include(AggressiveCaching::Patches::WebApi::V1::PhasesController)

--- a/back/app/controllers/web_api/v1/project_custom_fields_controller.rb
+++ b/back/app/controllers/web_api/v1/project_custom_fields_controller.rb
@@ -27,3 +27,5 @@ class WebApi::V1::ProjectCustomFieldsController < ApplicationController
     IdeaCustomFieldsService.new(phase.pmethod.custom_form).enabled_fields
   end
 end
+
+WebApi::V1::ProjectCustomFieldsController.include(AggressiveCaching::Patches::WebApi::V1::ProjectCustomFieldsController)

--- a/back/app/controllers/web_api/v1/projects_controller.rb
+++ b/back/app/controllers/web_api/v1/projects_controller.rb
@@ -215,3 +215,5 @@ class WebApi::V1::ProjectsController < ApplicationController
     end
   end
 end
+
+WebApi::V1::ProjectsController.include(AggressiveCaching::Patches::WebApi::V1::ProjectsController)

--- a/back/app/controllers/web_api/v1/static_pages_controller.rb
+++ b/back/app/controllers/web_api/v1/static_pages_controller.rb
@@ -81,3 +81,5 @@ class WebApi::V1::StaticPagesController < ApplicationController
     authorize @page
   end
 end
+
+WebApi::V1::StaticPagesController.include(AggressiveCaching::Patches::WebApi::V1::StaticPagesController)

--- a/back/app/controllers/web_api/v1/topics_controller.rb
+++ b/back/app/controllers/web_api/v1/topics_controller.rb
@@ -112,3 +112,5 @@ class WebApi::V1::TopicsController < ApplicationController
     authorize @topic
   end
 end
+
+WebApi::V1::TopicsController.include(AggressiveCaching::Patches::WebApi::V1::TopicsController)

--- a/back/config/environments/test.rb
+++ b/back/config/environments/test.rb
@@ -34,7 +34,7 @@ Rails.application.configure do
   config.action_controller.perform_caching = false
 
   # Caching must be turned on for Rack::Attack to work and Rack::Attack tests to pass.
-  # config.cache_store = :null_store
+  config.cache_store = :memory_store
 
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false

--- a/back/engines/commercial/aggressive_caching/aggressive_caching.gemspec
+++ b/back/engines/commercial/aggressive_caching/aggressive_caching.gemspec
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.push File.expand_path('lib', __dir__)
+
+# Maintain your gem's version:
+require 'aggressive_caching/version'
+
+# Describe your gem and declare its dependencies:
+Gem::Specification.new do |s|
+  s.name        = 'aggressive_caching'
+  s.version     = AggressiveCaching::VERSION
+  s.summary     = 'Optionally enable aggressive caching for high traffic situations'
+  s.authors     = ['CitizenLab']
+  s.licenses    = [Gem::Licenses::NONSTANDARD] # ['CitizenLab Commercial License V2']
+  s.files = Dir['{app,config,db,lib}/**/*', 'Rakefile', 'README.md']
+
+  s.add_dependency 'rails', '~> 7.0'
+  s.add_dependency 'actionpack-action_caching', '~> 1.2'
+
+  s.add_development_dependency 'rspec_api_documentation'
+  s.add_development_dependency 'rspec-rails'
+end

--- a/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/application_controller.rb
+++ b/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/application_controller.rb
@@ -20,10 +20,25 @@ module AggressiveCaching
         value
       end
 
-      # This method is typically overriden in the controller to determine for
-      # which users aggressive caching should be active
       def aggressive_caching_active?
         AppConfiguration.instance.feature_activated?('aggressive_caching')
+      end
+
+      # Helpers for the subclasses to determinte for whom to cache
+      def caching_and_visitor?
+        aggressive_caching_active? && current_user.nil?
+      end
+
+      def caching_and_non_admin?
+        aggressive_caching_active? && (current_user.nil? || current_user.normal_user?)
+      end
+
+      # Quite some API responses embed data about whether the current user
+      # follows the returned resource. This lets us still cache those responses
+      # for users that are not following anything
+      def caching_and_not_following?
+        aggressive_caching_active? &&
+          (current_user.nil? || (current_user.normal_user? && current_user&.follows&.none?))
       end
     end
   end

--- a/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/application_controller.rb
+++ b/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/application_controller.rb
@@ -4,8 +4,15 @@ module AggressiveCaching
       extend ActiveSupport::Concern
 
       included do
-        include ActionController::Caching # Needed to make actionpack-action_caching work with ActionController::API
+        # Needed to make actionpack-action_caching work with ActionController::API
+        include ActionController::Caching
+        # For some Reason, ActionController::Caching is not picking up the Rails
+        # cache_store by itself. This initialization works, but could probaby be
+        # improved
         self.cache_store = Rails.cache
+
+        skip_after_action :verify_policy_scoped, if: :aggressive_caching_active?
+        skip_after_action :verify_authorized, if: :aggressive_caching_active?
       end
 
       # Needed to make actionpack-action_caching work with ActionController::API. Fake implemenetation of what is normally provided by ActionController::Base
@@ -13,7 +20,9 @@ module AggressiveCaching
         value
       end
 
-      def aggressive_caching_enabled?
+      # This method is typically overriden in the controller to determine for
+      # which users aggressive caching should be active
+      def aggressive_caching_active?
         AppConfiguration.instance.feature_activated?('aggressive_caching')
       end
     end

--- a/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/application_controller.rb
+++ b/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/application_controller.rb
@@ -1,0 +1,21 @@
+module AggressiveCaching
+  module Patches
+    module ApplicationController
+      extend ActiveSupport::Concern
+
+      included do
+        include ActionController::Caching # Needed to make actionpack-action_caching work with ActionController::API
+        self.cache_store = Rails.cache
+      end
+
+      # Needed to make actionpack-action_caching work with ActionController::API. Fake implemenetation of what is normally provided by ActionController::Base
+      def action_has_layout=(value)
+        value
+      end
+
+      def aggressive_caching_enabled?
+        AppConfiguration.instance.feature_activated?('aggressive_caching')
+      end
+    end
+  end
+end

--- a/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/admin_publications_controller.rb
+++ b/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/admin_publications_controller.rb
@@ -4,11 +4,12 @@ module AggressiveCaching
   module Patches
     module WebApi
       module V1
-        module AppConfigurationsController
+        module AdminPublicationsController
           def self.included(base)
             base.class_eval do
               with_options if: :aggressive_caching_active? do
-                caches_action :show, expires_in: 1.minute
+                caches_action :index, expires_in: 1.minute, cache_path: -> { params.to_s }
+                caches_action :show, :status_counts, expires_in: 1.minute
               end
             end
           end

--- a/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/admin_publications_controller.rb
+++ b/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/admin_publications_controller.rb
@@ -7,15 +7,12 @@ module AggressiveCaching
         module AdminPublicationsController
           def self.included(base)
             base.class_eval do
-              with_options if: :aggressive_caching_active? do
-                caches_action :index, expires_in: 1.minute, cache_path: -> { params.to_s }
+              # We can only cache for visitors, because permissions play a role in the admin publications shown
+              with_options if: :caching_and_visitor? do
+                caches_action :index, expires_in: 1.minute, cache_path: -> { request.query_parameters }
                 caches_action :show, :status_counts, expires_in: 1.minute
               end
             end
-          end
-
-          def aggressive_caching_active?
-            super && (!current_user || current_user.normal_user?)
           end
         end
       end

--- a/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/app_configurations_controller.rb
+++ b/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/app_configurations_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module AggressiveCaching
+  module Patches
+    module WebApi
+      module V1
+        module AppConfigurationsController
+          def self.included(base)
+            base.class_eval do
+              skip_after_action :verify_authorized, only: [:show], if: :aggressive_caching_enabled?
+
+              caches_action :show, expires_in: 1.minute, if: lambda {
+                aggressive_caching_enabled? && (!current_user || current_user.highest_role == 'user')
+              }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/app_configurations_controller.rb
+++ b/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/app_configurations_controller.rb
@@ -7,14 +7,10 @@ module AggressiveCaching
         module AppConfigurationsController
           def self.included(base)
             base.class_eval do
-              with_options if: :aggressive_caching_active? do
+              with_options if: :caching_and_non_admin? do
                 caches_action :show, expires_in: 1.minute
               end
             end
-          end
-
-          def aggressive_caching_active?
-            super && (!current_user || current_user.normal_user?)
           end
         end
       end

--- a/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/areas_controller.rb
+++ b/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/areas_controller.rb
@@ -4,10 +4,11 @@ module AggressiveCaching
   module Patches
     module WebApi
       module V1
-        module AppConfigurationsController
+        module AreasController
           def self.included(base)
             base.class_eval do
               with_options if: :aggressive_caching_active? do
+                caches_action :index, expires_in: 1.minute, cache_path: -> { params.to_s }
                 caches_action :show, expires_in: 1.minute
               end
             end

--- a/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/comments_controller.rb
+++ b/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/comments_controller.rb
@@ -4,17 +4,19 @@ module AggressiveCaching
   module Patches
     module WebApi
       module V1
-        module AppConfigurationsController
+        module CommentsController
           def self.included(base)
             base.class_eval do
               with_options if: :aggressive_caching_active? do
+                caches_action :index, :children, expires_in: 1.minute, cache_path: -> { params.to_s }
                 caches_action :show, expires_in: 1.minute
               end
             end
           end
 
+          # We don't cache comments for normal users, since they might post/change
           def aggressive_caching_active?
-            super && (!current_user || current_user.normal_user?)
+            super && !current_user
           end
         end
       end

--- a/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/comments_controller.rb
+++ b/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/comments_controller.rb
@@ -7,16 +7,11 @@ module AggressiveCaching
         module CommentsController
           def self.included(base)
             base.class_eval do
-              with_options if: :aggressive_caching_active? do
-                caches_action :index, :children, expires_in: 1.minute, cache_path: -> { params.to_s }
+              with_options if: :caching_and_visitor? do
+                caches_action :index, :children, expires_in: 1.minute, cache_path: -> { request.query_parameters }
                 caches_action :show, expires_in: 1.minute
               end
             end
-          end
-
-          # We don't cache comments for normal users, since they might post/change
-          def aggressive_caching_active?
-            super && !current_user
           end
         end
       end

--- a/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/content_builder_layouts_controller.rb
+++ b/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/content_builder_layouts_controller.rb
@@ -4,7 +4,7 @@ module AggressiveCaching
   module Patches
     module WebApi
       module V1
-        module AppConfigurationsController
+        module ContentBuilderLayoutsController
           def self.included(base)
             base.class_eval do
               with_options if: :aggressive_caching_active? do

--- a/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/content_builder_layouts_controller.rb
+++ b/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/content_builder_layouts_controller.rb
@@ -7,14 +7,10 @@ module AggressiveCaching
         module ContentBuilderLayoutsController
           def self.included(base)
             base.class_eval do
-              with_options if: :aggressive_caching_active? do
+              with_options if: :caching_and_non_admin? do
                 caches_action :show, expires_in: 1.minute
               end
             end
-          end
-
-          def aggressive_caching_active?
-            super && (!current_user || current_user.normal_user?)
           end
         end
       end

--- a/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/events_controller.rb
+++ b/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/events_controller.rb
@@ -4,10 +4,10 @@ module AggressiveCaching
   module Patches
     module WebApi
       module V1
-        module AreasController
+        module EventsController
           def self.included(base)
             base.class_eval do
-              with_options if: :caching_and_not_following? do
+              with_options if: :caching_and_visitor? do
                 caches_action :index, expires_in: 1.minute, cache_path: -> { request.query_parameters }
                 caches_action :show, expires_in: 1.minute
               end

--- a/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/folders_controller.rb
+++ b/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/folders_controller.rb
@@ -4,11 +4,12 @@ module AggressiveCaching
   module Patches
     module WebApi
       module V1
-        module AppConfigurationsController
+        module FoldersController
           def self.included(base)
             base.class_eval do
               with_options if: :aggressive_caching_active? do
-                caches_action :show, expires_in: 1.minute
+                caches_action :index, expires_in: 1.minute, cache_path: -> { params.to_s }
+                caches_action :show, :by_slug, expires_in: 1.minute
               end
             end
           end

--- a/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/folders_controller.rb
+++ b/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/folders_controller.rb
@@ -7,15 +7,11 @@ module AggressiveCaching
         module FoldersController
           def self.included(base)
             base.class_eval do
-              with_options if: :aggressive_caching_active? do
-                caches_action :index, expires_in: 1.minute, cache_path: -> { params.to_s }
+              with_options if: :caching_and_visitor? do
+                caches_action :index, expires_in: 1.minute, cache_path: -> { request.query_parameters }
                 caches_action :show, :by_slug, expires_in: 1.minute
               end
             end
-          end
-
-          def aggressive_caching_active?
-            super && (!current_user || current_user.normal_user?)
           end
         end
       end

--- a/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/idea_statuses_controller.rb
+++ b/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/idea_statuses_controller.rb
@@ -7,15 +7,11 @@ module AggressiveCaching
         module IdeaStatusesController
           def self.included(base)
             base.class_eval do
-              with_options if: :aggressive_caching_active? do
-                caches_action :index, expires_in: 1.minute, cache_path: -> { params.to_s }
+              with_options if: :caching_and_non_admin? do
+                caches_action :index, expires_in: 1.minute, cache_path: -> { request.query_parameters }
                 caches_action :show, expires_in: 1.minute
               end
             end
-          end
-
-          def aggressive_caching_active?
-            super && (!current_user || current_user.normal_user?)
           end
         end
       end

--- a/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/idea_statuses_controller.rb
+++ b/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/idea_statuses_controller.rb
@@ -4,10 +4,11 @@ module AggressiveCaching
   module Patches
     module WebApi
       module V1
-        module AppConfigurationsController
+        module IdeaStatusesController
           def self.included(base)
             base.class_eval do
               with_options if: :aggressive_caching_active? do
+                caches_action :index, expires_in: 1.minute, cache_path: -> { params.to_s }
                 caches_action :show, expires_in: 1.minute
               end
             end

--- a/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/ideas_controller.rb
+++ b/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/ideas_controller.rb
@@ -7,27 +7,17 @@ module AggressiveCaching
         module IdeasController
           def self.included(base)
             base.class_eval do
-              with_options if: :aggressive_caching_active? do
+              with_options if: :caching_and_visitor? do
                 # We need an extra :skip_after_action here, because the
                 # IdeasController re-specifies the after_action hook explicitly
                 # and takes precedence
                 skip_after_action :verify_policy_scoped
 
-                caches_action :index, :index_mini, :filter_counts, expires_in: 1.minute, cache_path: -> { params.to_s }
+                caches_action :index, :index_mini, :filter_counts, :as_markers, expires_in: 1.minute, cache_path: -> { request.query_parameters }
                 caches_action :show, :by_slug, expires_in: 1.minute
               end
-              caches_action :json_forms_schema, expires_in: 1.day, if: :aggressive_caching_active_and_not_admin?
+              caches_action :json_forms_schema, expires_in: 1.day, if: :caching_and_non_admin?
             end
-          end
-
-          # We don't cache ideas for normal users, since they might post/change ideas
-          def aggressive_caching_active?
-            super && !current_user
-          end
-
-          # But we do cache the json_forms_schema for normal users, since they can't impact it
-          def aggressive_caching_active_and_not_admin?
-            AppConfiguration.instance.feature_activated?('aggressive_caching') && (!current_user || current_user.normal_user?)
           end
         end
       end

--- a/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/ideas_controller.rb
+++ b/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/ideas_controller.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module AggressiveCaching
+  module Patches
+    module WebApi
+      module V1
+        module IdeasController
+          def self.included(base)
+            base.class_eval do
+              with_options if: :aggressive_caching_active? do
+                # We need an extra :skip_after_action here, because the
+                # IdeasController re-specifies the after_action hook explicitly
+                # and takes precedence
+                skip_after_action :verify_policy_scoped
+
+                caches_action :index, :index_mini, :filter_counts, expires_in: 1.minute, cache_path: -> { params.to_s }
+                caches_action :show, :by_slug, expires_in: 1.minute
+              end
+              caches_action :json_forms_schema, expires_in: 1.day, if: :aggressive_caching_active_and_not_admin?
+            end
+          end
+
+          # We don't cache ideas for normal users, since they might post/change ideas
+          def aggressive_caching_active?
+            super && !current_user
+          end
+
+          # But we do cache the json_forms_schema for normal users, since they can't impact it
+          def aggressive_caching_active_and_not_admin?
+            AppConfiguration.instance.feature_activated?('aggressive_caching') && (!current_user || current_user.normal_user?)
+          end
+        end
+      end
+    end
+  end
+end

--- a/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/nav_bar_items_controller.rb
+++ b/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/nav_bar_items_controller.rb
@@ -7,14 +7,11 @@ module AggressiveCaching
         module NavBarItemsController
           def self.included(base)
             base.class_eval do
-              with_options if: :aggressive_caching_active? do
-                caches_action :index, expires_in: 1.minute
+              with_options if: :caching_and_non_admin? do
+                skip_after_action :verify_policy_scoped
+                caches_action :index, expires_in: 1.minute, cache_path: -> { request.query_parameters }
               end
             end
-          end
-
-          def aggressive_caching_active?
-            super && (!current_user || current_user.normal_user?)
           end
         end
       end

--- a/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/nav_bar_items_controller.rb
+++ b/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/nav_bar_items_controller.rb
@@ -4,11 +4,11 @@ module AggressiveCaching
   module Patches
     module WebApi
       module V1
-        module AppConfigurationsController
+        module NavBarItemsController
           def self.included(base)
             base.class_eval do
               with_options if: :aggressive_caching_active? do
-                caches_action :show, expires_in: 1.minute
+                caches_action :index, expires_in: 1.minute
               end
             end
           end

--- a/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/official_feedback_controller.rb
+++ b/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/official_feedback_controller.rb
@@ -4,10 +4,10 @@ module AggressiveCaching
   module Patches
     module WebApi
       module V1
-        module AreasController
+        module OfficialFeedbackController
           def self.included(base)
             base.class_eval do
-              with_options if: :caching_and_not_following? do
+              with_options if: :caching_and_visitor? do
                 caches_action :index, expires_in: 1.minute, cache_path: -> { request.query_parameters }
                 caches_action :show, expires_in: 1.minute
               end

--- a/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/phase_custom_fields_controller.rb
+++ b/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/phase_custom_fields_controller.rb
@@ -4,12 +4,11 @@ module AggressiveCaching
   module Patches
     module WebApi
       module V1
-        module AreasController
+        module PhaseCustomFieldsController
           def self.included(base)
             base.class_eval do
-              with_options if: :caching_and_not_following? do
-                caches_action :index, expires_in: 1.minute, cache_path: -> { request.query_parameters }
-                caches_action :show, expires_in: 1.minute
+              with_options if: :caching_and_visitor? do
+                caches_action :json_forms_schema, expires_in: 1.minute
               end
             end
           end

--- a/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/phases_controller.rb
+++ b/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/phases_controller.rb
@@ -4,12 +4,12 @@ module AggressiveCaching
   module Patches
     module WebApi
       module V1
-        module AreasController
+        module PhasesController
           def self.included(base)
             base.class_eval do
-              with_options if: :caching_and_not_following? do
+              with_options if: :caching_and_visitor? do
                 caches_action :index, expires_in: 1.minute, cache_path: -> { request.query_parameters }
-                caches_action :show, expires_in: 1.minute
+                caches_action :show, :submission_count, expires_in: 1.minute
               end
             end
           end

--- a/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/project_custom_fields_controller.rb
+++ b/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/project_custom_fields_controller.rb
@@ -4,12 +4,11 @@ module AggressiveCaching
   module Patches
     module WebApi
       module V1
-        module AreasController
+        module ProjectCustomFieldsController
           def self.included(base)
             base.class_eval do
-              with_options if: :caching_and_not_following? do
-                caches_action :index, expires_in: 1.minute, cache_path: -> { request.query_parameters }
-                caches_action :show, expires_in: 1.minute
+              with_options if: :caching_and_visitor? do
+                caches_action :json_forms_schema, expires_in: 1.minute
               end
             end
           end

--- a/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/projects_controller.rb
+++ b/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/projects_controller.rb
@@ -4,11 +4,12 @@ module AggressiveCaching
   module Patches
     module WebApi
       module V1
-        module AppConfigurationsController
+        module ProjectsController
           def self.included(base)
             base.class_eval do
               with_options if: :aggressive_caching_active? do
-                caches_action :show, expires_in: 1.minute
+                caches_action :index, expires_in: 1.minute, cache_path: -> { params.to_s }
+                caches_action :show, :by_slug, expires_in: 1.minute
               end
             end
           end

--- a/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/projects_controller.rb
+++ b/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/projects_controller.rb
@@ -7,15 +7,11 @@ module AggressiveCaching
         module ProjectsController
           def self.included(base)
             base.class_eval do
-              with_options if: :aggressive_caching_active? do
-                caches_action :index, expires_in: 1.minute, cache_path: -> { params.to_s }
+              with_options if: :caching_and_visitor? do
+                caches_action :index, expires_in: 1.minute, cache_path: -> { request.query_parameters }
                 caches_action :show, :by_slug, expires_in: 1.minute
               end
             end
-          end
-
-          def aggressive_caching_active?
-            super && (!current_user || current_user.normal_user?)
           end
         end
       end

--- a/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/static_pages_controller.rb
+++ b/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/static_pages_controller.rb
@@ -4,11 +4,11 @@ module AggressiveCaching
   module Patches
     module WebApi
       module V1
-        module AppConfigurationsController
+        module StaticPagesController
           def self.included(base)
             base.class_eval do
               with_options if: :aggressive_caching_active? do
-                caches_action :show, expires_in: 1.minute
+                caches_action :index, :show, :by_slug, expires_in: 1.minute
               end
             end
           end

--- a/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/static_pages_controller.rb
+++ b/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/static_pages_controller.rb
@@ -7,14 +7,11 @@ module AggressiveCaching
         module StaticPagesController
           def self.included(base)
             base.class_eval do
-              with_options if: :aggressive_caching_active? do
-                caches_action :index, :show, :by_slug, expires_in: 1.minute
+              with_options if: :caching_and_non_admin? do
+                caches_action :index, expires_in: 1.minute, cache_path: -> { request.query_parameters }
+                caches_action :show, :by_slug, expires_in: 1.minute
               end
             end
-          end
-
-          def aggressive_caching_active?
-            super && (!current_user || current_user.normal_user?)
           end
         end
       end

--- a/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/topics_controller.rb
+++ b/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/topics_controller.rb
@@ -4,10 +4,11 @@ module AggressiveCaching
   module Patches
     module WebApi
       module V1
-        module AppConfigurationsController
+        module TopicsController
           def self.included(base)
             base.class_eval do
               with_options if: :aggressive_caching_active? do
+                caches_action :index, expires_in: 1.minute, cache_path: -> { params.to_s }
                 caches_action :show, expires_in: 1.minute
               end
             end

--- a/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/topics_controller.rb
+++ b/back/engines/commercial/aggressive_caching/app/controllers/aggressive_caching/patches/web_api/v1/topics_controller.rb
@@ -7,15 +7,11 @@ module AggressiveCaching
         module TopicsController
           def self.included(base)
             base.class_eval do
-              with_options if: :aggressive_caching_active? do
-                caches_action :index, expires_in: 1.minute, cache_path: -> { params.to_s }
+              with_options if: :caching_and_not_following? do
+                caches_action :index, expires_in: 1.minute, cache_path: -> { request.query_parameters }
                 caches_action :show, expires_in: 1.minute
               end
             end
-          end
-
-          def aggressive_caching_active?
-            super && (!current_user || current_user.normal_user?)
           end
         end
       end

--- a/back/engines/commercial/aggressive_caching/lib/aggressive_caching.rb
+++ b/back/engines/commercial/aggressive_caching/lib/aggressive_caching.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'actionpack/action_caching'
+require 'aggressive_caching/engine'
+
+module AggressiveCaching
+  # Your code goes here...
+end

--- a/back/engines/commercial/aggressive_caching/lib/aggressive_caching/engine.rb
+++ b/back/engines/commercial/aggressive_caching/lib/aggressive_caching/engine.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module AggressiveCaching
+  class Engine < ::Rails::Engine
+    isolate_namespace AggressiveCaching
+
+    config.to_prepare do
+      require 'aggressive_caching/feature_specification'
+      AppConfiguration::Settings.add_feature(AggressiveCaching::FeatureSpecification)
+    end
+  end
+end

--- a/back/engines/commercial/aggressive_caching/lib/aggressive_caching/feature_specification.rb
+++ b/back/engines/commercial/aggressive_caching/lib/aggressive_caching/feature_specification.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Engine namespace
+module AggressiveCaching
+  module FeatureSpecification
+    # Note that we are extending (not including) here!
+    extend CitizenLab::Mixins::FeatureSpecification
+
+    # will be used as the property key in the main settings json schema
+    def self.feature_name
+      'aggressive_caching'
+    end
+
+    def self.feature_title
+      'Aggressive caching'
+    end
+
+    def self.feature_description
+      <<~DESC
+        This feature is used to aggressivel cache API responses.
+        It should always be turned off, unless in exceptional circumstances where we are experiencing major traffic peaks which the platform can no longer handle.
+        When enabled, some data on the platform might take some time to update after changes have been made.'
+      DESC
+    end
+
+    def self.allowed_by_default
+      true
+    end
+
+    def self.enabled_by_default
+      false
+    end
+  end
+end

--- a/back/engines/commercial/aggressive_caching/lib/aggressive_caching/version.rb
+++ b/back/engines/commercial/aggressive_caching/lib/aggressive_caching/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module AggressiveCaching
+  VERSION = '0.1.0'
+end

--- a/back/engines/commercial/aggressive_caching/spec/acceptance/ideas_spec.rb
+++ b/back/engines/commercial/aggressive_caching/spec/acceptance/ideas_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rspec_api_documentation/dsl'
+
+resource 'Ideas', :clear_cache, document: false do
+  before do
+    header 'Content-Type', 'application/json'
+    settings = AppConfiguration.instance.settings
+    settings['aggressive_caching'] = { 'enabled' => true, 'allowed' => true }
+    AppConfiguration.instance.update!(settings:)
+  end
+
+  get 'web_api/v1/ideas' do
+    example 'caches for a visitor' do
+      expect(Rails.cache.read('views/example.org/web_api/v1/ideas.json')).to be_nil
+      do_request
+      expect(status).to eq 200
+      expect(Rails.cache.read('views/example.org/web_api/v1/ideas.json')).to be_present
+    end
+
+    context 'when logged in' do
+      before { header_token_for create(:user) }
+
+      example 'does not cache' do
+        expect(Rails.cache.read('views/example.org/web_api/v1/ideas.json')).to be_nil
+        do_request
+        expect(status).to eq 200
+        expect(Rails.cache.read('views/example.org/web_api/v1/ideas.json')).to be_nil
+      end
+    end
+
+    context 'with aggressive caching disabled' do
+      before do
+        settings = AppConfiguration.instance.settings
+        settings['aggressive_caching'] = { 'enabled' => false, 'allowed' => true }
+        AppConfiguration.instance.update!(settings:)
+      end
+
+      example 'does not cache' do
+        expect(Rails.cache.read('views/example.org/web_api/v1/ideas.json')).to be_nil
+        do_request
+        expect(status).to eq 200
+        expect(Rails.cache.read('views/example.org/web_api/v1/ideas.json')).to be_nil
+      end
+    end
+  end
+
+  get 'web_api/v1/ideas/:id' do
+    let(:idea) { create(:idea) }
+    let(:id) { idea.id }
+
+    example 'caches for a visitor' do
+      expect(Rails.cache.read("views/example.org/web_api/v1/ideas/#{id}.json")).to be_nil
+      do_request
+      expect(status).to eq 200
+      expect(Rails.cache.read("views/example.org/web_api/v1/ideas/#{id}.json")).to be_present
+    end
+
+    context 'when logged in' do
+      before { header_token_for create(:user) }
+
+      example 'does not cache' do
+        expect(Rails.cache.read("views/example.org/web_api/v1/ideas/#{id}.json")).to be_nil
+        do_request
+        expect(status).to eq 200
+        expect(Rails.cache.read("views/example.org/web_api/v1/ideas/#{id}.json")).to be_nil
+      end
+    end
+
+    context 'with aggressive caching disabled' do
+      before do
+        settings = AppConfiguration.instance.settings
+        settings['aggressive_caching'] = { 'enabled' => false, 'allowed' => true }
+        AppConfiguration.instance.update!(settings:)
+      end
+
+      example 'does not cache' do
+        expect(Rails.cache.read("views/example.org/web_api/v1/ideas/#{id}.json")).to be_nil
+        do_request
+        expect(status).to eq 200
+        expect(Rails.cache.read("views/example.org/web_api/v1/ideas/#{id}.json")).to be_nil
+      end
+    end
+  end
+end

--- a/back/engines/commercial/aggressive_caching/spec/acceptance/static_pages_spec.rb
+++ b/back/engines/commercial/aggressive_caching/spec/acceptance/static_pages_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rspec_api_documentation/dsl'
+
+resource 'StaticPages', :clear_cache, document: false do
+  before do
+    header 'Content-Type', 'application/json'
+    settings = AppConfiguration.instance.settings
+    settings['aggressive_caching'] = { 'enabled' => true, 'allowed' => true }
+    AppConfiguration.instance.update!(settings:)
+  end
+
+  get 'web_api/v1/static_pages' do
+    example 'Caches for a visitor' do
+      expect(Rails.cache.read('views/example.org/web_api/v1/static_pages.json')).to be_nil
+      do_request
+      expect(status).to eq 200
+      expect(Rails.cache.read('views/example.org/web_api/v1/static_pages.json')).to be_present
+    end
+  end
+end

--- a/back/engines/commercial/aggressive_caching/spec/acceptance/topics_spec.rb
+++ b/back/engines/commercial/aggressive_caching/spec/acceptance/topics_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rspec_api_documentation/dsl'
+
+resource 'Topics', :clear_cache, document: false do
+  before do
+    header 'Content-Type', 'application/json'
+    settings = AppConfiguration.instance.settings
+    settings['aggressive_caching'] = { 'enabled' => true, 'allowed' => true }
+    AppConfiguration.instance.update!(settings:)
+  end
+
+  get 'web_api/v1/topics' do
+    example 'caches for a visitor' do
+      expect(Rails.cache.read('views/example.org/web_api/v1/topics.json')).to be_nil
+      do_request
+      expect(status).to eq 200
+      expect(Rails.cache.read('views/example.org/web_api/v1/topics.json')).to be_present
+    end
+
+    context 'when logged in and following something' do
+      before { header_token_for create(:follower).user }
+
+      example 'it does not cache' do
+        expect(Rails.cache.read('views/example.org/web_api/v1/topics.json')).to be_nil
+        do_request
+        expect(status).to eq 200
+        expect(Rails.cache.read('views/example.org/web_api/v1/topics.json')).to be_nil
+      end
+    end
+
+    context 'when logged in and not following anything' do
+      before { header_token_for create(:user) }
+
+      example 'it caches' do
+        expect(Rails.cache.read('views/example.org/web_api/v1/topics.json')).to be_nil
+        do_request
+        expect(status).to eq 200
+        expect(Rails.cache.read('views/example.org/web_api/v1/topics.json')).to be_present
+      end
+    end
+
+    context 'with aggressive caching disabled' do
+      before do
+        settings = AppConfiguration.instance.settings
+        settings['aggressive_caching'] = { 'enabled' => false, 'allowed' => true }
+        AppConfiguration.instance.update!(settings:)
+      end
+
+      example 'does not cache' do
+        expect(Rails.cache.read('views/example.org/web_api/v1/topics.json')).to be_nil
+        do_request
+        expect(status).to eq 200
+        expect(Rails.cache.read('views/example.org/web_api/v1/topics.json')).to be_nil
+      end
+    end
+  end
+
+  get 'web_api/v1/topics/:id' do
+    let(:topic) { create(:topic) }
+    let(:id) { topic.id }
+
+    example 'caches for a visitor' do
+      expect(Rails.cache.read("views/example.org/web_api/v1/topics/#{id}.json")).to be_nil
+      do_request
+      expect(status).to eq 200
+      expect(Rails.cache.read("views/example.org/web_api/v1/topics/#{id}.json")).to be_present
+    end
+
+    context 'when logged in and not following' do
+      before { header_token_for create(:user) }
+
+      example 'it caches' do
+        expect(Rails.cache.read("views/example.org/web_api/v1/topics/#{id}.json")).to be_nil
+        do_request
+        expect(status).to eq 200
+        expect(Rails.cache.read("views/example.org/web_api/v1/topics/#{id}.json")).to be_present
+      end
+    end
+
+    context 'with aggressive caching disabled' do
+      before do
+        settings = AppConfiguration.instance.settings
+        settings['aggressive_caching'] = { 'enabled' => false, 'allowed' => true }
+        AppConfiguration.instance.update!(settings:)
+      end
+
+      example 'does not cache' do
+        expect(Rails.cache.read("views/example.org/web_api/v1/topics/#{id}.json")).to be_nil
+        do_request
+        expect(status).to eq 200
+        expect(Rails.cache.read("views/example.org/web_api/v1/topics/#{id}.json")).to be_nil
+      end
+    end
+  end
+end

--- a/back/engines/commercial/content_builder/app/controllers/content_builder/web_api/v1/content_builder_layouts_controller.rb
+++ b/back/engines/commercial/content_builder/app/controllers/content_builder/web_api/v1/content_builder_layouts_controller.rb
@@ -106,3 +106,5 @@ module ContentBuilder
     end
   end
 end
+
+ContentBuilder::WebApi::V1::ContentBuilderLayoutsController.include(AggressiveCaching::Patches::WebApi::V1::ContentBuilderLayoutsController)

--- a/back/spec/spec_helper.rb
+++ b/back/spec/spec_helper.rb
@@ -222,6 +222,14 @@ RSpec.configure do |config|
 
   # By default, skip the slow tests and template tests. Can be overriden on the command line.
   config.filter_run_excluding template_test: true
+
+  config.before(:example, clear_cache: true) do
+    Rails.cache.clear
+  end
+
+  config.after(:example, clear_cache: true) do
+    Rails.cache.clear
+  end
 end
 
 RSpec::Matchers.define_negated_matcher :not_change, :change


### PR DESCRIPTION
# Changelog
## Added
- Added a feature flag to enable "Aggressive caching", which can exceptionally be activated for a tenant through Admin HQ. It helps to deal with extreme traffic peaks, at the risk of having some out of date data on the platforms.
