### PR TITLE
Removed unneeded host mapping from Gutenberg in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,8 +98,6 @@ services:
     container_name: cl-gotenberg
     image: gotenberg/gotenberg:8
     restart: always
-    ports:
-      - 7000:3000
 
 volumes:
   postgres:


### PR DESCRIPTION
# Changelog
## Technical
- Removed unneeded port mapping for Gutenberg docker container
