### PR TITLE
TAN-3095: Add upsell nudge for internal comments

### DIFF
--- a/front/app/components/PostShowComponents/Comments/CommentsSection/index.tsx
+++ b/front/app/components/PostShowComponents/Comments/CommentsSection/index.tsx
@@ -48,6 +48,12 @@ const CommentsSection = ({
   const isInternalCommentingEnabled = useFeatureFlag({
     name: 'internal_commenting',
   });
+  const isInternalCommentingAllowed = useFeatureFlag({
+    name: 'internal_commenting',
+    onlyCheckAllowed: true,
+  });
+  const isInternalCommentingAllowedAndDisabled =
+    isInternalCommentingAllowed && !isInternalCommentingEnabled;
 
   const [selectedTab, setSelectedTab] = useState<CommentType>('internal');
   const { data: idea } = useIdeaById(postId);
@@ -80,7 +86,7 @@ const CommentsSection = ({
     },
   ];
 
-  if (showInternalComments && isInternalCommentingEnabled) {
+  if (showInternalComments && !isInternalCommentingAllowedAndDisabled) {
     return (
       <Box mt="70px">
         <NavigationTabs>
@@ -114,7 +120,18 @@ const CommentsSection = ({
             </Box>
           )}
           {selectedTab === 'internal' && (
-            <InternalComments postId={postId} className={className} />
+            <>
+              {!isInternalCommentingAllowed && (
+                <Box mt="16px">
+                  <Warning>
+                    {formatMessage(messages.internalCommentingNudgeMessage)}
+                  </Warning>
+                </Box>
+              )}
+              {isInternalCommentingEnabled && (
+                <InternalComments postId={postId} className={className} />
+              )}
+            </>
           )}
         </Box>
       </Box>

--- a/front/app/components/PostShowComponents/Comments/messages.ts
+++ b/front/app/components/PostShowComponents/Comments/messages.ts
@@ -229,6 +229,11 @@ export default defineMessages({
     id: 'app.containers.Comments.visibleToUsersWarning',
     defaultMessage: 'Comments posted here will be visible to regular users.',
   },
+  internalCommentingNudgeMessage: {
+    id: 'app.containers.Comments.internalCommentingNudgeMessage',
+    defaultMessage:
+      'Making internal comments is not included in your current license. Reach out to your GovSuccess Manager to learn more about it.',
+  },
   notVisibleToUsersPlaceholder: {
     id: 'app.containers.Comments.notVisibleToUsersPlaceholder',
     defaultMessage: 'This comment is not visible to regular users',

--- a/front/app/translations/en.json
+++ b/front/app/translations/en.json
@@ -1064,6 +1064,7 @@
   "app.containers.Comments.editComment": "Edit",
   "app.containers.Comments.guidelinesLinkText": "our community guidelines",
   "app.containers.Comments.ideaCommentBodyPlaceholder": "Write your comment here",
+  "app.containers.Comments.internalCommentingNudgeMessage": "Making internal comments is not included in your current license. Reach out to your GovSuccess Manager to learn more about it.",
   "app.containers.Comments.internalConversation": "Internal conversation",
   "app.containers.Comments.loadMoreComments": "Load more comments",
   "app.containers.Comments.loadingComments": "Loading comments...",


### PR DESCRIPTION
# Changelog

## Added
- Add upsell nudge for internal comments. This will be visible to admins who are not commercially allowed to add internal comments
