### PR TITLE
TAN-2917 - Do not try log updates to custom fields when nothing has changed in form editor

### DIFF
--- a/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
+++ b/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
@@ -110,7 +110,7 @@ module IdeaCustomFields
           options_params = field_params.delete :options
           if field_params[:id] && fields_by_id.key?(field_params[:id])
             field = fields_by_id[field_params[:id]]
-            next unless update_field! field, field_params, errors, index
+            next unless update_field!(field, field_params, errors, index)
           else
             field = create_field! field_params, errors, page_temp_ids_to_ids_mapping, index
             next unless field
@@ -164,6 +164,8 @@ module IdeaCustomFields
       field_params = idea_custom_field_service.remove_ignored_update_params field_params
       if field.errors.errors.empty?
         field.assign_attributes field_params
+        return true unless field.changed?
+
         SideFxCustomFieldService.new.before_update field, current_user
         if field.save
           SideFxCustomFieldService.new.after_update field, current_user
@@ -248,6 +250,7 @@ module IdeaCustomFields
     def update_option!(option, option_params, errors, field_index, option_index)
       update_params = option_params.except('image_id')
       option.assign_attributes update_params
+      return true unless option.changed?
 
       SideFxCustomFieldOptionService.new.before_update option, current_user
       if option.save

--- a/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/update_all_native_survey_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/update_all_native_survey_spec.rb
@@ -3160,6 +3160,31 @@ resource 'Idea Custom Fields' do
         assert_status 200
       end
 
+      example 'Updating fields only logs activities when they have changed' do
+        page = create(:custom_field_page, resource: custom_form)
+        field1 = create(:custom_field, resource: custom_form, title_multiloc: { 'en' => 'Field 1' })
+        field2 = create(:custom_field, resource: custom_form, title_multiloc: { 'en' => 'Field 2' })
+        request = {
+          custom_fields: [
+            {
+              id: page.id,
+              input_type: 'page',
+              page_layout: 'default'
+            },
+            {
+              id: field1.id,
+              title_multiloc: { 'en' => 'Field 1' }
+            },
+            {
+              id: field2.id,
+              title_multiloc: { 'en' => 'Field 2 changed' }
+            }
+          ]
+        }
+
+        expect{do_request(request)}.to enqueue_job(LogActivityJob).exactly(1).times
+      end
+
       context "Update custom field's map config relation" do
         let!(:map_config1) { create(:map_config, mappable: nil) }
         let!(:map_config2) { create(:map_config, mappable: nil) }

--- a/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/update_all_native_survey_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/update_all_native_survey_spec.rb
@@ -3182,7 +3182,7 @@ resource 'Idea Custom Fields' do
           ]
         }
 
-        expect{do_request(request)}.to enqueue_job(LogActivityJob).exactly(1).times
+        expect { do_request(request) }.to enqueue_job(LogActivityJob).exactly(1).times
       end
 
       context "Update custom field's map config relation" do


### PR DESCRIPTION
Tested locally by updating one field on a form having 1 page & 5 questions each with 5 options:

- Before: Logged 31 'updated' activities
- After: Logged 1 'updated' activity

There are probably other efficiencies that could be made here too, but this solves the main problem of this ticket.

# Changelog
## Technical
- Stop excessive logging of updates to custom fields and options when nothing has changed
