### PR TITLE
[TAN-4272] disable GraphQL introspection in production

### DIFF
--- a/back/engines/commercial/admin_api/app/graphql/admin_api/schema.rb
+++ b/back/engines/commercial/admin_api/app/graphql/admin_api/schema.rb
@@ -4,5 +4,8 @@ module AdminApi
   class Schema < GraphQL::Schema
     query Types::QueryType
     default_max_page_size 100
+
+    # Disable introspection in non-production environments for security
+    disable_introspection_entry_points if Rails.env.production?
   end
 end


### PR DESCRIPTION
Plan: Check project templates still work on staging after merging to `master` (I have checked they work now, before this is merged)

# Changelog
## Technical
- [TAN-4272] disable GraphQL introspection in production
