### PR TITLE
TAN-4531 - Prevent community monitor project being returned in report projects widget

### DIFF
--- a/back/engines/commercial/report_builder/app/services/report_builder/queries/projects.rb
+++ b/back/engines/commercial/report_builder/app/services/report_builder/queries/projects.rb
@@ -11,6 +11,7 @@ module ReportBuilder
         .joins(:admin_publication)
         .where(id: overlapping_project_ids)
         .where(admin_publication: { publication_status: publication_statuses })
+        .not_hidden
 
       periods = Phase
         .select(

--- a/back/engines/commercial/report_builder/spec/services/report_builder/queries/projects_spec.rb
+++ b/back/engines/commercial/report_builder/spec/services/report_builder/queries/projects_spec.rb
@@ -42,6 +42,9 @@ RSpec.describe ReportBuilder::Queries::Projects do
       # Empty project
       create(:project)
 
+      # Community monitor project - should not be returned
+      create(:community_monitor_project)
+
       # Make TimeBoundariesParser work as expected
       AppConfiguration.instance.update!(created_at: Date.new(2019, 12, 31))
 


### PR DESCRIPTION
# Changelog
## Fixed
- Prevented community monitor project from appearing in projects report widget
