### PR TITLE
Remove unreachable code PDF export modal

### DIFF
--- a/front/app/containers/Admin/projects/components/PDFExportModal/index.tsx
+++ b/front/app/containers/Admin/projects/components/PDFExportModal/index.tsx
@@ -5,8 +5,6 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { useForm, FormProvider } from 'react-hook-form';
 import { object, boolean } from 'yup';
 
-import useFeatureFlag from 'hooks/useFeatureFlag';
-
 import CheckboxWithLabel from 'components/HookForm/CheckboxWithLabel';
 import Feedback from 'components/HookForm/Feedback';
 import Modal from 'components/UI/Modal';
@@ -42,9 +40,6 @@ const IT_IS_POSSIBLE_MESSAGES = {
 };
 
 const PDFExportModal = ({ open, formType, onClose, onExport }: Props) => {
-  const importPrintedFormsEnabled = useFeatureFlag({
-    name: 'import_printed_forms',
-  });
   const [loading, setLoading] = useState(false);
 
   const schema = object({
@@ -102,32 +97,20 @@ const PDFExportModal = ({ open, formType, onClose, onExport }: Props) => {
               )}
               <Text as="li" mb="4px">
                 <FormattedMessage {...IT_IS_POSSIBLE_MESSAGES[formType]} />
-                {importPrintedFormsEnabled || (
-                  <>
-                    {' '}
-                    <FormattedMessage {...messages.notIncludedInYourPlan} />
-                  </>
-                )}
               </Text>
-              {importPrintedFormsEnabled ? (
-                <>
-                  <Text as="li" mb="24px">
-                    <FormattedMessage {...messages.personalDataExplanation} />
-                  </Text>
-                  <Box mb="24px" ml="-20px">
-                    <CheckboxWithLabel
-                      name="personal_data"
-                      label={
-                        <Text m="0">
-                          <FormattedMessage {...messages.askPersonalData} />
-                        </Text>
-                      }
-                    />
-                  </Box>
-                </>
-              ) : (
-                <Box mb="24px" />
-              )}
+              <Text as="li" mb="24px">
+                <FormattedMessage {...messages.personalDataExplanation} />
+              </Text>
+              <Box mb="24px" ml="-20px">
+                <CheckboxWithLabel
+                  name="personal_data"
+                  label={
+                    <Text m="0">
+                      <FormattedMessage {...messages.askPersonalData} />
+                    </Text>
+                  }
+                />
+              </Box>
             </Box>
             <Box w="100%" display="flex">
               <Button width="auto" type="submit" processing={loading}>

--- a/front/app/containers/Admin/projects/components/PDFExportModal/messages.ts
+++ b/front/app/containers/Admin/projects/components/PDFExportModal/messages.ts
@@ -33,11 +33,6 @@ export default defineMessages({
     defaultMessage:
       "You can combine online and offline responses. To upload offline responses, go to the 'Survey' tab of this project, and click 'Import'.",
   },
-  notIncludedInYourPlan: {
-    id: 'app.containers.Admin.projects.all.notIncludedInYourPlan',
-    defaultMessage:
-      'However, this is not included in your current plan. Reach out to your Government Success Manager or admin to unlock it.',
-  },
   logicNotInPDF: {
     id: 'app.containers.Admin.projects.all.logicNotInPDF',
     defaultMessage:

--- a/front/app/translations/admin/ar-SA.json
+++ b/front/app/translations/admin/ar-SA.json
@@ -1040,7 +1040,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossible1": "يمكنك الجمع بين الاستجابات عبر الإنترنت وغير متصل. لتحميل الردود دون الاتصال بالإنترنت، انتقل إلى علامة التبويب \"مدير الإدخال\" لهذا المشروع، ثم انقر فوق \"استيراد\".",
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "يمكنك الجمع بين الاستجابات عبر الإنترنت وغير متصل. لتحميل الردود دون الاتصال بالإنترنت، انتقل إلى علامة التبويب \"استطلاع\" في هذا المشروع، ثم انقر فوق \"استيراد\".",
   "app.containers.Admin.projects.all.logicNotInPDF": "لن ينعكس منطق الاستطلاع في ملف PDF الذي تم تنزيله. سوف يرى المستجيبون الورقيون جميع أسئلة الاستطلاع.",
-  "app.containers.Admin.projects.all.notIncludedInYourPlan": "ومع ذلك، هذا غير مدرج في خطتك الحالية. تواصل مع مدير النجاح الحكومي أو المسؤول لفتحه.",
   "app.containers.Admin.projects.all.notes": "ملحوظات",
   "app.containers.Admin.projects.all.personalDataExplanation2": "حدد المربع أدناه، إذا كنت تريد أن يحتوي ملف PDF الذي تم تنزيله على حقول الاسم والاسم الأخير والبريد الإلكتروني. عند تحميل النموذج الورقي، سنستخدم بيانات المستخدم هذه لإنشاء حساب تلقائيًا للمستجيب للاستبيان غير المتصل بالإنترنت.",
   "app.containers.Admin.projects.project.analysis.Comments.aiSummary": "ملخص الذكاء الاصطناعي",

--- a/front/app/translations/admin/cy-GB.json
+++ b/front/app/translations/admin/cy-GB.json
@@ -1040,7 +1040,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossible1": "Gallwch gyfuno ymatebion ar-lein ac all-lein. I uwchlwytho ymatebion all-lein, ewch i dab 'Rheolwr Mewnbwn' y prosiect hwn, a chliciwch ar 'Mewnforio'.",
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "Gallwch gyfuno ymatebion ar-lein ac all-lein. I uwchlwytho ymatebion all-lein, ewch i dab 'Arolwg' y prosiect hwn, a chliciwch ar 'Mewnforio'.",
   "app.containers.Admin.projects.all.logicNotInPDF": "Ni fydd rhesymeg yr arolwg yn cael ei hadlewyrchu yn y PDF a lawrlwythwyd. Bydd ymatebwyr papur yn gweld holl gwestiynau’r arolwg.",
-  "app.containers.Admin.projects.all.notIncludedInYourPlan": "Fodd bynnag, nid yw hyn wedi'i gynnwys yn eich cynllun presennol. Cysylltwch â Rheolwr Llwyddiant eich Llywodraeth neu weinyddwr i'w ddatgloi.",
   "app.containers.Admin.projects.all.notes": "Nodiadau",
   "app.containers.Admin.projects.all.personalDataExplanation2": "Ticiwch y blwch isod, os ydych chi am i'ch PDF wedi'i lawrlwytho gynnwys meysydd enw, enw olaf, ac e-bost. Ar ôl lanlwytho’r ffurflen bapur, byddwn yn defnyddio’r data defnyddiwr hwnnw, i gynhyrchu cyfrif yn awtomatig ar gyfer yr ymatebydd i’r arolwg all-lein.",
   "app.containers.Admin.projects.project.analysis.Comments.aiSummary": "Crynodeb AI",

--- a/front/app/translations/admin/da-DK.json
+++ b/front/app/translations/admin/da-DK.json
@@ -1040,7 +1040,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossible1": "Du kan kombinere online- og offline-svar. For at uploade offline-svar skal du gå til fanen \"Input manager\" i dette projekt og klikke på \"Import\".",
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "Du kan kombinere online- og offlinebesvarelser. For at uploade offline-besvarelser skal du gå til fanen \"Survey\" i dette projekt og klikke på \"Import\".",
   "app.containers.Admin.projects.all.logicNotInPDF": "Undersøgelsens logik vil ikke blive afspejlet i den downloadede PDF. Papirrespondenter vil se alle undersøgelsens spørgsmål.",
-  "app.containers.Admin.projects.all.notIncludedInYourPlan": "Dette er dog ikke inkluderet i din nuværende plan. Kontakt din Government Success Manager eller administrator for at låse den op.",
   "app.containers.Admin.projects.all.notes": "Noter",
   "app.containers.Admin.projects.all.personalDataExplanation2": "Marker feltet nedenfor, hvis du ønsker, at din downloadede PDF skal indeholde felter med navn, efternavn og e-mail. Når vi uploader papirformularen, bruger vi disse brugerdata til automatisk at generere en konto til offline-undersøgelsens respondent.",
   "app.containers.Admin.projects.project.analysis.Comments.aiSummary": "Sammenfatning af AI",

--- a/front/app/translations/admin/de-DE.json
+++ b/front/app/translations/admin/de-DE.json
@@ -1040,7 +1040,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossible1": "Sie können Online- und Offline-Antworten kombinieren. Um Offline-Antworten hochzuladen, gehen Sie in diesem Projekt auf die Registerkarte \"Beitragsmanager\" und klicken Sie auf \"Importieren\".",
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "Sie können Online- und Offline-Antworten kombinieren. Um Offline-Antworten hochzuladen, gehen Sie zur Registerkarte „Umfrage“ dieses Projekts und klicken Sie auf „Importieren“.",
   "app.containers.Admin.projects.all.logicNotInPDF": "Die Logik der Umfrage wird in der heruntergeladenen PDF-Datei nicht berücksichtigt. Befragte sehen auf Papier alle Fragen der Umfrage.",
-  "app.containers.Admin.projects.all.notIncludedInYourPlan": "Diese Funktion ist in Ihrer aktuellen Lizenz nicht enthalten. Sprechen Sie mit Ihrer Kundenbetreuerin oder Ihrem Admin, um sie freizuschalten.",
   "app.containers.Admin.projects.all.notes": "Anmerkungen",
   "app.containers.Admin.projects.all.personalDataExplanation2": "Markieren Sie das Kästchen unten, wenn Sie möchten, dass die heruntergeladene PDF-Datei Felder für Vorname, Nachname und E-Mail-Adresse enthält. Beim Hochladen des Papierformulars werden wir diese Benutzerdaten verwenden, um automatisch ein Konto für Offline-Umfrageteilnehmende zu erstellen.",
   "app.containers.Admin.projects.project.analysis.Comments.aiSummary": "KI-Zusammenfassung",

--- a/front/app/translations/admin/en-CA.json
+++ b/front/app/translations/admin/en-CA.json
@@ -1040,7 +1040,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossible1": "You can combine online and offline responses. To upload offline responses, go to the 'Input manager' tab of this project, and click 'Import'.",
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "You can combine online and offline responses. To upload offline responses, go to the 'Survey' tab of this project, and click 'Import'.",
   "app.containers.Admin.projects.all.logicNotInPDF": "Survey logic will not be reflected in the downloaded PDF. Paper respondents will see all survey questions.",
-  "app.containers.Admin.projects.all.notIncludedInYourPlan": "However, this is not included in your current plan. Reach out to your Government Success Manager or admin to unlock it.",
   "app.containers.Admin.projects.all.notes": "Notes",
   "app.containers.Admin.projects.all.personalDataExplanation2": "Check the box below, if you want your downloaded PDF to contain name, last name, and email fields. Upon upload of the paper form, we will use that user data, to auto-generate an account for the offline survey respondent.",
   "app.containers.Admin.projects.project.analysis.Comments.aiSummary": "AI Summary",

--- a/front/app/translations/admin/en-GB.json
+++ b/front/app/translations/admin/en-GB.json
@@ -1040,7 +1040,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossible1": "You can combine online and offline responses. To upload offline responses, go to the 'Input manager' tab of this project, and click 'Import'.",
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "You can combine online and offline responses. To upload offline responses, go to the 'Survey' tab of this project, and click 'Import'.",
   "app.containers.Admin.projects.all.logicNotInPDF": "Survey logic will not be reflected in the downloaded PDF. Paper respondents will see all survey questions.",
-  "app.containers.Admin.projects.all.notIncludedInYourPlan": "However, this is not included in your current plan. Reach out to your Government Success Manager or admin to unlock it.",
   "app.containers.Admin.projects.all.notes": "Notes",
   "app.containers.Admin.projects.all.personalDataExplanation2": "Check the box below, if you want your downloaded PDF to contain name, last name, and email fields. Upon upload of the paper form, we will use that user data, to auto-generate an account for the offline survey respondent.",
   "app.containers.Admin.projects.project.analysis.Comments.aiSummary": "AI Summary",

--- a/front/app/translations/admin/en-IE.json
+++ b/front/app/translations/admin/en-IE.json
@@ -1040,7 +1040,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossible1": "You can combine online and offline responses. To upload offline responses, go to the 'Input manager' tab of this project, and click 'Import'.",
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "You can combine online and offline responses. To upload offline responses, go to the 'Survey' tab of this project, and click 'Import'.",
   "app.containers.Admin.projects.all.logicNotInPDF": "Survey logic will not be reflected in the downloaded PDF. Paper respondents will see all survey questions.",
-  "app.containers.Admin.projects.all.notIncludedInYourPlan": "However, this is not included in your current plan. Reach out to your Government Success Manager or admin to unlock it.",
   "app.containers.Admin.projects.all.notes": "Notes",
   "app.containers.Admin.projects.all.personalDataExplanation2": "Check the box below, if you want your downloaded PDF to contain name, last name, and email fields. Upon upload of the paper form, we will use that user data, to auto-generate an account for the offline survey respondent.",
   "app.containers.Admin.projects.project.analysis.Comments.aiSummary": "AI Summary",

--- a/front/app/translations/admin/en.json
+++ b/front/app/translations/admin/en.json
@@ -1040,7 +1040,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossible1": "You can combine online and offline responses. To upload offline responses, go to the 'Input manager' tab of this project, and click 'Import'.",
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "You can combine online and offline responses. To upload offline responses, go to the 'Survey' tab of this project, and click 'Import'.",
   "app.containers.Admin.projects.all.logicNotInPDF": "Survey logic will not be reflected in the downloaded PDF. Paper respondents will see all survey questions.",
-  "app.containers.Admin.projects.all.notIncludedInYourPlan": "However, this is not included in your current plan. Reach out to your Government Success Manager or admin to unlock it.",
   "app.containers.Admin.projects.all.notes": "Notes",
   "app.containers.Admin.projects.all.personalDataExplanation2": "Check the box below, if you want your downloaded PDF to contain name, last name, and email fields. Upon upload of the paper form, we will use that user data, to auto-generate an account for the offline survey respondent.",
   "app.containers.Admin.projects.project.analysis.Comments.aiSummary": "AI Summary",

--- a/front/app/translations/admin/es-CL.json
+++ b/front/app/translations/admin/es-CL.json
@@ -1040,7 +1040,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossible1": "Puedes combinar respuestas online y offline. Para cargar respuestas offline, ve a la pestaña \"Gestor de entradas\" de este proyecto, y haz clic en \"Importar\".",
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "Puedes combinar respuestas online y offline. Para cargar respuestas sin conexión, ve a la pestaña \"Encuesta\" de este proyecto y haz clic en \"Importar\".",
   "app.containers.Admin.projects.all.logicNotInPDF": "La lógica de la encuesta no se reflejará en el PDF descargado. Los encuestados en papel verán todas las preguntas de la encuesta.",
-  "app.containers.Admin.projects.all.notIncludedInYourPlan": "Sin embargo, esto no está incluido en tu plan actual. Ponte en contacto con tu Gestor de Éxito Gubernamental o con el administrador para desbloquearlo.",
   "app.containers.Admin.projects.all.notes": "Notas",
   "app.containers.Admin.projects.all.personalDataExplanation2": "Marca la casilla de abajo si quieres que el PDF descargado contenga los campos de nombre, apellidos y correo electrónico. Al cargar el formulario en papel, utilizaremos esos datos de usuario para generar automáticamente una cuenta para el encuestado offline.",
   "app.containers.Admin.projects.project.analysis.Comments.aiSummary": "Resumen de la IA",

--- a/front/app/translations/admin/es-ES.json
+++ b/front/app/translations/admin/es-ES.json
@@ -1040,7 +1040,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossible1": "Puedes combinar respuestas online y offline. Para cargar respuestas offline, ve a la pestaña \"Gestor de entradas\" de este proyecto, y haz clic en \"Importar\".",
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "Puedes combinar respuestas online y offline. Para cargar respuestas sin conexión, ve a la pestaña \"Encuesta\" de este proyecto y haz clic en \"Importar\".",
   "app.containers.Admin.projects.all.logicNotInPDF": "La lógica de la encuesta no se reflejará en el PDF descargado. Los encuestados en papel verán todas las preguntas de la encuesta.",
-  "app.containers.Admin.projects.all.notIncludedInYourPlan": "Sin embargo, esto no está incluido en tu plan actual. Ponte en contacto con tu Gestor de Éxito Gubernamental o con el administrador para desbloquearlo.",
   "app.containers.Admin.projects.all.notes": "Notas",
   "app.containers.Admin.projects.all.personalDataExplanation2": "Marca la casilla de abajo si quieres que el PDF descargado contenga los campos de nombre, apellidos y correo electrónico. Al cargar el formulario en papel, utilizaremos esos datos de usuario para generar automáticamente una cuenta para el encuestado offline.",
   "app.containers.Admin.projects.project.analysis.Comments.aiSummary": "Resumen de la IA",

--- a/front/app/translations/admin/fi-FI.json
+++ b/front/app/translations/admin/fi-FI.json
@@ -1040,7 +1040,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossible1": "Voit yhdistää online- ja offline-vastauksia. Jos haluat ladata offline-vastauksia, siirry tämän projektin Syötteiden hallinta -välilehteen ja napsauta Tuo.",
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "Voit yhdistää online- ja offline-vastauksia. Voit ladata offline-vastauksia siirtymällä tämän projektin Kysely-välilehdelle ja napsauttamalla Tuo.",
   "app.containers.Admin.projects.all.logicNotInPDF": "Kyselylogiikka ei näy ladatussa PDF-tiedostossa. Paperivastaajat näkevät kaikki kyselyn kysymykset.",
-  "app.containers.Admin.projects.all.notIncludedInYourPlan": "Tämä ei kuitenkaan sisälly nykyiseen suunnitelmaasi. Ota yhteyttä Government Success Manageriin tai järjestelmänvalvojaan avataksesi sen lukituksen.",
   "app.containers.Admin.projects.all.notes": "Huomautuksia",
   "app.containers.Admin.projects.all.personalDataExplanation2": "Valitse alla oleva ruutu, jos haluat, että ladattu PDF sisältää nimi-, sukunimi- ja sähköpostikentät. Kun lataamme paperilomakkeen, käytämme näitä käyttäjätietoja tilin luomiseen offline-kyselyyn vastanneelle automaattisesti.",
   "app.containers.Admin.projects.project.analysis.Comments.aiSummary": "AI yhteenveto",

--- a/front/app/translations/admin/fr-BE.json
+++ b/front/app/translations/admin/fr-BE.json
@@ -1040,7 +1040,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossible1": "Vous pouvez combiner des réponses en ligne et hors ligne. Pour importer des réponses hors ligne, rendez-vous dans l'onglet « Gestion des contributions » de ce projet, puis cliquez sur « Importer ».",
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "Vous pouvez combiner des réponses en ligne et hors ligne. Pour importer des réponses hors ligne, rendez-vous dans l'onglet « Enquête » de ce projet, puis cliquez sur « Importer ».",
   "app.containers.Admin.projects.all.logicNotInPDF": "Il n'est pas possible de reproduire les sauts logiques dans le PDF téléchargé. Les répondants sur papier verront donc toutes les questions de l'enquête.",
-  "app.containers.Admin.projects.all.notIncludedInYourPlan": "Cependant, cette fonctionnalité n'est pas incluse dans votre plan actuel. Contactez votre Spécialiste en participation Go Vocal ou votre administrateur pour l'activer.",
   "app.containers.Admin.projects.all.notes": "Notes",
   "app.containers.Admin.projects.all.personalDataExplanation2": "Cochez la case ci-dessous si vous souhaitez que le formulaire PDF contienne les champs nom, prénom et e-mail. À l'importation, nous utiliserons ces données pour créer automatiquement un compte pour les répondants hors ligne.",
   "app.containers.Admin.projects.project.analysis.Comments.aiSummary": "Résumé",

--- a/front/app/translations/admin/fr-FR.json
+++ b/front/app/translations/admin/fr-FR.json
@@ -1040,7 +1040,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossible1": "Vous pouvez combiner des réponses en ligne et hors ligne. Pour importer des réponses hors ligne, rendez-vous dans l'onglet « Gestion des contributions » de ce projet, puis cliquez sur « Importer ».",
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "Vous pouvez combiner des réponses en ligne et hors ligne. Pour importer des réponses hors ligne, rendez-vous dans l'onglet « Enquête » de ce projet, puis cliquez sur « Importer ».",
   "app.containers.Admin.projects.all.logicNotInPDF": "Il n'est pas possible de reproduire les sauts logiques dans le PDF téléchargé. Les répondants sur papier verront donc toutes les questions de l'enquête.",
-  "app.containers.Admin.projects.all.notIncludedInYourPlan": "Cependant, cette fonctionnalité n'est pas incluse dans votre plan actuel. Contactez votre Spécialiste en participation Go Vocal ou votre administrateur pour l'activer.",
   "app.containers.Admin.projects.all.notes": "Notes",
   "app.containers.Admin.projects.all.personalDataExplanation2": "Cochez la case ci-dessous si vous souhaitez que le formulaire PDF contienne les champs nom, prénom et e-mail. À l'importation, nous utiliserons ces données pour créer automatiquement un compte pour les répondants hors ligne.",
   "app.containers.Admin.projects.project.analysis.Comments.aiSummary": "Résumé",

--- a/front/app/translations/admin/hr-HR.json
+++ b/front/app/translations/admin/hr-HR.json
@@ -1040,7 +1040,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossible1": "Možete kombinirati online i offline odgovore. Za prijenos izvanmrežnih odgovora idite na karticu \"Upravitelj unosa\" ovog projekta i kliknite \"Uvezi\".",
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "Možete kombinirati online i offline odgovore. Za prijenos izvanmrežnih odgovora idite na karticu \"Anketa\" ovog projekta i kliknite \"Uvezi\".",
   "app.containers.Admin.projects.all.logicNotInPDF": "Logika ankete neće se odraziti na preuzeti PDF. Papirnati ispitanici će vidjeti sva anketna pitanja.",
-  "app.containers.Admin.projects.all.notIncludedInYourPlan": "Međutim, to nije uključeno u vaš trenutni plan. Obratite se svom upravitelju uspjeha vlade ili administratoru da ga otključa.",
   "app.containers.Admin.projects.all.notes": "Bilješke",
   "app.containers.Admin.projects.all.personalDataExplanation2": "Označite okvir u nastavku ako želite da preuzeti PDF sadrži polja za ime, prezime i e-poštu. Nakon učitavanja papirnatog obrasca, koristit ćemo te korisničke podatke za automatsko generiranje računa za izvanmrežnog ispitanika.",
   "app.containers.Admin.projects.project.analysis.Comments.aiSummary": "AI Sažetak",

--- a/front/app/translations/admin/lt-LT.json
+++ b/front/app/translations/admin/lt-LT.json
@@ -1040,7 +1040,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossible1": "Galite derinti internetinius ir neprisijungus prie interneto teikiamus atsakymus. Norėdami įkelti ne internetu gautus atsakymus, eikite į šio projekto skirtuką \"Įvesties tvarkytuvas\" ir spustelėkite \"Importuoti\".",
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "Galite derinti internetinius ir neprisijungus prie interneto teikiamus atsakymus. Norėdami įkelti ne internetu gautus atsakymus, eikite į šio projekto skirtuką \"Apklausa\" ir spustelėkite \"Importuoti\".",
   "app.containers.Admin.projects.all.logicNotInPDF": "Apklausos logika neatsispindės atsisiųstame PDF dokumente. Respondentai, atsakę į popierinius klausimus, matys visus apklausos klausimus.",
-  "app.containers.Admin.projects.all.notIncludedInYourPlan": "Tačiau tai nėra įtraukta į jūsų dabartinį planą. Kreipkitės į savo vyriausybės sėkmės vadybininką arba administratorių, kad jį atrakintumėte.",
   "app.containers.Admin.projects.all.notes": "Pastabos",
   "app.containers.Admin.projects.all.personalDataExplanation2": "Pažymėkite toliau esantį langelį, jei norite, kad atsisiųstame PDF dokumente būtų vardo, pavardės ir el. pašto laukai. Įkėlus popierinę formą, naudosime šiuos naudotojo duomenis, kad automatiškai sukurtume neprisijungusio apklausos respondento paskyrą.",
   "app.containers.Admin.projects.project.analysis.Comments.aiSummary": "AI santrauka",

--- a/front/app/translations/admin/lv-LV.json
+++ b/front/app/translations/admin/lv-LV.json
@@ -1040,7 +1040,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossible1": "Varat apvienot tiešsaistes un bezsaistes atbildes. Lai augšupielādētu bezsaistes atbildes, dodieties uz šā projekta cilni \"Ievades pārvaldnieks\" un noklikšķiniet uz \"Importēt\".",
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "Varat apvienot tiešsaistes un bezsaistes atbildes. Lai augšupielādētu bezsaistes atbildes, dodieties uz šī projekta cilni \"Aptauja\" un noklikšķiniet uz \"Importēt\".",
   "app.containers.Admin.projects.all.logicNotInPDF": "Aptaujas loģika netiks atspoguļota lejupielādētajā PDF failā. Papīra formātā respondenti redzēs visus aptaujas jautājumus.",
-  "app.containers.Admin.projects.all.notIncludedInYourPlan": "Tomēr tas nav iekļauts jūsu pašreizējā plānā. Lai to atbloķētu, sazinieties ar savu valdības veiksmes menedžeri vai administratoru.",
   "app.containers.Admin.projects.all.notes": "Piezīmes",
   "app.containers.Admin.projects.all.personalDataExplanation2": "Ja vēlaties, lai lejupielādētajā PDF failā tiktu iekļauti vārda, uzvārda un e-pasta lauki, atzīmējiet šo izvēles rūtiņu. Pēc papīra veidlapas augšupielādes mēs izmantosim šos lietotāja datus, lai automātiski izveidotu kontu bezsaistes aptaujas respondentam.",
   "app.containers.Admin.projects.project.analysis.Comments.aiSummary": "AI kopsavilkums",

--- a/front/app/translations/admin/nb-NO.json
+++ b/front/app/translations/admin/nb-NO.json
@@ -1040,7 +1040,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossible1": "Du kan kombinere online- og offline-svar. Hvis du vil laste opp offline-svar, går du til fanen \"Input manager\" i dette prosjektet og klikker på \"Import\".",
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "Du kan kombinere online- og offline-svar. Hvis du vil laste opp svar som ikke er på nett, går du til fanen \"Survey\" i dette prosjektet og klikker på \"Import\".",
   "app.containers.Admin.projects.all.logicNotInPDF": "Undersøkelseslogikken gjenspeiles ikke i den nedlastede PDF-filen. Papirrespondenter vil se alle spørsmålene i undersøkelsen.",
-  "app.containers.Admin.projects.all.notIncludedInYourPlan": "Dette er imidlertid ikke inkludert i din nåværende plan. Ta kontakt med din Government Success Manager eller administrator for å låse den opp.",
   "app.containers.Admin.projects.all.notes": "Merknader",
   "app.containers.Admin.projects.all.personalDataExplanation2": "Merk av i boksen nedenfor hvis du vil at den nedlastede PDF-filen skal inneholde felt for navn, etternavn og e-post. Når du laster opp papirskjemaet, bruker vi disse brukerdataene til å automatisk generere en konto for den som svarer på undersøkelsen offline.",
   "app.containers.Admin.projects.project.analysis.Comments.aiSummary": "Sammendrag av AI",

--- a/front/app/translations/admin/nl-BE.json
+++ b/front/app/translations/admin/nl-BE.json
@@ -1040,7 +1040,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossible1": "Je kunt online en offline reacties combineren. Om offline reacties te uploaden, ga je naar het tabblad 'Beheer bijdragen' van dit project en klik je op 'Importeren'.",
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "Je kunt online en offline reacties combineren. Als je offline reacties wilt uploaden, ga je naar het tabblad 'Vragenlijst' van dit project en klik je op 'Importeren'.",
   "app.containers.Admin.projects.all.logicNotInPDF": "Enquêtelogica wordt niet weergegeven in de gedownloade PDF. Papieren respondenten zien alle enquêtevragen.",
-  "app.containers.Admin.projects.all.notIncludedInYourPlan": "Dit is echter niet inbegrepen in je huidige abonnement. Neem contact op met je Government Success Manager of platformbeheerder om dit te ontgrendelen.",
   "app.containers.Admin.projects.all.notes": "Opmerkingen",
   "app.containers.Admin.projects.all.personalDataExplanation2": "Vink het vakje hieronder aan als je wilt dat de gedownloade PDF velden voor naam, achternaam en e-mail bevat. Bij het uploaden van het papieren formulier zullen we deze gebruikersgegevens gebruiken om automatisch een account te genereren voor de offline respondent.",
   "app.containers.Admin.projects.project.analysis.Comments.aiSummary": "AI Samenvatting",

--- a/front/app/translations/admin/nl-NL.json
+++ b/front/app/translations/admin/nl-NL.json
@@ -1040,7 +1040,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossible1": "Je kunt online en offline reacties combineren. Om offline reacties te uploaden, ga je naar het tabblad 'Beheer bijdragen' van dit project en klik je op 'Importeren'.",
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "Je kunt online en offline reacties combineren. Als je offline reacties wilt uploaden, ga je naar het tabblad 'Vragenlijst' van dit project en klik je op 'Importeren'.",
   "app.containers.Admin.projects.all.logicNotInPDF": "Enquêtelogica wordt niet weergegeven in de gedownloade PDF. Papieren respondenten zien alle enquêtevragen.",
-  "app.containers.Admin.projects.all.notIncludedInYourPlan": "Dit is echter niet inbegrepen in je huidige abonnement. Neem contact op met je Government Success Manager of platformbeheerder om dit te ontgrendelen.",
   "app.containers.Admin.projects.all.notes": "Opmerkingen",
   "app.containers.Admin.projects.all.personalDataExplanation2": "Vink het vakje hieronder aan als je wilt dat de gedownloade PDF velden voor naam, achternaam en e-mail bevat. Bij het uploaden van het papieren formulier zullen we deze gebruikersgegevens gebruiken om automatisch een account te genereren voor de offline respondent.",
   "app.containers.Admin.projects.project.analysis.Comments.aiSummary": "AI Samenvatting",

--- a/front/app/translations/admin/pa-IN.json
+++ b/front/app/translations/admin/pa-IN.json
@@ -1040,7 +1040,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossible1": "ਤੁਸੀਂ ਔਨਲਾਈਨ ਅਤੇ ਔਫਲਾਈਨ ਜਵਾਬਾਂ ਨੂੰ ਜੋੜ ਸਕਦੇ ਹੋ। ਔਫਲਾਈਨ ਜਵਾਬਾਂ ਨੂੰ ਅੱਪਲੋਡ ਕਰਨ ਲਈ, ਇਸ ਪ੍ਰੋਜੈਕਟ ਦੇ 'ਇਨਪੁਟ ਮੈਨੇਜਰ' ਟੈਬ 'ਤੇ ਜਾਓ, ਅਤੇ 'ਆਯਾਤ' 'ਤੇ ਕਲਿੱਕ ਕਰੋ।",
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "ਤੁਸੀਂ ਔਨਲਾਈਨ ਅਤੇ ਔਫਲਾਈਨ ਜਵਾਬਾਂ ਨੂੰ ਜੋੜ ਸਕਦੇ ਹੋ। ਔਫਲਾਈਨ ਜਵਾਬ ਅੱਪਲੋਡ ਕਰਨ ਲਈ, ਇਸ ਪ੍ਰੋਜੈਕਟ ਦੇ 'ਸਰਵੇਖਣ' ਟੈਬ 'ਤੇ ਜਾਓ, ਅਤੇ 'ਆਯਾਤ' 'ਤੇ ਕਲਿੱਕ ਕਰੋ।",
   "app.containers.Admin.projects.all.logicNotInPDF": "ਸਰਵੇਖਣ ਤਰਕ ਡਾਊਨਲੋਡ ਕੀਤੀ PDF ਵਿੱਚ ਪ੍ਰਤੀਬਿੰਬਿਤ ਨਹੀਂ ਹੋਵੇਗਾ। ਪੇਪਰ ਉੱਤਰਦਾਤਾ ਸਾਰੇ ਸਰਵੇਖਣ ਸਵਾਲਾਂ ਨੂੰ ਦੇਖਣਗੇ।",
-  "app.containers.Admin.projects.all.notIncludedInYourPlan": "ਹਾਲਾਂਕਿ, ਇਹ ਤੁਹਾਡੀ ਮੌਜੂਦਾ ਯੋਜਨਾ ਵਿੱਚ ਸ਼ਾਮਲ ਨਹੀਂ ਹੈ। ਇਸਨੂੰ ਅਨਲੌਕ ਕਰਨ ਲਈ ਆਪਣੇ ਸਰਕਾਰੀ ਸਫਲਤਾ ਪ੍ਰਬੰਧਕ ਜਾਂ ਪ੍ਰਸ਼ਾਸਕ ਨਾਲ ਸੰਪਰਕ ਕਰੋ।",
   "app.containers.Admin.projects.all.notes": "ਨੋਟਸ",
   "app.containers.Admin.projects.all.personalDataExplanation2": "ਜੇਕਰ ਤੁਸੀਂ ਚਾਹੁੰਦੇ ਹੋ ਕਿ ਤੁਹਾਡੀ ਡਾਊਨਲੋਡ ਕੀਤੀ PDF ਵਿੱਚ ਨਾਮ, ਆਖਰੀ ਨਾਮ ਅਤੇ ਈਮੇਲ ਖੇਤਰ ਸ਼ਾਮਲ ਹੋਣ ਤਾਂ ਹੇਠਾਂ ਦਿੱਤੇ ਬਾਕਸ ਨੂੰ ਚੁਣੋ। ਪੇਪਰ ਫਾਰਮ ਨੂੰ ਅਪਲੋਡ ਕਰਨ 'ਤੇ, ਅਸੀਂ ਉਸ ਉਪਭੋਗਤਾ ਡੇਟਾ ਦੀ ਵਰਤੋਂ ਕਰਾਂਗੇ, ਔਫਲਾਈਨ ਸਰਵੇਖਣ ਉੱਤਰਦਾਤਾ ਲਈ ਇੱਕ ਖਾਤਾ ਸਵੈ-ਤਿਆਰ ਕਰਨ ਲਈ।",
   "app.containers.Admin.projects.project.analysis.Comments.aiSummary": "ਏਆਈ ਸੰਖੇਪ",

--- a/front/app/translations/admin/pl-PL.json
+++ b/front/app/translations/admin/pl-PL.json
@@ -1040,7 +1040,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossible1": "Możesz łączyć odpowiedzi online i offline. Aby przesłać odpowiedzi offline, przejdź do zakładki \"Menedżer danych wejściowych\" tego projektu i kliknij \"Importuj\".",
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "Możesz łączyć odpowiedzi online i offline. Aby przesłać odpowiedzi offline, przejdź do zakładki \"Ankieta\" tego projektu i kliknij \"Importuj\".",
   "app.containers.Admin.projects.all.logicNotInPDF": "Logika ankiety nie zostanie odzwierciedlona w pobranym pliku PDF. Respondenci papierowi zobaczą wszystkie pytania ankiety.",
-  "app.containers.Admin.projects.all.notIncludedInYourPlan": "Nie jest to jednak uwzględnione w Twoim obecnym planie. Skontaktuj się ze swoim Government Success Managerem lub administratorem, aby ją odblokować.",
   "app.containers.Admin.projects.all.notes": "Uwagi",
   "app.containers.Admin.projects.all.personalDataExplanation2": "Zaznacz poniższe pole, jeśli chcesz, aby pobrany plik PDF zawierał pola imienia, nazwiska i adresu e-mail. Po przesłaniu papierowego formularza użyjemy tych danych użytkownika do automatycznego wygenerowania konta dla respondenta ankiety offline.",
   "app.containers.Admin.projects.project.analysis.Comments.aiSummary": "Podsumowanie AI",

--- a/front/app/translations/admin/pt-BR.json
+++ b/front/app/translations/admin/pt-BR.json
@@ -1040,7 +1040,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossible1": "Você pode combinar respostas on-line e off-line. Para carregar respostas off-line, vá para a guia \"Gerenciador de entrada\" deste projeto e clique em \"Importar\".",
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "Você pode combinar respostas on-line e off-line. Para carregar respostas off-line, vá para a guia \"Survey\" (Pesquisa) desse projeto e clique em \"Import\" (Importar).",
   "app.containers.Admin.projects.all.logicNotInPDF": "A lógica da pesquisa não será refletida no PDF baixado. Os questionados em papel verão todas as perguntas da pesquisa.",
-  "app.containers.Admin.projects.all.notIncludedInYourPlan": "No entanto, isso não está incluído em seu plano atual. Entre em contato com seu gerente de sucesso do governo ou administrador para desbloqueá-lo.",
   "app.containers.Admin.projects.all.notes": "Notas",
   "app.containers.Admin.projects.all.personalDataExplanation2": "Marque a caixa abaixo se você quiser que o PDF baixado contenha campos de nome, sobrenome e e-mail. Após o upload do formulário em papel, usaremos esses dados do usuário para gerar automaticamente uma conta para o respondente da pesquisa off-line.",
   "app.containers.Admin.projects.project.analysis.Comments.aiSummary": "Resumo da IA",

--- a/front/app/translations/admin/sr-Latn.json
+++ b/front/app/translations/admin/sr-Latn.json
@@ -1040,7 +1040,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossible1": "You can combine online and offline responses. To upload offline responses, go to the 'Input manager' tab of this project, and click 'Import'.",
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "You can combine online and offline responses. To upload offline responses, go to the 'Survey' tab of this project, and click 'Import'.",
   "app.containers.Admin.projects.all.logicNotInPDF": "Survey logic will not be reflected in the downloaded PDF. Paper respondents will see all survey questions.",
-  "app.containers.Admin.projects.all.notIncludedInYourPlan": "However, this is not included in your current plan. Reach out to your Government Success Manager or admin to unlock it.",
   "app.containers.Admin.projects.all.notes": "Notes",
   "app.containers.Admin.projects.all.personalDataExplanation2": "Check the box below, if you want your downloaded PDF to contain name, last name, and email fields. Upon upload of the paper form, we will use that user data, to auto-generate an account for the offline survey respondent.",
   "app.containers.Admin.projects.project.analysis.Comments.aiSummary": "AI Summary",

--- a/front/app/translations/admin/sr-SP.json
+++ b/front/app/translations/admin/sr-SP.json
@@ -1040,7 +1040,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossible1": "You can combine online and offline responses. To upload offline responses, go to the 'Input manager' tab of this project, and click 'Import'.",
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "You can combine online and offline responses. To upload offline responses, go to the 'Survey' tab of this project, and click 'Import'.",
   "app.containers.Admin.projects.all.logicNotInPDF": "Survey logic will not be reflected in the downloaded PDF. Paper respondents will see all survey questions.",
-  "app.containers.Admin.projects.all.notIncludedInYourPlan": "However, this is not included in your current plan. Reach out to your Government Success Manager or admin to unlock it.",
   "app.containers.Admin.projects.all.notes": "Notes",
   "app.containers.Admin.projects.all.personalDataExplanation2": "Check the box below, if you want your downloaded PDF to contain name, last name, and email fields. Upon upload of the paper form, we will use that user data, to auto-generate an account for the offline survey respondent.",
   "app.containers.Admin.projects.project.analysis.Comments.aiSummary": "AI Summary",

--- a/front/app/translations/admin/sv-SE.json
+++ b/front/app/translations/admin/sv-SE.json
@@ -1040,7 +1040,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossible1": "Du kan kombinera online- och offline-svar. För att ladda upp offline-svar går du till fliken \"Input manager\" i det här projektet och klickar på \"Import\".",
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "Du kan kombinera online- och offline-svar. För att ladda upp offline-svar går du till fliken \"Survey\" i det här projektet och klickar på \"Import\".",
   "app.containers.Admin.projects.all.logicNotInPDF": "Enkätlogiken kommer inte att återspeglas i den nedladdade PDF-filen. Respondenter som svarar på papper ser alla enkätfrågor.",
-  "app.containers.Admin.projects.all.notIncludedInYourPlan": "Detta ingår dock inte i din nuvarande plan. Kontakta din Government Success Manager eller administratör för att låsa upp den.",
   "app.containers.Admin.projects.all.notes": "Anteckningar",
   "app.containers.Admin.projects.all.personalDataExplanation2": "Markera rutan nedan om du vill att den nedladdade PDF-filen ska innehålla fält för namn, efternamn och e-post. När pappersformuläret laddas upp kommer vi att använda dessa användardata för att automatiskt generera ett konto för den som svarar på offlineundersökningen.",
   "app.containers.Admin.projects.project.analysis.Comments.aiSummary": "Sammanfattning av AI",

--- a/front/app/translations/admin/tr-TR.json
+++ b/front/app/translations/admin/tr-TR.json
@@ -1040,7 +1040,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossible1": "Çevrimiçi ve çevrimdışı yanıtları birleştirebilirsiniz. Çevrimdışı yanıtları yüklemek için bu projenin 'Girdi yöneticisi' sekmesine gidin ve 'İçe aktar' seçeneğine tıklayın.",
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "Çevrimiçi ve çevrimdışı yanıtları birleştirebilirsiniz. Çevrimdışı yanıtları yüklemek için bu projenin 'Anket' sekmesine gidin ve 'İçe Aktar'a tıklayın.",
   "app.containers.Admin.projects.all.logicNotInPDF": "Anket mantığı indirilen PDF'ye yansıtılmayacaktır. Basılı anket katılımcıları tüm anket sorularını görecektir.",
-  "app.containers.Admin.projects.all.notIncludedInYourPlan": "Ancak, bu mevcut planınıza dahil değildir. Kilidi açmak için Kamu Başarı Yöneticinize veya yöneticinize ulaşın.",
   "app.containers.Admin.projects.all.notes": "Notlar",
   "app.containers.Admin.projects.all.personalDataExplanation2": "İndirdiğiniz PDF'nin ad, soyad ve e-posta alanlarını içermesini istiyorsanız aşağıdaki kutuyu işaretleyin. Kağıt formun yüklenmesinin ardından, çevrimdışı anket katılımcısı için otomatik olarak bir hesap oluşturmak üzere bu kullanıcı verilerini kullanacağız.",
   "app.containers.Admin.projects.project.analysis.Comments.aiSummary": "Yapay Zeka Özeti",

--- a/front/app/translations/admin/ur-PK.json
+++ b/front/app/translations/admin/ur-PK.json
@@ -1040,7 +1040,6 @@
   "app.containers.Admin.projects.all.itIsAlsoPossible1": "آپ آن لائن اور آف لائن جوابات کو یکجا کر سکتے ہیں۔ آف لائن جوابات اپ لوڈ کرنے کے لیے، اس پروجیکٹ کے 'ان پٹ مینیجر' ٹیب پر جائیں، اور 'درآمد کریں' پر کلک کریں۔",
   "app.containers.Admin.projects.all.itIsAlsoPossibleSurvey1": "آپ آن لائن اور آف لائن جوابات کو یکجا کر سکتے ہیں۔ آف لائن جوابات اپ لوڈ کرنے کے لیے، اس پروجیکٹ کے 'سروے' ٹیب پر جائیں، اور 'درآمد کریں' پر کلک کریں۔",
   "app.containers.Admin.projects.all.logicNotInPDF": "ڈاؤن لوڈ کردہ پی ڈی ایف میں سروے کی منطق کی عکاسی نہیں کی جائے گی۔ کاغذی جواب دہندگان سروے کے تمام سوالات دیکھیں گے۔",
-  "app.containers.Admin.projects.all.notIncludedInYourPlan": "تاہم، یہ آپ کے موجودہ پلان میں شامل نہیں ہے۔ اسے غیر مقفل کرنے کے لیے اپنے سرکاری کامیابی کے مینیجر یا منتظم سے رابطہ کریں۔",
   "app.containers.Admin.projects.all.notes": "نوٹس",
   "app.containers.Admin.projects.all.personalDataExplanation2": "اگر آپ چاہتے ہیں کہ آپ کی ڈاؤن لوڈ کردہ پی ڈی ایف میں نام، آخری نام اور ای میل فیلڈز ہوں تو نیچے والے باکس کو چیک کریں۔ کاغذی فارم اپ لوڈ کرنے پر، ہم اس صارف کے ڈیٹا کا استعمال کریں گے، تاکہ آف لائن سروے کے جواب دہندہ کے لیے ایک اکاؤنٹ خود بخود تیار کیا جا سکے۔",
   "app.containers.Admin.projects.project.analysis.Comments.aiSummary": "AI کا خلاصہ",


### PR DESCRIPTION
Modal can only be launched if the `import_printed_forms` feature is enabled.

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->
