### PR TITLE
TAN-4568 Sentry impact tracking issue

### DIFF
--- a/front/app/modules/commercial/impact_tracking/index.ts
+++ b/front/app/modules/commercial/impact_tracking/index.ts
@@ -117,12 +117,7 @@ const configuration: ModuleConfiguration = {
 
       if (hasLocale(strippedPath)) {
         if (!sessionTracked) {
-          // We add a small timeout, because some browsers
-          // seem to block the request if it happens too fast.
-          setTimeout(() => {
-            trackSessionStarted(strippedPath); // This will also track the first page view
-          }, 1000);
-
+          trackSessionStarted(strippedPath); // This will also track the first page view
           sessionTracked = true;
         } else {
           trackPageView(strippedPath);

--- a/front/app/modules/commercial/impact_tracking/index.ts
+++ b/front/app/modules/commercial/impact_tracking/index.ts
@@ -117,7 +117,12 @@ const configuration: ModuleConfiguration = {
 
       if (hasLocale(strippedPath)) {
         if (!sessionTracked) {
-          trackSessionStarted(strippedPath); // This will also track the first page view
+          // We add a small timeout, because some browsers
+          // seem to block the request if it happens too fast.
+          setTimeout(() => {
+            trackSessionStarted(strippedPath); // This will also track the first page view
+          }, 1000);
+
           sessionTracked = true;
         } else {
           trackPageView(strippedPath);

--- a/front/app/modules/commercial/impact_tracking/index.ts
+++ b/front/app/modules/commercial/impact_tracking/index.ts
@@ -1,6 +1,6 @@
 import createRoutes from 'routes';
 
-import { API_PATH } from 'containers/App/constants';
+import { API_PATH, locales } from 'containers/App/constants';
 import authenticationTracks from 'containers/Authentication/tracks';
 
 import { events$, pageChanges$ } from 'utils/analytics';
@@ -8,7 +8,6 @@ import { getJwt } from 'utils/auth/jwt';
 import fetcher from 'utils/cl-react-query/fetcher';
 import matchPath, { getAllPathsFromRoutes } from 'utils/matchPath';
 import { ModuleConfiguration } from 'utils/moduleUtils';
-import { locales } from 'containers/App/constants';
 
 let sessionId: string | undefined;
 let allAppPaths: string[] | undefined;

--- a/front/app/modules/commercial/impact_tracking/index.ts
+++ b/front/app/modules/commercial/impact_tracking/index.ts
@@ -8,12 +8,14 @@ import { getJwt } from 'utils/auth/jwt';
 import fetcher from 'utils/cl-react-query/fetcher';
 import matchPath, { getAllPathsFromRoutes } from 'utils/matchPath';
 import { ModuleConfiguration } from 'utils/moduleUtils';
+import { locales } from 'containers/App/constants';
 
 let sessionId: string | undefined;
 let allAppPaths: string[] | undefined;
 let previousPathTracked: string | undefined;
+let sessionTracked = false;
 
-const trackSessionStarted = async () => {
+const trackSessionStarted = async (path: string) => {
   // eslint-disable-next-line
   const referrer = document.referrer ?? window.frames?.top?.document.referrer;
 
@@ -46,7 +48,7 @@ const trackSessionStarted = async () => {
 
   // Because the first page view depends on the response of the session creation,
   // we handle it here and ignore the first page view event (see below).
-  trackPageView(window.location.pathname);
+  trackPageView(path);
 };
 
 const upgradeSession = () => {
@@ -65,15 +67,6 @@ const trackPageView = async (path: string) => {
   // For some reason, sometimes the page view event is triggered twice
   // for the same path. This prevents that.
   if (previousPathTracked === path) return;
-
-  // On first homepage load, if we don't enter the platform on a locale,
-  // we set the locale immediately. Usually, we set the locale before the
-  // page track event fires, but in some cases our app is too slow.
-  // This then triggers the page view event twice.
-  // With this check, we avoid logging this pageview twice.
-  // We check both '/' and '' because the path can be either-
-  // usually it's '/' but some browsers seem to omit the trailing slash.
-  if (path === '/' || path === '') return;
 
   // We also only start tracking page views after the session has been created.
   if (sessionId === undefined) return;
@@ -99,12 +92,37 @@ const trackPageView = async (path: string) => {
   });
 };
 
+const stripPath = (path: string) => {
+  if (path.length < 2) return path;
+  if (path.endsWith('/')) return path.slice(0, -1);
+  return path;
+};
+
+const hasLocale = (path: string) => {
+  for (const locale of locales) {
+    if (path.startsWith(`/${locale}/`) || path === `/${locale}`) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
 const configuration: ModuleConfiguration = {
   beforeMountApplication: () => {
-    trackSessionStarted();
-
     pageChanges$.subscribe((e) => {
-      trackPageView(e.path);
+      // We remove the trailing slash from the path,
+      // so that we don't track e.g. /en and /en/ as two different paths.
+      const strippedPath = stripPath(e.path);
+
+      if (hasLocale(strippedPath)) {
+        if (!sessionTracked) {
+          trackSessionStarted(strippedPath); // This will also track the first page view
+          sessionTracked = true;
+        } else {
+          trackPageView(strippedPath);
+        }
+      }
     });
 
     events$.subscribe((event) => {


### PR DESCRIPTION
Explanation:

So I did a bit of research on why we could be getting these errors: the `TypeError: Load failed` (seems to happen only on apple devices) and the  `TypeError: Failed to fetch` (seems to happen mostly on windows devices). Both of these issues seem to point at a general fetch failure error, which does not give us much to work with. However, I found the following two links:

- https://developer.apple.com/forums/thread/771127
- https://stackoverflow.com/a/56908493

In both cases, the issue seems related to the POST request being fired very soon after the page loads. In the second link, it is also related to the page reloading very soon. So I figured, maybe it will help if this request fires a little bit later, and after any redirects that might happen (e.g. when you visit `/ideas` and it redirects to `/en/ideas`). So I made sure that the request is only made after the URL has a valid locale, and it now also waits until the `App` container is rendered. This delays the first request with maybe 0.5 - 1 second, which could be enough.

I also made sure that we reduce the number of duplicates in our pageviews table. We currently have quite some sessions where we track `/`, followed by `/en`, for example. Or we have both  `/en/` and `/en` as paths. I now made sure that we only track URLs with locales, and always strip the last slash for paths longer than 1 character, so that we reduce duplication.

I am not sure if this will solve the sentry issue, but I think we can try releasing this and see what happens? In any case it is an improvement to the code :) if the issue persists we can look further into this. Let me know if you have any questions! One thing that I didn't check is the BE logs, maybe if this does not do anything we can look into that next and see if we also see the request failling on the BE, or if the request never even makes it there. But I couldn't really see any reason for the BE to fail, except if the user is detected to be a bot.

# Changelog
## Changed
- Make page tracking a bit cleaner, remove duplicates etc
- Only save session once the locale is available and after small delay
