### PR TITLE
[TAN-3240] Clean up MapView filter view

### DIFF
--- a/front/app/components/IdeaCards/IdeasWithFiltersSidebar/MapView/TopBar.tsx
+++ b/front/app/components/IdeaCards/IdeasWithFiltersSidebar/MapView/TopBar.tsx
@@ -19,26 +19,27 @@ const TopBar = ({ onClose }: Props) => {
       borderBottom={`1px solid ${colors.grey300}`}
       display="flex"
       alignItems="center"
-      justifyContent="space-between"
-      px="16px"
+      justifyContent="center"
+      position="relative"
     >
       <Title
-        as="h2"
-        variant="h5"
+        id="full-screen-modal-title"
+        as={'h2'}
+        variant={'h5'}
+        m="0"
+        p="16px"
         fontWeight="bold"
-        // CloseIconButton has margin or padding on the right,
-        // which makes the px from Box above look assymetical
-        // This ml visually corrects this.
-        ml="8px"
       >
         <FormattedMessage {...messages.filters} />
       </Title>
-      <CloseIconButton
-        a11y_buttonActionMessage={messages.a11y_closeFilterPanel}
-        onClick={onClose}
-        iconColor={colors.textSecondary}
-        iconColorOnHover={colors.grey800}
-      />
+      <Box position="absolute" right="8px">
+        <CloseIconButton
+          a11y_buttonActionMessage={messages.a11y_closeFilterPanel}
+          onClick={onClose}
+          iconColor={colors.textSecondary}
+          iconColorOnHover={colors.grey800}
+        />
+      </Box>
     </Box>
   );
 };

--- a/front/app/components/IdeaCards/IdeasWithFiltersSidebar/MapView/TopBar.tsx
+++ b/front/app/components/IdeaCards/IdeasWithFiltersSidebar/MapView/TopBar.tsx
@@ -22,14 +22,7 @@ const TopBar = ({ onClose }: Props) => {
       justifyContent="center"
       position="relative"
     >
-      <Title
-        id="full-screen-modal-title"
-        as={'h2'}
-        variant={'h5'}
-        m="0"
-        p="16px"
-        fontWeight="bold"
-      >
+      <Title as={'h2'} variant={'h5'} m="0" p="16px" fontWeight="bold">
         <FormattedMessage {...messages.filters} />
       </Title>
       <Box position="absolute" right="8px">


### PR DESCRIPTION
There were 3 points for this cleanup ticket:
- Use the same styles as in FiltersModal? So a top bar that’s less high, with centered title, etc. **Done!** :heavy_check_mark: 
- It still has `TopBar` , whereas we moved that part inside `FullscreenModal` for the `FiltersModal`. Should we keep it?
    - ***Amanda**: I think it’s cleaner in the MapView to have it as a separate component at least - keeps FiltersMapView more abstracted*
- See if we can use a reusable CloseIconButton, because I’ve updated in 2 spots already and missed the one in `TopBar` in this folder
    - _**Amanda**: This makes sense actually, since I had to add this TopBar back in before release since it got removed from the MapView. This CloseIconButton styling is only used in 2 fairly different components (FullscreenModal & FiltersMapView), so I feel it’s ok as-is?_ :thinking:
