### PR TITLE
[TAN-2985] Replace 'approved' attribute with 'state' attribute

### DIFF
--- a/back/app/models/project_review.rb
+++ b/back/app/models/project_review.rb
@@ -37,6 +37,10 @@ class ProjectReview < ApplicationRecord
     approved_at.present?
   end
 
+  def state
+    approved? ? 'approved' : 'pending'
+  end
+
   # @param [User] reviewer
   def approve!(reviewer)
     approve(reviewer)

--- a/back/app/serializers/web_api/v1/project_review_serializer.rb
+++ b/back/app/serializers/web_api/v1/project_review_serializer.rb
@@ -2,12 +2,11 @@
 
 class WebApi::V1::ProjectReviewSerializer < WebApi::V1::BaseSerializer
   attributes(
+    :state,
     :approved_at,
     :created_at,
     :updated_at
   )
-
-  attribute :approved, &:approved?
 
   belongs_to :project
   belongs_to :requester, record_type: :user, serializer: WebApi::V1::UserSerializer

--- a/back/spec/acceptance/project_reviews_spec.rb
+++ b/back/spec/acceptance/project_reviews_spec.rb
@@ -69,7 +69,7 @@ resource 'Project reviews' do
           id: project_review.id,
           type: 'project_review',
           attributes: {
-            approved: project_review.approved?,
+            state: project_review.state,
             approved_at: project_review.approved_at&.iso8601(3),
             created_at: project_review.created_at.iso8601(3),
             updated_at: project_review.updated_at.iso8601(3)
@@ -125,7 +125,7 @@ resource 'Project reviews' do
           id: project_review.id,
           type: 'project_review',
           attributes: hash_including(
-            approved: true,
+            state: 'approved',
             approved_at: project_review.approved_at&.iso8601(3)
           ),
           relationships: hash_including(


### PR DESCRIPTION
# Changelog
## Technical
- [TAN-2985] Replaced the 'approved' attribute (boolean) with the 'state' attribute (enum) in project reviews to comply with the API spec.
