### PR TITLE
useBreakpoint improvement

### DIFF
--- a/front/app/component-library/hooks/useBreakpoint.ts
+++ b/front/app/component-library/hooks/useBreakpoint.ts
@@ -11,23 +11,23 @@ const mediaQueries = {
 type BreakpointType = keyof typeof mediaQueries;
 
 const useBreakpoint = (breakpointType: BreakpointType) => {
-  const [breakpoint, setBreakpoint] = useState(
+  const [matchesBreakpoint, setMatchesBreakpoint] = useState(
     window.matchMedia(mediaQueries[breakpointType]).matches
   );
 
   useEffect(() => {
-    const media = window.matchMedia(mediaQueries[breakpointType]);
-    if (media.matches !== breakpoint) {
-      setBreakpoint(media.matches);
-    }
+    const newMediaQueryList = window.matchMedia(mediaQueries[breakpointType]);
 
-    const listener = () => setBreakpoint(media.matches);
-    media.addEventListener('change', listener);
+    const listener = (e: MediaQueryListEvent) => {
+      setMatchesBreakpoint(e.matches);
+    };
 
-    return () => media.removeEventListener('change', listener);
-  }, [breakpointType, breakpoint]);
+    newMediaQueryList.addEventListener('change', listener);
 
-  return breakpoint;
+    return () => newMediaQueryList.removeEventListener('change', listener);
+  }, [breakpointType]);
+
+  return matchesBreakpoint;
 };
 
 export default useBreakpoint;


### PR DESCRIPTION
Initially, I thought this was causing one of many App re-renders we had a while back (but turns out it wasn't). There was some inefficiency in this code, however, that we can still get out. 

For example, switching between `tablet` and `smallDesktop` viewport width on the homepage results in this effect being called 1-2 times vs. 10 times before.

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Technical
- Remove unnecessary effect re-creation in useBreakpoint hook.