### PR TITLE
[TAN-4361] Make sure focus ring is visible for homepage project widgets when navigating with keyboard

### DIFF
--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/BaseCard.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/BaseCard.tsx
@@ -8,6 +8,11 @@ import { CARD_IMAGE_ASPECT_RATIO } from 'api/project_images/useProjectImages';
 import ImagePlaceholder from 'components/ProjectCard/ImagePlaceholder';
 
 export const CardContainer = styled(Box)`
+  &:focus-visible {
+    margin-left: 12px;
+    margin-top: 2px;
+    margin-bottom: 2px;
+  }
   &:hover {
     h3 {
       color: ${({ theme }) => theme.colors.tenantPrimary};


### PR DESCRIPTION
# Changelog
## Fixed
- [TAN-4361] Accessibility Fix: Make sure focus ring is fully visible for homepage project widgets when navigating with keyboard.
