### PR TITLE
TAN-3266: Fix disabled date picker

### DIFF
--- a/front/app/containers/Admin/projects/project/phaseSetup/components/DateSetup.tsx
+++ b/front/app/containers/Admin/projects/project/phaseSetup/components/DateSetup.tsx
@@ -58,8 +58,8 @@ const DateSetup = ({
     const otherPhases = phases.data.filter((phase) => phase.id !== phaseId);
     const disabledRanges = otherPhases.map(
       ({ attributes: { start_at, end_at } }) => ({
-        from: new Date(start_at),
-        to: end_at ? new Date(end_at) : undefined,
+        from: startOfDay(parseISO(start_at)),
+        to: end_at ? startOfDay(parseISO(end_at)) : undefined,
       })
     );
 


### PR DESCRIPTION
# Changelog

## Fixed
- This addresses an issue where the disabled date ranges in the date picker were affected by time zone differences. The problem arose from start_at and end_at dates being interpreted with time zones, causing inconsistencies in the date picker behavior
