### PR TITLE
Tan 3838/remove follow button from cards on user profile

### DIFF
--- a/front/app/components/IdeaCard/CardImage/index.tsx
+++ b/front/app/components/IdeaCard/CardImage/index.tsx
@@ -9,10 +9,10 @@ import Image from 'components/UI/Image';
 
 import ImagePlaceholder from './ImagePlaceholder';
 
-const IdeaCardImageWrapper = styled.div<{ $cardInnerHeight: string }>`
-  flex: 0 0 ${(props) => props.$cardInnerHeight};
-  width: ${(props) => props.$cardInnerHeight};
-  height: ${(props) => props.$cardInnerHeight};
+const IdeaCardImageWrapper = styled.div`
+  flex: 0 0 162px;
+  width: 162px;
+  height: 162px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -36,28 +36,22 @@ interface Props {
   phase?: IPhaseData;
   image: string | null;
   hideImagePlaceholder: boolean;
-  innerHeight: string;
 }
 
-const CardImage = ({
-  phase,
-  image,
-  hideImagePlaceholder,
-  innerHeight,
-}: Props) => {
+const CardImage = ({ phase, image, hideImagePlaceholder }: Props) => {
   const participationMethod = phase?.attributes.participation_method;
   const votingMethod = phase?.attributes.voting_method;
 
   return (
     <>
       {image && (
-        <IdeaCardImageWrapper $cardInnerHeight={innerHeight}>
+        <IdeaCardImageWrapper>
           <IdeaCardImage src={image} cover={true} alt="" />
         </IdeaCardImageWrapper>
       )}
 
       {!image && !hideImagePlaceholder && (
-        <IdeaCardImageWrapper $cardInnerHeight={innerHeight}>
+        <IdeaCardImageWrapper>
           <ImagePlaceholder
             participationMethod={participationMethod}
             votingMethod={votingMethod}

--- a/front/app/components/IdeaCard/IdeaCard.stories.tsx
+++ b/front/app/components/IdeaCard/IdeaCard.stories.tsx
@@ -55,7 +55,6 @@ export const Standard: Story = {
   render: (props) => <IdeaCards {...props} />,
   args: {
     ideaId: '1',
-    showFollowButton: false,
     hideImage: false,
     hideImagePlaceholder: false,
   },

--- a/front/app/components/IdeaCard/index.tsx
+++ b/front/app/components/IdeaCard/index.tsx
@@ -12,7 +12,6 @@ import usePhase from 'api/phases/usePhase';
 import useLocalize from 'hooks/useLocalize';
 
 import { IMAGES_LOADED_EVENT } from 'components/admin/ContentBuilder/constants';
-import FollowUnfollow from 'components/FollowUnfollow';
 
 import clHistory from 'utils/cl-router/history';
 import Link from 'utils/cl-router/Link';
@@ -34,18 +33,7 @@ export interface Props {
   hideImage?: boolean;
   hideImagePlaceholder?: boolean;
   hideIdeaStatus?: boolean;
-  showFollowButton?: boolean;
 }
-
-const IdeaLoading = (props: Props) => {
-  const { data: idea } = useIdeaById(props.ideaId);
-
-  if (idea) {
-    return <IdeaCard idea={idea} {...props} />;
-  }
-
-  return null;
-};
 
 interface IdeaCardProps extends Props {
   idea: IIdea;
@@ -57,7 +45,6 @@ const IdeaCard = ({
   hideImage = false,
   hideImagePlaceholder = false,
   hideIdeaStatus = false,
-  showFollowButton = false,
 }: IdeaCardProps) => {
   const { data: ideaImage } = useIdeaImage(
     idea.data.id,
@@ -118,8 +105,6 @@ const IdeaCard = ({
     });
   };
 
-  const innerHeight = showFollowButton ? '192px' : '162px';
-
   return (
     <Container
       className={`e2e-card e2e-idea-card`}
@@ -130,7 +115,6 @@ const IdeaCard = ({
         phase={phaseData}
         image={image}
         hideImagePlaceholder={hideImagePlaceholder}
-        innerHeight={innerHeight}
       />
 
       <Box
@@ -172,24 +156,18 @@ const IdeaCard = ({
             hideIdeaStatus={hideIdeaStatus}
             participationMethod={participationMethod}
           />
-          {showFollowButton && (
-            <Box mt="16px" display="flex" justifyContent="flex-end">
-              <FollowUnfollow
-                followableType="ideas"
-                followableId={idea.data.id}
-                followersCount={idea.data.attributes.followers_count}
-                // TODO: Fix this the next time the file is edited.
-                // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-                followerId={idea.data.relationships.user_follower?.data?.id}
-                w="auto"
-                toolTipType="input"
-              />
-            </Box>
-          )}
         </Box>
       </Box>
     </Container>
   );
 };
 
-export default IdeaLoading;
+export default (props: Props) => {
+  const { data: idea } = useIdeaById(props.ideaId);
+
+  if (idea) {
+    return <IdeaCard idea={idea} {...props} />;
+  }
+
+  return null;
+};

--- a/front/app/components/ProjectAndFolderCards/components/ProjectFolderCard/index.tsx
+++ b/front/app/components/ProjectAndFolderCards/components/ProjectFolderCard/index.tsx
@@ -26,7 +26,6 @@ import useProjectFolderById from 'api/project_folders/useProjectFolderById';
 import useLocalize from 'hooks/useLocalize';
 
 import AvatarBubbles from 'components/AvatarBubbles';
-import FollowUnfollow from 'components/FollowUnfollow';
 import { TLayout } from 'components/ProjectAndFolderCards';
 import T from 'components/T';
 import Image from 'components/UI/Image';
@@ -314,11 +313,10 @@ export interface Props {
   size: TProjectFolderCardSize;
   layout: TLayout;
   className?: string;
-  showFollowButton?: boolean;
 }
 
 const ProjectFolderCard = memo<Props>(
-  ({ folderId, size, layout, className, showFollowButton }) => {
+  ({ folderId, size, layout, className }) => {
     const isSmallerThanPhone = useBreakpoint('phone');
     const { data: projectFolder } = useProjectFolderById(folderId);
     const localize = useLocalize();
@@ -505,22 +503,6 @@ const ProjectFolderCard = memo<Props>(
                   />
                 </Box>
               </ContentFooter>
-            </Box>
-          )}
-          {showFollowButton && (
-            <Box display="flex" justifyContent="flex-end" mt="24px">
-              <FollowUnfollow
-                followableType="projects"
-                followableId={projectFolder.data.id}
-                followersCount={projectFolder.data.attributes.followers_count}
-                followerId={
-                  // TODO: Fix this the next time the file is edited.
-                  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-                  projectFolder.data.relationships.user_follower?.data?.id
-                }
-                w="100%"
-                toolTipType="projectOrFolder"
-              />
             </Box>
           )}
         </FolderContent>

--- a/front/app/components/ProjectCard/index.tsx
+++ b/front/app/components/ProjectCard/index.tsx
@@ -28,7 +28,6 @@ import useReport from 'api/reports/useReport';
 import useLocalize from 'hooks/useLocalize';
 
 import AvatarBubbles from 'components/AvatarBubbles';
-import FollowUnfollow from 'components/FollowUnfollow';
 import PhaseTimeLeft from 'components/PhaseTimeLeft';
 import { TLayout } from 'components/ProjectAndFolderCards';
 import T from 'components/T';
@@ -352,18 +351,10 @@ export interface InputProps {
   layout?: TLayout;
   hideDescriptionPreview?: boolean;
   className?: string;
-  showFollowButton?: boolean;
 }
 
 const ProjectCard = memo<InputProps>(
-  ({
-    projectId,
-    size,
-    layout,
-    hideDescriptionPreview,
-    className,
-    showFollowButton,
-  }) => {
+  ({ projectId, size, layout, hideDescriptionPreview, className }) => {
     const { ref: progressBarRef } = useInView({
       onChange: (inView) => {
         if (inView) {
@@ -615,22 +606,6 @@ const ProjectCard = memo<InputProps>(
                   />
                 </Box>
               </ContentFooter>
-            </Box>
-          )}
-          {showFollowButton && (
-            <Box display="flex" justifyContent="flex-end" mt="24px">
-              <FollowUnfollow
-                followableType="projects"
-                followableId={project.data.id}
-                followersCount={project.data.attributes.followers_count}
-                followerId={
-                  // TODO: Fix this the next time the file is edited.
-                  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-                  project.data.relationships.user_follower?.data?.id
-                }
-                w="100%"
-                toolTipType="projectOrFolder"
-              />
             </Box>
           )}
         </ProjectContent>

--- a/front/app/containers/UsersShowPage/Following/UserFollowingList.tsx
+++ b/front/app/containers/UsersShowPage/Following/UserFollowingList.tsx
@@ -81,7 +81,6 @@ const UserFollowingList = ({ value }: Props) => {
                   key={follower.id}
                   projectId={follower.relationships.followable.data.id}
                   size="small"
-                  showFollowButton
                 />
               );
             } else if (
@@ -93,7 +92,6 @@ const UserFollowingList = ({ value }: Props) => {
                   folderId={follower.relationships.followable.data.id}
                   size="small"
                   layout="threecolumns"
-                  showFollowButton
                 />
               );
             }

--- a/front/app/containers/UsersShowPage/Following/UserFollowingList.tsx
+++ b/front/app/containers/UsersShowPage/Following/UserFollowingList.tsx
@@ -69,7 +69,6 @@ const UserFollowingList = ({ value }: Props) => {
                   <Box width="100%">
                     <IdeaCard
                       ideaId={follower.relationships.followable.data.id}
-                      showFollowButton
                     />
                   </Box>
                 </Box>


### PR DESCRIPTION
See TAN-3838 for the reason.

Before
<img width="998" alt="Screenshot 2025-02-12 at 13 56 35" src="https://github.com/user-attachments/assets/cca71a94-0cea-4db1-a17e-d2410db27d2e" />
<img width="994" alt="Screenshot 2025-02-12 at 13 56 30" src="https://github.com/user-attachments/assets/e3ffd360-410d-4f91-8d5f-7b388a63a3a7" />

After
<img width="993" alt="Screenshot 2025-02-12 at 13 56 08" src="https://github.com/user-attachments/assets/b2c29a26-4c0e-4ea1-9844-0c4936ec1f46" />
<img width="998" alt="Screenshot 2025-02-12 at 13 56 14" src="https://github.com/user-attachments/assets/2c4bfeb6-519a-4b67-9516-ebde32ccde6f" />


# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Changed
- Remove follow buttons from input/project/folder cards on user profile pages ([before/after](https://github.com/CitizenLabDotCo/citizenlab/pull/10328)).