### PR TITLE
Add currency formatting to "add to basket" button

### DIFF
--- a/front/app/components/ScreenReaderCurrencyValue/index.tsx
+++ b/front/app/components/ScreenReaderCurrencyValue/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { TCurrency } from 'api/app_configuration/types';
+import useAppConfiguration from 'api/app_configuration/useAppConfiguration';
 
 import { ScreenReaderOnly } from 'utils/a11y';
 import { useIntl } from 'utils/cl-intl';
@@ -9,11 +9,17 @@ import messages from './messages';
 
 interface Props {
   amount: number;
-  currency: TCurrency;
 }
 
-const ScreenReaderCurrencyValue = ({ amount, currency }: Props) => {
+const ScreenReaderCurrencyValue = ({ amount }: Props) => {
   const { formatMessage } = useIntl();
+  const { data: appConfig } = useAppConfiguration();
+
+  if (!appConfig) {
+    return null;
+  }
+
+  const currency = appConfig.data.attributes.settings.core.currency;
 
   // An extra check to prevent the component from crashing if the message is missing
   // TODO: Fix this the next time the file is edited.

--- a/front/app/components/VoteInputs/budgeting/AddToBasketButton/index.tsx
+++ b/front/app/components/VoteInputs/budgeting/AddToBasketButton/index.tsx
@@ -9,7 +9,6 @@ import {
 } from '@citizenlab/cl2-component-library';
 import { useSearchParams } from 'react-router-dom';
 
-import useAppConfiguration from 'api/app_configuration/useAppConfiguration';
 import useBasket from 'api/baskets/useBasket';
 import useVoting from 'api/baskets_ideas/useVoting';
 import useIdeaById from 'api/ideas/useIdeaById';
@@ -27,6 +26,7 @@ import {
 } from 'utils/actionDescriptors';
 import { trackEventByName } from 'utils/analytics';
 import { FormattedMessage, useIntl } from 'utils/cl-intl';
+import useFormatCurrency from 'utils/currency/useFormatCurrency';
 import eventEmitter from 'utils/eventEmitter';
 import { isNil } from 'utils/helperUtils';
 import { isPhaseActive } from 'utils/projectUtils';
@@ -48,24 +48,23 @@ const AddToBasketButton = ({
   phase,
   onIdeaPage,
 }: Props) => {
-  const { data: appConfig } = useAppConfiguration();
   const { data: idea } = useIdeaById(ideaId);
   const { getVotes, setVotes, numberOfVotesCast } = useVoting();
   const { formatMessage } = useIntl();
+  const formatCurrency = useFormatCurrency();
 
   // TODO: Fix this the next time the file is edited.
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const basketId = phase.relationships?.user_basket?.data?.id;
   const { data: basket } = useBasket(basketId);
   const ideaBudget = idea?.data.attributes.budget;
-  const currency = appConfig?.data.attributes.settings.core.currency;
 
   const ideaInBasket = !!getVotes?.(ideaId);
 
   const [searchParams] = useSearchParams();
   const isProcessing = searchParams.get('processing_vote') === ideaId;
 
-  if (!idea || !ideaBudget || !currency) {
+  if (!idea || !ideaBudget) {
     return null;
   }
 
@@ -182,11 +181,8 @@ const AddToBasketButton = ({
           >
             {ideaInBasket && <Icon mb="4px" fill="white" name="check" />}
             <FormattedMessage {...buttonMessage} />
-            <span aria-hidden>{` (${ideaBudget} ${currency})`}</span>
-            <ScreenReaderCurrencyValue
-              amount={ideaBudget}
-              currency={currency}
-            />
+            <span aria-hidden>{` (${formatCurrency(ideaBudget)})`}</span>
+            <ScreenReaderCurrencyValue amount={ideaBudget} />
           </Button>
         </div>
       </Tooltip>


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Apply currency formatting based on locale an currency to "add to basket" button.