### PR TITLE
TAN-4263 switch local tenants without restarting

### DIFF
--- a/back/engines/commercial/multi_tenancy/config/initializers/apartment.rb
+++ b/back/engines/commercial/multi_tenancy/config/initializers/apartment.rb
@@ -132,7 +132,7 @@ class RescuedApartmentMiddleware < Apartment::Elevators::Generic
       host = if Rails.env.development? || Rails.env.staging?
         if request.host.end_with?('.localhost')
           # This lets you do my.city.localhost in local development to switch tenants without having to set OVERRIDE_HOST
-          request.host[0..-11]
+          request.host.sub(/\.localhost$/, '')
         else
           ENV.fetch('OVERRIDE_HOST', request.host)
         end

--- a/back/engines/commercial/multi_tenancy/config/initializers/apartment.rb
+++ b/back/engines/commercial/multi_tenancy/config/initializers/apartment.rb
@@ -130,7 +130,12 @@ class RescuedApartmentMiddleware < Apartment::Elevators::Generic
       nil
     else
       host = if Rails.env.development? || Rails.env.staging?
-        ENV.fetch('OVERRIDE_HOST', request.host)
+        if request.host.end_with?('.localhost')
+          # This lets you do my.city.localhost in local development to switch tenants without having to set OVERRIDE_HOST
+          request.host[0..-11]
+        else
+          ENV.fetch('OVERRIDE_HOST', request.host)
+        end
       else
         request.host
       end

--- a/env_files/front-safe.env
+++ b/env_files/front-safe.env
@@ -1,1 +1,2 @@
-API_HOST=localhost
+# Set API_HOST in case you are running the back-end on a different server or address in development mode
+# API_HOST=localhost

--- a/front/vite.config.ts
+++ b/front/vite.config.ts
@@ -42,31 +42,31 @@ export default defineConfig(({ mode }) => {
       proxy: {
         '/web_api/': {
           target: `http://${API_HOST}:${API_PORT}`,
-          changeOrigin: true,
+          changeOrigin: false,
         },
         '/auth/': {
           target: `http://${API_HOST}:${API_PORT}`,
-          changeOrigin: true,
+          changeOrigin: false,
         },
         '/widgets/': {
           target: `http://${API_HOST}:3200`,
-          changeOrigin: true,
+          changeOrigin: false,
         },
         '/admin_templates_api': {
           target: `http://${GRAPHQL_HOST}:${GRAPHQL_PORT}`,
-          changeOrigin: true,
+          changeOrigin: false,
         },
         '/uploads': {
           target: `http://${API_HOST}:${API_PORT}`,
-          changeOrigin: true,
+          changeOrigin: false,
         },
         '/workshops': {
           target: `http://${DEV_WORKSHOPS_HOST}:${DEV_WORKSHOPS_PORT}`,
-          changeOrigin: true,
+          changeOrigin: false,
         },
         '/project_library_api': {
           target: `http://${DEV_LIBRARY_HOST}:${DEV_LIBRARY_PORT}`,
-          changeOrigin: true,
+          changeOrigin: false,
         },
       },
     },


### PR DESCRIPTION
# Changelog

## Technical
- Access different local tenants without setting ENV vars or restarting by prepending their URL to localhost, e.g. `some.tenant.url.localhost:3000`
