### PR TITLE
[TAN-4535] Remove svg from image upload whitelist

### DIFF
--- a/back/app/uploaders/base_image_uploader.rb
+++ b/back/app/uploaders/base_image_uploader.rb
@@ -3,7 +3,7 @@
 class BaseImageUploader < BaseUploader
   include CarrierWave::MiniMagick
 
-  ALLOWED_TYPES = %w[jpg jpeg gif png webp svg]
+  ALLOWED_TYPES = %w[jpg jpeg gif png webp]
 
   # Using process at the class level applies it to all versions, including the original.
   process :strip

--- a/back/spec/uploaders/base_image_uploader_spec.rb
+++ b/back/spec/uploaders/base_image_uploader_spec.rb
@@ -31,6 +31,9 @@ RSpec.describe BaseImageUploader do
     end
   end
 
+  # Note that we no longer permit .svg files, due to cross-site scripting concerns,
+  # raised in TAN-4535:
+  # https://www.notion.so/govocal/Vilnius-security-concerns-to-investigate-1eb9663b7b26801cb669f161e527d4d9
   it 'whitelists exactly [image/jpg image/jpeg image/gif image/png image/webp]' do
     expect(uploader.extension_allowlist).to match_array %w[jpg jpeg gif png webp]
     expect(uploader.content_type_allowlist).to match_array %w[image/jpg image/jpeg image/gif image/png image/webp]

--- a/back/spec/uploaders/base_image_uploader_spec.rb
+++ b/back/spec/uploaders/base_image_uploader_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe BaseImageUploader do
     end
   end
 
-  it 'whitelists exactly [image/jpg image/jpeg image/gif image/png image/webp image/svg]' do
-    expect(uploader.extension_allowlist).to match_array %w[jpg jpeg gif png webp svg]
-    expect(uploader.content_type_allowlist).to match_array %w[image/jpg image/jpeg image/gif image/png image/webp image/svg]
+  it 'whitelists exactly [image/jpg image/jpeg image/gif image/png image/webp]' do
+    expect(uploader.extension_allowlist).to match_array %w[jpg jpeg gif png webp]
+    expect(uploader.content_type_allowlist).to match_array %w[image/jpg image/jpeg image/gif image/png image/webp]
     expect(uploader.extension_denylist).to be_blank
     expect(uploader.content_type_denylist).to be_blank
   end


### PR DESCRIPTION
Note that we don't seem to inform the user (via the UI) what image types are acceptable, nor do we seem to give any clear error message when uploading a not permitted image type fails (though the BE responds with a 422: `{"errors":{"image":[{"error":"extension_whitelist_error"},{"error":"blank"}]}}`).

I have created a ticket to address this: [TAN-4545](https://www.notion.so/govocal/No-error-message-in-UI-when-non-permitted-image-type-upload-attempted-1ec9663b7b26808094d3d3f05df294f2?pvs=4)

# Changelog
## Technical
- [TAN-4535] Remove svg from image upload whitelist. Addresses cross-site scripting vulnerability.
