### PR TITLE
[TAN-3254] Bugfix: BE includes links in response even when no items found for follows widget

### DIFF
--- a/back/app/controllers/web_api/v1/projects_controller.rb
+++ b/back/app/controllers/web_api/v1/projects_controller.rb
@@ -2,7 +2,6 @@
 
 class WebApi::V1::ProjectsController < ApplicationController
   before_action :set_project, only: %i[show update reorder destroy index_xlsx votes_by_user_xlsx votes_by_input_xlsx delete_inputs refresh_preview_token destroy_participation_data]
-  before_action :empty_data_for_visitor, only: [:index_for_followed_item]
 
   skip_before_action :authenticate_user
   skip_after_action :verify_policy_scoped, only: :index
@@ -340,13 +339,6 @@ class WebApi::V1::ProjectsController < ApplicationController
       }),
       include: %i[project_images current_phase]
     )
-  end
-
-  def empty_data_for_visitor
-    unless current_user
-      render json: { data: [] }, status: :ok
-      nil
-    end
   end
 end
 

--- a/back/app/services/projects_finder_service.rb
+++ b/back/app/services/projects_finder_service.rb
@@ -70,6 +70,9 @@ class ProjectsFinderService
   # ordered by the follow created_at (most recent first).
   # => [Project]
   def followed_by_user
+    # return empty collection if user is not signed in
+    return Project.none unless @user
+
     subquery = Follower
       .where(user_id: @user.id)
       .where.not(followable_type: 'Initiative')


### PR DESCRIPTION
# Changelog
## Technical
- [TAN-3254] Bugfix: BE includes links in response even when no items found for follows widget (feature in development)
