### PR TITLE
Fix date picker jumping around when navigating

### DIFF
--- a/front/app/components/admin/DatePickers/DatePhasePicker/Calendar/index.tsx
+++ b/front/app/components/admin/DatePickers/DatePhasePicker/Calendar/index.tsx
@@ -199,6 +199,7 @@ const Calendar = ({
         mode="range"
         numberOfMonths={2}
         captionLayout="dropdown"
+        fixedWeeks
         locale={getLocale(locale)}
         startMonth={startMonth}
         endMonth={endMonth}

--- a/front/app/components/admin/DatePickers/DateRangePicker/Calendar/index.tsx
+++ b/front/app/components/admin/DatePickers/DateRangePicker/Calendar/index.tsx
@@ -74,6 +74,7 @@ const Calendar = ({
         mode="range"
         numberOfMonths={numberOfMonths}
         captionLayout="dropdown"
+        fixedWeeks
         locale={getLocale(locale)}
         startMonth={startMonth}
         endMonth={endMonth}

--- a/front/app/components/admin/DatePickers/DateSinglePicker/Calendar/index.tsx
+++ b/front/app/components/admin/DatePickers/DateSinglePicker/Calendar/index.tsx
@@ -43,6 +43,7 @@ const Calendar = ({
       <DayPicker
         mode="single"
         captionLayout="dropdown"
+        fixedWeeks
         locale={getLocale(locale)}
         startMonth={startMonth}
         endMonth={endMonth}


### PR DESCRIPTION
# Changelog
## Fixed
- Date picker 'jumping around' when navigating through the months. Also you could have just clicked on the month and/or year to open a dropdown and navigate to the correct month like that