### PR TITLE
[TAN-3358] Upgrade `ros-apartment` to v3.2.0

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -194,7 +194,7 @@ free_engines.each do |engine_name|
   gem engine_name, path: path if File.directory?(path)
 end
 
-gem 'ros-apartment', '~> 3.1.0', require: 'apartment'
+gem 'ros-apartment', '~> 3.2.0', require: 'apartment'
 
 commercial_engines = [
   'multi_tenancy',

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -1059,10 +1059,11 @@ GEM
       multi_json (~> 1.15)
       rgeo (>= 1.0.0)
     rinku (2.0.6)
-    ros-apartment (3.1.0)
-      activerecord (>= 6.1.0, < 7.2)
+    ros-apartment (3.2.0)
+      activerecord (>= 6.1.0, < 8.1)
+      activesupport (>= 6.1.0, < 8.1)
       parallel (< 2.0)
-      public_suffix (>= 2.0.5, < 6.0)
+      public_suffix (>= 2.0.5, <= 6.0.1)
       rack (>= 1.3.6, < 4.0)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
@@ -1402,7 +1403,7 @@ DEPENDENCIES
   rest-client
   rgeo-geojson
   rinku (~> 2)
-  ros-apartment (~> 3.1.0)
+  ros-apartment (~> 3.2.0)
   rspec-html-matchers (~> 0.10)
   rspec-its
   rspec-parameterized


### PR DESCRIPTION
# Changelog
## Technical
- [TAN-3358] Upgrade `ros-apartment` to v3.2.0. This is a prerequisite for upgrading Rails to v7.2 (or v8.0).
