### PR TITLE
TAN-3282 Broken project copy: Temporary fix

### DIFF
--- a/back/app/services/anonymize_user_service.rb
+++ b/back/app/services/anonymize_user_service.rb
@@ -119,11 +119,14 @@ class AnonymizeUserService
   def random_avatar_assignment(first_name, last_name, gender)
     gender = mismatch_gender(gender) if rand(30) == 0
 
-    if rand(5) == 0
-      { 'remote_avatar_url' => random_face_avatar_url(gender) }
-    else
-      { 'remote_avatar_url' => "#{@initials_avatars_url}#{(first_name[0] + last_name[0]).downcase}_avatar.png" }
-    end
+    # Some initials avatars, like do_avatar.png are currently broken.
+    # We are no longer using the initials avatars as a temporary fix.
+    # if rand(5) == 0
+    #   { 'remote_avatar_url' => random_face_avatar_url(gender) }
+    # else
+    #   { 'remote_avatar_url' => "#{@initials_avatars_url}#{(first_name[0] + last_name[0]).downcase}_avatar.png" }
+    # end
+    { 'remote_avatar_url' => random_face_avatar_url(gender) }
   rescue StandardError => e
     ErrorReporter.report e
     {}

--- a/back/app/services/anonymize_user_service.rb
+++ b/back/app/services/anonymize_user_service.rb
@@ -116,7 +116,7 @@ class AnonymizeUserService
     "#{email.split('@').first}_#{SecureRandom.uuid[...6]}@anonymized.com"
   end
 
-  def random_avatar_assignment(first_name, last_name, gender)
+  def random_avatar_assignment(_first_name, _last_name, gender)
     gender = mismatch_gender(gender) if rand(30) == 0
 
     # Some initials avatars, like do_avatar.png are currently broken.

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_deserializer.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/tenant_deserializer.rb
@@ -104,11 +104,13 @@ module MultiTenancy
             rescue StandardError => e
               json_info = {
                 error_message: e.message,
-                error_backtrace: e.backtrace,
                 model_class: model_class.name,
-                attributes: attributes
+                attributes: attributes,
+                error_backtrace: e.backtrace
               }.to_json
-              raise "Failed to create instance during template application: #{json_info}"
+              message = "Failed to create instance during template application: #{json_info}"
+              ErrorReporter.report_msg(message)
+              raise message
             end
 
             obj_to_id_and_class[attributes] = [model.id, model_class]


### PR DESCRIPTION
Some initials avatars are currently broken. For example: https://cl2-seed-and-template-assets.s3.eu-central-1.amazonaws.com/images/avatars/initials_avatars/do_avatar.png. The avatar images do exist in S3, but are somehow broken. What's strange is that they didn't seem to have been modified.

Hypothesis: These images have always been broken, but we updated Faker 5-6 months ago, which might have introduced this issue because new fake first and last names were introduced, resulting in new combinations for the initials. So the combination "DO" as initials might never have occurred until Faker was updated.

Another problem is that the full error was not visible in Admin HQ and no error was reported in Sentry. The former issue was "fixed" by showing the model and attributes before the stacktrace, the latter issue was fixed by using the error reporter.


# Changelog
### Fixed
- [TAN-3282] Temporary fix: Project copy without initials avatars (while working on fixing the initials avatars).
