### PR TITLE
[TAN-2940] Fix status capitalization issue

### DIFF
--- a/front/app/components/FilterBoxes/StatusFilter.tsx
+++ b/front/app/components/FilterBoxes/StatusFilter.tsx
@@ -9,7 +9,7 @@ import {
   colors,
   ColorIndicator,
 } from '@citizenlab/cl2-component-library';
-import { capitalize, get } from 'lodash-es';
+import { get } from 'lodash-es';
 import { darken } from 'polished';
 import styled from 'styled-components';
 
@@ -19,7 +19,7 @@ import T from 'components/T';
 
 import { ScreenReaderOnly } from 'utils/a11y';
 import { FormattedMessage, useIntl } from 'utils/cl-intl';
-import { removeFocusAfterMouseClick } from 'utils/helperUtils';
+import { capitalize, removeFocusAfterMouseClick } from 'utils/helperUtils';
 
 import InputFilterCollapsible from './InputFilterCollapsible';
 import messages from './messages';

--- a/front/app/components/FilterBoxes/StatusFilter.tsx
+++ b/front/app/components/FilterBoxes/StatusFilter.tsx
@@ -19,7 +19,8 @@ import T from 'components/T';
 
 import { ScreenReaderOnly } from 'utils/a11y';
 import { FormattedMessage, useIntl } from 'utils/cl-intl';
-import { capitalize, removeFocusAfterMouseClick } from 'utils/helperUtils';
+import { removeFocusAfterMouseClick } from 'utils/helperUtils';
+import { capitalize } from 'utils/textUtils';
 
 import InputFilterCollapsible from './InputFilterCollapsible';
 import messages from './messages';

--- a/front/app/components/IdeaCards/shared/Filters/StatusFilterDropdown.tsx
+++ b/front/app/components/IdeaCards/shared/Filters/StatusFilterDropdown.tsx
@@ -1,7 +1,5 @@
 import React, { useMemo } from 'react';
 
-import { capitalize } from 'lodash-es';
-
 import useIdeaStatuses from 'api/idea_statuses/useIdeaStatuses';
 
 import useLocalize from 'hooks/useLocalize';
@@ -9,6 +7,7 @@ import useLocalize from 'hooks/useLocalize';
 import FilterSelector from 'components/FilterSelector';
 
 import { FormattedMessage, useIntl } from 'utils/cl-intl';
+import { capitalize } from 'utils/helperUtils';
 
 import messages from '../../messages';
 

--- a/front/app/components/IdeaCards/shared/Filters/StatusFilterDropdown.tsx
+++ b/front/app/components/IdeaCards/shared/Filters/StatusFilterDropdown.tsx
@@ -7,7 +7,7 @@ import useLocalize from 'hooks/useLocalize';
 import FilterSelector from 'components/FilterSelector';
 
 import { FormattedMessage, useIntl } from 'utils/cl-intl';
-import { capitalize } from 'utils/helperUtils';
+import { capitalize } from 'utils/textUtils';
 
 import messages from '../../messages';
 

--- a/front/app/utils/helperUtils.ts
+++ b/front/app/utils/helperUtils.ts
@@ -163,10 +163,6 @@ export function isString(s: unknown): s is string {
   return typeof s === 'string';
 }
 
-export function capitalize(string: string) {
-  return string.charAt(0).toUpperCase() + string.slice(1);
-}
-
 export const isTopBarNavActive = (
   basePath: string,
   pathname: string,

--- a/front/app/utils/helperUtils.ts
+++ b/front/app/utils/helperUtils.ts
@@ -163,6 +163,10 @@ export function isString(s: unknown): s is string {
   return typeof s === 'string';
 }
 
+export function capitalize(string: string) {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
 export const isTopBarNavActive = (
   basePath: string,
   pathname: string,

--- a/front/app/utils/textUtils.test.ts
+++ b/front/app/utils/textUtils.test.ts
@@ -1,4 +1,4 @@
-import { withoutSpacing } from './textUtils';
+import { capitalize, withoutSpacing } from './textUtils';
 
 describe('withoutSpacing', () => {
   it('removes spaces from simple string', () => {
@@ -15,5 +15,17 @@ describe('withoutSpacing', () => {
       <li>${'with spaces 2'}</li>
     </ul>
   `).toEqual(expectedResult);
+  });
+});
+
+describe('capitalize', () => {
+  it('capitalizes strings correctly', () => {
+    expect(capitalize(`hello world`)).toEqual('Hello world');
+    expect(capitalize(`hello World`)).toEqual('Hello World');
+    expect(capitalize(`HELLO WORLD`)).toEqual('HELLO WORLD');
+    expect(capitalize('123')).toEqual('123');
+    expect(capitalize('!@#')).toEqual('!@#');
+    expect(capitalize('')).toEqual('');
+    expect(capitalize('a')).toEqual('A');
   });
 });

--- a/front/app/utils/textUtils.ts
+++ b/front/app/utils/textUtils.ts
@@ -1,5 +1,9 @@
 import { Multiloc } from 'typings';
 
+export function capitalize(string: string) {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
 export function truncate(str: string, length?: number) {
   if (typeof length === 'number' && str.length > length) {
     return `${str.substring(0, length - 3)}...`;


### PR DESCRIPTION
After hearing from Sebi that this is quite high-effort on the BE, I think that this is the best solution (and probably the one I should've gone with first, as it makes more sense).

The lodash `capitalize` function capitalizes the first letter, but then also forced all other letters to lowercase. I don't think this is really our intention when capitalizing strings. What we want is to just make sure the first letter is at least uppercase. 

I've added a new util function instead that's meant to replace our use of the lodash capitalize.

# Changelog
## Fixed
- [TAN-2940] Fix status capitalization issue (specifically impacted the German locale).
