### PR TITLE
[TAN-3322] Fix date range used in create_phase_ended_activities

### DIFF
--- a/back/app/services/activities_service.rb
+++ b/back/app/services/activities_service.rb
@@ -95,7 +95,7 @@ class ActivitiesService
   end
 
   def create_phase_ended_activities(now)
-    Phase.published.where(end_at: ..now).each do |phase|
+    Phase.published.where(end_at: ..now - 1.day).each do |phase|
       if Activity.find_by(item: phase, action: 'ended').nil?
         LogActivityJob.perform_later(phase, 'ended', nil, now)
       end

--- a/back/spec/services/activities_service_spec.rb
+++ b/back/spec/services/activities_service_spec.rb
@@ -240,7 +240,7 @@ describe ActivitiesService do
       end
 
       it 'does not log a phase ended activity when the phase has not ended' do
-        phase = create(:budgeting_phase, start_at: now - 10.days, end_at: now + 1.day)
+        phase = create(:budgeting_phase, start_at: now - 10.days, end_at: now)
         expect { service.create_periodic_activities(now: now) }
           .not_to have_enqueued_job(LogActivityJob)
           .with(phase, 'ended', nil, now, project_id: phase.project_id)

--- a/back/spec/services/activities_service_spec.rb
+++ b/back/spec/services/activities_service_spec.rb
@@ -233,7 +233,7 @@ describe ActivitiesService do
       end
 
       it 'does not log a phase ended activity when one has already been logged' do
-        phase = create(:budgeting_phase, start_at: now - 10.days, end_at: now - 1.hour)
+        phase = create(:budgeting_phase, start_at: now - 10.days, end_at: date_now - 1.day)
         create(:activity, item: phase, action: 'ended')
         expect { service.create_periodic_activities(now: now) }
           .not_to have_enqueued_job(LogActivityJob)
@@ -241,7 +241,7 @@ describe ActivitiesService do
       end
 
       it 'does not log a phase ended activity when the phase has not ended' do
-        phase = create(:budgeting_phase, start_at: now - 10.days, end_at: now)
+        phase = create(:budgeting_phase, start_at: now - 10.days, end_at: date_now)
         expect { service.create_periodic_activities(now: now) }
           .not_to have_enqueued_job(LogActivityJob)
           .with(phase, 'ended', nil, now, project_id: phase.project_id)

--- a/back/spec/services/activities_service_spec.rb
+++ b/back/spec/services/activities_service_spec.rb
@@ -223,9 +223,10 @@ describe ActivitiesService do
 
     describe '#create_phase_ended_activities' do
       let(:now) { Time.parse '2022-07-01 10:00:00 +0000' }
+      let(:date_now) { Date.parse '2022-07-01' }
 
       it 'logs phase ended activity when a phase has ended' do
-        phase = create(:budgeting_phase, start_at: now - 10.days, end_at: now - 1.hour)
+        phase = create(:budgeting_phase, start_at: now - 10.days, end_at: date_now - 1.day)
         expect { service.create_periodic_activities(now: now) }
           .to have_enqueued_job(LogActivityJob)
           .with(phase, 'ended', nil, now, project_id: phase.project_id)


### PR DESCRIPTION
# Changelog
## Fixed
- [TAN-3322] Phase-end related notifications and emails (e.g. voting results) now should not be sent a day early.
