### PR TITLE
TAN-4600 Avg pages and seconds per session: ignore sessions without pageviews

### DIFF
--- a/back/engines/commercial/report_builder/app/services/report_builder/queries/visitors.rb
+++ b/back/engines/commercial/report_builder/app/services/report_builder/queries/visitors.rb
@@ -98,7 +98,10 @@ module ReportBuilder
       # Calculate avg pages visited per session
       # Or, if project filter is applied:
       # Avg pages visited per session where someone visited the project during the session
-      avg_pages_visited = visits == 0 ? 0 : pageviews.count / visits.to_f
+      # ALSO: here we only sessions that have pageviews, otherwise we might
+      # also count sessions without pageviews (from before we collected pageview data)
+      visits_with_pageviews = pageviews.select(:session_id).distinct.count
+      avg_pages_visited = visits_with_pageviews == 0 ? 0 : pageviews.count / visits_with_pageviews.to_f
 
       # Avg seconds per session
       # Because we can only know the time spent on a page if there is

--- a/back/engines/commercial/report_builder/spec/services/report_builder/queries/visitors_spec.rb
+++ b/back/engines/commercial/report_builder/spec/services/report_builder/queries/visitors_spec.rb
@@ -276,7 +276,7 @@ RSpec.describe ReportBuilder::Queries::Visitors do
     it 'for avg seconds and pages per session: it ignores sessions without pageviews' do
       # Create sessions with no pageviews
       10.times do
-        session = create(:session, created_at: Date.new(2022, 7, 2), monthly_user_hash: 'some_hash')
+        create(:session, created_at: Date.new(2022, 7, 2), monthly_user_hash: 'some_hash')
       end
 
       params = {

--- a/back/engines/commercial/report_builder/spec/services/report_builder/queries/visitors_spec.rb
+++ b/back/engines/commercial/report_builder/spec/services/report_builder/queries/visitors_spec.rb
@@ -272,5 +272,24 @@ RSpec.describe ReportBuilder::Queries::Visitors do
       expect(result[:avg_seconds_per_session_whole_period]).to eq(180)
       expect(result[:avg_pages_visited_whole_period]).to eq(2)
     end
+
+    it 'for avg seconds and pages per session: it ignores sessions without pageviews' do
+      # Create sessions with no pageviews
+      10.times do
+        session = create(:session, created_at: Date.new(2022, 7, 2), monthly_user_hash: 'some_hash')
+      end
+
+      params = {
+        start_at: Date.new(2022, 7, 1),
+        end_at: Date.new(2023, 1, 1)
+      }
+
+      result = query.run_query(**params)
+
+      expect(result[:visits_whole_period]).to eq(18) # should increase
+      expect(result[:visitors_whole_period]).to eq(5) # should increase
+      expect(result[:avg_seconds_per_session_whole_period]).to eq(135) # should not be affected
+      expect(result[:avg_pages_visited_whole_period]).to eq(1.5) # should not be affected
+    end
   end
 end


### PR DESCRIPTION
# Changelog
## Fixed
- Visitors dashboard: average pages and seconds per visit were incorrect due to mistake in calculation. Fixed now