### PR TITLE
TAN-2922: Use editable survey title as page title for surveys

### DIFF
--- a/front/app/containers/IdeasNewSurveyPage/IdeasNewSurveyForm/index.tsx
+++ b/front/app/containers/IdeasNewSurveyPage/IdeasNewSurveyForm/index.tsx
@@ -283,9 +283,15 @@ const IdeasNewSurveyForm = ({ project, phaseId }: Props) => {
     return `${dynamicHeight}px`;
   }
 
+  if (!phase) {
+    return null;
+  }
+
   return (
     <>
-      <IdeasNewSurveyMeta />
+      <IdeasNewSurveyMeta
+        surveyTitle={localize(phase.attributes.native_survey_title_multiloc)}
+      />
       <Box
         w="100%"
         bgColor={colors.grey100}
@@ -300,7 +306,7 @@ const IdeasNewSurveyForm = ({ project, phaseId }: Props) => {
           maxWidth={usingMapView ? '1100px' : '700px'}
         >
           <SurveyHeading
-            titleText={localize(phase?.attributes.native_survey_title_multiloc)}
+            titleText={localize(phase.attributes.native_survey_title_multiloc)}
             phaseId={phaseId}
           />
         </Box>

--- a/front/app/containers/IdeasNewSurveyPage/IdeasNewSurveyMeta.tsx
+++ b/front/app/containers/IdeasNewSurveyPage/IdeasNewSurveyMeta.tsx
@@ -18,7 +18,7 @@ const IdeasNewSurveyMeta = ({ surveyTitle }: Props) => {
   const { formatMessage } = useIntl();
   const locales = useAppConfigurationLocales();
   const { location } = window;
-  const title = formatMessage(messages.surveyNewMetaTitle2, {
+  const title = formatMessage(messages.surveyNewMetaTitle, {
     surveyTitle,
   });
 

--- a/front/app/containers/IdeasNewSurveyPage/IdeasNewSurveyMeta.tsx
+++ b/front/app/containers/IdeasNewSurveyPage/IdeasNewSurveyMeta.tsx
@@ -4,24 +4,31 @@ import { Helmet } from 'react-helmet';
 
 import useAppConfigurationLocales from 'hooks/useAppConfigurationLocales';
 
+import { useIntl } from 'utils/cl-intl';
 import getAlternateLinks from 'utils/cl-router/getAlternateLinks';
 import getCanonicalLink from 'utils/cl-router/getCanonicalLink';
+
+import messages from './messages';
 
 interface Props {
   surveyTitle: string;
 }
 
 const IdeasNewSurveyMeta = ({ surveyTitle }: Props) => {
+  const { formatMessage } = useIntl();
   const locales = useAppConfigurationLocales();
   const { location } = window;
+  const title = formatMessage(messages.surveyNewMetaTitle2, {
+    surveyTitle,
+  });
 
   return (
     <Helmet>
-      <title>{surveyTitle}</title>
+      <title>{title}</title>
       {getAlternateLinks(locales)}
       {getCanonicalLink()}
-      <meta name="title" content={surveyTitle} />
-      <meta property="og:title" content={surveyTitle} />
+      <meta name="title" content={title} />
+      <meta property="og:title" content={title} />
       <meta property="og:url" content={location.href} />
     </Helmet>
   );

--- a/front/app/containers/IdeasNewSurveyPage/IdeasNewSurveyMeta.tsx
+++ b/front/app/containers/IdeasNewSurveyPage/IdeasNewSurveyMeta.tsx
@@ -2,47 +2,26 @@ import React from 'react';
 
 import { Helmet } from 'react-helmet';
 
-import useAuthUser from 'api/me/useAuthUser';
-
 import useAppConfigurationLocales from 'hooks/useAppConfigurationLocales';
 
-import { useIntl } from 'utils/cl-intl';
 import getAlternateLinks from 'utils/cl-router/getAlternateLinks';
 import getCanonicalLink from 'utils/cl-router/getCanonicalLink';
 
-import ideationMessages from '../IdeasNewPage/messages';
+interface Props {
+  surveyTitle: string;
+}
 
-import messages from './messages';
-
-const IdeasNewSurveyMeta = () => {
-  const { formatMessage } = useIntl();
-  const { data: authUser } = useAuthUser();
+const IdeasNewSurveyMeta = ({ surveyTitle }: Props) => {
   const locales = useAppConfigurationLocales();
   const { location } = window;
 
-  const ideasIndexTitle = formatMessage(messages.surveyNewMetaTitle1);
-  const ideasIndexDescription = formatMessage(
-    ideationMessages.ideaNewMetaDescription
-  );
-
   return (
     <Helmet>
-      <title>
-        {`
-            ${
-              authUser && authUser.data.attributes.unread_notifications
-                ? `(${authUser.data.attributes.unread_notifications}) `
-                : ''
-            }
-            ${ideasIndexTitle}
-          `}
-      </title>
+      <title>{surveyTitle}</title>
       {getAlternateLinks(locales)}
       {getCanonicalLink()}
-      <meta name="title" content={ideasIndexTitle} />
-      <meta name="description" content={ideasIndexDescription} />
-      <meta property="og:title" content={ideasIndexTitle} />
-      <meta property="og:description" content={ideasIndexDescription} />
+      <meta name="title" content={surveyTitle} />
+      <meta property="og:title" content={surveyTitle} />
       <meta property="og:url" content={location.href} />
     </Helmet>
   );

--- a/front/app/containers/IdeasNewSurveyPage/messages.ts
+++ b/front/app/containers/IdeasNewSurveyPage/messages.ts
@@ -1,7 +1,7 @@
 import { defineMessages } from 'react-intl';
 
 export default defineMessages({
-  surveyNewMetaTitle2: {
+  surveyNewMetaTitle: {
     id: 'app.containers.IdeasNewPage.surveyNewMetaTitle2',
     defaultMessage: '{surveyTitle} | {orgName}',
   },

--- a/front/app/containers/IdeasNewSurveyPage/messages.ts
+++ b/front/app/containers/IdeasNewSurveyPage/messages.ts
@@ -1,9 +1,9 @@
 import { defineMessages } from 'react-intl';
 
 export default defineMessages({
-  surveyNewMetaTitle1: {
-    id: 'app.containers.IdeasNewPage.surveyNewMetaTitle1',
-    defaultMessage: 'Add survey response to project | {orgName}',
+  surveyNewMetaTitle2: {
+    id: 'app.containers.IdeasNewPage.surveyNewMetaTitle2',
+    defaultMessage: '{surveyTitle} | {orgName}',
   },
   surveySubmittedTitle: {
     id: 'app.containers.IdeasNewPage.SurveySubmittedNotice.surveySubmittedTitle',

--- a/front/app/translations/ar-MA.json
+++ b/front/app/translations/ar-MA.json
@@ -1298,7 +1298,6 @@
   "app.containers.IdeasNewPage.projectMetaTitle1": "إضافة مشروع جديد للمشروع | {orgName}",
   "app.containers.IdeasNewPage.proposalMetaTitle1": "إضافة اقتراح جديد للمشروع | {orgName}",
   "app.containers.IdeasNewPage.questionMetaTitle1": "أضف سؤال جديد للمشروع | {orgName}",
-  "app.containers.IdeasNewPage.surveyNewMetaTitle1": "إضافة استجابة الاستطلاع للمشروع | {orgName}",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorAcceptInvitation": "قبول الدعوة",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorInvitation": "دعوة للمشاركة في الرعاية",
   "app.containers.IdeasShow.Cosponsorship.co-sponsors": "الرعاة المشاركون",

--- a/front/app/translations/ar-SA.json
+++ b/front/app/translations/ar-SA.json
@@ -1298,7 +1298,6 @@
   "app.containers.IdeasNewPage.projectMetaTitle1": "إضافة مشروع جديد للمشروع | {orgName}",
   "app.containers.IdeasNewPage.proposalMetaTitle1": "إضافة اقتراح جديد للمشروع | {orgName}",
   "app.containers.IdeasNewPage.questionMetaTitle1": "أضف سؤال جديد للمشروع | {orgName}",
-  "app.containers.IdeasNewPage.surveyNewMetaTitle1": "إضافة استجابة الاستطلاع للمشروع | {orgName}",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorAcceptInvitation": "قبول الدعوة",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorInvitation": "دعوة للمشاركة في الرعاية",
   "app.containers.IdeasShow.Cosponsorship.co-sponsors": "الرعاة المشاركون",

--- a/front/app/translations/ca-ES.json
+++ b/front/app/translations/ca-ES.json
@@ -1298,7 +1298,6 @@
   "app.containers.IdeasNewPage.projectMetaTitle1": "Afegeix un nou projecte al projecte | {orgName}",
   "app.containers.IdeasNewPage.proposalMetaTitle1": "Afegeix una nova proposta al projecte | {orgName}",
   "app.containers.IdeasNewPage.questionMetaTitle1": "Afegeix una pregunta nova al projecte | {orgName}",
-  "app.containers.IdeasNewPage.surveyNewMetaTitle1": "Afegeix la resposta de l'enquesta al projecte | {orgName}",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorAcceptInvitation": "Accepta la invitació",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorInvitation": "Invitació de copatrocini",
   "app.containers.IdeasShow.Cosponsorship.co-sponsors": "Copatrocinadors",

--- a/front/app/translations/cy-GB.json
+++ b/front/app/translations/cy-GB.json
@@ -1238,7 +1238,6 @@
   "app.containers.IdeasNewPage.optionMetaTitle1": "Ychwanegu opsiwn newydd i'r prosiect | {orgName}",
   "app.containers.IdeasNewPage.projectMetaTitle1": "Ychwanegu prosiect newydd i'r prosiect | {orgName}",
   "app.containers.IdeasNewPage.questionMetaTitle1": "Ychwanegu cwestiwn newydd i'r prosiect | {orgName}",
-  "app.containers.IdeasNewPage.surveyNewMetaTitle1": "Ychwanegu ymateb arolwg i'r prosiect | {orgName}",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorAcceptInvitation": "Derbyn gwahoddiad",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorInvitation": "Gwahoddiad i gyd-noddi",
   "app.containers.IdeasShow.Cosponsorship.co-sponsors": "Cyd-noddwyr",

--- a/front/app/translations/da-DK.json
+++ b/front/app/translations/da-DK.json
@@ -1298,7 +1298,6 @@
   "app.containers.IdeasNewPage.projectMetaTitle1": "Tilføj nyt projekt til projekt | {orgName}",
   "app.containers.IdeasNewPage.proposalMetaTitle1": "Tilføj nyt forslag til projektet | {orgName}",
   "app.containers.IdeasNewPage.questionMetaTitle1": "Tilføj nyt spørgsmål til projektet | {orgName}",
-  "app.containers.IdeasNewPage.surveyNewMetaTitle1": "Tilføj spørgeskemasvar til projektet | {orgName}",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorAcceptInvitation": "Accepter invitation",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorInvitation": "Invitation til at blive medstiller",
   "app.containers.IdeasShow.Cosponsorship.co-sponsors": "Medstillere",

--- a/front/app/translations/de-DE.json
+++ b/front/app/translations/de-DE.json
@@ -1298,7 +1298,6 @@
   "app.containers.IdeasNewPage.projectMetaTitle1": "Neues Projekt zum Projekt hinzufügen | {orgName}",
   "app.containers.IdeasNewPage.proposalMetaTitle1": "Neuen Vorschlag zum Projekt hinzufügen | {orgName}",
   "app.containers.IdeasNewPage.questionMetaTitle1": "Neue Frage zum Projekt hinzufügen | {orgName}",
-  "app.containers.IdeasNewPage.surveyNewMetaTitle1": "Umfrageantwort zum Projekt hinzufügen | {orgName}",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorAcceptInvitation": "Einladung annehmen",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorInvitation": "Einladung zum Unterstützen",
   "app.containers.IdeasShow.Cosponsorship.co-sponsors": "Unterstützer*innen",

--- a/front/app/translations/el-GR.json
+++ b/front/app/translations/el-GR.json
@@ -1298,7 +1298,6 @@
   "app.containers.IdeasNewPage.projectMetaTitle1": "Προσθήκη νέου έργου στο έργο | {orgName}",
   "app.containers.IdeasNewPage.proposalMetaTitle1": "Προσθήκη νέας πρότασης στο έργο | {orgName}",
   "app.containers.IdeasNewPage.questionMetaTitle1": "Προσθήκη νέας ερώτησης στο έργο | {orgName}",
-  "app.containers.IdeasNewPage.surveyNewMetaTitle1": "Προσθέστε την απάντηση της έρευνας στο έργο | {orgName}",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorAcceptInvitation": "Αποδοχή πρόσκλησης",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorInvitation": "Πρόσκληση για συν-χορηγία",
   "app.containers.IdeasShow.Cosponsorship.co-sponsors": "Συν-χορηγοί",

--- a/front/app/translations/en-CA.json
+++ b/front/app/translations/en-CA.json
@@ -1298,7 +1298,6 @@
   "app.containers.IdeasNewPage.projectMetaTitle1": "Add new project to project | {orgName}",
   "app.containers.IdeasNewPage.proposalMetaTitle1": "Add new proposal to project | {orgName}",
   "app.containers.IdeasNewPage.questionMetaTitle1": "Add new question to project | {orgName}",
-  "app.containers.IdeasNewPage.surveyNewMetaTitle1": "Add survey response to project | {orgName}",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorAcceptInvitation": "Accept invitation",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorInvitation": "Co-sponsorship invitation",
   "app.containers.IdeasShow.Cosponsorship.co-sponsors": "Co-sponsors",

--- a/front/app/translations/en-GB.json
+++ b/front/app/translations/en-GB.json
@@ -1298,7 +1298,6 @@
   "app.containers.IdeasNewPage.projectMetaTitle1": "Add new project to project | {orgName}",
   "app.containers.IdeasNewPage.proposalMetaTitle1": "Add new proposal to project | {orgName}",
   "app.containers.IdeasNewPage.questionMetaTitle1": "Add new question to project | {orgName}",
-  "app.containers.IdeasNewPage.surveyNewMetaTitle1": "Add survey response to project | {orgName}",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorAcceptInvitation": "Accept invitation",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorInvitation": "Co-sponsorship invitation",
   "app.containers.IdeasShow.Cosponsorship.co-sponsors": "Co-sponsors",

--- a/front/app/translations/en-IE.json
+++ b/front/app/translations/en-IE.json
@@ -1298,7 +1298,6 @@
   "app.containers.IdeasNewPage.projectMetaTitle1": "Add new project to project | {orgName}",
   "app.containers.IdeasNewPage.proposalMetaTitle1": "Add new proposal to project | {orgName}",
   "app.containers.IdeasNewPage.questionMetaTitle1": "Add new question to project | {orgName}",
-  "app.containers.IdeasNewPage.surveyNewMetaTitle1": "Add survey response to project | {orgName}",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorAcceptInvitation": "Accept invitation",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorInvitation": "Co-sponsorship invitation",
   "app.containers.IdeasShow.Cosponsorship.co-sponsors": "Co-sponsors",

--- a/front/app/translations/en.json
+++ b/front/app/translations/en.json
@@ -1298,7 +1298,7 @@
   "app.containers.IdeasNewPage.projectMetaTitle1": "Add new project to project | {orgName}",
   "app.containers.IdeasNewPage.proposalMetaTitle1": "Add new proposal to project | {orgName}",
   "app.containers.IdeasNewPage.questionMetaTitle1": "Add new question to project | {orgName}",
-  "app.containers.IdeasNewPage.surveyNewMetaTitle1": "Add survey response to project | {orgName}",
+  "app.containers.IdeasNewPage.surveyNewMetaTitle2": "{surveyTitle} | {orgName}",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorAcceptInvitation": "Accept invitation",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorInvitation": "Co-sponsorship invitation",
   "app.containers.IdeasShow.Cosponsorship.co-sponsors": "Co-sponsors",

--- a/front/app/translations/es-CL.json
+++ b/front/app/translations/es-CL.json
@@ -1298,7 +1298,6 @@
   "app.containers.IdeasNewPage.projectMetaTitle1": "Añadir nuevo proyecto al proyecto | {orgName}",
   "app.containers.IdeasNewPage.proposalMetaTitle1": "Añadir nueva propuesta al proyecto | {orgName}",
   "app.containers.IdeasNewPage.questionMetaTitle1": "Añadir una nueva pregunta al proyecto | {orgName}",
-  "app.containers.IdeasNewPage.surveyNewMetaTitle1": "Añade la respuesta de la encuesta al proyecto | {orgName}",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorAcceptInvitation": "Acepta la invitación",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorInvitation": "Invitación al copatrocinio",
   "app.containers.IdeasShow.Cosponsorship.co-sponsors": "Copatrocinadores",

--- a/front/app/translations/es-ES.json
+++ b/front/app/translations/es-ES.json
@@ -1298,7 +1298,6 @@
   "app.containers.IdeasNewPage.projectMetaTitle1": "Añadir nuevo proyecto al proyecto | {orgName}",
   "app.containers.IdeasNewPage.proposalMetaTitle1": "Añadir nueva propuesta al proyecto | {orgName}",
   "app.containers.IdeasNewPage.questionMetaTitle1": "Añadir una nueva pregunta al proyecto | {orgName}",
-  "app.containers.IdeasNewPage.surveyNewMetaTitle1": "Añade la respuesta de la encuesta al proyecto | {orgName}",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorAcceptInvitation": "Acepta la invitación",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorInvitation": "Invitación al copatrocinio",
   "app.containers.IdeasShow.Cosponsorship.co-sponsors": "Copatrocinadores",

--- a/front/app/translations/fi-FI.json
+++ b/front/app/translations/fi-FI.json
@@ -1238,7 +1238,6 @@
   "app.containers.IdeasNewPage.optionMetaTitle1": "Lisää uusi vaihtoehto projektiin | {orgName}",
   "app.containers.IdeasNewPage.projectMetaTitle1": "Lisää uusi projekti projektiin | {orgName}",
   "app.containers.IdeasNewPage.questionMetaTitle1": "Lisää uusi kysymys projektiin | {orgName}",
-  "app.containers.IdeasNewPage.surveyNewMetaTitle1": "Lisää kyselyvastaus projektiin | {orgName}",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorAcceptInvitation": "Hyväksy kutsu",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorInvitation": "Yhteissponsorointikutsu",
   "app.containers.IdeasShow.Cosponsorship.co-sponsors": "Yhteissponsorit",

--- a/front/app/translations/fr-BE.json
+++ b/front/app/translations/fr-BE.json
@@ -1298,7 +1298,6 @@
   "app.containers.IdeasNewPage.projectMetaTitle1": "Ajouter un nouveau projet au projet {orgName}",
   "app.containers.IdeasNewPage.proposalMetaTitle1": "Ajouter une nouvelle proposition au projet | {orgName}",
   "app.containers.IdeasNewPage.questionMetaTitle1": "Ajouter une nouvelle question au projet {orgName}",
-  "app.containers.IdeasNewPage.surveyNewMetaTitle1": "Répondre à l'enquête | {orgName}",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorAcceptInvitation": "Accepter l'invitation",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorInvitation": "Invitation à soutenir",
   "app.containers.IdeasShow.Cosponsorship.co-sponsors": "Coparrainants",

--- a/front/app/translations/fr-FR.json
+++ b/front/app/translations/fr-FR.json
@@ -1298,7 +1298,6 @@
   "app.containers.IdeasNewPage.projectMetaTitle1": "Ajouter un nouveau projet au projet {orgName}",
   "app.containers.IdeasNewPage.proposalMetaTitle1": "Ajouter une nouvelle proposition au projet | {orgName}",
   "app.containers.IdeasNewPage.questionMetaTitle1": "Ajouter une nouvelle question au projet {orgName}",
-  "app.containers.IdeasNewPage.surveyNewMetaTitle1": "Répondre à l'enquête | {orgName}",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorAcceptInvitation": "Accepter l'invitation",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorInvitation": "Invitation à soutenir",
   "app.containers.IdeasShow.Cosponsorship.co-sponsors": "Coparrainants",

--- a/front/app/translations/hr-HR.json
+++ b/front/app/translations/hr-HR.json
@@ -1238,7 +1238,6 @@
   "app.containers.IdeasNewPage.optionMetaTitle1": "Dodaj novu opciju projektu | {orgName}",
   "app.containers.IdeasNewPage.projectMetaTitle1": "Dodaj novi projekt projektu | {orgName}",
   "app.containers.IdeasNewPage.questionMetaTitle1": "Dodaj novo pitanje projektu | {orgName}",
-  "app.containers.IdeasNewPage.surveyNewMetaTitle1": "Dodajte odgovor na anketu projektu | {orgName}",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorAcceptInvitation": "Prihvatite poziv",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorInvitation": "Poziv za supokroviteljstvo",
   "app.containers.IdeasShow.Cosponsorship.co-sponsors": "Supokrovitelji",

--- a/front/app/translations/it-IT.json
+++ b/front/app/translations/it-IT.json
@@ -1298,7 +1298,6 @@
   "app.containers.IdeasNewPage.projectMetaTitle1": "Aggiungi un nuovo progetto al progetto | {orgName}",
   "app.containers.IdeasNewPage.proposalMetaTitle1": "Aggiungi una nuova proposta al progetto | {orgName}",
   "app.containers.IdeasNewPage.questionMetaTitle1": "Aggiungi una nuova domanda al progetto | {orgName}",
-  "app.containers.IdeasNewPage.surveyNewMetaTitle1": "Aggiungi la risposta al sondaggio al progetto | {orgName}",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorAcceptInvitation": "Accetta l'invito",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorInvitation": "Invito alla co-sponsorizzazione",
   "app.containers.IdeasShow.Cosponsorship.co-sponsors": "Co-sponsor",

--- a/front/app/translations/lb-LU.json
+++ b/front/app/translations/lb-LU.json
@@ -1238,7 +1238,6 @@
   "app.containers.IdeasNewPage.optionMetaTitle1": "Füügt nei Optioun fir de Projet | {orgName}",
   "app.containers.IdeasNewPage.projectMetaTitle1": "Füügt neie Projet un de Projet | {orgName}",
   "app.containers.IdeasNewPage.questionMetaTitle1": "Füügt nei Fro zum Projet | {orgName}",
-  "app.containers.IdeasNewPage.surveyNewMetaTitle1": "Füügt Ëmfro Äntwert op Projet | {orgName}",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorAcceptInvitation": "Akzeptéieren Invitatioun",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorInvitation": "Co-Sponsoring Invitatioun",
   "app.containers.IdeasShow.Cosponsorship.co-sponsors": "Co-Sponsoren",

--- a/front/app/translations/lv-LV.json
+++ b/front/app/translations/lv-LV.json
@@ -1298,7 +1298,6 @@
   "app.containers.IdeasNewPage.projectMetaTitle1": "Pievienot jaunu projektu projektam | {orgName}",
   "app.containers.IdeasNewPage.proposalMetaTitle1": "Pievienot jaunu priekšlikumu projektam | {orgName}",
   "app.containers.IdeasNewPage.questionMetaTitle1": "Pievienot jaunu jautājumu projektam | {orgName}",
-  "app.containers.IdeasNewPage.surveyNewMetaTitle1": "Aptaujas atbilžu pievienošana projektam | {orgName}",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorAcceptInvitation": "Pieņemt ielūgumu",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorInvitation": "Līdzfinansējuma uzaicinājums",
   "app.containers.IdeasShow.Cosponsorship.co-sponsors": "Līdzfinansētāji",

--- a/front/app/translations/nb-NO.json
+++ b/front/app/translations/nb-NO.json
@@ -1298,7 +1298,6 @@
   "app.containers.IdeasNewPage.projectMetaTitle1": "Legg til nytt prosjekt i prosjekt | {orgName}",
   "app.containers.IdeasNewPage.proposalMetaTitle1": "Legg til nytt forslag i prosjektet | {orgName}",
   "app.containers.IdeasNewPage.questionMetaTitle1": "Legg til nytt spørsmål i prosjektet | {orgName}",
-  "app.containers.IdeasNewPage.surveyNewMetaTitle1": "Legg til svar på undersøkelsen i prosjektet {orgName}",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorAcceptInvitation": "Godta invitasjon",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorInvitation": "Invitasjon til medsponsorskap",
   "app.containers.IdeasShow.Cosponsorship.co-sponsors": "Medsponsorer",

--- a/front/app/translations/nl-BE.json
+++ b/front/app/translations/nl-BE.json
@@ -1298,7 +1298,6 @@
   "app.containers.IdeasNewPage.projectMetaTitle1": "Voeg nieuwe project toe aan project | {orgName}",
   "app.containers.IdeasNewPage.proposalMetaTitle1": "Nieuw voorstel toevoegen aan project | {orgName}",
   "app.containers.IdeasNewPage.questionMetaTitle1": "Voeg nieuwe vraag toe aan project | {orgName}",
-  "app.containers.IdeasNewPage.surveyNewMetaTitle1": "Voeg vragenlijst-reactie toe aan project {orgName}",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorAcceptInvitation": "Uitnodiging accepteren",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorInvitation": "Uitnodiging tot ondersteuner",
   "app.containers.IdeasShow.Cosponsorship.co-sponsors": "Ondersteuners",

--- a/front/app/translations/nl-NL.json
+++ b/front/app/translations/nl-NL.json
@@ -1298,7 +1298,6 @@
   "app.containers.IdeasNewPage.projectMetaTitle1": "Voeg nieuwe project toe aan project | {orgName}",
   "app.containers.IdeasNewPage.proposalMetaTitle1": "Nieuw voorstel toevoegen aan project | {orgName}",
   "app.containers.IdeasNewPage.questionMetaTitle1": "Voeg nieuwe vraag toe aan project | {orgName}",
-  "app.containers.IdeasNewPage.surveyNewMetaTitle1": "Voeg vragenlijst-reactie toe aan project {orgName}",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorAcceptInvitation": "Uitnodiging accepteren",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorInvitation": "Uitnodiging tot ondersteuner",
   "app.containers.IdeasShow.Cosponsorship.co-sponsors": "Ondersteuners",

--- a/front/app/translations/pa-IN.json
+++ b/front/app/translations/pa-IN.json
@@ -1298,7 +1298,6 @@
   "app.containers.IdeasNewPage.projectMetaTitle1": "ਪ੍ਰੋਜੈਕਟ ਵਿੱਚ ਨਵਾਂ ਪ੍ਰੋਜੈਕਟ ਸ਼ਾਮਲ ਕਰੋ | {orgName}",
   "app.containers.IdeasNewPage.proposalMetaTitle1": "ਪ੍ਰੋਜੈਕਟ ਵਿੱਚ ਨਵਾਂ ਪ੍ਰਸਤਾਵ ਸ਼ਾਮਲ ਕਰੋ | {orgName}",
   "app.containers.IdeasNewPage.questionMetaTitle1": "ਪ੍ਰੋਜੈਕਟ ਵਿੱਚ ਨਵਾਂ ਸਵਾਲ ਸ਼ਾਮਲ ਕਰੋ | {orgName}",
-  "app.containers.IdeasNewPage.surveyNewMetaTitle1": "ਪ੍ਰੋਜੈਕਟ ਲਈ ਸਰਵੇਖਣ ਜਵਾਬ ਸ਼ਾਮਲ ਕਰੋ | {orgName}",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorAcceptInvitation": "ਸੱਦਾ ਸਵੀਕਾਰ ਕਰੋ",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorInvitation": "ਸਹਿ-ਸਪਾਂਸਰਸ਼ਿਪ ਦਾ ਸੱਦਾ",
   "app.containers.IdeasShow.Cosponsorship.co-sponsors": "ਸਹਿ-ਪ੍ਰਾਯੋਜਕ",

--- a/front/app/translations/pl-PL.json
+++ b/front/app/translations/pl-PL.json
@@ -1298,7 +1298,6 @@
   "app.containers.IdeasNewPage.projectMetaTitle1": "Dodaj nowy projekt do projektu | {orgName}",
   "app.containers.IdeasNewPage.proposalMetaTitle1": "Dodaj nową propozycję do projektu | {orgName}",
   "app.containers.IdeasNewPage.questionMetaTitle1": "Dodaj nowe pytanie do projektu | {orgName}",
-  "app.containers.IdeasNewPage.surveyNewMetaTitle1": "Dodaj odpowiedź z ankiety do projektu | {orgName}",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorAcceptInvitation": "Przyjmij zaproszenie",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorInvitation": "Zaproszenie do współsponsorowania",
   "app.containers.IdeasShow.Cosponsorship.co-sponsors": "Współsponsorzy",

--- a/front/app/translations/pt-BR.json
+++ b/front/app/translations/pt-BR.json
@@ -1298,7 +1298,6 @@
   "app.containers.IdeasNewPage.projectMetaTitle1": "Adicionar novo projeto ao projeto | {orgName}",
   "app.containers.IdeasNewPage.proposalMetaTitle1": "Adicionar nova proposta ao projeto | {orgName}",
   "app.containers.IdeasNewPage.questionMetaTitle1": "Adicionar nova pergunta ao projeto | {orgName}",
-  "app.containers.IdeasNewPage.surveyNewMetaTitle1": "Adicione a resposta da pesquisa ao projeto | {orgName}",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorAcceptInvitation": "Aceitar o convite",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorInvitation": "Convite de copatrocínio",
   "app.containers.IdeasShow.Cosponsorship.co-sponsors": "Co-patrocinadores",

--- a/front/app/translations/sr-Latn.json
+++ b/front/app/translations/sr-Latn.json
@@ -1298,7 +1298,6 @@
   "app.containers.IdeasNewPage.projectMetaTitle1": "Add new project to project | {orgName}",
   "app.containers.IdeasNewPage.proposalMetaTitle1": "Add new proposal to project | {orgName}",
   "app.containers.IdeasNewPage.questionMetaTitle1": "Add new question to project | {orgName}",
-  "app.containers.IdeasNewPage.surveyNewMetaTitle1": "Add survey response to project | {orgName}",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorAcceptInvitation": "Accept invitation",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorInvitation": "Co-sponsorship invitation",
   "app.containers.IdeasShow.Cosponsorship.co-sponsors": "Co-sponsors",

--- a/front/app/translations/sr-SP.json
+++ b/front/app/translations/sr-SP.json
@@ -1298,7 +1298,6 @@
   "app.containers.IdeasNewPage.projectMetaTitle1": "Add new project to project | {orgName}",
   "app.containers.IdeasNewPage.proposalMetaTitle1": "Add new proposal to project | {orgName}",
   "app.containers.IdeasNewPage.questionMetaTitle1": "Add new question to project | {orgName}",
-  "app.containers.IdeasNewPage.surveyNewMetaTitle1": "Add survey response to project | {orgName}",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorAcceptInvitation": "Accept invitation",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorInvitation": "Co-sponsorship invitation",
   "app.containers.IdeasShow.Cosponsorship.co-sponsors": "Co-sponsors",

--- a/front/app/translations/sv-SE.json
+++ b/front/app/translations/sv-SE.json
@@ -1298,7 +1298,6 @@
   "app.containers.IdeasNewPage.projectMetaTitle1": "Lägg till nytt projekt till projekt | {orgName}",
   "app.containers.IdeasNewPage.proposalMetaTitle1": "Lägg till nytt förslag till projekt | {orgName}",
   "app.containers.IdeasNewPage.questionMetaTitle1": "Lägg till ny fråga i projektet | {orgName}",
-  "app.containers.IdeasNewPage.surveyNewMetaTitle1": "Lägg till enkätsvar i projektet | {orgName}",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorAcceptInvitation": "Acceptera inbjudan",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorInvitation": "Inbjudan till medsponsring",
   "app.containers.IdeasShow.Cosponsorship.co-sponsors": "Medförslagsställare",

--- a/front/app/translations/tr-TR.json
+++ b/front/app/translations/tr-TR.json
@@ -1298,7 +1298,6 @@
   "app.containers.IdeasNewPage.projectMetaTitle1": "Projeye yeni proje ekle | {orgName}",
   "app.containers.IdeasNewPage.proposalMetaTitle1": "Projeye yeni teklif ekleyin | {orgName}",
   "app.containers.IdeasNewPage.questionMetaTitle1": "Projeye yeni soru ekleyin | {orgName}",
-  "app.containers.IdeasNewPage.surveyNewMetaTitle1": "Anket yanıtını projeye ekleyin | {orgName}",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorAcceptInvitation": "Daveti kabul et",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorInvitation": "Eş sponsorluk daveti",
   "app.containers.IdeasShow.Cosponsorship.co-sponsors": "Eş sponsorlar",

--- a/front/app/translations/ur-PK.json
+++ b/front/app/translations/ur-PK.json
@@ -1298,7 +1298,6 @@
   "app.containers.IdeasNewPage.projectMetaTitle1": "پروجیکٹ میں نیا پروجیکٹ شامل کریں | {orgName}",
   "app.containers.IdeasNewPage.proposalMetaTitle1": "پروجیکٹ میں نئی تجویز شامل کریں | {orgName}",
   "app.containers.IdeasNewPage.questionMetaTitle1": "پروجیکٹ میں نیا سوال شامل کریں | {orgName}",
-  "app.containers.IdeasNewPage.surveyNewMetaTitle1": "پروجیکٹ میں سروے کا جواب شامل کریں | {orgName}",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorAcceptInvitation": "دعوت قبول کریں۔",
   "app.containers.IdeasShow.Cosponsorship.co-sponsorInvitation": "شریک کفالت کی دعوت",
   "app.containers.IdeasShow.Cosponsorship.co-sponsors": "شریک سپانسرز",


### PR DESCRIPTION
# Changelog

## Changed
- Use the editable survey title on the phase as the title for the survey page in the front office. This also helps us have unique titles and have the page title convey the context of the survey
