### PR TITLE
[TAN-3274] Add warning component to show drag instructions

### DIFF
--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Analysis/Analyses.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Analysis/Analyses.tsx
@@ -71,7 +71,7 @@ const Analyses = ({
   return (
     <div>
       {phaseId && hasRelevantAnalyses && (
-        <Box mb="12px">
+        <Box mb="16px">
           <Warning>
             <Text p="0px" m="0px" fontSize="s" color="teal700">
               {formatMessage(messages.dragAiContentInfo)}

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Analysis/Analyses.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Analysis/Analyses.tsx
@@ -8,6 +8,7 @@ import { ParticipationMethod } from 'api/phases/types';
 
 import Divider from 'components/admin/Divider';
 import Button from 'components/UI/Button';
+import Warning from 'components/UI/Warning';
 
 import { useIntl } from 'utils/cl-intl';
 
@@ -42,6 +43,8 @@ const Analyses = ({
       )
     : analyses?.data;
 
+  const hasRelevantAnalyses = relevantAnalyses && relevantAnalyses.length > 0;
+
   const projectLink: RouteType =
     participationMethod === 'ideation'
       ? `/admin/projects/${projectId}/phases/${phaseId}/ideas`
@@ -67,6 +70,16 @@ const Analyses = ({
 
   return (
     <div>
+      {phaseId && hasRelevantAnalyses && (
+        <Box mb="12px">
+          <Warning>
+            <Text p="0px" m="0px" fontSize="s" color="teal700">
+              {formatMessage(messages.dragAiContentInfo)}
+            </Text>
+          </Warning>
+        </Box>
+      )}
+
       {projectId &&
         relevantAnalyses?.map((analysis) => (
           <Insights

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Analysis/messages.ts
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Analysis/messages.ts
@@ -35,4 +35,8 @@ export default defineMessages({
     defaultMessage:
       'Reporting with AI is not included in your current plan. Talk to your Government Success Manager to unlock this feature.',
   },
+  dragAiContentInfo: {
+    id: 'containers.Admin.reporting.components.ReportBuilder.Widgets.Analysis.dragAiContentInfo',
+    defaultMessage: 'Use the ☰ icon below to drag AI content into your report.',
+  },
 });

--- a/front/app/translations/admin/en.json
+++ b/front/app/translations/admin/en.json
@@ -2821,6 +2821,7 @@
   "app.modules.navbar.admin.containers.pageSubtitle": "Your navigation bar can display up to five pages in addition to the Home and projects pages. You can rename menu items, re-order and add new pages  with your own content.",
   "containers.Admin.reporting.components.ReportBuilder.Toolbox.ai": "AI",
   "containers.Admin.reporting.components.ReportBuilder.Toolbox.widgets": "Widgets",
+  "containers.Admin.reporting.components.ReportBuilder.Widgets.Analysis.dragAiContentInfo": "Use the ☰ icon below to drag AI content into your report.",
   "containers.Admin.reporting.components.ReportBuilder.Widgets.Analysis.noAIInsights": "There are no available AI insights. You can create them in your project.",
   "containers.Admin.reporting.components.ReportBuilder.Widgets.Analysis.openProject": "Go to project",
   "containers.Admin.reporting.components.ReportBuilder.Widgets.Analysis.question": "Question",


### PR DESCRIPTION
# Changelog
## Changed
- [TAN-3274] Small improvement for discoverability of AI Summary Drag & Drop (by adding more instruction) ([before](https://github.com/user-attachments/assets/bde6da99-01c3-406b-98e7-1f01bf512e93)/[after](https://github.com/user-attachments/assets/32eb07ac-dc90-4e68-a557-6b864549e5f8)).

