### PR TITLE
[TAN-3682] Fix phase titles UI bug in input manager

### DIFF
--- a/front/app/components/admin/PostManager/components/FilterSidebar/FilterRadioButton/LabelContentWrapper.tsx
+++ b/front/app/components/admin/PostManager/components/FilterSidebar/FilterRadioButton/LabelContentWrapper.tsx
@@ -13,11 +13,6 @@ const LabelContentWrapper = ({ children }: Props) => {
       width="100%"
       justifyContent="space-between"
       alignItems="center"
-      // This is needed to ensure buttons of the same height.
-      // The 'All filters' button, for example, is less tall than the phase filters
-      // that have a circled phase number.
-      // (This could perhaps be moved to phase filter specific components if it turns out the others don't need it.)
-      height="24px"
     >
       {children}
     </Box>

--- a/front/app/components/admin/PostManager/components/FilterSidebar/phases/FilterSidebarPhasesItem.tsx
+++ b/front/app/components/admin/PostManager/components/FilterSidebar/phases/FilterSidebarPhasesItem.tsx
@@ -55,6 +55,7 @@ const FilterSidebarPhasesItem = ({
         labelContent={
           <LabelContentWrapper>
             {localize(phase.attributes.title_multiloc)}
+            {/* Flex shrink needed to prevent number from becoming squished  */}
             <Box flexShrink={0}>
               <CircledPhaseNumber phaseNumber={phaseNumber} />
             </Box>

--- a/front/app/components/admin/PostManager/components/FilterSidebar/phases/FilterSidebarPhasesItem.tsx
+++ b/front/app/components/admin/PostManager/components/FilterSidebar/phases/FilterSidebarPhasesItem.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { Box } from '@citizenlab/cl2-component-library';
 import { useDrop } from 'react-dnd';
 
 import { IPhaseData } from 'api/phases/types';
@@ -54,7 +55,9 @@ const FilterSidebarPhasesItem = ({
         labelContent={
           <LabelContentWrapper>
             {localize(phase.attributes.title_multiloc)}
-            <CircledPhaseNumber phaseNumber={phaseNumber} />
+            <Box flexShrink={0}>
+              <CircledPhaseNumber phaseNumber={phaseNumber} />
+            </Box>
           </LabelContentWrapper>
         }
         id={id}


### PR DESCRIPTION
# Changelog
## Fixed
- [TAN-3682] Fix UI issue where long phase titles overlapped in Input Manager.