### PR TITLE
TAN-2882 - Remove verification onboarding banner when methods are set to hide_from_profile

### DIFF
--- a/back/engines/commercial/verification/app/services/verification/patches/onboarding/onboarding_service.rb
+++ b/back/engines/commercial/verification/app/services/verification/patches/onboarding/onboarding_service.rb
@@ -27,7 +27,8 @@ module Verification
         private
 
         def needs_verification?(user)
-          AppConfiguration.instance.feature_activated?('verification') && !user.verified
+          settings = ::SettingsService.new.disable_verification_if_no_methods_enabled(AppConfiguration.instance.settings)
+          settings['verification']['enabled'] && !user.verified
         end
       end
     end

--- a/back/engines/commercial/verification/app/services/verification/patches/settings_service.rb
+++ b/back/engines/commercial/verification/app/services/verification/patches/settings_service.rb
@@ -8,8 +8,6 @@ module Verification
         super
       end
 
-      private
-
       # Ensures the FE does not show verification if:
       # a) There are no verification methods
       # b) All verification methods are flagged as 'hide_from_profile'

--- a/back/engines/commercial/verification/spec/services/onboarding/onboarding_service_spec.rb
+++ b/back/engines/commercial/verification/spec/services/onboarding/onboarding_service_spec.rb
@@ -10,21 +10,23 @@ describe Onboarding::OnboardingService do
       cfg.settings['verification'] = {
         allowed: true,
         enabled: true,
-        verification_methods: []
+        verification_methods: [
+          { name: 'fake_sso' }
+        ]
       }
       cfg.save!
     end
   end
 
   describe '#current_campaign' do
+    context 'when the user is verified' do
+      let(:verified_user) { create(:user, verified: true) }
+
+      it { expect(service.current_campaign(verified_user)).not_to eq :verification }
+    end
+
     context 'when the user is not verified' do
-      let(:user_not_verified) do
-        create(
-          :user,
-          bio_multiloc: { en: "I'm a great bloke" },
-          verified: false
-        )
-      end
+      let(:user_not_verified) { create(:user, verified: false) }
 
       it { expect(service.current_campaign(user_not_verified)).to eq(:verification) }
 
@@ -34,11 +36,30 @@ describe Onboarding::OnboardingService do
       end
 
       context 'when verification is not active' do
-        before do
-          SettingsService.new.deactivate_feature! 'verification'
-        end
-
         it 'does not return :verification' do
+          SettingsService.new.deactivate_feature! 'verification'
+          Onboarding::CampaignDismissal.create(user: user_not_verified, campaign_name: 'verification')
+          expect(service.current_campaign(user_not_verified)).not_to eq :verification
+        end
+      end
+
+      context 'when there are no verification methods' do
+        it 'does not return :verification' do
+          settings = AppConfiguration.instance.settings
+          settings['verification']['verification_methods'] = []
+          AppConfiguration.instance.update!(settings:)
+          Onboarding::CampaignDismissal.create(user: user_not_verified, campaign_name: 'verification')
+          expect(service.current_campaign(user_not_verified)).not_to eq :verification
+        end
+      end
+
+      context 'when all verification methods have "hide_from_profile = true"' do
+        it 'does not return :verification' do
+          settings = AppConfiguration.instance.settings
+          settings['verification']['verification_methods'] = [
+            { name: 'fake_sso', hide_from_profile: true }
+          ]
+          AppConfiguration.instance.update!(settings:)
           Onboarding::CampaignDismissal.create(user: user_not_verified, campaign_name: 'verification')
           expect(service.current_campaign(user_not_verified)).not_to eq :verification
         end


### PR DESCRIPTION
`hide_from_profile` is only set currently for keycloak (ID-Porten) verification on the Oslo platform

# Changelog
## Fixed
- Removed verification onboarding banner when methods are set to hide_from_profile
