### PR TITLE
Tan 3808/button color

### DIFF
--- a/front/app/containers/Admin/projects/project/projectHeader/index.tsx
+++ b/front/app/containers/Admin/projects/project/projectHeader/index.tsx
@@ -18,7 +18,7 @@ import useUserById from 'api/users/useUserById';
 import useLocalize from 'hooks/useLocalize';
 
 import NavigationTabs from 'components/admin/NavigationTabs';
-import Button from 'components/UI/ButtonWithLink';
+import ButtonWithLink from 'components/UI/ButtonWithLink';
 
 import { FormattedMessage, MessageDescriptor, useIntl } from 'utils/cl-intl';
 import { getFullName } from 'utils/textUtils';
@@ -84,7 +84,7 @@ const ProjectHeader = ({ projectId }: Props) => {
             gap="8px"
             className="intercom-projects-project-header-buttons"
           >
-            <Button
+            <ButtonWithLink
               linkTo={`/projects/${project.data.attributes.slug}`}
               buttonStyle="secondary-outlined"
               icon="eye"
@@ -98,7 +98,7 @@ const ProjectHeader = ({ projectId }: Props) => {
               projectSlug={project.data.attributes.slug}
               token={project.data.attributes.preview_token}
             />
-            <Button
+            <ButtonWithLink
               linkTo={`/admin/projects/${project.data.id}/settings`}
               buttonStyle="admin-dark"
               size="s"
@@ -107,13 +107,13 @@ const ProjectHeader = ({ projectId }: Props) => {
               iconSize="18px"
             >
               {formatMessage(messages.settings)}
-            </Button>
+            </ButtonWithLink>
 
             <ReviewFlow project={project.data} />
           </Box>
         </Box>
         <Box display="flex" gap="8px">
-          <Button
+          <ButtonWithLink
             linkTo={`/admin/projects/${project.data.id}/settings/access-rights`}
             buttonStyle="text"
             size="s"
@@ -129,7 +129,7 @@ const ProjectHeader = ({ projectId }: Props) => {
                 {formatMessage(visibilityMessage)}
               </Text>
             </Box>
-          </Button>
+          </ButtonWithLink>
           <Text color="coolGrey600" fontSize="s" mb="0px" mt="2px">
             ·
           </Text>

--- a/front/app/containers/Admin/projects/project/projectHeader/index.tsx
+++ b/front/app/containers/Admin/projects/project/projectHeader/index.tsx
@@ -100,9 +100,11 @@ const ProjectHeader = ({ projectId }: Props) => {
             />
             <Button
               linkTo={`/admin/projects/${project.data.id}/settings`}
-              buttonStyle="secondary-outlined"
+              buttonStyle="admin-dark"
               size="s"
               padding="4px 8px"
+              icon="settings"
+              iconSize="18px"
             >
               {formatMessage(messages.settings)}
             </Button>


### PR DESCRIPTION
Before 
<img width="450" alt="Screenshot 2025-02-10 at 11 32 03" src="https://github.com/user-attachments/assets/8049b764-8420-4f85-af6d-f6a841ef4809" />

After
<img width="411" alt="Screenshot 2025-02-10 at 11 28 45" src="https://github.com/user-attachments/assets/e708945f-546e-45d3-b3c6-f5cd50ae7944" />

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Changed
- Project settings button stands out more. (See [this page](https://github.com/CitizenLabDotCo/citizenlab/pull/10303) for the before/after.)