### PR TITLE
Replace semantic-ui-react in PhasesSelector

### DIFF
--- a/front/app/components/admin/PostManager/components/FilterSidebar/phases/CircledPhaseNumber.tsx
+++ b/front/app/components/admin/PostManager/components/FilterSidebar/phases/CircledPhaseNumber.tsx
@@ -4,22 +4,28 @@ import { Box, Color, colors, Text } from '@citizenlab/cl2-component-library';
 
 interface Props {
   phaseNumber: number;
-  borderColor?: Color;
+  color?: Color;
 }
 
-const CircledPhaseNumber = ({ phaseNumber, borderColor }: Props) => {
+const CircledPhaseNumber = ({ phaseNumber, color }: Props) => {
   return (
     <Box
       width="24px"
       height="24px"
-      border={`1px solid ${borderColor ? colors[borderColor] : colors.teal}`}
+      border={`1px solid ${color ? colors[color] : colors.teal}`}
       borderRadius="50%"
       display="flex"
       alignItems="center"
       justifyContent="center"
       background={colors.white}
     >
-      <Text m="0" as="span" fontWeight="bold" fontSize="xs" color="teal">
+      <Text
+        m="0"
+        as="span"
+        fontWeight="bold"
+        fontSize="xs"
+        color={color || 'teal'}
+      >
         {phaseNumber}
       </Text>
     </Box>

--- a/front/app/components/admin/PostManager/components/FilterSidebar/phases/CircledPhaseNumber.tsx
+++ b/front/app/components/admin/PostManager/components/FilterSidebar/phases/CircledPhaseNumber.tsx
@@ -1,17 +1,18 @@
 import React from 'react';
 
-import { Box, colors, Text } from '@citizenlab/cl2-component-library';
+import { Box, Color, colors, Text } from '@citizenlab/cl2-component-library';
 
 interface Props {
   phaseNumber: number;
+  borderColor?: Color;
 }
 
-const CircledPhaseNumber = ({ phaseNumber }: Props) => {
+const CircledPhaseNumber = ({ phaseNumber, borderColor }: Props) => {
   return (
     <Box
       width="24px"
       height="24px"
-      border={`1px solid ${colors.teal}`}
+      border={`1px solid ${borderColor ? colors[borderColor] : colors.teal}`}
       borderRadius="50%"
       display="flex"
       alignItems="center"

--- a/front/app/components/admin/PostManager/components/PostTable/Row/selectors/PhasesSelector.tsx
+++ b/front/app/components/admin/PostManager/components/PostTable/Row/selectors/PhasesSelector.tsx
@@ -37,7 +37,7 @@ class PhasesSelector extends React.PureComponent<Props> {
     return (
       <Box display="flex">
         {phases.map((phase, index) => (
-          <Box key={phase.id} mr="4px">
+          <Box key={phase.id}>
             <Tooltip content={<T value={phase.attributes.title_multiloc} />}>
               <Button
                 buttonStyle="text"

--- a/front/app/components/admin/PostManager/components/PostTable/Row/selectors/PhasesSelector.tsx
+++ b/front/app/components/admin/PostManager/components/PostTable/Row/selectors/PhasesSelector.tsx
@@ -48,7 +48,7 @@ class PhasesSelector extends React.PureComponent<Props> {
               >
                 <CircledPhaseNumber
                   phaseNumber={index + 1}
-                  borderColor={this.isActive(phase.id) ? 'teal' : 'grey400'}
+                  color={this.isActive(phase.id) ? 'teal' : 'grey600'}
                 />
               </Button>
             </Tooltip>

--- a/front/app/components/admin/PostManager/components/PostTable/Row/selectors/PhasesSelector.tsx
+++ b/front/app/components/admin/PostManager/components/PostTable/Row/selectors/PhasesSelector.tsx
@@ -37,7 +37,7 @@ class PhasesSelector extends React.PureComponent<Props> {
     return (
       <Box display="flex">
         {phases.map((phase, index) => (
-          <Box key={phase.id}>
+          <Box key={phase.id} mr="2px">
             <Tooltip content={<T value={phase.attributes.title_multiloc} />}>
               <Button
                 buttonStyle="text"

--- a/front/app/components/admin/PostManager/components/PostTable/Row/selectors/PhasesSelector.tsx
+++ b/front/app/components/admin/PostManager/components/PostTable/Row/selectors/PhasesSelector.tsx
@@ -1,11 +1,12 @@
 import React, { MouseEvent } from 'react';
 
+import { Box, Button, Tooltip } from '@citizenlab/cl2-component-library';
 import { xor } from 'lodash-es';
-import { Label, Popup } from 'semantic-ui-react';
 
 import { IPhaseData } from 'api/phases/types';
 import { canContainIdeas } from 'api/phases/utils';
 
+import CircledPhaseNumber from 'components/admin/PostManager/components/FilterSidebar/phases/CircledPhaseNumber';
 import T from 'components/T';
 
 type Props = {
@@ -34,28 +35,26 @@ class PhasesSelector extends React.PureComponent<Props> {
   render() {
     const { phases } = this.props;
     return (
-      <div>
+      <Box display="flex">
         {phases.map((phase, index) => (
-          <Popup
-            basic
-            key={phase.id}
-            trigger={
-              <Label
-                as={this.isEnabled(phase) ? 'a' : undefined}
-                color={this.isActive(phase.id) ? 'teal' : undefined}
-                active={this.isActive(phase.id)}
+          <Box key={phase.id} mr="4px">
+            <Tooltip content={<T value={phase.attributes.title_multiloc} />}>
+              <Button
+                buttonStyle="text"
+                type="button"
+                p="0"
                 onClick={this.handlePhaseClick(phase)}
-                circular
-                basic
+                disabled={!this.isEnabled(phase)}
               >
-                {index + 1}
-              </Label>
-            }
-            content={<T value={phase.attributes.title_multiloc} />}
-            position="top center"
-          />
+                <CircledPhaseNumber
+                  phaseNumber={index + 1}
+                  borderColor={this.isActive(phase.id) ? 'teal' : 'grey400'}
+                />
+              </Button>
+            </Tooltip>
+          </Box>
         ))}
-      </div>
+      </Box>
     );
   }
 }


### PR DESCRIPTION
Before
<img width="884" alt="Screenshot 2024-12-20 at 11 41 18" src="https://github.com/user-attachments/assets/053c09c9-0c30-4823-b2fd-e1bf606d4feb" />

After
<img width="875" alt="Screenshot 2024-12-20 at 11 59 20" src="https://github.com/user-attachments/assets/8f068cdc-3fbd-4915-b177-99cb921302eb" />

Both use the same data. Disabled and unselected have clearer styles now, FWIW (little effort).

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Changed
- Input phase selectors in the input manager have clearer styles to differentiate between disabled/non-active/active (before/after can be seen [here](https://github.com/CitizenLabDotCo/citizenlab/pull/9870)).
