### PR TITLE
TAN-3104 - Remove duplicate draft survey responses when survey is submitted

### DIFF
--- a/back/engines/commercial/idea_assignment/app/services/idea_assignment/patches/side_fx_idea_service.rb
+++ b/back/engines/commercial/idea_assignment/app/services/idea_assignment/patches/side_fx_idea_service.rb
@@ -12,6 +12,9 @@ module IdeaAssignment
 
       def after_update(idea, user)
         super
+
+        remove_duplicate_survey_responses_on_publish(idea)
+
         return unless idea.assignee_id_previously_changed?
 
         initiating_user = user_for_activity_on_anonymizable_item(idea, @automatic_assignment ? nil : user)
@@ -21,10 +24,26 @@ module IdeaAssignment
 
       def before_publish(idea, user)
         super
+
         return if idea.assignee
 
         idea.assignee = IdeaAssignmentService.new.automatically_assigned_idea_assignee idea
         @automatic_assignment = true if idea.assignee
+      end
+
+      private
+
+      # If a survey is opened in multiple tabs then different draft responses can be created for the same user.
+      # We need to remove any duplicates when the survey is submitted.
+      def remove_duplicate_survey_responses_on_publish(idea)
+        return unless idea.creation_phase&.native_survey? && idea.publication_status_previously_changed?(from: 'draft', to: 'published')
+
+        Idea.where(
+          creation_phase_id: idea.creation_phase_id,
+          author: idea.author,
+          publication_status: 'draft')
+            .where.not(id: idea.id)
+            .destroy_all
       end
     end
   end

--- a/back/engines/commercial/idea_assignment/app/services/idea_assignment/patches/side_fx_idea_service.rb
+++ b/back/engines/commercial/idea_assignment/app/services/idea_assignment/patches/side_fx_idea_service.rb
@@ -42,9 +42,9 @@ module IdeaAssignment
           creation_phase_id: idea.creation_phase_id,
           author: idea.author,
           publication_status: 'draft'
-        )
-          .where.not(id: idea.id)
-          .destroy_all
+        ).where.not(
+          id: idea.id
+        ).destroy_all
       end
     end
   end

--- a/back/engines/commercial/idea_assignment/app/services/idea_assignment/patches/side_fx_idea_service.rb
+++ b/back/engines/commercial/idea_assignment/app/services/idea_assignment/patches/side_fx_idea_service.rb
@@ -41,9 +41,10 @@ module IdeaAssignment
         Idea.where(
           creation_phase_id: idea.creation_phase_id,
           author: idea.author,
-          publication_status: 'draft')
-            .where.not(id: idea.id)
-            .destroy_all
+          publication_status: 'draft'
+        )
+          .where.not(id: idea.id)
+          .destroy_all
       end
     end
   end

--- a/back/engines/commercial/idea_assignment/app/services/idea_assignment/patches/side_fx_idea_service.rb
+++ b/back/engines/commercial/idea_assignment/app/services/idea_assignment/patches/side_fx_idea_service.rb
@@ -12,9 +12,7 @@ module IdeaAssignment
 
       def after_update(idea, user)
         super
-
         remove_duplicate_survey_responses_on_publish(idea)
-
         return unless idea.assignee_id_previously_changed?
 
         initiating_user = user_for_activity_on_anonymizable_item(idea, @automatic_assignment ? nil : user)
@@ -24,7 +22,6 @@ module IdeaAssignment
 
       def before_publish(idea, user)
         super
-
         return if idea.assignee
 
         idea.assignee = IdeaAssignmentService.new.automatically_assigned_idea_assignee idea

--- a/back/spec/acceptance/resident_native_survey_responses_spec.rb
+++ b/back/spec/acceptance/resident_native_survey_responses_spec.rb
@@ -583,7 +583,7 @@ resource 'Ideas' do
 
         # Tests the context where the survey has been opened in two tabs and the user submits one of them.
         context 'when there are two surveys in draft' do
-          let(:publication_status) { 'published'}
+          let(:publication_status) { 'published' }
 
           example 'Survey submits and removes other drafts by the same user' do
             input.update!(publication_status: 'draft')

--- a/back/spec/acceptance/resident_native_survey_responses_spec.rb
+++ b/back/spec/acceptance/resident_native_survey_responses_spec.rb
@@ -438,6 +438,7 @@ resource 'Ideas' do
       parameter :custom_field_name3, 'A value for another custom field'
       parameter :custom_field_name4, 'A value for another custom field'
       parameter :custom_field_name5, 'A value for another custom field'
+      parameter :publication_status, 'published or draft'
     end
     ValidationErrorHelper.new.error_fields(self, Idea)
     let(:project) { create(:project_with_active_native_survey_phase) }
@@ -577,6 +578,28 @@ resource 'Ideas' do
                 'coordinates' => [[[4.3, 50.85], [4.31, 50.85], [4.31, 50.86], [4.3, 50.85]]]
               }
             })
+          end
+        end
+
+        # Tests the context where the survey has been opened in two tabs and the user submits one of them.
+        context 'when there are two surveys in draft' do
+          let(:publication_status) { 'published'}
+
+          example 'Survey submits and removes other drafts by the same user' do
+            input.update!(publication_status: 'draft')
+            draft_survey_to_delete = create(
+              :native_survey_response,
+              author: user,
+              project: project,
+              creation_phase: creation_phase,
+              publication_status: 'draft'
+            )
+            draft_survey_to_delete_id = draft_survey_to_delete.id
+
+            do_request
+            assert_status 200
+            expect(project.reload.ideas.size).to eq 1
+            expect { Idea.find(draft_survey_to_delete_id) }.to raise_error(ActiveRecord::RecordNotFound)
           end
         end
       end

--- a/back/spec/services/side_fx_idea_service_spec.rb
+++ b/back/spec/services/side_fx_idea_service_spec.rb
@@ -300,6 +300,33 @@ describe SideFxIdeaService do
 
       expect(phase.reload.manual_votes_count).to eq 2
     end
+
+    context 'native survey responses' do
+      before { create(:idea_status_proposed) }
+
+      let(:idea) { create(:native_survey_response, publication_status: 'draft') }
+
+      it 'deletes other draft responses by the same user when the survey response is submitted (published)' do
+        create(:native_survey_response, publication_status: 'draft', project: idea.project, creation_phase: idea.creation_phase, author: idea.author)
+        idea.update!(publication_status: 'published')
+        expect { service.after_update(idea, user) }
+          .to change { Idea.all.count }.from(2).to(1)
+      end
+
+      it 'does not deletes draft responses by different users when the survey response is submitted (published)' do
+        create(:native_survey_response, publication_status: 'draft', project: idea.project, creation_phase: idea.creation_phase)
+        idea.update!(publication_status: 'published')
+        service.after_update(idea, user)
+        expect(Idea.all.count).to eq 2
+      end
+
+      it 'does not deletes draft responses when the survey response is still in draft' do
+        create(:native_survey_response, publication_status: 'draft', project: idea.project, creation_phase: idea.creation_phase)
+        idea.update!(custom_field_values: {})
+        service.after_update(idea, user)
+        expect(Idea.all.count).to eq 2
+      end
+    end
   end
 
   describe 'after_destroy' do


### PR DESCRIPTION
Platform already prevented the submission of these, but they were just sat there in draft and causing emails to be sent saying users had not completed the survey.

# Changelog
## Fixed
- Delete duplicate draft survey responses for a user when they submit the final page of a survey response - these duplicates can sometimes be created if the survey has been opened without progress in multiple tabs.
