### PR TITLE
[TAN-3332] BE returns followed & all-areas projects from index_for_areas if param omitted

### DIFF
--- a/back/app/controllers/web_api/v1/projects_controller.rb
+++ b/back/app/controllers/web_api/v1/projects_controller.rb
@@ -108,32 +108,12 @@ class WebApi::V1::ProjectsController < ApplicationController
   end
 
   # For use with 'Areas or topics' homepage widget. Uses ProjectMiniSerializer.
-  # Returns all non-draft projects that are visible to user, for the selected areas.
+  # If :areas param: Returns all non-draft projects that are visible to user, for the selected areas.
+  # Else: Returns all non-draft projects that are visible to user, for the areas user follows or for all-areas.
   # Ordered by created_at, newest first.
   def index_for_areas
     projects = policy_scope(Project)
-    projects = projects.not_draft
-
-    projects = if params[:areas].present?
-      projects.where(include_all_areas: true).or(projects.with_some_areas(params[:areas]))
-    else
-      subquery = Follower
-        .where(user_id: current_user&.id)
-        .where.not(followable_type: 'Initiative')
-        .joins(
-          'LEFT JOIN areas AS followed_areas ON followers.followable_type = \'Area\' ' \
-          'AND followed_areas.id = followers.followable_id'
-        )
-        .joins('LEFT JOIN areas_projects ON areas_projects.area_id = followed_areas.id')
-        .joins(
-          'INNER JOIN projects ON areas_projects.project_id = projects.id'
-        )
-        .select('projects.id AS project_id')
-
-      projects.where(include_all_areas: true).or(projects.where(id: subquery))
-    end
-
-    projects = projects.order(created_at: :desc)
+    projects = ProjectsFinderService.new(projects, current_user, params).projects_for_areas
 
     @projects = paginate projects
     @projects = @projects.includes(:project_images, phases: [:report, { permissions: [:groups] }])

--- a/back/app/services/projects_finder_service.rb
+++ b/back/app/services/projects_finder_service.rb
@@ -5,6 +5,7 @@ class ProjectsFinderService
     @page_size = (params.dig(:page, :size) || 500).to_i
     @page_number = (params.dig(:page, :number) || 1).to_i
     @filter_by = params[:filter_by]
+    @areas = params[:areas]
   end
 
   # Returns an ActiveRecord collection of published projects that are
@@ -110,6 +111,29 @@ class ProjectsFinderService
       .joins("INNER JOIN (#{subquery.to_sql}) AS subquery ON projects.id = subquery.project_id")
       .select('projects.*, subquery.latest_follower_created_at')
       .order('subquery.latest_follower_created_at DESC')
+  end
+
+  def projects_for_areas
+    @projects = @projects.not_draft
+
+    projects = if @areas.present?
+      @projects.where(include_all_areas: true).or(@projects.with_some_areas(@areas))
+    else
+      subquery = Follower
+        .where(user_id: @user&.id)
+        .where.not(followable_type: 'Initiative')
+        .joins(
+          'LEFT JOIN areas AS followed_areas ON followers.followable_type = \'Area\' ' \
+          'AND followed_areas.id = followers.followable_id'
+        )
+        .joins('LEFT JOIN areas_projects ON areas_projects.area_id = followed_areas.id')
+        .joins('INNER JOIN projects ON areas_projects.project_id = projects.id')
+        .select('projects.id AS project_id')
+
+      @projects.where(include_all_areas: true).or(@projects.where(id: subquery))
+    end
+
+    projects.order(created_at: :desc)
   end
 
   # Returns ActiveRecord collection of projects that are either (finished OR have a last phase that contains a report)

--- a/back/app/services/projects_finder_service.rb
+++ b/back/app/services/projects_finder_service.rb
@@ -113,6 +113,11 @@ class ProjectsFinderService
       .order('subquery.latest_follower_created_at DESC')
   end
 
+  # Returns an ActiveRecord collection of published projects, visible to user, that are also
+  # If :areas param: Returns all non-draft projects that are visible to user, for the selected areas.
+  # Else: Returns all non-draft projects that are visible to user, for the areas the user follows or for all-areas.
+  # Ordered by created_at, newest first.
+  # # => [Project]
   def projects_for_areas
     @projects = @projects.not_draft
 

--- a/back/spec/acceptance/projects_mini_spec.rb
+++ b/back/spec/acceptance/projects_mini_spec.rb
@@ -345,7 +345,7 @@ resource 'ProjectsMini' do # == Projects, but labeled as ProjectsMini, to help d
     let!(:area1) { create(:area) }
     let!(:area2) { create(:area) }
     let!(:project_with_areas) { create(:project_with_active_ideation_phase) }
-    let!(:areas_project1) { create(:areas_project, project: project_with_areas, area: area1) }
+    let!(:_areas_project1) { create(:areas_project, project: project_with_areas, area: area1) }
     let!(:_areas_project2) { create(:areas_project, project: project_with_areas, area: area2) }
 
     let!(:project_for_all_areas) { create(:project_with_active_ideation_phase, include_all_areas: true) }
@@ -362,32 +362,6 @@ resource 'ProjectsMini' do # == Projects, but labeled as ProjectsMini, to help d
       expect(project_ids).to match_array [project_with_areas.id, project_for_all_areas.id]
     end
 
-    example 'Orders projects by created_at DESC', document: false do
-      project2 = create(:project)
-      project3 = create(:project)
-      create(:areas_project, project: project2, area: area1)
-      create(:areas_project, project: project3, area: area1)
-
-      project_with_areas.update!(created_at: 4.days.ago)
-      project2.update!(created_at: 1.day.ago)
-      project3.update!(created_at: 3.days.ago)
-      project_for_all_areas.update!(created_at: 2.days.ago)
-
-      do_request areas: [area1.id]
-      expect(status).to eq 200
-
-      project_ids = json_response[:data].pluck(:id)
-      expect(project_ids).to eq [project2.id, project_for_all_areas.id, project3.id, project_with_areas.id]
-    end
-
-    example_request 'Does not return duplicate projects when more than one areas_project matches', document: false do
-      do_request areas: [area1.id, area2.id]
-      expect(status).to eq 200
-
-      project_ids = json_response[:data].pluck(:id)
-      expect(project_ids).to match_array [project_with_areas.id, project_for_all_areas.id]
-    end
-
     example_request 'Returns projects for followed areas & for all areas when areas param is nil', document: false do
       create(:follower, followable: area1, user: @user)
 
@@ -395,23 +369,6 @@ resource 'ProjectsMini' do # == Projects, but labeled as ProjectsMini, to help d
       expect(status).to eq 200
 
       expect(json_response[:data].pluck(:id)).to match_array [project_for_all_areas.id, project_with_areas.id]
-    end
-
-    context 'when admin' do
-      before do
-        @user = create(:admin)
-        header_token_for @user
-      end
-
-      example 'Does not include draft projects', document: false do
-        project_with_areas.update!(admin_publication_attributes: { publication_status: 'draft' })
-
-        do_request areas: [area1.id]
-        expect(status).to eq 200
-
-        project_ids = json_response[:data].pluck(:id)
-        expect(project_ids).to eq [project_for_all_areas.id]
-      end
     end
   end
 

--- a/back/spec/acceptance/projects_mini_spec.rb
+++ b/back/spec/acceptance/projects_mini_spec.rb
@@ -345,7 +345,7 @@ resource 'ProjectsMini' do # == Projects, but labeled as ProjectsMini, to help d
     let!(:area1) { create(:area) }
     let!(:area2) { create(:area) }
     let!(:project_with_areas) { create(:project_with_active_ideation_phase) }
-    let!(:_areas_project1) { create(:areas_project, project: project_with_areas, area: area1) }
+    let!(:areas_project1) { create(:areas_project, project: project_with_areas, area: area1) }
     let!(:_areas_project2) { create(:areas_project, project: project_with_areas, area: area2) }
 
     let!(:project_for_all_areas) { create(:project_with_active_ideation_phase, include_all_areas: true) }
@@ -388,12 +388,13 @@ resource 'ProjectsMini' do # == Projects, but labeled as ProjectsMini, to help d
       expect(project_ids).to match_array [project_with_areas.id, project_for_all_areas.id]
     end
 
-    example_request 'Returns empty list when areas param is nil and no projects are for all areas', document: false do
-      project_for_all_areas.destroy!
+    example_request 'Returns projects for followed areas & for all areas when areas param is nil', document: false do
+      create(:follower, followable: area1, user: @user)
 
       do_request
       expect(status).to eq 200
-      expect(json_response[:data]).to eq []
+
+      expect(json_response[:data].pluck(:id)).to match_array [project_for_all_areas.id, project_with_areas.id]
     end
 
     context 'when admin' do

--- a/back/spec/acceptance/projects_mini_spec.rb
+++ b/back/spec/acceptance/projects_mini_spec.rb
@@ -362,7 +362,7 @@ resource 'ProjectsMini' do # == Projects, but labeled as ProjectsMini, to help d
       expect(project_ids).to match_array [project_with_areas.id, project_for_all_areas.id]
     end
 
-    example_request 'Returns projects for followed areas & for all areas when areas param is nil', document: false do
+    example_request 'Returns projects for followed areas & for all areas when areas param is blank', document: false do
       create(:follower, followable: area1, user: @user)
 
       do_request


### PR DESCRIPTION
# Changelog
## Technical
- [TAN-3332] BE returns followed & all-areas projects from index_for_areas if param omitted (new homepage 'for areas' widget in development)
