### PR TITLE
Saving of inputs (proposals) with "prescreening" status

### DIFF
--- a/front/app/api/ideas/types.ts
+++ b/front/app/api/ideas/types.ts
@@ -198,7 +198,6 @@ export interface IIdeaAdd {
 export interface IIdeaUpdate {
   // All optional
   project_id?: string | null;
-  publication_status?: IdeaPublicationStatus;
   title_multiloc?: Multiloc;
   author_id?: string | null;
   assignee_id?: string | null;

--- a/front/app/api/ideas/useAddIdea.test.ts
+++ b/front/app/api/ideas/useAddIdea.test.ts
@@ -30,7 +30,6 @@ describe('useAddIdea', () => {
         title_multiloc: {
           en: 'test',
         },
-        publication_status: 'published',
         body_multiloc: {
           en: 'test',
         },
@@ -58,7 +57,6 @@ describe('useAddIdea', () => {
         title_multiloc: {
           en: 'test',
         },
-        publication_status: 'published',
         body_multiloc: {
           en: 'test',
         },

--- a/front/app/containers/Admin/projects/project/inputImporter/ReviewSection/IdeaEditor/index.tsx
+++ b/front/app/containers/Admin/projects/project/inputImporter/ReviewSection/IdeaEditor/index.tsx
@@ -194,7 +194,6 @@ const IdeaEditor = ({ ideaId, setIdeaId }: Props) => {
       await updateIdea({
         id: ideaId,
         requestBody: {
-          publication_status: 'published',
           ...supportedFormData,
           ...(location_description ? { location_description } : {}),
           ...(location_point_geojson ? { location_point_geojson } : {}),

--- a/front/app/containers/IdeasEditPage/IdeasEditForm.tsx
+++ b/front/app/containers/IdeasEditPage/IdeasEditForm.tsx
@@ -190,7 +190,6 @@ const IdeasEditForm = ({ ideaId }: Props) => {
       idea_images_attributes,
       location_point_geojson,
       project_id: projectId,
-      publication_status: 'published',
     };
 
     const idea = await updateIdea({


### PR DESCRIPTION
@adessy Quick fix so our client can proceed. It indeed doesn't seem necessary to send over publication_status along when updating an input. I'd still like to spend some time on how to prevent similar bugs in the future.

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Saving of inputs (including proposals) with "prescreening" status.