### PR TITLE
TAN-4651 Fix idea form throw error when saving twice

### DIFF
--- a/front/app/api/custom_fields/useUpdateCustomFields.ts
+++ b/front/app/api/custom_fields/useUpdateCustomFields.ts
@@ -56,12 +56,21 @@ const useUpdateCustomField = () => {
           phaseId: variables.phaseId,
         }),
       });
+
       queryClient.invalidateQueries({
         queryKey: customFormKeys.item({
           projectId: variables.projectId,
-          phaseId: variables.phaseId,
         }),
       });
+
+      if (variables.phaseId) {
+        queryClient.invalidateQueries({
+          queryKey: customFormKeys.item({
+            projectId: variables.projectId,
+            phaseId: variables.phaseId,
+          }),
+        });
+      }
     },
   });
 };


### PR DESCRIPTION
The reason why this was failing was the that custom form invalidation was not working. When you save the form, you need to fetch the latest version of the custom form, in order to get the latest version of the `fields_last_updated_at`. If you are using an outdated version of that attribute, the next save gets rejected.

It seems that `react-query` sees `{ projectId: 'abc', phaseId: undefined }` and `{ projectId: 'abc' }` as two different things. The query is cached under latter key, but the invalidation was using the former key. This change makes sure we use the correct key, without breaking the invalidation for the survey, which does need both the `projectId` and `phaseId`.

# Changelog
## Fixed
- Idea form throwing error when trying to save it twice
