### PR TITLE
Add upsell nudge for screening setting in ideation phases

### DIFF
--- a/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/IdeationInputs/index.tsx
+++ b/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/IdeationInputs/index.tsx
@@ -93,8 +93,9 @@ const IdeationInputs = ({
   prescreening_enabled,
   togglePrescreeningEnabled,
 }: Props) => {
-  const prescreeningIdeationEnabled = useFeatureFlag({
+  const prescreeningIdeationAllowed = useFeatureFlag({
     name: 'prescreening_ideation',
+    onlyCheckAllowed: true,
   });
 
   return (
@@ -109,17 +110,11 @@ const IdeationInputs = ({
         input_term={input_term}
         handleInputTermChange={handleInputTermChange}
       />
-      {
-        // Remove the following condition when pricing decision made
-        // And add feature flag with onlyCheckAllowed back into prescreeningFeatureAllowed
-        prescreeningIdeationEnabled && (
-          <PrescreeningToggle
-            prescreening_enabled={prescreening_enabled}
-            togglePrescreeningEnabled={togglePrescreeningEnabled}
-            prescreeningFeatureAllowed={true}
-          />
-        )
-      }
+      <PrescreeningToggle
+        prescreening_enabled={prescreening_enabled}
+        togglePrescreeningEnabled={togglePrescreeningEnabled}
+        prescreeningFeatureAllowed={prescreeningIdeationAllowed}
+      />
       <UserActions
         submission_enabled={submission_enabled || false}
         commenting_enabled={commenting_enabled || false}


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Added
- Add upsell nudge for pre-screening setting in ideation phases