### PR TITLE
TAN-4626 - Add ranking, matrix, multiselect image fields to PDF download

### DIFF
--- a/back/config/locales/en.yml
+++ b/back/config/locales/en.yml
@@ -331,6 +331,7 @@ en:
       write_in_language: 'Write your answers in the same language as this form'
       linear_scale_print_description: 'Please write a number between %{min_label} and %{max_label} only'
       unsupported_field: 'This field cannot be completed on paper. Please use the online version of this form instead.'
+      ranking_print_description: 'Please write a number from 1 (most preferred) and %{max_rank} (least preferred) in each box. Use each number only once.'
   project_copy:
     title_suffix: 'Copy'
   confirmations_mailer:

--- a/back/config/locales/en.yml
+++ b/back/config/locales/en.yml
@@ -333,6 +333,7 @@ en:
       unsupported_field: 'This field cannot be completed on paper. Please use the online version of this form instead.'
       ranking_print_description: 'Please write a number from 1 (most preferred) and %{max_rank} (least preferred) in each box. Use each number only once.'
       matrix_print_description: 'For each row, mark one circle with a cross to indicate your preference.'
+      rating_print_description: 'Rate this by writing a number between 1 (worst) and %{max_stars} (best).'
   project_copy:
     title_suffix: 'Copy'
   confirmations_mailer:

--- a/back/config/locales/en.yml
+++ b/back/config/locales/en.yml
@@ -334,6 +334,8 @@ en:
       ranking_print_description: 'Please write a number from 1 (most preferred) and %{max_rank} (least preferred) in each box. Use each number only once.'
       matrix_print_description: 'For each row, mark one circle with a cross to indicate your preference.'
       rating_print_description: 'Rate this by writing a number between 1 (worst) and %{max_stars} (best).'
+      sentiment_linear_scale_print_description: 'Please write a number between 1 and 5.'
+      sentiment_linear_scale_print_labels: '1 = %{min_label}, 3 = %{neutral_label}, 5 = %{max_label}.'
   project_copy:
     title_suffix: 'Copy'
   confirmations_mailer:

--- a/back/config/locales/en.yml
+++ b/back/config/locales/en.yml
@@ -332,6 +332,7 @@ en:
       linear_scale_print_description: 'Please write a number between %{min_label} and %{max_label} only'
       unsupported_field: 'This field cannot be completed on paper. Please use the online version of this form instead.'
       ranking_print_description: 'Please write a number from 1 (most preferred) and %{max_rank} (least preferred) in each box. Use each number only once.'
+      matrix_print_description: 'For each row, mark one circle with a cross to indicate your preference.'
   project_copy:
     title_suffix: 'Copy'
   confirmations_mailer:

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_html_form_exporter.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_html_form_exporter.rb
@@ -176,7 +176,7 @@ module BulkImportIdeas::Exporters
         :multi_select_image
       when 'multiline_text', 'html_multiloc'
         :multi_line_text
-      when 'text', 'text_multiloc', 'number', 'linear_scale'
+      when 'text', 'text_multiloc', 'number', 'linear_scale', 'rating'
         :single_line_text
       when 'ranking'
         :ranking
@@ -206,8 +206,10 @@ module BulkImportIdeas::Exporters
     end
 
     def field_print_description(field)
-      if (field.linear_scale? || field.rating?) && field.description_multiloc[@locale].blank?
+      if field.linear_scale? && field.description_multiloc[@locale].blank?
         linear_scale_print_instructions(field)
+      elsif field.rating? && field.description_multiloc[@locale].blank?
+        rating_print_instructions(field)
       else
         description = TextImageService.new.render_data_images_multiloc(field.description_multiloc, field: :description_multiloc, imageable: field)
         html = format_urls(description[@locale]) || ''
@@ -239,7 +241,18 @@ module BulkImportIdeas::Exporters
         )
       end
 
-      "<p>#{description}</p>"
+      format_instructions(description)
+    end
+
+    def rating_print_instructions(field)
+      description = I18n.with_locale(@locale) do
+        I18n.t(
+          'form_builder.pdf_export.rating_print_description',
+          max_stars: field.maximum
+        )
+      end
+
+      format_instructions(description)
     end
 
     def ranking_print_instructions(field)
@@ -253,7 +266,7 @@ module BulkImportIdeas::Exporters
         )
       end
 
-      "<p>#{description}</p>"
+      format_instructions(description)
     end
 
     def print_visibility_disclaimer(field)
@@ -283,7 +296,7 @@ module BulkImportIdeas::Exporters
           I18n.t('form_builder.pdf_export.choose_as_many')
         end
       end
-      "<p>*#{message}</p>"
+      format_instructions(message)
     end
 
     def field_matrix_details(field)
@@ -305,7 +318,13 @@ module BulkImportIdeas::Exporters
         I18n.t('form_builder.pdf_export.matrix_print_description')
       end
 
-      "<p>#{description}</p>"
+      format_instructions(description)
+    end
+
+    def format_instructions(instructions)
+      return '' if instructions.blank?
+
+      "<p><em>#{instructions}</em></p>"
     end
 
     def font_family

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_html_form_exporter.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_html_form_exporter.rb
@@ -176,7 +176,7 @@ module BulkImportIdeas::Exporters
         :multi_select_image
       when 'multiline_text', 'html_multiloc'
         :multi_line_text
-      when 'text', 'text_multiloc', 'number', 'linear_scale', 'rating'
+      when 'text', 'text_multiloc', 'number', 'linear_scale', 'rating', 'sentiment_linear_scale'
         :single_line_text
       when 'ranking'
         :ranking
@@ -184,14 +184,11 @@ module BulkImportIdeas::Exporters
         :matrix_linear_scale
       else
         # CURRENTLY UNSUPPORTED
-        # rating
         # file_upload
         # shapefile_upload
         # point
         # line
         # polygon
-        # matrix_linear_scale
-        # sentiment_linear_scale
         :unsupported
       end
     end
@@ -206,18 +203,15 @@ module BulkImportIdeas::Exporters
     end
 
     def field_print_description(field)
-      if field.linear_scale? && field.description_multiloc[@locale].blank?
-        linear_scale_print_instructions(field)
-      elsif field.rating? && field.description_multiloc[@locale].blank?
-        rating_print_instructions(field)
-      else
-        description = TextImageService.new.render_data_images_multiloc(field.description_multiloc, field: :description_multiloc, imageable: field)
-        html = format_urls(description[@locale]) || ''
-        html += multiselect_print_instructions(field)
-        html += ranking_print_instructions(field)
-        html += matrix_print_instructions(field)
-        html
-      end
+      description = TextImageService.new.render_data_images_multiloc(field.description_multiloc, field: :description_multiloc, imageable: field)
+      html = format_urls(description[@locale]) || ''
+      html += linear_scale_print_instructions(field)
+      html += sentiment_linear_scale_print_instructions(field)
+      html += rating_print_instructions(field)
+      html += multiselect_print_instructions(field)
+      html += ranking_print_instructions(field)
+      html += matrix_print_instructions(field)
+      html
     end
 
     def field_has_question_number?(field)
@@ -225,6 +219,8 @@ module BulkImportIdeas::Exporters
     end
 
     def linear_scale_print_instructions(field)
+      return '' unless field.input_type == 'linear_scale'
+
       multiloc_service = MultilocService.new
 
       min_text = multiloc_service.t(field.linear_scale_label_1_multiloc, @locale)
@@ -244,7 +240,34 @@ module BulkImportIdeas::Exporters
       format_instructions(description)
     end
 
+    def sentiment_linear_scale_print_instructions(field)
+      return '' unless field.input_type == 'sentiment_linear_scale'
+
+      description = I18n.with_locale(@locale) { I18n.t('form_builder.pdf_export.sentiment_linear_scale_print_description') }
+
+      multiloc_service = MultilocService.new
+      min_label = multiloc_service.t(field.linear_scale_label_1_multiloc, @locale)
+      neutral_label = multiloc_service.t(field.linear_scale_label_3_multiloc, @locale)
+      max_label = multiloc_service.t(field.linear_scale_label_5_multiloc, @locale)
+
+      if min_label && neutral_label && max_label
+        label_text = I18n.with_locale(@locale) do
+          I18n.t(
+            'form_builder.pdf_export.sentiment_linear_scale_print_labels',
+            min_label: min_label,
+            neutral_label: neutral_label,
+            max_label: max_label
+          )
+        end
+        description += " <br>#{label_text}"
+      end
+
+      format_instructions(description)
+    end
+
     def rating_print_instructions(field)
+      return '' unless field.input_type == 'rating'
+
       description = I18n.with_locale(@locale) do
         I18n.t(
           'form_builder.pdf_export.rating_print_description',

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_html_form_exporter.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_html_form_exporter.rb
@@ -296,7 +296,7 @@ module BulkImportIdeas::Exporters
           I18n.t('form_builder.pdf_export.choose_as_many')
         end
       end
-      format_instructions(message)
+      format_instructions("*#{message}")
     end
 
     def field_matrix_details(field)

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_html_form_exporter.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_html_form_exporter.rb
@@ -133,7 +133,8 @@ module BulkImportIdeas::Exporters
               title: option.title_multiloc[@locale],
               image_url: option_image_url(field, option)
             }
-          end
+          end,
+          matrix: field_matrix_details(field)
         }
       end
 
@@ -179,6 +180,8 @@ module BulkImportIdeas::Exporters
         :single_line_text
       when 'ranking'
         :ranking
+      when 'matrix_linear_scale'
+        :matrix_linear_scale
       else
         # CURRENTLY UNSUPPORTED
         # rating
@@ -210,6 +213,7 @@ module BulkImportIdeas::Exporters
         html = format_urls(description[@locale]) || ''
         html += multiselect_print_instructions(field)
         html += ranking_print_instructions(field)
+        html += matrix_print_instructions(field)
         html
       end
     end
@@ -280,6 +284,28 @@ module BulkImportIdeas::Exporters
         end
       end
       "<p>*#{message}</p>"
+    end
+
+    def field_matrix_details(field)
+      return unless field.supports_matrix_statements?
+
+      {
+        statements: field.matrix_statements.map { |statement| field_print_title(statement) },
+        labels: (1..field.maximum).map do |i|
+          field["linear_scale_label_#{i}_multiloc"][@locale]
+        end,
+        label_width: 70 / field.maximum # 70% of the printed width for the labels, 30% for the statements
+      }
+    end
+
+    def matrix_print_instructions(field)
+      return '' unless field.supports_matrix_statements?
+
+      description = I18n.with_locale(@locale) do
+        I18n.t('form_builder.pdf_export.matrix_print_description')
+      end
+
+      "<p>#{description}</p>"
     end
 
     def font_family

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_html_pdf_form_exporter.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_html_pdf_form_exporter.rb
@@ -140,7 +140,7 @@ module BulkImportIdeas::Exporters
     end
 
     # Allow rendering of images in the PDF when in development
-    def format_html_field(description)
+    def format_urls(description)
       new_description = super
       new_description&.sub!('localhost:4000', 'cl-back-web:4000') if Rails.env.development?
       new_description

--- a/back/engines/commercial/bulk_import_ideas/app/views/bulk_import_ideas/web_api/v1/export_form.html.erb
+++ b/back/engines/commercial/bulk_import_ideas/app/views/bulk_import_ideas/web_api/v1/export_form.html.erb
@@ -109,8 +109,6 @@
         <div class="content">
           <%== sanitize field[:description] %>
 
-          <p><%= field[:multiselect_print_instructions] %></p>
-
           <% if field[:format] == :single_select %>
             <div class="options">
               <% field[:options].each do |option| %>

--- a/back/engines/commercial/bulk_import_ideas/app/views/bulk_import_ideas/web_api/v1/export_form.html.erb
+++ b/back/engines/commercial/bulk_import_ideas/app/views/bulk_import_ideas/web_api/v1/export_form.html.erb
@@ -37,6 +37,7 @@
     div.radio { border-radius: 50%; }
     span.optional { font-weight: normal; }
     div.field-group { page-break-inside: avoid; }
+    div.options { margin-top: 10px; }
 
     #header {
       margin-bottom: 30px;

--- a/back/engines/commercial/bulk_import_ideas/app/views/bulk_import_ideas/web_api/v1/export_form.html.erb
+++ b/back/engines/commercial/bulk_import_ideas/app/views/bulk_import_ideas/web_api/v1/export_form.html.erb
@@ -28,7 +28,7 @@
     h1 { font-size: 18pt; }
     h2 { font-size: 16pt; }
     h3 { font-size: 14pt; }
-    h4, p, li { font-size: 12pt; line-height: 1.2; }
+    h4, p, li, td, th { font-size: 12pt; line-height: 1.2; }
 
     div.line { border-bottom: solid 1px #000; margin: 10px 0; height: 25px; }
     div.select, div.ranking { display: flex; align-items: center; margin-top: -6px; }
@@ -68,6 +68,22 @@
           background: #eee;
           img { object-fit: contain; height: 140px; }
           svg { border-radius: 5px; object-fit: contain; height: 50px; margin: 45px 0 45px 0; }
+        }
+      }
+      div.matrix {
+        table {
+          margin-top: 10px;
+          border-collapse: collapse;
+          width: 100%;
+          th, td {
+            border-bottom: 1px solid #000;
+            padding: 5px;
+            text-align: center;
+            font-weight: normal;
+          }
+          td.statement {
+            text-align: left;
+          }
         }
       }
     }
@@ -184,6 +200,26 @@
                   <div><%= option[:title] %></div>
                 </div>
               <% end %>
+            </div>
+
+          <% elsif field[:format] == :matrix_linear_scale %>
+            <div class="matrix">
+              <table>
+                <tr>
+                  <th></th>
+                  <% field[:matrix][:labels].each do |label| %>
+                    <th style="width: <%= field[:matrix][:label_width] %>%"><%= label %></th>
+                  <% end %>
+                </tr>
+                <% field[:matrix][:statements].each do |statement| %>
+                  <tr>
+                    <td class="statement"><%= statement %></td>
+                    <% field[:matrix][:labels].each do |_| %>
+                      <td><div class="checkbox radio"></div></td>
+                    <% end %>
+                  </tr>
+                  <% end %>
+              </table>
             </div>
 
           <% else %>

--- a/back/engines/commercial/bulk_import_ideas/app/views/bulk_import_ideas/web_api/v1/export_form.html.erb
+++ b/back/engines/commercial/bulk_import_ideas/app/views/bulk_import_ideas/web_api/v1/export_form.html.erb
@@ -28,11 +28,12 @@
       h1 { font-size: 18pt; }
       h2 { font-size: 16pt; }
       h3 { font-size: 14pt; }
-      h4, p, li { font-size: 12pt; }
+      h4, p, li { font-size: 12pt; line-height: 1.2; }
 
       div.line { border-bottom: solid 1px #000; margin: 10px 0; height: 25px; }
-      div.select { display: flex; align-items: center; margin-top: -6px; }
-      div.checkbox { border: solid 1px #000; width: 12px; height: 12px; margin: 8px 10px 8px 4px; display: inline-block; }
+      div.select, div.ranking { display: flex; align-items: center; margin-top: -6px; }
+      div.checkbox { border: solid 1px #000; width: 12px; height: 12px; margin: 8px 10px 8px 2px; display: inline-block; }
+      div.ranking-box { border: solid 1px #000; width: 24px; height: 24px; margin: 8px 10px 8px 2px; display: inline-block; }
       div.radio { border-radius: 50%; }
       span.optional { font-weight: normal; }
       div.field-group { page-break-inside: avoid; }
@@ -89,13 +90,13 @@
 <% fields.each do |field| %>
   <% if field[:field_group][:start] %><div class="field-group"><% end %>
     <% if field[:input_type] == 'page' %>
-      <div class="page">
+      <div class="page" id="<%= field[:id] %>">
         <h2><%= field[:title] %></h2>
         <%= sanitize field[:description] %>
       </div>
 
     <% else %>
-      <div class="question">
+      <div class="question" id="<%= field[:id] %>">
         <% if field[:additional_text_question] %>
           <h4><span class="number"> </span><%= field[:title] %></h4>
         <% else %>
@@ -136,6 +137,16 @@
 
           <% elsif field[:format] == :single_line_text %>
             <div class="line"></div>
+
+          <% elsif field[:format] == :ranking %>
+            <div class="options">
+              <% field[:options].each do |option| %>
+                <div class="ranking">
+                  <div class="ranking-box"></div>
+                  <div><%= option[:title] %></div>
+                </div>
+              <% end %>
+            </div>
 
           <% else %>
             <div class="unsupported">

--- a/back/engines/commercial/bulk_import_ideas/app/views/bulk_import_ideas/web_api/v1/export_form.html.erb
+++ b/back/engines/commercial/bulk_import_ideas/app/views/bulk_import_ideas/web_api/v1/export_form.html.erb
@@ -14,51 +14,63 @@
   <% end %>
 
   <style>
-      @page {
-        size: A4;
-        margin: 40px 40px 80px;
-        @bottom-right {
-          font-family: <%== font_family %>;
-          content: '<%= page_copy %> ' counter(page);
+    @page {
+      size: A4;
+      margin: 40px 40px 80px;
+      @bottom-right {
+        font-family: <%== font_family %>;
+        content: '<%= page_copy %> ' counter(page);
+        margin-bottom: 10px;
+      }
+    }
+
+    body { font-family: <%== font_family %>; }
+    h1 { font-size: 18pt; }
+    h2 { font-size: 16pt; }
+    h3 { font-size: 14pt; }
+    h4, p, li { font-size: 12pt; line-height: 1.2; }
+
+    div.line { border-bottom: solid 1px #000; margin: 10px 0; height: 25px; }
+    div.select, div.ranking { display: flex; align-items: center; margin-top: -6px; }
+    div.checkbox { border: solid 1px #000; width: 12px; height: 12px; margin: 8px 10px 8px 2px; display: inline-block; }
+    div.ranking-box { border: solid 1px #000; width: 24px; height: 24px; margin: 8px 10px 8px 2px; display: inline-block; }
+    div.radio { border-radius: 50%; }
+    span.optional { font-weight: normal; }
+    div.field-group { page-break-inside: avoid; }
+
+    #header {
+      margin-bottom: 30px;
+      img { height: auto; }
+      h1 { margin-top: 0; }
+    }
+
+    #personal-data {
+      page-break-after: always;
+    }
+
+    #questions {
+      h2, h3 { margin-bottom: 8px; }
+      span.number { width: 30px; display: inline-block; }
+      div.content { margin-left: 30px; margin-right: 30px;}
+      p { margin-top: 0; margin-bottom: 4px;}
+      div.question, div.page { margin-bottom: 30px; }
+      div.unsupported p, div.visibility_disclaimer p { color: #666; font-style: italic; }
+      div.image-select {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 10px;
+        margin-bottom: 10px;
+        div.image {
+          border: #ccc solid 1px;
           margin-bottom: 10px;
+          height: 140px;
+          text-align: center;
+          background: #eee;
+          img { object-fit: contain; height: 140px; }
+          svg { border-radius: 5px; object-fit: contain; height: 50px; margin: 45px 0 45px 0; }
         }
       }
-
-      body { font-family: <%== font_family %>; }
-      h1 { font-size: 18pt; }
-      h2 { font-size: 16pt; }
-      h3 { font-size: 14pt; }
-      h4, p, li { font-size: 12pt; line-height: 1.2; }
-
-      div.line { border-bottom: solid 1px #000; margin: 10px 0; height: 25px; }
-      div.select, div.ranking { display: flex; align-items: center; margin-top: -6px; }
-      div.checkbox { border: solid 1px #000; width: 12px; height: 12px; margin: 8px 10px 8px 2px; display: inline-block; }
-      div.ranking-box { border: solid 1px #000; width: 24px; height: 24px; margin: 8px 10px 8px 2px; display: inline-block; }
-      div.radio { border-radius: 50%; }
-      span.optional { font-weight: normal; }
-      div.field-group { page-break-inside: avoid; }
-
-      #header {
-        margin-bottom: 30px;
-        img { height: auto; }
-        h1 { margin-top: 0; }
-      }
-
-      #personal-data {
-        page-break-after: always;
-      }
-
-      #questions {
-        h2, h3 { margin-bottom: 8px; }
-        span.number { width: 30px; display: inline-block; }
-          div.content {
-            margin-left: 30px;
-            margin-right: 30px;
-          }
-        p { margin-top: 0; margin-bottom: 4px;}
-        div.question, div.page { margin-bottom: 30px; }
-        div.unsupported p, div.visibility_disclaimer p { color: #666; font-style: italic; }
-      }
+    }
   </style>
 </head>
 <body>
@@ -155,33 +167,6 @@
                 </div>
               <% end %>
             </div>
-
-            <style>
-                .image-select {
-                    display: grid;
-                    grid-template-columns: repeat(3, 1fr);
-                    gap: 10px;
-                    margin-bottom: 10px;
-                }
-                .image-select div.image {
-                    border: #ccc solid 1px;
-                    margin-bottom: 10px;
-                    height: 140px;
-                    text-align: center;
-                    background: #eee;
-                }
-                .image-select img {
-                    object-fit: contain;
-                    height: 140px;
-                }
-                .image-select svg {
-                    border-radius: 5px;
-                    object-fit: contain;
-                    height: 50px;
-                    margin: 45px 0 45px 0;
-                }
-
-            </style>
 
           <% elsif field[:format] == :multi_line_text %>
             <% 7.times do %>

--- a/back/engines/commercial/bulk_import_ideas/app/views/bulk_import_ideas/web_api/v1/export_form.html.erb
+++ b/back/engines/commercial/bulk_import_ideas/app/views/bulk_import_ideas/web_api/v1/export_form.html.erb
@@ -66,7 +66,7 @@
           height: 140px;
           text-align: center;
           background: #eee;
-          img { object-fit: contain; height: 140px; }
+          img { object-fit: contain; height: 100%; width: 100%; }
           svg { border-radius: 5px; object-fit: contain; height: 50px; margin: 45px 0 45px 0; }
         }
       }

--- a/back/engines/commercial/bulk_import_ideas/app/views/bulk_import_ideas/web_api/v1/export_form.html.erb
+++ b/back/engines/commercial/bulk_import_ideas/app/views/bulk_import_ideas/web_api/v1/export_form.html.erb
@@ -130,6 +130,59 @@
               <% end %>
             </div>
 
+          <% elsif field[:format] == :multi_select_image %>
+            <div class="image-select">
+              <% field[:options].each do |option| %>
+                <div>
+                  <div class="image">
+                    <% if option[:image_url] %>
+                      <img alt="<%= option[:title] %>" src="<%= option[:image_url] %>" />
+                    <% else %>
+                      <!-- No image placeholder -->
+                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180.119 139.794">
+                        <g transform="translate(-13.59 -66.639)">
+                          <path fill="#d0d0d0" d="M13.591 66.639H193.71v139.794H13.591z"/>
+                          <path d="m118.507 133.514-34.249 34.249-15.968-15.968-41.938 41.937H178.726z" opacity=".675" fill="#fff"/>
+                          <path fill="none" d="M26.111 77.634h152.614v116.099H26.111z"/>
+                        </g>
+                      </svg>
+                    <% end %>
+                  </div>
+                  <div class="select">
+                    <div class="checkbox"></div>
+                    <div><%= option[:title] %></div>
+                  </div>
+                </div>
+              <% end %>
+            </div>
+
+            <style>
+                .image-select {
+                    display: grid;
+                    grid-template-columns: repeat(3, 1fr);
+                    gap: 10px;
+                    margin-bottom: 10px;
+                }
+                .image-select div.image {
+                    border: #ccc solid 1px;
+                    margin-bottom: 10px;
+                    height: 140px;
+                    text-align: center;
+                    background: #eee;
+                }
+                .image-select img {
+                    object-fit: contain;
+                    height: 140px;
+                }
+                .image-select svg {
+                    border-radius: 5px;
+                    object-fit: contain;
+                    height: 50px;
+                    margin: 45px 0 45px 0;
+                }
+
+            </style>
+
           <% elsif field[:format] == :multi_line_text %>
             <% 7.times do %>
               <div class="line"></div>

--- a/back/engines/commercial/bulk_import_ideas/app/views/bulk_import_ideas/web_api/v1/export_form.html.erb
+++ b/back/engines/commercial/bulk_import_ideas/app/views/bulk_import_ideas/web_api/v1/export_form.html.erb
@@ -37,6 +37,7 @@
       div.radio { border-radius: 50%; }
       span.optional { font-weight: normal; }
       div.field-group { page-break-inside: avoid; }
+      div.options { margin-top: 10px; }
 
       #header {
         margin-bottom: 30px;

--- a/back/engines/commercial/bulk_import_ideas/spec/services/exporters/idea_html_form_exporter_spec.rb
+++ b/back/engines/commercial/bulk_import_ideas/spec/services/exporters/idea_html_form_exporter_spec.rb
@@ -23,6 +23,20 @@ describe BulkImportIdeas::Exporters::IdeaHtmlFormExporter do
     field.options.create!(key: 'ranking_two', title_multiloc: { 'en' => 'Ranking two' })
     field
   end
+  let!(:multiselect_image_field) do
+    field = create(
+      :custom_field_multiselect_image,
+      resource: custom_form,
+      title_multiloc: { 'en' => 'Select image field' },
+      select_count_enabled: true,
+      minimum_select_count: 1,
+      maximum_select_count: 2
+    )
+    field.options.create!(title_multiloc: { 'en' => 'Image one' }, image: create(:custom_field_option_image))
+    field.options.create!(title_multiloc: { 'en' => 'Image two' }, image: create(:custom_field_option_image))
+    field.options.create!(title_multiloc: { 'en' => 'Image three' }, image: create(:custom_field_option_image))
+    field
+  end
   let!(:end_page_field) { create(:custom_field_form_end_page, resource: custom_form) }
 
   describe 'export' do
@@ -61,12 +75,16 @@ describe BulkImportIdeas::Exporters::IdeaHtmlFormExporter do
         expect(titles[0]).to include 'Text field'
         expect(titles[1]).to include 'Multiline field'
         expect(titles[2]).to include 'Select field'
+        expect(titles[3]).to include 'Ranking field'
+        expect(titles[4]).to include 'Select image field'
       end
 
       it 'shows optional if questions are not required' do
         expect(titles[0]).not_to include '(optional)'
         expect(titles[1]).to include '(optional)'
         expect(titles[2]).to include '(optional)'
+        expect(titles[3]).to include '(optional)'
+        expect(titles[4]).to include '(optional)'
       end
 
       it 'shows 1 line for short text fields' do
@@ -75,8 +93,8 @@ describe BulkImportIdeas::Exporters::IdeaHtmlFormExporter do
       end
 
       it 'shows 7 lines for longer text fields' do
-        multi_line_text = parsed_html.css("div##{multiline_field.id}")
-        expect(multi_line_text.css('div.line').count).to eq 7
+        multiline_text = parsed_html.css("div##{multiline_field.id}")
+        expect(multiline_text.css('div.line').count).to eq 7
       end
 
       it 'shows multiselect instructions and options' do
@@ -91,6 +109,14 @@ describe BulkImportIdeas::Exporters::IdeaHtmlFormExporter do
         expect(ranking.text).to include 'Please write a number from 1 (most preferred) and 2 (least preferred) in each box. Use each number only once.'
         expect(ranking.text).to include 'Ranking one'
         expect(ranking.text).to include 'Ranking two'
+      end
+
+      it 'shows multiselect image instructions and options' do
+        multiselect_image = parsed_html.css("div##{multiselect_image_field.id}")
+        expect(multiselect_image.text).to include '*Choose between 1 and 2 options'
+        expect(multiselect_image.text).to include 'Image one'
+        expect(multiselect_image.text).to include 'Image two'
+        expect(multiselect_image.text).to include 'Image three'
       end
     end
   end

--- a/back/engines/commercial/bulk_import_ideas/spec/services/exporters/idea_html_form_exporter_spec.rb
+++ b/back/engines/commercial/bulk_import_ideas/spec/services/exporters/idea_html_form_exporter_spec.rb
@@ -54,7 +54,8 @@ describe BulkImportIdeas::Exporters::IdeaHtmlFormExporter do
     field.matrix_statements.create!(title_multiloc: { 'en' => 'Matrix statement two' })
     field
   end
-
+  let!(:rating_field) { create(:custom_field_rating, resource: custom_form, key: 'rating_field', title_multiloc: { 'en' => 'Rating field' }) }
+  let!(:sentiment_linear_scale_field) { create(:custom_field_sentiment_linear_scale, resource: custom_form, key: 'sentiment_field', title_multiloc: { 'en' => 'Sentiment scale field' }) }
   let!(:end_page_field) { create(:custom_field_form_end_page, resource: custom_form) }
 
   describe 'export' do
@@ -96,6 +97,8 @@ describe BulkImportIdeas::Exporters::IdeaHtmlFormExporter do
         expect(titles[3]).to include 'Ranking field'
         expect(titles[4]).to include 'Select image field'
         expect(titles[5]).to include 'Matrix field'
+        expect(titles[6]).to include 'Rating field'
+        expect(titles[7]).to include 'Sentiment scale field'
       end
 
       it 'shows optional if questions are not required' do
@@ -105,6 +108,8 @@ describe BulkImportIdeas::Exporters::IdeaHtmlFormExporter do
         expect(titles[3]).to include '(optional)'
         expect(titles[4]).to include '(optional)'
         expect(titles[5]).to include '(optional)'
+        expect(titles[6]).to include '(optional)'
+        expect(titles[7]).to include '(optional)'
       end
 
       it 'shows 1 line for short text fields' do
@@ -149,6 +154,17 @@ describe BulkImportIdeas::Exporters::IdeaHtmlFormExporter do
         expect(matrix.text).to include 'Neutral'
         expect(matrix.text).to include 'Agree'
         expect(matrix.text).to include 'Strongly agree'
+      end
+
+      it 'shows rating field instructions' do
+        rating = parsed_html.css("div##{rating_field.id}")
+        expect(rating.text).to include 'Rate this by writing a number between 1 (worst) and 5 (best).'
+      end
+
+      it 'shows sentiment scale field instructions' do
+        sentiment_scale = parsed_html.css("div##{sentiment_linear_scale_field.id}")
+        expect(sentiment_scale.text).to include 'Please write a number between 1 and 5.'
+        expect(sentiment_scale.text).to include '1 = Strongly disagree, 3 = Neutral, 5 = Strongly agree.'
       end
     end
   end

--- a/back/engines/commercial/bulk_import_ideas/spec/services/exporters/idea_html_form_exporter_spec.rb
+++ b/back/engines/commercial/bulk_import_ideas/spec/services/exporters/idea_html_form_exporter_spec.rb
@@ -37,6 +37,24 @@ describe BulkImportIdeas::Exporters::IdeaHtmlFormExporter do
     field.options.create!(title_multiloc: { 'en' => 'Image three' }, image: create(:custom_field_option_image))
     field
   end
+  let!(:matrix_field) do
+    field = create(
+      :custom_field_matrix_linear_scale,
+      resource: custom_form,
+      key: 'matrix_field',
+      title_multiloc: { 'en' => 'Matrix field' },
+      linear_scale_label_1_multiloc: { 'en' => 'Strongly disagree' },
+      linear_scale_label_2_multiloc: { 'en' => 'Disagree' },
+      linear_scale_label_3_multiloc: { 'en' => 'Neutral' },
+      linear_scale_label_4_multiloc: { 'en' => 'Agree' },
+      linear_scale_label_5_multiloc: { 'en' => 'Strongly agree' },
+      maximum: 5
+    )
+    field.matrix_statements.create!(title_multiloc: { 'en' => 'Matrix statement one' })
+    field.matrix_statements.create!(title_multiloc: { 'en' => 'Matrix statement two' })
+    field
+  end
+
   let!(:end_page_field) { create(:custom_field_form_end_page, resource: custom_form) }
 
   describe 'export' do
@@ -77,6 +95,7 @@ describe BulkImportIdeas::Exporters::IdeaHtmlFormExporter do
         expect(titles[2]).to include 'Select field'
         expect(titles[3]).to include 'Ranking field'
         expect(titles[4]).to include 'Select image field'
+        expect(titles[5]).to include 'Matrix field'
       end
 
       it 'shows optional if questions are not required' do
@@ -85,6 +104,7 @@ describe BulkImportIdeas::Exporters::IdeaHtmlFormExporter do
         expect(titles[2]).to include '(optional)'
         expect(titles[3]).to include '(optional)'
         expect(titles[4]).to include '(optional)'
+        expect(titles[5]).to include '(optional)'
       end
 
       it 'shows 1 line for short text fields' do
@@ -117,6 +137,18 @@ describe BulkImportIdeas::Exporters::IdeaHtmlFormExporter do
         expect(multiselect_image.text).to include 'Image one'
         expect(multiselect_image.text).to include 'Image two'
         expect(multiselect_image.text).to include 'Image three'
+      end
+
+      it 'shows matrix statements and instructions' do
+        matrix = parsed_html.css("div##{matrix_field.id}")
+        expect(matrix.text).to include 'For each row, mark one circle with a cross to indicate your preference.'
+        expect(matrix.text).to include 'Matrix statement one'
+        expect(matrix.text).to include 'Matrix statement two'
+        expect(matrix.text).to include 'Strongly disagree'
+        expect(matrix.text).to include 'Disagree'
+        expect(matrix.text).to include 'Neutral'
+        expect(matrix.text).to include 'Agree'
+        expect(matrix.text).to include 'Strongly agree'
       end
     end
   end

--- a/back/spec/fixtures/locales/en.yml
+++ b/back/spec/fixtures/locales/en.yml
@@ -34,6 +34,7 @@ en:
       write_in_language: 'Write your answers in the same language as this form'
       linear_scale_print_description: 'Please write a number between %{min_label} and %{max_label} only'
       unsupported_field: This field cannot be completed on paper. Please use the online version of this form instead.
+      ranking_print_description: 'Please write a number from 1 (most preferred) and %{max_rank} (least preferred) in each box. Use each number only once.'
   custom_fields:
     ideas:
       title:

--- a/back/spec/fixtures/locales/en.yml
+++ b/back/spec/fixtures/locales/en.yml
@@ -35,6 +35,7 @@ en:
       linear_scale_print_description: 'Please write a number between %{min_label} and %{max_label} only'
       unsupported_field: This field cannot be completed on paper. Please use the online version of this form instead.
       ranking_print_description: 'Please write a number from 1 (most preferred) and %{max_rank} (least preferred) in each box. Use each number only once.'
+      matrix_print_description: 'For each row, mark one circle with a cross to indicate your preference.'
   custom_fields:
     ideas:
       title:

--- a/back/spec/fixtures/locales/en.yml
+++ b/back/spec/fixtures/locales/en.yml
@@ -36,6 +36,7 @@ en:
       unsupported_field: This field cannot be completed on paper. Please use the online version of this form instead.
       ranking_print_description: 'Please write a number from 1 (most preferred) and %{max_rank} (least preferred) in each box. Use each number only once.'
       matrix_print_description: 'For each row, mark one circle with a cross to indicate your preference.'
+      rating_print_description: 'Rate this by writing a number between 1 (worst) and %{max_stars} (best).'
   custom_fields:
     ideas:
       title:


### PR DESCRIPTION
# Changelog
## Added 
- Added ranking field to the PDF download (feature flagged)
- Added matrix field to the printed PDF  (feature flagged)
- Added Multiselect image questions added to the PDF (feature flagged)
- Added better text description for Rating field in PDF (feature flagged)
- Added better text description for Sentiment linear scale fields & enabled for importing (feature flagged)
