### PR TITLE
TAN-3475 Enable YJIT and jemalloc

### DIFF
--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -37,6 +37,8 @@ RUN apt-get update                                        \
    jpegoptim                                              \
    optipng                                                \
    pngquant                                               \
+   # jemalloc
+   libjemalloc2 \
    # tiktoken_ruby
    clang                                                  \
    && curl -sL https://deb.nodesource.com/setup_18.x  | bash - \

--- a/back/Dockerfile.development
+++ b/back/Dockerfile.development
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -qq -y --no-install-recommends \
       optipng              \
       jpegoptim            \
       pngquant             \
+      libjemalloc2         \
       libgeos-dev          \
       libgmp3-dev          \
       netcat-openbsd       \

--- a/back/config/initializers/enable_yjit.rb
+++ b/back/config/initializers/enable_yjit.rb
@@ -1,0 +1,12 @@
+# Automatically enable YJIT if running Ruby 3.3 or newer,
+# as it brings very sizeable performance improvements.
+# Many users reported 15-25% improved latency.
+
+# If you are deploying to a memory-constrained environment,
+# you may want to delete this file, but otherwise, it's free
+# performance.
+if defined? RubyVM::YJIT.enable
+  Rails.application.config.after_initialize do
+    RubyVM::YJIT.enable
+  end
+end

--- a/env_files/back-safe.env
+++ b/env_files/back-safe.env
@@ -39,5 +39,6 @@ VERIFICATION_ID_CARD_SALT='$2a$10$Cu8AnxXnDwWAH0OkCBrbd.'
 ADMIN_API_TOKEN=e0Gd9oCkCBIplT0Pkl0XBo0WqnROkHKFpnabXMtS7yPbs
 PUBLIC_API_CLIENT_ID=42cb419a-b1f8-4600-8c4e-fd45cca4bfd9
 PUBLIC_API_CLIENT_SECRET=Hx7C27lxV7Qszw-zCg9UT-GFRQuxJNffllTpeU262CGabllbyTYwOmpizCygtPIZSwg
+# jemalloc is an improved malloc implementation that improves memory fragmentation and usage. These ENV vars are needed to active it.
 LD_PRELOAD="libjemalloc.so.2"
 MALLOC_CONF="background_thread:true,metadata_thp:auto,dirty_decay_ms:5000,muzzy_decay_ms:5000,narenas:2"

--- a/env_files/back-safe.env
+++ b/env_files/back-safe.env
@@ -39,3 +39,5 @@ VERIFICATION_ID_CARD_SALT='$2a$10$Cu8AnxXnDwWAH0OkCBrbd.'
 ADMIN_API_TOKEN=e0Gd9oCkCBIplT0Pkl0XBo0WqnROkHKFpnabXMtS7yPbs
 PUBLIC_API_CLIENT_ID=42cb419a-b1f8-4600-8c4e-fd45cca4bfd9
 PUBLIC_API_CLIENT_SECRET=Hx7C27lxV7Qszw-zCg9UT-GFRQuxJNffllTpeU262CGabllbyTYwOmpizCygtPIZSwg
+LD_PRELOAD="libjemalloc.so.2"
+MALLOC_CONF="background_thread:true,metadata_thp:auto,dirty_decay_ms:5000,muzzy_decay_ms:5000,narenas:2"


### PR DESCRIPTION
# Changelog

I've already been testing out yjit on staging using an environment variable, and all seems stable. Hard to say anything about performance due to low traffic, so propose we just roll it out. Doing it in an initializer, as I'm doing here (copy/paste from a default initializer in rails 7.2) is the better approach, because it only activates the JIT after startup, meaning the startup time is not delayed (JIT takes some warmup).

People seem to advice activating jemalloc, as it leads to lower memory usage, the one downside of the JIT. According to [this  example](https://matthaliski.com/blog/upgrading-to-rails-7-1-ruby-3-3-and-jemalloc) at least, the difference could be substantial.

## Technical
- Enable YJIT for Ruby, which could lead to an average 10-25% latency improvement on back-end calls (to be measured)
- Enabled jemalloc in the back-end Dockerfile, which should lead to lower memory usage
