### PR TITLE
TAN-2809: Use correctly saved cookie settings

### DIFF
--- a/front/app/components/ConsentManager/ConsentManager.test.tsx
+++ b/front/app/components/ConsentManager/ConsentManager.test.tsx
@@ -118,7 +118,7 @@ describe('<ConsentManager />', () => {
       });
     });
 
-    it('rejects all cookies except functional if preference modal is openend and confirmed without changes', () => {
+    it('rejects all cookies except functional if preference modal is opened and confirmed without changes', () => {
       const { container } = render(<ConsentManager />);
       fireEvent.click(container.querySelector('.integration-open-modal'));
       fireEvent.click(container.querySelector('#e2e-preferences-save'));

--- a/front/app/components/ConsentManager/index.tsx
+++ b/front/app/components/ConsentManager/index.tsx
@@ -34,6 +34,16 @@ const ConsentManager = () => {
   const { data: appConfiguration } = useAppConfiguration();
   const { data: authUser } = useAuthUser();
 
+  const resetPreferences = useCallback(() => {
+    setPreferences(
+      getCurrentPreferences(
+        appConfiguration?.data,
+        authUser?.data,
+        cookieConsent
+      )
+    );
+  }, [appConfiguration, authUser, cookieConsent]);
+
   useEffect(() => {
     const cookieConsent = getConsent();
     setCookieConsent(cookieConsent);
@@ -44,15 +54,9 @@ const ConsentManager = () => {
     );
   }, []);
 
-  const resetPreferences = useCallback(() => {
-    setPreferences(
-      getCurrentPreferences(
-        appConfiguration?.data,
-        authUser?.data,
-        cookieConsent
-      )
-    );
-  }, [appConfiguration, authUser, cookieConsent]);
+  useEffect(() => {
+    resetPreferences();
+  }, [appConfiguration, authUser, resetPreferences]);
 
   const updatePreference = useCallback(
     (category: TCategory, value: boolean) => {

--- a/front/app/components/ConsentManager/index.tsx
+++ b/front/app/components/ConsentManager/index.tsx
@@ -48,15 +48,23 @@ const ConsentManager = () => {
     const cookieConsent = getConsent();
     setCookieConsent(cookieConsent);
 
+    const defaultPreferences = getCurrentPreferences(
+      appConfiguration?.data,
+      authUser?.data,
+      cookieConsent
+    );
+
+    if (defaultPreferences.functional === undefined) {
+      defaultPreferences.functional = true;
+    }
+
+    setPreferences(defaultPreferences);
+
     eventEmitter.emit<ISavedDestinations>(
       'destinationConsentChanged',
       cookieConsent?.savedChoices || {}
     );
-  }, []);
-
-  useEffect(() => {
-    resetPreferences();
-  }, [appConfiguration, authUser, resetPreferences]);
+  }, [appConfiguration?.data, authUser?.data]);
 
   const updatePreference = useCallback(
     (category: TCategory, value: boolean) => {


### PR DESCRIPTION
# Changelog

## Fixed
- Persist user cookie preferences to ensure settings are remembered across sessions, including the display of selected options upon reload and reopening of the cookie preferences modal.
