### PR TITLE
[TAN-3194] Bugfix: Delete project is possible when a related pageviews record exists

### DIFF
--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -64,6 +64,7 @@ class Project < ApplicationRecord
   accepts_nested_attributes_for :text_images
   has_many :project_files, -> { order(:ordering) }, dependent: :destroy
   has_many :followers, as: :followable, dependent: :destroy
+  has_many :impact_tracking_pageviews, class_name: 'ImpactTracking::Pageview', dependent: :nullify
 
   after_initialize :init
 


### PR DESCRIPTION
# Changelog
## Fixed
- [TAN-3194] Bugfix: Delete project is possible when a related `pageviews` record exists. Fixes an issue preventing the deletion of some projects in the BO.
