### PR TITLE
[No-ticket] Remove que-web route from dev env

### DIFF
--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -306,9 +306,4 @@ Rails.application.routes.draw do
   post '/auth/failure', to: 'omniauth_callback#failure'
   get '/auth/:provider/logout_data', to: 'omniauth_callback#logout_data'
   get '/auth/:provider/spslo', to: 'omniauth_callback#spslo'
-
-  if Rails.env.development?
-    require 'que/web'
-    mount Que::Web => '/que'
-  end
 end


### PR DESCRIPTION
`que-web` gem was recently removed in #9275 

# Changelog
## Technical
- Remove `que-web` route from dev env