### PR TITLE
[TAN-3248] Include projects for all areas in new homepage areas widget query

### DIFF
--- a/back/app/controllers/web_api/v1/projects_controller.rb
+++ b/back/app/controllers/web_api/v1/projects_controller.rb
@@ -112,9 +112,10 @@ class WebApi::V1::ProjectsController < ApplicationController
   # Ordered by created_at, newest first.
   def index_for_areas
     projects = policy_scope(Project)
+    projects = projects.not_draft
     projects = projects
-      .not_draft
-      .with_some_areas(params[:areas])
+      .where(include_all_areas: true)
+      .or(projects.with_some_areas(params[:areas]))
       .order(created_at: :desc)
 
     @projects = paginate projects


### PR DESCRIPTION
# Changelog
## Technical
- [TAN-3269](https://www.notion.so/govocal/Ensure-all-areas-projects-returned-by-BE-for-new-homepage-areas-widget-1569663b7b2680aaae4cf84583309185?pvs=4) Include projects for all areas in new homepage areas widget query (feature in development)
