### PR TITLE
TAN-4580: Filter disabled and hidden for residents in custom field policy

### DIFF
--- a/back/app/policies/custom_field_policy.rb
+++ b/back/app/policies/custom_field_policy.rb
@@ -10,7 +10,7 @@ class CustomFieldPolicy < ApplicationPolicy
     def resolve
       if user && UserRoleService.new.can_moderate?(custom_form&.participation_context, user)
         scope.all
-      elsif !custom_form || policy_for(project).show?
+      elsif !custom_form&.participation_context || policy_for(custom_form.participation_context).show?
         scope.not_hidden.enabled
       else
         scope.none

--- a/back/app/policies/custom_field_policy.rb
+++ b/back/app/policies/custom_field_policy.rb
@@ -1,0 +1,20 @@
+class CustomFieldPolicy < ApplicationPolicy
+  class Scope < ApplicationPolicy::Scope
+    attr_reader :custom_form
+
+    def initialize(user_context, scope, custom_form = nil)
+      super(user_context, scope)
+      @custom_form = custom_form
+    end
+
+    def resolve
+      if user && UserRoleService.new.can_moderate?(custom_form&.participation_context, user)
+        scope.all
+      elsif !custom_form || policy_for(project).show?
+        scope.not_hidden.enabled
+      else
+        scope.none
+      end
+    end
+  end
+end

--- a/back/app/policies/custom_field_policy.rb
+++ b/back/app/policies/custom_field_policy.rb
@@ -17,4 +17,15 @@ class CustomFieldPolicy < ApplicationPolicy
       end
     end
   end
+
+  def show?
+    form = record.custom_form
+    if user && UserRoleService.new.can_moderate?(form&.participation_context, user)
+      true
+    elsif !form&.participation_context || policy_for(form.participation_context).show?
+      !record.hidden? && record.enabled?
+    else
+      false
+    end
+  end
 end

--- a/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
+++ b/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
@@ -30,9 +30,12 @@ module IdeaCustomFields
 
     def index
       authorize CustomField.new(resource: @custom_form), :index?, policy_class: IdeaCustomFieldPolicy
-      service = IdeaCustomFieldsService.new(@custom_form)
 
-      fields = params[:copy] == 'true' ? service.duplicate_all_fields : service.all_fields
+      fields = if params[:copy] == 'true'
+        IdeaCustomFieldsService.new(@custom_form).duplicate_all_fields
+      else
+        CustomFieldPolicy::Scope.new(pundit_user, CustomField, @custom_form).resolve
+      end
       fields = fields.filter(&:support_free_text_value?) if params[:support_free_text_value].present?
       fields = fields.filter { |field| params[:input_types].include?(field.input_type) } if params[:input_types].present?
 

--- a/back/engines/commercial/idea_custom_fields/app/policies/idea_custom_fields/idea_custom_field_policy.rb
+++ b/back/engines/commercial/idea_custom_fields/app/policies/idea_custom_fields/idea_custom_field_policy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module IdeaCustomFields
-  class IdeaCustomFieldPolicy < ApplicationPolicy
+  class IdeaCustomFieldPolicy < CustomFieldPolicy
     def index?
       can_access_custom_fields? record
     end

--- a/back/engines/commercial/idea_custom_fields/app/policies/idea_custom_fields/idea_custom_field_policy.rb
+++ b/back/engines/commercial/idea_custom_fields/app/policies/idea_custom_fields/idea_custom_field_policy.rb
@@ -7,7 +7,7 @@ module IdeaCustomFields
     end
 
     def show?
-      can_access_custom_fields? record
+      super && can_access_custom_fields?(record)
     end
 
     def update_all?

--- a/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/project_context/index_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/project_context/index_spec.rb
@@ -72,5 +72,25 @@ resource 'Idea Custom Fields' do
         ]
       end
     end
+
+    context 'when resident' do
+      let!(:hidden_field) { create(:custom_field_text, resource: form, key: 'extra_field2', hidden: true) }
+      let!(:disabled_field) { create(:custom_field_text, resource: form, key: 'extra_field3', enabled: false) }
+
+      before { resident_header_token }
+
+      example_request 'List all allowed custom fields for a project' do
+        assert_status 200
+        json_response = json_parse response_body
+        expect(json_response[:data].size).to eq 12
+        expect(json_response[:data].map { |d| d.dig(:attributes, :key) }).to eq [
+          nil, 'title_multiloc',
+          nil, 'body_multiloc',
+          nil, 'idea_images_attributes', 'idea_files_attributes',
+          nil, 'topic_ids', 'location_description',
+          'extra_field1', 'form_end'
+        ]
+      end
+    end
   end
 end

--- a/back/engines/commercial/user_custom_fields/app/controllers/user_custom_fields/web_api/v1/user_custom_fields_controller.rb
+++ b/back/engines/commercial/user_custom_fields/app/controllers/user_custom_fields/web_api/v1/user_custom_fields_controller.rb
@@ -7,7 +7,7 @@ module UserCustomFields
     skip_after_action :verify_policy_scoped
 
     def index
-      @custom_fields = policy_scope(CustomField, policy_scope_class: UserCustomFieldPolicy::Scope)
+      @custom_fields = policy_scope(CustomField.registration, policy_scope_class: UserCustomFieldPolicy::Scope)
         .registration.order(:ordering)
       @custom_fields = @custom_fields.where(input_type: params[:input_types]) if params[:input_types]
 

--- a/back/engines/commercial/user_custom_fields/app/controllers/user_custom_fields/web_api/v1/user_custom_fields_controller.rb
+++ b/back/engines/commercial/user_custom_fields/app/controllers/user_custom_fields/web_api/v1/user_custom_fields_controller.rb
@@ -7,7 +7,7 @@ module UserCustomFields
     skip_after_action :verify_policy_scoped
 
     def index
-      @custom_fields = policy_scope(CustomField.registration, policy_scope_class: UserCustomFieldPolicy::Scope)
+      @custom_fields = policy_scope(CustomField, policy_scope_class: UserCustomFieldPolicy::Scope)
         .registration.order(:ordering)
       @custom_fields = @custom_fields.where(input_type: params[:input_types]) if params[:input_types]
 

--- a/back/engines/commercial/user_custom_fields/app/controllers/user_custom_fields/web_api/v1/user_custom_fields_controller.rb
+++ b/back/engines/commercial/user_custom_fields/app/controllers/user_custom_fields/web_api/v1/user_custom_fields_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module UserCustomFields
-  class WebApi::V1::UserCustomFieldsController < ApplicationController
+  class WebApi::V1::UserCustomFieldsController < CustomFieldPolicy
     before_action :set_custom_field, only: %i[show update reorder destroy]
     skip_before_action :authenticate_user
     skip_after_action :verify_policy_scoped

--- a/back/engines/commercial/user_custom_fields/app/controllers/user_custom_fields/web_api/v1/user_custom_fields_controller.rb
+++ b/back/engines/commercial/user_custom_fields/app/controllers/user_custom_fields/web_api/v1/user_custom_fields_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module UserCustomFields
-  class WebApi::V1::UserCustomFieldsController < CustomFieldPolicy
+  class WebApi::V1::UserCustomFieldsController < ApplicationController
     before_action :set_custom_field, only: %i[show update reorder destroy]
     skip_before_action :authenticate_user
     skip_after_action :verify_policy_scoped

--- a/back/engines/commercial/user_custom_fields/app/policies/user_custom_fields/user_custom_field_policy.rb
+++ b/back/engines/commercial/user_custom_fields/app/policies/user_custom_fields/user_custom_field_policy.rb
@@ -2,12 +2,6 @@
 
 module UserCustomFields
   class UserCustomFieldPolicy < ApplicationPolicy
-    class Scope < ApplicationPolicy::Scope
-      def resolve
-        scope
-      end
-    end
-
     def create?
       user&.active? && user.admin? && !record.code
     end

--- a/back/engines/commercial/user_custom_fields/app/policies/user_custom_fields/user_custom_field_policy.rb
+++ b/back/engines/commercial/user_custom_fields/app/policies/user_custom_fields/user_custom_field_policy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module UserCustomFields
-  class UserCustomFieldPolicy < ApplicationPolicy
+  class UserCustomFieldPolicy < CustomFieldPolicy
     def create?
       user&.active? && user.admin? && !record.code
     end

--- a/back/engines/commercial/user_custom_fields/spec/acceptance/user_custom_fields_spec.rb
+++ b/back/engines/commercial/user_custom_fields/spec/acceptance/user_custom_fields_spec.rb
@@ -18,10 +18,12 @@ resource 'User Custom Fields' do
     end
     parameter :input_types, "Array of input types. Only return custom fields for the given types. Allowed values: #{CustomField::INPUT_TYPES.join(', ')}", required: false
 
-    example_request 'List all custom fields' do
-      expect(status).to eq(200)
-      json_response = json_parse(response_body)
-      expect(json_response[:data].size).to eq 3
+    example 'List all accessible custom fields' do
+      create(:custom_field, enabled: false)
+      create(:custom_field, hidden: true)
+      do_request
+      assert_status 200
+      expect(json_response_body[:data].size).to eq 3
     end
 
     example 'List all custom fields with the projects that they are used in' do

--- a/back/spec/policies/custom_field_policy_spec.rb
+++ b/back/spec/policies/custom_field_policy_spec.rb
@@ -1,25 +1,143 @@
 require 'rails_helper'
 
 describe CustomFieldPolicy do
-  let(:scope) { CustomFieldPolicy::Scope.new(user, CustomField.where(custom_form_id: custom_form.id), custom_form) }
+  subject(:policy) { described_class.new(user, field) }
 
-  let(:custom_form) { create(:custom_form) }
-  let(:visible_field) { create(:custom_field, hidden: false, enabled: true, custom_form: custom_form) }
-  let(:disabled_field) { create(:custom_field, hidden: false, enabled: false, custom_form: custom_form) }
-  let(:hidden_field) { create(:custom_field, hidden: true, enabled: true, custom_form: custom_form) }
+  let(:scope) { CustomFieldPolicy::Scope.new(user, CustomField.where(resource_id: custom_form&.id), custom_form) }
 
-  context 'for a visitor who cannot see the form context' do
+  let(:custom_form) { create(:custom_form, participation_context: context) }
+  let(:resource_atts) { {}.tap { |h| custom_form ? h[:resource] = custom_form : h[:resource_type] = 'User' } }
+  let!(:visible_field) { create(:custom_field, hidden: false, enabled: true, **resource_atts) }
+  let!(:disabled_field) { create(:custom_field, hidden: false, enabled: false, **resource_atts) }
+  let!(:hidden_field) { create(:custom_field, hidden: true, enabled: true, **resource_atts) }
+
+  context 'for a visitor' do
     let(:user) { nil }
-    let(:custom_form) { create(:custom_form, participation_context: create(:private_admins_project)) }
 
-    it 'does not index any field' do
-      expect(scope.resolve.size).to eq 0
+    context 'cannot see the form context' do
+      let(:context) { create(:private_admins_project) }
+
+      context 'visible field' do
+        let(:field) { visible_field }
+
+        it { is_expected.not_to permit(:show) }
+      end
+
+      it 'does not index any field' do
+        expect(scope.resolve.size).to eq 0
+      end
+    end
+
+    context 'can see the form context' do
+      let(:context) { create(:project) }
+
+      context 'visible field' do
+        let(:field) { visible_field }
+
+        it { is_expected.to permit(:show) }
+      end
+
+      context 'disabled field' do
+        let(:field) { disabled_field }
+
+        it { is_expected.not_to permit(:show) }
+      end
+
+      context 'hidden field' do
+        let(:field) { hidden_field }
+
+        it { is_expected.not_to permit(:show) }
+      end
+
+      it 'indexes only visible fields' do
+        expect(scope.resolve.size).to eq 1
+        expect(scope.resolve).to match_array [visible_field]
+      end
+    end
+
+    context 'registration form' do
+      let(:custom_form) { nil }
+
+      context 'visible field' do
+        let(:field) { visible_field }
+
+        it { is_expected.to permit(:show) }
+      end
+
+      context 'disabled field' do
+        let(:field) { disabled_field }
+
+        it { is_expected.not_to permit(:show) }
+      end
+
+      context 'hidden field' do
+        let(:field) { hidden_field }
+
+        it { is_expected.not_to permit(:show) }
+      end
+
+      it 'indexes only visible fields' do
+        expect(scope.resolve.size).to eq 1
+        expect(scope.resolve).to match_array [visible_field]
+      end
     end
   end
 
-  # visitor cannot see project
-  # visitor can see project
-  # moderator can moderate form
-  # moderator cannot moderate form
-  # admin for registration fields
+  context 'for a moderator' do
+    let(:user) { create(:admin) }
+
+    context 'input form' do
+      let(:context) { create(:native_survey_phase) }
+
+      context 'visible field' do
+        let(:field) { visible_field }
+
+        it { is_expected.to permit(:show) }
+      end
+
+      context 'disabled field' do
+        let(:field) { disabled_field }
+
+        it { is_expected.to permit(:show) }
+      end
+
+      context 'hidden field' do
+        let(:field) { hidden_field }
+
+        it { is_expected.to permit(:show) }
+      end
+
+      it 'indexes all fields' do
+        expect(scope.resolve.size).to eq 3
+        expect(scope.resolve).to match_array [visible_field, disabled_field, hidden_field]
+      end
+    end
+
+    context 'registration form' do
+      let(:custom_form) { nil }
+
+      context 'visible field' do
+        let(:field) { visible_field }
+
+        it { is_expected.to permit(:show) }
+      end
+
+      context 'disabled field' do
+        let(:field) { disabled_field }
+
+        it { is_expected.to permit(:show) }
+      end
+
+      context 'hidden field' do
+        let(:field) { hidden_field }
+
+        it { is_expected.to permit(:show) }
+      end
+
+      it 'indexes all fields' do
+        expect(scope.resolve.size).to eq 3
+        expect(scope.resolve).to match_array [visible_field, disabled_field, hidden_field]
+      end
+    end
+  end
 end

--- a/back/spec/policies/custom_field_policy_spec.rb
+++ b/back/spec/policies/custom_field_policy_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe CustomFieldPolicy do
+  let(:scope) { CustomFieldPolicy::Scope.new(user, CustomField.where(custom_form_id: custom_form.id), custom_form) }
+
+  let(:custom_form) { create(:custom_form) }
+  let(:visible_field) { create(:custom_field, hidden: false, enabled: true, custom_form: custom_form) }
+  let(:disabled_field) { create(:custom_field, hidden: false, enabled: false, custom_form: custom_form) }
+  let(:hidden_field) { create(:custom_field, hidden: true, enabled: true, custom_form: custom_form) }
+
+  context 'for a visitor who cannot see the form context' do
+    let(:user) { nil }
+    let(:custom_form) { create(:custom_form, participation_context: create(:private_admins_project)) }
+
+    it 'does not index any field' do
+      expect(scope.resolve.size).to eq 0
+    end
+  end
+
+  # visitor cannot see project
+  # visitor can see project
+  # moderator can moderate form
+  # moderator cannot moderate form
+  # admin for registration fields
+end

--- a/back/spec/policies/custom_field_policy_spec.rb
+++ b/back/spec/policies/custom_field_policy_spec.rb
@@ -11,132 +11,88 @@ describe CustomFieldPolicy do
   let!(:disabled_field) { create(:custom_field, hidden: false, enabled: false, **resource_atts) }
   let!(:hidden_field) { create(:custom_field, hidden: true, enabled: true, **resource_atts) }
 
+  shared_examples 'can see all fields' do
+    %i[visible_field disabled_field hidden_field].each do |field_name|
+      context field_name.to_s do
+        let(:field) { send(field_name) }
+
+        it { is_expected.to permit(:show) }
+      end
+    end
+
+    it 'indexes all fields' do
+      expect(scope.resolve).to match_array [visible_field, disabled_field, hidden_field]
+    end
+  end
+
+  shared_examples 'can see only visible fields' do
+    [
+      [:visible_field, true],
+      [:disabled_field, false],
+      [:hidden_field, false]
+    ].each do |field_name, permitted|
+      context field_name.to_s do
+        let(:field) { send(field_name) }
+
+        it { is_expected.send(permitted ? :to : :not_to, permit(:show)) }
+      end
+    end
+
+    it 'indexes only visible fields' do
+      expect(scope.resolve).to match_array [visible_field]
+    end
+  end
+
+  shared_examples 'cannot see any fields' do
+    %i[visible_field disabled_field hidden_field].each do |field_name|
+      context field_name.to_s do
+        let(:field) { send(field_name) }
+
+        it { is_expected.not_to permit(:show) }
+      end
+    end
+
+    it 'does not index any field' do
+      expect(scope.resolve).to be_empty
+    end
+  end
+
   context 'for a visitor' do
     let(:user) { nil }
 
     context 'cannot see the form context' do
       let(:context) { create(:private_admins_project) }
 
-      context 'visible field' do
-        let(:field) { visible_field }
-
-        it { is_expected.not_to permit(:show) }
-      end
-
-      it 'does not index any field' do
-        expect(scope.resolve.size).to eq 0
-      end
+      include_examples 'cannot see any fields'
     end
 
     context 'can see the form context' do
       let(:context) { create(:project) }
 
-      context 'visible field' do
-        let(:field) { visible_field }
-
-        it { is_expected.to permit(:show) }
-      end
-
-      context 'disabled field' do
-        let(:field) { disabled_field }
-
-        it { is_expected.not_to permit(:show) }
-      end
-
-      context 'hidden field' do
-        let(:field) { hidden_field }
-
-        it { is_expected.not_to permit(:show) }
-      end
-
-      it 'indexes only visible fields' do
-        expect(scope.resolve.size).to eq 1
-        expect(scope.resolve).to match_array [visible_field]
-      end
+      include_examples 'can see only visible fields'
     end
 
     context 'registration form' do
       let(:custom_form) { nil }
 
-      context 'visible field' do
-        let(:field) { visible_field }
-
-        it { is_expected.to permit(:show) }
-      end
-
-      context 'disabled field' do
-        let(:field) { disabled_field }
-
-        it { is_expected.not_to permit(:show) }
-      end
-
-      context 'hidden field' do
-        let(:field) { hidden_field }
-
-        it { is_expected.not_to permit(:show) }
-      end
-
-      it 'indexes only visible fields' do
-        expect(scope.resolve.size).to eq 1
-        expect(scope.resolve).to match_array [visible_field]
-      end
+      include_examples 'can see only visible fields'
     end
   end
 
   context 'for a moderator' do
     let(:user) { create(:admin) }
 
-    context 'input form' do
-      let(:context) { create(:native_survey_phase) }
+    %i[input_form registration_form].each do |form_type|
+      context form_type.to_s do
+        let(:custom_form) do
+          if form_type == :registration_form
+            nil
+          else
+            create(:custom_form, participation_context: create(:native_survey_phase))
+          end
+        end
 
-      context 'visible field' do
-        let(:field) { visible_field }
-
-        it { is_expected.to permit(:show) }
-      end
-
-      context 'disabled field' do
-        let(:field) { disabled_field }
-
-        it { is_expected.to permit(:show) }
-      end
-
-      context 'hidden field' do
-        let(:field) { hidden_field }
-
-        it { is_expected.to permit(:show) }
-      end
-
-      it 'indexes all fields' do
-        expect(scope.resolve.size).to eq 3
-        expect(scope.resolve).to match_array [visible_field, disabled_field, hidden_field]
-      end
-    end
-
-    context 'registration form' do
-      let(:custom_form) { nil }
-
-      context 'visible field' do
-        let(:field) { visible_field }
-
-        it { is_expected.to permit(:show) }
-      end
-
-      context 'disabled field' do
-        let(:field) { disabled_field }
-
-        it { is_expected.to permit(:show) }
-      end
-
-      context 'hidden field' do
-        let(:field) { hidden_field }
-
-        it { is_expected.to permit(:show) }
-      end
-
-      it 'indexes all fields' do
-        expect(scope.resolve.size).to eq 3
-        expect(scope.resolve).to match_array [visible_field, disabled_field, hidden_field]
+        include_examples 'can see all fields'
       end
     end
   end


### PR DESCRIPTION
As we're looking into removing the JSON/UI schema endpoints, we need to be able to instead get the corresponding fields from the custom fields controllers (index). The main difference is that hidden and disabled fields are not included in the schemas, and so we decided to leave out those fields for residents.
