### PR TITLE
[TAN-4066] Notify superadmins of project review requests

### DIFF
--- a/back/app/models/notifications/project_review_request.rb
+++ b/back/app/models/notifications/project_review_request.rb
@@ -79,7 +79,7 @@ module Notifications
         reviewers = User.project_reviewers
         folder = project_review.project.folder
         reviewers = reviewers.or(folder.moderators) if folder
-        reviewers.presence || User.admin.not_citizenlab_member
+        reviewers.presence || User.admin
       end
 
       reviewers.map do |reviewer|

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/project_review_request.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/project_review_request.rb
@@ -44,7 +44,12 @@ module EmailCampaigns
     end
 
     def notification_recipient(users_scope, activity:, time: nil)
-      users_scope.where(id: activity.item.recipient_id)
+      # This is a bit convoluted, but that's because we only want to send the email to
+      # superadmins if they’re explicitly set as project reviewers. In other words, when
+      # the request is being broadcast to all admins because project reviewers haven’t
+      # been configured, we don’t want to include the superadmins.
+      recipient_scope = users_scope.where(id: activity.item.recipient_id)
+      recipient_scope.not_citizenlab_member.or(recipient_scope.citizenlab_member.project_reviewers)
     end
 
     def self.recipient_role_multiloc_key


### PR DESCRIPTION
# Changelog
## Changed
- [TAN-4066] Notify superadmins of project review requests. Previously, we were filtering out superadmins from the list of notified users (only applies when no project reviewers were configured), but this was causing too much confusion. With this change, notifications will be sent to all admins, including superadmins. However, the email will still be withheld for superadmins to avoid spamming GSMs.

