### PR TITLE
Move portal creation outside of FullscreenModal

### DIFF
--- a/front/app/components/UI/FullscreenModal/index.tsx
+++ b/front/app/components/UI/FullscreenModal/index.tsx
@@ -87,7 +87,6 @@ interface InputProps {
 
 interface Props extends InputProps {
   locale: SupportedLocale;
-  modalPortalElement: HTMLElement;
 }
 
 interface State {
@@ -121,17 +120,10 @@ class FullscreenModal extends PureComponent<Props, State> {
 
   render() {
     const { windowHeight } = this.state;
-    const {
-      children,
-      opened,
-      topBar,
-      bottomBar,
-      className,
-      contentBgColor,
-      modalPortalElement,
-    } = this.props;
+    const { children, opened, topBar, bottomBar, className, contentBgColor } =
+      this.props;
 
-    return createPortal(
+    return (
       <CSSTransition
         classNames="modal"
         in={opened}
@@ -158,8 +150,7 @@ class FullscreenModal extends PureComponent<Props, State> {
             {bottomBar}
           </StyledFocusOn>
         </Container>
-      </CSSTransition>,
-      modalPortalElement
+      </CSSTransition>
     );
   }
 }
@@ -168,11 +159,10 @@ export default (inputProps: InputProps) => {
   const locale = useLocale();
   const modalPortalElement = document.getElementById('modal-portal');
 
-  return modalPortalElement ? (
-    <FullscreenModal
-      {...inputProps}
-      locale={locale}
-      modalPortalElement={modalPortalElement}
-    />
-  ) : null;
+  return modalPortalElement
+    ? createPortal(
+        <FullscreenModal {...inputProps} locale={locale} />,
+        modalPortalElement
+      )
+    : null;
 };


### PR DESCRIPTION
Just a small change to keep `FullscreenModal` compact & focused, and this is how we do it in `Modal` too.