### PR TITLE
Always show "Edit description" as link text

### DIFF
--- a/front/app/containers/Admin/projects/project/projectHeader/ProjectDescriptionPreview.tsx
+++ b/front/app/containers/Admin/projects/project/projectHeader/ProjectDescriptionPreview.tsx
@@ -6,12 +6,8 @@ import { RouteType } from 'routes';
 import useProjectDescriptionBuilderLayout from 'api/project_description_builder/useProjectDescriptionBuilderLayout';
 import { IProject } from 'api/projects/types';
 
-import useLocalize from 'hooks/useLocalize';
-
 import { useIntl } from 'utils/cl-intl';
 import Link from 'utils/cl-router/Link';
-import { isEmptyMultiloc } from 'utils/helperUtils';
-import { stripHtml } from 'utils/textUtils';
 
 import messages from './messages';
 
@@ -34,7 +30,6 @@ const EditDescriptionLinkContent = () => {
 
 const ProjectDescriptionPreview = ({ project }: Props) => {
   const projectId = project.data.id;
-  const localize = useLocalize();
   const { data: projectDescriptionBuilderLayout } =
     useProjectDescriptionBuilderLayout(projectId);
   const projectDescriptionBuilderEnabled =
@@ -49,8 +44,6 @@ const ProjectDescriptionPreview = ({ project }: Props) => {
         `/admin/project-description-builder/projects/${projectId}/description` as RouteType
       }
     >
-      {/* Given the wide range of elements the content builder provides, it's hard to show a reliable preview. 
-      Hence we show the "Edit description" text when we use the content builder. */}
       <EditDescriptionLinkContent />
     </Link>
   ) : (
@@ -58,16 +51,7 @@ const ProjectDescriptionPreview = ({ project }: Props) => {
       data-cy="e2e-project-description-preview-link-to-multiloc-settings"
       to={`/admin/projects/${projectId}/settings/description`}
     >
-      {isEmptyMultiloc(project.data.attributes.description_multiloc) ? (
-        <EditDescriptionLinkContent />
-      ) : (
-        <Text color="coolGrey600" m="0px" fontSize="s" p="0">
-          {stripHtml(
-            localize(project.data.attributes.description_multiloc),
-            100
-          )}
-        </Text>
-      )}
+      <EditDescriptionLinkContent />
     </Link>
   );
 };


### PR DESCRIPTION
Before
<img width="433" alt="Screenshot 2025-02-12 at 10 13 44" src="https://github.com/user-attachments/assets/96f7ee1a-2974-471a-8efa-db5eee137f79" />

After
<img width="386" alt="Screenshot 2025-02-12 at 10 13 53" src="https://github.com/user-attachments/assets/4a45b4f1-5399-4e1d-8930-41f19853e977" />


# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Changed
- Link to project description settings: always show "Edit description" as the link text instead of a description preview (as previewing HTML-formatted text turned out to be too tricky). [See before/after](https://github.com/CitizenLabDotCo/citizenlab/pull/10324).