### PR TITLE
[TAN-2849] Bugfix: Ensure pagination `next` link in widget response when appropriate

### DIFF
--- a/back/app/services/projects_finder_service.rb
+++ b/back/app/services/projects_finder_service.rb
@@ -59,7 +59,7 @@ class ProjectsFinderService
       next unless service.participation_possible?(action_descriptors)
 
       project_descriptor_pairs[project.id] = action_descriptors
-      break if project_descriptor_pairs.size >= pagination_limit
+      break if project_descriptor_pairs.size >= pagination_limit + 1 # +1 needed to produce pagination link to next page
     end
 
     # Step 2: Use project_descriptor_pairs keys (project IDs) to filter projects

--- a/back/spec/acceptance/projects_spec.rb
+++ b/back/spec/acceptance/projects_spec.rb
@@ -1369,5 +1369,25 @@ resource 'Projects' do
 
       expect(current_phase_ids).to match included_phase_ids
     end
+
+    example 'includes next page link in response when appropriate', document: false do
+      Project.destroy_all
+
+      create_list(:project_with_active_ideation_phase, 5)
+
+      do_request page: { number: 1, size: 2 }
+      json_response = json_parse(response_body)
+      expect(json_response[:links][:next])
+        .to eq 'http://example.org/web_api/v1/projects/with_active_participatory_phase?page%5Bnumber%5D=2&page%5Bsize%5D=2'
+
+      do_request page: { number: 2, size: 2 }
+      json_response = json_parse(response_body)
+      expect(json_response[:links][:next])
+        .to eq 'http://example.org/web_api/v1/projects/with_active_participatory_phase?page%5Bnumber%5D=3&page%5Bsize%5D=2'
+
+      do_request page: { number: 3, size: 2 }
+      json_response = json_parse(response_body)
+      expect(json_response[:links][:next]).to be_nil
+    end
   end
 end

--- a/back/spec/services/projects_finder_service_spec.rb
+++ b/back/spec/services/projects_finder_service_spec.rb
@@ -46,15 +46,6 @@ describe ProjectsFinderService do
       expect(result[:projects].map(&:id)).to eq [active_ideation_project.id, active_project2.id, active_project3.id]
     end
 
-    it 'handles case where n of projects is greater than page size * page number' do
-      _active_project2 = create(:project_with_active_ideation_phase)
-      _active_project3 = create(:project_with_active_ideation_phase)
-
-      result = service.new(Project.all, user, { page: { size: 2, number: 1 } }).participation_possible
-
-      expect(result[:projects].size).to eq 2
-    end
-
     it 'includes action descriptors for each returned project' do
       expect(Project.count).to eq 3
       expect(result[:projects].size).to eq 1


### PR DESCRIPTION
# Changelog
## Technical
[TAN-2849] Bugfix: Ensure pagination `next` link in widget response when appropriate (new homepage widget - not visible on production yet)
