### PR TITLE
TAN-2893 - Fixed posted date for ideas in pre-screening

### DIFF
--- a/front/app/api/ideas/types.ts
+++ b/front/app/api/ideas/types.ts
@@ -93,7 +93,7 @@ export interface IIdeaData {
     proposed_budget: number | null;
     created_at: string;
     updated_at: string;
-    published_at: string;
+    published_at: string | null;
     // For manual_votes_amount, in a PB phase this refers to the # offline baskets with this idea (I.e. # offline picks)
     // In the other voting methods, this refers to the total # offline votes cast for this idea.
     manual_votes_amount: number;

--- a/front/app/containers/IdeasShow/components/MetaInformation/PostedBy.tsx
+++ b/front/app/containers/IdeasShow/components/MetaInformation/PostedBy.tsx
@@ -58,7 +58,9 @@ const PostedBy = memo<Props>(
     const { data: user } = useUserById(authorId);
 
     if (!isNilOrError(idea)) {
-      const ideaPublishedAtDate = idea.data.attributes.published_at;
+      // Ideas in pre-screening don't have a published_at date so use the created_at date
+      const ideaPublishedAtDate =
+        idea.data.attributes.published_at ?? idea.data.attributes.created_at;
       const authorHash = idea.data.attributes.author_hash;
       const isLinkToProfile =
         user?.data.attributes.registration_completed_at !== null;


### PR DESCRIPTION
# Changelog
## Fixed
- Ideas in pre-screening now have a valid 'posted on' date
