### PR TITLE
Remove unused code FullscreenModal

### DIFF
--- a/front/app/components/UI/FullscreenModal/index.tsx
+++ b/front/app/components/UI/FullscreenModal/index.tsx
@@ -127,17 +127,6 @@ class FullscreenModal extends PureComponent<Props, State> {
     this.subscription?.unsubscribe();
   }
 
-  handleKeypress = (event: KeyboardEvent) => {
-    if (event.type === 'keydown' && event.key === 'Escape') {
-      event.preventDefault();
-      this.props.close();
-    }
-  };
-
-  handlePopstateEvent = () => {
-    this.props.close();
-  };
-
   render() {
     const { windowHeight } = this.state;
     const {

--- a/front/app/components/UI/FullscreenModal/index.tsx
+++ b/front/app/components/UI/FullscreenModal/index.tsx
@@ -101,9 +101,6 @@ interface State {
 
 class FullscreenModal extends PureComponent<Props, State> {
   subscription: Subscription | null = null;
-  unlisten: { (): void } | null = null;
-  url: string | null | undefined = null;
-  goBackUrl: string | null | undefined = null;
 
   constructor(props: Props) {
     super(props);

--- a/front/app/components/UI/FullscreenModal/index.tsx
+++ b/front/app/components/UI/FullscreenModal/index.tsx
@@ -86,7 +86,6 @@ interface InputProps {
   topBar?: JSX.Element | null;
   bottomBar?: JSX.Element | null;
   animateInOut?: boolean;
-  navbarRef?: HTMLElement | null;
   mobileNavbarRef?: HTMLElement | null;
   children: JSX.Element | null | undefined;
   modalPortalElement?: HTMLElement;
@@ -149,13 +148,12 @@ class FullscreenModal extends PureComponent<Props, State> {
       topBar,
       bottomBar,
       animateInOut,
-      navbarRef,
       mobileNavbarRef,
       className,
       zIndex,
       contentBgColor,
     } = this.props;
-    const shards = compact([navbarRef, mobileNavbarRef]);
+    const shards = compact([mobileNavbarRef]);
     const modalPortalElement =
       // TODO: Fix this the next time the file is edited.
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition

--- a/front/app/components/UI/FullscreenModal/index.tsx
+++ b/front/app/components/UI/FullscreenModal/index.tsx
@@ -19,7 +19,6 @@ const slideInOutEasing = 'cubic-bezier(0.19, 1, 0.22, 1)';
 
 const Container = styled.div<{
   windowHeight: number;
-  zIndex?: number;
   contentBgColor?: InputProps['contentBgColor'];
 }>`
   width: 100vw;
@@ -32,7 +31,7 @@ const Container = styled.div<{
   overflow: hidden;
   background: ${({ contentBgColor }) =>
     contentBgColor ? colors[contentBgColor] : colors.white};
-  z-index: ${({ zIndex }) => (!zIndex ? '1003' : zIndex.toString())};
+  z-index: 1003;
 
   &.modal-enter {
     transform: translateY(100vh);
@@ -89,7 +88,6 @@ interface InputProps {
   mobileNavbarRef?: HTMLElement | null;
   children: JSX.Element | null | undefined;
   modalPortalElement?: HTMLElement;
-  zIndex?: number;
   contentBgColor?: Color;
 }
 
@@ -150,7 +148,6 @@ class FullscreenModal extends PureComponent<Props, State> {
       animateInOut,
       mobileNavbarRef,
       className,
-      zIndex,
       contentBgColor,
     } = this.props;
     const shards = compact([mobileNavbarRef]);
@@ -168,7 +165,6 @@ class FullscreenModal extends PureComponent<Props, State> {
           id="e2e-fullscreenmodal-content"
           className={[bottomBar ? 'hasBottomBar' : '', className].join()}
           windowHeight={windowHeight}
-          zIndex={zIndex}
           contentBgColor={contentBgColor}
         >
           <StyledFocusOn autoFocus={false} shards={shards}>

--- a/front/app/components/UI/FullscreenModal/index.tsx
+++ b/front/app/components/UI/FullscreenModal/index.tsx
@@ -89,7 +89,6 @@ interface InputProps {
   opened: boolean;
   close: () => void;
   url?: string | null;
-  goBackUrl?: string | null;
   topBar?: JSX.Element | null;
   bottomBar?: JSX.Element | null;
   animateInOut?: boolean;
@@ -149,13 +148,13 @@ class FullscreenModal extends PureComponent<Props, State> {
   }
 
   openModal = () => {
-    const { locale, url, goBackUrl } = this.props;
+    const { locale, url } = this.props;
 
     if (!isNilOrError(locale) && url) {
       const { pathname } = removeLocale(url);
       this.url = `${window.location.origin}/${locale}${pathname}`;
       this.goBackUrl = `${window.location.origin}/${locale}${
-        removeLocale(goBackUrl || window.location.pathname).pathname
+        removeLocale(window.location.pathname).pathname
       }`;
       window.history.pushState({ path: this.url }, '', this.url);
       window.addEventListener('popstate', this.handlePopstateEvent, useCapture);

--- a/front/app/components/UI/FullscreenModal/index.tsx
+++ b/front/app/components/UI/FullscreenModal/index.tsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 
-import { Box, Color, colors, media } from '@citizenlab/cl2-component-library';
+import { Color, colors, media } from '@citizenlab/cl2-component-library';
 import { isFunction, compact } from 'lodash-es';
 import { createPortal } from 'react-dom';
 import { FocusOn } from 'react-focus-on';
@@ -212,7 +212,6 @@ class FullscreenModal extends PureComponent<Props, State> {
       navbarRef,
       mobileNavbarRef,
       className,
-      disableFocusOn,
       zIndex,
       contentBgColor,
     } = this.props;
@@ -234,28 +233,13 @@ class FullscreenModal extends PureComponent<Props, State> {
           zIndex={zIndex}
           contentBgColor={contentBgColor}
         >
-          {disableFocusOn ? (
-            <Box
-              flex="1"
-              display="flex"
-              flexDirection="column"
-              alignItems="stretch"
-            >
-              {topBar}
-              <Content className="fullscreenmodal-scrollcontainer">
-                {children}
-              </Content>
-              {bottomBar}
-            </Box>
-          ) : (
-            <StyledFocusOn autoFocus={false} shards={shards}>
-              {topBar}
-              <Content className="fullscreenmodal-scrollcontainer">
-                {children}
-              </Content>
-              {bottomBar}
-            </StyledFocusOn>
-          )}
+          <StyledFocusOn autoFocus={false} shards={shards}>
+            {topBar}
+            <Content className="fullscreenmodal-scrollcontainer">
+              {children}
+            </Content>
+            {bottomBar}
+          </StyledFocusOn>
         </Container>
       );
     }

--- a/front/app/components/UI/FullscreenModal/index.tsx
+++ b/front/app/components/UI/FullscreenModal/index.tsx
@@ -97,7 +97,6 @@ interface InputProps {
   mobileNavbarRef?: HTMLElement | null;
   children: JSX.Element | null | undefined;
   modalPortalElement?: HTMLElement;
-  disableFocusOn?: boolean;
   zIndex?: number;
   contentBgColor?: Color;
 }


### PR DESCRIPTION
Before fixing the bottom part of the modal not appearing, I cleaned up this component (and found some a11y bugs).

🧪 Did functional tests on desktop and phone.
🧪 Triggered E2E tests as well.

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Technical
- Remove unused code from FullscreenModal component