### PR TITLE
Align survey editor route with survey form tab + how it's done for id…

### DIFF
--- a/front/app/containers/Admin/projects/project/surveyForm/TabPanel.tsx
+++ b/front/app/containers/Admin/projects/project/surveyForm/TabPanel.tsx
@@ -25,7 +25,7 @@ const TabPanel = ({
   projectId: string;
   phaseId: string;
 }) => {
-  const editFormLink: RouteType = `/admin/projects/${projectId}/phases/${phaseId}/native-survey/edit`;
+  const editFormLink: RouteType = `/admin/projects/${projectId}/phases/${phaseId}/survey-form/edit`;
 
   return (
     <Box maxWidth="700px">

--- a/front/app/containers/Admin/projects/routes.tsx
+++ b/front/app/containers/Admin/projects/routes.tsx
@@ -113,9 +113,9 @@ export enum projectsRoutes {
   projectPhaseMap = ':phaseId/map',
   projectPhaseNativeSurvey = ':phaseId/native-survey',
   projectPhaseSurveyForm = ':phaseId/survey-form',
+  projectPhaseNativeSurveyFormEdit = ':phaseId/survey-form/edit',
   projectPhaseVolunteeringNewCause = ':phaseId/volunteering/causes/new',
   projectPhaseIdeaFormEdit = ':phaseId/form/edit',
-  projectPhaseNativeSurveyEdit = ':phaseId/native-survey/edit',
   projectPhaseVolunteeringCause = ':phaseId/volunteering/causes/:causeId',
   projectPhaseInputImporter = ':phaseId/input-importer',
   projectPhaseReport = ':phaseId/report',
@@ -159,9 +159,8 @@ export type projectsRouteTypes =
   | AdminRoute<`${projectsRoutes.projects}/${string}/phases/${string}/volunteering/causes/new`>
   | AdminRoute<`${projectsRoutes.projects}/${string}/phases/${string}/form/edit`>
   | AdminRoute<`${projectsRoutes.projects}/${string}/phases/${string}/native-survey`>
-  | AdminRoute<`${projectsRoutes.projects}/${string}/phases/${string}/native-survey/edit`>
-  | AdminRoute<`${projectsRoutes.projects}/${string}/phases/${string}/native-survey/edit?${string}`>
   | AdminRoute<`${projectsRoutes.projects}/${string}/phases/${string}/survey-form`>
+  | AdminRoute<`${projectsRoutes.projects}/${string}/phases/${string}/survey-form/edit?${string}`>
   | AdminRoute<`${projectsRoutes.projects}/${string}/phases/${string}/volunteering/causes/${string}`>
   | AdminRoute<`${projectsRoutes.projects}/${string}/analysis/${string}`>;
 
@@ -536,7 +535,7 @@ const createAdminProjectsRoutes = () => {
                 ),
               },
               {
-                path: projectsRoutes.projectPhaseNativeSurveyEdit,
+                path: projectsRoutes.projectPhaseNativeSurveyFormEdit,
                 element: (
                   <PageLoading>
                     <SurveyFormBuilder />

--- a/front/app/containers/Admin/projects/routes.tsx
+++ b/front/app/containers/Admin/projects/routes.tsx
@@ -160,6 +160,7 @@ export type projectsRouteTypes =
   | AdminRoute<`${projectsRoutes.projects}/${string}/phases/${string}/form/edit`>
   | AdminRoute<`${projectsRoutes.projects}/${string}/phases/${string}/native-survey`>
   | AdminRoute<`${projectsRoutes.projects}/${string}/phases/${string}/survey-form`>
+  | AdminRoute<`${projectsRoutes.projects}/${string}/phases/${string}/survey-form/edit`>
   | AdminRoute<`${projectsRoutes.projects}/${string}/phases/${string}/survey-form/edit?${string}`>
   | AdminRoute<`${projectsRoutes.projects}/${string}/phases/${string}/volunteering/causes/${string}`>
   | AdminRoute<`${projectsRoutes.projects}/${string}/analysis/${string}`>;

--- a/front/app/containers/IdeasNewSurveyPage/IdeasNewSurveyForm/SurveyHeading/index.tsx
+++ b/front/app/containers/IdeasNewSurveyPage/IdeasNewSurveyForm/SurveyHeading/index.tsx
@@ -73,7 +73,7 @@ const SurveyHeading = ({ titleText, phaseId }: Props) => {
   const linkToSurveyBuilder: RouteType =
     phaseParticipationMethod === 'community_monitor_survey'
       ? `/admin/community-monitor/projects/${project.data.id}/phases/${phaseId}/survey/edit`
-      : `/admin/projects/${project.data.id}/phases/${phaseId}/native-survey/edit`;
+      : `/admin/projects/${project.data.id}/phases/${phaseId}/survey-form/edit`;
 
   const leaveForm = () => {
     const leaveFormDestination = getLeaveFormDestination(

--- a/front/cypress/e2e/admin/phases/nativeSurvey/survey_form_tab.cy.ts
+++ b/front/cypress/e2e/admin/phases/nativeSurvey/survey_form_tab.cy.ts
@@ -34,7 +34,7 @@ describe('Survey Form Tab Navigation', () => {
     // Verify we're on the survey form builder page
     cy.url().should(
       'include',
-      `/admin/projects/${projectId}/phases/${phaseId}/native-survey/edit`
+      `/admin/projects/${projectId}/phases/${phaseId}/survey-form/edit`
     );
 
     // Verify the form builder content has loaded

--- a/front/cypress/e2e/form_builder/elements/file_upload_field.cy.ts
+++ b/front/cypress/e2e/form_builder/elements/file_upload_field.cy.ts
@@ -49,9 +49,7 @@ describe('Form builder file upload field', () => {
   });
 
   it('adds file upload field and user can attach a file in the field', () => {
-    cy.visit(
-      `admin/projects/${projectId}/phases/${phaseId}/native-survey/edit`
-    );
+    cy.visit(`admin/projects/${projectId}/phases/${phaseId}/survey-form/edit`);
     cy.get('[data-cy="e2e-file-upload-field"]');
     cy.wait(2000);
     cy.get('[data-cy="e2e-file-upload-field"]').click({ force: true });

--- a/front/cypress/e2e/form_builder/elements/image_multiple_choice.cy.ts
+++ b/front/cypress/e2e/form_builder/elements/image_multiple_choice.cy.ts
@@ -43,9 +43,7 @@ describe('Form builder image multiple choice choose multiple component', () => {
   });
 
   it('adds image multiple choice field and is displayed when filling survey', () => {
-    cy.visit(
-      `admin/projects/${projectId}/phases/${phaseId}/native-survey/edit`
-    );
+    cy.visit(`admin/projects/${projectId}/phases/${phaseId}/survey-form/edit`);
     cy.get('[data-cy="e2e-image-choice"]');
     cy.wait(2000);
     cy.get('[data-cy="e2e-image-choice"]').click();
@@ -61,9 +59,7 @@ describe('Form builder image multiple choice choose multiple component', () => {
   it('allows using an other option that is mandatory when other is selected when entering data in the form/survey', () => {
     const questionTitle = randomString();
     const otherAnswer = 'Walking';
-    cy.visit(
-      `admin/projects/${projectId}/phases/${phaseId}/native-survey/edit`
-    );
+    cy.visit(`admin/projects/${projectId}/phases/${phaseId}/survey-form/edit`);
     cy.acceptCookies();
     cy.get('[data-cy="e2e-image-choice"]');
     cy.wait(2000);

--- a/front/cypress/e2e/form_builder/elements/linear_scale_field.cy.ts
+++ b/front/cypress/e2e/form_builder/elements/linear_scale_field.cy.ts
@@ -50,9 +50,7 @@ describe('Form builder linear scale', () => {
   });
 
   it('adds linear scale field and tests validations', () => {
-    cy.visit(
-      `admin/projects/${projectId}/phases/${phaseId}/native-survey/edit`
-    );
+    cy.visit(`admin/projects/${projectId}/phases/${phaseId}/survey-form/edit`);
     cy.get('[data-cy="e2e-linear-scale"]');
     cy.wait(2000);
     cy.get('[data-cy="e2e-linear-scale"]').click();

--- a/front/cypress/e2e/form_builder/elements/long_field.cy.ts
+++ b/front/cypress/e2e/form_builder/elements/long_field.cy.ts
@@ -51,9 +51,7 @@ describe('Form builder long text field', () => {
 
   it('adds long text field and user can fill in data in the field', () => {
     const testText = randomString(400);
-    cy.visit(
-      `admin/projects/${projectId}/phases/${phaseId}/native-survey/edit`
-    );
+    cy.visit(`admin/projects/${projectId}/phases/${phaseId}/survey-form/edit`);
     cy.get('[data-cy="e2e-long-answer"]');
     cy.wait(2000);
     cy.get('[data-cy="e2e-long-answer"]').click();

--- a/front/cypress/e2e/form_builder/elements/matrix_field.cy.ts
+++ b/front/cypress/e2e/form_builder/elements/matrix_field.cy.ts
@@ -43,9 +43,7 @@ describe('Form builder matrix component', () => {
   });
 
   it('adds matrix field and is displayed when filling survey', () => {
-    cy.visit(
-      `admin/projects/${projectId}/phases/${phaseId}/native-survey/edit`
-    );
+    cy.visit(`admin/projects/${projectId}/phases/${phaseId}/survey-form/edit`);
 
     cy.get('[data-cy="e2e-matrix"]');
     cy.wait(2000);

--- a/front/cypress/e2e/form_builder/elements/multiple_choice_field.cy.ts
+++ b/front/cypress/e2e/form_builder/elements/multiple_choice_field.cy.ts
@@ -43,9 +43,7 @@ describe('Form builder multiple choice choose multiple component', () => {
   });
 
   it('adds multiselect multiple choice field and is displayed when filling survey', () => {
-    cy.visit(
-      `admin/projects/${projectId}/phases/${phaseId}/native-survey/edit`
-    );
+    cy.visit(`admin/projects/${projectId}/phases/${phaseId}/survey-form/edit`);
     cy.get('[data-cy="e2e-multiple-choice"]');
     cy.wait(2000);
     cy.get('[data-cy="e2e-multiple-choice"]').click();
@@ -61,9 +59,7 @@ describe('Form builder multiple choice choose multiple component', () => {
   it('allows submitting when there is an other option but it is not filled out', () => {
     const questionTitle = randomString();
 
-    cy.visit(
-      `admin/projects/${projectId}/phases/${phaseId}/native-survey/edit`
-    );
+    cy.visit(`admin/projects/${projectId}/phases/${phaseId}/survey-form/edit`);
     cy.acceptCookies();
 
     cy.get('[data-cy="e2e-multiple-choice"]');
@@ -98,9 +94,7 @@ describe('Form builder multiple choice choose multiple component', () => {
     const otherText = 'Other';
     const questionTitle = randomString();
     const otherAnswer = 'Walking';
-    cy.visit(
-      `admin/projects/${projectId}/phases/${phaseId}/native-survey/edit`
-    );
+    cy.visit(`admin/projects/${projectId}/phases/${phaseId}/survey-form/edit`);
     cy.acceptCookies();
 
     cy.get('[data-cy="e2e-multiple-choice"]');

--- a/front/cypress/e2e/form_builder/elements/number_field.cy.ts
+++ b/front/cypress/e2e/form_builder/elements/number_field.cy.ts
@@ -50,9 +50,7 @@ describe('Form builder number field', () => {
   });
 
   it('adds number field and tests validations', () => {
-    cy.visit(
-      `admin/projects/${projectId}/phases/${phaseId}/native-survey/edit`
-    );
+    cy.visit(`admin/projects/${projectId}/phases/${phaseId}/survey-form/edit`);
     cy.get('[data-cy="e2e-number-field"]');
     cy.wait(2000);
     cy.get('[data-cy="e2e-number-field"]').click();

--- a/front/cypress/e2e/form_builder/elements/page_element.cy.ts
+++ b/front/cypress/e2e/form_builder/elements/page_element.cy.ts
@@ -43,9 +43,7 @@ describe('Form builder page element', () => {
   });
 
   it('adds page element and tests settings', () => {
-    cy.visit(
-      `admin/projects/${projectId}/phases/${phaseId}/native-survey/edit`
-    );
+    cy.visit(`admin/projects/${projectId}/phases/${phaseId}/survey-form/edit`);
     cy.acceptCookies();
     cy.get('[data-cy="e2e-page"]');
     cy.wait(2000);
@@ -66,9 +64,7 @@ describe('Form builder page element', () => {
     cy.get('[data-testid="feedbackSuccessMessage"]').should('exist');
 
     // Reload page
-    cy.visit(
-      `admin/projects/${projectId}/phases/${phaseId}/native-survey/edit`
-    );
+    cy.visit(`admin/projects/${projectId}/phases/${phaseId}/survey-form/edit`);
     cy.contains('Page title').click();
 
     // Confirm the settings are loaded correctly
@@ -94,9 +90,7 @@ describe('Form builder page element', () => {
   });
 
   it('does not let the user delete the page if there is only one page', () => {
-    cy.visit(
-      `admin/projects/${projectId}/phases/${phaseId}/native-survey/edit`
-    );
+    cy.visit(`admin/projects/${projectId}/phases/${phaseId}/survey-form/edit`);
 
     // Add a second page
     cy.get('[data-cy="e2e-page"]');

--- a/front/cypress/e2e/form_builder/elements/point_field.cy.ts
+++ b/front/cypress/e2e/form_builder/elements/point_field.cy.ts
@@ -50,9 +50,7 @@ describe('Form builder point field', () => {
   });
 
   it('adds point field and tests validations', () => {
-    cy.visit(
-      `admin/projects/${projectId}/phases/${phaseId}/native-survey/edit`
-    );
+    cy.visit(`admin/projects/${projectId}/phases/${phaseId}/survey-form/edit`);
     cy.get('[data-cy="e2e-point-field"]');
     cy.wait(2000);
     cy.get('[data-cy="e2e-point-field"]').click();
@@ -76,9 +74,7 @@ describe('Form builder point field', () => {
     checkMapInputWorks();
 
     // Configure the map in the back office
-    cy.visit(
-      `admin/projects/${projectId}/phases/${phaseId}/native-survey/edit`
-    );
+    cy.visit(`admin/projects/${projectId}/phases/${phaseId}/survey-form/edit`);
     cy.contains(questionTitle).click();
     cy.get('[data-cy="e2e-configure-map-button"]').click();
     cy.get('[data-cy="e2e-web-map-upload-btn"]').click();

--- a/front/cypress/e2e/form_builder/elements/ranking_field.cy.ts
+++ b/front/cypress/e2e/form_builder/elements/ranking_field.cy.ts
@@ -43,9 +43,7 @@ describe('Form builder ranking component', () => {
   });
 
   it('adds ranking field and is displayed when filling survey', () => {
-    cy.visit(
-      `admin/projects/${projectId}/phases/${phaseId}/native-survey/edit`
-    );
+    cy.visit(`admin/projects/${projectId}/phases/${phaseId}/survey-form/edit`);
     cy.get('[data-cy="e2e-ranking"]');
     cy.wait(2000);
     cy.get('[data-cy="e2e-ranking"]').click();

--- a/front/cypress/e2e/form_builder/elements/single_choice_field.cy.ts
+++ b/front/cypress/e2e/form_builder/elements/single_choice_field.cy.ts
@@ -43,9 +43,7 @@ describe('Form builder single choice field', () => {
   });
 
   it('adds single select multiple choice field and is displayed when filling survey', () => {
-    cy.visit(
-      `admin/projects/${projectId}/phases/${phaseId}/native-survey/edit`
-    );
+    cy.visit(`admin/projects/${projectId}/phases/${phaseId}/survey-form/edit`);
     cy.get('[data-cy="e2e-single-choice"]');
     cy.wait(2000);
     cy.get('[data-cy="e2e-single-choice"]').click();
@@ -64,9 +62,7 @@ describe('Form builder single choice field', () => {
 
   it('allows submitting when there is an other option that is not selected and is not filled out', () => {
     const questionTitle = randomString();
-    cy.visit(
-      `admin/projects/${projectId}/phases/${phaseId}/native-survey/edit`
-    );
+    cy.visit(`admin/projects/${projectId}/phases/${phaseId}/survey-form/edit`);
     cy.acceptCookies();
     cy.get('[data-cy="e2e-single-choice"]');
     cy.wait(2000);
@@ -98,9 +94,7 @@ describe('Form builder single choice field', () => {
     const otherText = 'Other';
     const questionTitle = randomString();
     const otherAnswer = 'Walking';
-    cy.visit(
-      `admin/projects/${projectId}/phases/${phaseId}/native-survey/edit`
-    );
+    cy.visit(`admin/projects/${projectId}/phases/${phaseId}/survey-form/edit`);
     cy.acceptCookies();
     cy.get('[data-cy="e2e-single-choice"]');
     cy.wait(2000);

--- a/front/cypress/e2e/survey_builder/create_and_fill_survey.cy.ts
+++ b/front/cypress/e2e/survey_builder/create_and_fill_survey.cy.ts
@@ -109,14 +109,12 @@ describe('Survey builder', () => {
     cy.get('[data-cy="e2e-edit-survey-link"]').click();
     cy.location('pathname').should(
       'eq',
-      `/en/admin/projects/${projectId}/phases/${phaseId}/native-survey/edit`
+      `/en/admin/projects/${projectId}/phases/${phaseId}/survey-form/edit`
     );
   });
 
   it('deletes a field when the delete button is clicked', () => {
-    cy.visit(
-      `admin/projects/${projectId}/phases/${phaseId}/native-survey/edit`
-    );
+    cy.visit(`admin/projects/${projectId}/phases/${phaseId}/survey-form/edit`);
     waitForCustomFormFields();
     cy.get('[data-cy="e2e-linear-scale"]').click();
     cy.get('#e2e-title-multiloc').type(questionTitle, { force: true });
@@ -126,9 +124,7 @@ describe('Survey builder', () => {
     // Should show success message on saving
     cy.get('[data-testid="feedbackSuccessMessage"]').should('exist');
 
-    cy.visit(
-      `admin/projects/${projectId}/phases/${phaseId}/native-survey/edit`
-    );
+    cy.visit(`admin/projects/${projectId}/phases/${phaseId}/survey-form/edit`);
 
     cy.contains(questionTitle).should('exist').click();
 
@@ -155,9 +151,7 @@ describe('Survey builder', () => {
     const multipleChoiceChooseOneTitle = 'multiplechoicechooseonefield';
     const multipleChoiceChooseManyTitle = 'multiplechoicechoosemultiplefield';
     const linearScaleTitle = 'linearscalefield';
-    cy.visit(
-      `admin/projects/${projectId}/phases/${phaseId}/native-survey/edit`
-    );
+    cy.visit(`admin/projects/${projectId}/phases/${phaseId}/survey-form/edit`);
     waitForCustomFormFields();
 
     // Multiple choice choose one
@@ -235,7 +229,7 @@ describe('Survey builder', () => {
     cy.get(`[data-cy="e2e-edit-survey-form"]`).click();
     cy.get(`[data-cy="e2e-edit-warning-modal"]`).should('exist');
     cy.get(`[data-cy="e2e-edit-warning-modal-continue"]`).click();
-    cy.url().should('include', `/native-survey/edit`);
+    cy.url().should('include', `/survey-form/edit`);
   });
 
   it('navigates to live project in a new tab when view project button in content builder is clicked', () => {
@@ -268,9 +262,7 @@ describe('Survey builder', () => {
   it('allows deleting survey results when user clicks the delete button', () => {
     const numberAnswer = '37';
 
-    cy.visit(
-      `admin/projects/${projectId}/phases/${phaseId}/native-survey/edit`
-    );
+    cy.visit(`admin/projects/${projectId}/phases/${phaseId}/survey-form/edit`);
     waitForCustomFormFields();
     cy.get('[data-cy="e2e-number-field"]').click();
     cy.get('#e2e-title-multiloc').type(questionTitle, { force: true });
@@ -312,9 +304,7 @@ describe('Survey builder', () => {
   });
 
   it('allows export of survey results', () => {
-    cy.visit(
-      `admin/projects/${projectId}/phases/${phaseId}/native-survey/edit`
-    );
+    cy.visit(`admin/projects/${projectId}/phases/${phaseId}/survey-form/edit`);
     waitForCustomFormFields();
     cy.get('[data-cy="e2e-long-answer"]').click();
     cy.get('#e2e-title-multiloc').type(questionTitle, { force: true });

--- a/front/cypress/e2e/survey_builder/custom_survey_end_page_button.cy.ts
+++ b/front/cypress/e2e/survey_builder/custom_survey_end_page_button.cy.ts
@@ -38,9 +38,7 @@ describe('Survey page logic', () => {
 
   it('uses custom button link and text on survey end page if customized', () => {
     // Visit the form builder
-    cy.visit(
-      `/admin/projects/${projectId}/phases/${phaseId}/native-survey/edit`
-    );
+    cy.visit(`/admin/projects/${projectId}/phases/${phaseId}/survey-form/edit`);
 
     // For the survey end page, set a custom button link + label
     cy.get('[data-cy="e2e-field-row"]').last().click();

--- a/front/cypress/e2e/survey_builder/survey_logic_conflict.cy.ts
+++ b/front/cypress/e2e/survey_builder/survey_logic_conflict.cy.ts
@@ -26,9 +26,7 @@ describe('Survey logic conflict', () => {
 
   it('prioritizes question logic over page logic', () => {
     cy.setAdminLoginCookie();
-    cy.visit(
-      `/admin/projects/${projectId}/phases/${phaseId}/native-survey/edit`
-    );
+    cy.visit(`/admin/projects/${projectId}/phases/${phaseId}/survey-form/edit`);
     cy.get('[data-cy="e2e-field-row"]').should('have.length', 3);
 
     // Add a new page

--- a/front/cypress/e2e/survey_builder/survey_page_logic.cy.ts
+++ b/front/cypress/e2e/survey_builder/survey_page_logic.cy.ts
@@ -21,9 +21,7 @@ describe('Survey page logic', () => {
 
   beforeEach(() => {
     cy.setAdminLoginCookie();
-    cy.visit(
-      `/admin/projects/${projectId}/phases/${phaseId}/native-survey/edit`
-    );
+    cy.visit(`/admin/projects/${projectId}/phases/${phaseId}/survey-form/edit`);
     cy.get('[data-cy="e2e-field-row"]').should('have.length', 3);
 
     // Make sure first page references "Ending"

--- a/front/cypress/e2e/survey_builder/survey_question_logic.cy.ts
+++ b/front/cypress/e2e/survey_builder/survey_question_logic.cy.ts
@@ -22,9 +22,7 @@ describe('Survey question logic', () => {
 
   it('allows setting logic for select question', () => {
     cy.setAdminLoginCookie();
-    cy.visit(
-      `/admin/projects/${projectId}/phases/${phaseId}/native-survey/edit`
-    );
+    cy.visit(`/admin/projects/${projectId}/phases/${phaseId}/survey-form/edit`);
     cy.get('[data-cy="e2e-field-row"]').should('have.length', 3);
 
     // Add a new page


### PR DESCRIPTION
…eation


# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Changed
- Survey form builder: change URL from `.../native-survey/edit` to `.../survey-form/edit` to align it with that of the new Survey form tab (`.../survey-form`).
