### PR TITLE
TAN-3169: Move survey page navigation buttons out of the progress bar

### DIFF
--- a/front/app/components/Form/Components/Layouts/CLSurveyPageLayout.tsx
+++ b/front/app/components/Form/Components/Layouts/CLSurveyPageLayout.tsx
@@ -462,7 +462,6 @@ const CLSurveyPageLayout = memo(
           maxWidth={isMapPage ? '1100px' : '700px'}
           w="100%"
           position="fixed"
-          bottom={isMobileOrSmaller ? '0' : '40px'}
           role="progressbar"
           aria-valuemin={0}
           aria-valuemax={100}
@@ -476,6 +475,13 @@ const CLSurveyPageLayout = memo(
               style={{ transition: 'width 0.3s ease-in-out' }}
             />
           </Box>
+        </Box>
+        <Box
+          maxWidth={isMapPage ? '1100px' : '700px'}
+          w="100%"
+          position="fixed"
+          bottom={isMobileOrSmaller ? '0' : '40px'}
+        >
           <PageControlButtons
             handleNextAndSubmit={handleNextAndSubmit}
             handlePrevious={handlePrevious}


### PR DESCRIPTION
# Changelog

## Fixed
- a11y: Move the survey page navigation buttons out of the progress bar to ensure they are correctly identified and operable by screen readers (Testing)
