### PR TITLE
[TAN-2951] Add BE for new selection of projects/folders homepage widget

### DIFF
--- a/back/app/services/admin_publications_filtering_service.rb
+++ b/back/app/services/admin_publications_filtering_service.rb
@@ -14,6 +14,10 @@ class AdminPublicationsFilteringService
 
   # NOTE: This service is very fragile and the ORDER of filters matters for the Front-End, do not change it.
 
+  add_filter('with_ids') do |scope, options|
+    scope.where(id: options[:ids])
+  end
+
   add_filter('only_projects') do |scope, options|
     next scope unless ['true', true, '1'].include? options[:only_projects]
 

--- a/back/app/services/admin_publications_filtering_service.rb
+++ b/back/app/services/admin_publications_filtering_service.rb
@@ -15,6 +15,8 @@ class AdminPublicationsFilteringService
   # NOTE: This service is very fragile and the ORDER of filters matters for the Front-End, do not change it.
 
   add_filter('with_ids') do |scope, options|
+    next scope if options[:ids].blank?
+
     scope.where(id: options[:ids])
   end
 

--- a/back/spec/services/admin_publications_filtering_service_spec.rb
+++ b/back/spec/services/admin_publications_filtering_service_spec.rb
@@ -64,4 +64,18 @@ describe AdminPublicationsFilteringService do
       expect(result.ids).to include(*AdminPublication.ids)
     end
   end
+
+  context 'when filtering by ids' do
+    let(:admin_publication1) { create(:admin_publication) }
+    let(:admin_publication2) { create(:admin_publication) }
+    let(:admin_publication3) { create(:admin_publication) }
+
+    let(:base_scope) { Pundit.policy_scope(create(:admin), AdminPublication.includes(:parent)) }
+    let(:options) { { ids: [admin_publication1.id, admin_publication2.id] } }
+
+    it 'returns only the admin_publications with the specified ids' do
+      expect(base_scope.size).to be > 2
+      expect(result.ids).to contain_exactly(admin_publication1.id, admin_publication2.id)
+    end
+  end
 end


### PR DESCRIPTION
For use with the existing `AdminPublicationsController#index` action, with query params, such as;

`.../web_api/v1/admin_publications?ids%5B%5D=de05b89e-2028-4fb4-8204-d6b88d9bcfaa&ids%5B%5D=328d19ef-e2b8-445a-8ed3-ba9af2628b1a`

# Changelog
## Technical
- [TAN-2951] Add BE for new selection of projects/folders homepage widget
