### PR TITLE
Fixed include_in_printed_form so that the correct default value saves

### DIFF
--- a/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
+++ b/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
@@ -176,8 +176,6 @@ module IdeaCustomFields
       given_fields = update_all_params.fetch :custom_fields, []
       given_field_ids = given_fields.pluck(:id)
 
-      binding.pry
-
       ActiveRecord::Base.transaction do
         delete_fields = fields.reject { |field| given_field_ids.include? field.id }
         delete_fields.each { |field| delete_field! field }

--- a/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
+++ b/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
@@ -176,6 +176,8 @@ module IdeaCustomFields
       given_fields = update_all_params.fetch :custom_fields, []
       given_field_ids = given_fields.pluck(:id)
 
+      binding.pry
+
       ActiveRecord::Base.transaction do
         delete_fields = fields.reject { |field| given_field_ids.include? field.id }
         delete_fields.each { |field| delete_field! field }

--- a/front/app/api/custom_fields/types.ts
+++ b/front/app/api/custom_fields/types.ts
@@ -109,6 +109,7 @@ export interface IAttributes {
   random_option_ordering?: boolean;
   dropdown_layout?: boolean;
   question_category?: string;
+  include_in_printed_form?: boolean;
 }
 
 export interface ICustomFieldResponse {
@@ -179,6 +180,7 @@ export type IFlatCreateCustomField = Optional<
   | 'dropdown_layout'
   | 'question_category'
   | 'ask_follow_up'
+  | 'include_in_printed_form'
 > & {
   isLocalOnly: boolean;
 };

--- a/front/app/components/FormBuilder/edit/index.tsx
+++ b/front/app/components/FormBuilder/edit/index.tsx
@@ -259,6 +259,7 @@ const FormEdit = ({
               page_button_label_multiloc:
                 field.page_button_label_multiloc || {},
               page_button_link: field.page_button_link || '',
+              include_in_printed_form: field.include_in_printed_form || false,
             }
           : {}),
         ...(field.map_config_id && {


### PR DESCRIPTION
# Changelog
## Fixed
- Ensured that correct value of include_in_printed_forms is saved to custom fields
