### PR TITLE
[TAN-4791] Permit visitors to see appropriate survey custom_fields

### DIFF
--- a/back/app/policies/phase_policy.rb
+++ b/back/app/policies/phase_policy.rb
@@ -21,9 +21,11 @@ class PhasePolicy < ApplicationPolicy
       user
     ).denied_reason_for_action 'posting_idea'
 
+    puts "PhasePolicy#show? - reason: #{reason}" if reason
+
     raise_not_authorized(reason) if reason
 
-    false
+    true
   end
 
   def update?

--- a/back/app/policies/phase_policy.rb
+++ b/back/app/policies/phase_policy.rb
@@ -17,9 +17,9 @@ class PhasePolicy < ApplicationPolicy
     return policy_for(record.project).show? unless participation_method == 'native_survey'
 
     reason = Permissions::ProjectPermissionsService.new(
-        record.project,
-        user
-      ).denied_reason_for_action 'posting_idea'
+      record.project,
+      user
+    ).denied_reason_for_action 'posting_idea'
 
     raise_not_authorized(reason) if reason
 

--- a/back/app/policies/phase_policy.rb
+++ b/back/app/policies/phase_policy.rb
@@ -16,14 +16,10 @@ class PhasePolicy < ApplicationPolicy
 
     return policy_for(record.project).show? unless participation_method == 'native_survey' && (user.nil? || user.normal_user?)
 
-    puts 'HERE!!'
-
     reason = Permissions::ProjectPermissionsService.new(
       record.project,
       user
     ).denied_reason_for_action 'posting_idea'
-
-    puts "Reason for not authorized: #{reason}" if reason
 
     raise_not_authorized(reason) if reason
 

--- a/back/app/policies/phase_policy.rb
+++ b/back/app/policies/phase_policy.rb
@@ -12,7 +12,18 @@ class PhasePolicy < ApplicationPolicy
   end
 
   def show?
-    policy_for(record.project).show?
+    participation_method = record.participation_method
+
+    return policy_for(record.project).show? unless participation_method == 'native_survey'
+
+    reason = Permissions::ProjectPermissionsService.new(
+        record.project,
+        user
+      ).denied_reason_for_action 'posting_idea'
+
+    raise_not_authorized(reason) if reason
+
+    true
   end
 
   def update?

--- a/back/app/policies/phase_policy.rb
+++ b/back/app/policies/phase_policy.rb
@@ -21,8 +21,6 @@ class PhasePolicy < ApplicationPolicy
       user
     ).denied_reason_for_action 'posting_idea'
 
-    puts "PhasePolicy#show? - reason: #{reason}" if reason
-
     raise_not_authorized(reason) if reason
 
     true

--- a/back/app/policies/phase_policy.rb
+++ b/back/app/policies/phase_policy.rb
@@ -43,7 +43,7 @@ class PhasePolicy < ApplicationPolicy
   end
 
   def submission_count?
-    return policy_for(record.project).show?
+    policy_for(record.project).show?
   end
 
   def index_xlsx?

--- a/back/app/policies/phase_policy.rb
+++ b/back/app/policies/phase_policy.rb
@@ -47,7 +47,7 @@ class PhasePolicy < ApplicationPolicy
   end
 
   def submission_count?
-    show?
+    return policy_for(record.project).show?
   end
 
   def index_xlsx?

--- a/back/app/policies/phase_policy.rb
+++ b/back/app/policies/phase_policy.rb
@@ -14,12 +14,16 @@ class PhasePolicy < ApplicationPolicy
   def show?
     participation_method = record.participation_method
 
-    return policy_for(record.project).show? unless participation_method == 'native_survey'
+    return policy_for(record.project).show? unless participation_method == 'native_survey' && (user.nil? || user.normal_user?)
+
+    puts 'HERE!!'
 
     reason = Permissions::ProjectPermissionsService.new(
       record.project,
       user
     ).denied_reason_for_action 'posting_idea'
+
+    puts "Reason for not authorized: #{reason}" if reason
 
     raise_not_authorized(reason) if reason
 

--- a/back/app/policies/phase_policy.rb
+++ b/back/app/policies/phase_policy.rb
@@ -23,7 +23,7 @@ class PhasePolicy < ApplicationPolicy
 
     raise_not_authorized(reason) if reason
 
-    true
+    false
   end
 
   def update?

--- a/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
+++ b/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
@@ -40,11 +40,9 @@ module IdeaCustomFields
       fields = if params[:copy] == 'true'
         service.duplicate_all_fields
       elsif @custom_form.custom_field_ids.present?
-        puts "HERE 1"
         authorized_ids = IdeaCustomFieldPolicy::Scope.new(pundit_user, @custom_form.custom_fields, @custom_form).resolve.ids
         service.all_fields.select { |field| authorized_ids.include? field.id }
       else
-        puts "HERE 2"
         service.all_fields.select { |field| IdeaCustomFieldPolicy.new(current_user, field).show? }
       end
       fields = fields.filter(&:support_free_text_value?) if params[:support_free_text_value].present?

--- a/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
+++ b/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
@@ -23,6 +23,7 @@ module IdeaCustomFields
       }
     }
 
+    skip_before_action :authenticate_user, only: %i[index]
     before_action :set_custom_field, only: %i[show as_geojson]
     before_action :set_custom_form, only: %i[index update_all]
     skip_after_action :verify_policy_scoped

--- a/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
+++ b/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
@@ -40,9 +40,11 @@ module IdeaCustomFields
       fields = if params[:copy] == 'true'
         service.duplicate_all_fields
       elsif @custom_form.custom_field_ids.present?
+        puts "HERE 1"
         authorized_ids = IdeaCustomFieldPolicy::Scope.new(pundit_user, @custom_form.custom_fields, @custom_form).resolve.ids
         service.all_fields.select { |field| authorized_ids.include? field.id }
       else
+        puts "HERE 2"
         service.all_fields.select { |field| IdeaCustomFieldPolicy.new(current_user, field).show? }
       end
       fields = fields.filter(&:support_free_text_value?) if params[:support_free_text_value].present?

--- a/back/engines/commercial/idea_custom_fields/app/policies/idea_custom_fields/idea_custom_field_policy.rb
+++ b/back/engines/commercial/idea_custom_fields/app/policies/idea_custom_fields/idea_custom_field_policy.rb
@@ -7,6 +7,7 @@ module IdeaCustomFields
     end
 
     def show?
+      puts 'HERE 1'
       return super && can_access_custom_fields?(record) if user && !user.normal_user?
 
       false # Empty list if no project, as in case of unsaved native survey form (TODO: Maybe make this not authorized?)

--- a/back/engines/commercial/idea_custom_fields/app/policies/idea_custom_fields/idea_custom_field_policy.rb
+++ b/back/engines/commercial/idea_custom_fields/app/policies/idea_custom_fields/idea_custom_field_policy.rb
@@ -7,8 +7,7 @@ module IdeaCustomFields
     end
 
     def show?
-      puts 'HERE 1'
-      return super && can_access_custom_fields?(record) if user && !user.normal_user?
+      return super && can_access_custom_fields?(record) if (user && !user.normal_user?) || record&.resource&.participation_context_type == 'Project'
 
       false # Empty list if no project, as in case of unsaved native survey form (TODO: Maybe make this not authorized?)
     end

--- a/back/engines/commercial/idea_custom_fields/app/policies/idea_custom_fields/idea_custom_field_policy.rb
+++ b/back/engines/commercial/idea_custom_fields/app/policies/idea_custom_fields/idea_custom_field_policy.rb
@@ -7,7 +7,7 @@ module IdeaCustomFields
     end
 
     def show?
-      super && can_access_custom_fields?(record) if user && !user.normal_user?
+      return super && can_access_custom_fields?(record) if user && !user.normal_user?
 
       false # Empty list if no project, as in case of unsaved native survey form (TODO: Maybe make this not authorized?)
     end

--- a/back/engines/commercial/idea_custom_fields/app/policies/idea_custom_fields/idea_custom_field_policy.rb
+++ b/back/engines/commercial/idea_custom_fields/app/policies/idea_custom_fields/idea_custom_field_policy.rb
@@ -7,7 +7,9 @@ module IdeaCustomFields
     end
 
     def show?
-      super && can_access_custom_fields?(record)
+      super && can_access_custom_fields?(record) if user && !user.normal_user?
+
+      false # Empty list if no project, as in case of unsaved native survey form (TODO: Maybe make this not authorized?)
     end
 
     def update_all?

--- a/back/engines/commercial/idea_custom_fields/spec/policies/idea_custom_field_policy_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/policies/idea_custom_field_policy_spec.rb
@@ -6,19 +6,14 @@ describe IdeaCustomFields::IdeaCustomFieldPolicy do
   subject(:policy) { described_class.new(user, idea_custom_field) }
 
   let(:custom_form) { create(:custom_form) }
-  let!(:phase) { create(:phase, start_at: 1.month.ago, end_at: 1.month.from_now) }
-  let!(:_permission) { create(:permission, action: 'posting_idea', permission_scope: phase) }
-  let!(:project) { create(:project, custom_form: custom_form, phases: [phase]) }
+  let!(:project) { create(:project, custom_form: custom_form) }
   let!(:idea_custom_field) { create(:custom_field, resource: custom_form) }
 
   context 'for a normal user who can access the project' do
     let(:user) { create(:user) }
 
     it { is_expected.to permit(:index) }
-    it do
-      pp project.phases
-      is_expected.to permit(:show)
-    end
+    it { is_expected.to permit(:show) }
     it { is_expected.not_to permit(:update_all) }
   end
 

--- a/back/engines/commercial/idea_custom_fields/spec/policies/idea_custom_field_policy_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/policies/idea_custom_field_policy_spec.rb
@@ -6,14 +6,19 @@ describe IdeaCustomFields::IdeaCustomFieldPolicy do
   subject(:policy) { described_class.new(user, idea_custom_field) }
 
   let(:custom_form) { create(:custom_form) }
-  let!(:project) { create(:project, custom_form: custom_form) }
+  let!(:phase) { create(:phase, start_at: 1.month.ago, end_at: 1.month.from_now) }
+  let!(:_permission) { create(:permission, action: 'posting_idea', permission_scope: phase) }
+  let!(:project) { create(:project, custom_form: custom_form, phases: [phase]) }
   let!(:idea_custom_field) { create(:custom_field, resource: custom_form) }
 
   context 'for a normal user who can access the project' do
     let(:user) { create(:user) }
 
     it { is_expected.to permit(:index) }
-    it { is_expected.to permit(:show) }
+    it do
+      pp project.phases
+      is_expected.to permit(:show)
+    end
     it { is_expected.not_to permit(:update_all) }
   end
 

--- a/back/spec/acceptance/custom_forms_spec.rb
+++ b/back/spec/acceptance/custom_forms_spec.rb
@@ -104,9 +104,10 @@ resource 'Custom Forms' do
     before { header_token_for create(:user) }
 
     context 'phase level forms' do
-      let(:context) { create(:native_survey_phase) }
+      let(:context) { create(:native_survey_phase, start_at: 1.month.ago, end_at: 1.month.from_now) }
       let!(:form) { create(:custom_form, participation_context: context) }
       let(:phase_id) { context.id }
+      let(:_permission) { create(:permission, action: 'posting_idea', permission_scope: context) }
 
       get 'web_api/v1/phases/:phase_id/custom_form' do
         example_request 'Returns the custom form for a phase' do


### PR DESCRIPTION
Trying to sort out the policy for front-office `custom_fields` for survey form (the questions) for regular user/visitor.

I really don't like the spaghetti code here, and feel like this highlights some fundamental issues with our current custom_fields setup, though I'm not sure exactly what/how to improve. See my vague noodlings on this here: https://www.notion.so/govocal/Custom-fields-for-non-admin-like-2129663b7b2680179368c5b565085a68

No tests yet, though we certainly will need some, as I'd like to discuss this fully (with BE dev(s)) before committing to a particular solution.

# Changelog
- [TAN-4791] Permit visitors to see appropriate survey custom_fields
