### PR TITLE
Allow submission of edited proposal in admin input manager when prescreening is turned on

### DIFF
--- a/front/app/components/admin/PostManager/components/PostPreview/Idea/AdminIdeaEdit.tsx
+++ b/front/app/components/admin/PostManager/components/PostPreview/Idea/AdminIdeaEdit.tsx
@@ -148,8 +148,12 @@ const AdminIdeaEdit = ({
       {
         id: ideaId,
         requestBody: isImageNew
-          ? omit(payload, 'idea_files_attributes')
-          : omit(payload, ['idea_images_attributes', 'idea_files_attributes']),
+          ? omit(payload, ['idea_files_attributes', 'publication_status'])
+          : omit(payload, [
+              'idea_images_attributes',
+              'idea_files_attributes',
+              'publication_status',
+            ]),
       },
       {
         onSuccess: () => {


### PR DESCRIPTION
# Changelog

## Fixed
- Allow submission of edited proposal in admin input manager when prescreening is turned on

