### PR TITLE
[TAN-4458] Log registration_completed activity in new after_save callback

### DIFF
--- a/back/engines/commercial/custom_maps/spec/services/custom_maps/side_fx_map_config_spec.rb
+++ b/back/engines/commercial/custom_maps/spec/services/custom_maps/side_fx_map_config_spec.rb
@@ -29,7 +29,13 @@ describe CustomMaps::SideFxMapConfigService do
       freeze_time do
         frozen_map_config = map_config.destroy
         expect { service.after_destroy(frozen_map_config, user) }
-          .to have_enqueued_job(LogActivityJob)
+          .to have_enqueued_job(LogActivityJob).with(
+            "CustomMaps::MapConfig/#{frozen_map_config.id}",
+            'deleted',
+            user,
+            anything,
+            anything
+          )
       end
     end
   end

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -1388,6 +1388,34 @@ RSpec.describe User do
     end
   end
 
+  describe 'on_registration_completed' do
+    it 'logs registration_completed_at activity when value is saved' do
+      user = create(:invited_user)
+      user.registration_completed_at = Time.now
+      
+      expect { user.save! }.to have_enqueued_job(LogActivityJob).with(
+        user,
+        'completed_registration',
+        nil,
+        user.updated_at.to_i
+      )
+    end
+
+    it 'does not log registration_completed_at activity when value not saved' do
+      user = create(:invited_user)
+      user.registration_completed_at = nil
+
+      expect { user.save! }.not_to have_enqueued_job(LogActivityJob)
+    end
+
+    it 'does not log registration_completed_at activity when value set to nil' do
+      user = create(:user)
+      user.registration_completed_at = nil
+
+      expect { user.save! }.not_to have_enqueued_job(LogActivityJob)
+    end
+  end
+
   context '(super_admins scopes)' do
     let_it_be(:super_admins) { create_list(:super_admin, 1) }
     let_it_be(:non_super_admins) do

--- a/back/spec/services/additional_seats_incrementer_spec.rb
+++ b/back/spec/services/additional_seats_incrementer_spec.rb
@@ -19,33 +19,39 @@ describe AdditionalSeatsIncrementer do
 
   describe '.increment_if_necessary' do
     it 'logs activity for admin', active_job_inline_adapter: true do
-      expect(PublishActivityToRabbitJob).to receive(:perform_later)
+      allow(PublishActivityToRabbitJob).to receive(:perform_later).and_call_original
 
       create(:admin) # to reach limit
       new_role = { 'type' => 'admin' }
       updated_user.update!(roles: [new_role])
-      expect { described_class.increment_if_necessary(updated_user, current_user) }.to change(Activity, :count).from(0).to(1)
 
-      activity = Activity.first
-      expect(activity.action).to eq('additional_admins_number_incremented')
+      expect { described_class.increment_if_necessary(updated_user, current_user) }
+        .to change(Activity.where(action: 'additional_admins_number_incremented'), :count).from(0).to(1)
+
+      activity = Activity.find_by(action: 'additional_admins_number_incremented')
       expect(activity.payload).to eq({ 'role' => new_role })
       expect(activity.item).to eq(updated_user)
       expect(activity.user).to eq(current_user)
+
+      expect(PublishActivityToRabbitJob).to have_received(:perform_later).with(activity)
     end
 
     it 'logs activity for moderator', active_job_inline_adapter: true do
-      expect(PublishActivityToRabbitJob).to receive(:perform_later)
+      allow(PublishActivityToRabbitJob).to receive(:perform_later).and_call_original
 
       create(:project_moderator) # to reach limit
       new_role = { 'type' => 'project_moderator', 'project_id' => create(:project).id }
       updated_user.update!(roles: [new_role])
-      expect { described_class.increment_if_necessary(updated_user, current_user) }.to change(Activity, :count).from(0).to(1)
 
-      activity = Activity.first
-      expect(activity.action).to eq('additional_moderators_number_incremented')
+      expect { described_class.increment_if_necessary(updated_user, current_user) }
+        .to change(Activity.where(action: 'additional_moderators_number_incremented'), :count).from(0).to(1)
+
+      activity = Activity.find_by(action: 'additional_moderators_number_incremented')
       expect(activity.payload).to eq({ 'role' => new_role })
       expect(activity.item).to eq(updated_user)
       expect(activity.user).to eq(current_user)
+
+      expect(PublishActivityToRabbitJob).to have_received(:perform_later).with(activity)
     end
 
     it 'increments additional moderator seats' do
@@ -56,8 +62,13 @@ describe AdditionalSeatsIncrementer do
         described_class.increment_if_necessary(updated_user, nil)
       end.to not_change { AppConfiguration.instance.settings['core']['additional_admins_number'] }
         .and(change { AppConfiguration.instance.settings['core']['additional_moderators_number'] }.from(0).to(1))
-
-      expect(LogActivityJob).to have_been_enqueued
+        .and(have_enqueued_job(LogActivityJob).with(
+          updated_user,
+          'additional_moderators_number_incremented',
+          nil,
+          updated_user.updated_at.to_i,
+          payload: { role: new_role }
+        ))
     end
 
     it 'increments additional admin seats' do
@@ -68,8 +79,13 @@ describe AdditionalSeatsIncrementer do
         described_class.increment_if_necessary(updated_user, nil)
       end.to change { AppConfiguration.instance.settings['core']['additional_admins_number'] }.from(0).to(1)
         .and(not_change { AppConfiguration.instance.settings['core']['additional_moderators_number'] })
-
-      expect(LogActivityJob).to have_been_enqueued
+        .and(have_enqueued_job(LogActivityJob).with(
+          updated_user,
+          'additional_admins_number_incremented',
+          nil,
+          updated_user.updated_at.to_i,
+          payload: { role: new_role }
+        ))
     end
 
     # it can happen if both moderator and admin checkboxes are checked on the bulk invite page
@@ -84,8 +100,21 @@ describe AdditionalSeatsIncrementer do
           described_class.increment_if_necessary(updated_user, nil)
         end.to change { AppConfiguration.instance.settings['core']['additional_admins_number'] }.from(0).to(1)
           .and(not_change { AppConfiguration.instance.settings['core']['additional_moderators_number'] })
+          .and(have_enqueued_job(LogActivityJob).with(
+            updated_user,
+            'additional_admins_number_incremented',
+            nil,
+            updated_user.updated_at.to_i,
+            payload: { role: { 'type' => 'admin' } }
+          ))
 
-        expect(LogActivityJob).to have_been_enqueued
+        expect(LogActivityJob).not_to have_been_enqueued.with(
+          anything,
+          'additional_moderators_number_incremented',
+          anything,
+          anything,
+          anything
+        )
       end
 
       it 'increments only admin seats when admin role goes second' do
@@ -98,8 +127,21 @@ describe AdditionalSeatsIncrementer do
           described_class.increment_if_necessary(updated_user, nil)
         end.to change { AppConfiguration.instance.settings['core']['additional_admins_number'] }.from(0).to(1)
           .and(not_change { AppConfiguration.instance.settings['core']['additional_moderators_number'] })
+          .and(have_enqueued_job(LogActivityJob).with(
+            updated_user,
+            'additional_admins_number_incremented',
+            nil,
+            updated_user.updated_at.to_i,
+            payload: { role: { 'type' => 'admin' } }
+          ))
 
-        expect(LogActivityJob).to have_been_enqueued
+        expect(LogActivityJob).not_to have_been_enqueued.with(
+          anything,
+          'additional_moderators_number_incremented',
+          anything,
+          anything,
+          anything
+        )
       end
     end
 
@@ -111,8 +153,13 @@ describe AdditionalSeatsIncrementer do
         described_class.increment_if_necessary(updated_user, nil)
       end.to change { AppConfiguration.instance.settings['core']['additional_admins_number'] }.from(0).to(1)
         .and(not_change { AppConfiguration.instance.settings['core']['additional_moderators_number'] })
-
-      expect(LogActivityJob).to have_been_enqueued
+        .and(have_enqueued_job(LogActivityJob).with(
+            updated_user,
+            'additional_admins_number_incremented',
+            nil,
+            updated_user.updated_at.to_i,
+            payload: { role: { 'type' => 'admin' } }
+          ))
 
       updated_user = create(:user)
       updated_user.update!(roles: [new_role])
@@ -120,8 +167,13 @@ describe AdditionalSeatsIncrementer do
         described_class.increment_if_necessary(updated_user, nil)
       end.to change { AppConfiguration.instance.settings['core']['additional_admins_number'] }.from(1).to(2)
         .and(not_change { AppConfiguration.instance.settings['core']['additional_moderators_number'] })
-
-      expect(LogActivityJob).to have_been_enqueued.twice
+        .and(have_enqueued_job(LogActivityJob).with(
+            updated_user,
+            'additional_admins_number_incremented',
+            nil,
+            updated_user.updated_at.to_i,
+            payload: { role: { 'type' => 'admin' } }
+          ))
     end
 
     it 'does not increment additional seats if limit is not reached' do
@@ -132,7 +184,13 @@ describe AdditionalSeatsIncrementer do
       end.to not_change { AppConfiguration.instance.settings['core']['additional_admins_number'] }
         .and(not_change { AppConfiguration.instance.settings['core']['additional_moderators_number'] })
 
-      expect(LogActivityJob).not_to have_been_enqueued
+      expect(LogActivityJob).not_to have_been_enqueued.with(
+        anything,
+        'additional_admins_number_incremented',
+        anything,
+        anything,
+        anything
+      )
     end
   end
 end

--- a/back/spec/services/reset_password_service_spec.rb
+++ b/back/spec/services/reset_password_service_spec.rb
@@ -40,8 +40,15 @@ describe ResetPasswordService do
     let(:user) { create(:user) }
     let(:token) { 'token' }
 
-    it 'schedules a LogAcitvityJob' do
-      expect { service.log_activity(user, token) }.to have_enqueued_job(LogActivityJob)
+    it 'schedules a LogActivityJob' do
+      expect { service.log_activity(user, token) }
+        .to have_enqueued_job(LogActivityJob).with(
+          user,
+          'requested_password_reset',
+          user,
+          anything,
+          payload: { token: token }
+        )
     end
   end
 end

--- a/back/spec/services/side_fx_follower_spec.rb
+++ b/back/spec/services/side_fx_follower_spec.rb
@@ -25,7 +25,13 @@ describe SideFxFollowerService do
       freeze_time do
         frozen_follower = follower.destroy
         expect { service.after_destroy(frozen_follower, user) }
-          .to enqueue_job(LogActivityJob)
+          .to enqueue_job(LogActivityJob).with(
+            "Follower/#{frozen_follower.id}",
+            'deleted',
+            user,
+            anything,
+            anything
+          )
       end
     end
 

--- a/back/spec/services/side_fx_project_service_spec.rb
+++ b/back/spec/services/side_fx_project_service_spec.rb
@@ -98,7 +98,13 @@ describe SideFxProjectService do
       freeze_time do
         frozen_project = project.destroy
         expect { service.after_destroy(frozen_project, user) }
-          .to have_enqueued_job(LogActivityJob)
+          .to have_enqueued_job(LogActivityJob).with(
+            "Project/#{frozen_project.id}",
+            'deleted',
+            user,
+            anything,
+            anything
+          )
       end
     end
 

--- a/back/spec/services/side_fx_static_page_spec.rb
+++ b/back/spec/services/side_fx_static_page_spec.rb
@@ -45,7 +45,13 @@ describe SideFxStaticPageService do
       freeze_time do
         frozen_page = page.destroy!
         expect { service.after_destroy(frozen_page, user) }
-          .to have_enqueued_job(LogActivityJob)
+          .to have_enqueued_job(LogActivityJob).with(
+            "StaticPage/#{frozen_page.id}",
+            'deleted',
+            user,
+            anything,
+            anything
+          )
       end
     end
   end

--- a/back/spec/services/side_fx_user_service_spec.rb
+++ b/back/spec/services/side_fx_user_service_spec.rb
@@ -78,12 +78,13 @@ describe SideFxUserService do
         .to have_enqueued_job(LogActivityJob).with(user, 'changed', current_user, user.updated_at.to_i)
     end
 
-    it "logs a 'completed_registration' action job when the registration is set" do
-      user.update(registration_completed_at: nil)
-      user.update(registration_completed_at: Time.now)
-      expect { service.after_update(user, current_user) }
-        .to have_enqueued_job(LogActivityJob).with(user, 'completed_registration', current_user, user.updated_at.to_i)
-    end
+    # TODO: remove
+    # it "logs a 'completed_registration' action job when the registration is set" do
+    #   user.update(registration_completed_at: nil)
+    #   user.update(registration_completed_at: Time.now)
+    #   expect { service.after_update(user, current_user) }
+    #     .to have_enqueued_job(LogActivityJob).with(user, 'completed_registration', current_user, user.updated_at.to_i)
+    # end
 
     it "logs a 'admin_rights_given' action job when user has been made admin" do
       user.update(roles: [{ 'type' => 'admin' }])
@@ -112,7 +113,12 @@ describe SideFxUserService do
       freeze_time do
         frozen_user = user.destroy
         expect { service.after_destroy(frozen_user, current_user) }
-          .to have_enqueued_job(LogActivityJob)
+          .to have_enqueued_job(LogActivityJob).with(
+            "User/#{frozen_user.id}",
+            'deleted',
+            current_user,
+            anything
+          )
       end
     end
 


### PR DESCRIPTION
EDIT: I've decided I don't like this (for 'reasons') and will probably go with the solution I'm developing in #10924

The `SideFxUser#after_update`, which was the only place we logged a 'completed_registration' activity, is generally no longer called when `registration_completed_at` is being set, as this is now done via the `ConfirmationsController` or other controller (e.g. `OmniauthCallbackController`), and thus the `UsersController#update` action is rarely involved in setting this attribute, and thus the activity has not been being created.

Sometimes, however, it appears it has been set via the `SideFxUser#after_update`. E.g. Vienna data includes a most recent 'completed_registration' activity in Oct 24, and the next most recent was in Oct 23.

Because we now seem to have multiple flows that can set the `registration_completed_at` value for a user, we felt it best to log this activity at the model level, via an `after_save` hook.

# Changelog
## Fixed
- [TAN-4458] Welcome email once again sent whenever registration completed.
