### PR TITLE
fix e2e: Add overlooked warning modal to survey edit button

### DIFF
--- a/front/app/containers/Admin/projects/project/nativeSurvey/index.tsx
+++ b/front/app/containers/Admin/projects/project/nativeSurvey/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { Box, Title, Toggle, Spinner } from '@citizenlab/cl2-component-library';
+import { Box, Spinner, Title, Toggle } from '@citizenlab/cl2-component-library';
 import { useParams } from 'react-router-dom';
 
 import usePhase from 'api/phases/usePhase';
@@ -15,7 +15,6 @@ import useLocale from 'hooks/useLocale';
 import FormResults from 'components/admin/FormResults';
 import DeleteModal from 'components/admin/SurveyDeleteModal/SurveyDeleteModal';
 import DropdownSettings from 'components/admin/SurveyDropdownSettings/DropdownSettings';
-import EditWarningModal from 'components/admin/SurveyEditWarningModal';
 import Button from 'components/UI/ButtonWithLink';
 
 import { useIntl } from 'utils/cl-intl';
@@ -46,7 +45,6 @@ const Forms = () => {
 
   // Modal states
   const [showDeleteModal, setShowDeleteModal] = useState(false);
-  const [showEditWarningModal, setShowEditWarningModal] = useState(false);
   const [showCopySurveyModal, setShowCopySurveyModal] = useState(false);
 
   // Other states
@@ -164,12 +162,6 @@ const Forms = () => {
           </Box>
         </Box>
         <FormResults />
-        <EditWarningModal
-          editFormLink={editFormLink}
-          showEditWarningModal={showEditWarningModal}
-          setShowEditWarningModal={setShowEditWarningModal}
-          handleDownloadResults={handleDownloadResults}
-        />
         <CopySurveyModal
           editFormLink={editFormLink}
           showCopySurveyModal={showCopySurveyModal}

--- a/front/app/containers/Admin/projects/project/surveyForm/EditButtonWithWarningModal.tsx
+++ b/front/app/containers/Admin/projects/project/surveyForm/EditButtonWithWarningModal.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+
+import { RouteType } from 'routes';
+
+import usePhase from 'api/phases/usePhase';
+import useFormSubmissionCount from 'api/submission_count/useSubmissionCount';
+import { downloadSurveyResults } from 'api/survey_results/utils';
+
+import useLocale from 'hooks/useLocale';
+
+import EditWarningModal from 'components/admin/SurveyEditWarningModal';
+import Button from 'components/UI/ButtonWithLink';
+
+import { FormattedMessage } from 'utils/cl-intl';
+import clHistory from 'utils/cl-router/history';
+
+import messages from './messages';
+
+interface Props {
+  projectId: string;
+  phaseId: string;
+}
+
+const EditButtonWithWarningModal = ({ projectId, phaseId }: Props) => {
+  const [showEditWarningModal, setShowEditWarningModal] = useState(false);
+  const editFormLink: RouteType = `/admin/projects/${projectId}/phases/${phaseId}/native-survey/edit`;
+  const locale = useLocale();
+  const { data: phase } = usePhase(phaseId);
+  const { data: submissionCount } = useFormSubmissionCount({
+    phaseId,
+  });
+
+  if (!phase || !submissionCount) {
+    return null;
+  }
+
+  const handleDownloadResults = async () => {
+    try {
+      await downloadSurveyResults(locale, phase.data);
+    } catch (error) {
+      // Not handling errors for now
+    }
+  };
+
+  return (
+    <>
+      <Button
+        mr="8px"
+        onClick={() => {
+          submissionCount.data.attributes.totalSubmissions > 0
+            ? setShowEditWarningModal(true)
+            : clHistory.push(editFormLink);
+        }}
+        width="auto"
+        icon="edit"
+        data-cy="e2e-edit-survey-form"
+      >
+        <FormattedMessage {...messages.editSurveyForm} />
+      </Button>
+      <EditWarningModal
+        showEditWarningModal={showEditWarningModal}
+        setShowEditWarningModal={setShowEditWarningModal}
+        editFormLink={editFormLink}
+        handleDownloadResults={handleDownloadResults}
+      />
+    </>
+  );
+};
+
+export default EditButtonWithWarningModal;

--- a/front/app/containers/Admin/projects/project/surveyForm/TabPanel.tsx
+++ b/front/app/containers/Admin/projects/project/surveyForm/TabPanel.tsx
@@ -6,10 +6,10 @@ import { useParams } from 'react-router-dom';
 import { SectionTitle, SectionDescription } from 'components/admin/Section';
 import DownloadPDFButtonWithModal from 'components/FormBuilder/components/FormBuilderTopBar/DownloadPDFButtonWithModal';
 import ExcelDownloadButton from 'components/FormSync/ExcelDownloadButton';
-import Button from 'components/UI/ButtonWithLink';
 
 import { FormattedMessage } from 'utils/cl-intl';
 
+import EditButtonWithWarningModal from './EditButtonWithWarningModal';
 import messages from './messages';
 
 const TabPanel = ({
@@ -28,15 +28,7 @@ const TabPanel = ({
         <FormattedMessage {...messages.inputFormDescription} />
       </SectionDescription>
       <Box display="flex">
-        <Button
-          mr="8px"
-          linkTo={`/admin/projects/${projectId}/phases/${phaseId}/native-survey/edit`}
-          width="auto"
-          icon="edit"
-          data-cy="e2e-edit-survey-form"
-        >
-          <FormattedMessage {...messages.editSurveyForm} />
-        </Button>
+        <EditButtonWithWarningModal projectId={projectId} phaseId={phaseId} />
         <DownloadPDFButtonWithModal
           mr="8px"
           formType="survey"


### PR DESCRIPTION
E2E tests proving useful! I forgot to add this "Edit warning modal".

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->
