### PR TITLE
Tan 3488/missing input status code (type)

### DIFF
--- a/front/app/api/idea_statuses/types.ts
+++ b/front/app/api/idea_statuses/types.ts
@@ -36,7 +36,7 @@ type ProposalsStatusCode =
   | 'custom';
 export type InputStatusCode = IdeationStatusCode | ProposalsStatusCode;
 
-export const ideationInputStatusCodes: IdeationStatusCode[] = [
+const ideationInputStatusCodes: IdeationStatusCode[] = [
   'prescreening',
   'proposed',
   'viewed',
@@ -47,7 +47,7 @@ export const ideationInputStatusCodes: IdeationStatusCode[] = [
   'custom',
 ];
 
-export const proposalsInputStatusCodes: ProposalsStatusCode[] = [
+const proposalsInputStatusCodes: ProposalsStatusCode[] = [
   'prescreening',
   'proposed',
   'threshold_reached',
@@ -59,7 +59,7 @@ export const proposalsInputStatusCodes: ProposalsStatusCode[] = [
 
 export const inputStatusCodes: Record<
   IdeaStatusParticipationMethod,
-  InputStatusCode[]
+  IdeationStatusCode[] | ProposalsStatusCode[]
 > = {
   ideation: ideationInputStatusCodes,
   proposals: proposalsInputStatusCodes,

--- a/front/app/api/idea_statuses/types.ts
+++ b/front/app/api/idea_statuses/types.ts
@@ -18,7 +18,7 @@ export type IdeaStatusesQueryParams = {
 };
 
 export type InputStatusCode =
-type InputStatusCode =
+  | 'prescreening'
   | 'proposed'
   | 'viewed'
   | 'under_consideration'
@@ -36,6 +36,7 @@ export const inputStatusCodes: Record<
   InputStatusCode[]
 > = {
   ideation: [
+    'prescreening',
     'proposed',
     'viewed',
     'under_consideration',
@@ -45,6 +46,7 @@ export const inputStatusCodes: Record<
     'custom',
   ],
   proposals: [
+    'prescreening',
     'proposed',
     'threshold_reached',
     'expired',

--- a/front/app/api/idea_statuses/types.ts
+++ b/front/app/api/idea_statuses/types.ts
@@ -17,7 +17,7 @@ export type IdeaStatusesQueryParams = {
   participation_method?: IdeaStatusParticipationMethod;
 };
 
-export type InputStatusCode =
+type IdeationStatusCode =
   | 'prescreening'
   | 'proposed'
   | 'viewed'
@@ -25,36 +25,37 @@ export type InputStatusCode =
   | 'accepted'
   | 'rejected'
   | 'implemented'
-  | 'custom'
+  | 'custom';
+type ProposalsStatusCode =
+  | 'prescreening'
+  | 'proposed'
   | 'threshold_reached'
   | 'expired'
   | 'answered'
-  | 'ineligible';
+  | 'ineligible'
+  | 'custom';
+export type InputStatusCode = IdeationStatusCode | ProposalsStatusCode;
 
-export const inputStatusCodes: Record<
-  IdeaStatusParticipationMethod,
-  InputStatusCode[]
-> = {
-  ideation: [
-    'prescreening',
-    'proposed',
-    'viewed',
-    'under_consideration',
-    'accepted',
-    'rejected',
-    'implemented',
-    'custom',
-  ],
-  proposals: [
-    'prescreening',
-    'proposed',
-    'threshold_reached',
-    'expired',
-    'answered',
-    'ineligible',
-    'custom',
-  ],
-} as const;
+export const ideationInputStatusCodes: IdeationStatusCode[] = [
+  'prescreening',
+  'proposed',
+  'viewed',
+  'under_consideration',
+  'accepted',
+  'rejected',
+  'implemented',
+  'custom',
+];
+
+export const proposalsInputStatusCodes: ProposalsStatusCode[] = [
+  'prescreening',
+  'proposed',
+  'threshold_reached',
+  'expired',
+  'answered',
+  'ineligible',
+  'custom',
+];
 
 export const automatedInputStatusCodes: Set<InputStatusCode> = new Set([
   'proposed',

--- a/front/app/api/idea_statuses/types.ts
+++ b/front/app/api/idea_statuses/types.ts
@@ -57,6 +57,11 @@ export const proposalsInputStatusCodes: ProposalsStatusCode[] = [
   'custom',
 ];
 
+export const inputStatusCodes = {
+  ideation: ideationInputStatusCodes,
+  proposals: proposalsInputStatusCodes,
+};
+
 export const automatedInputStatusCodes: Set<InputStatusCode> = new Set([
   'proposed',
   'threshold_reached',

--- a/front/app/api/idea_statuses/types.ts
+++ b/front/app/api/idea_statuses/types.ts
@@ -1,4 +1,3 @@
-import { uniq } from 'lodash-es';
 import { Multiloc } from 'typings';
 
 import { ParticipationMethod } from 'api/phases/types';
@@ -18,7 +17,8 @@ export type IdeaStatusesQueryParams = {
   participation_method?: IdeaStatusParticipationMethod;
 };
 
-type InputStatusCode =
+export type InputStatusCode =
+  | 'prescreening'
   | 'proposed'
   | 'viewed'
   | 'under_consideration'
@@ -36,6 +36,7 @@ export const inputStatusCodes: Record<
   InputStatusCode[]
 > = {
   ideation: [
+    'prescreening',
     'proposed',
     'viewed',
     'under_consideration',
@@ -45,6 +46,7 @@ export const inputStatusCodes: Record<
     'custom',
   ],
   proposals: [
+    'prescreening',
     'proposed',
     'threshold_reached',
     'expired',
@@ -52,7 +54,7 @@ export const inputStatusCodes: Record<
     'ineligible',
     'custom',
   ],
-};
+} as const;
 
 export const automatedInputStatusCodes: Set<InputStatusCode> = new Set([
   'proposed',
@@ -60,22 +62,13 @@ export const automatedInputStatusCodes: Set<InputStatusCode> = new Set([
   'expired',
 ]);
 
-const allMergedInputStatusCodes = uniq(
-  Object.keys(inputStatusCodes)
-    .map(function (v) {
-      return inputStatusCodes[v];
-    })
-    .flat()
-);
-export type TIdeaStatusCode = (typeof allMergedInputStatusCodes)[number];
-
 export interface IIdeaStatusData {
   id: string;
   type: string;
   attributes: {
     title_multiloc: Multiloc;
     color: string;
-    code: TIdeaStatusCode;
+    code: InputStatusCode;
     ordering: number;
     description_multiloc: Multiloc;
     ideas_count?: number;
@@ -89,7 +82,7 @@ export interface IIdeaStatusAdd {
   title_multiloc: Multiloc;
   description_multiloc?: Multiloc;
   color?: string;
-  code?: TIdeaStatusCode;
+  code?: InputStatusCode;
   ordering?: number;
   participation_method: IdeaStatusParticipationMethod;
 }
@@ -98,7 +91,7 @@ export interface IIdeaStatusUpdate {
   title_multiloc?: Multiloc;
   description_multiloc?: Multiloc;
   color?: string;
-  code?: TIdeaStatusCode;
+  code?: InputStatusCode;
   ordering?: number;
   participation_method: IdeaStatusParticipationMethod;
 }

--- a/front/app/api/idea_statuses/types.ts
+++ b/front/app/api/idea_statuses/types.ts
@@ -57,7 +57,10 @@ export const proposalsInputStatusCodes: ProposalsStatusCode[] = [
   'custom',
 ];
 
-export const inputStatusCodes = {
+export const inputStatusCodes: Record<
+  IdeaStatusParticipationMethod,
+  InputStatusCode[]
+> = {
   ideation: ideationInputStatusCodes,
   proposals: proposalsInputStatusCodes,
 };

--- a/front/app/api/idea_statuses/types.ts
+++ b/front/app/api/idea_statuses/types.ts
@@ -1,4 +1,3 @@
-import { uniq } from 'lodash-es';
 import { Multiloc } from 'typings';
 
 import { ParticipationMethod } from 'api/phases/types';
@@ -18,6 +17,7 @@ export type IdeaStatusesQueryParams = {
   participation_method?: IdeaStatusParticipationMethod;
 };
 
+export type InputStatusCode =
 type InputStatusCode =
   | 'proposed'
   | 'viewed'
@@ -52,7 +52,7 @@ export const inputStatusCodes: Record<
     'ineligible',
     'custom',
   ],
-};
+} as const;
 
 export const automatedInputStatusCodes: Set<InputStatusCode> = new Set([
   'proposed',
@@ -60,22 +60,13 @@ export const automatedInputStatusCodes: Set<InputStatusCode> = new Set([
   'expired',
 ]);
 
-const allMergedInputStatusCodes = uniq(
-  Object.keys(inputStatusCodes)
-    .map(function (v) {
-      return inputStatusCodes[v];
-    })
-    .flat()
-);
-export type TIdeaStatusCode = (typeof allMergedInputStatusCodes)[number];
-
 export interface IIdeaStatusData {
   id: string;
   type: string;
   attributes: {
     title_multiloc: Multiloc;
     color: string;
-    code: TIdeaStatusCode;
+    code: InputStatusCode;
     ordering: number;
     description_multiloc: Multiloc;
     ideas_count?: number;
@@ -89,7 +80,7 @@ export interface IIdeaStatusAdd {
   title_multiloc: Multiloc;
   description_multiloc?: Multiloc;
   color?: string;
-  code?: TIdeaStatusCode;
+  code?: InputStatusCode;
   ordering?: number;
   participation_method: IdeaStatusParticipationMethod;
 }
@@ -98,7 +89,7 @@ export interface IIdeaStatusUpdate {
   title_multiloc?: Multiloc;
   description_multiloc?: Multiloc;
   color?: string;
-  code?: TIdeaStatusCode;
+  code?: InputStatusCode;
   ordering?: number;
   participation_method: IdeaStatusParticipationMethod;
 }

--- a/front/app/containers/Admin/settings/statuses/components/IdeaStatusForm.tsx
+++ b/front/app/containers/Admin/settings/statuses/components/IdeaStatusForm.tsx
@@ -17,9 +17,8 @@ import { string, object } from 'yup';
 import {
   automatedInputStatusCodes,
   IdeaStatusParticipationMethod,
-  ideationInputStatusCodes,
+  inputStatusCodes,
   InputStatusCode,
-  proposalsInputStatusCodes,
 } from 'api/idea_statuses/types';
 
 import { Section, SectionField } from 'components/admin/Section';
@@ -113,10 +112,7 @@ const IdeaStatusForm = ({
     }
   };
 
-  const codes = {
-    proposals: proposalsInputStatusCodes,
-    ideation: ideationInputStatusCodes,
-  }[variant];
+  const codes = inputStatusCodes[variant];
   const allowedCodes = codes.filter(
     (code) => !automatedInputStatusCodes.has(code)
   );

--- a/front/app/containers/Admin/settings/statuses/components/IdeaStatusForm.tsx
+++ b/front/app/containers/Admin/settings/statuses/components/IdeaStatusForm.tsx
@@ -17,8 +17,8 @@ import { string, object } from 'yup';
 import {
   automatedInputStatusCodes,
   IdeaStatusParticipationMethod,
+  InputStatusCode,
   inputStatusCodes,
-  TIdeaStatusCode,
 } from 'api/idea_statuses/types';
 
 import { Section, SectionField } from 'components/admin/Section';
@@ -37,7 +37,7 @@ import messages from './messages';
 
 export interface FormValues {
   color: string;
-  code: TIdeaStatusCode;
+  code: InputStatusCode;
   title_multiloc: Multiloc;
   description_multiloc: Multiloc;
 }

--- a/front/app/containers/Admin/settings/statuses/components/IdeaStatusForm.tsx
+++ b/front/app/containers/Admin/settings/statuses/components/IdeaStatusForm.tsx
@@ -17,8 +17,9 @@ import { string, object } from 'yup';
 import {
   automatedInputStatusCodes,
   IdeaStatusParticipationMethod,
+  ideationInputStatusCodes,
   InputStatusCode,
-  inputStatusCodes,
+  proposalsInputStatusCodes,
 } from 'api/idea_statuses/types';
 
 import { Section, SectionField } from 'components/admin/Section';
@@ -112,7 +113,10 @@ const IdeaStatusForm = ({
     }
   };
 
-  const codes = inputStatusCodes[variant];
+  const codes = {
+    proposals: proposalsInputStatusCodes,
+    ideation: ideationInputStatusCodes,
+  }[variant];
   const allowedCodes = codes.filter(
     (code) => !automatedInputStatusCodes.has(code)
   );


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Technical
- Add missing `InputStatusCode`: `prescreening`.