### PR TITLE
Move down clearFilters to where it's used

### DIFF
--- a/front/app/components/IdeaCards/IdeasWithFiltersSidebar/ButtonWithFiltersModal/FiltersModal/BottomBar.tsx
+++ b/front/app/components/IdeaCards/IdeasWithFiltersSidebar/ButtonWithFiltersModal/FiltersModal/BottomBar.tsx
@@ -17,11 +17,10 @@ interface Props {
   onClick: (event: FormEvent) => void;
   ideaQueryParameters: InputFiltersProps['ideaQueryParameters'];
   filtersActive: boolean;
-  onReset: () => void;
 }
 
 const BottomBar = memo<Props>(
-  ({ onClick, ideaQueryParameters, onReset, filtersActive }) => {
+  ({ onClick, ideaQueryParameters, filtersActive }) => {
     const { data: ideasFilterCounts } =
       useIdeasFilterCounts(ideaQueryParameters);
 
@@ -43,7 +42,7 @@ const BottomBar = memo<Props>(
             }}
           />
         </Button>
-        <ResetFiltersButton onClick={onReset} filtersActive={filtersActive} />
+        <ResetFiltersButton filtersActive={filtersActive} />
       </Box>
     );
   }

--- a/front/app/components/IdeaCards/IdeasWithFiltersSidebar/ButtonWithFiltersModal/FiltersModal/index.tsx
+++ b/front/app/components/IdeaCards/IdeasWithFiltersSidebar/ButtonWithFiltersModal/FiltersModal/index.tsx
@@ -19,7 +19,6 @@ interface Props extends InputFiltersProps {
 const FiltersModal = ({
   opened,
   ideaQueryParameters,
-  onClearFilters,
   onClose,
   ...filtersProps
 }: Props) => {
@@ -32,7 +31,6 @@ const FiltersModal = ({
         <BottomBar
           onClick={onClose}
           ideaQueryParameters={ideaQueryParameters}
-          onReset={onClearFilters}
           filtersActive={filtersProps.filtersActive}
         />
       }
@@ -41,7 +39,6 @@ const FiltersModal = ({
       <Box p="16px">
         <InputFilters
           ideaQueryParameters={ideaQueryParameters}
-          onClearFilters={onClearFilters}
           // We have a reset filters button in TopBar
           showResetButton={false}
           {...filtersProps}

--- a/front/app/components/IdeaCards/IdeasWithFiltersSidebar/ButtonWithFiltersModal/index.tsx
+++ b/front/app/components/IdeaCards/IdeasWithFiltersSidebar/ButtonWithFiltersModal/index.tsx
@@ -14,7 +14,6 @@ const FiltersModal = lazy(() => import('./FiltersModal'));
 
 const ButtonWithFiltersModal = ({
   ideaQueryParameters,
-  onClearFilters,
   ...filtersProps
 }: InputFiltersProps) => {
   const isSmallerThanTablet = useBreakpoint('tablet');
@@ -45,7 +44,6 @@ const ButtonWithFiltersModal = ({
         <FiltersModal
           opened={filtersModalOpened}
           ideaQueryParameters={ideaQueryParameters}
-          onClearFilters={onClearFilters}
           onClose={closeModal}
           {...filtersProps}
         />

--- a/front/app/components/IdeaCards/IdeasWithFiltersSidebar/InputFilters.tsx
+++ b/front/app/components/IdeaCards/IdeasWithFiltersSidebar/InputFilters.tsx
@@ -26,7 +26,6 @@ export interface InputFiltersProps {
   ideasFilterCounts: IIdeasFilterCounts | NilOrError;
   numberOfSearchResults: number;
   ideaQueryParameters: Partial<IIdeaQueryParameters>;
-  onClearFilters: () => void;
   onSearch: (searchTerm: string) => void;
   onChangeStatus: (ideaStatus: string | null) => void;
   onChangeTopics: (topics: string[] | null) => void;
@@ -44,7 +43,6 @@ const InputFilters = ({
   numberOfSearchResults,
   ideaQueryParameters,
   phaseId,
-  onClearFilters,
   showResetButton = true,
   showStatusFilter = true,
   showSearchField = true,
@@ -101,10 +99,7 @@ const InputFilters = ({
       )}
       {showResetButton && (
         <Box mt="8px">
-          <ResetFiltersButton
-            onClick={onClearFilters}
-            filtersActive={filtersActive}
-          />
+          <ResetFiltersButton filtersActive={filtersActive} />
         </Box>
       )}
     </>

--- a/front/app/components/IdeaCards/IdeasWithFiltersSidebar/MapView/FiltersMapView.tsx
+++ b/front/app/components/IdeaCards/IdeasWithFiltersSidebar/MapView/FiltersMapView.tsx
@@ -14,7 +14,6 @@ interface Props extends InputFiltersProps {
 
 const FiltersMapView = ({
   ideaQueryParameters,
-  onClearFilters,
   onClose,
   ...filtersProps
 }: Props) => {
@@ -25,7 +24,6 @@ const FiltersMapView = ({
         <Box p="16px">
           <InputFilters
             ideaQueryParameters={ideaQueryParameters}
-            onClearFilters={onClearFilters}
             // A reset button is available in the filters top bar
             showResetButton={false}
             // BE doesn't currently support filtering map markers by status.
@@ -38,7 +36,6 @@ const FiltersMapView = ({
       <BottomBar
         onClick={onClose}
         ideaQueryParameters={ideaQueryParameters}
-        onReset={onClearFilters}
         filtersActive={filtersProps.filtersActive}
       />
     </>

--- a/front/app/components/IdeaCards/IdeasWithFiltersSidebar/ResetFiltersButton.tsx
+++ b/front/app/components/IdeaCards/IdeasWithFiltersSidebar/ResetFiltersButton.tsx
@@ -2,18 +2,34 @@ import React from 'react';
 
 import { Button } from '@citizenlab/cl2-component-library';
 
+import tracks from 'components/IdeaCards/tracks';
+
+import { trackEventByName } from 'utils/analytics';
 import { FormattedMessage } from 'utils/cl-intl';
+import { updateSearchParams } from 'utils/cl-router/updateSearchParams';
 
 import ideaCardsMessages from '../messages';
 
 interface Props {
-  onClick: () => void;
   filtersActive: boolean;
 }
 
-const ResetFiltersButton = ({ onClick, filtersActive }: Props) => {
+const ResetFiltersButton = ({ filtersActive }: Props) => {
+  const handleOnClick = () => {
+    trackEventByName(tracks.clearFiltersClicked);
+    updateSearchParams({
+      search: undefined,
+      idea_status: undefined,
+      topics: undefined,
+    });
+  };
+
   return (
-    <Button onClick={onClick} buttonStyle="text" disabled={!filtersActive}>
+    <Button
+      onClick={handleOnClick}
+      buttonStyle="text"
+      disabled={!filtersActive}
+    >
       <FormattedMessage {...ideaCardsMessages.resetFilters} />
     </Button>
   );

--- a/front/app/components/IdeaCards/IdeasWithFiltersSidebar/index.tsx
+++ b/front/app/components/IdeaCards/IdeasWithFiltersSidebar/index.tsx
@@ -190,15 +190,6 @@ const IdeasWithFiltersSidebar = ({
     [onUpdateQuery]
   );
 
-  const clearFilters = useCallback(() => {
-    trackEventByName(tracks.clearFiltersClicked);
-    onUpdateQuery({
-      search: undefined,
-      idea_status: undefined,
-      topics: undefined,
-    });
-  }, [onUpdateQuery]);
-
   const filtersActive = !!(
     ideaQueryParameters.search ||
     ideaQueryParameters.idea_status ||
@@ -213,7 +204,6 @@ const IdeasWithFiltersSidebar = ({
     ideasFilterCounts,
     numberOfSearchResults: ideasCount,
     ideaQueryParameters,
-    onClearFilters: clearFilters,
     onSearch: handleSearchOnChange,
     onChangeStatus: handleStatusOnChange,
     onChangeTopics: handleTopicsOnChange,

--- a/front/app/components/IdeasMap/desktop/MapIdeasList.tsx
+++ b/front/app/components/IdeasMap/desktop/MapIdeasList.tsx
@@ -59,14 +59,13 @@ const MapIdeasList = memo<Props>(
       onChangeStatus,
       onChangeTopics,
       handleSortOnChange,
-      onClearFilters,
       filtersActive,
       ideasFilterCounts,
       numberOfSearchResults,
     } = inputFiltersProps ?? {};
 
     const hasInputFilterProps =
-      onChangeStatus && onChangeTopics && handleSortOnChange && onClearFilters;
+      onChangeStatus && onChangeTopics && handleSortOnChange;
 
     const { data: ideaCustomFieldsSchema } = useIdeaJsonFormSchema({
       projectId,
@@ -127,7 +126,6 @@ const MapIdeasList = memo<Props>(
           <>
             <FiltersMapView
               ideaQueryParameters={ideaQueryParameters || {}}
-              onClearFilters={onClearFilters}
               filtersActive={!!filtersActive}
               ideasFilterCounts={ideasFilterCounts}
               numberOfSearchResults={


### PR DESCRIPTION
I wanted to show an example of what I meant by "we don't need this (much) prop drilling." We can do this for more handlers, but I'll leave it at this until platform week priorities become clear.

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->
