### PR TITLE
Add option to not allow creating links in Quill editor

### DIFF
--- a/front/app/components/UI/QuillEditor/Toolbar.tsx
+++ b/front/app/components/UI/QuillEditor/Toolbar.tsx
@@ -50,6 +50,7 @@ interface Props {
   noImages?: boolean;
   noVideos?: boolean;
   noAlign?: boolean;
+  noLinks?: boolean;
   editor: Quill | null;
   setIsButtonsMenuVisible: React.Dispatch<React.SetStateAction<boolean>>;
 }
@@ -62,6 +63,7 @@ const Toolbar = ({
   noImages,
   noVideos,
   noAlign,
+  noLinks,
   editor,
   setIsButtonsMenuVisible,
 }: Props) => {
@@ -183,7 +185,7 @@ const Toolbar = ({
           onClick={trackBasic('italic')}
           aria-label={formatMessage(messages.italic)}
         />
-        {withCTAButton ? (
+        {withCTAButton && (
           <Tooltip
             placement="bottom"
             theme="light"
@@ -219,7 +221,8 @@ const Toolbar = ({
               </svg>
             </button>
           </Tooltip>
-        ) : (
+        )}
+        {!withCTAButton && !noLinks && (
           <button
             className="ql-link"
             onClick={trackBasic('link')}

--- a/front/app/components/UI/QuillEditor/Toolbar.tsx
+++ b/front/app/components/UI/QuillEditor/Toolbar.tsx
@@ -185,49 +185,52 @@ const Toolbar = ({
           onClick={trackBasic('italic')}
           aria-label={formatMessage(messages.italic)}
         />
-        {withCTAButton && (
-          <Tooltip
-            placement="bottom"
-            theme="light"
-            visible={isButtonsMenuVisible}
-            onClickOutside={hideButtonsMenu}
-            duration={[200, 0]}
-            content={
-              <DropdownList>
-                <DropdownListItem onClick={handleCustomLink} type="button">
-                  {formatMessage(messages.customLink)}
-                </DropdownListItem>
-                <DropdownListItem
-                  onClick={handleNormalLink}
-                  type="button"
-                  className="ql-link"
-                >
-                  {formatMessage(messages.link)}
-                </DropdownListItem>
-              </DropdownList>
-            }
-          >
-            <button type="button" onClick={toggleButtonsMenu}>
-              <svg viewBox="0 0 18 18">
-                <line className="ql-stroke" x1="7" x2="11" y1="7" y2="11" />
-                <path
-                  className="ql-even ql-stroke"
-                  d="M8.9,4.577a3.476,3.476,0,0,1,.36,4.679A3.476,3.476,0,0,1,4.577,8.9C3.185,7.5,2.035,6.4,4.217,4.217S7.5,3.185,8.9,4.577Z"
-                />
-                <path
-                  className="ql-even ql-stroke"
-                  d="M13.423,9.1a3.476,3.476,0,0,0-4.679-.36,3.476,3.476,0,0,0,.36,4.679c1.392,1.392,2.5,2.542,4.679.36S14.815,10.5,13.423,9.1Z"
-                />
-              </svg>
-            </button>
-          </Tooltip>
-        )}
-        {!withCTAButton && !noLinks && (
-          <button
-            className="ql-link"
-            onClick={trackBasic('link')}
-            aria-label={formatMessage(messages.link)}
-          />
+        {!noLinks && (
+          <>
+            {withCTAButton ? (
+              <Tooltip
+                placement="bottom"
+                theme="light"
+                visible={isButtonsMenuVisible}
+                onClickOutside={hideButtonsMenu}
+                duration={[200, 0]}
+                content={
+                  <DropdownList>
+                    <DropdownListItem onClick={handleCustomLink} type="button">
+                      {formatMessage(messages.customLink)}
+                    </DropdownListItem>
+                    <DropdownListItem
+                      onClick={handleNormalLink}
+                      type="button"
+                      className="ql-link"
+                    >
+                      {formatMessage(messages.link)}
+                    </DropdownListItem>
+                  </DropdownList>
+                }
+              >
+                <button type="button" onClick={toggleButtonsMenu}>
+                  <svg viewBox="0 0 18 18">
+                    <line className="ql-stroke" x1="7" x2="11" y1="7" y2="11" />
+                    <path
+                      className="ql-even ql-stroke"
+                      d="M8.9,4.577a3.476,3.476,0,0,1,.36,4.679A3.476,3.476,0,0,1,4.577,8.9C3.185,7.5,2.035,6.4,4.217,4.217S7.5,3.185,8.9,4.577Z"
+                    />
+                    <path
+                      className="ql-even ql-stroke"
+                      d="M13.423,9.1a3.476,3.476,0,0,0-4.679-.36,3.476,3.476,0,0,0,.36,4.679c1.392,1.392,2.5,2.542,4.679.36S14.815,10.5,13.423,9.1Z"
+                    />
+                  </svg>
+                </button>
+              </Tooltip>
+            ) : (
+              <button
+                className="ql-link"
+                onClick={trackBasic('link')}
+                aria-label={formatMessage(messages.link)}
+              />
+            )}
+          </>
         )}
       </span>
 

--- a/front/app/components/UI/QuillEditor/Toolbar.tsx
+++ b/front/app/components/UI/QuillEditor/Toolbar.tsx
@@ -47,10 +47,10 @@ interface Props {
   limitedTextFormatting?: boolean;
   withCTAButton?: boolean;
   isButtonsMenuVisible: boolean;
-  noImages?: boolean;
-  noVideos?: boolean;
-  noAlign?: boolean;
-  noLinks?: boolean;
+  noImages: boolean;
+  noVideos: boolean;
+  noAlign: boolean;
+  noLinks: boolean;
   editor: Quill | null;
   setIsButtonsMenuVisible: React.Dispatch<React.SetStateAction<boolean>>;
 }

--- a/front/app/components/UI/QuillEditor/createQuill.ts
+++ b/front/app/components/UI/QuillEditor/createQuill.ts
@@ -10,6 +10,7 @@ interface Params {
   noAlign?: boolean;
   limitedTextFormatting?: boolean;
   withCTAButton?: boolean;
+  noLinks?: boolean;
   onBlur?: () => void;
 }
 
@@ -22,6 +23,7 @@ export const createQuill = (
     noAlign,
     noImages,
     noVideos,
+    noLinks,
     withCTAButton,
     onBlur,
   }: Params
@@ -31,7 +33,7 @@ export const createQuill = (
     formats: [
       'bold',
       'italic',
-      'link',
+      ...(!noLinks ? ['link'] : []),
       ...attributes,
       ...(withCTAButton ? ['button'] : []),
       ...(!limitedTextFormatting ? ['header', 'list'] : []),

--- a/front/app/components/UI/QuillEditor/createQuill.ts
+++ b/front/app/components/UI/QuillEditor/createQuill.ts
@@ -5,12 +5,12 @@ import { attributes } from './altTextToImagesModule';
 interface Params {
   id: string;
   toolbarId?: string;
-  noImages?: boolean;
-  noVideos?: boolean;
-  noAlign?: boolean;
+  noImages: boolean;
+  noVideos: boolean;
+  noAlign: boolean;
   limitedTextFormatting?: boolean;
   withCTAButton?: boolean;
-  noLinks?: boolean;
+  noLinks: boolean;
   onBlur?: () => void;
 }
 

--- a/front/app/components/UI/QuillEditor/createQuill.ts
+++ b/front/app/components/UI/QuillEditor/createQuill.ts
@@ -4,7 +4,7 @@ import { attributes } from './altTextToImagesModule';
 
 interface Params {
   id: string;
-  toolbarId?: string;
+  toolbarId: string;
   noImages: boolean;
   noVideos: boolean;
   noAlign: boolean;
@@ -44,7 +44,7 @@ export const createQuill = (
     modules: {
       altTextToImages: true,
       blotFormatter: !noImages || !noVideos,
-      toolbar: toolbarId ? `#${toolbarId}` : false,
+      toolbar: `#${toolbarId}`,
       keyboard: {
         bindings: {
           // overwrite default tab behavior

--- a/front/app/components/UI/QuillEditor/index.tsx
+++ b/front/app/components/UI/QuillEditor/index.tsx
@@ -26,7 +26,6 @@ export interface Props {
   value?: string;
   label?: string | JSX.Element | null;
   labelTooltipText?: string | JSX.Element | null;
-  noToolbar?: boolean;
   noImages?: boolean;
   noVideos?: boolean;
   noAlign?: boolean;
@@ -47,11 +46,10 @@ const QuillEditor = ({
   value,
   label,
   labelTooltipText,
-  noAlign,
-  noToolbar,
-  noImages,
-  noVideos,
-  noLinks,
+  noAlign = false,
+  noImages = false,
+  noVideos = false,
+  noLinks = false,
   limitedTextFormatting,
   maxHeight,
   minHeight,
@@ -78,7 +76,7 @@ const QuillEditor = ({
     onFocusRef.current = onFocus;
   });
 
-  const toolbarId = !noToolbar ? `ql-editor-toolbar-${id}` : undefined;
+  const toolbarId = `ql-editor-toolbar-${id}`;
 
   // Initialize Quill
   // https://quilljs.com/playground/react
@@ -96,6 +94,7 @@ const QuillEditor = ({
       noImages,
       noVideos,
       noAlign,
+      noLinks,
       limitedTextFormatting,
       withCTAButton,
       onBlur: onBlurRef.current,
@@ -199,20 +198,18 @@ const QuillEditor = ({
           {labelTooltipText && <IconTooltip content={labelTooltipText} />}
         </Label>
       )}
-      {toolbarId && (
-        <Toolbar
-          id={toolbarId}
-          limitedTextFormatting={limitedTextFormatting}
-          withCTAButton={withCTAButton}
-          isButtonsMenuVisible={isButtonsMenuVisible}
-          noImages={noImages}
-          noVideos={noVideos}
-          noAlign={noAlign}
-          noLinks={noLinks}
-          editor={editor}
-          setIsButtonsMenuVisible={setIsButtonsMenuVisible}
-        />
-      )}
+      <Toolbar
+        id={toolbarId}
+        limitedTextFormatting={limitedTextFormatting}
+        withCTAButton={withCTAButton}
+        isButtonsMenuVisible={isButtonsMenuVisible}
+        noImages={noImages}
+        noVideos={noVideos}
+        noAlign={noAlign}
+        noLinks={noLinks}
+        editor={editor}
+        setIsButtonsMenuVisible={setIsButtonsMenuVisible}
+      />
       <div>
         <div ref={containerRef} />
       </div>

--- a/front/app/components/UI/QuillEditor/index.tsx
+++ b/front/app/components/UI/QuillEditor/index.tsx
@@ -30,6 +30,7 @@ export interface Props {
   noImages?: boolean;
   noVideos?: boolean;
   noAlign?: boolean;
+  noLinks?: boolean;
   limitedTextFormatting?: boolean;
   maxHeight?: string;
   minHeight?: string;
@@ -50,6 +51,7 @@ const QuillEditor = ({
   noToolbar,
   noImages,
   noVideos,
+  noLinks,
   limitedTextFormatting,
   maxHeight,
   minHeight,
@@ -206,6 +208,7 @@ const QuillEditor = ({
           noImages={noImages}
           noVideos={noVideos}
           noAlign={noAlign}
+          noLinks={noLinks}
           editor={editor}
           setIsButtonsMenuVisible={setIsButtonsMenuVisible}
         />


### PR DESCRIPTION
With noLinks:
<img width="567" alt="Screenshot 2025-05-02 at 11 10 55" src="https://github.com/user-attachments/assets/8a8064a1-607e-4377-9131-6c812c37bf33" />

With links:
<img width="578" alt="Screenshot 2025-05-02 at 11 10 46" src="https://github.com/user-attachments/assets/bd9d489f-5473-473c-af62-a0a8f3bd011f" />

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Technical
- Add `noLinks` props to QuillEditor to not allow links.