### PR TITLE
TAN-4629 - Add multiselect image field to PDF

### DIFF
--- a/back/config/locales/en.yml
+++ b/back/config/locales/en.yml
@@ -332,6 +332,7 @@ en:
       linear_scale_print_description: 'Please write a number between %{min_label} and %{max_label} only'
       unsupported_field: 'This field cannot be completed on paper. Please use the online version of this form instead.'
       ranking_print_description: 'Please write a number from 1 (most preferred) and %{max_rank} (least preferred) in each box. Use each number only once.'
+      matrix_print_description: 'For each row, mark one circle with a cross to indicate your preference.'
   project_copy:
     title_suffix: 'Copy'
   confirmations_mailer:

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_html_form_exporter.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_html_form_exporter.rb
@@ -133,7 +133,8 @@ module BulkImportIdeas::Exporters
               title: option.title_multiloc[@locale],
               image_url: option_image_url(field, option)
             }
-          end
+          end,
+          matrix: field_matrix_details(field)
         }
       end
 
@@ -179,6 +180,8 @@ module BulkImportIdeas::Exporters
         :single_line_text
       when 'ranking'
         :ranking
+      when 'matrix_linear_scale'
+        :matrix_linear_scale
       else
         # CURRENTLY UNSUPPORTED
         # rating
@@ -210,6 +213,7 @@ module BulkImportIdeas::Exporters
         html = format_urls(description[@locale]) || ''
         html += multiselect_print_instructions(field)
         html += ranking_print_instructions(field)
+        html += matrix_print_instructions(field)
         html
       end
     end
@@ -280,6 +284,28 @@ module BulkImportIdeas::Exporters
         end
       end
       "<p>*#{message}</p>"
+    end
+
+    def field_matrix_details(field)
+      return unless field.supports_matrix_statements?
+
+      {
+        statements: field.matrix_statements.map { |statement| field_print_title(statement) },
+        labels: (1..field.maximum).map do |i|
+          field["linear_scale_label_#{i}_multiloc"][@locale]
+        end,
+        label_width: 70 / field.maximum # 70% of the printed width for the labels, 30% for the statements
+      }
+    end
+
+    def matrix_print_instructions(field)
+      return '' unless field.supports_matrix_statements?
+
+      description = I18n.with_locale(@locale) do
+        I18n.t('form_builder.pdf_export.matrix_print_description')
+      end
+
+      "<p>#{description}</p>"
     end
 
     def font_family

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_html_pdf_form_exporter.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_html_pdf_form_exporter.rb
@@ -140,7 +140,7 @@ module BulkImportIdeas::Exporters
     end
 
     # Allow rendering of images in the PDF when in development
-    def format_html_field(description)
+    def format_urls(description)
       new_description = super
       new_description&.sub!('localhost:4000', 'cl-back-web:4000') if Rails.env.development?
       new_description

--- a/back/engines/commercial/bulk_import_ideas/app/views/bulk_import_ideas/web_api/v1/export_form.html.erb
+++ b/back/engines/commercial/bulk_import_ideas/app/views/bulk_import_ideas/web_api/v1/export_form.html.erb
@@ -37,6 +37,7 @@
     div.radio { border-radius: 50%; }
     span.optional { font-weight: normal; }
     div.field-group { page-break-inside: avoid; }
+    div.options { margin-top: 10px; }
 
     #header {
       margin-bottom: 30px;

--- a/back/engines/commercial/bulk_import_ideas/app/views/bulk_import_ideas/web_api/v1/export_form.html.erb
+++ b/back/engines/commercial/bulk_import_ideas/app/views/bulk_import_ideas/web_api/v1/export_form.html.erb
@@ -28,7 +28,7 @@
     h1 { font-size: 18pt; }
     h2 { font-size: 16pt; }
     h3 { font-size: 14pt; }
-    h4, p, li { font-size: 12pt; line-height: 1.2; }
+    h4, p, li, td, th { font-size: 12pt; line-height: 1.2; }
 
     div.line { border-bottom: solid 1px #000; margin: 10px 0; height: 25px; }
     div.select, div.ranking { display: flex; align-items: center; margin-top: -6px; }
@@ -68,6 +68,22 @@
           background: #eee;
           img { object-fit: contain; height: 140px; }
           svg { border-radius: 5px; object-fit: contain; height: 50px; margin: 45px 0 45px 0; }
+        }
+      }
+      div.matrix {
+        table {
+          margin-top: 10px;
+          border-collapse: collapse;
+          width: 100%;
+          th, td {
+            border-bottom: 1px solid #000;
+            padding: 5px;
+            text-align: center;
+            font-weight: normal;
+          }
+          td.statement {
+            text-align: left;
+          }
         }
       }
     }
@@ -184,6 +200,26 @@
                   <div><%= option[:title] %></div>
                 </div>
               <% end %>
+            </div>
+
+          <% elsif field[:format] == :matrix_linear_scale %>
+            <div class="matrix">
+              <table>
+                <tr>
+                  <th></th>
+                  <% field[:matrix][:labels].each do |label| %>
+                    <th style="width: <%= field[:matrix][:label_width] %>%"><%= label %></th>
+                  <% end %>
+                </tr>
+                <% field[:matrix][:statements].each do |statement| %>
+                  <tr>
+                    <td class="statement"><%= statement %></td>
+                    <% field[:matrix][:labels].each do |_| %>
+                      <td><div class="checkbox radio"></div></td>
+                    <% end %>
+                  </tr>
+                  <% end %>
+              </table>
             </div>
 
           <% else %>

--- a/back/engines/commercial/bulk_import_ideas/app/views/bulk_import_ideas/web_api/v1/export_form.html.erb
+++ b/back/engines/commercial/bulk_import_ideas/app/views/bulk_import_ideas/web_api/v1/export_form.html.erb
@@ -14,51 +14,63 @@
   <% end %>
 
   <style>
-      @page {
-        size: A4;
-        margin: 40px 40px 80px;
-        @bottom-right {
-          font-family: <%== font_family %>;
-          content: '<%= page_copy %> ' counter(page);
+    @page {
+      size: A4;
+      margin: 40px 40px 80px;
+      @bottom-right {
+        font-family: <%== font_family %>;
+        content: '<%= page_copy %> ' counter(page);
+        margin-bottom: 10px;
+      }
+    }
+
+    body { font-family: <%== font_family %>; }
+    h1 { font-size: 18pt; }
+    h2 { font-size: 16pt; }
+    h3 { font-size: 14pt; }
+    h4, p, li { font-size: 12pt; line-height: 1.2; }
+
+    div.line { border-bottom: solid 1px #000; margin: 10px 0; height: 25px; }
+    div.select, div.ranking { display: flex; align-items: center; margin-top: -6px; }
+    div.checkbox { border: solid 1px #000; width: 12px; height: 12px; margin: 8px 10px 8px 2px; display: inline-block; }
+    div.ranking-box { border: solid 1px #000; width: 24px; height: 24px; margin: 8px 10px 8px 2px; display: inline-block; }
+    div.radio { border-radius: 50%; }
+    span.optional { font-weight: normal; }
+    div.field-group { page-break-inside: avoid; }
+
+    #header {
+      margin-bottom: 30px;
+      img { height: auto; }
+      h1 { margin-top: 0; }
+    }
+
+    #personal-data {
+      page-break-after: always;
+    }
+
+    #questions {
+      h2, h3 { margin-bottom: 8px; }
+      span.number { width: 30px; display: inline-block; }
+      div.content { margin-left: 30px; margin-right: 30px;}
+      p { margin-top: 0; margin-bottom: 4px;}
+      div.question, div.page { margin-bottom: 30px; }
+      div.unsupported p, div.visibility_disclaimer p { color: #666; font-style: italic; }
+      div.image-select {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 10px;
+        margin-bottom: 10px;
+        div.image {
+          border: #ccc solid 1px;
           margin-bottom: 10px;
+          height: 140px;
+          text-align: center;
+          background: #eee;
+          img { object-fit: contain; height: 140px; }
+          svg { border-radius: 5px; object-fit: contain; height: 50px; margin: 45px 0 45px 0; }
         }
       }
-
-      body { font-family: <%== font_family %>; }
-      h1 { font-size: 18pt; }
-      h2 { font-size: 16pt; }
-      h3 { font-size: 14pt; }
-      h4, p, li { font-size: 12pt; line-height: 1.2; }
-
-      div.line { border-bottom: solid 1px #000; margin: 10px 0; height: 25px; }
-      div.select, div.ranking { display: flex; align-items: center; margin-top: -6px; }
-      div.checkbox { border: solid 1px #000; width: 12px; height: 12px; margin: 8px 10px 8px 2px; display: inline-block; }
-      div.ranking-box { border: solid 1px #000; width: 24px; height: 24px; margin: 8px 10px 8px 2px; display: inline-block; }
-      div.radio { border-radius: 50%; }
-      span.optional { font-weight: normal; }
-      div.field-group { page-break-inside: avoid; }
-
-      #header {
-        margin-bottom: 30px;
-        img { height: auto; }
-        h1 { margin-top: 0; }
-      }
-
-      #personal-data {
-        page-break-after: always;
-      }
-
-      #questions {
-        h2, h3 { margin-bottom: 8px; }
-        span.number { width: 30px; display: inline-block; }
-          div.content {
-            margin-left: 30px;
-            margin-right: 30px;
-          }
-        p { margin-top: 0; margin-bottom: 4px;}
-        div.question, div.page { margin-bottom: 30px; }
-        div.unsupported p, div.visibility_disclaimer p { color: #666; font-style: italic; }
-      }
+    }
   </style>
 </head>
 <body>
@@ -155,33 +167,6 @@
                 </div>
               <% end %>
             </div>
-
-            <style>
-                .image-select {
-                    display: grid;
-                    grid-template-columns: repeat(3, 1fr);
-                    gap: 10px;
-                    margin-bottom: 10px;
-                }
-                .image-select div.image {
-                    border: #ccc solid 1px;
-                    margin-bottom: 10px;
-                    height: 140px;
-                    text-align: center;
-                    background: #eee;
-                }
-                .image-select img {
-                    object-fit: contain;
-                    height: 140px;
-                }
-                .image-select svg {
-                    border-radius: 5px;
-                    object-fit: contain;
-                    height: 50px;
-                    margin: 45px 0 45px 0;
-                }
-
-            </style>
 
           <% elsif field[:format] == :multi_line_text %>
             <% 7.times do %>

--- a/back/engines/commercial/bulk_import_ideas/app/views/bulk_import_ideas/web_api/v1/export_form.html.erb
+++ b/back/engines/commercial/bulk_import_ideas/app/views/bulk_import_ideas/web_api/v1/export_form.html.erb
@@ -66,7 +66,7 @@
           height: 140px;
           text-align: center;
           background: #eee;
-          img { object-fit: contain; height: 140px; }
+          img { object-fit: contain; height: 100%; width: 100%; }
           svg { border-radius: 5px; object-fit: contain; height: 50px; margin: 45px 0 45px 0; }
         }
       }

--- a/back/engines/commercial/bulk_import_ideas/app/views/bulk_import_ideas/web_api/v1/export_form.html.erb
+++ b/back/engines/commercial/bulk_import_ideas/app/views/bulk_import_ideas/web_api/v1/export_form.html.erb
@@ -130,6 +130,59 @@
               <% end %>
             </div>
 
+          <% elsif field[:format] == :multi_select_image %>
+            <div class="image-select">
+              <% field[:options].each do |option| %>
+                <div>
+                  <div class="image">
+                    <% if option[:image_url] %>
+                      <img alt="<%= option[:title] %>" src="<%= option[:image_url] %>" />
+                    <% else %>
+                      <!-- No image placeholder -->
+                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180.119 139.794">
+                        <g transform="translate(-13.59 -66.639)">
+                          <path fill="#d0d0d0" d="M13.591 66.639H193.71v139.794H13.591z"/>
+                          <path d="m118.507 133.514-34.249 34.249-15.968-15.968-41.938 41.937H178.726z" opacity=".675" fill="#fff"/>
+                          <path fill="none" d="M26.111 77.634h152.614v116.099H26.111z"/>
+                        </g>
+                      </svg>
+                    <% end %>
+                  </div>
+                  <div class="select">
+                    <div class="checkbox"></div>
+                    <div><%= option[:title] %></div>
+                  </div>
+                </div>
+              <% end %>
+            </div>
+
+            <style>
+                .image-select {
+                    display: grid;
+                    grid-template-columns: repeat(3, 1fr);
+                    gap: 10px;
+                    margin-bottom: 10px;
+                }
+                .image-select div.image {
+                    border: #ccc solid 1px;
+                    margin-bottom: 10px;
+                    height: 140px;
+                    text-align: center;
+                    background: #eee;
+                }
+                .image-select img {
+                    object-fit: contain;
+                    height: 140px;
+                }
+                .image-select svg {
+                    border-radius: 5px;
+                    object-fit: contain;
+                    height: 50px;
+                    margin: 45px 0 45px 0;
+                }
+
+            </style>
+
           <% elsif field[:format] == :multi_line_text %>
             <% 7.times do %>
               <div class="line"></div>

--- a/back/engines/commercial/bulk_import_ideas/spec/services/exporters/idea_html_form_exporter_spec.rb
+++ b/back/engines/commercial/bulk_import_ideas/spec/services/exporters/idea_html_form_exporter_spec.rb
@@ -23,6 +23,20 @@ describe BulkImportIdeas::Exporters::IdeaHtmlFormExporter do
     field.options.create!(key: 'ranking_two', title_multiloc: { 'en' => 'Ranking two' })
     field
   end
+  let!(:multiselect_image_field) do
+    field = create(
+      :custom_field_multiselect_image,
+      resource: custom_form,
+      title_multiloc: { 'en' => 'Select image field' },
+      select_count_enabled: true,
+      minimum_select_count: 1,
+      maximum_select_count: 2
+    )
+    field.options.create!(title_multiloc: { 'en' => 'Image one' }, image: create(:custom_field_option_image))
+    field.options.create!(title_multiloc: { 'en' => 'Image two' }, image: create(:custom_field_option_image))
+    field.options.create!(title_multiloc: { 'en' => 'Image three' }, image: create(:custom_field_option_image))
+    field
+  end
   let!(:end_page_field) { create(:custom_field_form_end_page, resource: custom_form) }
 
   describe 'export' do
@@ -61,12 +75,16 @@ describe BulkImportIdeas::Exporters::IdeaHtmlFormExporter do
         expect(titles[0]).to include 'Text field'
         expect(titles[1]).to include 'Multiline field'
         expect(titles[2]).to include 'Select field'
+        expect(titles[3]).to include 'Ranking field'
+        expect(titles[4]).to include 'Select image field'
       end
 
       it 'shows optional if questions are not required' do
         expect(titles[0]).not_to include '(optional)'
         expect(titles[1]).to include '(optional)'
         expect(titles[2]).to include '(optional)'
+        expect(titles[3]).to include '(optional)'
+        expect(titles[4]).to include '(optional)'
       end
 
       it 'shows 1 line for short text fields' do
@@ -75,8 +93,8 @@ describe BulkImportIdeas::Exporters::IdeaHtmlFormExporter do
       end
 
       it 'shows 7 lines for longer text fields' do
-        multi_line_text = parsed_html.css("div##{multiline_field.id}")
-        expect(multi_line_text.css('div.line').count).to eq 7
+        multiline_text = parsed_html.css("div##{multiline_field.id}")
+        expect(multiline_text.css('div.line').count).to eq 7
       end
 
       it 'shows multiselect instructions and options' do
@@ -91,6 +109,14 @@ describe BulkImportIdeas::Exporters::IdeaHtmlFormExporter do
         expect(ranking.text).to include 'Please write a number from 1 (most preferred) and 2 (least preferred) in each box. Use each number only once.'
         expect(ranking.text).to include 'Ranking one'
         expect(ranking.text).to include 'Ranking two'
+      end
+
+      it 'shows multiselect image instructions and options' do
+        multiselect_image = parsed_html.css("div##{multiselect_image_field.id}")
+        expect(multiselect_image.text).to include '*Choose between 1 and 2 options'
+        expect(multiselect_image.text).to include 'Image one'
+        expect(multiselect_image.text).to include 'Image two'
+        expect(multiselect_image.text).to include 'Image three'
       end
     end
   end

--- a/back/engines/commercial/bulk_import_ideas/spec/services/exporters/idea_html_form_exporter_spec.rb
+++ b/back/engines/commercial/bulk_import_ideas/spec/services/exporters/idea_html_form_exporter_spec.rb
@@ -37,6 +37,24 @@ describe BulkImportIdeas::Exporters::IdeaHtmlFormExporter do
     field.options.create!(title_multiloc: { 'en' => 'Image three' }, image: create(:custom_field_option_image))
     field
   end
+  let!(:matrix_field) do
+    field = create(
+      :custom_field_matrix_linear_scale,
+      resource: custom_form,
+      key: 'matrix_field',
+      title_multiloc: { 'en' => 'Matrix field' },
+      linear_scale_label_1_multiloc: { 'en' => 'Strongly disagree' },
+      linear_scale_label_2_multiloc: { 'en' => 'Disagree' },
+      linear_scale_label_3_multiloc: { 'en' => 'Neutral' },
+      linear_scale_label_4_multiloc: { 'en' => 'Agree' },
+      linear_scale_label_5_multiloc: { 'en' => 'Strongly agree' },
+      maximum: 5
+    )
+    field.matrix_statements.create!(title_multiloc: { 'en' => 'Matrix statement one' })
+    field.matrix_statements.create!(title_multiloc: { 'en' => 'Matrix statement two' })
+    field
+  end
+
   let!(:end_page_field) { create(:custom_field_form_end_page, resource: custom_form) }
 
   describe 'export' do
@@ -77,6 +95,7 @@ describe BulkImportIdeas::Exporters::IdeaHtmlFormExporter do
         expect(titles[2]).to include 'Select field'
         expect(titles[3]).to include 'Ranking field'
         expect(titles[4]).to include 'Select image field'
+        expect(titles[5]).to include 'Matrix field'
       end
 
       it 'shows optional if questions are not required' do
@@ -85,6 +104,7 @@ describe BulkImportIdeas::Exporters::IdeaHtmlFormExporter do
         expect(titles[2]).to include '(optional)'
         expect(titles[3]).to include '(optional)'
         expect(titles[4]).to include '(optional)'
+        expect(titles[5]).to include '(optional)'
       end
 
       it 'shows 1 line for short text fields' do
@@ -117,6 +137,18 @@ describe BulkImportIdeas::Exporters::IdeaHtmlFormExporter do
         expect(multiselect_image.text).to include 'Image one'
         expect(multiselect_image.text).to include 'Image two'
         expect(multiselect_image.text).to include 'Image three'
+      end
+
+      it 'shows matrix statements and instructions' do
+        matrix = parsed_html.css("div##{matrix_field.id}")
+        expect(matrix.text).to include 'For each row, mark one circle with a cross to indicate your preference.'
+        expect(matrix.text).to include 'Matrix statement one'
+        expect(matrix.text).to include 'Matrix statement two'
+        expect(matrix.text).to include 'Strongly disagree'
+        expect(matrix.text).to include 'Disagree'
+        expect(matrix.text).to include 'Neutral'
+        expect(matrix.text).to include 'Agree'
+        expect(matrix.text).to include 'Strongly agree'
       end
     end
   end

--- a/back/spec/fixtures/locales/en.yml
+++ b/back/spec/fixtures/locales/en.yml
@@ -35,6 +35,7 @@ en:
       linear_scale_print_description: 'Please write a number between %{min_label} and %{max_label} only'
       unsupported_field: This field cannot be completed on paper. Please use the online version of this form instead.
       ranking_print_description: 'Please write a number from 1 (most preferred) and %{max_rank} (least preferred) in each box. Use each number only once.'
+      matrix_print_description: 'For each row, mark one circle with a cross to indicate your preference.'
   custom_fields:
     ideas:
       title:


### PR DESCRIPTION
Looks like this:

<img width="714" alt="image" src="https://github.com/user-attachments/assets/18cfa21f-6bdb-4ba3-922d-29262d2935b0" />

# Changelog
## Added
- Multiselect image questions added to the PDF
