### PR TITLE
TAN-3407 - Fix imported idea published at date

### DIFF
--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/importers/idea_importer.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/importers/idea_importer.rb
@@ -113,12 +113,24 @@ module BulkImportIdeas::Importers
       raise invalid_date_error unless idea_row[:published_at].match? DATE_FORMAT_REGEX
 
       begin
-        published_at = Date.parse idea_row[:published_at]
+        published_at = date_with_time idea_row[:published_at]
       rescue StandardError => _e
         raise invalid_date_error
       end
 
       idea_attributes[:published_at] = published_at
+    end
+
+    # Add the current time to the date to ensure consistent sorting by published_at date
+    def date_with_time(date_string)
+      published_date = DateTime.parse date_string
+      current_time = Time.now
+      published_date.change(
+        hour: current_time.hour,
+        min: current_time.min,
+        sec: current_time.sec,
+        usec: current_time.usec
+      )
     end
 
     def add_publication_status(_idea_row, idea_attributes)

--- a/back/engines/commercial/bulk_import_ideas/spec/services/importers/idea_importer_spec.rb
+++ b/back/engines/commercial/bulk_import_ideas/spec/services/importers/idea_importer_spec.rb
@@ -189,6 +189,20 @@ describe BulkImportIdeas::Importers::IdeaImporter do
       )
     end
 
+    it 'adds a timestamp to published at so that idea sorting is consistent' do
+      allow(Time).to receive(:now).and_return(Time.new(2024, 12, 25, 11, 22, 33))
+      project = create(:project, title_multiloc: { 'en' => 'Project title' })
+      idea_rows = [
+        {
+          title_multiloc: { 'en' => 'My idea title' },
+          project_id: project.id,
+          published_at: '01-11-2024'
+        }
+      ]
+      service.import idea_rows
+      expect(project.ideas.first.published_at.strftime('%F %T')).to eq '2024-11-01 11:22:33'
+    end
+
     it 'does not import a user if there is a problem with saving a named user' do
       project = create(:project, title_multiloc: { 'en' => 'Project title' })
       idea_rows = [

--- a/back/engines/commercial/user_custom_fields/app/controllers/user_custom_fields/web_api/v1/stats_users_controller.rb
+++ b/back/engines/commercial/user_custom_fields/app/controllers/user_custom_fields/web_api/v1/stats_users_controller.rb
@@ -118,6 +118,8 @@ module UserCustomFields
               }
             end
 
+          # Remove option id from xlsx output - confusing for customers
+          xlsx_columns.delete(:option_id)
           XlsxService.new.xlsx_from_columns(xlsx_columns, sheetname: "users_by_#{custom_field.key}")
         end
 

--- a/back/engines/commercial/user_custom_fields/spec/acceptance/stats_users_spec.rb
+++ b/back/engines/commercial/user_custom_fields/spec/acceptance/stats_users_spec.rb
@@ -346,11 +346,11 @@ resource 'Stats - Users' do
             let(:expected_worksheet_name) { 'users_by_select_field' }
             let(:expected_worksheet_values) do
               [
-                %w[option option_id users reference_population],
-                ['youth council', @option1.key, 1, 80],
-                ['youth council', @option2.key, 1, ''],
-                ['youth council', @option3.key, 0, 20],
-                ['_blank', '_blank', 1, '']
+                %w[option users reference_population],
+                ['youth council', 1, 80],
+                ['youth council', 1, ''],
+                ['youth council', 0, 20],
+                ['_blank', 1, '']
               ]
             end
           end
@@ -385,11 +385,11 @@ resource 'Stats - Users' do
           let(:expected_worksheet_name) { 'users_by_multiselect_field' }
           let(:expected_worksheet_values) do
             [
-              %w[option option_id users],
-              ['youth council', @option1.key, 2],
-              ['youth council', @option2.key, 1],
-              ['youth council', @option3.key, 0],
-              ['_blank', '_blank', 1]
+              %w[option users],
+              ['youth council', 2],
+              ['youth council', 1],
+              ['youth council', 0],
+              ['_blank', 1]
             ]
           end
         end

--- a/back/engines/commercial/user_custom_fields/spec/acceptance/stats_users_spec.rb
+++ b/back/engines/commercial/user_custom_fields/spec/acceptance/stats_users_spec.rb
@@ -325,11 +325,11 @@ resource 'Stats - Users' do
             let(:expected_worksheet_name) { 'users_by_select_field' }
             let(:expected_worksheet_values) do
               [
-                %w[option option_id users],
-                ['youth council', @option1.key, 1],
-                ['youth council', @option2.key, 1],
-                ['youth council', @option3.key, 0],
-                ['_blank', '_blank', 1]
+                %w[option users],
+                ['youth council', 1],
+                ['youth council', 1],
+                ['youth council', 0],
+                ['_blank', 1]
               ]
             end
           end


### PR DESCRIPTION
This fix is actually the solution to ideas not being found on both phases in input manager, because this bug was causing inconsistent sorting/paging there.

# Changelog
## Fixed
- Added timestamp to imported ideas with published_at date to avoid inconsistency in idea sorting
- Removed confusing 'option_id' column from user dashboard XLSX export
