### PR TITLE
[TAN-4458] Fix welcome email not being sent

### DIFF
--- a/back/app/controllers/omniauth_callback_controller.rb
+++ b/back/app/controllers/omniauth_callback_controller.rb
@@ -84,6 +84,7 @@ class OmniauthCallbackController < ApplicationController
           @invite.save!
           SideFxInviteService.new.after_accept @invite
           verify_and_sign_in(auth, @user, verify, sign_up: true)
+          SideFxUserService.new.after_update(@user, nil)
         rescue ActiveRecord::RecordInvalid => e
           ErrorReporter.report(e)
           signin_failure_redirect
@@ -92,6 +93,7 @@ class OmniauthCallbackController < ApplicationController
       else # !@user.invite_pending?
         begin
           update_user!(auth, @user, authver_method)
+          SideFxUserService.new.after_update(@user, nil)
         rescue ActiveRecord::RecordInvalid => e
           ErrorReporter.report(e)
           signin_failure_redirect

--- a/back/app/controllers/omniauth_callback_controller.rb
+++ b/back/app/controllers/omniauth_callback_controller.rb
@@ -81,9 +81,9 @@ class OmniauthCallbackController < ApplicationController
         ActiveRecord::Base.transaction do
           SideFxInviteService.new.before_accept @invite
           @user.save!
-          SideFxUserService.new.after_update(@user, nil)
+          SideFxUserService.new.after_update(@user, nil) # Logs 'registration_completd' activity Job`
           @invite.save!
-          SideFxInviteService.new.after_accept @invite
+          SideFxInviteService.new.after_accept @invite # Logs 'accepted' activity Job
           verify_and_sign_in(auth, @user, verify, sign_up: true)
         rescue ActiveRecord::RecordInvalid => e
           ErrorReporter.report(e)

--- a/back/app/controllers/omniauth_callback_controller.rb
+++ b/back/app/controllers/omniauth_callback_controller.rb
@@ -81,7 +81,7 @@ class OmniauthCallbackController < ApplicationController
         ActiveRecord::Base.transaction do
           SideFxInviteService.new.before_accept @invite
           @user.save!
-          SideFxUserService.new.after_update(@user, nil) # Logs 'registration_completd' activity Job`
+          SideFxUserService.new.after_update(@user, nil) # Logs 'registration_completed' activity Job`
           @invite.save!
           SideFxInviteService.new.after_accept @invite # Logs 'accepted' activity Job
           verify_and_sign_in(auth, @user, verify, sign_up: true)

--- a/back/app/controllers/omniauth_callback_controller.rb
+++ b/back/app/controllers/omniauth_callback_controller.rb
@@ -81,10 +81,10 @@ class OmniauthCallbackController < ApplicationController
         ActiveRecord::Base.transaction do
           SideFxInviteService.new.before_accept @invite
           @user.save!
+          SideFxUserService.new.after_update(@user, nil)
           @invite.save!
           SideFxInviteService.new.after_accept @invite
           verify_and_sign_in(auth, @user, verify, sign_up: true)
-          SideFxUserService.new.after_update(@user, nil)
         rescue ActiveRecord::RecordInvalid => e
           ErrorReporter.report(e)
           signin_failure_redirect

--- a/back/app/controllers/web_api/v1/confirmations_controller.rb
+++ b/back/app/controllers/web_api/v1/confirmations_controller.rb
@@ -7,6 +7,15 @@ class WebApi::V1::ConfirmationsController < ApplicationController
     result = ConfirmUser.call(user: current_user, code: confirmation_params[:code])
 
     if result.success?
+      if current_user.registration_completed_at?
+        LogActivityJob.perform_later(
+          current_user,
+          'completed_registration',
+          current_user,
+          current_user.updated_at.to_i
+        )
+      end
+
       head :ok
     else
       render json: { errors: result.errors.details }, status: :unprocessable_entity

--- a/back/app/controllers/web_api/v1/confirmations_controller.rb
+++ b/back/app/controllers/web_api/v1/confirmations_controller.rb
@@ -7,14 +7,7 @@ class WebApi::V1::ConfirmationsController < ApplicationController
     result = ConfirmUser.call(user: current_user, code: confirmation_params[:code])
 
     if result.success?
-      if current_user.registration_completed_at?
-        LogActivityJob.perform_later(
-          current_user,
-          'completed_registration',
-          current_user,
-          current_user.updated_at.to_i
-        )
-      end
+      SideFxUserService.new.after_update(current_user, current_user)
 
       head :ok
     else

--- a/back/app/services/side_fx_invite_service.rb
+++ b/back/app/services/side_fx_invite_service.rb
@@ -15,6 +15,10 @@ class SideFxInviteService
   end
 
   def after_accept(invite)
+    if invite.invitee.registration_completed_at_previously_changed? # For example, when a user is created via SSO
+      LogActivityJob.perform_later(invite.invitee, 'completed_registration', invite.invitee, invite.invitee.updated_at.to_i)
+    end
+
     TrackUserJob.perform_later(invite.invitee)
     LogActivityJob.perform_later(invite, 'accepted', invite.invitee, invite.accepted_at.to_i)
     UpdateMemberCountJob.perform_later

--- a/back/app/services/side_fx_invite_service.rb
+++ b/back/app/services/side_fx_invite_service.rb
@@ -15,7 +15,7 @@ class SideFxInviteService
   end
 
   def after_accept(invite)
-    if invite.invitee.registration_completed_at_previously_changed? # For example, when a user is created via SSO
+    if invite.invitee.registration_completed_at_previously_changed?
       LogActivityJob.perform_later(invite.invitee, 'completed_registration', invite.invitee, invite.invitee.updated_at.to_i)
     end
 

--- a/back/app/services/side_fx_user_service.rb
+++ b/back/app/services/side_fx_user_service.rb
@@ -12,6 +12,11 @@ class SideFxUserService
     if user.admin?
       LogActivityJob.set(wait: 5.seconds).perform_later(user, 'admin_rights_given', current_user, user.created_at.to_i)
     end
+
+    if user.registration_completed_at # For example, when a user is created via SSO
+      LogActivityJob.perform_later(user, 'completed_registration', current_user, user.updated_at.to_i)
+    end
+  
     user.create_email_campaigns_unsubscription_token
     RequestConfirmationCodeJob.perform_now(user) if should_send_confirmation_email?(user)
     AdditionalSeatsIncrementer.increment_if_necessary(user, current_user) if user.roles_previously_changed?

--- a/back/app/services/side_fx_user_service.rb
+++ b/back/app/services/side_fx_user_service.rb
@@ -16,7 +16,7 @@ class SideFxUserService
     if user.registration_completed_at # For example, when a user is created via SSO
       LogActivityJob.perform_later(user, 'completed_registration', current_user, user.updated_at.to_i)
     end
-  
+
     user.create_email_campaigns_unsubscription_token
     RequestConfirmationCodeJob.perform_now(user) if should_send_confirmation_email?(user)
     AdditionalSeatsIncrementer.increment_if_necessary(user, current_user) if user.roles_previously_changed?

--- a/back/spec/acceptance/confirmations_spec.rb
+++ b/back/spec/acceptance/confirmations_spec.rb
@@ -71,6 +71,20 @@ resource 'Confirmations' do
         json_response = json_parse response_body
         expect(json_response).to include_response_error(:code, 'invalid')
       end
+
+      example "does not log 'completed_registration' activity when the code is invalid" do
+        # Clear any previously enqueued jobs
+        ActiveJob::Base.queue_adapter.enqueued_jobs.clear
+
+        do_request(confirmation: { code: 'badcode' })
+
+        expect(LogActivityJob).not_to have_been_enqueued.with(
+          anything,
+          'completed_registration',
+          anything,
+          anything
+        )
+      end
     end
   end
 end

--- a/back/spec/acceptance/confirmations_spec.rb
+++ b/back/spec/acceptance/confirmations_spec.rb
@@ -36,6 +36,16 @@ resource 'Confirmations' do
         assert_status 200
       end
 
+      example 'logs activity job when passed the right code' do
+        do_request(confirmation: { code: user.email_confirmation_code })
+        expect(LogActivityJob).to have_been_enqueued.with(
+          user,
+          'completed_registration',
+          user,
+          user.updated_at.to_i
+        )
+      end
+
       example 'returns an unprocessable entity status passing no code' do
         do_request(confirmation: { code: nil })
         assert_status 422

--- a/back/spec/acceptance/confirmations_spec.rb
+++ b/back/spec/acceptance/confirmations_spec.rb
@@ -36,7 +36,7 @@ resource 'Confirmations' do
         assert_status 200
       end
 
-      example 'logs activity job when passed the right code' do
+      example "logs 'completed_registration' activity job when passed the right code" do
         do_request(confirmation: { code: user.email_confirmation_code })
         expect(LogActivityJob).to have_been_enqueued.with(
           user,

--- a/back/spec/acceptance/confirmations_spec.rb
+++ b/back/spec/acceptance/confirmations_spec.rb
@@ -43,7 +43,7 @@ resource 'Confirmations' do
           'completed_registration',
           user,
           user.updated_at.to_i
-        )
+        ).exactly(1).times
       end
 
       example 'returns an unprocessable entity status passing no code' do

--- a/back/spec/acceptance/invites_spec.rb
+++ b/back/spec/acceptance/invites_spec.rb
@@ -352,7 +352,7 @@ resource 'Invites' do
           'completed_registration',
           invite.invitee,
           invite.invitee.updated_at.to_i
-        )
+        ).exactly(1).times
       end
 
       describe do

--- a/back/spec/acceptance/invites_spec.rb
+++ b/back/spec/acceptance/invites_spec.rb
@@ -346,6 +346,13 @@ resource 'Invites' do
         expect(boulettos&.dig(:attributes, :last_name)).to eq('Boulettos')
         expect(boulettos&.dig(:attributes, :invite_status)).to eq('accepted')
         expect(invite.reload.invitee.registration_completed_at).not_to be_nil
+        
+        expect(LogActivityJob).to have_been_enqueued.with(
+          invite.invitee,
+          'completed_registration',
+          invite.invitee,
+          invite.invitee.updated_at.to_i
+        )
       end
 
       describe do

--- a/back/spec/acceptance/invites_spec.rb
+++ b/back/spec/acceptance/invites_spec.rb
@@ -346,7 +346,7 @@ resource 'Invites' do
         expect(boulettos&.dig(:attributes, :last_name)).to eq('Boulettos')
         expect(boulettos&.dig(:attributes, :invite_status)).to eq('accepted')
         expect(invite.reload.invitee.registration_completed_at).not_to be_nil
-        
+
         expect(LogActivityJob).to have_been_enqueued.with(
           invite.invitee,
           'completed_registration',

--- a/back/spec/requests/google_authentication_spec.rb
+++ b/back/spec/requests/google_authentication_spec.rb
@@ -173,7 +173,7 @@ describe 'google authentication' do
         'completed_registration',
         nil,
         user.updated_at.to_i
-      )
+      ).exactly(1).times
     end
 
     it 'creates a new user with previously selected locale' do
@@ -226,6 +226,19 @@ describe 'google authentication' do
           user = User.find_by(email: 'boris.brompton@orange.uk')
           expect(user.confirmation_required?).to be(true)
         end
+
+        it "does not log 'registration_completed' activity job" do
+          get '/auth/google'
+          follow_redirect!
+          user = User.find_by(email: 'boris.brompton@orange.uk')
+
+          expect(LogActivityJob).not_to have_been_enqueued.with(
+            user,
+            'completed_registration',
+            nil,
+            user.updated_at.to_i
+          )
+        end
       end
     end
   end
@@ -252,5 +265,12 @@ describe 'google authentication' do
       user_id: user.id
     })
     expect(cookies[:cl2_jwt]).to be_present
+
+    expect(LogActivityJob).to have_been_enqueued.with(
+      user,
+      'completed_registration',
+      nil,
+      user.updated_at.to_i
+    ).exactly(1).times
   end
 end

--- a/back/spec/requests/google_authentication_spec.rb
+++ b/back/spec/requests/google_authentication_spec.rb
@@ -167,6 +167,13 @@ describe 'google authentication' do
         user_id: user.id
       })
       expect(cookies[:cl2_jwt]).to be_present
+
+      expect(LogActivityJob).to have_been_enqueued.with(
+          user,
+          'completed_registration',
+          nil,
+          user.updated_at.to_i
+        )
     end
 
     it 'creates a new user with previously selected locale' do

--- a/back/spec/requests/google_authentication_spec.rb
+++ b/back/spec/requests/google_authentication_spec.rb
@@ -233,10 +233,10 @@ describe 'google authentication' do
           user = User.find_by(email: 'boris.brompton@orange.uk')
 
           expect(LogActivityJob).not_to have_been_enqueued.with(
-            user,
+            anything,
             'completed_registration',
-            nil,
-            user.updated_at.to_i
+            anything,
+            anything
           )
         end
       end

--- a/back/spec/requests/google_authentication_spec.rb
+++ b/back/spec/requests/google_authentication_spec.rb
@@ -230,7 +230,6 @@ describe 'google authentication' do
         it "does not log 'registration_completed' activity job" do
           get '/auth/google'
           follow_redirect!
-          user = User.find_by(email: 'boris.brompton@orange.uk')
 
           expect(LogActivityJob).not_to have_been_enqueued.with(
             anything,

--- a/back/spec/requests/google_authentication_spec.rb
+++ b/back/spec/requests/google_authentication_spec.rb
@@ -169,11 +169,11 @@ describe 'google authentication' do
       expect(cookies[:cl2_jwt]).to be_present
 
       expect(LogActivityJob).to have_been_enqueued.with(
-          user,
-          'completed_registration',
-          nil,
-          user.updated_at.to_i
-        )
+        user,
+        'completed_registration',
+        nil,
+        user.updated_at.to_i
+      )
     end
 
     it 'creates a new user with previously selected locale' do


### PR DESCRIPTION
## Problem

The `SideFxUser#after_update`, which was the only place we logged a 'completed_registration' activity, is generally no longer called when `registration_completed_at` is being set, as this is now done via the `ConfirmationsController` or other controller (e.g. `OmniauthCallbackController`), and thus the `UsersController#update` action is rarely involved in setting this attribute, and thus the activity has not been being created.

Occasionally, however, it appears it has been set via the `SideFxUser#after_update`. E.g. Vienna data includes a most recent 'completed_registration' activity in Oct 24, and the next most recent was in Oct 23.

## Solution
- Add `SideFxUserService#after_update` to to `ConfirmationsController#create`. This catches case where user confirms with email confirmation code.
- Add a 'registration_completed' `LogActivityJob` to `SideFxUserService#after_create` if `registration_completed_at` was set. This catches registration via SSO (as `SideFxUserService#after_create` now added to `OmniauthCallbackController` for this case).
- Also add `SideFxUserService#after_update` to `OmniauthCallbackController` for the two cases where a user may be updated. This, at least, catches the case where a user accepts an invite via SSO.

## Notes
- I decided against adding the `LogActivityJob` in a User model `after_save` callback, (see #10914, now abandoned), as it is unconventional in our codebase, and I didn't like the idea that we could trigger a wave of emails if we ever ran a script to update `registration_completed_at` dates. The fact that I would have had to fix 38 unrelated broken tests was also a clue this was not the best approach.
- I have added acceptance tests of the SSO flows only to the google authentication spec, so that we have at least one set of such tests to catch regression. The `omniauth_callback_spec` has no tests of the `auth_callback` method, presumably because this is a callback mechanism and thus not amenable to such testing.
- @jamesspeake I am assuming that `OmniauthCallbackController#auth_callback` is always involved in any SSO user creation or update that might result in the setting of `registration_completed_at`. Is this assumption correct, or are there other SSO cases/flows we need to include?
- The inclusion of both `SideFxUserService#after_update` and `SideFxInviteService#after_accept` in the SSO invite acceptance flow will result in some duplicate job creation (e.g. `UpdateMemberCountJob`). I don't think this will result in any unwanted side-effects, and I'm not concerned about the performance hit of scheduling pairs of jobs that do the same thing, since this will only happen for individual SSO invite acceptances and thus will not happen often.

# Changelog
## Fixed
- [TAN-4458] Fix welcome email not being sent
