### PR TITLE
[TAN-3070] BE removes deleted admin publication ids from selection widgets in homepage layout

### DIFF
--- a/back/app/services/project_folders/side_fx_project_folder_service.rb
+++ b/back/app/services/project_folders/side_fx_project_folder_service.rb
@@ -27,8 +27,10 @@ module ProjectFolders
       LogActivityJob.perform_later(folder, 'changed', user, folder.updated_at.to_i, payload: payload)
     end
 
-    def after_destroy(frozen_folder, user)
-      ContentBuilder::LayoutService.new.delete_admin_publication_id_from_homepage_layout(frozen_folder)
+    def after_destroy(frozen_folder, user, children_ids = [])
+      ContentBuilder::LayoutService.new.delete_admin_pub_ids_from_homepage_layout(
+        [frozen_folder.admin_publication.id] + children_ids
+      )
 
       serialized_folder = clean_time_attributes(frozen_folder.attributes)
 

--- a/back/app/services/project_folders/side_fx_project_folder_service.rb
+++ b/back/app/services/project_folders/side_fx_project_folder_service.rb
@@ -28,7 +28,7 @@ module ProjectFolders
     end
 
     def after_destroy(frozen_folder, user)
-      delete_admin_publication_ids_from_homepage_layout(frozen_folder)
+      ContentBuilder::LayoutService.new.delete_admin_publication_id_from_homepage_layout(frozen_folder)
 
       serialized_folder = clean_time_attributes(frozen_folder.attributes)
 
@@ -37,21 +37,6 @@ module ProjectFolders
         user, Time.now.to_i,
         payload: { project_folder: serialized_folder }
       )
-    end
-
-    private
-
-    def delete_admin_publication_ids_from_homepage_layout(folder)
-      homepage_layout = ContentBuilder::Layout.find_by(code: 'homepage')
-      return unless homepage_layout
-
-      homepage_layout.craftjs_json = homepage_layout.craftjs_json.each_value do |node|
-        next unless node['type']['resolvedName'] == 'Selection'
-
-        node['props']['adminPublicationIds'].delete(folder.admin_publication.id)
-      end
-
-      homepage_layout.save!
     end
   end
 end

--- a/back/app/services/side_fx_project_service.rb
+++ b/back/app/services/side_fx_project_service.rb
@@ -62,7 +62,7 @@ class SideFxProjectService
   def before_destroy(project, user); end
 
   def after_destroy(frozen_project, user)
-    delete_admin_publication_ids_from_homepage_layout(frozen_project)
+    ContentBuilder::LayoutService.new.delete_admin_publication_id_from_homepage_layout(frozen_project)
 
     serialized_project = clean_time_attributes(frozen_project.attributes)
 
@@ -108,19 +108,6 @@ class SideFxProjectService
   def after_folder_changed(project, current_user)
     # Defined in core app to eliminate dependency between
     # idea assignment and folder engine.
-  end
-
-  def delete_admin_publication_ids_from_homepage_layout(project)
-    homepage_layout = ContentBuilder::Layout.find_by(code: 'homepage')
-    return unless homepage_layout
-
-    homepage_layout.craftjs_json = homepage_layout.craftjs_json.each_value do |node|
-      next unless node['type']['resolvedName'] == 'Selection'
-
-      node['props']['adminPublicationIds'].delete(project.admin_publication.id)
-    end
-
-    homepage_layout.save!
   end
 end
 

--- a/back/app/services/side_fx_project_service.rb
+++ b/back/app/services/side_fx_project_service.rb
@@ -62,7 +62,7 @@ class SideFxProjectService
   def before_destroy(project, user); end
 
   def after_destroy(frozen_project, user)
-    delete_admin_publication_ids_in_homepage_layout(frozen_project)
+    delete_admin_publication_ids_from_homepage_layout(frozen_project)
 
     serialized_project = clean_time_attributes(frozen_project.attributes)
 
@@ -110,7 +110,7 @@ class SideFxProjectService
     # idea assignment and folder engine.
   end
 
-  def delete_admin_publication_ids_in_homepage_layout(project)
+  def delete_admin_publication_ids_from_homepage_layout(project)
     homepage_layout = ContentBuilder::Layout.find_by(code: 'homepage')
     return unless homepage_layout
 

--- a/back/app/services/side_fx_project_service.rb
+++ b/back/app/services/side_fx_project_service.rb
@@ -62,6 +62,16 @@ class SideFxProjectService
   def before_destroy(project, user); end
 
   def after_destroy(frozen_project, user)
+    homepage_layout = ContentBuilder::Layout.find_by(code: 'homepage')
+
+    homepage_layout.craftjs_json = homepage_layout.craftjs_json.each_value do |node|
+      next unless node['type']['resolvedName'] == 'Selection'
+
+      node['props']['adminPublicationIds'].delete(frozen_project.admin_publication.id)
+    end
+
+    homepage_layout.save!
+
     serialized_project = clean_time_attributes(frozen_project.attributes)
 
     LogActivityJob.perform_later(

--- a/back/app/services/side_fx_project_service.rb
+++ b/back/app/services/side_fx_project_service.rb
@@ -62,7 +62,7 @@ class SideFxProjectService
   def before_destroy(project, user); end
 
   def after_destroy(frozen_project, user)
-    ContentBuilder::LayoutService.new.delete_admin_publication_id_from_homepage_layout(frozen_project)
+    ContentBuilder::LayoutService.new.delete_admin_pub_ids_from_homepage_layout(frozen_project.admin_publication.id)
 
     serialized_project = clean_time_attributes(frozen_project.attributes)
 

--- a/back/app/services/side_fx_project_service.rb
+++ b/back/app/services/side_fx_project_service.rb
@@ -62,15 +62,7 @@ class SideFxProjectService
   def before_destroy(project, user); end
 
   def after_destroy(frozen_project, user)
-    homepage_layout = ContentBuilder::Layout.find_by(code: 'homepage')
-
-    homepage_layout.craftjs_json = homepage_layout.craftjs_json.each_value do |node|
-      next unless node['type']['resolvedName'] == 'Selection'
-
-      node['props']['adminPublicationIds'].delete(frozen_project.admin_publication.id)
-    end
-
-    homepage_layout.save!
+    delete_admin_publication_ids_in_homepage_layout(frozen_project)
 
     serialized_project = clean_time_attributes(frozen_project.attributes)
 
@@ -116,6 +108,19 @@ class SideFxProjectService
   def after_folder_changed(project, current_user)
     # Defined in core app to eliminate dependency between
     # idea assignment and folder engine.
+  end
+
+  def delete_admin_publication_ids_in_homepage_layout(project)
+    homepage_layout = ContentBuilder::Layout.find_by(code: 'homepage')
+    return unless homepage_layout
+
+    homepage_layout.craftjs_json = homepage_layout.craftjs_json.each_value do |node|
+      next unless node['type']['resolvedName'] == 'Selection'
+
+      node['props']['adminPublicationIds'].delete(project.admin_publication.id)
+    end
+
+    homepage_layout.save!
   end
 end
 

--- a/back/engines/commercial/content_builder/app/services/content_builder/layout_service.rb
+++ b/back/engines/commercial/content_builder/app/services/content_builder/layout_service.rb
@@ -12,14 +12,18 @@ module ContentBuilder
       elt.is_a?(Hash) && elt['type'].is_a?(Hash) && types.include?(elt.dig('type', 'resolvedName'))
     end
 
-    def delete_admin_publication_id_from_homepage_layout(publication)
+    def delete_admin_pub_ids_from_homepage_layout(id_or_array_of_ids)
       homepage_layout = ContentBuilder::Layout.find_by(code: 'homepage')
       return unless homepage_layout
+
+      ids = id_or_array_of_ids.is_a?(Array) ? id_or_array_of_ids : [id_or_array_of_ids]
 
       homepage_layout.craftjs_json = homepage_layout.craftjs_json.each_value do |node|
         next unless node['type']['resolvedName'] == 'Selection'
 
-        node['props']['adminPublicationIds'].delete(publication.admin_publication.id)
+        ids.each do |id|
+          node['props']['adminPublicationIds'].delete(id)
+        end
       end
 
       homepage_layout.save!

--- a/back/engines/commercial/content_builder/app/services/content_builder/layout_service.rb
+++ b/back/engines/commercial/content_builder/app/services/content_builder/layout_service.rb
@@ -11,5 +11,18 @@ module ContentBuilder
     def craftjs_element_of_types?(elt, types)
       elt.is_a?(Hash) && elt['type'].is_a?(Hash) && types.include?(elt.dig('type', 'resolvedName'))
     end
+
+    def delete_admin_publication_id_from_homepage_layout(publication)
+      homepage_layout = ContentBuilder::Layout.find_by(code: 'homepage')
+      return unless homepage_layout
+
+      homepage_layout.craftjs_json = homepage_layout.craftjs_json.each_value do |node|
+        next unless node['type']['resolvedName'] == 'Selection'
+
+        node['props']['adminPublicationIds'].delete(publication.admin_publication.id)
+      end
+
+      homepage_layout.save!
+    end
   end
 end

--- a/back/engines/commercial/content_builder/app/services/content_builder/layout_service.rb
+++ b/back/engines/commercial/content_builder/app/services/content_builder/layout_service.rb
@@ -21,9 +21,7 @@ module ContentBuilder
       homepage_layout.craftjs_json = homepage_layout.craftjs_json.each_value do |node|
         next unless node['type']['resolvedName'] == 'Selection'
 
-        ids.each do |id|
-          node['props']['adminPublicationIds'].delete(id)
-        end
+        ids.each { |id| node['props']['adminPublicationIds'].delete(id) }
       end
 
       homepage_layout.save!

--- a/back/engines/commercial/content_builder/spec/services/content_builder/layout_service_spec.rb
+++ b/back/engines/commercial/content_builder/spec/services/content_builder/layout_service_spec.rb
@@ -121,7 +121,7 @@ describe ContentBuilder::LayoutService do
     let!(:layout) { create(:homepage_layout, craftjs_json: craftjs) }
 
     it 'deletes an admin_publication id from the homepage layout craftjs_json' do
-      service.delete_admin_publication_id_from_homepage_layout project1
+      service.delete_admin_pub_ids_from_homepage_layout project1.admin_publication.id
 
       expect(layout.reload.craftjs_json['nUOW77iNcW']['props']['adminPublicationIds'])
         .to match_array [project2.admin_publication.id, project_folder.admin_publication.id]

--- a/back/engines/commercial/content_builder/spec/services/content_builder/layout_service_spec.rb
+++ b/back/engines/commercial/content_builder/spec/services/content_builder/layout_service_spec.rb
@@ -65,68 +65,26 @@ describe ContentBuilder::LayoutService do
           isCanvas: false,
           displayName: 'Selection',
           linkedNodes: {}
-        },
-        PROJECTS: {
-          type: {
-            resolvedName: 'Projects'
-          },
-          nodes: [],
-          props: {
-            currentlyWorkingOnText: {
-              en: '',
-              'fr-BE': '',
-              'nl-BE': ''
-            }
-          },
-          custom: {
-            title: {
-              id: 'app.containers.Admin.pagesAndMenu.containers.ContentBuilder.components.CraftComponents.Projects.projectsTitle',
-              defaultMessage: 'Projects'
-            },
-            noDelete: true,
-            noPointerEvents: true
-          },
-          hidden: false,
-          parent: 'ROOT',
-          isCanvas: false,
-          displayName: 'Projects',
-          linkedNodes: {}
-        },
-        x08l42oNsD: {
-          type: {
-            resolvedName: 'Selection'
-          },
-          nodes: [],
-          props: {
-            titleMultiloc: {
-              en: 'Projects and folders',
-              'fr-BE': 'Projects and folders',
-              'nl-BE': 'Projects and folders'
-            },
-            adminPublicationIds: [
-              project1.admin_publication.id,
-              project_folder.admin_publication.id
-            ]
-          },
-          custom: {},
-          hidden: false,
-          parent: 'ROOT',
-          isCanvas: false,
-          displayName: 'Selection',
-          linkedNodes: {}
         }
       }
     end
 
     let!(:layout) { create(:homepage_layout, craftjs_json: craftjs) }
 
-    it 'deletes an admin_publication id from the homepage layout craftjs_json' do
+    it 'deletes a single admin_publication ID from the homepage layout craftjs_json' do
       service.delete_admin_pub_ids_from_homepage_layout project1.admin_publication.id
 
       expect(layout.reload.craftjs_json['nUOW77iNcW']['props']['adminPublicationIds'])
         .to match_array [project2.admin_publication.id, project_folder.admin_publication.id]
-      expect(layout.reload.craftjs_json['x08l42oNsD']['props']['adminPublicationIds'])
-        .to eq([project_folder.admin_publication.id])
+    end
+
+    it 'deletes multiple admin_publication IDs from the homepage layout craftjs_json' do
+      service.delete_admin_pub_ids_from_homepage_layout(
+        [project1.admin_publication.id, project_folder.admin_publication.id]
+      )
+
+      expect(layout.reload.craftjs_json['nUOW77iNcW']['props']['adminPublicationIds'])
+        .to match_array [project2.admin_publication.id]
     end
   end
 end

--- a/back/engines/commercial/content_builder/spec/services/content_builder/layout_service_spec.rb
+++ b/back/engines/commercial/content_builder/spec/services/content_builder/layout_service_spec.rb
@@ -20,4 +20,113 @@ describe ContentBuilder::LayoutService do
       ]
     end
   end
+
+  describe 'delete_admin_publication_id_from_homepage_layout' do
+    let(:project1) { create(:project) }
+    let(:project2) { create(:project) }
+    let(:project_folder) { create(:project_folder) }
+
+    let(:craftjs) do
+      {
+        ROOT: {
+          type: 'div',
+          nodes: %w[
+            nUOW77iNcW
+          ],
+          props: {
+            id: 'e2e-content-builder-frame'
+          },
+          custom: {},
+          hidden: false,
+          isCanvas: true,
+          displayName: 'div',
+          linkedNodes: {}
+        },
+        nUOW77iNcW: {
+          type: {
+            resolvedName: 'Selection'
+          },
+          nodes: [],
+          props: {
+            titleMultiloc: {
+              en: 'Projects and folders',
+              'fr-BE': 'Projects and folders',
+              'nl-BE': 'Projects and folders'
+            },
+            adminPublicationIds: [
+              project2.admin_publication.id,
+              project1.admin_publication.id,
+              project_folder.admin_publication.id
+            ]
+          },
+          custom: {},
+          hidden: false,
+          parent: 'ROOT',
+          isCanvas: false,
+          displayName: 'Selection',
+          linkedNodes: {}
+        },
+        PROJECTS: {
+          type: {
+            resolvedName: 'Projects'
+          },
+          nodes: [],
+          props: {
+            currentlyWorkingOnText: {
+              en: '',
+              'fr-BE': '',
+              'nl-BE': ''
+            }
+          },
+          custom: {
+            title: {
+              id: 'app.containers.Admin.pagesAndMenu.containers.ContentBuilder.components.CraftComponents.Projects.projectsTitle',
+              defaultMessage: 'Projects'
+            },
+            noDelete: true,
+            noPointerEvents: true
+          },
+          hidden: false,
+          parent: 'ROOT',
+          isCanvas: false,
+          displayName: 'Projects',
+          linkedNodes: {}
+        },
+        x08l42oNsD: {
+          type: {
+            resolvedName: 'Selection'
+          },
+          nodes: [],
+          props: {
+            titleMultiloc: {
+              en: 'Projects and folders',
+              'fr-BE': 'Projects and folders',
+              'nl-BE': 'Projects and folders'
+            },
+            adminPublicationIds: [
+              project1.admin_publication.id,
+              project_folder.admin_publication.id
+            ]
+          },
+          custom: {},
+          hidden: false,
+          parent: 'ROOT',
+          isCanvas: false,
+          displayName: 'Selection',
+          linkedNodes: {}
+        }
+      }
+    end
+
+    let!(:layout) { create(:homepage_layout, craftjs_json: craftjs) }
+
+    it 'deletes an admin_publication id from the homepage layout craftjs_json' do
+      service.delete_admin_publication_id_from_homepage_layout project1
+
+      expect(layout.reload.craftjs_json['nUOW77iNcW']['props']['adminPublicationIds'])
+        .to match_array [project2.admin_publication.id, project_folder.admin_publication.id]
+      expect(layout.reload.craftjs_json['x08l42oNsD']['props']['adminPublicationIds'])
+        .to eq([project_folder.admin_publication.id])
+    end
+  end
 end

--- a/back/spec/services/project_folders/side_fx_project_folder_service_spec.rb
+++ b/back/spec/services/project_folders/side_fx_project_folder_service_spec.rb
@@ -60,5 +60,111 @@ describe ProjectFolders::SideFxProjectFolderService do
           .to enqueue_job(LogActivityJob).exactly(1).times
       end
     end
+
+    it "removes the folder's admin_publication ID from homepage layout craftJSON" do
+      project_folder2 = create(:project_folder)
+      project = create(:project)
+
+      layout = create(
+        :homepage_layout,
+        craftjs_json: {
+          ROOT: {
+            type: 'div',
+            nodes: %w[
+              nUOW77iNcW
+            ],
+            props: {
+              id: 'e2e-content-builder-frame'
+            },
+            custom: {},
+            hidden: false,
+            isCanvas: true,
+            displayName: 'div',
+            linkedNodes: {}
+          },
+          nUOW77iNcW: {
+            type: {
+              resolvedName: 'Selection'
+            },
+            nodes: [],
+            props: {
+              titleMultiloc: {
+                en: 'Projects and folders',
+                'fr-BE': 'Projects and folders',
+                'nl-BE': 'Projects and folders'
+              },
+              adminPublicationIds: [
+                project_folder2.admin_publication.id,
+                project.admin_publication.id,
+                project_folder.admin_publication.id
+              ]
+            },
+            custom: {},
+            hidden: false,
+            parent: 'ROOT',
+            isCanvas: false,
+            displayName: 'Selection',
+            linkedNodes: {}
+          },
+          PROJECTS: {
+            type: {
+              resolvedName: 'Projects'
+            },
+            nodes: [],
+            props: {
+              currentlyWorkingOnText: {
+                en: '',
+                'fr-BE': '',
+                'nl-BE': ''
+              }
+            },
+            custom: {
+              title: {
+                id: 'app.containers.Admin.pagesAndMenu.containers.ContentBuilder.components.CraftComponents.Projects.projectsTitle',
+                defaultMessage: 'Projects'
+              },
+              noDelete: true,
+              noPointerEvents: true
+            },
+            hidden: false,
+            parent: 'ROOT',
+            isCanvas: false,
+            displayName: 'Projects',
+            linkedNodes: {}
+          },
+          x08l42oNsD: {
+            type: {
+              resolvedName: 'Selection'
+            },
+            nodes: [],
+            props: {
+              titleMultiloc: {
+                en: 'Projects and folders',
+                'fr-BE': 'Projects and folders',
+                'nl-BE': 'Projects and folders'
+              },
+              adminPublicationIds: [
+                project.admin_publication.id,
+                project_folder.admin_publication.id
+              ]
+            },
+            custom: {},
+            hidden: false,
+            parent: 'ROOT',
+            isCanvas: false,
+            displayName: 'Selection',
+            linkedNodes: {}
+          }
+        }
+      )
+
+      frozen_folder = project_folder.destroy
+      service.after_destroy(frozen_folder, user)
+
+      expect(layout.reload.craftjs_json['nUOW77iNcW']['props']['adminPublicationIds'])
+        .to match_array [project.admin_publication.id, project_folder2.admin_publication.id]
+      expect(layout.reload.craftjs_json['x08l42oNsD']['props']['adminPublicationIds'])
+        .to eq([project.admin_publication.id])
+    end
   end
 end

--- a/back/spec/services/project_folders/side_fx_project_folder_service_spec.rb
+++ b/back/spec/services/project_folders/side_fx_project_folder_service_spec.rb
@@ -166,5 +166,66 @@ describe ProjectFolders::SideFxProjectFolderService do
       expect(layout.reload.craftjs_json['x08l42oNsD']['props']['adminPublicationIds'])
         .to eq([project.admin_publication.id])
     end
+
+    it "removes the specified folder's children's admin_publication IDs from homepage layout craftJSON" do
+      project1 = create(:project, admin_publication_attributes: { parent_id: project_folder.admin_publication.id })
+      project2 = create(:project, admin_publication_attributes: { parent_id: project_folder.admin_publication.id })
+
+      project_folder2 = create(:project_folder)
+      project3 = create(:project, admin_publication_attributes: { parent_id: project_folder2.admin_publication.id })
+
+      layout = create(
+        :homepage_layout,
+        craftjs_json: {
+          ROOT: {
+            type: 'div',
+            nodes: %w[
+              nUOW77iNcW
+            ],
+            props: {
+              id: 'e2e-content-builder-frame'
+            },
+            custom: {},
+            hidden: false,
+            isCanvas: true,
+            displayName: 'div',
+            linkedNodes: {}
+          },
+          nUOW77iNcW: {
+            type: {
+              resolvedName: 'Selection'
+            },
+            nodes: [],
+            props: {
+              titleMultiloc: {
+                en: 'Projects and folders',
+                'fr-BE': 'Projects and folders',
+                'nl-BE': 'Projects and folders'
+              },
+              adminPublicationIds: [
+                project_folder.admin_publication.id,
+                project1.admin_publication.id,
+                project2.admin_publication.id,
+                project_folder2.admin_publication.id,
+                project3.admin_publication.id
+              ]
+            },
+            custom: {},
+            hidden: false,
+            parent: 'ROOT',
+            isCanvas: false,
+            displayName: 'Selection',
+            linkedNodes: {}
+          }
+        }
+      )
+
+      children_ids = project_folder.admin_publication.children.pluck(:id)
+      frozen_folder = project_folder.destroy
+      service.after_destroy(frozen_folder, user, children_ids)
+
+      expect(layout.reload.craftjs_json['nUOW77iNcW']['props']['adminPublicationIds'])
+        .to match_array [project_folder2.admin_publication.id, project3.admin_publication.id]
+    end
   end
 end

--- a/back/spec/services/side_fx_project_service_spec.rb
+++ b/back/spec/services/side_fx_project_service_spec.rb
@@ -102,9 +102,9 @@ describe SideFxProjectService do
       end
     end
 
-    it "removes the project's admin_publication ID from homepage selection widget craftJSON" do
+    it "removes the project's admin_publication ID from homepage layout craftJSON" do
       project2 = create(:project)
-      project3 = create(:project)
+      project_folder = create(:project_folder)
 
       layout = create(
         :homepage_layout,
@@ -135,9 +135,9 @@ describe SideFxProjectService do
                 'nl-BE': 'Projects and folders'
               },
               adminPublicationIds: [
-                project3.admin_publication.id,
+                project2.admin_publication.id,
                 project.admin_publication.id,
-                project2.admin_publication.id
+                project_folder.admin_publication.id
               ]
             },
             custom: {},
@@ -203,7 +203,7 @@ describe SideFxProjectService do
       service.after_destroy(frozen_project, user)
 
       expect(layout.reload.craftjs_json['nUOW77iNcW']['props']['adminPublicationIds'])
-        .to match_array [project3.admin_publication.id, project2.admin_publication.id]
+        .to match_array [project_folder.admin_publication.id, project2.admin_publication.id]
       expect(layout.reload.craftjs_json['x08l42oNsD']['props']['adminPublicationIds'])
         .to eq([project2.admin_publication.id])
     end

--- a/back/spec/services/side_fx_project_service_spec.rb
+++ b/back/spec/services/side_fx_project_service_spec.rb
@@ -101,6 +101,112 @@ describe SideFxProjectService do
           .to have_enqueued_job(LogActivityJob)
       end
     end
+
+    it "removes the project's admin_publication ID from homepage selection widget craftJSON" do
+      project2 = create(:project)
+      project3 = create(:project)
+
+      layout = create(
+        :homepage_layout,
+        craftjs_json: {
+          ROOT: {
+            type: 'div',
+            nodes: %w[
+              nUOW77iNcW
+            ],
+            props: {
+              id: 'e2e-content-builder-frame'
+            },
+            custom: {},
+            hidden: false,
+            isCanvas: true,
+            displayName: 'div',
+            linkedNodes: {}
+          },
+          nUOW77iNcW: {
+            type: {
+              resolvedName: 'Selection'
+            },
+            nodes: [],
+            props: {
+              titleMultiloc: {
+                en: 'Projects and folders',
+                'fr-BE': 'Projects and folders',
+                'nl-BE': 'Projects and folders'
+              },
+              adminPublicationIds: [
+                project3.admin_publication.id,
+                project.admin_publication.id,
+                project2.admin_publication.id
+              ]
+            },
+            custom: {},
+            hidden: false,
+            parent: 'ROOT',
+            isCanvas: false,
+            displayName: 'Selection',
+            linkedNodes: {}
+          },
+          PROJECTS: {
+            type: {
+              resolvedName: 'Projects'
+            },
+            nodes: [],
+            props: {
+              currentlyWorkingOnText: {
+                en: '',
+                'fr-BE': '',
+                'nl-BE': ''
+              }
+            },
+            custom: {
+              title: {
+                id: 'app.containers.Admin.pagesAndMenu.containers.ContentBuilder.components.CraftComponents.Projects.projectsTitle',
+                defaultMessage: 'Projects'
+              },
+              noDelete: true,
+              noPointerEvents: true
+            },
+            hidden: false,
+            parent: 'ROOT',
+            isCanvas: false,
+            displayName: 'Projects',
+            linkedNodes: {}
+          },
+          x08l42oNsD: {
+            type: {
+              resolvedName: 'Selection'
+            },
+            nodes: [],
+            props: {
+              titleMultiloc: {
+                en: 'Projects and folders',
+                'fr-BE': 'Projects and folders',
+                'nl-BE': 'Projects and folders'
+              },
+              adminPublicationIds: [
+                project.admin_publication.id,
+                project2.admin_publication.id
+              ]
+            },
+            custom: {},
+            hidden: false,
+            parent: 'ROOT',
+            isCanvas: false,
+            displayName: 'Selection',
+            linkedNodes: {}
+          }
+        }
+      )
+
+      frozen_project = project.destroy
+      service.after_destroy(frozen_project, user)
+
+      expect(layout.reload.craftjs_json['nUOW77iNcW']['props']['adminPublicationIds'])
+        .to match_array [project3.admin_publication.id, project2.admin_publication.id]
+      expect(layout.reload.craftjs_json['x08l42oNsD']['props']['adminPublicationIds'])
+        .to eq([project2.admin_publication.id])
+    end
   end
 
   describe 'after_delete_inputs' do


### PR DESCRIPTION
# Changelog
## Technical
- [TAN-3070] Remove deleted admin publication ids from selection widgets in homepage layout (feature in development)
