### PR TITLE
Ensure button text is visible on hover

### DIFF
--- a/front/app/components/ParticipationCTABars/VotingCTABar/CTAButton.tsx
+++ b/front/app/components/ParticipationCTABars/VotingCTABar/CTAButton.tsx
@@ -157,12 +157,9 @@ const CTAButton = ({ phase, project }: Props) => {
         <Box width="100%" tabIndex={disabledExplanation ? 0 : -1}>
           <StyledButton
             icon="vote-ballot"
-            buttonStyle="secondary-outlined"
-            iconColor={theme.colors.tenantText}
+            buttonStyle="primary-inverse"
             onClick={handleSubmitOnClick}
             fontWeight="500"
-            bgColor={theme.colors.white}
-            textColor={theme.colors.tenantText}
             id="e2e-voting-submit-button"
             textHoverColor={theme.colors.black}
             padding="6px 12px"


### PR DESCRIPTION
Before
<img width="324" alt="Screenshot 2025-04-24 at 15 09 52" src="https://github.com/user-attachments/assets/663e91c2-386c-4fff-bd79-48cd3b09717b" />

After
<img width="338" alt="Screenshot 2025-04-24 at 15 08 07" src="https://github.com/user-attachments/assets/72467d77-f7cb-445d-87db-54f16df70f3e" />

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Participatory budgeting submit button: button text is visible on hover ([before/after](https://github.com/CitizenLabDotCo/citizenlab/pull/10869))