### PR TITLE
Disable pre-screening idea toggle display unless feature flag enabled

### DIFF
--- a/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/IdeationInputs/index.tsx
+++ b/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/IdeationInputs/index.tsx
@@ -107,14 +107,21 @@ const IdeationInputs = ({
         input_term={input_term}
         handleInputTermChange={handleInputTermChange}
       />
-      <PrescreeningToggle
-        prescreening_enabled={prescreening_enabled}
-        togglePrescreeningEnabled={togglePrescreeningEnabled}
-        prescreeningFeatureAllowed={useFeatureFlag({
+      {
+        // Remove the following condition when pricing decision made
+        useFeatureFlag({
           name: 'prescreening_ideation',
-          onlyCheckAllowed: true,
-        })}
-      />
+        }) && (
+          <PrescreeningToggle
+            prescreening_enabled={prescreening_enabled}
+            togglePrescreeningEnabled={togglePrescreeningEnabled}
+            prescreeningFeatureAllowed={useFeatureFlag({
+              name: 'prescreening_ideation',
+              onlyCheckAllowed: true,
+            })}
+          />
+        )
+      }
       <UserActions
         submission_enabled={submission_enabled || false}
         commenting_enabled={commenting_enabled || false}

--- a/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/IdeationInputs/index.tsx
+++ b/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/IdeationInputs/index.tsx
@@ -109,16 +109,14 @@ const IdeationInputs = ({
       />
       {
         // Remove the following condition when pricing decision made
+        // And add feature flag with onlyCheckAllowed back into prescreeningFeatureAllowed
         useFeatureFlag({
           name: 'prescreening_ideation',
         }) && (
           <PrescreeningToggle
             prescreening_enabled={prescreening_enabled}
             togglePrescreeningEnabled={togglePrescreeningEnabled}
-            prescreeningFeatureAllowed={useFeatureFlag({
-              name: 'prescreening_ideation',
-              onlyCheckAllowed: true,
-            })}
+            prescreeningFeatureAllowed={true}
           />
         )
       }

--- a/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/_shared/PrescreeningToggle.tsx
+++ b/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/_shared/PrescreeningToggle.tsx
@@ -19,8 +19,6 @@ const PrescreeningToggle = ({
   togglePrescreeningEnabled,
   prescreeningFeatureAllowed,
 }: Props) => {
-  if (!prescreening_enabled) return null; // Remove when pricing decision made
-
   return (
     <SectionField>
       <SubSectionTitle style={{ marginBottom: '0px' }}>

--- a/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/_shared/PrescreeningToggle.tsx
+++ b/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/_shared/PrescreeningToggle.tsx
@@ -19,6 +19,8 @@ const PrescreeningToggle = ({
   togglePrescreeningEnabled,
   prescreeningFeatureAllowed,
 }: Props) => {
+  if (!prescreening_enabled) return null; // Remove when pricing decision made
+
   return (
     <SectionField>
       <SubSectionTitle style={{ marginBottom: '0px' }}>


### PR DESCRIPTION
# Changelog
## Changed
- Hide ideation pre-screening toggle until pricing decision is made
