### PR TITLE
[TAN-3474] Fix project copy when default_assignee is a PM (alternative)

### DIFF
--- a/back/app/controllers/web_api/v1/projects_controller.rb
+++ b/back/app/controllers/web_api/v1/projects_controller.rb
@@ -193,10 +193,14 @@ class WebApi::V1::ProjectsController < ApplicationController
     # A final authorization check is performed afterward on the actual copied project.
     Project.transaction do
       source_project.dup.tap do |p|
-        p.assign_attributes(slug: nil, admin_publication_attributes: {
-          publication_status: 'draft',
-          parent_id: dest_folder&.admin_publication&.id
-        })
+        p.assign_attributes(
+          slug: nil,
+          default_assignee_id: nil,
+          admin_publication_attributes: {
+            publication_status: 'draft',
+            parent_id: dest_folder&.admin_publication&.id
+          }
+        )
 
         p.save!
         authorize(p, :create?)

--- a/back/app/services/side_fx_project_service.rb
+++ b/back/app/services/side_fx_project_service.rb
@@ -6,10 +6,7 @@ class SideFxProjectService
   def before_create(project, user); end
 
   def after_create(project, user)
-    if user && !UserRoleService.new.can_moderate_project?(project, user)
-      user.add_role('project_moderator', project_id: project.id).save!
-    end
-
+    ensure_user_can_moderate_project!(project, user)
     project.set_default_topics!
     project.update!(description_multiloc: TextImageService.new.swap_data_images_multiloc(project.description_multiloc, field: :description_multiloc, imageable: project))
     serialized_project = clean_time_attributes(project.attributes)
@@ -26,6 +23,8 @@ class SideFxProjectService
   end
 
   def after_copy(source_project, copied_project, user, start_time)
+    ensure_user_can_moderate_project!(copied_project, user)
+
     LogActivityJob.perform_later(
       copied_project,
       'local_copy_created',
@@ -113,6 +112,12 @@ class SideFxProjectService
   end
 
   private
+
+  def ensure_user_can_moderate_project!(project, user)
+    if user && !UserRoleService.new.can_moderate_project?(project, user)
+      user.add_role('project_moderator', project_id: project.id).save!
+    end
+  end
 
   def after_publish(project, user)
     LogActivityJob.perform_later project, 'published', user, project.updated_at.to_i

--- a/back/engines/commercial/idea_assignment/app/services/idea_assignment/patches/side_fx_project_service.rb
+++ b/back/engines/commercial/idea_assignment/app/services/idea_assignment/patches/side_fx_project_service.rb
@@ -8,6 +8,11 @@ module IdeaAssignment
         set_default_assignee!(project, current_user) unless project.default_assignee
       end
 
+      def after_copy(source_project, copied_project, current_user, start_time)
+        super
+        set_default_assignee!(copied_project, current_user) unless copied_project.default_assignee
+      end
+
       private
 
       def after_folder_changed(project, current_user)

--- a/back/engines/commercial/idea_assignment/app/services/idea_assignment/patches/side_fx_project_service.rb
+++ b/back/engines/commercial/idea_assignment/app/services/idea_assignment/patches/side_fx_project_service.rb
@@ -5,12 +5,12 @@ module IdeaAssignment
     module SideFxProjectService
       def after_create(project, current_user)
         super
-        set_default_assignee!(project, current_user) unless project.default_assignee
+        set_default_assignee!(project, current_user)
       end
 
       def after_copy(source_project, copied_project, current_user, start_time)
         super
-        set_default_assignee!(copied_project, current_user) unless copied_project.default_assignee
+        set_default_assignee!(copied_project, current_user)
       end
 
       private
@@ -24,7 +24,9 @@ module IdeaAssignment
       end
 
       def set_default_assignee!(project, current_user)
-        project.default_assignee ||= current_user&.super_admin? ? ::User.oldest_admin : current_user
+        return if project.default_assignee
+
+        project.default_assignee = current_user&.super_admin? ? ::User.oldest_admin : current_user
         project.save!
       end
     end

--- a/back/spec/acceptance/projects_spec.rb
+++ b/back/spec/acceptance/projects_spec.rb
@@ -686,7 +686,7 @@ resource 'Projects' do
 
       context 'as a folder moderator' do
         let(:folder) { create(:project_folder, projects: [source_project]) }
- 
+
         before do
           header 'Content-Type', 'application/json'
           @user = create(:user, roles: [{ type: 'project_folder_moderator', project_folder_id: folder.id }])

--- a/back/spec/acceptance/projects_spec.rb
+++ b/back/spec/acceptance/projects_spec.rb
@@ -635,6 +635,26 @@ resource 'Projects' do
         expect(copied_project.title_multiloc['en']).to include(source_project.title_multiloc['en'])
       end
 
+      example 'Copy non-draft project', document: false do
+        expect(source_project.admin_publication.publication_status).not_to eq 'draft'
+
+        do_request
+        assert_status 201
+
+        copied_project = Project.find(json_response.dig(:data, :id))
+        expect(copied_project.admin_publication.publication_status).to eq 'draft'
+      end
+      
+      example 'Copy a project in a folder', document: false do
+        folder = create(:project_folder, projects: [source_project])
+
+        do_request
+        assert_status 201
+
+        copied_project = Project.find(json_response.dig(:data, :id))
+        expect(copied_project.folder_id).to eq folder.id
+      end
+
       example 'Copy a project with a project moderator as default_assignee', document: false do
         moderator = create(:project_moderator, projects: [source_project])
         source_project.update!(default_assignee: moderator)

--- a/back/spec/acceptance/projects_spec.rb
+++ b/back/spec/acceptance/projects_spec.rb
@@ -673,7 +673,7 @@ resource 'Projects' do
           header_token_for @user
         end
 
-        example 'Copy a project in a folder', document: false do
+        example 'Copying a project in a folder copies to root', document: false do
           create(:project_folder, projects: [source_project])
 
           do_request
@@ -693,7 +693,7 @@ resource 'Projects' do
           header_token_for @user
         end
 
-        example_request 'Copy a project in a folder', document: false do
+        example_request 'Copying a project in a folder copies to the same folder', document: false do
           assert_status 201
 
           copied_project = Project.find(json_response.dig(:data, :id))

--- a/back/spec/acceptance/projects_spec.rb
+++ b/back/spec/acceptance/projects_spec.rb
@@ -634,6 +634,17 @@ resource 'Projects' do
         copied_project = Project.find(json_response.dig(:data, :id))
         expect(copied_project.title_multiloc['en']).to include(source_project.title_multiloc['en'])
       end
+
+      example 'Copy a project with a project moderator as default_assignee', document: false do
+        moderator = create(:project_moderator, projects: [source_project])
+        source_project.update!(default_assignee: moderator)
+
+        do_request
+        assert_status 201
+
+        copied_project = Project.find(json_response.dig(:data, :id))
+        expect(copied_project.default_assignee_id).to eq @user.id
+      end
     end
 
     get 'web_api/v1/projects/:id/as_xlsx' do

--- a/back/spec/acceptance/projects_spec.rb
+++ b/back/spec/acceptance/projects_spec.rb
@@ -675,18 +675,18 @@ resource 'Projects' do
 
         example 'Copy a project in a folder', document: false do
           create(:project_folder, projects: [source_project])
-  
+
           do_request
           assert_status 201
-  
+
           copied_project = Project.find(json_response.dig(:data, :id))
           expect(copied_project.folder_id).to be_nil
         end
       end
 
       context 'as a folder moderator' do
-        let(:folder) { create(:project_folder, projects: [source_project])}
-        
+        let(:folder) { create(:project_folder, projects: [source_project]) }
+ 
         before do
           header 'Content-Type', 'application/json'
           @user = create(:user, roles: [{ type: 'project_folder_moderator', project_folder_id: folder.id }])
@@ -695,7 +695,7 @@ resource 'Projects' do
 
         example_request 'Copy a project in a folder', document: false do
           assert_status 201
-  
+
           copied_project = Project.find(json_response.dig(:data, :id))
           expect(copied_project.folder_id).to eq folder.id
         end

--- a/back/spec/acceptance/projects_spec.rb
+++ b/back/spec/acceptance/projects_spec.rb
@@ -644,7 +644,7 @@ resource 'Projects' do
         copied_project = Project.find(json_response.dig(:data, :id))
         expect(copied_project.admin_publication.publication_status).to eq 'draft'
       end
-      
+
       example 'Copy a project in a folder', document: false do
         folder = create(:project_folder, projects: [source_project])
 

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -223,9 +223,6 @@
       },
       "optionalDependencies": {
         "fsevents": "2"
-      },
-      "peerDependencies": {
-        "typescript": "5.3.3"
       }
     },
     "node_modules/@adobe/css-tools": {


### PR DESCRIPTION
# Changelog
## Fixed
- [TAN-3474] Internal project copy no longer fails when used by a project moderator.
- [TAN-3474] Internal project copy copies project to same folder as source project.
