### PR TITLE
Small fixes

### DIFF
--- a/front/app/components/LandingPages/citizen/EventsWidget.tsx
+++ b/front/app/components/LandingPages/citizen/EventsWidget.tsx
@@ -37,12 +37,6 @@ const Header = styled.div`
   width: 100%;
   display: flex;
   justify-content: space-between;
-  padding-bottom: 30px;
-  margin-bottom: 30px;
-
-  ${media.phone`
-    margin-bottom: 21px;
-  `}
 
   ${isRtl`
     flex-direction: row-reverse;

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Toolbox/utils.ts
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Toolbox/utils.ts
@@ -1,4 +1,4 @@
-const releaseDateNewWidgets = new Date('2024-11-16');
+const releaseDateNewWidgets = new Date('2024-12-16');
 
 export const platformCreatedBeforeReleaseNewWidgets = (
   creationDate: string


### PR DESCRIPTION
# Changelog
## Fixed
- Excessive space under events widget title
- Wrong date to hide legacy projects widget