### PR TITLE
Allow multimedia (image & video) in accordion widget

### DIFF
--- a/front/app/components/admin/ContentBuilder/Widgets/AccordionMultiloc/index.tsx
+++ b/front/app/components/admin/ContentBuilder/Widgets/AccordionMultiloc/index.tsx
@@ -85,9 +85,6 @@ const AccordionSettings = () => {
       <Box flex="0 1 100%" background="#ffffff">
         <QuillMutilocWithLocaleSwitcher
           label={formatMessage(messages.accordionMultilocTextLabel)}
-          maxHeight="225px"
-          noImages
-          noVideos
           id="quill-editor"
           valueMultiloc={text}
           onChange={(value) => {


### PR DESCRIPTION
https://github.com/user-attachments/assets/5aa6e808-45f1-47d8-99a6-c0217c18e25a

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Added
- Project description & homepage builder: allow image & video to be added in the accordion widget ([demo of adding an image](https://github.com/CitizenLabDotCo/citizenlab/pull/10800)).