### PR TITLE
Intercom tour "configure a project": pass className to tab

### DIFF
--- a/front/app/containers/Admin/projects/project/settings/index.tsx
+++ b/front/app/containers/Admin/projects/project/settings/index.tsx
@@ -79,7 +79,7 @@ const Settings = () => {
         </NavigationTabs>
         <Box mt="58px">
           <NavigationTabs>
-            {tabs.map(({ url, label }) => (
+            {tabs.map(({ url, label, className }) => (
               <Tab
                 label={label}
                 url={url}
@@ -89,6 +89,7 @@ const Settings = () => {
                   pathname,
                   url
                 )}
+                className={className}
               />
             ))}
           </NavigationTabs>


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Project settings tabs: Intercom classnames are set