### PR TITLE
[TAN-4605] Display '&' in organization_name correctly in emails

### DIFF
--- a/back/app/mailers/application_mailer.rb
+++ b/back/app/mailers/application_mailer.rb
@@ -15,7 +15,7 @@ class ApplicationMailer < ActionMailer::Base
     :show_header?, :preheader, :subject, :user, :recipient, :locale, :count_from, :days_since_publishing,
     :align_direction
 
-  helper_method :organization_name, :recipient_name, :url_service, :multiloc_service, :organization_name,
+  helper_method :organization_name, :recipient_name, :url_service, :multiloc_service,
     :loc, :localize_for_recipient, :localize_for_recipient_and_truncate, :recipient_first_name
 
   helper_method :unsubscribe_url, :terms_conditions_url, :privacy_policy_url, :gv_gray_logo_url,
@@ -170,7 +170,8 @@ class ApplicationMailer < ActionMailer::Base
   end
 
   def organization_name
-    @organization_name ||= localize_for_recipient(app_settings.core.organization_name)
+    # We unescape '&amp;' to '&' to ensure the organization name is displayed correctly in emails.
+    @organization_name ||= localize_for_recipient(app_settings.core.organization_name).gsub('&amp;', '&')
   end
 
   def app_configuration

--- a/back/spec/mailers/application_mailer_spec.rb
+++ b/back/spec/mailers/application_mailer_spec.rb
@@ -17,4 +17,18 @@ RSpec.describe ApplicationMailer do
         .to eq("Some test content text. A link is included here to test links when text is truncated: <a href=\"https://en.wikipedia.org/wiki/Ada_Lovelace\" target=\"_blank\" rel=\"noreferrer noopener nofollow\">https://en.wikipedia.org/wiki/Ada_Lovelace</a>\nThis is...")
     end
   end
+
+  describe 'organization_name' do
+    before do
+      config = AppConfiguration.instance
+      config.settings['core']['organization_name'] = { 'en' => 'Brighton &amp; Hove' }
+      config.save!
+    end
+
+    it 'unescapes &amp; to &' do
+      instance = described_class.new
+
+      expect(instance.organization_name).to eq('Brighton & Hove')
+    end
+  end
 end


### PR DESCRIPTION
# Changelog
## Fixed
- [TAN-4605] Display '&' in organization_name correctly in emails
