### PR TITLE
[TAN-3358] Upgrade ros-apartment from 2.11.0 to 3.0.4

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -194,7 +194,7 @@ free_engines.each do |engine_name|
   gem engine_name, path: path if File.directory?(path)
 end
 
-gem 'ros-apartment', require: 'apartment'
+gem 'ros-apartment', '~> 3.0.0', require: 'apartment'
 
 commercial_engines = [
   'multi_tenancy',

--- a/back/Gemfile
+++ b/back/Gemfile
@@ -194,7 +194,7 @@ free_engines.each do |engine_name|
   gem engine_name, path: path if File.directory?(path)
 end
 
-gem 'ros-apartment', '~> 3.0.0', require: 'apartment'
+gem 'ros-apartment', '~> 3.1.0', require: 'apartment'
 
 commercial_engines = [
   'multi_tenancy',

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -1040,7 +1040,7 @@ GEM
       multi_json (~> 1.15)
       rgeo (>= 1.0.0)
     rinku (2.0.6)
-    ros-apartment (3.0.4)
+    ros-apartment (3.1.0)
       activerecord (>= 6.1.0, < 7.2)
       parallel (< 2.0)
       public_suffix (>= 2.0.5, < 6.0)
@@ -1377,7 +1377,7 @@ DEPENDENCIES
   rest-client
   rgeo-geojson
   rinku (~> 2)
-  ros-apartment (~> 3.0.0)
+  ros-apartment (~> 3.1.0)
   rspec-html-matchers (~> 0.10)
   rspec-its
   rspec-parameterized

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -1040,11 +1040,11 @@ GEM
       multi_json (~> 1.15)
       rgeo (>= 1.0.0)
     rinku (2.0.6)
-    ros-apartment (2.11.0)
-      activerecord (>= 5.0.0, < 7.1)
+    ros-apartment (3.0.4)
+      activerecord (>= 6.1.0, < 7.2)
       parallel (< 2.0)
-      public_suffix (>= 2.0.5, < 5.0)
-      rack (>= 1.3.6, < 3.0)
+      public_suffix (>= 2.0.5, < 6.0)
+      rack (>= 1.3.6, < 4.0)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -1377,7 +1377,7 @@ DEPENDENCIES
   rest-client
   rgeo-geojson
   rinku (~> 2)
-  ros-apartment
+  ros-apartment (~> 3.0.0)
   rspec-html-matchers (~> 0.10)
   rspec-its
   rspec-parameterized


### PR DESCRIPTION
# Changelog
## Technical
- [TAN-3358] Upgrade `ros-apartment` from 2.11.0 to 3.1.0 to prepare for the Rails upgrade. There is currently no release of `ros-apartment` that supports Rails 7.2. Version 3.1.0 is only compatible up to Rails 7.1.0. We have two options moving forward: wait for the next release of the gem, which will support up to Rails 8.0 (in progress), or use the development branch of the gem, which already supports Rails 7.2.
