### PR TITLE
TAN-2875: Disable loading markers when not viewing the map

### DIFF
--- a/front/app/api/idea_markers/useIdeaMarkers.ts
+++ b/front/app/api/idea_markers/useIdeaMarkers.ts
@@ -23,10 +23,14 @@ const fetchIdeaMarkers = ({
     },
   });
 
-const useIdeaMarkers = (queryParameters: QueryParameters) => {
+const useIdeaMarkers = (
+  queryParameters: QueryParameters,
+  loadIdeaMarkers = true
+) => {
   return useQuery<IIdeaMarkers, CLErrors, IIdeaMarkers, IdeaMarkersKeys>({
     queryKey: ideaMarkerKeys.list(queryParameters),
     queryFn: () => fetchIdeaMarkers(queryParameters),
+    enabled: loadIdeaMarkers,
   });
 };
 

--- a/front/app/components/IdeaCards/IdeasWithoutFiltersSidebar/index.tsx
+++ b/front/app/components/IdeaCards/IdeasWithoutFiltersSidebar/index.tsx
@@ -134,11 +134,22 @@ const IdeasWithoutFiltersSidebar = ({
     return data?.pages.map((page) => page.data).flat();
   }, [data?.pages]);
   const { data: phase } = usePhase(phaseId);
-  const { data: ideaMarkers } = useIdeaMarkers({
-    projectIds: projectId ? [projectId] : null,
-    phaseId,
-    ...ideaQueryParameters,
-  });
+  const locationEnabled = !isNilOrError(ideaCustomFieldsSchemas)
+    ? isFieldEnabled(
+        'location_description',
+        ideaCustomFieldsSchemas.data.attributes,
+        locale
+      )
+    : false;
+  const loadIdeaMarkers = locationEnabled && selectedView === 'map';
+  const { data: ideaMarkers } = useIdeaMarkers(
+    {
+      projectIds: projectId ? [projectId] : null,
+      phaseId,
+      ...ideaQueryParameters,
+    },
+    loadIdeaMarkers
+  );
 
   const handleSearchOnChange = useCallback(
     (search: string) => {
@@ -178,13 +189,6 @@ const IdeasWithoutFiltersSidebar = ({
 
     onUpdateQuery({ idea_status });
   };
-  const locationEnabled = !isNilOrError(ideaCustomFieldsSchemas)
-    ? isFieldEnabled(
-        'location_description',
-        ideaCustomFieldsSchemas.data.attributes,
-        locale
-      )
-    : false;
 
   const topicsEnabled = !isNilOrError(ideaCustomFieldsSchemas)
     ? isFieldEnabled(


### PR DESCRIPTION
# Changelog

## Fixed
- Disable the network call for idea markers when not viewing ideas on a map. This should subsequently lead to some performance gains on the ideation project for the NHS and similar projects
