### PR TITLE
Allow saving of inputs with prescreening status in admin editor

### DIFF
--- a/front/app/components/admin/PostManager/components/PostPreview/Idea/AdminIdeaEdit.tsx
+++ b/front/app/components/admin/PostManager/components/PostPreview/Idea/AdminIdeaEdit.tsx
@@ -7,12 +7,14 @@ import { useTheme } from 'styled-components';
 import useIdeaFiles from 'api/idea_files/useIdeaFiles';
 import useDeleteIdeaImage from 'api/idea_images/useDeleteIdeaImage';
 import useIdeaImages from 'api/idea_images/useIdeaImages';
+import { IIdeaUpdate } from 'api/ideas/types';
 import useIdeaById from 'api/ideas/useIdeaById';
 import useUpdateIdea from 'api/ideas/useUpdateIdea';
 import useProjectById from 'api/projects/useProjectById';
 
 import useInputSchema from 'hooks/useInputSchema';
 
+import { FormValues } from 'containers/IdeasEditPage/IdeasEditForm';
 import { getLocationGeojson } from 'containers/IdeasEditPage/utils';
 import ideaFormMessages from 'containers/IdeasNewPage/messages';
 
@@ -115,7 +117,7 @@ const AdminIdeaEdit = ({
       idea.data.attributes.location_point_geojson;
   }
 
-  const onSubmit = async (data) => {
+  const onSubmit = async (data: FormValues) => {
     const { idea_images_attributes, ...ideaWithoutImages } = data;
 
     const location_point_geojson = await getLocationGeojson(
@@ -134,14 +136,11 @@ const AdminIdeaEdit = ({
       });
     }
 
-    const payload = {
+    const payload: IIdeaUpdate = {
       ...ideaWithoutImages,
       idea_images_attributes,
       location_point_geojson,
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      project_id: project?.data.id,
-      publication_status: 'published',
+      project_id: project.data.id,
     };
 
     updateIdea(

--- a/front/app/containers/IdeasEditPage/IdeasEditForm.tsx
+++ b/front/app/containers/IdeasEditPage/IdeasEditForm.tsx
@@ -30,7 +30,7 @@ import IdeasEditMeta from './IdeasEditMeta';
 import messages from './messages';
 import { getLocationGeojson, getFormValues } from './utils';
 
-interface FormValues {
+export interface FormValues {
   title_multiloc: Multiloc;
   body_multiloc: Multiloc;
   author_id?: string;
@@ -44,6 +44,7 @@ interface FormValues {
   topic_ids?: string[];
   cosponsor_ids?: string[];
 }
+
 interface Props {
   ideaId: string;
 }


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Saving of inputs (including proposals) with "prescreening" status (in admin editor)