### PR TITLE
Tan 3377/remove Semantic icon/button from post manager

### DIFF
--- a/front/app/components/admin/PostManager/InputManager.tsx
+++ b/front/app/components/admin/PostManager/InputManager.tsx
@@ -357,7 +357,7 @@ const InputManager = ({
             openPreview={openPreview}
           />
         </MiddleColumn>
-        <InfoSidebar postIds={[...selection]} openPreview={openPreview} />
+        <InfoSidebar selection={selection} openPreview={openPreview} />
       </ThreeColumns>
       <Suspense fallback={null}>
         <LazyPostPreview

--- a/front/app/components/admin/PostManager/components/ActionBar/ActionBarMulti.tsx
+++ b/front/app/components/admin/PostManager/components/ActionBar/ActionBarMulti.tsx
@@ -1,13 +1,12 @@
 import React, { useState } from 'react';
 
-import { Button, fontSizes } from '@citizenlab/cl2-component-library';
-
 import useDeleteIdea from 'api/ideas/useDeleteIdea';
 
 import WarningModal from 'components/WarningModal';
 
 import { FormattedMessage, useIntl } from 'utils/cl-intl';
 
+import DeleteButton from './DeleteButton';
 import messages from './messages';
 
 interface Props {
@@ -45,19 +44,12 @@ const ActionBarMulti = ({ selection, resetSelection }: Props) => {
 
   return (
     <>
-      <Button
-        buttonStyle="delete"
-        onClick={openWarningModal}
-        icon="delete"
-        size="s"
-        p="4px 8px"
-        fontSize={`${fontSizes.s}px`}
-      >
+      <DeleteButton onClick={openWarningModal}>
         <FormattedMessage
           {...deleteMessage}
           values={{ count: selection.size }}
         />
-      </Button>
+      </DeleteButton>
       <WarningModal
         open={warningModalOpen}
         isLoading={isLoadingDeleteIdea}

--- a/front/app/components/admin/PostManager/components/ActionBar/ActionBarMulti.tsx
+++ b/front/app/components/admin/PostManager/components/ActionBar/ActionBarMulti.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { Button, Icon } from 'semantic-ui-react';
+import { Button, fontSizes } from '@citizenlab/cl2-component-library';
 
 import useDeleteIdea from 'api/ideas/useDeleteIdea';
 
@@ -45,8 +45,14 @@ const ActionBarMulti = ({ selection, resetSelection }: Props) => {
 
   return (
     <>
-      <Button negative={true} basic={true} onClick={openWarningModal}>
-        <Icon name="delete" />
+      <Button
+        buttonStyle="delete"
+        onClick={openWarningModal}
+        icon="delete"
+        size="s"
+        p="4px 8px"
+        fontSize={`${fontSizes.s}px`}
+      >
         <FormattedMessage
           {...deleteMessage}
           values={{ count: selection.size }}

--- a/front/app/components/admin/PostManager/components/ActionBar/ActionBarSingle.tsx
+++ b/front/app/components/admin/PostManager/components/ActionBar/ActionBarSingle.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { Icon, Button } from 'semantic-ui-react';
+import { Button, fontSizes } from '@citizenlab/cl2-component-library';
 
 import useDeleteIdea from 'api/ideas/useDeleteIdea';
 
@@ -42,12 +42,25 @@ const ActionBarSingle = ({
 
   return (
     <>
-      <Button onClick={handleClickEdit}>
-        <Icon name="edit" />
+      <Button
+        buttonStyle="secondary-outlined"
+        onClick={handleClickEdit}
+        icon="edit"
+        mr="8px"
+        size="s"
+        p="4px 8px"
+        fontSize={`${fontSizes.s}px`}
+      >
         <FormattedMessage {...messages.edit} />
       </Button>
-      <Button negative={true} basic={true} onClick={openWarningModal}>
-        <Icon name="delete" />
+      <Button
+        buttonStyle="delete"
+        onClick={openWarningModal}
+        icon="delete"
+        size="s"
+        p="4px 8px"
+        fontSize={`${fontSizes.s}px`}
+      >
         <FormattedMessage {...messages.delete} />
       </Button>
 

--- a/front/app/components/admin/PostManager/components/ActionBar/ActionBarSingle.tsx
+++ b/front/app/components/admin/PostManager/components/ActionBar/ActionBarSingle.tsx
@@ -9,6 +9,7 @@ import modalMessages from 'components/WarningModal/messages';
 
 import { FormattedMessage, useIntl } from 'utils/cl-intl';
 
+import DeleteButton from './DeleteButton';
 import messages from './messages';
 
 interface Props {
@@ -53,16 +54,9 @@ const ActionBarSingle = ({
       >
         <FormattedMessage {...messages.edit} />
       </Button>
-      <Button
-        buttonStyle="delete"
-        onClick={openWarningModal}
-        icon="delete"
-        size="s"
-        p="4px 8px"
-        fontSize={`${fontSizes.s}px`}
-      >
+      <DeleteButton onClick={openWarningModal}>
         <FormattedMessage {...messages.delete} />
-      </Button>
+      </DeleteButton>
 
       <WarningModal
         open={warningModalOpen}

--- a/front/app/components/admin/PostManager/components/ActionBar/DeleteButton.tsx
+++ b/front/app/components/admin/PostManager/components/ActionBar/DeleteButton.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import { Button, fontSizes } from '@citizenlab/cl2-component-library';
+
+interface Props {
+  children: React.ReactNode;
+  onClick: () => void;
+}
+
+const DeleteButton = ({ children, onClick }: Props) => {
+  return (
+    <Button
+      buttonStyle="delete"
+      onClick={onClick}
+      icon="delete"
+      size="s"
+      p="4px 8px"
+      fontSize={`${fontSizes.s}px`}
+    >
+      {children}
+    </Button>
+  );
+};
+
+export default DeleteButton;

--- a/front/app/components/admin/PostManager/components/InfoSidebar/index.tsx
+++ b/front/app/components/admin/PostManager/components/InfoSidebar/index.tsx
@@ -58,26 +58,32 @@ export function handlePreviewCLick(
 }
 
 interface Props {
-  postIds: string[];
+  selection: Set<string>;
   openPreview: (id: string) => void;
 }
 
-export default ({ postIds, openPreview }: Props) => (
-  <CSSTransition
-    in={postIds.length !== 0}
-    mountOnEnter={true}
-    unmountOnExit={true}
-    timeout={200}
-    classNames="slide"
-  >
-    <RightColumn>
-      <Sticky>
-        {postIds.length > 1 ? (
-          <InfoSidebarMulti postIds={postIds} openPreview={openPreview} />
-        ) : (
-          <InfoSidebarSingle postId={postIds[0]} openPreview={openPreview} />
-        )}
-      </Sticky>
-    </RightColumn>
-  </CSSTransition>
-);
+const InfoSidebar = ({ selection, openPreview }: Props) => {
+  const postIds = [...selection];
+
+  return (
+    <CSSTransition
+      in={postIds.length !== 0}
+      mountOnEnter={true}
+      unmountOnExit={true}
+      timeout={200}
+      classNames="slide"
+    >
+      <RightColumn>
+        <Sticky>
+          {postIds.length > 1 ? (
+            <InfoSidebarMulti postIds={postIds} openPreview={openPreview} />
+          ) : (
+            <InfoSidebarSingle postId={postIds[0]} openPreview={openPreview} />
+          )}
+        </Sticky>
+      </RightColumn>
+    </CSSTransition>
+  );
+};
+
+export default InfoSidebar;


### PR DESCRIPTION
Before:
<img width="741" alt="Screenshot 2024-12-17 at 09 32 58" src="https://github.com/user-attachments/assets/dc7eb87d-dd5a-40c4-8a88-88556047dcf9" />
After:
<img width="667" alt="Screenshot 2024-12-17 at 09 29 48" src="https://github.com/user-attachments/assets/835fbecd-71ef-4451-a78a-8fdc59e6f897" />

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->
