### PR TITLE
Autovote on idea update bug

### DIFF
--- a/back/app/services/side_fx_idea_service.rb
+++ b/back/app/services/side_fx_idea_service.rb
@@ -106,12 +106,12 @@ class SideFxIdeaService
   def before_publish(idea, _user); end
 
   def after_submission(idea, user)
+    add_autoreaction(idea)
+    create_followers(idea, user) unless idea.anonymous?
     LogActivityJob.set(wait: 20.seconds).perform_later(idea, 'submitted', user_for_activity_on_anonymizable_item(idea, user), idea.submitted_at.to_i)
   end
 
   def after_publish(idea, user)
-    add_autoreaction(idea)
-    create_followers(idea, user) unless idea.anonymous?
     log_activity_jobs_after_published(idea, user)
   end
 

--- a/back/app/services/side_fx_idea_service.rb
+++ b/back/app/services/side_fx_idea_service.rb
@@ -119,7 +119,7 @@ class SideFxIdeaService
     return unless idea.author
     return if Permissions::IdeaPermissionsService.new(idea, idea.author).denied_reason_for_action 'reacting_idea', reaction_mode: 'up'
 
-    idea.reactions.create!(mode: 'up', user: idea.author)
+    idea.reactions.create!(mode: 'up', user: idea.author) if !idea.reactions.where(mode: 'up', user: idea.author).exists?
     idea.reload
   end
 

--- a/back/spec/acceptance/ideas_update_spec.rb
+++ b/back/spec/acceptance/ideas_update_spec.rb
@@ -481,7 +481,7 @@ resource 'Ideas' do
             before { create(:reaction, reactable: input, mode: 'up', user: input.author) }
 
             let(:input) { create(:proposal, idea_status: create(:proposals_status, code: 'prescreening'), publication_status: 'submitted') }
-  
+
             example 'Publish the proposal', document: false do
               do_request(idea: { idea_status_id: create(:proposals_status, code: 'proposed').id })
               assert_status 200

--- a/back/spec/acceptance/ideas_update_spec.rb
+++ b/back/spec/acceptance/ideas_update_spec.rb
@@ -476,6 +476,17 @@ resource 'Ideas' do
             json_response = json_parse response_body
             expect(json_response.dig(:data, :relationships, :idea_status, :data, :id)).to eq idea_status_id
           end
+
+          context 'when the proposal has reactions' do
+            before { create(:reaction, reactable: input, mode: 'up', user: input.author) }
+
+            let(:input) { create(:proposal, idea_status: create(:proposals_status, code: 'prescreening'), publication_status: 'submitted') }
+  
+            example 'Publish the proposal', document: false do
+              do_request(idea: { idea_status_id: create(:proposals_status, code: 'proposed').id })
+              assert_status 200
+            end
+          end
         end
 
         describe do


### PR DESCRIPTION
Sentry issue: https://sentry.hq.citizenlab.co/share/issue/f3a11d27eaf3473c834bfb092f344e38/

It seems like users could already like their proposals when their proposals are still in "screening". However, the autovote was created on publication and so when their proposal would be moved to "proposed" the request would fail because this would cause the like to be added twice. The added spec covers the situation that corresponds to the Sentry issue. The proposed solution is to add the autovote on submission instead.


# Changelog
## Fixed
- Issues with updating some proposals (for example not being able to move a proposal from "screening" to "proposed")