### PR TITLE
[TAN-3722] Change option separator in XLSX exports

### DIFF
--- a/back/app/services/export/xlsx/value_visitor.rb
+++ b/back/app/services/export/xlsx/value_visitor.rb
@@ -1,6 +1,8 @@
 module Export
   module Xlsx
     class ValueVisitor < FieldVisitorService
+      VALUE_SEPARATOR = ';'
+
       def initialize(model, option_index, app_configuration: nil)
         super()
         @model = model
@@ -130,8 +132,6 @@ module Export
       private
 
       attr_reader :model, :option_index, :multiloc_service
-
-      VALUE_SEPARATOR = ', '
 
       def built_in_files
         return '' if model.idea_files.empty?

--- a/back/spec/acceptance/phases_spec.rb
+++ b/back/spec/acceptance/phases_spec.rb
@@ -879,7 +879,7 @@ resource 'Phases' do
                 rows: [
                   [
                     survey_response1.id,
-                    'Cat, Dog',
+                    'Cat;Dog',
                     survey_response1.author_name,
                     survey_response1.author.email,
                     survey_response1.author_id,
@@ -1002,7 +1002,7 @@ resource 'Phases' do
             rows: [
               [
                 survey_response.id,
-                'Cat, Dog',
+                'Cat;Dog',
                 survey_response.author_name,
                 survey_response.author.email,
                 survey_response.author_id,

--- a/back/spec/services/export/xlsx/input_sheet_generator_spec.rb
+++ b/back/spec/services/export/xlsx/input_sheet_generator_spec.rb
@@ -109,7 +109,7 @@ describe Export::Xlsx::InputSheetGenerator do
                   ideation_response1.title_multiloc['en'],
                   'It would improve the air quality!', # html tags are removed
                   %r{\A/uploads/.+/idea_file/file/#{attachment1.id}/#{attachment1.name}\Z},
-                  "#{ideation_response1.topics[0].title_multiloc['en']}, #{ideation_response1.topics[1].title_multiloc['en']}",
+                  "#{ideation_response1.topics[0].title_multiloc['en']};#{ideation_response1.topics[1].title_multiloc['en']}",
                   ideation_response1.location_point.coordinates.last,
                   ideation_response1.location_point.coordinates.first,
                   ideation_response1.location_description,
@@ -199,7 +199,7 @@ describe Export::Xlsx::InputSheetGenerator do
                   ideation_response1.title_multiloc['en'],
                   'It would improve the air quality!', # html tags are removed
                   %r{\A/uploads/.+/idea_file/file/#{attachment1.id}/#{attachment1.name}\n/uploads/.+/idea_file/file/#{attachment2.id}/#{attachment2.name}\Z},
-                  "#{ideation_response1.topics[0].title_multiloc['en']}, #{ideation_response1.topics[1].title_multiloc['en']}",
+                  "#{ideation_response1.topics[0].title_multiloc['en']};#{ideation_response1.topics[1].title_multiloc['en']}",
                   ideation_response1.location_point.coordinates.last,
                   ideation_response1.location_point.coordinates.first,
                   ideation_response1.location_description,
@@ -304,8 +304,8 @@ describe Export::Xlsx::InputSheetGenerator do
               rows: [
                 [
                   survey_response1.id,
-                  'Cat, Dog',
-                  'By train, By bike',
+                  'Cat;Dog',
+                  'By train;By bike',
                   nil,
                   nil,
                   survey_response1.author_id,
@@ -325,7 +325,7 @@ describe Export::Xlsx::InputSheetGenerator do
                 [
                   survey_response3.id,
                   'Dog',
-                  'By bike, By train',
+                  'By bike;By train',
                   nil,
                   nil,
                   survey_response3.author_id,
@@ -358,7 +358,7 @@ describe Export::Xlsx::InputSheetGenerator do
                 rows: [
                   [
                     survey_response1.id,
-                    'Cat, Dog, Other',
+                    'Cat;Dog;Other',
                     'Fish',
                     '',
                     nil,
@@ -382,7 +382,7 @@ describe Export::Xlsx::InputSheetGenerator do
                     survey_response3.id,
                     'Dog',
                     '',
-                    'By bike, By train',
+                    'By bike;By train',
                     nil,
                     nil,
                     survey_response3.author_id,
@@ -447,8 +447,8 @@ describe Export::Xlsx::InputSheetGenerator do
               rows: [
                 [
                   survey_response1.id,
-                  'Cat, Dog',
-                  'By train, By bike',
+                  'Cat;Dog',
+                  'By train;By bike',
                   nil,
                   nil,
                   survey_response1.author_name,
@@ -472,7 +472,7 @@ describe Export::Xlsx::InputSheetGenerator do
                 [
                   survey_response3.id,
                   'Dog',
-                  'By bike, By train',
+                  'By bike;By train',
                   nil,
                   nil,
                   nil,
@@ -661,7 +661,7 @@ describe Export::Xlsx::InputSheetGenerator do
                   ideation_response1.title_multiloc['en'],
                   'It would improve the air quality!', # html tags are removed
                   %r{\A/uploads/.+/idea_file/file/#{attachment1.id}/#{attachment1.name}\Z},
-                  "#{ideation_response1.topics[0].title_multiloc['en']}, #{ideation_response1.topics[1].title_multiloc['en']}",
+                  "#{ideation_response1.topics[0].title_multiloc['en']};#{ideation_response1.topics[1].title_multiloc['en']}",
                   ideation_response1.location_point.coordinates.last,
                   ideation_response1.location_point.coordinates.first,
                   ideation_response1.location_description,
@@ -763,7 +763,7 @@ describe Export::Xlsx::InputSheetGenerator do
                     ideation_response1.title_multiloc['en'],
                     'It would improve the air quality!', # html tags are removed
                     %r{\A/uploads/.+/idea_file/file/#{attachment1.id}/#{attachment1.name}\n/uploads/.+/idea_file/file/#{attachment2.id}/#{attachment2.name}\Z},
-                    "#{ideation_response1.topics[0].title_multiloc['en']}, #{ideation_response1.topics[1].title_multiloc['en']}",
+                    "#{ideation_response1.topics[0].title_multiloc['en']};#{ideation_response1.topics[1].title_multiloc['en']}",
                     ideation_response1.location_point.coordinates.last,
                     ideation_response1.location_point.coordinates.first,
                     ideation_response1.location_description,
@@ -827,7 +827,7 @@ describe Export::Xlsx::InputSheetGenerator do
                     ideation_response1.title_multiloc['en'],
                     'It would improve the air quality!', # html tags are removed
                     %r{\A/uploads/.+/idea_file/file/#{attachment1.id}/#{attachment1.name}\n/uploads/.+/idea_file/file/#{attachment2.id}/#{attachment2.name}\Z},
-                    "#{ideation_response1.topics[0].title_multiloc['en']}, #{ideation_response1.topics[1].title_multiloc['en']}",
+                    "#{ideation_response1.topics[0].title_multiloc['en']};#{ideation_response1.topics[1].title_multiloc['en']}",
                     ideation_response1.location_point.coordinates.last,
                     ideation_response1.location_point.coordinates.first,
                     ideation_response1.location_description,

--- a/back/spec/services/export/xlsx/value_visitor_spec.rb
+++ b/back/spec/services/export/xlsx/value_visitor_spec.rb
@@ -330,7 +330,7 @@ describe Export::Xlsx::ValueVisitor do
 
         it 'returns the value for the report' do
           I18n.with_locale('nl-NL') do
-            expect(visitor.visit_multiselect(field)).to eq 'Kat, Hond'
+            expect(visitor.visit_multiselect(field)).to eq 'Kat;Hond'
           end
         end
       end
@@ -388,7 +388,7 @@ describe Export::Xlsx::ValueVisitor do
 
         it 'returns the value for the report' do
           I18n.with_locale('en') do
-            expect(visitor.visit_multiselect(field)).to eq 'Cat, Dog'
+            expect(visitor.visit_multiselect(field)).to eq 'Cat;Dog'
           end
         end
       end
@@ -649,7 +649,7 @@ describe Export::Xlsx::ValueVisitor do
 
         it 'returns the value for the report' do
           I18n.with_locale('nl-NL') do
-            expect(visitor.visit_topic_ids(field)).to eq 'Onderwerp 1, Onderwerp 2'
+            expect(visitor.visit_topic_ids(field)).to eq 'Onderwerp 1;Onderwerp 2'
           end
         end
       end


### PR DESCRIPTION
# Changelog
## Changed
- [TAN-3722] Change option separator in XLSX exports to `;` since `,` is commonly used in option titles. This mitigates the issue by using a less frequent character, but ideally, we should make it configurable or split it into multiple columns.
