### PR TITLE
E2E tests to verify appearance of status forms

### DIFF
--- a/front/app/containers/Admin/settings/statuses/components/EditStatusButton.tsx
+++ b/front/app/containers/Admin/settings/statuses/components/EditStatusButton.tsx
@@ -36,6 +36,7 @@ const EditStatusButton = ({
           buttonStyle="secondary-outlined"
           icon="edit"
           disabled={buttonDisabled}
+          data-testid="e2e-edit-status-button"
         >
           <FormattedMessage {...messages.editButtonLabel} />
         </Button>

--- a/front/app/containers/Admin/settings/statuses/containers/edit.tsx
+++ b/front/app/containers/Admin/settings/statuses/containers/edit.tsx
@@ -55,7 +55,7 @@ const Edit = ({ variant }: { variant: IdeaStatusParticipationMethod }) => {
     const { color, title_multiloc, description_multiloc, code, locked } =
       ideaStatus.data.attributes;
     return (
-      <>
+      <div data-testid="e2e-edit-status-page">
         <StyledGoBackButton onClick={goBack} />
         <Section>
           <StyledSectionTitle>
@@ -73,7 +73,7 @@ const Edit = ({ variant }: { variant: IdeaStatusParticipationMethod }) => {
             variant={variant}
           />
         </Section>
-      </>
+      </div>
     );
   }
 

--- a/front/app/containers/Admin/settings/statuses/containers/index.tsx
+++ b/front/app/containers/Admin/settings/statuses/containers/index.tsx
@@ -132,6 +132,7 @@ const IdeaStatuses = ({
           >
             <Box>
               <Button
+                data-testid="e2e-add-status-button"
                 buttonStyle="admin-dark"
                 icon="plus-circle"
                 linkTo={`/admin/settings/${variant}/statuses/new`}

--- a/front/app/containers/Admin/settings/statuses/containers/new.tsx
+++ b/front/app/containers/Admin/settings/statuses/containers/new.tsx
@@ -43,7 +43,7 @@ const NewIdeaStatus = ({
 
   if (tenantLocales && ideaStatuses) {
     return (
-      <Section>
+      <Section data-testid={'e2e-new-status-page'}>
         <GoBackButton onClick={goBack} />
         <StyledSectionTitle>
           <FormattedMessage {...messages.addIdeaStatus} />

--- a/front/app/containers/Admin/settings/statuses/containers/new.tsx
+++ b/front/app/containers/Admin/settings/statuses/containers/new.tsx
@@ -43,21 +43,23 @@ const NewIdeaStatus = ({
 
   if (tenantLocales && ideaStatuses) {
     return (
-      <Section data-testid={'e2e-new-status-page'}>
+      <div data-testid="e2e-new-status-page">
         <GoBackButton onClick={goBack} />
-        <StyledSectionTitle>
-          <FormattedMessage {...messages.addIdeaStatus} />
-        </StyledSectionTitle>
-        <IdeaStatusForm
-          defaultValues={{
-            color: '#b5b5b5',
-            code: 'custom',
-          }}
-          onSubmit={handleSubmit}
-          showCategorySelector
-          variant={variant}
-        />
-      </Section>
+        <Section>
+          <StyledSectionTitle>
+            <FormattedMessage {...messages.addIdeaStatus} />
+          </StyledSectionTitle>
+          <IdeaStatusForm
+            defaultValues={{
+              color: '#b5b5b5',
+              code: 'custom',
+            }}
+            onSubmit={handleSubmit}
+            showCategorySelector
+            variant={variant}
+          />
+        </Section>
+      </div>
     );
   }
 

--- a/front/cypress/e2e/admin/settings/ideation_status_form.cy.ts
+++ b/front/cypress/e2e/admin/settings/ideation_status_form.cy.ts
@@ -10,4 +10,9 @@ describe('Ideation status form', () => {
     cy.get('[data-testid="e2e-add-status-button"]').click();
     cy.get('[data-testid="e2e-new-status-page"]').should('exist');
   });
+
+  it('Shows the form when editing an existing ideation input status', () => {
+    cy.get('[data-testid="e2e-edit-status-button"]').first().click();
+    cy.get('[data-testid="e2e-edit-status-page"]').should('exist');
+  });
 });

--- a/front/cypress/e2e/admin/settings/ideation_status_form.cy.ts
+++ b/front/cypress/e2e/admin/settings/ideation_status_form.cy.ts
@@ -1,0 +1,13 @@
+// Test that the ideation input status form shows when creating a new status
+describe('Ideation status form', () => {
+  beforeEach(() => {
+    cy.setAdminLoginCookie();
+    cy.visit('/admin/settings/ideation/statuses');
+    cy.acceptCookies();
+  });
+
+  it('Shows form when creating a new ideation input status', () => {
+    cy.get('[data-testid="e2e-add-status-button"]').click();
+    cy.get('[data-testid="e2e-new-status-page"]').should('exist');
+  });
+});

--- a/front/cypress/e2e/admin/settings/proposals_status_form.cy.ts
+++ b/front/cypress/e2e/admin/settings/proposals_status_form.cy.ts
@@ -1,0 +1,18 @@
+// Test that the proposals input status form shows when creating a new status
+describe('Proposals status form', () => {
+  beforeEach(() => {
+    cy.setAdminLoginCookie();
+    cy.visit('/admin/settings/proposals/statuses');
+    cy.acceptCookies();
+  });
+
+  it('Shows form when creating a new proposals input status', () => {
+    cy.get('[data-testid="e2e-add-status-button"]').click();
+    cy.get('[data-testid="e2e-new-status-page"]').should('exist');
+  });
+
+  it('Shows the form when editing an existing proposals input status', () => {
+    cy.get('[data-testid="e2e-edit-status-button"]').first().click();
+    cy.get('[data-testid="e2e-edit-status-page"]').should('exist');
+  });
+});


### PR DESCRIPTION
Next to the checks added [here](https://github.com/CitizenLabDotCo/citizenlab/pull/10128), these basic "verify that things have loaded" tests would have caught yesterday's [bug](https://go-vocal.slack.com/archives/C01J9DHRJTE/p1737450703519269) as well.

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->
