### PR TITLE
Align file size to the right when file is draggable

### DIFF
--- a/front/app/components/UI/FileUploader/FileDisplay.tsx
+++ b/front/app/components/UI/FileUploader/FileDisplay.tsx
@@ -38,6 +38,7 @@ const FileInfo = styled.div`
   flex: 1;
   display: flex;
   align-items: center;
+  justify-content: space-between;
 `;
 
 const FileDownloadLink = styled.a<{ error: boolean }>`


### PR DESCRIPTION
Before
<img width="597" alt="Screenshot 2025-04-10 at 08 33 29" src="https://github.com/user-attachments/assets/5bdbf2d3-ed93-4bf9-9e1b-fb810925603d" />

After
<img width="549" alt="Screenshot 2025-04-10 at 08 33 39" src="https://github.com/user-attachments/assets/0064c628-1eee-4fee-80b4-75518cc66818" />

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Align file size to the right when file is draggable ([before/after](https://github.com/CitizenLabDotCo/citizenlab/pull/10719))
