### PR TITLE
TAN-3003: Remove styled wrapper from QuillEditedContent in InfoSection component

### DIFF
--- a/front/app/components/LandingPages/citizen/InfoSection.tsx
+++ b/front/app/components/LandingPages/citizen/InfoSection.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { colors, media, fontSizes } from '@citizenlab/cl2-component-library';
+import { media } from '@citizenlab/cl2-component-library';
 import styled from 'styled-components';
 import { Multiloc } from 'typings';
 
@@ -11,20 +11,6 @@ import T from 'components/T';
 import QuillEditedContent from 'components/UI/QuillEditedContent';
 
 import { isEmptyMultiloc } from 'utils/helperUtils';
-
-const StyledQuillEditedContent = styled(QuillEditedContent)`
-  h1,
-  h2 {
-    font-weight: 500;
-    color: ${(props) => props.theme.colors.tenantText};
-    font-size: ${fontSizes.xl}px;
-  }
-
-  p,
-  li {
-    color: ${colors.textSecondary};
-  }
-`;
 
 const StyledContentContainer = styled(ContentContainer)`
   width: 100%;
@@ -67,13 +53,13 @@ const InfoSection = ({ multilocContent, fragmentName }: Props) => {
 
   return (
     <StyledContentContainer>
-      <StyledQuillEditedContent>
+      <QuillEditedContent>
         {fragmentName ? (
           <Fragment name={fragmentName}>{pageContent}</Fragment>
         ) : (
           pageContent
         )}
-      </StyledQuillEditedContent>
+      </QuillEditedContent>
     </StyledContentContainer>
   );
 };


### PR DESCRIPTION
# Changelog

## Fixed
- Display consistent style in custom pages content and page descriptions created with the quill editor. Information in the custom page will look the same way it looks like when set in the back office
