### PR TITLE
Improve tab styles

### DIFF
--- a/front/app/components/admin/PostManager/components/FilterSidebar/index.tsx
+++ b/front/app/components/admin/PostManager/components/FilterSidebar/index.tsx
@@ -115,8 +115,8 @@ const FilterSidebar = ({
     const active = activeFilterMenu === key;
     const selectionSign = isEmpty(selection) ? '' : '*';
     return (
-      <>
-        {title}
+      <Box display="flex" alignItems="center">
+        {active ? <b>{title}</b> : title}
         {selectionSign}&nbsp;
         {active ? (
           <IconTooltip
@@ -125,7 +125,7 @@ const FilterSidebar = ({
             theme="light"
           />
         ) : null}
-      </>
+      </Box>
     );
   };
 
@@ -199,9 +199,6 @@ const FilterSidebar = ({
 
           return (
             <Box
-              display="flex"
-              justifyContent="space-between"
-              alignItems="center"
               w="100%"
               as="button"
               key={item.key}
@@ -209,11 +206,13 @@ const FilterSidebar = ({
               p="12px"
               className={`intercom-admin-input-manager-filter-sidebar-${item.key}`}
               data-cy={`e2e-admin-post-manager-filter-sidebar-${item.key}`}
-              {...getBorders(active)}
               onClick={() => {
                 handleItemClick(item.key);
               }}
               cursor="pointer"
+              borderBottom={
+                active ? `3px solid ${colors.teal500}` : '3px solid transparent'
+              }
             >
               {item.name}
             </Box>
@@ -225,17 +224,6 @@ const FilterSidebar = ({
       </Box>
     </>
   );
-};
-
-const getBorders = (active: boolean) => {
-  if (!active) return {};
-
-  return {
-    borderRadius: stylingConsts.borderRadius,
-    borderLeft: BORDER,
-    borderTop: BORDER,
-    borderRight: BORDER,
-  };
 };
 
 export default FilterSidebar;


### PR DESCRIPTION
Aligning them with tab styles from the admin.

Before
<img width="1492" alt="Project before" src="https://github.com/user-attachments/assets/6b415d56-4c12-4e6d-a96c-aa8a9c070ef9" />
<img width="1492" alt="General before" src="https://github.com/user-attachments/assets/1e7c472e-1034-482e-bd9c-f0da78b27033" />

After
<img width="1498" alt="Project after" src="https://github.com/user-attachments/assets/f2666ba0-e701-430c-9de4-2662a398aecb" />
<img width="1507" alt="General after" src="https://github.com/user-attachments/assets/174e6748-5b51-4ad1-8f94-9632502446f3" />

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Changed
- Tab styles of left column of input manager. (See [here](https://github.com/CitizenLabDotCo/citizenlab/pull/9892) for a before/after.)