### PR TITLE
[TAN-4052] Calculate correct percentages for multi-select survey results

### DIFF
--- a/front/app/components/admin/Graphs/SurveyBars/utils.ts
+++ b/front/app/components/admin/Graphs/SurveyBars/utils.ts
@@ -58,7 +58,8 @@ export const parseQuestionResult = (
     });
   }
 
-  const { multilocs, answers, logic, totalPickCount } = result;
+  const { multilocs, answers, logic, totalPickCount, totalResponseCount } =
+    result;
   if (!multilocs) throw new Error('Multilocs are missing');
 
   // Don't return 'No answer' if everyone answered
@@ -72,8 +73,12 @@ export const parseQuestionResult = (
         answer === null
           ? noAnswerCopy
           : localize(multilocs.answer[answer].title_multiloc);
+
       const image = answer ? multilocs.answer[answer].image : undefined;
-      const percentage = roundPercentage(count, totalPickCount, 1);
+      const percentage =
+        result.inputType === 'multiselect'
+          ? roundPercentage(count, totalResponseCount, 1)
+          : roundPercentage(count, totalPickCount, 1);
 
       const logicAnswerKey = answer === null ? 'no_answer' : answer;
       const logicForAnswer = logic?.answer?.[logicAnswerKey];

--- a/front/app/components/admin/Graphs/SurveyBars/utils.ts
+++ b/front/app/components/admin/Graphs/SurveyBars/utils.ts
@@ -82,6 +82,9 @@ export const parseQuestionResult = (
 
       const image = answer ? multilocs.answer[answer].image : undefined;
       const percentage =
+        // When we show results of a multi-select question,
+        // we use the percentage of total responses (totalResponseCount) per option
+        // rather than percentage of total options selected (totalPickCount).
         inputType === 'multiselect'
           ? roundPercentage(count, totalResponseCount, 1)
           : roundPercentage(count, totalPickCount, 1);

--- a/front/app/components/admin/Graphs/SurveyBars/utils.ts
+++ b/front/app/components/admin/Graphs/SurveyBars/utils.ts
@@ -58,8 +58,14 @@ export const parseQuestionResult = (
     });
   }
 
-  const { multilocs, answers, logic, totalPickCount, totalResponseCount } =
-    result;
+  const {
+    multilocs,
+    answers,
+    logic,
+    inputType,
+    totalPickCount,
+    totalResponseCount,
+  } = result;
   if (!multilocs) throw new Error('Multilocs are missing');
 
   // Don't return 'No answer' if everyone answered
@@ -76,7 +82,7 @@ export const parseQuestionResult = (
 
       const image = answer ? multilocs.answer[answer].image : undefined;
       const percentage =
-        result.inputType === 'multiselect'
+        inputType === 'multiselect'
           ? roundPercentage(count, totalResponseCount, 1)
           : roundPercentage(count, totalPickCount, 1);
 


### PR DESCRIPTION
Changes percentage calculation for multi-select question results to be a percentage of total responses (`totalResponseCount`), per option, rather than percentage of total options selected (`totalPickCount`).

<img width="601" alt="Screenshot 2025-06-06 at 15 04 33" src="https://github.com/user-attachments/assets/2a9c5ac7-9434-4e1d-9b3f-f87c1fb0bff0" />

# Changelog
## Fixed
- [TAN-4052] Calculate correct percentages for multi-select question survey results
