### PR TITLE
[TAN-2795] Automatically set idea assignee when idea submitted

### DIFF
--- a/back/app/models/idea.rb
+++ b/back/app/models/idea.rb
@@ -283,6 +283,13 @@ class Idea < ApplicationRecord
     from != 'published' && to == 'published'
   end
 
+  def will_be_submitted?
+    # It would be better to foresee separate endpoints for publication,
+    # rather than relying on Rails dirty to detect publication.
+    from, to = publication_status_change
+    from != 'submitted' && to == 'submitted'
+  end
+
   def will_be_published?
     # It would be better to foresee separate endpoints for publication,
     # rather than relying on Rails dirty to detect publication.

--- a/back/app/models/idea.rb
+++ b/back/app/models/idea.rb
@@ -284,8 +284,6 @@ class Idea < ApplicationRecord
   end
 
   def will_be_submitted?
-    # It would be better to foresee separate endpoints for publication,
-    # rather than relying on Rails dirty to detect publication.
     from, to = publication_status_change
     from != 'submitted' && to == 'submitted'
   end

--- a/back/app/services/side_fx_idea_service.rb
+++ b/back/app/services/side_fx_idea_service.rb
@@ -10,7 +10,7 @@ class SideFxIdeaService
   end
 
   def before_create(idea, user)
-    before_publish idea, user if idea.published?
+    before_publish_or_submit idea, user if idea.submitted_or_published?
   end
 
   def after_create(idea, user)
@@ -37,7 +37,7 @@ class SideFxIdeaService
     @old_phase_ids = idea.phase_ids
     idea.body_multiloc = TextImageService.new.swap_data_images_multiloc(idea.body_multiloc, field: :body_multiloc, imageable: idea)
     idea.publication_status = 'published' if idea.submitted_or_published? && idea.idea_status&.public_post?
-    before_publish idea, user if idea.will_be_published?
+    before_publish_or_submit idea, user if idea.will_be_published? || idea.will_be_submitted?
   end
 
   def after_update(idea, user)
@@ -134,7 +134,7 @@ class SideFxIdeaService
 
   private
 
-  def before_publish(idea, _user); end
+  def before_publish_or_submit(idea, _user); end
 
   def after_submission(idea, user)
     add_autoreaction(idea)

--- a/back/app/services/side_fx_idea_service.rb
+++ b/back/app/services/side_fx_idea_service.rb
@@ -37,7 +37,7 @@ class SideFxIdeaService
     @old_phase_ids = idea.phase_ids
     idea.body_multiloc = TextImageService.new.swap_data_images_multiloc(idea.body_multiloc, field: :body_multiloc, imageable: idea)
     idea.publication_status = 'published' if idea.submitted_or_published? && idea.idea_status&.public_post?
-    before_publish_or_submit idea, user if idea.will_be_published? || idea.will_be_submitted?
+    before_publish_or_submit idea, user if idea.will_be_submitted? || idea.will_be_published?
   end
 
   def after_update(idea, user)

--- a/back/engines/commercial/idea_assignment/app/services/idea_assignment/patches/side_fx_idea_service.rb
+++ b/back/engines/commercial/idea_assignment/app/services/idea_assignment/patches/side_fx_idea_service.rb
@@ -20,7 +20,7 @@ module IdeaAssignment
           payload: { change: idea.assignee_id_previous_change })
       end
 
-      def before_publish(idea, user)
+      def before_publish_or_submit(idea, user)
         super
         return if idea.assignee
 


### PR DESCRIPTION
This PR changes when we check for idea assignee, and set if possible/needed.

We now check (and set if possible/needed) the idea assignee both before create and before update, and then only if the `idea.publication_status` is 'submitted' or 'published'.

This covers the cases where:
1. An idea is created with 'submitted' status
2. An idea is created with 'published' status
3. An idea is updated to 'submitted' status
4. An idea is updated to 'published' status

If the assignee is already set, then the `before_publish_or_submit` method will not change anything.

# Changelog
## Fixed
- [TAN-2795]  Fixes case where idea assignee not automatically set when idea submitted and prescreening active.
