### PR TITLE
Fix E2E master

### DIFF
--- a/front/cypress/e2e/survey_builder/create_and_fill_survey.cy.ts
+++ b/front/cypress/e2e/survey_builder/create_and_fill_survey.cy.ts
@@ -3,9 +3,9 @@ import { randomString, randomEmail } from '../../support/commands';
 import moment = require('moment');
 
 const waitForCustomFormFields = () => {
-  cy.intercept('**/phases/**/custom_fields').as('customFields');
+  cy.intercept('**/phases/**/custom_fields**').as('customFields');
   cy.intercept('**/phases/**/custom_form').as('customForm');
-  cy.wait('@customFields');
+  cy.wait('@customFields', { timeout: 10000 });
   cy.wait('@customForm');
   cy.wait(1000);
 };


### PR DESCRIPTION
It seems like `?copy=false` was added to the custom fields request by someone, which broke the E2E tests. Iva helped me fix this. I'm also running the E2E tests on CI to be (as) sure (as possible) there's no issues there: https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/263889/workflows/00799099-73b4-4b94-ba4b-e9ea333f639d