### PR TITLE
TAN-4407 Fix issues with transposed heatmap cells

### DIFF
--- a/back/engines/commercial/analysis/app/models/analysis/heatmap_cell.rb
+++ b/back/engines/commercial/analysis/app/models/analysis/heatmap_cell.rb
@@ -49,6 +49,5 @@ module Analysis
     }
 
     scope :significant, ->(max_p_value = 0.05) { where(p_value: ..max_p_value) }
-
   end
 end

--- a/back/engines/commercial/analysis/app/models/analysis/heatmap_cell.rb
+++ b/back/engines/commercial/analysis/app/models/analysis/heatmap_cell.rb
@@ -50,11 +50,5 @@ module Analysis
 
     scope :significant, ->(max_p_value = 0.05) { where(p_value: ..max_p_value) }
 
-    def swap_row_column
-      original_column = column
-      self.column = row
-      self.row = original_column
-      self
-    end
   end
 end

--- a/back/engines/commercial/analysis/app/services/analysis/auto_insights_service.rb
+++ b/back/engines/commercial/analysis/app/services/analysis/auto_insights_service.rb
@@ -43,16 +43,14 @@ module Analysis
           end
 
         add_lift!(cells)
+
         HeatmapCell.insert_all!(
-          cells.flat_map do |original_cell|
-            transposed_cell = original_cell.dup.swap_row_column
-            [original_cell, transposed_cell].map do |cell|
-              cell.attributes.except('id', 'created_at', 'updated_at')
-                .merge(
-                  created_at: Time.current,
-                  updated_at: Time.current
-                )
-            end
+          cells.map do |cell|
+            cell.attributes.except('id', 'created_at', 'updated_at')
+              .merge(
+                created_at: Time.current,
+                updated_at: Time.current
+              )
           end
         )
       end

--- a/back/engines/commercial/analysis/spec/acceptance/heatmap_cells_spec.rb
+++ b/back/engines/commercial/analysis/spec/acceptance/heatmap_cells_spec.rb
@@ -87,6 +87,38 @@ resource 'HeatmapCells' do
       expect(response_data.first[:id]).to eq(heatmap_cells.first.id)
     end
 
+    example 'Respects the combination of row_category and column_category filters' do
+      create(:heatmap_cell, analysis:, row: create(:option_bin), column: create(:option_bin))
+      cell = create(:heatmap_cell, analysis:, row: create(:option_bin), column: create(:option_bin))
+      custom_field = cell.row.custom_field
+      row_category_type = 'user_custom_field'
+      row_category_id = custom_field.id
+      column_category_type = 'input_custom_field'
+      column_category_id = cell.column.custom_field.id
+
+      do_request(row_category_type:, row_category_id:, column_category_type:, column_category_id:)
+
+      expect(status).to eq 200
+      expect(response_data.size).to eq(1)
+      expect(response_data.first[:id]).to eq(cell.id)
+    end
+
+    example 'It also searches for swapped row/column category filters' do
+      create(:heatmap_cell, analysis:, row: create(:option_bin), column: create(:option_bin))
+      cell = create(:heatmap_cell, analysis:, row: create(:option_bin), column: create(:option_bin))
+      custom_field = cell.row.custom_field
+      column_category_type = 'user_custom_field'
+      column_category_id = custom_field.id
+      row_category_type = 'input_custom_field'
+      row_category_id = cell.column.custom_field.id
+
+      do_request(row_category_type:, row_category_id:, column_category_type:, column_category_id:)
+
+      expect(status).to eq 200
+      expect(response_data.size).to eq(1)
+      expect(response_data.first[:id]).to eq(cell.id)
+    end
+
     example 'Respects the unit filter' do
       cell = create(:heatmap_cell, analysis:, unit: 'likes')
 

--- a/back/engines/commercial/analysis/spec/jobs/heatmap_generation_job_spec.rb
+++ b/back/engines/commercial/analysis/spec/jobs/heatmap_generation_job_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Analysis::HeatmapGenerationJob do
 
     it 'generates the heatmap for all units' do
       expect { described_class.perform_now(analysis.reload) }
-        .to change { analysis.heatmap_cells.count }.by(32)
+        .to change { analysis.heatmap_cells.count }.by(16)
 
       expect(Analysis::HeatmapCell.all.pluck(:unit).uniq)
         .to match_array(%w[inputs likes dislikes participants])

--- a/back/engines/commercial/analysis/spec/services/auto_insights_spec.rb
+++ b/back/engines/commercial/analysis/spec/services/auto_insights_spec.rb
@@ -29,7 +29,7 @@ describe Analysis::AutoInsightsService do
         # - 2 options in custom_field1
         # - 3 linear scale bins in custom_field2
         # So we should get ((2*3+2*2+2*3)+(3*2+3*3)+(2*3))*2=(16+15+6)*2=74 cells
-        expect { service.generate }.to change { analysis.heatmap_cells.count }.from(0).to(74)
+        expect { service.generate }.to change { analysis.heatmap_cells.count }.from(0).to(37)
         male, female, unspecified = custom_field_gender.options.map { |o| o.custom_field_bins.first }
         expect(Analysis::HeatmapCell.find_by(row: tag1, column: male)).to have_attributes(
           count: 1,
@@ -37,14 +37,6 @@ describe Analysis::AutoInsightsService do
           lift: 1.0,
           row: tag1,
           column: male
-        )
-        # Test transposed cell
-        expect(Analysis::HeatmapCell.find_by(row: male, column: tag1)).to have_attributes(
-          count: 1,
-          p_value: 1.0,
-          lift: 1.0,
-          row: male,
-          column: tag1
         )
 
         expect(Analysis::HeatmapCell.find_by(row: tag1, column: female)).to have_attributes(
@@ -103,7 +95,7 @@ describe Analysis::AutoInsightsService do
         create(:reaction, reactable: input1)
 
         service = described_class.new(analysis)
-        expect { service.generate(unit: 'likes') }.to change { analysis.heatmap_cells.count }.from(0).to(74)
+        expect { service.generate(unit: 'likes') }.to change { analysis.heatmap_cells.count }.from(0).to(37)
         male, female, _unspecified = custom_field_gender.options.map { |o| o.custom_field_bins.first }
 
         expect(Analysis::HeatmapCell.find_by(row: tag1, column: male)).to have_attributes(
@@ -147,7 +139,7 @@ describe Analysis::AutoInsightsService do
         create(:comment, idea: input2, author: create(:user, custom_field_values: { custom_field_gender.key => male.key }))
 
         service = described_class.new(analysis)
-        expect { service.generate(unit: 'participants') }.to change { analysis.heatmap_cells.count }.from(0).to(74)
+        expect { service.generate(unit: 'participants') }.to change { analysis.heatmap_cells.count }.from(0).to(37)
 
         male, female, _unspecified = custom_field_gender.options.map { |o| o.custom_field_bins.first }
 
@@ -203,7 +195,7 @@ describe Analysis::AutoInsightsService do
 
       it 'works well with the domicile custom field' do
         service = described_class.new(analysis)
-        expect { service.generate }.to change { analysis.heatmap_cells.count }.from(0).to(12)
+        expect { service.generate }.to change { analysis.heatmap_cells.count }.from(0).to(6)
         bin0 = areas[0].custom_field_option.custom_field_bins.first
         expect(Analysis::HeatmapCell.find_by(row: tag1, column: bin0)).to have_attributes(
           count: 1,
@@ -233,7 +225,7 @@ describe Analysis::AutoInsightsService do
       it 'works well with the birthyear custom field' do
         service = described_class.new(analysis)
         travel_to(Date.parse('2025-03-18')) do
-          expect { service.generate }.to change { analysis.heatmap_cells.count }.from(0).to(20)
+          expect { service.generate }.to change { analysis.heatmap_cells.count }.from(0).to(10)
           bin2040 = CustomFieldBin.find_by(custom_field: custom_field_birthyear, range: 20...40)
           expect(Analysis::HeatmapCell.find_by(row: tag1, column: bin2040)).to have_attributes(
             count: 1,

--- a/front/app/containers/Admin/projects/project/analysis/Heatmap/HeatmapDetails/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Heatmap/HeatmapDetails/index.tsx
@@ -169,6 +169,7 @@ const HeatmapDetails = ({
               ...inputCustomFields.map((field) => ({
                 value: field.id,
                 label: localize(field.title_multiloc),
+                disabled: selectedColumnFieldId === field.id,
               })),
             ]}
             disabled={inputCustomFieldsIds.length === 0}
@@ -191,6 +192,7 @@ const HeatmapDetails = ({
               ...inputCustomFields.map((field) => ({
                 value: field.id,
                 label: localize(field.title_multiloc),
+                disabled: selectedRowType === field.id,
               })),
             ]}
           />
@@ -238,8 +240,10 @@ const HeatmapDetails = ({
                   {columnBins.data.map((bin) => {
                     const cell = analysisHeatmapCells?.data.find(
                       (cell) =>
-                        cell.relationships.row.data.id === tag.id &&
-                        cell.relationships.column.data.id === bin.id
+                        (cell.relationships.row.data.id === tag.id &&
+                          cell.relationships.column.data.id === bin.id) || //Also search for the transposed row/column, because the back-end only generates one version
+                        (cell.relationships.column.data.id === tag.id &&
+                          cell.relationships.row.data.id === bin.id)
                     );
 
                     return (
@@ -265,8 +269,10 @@ const HeatmapDetails = ({
                   {columnBins.data.map((columnBin) => {
                     const cell = analysisHeatmapCells?.data.find(
                       (cell) =>
-                        cell.relationships.row.data.id === rowBin.id &&
-                        cell.relationships.column.data.id === columnBin.id
+                        (cell.relationships.row.data.id === rowBin.id &&
+                          cell.relationships.column.data.id === columnBin.id) || //Also search for the transposed row/column, because the back-end only generates one version
+                        (cell.relationships.column.data.id === rowBin.id &&
+                          cell.relationships.row.data.id === columnBin.id)
                     );
 
                     return (


### PR DESCRIPTION
# Changelog
This changes back the strategy of generating the transposed heatmap cells, and instead solves it at the API level
## Fixed
- Auto-insights no longer have duplicates (behind feature flag)
- Heatmap cells no longer keep on loading forever in certain row/column combinations (behind feature flag)
- It's no longer possible to select the same field for row and column in the heatmap view (behind feature flag)
