### PR TITLE
Project description: "Homepage description" field visibility

### DIFF
--- a/front/app/containers/Admin/projects/project/description/index.tsx
+++ b/front/app/containers/Admin/projects/project/description/index.tsx
@@ -32,6 +32,7 @@ interface IFormValues {
   description_preview_multiloc: Multiloc | null;
   description_multiloc: Multiloc | null;
 }
+const submitBarHeight = '62px';
 
 const ProjectDescription = () => {
   const { formatMessage } = useIntl();
@@ -115,9 +116,10 @@ const ProjectDescription = () => {
 
   return (
     <Box
-      // To improve: have standardize page height calculation for all admin pages
-      height="100vh"
       ref={containerRef}
+      // Temporary fix to ensure the submit bar does
+      // not overlap the content. Submit bar should be standardized
+      pb={submitBarHeight}
     >
       <SectionTitle>
         <FormattedMessage {...messages.titleDescription} />


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- "Homepage description" field in project description settings does not hide behind bottom bar with Save button on smaller screens. 