### PR TITLE
Don't open mobile nav by hitting the 'Escape' key

### DIFF
--- a/front/app/containers/MainHeader/Components/NavbarContent/MobileNavbarContent/ButtonWithFullMobileNavMenu/index.tsx
+++ b/front/app/containers/MainHeader/Components/NavbarContent/MobileNavbarContent/ButtonWithFullMobileNavMenu/index.tsx
@@ -9,22 +9,23 @@ const FullMobileNavMenu = lazy(() => import('../FullMobileNavMenu'));
 const ButtonWithFullMobileNavMenu = () => {
   const [isFullMenuOpened, setIsFullMenuOpened] = useState(false);
 
-  const toggleFullMenu = () => {
-    setIsFullMenuOpened(!isFullMenuOpened);
-    trackEventByName(
-      isFullMenuOpened
-        ? tracks.moreButtonClickedFullMenuOpened
-        : tracks.moreButtonClickedFullMenuClosed
-    );
+  const openMenu = () => {
+    setIsFullMenuOpened(true);
+    trackEventByName(tracks.moreButtonClickedFullMenuOpened);
+  };
+
+  const closeMenu = () => {
+    setIsFullMenuOpened(false);
+    trackEventByName(tracks.moreButtonClickedFullMenuClosed);
   };
 
   return (
     <>
-      <ShowFullMenuButton onClick={toggleFullMenu} />
+      <ShowFullMenuButton onClick={openMenu} />
       <Suspense fallback={null}>
         <FullMobileNavMenu
           isFullMenuOpened={isFullMenuOpened}
-          onClose={toggleFullMenu}
+          onClose={closeMenu}
         />
       </Suspense>
     </>


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Don't open the mobile navigation menu by hitting the "Esc" key.