### PR TITLE
Revert "Fix capitalization"

### DIFF
--- a/front/app/containers/Admin/projects/project/nativeSurvey/messages.ts
+++ b/front/app/containers/Admin/projects/project/nativeSurvey/messages.ts
@@ -180,8 +180,8 @@ export default defineMessages({
     defaultMessage: 'Esri shapefile upload',
   },
   downloadExcelTemplate: {
-    id: 'app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplate',
-    defaultMessage: 'Download an Excel template',
+    id: 'app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplate1',
+    defaultMessage: 'Download an excel template',
   },
   importInputs: {
     id: 'app.containers.AdminPage.ProjectEdit.survey.importInputs',

--- a/front/app/translations/admin/ar-SA.json
+++ b/front/app/translations/admin/ar-SA.json
@@ -1833,6 +1833,7 @@
   "app.containers.AdminPage.ProjectEdit.survey.disabledImportInputsTooltip": "لم يتم تضمين هذه الميزة في خطتك الحالية. تواصل مع مدير GovSuccess الخاص بك لمعرفة المزيد حول هذا الموضوع.",
   "app.containers.AdminPage.ProjectEdit.survey.disabledSurveyMessage2": "لا يمكن تعديل محتوى الاستبيان؛ إذ بدأت نتائج الاستبيان في القدوم.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadAllResults2": "تنزيل كل نتائج الاستبيان",
+  "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplate1": "تحميل قالب اكسل",
   "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplateTooltip": "لن تتضمن قوالب Excel أي أسئلة حول إدخال التعيينات، حيث إنها غير مدعومة للاستيراد المجمع في الوقت الحالي.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadResults2": "تنزيل نتائج الاستبيان",
   "app.containers.AdminPage.ProjectEdit.survey.downloadSurvey": "تحميل الاستبيان بصيغة pdf",

--- a/front/app/translations/admin/cy-GB.json
+++ b/front/app/translations/admin/cy-GB.json
@@ -1833,6 +1833,7 @@
   "app.containers.AdminPage.ProjectEdit.survey.disabledImportInputsTooltip": "Nid yw'r nodwedd hon wedi'i chynnwys yn eich cynllun cyfredol. Cysylltwch â'ch Rheolwr GovSuccess i ddysgu mwy amdano.",
   "app.containers.AdminPage.ProjectEdit.survey.disabledSurveyMessage2": "Nid oes modd golygu cynnwys yr arolwg gan fod canlyniadau'r arolwg wedi dechrau dod i mewn.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadAllResults2": "Lawrlwythwch holl ganlyniadau'r arolwg",
+  "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplate1": "Lawrlwythwch templed excel",
   "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplateTooltip": "Ni fydd templedi Excel yn cynnwys unrhyw gwestiynau mewnbwn mapio gan nad yw'r rhain yn cael eu cefnogi ar gyfer mewnforio swmp ar hyn o bryd.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadResults2": "Lawrlwytho canlyniadau arolwg",
   "app.containers.AdminPage.ProjectEdit.survey.downloadSurvey": "Lawrlwythwch yr arolwg fel pdf",

--- a/front/app/translations/admin/da-DK.json
+++ b/front/app/translations/admin/da-DK.json
@@ -1833,6 +1833,7 @@
   "app.containers.AdminPage.ProjectEdit.survey.disabledImportInputsTooltip": "Denne funktion er ikke inkluderet i din nuværende plan. Kontakt din GovSuccess Manager for at høre mere om den.",
   "app.containers.AdminPage.ProjectEdit.survey.disabledSurveyMessage2": "Undersøgelsesindholdet kan ikke redigeres, da undersøgelsesresultaterne er begyndt at komme ind.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadAllResults2": "Hent alle undersøgelsesresultater",
+  "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplate1": "Download en Excel-skabelon",
   "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplateTooltip": "Excel-skabeloner vil ikke indeholde spørgsmål om kortlægningsinput, da disse ikke understøttes til masseimport på nuværende tidspunkt.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadResults2": "Hent undersøgelsesresultater",
   "app.containers.AdminPage.ProjectEdit.survey.downloadSurvey": "Download undersøgelsen som pdf",

--- a/front/app/translations/admin/de-DE.json
+++ b/front/app/translations/admin/de-DE.json
@@ -1833,6 +1833,7 @@
   "app.containers.AdminPage.ProjectEdit.survey.disabledImportInputsTooltip": "Diese Funktion ist in Ihrer aktuellen Lizenz nicht enthalten. Sprechen Sie mit Ihrer Kundenbetreuerin oder Ihrem Admin, um sie freizuschalten.",
   "app.containers.AdminPage.ProjectEdit.survey.disabledSurveyMessage2": "Der Inhalt der Umfrage kann nicht mehr bearbeitet werden, da die ersten Umfrageergebnisse bereits vorliegen.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadAllResults2": "Alle Umfrageergebnisse herunterladen",
+  "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplate1": "Download einer Excel-Vorlage",
   "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplateTooltip": "Excel-Vorlagen enthalten keine Kartenfragen, da diese derzeit für den Massenimport nicht unterstützt werden.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadResults2": "Umfrageergebnisse herunterladen",
   "app.containers.AdminPage.ProjectEdit.survey.downloadSurvey": "Umfrage als PDF herunterladen",

--- a/front/app/translations/admin/en-CA.json
+++ b/front/app/translations/admin/en-CA.json
@@ -1833,6 +1833,7 @@
   "app.containers.AdminPage.ProjectEdit.survey.disabledImportInputsTooltip": "This feature is not included in your current plan. Reach out to your GovSuccess Manager to learn more about it.",
   "app.containers.AdminPage.ProjectEdit.survey.disabledSurveyMessage2": "Survey content can't be edited as survey results have started coming in.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadAllResults2": "Download all survey results",
+  "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplate1": "Download an excel template",
   "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplateTooltip": "Excel templates will not include any mapping input questions as these are not supported for bulk importing at this time.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadResults2": "Download survey results",
   "app.containers.AdminPage.ProjectEdit.survey.downloadSurvey": "Download survey as pdf",

--- a/front/app/translations/admin/en-GB.json
+++ b/front/app/translations/admin/en-GB.json
@@ -1833,6 +1833,7 @@
   "app.containers.AdminPage.ProjectEdit.survey.disabledImportInputsTooltip": "This feature is not included in your current plan. Reach out to your GovSuccess Manager to learn more about it.",
   "app.containers.AdminPage.ProjectEdit.survey.disabledSurveyMessage2": "Survey content can't be edited as survey results have started coming in.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadAllResults2": "Download all survey results",
+  "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplate1": "Download an excel template",
   "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplateTooltip": "Excel templates will not include any mapping input questions as these are not supported for bulk importing at this time.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadResults2": "Download survey results",
   "app.containers.AdminPage.ProjectEdit.survey.downloadSurvey": "Download survey as pdf",

--- a/front/app/translations/admin/en-IE.json
+++ b/front/app/translations/admin/en-IE.json
@@ -1833,6 +1833,7 @@
   "app.containers.AdminPage.ProjectEdit.survey.disabledImportInputsTooltip": "This feature is not included in your current plan. Reach out to your GovSuccess Manager to learn more about it.",
   "app.containers.AdminPage.ProjectEdit.survey.disabledSurveyMessage2": "Survey content can't be edited as survey results have started coming in.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadAllResults2": "Download all survey results",
+  "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplate1": "Download an excel template",
   "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplateTooltip": "Excel templates will not include any mapping input questions as these are not supported for bulk importing at this time.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadResults2": "Download survey results",
   "app.containers.AdminPage.ProjectEdit.survey.downloadSurvey": "Download survey as pdf",

--- a/front/app/translations/admin/en.json
+++ b/front/app/translations/admin/en.json
@@ -1833,7 +1833,7 @@
   "app.containers.AdminPage.ProjectEdit.survey.disabledImportInputsTooltip": "This feature is not included in your current plan. Reach out to your GovSuccess Manager to learn more about it.",
   "app.containers.AdminPage.ProjectEdit.survey.disabledSurveyMessage2": "Survey content can't be edited as survey results have started coming in.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadAllResults2": "Download all survey results",
-  "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplate": "Download an Excel template",
+  "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplate1": "Download an excel template",
   "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplateTooltip": "Excel templates will not include any mapping input questions as these are not supported for bulk importing at this time.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadResults2": "Download survey results",
   "app.containers.AdminPage.ProjectEdit.survey.downloadSurvey": "Download survey as pdf",

--- a/front/app/translations/admin/es-CL.json
+++ b/front/app/translations/admin/es-CL.json
@@ -1833,6 +1833,7 @@
   "app.containers.AdminPage.ProjectEdit.survey.disabledImportInputsTooltip": "Esta función no está incluida en tu plan actual. Ponte en contacto con tu Gestor de GovSuccess para obtener más información.",
   "app.containers.AdminPage.ProjectEdit.survey.disabledSurveyMessage2": "El contenido de la encuesta no puede editarse, ya que los resultados han empezado a llegar.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadAllResults2": "Descargar todos los resultados de la encuesta",
+  "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplate1": "Descargar una plantilla Excel",
   "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplateTooltip": "Las plantillas de Excel no incluirán ninguna pregunta de introducción de mapas, ya que por el momento no se admiten para la importación masiva.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadResults2": "Descargar los resultados de la encuesta",
   "app.containers.AdminPage.ProjectEdit.survey.downloadSurvey": "Descargar encuesta como pdf",

--- a/front/app/translations/admin/es-ES.json
+++ b/front/app/translations/admin/es-ES.json
@@ -1833,6 +1833,7 @@
   "app.containers.AdminPage.ProjectEdit.survey.disabledImportInputsTooltip": "Esta función no está incluida en tu plan actual. Ponte en contacto con tu Gestor de GovSuccess para obtener más información.",
   "app.containers.AdminPage.ProjectEdit.survey.disabledSurveyMessage2": "El contenido de la encuesta no se puede editar ya que los resultados de la encuesta han empezado a llegar.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadAllResults2": "Descargar todos los resultados de la encuesta",
+  "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplate1": "Descargar una plantilla Excel",
   "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplateTooltip": "Las plantillas de Excel no incluirán ninguna pregunta de introducción de mapas, ya que por el momento no se admiten para la importación masiva.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadResults2": "Descargar los resultados de la encuesta",
   "app.containers.AdminPage.ProjectEdit.survey.downloadSurvey": "Descargar encuesta como pdf",

--- a/front/app/translations/admin/fi-FI.json
+++ b/front/app/translations/admin/fi-FI.json
@@ -1833,6 +1833,7 @@
   "app.containers.AdminPage.ProjectEdit.survey.disabledImportInputsTooltip": "Tämä ominaisuus ei sisälly nykyiseen suunnitelmaasi. Ota yhteyttä GovSuccess Manageriin saadaksesi lisätietoja siitä.",
   "app.containers.AdminPage.ProjectEdit.survey.disabledSurveyMessage2": "Kyselyn sisältöä ei voi muokata, koska kyselyn tuloksia on alkanut tulla.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadAllResults2": "Lataa kaikki kyselyn tulokset",
+  "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplate1": "Lataa Excel-malli",
   "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplateTooltip": "Excel-mallit eivät sisällä kartoitussyöttökysymyksiä, koska niitä ei tueta joukkotuonnissa tällä hetkellä.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadResults2": "Lataa kyselyn tulokset",
   "app.containers.AdminPage.ProjectEdit.survey.downloadSurvey": "Lataa kysely pdf-muodossa",

--- a/front/app/translations/admin/fr-BE.json
+++ b/front/app/translations/admin/fr-BE.json
@@ -1833,6 +1833,7 @@
   "app.containers.AdminPage.ProjectEdit.survey.disabledImportInputsTooltip": "Cette fonctionnalité n'est pas incluse dans votre plan actuel. Contactez votre Spécialiste en participation Go Vocal pour en savoir plus.",
   "app.containers.AdminPage.ProjectEdit.survey.disabledSurveyMessage2": "Le contenu de l'enquête ne peut pas être modifié car les résultats de l'enquête ont commencé à arriver.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadAllResults2": "Télécharger tous les résultats de l'enquête",
+  "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplate1": "Télécharger un modèle Excel",
   "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplateTooltip": "Les modèles Excel n'incluent pas les questions de type cartographie, car leur importation n'est pas encore prise en charge.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadResults2": "Télécharger les résultats de l'enquête",
   "app.containers.AdminPage.ProjectEdit.survey.downloadSurvey": "Télécharger l'enquête au format PDF",

--- a/front/app/translations/admin/fr-FR.json
+++ b/front/app/translations/admin/fr-FR.json
@@ -1833,6 +1833,7 @@
   "app.containers.AdminPage.ProjectEdit.survey.disabledImportInputsTooltip": "Cette fonctionnalité n'est pas incluse dans votre plan actuel. Contactez votre Spécialiste en participation Go Vocal pour en savoir plus.",
   "app.containers.AdminPage.ProjectEdit.survey.disabledSurveyMessage2": "Le contenu des enquêtes ne peut pas être édité car les résultats des enquêtes ont commencé à arriver.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadAllResults2": "Télécharger tous les résultats de l'enquête",
+  "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplate1": "Télécharger un modèle Excel",
   "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplateTooltip": "Les modèles Excel n'incluent pas les questions de type cartographie, car leur importation n'est pas encore prise en charge.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadResults2": "Télécharger les résultats de l'enquête",
   "app.containers.AdminPage.ProjectEdit.survey.downloadSurvey": "Télécharger l'enquête au format PDF",

--- a/front/app/translations/admin/hr-HR.json
+++ b/front/app/translations/admin/hr-HR.json
@@ -1833,6 +1833,7 @@
   "app.containers.AdminPage.ProjectEdit.survey.disabledImportInputsTooltip": "Ova značajka nije uključena u vaš trenutni plan. Obratite se svom GovSuccess Manageru da saznate više o tome.",
   "app.containers.AdminPage.ProjectEdit.survey.disabledSurveyMessage2": "Sadržaj upitnika nije moguće uređivati jer su rezultati upitnika počeli pristizati.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadAllResults2": "Preuzmi sve rezultate upitnika",
+  "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplate1": "Preuzmite excel predložak",
   "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplateTooltip": "Predlošci programa Excel neće sadržavati nikakva pitanja o unosu mapiranja jer trenutno nisu podržana za skupni uvoz.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadResults2": "Preuzmi rezultate upitnika",
   "app.containers.AdminPage.ProjectEdit.survey.downloadSurvey": "Preuzmite anketu kao pdf",

--- a/front/app/translations/admin/lt-LT.json
+++ b/front/app/translations/admin/lt-LT.json
@@ -1833,6 +1833,7 @@
   "app.containers.AdminPage.ProjectEdit.survey.disabledImportInputsTooltip": "Ši funkcija neįtraukta į dabartinį planą. Susisiekite su savo \"GovSuccess\" vadybininku ir sužinokite apie ją daugiau.",
   "app.containers.AdminPage.ProjectEdit.survey.disabledSurveyMessage2": "Apklausos turinio negalima redaguoti, nes apklausos rezultatai jau pradėti gauti.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadAllResults2": "Atsisiųsti visus apklausos rezultatus",
+  "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplate1": "Atsisiųsti \"Excel\" šabloną",
   "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplateTooltip": "Į \"Excel\" šablonus nebus įtraukti jokie žemėlapių įvesties klausimai, nes šiuo metu jie nepalaikomi masiniam importui.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadResults2": "Atsisiųsti apklausos rezultatus",
   "app.containers.AdminPage.ProjectEdit.survey.downloadSurvey": "Atsisiųsti apklausą kaip pdf",

--- a/front/app/translations/admin/lv-LV.json
+++ b/front/app/translations/admin/lv-LV.json
@@ -1833,6 +1833,7 @@
   "app.containers.AdminPage.ProjectEdit.survey.disabledImportInputsTooltip": "Šī funkcija nav iekļauta jūsu pašreizējā plānā. Sazinieties ar savu GovSuccess menedžeri, lai uzzinātu vairāk par to.",
   "app.containers.AdminPage.ProjectEdit.survey.disabledSurveyMessage2": "Aptaujas saturu nevar rediģēt, jo ir sākusies apsekojumu rezultātu saņemšana.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadAllResults2": "Lejupielādēt visus apsekojuma rezultātus",
+  "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplate1": "Lejupielādēt Excel veidni",
   "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplateTooltip": "Excel veidnēs nebūs iekļauti kartēšanas ievades jautājumi, jo pašlaik tie netiek atbalstīti masveida importēšanai.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadResults2": "Aptaujas rezultātu lejupielāde",
   "app.containers.AdminPage.ProjectEdit.survey.downloadSurvey": "Lejupielādēt apsekojumu pdf formātā",

--- a/front/app/translations/admin/nb-NO.json
+++ b/front/app/translations/admin/nb-NO.json
@@ -1833,6 +1833,7 @@
   "app.containers.AdminPage.ProjectEdit.survey.disabledImportInputsTooltip": "Denne funksjonen er ikke inkludert i din nåværende plan. Ta kontakt med din GovSuccess Manager for å finne ut mer om den.",
   "app.containers.AdminPage.ProjectEdit.survey.disabledSurveyMessage2": "Innholdet i undersøkelsen kan ikke redigeres etter hvert som resultatene har begynt å komme inn.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadAllResults2": "Last ned alle resultatene fra undersøkelsen",
+  "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplate1": "Last ned en Excel-mal",
   "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplateTooltip": "Excel-maler vil ikke inneholde noen spørsmål om kartleggingsinndata, ettersom disse ikke støttes for masseimport på nåværende tidspunkt.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadResults2": "Last ned resultatene fra undersøkelsen",
   "app.containers.AdminPage.ProjectEdit.survey.downloadSurvey": "Last ned undersøkelsen som pdf",

--- a/front/app/translations/admin/nl-BE.json
+++ b/front/app/translations/admin/nl-BE.json
@@ -1833,6 +1833,7 @@
   "app.containers.AdminPage.ProjectEdit.survey.disabledImportInputsTooltip": "Deze functionaliteit is niet in je huidige abonnement inbegrepen. Neem contact op met je Government Success Manager voor meer informatie.",
   "app.containers.AdminPage.ProjectEdit.survey.disabledSurveyMessage2": "De inhoud van de enquête kan niet worden bewerkt nu de enquêteresultaten binnenkomen.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadAllResults2": "Download alle enquêteresultaten",
+  "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplate1": "Download een Excel-sjabloon",
   "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplateTooltip": "Excel-sjablonen bevatten geen kaart-gerelateerde vragen, omdat deze op dit moment niet worden ondersteund voor bulkimport.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadResults2": "Download de resultaten van de enquête",
   "app.containers.AdminPage.ProjectEdit.survey.downloadSurvey": "Download vragenlijst als pdf",

--- a/front/app/translations/admin/nl-NL.json
+++ b/front/app/translations/admin/nl-NL.json
@@ -1833,6 +1833,7 @@
   "app.containers.AdminPage.ProjectEdit.survey.disabledImportInputsTooltip": "Deze functionaliteit is niet in je huidige abonnement inbegrepen. Neem contact op met je Government Success Manager voor meer informatie.",
   "app.containers.AdminPage.ProjectEdit.survey.disabledSurveyMessage2": "De inhoud van de vragenlijst kan niet worden bewerkt nu de resultaten binnenkomen.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadAllResults2": "Download alle onderzoeksresultaten",
+  "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplate1": "Download een Excel-sjabloon",
   "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplateTooltip": "Excel-sjablonen bevatten geen kaart-gerelateerde vragen, omdat deze op dit moment niet worden ondersteund voor bulkimport.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadResults2": "Download de resultaten van de vragenlijst",
   "app.containers.AdminPage.ProjectEdit.survey.downloadSurvey": "Download vragenlijst als pdf",

--- a/front/app/translations/admin/pa-IN.json
+++ b/front/app/translations/admin/pa-IN.json
@@ -1833,6 +1833,7 @@
   "app.containers.AdminPage.ProjectEdit.survey.disabledImportInputsTooltip": "ਇਹ ਵਿਸ਼ੇਸ਼ਤਾ ਤੁਹਾਡੀ ਮੌਜੂਦਾ ਯੋਜਨਾ ਵਿੱਚ ਸ਼ਾਮਲ ਨਹੀਂ ਹੈ। ਇਸ ਬਾਰੇ ਹੋਰ ਜਾਣਨ ਲਈ ਆਪਣੇ GovSuccess ਮੈਨੇਜਰ ਨਾਲ ਸੰਪਰਕ ਕਰੋ।",
   "app.containers.AdminPage.ProjectEdit.survey.disabledSurveyMessage2": "ਸਰਵੇਖਣ ਸਮੱਗਰੀ ਨੂੰ ਸੰਪਾਦਿਤ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਦਾ ਕਿਉਂਕਿ ਸਰਵੇਖਣ ਨਤੀਜੇ ਆਉਣੇ ਸ਼ੁਰੂ ਹੋ ਗਏ ਹਨ।",
   "app.containers.AdminPage.ProjectEdit.survey.downloadAllResults2": "ਸਾਰੇ ਸਰਵੇਖਣ ਨਤੀਜੇ ਡਾਊਨਲੋਡ ਕਰੋ",
+  "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplate1": "ਇੱਕ ਐਕਸਲ ਟੈਂਪਲੇਟ ਡਾਊਨਲੋਡ ਕਰੋ",
   "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplateTooltip": "ਐਕਸਲ ਟੈਂਪਲੇਟਸ ਵਿੱਚ ਕੋਈ ਵੀ ਮੈਪਿੰਗ ਇਨਪੁਟ ਸਵਾਲ ਸ਼ਾਮਲ ਨਹੀਂ ਹੋਣਗੇ ਕਿਉਂਕਿ ਇਹ ਇਸ ਸਮੇਂ ਬਲਕ ਆਯਾਤ ਲਈ ਸਮਰਥਿਤ ਨਹੀਂ ਹਨ।",
   "app.containers.AdminPage.ProjectEdit.survey.downloadResults2": "ਸਰਵੇਖਣ ਨਤੀਜੇ ਡਾਊਨਲੋਡ ਕਰੋ",
   "app.containers.AdminPage.ProjectEdit.survey.downloadSurvey": "ਸਰਵੇਖਣ ਨੂੰ ਪੀਡੀਐਫ ਵਜੋਂ ਡਾਊਨਲੋਡ ਕਰੋ",

--- a/front/app/translations/admin/pl-PL.json
+++ b/front/app/translations/admin/pl-PL.json
@@ -1833,6 +1833,7 @@
   "app.containers.AdminPage.ProjectEdit.survey.disabledImportInputsTooltip": "Ta funkcja nie jest uwzględniona w Twoim obecnym planie. Skontaktuj się ze swoim menedżerem GovSuccess, aby dowiedzieć się więcej na ten temat.",
   "app.containers.AdminPage.ProjectEdit.survey.disabledSurveyMessage2": "Treść ankiety nie może być edytowana, ponieważ zaczęły napływać wyniki ankiet.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadAllResults2": "Pobierz wszystkie wyniki badań",
+  "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplate1": "Pobierz szablon Excel",
   "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplateTooltip": "Szablony Excel nie będą zawierać żadnych pytań dotyczących mapowania, ponieważ nie są one obecnie obsługiwane w przypadku importu zbiorczego.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadResults2": "Pobierz wyniki badania",
   "app.containers.AdminPage.ProjectEdit.survey.downloadSurvey": "Pobierz ankietę w formacie pdf",

--- a/front/app/translations/admin/pt-BR.json
+++ b/front/app/translations/admin/pt-BR.json
@@ -1833,6 +1833,7 @@
   "app.containers.AdminPage.ProjectEdit.survey.disabledImportInputsTooltip": "Esse recurso não está incluído em seu plano atual. Entre em contato com seu gerente do GovSuccess para saber mais sobre ele.",
   "app.containers.AdminPage.ProjectEdit.survey.disabledSurveyMessage2": "O conteúdo da pesquisa não pode ser editado, uma vez que os resultados da pesquisa já começaram a chegar.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadAllResults2": "Descarregar todos os resultados da pesquisa",
+  "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplate1": "Faça o download de um modelo do Excel",
   "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplateTooltip": "Os modelos do Excel não incluirão nenhuma pergunta de entrada de mapeamento, pois elas não são compatíveis com a importação em massa no momento.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadResults2": "Descarregar resultados da pesquisa",
   "app.containers.AdminPage.ProjectEdit.survey.downloadSurvey": "Baixe a pesquisa em PDF",

--- a/front/app/translations/admin/sr-Latn.json
+++ b/front/app/translations/admin/sr-Latn.json
@@ -1833,6 +1833,7 @@
   "app.containers.AdminPage.ProjectEdit.survey.disabledImportInputsTooltip": "This feature is not included in your current plan. Reach out to your GovSuccess Manager to learn more about it.",
   "app.containers.AdminPage.ProjectEdit.survey.disabledSurveyMessage2": "Sadržaj ankete ne može se uređivati zato što su rezultati ankete počeli da pristižu.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadAllResults2": "Preuzmi sve rezultate ankete",
+  "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplate1": "Download an excel template",
   "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplateTooltip": "Excel templates will not include any mapping input questions as these are not supported for bulk importing at this time.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadResults2": "Preuzmi rezultate ankete",
   "app.containers.AdminPage.ProjectEdit.survey.downloadSurvey": "Download survey as pdf",

--- a/front/app/translations/admin/sr-SP.json
+++ b/front/app/translations/admin/sr-SP.json
@@ -1833,6 +1833,7 @@
   "app.containers.AdminPage.ProjectEdit.survey.disabledImportInputsTooltip": "This feature is not included in your current plan. Reach out to your GovSuccess Manager to learn more about it.",
   "app.containers.AdminPage.ProjectEdit.survey.disabledSurveyMessage2": "Садржај анкете се не може уређивати јер су почели да пристижу резултати анкете.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadAllResults2": "Преузмите све резултате анкете",
+  "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplate1": "Преузмите Екцел шаблон",
   "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplateTooltip": "Excel templates will not include any mapping input questions as these are not supported for bulk importing at this time.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadResults2": "Преузмите резултате анкете",
   "app.containers.AdminPage.ProjectEdit.survey.downloadSurvey": "Преузмите анкету у пдф формату",

--- a/front/app/translations/admin/sv-SE.json
+++ b/front/app/translations/admin/sv-SE.json
@@ -1833,6 +1833,7 @@
   "app.containers.AdminPage.ProjectEdit.survey.disabledImportInputsTooltip": "Den här funktionen ingår inte i din nuvarande plan. Kontakta din GovSuccess Manager om du vill veta mer om den.",
   "app.containers.AdminPage.ProjectEdit.survey.disabledSurveyMessage2": "Undersökningsinnehållet kan inte redigeras när undersökningsresultat har börjat komma in.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadAllResults2": "Ladda ner alla undersökningsresultat",
+  "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplate1": "Ladda ner en Excel-mall",
   "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplateTooltip": "Excel-mallarna kommer inte att innehålla några frågor om mappning eftersom dessa inte stöds för bulkimport för närvarande.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadResults2": "Ladda ner undersökningsresultat",
   "app.containers.AdminPage.ProjectEdit.survey.downloadSurvey": "Ladda ner undersökningen som pdf",

--- a/front/app/translations/admin/tr-TR.json
+++ b/front/app/translations/admin/tr-TR.json
@@ -1833,6 +1833,7 @@
   "app.containers.AdminPage.ProjectEdit.survey.disabledImportInputsTooltip": "Bu özellik mevcut planınıza dahil değildir. Bu konuda daha fazla bilgi edinmek için GovSuccess Yöneticinize ulaşın.",
   "app.containers.AdminPage.ProjectEdit.survey.disabledSurveyMessage2": "Anket sonuçları gelmeye başladığı için anket içeriği düzenlenemiyor.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadAllResults2": "Tüm anket sonuçlarını indirin",
+  "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplate1": "Bir excel şablonu indirin",
   "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplateTooltip": "Şu anda toplu içe aktarma için desteklenmediğinden, Excel şablonları herhangi bir eşleme giriş sorusu içermeyecektir.",
   "app.containers.AdminPage.ProjectEdit.survey.downloadResults2": "Anket sonuçlarını indirin",
   "app.containers.AdminPage.ProjectEdit.survey.downloadSurvey": "Anketi pdf olarak indirin",

--- a/front/app/translations/admin/ur-PK.json
+++ b/front/app/translations/admin/ur-PK.json
@@ -1833,6 +1833,7 @@
   "app.containers.AdminPage.ProjectEdit.survey.disabledImportInputsTooltip": "یہ خصوصیت آپ کے موجودہ پلان میں شامل نہیں ہے۔ اس کے بارے میں مزید جاننے کے لیے اپنے GovSuccess مینیجر سے رابطہ کریں۔",
   "app.containers.AdminPage.ProjectEdit.survey.disabledSurveyMessage2": "سروے کے مواد میں ترمیم نہیں کی جا سکتی کیونکہ سروے کے نتائج آنا شروع ہو گئے ہیں۔",
   "app.containers.AdminPage.ProjectEdit.survey.downloadAllResults2": "سروے کے تمام نتائج ڈاؤن لوڈ کریں۔",
+  "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplate1": "ایکسل ٹیمپلیٹ ڈاؤن لوڈ کریں۔",
   "app.containers.AdminPage.ProjectEdit.survey.downloadExcelTemplateTooltip": "ایکسل ٹیمپلیٹس میں کوئی میپنگ ان پٹ سوالات شامل نہیں ہوں گے کیونکہ یہ اس وقت بلک امپورٹنگ کے لیے تعاون یافتہ نہیں ہیں۔",
   "app.containers.AdminPage.ProjectEdit.survey.downloadResults2": "سروے کے نتائج ڈاؤن لوڈ کریں۔",
   "app.containers.AdminPage.ProjectEdit.survey.downloadSurvey": "سروے کو پی ڈی ایف کے طور پر ڈاؤن لوڈ کریں۔",


### PR DESCRIPTION
Reverts CitizenLabDotCo/citizenlab#10362.

(Reason: translations checker was all ✅ but no translations exist. Might be a conflict in Crowdin's memory since I reused an id we used before.)
