### PR TITLE
TAN-3670 Fix autotagging disabled state

### DIFF
--- a/front/app/containers/Admin/projects/project/analysis/Tags/AutoTaggingModal/AutoTagOption.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Tags/AutoTaggingModal/AutoTagOption.tsx
@@ -60,7 +60,7 @@ const AutoTagOption = ({
 }: Props) => {
   const { formatMessage } = useIntl();
   return (
-    <Box w="30%">
+    <Box w="30%" bgColor={colors.grey100}>
       <Tooltip
         content={
           <p>{formatMessage(messages.advancedAutotaggingUpsellMessage)}</p>

--- a/front/app/containers/Admin/projects/project/analysis/Tags/AutoTaggingModal/Step1.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Tags/AutoTaggingModal/Step1.tsx
@@ -158,7 +158,7 @@ const Step1 = ({
           tagType="custom"
           title={formatMessage(messages.classificationByLabelTitle)}
           onSelect={() => onSelectMethod('label_classification')}
-          isDisabled={isLoading}
+          isDisabled={!advancedAutotaggingAllowed}
           isLoading={isLoading && loadingMethod === 'label_classification'}
           tooltip={formatMessage(messages.classificationByLabelTooltip)}
         >


### PR DESCRIPTION
# Changelog
## Fixed
- All auto-tagging options are now disabled when the analysis feature flag is off
