### PR TITLE
[TAN-4469] Avoid sending mails related to old activities

### DIFF
--- a/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/activity_triggerable.rb
+++ b/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/activity_triggerable.rb
@@ -6,10 +6,19 @@ module EmailCampaigns
 
     included do
       before_send :filter_activity_triggered
+      before_send :filter_activity_too_old
     end
 
     def filter_activity_triggered(activity:, time: nil)
       activity && activity_triggers.dig(activity.item_type, activity.action)
+    end
+
+    # Skip activities that are older than a reasonable threshold
+    # to prevent reprocessing of old activities
+    def filter_activity_too_old(activity:, time: nil)
+      return false if activity.nil?
+
+      activity.acted_at >= 7.days.ago
     end
   end
 end

--- a/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/activity_triggerable.rb
+++ b/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/activity_triggerable.rb
@@ -18,7 +18,25 @@ module EmailCampaigns
     def filter_activity_too_old(activity:, time: nil)
       return false if activity.nil?
 
-      activity.acted_at >= 7.days.ago
+      # Only report if the activity is actually too old
+      # Report so that we can examine the backtraces to get more context
+      # on why this is happening (see: TAN-4469)
+      if activity.acted_at < 7.days.ago
+        ErrorReporter.report_msg(
+          "ActivityTriggerable attempted to process an old activity",
+          extra: {
+            activity_id: activity.id,
+            activity_type: activity.item_type,
+            activity_action: activity.action,
+            activity_acted_at: activity.acted_at,
+            campaign_id: id,
+            campaign_type: self.class.name
+          }
+        )
+        return false
+      end
+
+      true
     end
   end
 end

--- a/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/activity_triggerable.rb
+++ b/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/activity_triggerable.rb
@@ -23,7 +23,7 @@ module EmailCampaigns
       # on why this is happening (see: TAN-4469)
       if activity.acted_at < 7.days.ago
         ErrorReporter.report_msg(
-          "ActivityTriggerable attempted to process an old activity",
+          'ActivityTriggerable attempted to process an old activity',
           extra: {
             activity_id: activity.id,
             activity_type: activity.item_type,

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/concerns/activity_triggerable_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/concerns/activity_triggerable_spec.rb
@@ -31,5 +31,14 @@ RSpec.describe EmailCampaigns::ActivityTriggerable do
     it 'returns false if no activity is specified' do
       expect(campaign.run_before_send_hooks).to be_falsy
     end
+
+    it 'returns false if the activity acted_at is more than 7 days ago' do
+      activity = create(:published_activity, acted_at: 8.days.ago)
+      campaign.activity_triggers = {
+        'Idea' => { 'published' => true }
+      }
+
+      expect(campaign.run_before_send_hooks(activity: activity)).to be_falsy
+    end
   end
 end

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/concerns/activity_triggerable_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/concerns/activity_triggerable_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe EmailCampaigns::ActivityTriggerable do
       }
 
       expect(ErrorReporter).to receive(:report_msg).with(
-        "ActivityTriggerable attempted to process an old activity",
+        'ActivityTriggerable attempted to process an old activity',
         extra: {
           activity_id: activity.id,
           activity_type: activity.item_type,


### PR DESCRIPTION
This is not a great 'fix' as it only prevents the majority of such cases, without understanding (or resolving) the cause of such reprocessing of old activities re-triggering a campaign delivery.

It does, however, also add Sentry logging, in the hope that the error log will provide more context/clues as to the mechanism that causes the issue.

Discussed with Koen today, and we felt this approach is probably wiser than spending too much more time on trying to discover the root cause.

See ticket for a few more details.

# Changelog
## Fixed
- [TAN-4469] Avoid sending mails related to old activities. A quick fix for now, while we investigate further.
