### PR TITLE
TAN-3271 Add keyboard navigation to survey form builder multi and single questions

### DIFF
--- a/front/app/component-library/components/Tooltip/index.tsx
+++ b/front/app/component-library/components/Tooltip/index.tsx
@@ -25,26 +25,90 @@ const useActiveElement = () => {
   };
 
   useEffect(() => {
-    document.addEventListener('focusin', handleFocusIn);
-    return () => {
-      document.removeEventListener('focusin', handleFocusIn);
-    };
-  }, []);
-
-  useEffect(() => {
     document.addEventListener('click', handleOutsideClick);
     return () => {
       document.removeEventListener('click', handleOutsideClick);
     };
   });
 
+  useEffect(() => {
+    document.addEventListener('focusin', handleFocusIn);
+    return () => {
+      document.removeEventListener('focusin', handleFocusIn);
+    };
+  }, []);
+
   return active;
+};
+
+const TippyComponent = ({
+  children,
+  theme,
+  width,
+  key,
+  isFocused,
+  setIsFocused,
+  setKey,
+  tooltipId,
+  ...rest
+}: {
+  children: React.ReactNode;
+  theme: string;
+  width: string | undefined;
+  key: number;
+  isFocused: boolean | undefined;
+  setIsFocused: React.Dispatch<React.SetStateAction<boolean | undefined>>;
+  setKey: React.Dispatch<React.SetStateAction<number>>;
+  tooltipId: React.MutableRefObject<string>;
+} & TooltipProps) => {
+  return (
+    <Tippy
+      key={key}
+      plugins={[
+        {
+          name: 'hideOnEsc',
+          defaultValue: true,
+          fn({ hide }) {
+            function onKeyDown(event: KeyboardEvent) {
+              if (event.key === 'Escape') {
+                hide();
+              }
+            }
+
+            return {
+              onShow() {
+                document.addEventListener('keydown', onKeyDown);
+              },
+              onHide() {
+                document.removeEventListener('keydown', onKeyDown);
+              },
+            };
+          },
+        },
+      ]}
+      interactive={true}
+      role="tooltip"
+      visible={isFocused}
+      // Ensures tippy works with both keyboard and mouse
+      onHidden={() => {
+        setIsFocused(undefined);
+        setKey((prev) => prev + 1);
+      }}
+      theme={theme}
+      {...rest}
+    >
+      <Box as="span" id={tooltipId.current} w={width || 'fit-content'}>
+        {children}
+      </Box>
+    </Tippy>
+  );
 };
 
 const Tooltip = ({
   children,
   theme = 'light',
   width,
+  // This prop is used to determine if the native Tippy component should be wrapped in a Box component
   useWrapper = true,
   ...rest
 }: TooltipProps) => {
@@ -72,87 +136,35 @@ const Tooltip = ({
 
   if (useWrapper) {
     return (
-      <Tippy
+      <TippyComponent
         key={key}
-        plugins={[
-          {
-            name: 'hideOnEsc',
-            defaultValue: true,
-            fn({ hide }) {
-              function onKeyDown(event: KeyboardEvent) {
-                if (event.key === 'Escape') {
-                  hide();
-                }
-              }
-
-              return {
-                onShow() {
-                  document.addEventListener('keydown', onKeyDown);
-                },
-                onHide() {
-                  document.removeEventListener('keydown', onKeyDown);
-                },
-              };
-            },
-          },
-        ]}
-        interactive={true}
-        role="tooltip"
-        visible={isFocused}
-        // Ensures tippy works with both keyboard and mouse
-        onHidden={() => {
-          setIsFocused(undefined);
-          setKey((prev) => prev + 1);
-        }}
         theme={theme}
+        width={width}
+        isFocused={isFocused}
+        setIsFocused={setIsFocused}
+        setKey={setKey}
+        tooltipId={tooltipId}
         {...rest}
       >
-        <Box as="span" id={tooltipId.current} w={width || 'fit-content'}>
-          {children}
-        </Box>
-      </Tippy>
+        {children}
+      </TippyComponent>
     );
   } else {
     return (
       // This option is used for more accessible tooltips when useWrapper is false
       <Box as="span" id={tooltipId.current} w={width || 'fit-content'}>
-        <Tippy
+        <TippyComponent
           key={key}
-          plugins={[
-            {
-              name: 'hideOnEsc',
-              defaultValue: true,
-              fn({ hide }) {
-                function onKeyDown(event: KeyboardEvent) {
-                  if (event.key === 'Escape') {
-                    hide();
-                  }
-                }
-
-                return {
-                  onShow() {
-                    document.addEventListener('keydown', onKeyDown);
-                  },
-                  onHide() {
-                    document.removeEventListener('keydown', onKeyDown);
-                  },
-                };
-              },
-            },
-          ]}
-          interactive={true}
-          role="tooltip"
-          visible={isFocused}
-          // Ensures tippy works with both keyboard and mouse
-          onHidden={() => {
-            setIsFocused(undefined);
-            setKey((prev) => prev + 1);
-          }}
           theme={theme}
+          width={width}
+          isFocused={isFocused}
+          setIsFocused={setIsFocused}
+          setKey={setKey}
+          tooltipId={tooltipId}
           {...rest}
         >
           {children}
-        </Tippy>
+        </TippyComponent>
       </Box>
     );
   }

--- a/front/app/components/FormBuilder/components/FormBuilderSettings/ConfigSelectWithLocaleSwitcher/SelectFieldOption.tsx
+++ b/front/app/components/FormBuilder/components/FormBuilderSettings/ConfigSelectWithLocaleSwitcher/SelectFieldOption.tsx
@@ -106,6 +106,7 @@ const SelectFieldOption = memo(
               choice.title_multiloc[locale] = value;
               onChoiceUpdate(choice, index);
             }}
+            autoFocus={false}
           />
 
           {showImageSettings && (

--- a/front/app/components/FormBuilder/components/FormBuilderSettings/ConfigSelectWithLocaleSwitcher/index.tsx
+++ b/front/app/components/FormBuilder/components/FormBuilderSettings/ConfigSelectWithLocaleSwitcher/index.tsx
@@ -58,6 +58,12 @@ const ConfigSelectWithLocaleSwitcher = ({
     formState: { errors: formContextErrors },
     trigger,
   } = useFormContext();
+
+  // Handles drag and drop
+  const { move, update, append, remove, insert } = useFieldArray({
+    name,
+  });
+
   const [selectedLocale, setSelectedLocale] = useState<SupportedLocale | null>(
     platformLocale
   );
@@ -108,26 +114,6 @@ const ConfigSelectWithLocaleSwitcher = ({
     onSelectedLocaleChange?.(platformLocale);
   }, [platformLocale, onSelectedLocaleChange]);
 
-  const handleOnSelectedLocaleChange = useCallback(
-    (newSelectedLocale: SupportedLocale) => {
-      setSelectedLocale(newSelectedLocale);
-      onSelectedLocaleChange?.(newSelectedLocale);
-    },
-    [onSelectedLocaleChange]
-  );
-
-  // Handles drag and drop
-  const { move, update, append, remove, insert } = useFieldArray({
-    name,
-  });
-
-  const handleDragRow = useCallback(
-    (fromIndex: number, toIndex: number) => {
-      move(fromIndex, toIndex);
-    },
-    [move]
-  );
-
   const addOption = useCallback(() => {
     const otherOptionIndex = selectOptions.findIndex(
       (choice) => choice.other === true
@@ -144,7 +130,43 @@ const ConfigSelectWithLocaleSwitcher = ({
     };
 
     insert(insertIndex, newOption);
+    document.getElementById(`e2e-option-input-${insertIndex}`)?.focus();
   }, [insert, inputType, selectOptions]);
+
+  // Handles adding an option when pressing enter
+  // It only works when the focus is on the input fields
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        document
+          .getElementById('select-options')
+          ?.contains(document.activeElement) &&
+        event.key === 'Enter'
+      ) {
+        addOption();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [addOption]);
+
+  const handleOnSelectedLocaleChange = useCallback(
+    (newSelectedLocale: SupportedLocale) => {
+      setSelectedLocale(newSelectedLocale);
+      onSelectedLocaleChange?.(newSelectedLocale);
+    },
+    [onSelectedLocaleChange]
+  );
+
+  const handleDragRow = useCallback(
+    (fromIndex: number, toIndex: number) => {
+      move(fromIndex, toIndex);
+    },
+    [move]
+  );
 
   const removeOption = useCallback(
     (index: number) => {
@@ -219,6 +241,7 @@ const ConfigSelectWithLocaleSwitcher = ({
                 onBlur();
                 trigger();
               }}
+              id="select-options"
             >
               <SectionField>
                 <Box
@@ -304,25 +327,8 @@ const ConfigSelectWithLocaleSwitcher = ({
                   data-cy="e2e-add-answer"
                   onClick={addOption}
                   text={formatMessage(messages.addAnswer)}
+                  type="button"
                 />
-
-                <Box mt="24px" data-cy="e2e-other-option-toggle">
-                  <Toggle
-                    label={
-                      <Box display="flex">
-                        {formatMessage(messages.otherOption)}
-                        <Box pl="4px">
-                          <IconTooltip
-                            placement="top-start"
-                            content={formatMessage(messages.otherOptionTooltip)}
-                          />
-                        </Box>
-                      </Box>
-                    }
-                    checked={hasOtherOption}
-                    onChange={toggleOtherOption}
-                  />
-                </Box>
 
                 {validationError && (
                   <Error
@@ -341,6 +347,24 @@ const ConfigSelectWithLocaleSwitcher = ({
                     scrollIntoView={false}
                   />
                 )}
+
+                <Box mt="24px" data-cy="e2e-other-option-toggle">
+                  <Toggle
+                    label={
+                      <Box display="flex">
+                        {formatMessage(messages.otherOption)}
+                        <Box pl="4px">
+                          <IconTooltip
+                            placement="top-start"
+                            content={formatMessage(messages.otherOptionTooltip)}
+                          />
+                        </Box>
+                      </Box>
+                    }
+                    checked={hasOtherOption}
+                    onChange={toggleOtherOption}
+                  />
+                </Box>
               </SectionField>
             </Box>
           );


### PR DESCRIPTION
# Changelog
## Added
- Users can now add answer options to the multi and single choice survey questions in the form builder by pressing the "Enter" key, as long as they are already editing the answer options.
