### PR TITLE
[TAN-4341] Fix not using tenant locale query param when fetching tenant countries

### DIFF
--- a/front/app/api/project_library_countries/keys.ts
+++ b/front/app/api/project_library_countries/keys.ts
@@ -1,11 +1,13 @@
 import { QueryKeys } from 'utils/cl-react-query/types';
+import { ILocaleParameters } from './types';
+
+const baseKey = { type: 'project_library_tenant_countries' };
 
 const projectLibraryCountriesKeys = {
-  all: (locale?: string) => [
-    {
-      type: 'project_library_tenant_countries',
-      locale,
-    },
+  all: () => [baseKey],
+  lists: () => [{ ...baseKey, operation: 'list' }],
+  list: (params: ILocaleParameters = {}) => [
+    { ...baseKey, operation: 'list', parameters: params },
   ],
 } satisfies QueryKeys;
 

--- a/front/app/api/project_library_countries/keys.ts
+++ b/front/app/api/project_library_countries/keys.ts
@@ -1,6 +1,12 @@
+import { QueryKeys } from 'utils/cl-react-query/types';
+
 const projectLibraryCountriesKeys = {
-  all: (locale?: string) =>
-    ['project_library_tenant_countries', ...(locale ? [locale] : [])] as const,
-};
+  all: (locale?: string) => [
+    {
+      type: 'project_library_tenant_countries',
+      locale,
+    },
+  ],
+} satisfies QueryKeys;
 
 export default projectLibraryCountriesKeys;

--- a/front/app/api/project_library_countries/keys.ts
+++ b/front/app/api/project_library_countries/keys.ts
@@ -1,9 +1,6 @@
-import { QueryKeys } from 'utils/cl-react-query/types';
-
-const baseKey = { type: 'project_library_tenant_countries' };
-
 const projectLibraryCountriesKeys = {
-  all: () => [baseKey],
-} satisfies QueryKeys;
+  all: (locale?: string) =>
+    ['project_library_countries', ...(locale ? [locale] : [])] as const,
+};
 
 export default projectLibraryCountriesKeys;

--- a/front/app/api/project_library_countries/keys.ts
+++ b/front/app/api/project_library_countries/keys.ts
@@ -1,6 +1,6 @@
 const projectLibraryCountriesKeys = {
   all: (locale?: string) =>
-    ['project_library_countries', ...(locale ? [locale] : [])] as const,
+    ['project_library_tenant_countries', ...(locale ? [locale] : [])] as const,
 };
 
 export default projectLibraryCountriesKeys;

--- a/front/app/api/project_library_countries/types.ts
+++ b/front/app/api/project_library_countries/types.ts
@@ -4,6 +4,10 @@ import projectLibraryPhasesKeys from './keys';
 
 export type ProjectLibraryCountriesKeys = Keys<typeof projectLibraryPhasesKeys>;
 
+export interface ILocaleParameters {
+  locale?: string;
+}
+
 export type Country = {
   code: string;
   emoji_flag: string;

--- a/front/app/api/project_library_countries/useProjectLibraryCountries.ts
+++ b/front/app/api/project_library_countries/useProjectLibraryCountries.ts
@@ -1,19 +1,23 @@
 import { useQuery } from '@tanstack/react-query';
 import { CLErrors } from 'typings';
 
+import useLocale from 'hooks/useLocale';
 import fetcher from 'utils/cl-react-query/fetcher';
 
 import projectLibraryCountriesKeys from './keys';
 import { ProjectLibraryCountries, ProjectLibraryCountriesKeys } from './types';
 
-const fetchProjectLibraryCountries = () =>
-  fetcher<ProjectLibraryCountries>({
-    path: `/tenant_countries`,
-    action: 'get',
-    apiPath: '/project_library_api',
-  });
-
 const useProjectLibraryCountries = () => {
+  const locale = useLocale();
+
+  const fetchProjectLibraryCountries = () =>
+    fetcher<ProjectLibraryCountries>({
+      path: `/tenant_countries`,
+      action: 'get',
+      apiPath: '/project_library_api',
+      queryParams: { locale },
+    });
+
   return useQuery<
     ProjectLibraryCountries,
     CLErrors,

--- a/front/app/api/project_library_countries/useProjectLibraryCountries.ts
+++ b/front/app/api/project_library_countries/useProjectLibraryCountries.ts
@@ -24,7 +24,7 @@ const useProjectLibraryCountries = () => {
     ProjectLibraryCountries,
     ProjectLibraryCountriesKeys
   >({
-    queryKey: projectLibraryCountriesKeys.all(),
+    queryKey: projectLibraryCountriesKeys.all(locale),
     queryFn: () => fetchProjectLibraryCountries(),
   });
 };

--- a/front/app/api/project_library_countries/useProjectLibraryCountries.ts
+++ b/front/app/api/project_library_countries/useProjectLibraryCountries.ts
@@ -24,7 +24,7 @@ const useProjectLibraryCountries = () => {
     ProjectLibraryCountries,
     ProjectLibraryCountriesKeys
   >({
-    queryKey: projectLibraryCountriesKeys.all(locale),
+    queryKey: projectLibraryCountriesKeys.list({ locale }),
     queryFn: () => fetchProjectLibraryCountries(),
   });
 };


### PR DESCRIPTION
See ticket for background and a few more details.

This fix seems to work, but I admit to a large amount of 'vibe coding' here, so would appreciate an FE dev's review. Thanks!

# Changelog
## Fixed
- [TAN-4341] Fix not using tenant locale query param when fetching tenant countries for Inspiration Hub. Country selection options should now be translated (for most languages).
