### PR TITLE
Automatically handle logic to determine correct custom form endpoint

### DIFF
--- a/front/app/api/custom_form/getApiEndpoint.ts
+++ b/front/app/api/custom_form/getApiEndpoint.ts
@@ -1,10 +1,11 @@
 import { IPhaseData } from 'api/phases/types';
 
 const getApiEndpoint = (phase: IPhaseData) => {
-  /* For Ideation, when you configure the form it gets applied to ALL ideation phases within a project, 
+  /* For Ideation & voting, when you configure the form it gets applied to ALL ideation/voting phases within a project, 
   however when you configure the form for surveys for example, 
   each survey phase within a project can have a different form */
-  return phase.attributes.participation_method === 'ideation'
+  return phase.attributes.participation_method === 'ideation' ||
+    phase.attributes.participation_method === 'voting'
     ? `projects/${phase.relationships.project.data.id}/custom_form`
     : `phases/${phase.id}/custom_form`;
 };

--- a/front/app/api/custom_form/getApiEndpoint.ts
+++ b/front/app/api/custom_form/getApiEndpoint.ts
@@ -1,0 +1,12 @@
+import { IPhaseData } from 'api/phases/types';
+
+const getApiEndpoint = (phase: IPhaseData) => {
+  /* For Ideation, when you configure the form it gets applied to ALL ideation phases within a project, 
+  however when you configure the form for surveys for example, 
+  each survey phase within a project can have a different form */
+  return phase.attributes.participation_method === 'ideation'
+    ? `projects/${phase.relationships.project.data.id}/custom_form`
+    : `phases/${phase.id}/custom_form`;
+};
+
+export default getApiEndpoint;

--- a/front/app/api/custom_form/getApiEndpoint.ts
+++ b/front/app/api/custom_form/getApiEndpoint.ts
@@ -1,12 +1,13 @@
 import { IPhaseData } from 'api/phases/types';
 
 const getApiEndpoint = (phase: IPhaseData) => {
+  const participationMethod = phase.attributes.participation_method;
+
   /* For Ideation & voting, when you configure the form it gets applied to ALL ideation/voting phases within a project, 
   however when you configure the form for surveys for example, 
   each survey phase within a project can have a different form. 
   Hence we call different endpoints depending on the participation method. */
-  return phase.attributes.participation_method === 'ideation' ||
-    phase.attributes.participation_method === 'voting'
+  return participationMethod === 'ideation' || participationMethod === 'voting'
     ? `projects/${phase.relationships.project.data.id}/custom_form`
     : `phases/${phase.id}/custom_form`;
 };

--- a/front/app/api/custom_form/getApiEndpoint.ts
+++ b/front/app/api/custom_form/getApiEndpoint.ts
@@ -3,7 +3,8 @@ import { IPhaseData } from 'api/phases/types';
 const getApiEndpoint = (phase: IPhaseData) => {
   /* For Ideation & voting, when you configure the form it gets applied to ALL ideation/voting phases within a project, 
   however when you configure the form for surveys for example, 
-  each survey phase within a project can have a different form */
+  each survey phase within a project can have a different form. 
+  Hence we call different endpoints depending on the participation method. */
   return phase.attributes.participation_method === 'ideation' ||
     phase.attributes.participation_method === 'voting'
     ? `projects/${phase.relationships.project.data.id}/custom_form`

--- a/front/app/api/custom_form/types.ts
+++ b/front/app/api/custom_form/types.ts
@@ -1,14 +1,10 @@
+import { Multiloc } from 'typings';
+
 import { Keys } from 'utils/cl-react-query/types';
 
 import customFormKeys from './keys';
-import { Multiloc } from 'typings';
 
 export type CustomFormKeys = Keys<typeof customFormKeys>;
-
-export interface ICustomFormParameters {
-  projectId: string;
-  phaseId?: string;
-}
 
 export type CustomFormAttributes = {
   opened_at: string;

--- a/front/app/api/custom_form/useCustomForm.ts
+++ b/front/app/api/custom_form/useCustomForm.ts
@@ -1,15 +1,16 @@
 import { useQuery } from '@tanstack/react-query';
 import { CLErrors } from 'typings';
 
+import { IPhaseData } from 'api/phases/types';
+
 import fetcher from 'utils/cl-react-query/fetcher';
 
+import getApiEndpoint from './getApiEndpoint';
 import customFormKeys from './keys';
-import { CustomFormKeys, ICustomForm, ICustomFormParameters } from './types';
+import { CustomFormKeys, ICustomForm } from './types';
 
-const fetchCustomForm = ({ projectId, phaseId }: ICustomFormParameters) => {
-  const apiEndpoint = phaseId
-    ? `phases/${phaseId}/custom_form`
-    : `projects/${projectId}/custom_form`;
+const fetchCustomForm = (phase: IPhaseData) => {
+  const apiEndpoint = getApiEndpoint(phase);
 
   return fetcher<ICustomForm>({
     path: `/${apiEndpoint}`,
@@ -17,14 +18,13 @@ const fetchCustomForm = ({ projectId, phaseId }: ICustomFormParameters) => {
   });
 };
 
-const useCustomForm = ({ projectId, phaseId }: ICustomFormParameters) => {
+const useCustomForm = (phase: IPhaseData) => {
   return useQuery<ICustomForm, CLErrors, ICustomForm, CustomFormKeys>({
-    queryKey: customFormKeys.item({ projectId, phaseId }),
-    queryFn: () =>
-      fetchCustomForm({
-        projectId,
-        phaseId,
-      }),
+    queryKey: customFormKeys.item({
+      projectId: phase.relationships.project.data.id,
+      phaseId: phase.id,
+    }),
+    queryFn: () => fetchCustomForm(phase),
   });
 };
 

--- a/front/app/components/FormBuilder/edit/index.tsx
+++ b/front/app/components/FormBuilder/edit/index.tsx
@@ -23,6 +23,8 @@ import useFormCustomFields from 'api/custom_fields/useCustomFields';
 import useUpdateCustomField from 'api/custom_fields/useUpdateCustomFields';
 import { isNewCustomFieldObject } from 'api/custom_fields/util';
 import useCustomForm from 'api/custom_form/useCustomForm';
+import { IPhaseData } from 'api/phases/types';
+import usePhase from 'api/phases/usePhase';
 import useFormSubmissionCount from 'api/submission_count/useSubmissionCount';
 
 import FormBuilderSettings from 'components/FormBuilder/components/FormBuilderSettings';
@@ -62,21 +64,21 @@ type FormEditProps = {
   defaultValues: {
     customFields: IFlatCustomField[];
   };
-  projectId: string;
-  phaseId: string;
   builderConfig: FormBuilderConfig;
   totalSubmissions: number;
   viewFormLink: RouteType;
+  phase: IPhaseData;
 };
 
 const FormEdit = ({
   defaultValues,
-  phaseId,
-  projectId,
   builderConfig,
   totalSubmissions,
   viewFormLink,
+  phase,
 }: FormEditProps) => {
+  const phaseId = phase.id;
+  const projectId = phase.relationships.project.data.id;
   const { formatMessage } = useIntl();
   const [selectedField, setSelectedField] = useState<
     IFlatCustomFieldWithIndex | undefined
@@ -93,10 +95,7 @@ const FormEdit = ({
     phaseId: isFormPhaseSpecific ? phaseId : undefined,
   });
 
-  const { data: customForm } = useCustomForm({
-    projectId,
-    phaseId: isFormPhaseSpecific ? phaseId : undefined,
-  });
+  const { data: customForm } = useCustomForm(phase);
 
   // Set the form opened at date from the API date only when the form is first loaded
   const [formOpenedAt, setFormOpenedAt] = useState<string | undefined>();
@@ -512,14 +511,15 @@ const FormBuilderPage = ({
   viewFormLink,
 }: FormBuilderPageProps) => {
   const modalPortalElement = document.getElementById('modal-portal');
-  const { projectId, phaseId } = useParams();
+  const { phaseId } = useParams();
   const { data: submissionCount } = useFormSubmissionCount({
     phaseId,
   });
+  const { data: phase } = usePhase(phaseId);
 
   const formCustomFields = builderConfig.formCustomFields;
 
-  if (typeof projectId !== 'string' || typeof phaseId !== 'string') {
+  if (!phase) {
     return null;
   }
 
@@ -531,8 +531,7 @@ const FormBuilderPage = ({
     ? createPortal(
         <FormEdit
           defaultValues={{ customFields: formCustomFields }}
-          phaseId={phaseId}
-          projectId={projectId}
+          phase={phase.data}
           builderConfig={builderConfig}
           totalSubmissions={submissionCount.data.attributes.totalSubmissions}
           viewFormLink={viewFormLink}

--- a/front/app/containers/Admin/projects/project/inputForm/utils.tsx
+++ b/front/app/containers/Admin/projects/project/inputForm/utils.tsx
@@ -9,6 +9,7 @@ import { FormattedMessage } from 'utils/cl-intl';
 
 import messages from './messages';
 
+// ideationConfig is also used for participation method 'voting'
 export const ideationConfig: FormBuilderConfig = {
   type: 'input_form',
   formBuilderTitle: messages.inputForm,


### PR DESCRIPTION
Prep work to deal with custom form updates more easily. The end goal is to remove the need for isFormPhaseSpecific in the form builder config.

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->
