### PR TITLE
[TAN-3088] New BE for homepage 'selection' widget that maintains ordering by IDs

### DIFF
--- a/back/app/controllers/web_api/v1/admin_publications_controller.rb
+++ b/back/app/controllers/web_api/v1/admin_publications_controller.rb
@@ -39,6 +39,9 @@ class WebApi::V1::AdminPublicationsController < ApplicationController
     )
   end
 
+  # For use with 'Selected items' homepage widget.
+  # Returns non-draft admin_publications for specified ids, ordered by order of the specified ids.
+  # => [AdminPublication]
   def index_select_and_order_by_ids
     ids = params[:ids]
 

--- a/back/app/controllers/web_api/v1/admin_publications_controller.rb
+++ b/back/app/controllers/web_api/v1/admin_publications_controller.rb
@@ -40,7 +40,7 @@ class WebApi::V1::AdminPublicationsController < ApplicationController
   end
 
   # For use with 'Selected items' homepage widget.
-  # Returns non-draft admin_publications for specified ids, ordered by order of the specified ids.
+  # Returns non-draft admin_publications for specified IDs, ordered by order of the specified IDs.
   # => [AdminPublication]
   def index_select_and_order_by_ids
     ids = params[:ids]

--- a/back/app/controllers/web_api/v1/admin_publications_controller.rb
+++ b/back/app/controllers/web_api/v1/admin_publications_controller.rb
@@ -40,8 +40,10 @@ class WebApi::V1::AdminPublicationsController < ApplicationController
   end
 
   def index_select_and_order_by_ids
+    ids = params[:ids]
+
     admin_publications = policy_scope(AdminPublication.includes(:parent))
-    admin_publications = admin_publications.where(id: params[:ids]).in_order_of(:id, params[:ids])
+    admin_publications = admin_publications.not_draft.where(id: ids).in_order_of(:id, ids)
 
     @admin_publications = paginate admin_publications
     @admin_publications = includes_publications(@admin_publications)

--- a/back/app/models/admin_publication.rb
+++ b/back/app/models/admin_publication.rb
@@ -69,6 +69,10 @@ class AdminPublication < ApplicationRecord
     where(publication_status: 'published')
   }
 
+  scope :draft, lambda {
+    where(publication_status: 'draft')
+  }
+
   scope :not_draft, lambda {
     where.not(publication_status: 'draft')
   }

--- a/back/app/policies/admin_publication_policy.rb
+++ b/back/app/policies/admin_publication_policy.rb
@@ -10,6 +10,10 @@ class AdminPublicationPolicy < ApplicationPolicy
     end
   end
 
+  def index_select_and_order_by_ids?
+    true
+  end
+
   def show?
     policy_for(record.publication).show?
   end

--- a/back/app/services/admin_publications_filtering_service.rb
+++ b/back/app/services/admin_publications_filtering_service.rb
@@ -14,12 +14,6 @@ class AdminPublicationsFilteringService
 
   # NOTE: This service is very fragile and the ORDER of filters matters for the Front-End, do not change it.
 
-  add_filter('with_ids') do |scope, options|
-    next scope if options[:ids].blank?
-
-    scope.where(id: options[:ids])
-  end
-
   add_filter('only_projects') do |scope, options|
     next scope unless ['true', true, '1'].include? options[:only_projects]
 

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -220,6 +220,7 @@ Rails.application.routes.draw do
 
       resources :admin_publications, only: %i[index show] do
         patch 'reorder', on: :member
+        get 'select_and_order_by_ids', on: :collection, action: 'index_select_and_order_by_ids'
         get 'status_counts', on: :collection
       end
 

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -308,6 +308,15 @@ resource 'AdminPublication' do
         expect(json_response[:data].pluck(:id))
           .to eq [non_draft_ids[3], non_draft_ids[0], non_draft_ids[1], non_draft_ids[4]]
       end
+
+      example 'Returns empty data when no records are found', document: false do
+        do_request(ids: ['not_an_admin_publication_id'])
+
+        expect(status).to eq(200)
+        json_response = json_parse(response_body)
+
+        expect(json_response[:data]).to be_empty
+      end
     end
 
     patch 'web_api/v1/admin_publications/:id/reorder' do

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -269,7 +269,7 @@ resource 'AdminPublication' do
       let(:draft_ids) { AdminPublication.all.draft.pluck(:id) }
       let(:non_draft_ids) { AdminPublication.all.not_draft.pluck(:id) }
 
-      example 'List records with specified ids, in order of ids' do
+      example 'List records with specified IDs, in order of IDs' do
         do_request(ids: [
           non_draft_ids[3],
           non_draft_ids[0],
@@ -285,7 +285,7 @@ resource 'AdminPublication' do
           .to eq [non_draft_ids[3], non_draft_ids[0], non_draft_ids[1], non_draft_ids[4]]
       end
 
-      example 'Maintains ordering by ids in pagination', document: false do
+      example 'Maintains ordering by IDs in pagination', document: false do
         do_request(
           ids: [
             non_draft_ids[3],

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -266,33 +266,45 @@ resource 'AdminPublication' do
       end
       parameter :ids, 'Filter and order by IDs', required: false
 
-      let(:all_ids) { AdminPublication.all.pluck(:id) }
+      let(:draft_ids) { AdminPublication.all.draft.pluck(:id) }
+      let(:non_draft_ids) { AdminPublication.all.not_draft.pluck(:id) }
 
       example 'List records with specified ids, in order of ids' do
-        do_request(ids: [all_ids[3], all_ids[0], 'not_an_admin_publication_id', all_ids[1], all_ids[4], all_ids[2]])
+        do_request(ids: [
+          non_draft_ids[3],
+          non_draft_ids[0],
+          'not_an_admin_publication_id',
+          non_draft_ids[1],
+          non_draft_ids[4]
+        ])
 
         expect(status).to eq(200)
         json_response = json_parse(response_body)
 
-        expect(json_response[:data].pluck(:id)).to eq [all_ids[3], all_ids[0], all_ids[1], all_ids[4], all_ids[2]]
+        expect(json_response[:data].pluck(:id))
+          .to eq [non_draft_ids[3], non_draft_ids[0], non_draft_ids[1], non_draft_ids[4]]
       end
 
       example 'Maintains ordering by ids in pagination', document: false do
         do_request(
-          ids: [all_ids[3], all_ids[0], 'not_an_admin_publication_id', all_ids[1], all_ids[4], all_ids[2]],
+          ids: [
+            non_draft_ids[3],
+            non_draft_ids[0],
+            'not_an_admin_publication_id',
+            non_draft_ids[1],
+            non_draft_ids[4],
+            non_draft_ids[2]
+          ],
           page: { number: 2, size: 3 }
         )
 
         expect(status).to eq(200)
         json_response = json_parse(response_body)
 
-        expect(json_response[:data].pluck(:id)).to eq [all_ids[4], all_ids[2]]
+        expect(json_response[:data].pluck(:id)).to eq [non_draft_ids[4], non_draft_ids[2]]
       end
 
       example 'Does not include draft admin_publications', document: false do
-        draft_ids = AdminPublication.where(publication_status: 'draft').pluck(:id)
-        non_draft_ids = all_ids - draft_ids
-
         do_request(ids: [
           non_draft_ids[3],
           draft_ids[1],

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -266,17 +266,27 @@ resource 'AdminPublication' do
       end
       parameter :ids, 'Filter and order by IDs', required: false
 
-      example 'List of records with specified ids, in order of ids' do
-        all_ids = AdminPublication.all.pluck(:id)
+      let(:all_ids) { AdminPublication.all.pluck(:id) }
 
-        do_request(ids: [
-          all_ids[3], all_ids[0], 'not_an_id_of_an_admin_publication', all_ids[1], all_ids[4], all_ids[2]
-        ])
+      example 'List records with specified ids, in order of ids' do
+        do_request(ids: [all_ids[3], all_ids[0], 'not_an_admin_publication_id', all_ids[1], all_ids[4], all_ids[2]])
 
         expect(status).to eq(200)
         json_response = json_parse(response_body)
 
         expect(json_response[:data].pluck(:id)).to eq [all_ids[3], all_ids[0], all_ids[1], all_ids[4], all_ids[2]]
+      end
+
+      example 'Maintains ordering by ids in pagination', document: false do
+        do_request(
+          ids: [all_ids[3], all_ids[0], 'not_an_admin_publication_id', all_ids[1], all_ids[4], all_ids[2]],
+          page: { number: 2, size: 3 }
+        )
+
+        expect(status).to eq(200)
+        json_response = json_parse(response_body)
+
+        expect(json_response[:data].pluck(:id)).to eq [all_ids[4], all_ids[2]]
       end
     end
 

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -288,6 +288,26 @@ resource 'AdminPublication' do
 
         expect(json_response[:data].pluck(:id)).to eq [all_ids[4], all_ids[2]]
       end
+
+      example 'Does not include draft admin_publications', document: false do
+        draft_ids = AdminPublication.where(publication_status: 'draft').pluck(:id)
+        non_draft_ids = all_ids - draft_ids
+
+        do_request(ids: [
+          non_draft_ids[3],
+          draft_ids[1],
+          non_draft_ids[0],
+          draft_ids[0],
+          non_draft_ids[1],
+          non_draft_ids[4]
+        ])
+
+        expect(status).to eq(200)
+        json_response = json_parse(response_body)
+
+        expect(json_response[:data].pluck(:id))
+          .to eq [non_draft_ids[3], non_draft_ids[0], non_draft_ids[1], non_draft_ids[4]]
+      end
     end
 
     patch 'web_api/v1/admin_publications/:id/reorder' do

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -259,6 +259,27 @@ resource 'AdminPublication' do
       end
     end
 
+    get 'web_api/v1/admin_publications/select_and_order_by_ids' do
+      with_options scope: :page do
+        parameter :number, 'Page number'
+        parameter :size, 'Number of projects per page'
+      end
+      parameter :ids, 'Filter and order by IDs', required: false
+
+      example 'List of records with specified ids, in order of ids' do
+        all_ids = AdminPublication.all.pluck(:id)
+
+        do_request(ids: [
+          all_ids[3], all_ids[0], 'not_an_id_of_an_admin_publication', all_ids[1], all_ids[4], all_ids[2]
+        ])
+
+        expect(status).to eq(200)
+        json_response = json_parse(response_body)
+
+        expect(json_response[:data].pluck(:id)).to eq [all_ids[3], all_ids[0], all_ids[1], all_ids[4], all_ids[2]]
+      end
+    end
+
     patch 'web_api/v1/admin_publications/:id/reorder' do
       with_options scope: :admin_publication do
         parameter :ordering, 'The position, starting from 0, where the folder or project should be at. Publications after will move down.', required: true

--- a/back/spec/services/admin_publications_filtering_service_spec.rb
+++ b/back/spec/services/admin_publications_filtering_service_spec.rb
@@ -64,18 +64,4 @@ describe AdminPublicationsFilteringService do
       expect(result.ids).to include(*AdminPublication.ids)
     end
   end
-
-  context 'when filtering by ids' do
-    let(:admin_publication1) { create(:admin_publication) }
-    let(:admin_publication2) { create(:admin_publication) }
-    let(:admin_publication3) { create(:admin_publication) }
-
-    let(:base_scope) { Pundit.policy_scope(create(:admin), AdminPublication.includes(:parent)) }
-    let(:options) { { ids: [admin_publication1.id, admin_publication2.id] } }
-
-    it 'returns only the admin_publications with the specified ids' do
-      expect(base_scope.size).to be > 2
-      expect(result.ids).to contain_exactly(admin_publication1.id, admin_publication2.id)
-    end
-  end
 end


### PR DESCRIPTION
- For use with 'Selected items' homepage widget.
- Returns non-draft `admin_publications` for specified ids, ordered by order of the specified ids.

Example request URL: `.../web_api/v1/admin_publications/select_and_order_by_ids?ids%5B%5D=85baac1d-7eeb-4ef8-87f8-fdf4acfb8a9f&ids%5B%5D=c9d29f01-b1a6-4e0b-a31b-b818926ad55e&page%5Bnumber%5D=1&page%5Bsize%5D=6`

Separate endpoint, rather than use the existing `index` action and add a new filter to the `AdminPublicationsFilteringService`, as I couldn't find a way to do this without being thwarted by mismatches in columns, not having the resultant SQL included in other select or order_by queries, and other SQL related errors that arise when trying to ensure a specified ordering is maintained throughout the chain of queries involved in the filtering service.

# Changelog
## Technical
- [TAN-3088] New BE for homepage 'selection' widget that maintains ordering by IDs
