### PR TITLE
TAN-2875: Fix performance issues on idea page with many comments

### DIFF
--- a/front/app/api/comments/useComments.ts
+++ b/front/app/api/comments/useComments.ts
@@ -38,7 +38,8 @@ const fetchComments = (
   });
 
 const useComments = (
-  parameters: ICommentParameters & ICommentQueryParameters
+  parameters: ICommentParameters & ICommentQueryParameters,
+  hasComments = true
 ) => {
   return useInfiniteQuery<IComments, CLErrors, IComments, CommentsKeys>({
     queryKey: commentKeys.list(parameters),
@@ -53,7 +54,8 @@ const useComments = (
       return hasNextPage && pageNumber ? pageNumber + 1 : null;
     },
     enabled:
-      !!parameters.authorId || !!parameters.ideaId || !!parameters.commentId,
+      hasComments &&
+      (!!parameters.authorId || !!parameters.ideaId || !!parameters.commentId),
   });
 };
 

--- a/front/app/components/PostShowComponents/Comments/CommentsSection/PublicComments/Comments/ParentComment.tsx
+++ b/front/app/components/PostShowComponents/Comments/CommentsSection/PublicComments/Comments/ParentComment.tsx
@@ -59,7 +59,10 @@ const ParentComment = ({
     fetchNextPage,
     isFetchingNextPage,
     hasNextPage,
-  } = useComments({ commentId, pageSize: 5 });
+  } = useComments(
+    { commentId, pageSize: 5 },
+    !!comment?.data.attributes.children_count
+  );
   const childComments = childCommentsData?.pages
     .map((page) => page.data)
     .flat();

--- a/front/app/components/PostShowComponents/Comments/CommentsSection/PublicComments/index.tsx
+++ b/front/app/components/PostShowComponents/Comments/CommentsSection/PublicComments/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 import {
   colors,
@@ -56,15 +56,9 @@ const PublicComments = ({
   className,
   allowAnonymousParticipation,
 }: Props) => {
-  const { ref } = useInView({
-    rootMargin: '3000px',
-    onChange: (inView) => {
-      if (inView) {
-        if (hasNextPage) {
-          fetchNextPage();
-        }
-      }
-    },
+  const { ref: loadMoreRef, inView } = useInView({
+    rootMargin: '200px',
+    threshold: 0,
   });
   const isSmallerThanPhone = useBreakpoint('phone');
 
@@ -80,6 +74,7 @@ const PublicComments = ({
   } = useComments({
     ideaId: postId,
     sort: sortOrder,
+    pageSize: 5,
   });
 
   const commentsList = comments?.pages.flatMap((page) => page.data);
@@ -90,6 +85,13 @@ const PublicComments = ({
   const { data: project } = useProjectById(projectId);
 
   const [posting, setPosting] = useState(false);
+
+  // Trigger fetching of next page when the user scrolls to the bottom
+  useEffect(() => {
+    if (inView && hasNextPage) {
+      fetchNextPage();
+    }
+  }, [inView, hasNextPage, fetchNextPage]);
 
   if (!idea || !commentsList) return null;
 
@@ -162,7 +164,9 @@ const PublicComments = ({
         allowAnonymousParticipation={allowAnonymousParticipation}
       />
 
-      {hasNextPage && !isFetchingNextPage && <Box ref={ref} w="100%" />}
+      {hasNextPage && !isFetchingNextPage && (
+        <Box ref={loadMoreRef} w="100%" h="50px" />
+      )}
 
       {isFetchingNextPage && !posting && (
         <Box

--- a/front/app/components/PostShowComponents/Comments/CommentsSection/PublicComments/index.tsx
+++ b/front/app/components/PostShowComponents/Comments/CommentsSection/PublicComments/index.tsx
@@ -74,7 +74,7 @@ const PublicComments = ({
   } = useComments({
     ideaId: postId,
     sort: sortOrder,
-    pageSize: 5,
+    pageSize: 10,
   });
 
   const commentsList = comments?.pages.flatMap((page) => page.data);


### PR DESCRIPTION
# Changelog

## Fixed
- Improve performance on idea page with very many comments. We load the first 5 comments on initial load and more comments as the user scrolls to the bottom of the page. This reduces the number of calls and subsequently the data that we have to cache before the page becomes interactive
