### PR TITLE
TAN-3253 Handle case where links is undefined

### DIFF
--- a/front/app/api/projects_mini/types.ts
+++ b/front/app/api/projects_mini/types.ts
@@ -33,7 +33,7 @@ export type MiniProjectsKeys = Keys<typeof miniProjectsKeys>;
 
 export interface MiniProjects {
   data: MiniProjectData[];
-  links: ILinks;
+  links?: ILinks;
 }
 
 export interface MiniProjectData {

--- a/front/app/api/projects_mini/useProjectsMini.ts
+++ b/front/app/api/projects_mini/useProjectsMini.ts
@@ -36,8 +36,10 @@ const useProjectsMini = (
       });
     },
     getNextPageParam: (lastPage) => {
-      const hasNextPage = lastPage.links.next;
-      const pageNumber = getPageNumberFromUrl(lastPage.links.self);
+      const links = lastPage.links;
+      if (!links) return null;
+      const hasNextPage = links.next;
+      const pageNumber = getPageNumberFromUrl(links.self);
       return hasNextPage && pageNumber ? pageNumber + 1 : null;
     },
     enabled,


### PR DESCRIPTION
# Changelog
## Technical
- For mini projects endpoints, the `links` attribute of the response is not included if the response is an empty array. The frontend previously couldn't handle that. Now it can.
