### PR TITLE
Add constraint on editing community monitor category names

### DIFF
--- a/back/app/models/custom_field.rb
+++ b/back/app/models/custom_field.rb
@@ -76,8 +76,9 @@ class CustomField < ApplicationRecord
   ].freeze
   CODES = %w[
     author_id birthyear body_multiloc budget domicile gender idea_files_attributes idea_images_attributes
-    location_description proposed_budget title_multiloc topic_ids cosponsor_ids title_page body_page
-    uploads_page details_page
+    location_description proposed_budget title_multiloc topic_ids cosponsor_ids
+    title_page body_page uploads_page details_page
+    page_quality_of_life page_service_delivery page_governance_and_trust
   ].freeze
   VISIBLE_TO_PUBLIC = 'public'
   VISIBLE_TO_ADMINS = 'admins'

--- a/back/lib/participation_method/community_monitor_survey.rb
+++ b/back/lib/participation_method/community_monitor_survey.rb
@@ -32,8 +32,13 @@ module ParticipationMethod
       ]
     end
 
+    # Default category names are locked
     def constraints
-      {} # TODO: Any constraints to be added once we know what the fields are
+      {
+        page_quality_of_life: { locks: { title_multiloc: true } },
+        page_service_delivery: { locks: { title_multiloc: true } },
+        page_governance_and_trust: { locks: { title_multiloc: true } }
+      }
     end
 
     def form_logic_enabled?
@@ -72,6 +77,7 @@ module ParticipationMethod
       CustomField.new(
         id: SecureRandom.uuid,
         key: "page_#{key}",
+        code: "page_#{key}",
         title_multiloc: multiloc_service.i18n_to_multiloc("custom_fields.community_monitor.question_categories.#{key}"),
         resource: custom_form,
         input_type: 'page',

--- a/back/spec/lib/participation_method/community_monitor_survey_spec.rb
+++ b/back/spec/lib/participation_method/community_monitor_survey_spec.rb
@@ -84,6 +84,25 @@ RSpec.describe ParticipationMethod::CommunityMonitorSurvey do
     end
   end
 
+  describe 'constraints' do
+    it 'has constraints on built in fields to lock certain values from being changed' do
+      expect(participation_method.constraints.size).to be 3
+      expect(participation_method.constraints.keys).to match_array %i[
+        page_quality_of_life
+        page_service_delivery
+        page_governance_and_trust
+      ]
+    end
+
+    it 'each constraint has locks only title_multiloc' do
+      participation_method.constraints.each_value do |value|
+        expect(value.key?(:locks)).to be true
+        valid_locks = %i[title_multiloc]
+        expect(valid_locks).to include(*value[:locks].keys)
+      end
+    end
+  end
+
   describe '#generate_slug' do
     let(:input) { create(:input, slug: nil, project: phase.project, creation_phase: phase) }
 


### PR DESCRIPTION
# Changelog
## Added
- Disabled editing of category pages in community monitor
