### PR TITLE
Fix keyboard focus for FullscreenModal instances

### DIFF
--- a/front/app/components/UI/FullscreenModal/index.tsx
+++ b/front/app/components/UI/FullscreenModal/index.tsx
@@ -11,8 +11,6 @@ import { SupportedLocale } from 'typings';
 
 import useLocale from 'hooks/useLocale';
 
-// resource
-
 const slideInOutTimeout = 500;
 const slideInOutEasing = 'cubic-bezier(0.19, 1, 0.22, 1)';
 
@@ -89,6 +87,7 @@ interface InputProps {
 
 interface Props extends InputProps {
   locale: SupportedLocale;
+  modalPortalElement: HTMLElement;
 }
 
 interface State {
@@ -122,8 +121,15 @@ class FullscreenModal extends PureComponent<Props, State> {
 
   render() {
     const { windowHeight } = this.state;
-    const { children, opened, topBar, bottomBar, className, contentBgColor } =
-      this.props;
+    const {
+      children,
+      opened,
+      topBar,
+      bottomBar,
+      className,
+      contentBgColor,
+      modalPortalElement,
+    } = this.props;
 
     return createPortal(
       <CSSTransition
@@ -153,13 +159,20 @@ class FullscreenModal extends PureComponent<Props, State> {
           </StyledFocusOn>
         </Container>
       </CSSTransition>,
-      document.getElementById('modal-portal') as HTMLElement
+      modalPortalElement
     );
   }
 }
 
 export default (inputProps: InputProps) => {
   const locale = useLocale();
+  const modalPortalElement = document.getElementById('modal-portal');
 
-  return <FullscreenModal {...inputProps} locale={locale} />;
+  return modalPortalElement ? (
+    <FullscreenModal
+      {...inputProps}
+      locale={locale}
+      modalPortalElement={modalPortalElement}
+    />
+  ) : null;
 };

--- a/front/app/components/UI/FullscreenModal/index.tsx
+++ b/front/app/components/UI/FullscreenModal/index.tsx
@@ -1,7 +1,6 @@
 import React, { PureComponent } from 'react';
 
 import { Color, colors, media } from '@citizenlab/cl2-component-library';
-import { compact } from 'lodash-es';
 import { createPortal } from 'react-dom';
 import { FocusOn } from 'react-focus-on';
 import CSSTransition from 'react-transition-group/CSSTransition';
@@ -84,7 +83,6 @@ interface InputProps {
   close: () => void;
   topBar?: JSX.Element | null;
   bottomBar?: JSX.Element | null;
-  mobileNavbarRef?: HTMLElement | null;
   children: JSX.Element | null | undefined;
   contentBgColor?: Color;
 }
@@ -124,16 +122,8 @@ class FullscreenModal extends PureComponent<Props, State> {
 
   render() {
     const { windowHeight } = this.state;
-    const {
-      children,
-      opened,
-      topBar,
-      bottomBar,
-      mobileNavbarRef,
-      className,
-      contentBgColor,
-    } = this.props;
-    const shards = compact([mobileNavbarRef]);
+    const { children, opened, topBar, bottomBar, className, contentBgColor } =
+      this.props;
 
     return createPortal(
       <CSSTransition
@@ -154,7 +144,7 @@ class FullscreenModal extends PureComponent<Props, State> {
           windowHeight={windowHeight}
           contentBgColor={contentBgColor}
         >
-          <StyledFocusOn autoFocus={false} shards={shards}>
+          <StyledFocusOn autoFocus>
             {topBar}
             <Content className="fullscreenmodal-scrollcontainer">
               {children}

--- a/front/app/containers/MainHeader/Components/NavbarContent/MobileNavbarContent/FullMobileNavMenu.tsx
+++ b/front/app/containers/MainHeader/Components/NavbarContent/MobileNavbarContent/FullMobileNavMenu.tsx
@@ -89,14 +89,9 @@ const StyledFullscreenModal = styled(FullscreenModal)`
 interface Props {
   onClose: () => void;
   isFullMenuOpened: boolean;
-  mobileNavbarRef: HTMLElement;
 }
 
-const FullMobileNavMenu = ({
-  mobileNavbarRef,
-  onClose,
-  isFullMenuOpened,
-}: Props) => {
+const FullMobileNavMenu = ({ onClose, isFullMenuOpened }: Props) => {
   const { data: navbarItems } = useNavbarItems();
   const localize = useLocalize();
   const { formatMessage } = useIntl();
@@ -118,11 +113,7 @@ const FullMobileNavMenu = ({
   };
 
   return (
-    <StyledFullscreenModal
-      opened={isFullMenuOpened}
-      close={onClose}
-      mobileNavbarRef={mobileNavbarRef}
-    >
+    <StyledFullscreenModal opened={isFullMenuOpened} close={onClose}>
       <Container>
         <ContentContainer
           // Screen reader will add "navigation", so this will become

--- a/front/app/containers/MainHeader/Components/NavbarContent/MobileNavbarContent/index.tsx
+++ b/front/app/containers/MainHeader/Components/NavbarContent/MobileNavbarContent/index.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useState } from 'react';
+import React, { lazy, Suspense, useState } from 'react';
 
 import { Box, Button, media, isRtl } from '@citizenlab/cl2-component-library';
 import styled from 'styled-components';
@@ -17,7 +17,7 @@ import LanguageSelector from '../../LanguageSelector';
 import NotificationMenu from '../../NotificationMenu';
 import UserMenu from '../../UserMenu';
 
-import FullMobileNavMenu from './FullMobileNavMenu';
+const FullMobileNavMenu = lazy(() => import('./FullMobileNavMenu'));
 import ShowFullMenuButton from './ShowFullMenuButton';
 
 const RightContainer = styled(Box)`

--- a/front/app/containers/MainHeader/Components/NavbarContent/MobileNavbarContent/index.tsx
+++ b/front/app/containers/MainHeader/Components/NavbarContent/MobileNavbarContent/index.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useRef, useState } from 'react';
+import React, { Suspense, useState } from 'react';
 
 import { Box, Button, media, isRtl } from '@citizenlab/cl2-component-library';
 import styled from 'styled-components';
@@ -84,7 +84,6 @@ const MobileNavbarContent = () => {
   const isEmailSettingsPage = isPage('email-settings', location.pathname);
 
   const [isFullMenuOpened, setIsFullMenuOpened] = useState(false);
-  const containerRef = useRef<HTMLElement>(null);
 
   const signIn = () => {
     triggerAuthenticationFlow({}, 'signin');
@@ -104,7 +103,7 @@ const MobileNavbarContent = () => {
   };
 
   return (
-    <nav ref={containerRef}>
+    <nav>
       <RightContainer>
         {!isEmailSettingsPage && (
           <>
@@ -140,13 +139,10 @@ const MobileNavbarContent = () => {
         )}
       </RightContainer>
       <Suspense fallback={null}>
-        {containerRef.current && (
-          <FullMobileNavMenu
-            isFullMenuOpened={isFullMenuOpened}
-            onClose={onCloseFullMenu}
-            mobileNavbarRef={containerRef.current}
-          />
-        )}
+        <FullMobileNavMenu
+          isFullMenuOpened={isFullMenuOpened}
+          onClose={onCloseFullMenu}
+        />
       </Suspense>
     </nav>
   );


### PR DESCRIPTION
Attempting https://github.com/CitizenLabDotCo/citizenlab/pull/9442 again.

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Keyboard focus of mobile navigation & filters modal on the "all input" page (/ideas route). If you open them with a keyboard, they will be auto-focused. If opened with a mouse, hitting tab will show the focus. Focus will also not move "underneath" these modals anymore