### PR TITLE
TAN-3282 Restore initials avatars

### DIFF
--- a/back/app/services/anonymize_user_service.rb
+++ b/back/app/services/anonymize_user_service.rb
@@ -116,17 +116,14 @@ class AnonymizeUserService
     "#{email.split('@').first}_#{SecureRandom.uuid[...6]}@anonymized.com"
   end
 
-  def random_avatar_assignment(_first_name, _last_name, gender)
+  def random_avatar_assignment(first_name, last_name, gender)
     gender = mismatch_gender(gender) if rand(30) == 0
 
-    # Some initials avatars, like do_avatar.png are currently broken.
-    # We are no longer using the initials avatars as a temporary fix.
-    # if rand(5) == 0
-    #   { 'remote_avatar_url' => random_face_avatar_url(gender) }
-    # else
-    #   { 'remote_avatar_url' => "#{@initials_avatars_url}#{(first_name[0] + last_name[0]).downcase}_avatar.png" }
-    # end
-    { 'remote_avatar_url' => random_face_avatar_url(gender) }
+    if rand(5) == 0
+      { 'remote_avatar_url' => random_face_avatar_url(gender) }
+    else
+      { 'remote_avatar_url' => "#{@initials_avatars_url}#{(first_name[0] + last_name[0]).downcase}_avatar.png" }
+    end
   rescue StandardError => e
     ErrorReporter.report e
     {}

--- a/back/spec/acceptance/phases_spec.rb
+++ b/back/spec/acceptance/phases_spec.rb
@@ -550,7 +550,7 @@ resource 'Phases' do
                 phase,
                 'changed_manual_voters_amount',
                 User.admin.first,
-                phase.updated_at.to_i,
+                anything,
                 payload: { change: [nil, manual_voters_amount] },
                 project_id: phase.project_id
               ).exactly(1).times


### PR DESCRIPTION
A proper fix was realized by generating and uploading the broken images to s3: `do_avatar.png` and `fo_avatar.png`.

Also included a fix for a flaky spec. Previous occurrences were already fixed the same way, but this one still slipped through.

# Changelog
### Fixed
- [TAN-3282] Initials avatars are back for project copy.