### PR TITLE
[TAN-2849] Bugfix: Add secondary ordering to prevent duplicates when active phase end dates match

### DIFF
--- a/back/app/services/projects_finder_service.rb
+++ b/back/app/services/projects_finder_service.rb
@@ -95,8 +95,8 @@ class ProjectsFinderService
       .where.not(phases: { participation_method: 'information' })
       .select('projects.*, projects.created_at AS projects_created_at')
 
-    # Perform the SELECT DISTINCT on the outer query and order by the end date of the active phase.
-    # We also order by the project creation date to break ties where the end dates are equal.
+    # Perform the SELECT DISTINCT on the outer query and order first by the end date of the active phase,
+    # and second by project creation date. The secondary ordering prevents duplicates when paginating.
     projects = Project
       .from(subquery, :projects)
       .distinct
@@ -127,6 +127,7 @@ class ProjectsFinderService
     projects = Project.where(id: project_descriptor_pairs.keys)
 
     # We join with active phases again here, to reorder by their end dates first, and projects.created_at second.
+    # The secondary ordering prevents duplicates when paginating.
     projects = projects_with_active_phase(projects)
       .order('phase_end_at ASC NULLS LAST, projects.created_at ASC')
 

--- a/back/app/services/projects_finder_service.rb
+++ b/back/app/services/projects_finder_service.rb
@@ -93,14 +93,14 @@ class ProjectsFinderService
     subquery = projects_with_active_phase(subquery)
       .joins('INNER JOIN phases AS active_phases ON active_phases.project_id = projects.id')
       .where.not(phases: { participation_method: 'information' })
-      .select('projects.*, projects.created_at AS created_at_1')
+      .select('projects.*, projects.created_at AS projects_created_at')
 
     # Perform the SELECT DISTINCT on the outer query and order by the end date of the active phase.
     # We also order by the project creation date to break ties where the end dates are equal.
     projects = Project
       .from(subquery, :projects)
       .distinct
-      .order('phase_end_at ASC NULLS LAST, created_at_1 ASC')
+      .order('phase_end_at ASC NULLS LAST, projects_created_at ASC')
       .preload(phases: { permissions: [:groups] })
 
     # Projects user can participate in, or where such participation could (probably) be made possible by user
@@ -142,7 +142,7 @@ class ProjectsFinderService
         'phases.start_at <= ? AND (phases.end_at >= ? OR phases.end_at IS NULL)',
         Time.zone.now.to_fs(:db), Time.zone.now.to_fs(:db)
       )
-      .select('projects.* AS projects, phases.end_at AS phase_end_at')
+      .select('projects.*, phases.end_at AS phase_end_at')
   end
 
   def user_requirements_service

--- a/back/app/services/projects_finder_service.rb
+++ b/back/app/services/projects_finder_service.rb
@@ -126,7 +126,7 @@ class ProjectsFinderService
     # Step 2: Use project_descriptor_pairs keys (project IDs) to filter projects
     projects = Project.where(id: project_descriptor_pairs.keys)
 
-    # We join with active phases again here, to reorder by their end dates.
+    # We join with active phases again here, to reorder by their end dates first, and projects.created_at second.
     projects = projects_with_active_phase(projects)
       .order('phase_end_at ASC NULLS LAST, projects.created_at ASC')
 


### PR DESCRIPTION
# Changelog
## Technical
- [TAN-2849] Bugfix: Add secondary ordering to projects for active participation homepage widget. This avoids arbitrary ordering when active `phases.end_at` dates match, which would introduce duplicates in the paginated results.
