### PR TITLE
TAN-3205 Also return projects linked to all areas when area filteringin public API

### DIFF
--- a/back/engines/commercial/public_api/app/finders/public_api/projects_finder.rb
+++ b/back/engines/commercial/public_api/app/finders/public_api/projects_finder.rb
@@ -59,11 +59,10 @@ module PublicApi
     def filter_by_area_ids(scope)
       return scope unless @area_ids
 
-      scope
-        .joins(:areas)
-        .where(areas: { id: @area_ids })
+      scope.left_joins(:areas_projects)
+        .where('projects.include_all_areas = ? OR areas_projects.area_id IN (?)', true, @area_ids)
         .group('projects.id')
-        .having('COUNT(areas.id) = ?', @area_ids.size)
+        .having('projects.include_all_areas = ? OR COUNT(DISTINCT areas_projects.area_id) = ?', true, @area_ids.size)
     end
   end
 end

--- a/back/engines/commercial/public_api/spec/acceptance/v2/projects_spec.rb
+++ b/back/engines/commercial/public_api/spec/acceptance/v2/projects_spec.rb
@@ -148,6 +148,7 @@ resource 'Projects' do
       let(:areas) { create_list(:area, 2) }
       let(:area_ids) { areas.pluck(:id) }
       let!(:project) { create(:project, areas: areas) }
+      let!(:project_in_all_areas) { create(:project, include_all_areas: true) }
 
       before do
         # This project shouldn't be returned since it only has one of the requested areas.
@@ -157,7 +158,7 @@ resource 'Projects' do
       example_request 'List only the projects that are in the specified areas' do
         assert_status 200
         expect(json_response_body[:projects].pluck(:id))
-          .to match_array [project.id]
+          .to match_array [project.id, project_in_all_areas.id]
       end
     end
 


### PR DESCRIPTION
# Changelog
## Fixed
- The Public API now also return projects that have checked "All areas" when filtering for an area. This fixes the issue where the Hoplr timeline would not show these projects when looking at a specific neighborhood.