### PR TITLE
Add test to confirm that nullify works

### DIFF
--- a/back/engines/commercial/impact_tracking/spec/models/pageview_spec.rb
+++ b/back/engines/commercial/impact_tracking/spec/models/pageview_spec.rb
@@ -8,4 +8,17 @@ RSpec.describe ImpactTracking::Pageview do
   describe 'Default factory' do
     it { is_expected.to be_valid }
   end
+
+  describe 'Relations' do
+    it 'nullifies project_id if project is deleted' do
+      project = create(:project)
+      pageview = create(:pageview, project_id: project.id)
+
+      expect(pageview.project_id).to eq(project.id)
+
+      project.destroy
+
+      expect(pageview.reload.project_id).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
# Changelog
## Technical
- Add test to confirm that project id in pageviews table gets nullified when project gets deleted
