### PR TITLE
Always animate "in out" full-screen modal

### DIFF
--- a/front/app/components/IdeaCards/IdeasWithFiltersSidebar/FiltersModal.tsx
+++ b/front/app/components/IdeaCards/IdeasWithFiltersSidebar/FiltersModal.tsx
@@ -37,7 +37,6 @@ const FiltersModal = ({
     <FullscreenModal
       opened={opened}
       close={onClose}
-      animateInOut={true}
       topBar={<TopBar onReset={onClearFilters} onClose={onClose} />}
       bottomBar={
         <BottomBar

--- a/front/app/components/UI/FullscreenModal/index.tsx
+++ b/front/app/components/UI/FullscreenModal/index.tsx
@@ -84,10 +84,8 @@ interface InputProps {
   close: () => void;
   topBar?: JSX.Element | null;
   bottomBar?: JSX.Element | null;
-  animateInOut?: boolean;
   mobileNavbarRef?: HTMLElement | null;
   children: JSX.Element | null | undefined;
-  modalPortalElement?: HTMLElement;
   contentBgColor?: Color;
 }
 
@@ -131,22 +129,25 @@ class FullscreenModal extends PureComponent<Props, State> {
       opened,
       topBar,
       bottomBar,
-      animateInOut,
       mobileNavbarRef,
       className,
       contentBgColor,
     } = this.props;
     const shards = compact([mobileNavbarRef]);
-    const modalPortalElement =
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      this.props.modalPortalElement || document?.getElementById('modal-portal');
-    let modalContent: React.ReactChild | null = null;
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    if (animateInOut || (!animateInOut && opened)) {
-      modalContent = (
+    return createPortal(
+      <CSSTransition
+        classNames="modal"
+        in={opened}
+        timeout={{
+          enter: slideInOutTimeout,
+          exit: slideInOutTimeout,
+        }}
+        mountOnEnter={true}
+        unmountOnExit={true}
+        enter={true}
+        exit={true}
+      >
         <Container
           id="e2e-fullscreenmodal-content"
           className={[bottomBar ? 'hasBottomBar' : '', className].join()}
@@ -161,36 +162,9 @@ class FullscreenModal extends PureComponent<Props, State> {
             {bottomBar}
           </StyledFocusOn>
         </Container>
-      );
-    }
-
-    if (animateInOut) {
-      return createPortal(
-        <CSSTransition
-          classNames="modal"
-          in={opened}
-          timeout={{
-            enter: slideInOutTimeout,
-            exit: slideInOutTimeout,
-          }}
-          mountOnEnter={true}
-          unmountOnExit={true}
-          enter={true}
-          exit={true}
-        >
-          {modalContent}
-        </CSSTransition>,
-        document.getElementById('modal-portal') as HTMLElement
-      );
-    }
-
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    if (!animateInOut && opened && modalPortalElement) {
-      return createPortal(modalContent, modalPortalElement);
-    }
-
-    return null;
+      </CSSTransition>,
+      document.getElementById('modal-portal') as HTMLElement
+    );
   }
 }
 

--- a/front/app/containers/MainHeader/Components/NavbarContent/MobileNavbarContent/FullMobileNavMenu.tsx
+++ b/front/app/containers/MainHeader/Components/NavbarContent/MobileNavbarContent/FullMobileNavMenu.tsx
@@ -105,10 +105,6 @@ const FullMobileNavMenu = ({
 
   const navbarItemPropsArray = getNavbarItemPropsArray(navbarItems.data);
 
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  const modalPortalElement = document?.getElementById('mobile-nav-portal');
-
   const handleOnCloseButtonClick = () => {
     onClose();
     trackEventByName(tracks.closeButtonClickedFullMenu);
@@ -121,63 +117,58 @@ const FullMobileNavMenu = ({
     });
   };
 
-  if (modalPortalElement) {
-    return (
-      <StyledFullscreenModal
-        opened={isFullMenuOpened}
-        close={onClose}
-        mobileNavbarRef={mobileNavbarRef}
-        modalPortalElement={modalPortalElement}
-      >
-        <Container>
-          <ContentContainer
-            // Screen reader will add "navigation", so this will become
-            // "Full mobile navigation"
-            // Needed because there's also a different nav (see MobileNavbarContent/index)
-            aria-label={formatMessage(messages.fullMobileNavigation)}
-          >
-            <Box mb="16px">
-              <TenantLogo />
-            </Box>
-            <MenuItems>
-              {navbarItemPropsArray.map((navbarItemProps) => {
-                const { linkTo, onlyActiveOnIndex, navigationItemTitle } =
-                  navbarItemProps;
-                if (linkTo) {
-                  return (
-                    <FullMobileNavMenuItem
-                      key={linkTo}
-                      linkTo={linkTo}
-                      onlyActiveOnIndex={onlyActiveOnIndex}
-                      navigationItemTitle={localize(navigationItemTitle)}
-                      onClick={handleOnMenuItemClick(linkTo)}
-                      scrollToTop
-                    />
-                  );
-                }
-                return null;
-              })}
-              <FullMobileNavMenuItem
-                linkTo={'/projects?focusSearch=true'}
-                navigationItemTitle={formatMessage(messages.search)}
-                onClick={handleOnMenuItemClick('/projects?focusSearch=true')}
-                iconName="search"
-                scrollToTop
-              />
-            </MenuItems>
-            <StyledCloseIconButton
-              a11y_buttonActionMessage={messages.closeMobileNavMenu}
-              onClick={handleOnCloseButtonClick}
-              iconColor={colors.textSecondary}
-              iconColorOnHover={darken(0.1, colors.textSecondary)}
+  return (
+    <StyledFullscreenModal
+      opened={isFullMenuOpened}
+      close={onClose}
+      mobileNavbarRef={mobileNavbarRef}
+    >
+      <Container>
+        <ContentContainer
+          // Screen reader will add "navigation", so this will become
+          // "Full mobile navigation"
+          // Needed because there's also a different nav (see MobileNavbarContent/index)
+          aria-label={formatMessage(messages.fullMobileNavigation)}
+        >
+          <Box mb="16px">
+            <TenantLogo />
+          </Box>
+          <MenuItems>
+            {navbarItemPropsArray.map((navbarItemProps) => {
+              const { linkTo, onlyActiveOnIndex, navigationItemTitle } =
+                navbarItemProps;
+              if (linkTo) {
+                return (
+                  <FullMobileNavMenuItem
+                    key={linkTo}
+                    linkTo={linkTo}
+                    onlyActiveOnIndex={onlyActiveOnIndex}
+                    navigationItemTitle={localize(navigationItemTitle)}
+                    onClick={handleOnMenuItemClick(linkTo)}
+                    scrollToTop
+                  />
+                );
+              }
+              return null;
+            })}
+            <FullMobileNavMenuItem
+              linkTo={'/projects?focusSearch=true'}
+              navigationItemTitle={formatMessage(messages.search)}
+              onClick={handleOnMenuItemClick('/projects?focusSearch=true')}
+              iconName="search"
+              scrollToTop
             />
-          </ContentContainer>
-        </Container>
-      </StyledFullscreenModal>
-    );
-  }
-
-  return null;
+          </MenuItems>
+          <StyledCloseIconButton
+            a11y_buttonActionMessage={messages.closeMobileNavMenu}
+            onClick={handleOnCloseButtonClick}
+            iconColor={colors.textSecondary}
+            iconColorOnHover={darken(0.1, colors.textSecondary)}
+          />
+        </ContentContainer>
+      </Container>
+    </StyledFullscreenModal>
+  );
 };
 
 export default FullMobileNavMenu;


### PR DESCRIPTION
Further simplifying `FullscreenModal` (which will help fix our keyboard focus in a later PR).

🧪 Did functional tests on desktop and phone.
🧪 Triggered E2E tests as well.

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Changed
- Use "in out" animation for mobile navigation appearance