### PR TITLE
Tan 3515/no screening status general input manager

### DIFF
--- a/front/app/components/admin/PostManager/components/FilterSidebar/statuses/ScreeningStatusFilter.tsx
+++ b/front/app/components/admin/PostManager/components/FilterSidebar/statuses/ScreeningStatusFilter.tsx
@@ -11,6 +11,7 @@ import usePhase from 'api/phases/usePhase';
 
 import useFeatureFlag from 'hooks/useFeatureFlag';
 
+import { ManagerType } from 'components/admin/PostManager';
 import T from 'components/T';
 
 import { FormattedMessage } from 'utils/cl-intl';
@@ -29,23 +30,20 @@ interface Props {
   status: IIdeaStatusData;
   active: boolean;
   onClick: () => void;
+  type: ManagerType;
 }
 
-const ScreeningStatusFilter = ({ status, active, onClick }: Props) => {
+const ScreeningStatusFilter = ({ status, active, onClick, type }: Props) => {
   const { phaseId } = useParams() as { phaseId: string };
   const { data: phase } = usePhase(phaseId);
-
   const preScreeningFeatureFlag =
     phase?.data.attributes.participation_method === 'ideation'
       ? 'prescreening_ideation'
       : 'prescreening';
-
   const preScreeningFeatureAllowed = useFeatureFlag({
     name: preScreeningFeatureFlag,
     onlyCheckAllowed: true,
   });
-  const phasePrescreeningEnabled =
-    phase?.data.attributes.prescreening_enabled === true;
 
   const [{ canDrop, isOver }, drop] = useDrop({
     accept: 'IDEA',
@@ -59,12 +57,18 @@ const ScreeningStatusFilter = ({ status, active, onClick }: Props) => {
     }),
   });
 
+  // Prescreening is a special status that can be configured in a project,
+  // so we don't want to show it in a context without projects to not get status conflicts
+  // (e.g. the general input manager has ideas from all projects,
+  // including those without the prescreening status filter)
+  if (type === 'AllIdeas') return null;
+
+  const phasePrescreeningEnabled =
+    phase?.data.attributes.prescreening_enabled === true;
   const showAutomaticStatusTooltip =
     status.attributes.can_manually_transition_to === false;
-
   const prescreeningButtonIsDisabled =
     !phasePrescreeningEnabled || !preScreeningFeatureAllowed;
-
   const prescreeningTooltipIsDisabled =
     phasePrescreeningEnabled && preScreeningFeatureAllowed;
 

--- a/front/app/components/admin/PostManager/components/FilterSidebar/statuses/StatusFilters.tsx
+++ b/front/app/components/admin/PostManager/components/FilterSidebar/statuses/StatusFilters.tsx
@@ -79,6 +79,7 @@ const StatusFilters = ({
             status={status}
             active={isActive(status.id)}
             onClick={() => handleItemClick(status.id)}
+            type={type}
           />
         ) : (
           <StatusFilter

--- a/front/app/components/admin/PostManager/components/PostTable/Row/IdeaRow.tsx
+++ b/front/app/components/admin/PostManager/components/PostTable/Row/IdeaRow.tsx
@@ -465,6 +465,7 @@ const IdeaRow = ({
         onUpdatePhases={onUpdateIdeaPhases}
         onUpdateTopics={onUpdateIdeaTopics}
         onUpdateStatus={onUpdateIdeaStatus}
+        type={type}
       />
       <PhaseDeselectModal
         open={phaseDeselectModalOpen}

--- a/front/app/components/admin/PostManager/components/PostTable/Row/SubRow.tsx
+++ b/front/app/components/admin/PostManager/components/PostTable/Row/SubRow.tsx
@@ -5,7 +5,7 @@ import { Tr, Td, colors } from '@citizenlab/cl2-component-library';
 import { IIdeaStatusData } from 'api/idea_statuses/types';
 import { IPhaseData } from 'api/phases/types';
 
-import { TFilterMenu } from '../../..';
+import { ManagerType, TFilterMenu } from '../../..';
 
 import IdeasStatusSelector from './selectors/IdeasStatusSelector';
 import PhasesSelector from './selectors/PhasesSelector';
@@ -26,6 +26,7 @@ interface Props {
   onUpdatePhases?: (id: string[]) => void;
   onUpdateTopics: (id: string[]) => void;
   onUpdateStatus: (id: string) => void;
+  type: ManagerType;
 }
 
 const SubRow = ({
@@ -41,6 +42,7 @@ const SubRow = ({
   onUpdatePhases,
   onUpdateTopics,
   onUpdateStatus,
+  type,
 }: Props) => {
   return (
     <Tr className={className} background={active ? colors.grey300 : undefined}>
@@ -67,6 +69,7 @@ const SubRow = ({
             statuses={statuses as IIdeaStatusData[]}
             selectedStatus={selectedStatus}
             onUpdateStatus={onUpdateStatus}
+            type={type}
           />
         )}
       </Td>

--- a/front/app/components/admin/PostManager/components/PostTable/Row/selectors/IdeasStatusSelector.tsx
+++ b/front/app/components/admin/PostManager/components/PostTable/Row/selectors/IdeasStatusSelector.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 
 import { IIdeaStatusData } from 'api/idea_statuses/types';
 
+import { ManagerType } from 'components/admin/PostManager';
 import T from 'components/T';
 
 import { FormattedMessage } from 'utils/cl-intl';
@@ -32,6 +33,7 @@ type Props = {
   selectedStatus?: string;
   statuses: IIdeaStatusData[];
   onUpdateStatus: (statusId: string) => void;
+  type: ManagerType;
 };
 
 class IdeasStatusSelector extends React.PureComponent<Props> {
@@ -45,31 +47,46 @@ class IdeasStatusSelector extends React.PureComponent<Props> {
   };
 
   render() {
-    const { statuses } = this.props;
+    const { statuses, type } = this.props;
     return (
       <Container>
-        {statuses.map((status) => (
-          <Tooltip
-            key={status.id}
-            content={
-              <div>
-                <Text fontWeight="bold" m="0px">
-                  <T value={status.attributes.title_multiloc} />
-                </Text>
-                {!status.attributes.can_manually_transition_to && (
-                  <FormattedMessage {...messages.automatedStatusTooltipText} />
-                )}
-              </div>
-            }
-          >
-            <ColorIndicator
-              color={status.attributes.color}
-              active={this.isActive(status.id)}
-              onClick={this.handleStatusClick(status.id)}
-              disabled={!status.attributes.can_manually_transition_to}
-            />
-          </Tooltip>
-        ))}
+        {statuses.map((status) => {
+          // Prescreening is a special status that can be configured in a project,
+          // so we don't want to show it in a context without projects to not get status conflicts
+          // (e.g. the general input manager has ideas from all projects,
+          // including those without the prescreening status filter)
+          if (
+            type === 'AllIdeas' &&
+            status.attributes.code === 'prescreening'
+          ) {
+            return null;
+          }
+
+          return (
+            <Tooltip
+              key={status.id}
+              content={
+                <div>
+                  <Text fontWeight="bold" m="0px">
+                    <T value={status.attributes.title_multiloc} />
+                  </Text>
+                  {!status.attributes.can_manually_transition_to && (
+                    <FormattedMessage
+                      {...messages.automatedStatusTooltipText}
+                    />
+                  )}
+                </div>
+              }
+            >
+              <ColorIndicator
+                color={status.attributes.color}
+                active={this.isActive(status.id)}
+                onClick={this.handleStatusClick(status.id)}
+                disabled={!status.attributes.can_manually_transition_to}
+              />
+            </Tooltip>
+          );
+        })}
       </Container>
     );
   }


### PR DESCRIPTION
Before

<img width="1477" alt="Screenshot 2025-01-09 at 11 13 45" src="https://github.com/user-attachments/assets/25e5712e-48ce-4d33-8443-765a81ff46c2" />
<img width="671" alt="Screenshot 2025-01-09 at 11 14 17" src="https://github.com/user-attachments/assets/51123a68-287f-4823-923a-b198df2aa4af" />

After

<img width="1484" alt="Screenshot 2025-01-09 at 11 13 07" src="https://github.com/user-attachments/assets/c7869a45-1c02-4064-bea3-3bdcce2a2bad" />

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Do not show Screening filter (and its phase-specific tooltip) in the general input manager anymore. Prescreening is a special status that can be configured in a project, so we don't want to show it in a context without projects.