### PR TITLE
Quickfix: Back to home

### DIFF
--- a/back/spec/lib/participation_method/community_monitor_survey_spec.rb
+++ b/back/spec/lib/participation_method/community_monitor_survey_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe ParticipationMethod::CommunityMonitorSurvey do
       # Last page
       expect(participation_method.default_fields(form).last.page_button_link).to eq '/'
       expect(participation_method.default_fields(form).last.page_button_label_multiloc).to match(
-        { 'en' => 'Back to home', 'fr-FR' => 'Back to home', 'nl-NL' => 'Back to home' }
+        { 'en' => 'Back to home', 'fr-FR' => "Retour à l'accueil", 'nl-NL' => 'Terug naar home' }
       )
     end
   end


### PR DESCRIPTION
I will merge it like this as a quickfix, but I think we should use fixtures instead, so this spec no longer depends on Crowdin translations (I can't do this right now as I need to get my lunch soon).
