### PR TITLE
TAN-4095 Ensure form error exists before accessing it

### DIFF
--- a/front/app/components/FormBuilder/edit/index.tsx
+++ b/front/app/components/FormBuilder/edit/index.tsx
@@ -351,7 +351,9 @@ const FormEdit = ({
       );
     } catch (error) {
       const errorType =
-        error?.errors?.form[0].error === 'stale_data'
+        Array.isArray(error?.errors?.form) &&
+        error.errors.form.length > 0 &&
+        error.errors.form[0].error === 'stale_data'
           ? 'staleData'
           : 'customFields';
       handleHookFormSubmissionError(error, setError, errorType);


### PR DESCRIPTION
Sentry issue can be found in the ticket.

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Ensure form builder errors are displayed on save.