### PR TITLE
[TAN-4745] Add event metadata to header for use when sharing

### DIFF
--- a/front/app/containers/EventsShowPage/components/EventShowPageMeta.tsx
+++ b/front/app/containers/EventsShowPage/components/EventShowPageMeta.tsx
@@ -29,7 +29,7 @@ const EventShowPageMeta = ({ event }: Props) => {
   if (!tenantLocales) return null;
 
   const metaTitle = formatMessage(messages.metaTitle1, {
-    projectTitle: localize(event.attributes.title_multiloc, {
+    eventTitle: localize(event.attributes.title_multiloc, {
       maxChar: 50,
     }),
   });

--- a/front/app/containers/EventsShowPage/components/EventShowPageMeta.tsx
+++ b/front/app/containers/EventsShowPage/components/EventShowPageMeta.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+
+import { Helmet } from 'react-helmet-async';
+
+import { IEventData } from 'api/events/types';
+import useEventImage from 'api/event_images/useEventImage';
+
+import useAppConfigurationLocales from 'hooks/useAppConfigurationLocales';
+import useLocalize from 'hooks/useLocalize';
+
+import messages from '../messages';
+
+import { useIntl } from 'utils/cl-intl';
+import getAlternateLinks from 'utils/cl-router/getAlternateLinks';
+import getCanonicalLink from 'utils/cl-router/getCanonicalLink';
+import { imageSizes } from 'utils/fileUtils';
+import { stripHtml } from 'utils/textUtils';
+
+interface Props {
+  event: IEventData;
+}
+
+const EventShowPageMeta = ({ event }: Props) => {
+  const { formatMessage } = useIntl();
+  const localize = useLocalize();
+  const tenantLocales = useAppConfigurationLocales();
+  const { data: eventImage } = useEventImage(event);
+
+  if (!tenantLocales) return null;
+
+  const metaTitle = formatMessage(messages.metaTitle1, {
+    projectTitle: localize(event.attributes.title_multiloc, {
+      maxChar: 50,
+    }),
+  });
+  const description = stripHtml(
+    localize(event.attributes.description_multiloc),
+    250
+  );
+  const image = eventImage?.data?.attributes?.versions?.large;
+  const { location } = window;
+
+  return (
+    <Helmet>
+      <title>{metaTitle}</title>
+      {getCanonicalLink()}
+      {getAlternateLinks(tenantLocales)}
+      <meta name="title" content={metaTitle} />
+      <meta name="description" content={description} />
+      <meta property="og:title" content={metaTitle} />
+      <meta property="og:description" content={description} />
+      {image && <meta property="og:image" content={image} />}
+      <meta
+        property="og:image:width"
+        content={`${imageSizes.projectBg.large[0]}`}
+      />
+      <meta
+        property="og:image:height"
+        content={`${imageSizes.projectBg.large[1]}`}
+      />
+      <meta property="og:url" content={location.href} />
+      <meta name="twitter:card" content="summary_large_image" />
+    </Helmet>
+  );
+};
+
+export default EventShowPageMeta;

--- a/front/app/containers/EventsShowPage/components/EventShowPageMeta.tsx
+++ b/front/app/containers/EventsShowPage/components/EventShowPageMeta.tsx
@@ -2,19 +2,19 @@ import React from 'react';
 
 import { Helmet } from 'react-helmet-async';
 
-import { IEventData } from 'api/events/types';
 import useEventImage from 'api/event_images/useEventImage';
+import { IEventData } from 'api/events/types';
 
 import useAppConfigurationLocales from 'hooks/useAppConfigurationLocales';
 import useLocalize from 'hooks/useLocalize';
-
-import messages from '../messages';
 
 import { useIntl } from 'utils/cl-intl';
 import getAlternateLinks from 'utils/cl-router/getAlternateLinks';
 import getCanonicalLink from 'utils/cl-router/getCanonicalLink';
 import { imageSizes } from 'utils/fileUtils';
 import { stripHtml } from 'utils/textUtils';
+
+import messages from '../messages';
 
 interface Props {
   event: IEventData;
@@ -37,7 +37,7 @@ const EventShowPageMeta = ({ event }: Props) => {
     localize(event.attributes.description_multiloc),
     250
   );
-  const image = eventImage?.data?.attributes?.versions?.large;
+  const image = eventImage?.data.attributes.versions.large;
   const { location } = window;
 
   return (

--- a/front/app/containers/EventsShowPage/components/EventShowPageMeta.tsx
+++ b/front/app/containers/EventsShowPage/components/EventShowPageMeta.tsx
@@ -28,7 +28,7 @@ const EventShowPageMeta = ({ event }: Props) => {
 
   if (!tenantLocales) return null;
 
-  const metaTitle = formatMessage(messages.metaTitle1, {
+  const metaTitle = formatMessage(messages.metaTitle, {
     eventTitle: localize(event.attributes.title_multiloc, {
       maxChar: 50,
     }),

--- a/front/app/containers/EventsShowPage/components/EventShowPageMeta.tsx
+++ b/front/app/containers/EventsShowPage/components/EventShowPageMeta.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { Helmet } from 'react-helmet-async';
 
+import useAuthUser from 'api/me/useAuthUser';
 import useEventImage from 'api/event_images/useEventImage';
 import { IEventData } from 'api/events/types';
 
@@ -24,6 +25,7 @@ const EventShowPageMeta = ({ event }: Props) => {
   const { formatMessage } = useIntl();
   const localize = useLocalize();
   const tenantLocales = useAppConfigurationLocales();
+  const { data: authUser } = useAuthUser();
   const { data: eventImage } = useEventImage(event);
 
   if (!tenantLocales) return null;
@@ -42,7 +44,16 @@ const EventShowPageMeta = ({ event }: Props) => {
 
   return (
     <Helmet>
-      <title>{metaTitle}</title>
+      <title>
+        {`${
+          authUser &&
+          typeof authUser.data.attributes.unread_notifications === 'number' &&
+          authUser.data.attributes.unread_notifications > 0
+            ? `(${authUser.data.attributes.unread_notifications}) `
+            : ''
+        }
+            ${metaTitle}`}
+      </title>
       {getCanonicalLink()}
       {getAlternateLinks(tenantLocales)}
       <meta name="title" content={metaTitle} />

--- a/front/app/containers/EventsShowPage/index.tsx
+++ b/front/app/containers/EventsShowPage/index.tsx
@@ -23,6 +23,7 @@ import VerticalCenterer from 'components/VerticalCenterer';
 
 import { isUnauthorizedRQ } from 'utils/errorUtils';
 
+import EventShowPageMeta from './components/EventShowPageMeta';
 import DesktopTopBar from './components/DesktopTopBar';
 import EventDescription from './components/EventDescription';
 import InformationColumnDesktop from './components/InformationColumnDesktop';
@@ -102,6 +103,7 @@ const EventsShowPage = () => {
 
   return (
     <>
+      <EventShowPageMeta event={event.data} />
       {isSmallerThanTablet ? (
         <MobileTopBar projectId={event.data.relationships.project.data.id} />
       ) : (

--- a/front/app/containers/EventsShowPage/messages.ts
+++ b/front/app/containers/EventsShowPage/messages.ts
@@ -26,4 +26,8 @@ export default defineMessages({
     id: 'app.containers.EventsShow.editEvent',
     defaultMessage: 'Edit event',
   },
+  metaTitle1: {
+    id: 'app.containers.EventsShow.metaTitle1',
+    defaultMessage: 'Event: {eventTitle} | {orgName}',
+  },
 });

--- a/front/app/containers/EventsShowPage/messages.ts
+++ b/front/app/containers/EventsShowPage/messages.ts
@@ -26,8 +26,8 @@ export default defineMessages({
     id: 'app.containers.EventsShow.editEvent',
     defaultMessage: 'Edit event',
   },
-  metaTitle1: {
-    id: 'app.containers.EventsShow.metaTitle1',
+  metaTitle: {
+    id: 'app.containers.EventsShow.metaTitle',
     defaultMessage: 'Event: {eventTitle} | {orgName}',
   },
 });

--- a/front/app/translations/en.json
+++ b/front/app/translations/en.json
@@ -1252,6 +1252,7 @@
   "app.containers.EventsShow.icsError": "Error downloading the ICS file",
   "app.containers.EventsShow.linkToOnlineEvent": "Link to online event",
   "app.containers.EventsShow.locationIconAltText": "Location",
+  "app.containers.EventsShow.metaTitle1": "Event: {eventTitle} | {orgName}",
   "app.containers.EventsShow.online2": "Online meeting",
   "app.containers.EventsShow.onlineLinkIconAltText": "Online meeting link",
   "app.containers.EventsShow.socialMediaSharingMessage": "Attend this event: {eventTitle}",

--- a/front/app/translations/en.json
+++ b/front/app/translations/en.json
@@ -1252,7 +1252,7 @@
   "app.containers.EventsShow.icsError": "Error downloading the ICS file",
   "app.containers.EventsShow.linkToOnlineEvent": "Link to online event",
   "app.containers.EventsShow.locationIconAltText": "Location",
-  "app.containers.EventsShow.metaTitle1": "Event: {eventTitle} | {orgName}",
+  "app.containers.EventsShow.metaTitle": "Event: {eventTitle} | {orgName}",
   "app.containers.EventsShow.online2": "Online meeting",
   "app.containers.EventsShow.onlineLinkIconAltText": "Online meeting link",
   "app.containers.EventsShow.socialMediaSharingMessage": "Attend this event: {eventTitle}",


### PR DESCRIPTION
### IMPORTANT! Awaiting translation proofreading (synced on Crowdin 26-6-25)

We were not setting metadata in the header of the event show page, like we do for the project show page.

This meant that if the event show page URL was shared on Facebook, it would display the homepage banner image (not the event image, if present) and the title would display as 'Reject policy and close banner, from the cookie banner (not the event title).

This PR introduces a new `EventShowPageMeta` container, largely modelled on the existing [ProjectShowPageMeta](https://github.com/CitizenLabDotCo/citizenlab/blob/master/front/app/containers/ProjectsShowPage/shared/header/ProjectShowPageMeta.tsx).

Not sure it's entirely correct, but I see 'correct looking' elements added to the header, so it's almost certainly better than nothing. Probably the easiest way to test is to merge it and then check what the [Facebook URL debugger](https://developers.facebook.com/tools/debug/) sees when it scapes the page.

# Changelog
## Fixed
- [TAN-4745] Event image and information now passed to Facebook when sharing an event URL
