### PR TITLE
Add result count all ideas page

### DIFF
--- a/front/app/components/IdeaCards/IdeasWithFiltersSidebar/index.tsx
+++ b/front/app/components/IdeaCards/IdeasWithFiltersSidebar/index.tsx
@@ -232,13 +232,11 @@ const IdeasWithFiltersSidebar = ({
             })}
           </Title>
         ) : (
-          <Box ml="auto">
-            <Text m="0px">
-              {formatMessage(messages.numberResults, {
-                postCount: list ? list.length : 0,
-              })}
-            </Text>
-          </Box>
+          <Text m="0px">
+            {formatMessage(messages.numberResults, {
+              postCount: list ? list.length : 0,
+            })}
+          </Text>
         )}
 
         {showViewButtons && (

--- a/front/app/components/IdeaCards/IdeasWithFiltersSidebar/index.tsx
+++ b/front/app/components/IdeaCards/IdeasWithFiltersSidebar/index.tsx
@@ -233,7 +233,7 @@ const IdeasWithFiltersSidebar = ({
           </Title>
         ) : (
           <Box ml="auto">
-            <Text>
+            <Text m="0px">
               {formatMessage(messages.numberResults, {
                 postCount: list ? list.length : 0,
               })}

--- a/front/app/components/IdeaCards/IdeasWithFiltersSidebar/index.tsx
+++ b/front/app/components/IdeaCards/IdeasWithFiltersSidebar/index.tsx
@@ -8,6 +8,7 @@ import {
   useWindowSize,
   Box,
   Title,
+  Text,
 } from '@citizenlab/cl2-component-library';
 import { useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
@@ -211,7 +212,7 @@ const IdeasWithFiltersSidebar = ({
   return (
     <Container id="e2e-ideas-container">
       <Box display="flex" justifyContent="space-between" mb="8px">
-        {inputTerm && (
+        {inputTerm ? (
           <Title variant="h4" as="h2" mt="auto" mb="auto" color="tenantText">
             {formatMessage(messages.ideasFilterSidebarTitle, {
               numberIdeas: list ? list.length : 0,
@@ -230,6 +231,14 @@ const IdeasWithFiltersSidebar = ({
               ),
             })}
           </Title>
+        ) : (
+          <Box ml="auto">
+            <Text>
+              {formatMessage(messages.numberResults, {
+                postCount: list ? list.length : 0,
+              })}
+            </Text>
+          </Box>
         )}
 
         {showViewButtons && (

--- a/front/app/components/IdeaCards/messages.ts
+++ b/front/app/components/IdeaCards/messages.ts
@@ -15,6 +15,10 @@ export default defineMessages({
     defaultMessage:
       'No results found. Please try a different filter or search term.',
   },
+  numberResults: {
+    id: 'app.containers.IdeaCards.numberResults',
+    defaultMessage: 'Results ({postCount})',
+  },
   ideasFilterSidebarTitle: {
     id: 'app.containers.IdeaCards.ideasFilterSidebarTitle',
     defaultMessage: '{inputTerm} ({numberIdeas})',

--- a/front/app/translations/en.json
+++ b/front/app/translations/en.json
@@ -1175,6 +1175,7 @@
   "app.containers.IdeaCards.mostDiscussed": "Most discussed",
   "app.containers.IdeaCards.newest": "Most recent",
   "app.containers.IdeaCards.noFilteredResults": "No results found. Please try a different filter or search term.",
+  "app.containers.IdeaCards.numberResults": "Results ({postCount})",
   "app.containers.IdeaCards.oldest": "Oldest",
   "app.containers.IdeaCards.optionTerm": "Options",
   "app.containers.IdeaCards.petitions": "Petitions",


### PR DESCRIPTION
Adds the result count to the UI when there isn't an input term ([before](https://github.com/user-attachments/assets/23010224-9972-4004-9ed6-cb420d72ba0f)/[after](https://github.com/user-attachments/assets/b0fc70f0-3d8e-4fc5-bcf9-c811cad7b7e6)).