### PR TITLE
Admin sidebar: Proposals tooltip visibility

### DIFF
--- a/front/app/containers/Admin/sideBar/MenuItem.tsx
+++ b/front/app/containers/Admin/sideBar/MenuItem.tsx
@@ -137,7 +137,7 @@ const MenuItem = ({ navItem }: Props) => {
           <FormattedMessage {...messages.proposalsTooltip} />
         </Box>
       }
-      placement="right"
+      placement="bottom-end"
       disabled={!isItemDisabled}
       theme="dark"
     >


### PR DESCRIPTION
Before

<img width="1265" alt="Screenshot 2025-01-06 at 16 28 53" src="https://github.com/user-attachments/assets/6ddcd07b-a26a-47e7-b027-ac42ac2546a5" />

After
<img width="1267" alt="Screenshot 2025-01-06 at 16 28 42" src="https://github.com/user-attachments/assets/7aca0018-9e29-4eb3-a59f-9571403585ff" />

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Admin sidebar/navigation: tooltip of Proposals item doesn't hide under content of the project settings anymore. (See before/after [here](https://github.com/CitizenLabDotCo/citizenlab/pull/9957).)
