### PR TITLE
Speed up test

### DIFF
--- a/front/cypress/e2e/project_page_timeline.cy.ts
+++ b/front/cypress/e2e/project_page_timeline.cy.ts
@@ -9,12 +9,11 @@ describe('Existing Timeline project', () => {
     cy.wait(1000);
   });
 
-  beforeEach(() => {
-    cy.visit('/projects/test-project-1-timeline-with-file');
+  it('shows the correct elements', () => {
+    // shows the project page
     cy.get('#e2e-project-page');
-  });
 
-  it('shows the correct project header', () => {
+    // shows the project header
     cy.get('#e2e-project-header-image');
     cy.get('#e2e-project-description');
     cy.get('#e2e-project-sidebar');
@@ -23,29 +22,23 @@ describe('Existing Timeline project', () => {
     cy.get('.e2e-project-info')
       .contains('20190110_rueil_intermediaire.pdf')
       .should('have.attr', 'href');
-  });
 
-  it('shows the timeline', () => {
+    // shows the timeline
     cy.get('#project-timeline');
-  });
 
-  it('shows the timeline phases', () => {
+    // shows the timeline phases
     cy.get('.e2e-phases');
-  });
 
-  it('shows the phase navigation buttons', () => {
+    // shows the phase navigation buttons
     cy.get('.e2e-timeline-phase-navigation');
-  });
 
-  it('has a selected phase', () => {
+    // has a selected phase
     cy.get('.e2e-phases .selectedPhase');
-  });
 
-  it('shows the phase title', () => {
+    // shows the phase title
     cy.get('.e2e-phase-title');
-  });
 
-  it('shows the phase description', () => {
+    // shows the phase description
     cy.get('.e2e-phase-description');
   });
 });


### PR DESCRIPTION
Speeding up `project_page_timeline` by asserting all elements in 1 test vs. reloading the app and only asserting 1 element at a time.

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->
