### PR TITLE
TAN-3175 - Fix proposals input manager export buttons

### DIFF
--- a/front/app/components/admin/PostManager/ProjectProposalsManager.tsx
+++ b/front/app/components/admin/PostManager/ProjectProposalsManager.tsx
@@ -182,7 +182,11 @@ const ProjectProposalsManager = ({
           project={projectId}
           queryParameters={queryParameters}
         />
-        <StyledExportMenu type={'ProjectProposals'} selection={selection} />
+        <StyledExportMenu
+          type={'ProjectProposals'}
+          selectedProject={projectId}
+          selection={selection}
+        />
       </TopActionBar>
 
       <ThreeColumns>


### PR DESCRIPTION
# Changelog
## Fixed
- Input manager for a proposals phase correctly downloads the posts and comments only for this project and not for the whole platform
