### PR TITLE
[TAN-3146] Bugfix: Do not include projects with invisible report in last phase in Finished projects homepage widget

### DIFF
--- a/back/app/services/projects_finder_service.rb
+++ b/back/app/services/projects_finder_service.rb
@@ -124,8 +124,9 @@ class ProjectsFinderService
       finished_scope = base_scope.where(admin_publications: { publication_status: 'published' })
       finished_scope = joins_last_phases_with_reports(finished_scope)
         .where(
-          '(last_phases.last_phase_end_at < ? OR reports.id IS NOT NULL) AND admin_publications.publication_status = ?',
-          Time.zone.now, 'published'
+          '(last_phases.last_phase_end_at < ? OR (reports.id IS NOT NULL AND reports.visible = true))' \
+          "AND admin_publications.publication_status = 'published'",
+          Time.zone.now
         )
     end
 

--- a/back/spec/acceptance/projects_mini_spec.rb
+++ b/back/spec/acceptance/projects_mini_spec.rb
@@ -4,7 +4,7 @@ require 'rspec_api_documentation/dsl'
 # A somewhat arbitrary choice to put specs related to projects actions that make use of the ProjectMiniSerializer
 # in this file, mainly to reduce the n of tests in the projects_spec.rb file.
 
-resource 'Projects' do
+resource 'ProjectsMini' do # == Projects, but labeled as Mini, to help differentiate when/if tests fail
   explanation 'Projects can have phases which can be of different participation methods.'
 
   before do
@@ -233,7 +233,7 @@ resource 'Projects' do
       let!(:_unfinished_project1) { create(:project_with_active_ideation_phase) }
       let!(:unfinished_project2) { create(:project) }
       let!(:phase) { create(:phase, project: unfinished_project2, start_at: 2.days.ago, end_at: 2.days.from_now) }
-      let!(:_report) { create(:report, phase: phase) }
+      let!(:_report) { create(:report, phase: phase, visible: true) }
 
       example 'Lists only projects with all phases finished or with a report in the last phase' do
         do_request filter_by: 'finished'
@@ -297,7 +297,7 @@ resource 'Projects' do
       let!(:_unfinished_project1) { create(:project_with_active_ideation_phase) } # we do not expect this one
       let!(:unfinished_project2) { create(:project) }
       let!(:phase) { create(:phase, project: unfinished_project2, start_at: 2.days.ago, end_at: 2.days.from_now) }
-      let!(:_report) { create(:report, phase: phase) }
+      let!(:_report) { create(:report, phase: phase, visible: true) }
 
       example 'Lists (published projects with phases finished OR with a report in last phase) OR archived projects' do
         do_request({ filter_by: 'finished_and_archived' })

--- a/back/spec/acceptance/projects_mini_spec.rb
+++ b/back/spec/acceptance/projects_mini_spec.rb
@@ -4,7 +4,7 @@ require 'rspec_api_documentation/dsl'
 # A somewhat arbitrary choice to put specs related to projects actions that make use of the ProjectMiniSerializer
 # in this file, mainly to reduce the n of tests in the projects_spec.rb file.
 
-resource 'ProjectsMini' do # == Projects, but labeled as Mini, to help differentiate when/if tests fail
+resource 'ProjectsMini' do # == Projects, but labeled as ProjecctsMini, to help differentiate when/if tests fail
   explanation 'Projects can have phases which can be of different participation methods.'
 
   before do

--- a/back/spec/acceptance/projects_mini_spec.rb
+++ b/back/spec/acceptance/projects_mini_spec.rb
@@ -4,7 +4,7 @@ require 'rspec_api_documentation/dsl'
 # A somewhat arbitrary choice to put specs related to projects actions that make use of the ProjectMiniSerializer
 # in this file, mainly to reduce the n of tests in the projects_spec.rb file.
 
-resource 'ProjectsMini' do # == Projects, but labeled as ProjecctsMini, to help differentiate when/if tests fail
+resource 'ProjectsMini' do # == Projects, but labeled as ProjectsMini, to help differentiate when/if tests fail
   explanation 'Projects can have phases which can be of different participation methods.'
 
   before do

--- a/back/spec/services/projects_finder_service_spec.rb
+++ b/back/spec/services/projects_finder_service_spec.rb
@@ -250,7 +250,7 @@ describe ProjectsFinderService do
         expect(result).to match_array([finished_project1, unfinished_project2])
       end
 
-      it 'excludes unfinished projects with a last phase that contains a invisible report' do
+      it 'excludes unfinished projects with a last phase that contains an invisible report' do
         unfinished_project2 = create(:project)
         create(:phase, project: unfinished_project2, start_at: 2.days.ago, end_at: 2.days.from_now)
         create(:report, phase: unfinished_project2.phases.last, visible: false)

--- a/back/spec/services/projects_finder_service_spec.rb
+++ b/back/spec/services/projects_finder_service_spec.rb
@@ -241,29 +241,38 @@ describe ProjectsFinderService do
         expect(result).to eq [finished_project1]
       end
 
-      it 'includes unfinished projects with a last phase that contains a report' do
+      it 'includes unfinished projects with a last phase that contains a visible report' do
         unfinished_project2 = create(:project)
         create(:phase, project: unfinished_project2, start_at: 2.days.ago, end_at: 2.days.from_now)
-        create(:report, phase: unfinished_project2.phases.last)
+        create(:report, phase: unfinished_project2.phases.last, visible: true)
 
         expect(Project.count).to eq 3
         expect(result).to match_array([finished_project1, unfinished_project2])
       end
 
-      it 'excludes unfinished projects with a phase containing a report that is not the final phase' do
+      it 'excludes unfinished projects with a last phase that contains a invisible report' do
         unfinished_project2 = create(:project)
-        phase1 = create(:phase, project: unfinished_project2, start_at: 3.days.ago, end_at: 2.days.ago)
-        _phase2 = create(:phase, project: unfinished_project2, start_at: 1.day.ago, end_at: 1.day.from_now)
-        create(:report, phase: phase1)
+        create(:phase, project: unfinished_project2, start_at: 2.days.ago, end_at: 2.days.from_now)
+        create(:report, phase: unfinished_project2.phases.last, visible: false)
 
         expect(Project.count).to eq 3
         expect(result).to match_array([finished_project1])
       end
 
-      it 'inludes projects with an endless last phase & report in last phase' do
+      it 'excludes unfinished projects with a phase containing a visible report that is not the final phase' do
+        unfinished_project2 = create(:project)
+        phase1 = create(:phase, project: unfinished_project2, start_at: 3.days.ago, end_at: 2.days.ago)
+        _phase2 = create(:phase, project: unfinished_project2, start_at: 1.day.ago, end_at: 1.day.from_now)
+        create(:report, phase: phase1, visible: true)
+
+        expect(Project.count).to eq 3
+        expect(result).to match_array([finished_project1])
+      end
+
+      it 'inludes projects with an endless last phase & visible report in last phase' do
         endless_project = create(:project)
         create(:phase, project: endless_project, start_at: 2.days.ago, end_at: nil)
-        create(:report, phase: endless_project.phases.last)
+        create(:report, phase: endless_project.phases.last, visible: true)
 
         expect(Project.count).to eq 3
         expect(result).to match_array([endless_project, finished_project1])
@@ -287,7 +296,7 @@ describe ProjectsFinderService do
       it 'lists projects ordered by last phase end_at DESC' do
         endless_project = create(:project)
         create(:phase, project: endless_project, start_at: 2.days.ago, end_at: nil)
-        create(:report, phase: endless_project.phases.last)
+        create(:report, phase: endless_project.phases.last, visible: true)
 
         finished_project2 = create(:project_with_two_past_ideation_phases)
         finished_project2.phases[1].update!(end_at: 5.days.ago)
@@ -356,7 +365,7 @@ describe ProjectsFinderService do
       # Should include `finished_project1` and:
       let!(:unfinished_project1) { create(:project) }
       let!(:phase) { create(:phase, project: unfinished_project1, start_at: 2.days.ago, end_at: 2.days.from_now) }
-      let!(:_report1) { create(:report, phase: phase) }
+      let!(:_report1) { create(:report, phase: phase, visible: true) }
 
       let!(:archived_project) do
         create(:project_with_past_information_phase, admin_publication_attributes: { publication_status: 'archived' })
@@ -381,7 +390,7 @@ describe ProjectsFinderService do
       it 'lists projects ordered by last phase end_at DESC (Nulls first)' do
         endless_project = create(:project)
         create(:phase, project: endless_project, start_at: 2.days.ago, end_at: nil)
-        create(:report, phase: endless_project.phases.last)
+        create(:report, phase: endless_project.phases.last, visible: true)
 
         finished_project1.phases[1].update!(end_at: 3.days.ago)
         archived_project.phases[0].update!(end_at: 5.days.ago)


### PR DESCRIPTION
Do not include projects with _invisible_ report in last phase in Finished projects homepage widget

# Changelog
## Technical
- [TAN-3146] Bugfix: Do not include projects with _invisible_ report in last phase in Finished projects homepage widget (feature in development)
