### PR TITLE
TAN-3125: Prevent multiple calls to get custom fields on saving a survey

### DIFF
--- a/front/app/api/custom_fields/useUpdateCustomFields.ts
+++ b/front/app/api/custom_fields/useUpdateCustomFields.ts
@@ -1,8 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { CLErrors } from 'typings';
 
-import customFieldOptionKeys from 'api/custom_field_options/keys';
-
 import fetcher from 'utils/cl-react-query/fetcher';
 
 import customFieldsKeys from './keys';
@@ -44,12 +42,6 @@ const useUpdateCustomField = () => {
           projectId: variables.projectId,
           phaseId: variables.phaseId,
         }),
-      });
-      queryClient.invalidateQueries({
-        queryKey: customFieldsKeys.lists(),
-      });
-      queryClient.invalidateQueries({
-        queryKey: customFieldOptionKeys.items(),
       });
     },
   });

--- a/front/app/components/FormBuilder/edit/index.tsx
+++ b/front/app/components/FormBuilder/edit/index.tsx
@@ -84,11 +84,7 @@ const FormEdit = ({
   const { formSavedSuccessMessage, isFormPhaseSpecific } = builderConfig;
   const { mutateAsync: updateFormCustomFields } = useUpdateCustomField();
   const showWarningNotice = totalSubmissions > 0;
-  const {
-    data: formCustomFields,
-    refetch,
-    isFetching,
-  } = useFormCustomFields({
+  const { data: formCustomFields, isFetching } = useFormCustomFields({
     projectId,
     phaseId: isFormPhaseSpecific ? phaseId : undefined,
   });

--- a/front/app/components/FormBuilder/edit/index.tsx
+++ b/front/app/components/FormBuilder/edit/index.tsx
@@ -262,11 +262,9 @@ const FormEdit = ({
         },
         {
           onSuccess: () => {
-            refetch().then(() => {
-              setIsUpdatingForm(true);
-              setSuccessMessageIsVisible(true);
-              resetCopyFrom();
-            });
+            setIsUpdatingForm(true);
+            setSuccessMessageIsVisible(true);
+            resetCopyFrom();
           },
         }
       );


### PR DESCRIPTION
# Changelog

## Changed
- Slight improvement in performance by preventing multiple calls to get custom field options after saving a survey
