### PR TITLE
Adjust links to use survey form tab route

### DIFF
--- a/front/app/containers/Admin/projects/project/inputImporter/ImportModal/ImportExcelModal.tsx
+++ b/front/app/containers/Admin/projects/project/inputImporter/ImportModal/ImportExcelModal.tsx
@@ -53,7 +53,7 @@ const ImportExcelModal = ({ open, onClose, onImport }: Props) => {
 
   const downloadFormPath =
     phase?.data.attributes.participation_method === 'native_survey'
-      ? `/admin/projects/${projectId}/phases/${phaseId}/native-survey`
+      ? `/admin/projects/${projectId}/phases/${phaseId}/survey-form`
       : `/admin/projects/${projectId}/phases/${phaseId}/form`;
 
   const defaultValues: FormValues = {

--- a/front/app/containers/Admin/projects/project/inputImporter/ImportModal/ImportPdfModal.tsx
+++ b/front/app/containers/Admin/projects/project/inputImporter/ImportModal/ImportPdfModal.tsx
@@ -56,7 +56,7 @@ const ImportPdfModal = ({ open, onClose, onImport }: Props) => {
 
   const downloadFormPath =
     phase?.data.attributes.participation_method === 'native_survey'
-      ? `/admin/projects/${projectId}/phases/${phaseId}/survey_form`
+      ? `/admin/projects/${projectId}/phases/${phaseId}/survey-form`
       : `/admin/projects/${projectId}/phases/${phaseId}/form`;
 
   const defaultValues: FormValues = {

--- a/front/app/containers/Admin/projects/project/inputImporter/ImportModal/ImportPdfModal.tsx
+++ b/front/app/containers/Admin/projects/project/inputImporter/ImportModal/ImportPdfModal.tsx
@@ -56,7 +56,7 @@ const ImportPdfModal = ({ open, onClose, onImport }: Props) => {
 
   const downloadFormPath =
     phase?.data.attributes.participation_method === 'native_survey'
-      ? `/admin/projects/${projectId}/phases/${phaseId}/native-survey`
+      ? `/admin/projects/${projectId}/phases/${phaseId}/survey_form`
       : `/admin/projects/${projectId}/phases/${phaseId}/form`;
 
   const defaultValues: FormValues = {

--- a/front/app/containers/Admin/projects/project/nativeSurvey/SurveyFormBuilder/index.tsx
+++ b/front/app/containers/Admin/projects/project/nativeSurvey/SurveyFormBuilder/index.tsx
@@ -43,7 +43,7 @@ const SurveyFormBuilder = ({
       builderConfig={{
         ...nativeSurveyConfig,
         formCustomFields: newCustomFields,
-        goBackUrl: `/admin/projects/${projectId}/phases/${phaseId}/native-survey`,
+        goBackUrl: `/admin/projects/${projectId}/phases/${phaseId}/survey-form`,
       }}
       viewFormLink={`/projects/${project.data.attributes.slug}/surveys/new?phase_id=${phase.data.id}`}
     />


### PR DESCRIPTION
I forgot to adjust some routes now that the template download buttons have moved to a different tab. cc @jamesspeake

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->
