### PR TITLE
[TAN-3327] Add mailinator.com to domain blacklist

### DIFF
--- a/back/config/domain_blacklist.txt
+++ b/back/config/domain_blacklist.txt
@@ -1,2 +1,3 @@
 039b1ee.netsolhost.com
 awgarstone.com
+mailinator.com


### PR DESCRIPTION
# Changelog
## Fixed
[TAN-3327] Users can no longer sign up with spam email `@mailinator.com` domain
