### PR TITLE
[TAN-3680] Do not show projects in draft folder in open to participation widget

### DIFF
--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -134,6 +134,12 @@ class Project < ApplicationRecord
     where(id: project_ids)
   }
 
+  scope :not_in_draft_folder, lambda {
+    joins(:admin_publication)
+      .joins("LEFT OUTER JOIN admin_publications parents ON admin_publications.parent_id = parents.id")
+      .where("admin_publications.parent_id IS NULL OR parents.publication_status != 'draft'")
+  }
+
   alias project_id id
 
   delegate :ever_published?, :never_published?, to: :admin_publication, allow_nil: true

--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -136,7 +136,7 @@ class Project < ApplicationRecord
 
   scope :not_in_draft_folder, lambda {
     joins(:admin_publication)
-      .joins("LEFT OUTER JOIN admin_publications parents ON admin_publications.parent_id = parents.id")
+      .joins('LEFT OUTER JOIN admin_publications parents ON admin_publications.parent_id = parents.id')
       .where("admin_publications.parent_id IS NULL OR parents.publication_status != 'draft'")
   }
 

--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -136,8 +136,8 @@ class Project < ApplicationRecord
 
   scope :not_in_draft_folder, lambda {
     joins(:admin_publication)
-      .joins('LEFT OUTER JOIN admin_publications parents ON admin_publications.parent_id = parents.id')
-      .where("admin_publications.parent_id IS NULL OR parents.publication_status != 'draft'")
+      .joins('LEFT OUTER JOIN admin_publications AS parent_pubs ON admin_publications.parent_id = parent_pubs.id')
+      .where("admin_publications.parent_id IS NULL OR parent_pubs.publication_status != 'draft'")
   }
 
   alias project_id id

--- a/back/app/services/projects_finder_service.rb
+++ b/back/app/services/projects_finder_service.rb
@@ -15,7 +15,7 @@ class ProjectsFinderService
   # => { projects: [Project], descriptor_pairs: { <project.id>: { <action_descriptors> }, ... } }
   def participation_possible
     subquery = @projects
-      .joins('INNER JOIN admin_publications AS admin_publications ON admin_publications.publication_id = projects.id')
+      .not_in_draft_folder # This includes a LEFT OUTER JOIN with admin_publications
       .where(admin_publications: { publication_status: 'published' })
 
     # Projects with active participatory (not information) phase & include the phases.end_at column

--- a/back/spec/models/project_spec.rb
+++ b/back/spec/models/project_spec.rb
@@ -127,19 +127,19 @@ RSpec.describe Project do
 
   describe "'not in draft folder' scope" do
     let(:project1) { create(:project) }
-    let(:draft_folder) do  
+    let(:draft_folder) do
       create(:project_folder, admin_publication_attributes: { publication_status: 'draft' }, projects: [project1])
     end
 
     let(:project2) { create(:project) }
-    let(:published_folder) do  
+    let(:published_folder) do
       create(:project_folder, admin_publication_attributes: { publication_status: 'published' }, projects: [project2])
     end
 
     let(:project3) { create(:project) }
 
     it 'returns projects not in a draft folder' do
-      expect(Project.not_in_draft_folder).to match_array([project2, project3])
+      expect(described_class.not_in_draft_folder).to match_array([project2, project3])
     end
   end
 end

--- a/back/spec/models/project_spec.rb
+++ b/back/spec/models/project_spec.rb
@@ -124,4 +124,22 @@ RSpec.describe Project do
       expect(project.preview_token).not_to eq(old_token)
     end
   end
+
+  describe "'not in draft folder' scope" do
+    let(:project1) { create(:project) }
+    let(:draft_folder) do  
+      create(:project_folder, admin_publication_attributes: { publication_status: 'draft' }, projects: [project1])
+    end
+
+    let(:project2) { create(:project) }
+    let(:published_folder) do  
+      create(:project_folder, admin_publication_attributes: { publication_status: 'published' }, projects: [project2])
+    end
+
+    let(:project3) { create(:project) }
+
+    it 'returns projects not in a draft folder' do
+      expect(Project.not_in_draft_folder).to match_array([project2, project3])
+    end
+  end
 end

--- a/back/spec/models/project_spec.rb
+++ b/back/spec/models/project_spec.rb
@@ -126,17 +126,17 @@ RSpec.describe Project do
   end
 
   describe "'not in draft folder' scope" do
-    let(:project1) { create(:project) }
-    let(:draft_folder) do
+    let!(:project1) { create(:project) }
+    let!(:draft_folder) do
       create(:project_folder, admin_publication_attributes: { publication_status: 'draft' }, projects: [project1])
     end
 
-    let(:project2) { create(:project) }
-    let(:published_folder) do
+    let!(:project2) { create(:project) }
+    let!(:published_folder) do
       create(:project_folder, admin_publication_attributes: { publication_status: 'published' }, projects: [project2])
     end
 
-    let(:project3) { create(:project) }
+    let!(:project3) { create(:project) }
 
     it 'returns projects not in a draft folder' do
       expect(described_class.not_in_draft_folder).to match_array([project2, project3])

--- a/back/spec/services/projects_finder_service_spec.rb
+++ b/back/spec/services/projects_finder_service_spec.rb
@@ -20,6 +20,14 @@ describe ProjectsFinderService do
       expect(result[:projects][0].id).to eq active_ideation_project.id
     end
 
+    it 'excludes projects in draft folder' do
+      folder = create(:project_folder, projects: [active_ideation_project])
+      folder.admin_publication.update!(publication_status: 'draft')
+
+      expect(Project.count).to eq 3
+      expect(result[:projects].size).to eq 0
+    end
+
     it 'excludes projects without active participatory (not information) phase' do
       expect(Project.count).to eq 3
       expect(result[:projects].size).to eq 1


### PR DESCRIPTION
# Changelog
## Fixed
- [TAN-3680] Do not show projects in draft folder in 'Open to participation' widget
