### PR TITLE
[TAN-4468] Return `not_reactable_status_code` permission denied reason before `user_not_signed_in`

### DIFF
--- a/back/app/services/permissions/idea_permissions_service.rb
+++ b/back/app/services/permissions/idea_permissions_service.rb
@@ -32,6 +32,9 @@ module Permissions
 
         IDEA_DENIED_REASONS[:published_after_screening] if idea.creation_phase&.prescreening_enabled && idea.published?
       else
+        # Check for idea status reason first, to avoid situations where FE presents user
+        # with what looks like a possible action, (e.g. voting), redirects user to signin flow,
+        # and then once signed in, the user finds the action is not possible.
         if action == 'reacting_idea' && IdeaStatus::REACTING_NOT_ALLOWED_CODES.include?(idea&.idea_status&.code)
           return IDEA_DENIED_REASONS[:not_reactable_status_code]
         end

--- a/back/app/services/permissions/idea_permissions_service.rb
+++ b/back/app/services/permissions/idea_permissions_service.rb
@@ -33,7 +33,7 @@ module Permissions
         IDEA_DENIED_REASONS[:published_after_screening] if idea.creation_phase&.prescreening_enabled && idea.published?
       else
         # Check for idea status reason first, to avoid situations where FE presents user
-        # with what looks like a possible action, (e.g. voting), redirects user to signin flow,
+        # with what looks like a possible action, (i.e. reacting), redirects user to signin flow,
         # and then once signed in, the user finds the action is not possible.
         if action == 'reacting_idea' && IdeaStatus::REACTING_NOT_ALLOWED_CODES.include?(idea&.idea_status&.code)
           return IDEA_DENIED_REASONS[:not_reactable_status_code]

--- a/back/app/services/permissions/idea_permissions_service.rb
+++ b/back/app/services/permissions/idea_permissions_service.rb
@@ -32,6 +32,10 @@ module Permissions
 
         IDEA_DENIED_REASONS[:published_after_screening] if idea.creation_phase&.prescreening_enabled && idea.published?
       else
+        if action == 'reacting_idea' && IdeaStatus::REACTING_NOT_ALLOWED_CODES.include?(idea.idea_status.code)
+          return IDEA_DENIED_REASONS[:not_reactable_status_code]
+        end
+
         reason = super
         return reason if reason
         return if user && UserRoleService.new.can_moderate_project?(idea.project, user)
@@ -40,11 +44,7 @@ module Permissions
         # We preserved the behaviour that was already there, but we're not
         # sure if this is the desired behaviour.
         current_phase = @timeline_service.current_phase_not_archived project
-        return IDEA_DENIED_REASONS[:idea_not_in_current_phase] if current_phase && !idea_in_current_phase?(current_phase)
-
-        if action == 'reacting_idea' && IdeaStatus::REACTING_NOT_ALLOWED_CODES.include?(idea.idea_status.code)
-          IDEA_DENIED_REASONS[:not_reactable_status_code]
-        end
+        IDEA_DENIED_REASONS[:idea_not_in_current_phase] if current_phase && !idea_in_current_phase?(current_phase)
       end
     end
 

--- a/back/app/services/permissions/idea_permissions_service.rb
+++ b/back/app/services/permissions/idea_permissions_service.rb
@@ -32,7 +32,7 @@ module Permissions
 
         IDEA_DENIED_REASONS[:published_after_screening] if idea.creation_phase&.prescreening_enabled && idea.published?
       else
-        if action == 'reacting_idea' && IdeaStatus::REACTING_NOT_ALLOWED_CODES.include?(idea.idea_status.code)
+        if action == 'reacting_idea' && IdeaStatus::REACTING_NOT_ALLOWED_CODES.include?(idea&.idea_status&.code)
           return IDEA_DENIED_REASONS[:not_reactable_status_code]
         end
 

--- a/back/spec/acceptance/ideas_spec.rb
+++ b/back/spec/acceptance/ideas_spec.rb
@@ -582,21 +582,30 @@ resource 'Ideas' do
   context 'when not logged in' do
     let(:user) { create(:user) }
     let(:project) { create(:single_phase_proposals_project) }
-    let(:ineligible_proposal) { create(
-      :idea,
-      project: project,
-      idea_status: create(:proposals_status, code: 'ineligible')
-    ) }
-    let(:expired_proposal) { create(
-      :idea,
-      project: project,
-      idea_status: create(:proposals_status, code: 'expired')
-    ) }
-    let(:proposed_proposal) { create(
-      :idea,
-      project: project,
-      idea_status: create(:proposals_status, code: 'proposed')
-    ) }
+
+    let(:ineligible_proposal) do
+      create(
+        :idea,
+        project: project,
+        idea_status: create(:proposals_status, code: 'ineligible')
+      )
+    end
+
+    let(:expired_proposal) do
+      create(
+        :idea,
+        project: project,
+        idea_status: create(:proposals_status, code: 'expired')
+      )
+    end
+
+    let(:proposed_proposal) do
+      create(
+        :idea,
+        project: project,
+        idea_status: create(:proposals_status, code: 'proposed')
+      )
+    end
 
     let(:upvote_disabled_reason) do
       response_data.dig(

--- a/back/spec/acceptance/ideas_spec.rb
+++ b/back/spec/acceptance/ideas_spec.rb
@@ -578,4 +578,57 @@ resource 'Ideas' do
       end
     end
   end
+
+  context 'when not logged in' do
+    let(:user) { create(:user) }
+    let(:project) { create(:single_phase_proposals_project) }
+    let(:ineligible_proposal) { create(
+      :idea,
+      project: project,
+      idea_status: create(:proposals_status, code: 'ineligible')
+    ) }
+    let(:expired_proposal) { create(
+      :idea,
+      project: project,
+      idea_status: create(:proposals_status, code: 'expired')
+    ) }
+    let(:proposed_proposal) { create(
+      :idea,
+      project: project,
+      idea_status: create(:proposals_status, code: 'proposed')
+    ) }
+
+    let(:upvote_disabled_reason) do
+      response_data.dig(
+        :attributes,
+        :action_descriptors,
+        :reacting_idea,
+        :up,
+        :disabled_reason
+      )
+    end
+
+    get 'web_api/v1/ideas/by_slug/:slug' do
+      example 'Includes not_reactable_status_code in response when ineligible' do
+        do_request slug: ineligible_proposal.slug
+
+        expect(status).to eq 200
+        expect(upvote_disabled_reason).to eq 'not_reactable_status_code'
+      end
+
+      example 'Includes not_reactable_status_code in response when expired' do
+        do_request slug: expired_proposal.slug
+
+        expect(status).to eq 200
+        expect(upvote_disabled_reason).to eq 'not_reactable_status_code'
+      end
+
+      example 'Includes user_not_signed_in in response when proposed' do
+        do_request slug: proposed_proposal.slug
+
+        expect(status).to eq 200
+        expect(upvote_disabled_reason).to eq 'user_not_signed_in'
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Changelog
## Fixed
- [TAN-4468] Hide vote button for ineligible & expired proposals. Technical: BE now returns `not_reactable_status_code` permission denied reason before `user_not_signed_in`.
