### PR TITLE
Tan 3576/useideastatuses variant usage

### DIFF
--- a/front/app/api/idea_statuses/types.ts
+++ b/front/app/api/idea_statuses/types.ts
@@ -14,7 +14,7 @@ export type IdeaStatusParticipationMethod = Extract<
 >;
 
 export type IdeaStatusesQueryParams = {
-  participation_method?: IdeaStatusParticipationMethod;
+  participation_method: IdeaStatusParticipationMethod;
   // Not ready for usage yet
   exclude_screening_status?: boolean;
 };

--- a/front/app/api/idea_statuses/useIdeaStatuses.ts
+++ b/front/app/api/idea_statuses/useIdeaStatuses.ts
@@ -19,10 +19,10 @@ const fetchIdeaStatuses = (queryParams: IdeaStatusesQueryParams) =>
 
 const useIdeaStatuses = ({
   enabled = true,
-  queryParams = {},
+  queryParams,
 }: {
   enabled?: boolean;
-  queryParams?: IdeaStatusesQueryParams;
+  queryParams: IdeaStatusesQueryParams;
 }) => {
   return useQuery<IIdeaStatuses, CLErrors, IIdeaStatuses, IdeaStatusesKeys>({
     queryKey: ideaStatusesKeys.list(queryParams),

--- a/front/app/components/IdeaCards/shared/Filters/StatusFilterBox.tsx
+++ b/front/app/components/IdeaCards/shared/Filters/StatusFilterBox.tsx
@@ -12,7 +12,7 @@ interface Props {
   ideaQueryParameters: IIdeasFilterCountsQueryParameters;
   onChange: (arg: string | null) => void;
   className?: string;
-  participationMethod?: IdeaStatusParticipationMethod;
+  participationMethod: IdeaStatusParticipationMethod;
 }
 
 const StatusFilterBox = ({

--- a/front/app/modules/commercial/smart_groups/components/UserFilterConditions/ValueSelector/IdeaStatusValueSelector.tsx
+++ b/front/app/modules/commercial/smart_groups/components/UserFilterConditions/ValueSelector/IdeaStatusValueSelector.tsx
@@ -17,29 +17,31 @@ export interface Props {
 }
 
 const IdeaStatusValueSelector = memo(({ value, onChange }: Props) => {
-  const { data: ideaStatuses } = useIdeaStatuses({});
+  const { data: proposalInputStatuses } = useIdeaStatuses({
+    queryParams: { participation_method: 'proposals' },
+  });
+  const { data: ideationInputStatuses } = useIdeaStatuses({
+    queryParams: { participation_method: 'ideation' },
+  });
   const localize = useLocalize();
   const { formatMessage } = useIntl();
 
-  const methodName = {
-    proposals: formatMessage(messages.ideaStatusMethodProposals),
-    ideation: formatMessage(messages.ideaStatusMethodIdeation),
-  };
+  if (!ideationInputStatuses || !proposalInputStatuses) return null;
 
-  const generateOptions = (): IOption[] => {
-    if (ideaStatuses) {
-      return ideaStatuses.data.map((ideaStatus) => {
-        return {
-          value: ideaStatus.id,
-          label: `${localize(ideaStatus.attributes.title_multiloc)} (${
-            methodName[ideaStatus.attributes.participation_method]
-          })`,
-        };
-      });
-    } else {
-      return [];
-    }
-  };
+  const generateOptions = (): IOption[] => [
+    ...ideationInputStatuses.data.map((status) => ({
+      value: status.id,
+      label: `${localize(status.attributes.title_multiloc)} (${formatMessage(
+        messages.ideaStatusMethodIdeation
+      )})`,
+    })),
+    ...proposalInputStatuses.data.map((status) => ({
+      value: status.id,
+      label: `${localize(status.attributes.title_multiloc)} (${formatMessage(
+        messages.ideaStatusMethodProposals
+      )})`,
+    })),
+  ];
 
   const handleOnChange = (option: IOption) => {
     onChange(option.value);

--- a/front/app/modules/commercial/smart_groups/components/UserFilterConditions/ValueSelector/IdeaStatusValuesSelector.tsx
+++ b/front/app/modules/commercial/smart_groups/components/UserFilterConditions/ValueSelector/IdeaStatusValuesSelector.tsx
@@ -18,28 +18,31 @@ export interface Props {
 }
 
 const IdeaStatusValuesSelector = memo(({ value, onChange }: Props) => {
-  const { data: ideaStatuses } = useIdeaStatuses({});
+  const { data: proposalInputStatuses } = useIdeaStatuses({
+    queryParams: { participation_method: 'proposals' },
+  });
+  const { data: ideationInputStatuses } = useIdeaStatuses({
+    queryParams: { participation_method: 'ideation' },
+  });
   const localize = useLocalize();
   const { formatMessage } = useIntl();
 
-  const methodName = {
-    proposals: formatMessage(messages.ideaStatusMethodProposals),
-    ideation: formatMessage(messages.ideaStatusMethodIdeation),
-  };
-  const generateOptions = (): IOption[] => {
-    if (ideaStatuses) {
-      return ideaStatuses.data.map((ideaStatus) => {
-        return {
-          value: ideaStatus.id,
-          label: `${localize(ideaStatus.attributes.title_multiloc)} (${
-            methodName[ideaStatus.attributes.participation_method]
-          })`,
-        };
-      });
-    } else {
-      return [];
-    }
-  };
+  if (!ideationInputStatuses || !proposalInputStatuses) return null;
+
+  const generateOptions = (): IOption[] => [
+    ...ideationInputStatuses.data.map((status) => ({
+      value: status.id,
+      label: `${localize(status.attributes.title_multiloc)} (${formatMessage(
+        messages.ideaStatusMethodIdeation
+      )})`,
+    })),
+    ...proposalInputStatuses.data.map((status) => ({
+      value: status.id,
+      label: `${localize(status.attributes.title_multiloc)} (${formatMessage(
+        messages.ideaStatusMethodProposals
+      )})`,
+    })),
+  ];
 
   const handleOnChange = (options: IOption[]) => {
     const optionIds = options.map((o) => o.value) as string[];


### PR DESCRIPTION
Make `participation_method` query param required for `useIdeaStatuses`.

This work started because I thought there was a bug, but there wasn't. It's still an improvement worth merging, IMO. We'll have more explicit code that potentially prevents bugs (in case someone forgets to add the `participation_method`).

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->
