### PR TITLE
Fix MainHeader re-rendering/performance

### DIFF
--- a/front/app/containers/MainHeader/index.tsx
+++ b/front/app/containers/MainHeader/index.tsx
@@ -70,30 +70,32 @@ const MainHeader = () => {
 
   const [showMobileStickyNav, setShowMobileStickyNav] =
     useState<boolean>(false);
-  const [scrollTop, setScrollTop] = useState(0);
 
   const isSmallerThanTablet = useBreakpoint('tablet');
   const isDesktopUser = !isSmallerThanTablet;
 
-  // Used to show/hide the mobile navbar on scroll
+  // Used to show the mobile navbar on scrolling up, or hide it on scrolling down
   useEffect(() => {
+    let lastScrollTop = 0;
+
     function onScroll() {
+      // Positive value means we've scrolled down
       const currentPosition = document.documentElement.scrollTop;
-      if (currentPosition <= 0) {
-        setShowMobileStickyNav(false); // Don't show if we're at the top already
-      } else if (currentPosition > scrollTop) {
-        // downscroll
+
+      // not scrolled/at the top or downscroll
+      if (currentPosition <= 0 || currentPosition > lastScrollTop) {
         setShowMobileStickyNav(false);
-      } else {
         // upscroll
+      } else {
         setShowMobileStickyNav(true);
       }
-      setScrollTop(currentPosition <= 0 ? 0 : currentPosition);
+
+      lastScrollTop = currentPosition <= 0 ? 0 : currentPosition;
     }
 
     window.addEventListener('scroll', onScroll);
     return () => window.removeEventListener('scroll', onScroll);
-  }, [scrollTop]);
+  }, []);
 
   return (
     <Container

--- a/front/app/containers/MainHeader/index.tsx
+++ b/front/app/containers/MainHeader/index.tsx
@@ -82,7 +82,7 @@ const MainHeader = () => {
       // Positive value means we've scrolled down
       const currentPosition = document.documentElement.scrollTop;
 
-      // not scrolled/at the top or downscroll
+      // not scrolled yet/still at the top or downscroll
       if (currentPosition <= 0 || currentPosition > lastScrollTop) {
         setShowMobileStickyNav(false);
         // upscroll


### PR DESCRIPTION
# Problem
The current implementation of showing the sticky navbar is not performant. The `useEffect` has `scrollTop` as a dependency, which means the effect will be re-created every time `scrollTop` changes. We also do a state update on each scroll event, which causes non-stop re-rendering.

# Improvements
- Removed `scrollTop` from the `useEffect` dependency array to prevent unnecessary effect re-creation. The effect now runs only once when the component mounts.
- Replaced the `setScrollTop` state update, which was causing re-renders, with a local `lastScrollTop` variable.

Measured a comparable scroll down/up. 

Before:
<img width="1284" alt="Screenshot 2024-11-01 at 16 00 29" src="https://github.com/user-attachments/assets/ab3a1503-f213-4698-a25e-b859a17a8f66">

After:
<img width="1283" alt="Screenshot 2024-11-01 at 16 14 44" src="https://github.com/user-attachments/assets/06a4fac9-cdb4-4a39-8fef-8ddb3d72aeae">

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Changed
- Improved performance when scrolling: we now prevent unnecessary re-rendering of the [main navigation](https://github.com/user-attachments/assets/777759c8-5ff6-4ea8-b172-54f735f337ae).
