### PR TITLE
[TAN-3573] Hide folders that contain only non-visible projects in homepage selection widget

### DIFF
--- a/back/app/controllers/web_api/v1/admin_publications_controller.rb
+++ b/back/app/controllers/web_api/v1/admin_publications_controller.rb
@@ -46,7 +46,8 @@ class WebApi::V1::AdminPublicationsController < ApplicationController
     ids = params[:ids]
 
     visible_not_draft_admin_publications = policy_scope(AdminPublication.includes(:parent)).not_draft
-    admin_publications = admin_publication_filterer.filter(visible_not_draft_admin_publications, params.merge(current_user: current_user, remove_not_allowed_parents: true))
+    admin_publications = admin_publication_filterer.filter(visible_not_draft_admin_publications,
+      params.merge(current_user: current_user, remove_not_allowed_parents: true))
 
     # Performance-wise it is not optimal to break the query-chain like this, but it avoids a conflict
     # between the in_order_of method and SELECT_DISTINCT that can be included elsewhere in the query chain.

--- a/back/app/controllers/web_api/v1/admin_publications_controller.rb
+++ b/back/app/controllers/web_api/v1/admin_publications_controller.rb
@@ -46,7 +46,13 @@ class WebApi::V1::AdminPublicationsController < ApplicationController
     ids = params[:ids]
 
     visible_not_draft_admin_publications = policy_scope(AdminPublication.includes(:parent)).not_draft
-    admin_publications = visible_not_draft_admin_publications.where(id: ids).in_order_of(:id, ids)
+    admin_publications = admin_publication_filterer.filter(visible_not_draft_admin_publications, params.merge(current_user: current_user, remove_not_allowed_parents: true))
+
+    # Performance-wise it is not optimal to break the query-chain like this, but it avoids a conflict
+    # between the in_order_of method and SELECT_DISTINCT that can be included elsewhere in the query chain.
+    # Since we do not expect large collections to be selected for this widget, this is an acceptable trade-off.
+    subquery = admin_publications.where(id: ids).select(:id).distinct
+    admin_publications = AdminPublication.where(id: subquery).in_order_of(:id, ids)
 
     @admin_publications = paginate admin_publications
     @admin_publications = includes_publications(@admin_publications)
@@ -56,7 +62,7 @@ class WebApi::V1::AdminPublicationsController < ApplicationController
     # Initialize the filtering in the AdminPublicationsFilteringService,
     # so that we can use the visible_children_counts_by_parent_id in the serializer, via the jsonapi_serializer_params.
     # Not part of query chain, unlike the index action, as this raises an error due to conflict with in_order_of method.
-    admin_publication_filterer.filter(visible_not_draft_admin_publications, params.merge(current_user: current_user))
+    # admin_publication_filterer.filter(visible_not_draft_admin_publications, params.merge(current_user: current_user))
 
     render json: linked_json(
       @admin_publications,

--- a/back/app/controllers/web_api/v1/admin_publications_controller.rb
+++ b/back/app/controllers/web_api/v1/admin_publications_controller.rb
@@ -60,11 +60,6 @@ class WebApi::V1::AdminPublicationsController < ApplicationController
 
     authorize @admin_publications, :index_select_and_order_by_ids?
 
-    # Initialize the filtering in the AdminPublicationsFilteringService,
-    # so that we can use the visible_children_counts_by_parent_id in the serializer, via the jsonapi_serializer_params.
-    # Not part of query chain, unlike the index action, as this raises an error due to conflict with in_order_of method.
-    # admin_publication_filterer.filter(visible_not_draft_admin_publications, params.merge(current_user: current_user))
-
     render json: linked_json(
       @admin_publications,
       WebApi::V1::AdminPublicationSerializer,

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -627,6 +627,18 @@ resource 'AdminPublication' do
         json_response = json_parse(response_body)
         expect(json_response[:data].first.dig(:attributes, :visible_children_count)).to eq 1
       end
+
+      example 'Does not includes folders containing only non-visible children', document: false do
+        group_project = create(:project, visible_to: 'groups')
+        draft_project = create(:project, admin_publication_attributes: { publication_status: 'draft' })
+        folder_with_non_visible_children = create(:project_folder, projects: [group_project, draft_project])
+
+        do_request(ids: [folder_with_non_visible_children.admin_publication.id])
+
+        expect(status).to eq(200)
+        json_response = json_parse(response_body)
+        expect(json_response[:data]).to be_empty
+      end
     end
   end
 


### PR DESCRIPTION
# Changelog
## Fixed
- [TAN-3573] Hide folders that contain only non-visible projects in homepage selection widget (align with folder visibility in legacy folders & projects widget)
