### PR TITLE
fix: update Lithuanian locale code to use the correct abbreviation

### DIFF
--- a/front/app/containers/App/constants.ts
+++ b/front/app/containers/App/constants.ts
@@ -210,7 +210,7 @@ export const appLocalesMomentPairs = {
   'it-IT': 'it',
   'kl-GL': 'da',
   'lb-LU': 'lb',
-  'lt-LT': 'Lietuvių',
+  'lt-LT': 'lt',
   'lv-LV': 'lv',
   mi: 'mi',
   'nb-NO': 'nb',


### PR DESCRIPTION
# Changelog

## Fixed
- Fix crash when Lithuanian locale is added
