### PR TITLE
[TAN-4476] Add title to cookie policy iframe

### DIFF
--- a/front/app/containers/CookiePolicy/index.tsx
+++ b/front/app/containers/CookiePolicy/index.tsx
@@ -59,7 +59,10 @@ const CookiePolicy = () => {
           <Container>
             <PageContent>
               <StyledContentContainer>
-                <Fragment name="pages/cookie-policy/content">
+                <Fragment
+                  name="pages/cookie-policy/content"
+                  title={formatMessage(messages.cookiePolicyTitle)}
+                >
                   <PageTitle>
                     {pageAttributes?.title_multiloc ? (
                       <T value={pageAttributes.title_multiloc} />


### PR DESCRIPTION
# Changelog
## Fixed
- [TAN-4476] Fixed accessibility issue where custom cookie policy iframes did not have a title.
