### PR TITLE
Tan 4352/survey submission reference: layout bug

### DIFF
--- a/front/app/components/Form/Components/Layouts/CLPageLayout.tsx
+++ b/front/app/components/Form/Components/Layouts/CLPageLayout.tsx
@@ -397,9 +397,6 @@ const CLPageLayout = memo(
       (page) => page === currentPage
     );
 
-    const showSubmissionReference =
-      ideaId && pageVariant === 'after-submission' && showIdeaId;
-
     return (
       <>
         <Box
@@ -536,19 +533,21 @@ const CLPageLayout = memo(
                           onChange={handleOnChangeAnonymousPosting}
                         />
                       )}
+                    {pageVariant === 'after-submission' &&
+                      ideaId &&
+                      showIdeaId && (
+                        <Box
+                          display="flex"
+                          flexDirection="column"
+                          alignItems="center"
+                          flex="1"
+                        >
+                          <SubmissionReference ideaId={ideaId} />
+                        </Box>
+                      )}
                   </Box>
                 </Box>
               </Box>
-              {showSubmissionReference && (
-                <Box
-                  display="flex"
-                  flexDirection="column"
-                  alignItems="center"
-                  flex="1"
-                >
-                  <SubmissionReference ideaId={ideaId} />
-                </Box>
-              )}
             </Box>
           </Box>
         </Box>

--- a/front/app/components/Form/Components/Layouts/CLPageLayout.tsx
+++ b/front/app/components/Form/Components/Layouts/CLPageLayout.tsx
@@ -535,16 +535,7 @@ const CLPageLayout = memo(
                       )}
                     {pageVariant === 'after-submission' &&
                       ideaId &&
-                      showIdeaId && (
-                        <Box
-                          display="flex"
-                          flexDirection="column"
-                          alignItems="center"
-                          flex="1"
-                        >
-                          <SubmissionReference ideaId={ideaId} />
-                        </Box>
-                      )}
+                      showIdeaId && <SubmissionReference ideaId={ideaId} />}
                   </Box>
                 </Box>
               </Box>

--- a/front/app/components/Form/Components/Layouts/SubmissionReference/index.tsx
+++ b/front/app/components/Form/Components/Layouts/SubmissionReference/index.tsx
@@ -5,6 +5,7 @@ import { Box, Text } from '@citizenlab/cl2-component-library';
 import useAuthUser from 'api/me/useAuthUser';
 
 import ButtonWithLink from 'components/UI/ButtonWithLink';
+import Warning from 'components/UI/Warning';
 
 import { FormattedMessage, useIntl } from 'utils/cl-intl';
 
@@ -20,20 +21,21 @@ const SubmissionReference = ({ ideaId }: Props) => {
   const { data: authUser } = useAuthUser();
 
   return (
-    <Box w="100%" p="24px">
-      <Text color="tenantText">
-        <FormattedMessage {...messages.ifYouLaterDecide} />
-      </Text>
-      <Text
-        color="tenantText"
-        fontWeight="bold"
-        id="idea-id-success-modal"
-        mb="8px"
-      >
-        {ideaId}
-      </Text>
-      <Box w="100%" display="flex">
+    <Warning hideIcon>
+      <Box display="flex" flexDirection="column" alignItems="flex-start">
+        <Text mb="0" color="tenantText">
+          <FormattedMessage {...messages.ifYouLaterDecide} />
+        </Text>
+        <Text
+          color="tenantText"
+          fontWeight="bold"
+          id="idea-id-success-modal"
+          mb="0"
+        >
+          {ideaId}
+        </Text>
         <ButtonWithLink
+          p="0"
           linkTo={getMailLink({
             email: authUser?.data.attributes.email,
             subject: formatMessage(messages.surveySubmission),
@@ -42,14 +44,15 @@ const SubmissionReference = ({ ideaId }: Props) => {
             }),
           })}
           buttonStyle="text"
-          w="auto"
           icon="email"
-          paddingLeft="0"
+          iconSize="20px"
         >
-          <FormattedMessage {...messages.sendSurveySubmission} />
+          <Text fontSize="s" color="primary">
+            <FormattedMessage {...messages.sendSurveySubmission} />
+          </Text>
         </ButtonWithLink>
       </Box>
-    </Box>
+    </Warning>
   );
 };
 

--- a/front/app/components/UI/Warning/index.tsx
+++ b/front/app/components/UI/Warning/index.tsx
@@ -73,12 +73,13 @@ export interface Props {
   children: string | JSX.Element;
   icon?: IconNames;
   className?: string;
+  hideIcon?: boolean;
 }
 
-const Warning = ({ children, icon, className }: Props) => {
+const Warning = ({ children, icon, className, hideIcon }: Props) => {
   return (
     <Container className={`${className || ''}`}>
-      <StyledIcon name={icon || 'info-outline'} />
+      {!hideIcon && <StyledIcon name={icon || 'info-outline'} />}
       <Text>{children}</Text>
     </Container>
   );


### PR DESCRIPTION
**Before**
Desktop
<img width="839" alt="Screenshot 2025-04-15 at 16 49 12" src="https://github.com/user-attachments/assets/7385bcee-831e-4901-8c34-02835233570e" />

Mobile
<img width="557" alt="Screenshot 2025-04-15 at 16 49 31" src="https://github.com/user-attachments/assets/842556c5-140a-40c5-9df0-55f14a5466dc" />

**After**
Desktop
<img width="796" alt="Screenshot 2025-04-15 at 16 44 45" src="https://github.com/user-attachments/assets/24a84841-3e3c-4dc7-86af-a0c91557fb3d" />

Mobile
<img width="477" alt="Screenshot 2025-04-15 at 16 44 51" src="https://github.com/user-attachments/assets/f0e4620f-dc26-441c-9689-5f593b38f940" />

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Survey "after submission" page: submission id box overlaps rest of the page ([before/after)](https://github.com/CitizenLabDotCo/citizenlab/pull/10768).