### PR TITLE
Add missing copy for prescreening status for the status form

### DIFF
--- a/front/app/containers/Admin/settings/statuses/components/IdeaStatusForm.tsx
+++ b/front/app/containers/Admin/settings/statuses/components/IdeaStatusForm.tsx
@@ -182,6 +182,7 @@ const IdeaStatusForm = ({
                               expired: messages.expiredFieldCodeTitle,
                               answered: messages.answeredFieldCodeTitle,
                               ineligible: messages.ineligibleFieldCodeTitle,
+                              prescreening: messages.prescreeningFieldCodeTitle,
                             }[code]
                           )}
                         </span>
@@ -203,6 +204,8 @@ const IdeaStatusForm = ({
                                 answered: messages.answeredFieldCodeDescription,
                                 ineligible:
                                   messages.ineligibleFieldCodeDescription,
+                                prescreening:
+                                  messages.prescreeningFieldCodeDescription,
                               }[code]
                             )}
                           </span>

--- a/front/app/containers/Admin/settings/statuses/components/messages.ts
+++ b/front/app/containers/Admin/settings/statuses/components/messages.ts
@@ -74,6 +74,10 @@ export default defineMessages({
     id: 'app.containers.admin.ideaStatuses.form.ineligibleFieldCodeTitle',
     defaultMessage: 'Ineligible',
   },
+  prescreeningFieldCodeTitle: {
+    id: 'app.containers.admin.ideaStatuses.form.prescreeningFieldCodeTitle',
+    defaultMessage: 'Prescreening',
+  },
   proposedFieldCodeDescription: {
     id: 'app.containers.admin.ideaStatuses.form.proposedFieldCodeDescription',
     defaultMessage: 'Successfully submitted as a proposal for consideration',
@@ -113,6 +117,10 @@ export default defineMessages({
   ineligibleFieldCodeDescription: {
     id: 'app.containers.admin.ideaStatuses.form.ineligibleFieldCodeDescription',
     defaultMessage: 'Proposal is ineligible',
+  },
+  prescreeningFieldCodeDescription: {
+    id: 'app.containers.admin.ideaStatuses.form.prescreeningFieldCodeDescription',
+    defaultMessage: 'Awaiting screening',
   },
   saveStatus: {
     id: 'app.containers.admin.ideaStatuses.form.saveStatus',

--- a/front/app/translations/admin/en.json
+++ b/front/app/translations/admin/en.json
@@ -2707,6 +2707,8 @@
   "app.containers.admin.ideaStatuses.form.implementedFieldCodeTitle": "Implemented",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeDescription": "Proposal is ineligible",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeTitle": "Ineligible",
+  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeDescription": "Awaiting screening",
+  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeTitle": "Prescreening",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeDescription": "Successfully submitted as a proposal for consideration",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeTitle": "Proposed",
   "app.containers.admin.ideaStatuses.form.rejectedFieldCodeDescription": "Ineligible or not selected to move forward",


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Add missing copy for prescreening status to prevent page crash of the new/edit status form pages.