### PR TITLE
Reduce project page jumping because of different loading state heights

### DIFF
--- a/front/app/containers/ProjectsShowPage/index.tsx
+++ b/front/app/containers/ProjectsShowPage/index.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useMemo, useState } from 'react';
 
 import {
   Box,
-  Spinner,
   useBreakpoint,
   media,
   colors,
@@ -29,7 +28,7 @@ import EventsViewer from 'containers/EventsPage/EventsViewer';
 
 import ErrorBoundary from 'components/ErrorBoundary';
 import PageNotFound from 'components/PageNotFound';
-import Centerer from 'components/UI/Centerer';
+import FullPageSpinner from 'components/UI/FullPageSpinner';
 import Unauthorized from 'components/Unauthorized';
 
 import { useIntl } from 'utils/cl-intl';
@@ -122,11 +121,7 @@ const ProjectsShowPage = ({ project }: Props) => {
   let content: JSX.Element | null = null;
 
   if (loading) {
-    content = (
-      <Centerer flex="1 0 auto" height="500px">
-        <Spinner />
-      </Centerer>
-    );
+    content = <FullPageSpinner />;
   } else {
     content = (
       <ContentWrapper id="e2e-project-page">
@@ -218,11 +213,7 @@ const ProjectsShowPageWrapper = () => {
   }, [pending, user]);
 
   if (pending) {
-    return (
-      <Centerer height="500px">
-        <Spinner />
-      </Centerer>
-    );
+    return <FullPageSpinner />;
   }
 
   // TODO: Fix this the next time the file is edited.


### PR DESCRIPTION
Before

https://github.com/user-attachments/assets/413f22d9-2d8a-477f-81dd-4c3d38d45610

After

https://github.com/user-attachments/assets/0cae48b0-d7aa-4bc8-a189-356f8becfcb4

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Changed
- Reduce project page jumping when loading the page by using a full-height loading component. 