### PR TITLE
[TAN-3081] Sort by last phase end_at in homepage finished projects widget

### DIFF
--- a/back/app/controllers/web_api/v1/projects_controller.rb
+++ b/back/app/controllers/web_api/v1/projects_controller.rb
@@ -55,7 +55,7 @@ class WebApi::V1::ProjectsController < ApplicationController
 
   # For use with 'Finished or archived' homepage widget. Uses ProjectMiniSerializer.
   # Returns projects that are either ( published AND (finished OR have a last phase that contains a report))
-  # OR are archived, ordered by creation date first and ID second.
+  # OR are archived, ordered by last phase end_at (nulls first), creation date second and ID third.
   # => [Project]
   def index_finished_or_archived
     projects = policy_scope(Project)

--- a/back/app/services/projects_finder_service.rb
+++ b/back/app/services/projects_finder_service.rb
@@ -106,7 +106,7 @@ class ProjectsFinderService
   end
 
   # Returns ActiveRecord collection of projects that are either (finished OR have a last phase that contains a report)
-  # OR are archived, ordered by creation date first and ID second.
+  # OR are archived, ordered by last phase end_at (nulls first), creation date second and ID third.
   # => [Project]
   def finished_or_archived
     return @projects.none unless @filter_by

--- a/back/app/services/projects_finder_service.rb
+++ b/back/app/services/projects_finder_service.rb
@@ -109,7 +109,7 @@ class ProjectsFinderService
   # OR are archived, ordered by last phase end_at (nulls first), creation date second and ID third.
   # => [Project]
   def finished_or_archived
-    return @projects.none unless @filter_by
+    # return @projects.none unless @filter_by
 
     base_scope = @projects
       .joins('INNER JOIN admin_publications AS admin_publications ON admin_publications.publication_id = projects.id')

--- a/back/app/services/projects_finder_service.rb
+++ b/back/app/services/projects_finder_service.rb
@@ -4,7 +4,7 @@ class ProjectsFinderService
     @user = user
     @page_size = (params.dig(:page, :size) || 500).to_i
     @page_number = (params.dig(:page, :number) || 1).to_i
-    @params = params
+    @filter_by = params[:filter_by]
   end
 
   # Returns an ActiveRecord collection of published projects that are
@@ -109,14 +109,14 @@ class ProjectsFinderService
   # OR are archived, ordered by creation date first and ID second.
   # => [Project]
   def finished_or_archived
-    include_finished = %w[finished finished_and_archived].include?(@params[:filter_by])
-    include_archived = %w[archived finished_and_archived].include?(@params[:filter_by])
-
-    return @projects.none unless include_finished || include_archived
+    return @projects.none unless @filter_by
 
     base_scope = @projects
       .joins('INNER JOIN admin_publications AS admin_publications ON admin_publications.publication_id = projects.id')
       .joins('INNER JOIN phases ON phases.project_id = projects.id')
+
+    include_finished = %w[finished finished_and_archived].include?(@filter_by)
+    include_archived = %w[archived finished_and_archived].include?(@filter_by)
 
     if include_finished
       finished_scope = base_scope.where(admin_publications: { publication_status: 'published' })

--- a/back/app/services/projects_finder_service.rb
+++ b/back/app/services/projects_finder_service.rb
@@ -109,8 +109,6 @@ class ProjectsFinderService
   # OR are archived, ordered by last phase end_at (nulls first), creation date second and ID third.
   # => [Project]
   def finished_or_archived
-    # return @projects.none unless @filter_by
-
     base_scope = @projects
       .joins('INNER JOIN admin_publications AS admin_publications ON admin_publications.publication_id = projects.id')
       .joins('INNER JOIN phases ON phases.project_id = projects.id')

--- a/back/app/services/projects_finder_service.rb
+++ b/back/app/services/projects_finder_service.rb
@@ -4,8 +4,7 @@ class ProjectsFinderService
     @user = user
     @page_size = (params.dig(:page, :size) || 500).to_i
     @page_number = (params.dig(:page, :number) || 1).to_i
-    @finished = params[:finished]
-    @archived = params[:archived]
+    @params = params
   end
 
   # Returns an ActiveRecord collection of published projects that are
@@ -110,13 +109,16 @@ class ProjectsFinderService
   # OR are archived, ordered by creation date first and ID second.
   # => [Project]
   def finished_or_archived
-    return @projects.none unless @finished || @archived
+    include_finished = %w[finished finished_and_archived].include?(@params[:filter_by])
+    include_archived = %w[archived finished_and_archived].include?(@params[:filter_by])
+
+    return @projects.none unless include_finished || include_archived
 
     base_scope = @projects
       .joins('INNER JOIN admin_publications AS admin_publications ON admin_publications.publication_id = projects.id')
       .joins('INNER JOIN phases ON phases.project_id = projects.id')
 
-    if @finished
+    if include_finished
       finished_scope = base_scope.where(admin_publications: { publication_status: 'published' })
       finished_scope = joins_last_phases_with_reports(finished_scope)
         .where(
@@ -125,11 +127,16 @@ class ProjectsFinderService
         )
     end
 
-    archived_scope = base_scope.where(admin_publications: { publication_status: 'archived' }) if @archived
-    archived_scope = joins_last_phases_with_reports(archived_scope) if @archived
+    if include_archived
+      archived_scope = base_scope.where(admin_publications: { publication_status: 'archived' })
+      archived_scope = joins_last_phases_with_reports(archived_scope)
+    end
 
-    return order_by_created_at_and_id_with_distinct_on(finished_scope.or(archived_scope)) if @finished && @archived
-    return order_by_created_at_and_id_with_distinct_on(finished_scope) if @finished
+    if include_finished && include_archived
+      return order_by_created_at_and_id_with_distinct_on(finished_scope.or(archived_scope))
+    end
+
+    return order_by_created_at_and_id_with_distinct_on(finished_scope) if include_finished
 
     order_by_created_at_and_id_with_distinct_on(archived_scope)
   end

--- a/back/spec/acceptance/projects_spec.rb
+++ b/back/spec/acceptance/projects_spec.rb
@@ -1598,9 +1598,17 @@ resource 'Projects' do
     end
 
     context "when passed only the 'archived' parameter" do
-      let!(:archived_project) { create(:project, admin_publication_attributes: { publication_status: 'archived' }) }
-      let!(:published_project) { create(:project, admin_publication_attributes: { publication_status: 'published' }) }
-      let!(:draft_project) { create(:project, admin_publication_attributes: { publication_status: 'draft' }) }
+      let!(:archived_project) do
+        create(:project_with_past_information_phase, admin_publication_attributes: { publication_status: 'archived' })
+      end
+
+      let!(:published_project) do
+        create(:project_with_past_information_phase, admin_publication_attributes: { publication_status: 'published' })
+      end
+
+      let!(:draft_project) do
+        create(:project_with_past_information_phase, admin_publication_attributes: { publication_status: 'draft' })
+      end
 
       example 'Lists only archived projects' do
         do_request archived: true
@@ -1614,9 +1622,17 @@ resource 'Projects' do
     end
 
     context "when passed both the 'finished' and the 'archived' parameter" do
-      let!(:archived_project) { create(:project, admin_publication_attributes: { publication_status: 'archived' }) }
-      let!(:published_project) { create(:project, admin_publication_attributes: { publication_status: 'published' }) }
-      let!(:draft_project) { create(:project, admin_publication_attributes: { publication_status: 'draft' }) }
+      let!(:archived_project) do
+        create(:project_with_active_ideation_phase, admin_publication_attributes: { publication_status: 'archived' })
+      end
+
+      let!(:published_project) do
+        create(:project_with_active_ideation_phase, admin_publication_attributes: { publication_status: 'published' })
+      end
+
+      let!(:draft_project) do
+        create(:project_with_active_ideation_phase, admin_publication_attributes: { publication_status: 'draft' })
+      end
 
       let!(:finished_project1) { create(:project_with_two_past_ideation_phases) }
       let!(:_unfinished_project1) { create(:project_with_active_ideation_phase) } # we do not expect this one

--- a/back/spec/acceptance/projects_spec.rb
+++ b/back/spec/acceptance/projects_spec.rb
@@ -1562,11 +1562,10 @@ resource 'Projects' do
     with_options scope: :page do
       parameter :number, 'Page number'
       parameter :size, 'Number of projects per page'
-      parameter :finished, 'Include projects with all phases finished or with a report in last phase', required: false
-      parameter :archived, 'Include archived projects', required: false
+      parameter :filter_by, 'Whether to filter by finished or archived projects, or both', required: false
     end
 
-    context "when passed only the 'finished' parameter" do
+    context "when passed filter_by: 'finished'" do
       let!(:finished_project1) { create(:project_with_two_past_ideation_phases) }
       let!(:_unfinished_project1) { create(:project_with_active_ideation_phase) }
       let!(:unfinished_project2) { create(:project) }
@@ -1574,7 +1573,7 @@ resource 'Projects' do
       let!(:_report) { create(:report, phase: phase) }
 
       example 'Lists only projects with all phases finished or with a report in the last phase' do
-        do_request finished: true
+        do_request filter_by: 'finished'
         expect(status).to eq 200
 
         json_response = json_parse(response_body)
@@ -1587,7 +1586,7 @@ resource 'Projects' do
         create(:project_with_two_past_ideation_phases, admin_publication_attributes: { publication_status: 'draft' })
         create(:project_with_two_past_ideation_phases, admin_publication_attributes: { publication_status: 'archived' })
 
-        do_request finished: true
+        do_request filter_by: 'finished'
         expect(status).to eq 200
 
         json_response = json_parse(response_body)
@@ -1597,7 +1596,7 @@ resource 'Projects' do
       end
     end
 
-    context "when passed only the 'archived' parameter" do
+    context "when passed filter_by: 'archived'" do
       let!(:archived_project) do
         create(:project_with_past_information_phase, admin_publication_attributes: { publication_status: 'archived' })
       end
@@ -1611,7 +1610,7 @@ resource 'Projects' do
       end
 
       example 'Lists only archived projects' do
-        do_request archived: true
+        do_request filter_by: 'archived'
         expect(status).to eq 200
 
         json_response = json_parse(response_body)
@@ -1621,7 +1620,7 @@ resource 'Projects' do
       end
     end
 
-    context "when passed both the 'finished' and the 'archived' parameter" do
+    context "when passed filter_by: 'finished_and_archived'" do
       let!(:archived_project) do
         create(:project_with_active_ideation_phase, admin_publication_attributes: { publication_status: 'archived' })
       end
@@ -1641,7 +1640,7 @@ resource 'Projects' do
       let!(:_report) { create(:report, phase: phase) }
 
       example 'Lists (published projects with phases finished OR with a report in last phase) OR archived projects' do
-        do_request({ archived: true, finished: true })
+        do_request({ filter_by: 'finished_and_archived' })
         expect(status).to eq 200
 
         json_response = json_parse(response_body)
@@ -1654,7 +1653,7 @@ resource 'Projects' do
         finished_project1.phases[0].update!(start_at: 342.days.ago, end_at: 339.days.ago)
         finished_project1.phases[1].update!(start_at: 338.days.ago, end_at: 335.days.ago)
 
-        do_request({ archived: true, finished: true })
+        do_request({ filter_by: 'finished_and_archived' })
         expect(status).to eq 200
 
         json_response = json_parse(response_body)
@@ -1667,11 +1666,11 @@ resource 'Projects' do
       example 'Does not duplicate projects on different pages when created_at dates are the same', document: false do
         create_list(:project_with_two_past_ideation_phases, 10)
 
-        do_request page: { number: 1, size: 4 }
+        do_request({ page: { number: 1, size: 4 }, filter_by: 'finished' })
         json_response = json_parse(response_body)
         project_ids_page1 = json_response[:data].pluck(:id)
 
-        do_request page: { number: 2, size: 4 }
+        do_request({ page: { number: 2, size: 4 }, filter_by: 'finished' })
         json_response = json_parse(response_body)
         project_ids_page2 = json_response[:data].pluck(:id)
 

--- a/back/spec/factories/phases.rb
+++ b/back/spec/factories/phases.rb
@@ -52,6 +52,13 @@ FactoryBot.define do
       end
     end
 
+    factory :past_phase do
+      after(:create) do |phase, _evaluator|
+        phase.start_at = Time.now - 30.days
+        phase.end_at = Time.now - 20.days
+      end
+    end
+
     factory :phase_sequence do
       transient do
         duration_in_days { 5 }

--- a/back/spec/factories/projects.rb
+++ b/back/spec/factories/projects.rb
@@ -87,6 +87,12 @@ FactoryBot.define do
       end
     end
 
+    factory :project_with_past_information_phase do
+      after(:create) do |project, _evaluator|
+        project.phases << create(:past_phase, project: project, participation_method: 'information')
+      end
+    end
+
     factory :project_with_past_ideation_and_active_budgeting_phase do
       after(:create) do |project, _evaluator|
         project.phases << create(

--- a/back/spec/services/projects_finder_service_spec.rb
+++ b/back/spec/services/projects_finder_service_spec.rb
@@ -210,7 +210,7 @@ describe ProjectsFinderService do
     let!(:unfinished_project) { create(:project_with_active_ideation_phase) }
 
     describe "when passed only the 'finished' parameter" do
-      let(:result) { service.new(Project.all, user, { finished: true }).finished_or_archived }
+      let(:result) { service.new(Project.all, user, { filter_by: 'finished' }).finished_or_archived }
 
       it 'includes finished projects' do
         expect(Project.count).to eq 2
@@ -250,7 +250,7 @@ describe ProjectsFinderService do
         expect(result).to match_array([finished_project1])
       end
 
-      it 'inludes projects with an endless phase & report in last phase' do
+      it 'inludes projects with an endless last phase & report in last phase' do
         endless_project = create(:project)
         create(:phase, project: endless_project, start_at: 2.days.ago, end_at: nil)
         create(:report, phase: endless_project.phases.last)
@@ -259,7 +259,7 @@ describe ProjectsFinderService do
         expect(result).to match_array([endless_project, finished_project1])
       end
 
-      it 'excludes projects with an endless phase & NO report in last phase' do
+      it 'excludes projects with an endless last phase & NO report in last phase' do
         endless_project = create(:project)
         create(:phase, project: endless_project, start_at: 3.days.ago, end_at: nil)
 
@@ -304,7 +304,7 @@ describe ProjectsFinderService do
         create(:project, admin_publication_attributes: { publication_status: 'published' })
       end
 
-      let(:result) { service.new(Project.all, user, { archived: true }).finished_or_archived }
+      let(:result) { service.new(Project.all, user, { filter_by: 'archived' }).finished_or_archived }
 
       it 'includes archived projects' do
         expect(Project.count).to eq 5
@@ -361,7 +361,7 @@ describe ProjectsFinderService do
       let!(:_phase2) { create(:phase, project: unfinished_project2, start_at: 1.day.ago, end_at: 1.day.from_now) }
       let!(:_report2) { create(:report, phase: phase1) }
 
-      let(:result) { service.new(Project.all, user, { finished: true, archived: true }).finished_or_archived }
+      let(:result) { service.new(Project.all, user, { filter_by: 'finished_and_archived' }).finished_or_archived }
 
       it 'includes expected projects' do
         expect(Project.count).to eq 7

--- a/back/spec/services/projects_finder_service_spec.rb
+++ b/back/spec/services/projects_finder_service_spec.rb
@@ -209,7 +209,7 @@ describe ProjectsFinderService do
     let!(:finished_project1) { create(:project_with_two_past_ideation_phases) }
     let!(:unfinished_project) { create(:project_with_active_ideation_phase) }
 
-    describe "when passed only the 'finished' parameter" do
+    describe "when passed filter_by: 'finished'" do
       let(:result) { service.new(Project.all, user, { filter_by: 'finished' }).finished_or_archived }
 
       it 'includes finished projects' do
@@ -291,7 +291,7 @@ describe ProjectsFinderService do
       end
     end
 
-    describe "when passed only the 'archived' parameter" do
+    describe "when passed filter_by: 'archived'" do
       let!(:archived_project) do
         create(:project_with_past_information_phase, admin_publication_attributes: { publication_status: 'archived' })
       end
@@ -342,7 +342,7 @@ describe ProjectsFinderService do
       end
     end
 
-    describe "when passed 'finished' AND 'archived' parameter" do
+    describe "when passed filter_by: 'finished_and_archived'" do
       # Should include `finished_project1` and:
       let!(:unfinished_project1) { create(:project) }
       let!(:phase) { create(:phase, project: unfinished_project1, start_at: 2.days.ago, end_at: 2.days.from_now) }


### PR DESCRIPTION
Introduces primary sort by last phase `end_at` (DESC, nulls first)

- also filters out projects with no phases early in the query chain (it makes little sense for these to be considered 'finished', and unlikely to be archived with a view to presenting in this widget). In any case, ordering by last phase `end_at` would become tricky/inefficient if there is no phase.

# Changelog
## Technical
- [TAN-3081] Sort by last phase `end_at` in homepage finished projects widget (feature in development)