### PR TITLE
TAN-4354 Classification by label is possible without advanced_auto_tagging

### DIFF
--- a/front/app/containers/Admin/projects/project/analysis/Tags/AutoTaggingModal/Step1.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Tags/AutoTaggingModal/Step1.tsx
@@ -65,6 +65,10 @@ const Step1 = ({
   onChangeAutoTaggingTarget,
   filters,
 }: Props) => {
+  const analysisEnabled = useFeatureFlag({
+    name: 'analysis',
+    onlyCheckAllowed: true,
+  });
   const advancedAutotaggingAllowed = useFeatureFlag({
     name: 'advanced_autotagging',
     onlyCheckAllowed: true,
@@ -158,7 +162,7 @@ const Step1 = ({
           tagType="custom"
           title={formatMessage(messages.classificationByLabelTitle)}
           onSelect={() => onSelectMethod('label_classification')}
-          isDisabled={false}
+          isDisabled={!analysisEnabled}
           isLoading={isLoading && loadingMethod === 'label_classification'}
           tooltip={formatMessage(messages.classificationByLabelTooltip)}
         >

--- a/front/app/containers/Admin/projects/project/analysis/Tags/AutoTaggingModal/Step1.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Tags/AutoTaggingModal/Step1.tsx
@@ -158,7 +158,7 @@ const Step1 = ({
           tagType="custom"
           title={formatMessage(messages.classificationByLabelTitle)}
           onSelect={() => onSelectMethod('label_classification')}
-          isDisabled={!advancedAutotaggingAllowed}
+          isDisabled={false}
           isLoading={isLoading && loadingMethod === 'label_classification'}
           tooltip={formatMessage(messages.classificationByLabelTooltip)}
         >


### PR DESCRIPTION
# Changelog
## Fixed
- It's again possible to auto-tag by label examples without requiring the  advanced_auto_tagging feature (affects standard+)