### PR TITLE
TAN-3920 - Fix links in emails

### DIFF
--- a/back/config/environments/development.rb
+++ b/back/config/environments/development.rb
@@ -58,7 +58,7 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   # Previewing mails from all engines.
-  config.action_mailer.preview_path = Rails.root.join('engines/*/*/spec/mailers/previews')
+  config.action_mailer.preview_paths = [Rails.root.join('engines/*/*/spec/mailers/previews')]
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/back/engines/free/frontend/app/services/frontend/url_service.rb
+++ b/back/engines/free/frontend/app/services/frontend/url_service.rb
@@ -131,13 +131,7 @@ module Frontend
     end
 
     def admin_project_url(project_id, configuration = app_config_instance)
-      project = Project.find(project_id)
-      last_phase_id = project ? TimelineService.new.current_or_backup_transitive_phase(project)&.id : nil
-      if last_phase_id
-        "#{configuration.base_frontend_uri}/admin/projects/#{project_id}/phases/#{last_phase_id}/ideas"
-      else
-        "#{configuration.base_frontend_uri}/admin/projects/#{project_id}/settings"
-      end
+      "#{configuration.base_frontend_uri}/admin/projects/#{project_id}"
     end
 
     def idea_edit_url(configuration, idea_id)

--- a/front/app/containers/Admin/messaging/messages.ts
+++ b/front/app/containers/Admin/messaging/messages.ts
@@ -218,9 +218,9 @@ export default defineMessages({
     defaultMessage: 'See examples on our support page',
   },
   supportButtonLink: {
-    id: 'app.containers.Admin.emails.supportButtonLink',
+    id: 'app.containers.Admin.emails.supportButtonLink2',
     defaultMessage:
-      'https://support.govocal.com/en/articles/2762939-what-are-automated-emails',
+      'https://support.govocal.com/en/articles/7042664-changing-the-settings-of-the-automated-email-notifications',
   },
   sentToUsers: {
     id: 'app.containers.Admin.emails.sentToUsers',

--- a/front/app/translations/admin/ar-SA.json
+++ b/front/app/translations/admin/ar-SA.json
@@ -869,7 +869,6 @@
   "app.containers.Admin.emails.sentToUsers": "هذه هي رسائل البريد الإلكتروني المرسلة إلى المستخدمين",
   "app.containers.Admin.emails.subject": "موضوع:",
   "app.containers.Admin.emails.supportButtonLabel": "انظر الأمثلة على صفحة الدعم الخاصة بنا",
-  "app.containers.Admin.emails.supportButtonLink": "https://support.govocal.com/en/articles/2762939-what-are-automated-emails",
   "app.containers.Admin.emails.to": "ل:",
   "app.containers.Admin.emails.toAllUsers": "هل ترغب في إرسال هذه الرسالة الإلكترونية إلى جميع المستخدمين؟",
   "app.containers.Admin.emails.viewExample": "منظر",

--- a/front/app/translations/admin/ca-ES.json
+++ b/front/app/translations/admin/ca-ES.json
@@ -490,7 +490,6 @@
   "app.containers.Admin.emails.sentToUsers": "Són correus electrònics enviats als usuaris",
   "app.containers.Admin.emails.subject": "Assignatura:",
   "app.containers.Admin.emails.supportButtonLabel": "Vegeu exemples a la nostra pàgina d'assistència",
-  "app.containers.Admin.emails.supportButtonLink": "https://support.govocal.com/en/articles/2762939-what-are-automated-emails",
   "app.containers.Admin.emails.to": "A:",
   "app.containers.Admin.emails.toAllUsers": "Voleu enviar aquest correu electrònic a tots els usuaris registrats?",
   "app.containers.Admin.emails.viewExample": "Veure",

--- a/front/app/translations/admin/cy-GB.json
+++ b/front/app/translations/admin/cy-GB.json
@@ -869,7 +869,6 @@
   "app.containers.Admin.emails.sentToUsers": "Mae'r rhain yn negeseuon e-bost a anfonir at ddefnyddwyr",
   "app.containers.Admin.emails.subject": "Testun:",
   "app.containers.Admin.emails.supportButtonLabel": "Gweler enghreifftiau ar ein tudalen cymorth",
-  "app.containers.Admin.emails.supportButtonLink": "https://support.govocal.com/en/articles/2762939-what-are-automated-emails",
   "app.containers.Admin.emails.to": "I:",
   "app.containers.Admin.emails.toAllUsers": "Ydych chi am anfon yr e-bost hwn at bob defnyddiwr cofrestredig?",
   "app.containers.Admin.emails.viewExample": "Golwg",

--- a/front/app/translations/admin/da-DK.json
+++ b/front/app/translations/admin/da-DK.json
@@ -869,7 +869,6 @@
   "app.containers.Admin.emails.sentToUsers": "Dette er e-mails, der sendes til brugerne",
   "app.containers.Admin.emails.subject": "Emne:",
   "app.containers.Admin.emails.supportButtonLabel": "Se eksempler på vores supportside",
-  "app.containers.Admin.emails.supportButtonLink": "https://support.govocal.com/en/articles/2762939-what-are-automated-emails",
   "app.containers.Admin.emails.to": "Til:",
   "app.containers.Admin.emails.toAllUsers": "Ønsker du at sende denne e-mail til alle registrerede brugere?",
   "app.containers.Admin.emails.viewExample": "Se",

--- a/front/app/translations/admin/de-DE.json
+++ b/front/app/translations/admin/de-DE.json
@@ -869,7 +869,6 @@
   "app.containers.Admin.emails.sentToUsers": "Dies sind E-Mails, die an Nutzer*innen gesendet werden",
   "app.containers.Admin.emails.subject": "Betreff:",
   "app.containers.Admin.emails.supportButtonLabel": "Beispiele finden Sie in unserer Wissensdatenbank",
-  "app.containers.Admin.emails.supportButtonLink": "https://support.govocal.com/en/articles/2762939-what-are-automated-emails",
   "app.containers.Admin.emails.to": "An:",
   "app.containers.Admin.emails.toAllUsers": "Möchten Sie diese E-Mail an alle registrierten Nutzer*innen senden?",
   "app.containers.Admin.emails.viewExample": "Vorschau",

--- a/front/app/translations/admin/el-GR.json
+++ b/front/app/translations/admin/el-GR.json
@@ -490,7 +490,6 @@
   "app.containers.Admin.emails.sentToUsers": "Πρόκειται για μηνύματα ηλεκτρονικού ταχυδρομείου που αποστέλλονται στους χρήστες",
   "app.containers.Admin.emails.subject": "Θέμα:",
   "app.containers.Admin.emails.supportButtonLabel": "Δείτε παραδείγματα στη σελίδα υποστήριξης",
-  "app.containers.Admin.emails.supportButtonLink": "https://support.govocal.com/en/articles/2762939-what-are-automated-emails",
   "app.containers.Admin.emails.to": "Προς:",
   "app.containers.Admin.emails.toAllUsers": "Θέλετε να στείλετε αυτό το μήνυμα ηλεκτρονικού ταχυδρομείου σε όλους τους εγγεγραμμένους χρήστες;",
   "app.containers.Admin.emails.viewExample": "Προβολή",

--- a/front/app/translations/admin/en-CA.json
+++ b/front/app/translations/admin/en-CA.json
@@ -869,7 +869,6 @@
   "app.containers.Admin.emails.sentToUsers": "These are emails sent to users",
   "app.containers.Admin.emails.subject": "Subject:",
   "app.containers.Admin.emails.supportButtonLabel": "See examples on our support page",
-  "app.containers.Admin.emails.supportButtonLink": "https://support.govocal.com/en/articles/2762939-what-are-automated-emails",
   "app.containers.Admin.emails.to": "To:",
   "app.containers.Admin.emails.toAllUsers": "Do you want to send this email to all registered users?",
   "app.containers.Admin.emails.viewExample": "View",

--- a/front/app/translations/admin/en-GB.json
+++ b/front/app/translations/admin/en-GB.json
@@ -869,7 +869,6 @@
   "app.containers.Admin.emails.sentToUsers": "These are emails sent to users",
   "app.containers.Admin.emails.subject": "Subject:",
   "app.containers.Admin.emails.supportButtonLabel": "See examples on our support page",
-  "app.containers.Admin.emails.supportButtonLink": "https://support.govocal.com/en/articles/2762939-what-are-automated-emails",
   "app.containers.Admin.emails.to": "To:",
   "app.containers.Admin.emails.toAllUsers": "Do you want to send this email to all registered users?",
   "app.containers.Admin.emails.viewExample": "View",

--- a/front/app/translations/admin/en-IE.json
+++ b/front/app/translations/admin/en-IE.json
@@ -869,7 +869,6 @@
   "app.containers.Admin.emails.sentToUsers": "These are emails sent to users",
   "app.containers.Admin.emails.subject": "Subject:",
   "app.containers.Admin.emails.supportButtonLabel": "See examples on our support page",
-  "app.containers.Admin.emails.supportButtonLink": "https://support.govocal.com/en/articles/2762939-what-are-automated-emails",
   "app.containers.Admin.emails.to": "To:",
   "app.containers.Admin.emails.toAllUsers": "Do you want to send this email to all registered users?",
   "app.containers.Admin.emails.viewExample": "View",

--- a/front/app/translations/admin/en.json
+++ b/front/app/translations/admin/en.json
@@ -869,7 +869,7 @@
   "app.containers.Admin.emails.sentToUsers": "These are emails sent to users",
   "app.containers.Admin.emails.subject": "Subject:",
   "app.containers.Admin.emails.supportButtonLabel": "See examples on our support page",
-  "app.containers.Admin.emails.supportButtonLink": "https://support.govocal.com/en/articles/2762939-what-are-automated-emails",
+  "app.containers.Admin.emails.supportButtonLink2": "https://support.govocal.com/en/articles/7042664-changing-the-settings-of-the-automated-email-notifications",
   "app.containers.Admin.emails.to": "To:",
   "app.containers.Admin.emails.toAllUsers": "Do you want to send this email to all registered users?",
   "app.containers.Admin.emails.viewExample": "View",

--- a/front/app/translations/admin/es-CL.json
+++ b/front/app/translations/admin/es-CL.json
@@ -869,7 +869,6 @@
   "app.containers.Admin.emails.sentToUsers": "Son correos electrónicos enviados a los usuarios",
   "app.containers.Admin.emails.subject": "Asunto:",
   "app.containers.Admin.emails.supportButtonLabel": "Ver ejemplos en nuestra página de ayuda",
-  "app.containers.Admin.emails.supportButtonLink": "https://support.govocal.com/en/articles/7042664-changing-the-settings-of-the-automated-email-notifications",
   "app.containers.Admin.emails.to": "Para:",
   "app.containers.Admin.emails.toAllUsers": "¿Quieres enviar este correo electrónico a todos los usuarios?",
   "app.containers.Admin.emails.viewExample": "Ver",

--- a/front/app/translations/admin/es-ES.json
+++ b/front/app/translations/admin/es-ES.json
@@ -869,7 +869,6 @@
   "app.containers.Admin.emails.sentToUsers": "Son correos electrónicos enviados a los usuarios",
   "app.containers.Admin.emails.subject": "Asunto:",
   "app.containers.Admin.emails.supportButtonLabel": "Ver ejemplos en nuestra página de ayuda",
-  "app.containers.Admin.emails.supportButtonLink": "https://support.govocal.com/en/articles/7042664-changing-the-settings-of-the-automated-email-notifications",
   "app.containers.Admin.emails.to": "Para:",
   "app.containers.Admin.emails.toAllUsers": "¿Quieres enviar este correo electrónico a todos los usuarios?",
   "app.containers.Admin.emails.viewExample": "Ver",

--- a/front/app/translations/admin/fi-FI.json
+++ b/front/app/translations/admin/fi-FI.json
@@ -869,7 +869,6 @@
   "app.containers.Admin.emails.sentToUsers": "Nämä ovat käyttäjille lähetettyjä sähköposteja",
   "app.containers.Admin.emails.subject": "Aihe:",
   "app.containers.Admin.emails.supportButtonLabel": "Katso esimerkkejä tukisivultamme",
-  "app.containers.Admin.emails.supportButtonLink": "https://support.govocal.com/en/articles/2762939-what-are-automated-emails",
   "app.containers.Admin.emails.to": "Vastaanottaja:",
   "app.containers.Admin.emails.toAllUsers": "Haluatko lähettää tämän sähköpostin kaikille rekisteröityneille käyttäjille?",
   "app.containers.Admin.emails.viewExample": "Näytä",

--- a/front/app/translations/admin/fr-BE.json
+++ b/front/app/translations/admin/fr-BE.json
@@ -869,7 +869,6 @@
   "app.containers.Admin.emails.sentToUsers": "Il s'agit d'e-mails envoyés aux utilisateurs",
   "app.containers.Admin.emails.subject": "Objet :",
   "app.containers.Admin.emails.supportButtonLabel": "Consultez les exemples sur notre page de support",
-  "app.containers.Admin.emails.supportButtonLink": "https://support.govocal.com/en/articles/2762939-what-are-automated-emails",
   "app.containers.Admin.emails.to": "À :",
   "app.containers.Admin.emails.toAllUsers": "Voulez-vous envoyer ce courriel à tous les utilisateurs ?",
   "app.containers.Admin.emails.viewExample": "Voir",

--- a/front/app/translations/admin/fr-FR.json
+++ b/front/app/translations/admin/fr-FR.json
@@ -869,7 +869,6 @@
   "app.containers.Admin.emails.sentToUsers": "Il s'agit d'e-mails envoyés aux utilisateurs",
   "app.containers.Admin.emails.subject": "Objet :",
   "app.containers.Admin.emails.supportButtonLabel": "Consultez les exemples sur notre page de support",
-  "app.containers.Admin.emails.supportButtonLink": "https://support.govocal.com/en/articles/2762939-what-are-automated-emails",
   "app.containers.Admin.emails.to": "À :",
   "app.containers.Admin.emails.toAllUsers": "Voulez-vous envoyer ce courriel à tous les utilisateurs ?",
   "app.containers.Admin.emails.viewExample": "Voir",

--- a/front/app/translations/admin/hr-HR.json
+++ b/front/app/translations/admin/hr-HR.json
@@ -869,7 +869,6 @@
   "app.containers.Admin.emails.sentToUsers": "Ovo su e-poruke poslane korisnicima",
   "app.containers.Admin.emails.subject": "Predmet:",
   "app.containers.Admin.emails.supportButtonLabel": "Pogledajte primjere na našoj stranici za podršku",
-  "app.containers.Admin.emails.supportButtonLink": "https://support.govocal.com/en/articles/2762939-what-are-automated-emails",
   "app.containers.Admin.emails.to": "Do:",
   "app.containers.Admin.emails.toAllUsers": "Želite li poslati ovu e-poruku svim registriranim korisnicima?",
   "app.containers.Admin.emails.viewExample": "Pogled",

--- a/front/app/translations/admin/it-IT.json
+++ b/front/app/translations/admin/it-IT.json
@@ -490,7 +490,6 @@
   "app.containers.Admin.emails.sentToUsers": "Si tratta di email inviate agli utenti",
   "app.containers.Admin.emails.subject": "Oggetto:",
   "app.containers.Admin.emails.supportButtonLabel": "Guarda gli esempi nella nostra pagina di supporto",
-  "app.containers.Admin.emails.supportButtonLink": "https://support.govocal.com/en/articles/2762939-what-are-automated-emails",
   "app.containers.Admin.emails.to": "A:",
   "app.containers.Admin.emails.toAllUsers": "Do you want to send this email to all registered users?",
   "app.containers.Admin.emails.viewExample": "Guarda",

--- a/front/app/translations/admin/lt-LT.json
+++ b/front/app/translations/admin/lt-LT.json
@@ -869,7 +869,6 @@
   "app.containers.Admin.emails.sentToUsers": "Tai naudotojams siunčiami el. laiškai",
   "app.containers.Admin.emails.subject": "Tema:",
   "app.containers.Admin.emails.supportButtonLabel": "Žr. pavyzdžius mūsų pagalbos puslapyje",
-  "app.containers.Admin.emails.supportButtonLink": "https://support.govocal.com/en/articles/2762939-what-are-automated-emails",
   "app.containers.Admin.emails.to": "Kam:",
   "app.containers.Admin.emails.toAllUsers": "Ar norite siųsti šį el. laišką visiems registruotiems naudotojams?",
   "app.containers.Admin.emails.viewExample": "Peržiūrėti",

--- a/front/app/translations/admin/lv-LV.json
+++ b/front/app/translations/admin/lv-LV.json
@@ -869,7 +869,6 @@
   "app.containers.Admin.emails.sentToUsers": "Tie ir e-pasta ziņojumi, kas nosūtīti lietotājiem",
   "app.containers.Admin.emails.subject": "Temats:",
   "app.containers.Admin.emails.supportButtonLabel": "Skatīt piemērus mūsu atbalsta lapā",
-  "app.containers.Admin.emails.supportButtonLink": "https://support.govocal.com/en/articles/2762939-what-are-automated-emails",
   "app.containers.Admin.emails.to": "Uz:",
   "app.containers.Admin.emails.toAllUsers": "Vai vēlaties nosūtīt šo e-pastu visiem reģistrētajiem lietotājiem?",
   "app.containers.Admin.emails.viewExample": "Skatīt",

--- a/front/app/translations/admin/nb-NO.json
+++ b/front/app/translations/admin/nb-NO.json
@@ -869,7 +869,6 @@
   "app.containers.Admin.emails.sentToUsers": "Dette er e-poster som sendes til brukere",
   "app.containers.Admin.emails.subject": "Emne:",
   "app.containers.Admin.emails.supportButtonLabel": "Se eksempler på supportsiden vår",
-  "app.containers.Admin.emails.supportButtonLink": "https://support.govocal.com/en/articles/2762939-what-are-automated-emails",
   "app.containers.Admin.emails.to": "Til..:",
   "app.containers.Admin.emails.toAllUsers": "Ønsker du å sende denne e-posten til alle registrerte brukere?",
   "app.containers.Admin.emails.viewExample": "Vis",

--- a/front/app/translations/admin/nl-BE.json
+++ b/front/app/translations/admin/nl-BE.json
@@ -869,7 +869,6 @@
   "app.containers.Admin.emails.sentToUsers": "Dit zijn e-mails die naar gebruikers worden gestuurd",
   "app.containers.Admin.emails.subject": "Onderwerp:",
   "app.containers.Admin.emails.supportButtonLabel": "Zie voorbeelden op onze support pagina",
-  "app.containers.Admin.emails.supportButtonLink": "https://support.govocal.com/en/articles/2762939-what-are-automated-emails",
   "app.containers.Admin.emails.to": "Aan:",
   "app.containers.Admin.emails.toAllUsers": "Wil je deze e-mail naar alle gebruikers sturen?",
   "app.containers.Admin.emails.viewExample": "Bekijk",

--- a/front/app/translations/admin/nl-NL.json
+++ b/front/app/translations/admin/nl-NL.json
@@ -869,7 +869,6 @@
   "app.containers.Admin.emails.sentToUsers": "Dit zijn e-mails die naar gebruikers worden gestuurd",
   "app.containers.Admin.emails.subject": "Onderwerp:",
   "app.containers.Admin.emails.supportButtonLabel": "Zie voorbeelden op onze support pagina",
-  "app.containers.Admin.emails.supportButtonLink": "https://support.govocal.com/en/articles/2762939-what-are-automated-emails",
   "app.containers.Admin.emails.to": "Aan:",
   "app.containers.Admin.emails.toAllUsers": "Wil je deze e-mail naar alle gebruikers sturen?",
   "app.containers.Admin.emails.viewExample": "Bekijk",

--- a/front/app/translations/admin/pa-IN.json
+++ b/front/app/translations/admin/pa-IN.json
@@ -869,7 +869,6 @@
   "app.containers.Admin.emails.sentToUsers": "ਇਹ ਉਪਭੋਗਤਾਵਾਂ ਨੂੰ ਭੇਜੀਆਂ ਗਈਆਂ ਈਮੇਲਾਂ ਹਨ",
   "app.containers.Admin.emails.subject": "ਵਿਸ਼ਾ:",
   "app.containers.Admin.emails.supportButtonLabel": "ਸਾਡੇ ਸਹਾਇਤਾ ਪੰਨੇ 'ਤੇ ਉਦਾਹਰਨਾਂ ਦੇਖੋ",
-  "app.containers.Admin.emails.supportButtonLink": "https://support.govocal.com/en/articles/2762939-what-are-automated-emails",
   "app.containers.Admin.emails.to": "ਨੂੰ:",
   "app.containers.Admin.emails.toAllUsers": "ਕੀ ਤੁਸੀਂ ਸਾਰੇ ਰਜਿਸਟਰਡ ਉਪਭੋਗਤਾਵਾਂ ਨੂੰ ਇਹ ਈਮੇਲ ਭੇਜਣਾ ਚਾਹੁੰਦੇ ਹੋ?",
   "app.containers.Admin.emails.viewExample": "ਦੇਖੋ",

--- a/front/app/translations/admin/pl-PL.json
+++ b/front/app/translations/admin/pl-PL.json
@@ -869,7 +869,6 @@
   "app.containers.Admin.emails.sentToUsers": "Są to wiadomości e-mail wysyłane do użytkowników",
   "app.containers.Admin.emails.subject": "Temat:",
   "app.containers.Admin.emails.supportButtonLabel": "Zobacz przykłady na naszej stronie wsparcia",
-  "app.containers.Admin.emails.supportButtonLink": "https://support.govocal.com/en/articles/2762939-what-are-automated-emails",
   "app.containers.Admin.emails.to": "Do:",
   "app.containers.Admin.emails.toAllUsers": "Czy chcesz wysłać tę wiadomość do wszystkich użytkowników?",
   "app.containers.Admin.emails.viewExample": "Zobacz",

--- a/front/app/translations/admin/pt-BR.json
+++ b/front/app/translations/admin/pt-BR.json
@@ -869,7 +869,6 @@
   "app.containers.Admin.emails.sentToUsers": "Estes são e-mails enviados aos usuários",
   "app.containers.Admin.emails.subject": "Assunto:",
   "app.containers.Admin.emails.supportButtonLabel": "Veja exemplos em nossa página de suporte",
-  "app.containers.Admin.emails.supportButtonLink": "https://support.govocal.com/en/articles/2762939-what-are-automated-emails",
   "app.containers.Admin.emails.to": "Para:",
   "app.containers.Admin.emails.toAllUsers": "Quer enviar este email para todos os usuários?",
   "app.containers.Admin.emails.viewExample": "Visualizar",

--- a/front/app/translations/admin/sr-Latn.json
+++ b/front/app/translations/admin/sr-Latn.json
@@ -869,7 +869,6 @@
   "app.containers.Admin.emails.sentToUsers": "Ово су е-поруке које се шаљу корисницима",
   "app.containers.Admin.emails.subject": "Тема:",
   "app.containers.Admin.emails.supportButtonLabel": "Погледајте примере на нашој страници за подршку",
-  "app.containers.Admin.emails.supportButtonLink": "https://support.govocal.com/en/articles/2762939-what-are-automated-emails",
   "app.containers.Admin.emails.to": "До:",
   "app.containers.Admin.emails.toAllUsers": "Da li želite da pošaljete ovaj email svim korisnicima?",
   "app.containers.Admin.emails.viewExample": "Поглед",

--- a/front/app/translations/admin/sr-SP.json
+++ b/front/app/translations/admin/sr-SP.json
@@ -869,7 +869,6 @@
   "app.containers.Admin.emails.sentToUsers": "Ово су е-поруке које се шаљу корисницима",
   "app.containers.Admin.emails.subject": "Предмет:",
   "app.containers.Admin.emails.supportButtonLabel": "Погледајте примере на нашој страници за подршку",
-  "app.containers.Admin.emails.supportButtonLink": "https://support.govocal.com/en/articles/2762939-what-are-automated-emails",
   "app.containers.Admin.emails.to": "До:",
   "app.containers.Admin.emails.toAllUsers": "Да ли желите да пошаљете ову е-пошту свим регистрованим корисницима?",
   "app.containers.Admin.emails.viewExample": "Поглед",

--- a/front/app/translations/admin/sv-SE.json
+++ b/front/app/translations/admin/sv-SE.json
@@ -869,7 +869,6 @@
   "app.containers.Admin.emails.sentToUsers": "Detta är e-postmeddelanden som skickas till användare",
   "app.containers.Admin.emails.subject": "Ämne:",
   "app.containers.Admin.emails.supportButtonLabel": "Se exempel på vår supportsida",
-  "app.containers.Admin.emails.supportButtonLink": "https://support.govocal.com/de/articles/7042664-andern-der-einstellungen-fur-die-automatischen-e-mail-benachrichtigungen",
   "app.containers.Admin.emails.to": "Till:",
   "app.containers.Admin.emails.toAllUsers": "Vill du skicka det här e-postmeddelandet till alla registrerade användare?",
   "app.containers.Admin.emails.viewExample": "Visa",

--- a/front/app/translations/admin/tr-TR.json
+++ b/front/app/translations/admin/tr-TR.json
@@ -869,7 +869,6 @@
   "app.containers.Admin.emails.sentToUsers": "Bunlar kullanıcılara gönderilen e-postalardır",
   "app.containers.Admin.emails.subject": "Konu:",
   "app.containers.Admin.emails.supportButtonLabel": "Destek sayfamızdaki örneklere bakın",
-  "app.containers.Admin.emails.supportButtonLink": "https://support.govocal.com/en/articles/2762939-what-are-automated-emails",
   "app.containers.Admin.emails.to": "Kime?",
   "app.containers.Admin.emails.toAllUsers": "Bu e-postayı tüm kayıtlı kullanıcılara göndermek istiyor musunuz?",
   "app.containers.Admin.emails.viewExample": "Görünüm",

--- a/front/app/translations/admin/ur-PK.json
+++ b/front/app/translations/admin/ur-PK.json
@@ -869,7 +869,6 @@
   "app.containers.Admin.emails.sentToUsers": "یہ صارفین کو بھیجی گئی ای میلز ہیں۔",
   "app.containers.Admin.emails.subject": "موضوع:",
   "app.containers.Admin.emails.supportButtonLabel": "ہمارے سپورٹ پیج پر مثالیں دیکھیں",
-  "app.containers.Admin.emails.supportButtonLink": "https://support.govocal.com/en/articles/2762939-what-are-automated-emails",
   "app.containers.Admin.emails.to": "کو:",
   "app.containers.Admin.emails.toAllUsers": "کیا آپ یہ ای میل تمام رجسٹرڈ صارفین کو بھیجنا چاہتے ہیں؟",
   "app.containers.Admin.emails.viewExample": "دیکھیں",


### PR DESCRIPTION
# Changelog
## Fixed
- Fixed broken support link on automated emails page
- Fixed project admin link in project review emails so it does not route to /setup
