### PR TITLE
Fix "skip button" overlapping the carrousel title

### DIFF
--- a/front/app/component-library/components/Box/index.tsx
+++ b/front/app/component-library/components/Box/index.tsx
@@ -198,6 +198,10 @@ type BoxAspectRatioProps = {
   aspectRatio?: string;
 };
 
+type BoxTransformProps = {
+  transform?: string;
+};
+
 export type BoxProps = BoxColorProps &
   BoxShadowProps &
   BoxBackgroundProps &
@@ -214,6 +218,7 @@ export type BoxProps = BoxColorProps &
   BoxZIndexProps &
   BoxCursorProps &
   BoxAspectRatioProps &
+  BoxTransformProps &
   React.HTMLAttributes<HTMLDivElement>;
 
 const Box = styled.div<BoxProps>`
@@ -375,6 +380,11 @@ const Box = styled.div<BoxProps>`
   // aspect ratio
   ${(props) => css`
     ${props.aspectRatio ? `aspect-ratio: ${props.aspectRatio}` : ''};
+  `}
+
+  // transformation
+  ${(props) => css`
+    ${props.transform ? `transform: ${props.transform}` : ''};
   `}
 `;
 

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/AdminPublicationsCarrousel/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/AdminPublicationsCarrousel/index.tsx
@@ -70,7 +70,6 @@ const AdminPublicationsCarrousel = ({
       scrollContainerRef={scrollContainerRef}
       setScrollContainerRef={setScrollContainerRef}
       cardWidth={cardWidth}
-      scrollButtonTop={200}
       hasMore={hasMore}
       endId={endId}
     >

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/BaseCarrousel/ScrollableCarrousel/Gradient.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/BaseCarrousel/ScrollableCarrousel/Gradient.tsx
@@ -8,11 +8,11 @@ interface Props {
 
 const Gradient = ({ variant }: Props) => (
   <Box
-    top="32px"
+    top="0"
     left={variant === 'left' ? '0' : undefined}
     right={variant === 'right' ? '0' : undefined}
     w="30px"
-    h="calc(100% - 32px)"
+    h="100%"
     position="absolute"
     zIndex="2"
     background={`linear-gradient(to ${

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/BaseCarrousel/ScrollableCarrousel/ScrollButton.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/BaseCarrousel/ScrollableCarrousel/ScrollButton.tsx
@@ -22,8 +22,8 @@ const ScrollButton = ({
       position="absolute"
       left={variant === 'left' ? '8px' : undefined}
       right={variant === 'right' ? '8px' : undefined}
-      // Center the button vertically
       top="50%"
+      transform="translateY(-50%)"
       borderRadius="30px"
       bgColor="white"
       w="52px"

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/BaseCarrousel/ScrollableCarrousel/ScrollButton.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/BaseCarrousel/ScrollableCarrousel/ScrollButton.tsx
@@ -4,7 +4,6 @@ import { Box, Icon, colors } from '@citizenlab/cl2-component-library';
 
 interface Props {
   variant: 'left' | 'right';
-  top: string;
   onClick: () => void;
   onMouseEnter: () => void;
   onMouseLeave: () => void;
@@ -12,7 +11,6 @@ interface Props {
 
 const ScrollButton = ({
   variant,
-  top,
   onClick,
   onMouseEnter,
   onMouseLeave,
@@ -24,7 +22,8 @@ const ScrollButton = ({
       position="absolute"
       left={variant === 'left' ? '8px' : undefined}
       right={variant === 'right' ? '8px' : undefined}
-      top={top}
+      // Center the button vertically
+      top="50%"
       borderRadius="30px"
       bgColor="white"
       w="52px"

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/BaseCarrousel/ScrollableCarrousel/SkipButton.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/BaseCarrousel/ScrollableCarrousel/SkipButton.tsx
@@ -17,7 +17,6 @@ const StyledButton = styled.button`
   background: ${colors.white};
 
   &:focus {
-    top: 40px;
     opacity: 1;
   }
 `;

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/BaseCarrousel/ScrollableCarrousel/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/BaseCarrousel/ScrollableCarrousel/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useEffect } from 'react';
 
-import { useBreakpoint } from '@citizenlab/cl2-component-library';
+import { Box, useBreakpoint } from '@citizenlab/cl2-component-library';
 import { debounce } from 'lodash-es';
 
 import { CARD_GAP } from '../constants';
@@ -90,7 +90,7 @@ const ScrollableCarrousel = ({
   }, [scrollContainerRef, hasMore, handleButtonVisiblity]);
 
   return (
-    <>
+    <Box position="relative">
       <SkipButton onSkip={() => skipCarrousel(endId)} />
       <HorizontalScroll
         setRef={(ref) => {
@@ -147,7 +147,7 @@ const ScrollableCarrousel = ({
         </>
       )}
       <i id={endId} />
-    </>
+    </Box>
   );
 };
 

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/BaseCarrousel/ScrollableCarrousel/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/BaseCarrousel/ScrollableCarrousel/index.tsx
@@ -90,7 +90,13 @@ const ScrollableCarrousel = ({
   }, [scrollContainerRef, hasMore, handleButtonVisiblity]);
 
   return (
-    <Box position="relative">
+    <Box
+      /* We set position relative to be able to position the skip (& scroll?) buttons.
+        I'd actually prefer to move the SkipButton's absolute positioning styles onto a Box that wraps the button here, so the relative/absolute relationship is clearer.
+        Similarly, I think the ScrollButtons could go inside HorizontalScroll so the positioning relationship could be made clearer.
+      */
+      position="relative"
+    >
       <SkipButton onSkip={() => skipCarrousel(endId)} />
       <HorizontalScroll
         setRef={(ref) => {

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/BaseCarrousel/ScrollableCarrousel/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/BaseCarrousel/ScrollableCarrousel/index.tsx
@@ -91,10 +91,7 @@ const ScrollableCarrousel = ({
 
   return (
     <Box
-      /* We set position relative to be able to position the skip (& scroll?) buttons.
-        I'd actually prefer to move the SkipButton's absolute positioning styles onto a Box that wraps the button here, so the relative/absolute relationship is clearer.
-        Similarly, I think the ScrollButtons could go inside HorizontalScroll so the positioning relationship could be made clearer.
-      */
+      // We set position relative to be able to position the skip (& scroll?) buttons.
       position="relative"
     >
       <SkipButton onSkip={() => skipCarrousel(endId)} />

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/BaseCarrousel/ScrollableCarrousel/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/BaseCarrousel/ScrollableCarrousel/index.tsx
@@ -15,7 +15,6 @@ interface Props {
   scrollContainerRef?: HTMLDivElement;
   setScrollContainerRef: (instance: HTMLDivElement) => void;
   cardWidth: number;
-  scrollButtonTop: number;
   hasMore: boolean;
   endId: string;
   children: React.ReactNode;
@@ -25,7 +24,6 @@ const ScrollableCarrousel = ({
   scrollContainerRef,
   setScrollContainerRef,
   cardWidth,
-  scrollButtonTop,
   hasMore,
   endId,
   children,
@@ -109,7 +107,6 @@ const ScrollableCarrousel = ({
           {showPreviousButton && (
             <ScrollButton
               variant="left"
-              top={`${scrollButtonTop}px`}
               onClick={() => {
                 if (!scrollContainerRef) return;
                 scrollContainerRef.scrollLeft -= cardWidth + CARD_GAP;
@@ -132,7 +129,6 @@ const ScrollableCarrousel = ({
           {showNextButton && (
             <ScrollButton
               variant="right"
-              top={`${scrollButtonTop}px`}
               onClick={() => {
                 if (!scrollContainerRef) return;
                 scrollContainerRef.scrollLeft += cardWidth + CARD_GAP;

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/BaseCarrousel/ScrollableCarrousel/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/BaseCarrousel/ScrollableCarrousel/index.tsx
@@ -90,7 +90,13 @@ const ScrollableCarrousel = ({
   }, [scrollContainerRef, hasMore, handleButtonVisiblity]);
 
   return (
-    <Box position="relative">
+    <Box
+      /* We set position relative to be able to position the skip & scroll buttons.
+        I'd actually prefer to move the SkipButton's absolute positioning styles onto a Box that wraps the button here, so the relative/absolute relationship is clearer.
+        Similarly, I think the ScrollButtons could go inside HorizontalScroll so the positioning relationship could be made clearer.
+      */
+      position="relative"
+    >
       <SkipButton onSkip={() => skipCarrousel(endId)} />
       <HorizontalScroll
         setRef={(ref) => {

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/ProjectCarrousel/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/ProjectCarrousel/index.tsx
@@ -63,7 +63,6 @@ const ProjectCarrousel = ({ projects, hasMore, onLoadMore }: Props) => {
       scrollContainerRef={scrollContainerRef}
       setScrollContainerRef={setScrollContainerRef}
       cardWidth={CARD_WIDTH}
-      scrollButtonTop={120}
       hasMore={hasMore}
       endId={endId}
     >


### PR DESCRIPTION
Prep work for areas widget.

**Problem**: clicking the follow areas button here doesn't work if the "skip carrousel" button is also visible.

<img width="322" alt="image" src="https://github.com/user-attachments/assets/b6390db8-d460-41c2-9d0c-0cc4f3814ddb" />

**Solution**: position the skip button within the carrousel container. 
<img width="1323" alt="Screenshot 2025-03-18 at 15 43 34" src="https://github.com/user-attachments/assets/d645b1f3-2cb7-48ed-b4c2-899b4f77ac4a" />

The prev/next buttons have moved a bit but still look good, imo.

<img width="1286" alt="Screenshot 2025-03-18 at 15 43 43" src="https://github.com/user-attachments/assets/258844b1-a98e-4bc8-a696-9e33d03223cb" />


# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->