### PR TITLE
TAN-4585 Only generate heatmaps for analyses with less than 50 questions

### DIFF
--- a/back/engines/commercial/analysis/app/jobs/analysis/heatmap_generation_job.rb
+++ b/back/engines/commercial/analysis/app/jobs/analysis/heatmap_generation_job.rb
@@ -18,7 +18,7 @@ module Analysis
       additional_custom_field_ids = analysis.additional_custom_fields.pluck(:id)
 
       if participants_count >= 30 &&
-         analysis.associated_custom_fields <= 50 && # Arbitrary limit to avoid the curse of dimensionality
+         analysis.associated_custom_fields.size <= 50 && # Arbitrary limit to avoid the curse of dimensionality
          (newest_activity.nil? ||
           newest_activity.payload['participants_count'] != participants_count ||
           newest_activity.payload['inputs_count'] != inputs_count ||

--- a/back/engines/commercial/analysis/app/jobs/analysis/heatmap_generation_job.rb
+++ b/back/engines/commercial/analysis/app/jobs/analysis/heatmap_generation_job.rb
@@ -18,6 +18,7 @@ module Analysis
       additional_custom_field_ids = analysis.additional_custom_fields.pluck(:id)
 
       if participants_count >= 30 &&
+         analysis.associated_custom_fields <= 50 && # Arbitrary limit to avoid the curse of dimensionality
          (newest_activity.nil? ||
           newest_activity.payload['participants_count'] != participants_count ||
           newest_activity.payload['inputs_count'] != inputs_count ||


### PR DESCRIPTION
# Changelog
## Fixed
- Recent delayed email issues have been resolved. They were caused by slow and massive calculations of Auto-Insights for very large surveys. As a temporary solution, auto-insights or heatmaps no longer work for analyses with more than 50 questions.