### PR TITLE
Add handling for "question_skipped" state in form controls

### DIFF
--- a/front/app/components/Form/Components/Controls/ImageMultichoiceControl.tsx
+++ b/front/app/components/Form/Components/Controls/ImageMultichoiceControl.tsx
@@ -61,11 +61,12 @@ const ImageMultichoiceControl = ({
 
     return () => {
       // 🌟 On unmount: If no value was set, mark as "question_skipped"
-      if (data === undefined || data === null) {
+      if (data === undefined) {
         handleChange(path, 'question_skipped');
       }
     };
-  }, [data, handleChange, path]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   if (!visible) {
     return null;

--- a/front/app/components/Form/Components/Controls/ImageMultichoiceControl.tsx
+++ b/front/app/components/Form/Components/Controls/ImageMultichoiceControl.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import {
   Box,
@@ -53,6 +53,19 @@ const ImageMultichoiceControl = ({
 
   const maxItems = schema.maxItems;
   const minItems = schema.minItems;
+
+  useEffect(() => {
+    if (data === 'question_skipped') {
+      handleChange(path, undefined);
+    }
+
+    return () => {
+      // 🌟 On unmount: If no value was set, mark as "question_skipped"
+      if (data === undefined || data === null) {
+        handleChange(path, 'question_skipped');
+      }
+    };
+  }, [data, handleChange, path]);
 
   if (!visible) {
     return null;

--- a/front/app/components/Form/Components/Controls/LinearScaleControl.tsx
+++ b/front/app/components/Form/Components/Controls/LinearScaleControl.tsx
@@ -77,6 +77,19 @@ const LinearScaleControl = ({
     }
   }, [data, getAriaValueText, minimum, maximum]);
 
+  useEffect(() => {
+    if (data === 'question_skipped') {
+      handleChange(path, undefined);
+    }
+
+    return () => {
+      // 🌟 On unmount: If no value was set, mark as "question_skipped"
+      if (data === undefined || data === null) {
+        handleChange(path, 'question_skipped');
+      }
+    };
+  }, [data, handleChange, path]);
+
   if (!visible) {
     return null;
   }

--- a/front/app/components/Form/Components/Controls/LinearScaleControl.tsx
+++ b/front/app/components/Form/Components/Controls/LinearScaleControl.tsx
@@ -88,7 +88,8 @@ const LinearScaleControl = ({
         handleChange(path, 'question_skipped');
       }
     };
-  }, [data, handleChange, path]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   if (!visible) {
     return null;

--- a/front/app/components/Form/Components/Controls/LinearScaleControl.tsx
+++ b/front/app/components/Form/Components/Controls/LinearScaleControl.tsx
@@ -84,7 +84,7 @@ const LinearScaleControl = ({
 
     return () => {
       // 🌟 On unmount: If no value was set, mark as "question_skipped"
-      if (data === undefined || data === null) {
+      if (data === undefined) {
         handleChange(path, 'question_skipped');
       }
     };

--- a/front/app/components/Form/Components/Controls/MultiSelectControl.tsx
+++ b/front/app/components/Form/Components/Controls/MultiSelectControl.tsx
@@ -54,7 +54,8 @@ const MultiSelectControl = ({
         handleChange(path, 'question_skipped');
       }
     };
-  }, [data, handleChange, path]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   if (!visible) {
     return null;

--- a/front/app/components/Form/Components/Controls/MultiSelectControl.tsx
+++ b/front/app/components/Form/Components/Controls/MultiSelectControl.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { Box, Text, useBreakpoint } from '@citizenlab/cl2-component-library';
 import {
@@ -42,6 +42,19 @@ const MultiSelectControl = ({
   const [didBlur, setDidBlur] = useState(false);
   const options = getOptions(schema, 'multi');
   const isSmallerThanPhone = useBreakpoint('phone');
+
+  useEffect(() => {
+    if (data === 'question_skipped') {
+      handleChange(path, undefined);
+    }
+
+    return () => {
+      // 🌟 On unmount: If no value was set, mark as "question_skipped"
+      if (data === undefined || data === null) {
+        handleChange(path, 'question_skipped');
+      }
+    };
+  }, [data, handleChange, path]);
 
   if (!visible) {
     return null;

--- a/front/app/components/Form/Components/Controls/MultiSelectControl.tsx
+++ b/front/app/components/Form/Components/Controls/MultiSelectControl.tsx
@@ -50,7 +50,7 @@ const MultiSelectControl = ({
 
     return () => {
       // 🌟 On unmount: If no value was set, mark as "question_skipped"
-      if (data === undefined || data === null) {
+      if (data === undefined) {
         handleChange(path, 'question_skipped');
       }
     };

--- a/front/app/components/Form/Components/Controls/RatingControl.tsx
+++ b/front/app/components/Form/Components/Controls/RatingControl.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 import {
   Box,
@@ -40,6 +40,19 @@ const RatingControl = ({
   const maximum = schema.maximum ?? 10;
   const answerNotPublic = uischema.options?.answer_visible_to === 'admins';
   const sliderRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (data === 'question_skipped') {
+      handleChange(path, undefined);
+    }
+
+    return () => {
+      // 🌟 On unmount: If no value was set, mark as "question_skipped"
+      if (data === undefined || data === null) {
+        handleChange(path, 'question_skipped');
+      }
+    };
+  }, [data, handleChange, path]);
 
   if (!visible) {
     return null;

--- a/front/app/components/Form/Components/Controls/RatingControl.tsx
+++ b/front/app/components/Form/Components/Controls/RatingControl.tsx
@@ -52,7 +52,8 @@ const RatingControl = ({
         handleChange(path, 'question_skipped');
       }
     };
-  }, [data, handleChange, path]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   if (!visible) {
     return null;

--- a/front/app/components/Form/Components/Controls/RatingControl.tsx
+++ b/front/app/components/Form/Components/Controls/RatingControl.tsx
@@ -48,7 +48,7 @@ const RatingControl = ({
 
     return () => {
       // 🌟 On unmount: If no value was set, mark as "question_skipped"
-      if (data === undefined || data === null) {
+      if (data === undefined) {
         handleChange(path, 'question_skipped');
       }
     };

--- a/front/app/components/Form/Components/Controls/SingleSelectRadioEnumControl.tsx
+++ b/front/app/components/Form/Components/Controls/SingleSelectRadioEnumControl.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { Box, Text, Radio } from '@citizenlab/cl2-component-library';
 import {
@@ -43,6 +43,19 @@ const SingleSelectRadioEnumControl = ({
   const [didBlur, setDidBlur] = useState(false);
   const options = getOptions(schema, 'singleEnum', uischema);
   const answerNotPublic = uischema.options?.answer_visible_to === 'admins';
+
+  useEffect(() => {
+    if (data === 'question_skipped') {
+      handleChange(path, undefined);
+    }
+
+    return () => {
+      // 🌟 On unmount: If no value was set, mark as "question_skipped"
+      if (data === undefined || data === null) {
+        handleChange(path, 'question_skipped');
+      }
+    };
+  }, [data, handleChange, path]);
 
   if (!visible) {
     return null;

--- a/front/app/components/Form/Components/Controls/SingleSelectRadioEnumControl.tsx
+++ b/front/app/components/Form/Components/Controls/SingleSelectRadioEnumControl.tsx
@@ -51,7 +51,7 @@ const SingleSelectRadioEnumControl = ({
 
     return () => {
       // 🌟 On unmount: If no value was set, mark as "question_skipped"
-      if (data === undefined || data === null) {
+      if (data === undefined) {
         handleChange(path, 'question_skipped');
       }
     };

--- a/front/app/components/Form/Components/Controls/SingleSelectRadioEnumControl.tsx
+++ b/front/app/components/Form/Components/Controls/SingleSelectRadioEnumControl.tsx
@@ -55,7 +55,8 @@ const SingleSelectRadioEnumControl = ({
         handleChange(path, 'question_skipped');
       }
     };
-  }, [data, handleChange, path]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   if (!visible) {
     return null;

--- a/front/app/components/Form/Components/Controls/visibilityUtils.ts
+++ b/front/app/components/Form/Components/Controls/visibilityUtils.ts
@@ -91,7 +91,10 @@ const validateSchemaCondition = (
   if (Array.isArray(value)) {
     // For arrays, check if at least one element passes validation. Important for multi-select and image-select
     return value.some((val) => ajv.validate(schema, val));
-  } else if (schema.enum?.includes('no_answer') && value === undefined) {
+  } else if (
+    schema.enum?.includes('no_answer') &&
+    value === 'question_skipped'
+  ) {
     return true;
   }
 

--- a/front/app/components/Form/Components/Layouts/utils.ts
+++ b/front/app/components/Form/Components/Layouts/utils.ts
@@ -79,7 +79,12 @@ export const getSanitizedFormData = (data) => {
   const sanitizedFormData = {};
   forOwn(data, (value, key) => {
     sanitizedFormData[key] =
-      value === null || value === '' || value === false ? undefined : value;
+      value === null ||
+      value === '' ||
+      value === false ||
+      value === 'question_skipped'
+        ? undefined
+        : value;
   });
 
   return sanitizedFormData;


### PR DESCRIPTION
# Changelog


## Fixed
- Add temporary fix to ensure that that pages with skipped logic are correctly handled even when all fields on the page have no responses yet.
