### PR TITLE
[TAN-2148] Update default messages to use new govocal support URL

### DIFF
--- a/front/app/components/admin/AnonymousPostingToggle/messages.ts
+++ b/front/app/components/admin/AnonymousPostingToggle/messages.ts
@@ -30,6 +30,6 @@ export default defineMessages({
   userAnonymitySupportTooltipLinkUrl: {
     id: 'app.components.AnonymousPostingToggle.userAnonymitySupportTooltipLinkUrl',
     defaultMessage:
-      'https://support.citizenlab.co/en/articles/7946486-enabling-anonymous-participation',
+      'https://support.govocal.com/en/articles/7946486-enabling-anonymous-participation',
   },
 });

--- a/front/app/components/admin/ContentBuilder/Widgets/IframeMultiloc/messages.ts
+++ b/front/app/components/admin/ContentBuilder/Widgets/IframeMultiloc/messages.ts
@@ -57,6 +57,6 @@ export default defineMessages({
   iframeSupportLink: {
     id: 'app.containers.admin.ContentBuilder.IframeMultiloc.iframeSupportLink',
     defaultMessage:
-      'https://support.citizenlab.co/en/articles/6354058-embedding-elements-in-the-content-builder-to-enrich-project-descriptions',
+      'https://support.govocal.com/en/articles/6354058-embedding-elements-in-the-content-builder-to-enrich-project-descriptions',
   },
 });

--- a/front/app/components/admin/ImageCropper/messages.ts
+++ b/front/app/components/admin/ImageCropper/messages.ts
@@ -13,6 +13,6 @@ export default defineMessages({
   imageSupportPageURL: {
     id: 'app.components.Admin.ImageCropper.imageSupportPageURL',
     defaultMessage:
-      'https://support.citizenlab.co/en/articles/1346397-what-are-the-recommended-dimensions-and-sizes-of-the-platform-images',
+      'https://support.govocal.com/en/articles/1346397-what-are-the-recommended-dimensions-and-sizes-of-the-platform-images',
   },
 });

--- a/front/app/components/admin/SeatBasedBilling/SeatInfo/messages.ts
+++ b/front/app/components/admin/SeatBasedBilling/SeatInfo/messages.ts
@@ -101,7 +101,7 @@ export default defineMessages({
   rolesSupportPage: {
     id: 'app.components.SeatInfo.rolesSupportPage',
     defaultMessage:
-      'https://support.citizenlab.co/en/articles/2672884-what-are-the-different-roles-on-the-platform',
+      'https://support.govocal.com/en/articles/2672884-what-are-the-different-roles-on-the-platform',
   },
   visitHelpCenter: {
     id: 'app.components.SeatInfo.visitHelpCenter',

--- a/front/app/containers/Admin/CustomMapConfigPage/messages.ts
+++ b/front/app/containers/Admin/CustomMapConfigPage/messages.ts
@@ -67,7 +67,7 @@ export default defineMessages({
   supportArticleUrl: {
     id: 'app.containers.AdminPage.ProjectEdit.MapTab.supportArticleUrl2',
     defaultMessage:
-      'https://support.citizenlab.co/en/articles/7022129-collecting-input-and-feedback-list-and-map-view',
+      'https://support.govocal.com/en/articles/7022129-collecting-input-and-feedback-list-and-map-view',
   },
   layersTooltip: {
     id: 'app.containers.AdminPage.ProjectEdit.MapTab.layersTooltip',

--- a/front/app/containers/Admin/invitations/messages.ts
+++ b/front/app/containers/Admin/invitations/messages.ts
@@ -90,7 +90,7 @@ export default defineMessages({
   moderatorLabelTooltipLink: {
     id: 'app.containers.Admin.Invitations.moderatorLabelTooltipLink',
     defaultMessage:
-      'http://support.citizenlab.co/en-your-citizenlab-platform-step-by-step/set-up/pointing-out-the-right-project-moderators',
+      'http://support.govocal.com/en-your-citizenlab-platform-step-by-step/set-up/pointing-out-the-right-project-moderators',
   },
   moderatorLabelTooltipLinkText: {
     id: 'app.containers.Admin.Invitations.moderatorLabelTooltipLinkText',
@@ -189,7 +189,7 @@ export default defineMessages({
   invitesSupportPageURL: {
     id: 'app.containers.Admin.Invitations.invitesSupportPageURL',
     defaultMessage:
-      'http://support.citizenlab.co/en/articles/1771605-invite-people-to-the-platform',
+      'http://support.govocal.com/en/articles/1771605-invite-people-to-the-platform',
   },
   tabInviteUsers: {
     id: 'app.containers.Admin.Invitations.tabInviteUsers',

--- a/front/app/containers/Admin/messaging/messages.ts
+++ b/front/app/containers/Admin/messaging/messages.ts
@@ -220,7 +220,7 @@ export default defineMessages({
   supportButtonLink: {
     id: 'app.containers.Admin.emails.supportButtonLink',
     defaultMessage:
-      'https://support.citizenlab.co/en/articles/2762939-what-are-automated-emails',
+      'https://support.govocal.com/en/articles/2762939-what-are-automated-emails',
   },
   sentToUsers: {
     id: 'app.containers.Admin.emails.sentToUsers',

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/HomepageBanner/messages.ts
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/HomepageBanner/messages.ts
@@ -108,7 +108,7 @@ export default defineMessages({
   imageSupportPageURL: {
     id: 'app.containers.ContentBuilder.homepage.imageSupportPageURL',
     defaultMessage:
-      'https://support.citizenlab.co/en/articles/1346397-what-are-the-recommended-dimensions-and-sizes-of-the-platform-images',
+      'https://support.govocal.com/en/articles/1346397-what-are-the-recommended-dimensions-and-sizes-of-the-platform-images',
   },
   overlayToggleLabel: {
     id: 'app.containers.ContentBuilder.homepage.overlayToggleLabel',

--- a/front/app/containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/BannerImageFields/messages.ts
+++ b/front/app/containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/BannerImageFields/messages.ts
@@ -4,7 +4,7 @@ export default defineMessages({
   imageSupportPageURL: {
     id: 'pagesAndMenu.GenericHeroBannerForm.BannerImageFields.imageSupportPageURL',
     defaultMessage:
-      'https://support.citizenlab.co/en/articles/1346397-what-are-the-recommended-dimensions-and-sizes-of-the-platform-images',
+      'https://support.govocal.com/en/articles/1346397-what-are-the-recommended-dimensions-and-sizes-of-the-platform-images',
   },
   imageTooltip: {
     id: 'pagesAndMenu.GenericHeroBannerForm.BannerImageFields.imageTooltip',

--- a/front/app/containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/messages.ts
+++ b/front/app/containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/messages.ts
@@ -180,6 +180,6 @@ export default defineMessages({
   imageSupportPageURL: {
     id: 'app.containers.AdminPage.SettingsPage.imageSupportPageURL',
     defaultMessage:
-      'https://support.citizenlab.co/en/articles/1346397-what-are-the-recommended-dimensions-and-sizes-of-the-platform-images',
+      'https://support.govocal.com/en/articles/1346397-what-are-the-recommended-dimensions-and-sizes-of-the-platform-images',
   },
 });

--- a/front/app/containers/Admin/projectFolders/containers/permissions/messages.ts
+++ b/front/app/containers/Admin/projectFolders/containers/permissions/messages.ts
@@ -9,7 +9,7 @@ export default defineMessages({
   moreInfoFolderManagerLink: {
     id: 'app.containers.AdminPage.FolderPermissions.moreInfoFolderManagerLink',
     defaultMessage:
-      'https://support.citizenlab.co/en/articles/4648650-assign-the-right-project-managers',
+      'https://support.govocal.com/en/articles/4648650-assign-the-right-project-managers',
   },
   projectManagementInfoCenterLinkText: {
     id: 'app.containers.AdminPage.FolderPermissions.projectManagementInfoCenterLinkText',

--- a/front/app/containers/Admin/projectFolders/containers/settings/ProjectFolderForm/messages.ts
+++ b/front/app/containers/Admin/projectFolders/containers/settings/ProjectFolderForm/messages.ts
@@ -4,7 +4,7 @@ export default defineMessages({
   imageSupportPageURL: {
     id: 'app.containers.Admin.projectFolders.containers.settings.ProjectFolderForm.imageSupportPageURL',
     defaultMessage:
-      'https://support.citizenlab.co/en/articles/1346397-what-are-the-recommended-dimensions-and-sizes-of-the-platform-images',
+      'https://support.govocal.com/en/articles/1346397-what-are-the-recommended-dimensions-and-sizes-of-the-platform-images',
   },
   supportPageLinkText: {
     id: 'app.containers.Admin.projectFolders.containers.settings.ProjectFolderForm.supportPageLinkText',

--- a/front/app/containers/Admin/projects/project/analysis/TopBar/messages.ts
+++ b/front/app/containers/Admin/projects/project/analysis/TopBar/messages.ts
@@ -72,7 +72,7 @@ export default defineMessages({
   supportArticleLink: {
     id: 'app.containers.AdminPage.projects.project.analysis.supportArticleLink',
     defaultMessage:
-      'https://support.citizenlab.co/en/articles/8316692-ai-analysis',
+      'https://support.govocal.com/en/articles/8316692-ai-analysis',
   },
   emptyCustomFields: {
     id: 'app.containers.AdminPage.projects.project.analysis.emptyCustomFieldsLabel',

--- a/front/app/containers/Admin/projects/project/events/messages.ts
+++ b/front/app/containers/Admin/projects/project/events/messages.ts
@@ -112,7 +112,7 @@ export default defineMessages({
   attendanceSupportArticleLink: {
     id: 'app.containers.AdminPage.ProjectEvents.attendanceSupportArticleLink',
     defaultMessage:
-      'https://support.citizenlab.co/en/articles/5481527-adding-events-to-your-platform',
+      'https://support.govocal.com/en/articles/5481527-adding-events-to-your-platform',
   },
   refineOnMapInstructions: {
     id: 'app.containers.AdminPage.ProjectEvents.refineOnMapInstructions',

--- a/front/app/containers/Admin/projects/project/general/messages.ts
+++ b/front/app/containers/Admin/projects/project/general/messages.ts
@@ -144,7 +144,7 @@ export default defineMessages({
   imageSupportPageURL: {
     id: 'app.containers.AdminPage.ProjectEdit.imageSupportPageURL',
     defaultMessage:
-      'https://support.citizenlab.co/en/articles/1346397-what-are-the-recommended-dimensions-and-sizes-of-the-platform-images',
+      'https://support.govocal.com/en/articles/1346397-what-are-the-recommended-dimensions-and-sizes-of-the-platform-images',
   },
   supportPageLinkText: {
     id: 'app.containers.AdminPage.ProjectEdit.supportPageLinkText',

--- a/front/app/containers/Admin/projects/project/messages.ts
+++ b/front/app/containers/Admin/projects/project/messages.ts
@@ -329,7 +329,7 @@ export default defineMessages({
   surveyServiceTooltipLink: {
     id: 'app.containers.AdminPage.ProjectEdit.surveyServiceTooltipLink1',
     defaultMessage:
-      'https://support.citizenlab.co/en/articles/7025887-creating-an-external-survey-project',
+      'https://support.govocal.com/en/articles/7025887-creating-an-external-survey-project',
   },
   surveyServiceTooltip: {
     id: 'app.containers.AdminPage.ProjectEdit.surveyServiceTooltip',
@@ -452,7 +452,7 @@ export default defineMessages({
   },
   hiddenFieldsSupportArticleUrl: {
     id: 'app.components.admin.PostManager.hiddenFieldsSupportArticleUrl',
-    defaultMessage: 'https://support.citizenlab.co/en/articles/1641202',
+    defaultMessage: 'https://support.govocal.com/en/articles/1641202',
   },
   // #input_term_copy
   ideaTerm: {
@@ -534,7 +534,7 @@ export default defineMessages({
   googleFormsTooltipLink: {
     id: 'app.components.app.containers.AdminPage.ProjectEdit.googleFormsTooltipLink',
     defaultMessage:
-      'https://support.citizenlab.co/en/articles/5050525-how-to-embed-your-google-forms-survey-in-a-project-phase',
+      'https://support.govocal.com/en/articles/5050525-how-to-embed-your-google-forms-survey-in-a-project-phase',
   },
   googleFormsTooltipLinkText: {
     id: 'app.components.app.containers.AdminPage.ProjectEdit.googleFormsTooltipLinkText',

--- a/front/app/containers/Admin/projects/project/nativeSurvey/FormResults/FormResultsQuestion/TextQuestion/AnalysisUpsell/messages.ts
+++ b/front/app/containers/Admin/projects/project/nativeSurvey/FormResults/FormResultsQuestion/TextQuestion/AnalysisUpsell/messages.ts
@@ -29,7 +29,7 @@ export default defineMessages({
   supportArticleLink: {
     id: 'app.containers.Admin.projects.project.survey.upsell.supportArticleLink',
     defaultMessage:
-      'https://support.citizenlab.co/en/articles/8316692-ai-analysis',
+      'https://support.govocal.com/en/articles/8316692-ai-analysis',
   },
   button: {
     id: 'app.containers.Admin.projects.project.survey.upsell.button',

--- a/front/app/containers/Admin/projects/project/nativeSurvey/messages.ts
+++ b/front/app/containers/Admin/projects/project/nativeSurvey/messages.ts
@@ -120,7 +120,7 @@ export default defineMessages({
   supportArticleLink: {
     id: 'app.containers.AdminPage.ProjectEdit.survey.supportArticleLink2',
     defaultMessage:
-      'https://support.citizenlab.co/en/articles/6673873-creating-an-in-platform-survey',
+      'https://support.govocal.com/en/articles/6673873-creating-an-in-platform-survey',
   },
   surveyEnd: {
     id: 'app.containers.AdminPage.ProjectEdit.formBuilder.surveyEnd2',

--- a/front/app/containers/Admin/projects/project/permissions/Project/ProjectManagement/messages.ts
+++ b/front/app/containers/Admin/projects/project/permissions/Project/ProjectManagement/messages.ts
@@ -17,7 +17,7 @@ export default defineMessages({
   moreInfoModeratorLink: {
     id: 'app.containers.AdminPage.ProjectEdit.moreInfoModeratorLink',
     defaultMessage:
-      'http://support.citizenlab.co/en-your-citizenlab-platform-step-by-step/set-up/pointing-out-the-right-project-moderators',
+      'http://support.govocal.com/en-your-citizenlab-platform-step-by-step/set-up/pointing-out-the-right-project-moderators',
   },
   moderatorSearchFieldLabel: {
     id: 'app.containers.AdminPage.ProjectEdit.moderatorSearchFieldLabel1',

--- a/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/VotingInputs/index.tsx
+++ b/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/VotingInputs/index.tsx
@@ -122,7 +122,7 @@ export default ({
                 voteTypeDescription: getVoteTypeDescription(),
                 optionAnalysisArticleLink: (
                   <a
-                    href="https://support.citizenlab.co/en/articles/8124630-voting-and-prioritization-methods-for-enhanced-decision-making"
+                    href="https://support.govocal.com/en/articles/8124630-voting-and-prioritization-methods-for-enhanced-decision-making"
                     target="_blank"
                     rel="noreferrer"
                   >

--- a/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/messages.ts
+++ b/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/messages.ts
@@ -13,7 +13,7 @@ export default defineMessages({
   konveioSupportPageURL: {
     id: 'app.components.app.containers.AdminPage.ProjectEdit.konveioSupportPageURL',
     defaultMessage:
-      'https://support.citizenlab.co/en/articles/7946532-embedding-konveio-pdf-documents-for-collecting-feedback',
+      'https://support.govocal.com/en/articles/7946532-embedding-konveio-pdf-documents-for-collecting-feedback',
   },
   konveioSupportArticle: {
     id: 'app.components.app.containers.AdminPage.ProjectEdit.konveioSupportArticle',

--- a/front/app/containers/Admin/tools/PowerBI/PowerBITemplates/messages.ts
+++ b/front/app/containers/Admin/tools/PowerBI/PowerBITemplates/messages.ts
@@ -56,7 +56,7 @@ export default defineMessages({
   supportLinkUrl: {
     id: 'app.containers.Admin.tools.powerBITemplates.supportLinkUrl',
     defaultMessage:
-      'https://support.citizenlab.co/en/articles/8512834-use-citizenlab-data-in-powerbi',
+      'https://support.govocal.com/en/articles/8512834-use-citizenlab-data-in-powerbi',
   },
   supportLinkText: {
     id: 'app.containers.Admin.tools.powerBITemplates.supportLinkText',

--- a/front/app/containers/Admin/tools/messages.ts
+++ b/front/app/containers/Admin/tools/messages.ts
@@ -29,7 +29,7 @@ export default defineMessages({
   workshopsSupportLink: {
     id: 'app.containers.Admin.tools.workshopsSupportLink',
     defaultMessage:
-      'https://support.citizenlab.co/en/articles/4155778-setting-up-an-online-workshop',
+      'https://support.govocal.com/en/articles/4155778-setting-up-an-online-workshop',
   },
   widgetTitle: {
     id: 'app.containers.Admin.tools.widgetTitle',

--- a/front/app/containers/Admin/users/messages.ts
+++ b/front/app/containers/Admin/users/messages.ts
@@ -182,7 +182,7 @@ export default defineMessages({
   readMoreLink: {
     id: 'app.containers.AdminPage.Users.GroupCreation.readMoreLink',
     defaultMessage:
-      'http://support.citizenlab.co/nl-opstartgids/stap-2-configureer-de-belangrijkste-settings/maak-eventueel-verschillende-gebruikersgroepen-aan',
+      'http://support.govocal.com/nl-opstartgids/stap-2-configureer-de-belangrijkste-settings/maak-eventueel-verschillende-gebruikersgroepen-aan',
   },
   modalHeaderStep1: {
     id: 'app.containers.AdminPage.Users.GroupCreation.modalHeaderStep1',


### PR DESCRIPTION
Translations for these are already updated on Crowdin and all related translation files on master.

# Changelog
## Technical
- [TAN-2148] Update default messages to use new govocal support URL
