### PR TITLE
Performance: don't re-render App on opening auth modal

### DIFF
--- a/front/app/containers/App/index.tsx
+++ b/front/app/containers/App/index.tsx
@@ -361,9 +361,9 @@ const App = ({ children }: Props) => {
             </ErrorBoundary>
             <ErrorBoundary>
               <Authentication
-                setModalOpen={(open) => {
+                onToggleModal={(opened) => {
                   if (franceConnectLoginEnabled) {
-                    setDisableScroll(open);
+                    setDisableScroll(opened);
                   }
                 }}
               />

--- a/front/app/containers/App/index.tsx
+++ b/front/app/containers/App/index.tsx
@@ -100,11 +100,11 @@ const App = ({ children }: Props) => {
   const [userSuccessfullyDeleted, setUserSuccessfullyDeleted] = useState(false);
 
   const [locale, setLocale] = useState<SupportedLocale | null>(null);
-  const [signUpInModalOpened, setSignUpInModalOpened] = useState(false);
+  const [disableScroll, setDisableScroll] = useState(false);
 
   const redirectsEnabled = useFeatureFlag({ name: 'redirects' });
 
-  const fullscreenModalEnabled = useFeatureFlag({
+  const franceConnectLoginEnabled = useFeatureFlag({
     name: 'franceconnect_login',
   });
 
@@ -285,7 +285,6 @@ const App = ({ children }: Props) => {
   const showFooter =
     !isAdminPage && !isIdeaFormPage && !isIdeaEditPage && !isNativeSurveyPage;
   const { pathname } = removeLocale(location.pathname);
-  const disableScroll = fullscreenModalEnabled && signUpInModalOpened;
   const isAuthenticationPending = authUser === undefined;
   const canAccessRoute = usePermission({
     item: {
@@ -361,7 +360,13 @@ const App = ({ children }: Props) => {
               </Suspense>
             </ErrorBoundary>
             <ErrorBoundary>
-              <Authentication setModalOpen={setSignUpInModalOpened} />
+              <Authentication
+                setModalOpen={(open) => {
+                  if (franceConnectLoginEnabled) {
+                    setDisableScroll(open);
+                  }
+                }}
+              />
             </ErrorBoundary>
             <ErrorBoundary>
               <div id="modal-portal" />

--- a/front/app/containers/Authentication/Modal.tsx
+++ b/front/app/containers/Authentication/Modal.tsx
@@ -45,7 +45,7 @@ import useSteps from './useSteps';
 // but this one was the worst in terms of bundle size impact
 const CustomFields = lazy(() => import('./steps/CustomFields'));
 
-const AuthModal = ({ setModalOpen }: ModalProps) => {
+const AuthModal = ({ onToggleModal }: ModalProps) => {
   const {
     currentStep,
     state,
@@ -60,8 +60,8 @@ const AuthModal = ({ setModalOpen }: ModalProps) => {
   const theme = useTheme();
 
   useEffect(() => {
-    setModalOpen?.(currentStep !== 'closed');
-  }, [currentStep, setModalOpen]);
+    onToggleModal?.(currentStep !== 'closed');
+  }, [currentStep, onToggleModal]);
 
   const smallerThanPhone = useBreakpoint('phone');
   const { formatMessage } = useIntl();

--- a/front/app/containers/Authentication/Modal.tsx
+++ b/front/app/containers/Authentication/Modal.tsx
@@ -60,7 +60,7 @@ const AuthModal = ({ onToggleModal }: ModalProps) => {
   const theme = useTheme();
 
   useEffect(() => {
-    onToggleModal?.(currentStep !== 'closed');
+    onToggleModal(currentStep !== 'closed');
   }, [currentStep, onToggleModal]);
 
   const smallerThanPhone = useBreakpoint('phone');

--- a/front/app/containers/Authentication/index.tsx
+++ b/front/app/containers/Authentication/index.tsx
@@ -4,14 +4,14 @@ import Modal from './Modal';
 import SuccessActions from './SuccessActions';
 
 export interface Props {
-  setModalOpen: (bool: boolean) => void;
+  onToggleModal: (opened: boolean) => void;
 }
 
-const Authentication = ({ setModalOpen }: Props) => {
+const Authentication = ({ onToggleModal: setModalOpen }: Props) => {
   return (
     <>
       <SuccessActions />
-      <Modal setModalOpen={setModalOpen} />
+      <Modal onToggleModal={setModalOpen} />
     </>
   );
 };

--- a/front/app/containers/Authentication/index.tsx
+++ b/front/app/containers/Authentication/index.tsx
@@ -7,11 +7,11 @@ export interface Props {
   onToggleModal: (opened: boolean) => void;
 }
 
-const Authentication = ({ onToggleModal: setModalOpen }: Props) => {
+const Authentication = ({ onToggleModal }: Props) => {
   return (
     <>
       <SuccessActions />
-      <Modal onToggleModal={setModalOpen} />
+      <Modal onToggleModal={onToggleModal} />
     </>
   );
 };

--- a/front/app/containers/Authentication/typings.ts
+++ b/front/app/containers/Authentication/typings.ts
@@ -8,7 +8,7 @@ import { SuccessAction } from './SuccessActions/actions';
 import { getStepConfig } from './useSteps/stepConfig';
 
 export interface ModalProps {
-  setModalOpen?: (bool: boolean) => void;
+  onToggleModal?: (opened: boolean) => void;
 }
 
 export type ErrorCode =

--- a/front/app/containers/Authentication/typings.ts
+++ b/front/app/containers/Authentication/typings.ts
@@ -8,7 +8,7 @@ import { SuccessAction } from './SuccessActions/actions';
 import { getStepConfig } from './useSteps/stepConfig';
 
 export interface ModalProps {
-  onToggleModal?: (opened: boolean) => void;
+  onToggleModal: (opened: boolean) => void;
 }
 
 export type ErrorCode =


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Problem
When `franceconnect_login` is enabled, we want to disable scrolling underneath the authentical modal when it is opened. However, currently, we set the `signUpInModalOpened` state each time we open the authentication modal, regardless of whether `franceconnect_login` is enabled. This leads to a full `App` re-render on opening or closing the modal (~100ms extra scripting before the modals opens in dev mode on my fast laptop). 

If you test opening the auth modal on production sites, you can see it has some lag (especially the sign-up version). This fix should improve this slightly.

(The current solution for franceconnect is questionable on its own, but changing that is a different, more involved task. This PR doesn't change anything to the current franceconnect behavior.)

## Improvements
- Only set state to determine scroll disabling when it matters: when `franceconnect_login` is enabled (and we're using a full-screen authentication window).
- Simplify the `disableScroll` variable.

## Changelog
### Fixed
- Performance improvement: when launching the sign-up/in modal, the full app won't re-render, leading to a faster modal appearance.