### PR TITLE
TAN-3042: Make card container not focusable

### DIFF
--- a/front/app/components/IdeaCards/shared/IdeasView/index.tsx
+++ b/front/app/components/IdeaCards/shared/IdeasView/index.tsx
@@ -54,9 +54,7 @@ const IdeasView = ({
 
   return (
     <>
-      {/* TODO: Fix this the next time the file is edited. */}
-      {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition */}
-      {view === 'card' && list && (
+      {view === 'card' && (
         <IdeasList
           ariaLabelledBy={hasMoreThanOneView ? 'view-tab-1' : undefined}
           id={'view-panel-1'}
@@ -66,7 +64,6 @@ const IdeasView = ({
           hasIdeas={list.length > 0}
           loadingMore={loadingMore}
           list={list}
-          tabIndex={0}
           hideImage={hideImage}
           hideImagePlaceholder={hideImagePlaceholder}
           hideIdeaStatus={hideIdeaStatus}

--- a/front/app/components/ProjectAndFolderCards/components/ProjectsTabPanel.tsx
+++ b/front/app/components/ProjectAndFolderCards/components/ProjectsTabPanel.tsx
@@ -29,6 +29,7 @@ const MockProjectCard = styled.div`
 
 interface Props extends BaseProps {
   tab: PublicationTab;
+  hasMoreThanOneTab: boolean;
 }
 
 const ProjectsTabPanel = ({
@@ -37,6 +38,7 @@ const ProjectsTabPanel = ({
   list,
   layout,
   hasMore,
+  hasMoreThanOneTab,
 }: Props) => {
   const isSmallerThanTablet = useBreakpoint('tablet');
   const isLargerThanTablet = !isSmallerThanTablet;
@@ -57,10 +59,9 @@ const ProjectsTabPanel = ({
     // See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role
     <Container
       id={getTabPanelId(tab)}
-      role="tabpanel"
+      role={hasMoreThanOneTab ? 'tabpanel' : undefined}
       className={`e2e-projects-list ${tab === currentTab ? 'active-tab' : ''}`}
-      tabIndex={0}
-      aria-labelledby={getTabId(tab)}
+      aria-labelledby={hasMoreThanOneTab ? `${getTabId(tab)}` : undefined}
       hidden={tab !== currentTab}
       hide={tab !== currentTab}
     >

--- a/front/app/components/ProjectAndFolderCards/components/PublicationStatusTabs.tsx
+++ b/front/app/components/ProjectAndFolderCards/components/PublicationStatusTabs.tsx
@@ -42,6 +42,7 @@ const PublicationStatusTabs = ({
           list={list}
           layout={layout}
           hasMore={hasMore}
+          hasMoreThanOneTab={!!availableTabs.length}
         />
       ))}
     </>


### PR DESCRIPTION
# Changelog

## Fixed
- a11y: Make project and idea card containers un focusable
- a11y: Only use `tabpanel` role when there is more than 1 tab on the projects page