### PR TITLE
E2E: unskip profile deletion test

### DIFF
--- a/front/app/containers/App/UserDeletedModal/index.tsx
+++ b/front/app/containers/App/UserDeletedModal/index.tsx
@@ -81,7 +81,7 @@ const UserDeletedModal = ({
       {userSuccessfullyDeleted ? (
         <Container>
           <img src={illustration} alt="illu" />
-          <Title className="e2e-user-deleted-success-modal-content">
+          <Title data-cy="e2e-user-deleted-success-modal-content">
             <FormattedMessage {...messages.userDeletedTitle} />
           </Title>
           <Subtitle>

--- a/front/app/containers/MainHeader/Components/UserMenu/index.tsx
+++ b/front/app/containers/MainHeader/Components/UserMenu/index.tsx
@@ -46,7 +46,6 @@ const UserMenu = () => {
     return (
       <Container
         id="e2e-user-menu-container"
-        data-cy="e2e-user-menu-container"
         className={
           authUser.data.attributes.verified
             ? 'e2e-verified'

--- a/front/app/containers/MainHeader/Components/UserMenu/index.tsx
+++ b/front/app/containers/MainHeader/Components/UserMenu/index.tsx
@@ -46,6 +46,7 @@ const UserMenu = () => {
     return (
       <Container
         id="e2e-user-menu-container"
+        data-cy="e2e-user-menu-container"
         className={
           authUser.data.attributes.verified
             ? 'e2e-verified'

--- a/front/app/containers/UsersEditPage/DeletionDialog.tsx
+++ b/front/app/containers/UsersEditPage/DeletionDialog.tsx
@@ -128,7 +128,7 @@ const DeletionDialog = ({
             onClick={deleteProfile}
             width="auto"
             justifyWrapper="left"
-            className="e2e-delete-profile-confirm"
+            data-cy="e2e-delete-profile-confirmation"
           >
             <FormattedMessage {...messages.deleteMyAccount} />
           </Button>

--- a/front/app/containers/UsersEditPage/ProfileDeletion.tsx
+++ b/front/app/containers/UsersEditPage/ProfileDeletion.tsx
@@ -63,7 +63,7 @@ class ProfileDeletion extends PureComponent<
               onClick={this.openDialog}
               width="auto"
               justifyWrapper="left"
-              className="e2e-delete-profile"
+              data-cy="e2e-delete-profile-button"
             >
               <FormattedMessage {...messages.deleteMyAccount} />
             </Button>

--- a/front/cypress/e2e/profile-deletion.cy.ts
+++ b/front/cypress/e2e/profile-deletion.cy.ts
@@ -3,25 +3,22 @@ import { randomString, randomEmail } from '../support/commands';
 describe('profile deletion', () => {
   const firstName = randomString();
   const lastName = randomString();
-  const peasantEmail = randomEmail();
-  const peasantPassword = randomString();
+  const email = randomEmail();
+  const password = randomString();
 
   before(() => {
-    cy.apiSignup(firstName, lastName, peasantEmail, peasantPassword).then(
-      () => {
-        cy.setLoginCookie(peasantEmail, peasantPassword);
-        cy.visit('/profile/edit');
-        cy.acceptCookies();
-      }
-    );
+    cy.apiSignup(firstName, lastName, email, password).then(() => {
+      cy.setLoginCookie(email, password);
+    });
   });
-  it.skip('lets user delete their profile', () => {
-    cy.get('.e2e-delete-profile').find('button').click();
-    cy.get('.e2e-delete-profile-confirm').find('button').click();
-    cy.wait(3000);
-    cy.get('.e2e-user-deleted-success-modal-content');
-    cy.get('.e2e-modal-close-button').click();
-    cy.get('.e2e-user-deleted-success-modal-content').should('not.exist');
-    cy.get('.e2e-user-menu-container').should('not.exist');
+
+  it('lets user delete their profile', () => {
+    cy.visit('/profile/edit');
+    cy.dataCy('e2e-delete-profile-button').should('be.visible').click();
+    cy.dataCy('e2e-delete-profile-confirmation').should('be.visible').click();
+    cy.dataCy('e2e-user-deleted-success-modal-content').should('be.visible');
+    // Check that the user is logged out
+    cy.visit('/profile/edit');
+    cy.dataCy('e2e-unauthorized-must-sign-in').should('exist');
   });
 });

--- a/front/cypress/e2e/profile-deletion.cy.ts
+++ b/front/cypress/e2e/profile-deletion.cy.ts
@@ -19,6 +19,6 @@ describe('profile deletion', () => {
     cy.dataCy('e2e-user-deleted-success-modal-content').should('be.visible');
     // Check that the user is logged out
     cy.visit('/profile/edit');
-    cy.dataCy('e2e-unauthorized-must-sign-in').should('exist');
+    cy.dataCy('e2e-unauthorized-must-sign-in').should('be.visible');
   });
 });


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Technical
- Re-enable skipped `profile-deletion` E2E test.