### PR TITLE
TAN-3140/project select resets on search

### DIFF
--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/Selection/Settings/AdminPublicationSearchInput.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/Selection/Settings/AdminPublicationSearchInput.tsx
@@ -30,7 +30,6 @@ const AdminPublicationSearchInput = ({
     data: adminPublications,
     fetchNextPage,
     hasNextPage,
-    isFetching,
     isFetchingNextPage,
   } = useAdminPublications({
     search,

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/Selection/Settings/AdminPublicationSearchInput.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/Selection/Settings/AdminPublicationSearchInput.tsx
@@ -14,8 +14,7 @@ import OptionLabel from './OptionLabel';
 import { LoadMore, getOptionId, getOptions } from './utils';
 
 interface Props {
-  /* adminPublicationsIds is undefined if fetching new selections */
-  adminPublicationIds?: string[];
+  adminPublicationIds: string[];
   onChange: (option?: IAdminPublicationData | LoadMore) => void;
 }
 
@@ -66,7 +65,6 @@ const AdminPublicationSearchInput = ({
         value={null}
         inputValue={visibleSearchTerm}
         placeholder={''}
-        isDisabled={!adminPublicationIds || isFetching}
         options={options}
         getOptionValue={getOptionId}
         getOptionLabel={(option) =>


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Do not disable (and seemingly reset) the project selector in the homepage content builder anymore.