### PR TITLE
TAN-2927: fix color contrast issues in quill links

### DIFF
--- a/front/app/component-library/utils/styleUtils.ts
+++ b/front/app/component-library/utils/styleUtils.ts
@@ -341,6 +341,8 @@ export function quillEditedContent(
     }
 
     a {
+      color: #0000EE; /* Standard fallback for all browsers */
+      color: -webkit-link; /* Overrides the fallback in WebKit browsers */
       text-decoration: underline;
       overflow-wrap: break-word;
       word-wrap: break-word;

--- a/front/app/component-library/utils/styleUtils.ts
+++ b/front/app/component-library/utils/styleUtils.ts
@@ -274,7 +274,6 @@ type StylingConstsType = {
 // Reusable text styling
 export function quillEditedContent(
   buttonColor = colors.teal,
-  linkColor = colors.teal,
   textColor = colors.textPrimary,
   mentionColor = colors.textPrimary,
   fontSize: 's' | 'base' | 'm' | 'l' = 'base',
@@ -295,7 +294,7 @@ export function quillEditedContent(
   return `
     ${defaultFontStyle}
 
-    a, li, p {
+    li, p {
       ${defaultFontStyle}
     }
 
@@ -315,7 +314,7 @@ export function quillEditedContent(
       a {
         font-size: inherit;
         font-weight: inherit;
-        text-decoration: inherit;
+        text-decoration: underline;
       }
     }
 
@@ -329,7 +328,7 @@ export function quillEditedContent(
       a {
         font-size: inherit;
         font-weight: inherit;
-        text-decoration: inherit;
+        text-decoration: underline;
       }
     }
 
@@ -342,7 +341,6 @@ export function quillEditedContent(
     }
 
     a {
-      color: ${linkColor};
       text-decoration: underline;
       overflow-wrap: break-word;
       word-wrap: break-word;
@@ -350,12 +348,6 @@ export function quillEditedContent(
       word-break: break-word;
       hyphens: auto;
       transition: background 80ms ease-out;
-
-      &:hover {
-        color: ${darken(0.15, linkColor)};
-        background: ${transparentize(0.91, linkColor)};
-        text-decoration: underline;
-      }
     }
 
     ul, ol {

--- a/front/app/components/UI/QuillEditedContent/index.tsx
+++ b/front/app/components/UI/QuillEditedContent/index.tsx
@@ -4,7 +4,6 @@ import { quillEditedContent } from '@citizenlab/cl2-component-library';
 import styled, { useTheme } from 'styled-components';
 
 const Container = styled.div<{
-  linkColor: Props['linkColor'];
   textColor: Props['textColor'];
   mentionColor: Props['mentionColor'];
   fontSize: Props['fontSize'];
@@ -13,7 +12,6 @@ const Container = styled.div<{
   ${(props) =>
     quillEditedContent(
       props.theme.colors.tenantPrimary,
-      props.linkColor,
       props.textColor,
       props.mentionColor,
       props.fontSize,
@@ -23,7 +21,6 @@ const Container = styled.div<{
 
 interface Props {
   disableTabbing?: boolean;
-  linkColor?: string;
   textColor?: string;
   mentionColor?: string;
   fontSize?: 's' | 'base' | 'm' | 'l';
@@ -33,7 +30,6 @@ interface Props {
 }
 
 const QuillEditedContent = ({
-  linkColor,
   textColor,
   mentionColor,
   fontSize,
@@ -59,7 +55,6 @@ const QuillEditedContent = ({
 
   return (
     <Container
-      linkColor={linkColor}
       textColor={textColor}
       mentionColor={mentionColor || theme.colors.tenantText}
       fontSize={fontSize}


### PR DESCRIPTION
# Changelog

## Fixed
- Color contrast issues in links created using the Quill editor
