### PR TITLE
[TAN-4535] Limit block & unblock user to admins only

### DIFF
--- a/back/app/policies/user_policy.rb
+++ b/back/app/policies/user_policy.rb
@@ -57,11 +57,11 @@ class UserPolicy < ApplicationPolicy
   end
 
   def block?
-    index_xlsx?
+    user&.active? && user.admin?
   end
 
   def unblock?
-    index_xlsx?
+    user&.active? && user.admin?
   end
 
   def blocked_count?

--- a/back/app/policies/user_policy.rb
+++ b/back/app/policies/user_policy.rb
@@ -20,7 +20,7 @@ class UserPolicy < ApplicationPolicy
   end
 
   def index?
-    user&.active? && !user.normal_user?
+    user&.active? && user.admin?
   end
 
   def seats?

--- a/back/app/policies/user_policy.rb
+++ b/back/app/policies/user_policy.rb
@@ -20,7 +20,7 @@ class UserPolicy < ApplicationPolicy
   end
 
   def index?
-    user&.active? && user.admin?
+    user&.active? && !user.normal_user?
   end
 
   def seats?
@@ -57,11 +57,11 @@ class UserPolicy < ApplicationPolicy
   end
 
   def block?
-    index?
+    index_xlsx?
   end
 
   def unblock?
-    index?
+    index_xlsx?
   end
 
   def blocked_count?

--- a/back/spec/policies/user_policy_spec.rb
+++ b/back/spec/policies/user_policy_spec.rb
@@ -111,7 +111,7 @@ describe UserPolicy do
       it { is_expected.to     permit(:show)    }
       it { is_expected.to     permit(:update)  }
       it { is_expected.to     permit(:destroy) }
-      it { is_expected.not_to permit(:index)   }
+      it { is_expected.to     permit(:index)   }
       it { is_expected.not_to permit(:block)   }
       it { is_expected.not_to permit(:unblock) }
       it { is_expected.not_to permit(:index_xlsx) }
@@ -128,7 +128,7 @@ describe UserPolicy do
       it { is_expected.to     permit(:show)    }
       it { is_expected.not_to permit(:update)  }
       it { is_expected.not_to permit(:destroy) }
-      it { is_expected.not_to permit(:index)   }
+      it { is_expected.to     permit(:index)   }
       it { is_expected.not_to permit(:block)   }
       it { is_expected.not_to permit(:unblock) }
       it { is_expected.not_to permit(:index_xlsx) }
@@ -165,7 +165,7 @@ describe UserPolicy do
       it { is_expected.to     permit(:show)    }
       it { is_expected.to     permit(:update)  }
       it { is_expected.to     permit(:destroy) }
-      it { is_expected.not_to permit(:index)   }
+      it { is_expected.to     permit(:index)   }
       it { is_expected.not_to permit(:block)   }
       it { is_expected.not_to permit(:unblock) }
       it { is_expected.not_to permit(:index_xlsx) }
@@ -182,7 +182,7 @@ describe UserPolicy do
       it { is_expected.to     permit(:show)    }
       it { is_expected.not_to permit(:update)  }
       it { is_expected.not_to permit(:destroy) }
-      it { is_expected.not_to permit(:index)   }
+      it { is_expected.to     permit(:index)   }
       it { is_expected.not_to permit(:block)   }
       it { is_expected.not_to permit(:unblock) }
       it { is_expected.not_to permit(:index_xlsx) }

--- a/back/spec/policies/user_policy_spec.rb
+++ b/back/spec/policies/user_policy_spec.rb
@@ -111,7 +111,9 @@ describe UserPolicy do
       it { is_expected.to     permit(:show)    }
       it { is_expected.to     permit(:update)  }
       it { is_expected.to     permit(:destroy) }
-      it { is_expected.to     permit(:index) }
+      it { is_expected.not_to permit(:index)   }
+      it { is_expected.not_to permit(:block)   }
+      it { is_expected.not_to permit(:unblock) }
       it { is_expected.not_to permit(:index_xlsx) }
 
       it 'indexes the user through the scope' do
@@ -126,7 +128,9 @@ describe UserPolicy do
       it { is_expected.to     permit(:show)    }
       it { is_expected.not_to permit(:update)  }
       it { is_expected.not_to permit(:destroy) }
-      it { is_expected.to     permit(:index) }
+      it { is_expected.not_to permit(:index)   }
+      it { is_expected.not_to permit(:block)   }
+      it { is_expected.not_to permit(:unblock) }
       it { is_expected.not_to permit(:index_xlsx) }
 
       it 'does not index the user through the scope' do
@@ -161,7 +165,9 @@ describe UserPolicy do
       it { is_expected.to     permit(:show)    }
       it { is_expected.to     permit(:update)  }
       it { is_expected.to     permit(:destroy) }
-      it { is_expected.to     permit(:index) }
+      it { is_expected.not_to permit(:index)   }
+      it { is_expected.not_to permit(:block)   }
+      it { is_expected.not_to permit(:unblock) }
       it { is_expected.not_to permit(:index_xlsx) }
 
       it 'indexes the user through the scope' do
@@ -176,7 +182,9 @@ describe UserPolicy do
       it { is_expected.to     permit(:show)    }
       it { is_expected.not_to permit(:update)  }
       it { is_expected.not_to permit(:destroy) }
-      it { is_expected.to     permit(:index) }
+      it { is_expected.not_to permit(:index)   }
+      it { is_expected.not_to permit(:block)   }
+      it { is_expected.not_to permit(:unblock) }
       it { is_expected.not_to permit(:index_xlsx) }
 
       it 'does not index the user through the scope' do


### PR DESCRIPTION
Mitigating a mild security issue where project & folder moderators could block or unblock user(s) via the API (not via the UI).

e2e tests pass. I ran them as an extra check these changes do not break any intended functionality.

# Changelog
## Fixed
- [TAN-4535] Limit block & unblock user to admins only
