### PR TITLE
[TAN-3688] Remove GOOGLE_MAPS_API_KEY

### DIFF
--- a/env_files/front-secret.example.env
+++ b/env_files/front-secret.example.env
@@ -1,1 +1,1 @@
-GOOGLE_MAPS_API_KEY=
+

--- a/front/app/containers/App/constants-commonjs.js
+++ b/front/app/containers/App/constants-commonjs.js
@@ -10,13 +10,11 @@ exports.appLocalesMomentPairs =
   exports.GRAPHQL_HOST =
   exports.API_PORT =
   exports.API_HOST =
-  exports.GOOGLE_MAPS_API_KEY =
   exports.API_PATH =
   exports.AUTH_PATH =
     void 0;
 exports.AUTH_PATH = '/auth';
 exports.API_PATH = '/web_api/v1';
-exports.GOOGLE_MAPS_API_KEY = process.env.GOOGLE_MAPS_API_KEY || '';
 exports.API_HOST =
   process.env.API_HOST ||
   (typeof window === 'undefined' ? 'localhost' : window.location.hostname);

--- a/front/app/containers/App/constants.ts
+++ b/front/app/containers/App/constants.ts
@@ -1,6 +1,5 @@
 export const AUTH_PATH = '/auth';
 export const API_PATH = '/web_api/v1';
-export const GOOGLE_MAPS_API_KEY = process.env.GOOGLE_MAPS_API_KEY || '';
 export const API_HOST =
   process.env.API_HOST ||
   (typeof window === 'undefined' ? 'localhost' : window.location.hostname);

--- a/front/vite.config.ts
+++ b/front/vite.config.ts
@@ -74,13 +74,6 @@ export default defineConfig(({ mode }) => {
         },
         overlay: false,
       }),
-      createHtmlPlugin({
-        inject: {
-          data: {
-            GOOGLE_MAPS_API_KEY: process.env.GOOGLE_MAPS_API_KEY,
-          },
-        },
-      }),
       ...[
         sourceMapToSentry &&
           sentryVitePlugin({
@@ -156,7 +149,6 @@ export default defineConfig(({ mode }) => {
         CIRCLE_BRANCH: process.env.CIRCLE_BRANCH,
         MATOMO_HOST: process.env.MATOMO_HOST,
         POSTHOG_API_KEY: process.env.POSTHOG_API_KEY,
-        GOOGLE_MAPS_API_KEY: process.env.GOOGLE_MAPS_API_KEY,
       },
     },
   };

--- a/front/vite.config.ts
+++ b/front/vite.config.ts
@@ -6,7 +6,6 @@ import dotenv from 'dotenv';
 import { defineConfig } from 'vite';
 import checker from 'vite-plugin-checker';
 import commonjs from 'vite-plugin-commonjs';
-import { createHtmlPlugin } from 'vite-plugin-html';
 import tsconfigPaths from 'vite-plugin-tsconfig-paths';
 
 // Load environment variables using dotenv


### PR DESCRIPTION
GOOGLE_MAPS_API_KEY is no longer in use, but was visible in `min.js` which presented a risk it could be used by someone at our expense.

# Changelog
## Technical
- [TAN-3688] Remove GOOGLE_MAPS_API_KEY from FE - no longer in use
