### PR TITLE
[TAN-2849] Add ternary sort by projects.id to projects for active participation homepage widget

### DIFF
--- a/back/spec/acceptance/projects_spec.rb
+++ b/back/spec/acceptance/projects_spec.rb
@@ -1423,11 +1423,16 @@ resource 'Projects' do
       expect(json_response[:links][:next]).to be_nil
     end
 
-    # Test to catch duplicates that can occur when active phase end dates match, and no secondary sorting is applied.
+    # Test to catch duplicates that can occur when active phase end dates match, and no secondary sorting is applied,
+    # or when project created_at dates also match, and no ternary sorting is applied.
+    # This would cuase duplicates to appear on different pages.
     example 'Does not duplicate projects on different pages when phase end dates are the same', document: false do
       Project.destroy_all
 
       create_list(:project_with_active_ideation_phase, 10)
+
+      created_at = 1.day.ago
+      Project.all.each { |p| p.update!(created_at: created_at) }
 
       do_request page: { number: 1, size: 4 }
       json_response = json_parse(response_body)


### PR DESCRIPTION
# Changelog
## Technical
- [TAN-2849] Add ternary sort by `projects.id` to projects for active participation homepage widget. Prevents duplicates when paginating projects from templates containing projects with matching `created_at` dates.
