### PR TITLE
Project settings: visibility of form bottom

### DIFF
--- a/front/app/containers/Admin/projects/project/general/components/styling.ts
+++ b/front/app/containers/Admin/projects/project/general/components/styling.ts
@@ -5,8 +5,10 @@ import FileUploader from 'components/UI/FileUploader';
 import InputMultilocWithLocaleSwitcher from 'components/UI/InputMultilocWithLocaleSwitcher';
 import MultipleSelect from 'components/UI/MultipleSelect';
 
-export const StyledForm = styled.form`
+export const StyledForm = styled.form<{ showStickySaveButton: boolean }>`
   width: 500px;
+  // Needed to ensure an uploaded file (or whichever field is last) is visible
+  padding-bottom: ${(props) => (props.showStickySaveButton ? '80px' : '0')};
 `;
 
 export const StyledInputMultiloc = styled(InputMultilocWithLocaleSwitcher)`

--- a/front/app/containers/Admin/projects/project/general/index.tsx
+++ b/front/app/containers/Admin/projects/project/general/index.tsx
@@ -527,6 +527,7 @@ const AdminProjectsProjectGeneral = () => {
       <StyledForm
         className="e2e-project-general-form intercom-projects-new-project-form"
         onSubmit={onSubmit}
+        showStickySaveButton={showStickySaveButton}
       >
         <Section>
           {projectId && (
@@ -669,39 +670,33 @@ const AdminProjectsProjectGeneral = () => {
             handleProjectFileOnRemove={handleProjectFileOnRemove}
             onFileReorder={handleFilesReorder}
           />
-
-          {/* 
-            The sticky save button is only shown when you edit a form so that the user 
-            is not forced to scroll to the bottom of the page to save it.
-          */}
-
-          <Box
-            {...(showStickySaveButton && {
-              position: 'fixed',
-              borderTop: `1px solid ${colors.divider}`,
-              bottom: '0',
-              w: `calc(${width}px + ${defaultAdminCardPadding * 2}px)`,
-              ml: `-${defaultAdminCardPadding}px`,
-              background: colors.white,
-              display: 'flex',
-              justifyContent: 'flex-start',
-              px: `${defaultAdminCardPadding}px`,
-            })}
-            py="8px"
-          >
-            <SubmitWrapper
-              className="intercom-projects-new-project-save-button"
-              loading={processing}
-              status={submitState}
-              messages={{
-                buttonSave: messages.saveProject,
-                buttonSuccess: messages.saveSuccess,
-                messageError: messages.saveErrorMessage,
-                messageSuccess: messages.saveSuccessMessage,
-              }}
-            />
-          </Box>
         </Section>
+        <Box
+          {...(showStickySaveButton && {
+            position: 'fixed',
+            borderTop: `1px solid ${colors.divider}`,
+            bottom: '0',
+            w: `calc(${width}px + ${defaultAdminCardPadding * 2}px)`,
+            ml: `-${defaultAdminCardPadding}px`,
+            background: colors.white,
+            display: 'flex',
+            justifyContent: 'flex-start',
+            px: `${defaultAdminCardPadding}px`,
+          })}
+          py="8px"
+        >
+          <SubmitWrapper
+            className="intercom-projects-new-project-save-button"
+            loading={processing}
+            status={submitState}
+            messages={{
+              buttonSave: messages.saveProject,
+              buttonSuccess: messages.saveSuccess,
+              messageError: messages.saveErrorMessage,
+              messageSuccess: messages.saveSuccessMessage,
+            }}
+          />
+        </Box>
       </StyledForm>
     </Box>
   );


### PR DESCRIPTION
Before
<img width="542" alt="Screenshot 2025-04-10 at 09 49 30" src="https://github.com/user-attachments/assets/04723ea5-f3de-440d-b82f-1d88448de38c" />

After
<img width="584" alt="Screenshot 2025-04-10 at 09 48 55" src="https://github.com/user-attachments/assets/f77887f0-055d-4c7a-9095-e87f593bd107" />

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- General project settings: ensure uploaded file is visible without scrolling ([before/after](https://github.com/CitizenLabDotCo/citizenlab/pull/10722)).