### PR TITLE
[TAN-3173] Only update idea list tab focus if it's clicked

### DIFF
--- a/front/app/components/PostCardsComponents/ViewButtons.tsx
+++ b/front/app/components/PostCardsComponents/ViewButtons.tsx
@@ -89,6 +89,9 @@ const ViewButtons = memo<Props>(({ className, selectedView, onClick }) => {
   const [viewChanged, setViewChanged] = useState<boolean | null>(null);
 
   useEffect(() => {
+    // We only want to update this focus if the user clicks/selects the tabs.
+    // Otherwise we end up setting focus when the page loads (which leads an
+    // issue where the user is incorrectly scrolled down to the idea section on page load).
     if (viewChanged) {
       selectedView === 'map'
         ? mapButtonRef.current?.focus()

--- a/front/app/components/PostCardsComponents/ViewButtons.tsx
+++ b/front/app/components/PostCardsComponents/ViewButtons.tsx
@@ -4,6 +4,7 @@ import React, {
   useRef,
   KeyboardEvent,
   useEffect,
+  useState,
 } from 'react';
 
 import {
@@ -79,21 +80,26 @@ interface Props {
 }
 
 const ViewButtons = memo<Props>(({ className, selectedView, onClick }) => {
+  const theme = useTheme();
   const isListViewSelected = selectedView === 'card';
   const isMapViewSelected = selectedView === 'map';
   const listButtonRef = useRef<HTMLButtonElement | null>(null);
   const mapButtonRef = useRef<HTMLButtonElement | null>(null);
-  const theme = useTheme();
+
+  const [viewChanged, setViewChanged] = useState<boolean | null>(null);
 
   useEffect(() => {
-    selectedView === 'map'
-      ? mapButtonRef.current?.focus()
-      : listButtonRef.current?.focus();
-  }, [selectedView]);
+    if (viewChanged) {
+      selectedView === 'map'
+        ? mapButtonRef.current?.focus()
+        : listButtonRef.current?.focus();
+    }
+  }, [selectedView, viewChanged]);
 
   const handleOnClick =
     (selectedView: 'card' | 'map') => (event: FormEvent) => {
       event.preventDefault();
+      setViewChanged(true);
       onClick(selectedView);
       trackEventByName(tracks.toggleDisplay, {
         locationButtonWasClicked: location.pathname,
@@ -106,6 +112,7 @@ const ViewButtons = memo<Props>(({ className, selectedView, onClick }) => {
     const arrowRightPressed = e.key === 'ArrowRight';
 
     if (arrowLeftPressed || arrowRightPressed) {
+      setViewChanged(true);
       onClick(selectedView === 'card' ? 'map' : 'card');
     }
   };


### PR DESCRIPTION
# Changelog
## Fixed
- [TAN-3173] On project pages, don't jump down to the idea list section when it loads.
