### PR TITLE
TAN-4265 Add all questions to the analysis for survey

### DIFF
--- a/front/app/containers/Admin/projects/project/nativeSurvey/FormResults/FormResultsQuestion/TextQuestion/Analysis/index.tsx
+++ b/front/app/containers/Admin/projects/project/nativeSurvey/FormResults/FormResultsQuestion/TextQuestion/Analysis/index.tsx
@@ -16,9 +16,6 @@ import useAddAnalysis from 'api/analyses/useAddAnalysis';
 import useAnalyses from 'api/analyses/useAnalyses';
 import useUpdateAnalysis from 'api/analyses/useUpdateAnalysis';
 import useAnalysisInsights from 'api/analysis_insights/useAnalysisInsights';
-import useCustomFields from 'api/custom_fields/useCustomFields';
-
-import useRelevantToHeatmapInputCustomFields from 'containers/Admin/projects/project/analysis/hooks/useRelevantToHeatmapInputCustomFields';
 
 import Button from 'components/UI/ButtonWithLink';
 
@@ -58,32 +55,12 @@ const Analysis = ({
     phaseId,
   });
 
-  const additionalCustomFieldsIds = useRelevantToHeatmapInputCustomFields({
-    projectId,
-    phaseId,
-  })?.map((customField) => customField.id);
-
-  // Needed in order to create stable references for the additional custom fields
-  const stringifiedAdditionalCustomFieldsIds = JSON.stringify(
-    additionalCustomFieldsIds
-  );
-
   const relevantAnalysis =
     analyses?.data &&
     analyses.data.find(
       (analysis) =>
         analysis.relationships.main_custom_field?.data?.id === customFieldId
     );
-
-  const { data: inputCustomFields } = useCustomFields({
-    projectId,
-    phaseId,
-  });
-
-  const firstTextQuestionId = inputCustomFields?.find(
-    (result) =>
-      result.input_type === 'text' || result.input_type === 'multiline_text'
-  )?.id;
 
   const { data: insights, isLoading: isInsightsLoading } = useAnalysisInsights({
     analysisId: relevantAnalysis?.id,
@@ -97,16 +74,10 @@ const Analysis = ({
       !relevantAnalysis &&
       textResponsesCount > 10
     ) {
-      // We are including the additional custom fields in the analysis in order to be able to display heatmaps for them correctly
-
       addAnalysis({
         projectId: phaseId ? undefined : projectId,
         phaseId,
         mainCustomField: customFieldId,
-        additionalCustomFields:
-          firstTextQuestionId === customFieldId
-            ? JSON.parse(stringifiedAdditionalCustomFieldsIds)
-            : undefined,
       });
     }
   }, [
@@ -117,8 +88,6 @@ const Analysis = ({
     phaseId,
     addAnalysis,
     textResponsesCount,
-    firstTextQuestionId,
-    stringifiedAdditionalCustomFieldsIds,
   ]);
 
   const toggleDropdown = () => {

--- a/front/app/containers/Admin/projects/project/nativeSurvey/FormResults/FormResultsQuestion/components/ViewSingleSubmissionNotice.tsx
+++ b/front/app/containers/Admin/projects/project/nativeSurvey/FormResults/FormResultsQuestion/components/ViewSingleSubmissionNotice.tsx
@@ -6,8 +6,7 @@ import { useParams } from 'react-router-dom';
 
 import useAddAnalysis from 'api/analyses/useAddAnalysis';
 import useAnalyses from 'api/analyses/useAnalyses';
-
-import useRelevantToHeatmapInputCustomFields from 'containers/Admin/projects/project/analysis/hooks/useRelevantToHeatmapInputCustomFields';
+import useCustomFields from 'api/custom_fields/useCustomFields';
 
 import Button from 'components/UI/ButtonWithLink';
 
@@ -16,11 +15,7 @@ import clHistory from 'utils/cl-router/history';
 
 import messages from './messages';
 
-type Props = {
-  customFieldId: string;
-};
-
-const ViewSingleSubmissionNotice = ({ customFieldId }: Props) => {
+const ViewSingleSubmissionNotice = () => {
   const { formatMessage } = useIntl();
 
   const { mutate: addAnalysis } = useAddAnalysis();
@@ -34,15 +29,17 @@ const ViewSingleSubmissionNotice = ({ customFieldId }: Props) => {
     projectId: phaseId ? undefined : projectId,
     phaseId,
   });
-
-  const additionalCustomFieldsIds = useRelevantToHeatmapInputCustomFields({
+  const { data: inputCustomFields } = useCustomFields({
     projectId,
     phaseId,
-  })?.map((customField) => customField.id);
+  });
+
+  const inputCustomFieldsIds = inputCustomFields?.map(
+    (customField) => customField.id
+  );
 
   const relevantAnalysis = analyses?.data.find(
-    (analysis) =>
-      analysis.relationships.main_custom_field?.data?.id === customFieldId
+    (analysis) => analysis.relationships.main_custom_field?.data === null
   );
 
   const goToAnalysis = () => {
@@ -59,8 +56,7 @@ const ViewSingleSubmissionNotice = ({ customFieldId }: Props) => {
         {
           projectId: phaseId ? undefined : projectId,
           phaseId,
-          mainCustomField: customFieldId,
-          additionalCustomFields: additionalCustomFieldsIds,
+          additionalCustomFields: inputCustomFieldsIds,
         },
         {
           onSuccess: (response) => {

--- a/front/app/containers/Admin/projects/project/nativeSurvey/FormResults/index.tsx
+++ b/front/app/containers/Admin/projects/project/nativeSurvey/FormResults/index.tsx
@@ -70,11 +70,7 @@ const FormResults = () => {
           {surveyResponseMessage}
         </Text>
       </Box>
-      {firstTextQuestion?.customFieldId && (
-        <ViewSingleSubmissionNotice
-          customFieldId={firstTextQuestion.customFieldId}
-        />
-      )}
+      {firstTextQuestion?.customFieldId && <ViewSingleSubmissionNotice />}
       <Box mt="24px">
         {totalSubmissions > 0 &&
           results.map((result, index) => {


### PR DESCRIPTION
@kogre I've made the analysis with all the questions for survey work in the exact same way as ideation. All the questions are always included and there is no way to add / remove questions for this particular analysis. I think this makes sense given that we are creating a mechanism to browse full survey responses in a way. And it somewhat reduces the complexity for us. Screenshot below.
![image](https://github.com/user-attachments/assets/2cb2eb37-8198-4472-9290-2797d1a340f6)

# Changelog
## Changed
- The AI analysis accessible from the CTA on top of the surveys results page now includes all survey questions, not just the first textual question from the survey.


