### PR TITLE
Remove unused context causing App re-render on route change

### DIFF
--- a/front/app/containers/IdeasEditPage/IdeasEditForm.tsx
+++ b/front/app/containers/IdeasEditPage/IdeasEditForm.tsx
@@ -1,7 +1,6 @@
-import React, { useCallback, useContext, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 
 import { Box, colors } from '@citizenlab/cl2-component-library';
-import { PreviousPathnameContext } from 'context';
 import { omit } from 'lodash-es';
 import { Multiloc } from 'typings';
 
@@ -11,7 +10,6 @@ import useIdeaImages from 'api/idea_images/useIdeaImages';
 import { IIdeaUpdate } from 'api/ideas/types';
 import useIdeaById from 'api/ideas/useIdeaById';
 import useUpdateIdea from 'api/ideas/useUpdateIdea';
-import useAuthUser from 'api/me/useAuthUser';
 
 import useInputSchema from 'hooks/useInputSchema';
 
@@ -27,7 +25,6 @@ import PageContainer from 'components/UI/PageContainer';
 import { FormattedMessage } from 'utils/cl-intl';
 import clHistory from 'utils/cl-router/history';
 import { getFieldNameFromPath } from 'utils/JSONFormUtils';
-import { usePermission } from 'utils/permissions';
 
 import IdeasEditMeta from './IdeasEditMeta';
 import messages from './messages';
@@ -52,18 +49,11 @@ interface Props {
 }
 
 const IdeasEditForm = ({ ideaId }: Props) => {
-  const previousPathName = useContext(PreviousPathnameContext);
   const [isDisclaimerOpened, setIsDisclaimerOpened] = useState(false);
   const [formData, setFormData] = useState<FormValues | null>(null);
   const [loading, setLoading] = useState(false);
-  const { data: authUser } = useAuthUser();
   const { data: idea } = useIdeaById(ideaId);
   const { mutate: deleteIdeaImage } = useDeleteIdeaImage();
-  const granted = usePermission({
-    item: idea?.data || null,
-    action: 'edit',
-    context: idea?.data || null,
-  });
 
   const { mutateAsync: updateIdea } = useUpdateIdea();
   const { data: remoteImages } = useIdeaImages(ideaId);
@@ -79,14 +69,6 @@ const IdeasEditForm = ({ ideaId }: Props) => {
     projectId,
     inputId: ideaId,
   });
-
-  useEffect(() => {
-    if (idea && authUser !== undefined && !granted) {
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      clHistory.replace(previousPathName || (!authUser ? '/sign-up' : '/'));
-    }
-  }, [idea, granted, previousPathName, authUser]);
 
   const getApiErrorMessage: ApiErrorGetter = useCallback(
     (error) => {

--- a/front/app/containers/IdeasEditPage/index.tsx
+++ b/front/app/containers/IdeasEditPage/index.tsx
@@ -10,12 +10,17 @@ import Unauthorized from 'components/Unauthorized';
 import VerticalCenterer from 'components/VerticalCenterer';
 
 import { isUnauthorizedRQ } from 'utils/errorUtils';
+import { usePermission } from 'utils/permissions';
 
 import IdeasEditForm from './IdeasEditForm';
 
 const IdeasEditPage = () => {
   const { ideaId } = useParams() as { ideaId: string };
-  const { status, error } = useIdeaById(ideaId);
+  const { status, error, data: idea } = useIdeaById(ideaId);
+  const ideaEditPermission = usePermission({
+    item: idea?.data || null,
+    action: 'edit',
+  });
 
   if (status === 'loading') {
     return (
@@ -31,6 +36,10 @@ const IdeasEditPage = () => {
     }
 
     return <PageNotFound />;
+  }
+
+  if (!ideaEditPermission) {
+    return <Unauthorized />;
   }
 
   return <IdeasEditForm ideaId={ideaId} />;

--- a/front/app/context/index.ts
+++ b/front/app/context/index.ts
@@ -1,7 +1,0 @@
-import React from 'react';
-
-import { RouteType } from 'routes';
-
-export const PreviousPathnameContext = React.createContext<RouteType | null>(
-  null
-);


### PR DESCRIPTION
We're doing a full `App` re-render on almost each route change for context that's used in one spot. In this one spot, it's not working as intended (intention: redirect away from idea edit page if you don't have permission).

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- [Show the "Unauthorized" page](https://github.com/user-attachments/assets/1bbd1506-e813-49de-bbc8-45c9381eb6b1) when the user doesn't have permission to edit an idea (input).

## Technical
- Performance improvement: prevent a full application re-render on every URL change by removing `previousPathname` global state.
