### PR TITLE
TAN-4634 - Add matrix field to PDF

### DIFF
--- a/back/config/locales/en.yml
+++ b/back/config/locales/en.yml
@@ -332,6 +332,7 @@ en:
       linear_scale_print_description: 'Please write a number between %{min_label} and %{max_label} only'
       unsupported_field: 'This field cannot be completed on paper. Please use the online version of this form instead.'
       ranking_print_description: 'Please write a number from 1 (most preferred) and %{max_rank} (least preferred) in each box. Use each number only once.'
+      matrix_print_description: 'For each row, mark one circle with a cross to indicate your preference.'
   project_copy:
     title_suffix: 'Copy'
   confirmations_mailer:

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_html_form_exporter.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_html_form_exporter.rb
@@ -133,7 +133,8 @@ module BulkImportIdeas::Exporters
               title: option.title_multiloc[@locale],
               image_url: option_image_url(field, option)
             }
-          end
+          end,
+          matrix: field_matrix_details(field)
         }
       end
 
@@ -179,6 +180,8 @@ module BulkImportIdeas::Exporters
         :single_line_text
       when 'ranking'
         :ranking
+      when 'matrix_linear_scale'
+        :matrix_linear_scale
       else
         # CURRENTLY UNSUPPORTED
         # rating
@@ -210,6 +213,7 @@ module BulkImportIdeas::Exporters
         html = format_urls(description[@locale]) || ''
         html += multiselect_print_instructions(field)
         html += ranking_print_instructions(field)
+        html += matrix_print_instructions(field)
         html
       end
     end
@@ -280,6 +284,28 @@ module BulkImportIdeas::Exporters
         end
       end
       "<p>*#{message}</p>"
+    end
+
+    def field_matrix_details(field)
+      return unless field.supports_matrix_statements?
+
+      {
+        statements: field.matrix_statements.map { |statement| field_print_title(statement) },
+        labels: (1..field.maximum).map do |i|
+          field["linear_scale_label_#{i}_multiloc"][@locale]
+        end,
+        label_width: 70 / field.maximum # 70% of the printed width for the labels, 30% for the statements
+      }
+    end
+
+    def matrix_print_instructions(field)
+      return '' unless field.supports_matrix_statements?
+
+      description = I18n.with_locale(@locale) do
+        I18n.t('form_builder.pdf_export.matrix_print_description')
+      end
+
+      "<p>#{description}</p>"
     end
 
     def font_family

--- a/back/engines/commercial/bulk_import_ideas/app/views/bulk_import_ideas/web_api/v1/export_form.html.erb
+++ b/back/engines/commercial/bulk_import_ideas/app/views/bulk_import_ideas/web_api/v1/export_form.html.erb
@@ -28,7 +28,7 @@
     h1 { font-size: 18pt; }
     h2 { font-size: 16pt; }
     h3 { font-size: 14pt; }
-    h4, p, li { font-size: 12pt; line-height: 1.2; }
+    h4, p, li, td, th { font-size: 12pt; line-height: 1.2; }
 
     div.line { border-bottom: solid 1px #000; margin: 10px 0; height: 25px; }
     div.select, div.ranking { display: flex; align-items: center; margin-top: -6px; }
@@ -68,6 +68,22 @@
           background: #eee;
           img { object-fit: contain; height: 140px; }
           svg { border-radius: 5px; object-fit: contain; height: 50px; margin: 45px 0 45px 0; }
+        }
+      }
+      div.matrix {
+        table {
+          margin-top: 10px;
+          border-collapse: collapse;
+          width: 100%;
+          th, td {
+            border-bottom: 1px solid #000;
+            padding: 5px;
+            text-align: center;
+            font-weight: normal;
+          }
+          td.statement {
+            text-align: left;
+          }
         }
       }
     }
@@ -184,6 +200,26 @@
                   <div><%= option[:title] %></div>
                 </div>
               <% end %>
+            </div>
+
+          <% elsif field[:format] == :matrix_linear_scale %>
+            <div class="matrix">
+              <table>
+                <tr>
+                  <th></th>
+                  <% field[:matrix][:labels].each do |label| %>
+                    <th style="width: <%= field[:matrix][:label_width] %>%"><%= label %></th>
+                  <% end %>
+                </tr>
+                <% field[:matrix][:statements].each do |statement| %>
+                  <tr>
+                    <td class="statement"><%= statement %></td>
+                    <% field[:matrix][:labels].each do |_| %>
+                      <td><div class="checkbox radio"></div></td>
+                    <% end %>
+                  </tr>
+                  <% end %>
+              </table>
             </div>
 
           <% else %>

--- a/back/engines/commercial/bulk_import_ideas/spec/services/exporters/idea_html_form_exporter_spec.rb
+++ b/back/engines/commercial/bulk_import_ideas/spec/services/exporters/idea_html_form_exporter_spec.rb
@@ -37,6 +37,24 @@ describe BulkImportIdeas::Exporters::IdeaHtmlFormExporter do
     field.options.create!(title_multiloc: { 'en' => 'Image three' }, image: create(:custom_field_option_image))
     field
   end
+  let!(:matrix_field) do
+    field = create(
+      :custom_field_matrix_linear_scale,
+      resource: custom_form,
+      key: 'matrix_field',
+      title_multiloc: { 'en' => 'Matrix field' },
+      linear_scale_label_1_multiloc: { 'en' => 'Strongly disagree' },
+      linear_scale_label_2_multiloc: { 'en' => 'Disagree' },
+      linear_scale_label_3_multiloc: { 'en' => 'Neutral' },
+      linear_scale_label_4_multiloc: { 'en' => 'Agree' },
+      linear_scale_label_5_multiloc: { 'en' => 'Strongly agree' },
+      maximum: 5
+    )
+    field.matrix_statements.create!(title_multiloc: { 'en' => 'Matrix statement one' })
+    field.matrix_statements.create!(title_multiloc: { 'en' => 'Matrix statement two' })
+    field
+  end
+
   let!(:end_page_field) { create(:custom_field_form_end_page, resource: custom_form) }
 
   describe 'export' do
@@ -77,6 +95,7 @@ describe BulkImportIdeas::Exporters::IdeaHtmlFormExporter do
         expect(titles[2]).to include 'Select field'
         expect(titles[3]).to include 'Ranking field'
         expect(titles[4]).to include 'Select image field'
+        expect(titles[5]).to include 'Matrix field'
       end
 
       it 'shows optional if questions are not required' do
@@ -85,6 +104,7 @@ describe BulkImportIdeas::Exporters::IdeaHtmlFormExporter do
         expect(titles[2]).to include '(optional)'
         expect(titles[3]).to include '(optional)'
         expect(titles[4]).to include '(optional)'
+        expect(titles[5]).to include '(optional)'
       end
 
       it 'shows 1 line for short text fields' do
@@ -117,6 +137,18 @@ describe BulkImportIdeas::Exporters::IdeaHtmlFormExporter do
         expect(multiselect_image.text).to include 'Image one'
         expect(multiselect_image.text).to include 'Image two'
         expect(multiselect_image.text).to include 'Image three'
+      end
+
+      it 'shows matrix statements and instructions' do
+        matrix = parsed_html.css("div##{matrix_field.id}")
+        expect(matrix.text).to include 'For each row, mark one circle with a cross to indicate your preference.'
+        expect(matrix.text).to include 'Matrix statement one'
+        expect(matrix.text).to include 'Matrix statement two'
+        expect(matrix.text).to include 'Strongly disagree'
+        expect(matrix.text).to include 'Disagree'
+        expect(matrix.text).to include 'Neutral'
+        expect(matrix.text).to include 'Agree'
+        expect(matrix.text).to include 'Strongly agree'
       end
     end
   end

--- a/back/spec/fixtures/locales/en.yml
+++ b/back/spec/fixtures/locales/en.yml
@@ -35,6 +35,7 @@ en:
       linear_scale_print_description: 'Please write a number between %{min_label} and %{max_label} only'
       unsupported_field: This field cannot be completed on paper. Please use the online version of this form instead.
       ranking_print_description: 'Please write a number from 1 (most preferred) and %{max_rank} (least preferred) in each box. Use each number only once.'
+      matrix_print_description: 'For each row, mark one circle with a cross to indicate your preference.'
   custom_fields:
     ideas:
       title:


### PR DESCRIPTION
Looks like this:

<img width="723" alt="image" src="https://github.com/user-attachments/assets/c81ac50c-16d9-426d-9452-631a0c263660" />

# Changelog
## Added
- Added matrix field to the printed PDF
