### PR TITLE
Postmortem: Mailgun headers

### DIFF
--- a/back/app/controllers/web_api/v1/phases_controller.rb
+++ b/back/app/controllers/web_api/v1/phases_controller.rb
@@ -187,7 +187,6 @@ class WebApi::V1::PhasesController < ApplicationController
         voting_term_plural_multiloc: CL2_SUPPORTED_LOCALES,
         native_survey_title_multiloc: CL2_SUPPORTED_LOCALES,
         native_survey_button_multiloc: CL2_SUPPORTED_LOCALES,
-        campaigns_settings: Phase::CAMPAIGNS
       }
     ]
     if AppConfiguration.instance.feature_activated? 'disable_disliking'

--- a/back/app/mailers/application_mailer.rb
+++ b/back/app/mailers/application_mailer.rb
@@ -119,11 +119,9 @@ class ApplicationMailer < ActionMailer::Base
   end
 
   def mailgun_variables
-    variables = {
+    {
       'cl_tenant_id' => app_configuration.id
     }
-    variables['cl_delivery_id'] = command[:delivery_id] if defined?(command) && command
-    variables
   end
 
   def email_address_with_name(email, name)

--- a/back/app/models/phase.rb
+++ b/back/app/models/phase.rb
@@ -72,7 +72,6 @@ class Phase < ApplicationRecord
   REACTING_METHODS      = %w[unlimited limited].freeze
   INPUT_TERMS           = %w[idea question contribution project issue option proposal initiative petition].freeze
   FALLBACK_INPUT_TERM = 'idea'
-  CAMPAIGNS = [:project_phase_started].freeze
 
   attribute :reacting_dislike_enabled, :boolean, default: -> { disliking_enabled_default }
 
@@ -103,14 +102,12 @@ class Phase < ApplicationRecord
   validates :project, presence: true
   validates :title_multiloc, presence: true, multiloc: { presence: true }
   validates :description_multiloc, multiloc: { presence: false, html: true }
-  validates :campaigns_settings, presence: true
   validates :start_at, presence: true
   validates :prescreening_enabled, inclusion: { in: [true, false] }
   validate :validate_end_at
   validate :validate_previous_blank_end_at
   validate :validate_start_at_before_end_at
   validate :validate_no_other_overlapping_phases
-  validate :validate_campaigns_settings_keys_and_values
   validates :manual_voters_amount, numericality: { only_integer: true, greater_than_or_equal_to: 0, allow_nil: true }
   # This is a counter cache column, but it was too complex to implement it with counter_culture. It's
   # therefore updated manually by calling update_manual_votes_count! through the idea sidefx service.
@@ -315,17 +312,6 @@ class Phase < ApplicationRecord
         previous_phase.update!(end_at: (start_at - 1.day))
         @previous_phase_end_at_updated = true
       end
-    end
-  end
-
-  def validate_campaigns_settings_keys_and_values
-    return if campaigns_settings.blank?
-
-    campaigns_settings.each do |key, value|
-      errors.add(:campaigns_settings, :invalid_key, message: 'invalid key') unless CAMPAIGNS.include?(key.to_sym)
-      next if Utils.boolean? value
-
-      errors.add(:campaigns_settings, :invalid_value, message: 'invalid value')
     end
   end
 

--- a/back/app/serializers/web_api/v1/phase_serializer.rb
+++ b/back/app/serializers/web_api/v1/phase_serializer.rb
@@ -5,7 +5,7 @@ class WebApi::V1::PhaseSerializer < WebApi::V1::BaseSerializer
   include Surveys::WebApi::V1::SurveyPhaseSerializer
   include DocumentAnnotation::WebApi::V1::DocumentAnnotationPhaseSerializer
 
-  attributes :title_multiloc, :start_at, :end_at, :created_at, :updated_at, :ideas_count, :campaigns_settings,
+  attributes :title_multiloc, :start_at, :end_at, :created_at, :updated_at, :ideas_count,
     :participation_method, :submission_enabled, :commenting_enabled,
     :reacting_enabled, :reacting_like_method, :reacting_like_limited_max,
     :reacting_dislike_enabled, :reacting_dislike_method, :reacting_dislike_limited_max,

--- a/back/app/services/community_monitor_service.rb
+++ b/back/app/services/community_monitor_service.rb
@@ -58,7 +58,6 @@ class CommunityMonitorService
           commenting_enabled: false,
           reacting_enabled: false,
           start_at: Time.now,
-          campaigns_settings: { project_phase_started: true },
           native_survey_title_multiloc: multiloc_service.i18n_to_multiloc('phases.community_monitor_title'),
           native_survey_button_multiloc: multiloc_service.i18n_to_multiloc('phases.native_survey_button')
         )

--- a/back/app/services/project_copy_service.rb
+++ b/back/app/services/project_copy_service.rb
@@ -304,7 +304,6 @@ class ProjectCopyService < TemplateService # rubocop:disable Metrics/ClassLength
         'project_ref' => lookup_ref(phase.project_id, :project),
         'title_multiloc' => phase.title_multiloc,
         'description_multiloc' => phase.description_multiloc,
-        'campaigns_settings' => phase.campaigns_settings,
         'start_at' => shift_timestamp(phase.start_at, shift_timestamps, leave_blank: false)&.iso8601,
         'end_at' => shift_timestamp(phase.end_at, shift_timestamps, leave_blank: false)&.iso8601,
         'created_at' => shift_timestamp(phase.created_at, shift_timestamps)&.iso8601,

--- a/back/config/tenant_templates/base.yml
+++ b/back/config/tenant_templates/base.yml
@@ -425,8 +425,6 @@ models:
       start_at_timediff: -1440
       end_at: null
       participation_method: ideation
-      campaigns_settings:
-        project_phase_started: true
       submission_enabled: true
       commenting_enabled: true
       reacting_enabled: true

--- a/back/config/tenant_templates/e2etests_template.yml
+++ b/back/config/tenant_templates/e2etests_template.yml
@@ -7068,8 +7068,6 @@ models:
       reacting_like_limited_max: 10
       voting_method: budgeting
       voting_max_total: 100000
-      campaigns_settings:
-        project_phase_started: true
       start_at: '2018-03-28'
       end_at:
       project_ref: *Pb
@@ -7086,8 +7084,6 @@ models:
       reacting_like_limited_max: 10
       voting_method: budgeting
       voting_max_total: 100000
-      campaigns_settings:
-        project_phase_started: true
       start_at: '2018-03-28'
       end_at:
       project_ref: *charliesPb
@@ -7104,8 +7100,6 @@ models:
       reacting_like_limited_max: 10
       voting_method: budgeting
       voting_max_total: 100000
-      campaigns_settings:
-        project_phase_started: true
       start_at: '2018-03-28'
       end_at:
       project_ref: *verifiedPb
@@ -7117,8 +7111,6 @@ models:
       commenting_enabled: true
       reacting_enabled: true
       reacting_like_method: unlimited
-      campaigns_settings:
-        project_phase_started: true
       start_at: '2018-03-28'
       end_at:
       project_ref: *76
@@ -7134,8 +7126,6 @@ models:
       reacting_enabled: true
       reacting_like_method: unlimited
       reacting_like_limited_max: 7
-      campaigns_settings:
-        project_phase_started: true
       start_at: '2018-03-28'
       end_at:
       project_ref: *121
@@ -7151,8 +7141,6 @@ models:
       reacting_enabled: true
       reacting_like_method: unlimited
       reacting_like_limited_max: 7
-      campaigns_settings:
-        project_phase_started: true
       start_at: '2018-03-28'
       end_at:
       project_ref: *charliesVerifiedPPlproject
@@ -7166,8 +7154,6 @@ models:
       commenting_enabled: true
       reacting_enabled: true
       reacting_like_method: unlimited
-      campaigns_settings:
-        project_phase_started: true
       start_at: '2018-03-28'
       end_at:
       project_ref: *verifiedIdeation
@@ -7181,8 +7167,6 @@ models:
       commenting_enabled: true
       reacting_enabled: true
       reacting_like_method: unlimited
-      campaigns_settings:
-        project_phase_started: true
       start_at: '2018-03-28'
       end_at:
       project_ref: *charliesIdeation
@@ -7200,8 +7184,6 @@ models:
       reacting_like_limited_max: 7
       survey_embed_url: https://citizenlabco.typeform.com/to/qRBP2v
       survey_service: typeform
-      campaigns_settings:
-        project_phase_started: true
       start_at: '2018-03-28'
       end_at:
       project_ref: *contsurv
@@ -7219,8 +7201,6 @@ models:
       reacting_like_limited_max: 7
       survey_embed_url: https://citizenlabco.typeform.com/to/qRBP2v
       survey_service: typeform
-      campaigns_settings:
-        project_phase_started: true
       start_at: '2018-03-28'
       end_at:
       project_ref: *verifiedSurvey
@@ -7231,8 +7211,6 @@ models:
       presentation_mode: map
       created_at: '2018-03-28 13:35:06'
       updated_at: '2018-03-28 13:35:06'
-      campaigns_settings:
-        project_phase_started: true
       start_at: '2018-03-28'
       end_at:
       project_ref: *polling
@@ -7243,8 +7221,6 @@ models:
       presentation_mode: map
       created_at: '2018-03-28 13:35:06'
       updated_at: '2018-03-28 13:35:06'
-      campaigns_settings:
-        project_phase_started: true
       start_at: '2018-03-28'
       end_at:
       project_ref: *verifiedPoll
@@ -7262,8 +7238,6 @@ models:
       reacting_like_limited_max: 7
       survey_embed_url: https://citizenlabco.typeform.com/to/qRBP2v
       survey_service: typeform
-      campaigns_settings:
-        project_phase_started: true
       start_at: '2018-03-28'
       end_at:
       project_ref: *charliesSurvey
@@ -7278,8 +7252,6 @@ models:
       commenting_enabled: true
       reacting_enabled: true
       reacting_like_method: unlimited
-      campaigns_settings:
-        project_phase_started: true
       start_at: '2018-03-28'
       end_at:
       project_ref: *charliesPoll
@@ -7304,8 +7276,6 @@ models:
       start_at_timediff: -1440
       end_at_timediff: 1440
       participation_method: ideation
-      campaigns_settings:
-        project_phase_started: true
       created_at: '2018-03-28 13:35:05'
       updated_at: '2018-03-28 13:35:05'
       submission_enabled: true
@@ -7336,8 +7306,6 @@ models:
       start_at_timediff: -4320
       end_at_timediff: -2880
       participation_method: ideation
-      campaigns_settings:
-        project_phase_started: true
       created_at: '2018-03-28 13:35:05'
       updated_at: '2018-03-28 13:35:05'
       submission_enabled: false
@@ -7367,8 +7335,6 @@ models:
       start_at_timediff: -6226
       end_at_timediff: -5978
       participation_method: survey
-      campaigns_settings:
-        project_phase_started: true
       created_at: '2018-03-28 13:35:05'
       updated_at: '2018-03-28 13:35:05'
       submission_enabled: true
@@ -7402,8 +7368,6 @@ models:
       start_at_timediff: -5678
       end_at_timediff: -4760
       participation_method: voting
-      campaigns_settings:
-        project_phase_started: true
       created_at: '2018-03-28 13:35:05'
       updated_at: '2018-03-28 13:35:05'
       submission_enabled: false
@@ -7433,8 +7397,6 @@ models:
       start_at_timediff: 2280
       end_at_timediff: 3798
       participation_method: ideation
-      campaigns_settings:
-        project_phase_started: true
       created_at: '2018-03-28 13:35:05'
       updated_at: '2018-03-28 13:35:05'
       submission_enabled: true
@@ -7453,8 +7415,6 @@ models:
       start_at: 2018-06-22
       end_at: 2018-08-21
       participation_method: poll
-      campaigns_settings:
-        project_phase_started: true
       created_at: '2018-03-28 13:35:05'
       updated_at: '2018-03-28 13:35:05'
     - &42
@@ -7480,8 +7440,6 @@ models:
       start_at: 2017-10-22
       end_at: 2017-10-28
       participation_method: ideation
-      campaigns_settings:
-        project_phase_started: true
       created_at: '2018-03-28 13:35:07'
       updated_at: '2018-03-28 13:35:07'
       submission_enabled: false
@@ -7513,8 +7471,6 @@ models:
       start_at_timediff: -1440
       end_at_timediff: 1440
       participation_method: ideation
-      campaigns_settings:
-        project_phase_started: true
       created_at: '2018-03-28 13:35:07'
       updated_at: '2018-03-28 13:35:07'
       submission_enabled: true
@@ -7541,8 +7497,6 @@ models:
       start_at: 2017-11-20
       end_at: 2017-12-12
       participation_method: information
-      campaigns_settings:
-        project_phase_started: true
       created_at: '2018-03-28 13:35:07'
       updated_at: '2018-03-28 13:35:07'
       submission_enabled: true
@@ -7571,8 +7525,6 @@ models:
       start_at: 2017-12-13
       end_at: 2017-12-25
       participation_method: ideation
-      campaigns_settings:
-        project_phase_started: true
       created_at: '2018-03-28 13:35:08'
       updated_at: '2018-03-28 13:35:08'
       submission_enabled: true
@@ -7605,8 +7557,6 @@ models:
       start_at: 2017-12-26
       end_at: 2018-01-12
       participation_method: ideation
-      campaigns_settings:
-        project_phase_started: true
       created_at: '2018-03-28 13:35:08'
       updated_at: '2018-03-28 13:35:08'
       submission_enabled: true
@@ -7634,8 +7584,6 @@ models:
       start_at: 2018-01-13
       end_at: 2018-02-12
       participation_method: information
-      campaigns_settings:
-        project_phase_started: true
       created_at: '2018-03-28 13:35:08'
       updated_at: '2018-03-28 13:35:08'
       submission_enabled: true
@@ -7664,8 +7612,6 @@ models:
       start_at: 2018-02-13
       end_at: 2018-03-15
       participation_method: ideation
-      campaigns_settings:
-        project_phase_started: true
       created_at: '2018-03-28 13:35:08'
       updated_at: '2018-03-28 13:35:08'
       submission_enabled: true
@@ -7691,8 +7637,6 @@ models:
       start_at: 2018-03-16
       end_at: 2018-04-06
       participation_method: ideation
-      campaigns_settings:
-        project_phase_started: true
       created_at: '2018-03-28 13:35:08'
       updated_at: '2018-03-28 13:35:08'
       submission_enabled: true
@@ -7721,8 +7665,6 @@ models:
       start_at: 2018-04-07
       end_at: 2018-04-20
       participation_method: ideation
-      campaigns_settings:
-        project_phase_started: true
       created_at: '2018-03-28 13:35:08'
       updated_at: '2018-03-28 13:35:08'
       submission_enabled: false
@@ -7750,8 +7692,6 @@ models:
       start_at: 2018-04-21
       end_at: 2018-04-26
       participation_method: ideation
-      campaigns_settings:
-        project_phase_started: true
       created_at: '2018-03-28 13:35:08'
       updated_at: '2018-03-28 13:35:08'
       submission_enabled: true
@@ -7779,8 +7719,6 @@ models:
       start_at: 2018-02-09
       end_at: 2018-02-25
       participation_method: information
-      campaigns_settings:
-        project_phase_started: true
       created_at: '2018-03-28 13:35:09'
       updated_at: '2018-03-28 13:35:09'
       submission_enabled: true
@@ -7811,8 +7749,6 @@ models:
       start_at: 2018-02-26
       end_at: 2018-03-18
       participation_method: information
-      campaigns_settings:
-        project_phase_started: true
       created_at: '2018-03-28 13:35:09'
       updated_at: '2018-03-28 13:35:09'
       submission_enabled: true
@@ -7842,8 +7778,6 @@ models:
       start_at: 2018-03-19
       end_at: 2018-04-08
       participation_method: ideation
-      campaigns_settings:
-        project_phase_started: true
       created_at: '2018-03-28 13:35:09'
       updated_at: '2018-03-28 13:35:09'
       submission_enabled: true

--- a/back/engines/commercial/flag_inappropriate_content/spec/mailers/inappropriate_content_flagged_mailer_spec.rb
+++ b/back/engines/commercial/flag_inappropriate_content/spec/mailers/inappropriate_content_flagged_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative '../../../../free/email_campaigns/spec/mailers/shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe FlagInappropriateContent::EmailCampaigns::InappropriateContentFlaggedMailer do
   describe 'campaign_mail' do
@@ -20,12 +21,14 @@ RSpec.describe FlagInappropriateContent::EmailCampaigns::InappropriateContentFla
         }
       }
     end
-
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
 
     before do
       EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id)
     end
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject' do
       expect(mail.subject).to eq('A post on your platform has been flagged for review')

--- a/back/engines/commercial/id_fake_sso/lib/tasks/dev.rake
+++ b/back/engines/commercial/id_fake_sso/lib/tasks/dev.rake
@@ -30,8 +30,7 @@ namespace :dev do
         title_multiloc: { en: 'Verified actions test phase' },
         description_multiloc: { en: 'This phase has verified actions enabled' },
         start_at: Time.now - 1.day,
-        participation_method: 'ideation',
-        campaigns_settings: { project_phase_started: true }
+        participation_method: 'ideation'
       )
       phase.ideas.create!(
         title_multiloc: { en: 'Verified actions test idea' },

--- a/back/engines/commercial/idea_assignment/spec/mailers/idea_assigned_to_you_mailer_spec.rb
+++ b/back/engines/commercial/idea_assignment/spec/mailers/idea_assigned_to_you_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative '../../../../free/email_campaigns/spec/mailers/shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe IdeaAssignment::EmailCampaigns::IdeaAssignedToYouMailer do
   describe 'campaign_mail' do
@@ -22,10 +23,12 @@ RSpec.describe IdeaAssignment::EmailCampaigns::IdeaAssignedToYouMailer do
         }
       }
     end
-
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
 
     before_all { EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id) }
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject' do
       expect(mail.subject).to start_with('You have an assignment on the platform of')

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/phase.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/phase.rb
@@ -9,7 +9,6 @@ module MultiTenancy
         attributes %i[
           title_multiloc
           description_multiloc
-          campaigns_settings
           commenting_enabled
           reacting_dislike_enabled
           reacting_dislike_limited_max

--- a/back/engines/commercial/multi_tenancy/db/seeds/projects.rb
+++ b/back/engines/commercial/multi_tenancy/db/seeds/projects.rb
@@ -30,16 +30,14 @@ module MultiTenancy
           description_multiloc: runner.rand_description_multiloc,
           participation_method: 'proposals',
           start_at: Time.zone.today - 30.days,
-          end_at: Time.zone.today - 11.days,
-          campaigns_settings: { project_phase_started: true }
+          end_at: Time.zone.today - 11.days
         )
         project.phases.create!(
           title_multiloc: { 'en' => 'Current ideation phase' },
           description_multiloc: runner.rand_description_multiloc,
           participation_method: 'ideation',
           start_at: Time.zone.today - 10.days,
-          end_at: Time.zone.today + 10.days,
-          campaigns_settings: { project_phase_started: true }
+          end_at: Time.zone.today + 10.days
         )
         project.phases.create!(
           title_multiloc: { 'en' => 'Future native survey phase' },
@@ -47,7 +45,6 @@ module MultiTenancy
           participation_method: 'native_survey',
           start_at: Time.zone.today + 11.days,
           end_at: nil,
-          campaigns_settings: { project_phase_started: true },
           native_survey_title_multiloc: { 'en' => 'Survey' },
           native_survey_button_multiloc: { 'en' => 'Take the survey' }
         )
@@ -68,8 +65,7 @@ module MultiTenancy
           description_multiloc: runner.rand_description_multiloc,
           participation_method: 'information',
           start_at: Time.zone.today - 30.days,
-          end_at: Time.zone.today - 11.days,
-          campaigns_settings: { project_phase_started: true }
+          end_at: Time.zone.today - 11.days
         )
         project.project_images.create!(image: Rails.root.join("spec/fixtures/image#{rand(20)}.png").open)
       end
@@ -124,8 +120,7 @@ module MultiTenancy
             description_multiloc: runner.rand_description_multiloc,
             start_at: start_at,
             end_at: (start_at += rand(150).days),
-            participation_method: %w[ideation voting poll information ideation ideation][rand(6)],
-            campaigns_settings: { project_phase_started: true }
+            participation_method: %w[ideation voting poll information ideation ideation][rand(6)]
           })
           if phase.voting?
             phase.assign_attributes(voting_method: 'budgeting', voting_max_total: rand(100..1_000_099).round(-2))

--- a/back/engines/commercial/multi_tenancy/db/seeds/volunteering_causes.rb
+++ b/back/engines/commercial/multi_tenancy/db/seeds/volunteering_causes.rb
@@ -35,8 +35,7 @@ module MultiTenancy
           description_multiloc: volunteering_project.description_multiloc,
           start_at: phase_start_at,
           end_at: (phase_start_at + rand(150).days),
-          participation_method: 'volunteering',
-          campaigns_settings: { project_phase_started: true }
+          participation_method: 'volunteering'
         })
 
         Volunteering::Cause.create!([

--- a/back/engines/free/email_campaigns/README.md
+++ b/back/engines/free/email_campaigns/README.md
@@ -40,7 +40,7 @@ Every campaign subclass can make use of the following 3 hooks. Here's a minimal 
 ```ruby
 module EmailCampaigns
   class Campaigns::DemoCampaign < Campaign
-    before_send :demo_content_exists?
+    filter :demo_content_exists?
     recipient_filter :filter_new_users
     after_send :notify_demo_api
 
@@ -65,11 +65,11 @@ module EmailCampaigns
 end
 ```
 
-### `before_send`
+### `filter`
 
-Registered `before_send` actions are possibly passed `time` and `activity` options, depending on how the campaign is  triggered - through a schedule or through an activity trigger.
+Registered `filter` actions are possibly passed `time` and `activity` options, depending on how the campaign is  triggered - through a schedule or through an activity trigger.
 
-The `before_send` actions have 2 purposes:
+The `filter` actions have 2 purposes:
 * Run any code that would be needed before send a campaign
 * Returning a falsy value to stop the campaign from being sent out, a truthy value to continue
 

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/application_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/application_mailer.rb
@@ -26,6 +26,10 @@ module EmailCampaigns
 
     private
 
+    def mailgun_variables
+      super.merge(campaign&.extra_mailgun_variables || {})
+    end
+
     def show_unsubscribe_link?
       user && campaign.class.try(:consentable_for?, user)
     end

--- a/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/activity_triggerable.rb
+++ b/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/activity_triggerable.rb
@@ -5,8 +5,8 @@ module EmailCampaigns
     extend ActiveSupport::Concern
 
     included do
-      before_send :filter_activity_triggered
-      before_send :filter_activity_too_old
+      filter :filter_activity_triggered
+      filter :filter_activity_too_old
     end
 
     def filter_activity_triggered(activity:, time: nil)

--- a/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/disableable.rb
+++ b/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/disableable.rb
@@ -19,7 +19,7 @@ module EmailCampaigns
     included do
       validates :enabled, inclusion: { in: [true, false] }
 
-      before_send :filter_enabled?
+      filter :filter_enabled?
     end
 
     def filter_enabled?(_options = {})

--- a/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/lifecycle_stage_restrictable.rb
+++ b/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/lifecycle_stage_restrictable.rb
@@ -19,7 +19,7 @@ module EmailCampaigns
     end
 
     included do
-      before_send :allowed_lifecycle_stage?
+      filter :allowed_lifecycle_stage?
     end
 
     def allowed_lifecycle_stage?(_options = {})

--- a/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/schedulable.rb
+++ b/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/schedulable.rb
@@ -7,7 +7,7 @@ module EmailCampaigns
     included do
       validates :schedule, presence: true
 
-      before_send :filter_campaign_scheduled
+      filter :filter_campaign_scheduled
       before_validation :force_schedule_start_in_config_timezone
     end
 

--- a/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/trackable.rb
+++ b/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/trackable.rb
@@ -30,7 +30,7 @@ module EmailCampaigns
 
     private
 
-    def generate_delivery_id
+    def generate_delivery_id(_)
       @delivery_id = SecureRandom.uuid
     end
 

--- a/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/trackable.rb
+++ b/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/trackable.rb
@@ -5,6 +5,7 @@ module EmailCampaigns
     extend ActiveSupport::Concern
 
     included do
+      before_send :generate_delivery_id
       after_send :save_delivery
 
       has_many :deliveries, class_name: 'EmailCampaigns::Delivery', foreign_key: :campaign_id, dependent: :destroy
@@ -23,9 +24,19 @@ module EmailCampaigns
         &.sent_at
     end
 
+    def extra_mailgun_variables
+      { 'cl_delivery_id' => @delivery_id }
+    end
+
+    private
+
+    def generate_delivery_id
+      @delivery_id = SecureRandom.uuid
+    end
+
     def save_delivery(command)
       deliveries.create(
-        id: command[:delivery_id],
+        id: @delivery_id,
         delivery_status: 'sent',
         user: command[:recipient],
         tracked_content: command[:tracked_content]

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaign.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaign.rb
@@ -158,6 +158,10 @@ module EmailCampaigns
       false
     end
 
+    def extra_mailgun_variables
+      super || {}
+    end
+
     protected
 
     def set_enabled

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaign.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaign.rb
@@ -55,6 +55,15 @@ module EmailCampaigns
                   end.map(&:name))
     }
 
+    def self.filter(action_symbol)
+      @filter_hooks ||= []
+      @filter_hooks << action_symbol
+    end
+
+    def self.filter_hooks
+      @filter_hooks || []
+    end
+
     def self.before_send(action_symbol)
       @before_send_hooks ||= []
       @before_send_hooks << action_symbol
@@ -113,13 +122,28 @@ module EmailCampaigns
       users_scope
     end
 
-    def run_before_send_hooks(activity: nil, time: nil)
+    def run_filter_hooks(activity: nil, time: nil)
+      result = true
+      current_class = self.class
+
+      while current_class <= ::EmailCampaigns::Campaign
+        result &&= current_class.filter_hooks.all? do |action_symbol|
+          send(action_symbol, activity: activity, time: time)
+        end
+
+        current_class = current_class.superclass
+      end
+
+      result
+    end
+
+    def run_before_send_hooks(campaign)
       result = true
       current_class = self.class
 
       while current_class <= ::EmailCampaigns::Campaign
         result &&= current_class.before_send_hooks.all? do |action_symbol|
-          send(action_symbol, activity: activity, time: time)
+          send(action_symbol, campaign)
         end
 
         current_class = current_class.superclass

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/admin_digest.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/admin_digest.rb
@@ -42,7 +42,7 @@ module EmailCampaigns
     recipient_filter :user_filter_admin_only
     recipient_filter :user_filter_no_invitees
 
-    before_send :content_worth_sending?
+    filter :content_worth_sending?
 
     N_TOP_IDEAS = 12
 

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/base_manual.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/base_manual.rb
@@ -38,7 +38,7 @@ module EmailCampaigns
     include LifecycleStageRestrictable
 
     # Without this, the campaign would be sent on every event and every schedule trigger
-    before_send :only_manual_send
+    filter :only_manual_send
 
     def mailer_class
       ManualCampaignMailer

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/community_monitor_report.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/community_monitor_report.rb
@@ -42,7 +42,7 @@ module EmailCampaigns
     recipient_filter :user_filter_admins_moderators_only
     recipient_filter :user_filter_no_invitees
 
-    before_send :content_worth_sending?
+    filter :content_worth_sending?
 
     def mailer_class
       CommunityMonitorReportMailer

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/invite_received.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/invite_received.rb
@@ -35,7 +35,7 @@ module EmailCampaigns
     include LifecycleStageRestrictable
     allow_lifecycle_stages except: ['churned']
 
-    before_send :check_send_invite_email_toggle
+    filter :check_send_invite_email_toggle
     recipient_filter :filter_recipient
 
     def mailer_class

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/invite_reminder.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/invite_reminder.rb
@@ -36,7 +36,7 @@ module EmailCampaigns
     include Trackable
     allow_lifecycle_stages except: %w[trial churned]
 
-    before_send :check_send_invite_email_toggle
+    filter :check_send_invite_email_toggle
     recipient_filter :filter_recipient
 
     def mailer_class

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/moderator_digest.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/moderator_digest.rb
@@ -40,7 +40,7 @@ module EmailCampaigns
     recipient_filter :user_filter_moderator_only
     recipient_filter :user_filter_no_invitees
 
-    before_send :content_worth_sending?
+    filter :content_worth_sending?
 
     N_TOP_IDEAS = 12
 

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/project_phase_started.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/project_phase_started.rb
@@ -40,8 +40,6 @@ module EmailCampaigns
 
     filter :campaign_enabled_for_phase?
 
-    recipient_filter :filter_notification_recipient
-
     def mailer_class
       ProjectPhaseStartedMailer
     end
@@ -93,12 +91,6 @@ module EmailCampaigns
 
     def manageable_by_project_moderator?
       true
-    end
-
-    private
-
-    def campaign_enabled_for_phase?(activity:, time: nil)
-      activity.item.phase.campaigns_settings['project_phase_started']
     end
   end
 end

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/project_phase_started.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/project_phase_started.rb
@@ -38,7 +38,7 @@ module EmailCampaigns
     include LifecycleStageRestrictable
     allow_lifecycle_stages only: ['active']
 
-    before_send :campaign_enabled_for_phase?
+    filter :campaign_enabled_for_phase?
 
     recipient_filter :filter_notification_recipient
 

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/user_digest.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/user_digest.rb
@@ -39,7 +39,7 @@ module EmailCampaigns
 
     recipient_filter :user_filter_no_invitees
 
-    before_send :content_worth_sending?
+    filter :content_worth_sending?
 
     N_TOP_IDEAS = 3
     N_TOP_COMMENTS = 2

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/your_input_in_screening.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/your_input_in_screening.rb
@@ -37,7 +37,7 @@ module EmailCampaigns
     allow_lifecycle_stages only: %w[trial active]
 
     recipient_filter :filter_input_author
-    before_send :status_is_prescreening?
+    filter :status_is_prescreening?
 
     def mailer_class
       YourInputInScreeningMailer

--- a/back/engines/free/email_campaigns/app/services/email_campaigns/delivery_service.rb
+++ b/back/engines/free/email_campaigns/app/services/email_campaigns/delivery_service.rb
@@ -111,7 +111,7 @@ module EmailCampaigns
     # * time: Time object when the sending command happened
     # * activity: Activity object which activity happened
     def apply_send_pipeline(campaign_candidates, options = {})
-      valid_campaigns           = filter_valid_campaigns_before_send(campaign_candidates, options)
+      valid_campaigns           = filter_campaigns(campaign_candidates, options)
       campaigns_with_recipients = assign_campaigns_recipients(valid_campaigns, options)
       campaigns_with_command    = assign_campaigns_command(campaigns_with_recipients, options)
 
@@ -119,8 +119,8 @@ module EmailCampaigns
       process_send_campaigns(campaigns_with_command)
     end
 
-    def filter_valid_campaigns_before_send(campaigns, options)
-      campaigns.select { |campaign| campaign.run_before_send_hooks(**options) }
+    def filter_campaigns(campaigns, options)
+      campaigns.select { |campaign| campaign.run_filter_hooks(**options) }
     end
 
     def assign_campaigns_recipients(campaigns, options)
@@ -140,6 +140,7 @@ module EmailCampaigns
 
     def process_send_campaigns(campaigns_with_command)
       campaigns_with_command.each do |(command, campaign)|
+        campaign.run_before_send_hooks(command)
         process_command(campaign, command)
         campaign.run_after_send_hooks(command)
       end

--- a/back/engines/free/email_campaigns/app/services/email_campaigns/delivery_service.rb
+++ b/back/engines/free/email_campaigns/app/services/email_campaigns/delivery_service.rb
@@ -170,8 +170,7 @@ module EmailCampaigns
       campaign.generate_commands(recipient:, **options).map do |command|
         command.merge(
           recipient: recipient,
-          time: Time.zone.now,
-          delivery_id: SecureRandom.uuid # Needed to be included in the Mailgun headers, so Mailgun can update the delivery status
+          time: Time.zone.now
         )
       end
     end

--- a/back/engines/free/email_campaigns/app/services/email_campaigns/side_fx_campaign_service.rb
+++ b/back/engines/free/email_campaigns/app/services/email_campaigns/side_fx_campaign_service.rb
@@ -8,19 +8,7 @@ module EmailCampaigns
 
     def before_update(campaign, user); end
 
-    def after_update(campaign, _user)
-      # This is a special case for the project_phase_started campaign, the only
-      # campaign that's currently configurable on a phase level.
-      # We turn off all phase email toggles for this campaign when the platform-wide
-      # setting is turned off.
-      # attribute_before_last_save:
-      # https://apidock.com/rails/v6.0.0/ActiveRecord/AttributeMethods/Dirty/attribute_before_last_save
-      if campaign.enabled_before_last_save &&
-         !campaign.enabled &&
-         campaign.instance_of?(EmailCampaigns::Campaigns::ProjectPhaseStarted)
-        toggle_project_phase_started(campaign)
-      end
-    end
+    def after_update(campaign, _user); end
 
     def before_send(campaign, user); end
 
@@ -34,13 +22,6 @@ module EmailCampaigns
 
     def resource_name
       :campaign
-    end
-
-    def toggle_project_phase_started(campaign)
-      Phase.update_all(
-        "campaigns_settings = jsonb_set(campaigns_settings, array['project_phase_started']," \
-        "to_jsonb(#{campaign.enabled}));"
-      )
     end
   end
 end

--- a/back/engines/free/email_campaigns/spec/acceptance/campaigns_spec.rb
+++ b/back/engines/free/email_campaigns/spec/acceptance/campaigns_spec.rb
@@ -199,35 +199,6 @@ resource 'Campaigns' do
         expect(json_response.dig(:data, :relationships, :author, :data, :id)).to eq campaign.author_id
         expect(json_response.dig(:data, :relationships, :groups, :data).pluck(:id)).to eq group_ids
       end
-
-      context 'when updating ProjectPhaseStarted campaign' do
-        let!(:phase_with_campaign_enabled) { create(:phase, campaigns_settings: { project_phase_started: true }) }
-        let!(:phase_with_campaign_disabled) { create(:phase, campaigns_settings: { project_phase_started: false }) }
-
-        context do
-          let(:campaign) { create(:project_phase_started_campaign, enabled: true) }
-          let(:id) { campaign.id }
-          let(:enabled) { false }
-
-          example_request 'Update campaign enabled to false' do
-            assert_status 200
-            expect(phase_with_campaign_enabled.reload.campaigns_settings['project_phase_started']).to be false
-            expect(phase_with_campaign_disabled.reload.campaigns_settings['project_phase_started']).to be false
-          end
-        end
-
-        context do
-          let(:campaign) { create(:project_phase_started_campaign, enabled: false) }
-          let(:id) { campaign.id }
-          let(:enabled) { true }
-
-          example_request 'Update campaign enabled to true' do
-            assert_status 200
-            expect(phase_with_campaign_enabled.reload.campaigns_settings['project_phase_started']).to be true
-            expect(phase_with_campaign_disabled.reload.campaigns_settings['project_phase_started']).to be false
-          end
-        end
-      end
     end
 
     delete 'web_api/v1/campaigns/:id' do

--- a/back/engines/free/email_campaigns/spec/mailers/admin_digest_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/admin_digest_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::AdminDigestMailer do
   describe 'campaign_mail' do
@@ -42,10 +43,13 @@ RSpec.describe EmailCampaigns::AdminDigestMailer do
       }
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
     let_it_be(:mail_document) { Nokogiri::HTML.fragment(mail.html_part.body.raw_source) }
 
     before_all { EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id) }
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject' do
       expect(mail.subject).to start_with('Your weekly admin report')

--- a/back/engines/free/email_campaigns/spec/mailers/admin_rights_received_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/admin_rights_received_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::AdminRightsReceivedMailer do
   describe 'campaign_mail' do
@@ -13,9 +14,12 @@ RSpec.describe EmailCampaigns::AdminRightsReceivedMailer do
       }
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
 
     before_all { EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id) }
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject' do
       expect(mail.subject).to start_with('You became an administrator on the platform of')

--- a/back/engines/free/email_campaigns/spec/mailers/assignee_digest_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/assignee_digest_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::AssigneeDigestMailer do
   describe 'AssigneeDigest' do
@@ -45,9 +46,12 @@ RSpec.describe EmailCampaigns::AssigneeDigestMailer do
       }
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
 
     before_all { EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id) }
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject' do
       expect(mail.subject).to start_with('Ideas requiring your feedback:')

--- a/back/engines/free/email_campaigns/spec/mailers/comment_deleted_by_admin_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/comment_deleted_by_admin_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::CommentDeletedByAdminMailer do
   describe 'campaign_mail' do
@@ -20,9 +21,12 @@ RSpec.describe EmailCampaigns::CommentDeletedByAdminMailer do
       }
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
 
     before_all { EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id) }
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject' do
       expect(mail.subject).to start_with('Your comment has been deleted from the platform of')

--- a/back/engines/free/email_campaigns/spec/mailers/comment_marked_as_spam_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/comment_marked_as_spam_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::CommentMarkedAsSpamMailer do
   describe 'campaign_mail' do
@@ -24,11 +25,14 @@ RSpec.describe EmailCampaigns::CommentMarkedAsSpamMailer do
       }
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
 
     before_all do
       EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id)
     end
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject' do
       expect(mail.subject).to end_with('reported this comment as spam')

--- a/back/engines/free/email_campaigns/spec/mailers/comment_on_idea_you_follow_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/comment_on_idea_you_follow_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::CommentOnIdeaYouFollowMailer do
   describe 'CommentOnIdeaYouFollow' do
@@ -18,9 +19,12 @@ RSpec.describe EmailCampaigns::CommentOnIdeaYouFollowMailer do
       ).first.merge({ recipient: recipient })
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
 
     before { EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id) }
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject' do
       expect(mail.subject).to be_present

--- a/back/engines/free/email_campaigns/spec/mailers/comment_on_your_comment_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/comment_on_your_comment_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::CommentOnYourCommentMailer do
   describe 'CommentOnYourComment' do
@@ -26,9 +27,12 @@ RSpec.describe EmailCampaigns::CommentOnYourCommentMailer do
       }
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
 
     before_all { EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id) }
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject' do
       expect(mail.subject).to be_present

--- a/back/engines/free/email_campaigns/spec/mailers/community_monitor_report_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/community_monitor_report_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::CommunityMonitorReportMailer do
   describe 'campaign_mail' do
@@ -17,10 +18,13 @@ RSpec.describe EmailCampaigns::CommunityMonitorReportMailer do
       }
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
     let_it_be(:mail_document) { Nokogiri::HTML.fragment(mail.html_part.body.raw_source) }
 
     before_all { EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id) }
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject' do
       expect(mail.subject).to start_with('A new community monitor report is available')

--- a/back/engines/free/email_campaigns/spec/mailers/cosponsor_of_your_idea_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/cosponsor_of_your_idea_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::CosponsorOfYourIdeaMailer do
   describe 'campaign_mail' do
@@ -17,9 +18,12 @@ RSpec.describe EmailCampaigns::CosponsorOfYourIdeaMailer do
       commands[0].merge({ recipient: recipient })
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
 
     before_all { EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id) }
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject' do
       expect(mail.subject).to match('has accepted your invitation to co-sponsor your proposal')

--- a/back/engines/free/email_campaigns/spec/mailers/event_registration_confirmation_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/event_registration_confirmation_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::EventRegistrationConfirmationMailer do
   describe 'campaign_mail' do
@@ -19,11 +20,12 @@ RSpec.describe EmailCampaigns::EventRegistrationConfirmationMailer do
       }
     end
 
-    let(:mail) do
-      campaign = EmailCampaigns::Campaigns::EventRegistrationConfirmation.create!
-      command = { recipient: recipient, event_payload: event_payload }
-      described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now
-    end
+    let(:command) { { recipient: recipient, event_payload: event_payload } }
+    let(:campaign) { EmailCampaigns::Campaigns::EventRegistrationConfirmation.create! }
+    let(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let(:mail) { mailer.campaign_mail.deliver_now }
+
+    include_examples 'campaign delivery tracking'
 
     it 'has the correct subject' do
       event_title = event_attributes['title_multiloc'][recipient.locale]

--- a/back/engines/free/email_campaigns/spec/mailers/idea_marked_as_spam_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/idea_marked_as_spam_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::IdeaMarkedAsSpamMailer do
   describe 'campaign_mail' do
@@ -24,9 +25,12 @@ RSpec.describe EmailCampaigns::IdeaMarkedAsSpamMailer do
       }
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
 
     before_all { EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id) }
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject' do
       expect(mail.subject).to start_with('You have a spam report on the platform of')

--- a/back/engines/free/email_campaigns/spec/mailers/internal_comment_on_idea_assigned_to_you_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/internal_comment_on_idea_assigned_to_you_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::InternalCommentOnIdeaAssignedToYouMailer do
   describe 'InternalCommentOnIdeaAssignedToYouMailer' do
@@ -27,11 +28,13 @@ RSpec.describe EmailCampaigns::InternalCommentOnIdeaAssignedToYouMailer do
       }
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
     let_it_be(:body) { mail_body(mail) }
 
     before_all { EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id) }
 
+    include_examples 'campaign delivery tracking'
     include_examples 'internal_comment_campaign_mailer_examples'
   end
 end

--- a/back/engines/free/email_campaigns/spec/mailers/internal_comment_on_idea_you_commented_internally_on_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/internal_comment_on_idea_you_commented_internally_on_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::InternalCommentOnIdeaYouCommentedInternallyOnMailer do
   describe 'InternalCommentOnIdeaYouCommentedInternallyOnMailer' do
@@ -27,11 +28,13 @@ RSpec.describe EmailCampaigns::InternalCommentOnIdeaYouCommentedInternallyOnMail
       }
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
     let_it_be(:body) { mail_body(mail) }
 
     before_all { EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id) }
 
+    include_examples 'campaign delivery tracking'
     include_examples 'internal_comment_campaign_mailer_examples'
   end
 end

--- a/back/engines/free/email_campaigns/spec/mailers/internal_comment_on_idea_you_moderate_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/internal_comment_on_idea_you_moderate_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::InternalCommentOnIdeaYouModerateMailer do
   describe 'InternalCommentOnIdeaYouModerateMailer' do
@@ -27,11 +28,13 @@ RSpec.describe EmailCampaigns::InternalCommentOnIdeaYouModerateMailer do
       }
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
     let_it_be(:body) { mail_body(mail) }
 
     before_all { EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id) }
 
+    include_examples 'campaign delivery tracking'
     include_examples 'internal_comment_campaign_mailer_examples'
   end
 end

--- a/back/engines/free/email_campaigns/spec/mailers/internal_comment_on_unassigned_unmoderated_idea_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/internal_comment_on_unassigned_unmoderated_idea_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::InternalCommentOnUnassignedUnmoderatedIdeaMailer do
   describe 'InternalCommentOnUnassignedUnmoderatedIdeaMailer' do
@@ -27,11 +28,13 @@ RSpec.describe EmailCampaigns::InternalCommentOnUnassignedUnmoderatedIdeaMailer 
       }
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
     let_it_be(:body) { mail_body(mail) }
 
     before_all { EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id) }
 
+    include_examples 'campaign delivery tracking'
     include_examples 'internal_comment_campaign_mailer_examples'
   end
 end

--- a/back/engines/free/email_campaigns/spec/mailers/internal_comment_on_your_internal_comment_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/internal_comment_on_your_internal_comment_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::InternalCommentOnYourInternalCommentMailer do
   describe 'InternalCommentOnYourInternalCommentMailer' do
@@ -27,11 +28,13 @@ RSpec.describe EmailCampaigns::InternalCommentOnYourInternalCommentMailer do
       }
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
     let_it_be(:body) { mail_body(mail) }
 
     before_all { EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id) }
 
+    include_examples 'campaign delivery tracking'
     include_examples 'internal_comment_campaign_mailer_examples'
   end
 end

--- a/back/engines/free/email_campaigns/spec/mailers/invitation_to_cosponsor_idea_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/invitation_to_cosponsor_idea_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::InvitationToCosponsorIdeaMailer do
   describe 'campaign_mail' do
@@ -16,9 +17,12 @@ RSpec.describe EmailCampaigns::InvitationToCosponsorIdeaMailer do
       commands[0].merge({ recipient: recipient })
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
 
     before_all { EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id) }
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject' do
       expect(mail.subject).to start_with('You have been invited to co-sponsor a proposal')

--- a/back/engines/free/email_campaigns/spec/mailers/invite_received_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/invite_received_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::InviteReceivedMailer do
   describe 'InviteReceived' do
@@ -23,9 +24,12 @@ RSpec.describe EmailCampaigns::InviteReceivedMailer do
       }
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
 
     before_all { EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id) }
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject' do
       expect(mail.subject).to start_with('You are invited to')

--- a/back/engines/free/email_campaigns/spec/mailers/invite_reminder_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/invite_reminder_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::InviteReminderMailer do
   describe 'InviteReminder' do
@@ -24,9 +25,12 @@ RSpec.describe EmailCampaigns::InviteReminderMailer do
       }
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
 
     before_all { EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id) }
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject' do
       expect(mail.subject).to start_with('Pending invitation for the participation platform')

--- a/back/engines/free/email_campaigns/spec/mailers/manual_campaign_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/manual_campaign_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::ManualCampaignMailer do
   describe 'campaign_mail' do
@@ -42,9 +43,12 @@ RSpec.describe EmailCampaigns::ManualCampaignMailer do
       }
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command:, campaign:) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
 
     before_all { EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id) }
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject' do
       expect(mail.subject).to end_with('Title')

--- a/back/engines/free/email_campaigns/spec/mailers/mention_in_internal_comment_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/mention_in_internal_comment_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::MentionInInternalCommentMailer do
   describe 'MentionInInternalCommentMailer' do
@@ -27,11 +28,13 @@ RSpec.describe EmailCampaigns::MentionInInternalCommentMailer do
       }
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
     let_it_be(:body) { mail_body(mail) }
 
     before_all { EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id) }
 
+    include_examples 'campaign delivery tracking'
     include_examples 'internal_comment_campaign_mailer_examples'
   end
 end

--- a/back/engines/free/email_campaigns/spec/mailers/mention_in_official_feedback_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/mention_in_official_feedback_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::MentionInOfficialFeedbackMailer do
   describe 'campaign_mail' do
@@ -21,9 +22,12 @@ RSpec.describe EmailCampaigns::MentionInOfficialFeedbackMailer do
       }
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
 
     before_all { EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id) }
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject' do
       expect(mail.subject).to end_with('mentioned you in their feedback')

--- a/back/engines/free/email_campaigns/spec/mailers/moderator_digest_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/moderator_digest_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::ModeratorDigestMailer do
   describe 'campaign_mail' do
@@ -67,11 +68,14 @@ RSpec.describe EmailCampaigns::ModeratorDigestMailer do
       }
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
 
     before_all do
       EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id)
     end
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject' do
       expect(mail.subject).to start_with('Weekly manager report')

--- a/back/engines/free/email_campaigns/spec/mailers/native_survey_not_submitted_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/native_survey_not_submitted_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::NativeSurveyNotSubmittedMailer do
   describe 'campaign_mail' do
@@ -21,7 +22,10 @@ RSpec.describe EmailCampaigns::NativeSurveyNotSubmittedMailer do
       }
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject' do
       expect(mail.subject).to end_with 'Almost there! Submit your answers'

--- a/back/engines/free/email_campaigns/spec/mailers/new_comment_for_admin_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/new_comment_for_admin_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::NewCommentForAdminMailer do
   describe 'NewCommentForAdmin' do
@@ -26,9 +27,12 @@ RSpec.describe EmailCampaigns::NewCommentForAdminMailer do
       }
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
 
     before_all { EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id) }
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject' do
       expect(mail.subject).to be_present

--- a/back/engines/free/email_campaigns/spec/mailers/new_idea_for_admin_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/new_idea_for_admin_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::NewIdeaForAdminMailer do
   describe 'campaign_mail' do
@@ -17,8 +18,11 @@ RSpec.describe EmailCampaigns::NewIdeaForAdminMailer do
           recipient: recipient
         ).first.merge({ recipient: recipient })
       end
-      let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+      let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+      let_it_be(:mail) { mailer.campaign_mail.deliver_now }
       let_it_be(:body) { mail_body(mail) }
+
+      include_examples 'campaign delivery tracking'
 
       it 'renders the subject' do
         expect(mail.subject).to eq('Gonzo, a new input has been published on your platform')
@@ -75,8 +79,11 @@ RSpec.describe EmailCampaigns::NewIdeaForAdminMailer do
           }
         }
       end
-      let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+      let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+      let_it_be(:mail) { mailer.campaign_mail.deliver_now }
       let_it_be(:body) { mail_body(mail) }
+
+      include_examples 'campaign delivery tracking'
 
       it 'renders the subject' do
         expect(mail.subject).to eq('Gonzo, an input requires your review')

--- a/back/engines/free/email_campaigns/spec/mailers/official_feedback_on_idea_you_follow_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/official_feedback_on_idea_you_follow_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::OfficialFeedbackOnIdeaYouFollowMailer do
   describe 'campaign_mail' do
@@ -24,8 +25,11 @@ RSpec.describe EmailCampaigns::OfficialFeedbackOnIdeaYouFollowMailer do
         recipient: recipient
       ).first.merge({ recipient: recipient })
     end
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
     let_it_be(:body) { mail_body(mail) }
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject' do
       expect(mail.subject).to eq('An input you follow has received an official update on the platform of Vaudeville')

--- a/back/engines/free/email_campaigns/spec/mailers/previews/email_campaigns/native_survey_not_submitted_mailer_preview.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/previews/email_campaigns/native_survey_not_submitted_mailer_preview.rb
@@ -23,8 +23,7 @@ module EmailCampaigns
           participation_method: 'native_survey',
           submission_enabled: true,
           native_survey_title_multiloc: { 'en' => 'Survey' },
-          native_survey_button_multiloc: { 'en' => 'Take the survey' },
-          campaigns_settings: { 'project_phase_started' => true }
+          native_survey_button_multiloc: { 'en' => 'Take the survey' }
         )
         idea = Idea.create!(
           project: project,

--- a/back/engines/free/email_campaigns/spec/mailers/project_folder_moderation_rights_received_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/project_folder_moderation_rights_received_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe ProjectFolders::EmailCampaigns::ProjectFolderModerationRightsReceivedMailer do
   describe 'campaign_mail' do
@@ -19,11 +20,14 @@ RSpec.describe ProjectFolders::EmailCampaigns::ProjectFolderModerationRightsRece
       }
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
 
     before do
       EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id)
     end
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject' do
       expect(mail.subject).to start_with('You became a project folder manager')

--- a/back/engines/free/email_campaigns/spec/mailers/project_moderation_rights_received_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/project_moderation_rights_received_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::ProjectModerationRightsReceivedMailer do
   describe 'campaign_mail' do
@@ -19,9 +20,12 @@ RSpec.describe EmailCampaigns::ProjectModerationRightsReceivedMailer do
       }
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
 
     before_all { EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id) }
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject' do
       expect(mail.subject).to start_with('You became a project manager on the platform of')

--- a/back/engines/free/email_campaigns/spec/mailers/project_phase_started_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/project_phase_started_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::ProjectPhaseStartedMailer do
   describe 'campaign_mail' do
@@ -17,9 +18,12 @@ RSpec.describe EmailCampaigns::ProjectPhaseStartedMailer do
       ).first.merge({ recipient: recipient })
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
 
     before { EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id) }
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject' do
       expect(mail.subject).to end_with('entered a new phase')

--- a/back/engines/free/email_campaigns/spec/mailers/project_phase_upcoming_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/project_phase_upcoming_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::ProjectPhaseUpcomingMailer do
   describe 'campaign_mail' do
@@ -25,9 +26,12 @@ RSpec.describe EmailCampaigns::ProjectPhaseUpcomingMailer do
       }
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
 
     before_all { EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id) }
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject' do
       expect(mail.subject).to start_with('Get everything set up for the new phase of')

--- a/back/engines/free/email_campaigns/spec/mailers/project_published_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/project_published_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::ProjectPublishedMailer do
   describe 'campaign_mail' do
@@ -15,9 +16,12 @@ RSpec.describe EmailCampaigns::ProjectPublishedMailer do
       ).first.merge({ recipient: recipient })
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
 
     before { EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id) }
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject' do
       expect(mail.subject).to start_with('A new project was published on')

--- a/back/engines/free/email_campaigns/spec/mailers/project_review_request_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/project_review_request_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::ProjectReviewRequestMailer do
   describe 'campaign_mail' do
@@ -8,12 +9,13 @@ RSpec.describe EmailCampaigns::ProjectReviewRequestMailer do
     let_it_be(:recipient) { project_review.reviewer }
 
     let(:event_payload) { { project_review_id: project_review.id } }
+    let(:command) { { recipient: recipient, event_payload: event_payload } }
+    let(:campaign) { EmailCampaigns::Campaigns::ProjectReviewRequest.create! }
 
-    let(:mail) do
-      campaign = EmailCampaigns::Campaigns::ProjectReviewRequest.create!
-      command = { recipient: recipient, event_payload: event_payload }
-      described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now
-    end
+    let(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let(:mail) { mailer.campaign_mail.deliver_now }
+
+    include_examples 'campaign delivery tracking'
 
     it 'has the correct subject' do
       expect(mail.subject).to eq('Review request: A project is waiting for approval.')

--- a/back/engines/free/email_campaigns/spec/mailers/project_review_state_change_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/project_review_state_change_mailer_spec.rb
@@ -1,17 +1,19 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::ProjectReviewStateChangeMailer do
   describe 'campaign_mail' do
     let_it_be(:project_review) { create(:project_review) }
     let_it_be(:recipient) { project_review.reviewer }
     let_it_be(:event_payload) { { project_review_id: project_review.id } }
-    let_it_be(:mail) do
-      campaign = EmailCampaigns::Campaigns::ProjectReviewStateChange.create!
-      command = { recipient: recipient, event_payload: event_payload }
-      described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now
-    end
+    let_it_be(:command) { { recipient: recipient, event_payload: event_payload } }
+    let_it_be(:campaign) { EmailCampaigns::Campaigns::ProjectReviewStateChange.create! }
+    let_it_be(:mailer) { described_class.with(command:, campaign:) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
+
+    include_examples 'campaign delivery tracking'
 
     it 'has the correct subject' do
       project_title = project_review.project.title_multiloc['en']

--- a/back/engines/free/email_campaigns/spec/mailers/shared_examples_for_campaign_delivery_tracking.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/shared_examples_for_campaign_delivery_tracking.rb
@@ -1,0 +1,28 @@
+RSpec.shared_examples 'campaign delivery tracking' do
+  describe 'campaign delivery tracking' do
+    it 'creates the delivery and includes its ID in the Mailgun headers' do
+      # We need to do this as we cannot directly access the true mailer instance
+      # when using `described_class.with(...)` in the test setup.
+      mailer_instance = nil
+      allow(described_class).to receive(:new).and_wrap_original do |original, *args|
+        mailer_instance = original.call(*args)
+        allow(mailer_instance).to receive(:mailgun_headers).and_call_original
+        mailer_instance
+      end
+
+      campaign.run_before_send_hooks(activity:)
+      mailer.campaign_mail.deliver_now
+      campaign.run_after_send_hooks(command)
+
+      expect(mailer_instance.mailgun_headers).to have_key('X-Mailgun-Variables')
+      mailgun_variables = JSON.parse mailer_instance.mailgun_headers['X-Mailgun-Variables']
+      expect(mailgun_variables).to match(
+        hash_including(
+          'cl_tenant_id' => instance_of(String),
+          'cl_delivery_id' => instance_of(String)
+        )
+      )
+      expect(EmailCampaigns::Delivery.ids).to eq [mailgun_variables['cl_delivery_id']]
+    end
+  end
+end

--- a/back/engines/free/email_campaigns/spec/mailers/shared_examples_for_campaign_delivery_tracking.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/shared_examples_for_campaign_delivery_tracking.rb
@@ -10,7 +10,7 @@ RSpec.shared_examples 'campaign delivery tracking' do
         mailer_instance
       end
 
-      campaign.run_before_send_hooks(activity:)
+      campaign.run_before_send_hooks({})
       mailer.campaign_mail.deliver_now
       campaign.run_after_send_hooks(command)
 

--- a/back/engines/free/email_campaigns/spec/mailers/status_change_on_idea_you_follow_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/status_change_on_idea_you_follow_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::StatusChangeOnIdeaYouFollowMailer do
   describe 'campaign_mail' do
@@ -21,10 +22,13 @@ RSpec.describe EmailCampaigns::StatusChangeOnIdeaYouFollowMailer do
       ).first.merge({ recipient: recipient })
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
     let_it_be(:body) { mail_body(mail) }
 
     before { EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id) }
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject' do
       expect(mail.subject).to eq('The status of "Input title" has changed')

--- a/back/engines/free/email_campaigns/spec/mailers/survey_submitted_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/survey_submitted_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::SurveySubmittedMailer do
   describe 'campaign_mail' do
@@ -22,8 +23,11 @@ RSpec.describe EmailCampaigns::SurveySubmittedMailer do
         recipient: recipient
       ).first.merge({ recipient: recipient })
     end
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
     let_it_be(:body) { mail_body(mail) }
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject' do
       expect(mail.subject).to eq('Vaudeville: Thank you for your response! 🎉')

--- a/back/engines/free/email_campaigns/spec/mailers/threshold_reached_for_admin_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/threshold_reached_for_admin_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::ThresholdReachedForAdminMailer do
   describe 'campaign_mail' do
@@ -26,9 +27,12 @@ RSpec.describe EmailCampaigns::ThresholdReachedForAdminMailer do
       }
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
 
     before_all { EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id) }
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject' do
       expect(mail.subject).to start_with('An initiative reached the voting threshold on your platform')

--- a/back/engines/free/email_campaigns/spec/mailers/user_digest_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/user_digest_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::UserDigestMailer do
   describe 'UserDigest' do
@@ -44,9 +45,12 @@ RSpec.describe EmailCampaigns::UserDigestMailer do
       }
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
 
     before_all { EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id) }
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject' do
       expect(mail.subject).to start_with('Your activity on')

--- a/back/engines/free/email_campaigns/spec/mailers/voting_basket_not_submitted_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/voting_basket_not_submitted_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::VotingBasketNotSubmittedMailer do
   describe 'campaign_mail' do
@@ -17,11 +18,14 @@ RSpec.describe EmailCampaigns::VotingBasketNotSubmittedMailer do
       }
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
 
     before_all do
       EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id)
     end
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject' do
       expect(mail.subject).to end_with "You didn't submit your votes"

--- a/back/engines/free/email_campaigns/spec/mailers/voting_basket_submitted_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/voting_basket_submitted_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::VotingBasketSubmittedMailer do
   describe 'campaign_mail' do
@@ -34,12 +35,15 @@ RSpec.describe EmailCampaigns::VotingBasketSubmittedMailer do
       }
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
     let_it_be(:body) { mail_body(mail) }
 
     before_all do
       EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id)
     end
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject' do
       expect(mail.subject).to end_with('You voted successfully')

--- a/back/engines/free/email_campaigns/spec/mailers/voting_last_chance_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/voting_last_chance_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::VotingLastChanceMailer do
   describe 'campaign_mail' do
@@ -18,11 +19,14 @@ RSpec.describe EmailCampaigns::VotingLastChanceMailer do
       }
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
 
     before_all do
       EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id)
     end
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject including phase title' do
       expect(mail.subject).to match 'Last chance to vote'

--- a/back/engines/free/email_campaigns/spec/mailers/voting_phase_started_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/voting_phase_started_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::VotingPhaseStartedMailer do
   describe 'campaign_mail' do
@@ -52,12 +53,15 @@ RSpec.describe EmailCampaigns::VotingPhaseStartedMailer do
       }
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
     let_it_be(:body) { mail_body(mail) }
 
     before_all do
       EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id)
     end
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject including project title' do
       expect(mail.subject).to match 'The voting phase started'

--- a/back/engines/free/email_campaigns/spec/mailers/voting_results_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/voting_results_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::VotingResultsMailer do
   describe 'campaign_mail' do
@@ -18,11 +19,14 @@ RSpec.describe EmailCampaigns::VotingResultsMailer do
       }
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
 
     before_all do
       EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id)
     end
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject including phase title' do
       expect(mail.subject).to match 'vote results revealed!'

--- a/back/engines/free/email_campaigns/spec/mailers/welcome_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/welcome_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::WelcomeMailer do
   describe 'Welcome' do
@@ -8,9 +9,12 @@ RSpec.describe EmailCampaigns::WelcomeMailer do
     let_it_be(:campaign) { EmailCampaigns::Campaigns::Welcome.create! }
     let_it_be(:command) { { recipient: recipient } }
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
 
     before_all { EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id) }
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject' do
       expect(mail.subject).to start_with('Welcome')

--- a/back/engines/free/email_campaigns/spec/mailers/your_input_in_screening_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/your_input_in_screening_mailer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative 'shared_examples_for_campaign_delivery_tracking'
 
 RSpec.describe EmailCampaigns::YourInputInScreeningMailer do
   describe 'Welcome' do
@@ -21,9 +22,12 @@ RSpec.describe EmailCampaigns::YourInputInScreeningMailer do
       }
     end
 
-    let_it_be(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
+    let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let_it_be(:mail) { mailer.campaign_mail.deliver_now }
 
     before_all { EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id) }
+
+    include_examples 'campaign delivery tracking'
 
     it 'renders the subject which mentions the title' do
       expect(mail.subject).to include('title')

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/invite_received_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/invite_received_spec.rb
@@ -51,13 +51,13 @@ RSpec.describe EmailCampaigns::Campaigns::InviteReceived do
     end
   end
 
-  describe '#before_send' do
+  describe '#filter' do
     let(:campaign) { create(:invite_received_campaign) }
     let(:invite) { create(:invite, send_invite_email: false) }
     let(:activity) { create(:activity, item: invite, action: 'created', user: invite.inviter) }
 
     it 'returns false when send_invite_email is false' do
-      expect(campaign.run_before_send_hooks(activity: activity)).to be_falsy
+      expect(campaign.run_filter_hooks(activity: activity)).to be_falsy
     end
   end
 end

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/project_phase_started_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/project_phase_started_spec.rb
@@ -9,24 +9,6 @@ RSpec.describe EmailCampaigns::Campaigns::ProjectPhaseStarted do
     it { expect(campaign).to be_valid }
   end
 
-  describe '#campaign_enabled_for_phase?' do
-    it 'returns false when campaign is disabled at phase level' do
-      phase = create(:phase, campaigns_settings: { project_phase_started: false })
-      notification = create(:project_phase_started, phase: phase)
-      notification_activity = create(:activity, item: notification, action: 'created')
-
-      expect(campaign.reload.send(:campaign_enabled_for_phase?, activity: notification_activity)).to be false
-    end
-
-    it 'returns true when campaign is enabled at phase level' do
-      phase = create(:phase, campaigns_settings: { project_phase_started: true })
-      notification = create(:project_phase_started, phase: phase)
-      notification_activity = create(:activity, item: notification, action: 'created')
-
-      expect(campaign.reload.send(:campaign_enabled_for_phase?, activity: notification_activity)).to be true
-    end
-  end
-
   describe '#generate_commands' do
     context 'phase is not a voting phase' do
       let(:project) { create(:project_with_current_phase) }

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/user_digest_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/user_digest_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe EmailCampaigns::Campaigns::UserDigest do
     end
   end
 
-  describe 'before_send_hooks' do
+  describe 'filter_hooks' do
     let(:campaign) { build(:user_digest_campaign) }
 
     let_it_be(:activity) { create(:activity) }

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/your_idea_in_screening_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/your_idea_in_screening_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe EmailCampaigns::Campaigns::YourInputInScreening do
     end
   end
 
-  describe 'before_send' do
+  describe 'filter' do
     it "doesn't block the campaign if the input is in prescreening status" do
       campaign = create(:your_input_in_screening_campaign)
       user = create(:user)
@@ -32,7 +32,7 @@ RSpec.describe EmailCampaigns::Campaigns::YourInputInScreening do
       proposal = create(:proposal, author: user, publication_status: 'submitted', idea_status:)
       activity = create(:activity, item: proposal, action: 'submitted', user: user)
 
-      expect(campaign.run_before_send_hooks(activity: activity)).to be_truthy
+      expect(campaign.run_filter_hooks(activity: activity)).to be_truthy
     end
 
     it "doesn't send the campaign if the input is not in prescreening status" do
@@ -41,7 +41,7 @@ RSpec.describe EmailCampaigns::Campaigns::YourInputInScreening do
       proposal = create(:proposal, author: user)
       activity = create(:activity, item: proposal, action: 'submitted', user: user)
 
-      expect(campaign.run_before_send_hooks(activity: activity)).to be_falsy
+      expect(campaign.run_filter_hooks(activity: activity)).to be_falsy
     end
   end
 end

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/concerns/activity_triggerable_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/concerns/activity_triggerable_spec.rb
@@ -11,13 +11,13 @@ RSpec.describe EmailCampaigns::ActivityTriggerable do
   let(:campaign) { ActivityTriggerableCampaignForTest.create! }
   let(:activity) { create(:published_activity) }
 
-  describe 'run_before_send_hooks' do
+  describe 'run_filter_hooks' do
     it 'returns true when the activity is part of the returned activity_triggers' do
       campaign.activity_triggers = {
         'Idea' => { 'published' => true },
         'Comment' => { 'created' => true }
       }
-      expect(campaign.run_before_send_hooks(activity: activity)).to be true
+      expect(campaign.run_filter_hooks(activity: activity)).to be true
     end
 
     it 'returns false when the activity is not part of the returned activity_triggers' do
@@ -25,11 +25,11 @@ RSpec.describe EmailCampaigns::ActivityTriggerable do
         'Comment' => { 'created' => true }
       }
 
-      expect(campaign.run_before_send_hooks(activity: activity)).to be_falsy
+      expect(campaign.run_filter_hooks(activity: activity)).to be_falsy
     end
 
     it 'returns false if no activity is specified' do
-      expect(campaign.run_before_send_hooks).to be_falsy
+      expect(campaign.run_filter_hooks).to be_falsy
     end
 
     it 'returns false if the activity acted_at is more than 7 days ago' do
@@ -38,7 +38,7 @@ RSpec.describe EmailCampaigns::ActivityTriggerable do
         'Idea' => { 'published' => true }
       }
 
-      expect(campaign.run_before_send_hooks(activity: activity)).to be_falsy
+      expect(campaign.run_filter_hooks(activity: activity)).to be_falsy
     end
 
     it 'creates a create an error report if the activity is too old' do
@@ -59,7 +59,7 @@ RSpec.describe EmailCampaigns::ActivityTriggerable do
         }
       )
 
-      campaign.run_before_send_hooks(activity: activity)
+      campaign.run_filter_hooks(activity: activity)
     end
   end
 end

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/concerns/disableable_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/concerns/disableable_spec.rb
@@ -9,15 +9,15 @@ end
 RSpec.describe EmailCampaigns::Disableable do
   let(:campaign) { DisableableCampaignForTest.create! }
 
-  describe 'run_before_send_hooks' do
+  describe 'run_filter_hooks' do
     it 'returns true when the campaign is enabled' do
       campaign.update!(enabled: true)
-      expect(campaign.run_before_send_hooks).to be true
+      expect(campaign.run_filter_hooks).to be true
     end
 
     it 'returns false when the campaign is disabled' do
       campaign.update!(enabled: false)
-      expect(campaign.run_before_send_hooks).to be_falsy
+      expect(campaign.run_filter_hooks).to be_falsy
     end
   end
 end

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/concerns/lifecycle_stage_restrictable_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/concerns/lifecycle_stage_restrictable_spec.rb
@@ -18,17 +18,17 @@ RSpec.describe EmailCampaigns::LifecycleStageRestrictable do
   context 'on a campaign limited to demo and active platforms' do
     let(:campaign) { LifecycleStageActiveAndDemoCampaignForTest.create! }
 
-    describe 'run_before_send_hooks' do
+    describe 'run_filter_hooks' do
       it 'returns true when the platform is active' do
         app_configuration.settings['core']['lifecycle_stage'] = 'active'
         app_configuration.save!
-        expect(campaign.run_before_send_hooks).to be true
+        expect(campaign.run_filter_hooks).to be true
       end
 
       it 'returns false when the platform is churned' do
         app_configuration.settings['core']['lifecycle_stage'] = 'churned'
         app_configuration.save!
-        expect(campaign.run_before_send_hooks).to be_falsy
+        expect(campaign.run_filter_hooks).to be_falsy
       end
     end
   end
@@ -36,17 +36,17 @@ RSpec.describe EmailCampaigns::LifecycleStageRestrictable do
   context 'on a campaign limited to non-demo platforms' do
     let(:campaign) { LifecycleStageNotChurnedCampaignForTest.create! }
 
-    describe 'run_before_send_hooks' do
+    describe 'run_filter_hooks' do
       it 'returns true when the platform is active' do
         app_configuration.settings['core']['lifecycle_stage'] = 'active'
         app_configuration.save!
-        expect(campaign.run_before_send_hooks).to be true
+        expect(campaign.run_filter_hooks).to be true
       end
 
       it 'returns false when the platform is demo' do
         app_configuration.settings['core']['lifecycle_stage'] = 'demo'
         app_configuration.update_column :settings, app_configuration.settings
-        expect(campaign.run_before_send_hooks).to be_falsy
+        expect(campaign.run_filter_hooks).to be_falsy
       end
     end
   end

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/concerns/schedulable_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/concerns/schedulable_spec.rb
@@ -17,14 +17,14 @@ RSpec.describe EmailCampaigns::Schedulable do
     end
   end
 
-  describe 'run_before_send_hooks' do
+  describe 'run_filter_hooks' do
     it 'allows sending when and only when the passed time is within half an hour of the scheduled target' do
       time = config_timezone.local(2018, 8, 13, 10)
-      expect(campaign.run_before_send_hooks(time: time)).to be true
-      expect(campaign.run_before_send_hooks(time: time - 30.minutes)).to be true
-      expect(campaign.run_before_send_hooks(time: time + 30.minutes)).to be true
-      expect(campaign.run_before_send_hooks(time: time - 31.minutes)).to be false
-      expect(campaign.run_before_send_hooks(time: time + 31.minutes)).to be false
+      expect(campaign.run_filter_hooks(time: time)).to be true
+      expect(campaign.run_filter_hooks(time: time - 30.minutes)).to be true
+      expect(campaign.run_filter_hooks(time: time + 30.minutes)).to be true
+      expect(campaign.run_filter_hooks(time: time - 31.minutes)).to be false
+      expect(campaign.run_filter_hooks(time: time + 31.minutes)).to be false
     end
   end
 

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/concerns/trackable_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/concerns/trackable_spec.rb
@@ -35,21 +35,25 @@ RSpec.describe EmailCampaigns::Trackable do
     end
   end
 
-  describe 'run_after_send_hooks' do
-    it 'creates a delivery' do
-      user = create(:user)
-      command = {
-        event_payload: {},
-        recipient: user,
-        tracked_content: {},
-        delivery_id: SecureRandom.uuid
-      }
-      campaign.run_after_send_hooks(command)
-      expect(EmailCampaigns::Delivery.first).to have_attributes({
-        campaign_id: campaign.id,
-        user_id: user.id,
-        delivery_status: 'sent'
-      })
-    end
+  it 'generates the delivery ID, includes it in the Mailgun headers, and persists the delivery after sending' do
+    user = create(:user)
+    command = {
+      event_payload: {},
+      recipient: user,
+      tracked_content: {}
+    }
+    expect(campaign.extra_mailgun_variables['cl_delivery_id']).to be_nil
+
+    campaign.run_before_send_hooks(command)
+    delivery_id = campaign.extra_mailgun_variables['cl_delivery_id']
+    expect(delivery_id).to be_present
+    campaign.run_after_send_hooks(command)
+
+    expect(EmailCampaigns::Delivery.first).to have_attributes({
+      id: delivery_id,
+      campaign_id: campaign.id,
+      user_id: user.id,
+      delivery_status: 'sent'
+    })
   end
 end

--- a/back/lib/tasks/single_use/services/continuous_project_migration_service.rb
+++ b/back/lib/tasks/single_use/services/continuous_project_migration_service.rb
@@ -91,7 +91,6 @@ class Tasks::SingleUse::Services::ContinuousProjectMigrationService
 
       participation_method: project.participation_method,
       allow_anonymous_participation: project.allow_anonymous_participation,
-      campaigns_settings: { project_phase_started: true },
       document_annotation_embed_url: project.document_annotation_embed_url,
       ideas_order: project.ideas_order,
       input_term: project.input_term,

--- a/back/spec/acceptance/phases_spec.rb
+++ b/back/spec/acceptance/phases_spec.rb
@@ -272,7 +272,6 @@ resource 'Phases' do
         parameter :poll_anonymous, "Are users associated with their answer? Defaults to false. Only applies if participation_method is 'poll'", required: false
         parameter :ideas_order, 'The default order of ideas.'
         parameter :input_term, 'The input term for something.'
-        parameter :campaigns_settings, "A hash, only including keys in #{Phase::CAMPAIGNS} and with only boolean values", required: true
         parameter :native_survey_title_multiloc, 'A title for the native survey.'
         parameter :native_survey_button_multiloc, 'Text for native survey call to action button.'
         parameter :prescreening_enabled, 'Do inputs need to go through pre-screening before being published? Defaults to false', required: false
@@ -292,7 +291,6 @@ resource 'Phases' do
       let(:participation_method) { phase.participation_method }
       let(:start_at) { phase.start_at }
       let(:end_at) { phase.end_at }
-      let(:campaigns_settings) { phase.campaigns_settings }
 
       example_request 'Create a phase for a project' do
         assert_status 201

--- a/back/spec/factories/phases.rb
+++ b/back/spec/factories/phases.rb
@@ -29,7 +29,6 @@ FactoryBot.define do
 
     voting_min_total { 1 }
     voting_max_total { 10_000 }
-    campaigns_settings { { project_phase_started: true } }
 
     transient do
       with_permissions { false }

--- a/back/spec/mailers/confirmations_mailer_spec.rb
+++ b/back/spec/mailers/confirmations_mailer_spec.rb
@@ -5,10 +5,31 @@ require 'rails_helper'
 RSpec.describe ConfirmationsMailer do
   describe 'send_confirmation_code' do
     let_it_be(:user) { create(:user_with_confirmation, email: 'some_email@email.com') }
-    let_it_be(:message) { described_class.with(user: user).send_confirmation_code.deliver_now }
+    let_it_be(:mailer) { described_class.with(user: user) }
+    let_it_be(:message) { mailer.send_confirmation_code.deliver_now }
 
     before do
       SettingsService.new.activate_feature! 'user_confirmation'
+    end
+
+    describe 'mailgun_headers' do
+      it 'includes X-Mailgun-Variables and cl_tenant_id' do
+        # We need to do this as we cannot directly access the true mailer instance
+        # when using `described_class.with(...)` in the test setup.
+        mailer_instance = nil
+        allow(described_class).to receive(:new).and_wrap_original do |original, *args|
+          mailer_instance = original.call(*args)
+          allow(mailer_instance).to receive(:mailgun_headers).and_call_original
+          mailer_instance
+        end
+
+        mailer.send_confirmation_code.deliver_now
+
+        expect(mailer_instance.mailgun_headers).to have_key('X-Mailgun-Variables')
+        expect(JSON.parse(mailer_instance.mailgun_headers['X-Mailgun-Variables'])).to match(
+          hash_including('cl_tenant_id' => instance_of(String))
+        )
+      end
     end
 
     it 'renders the subject' do

--- a/back/spec/mailers/reset_password_mailer_spec.rb
+++ b/back/spec/mailers/reset_password_mailer_spec.rb
@@ -3,11 +3,29 @@
 require 'rails_helper'
 
 RSpec.describe ResetPasswordMailer do
-  describe 'send_reset_password' do
-    let_it_be(:user) { create(:user, locale: 'en') }
-    let_it_be(:url) { 'https://example.com' }
-    let_it_be(:mail) { described_class.with(user: user, password_reset_url: url).send_reset_password.deliver_now }
+  let_it_be(:user) { create(:user, locale: 'en') }
+  let_it_be(:url) { 'https://example.com' }
+  let_it_be(:mailer) { described_class.with(user: user, password_reset_url: url) }
+  let_it_be(:mail) { mailer.send_reset_password.deliver_now }
 
+  describe 'mailgun_headers' do
+    it 'includes X-Mailgun-Variables in headers' do
+      # We need to do this as we cannot directly access the true mailer instance
+      # when using `described_class.with(...)` in the test setup.
+      mailer_instance = nil
+      allow(described_class).to receive(:new).and_wrap_original do |original, *args|
+        mailer_instance = original.call(*args)
+        allow(mailer_instance).to receive(:mailgun_headers).and_call_original
+        mailer_instance
+      end
+
+      mailer.send_reset_password.deliver_now
+
+      expect(mailer_instance.mailgun_headers).to have_key('X-Mailgun-Variables')
+    end
+  end
+
+  describe 'send_reset_password' do
     it 'renders the subject' do
       expect(mail.subject).to end_with('Reset your password')
     end
@@ -26,15 +44,11 @@ RSpec.describe ResetPasswordMailer do
   end
 
   describe 'when sent to users with a different locale set for each' do
-    let_it_be(:recipient1) { create(:user, locale: 'en') }
     let_it_be(:recipient2) { create(:user, locale: 'nl-NL') }
-    let_it_be(:url) { 'https://example.com' }
-
-    let_it_be(:mail1) { described_class.with(user: recipient1, password_reset_url: url).send_reset_password.deliver_now }
     let_it_be(:mail2) { described_class.with(user: recipient2, password_reset_url: url).send_reset_password.deliver_now }
 
     it 'renders the mails in the correct language' do
-      expect(mail1.body.encoded).to include('You requested a password reset')
+      expect(mail.body.encoded).to include('You requested a password reset')
       expect(mail2.body.encoded).to include('Je vroeg een reset van je wachtwoord')
     end
   end

--- a/back/spec/mailers/reset_password_mailer_spec.rb
+++ b/back/spec/mailers/reset_password_mailer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ResetPasswordMailer do
   let_it_be(:mail) { mailer.send_reset_password.deliver_now }
 
   describe 'mailgun_headers' do
-    it 'includes X-Mailgun-Variables in headers' do
+    it 'includes X-Mailgun-Variables and cl_tenant_id' do
       # We need to do this as we cannot directly access the true mailer instance
       # when using `described_class.with(...)` in the test setup.
       mailer_instance = nil
@@ -22,6 +22,9 @@ RSpec.describe ResetPasswordMailer do
       mailer.send_reset_password.deliver_now
 
       expect(mailer_instance.mailgun_headers).to have_key('X-Mailgun-Variables')
+      expect(JSON.parse(mailer_instance.mailgun_headers['X-Mailgun-Variables'])).to match(
+        hash_including('cl_tenant_id' => instance_of(String))
+      )
     end
   end
 

--- a/back/spec/mailers/user_blocked_mailer_spec.rb
+++ b/back/spec/mailers/user_blocked_mailer_spec.rb
@@ -5,7 +5,28 @@ require 'rails_helper'
 RSpec.describe UserBlockedMailer do
   describe 'send_email_to_blocked_user' do
     let_it_be(:user) { create(:user, block_end_at: 5.days.from_now) }
-    let_it_be(:message) { described_class.with(user: user).send_user_blocked_email.deliver_now }
+    let_it_be(:mailer) { described_class.with(user: user) }
+    let_it_be(:message) { mailer.send_user_blocked_email.deliver_now }
+
+    describe 'mailgun_headers' do
+      it 'includes X-Mailgun-Variables and cl_tenant_id' do
+        # We need to do this as we cannot directly access the true mailer instance
+        # when using `described_class.with(...)` in the test setup.
+        mailer_instance = nil
+        allow(described_class).to receive(:new).and_wrap_original do |original, *args|
+          mailer_instance = original.call(*args)
+          allow(mailer_instance).to receive(:mailgun_headers).and_call_original
+          mailer_instance
+        end
+
+        mailer.send_user_blocked_email.deliver_now
+
+        expect(mailer_instance.mailgun_headers).to have_key('X-Mailgun-Variables')
+        expect(JSON.parse(mailer_instance.mailgun_headers['X-Mailgun-Variables'])).to match(
+          hash_including('cl_tenant_id' => instance_of(String))
+        )
+      end
+    end
 
     it 'renders the subject' do
       expect(message.subject).to start_with('Your account has been temporarily disabled')

--- a/back/spec/models/phase_spec.rb
+++ b/back/spec/models/phase_spec.rb
@@ -154,33 +154,6 @@ RSpec.describe Phase do
     end
   end
 
-  describe 'campaigns_settings validation' do
-    it 'fails when null' do
-      phase = build(:phase, campaigns_settings: nil)
-      expect(phase).to be_invalid
-    end
-
-    it 'fails when empty' do
-      phase = build(:phase, campaigns_settings: {})
-      expect(phase).to be_invalid
-    end
-
-    it 'fails when contains invalid key' do
-      phase = build(:phase, campaigns_settings: { invalid_key: true })
-      expect(phase).to be_invalid
-    end
-
-    it 'fails when contains invalid value' do
-      phase = build(:phase, campaigns_settings: { project_phase_started: 'not_a_boolean' })
-      expect(phase).to be_invalid
-    end
-
-    it 'succeeds when contains valid key and value' do
-      phase = build(:phase, campaigns_settings: { project_phase_started: true })
-      expect(phase).to be_valid
-    end
-  end
-
   describe 'project validation' do
     it 'succeeds when the associated project is a timeline project' do
       phase = build(:phase, project: build(:project))

--- a/back/spec/tasks/single_use/continuous_project_migration_service_spec.ignore.rb
+++ b/back/spec/tasks/single_use/continuous_project_migration_service_spec.ignore.rb
@@ -37,7 +37,6 @@ RSpec.describe Tasks::SingleUse::Services::ContinuousProjectMigrationService do
       expect(phase.attributes.symbolize_keys).to include({
         participation_method: continuous_project_attributes[:participation_method],
         allow_anonymous_participation: continuous_project_attributes[:allow_anonymous_participation],
-        campaigns_settings: { 'project_phase_started' => true },
         document_annotation_embed_url: continuous_project_attributes[:document_annotation_embed_url],
         ideas_order: continuous_project_attributes[:ideas_order],
         input_term: continuous_project_attributes[:input_term],


### PR DESCRIPTION
- Avoids future occurrences of the bug we had on Tuesday, by testing in the mailer specs if the Mailgun headers are set correctly (and don't crash)
- Improve cohesion of managing the delivery creation and ID, by moving all code into the Trackable concern, with test coverage.
- Separated before_send from filter, because the Rails convention seems to be that before_send should be executed for each email being send (even when the same mailer instance is being reused). This is necessary to generate a unique ID for each delivery.