### PR TITLE
Tan 4000/dateutils test

### DIFF
--- a/front/app/utils/dateUtils.test.ts
+++ b/front/app/utils/dateUtils.test.ts
@@ -75,7 +75,7 @@ describe('timeAgo is reported correctly', () => {
     expect(timeAgoResponse).toEqual('2 weeks ago');
   });
 
-  it.skip('should accurately return months passed since a date', () => {
+  it('should accurately return months passed since a date', () => {
     let date = new Date();
     date.setMonth(date.getMonth() - 1);
     let timeAgoResponse = timeAgo(date.valueOf(), 'en') || '';

--- a/front/app/utils/dateUtils.test.ts
+++ b/front/app/utils/dateUtils.test.ts
@@ -79,7 +79,7 @@ describe('timeAgo is reported correctly', () => {
     let date = new Date();
     date.setMonth(date.getMonth() - 1);
     let timeAgoResponse = timeAgo(date.valueOf(), 'en') || '';
-    // expect(timeAgoResponse).toEqual('1 month ago'); Comment out for today to get tests passing.
+    expect(timeAgoResponse).toEqual('1 month ago');
 
     date = new Date();
     date.setMonth(date.getMonth() - 2);
@@ -91,7 +91,7 @@ describe('timeAgo is reported correctly', () => {
     let date = new Date();
     date.setMonth(date.getMonth() - 12);
     let timeAgoResponse = timeAgo(date.valueOf(), 'en') || '';
-    // expect(timeAgoResponse).toEqual('1 year ago');
+    expect(timeAgoResponse).toEqual('1 year ago');
 
     date = new Date();
     date.setMonth(date.getMonth() - 24);
@@ -103,7 +103,7 @@ describe('timeAgo is reported correctly', () => {
     let date = new Date();
     date.setMonth(date.getMonth() - 12);
     let timeAgoResponse = timeAgo(date.valueOf(), 'fr-BE') || '';
-    // expect(timeAgoResponse).toEqual('il y a 1 an');
+    expect(timeAgoResponse).toEqual('il y a 1 an');
 
     date = new Date();
     date.setMonth(date.getMonth() - 24);

--- a/front/app/utils/dateUtils.ts
+++ b/front/app/utils/dateUtils.ts
@@ -77,6 +77,21 @@ export function timeAgo(dateInput: number, locale: SupportedLocale) {
 
     if (value <= Math.abs(secondsElapsed)) {
       const delta = secondsElapsed / value;
+
+      // Special handling for months: if it's near 12 months or multiples of 12 months,
+      // convert to years
+      if (key === 'months') {
+        const monthsElapsed = Math.abs(delta);
+        // Check if the months elapsed is near a multiple of 12 (within 0.5 month)
+        const yearCount = Math.round(monthsElapsed / 12);
+        if (yearCount >= 1 && Math.abs(monthsElapsed - yearCount * 12) <= 0.5) {
+          const unit = yearCount === 1 ? 'year' : 'years';
+          // Preserve the original sign of delta for proper formatting
+          const sign = Math.sign(delta);
+          return formatter.format(sign * yearCount, unit);
+        }
+      }
+
       return formatter.format(Math.round(delta), key as RelativeTimeFormatUnit);
     }
   }


### PR DESCRIPTION
- Fixed bug where "12 months ago" wasn't converting to "1 year ago"
- Added threshold to convert near-year values (11.5-12.5 months) to years
- Enabled other skipped/commented out tests again

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->
