### PR TITLE
[TAN-3079] Add new PhaseMiniSerialzer and use in ProjectMiniSerializer

### DIFF
--- a/back/app/controllers/web_api/v1/projects_controller.rb
+++ b/back/app/controllers/web_api/v1/projects_controller.rb
@@ -62,7 +62,7 @@ class WebApi::V1::ProjectsController < ApplicationController
     projects = ProjectsFinderService.new(projects, current_user, params).finished_or_archived
 
     @projects = paginate projects
-    @projects = @projects.includes(:project_images, phases: %i[report permissions])
+    @projects = @projects.includes(:project_images, phases: [:report, { permissions: [:groups] }])
 
     authorize @projects, :index_finished_or_archived?
 
@@ -79,7 +79,7 @@ class WebApi::V1::ProjectsController < ApplicationController
     projects = ProjectsFinderService.new(projects, current_user).followed_by_user
 
     @projects = paginate projects
-    @projects = @projects.includes(:project_images, phases: %i[report permissions])
+    @projects = @projects.includes(:project_images, phases: [:report, { permissions: [:groups] }])
 
     authorize @projects, :index_for_followed_item?
 
@@ -96,7 +96,7 @@ class WebApi::V1::ProjectsController < ApplicationController
     projects = projects_and_descriptors[:projects]
 
     @projects = paginate projects
-    @projects = @projects.includes(:project_images, phases: %i[report permissions])
+    @projects = @projects.includes(:project_images, phases: [:report, { permissions: [:groups] }])
 
     authorize @projects, :index_with_active_participatory_phase?
 
@@ -119,7 +119,7 @@ class WebApi::V1::ProjectsController < ApplicationController
       .order(created_at: :desc)
 
     @projects = paginate projects
-    @projects = @projects.includes(:project_images, phases: %i[report permissions])
+    @projects = @projects.includes(:project_images, phases: [:report, { permissions: [:groups] }])
 
     authorize @projects, :index_for_areas?
 
@@ -137,7 +137,7 @@ class WebApi::V1::ProjectsController < ApplicationController
       .order(created_at: :desc)
 
     @projects = paginate projects
-    @projects = @projects.includes(:project_images, phases: %i[report permissions])
+    @projects = @projects.includes(:project_images, phases: [:report, { permissions: [:groups] }])
 
     authorize @projects, :index_for_topics?
 

--- a/back/app/controllers/web_api/v1/projects_controller.rb
+++ b/back/app/controllers/web_api/v1/projects_controller.rb
@@ -62,7 +62,7 @@ class WebApi::V1::ProjectsController < ApplicationController
     projects = ProjectsFinderService.new(projects, current_user, params).finished_or_archived
 
     @projects = paginate projects
-    @projects = @projects.includes(:project_images, :phases)
+    @projects = @projects.includes(:project_images, phases: %i[report permissions])
 
     authorize @projects, :index_finished_or_archived?
 
@@ -79,7 +79,7 @@ class WebApi::V1::ProjectsController < ApplicationController
     projects = ProjectsFinderService.new(projects, current_user).followed_by_user
 
     @projects = paginate projects
-    @projects = @projects.includes(:project_images, :admin_publication, phases: %i[custom_form report permissions])
+    @projects = @projects.includes(:project_images, phases: %i[report permissions])
 
     authorize @projects, :index_for_followed_item?
 
@@ -96,7 +96,7 @@ class WebApi::V1::ProjectsController < ApplicationController
     projects = projects_and_descriptors[:projects]
 
     @projects = paginate projects
-    @projects = @projects.includes(:project_images, :phases)
+    @projects = @projects.includes(:project_images, phases: %i[report permissions])
 
     authorize @projects, :index_with_active_participatory_phase?
 
@@ -119,7 +119,7 @@ class WebApi::V1::ProjectsController < ApplicationController
       .order(created_at: :desc)
 
     @projects = paginate projects
-    @projects = @projects.includes(:project_images, :phases)
+    @projects = @projects.includes(:project_images, phases: %i[report permissions])
 
     authorize @projects, :index_for_areas?
 
@@ -137,7 +137,7 @@ class WebApi::V1::ProjectsController < ApplicationController
       .order(created_at: :desc)
 
     @projects = paginate projects
-    @projects = @projects.includes(:project_images, :phases)
+    @projects = @projects.includes(:project_images, phases: %i[report permissions])
 
     authorize @projects, :index_for_topics?
 

--- a/back/app/serializers/web_api/v1/phase_mini_serializer.rb
+++ b/back/app/serializers/web_api/v1/phase_mini_serializer.rb
@@ -1,12 +1,4 @@
 class WebApi::V1::PhaseMiniSerializer < WebApi::V1::BaseSerializer
-  # So for the new widgets using the light project card, I need the following attributes:
-  #   end_at
-  #   participation_method
-  #   voting_method
-  #   input_term
-  #   native_survey_button_multiloc
-  # Plus the report relationship, which does not need to be included.
-
   attributes :end_at, :participation_method, :input_term
 
   %i[

--- a/back/app/serializers/web_api/v1/phase_mini_serializer.rb
+++ b/back/app/serializers/web_api/v1/phase_mini_serializer.rb
@@ -1,0 +1,22 @@
+class WebApi::V1::PhaseMiniSerializer < WebApi::V1::BaseSerializer
+  # So for the new widgets using the light project card, I need the following attributes:
+  #   end_at
+  #   participation_method
+  #   voting_method
+  #   input_term
+  #   native_survey_button_multiloc
+  # Plus the report relationship, which does not need to be included.
+
+  attributes :end_at, :participation_method, :input_term
+
+  %i[
+    voting_method native_survey_button_multiloc
+  ].each do |attribute_name|
+    attribute attribute_name, if: proc { |phase|
+      phase.pmethod.supports_serializing?(attribute_name)
+    }
+  end
+
+  belongs_to :project
+  has_one :report, serializer: ReportBuilder::WebApi::V1::ReportSerializer
+end

--- a/back/app/serializers/web_api/v1/project_mini_serializer.rb
+++ b/back/app/serializers/web_api/v1/project_mini_serializer.rb
@@ -35,7 +35,7 @@ class WebApi::V1::ProjectMiniSerializer < WebApi::V1::BaseSerializer
 
   has_many :project_images, serializer: WebApi::V1::ImageSerializer
 
-  has_one :current_phase, serializer: WebApi::V1::PhaseSerializer, record_type: :phase do |object|
+  has_one :current_phase, serializer: WebApi::V1::PhaseMiniSerializer, record_type: :phase do |object|
     TimelineService.new.current_phase(object)
   end
 end

--- a/back/spec/acceptance/projects_spec.rb
+++ b/back/spec/acceptance/projects_spec.rb
@@ -1505,7 +1505,7 @@ resource 'Projects' do
       json_response = json_parse(response_body)
 
       current_phase_ids = json_response[:data].filter_map { |d| d.dig(:relationships, :current_phase, :data, :id) }
-      included_phase_ids = json_response[:included].select { |d| d[:type] == 'phase' }.pluck(:id)
+      included_phase_ids = json_response[:included].select { |d| d[:type] == 'phase_mini' }.pluck(:id)
 
       expect(current_phase_ids).to match included_phase_ids
     end

--- a/back/spec/acceptance/projects_spec.rb
+++ b/back/spec/acceptance/projects_spec.rb
@@ -1693,13 +1693,13 @@ resource 'Projects' do
 
     let!(:area1) { create(:area) }
     let!(:area2) { create(:area) }
-    let!(:project_with_areas) { create(:project) }
+    let!(:project_with_areas) { create(:project_with_active_ideation_phase) }
     let!(:_areas_project1) { create(:areas_project, project: project_with_areas, area: area1) }
     let!(:_areas_project2) { create(:areas_project, project: project_with_areas, area: area2) }
 
     let!(:_project_without_area) { create(:project) }
 
-    example_request 'Lists projects for a given area' do
+    example 'Lists projects for a given area' do
       do_request areas: [area1.id]
       expect(status).to eq 200
 


### PR DESCRIPTION
Adds new `PhaseMiniSerialzer` and uses in `ProjectMiniSerializer`.

This is only used, in this PR, by the new homepage projects widgets that return only projects (so, excluding the new selection and legacy replacement widgets)

## Also improves `includes` in new `ProjectsController` actions
Testing locally, including phases permissions groups reduces the n of queries. This is because the `ProjectMiniSerialzer` (like the main `ProjectSerializer`) serializes the action descriptors, which invoke queries of groups permissions for the related phases.
Using:
```
@projects.includes(:project_images, phases: [:report, { permissions: [:groups] }])
```
... reduced the n of queries from 48 to 26, when locally testing the `for_areas` endpoint, when compared to the same includes without `:groups`

We also include the phases report, since we always serialize the relationship with the report (if any) in the `PhaseMiniSerialzer`, though we don't serialize the report itself.

# Changelog
## Technical
- [TAN-3079] Add new `PhaseMiniSerialzer` and use in `ProjectMiniSerializer`
