### PR TITLE
Tan 3788/swap fields

### DIFF
--- a/front/app/containers/Admin/projects/project/description/index.tsx
+++ b/front/app/containers/Admin/projects/project/description/index.tsx
@@ -126,7 +126,11 @@ const ProjectDescription = memo<
 
   if (!isNilOrError(project)) {
     return (
-      <Box ref={containerRef}>
+      <Box
+        // To improve: have standardize page height calculation for all admin pages
+        height="100vh"
+        ref={containerRef}
+      >
         <SectionTitle>
           <FormattedMessage {...messages.titleDescription} />
         </SectionTitle>

--- a/front/app/containers/Admin/projects/project/description/index.tsx
+++ b/front/app/containers/Admin/projects/project/description/index.tsx
@@ -136,48 +136,48 @@ const ProjectDescription = memo<
 
         <Section>
           <SectionField>
-            <TextAreaMultilocWithLocaleSwitcher
-              id="project-description-preview"
-              valueMultiloc={formValues.description_preview_multiloc}
-              onChange={handleDescriptionPreviewOnChange}
-              label={formatMessage(messages.descriptionPreviewLabel)}
-              labelTooltipText={formatMessage(
-                messages.descriptionPreviewTooltip
-              )}
-              rows={5}
-              maxCharCount={280}
+            {!showProjectDescriptionBuilder && (
+              <QuillMultilocWithLocaleSwitcher
+                id="project-description-module-inactive"
+                valueMultiloc={formValues.description_multiloc}
+                onChange={handleDescriptionOnChange}
+                label={formatMessage(messages.descriptionLabel)}
+                labelTooltipText={formatMessage(messages.descriptionTooltip)}
+                withCTAButton
+              />
+            )}
+            <ProjectDescriptionBuilderToggle
+              valueMultiloc={formValues.description_multiloc}
+              onChange={handleDescriptionOnChange}
+              label={formatMessage(messages.descriptionLabel)}
+              labelTooltipText={formatMessage(messages.descriptionTooltip)}
             />
             <Error
-              fieldName="description_preview_multiloc"
+              fieldName="description_multiloc"
               // TODO: Fix this the next time the file is edited.
               // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-              apiErrors={apiError?.description_preview_multiloc}
+              apiErrors={apiError?.description_multiloc}
             />
           </SectionField>
 
           <Box mb="40px">
             <SectionField>
-              {!showProjectDescriptionBuilder && (
-                <QuillMultilocWithLocaleSwitcher
-                  id="project-description-module-inactive"
-                  valueMultiloc={formValues.description_multiloc}
-                  onChange={handleDescriptionOnChange}
-                  label={formatMessage(messages.descriptionLabel)}
-                  labelTooltipText={formatMessage(messages.descriptionTooltip)}
-                  withCTAButton
-                />
-              )}
-              <ProjectDescriptionBuilderToggle
-                valueMultiloc={formValues.description_multiloc}
-                onChange={handleDescriptionOnChange}
-                label={formatMessage(messages.descriptionLabel)}
-                labelTooltipText={formatMessage(messages.descriptionTooltip)}
+              <TextAreaMultilocWithLocaleSwitcher
+                id="project-description-preview"
+                valueMultiloc={formValues.description_preview_multiloc}
+                onChange={handleDescriptionPreviewOnChange}
+                label={formatMessage(messages.descriptionPreviewLabel)}
+                labelTooltipText={formatMessage(
+                  messages.descriptionPreviewTooltip
+                )}
+                rows={5}
+                maxCharCount={280}
               />
               <Error
-                fieldName="description_multiloc"
+                fieldName="description_preview_multiloc"
                 // TODO: Fix this the next time the file is edited.
                 // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-                apiErrors={apiError?.description_multiloc}
+                apiErrors={apiError?.description_preview_multiloc}
               />
             </SectionField>
           </Box>


### PR DESCRIPTION
Prep work for TAN-3724.

Before
<img width="999" alt="Screenshot 2025-02-07 at 09 50 44" src="https://github.com/user-attachments/assets/5f347d47-ce61-4828-bee3-f0a3610b543e" />

After
<img width="1107" alt="Screenshot 2025-02-07 at 09 50 28" src="https://github.com/user-attachments/assets/595791db-9195-4fd8-bf17-298353f5ebbd" />

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->
