### PR TITLE
Add secure attributes to cookies

### DIFF
--- a/back/app/controllers/omniauth_callback_controller.rb
+++ b/back/app/controllers/omniauth_callback_controller.rb
@@ -201,7 +201,9 @@ class OmniauthCallbackController < ApplicationController
   def set_auth_cookie(provider: nil)
     cookies[:cl2_jwt] = {
       value: auth_token(@user, provider).token,
-      expires: 1.month.from_now
+      expires: 1.month.from_now,
+      secure: !Rails.env.development? && !Rails.env.test?,
+      sameSite: 'strict'
     }
   end
 

--- a/back/app/controllers/omniauth_callback_controller.rb
+++ b/back/app/controllers/omniauth_callback_controller.rb
@@ -202,7 +202,7 @@ class OmniauthCallbackController < ApplicationController
     cookies[:cl2_jwt] = {
       value: auth_token(@user, provider).token,
       expires: 1.month.from_now,
-      secure: !Rails.env.development? && !Rails.env.test?,
+      secure: !Rails.env.local?,
       sameSite: 'strict'
     }
   end

--- a/back/app/controllers/omniauth_callback_controller.rb
+++ b/back/app/controllers/omniauth_callback_controller.rb
@@ -203,7 +203,7 @@ class OmniauthCallbackController < ApplicationController
       value: auth_token(@user, provider).token,
       expires: 1.month.from_now,
       secure: !Rails.env.local?,
-      sameSite: 'strict'
+      same_site: 'Strict'
     }
   end
 

--- a/back/spec/acceptance/omniauth_callback_spec.rb
+++ b/back/spec/acceptance/omniauth_callback_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 require 'rspec_api_documentation/dsl'
 
 def mock_app_configuration
-  app_config_mock = instance_double('AppConfiguration')
+  app_config_mock = instance_double(AppConfiguration)
   allow(app_config_mock).to receive(:closest_locale_to).and_return('en')
   allow(app_config_mock).to receive(:feature_activated?).with('facebook_login').and_return(true)
   allow(app_config_mock).to receive(:feature_activated?).with('user_confirmation').and_return(false)
@@ -16,7 +16,7 @@ def mock_app_configuration
 end
 
 def mock_facebook_auth_method(user)
-  facebook_method = instance_double('OmniauthMethods::Facebook')
+  facebook_method = instance_double(OmniauthMethods::Facebook)
   allow(facebook_method).to receive_messages(
     profile_to_user_attrs: { email: user.email, first_name: user.first_name },
     email_confirmed?: true,
@@ -29,14 +29,14 @@ def mock_facebook_auth_method(user)
 end
 
 def mock_authentication_service(facebook_method, user)
-  auth_service_mock = instance_double('AuthenticationService')
+  auth_service_mock = instance_double(AuthenticationService)
   allow(auth_service_mock).to receive(:method_by_provider).with('facebook').and_return(facebook_method)
   allow(auth_service_mock).to receive(:prevent_user_account_hijacking).and_return(user)
 
   auth_service_mock
 end
 
-def mock_omniauth_callback_controller(auth_service_mock, user)
+def mock_omniauth_callback_controller(auth_service_mock)
   # Mock auth token
   auth_token_double = instance_double(AuthToken::AuthToken, token: 'test-jwt-token')
   allow_any_instance_of(OmniauthCallbackController).to receive(:auth_token).and_return(auth_token_double)
@@ -100,19 +100,19 @@ resource 'Omniauth Callback', document: false do
       })
 
       # Mock identity to return our test user
-      identity_double = instance_double('Identity', user: @user)
+      identity_double = instance_double(Identity, user: @user)
       allow(Identity).to receive(:find_or_build_with_omniauth).and_return(identity_double)
 
       mock_app_configuration
       facebook_method = mock_facebook_auth_method(@user)
       auth_service_mock = mock_authentication_service(facebook_method, @user)
-      mock_omniauth_callback_controller(auth_service_mock, @user)
+      mock_omniauth_callback_controller(auth_service_mock)
     end
 
     after do
       OmniAuth.config.test_mode = false
     end
-  
+
     get '/auth/facebook/callback' do
       example 'Sets secure cookie with expected headers' do
         do_request

--- a/back/spec/acceptance/omniauth_callback_spec.rb
+++ b/back/spec/acceptance/omniauth_callback_spec.rb
@@ -3,6 +3,52 @@
 require 'rails_helper'
 require 'rspec_api_documentation/dsl'
 
+def mock_app_configuration
+  app_config_mock = double('AppConfiguration')
+  allow(app_config_mock).to receive(:closest_locale_to).and_return('en')
+  allow(app_config_mock).to receive(:feature_activated?).with('facebook_login').and_return(true)
+  allow(app_config_mock).to receive(:feature_activated?).with('user_confirmation').and_return(false)
+  allow(app_config_mock).to receive(:settings).with('facebook_login', 'app_id').and_return('mock_facebook_app_id')
+  allow(app_config_mock).to receive(:settings).with('facebook_login', 'app_secret').and_return('mock_facebook_app_secret')
+  allow(AppConfiguration).to receive(:instance).and_return(app_config_mock)
+  app_config_mock
+end
+
+def mock_facebook_auth_method(user)
+  facebook_method = double('OmniauthMethods::Facebook')
+  allow(facebook_method).to receive(:profile_to_user_attrs).and_return({
+    email: user.email, 
+    first_name: user.first_name
+  })
+  allow(facebook_method).to receive(:email_confirmed?).and_return(true)
+  allow(facebook_method).to receive(:verification_prioritized?).and_return(false)
+  allow(facebook_method).to receive(:updateable_user_attrs).and_return([])
+  allow(facebook_method).to receive(:can_merge?).and_return(true)
+  facebook_method
+end
+
+def mock_authentication_service(facebook_method, user)
+  auth_service_mock = double('AuthenticationService')
+  allow(auth_service_mock).to receive(:method_by_provider).with('facebook').and_return(facebook_method)
+  allow(auth_service_mock).to receive(:prevent_user_account_hijacking).and_return(user)
+  auth_service_mock
+end
+
+def mock_omniauth_callback_controller(auth_service_mock, user)
+  # Mock auth token
+  auth_token_double = instance_double(AuthToken::AuthToken, token: 'test-jwt-token')
+  allow_any_instance_of(OmniauthCallbackController).to receive(:auth_token).and_return(auth_token_double)
+  
+  # Make sure set_auth_cookie is actually called
+  allow_any_instance_of(OmniauthCallbackController).to receive(:set_auth_cookie).and_call_original
+  
+  # Mock other methods
+  allow_any_instance_of(OmniauthCallbackController).to receive(:authentication_service).and_return(auth_service_mock)
+  allow_any_instance_of(OmniauthCallbackController).to receive(:update_user!).and_return(true)
+  allow_any_instance_of(OmniauthCallbackController).to receive(:verified_for_sso?).and_return(true)
+  allow_any_instance_of(OmniauthCallbackController).to receive(:signin_success_redirect)
+end
+
 resource 'Omniauth Callback', document: false do
   before { header 'Content-Type', 'application/json' }
 
@@ -26,6 +72,56 @@ resource 'Omniauth Callback', document: false do
       example_request 'Returns ClaveUnica redirect URL' do
         expect(status).to eq(200)
         expect(json_response_body[:url]).to start_with('https://accounts.claveunica.gob.cl/api/v1/accounts/app/logout')
+      end
+    end
+  end
+
+  context 'when authenticating via OAuth' do
+    before do
+      @user = create(:user)
+      
+      # Skip OmniAuth's actual authentication - add missing raw_info
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.mock_auth[:facebook] = OmniAuth::AuthHash.new({
+        'provider' => 'facebook',
+        'uid' => '12345',
+        'info' => {
+          'email' => @user.email,
+          'name' => @user.first_name
+        },
+        'extra' => {
+          'raw_info' => {
+            'locale' => 'en_US',
+            'id' => '12345'
+          }
+        }
+      })
+      
+      # Mock identity to return our test user
+      identity_double = double('Identity', user: @user)
+      allow(Identity).to receive(:find_or_build_with_omniauth).and_return(identity_double)
+      
+      mock_app_configuration
+      facebook_method = mock_facebook_auth_method(@user)
+      auth_service_mock = mock_authentication_service(facebook_method, @user)
+      mock_omniauth_callback_controller(auth_service_mock, @user)
+    end
+    
+    after do
+      OmniAuth.config.test_mode = false
+    end
+  
+    get '/auth/facebook/callback' do
+      example 'Sets secure cookie with expected headers' do
+        do_request
+        
+        expect(status).to eq(204)
+
+        cookie_header = response_headers['Set-Cookie']
+        expect(cookie_header).to include('cl2_jwt=test-jwt-token')
+        expect(cookie_header).to include('SameSite=Strict')
+        expect(cookie_header.include?('Secure')).to eq(!Rails.env.local?)
+        expect(cookie_header).to match(/expires=.+GMT/i)
       end
     end
   end

--- a/front/app/utils/auth/jwt.ts
+++ b/front/app/utils/auth/jwt.ts
@@ -24,7 +24,10 @@ export function setJwt(
   rememberMe: boolean,
   tokenLifetime?: number
 ) {
-  const attrs = { secure: SECURE_COOKIE } as CookieAttributes;
+  const attrs = {
+    secure: SECURE_COOKIE,
+    sameSite: 'strict',
+  } as CookieAttributes;
   if (rememberMe) {
     attrs.expires = tokenLifetime; // If omitted, the cookie becomes a session cookie. Fore more info, check https://stackoverflow.com/a/36421888
   }


### PR DESCRIPTION
We definitely cannot support `httponly` at this point in time as the front-end reads the content of the JWT so it can add the bearer token to API requests. But also for things like 'supports_logout' in some of the  the BE. We could change the API so that:

- The API writes the cookie (httponly)
- The API reads the JWT not from the BEARER header, but directly from the cookie instead
- Supports logout could likely be done in other ways via an API call

This may not be too much work, but likely a lot of testing. Not sure how this would affect workshops or other APIs but probably small changes.

May be able to introduce this by allowing cookie & bearer, so that if we need external apps to be able to auth (eg public API), they can still use the bearer token route...I feel a 10% coming on...

# Changelog
## Changed
- Additional security added to jwt cookie
