### PR TITLE
Tan 3641/remove prescreening allowed categories

### DIFF
--- a/front/app/api/idea_statuses/types.ts
+++ b/front/app/api/idea_statuses/types.ts
@@ -68,6 +68,7 @@ export const inputStatusCodes: Record<
 };
 
 export const automatedInputStatusCodes: Set<InputStatusCode> = new Set([
+  'prescreening',
   'proposed',
   'threshold_reached',
   'expired',

--- a/front/app/containers/Admin/settings/statuses/components/IdeaStatusForm.tsx
+++ b/front/app/containers/Admin/settings/statuses/components/IdeaStatusForm.tsx
@@ -182,7 +182,6 @@ const IdeaStatusForm = ({
                               expired: messages.expiredFieldCodeTitle,
                               answered: messages.answeredFieldCodeTitle,
                               ineligible: messages.ineligibleFieldCodeTitle,
-                              prescreening: messages.prescreeningFieldCodeTitle,
                             }[code]
                           )}
                         </span>
@@ -204,8 +203,6 @@ const IdeaStatusForm = ({
                                 answered: messages.answeredFieldCodeDescription,
                                 ineligible:
                                   messages.ineligibleFieldCodeDescription,
-                                prescreening:
-                                  messages.prescreeningFieldCodeDescription,
                               }[code]
                             )}
                           </span>

--- a/front/app/containers/Admin/settings/statuses/components/messages.ts
+++ b/front/app/containers/Admin/settings/statuses/components/messages.ts
@@ -74,10 +74,6 @@ export default defineMessages({
     id: 'app.containers.admin.ideaStatuses.form.ineligibleFieldCodeTitle',
     defaultMessage: 'Ineligible',
   },
-  prescreeningFieldCodeTitle: {
-    id: 'app.containers.admin.ideaStatuses.form.prescreeningFieldCodeTitle',
-    defaultMessage: 'Prescreening',
-  },
   proposedFieldCodeDescription: {
     id: 'app.containers.admin.ideaStatuses.form.proposedFieldCodeDescription',
     defaultMessage: 'Successfully submitted as a proposal for consideration',
@@ -117,10 +113,6 @@ export default defineMessages({
   ineligibleFieldCodeDescription: {
     id: 'app.containers.admin.ideaStatuses.form.ineligibleFieldCodeDescription',
     defaultMessage: 'Proposal is ineligible',
-  },
-  prescreeningFieldCodeDescription: {
-    id: 'app.containers.admin.ideaStatuses.form.prescreeningFieldCodeDescription',
-    defaultMessage: 'Awaiting screening',
   },
   saveStatus: {
     id: 'app.containers.admin.ideaStatuses.form.saveStatus',

--- a/front/app/translations/admin/ar-SA.json
+++ b/front/app/translations/admin/ar-SA.json
@@ -2707,8 +2707,6 @@
   "app.containers.admin.ideaStatuses.form.implementedFieldCodeTitle": "منفَّذ",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeDescription": "الاقتراح غير مؤهل",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeTitle": "غير مؤهل",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeDescription": "في انتظار الفحص",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeTitle": "الفحص المسبق",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeDescription": "تم التقديم بنجاح كمقترح للدراسة",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeTitle": "مقترح",
   "app.containers.admin.ideaStatuses.form.rejectedFieldCodeDescription": "غير مؤهل أو غير محدد للمضي قدمًا",

--- a/front/app/translations/admin/cy-GB.json
+++ b/front/app/translations/admin/cy-GB.json
@@ -2707,8 +2707,6 @@
   "app.containers.admin.ideaStatuses.form.implementedFieldCodeTitle": "Gweithredwyd",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeDescription": "Mae'r cynnig yn anghymwys",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeTitle": "Anghymwys",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeDescription": "Aros am sgrinio",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeTitle": "Rhag-sgrinio",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeDescription": "Wedi'i gyflwyno'n llwyddiannus fel cynnig i'w ystyried",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeTitle": "Arfaethedig",
   "app.containers.admin.ideaStatuses.form.rejectedFieldCodeDescription": "Yn anghymwys neu heb ei ddewis i symud ymlaen",

--- a/front/app/translations/admin/da-DK.json
+++ b/front/app/translations/admin/da-DK.json
@@ -2707,8 +2707,6 @@
   "app.containers.admin.ideaStatuses.form.implementedFieldCodeTitle": "Implementeret",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeDescription": "Forslaget er ikke støtteberettiget",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeTitle": "Ikke støtteberettiget",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeDescription": "Afventer screening",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeTitle": "Forudgående screening",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeDescription": "Afleveret som et forslag til overvejelse",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeTitle": "Foreslået",
   "app.containers.admin.ideaStatuses.form.rejectedFieldCodeDescription": "Ikke kvalificeret eller ikke valgt til at komme videre",

--- a/front/app/translations/admin/de-DE.json
+++ b/front/app/translations/admin/de-DE.json
@@ -2707,8 +2707,6 @@
   "app.containers.admin.ideaStatuses.form.implementedFieldCodeTitle": "Umgesetzt",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeDescription": "Der Vorschlag ist nicht zulässig",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeTitle": "Unzulässig",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeDescription": "Warten auf Vorabprüfung",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeTitle": "Vorabprüfung",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeDescription": "Erfolgreich als Vorschlag zur Prüfung eingereicht",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeTitle": "Vorgeschlagen",
   "app.containers.admin.ideaStatuses.form.rejectedFieldCodeDescription": "Nicht wählbar oder nicht zum Weitermachen ausgewählt",

--- a/front/app/translations/admin/en-CA.json
+++ b/front/app/translations/admin/en-CA.json
@@ -2707,8 +2707,6 @@
   "app.containers.admin.ideaStatuses.form.implementedFieldCodeTitle": "Implemented",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeDescription": "Proposal is ineligible",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeTitle": "Ineligible",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeDescription": "Awaiting screening",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeTitle": "Prescreening",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeDescription": "Successfully submitted as a proposal for consideration",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeTitle": "Proposed",
   "app.containers.admin.ideaStatuses.form.rejectedFieldCodeDescription": "Ineligible or not selected to move forward",

--- a/front/app/translations/admin/en-GB.json
+++ b/front/app/translations/admin/en-GB.json
@@ -2707,8 +2707,6 @@
   "app.containers.admin.ideaStatuses.form.implementedFieldCodeTitle": "Implemented",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeDescription": "Proposal is ineligible",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeTitle": "Ineligible",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeDescription": "Awaiting screening",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeTitle": "Prescreening",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeDescription": "Successfully submitted as a proposal for consideration",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeTitle": "Proposed",
   "app.containers.admin.ideaStatuses.form.rejectedFieldCodeDescription": "Ineligible or not selected to move forward",

--- a/front/app/translations/admin/en-IE.json
+++ b/front/app/translations/admin/en-IE.json
@@ -2707,8 +2707,6 @@
   "app.containers.admin.ideaStatuses.form.implementedFieldCodeTitle": "Implemented",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeDescription": "Proposal is ineligible",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeTitle": "Ineligible",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeDescription": "Awaiting screening",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeTitle": "Prescreening",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeDescription": "Successfully submitted as a proposal for consideration",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeTitle": "Proposed",
   "app.containers.admin.ideaStatuses.form.rejectedFieldCodeDescription": "Ineligible or not selected to move forward",

--- a/front/app/translations/admin/en.json
+++ b/front/app/translations/admin/en.json
@@ -2707,8 +2707,6 @@
   "app.containers.admin.ideaStatuses.form.implementedFieldCodeTitle": "Implemented",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeDescription": "Proposal is ineligible",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeTitle": "Ineligible",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeDescription": "Awaiting screening",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeTitle": "Prescreening",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeDescription": "Successfully submitted as a proposal for consideration",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeTitle": "Proposed",
   "app.containers.admin.ideaStatuses.form.rejectedFieldCodeDescription": "Ineligible or not selected to move forward",

--- a/front/app/translations/admin/es-CL.json
+++ b/front/app/translations/admin/es-CL.json
@@ -2707,8 +2707,6 @@
   "app.containers.admin.ideaStatuses.form.implementedFieldCodeTitle": "Implementado",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeDescription": "La propuesta no es elegible",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeTitle": "No apto",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeDescription": "En espera de examen",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeTitle": "Preselección",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeDescription": "Propuesta presentada con éxito para su consideración",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeTitle": "Propuesta",
   "app.containers.admin.ideaStatuses.form.rejectedFieldCodeDescription": "Inelegible o no seleccionado para avanzar",

--- a/front/app/translations/admin/es-ES.json
+++ b/front/app/translations/admin/es-ES.json
@@ -2707,8 +2707,6 @@
   "app.containers.admin.ideaStatuses.form.implementedFieldCodeTitle": "Implementado",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeDescription": "La propuesta no es elegible",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeTitle": "No apto",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeDescription": "En espera de examen",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeTitle": "Preselección",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeDescription": "Propuesta presentada con éxito para su consideración",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeTitle": "Propuesta",
   "app.containers.admin.ideaStatuses.form.rejectedFieldCodeDescription": "Inelegible o no seleccionado para avanzar",

--- a/front/app/translations/admin/fi-FI.json
+++ b/front/app/translations/admin/fi-FI.json
@@ -2707,8 +2707,6 @@
   "app.containers.admin.ideaStatuses.form.implementedFieldCodeTitle": "Toteutettu",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeDescription": "Ehdotus ei kelpaa",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeTitle": "Ei kelpaa",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeDescription": "Seulontaa odotellessa",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeTitle": "Esiseulonta",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeDescription": "Onnistuneesti toimitettu ehdotuksena käsiteltäväksi",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeTitle": "Ehdotettu",
   "app.containers.admin.ideaStatuses.form.rejectedFieldCodeDescription": "Ei kelvollinen tai ei valittu siirtymään eteenpäin",

--- a/front/app/translations/admin/fr-BE.json
+++ b/front/app/translations/admin/fr-BE.json
@@ -2707,8 +2707,6 @@
   "app.containers.admin.ideaStatuses.form.implementedFieldCodeTitle": "Mis en place",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeDescription": "La proposition est inéligible",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeTitle": "Inéligible",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeDescription": "En attente de dépistage",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeTitle": "Présélection",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeDescription": "Proposition soumise avec succès pour examen",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeTitle": "Proposée",
   "app.containers.admin.ideaStatuses.form.rejectedFieldCodeDescription": "Non éligible ou non sélectionnée pour l'étape suivante",

--- a/front/app/translations/admin/fr-FR.json
+++ b/front/app/translations/admin/fr-FR.json
@@ -2707,8 +2707,6 @@
   "app.containers.admin.ideaStatuses.form.implementedFieldCodeTitle": "Mis en place",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeDescription": "La proposition est inéligible",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeTitle": "Inéligible",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeDescription": "En attente de dépistage",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeTitle": "Présélection",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeDescription": "Proposition soumise avec succès pour examen",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeTitle": "Proposée",
   "app.containers.admin.ideaStatuses.form.rejectedFieldCodeDescription": "Non éligible ou non sélectionnée pour l'étape suivante",

--- a/front/app/translations/admin/hr-HR.json
+++ b/front/app/translations/admin/hr-HR.json
@@ -2707,8 +2707,6 @@
   "app.containers.admin.ideaStatuses.form.implementedFieldCodeTitle": "Implementirano",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeDescription": "Prijedlog ne ispunjava uvjete",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeTitle": "Ne ispunjava uvjete",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeDescription": "Čeka se projekcija",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeTitle": "Prescreening",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeDescription": "Uspješno poslano kao prijedlog koji je potrebno razmotriti",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeTitle": "Predloženo",
   "app.containers.admin.ideaStatuses.form.rejectedFieldCodeDescription": "Neprihvatljivo ili nije odabrano za daljnje postupanje",

--- a/front/app/translations/admin/lt-LT.json
+++ b/front/app/translations/admin/lt-LT.json
@@ -2707,8 +2707,6 @@
   "app.containers.admin.ideaStatuses.form.implementedFieldCodeTitle": "Įgyvendinta",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeDescription": "Pasiūlymas neatitinka reikalavimų",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeTitle": "Netinkamas",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeDescription": "Laukiama patikros",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeTitle": "Išankstinė atranka",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeDescription": "Sėkmingai pateiktas svarstyti pasiūlymas",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeTitle": "Siūloma",
   "app.containers.admin.ideaStatuses.form.rejectedFieldCodeDescription": "Netinkami arba neatrinkti tolesniam darbui",

--- a/front/app/translations/admin/lv-LV.json
+++ b/front/app/translations/admin/lv-LV.json
@@ -2707,8 +2707,6 @@
   "app.containers.admin.ideaStatuses.form.implementedFieldCodeTitle": "Īstenots",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeDescription": "Priekšlikums nav atbilstīgs",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeTitle": "Neatbilstoši",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeDescription": "Gaida skrīningu",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeTitle": "Iepriekšēja pārbaude",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeDescription": "Veiksmīgi iesniegts izskatīšanai kā priekšlikums",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeTitle": "Ierosināts",
   "app.containers.admin.ideaStatuses.form.rejectedFieldCodeDescription": "Neatbilstošs vai nav izvēlēts virzīšanai tālāk",

--- a/front/app/translations/admin/nb-NO.json
+++ b/front/app/translations/admin/nb-NO.json
@@ -2707,8 +2707,6 @@
   "app.containers.admin.ideaStatuses.form.implementedFieldCodeTitle": "Implementert",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeDescription": "Forslaget er ikke støtteberettiget",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeTitle": "Ikke kvalifisert",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeDescription": "Venter på screening",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeTitle": "Forhåndsscreening",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeDescription": "Vellykket innsendt som et forslag til vurdering",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeTitle": "Foreslått",
   "app.containers.admin.ideaStatuses.form.rejectedFieldCodeDescription": "Ikke kvalifisert eller ikke valgt til å gå videre",

--- a/front/app/translations/admin/nl-BE.json
+++ b/front/app/translations/admin/nl-BE.json
@@ -2707,8 +2707,6 @@
   "app.containers.admin.ideaStatuses.form.implementedFieldCodeTitle": "Uitgevoerd",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeDescription": "Voorstel komt niet in aanmerking",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeTitle": "Komt niet in aanmerking",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeDescription": "In afwachting van screening",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeTitle": "Voorscreening",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeDescription": "Succesvol ingediend als voorstel voor overweging",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeTitle": "Voorgesteld",
   "app.containers.admin.ideaStatuses.form.rejectedFieldCodeDescription": "Niet in aanmerking komend of niet geselecteerd om verder te gaan",

--- a/front/app/translations/admin/nl-NL.json
+++ b/front/app/translations/admin/nl-NL.json
@@ -2707,8 +2707,6 @@
   "app.containers.admin.ideaStatuses.form.implementedFieldCodeTitle": "Uitgevoerd",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeDescription": "Voorstel komt niet in aanmerking",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeTitle": "Komt niet in aanmerking",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeDescription": "In afwachting van screening",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeTitle": "Voorscreening",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeDescription": "Succesvol ingediend als voorstel voor overweging",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeTitle": "Voorgesteld",
   "app.containers.admin.ideaStatuses.form.rejectedFieldCodeDescription": "Niet in aanmerking komend of niet geselecteerd om verder te gaan",

--- a/front/app/translations/admin/pa-IN.json
+++ b/front/app/translations/admin/pa-IN.json
@@ -2707,8 +2707,6 @@
   "app.containers.admin.ideaStatuses.form.implementedFieldCodeTitle": "ਲਾਗੂ ਕੀਤਾ",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeDescription": "ਪ੍ਰਸਤਾਵ ਅਯੋਗ ਹੈ",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeTitle": "ਅਯੋਗ",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeDescription": "ਸਕ੍ਰੀਨਿੰਗ ਦੀ ਉਡੀਕ ਕੀਤੀ ਜਾ ਰਹੀ ਹੈ",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeTitle": "ਪ੍ਰੀਸਕਰੀਨਿੰਗ",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeDescription": "ਵਿਚਾਰ ਲਈ ਇੱਕ ਪ੍ਰਸਤਾਵ ਦੇ ਰੂਪ ਵਿੱਚ ਸਫਲਤਾਪੂਰਵਕ ਸਪੁਰਦ ਕੀਤਾ ਗਿਆ",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeTitle": "ਪ੍ਰਸਤਾਵਿਤ",
   "app.containers.admin.ideaStatuses.form.rejectedFieldCodeDescription": "ਅੱਗੇ ਵਧਣ ਲਈ ਅਯੋਗ ਜਾਂ ਨਹੀਂ ਚੁਣਿਆ ਗਿਆ",

--- a/front/app/translations/admin/pl-PL.json
+++ b/front/app/translations/admin/pl-PL.json
@@ -2707,8 +2707,6 @@
   "app.containers.admin.ideaStatuses.form.implementedFieldCodeTitle": "Wdrożony",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeDescription": "Wniosek nie kwalifikuje się",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeTitle": "Nie kwalifikuje się",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeDescription": "Oczekiwanie na badanie przesiewowe",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeTitle": "Kontrola wstępna",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeDescription": "Skutecznie przedłożony jako wniosek do rozpatrzenia",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeTitle": "Zaproponowany",
   "app.containers.admin.ideaStatuses.form.rejectedFieldCodeDescription": "Niekwalifikujący się lub niewybrany do dalszego etapu",

--- a/front/app/translations/admin/pt-BR.json
+++ b/front/app/translations/admin/pt-BR.json
@@ -2707,8 +2707,6 @@
   "app.containers.admin.ideaStatuses.form.implementedFieldCodeTitle": "Implementado",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeDescription": "A proposta não é elegível",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeTitle": "Inelegível",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeDescription": "Aguardando triagem",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeTitle": "Pré-triagem",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeDescription": "Submetido com sucesso como proposta para consideração",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeTitle": "Proposta",
   "app.containers.admin.ideaStatuses.form.rejectedFieldCodeDescription": "Inelegível ou não selecionado para avançar",

--- a/front/app/translations/admin/sr-Latn.json
+++ b/front/app/translations/admin/sr-Latn.json
@@ -2707,8 +2707,6 @@
   "app.containers.admin.ideaStatuses.form.implementedFieldCodeTitle": "Realizovano",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeDescription": "Proposal is ineligible",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeTitle": "Ineligible",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeDescription": "Awaiting screening",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeTitle": "Prescreening",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeDescription": "Uspešno poslato kao predlog koji je potrebno razmotriti",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeTitle": "Predloženo",
   "app.containers.admin.ideaStatuses.form.rejectedFieldCodeDescription": "Neprihvatljivo ili nije odabrano za dalji proces",

--- a/front/app/translations/admin/sr-SP.json
+++ b/front/app/translations/admin/sr-SP.json
@@ -2707,8 +2707,6 @@
   "app.containers.admin.ideaStatuses.form.implementedFieldCodeTitle": "Имплементирано",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeDescription": "Proposal is ineligible",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeTitle": "Ineligible",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeDescription": "Awaiting screening",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeTitle": "Prescreening",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeDescription": "Успешно поднет као предлог на разматрање",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeTitle": "Предложено",
   "app.containers.admin.ideaStatuses.form.rejectedFieldCodeDescription": "Не испуњава услове или није изабрано за напредовање",

--- a/front/app/translations/admin/sv-SE.json
+++ b/front/app/translations/admin/sv-SE.json
@@ -2707,8 +2707,6 @@
   "app.containers.admin.ideaStatuses.form.implementedFieldCodeTitle": "Genomfördes",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeDescription": "Förslaget är inte stödberättigande",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeTitle": "Ej valbar",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeDescription": "Väntar på screening",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeTitle": "Förhandsgranskning",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeDescription": "Skickades in som ett förslag för behandling",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeTitle": "Föreslagen",
   "app.containers.admin.ideaStatuses.form.rejectedFieldCodeDescription": "Oberättigad eller inte vald för att gå vidare",

--- a/front/app/translations/admin/tr-TR.json
+++ b/front/app/translations/admin/tr-TR.json
@@ -2707,8 +2707,6 @@
   "app.containers.admin.ideaStatuses.form.implementedFieldCodeTitle": "Uygulandı",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeDescription": "Teklif uygun değildir",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeTitle": "Uygun değil",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeDescription": "Tarama bekleniyor",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeTitle": "Ön Tarama",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeDescription": "Değerlendirilecek bir öneri olarak gönderildi",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeTitle": "Önerilen",
   "app.containers.admin.ideaStatuses.form.rejectedFieldCodeDescription": "Devam etmek için uygun değil veya seçilmedi",

--- a/front/app/translations/admin/ur-PK.json
+++ b/front/app/translations/admin/ur-PK.json
@@ -2707,8 +2707,6 @@
   "app.containers.admin.ideaStatuses.form.implementedFieldCodeTitle": "لاگو کیا",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeDescription": "تجویز نا اہل ہے۔",
   "app.containers.admin.ideaStatuses.form.ineligibleFieldCodeTitle": "نااہل",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeDescription": "اسکریننگ کا انتظار ہے۔",
-  "app.containers.admin.ideaStatuses.form.prescreeningFieldCodeTitle": "پری اسکریننگ",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeDescription": "غور کے لیے ایک تجویز کے طور پر کامیابی کے ساتھ پیش کر دیا گیا۔",
   "app.containers.admin.ideaStatuses.form.proposedFieldCodeTitle": "تجویز کردہ",
   "app.containers.admin.ideaStatuses.form.rejectedFieldCodeDescription": "آگے بڑھنے کے لیے نااہل یا منتخب نہیں کیا گیا۔",


### PR DESCRIPTION
# Changelog

## Fixed

Remove "Prescreening" again as category when creating/editing input statuses. ("Prescreening" is a locked status and therefore can't be picked as a category when creating/editing an input status. This reverts a mistake that was released earlier today to fix the crashing input status form.)