### PR TITLE
Revert "Revert "[TAN-4272] disable GraphQL introspection in production""

### DIFF
--- a/back/engines/commercial/admin_api/app/graphql/admin_api/schema.rb
+++ b/back/engines/commercial/admin_api/app/graphql/admin_api/schema.rb
@@ -4,5 +4,8 @@ module AdminApi
   class Schema < GraphQL::Schema
     query Types::QueryType
     default_max_page_size 100
+
+    # Disable introspection in non-production environments for security
+    disable_introspection_entry_points if Rails.env.production?
   end
 end


### PR DESCRIPTION
Reverts CitizenLabDotCo/citizenlab#11152

Reverts the revert of #11151, effectively reinstating it.

I was concerned about the n of cancelled GraphQL requests I saw on staging after the original merge to `master`, but have subsequently checked and this was the case before the original change, so this is probably fine.

In the unlikely even it does cause problems on production, this is easy to undo.