### PR TITLE
TAN-3129 Make admin pub cards same size as other project cards on mobile

### DIFF
--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/AdminPublicationsCarrousel/AdminPublicationCard/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/AdminPublicationsCarrousel/AdminPublicationCard/index.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 
-import { Box, Text, Icon, Title } from '@citizenlab/cl2-component-library';
+import {
+  Box,
+  Text,
+  Icon,
+  Title,
+  useBreakpoint,
+} from '@citizenlab/cl2-component-library';
 
 import { IAdminPublicationData } from 'api/admin_publications/types';
 import useProjectFolderImage from 'api/project_folder_images/useProjectFolderImage';
@@ -17,7 +23,7 @@ import Link from 'utils/cl-router/Link';
 import { truncate } from 'utils/textUtils';
 
 import { CardContainer, CardImage } from '../../BaseCard';
-import { CARD_WIDTH } from '../constants';
+import { BIG_CARD_WIDTH, SMALL_CARD_WIDTH } from '../constants';
 
 import messages from './messages';
 import { getPublicationURL } from './utils';
@@ -49,6 +55,9 @@ export const AdminPublicationCard = ({
 }: InnerProps) => {
   const { formatMessage } = useIntl();
   const localize = useLocalize();
+  const isSmallerThanPhone = useBreakpoint('phone');
+
+  const cardWidth = isSmallerThanPhone ? SMALL_CARD_WIDTH : BIG_CARD_WIDTH;
 
   const {
     visible_children_count,
@@ -62,7 +71,7 @@ export const AdminPublicationCard = ({
     <CardContainer
       as={Link}
       tabIndex={0}
-      w={`${CARD_WIDTH}px`}
+      w={`${cardWidth}px`}
       ml={ml}
       mr={mr}
       to={getPublicationURL(adminPublication)}

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/AdminPublicationsCarrousel/constants.ts
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/AdminPublicationsCarrousel/constants.ts
@@ -1,1 +1,2 @@
-export const CARD_WIDTH = 376;
+export { CARD_WIDTH as SMALL_CARD_WIDTH } from '../ProjectCarrousel/constants';
+export const BIG_CARD_WIDTH = 376;

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/AdminPublicationsCarrousel/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/AdminPublicationsCarrousel/index.tsx
@@ -27,7 +27,7 @@ import {
 } from '../BaseCarrousel/utils';
 
 import AdminPublicationCard from './AdminPublicationCard';
-import { CARD_WIDTH } from './constants';
+import { BIG_CARD_WIDTH, SMALL_CARD_WIDTH } from './constants';
 
 interface Props {
   title: string;
@@ -50,6 +50,7 @@ const AdminPublicationsCarrousel = ({
   const isSmallerThanPhone = useBreakpoint('phone');
   const instanceId = useInstanceId();
   const endId = `end-carrousel-${instanceId}`;
+  const cardWidth = isSmallerThanPhone ? SMALL_CARD_WIDTH : BIG_CARD_WIDTH;
 
   const { ref } = useInView({
     onChange: (inView) => {
@@ -95,8 +96,8 @@ const AdminPublicationsCarrousel = ({
     if (e.code === 'Tab' && scrollContainerRef) {
       setTimeout(() => {
         e.shiftKey
-          ? (scrollContainerRef.scrollLeft -= CARD_WIDTH + CARD_GAP)
-          : (scrollContainerRef.scrollLeft += CARD_WIDTH + CARD_GAP);
+          ? (scrollContainerRef.scrollLeft -= cardWidth + CARD_GAP)
+          : (scrollContainerRef.scrollLeft += cardWidth + CARD_GAP);
       }, 50);
     }
   };
@@ -135,8 +136,8 @@ const AdminPublicationsCarrousel = ({
             <CardContainer>
               <Box
                 ref={ref}
-                w={`${CARD_WIDTH}px`}
-                h={`${CARD_WIDTH / CARD_IMAGE_ASPECT_RATIO}px`}
+                w={`${cardWidth}px`}
+                h={`${cardWidth / CARD_IMAGE_ASPECT_RATIO}px`}
                 display="flex"
                 justifyContent="center"
                 alignItems="center"
@@ -153,7 +154,7 @@ const AdminPublicationsCarrousel = ({
               top="200px"
               onClick={() => {
                 if (!scrollContainerRef) return;
-                scrollContainerRef.scrollLeft -= CARD_WIDTH + CARD_GAP;
+                scrollContainerRef.scrollLeft -= cardWidth + CARD_GAP;
               }}
             />
             <Gradient variant="left" />
@@ -166,7 +167,7 @@ const AdminPublicationsCarrousel = ({
               top="200px"
               onClick={() => {
                 if (!scrollContainerRef) return;
-                scrollContainerRef.scrollLeft += CARD_WIDTH + CARD_GAP;
+                scrollContainerRef.scrollLeft += cardWidth + CARD_GAP;
               }}
             />
             <Gradient variant="right" />


### PR DESCRIPTION
# Changelog
## Changed
- Make larger carrousel cards same size as other carrousel cards on mobile. This way it's more clear on mobile that it's a carrousel that you can scroll
