### PR TITLE
TAN-3397: Preserve folder_id in save_project if not explicitly provided

### DIFF
--- a/back/app/controllers/web_api/v1/projects_controller.rb
+++ b/back/app/controllers/web_api/v1/projects_controller.rb
@@ -319,8 +319,10 @@ class WebApi::V1::ProjectsController < ApplicationController
   end
 
   def save_project(project)
-    # Preserve folder_id unless explicitly provided in params
-    project.folder_id = params.dig(:project, :folder_id) if params.dig(:project, :folder_id).present?
+    # Update folder_id only if it is provided in the request (even if it's nil)
+    if params[:project].key?(:folder_id)
+      project.folder_id = params.dig(:project, :folder_id)
+    end
 
     ActiveRecord::Base.transaction do
       project.save.tap do |saved|

--- a/back/app/controllers/web_api/v1/projects_controller.rb
+++ b/back/app/controllers/web_api/v1/projects_controller.rb
@@ -319,12 +319,13 @@ class WebApi::V1::ProjectsController < ApplicationController
   end
 
   def save_project(project)
-    project.folder_id = params.dig(:project, :folder_id)
-
+    # Preserve folder_id unless explicitly provided in params
+    project.folder_id = params.dig(:project, :folder_id) if params.dig(:project, :folder_id).present?
+  
     ActiveRecord::Base.transaction do
       project.save.tap do |saved|
         if saved
-          # The project must saved before performing the authorization because it requires
+          # The project must be saved before performing the authorization because it requires
           # the admin publication to be created.
           authorize(project)
           check_publication_inconsistencies!

--- a/back/app/controllers/web_api/v1/projects_controller.rb
+++ b/back/app/controllers/web_api/v1/projects_controller.rb
@@ -321,7 +321,7 @@ class WebApi::V1::ProjectsController < ApplicationController
   def save_project(project)
     # Preserve folder_id unless explicitly provided in params
     project.folder_id = params.dig(:project, :folder_id) if params.dig(:project, :folder_id).present?
-  
+
     ActiveRecord::Base.transaction do
       project.save.tap do |saved|
         if saved


### PR DESCRIPTION
# Changelog

## Fixed
- Resolved an issue where updating a project's status inadvertently removed it from its folder