### PR TITLE
[TAN-4037] Fix visitor data widget number formatting

### DIFF
--- a/front/app/components/admin/Graphs/Statistic/index.tsx
+++ b/front/app/components/admin/Graphs/Statistic/index.tsx
@@ -28,14 +28,9 @@ const Statistic = ({
 }: Props) => {
   const { formatNumber } = useIntl();
 
-  // Format the numbers according to the locale
+  // Format the value according to the locale
   const formattedValue =
-    typeof value === 'string' ? formatNumber(parseInt(value, 10)) : value;
-
-  const formattedBottomLabelValue =
-    typeof bottomLabelValue === 'string'
-      ? formatNumber(parseInt(bottomLabelValue, 10))
-      : bottomLabelValue;
+    typeof value === 'string' ? value : value && formatNumber(value);
 
   return (
     <Box
@@ -56,7 +51,7 @@ const Statistic = ({
       {bottomLabel && (
         <StatisticBottomLabel
           bottomLabel={bottomLabel}
-          bottomLabelValue={formattedBottomLabelValue}
+          bottomLabelValue={bottomLabelValue}
         />
       )}
     </Box>

--- a/front/app/components/admin/Graphs/Statistic/index.tsx
+++ b/front/app/components/admin/Graphs/Statistic/index.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 
 import { Box, Text, Color } from '@citizenlab/cl2-component-library';
 
+import { useIntl } from 'utils/cl-intl';
+
 import StatisticBottomLabel from './StatisticBottomLabel';
 import StatisticName from './StatisticName';
 
@@ -23,29 +25,42 @@ const Statistic = ({
   tooltipContent,
   textAlign = 'left',
   nameColor = 'primary',
-}: Props) => (
-  <Box
-    {...(textAlign === 'left'
-      ? {}
-      : { display: 'flex', flexDirection: 'column', alignItems: 'center' })}
-  >
-    <StatisticName
-      name={name}
-      nameColor={nameColor}
-      tooltipContent={tooltipContent}
-    />
-    <Box mt="2px">
-      <Text color="textPrimary" fontSize="xl" display="inline">
-        {value}
-      </Text>
-    </Box>
-    {bottomLabel && (
-      <StatisticBottomLabel
-        bottomLabel={bottomLabel}
-        bottomLabelValue={bottomLabelValue}
+}: Props) => {
+  const { formatNumber } = useIntl();
+
+  // Format the numbers according to the locale
+  const formattedValue =
+    typeof value === 'string' ? formatNumber(parseInt(value, 10)) : value;
+
+  const formattedBottomLabelValue =
+    typeof bottomLabelValue === 'string'
+      ? formatNumber(parseInt(bottomLabelValue, 10))
+      : bottomLabelValue;
+
+  return (
+    <Box
+      {...(textAlign === 'left'
+        ? {}
+        : { display: 'flex', flexDirection: 'column', alignItems: 'center' })}
+    >
+      <StatisticName
+        name={name}
+        nameColor={nameColor}
+        tooltipContent={tooltipContent}
       />
-    )}
-  </Box>
-);
+      <Box mt="2px">
+        <Text color="textPrimary" fontSize="xl" display="inline">
+          {formattedValue}
+        </Text>
+      </Box>
+      {bottomLabel && (
+        <StatisticBottomLabel
+          bottomLabel={bottomLabel}
+          bottomLabelValue={formattedBottomLabelValue}
+        />
+      )}
+    </Box>
+  );
+};
 
 export default Statistic;

--- a/front/app/components/admin/Graphs/Statistic/index.tsx
+++ b/front/app/components/admin/Graphs/Statistic/index.tsx
@@ -28,7 +28,7 @@ const Statistic = ({
 }: Props) => {
   const { formatNumber } = useIntl();
 
-  // Format the value according to the locale
+  // When value is a number, format according to the locale
   const formattedValue =
     typeof value === 'string' ? value : value && formatNumber(value);
 


### PR DESCRIPTION
# Changelog
## Fixed
- [TAN-4037] Fix number formatting for locales for visitor data widget (I.e. Using "." and "," correctly).
