### PR TITLE
TAN-3750/Fix translations of tooltips when vote/like buttons are disabled

### DIFF
--- a/front/app/components/ReactionControl/ReactionButton.tsx
+++ b/front/app/components/ReactionControl/ReactionButton.tsx
@@ -407,14 +407,16 @@ const ReactionButton = ({
     const describedById = disabledReason ? `tooltip-${ideaId}` : undefined;
 
     const disabledMessage = disabledReasonMessage && (
-      <FormattedMessage
-        {...disabledReasonMessage}
-        values={{
-          enabledFromDate,
-          projectName,
-        }}
-        id={describedById}
-      />
+      // We can't put id on FormattedMessage because it'll overwrite the message descriptor's id.
+      <span id={describedById}>
+        <FormattedMessage
+          {...disabledReasonMessage}
+          values={{
+            enabledFromDate,
+            projectName,
+          }}
+        />
+      </span>
     );
 
     return (

--- a/front/app/components/ReactionControl/ReactionButton.tsx
+++ b/front/app/components/ReactionControl/ReactionButton.tsx
@@ -407,7 +407,9 @@ const ReactionButton = ({
     const describedById = disabledReason ? `tooltip-${ideaId}` : undefined;
 
     const disabledMessage = disabledReasonMessage && (
-      // We can't put id on FormattedMessage because it'll overwrite the message descriptor's id.
+      // We can't put id on FormattedMessage:
+      // - If it's after the message descriptor, it'll overwrite the message descriptor's id.
+      // - It it's before the message descriptor, it'll be overwritten by the message descriptor's id.
       <span id={describedById}>
         <FormattedMessage
           {...disabledReasonMessage}


### PR DESCRIPTION
<img width="853" alt="Screenshot 2025-02-05 at 10 55 23" src="https://github.com/user-attachments/assets/0d2b6171-4de4-4f4f-a79e-2b3e04eb362a" />

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Translations of tooltips when vote/like buttons were disabled. ([Screenshot of bug](https://github.com/user-attachments/assets/450e1073-113b-4b6c-aef5-8ea990c351a1))