### PR TITLE
Use same font styles across admin project tabs

### DIFF
--- a/front/app/containers/Admin/projects/project/data/index.tsx
+++ b/front/app/containers/Admin/projects/project/data/index.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 
-import { Title, Text, Box } from '@citizenlab/cl2-component-library';
+import { Box } from '@citizenlab/cl2-component-library';
+
+import { SectionDescription, SectionTitle } from 'components/admin/Section';
 
 import { useIntl } from 'utils/cl-intl';
 
@@ -11,13 +13,10 @@ const Data = () => {
   const { formatMessage } = useIntl();
   return (
     <Box>
-      <Title color="primary" fontSize="xxl">
-        {formatMessage(messages.dataTitle)}
-      </Title>
-      <Text>{formatMessage(messages.dataDescription)}</Text>
-      <Text fontWeight="bold" mb="40px">
-        {formatMessage(messages.dataWarning)}
-      </Text>
+      <SectionTitle>{formatMessage(messages.dataTitle)}</SectionTitle>
+      <SectionDescription>
+        {formatMessage(messages.dataDescription)}
+      </SectionDescription>
       <ResetParticipationData />
     </Box>
   );

--- a/front/app/containers/Admin/projects/project/data/messages.ts
+++ b/front/app/containers/Admin/projects/project/data/messages.ts
@@ -10,10 +10,6 @@ export default defineMessages({
     defaultMessage:
       'Clear ideas, comments, votes, reactions, survey responses, poll responses, volunteers and event attendees. In the case of voting phases, this action will clear the votes but not the options.',
   },
-  dataWarning: {
-    id: 'app.containers.AdminPage.Project.data.warningMessage',
-    defaultMessage: 'This action cannot be undone.',
-  },
   resetParticipationData: {
     id: 'app.containers.AdminPage.Project.resetParticipationData',
     defaultMessage: 'Reset all participation data',

--- a/front/app/containers/Admin/projects/project/permissions/Project/index.tsx
+++ b/front/app/containers/Admin/projects/project/permissions/Project/index.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 
-import { Title, Text, Box } from '@citizenlab/cl2-component-library';
+import { Box } from '@citizenlab/cl2-component-library';
 import { useParams } from 'react-router-dom';
 
 import useProjectById from 'api/projects/useProjectById';
 
+import { SectionDescription, SectionTitle } from 'components/admin/Section';
 import Outlet from 'components/Outlet';
 
 import { FormattedMessage } from 'utils/cl-intl';
@@ -22,12 +23,12 @@ const Project = () => {
 
   return (
     <>
-      <Title variant="h2" color="primary">
+      <SectionTitle>
         <FormattedMessage {...messages.projectVisibilityTitle} />
-      </Title>
-      <Text color="coolGrey600">
+      </SectionTitle>
+      <SectionDescription>
         <FormattedMessage {...messages.projectVisibilitySubtitle} />
-      </Text>
+      </SectionDescription>
       <ProjectVisibility projectId={projectId} />
       <Outlet
         id="app.containers.Admin.project.edit.permissions.moderatorRights"

--- a/front/app/translations/admin/ar-SA.json
+++ b/front/app/translations/admin/ar-SA.json
@@ -1481,7 +1481,6 @@
   "app.containers.AdminPage.Project.confirmation.yes": "إعادة تعيين كافة بيانات المشاركة",
   "app.containers.AdminPage.Project.data.descriptionText": "قم بمسح الأفكار والتعليقات والأصوات وردود الأفعال واستجابات الاستطلاعات واستجابات استطلاعات الرأي والمتطوعين وحضور الفعاليات. في حالة مراحل التصويت، سيؤدي هذا الإجراء إلى مسح الأصوات ولكن ليس الخيارات.",
   "app.containers.AdminPage.Project.data.title": "مسح جميع بيانات المشاركة من هذا المشروع",
-  "app.containers.AdminPage.Project.data.warningMessage": "لا يمكن التراجع عن هذا الإجراء.",
   "app.containers.AdminPage.Project.resetParticipationData": "إعادة تعيين كافة بيانات المشاركة",
   "app.containers.AdminPage.Project.settings.accessRights": "حقوق الوصول",
   "app.containers.AdminPage.Project.settings.back": "خلف",

--- a/front/app/translations/admin/cy-GB.json
+++ b/front/app/translations/admin/cy-GB.json
@@ -1481,7 +1481,6 @@
   "app.containers.AdminPage.Project.confirmation.yes": "Ailosod yr holl ddata cyfranogiad",
   "app.containers.AdminPage.Project.data.descriptionText": "Syniadau clir, sylwadau, pleidleisiau, ymatebion, ymatebion arolwg, ymatebion pleidleisio, gwirfoddolwyr a mynychwyr digwyddiadau. Yn achos cyfnodau pleidleisio, bydd y cam gweithredu hwn yn clirio'r pleidleisiau ond nid yr opsiynau.",
   "app.containers.AdminPage.Project.data.title": "Clirio'r holl ddata cyfranogiad o'r prosiect hwn",
-  "app.containers.AdminPage.Project.data.warningMessage": "Ni ellir dadwneud y weithred hon.",
   "app.containers.AdminPage.Project.resetParticipationData": "Ailosod yr holl ddata cyfranogiad",
   "app.containers.AdminPage.Project.settings.accessRights": "Hawliau mynediad",
   "app.containers.AdminPage.Project.settings.back": "Yn ol",

--- a/front/app/translations/admin/da-DK.json
+++ b/front/app/translations/admin/da-DK.json
@@ -1481,7 +1481,6 @@
   "app.containers.AdminPage.Project.confirmation.yes": "Nulstil alle deltagelsesdata",
   "app.containers.AdminPage.Project.data.descriptionText": "Ryd ideer, kommentarer, stemmer, reaktioner, svar på undersøgelser, svar på afstemninger, frivillige og eventdeltagere. I tilfælde af afstemningsfaser vil denne handling rydde stemmerne, men ikke valgmulighederne.",
   "app.containers.AdminPage.Project.data.title": "Slet alle deltagelsesdata fra dette projekt",
-  "app.containers.AdminPage.Project.data.warningMessage": "Denne handling kan ikke fortrydes.",
   "app.containers.AdminPage.Project.resetParticipationData": "Nulstil alle deltagelsesdata",
   "app.containers.AdminPage.Project.settings.accessRights": "Adgangsrettigheder",
   "app.containers.AdminPage.Project.settings.back": "Tilbage",

--- a/front/app/translations/admin/de-DE.json
+++ b/front/app/translations/admin/de-DE.json
@@ -1481,7 +1481,6 @@
   "app.containers.AdminPage.Project.confirmation.yes": "Alle Teilnahmedaten löschen",
   "app.containers.AdminPage.Project.data.descriptionText": "Löschen Sie Ideen, Kommentare, Stimmen, Reaktionen, Umfrageantworten, usw.. Bei Abstimmungsphasen löscht diese Aktion die Stimmen, aber nicht die Optionen.",
   "app.containers.AdminPage.Project.data.title": "Alle Daten von Teilnehmenden aus diesem Projekt löschen",
-  "app.containers.AdminPage.Project.data.warningMessage": "Diese Aktion kann nicht rückgängig gemacht werden.",
   "app.containers.AdminPage.Project.resetParticipationData": "Alle Teilnahmedaten löschen",
   "app.containers.AdminPage.Project.settings.accessRights": "Zugriffsrechte",
   "app.containers.AdminPage.Project.settings.back": "Zurück",

--- a/front/app/translations/admin/en-CA.json
+++ b/front/app/translations/admin/en-CA.json
@@ -1481,7 +1481,6 @@
   "app.containers.AdminPage.Project.confirmation.yes": "Reset all participation data",
   "app.containers.AdminPage.Project.data.descriptionText": "Clear ideas, comments, votes, reactions, survey responses, poll responses, volunteers and event attendees. In the case of voting phases, this action will clear the votes but not the options.",
   "app.containers.AdminPage.Project.data.title": "Clear all participation data from this project",
-  "app.containers.AdminPage.Project.data.warningMessage": "This action cannot be undone.",
   "app.containers.AdminPage.Project.resetParticipationData": "Reset all participation data",
   "app.containers.AdminPage.Project.settings.accessRights": "Access rights",
   "app.containers.AdminPage.Project.settings.back": "Back",

--- a/front/app/translations/admin/en-GB.json
+++ b/front/app/translations/admin/en-GB.json
@@ -1481,7 +1481,6 @@
   "app.containers.AdminPage.Project.confirmation.yes": "Reset all participation data",
   "app.containers.AdminPage.Project.data.descriptionText": "Clear ideas, comments, votes, reactions, survey responses, poll responses, volunteers and event attendees. In the case of voting phases, this action will clear the votes but not the options.",
   "app.containers.AdminPage.Project.data.title": "Clear all participation data from this project",
-  "app.containers.AdminPage.Project.data.warningMessage": "This action cannot be undone.",
   "app.containers.AdminPage.Project.resetParticipationData": "Reset all participation data",
   "app.containers.AdminPage.Project.settings.accessRights": "Access rights",
   "app.containers.AdminPage.Project.settings.back": "Back",

--- a/front/app/translations/admin/en-IE.json
+++ b/front/app/translations/admin/en-IE.json
@@ -1481,7 +1481,6 @@
   "app.containers.AdminPage.Project.confirmation.yes": "Reset all participation data",
   "app.containers.AdminPage.Project.data.descriptionText": "Clear ideas, comments, votes, reactions, survey responses, poll responses, volunteers and event attendees. In the case of voting phases, this action will clear the votes but not the options.",
   "app.containers.AdminPage.Project.data.title": "Clear all participation data from this project",
-  "app.containers.AdminPage.Project.data.warningMessage": "This action cannot be undone.",
   "app.containers.AdminPage.Project.resetParticipationData": "Reset all participation data",
   "app.containers.AdminPage.Project.settings.accessRights": "Access rights",
   "app.containers.AdminPage.Project.settings.back": "Back",

--- a/front/app/translations/admin/en.json
+++ b/front/app/translations/admin/en.json
@@ -1481,7 +1481,6 @@
   "app.containers.AdminPage.Project.confirmation.yes": "Reset all participation data",
   "app.containers.AdminPage.Project.data.descriptionText": "Clear ideas, comments, votes, reactions, survey responses, poll responses, volunteers and event attendees. In the case of voting phases, this action will clear the votes but not the options.",
   "app.containers.AdminPage.Project.data.title": "Clear all participation data from this project",
-  "app.containers.AdminPage.Project.data.warningMessage": "This action cannot be undone.",
   "app.containers.AdminPage.Project.resetParticipationData": "Reset all participation data",
   "app.containers.AdminPage.Project.settings.accessRights": "Access rights",
   "app.containers.AdminPage.Project.settings.back": "Back",

--- a/front/app/translations/admin/es-CL.json
+++ b/front/app/translations/admin/es-CL.json
@@ -1481,7 +1481,6 @@
   "app.containers.AdminPage.Project.confirmation.yes": "Resetear los datos de participación",
   "app.containers.AdminPage.Project.data.descriptionText": "Borra ideas, comentarios, votos, reacciones, respuestas a encuestas, respuestas a sondeos, voluntarios y asistentes al evento. En el caso de las fases de votación, esta acción borrará los votos pero no las opciones/ideas. ",
   "app.containers.AdminPage.Project.data.title": "Borrar todos los datos de participación de este proyecto",
-  "app.containers.AdminPage.Project.data.warningMessage": "Esta acción no se puede deshacer.",
   "app.containers.AdminPage.Project.resetParticipationData": "Resetear todos los datos de participación",
   "app.containers.AdminPage.Project.settings.accessRights": "Derechos de acceso",
   "app.containers.AdminPage.Project.settings.back": "Volver",

--- a/front/app/translations/admin/es-ES.json
+++ b/front/app/translations/admin/es-ES.json
@@ -1481,7 +1481,6 @@
   "app.containers.AdminPage.Project.confirmation.yes": "Resetear los datos de participación",
   "app.containers.AdminPage.Project.data.descriptionText": "Borra ideas, comentarios, votos, reacciones, respuestas a encuestas, respuestas a sondeos, voluntarios y asistentes al evento. En el caso de las fases de votación, esta acción borrará los votos pero no las opciones/ideas. ",
   "app.containers.AdminPage.Project.data.title": "Borrar todos los datos de participación de este proyecto",
-  "app.containers.AdminPage.Project.data.warningMessage": "Esta acción no se puede deshacer.",
   "app.containers.AdminPage.Project.resetParticipationData": "Resetear todos los datos de participación",
   "app.containers.AdminPage.Project.settings.accessRights": "Derechos de acceso",
   "app.containers.AdminPage.Project.settings.back": "Volver",

--- a/front/app/translations/admin/fi-FI.json
+++ b/front/app/translations/admin/fi-FI.json
@@ -1481,7 +1481,6 @@
   "app.containers.AdminPage.Project.confirmation.yes": "Nollaa kaikki osallistumistiedot",
   "app.containers.AdminPage.Project.data.descriptionText": "Selkeät ideat, kommentit, äänet, reaktiot, kyselyvastaukset, kyselyvastaukset, vapaaehtoiset ja tapahtuman osallistujat. Äänestysvaiheissa tämä toiminto tyhjentää äänet, mutta ei vaihtoehtoja.",
   "app.containers.AdminPage.Project.data.title": "Poista kaikki osallistumistiedot tästä projektista",
-  "app.containers.AdminPage.Project.data.warningMessage": "Tätä toimintoa ei voi kumota.",
   "app.containers.AdminPage.Project.resetParticipationData": "Nollaa kaikki osallistumistiedot",
   "app.containers.AdminPage.Project.settings.accessRights": "Käyttöoikeudet",
   "app.containers.AdminPage.Project.settings.back": "Takaisin",

--- a/front/app/translations/admin/fr-BE.json
+++ b/front/app/translations/admin/fr-BE.json
@@ -1481,7 +1481,6 @@
   "app.containers.AdminPage.Project.confirmation.yes": "Supprimer toutes les données de participation",
   "app.containers.AdminPage.Project.data.descriptionText": "Supprimez les idées, commentaires, votes, réactions, réponses aux enquêtes et sondages, ainsi que les inscriptions en tant que volontaire ou aux événements. Cependant, cette action ne supprimera pas les options associées aux phases de vote (uniquement les votes, réactions et commentaires qui leurs sont associés).",
   "app.containers.AdminPage.Project.data.title": "Effacer toutes les données de participation de ce projet",
-  "app.containers.AdminPage.Project.data.warningMessage": "Cette action est irréversible.",
   "app.containers.AdminPage.Project.resetParticipationData": "Supprimer toutes les données de participation",
   "app.containers.AdminPage.Project.settings.accessRights": "Droits d'accès",
   "app.containers.AdminPage.Project.settings.back": "Retour",

--- a/front/app/translations/admin/fr-FR.json
+++ b/front/app/translations/admin/fr-FR.json
@@ -1481,7 +1481,6 @@
   "app.containers.AdminPage.Project.confirmation.yes": "Supprimer toutes les données de participation",
   "app.containers.AdminPage.Project.data.descriptionText": "Supprimez les idées, commentaires, votes, réactions, réponses aux enquêtes et sondages, ainsi que les inscriptions en tant que volontaire ou aux événements. Cependant, cette action ne supprimera pas les options associées aux phases de vote (uniquement les votes, réactions et commentaires qui leurs sont associés).",
   "app.containers.AdminPage.Project.data.title": "Effacer toutes les données de participation de ce projet",
-  "app.containers.AdminPage.Project.data.warningMessage": "Cette action est irréversible.",
   "app.containers.AdminPage.Project.resetParticipationData": "Supprimer toutes les données de participation",
   "app.containers.AdminPage.Project.settings.accessRights": "Droits d'accès",
   "app.containers.AdminPage.Project.settings.back": "Retour",

--- a/front/app/translations/admin/hr-HR.json
+++ b/front/app/translations/admin/hr-HR.json
@@ -1481,7 +1481,6 @@
   "app.containers.AdminPage.Project.confirmation.yes": "Poništi sve podatke o sudjelovanju",
   "app.containers.AdminPage.Project.data.descriptionText": "Jasne ideje, komentari, glasovi, reakcije, odgovori na ankete, odgovori na ankete, volonteri i sudionici događaja. U slučaju faza glasovanja, ova radnja će izbrisati glasove, ali ne i opcije.",
   "app.containers.AdminPage.Project.data.title": "Izbrišite sve podatke o sudjelovanju iz ovog projekta",
-  "app.containers.AdminPage.Project.data.warningMessage": "Ova se radnja ne može poništiti.",
   "app.containers.AdminPage.Project.resetParticipationData": "Poništi sve podatke o sudjelovanju",
   "app.containers.AdminPage.Project.settings.accessRights": "Prava pristupa",
   "app.containers.AdminPage.Project.settings.back": "leđa",

--- a/front/app/translations/admin/lt-LT.json
+++ b/front/app/translations/admin/lt-LT.json
@@ -1481,7 +1481,6 @@
   "app.containers.AdminPage.Project.confirmation.yes": "Iš naujo nustatyti visus dalyvavimo duomenis",
   "app.containers.AdminPage.Project.data.descriptionText": "Aiškios idėjos, komentarai, balsai, reakcijos, atsakymai į apklausas, apklausų atsakymai, savanoriai ir renginių dalyviai. Balsavimo etapų atveju šiuo veiksmu bus išvalyti balsai, bet ne parinktys.",
   "app.containers.AdminPage.Project.data.title": "Išvalyti visus šio projekto dalyvavimo duomenis",
-  "app.containers.AdminPage.Project.data.warningMessage": "Šio veiksmo negalima atšaukti.",
   "app.containers.AdminPage.Project.resetParticipationData": "Iš naujo nustatyti visus dalyvavimo duomenis",
   "app.containers.AdminPage.Project.settings.accessRights": "Prieigos teisės",
   "app.containers.AdminPage.Project.settings.back": "Atgal",

--- a/front/app/translations/admin/lv-LV.json
+++ b/front/app/translations/admin/lv-LV.json
@@ -1481,7 +1481,6 @@
   "app.containers.AdminPage.Project.confirmation.yes": "Visu dalības datu atiestatīšana",
   "app.containers.AdminPage.Project.data.descriptionText": "Skaidras idejas, komentāri, balsojumi, reakcijas, aptaujas atbildes, aptaujas atbildes, brīvprātīgo un pasākumu apmeklētāju atbildes. Balsošanas posmu gadījumā šī darbība dzēsīs balsojumus, bet ne iespējas.",
   "app.containers.AdminPage.Project.data.title": "Izdzēst visus šā projekta dalības datus",
-  "app.containers.AdminPage.Project.data.warningMessage": "Šo darbību nevar atcelt.",
   "app.containers.AdminPage.Project.resetParticipationData": "Visu dalības datu atiestatīšana",
   "app.containers.AdminPage.Project.settings.accessRights": "Piekļuves tiesības",
   "app.containers.AdminPage.Project.settings.back": "Atpakaļ",

--- a/front/app/translations/admin/nb-NO.json
+++ b/front/app/translations/admin/nb-NO.json
@@ -1481,7 +1481,6 @@
   "app.containers.AdminPage.Project.confirmation.yes": "Tilbakestill alle deltakelsesdata",
   "app.containers.AdminPage.Project.data.descriptionText": "Fjern ideer, kommentarer, stemmer, reaksjoner, svar på spørreundersøkelser, svar på avstemninger, frivillige og deltakere på arrangementer. I avstemningsfaser vil denne handlingen fjerne stemmene, men ikke alternativene.",
   "app.containers.AdminPage.Project.data.title": "Slett alle deltakelsesdata fra dette prosjektet",
-  "app.containers.AdminPage.Project.data.warningMessage": "Denne handlingen kan ikke gjøres ugjort.",
   "app.containers.AdminPage.Project.resetParticipationData": "Tilbakestill alle deltakelsesdata",
   "app.containers.AdminPage.Project.settings.accessRights": "Tilgangsrettigheter",
   "app.containers.AdminPage.Project.settings.back": "Tilbake",

--- a/front/app/translations/admin/nl-BE.json
+++ b/front/app/translations/admin/nl-BE.json
@@ -1481,7 +1481,6 @@
   "app.containers.AdminPage.Project.confirmation.yes": "Reset alle deelnamegegevens",
   "app.containers.AdminPage.Project.data.descriptionText": "Verwijder ideeën, reacties, stemmen, likes/dislikes, reacties op vragenlijsten, reacties op polls, vrijwilligers en bezoekers van evenementen. In het geval van stemfasen wist deze actie de stemmen, maar niet de opties.",
   "app.containers.AdminPage.Project.data.title": "Wis alle deelnamegegevens van dit project",
-  "app.containers.AdminPage.Project.data.warningMessage": "Deze actie kan niet ongedaan worden gemaakt.",
   "app.containers.AdminPage.Project.resetParticipationData": "Reset alle deelnamegegevens",
   "app.containers.AdminPage.Project.settings.accessRights": "Toegangsrechten",
   "app.containers.AdminPage.Project.settings.back": "Vorige",

--- a/front/app/translations/admin/nl-NL.json
+++ b/front/app/translations/admin/nl-NL.json
@@ -1481,7 +1481,6 @@
   "app.containers.AdminPage.Project.confirmation.yes": "Reset alle deelnamegegevens",
   "app.containers.AdminPage.Project.data.descriptionText": "Verwijder ideeën, reacties, stemmen, likes/dislikes, reacties op vragenlijsten, reacties op polls, vrijwilligers en bezoekers van evenementen. In het geval van stemfasen wist deze actie de stemmen, maar niet de opties.",
   "app.containers.AdminPage.Project.data.title": "Wis alle deelnamegegevens van dit project",
-  "app.containers.AdminPage.Project.data.warningMessage": "Deze actie kan niet ongedaan worden gemaakt.",
   "app.containers.AdminPage.Project.resetParticipationData": "Reset alle deelnamegegevens",
   "app.containers.AdminPage.Project.settings.accessRights": "Toegangsrechten",
   "app.containers.AdminPage.Project.settings.back": "Vorige",

--- a/front/app/translations/admin/pa-IN.json
+++ b/front/app/translations/admin/pa-IN.json
@@ -1481,7 +1481,6 @@
   "app.containers.AdminPage.Project.confirmation.yes": "ਸਾਰੇ ਭਾਗੀਦਾਰੀ ਡੇਟਾ ਨੂੰ ਰੀਸੈਟ ਕਰੋ",
   "app.containers.AdminPage.Project.data.descriptionText": "ਸਪਸ਼ਟ ਵਿਚਾਰ, ਟਿੱਪਣੀਆਂ, ਵੋਟਾਂ, ਪ੍ਰਤੀਕਰਮ, ਸਰਵੇਖਣ ਜਵਾਬ, ਪੋਲ ਜਵਾਬ, ਵਾਲੰਟੀਅਰ ਅਤੇ ਇਵੈਂਟ ਹਾਜ਼ਰ। ਮਤਦਾਨ ਪੜਾਵਾਂ ਦੇ ਮਾਮਲੇ ਵਿੱਚ, ਇਹ ਕਾਰਵਾਈ ਵੋਟਾਂ ਨੂੰ ਸਾਫ਼ ਕਰੇਗੀ ਪਰ ਵਿਕਲਪਾਂ ਨੂੰ ਨਹੀਂ।",
   "app.containers.AdminPage.Project.data.title": "ਇਸ ਪ੍ਰੋਜੈਕਟ ਤੋਂ ਸਾਰੇ ਭਾਗੀਦਾਰੀ ਡੇਟਾ ਨੂੰ ਸਾਫ਼ ਕਰੋ",
-  "app.containers.AdminPage.Project.data.warningMessage": "ਇਸ ਕਾਰਵਾਈ ਨੂੰ ਅਣਕੀਤਾ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਦਾ।",
   "app.containers.AdminPage.Project.resetParticipationData": "ਸਾਰੇ ਭਾਗੀਦਾਰੀ ਡੇਟਾ ਨੂੰ ਰੀਸੈਟ ਕਰੋ",
   "app.containers.AdminPage.Project.settings.accessRights": "ਪਹੁੰਚ ਅਧਿਕਾਰ",
   "app.containers.AdminPage.Project.settings.back": "ਵਾਪਸ",

--- a/front/app/translations/admin/pl-PL.json
+++ b/front/app/translations/admin/pl-PL.json
@@ -1481,7 +1481,6 @@
   "app.containers.AdminPage.Project.confirmation.yes": "Zresetuj wszystkie dane dotyczące uczestnictwa",
   "app.containers.AdminPage.Project.data.descriptionText": "Wyczyść pomysły, komentarze, głosy, reakcje, odpowiedzi na ankiety, odpowiedzi na ankiety, wolontariuszy i uczestników wydarzenia. W przypadku faz głosowania ta akcja wyczyści głosy, ale nie opcje.",
   "app.containers.AdminPage.Project.data.title": "Wyczyść wszystkie dane dotyczące uczestnictwa w tym projekcie",
-  "app.containers.AdminPage.Project.data.warningMessage": "Tego działania nie można cofnąć.",
   "app.containers.AdminPage.Project.resetParticipationData": "Zresetuj wszystkie dane dotyczące uczestnictwa",
   "app.containers.AdminPage.Project.settings.accessRights": "Prawa dostępu",
   "app.containers.AdminPage.Project.settings.back": "Powrót",

--- a/front/app/translations/admin/pt-BR.json
+++ b/front/app/translations/admin/pt-BR.json
@@ -1481,7 +1481,6 @@
   "app.containers.AdminPage.Project.confirmation.yes": "Redefinir todos os dados de participação",
   "app.containers.AdminPage.Project.data.descriptionText": "Limpar ideias, comentários, votos, reações, respostas a pesquisas, respostas a enquetes, voluntários e participantes de eventos. No caso das fases de votação, essa ação limpará os votos, mas não as opções.",
   "app.containers.AdminPage.Project.data.title": "Limpar todos os dados de participação desse projeto",
-  "app.containers.AdminPage.Project.data.warningMessage": "Essa ação não pode ser desfeita.",
   "app.containers.AdminPage.Project.resetParticipationData": "Redefinir todos os dados de participação",
   "app.containers.AdminPage.Project.settings.accessRights": "Direitos de acesso",
   "app.containers.AdminPage.Project.settings.back": "Voltar",

--- a/front/app/translations/admin/sr-Latn.json
+++ b/front/app/translations/admin/sr-Latn.json
@@ -1481,7 +1481,6 @@
   "app.containers.AdminPage.Project.confirmation.yes": "Reset all participation data",
   "app.containers.AdminPage.Project.data.descriptionText": "Clear ideas, comments, votes, reactions, survey responses, poll responses, volunteers and event attendees. In the case of voting phases, this action will clear the votes but not the options.",
   "app.containers.AdminPage.Project.data.title": "Clear all participation data from this project",
-  "app.containers.AdminPage.Project.data.warningMessage": "This action cannot be undone.",
   "app.containers.AdminPage.Project.resetParticipationData": "Reset all participation data",
   "app.containers.AdminPage.Project.settings.accessRights": "Access rights",
   "app.containers.AdminPage.Project.settings.back": "Back",

--- a/front/app/translations/admin/sr-SP.json
+++ b/front/app/translations/admin/sr-SP.json
@@ -1481,7 +1481,6 @@
   "app.containers.AdminPage.Project.confirmation.yes": "Reset all participation data",
   "app.containers.AdminPage.Project.data.descriptionText": "Clear ideas, comments, votes, reactions, survey responses, poll responses, volunteers and event attendees. In the case of voting phases, this action will clear the votes but not the options.",
   "app.containers.AdminPage.Project.data.title": "Clear all participation data from this project",
-  "app.containers.AdminPage.Project.data.warningMessage": "This action cannot be undone.",
   "app.containers.AdminPage.Project.resetParticipationData": "Reset all participation data",
   "app.containers.AdminPage.Project.settings.accessRights": "Права приступа",
   "app.containers.AdminPage.Project.settings.back": "Назад",

--- a/front/app/translations/admin/sv-SE.json
+++ b/front/app/translations/admin/sv-SE.json
@@ -1481,7 +1481,6 @@
   "app.containers.AdminPage.Project.confirmation.yes": "Återställ alla deltagardata",
   "app.containers.AdminPage.Project.data.descriptionText": "Rensa idéer, kommentarer, röster, reaktioner, enkätsvar, svar på opinionsundersökningar, volontärer och deltagare i evenemanget. När det gäller omröstningsfaser kommer denna åtgärd att rensa rösterna men inte alternativen.",
   "app.containers.AdminPage.Project.data.title": "Rensa alla deltagardata från detta projekt",
-  "app.containers.AdminPage.Project.data.warningMessage": "Denna åtgärd kan inte ångras.",
   "app.containers.AdminPage.Project.resetParticipationData": "Återställ alla deltagardata",
   "app.containers.AdminPage.Project.settings.accessRights": "Tillträdesrättigheter",
   "app.containers.AdminPage.Project.settings.back": "Tillbaka",

--- a/front/app/translations/admin/tr-TR.json
+++ b/front/app/translations/admin/tr-TR.json
@@ -1481,7 +1481,6 @@
   "app.containers.AdminPage.Project.confirmation.yes": "Tüm katılım verilerini sıfırlayın",
   "app.containers.AdminPage.Project.data.descriptionText": "Fikirleri, yorumları, oyları, tepkileri, anket yanıtlarını, anket yanıtlarını, gönüllüleri ve etkinlik katılımcılarını temizleyin. Oylama aşamaları söz konusu olduğunda, bu eylem oyları temizleyecek ancak seçenekleri temizlemeyecektir.",
   "app.containers.AdminPage.Project.data.title": "Bu projedeki tüm katılım verilerini temizleyin",
-  "app.containers.AdminPage.Project.data.warningMessage": "Bu işlem geri alınamaz.",
   "app.containers.AdminPage.Project.resetParticipationData": "Tüm katılım verilerini sıfırlayın",
   "app.containers.AdminPage.Project.settings.accessRights": "Erişim hakları",
   "app.containers.AdminPage.Project.settings.back": "Geri",

--- a/front/app/translations/admin/ur-PK.json
+++ b/front/app/translations/admin/ur-PK.json
@@ -1481,7 +1481,6 @@
   "app.containers.AdminPage.Project.confirmation.yes": "شرکت کا تمام ڈیٹا ری سیٹ کریں۔",
   "app.containers.AdminPage.Project.data.descriptionText": "واضح خیالات، تبصرے، ووٹ، رد عمل، سروے کے جوابات، رائے شماری کے جوابات، رضاکار اور تقریب کے شرکاء۔ ووٹنگ کے مراحل کے معاملے میں، یہ عمل ووٹوں کو صاف کرے گا لیکن اختیارات نہیں.",
   "app.containers.AdminPage.Project.data.title": "اس پروجیکٹ سے شرکت کا تمام ڈیٹا صاف کریں۔",
-  "app.containers.AdminPage.Project.data.warningMessage": "اس کارروائی کو کالعدم نہیں کیا جا سکتا۔",
   "app.containers.AdminPage.Project.resetParticipationData": "شرکت کا تمام ڈیٹا ری سیٹ کریں۔",
   "app.containers.AdminPage.Project.settings.accessRights": "رسائی کے حقوق",
   "app.containers.AdminPage.Project.settings.back": "پیچھے",


### PR DESCRIPTION
The tabs use different font styles. E.g.:
<img width="1193" alt="Screenshot 2025-02-07 at 12 06 20" src="https://github.com/user-attachments/assets/8974c4b4-8429-4f22-ae31-7da315b68003" />
<img width="1214" alt="Screenshot 2025-02-07 at 12 06 27" src="https://github.com/user-attachments/assets/da594538-7c26-4105-a6d8-f5a719405505" />

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->
