### PR TITLE
Add linked text responses for fields to AI analysis view

### DIFF
--- a/front/app/containers/Admin/projects/project/analysis/InputPreview/components/CustomFields/LongFieldValue/CustomFieldLongFieldValues/LinearScaleLongField.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/InputPreview/components/CustomFields/LongFieldValue/CustomFieldLongFieldValues/LinearScaleLongField.tsx
@@ -17,29 +17,38 @@ type Props = {
   input: IInputsData;
   customField: IIdeaCustomField;
   rawValue: any;
+  rawValueRelatedTextAnswer?: string;
 };
 
-const LinearScaleLongField = ({ input, customField, rawValue }: Props) => {
+const LinearScaleLongField = ({
+  input,
+  customField,
+  rawValue,
+  rawValueRelatedTextAnswer,
+}: Props) => {
   const { formatMessage } = useIntl();
 
   return (
     <Box>
-      <Title variant="h5" m="0px">
-        <T value={customField.data.attributes.title_multiloc} />
-      </Title>
-      <Box display="flex" justifyContent="flex-start" alignItems="flex-start">
-        <Text m="0">
-          {input.attributes.custom_field_values[
-            customField.data.attributes.key
-          ] || formatMessage(messages.noAnswer)}
-        </Text>
-        <Box ml="8px">
-          <FilterToggleButton
-            customFieldId={customField.data.id}
-            value={rawValue || null}
-          />
+      <Box>
+        <Title variant="h5" m="0px">
+          <T value={customField.data.attributes.title_multiloc} />
+        </Title>
+        <Box display="flex" justifyContent="flex-start" alignItems="flex-start">
+          <Text m="0">
+            {input.attributes.custom_field_values[
+              customField.data.attributes.key
+            ] || formatMessage(messages.noAnswer)}
+          </Text>
+          <Box ml="8px">
+            <FilterToggleButton
+              customFieldId={customField.data.id}
+              value={rawValue || null}
+            />
+          </Box>
         </Box>
       </Box>
+      <Text my="4px">{rawValueRelatedTextAnswer}</Text>
     </Box>
   );
 };

--- a/front/app/containers/Admin/projects/project/analysis/InputPreview/components/CustomFields/LongFieldValue/CustomFieldLongFieldValues/LinearScaleLongField.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/InputPreview/components/CustomFields/LongFieldValue/CustomFieldLongFieldValues/LinearScaleLongField.tsx
@@ -48,7 +48,9 @@ const LinearScaleLongField = ({
           </Box>
         </Box>
       </Box>
-      <Text my="4px">{rawValueRelatedTextAnswer}</Text>
+      {rawValueRelatedTextAnswer && (
+        <Text my="4px">{rawValueRelatedTextAnswer}</Text>
+      )}
     </Box>
   );
 };

--- a/front/app/containers/Admin/projects/project/analysis/InputPreview/components/CustomFields/LongFieldValue/CustomFieldLongFieldValues/MultilineTextLongField.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/InputPreview/components/CustomFields/LongFieldValue/CustomFieldLongFieldValues/MultilineTextLongField.tsx
@@ -14,20 +14,28 @@ import messages from '../../../../../messages';
 type Props = {
   input: IInputsData;
   customField: IIdeaCustomField;
+  rawValueRelatedTextAnswer?: string;
 };
 
-const MultilineTextLongField = ({ input, customField }: Props) => {
+const MultilineTextLongField = ({
+  input,
+  customField,
+  rawValueRelatedTextAnswer,
+}: Props) => {
   const { formatMessage } = useIntl();
   return (
     <Box>
-      <Title variant="h5" m="0px">
-        <T value={customField.data.attributes.title_multiloc} />
-      </Title>
-      <Text whiteSpace="pre-line">
-        {input.attributes.custom_field_values[
-          customField.data.attributes.key
-        ] || formatMessage(messages.noAnswer)}
-      </Text>
+      <Box>
+        <Title variant="h5" m="0px">
+          <T value={customField.data.attributes.title_multiloc} />
+        </Title>
+        <Text whiteSpace="pre-line">
+          {input.attributes.custom_field_values[
+            customField.data.attributes.key
+          ] || formatMessage(messages.noAnswer)}
+        </Text>
+      </Box>
+      <Text my="4px">{rawValueRelatedTextAnswer}</Text>
     </Box>
   );
 };

--- a/front/app/containers/Admin/projects/project/analysis/InputPreview/components/CustomFields/LongFieldValue/CustomFieldLongFieldValues/MultilineTextLongField.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/InputPreview/components/CustomFields/LongFieldValue/CustomFieldLongFieldValues/MultilineTextLongField.tsx
@@ -35,7 +35,9 @@ const MultilineTextLongField = ({
           ] || formatMessage(messages.noAnswer)}
         </Text>
       </Box>
-      <Text my="4px">{rawValueRelatedTextAnswer}</Text>
+      {rawValueRelatedTextAnswer && (
+        <Text my="4px">{rawValueRelatedTextAnswer}</Text>
+      )}
     </Box>
   );
 };

--- a/front/app/containers/Admin/projects/project/analysis/InputPreview/components/CustomFields/LongFieldValue/CustomFieldLongFieldValues/SelectLongField.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/InputPreview/components/CustomFields/LongFieldValue/CustomFieldLongFieldValues/SelectLongField.tsx
@@ -41,7 +41,9 @@ const SelectLongField = ({
           </Box>
         </Box>
       </Box>
-      <Text my="4px">{rawValueRelatedTextAnswer}</Text>
+      {rawValueRelatedTextAnswer && (
+        <Text my="4px">{rawValueRelatedTextAnswer}</Text>
+      )}
     </Box>
   );
 };

--- a/front/app/containers/Admin/projects/project/analysis/InputPreview/components/CustomFields/LongFieldValue/CustomFieldLongFieldValues/SelectLongField.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/InputPreview/components/CustomFields/LongFieldValue/CustomFieldLongFieldValues/SelectLongField.tsx
@@ -12,28 +12,36 @@ import { SelectOptionText } from './SelectOptionText';
 type Props = {
   customField: IIdeaCustomField;
   rawValue: any;
+  rawValueRelatedTextAnswer?: string;
 };
 
-const SelectLongField = ({ customField, rawValue }: Props) => {
+const SelectLongField = ({
+  customField,
+  rawValue,
+  rawValueRelatedTextAnswer,
+}: Props) => {
   return (
     <Box>
-      <Title variant="h5" m="0px">
-        <T value={customField.data.attributes.title_multiloc} />
-      </Title>
-      <Box display="flex" justifyContent="flex-start" alignItems="flex-start">
-        <Text m="0">
-          <SelectOptionText
-            customFieldId={customField.data.id}
-            selectedOptionKey={rawValue}
-          />
-        </Text>
-        <Box ml="8px">
-          <FilterToggleButton
-            customFieldId={customField.data.id}
-            value={rawValue || null}
-          />
+      <Box>
+        <Title variant="h5" m="0px">
+          <T value={customField.data.attributes.title_multiloc} />
+        </Title>
+        <Box display="flex" justifyContent="flex-start" alignItems="flex-start">
+          <Text m="0">
+            <SelectOptionText
+              customFieldId={customField.data.id}
+              selectedOptionKey={rawValue}
+            />
+          </Text>
+          <Box ml="8px">
+            <FilterToggleButton
+              customFieldId={customField.data.id}
+              value={rawValue || null}
+            />
+          </Box>
         </Box>
       </Box>
+      <Text my="4px">{rawValueRelatedTextAnswer}</Text>
     </Box>
   );
 };

--- a/front/app/containers/Admin/projects/project/analysis/InputPreview/components/CustomFields/LongFieldValue/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/InputPreview/components/CustomFields/LongFieldValue/index.tsx
@@ -49,6 +49,15 @@ const FieldValue = ({ projectId, phaseId, customFieldId, input }: Props) => {
   const rawValue =
     input.attributes.custom_field_values[customField.data.attributes.key];
 
+  // Get any related text answer for the custom field (E.g. "other" or "follow up" answer)
+  const rawValueRelatedTextAnswer =
+    input.attributes.custom_field_values[
+      `${customField.data.attributes.key}_follow_up`
+    ] ||
+    input.attributes.custom_field_values[
+      `${customField.data.attributes.key}_other`
+    ];
+
   switch (customField.data.attributes.code) {
     case 'title_multiloc':
       return <TitleMultilocLongField input={input} customField={customField} />;
@@ -78,17 +87,26 @@ const FieldValue = ({ projectId, phaseId, customFieldId, input }: Props) => {
               input={input}
               customField={customField}
               rawValue={rawValue}
+              rawValueRelatedTextAnswer={rawValueRelatedTextAnswer}
             />
           );
         }
         case 'multiline_text': {
           return (
-            <MultilineTextLongField input={input} customField={customField} />
+            <MultilineTextLongField
+              input={input}
+              customField={customField}
+              rawValueRelatedTextAnswer={rawValueRelatedTextAnswer}
+            />
           );
         }
         case 'select': {
           return (
-            <SelectLongField customField={customField} rawValue={rawValue} />
+            <SelectLongField
+              customField={customField}
+              rawValue={rawValue}
+              rawValueRelatedTextAnswer={rawValueRelatedTextAnswer}
+            />
           );
         }
         case 'multiselect': {

--- a/front/app/containers/Admin/projects/project/analysis/InputPreview/components/CustomFields/LongFieldValue/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/InputPreview/components/CustomFields/LongFieldValue/index.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 import { IInputsData } from 'api/analysis_inputs/types';
 import useIdeaCustomField from 'api/idea_custom_fields/useIdeaCustomField';
 
+import { getRelatedTextAnswer } from '../../../../util';
+
 import BodyMultilocLongField from './CustomFieldLongFieldValues/BodyMultilocLongField';
 import CheckboxLongField from './CustomFieldLongFieldValues/CheckboxLongField';
 import DateLongField from './CustomFieldLongFieldValues/DateLongField';
@@ -50,13 +52,10 @@ const FieldValue = ({ projectId, phaseId, customFieldId, input }: Props) => {
     input.attributes.custom_field_values[customField.data.attributes.key];
 
   // Get any related text answer for the custom field (E.g. "other" or "follow up" answer)
-  const rawValueRelatedTextAnswer =
-    input.attributes.custom_field_values[
-      `${customField.data.attributes.key}_follow_up`
-    ] ||
-    input.attributes.custom_field_values[
-      `${customField.data.attributes.key}_other`
-    ];
+  const rawValueRelatedTextAnswer = getRelatedTextAnswer(
+    input,
+    customField.data.attributes.key
+  );
 
   switch (customField.data.attributes.code) {
     case 'title_multiloc':

--- a/front/app/containers/Admin/projects/project/analysis/InputsList/FieldValue.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/InputsList/FieldValue.tsx
@@ -4,6 +4,7 @@ import { IInputsData } from 'api/analysis_inputs/types';
 import useIdeaCustomField from 'api/idea_custom_fields/useIdeaCustomField';
 
 import ShortInputFieldValue from '../components/ShortInputFieldValue';
+import { getRelatedTextAnswer } from '../util';
 
 type Props = {
   customFieldId: string;
@@ -34,13 +35,10 @@ const FieldValue = ({ projectId, phaseId, customFieldId, input }: Props) => {
     input.attributes.custom_field_values[customField.data.attributes.key];
 
   // Get any related text answer for the custom field (E.g. "other" or "follow up" answer)
-  const rawValueRelatedTextAnswer =
-    input.attributes.custom_field_values[
-      `${customField.data.attributes.key}_follow_up`
-    ] ||
-    input.attributes.custom_field_values[
-      `${customField.data.attributes.key}_other`
-    ];
+  const rawValueRelatedTextAnswer = getRelatedTextAnswer(
+    input,
+    customField.data.attributes.key
+  );
 
   return (
     <ShortInputFieldValue

--- a/front/app/containers/Admin/projects/project/analysis/InputsList/FieldValue.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/InputsList/FieldValue.tsx
@@ -30,11 +30,25 @@ const FieldValue = ({ projectId, phaseId, customFieldId, input }: Props) => {
   });
 
   if (!customField) return null;
-
   const rawValue =
     input.attributes.custom_field_values[customField.data.attributes.key];
 
-  return <ShortInputFieldValue customField={customField} rawValue={rawValue} />;
+  // Get any related text answer for the custom field (E.g. "other" or "follow up" answer)
+  const rawValueRelatedTextAnswer =
+    input.attributes.custom_field_values[
+      `${customField.data.attributes.key}_follow_up`
+    ] ||
+    input.attributes.custom_field_values[
+      `${customField.data.attributes.key}_other`
+    ];
+
+  return (
+    <ShortInputFieldValue
+      customField={customField}
+      rawValue={rawValue}
+      rawValueRelatedTextAnswer={rawValueRelatedTextAnswer}
+    />
+  );
 };
 
 export default FieldValue;

--- a/front/app/containers/Admin/projects/project/analysis/components/ShortInputFieldValue.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/components/ShortInputFieldValue.tsx
@@ -78,10 +78,13 @@ const ShortInputFieldValue = ({
     }
     case 'select': {
       return (
-        <SelectOptionText
-          customFieldId={customField.data.id}
-          selectedOptionKey={rawValue}
-        />
+        <Box>
+          <SelectOptionText
+            customFieldId={customField.data.id}
+            selectedOptionKey={rawValue}
+          />
+          <Box>{rawValueRelatedTextAnswer}</Box>
+        </Box>
       );
     }
     case 'multiselect': {
@@ -97,6 +100,7 @@ const ShortInputFieldValue = ({
               />
             </>
           ))}
+          <Box>{rawValueRelatedTextAnswer}</Box>
         </>
       );
     }

--- a/front/app/containers/Admin/projects/project/analysis/components/ShortInputFieldValue.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/components/ShortInputFieldValue.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
 
+import { Box } from '@citizenlab/cl2-component-library';
 import { isNil } from 'lodash-es';
 import { FormattedDate } from 'react-intl';
 
@@ -15,6 +16,7 @@ import messages from '../messages';
 type Props = {
   customField: IIdeaCustomField;
   rawValue?: any;
+  rawValueRelatedTextAnswer?: string;
 };
 
 const SelectOptionText = ({
@@ -41,7 +43,11 @@ const SelectOptionText = ({
  * the custom field for that input. Only renders anything for non-built-in
  * custom fields
  */
-const ShortInputFieldValue = ({ customField, rawValue }: Props) => {
+const ShortInputFieldValue = ({
+  customField,
+  rawValue,
+  rawValueRelatedTextAnswer,
+}: Props) => {
   const { formatMessage } = useIntl();
   // We only render non-built-in custom fields, assuming the parent has
   // dedicated logic to render the built-in fields
@@ -62,7 +68,12 @@ const ShortInputFieldValue = ({ customField, rawValue }: Props) => {
       if (rawValue === null || rawValue === undefined || rawValue === '') {
         return <>No Answer</>;
       } else {
-        return <>{rawValue}</>;
+        return (
+          <Box display="flex" flexDirection="column">
+            <Box>{rawValue}</Box>
+            <Box>{rawValueRelatedTextAnswer}</Box>
+          </Box>
+        );
       }
     }
     case 'select': {

--- a/front/app/containers/Admin/projects/project/analysis/util.ts
+++ b/front/app/containers/Admin/projects/project/analysis/util.ts
@@ -1,3 +1,5 @@
+import { IInputsData } from 'api/analysis_inputs/types';
+
 export const handleArraySearchParam = (
   searchParams: URLSearchParams,
   paramName: string
@@ -9,4 +11,14 @@ export const handleArraySearchParam = (
       : undefined;
 
   return result;
+};
+
+export const getRelatedTextAnswer = (
+  input: IInputsData,
+  customFieldKey: string
+) => {
+  return (
+    input.attributes.custom_field_values[`${customFieldKey}_follow_up`] ||
+    input.attributes.custom_field_values[`${customFieldKey}_other`]
+  );
 };


### PR DESCRIPTION
# Changelog
## Fixed
- Added linked text responses to AI analysis view for sentiment scale questions and select/multiselect "other" responses ([before](https://github.com/user-attachments/assets/76fb74b9-e46b-45ac-b299-a70c3517ff79)/[after](https://github.com/user-attachments/assets/5cf7bc85-edb1-467a-89fa-178e4fe347a1)).
