### PR TITLE
Revert file mapping on reorder

### DIFF
--- a/front/app/components/UI/FileUploader/index.tsx
+++ b/front/app/components/UI/FileUploader/index.tsx
@@ -74,15 +74,13 @@ const FileUploader = ({
     // Insert the file at its new position
     filesCopy.splice(toIndex, 0, movedFile);
 
-    // Create a new array with updated ordering properties
-    const reorderedFiles = filesCopy.map((file, index) => ({
-      ...file,
-      ordering: index,
-    }));
+    filesCopy.forEach((file, index) => {
+      file.ordering = index;
+    });
 
     // Update state and notify parent component about the change
-    setFiles(reorderedFiles);
-    onFileReorder?.(reorderedFiles);
+    setFiles(filesCopy);
+    onFileReorder?.(filesCopy);
   };
 
   const fileNames = files.map((file) => file.name).join(', ');


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Project settings: unsaved files do not lose their names on reorder
