### PR TITLE
Only show "read the report" label on project card when report is public

### DIFF
--- a/front/app/components/ProjectCard/getCTAMessage.ts
+++ b/front/app/components/ProjectCard/getCTAMessage.ts
@@ -15,6 +15,7 @@ interface Params {
   actionDescriptors: ActionDescriptors;
   formatMessage: FormatMessage;
   localize: Localize;
+  hasPublicReport: boolean;
 }
 
 const getCTAMessage = ({
@@ -22,6 +23,7 @@ const getCTAMessage = ({
   actionDescriptors,
   formatMessage,
   localize,
+  hasPublicReport,
 }: Params) => {
   const {
     participation_method,
@@ -41,9 +43,7 @@ const getCTAMessage = ({
       return formatMessage(messages.vote);
     }
   } else if (participation_method === 'information') {
-    const hasReport = !!phase.relationships.report?.data;
-
-    return hasReport
+    return hasPublicReport
       ? formatMessage(messages.readTheReport)
       : formatMessage(messages.learnMore);
   } else if (participation_method === 'survey') {

--- a/front/app/components/ProjectCard/index.tsx
+++ b/front/app/components/ProjectCard/index.tsx
@@ -388,7 +388,7 @@ const ProjectCard = memo<InputProps>(
     const { data: report } = useReport(
       phase?.data.relationships.report?.data?.id
     );
-    const hasPublicReport = report?.data.attributes.visible || false;
+    const hasPublicReport = !!report?.data.attributes.visible;
 
     const projectImage = imageId ? _projectImage : undefined;
 

--- a/front/app/components/ProjectCard/index.tsx
+++ b/front/app/components/ProjectCard/index.tsx
@@ -23,6 +23,7 @@ import useProjectImage from 'api/project_images/useProjectImage';
 import { CARD_IMAGE_ASPECT_RATIO } from 'api/project_images/useProjectImages';
 import useProjectById from 'api/projects/useProjectById';
 import { getProjectUrl } from 'api/projects/utils';
+import useReport from 'api/reports/useReport';
 
 import useLocalize from 'hooks/useLocalize';
 
@@ -379,14 +380,18 @@ const ProjectCard = memo<InputProps>(
       projectId,
       imageId,
     });
-
-    const projectImage = imageId ? _projectImage : undefined;
-
     const currentPhaseId =
       // TODO: Fix this the next time the file is edited.
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       project?.data?.relationships?.current_phase?.data?.id ?? null;
     const { data: phase } = usePhase(currentPhaseId);
+    const { data: report } = useReport(
+      phase?.data.relationships.report?.data?.id
+    );
+    const hasPublicReport = report?.data.attributes.visible || false;
+
+    const projectImage = imageId ? _projectImage : undefined;
+
     const localize = useLocalize();
     const { formatMessage } = useIntl();
 
@@ -471,6 +476,7 @@ const ProjectCard = memo<InputProps>(
           phase: phase.data,
           formatMessage,
           localize,
+          hasPublicReport,
         })
       : undefined;
 

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/ProjectCarrousel/LightProjectCard/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/ProjectCarrousel/LightProjectCard/index.tsx
@@ -44,7 +44,7 @@ const LightProjectCard = ({ project, ml, mr, onKeyDown }: Props) => {
   const { data: report } = useReport(
     phase?.data.relationships.report?.data?.id
   );
-  const hasPublicReport = report?.data.attributes.visible || false;
+  const hasPublicReport = !!report?.data.attributes.visible;
 
   const title = localize(project.attributes.title_multiloc);
   const imageVersions = image?.data.attributes.versions;

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/ProjectCarrousel/LightProjectCard/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/ProjectCarrousel/LightProjectCard/index.tsx
@@ -7,6 +7,7 @@ import usePhaseMini from 'api/phases_mini/usePhaseMini';
 import useProjectImage from 'api/project_images/useProjectImage';
 import { getProjectUrl } from 'api/projects/utils';
 import { MiniProjectData } from 'api/projects_mini/types';
+import useReport from 'api/reports/useReport';
 
 import useLocalize from 'hooks/useLocalize';
 
@@ -40,6 +41,10 @@ const LightProjectCard = ({ project, ml, mr, onKeyDown }: Props) => {
 
   const phaseId = project.relationships.current_phase?.data?.id;
   const { data: phase } = usePhaseMini(phaseId);
+  const { data: report } = useReport(
+    phase?.data.relationships.report?.data?.id
+  );
+  const hasPublicReport = report?.data.attributes.visible || false;
 
   const title = localize(project.attributes.title_multiloc);
   const imageVersions = image?.data.attributes.versions;
@@ -78,6 +83,7 @@ const LightProjectCard = ({ project, ml, mr, onKeyDown }: Props) => {
               actionDescriptors: project.attributes.action_descriptors,
               localize,
               formatMessage,
+              hasPublicReport,
             })}
           </Text>
         )}


### PR DESCRIPTION
When we have a draft phase report:

Before
<img width="274" alt="Screenshot 2025-02-11 at 14 15 10" src="https://github.com/user-attachments/assets/46f91f22-a117-4d03-9c5e-b10f60b34a1a" />

After
<img width="267" alt="Screenshot 2025-02-11 at 14 15 26" src="https://github.com/user-attachments/assets/4545af86-1e35-46ce-b92f-ec8f6bbe2f21" />

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Information phase: only show "read the report" label on project card when the report is public. Otherwise, show "Learn more" (see [this page](https://github.com/CitizenLabDotCo/citizenlab/pull/10316) for before/after).