### PR TITLE
[TAN-4520] Add tie-breaking logic to the top consensus ideas ranking

### DIFF
--- a/back/app/services/common_ground/results_service.rb
+++ b/back/app/services/common_ground/results_service.rb
@@ -19,11 +19,13 @@ module CommonGround
     private
 
     def top_consensus_ideas(n, reverse: false)
-      order_sql = Arel.sql('greatest(likes_count, dislikes_count) * 1.0 / (likes_count + dislikes_count)')
+      consensus_score_sql = Arel.sql('greatest(likes_count, dislikes_count) * 1.0 / (likes_count + dislikes_count)')
+      # The votes counts (excluding neutral votes) are used to break ties.
+      votes_count_sql = Arel.sql('(likes_count + dislikes_count)')
 
       ideas
         .where('likes_count + dislikes_count > 0')
-        .order(reverse ? order_sql.asc : order_sql.desc)
+        .order(reverse ? consensus_score_sql.asc : consensus_score_sql.desc, votes_count_sql.desc)
         .limit(n)
     end
 

--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -1432,7 +1432,7 @@
       "common_ground": {
         "type": "object",
         "title": "Common ground",
-        "description": "New participation method that is currently under development. [DO NOT ENABLE]",
+        "description": "Common Ground is a participation method that lets participants post and react to concise statements using a swipe style: agree, disagree, or unsure. Statements are then ranked by consensus and controversy.",
         "additionalProperties": false,
         "required": ["allowed", "enabled"],
         "properties": {

--- a/back/spec/services/common_ground/results_service_spec.rb
+++ b/back/spec/services/common_ground/results_service_spec.rb
@@ -92,6 +92,18 @@ describe CommonGround::ResultsService do
         expect(results.top_consensus_ideas).to eq [idea1, idea2]
       end
 
+      context 'when there are ties in consensus scores' do
+        let!(:idea5) do
+          idea = create(:idea, project: phase.project, phases: [phase])
+          create_list(:reaction, 5, reactable: idea, mode: 'up')
+          idea
+        end
+
+        it 'returns the idea with the highest number of votes first' do
+          expect(results.top_consensus_ideas).to eq [idea5, idea1]
+        end
+      end
+
       it 'returns top controversial ideas ordered by consensus score (lowest first)' do
         expect(results.top_controversial_ideas).to eq [idea3, idea2]
       end


### PR DESCRIPTION
# Changelog
## Added
- [TAN-4520] Add tie-breaking logic to the top consensus statement ranking in Common Ground. The total number of votes (likes + dislikes, i.e., excluding "unsure" votes) is used to break ties between statements with the same consensus scores.


