### PR TITLE
Don't needlessly re-render other mobile nav items on toggling the full-screen nav

### DIFF
--- a/front/app/containers/MainHeader/Components/NavbarContent/MobileNavbarContent/MobileNavWithLaunchButton/index.tsx
+++ b/front/app/containers/MainHeader/Components/NavbarContent/MobileNavbarContent/MobileNavWithLaunchButton/index.tsx
@@ -6,7 +6,7 @@ import tracks from '../../../../tracks';
 import ShowFullMenuButton from '../ShowFullMenuButton';
 const FullMobileNavMenu = lazy(() => import('../FullMobileNavMenu'));
 
-const MobileNavWithLaunchButton = () => {
+const ButtonWithFullMobileNavMenu = () => {
   const [isFullMenuOpened, setIsFullMenuOpened] = useState(false);
 
   const toggleFullMenu = () => {
@@ -31,4 +31,4 @@ const MobileNavWithLaunchButton = () => {
   );
 };
 
-export default MobileNavWithLaunchButton;
+export default ButtonWithFullMobileNavMenu;

--- a/front/app/containers/MainHeader/Components/NavbarContent/MobileNavbarContent/MobileNavWithLaunchButton/index.tsx
+++ b/front/app/containers/MainHeader/Components/NavbarContent/MobileNavbarContent/MobileNavWithLaunchButton/index.tsx
@@ -1,0 +1,34 @@
+import React, { Suspense, lazy, useState } from 'react';
+
+import { trackEventByName } from 'utils/analytics';
+
+import tracks from '../../../../tracks';
+import ShowFullMenuButton from '../ShowFullMenuButton';
+const FullMobileNavMenu = lazy(() => import('../FullMobileNavMenu'));
+
+const MobileNavWithLaunchButton = () => {
+  const [isFullMenuOpened, setIsFullMenuOpened] = useState(false);
+
+  const toggleFullMenu = () => {
+    setIsFullMenuOpened(!isFullMenuOpened);
+    trackEventByName(
+      isFullMenuOpened
+        ? tracks.moreButtonClickedFullMenuOpened
+        : tracks.moreButtonClickedFullMenuClosed
+    );
+  };
+
+  return (
+    <>
+      <ShowFullMenuButton onClick={toggleFullMenu} />
+      <Suspense fallback={null}>
+        <FullMobileNavMenu
+          isFullMenuOpened={isFullMenuOpened}
+          onClose={toggleFullMenu}
+        />
+      </Suspense>
+    </>
+  );
+};
+
+export default MobileNavWithLaunchButton;

--- a/front/app/containers/MainHeader/Components/NavbarContent/MobileNavbarContent/index.tsx
+++ b/front/app/containers/MainHeader/Components/NavbarContent/MobileNavbarContent/index.tsx
@@ -15,7 +15,7 @@ import LanguageSelector from '../../LanguageSelector';
 import NotificationMenu from '../../NotificationMenu';
 import UserMenu from '../../UserMenu';
 
-import MobileNavWithLaunchButton from './MobileNavWithLaunchButton';
+import ButtonWithFullMobileNavMenu from './MobileNavWithLaunchButton';
 
 const RightContainer = styled(Box)`
   display: flex;
@@ -111,7 +111,7 @@ const MobileNavbarContent = () => {
               </>
             )}
             <NavItem>
-              <MobileNavWithLaunchButton />
+              <ButtonWithFullMobileNavMenu />
             </NavItem>
           </>
         )}

--- a/front/app/containers/MainHeader/Components/NavbarContent/MobileNavbarContent/index.tsx
+++ b/front/app/containers/MainHeader/Components/NavbarContent/MobileNavbarContent/index.tsx
@@ -1,4 +1,4 @@
-import React, { lazy, Suspense, useState } from 'react';
+import React from 'react';
 
 import { Box, Button, media, isRtl } from '@citizenlab/cl2-component-library';
 import styled from 'styled-components';
@@ -7,18 +7,15 @@ import useAuthUser from 'api/me/useAuthUser';
 
 import { triggerAuthenticationFlow } from 'containers/Authentication/events';
 
-import { trackEventByName } from 'utils/analytics';
 import { useIntl } from 'utils/cl-intl';
 import { isNilOrError, isPage } from 'utils/helperUtils';
 
 import messages from '../../../messages';
-import tracks from '../../../tracks';
 import LanguageSelector from '../../LanguageSelector';
 import NotificationMenu from '../../NotificationMenu';
 import UserMenu from '../../UserMenu';
 
-const FullMobileNavMenu = lazy(() => import('./FullMobileNavMenu'));
-import ShowFullMenuButton from './ShowFullMenuButton';
+import MobileNavWithLaunchButton from './MobileNavWithLaunchButton';
 
 const RightContainer = styled(Box)`
   display: flex;
@@ -83,23 +80,8 @@ const MobileNavbarContent = () => {
 
   const isEmailSettingsPage = isPage('email-settings', location.pathname);
 
-  const [isFullMenuOpened, setIsFullMenuOpened] = useState(false);
-
   const signIn = () => {
     triggerAuthenticationFlow({}, 'signin');
-  };
-
-  const onShowMore = (isFullMenuOpened: boolean) => {
-    setIsFullMenuOpened((prevIsFullMenuOpened) => !prevIsFullMenuOpened);
-    trackEventByName(
-      isFullMenuOpened
-        ? tracks.moreButtonClickedFullMenuOpened
-        : tracks.moreButtonClickedFullMenuClosed
-    );
-  };
-
-  const onCloseFullMenu = () => {
-    setIsFullMenuOpened(false);
   };
 
   return (
@@ -129,21 +111,11 @@ const MobileNavbarContent = () => {
               </>
             )}
             <NavItem>
-              <ShowFullMenuButton
-                onClick={() => {
-                  onShowMore(isFullMenuOpened);
-                }}
-              />
+              <MobileNavWithLaunchButton />
             </NavItem>
           </>
         )}
       </RightContainer>
-      <Suspense fallback={null}>
-        <FullMobileNavMenu
-          isFullMenuOpened={isFullMenuOpened}
-          onClose={onCloseFullMenu}
-        />
-      </Suspense>
     </nav>
   );
 };


### PR DESCRIPTION
A minor performance optimization I did a few weeks ago. Similar to what we did elsewhere before: move a modal's opened state down one level, to not re-render all surrounding components when we open/close it.

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->
