### PR TITLE
[TAN-3660] Rake task to remove the troublesome end pages from proposal phases forms

### DIFF
--- a/back/lib/tasks/single_use/20250206_remove_last_page_proposal_phase_forms.rake
+++ b/back/lib/tasks/single_use/20250206_remove_last_page_proposal_phase_forms.rake
@@ -1,0 +1,39 @@
+require 'json'
+
+namespace :single_use do
+  desc 'Sets code: null for education custom fields'
+  task remove_proposal_phase_last_survey_pages: :environment do
+    reporter = ScriptReporter.new
+
+    Tenant.safe_switch_each do |tenant|
+      puts "\nProcessing tenant #{tenant.host} \n\n"
+
+      proposals_phases = Phase.where(participation_method: 'proposals')
+
+      proposals_custom_forms = CustomForm.where(participation_context: proposals_phases)
+      proposals_custom_forms.each do |custom_form|
+        fields = custom_form.custom_fields
+        fields.each do |field|
+          if field.input_type == 'page' && field.key == 'survey_end'
+            puts "Removing last page from form #{custom_form.id}"
+
+            if field.destroy
+              reporter.add_change(
+                field.attributes,
+                'destroyed',
+                context: { tenant: tenant.host }
+              )
+            else
+              reporter.add_error(
+                field.errors.details,
+                context: { tenant: tenant.host }
+              )
+            end
+          end
+        end
+      end
+    end
+
+    reporter.report!('remove_proposal_phase_last_survey_pages.json', verbose: true)
+  end
+end


### PR DESCRIPTION
# Changelog
## Fixed
- [TAN-3660] Rake task to fix: Proposals in phases, where input form has been customised, can again be edited. (Will be within an hour of this release. I need to run this task on all server clusters)
