### PR TITLE
TAN-2983: Remove wrong total budget explanation tooltip from project budgeting inputs

### DIFF
--- a/front/app/containers/Admin/projects/project/messages.ts
+++ b/front/app/containers/Admin/projects/project/messages.ts
@@ -160,11 +160,6 @@ export default defineMessages({
     id: 'app.containers.AdminPage.ProjectEdit.totalBudget',
     defaultMessage: 'Total budget',
   },
-  totalBudgetExplanation: {
-    id: 'app.containers.AdminPage.ProjectEdit.totalBudgetExplanation',
-    defaultMessage:
-      "By default, your budget is set using your local currency. You can change your platform's currency to 'credits' or 'tokens' by contacting our support center.",
-  },
   minimum: {
     id: 'app.containers.AdminPage.ProjectEdit.minimum',
     defaultMessage: 'Minimum',

--- a/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/VotingInputs/votingMethodInputs/BudgetingInputs.tsx
+++ b/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/VotingInputs/votingMethodInputs/BudgetingInputs.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { IconTooltip } from '@citizenlab/cl2-component-library';
 import { CLErrors } from 'typings';
 
 import { SectionField, SubSectionTitle } from 'components/admin/Section';
@@ -48,9 +47,6 @@ const BudgetingInputs = ({
       <SectionField>
         <SubSectionTitle>
           <FormattedMessage {...messages.totalBudget} />
-          <IconTooltip
-            content={<FormattedMessage {...messages.totalBudgetExplanation} />}
-          />
         </SubSectionTitle>
         <BudgetingAmountInput
           onChange={handleMinBudgetingAmountChange}

--- a/front/app/translations/admin/ar-MA.json
+++ b/front/app/translations/admin/ar-MA.json
@@ -834,7 +834,6 @@
   "app.containers.AdminPage.ProjectEdit.topicLabel": "الموضوعات",
   "app.containers.AdminPage.ProjectEdit.topicLabelTooltip": "حدد {topicsCopy} لهذا المشروع. وباستطاعة المستخدمين استخدامها لتصفية مشاريع.",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "الميزانية الإجمالية",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "يتم تعيين ميزانيتك افتراضيًا باستخدام عملتك المحلية. يمكنك تغيير عملة منصتك إلى \"رموز ائتمان\" أو \"رموز مميزة\" من خلال التواصل مع مركز الدعم التابع لنا.",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "الرائجة",
   "app.containers.AdminPage.ProjectEdit.typeform": "Typeform",
   "app.containers.AdminPage.ProjectEdit.unassigned": "غير مُعيّن",

--- a/front/app/translations/admin/ar-SA.json
+++ b/front/app/translations/admin/ar-SA.json
@@ -1848,7 +1848,6 @@
   "app.containers.AdminPage.ProjectEdit.topicLabel": "الموضوعات",
   "app.containers.AdminPage.ProjectEdit.topicLabelTooltip": "حدد {topicsCopy} لهذا المشروع. وباستطاعة المستخدمين استخدامها لتصفية مشاريع.",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "الميزانية الإجمالية",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "يتم تعيين ميزانيتك افتراضيًا باستخدام عملتك المحلية. يمكنك تغيير عملة منصتك إلى \"رموز ائتمان\" أو \"رموز مميزة\" من خلال التواصل مع مركز الدعم التابع لنا.",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "الرائجة",
   "app.containers.AdminPage.ProjectEdit.typeform": "Typeform",
   "app.containers.AdminPage.ProjectEdit.unassigned": "غير مُعيّن",

--- a/front/app/translations/admin/ca-ES.json
+++ b/front/app/translations/admin/ca-ES.json
@@ -1125,7 +1125,6 @@
   "app.containers.AdminPage.ProjectEdit.topicLabel": "Tags",
   "app.containers.AdminPage.ProjectEdit.topicLabelTooltip": "Seleccioneu {topicsCopy} per a aquest projecte. Els usuaris poden utilitzar-los per filtrar projectes.",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "Pressupost total",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "De manera predeterminada, el vostre pressupost s'estableix amb la vostra moneda local. Podeu canviar la moneda de la vostra plataforma a \"crèdits\" o \"fitxes\" posant-vos en contacte amb el nostre centre d'assistència.",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "Trending",
   "app.containers.AdminPage.ProjectEdit.typeform": "Tipus de forma",
   "app.containers.AdminPage.ProjectEdit.unassigned": "Unassigned",

--- a/front/app/translations/admin/cy-GB.json
+++ b/front/app/translations/admin/cy-GB.json
@@ -1848,7 +1848,6 @@
   "app.containers.AdminPage.ProjectEdit.topicLabel": "Tagiau",
   "app.containers.AdminPage.ProjectEdit.topicLabelTooltip": "Dewiswch {topicsCopy} ar gyfer y prosiect hwn. Gall defnyddwyr ddefnyddio'r rhain i hidlo prosiectau erbyn.",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "Cyfanswm y gyllideb",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "Yn ddiofyn, caiff eich cyllideb ei gosod gan ddefnyddio'ch arian lleol. Gallwch newid arian cyfred eich platfform i 'gredydau' neu 'tocynnau' trwy gysylltu â'n canolfan gymorth.",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "Tueddu",
   "app.containers.AdminPage.ProjectEdit.typeform": "Teipffurf",
   "app.containers.AdminPage.ProjectEdit.unassigned": "Heb ei aseinio",

--- a/front/app/translations/admin/da-DK.json
+++ b/front/app/translations/admin/da-DK.json
@@ -1848,7 +1848,6 @@
   "app.containers.AdminPage.ProjectEdit.topicLabel": "Emner",
   "app.containers.AdminPage.ProjectEdit.topicLabelTooltip": "Vælg {topicsCopy} for dette projekt. Brugere kan bruge disse til at filtrere projekter efter.",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "Samlet budget",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "Dit budget er som standard indstillet i din lokale valuta. Du kan ændre din platforms valuta til \"credits\" eller \"tokens\" ved at kontakte vores supportcenter.",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "Populære",
   "app.containers.AdminPage.ProjectEdit.typeform": "Typeform",
   "app.containers.AdminPage.ProjectEdit.unassigned": "Ikke tildelt",

--- a/front/app/translations/admin/de-DE.json
+++ b/front/app/translations/admin/de-DE.json
@@ -1848,7 +1848,6 @@
   "app.containers.AdminPage.ProjectEdit.topicLabel": "Themen-Tags",
   "app.containers.AdminPage.ProjectEdit.topicLabelTooltip": "{topicsCopy} für dieses Projekt auswählen. Nutzer*nnen können diese verwenden, um Projekte zu filtern.",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "Gesamtbudget",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "Standardmäßig wird Ihr Budget in Ihrer Landeswährung festgelegt. Sie können die Währung Ihrer Plattform in \"Guthaben\" oder \"Münzen\" ändern, indem Sie sich an unser Support-Center wenden.",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "Beliebt",
   "app.containers.AdminPage.ProjectEdit.typeform": "Typeform",
   "app.containers.AdminPage.ProjectEdit.unassigned": "Nicht zugewiesen",

--- a/front/app/translations/admin/el-GR.json
+++ b/front/app/translations/admin/el-GR.json
@@ -1125,7 +1125,6 @@
   "app.containers.AdminPage.ProjectEdit.topicLabel": "Tags",
   "app.containers.AdminPage.ProjectEdit.topicLabelTooltip": "Επιλέξτε {topicsCopy} για αυτό το έργο. Οι χρήστες μπορούν να τα χρησιμοποιήσουν για να φιλτράρουν τα έργα με βάση αυτά.",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "Συνολικός προϋπολογισμός",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "Από προεπιλογή, ο προϋπολογισμός σας ορίζεται χρησιμοποιώντας το τοπικό σας νόμισμα. Μπορείτε να αλλάξετε το νόμισμα της πλατφόρμας σας σε \"μονάδες\" ή \"διακριτικά\" επικοινωνώντας με το κέντρο υποστήριξής μας.",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "Trending",
   "app.containers.AdminPage.ProjectEdit.typeform": "Typeform",
   "app.containers.AdminPage.ProjectEdit.unassigned": "Unassigned",

--- a/front/app/translations/admin/en-CA.json
+++ b/front/app/translations/admin/en-CA.json
@@ -1848,7 +1848,6 @@
   "app.containers.AdminPage.ProjectEdit.topicLabel": "Tags",
   "app.containers.AdminPage.ProjectEdit.topicLabelTooltip": "Select {topicsCopy} for this project. Users can use these to filter projects by.",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "Total budget",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "By default, your budget is set using your local currency. You can change your platform's currency to 'credits' or 'tokens' by contacting our support center.",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "Trending",
   "app.containers.AdminPage.ProjectEdit.typeform": "Typeform",
   "app.containers.AdminPage.ProjectEdit.unassigned": "Unassigned",

--- a/front/app/translations/admin/en-GB.json
+++ b/front/app/translations/admin/en-GB.json
@@ -1848,7 +1848,6 @@
   "app.containers.AdminPage.ProjectEdit.topicLabel": "Tags",
   "app.containers.AdminPage.ProjectEdit.topicLabelTooltip": "Select {topicsCopy} for this project. Users can use these to filter projects by.",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "Total budget",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "By default, your budget is set using your local currency. You can change your platform's currency to 'credits' or 'tokens' by contacting our support center.",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "Trending",
   "app.containers.AdminPage.ProjectEdit.typeform": "Typeform",
   "app.containers.AdminPage.ProjectEdit.unassigned": "Unassigned",

--- a/front/app/translations/admin/en-IE.json
+++ b/front/app/translations/admin/en-IE.json
@@ -1848,7 +1848,6 @@
   "app.containers.AdminPage.ProjectEdit.topicLabel": "Tags",
   "app.containers.AdminPage.ProjectEdit.topicLabelTooltip": "Select {topicsCopy} for this project. Users can use these to filter projects by.",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "Total budget",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "By default, your budget is set using your local currency. You can change your platform's currency to 'credits' or 'tokens' by contacting our support center.",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "Trending",
   "app.containers.AdminPage.ProjectEdit.typeform": "Typeform",
   "app.containers.AdminPage.ProjectEdit.unassigned": "Unassigned",

--- a/front/app/translations/admin/en.json
+++ b/front/app/translations/admin/en.json
@@ -1848,7 +1848,6 @@
   "app.containers.AdminPage.ProjectEdit.topicLabel": "Tags",
   "app.containers.AdminPage.ProjectEdit.topicLabelTooltip": "Select {topicsCopy} for this project. Users can use these to filter projects by.",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "Total budget",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "By default, your budget is set using your local currency. You can change your platform's currency to 'credits' or 'tokens' by contacting our support center.",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "Trending",
   "app.containers.AdminPage.ProjectEdit.typeform": "Typeform",
   "app.containers.AdminPage.ProjectEdit.unassigned": "Unassigned",

--- a/front/app/translations/admin/es-CL.json
+++ b/front/app/translations/admin/es-CL.json
@@ -1848,7 +1848,6 @@
   "app.containers.AdminPage.ProjectEdit.topicLabel": "Temas",
   "app.containers.AdminPage.ProjectEdit.topicLabelTooltip": "Seleccione {topicsCopy} para este proyecto. Los usuarios pueden utilizarlas para filtrar los proyectos por.",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "Presupuesto total",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "Por defecto, tu presupuesto se establece utilizando la moneda local. Puedes cambiar la moneda de tu plataforma a 'créditos' o 'fichas' poniéndote en contacto con nuestro centro de soporte.",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "Tendencias",
   "app.containers.AdminPage.ProjectEdit.typeform": "Typeform",
   "app.containers.AdminPage.ProjectEdit.unassigned": "Sin asignar",

--- a/front/app/translations/admin/es-ES.json
+++ b/front/app/translations/admin/es-ES.json
@@ -1848,7 +1848,6 @@
   "app.containers.AdminPage.ProjectEdit.topicLabel": "Temas",
   "app.containers.AdminPage.ProjectEdit.topicLabelTooltip": "Seleccione {topicsCopy} para este proyecto. Los usuarios pueden utilizarlas para filtrar los proyectos por.",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "Presupuesto total",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "Por defecto, tu presupuesto se establece utilizando la moneda local. Puedes cambiar la moneda de tu plataforma a 'créditos' o 'fichas' poniéndote en contacto con nuestro centro de soporte.",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "Tendencias",
   "app.containers.AdminPage.ProjectEdit.typeform": "Typeform",
   "app.containers.AdminPage.ProjectEdit.unassigned": "Sin asignar",

--- a/front/app/translations/admin/fi-FI.json
+++ b/front/app/translations/admin/fi-FI.json
@@ -1848,7 +1848,6 @@
   "app.containers.AdminPage.ProjectEdit.topicLabel": "Tunnisteet",
   "app.containers.AdminPage.ProjectEdit.topicLabelTooltip": "Valitse {topicsCopy} tälle projektille. Käyttäjät voivat käyttää näitä suodattaessaan projekteja.",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "Kokonaisbudjetti",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "Oletusarvoisesti budjettisi on määritetty paikallisessa valuutassasi. Voit vaihtaa alustasi valuutaksi \"krediitit\" tai \"tunnukset\" ottamalla yhteyttä tukikeskukseemme.",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "Trendaavat",
   "app.containers.AdminPage.ProjectEdit.typeform": "Tyyppimuoto",
   "app.containers.AdminPage.ProjectEdit.unassigned": "Ei määritetty",

--- a/front/app/translations/admin/fr-BE.json
+++ b/front/app/translations/admin/fr-BE.json
@@ -1848,7 +1848,6 @@
   "app.containers.AdminPage.ProjectEdit.topicLabel": "Étiquettes",
   "app.containers.AdminPage.ProjectEdit.topicLabelTooltip": "Sélectionnez {topicsCopy} pour ce projet. Les utilisateurs peuvent utiliser ces critères pour filtrer les projets.",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "Budget total",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "Par défaut, votre budget est défini en utilisant votre devise locale. Vous pouvez changer la devise de votre plateforme en \"crédits\" ou \"jetons\" en contactant notre équipe support.",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "Populaires",
   "app.containers.AdminPage.ProjectEdit.typeform": "Typeform",
   "app.containers.AdminPage.ProjectEdit.unassigned": "Non attribué",

--- a/front/app/translations/admin/fr-FR.json
+++ b/front/app/translations/admin/fr-FR.json
@@ -1848,7 +1848,6 @@
   "app.containers.AdminPage.ProjectEdit.topicLabel": "Étiquettes",
   "app.containers.AdminPage.ProjectEdit.topicLabelTooltip": "Sélectionnez {topicsCopy} pour ce projet. Les utilisateurs peuvent utiliser ces critères pour filtrer les projets.",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "Budget total",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "Par défaut, votre budget est défini en utilisant votre devise locale. Vous pouvez changer la devise de votre plateforme en \"crédits\" ou \"jetons\" en contactant notre équipe support.",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "Populaires",
   "app.containers.AdminPage.ProjectEdit.typeform": "Typeform",
   "app.containers.AdminPage.ProjectEdit.unassigned": "Non attribué",

--- a/front/app/translations/admin/hr-HR.json
+++ b/front/app/translations/admin/hr-HR.json
@@ -1848,7 +1848,6 @@
   "app.containers.AdminPage.ProjectEdit.topicLabel": "Oznake",
   "app.containers.AdminPage.ProjectEdit.topicLabelTooltip": "Odaberite {topicsCopy} za ovaj projekt. Korisnici ovo mogu koristiti za filtriranje projekata.",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "Ukupan proračun",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "Proračun je prema zadanim postavkama postavljen na lokalnu valutu. Valutu svoje platforme možete promijeniti i u „krediti“ ili „žetoni“ tako što ćete kontaktirati naš centar za podršku.",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "U trendu",
   "app.containers.AdminPage.ProjectEdit.typeform": "Typeform",
   "app.containers.AdminPage.ProjectEdit.unassigned": "Nedodijeljeno",

--- a/front/app/translations/admin/hu-HU.json
+++ b/front/app/translations/admin/hu-HU.json
@@ -537,7 +537,6 @@
   "app.containers.AdminPage.ProjectEdit.titleLabel": "Title",
   "app.containers.AdminPage.ProjectEdit.titleLabelTooltip": "Choose a title that is short, engaging and clear. It will be shown in the dropdown overview and on the project cards on the home page.",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "Total budget",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "By default, your budget is set using your local currency. You can change your platform's currency to 'credits' or 'tokens' by contacting our support center.",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "Trending",
   "app.containers.AdminPage.ProjectEdit.typeform": "Typeform",
   "app.containers.AdminPage.ProjectEdit.unassigned": "Unassigned",

--- a/front/app/translations/admin/it-IT.json
+++ b/front/app/translations/admin/it-IT.json
@@ -1125,7 +1125,6 @@
   "app.containers.AdminPage.ProjectEdit.topicLabel": "Tags",
   "app.containers.AdminPage.ProjectEdit.topicLabelTooltip": "Seleziona {topicsCopy} per questo progetto. Gli utenti possono usarli per filtrare i progetti.",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "Bilancio totale",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "Per impostazione predefinita, il tuo budget è impostato utilizzando la tua valuta locale. Puoi cambiare la valuta della tua piattaforma in 'crediti' o 'token' contattando il nostro centro assistenza.",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "Trending",
   "app.containers.AdminPage.ProjectEdit.typeform": "Typeform",
   "app.containers.AdminPage.ProjectEdit.unassigned": "Unassigned",

--- a/front/app/translations/admin/kl-GL.json
+++ b/front/app/translations/admin/kl-GL.json
@@ -904,7 +904,6 @@
   "app.containers.AdminPage.ProjectEdit.topicLabel": "Tags",
   "app.containers.AdminPage.ProjectEdit.topicLabelTooltip": "Suliniummut {topicsCopy}-mik toqqaagit. Atuisut suliniutinik filteriiniarlutik taakku atorsinnaavaat.",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "Missingersuutit tamakkiisut",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "Missingersuutitit nalinginnaasumik inissiissutitut najukkami aningaasat atorlugit ersissapput. Ikiorsiiviup attavigineratigut qupperninni aningaasat 'kredit'-inngortissinnaavatit imaluunniit 'tokens'-inngortillugit.",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "Trending",
   "app.containers.AdminPage.ProjectEdit.typeform": "Typeform",
   "app.containers.AdminPage.ProjectEdit.unassigned": "Unassigned",

--- a/front/app/translations/admin/lb-LU.json
+++ b/front/app/translations/admin/lb-LU.json
@@ -904,7 +904,6 @@
   "app.containers.AdminPage.ProjectEdit.topicLabel": "Tags",
   "app.containers.AdminPage.ProjectEdit.topicLabelTooltip": "Wielt {topicsCopy} fir dëse Projet. Benotzer kënnen dëst gebrauchen, fir Projeten dono ze filteren.",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "Total budget",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "By default, your budget is set using your local currency. You can change your platform's currency to 'credits' or 'tokens' by contacting our support center.",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "Trending",
   "app.containers.AdminPage.ProjectEdit.typeform": "Typeform",
   "app.containers.AdminPage.ProjectEdit.unassigned": "Unassigned",

--- a/front/app/translations/admin/lt-LT.json
+++ b/front/app/translations/admin/lt-LT.json
@@ -1848,7 +1848,6 @@
   "app.containers.AdminPage.ProjectEdit.topicLabel": "Žymos",
   "app.containers.AdminPage.ProjectEdit.topicLabelTooltip": "Šiam projektui pasirinkite {topicsCopy} . Vartotojai gali naudoti šiuos parametrus projektams filtruoti.",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "Bendras biudžetas",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "Pagal numatytuosius nustatymus biudžetas nustatomas vietine valiuta. Galite pakeisti platformos valiutą į \"kreditus\" arba \"žetonus\" susisiekę su mūsų pagalbos centru.",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "Tendencijos",
   "app.containers.AdminPage.ProjectEdit.typeform": "Typeform",
   "app.containers.AdminPage.ProjectEdit.unassigned": "Nepriskirta",

--- a/front/app/translations/admin/lv-LV.json
+++ b/front/app/translations/admin/lv-LV.json
@@ -1848,7 +1848,6 @@
   "app.containers.AdminPage.ProjectEdit.topicLabel": "Tagi",
   "app.containers.AdminPage.ProjectEdit.topicLabelTooltip": "Izvēlieties {topicsCopy} šim projektam. Lietotāji tos var izmantot projektu filtrēšanai.",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "Kopējais budžets",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "Pēc noklusējuma budžets tiek norādīts vietējā valūtā. Jūs varat mainīt platformas valūtu uz “kredītiem” vai “žetoniem”, sazinoties ar mūsu atbalsta centru.",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "Tendences",
   "app.containers.AdminPage.ProjectEdit.typeform": "Typeform",
   "app.containers.AdminPage.ProjectEdit.unassigned": "Nepiešķirts",

--- a/front/app/translations/admin/mi.json
+++ b/front/app/translations/admin/mi.json
@@ -537,7 +537,6 @@
   "app.containers.AdminPage.ProjectEdit.titleLabel": "Title",
   "app.containers.AdminPage.ProjectEdit.titleLabelTooltip": "Choose a title that is short, engaging and clear. It will be shown in the dropdown overview and on the project cards on the home page.",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "Total budget",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "By default, your budget is set using your local currency. You can change your platform's currency to 'credits' or 'tokens' by contacting our support center.",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "Trending",
   "app.containers.AdminPage.ProjectEdit.typeform": "Typeform",
   "app.containers.AdminPage.ProjectEdit.unassigned": "Unassigned",

--- a/front/app/translations/admin/nb-NO.json
+++ b/front/app/translations/admin/nb-NO.json
@@ -1848,7 +1848,6 @@
   "app.containers.AdminPage.ProjectEdit.topicLabel": "Tagger",
   "app.containers.AdminPage.ProjectEdit.topicLabelTooltip": "Velg {topicsCopy} for dette prosjektet. Brukere kan bruke disse til å filtrere prosjekter etter.",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "Totalt budsjett",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "Som standard er budsjettet ditt satt i din lokale valuta. Du kan endre plattformens valuta til \"kreditter\" eller \"tokens\" ved å kontakte kundestøttesenteret vårt.",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "Trender",
   "app.containers.AdminPage.ProjectEdit.typeform": "Typeform",
   "app.containers.AdminPage.ProjectEdit.unassigned": "Ikke tildelt",

--- a/front/app/translations/admin/nl-BE.json
+++ b/front/app/translations/admin/nl-BE.json
@@ -1848,7 +1848,6 @@
   "app.containers.AdminPage.ProjectEdit.topicLabel": "Tags",
   "app.containers.AdminPage.ProjectEdit.topicLabelTooltip": "Selecteer {topicsCopy} voor dit project. Gebruikers kunnen deze gebruiken om projecten mee te filteren.",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "Totaalbedrag",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "Je budget is in je lokale valuta ingesteld. Je kan de munteenheid van je platform wijzigen in 'credits' of 'tokens' door contact op te nemen met ons support center.",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "Populair",
   "app.containers.AdminPage.ProjectEdit.typeform": "Typeform",
   "app.containers.AdminPage.ProjectEdit.unassigned": "Niet toegewezen",

--- a/front/app/translations/admin/nl-NL.json
+++ b/front/app/translations/admin/nl-NL.json
@@ -1848,7 +1848,6 @@
   "app.containers.AdminPage.ProjectEdit.topicLabel": "Tags",
   "app.containers.AdminPage.ProjectEdit.topicLabelTooltip": "Selecteer {topicsCopy} voor dit project. Gebruikers kunnen deze gebruiken om projecten mee te filteren.",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "Totaalbedrag",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "Je budget is in je lokale valuta ingesteld. Je kan de munteenheid van je platform wijzigen in 'credits' of 'tokens' door contact op te nemen met ons support center.",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "Populair",
   "app.containers.AdminPage.ProjectEdit.typeform": "Typeform",
   "app.containers.AdminPage.ProjectEdit.unassigned": "Niet toegewezen",

--- a/front/app/translations/admin/pa-IN.json
+++ b/front/app/translations/admin/pa-IN.json
@@ -1848,7 +1848,6 @@
   "app.containers.AdminPage.ProjectEdit.topicLabel": "ਟੈਗਸ",
   "app.containers.AdminPage.ProjectEdit.topicLabelTooltip": "ਇਸ ਪ੍ਰੋਜੈਕਟ ਲਈ {topicsCopy} ਚੁਣੋ। ਉਪਭੋਗਤਾ ਇਹਨਾਂ ਦੁਆਰਾ ਪ੍ਰੋਜੈਕਟਾਂ ਨੂੰ ਫਿਲਟਰ ਕਰਨ ਲਈ ਵਰਤ ਸਕਦੇ ਹਨ.",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "ਕੁੱਲ ਬਜਟ",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "ਮੂਲ ਰੂਪ ਵਿੱਚ, ਤੁਹਾਡਾ ਬਜਟ ਤੁਹਾਡੀ ਸਥਾਨਕ ਮੁਦਰਾ ਦੀ ਵਰਤੋਂ ਕਰਕੇ ਸੈੱਟ ਕੀਤਾ ਜਾਂਦਾ ਹੈ। ਤੁਸੀਂ ਸਾਡੇ ਸਹਾਇਤਾ ਕੇਂਦਰ ਨਾਲ ਸੰਪਰਕ ਕਰਕੇ ਆਪਣੇ ਪਲੇਟਫਾਰਮ ਦੀ ਮੁਦਰਾ ਨੂੰ 'ਕ੍ਰੈਡਿਟ' ਜਾਂ 'ਟੋਕਨ' ਵਿੱਚ ਬਦਲ ਸਕਦੇ ਹੋ।",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "ਪ੍ਰਚਲਿਤ",
   "app.containers.AdminPage.ProjectEdit.typeform": "ਕਿਸਮ",
   "app.containers.AdminPage.ProjectEdit.unassigned": "ਅਸਾਈਨ ਨਹੀਂ ਕੀਤਾ ਗਿਆ",

--- a/front/app/translations/admin/pl-PL.json
+++ b/front/app/translations/admin/pl-PL.json
@@ -1848,7 +1848,6 @@
   "app.containers.AdminPage.ProjectEdit.topicLabel": "Tematy",
   "app.containers.AdminPage.ProjectEdit.topicLabelTooltip": "Wybierz {topicsCopy} dla tego projektu. Użytkownicy mogą używać ich do filtrowania projektów.",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "Budżet całkowity",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "Domyślnie Twój budżet jest ustawiony w Twojej lokalnej walucie. Możesz zmienić walutę swojej platformy na \"kredyty\" lub \"tokeny\" kontaktując się z naszym centrum wsparcia.",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "Na czasie",
   "app.containers.AdminPage.ProjectEdit.typeform": "Typeform",
   "app.containers.AdminPage.ProjectEdit.unassigned": "Nieprzypisany",

--- a/front/app/translations/admin/pt-BR.json
+++ b/front/app/translations/admin/pt-BR.json
@@ -1848,7 +1848,6 @@
   "app.containers.AdminPage.ProjectEdit.topicLabel": "Tópicos",
   "app.containers.AdminPage.ProjectEdit.topicLabelTooltip": "Selecione {topicsCopy} para este projeto. Os usuários podem utilizá-los para filtrar projetos por.",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "Orçamento total",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "Por padrão, o seu orçamento é definido usando a sua moeda local. Você pode mudar a moeda da sua plataforma para 'créditos' ou 'fichas' entrando em contato com o nosso centro de suporte.",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "Tendência",
   "app.containers.AdminPage.ProjectEdit.typeform": "Typeform",
   "app.containers.AdminPage.ProjectEdit.unassigned": "Não atribuído",

--- a/front/app/translations/admin/ro-RO.json
+++ b/front/app/translations/admin/ro-RO.json
@@ -822,7 +822,6 @@
   "app.containers.AdminPage.ProjectEdit.topicLabel": "Tags",
   "app.containers.AdminPage.ProjectEdit.topicLabelTooltip": "Select {topicsCopy} for this project. Users can use these to filter projects by.",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "Total budget",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "By default, your budget is set using your local currency. You can change your platform's currency to 'credits' or 'tokens' by contacting our support center.",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "În tendințe",
   "app.containers.AdminPage.ProjectEdit.typeform": "Typeform",
   "app.containers.AdminPage.ProjectEdit.unassigned": "Neatribuit",

--- a/front/app/translations/admin/sr-Latn.json
+++ b/front/app/translations/admin/sr-Latn.json
@@ -1848,7 +1848,6 @@
   "app.containers.AdminPage.ProjectEdit.topicLabel": "Teme",
   "app.containers.AdminPage.ProjectEdit.topicLabelTooltip": "Izaberite {topicsCopy} za ovaj projekat. Korisnici ovo mogu da koriste za filtriranje projekata.",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "Ukupan budžet",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "Budžet je podrazumevano podešen u lokalnoj valuti. Valutu svoje platforme možete promeniti i u „krediti“ ili „žetoni“ tako što ćete kontaktirati naš centar za podršku.",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "U trendu",
   "app.containers.AdminPage.ProjectEdit.typeform": "Typeform",
   "app.containers.AdminPage.ProjectEdit.unassigned": "Nedodeljeno",

--- a/front/app/translations/admin/sr-SP.json
+++ b/front/app/translations/admin/sr-SP.json
@@ -1848,7 +1848,6 @@
   "app.containers.AdminPage.ProjectEdit.topicLabel": "Ознаке",
   "app.containers.AdminPage.ProjectEdit.topicLabelTooltip": "Изаберите {topicsCopy} за овај пројекат. Корисници могу да их користе за филтрирање пројеката према.",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "Укупан буџет",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "Ваш буџет је подразумевано подешен користећи локалну валуту. Можете да промените валуту своје платформе у „кредите“ или „токене“ тако што ћете контактирати наш центар за подршку.",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "У тренду",
   "app.containers.AdminPage.ProjectEdit.typeform": "Типеформ",
   "app.containers.AdminPage.ProjectEdit.unassigned": "Унассигнед",

--- a/front/app/translations/admin/sv-SE.json
+++ b/front/app/translations/admin/sv-SE.json
@@ -1848,7 +1848,6 @@
   "app.containers.AdminPage.ProjectEdit.topicLabel": "Ämnen",
   "app.containers.AdminPage.ProjectEdit.topicLabelTooltip": "Välj {topicsCopy} för det här projektet. Användare kan använda dem för att filtrera projekt efter.",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "Totalbudget",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "Som standard konfigureras din budget med din lokala valuta. Du kan ändra din plattforms valuta till \"krediter\" eller \"tokens\" genom att kontakta vårt supportcenter.",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "Trender",
   "app.containers.AdminPage.ProjectEdit.typeform": "Typeform",
   "app.containers.AdminPage.ProjectEdit.unassigned": "Otilldelad",

--- a/front/app/translations/admin/tr-TR.json
+++ b/front/app/translations/admin/tr-TR.json
@@ -1848,7 +1848,6 @@
   "app.containers.AdminPage.ProjectEdit.topicLabel": "Etiketler",
   "app.containers.AdminPage.ProjectEdit.topicLabelTooltip": "Bu proje için {topicsCopy} seçin. Kullanıcılar bunları projeleri filtreleme ölçütü olarak kullanabilir.",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "Toplam bütçe",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "Varsayılan olarak, bütçeniz yerel para biriminiz cinsinden belirlenir. Destek merkezimizle iletişime geçerek platformunuzun para birimini 'kredi' veya 'token' olarak değiştirebilirsiniz.",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "Popüler",
   "app.containers.AdminPage.ProjectEdit.typeform": "Typeform",
   "app.containers.AdminPage.ProjectEdit.unassigned": "Atanmamış",

--- a/front/app/translations/admin/ur-PK.json
+++ b/front/app/translations/admin/ur-PK.json
@@ -1848,7 +1848,6 @@
   "app.containers.AdminPage.ProjectEdit.topicLabel": "ٹیگز",
   "app.containers.AdminPage.ProjectEdit.topicLabelTooltip": "اس پروجیکٹ کے لیے {topicsCopy} کو منتخب کریں۔ صارفین ان کا استعمال کرکے پروجیکٹس کو فلٹر کرسکتے ہیں۔",
   "app.containers.AdminPage.ProjectEdit.totalBudget": "کل بجٹ",
-  "app.containers.AdminPage.ProjectEdit.totalBudgetExplanation": "پہلے سے طے شدہ طور پر، آپ کا بجٹ آپ کی مقامی کرنسی کا استعمال کرتے ہوئے سیٹ کیا جاتا ہے۔ آپ ہمارے سپورٹ سینٹر سے رابطہ کر کے اپنے پلیٹ فارم کی کرنسی کو 'کریڈٹس' یا 'ٹوکنز' میں تبدیل کر سکتے ہیں۔",
   "app.containers.AdminPage.ProjectEdit.trendingSortingMethod": "ٹرینڈنگ",
   "app.containers.AdminPage.ProjectEdit.typeform": "ٹائپ فارم",
   "app.containers.AdminPage.ProjectEdit.unassigned": "غیر تفویض کردہ",

--- a/front/app/translations/lt-LT.json
+++ b/front/app/translations/lt-LT.json
@@ -165,7 +165,6 @@
   "app.components.FilterBoxes.showTagsWithNumber": "Rodyti visus ({numberTags})",
   "app.components.FilterBoxes.statusTitle": "Statusas",
   "app.components.FilterBoxes.topicsTitle": "Žymos",
-  "app.components.FiltersModal.a11y_closeFilterPanel": "Uždarykite filtro skydelį",
   "app.components.FiltersModal.filters": "Filtrai",
   "app.components.FiltersModal.resetFilters": "Iš naujo nustatyti filtrus",
   "app.components.FolderFolderCard.a11y_folderDescription": "Aplankų aprašymas:",


### PR DESCRIPTION
# Changelog

## Fixed
- Remove wrong total budget explanation tooltip from project budgeting inputs
