### PR TITLE
[TAN-3283] Add BE filtering of prescreening input statuses

### DIFF
--- a/back/app/controllers/web_api/v1/idea_statuses_controller.rb
+++ b/back/app/controllers/web_api/v1/idea_statuses_controller.rb
@@ -92,9 +92,24 @@ class WebApi::V1::IdeaStatusesController < ApplicationController
   end
 
   def apply_index_filters
-    return if params[:participation_method].blank?
+    participation_method = params[:participation_method]
+    return if participation_method.blank?
 
-    @idea_statuses = @idea_statuses.where(participation_method: params[:participation_method])
+    @idea_statuses = @idea_statuses.where(participation_method: participation_method)
+
+    if prescreening_feature_inactive?(participation_method) || params[:exclude_screening_status] == 'true'
+      @idea_statuses = @idea_statuses.where.not(code: 'prescreening')
+    end
+  end
+
+  def prescreening_feature_inactive?(participation_method)
+    if participation_method == 'ideation' && !AppConfiguration.instance.feature_activated?('prescreening_ideation')
+      return true
+    elsif participation_method == 'proposals' && !AppConfiguration.instance.feature_activated?('prescreening')
+      return true
+    end
+
+    false
   end
 
   def idea_status_params_for_create

--- a/back/app/controllers/web_api/v1/idea_statuses_controller.rb
+++ b/back/app/controllers/web_api/v1/idea_statuses_controller.rb
@@ -104,7 +104,7 @@ class WebApi::V1::IdeaStatusesController < ApplicationController
 
   def prescreening_feature_inactive?(participation_method)
     if (participation_method == 'ideation' && !AppConfiguration.instance.feature_activated?('prescreening_ideation')) ||
-        (participation_method == 'proposals' && !AppConfiguration.instance.feature_activated?('prescreening'))
+       (participation_method == 'proposals' && !AppConfiguration.instance.feature_activated?('prescreening'))
       return true
     end
 

--- a/back/app/controllers/web_api/v1/idea_statuses_controller.rb
+++ b/back/app/controllers/web_api/v1/idea_statuses_controller.rb
@@ -103,9 +103,8 @@ class WebApi::V1::IdeaStatusesController < ApplicationController
   end
 
   def prescreening_feature_inactive?(participation_method)
-    if participation_method == 'ideation' && !AppConfiguration.instance.feature_activated?('prescreening_ideation')
-      return true
-    elsif participation_method == 'proposals' && !AppConfiguration.instance.feature_activated?('prescreening')
+    if (participation_method == 'ideation' && !AppConfiguration.instance.feature_activated?('prescreening_ideation')) ||
+        (participation_method == 'proposals' && !AppConfiguration.instance.feature_activated?('prescreening'))
       return true
     end
 

--- a/back/spec/acceptance/idea_statuses_spec.rb
+++ b/back/spec/acceptance/idea_statuses_spec.rb
@@ -21,8 +21,6 @@ resource 'IdeaStatuses' do
       let(:participation_method) { 'ideation' }
 
       example_request 'List all ideation input statuses' do
-        pp "ideation: #{AppConfiguration.instance.feature_activated?('prescreening_ideation')}"
-        pp "proposals: #{AppConfiguration.instance.feature_activated?('prescreening')}"
         assert_status 200
         json_response = json_parse(response_body)
         expect(json_response[:data].size).to eq 3


### PR DESCRIPTION
@Brent This also implements the logic described in the ticket (in your comment) for proposals input statuses, as well as ideation input statuses, which is not really necessary (since we don't seem to use proposals version except by still listing them in the BO).

One side effect of these changes, seems to be that an input created with a status of prescreening (when feature on), will show as having no current status in the BO input managers when feature off, which I think is not ideal.

Note: I interpreted your comment to mean:
1. BE filters when feature inactive (`prescreening_ideation`) OR when passed `exclude_screening_status` param.
2. BE does not filter when `phase.prescreening_enabled == false`, as FE will do this when necessary, by using the new param when necessary.

# Changelog
## Technical
- [TAN-3283] Add BE filtering of prescreening input statuses
