### PR TITLE
Update results tab route

### DIFF
--- a/front/app/containers/Admin/projects/project/analysis/TopBar/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/TopBar/index.tsx
@@ -88,9 +88,7 @@ const TopBar = () => {
 
   const goBack = () => {
     if (analysis?.data.attributes.participation_method === 'native_survey') {
-      clHistory.push(
-        `/admin/projects/${projectId}/phases/${phaseId}/native-survey`
-      );
+      clHistory.push(`/admin/projects/${projectId}/phases/${phaseId}/results`);
     } else if (
       analysis?.data.attributes.participation_method ===
       'community_monitor_survey'

--- a/front/app/containers/Admin/projects/project/inputImporter/TopBar/utils.ts
+++ b/front/app/containers/Admin/projects/project/inputImporter/TopBar/utils.ts
@@ -9,7 +9,7 @@ export const getBackPath = (
 ): RouteType => {
   switch (participationMethod) {
     case 'native_survey':
-      return `/admin/projects/${projectId}/phases/${phaseId}/native-survey`;
+      return `/admin/projects/${projectId}/phases/${phaseId}/results`;
     case 'community_monitor_survey':
       return `/admin/community-monitor/settings`;
     default:

--- a/front/app/containers/Admin/projects/project/phaseSetup/utils.ts
+++ b/front/app/containers/Admin/projects/project/phaseSetup/utils.ts
@@ -6,7 +6,7 @@ export function getTimelineTab(
   | 'setup'
   | 'ideas'
   | 'proposals'
-  | 'native-survey'
+  | 'results'
   | 'polls'
   | 'survey-results'
   | 'volunteering' {
@@ -17,7 +17,7 @@ export function getTimelineTab(
   } else if (participationMethod === 'proposals') {
     return 'proposals';
   } else if (participationMethod === 'native_survey') {
-    return 'native-survey';
+    return 'results';
   } else if (participationMethod === 'poll') {
     return 'polls';
   } else if (participationMethod === 'survey') {

--- a/front/app/containers/Admin/projects/project/tabs.ts
+++ b/front/app/containers/Admin/projects/project/tabs.ts
@@ -59,8 +59,8 @@ export const getTabs = (
       ? [
           {
             label: formatMessage(messages.resultsTab),
-            url: 'native-survey',
-            name: 'survey',
+            url: 'results',
+            name: 'results',
           },
           {
             label: formatMessage(messages.surveyFormTab),

--- a/front/app/containers/Admin/projects/routes.tsx
+++ b/front/app/containers/Admin/projects/routes.tsx
@@ -103,7 +103,7 @@ export enum projectsRoutes {
   projectPhasesSetup = 'setup',
   projectPhaseSetup = ':phaseId/setup',
   projectPhase = ':phaseId',
-  projectPhaseSurveyResults = ':phaseId/survey-results',
+  projectPhaseExternalSurveyResults = ':phaseId/survey-results',
   projectPhasePolls = ':phaseId/polls',
   projectPhaseAccessRights = ':phaseId/access-rights',
   projectPhaseIdeas = ':phaseId/ideas',
@@ -111,7 +111,7 @@ export enum projectsRoutes {
   projectPhaseIdeaForm = ':phaseId/form',
   projectPhaseVolunteering = ':phaseId/volunteering',
   projectPhaseMap = ':phaseId/map',
-  projectPhaseNativeSurvey = ':phaseId/native-survey',
+  projectPhaseNativeSurveyResults = ':phaseId/results',
   projectPhaseSurveyForm = ':phaseId/survey-form',
   projectPhaseNativeSurveyFormEdit = ':phaseId/survey-form/edit',
   projectPhaseVolunteeringNewCause = ':phaseId/volunteering/causes/new',
@@ -158,7 +158,7 @@ export type projectsRouteTypes =
   | AdminRoute<`${projectsRoutes.projects}/${string}/phases/${string}/volunteering/causes/new`>
   | AdminRoute<`${projectsRoutes.projects}/${string}/phases/${string}/volunteering/causes/new`>
   | AdminRoute<`${projectsRoutes.projects}/${string}/phases/${string}/form/edit`>
-  | AdminRoute<`${projectsRoutes.projects}/${string}/phases/${string}/native-survey`>
+  | AdminRoute<`${projectsRoutes.projects}/${string}/phases/${string}/results`>
   | AdminRoute<`${projectsRoutes.projects}/${string}/phases/${string}/survey-form`>
   | AdminRoute<`${projectsRoutes.projects}/${string}/phases/${string}/survey-form/edit`>
   | AdminRoute<`${projectsRoutes.projects}/${string}/phases/${string}/survey-form/edit?${string}`>
@@ -440,7 +440,7 @@ const createAdminProjectsRoutes = () => {
                 ),
               },
               {
-                path: projectsRoutes.projectPhaseSurveyResults,
+                path: projectsRoutes.projectPhaseExternalSurveyResults,
                 element: (
                   <PageLoading>
                     <AdminProjectSurveyResults />
@@ -512,7 +512,7 @@ const createAdminProjectsRoutes = () => {
                 ),
               },
               {
-                path: projectsRoutes.projectPhaseNativeSurvey,
+                path: projectsRoutes.projectPhaseNativeSurveyResults,
                 element: (
                   <PageLoading>
                     <AdminProjectsSurvey />

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Analysis/Analyses.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Analysis/Analyses.tsx
@@ -47,7 +47,7 @@ const Analyses = ({
   const projectLink: RouteType =
     participationMethod === 'ideation'
       ? `/admin/projects/${projectId}/phases/${phaseId}/ideas`
-      : `/admin/projects/${projectId}/phases/${phaseId}/native-survey`;
+      : `/admin/projects/${projectId}/phases/${phaseId}/results`;
 
   if (relevantAnalyses?.length === 0 && !isLoading) {
     return (

--- a/front/cypress/e2e/admin/analysis/survey_analysis.cy.ts
+++ b/front/cypress/e2e/admin/analysis/survey_analysis.cy.ts
@@ -73,7 +73,7 @@ describe('Admin: survey analysis', () => {
   });
 
   it('shows and hides summaries on the survey results page', () => {
-    cy.visit(`/admin/projects/${projectId}/phases/${phaseId}/native-survey`);
+    cy.visit(`/admin/projects/${projectId}/phases/${phaseId}/results`);
     cy.intercept('GET', '**/insights', {
       fixture: 'analysis_insights_survey.json',
     });
@@ -87,7 +87,7 @@ describe('Admin: survey analysis', () => {
   });
 
   it('adds and removes questions from the analysis', () => {
-    cy.visit(`/admin/projects/${projectId}/phases/${phaseId}/native-survey`);
+    cy.visit(`/admin/projects/${projectId}/phases/${phaseId}/results`);
     cy.intercept('GET', '**/insights', {
       fixture: 'analysis_insights_survey.json',
     });

--- a/front/cypress/e2e/form_builder/elements/point_field.cy.ts
+++ b/front/cypress/e2e/form_builder/elements/point_field.cy.ts
@@ -99,7 +99,7 @@ describe('Form builder point field', () => {
     cy.url().should('include', `projects/${projectSlug}`);
 
     // Check results in back office
-    cy.visit(`/admin/projects/${projectId}/phases/${phaseId}/native-survey`);
+    cy.visit(`/admin/projects/${projectId}/phases/${phaseId}/results`);
     cy.contains(questionTitle).should('exist');
     // Open the legend and check the correct data is shown
     cy.get(

--- a/front/cypress/e2e/report_builder/widgets/ai_widget.cy.ts
+++ b/front/cypress/e2e/report_builder/widgets/ai_widget.cy.ts
@@ -134,9 +134,7 @@ describe('Report builder: AI widget', () => {
     cy.get('#e2e-report-buider-ai-no-analyses').should('exist');
 
     // Go to the survey page where the analysis is created automatically
-    cy.visit(
-      `/admin/projects/${projectId}/phases/${surveyPhaseId}/native-survey`
-    );
+    cy.visit(`/admin/projects/${projectId}/phases/${surveyPhaseId}/results`);
     cy.wait('@createAnalysis');
 
     // Go back to the report builder

--- a/front/cypress/e2e/survey_builder/create_and_fill_survey.cy.ts
+++ b/front/cypress/e2e/survey_builder/create_and_fill_survey.cy.ts
@@ -193,7 +193,7 @@ describe('Survey builder', () => {
     cy.get('[data-cy="e2e-page-number-1"]').should('exist');
     cy.get('[data-cy="e2e-after-submission"]').should('exist');
 
-    cy.visit(`admin/projects/${projectId}/phases/${phaseId}/native-survey`);
+    cy.visit(`admin/projects/${projectId}/phases/${phaseId}/results`);
     cy.get(`[data-cy="e2e-${snakeCase(multipleChoiceChooseOneTitle)}"]`).should(
       'exist'
     );
@@ -269,7 +269,7 @@ describe('Survey builder', () => {
     cy.get('[data-cy="e2e-page-number-1"]').should('exist');
     cy.get('[data-cy="e2e-after-submission"]').should('exist');
 
-    cy.visit(`admin/projects/${projectId}/phases/${phaseId}/native-survey`);
+    cy.visit(`admin/projects/${projectId}/phases/${phaseId}/results`);
     cy.get('[data-cy="e2e-more-survey-actions-button"]').click();
 
     // Click the delete button
@@ -309,7 +309,7 @@ describe('Survey builder', () => {
     cy.get('[data-cy="e2e-page-number-1"]').should('be.visible');
     cy.get('[data-cy="e2e-after-submission"]').should('be.visible');
 
-    cy.visit(`admin/projects/${projectId}/phases/${phaseId}/native-survey`);
+    cy.visit(`admin/projects/${projectId}/phases/${phaseId}/results`);
     cy.get('[data-cy="e2e-more-survey-actions-button"]').click();
 
     // Click button to export survey results


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Changed
- Survey admin: URL of the new Results tab changed from `.../native-survey` to `.../results`.