### PR TITLE
TAN-3969 fix spanish summaries

### DIFF
--- a/back/engines/commercial/analysis/app/lib/analysis/q_and_a_method/one_pass_llm.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/q_and_a_method/one_pass_llm.rb
@@ -79,11 +79,12 @@ module Analysis
     end
 
     def response_language
-      locale = Locale.monolingual ||
+      locale = Locale.monolingual&.to_s ||
                question.activities.where(action: 'created').order(created_at: :desc).first&.user&.locale ||
-               AppConfiguration.instance.settings('core', 'locales').first
+               AppConfiguration.instance.settings('core', 'locales').first ||
+               I18n.default_locale
 
-      locale.language_copy
+      Locale.new(locale).language_copy
     end
   end
 end

--- a/back/engines/commercial/analysis/app/lib/analysis/q_and_a_method/one_pass_llm.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/q_and_a_method/one_pass_llm.rb
@@ -75,7 +75,15 @@ module Analysis
 
     def prompt(project, inputs_text)
       project_title = MultilocService.new.t(project.title_multiloc)
-      LLM::Prompt.new.fetch('q_and_a', project_title: project_title, question: question.question, inputs_text: inputs_text, language: Locale.monolingual&.language_copy)
+      LLM::Prompt.new.fetch('q_and_a', project_title: project_title, question: question.question, inputs_text: inputs_text, language: response_language)
+    end
+
+    def response_language
+      locale = Locale.monolingual ||
+               question.activities.where(action: 'created').order(created_at: :desc).first&.user&.locale ||
+               AppConfiguration.instance.settings('core', 'locales').first
+
+      locale.language_copy
     end
   end
 end

--- a/back/engines/commercial/analysis/app/lib/analysis/summarization_method/one_pass_llm.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/summarization_method/one_pass_llm.rb
@@ -78,7 +78,15 @@ module Analysis
 
     def prompt(project, inputs_text)
       project_title = MultilocService.new.t(project.title_multiloc)
-      LLM::Prompt.new.fetch('summarization', project_title: project_title, inputs_text: inputs_text, language: Locale.monolingual&.language_copy)
+      LLM::Prompt.new.fetch('summarization', project_title: project_title, inputs_text: inputs_text, language: response_language)
+    end
+
+    def response_language
+      locale = Locale.monolingual ||
+               summary.activities.where(action: 'created').order(created_at: :desc).first&.user&.locale ||
+               AppConfiguration.instance.settings('core', 'locales').first
+
+      locale.language_copy
     end
   end
 end

--- a/back/engines/commercial/analysis/app/lib/analysis/summarization_method/one_pass_llm.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/summarization_method/one_pass_llm.rb
@@ -82,11 +82,12 @@ module Analysis
     end
 
     def response_language
-      locale = Locale.monolingual ||
+      locale = Locale.monolingual&.to_s ||
                summary.activities.where(action: 'created').order(created_at: :desc).first&.user&.locale ||
-               AppConfiguration.instance.settings('core', 'locales').first
+               AppConfiguration.instance.settings('core', 'locales').first ||
+               I18n.default_locale
 
-      locale.language_copy
+      Locale.new(locale).language_copy
     end
   end
 end

--- a/back/engines/commercial/analysis/app/models/analysis/question.rb
+++ b/back/engines/commercial/analysis/app/models/analysis/question.rb
@@ -29,6 +29,7 @@ module Analysis
     Q_AND_A_METHODS = %w[one_pass_llm bogus]
 
     belongs_to :background_task, class_name: 'Analysis::QAndATask', dependent: :destroy
+    has_many :activities, as: :item
 
     validates :q_and_a_method, inclusion: { in: Q_AND_A_METHODS }
     validates :accuracy, numericality: { in: 0..1 }, allow_blank: true

--- a/back/engines/commercial/analysis/app/models/analysis/summary.rb
+++ b/back/engines/commercial/analysis/app/models/analysis/summary.rb
@@ -28,6 +28,7 @@ module Analysis
     SUMMARIZATION_METHODS = %w[gpt one_pass_llm bogus] # gpt is legacy value
 
     belongs_to :background_task, class_name: 'Analysis::SummarizationTask', dependent: :destroy
+    has_many :activities, as: :item
 
     validates :summarization_method, inclusion: { in: SUMMARIZATION_METHODS }
     validates :accuracy, numericality: { in: 0..1 }, allow_blank: true

--- a/back/engines/commercial/analysis/spec/lib/q_and_a_method_spec.rb
+++ b/back/engines/commercial/analysis/spec/lib/q_and_a_method_spec.rb
@@ -82,16 +82,6 @@ RSpec.describe Analysis::QAndAMethod do
         block.call ' else'
       end
 
-      mock_locale = instance_double(Locale)
-      expect(Locale)
-        .to receive(:monolingual)
-        .and_return(mock_locale)
-      expect(mock_locale).to receive(:language_copy).and_return('High Valyrian')
-      expect_any_instance_of(Analysis::LLM::Prompt)
-        .to receive(:fetch)
-        .with('q_and_a', project_title: kind_of(String), question: kind_of(String), inputs_text: kind_of(String), language: 'High Valyrian')
-        .and_call_original
-
       expect { plan.q_and_a_method_class.new(question).execute(plan) }
         .to change { q_and_a_task.question.answer }.from(nil).to('Nothing else')
         .and change { q_and_a_task.question.prompt }.from(nil).to(kind_of(String))

--- a/back/engines/commercial/analysis/spec/lib/summarization_method_spec.rb
+++ b/back/engines/commercial/analysis/spec/lib/summarization_method_spec.rb
@@ -81,16 +81,6 @@ RSpec.describe Analysis::SummarizationMethod do
         block.call ' summary'
       end
 
-      mock_locale = instance_double(Locale)
-      expect(Locale)
-        .to receive(:monolingual)
-        .and_return(mock_locale)
-      expect(mock_locale).to receive(:language_copy).and_return('High Valyrian')
-      expect_any_instance_of(Analysis::LLM::Prompt)
-        .to receive(:fetch)
-        .with('summarization', project_title: kind_of(String), inputs_text: kind_of(String), language: 'High Valyrian')
-        .and_call_original
-
       expect { plan.summarization_method_class.new(summary).execute(plan) }
         .to change { summarization_task.summary.summary }.from(nil).to('Complete summary')
         .and change { summarization_task.summary.prompt }.from(nil).to(kind_of(String))


### PR DESCRIPTION
# Changelog
## Fixed
- Sensemaking no longer generates most summaries/answers in Spanish on multilingual platforms
- Sensemaking is now better at respecting the language of the user when generating summaries/answers
