### PR TITLE
[TAN-3177] Allow project moderators to create/delete draft projects

### DIFF
--- a/back/app/controllers/web_api/v1/projects_controller.rb
+++ b/back/app/controllers/web_api/v1/projects_controller.rb
@@ -159,24 +159,23 @@ class WebApi::V1::ProjectsController < ApplicationController
   end
 
   def create
-    project_params = permitted_attributes(Project)
-    @project = Project.new(project_params)
-    sidefx.before_create(@project, current_user)
+    project = Project.new(permitted_attributes(Project))
+    sidefx.before_create(project, current_user)
 
     created = Project.transaction do
-      save_project(@project).tap do |saved|
-        sidefx.after_create(@project, current_user) if saved
+      save_project(project).tap do |saved|
+        sidefx.after_create(project, current_user) if saved
       end
     end
 
     if created
       render json: WebApi::V1::ProjectSerializer.new(
-        @project,
+        project,
         params: jsonapi_serializer_params,
         include: [:admin_publication]
       ).serializable_hash, status: :created
     else
-      render json: { errors: @project.errors.details }, status: :unprocessable_entity
+      render json: { errors: project.errors.details }, status: :unprocessable_entity
     end
   end
 

--- a/back/app/controllers/web_api/v1/projects_controller.rb
+++ b/back/app/controllers/web_api/v1/projects_controller.rb
@@ -199,7 +199,7 @@ class WebApi::V1::ProjectsController < ApplicationController
     params[:project][:area_ids] ||= [] if params[:project].key?(:area_ids)
     params[:project][:topic_ids] ||= [] if params[:project].key?(:topic_ids)
 
-    project_params = permitted_attributes(Project)
+    project_params = permitted_attributes(@project)
 
     @project.assign_attributes project_params
     remove_image_if_requested!(@project, project_params, :header_bg)

--- a/back/app/models/admin_publication.rb
+++ b/back/app/models/admin_publication.rb
@@ -87,6 +87,14 @@ class AdminPublication < ApplicationRecord
     publication_status == 'published'
   end
 
+  def ever_published?
+    first_published_at.present?
+  end
+
+  def never_published?
+    !ever_published?
+  end
+
   def draft?
     publication_status == 'draft'
   end

--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -136,6 +136,8 @@ class Project < ApplicationRecord
 
   alias project_id id
 
+  delegate :ever_published?, :never_published?, to: :admin_publication, allow_nil: true
+
   class << self
     def search_ids_by_all_including_patches(term)
       result = defined?(super) ? super : []

--- a/back/app/policies/project_policy.rb
+++ b/back/app/policies/project_policy.rb
@@ -128,7 +128,7 @@ class ProjectPolicy < ApplicationPolicy
   end
 
   def copy?
-    create?
+    active_moderator?
   end
 
   def destroy_participation_data?

--- a/back/app/policies/project_policy.rb
+++ b/back/app/policies/project_policy.rb
@@ -138,7 +138,6 @@ class ProjectPolicy < ApplicationPolicy
       :visible_to,
       :include_all_areas,
       {
-        admin_publication_attributes: [:publication_status],
         title_multiloc: CL2_SUPPORTED_LOCALES,
         description_multiloc: CL2_SUPPORTED_LOCALES,
         description_preview_multiloc: CL2_SUPPORTED_LOCALES,
@@ -157,11 +156,19 @@ class ProjectPolicy < ApplicationPolicy
   end
 
   def permitted_attributes_for_create
-    shared_permitted_attributes
+    shared_permitted_attributes.tap do |attrs|
+      nested_attrs = attrs.find { |attr| attr.is_a?(Hash) }
+      nested_attrs.deep_merge!({ admin_publication_attributes: [:publication_status] })
+    end
   end
 
   def permitted_attributes_for_update
-    shared_permitted_attributes
+    shared_permitted_attributes.tap do |attrs|
+      next unless update_status?
+
+      nested_attrs = attrs.find { |attr| attr.is_a?(Hash) }
+      nested_attrs.deep_merge!({ admin_publication_attributes: [:publication_status] })
+    end
   end
 
   def permitted_attributes_for_reorder
@@ -175,6 +182,18 @@ class ProjectPolicy < ApplicationPolicy
   end
 
   private
+
+  def update_status?
+    admin_like? || record.ever_published? || record.review&.approved?
+  end
+
+  def admin_like?
+    admin? || folder_moderator?
+  end
+
+  def folder_moderator?
+    record.folder && UserRoleService.new.can_moderate?(record.folder, user)
+  end
 
   def project_preview?
     return false unless record.admin_publication.publication_status == 'draft'

--- a/back/app/policies/project_policy.rb
+++ b/back/app/policies/project_policy.rb
@@ -118,7 +118,9 @@ class ProjectPolicy < ApplicationPolicy
   end
 
   def destroy?
-    active? && admin?
+    return false unless active?
+
+    admin? || (active_moderator? && record.never_published?)
   end
 
   def copy?

--- a/back/app/policies/project_policy.rb
+++ b/back/app/policies/project_policy.rb
@@ -92,7 +92,11 @@ class ProjectPolicy < ApplicationPolicy
     return false unless active?
     return true if admin?
 
-    record.folder && UserRoleService.new.can_moderate?(record.folder, user)
+    if record.folder
+      UserRoleService.new.can_moderate?(record.folder, user)
+    else
+      record.admin_publication.draft? && (user.project_moderator? || user.project_folder_moderator?)
+    end
   end
 
   def show?

--- a/back/app/services/local_project_copy_service.rb
+++ b/back/app/services/local_project_copy_service.rb
@@ -2,7 +2,7 @@
 
 # Copies a project within a tenant.
 class LocalProjectCopyService < ProjectCopyService
-  def copy(source_project)
+  def copy(source_project, dest_folder: source_project.folder)
     new_title_multiloc = add_suffix_to_title(source_project.title_multiloc)
 
     options = {
@@ -15,8 +15,7 @@ class LocalProjectCopyService < ProjectCopyService
     }
 
     template = export(source_project, **options)
-    folder_id = ProjectFolders::Folder.find(source_project.folder_id) if source_project.folder_id
-    copied_project = import(template, folder: folder_id, local_copy: true)
+    copied_project = import(template, folder: dest_folder, local_copy: true)
 
     copy_project_visibility_permission_groups(source_project, copied_project)
     copy_project_and_phases_actions_groups_permissions(source_project, copied_project)

--- a/back/app/services/side_fx_project_service.rb
+++ b/back/app/services/side_fx_project_service.rb
@@ -6,6 +6,10 @@ class SideFxProjectService
   def before_create(project, user); end
 
   def after_create(project, user)
+    if user && !UserRoleService.new.can_moderate_project?(project, user)
+      user.add_role('project_moderator', project_id: project.id).save!
+    end
+
     project.set_default_topics!
     project.update!(description_multiloc: TextImageService.new.swap_data_images_multiloc(project.description_multiloc, field: :description_multiloc, imageable: project))
     serialized_project = clean_time_attributes(project.attributes)

--- a/back/engines/commercial/idea_assignment/app/services/idea_assignment/patches/side_fx_project_service.rb
+++ b/back/engines/commercial/idea_assignment/app/services/idea_assignment/patches/side_fx_project_service.rb
@@ -3,9 +3,9 @@
 module IdeaAssignment
   module Patches
     module SideFxProjectService
-      def before_create(project, current_user)
+      def after_create(project, current_user)
         super
-        set_default_assignee(project, current_user)
+        set_default_assignee!(project, current_user) unless project.default_assignee
       end
 
       private
@@ -18,12 +18,9 @@ module IdeaAssignment
         IdeaAssignmentService.new.clean_assignees_for_project! project
       end
 
-      def set_default_assignee(project, current_user)
-        project.default_assignee ||= if current_user&.super_admin?
-          ::User.oldest_admin
-        else
-          current_user
-        end
+      def set_default_assignee!(project, current_user)
+        project.default_assignee ||= current_user&.super_admin? ? ::User.oldest_admin : current_user
+        project.save!
       end
     end
   end

--- a/back/engines/commercial/idea_assignment/spec/services/side_fx_project_spec.rb
+++ b/back/engines/commercial/idea_assignment/spec/services/side_fx_project_spec.rb
@@ -7,12 +7,12 @@ describe SideFxProjectService do
   let(:user) { create(:user) }
   let(:project) { create(:project) }
 
-  describe 'before_create' do
+  describe 'after_create' do
     it "sets the default_assignee to the user that creates the project if it's not a super admin" do
       create(:super_admin)
       create(:admin)
       admin2 = create(:admin)
-      expect { service.before_create(project, admin2) }.to change(project, :default_assignee)
+      expect { service.after_create(project, admin2) }.to change(project, :default_assignee)
         .from(nil).to(admin2)
     end
 
@@ -21,7 +21,7 @@ describe SideFxProjectService do
       create(:invite, invitee: create(:admin, registration_completed_at: nil, invite_status: 'pending'))
       admin1 = create(:admin)
       create(:admin)
-      expect { service.before_create(project, super_admin) }.to change(project, :default_assignee)
+      expect { service.after_create(project, super_admin) }.to change(project, :default_assignee)
         .from(nil).to(admin1)
     end
 

--- a/back/spec/policies/project_policy_spec.rb
+++ b/back/spec/policies/project_policy_spec.rb
@@ -378,7 +378,10 @@ describe ProjectPolicy do
       it { is_expected.to permit(:votes_by_input_xlsx)   }
 
       context 'when the project has never been published' do
-        before { expect(project).to(be_never_published) }
+        before do
+          # Sanity check
+          raise 'Project should not have been published' if project.ever_published?
+        end
 
         it { is_expected.to permit(:destroy) }
 

--- a/back/spec/policies/project_policy_spec.rb
+++ b/back/spec/policies/project_policy_spec.rb
@@ -368,10 +368,23 @@ describe ProjectPolicy do
       it { is_expected.to permit(:update)                }
       it { is_expected.to permit(:reorder)               }
       it { is_expected.to permit(:refresh_preview_token) }
-      it { is_expected.not_to permit(:destroy)           }
       it { is_expected.to permit(:index_xlsx)            }
       it { is_expected.to permit(:votes_by_user_xlsx)    }
       it { is_expected.to permit(:votes_by_input_xlsx)   }
+
+      context 'when the project has never been published' do
+        before { expect(project).to(be_never_published) }
+
+        it { is_expected.to permit(:destroy) }
+      end
+
+      context 'when the project has been published' do
+        before do
+          project.admin_publication.update!(first_published_at: Time.current)
+        end
+
+        it { is_expected.not_to permit(:destroy) }
+      end
 
       it 'indexes the project' do
         expect(scope.resolve.size).to eq 1

--- a/back/spec/policies/project_policy_spec.rb
+++ b/back/spec/policies/project_policy_spec.rb
@@ -18,6 +18,7 @@ describe ProjectPolicy do
 
       it { is_expected.to     permit(:show)                  }
       it { is_expected.not_to permit(:create)                }
+      it { is_expected.not_to permit(:copy)                  }
       it { is_expected.not_to permit(:update)                }
       it { is_expected.not_to permit(:reorder)               }
       it { is_expected.not_to permit(:refresh_preview_token) }
@@ -36,6 +37,7 @@ describe ProjectPolicy do
 
       it { is_expected.to     permit(:show)                  }
       it { is_expected.not_to permit(:create)                }
+      it { is_expected.not_to permit(:copy)                  }
       it { is_expected.not_to permit(:update)                }
       it { is_expected.not_to permit(:reorder)               }
       it { is_expected.not_to permit(:refresh_preview_token) }
@@ -58,6 +60,7 @@ describe ProjectPolicy do
 
       it { is_expected.to permit(:show)                  }
       it { is_expected.to permit(:create)                }
+      it { is_expected.to permit(:copy)                  }
       it { is_expected.to permit(:update)                }
       it { is_expected.to permit(:reorder)               }
       it { is_expected.to permit(:refresh_preview_token) }
@@ -80,6 +83,7 @@ describe ProjectPolicy do
 
       it { is_expected.to permit(:show)                  }
       it { is_expected.not_to permit(:create)            }
+      it { is_expected.to permit(:copy)                  }
       it { is_expected.to permit(:update)                }
       it { is_expected.to permit(:reorder)               }
       it { is_expected.to permit(:refresh_preview_token) }
@@ -102,6 +106,7 @@ describe ProjectPolicy do
 
       it { is_expected.to permit(:show)                      }
       it { is_expected.not_to permit(:create)                }
+      it { is_expected.not_to permit(:copy)                  }
       it { is_expected.not_to permit(:update)                }
       it { is_expected.not_to permit(:reorder)               }
       it { is_expected.not_to permit(:refresh_preview_token) }
@@ -457,12 +462,14 @@ describe ProjectPolicy do
       let!(:project) { create(:single_phase_ideation_project, admin_publication_attributes: { parent_id: project_folder.admin_publication.id }) }
 
       it { is_expected.to permit(:create) }
+      it { is_expected.to permit(:copy)   }
     end
 
     context 'for a timeline project not contained within a folder the user moderates' do
       let!(:project) { create(:single_phase_ideation_project) }
 
       it { is_expected.not_to permit(:create) }
+      it { is_expected.not_to permit(:copy)   }
     end
   end
 end

--- a/back/spec/policies/project_policy_spec.rb
+++ b/back/spec/policies/project_policy_spec.rb
@@ -363,8 +363,8 @@ describe ProjectPolicy do
     context 'for a moderator' do
       let(:user) { create(:project_moderator, projects: [project]) }
 
-      it { is_expected.to permit(:show)                  }
-      it { is_expected.not_to permit(:create)            }
+      it { is_expected.to permit(:show) }
+      it { is_expected.to permit(:create) }
       it { is_expected.to permit(:update)                }
       it { is_expected.to permit(:reorder)               }
       it { is_expected.to permit(:refresh_preview_token) }
@@ -418,7 +418,24 @@ describe ProjectPolicy do
       let(:user) { create(:project_moderator) }
 
       it { is_expected.not_to permit(:show)                  }
-      it { is_expected.not_to permit(:create)                }
+      it { is_expected.to permit(:create)                    }
+      it { is_expected.not_to permit(:update)                }
+      it { is_expected.not_to permit(:reorder)               }
+      it { is_expected.not_to permit(:refresh_preview_token) }
+      it { is_expected.not_to permit(:destroy)               }
+      it { is_expected.not_to permit(:index_xlsx)            }
+      it { is_expected.not_to permit(:votes_by_user_xlsx)    }
+      it { is_expected.not_to permit(:votes_by_input_xlsx)   }
+
+      it { expect(scope.resolve).not_to include(project) }
+      it { expect(inverse_scope.resolve).not_to include(user) }
+    end
+
+    context 'for a project folder moderator' do
+      let(:user) { create(:project_folder_moderator) }
+
+      it { is_expected.not_to permit(:show)                  }
+      it { is_expected.to permit(:create)                    }
       it { is_expected.not_to permit(:update)                }
       it { is_expected.not_to permit(:reorder)               }
       it { is_expected.not_to permit(:refresh_preview_token) }


### PR DESCRIPTION
# Changelog
## Added
- [TAN-3177] Allow project moderators to create and delete draft projects, and copy projects.
## Changed
- [TAN-3177] Rework project-status update permissions for PMs to implement the project review flow.