### PR TITLE
Tan 4506/remove feature flag form PDF export

### DIFF
--- a/front/app/components/admin/FormSync/DownloadPDFButtonWithModal.tsx
+++ b/front/app/components/admin/FormSync/DownloadPDFButtonWithModal.tsx
@@ -2,12 +2,9 @@ import React, { useState } from 'react';
 
 import { Button, ButtonProps } from '@citizenlab/cl2-component-library';
 
-import useFeatureFlag from 'hooks/useFeatureFlag';
-
 import PDFExportModal from 'containers/Admin/projects/components/PDFExportModal';
 
 import { FormType } from 'components/FormBuilder/utils';
-import UpsellTooltip from 'components/UpsellTooltip';
 
 import { FormattedMessage } from 'utils/cl-intl';
 
@@ -23,25 +20,18 @@ const DownloadPDFButtonWithModal = ({
   phaseId,
   ...buttonProps
 }: Props) => {
-  const importPrintedFormsAllowed = useFeatureFlag({
-    name: 'import_printed_forms',
-    onlyCheckAllowed: true,
-  });
   const [exportModalOpen, setExportModalOpen] = useState(false);
 
   return (
     <>
-      <UpsellTooltip disabled={importPrintedFormsAllowed}>
-        <Button
-          buttonStyle="secondary-outlined"
-          icon="download"
-          onClick={() => setExportModalOpen(true)}
-          disabled={!importPrintedFormsAllowed}
-          {...buttonProps}
-        >
-          <FormattedMessage {...messages.downloadPDF} />
-        </Button>
-      </UpsellTooltip>
+      <Button
+        buttonStyle="secondary-outlined"
+        icon="download"
+        onClick={() => setExportModalOpen(true)}
+        {...buttonProps}
+      >
+        <FormattedMessage {...messages.downloadPDF} />
+      </Button>
       <PDFExportModal
         open={exportModalOpen}
         formType={formType}


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Changed
- Always allow downloading/exporting the PDF version of forms (feature flag removed)