### PR TITLE
Improve FE events: clean up usage of trackEventByName

### DIFF
--- a/front/app/components/CampaignConsentForm/index.tsx
+++ b/front/app/components/CampaignConsentForm/index.tsx
@@ -146,13 +146,15 @@ const CampaignConsentForm = ({
         })
       );
 
+    const consentChangesObject: Record<string, any> = Object.fromEntries(
+      Object.values(consentChanges).map((consent: IConsentChanges) => [
+        consent.campaignConsentId,
+        consent.consented,
+      ])
+    );
+
     trackEventByName(trackEventName, {
-      consentChanges: Object.fromEntries(
-        Object.values(consentChanges).map((consent: IConsentChanges) => [
-          consent.campaignConsentId,
-          consent.consented,
-        ])
-      ),
+      consentChanges: consentChangesObject.toString(),
     });
 
     setShowFeedback(false);

--- a/front/app/components/CampaignConsentForm/index.tsx
+++ b/front/app/components/CampaignConsentForm/index.tsx
@@ -154,7 +154,7 @@ const CampaignConsentForm = ({
     );
 
     trackEventByName(trackEventName, {
-      consentChanges: consentChangesObject.toString(),
+      consentChanges: JSON.stringify(consentChangesObject),
     });
 
     setShowFeedback(false);

--- a/front/app/components/CampaignConsentForm/index.tsx
+++ b/front/app/components/CampaignConsentForm/index.tsx
@@ -147,14 +147,12 @@ const CampaignConsentForm = ({
       );
 
     trackEventByName(trackEventName, {
-      extra: {
-        consentChanges: Object.fromEntries(
-          Object.values(consentChanges).map((consent: IConsentChanges) => [
-            consent.campaignConsentId,
-            consent.consented,
-          ])
-        ),
-      },
+      consentChanges: Object.fromEntries(
+        Object.values(consentChanges).map((consent: IConsentChanges) => [
+          consent.campaignConsentId,
+          consent.consented,
+        ])
+      ),
     });
 
     setShowFeedback(false);

--- a/front/app/components/IdeaCards/IdeasWithFiltersSidebar/index.tsx
+++ b/front/app/components/IdeaCards/IdeasWithFiltersSidebar/index.tsx
@@ -182,7 +182,7 @@ const IdeasWithFiltersSidebar = ({
   const handleTopicsOnChange = useCallback(
     (topics: string[] | null) => {
       trackEventByName(tracks.topicsFilter, {
-        topics,
+        topics: topics?.toString(),
       });
 
       onUpdateQuery({ topics: topics ?? undefined });

--- a/front/app/components/IdeaCards/IdeasWithoutFiltersSidebar/index.tsx
+++ b/front/app/components/IdeaCards/IdeasWithoutFiltersSidebar/index.tsx
@@ -174,7 +174,7 @@ const IdeasWithoutFiltersSidebar = ({
 
   const handleTopicsOnChange = (topics: string[]) => {
     trackEventByName(tracks.topicsFilter, {
-      topics,
+      topics: topics.toString(),
     });
 
     topics.length === 0

--- a/front/app/components/PostShowComponents/Comments/CommentsSection/PublicComments/Comments/ChildCommentForm.tsx
+++ b/front/app/components/PostShowComponents/Comments/CommentsSection/PublicComments/Comments/ChildCommentForm.tsx
@@ -149,11 +149,9 @@ const ChildCommentForm = ({
 
   const onFocus = () => {
     trackEventByName(tracks.focusChildCommentEditor, {
-      extra: {
-        postId: ideaId,
-        postType: 'idea',
-        parentId,
-      },
+      postId: ideaId,
+      postType: 'idea',
+      parentId,
     });
 
     setFocused(true);
@@ -181,12 +179,10 @@ const ChildCommentForm = ({
       setCanSubmit(false);
 
       trackEventByName(tracks.clickChildCommentPublish, {
-        extra: {
-          postId: ideaId,
-          postType: 'idea',
-          parentId,
-          content: inputValue,
-        },
+        postId: ideaId,
+        postType: 'idea',
+        parentId,
+        content: inputValue,
       });
 
       if (projectId) {

--- a/front/app/components/PostShowComponents/Comments/CommentsSection/PublicComments/ParentCommentForm.tsx
+++ b/front/app/components/PostShowComponents/Comments/CommentsSection/PublicComments/ParentCommentForm.tsx
@@ -124,10 +124,8 @@ const ParentCommentForm = ({
   const onFocus = () => {
     setCommentCancelledMessage('');
     trackEventByName(tracks.focusParentCommentEditor, {
-      extra: {
-        postId: ideaId,
-        postType: 'idea',
-      },
+      postId: ideaId,
+      postType: 'idea',
     });
 
     setFocused(true);
@@ -159,11 +157,9 @@ const ParentCommentForm = ({
       };
 
       trackEventByName(tracks.clickParentCommentPublish, {
-        extra: {
-          postId: ideaId,
-          postType: 'idea',
-          content: inputValue,
-        },
+        postId: ideaId,
+        postType: 'idea',
+        content: inputValue,
       });
 
       if (projectId) {

--- a/front/app/components/ProjectAndFolderCards/components/ProjectFolderCard/index.tsx
+++ b/front/app/components/ProjectAndFolderCards/components/ProjectFolderCard/index.tsx
@@ -337,7 +337,7 @@ const ProjectFolderCard = memo<Props>(
     const handleProjectCardOnClick = useCallback(
       (projectFolderId: string) => () => {
         trackEventByName(tracks.clickOnProjectCard, {
-          extra: { projectFolderId },
+          projectFolderId,
         });
       },
       []
@@ -346,7 +346,7 @@ const ProjectFolderCard = memo<Props>(
     const handleProjectTitleOnClick = useCallback(
       (projectFolderId: string) => () => {
         trackEventByName(tracks.clickOnProjectTitle, {
-          extra: { projectFolderId },
+          projectFolderId,
         });
       },
       []

--- a/front/app/components/ProjectCard/index.tsx
+++ b/front/app/components/ProjectCard/index.tsx
@@ -393,15 +393,15 @@ const ProjectCard = memo<InputProps>(
     const [visible, setVisible] = useState(false);
 
     const handleProjectCardOnClick = (projectId: string) => {
-      trackEventByName(tracks.clickOnProjectCard, { extra: { projectId } });
+      trackEventByName(tracks.clickOnProjectCard, { projectId });
     };
 
     const handleCTAOnClick = (projectId: string) => {
-      trackEventByName(tracks.clickOnProjectCardCTA, { extra: { projectId } });
+      trackEventByName(tracks.clickOnProjectCardCTA, { projectId });
     };
 
     const handleProjectTitleOnClick = (projectId: string) => {
-      trackEventByName(tracks.clickOnProjectTitle, { extra: { projectId } });
+      trackEventByName(tracks.clickOnProjectTitle, { projectId });
     };
 
     if (project) {

--- a/front/app/components/UI/QuillEditor/Toolbar.tsx
+++ b/front/app/components/UI/QuillEditor/Toolbar.tsx
@@ -109,10 +109,8 @@ const Toolbar = ({
       | { type: 'list'; option: 'bullet' | 'ordered' }) =>
     (_event: React.MouseEvent<HTMLElement>) => {
       trackEventByName(tracks.advancedEditing.name, {
-        extra: {
-          type,
-          option,
-        },
+        type,
+        option,
       });
     };
 
@@ -135,10 +133,8 @@ const Toolbar = ({
       }
 
       trackEventByName(tracks.advancedEditing.name, {
-        extra: {
-          option,
-          type: 'heading',
-        },
+        option,
+        type: 'heading',
       });
     }
   };
@@ -147,9 +143,7 @@ const Toolbar = ({
     (type: 'bold' | 'italic' | 'custom-link' | 'link') =>
     (_event: React.MouseEvent<HTMLElement>) => {
       trackEventByName(tracks.basicEditing.name, {
-        extra: {
-          type,
-        },
+        type,
       });
     };
 

--- a/front/app/components/admin/InternalComments/InternalChildCommentForm.tsx
+++ b/front/app/components/admin/InternalComments/InternalChildCommentForm.tsx
@@ -150,11 +150,9 @@ const InternalChildCommentForm = ({
 
   const onFocus = () => {
     trackEventByName(tracks.focusChildCommentEditor, {
-      extra: {
-        postId: ideaId,
-        postType: 'idea',
-        parentId,
-      },
+      postId: ideaId,
+      postType: 'idea',
+      parentId,
     });
 
     setFocused(true);
@@ -175,12 +173,10 @@ const InternalChildCommentForm = ({
       setCanSubmit(false);
 
       trackEventByName(tracks.clickChildCommentPublish, {
-        extra: {
-          postId: ideaId,
-          postType: 'idea',
-          parentId,
-          content: inputValue,
-        },
+        postId: ideaId,
+        postType: 'idea',
+        parentId,
+        content: inputValue,
       });
 
       if (projectId && ideaId) {

--- a/front/app/components/admin/InternalComments/InternalParentCommentForm.tsx
+++ b/front/app/components/admin/InternalComments/InternalParentCommentForm.tsx
@@ -121,10 +121,8 @@ const InternalParentCommentForm = ({ ideaId, className }: Props) => {
 
   const onFocus = () => {
     trackEventByName(tracks.focusParentCommentEditor, {
-      extra: {
-        postId: ideaId,
-        postType: 'idea',
-      },
+      postId: ideaId,
+      postType: 'idea',
     });
 
     setFocused(true);
@@ -149,11 +147,9 @@ const InternalParentCommentForm = ({ ideaId, className }: Props) => {
       );
 
       trackEventByName(tracks.clickParentCommentPublish, {
-        extra: {
-          postId: ideaId,
-          postType: 'idea',
-          content: inputValue,
-        },
+        postId: ideaId,
+        postType: 'idea',
+        content: inputValue,
       });
 
       if (projectId && ideaId) {

--- a/front/app/components/admin/ReportExportMenu/index.tsx
+++ b/front/app/components/admin/ReportExportMenu/index.tsx
@@ -134,7 +134,7 @@ const ReportExportMenu = ({
       }
     });
 
-    trackEventByName('Clicked export svg', { extra: { graph: name } });
+    trackEventByName('Clicked export svg', { graph: name });
   };
 
   const handleDownloadPng = async () => {
@@ -194,7 +194,7 @@ const ReportExportMenu = ({
       }
     });
 
-    trackEventByName('Clicked export png', { extra: { graph: name } });
+    trackEventByName('Clicked export png', { graph: name });
   };
 
   const toggleDropdown = (value?: boolean) => () => {
@@ -264,7 +264,7 @@ const ReportExportMenu = ({
     setExportingXls(false);
 
     // track this click for user analytics
-    trackEventByName('Clicked export xlsx', { extra: { graph: name } });
+    trackEventByName('Clicked export xlsx', { graph: name });
   };
 
   return (

--- a/front/app/containers/Admin/dashboard/overview/index.tsx
+++ b/front/app/containers/Admin/dashboard/overview/index.tsx
@@ -76,7 +76,8 @@ const OverviewDashboard = () => {
   const handleOnProjectFilter = useCallback(
     (filter: { value: string; label: string }) => {
       trackEventByName(tracks.filteredOnProject.name, {
-        project: filter.toString(),
+        filterValue: filter.value,
+        filterLabel: filter.label,
       });
 
       setCurrentProjectFilter(filter.value);

--- a/front/app/containers/Admin/dashboard/overview/index.tsx
+++ b/front/app/containers/Admin/dashboard/overview/index.tsx
@@ -75,7 +75,9 @@ const OverviewDashboard = () => {
 
   const handleOnProjectFilter = useCallback(
     (filter: { value: string; label: string }) => {
-      trackEventByName(tracks.filteredOnProject.name, { project: filter });
+      trackEventByName(tracks.filteredOnProject.name, {
+        project: filter.toString(),
+      });
 
       setCurrentProjectFilter(filter.value);
       setCurrentProjectFilterLabel(filter.label);

--- a/front/app/containers/Admin/dashboard/users/index.tsx
+++ b/front/app/containers/Admin/dashboard/users/index.tsx
@@ -39,7 +39,7 @@ export class UsersDashboard extends PureComponent<Props, State> {
   };
 
   handleOnGroupFilter = (filter) => {
-    trackEventByName(tracks.filteredOnGroup.name, { extra: { group: filter } });
+    trackEventByName(tracks.filteredOnGroup.name, { group: filter });
     this.setState({
       currentGroupFilter: filter.value,
       currentGroupFilterLabel: filter.label,

--- a/front/app/containers/Admin/projects/components/AnalysisBanner.tsx
+++ b/front/app/containers/Admin/projects/components/AnalysisBanner.tsx
@@ -71,12 +71,10 @@ const AnalysisBanner = ({ projectId, phaseId }: Props) => {
               }/analysis/${analysis.data.id}`
             );
             trackEventByName(tracks.analysisCreated.name, {
-              extra: {
-                projectId,
-                phaseId,
-                participationMethod:
-                  phase?.data.attributes.participation_method || 'ideation',
-              },
+              projectId,
+              phaseId,
+              participationMethod:
+                phase?.data.attributes.participation_method || 'ideation',
             });
           },
         }

--- a/front/app/containers/Admin/projects/components/NewIdeaButton/index.tsx
+++ b/front/app/containers/Admin/projects/components/NewIdeaButton/index.tsx
@@ -31,7 +31,7 @@ const NewIdeaButton = ({ linkTo, inputTerm }: Props) => {
       linkTo={linkTo}
       onClick={() => {
         trackEventByName(tracks.clickNewIdea.name, {
-          extra: { pathnameFrom: pathname },
+          pathnameFrom: pathname,
         });
       }}
       text={formatMessage(

--- a/front/app/containers/Admin/projects/project/analysis/InputsList/InputListItem.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/InputsList/InputListItem.tsx
@@ -63,7 +63,7 @@ const InputListItem = memo(({ input, onSelect, selected }: Props) => {
         onClick={() => {
           onSelect(input.id);
           trackEventByName(tracks.inputPreviewedFromList.name, {
-            extra: { inputId: input.id },
+            inputId: input.id,
           });
         }}
         bg={selected ? colors.background : colors.white}

--- a/front/app/containers/Admin/projects/project/analysis/Insights/Question.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Insights/Question.tsx
@@ -55,7 +55,7 @@ const Question = ({ insight }: Props) => {
         {
           onSuccess: () => {
             trackEventByName(tracks.questionDeleted.name, {
-              extra: { analysisId },
+              analysisId,
             });
           },
         }

--- a/front/app/containers/Admin/projects/project/analysis/Insights/QuestionInput.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Insights/QuestionInput.tsx
@@ -37,7 +37,7 @@ const QuestionInput = ({ onClose }: { onClose: () => void }) => {
       {
         onSuccess: () => {
           trackEventByName(tracks.questionCreated.name, {
-            extra: { analysisId },
+            analysisId,
           });
           onClose();
         },

--- a/front/app/containers/Admin/projects/project/analysis/Insights/SummarizeButton.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Insights/SummarizeButton.tsx
@@ -40,7 +40,7 @@ const SummarizeButton = ({
       {
         onSuccess: () => {
           trackEventByName(tracks.summaryCreated.name, {
-            extra: { analysisId },
+            analysisId,
           });
         },
       }

--- a/front/app/containers/Admin/projects/project/analysis/Insights/Summary.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Insights/Summary.tsx
@@ -55,7 +55,7 @@ const Summary = ({ insight }: Props) => {
         {
           onSuccess: () => {
             trackEventByName(tracks.summaryDeleted.name, {
-              extra: { analysisId },
+              analysisId,
             });
           },
         }

--- a/front/app/containers/Admin/projects/project/analysis/Tags/AddTag.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Tags/AddTag.tsx
@@ -35,7 +35,8 @@ const AddTag = ({ onCreateTag }: { onCreateTag?: (tagId: string) => void }) => {
       {
         onSuccess: (data) => {
           trackEventByName(tracks.manualTagCreated.name, {
-            extra: { analysisId, name },
+            analysisId,
+            name,
           });
           setName('');
           onCreateTag && onCreateTag(data.data.id);

--- a/front/app/containers/Admin/projects/project/analysis/Tags/AutoTaggingModal/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Tags/AutoTaggingModal/index.tsx
@@ -55,7 +55,8 @@ const AutotaggingModal = ({ onCloseModal }: { onCloseModal: () => void }) => {
       {
         onSuccess: () => {
           trackEventByName(tracks.autoTaggingPerformed.name, {
-            extra: { analysisId, autoTaggingMethod },
+            analysisId,
+            autoTaggingMethod,
           });
           onCloseModal();
         },

--- a/front/app/containers/Admin/projects/project/analysis/Tags/TagActions.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Tags/TagActions.tsx
@@ -65,7 +65,7 @@ const TagActions = ({ tag }: { tag: ITagData }) => {
         {
           onSuccess: () => {
             trackEventByName(tracks.tagDeleted.name, {
-              extra: { analysisId },
+              analysisId,
             });
             closeDropdown();
           },
@@ -93,7 +93,7 @@ const TagActions = ({ tag }: { tag: ITagData }) => {
       {
         onSuccess: () => {
           trackEventByName(tracks.bulkTagAssignmentPerformed.name, {
-            extra: { analysisId },
+            analysisId,
           });
           closeDropdown();
         },

--- a/front/app/containers/Admin/projects/project/analysis/Tags/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Tags/index.tsx
@@ -149,7 +149,7 @@ const Tags = () => {
     }
     queryClient.invalidateQueries(inputsKeys.lists());
     trackEventByName(tracks.tagFilterUsed.name, {
-      extra: { tagId: id },
+      tagId: id,
     });
   };
 

--- a/front/app/containers/Admin/projects/project/analysis/TopBar/Filters/AuthorFilters.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/TopBar/Filters/AuthorFilters.tsx
@@ -116,9 +116,7 @@ const AuthorFilters = () => {
                 ),
               });
               trackEventByName(tracks.authorFilterUsed.name, {
-                extra: {
-                  type: 'gender',
-                },
+                type: 'gender',
               });
             }}
             p="4px 8px"
@@ -161,9 +159,7 @@ const AuthorFilters = () => {
                 ),
               });
               trackEventByName(tracks.authorFilterUsed.name, {
-                extra: {
-                  type: 'domicile',
-                },
+                type: 'domicile',
               });
             }}
             p="4px 8px"
@@ -186,9 +182,7 @@ const AuthorFilters = () => {
                     [birthyearUrlQueryParamFromKey]: option.value,
                   });
                   trackEventByName(tracks.authorFilterUsed.name, {
-                    extra: {
-                      type: 'birthyear',
-                    },
+                    type: 'birthyear',
                   });
                 }}
                 value={searchParams.get(birthyearUrlQueryParamFromKey)}
@@ -204,9 +198,7 @@ const AuthorFilters = () => {
                     [birthyearUrlQueryParamToKey]: option.value,
                   });
                   trackEventByName(tracks.authorFilterUsed.name, {
-                    extra: {
-                      type: 'birthyear',
-                    },
+                    type: 'birthyear',
                   });
                 }}
                 value={searchParams.get(birthyearUrlQueryParamToKey)}

--- a/front/app/containers/Admin/projects/project/analysis/TopBar/Filters/EngagementFilter.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/TopBar/Filters/EngagementFilter.tsx
@@ -63,9 +63,7 @@ const EngagementFilter = ({
             removeSearchParams([from, to]);
             value && updateSearchParams({ [selectValue]: value });
             trackEventByName(tracks.engagementFilterUsed.name, {
-              extra: {
-                type: selectValue,
-              },
+              type: selectValue,
             });
           }}
         />

--- a/front/app/containers/Admin/projects/project/analysis/TopBar/Filters/TimeFilter.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/TopBar/Filters/TimeFilter.tsx
@@ -29,10 +29,8 @@ const TimeFilter = () => {
           published_at_to: to?.format('YYYY-MM-DD'),
         });
         trackEventByName(tracks.timeFilterUsed.name, {
-          extra: {
-            from: from?.format('YYYY-MM-DD'),
-            to: to?.format('YYYY-MM-DD'),
-          },
+          from: from?.format('YYYY-MM-DD'),
+          to: to?.format('YYYY-MM-DD'),
         });
       }}
       endAtMoment={endAtMoment}

--- a/front/app/containers/Admin/projects/project/poll/ExportPollButton.tsx
+++ b/front/app/containers/Admin/projects/project/poll/ExportPollButton.tsx
@@ -36,7 +36,10 @@ class ExportPollButton extends React.PureComponent<
   }
 
   trackExportPoll = () => {
-    trackEventByName(tracks.clickExportPoll.name, { ...this.props });
+    trackEventByName(tracks.clickExportPoll.name, {
+      phaseId: this.props.phaseId,
+      phaseName: this.props.phaseName,
+    });
   };
 
   handleExportPollResults = async () => {

--- a/front/app/containers/Admin/projects/project/poll/ExportPollButton.tsx
+++ b/front/app/containers/Admin/projects/project/poll/ExportPollButton.tsx
@@ -36,7 +36,7 @@ class ExportPollButton extends React.PureComponent<
   }
 
   trackExportPoll = () => {
-    trackEventByName(tracks.clickExportPoll.name, { extra: { ...this.props } });
+    trackEventByName(tracks.clickExportPoll.name, { ...this.props });
   };
 
   handleExportPollResults = async () => {

--- a/front/app/containers/Admin/projects/project/surveyResults/ExportSurveyButton.tsx
+++ b/front/app/containers/Admin/projects/project/surveyResults/ExportSurveyButton.tsx
@@ -34,7 +34,7 @@ export default class ExportSurveyButton extends React.PureComponent<
 
   trackExportSurvey = () => {
     trackEventByName(tracks.clickExportSurvey.name, {
-      ...this.props,
+      phaseId: this.props.phaseId,
     });
   };
 

--- a/front/app/containers/Admin/projects/project/surveyResults/ExportSurveyButton.tsx
+++ b/front/app/containers/Admin/projects/project/surveyResults/ExportSurveyButton.tsx
@@ -34,7 +34,7 @@ export default class ExportSurveyButton extends React.PureComponent<
 
   trackExportSurvey = () => {
     trackEventByName(tracks.clickExportSurvey.name, {
-      extra: { ...this.props },
+      ...this.props,
     });
   };
 

--- a/front/app/containers/Admin/projects/project/topics/ProjectTopicSelector.tsx
+++ b/front/app/containers/Admin/projects/project/topics/ProjectTopicSelector.tsx
@@ -87,7 +87,7 @@ const ProjectTopicSelector = memo(
 
       try {
         await Promise.all(promises);
-        trackEventByName(tracks.projectTagsEdited, projectId);
+        trackEventByName(tracks.projectTagsEdited, { projectId });
         setProcessing(false);
         setSelectedTopicOptions([]);
       } catch {

--- a/front/app/containers/Admin/projects/project/topics/SortableProjectTopicList.tsx
+++ b/front/app/containers/Admin/projects/project/topics/SortableProjectTopicList.tsx
@@ -83,7 +83,7 @@ const SortableProjectTopicList = memo(
       if (projectAllowedInputTopicIdToDelete) {
         deleteProjectAllowedInputTopic(projectAllowedInputTopicIdToDelete, {
           onSuccess: () => {
-            trackEventByName(tracks.projectTagsEdited, projectId);
+            trackEventByName(tracks.projectTagsEdited, { projectId });
             setShowConfirmationModal(false);
             setProjectAllowedInputTopicIdToDelete(null);
           },

--- a/front/app/containers/Admin/users/UserTable.tsx
+++ b/front/app/containers/Admin/users/UserTable.tsx
@@ -97,9 +97,7 @@ const UsersTable = ({
 
   const handleSortingOnChange = (sort: IQueryParameters['sort']) => () => {
     trackEventByName(tracks.sortChange.name, {
-      extra: {
-        sort,
-      },
+      sort,
     });
     onChangeSorting(sort);
   };

--- a/front/app/containers/Admin/users/UserTableActions.tsx
+++ b/front/app/containers/Admin/users/UserTableActions.tsx
@@ -229,10 +229,8 @@ const UserTableActions = ({
       };
 
       trackEventByName(tracks.addUsersToGroup.name, {
-        extra: {
-          usersIds,
-          selectedGroupIds,
-        },
+        usersIds: usersIds.toString(),
+        selectedGroupIds: selectedGroupIds.toString(),
       });
 
       if (isArray(usersIds)) {
@@ -252,9 +250,7 @@ const UserTableActions = ({
         return true;
       } catch (error) {
         trackEventByName(tracks.addedRedundantUserToGroup.name, {
-          extra: {
-            errorResponse: error,
-          },
+          errorResponse: error.toString(),
         });
 
         // if error because users already part of group(s)

--- a/front/app/containers/Admin/users/UsersGroup.tsx
+++ b/front/app/containers/Admin/users/UsersGroup.tsx
@@ -50,9 +50,7 @@ const UsersGroup = () => {
     if (group) {
       const groupType = group.data.attributes.membership_type;
       trackEventByName(tracks.editGroup.name, {
-        extra: {
-          groupType,
-        },
+        groupType,
       });
 
       setGroupEditionModal(groupType);

--- a/front/app/containers/HomePage/SignedInHeader/index.tsx
+++ b/front/app/containers/HomePage/SignedInHeader/index.tsx
@@ -68,7 +68,8 @@ const SignedInHeader = ({
 
   const handleSkip = (name: OnboardingCampaignName) => () => {
     trackEventByName(tracks.clickSkipButton, {
-      extra: { location: 'signed-in header', context: name },
+      location: 'signed-in header',
+      context: name,
     });
     dismissOnboardingCampaign(name);
   };

--- a/front/app/containers/HomePage/SignedOutHeader/HeaderContent.tsx
+++ b/front/app/containers/HomePage/SignedOutHeader/HeaderContent.tsx
@@ -63,7 +63,7 @@ const HeaderContent = ({
   const signUpIn = (event: React.FormEvent) => {
     event.preventDefault();
     trackEventByName(tracks.clickCreateAccountCTA, {
-      extra: { location: 'signed-out header' },
+      location: 'signed-out header',
     });
     triggerAuthenticationFlow();
   };

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/NotificationWrapper/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/NotificationWrapper/index.tsx
@@ -112,7 +112,7 @@ const NotificationWrapper = ({
 }: Props) => {
   const locale = useLocale();
   const track = () => {
-    trackEventByName(tracks.clickNotification.name, { extra: { linkTo } });
+    trackEventByName(tracks.clickNotification.name, { linkTo });
   };
 
   if (!isNilOrError(locale)) {

--- a/front/app/modules/commercial/admin_project_templates/admin/containers/CreateProjectFromTemplate.tsx
+++ b/front/app/modules/commercial/admin_project_templates/admin/containers/CreateProjectFromTemplate.tsx
@@ -138,7 +138,9 @@ const CreateProjectFromTemplate = memo(
 
     const handleDepartmentFilterOnChange = useCallback(
       (departments: string[]) => {
-        trackEventByName(tracks.departmentFilterChanged, { departments });
+        trackEventByName(tracks.departmentFilterChanged, {
+          departments: departments.toString(),
+        });
         setDepartments(
           // TODO: Fix this the next time the file is edited.
           // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
@@ -149,7 +151,9 @@ const CreateProjectFromTemplate = memo(
     );
 
     const handlePurposeFilterOnChange = useCallback((purposes: string[]) => {
-      trackEventByName(tracks.purposeFilterChanged, { purposes });
+      trackEventByName(tracks.purposeFilterChanged, {
+        purposes: purposes.toString(),
+      });
       // TODO: Fix this the next time the file is edited.
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       setPurposes(purposes && purposes.length > 0 ? purposes : null);
@@ -158,7 +162,7 @@ const CreateProjectFromTemplate = memo(
     const handleParticipationLevelFilterOnChange = useCallback(
       (participationLevels: string[]) => {
         trackEventByName(tracks.participationLevelFilterChanged, {
-          participationLevels,
+          participationLevels: participationLevels.toString(),
         });
         setParticipationLevels(
           // TODO: Fix this the next time the file is edited.

--- a/front/app/modules/commercial/representativeness/admin/containers/Dashboard/index.tsx
+++ b/front/app/modules/commercial/representativeness/admin/containers/Dashboard/index.tsx
@@ -27,7 +27,7 @@ const RepresentativenessDashboard = () => {
 
   const onProjectFilter = ({ value }) => {
     trackEventByName(tracks.filteredOnProject.name, {
-      extra: { projectId: value },
+      projectId: value,
     });
 
     setCurrentProjectFilter(value);

--- a/front/app/utils/analytics.ts
+++ b/front/app/utils/analytics.ts
@@ -131,7 +131,7 @@ export function trackPage(path: string, properties = {}) {
   });
 }
 
-type Properties = Record<string, string | number>;
+type Properties = Record<string, string | number | boolean | undefined | null>;
 
 export function trackEventByName(
   eventName: string,

--- a/front/app/utils/analytics.ts
+++ b/front/app/utils/analytics.ts
@@ -131,7 +131,12 @@ export function trackPage(path: string, properties = {}) {
   });
 }
 
-export function trackEventByName(eventName: string, properties = {}) {
+type Properties = Record<string, string | number>;
+
+export function trackEventByName(
+  eventName: string,
+  properties: Properties = {}
+) {
   events$.next({
     properties,
     name: eventName,


### PR DESCRIPTION
# Changelog
## Technical
- Clean up usage of `trackEventByName` so that extra event properties are primitives (i.e. strings or numbers) rather than weird complicated nested objects that are useless when you're trying to do analysis in posthog