### PR TITLE
TAN-2853 - Extend profanity filters to user profile

### DIFF
--- a/back/app/controllers/concerns/blocking_profanity.rb
+++ b/back/app/controllers/concerns/blocking_profanity.rb
@@ -16,7 +16,7 @@ module BlockingProfanity
   DEFAULT_CLASS_ATTRS = {
     Comment.name => [:body_multiloc],
     Idea.name => %i[title_multiloc body_multiloc location_description],
-    Initiative.name => %i[title_multiloc body_multiloc location_description],
+    Initiative.name => %i[title_multiloc body_multiloc location_description]
   }.freeze
 
   # Can be turned on in settings - extended_blocking = true

--- a/back/app/controllers/concerns/blocking_profanity.rb
+++ b/back/app/controllers/concerns/blocking_profanity.rb
@@ -13,10 +13,15 @@ module BlockingProfanity
     end
   end
 
-  SUPPORTED_CLASS_ATTRS = {
+  DEFAULT_CLASS_ATTRS = {
     Comment.name => [:body_multiloc],
     Idea.name => %i[title_multiloc body_multiloc location_description],
-    Initiative.name => %i[title_multiloc body_multiloc location_description]
+    Initiative.name => %i[title_multiloc body_multiloc location_description],
+  }.freeze
+
+  # Can be turned on in settings - extended_blocking = true
+  EXTENDED_CLASS_ATTRS = {
+    User.name => %i[first_name last_name bio_multiloc]
   }.freeze
 
   included do
@@ -29,7 +34,8 @@ module BlockingProfanity
     all_blocked_words = []
     violating_attributes = []
     service = ProfanityService.new
-    attrs = SUPPORTED_CLASS_ATTRS[object.class.name]
+    attrs = DEFAULT_CLASS_ATTRS[object.class.name] || []
+    attrs += EXTENDED_CLASS_ATTRS[object.class.name] if AppConfiguration.instance.settings.dig('blocking_profanity', 'extended_blocking')
     attrs&.each do |atr|
       next if object[atr].blank?
 

--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class WebApi::V1::UsersController < ApplicationController
+  include BlockingProfanity
+
   before_action :set_user, only: %i[show update destroy ideas_count initiatives_count comments_count block unblock]
   skip_before_action :authenticate_user, only: %i[create show check by_slug by_invite ideas_count initiatives_count comments_count]
 
@@ -111,6 +113,7 @@ class WebApi::V1::UsersController < ApplicationController
   def create
     @user = User.new
     saved = UserService.upsert_in_web_api(@user, permitted_attributes(@user)) do
+      verify_profanity @user
       authorize @user
     end
     if saved
@@ -132,6 +135,7 @@ class WebApi::V1::UsersController < ApplicationController
 
   def update
     saved = UserService.upsert_in_web_api(@user, update_params) do
+      verify_profanity @user
       remove_image_if_requested!(@user, update_params, :avatar)
       authorize(@user)
     end

--- a/back/config/blocked_words/en.txt
+++ b/back/config/blocked_words/en.txt
@@ -80,6 +80,7 @@ fucked
 fucker
 fuckers
 fuckhead
+fuckface
 fuckheads
 fuckin
 fucking

--- a/back/config/blocked_words/en.txt
+++ b/back/config/blocked_words/en.txt
@@ -168,6 +168,8 @@ niggaz
 nigger
 niggers
 nigger5
+ոіggеr
+ոіggеrs
 numbnuts
 nutsack
 paki

--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -959,7 +959,8 @@
         "required": ["allowed", "enabled"],
         "properties": {
           "allowed": { "type": "boolean", "default": true},
-          "enabled": { "type": "boolean", "default": false}
+          "enabled": { "type": "boolean", "default": false},
+          "extended_blocking": { "type": "boolean", "default": false}
         }
       },
 


### PR DESCRIPTION
Looks like this in settings and defaults to false for all platforms at the moment - ie we can just turn on for NHS for now:
<img width="657" alt="image" src="https://github.com/user-attachments/assets/e70f3bca-691d-42f3-8664-69e97d3ccf7d">

# Changelog
## Added
- Added extended_blocking setting to 'blocking_profanity' feature - when enabled, user first_name, last_name and bio will be checked for profanity


