### PR TITLE
[TAN-3454] Include visible projects counts for folders in homepage selection widget

### DIFF
--- a/back/app/controllers/web_api/v1/admin_publications_controller.rb
+++ b/back/app/controllers/web_api/v1/admin_publications_controller.rb
@@ -55,7 +55,7 @@ class WebApi::V1::AdminPublicationsController < ApplicationController
 
     # Initialize the filtering in the AdminPublicationsFilteringService,
     # so that we can use the visible_children_counts_by_parent_id in the serializer, via the jsonapi_serializer_params.
-    # Not part of the query chain, as in the index, as this raises an error due to conflict with the in_order_of method.
+    # Not part of query chain, unlike the index action, as this raises an error due to conflict with in_order_of method.
     admin_publication_filterer.filter(visible_not_draft_admin_publications, params.merge(current_user: current_user))
 
     render json: linked_json(

--- a/back/app/controllers/web_api/v1/admin_publications_controller.rb
+++ b/back/app/controllers/web_api/v1/admin_publications_controller.rb
@@ -45,8 +45,8 @@ class WebApi::V1::AdminPublicationsController < ApplicationController
   def index_select_and_order_by_ids
     ids = params[:ids]
 
-    visible_admin_publications = policy_scope(AdminPublication.includes(:parent))
-    admin_publications = visible_admin_publications.not_draft.where(id: ids).in_order_of(:id, ids)
+    visible_not_draft_admin_publications = policy_scope(AdminPublication.includes(:parent)).not_draft
+    admin_publications = visible_not_draft_admin_publications.where(id: ids).in_order_of(:id, ids)
 
     @admin_publications = paginate admin_publications
     @admin_publications = includes_publications(@admin_publications)
@@ -58,7 +58,7 @@ class WebApi::V1::AdminPublicationsController < ApplicationController
     # If we invoke the service as we do in the index action, to create the counts as an instance var, we get the error:
     # PG::InvalidColumnReference: ERROR:  for SELECT DISTINCT, ORDER BY expressions must appear in select list
     visible_children_counts_by_parent_id = Hash.new(0).tap do |counts|
-      parent_ids = visible_admin_publications.pluck(:parent_id).compact
+      parent_ids = visible_not_draft_admin_publications.pluck(:parent_id).compact
       parent_ids.each { |id| counts[id] += 1 }
     end
 

--- a/back/app/controllers/web_api/v1/admin_publications_controller.rb
+++ b/back/app/controllers/web_api/v1/admin_publications_controller.rb
@@ -53,9 +53,9 @@ class WebApi::V1::AdminPublicationsController < ApplicationController
 
     authorize @admin_publications, :index_select_and_order_by_ids?
 
-    # Initiailize the filtering in the AdminPublicationsFilteringService,
+    # Initialize the filtering in the AdminPublicationsFilteringService,
     # so that we can use the visible_children_counts_by_parent_id in the serializer, via the jsonapi_serializer_params.
-    # Not part of the query chain, as in the index, as this raises an error due to conflics with the in_order_of method.
+    # Not part of the query chain, as in the index, as this raises an error due to conflict with the in_order_of method.
     admin_publication_filterer.filter(visible_not_draft_admin_publications, params.merge(current_user: current_user))
 
     render json: linked_json(

--- a/back/app/controllers/web_api/v1/admin_publications_controller.rb
+++ b/back/app/controllers/web_api/v1/admin_publications_controller.rb
@@ -53,6 +53,10 @@ class WebApi::V1::AdminPublicationsController < ApplicationController
 
     authorize @admin_publications, :index_select_and_order_by_ids?
 
+    # Replicate visible_children_counts_by_parent_id from the AdminPublicationsFilteringService
+    # as, unfortunately, we cannot use the service here due to our use of the 'in_order_of' command.
+    # If we invoke the service as we do in the index action, to create the counts as an instance var, we get the error:
+    # PG::InvalidColumnReference: ERROR:  for SELECT DISTINCT, ORDER BY expressions must appear in select list
     visible_children_counts_by_parent_id = Hash.new(0).tap do |counts|
       parent_ids = visible_admin_publications.pluck(:parent_id).compact
       parent_ids.each { |id| counts[id] += 1 }

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -608,6 +608,26 @@ resource 'AdminPublication' do
         expect(json_response[:data].size).to eq 0
       end
     end
+
+    get 'web_api/v1/admin_publications/select_and_order_by_ids' do
+      with_options scope: :page do
+        parameter :number, 'Page number'
+        parameter :size, 'Number of projects per page'
+      end
+      parameter :ids, 'Filter and order by IDs', required: false
+
+      example 'Includes correct counts of visible children', document: false do
+        group_project = create(:project, visible_to: 'groups')
+        draft_project = create(:project, admin_publication_attributes: { publication_status: 'draft' })
+        folder_with_children = create(:project_folder, projects: [published_projects[0], group_project, draft_project])
+
+        do_request(ids: [folder_with_children.admin_publication.id])
+
+        expect(status).to eq(200)
+        json_response = json_parse(response_body)
+        expect(json_response[:data].first.dig(:attributes, :visible_children_count)).to eq 1
+      end
+    end
   end
 
   context 'when not logged in' do


### PR DESCRIPTION
# Changelog
## Fixed
- [TAN-3454] Include visible projects counts for folders in homepage selection widget
