### PR TITLE
Matrix field in surveys: mobile usability

### DIFF
--- a/front/app/components/Form/Components/Controls/MatrixControl.tsx
+++ b/front/app/components/Form/Components/Controls/MatrixControl.tsx
@@ -153,24 +153,26 @@ const MatrixControl = ({
           aria-labelledby={`matrix-question-label-${id}`}
         >
           <Thead>
-            <Td minWidth="84px" pt="0px" />
-            {columnsFromSchema.map((column, index) => {
-              return (
-                <Th minWidth="84px" key={index} scope="col" pt="0px">
-                  <Box title={column} display="flex" justifyContent="center">
-                    <Text
-                      textAlign="center"
-                      m="0px"
-                      p="0px"
-                      mx="auto"
-                      color={'tenantPrimary'}
-                    >
-                      {column}
-                    </Text>
-                  </Box>
-                </Th>
-              );
-            })}
+            <Tr>
+              <Th minWidth="84px" pt="0px" />
+              {columnsFromSchema.map((column, index) => {
+                return (
+                  <Th minWidth="84px" key={index} scope="col" pt="0px">
+                    <Box title={column} display="flex" justifyContent="center">
+                      <Text
+                        textAlign="center"
+                        m="0px"
+                        p="0px"
+                        mx="auto"
+                        color={'tenantPrimary'}
+                      >
+                        {column}
+                      </Text>
+                    </Box>
+                  </Th>
+                );
+              })}
+            </Tr>
           </Thead>
           <Tbody>
             {statements.map((statement, index) => {

--- a/front/app/components/Form/Components/Controls/MatrixControl.tsx
+++ b/front/app/components/Form/Components/Controls/MatrixControl.tsx
@@ -28,38 +28,40 @@ import ErrorDisplay from '../ErrorDisplay';
 import { getSubtextElement } from './controlUtils';
 import messages from './messages';
 
-const StickyTh = styled(Th)`
+const StickyTh = styled(Th)<{ hasLongContent: boolean }>`
   background: ${(props) =>
     RGBAtoRGB(props.theme.colors.tenantPrimaryLighten95, 0.05)};
-
   position: sticky;
   inset-inline-start: 0px;
   z-index: 1;
-  flex-grow: 1;
 
+  overflow-wrap: break-word;
+  hyphens: auto;
+
+  min-width: 200px;
+  max-width: 40vw;
+
+  // 200px is too much for phones, so we need something responsive for small screens.
   ${media.phone`
-    min-width: 120px;
-    `}
-
-  ${media.tablet`
-    min-width: 180px;
-    `}
-
-  ${media.desktop`
-      min-width: 200px;
-    `}
+    min-width: ${({ hasLongContent }) =>
+      // 40vw would be too wide on small screens for short labels such as "yes" or "no"
+      hasLongContent ? '40vw' : 'fit-content'};
+  `}
 `;
 
 const StyledTd = styled(Td)`
   background: ${(props) =>
     RGBAtoRGB(props.theme.colors.tenantPrimaryLighten95, 0.05)};
-  max-width: 100px;
+  // This min-width also ensures that the th elements have the same min-width.
+  min-width: 84px;
 
   .circle {
     margin-right: 0px;
     border: 1px solid ${(props) => props.theme.colors.tenantPrimary};
   }
 `;
+
+const LONG_LABEL_THRESHOLD = 10; // Threshold for long labels, used to apply specific styling
 
 const MatrixControl = ({
   data,
@@ -154,21 +156,19 @@ const MatrixControl = ({
         >
           <Thead>
             <Tr>
-              <Th minWidth="84px" pt="0px" />
+              <Th pt="0px" />
               {columnsFromSchema.map((column, index) => {
                 return (
-                  <Th minWidth="84px" key={index} scope="col" pt="0px">
-                    <Box title={column} display="flex" justifyContent="center">
-                      <Text
-                        textAlign="center"
-                        m="0px"
-                        p="0px"
-                        mx="auto"
-                        color={'tenantPrimary'}
-                      >
-                        {column}
-                      </Text>
-                    </Box>
+                  <Th key={index} scope="col" pt="0px">
+                    <Text
+                      textAlign="center"
+                      m="0px"
+                      p="0px"
+                      mx="auto"
+                      color="tenantPrimary"
+                    >
+                      {column}
+                    </Text>
                   </Th>
                 );
               })}
@@ -178,7 +178,12 @@ const MatrixControl = ({
             {statements.map((statement, index) => {
               return (
                 <Tr key={index}>
-                  <StickyTh scope="row">
+                  <StickyTh
+                    scope="row"
+                    hasLongContent={
+                      statement?.label.length > LONG_LABEL_THRESHOLD
+                    }
+                  >
                     <Text m="4px" color="tenantPrimary">
                       {statement?.label}
                     </Text>
@@ -187,11 +192,7 @@ const MatrixControl = ({
                   {columnsFromSchema.map((_, columnIndex) => {
                     return (
                       <StyledTd key={`radio-${columnIndex}-${index}`}>
-                        <Box
-                          min-width="84px"
-                          display="flex"
-                          justifyContent="center"
-                        >
+                        <Box display="flex" justifyContent="center">
                           <Radio
                             mx="auto"
                             onKeyDown={(e) => {


### PR DESCRIPTION
See [ticket](https://www.notion.so/govocal/Survey-matrix-questions-are-unreasonable-on-mobile-to-an-almost-un-useable-point-2089663b7b26803b8b23cc4a2cd6ad77?source=copy_link) (comments) for before/after screenshots.

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Input and survey forms on mobile: ensure the matrix field is usable and its x-axis labels (rows) look reasonable regardless of length.