### PR TITLE
Modal header should only contain the title and no button

### DIFF
--- a/front/app/components/IdeaCards/IdeasWithFiltersSidebar/FiltersModal/BottomBar.tsx
+++ b/front/app/components/IdeaCards/IdeasWithFiltersSidebar/FiltersModal/BottomBar.tsx
@@ -1,6 +1,6 @@
 import React, { memo, FormEvent } from 'react';
 
-import { Box, colors } from '@citizenlab/cl2-component-library';
+import { Box, colors, fontSizes } from '@citizenlab/cl2-component-library';
 
 import useIdeasFilterCounts from 'api/ideas_filter_counts/useIdeasFilterCounts';
 
@@ -15,9 +15,10 @@ import messages from './messages';
 interface Props {
   onClick: (event: FormEvent) => void;
   selectedIdeaFilters: InputFiltersProps['selectedIdeaFilters'];
+  onReset: (event: React.MouseEvent) => void;
 }
 
-const BottomBar = memo<Props>(({ onClick, selectedIdeaFilters }) => {
+const BottomBar = memo<Props>(({ onClick, selectedIdeaFilters, onReset }) => {
   const { data: ideasFilterCounts } = useIdeasFilterCounts(selectedIdeaFilters);
 
   if (!ideasFilterCounts) return null;
@@ -26,6 +27,7 @@ const BottomBar = memo<Props>(({ onClick, selectedIdeaFilters }) => {
     <Box
       background={colors.white}
       p="16px"
+      pb="0"
       flex="1"
       borderTop={`1px solid ${colors.grey300}`}
     >
@@ -36,6 +38,13 @@ const BottomBar = memo<Props>(({ onClick, selectedIdeaFilters }) => {
             ideasCount: ideasFilterCounts.data.attributes.total,
           }}
         />
+      </Button>
+      <Button
+        onClick={onReset}
+        buttonStyle="text"
+        fontSize={`${fontSizes.s}px`}
+      >
+        <FormattedMessage {...messages.resetFilters} />
       </Button>
     </Box>
   );

--- a/front/app/components/IdeaCards/IdeasWithFiltersSidebar/FiltersModal/TopBar.tsx
+++ b/front/app/components/IdeaCards/IdeasWithFiltersSidebar/FiltersModal/TopBar.tsx
@@ -1,13 +1,6 @@
-import React, { MouseEvent } from 'react';
+import React from 'react';
 
-import {
-  colors,
-  Box,
-  Button,
-  fontSizes,
-  Title,
-} from '@citizenlab/cl2-component-library';
-import { useTheme } from 'styled-components';
+import { colors, Box, Title } from '@citizenlab/cl2-component-library';
 
 import CloseIconButton from 'components/UI/CloseIconButton';
 
@@ -17,15 +10,11 @@ import messages from './messages';
 
 interface Props {
   onClose: () => void;
-  onReset: (event: MouseEvent) => void;
 }
 
-const TopBar = ({ onClose, onReset }: Props) => {
-  const theme = useTheme();
-
+const TopBar = ({ onClose }: Props) => {
   return (
     <Box
-      height={`${theme.mobileTopBarHeight}px`}
       bgColor={colors.white}
       borderBottom={`1px solid ${colors.grey300}`}
       display="flex"
@@ -44,21 +33,12 @@ const TopBar = ({ onClose, onReset }: Props) => {
       >
         <FormattedMessage {...messages.filters} />
       </Title>
-      <Box display="flex">
-        <Button
-          onClick={onReset}
-          buttonStyle="text"
-          fontSize={`${fontSizes.s}px`}
-        >
-          <FormattedMessage {...messages.resetFilters} />
-        </Button>
-        <CloseIconButton
-          a11y_buttonActionMessage={messages.a11y_closeFilterPanel}
-          onClick={onClose}
-          iconColor={colors.textSecondary}
-          iconColorOnHover={'#000'}
-        />
-      </Box>
+      <CloseIconButton
+        a11y_buttonActionMessage={messages.a11y_closeFilterPanel}
+        onClick={onClose}
+        iconColor={colors.textSecondary}
+        iconColorOnHover={'#000'}
+      />
     </Box>
   );
 };

--- a/front/app/components/IdeaCards/IdeasWithFiltersSidebar/FiltersModal/index.tsx
+++ b/front/app/components/IdeaCards/IdeasWithFiltersSidebar/FiltersModal/index.tsx
@@ -25,11 +25,12 @@ const FiltersModal = ({
     <FullscreenModal
       opened={opened}
       close={onClose}
-      topBar={<TopBar onReset={onClearFilters} onClose={onClose} />}
+      topBar={<TopBar onClose={onClose} />}
       bottomBar={
         <BottomBar
           onClick={onClose}
           selectedIdeaFilters={selectedIdeaFilters}
+          onReset={onClearFilters}
         />
       }
       contentBgColor="background"


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Changed
- Move reset filters to the bottom of the filters modal (to indicate the modal's title easily, so screen readers don't link the reset filters button to the modal's title). [Before](https://github.com/user-attachments/assets/148447ed-815d-4ff8-8120-d0e3eb31abe3)/[after](https://github.com/user-attachments/assets/551bfa09-2033-490d-a284-ac64238a647a)
