### PR TITLE
[TAN-3644] Fix link to idea in mention_in_internal_comment notification

### DIFF
--- a/back/app/serializers/web_api/v1/notifications/internal_comment_notification_serializer.rb
+++ b/back/app/serializers/web_api/v1/notifications/internal_comment_notification_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class WebApi::V1::Notifications::InternalCommentNotificationSerializer < WebApi::V1::Notifications::NotificationSerializer
-  attributes :project_id, :internal_comment_id
+  attributes :project_id, :internal_comment_id, :idea_id
 
   attribute :initiating_user_first_name do |object|
     object.initiating_user&.first_name

--- a/front/app/api/mentions/types.ts
+++ b/front/app/api/mentions/types.ts
@@ -10,7 +10,7 @@ export type MentionRoles = 'admin' | 'moderator';
 
 export type IQueryParameters = {
   mention: string;
-  post_id?: string;
+  idea_id?: string;
   roles?: MentionRoles[];
 };
 

--- a/front/app/api/notifications/types.ts
+++ b/front/app/api/notifications/types.ts
@@ -179,7 +179,7 @@ export interface IInternalCommentNotificationData
     initiating_user_slug: string | null;
     post_slug: string | null;
     post_title_multiloc: Multiloc;
-    post_id: string;
+    idea_id: string;
     internal_comment_id: string;
     project_id: string | null;
   };

--- a/front/app/components/UI/MentionsTextArea/index.tsx
+++ b/front/app/components/UI/MentionsTextArea/index.tsx
@@ -219,7 +219,7 @@ const MentionsTextArea = ({
     if (isString(query) && !isEmpty(query)) {
       const queryParameters = {
         mention: query.toLowerCase(),
-        post_id: postId,
+        idea_id: postId,
         roles,
       };
 

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/InternalCommentNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/InternalCommentNotification/index.tsx
@@ -34,8 +34,8 @@ const getNotificationMessage = (
 };
 
 const InternalCommentNotification = memo<Props>(({ notification }) => {
-  const { project_id, post_id, internal_comment_id } = notification.attributes;
-  const linkTo: RouteType | null = `/admin/projects/${project_id}/ideas/${post_id}#${internal_comment_id}`;
+  const { project_id, idea_id, internal_comment_id } = notification.attributes;
+  const linkTo: RouteType | null = `/admin/projects/${project_id}/ideas/${idea_id}#${internal_comment_id}`;
 
   // TODO: Fix this the next time the file is edited.
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition


### PR DESCRIPTION
Looks like this was a hangover from when we removed the `post` polymorphic model which was used as a representation of `idea` or `initiative`.

The FE was trying to using a `post_id` attribute on the `notification` that no longer exists.

This PR serializes `idea_id` in the `InternalCommentNotificationSerialzer`, defines a new `idea_id` type & uses it in the FE in place of the old `post_id` to construct a valid link to the related idea.

Since all the internal comment notification serializers inherit from this serializer, the `idea_id` should be serialized by them all, and since the FE uses `IInternalCommentNotificationData` for all the internal comment notifications (.e.g `getNotificationMessage` [here](https://github.com/CitizenLabDotCo/citizenlab/blob/99e324a8db0759daef1957acd121280f83781edc/front/app/containers/MainHeader/Components/NotificationMenu/components/InternalCommentNotification/index.tsx#L17-L32)), this should also fix any similar issues for the other internal comment notifications.

# Changelog
## Fixed
- [TAN-3644] Notifications of internal comments on ideas now link to the related idea again.
