### PR TITLE
Homepage content builder: close project/folder on select

### DIFF
--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/Selection/Settings/AdminPublicationSearchInput.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/Selection/Settings/AdminPublicationSearchInput.tsx
@@ -77,7 +77,7 @@ const AdminPublicationSearchInput = ({
             fetchNextPage={fetchNextPage}
           />
         )}
-        menuPlacement="auto"
+        menuPlacement="top"
         styles={selectStyles(theme)}
         filterOption={() => true}
         onInputChange={handleInputChange}
@@ -88,7 +88,7 @@ const AdminPublicationSearchInput = ({
         }}
         onChange={onChange}
         closeMenuOnScroll={false}
-        closeMenuOnSelect
+        closeMenuOnSelect={false}
       />
     </Box>
   );

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/Selection/Settings/AdminPublicationSearchInput.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/Selection/Settings/AdminPublicationSearchInput.tsx
@@ -69,16 +69,14 @@ const AdminPublicationSearchInput = ({
         isDisabled={!adminPublicationIds || isFetching}
         options={options}
         getOptionValue={getOptionId}
-        getOptionLabel={(option) =>
-          (
-            <OptionLabel
-              option={option}
-              hasNextPage={hasNextPage}
-              isLoading={isFetchingNextPage}
-              fetchNextPage={fetchNextPage}
-            />
-          ) as any
-        }
+        getOptionLabel={(option) => (
+          <OptionLabel
+            option={option}
+            hasNextPage={hasNextPage}
+            isLoading={isFetchingNextPage}
+            fetchNextPage={fetchNextPage}
+          />
+        )}
         menuPlacement="auto"
         styles={selectStyles(theme)}
         filterOption={() => true}
@@ -90,7 +88,7 @@ const AdminPublicationSearchInput = ({
         }}
         onChange={onChange}
         closeMenuOnScroll={false}
-        closeMenuOnSelect={false}
+        closeMenuOnSelect
       />
     </Box>
   );


### PR DESCRIPTION
Before
<img width="1258" alt="Screenshot 2025-01-15 at 18 05 41" src="https://github.com/user-attachments/assets/f7117531-ae53-4efb-b9e3-91a5bc0137de" />

After
<img width="1262" alt="Screenshot 2025-01-15 at 18 05 25" src="https://github.com/user-attachments/assets/48b58104-bc33-4a6d-ad18-66ac6a9fff75" />

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->
## Fixed
- Homepage content builder: open projects list upwards so selected projects remain visible (before/after can be seen [here](https://github.com/CitizenLabDotCo/citizenlab/pull/10059)).