### PR TITLE
Tan 3452/fix background idea page cta buttons

### DIFF
--- a/front/app/containers/IdeasShow/components/ProposalInfo/Status/index.tsx
+++ b/front/app/containers/IdeasShow/components/ProposalInfo/Status/index.tsx
@@ -89,7 +89,7 @@ const Status = ({ idea, ideaStatus, compact = false }: Props) => {
         </Text>
       </Box>
       {showProgressBar && (
-        <Box mb="12px">
+        <Box mb="24px">
           <ReactionCounter
             idea={idea}
             barColor={theme.colors.tenantPrimary || colors.success}

--- a/front/app/containers/IdeasShow/components/ProposalInfo/Status/index.tsx
+++ b/front/app/containers/IdeasShow/components/ProposalInfo/Status/index.tsx
@@ -84,12 +84,12 @@ const Status = ({ idea, ideaStatus, compact = false }: Props) => {
         </StatusHeading>
       </Box>
       <Box mb="24px" aria-live="polite">
-        <Text>
+        <Text m="0">
           <T value={ideaStatus.attributes.description_multiloc} />
         </Text>
       </Box>
       {showProgressBar && (
-        <Box mb="24px">
+        <Box mb="12px">
           <ReactionCounter
             idea={idea}
             barColor={theme.colors.tenantPrimary || colors.success}

--- a/front/app/containers/IdeasShow/components/RightColumnDesktop/index.tsx
+++ b/front/app/containers/IdeasShow/components/RightColumnDesktop/index.tsx
@@ -121,7 +121,7 @@ const RightColumnDesktop = ({
               </Box>
             )}
             {commentingEnabled && (
-              <Box mb="12px" bg={colors.white}>
+              <Box mb="12px">
                 <GoToCommentsButton />
               </Box>
             )}

--- a/front/app/containers/IdeasShow/components/RightColumnDesktop/index.tsx
+++ b/front/app/containers/IdeasShow/components/RightColumnDesktop/index.tsx
@@ -11,6 +11,7 @@ import {
 
 import useFeatureFlag from 'hooks/useFeatureFlag';
 
+import Divider from 'components/admin/Divider';
 import FollowUnfollow from 'components/FollowUnfollow';
 import ReactionControl from 'components/ReactionControl';
 import { showIdeaReactions } from 'components/ReactionControl/utils';
@@ -88,14 +89,19 @@ const RightColumnDesktop = ({
             mb="12px"
           >
             {participationMethod === 'proposals' && (
-              <Box bg="white" p="12px">
-                <ProposalInfo idea={idea} />
-              </Box>
+              <>
+                <Box p="12px" bg={colors.white}>
+                  <ProposalInfo idea={idea} />
+                </Box>
+                <Divider />
+              </>
             )}
+            {/* Doesn't show when participation method is proposals */}
             {showIdeaReactionControl && (
-              <Box pb="24px" mb="24px" borderBottom="solid 1px #ccc">
+              <>
                 <ReactionControl styleType="shadow" ideaId={ideaId} size="4" />
-              </Box>
+                <Divider />
+              </>
             )}
             {/* TODO: Fix this the next time the file is edited. */}
             {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition */}
@@ -109,19 +115,11 @@ const RightColumnDesktop = ({
               </Box>
             )}
             {commentingEnabled && (
-              <Box
-                mb="12px"
-                px={participationMethod === 'proposals' ? '12px' : '0px'}
-                bg={colors.white}
-              >
+              <Box mb="12px" bg={colors.white}>
                 <GoToCommentsButton />
               </Box>
             )}
-            <Box
-              pb={participationMethod === 'proposals' ? '12px' : '0px'}
-              px={participationMethod === 'proposals' ? '12px' : '0px'}
-              bg={colors.white}
-            >
+            <Box bg={colors.white}>
               <FollowUnfollow
                 followableType="ideas"
                 followableId={ideaId}

--- a/front/app/containers/IdeasShow/components/RightColumnDesktop/index.tsx
+++ b/front/app/containers/IdeasShow/components/RightColumnDesktop/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { Box, colors } from '@citizenlab/cl2-component-library';
+import { useTheme } from 'styled-components';
 
 import useIdeaById from 'api/ideas/useIdeaById';
 import usePhases from 'api/phases/usePhases';
@@ -41,6 +42,7 @@ const RightColumnDesktop = ({
   authorId,
   className,
 }: Props) => {
+  const theme = useTheme();
   const { data: phases } = usePhases(projectId);
   const { data: idea } = useIdeaById(ideaId);
   const followEnabled = useFeatureFlag({
@@ -84,13 +86,17 @@ const RightColumnDesktop = ({
         {showInteractionsContainer && participationMethod && (
           <Box
             padding="20px"
-            borderRadius="3px"
+            borderRadius={theme.borderRadius}
             background={colors.background}
             mb="12px"
           >
             {participationMethod === 'proposals' && (
               <>
-                <Box p="12px" bg={colors.white}>
+                <Box
+                  p="12px"
+                  bg={colors.white}
+                  borderRadius={theme.borderRadius}
+                >
                   <ProposalInfo idea={idea} />
                 </Box>
                 <Divider />

--- a/front/app/containers/IdeasShow/components/RightColumnDesktop/index.tsx
+++ b/front/app/containers/IdeasShow/components/RightColumnDesktop/index.tsx
@@ -125,17 +125,15 @@ const RightColumnDesktop = ({
                 <GoToCommentsButton />
               </Box>
             )}
-            <Box bg={colors.white}>
-              <FollowUnfollow
-                followableType="ideas"
-                followableId={ideaId}
-                followersCount={idea.data.attributes.followers_count}
-                // TODO: Fix this the next time the file is edited.
-                // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-                followerId={idea.data.relationships.user_follower?.data?.id}
-                toolTipType="input"
-              />
-            </Box>
+            <FollowUnfollow
+              followableType="ideas"
+              followableId={ideaId}
+              followersCount={idea.data.attributes.followers_count}
+              // TODO: Fix this the next time the file is edited.
+              // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+              followerId={idea.data.relationships.user_follower?.data?.id}
+              toolTipType="input"
+            />
           </Box>
         )}
         <Cosponsorship ideaId={ideaId} />

--- a/front/app/containers/IdeasShow/components/RightColumnDesktop/index.tsx
+++ b/front/app/containers/IdeasShow/components/RightColumnDesktop/index.tsx
@@ -128,11 +128,6 @@ const RightColumnDesktop = ({
                 // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
                 followerId={idea.data.relationships.user_follower?.data?.id}
                 toolTipType="input"
-                buttonStyle={
-                  participationMethod === 'proposals'
-                    ? 'secondary-outlined'
-                    : 'primary'
-                }
               />
             </Box>
           </Box>

--- a/front/app/containers/IdeasShow/components/RightColumnDesktop/index.tsx
+++ b/front/app/containers/IdeasShow/components/RightColumnDesktop/index.tsx
@@ -110,7 +110,7 @@ const RightColumnDesktop = ({
             )}
             {commentingEnabled && (
               <Box
-                pb="12px"
+                mb="12px"
                 px={participationMethod === 'proposals' ? '12px' : '0px'}
                 bg={colors.white}
               >


### PR DESCRIPTION
Initially, I only wanted to fix the background color between the "add a comment" and follow button:

Before
<img width="371" alt="Screenshot 2025-01-02 at 10 04 18" src="https://github.com/user-attachments/assets/36cb33d9-f922-40c5-8f64-ed1f7f22288b" />

After
<img width="375" alt="Screenshot 2025-01-02 at 09 51 42" src="https://github.com/user-attachments/assets/1b814216-881b-4456-8495-9490d23b8e4a" />

-----
When I fixed the above, I noticed I had broken the styles of the proposals CTA box. This box also had different styles than those of the CTA boxes of other participation methods and it looked a bit off (e.g. the white Add a comment button with a shadow against a white background, and there was no clear separation between the CTA box and the Add a comment and follow buttons), so I aligned the proposals version with the version of other participation methods: 

Before proposals CTA box
<img width="356" alt="Screenshot 2025-01-02 at 10 03 59" src="https://github.com/user-attachments/assets/12f199d9-7767-4cb0-9fd9-689e3c9f7cb3" />

After proposals CTA box
<img width="356" alt="image" src="https://github.com/user-attachments/assets/c0a1f43f-e8d8-4055-9001-627bad63842f" />

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Background color between "Add a comment" and follow button on idea page. (Before/after can be seen [here](https://github.com/CitizenLabDotCo/citizenlab/pull/9927).)

## Changed
- Improved styles of CTA box on idea page when participation method is proposals. (Before/after can be seen [here](https://github.com/CitizenLabDotCo/citizenlab/pull/9927).)
