### PR TITLE
Fix Analysis back button for community monitor insights

### DIFF
--- a/front/app/api/analyses/types.ts
+++ b/front/app/api/analyses/types.ts
@@ -17,7 +17,10 @@ export interface IAnalysisData {
   attributes: {
     created_at: string;
     updated_at: string;
-    participation_method: 'native_survey' | 'ideation';
+    participation_method:
+      | 'native_survey'
+      | 'ideation'
+      | 'community_monitor_survey';
     show_insights: boolean;
   };
   relationships: {

--- a/front/app/containers/Admin/projects/project/analysis/TopBar/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/TopBar/index.tsx
@@ -91,6 +91,11 @@ const TopBar = () => {
       clHistory.push(
         `/admin/projects/${projectId}/phases/${phaseId}/native-survey`
       );
+    } else if (
+      analysis?.data.attributes.participation_method ===
+      'community_monitor_survey'
+    ) {
+      clHistory.push(`/admin/community-monitor/live-monitor`);
     } else {
       clHistory.push(`/admin/projects/${projectId}/phases/${phaseId}/ideas`);
     }


### PR DESCRIPTION
Makes sure that the Analysis back button for community monitor insights goes back to correct URL.
