### PR TITLE
[TAN-3687] Rename domicile fields to "Waar woon je?" in Dutch

### DIFF
--- a/back/db/migrate/20250224150953_rename_nl_domicile_field_to_waarde_woon_je.rb
+++ b/back/db/migrate/20250224150953_rename_nl_domicile_field_to_waarde_woon_je.rb
@@ -1,0 +1,17 @@
+class RenameNlDomicileFieldToWaardeWoonJe < ActiveRecord::Migration[7.1]
+  class CustomField < ApplicationRecord
+    self.table_name = 'custom_fields'
+  end
+
+  def change
+    domicile_field = CustomField.find_by(key: 'domicile')
+    return unless domicile_field
+
+    title_multiloc = domicile_field.title_multiloc
+    title_multiloc['nl-NL'] = 'Waar woon je?' if title_multiloc.key?('nl-NL')
+    title_multiloc['nl-BE'] = 'Waar woon je?' if title_multiloc.key?('nl-BE')
+    return if title_multiloc['nl-NL'].nil? && title_multiloc['nl-BE'].nil?
+
+    domicile_field.update!(title_multiloc: title_multiloc)
+  end
+end

--- a/back/db/structure.sql
+++ b/back/db/structure.sql
@@ -6826,6 +6826,7 @@ ALTER TABLE ONLY public.ideas_topics
 SET search_path TO public,shared_extensions;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250224150953'),
 ('20250204143605'),
 ('20250120125531'),
 ('20250117121004'),


### PR DESCRIPTION
# Changelog
## Changed
- [TAN-3687] Rename domicile fields to "Waar woon je?" in Dutch (nl-NL and nl-BE).
