### PR TITLE
[TAN-3142] Create Activity record when geojson generated for export of mapping q responses

### DIFF
--- a/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
+++ b/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
@@ -58,6 +58,8 @@ module IdeaCustomFields
         geojson_generator.generate_geojson
       end
 
+      SideFxIdeaCustomFieldService.new.after_generate_geojson(@custom_field, current_user) if geojson.present?
+
       send_data geojson, type: 'application/json', filename: geojson_generator.filename
     end
 

--- a/back/engines/commercial/idea_custom_fields/app/services/side_fx_idea_custom_field_service.rb
+++ b/back/engines/commercial/idea_custom_fields/app/services/side_fx_idea_custom_field_service.rb
@@ -1,0 +1,12 @@
+class SideFxIdeaCustomFieldService
+  include SideFxHelper
+
+  def after_generate_geojson(custom_field, current_user)
+    LogActivityJob.perform_later(
+      custom_field,
+      'generated_geojson_for_export',
+      current_user,
+      Time.zone.now.to_i
+    )
+  end
+end

--- a/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/as_geojson_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/as_geojson_spec.rb
@@ -266,6 +266,12 @@ resource 'Idea Custom Fields' do
         ])
       end
 
+      example 'Generate GeoJSON request logs an activity job when GeoJSON successfully generated' do
+        expect { do_request }.to enqueue_job(LogActivityJob)
+          .with(custom_field_point, 'generated_geojson_for_export', any_args)
+          .exactly(1).times
+      end
+
       context 'when custom field is not a geographic input type' do
         let(:custom_field_id) { custom_field_text.id }
 


### PR DESCRIPTION
Needed to track usage of this feature.

# Changelog
## Technical
- [TAN-3142] Create Activity record when geojson generated for export of mapping q responses
