### PR TITLE
Form status

### DIFF
--- a/front/app/components/FormBuilder/components/FormStatus/index.tsx
+++ b/front/app/components/FormBuilder/components/FormStatus/index.tsx
@@ -18,7 +18,7 @@ import messages from './messages';
 type FormStatusProps = {
   successMessageIsVisible: boolean;
   isSubmitting: boolean;
-  closeSuccessMessage: () => void;
+  setSuccessMessageIsVisible: (visible: boolean) => void;
   builderConfig: FormBuilderConfig;
   projectId: string;
   phaseId: string;
@@ -27,7 +27,7 @@ type FormStatusProps = {
 const FormStatus = ({
   successMessageIsVisible,
   isSubmitting,
-  closeSuccessMessage,
+  setSuccessMessageIsVisible,
   builderConfig: {
     formSavedSuccessMessage,
     getWarningNotice,
@@ -105,7 +105,7 @@ const FormStatus = ({
       {showSuccessMessage && (
         <SuccessFeedback
           successMessage={formatMessage(formSavedSuccessMessage)}
-          closeSuccessMessage={closeSuccessMessage}
+          closeSuccessMessage={() => setSuccessMessageIsVisible(false)}
         />
       )}
       {showWarnings()}

--- a/front/app/components/FormBuilder/components/FormStatus/index.tsx
+++ b/front/app/components/FormBuilder/components/FormStatus/index.tsx
@@ -1,0 +1,116 @@
+import React, { useState } from 'react';
+
+import { Box } from '@citizenlab/cl2-component-library';
+import { useFormContext } from 'react-hook-form';
+
+import useFormSubmissionCount from 'api/submission_count/useSubmissionCount';
+
+import { FormBuilderConfig } from 'components/FormBuilder/utils';
+import Feedback from 'components/HookForm/Feedback';
+import SuccessFeedback from 'components/HookForm/Feedback/SuccessFeedback';
+import Error from 'components/UI/Error';
+import Warning from 'components/UI/Warning';
+
+import { useIntl } from 'utils/cl-intl';
+
+import messages from './messages';
+
+type FormStatusProps = {
+  successMessageIsVisible: boolean;
+  isSubmitting: boolean;
+  closeSuccessMessage: () => void;
+  builderConfig: FormBuilderConfig;
+  projectId: string;
+  phaseId: string;
+};
+
+const FormStatus = ({
+  successMessageIsVisible,
+  isSubmitting,
+  closeSuccessMessage,
+  builderConfig: {
+    formSavedSuccessMessage,
+    getWarningNotice,
+    getAccessRightsNotice,
+  },
+  projectId,
+  phaseId,
+}: FormStatusProps) => {
+  const { data: submissionCount } = useFormSubmissionCount({
+    phaseId,
+  });
+  const { formatMessage } = useIntl();
+  const [accessRightsMessageIsVisible, setAccessRightsMessageIsVisible] =
+    useState(true);
+  const {
+    formState: { errors, isDirty },
+  } = useFormContext();
+
+  const handleAccessRightsClose = () => setAccessRightsMessageIsVisible(false);
+
+  if (!submissionCount) {
+    return null;
+  }
+
+  const hasErrors = !!Object.keys(errors).length;
+  const editedAndCorrect = !isSubmitting && isDirty && !hasErrors;
+  const showSuccessMessage =
+    successMessageIsVisible &&
+    !editedAndCorrect &&
+    Object.keys(errors).length === 0;
+  const totalSubmissions = submissionCount.data.attributes.totalSubmissions;
+  const showWarningNotice = totalSubmissions > 0;
+
+  const showWarnings = () => {
+    if (editedAndCorrect) {
+      return (
+        <Box mb="8px">
+          <Warning>{formatMessage(messages.unsavedChanges)}</Warning>
+        </Box>
+      );
+    } else if (showWarningNotice && getWarningNotice) {
+      return getWarningNotice();
+    } else if (
+      !hasErrors &&
+      !successMessageIsVisible &&
+      getAccessRightsNotice &&
+      accessRightsMessageIsVisible
+    ) {
+      return getAccessRightsNotice(projectId, phaseId, handleAccessRightsClose);
+    }
+    return null;
+  };
+
+  return (
+    <>
+      {hasErrors && (
+        <Box mb="16px">
+          <Error
+            marginTop="8px"
+            marginBottom="8px"
+            text={formatMessage(
+              errors['staleData']
+                ? messages.staleDataErrorMessage
+                : messages.errorMessage
+            )}
+            scrollIntoView={false}
+          />
+        </Box>
+      )}
+
+      <Feedback
+        successMessage={formatMessage(formSavedSuccessMessage)}
+        onlyShowErrors
+      />
+      {showSuccessMessage && (
+        <SuccessFeedback
+          successMessage={formatMessage(formSavedSuccessMessage)}
+          closeSuccessMessage={closeSuccessMessage}
+        />
+      )}
+      {showWarnings()}
+    </>
+  );
+};
+
+export default FormStatus;

--- a/front/app/components/FormBuilder/components/FormStatus/messages.ts
+++ b/front/app/components/FormBuilder/components/FormStatus/messages.ts
@@ -1,0 +1,18 @@
+import { defineMessages } from 'react-intl';
+
+export default defineMessages({
+  errorMessage: {
+    id: 'app.components.formBuilder.errorMessage',
+    defaultMessage:
+      'There is a problem, please fix the issue to be able to save your changes',
+  },
+  staleDataErrorMessage: {
+    id: 'app.components.formBuilder.staleDataErrorMessage2',
+    defaultMessage:
+      'There has been a problem. This input form has been saved more recently somewhere else. This may be because you or another user has it open for editing in another browser window. Please refresh the page to get the latest form and then make your changes again.',
+  },
+  unsavedChanges: {
+    id: 'app.components.formBuilder.unsavedChanges',
+    defaultMessage: 'You have unsaved changes',
+  },
+});

--- a/front/app/components/FormBuilder/edit/index.tsx
+++ b/front/app/components/FormBuilder/edit/index.tsx
@@ -32,10 +32,6 @@ import FormBuilderToolbox from 'components/FormBuilder/components/FormBuilderToo
 import FormBuilderTopBar from 'components/FormBuilder/components/FormBuilderTopBar';
 import FormFields from 'components/FormBuilder/components/FormFields';
 import HelmetIntl from 'components/HelmetIntl';
-import Feedback from 'components/HookForm/Feedback';
-import SuccessFeedback from 'components/HookForm/Feedback/SuccessFeedback';
-import Error from 'components/UI/Error';
-import Warning from 'components/UI/Warning';
 
 import { useIntl } from 'utils/cl-intl';
 import { handleHookFormSubmissionError } from 'utils/errorUtils';
@@ -45,6 +41,7 @@ import validateLogic from 'utils/yup/validateLogic';
 import validateOneOptionForMultiSelect from 'utils/yup/validateOneOptionForMultiSelect';
 import validateOneStatementForMatrix from 'utils/yup/validateOneStatementForMatrix';
 
+import FormStatus from '../components/FormStatus';
 import messages from '../messages';
 import { FormBuilderConfig } from '../utils';
 
@@ -84,12 +81,9 @@ const FormEdit = ({
     IFlatCustomFieldWithIndex | undefined
   >(undefined);
   const [successMessageIsVisible, setSuccessMessageIsVisible] = useState(false);
-  const [accessRightsMessageIsVisible, setAccessRightsMessageIsVisible] =
-    useState(true);
   const [autosaveEnabled, setAutosaveEnabled] = useState(true);
-  const { formSavedSuccessMessage, isFormPhaseSpecific } = builderConfig;
+  const { isFormPhaseSpecific } = builderConfig;
   const { mutateAsync: updateFormCustomFields } = useUpdateCustomField();
-  const showWarningNotice = totalSubmissions > 0;
   const { data: formCustomFields, isFetching } = useFormCustomFields({
     projectId,
     phaseId: isFormPhaseSpecific ? phaseId : undefined,
@@ -153,7 +147,7 @@ const FormEdit = ({
     setError,
     handleSubmit,
     control,
-    formState: { errors, isDirty },
+    formState: { isDirty },
     getValues,
     reset,
   } = methods;
@@ -217,9 +211,6 @@ const FormEdit = ({
       setSelectedField(newField);
     }
   };
-
-  const hasErrors = !!Object.keys(errors).length;
-  const editedAndCorrect = !isSubmitting && isDirty && !hasErrors;
 
   const onFormSubmit = async ({ customFields }: FormValues) => {
     setSuccessMessageIsVisible(false);
@@ -376,36 +367,6 @@ const FormEdit = ({
   };
 
   const closeSuccessMessage = () => setSuccessMessageIsVisible(false);
-  const showSuccessMessage =
-    successMessageIsVisible &&
-    !editedAndCorrect &&
-    Object.keys(errors).length === 0;
-
-  const handleAccessRightsClose = () => setAccessRightsMessageIsVisible(false);
-
-  const showWarnings = () => {
-    if (editedAndCorrect) {
-      return (
-        <Box mb="8px">
-          <Warning>{formatMessage(messages.unsavedChanges)}</Warning>
-        </Box>
-      );
-    } else if (showWarningNotice && builderConfig.getWarningNotice) {
-      return builderConfig.getWarningNotice();
-    } else if (
-      !hasErrors &&
-      !successMessageIsVisible &&
-      builderConfig.getAccessRightsNotice &&
-      accessRightsMessageIsVisible
-    ) {
-      return builderConfig.getAccessRightsNotice(
-        projectId,
-        phaseId,
-        handleAccessRightsClose
-      );
-    }
-    return null;
-  };
 
   return (
     <Box
@@ -451,32 +412,14 @@ const FormEdit = ({
                 px="30px"
               >
                 <Box mt="16px">
-                  {hasErrors && (
-                    <Box mb="16px">
-                      <Error
-                        marginTop="8px"
-                        marginBottom="8px"
-                        text={formatMessage(
-                          errors['staleData']
-                            ? messages.staleDataErrorMessage
-                            : messages.errorMessage
-                        )}
-                        scrollIntoView={false}
-                      />
-                    </Box>
-                  )}
-
-                  <Feedback
-                    successMessage={formatMessage(formSavedSuccessMessage)}
-                    onlyShowErrors
+                  <FormStatus
+                    successMessageIsVisible={successMessageIsVisible}
+                    isSubmitting={isSubmitting}
+                    closeSuccessMessage={closeSuccessMessage}
+                    builderConfig={builderConfig}
+                    projectId={projectId}
+                    phaseId={phaseId}
                   />
-                  {showSuccessMessage && (
-                    <SuccessFeedback
-                      successMessage={formatMessage(formSavedSuccessMessage)}
-                      closeSuccessMessage={closeSuccessMessage}
-                    />
-                  )}
-                  {showWarnings()}
                   <FormFields
                     onEditField={setSelectedField}
                     selectedFieldId={selectedField?.id}

--- a/front/app/components/FormBuilder/edit/index.tsx
+++ b/front/app/components/FormBuilder/edit/index.tsx
@@ -366,8 +366,6 @@ const FormEdit = ({
     }
   };
 
-  const closeSuccessMessage = () => setSuccessMessageIsVisible(false);
-
   return (
     <Box
       display="flex"
@@ -414,8 +412,8 @@ const FormEdit = ({
                 <Box mt="16px">
                   <FormStatus
                     successMessageIsVisible={successMessageIsVisible}
+                    setSuccessMessageIsVisible={setSuccessMessageIsVisible}
                     isSubmitting={isSubmitting}
-                    closeSuccessMessage={closeSuccessMessage}
                     builderConfig={builderConfig}
                     projectId={projectId}
                     phaseId={phaseId}

--- a/front/app/components/FormBuilder/messages.ts
+++ b/front/app/components/FormBuilder/messages.ts
@@ -5,16 +5,7 @@ export default defineMessages({
     id: 'app.components.formBuilder.emptyTitleError',
     defaultMessage: 'Provide a question title',
   },
-  errorMessage: {
-    id: 'app.components.formBuilder.errorMessage',
-    defaultMessage:
-      'There is a problem, please fix the issue to be able to save your changes',
-  },
-  staleDataErrorMessage: {
-    id: 'app.components.formBuilder.staleDataErrorMessage2',
-    defaultMessage:
-      'There has been a problem. This input form has been saved more recently somewhere else. This may be because you or another user has it open for editing in another browser window. Please refresh the page to get the latest form and then make your changes again.',
-  },
+
   emptyOptionError: {
     id: 'app.components.formBuilder.emptyOptionError',
     defaultMessage: 'Provide at least 1 answer',
@@ -47,9 +38,5 @@ export default defineMessages({
   helmetTitle: {
     id: 'app.components.formBuilder.helmetTitle',
     defaultMessage: 'Form builder',
-  },
-  unsavedChanges: {
-    id: 'app.components.formBuilder.unsavedChanges',
-    defaultMessage: 'You have unsaved changes',
   },
 });


### PR DESCRIPTION
This is one of many steps needed to make the form builder performant. Moved down form state related to form status (`errors` and `isDirty`) one level, so that--after more refactoring in the future--we won't trigger a re-render of the whole form builder for each keystroke in child components.  

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->
