### PR TITLE
Allow .net as Konveio TLD

### DIFF
--- a/back/engines/free/document_annotation/app/models/document_annotation/document_annotation_phase.rb
+++ b/back/engines/free/document_annotation/app/models/document_annotation/document_annotation_phase.rb
@@ -6,7 +6,7 @@ module DocumentAnnotation::DocumentAnnotationPhase
   included do
     with_options if: :document_annotation? do
       validates :document_annotation_embed_url, presence: true, format: {
-        with: %r{\Ahttps://(?:.*\.konveio\.com|.*\.konveio\.site|.*\.konveio\.net)/.*\z},
+        with: %r{\Ahttps://(?:.*\.konveio\.(com|site|net))/.*\z},
         message: 'Not a valid Konveio embed URL' # rubocop:disable Rails/I18nLocaleTexts
       }
       before_validation :strip_document_annotation_embed_url

--- a/back/engines/free/document_annotation/app/models/document_annotation/document_annotation_phase.rb
+++ b/back/engines/free/document_annotation/app/models/document_annotation/document_annotation_phase.rb
@@ -6,7 +6,7 @@ module DocumentAnnotation::DocumentAnnotationPhase
   included do
     with_options if: :document_annotation? do
       validates :document_annotation_embed_url, presence: true, format: {
-        with: %r{\Ahttps://(?:.*\.konveio\.com|.*\.konveio\.site)/.*\z},
+        with: %r{\Ahttps://(?:.*\.konveio\.com|.*\.konveio\.site|.*\.konveio\.net)/.*\z},
         message: 'Not a valid Konveio embed URL' # rubocop:disable Rails/I18nLocaleTexts
       }
       before_validation :strip_document_annotation_embed_url

--- a/back/engines/free/document_annotation/spec/models/document_annotation/document_annotation_context_spec.rb
+++ b/back/engines/free/document_annotation/spec/models/document_annotation/document_annotation_context_spec.rb
@@ -4,15 +4,30 @@ require 'rails_helper'
 
 describe DocumentAnnotation::DocumentAnnotationPhase do
   describe 'validate document_annotation_embed_url for konveio' do
-    it 'validates a valid document_annotation_embed_url for konveio' do
+    it 'validates a valid document_annotation_embed_url for konveio from different orgs' do
       pc = build(
         :document_annotation_phase,
         document_annotation_embed_url: 'https://citizenlab.konveio.com/node/5'
       )
       expect(pc).to be_valid
+
       pc = build(
         :document_annotation_phase,
         document_annotation_embed_url: 'https://anotherorg.konveio.com/node/5'
+      )
+      expect(pc).to be_valid
+    end
+
+    it 'validates a valid document_annotation_embed_url for konveio with different top-level domains' do
+      pc = build(
+        :document_annotation_phase,
+        document_annotation_embed_url: 'https://anotherorg.konveio.site/node/5'
+      )
+      expect(pc).to be_valid
+
+      pc = build(
+        :document_annotation_phase,
+        document_annotation_embed_url: 'https://anotherorg.konveio.net/node/5'
       )
       expect(pc).to be_valid
     end


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Changed
- Allow `.net` top-level domains for document annotation with Konveio.
