### PR TITLE
Rake task for seeding community monitor in demo platforms

### DIFF
--- a/back/app/services/community_monitor_service.rb
+++ b/back/app/services/community_monitor_service.rb
@@ -31,7 +31,7 @@ class CommunityMonitorService
   # Create the hidden project, phase & default form
   def create_and_set_project(project: nil, current_user: nil)
     # Also check if the project exists but has not been added to settings (eg when creating platform from template)
-    project = project || Project.find_by(internal_role: 'community_monitor', hidden: true)
+    project ||= Project.find_by(internal_role: 'community_monitor', hidden: true)
     unless project
       ActiveRecord::Base.transaction do
         multiloc_service = MultilocService.new

--- a/back/app/services/community_monitor_service.rb
+++ b/back/app/services/community_monitor_service.rb
@@ -25,14 +25,13 @@ class CommunityMonitorService
 
     raise ActiveRecord::RecordNotFound unless current_user&.admin? # Only allow project to be created if an admin hits this endpoint
 
-    # Check first if the project exists but has not been added to settings (eg when creating platform from template)
-    project = Project.find_by(internal_role: 'community_monitor', hidden: true)
-
     create_and_set_project(project: project, current_user: current_user)
   end
 
   # Create the hidden project, phase & default form
   def create_and_set_project(project: nil, current_user: nil)
+    # Also check if the project exists but has not been added to settings (eg when creating platform from template)
+    project = project || Project.find_by(internal_role: 'community_monitor', hidden: true)
     unless project
       ActiveRecord::Base.transaction do
         multiloc_service = MultilocService.new

--- a/back/app/services/community_monitor_service.rb
+++ b/back/app/services/community_monitor_service.rb
@@ -12,7 +12,7 @@ class CommunityMonitorService
   end
 
   def project
-    return nil unless enabled?
+    return nil unless enabled? && project_id.present?
 
     Project.find(project_id)
   end

--- a/back/engines/commercial/analysis/config/prompts/sentiment_random_responses.erb
+++ b/back/engines/commercial/analysis/config/prompts/sentiment_random_responses.erb
@@ -1,0 +1,9 @@
+At the end of this message is a statement designed to assess sentiment about a city.
+
+Give me a json array of four randomly generated text responses that a resident of a city might give to this statement.
+
+Three must be positive and one must be negative.
+
+Each response must only be one sentence long and in the following language: <%= language %>.
+
+<%= question %>

--- a/back/engines/commercial/multi_tenancy/db/seeds/community_monitor.rb
+++ b/back/engines/commercial/multi_tenancy/db/seeds/community_monitor.rb
@@ -7,11 +7,8 @@ module MultiTenancy
     class CommunityMonitor < Base
       def initialize(runner:, num_quarters: 2, ai_responses: false, locale: nil)
         @num_quarters = num_quarters
-        @ai_responses = ai_responses
-        @locale = locale ||
-                  Locale.monolingual&.to_s ||
-                  AppConfiguration.instance.settings('core', 'locales').first ||
-                  I18n.default_locale
+        @ai_responses = ai_responses # NOTE: Never set this to true for any tests or environment resets
+        @locale = locale || Locale.default.to_s
         super(runner: runner)
       end
 

--- a/back/engines/commercial/multi_tenancy/db/seeds/community_monitor.rb
+++ b/back/engines/commercial/multi_tenancy/db/seeds/community_monitor.rb
@@ -64,7 +64,6 @@ module MultiTenancy
           )
           response = llm.chat(prompt).strip
           raw_statements = response.match(/\[.+\]/m)&.try(:[], 0)
-          pp raw_statements
           raw_statements ? JSON.parse(raw_statements) : []
         end
       end

--- a/back/engines/commercial/multi_tenancy/db/seeds/community_monitor.rb
+++ b/back/engines/commercial/multi_tenancy/db/seeds/community_monitor.rb
@@ -16,7 +16,7 @@ module MultiTenancy
         @phase = @project.phases.first
         @question_keys = @phase.custom_form.custom_fields.reject(&:page?).pluck(:key)
 
-        @num_quarters.times.with_index do |num_quarters_ago| # NOTE: 0 = current quarter
+        @num_quarters.times do |num_quarters_ago| # NOTE: 0 = current quarter
           runner.num_ideas.times { create_survey_response((3 * num_quarters_ago).months.ago) }
         end
       end

--- a/back/engines/commercial/multi_tenancy/db/seeds/community_monitor.rb
+++ b/back/engines/commercial/multi_tenancy/db/seeds/community_monitor.rb
@@ -5,8 +5,13 @@ require_relative 'base'
 module MultiTenancy
   module Seeds
     class CommunityMonitor < Base
-      def initialize(runner:, num_quarters: 2)
+      def initialize(runner:, num_quarters: 2, ai_responses: false, locale: nil)
         @num_quarters = num_quarters
+        @ai_responses = ai_responses
+        @locale = locale ||
+                  Locale.monolingual&.to_s ||
+                  AppConfiguration.instance.settings('core', 'locales').first ||
+                  I18n.default_locale
         super(runner: runner)
       end
 
@@ -14,18 +19,20 @@ module MultiTenancy
         service = CommunityMonitorService.new
         @project = service.project || service.create_and_set_project
         @phase = @project.phases.first
-        @question_keys = @phase.custom_form.custom_fields.reject(&:page?).pluck(:key)
-
+        @fields = @phase.custom_form.custom_fields.reject(&:page?)
         @num_quarters.times do |num_quarters_ago| # NOTE: 0 = current quarter
-          runner.num_ideas.times { create_survey_response((3 * num_quarters_ago).months.ago) }
+          runner.num_ideas.times do |index|
+            create_survey_response((3 * num_quarters_ago).months.ago, index)
+          end
         end
       end
 
       private
 
-      def create_survey_response(created_at)
-        answers = @question_keys.index_with { |_k| rand(1..5) }
-        follow_ups = @question_keys.each_with_object({}) { |k, accu| accu["#{k}_follow_up"] = Faker::Movie.quote }
+      def create_survey_response(created_at, index)
+        question_keys = @fields.pluck(:key)
+        answers = question_keys.index_with { |_k| rand(1..5) }
+        follow_ups = question_keys.each_with_object({}) { |key, accu| accu["#{key}_follow_up"] = random_follow_up(key, index) }
 
         Idea.create!({
           project: @project,
@@ -35,6 +42,31 @@ module MultiTenancy
           created_at: created_at,
           custom_field_values: answers.merge(follow_ups)
         })
+      end
+
+      def random_follow_up(question_key, index)
+        return Faker::Movie.quote unless @ai_responses
+
+        random_ai_responses(question_key)[index] || Faker::Movie.quote
+      end
+
+      def random_ai_responses(question_key)
+        @random_ai_responses ||= {}
+        @random_ai_responses[question_key] ||= begin
+          question = @fields.find { _1.key == question_key }.title_multiloc[@locale.to_s]
+          language = Locale.new(@locale).language_copy
+          llm = Analysis::LLM::GPT4oMini.new
+          prompt = Analysis::LLM::Prompt.new.fetch(
+            'sentiment_random_responses',
+            question: question,
+            language: language,
+            num_responses: runner.num_ideas
+          )
+          response = llm.chat(prompt).strip
+          raw_statements = response.match(/\[.+\]/m)&.try(:[], 0)
+          pp raw_statements
+          raw_statements ? JSON.parse(raw_statements) : []
+        end
       end
     end
   end

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/seed_community_monitor.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/seed_community_monitor.rake
@@ -12,12 +12,9 @@ namespace :demos do
       end
 
       # Ensure community monitor is enabled first
-      settings = AppConfiguration.instance.settings
-      settings['community_monitor']['allowed'] = true
-      settings['community_monitor']['enabled'] = true
-      AppConfiguration.instance.update!(settings:)
+      SettingsService.new.activate_feature! 'community_monitor'
 
-      num_quarters = args[:num_quarters].to_i || 2
+      num_quarters = args[:num_quarters]&.to_i || 2
       locale = args[:locale]
       num_existing_ideas = Idea.count
 

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/seed_community_monitor.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/seed_community_monitor.rake
@@ -28,6 +28,7 @@ namespace :demos do
   end
 end
 
+# Stripped back seeds runner for community monitor seeds only
 class CommunityMonitorSeedsRunner < MultiTenancy::Seeds::Runner
   attr_accessor :num_ideas
 

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/seed_community_monitor.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/seed_community_monitor.rake
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+require Rails.root.join('engines/commercial/multi_tenancy/db/seeds/runner')
+
+namespace :demos do
+  desc 'Enable community monitor (if not enabled) and seed with demo data'
+  task :seed_community_monitor, %i[host num_quarters] => [:environment] do |_, args|
+    Apartment::Tenant.switch(args[:host].tr('.', '_')) do
+      unless args[:host] == 'localhost' || AppConfiguration.instance.settings.dig('core', 'lifecycle_stage') == 'demo'
+        Rails.logger.error 'Lifecycle stage is not demo, exiting'
+        exit
+      end
+
+      # TODO: Enable community monitor first
+
+      num_quarters = args[:num_quarters].to_i || 2
+      Rails.logger.info "Seeding community monitor with #{num_quarters} quarters of data"
+      CommunityMonitorSeedsRunner.new(num_quarters:).execute
+
+      # TODO: Get the first locale of the tenant
+    end
+  end
+end
+
+class CommunityMonitorSeedsRunner < MultiTenancy::Seeds::Runner
+  attr_accessor :num_ideas
+
+  def initialize(num_ideas: 4, num_quarters: 2)
+    @num_ideas = num_ideas # NOTE: Currently always set to 4
+    @num_quarters = num_quarters
+  end
+
+  def execute
+    MultiTenancy::Seeds::CommunityMonitor.new(runner: self, num_quarters: @num_quarters).run
+  end
+end

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/seed_community_monitor.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/seed_community_monitor.rake
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require Rails.root.join('engines/commercial/multi_tenancy/db/seeds/runner')
 
 namespace :demos do


### PR DESCRIPTION
# Changelog
## Added
- Added rake task for seeding community monitor responses in demo platforms, including ai generated followup responses
