### PR TITLE
[TAN-2795] Automatically assign project_default assignee to idea in idea_side_fx before_create

### DIFF
--- a/back/app/services/side_fx_idea_service.rb
+++ b/back/app/services/side_fx_idea_service.rb
@@ -4,14 +4,11 @@ class SideFxIdeaService
   include SideFxHelper
 
   def initialize
-    @automatic_assignment = false
     @old_phase_ids = []
     @old_cosponsor_ids = []
   end
 
-  def before_create(idea, user)
-    before_publish idea, user if idea.published?
-  end
+  def before_create(idea, user); end
 
   def after_create(idea, user)
     idea.update!(body_multiloc: TextImageService.new.swap_data_images_multiloc(idea.body_multiloc, field: :body_multiloc, imageable: idea))
@@ -37,7 +34,6 @@ class SideFxIdeaService
     @old_phase_ids = idea.phase_ids
     idea.body_multiloc = TextImageService.new.swap_data_images_multiloc(idea.body_multiloc, field: :body_multiloc, imageable: idea)
     idea.publication_status = 'published' if idea.submitted_or_published? && idea.idea_status&.public_post?
-    before_publish idea, user if idea.will_be_published?
   end
 
   def after_update(idea, user)
@@ -133,8 +129,6 @@ class SideFxIdeaService
   end
 
   private
-
-  def before_publish(idea, _user); end
 
   def after_submission(idea, user)
     add_autoreaction(idea)

--- a/back/app/services/side_fx_idea_service.rb
+++ b/back/app/services/side_fx_idea_service.rb
@@ -29,7 +29,7 @@ class SideFxIdeaService
     log_activities_if_cosponsors_added(idea, user)
   end
 
-  def before_update(idea, user)
+  def before_update(idea, _user)
     @old_cosponsor_ids = idea.cosponsor_ids
     @old_phase_ids = idea.phase_ids
     idea.body_multiloc = TextImageService.new.swap_data_images_multiloc(idea.body_multiloc, field: :body_multiloc, imageable: idea)

--- a/back/engines/commercial/idea_assignment/app/services/idea_assignment/patches/side_fx_idea_service.rb
+++ b/back/engines/commercial/idea_assignment/app/services/idea_assignment/patches/side_fx_idea_service.rb
@@ -15,17 +15,15 @@ module IdeaAssignment
         # remove_duplicate_survey_responses_on_publish(idea)
         return unless idea.assignee_id_previously_changed?
 
-        initiating_user = user_for_activity_on_anonymizable_item(idea, @automatic_assignment ? nil : user)
-        LogActivityJob.perform_later(idea, 'changed_assignee', initiating_user, idea.updated_at.to_i,
+        LogActivityJob.perform_later(idea, 'changed_assignee', user, idea.updated_at.to_i,
           payload: { change: idea.assignee_id_previous_change })
       end
 
-      def before_publish(idea, user)
+      def before_create(idea, user)
         super
         return if idea.assignee
 
         idea.assignee = IdeaAssignmentService.new.automatically_assigned_idea_assignee idea
-        @automatic_assignment = true if idea.assignee
       end
 
       private

--- a/back/engines/commercial/idea_assignment/spec/services/side_fx_idea_spec.rb
+++ b/back/engines/commercial/idea_assignment/spec/services/side_fx_idea_spec.rb
@@ -7,7 +7,7 @@ describe SideFxIdeaService do
   let(:user) { create(:user) }
 
   describe 'before create' do
-    let(:default_assignee) { create (:admin) }
+    let(:default_assignee) { create(:admin) }
     let(:project) { create(:project, default_assignee: default_assignee) }
 
     it 'sets the assignee to the default_assignee of the project' do

--- a/back/engines/commercial/idea_assignment/spec/services/side_fx_idea_spec.rb
+++ b/back/engines/commercial/idea_assignment/spec/services/side_fx_idea_spec.rb
@@ -54,22 +54,6 @@ describe SideFxIdeaService do
         expect { service.before_update(idea, nil) }.not_to change(idea, :assignee)
       end
     end
-
-    it 'sets the assignee to the default_assignee of the project on publish' do
-      default_assignee = create(:admin)
-      project = create(:project, default_assignee: default_assignee)
-      idea = create(:idea, project: project, publication_status: 'draft')
-      idea.publication_status = 'published'
-      expect { service.before_update(idea, user) }.to change { idea.assignee }.from(nil).to(default_assignee)
-    end
-
-    it "doesn't set the assignee if it's already set before publish" do
-      default_assignee = create(:admin)
-      project = create(:project, default_assignee: default_assignee)
-      idea = create(:idea, project: project, publication_status: 'draft', assignee: create(:admin))
-      idea.publication_status = 'published'
-      expect { service.before_update(idea, user) }.not_to(change { idea.assignee })
-    end
   end
 
   describe 'after_update' do

--- a/back/engines/commercial/idea_assignment/spec/services/side_fx_idea_spec.rb
+++ b/back/engines/commercial/idea_assignment/spec/services/side_fx_idea_spec.rb
@@ -7,18 +7,29 @@ describe SideFxIdeaService do
   let(:user) { create(:user) }
 
   describe 'before create' do
+    let(:default_assignee) { create (:admin) }
+    let(:project) { create(:project, default_assignee: default_assignee) }
+
     it 'sets the assignee to the default_assignee of the project' do
-      default_assignee = create(:admin)
-      project = create(:project, default_assignee: default_assignee)
-      idea = build(:idea, project: project)
+      idea = build(:idea, assignee: nil, project: project)
+      service.before_create(idea, user)
+      expect(idea.assignee).to eq default_assignee
+    end
+
+    it 'sets assignee for a draft idea' do
+      idea = build(:idea, project: project, assignee: nil, publication_status: 'draft')
+      service.before_create(idea, user)
+      expect(idea.assignee).to eq default_assignee
+    end
+
+    it 'sets assignee for a submitted idea' do
+      idea = build(:idea, project: project, assignee: nil, publication_status: 'submitted')
       service.before_create(idea, user)
       expect(idea.assignee).to eq default_assignee
     end
 
     it "doesn't change the assignee if it's already set" do
-      default_assignee = create(:admin)
       assignee = build(:admin)
-      project = create(:project, default_assignee: default_assignee)
       idea = build(:idea, project: project, assignee: assignee)
       service.before_create(idea, user)
       expect(idea.assignee).to eq assignee


### PR DESCRIPTION
@sebastienhoorens Please see the various comments I have made in the code in the PR here. Thanks.

# Changelog
## Fixed
- [TAN-2795]  Project default assignee now assigned to an idea at creation. This fixes case where assignee not set when idea created and prescreening active.
