### PR TITLE
[TAN-3528] Support ranking questions in sensemaking view

### DIFF
--- a/front/app/api/idea_custom_fields/types.ts
+++ b/front/app/api/idea_custom_fields/types.ts
@@ -12,6 +12,7 @@ export type IIdeaCustomFieldInputType =
   | 'multiline_text'
   | 'select'
   | 'multiselect'
+  | 'ranking'
   | 'checkbox'
   | 'date'
   | 'linear_scale'

--- a/front/app/containers/Admin/projects/project/analysis/InputPreview/LongFieldValue.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/InputPreview/LongFieldValue.tsx
@@ -10,6 +10,7 @@ import {
 } from '@citizenlab/cl2-component-library';
 import { xor } from 'lodash-es';
 import { FormattedDate } from 'react-intl';
+import { useTheme } from 'styled-components';
 
 import { IInputsData } from 'api/analysis_inputs/types';
 import useIdeaCustomField from 'api/idea_custom_fields/useIdeaCustomField';
@@ -98,6 +99,7 @@ const FilterToggleButton = ({ customFieldId, value }) => {
  * representation of the value of the custom field for that input
  */
 const FieldValue = ({ projectId, phaseId, customFieldId, input }: Props) => {
+  const theme = useTheme();
   const { formatMessage } = useIntl();
 
   const containerId: { projectId?: string; phaseId?: string } = {};
@@ -275,6 +277,38 @@ const FieldValue = ({ projectId, phaseId, customFieldId, input }: Props) => {
                   formatMessage(messages.noAnswer)
                 )}
               </Text>
+            </Box>
+          );
+        }
+        case 'ranking': {
+          return (
+            <Box>
+              <Title variant="h5" m="0px">
+                <T value={customField.data.attributes.title_multiloc} />
+              </Title>
+              {!rawValue && (
+                <Text m="0px">{formatMessage(messages.noAnswer)}</Text>
+              )}
+              {rawValue?.map((optionKey: string, index: number) => (
+                <Box key={optionKey} display="flex" mt="8px">
+                  <Text mr="8px" my="auto">
+                    #{index + 1}
+                  </Text>
+                  <Text
+                    m="0px"
+                    p="4px 8px"
+                    style={{
+                      border: `1px solid ${theme.colors.divider}`,
+                      borderRadius: theme.borderRadius,
+                    }}
+                  >
+                    <SelectOptionText
+                      customFieldId={customField.data.id}
+                      selectedOptionKey={optionKey}
+                    />
+                  </Text>
+                </Box>
+              ))}
             </Box>
           );
         }

--- a/front/app/containers/Admin/projects/project/analysis/InputPreview/LongFieldValue.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/InputPreview/LongFieldValue.tsx
@@ -293,19 +293,17 @@ const FieldValue = ({ projectId, phaseId, customFieldId, input }: Props) => {
                       <Text mr="8px" my="auto">
                         #{index + 1}
                       </Text>
-                      <Text
-                        m="0px"
-                        p="4px 8px"
-                        style={{
-                          border: `1px solid ${theme.colors.divider}`,
-                          borderRadius: theme.borderRadius,
-                        }}
+                      <Box
+                        border={`1px solid ${theme.colors.divider}`}
+                        borderRadius={theme.borderRadius}
                       >
-                        <SelectOptionText
-                          customFieldId={customField.data.id}
-                          selectedOptionKey={optionKey}
-                        />
-                      </Text>
+                        <Text m="4px 8px">
+                          <SelectOptionText
+                            customFieldId={customField.data.id}
+                            selectedOptionKey={optionKey}
+                          />
+                        </Text>
+                      </Box>
                     </Box>
                   ))}
                 </>

--- a/front/app/containers/Admin/projects/project/analysis/InputPreview/LongFieldValue.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/InputPreview/LongFieldValue.tsx
@@ -286,29 +286,32 @@ const FieldValue = ({ projectId, phaseId, customFieldId, input }: Props) => {
               <Title variant="h5" m="0px">
                 <T value={customField.data.attributes.title_multiloc} />
               </Title>
-              {!rawValue && (
+              {rawValue ? (
+                <>
+                  {rawValue.map((optionKey: string, index: number) => (
+                    <Box key={optionKey} display="flex" mt="8px">
+                      <Text mr="8px" my="auto">
+                        #{index + 1}
+                      </Text>
+                      <Text
+                        m="0px"
+                        p="4px 8px"
+                        style={{
+                          border: `1px solid ${theme.colors.divider}`,
+                          borderRadius: theme.borderRadius,
+                        }}
+                      >
+                        <SelectOptionText
+                          customFieldId={customField.data.id}
+                          selectedOptionKey={optionKey}
+                        />
+                      </Text>
+                    </Box>
+                  ))}
+                </>
+              ) : (
                 <Text m="0px">{formatMessage(messages.noAnswer)}</Text>
               )}
-              {rawValue?.map((optionKey: string, index: number) => (
-                <Box key={optionKey} display="flex" mt="8px">
-                  <Text mr="8px" my="auto">
-                    #{index + 1}
-                  </Text>
-                  <Text
-                    m="0px"
-                    p="4px 8px"
-                    style={{
-                      border: `1px solid ${theme.colors.divider}`,
-                      borderRadius: theme.borderRadius,
-                    }}
-                  >
-                    <SelectOptionText
-                      customFieldId={customField.data.id}
-                      selectedOptionKey={optionKey}
-                    />
-                  </Text>
-                </Box>
-              ))}
             </Box>
           );
         }

--- a/front/app/containers/Admin/projects/project/analysis/components/ShortInputFieldValue.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/components/ShortInputFieldValue.tsx
@@ -107,6 +107,9 @@ const ShortInputFieldValue = ({ customField, rawValue }: Props) => {
     case 'polygon': {
       return null;
     }
+    case 'ranking': {
+      return null;
+    }
     default: {
       // Makes TS throw a compile error in case we're not covering for an input_type
       const exhaustiveCheck: never = customField.data.attributes.input_type;


### PR DESCRIPTION
Supports ranking survey questions in the sense-making view:
 
![image](https://github.com/user-attachments/assets/9eeb5c01-5437-4258-a7d5-92114ba6122b)

