### PR TITLE
TAN-2855 Enabling prescreening for ideation

### DIFF
--- a/back/app/controllers/web_api/v1/ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/ideas_controller.rb
@@ -167,7 +167,7 @@ class WebApi::V1::IdeasController < ApplicationController
       input.anonymous = true
     end
     input.author ||= current_user
-    phase.pmedhod.assign_defaults(input)
+    phase.pmethod.assign_defaults(input)
 
     sidefx.before_create(input, current_user)
 

--- a/back/app/controllers/web_api/v1/ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/ideas_controller.rb
@@ -167,7 +167,7 @@ class WebApi::V1::IdeasController < ApplicationController
       input.anonymous = true
     end
     input.author ||= current_user
-    input.assign_defaults
+    phase.pmedhod.assign_defaults(input)
 
     sidefx.before_create(input, current_user)
 

--- a/back/app/models/idea_status.rb
+++ b/back/app/models/idea_status.rb
@@ -21,7 +21,7 @@ class IdeaStatus < ApplicationRecord
   MANUAL_TRANSITION_NOT_ALLOWED_CODES = %w[prescreening threshold_reached expired].freeze
   NON_PUBLIC_CODES = %w[prescreening].freeze
 
-  scope :public, -> { where.not(code: NON_PUBLIC_CODES) }
+  scope :for_public_posts, -> { where.not(code: NON_PUBLIC_CODES) }
 
   acts_as_list column: :ordering, top_of_list: 0, scope: [:participation_method]
 

--- a/back/app/models/idea_status.rb
+++ b/back/app/models/idea_status.rb
@@ -21,7 +21,7 @@ class IdeaStatus < ApplicationRecord
   MANUAL_TRANSITION_NOT_ALLOWED_CODES = %w[prescreening threshold_reached expired].freeze
   NON_PUBLIC_CODES = %w[prescreening].freeze
 
-  scope(:public) { where.not(code: NON_PUBLIC_CODES) }
+  scope :public, -> { where.not(code: NON_PUBLIC_CODES) }
 
   acts_as_list column: :ordering, top_of_list: 0, scope: [:participation_method]
 

--- a/back/app/models/idea_status.rb
+++ b/back/app/models/idea_status.rb
@@ -21,6 +21,8 @@ class IdeaStatus < ApplicationRecord
   MANUAL_TRANSITION_NOT_ALLOWED_CODES = %w[prescreening threshold_reached expired].freeze
   NON_PUBLIC_CODES = %w[prescreening].freeze
 
+  scope(:public) { where.not(code: NON_PUBLIC_CODES) }
+
   acts_as_list column: :ordering, top_of_list: 0, scope: [:participation_method]
 
   default_scope -> { order(:participation_method, :ordering) }

--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -790,13 +790,25 @@
 
       "prescreening": {
         "type": "object",
-        "title": "Screening",
-        "description": "When active, screening can be activated on a per-project basis, which requires admins/moderators to explicitly approve each input before it becomes visible to the public.",
+        "title": "Screening (proposals)",
+        "description": "When active, screening can be activated for proposals phases, which requires admins/moderators to explicitly approve each input before it becomes visible to the public.",
         "additionalProperties": false,
         "required": ["allowed", "enabled"],
         "properties": {
           "allowed": { "type": "boolean", "default": true },
           "enabled": { "type": "boolean", "default": true }
+        }
+      },
+
+      "prescreening_ideation": {
+        "type": "object",
+        "title": "Screening (ideation)",
+        "description": "When active, screening can be activated for ideation phases, which requires admins/moderators to explicitly approve each input before it becomes visible to the public.",
+        "additionalProperties": false,
+        "required": ["allowed", "enabled"],
+        "properties": {
+          "allowed": { "type": "boolean", "default": false },
+          "enabled": { "type": "boolean", "default": false }
         }
       },
 

--- a/back/config/tenant_templates/base.yml
+++ b/back/config/tenant_templates/base.yml
@@ -4,43 +4,50 @@ models:
       enabled: true
   idea_status:
     -
-      title_multiloc: idea_statuses.proposed
+      title_multiloc: idea_statuses.prescreening
       ordering: 0
+      code: prescreening
+      color: '#4B4B4B'
+      description_multiloc: idea_statuses.prescreening_description
+      participation_method: ideation
+    -
+      title_multiloc: idea_statuses.proposed
+      ordering: 1
       code: proposed
       color: '#057ABE'
       description_multiloc: idea_statuses.proposed_description
       participation_method: ideation
     -
       title_multiloc: idea_statuses.viewed
-      ordering: 1
+      ordering: 2
       code: viewed
       color: '#01A1B1'
       description_multiloc: idea_statuses.viewed_description
       participation_method: ideation
     -
       title_multiloc: idea_statuses.under_consideration
-      ordering: 2
+      ordering: 3
       code: under_consideration
       color: '#0080A5'
       description_multiloc: idea_statuses.under_consideration_description
       participation_method: ideation
     -
       title_multiloc: idea_statuses.accepted
-      ordering: 3
+      ordering: 4
       code: accepted
       color: '#04884C'
       description_multiloc: idea_statuses.accepted_description
       participation_method: ideation
     -
       title_multiloc: idea_statuses.rejected
-      ordering: 4
+      ordering: 5
       code: rejected
       color: '#E52516'
       description_multiloc: idea_statuses.rejected_description
       participation_method: ideation
     -
       title_multiloc: idea_statuses.implemented
-      ordering: 5
+      ordering: 6
       code: implemented
       color: '#04884C'
       description_multiloc: idea_statuses.implemented_description

--- a/back/config/tenant_templates/e2etests_template.yml
+++ b/back/config/tenant_templates/e2etests_template.yml
@@ -5,48 +5,54 @@ models:
       enabled: true
   idea_status:
     -
-      title_multiloc: idea_statuses.proposed
+      title_multiloc: idea_statuses.prescreening
       ordering: 0
+      code: prescreening
+      color: '#4B4B4B'
+      description_multiloc: idea_statuses.prescreening_description
+      participation_method: ideation
+    -
+      title_multiloc: idea_statuses.proposed
+      ordering: 1
       code: proposed
       color: '#057ABE'
       description_multiloc: idea_statuses.proposed_description
       participation_method: ideation
     -
       title_multiloc: idea_statuses.viewed
-      ordering: 1
+      ordering: 2
       code: viewed
       color: '#01A1B1'
       description_multiloc: idea_statuses.viewed_description
       participation_method: ideation
     -
       title_multiloc: idea_statuses.under_consideration
-      ordering: 2
+      ordering: 3
       code: under_consideration
       color: '#0080A5'
       description_multiloc: idea_statuses.under_consideration_description
       participation_method: ideation
     -
       title_multiloc: idea_statuses.accepted
-      ordering: 3
+      ordering: 4
       code: accepted
       color: '#04884C'
       description_multiloc: idea_statuses.accepted_description
       participation_method: ideation
     -
       title_multiloc: idea_statuses.rejected
-      ordering: 4
+      ordering: 5
       code: rejected
       color: '#E52516'
       description_multiloc: idea_statuses.rejected_description
       participation_method: ideation
     -
       title_multiloc: idea_statuses.implemented
-      ordering: 5
+      ordering: 6
       code: implemented
       color: '#04884C'
       description_multiloc: idea_statuses.implemented_description
       participation_method: ideation
-    -
       title_multiloc: idea_statuses.prescreening
       ordering: 0
       code: prescreening

--- a/back/engines/commercial/multi_tenancy/db/seeds/ideas.rb
+++ b/back/engines/commercial/multi_tenancy/db/seeds/ideas.rb
@@ -17,7 +17,7 @@ module MultiTenancy
           idea = Idea.create!({
             title_multiloc: runner.create_for_some_locales { Faker::Lorem.sentence[0...80] },
             body_multiloc: runner.rand_description_multiloc,
-            idea_status: runner.rand_instance(IdeaStatus.all),
+            idea_status: runner.rand_instance(IdeaStatus.public),
             topics: topics,
             author: runner.rand_instance(User.all),
             project: project,

--- a/back/engines/commercial/multi_tenancy/db/seeds/ideas.rb
+++ b/back/engines/commercial/multi_tenancy/db/seeds/ideas.rb
@@ -17,7 +17,7 @@ module MultiTenancy
           idea = Idea.create!({
             title_multiloc: runner.create_for_some_locales { Faker::Lorem.sentence[0...80] },
             body_multiloc: runner.rand_description_multiloc,
-            idea_status: runner.rand_instance(IdeaStatus.public),
+            idea_status: runner.rand_instance(IdeaStatus.for_public_posts),
             topics: topics,
             author: runner.rand_instance(User.all),
             project: project,

--- a/back/lib/participation_method/ideation.rb
+++ b/back/lib/participation_method/ideation.rb
@@ -15,8 +15,7 @@ module ParticipationMethod
     end
 
     def assign_defaults(input)
-      current_phase = TimelineService.new.current_phase(input.project)
-      input_status_code = current_phase&.prescreening_enabled ? 'prescreening' : 'proposed'
+      input_status_code = phase&.prescreening_enabled ? 'prescreening' : 'proposed'
       input.idea_status ||= IdeaStatus.find_by!(code: input_status_code, participation_method: idea_status_method)
       input.publication_status ||= input.idea_status.public_post? ? 'published' : 'submitted'
     end

--- a/back/lib/participation_method/ideation.rb
+++ b/back/lib/participation_method/ideation.rb
@@ -15,7 +15,8 @@ module ParticipationMethod
     end
 
     def assign_defaults(input)
-      input_status_code = input.creation_phase&.prescreening_enabled ? 'prescreening' : 'proposed'
+      current_phase = TimelineService.new.current_phase(input.project)
+      input_status_code = current_phase&.prescreening_enabled ? 'prescreening' : 'proposed'
       input.idea_status ||= IdeaStatus.find_by!(code: input_status_code, participation_method: idea_status_method)
       input.publication_status ||= input.idea_status.public_post? ? 'published' : 'submitted'
     end

--- a/back/lib/tasks/single_use/20241022_add_prescreening_statusto_ideation.rake
+++ b/back/lib/tasks/single_use/20241022_add_prescreening_statusto_ideation.rake
@@ -1,0 +1,34 @@
+namespace :proposals_transition do
+  desc 'Adds the prescreening status at the top of the ideation status set'
+  task :add_prescreening_status_to_ideation, [] => [:environment] do
+    reporter = ScriptReporter.new
+    Tenant.safe_switch_each do |tenant|
+      # Should be none, but just in case
+      next if IdeaStatus.find_by(code: 'prescreening', participation_method: 'ideation')
+
+      multiloc_service = MultilocService.new
+      attributes = {
+        title_multiloc: multiloc_service.i18n_to_multiloc('idea_statuses.prescreening', locales: CL2_SUPPORTED_LOCALES),
+        code: 'prescreening',
+        color: '#4B4B4B',
+        description_multiloc: multiloc_service.i18n_to_multiloc('idea_statuses.prescreening_description', locales: CL2_SUPPORTED_LOCALES),
+        participation_method: 'ideation'
+      }
+      status = IdeaStatus.new attributes
+      if status.save
+        status.move_to_top
+        reporter.add_create(
+          'IdeaStatus',
+          attributes,
+          context: { tenant: tenant.host }
+        )
+      else
+        reporter.add_error(
+          status.errors.details,
+          context: { tenant: tenant.host }
+        )
+      end
+    end
+    reporter.report!('add_prescreening_report.json', verbose: true)
+  end
+end

--- a/back/spec/lib/participation_method/proposals_spec.rb
+++ b/back/spec/lib/participation_method/proposals_spec.rb
@@ -22,32 +22,32 @@ RSpec.describe ParticipationMethod::Proposals do
       let!(:custom_status) { create(:proposals_status) }
 
       context 'when the creation phase has reviewing enabled' do
-        let(:creation_phase) { create(:proposals_phase, prescreening_enabled: true) }
+        let(:phase) { create(:proposals_phase, prescreening_enabled: true) }
 
         it 'assignes the default "prescreening" status if not set' do
-          proposal = build(:proposal, idea_status: nil, creation_phase: creation_phase, project: creation_phase.project)
+          proposal = build(:proposal, idea_status: nil, creation_phase: phase, project: phase.project)
           participation_method.assign_defaults proposal
           expect(proposal.idea_status).to eq prescreening_status
         end
 
         it 'does not change the status if it is already set' do
-          proposal = build(:proposal, idea_status: custom_status, creation_phase: creation_phase, project: creation_phase.project)
+          proposal = build(:proposal, idea_status: custom_status, creation_phase: phase, project: phase.project)
           participation_method.assign_defaults proposal
           expect(proposal.idea_status).to eq custom_status
         end
       end
 
       context 'when the creation phase does not have reviewing enabled' do
-        let(:creation_phase) { create(:proposals_phase, prescreening_enabled: false) }
+        let(:phase) { create(:proposals_phase, prescreening_enabled: false) }
 
         it 'assigns the default "proposed" status if not set' do
-          proposal = build(:proposal, idea_status: nil, creation_phase: creation_phase, project: creation_phase.project)
+          proposal = build(:proposal, idea_status: nil, creation_phase: phase, project: phase.project)
           participation_method.assign_defaults proposal
           expect(proposal.idea_status).to eq proposed_status
         end
 
         it 'does not change the status if it is already set' do
-          proposal = build(:proposal, idea_status: custom_status, creation_phase: creation_phase, project: creation_phase.project)
+          proposal = build(:proposal, idea_status: custom_status, creation_phase: phase, project: phase.project)
           participation_method.assign_defaults proposal
           expect(proposal.idea_status).to eq custom_status
         end

--- a/front/app/api/app_configuration/types.ts
+++ b/front/app/api/app_configuration/types.ts
@@ -243,6 +243,7 @@ export interface IAppConfigurationSettings {
   management_feed?: AppConfigurationFeature;
   fake_sso?: AppConfigurationFeature;
   prescreening?: AppConfigurationFeature;
+  prescreening_ideation?: AppConfigurationFeature;
   input_cosponsorship?: AppConfigurationFeature;
 }
 

--- a/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/IdeationInputs/index.tsx
+++ b/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/IdeationInputs/index.tsx
@@ -5,6 +5,8 @@ import { CLErrors } from 'typings';
 
 import { IdeaDefaultSortMethod, InputTerm } from 'api/phases/types';
 
+import useFeatureFlag from 'hooks/useFeatureFlag';
+
 import AnonymousPostingToggle from 'components/admin/AnonymousPostingToggle/AnonymousPostingToggle';
 import { SectionField, SubSectionTitle } from 'components/admin/Section';
 import FeatureFlag from 'components/FeatureFlag';
@@ -108,6 +110,10 @@ const IdeationInputs = ({
       <PrescreeningToggle
         prescreening_enabled={prescreening_enabled}
         togglePrescreeningEnabled={togglePrescreeningEnabled}
+        prescreeningFeatureAllowed={useFeatureFlag({
+          name: 'prescreening_ideation',
+          onlyCheckAllowed: true,
+        })}
       />
       <UserActions
         submission_enabled={submission_enabled || false}

--- a/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/IdeationInputs/index.tsx
+++ b/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/IdeationInputs/index.tsx
@@ -16,6 +16,7 @@ import messages from '../../../../../../messages';
 import CustomFieldPicker from '../../shared/CustomFieldPicker';
 import DefaultViewPicker from '../../shared/DefaultViewPicker';
 import { ReactingLimitInput } from '../../shared/styling';
+import PrescreeningToggle from '../_shared/PrescreeningToggle';
 import SortingPicker from '../_shared/SortingPicker';
 import UserActions from '../_shared/UserActions';
 
@@ -57,6 +58,8 @@ interface Props {
   handleIdeaDefaultSortMethodChange: (
     ideas_order: IdeaDefaultSortMethod
   ) => void;
+  prescreening_enabled: boolean | null | undefined;
+  togglePrescreeningEnabled: (prescreening_enabled: boolean) => void;
 }
 
 const IdeationInputs = ({
@@ -87,6 +90,8 @@ const IdeationInputs = ({
   handleIdeasDisplayChange,
   ideas_order,
   handleIdeaDefaultSortMethodChange,
+  prescreening_enabled,
+  togglePrescreeningEnabled,
 }: Props) => {
   return (
     <>
@@ -99,6 +104,10 @@ const IdeationInputs = ({
       <CustomFieldPicker
         input_term={input_term}
         handleInputTermChange={handleInputTermChange}
+      />
+      <PrescreeningToggle
+        prescreening_enabled={prescreening_enabled}
+        togglePrescreeningEnabled={togglePrescreeningEnabled}
       />
       <UserActions
         submission_enabled={submission_enabled || false}

--- a/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/ProposalsInputs/index.tsx
+++ b/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/ProposalsInputs/index.tsx
@@ -5,6 +5,8 @@ import { CLErrors } from 'typings';
 
 import { IdeaDefaultSortMethod, InputTerm } from 'api/phases/types';
 
+import useFeatureFlag from 'hooks/useFeatureFlag';
+
 import AnonymousPostingToggle from 'components/admin/AnonymousPostingToggle/AnonymousPostingToggle';
 import { SectionField, SubSectionTitle } from 'components/admin/Section';
 import Error from 'components/UI/Error';
@@ -134,6 +136,10 @@ const ProposalsInputs = ({
       <PrescreeningToggle
         prescreening_enabled={prescreening_enabled}
         togglePrescreeningEnabled={togglePrescreeningEnabled}
+        prescreeningFeatureAllowed={useFeatureFlag({
+          name: 'prescreening',
+          onlyCheckAllowed: true,
+        })}
       />
       <UserActions
         submission_enabled={submission_enabled || false}

--- a/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/ProposalsInputs/index.tsx
+++ b/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/ProposalsInputs/index.tsx
@@ -1,18 +1,9 @@
 import React from 'react';
 
-import {
-  Input,
-  IOption,
-  Box,
-  Text,
-  Toggle,
-  Tooltip,
-} from '@citizenlab/cl2-component-library';
+import { Input, IOption } from '@citizenlab/cl2-component-library';
 import { CLErrors } from 'typings';
 
 import { IdeaDefaultSortMethod, InputTerm } from 'api/phases/types';
-
-import useFeatureFlag from 'hooks/useFeatureFlag';
 
 import AnonymousPostingToggle from 'components/admin/AnonymousPostingToggle/AnonymousPostingToggle';
 import { SectionField, SubSectionTitle } from 'components/admin/Section';
@@ -23,6 +14,7 @@ import { FormattedMessage } from 'utils/cl-intl';
 import messages from '../../../../../../messages';
 import CustomFieldPicker from '../../shared/CustomFieldPicker';
 import DefaultViewPicker from '../../shared/DefaultViewPicker';
+import PrescreeningToggle from '../_shared/PrescreeningToggle';
 import SortingPicker from '../_shared/SortingPicker';
 import UserActions from '../_shared/UserActions';
 
@@ -60,7 +52,7 @@ interface Props {
   handleDaysLimitChange: (limit: string) => void;
   handleReactingThresholdChange: (threshold: string) => void;
   prescreening_enabled: boolean | null | undefined;
-  toggleReviewingEnabled: (prescreening_enabled: boolean) => void;
+  togglePrescreeningEnabled: (prescreening_enabled: boolean) => void;
 }
 
 const ProposalsInputs = ({
@@ -91,10 +83,8 @@ const ProposalsInputs = ({
   handleDaysLimitChange,
   handleReactingThresholdChange,
   prescreening_enabled,
-  toggleReviewingEnabled,
+  togglePrescreeningEnabled,
 }: Props) => {
-  const prescreeningEnabled = useFeatureFlag({ name: 'prescreening' });
-
   return (
     <>
       <CustomFieldPicker
@@ -141,43 +131,10 @@ const ProposalsInputs = ({
           handleAllowAnonymousParticipationOnChange
         }
       />
-      <SectionField>
-        <SubSectionTitle style={{ marginBottom: '0px' }}>
-          <FormattedMessage {...messages.participationOptions} />
-        </SubSectionTitle>
-        <Tooltip
-          disabled={prescreeningEnabled}
-          content={<FormattedMessage {...messages.prescreeningTooltip} />}
-        >
-          <Box>
-            <Toggle
-              disabled={!prescreeningEnabled}
-              checked={prescreening_enabled || false}
-              onChange={() => {
-                toggleReviewingEnabled(!prescreening_enabled);
-              }}
-              label={
-                <Box ml="8px" id="e2e-participation-options-toggle">
-                  <Box display="flex">
-                    <Text
-                      color="primary"
-                      mb="0px"
-                      fontSize="m"
-                      style={{ fontWeight: 600 }}
-                    >
-                      <FormattedMessage {...messages.prescreeningText} />
-                    </Text>
-                  </Box>
-
-                  <Text color="coolGrey600" mt="0px" fontSize="m">
-                    <FormattedMessage {...messages.prescreeningSubtext} />
-                  </Text>
-                </Box>
-              }
-            />
-          </Box>
-        </Tooltip>
-      </SectionField>
+      <PrescreeningToggle
+        prescreening_enabled={prescreening_enabled}
+        togglePrescreeningEnabled={togglePrescreeningEnabled}
+      />
       <UserActions
         submission_enabled={submission_enabled || false}
         commenting_enabled={commenting_enabled || false}

--- a/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/_shared/PrescreeningToggle.tsx
+++ b/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/_shared/PrescreeningToggle.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 
 import { Box, Toggle, Tooltip, Text } from '@citizenlab/cl2-component-library';
 
-import useFeatureFlag from 'hooks/useFeatureFlag';
-
 import { SectionField, SubSectionTitle } from 'components/admin/Section';
 
 import { FormattedMessage } from 'utils/cl-intl';

--- a/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/_shared/PrescreeningToggle.tsx
+++ b/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/_shared/PrescreeningToggle.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+
+import { Box, Toggle, Tooltip, Text } from '@citizenlab/cl2-component-library';
+
+import useFeatureFlag from 'hooks/useFeatureFlag';
+
+import { SectionField, SubSectionTitle } from 'components/admin/Section';
+
+import { FormattedMessage } from 'utils/cl-intl';
+
+import messages from '../../../../../../messages';
+
+interface Props {
+  prescreening_enabled: boolean | null | undefined;
+  togglePrescreeningEnabled: (prescreening_enabled: boolean) => void;
+}
+
+const PrescreeningToggle = ({
+  prescreening_enabled,
+  togglePrescreeningEnabled,
+}: Props) => {
+  const prescreeningEnabled = useFeatureFlag({ name: 'prescreening' });
+
+  return (
+    <SectionField>
+      <SubSectionTitle style={{ marginBottom: '0px' }}>
+        <FormattedMessage {...messages.participationOptions} />
+      </SubSectionTitle>
+      <Tooltip
+        disabled={prescreeningEnabled}
+        content={<FormattedMessage {...messages.prescreeningTooltip} />}
+      >
+        <Box>
+          <Toggle
+            disabled={!prescreeningEnabled}
+            checked={prescreening_enabled || false}
+            onChange={() => {
+              togglePrescreeningEnabled(!prescreening_enabled);
+            }}
+            label={
+              <Box ml="8px" id="e2e-participation-options-toggle">
+                <Box display="flex">
+                  <Text
+                    color="primary"
+                    mb="0px"
+                    fontSize="m"
+                    style={{ fontWeight: 600 }}
+                  >
+                    <FormattedMessage {...messages.prescreeningText} />
+                  </Text>
+                </Box>
+
+                <Text color="coolGrey600" mt="0px" fontSize="m">
+                  <FormattedMessage {...messages.prescreeningSubtext} />
+                </Text>
+              </Box>
+            }
+          />
+        </Box>
+      </Tooltip>
+    </SectionField>
+  );
+};
+
+export default PrescreeningToggle;

--- a/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/_shared/PrescreeningToggle.tsx
+++ b/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/_shared/PrescreeningToggle.tsx
@@ -13,26 +13,26 @@ import messages from '../../../../../../messages';
 interface Props {
   prescreening_enabled: boolean | null | undefined;
   togglePrescreeningEnabled: (prescreening_enabled: boolean) => void;
+  prescreeningFeatureAllowed: boolean;
 }
 
 const PrescreeningToggle = ({
   prescreening_enabled,
   togglePrescreeningEnabled,
+  prescreeningFeatureAllowed,
 }: Props) => {
-  const prescreeningEnabled = useFeatureFlag({ name: 'prescreening' });
-
   return (
     <SectionField>
       <SubSectionTitle style={{ marginBottom: '0px' }}>
         <FormattedMessage {...messages.participationOptions} />
       </SubSectionTitle>
       <Tooltip
-        disabled={prescreeningEnabled}
+        disabled={prescreeningFeatureAllowed}
         content={<FormattedMessage {...messages.prescreeningTooltip} />}
       >
         <Box>
           <Toggle
-            disabled={!prescreeningEnabled}
+            disabled={!prescreeningFeatureAllowed}
             checked={prescreening_enabled || false}
             onChange={() => {
               togglePrescreeningEnabled(!prescreening_enabled);

--- a/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/index.tsx
+++ b/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/index.tsx
@@ -345,7 +345,7 @@ const PhaseParticipationConfig = ({
     }));
   };
 
-  const toggleReviewingEnabled = (prescreening_enabled: boolean) => {
+  const togglePrescreeningEnabled = (prescreening_enabled: boolean) => {
     updateFormData((state) => ({
       ...state,
       prescreening_enabled,
@@ -489,6 +489,8 @@ const PhaseParticipationConfig = ({
             handleIdeaDefaultSortMethodChange={
               handleIdeaDefaultSortMethodChange
             }
+            prescreening_enabled={prescreening_enabled}
+            togglePrescreeningEnabled={togglePrescreeningEnabled}
           />
         )}
 
@@ -525,7 +527,7 @@ const PhaseParticipationConfig = ({
             handleReactingThresholdChange={handleReactingThresholdChange}
             reactingThresholdError={validationErrors.reactingThresholdError}
             prescreening_enabled={prescreening_enabled}
-            toggleReviewingEnabled={toggleReviewingEnabled}
+            togglePrescreeningEnabled={togglePrescreeningEnabled}
           />
         )}
 

--- a/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/utils/participationMethodConfigs.ts
+++ b/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/utils/participationMethodConfigs.ts
@@ -44,6 +44,7 @@ export const ideationDefaultConfig: IUpdatedPhaseProperties = {
   presentation_mode: 'card',
   input_term: 'idea',
   ideas_order: 'trending',
+  prescreening_enabled: false,
 };
 
 export const nativeSurveyDefaultConfig: IUpdatedPhaseProperties = {


### PR DESCRIPTION
# Changelog
## Added
- Prescreening is now available in ideation, the same way it works for proposals. A Toggle is available in the phase settings, if the feature flag is active.