### PR TITLE
Community monitor BE & User fields fixes

### DIFF
--- a/back/app/services/idea_custom_fields_service.rb
+++ b/back/app/services/idea_custom_fields_service.rb
@@ -46,7 +46,9 @@ class IdeaCustomFieldsService
 
   # Used in the printable PDF export
   def printable_fields
-    enabled_fields_with_other_options.select(&:printable?)
+    # TODO: temporarily remove any user fields from the printable fields - currently unsupported
+    fields = enabled_fields_with_other_options.reject { |field| field.key.start_with?('u_') }
+    fields.select(&:printable?)
   end
 
   def importable_fields

--- a/back/app/services/idea_custom_fields_service.rb
+++ b/back/app/services/idea_custom_fields_service.rb
@@ -47,7 +47,7 @@ class IdeaCustomFieldsService
   # Used in the printable PDF export
   def printable_fields
     # TODO: temporarily remove any user fields from the printable fields - currently unsupported
-    fields = enabled_fields_with_other_options.reject { |field| field.key.start_with?('u_') }
+    fields = enabled_fields_with_other_options.reject { |field| field.key&.start_with?('u_') }
     fields.select(&:printable?)
   end
 

--- a/back/app/services/surveys/average_generator.rb
+++ b/back/app/services/surveys/average_generator.rb
@@ -7,7 +7,6 @@ module Surveys
       @fields = IdeaCustomFieldsService.new(form).enabled_fields.select do |f|
         input_type ? f.input_type == input_type : f.supports_average? # Defaults to returning all fields that support averages
       end
-
       @inputs = phase.ideas.supports_survey.published
       @phase = phase
     end
@@ -57,7 +56,6 @@ module Surveys
       averages = grouped_answers.transform_values do |answers|
         field_group_averages(answers, 'question_category')
       end
-
       averages = order_by_quarter(averages)
       averages = switch_keys(averages)
       averages['other'] = averages.delete(nil) if averages.key?(nil) # NOTE: custom_field model should have return 'other' but does not
@@ -76,7 +74,6 @@ module Surveys
 
     # Calculate the averages for groups of custom fields - grouped by custom field attribute
     def field_group_averages(answers, custom_field_attribute)
-      # binding.pry
       # Get an array of keys grouped by attribute
       key_group = @fields.group_by { |item| item[custom_field_attribute] }.map do |attribute, items|
         { attribute: attribute, keys: items.map { |item| item[:key] } } # TODO: item?

--- a/back/app/services/surveys/average_generator.rb
+++ b/back/app/services/surveys/average_generator.rb
@@ -58,7 +58,7 @@ module Surveys
       end
       averages = order_by_quarter(averages)
       averages = switch_keys(averages)
-      averages['other'] = averages.delete(nil) if averages.key?(nil) # NOTE: custom_field model should have return 'other' but does not
+      averages['other'] = averages.delete(nil) if averages.key?(nil) # NOTE: custom_field model should return 'other' but does not
 
       CustomField::QUESTION_CATEGORIES.each { |c| averages[c] ||= {} } # Add in any missing categories
       averages

--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -1395,7 +1395,7 @@
       "user_fields_in_surveys": {
         "type": "object",
         "title": "User fields in surveys",
-        "description": "Allow surveys to include user fields in a survey form. DO NOT USE UNTIL FURTHER NOTICE.",
+        "description": "Allow surveys to embed user fields directly in the survey form, instead of asking through registration.",
         "additionalProperties": false,
         "required": ["allowed", "enabled"],
         "properties": {

--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -1395,7 +1395,7 @@
       "user_fields_in_surveys": {
         "type": "object",
         "title": "User fields in surveys",
-        "description": "Allow surveys to embed user fields directly in the survey form, instead of asking through registration.",
+        "description": "Allow surveys to embed user fields directly in the survey form, instead of asking through registration. DO NOT ENABLE EXCEPT ON TEST PLATFORMS. Currently in live test on community monitor.",
         "additionalProperties": false,
         "required": ["allowed", "enabled"],
         "properties": {

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/patches/side_fx_idea_service.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/patches/side_fx_idea_service.rb
@@ -4,7 +4,12 @@ module BulkImportIdeas
   module Patches
     module SideFxIdeaService
       def after_import(idea, current_user)
-        return unless idea.author && idea.idea_import&.user_created
+        return unless idea.author
+
+        # Apply user custom field values from the idea to the author's user profile (if any)
+        update_user_profile(idea, idea.author)
+
+        return unless idea.idea_import&.user_created
 
         # Log a user 'create' activity - when the idea has been published
         LogActivityJob.perform_later(idea.author, 'created', current_user, idea.author.created_at.to_i, payload: { flow: 'importer' })

--- a/back/spec/services/surveys/average_generator_spec.rb
+++ b/back/spec/services/surveys/average_generator_spec.rb
@@ -79,6 +79,8 @@ RSpec.describe Surveys::AverageGenerator do
 
     before do
       survey_phase.pmethod.create_default_form!
+      # Additional question with no category
+      create(:custom_field_sentiment_linear_scale, key: 'another_question', resource: survey_phase.custom_form)
       create(:idea_status_proposed)
       create(:native_survey_response,
         project: survey_phase.project,
@@ -96,13 +98,13 @@ RSpec.describe Surveys::AverageGenerator do
         project: survey_phase.project,
         creation_phase: survey_phase,
         phases: [survey_phase],
-        custom_field_values: { 'affordable_housing' => 4, 'cleanliness_and_maintenance' => 3, 'transparency_of_money_spent' => 1 },
+        custom_field_values: { 'affordable_housing' => 4, 'cleanliness_and_maintenance' => 3, 'transparency_of_money_spent' => 1, 'another_question' => 2 },
         created_at: '2025-04-20')
       create(:native_survey_response,
         project: survey_phase.project,
         creation_phase: survey_phase,
         phases: [survey_phase],
-        custom_field_values: { 'sense_of_safety' => 1, 'quality_of_services' => 5, 'responsiveness_of_officials' => 2 },
+        custom_field_values: { 'sense_of_safety' => 1, 'quality_of_services' => 5, 'responsiveness_of_officials' => 2, 'another_question' => 1 },
         created_at: '2025-04-20')
     end
 
@@ -111,10 +113,10 @@ RSpec.describe Surveys::AverageGenerator do
         averages = generator.summary_averages_by_quarter
         expect(averages).to eq({
           overall: {
-            averages: { '2025-1' => 2.3, '2025-2' => 2.7 },
+            averages: { '2025-1' => 2.3, '2025-2' => 2.4 },
             totals: {
               '2025-1' => { 1 => 1, 2 => 2, 3 => 3, 4 => 0, 5 => 0 },
-              '2025-2' => { 1 => 2, 2 => 1, 3 => 1, 4 => 1, 5 => 1 }
+              '2025-2' => { 1 => 3, 2 => 2, 3 => 1, 4 => 1, 5 => 1 }
             }
           },
           categories: {
@@ -122,7 +124,7 @@ RSpec.describe Surveys::AverageGenerator do
               'quality_of_life' => { '2025-1' => 2.5, '2025-2' => 2.5 },
               'service_delivery' => { '2025-1' => 2.5, '2025-2' => 4.0 },
               'governance_and_trust' => { '2025-1' => 2.0, '2025-2' => 1.5 },
-              'other' => {}
+              'other' => { '2025-1' => 0.0, '2025-2' => 1.5 }
             },
             multilocs: {
               'quality_of_life' => { 'en' => 'Quality of life', 'fr-FR' => 'Qualité de vie', 'nl-NL' => 'Kwaliteit van leven' },
@@ -171,7 +173,7 @@ RSpec.describe Surveys::AverageGenerator do
           'quality_of_life' => { '2025-1' => 2.5, '2025-2' => 2.5 },
           'service_delivery' => { '2025-1' => 2.5, '2025-2' => 4.0 },
           'governance_and_trust' => { '2025-1' => 2.0, '2025-2' => 1.5 },
-          'other' => {}
+          'other' => { '2025-1' => 0.0, '2025-2' => 1.5 }
         })
       end
     end
@@ -181,7 +183,7 @@ RSpec.describe Surveys::AverageGenerator do
         totals = generator.send(:totals_by_quarter)
         expect(totals).to eq({
           '2025-1' => { 1 => 1, 2 => 2, 3 => 3, 4 => 0, 5 => 0 },
-          '2025-2' => { 1 => 2, 2 => 1, 3 => 1, 4 => 1, 5 => 1 }
+          '2025-2' => { 1 => 3, 2 => 2, 3 => 1, 4 => 1, 5 => 1 }
         })
       end
     end

--- a/front/app/components/admin/UserFieldsInSurveyToggle/UserFieldsInSurveyToggle.tsx
+++ b/front/app/components/admin/UserFieldsInSurveyToggle/UserFieldsInSurveyToggle.tsx
@@ -15,17 +15,19 @@ interface UserFieldsInSurveyToggleProps {
   handleUserFieldsInFormOnChange: (
     allow_anonymous_participation: boolean
   ) => void;
+  enabledByDefault?: boolean; // Used to override the feature flag for beta testing only on community monitor
 }
 
 const UserFieldsInSurveyToggle = ({
   userFieldsInForm,
   handleUserFieldsInFormOnChange,
+  enabledByDefault,
 }: UserFieldsInSurveyToggleProps) => {
   const userFieldsInSurveysEnabled = useFeatureFlag({
     name: 'user_fields_in_surveys',
   });
 
-  if (!userFieldsInSurveysEnabled) return null;
+  if (!userFieldsInSurveysEnabled && !enabledByDefault) return null;
 
   return (
     <SectionField>

--- a/front/app/components/admin/UserFieldsInSurveyToggle/UserFieldsInSurveyToggle.tsx
+++ b/front/app/components/admin/UserFieldsInSurveyToggle/UserFieldsInSurveyToggle.tsx
@@ -11,19 +11,16 @@ import { FormattedMessage } from 'utils/cl-intl';
 import messages from './messages';
 
 interface UserFieldsInSurveyToggleProps {
-  user_fields_in_form: boolean | null | undefined;
+  userFieldsInForm?: boolean | null;
   handleUserFieldsInFormOnChange: (
     allow_anonymous_participation: boolean
   ) => void;
-  // toggleLabel?: JSX.Element;
 }
 
 const UserFieldsInSurveyToggle = ({
-  user_fields_in_form,
+  userFieldsInForm,
   handleUserFieldsInFormOnChange,
-}: // toggleLabel,
-UserFieldsInSurveyToggleProps) => {
-  // const { formatMessage } = useIntl();
+}: UserFieldsInSurveyToggleProps) => {
   const userFieldsInSurveysEnabled = useFeatureFlag({
     name: 'user_fields_in_surveys',
   });
@@ -36,9 +33,9 @@ UserFieldsInSurveyToggleProps) => {
         <FormattedMessage {...messages.userFieldsInSurveyTitle} />
       </SubSectionTitle>
       <Toggle
-        checked={user_fields_in_form || false}
+        checked={userFieldsInForm || false}
         onChange={() => {
-          handleUserFieldsInFormOnChange(!user_fields_in_form);
+          handleUserFieldsInFormOnChange(!userFieldsInForm);
         }}
         label={
           <Box ml="8px" id="e2e-user-fields-in-form-toggle">

--- a/front/app/components/admin/UserFieldsInSurveyToggle/UserFieldsInSurveyToggle.tsx
+++ b/front/app/components/admin/UserFieldsInSurveyToggle/UserFieldsInSurveyToggle.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+
+import { Toggle, Text, Box } from '@citizenlab/cl2-component-library';
+
+import useFeatureFlag from 'hooks/useFeatureFlag';
+
+import { SectionField, SubSectionTitle } from 'components/admin/Section';
+
+import { FormattedMessage } from 'utils/cl-intl';
+
+import messages from './messages';
+
+interface UserFieldsInSurveyToggleProps {
+  user_fields_in_form: boolean | null | undefined;
+  handleUserFieldsInFormOnChange: (
+    allow_anonymous_participation: boolean
+  ) => void;
+  // toggleLabel?: JSX.Element;
+}
+
+const UserFieldsInSurveyToggle = ({
+  user_fields_in_form,
+  handleUserFieldsInFormOnChange,
+}: // toggleLabel,
+UserFieldsInSurveyToggleProps) => {
+  // const { formatMessage } = useIntl();
+  const userFieldsInSurveysEnabled = useFeatureFlag({
+    name: 'user_fields_in_surveys',
+  });
+
+  if (!userFieldsInSurveysEnabled) return null;
+
+  return (
+    <SectionField>
+      <SubSectionTitle style={{ marginBottom: '0px' }}>
+        <FormattedMessage {...messages.userFieldsInSurveyTitle} />
+      </SubSectionTitle>
+      <Toggle
+        checked={user_fields_in_form || false}
+        onChange={() => {
+          handleUserFieldsInFormOnChange(!user_fields_in_form);
+        }}
+        label={
+          <Box ml="8px" id="e2e-user-fields-in-form-toggle">
+            <Box display="flex">
+              <Text
+                color="primary"
+                mb="0px"
+                fontSize="m"
+                fontWeight="semi-bold"
+              >
+                <FormattedMessage {...messages.userFieldsInSurveyToggle} />
+              </Text>
+            </Box>
+
+            <Text color="coolGrey600" mt="0px" fontSize="m">
+              <FormattedMessage {...messages.userFieldsInSurveyDescription} />
+            </Text>
+          </Box>
+        }
+      />
+    </SectionField>
+  );
+};
+
+export default UserFieldsInSurveyToggle;

--- a/front/app/components/admin/UserFieldsInSurveyToggle/messages.ts
+++ b/front/app/components/admin/UserFieldsInSurveyToggle/messages.ts
@@ -1,0 +1,17 @@
+import { defineMessages } from 'react-intl';
+
+export default defineMessages({
+  userFieldsInSurveyTitle: {
+    id: 'app.containers.AdminPage.ProjectEdit.NativeSurvey.userFieldsInSurveyTitle2',
+    defaultMessage: 'Demographic fields in survey form',
+  },
+  userFieldsInSurveyToggle: {
+    id: 'app.containers.AdminPage.ProjectEdit.NativeSurvey.userFieldsInSurveyToggle2',
+    defaultMessage: 'Show demographic fields in survey?',
+  },
+  userFieldsInSurveyDescription: {
+    id: 'app.containers.AdminPage.ProjectEdit.NativeSurvey.userFieldsInSurveyDescription2',
+    defaultMessage:
+      'If you enable this option, user registration fields will be shown as the last page in the survey instead of as part of the signup process.',
+  },
+});

--- a/front/app/containers/Admin/communityMonitor/CommunityMonitorFormBuilder/index.tsx
+++ b/front/app/containers/Admin/communityMonitor/CommunityMonitorFormBuilder/index.tsx
@@ -9,7 +9,6 @@ import useProjectById from 'api/projects/useProjectById';
 import FormBuilder from 'components/FormBuilder/edit';
 
 import { communityMonitorConfig } from './utils';
-import UserFieldsInFormNotice from 'containers/Admin/projects/project/nativeSurvey/UserFieldsInFormNotice';
 
 const CommunityMonitorSurveyFormBuilder = () => {
   const { phaseId, projectId } = useParams() as {
@@ -35,15 +34,6 @@ const CommunityMonitorSurveyFormBuilder = () => {
           ...communityMonitorConfig,
           formCustomFields,
           goBackUrl: `/admin/community-monitor/settings`,
-          getUserFieldsNotice: () => {
-            return phase.data.attributes.user_fields_in_form ? (
-              <UserFieldsInFormNotice
-                projectId={projectId}
-                phaseId={phase.data.id}
-                communityMonitor={true}
-              />
-            ) : null;
-          },
         }}
         viewFormLink={`/projects/${project.data.attributes.slug}/surveys/new?phase_id=${phase.data.id}`}
       />

--- a/front/app/containers/Admin/communityMonitor/CommunityMonitorFormBuilder/index.tsx
+++ b/front/app/containers/Admin/communityMonitor/CommunityMonitorFormBuilder/index.tsx
@@ -9,6 +9,7 @@ import useProjectById from 'api/projects/useProjectById';
 import FormBuilder from 'components/FormBuilder/edit';
 
 import { communityMonitorConfig } from './utils';
+import UserFieldsInFormNotice from 'containers/Admin/projects/project/nativeSurvey/UserFieldsInFormNotice';
 
 const CommunityMonitorSurveyFormBuilder = () => {
   const { phaseId, projectId } = useParams() as {
@@ -34,6 +35,15 @@ const CommunityMonitorSurveyFormBuilder = () => {
           ...communityMonitorConfig,
           formCustomFields,
           goBackUrl: `/admin/community-monitor/settings`,
+          getUserFieldsNotice: () => {
+            return phase.data.attributes.user_fields_in_form ? (
+              <UserFieldsInFormNotice
+                projectId={projectId}
+                phaseId={phase.data.id}
+                communityMonitor={true}
+              />
+            ) : null;
+          },
         }}
         viewFormLink={`/projects/${project.data.attributes.slug}/surveys/new?phase_id=${phase.data.id}`}
       />

--- a/front/app/containers/Admin/communityMonitor/CommunityMonitorFormBuilder/utils.tsx
+++ b/front/app/containers/Admin/communityMonitor/CommunityMonitorFormBuilder/utils.tsx
@@ -10,6 +10,7 @@ import Warning from 'components/UI/Warning';
 import { FormattedMessage } from 'utils/cl-intl';
 
 import messages from './messages';
+import UserFieldsInFormNotice from 'containers/Admin/projects/project/nativeSurvey/UserFieldsInFormNotice';
 
 export const communityMonitorConfig: FormBuilderConfig = {
   type: 'survey',
@@ -43,5 +44,8 @@ export const communityMonitorConfig: FormBuilderConfig = {
         handleClose={handleClose}
       />
     ) : null;
+  },
+  getUserFieldsNotice: () => {
+    return <UserFieldsInFormNotice communityMonitor={true} />;
   },
 };

--- a/front/app/containers/Admin/communityMonitor/components/Settings/components/SurveySettings/index.tsx
+++ b/front/app/containers/Admin/communityMonitor/components/Settings/components/SurveySettings/index.tsx
@@ -24,6 +24,7 @@ import { getFormActionsConfig } from 'utils/configs/formActionsConfig/utils';
 import ViewSurveyButton from '../../../ViewSurveyButton';
 import messages from '../../messages';
 import AnonymousToggle from '../AnonymousToggle';
+import UserFieldsToggle from 'containers/Admin/communityMonitor/components/Settings/components/UserFieldsToggle';
 
 const SurveySettings = () => {
   const locale = useLocale();
@@ -176,6 +177,7 @@ const SurveySettings = () => {
       {phaseId && (
         <Box mt="20px">
           <AnonymousToggle phaseId={phaseId} />
+          <UserFieldsToggle phaseId={phaseId} />
         </Box>
       )}
     </Box>

--- a/front/app/containers/Admin/communityMonitor/components/Settings/components/UserFieldsToggle.tsx
+++ b/front/app/containers/Admin/communityMonitor/components/Settings/components/UserFieldsToggle.tsx
@@ -26,6 +26,7 @@ const UserFieldsToggle = ({ phaseId }: Props) => {
     <UserFieldsInSurveyToggle
       userFieldsInForm={phase?.data.attributes.user_fields_in_form}
       handleUserFieldsInFormOnChange={handleToggleChange}
+      enabledByDefault={true}
     />
   );
 };

--- a/front/app/containers/Admin/communityMonitor/components/Settings/components/UserFieldsToggle.tsx
+++ b/front/app/containers/Admin/communityMonitor/components/Settings/components/UserFieldsToggle.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import usePhase from 'api/phases/usePhase';
+import useUpdatePhase from 'api/phases/useUpdatePhase';
+import UserFieldsInSurveyToggle from 'components/admin/UserFieldsInSurveyToggle/UserFieldsInSurveyToggle';
+
+type Props = {
+  phaseId: string;
+};
+
+const UserFieldsToggle = ({ phaseId }: Props) => {
+  const { data: phase } = usePhase(phaseId);
+  const { mutate: updatePhase } = useUpdatePhase();
+
+  const userFieldsInForm = phase?.data.attributes.user_fields_in_form;
+
+  const handleToggleChange = () => {
+    phaseId &&
+      updatePhase({
+        phaseId,
+        user_fields_in_form: !userFieldsInForm,
+      });
+  };
+
+  return (
+    <UserFieldsInSurveyToggle
+      user_fields_in_form={phase?.data.attributes.user_fields_in_form}
+      handleUserFieldsInFormOnChange={handleToggleChange}
+    />
+  );
+};
+
+export default UserFieldsToggle;

--- a/front/app/containers/Admin/communityMonitor/components/Settings/components/UserFieldsToggle.tsx
+++ b/front/app/containers/Admin/communityMonitor/components/Settings/components/UserFieldsToggle.tsx
@@ -24,7 +24,7 @@ const UserFieldsToggle = ({ phaseId }: Props) => {
 
   return (
     <UserFieldsInSurveyToggle
-      user_fields_in_form={phase?.data.attributes.user_fields_in_form}
+      userFieldsInForm={phase?.data.attributes.user_fields_in_form}
       handleUserFieldsInFormOnChange={handleToggleChange}
     />
   );

--- a/front/app/containers/Admin/projects/project/nativeSurvey/SurveyFormBuilder/index.tsx
+++ b/front/app/containers/Admin/projects/project/nativeSurvey/SurveyFormBuilder/index.tsx
@@ -11,7 +11,6 @@ import useLocale from 'hooks/useLocale';
 import PDFExportModal, {
   FormValues,
 } from 'containers/Admin/projects/components/PDFExportModal';
-import UserFieldsInFormNotice from 'containers/Admin/projects/project/nativeSurvey/UserFieldsInFormNotice';
 import { API_PATH } from 'containers/App/constants';
 
 import FormBuilder from 'components/FormBuilder/edit';
@@ -62,14 +61,6 @@ const SurveyFormBuilder = () => {
           formCustomFields: newCustomFields,
           goBackUrl: `/admin/projects/${projectId}/phases/${phaseId}/native-survey`,
           onDownloadPDF: handleDownloadPDF,
-          getUserFieldsNotice: () => {
-            return phase.data.attributes.user_fields_in_form ? (
-              <UserFieldsInFormNotice
-                projectId={projectId}
-                phaseId={phase.data.id}
-              />
-            ) : null;
-          },
         }}
         viewFormLink={`/projects/${project.data.attributes.slug}/surveys/new?phase_id=${phase.data.id}`}
       />

--- a/front/app/containers/Admin/projects/project/nativeSurvey/UserFieldsInFormNotice/index.tsx
+++ b/front/app/containers/Admin/projects/project/nativeSurvey/UserFieldsInFormNotice/index.tsx
@@ -6,23 +6,27 @@ import { FormattedMessage, useIntl } from 'utils/cl-intl';
 import Link from 'utils/cl-router/Link';
 
 import messages from './messages';
+import { RouteType } from 'routes';
 
 type UserFieldsInFormNoticeProps = {
   projectId: string;
   phaseId: string;
+  communityMonitor?: boolean;
 };
 
 const UserFieldsInFormNotice = ({
   projectId,
   phaseId,
+  communityMonitor = false,
 }: UserFieldsInFormNoticeProps) => {
   const { formatMessage } = useIntl();
 
+  const accessRightsPath: RouteType = communityMonitor
+    ? `/admin/community-monitor/settings/access-rights`
+    : `/admin/projects/${projectId}/phases/${phaseId}/access-rights`;
+
   const accessRightsSettingsLink = (
-    <Link
-      to={`/admin/projects/${projectId}/phases/${phaseId}/access-rights`}
-      target="_blank"
-    >
+    <Link to={accessRightsPath} target="_blank">
       {formatMessage(messages.accessRightsSettings)}
     </Link>
   );

--- a/front/app/containers/Admin/projects/project/nativeSurvey/UserFieldsInFormNotice/index.tsx
+++ b/front/app/containers/Admin/projects/project/nativeSurvey/UserFieldsInFormNotice/index.tsx
@@ -7,19 +7,24 @@ import Link from 'utils/cl-router/Link';
 
 import messages from './messages';
 import { RouteType } from 'routes';
+import usePhase from 'api/phases/usePhase';
+import { useParams } from 'react-router-dom';
 
 type UserFieldsInFormNoticeProps = {
-  projectId: string;
-  phaseId: string;
   communityMonitor?: boolean;
 };
 
 const UserFieldsInFormNotice = ({
-  projectId,
-  phaseId,
   communityMonitor = false,
 }: UserFieldsInFormNoticeProps) => {
   const { formatMessage } = useIntl();
+  const { phaseId, projectId } = useParams() as {
+    projectId: string;
+    phaseId: string;
+  };
+  const { data: phase } = usePhase(phaseId);
+
+  if (!phase?.data.attributes.user_fields_in_form) return null;
 
   const accessRightsPath: RouteType = communityMonitor
     ? `/admin/community-monitor/settings/access-rights`

--- a/front/app/containers/Admin/projects/project/nativeSurvey/UserFieldsInFormNotice/messages.ts
+++ b/front/app/containers/Admin/projects/project/nativeSurvey/UserFieldsInFormNotice/messages.ts
@@ -2,9 +2,9 @@ import { defineMessages } from 'react-intl';
 
 export default defineMessages({
   fieldsEnabledMessage: {
-    id: 'app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.fieldsEnabledMessage',
+    id: 'app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.fieldsEnabledMessage2',
     defaultMessage:
-      "'User fields in survey form' is enabled. When the survey form is displayed any configured demographic questions will be added on a new page here. These questions can be changed in the {accessRightsSettingsLink}.",
+      "'Demographic fields in survey form' is enabled. When the survey form is displayed any configured demographic questions will be added on a new page immediately before the end of the survey. These questions can be changed in the {accessRightsSettingsLink}.",
   },
   accessRightsSettings: {
     id: 'app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.accessRightsSettings',

--- a/front/app/containers/Admin/projects/project/nativeSurvey/utils.tsx
+++ b/front/app/containers/Admin/projects/project/nativeSurvey/utils.tsx
@@ -11,6 +11,7 @@ import { FormattedMessage } from 'utils/cl-intl';
 
 import AccessRightsNotice from './AccessRightsNotice';
 import messages from './messages';
+import UserFieldsInFormNotice from 'containers/Admin/projects/project/nativeSurvey/UserFieldsInFormNotice';
 
 export const nativeSurveyConfig: FormBuilderConfig = {
   type: 'survey',
@@ -72,6 +73,9 @@ export const nativeSurveyConfig: FormBuilderConfig = {
         handleClose={handleClose}
       />
     ) : null;
+  },
+  getUserFieldsNotice: () => {
+    return <UserFieldsInFormNotice />;
   },
 };
 

--- a/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/NativeSurveyInputs.tsx
+++ b/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/NativeSurveyInputs.tsx
@@ -88,7 +88,7 @@ const NativeSurveyInputs = ({
       />
 
       <UserFieldsInSurveyToggle
-        user_fields_in_form={user_fields_in_form}
+        userFieldsInForm={user_fields_in_form}
         handleUserFieldsInFormOnChange={handleUserFieldsInFormOnChange}
       />
 

--- a/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/NativeSurveyInputs.tsx
+++ b/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/NativeSurveyInputs.tsx
@@ -1,17 +1,11 @@
 import React from 'react';
 
-import {
-  Box,
-  IconTooltip,
-  Text,
-  Toggle,
-} from '@citizenlab/cl2-component-library';
+import { Box, IconTooltip, Text } from '@citizenlab/cl2-component-library';
 import { CLErrors, Multiloc } from 'typings';
 
 import { IPhase, IUpdatedPhaseProperties } from 'api/phases/types';
 import useProjectById from 'api/projects/useProjectById';
 
-import useFeatureFlag from 'hooks/useFeatureFlag';
 import useLocalize from 'hooks/useLocalize';
 
 import AnonymousPostingToggle from 'components/admin/AnonymousPostingToggle/AnonymousPostingToggle';
@@ -24,6 +18,7 @@ import { FormattedMessage, useIntl } from 'utils/cl-intl';
 
 import parentMessages from '../../../../messages';
 import messages from '../messages';
+import UserFieldsInSurveyToggle from 'components/admin/UserFieldsInSurveyToggle/UserFieldsInSurveyToggle';
 
 interface Props {
   allow_anonymous_participation: boolean | null | undefined;
@@ -58,9 +53,6 @@ const NativeSurveyInputs = ({
   const { data: project } = useProjectById(
     phase?.data.relationships.project.data.id
   );
-  const userFieldsInSurveysEnabled = useFeatureFlag({
-    name: 'user_fields_in_surveys',
-  });
 
   return (
     <>
@@ -94,39 +86,11 @@ const NativeSurveyInputs = ({
           </Box>
         }
       />
-      {userFieldsInSurveysEnabled && (
-        <SectionField>
-          <SubSectionTitle style={{ marginBottom: '0px' }}>
-            <FormattedMessage {...messages.userFieldsInSurveyTitle} />
-          </SubSectionTitle>
-          <Toggle
-            checked={user_fields_in_form || false}
-            onChange={() => {
-              handleUserFieldsInFormOnChange(!user_fields_in_form);
-            }}
-            label={
-              <Box ml="8px" id="e2e-user-fields-in-form-toggle">
-                <Box display="flex">
-                  <Text
-                    color="primary"
-                    mb="0px"
-                    fontSize="m"
-                    fontWeight="semi-bold"
-                  >
-                    <FormattedMessage {...messages.userFieldsInSurveyToggle} />
-                  </Text>
-                </Box>
 
-                <Text color="coolGrey600" mt="0px" fontSize="m">
-                  <FormattedMessage
-                    {...messages.userFieldsInSurveyDescription}
-                  />
-                </Text>
-              </Box>
-            }
-          />
-        </SectionField>
-      )}
+      <UserFieldsInSurveyToggle
+        user_fields_in_form={user_fields_in_form}
+        handleUserFieldsInFormOnChange={handleUserFieldsInFormOnChange}
+      />
 
       <SectionField>
         <SubSectionTitle>

--- a/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/messages.ts
+++ b/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/messages.ts
@@ -192,17 +192,4 @@ export default defineMessages({
     defaultMessage:
       'This controls how similar two descriptions must be to show suggestions. Use values between 0 and 1. Only adjust if you know what you’re doing.',
   },
-  userFieldsInSurveyTitle: {
-    id: 'app.containers.AdminPage.ProjectEdit.NativeSurvey.userFieldsInSurveyTitle2',
-    defaultMessage: 'Demographic fields in survey form',
-  },
-  userFieldsInSurveyToggle: {
-    id: 'app.containers.AdminPage.ProjectEdit.NativeSurvey.userFieldsInSurveyToggle2',
-    defaultMessage: 'Show demographic fields in survey?',
-  },
-  userFieldsInSurveyDescription: {
-    id: 'app.containers.AdminPage.ProjectEdit.NativeSurvey.userFieldsInSurveyDescription2',
-    defaultMessage:
-      'If you enable this option, user registration fields will be shown as the last page in the survey instead of as part of the signup process.',
-  },
 });

--- a/front/app/translations/admin/ar-SA.json
+++ b/front/app/translations/admin/ar-SA.json
@@ -463,7 +463,6 @@
   "app.components.formBuilder.editWarningModal.title4": "تحرير الاستطلاع المباشر",
   "app.components.formBuilder.editWarningModal.yesContinue": "نعم، استمر",
   "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.accessRightsSettings": "إعدادات حقوق الوصول لهذا الاستطلاع",
-  "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.fieldsEnabledMessage": "تم تفعيل \"حقول المستخدم في نموذج الاستبيان\". عند عرض نموذج الاستبيان، ستُضاف أي أسئلة ديموغرافية مُعدّة إلى صفحة جديدة هنا. يمكن تغيير هذه الأسئلة في {accessRightsSettingsLink}.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.accessRightsSettings": "إعدادات حقوق الوصول لهذه المرحلة.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet1": "لن يُطلب من المشاركين في الاستطلاع التسجيل أو تسجيل الدخول لإرسال إجابات الاستطلاع، مما قد يؤدي إلى إرسالات مكررة",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet2": "من خلال تخطي خطوة الاشتراك/تسجيل الدخول، فإنك توافق على عدم جمع معلومات ديموغرافية عن المشاركين في الاستطلاع، مما قد يؤثر على قدرات تحليل البيانات لديك",

--- a/front/app/translations/admin/cy-GB.json
+++ b/front/app/translations/admin/cy-GB.json
@@ -463,7 +463,6 @@
   "app.components.formBuilder.editWarningModal.title4": "Golygu arolwg byw",
   "app.components.formBuilder.editWarningModal.yesContinue": "Ie, parhewch",
   "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.accessRightsSettings": "gosodiadau hawliau mynediad ar gyfer yr arolwg hwn",
-  "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.fieldsEnabledMessage": "Mae 'Meysydd defnyddiwr ar ffurf arolwg' wedi'i alluogi. Pan fydd y ffurflen arolwg yn cael ei harddangos bydd unrhyw gwestiynau demograffig cyfluniedig yn cael eu hychwanegu ar dudalen newydd yma. Gellir newid y cwestiynau hyn yn y {accessRightsSettingsLink}.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.accessRightsSettings": "gosodiadau hawliau mynediad ar gyfer y cam hwn.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet1": "Ni fydd yn ofynnol i ymatebwyr yr arolwg gofrestru na mewngofnodi i gyflwyno atebion i'r arolwg, a allai arwain at gyflwyniadau dyblyg",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet2": "Drwy hepgor y cam cofrestru/mewngofnodi, rydych yn derbyn i beidio â chasglu gwybodaeth ddemograffig ar ymatebwyr arolwg, a allai effeithio ar eich galluoedd dadansoddi data",

--- a/front/app/translations/admin/da-DK.json
+++ b/front/app/translations/admin/da-DK.json
@@ -463,7 +463,6 @@
   "app.components.formBuilder.editWarningModal.title4": "Rediger igangværende undersøgelse",
   "app.components.formBuilder.editWarningModal.yesContinue": "Ja, fortsæt",
   "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.accessRightsSettings": "Indstillinger for adgangsrettigheder til denne undersøgelse",
-  "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.fieldsEnabledMessage": "'Brugerfelter i undersøgelsesformular' er aktiveret. Når undersøgelsesformularen vises, vil alle konfigurerede demografiske spørgsmål blive tilføjet på en ny side her. Disse spørgsmål kan ændres på {accessRightsSettingsLink}.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.accessRightsSettings": "indstillinger for adgangsrettigheder til denne fase.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet1": "Respondenterne skal ikke tilmelde sig eller logge ind for at indsende svar, hvilket kan resultere i dobbelte indsendelser.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet2": "Ved at springe tilmeldings-/login-trinnet over, accepterer du ikke at indsamle demografiske oplysninger om respondenterne, hvilket kan påvirke dine dataanalysefunktioner.",

--- a/front/app/translations/admin/de-DE.json
+++ b/front/app/translations/admin/de-DE.json
@@ -463,7 +463,6 @@
   "app.components.formBuilder.editWarningModal.title4": "Live-Umfrage bearbeiten",
   "app.components.formBuilder.editWarningModal.yesContinue": "Ja, weiter",
   "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.accessRightsSettings": "Einstellungen der Zugriffsrechte für diese Umfrage",
-  "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.fieldsEnabledMessage": "'Nutzer*innenfelder im Umfrageformular' ist aktiviert. Wenn das Umfrageformular angezeigt wird, werden hier alle konfigurierten demografischen Fragen auf einer neuen Seite hinzugefügt. Diese Fragen können in den {accessRightsSettingsLink} geändert werden.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.accessRightsSettings": "Einstellungen der Zugriffsrechte für diese Phase.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet1": "Die Umfrageteilnehmenden müssen sich nicht anmelden oder einloggen, um Antworten zu übermitteln, was zu doppelten Übermittlungen führen kann",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet2": "Indem Sie den Schritt der Anmeldung überspringen, erklären Sie sich damit einverstanden, dass keine demografischen Daten der Umfrageteilnehmenden erfasst werden, was sich auf Ihre Datenanalyse auswirken kann",

--- a/front/app/translations/admin/en-CA.json
+++ b/front/app/translations/admin/en-CA.json
@@ -463,7 +463,6 @@
   "app.components.formBuilder.editWarningModal.title4": "Edit live survey",
   "app.components.formBuilder.editWarningModal.yesContinue": "Yes, continue",
   "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.accessRightsSettings": "access rights settings for this survey",
-  "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.fieldsEnabledMessage": "'User fields in survey form' is enabled. When the survey form is displayed any configured demographic questions will be added on a new page here. These questions can be changed in the {accessRightsSettingsLink}.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.accessRightsSettings": "access rights settings for this phase.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet1": "Survey respondents will not be required to sign up or log in to submit survey answers, which may result in duplicate submissions",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet2": "By skipping the sign up/log in step, you accept not to collect demographic information on survey respondents, which may impact your data analysis capabilities",

--- a/front/app/translations/admin/en-GB.json
+++ b/front/app/translations/admin/en-GB.json
@@ -463,7 +463,6 @@
   "app.components.formBuilder.editWarningModal.title4": "Edit live survey",
   "app.components.formBuilder.editWarningModal.yesContinue": "Yes, continue",
   "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.accessRightsSettings": "access rights settings for this survey",
-  "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.fieldsEnabledMessage": "'User fields in survey form' is enabled. When the survey form is displayed any configured demographic questions will be added on a new page here. These questions can be changed in the {accessRightsSettingsLink}.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.accessRightsSettings": "access rights settings for this phase.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet1": "Survey respondents will not be required to sign up or log in to submit survey answers, which may result in duplicate submissions",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet2": "By skipping the sign up/log in step, you accept not to collect demographic information on survey respondents, which may impact your data analysis capabilities",

--- a/front/app/translations/admin/en-IE.json
+++ b/front/app/translations/admin/en-IE.json
@@ -463,7 +463,6 @@
   "app.components.formBuilder.editWarningModal.title4": "Edit live survey",
   "app.components.formBuilder.editWarningModal.yesContinue": "Yes, continue",
   "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.accessRightsSettings": "access rights settings for this survey",
-  "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.fieldsEnabledMessage": "'User fields in survey form' is enabled. When the survey form is displayed any configured demographic questions will be added on a new page here. These questions can be changed in the {accessRightsSettingsLink}.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.accessRightsSettings": "access rights settings for this phase.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet1": "Survey respondents will not be required to sign up or log in to submit survey answers, which may result in duplicate submissions",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet2": "By skipping the sign up/log in step, you accept not to collect demographic information on survey respondents, which may impact your data analysis capabilities",

--- a/front/app/translations/admin/en.json
+++ b/front/app/translations/admin/en.json
@@ -463,7 +463,7 @@
   "app.components.formBuilder.editWarningModal.title4": "Edit live survey",
   "app.components.formBuilder.editWarningModal.yesContinue": "Yes, continue",
   "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.accessRightsSettings": "access rights settings for this survey",
-  "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.fieldsEnabledMessage": "'User fields in survey form' is enabled. When the survey form is displayed any configured demographic questions will be added on a new page here. These questions can be changed in the {accessRightsSettingsLink}.",
+  "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.fieldsEnabledMessage2": "'Demographic fields in survey form' is enabled. When the survey form is displayed any configured demographic questions will be added on a new page immediately before the end of the survey. These questions can be changed in the {accessRightsSettingsLink}.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.accessRightsSettings": "access rights settings for this phase.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet1": "Survey respondents will not be required to sign up or log in to submit survey answers, which may result in duplicate submissions",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet2": "By skipping the sign up/log in step, you accept not to collect demographic information on survey respondents, which may impact your data analysis capabilities",

--- a/front/app/translations/admin/es-CL.json
+++ b/front/app/translations/admin/es-CL.json
@@ -463,7 +463,6 @@
   "app.components.formBuilder.editWarningModal.title4": "Editar encuesta en directo",
   "app.components.formBuilder.editWarningModal.yesContinue": "Sí, continúa",
   "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.accessRightsSettings": "configuración de los derechos de acceso a esta encuesta",
-  "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.fieldsEnabledMessage": "'Campos de usuario en formulario de encuesta' está activado. Cuando se muestre el formulario de la encuesta, las preguntas demográficas configuradas se añadirán en una nueva página aquí. Estas preguntas pueden modificarse en {accessRightsSettingsLink}.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.accessRightsSettings": "configuración de los derechos de acceso para esta fase.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet1": "No se exigirá a los encuestados que se registren o inicien sesión para enviar las respuestas de la encuesta, lo que puede dar lugar a envíos duplicados",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet2": "Al omitir el paso de registro/inicio de sesión, aceptas no recopilar información demográfica sobre los encuestados, lo que puede afectar a tus capacidades de análisis de datos.",

--- a/front/app/translations/admin/es-ES.json
+++ b/front/app/translations/admin/es-ES.json
@@ -463,7 +463,6 @@
   "app.components.formBuilder.editWarningModal.title4": "Editar encuesta en directo",
   "app.components.formBuilder.editWarningModal.yesContinue": "Sí, continúa",
   "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.accessRightsSettings": "configuración de los derechos de acceso a esta encuesta",
-  "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.fieldsEnabledMessage": "'Campos de usuario en formulario de encuesta' está activado. Cuando se muestre el formulario de la encuesta, las preguntas demográficas configuradas se añadirán en una nueva página aquí. Estas preguntas pueden modificarse en {accessRightsSettingsLink}.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.accessRightsSettings": "configuración de los derechos de acceso para esta fase.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet1": "No se exigirá a los encuestados que se registren o inicien sesión para enviar las respuestas de la encuesta, lo que puede dar lugar a envíos duplicados",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet2": "Al omitir el paso de registro/inicio de sesión, aceptas no recopilar información demográfica sobre los encuestados, lo que puede afectar a tus capacidades de análisis de datos.",

--- a/front/app/translations/admin/fi-FI.json
+++ b/front/app/translations/admin/fi-FI.json
@@ -463,7 +463,6 @@
   "app.components.formBuilder.editWarningModal.title4": "Muokkaa live-kyselyä",
   "app.components.formBuilder.editWarningModal.yesContinue": "Kyllä, jatka",
   "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.accessRightsSettings": "tämän kyselyn käyttöoikeusasetukset",
-  "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.fieldsEnabledMessage": "\"Käyttäjäkentät kyselylomakkeessa\" on käytössä. Kun kyselylomake tulee näkyviin, kaikki määritetyt demografiset kysymykset lisätään uudelle sivulle tähän. Näitä kysymyksiä voi muuttaa kohdassa {accessRightsSettingsLink}.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.accessRightsSettings": "käyttöoikeusasetukset tälle vaiheelle.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet1": "Kyselyyn vastaajien ei tarvitse rekisteröityä tai kirjautua sisään lähettääkseen kyselyvastauksia, mikä voi johtaa päällekkäisiin lähetyksiin",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet2": "Ohitamalla rekisteröitymis-/sisäänkirjautumisvaiheen hyväksyt, että et kerää väestötietoja kyselyyn vastanneista, mikä saattaa vaikuttaa data-analyysikykyysi.",

--- a/front/app/translations/admin/fr-BE.json
+++ b/front/app/translations/admin/fr-BE.json
@@ -463,7 +463,6 @@
   "app.components.formBuilder.editWarningModal.title4": "Modifier une enquête en cours",
   "app.components.formBuilder.editWarningModal.yesContinue": "Oui, continuer",
   "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.accessRightsSettings": "les droits d'accès pour cette enquête",
-  "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.fieldsEnabledMessage": "L'option « Inclure les champs démographiques dans l'enquête » est activée. Lorsque le formulaire d'enquête est affiché, toutes les questions démographiques configurées seront ajoutées sur une nouvelle page ici. Ces questions peuvent être modifiées dans {accessRightsSettingsLink}.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.accessRightsSettings": "droits d'accès",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet1": "Les personnes interrogées ne seront pas obligées de s'inscrire ou de se connecter pour répondre à l'enquête, ce qui peut entraîner des doublons.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet2": "En sautant l'étape d'inscription ou de connexion, vous choisissez de ne pas collecter les informations démographiques des répondants, ce qui peut restreindre votre capacité à analyser les données",

--- a/front/app/translations/admin/fr-FR.json
+++ b/front/app/translations/admin/fr-FR.json
@@ -463,7 +463,6 @@
   "app.components.formBuilder.editWarningModal.title4": "Modifier une enquête en cours",
   "app.components.formBuilder.editWarningModal.yesContinue": "Oui, continuer",
   "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.accessRightsSettings": "les droits d'accès pour cette enquête",
-  "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.fieldsEnabledMessage": "L'option « Inclure les champs démographiques dans l'enquête » est activée. Lorsque le formulaire d'enquête est affiché, toutes les questions démographiques configurées seront ajoutées sur une nouvelle page ici. Ces questions peuvent être modifiées dans {accessRightsSettingsLink}.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.accessRightsSettings": "droits d'accès",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet1": "Les personnes interrogées ne seront pas obligées de s'inscrire ou de se connecter pour répondre à l'enquête, ce qui peut entraîner des doublons.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet2": "En sautant l'étape d'inscription ou de connexion, vous choisissez de ne pas collecter les informations démographiques des répondants, ce qui peut restreindre votre capacité à analyser les données",

--- a/front/app/translations/admin/hr-HR.json
+++ b/front/app/translations/admin/hr-HR.json
@@ -463,7 +463,6 @@
   "app.components.formBuilder.editWarningModal.title4": "Uredite anketu uživo",
   "app.components.formBuilder.editWarningModal.yesContinue": "Da, nastavi",
   "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.accessRightsSettings": "postavke prava pristupa za ovu anketu",
-  "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.fieldsEnabledMessage": "Omogućena su 'Korisnička polja u upitniku'. Kada se prikaže obrazac ankete, sva konfigurirana demografska pitanja bit će dodana na novu stranicu ovdje. Ova pitanja se mogu promijeniti u {accessRightsSettingsLink}.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.accessRightsSettings": "postavke prava pristupa za ovu fazu.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet1": "Ispitanici u anketi neće se morati prijaviti ili prijaviti za slanje odgovora na anketu, što može rezultirati dvostrukim slanjem",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet2": "Preskakanjem koraka prijave/prijave prihvaćate da nećete prikupljati demografske podatke o ispitanicima, što može utjecati na vaše mogućnosti analize podataka",

--- a/front/app/translations/admin/lt-LT.json
+++ b/front/app/translations/admin/lt-LT.json
@@ -463,7 +463,6 @@
   "app.components.formBuilder.editWarningModal.title4": "Redaguoti tiesioginę apklausą",
   "app.components.formBuilder.editWarningModal.yesContinue": "Taip, tęsti",
   "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.accessRightsSettings": "šios apklausos prieigos teisių nustatymai",
-  "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.fieldsEnabledMessage": "\"Vartotojo laukai apklausos formoje\" yra įjungta. Kai rodoma apklausos forma, visi sukonfigūruoti demografiniai klausimai bus įtraukti į naują puslapį. Šiuos klausimus galima keisti svetainėje {accessRightsSettingsLink}.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.accessRightsSettings": "šio etapo prieigos teisių nustatymus.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet1": "Norint pateikti apklausos atsakymus, iš apklausos respondentų nebus reikalaujama užsiregistruoti ar prisijungti, todėl gali būti, kad atsakymai bus pateikiami du kartus.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet2": "Atmesdami registracijos ir (arba) prisijungimo žingsnį, sutinkate, kad nebūtų renkama demografinė informacija apie apklausos respondentus, o tai gali turėti įtakos jūsų duomenų analizės galimybėms.",

--- a/front/app/translations/admin/lv-LV.json
+++ b/front/app/translations/admin/lv-LV.json
@@ -463,7 +463,6 @@
   "app.components.formBuilder.editWarningModal.title4": "Rediģēt tiešraides apsekojumu",
   "app.components.formBuilder.editWarningModal.yesContinue": "Jā, turpiniet",
   "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.accessRightsSettings": "šīs aptaujas piekļuves tiesību iestatījumi",
-  "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.fieldsEnabledMessage": "\"Lietotāja lauki aptaujas veidlapā\" ir iespējota. Kad tiek parādīta aptaujas veidlapa, visi konfigurētie demogrāfiskie jautājumi tiks pievienoti jaunā lapā. Šos jautājumus var mainīt vietnē {accessRightsSettingsLink}.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.accessRightsSettings": "piekļuves tiesību iestatījumi šajā posmā.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet1": "Aptaujas respondentiem nebūs jāreģistrējas vai jāpiesakās, lai iesniegtu atbildes uz aptaujas jautājumiem, kā rezultātā atbildes var tikt iesniegtas divreiz.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet2": "Izlaižot reģistrēšanās/pierakstīšanās posmu, jūs piekrītat, ka netiks vākti aptaujas respondentu demogrāfiskie dati, kas var ietekmēt jūsu datu analīzes iespējas.",

--- a/front/app/translations/admin/nb-NO.json
+++ b/front/app/translations/admin/nb-NO.json
@@ -463,7 +463,6 @@
   "app.components.formBuilder.editWarningModal.title4": "Rediger live-undersøkelse",
   "app.components.formBuilder.editWarningModal.yesContinue": "Ja, fortsett",
   "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.accessRightsSettings": "innstillinger for tilgangsrettigheter for denne undersøkelsen",
-  "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.fieldsEnabledMessage": "\"Brukerfelt i undersøkelsesskjema\" er aktivert. Når undersøkelsesskjemaet vises, vil eventuelle konfigurerte demografiske spørsmål bli lagt til på en ny side her. Disse spørsmålene kan endres på {accessRightsSettingsLink}.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.accessRightsSettings": "innstillinger for tilgangsrettigheter for denne fasen.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet1": "Respondentene trenger ikke å registrere seg eller logge inn for å sende inn svar på undersøkelsen, noe som kan føre til dobbeltinnsendinger",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet2": "Ved å hoppe over registrerings-/innloggingstrinnet godtar du å ikke samle inn demografisk informasjon om respondentene i undersøkelsen, noe som kan påvirke dataanalysemulighetene dine",

--- a/front/app/translations/admin/nl-BE.json
+++ b/front/app/translations/admin/nl-BE.json
@@ -463,7 +463,6 @@
   "app.components.formBuilder.editWarningModal.title4": "Bewerk live vragenlijst",
   "app.components.formBuilder.editWarningModal.yesContinue": "Ja, doorgaan",
   "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.accessRightsSettings": "instellingen voor toegangsrechten voor deze vragenlijst",
-  "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.fieldsEnabledMessage": "'Gebruikersvelden in vragenlijstformulier' is ingeschakeld. Als het vragenlijstformulier wordt weergegeven, worden alle geconfigureerde demografische vragen hier toegevoegd op een nieuwe pagina. Deze vragen kunnen worden gewijzigd in de {accessRightsSettingsLink}.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.accessRightsSettings": "instellingen voor toegangsrechten voor deze fase.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet1": "Deelnemers van enquêtes hoeven zich niet te registreren of in te loggen om antwoorden in te dienen, wat kan leiden tot dubbele inzendingen",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet2": "Door de stap registreren/inloggen over te slaan, accepteer je dat er geen demografische informatie over respondenten wordt verzameld, wat gevolgen kan hebben voor je gegevensanalyse",

--- a/front/app/translations/admin/nl-NL.json
+++ b/front/app/translations/admin/nl-NL.json
@@ -463,7 +463,6 @@
   "app.components.formBuilder.editWarningModal.title4": "Bewerk live vragenlijst",
   "app.components.formBuilder.editWarningModal.yesContinue": "Ja, doorgaan",
   "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.accessRightsSettings": "instellingen voor toegangsrechten voor deze vragenlijst",
-  "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.fieldsEnabledMessage": "'Gebruikersvelden in vragenlijstformulier' is ingeschakeld. Als het vragenlijstformulier wordt weergegeven, worden alle geconfigureerde demografische vragen hier toegevoegd op een nieuwe pagina. Deze vragen kunnen worden gewijzigd in de {accessRightsSettingsLink}.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.accessRightsSettings": "instellingen voor toegangsrechten voor deze fase.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet1": "Deelnemers van enquêtes hoeven zich niet te registreren of in te loggen om antwoorden in te dienen, wat kan leiden tot dubbele inzendingen",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet2": "Door de stap registreren/inloggen over te slaan, accepteer je dat er geen demografische informatie over respondenten wordt verzameld, wat gevolgen kan hebben voor je gegevensanalyse",

--- a/front/app/translations/admin/pa-IN.json
+++ b/front/app/translations/admin/pa-IN.json
@@ -463,7 +463,6 @@
   "app.components.formBuilder.editWarningModal.title4": "ਲਾਈਵ ਸਰਵੇਖਣ ਦਾ ਸੰਪਾਦਨ ਕਰੋ",
   "app.components.formBuilder.editWarningModal.yesContinue": "ਹਾਂ, ਜਾਰੀ ਰੱਖੋ",
   "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.accessRightsSettings": "ਇਸ ਸਰਵੇਖਣ ਲਈ ਪਹੁੰਚ ਅਧਿਕਾਰ ਸੈਟਿੰਗਾਂ",
-  "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.fieldsEnabledMessage": "'ਸਰਵੇਖਣ ਫਾਰਮ ਵਿੱਚ ਉਪਭੋਗਤਾ ਖੇਤਰ' ਯੋਗ ਹੈ। ਜਦੋਂ ਸਰਵੇਖਣ ਫਾਰਮ ਪ੍ਰਦਰਸ਼ਿਤ ਹੁੰਦਾ ਹੈ ਤਾਂ ਕੋਈ ਵੀ ਸੰਰਚਿਤ ਜਨਸੰਖਿਆ ਸੰਬੰਧੀ ਸਵਾਲ ਇੱਥੇ ਇੱਕ ਨਵੇਂ ਪੰਨੇ 'ਤੇ ਜੋੜੇ ਜਾਣਗੇ। ਇਹਨਾਂ ਸਵਾਲਾਂ ਨੂੰ {accessRightsSettingsLink}ਵਿੱਚ ਬਦਲਿਆ ਜਾ ਸਕਦਾ ਹੈ।",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.accessRightsSettings": "ਇਸ ਪੜਾਅ ਲਈ ਅਧਿਕਾਰ ਸੈਟਿੰਗਾਂ ਤੱਕ ਪਹੁੰਚ ਕਰੋ।",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet1": "ਸਰਵੇਖਣ ਉੱਤਰਦਾਤਾਵਾਂ ਨੂੰ ਸਰਵੇਖਣ ਦੇ ਜਵਾਬ ਜਮ੍ਹਾਂ ਕਰਾਉਣ ਲਈ ਸਾਈਨ ਅੱਪ ਜਾਂ ਲੌਗ ਇਨ ਕਰਨ ਦੀ ਲੋੜ ਨਹੀਂ ਹੋਵੇਗੀ, ਜਿਸ ਦੇ ਨਤੀਜੇ ਵਜੋਂ ਡੁਪਲੀਕੇਟ ਸਬਮਿਸ਼ਨ ਹੋ ਸਕਦੇ ਹਨ",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet2": "ਸਾਈਨ ਅੱਪ/ਲੌਗ ਇਨ ਪਗ ਨੂੰ ਛੱਡ ਕੇ, ਤੁਸੀਂ ਸਰਵੇਖਣ ਉੱਤਰਦਾਤਾਵਾਂ 'ਤੇ ਜਨਸੰਖਿਆ ਸੰਬੰਧੀ ਜਾਣਕਾਰੀ ਇਕੱਠੀ ਨਾ ਕਰਨ ਨੂੰ ਸਵੀਕਾਰ ਕਰਦੇ ਹੋ, ਜਿਸ ਨਾਲ ਤੁਹਾਡੀ ਡਾਟਾ ਵਿਸ਼ਲੇਸ਼ਣ ਸਮਰੱਥਾਵਾਂ 'ਤੇ ਅਸਰ ਪੈ ਸਕਦਾ ਹੈ।",

--- a/front/app/translations/admin/pl-PL.json
+++ b/front/app/translations/admin/pl-PL.json
@@ -463,7 +463,6 @@
   "app.components.formBuilder.editWarningModal.title4": "Edytuj ankietę na żywo",
   "app.components.formBuilder.editWarningModal.yesContinue": "Tak, kontynuuj",
   "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.accessRightsSettings": "ustawienia praw dostępu dla tej ankiety",
-  "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.fieldsEnabledMessage": "Opcja \"Pola użytkownika w formularzu ankiety\" jest włączona. Po wyświetleniu formularza ankiety wszelkie skonfigurowane pytania demograficzne zostaną dodane na nowej stronie w tym miejscu. Pytania te można zmienić na stronie {accessRightsSettingsLink}.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.accessRightsSettings": "ustawienia praw dostępu dla tej fazy.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet1": "Respondenci ankiety nie będą musieli się rejestrować ani logować, aby przesłać odpowiedzi na pytania ankiety, co może skutkować powielaniem zgłoszeń.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet2": "Pomijając krok rejestracji/zalogowania, zgadzasz się nie zbierać informacji demograficznych o respondentach ankiety, co może mieć wpływ na możliwości analizy danych.",

--- a/front/app/translations/admin/pt-BR.json
+++ b/front/app/translations/admin/pt-BR.json
@@ -463,7 +463,6 @@
   "app.components.formBuilder.editWarningModal.title4": "Editar pesquisa ao vivo",
   "app.components.formBuilder.editWarningModal.yesContinue": "Sim, continuar",
   "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.accessRightsSettings": "configurações de direitos de acesso para esta pesquisa",
-  "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.fieldsEnabledMessage": "'Campos de usuário no formulário de pesquisa' está ativado. Quando o formulário de pesquisa for exibido, todas as perguntas demográficas configuradas serão adicionadas em uma nova página aqui. Essas perguntas podem ser alteradas em {accessRightsSettingsLink}.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.accessRightsSettings": "configurações de direitos de acesso para essa fase.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet1": "Os respondentes da pesquisa não precisarão se inscrever ou fazer login para enviar as respostas da pesquisa, o que pode resultar em envios duplicados",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet2": "Ao ignorar a etapa de inscrição/logon, você aceita não coletar informações demográficas sobre os respondentes do questionário, o que pode afetar seus recursos de análise de dados",

--- a/front/app/translations/admin/sr-Latn.json
+++ b/front/app/translations/admin/sr-Latn.json
@@ -463,7 +463,6 @@
   "app.components.formBuilder.editWarningModal.title4": "Edit live survey",
   "app.components.formBuilder.editWarningModal.yesContinue": "Yes, continue",
   "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.accessRightsSettings": "access rights settings for this survey",
-  "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.fieldsEnabledMessage": "'User fields in survey form' is enabled. When the survey form is displayed any configured demographic questions will be added on a new page here. These questions can be changed in the {accessRightsSettingsLink}.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.accessRightsSettings": "access rights settings for this phase.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet1": "Survey respondents will not be required to sign up or log in to submit survey answers, which may result in duplicate submissions",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet2": "By skipping the sign up/log in step, you accept not to collect demographic information on survey respondents, which may impact your data analysis capabilities",

--- a/front/app/translations/admin/sr-SP.json
+++ b/front/app/translations/admin/sr-SP.json
@@ -463,7 +463,6 @@
   "app.components.formBuilder.editWarningModal.title4": "Измените анкету уживо",
   "app.components.formBuilder.editWarningModal.yesContinue": "Да, настави",
   "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.accessRightsSettings": "access rights settings for this survey",
-  "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.fieldsEnabledMessage": "'User fields in survey form' is enabled. When the survey form is displayed any configured demographic questions will be added on a new page here. These questions can be changed in the {accessRightsSettingsLink}.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.accessRightsSettings": "access rights settings for this phase.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet1": "Survey respondents will not be required to sign up or log in to submit survey answers, which may result in duplicate submissions",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet2": "By skipping the sign up/log in step, you accept not to collect demographic information on survey respondents, which may impact your data analysis capabilities",

--- a/front/app/translations/admin/sv-SE.json
+++ b/front/app/translations/admin/sv-SE.json
@@ -463,7 +463,6 @@
   "app.components.formBuilder.editWarningModal.title4": "Redigera live-undersökning",
   "app.components.formBuilder.editWarningModal.yesContinue": "Ja, fortsätt",
   "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.accessRightsSettings": "inställningar för åtkomsträttigheter för denna undersökning",
-  "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.fieldsEnabledMessage": "\"Användarfält i undersökningsformuläret\" är aktiverat. När undersökningsformuläret visas kommer alla konfigurerade demografiska frågor att läggas till på en ny sida här. Dessa frågor kan ändras på {accessRightsSettingsLink}.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.accessRightsSettings": "inställningar för åtkomsträttigheter för denna fas.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet1": "Undersökningens respondenter kommer inte att behöva registrera sig eller logga in för att skicka in svar, vilket kan leda till dubbla inlämningar",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet2": "Genom att hoppa över registrerings-/inloggningssteget accepterar du att inte samla in demografisk information om respondenterna, vilket kan påverka dina dataanalysmöjligheter",

--- a/front/app/translations/admin/tr-TR.json
+++ b/front/app/translations/admin/tr-TR.json
@@ -463,7 +463,6 @@
   "app.components.formBuilder.editWarningModal.title4": "Canlı anketi düzenle",
   "app.components.formBuilder.editWarningModal.yesContinue": "Evet, devam edin",
   "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.accessRightsSettings": "Bu anket için erişim hakları ayarları",
-  "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.fieldsEnabledMessage": "'Anket formundaki kullanıcı alanları' etkinleştirilir. Anket formu görüntülendiğinde, yapılandırılmış demografik sorular burada yeni bir sayfaya eklenecektir. Bu sorular {accessRightsSettingsLink}adresinden değiştirilebilir.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.accessRightsSettings": "Bu aşama için erişim hakları ayarları.",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet1": "Anket katılımcılarının anket cevaplarını göndermek için kaydolmaları veya giriş yapmaları gerekmeyecektir, bu da mükerrer gönderimlerle sonuçlanabilir",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet2": "Kaydolma/log in adımını atlayarak, anket katılımcıları hakkında demografik bilgi toplamamayı kabul etmiş olursunuz, bu da veri analizi yeteneklerinizi etkileyebilir",

--- a/front/app/translations/admin/ur-PK.json
+++ b/front/app/translations/admin/ur-PK.json
@@ -463,7 +463,6 @@
   "app.components.formBuilder.editWarningModal.title4": "لائیو سروے میں ترمیم کریں۔",
   "app.components.formBuilder.editWarningModal.yesContinue": "ہاں، جاری رکھیں",
   "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.accessRightsSettings": "اس سروے کے لیے حقوق کی ترتیبات تک رسائی حاصل کریں۔",
-  "app.components.formBuilder.nativeSurvey.UserFieldsInFormNotice.fieldsEnabledMessage": "'سروے فارم میں یوزر فیلڈز' فعال ہے۔ سروے کا فارم ظاہر ہونے پر کوئی بھی ترتیب شدہ آبادیاتی سوالات یہاں ایک نئے صفحہ پر شامل کیے جائیں گے۔ ان سوالات کو {accessRightsSettingsLink}میں تبدیل کیا جا سکتا ہے۔",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.accessRightsSettings": "اس مرحلے کے لیے حقوق کی ترتیبات تک رسائی حاصل کریں۔",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet1": "سروے کے جواب دہندگان کو سروے کے جوابات جمع کرانے کے لیے سائن اپ کرنے یا لاگ ان کرنے کی ضرورت نہیں ہوگی، جس کے نتیجے میں ڈپلیکیٹ گذارشات ہو سکتی ہیں۔",
   "app.components.formBuilder.nativeSurvey.accessRightsNotice.anyoneBullet2": "سائن اپ/لاگ ان مرحلہ کو چھوڑ کر، آپ سروے کے جواب دہندگان پر آبادیاتی معلومات اکٹھا نہ کرنے کو قبول کرتے ہیں، جو آپ کے ڈیٹا کے تجزیہ کی صلاحیتوں کو متاثر کر سکتی ہے۔",


### PR DESCRIPTION
Also added the toggle although it is not backend:
<img width="1037" alt="image" src="https://github.com/user-attachments/assets/819944bc-b8b7-4f46-8729-486c7d1997fb" />

# Changelog
## Fixed
- Correctly return sentiment averages for questions with 'other' category
- Stop user 'number' user fields being added to sentiment averages
- Added 'user demographic in form' toggle to community monitor setup
- Correctly show user demographics message in form editor for community monitor
- Fixed xlsx import so that user profiles are updated when ideas are approved
