### PR TITLE
Don't hide participants count tooltip under project CTA bar

### DIFF
--- a/front/app/containers/ProjectsShowPage/shared/header/ProjectInfoSideBar/index.tsx
+++ b/front/app/containers/ProjectsShowPage/shared/header/ProjectInfoSideBar/index.tsx
@@ -74,7 +74,10 @@ const ProjectInfoSideBar = memo<Props>(
             >
               <Tooltip
                 disabled={!isAdmin(authUser)}
-                placement="bottom"
+                // If the tooltip is very close to the top of the screen,
+                // it will hide under the project CTA bar but it has a low chance of
+                // happening (only in projects with no/short description and we've scrolled up the tooltip the most we can).
+                placement="auto"
                 content={formatMessage(messages.liveDataMessage)}
               >
                 <Box

--- a/front/app/containers/ProjectsShowPage/shared/header/ProjectInfoSideBar/index.tsx
+++ b/front/app/containers/ProjectsShowPage/shared/header/ProjectInfoSideBar/index.tsx
@@ -74,10 +74,9 @@ const ProjectInfoSideBar = memo<Props>(
             >
               <Tooltip
                 disabled={!isAdmin(authUser)}
-                // If the tooltip is very close to the top of the screen,
-                // it will hide under the project CTA bar but it has a low chance of
-                // happening (only in projects with no/short description and we've scrolled up the tooltip the most we can).
-                placement="auto"
+                // Needs to be "left" at the time of writing
+                // to ensure the tooltip doesn't slip under the project CTA bar.
+                placement="left"
                 content={formatMessage(messages.liveDataMessage)}
               >
                 <Box


### PR DESCRIPTION
Before
<img width="1494" alt="Screenshot 2025-01-06 at 16 21 11" src="https://github.com/user-attachments/assets/a46601e2-2d72-47ea-a039-4fca838d7998" />

After
<img width="1490" alt="Screenshot 2025-01-06 at 16 21 00" src="https://github.com/user-attachments/assets/9d8be063-8b3d-4ae8-a81f-819a5895e444" />

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Tooltip on participants count doesn't hide under CTA bar if project description is short. (See before/after [here](https://github.com/CitizenLabDotCo/citizenlab/compare/TAN-3470/tooltip-hides-under-cta-bar?expand=1).)