### PR TITLE
Add printPersonalDataFields support to custom form updates

### DIFF
--- a/front/app/api/custom_form/useUpdateCustomForm.ts
+++ b/front/app/api/custom_form/useUpdateCustomForm.ts
@@ -15,6 +15,7 @@ import { ICustomForm } from './types';
 type UpdateCustomFormProperties = {
   printStartMultiloc?: Multiloc;
   printEndMultiloc?: Multiloc;
+  printPersonalDataFields?: boolean;
 };
 
 /**
@@ -31,7 +32,7 @@ const updateCustomForm = async ({
   formValues: UpdateCustomFormProperties;
 }) => {
   // Only include properties that are defined
-  const body: Record<string, Multiloc> = {};
+  const body: Record<string, Multiloc | boolean> = {};
 
   if (formValues.printStartMultiloc) {
     body.print_start_multiloc = formValues.printStartMultiloc;
@@ -39,6 +40,10 @@ const updateCustomForm = async ({
 
   if (formValues.printEndMultiloc) {
     body.print_end_multiloc = formValues.printEndMultiloc;
+  }
+
+  if (typeof formValues.printPersonalDataFields === 'boolean') {
+    body.print_personal_data_fields = formValues.printPersonalDataFields;
   }
 
   return fetcher<ICustomForm>({

--- a/front/app/containers/Admin/projects/components/PDFExportModal/PersonalDataCheckbox.tsx
+++ b/front/app/containers/Admin/projects/components/PDFExportModal/PersonalDataCheckbox.tsx
@@ -15,7 +15,7 @@ interface Props {
 const PersonalDataCheckbox = ({ mb = '24px' }: Props) => {
   return (
     <CheckboxWithLabel
-      name="personal_data"
+      name="print_personal_data_fields"
       label={
         <Text as="span" m="0">
           <FormattedMessage {...messages.askPersonalData3} />

--- a/front/app/containers/Admin/projects/components/PDFExportModal/index.tsx
+++ b/front/app/containers/Admin/projects/components/PDFExportModal/index.tsx
@@ -75,11 +75,11 @@ const PDFExportModal = ({
   const phaseId = phase.id;
 
   const schema = object({
-    personal_data: boolean(),
     ...(htmlPdfsActive && {
       print_start_multiloc: object(),
       print_end_multiloc: object(),
     }),
+    personal_data: boolean(),
   });
 
   const methods = useForm({
@@ -95,10 +95,13 @@ const PDFExportModal = ({
   });
 
   useEffect(() => {
-    if (htmlPdfsActive && customForm) {
+    if (customForm) {
       methods.reset({
-        print_start_multiloc: customForm.data.attributes.print_start_multiloc,
-        print_end_multiloc: customForm.data.attributes.print_end_multiloc,
+        ...(htmlPdfsActive && {
+          print_start_multiloc: customForm.data.attributes.print_start_multiloc,
+          print_end_multiloc: customForm.data.attributes.print_end_multiloc,
+        }),
+        personal_data: customForm.data.attributes.print_personal_data_fields,
       });
     }
   }, [customForm, htmlPdfsActive, methods]);
@@ -119,12 +122,13 @@ const PDFExportModal = ({
     setLoading(true);
 
     try {
-      if (htmlPdfsActive) {
-        await updateCustomForm({
+      await updateCustomForm({
+        ...(htmlPdfsActive && {
           printStartMultiloc: formValues.print_start_multiloc,
           printEndMultiloc: formValues.print_end_multiloc,
-        });
-      }
+        }),
+        printPersonalDataFields: formValues.personal_data,
+      });
       await onExport(formValues);
       setLoading(false);
       onClose();

--- a/front/app/containers/Admin/projects/components/PDFExportModal/index.tsx
+++ b/front/app/containers/Admin/projects/components/PDFExportModal/index.tsx
@@ -39,7 +39,7 @@ import PersonalDataCheckbox from './PersonalDataCheckbox';
 export interface FormPDFExportFormValues {
   print_start_multiloc?: Multiloc;
   print_end_multiloc?: Multiloc;
-  personal_data: boolean;
+  print_personal_data_fields: boolean;
 }
 
 const CLICK_EXPORT_MESSAGES: { [key in FormType]: MessageDescriptor } = {
@@ -79,7 +79,7 @@ const PDFExportModal = ({
       print_start_multiloc: object(),
       print_end_multiloc: object(),
     }),
-    personal_data: boolean(),
+    print_personal_data_fields: boolean(),
   });
 
   const methods = useForm({
@@ -89,7 +89,7 @@ const PDFExportModal = ({
         print_start_multiloc: {},
         print_end_multiloc: {},
       }),
-      personal_data: false,
+      print_personal_data_fields: false,
     },
     resolver: yupResolver(schema),
   });
@@ -101,12 +101,15 @@ const PDFExportModal = ({
           print_start_multiloc: customForm.data.attributes.print_start_multiloc,
           print_end_multiloc: customForm.data.attributes.print_end_multiloc,
         }),
-        personal_data: customForm.data.attributes.print_personal_data_fields,
+        print_personal_data_fields:
+          customForm.data.attributes.print_personal_data_fields,
       });
     }
   }, [customForm, htmlPdfsActive, methods]);
 
-  const onExport = async ({ personal_data }: FormPDFExportFormValues) => {
+  const onExport = async ({
+    print_personal_data_fields: personal_data,
+  }: FormPDFExportFormValues) => {
     if (supportsNativeSurvey(phase.attributes.participation_method)) {
       await saveSurveyAsPDF({
         phaseId,
@@ -127,7 +130,7 @@ const PDFExportModal = ({
           printStartMultiloc: formValues.print_start_multiloc,
           printEndMultiloc: formValues.print_end_multiloc,
         }),
-        printPersonalDataFields: formValues.personal_data,
+        printPersonalDataFields: formValues.print_personal_data_fields,
       });
       await onExport(formValues);
       setLoading(false);


### PR DESCRIPTION
Part 2 of https://github.com/CitizenLabDotCo/citizenlab/pull/11050.

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Changed
- Persist value of "personal data" checkbox on form PDF export (in order to support more user-friendly trial-and-error when the PDF will be more customizable)