### PR TITLE
[TAN-3600] Don't raise MatomoMisconfigurationError if tenant not active or trial

### DIFF
--- a/back/engines/commercial/analytics/app/jobs/analytics/import_latest_matomo_data_job.rb
+++ b/back/engines/commercial/analytics/app/jobs/analytics/import_latest_matomo_data_job.rb
@@ -76,12 +76,17 @@ module Analytics
     def matomo_site_id
       app_config = AppConfiguration.instance
       site_id = app_config.settings.dig('matomo', 'tenant_site_id')
+      default_site_id = ENV['DEFAULT_MATOMO_TENANT_SITE_ID']
+      lifecycle = app_config.settings.dig('core', 'lifecycle_stage')
 
-      raise MatomoMisconfigurationError, <<~MSG if site_id.blank? || site_id == ENV['DEFAULT_MATOMO_TENANT_SITE_ID']
-        Matomo site (= #{site_id.inspect}) for tenant '#{app_config.id}' is misconfigured.
-      MSG
-
-      site_id
+      if (site_id.blank? || site_id == default_site_id) && ['active', 'trial'].include?(lifecycle)
+        puts "lifecycle: #{lifecycle}"
+        raise MatomoMisconfigurationError, <<~MSG
+          Matomo site (= #{site_id.inspect}) for tenant '#{app_config.id}' is misconfigured.
+        MSG
+      end
+     
+     site_id
     end
 
     class MatomoMisconfigurationError < RuntimeError; end

--- a/back/engines/commercial/analytics/app/jobs/analytics/import_latest_matomo_data_job.rb
+++ b/back/engines/commercial/analytics/app/jobs/analytics/import_latest_matomo_data_job.rb
@@ -85,7 +85,7 @@ module Analytics
         MSG
       end
 
-     site_id
+      site_id
     end
 
     class MatomoMisconfigurationError < RuntimeError; end

--- a/back/engines/commercial/analytics/app/jobs/analytics/import_latest_matomo_data_job.rb
+++ b/back/engines/commercial/analytics/app/jobs/analytics/import_latest_matomo_data_job.rb
@@ -76,15 +76,15 @@ module Analytics
     def matomo_site_id
       app_config = AppConfiguration.instance
       site_id = app_config.settings.dig('matomo', 'tenant_site_id')
-      default_site_id = ENV['DEFAULT_MATOMO_TENANT_SITE_ID']
+      default_site_id = ENV.fetch('DEFAULT_MATOMO_TENANT_SITE_ID')
       lifecycle = app_config.settings.dig('core', 'lifecycle_stage')
 
-      if (site_id.blank? || site_id == default_site_id) && ['active', 'trial'].include?(lifecycle)
+      if (site_id.blank? || site_id == default_site_id) && %w[active trial].include?(lifecycle)
         raise MatomoMisconfigurationError, <<~MSG
           Matomo site (= #{site_id.inspect}) for tenant '#{app_config.id}' is misconfigured.
         MSG
       end
-     
+
      site_id
     end
 

--- a/back/engines/commercial/analytics/app/jobs/analytics/import_latest_matomo_data_job.rb
+++ b/back/engines/commercial/analytics/app/jobs/analytics/import_latest_matomo_data_job.rb
@@ -80,7 +80,6 @@ module Analytics
       lifecycle = app_config.settings.dig('core', 'lifecycle_stage')
 
       if (site_id.blank? || site_id == default_site_id) && ['active', 'trial'].include?(lifecycle)
-        puts "lifecycle: #{lifecycle}"
         raise MatomoMisconfigurationError, <<~MSG
           Matomo site (= #{site_id.inspect}) for tenant '#{app_config.id}' is misconfigured.
         MSG

--- a/back/engines/commercial/analytics/spec/jobs/analytics/import_latest_matomo_data_job_spec.rb
+++ b/back/engines/commercial/analytics/spec/jobs/analytics/import_latest_matomo_data_job_spec.rb
@@ -72,8 +72,8 @@ RSpec.describe Analytics::ImportLatestMatomoDataJob do
   describe 'MatomoMisconfigurationError' do
     before do
       stub_const('ENV', ENV.to_h.merge(
-          'DEFAULT_MATOMO_TENANT_SITE_ID' => AppConfiguration.instance.settings('matomo', 'tenant_site_id')
-        ))  
+        'DEFAULT_MATOMO_TENANT_SITE_ID' => AppConfiguration.instance.settings('matomo', 'tenant_site_id')
+      ))
     end
 
     context 'when tenant has active lifecycle' do

--- a/back/engines/commercial/analytics/spec/jobs/analytics/import_latest_matomo_data_job_spec.rb
+++ b/back/engines/commercial/analytics/spec/jobs/analytics/import_latest_matomo_data_job_spec.rb
@@ -69,12 +69,67 @@ RSpec.describe Analytics::ImportLatestMatomoDataJob do
     end
   end
 
-  it 'raises an error if the configured matomo site is the default one' do
-    stub_const('ENV', ENV.to_h.merge(
-      'DEFAULT_MATOMO_TENANT_SITE_ID' => AppConfiguration.instance.settings('matomo', 'tenant_site_id')
-    ))
+  context 'when tenant has active lifecycle' do
+    it 'raises an error if the configured matomo site is the default one' do
+      stub_const('ENV', ENV.to_h.merge(
+        'DEFAULT_MATOMO_TENANT_SITE_ID' => AppConfiguration.instance.settings('matomo', 'tenant_site_id')
+      ))
 
-    expect { described_class.perform_now(Tenant.current.id) }
-      .to raise_error(described_class::MatomoMisconfigurationError)
+      expect(AppConfiguration.instance.settings.dig('core', 'lifecycle_stage')).to eq('active')
+      expect { described_class.perform_now(Tenant.current.id) }
+        .to raise_error(described_class::MatomoMisconfigurationError)
+    end
+  end
+
+  context 'when tenant has trial lifecycle' do
+    before do
+      AppConfiguration.instance.settings['core']['lifecycle_stage'] = 'trial'
+      AppConfiguration.instance.save!
+    end
+
+    after do
+      AppConfiguration.instance.settings['core']['lifecycle_stage'] = 'active'
+      AppConfiguration.instance.save!
+    end
+
+    it 'raises an error if the configured matomo site is the default one' do
+      stub_const('ENV', ENV.to_h.merge(
+        'DEFAULT_MATOMO_TENANT_SITE_ID' => AppConfiguration.instance.settings('matomo', 'tenant_site_id')
+      ))
+
+      expect(AppConfiguration.instance.settings.dig('core', 'lifecycle_stage')).to eq('trial')
+      expect { described_class.perform_now(Tenant.current.id) }
+        .to raise_error(described_class::MatomoMisconfigurationError)
+    end
+  end
+
+  context 'when tenant has demo lifecycle' do
+    before do
+      original_config = AppConfiguration.instance
+      demo_settings = original_config.settings.deep_dup
+      demo_settings['core']['lifecycle_stage'] = 'demo'
+      
+      allow(AppConfiguration).to receive(:instance).and_return(
+        double(
+          id: original_config.id,
+          created_at: original_config.created_at,
+          settings: demo_settings
+        )
+      )
+    end
+
+    it 'does not raise an error if the configured matomo site is the default one' do
+      pp AppConfiguration.instance.settings.dig('core', 'lifecycle_stage')
+      lifecycle = AppConfiguration.instance.settings.dig('core', 'lifecycle_stage')
+      pp ['active', 'trial'].include?(lifecycle)
+
+      stub_const('ENV', ENV.to_h.merge(
+        'DEFAULT_MATOMO_TENANT_SITE_ID' => AppConfiguration.instance.settings('matomo', 'tenant_site_id')
+      ))
+
+      expect(AppConfiguration.instance.settings.dig('core', 'lifecycle_stage')).to eq('demo')
+      expect { described_class.perform_now(Tenant.current.id) }
+        .to_not raise_error(described_class::MatomoMisconfigurationError)
+    end
   end
 end

--- a/back/engines/commercial/analytics/spec/jobs/analytics/import_latest_matomo_data_job_spec.rb
+++ b/back/engines/commercial/analytics/spec/jobs/analytics/import_latest_matomo_data_job_spec.rb
@@ -119,10 +119,6 @@ RSpec.describe Analytics::ImportLatestMatomoDataJob do
     end
 
     it 'does not raise an error if the configured matomo site is the default one' do
-      pp AppConfiguration.instance.settings.dig('core', 'lifecycle_stage')
-      lifecycle = AppConfiguration.instance.settings.dig('core', 'lifecycle_stage')
-      pp ['active', 'trial'].include?(lifecycle)
-
       stub_const('ENV', ENV.to_h.merge(
         'DEFAULT_MATOMO_TENANT_SITE_ID' => AppConfiguration.instance.settings('matomo', 'tenant_site_id')
       ))


### PR DESCRIPTION
# Changelog
## Technical
- [TAN-3600] Don't raise `MatomoMisconfigurationError` if tenant not active or trial
