### PR TITLE
Fix layout for longer statuses

### DIFF
--- a/front/app/components/FilterBoxes/TopicsFilter.tsx
+++ b/front/app/components/FilterBoxes/TopicsFilter.tsx
@@ -17,8 +17,6 @@ import { ITopicData } from 'api/topics/types';
 
 import useLocalize from 'hooks/useLocalize';
 
-import T from 'components/T';
-
 import { ScreenReaderOnly } from 'utils/a11y';
 import { trackEventByName } from 'utils/analytics';
 import { FormattedMessage, useIntl } from 'utils/cl-intl';
@@ -51,6 +49,7 @@ const Topic = styled.button<{ selected: boolean | undefined }>`
   border-radius: ${(props) => props.theme.borderRadius};
   transition: all 80ms ease-out;
   word-break: break-word;
+  text-align: left;
 
   ${isRtl`
       text-align: right;
@@ -155,7 +154,9 @@ const TopicsFilter = memo<Props>(
                       className={`e2e-topic ${topicSelected ? 'selected' : ''}`}
                       selected={topicSelected}
                     >
-                      <T value={topic.attributes.title_multiloc} />
+                      <Box as="span" mr="8px">
+                        {localize(topic.attributes.title_multiloc)}
+                      </Box>
                       <Box aria-hidden>{postCount}</Box>
                       <ScreenReaderOnly>
                         {`${postCount} ${formatMessage(messages.inputs)}`}

--- a/front/app/components/FilterBoxes/TopicsFilter.tsx
+++ b/front/app/components/FilterBoxes/TopicsFilter.tsx
@@ -165,7 +165,7 @@ const TopicsFilter = memo<Props>(
                       <Box as="span" mr="8px">
                         {localize(topic.attributes.title_multiloc)}
                       </Box>
-                      <Count aria-hidden>{1424}</Count>
+                      <Count aria-hidden>{postCount}</Count>
                       <ScreenReaderOnly>
                         {`${postCount} ${formatMessage(messages.inputs)}`}
                       </ScreenReaderOnly>

--- a/front/app/components/FilterBoxes/TopicsFilter.tsx
+++ b/front/app/components/FilterBoxes/TopicsFilter.tsx
@@ -70,6 +70,14 @@ const Topic = styled.button<{ selected: boolean | undefined }>`
   }
 `;
 
+const Count = styled.span`
+  // Prevents the count from breaking into multiple lines
+  // when the topic title is too long.
+  // Given the filter boxes keep their width,
+  // flex-shrink: 0 is not needed.
+  white-space: nowrap;
+`;
+
 interface Props {
   topics?: ITopicData[];
   selectedTopicIds: string[] | null | undefined;
@@ -157,7 +165,7 @@ const TopicsFilter = memo<Props>(
                       <Box as="span" mr="8px">
                         {localize(topic.attributes.title_multiloc)}
                       </Box>
-                      <Box aria-hidden>{postCount}</Box>
+                      <Count aria-hidden>{1424}</Count>
                       <ScreenReaderOnly>
                         {`${postCount} ${formatMessage(messages.inputs)}`}
                       </ScreenReaderOnly>


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Filter statuses layout for long statuses ([before](https://github.com/user-attachments/assets/64f7ea39-4b15-4961-8739-127521c46d3f)/[after](https://github.com/user-attachments/assets/099a8dbd-b859-4b11-95c8-f13f9bae89fb)).