### PR TITLE
Tan 3077/fullscreen modal esc

### DIFF
--- a/front/app/components/IdeaCards/IdeasWithFiltersSidebar/FiltersModal/index.tsx
+++ b/front/app/components/IdeaCards/IdeasWithFiltersSidebar/FiltersModal/index.tsx
@@ -24,6 +24,7 @@ const FiltersModal = ({
   return (
     <FullscreenModal
       opened={opened}
+      close={onClose}
       topBar={<TopBar onReset={onClearFilters} onClose={onClose} />}
       bottomBar={
         <BottomBar

--- a/front/app/components/UI/FullscreenModal/index.tsx
+++ b/front/app/components/UI/FullscreenModal/index.tsx
@@ -75,6 +75,7 @@ const ModalBottomBar = styled.div`
 interface InputProps {
   className?: string;
   opened: boolean;
+  close: () => void;
   topBar?: JSX.Element | null;
   bottomBar?: JSX.Element | null;
   children: JSX.Element | null | undefined;
@@ -88,6 +89,7 @@ interface Props extends InputProps {
 const FullscreenModal = ({
   className,
   opened,
+  close,
   topBar,
   bottomBar,
   children,

--- a/front/app/components/UI/FullscreenModal/index.tsx
+++ b/front/app/components/UI/FullscreenModal/index.tsx
@@ -112,10 +112,20 @@ const FullscreenModal = ({
         }
       });
 
+    const handleKeypress = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        close();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeypress);
+
     return () => {
       subscription.unsubscribe();
+      window.removeEventListener('keydown', handleKeypress);
     };
-  }, []);
+  }, [close]);
 
   return (
     <CSSTransition

--- a/front/app/containers/MainHeader/Components/NavbarContent/MobileNavbarContent/FullMobileNavMenu.tsx
+++ b/front/app/containers/MainHeader/Components/NavbarContent/MobileNavbarContent/FullMobileNavMenu.tsx
@@ -113,7 +113,7 @@ const FullMobileNavMenu = ({ onClose, isFullMenuOpened }: Props) => {
   };
 
   return (
-    <StyledFullscreenModal opened={isFullMenuOpened}>
+    <StyledFullscreenModal opened={isFullMenuOpened} close={onClose}>
       <Container>
         <ContentContainer
           // Screen reader will add "navigation", so this will become


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Close full-screen modal (used for full mobile navigation among other things) with the `esc` key.