### PR TITLE
A11y: clarify aria-label of event card "Read more" button

### DIFF
--- a/front/app/components/EventCards/EventInformation/index.tsx
+++ b/front/app/components/EventCards/EventInformation/index.tsx
@@ -231,7 +231,9 @@ const EventInformation = ({ event }: Props) => {
             // for multiple links/buttons is not accessible because it doesn't convey
             // the unique purpose of each link. Screen readers will not differentiate
             // between the links, making it difficult for users to navigate.
-            ariaLabel={localize(event.attributes.title_multiloc)}
+            ariaLabel={formatMessage(messages.a11y_readMore, {
+              eventTitle: localize(event.attributes.title_multiloc),
+            })}
           >
             {formatMessage(messages.readMore)}
           </ButtonWithLink>

--- a/front/app/components/EventCards/messages.ts
+++ b/front/app/components/EventCards/messages.ts
@@ -29,6 +29,10 @@ export default defineMessages({
     id: 'app.components.EventCard.readMore',
     defaultMessage: 'Read more',
   },
+  a11y_readMore: {
+    id: 'app.components.EventCard.a11y_readMore',
+    defaultMessage: 'Read more about the "{eventTitle}" event.',
+  },
   attending: {
     id: 'app.containers.EventsShow.attending',
     defaultMessage: 'attending',

--- a/front/app/translations/en.json
+++ b/front/app/translations/en.json
@@ -166,6 +166,7 @@
   "app.components.EventAttendanceButton.seeYouThereName": "See you there, {userFirstName}!",
   "app.components.EventCard.a11y_lessContentVisible": "Less event information became visible.",
   "app.components.EventCard.a11y_moreContentVisible": "More event information became visible.",
+  "app.components.EventCard.a11y_readMore": "Read more about the \"{eventTitle}\" event.",
   "app.components.EventCard.endsAt": "Ends at",
   "app.components.EventCard.readMore": "Read more",
   "app.components.EventCard.showLess": "Show less",


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->
