### PR TITLE
TAN-4516 - Increase maintainability of custom field serializer tests

### DIFF
--- a/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/update_all_native_survey_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/update_all_native_survey_spec.rb
@@ -9,15 +9,15 @@ resource 'Idea Custom Fields' do
 
   let!(:default_attributes) do
     {
-      code: nil,
-      created_at: an_instance_of(String),
+      title_multiloc: {},
       description_multiloc: {},
-      enabled: true,
       input_type: 'text',
       key: nil,
-      ordering: 0,
+      code: nil,
+      enabled: true,
       required: false,
-      title_multiloc: {},
+      ordering: 0,
+      created_at: an_instance_of(String),
       updated_at: an_instance_of(String),
       logic: {},
       constraints: {},
@@ -429,19 +429,11 @@ resource 'Idea Custom Fields' do
         expect(json_response[:data].size).to eq 3
         expect(json_response[:data][1]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: { en: 'Inserted field' },
             description_multiloc: {},
-            enabled: true,
             input_type: 'matrix_linear_scale',
             key: Regexp.new('inserted_field'),
             ordering: 1,
-            required: false,
-            title_multiloc: { en: 'Inserted field' },
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
             linear_scale_label_1_multiloc: { en: 'Closest' },
             linear_scale_label_2_multiloc: {},
             linear_scale_label_3_multiloc: {},
@@ -453,8 +445,7 @@ resource 'Idea Custom Fields' do
             linear_scale_label_9_multiloc: {},
             linear_scale_label_10_multiloc: {},
             linear_scale_label_11_multiloc: { en: 'Furthest' },
-            maximum: 11,
-            include_in_printed_form: true
+            maximum: 11
           }),
           id: an_instance_of(String),
           type: 'custom_field',
@@ -699,16 +690,12 @@ resource 'Idea Custom Fields' do
         expect(json_response[:data].size).to eq 3
         expect(json_response[:data][1]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: { en: 'Select a value from the scale' },
             description_multiloc: { en: 'Description of question' },
-            enabled: true,
             input_type: 'linear_scale',
             key: an_instance_of(String),
             ordering: 1,
             required: true,
-            title_multiloc: { en: 'Select a value from the scale' },
-            updated_at: an_instance_of(String),
             maximum: 7,
             linear_scale_label_1_multiloc: { en: 'Lowest' },
             linear_scale_label_2_multiloc: { en: 'Low' },
@@ -720,11 +707,7 @@ resource 'Idea Custom Fields' do
             linear_scale_label_8_multiloc: {},
             linear_scale_label_9_multiloc: {},
             linear_scale_label_10_multiloc: {},
-            linear_scale_label_11_multiloc: {},
-            logic: {},
-            random_option_ordering: false,
-            constraints: {},
-            include_in_printed_form: true
+            linear_scale_label_11_multiloc: {}
           }),
           id: an_instance_of(String),
           type: 'custom_field',
@@ -765,16 +748,12 @@ resource 'Idea Custom Fields' do
         expect(json_response[:data].size).to eq 3
         expect(json_response[:data][1]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: { en: 'Select a value from the scale' },
             description_multiloc: { en: 'Description of question' },
-            enabled: true,
             input_type: 'sentiment_linear_scale',
             key: an_instance_of(String),
             ordering: 1,
             required: true,
-            title_multiloc: { en: 'Select a value from the scale' },
-            updated_at: an_instance_of(String),
             maximum: 5,
             ask_follow_up: true,
             linear_scale_label_1_multiloc: { en: 'Lowest' },
@@ -787,11 +766,7 @@ resource 'Idea Custom Fields' do
             linear_scale_label_8_multiloc: {},
             linear_scale_label_9_multiloc: {},
             linear_scale_label_10_multiloc: {},
-            linear_scale_label_11_multiloc: {},
-            logic: {},
-            random_option_ordering: false,
-            constraints: {},
-            include_in_printed_form: true
+            linear_scale_label_11_multiloc: {}
           }),
           id: an_instance_of(String),
           type: 'custom_field',
@@ -832,24 +807,17 @@ resource 'Idea Custom Fields' do
         json_response = json_parse(response_body)
         expect(json_response[:data].size).to eq 3
         expect(json_response[:data][1][:attributes]).to match(default_attributes.merge({
-          code: nil,
-          created_at: an_instance_of(String),
+          title_multiloc: { en: 'Select a value' },
           description_multiloc: { en: 'Description of question' },
           dropdown_layout: false,
-          enabled: true,
           input_type: 'select',
           key: an_instance_of(String),
           ordering: 1,
           required: true,
-          title_multiloc: { en: 'Select a value' },
-          updated_at: an_instance_of(String),
           logic: { rules: [{
             if: 'any_other_answer',
             goto_page_id: form_end_page.id
-          }] },
-          random_option_ordering: false,
-          constraints: {},
-          include_in_printed_form: true
+          }] }
         }))
       end
 
@@ -880,21 +848,13 @@ resource 'Idea Custom Fields' do
         expect(json_response[:data].size).to eq 3
         expect(json_response[:data][1]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: { en: 'Rate your experince with us' },
             description_multiloc: { en: 'Description of question' },
-            enabled: true,
             input_type: 'rating',
             key: an_instance_of(String),
             ordering: 1,
             required: true,
-            title_multiloc: { en: 'Rate your experince with us' },
-            updated_at: an_instance_of(String),
-            maximum: 7,
-            logic: {},
-            random_option_ordering: false,
-            constraints: {},
-            include_in_printed_form: true
+            maximum: 7
           }),
           id: an_instance_of(String),
           type: 'custom_field',
@@ -1152,21 +1112,13 @@ resource 'Idea Custom Fields' do
         expect(json_response[:data].size).to eq 3
         expect(json_response[:data][1]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: { en: 'Updated field' },
             description_multiloc: an_instance_of(Hash),
             dropdown_layout: false,
-            enabled: true,
             input_type: 'select',
             key: field.key,
             ordering: 1,
-            required: true,
-            title_multiloc: { en: 'Updated field' },
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            required: true
           }),
           id: an_instance_of(String),
           type: 'custom_field',
@@ -1422,21 +1374,12 @@ resource 'Idea Custom Fields' do
         expect(json_response[:data].size).to eq 5
         expect(json_response[:data][0]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: page1.title_multiloc.symbolize_keys,
             description_multiloc: page1.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'page',
             key: page1.key,
             ordering: 0,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: page1.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: page1.id,
           type: 'custom_field',
@@ -1444,16 +1387,12 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][1]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: field_to_update.title_multiloc.symbolize_keys,
             description_multiloc: field_to_update.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'linear_scale',
             key: field_to_update.key,
             ordering: 1,
             required: true,
-            title_multiloc: field_to_update.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
             maximum: 5,
             linear_scale_label_1_multiloc: field_to_update.linear_scale_label_1_multiloc.symbolize_keys,
             linear_scale_label_2_multiloc: field_to_update.linear_scale_label_2_multiloc.symbolize_keys,
@@ -1468,10 +1407,7 @@ resource 'Idea Custom Fields' do
             linear_scale_label_11_multiloc: field_to_update.linear_scale_label_11_multiloc.symbolize_keys,
             logic: {
               rules: [{ if: 2, goto_page_id: page3.id }]
-            },
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            }
           }),
           id: field_to_update.id,
           type: 'custom_field',
@@ -1479,21 +1415,12 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][2]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: page2.title_multiloc.symbolize_keys,
             description_multiloc: page2.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'page',
             key: page2.key,
             ordering: 2,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: page2.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: page2.id,
           type: 'custom_field',
@@ -1501,21 +1428,13 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][3]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: page3.title_multiloc.symbolize_keys,
             description_multiloc: page3.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'page',
             key: page3.key,
             ordering: 3,
             page_layout: 'default',
-            required: false,
-            title_multiloc: page3.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            required: false
           }),
           id: page3.id,
           type: 'custom_field',
@@ -1578,21 +1497,13 @@ resource 'Idea Custom Fields' do
         expect(json_response[:data].size).to eq 5
         expect(json_response[:data][0]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: page_to_update.title_multiloc.symbolize_keys,
             description_multiloc: page_to_update.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'page',
             page_layout: 'default',
             key: page_to_update.key,
             ordering: 0,
-            required: false,
-            title_multiloc: page_to_update.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
-            logic: { next_page_id: page4.id },
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            logic: { next_page_id: page4.id }
           }),
           id: page_to_update.id,
           type: 'custom_field',
@@ -1600,21 +1511,12 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][1]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: page2.title_multiloc.symbolize_keys,
             description_multiloc: page2.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'page',
             key: page2.key,
             ordering: 1,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: page2.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: page2.id,
           type: 'custom_field',
@@ -1622,21 +1524,12 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][2]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: page3.title_multiloc.symbolize_keys,
             description_multiloc: page3.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'page',
             key: page3.key,
             ordering: 2,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: page3.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: page3.id,
           type: 'custom_field',
@@ -1644,21 +1537,12 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][3]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: page4.title_multiloc.symbolize_keys,
             description_multiloc: page4.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'page',
             key: page4.key,
             ordering: 3,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: page4.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: page4.id,
           type: 'custom_field',
@@ -1723,21 +1607,13 @@ resource 'Idea Custom Fields' do
         expect(json_response[:data].size).to eq 5
         expect(json_response[:data][0]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: page_to_update.title_multiloc.symbolize_keys,
             description_multiloc: page_to_update.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'page',
             key: page_to_update.key,
             ordering: 0,
             page_layout: 'default',
-            required: false,
-            title_multiloc: page_to_update.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
-            logic: { next_page_id: json_response[:data][3][:id] },
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            logic: { next_page_id: json_response[:data][3][:id] }
           }),
           id: page_to_update.id,
           type: 'custom_field',
@@ -1745,21 +1621,12 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][1]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: page2.title_multiloc.symbolize_keys,
             description_multiloc: page2.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'page',
             key: page2.key,
             ordering: 1,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: page2.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: page2.id,
           type: 'custom_field',
@@ -1767,21 +1634,12 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][2]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: page3.title_multiloc.symbolize_keys,
             description_multiloc: page3.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'page',
             key: page3.key,
             ordering: 2,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: page3.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: page3.id,
           type: 'custom_field',
@@ -1789,21 +1647,12 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][3]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: { en: 'Page 4' },
             description_multiloc: { en: 'Page 4 description' },
-            enabled: true,
             input_type: 'page',
             key: nil,
             ordering: 3,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: { en: 'Page 4' },
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: an_instance_of(String),
           type: 'custom_field',
@@ -1853,21 +1702,13 @@ resource 'Idea Custom Fields' do
         expect(json_response[:data].size).to eq 4
         expect(json_response[:data][0]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: { en: 'New page with logic' },
             description_multiloc: { en: 'New page with logic description' },
-            enabled: true,
             input_type: 'page',
             key: nil,
             ordering: 0,
             page_layout: 'default',
-            required: false,
-            title_multiloc: { en: 'New page with logic' },
-            updated_at: an_instance_of(String),
-            logic: { next_page_id: json_response[:data][2][:id] },
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            logic: { next_page_id: json_response[:data][2][:id] }
           }),
           id: an_instance_of(String),
           type: 'custom_field',
@@ -1875,21 +1716,12 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][1]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: existing_page.title_multiloc.symbolize_keys,
             description_multiloc: existing_page.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'page',
             key: existing_page.key,
             ordering: 1,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: existing_page.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: existing_page.id,
           type: 'custom_field',
@@ -1897,21 +1729,12 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][2]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: { en: 'Target page' },
             description_multiloc: { en: 'Target page description' },
-            enabled: true,
             input_type: 'page',
             key: nil,
             ordering: 2,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: { en: 'Target page' },
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: an_instance_of(String),
           type: 'custom_field',
@@ -1964,21 +1787,12 @@ resource 'Idea Custom Fields' do
         expect(json_response[:data].size).to eq 4
         expect(json_response[:data][0]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: page_to_update.title_multiloc.symbolize_keys,
             description_multiloc: page_to_update.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'page',
             key: page_to_update.key,
             ordering: 0,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: page_to_update.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: page_to_update.id,
           type: 'custom_field',
@@ -1986,21 +1800,12 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][1]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: page2.title_multiloc.symbolize_keys,
             description_multiloc: page2.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'page',
             key: page2.key,
             ordering: 1,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: page2.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: page2.id,
           type: 'custom_field',
@@ -2008,21 +1813,13 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][2]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: page3.title_multiloc.symbolize_keys,
             description_multiloc: page3.description_multiloc.symbolize_keys,
             enabled: true,
             input_type: 'page',
             key: page3.key,
             ordering: 2,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: page3.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: page3.id,
           type: 'custom_field',
@@ -2066,21 +1863,12 @@ resource 'Idea Custom Fields' do
         expect(json_response[:data].size).to eq 3
         expect(json_response[:data][0]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: page_to_update.title_multiloc.symbolize_keys,
             description_multiloc: page_to_update.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'page',
             key: page_to_update.key,
             ordering: 0,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: page_to_update.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: page_to_update.id,
           type: 'custom_field',
@@ -2088,21 +1876,13 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][1]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: page2.title_multiloc.symbolize_keys,
             description_multiloc: page2.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'page',
             key: page2.key,
             ordering: 1,
             page_layout: 'default',
-            required: false,
-            title_multiloc: page2.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            required: false
           }),
           id: page2.id,
           type: 'custom_field',
@@ -2184,21 +1964,12 @@ resource 'Idea Custom Fields' do
         expect(json_response[:data].size).to eq 5
         expect(json_response[:data][0]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: page1.title_multiloc.symbolize_keys,
             description_multiloc: page1.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'page',
             key: page1.key,
             ordering: 0,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: page1.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: page1.id,
           type: 'custom_field',
@@ -2206,16 +1977,13 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][1]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: field_to_update.title_multiloc.symbolize_keys,
+
             description_multiloc: field_to_update.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'linear_scale',
             key: field_to_update.key,
             ordering: 1,
             required: true,
-            title_multiloc: field_to_update.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
             maximum: 5,
             linear_scale_label_1_multiloc: field_to_update.linear_scale_label_1_multiloc.symbolize_keys,
             linear_scale_label_2_multiloc: field_to_update.linear_scale_label_2_multiloc.symbolize_keys,
@@ -2230,10 +1998,7 @@ resource 'Idea Custom Fields' do
             linear_scale_label_11_multiloc: field_to_update.linear_scale_label_11_multiloc.symbolize_keys,
             logic: {
               rules: [{ if: 2, goto_page_id: json_response[:data][3][:id] }]
-            },
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            }
           }),
           id: field_to_update.id,
           type: 'custom_field',
@@ -2241,21 +2006,12 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][2]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: page2.title_multiloc.symbolize_keys,
             description_multiloc: page2.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'page',
             key: page2.key,
             ordering: 2,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: page2.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: page2.id,
           type: 'custom_field',
@@ -2263,21 +2019,12 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][3]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: { en: 'Page 3' },
             description_multiloc: { en: 'Page 3 description' },
-            enabled: true,
             input_type: 'page',
             key: nil,
             ordering: 3,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: { en: 'Page 3' },
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: an_instance_of(String),
           type: 'custom_field',
@@ -2360,21 +2107,12 @@ resource 'Idea Custom Fields' do
         expect(json_response[:data].size).to eq 5
         expect(json_response[:data][0]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: page1.title_multiloc.symbolize_keys,
             description_multiloc: page1.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'page',
             key: page1.key,
             ordering: 0,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: page1.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: page1.id,
           type: 'custom_field',
@@ -2382,16 +2120,12 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][1]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: field_to_update.title_multiloc.symbolize_keys,
             description_multiloc: field_to_update.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'linear_scale',
             key: field_to_update.key,
             ordering: 1,
             required: true,
-            title_multiloc: field_to_update.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
             maximum: 5,
             linear_scale_label_1_multiloc: field_to_update.linear_scale_label_1_multiloc.symbolize_keys,
             linear_scale_label_2_multiloc: field_to_update.linear_scale_label_2_multiloc.symbolize_keys,
@@ -2406,10 +2140,7 @@ resource 'Idea Custom Fields' do
             linear_scale_label_11_multiloc: field_to_update.linear_scale_label_11_multiloc.symbolize_keys,
             logic: {
               rules: [{ if: 1, goto_page_id: page2.id }]
-            },
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            }
           }),
           id: field_to_update.id,
           type: 'custom_field',
@@ -2417,21 +2148,12 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][2]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: page3.title_multiloc.symbolize_keys,
             description_multiloc: page3.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'page',
             key: page3.key,
             ordering: 2,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: page3.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: page3.id,
           type: 'custom_field',
@@ -2439,21 +2161,12 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][3]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: page2.title_multiloc.symbolize_keys,
             description_multiloc: page2.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'page',
             key: page2.key,
             ordering: 3,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: page2.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: page2.id,
           type: 'custom_field',
@@ -2524,21 +2237,12 @@ resource 'Idea Custom Fields' do
         expect(json_response[:data].size).to eq 4
         expect(json_response[:data][0]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: page1.title_multiloc.symbolize_keys,
             description_multiloc: page1.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'page',
             key: page1.key,
             ordering: 0,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: page1.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: page1.id,
           type: 'custom_field',
@@ -2546,16 +2250,11 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][1]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: field_to_update.title_multiloc.symbolize_keys,
             description_multiloc: field_to_update.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'linear_scale',
             key: field_to_update.key,
             ordering: 1,
-            required: false,
-            title_multiloc: field_to_update.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
             maximum: 5,
             linear_scale_label_1_multiloc: field_to_update.linear_scale_label_1_multiloc.symbolize_keys,
             linear_scale_label_2_multiloc: field_to_update.linear_scale_label_2_multiloc.symbolize_keys,
@@ -2567,11 +2266,7 @@ resource 'Idea Custom Fields' do
             linear_scale_label_8_multiloc: field_to_update.linear_scale_label_8_multiloc.symbolize_keys,
             linear_scale_label_9_multiloc: field_to_update.linear_scale_label_9_multiloc.symbolize_keys,
             linear_scale_label_10_multiloc: field_to_update.linear_scale_label_10_multiloc.symbolize_keys,
-            linear_scale_label_11_multiloc: field_to_update.linear_scale_label_11_multiloc.symbolize_keys,
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            linear_scale_label_11_multiloc: field_to_update.linear_scale_label_11_multiloc.symbolize_keys
           }),
           id: field_to_update.id,
           type: 'custom_field',
@@ -2579,21 +2274,12 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][2]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: page2.title_multiloc.symbolize_keys,
             description_multiloc: page2.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'page',
             key: page2.key,
             ordering: 2,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: page2.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: page2.id,
           type: 'custom_field',
@@ -2656,21 +2342,12 @@ resource 'Idea Custom Fields' do
         expect(json_response[:data].size).to eq 3
         expect(json_response[:data][0]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: page1.title_multiloc.symbolize_keys,
             description_multiloc: page1.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'page',
             key: page1.key,
             ordering: 0,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: page1.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: page1.id,
           type: 'custom_field',
@@ -2678,16 +2355,11 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][1]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: field_to_update.title_multiloc.symbolize_keys,
             description_multiloc: field_to_update.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'linear_scale',
             key: field_to_update.key,
             ordering: 1,
-            required: false,
-            title_multiloc: field_to_update.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
             maximum: 5,
             linear_scale_label_1_multiloc: field_to_update.linear_scale_label_1_multiloc.symbolize_keys,
             linear_scale_label_2_multiloc: field_to_update.linear_scale_label_2_multiloc.symbolize_keys,
@@ -2699,11 +2371,7 @@ resource 'Idea Custom Fields' do
             linear_scale_label_8_multiloc: field_to_update.linear_scale_label_8_multiloc.symbolize_keys,
             linear_scale_label_9_multiloc: field_to_update.linear_scale_label_9_multiloc.symbolize_keys,
             linear_scale_label_10_multiloc: field_to_update.linear_scale_label_10_multiloc.symbolize_keys,
-            linear_scale_label_11_multiloc: field_to_update.linear_scale_label_11_multiloc.symbolize_keys,
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            linear_scale_label_11_multiloc: field_to_update.linear_scale_label_11_multiloc.symbolize_keys
           }),
           id: field_to_update.id,
           type: 'custom_field',
@@ -2746,21 +2414,12 @@ resource 'Idea Custom Fields' do
         expect(json_response[:data].size).to eq 2
         expect(json_response[:data][0]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: page1.title_multiloc.symbolize_keys,
             description_multiloc: page1.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'page',
             key: page1.key,
             ordering: 0,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: page1.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: page1.id,
           type: 'custom_field',
@@ -2848,21 +2507,12 @@ resource 'Idea Custom Fields' do
         expect(json_response[:data].size).to eq 5
         expect(json_response[:data][0]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: page1.title_multiloc.symbolize_keys,
             description_multiloc: page1.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'page',
             key: page1.key,
             ordering: 0,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: page1.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: page1.id,
           type: 'custom_field',
@@ -2870,16 +2520,12 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][1]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: field_to_update.title_multiloc.symbolize_keys,
             description_multiloc: field_to_update.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'linear_scale',
             key: field_to_update.key,
             ordering: 1,
             required: true,
-            title_multiloc: field_to_update.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
             maximum: 5,
             linear_scale_label_1_multiloc: field_to_update.linear_scale_label_1_multiloc.symbolize_keys,
             linear_scale_label_2_multiloc: field_to_update.linear_scale_label_2_multiloc.symbolize_keys,
@@ -2894,10 +2540,7 @@ resource 'Idea Custom Fields' do
             linear_scale_label_11_multiloc: field_to_update.linear_scale_label_11_multiloc.symbolize_keys,
             logic: {
               rules: [{ if: 2, goto_page_id: page3.id }]
-            },
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            }
           }),
           id: field_to_update.id,
           type: 'custom_field',
@@ -2905,21 +2548,12 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][2]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: page2.title_multiloc.symbolize_keys,
             description_multiloc: page2.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'page',
             key: page2.key,
             ordering: 2,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: page2.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: page2.id,
           type: 'custom_field',
@@ -2927,21 +2561,12 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][3]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: page3.title_multiloc.symbolize_keys,
             description_multiloc: page3.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'page',
             key: page3.key,
             ordering: 3,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: page3.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: page3.id,
           type: 'custom_field',
@@ -3010,21 +2635,12 @@ resource 'Idea Custom Fields' do
         expect(json_response[:data].size).to eq 4
         expect(json_response[:data][0]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: page1.title_multiloc.symbolize_keys,
             description_multiloc: page1.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'page',
             key: page1.key,
             ordering: 0,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: page1.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: page1.id,
           type: 'custom_field',
@@ -3032,16 +2648,12 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][1]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: field_to_update.title_multiloc.symbolize_keys,
             description_multiloc: field_to_update.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'linear_scale',
             key: field_to_update.key,
             ordering: 1,
             required: true,
-            title_multiloc: field_to_update.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
             maximum: 5,
             linear_scale_label_1_multiloc: field_to_update.linear_scale_label_1_multiloc.symbolize_keys,
             linear_scale_label_2_multiloc: field_to_update.linear_scale_label_2_multiloc.symbolize_keys,
@@ -3056,10 +2668,7 @@ resource 'Idea Custom Fields' do
             linear_scale_label_11_multiloc: field_to_update.linear_scale_label_11_multiloc.symbolize_keys,
             logic: {
               rules: [{ if: 2, goto_page_id: json_response[:data][2][:id] }]
-            },
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            }
           }),
           id: field_to_update.id,
           type: 'custom_field',
@@ -3067,21 +2676,12 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][2]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: { en: 'Page 2' },
             description_multiloc: { en: 'Page 2 description' },
-            enabled: true,
             input_type: 'page',
             key: nil,
             ordering: 2,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: { en: 'Page 2' },
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: an_instance_of(String),
           type: 'custom_field',
@@ -3181,21 +2781,13 @@ resource 'Idea Custom Fields' do
         expect(json_response[:data].size).to eq 6
         expect(json_response[:data][0]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: page1.title_multiloc.symbolize_keys,
             description_multiloc: page1.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'page',
             key: page1.key,
             ordering: 0,
             page_layout: 'default',
-            required: false,
-            title_multiloc: page1.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            required: false
           }),
           id: page1.id,
           type: 'custom_field',
@@ -3203,23 +2795,16 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][1]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: field1_to_update.title_multiloc.symbolize_keys,
             description_multiloc: field1_to_update.description_multiloc.symbolize_keys,
             dropdown_layout: false,
-            enabled: true,
             input_type: 'select',
             key: field1_to_update.key,
             ordering: 1,
             required: true,
-            title_multiloc: field1_to_update.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
             logic: {
               rules: [{ if: added_option1.id, goto_page_id: json_response[:data][3][:id] }]
-            },
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            }
           }),
           id: field1_to_update.id,
           type: 'custom_field',
@@ -3235,23 +2820,16 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][2]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: field2_to_update.title_multiloc.symbolize_keys,
             description_multiloc: field2_to_update.description_multiloc.symbolize_keys,
             dropdown_layout: false,
-            enabled: true,
             input_type: 'select',
             key: field2_to_update.key,
             ordering: 2,
             required: true,
-            title_multiloc: field2_to_update.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
             logic: {
               rules: [{ if: added_option2.id, goto_page_id: json_response[:data][4][:id] }]
-            },
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            }
           }),
           id: field2_to_update.id,
           type: 'custom_field',
@@ -3267,21 +2845,12 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][3]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: { en: 'Page 2' },
             description_multiloc: { en: 'Page 2 description' },
-            enabled: true,
             input_type: 'page',
             key: nil,
             ordering: 3,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: { en: 'Page 2' },
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: an_instance_of(String),
           type: 'custom_field',
@@ -3289,21 +2858,12 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][4]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: { en: 'Page 3' },
             description_multiloc: { en: 'Page 3 description' },
-            enabled: true,
             input_type: 'page',
             key: nil,
             ordering: 4,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: { en: 'Page 3' },
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: an_instance_of(String),
           type: 'custom_field',
@@ -3367,21 +2927,12 @@ resource 'Idea Custom Fields' do
         expect(json_response[:data].size).to eq 4
         expect(json_response[:data][0]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: page1.title_multiloc.symbolize_keys,
             description_multiloc: page1.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'page',
             key: page1.key,
             ordering: 0,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: page1.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: page1.id,
           type: 'custom_field',
@@ -3389,16 +2940,12 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][1]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: { en: 'Question 1 on page 1' },
             description_multiloc: { en: 'Description of question 1 on page 1' },
-            enabled: true,
             input_type: 'linear_scale',
             key: an_instance_of(String),
             ordering: 1,
             required: true,
-            title_multiloc: { en: 'Question 1 on page 1' },
-            updated_at: an_instance_of(String),
             maximum: 7,
             linear_scale_label_1_multiloc: { en: 'Lowest' },
             linear_scale_label_2_multiloc: { en: 'Low' },
@@ -3413,10 +2960,7 @@ resource 'Idea Custom Fields' do
             linear_scale_label_11_multiloc: {},
             logic: {
               rules: [{ if: 2, goto_page_id: json_response[:data][2][:id] }]
-            },
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            }
           }),
           id: an_instance_of(String),
           type: 'custom_field',
@@ -3424,21 +2968,12 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][2]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: { en: 'Page 2' },
             description_multiloc: { en: 'Page 2 description' },
-            enabled: true,
             input_type: 'page',
             key: nil,
             ordering: 2,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: { en: 'Page 2' },
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: an_instance_of(String),
           type: 'custom_field',
@@ -3526,21 +3061,12 @@ resource 'Idea Custom Fields' do
         expect(json_response[:data].size).to eq 5
         expect(json_response[:data][0]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: page1.title_multiloc.symbolize_keys,
             description_multiloc: page1.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'page',
             key: page1.key,
             ordering: 0,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: page1.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: page1.id,
           type: 'custom_field',
@@ -3548,16 +3074,12 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][1]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: field_to_update.title_multiloc.symbolize_keys,
             description_multiloc: field_to_update.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'linear_scale',
             key: field_to_update.key,
             ordering: 1,
             required: true,
-            title_multiloc: field_to_update.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
             maximum: 5,
             linear_scale_label_1_multiloc: field_to_update.linear_scale_label_1_multiloc.symbolize_keys,
             linear_scale_label_2_multiloc: field_to_update.linear_scale_label_2_multiloc.symbolize_keys,
@@ -3575,10 +3097,7 @@ resource 'Idea Custom Fields' do
                 { if: 1, goto_page_id: page2.id },
                 { if: 2, goto_page_id: page3.id }
               ]
-            },
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            }
           }),
           id: field_to_update.id,
           type: 'custom_field',
@@ -3586,21 +3105,12 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][2]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: page2.title_multiloc.symbolize_keys,
             description_multiloc: page2.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'page',
             key: page2.key,
             ordering: 2,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: page2.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: page2.id,
           type: 'custom_field',
@@ -3608,21 +3118,12 @@ resource 'Idea Custom Fields' do
         })
         expect(json_response[:data][3]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: page3.title_multiloc.symbolize_keys,
             description_multiloc: page3.description_multiloc.symbolize_keys,
-            enabled: true,
             input_type: 'page',
             key: page3.key,
             ordering: 3,
-            page_layout: 'default',
-            required: false,
-            title_multiloc: page3.title_multiloc.symbolize_keys,
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            page_layout: 'default'
           }),
           id: page3.id,
           type: 'custom_field',
@@ -3669,21 +3170,13 @@ resource 'Idea Custom Fields' do
         expect(json_response[:data].size).to eq 3
         expect(json_response[:data][1]).to match({
           attributes: default_attributes.merge({
-            code: nil,
-            created_at: an_instance_of(String),
+            title_multiloc: { en: 'Changed field' },
             description_multiloc: {},
             dropdown_layout: false,
-            enabled: true,
             input_type: 'select',
             key: an_instance_of(String),
             ordering: 1,
-            required: true,
-            title_multiloc: { en: 'Changed field' },
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
+            required: true
           }),
           id: an_instance_of(String),
           type: 'custom_field',

--- a/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/update_all_native_survey_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/update_all_native_survey_spec.rb
@@ -7,6 +7,25 @@ resource 'Idea Custom Fields' do
   explanation 'Fields in idea forms which are customized by the city, scoped on the project level.'
   before { header 'Content-Type', 'application/json' }
 
+  let!(:default_attributes) do
+    {
+      code: nil,
+      created_at: an_instance_of(String),
+      description_multiloc: {},
+      enabled: true,
+      input_type: 'text',
+      key: nil,
+      ordering: 0,
+      required: false,
+      title_multiloc: {},
+      updated_at: an_instance_of(String),
+      logic: {},
+      constraints: {},
+      random_option_ordering: false,
+      include_in_printed_form: true
+    }
+  end
+
   patch 'web_api/v1/admin/phases/:phase_id/custom_fields/update_all' do
     parameter :custom_fields, type: :array
     with_options scope: 'custom_fields[]' do
@@ -75,43 +94,27 @@ resource 'Idea Custom Fields' do
         json_response = json_parse(response_body)
         expect(json_response[:data].size).to eq 4
         expect(json_response[:data][1]).to match({
-          attributes: {
-            code: nil,
-            created_at: an_instance_of(String),
-            description_multiloc: {},
-            enabled: false,
-            input_type: 'text',
-            key: Regexp.new('inserted_field'),
-            ordering: 1,
-            required: false,
+          attributes: default_attributes.merge({
             title_multiloc: { en: 'Inserted field' },
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
-          },
+            description_multiloc: {},
+            input_type: 'text',
+            enabled: false,
+            key: Regexp.new('inserted_field'),
+            ordering: 1
+          }),
           id: an_instance_of(String),
           type: 'custom_field',
           relationships: { options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][2]).to match({
-          attributes: {
-            code: nil,
-            created_at: an_instance_of(String),
+          attributes: default_attributes.merge({
+            title_multiloc: { en: 'Updated field' },
             description_multiloc: { en: 'Which councils are you attending in our city?' },
-            enabled: true,
             input_type: 'text',
             key: field_to_update.key,
             ordering: 2,
-            required: true,
-            title_multiloc: { en: 'Updated field' },
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
-          },
+            required: true
+          }),
           id: an_instance_of(String),
           type: 'custom_field',
           relationships: { options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
@@ -165,26 +168,17 @@ resource 'Idea Custom Fields' do
         expect(CustomFieldOption.where(id: delete_options).count).to eq 0
         expect(json_response[:data].size).to eq 3
         expect(json_response[:data][1]).to match({
-          attributes: {
-            code: nil,
-            created_at: an_instance_of(String),
+          attributes: default_attributes.merge({
+            title_multiloc: { en: 'Inserted field' },
             description_multiloc: {},
             dropdown_layout: false,
-            enabled: true,
             input_type: 'multiselect',
             key: Regexp.new('inserted_field'),
             ordering: 1,
-            required: false,
             select_count_enabled: false,
             maximum_select_count: nil,
-            minimum_select_count: nil,
-            title_multiloc: { en: 'Inserted field' },
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
-          },
+            minimum_select_count: nil
+          }),
           id: an_instance_of(String),
           type: 'custom_field',
           relationships: {
@@ -270,22 +264,14 @@ resource 'Idea Custom Fields' do
 
         expect(json_response[:data].size).to eq 3
         expect(json_response[:data][1]).to match({
-          attributes: {
-            code: nil,
-            created_at: an_instance_of(String),
+          attributes: default_attributes.merge({
+            title_multiloc: { en: 'Inserted field' },
             description_multiloc: {},
-            enabled: true,
             input_type: 'ranking',
             key: Regexp.new('inserted_field'),
             ordering: 1,
-            required: false,
-            title_multiloc: { en: 'Inserted field' },
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: true,
-            include_in_printed_form: true
-          },
+            random_option_ordering: true
+          }),
           id: an_instance_of(String),
           type: 'custom_field',
           relationships: {
@@ -375,25 +361,17 @@ resource 'Idea Custom Fields' do
         expect(CustomFieldOption.all.count).to eq 2
         expect(CustomFieldOption.all.map { |c| c.image.id }).to match [image1.id, image2.id]
         expect(response_data[1]).to match({
-          attributes: {
-            code: nil,
-            created_at: an_instance_of(String),
+          attributes: default_attributes.merge({
+            title_multiloc: { en: 'Inserted field' },
             description_multiloc: {},
             enabled: true,
             input_type: 'multiselect_image',
             key: Regexp.new('inserted_field'),
             ordering: 1,
-            required: false,
             select_count_enabled: false,
             maximum_select_count: nil,
-            minimum_select_count: nil,
-            title_multiloc: { en: 'Inserted field' },
-            updated_at: an_instance_of(String),
-            logic: {},
-            constraints: {},
-            random_option_ordering: false,
-            include_in_printed_form: true
-          },
+            minimum_select_count: nil
+          }),
           id: an_instance_of(String),
           type: 'custom_field',
           relationships: {
@@ -450,7 +428,7 @@ resource 'Idea Custom Fields' do
 
         expect(json_response[:data].size).to eq 3
         expect(json_response[:data][1]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: {},
@@ -477,7 +455,7 @@ resource 'Idea Custom Fields' do
             linear_scale_label_11_multiloc: { en: 'Furthest' },
             maximum: 11,
             include_in_printed_form: true
-          },
+          }),
           id: an_instance_of(String),
           type: 'custom_field',
           relationships: {
@@ -720,7 +698,7 @@ resource 'Idea Custom Fields' do
         json_response = json_parse(response_body)
         expect(json_response[:data].size).to eq 3
         expect(json_response[:data][1]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: { en: 'Description of question' },
@@ -747,7 +725,7 @@ resource 'Idea Custom Fields' do
             random_option_ordering: false,
             constraints: {},
             include_in_printed_form: true
-          },
+          }),
           id: an_instance_of(String),
           type: 'custom_field',
           relationships: { options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
@@ -786,7 +764,7 @@ resource 'Idea Custom Fields' do
         json_response = json_parse(response_body)
         expect(json_response[:data].size).to eq 3
         expect(json_response[:data][1]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: { en: 'Description of question' },
@@ -814,7 +792,7 @@ resource 'Idea Custom Fields' do
             random_option_ordering: false,
             constraints: {},
             include_in_printed_form: true
-          },
+          }),
           id: an_instance_of(String),
           type: 'custom_field',
           relationships: { options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
@@ -853,7 +831,7 @@ resource 'Idea Custom Fields' do
         assert_status 200
         json_response = json_parse(response_body)
         expect(json_response[:data].size).to eq 3
-        expect(json_response[:data][1][:attributes]).to match({
+        expect(json_response[:data][1][:attributes]).to match(default_attributes.merge({
           code: nil,
           created_at: an_instance_of(String),
           description_multiloc: { en: 'Description of question' },
@@ -872,7 +850,7 @@ resource 'Idea Custom Fields' do
           random_option_ordering: false,
           constraints: {},
           include_in_printed_form: true
-        })
+        }))
       end
 
       example 'Update rating field' do
@@ -901,7 +879,7 @@ resource 'Idea Custom Fields' do
         json_response = json_parse(response_body)
         expect(json_response[:data].size).to eq 3
         expect(json_response[:data][1]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: { en: 'Description of question' },
@@ -917,7 +895,7 @@ resource 'Idea Custom Fields' do
             random_option_ordering: false,
             constraints: {},
             include_in_printed_form: true
-          },
+          }),
           id: an_instance_of(String),
           type: 'custom_field',
           relationships: { options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
@@ -1173,7 +1151,7 @@ resource 'Idea Custom Fields' do
         expect(field.reload.options.count).to eq 0
         expect(json_response[:data].size).to eq 3
         expect(json_response[:data][1]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: an_instance_of(Hash),
@@ -1189,7 +1167,7 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: an_instance_of(String),
           type: 'custom_field',
           relationships: { options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
@@ -1443,7 +1421,7 @@ resource 'Idea Custom Fields' do
         json_response = json_parse(response_body)
         expect(json_response[:data].size).to eq 5
         expect(json_response[:data][0]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: page1.description_multiloc.symbolize_keys,
@@ -1459,13 +1437,13 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: page1.id,
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][1]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: field_to_update.description_multiloc.symbolize_keys,
@@ -1494,13 +1472,13 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: field_to_update.id,
           type: 'custom_field',
           relationships: { options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][2]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: page2.description_multiloc.symbolize_keys,
@@ -1516,13 +1494,13 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: page2.id,
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][3]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: page3.description_multiloc.symbolize_keys,
@@ -1538,7 +1516,7 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: page3.id,
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
@@ -1599,7 +1577,7 @@ resource 'Idea Custom Fields' do
         json_response = json_parse(response_body)
         expect(json_response[:data].size).to eq 5
         expect(json_response[:data][0]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: page_to_update.description_multiloc.symbolize_keys,
@@ -1615,13 +1593,13 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: page_to_update.id,
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][1]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: page2.description_multiloc.symbolize_keys,
@@ -1637,13 +1615,13 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: page2.id,
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][2]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: page3.description_multiloc.symbolize_keys,
@@ -1659,13 +1637,13 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: page3.id,
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][3]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: page4.description_multiloc.symbolize_keys,
@@ -1681,7 +1659,7 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: page4.id,
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
@@ -1744,7 +1722,7 @@ resource 'Idea Custom Fields' do
         json_response = json_parse(response_body)
         expect(json_response[:data].size).to eq 5
         expect(json_response[:data][0]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: page_to_update.description_multiloc.symbolize_keys,
@@ -1760,13 +1738,13 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: page_to_update.id,
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][1]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: page2.description_multiloc.symbolize_keys,
@@ -1782,13 +1760,13 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: page2.id,
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][2]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: page3.description_multiloc.symbolize_keys,
@@ -1804,13 +1782,13 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: page3.id,
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][3]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: { en: 'Page 4 description' },
@@ -1826,7 +1804,7 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: an_instance_of(String),
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
@@ -1874,7 +1852,7 @@ resource 'Idea Custom Fields' do
         json_response = json_parse(response_body)
         expect(json_response[:data].size).to eq 4
         expect(json_response[:data][0]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: { en: 'New page with logic description' },
@@ -1890,13 +1868,13 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: an_instance_of(String),
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][1]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: existing_page.description_multiloc.symbolize_keys,
@@ -1912,13 +1890,13 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: existing_page.id,
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][2]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: { en: 'Target page description' },
@@ -1934,7 +1912,7 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: an_instance_of(String),
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
@@ -1985,7 +1963,7 @@ resource 'Idea Custom Fields' do
         json_response = json_parse(response_body)
         expect(json_response[:data].size).to eq 4
         expect(json_response[:data][0]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: page_to_update.description_multiloc.symbolize_keys,
@@ -2001,13 +1979,13 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: page_to_update.id,
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][1]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: page2.description_multiloc.symbolize_keys,
@@ -2023,13 +2001,13 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: page2.id,
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][2]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: page3.description_multiloc.symbolize_keys,
@@ -2045,7 +2023,7 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: page3.id,
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
@@ -2087,7 +2065,7 @@ resource 'Idea Custom Fields' do
         json_response = json_parse(response_body)
         expect(json_response[:data].size).to eq 3
         expect(json_response[:data][0]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: page_to_update.description_multiloc.symbolize_keys,
@@ -2103,13 +2081,13 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: page_to_update.id,
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][1]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: page2.description_multiloc.symbolize_keys,
@@ -2125,7 +2103,7 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: page2.id,
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
@@ -2205,7 +2183,7 @@ resource 'Idea Custom Fields' do
         json_response = json_parse(response_body)
         expect(json_response[:data].size).to eq 5
         expect(json_response[:data][0]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: page1.description_multiloc.symbolize_keys,
@@ -2221,13 +2199,13 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: page1.id,
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][1]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: field_to_update.description_multiloc.symbolize_keys,
@@ -2256,13 +2234,13 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: field_to_update.id,
           type: 'custom_field',
           relationships: { options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][2]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: page2.description_multiloc.symbolize_keys,
@@ -2278,13 +2256,13 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: page2.id,
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][3]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: { en: 'Page 3 description' },
@@ -2300,7 +2278,7 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: an_instance_of(String),
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
@@ -2381,7 +2359,7 @@ resource 'Idea Custom Fields' do
         json_response = json_parse(response_body)
         expect(json_response[:data].size).to eq 5
         expect(json_response[:data][0]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: page1.description_multiloc.symbolize_keys,
@@ -2397,13 +2375,13 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: page1.id,
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][1]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: field_to_update.description_multiloc.symbolize_keys,
@@ -2432,13 +2410,13 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: field_to_update.id,
           type: 'custom_field',
           relationships: { options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][2]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: page3.description_multiloc.symbolize_keys,
@@ -2454,13 +2432,13 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: page3.id,
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][3]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: page2.description_multiloc.symbolize_keys,
@@ -2476,7 +2454,7 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: page2.id,
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
@@ -2545,7 +2523,7 @@ resource 'Idea Custom Fields' do
         json_response = json_parse(response_body)
         expect(json_response[:data].size).to eq 4
         expect(json_response[:data][0]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: page1.description_multiloc.symbolize_keys,
@@ -2561,13 +2539,13 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: page1.id,
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][1]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: field_to_update.description_multiloc.symbolize_keys,
@@ -2594,13 +2572,13 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: field_to_update.id,
           type: 'custom_field',
           relationships: { options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][2]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: page2.description_multiloc.symbolize_keys,
@@ -2616,7 +2594,7 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: page2.id,
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
@@ -2677,7 +2655,7 @@ resource 'Idea Custom Fields' do
         json_response = json_parse(response_body)
         expect(json_response[:data].size).to eq 3
         expect(json_response[:data][0]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: page1.description_multiloc.symbolize_keys,
@@ -2693,13 +2671,13 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: page1.id,
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][1]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: field_to_update.description_multiloc.symbolize_keys,
@@ -2726,7 +2704,7 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: field_to_update.id,
           type: 'custom_field',
           relationships: { options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
@@ -2767,7 +2745,7 @@ resource 'Idea Custom Fields' do
         json_response = json_parse(response_body)
         expect(json_response[:data].size).to eq 2
         expect(json_response[:data][0]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: page1.description_multiloc.symbolize_keys,
@@ -2783,7 +2761,7 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: page1.id,
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
@@ -2869,7 +2847,7 @@ resource 'Idea Custom Fields' do
         json_response = json_parse(response_body)
         expect(json_response[:data].size).to eq 5
         expect(json_response[:data][0]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: page1.description_multiloc.symbolize_keys,
@@ -2885,13 +2863,13 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: page1.id,
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][1]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: field_to_update.description_multiloc.symbolize_keys,
@@ -2920,13 +2898,13 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: field_to_update.id,
           type: 'custom_field',
           relationships: { options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][2]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: page2.description_multiloc.symbolize_keys,
@@ -2942,13 +2920,13 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: page2.id,
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][3]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: page3.description_multiloc.symbolize_keys,
@@ -2964,7 +2942,7 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: page3.id,
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
@@ -3031,7 +3009,7 @@ resource 'Idea Custom Fields' do
         json_response = json_parse(response_body)
         expect(json_response[:data].size).to eq 4
         expect(json_response[:data][0]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: page1.description_multiloc.symbolize_keys,
@@ -3047,13 +3025,13 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: page1.id,
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][1]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: field_to_update.description_multiloc.symbolize_keys,
@@ -3082,13 +3060,13 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: field_to_update.id,
           type: 'custom_field',
           relationships: { options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][2]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: { en: 'Page 2 description' },
@@ -3104,7 +3082,7 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: an_instance_of(String),
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
@@ -3202,7 +3180,7 @@ resource 'Idea Custom Fields' do
         json_response = json_parse(response_body)
         expect(json_response[:data].size).to eq 6
         expect(json_response[:data][0]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: page1.description_multiloc.symbolize_keys,
@@ -3218,13 +3196,13 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: page1.id,
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][1]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: field1_to_update.description_multiloc.symbolize_keys,
@@ -3242,7 +3220,7 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: field1_to_update.id,
           type: 'custom_field',
           relationships: {
@@ -3256,7 +3234,7 @@ resource 'Idea Custom Fields' do
           }
         })
         expect(json_response[:data][2]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: field2_to_update.description_multiloc.symbolize_keys,
@@ -3274,7 +3252,7 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: field2_to_update.id,
           type: 'custom_field',
           relationships: {
@@ -3288,7 +3266,7 @@ resource 'Idea Custom Fields' do
           }
         })
         expect(json_response[:data][3]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: { en: 'Page 2 description' },
@@ -3304,13 +3282,13 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: an_instance_of(String),
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][4]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: { en: 'Page 3 description' },
@@ -3326,7 +3304,7 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: an_instance_of(String),
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
@@ -3388,7 +3366,7 @@ resource 'Idea Custom Fields' do
         json_response = json_parse(response_body)
         expect(json_response[:data].size).to eq 4
         expect(json_response[:data][0]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: page1.description_multiloc.symbolize_keys,
@@ -3404,13 +3382,13 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: page1.id,
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][1]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: { en: 'Description of question 1 on page 1' },
@@ -3439,13 +3417,13 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: an_instance_of(String),
           type: 'custom_field',
           relationships: { options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][2]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: { en: 'Page 2 description' },
@@ -3461,7 +3439,7 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: an_instance_of(String),
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
@@ -3547,7 +3525,7 @@ resource 'Idea Custom Fields' do
         json_response = json_parse(response_body)
         expect(json_response[:data].size).to eq 5
         expect(json_response[:data][0]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: page1.description_multiloc.symbolize_keys,
@@ -3563,13 +3541,13 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: page1.id,
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][1]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: field_to_update.description_multiloc.symbolize_keys,
@@ -3601,13 +3579,13 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: field_to_update.id,
           type: 'custom_field',
           relationships: { options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][2]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: page2.description_multiloc.symbolize_keys,
@@ -3623,13 +3601,13 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: page2.id,
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
         })
         expect(json_response[:data][3]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: page3.description_multiloc.symbolize_keys,
@@ -3645,7 +3623,7 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: page3.id,
           type: 'custom_field',
           relationships: { map_config: { data: nil }, options: { data: [] }, resource: { data: { id: custom_form.id, type: 'custom_form' } } }
@@ -3690,7 +3668,7 @@ resource 'Idea Custom Fields' do
 
         expect(json_response[:data].size).to eq 3
         expect(json_response[:data][1]).to match({
-          attributes: {
+          attributes: default_attributes.merge({
             code: nil,
             created_at: an_instance_of(String),
             description_multiloc: {},
@@ -3706,7 +3684,7 @@ resource 'Idea Custom Fields' do
             constraints: {},
             random_option_ordering: false,
             include_in_printed_form: true
-          },
+          }),
           id: an_instance_of(String),
           type: 'custom_field',
           relationships: {

--- a/back/spec/serializers/web_api/v1/custom_field_serializer_spec.rb
+++ b/back/spec/serializers/web_api/v1/custom_field_serializer_spec.rb
@@ -3,7 +3,6 @@
 require 'rails_helper'
 
 describe WebApi::V1::CustomFieldSerializer do
-
   let!(:default_attributes) do
     {
       code: nil,
@@ -185,7 +184,7 @@ describe WebApi::V1::CustomFieldSerializer do
         maximum_select_count: nil,
         minimum_select_count: nil,
         key: 'multiselect',
-        select_count_enabled: false,
+        select_count_enabled: false
       }))
     end
   end

--- a/back/spec/serializers/web_api/v1/custom_field_serializer_spec.rb
+++ b/back/spec/serializers/web_api/v1/custom_field_serializer_spec.rb
@@ -3,6 +3,26 @@
 require 'rails_helper'
 
 describe WebApi::V1::CustomFieldSerializer do
+
+  let!(:default_attributes) do
+    {
+      code: nil,
+      created_at: an_instance_of(ActiveSupport::TimeWithZone),
+      description_multiloc: {},
+      enabled: true,
+      input_type: 'text',
+      key: nil,
+      ordering: 0,
+      required: false,
+      title_multiloc: {},
+      updated_at: an_instance_of(ActiveSupport::TimeWithZone),
+      logic: {},
+      constraints: {},
+      random_option_ordering: false,
+      include_in_printed_form: true
+    }
+  end
+
   context 'for user custom fields' do
     let(:field) { create(:custom_field, resource_type: 'User') }
 
@@ -32,23 +52,13 @@ describe WebApi::V1::CustomFieldSerializer do
       params = { params: { constraints: {}, supports_answer_visible_to: true } }
       serialized_field = described_class.new(field, params).serializable_hash
       attributes = serialized_field[:data][:attributes]
-      expect(attributes).to match({
-        code: nil,
-        created_at: an_instance_of(ActiveSupport::TimeWithZone),
+      expect(attributes).to match(default_attributes.merge({
         description_multiloc: { 'en' => 'Which councils are you attending in our city?' },
-        enabled: true,
         input_type: 'text',
         key: 'extra',
-        ordering: 0,
-        required: false,
         title_multiloc: { 'en' => 'Did you attend' },
-        updated_at: an_instance_of(ActiveSupport::TimeWithZone),
-        logic: {},
-        constraints: {},
-        answer_visible_to: 'admins',
-        random_option_ordering: false,
-        include_in_printed_form: true
-      })
+        answer_visible_to: 'admins'
+      }))
     end
   end
 
@@ -71,11 +81,9 @@ describe WebApi::V1::CustomFieldSerializer do
     it 'includes maximum and scale value labels' do
       serialized_field = described_class.new(field).serializable_hash
       attributes = serialized_field[:data][:attributes]
-      expect(attributes).to match({
-        code: nil,
-        created_at: an_instance_of(ActiveSupport::TimeWithZone),
+      expect(attributes).to match(default_attributes.merge({
+        title_multiloc: { 'en' => 'We need a swimming pool.' },
         description_multiloc: { 'en' => 'Please indicate how strong you agree or disagree.' },
-        enabled: true,
         input_type: 'linear_scale',
         key: 'scale',
         maximum: 5,
@@ -89,16 +97,8 @@ describe WebApi::V1::CustomFieldSerializer do
         linear_scale_label_8_multiloc: {},
         linear_scale_label_9_multiloc: {},
         linear_scale_label_10_multiloc: {},
-        linear_scale_label_11_multiloc: {},
-        ordering: 0,
-        required: false,
-        title_multiloc: { 'en' => 'We need a swimming pool.' },
-        updated_at: an_instance_of(ActiveSupport::TimeWithZone),
-        logic: {},
-        constraints: {},
-        random_option_ordering: false,
-        include_in_printed_form: true
-      })
+        linear_scale_label_11_multiloc: {}
+      }))
     end
   end
 
@@ -108,15 +108,12 @@ describe WebApi::V1::CustomFieldSerializer do
     it 'includes maximum and scale value labels' do
       serialized_field = described_class.new(field).serializable_hash
       attributes = serialized_field[:data][:attributes]
-      expect(attributes).to match({
-        code: nil,
-        created_at: an_instance_of(ActiveSupport::TimeWithZone),
+      expect(attributes).to match(default_attributes.merge({
+        title_multiloc: { 'en' => 'We need a swimming pool.' },
         description_multiloc: { 'en' => 'Please indicate how strong you agree or disagree.' },
-        enabled: true,
         input_type: 'sentiment_linear_scale',
         key: 'scale',
         maximum: 5,
-        ask_follow_up: false,
         linear_scale_label_1_multiloc: { 'en' => 'Strongly disagree' },
         linear_scale_label_2_multiloc: { 'en' => 'Disagree' },
         linear_scale_label_3_multiloc: { 'en' => 'Neutral' },
@@ -128,15 +125,8 @@ describe WebApi::V1::CustomFieldSerializer do
         linear_scale_label_9_multiloc: {},
         linear_scale_label_10_multiloc: {},
         linear_scale_label_11_multiloc: {},
-        ordering: 0,
-        required: false,
-        title_multiloc: { 'en' => 'We need a swimming pool.' },
-        updated_at: an_instance_of(ActiveSupport::TimeWithZone),
-        logic: {},
-        constraints: {},
-        random_option_ordering: false,
-        include_in_printed_form: true
-      })
+        ask_follow_up: false
+      }))
     end
   end
 
@@ -146,23 +136,14 @@ describe WebApi::V1::CustomFieldSerializer do
     it 'includes maximum value' do
       serialized_field = described_class.new(field).serializable_hash
       attributes = serialized_field[:data][:attributes]
-      expect(attributes).to match({
-        code: nil,
-        created_at: an_instance_of(ActiveSupport::TimeWithZone),
+      expect(attributes).to match(default_attributes.merge({
+        title_multiloc: { 'en' => 'How would you rate our service?' },
         description_multiloc: { 'en' => 'Please rate your experience from 1 (poor) to 5 (excellent).' },
-        enabled: true,
         input_type: 'rating',
         key: 'scale',
         maximum: 5,
-        ordering: 0,
-        required: false,
-        title_multiloc: { 'en' => 'How would you rate our service?' },
-        updated_at: an_instance_of(ActiveSupport::TimeWithZone),
-        logic: {},
-        constraints: {},
-        random_option_ordering: false,
-        include_in_printed_form: true
-      })
+        ordering: 0
+      }))
     end
   end
 
@@ -179,23 +160,14 @@ describe WebApi::V1::CustomFieldSerializer do
     it 'does not include the logic' do
       serialized_field = described_class.new(field).serializable_hash
       attributes = serialized_field[:data][:attributes]
-      expect(attributes).to match({
-        code: nil,
-        created_at: an_instance_of(ActiveSupport::TimeWithZone),
+      expect(attributes).to match(default_attributes.merge({
+        title_multiloc: { 'en' => 'Cycling survey' },
         description_multiloc: { 'en' => 'This is a survey on your cycling habits.' },
-        enabled: true,
         input_type: 'page',
         key: 'page_1',
-        ordering: 0,
         page_layout: 'default',
-        required: false,
-        title_multiloc: { 'en' => 'Cycling survey' },
-        updated_at: an_instance_of(ActiveSupport::TimeWithZone),
-        logic: { 'next_page_id' => 'TEMP-ID-1' },
-        constraints: {},
-        random_option_ordering: false,
-        include_in_printed_form: true
-      })
+        logic: { 'next_page_id' => 'TEMP-ID-1' }
+      }))
     end
   end
 
@@ -205,26 +177,16 @@ describe WebApi::V1::CustomFieldSerializer do
     it 'includes the dropdown_layout attribute' do
       serialized_field = described_class.new(field).serializable_hash
       attributes = serialized_field[:data][:attributes]
-      expect(attributes).to match({
-        code: nil,
-        created_at: an_instance_of(ActiveSupport::TimeWithZone),
+      expect(attributes).to match(default_attributes.merge({
+        title_multiloc: { 'en' => 'What languages do you speak?' },
         description_multiloc: { 'en' => 'Which councils are you attending in our city?' },
         dropdown_layout: false,
-        enabled: true,
         input_type: 'multiselect',
         maximum_select_count: nil,
         minimum_select_count: nil,
         key: 'multiselect',
-        ordering: 0,
-        required: false,
         select_count_enabled: false,
-        title_multiloc: { 'en' => 'What languages do you speak?' },
-        updated_at: an_instance_of(ActiveSupport::TimeWithZone),
-        logic: {},
-        constraints: {},
-        random_option_ordering: false,
-        include_in_printed_form: true
-      })
+      }))
     end
   end
 
@@ -234,23 +196,13 @@ describe WebApi::V1::CustomFieldSerializer do
     it 'includes the dropdown_layout attribute' do
       serialized_field = described_class.new(field).serializable_hash
       attributes = serialized_field[:data][:attributes]
-      expect(attributes).to match({
-        code: nil,
-        created_at: an_instance_of(ActiveSupport::TimeWithZone),
+      expect(attributes).to match(default_attributes.merge({
+        title_multiloc: { 'en' => 'Member of councils?' },
         description_multiloc: { 'en' => 'Which councils are you attending in our city?' },
         dropdown_layout: false,
-        enabled: true,
         input_type: 'select',
-        key: 'select',
-        ordering: 0,
-        required: false,
-        title_multiloc: { 'en' => 'Member of councils?' },
-        updated_at: an_instance_of(ActiveSupport::TimeWithZone),
-        logic: {},
-        constraints: {},
-        random_option_ordering: false,
-        include_in_printed_form: true
-      })
+        key: 'select'
+      }))
     end
   end
 end


### PR DESCRIPTION
# Changelog
## Technical
- Increased maintainability of custom field serializer tests by basing all tests on a default object
