### PR TITLE
[TAN-4781] Whitelist table elements and attributes in static_pages

### DIFF
--- a/back/app/models/static_page.rb
+++ b/back/app/models/static_page.rb
@@ -186,7 +186,7 @@ class StaticPage < ApplicationRecord
 
     @service ||= SanitizationService.new
 
-    self[attribute] = @service.sanitize_multiloc(self[attribute], %i[title alignment list decoration link image video])
+    self[attribute] = @service.sanitize_multiloc(self[attribute], %i[title alignment list decoration link image video table])
     self[attribute] = @service.remove_multiloc_empty_trailing_tags(self[attribute])
     self[attribute] = @service.linkify_multiloc(self[attribute])
   end

--- a/back/app/services/sanitization_service.rb
+++ b/back/app/services/sanitization_service.rb
@@ -140,6 +140,10 @@ class SanitizationService
       mention: {
         tags: %w[span],
         attributes: %w[class data-user-id data-user-slug]
+      },
+      table: {
+        tags: %w[table thead tbody tr th td],
+        attributes: %w[class style width border border-collapse visibility display border-color padding text-align]
       }
     }.freeze
 

--- a/back/app/services/sanitization_service.rb
+++ b/back/app/services/sanitization_service.rb
@@ -143,7 +143,7 @@ class SanitizationService
       },
       table: {
         tags: %w[table thead tbody tr th td],
-        attributes: %w[class style width border border-collapse visibility display border-color padding text-align]
+        attributes: %w[class style width border border-collapse display border-color padding text-align]
       }
     }.freeze
 

--- a/back/spec/acceptance/static_pages_spec.rb
+++ b/back/spec/acceptance/static_pages_spec.rb
@@ -99,6 +99,29 @@ resource 'StaticPages' do
         expect(json_response.dig(:data, :attributes, :code)).to eq 'custom'
       end
 
+      # Althought the info section WYSIWYG for static pages does not support HTML tables,
+      # we sometimes use a static_page for custom content that can include tables.
+      # In such cases we save the HTML to the multiloc field directly.
+      example 'Update a static page with table elements in info section' do
+        table_HTML = <<~HTML
+            <table style="width:100%;border-collapse:collapse;display:table !important;border:1px solid #ddd;">
+              <tr style="display:table-row !important;">
+                <th style="width:80px;border:1px solid #ddd;padding:5px;text-align:left;display:table-cell !important;">Verktøy</th>
+              </tr>
+              <tr style="display:table-row !important;">
+                <td style="border:1px solid #ddd;padding:5px;text-align:left;display:table-cell !important;">Matomo</td>
+              </tr>
+            </table>
+          HTML
+
+        top_info_section_multiloc = { en: table_HTML.strip }
+        
+        do_request(static_page: { top_info_section_multiloc: top_info_section_multiloc })
+        assert_status 200
+        
+        expect(json_response.dig(:data, :attributes, :top_info_section_multiloc, :en).strip).to eq(top_info_section_multiloc[:en])
+      end
+
       describe 'updating topics' do
         let(:projects_filter_type) { 'topics' }
         let(:topic1) { create(:topic) }

--- a/back/spec/acceptance/static_pages_spec.rb
+++ b/back/spec/acceptance/static_pages_spec.rb
@@ -103,22 +103,22 @@ resource 'StaticPages' do
       # we sometimes use a static_page for custom content that can include tables.
       # In such cases we save the HTML to the multiloc field directly.
       example 'Update a static page with table elements in info section' do
-        table_HTML = <<~HTML
-            <table style="width:100%;border-collapse:collapse;display:table !important;border:1px solid #ddd;">
-              <tr style="display:table-row !important;">
-                <th style="width:80px;border:1px solid #ddd;padding:5px;text-align:left;display:table-cell !important;">Verktøy</th>
-              </tr>
-              <tr style="display:table-row !important;">
-                <td style="border:1px solid #ddd;padding:5px;text-align:left;display:table-cell !important;">Matomo</td>
-              </tr>
-            </table>
-          HTML
+        table_html = <<~HTML
+          <table style="width:100%;border-collapse:collapse;display:table !important;border:1px solid #ddd;">
+            <tr style="display:table-row !important;">
+              <th style="width:80px;border:1px solid #ddd;padding:5px;text-align:left;display:table-cell !important;">Verktøy</th>
+            </tr>
+            <tr style="display:table-row !important;">
+              <td style="border:1px solid #ddd;padding:5px;text-align:left;display:table-cell !important;">Matomo</td>
+            </tr>
+          </table>
+        HTML
 
-        top_info_section_multiloc = { en: table_HTML.strip }
-        
+        top_info_section_multiloc = { en: table_html.strip }
+
         do_request(static_page: { top_info_section_multiloc: top_info_section_multiloc })
         assert_status 200
-        
+
         expect(json_response.dig(:data, :attributes, :top_info_section_multiloc, :en).strip).to eq(top_info_section_multiloc[:en])
       end
 

--- a/back/spec/acceptance/static_pages_spec.rb
+++ b/back/spec/acceptance/static_pages_spec.rb
@@ -99,7 +99,7 @@ resource 'StaticPages' do
         expect(json_response.dig(:data, :attributes, :code)).to eq 'custom'
       end
 
-      # Althought the info section WYSIWYG for static pages does not support HTML tables,
+      # Although the info section WYSIWYG for static pages does not support HTML tables,
       # we sometimes use a static_page for custom content that can include tables.
       # In such cases we save the HTML to the multiloc field directly.
       example 'Update a static page with table elements in info section' do


### PR DESCRIPTION
Prevent the breaking of custom cookie page content layout when it include table(s), due to sanitization of the multiloc involved.

[Custom cookie policy docs](https://www.notion.so/govocal/Custom-cookie-policy-6bb995305a9344398b257fe1fdd3d910?source=copy_link#2049663b7b2680968dfafe1b9c2f9e82) also updated to reflect these changes

Example of such content saved (with new whitelisting of table elements & styling):
<img width="1002" alt="Screenshot 2025-06-05 at 13 26 56" src="https://github.com/user-attachments/assets/ce7eea21-6d0b-41f8-892c-64dc932bf7fb" />

# Changelog
## Technical
- [TAN-4781] Whitelist table elements and attributes in static_pages info multilocs.
