### PR TITLE
TAN-4233 - Minor refactoring of form_end page

### DIFF
--- a/back/app/models/custom_field.rb
+++ b/back/app/models/custom_field.rb
@@ -253,6 +253,10 @@ class CustomField < ApplicationRecord
     input_type == 'page'
   end
 
+  def form_end_page?
+    page? && key == 'form_end'
+  end
+
   def multiselect?
     %w[multiselect multiselect_image].include?(input_type)
   end

--- a/back/app/models/custom_field.rb
+++ b/back/app/models/custom_field.rb
@@ -241,6 +241,24 @@ class CustomField < ApplicationRecord
     required
   end
 
+  def visible_to_public?
+    answer_visible_to == VISIBLE_TO_PUBLIC
+  end
+
+  def submittable?
+    !page?
+  end
+
+  def printable?
+    ignore_field_types = %w[page date files image_files point file_upload shapefile_upload topic_ids cosponsor_ids ranking matrix_linear_scale]
+    ignore_field_types.exclude? input_type
+  end
+
+  def importable?
+    ignore_field_types = %w[page date files image_files file_upload shapefile_upload point line polygon cosponsor_ids ranking matrix_linear_scale]
+    ignore_field_types.exclude? input_type
+  end
+
   def domicile?
     key == 'domicile' && code == 'domicile'
   end

--- a/back/app/serializers/web_api/v1/custom_field_serializer.rb
+++ b/back/app/serializers/web_api/v1/custom_field_serializer.rb
@@ -21,11 +21,11 @@ class WebApi::V1::CustomFieldSerializer < WebApi::V1::BaseSerializer
   }
 
   attribute :page_button_link, if: proc { |object, _params|
-    object.input_type == 'page' && object.key == 'form_end'
+    object.form_end_page?
   }
 
   attribute :page_button_label_multiloc, if: proc { |object, _params|
-    object.input_type == 'page' && object.key == 'form_end'
+    object.form_end_page?
   }
 
   attribute :dropdown_layout, if: proc { |object, _params|

--- a/back/app/services/idea_custom_fields_service.rb
+++ b/back/app/services/idea_custom_fields_service.rb
@@ -104,18 +104,18 @@ class IdeaCustomFieldsService
     field_params.except(:code, :input_type)
   end
 
-  def check_form_structure(fields, errors)
-    return if fields.empty?
+  def check_form_structure(fields_from_params, errors)
+    return if fields_from_params.empty?
 
-    first_field_type = 'page'
-    if fields[0][:input_type] != first_field_type
-      error = { error: "First field must be of type '#{first_field_type}'" }
+    unless fields_from_params.first[:input_type] == 'page'
+      error = { error: "First field must be of type 'page'" }
       errors['0'] = { structure: [error] }
     end
 
     # Check the last field is a page
-    if fields.last[:input_type] != 'page'
-      errors[(fields.length - 1).to_s] = { structure: [{ error: "Last field must be of type 'page'" }] }
+    last_field = fields_from_params.last
+    unless last_field[:input_type] == 'page' && last_field[:key] == 'form_end'
+      errors[(fields_from_params.length - 1).to_s] = { structure: [{ error: "Last field must be of type 'page' with a key of 'form_end'" }] }
     end
   end
 

--- a/back/app/services/idea_custom_fields_service.rb
+++ b/back/app/services/idea_custom_fields_service.rb
@@ -15,7 +15,7 @@ class IdeaCustomFieldsService
 
     fields = fields.to_a
 
-    form_end_field = fields.find { |f| f.key == 'form_end' }
+    form_end_field = fields.find { |f| f.form_end_page? }
     if form_end_field
       fields.delete(form_end_field)
       fields << form_end_field

--- a/back/app/services/idea_custom_fields_service.rb
+++ b/back/app/services/idea_custom_fields_service.rb
@@ -15,7 +15,7 @@ class IdeaCustomFieldsService
 
     fields = fields.to_a
 
-    form_end_field = fields.find { |f| f.form_end_page? }
+    form_end_field = fields.find(&:form_end_page?)
     if form_end_field
       fields.delete(form_end_field)
       fields << form_end_field
@@ -37,8 +37,7 @@ class IdeaCustomFieldsService
   end
 
   def submittable_fields
-    unsubmittable_input_types = %w[page]
-    enabled_fields.reject { |field| unsubmittable_input_types.include? field.input_type }
+    enabled_fields.select(&:submittable?)
   end
 
   def submittable_fields_with_other_options
@@ -47,14 +46,11 @@ class IdeaCustomFieldsService
 
   # Used in the printable PDF export
   def printable_fields
-    ignore_field_types = %w[page date files image_files point file_upload shapefile_upload topic_ids cosponsor_ids ranking matrix_linear_scale]
-    fields = enabled_fields.reject { |field| ignore_field_types.include? field.input_type }
-    insert_other_option_text_fields(fields)
+    enabled_fields.select(&:printable?)
   end
 
   def importable_fields
-    ignore_field_types = %w[page date files image_files file_upload shapefile_upload point line polygon cosponsor_ids ranking matrix_linear_scale]
-    enabled_fields_with_other_options.reject { |field| ignore_field_types.include? field.input_type }
+    enabled_fields.select(&:importable?)
   end
 
   def enabled_fields
@@ -66,7 +62,7 @@ class IdeaCustomFieldsService
   end
 
   def enabled_public_fields
-    enabled_fields.select { |field| field.answer_visible_to == CustomField::VISIBLE_TO_PUBLIC }
+    enabled_fields.select(&:visible_to_public?)
   end
 
   def extra_visible_fields

--- a/back/app/services/idea_custom_fields_service.rb
+++ b/back/app/services/idea_custom_fields_service.rb
@@ -46,11 +46,11 @@ class IdeaCustomFieldsService
 
   # Used in the printable PDF export
   def printable_fields
-    enabled_fields.select(&:printable?)
+    enabled_fields_with_other_options.select(&:printable?)
   end
 
   def importable_fields
-    enabled_fields.select(&:importable?)
+    enabled_fields_with_other_options.select(&:importable?)
   end
 
   def enabled_fields

--- a/back/app/services/input_ui_schema_generator_service.rb
+++ b/back/app/services/input_ui_schema_generator_service.rb
@@ -49,7 +49,7 @@ class InputUiSchemaGeneratorService < UiSchemaGeneratorService
     }
 
     # Add these attributes only if the page key is "form_end"
-    if field.key == 'form_end'
+    if field.form_end_page?
       page_data[:options][:page_button_label_multiloc] = field.page_button_label_multiloc
       page_data[:options][:page_button_link] = field.page_button_link
     end
@@ -94,7 +94,7 @@ class InputUiSchemaGeneratorService < UiSchemaGeneratorService
         rules = form_logic.ui_schema_rules_for(field)
         field_schema[:ruleArray] = rules if rules.present?
 
-        if field.key == 'form_end'
+        if field.form_end_page?
           form_end_page = field_schema
         else
           field_schemas << field_schema

--- a/back/app/services/ui_schema_generator_service.rb
+++ b/back/app/services/ui_schema_generator_service.rb
@@ -130,7 +130,7 @@ class UiSchemaGeneratorService < FieldVisitorService
   end
 
   def visit_page(field)
-    if field.key == 'form_end'
+    if field.form_end_page?
       default(field).tap do |ui_field|
         ui_field[:options][:page_button_link] = field.page_button_link
         ui_field[:options][:page_button_label_multiloc] = multiloc_service.t(field.page_button_label_multiloc)

--- a/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
+++ b/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
@@ -120,7 +120,7 @@ module IdeaCustomFields
       return unless is_survey_or_ideation
 
       last_field = update_all_params.fetch(:custom_fields).last
-      return if last_field.form_end_page?
+      return if last_field['key'] == 'form_end' && last_field['input_type'] == 'page'
 
       raise UpdateAllFailedError, { form: [{ error: 'no_end_page' }] }
     end

--- a/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
+++ b/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
@@ -115,10 +115,6 @@ module IdeaCustomFields
     end
 
     def raise_error_if_no_end_page
-      pmethod = @custom_form.participation_context.pmethod.class.method_str
-      is_survey_or_ideation = pmethod.in?(%w[native_survey ideation])
-      return unless is_survey_or_ideation
-
       last_field = update_all_params.fetch(:custom_fields).last
       return if last_field['key'] == 'form_end' && last_field['input_type'] == 'page'
 

--- a/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
+++ b/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
@@ -120,7 +120,7 @@ module IdeaCustomFields
       return unless is_survey_or_ideation
 
       last_field = update_all_params.fetch(:custom_fields).last
-      return if last_field['key'] == 'form_end' && last_field['input_type'] == 'page'
+      return if last_field.form_end_page?
 
       raise UpdateAllFailedError, { form: [{ error: 'no_end_page' }] }
     end

--- a/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
+++ b/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
@@ -64,7 +64,6 @@ module IdeaCustomFields
     def update_all
       authorize CustomField.new(resource: @custom_form), :update_all?, policy_class: IdeaCustomFieldPolicy
       raise_error_if_stale_form_data
-      raise_error_if_no_end_page
 
       page_temp_ids_to_ids_mapping = {}
       option_temp_ids_to_ids_mapping = {}
@@ -112,13 +111,6 @@ module IdeaCustomFields
                     @custom_form.updated_at.to_i > update_all_params[:form_last_updated_at].to_datetime.to_i
 
       raise UpdateAllFailedError, { form: [{ error: 'stale_data' }] }
-    end
-
-    def raise_error_if_no_end_page
-      last_field = update_all_params.fetch(:custom_fields).last
-      return if last_field['key'] == 'form_end' && last_field['input_type'] == 'page'
-
-      raise UpdateAllFailedError, { form: [{ error: 'no_end_page' }] }
     end
 
     def update_fields!(page_temp_ids_to_ids_mapping, option_temp_ids_to_ids_mapping, errors)

--- a/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/update_all_community_monitor_survey_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/update_all_community_monitor_survey_spec.rb
@@ -184,7 +184,7 @@ resource 'Idea Custom Fields' do
             { structure: [{ error: "First field must be of type 'page'" }] }
           )
           expect(json_response_body.dig(:errors, :'1')).to eq(
-            { structure: [{ error: "Last field must be of type 'page'" }] }
+            { structure: [{ error: "Last field must be of type 'page' with a key of 'form_end'" }] }
           )
         end
       end

--- a/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/update_all_native_survey_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/update_all_native_survey_spec.rb
@@ -673,7 +673,7 @@ resource 'Idea Custom Fields' do
 
         assert_status 422
         json_response = json_parse response_body
-        expect(json_response).to eq({ :errors => { :form => [{ :error => 'no_end_page' }] } })
+        expect(json_response).to eq({errors: {"0": {structure: [{error: "Last field must be of type 'page' with a key of 'form_end'"}]}}})
       end
 
       example 'Update linear_scale field' do

--- a/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/update_all_native_survey_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/update_all_native_survey_spec.rb
@@ -814,7 +814,7 @@ resource 'Idea Custom Fields' do
 
       example 'Update select field with logic' do
         field_to_update = create(:custom_field_select, :with_options, resource: custom_form)
-        form_end_page = create(:custom_field_page, key: 'form_end', resource: custom_form)
+        form_end_page = create(:custom_field_form_end_page, resource: custom_form)
         final_page[:id] = form_end_page.id
         request = {
           custom_fields: [

--- a/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/update_all_native_survey_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/update_all_native_survey_spec.rb
@@ -673,7 +673,7 @@ resource 'Idea Custom Fields' do
 
         assert_status 422
         json_response = json_parse response_body
-        expect(json_response).to eq({errors: {"0": {structure: [{error: "Last field must be of type 'page' with a key of 'form_end'"}]}}})
+        expect(json_response).to eq({ errors: { '0': { structure: [{ error: "Last field must be of type 'page' with a key of 'form_end'" }] } } })
       end
 
       example 'Update linear_scale field' do

--- a/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/project_context/update_all_ideation_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/project_context/update_all_ideation_spec.rb
@@ -32,7 +32,7 @@ resource 'Idea Custom Fields' do
     let(:default_fields_param) do
       attributes = %i[id code input_type title_multiloc description_multiloc required enabled page_layout]
       # Remove the form_end. We will add that manually in the tests
-      IdeaCustomFieldsService.new(custom_form).all_fields.reject { |field| field.form_end_page? }.map do |field|
+      IdeaCustomFieldsService.new(custom_form).all_fields.reject(&:form_end_page?).map do |field|
         {}.tap do |field_param|
           attributes.each do |attribute|
             field_param[attribute] = field.send attribute

--- a/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/project_context/update_all_ideation_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/project_context/update_all_ideation_spec.rb
@@ -32,7 +32,7 @@ resource 'Idea Custom Fields' do
     let(:default_fields_param) do
       attributes = %i[id code input_type title_multiloc description_multiloc required enabled page_layout]
       # Remove the form_end. We will add that manually in the tests
-      IdeaCustomFieldsService.new(custom_form).all_fields.reject { |field| field.key == 'form_end' }.map do |field|
+      IdeaCustomFieldsService.new(custom_form).all_fields.reject { |field| field.form_end_page? }.map do |field|
         {}.tap do |field_param|
           attributes.each do |attribute|
             field_param[attribute] = field.send attribute

--- a/back/spec/factories/custom_fields.rb
+++ b/back/spec/factories/custom_fields.rb
@@ -234,6 +234,10 @@ FactoryBot.define do
       end
       input_type { 'page' }
       page_layout { 'default' }
+
+      factory :custom_field_form_end_page do
+        key { 'form_end' }
+      end
     end
 
     factory :custom_field_multiselect do

--- a/back/spec/services/input_ui_schema_generator_service_spec.rb
+++ b/back/spec/services/input_ui_schema_generator_service_spec.rb
@@ -705,9 +705,8 @@ RSpec.describe InputUiSchemaGeneratorService do
         end
         let!(:page3) do
           create(
-            :custom_field_page,
+            :custom_field_form_end_page,
             resource: custom_form,
-            key: 'form_end',
             title_multiloc: { 'en' => 'This is the end of the survey' },
             description_multiloc: { 'en' => 'Thank you for participating 🚀' }
           )
@@ -865,9 +864,8 @@ RSpec.describe InputUiSchemaGeneratorService do
         end
         let!(:page_end) do
           create(
-            :custom_field_page,
+            :custom_field_form_end_page,
             resource: custom_form,
-            key: 'form_end',
             title_multiloc: { 'en' => 'Almost done' },
             description_multiloc: { 'en' => "You are about to submit your answers. By clicking 'Submit' you give us permission to analyse your answers.<br/>After you submit, you will no longer be able to go back and change any of your answers." }
           )

--- a/back/spec/services/surveys/shared/survey_setup.rb
+++ b/back/spec/services/surveys/shared/survey_setup.rb
@@ -268,7 +268,7 @@ RSpec.shared_context 'survey_setup' do
 
   # The following page for form submission should not be returned in the results
   let_it_be(:last_page_field) do
-    create(:custom_field_page, resource: form, key: 'form_end')
+    create(:custom_field_form_end_page, resource: form)
   end
 
   # Set-up user custom fields for the platform


### PR DESCRIPTION
# Changelog
## Technical
- Minor refactoring of form_end to avoid so much hardcoding of 'form_end' key 
- Removed duplication of logic for checking that form end page is present
- Tidied IdeaCustomFieldService methods
