### PR TITLE
TAN-3355 - Fixed ID Austria to use the bPK value as the unique ID for a user

### DIFF
--- a/back/engines/commercial/id_id_austria/app/lib/id_id_austria/id_austria_omniauth.rb
+++ b/back/engines/commercial/id_id_austria/app/lib/id_id_austria/id_austria_omniauth.rb
@@ -4,6 +4,10 @@ module IdIdAustria
   class IdAustriaOmniauth < OmniauthMethods::Base
     include IdAustriaVerification
 
+    def profile_to_uid(auth)
+      auth['extra']['raw_info']['urn:pvpgvat:oidc.bpk']
+    end
+
     def profile_to_user_attrs(auth)
       {
         first_name: auth.info.first_name,


### PR DESCRIPTION
# Changelog
## Fixed
- Fixed ID Austria to use the bPK value as the unique ID for a user
