### PR TITLE
TAN-4286: Fix failing survey logic conflict tests

### DIFF
--- a/front/cypress.config.ts
+++ b/front/cypress.config.ts
@@ -10,7 +10,6 @@ export default defineConfig({
   viewportWidth: 1400,
   viewportHeight: 800,
   video: false,
-  videoUploadOnPasses: false,
   chromeWebSecurity: false,
   numTestsKeptInMemory: process.env.CYPRESS_NUM_TESTS_KEPT_IN_MEMORY
     ? Number(process.env.CYPRESS_NUM_TESTS_KEPT_IN_MEMORY)
@@ -27,6 +26,5 @@ export default defineConfig({
       return require('./cypress/plugins/index.js')(on, config);
     },
     baseUrl: 'http://localhost:3000',
-    experimentalSessionAndOrigin: false,
   },
 });

--- a/front/cypress/e2e/survey_builder/survey_logic_conflict.cy.ts
+++ b/front/cypress/e2e/survey_builder/survey_logic_conflict.cy.ts
@@ -5,7 +5,11 @@ describe('Survey logic conflict', () => {
   let projectSlug: string | undefined;
   let phaseId: string | undefined;
 
-  before(() => {
+  beforeEach(() => {
+    // Defensive cleanup in case a previous test left a project behind
+    if (projectId) {
+      cy.apiRemoveProject(projectId);
+    }
     createSurveyProject(cy).then((res: any) => {
       projectId = res.projectId;
       projectSlug = res.projectSlug;
@@ -14,6 +18,7 @@ describe('Survey logic conflict', () => {
   });
 
   after(() => {
+    // Clean up after the test
     if (projectId) {
       cy.apiRemoveProject(projectId);
     }


### PR DESCRIPTION
# Changelog

## Technical
- Fix flaky test for survey logic conflict. This test was intermittently failing due to leftover state from the previously created test project. Specifically, when the project was created in before() and not cleaned up after a failure, retries would use the existing project with unexpected extra fields, causing assertions like should('have.length', 3) to fail.
The fix ensures the test project is explicitly removed in beforeEach, so every test run starts with a clean slate.
This should improve test stability, but it's one to keep an eye on in case other state leakage issues resurface.