### PR TITLE
[TAN-3474] Fix project copy when default_assignee is a project moderator

### DIFF
--- a/back/app/controllers/web_api/v1/projects_controller.rb
+++ b/back/app/controllers/web_api/v1/projects_controller.rb
@@ -180,7 +180,7 @@ class WebApi::V1::ProjectsController < ApplicationController
     source_project = Project.find(params[:id])
     dest_folder = source_project.folder if user_role_service.can_moderate?(source_project.folder, current_user)
 
-    assignee = User.find_by(id: source_project&.default_assignee_id)
+    assignee = source_project&.default_assignee
     reassign_moderator = assignee && user_role_service.can_moderate?(source_project, assignee) && !assignee.admin?
 
     # The authorization of this action is more complex than usual. It works in two steps:
@@ -221,7 +221,7 @@ class WebApi::V1::ProjectsController < ApplicationController
       authorize(copy, :create?)
     end
 
-    sidefx.after_copy(source_project, project, current_user, start_time)
+    sidefx.after_copy(source_project, project, current_user, start_time, reassign_moderator)
 
     render json: WebApi::V1::ProjectSerializer.new(
       project,

--- a/back/app/controllers/web_api/v1/projects_controller.rb
+++ b/back/app/controllers/web_api/v1/projects_controller.rb
@@ -196,7 +196,7 @@ class WebApi::V1::ProjectsController < ApplicationController
     # A final authorization check is performed afterward on the actual copied project.
     #
     # We also set default_assignee_id: nil if the assignee is a project moderator of the source,
-    # to avoid validation error due to assignee not being moderator of the new project. In such cases,
+    # to avoid validation error due to assignee not being moderator of the new dummy project. In such cases,
     # we later add the new project moderator role to the assignee and reset default_assignee in sidefx.after_copy.
     Project.transaction do
       source_project.dup.tap do |p|
@@ -221,7 +221,7 @@ class WebApi::V1::ProjectsController < ApplicationController
       authorize(copy, :create?)
     end
 
-    sidefx.after_copy(source_project, project, current_user, start_time, reassign_moderator)
+    sidefx.after_copy(source_project, project, current_user, start_time, reassign_moderator: reassign_moderator)
 
     render json: WebApi::V1::ProjectSerializer.new(
       project,

--- a/back/app/services/side_fx_project_service.rb
+++ b/back/app/services/side_fx_project_service.rb
@@ -25,11 +25,9 @@ class SideFxProjectService
     after_publish project, user if project.admin_publication.published?
   end
 
-  def after_copy(source_project, copied_project, user, start_time)
-    assignee = User.find_by(id: source_project&.default_assignee_id)
-    reassign_moderator = assignee && UserRoleService.new.can_moderate?(source_project, assignee) && !assignee.admin?
-
+  def after_copy(source_project, copied_project, user, start_time, reassign_moderator = false)
     if reassign_moderator
+      assignee = source_project&.default_assignee
       assignee.roles << { type: 'project_moderator', project_id: copied_project.id }
       assignee.save!
       copied_project.update!(default_assignee_id: assignee.id)

--- a/back/app/services/side_fx_project_service.rb
+++ b/back/app/services/side_fx_project_service.rb
@@ -25,9 +25,9 @@ class SideFxProjectService
     after_publish project, user if project.admin_publication.published?
   end
 
-  def after_copy(source_project, copied_project, user, start_time, reassign_moderator = false)
+  def after_copy(source_project, copied_project, user, start_time, reassign_moderator: false)
     if reassign_moderator
-      assignee = source_project&.default_assignee
+      assignee = source_project.default_assignee
       assignee.roles << { type: 'project_moderator', project_id: copied_project.id }
       assignee.save!
       copied_project.update!(default_assignee_id: assignee.id)

--- a/back/spec/acceptance/projects_spec.rb
+++ b/back/spec/acceptance/projects_spec.rb
@@ -634,6 +634,20 @@ resource 'Projects' do
         copied_project = Project.find(json_response.dig(:data, :id))
         expect(copied_project.title_multiloc['en']).to include(source_project.title_multiloc['en'])
       end
+
+      example 'Copy a project with a project moderator as default_assignee', document: false do
+        moderator = create(:project_moderator, projects: [source_project])
+        source_project.update!(default_assignee: moderator)
+
+        do_request
+        assert_status 201
+
+        copied_project = Project.find(json_response.dig(:data, :id))
+        expect(copied_project.default_assignee_id).to eq moderator.id
+
+        assignee = User.find(moderator.id)
+        expect(UserRoleService.new.can_moderate?(source_project, assignee)).to be true
+      end
     end
 
     get 'web_api/v1/projects/:id/as_xlsx' do

--- a/back/spec/acceptance/projects_spec.rb
+++ b/back/spec/acceptance/projects_spec.rb
@@ -646,7 +646,7 @@ resource 'Projects' do
         expect(copied_project.default_assignee_id).to eq moderator.id
 
         assignee = User.find(moderator.id)
-        expect(UserRoleService.new.can_moderate?(source_project, assignee)).to be true
+        expect(UserRoleService.new.can_moderate?(copied_project, assignee)).to be true
       end
     end
 

--- a/back/spec/services/side_fx_project_service_spec.rb
+++ b/back/spec/services/side_fx_project_service_spec.rb
@@ -173,7 +173,7 @@ describe SideFxProjectService do
       moderator = create(:project_moderator, projects: [source_project])
       source_project.update!(default_assignee: moderator)
 
-      service.after_copy(source_project, copied_project, user, Time.now, true)
+      service.after_copy(source_project, copied_project, user, Time.now, reassign_moderator: true)
 
       expect(copied_project.default_assignee).to eq(moderator)
       expect(UserRoleService.new.can_moderate?(copied_project, moderator.reload)).to be true


### PR DESCRIPTION
# Changelog
## Fixed
[TAN-3474] Internal project copy should no longer fail when the project default_assignee is a project moderator.
