### PR TITLE
Move results underneath filters button

### DIFF
--- a/front/app/components/IdeaCards/IdeasWithFiltersSidebar/index.tsx
+++ b/front/app/components/IdeaCards/IdeasWithFiltersSidebar/index.tsx
@@ -274,8 +274,7 @@ const IdeasWithFiltersSidebar = ({
             </>
           )}
           {/* 
-            If we have an inputTerm (are on the project page), we don't need this. This fallback
-            is used on the /ideas page, where we have no inputTerm. 
+            If we have an inputTerm (are on the project page), we don't need this because the number of results is displayed next to the heading (see above). This fallback is used on the /ideas page, where we have no inputTerm. 
             TO DO: refactor this component so we can add it to the page instead to this general component.
           */}
           {!inputTerm && (

--- a/front/app/components/IdeaCards/IdeasWithFiltersSidebar/index.tsx
+++ b/front/app/components/IdeaCards/IdeasWithFiltersSidebar/index.tsx
@@ -273,11 +273,18 @@ const IdeasWithFiltersSidebar = ({
               />
             </>
           )}
-          <Text mb="8px">
-            {formatMessage(messages.numberResults, {
-              postCount: list.length,
-            })}
-          </Text>
+          {/* 
+            If we have an inputTerm (are on the project page), we don't need this. This fallback
+            is used on the /ideas page, where we have no inputTerm. 
+            TO DO: refactor this component so we can add it to the page instead to this general component.
+          */}
+          {!inputTerm && (
+            <Text mb="8px">
+              {formatMessage(messages.numberResults, {
+                postCount: list.length,
+              })}
+            </Text>
+          )}
           <Box display={selectedView === 'map' ? 'block' : 'flex'}>
             <ContentLeft>
               <IdeasView

--- a/front/app/components/IdeaCards/IdeasWithFiltersSidebar/index.tsx
+++ b/front/app/components/IdeaCards/IdeasWithFiltersSidebar/index.tsx
@@ -212,7 +212,7 @@ const IdeasWithFiltersSidebar = ({
   return (
     <Container id="e2e-ideas-container">
       <Box display="flex" justifyContent="space-between" mb="8px">
-        {inputTerm ? (
+        {inputTerm && (
           <Title variant="h4" as="h2" mt="auto" mb="auto" color="tenantText">
             {formatMessage(messages.ideasFilterSidebarTitle, {
               numberIdeas: list ? list.length : 0,
@@ -231,12 +231,6 @@ const IdeasWithFiltersSidebar = ({
               ),
             })}
           </Title>
-        ) : (
-          <Text m="0px">
-            {formatMessage(messages.numberResults, {
-              postCount: list ? list.length : 0,
-            })}
-          </Text>
         )}
 
         {showViewButtons && (
@@ -279,6 +273,11 @@ const IdeasWithFiltersSidebar = ({
               />
             </>
           )}
+          <Text mb="8px">
+            {formatMessage(messages.numberResults, {
+              postCount: list.length,
+            })}
+          </Text>
           <Box display={selectedView === 'map' ? 'block' : 'flex'}>
             <ContentLeft>
               <IdeasView


### PR DESCRIPTION
Not the most important page but mobile it was positioned above the filters button.

Before
<img width="886" alt="Screenshot 2024-11-29 at 11 03 23" src="https://github.com/user-attachments/assets/95cf1083-419e-4aa0-ae60-cda119b4fc78">

After
<img width="885" alt="Screenshot 2024-11-29 at 11 02 23" src="https://github.com/user-attachments/assets/83845129-8154-4886-8c6d-a7c8237e3b42">
