### PR TITLE
Better icon for "Open AI analysis" button

### DIFF
--- a/front/app/components/admin/FormResults/FormResultsQuestion/components/AnalysisBanner.tsx
+++ b/front/app/components/admin/FormResults/FormResultsQuestion/components/AnalysisBanner.tsx
@@ -139,7 +139,8 @@ const AnalysisBanner = () => {
           buttonStyle="text"
           textColor={colors.teal500}
           fontWeight="bold"
-          icon={'stars'}
+          icon="arrow-right"
+          iconPos="right"
           iconColor={colors.teal500}
           onClick={goToAnalysis}
           processing={isAddLoading || isUpdateLoading}

--- a/front/app/containers/Admin/projects/components/AnalysisBanner.tsx
+++ b/front/app/containers/Admin/projects/components/AnalysisBanner.tsx
@@ -7,7 +7,6 @@ import {
   Button,
   Box,
   stylingConsts,
-  Tooltip,
 } from '@citizenlab/cl2-component-library';
 
 import useAddAnalysis from 'api/analyses/useAddAnalysis';
@@ -17,6 +16,8 @@ import usePhase from 'api/phases/usePhase';
 import useFeatureFlag from 'hooks/useFeatureFlag';
 
 import tracks from 'containers/Admin/projects/project/analysis/tracks';
+
+import UpsellTooltip from 'components/UpsellTooltip';
 
 import { trackEventByName } from 'utils/analytics';
 import { useIntl } from 'utils/cl-intl';
@@ -98,27 +99,22 @@ const AnalysisBanner = ({ projectId, phaseId }: Props) => {
         <Icon name="stars" width="30px" height="30px" fill={colors.teal500} />
         <Text>{formatMessage(messages.analysisSubtitle)}</Text>
       </Box>
-      <Tooltip
-        content={<p>{formatMessage(messages.analysisUpsellTooltip)}</p>}
-        disabled={isAnalysisAllowed}
-      >
-        <Box>
-          <Button
-            buttonStyle="text"
-            textColor={colors.teal500}
-            onClick={handleGoToAnalysis}
-            fontWeight="bold"
-            icon="arrow-right"
-            iconPos="right"
-            iconColor={colors.teal500}
-            id="e2e-analysis-banner-button"
-            processing={isLoading}
-            disabled={!isAnalysisAllowed}
-          >
-            {formatMessage(messages.analysisButton)}
-          </Button>
-        </Box>
-      </Tooltip>
+      <UpsellTooltip disabled={isAnalysisAllowed}>
+        <Button
+          buttonStyle="text"
+          textColor={colors.teal500}
+          onClick={handleGoToAnalysis}
+          fontWeight="bold"
+          icon="arrow-right"
+          iconPos="right"
+          iconColor={colors.teal500}
+          id="e2e-analysis-banner-button"
+          processing={isLoading}
+          disabled={!isAnalysisAllowed}
+        >
+          {formatMessage(messages.analysisButton)}
+        </Button>
+      </UpsellTooltip>
     </Box>
   );
 };

--- a/front/app/containers/Admin/projects/components/AnalysisBanner.tsx
+++ b/front/app/containers/Admin/projects/components/AnalysisBanner.tsx
@@ -108,7 +108,8 @@ const AnalysisBanner = ({ projectId, phaseId }: Props) => {
             textColor={colors.teal500}
             onClick={handleGoToAnalysis}
             fontWeight="bold"
-            icon={isAnalysisAllowed ? 'stars' : 'lock'}
+            icon="arrow-right"
+            iconPos="right"
             iconColor={colors.teal500}
             id="e2e-analysis-banner-button"
             processing={isLoading}

--- a/front/app/containers/Admin/projects/project/ideas/messages.ts
+++ b/front/app/containers/Admin/projects/project/ideas/messages.ts
@@ -14,9 +14,4 @@ export default defineMessages({
     id: 'app.containers.Admin.projects.project.ideas.importInputs',
     defaultMessage: 'Import',
   },
-  analysisUpsellTooltip: {
-    id: 'app.containers.Admin.projects.project.ideas.analysisUpsellTooltip',
-    defaultMessage:
-      'This feature is not included in your current plan. Talk to your Government Success Manager or admin to unlock it.',
-  },
 });

--- a/front/app/translations/admin/ar-SA.json
+++ b/front/app/translations/admin/ar-SA.json
@@ -1051,7 +1051,6 @@
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "هذا محتوى تم إنشاؤه بواسطة الذكاء الاصطناعي. وقد لا تكون دقيقة بنسبة 100%. يرجى المراجعة والإحالة المرجعية مع المدخلات الفعلية للتأكد من دقتها. انتبه إلى أنه من المرجح أن تتحسن الدقة إذا تم تقليل عدد المدخلات المحددة.",
   "app.containers.Admin.projects.project.ideas.analysisAction1": "تحليل الذكاء الاصطناعي المفتوح",
   "app.containers.Admin.projects.project.ideas.analysisText2": "استكشف الملخصات المدعومة بالذكاء الاصطناعي واعرض الإرساليات الفردية.",
-  "app.containers.Admin.projects.project.ideas.analysisUpsellTooltip": "لم يتم تضمين هذه الميزة في خطتك الحالية. تحدث إلى مدير النجاح الحكومي أو المسؤول لفتحه.",
   "app.containers.Admin.projects.project.ideas.importInputs": "يستورد",
   "app.containers.Admin.projects.project.information.ReportTab.afterCreating": "بعد إنشاء التقرير، يمكنك اختيار مشاركته مع الجمهور بمجرد بدء المرحلة.",
   "app.containers.Admin.projects.project.information.ReportTab.createAMoreComplex": "قم بإنشاء صفحة أكثر تعقيدًا لمشاركة المعلومات",

--- a/front/app/translations/admin/cy-GB.json
+++ b/front/app/translations/admin/cy-GB.json
@@ -1051,7 +1051,6 @@
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "Mae hwn yn gynnwys a gynhyrchir gan AI. Efallai nad yw'n 100% yn gywir. Adolygwch a chroesgyfeiriwch gyda'r mewnbynnau gwirioneddol i sicrhau cywirdeb. Byddwch yn ymwybodol bod y cywirdeb yn debygol o wella os bydd nifer y mewnbynnau dethol yn cael eu lleihau.",
   "app.containers.Admin.projects.project.ideas.analysisAction1": "Dadansoddiad AI agored",
   "app.containers.Admin.projects.project.ideas.analysisText2": "Archwiliwch grynodebau wedi'u pweru gan AI a gweld cyflwyniadau unigol.",
-  "app.containers.Admin.projects.project.ideas.analysisUpsellTooltip": "Nid yw'r nodwedd hon wedi'i chynnwys yn eich cynllun cyfredol. Siaradwch â'ch Rheolwr Llwyddiant Llywodraeth neu weinyddwr i'w ddatgloi.",
   "app.containers.Admin.projects.project.ideas.importInputs": "Mewnforio",
   "app.containers.Admin.projects.project.information.ReportTab.afterCreating": "Ar ôl creu adroddiad, gallwch ddewis ei rannu â'r cyhoedd unwaith y bydd y cam yn dechrau.",
   "app.containers.Admin.projects.project.information.ReportTab.createAMoreComplex": "Creu tudalen fwy cymhleth ar gyfer rhannu gwybodaeth",

--- a/front/app/translations/admin/da-DK.json
+++ b/front/app/translations/admin/da-DK.json
@@ -1051,7 +1051,6 @@
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "Dette er AI-genereret indhold. Det er måske ikke 100% nøjagtigt. Gennemgå og krydsreferer med de faktiske input for nøjagtighed. Vær opmærksom på, at nøjagtigheden sandsynligvis forbedres, hvis antallet af valgte input reduceres.",
   "app.containers.Admin.projects.project.ideas.analysisAction1": "Åben AI-analyse",
   "app.containers.Admin.projects.project.ideas.analysisText2": "Udforsk AI-drevne resuméer og se individuelle indsendelser.",
-  "app.containers.Admin.projects.project.ideas.analysisUpsellTooltip": "Denne funktion er ikke inkluderet i din nuværende plan. Tal med jeres administrator for at låse den op.",
   "app.containers.Admin.projects.project.ideas.importInputs": "Import",
   "app.containers.Admin.projects.project.information.ReportTab.afterCreating": "Når du har oprettet en rapport, kan du vælge at dele den med offentligheden, når fasen starter.",
   "app.containers.Admin.projects.project.information.ReportTab.createAMoreComplex": "Opret en mere kompleks side til informationsdeling",

--- a/front/app/translations/admin/de-DE.json
+++ b/front/app/translations/admin/de-DE.json
@@ -1051,7 +1051,6 @@
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "Dies ist ein KI-generierter Inhalt. Dieser ist möglicherweise nicht 100%ig genau. Bitte überprüfen Sie die Genauigkeit und gleichen Sie sie mit den tatsächlichen Beiträgen ab. Beachten Sie, dass sich die Genauigkeit wahrscheinlich verbessert, wenn die Anzahl der ausgewählten Beiträge reduziert wird.",
   "app.containers.Admin.projects.project.ideas.analysisAction1": "Zur KI-Analyse",
   "app.containers.Admin.projects.project.ideas.analysisText2": "Erkunden Sie KI-gestützte Zusammenfassungen und sehen Sie sich einzelne Beiträge an.",
-  "app.containers.Admin.projects.project.ideas.analysisUpsellTooltip": "Diese Funktion ist in Ihrer aktuellen Lizenz nicht enthalten. Sprechen Sie mit Ihrer Kundenbetreuerin oder Ihrem Admin, um sie freizuschalten.",
   "app.containers.Admin.projects.project.ideas.importInputs": "Importieren",
   "app.containers.Admin.projects.project.information.ReportTab.afterCreating": "Nachdem Sie einen Bericht erstellt haben, können Sie ihn für die Öffentlichkeit freigeben, sobald die Phase beginnt.",
   "app.containers.Admin.projects.project.information.ReportTab.createAMoreComplex": "Erstellen Sie eine komplexere Seite für den Informationsaustausch",

--- a/front/app/translations/admin/en-CA.json
+++ b/front/app/translations/admin/en-CA.json
@@ -1051,7 +1051,6 @@
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "This is AI-generated content. It may not be 100% accurate. Please review and cross-reference with the actual inputs for accuracy. Be aware that the accuracy is likely to improve if the number of selected inputs is reduced.",
   "app.containers.Admin.projects.project.ideas.analysisAction1": "Open AI analysis",
   "app.containers.Admin.projects.project.ideas.analysisText2": "Explore AI-powered summaries and view individual submissions.",
-  "app.containers.Admin.projects.project.ideas.analysisUpsellTooltip": "This feature is not included in your current plan. Talk to your Government Success Manager or admin to unlock it.",
   "app.containers.Admin.projects.project.ideas.importInputs": "Import",
   "app.containers.Admin.projects.project.information.ReportTab.afterCreating": "After creating a report, you can choose to share it with the public once the phase starts.",
   "app.containers.Admin.projects.project.information.ReportTab.createAMoreComplex": "Create a more complex page for information sharing",

--- a/front/app/translations/admin/en-GB.json
+++ b/front/app/translations/admin/en-GB.json
@@ -1051,7 +1051,6 @@
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "This is AI-generated content. It may not be 100% accurate. Please review and cross-reference with the actual inputs for accuracy. Be aware that the accuracy is likely to improve if the number of selected inputs is reduced.",
   "app.containers.Admin.projects.project.ideas.analysisAction1": "Open AI analysis",
   "app.containers.Admin.projects.project.ideas.analysisText2": "Explore AI-powered summaries and view individual submissions.",
-  "app.containers.Admin.projects.project.ideas.analysisUpsellTooltip": "This feature is not included in your current plan. Talk to your Government Success Manager or admin to unlock it.",
   "app.containers.Admin.projects.project.ideas.importInputs": "Import",
   "app.containers.Admin.projects.project.information.ReportTab.afterCreating": "After creating a report, you can choose to share it with the public once the phase starts.",
   "app.containers.Admin.projects.project.information.ReportTab.createAMoreComplex": "Create a more complex page for information sharing",

--- a/front/app/translations/admin/en-IE.json
+++ b/front/app/translations/admin/en-IE.json
@@ -1051,7 +1051,6 @@
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "This is AI-generated content. It may not be 100% accurate. Please review and cross-reference with the actual inputs for accuracy. Be aware that the accuracy is likely to improve if the number of selected inputs is reduced.",
   "app.containers.Admin.projects.project.ideas.analysisAction1": "Open AI analysis",
   "app.containers.Admin.projects.project.ideas.analysisText2": "Explore AI-powered summaries and view individual submissions.",
-  "app.containers.Admin.projects.project.ideas.analysisUpsellTooltip": "This feature is not included in your current plan. Talk to your Government Success Manager or admin to unlock it.",
   "app.containers.Admin.projects.project.ideas.importInputs": "Import",
   "app.containers.Admin.projects.project.information.ReportTab.afterCreating": "After creating a report, you can choose to share it with the public once the phase starts.",
   "app.containers.Admin.projects.project.information.ReportTab.createAMoreComplex": "Create a more complex page for information sharing",

--- a/front/app/translations/admin/en.json
+++ b/front/app/translations/admin/en.json
@@ -1051,7 +1051,6 @@
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "This is AI-generated content. It may not be 100% accurate. Please review and cross-reference with the actual inputs for accuracy. Be aware that the accuracy is likely to improve if the number of selected inputs is reduced.",
   "app.containers.Admin.projects.project.ideas.analysisAction1": "Open AI analysis",
   "app.containers.Admin.projects.project.ideas.analysisText2": "Explore AI-powered summaries and view individual submissions.",
-  "app.containers.Admin.projects.project.ideas.analysisUpsellTooltip": "This feature is not included in your current plan. Talk to your Government Success Manager or admin to unlock it.",
   "app.containers.Admin.projects.project.ideas.importInputs": "Import",
   "app.containers.Admin.projects.project.information.ReportTab.afterCreating": "After creating a report, you can choose to share it with the public once the phase starts.",
   "app.containers.Admin.projects.project.information.ReportTab.createAMoreComplex": "Create a more complex page for information sharing",

--- a/front/app/translations/admin/es-CL.json
+++ b/front/app/translations/admin/es-CL.json
@@ -1051,7 +1051,6 @@
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "Se trata de contenido generado por IA. Puede que no sea 100% exacto. Por favor, revísalo y haz referencias cruzadas con las entradas reales para comprobar su exactitud. Ten en cuenta que es probable que la precisión mejore si se reduce el número de entradas seleccionadas.",
   "app.containers.Admin.projects.project.ideas.analysisAction1": "Abrir análisis de IA",
   "app.containers.Admin.projects.project.ideas.analysisText2": "Explora los resúmenes con IA y consulta las aportaciones individuales.",
-  "app.containers.Admin.projects.project.ideas.analysisUpsellTooltip": "Esta función no está incluida en tu plan actual. Habla con tu Gestor de Éxito Gubernamental o con el administrador para desbloquearla.",
   "app.containers.Admin.projects.project.ideas.importInputs": "Importar",
   "app.containers.Admin.projects.project.information.ReportTab.afterCreating": "Después de crear un informe, puedes elegir compartirlo con el público una vez iniciada la fase.",
   "app.containers.Admin.projects.project.information.ReportTab.createAMoreComplex": "Crear una página más compleja para compartir información",

--- a/front/app/translations/admin/es-ES.json
+++ b/front/app/translations/admin/es-ES.json
@@ -1051,7 +1051,6 @@
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "Se trata de contenido generado por IA. Puede que no sea 100% exacto. Por favor, revísalo y haz referencias cruzadas con las entradas reales para comprobar su exactitud. Ten en cuenta que es probable que la precisión mejore si se reduce el número de entradas seleccionadas.",
   "app.containers.Admin.projects.project.ideas.analysisAction1": "Abrir análisis de IA",
   "app.containers.Admin.projects.project.ideas.analysisText2": "Explora los resúmenes con IA y consulta las aportaciones individuales.",
-  "app.containers.Admin.projects.project.ideas.analysisUpsellTooltip": "Esta función no está incluida en tu plan actual. Habla con tu Gestor de Éxito Gubernamental o con el administrador para desbloquearla.",
   "app.containers.Admin.projects.project.ideas.importInputs": "Importar",
   "app.containers.Admin.projects.project.information.ReportTab.afterCreating": "Después de crear un informe, puedes elegir compartirlo con el público una vez iniciada la fase.",
   "app.containers.Admin.projects.project.information.ReportTab.createAMoreComplex": "Crear una página más compleja para compartir información",

--- a/front/app/translations/admin/fi-FI.json
+++ b/front/app/translations/admin/fi-FI.json
@@ -1051,7 +1051,6 @@
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "Tämä on tekoälyn luomaa sisältöä. Se ei välttämättä ole 100 % tarkka. Tarkista ja vertaa todellisia syötteitä tarkkuuden varmistamiseksi. Huomaa, että tarkkuus todennäköisesti paranee, jos valittujen tulojen määrää vähennetään.",
   "app.containers.Admin.projects.project.ideas.analysisAction1": "Avaa AI-analyysi",
   "app.containers.Admin.projects.project.ideas.analysisText2": "Tutustu tekoälypohjaisiin yhteenvedoihin ja tarkastele yksittäisiä lähetyksiä.",
-  "app.containers.Admin.projects.project.ideas.analysisUpsellTooltip": "Tämä ominaisuus ei sisälly nykyiseen suunnitelmaasi. Keskustele hallituksen menestyspäällikön tai järjestelmänvalvojan kanssa avataksesi sen.",
   "app.containers.Admin.projects.project.ideas.importInputs": "Tuonti",
   "app.containers.Admin.projects.project.information.ReportTab.afterCreating": "Kun olet luonut raportin, voit halutessasi jakaa sen julkisesti vaiheen alkaessa.",
   "app.containers.Admin.projects.project.information.ReportTab.createAMoreComplex": "Luo monimutkaisempi sivu tiedon jakamista varten",

--- a/front/app/translations/admin/fr-BE.json
+++ b/front/app/translations/admin/fr-BE.json
@@ -1051,7 +1051,6 @@
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "Ce contenu a été généré par un modèle d'intelligence artificielle. Il peut ne pas être totalement exact. Nous vous recommandons de le vérifier en le recoupant avec les contributions d'origine. Notez que la précision est susceptible de s'améliorer si le nombre de contributions sélectionnées est réduit.",
   "app.containers.Admin.projects.project.ideas.analysisAction1": "Accéder à l'outil d'analyse IA",
   "app.containers.Admin.projects.project.ideas.analysisText2": "Explorez les résumés générés par l'IA et consultez les contributions individuelles.",
-  "app.containers.Admin.projects.project.ideas.analysisUpsellTooltip": "Cette fonctionnalité n'est pas incluse dans votre plan actuel. Adressez-vous à votre GovSuccess Manager ou à votre administrateur pour l'activer.",
   "app.containers.Admin.projects.project.ideas.importInputs": "Importer",
   "app.containers.Admin.projects.project.information.ReportTab.afterCreating": "Après avoir créé un rapport, vous pouvez choisir de le partager avec le public dès que le début de la phase.",
   "app.containers.Admin.projects.project.information.ReportTab.createAMoreComplex": "créer une page plus élaborée pour le partage d'informations.",

--- a/front/app/translations/admin/fr-FR.json
+++ b/front/app/translations/admin/fr-FR.json
@@ -1051,7 +1051,6 @@
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "Ce contenu a été généré par un modèle d'intelligence artificielle. Il peut ne pas être totalement exact. Nous vous recommandons de le vérifier en le recoupant avec les contributions d'origine. Notez que la précision est susceptible de s'améliorer si le nombre de contributions sélectionnées est réduit.",
   "app.containers.Admin.projects.project.ideas.analysisAction1": "Accéder à l'outil d'analyse IA",
   "app.containers.Admin.projects.project.ideas.analysisText2": "Explorez les résumés générés par l'IA et consultez les contributions individuelles.",
-  "app.containers.Admin.projects.project.ideas.analysisUpsellTooltip": "Cette fonctionnalité n'est pas incluse dans votre plan actuel. Adressez-vous à votre Spécialiste en participation Go Vocal ou à votre administrateur pour l'activer.",
   "app.containers.Admin.projects.project.ideas.importInputs": "Importer",
   "app.containers.Admin.projects.project.information.ReportTab.afterCreating": "Après avoir créé un rapport, vous pouvez choisir de le partager avec le public dès que le début de la phase.",
   "app.containers.Admin.projects.project.information.ReportTab.createAMoreComplex": "créer une page plus élaborée pour le partage d'informations.",

--- a/front/app/translations/admin/hr-HR.json
+++ b/front/app/translations/admin/hr-HR.json
@@ -1051,7 +1051,6 @@
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "Ovo je sadržaj generiran umjetnom inteligencijom. Možda nije 100% točno. Pregledajte i usporedite sa stvarnim unosima radi točnosti. Imajte na umu da će se točnost vjerojatno poboljšati ako se smanji broj odabranih ulaza.",
   "app.containers.Admin.projects.project.ideas.analysisAction1": "Otvorena AI analiza",
   "app.containers.Admin.projects.project.ideas.analysisText2": "Istražite sažetke koje pokreće AI i pregledajte pojedinačne podneske.",
-  "app.containers.Admin.projects.project.ideas.analysisUpsellTooltip": "Ova značajka nije uključena u vaš trenutni plan. Razgovarajte sa svojim upraviteljem uspjeha vlade ili administratorom da ga otključate.",
   "app.containers.Admin.projects.project.ideas.importInputs": "Uvoz",
   "app.containers.Admin.projects.project.information.ReportTab.afterCreating": "Nakon što izradite izvješće, možete ga podijeliti s javnošću nakon što faza započne.",
   "app.containers.Admin.projects.project.information.ReportTab.createAMoreComplex": "Napravite složeniju stranicu za razmjenu informacija",

--- a/front/app/translations/admin/lt-LT.json
+++ b/front/app/translations/admin/lt-LT.json
@@ -1051,7 +1051,6 @@
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "Tai dirbtinio intelekto sukurtas turinys. Jis gali būti ne 100 % tikslus. Peržiūrėkite ir palyginkite su faktiniais įvesties duomenimis, kad įsitikintumėte tikslumu. Turėkite omenyje, kad tikslumas greičiausiai padidės, jei sumažės pasirinktų įvesties duomenų skaičius.",
   "app.containers.Admin.projects.project.ideas.analysisAction1": "Atvira AI analizė",
   "app.containers.Admin.projects.project.ideas.analysisText2": "Peržiūrėkite dirbtinio intelekto valdomas santraukas ir peržiūrėkite atskiras paraiškas.",
-  "app.containers.Admin.projects.project.ideas.analysisUpsellTooltip": "Ši funkcija neįtraukta į dabartinį planą. Norėdami ją atrakinti, pasitarkite su savo Vyriausybės sėkmės vadybininku arba administratoriumi.",
   "app.containers.Admin.projects.project.ideas.importInputs": "Importas",
   "app.containers.Admin.projects.project.information.ReportTab.afterCreating": "Sukūrę ataskaitą, galite pasirinkti, kad prasidėjus etapui ja dalytumėtės su visuomene.",
   "app.containers.Admin.projects.project.information.ReportTab.createAMoreComplex": "Sukurti sudėtingesnį informacijos dalijimosi puslapį",

--- a/front/app/translations/admin/lv-LV.json
+++ b/front/app/translations/admin/lv-LV.json
@@ -1051,7 +1051,6 @@
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "Šis ir mākslīgā intelekta radīts saturs. Tas var nebūt 100% precīzs. Lūdzu, pārbaudiet un salīdziniet ar faktiskajiem ievades datiem, lai pārliecinātos par precizitāti. Ņemiet vērā, ka precizitāte, visticamāk, uzlabosies, ja izvēlēto ievades datu skaits tiks samazināts.",
   "app.containers.Admin.projects.project.ideas.analysisAction1": "Atvērtā AI analīze",
   "app.containers.Admin.projects.project.ideas.analysisText2": "Izpētiet ar mākslīgo intelektu darbināmus kopsavilkumus un apskatiet atsevišķus iesniegumus.",
-  "app.containers.Admin.projects.project.ideas.analysisUpsellTooltip": "Šī funkcija nav iekļauta jūsu pašreizējā plānā. Lai to atbloķētu, sazinieties ar savu valdības veiksmes menedžeri vai administratoru.",
   "app.containers.Admin.projects.project.ideas.importInputs": "Importēt",
   "app.containers.Admin.projects.project.information.ReportTab.afterCreating": "Pēc ziņojuma izveides varat izvēlēties to kopīgot ar sabiedrību, tiklīdz posms ir sācies.",
   "app.containers.Admin.projects.project.information.ReportTab.createAMoreComplex": "Sarežģītākas informācijas kopīgošanas lapas izveide",

--- a/front/app/translations/admin/nb-NO.json
+++ b/front/app/translations/admin/nb-NO.json
@@ -1051,7 +1051,6 @@
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "Dette er AI-generert innhold. Det er ikke sikkert at det er 100 % nøyaktig. Vennligst se gjennom og kryssreferer med de faktiske inndataene for å sikre nøyaktighet. Vær oppmerksom på at nøyaktigheten sannsynligvis vil bli bedre hvis antallet valgte inndata reduseres.",
   "app.containers.Admin.projects.project.ideas.analysisAction1": "Åpen AI-analyse",
   "app.containers.Admin.projects.project.ideas.analysisText2": "Utforsk AI-drevne sammendrag og se individuelle bidrag.",
-  "app.containers.Admin.projects.project.ideas.analysisUpsellTooltip": "Denne funksjonen er ikke inkludert i din nåværende plan. Snakk med din Government Success Manager eller administrator for å låse den opp.",
   "app.containers.Admin.projects.project.ideas.importInputs": "Import",
   "app.containers.Admin.projects.project.information.ReportTab.afterCreating": "Når du har opprettet en rapport, kan du velge å dele den med offentligheten når fasen starter.",
   "app.containers.Admin.projects.project.information.ReportTab.createAMoreComplex": "Opprett en mer kompleks side for informasjonsdeling",

--- a/front/app/translations/admin/nl-BE.json
+++ b/front/app/translations/admin/nl-BE.json
@@ -1051,7 +1051,6 @@
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "Dit is AI-gegenereerde inhoud. Het is mogelijk niet 100% nauwkeurig. Controleer de nauwkeurigheid door te vergelijken met de werkelijke bijdragen. Houd er rekening mee dat de nauwkeurigheid waarschijnlijk verbetert als het aantal geselecteerde bijdragen wordt verminderd.",
   "app.containers.Admin.projects.project.ideas.analysisAction1": "Open AI-analyse",
   "app.containers.Admin.projects.project.ideas.analysisText2": "Ontdek samenvattingen op basis van AI en bekijk individuele inzendingen.",
-  "app.containers.Admin.projects.project.ideas.analysisUpsellTooltip": "Deze functionaliteit is niet in je huidige abonnement inbegrepen. Neem contact op met je Government Success Manager of platformbeheerder om deze functionaliteit te ontgrendelen.",
   "app.containers.Admin.projects.project.ideas.importInputs": "Importeren",
   "app.containers.Admin.projects.project.information.ReportTab.afterCreating": "Nadat je een rapport hebt gemaakt, kun je ervoor kiezen om het met het publiek te delen zodra de fase begint.",
   "app.containers.Admin.projects.project.information.ReportTab.createAMoreComplex": "Een complexere pagina te maken om informatie te delen",

--- a/front/app/translations/admin/nl-NL.json
+++ b/front/app/translations/admin/nl-NL.json
@@ -1051,7 +1051,6 @@
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "Dit is AI-gegenereerde inhoud. Het is mogelijk niet 100% nauwkeurig. Controleer de nauwkeurigheid door te vergelijken met de werkelijke bijdragen. Houd er rekening mee dat de nauwkeurigheid waarschijnlijk verbetert als het aantal geselecteerde bijdragen wordt verminderd.",
   "app.containers.Admin.projects.project.ideas.analysisAction1": "Open AI-analyse",
   "app.containers.Admin.projects.project.ideas.analysisText2": "Ontdek samenvattingen op basis van AI en bekijk individuele inzendingen.",
-  "app.containers.Admin.projects.project.ideas.analysisUpsellTooltip": "Deze functionaliteit is niet in je huidige abonnement inbegrepen. Neem contact op met je Government Success Manager of platformbeheerder om deze functionaliteit te ontgrendelen.",
   "app.containers.Admin.projects.project.ideas.importInputs": "Importeren",
   "app.containers.Admin.projects.project.information.ReportTab.afterCreating": "Nadat je een rapport hebt gemaakt, kun je ervoor kiezen om het met het publiek te delen zodra de fase begint.",
   "app.containers.Admin.projects.project.information.ReportTab.createAMoreComplex": "Een complexere pagina te maken om informatie te delen",

--- a/front/app/translations/admin/pa-IN.json
+++ b/front/app/translations/admin/pa-IN.json
@@ -1051,7 +1051,6 @@
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "ਇਹ AI ਦੁਆਰਾ ਤਿਆਰ ਕੀਤੀ ਸਮੱਗਰੀ ਹੈ। ਇਹ 100% ਸਹੀ ਨਹੀਂ ਹੋ ਸਕਦਾ। ਕਿਰਪਾ ਕਰਕੇ ਸਮੀਖਿਆ ਕਰੋ ਅਤੇ ਸ਼ੁੱਧਤਾ ਲਈ ਅਸਲ ਇਨਪੁਟਸ ਦੇ ਨਾਲ ਅੰਤਰ-ਸੰਦਰਭ ਕਰੋ। ਧਿਆਨ ਰੱਖੋ ਕਿ ਜੇਕਰ ਚੁਣੇ ਗਏ ਇਨਪੁਟਸ ਦੀ ਗਿਣਤੀ ਘਟਾਈ ਜਾਂਦੀ ਹੈ ਤਾਂ ਸ਼ੁੱਧਤਾ ਵਿੱਚ ਸੁਧਾਰ ਹੋਣ ਦੀ ਸੰਭਾਵਨਾ ਹੈ।",
   "app.containers.Admin.projects.project.ideas.analysisAction1": "ਓਪਨ ਏਆਈ ਵਿਸ਼ਲੇਸ਼ਣ",
   "app.containers.Admin.projects.project.ideas.analysisText2": "AI-ਸੰਚਾਲਿਤ ਸਾਰਾਂਸ਼ਾਂ ਦੀ ਪੜਚੋਲ ਕਰੋ ਅਤੇ ਵਿਅਕਤੀਗਤ ਸਬਮਿਸ਼ਨਾਂ ਵੇਖੋ।",
-  "app.containers.Admin.projects.project.ideas.analysisUpsellTooltip": "ਇਹ ਵਿਸ਼ੇਸ਼ਤਾ ਤੁਹਾਡੀ ਮੌਜੂਦਾ ਯੋਜਨਾ ਵਿੱਚ ਸ਼ਾਮਲ ਨਹੀਂ ਹੈ। ਇਸਨੂੰ ਅਨਲੌਕ ਕਰਨ ਲਈ ਆਪਣੇ ਸਰਕਾਰੀ ਸਫਲਤਾ ਪ੍ਰਬੰਧਕ ਜਾਂ ਪ੍ਰਸ਼ਾਸਕ ਨਾਲ ਗੱਲ ਕਰੋ।",
   "app.containers.Admin.projects.project.ideas.importInputs": "ਆਯਾਤ ਕਰੋ",
   "app.containers.Admin.projects.project.information.ReportTab.afterCreating": "ਰਿਪੋਰਟ ਬਣਾਉਣ ਤੋਂ ਬਾਅਦ, ਪੜਾਅ ਸ਼ੁਰੂ ਹੋਣ 'ਤੇ ਤੁਸੀਂ ਇਸਨੂੰ ਜਨਤਾ ਨਾਲ ਸਾਂਝਾ ਕਰਨਾ ਚੁਣ ਸਕਦੇ ਹੋ।",
   "app.containers.Admin.projects.project.information.ReportTab.createAMoreComplex": "ਜਾਣਕਾਰੀ ਸਾਂਝੀ ਕਰਨ ਲਈ ਇੱਕ ਹੋਰ ਗੁੰਝਲਦਾਰ ਪੰਨਾ ਬਣਾਓ",

--- a/front/app/translations/admin/pl-PL.json
+++ b/front/app/translations/admin/pl-PL.json
@@ -1051,7 +1051,6 @@
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "To jest zawartość generowana przez sztuczną inteligencję. Może ona nie być w 100% dokładna. Sprawdź i porównaj z rzeczywistymi danymi wejściowymi pod kątem dokładności. Pamiętaj, że dokładność prawdopodobnie poprawi się, jeśli liczba wybranych danych wejściowych zostanie zmniejszona.",
   "app.containers.Admin.projects.project.ideas.analysisAction1": "Otwarta analiza sztucznej inteligencji",
   "app.containers.Admin.projects.project.ideas.analysisText2": "Przeglądaj podsumowania oparte na sztucznej inteligencji i przeglądaj poszczególne zgłoszenia.",
-  "app.containers.Admin.projects.project.ideas.analysisUpsellTooltip": "Ta funkcja nie jest uwzględniona w Twoim bieżącym planie. Porozmawiaj ze swoim Government Success Managerem lub administratorem, aby ją odblokować.",
   "app.containers.Admin.projects.project.ideas.importInputs": "Import",
   "app.containers.Admin.projects.project.information.ReportTab.afterCreating": "Po utworzeniu raportu możesz udostępnić go publicznie po rozpoczęciu fazy.",
   "app.containers.Admin.projects.project.information.ReportTab.createAMoreComplex": "Utwórz bardziej złożoną stronę do udostępniania informacji",

--- a/front/app/translations/admin/pt-BR.json
+++ b/front/app/translations/admin/pt-BR.json
@@ -1051,7 +1051,6 @@
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "Este é um conteúdo gerado por IA. Ele pode não ser 100% preciso. Revise e faça referência cruzada com os inputs reais para verificar a precisão. Lembre-se de que a precisão provavelmente melhorará se o número de entradas selecionadas for reduzido.",
   "app.containers.Admin.projects.project.ideas.analysisAction1": "Análise de IA aberta",
   "app.containers.Admin.projects.project.ideas.analysisText2": "Explore resumos com tecnologia de IA e visualize envios individuais.",
-  "app.containers.Admin.projects.project.ideas.analysisUpsellTooltip": "Esse recurso não está incluído em seu plano atual. Fale com seu gerente de sucesso do governo ou administrador para desbloqueá-lo.",
   "app.containers.Admin.projects.project.ideas.importInputs": "Importação",
   "app.containers.Admin.projects.project.information.ReportTab.afterCreating": "Depois de criar um relatório, você pode optar por compartilhá-lo com o público assim que a fase começar.",
   "app.containers.Admin.projects.project.information.ReportTab.createAMoreComplex": "Criar uma página mais complexa para o compartilhamento de informações",

--- a/front/app/translations/admin/sr-Latn.json
+++ b/front/app/translations/admin/sr-Latn.json
@@ -1051,7 +1051,6 @@
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "This is AI-generated content. It may not be 100% accurate. Please review and cross-reference with the actual inputs for accuracy. Be aware that the accuracy is likely to improve if the number of selected inputs is reduced.",
   "app.containers.Admin.projects.project.ideas.analysisAction1": "Open AI analysis",
   "app.containers.Admin.projects.project.ideas.analysisText2": "Explore AI-powered summaries and view individual submissions.",
-  "app.containers.Admin.projects.project.ideas.analysisUpsellTooltip": "This feature is not included in your current plan. Talk to your Government Success Manager or admin to unlock it.",
   "app.containers.Admin.projects.project.ideas.importInputs": "Import",
   "app.containers.Admin.projects.project.information.ReportTab.afterCreating": "After creating a report, you can choose to share it with the public once the phase starts.",
   "app.containers.Admin.projects.project.information.ReportTab.createAMoreComplex": "Create a more complex page for information sharing",

--- a/front/app/translations/admin/sr-SP.json
+++ b/front/app/translations/admin/sr-SP.json
@@ -1051,7 +1051,6 @@
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "This is AI-generated content. It may not be 100% accurate. Please review and cross-reference with the actual inputs for accuracy. Be aware that the accuracy is likely to improve if the number of selected inputs is reduced.",
   "app.containers.Admin.projects.project.ideas.analysisAction1": "Open AI analysis",
   "app.containers.Admin.projects.project.ideas.analysisText2": "Explore AI-powered summaries and view individual submissions.",
-  "app.containers.Admin.projects.project.ideas.analysisUpsellTooltip": "This feature is not included in your current plan. Talk to your Government Success Manager or admin to unlock it.",
   "app.containers.Admin.projects.project.ideas.importInputs": "Import",
   "app.containers.Admin.projects.project.information.ReportTab.afterCreating": "After creating a report, you can choose to share it with the public once the phase starts.",
   "app.containers.Admin.projects.project.information.ReportTab.createAMoreComplex": "Create a more complex page for information sharing",

--- a/front/app/translations/admin/sv-SE.json
+++ b/front/app/translations/admin/sv-SE.json
@@ -1051,7 +1051,6 @@
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "Detta är AI-genererat innehåll. Det kanske inte är 100% korrekt. Vänligen granska och korsreferera med de faktiska indata för noggrannhet. Observera att noggrannheten sannolikt kommer att förbättras om antalet valda indata minskas.",
   "app.containers.Admin.projects.project.ideas.analysisAction1": "Öppen AI-analys",
   "app.containers.Admin.projects.project.ideas.analysisText2": "Utforska AI-drivna sammanfattningar och se enskilda bidrag.",
-  "app.containers.Admin.projects.project.ideas.analysisUpsellTooltip": "Den här funktionen ingår inte i din nuvarande plan. Prata med din Government Success Manager eller administratör för att låsa upp den.",
   "app.containers.Admin.projects.project.ideas.importInputs": "Import",
   "app.containers.Admin.projects.project.information.ReportTab.afterCreating": "När du har skapat en rapport kan du välja att dela den med allmänheten när fasen startar.",
   "app.containers.Admin.projects.project.information.ReportTab.createAMoreComplex": "Skapa en mer komplex sida för informationsdelning",

--- a/front/app/translations/admin/tr-TR.json
+++ b/front/app/translations/admin/tr-TR.json
@@ -1051,7 +1051,6 @@
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "Bu yapay zeka tarafından oluşturulmuş bir içeriktir. 100 doğru olmayabilir. Lütfen doğruluk için gerçek girdileri gözden geçirin ve çapraz referans alın. Seçilen girdilerin sayısı azaltılırsa doğruluğun muhtemelen artacağını unutmayın.",
   "app.containers.Admin.projects.project.ideas.analysisAction1": "Açık yapay zeka analizi",
   "app.containers.Admin.projects.project.ideas.analysisText2": "Yapay zeka destekli özetleri keşfedin ve bireysel başvuruları görüntüleyin.",
-  "app.containers.Admin.projects.project.ideas.analysisUpsellTooltip": "Bu özellik mevcut planınıza dahil değildir. Kilidi açmak için Kamu Başarı Yöneticinizle veya yöneticinizle konuşun.",
   "app.containers.Admin.projects.project.ideas.importInputs": "İthalat",
   "app.containers.Admin.projects.project.information.ReportTab.afterCreating": "Bir rapor oluşturduktan sonra, aşama başladığında bunu kamuoyu ile paylaşmayı seçebilirsiniz.",
   "app.containers.Admin.projects.project.information.ReportTab.createAMoreComplex": "Bilgi paylaşımı için daha karmaşık bir sayfa oluşturun",

--- a/front/app/translations/admin/ur-PK.json
+++ b/front/app/translations/admin/ur-PK.json
@@ -1051,7 +1051,6 @@
   "app.containers.Admin.projects.project.analysis.aiSummaryTooltipText": "یہ AI سے تیار کردہ مواد ہے۔ یہ 100% درست نہیں ہو سکتا۔ براہ کرم جائزہ لیں اور درستگی کے لیے اصل آدانوں کے ساتھ کراس حوالہ دیں۔ آگاہ رہیں کہ اگر منتخب کردہ آدانوں کی تعداد کم کردی جاتی ہے تو درستگی بہتر ہونے کا امکان ہے۔",
   "app.containers.Admin.projects.project.ideas.analysisAction1": "AI تجزیہ کھولیں۔",
   "app.containers.Admin.projects.project.ideas.analysisText2": "AI سے چلنے والے خلاصے دریافت کریں اور انفرادی گذارشات دیکھیں۔",
-  "app.containers.Admin.projects.project.ideas.analysisUpsellTooltip": "یہ خصوصیت آپ کے موجودہ پلان میں شامل نہیں ہے۔ اسے غیر مقفل کرنے کے لیے اپنے حکومتی کامیابی کے مینیجر یا منتظم سے بات کریں۔",
   "app.containers.Admin.projects.project.ideas.importInputs": "درآمد کریں۔",
   "app.containers.Admin.projects.project.information.ReportTab.afterCreating": "رپورٹ بنانے کے بعد، مرحلہ شروع ہونے کے بعد آپ اسے عوام کے ساتھ شیئر کرنے کا انتخاب کر سکتے ہیں۔",
   "app.containers.Admin.projects.project.information.ReportTab.createAMoreComplex": "معلومات کے اشتراک کے لیے مزید پیچیدہ صفحہ بنائیں",


### PR DESCRIPTION
I thought the icons looked a bit off:
- The sparkles icon doesn't hint at the functionality of the text next to it (which is a link/button). Additionally, using the same icon twice doesn't look as visually appealing. 
- When the feature is not allowed, the lock is not necessary if the link/button is already visibly disabled + has a tooltip on hover.

Also did some code clean-up. :)

Before:

Allowed
<img width="986" alt="Screenshot 2025-04-29 at 08 19 10" src="https://github.com/user-attachments/assets/24d88df6-616c-4883-8163-85d643985c71" />

Not allowed
<img width="1034" alt="image" src="https://github.com/user-attachments/assets/8b765d40-b817-40b0-8723-3298c67ee958" />

After:

Allowed
<img width="990" alt="Screenshot 2025-04-29 at 08 19 29" src="https://github.com/user-attachments/assets/9c0d81f6-a9bb-45b2-b1f1-2e3746ea3257" />

Not allowed
<img width="1018" alt="image" src="https://github.com/user-attachments/assets/bfaf15ec-22ba-439d-9c5b-9de542dd4c96" />


# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Changed
- Input manager: icon to go to AI analysis ([before/after](https://github.com/CitizenLabDotCo/citizenlab/pull/10887))