### PR TITLE
Don't update publication status in ideation and proposals

### DIFF
--- a/front/app/api/ideas/types.ts
+++ b/front/app/api/ideas/types.ts
@@ -212,6 +212,7 @@ export interface IIdeaUpdate {
   anonymous?: boolean;
   idea_images_attributes?: { image: string }[];
   manual_votes_amount?: number | null;
+  publication_status?: IdeaPublicationStatus;
 }
 
 export interface IIdeas {

--- a/front/app/containers/IdeasEditPage/IdeasEditForm.tsx
+++ b/front/app/containers/IdeasEditPage/IdeasEditForm.tsx
@@ -222,11 +222,16 @@ const IdeasEditForm = ({ ideaId }: Props) => {
       project_id: projectId,
     };
 
+    // TODO: Change publication status handling when adding draft ideas
     const idea = await updateIdea({
       id: ideaId,
       requestBody: isImageNew
-        ? omit(payload, 'idea_files_attributes')
-        : omit(payload, ['idea_images_attributes', 'idea_files_attributes']),
+        ? omit(payload, ['idea_files_attributes', 'publication_status'])
+        : omit(payload, [
+            'idea_images_attributes',
+            'idea_files_attributes',
+            'publication_status',
+          ]),
     });
 
     updateSearchParams({ idea_id: idea.data.id });

--- a/front/app/containers/IdeasNewPage/IdeasNewIdeationForm/index.tsx
+++ b/front/app/containers/IdeasNewPage/IdeasNewIdeationForm/index.tsx
@@ -205,6 +205,7 @@ const IdeasNewIdeationForm = ({ project, phaseId }: Props) => {
       project_id: project.data.id,
       phase_ids,
       anonymous: postAnonymously ? true : undefined,
+      publication_status: undefined, // TODO: Change this logic when handling draft ideas
     });
     updateSearchParams({ idea_id: idea.data.id });
     onSubmitCallback?.();


### PR DESCRIPTION
This temporarily prevents updating the publication status in ideation and proposals. This functionality will come with draft inputs in proposals and ideation projects
