### PR TITLE
Use component lib label > Semantic UI's

### DIFF
--- a/front/app/components/admin/PostManager/components/PostTable/Row/selectors/ProjectSelector.tsx
+++ b/front/app/components/admin/PostManager/components/PostTable/Row/selectors/ProjectSelector.tsx
@@ -1,26 +1,15 @@
 import React from 'react';
 
-import { Label } from '@citizenlab/cl2-component-library';
-import styled from 'styled-components';
+import {
+  Box,
+  colors,
+  stylingConsts,
+  Text,
+} from '@citizenlab/cl2-component-library';
 
 import useProjectById from 'api/projects/useProjectById';
 
 import T from 'components/T';
-
-const StyledLabel = styled(Label)`
-  display: inline;
-  white-space: nowrap;
-  -webkit-line-clamp: 1;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  color: ${({ theme }) => theme.colors.teal};
-  border: 1px solid ${({ theme }) => theme.colors.teal};
-  border-radius: ${({ theme }) => theme.borderRadius};
-  font-size: ${({ theme }) => theme.fontSizes.xs}px};
-  padding: 2px 4px;
-  font-weight: 600;
-`;
 
 interface Props {
   projectId: string;
@@ -32,9 +21,16 @@ const ProjectSelector = ({ projectId }: Props) => {
   if (!project) return null;
 
   return (
-    <StyledLabel>
-      <T value={project.data.attributes.title_multiloc} />
-    </StyledLabel>
+    <Box
+      display="inline-block"
+      border={`1px solid ${colors.teal}`}
+      borderRadius={stylingConsts.borderRadius}
+      p="2px 4px"
+    >
+      <Text as="span" m="0" fontWeight="semi-bold" fontSize="xs" color="teal">
+        <T value={project.data.attributes.title_multiloc} />
+      </Text>
+    </Box>
   );
 };
 

--- a/front/app/components/admin/PostManager/components/PostTable/Row/selectors/ProjectSelector.tsx
+++ b/front/app/components/admin/PostManager/components/PostTable/Row/selectors/ProjectSelector.tsx
@@ -14,10 +14,10 @@ const StyledLabel = styled(Label)`
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
-  color: teal;
-  border: 1px solid teal;
-  border-radius: 4px;
-  font-size: 12px;
+  color: ${({ theme }) => theme.colors.teal};
+  border: 1px solid ${({ theme }) => theme.colors.teal};
+  border-radius: ${({ theme }) => theme.borderRadius};
+  font-size: ${({ theme }) => theme.fontSizes.xs}px};
   padding: 2px 4px;
   font-weight: 600;
 `;

--- a/front/app/components/admin/PostManager/components/PostTable/Row/selectors/ProjectSelector.tsx
+++ b/front/app/components/admin/PostManager/components/PostTable/Row/selectors/ProjectSelector.tsx
@@ -1,23 +1,25 @@
 import React from 'react';
 
-import { Label } from 'semantic-ui-react';
+import { Label } from '@citizenlab/cl2-component-library';
 import styled from 'styled-components';
 
 import useProjectById from 'api/projects/useProjectById';
 
 import T from 'components/T';
 
-const LabelText = styled.span`
-  font-weight: 600;
-`;
-
 const StyledLabel = styled(Label)`
+  display: inline;
   white-space: nowrap;
   -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 175px;
+  color: teal;
+  border: 1px solid teal;
+  border-radius: 4px;
+  font-size: 12px;
+  padding: 2px 4px;
+  font-weight: 600;
 `;
 
 interface Props {
@@ -30,10 +32,8 @@ const ProjectSelector = ({ projectId }: Props) => {
   if (!project) return null;
 
   return (
-    <StyledLabel key={project.data.id} color="teal" basic={true}>
-      <LabelText>
-        <T value={project.data.attributes.title_multiloc} />
-      </LabelText>
+    <StyledLabel>
+      <T value={project.data.attributes.title_multiloc} />
     </StyledLabel>
   );
 };

--- a/front/app/components/admin/PostManager/components/PostTable/Row/selectors/ProjectSelector.tsx
+++ b/front/app/components/admin/PostManager/components/PostTable/Row/selectors/ProjectSelector.tsx
@@ -22,6 +22,7 @@ const ProjectSelector = ({ projectId }: Props) => {
 
   return (
     <Box
+      // inline-block is needed to make the top/bottom padding work
       display="inline-block"
       border={`1px solid ${colors.teal}`}
       borderRadius={stylingConsts.borderRadius}


### PR DESCRIPTION
Before
<img width="968" alt="Screenshot 2024-12-17 at 10 57 21" src="https://github.com/user-attachments/assets/ea95f9f3-2331-4d0b-b1a8-faea650547db" />

After

<img width="839" alt="Screenshot 2024-12-17 at 11 04 58" src="https://github.com/user-attachments/assets/9be1edbc-0cb5-48b7-865c-0b53aeba07cf" />

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->