### PR TITLE
TAN-4593 Improve custom forms, schemas and posting coverage in E2E

### DIFF
--- a/front/cypress/e2e/idea_new_page.cy.ts
+++ b/front/cypress/e2e/idea_new_page.cy.ts
@@ -3,7 +3,7 @@ import { randomString, randomEmail } from '../support/commands';
 
 const round = (x: number) => Math.round(x * 1000) / 1000;
 
-describe('Idea new page for continuous project', () => {
+describe('Idea submission form', () => {
   const firstName = randomString();
   const lastName = randomString();
   const email = randomEmail();
@@ -20,18 +20,12 @@ describe('Idea new page for continuous project', () => {
     cy.acceptCookies();
   });
 
-  it.skip('shows an error when no title is provided', () => {
-    const value = randomString(9);
-    cy.get('#idea-form');
-    cy.get('#e2e-idea-description-input .ql-editor').type(value);
-    cy.get('#e2e-idea-description-input .ql-editor').contains(value);
-    cy.wait(1000);
-    // Try to go to the next page
-    cy.get('[data-cy="e2e-next-page"]').should('be.visible').click();
-    cy.get('#e2e-idea-title-input .e2e-error-message');
-  });
-
   it('shows a back button to navigate to the projects page', () => {
+    const ideaTitle = randomString(9);
+    cy.get('#e2e-idea-title-input input').type(ideaTitle);
+    cy.get('#e2e-idea-title-input input').should('contain.value', ideaTitle);
+    cy.get('[data-cy="e2e-next-page"]').should('be.visible').click();
+
     cy.get('[data-cy="e2e-leave-new-idea-button"]').click();
     cy.get('[data-cy="e2e-confirm-leave-new-idea-button"]').should('exist');
     cy.get('[data-cy="e2e-confirm-leave-new-idea-button"]').click();
@@ -39,38 +33,51 @@ describe('Idea new page for continuous project', () => {
       'eq',
       '/en/projects/an-idea-bring-it-to-your-council'
     );
+    cy.wait(2000);
+    cy.contains(ideaTitle).should('not.exist');
   });
 
-  it.skip('shows an error when no description is provided', () => {
-    const value = randomString(9);
-    cy.get('#idea-form');
-    cy.get('#e2e-idea-title-input input').type(value);
-    cy.get('#e2e-idea-title-input input').should('contain.value', value);
-    cy.wait(1000);
+  it('shows an error when no title is provided', () => {
+    // Try to go to the next page
+    cy.get('[data-cy="e2e-next-page"]').should('be.visible').click();
+    cy.get('#e2e-idea-title-input .e2e-error-message');
+  });
+
+  it('shows an error when no description is provided', () => {
+    const ideaTitle = randomString(9);
+    cy.get('#e2e-idea-title-input input').type(ideaTitle);
+    cy.get('#e2e-idea-title-input input').should('contain.value', ideaTitle);
+
+    // Go to the description page
+    cy.get('[data-cy="e2e-next-page"]').should('be.visible').click();
+
     // Try to go to the next page
     cy.get('[data-cy="e2e-next-page"]').should('be.visible').click();
     cy.get('#e2e-idea-description-input .e2e-error-message');
   });
 
   it('shows an error when the title is less than 3 characters long', () => {
-    cy.get('#idea-form');
     cy.get('#e2e-idea-title-input input').type(randomString(2));
     // Try to go to the next page
     cy.get('[data-cy="e2e-next-page"]').should('be.visible').click();
     cy.get('#e2e-idea-title-input .e2e-error-message');
   });
 
-  it('shows an error when the description is less than 3 characters long', () => {
-    const title = randomString(10);
-    cy.get('#idea-form');
-    cy.get('#e2e-idea-title-input input').type(title);
-    cy.get('#e2e-idea-title-input input').should('contain.value', title);
+  it.only('shows no error when the description is less than 3 characters long', () => {
+    const ideaTitle = randomString(10);
+    cy.get('#e2e-idea-title-input input').type(ideaTitle);
+    cy.get('#e2e-idea-title-input input').should('contain.value', ideaTitle);
+
+    const ideaContent = randomString(2);
+    cy.get('[data-cy="e2e-next-page"]').should('be.visible').click();
+    cy.get('#e2e-idea-description-input .ql-editor').type(ideaContent);
+    cy.get('#e2e-idea-description-input .ql-editor').contains(ideaContent);
 
     cy.get('[data-cy="e2e-next-page"]').should('be.visible').click();
-
-    // Try to go to the next page
     cy.get('[data-cy="e2e-next-page"]').should('be.visible').click();
-    cy.get('#e2e-idea-description-input .e2e-error-message');
+    cy.get('[data-cy="e2e-submit-form"]').click();
+    cy.get('[data-cy="e2e-after-submission"]').should('exist').click();
+    cy.contains(ideaTitle).should('exist');
   });
 
   it.skip('saves correct location point when provided in URL', () => {
@@ -172,126 +179,6 @@ describe('Idea new page for continuous project', () => {
     // verify the content of the newly created idea page
     cy.location('pathname').should('eq', `/en/ideas/${ideaTitle}`);
     cy.get('#e2e-idea-show');
-    cy.get('#e2e-idea-show').find('#e2e-idea-title').contains(ideaTitle);
-    cy.get('#e2e-idea-show')
-      .find('#e2e-idea-description')
-      .contains(ideaContent);
-    cy.get('#e2e-idea-show')
-      .find('#e2e-idea-topics')
-      .find('.e2e-idea-topic')
-      .should('have.length', 1);
-    cy.get('#e2e-idea-show').contains('Boulevard Anspach');
-    cy.get('#e2e-idea-show')
-      .find('.e2e-author-link .e2e-username')
-      .contains(`${firstName} ${lastName}`);
-  });
-});
-
-describe('Idea new page for timeline project', () => {
-  const firstName = randomString();
-  const lastName = randomString();
-  const email = randomEmail();
-  const password = randomString();
-
-  const projectTitle = randomString();
-  const projectDescriptionPreview = randomString();
-  const projectDescription = randomString();
-
-  const phasePastTitle = randomString();
-
-  let projectId: string;
-  let projectSlug: string;
-
-  const twoMonthsAgo = moment().subtract(2, 'month').format('DD/MM/YYYY');
-  const inTwoMonths = moment().add(2, 'month').format('DD/MM/YYYY');
-
-  before(() => {
-    cy.apiSignup(firstName, lastName, email, password);
-
-    // create new project
-    cy.apiCreateProject({
-      title: projectTitle,
-      descriptionPreview: projectDescriptionPreview,
-      description: projectDescription,
-      publicationStatus: 'published',
-    }).then((project) => {
-      projectId = project.body.data.id;
-      projectSlug = project.body.data.attributes.slug;
-      // create active ideation phase
-      cy.apiCreatePhase({
-        projectId,
-        title: phasePastTitle,
-        startAt: twoMonthsAgo,
-        endAt: inTwoMonths,
-        participationMethod: 'ideation',
-        canComment: true,
-        canPost: true,
-        canReact: true,
-        description: `description ${phasePastTitle}`,
-      });
-    });
-  });
-
-  beforeEach(() => {
-    cy.setLoginCookie(email, password);
-    cy.visit(`/projects/${projectSlug}/ideas/new`);
-    cy.get('#idea-form');
-    cy.acceptCookies();
-  });
-
-  it('has a working idea form', () => {
-    const ideaTitle = randomString(40);
-    const ideaContent = randomString(60);
-
-    cy.get('#e2e-idea-new-page');
-    cy.get('#idea-form');
-    cy.contains('Add new idea').should('exist');
-
-    // Add a title
-    cy.get('#e2e-idea-title-input input').type(ideaTitle);
-    cy.get('#e2e-idea-title-input input').should('contain.value', ideaTitle);
-
-    cy.get('[data-cy="e2e-next-page"]').should('be.visible').click();
-
-    // Add a description
-    cy.get('#e2e-idea-description-input .ql-editor').type(ideaContent);
-    cy.get('#e2e-idea-description-input .ql-editor').contains(ideaContent);
-
-    // Go to the next page of the idea form
-    cy.get('[data-cy="e2e-next-page"]').should('be.visible').click();
-
-    // verify that image and file upload components are present
-    cy.get('#e2e-idea-image-upload');
-    cy.get('#e2e-idea-file-upload');
-
-    // Go to the page with topics
-    cy.get('[data-cy="e2e-next-page"]').should('be.visible').click();
-
-    // add a topic
-    cy.get('.e2e-topics-picker').find('button').eq(4).click();
-
-    // verify that the topic has been selected
-    cy.get('.e2e-topics-picker')
-      .find('button.selected')
-      .should('have.length', 1);
-
-    // add a location
-    cy.get('.e2e-idea-form-location-input-field input').type(
-      'Boulevard Anspach Brussels'
-    );
-    cy.wait(7000);
-    cy.get('.e2e-idea-form-location-input-field input').type('{enter}');
-
-    // save the form
-    cy.get('[data-cy="e2e-submit-form"]').click();
-    cy.wait(3000);
-
-    cy.get('[data-cy="e2e-after-submission"]').should('exist');
-    cy.get('[data-cy="e2e-after-submission"]').click();
-
-    // verify the content of the newly created idea page
-    cy.get('#e2e-idea-show');
-    cy.location('pathname').should('eq', `/en/ideas/${ideaTitle}`);
     cy.get('#e2e-idea-show').find('#e2e-idea-title').contains(ideaTitle);
     cy.get('#e2e-idea-show')
       .find('#e2e-idea-description')

--- a/front/cypress/e2e/idea_new_page.cy.ts
+++ b/front/cypress/e2e/idea_new_page.cy.ts
@@ -63,7 +63,7 @@ describe('Idea submission form', () => {
     cy.get('#e2e-idea-title-input .e2e-error-message');
   });
 
-  it.only('shows no error when the description is less than 3 characters long', () => {
+  it('shows no error when the description is less than 3 characters long', () => {
     const ideaTitle = randomString(10);
     cy.get('#e2e-idea-title-input input').type(ideaTitle);
     cy.get('#e2e-idea-title-input input').should('contain.value', ideaTitle);
@@ -80,20 +80,22 @@ describe('Idea submission form', () => {
     cy.contains(ideaTitle).should('exist');
   });
 
-  it.skip('saves correct location point when provided in URL', () => {
+  it('saves correct location point when provided in URL', () => {
     cy.intercept('POST', '**/ideas').as('submitIdea');
 
     const ideaTitle = randomString(40);
     const ideaContent = randomString(60);
-    const geocodedLocation = 'Maria-Louizasquare 47, 1000 Brussel, Belgium';
-    const lat = 50.84682103382404;
-    const long = 4.378963708877564;
+    const geocodedLocation = 'Korenmarkt 11, 9000 Gent, Belgium';
+    const lat = 51.0546195;
+    const long = 3.7219968;
 
     // Go to URL with lat/long where point is in body of water
     cy.visit(
       `/projects/an-idea-bring-it-to-your-council/ideas/new?lat=${lat}&lng=${long}`
     );
     cy.get('#idea-form');
+    // So typing the title doesn't get interrupted
+    cy.wait(1000);
     cy.contains('Add new idea').should('exist');
 
     // Add a title
@@ -111,11 +113,7 @@ describe('Idea submission form', () => {
     cy.get('[data-cy="e2e-next-page"]').should('be.visible').click();
 
     // Check that the geocoder has autofilled the location
-    cy.get('.e2e-idea-form-location-input-field [class^=singleValue]').should(
-      'contain.value',
-      geocodedLocation
-    );
-    cy.wait(1000);
+    cy.get('.e2e-idea-form-location-input-field').contains(geocodedLocation);
     // save the idea
     cy.get('[data-cy="e2e-submit-form"]').click();
     cy.wait(3000);

--- a/front/cypress/e2e/proposal_edit_page.cy.ts
+++ b/front/cypress/e2e/proposal_edit_page.cy.ts
@@ -5,11 +5,18 @@ describe('Proposal edit page', () => {
   const projectTitle = randomString();
   const projectDescriptionPreview = randomString();
   const projectDescription = randomString();
-  const inputOldTitle = randomString(40);
-  const inputOldContent = randomString(60);
-  const inputNewTitle = randomString(40);
-  const inputNewContent = randomString(60);
+  const oldTitle = randomString(40);
+  const newTitle = randomString(40);
+  const ideaContent = randomString(60);
+  const locationGeoJSON = {
+    type: 'Point',
+    coordinates: [4.351710300000036, 50.8503396],
+  };
+  const locationDescription = 'Brussel, België';
+  const extraFieldTitle = randomString();
+  const extraFieldAnswer = randomString();
   let projectId: string;
+  let phaseId: string;
   let inputId: string;
   let inputSlug: string;
 
@@ -25,25 +32,32 @@ describe('Proposal edit page', () => {
     }).then((project) => {
       projectId = project.body.data.id;
       // projectSlug = project.body.data.attributes.slug;
-      return cy.apiCreatePhase({
-        projectId: projectId,
-        title: 'Proposals',
-        startAt: moment().subtract(9, 'month').format('DD/MM/YYYY'),
-        participationMethod: 'proposals',
-        canPost: true,
-        canComment: true,
-        canReact: true,
-      });
-    });
-
-    // Create a proposal with location
-    cy.apiCreateIdea({
-      projectId,
-      ideaTitle: inputOldTitle,
-      ideaContent: inputOldContent,
-    }).then((idea) => {
-      inputId = idea.body.data.id;
-      inputSlug = idea.body.data.attributes.slug;
+      return cy
+        .apiCreatePhase({
+          projectId: projectId,
+          title: 'Proposals',
+          startAt: moment().subtract(9, 'month').format('DD/MM/YYYY'),
+          participationMethod: 'proposals',
+          canPost: true,
+          canComment: true,
+          canReact: true,
+        })
+        .then((phase) => {
+          phaseId = phase.body.data.id;
+          // Create a proposal with location
+          return cy
+            .apiCreateIdea({
+              projectId,
+              ideaTitle: oldTitle,
+              ideaContent: ideaContent,
+              locationGeoJSON,
+              locationDescription,
+            })
+            .then((idea) => {
+              inputId = idea.body.data.id;
+              inputSlug = idea.body.data.attributes.slug;
+            });
+        });
     });
   });
 
@@ -54,47 +68,76 @@ describe('Proposal edit page', () => {
   });
 
   it('edit a proposal after form changes while adding an image and cosponsors', () => {
-    // cy.setLoginCookie(email, password);
     cy.intercept('GET', `**/ideas/${inputSlug}**`).as('idea');
 
-    // check original values
+    // Check original values
     cy.visit(`/ideas/${inputSlug}`);
-
     cy.get('#e2e-idea-show');
-    cy.get('#e2e-idea-title').should('exist').contains(inputOldTitle);
-    cy.get('#e2e-idea-description').should('exist').contains(inputOldContent);
+    cy.get('#e2e-idea-title').should('exist').contains(oldTitle);
+    cy.get('#e2e-idea-description').should('exist').contains(ideaContent);
+    cy.get('#e2e-idea-location-map').should('exist');
 
-    // go to form
-    cy.visit(`/ideas/edit/${inputId}`);
-    cy.acceptCookies();
-
-    cy.wait('@idea');
-
-    cy.get('#e2e-idea-edit-page');
-    cy.get('#idea-form').should('exist');
-    cy.get('#e2e-idea-title-input input').as('titleInput');
-
-    // check initial form values
-    cy.get('@titleInput').should('exist');
-    cy.get('@titleInput').should(($input) => {
-      expect($input.val()).to.eq(inputOldTitle);
-    });
-
-    // So typing the title doesn't get interrupted
+    // Edit input form
+    cy.visit(`admin/projects/${projectId}/phases/${phaseId}/form/edit`);
+    // Delete the Details page
+    cy.get('[data-cy="e2e-more-field-actions"]').eq(2).click({ force: true });
+    cy.get('.e2e-more-actions-list button').contains('Delete').click();
+    // Delete the Location field
+    cy.get('[data-cy="e2e-more-field-actions"]').eq(3).click({ force: true });
+    cy.get('.e2e-more-actions-list button').contains('Delete').click();
+    // Add an extra field
+    cy.get('[data-cy="e2e-short-answer"]').click();
+    cy.get('#e2e-title-multiloc').type(extraFieldTitle, { force: true });
+    // Save the form
+    cy.get('form').submit();
     cy.wait(1000);
 
-    // Edit title and description
+    // Edit proposal
+    cy.visit(`/ideas/edit/${inputId}`);
+    cy.acceptCookies();
+    cy.wait('@idea');
+    cy.get('#e2e-idea-edit-page');
+    cy.get('#idea-form').should('exist');
+
+    // Edit title
+    cy.get('#e2e-idea-title-input input').as('titleInput');
+    cy.get('@titleInput').should('exist');
+    cy.get('@titleInput').should(($input) => {
+      expect($input.val()).to.eq(oldTitle);
+    });
+    cy.wait(1000); // So typing the title doesn't get interrupted
     cy.get('@titleInput')
       .clear()
       .should('exist')
       .should('not.be.disabled')
-      .type(inputNewTitle);
-
-    // verify the new values
+      .type(newTitle);
     cy.get('@titleInput').should('exist');
-    cy.get('@titleInput').should('contain.value', inputNewTitle);
+    cy.get('@titleInput').should('contain.value', newTitle);
 
-    // Go to the next page of the idea form
+    // Go to body page
     cy.get('[data-cy="e2e-next-page"]').should('be.visible').click();
+
+    // Go to uploads page and add an image
+    cy.get('[data-cy="e2e-next-page"]').should('be.visible').click();
+    cy.get('#e2e-idea-image-upload input').attachFile('icon.png');
+    // Check that the tags field was not removed
+    cy.get('#e2e-idea-topics-input').should('exist');
+    // Answer the extra field
+    cy.contains(extraFieldTitle).should('exist');
+    cy.get(`*[id^="properties${extraFieldTitle}"]`).type(extraFieldAnswer, {
+      force: true,
+    });
+
+    // Submit
+    cy.get('[data-cy="e2e-submit-form"]').click();
+    cy.get('#e2e-accept-disclaimer').click();
+    cy.wait(1000);
+
+    // Check new values
+    cy.visit(`/ideas/${inputSlug}`);
+    cy.get('#e2e-idea-show');
+    cy.get('#e2e-idea-title').should('exist').contains(newTitle);
+    cy.get('#e2e-idea-description').should('exist').contains(ideaContent);
+    cy.get('#e2e-idea-location-map').should('not.exist');
   });
 });

--- a/front/cypress/e2e/proposal_edit_page.cy.ts
+++ b/front/cypress/e2e/proposal_edit_page.cy.ts
@@ -1,0 +1,100 @@
+import { randomString, randomEmail } from '../support/commands';
+import moment = require('moment');
+
+describe('Proposal edit page', () => {
+  const projectTitle = randomString();
+  const projectDescriptionPreview = randomString();
+  const projectDescription = randomString();
+  const inputOldTitle = randomString(40);
+  const inputOldContent = randomString(60);
+  const inputNewTitle = randomString(40);
+  const inputNewContent = randomString(60);
+  let projectId: string;
+  let inputId: string;
+  let inputSlug: string;
+
+  beforeEach(() => {
+    cy.setAdminLoginCookie();
+
+    // Create proposals project
+    cy.apiCreateProject({
+      title: projectTitle,
+      descriptionPreview: projectDescriptionPreview,
+      description: projectDescription,
+      publicationStatus: 'published',
+    }).then((project) => {
+      projectId = project.body.data.id;
+      // projectSlug = project.body.data.attributes.slug;
+      return cy.apiCreatePhase({
+        projectId: projectId,
+        title: 'Proposals',
+        startAt: moment().subtract(9, 'month').format('DD/MM/YYYY'),
+        participationMethod: 'proposals',
+        canPost: true,
+        canComment: true,
+        canReact: true,
+      });
+    });
+
+    // Create a proposal with location
+    cy.apiCreateIdea({
+      projectId,
+      ideaTitle: inputOldTitle,
+      ideaContent: inputOldContent,
+    }).then((idea) => {
+      inputId = idea.body.data.id;
+      inputSlug = idea.body.data.attributes.slug;
+    });
+  });
+
+  afterEach(() => {
+    if (inputId) {
+      cy.apiRemoveIdea(inputId);
+    }
+  });
+
+  it('edit a proposal after form changes while adding an image and cosponsors', () => {
+    // cy.setLoginCookie(email, password);
+    cy.intercept('GET', `**/ideas/${inputSlug}**`).as('idea');
+
+    // check original values
+    cy.visit(`/ideas/${inputSlug}`);
+
+    cy.get('#e2e-idea-show');
+    cy.get('#e2e-idea-title').should('exist').contains(inputOldTitle);
+    cy.get('#e2e-idea-description').should('exist').contains(inputOldContent);
+
+    // go to form
+    cy.visit(`/ideas/edit/${inputId}`);
+    cy.acceptCookies();
+
+    cy.wait('@idea');
+
+    cy.get('#e2e-idea-edit-page');
+    cy.get('#idea-form').should('exist');
+    cy.get('#e2e-idea-title-input input').as('titleInput');
+
+    // check initial form values
+    cy.get('@titleInput').should('exist');
+    cy.get('@titleInput').should(($input) => {
+      expect($input.val()).to.eq(inputOldTitle);
+    });
+
+    // So typing the title doesn't get interrupted
+    cy.wait(1000);
+
+    // Edit title and description
+    cy.get('@titleInput')
+      .clear()
+      .should('exist')
+      .should('not.be.disabled')
+      .type(inputNewTitle);
+
+    // verify the new values
+    cy.get('@titleInput').should('exist');
+    cy.get('@titleInput').should('contain.value', inputNewTitle);
+
+    // Go to the next page of the idea form
+    cy.get('[data-cy="e2e-next-page"]').should('be.visible').click();
+  });
+});


### PR DESCRIPTION
Unskipped some e2e tests, and added a new one for editing proposals which now also covers:
- Editing a proposal (we had a bug with this)
- Add an image to an existing proposal (we had a bug with this)
- Deleting a page
- The location field is no longer shown in the visit idea page after removing the field
- Extra field for proposals

Sadly, I didn't have the time to look into covering changing the participation method (from proposals to ideation).

Tested E2E tests on CI: https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/265212/workflows/31df8910-2827-49ef-8284-0864aa43b5f7
