### PR TITLE
TAN-3359 Add ARM build for back

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,6 +212,7 @@ jobs:
           docker login -u $DOCKER_USER -p $DOCKER_PASS
           docker push citizenlabdotco/back-ee:amd64-$CIRCLE_SHA1
 
+  # We're doing a separate, parallel job for ARM64 builds as opposed to using docker buildx to do a single multi-arch build job, because the performance of the emulated ARM64 build on x86 is very poor, delaying the CI pipeline.
   back-build-docker-image-arm64:
     working_directory: ~/
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -954,6 +954,7 @@ workflows:
             branches:
               only:
                 - master
+                - TAN-3359-ARM-hosting
       - back-deploy-to-swarm:
           name: Deploy to staging
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ jobs:
   slack-invalid-data-success:
     resource_class: small
     docker:
-      - image: cimg/base:2021.03
+      - image: cimg/base:2025.01
     steps:
       - slack/notify:
           event: pass
@@ -200,7 +200,7 @@ jobs:
   back-build-docker-image:
     working_directory: ~/
     docker:
-      - image: cimg/base:2021.03
+      - image: cimg/base:2025.01
     steps:
       - echo_pipeline_parameters
       - shallow-clone
@@ -215,7 +215,7 @@ jobs:
   back-build-docker-arm-image:
     working_directory: ~/
     docker:
-      - image: cimg/base:2021.03
+      - image: cimg/base:2025.01
     resource_class: arm.medium
     steps:
       - echo_pipeline_parameters
@@ -313,7 +313,7 @@ jobs:
   back-trigger-deploy:
     resource_class: small
     docker:
-      - image: cimg/base:2021.03
+      - image: cimg/base:2025.01
     steps:
       - echo_pipeline_parameters
       - run: |
@@ -327,7 +327,7 @@ jobs:
   back-push-deployment-docker-image:
     resource_class: small
     docker:
-      - image: cimg/base:2021.03
+      - image: cimg/base:2025.01
     parameters:
       image_tag:
         type: string
@@ -371,7 +371,7 @@ jobs:
   back-generate-tenant-templates:
     resource_class: small
     docker:
-      - image: cimg/base:2021.03
+      - image: cimg/base:2025.01
     parameters:
       ssh_host:
         type: string
@@ -387,7 +387,7 @@ jobs:
   back-deploy-developer-documentation:
     resource_class: small
     docker:
-      - image: cimg/base:2021.03
+      - image: cimg/base:2025.01
     steps:
       - echo_pipeline_parameters
       - run: |
@@ -401,7 +401,7 @@ jobs:
   check-for-inconsistent-data:
     resource_class: small
     docker:
-      - image: cimg/base:2021.03
+      - image: cimg/base:2025.01
     parameters:
       ssh_host:
         type: string
@@ -576,7 +576,7 @@ jobs:
   front-trigger-deploy:
     resource_class: small
     docker:
-      - image: cimg/base:2021.03
+      - image: cimg/base:2025.01
     steps:
       - echo_pipeline_parameters
       - when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,7 +173,7 @@ jobs:
     resource_class: small
     executor:
       name: cl2-back
-      image-tag: $CIRCLE_SHA1
+      image-tag: amd64-$CIRCLE_SHA1
     working_directory: /cl2_back
     environment:
       RAILS_ENV: development
@@ -192,7 +192,7 @@ jobs:
     resource_class: small
     executor:
       name: cl2-back
-      image-tag: $CIRCLE_SHA1
+      image-tag: amd64-$CIRCLE_SHA1
     working_directory: /cl2_back
     steps:
       - run: bundle exec license_finder
@@ -232,7 +232,7 @@ jobs:
     resource_class: medium
     executor:
       name: cl2-back
-      image-tag: $CIRCLE_SHA1
+      image-tag: amd64-$CIRCLE_SHA1
     working_directory: /cl2_back
     environment:
       RAILS_ENV: development
@@ -243,7 +243,7 @@ jobs:
     resource_class: small
     executor:
       name: cl2-back
-      image-tag: $CIRCLE_SHA1
+      image-tag: amd64-$CIRCLE_SHA1
     working_directory: /cl2_back
     parallelism: 8
     environment:
@@ -262,7 +262,7 @@ jobs:
     resource_class: small
     executor:
       name: cl2-back
-      image-tag: $CIRCLE_SHA1
+      image-tag: amd64-$CIRCLE_SHA1
     working_directory: /cl2_back
     environment:
       RAILS_ENV: test
@@ -284,7 +284,7 @@ jobs:
     resource_class: small
     executor:
       name: cl2-back
-      image-tag: $CIRCLE_SHA1
+      image-tag: amd64-$CIRCLE_SHA1
     working_directory: /cl2_back
     steps:
       - attach_workspace:
@@ -295,7 +295,7 @@ jobs:
     resource_class: small
     executor:
       name: cl2-back
-      image-tag: $CIRCLE_SHA1
+      image-tag: amd64-$CIRCLE_SHA1
     working_directory: /cl2_back
     environment:
       RAILS_ENV: test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -954,7 +954,6 @@ workflows:
             branches:
               only:
                 - master
-                - TAN-3359-ARM-hosting
       - back-deploy-to-swarm:
           name: Deploy to staging
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,7 @@ jobs:
     steps:
       - run: bundle exec license_finder
 
-  back-build-docker-image:
+  back-build-docker-image-amd64:
     working_directory: ~/
     docker:
       - image: cimg/base:2025.01
@@ -207,12 +207,12 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run: |
-          docker build -t citizenlabdotco/back-ee:$CIRCLE_SHA1 --build-arg BUNDLE_JOBS=4 -f citizenlab/back/Dockerfile citizenlab/.
+          docker build -t citizenlabdotco/back-ee:amd64-$CIRCLE_SHA1 --build-arg BUNDLE_JOBS=4 -f citizenlab/back/Dockerfile citizenlab/.
       - run: |
           docker login -u $DOCKER_USER -p $DOCKER_PASS
-          docker push citizenlabdotco/back-ee:$CIRCLE_SHA1
+          docker push citizenlabdotco/back-ee:amd64-$CIRCLE_SHA1
 
-  back-build-docker-arm-image:
+  back-build-docker-image-arm64:
     working_directory: ~/
     docker:
       - image: cimg/base:2025.01
@@ -221,12 +221,12 @@ jobs:
       - echo_pipeline_parameters
       - shallow-clone
       - setup_remote_docker:
-          docker_layer_caching: true
+          docker_layer_caching: false
       - run: |
-          docker build -t citizenlabdotco/back-ee:$CIRCLE_SHA1 --build-arg BUNDLE_JOBS=4 -f citizenlab/back/Dockerfile citizenlab/.
+          docker build -t citizenlabdotco/back-ee:arm64-$CIRCLE_SHA1 --build-arg BUNDLE_JOBS=4 -f citizenlab/back/Dockerfile citizenlab/.
       - run: |
           docker login -u $DOCKER_USER -p $DOCKER_PASS
-          docker push citizenlabdotco/back-ee:$CIRCLE_SHA1
+          docker push citizenlabdotco/back-ee:arm64-$CIRCLE_SHA1
 
   back-lint:
     resource_class: medium
@@ -336,10 +336,15 @@ jobs:
       - echo_pipeline_parameters
       - setup_remote_docker
       - run: docker login -u $DOCKER_USER -p $DOCKER_PASS
-      - run: docker pull citizenlabdotco/back-ee:<< parameters.image_tag >>
-      - run: docker tag citizenlabdotco/back-ee:<< parameters.image_tag >> citizenlabdotco/back-ee:$CIRCLE_BRANCH
-      - deploy:
-          command: docker push citizenlabdotco/back-ee:$CIRCLE_BRANCH
+      - run: |
+          docker manifest create citizenlabdotco/back-ee:$CIRCLE_BRANCH \
+            citizenlabdotco/back-ee:amd64-<< parameters.image_tag >> \
+            citizenlabdotco/back-ee:arm64-<< parameters.image_tag >>
+          docker manifest annotate citizenlabdotco/back-ee:$CIRCLE_BRANCH \
+            citizenlabdotco/back-ee:amd64-<< parameters.image_tag >> --os linux --arch amd64
+          docker manifest annotate citizenlabdotco/back-ee:$CIRCLE_BRANCH \
+            citizenlabdotco/back-ee:arm64-<< parameters.image_tag >> --os linux --arch arm64
+          docker manifest push citizenlabdotco/back-ee:$CIRCLE_BRANCH
 
   back-deploy-to-swarm:
     resource_class: small
@@ -864,7 +869,7 @@ workflows:
         - not:
             equal: ["production", << pipeline.git.branch >>]
     jobs:
-      - back-build-docker-image:
+      - back-build-docker-image-amd64:
           filters:
             branches:
               ignore:
@@ -873,7 +878,7 @@ workflows:
           context:
             - docker-hub-access
             - citizenlab-ee-environment
-      - back-build-docker-arm-image:
+      - back-build-docker-image-arm64:
           filters:
             branches:
               ignore:
@@ -887,13 +892,13 @@ workflows:
             - docker-hub-access
             - citizenlab-ee-environment
           requires:
-            - back-build-docker-image
+            - back-build-docker-image-amd64
       - back-bundle-audit:
           context:
             - docker-hub-access
             - citizenlab-ee-environment
           requires:
-            - back-build-docker-image
+            - back-build-docker-image-amd64
           filters:
             branches:
               ignore:
@@ -904,7 +909,7 @@ workflows:
             - docker-hub-access
             - citizenlab-ee-environment
           requires:
-            - back-build-docker-image
+            - back-build-docker-image-amd64
           filters:
             branches:
               ignore:
@@ -915,13 +920,13 @@ workflows:
             - docker-hub-access
             - citizenlab-ee-environment
           requires:
-            - back-build-docker-image
+            - back-build-docker-image-amd64
       - back-docs-not-blocking:
           context:
             - docker-hub-access
             - citizenlab-ee-environment
           requires:
-            - back-build-docker-image
+            - back-build-docker-image-amd64
           filters:
             branches:
               only:
@@ -966,7 +971,14 @@ workflows:
   back-deploy-production:
     when: << pipeline.parameters.back >>
     jobs:
-      - back-build-docker-image:
+      - back-build-docker-image-amd64:
+          filters:
+            branches:
+              only: production
+          context:
+            - docker-hub-access
+            - citizenlab-ee-environment
+      - back-build-docker-image-arm64:
           filters:
             branches:
               only: production
@@ -981,7 +993,8 @@ workflows:
                 - production
           image_tag: $CIRCLE_SHA1
           requires:
-            - back-build-docker-image
+            - back-build-docker-image-amd64
+            - back-build-docker-image-arm64
       - back-deploy-developer-documentation:
           context: circleci-api-token
           filters:
@@ -1234,7 +1247,7 @@ workflows:
   manual-templates:
     when: << pipeline.parameters.templates >>
     jobs:
-      - back-build-docker-image:
+      - back-build-docker-image-amd64:
           context:
             - docker-hub-access
             - citizenlab-ee-environment
@@ -1310,7 +1323,7 @@ workflows:
             - slack-dev-notifications-tenant-templates
           <<: *slack-fail-post-step-templates
           requires:
-            - back-build-docker-image
+            - back-build-docker-image-amd64
             - "Europe (Frankfurt)"
             - "Europe (Paris)"
             - "Europe (Stockholm)"
@@ -1345,7 +1358,7 @@ workflows:
               only:
                 - production
     jobs:
-      - back-build-docker-image:
+      - back-build-docker-image-amd64:
           context:
             - docker-hub-access
             - citizenlab-ee-environment
@@ -1421,7 +1434,7 @@ workflows:
             - slack-dev-notifications-tenant-templates
           <<: *slack-fail-post-step-templates
           requires:
-            - back-build-docker-image
+            - back-build-docker-image-amd64
             - "Europe (Frankfurt)"
             - "Europe (Paris)"
             - "Europe (Stockholm)"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,6 +212,22 @@ jobs:
           docker login -u $DOCKER_USER -p $DOCKER_PASS
           docker push citizenlabdotco/back-ee:$CIRCLE_SHA1
 
+  back-build-arm-docker-image:
+    working_directory: ~/
+    docker:
+      - image: cimg/base:2021.03
+    resource_class: arm.medium
+    steps:
+      - echo_pipeline_parameters
+      - shallow-clone
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run: |
+          docker build -t citizenlabdotco/back-ee:$CIRCLE_SHA1 --build-arg BUNDLE_JOBS=4 -f citizenlab/back/Dockerfile citizenlab/.
+      - run: |
+          docker login -u $DOCKER_USER -p $DOCKER_PASS
+          docker push citizenlabdotco/back-ee:$CIRCLE_SHA1
+
   back-lint:
     resource_class: medium
     executor:
@@ -849,6 +865,15 @@ workflows:
             equal: ["production", << pipeline.git.branch >>]
     jobs:
       - back-build-docker-image:
+          filters:
+            branches:
+              ignore:
+                - crowdin_master
+                - /l10n_.*/
+          context:
+            - docker-hub-access
+            - citizenlab-ee-environment
+      - back-build-docker-arm-image:
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,7 +212,7 @@ jobs:
           docker login -u $DOCKER_USER -p $DOCKER_PASS
           docker push citizenlabdotco/back-ee:$CIRCLE_SHA1
 
-  back-build-arm-docker-image:
+  back-build-docker-arm-image:
     working_directory: ~/
     docker:
       - image: cimg/base:2021.03


### PR DESCRIPTION
# Changelog
## Technical
- We now push multi-arch (amd64 and arm64) deployment images to Docker Hub, so we can start testing out faster/cheaper ARM servers on AWS
