### PR TITLE
[TAN-3705] Show moderated folders in BO 'Your projects' list

### DIFF
--- a/back/app/services/admin_publications_filtering_service.rb
+++ b/back/app/services/admin_publications_filtering_service.rb
@@ -101,6 +101,16 @@ class AdminPublicationsFilteringService
     scope.where.not(id: unmoderated_parents)
   end
 
+  # This filter removes AdminPublications that are for projects in folders that are still included in the scope.
+  # This is used by the BO 'your projects' list to avoid duplicates when a moderated project is in a moderated folder.
+  add_filter('remove_projects_in_filtered_folders') do |scope, options|
+    next scope unless (['true', true, '1'].include? options[:remove_projects_in_filtered_folders])
+
+    filtered_folders = scope.where(children_allowed: true)
+
+    scope.where(parent_id: nil).or(scope.where.not(parent_id: filtered_folders))
+  end
+
   add_filter('top_level_only') do |scope, options|
     [0, '0'].include?(options[:depth]) ? scope.where(depth: 0) : scope
   end

--- a/back/app/services/admin_publications_filtering_service.rb
+++ b/back/app/services/admin_publications_filtering_service.rb
@@ -103,8 +103,8 @@ class AdminPublicationsFilteringService
 
   # This filter excludes AdminPublications that are for projects in folders that are still included in the scope.
   # This is used by the BO 'your projects' list to avoid duplicates when a moderated project is in a moderated folder.
-  add_filter('exclude_projects_in_filtered_folders') do |scope, options|
-    next scope unless ['true', true, '1'].include? options[:exclude_projects_in_filtered_folders]
+  add_filter('exclude_projects_in_included_folders') do |scope, options|
+    next scope unless ['true', true, '1'].include? options[:exclude_projects_in_included_folders]
 
     filtered_folders = scope.where(children_allowed: true)
 

--- a/back/app/services/admin_publications_filtering_service.rb
+++ b/back/app/services/admin_publications_filtering_service.rb
@@ -101,10 +101,10 @@ class AdminPublicationsFilteringService
     scope.where.not(id: unmoderated_parents)
   end
 
-  # This filter removes AdminPublications that are for projects in folders that are still included in the scope.
+  # This filter excludes AdminPublications that are for projects in folders that are still included in the scope.
   # This is used by the BO 'your projects' list to avoid duplicates when a moderated project is in a moderated folder.
-  add_filter('remove_projects_in_filtered_folders') do |scope, options|
-    next scope unless (['true', true, '1'].include? options[:remove_projects_in_filtered_folders])
+  add_filter('exclude_projects_in_filtered_folders') do |scope, options|
+    next scope unless ['true', true, '1'].include? options[:exclude_projects_in_filtered_folders]
 
     filtered_folders = scope.where(children_allowed: true)
 

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -45,6 +45,7 @@ resource 'AdminPublication' do
       parameter :filter_can_moderate, 'Filter out the projects the current_user is not allowed to moderate. False by default', required: false
       parameter :filter_is_moderator_of, 'Filter out the publications the current_user is not moderator of. False by default', required: false
       parameter :filter_user_is_moderator_of, 'Filter out the publications the given user is moderator of (user id)', required: false
+      parameter :exclude_projects_in_included_folders, 'Exclude projects in included folders', required: false
       parameter :review_state, 'Filter by project review status (pending, approved)', required: false
 
       example_request 'List all admin publications' do
@@ -676,6 +677,7 @@ resource 'AdminPublication' do
       parameter :only_projects, 'Include projects only (no folders)', required: false
       parameter :filter_can_moderate, 'Filter out the projects the user is allowed to moderate. False by default', required: false
       parameter :filter_is_moderator_of, 'Filter out the publications the user is not moderator of. False by default', required: false
+      parameter :exclude_projects_in_included_folders, 'Exclude projects in included folders', required: false
 
       before do
         @moderator = create(:project_moderator, projects: [published_projects[0], published_projects[1]])
@@ -689,6 +691,18 @@ resource 'AdminPublication' do
         expect(json_response[:data].size).to eq 2
         expect(json_response[:data].map { |d| d.dig(:relationships, :publication, :data, :id) })
           .to match_array [published_projects[0].id, published_projects[1].id]
+      end
+
+      # This is how the FE requests the admin_publications to show in the 'Your projects' tab,
+      # to avoid showing projects twice (as a seperate item AND in a moderated folder)
+      example 'List only folders (none unless also folder mod) and root level projects user is moderator of' do
+        root_project = create(:project, admin_publication_attributes: { publication_status: 'published' })
+        moderator_roles = @moderator.roles << { type: 'project_moderator', project_id: root_project.id }
+        @moderator.update!(roles: moderator_roles)
+
+        do_request(filter_is_moderator_of: true, exclude_projects_in_included_folders: true)
+        assert_status 200
+        expect(publication_ids).to match_array [published_projects[0].id, published_projects[1].id, root_project.id]
       end
     end
   end
@@ -726,6 +740,7 @@ resource 'AdminPublication' do
       parameter :only_projects, 'Include projects only (no folders)', required: false
       parameter :filter_can_moderate, 'Filter out the projects the user is allowed to moderate. False by default', required: false
       parameter :filter_is_moderator_of, 'Filter out the publications the user is not moderator of. False by default', required: false
+      parameter :exclude_projects_in_included_folders, 'Exclude projects in included folders', required: false
 
       example 'List publications user is moderator of', document: false do
         do_request filter_is_moderator_of: true
@@ -737,6 +752,18 @@ resource 'AdminPublication' do
         do_request(filter_is_moderator_of: true, only_projects: true)
         assert_status 200
         expect(publication_ids).to match_array @folder.projects.pluck(:id)
+      end
+
+      # This is how the FE requests the admin_publications to show in the 'Your projects' tab,
+      # to avoid showing projects twice (as a seperate item AND in a moderated folder)
+      example 'List only folders and root level projects user is moderator of' do
+        root_project = create(:project, admin_publication_attributes: { publication_status: 'published' })
+        moderator_roles = @moderator.roles << { type: 'project_moderator', project_id: root_project.id }
+        @moderator.update!(roles: moderator_roles)
+
+        do_request(filter_is_moderator_of: true, exclude_projects_in_included_folders: true)
+        assert_status 200
+        expect(publication_ids).to match_array [project_folder.id, @folder.id, root_project.id].flatten
       end
     end
 

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -45,7 +45,7 @@ resource 'AdminPublication' do
       parameter :filter_can_moderate, 'Filter out the projects the current_user is not allowed to moderate. False by default', required: false
       parameter :filter_is_moderator_of, 'Filter out the publications the current_user is not moderator of. False by default', required: false
       parameter :filter_user_is_moderator_of, 'Filter out the publications the given user is moderator of (user id)', required: false
-      parameter :exclude_projects_in_included_folders, 'Exclude projects in included folders', required: false
+      parameter :exclude_projects_in_included_folders, 'Exclude projects in included folders (boolean)', required: false
       parameter :review_state, 'Filter by project review status (pending, approved)', required: false
 
       example_request 'List all admin publications' do
@@ -677,7 +677,7 @@ resource 'AdminPublication' do
       parameter :only_projects, 'Include projects only (no folders)', required: false
       parameter :filter_can_moderate, 'Filter out the projects the user is allowed to moderate. False by default', required: false
       parameter :filter_is_moderator_of, 'Filter out the publications the user is not moderator of. False by default', required: false
-      parameter :exclude_projects_in_included_folders, 'Exclude projects in included folders', required: false
+      parameter :exclude_projects_in_included_folders, 'Exclude projects in included folders (boolean)', required: false
 
       before do
         @moderator = create(:project_moderator, projects: [published_projects[0], published_projects[1]])
@@ -740,7 +740,7 @@ resource 'AdminPublication' do
       parameter :only_projects, 'Include projects only (no folders)', required: false
       parameter :filter_can_moderate, 'Filter out the projects the user is allowed to moderate. False by default', required: false
       parameter :filter_is_moderator_of, 'Filter out the publications the user is not moderator of. False by default', required: false
-      parameter :exclude_projects_in_included_folders, 'Exclude projects in included folders', required: false
+      parameter :exclude_projects_in_included_folders, 'Exclude projects in included folders (boolean)', required: false
 
       example 'List publications user is moderator of', document: false do
         do_request filter_is_moderator_of: true

--- a/front/app/api/admin_publications/types.ts
+++ b/front/app/api/admin_publications/types.ts
@@ -22,6 +22,7 @@ export interface IQueryParameters {
   review_state?: 'pending' | 'approved';
   filter_is_moderator_of?: boolean;
   filter_user_is_moderator_of?: string;
+  remove_projects_in_filtered_folders?: boolean;
   include_publications?: boolean;
 }
 

--- a/front/app/api/admin_publications/types.ts
+++ b/front/app/api/admin_publications/types.ts
@@ -22,7 +22,7 @@ export interface IQueryParameters {
   review_state?: 'pending' | 'approved';
   filter_is_moderator_of?: boolean;
   filter_user_is_moderator_of?: string;
-  exclude_projects_in_filtered_folders?: boolean;
+  exclude_projects_in_included_folders?: boolean;
   include_publications?: boolean;
 }
 

--- a/front/app/api/admin_publications/types.ts
+++ b/front/app/api/admin_publications/types.ts
@@ -22,7 +22,7 @@ export interface IQueryParameters {
   review_state?: 'pending' | 'approved';
   filter_is_moderator_of?: boolean;
   filter_user_is_moderator_of?: string;
-  remove_projects_in_filtered_folders?: boolean;
+  exclude_projects_in_filtered_folders?: boolean;
   include_publications?: boolean;
 }
 

--- a/front/app/api/admin_publications/types.ts
+++ b/front/app/api/admin_publications/types.ts
@@ -22,6 +22,7 @@ export interface IQueryParameters {
   review_state?: 'pending' | 'approved';
   filter_is_moderator_of?: boolean;
   filter_user_is_moderator_of?: string;
+  // This excludes projects that are already inside included folders from the result set, so we don't show duplicates.
   exclude_projects_in_included_folders?: boolean;
   include_publications?: boolean;
 }

--- a/front/app/containers/Admin/projects/all/index.tsx
+++ b/front/app/containers/Admin/projects/all/index.tsx
@@ -96,7 +96,7 @@ const AdminProjectsList = memo(({ className }: Props) => {
   const { data: moderatedAdminPublications } = useAdminPublications({
     publicationStatusFilter: ['published', 'draft', 'archived'],
     filter_is_moderator_of: true,
-    exclude_projects_in_filtered_folders: true,
+    exclude_projects_in_included_folders: true,
     search,
   });
 

--- a/front/app/containers/Admin/projects/all/index.tsx
+++ b/front/app/containers/Admin/projects/all/index.tsx
@@ -93,8 +93,8 @@ const AdminProjectsList = memo(({ className }: Props) => {
 
   const { data: moderatedAdminPublications } = useAdminPublications({
     publicationStatusFilter: ['published', 'draft', 'archived'],
-    onlyProjects: true,
     filter_is_moderator_of: true,
+    remove_projects_in_filtered_folders: true,
     search,
   });
 

--- a/front/app/containers/Admin/projects/all/index.tsx
+++ b/front/app/containers/Admin/projects/all/index.tsx
@@ -94,7 +94,7 @@ const AdminProjectsList = memo(({ className }: Props) => {
   const { data: moderatedAdminPublications } = useAdminPublications({
     publicationStatusFilter: ['published', 'draft', 'archived'],
     filter_is_moderator_of: true,
-    remove_projects_in_filtered_folders: true,
+    exclude_projects_in_filtered_folders: true,
     search,
   });
 

--- a/front/app/containers/Admin/projects/all/index.tsx
+++ b/front/app/containers/Admin/projects/all/index.tsx
@@ -91,6 +91,8 @@ const AdminProjectsList = memo(({ className }: Props) => {
 
   const userIsAdmin = isAdmin(authUser);
 
+  // Fetch the admin publications to show in the 'Your projects' tab,
+  // including the (unexpanded) folders the user is a moderator of.
   const { data: moderatedAdminPublications } = useAdminPublications({
     publicationStatusFilter: ['published', 'draft', 'archived'],
     filter_is_moderator_of: true,
@@ -98,6 +100,9 @@ const AdminProjectsList = memo(({ className }: Props) => {
     search,
   });
 
+  // Fetch the admin publications for projects in the 'Your projects' tab,
+  // including the projects in folders the user is a moderator of.
+  // Used for the (n projects) counter displayed in the tab.
   const { data: moderatedProjectAdminPublications } = useAdminPublications({
     publicationStatusFilter: ['published', 'draft', 'archived'],
     filter_is_moderator_of: true,

--- a/front/app/containers/Admin/projects/all/index.tsx
+++ b/front/app/containers/Admin/projects/all/index.tsx
@@ -98,6 +98,13 @@ const AdminProjectsList = memo(({ className }: Props) => {
     search,
   });
 
+  const { data: moderatedProjectAdminPublications } = useAdminPublications({
+    publicationStatusFilter: ['published', 'draft', 'archived'],
+    filter_is_moderator_of: true,
+    onlyProjects: true,
+    search,
+  });
+
   const { data: publishedAdminPublications } = useAdminPublications({
     publicationStatusFilter: ['published'],
     onlyProjects: true,
@@ -155,6 +162,10 @@ const AdminProjectsList = memo(({ className }: Props) => {
 
   const flatModeratedAdminPublications = flattenPagesData(
     moderatedAdminPublications
+  );
+
+  const flatModeratedProjectAdminPublications = flattenPagesData(
+    moderatedProjectAdminPublications
   );
 
   const flatPendingReviewAdminPublications = flattenPagesData(
@@ -232,7 +243,7 @@ const AdminProjectsList = memo(({ className }: Props) => {
             <Tab
               url="/admin/projects"
               label={`${formatMessage(messages.yourProjects)} (${
-                flatModeratedAdminPublications?.length || 0
+                flatModeratedProjectAdminPublications?.length || 0
               })`}
               active={activeTab === 'your-projects'}
             />

--- a/front/app/containers/Admin/projects/all/index.tsx
+++ b/front/app/containers/Admin/projects/all/index.tsx
@@ -92,7 +92,8 @@ const AdminProjectsList = memo(({ className }: Props) => {
   const userIsAdmin = isAdmin(authUser);
 
   // Fetch the admin publications to show in the 'Your projects' tab,
-  // including the (unexpanded) folders the user is a moderator of.
+  // including the (unexpanded) folders the user is a moderator of,
+  // but excluding the projects in those folders.
   const { data: moderatedAdminPublications } = useAdminPublications({
     publicationStatusFilter: ['published', 'draft', 'archived'],
     filter_is_moderator_of: true,
@@ -101,7 +102,8 @@ const AdminProjectsList = memo(({ className }: Props) => {
   });
 
   // Fetch the admin publications for projects in the 'Your projects' tab,
-  // including the projects in folders the user is a moderator of.
+  // including the projects in folders the user is a moderator of,
+  // but excluding the folders themselves.
   // Used for the (n projects) counter displayed in the tab.
   const { data: moderatedProjectAdminPublications } = useAdminPublications({
     publicationStatusFilter: ['published', 'draft', 'archived'],


### PR DESCRIPTION
- When user moderates a folder, the folder is now shown in the 'Your projects' list.
- The folder is initially shown in the collapsed state (as in the 'All' list)
- Moderated projects in a moderated folder are **_not_** also shown outside of their folder.
- Moderated projects in an unmoderated folder are still shown outside of their folder.
- Counter in tab still counts n of moderated projects (whether they are in a folder or not)

<details>
  <summary>SCREENSHOTS - Click me</summary>
  
  ### User is folder mod (and mod of 2 projects in folder) + mod of 1 project not in folder:  
  
  Folder collapsed on page refresh:
<img width="848" alt="Screenshot 2025-01-30 at 14 38 47" src="https://github.com/user-attachments/assets/300c7ab8-c9a9-4827-b8cf-86c0352303c4" />  
  
  Folder expanded:
<img width="848" alt="Screenshot 2025-01-30 at 14 38 55" src="https://github.com/user-attachments/assets/7015e7ad-e1ca-4d01-a306-7919cd3e33d1" />
   
  ### User is project mod of 2 projects (1 in folder, 1 not in folder):  
  
<img width="848" alt="Screenshot 2025-01-30 at 14 39 41" src="https://github.com/user-attachments/assets/91d5c25f-ded1-45a2-b5b9-44a1d589a4b3" />
</details>


# Changelog
## Changed
- [TAN-3705] Show moderated folders in BO 'Your projects' list
  - Moderator of folder will now see their moderated folder(s) in 'Your projects' tab.
  - Behaviour unchanged for moderators of only projects.
    - Example for user who moderates a folder (and the 2 projects it contains) + 1 project not in folder: [screenshot (initial state)](https://private-user-images.githubusercontent.com/3944042/408176041-300c7ab8-c9a9-4827-b8cf-86c0352303c4.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MzgyNTAwNjIsIm5iZiI6MTczODI0OTc2MiwicGF0aCI6Ii8zOTQ0MDQyLzQwODE3NjA0MS0zMDBjN2FiOC1jOWE5LTQ4MjctYjhjZi04NmMwMzUyMzAzYzQucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI1MDEzMCUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNTAxMzBUMTUwOTIyWiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9NTY2NGIxOTI1MzJlMWI3ZGEwODM5NDJlOTllNjNkZTYwYzQ4YzYyMmYxNDc4MTA1Zjc3NjU5NGIxYjE2MDA3NCZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QifQ.-S6ifdPVFTsPVuQahyebU0xiOKmdPAw80gi-bWE9WbM), [screenshot (folder expanded)](https://private-user-images.githubusercontent.com/3944042/408166167-7015e7ad-e1ca-4d01-a306-7919cd3e33d1.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MzgyNDg2ODEsIm5iZiI6MTczODI0ODM4MSwicGF0aCI6Ii8zOTQ0MDQyLzQwODE2NjE2Ny03MDE1ZTdhZC1lMWNhLTRkMDEtYTMwNi03OTE5Y2QzZTMzZDEucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI1MDEzMCUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNTAxMzBUMTQ0NjIxWiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9ODIzYTM1MzQ3MjFiYTA4MjhhMDNhM2UyNGY0MmFjYjZiYTgxYzUzNTlkMjdjMWZjMTAyNzc3NWU4ZWQ4NjczYSZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QifQ.4WY0HUncLgxeL_aJPouPtXh62s-2m8f8nd-OC15gvis)
    - Example for user who moderates 2 projects (1 in folder, 1 not in folder): [screenshot](https://private-user-images.githubusercontent.com/3944042/408165917-91d5c25f-ded1-45a2-b5b9-44a1d589a4b3.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MzgyNDg2ODEsIm5iZiI6MTczODI0ODM4MSwicGF0aCI6Ii8zOTQ0MDQyLzQwODE2NTkxNy05MWQ1YzI1Zi1kZWQxLTQ1YTItYjViOS00NGExZDU4OWE0YjMucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI1MDEzMCUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNTAxMzBUMTQ0NjIxWiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9NzA1YTI4ODgyNDZmZWMxMTM2MjE4MTIyMzI0ZGQ5YjczOGQ1ZmNlNjg2NTcxOGVjODViNjM5MmI1M2Q1MDU3MiZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QifQ.yGjdTyq_JqmzsFLte58T6uRHhlwdjs4bE68mf52dS38)
