### PR TITLE
TAN-2880: fix date range issues

### DIFF
--- a/front/app/components/admin/DatePickers/DatePhasePicker/Calendar/index.tsx
+++ b/front/app/components/admin/DatePickers/DatePhasePicker/Calendar/index.tsx
@@ -6,6 +6,8 @@ import { transparentize } from 'polished';
 import { DayPicker, PropsBase } from 'react-day-picker';
 import styled from 'styled-components';
 
+import useAppConfiguration from 'api/app_configuration/useAppConfiguration';
+
 import useLocale from 'hooks/useLocale';
 
 import { getLocale } from '../../_shared/locales';
@@ -144,6 +146,9 @@ const Calendar = ({
   defaultMonth,
   onUpdateRange,
 }: Props) => {
+  const { data: appConfiguration } = useAppConfiguration();
+  const tenantTimezone =
+    appConfiguration?.data.attributes.settings.core.timezone;
   const startMonth = getStartMonth({
     startMonth: _startMonth,
     selectedRange,
@@ -209,6 +214,7 @@ const Calendar = ({
         // range rather than being controlled by our state.
         selected={[] as any}
         onSelect={NOOP}
+        timeZone={tenantTimezone}
       />
     </DayPickerStyles>
   );

--- a/front/app/components/admin/DatePickers/DatePhasePicker/Calendar/index.tsx
+++ b/front/app/components/admin/DatePickers/DatePhasePicker/Calendar/index.tsx
@@ -188,11 +188,7 @@ const Calendar = ({
       clickedDate: day,
     });
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    if (updatedRange) {
-      onUpdateRange(updatedRange);
-    }
+    onUpdateRange(updatedRange);
   };
 
   return (

--- a/front/app/components/admin/DatePickers/DatePhasePicker/Calendar/utils/getStartEndMonth.ts
+++ b/front/app/components/admin/DatePickers/DatePhasePicker/Calendar/utils/getStartEndMonth.ts
@@ -17,7 +17,7 @@ export const getStartMonth = ({
 }: GetStartMonthProps) => {
   if (startMonth) return startMonth;
 
-  const times: number[] = [addYears(new Date(), -2).getTime()];
+  const times: number[] = [addYears(new Date(), -10).getTime()];
 
   if (selectedRange.from) {
     times.push(addYears(selectedRange.from, -2).getTime());
@@ -49,7 +49,7 @@ export const getEndMonth = ({
 }: GetEndMonthProps) => {
   if (endMonth) return endMonth;
 
-  const times: number[] = [addYears(new Date(), 2).getTime()];
+  const times: number[] = [addYears(new Date(), 10).getTime()];
 
   if (selectedRange.to) {
     times.push(addYears(selectedRange.to, 2).getTime());

--- a/front/app/components/admin/DatePickers/DatePhasePicker/Calendar/utils/getStartEndMonth.ts
+++ b/front/app/components/admin/DatePickers/DatePhasePicker/Calendar/utils/getStartEndMonth.ts
@@ -52,7 +52,7 @@ export const getEndMonth = ({
   const times: number[] = [addYears(new Date(), 10).getTime()];
 
   if (selectedRange.to) {
-    times.push(addYears(selectedRange.to, 2).getTime());
+    times.push(addYears(selectedRange.to, 10).getTime());
   }
 
   if (disabledRanges.length > 0) {

--- a/front/app/components/admin/DatePickers/DatePhasePicker/Calendar/utils/getStartEndMonth.ts
+++ b/front/app/components/admin/DatePickers/DatePhasePicker/Calendar/utils/getStartEndMonth.ts
@@ -20,7 +20,7 @@ export const getStartMonth = ({
   const times: number[] = [addYears(new Date(), -10).getTime()];
 
   if (selectedRange.from) {
-    times.push(addYears(selectedRange.from, -2).getTime());
+    times.push(addYears(selectedRange.from, -10).getTime());
   }
 
   if (disabledRanges.length > 0) {

--- a/front/app/components/admin/DatePickers/DatePhasePicker/Calendar/utils/getUpdatedRange.ts
+++ b/front/app/components/admin/DatePickers/DatePhasePicker/Calendar/utils/getUpdatedRange.ts
@@ -15,7 +15,7 @@ export const getUpdatedRange = ({
   selectedRange: { from, to },
   disabledRanges,
   clickedDate,
-}: GetUpdatedRangeParams) => {
+}: GetUpdatedRangeParams): Partial<DateRange> => {
   const { valid, reason } = rangesValid({ from, to }, disabledRanges);
 
   if (!valid) {

--- a/front/app/components/admin/DatePickers/DatePhasePicker/typings.ts
+++ b/front/app/components/admin/DatePickers/DatePhasePicker/typings.ts
@@ -14,5 +14,5 @@ export interface Props {
   startMonth?: Date;
   endMonth?: Date;
   defaultMonth?: Date;
-  onUpdateRange: (range: DateRange) => void;
+  onUpdateRange: (range: Partial<DateRange>) => void;
 }

--- a/front/app/components/admin/DatePickers/DateSinglePicker/Calendar/index.tsx
+++ b/front/app/components/admin/DatePickers/DateSinglePicker/Calendar/index.tsx
@@ -10,7 +10,7 @@ import useLocale from 'hooks/useLocale';
 import { getLocale } from '../../_shared/locales';
 import { CalendarProps } from '../typings';
 
-import { getEndMonth, getStartMonth } from './utils/getStartEndMonth';
+import { getEndMonth } from './utils/getStartEndMonth';
 
 const DayPickerStyles = styled.div`
   .rdp-root {
@@ -34,8 +34,7 @@ const Calendar = ({
   onChange,
 }: CalendarProps) => {
   const locale = useLocale();
-
-  const startMonth = getStartMonth({ startMonth: _startMonth, selectedDate });
+  const startMonth = new Date(1900, 0);
   const endMonth = getEndMonth({ endMonth: _endMonth, selectedDate });
 
   return (

--- a/front/app/components/admin/DatePickers/DateSinglePicker/Calendar/utils/getStartEndMonth.ts
+++ b/front/app/components/admin/DatePickers/DateSinglePicker/Calendar/utils/getStartEndMonth.ts
@@ -1,26 +1,5 @@
 import { addYears } from 'date-fns';
 
-interface GetStartMonthProps {
-  startMonth?: Date;
-  selectedDate?: Date;
-}
-
-export const getStartMonth = ({
-  startMonth,
-  selectedDate,
-}: GetStartMonthProps) => {
-  if (startMonth) return startMonth;
-  const twoYearsAgo = addYears(new Date(), -2);
-
-  if (selectedDate) {
-    return new Date(
-      Math.min(addYears(selectedDate, -2).getTime(), twoYearsAgo.getTime())
-    );
-  }
-
-  return twoYearsAgo;
-};
-
 interface GetEndMonthProps {
   endMonth?: Date;
   selectedDate?: Date;
@@ -28,13 +7,13 @@ interface GetEndMonthProps {
 
 export const getEndMonth = ({ endMonth, selectedDate }: GetEndMonthProps) => {
   if (endMonth) return endMonth;
-  const twoYearsFromNow = addYears(new Date(), 2);
+  const tenYearsFromNow = addYears(new Date(), 10);
 
   if (selectedDate) {
     return new Date(
-      Math.max(addYears(selectedDate, 2).getTime(), twoYearsFromNow.getTime())
+      Math.max(addYears(selectedDate, 10).getTime(), tenYearsFromNow.getTime())
     );
   }
 
-  return twoYearsFromNow;
+  return tenYearsFromNow;
 };

--- a/front/app/containers/Admin/projects/project/phaseSetup/components/DateSetup.tsx
+++ b/front/app/containers/Admin/projects/project/phaseSetup/components/DateSetup.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 
 import { Box } from '@citizenlab/cl2-component-library';
-import { format } from 'date-fns';
+import { format, parseISO, startOfDay } from 'date-fns';
 import { useParams } from 'react-router-dom';
 import { CLErrors } from 'typings';
 
@@ -45,13 +45,12 @@ const DateSetup = ({
 
   const { start_at, end_at } = formData;
 
-  const selectedRange = useMemo(
-    () => ({
-      from: start_at ? new Date(start_at) : undefined,
-      to: end_at ? new Date(end_at) : undefined,
-    }),
-    [start_at, end_at]
-  );
+  const selectedRange = useMemo(() => {
+    return {
+      from: start_at ? startOfDay(parseISO(start_at)) : undefined,
+      to: end_at ? startOfDay(parseISO(end_at)) : undefined,
+    };
+  }, [start_at, end_at]);
 
   const disabledRanges = useMemo(() => {
     if (!phases) return undefined;


### PR DESCRIPTION
# Changelog

## Fixed
- Allow users setting start month of a phase to 10years earlier and end phase of a phase to 10 years from today
- Time zone issue where the clicking on a specific day on the phase date picker would sometimes select the day before. Issue was prevalent on some US platforms
