### PR TITLE
TAN-3270 Change default authentication flow from signup to signin

### DIFF
--- a/front/app/components/IdeaButton/index.tsx
+++ b/front/app/components/IdeaButton/index.tsx
@@ -103,7 +103,7 @@ const IdeaButton = memo<Props>(
       trackEventByName(tracks.postYourIdeaButtonClicked);
 
       if (authenticationRequirements) {
-        signUp();
+        signIn();
         return;
       }
 
@@ -113,8 +113,8 @@ const IdeaButton = memo<Props>(
       }
     };
 
-    const signUp = (event?: React.MouseEvent) => {
-      signUpIn('signup')(event);
+    const signIn = (event?: React.MouseEvent) => {
+      signUpIn('signin')(event);
     };
 
     const signUpIn =

--- a/front/app/containers/Authentication/events.ts
+++ b/front/app/containers/Authentication/events.ts
@@ -13,7 +13,7 @@ type Event = {
 
 export function triggerAuthenticationFlow(
   partialAuthenticationData?: Partial<AuthenticationData>,
-  flow: 'signup' | 'signin' = 'signup'
+  flow: 'signup' | 'signin' = 'signin'
 ) {
   const authenticationData: AuthenticationData = {
     context: partialAuthenticationData?.context ?? GLOBAL_CONTEXT,

--- a/front/cypress/e2e/auth/verification_modal.cy.ts
+++ b/front/cypress/e2e/auth/verification_modal.cy.ts
@@ -50,7 +50,7 @@ describe('Verification modal', () => {
       cy.visit('/projects/verified-charlie-poeple-project');
       cy.get('.e2e-idea-button').first().find('button').should('exist');
       cy.get('.e2e-idea-button').first().find('button').click({ force: true });
-
+      cy.get('#e2e-goto-signup').click();
       // email/password sign up step
       cy.get('#e2e-sign-up-email-password-container');
       const firstName = randomString();

--- a/front/cypress/e2e/auth/verification_modal.cy.ts
+++ b/front/cypress/e2e/auth/verification_modal.cy.ts
@@ -50,8 +50,9 @@ describe('Verification modal', () => {
       cy.visit('/projects/verified-charlie-poeple-project');
       cy.get('.e2e-idea-button').first().find('button').should('exist');
       cy.get('.e2e-idea-button').first().find('button').click({ force: true });
-      cy.get('#e2e-goto-signup').click();
+
       // email/password sign up step
+      cy.get('#e2e-goto-signup').click();
       cy.get('#e2e-sign-up-email-password-container');
       const firstName = randomString();
       const lastName = randomString();
@@ -100,6 +101,7 @@ describe('Verification modal', () => {
       cy.get('.e2e-idea-button').first().find('button').click({ force: true });
 
       // email/password sign up step
+      cy.get('#e2e-goto-signup').click();
       cy.get('#e2e-sign-up-email-password-container');
       const firstName = randomString();
       const lastName = randomString();

--- a/front/cypress/e2e/idea_voting_permissions.cy.ts
+++ b/front/cypress/e2e/idea_voting_permissions.cy.ts
@@ -18,6 +18,7 @@ describe('Idea reacting permissions', () => {
 
       // sign up modal check
       cy.get('#e2e-authentication-modal').should('exist');
+      cy.get('#e2e-goto-signup').click();
       cy.get('#firstName').type(firstName);
       cy.get('#lastName').type(lastName);
       cy.get('#email').type(email);
@@ -141,6 +142,7 @@ describe('Idea reacting permissions', () => {
 
       // Sign up flow
       cy.get('#e2e-authentication-modal');
+      cy.get('#e2e-goto-signup').click();
       cy.get('#firstName').type(firstName);
       cy.get('#lastName').type(lastName);
       cy.get('#email').type(email);

--- a/front/cypress/e2e/native_survey_permissions.cy.ts
+++ b/front/cypress/e2e/native_survey_permissions.cy.ts
@@ -101,6 +101,7 @@ describe('Native survey permissions', () => {
       const email = randomEmail();
       const password = randomString();
 
+      cy.get('#e2e-goto-signup').click();
       cy.get('#firstName').type(firstName);
       cy.get('#lastName').type(lastName);
       cy.get('#email').type(email);
@@ -156,6 +157,7 @@ describe('Native survey permissions', () => {
       const email = randomEmail();
       const password = randomString();
 
+      cy.get('#e2e-goto-signup').click();
       cy.get('#firstName').type(firstName);
       cy.get('#lastName').type(lastName);
       cy.get('#email').type(email);


### PR DESCRIPTION
# Changelog
## Changed
- From now on, actions that trigger the authentication flow when a user is signed out will default to the sign in flow rather than the sign up flow
