### PR TITLE
Bring structure.sql in line with migrations

### DIFF
--- a/back/app/models/phase.rb
+++ b/back/app/models/phase.rb
@@ -44,7 +44,7 @@
 #  expire_days_limit                :integer
 #  reacting_threshold               :integer
 #  prescreening_enabled             :boolean          default(FALSE), not null
-#  autoshare_results_enabled        :boolean          default(TRUE)
+#  autoshare_results_enabled        :boolean          default(TRUE), not null
 #  manual_votes_count               :integer          default(0), not null
 #  manual_voters_amount             :integer
 #  manual_voters_last_updated_by_id :uuid

--- a/back/db/structure.sql
+++ b/back/db/structure.sql
@@ -1192,8 +1192,8 @@ CREATE TABLE public.projects (
     baskets_count integer DEFAULT 0 NOT NULL,
     votes_count integer DEFAULT 0 NOT NULL,
     followers_count integer DEFAULT 0 NOT NULL,
-    header_bg_alt_text_multiloc jsonb DEFAULT '{}'::jsonb,
-    preview_token character varying NOT NULL
+    preview_token character varying NOT NULL,
+    header_bg_alt_text_multiloc jsonb DEFAULT '{}'::jsonb
 );
 
 
@@ -1411,7 +1411,7 @@ CREATE VIEW public.analytics_fact_email_deliveries AS
     (ecd.sent_at)::date AS dimension_date_sent_id,
     ecd.campaign_id,
     p.id AS dimension_project_id,
-    ((ecc.type)::text <> ALL (ARRAY[('EmailCampaigns::Campaigns::Manual'::character varying)::text, ('EmailCampaigns::Campaigns::ManualProjectParticipants'::character varying)::text])) AS automated
+    ((ecc.type)::text <> ALL ((ARRAY['EmailCampaigns::Campaigns::Manual'::character varying, 'EmailCampaigns::Campaigns::ManualProjectParticipants'::character varying])::text[])) AS automated
    FROM ((public.email_campaigns_deliveries ecd
      JOIN public.email_campaigns_campaigns ecc ON ((ecc.id = ecd.campaign_id)))
      LEFT JOIN public.projects p ON ((p.id = ecc.context_id)));
@@ -1623,7 +1623,7 @@ CREATE TABLE public.phases (
     expire_days_limit integer,
     reacting_threshold integer,
     prescreening_enabled boolean DEFAULT false NOT NULL,
-    autoshare_results_enabled boolean DEFAULT true,
+    autoshare_results_enabled boolean DEFAULT true NOT NULL,
     manual_votes_count integer DEFAULT 0 NOT NULL,
     manual_voters_amount integer,
     manual_voters_last_updated_by_id uuid,
@@ -7594,3 +7594,5 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20241105081014'),
 ('20241115141553'),
 ('20241115141717');
+
+


### PR DESCRIPTION
Hey @adessy , I noticed a diff on 2 different branches on structure.sql after having run db:migrate locally, so I suspect this is indeed off on master. Seems related to your recent work, so want to ask whether you can confirm that this is indeed correct?

Edit: Sorry, I think I was wrong, it's probably coming from @sebastienhoorens? Seems linked to voting. 