### PR TITLE
[TAN-4895] Enable deletion of file from form file upload fields

### DIFF
--- a/back/app/controllers/web_api/v1/files_controller.rb
+++ b/back/app/controllers/web_api/v1/files_controller.rb
@@ -88,6 +88,7 @@ class WebApi::V1::FilesController < ApplicationController
   def destroy
     file = @file.destroy
     if file.destroyed?
+      SideFxFileService.new.after_destroy(file, current_user)
       head :ok
     else
       head :internal_server_error

--- a/back/app/controllers/web_api/v1/files_controller.rb
+++ b/back/app/controllers/web_api/v1/files_controller.rb
@@ -88,7 +88,7 @@ class WebApi::V1::FilesController < ApplicationController
   def destroy
     file = @file.destroy
     if file.destroyed?
-      SideFxFileService.new.after_destroy(file, current_user)
+      SideFxFileService.new.after_destroy(file)
       head :ok
     else
       head :internal_server_error

--- a/back/app/services/side_fx_file_service.rb
+++ b/back/app/services/side_fx_file_service.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class SideFxFileService
+  include SideFxHelper
+
+  def after_destroy(file, current_user)
+    idea = file&.idea
+    return unless idea
+ 
+    keys_to_delete = idea.custom_field_values.select do |_key, value|
+      value.is_a?(Hash) && value["id"] == file.id
+    end.keys
+
+    keys_to_delete.each { |key| idea.custom_field_values.delete(key) }
+    
+    idea.save! if keys_to_delete.any?
+  end
+end

--- a/back/app/services/side_fx_file_service.rb
+++ b/back/app/services/side_fx_file_service.rb
@@ -3,16 +3,17 @@
 class SideFxFileService
   include SideFxHelper
 
-  def after_destroy(file, current_user)
-    idea = file&.idea
-    return unless idea
- 
+  def after_destroy(file)
+    return unless file.respond_to?(:idea) && file.idea
+
+    idea = file.idea
+
     keys_to_delete = idea.custom_field_values.select do |_key, value|
-      value.is_a?(Hash) && value["id"] == file.id
+      value.is_a?(Hash) && value['id'] == file.id
     end.keys
 
     keys_to_delete.each { |key| idea.custom_field_values.delete(key) }
-    
+
     idea.save! if keys_to_delete.any?
   end
 end

--- a/back/app/services/side_fx_file_service.rb
+++ b/back/app/services/side_fx_file_service.rb
@@ -6,7 +6,14 @@ class SideFxFileService
   def after_destroy(file)
     return unless file.respond_to?(:idea) && file.idea
 
+    remove_file_refs_from_idea_custom_field_values(file)
+  end
+
+  private
+
+  def remove_file_refs_from_idea_custom_field_values(file)
     idea = file.idea
+    return unless idea.custom_field_values
 
     keys_to_delete = idea.custom_field_values.select do |_key, value|
       value.is_a?(Hash) && value['id'] == file.id

--- a/back/spec/services/side_fx_file_service_spec.rb
+++ b/back/spec/services/side_fx_file_service_spec.rb
@@ -12,7 +12,7 @@ describe SideFxFileService do
     it 'removes the file reference from the idea custom field values' do
       idea.update!(
         custom_field_values: {
-          'some_survey_question': 'option2',
+          'some_survey_question' => 'option2',
           'deleted_file_upload' => { 'id' => idea_file.id, 'name' => idea_file.name },
           'other_file_upload' => { 'id' => 'fake_id', 'name' => 'fake_filename' }
         }

--- a/back/spec/services/side_fx_file_service_spec.rb
+++ b/back/spec/services/side_fx_file_service_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe SideFxFileService do
+  let(:service) { described_class.new }
+
+  describe 'after_destroy' do
+    let(:idea) { create(:idea) }
+    let(:idea_file) { create(:idea_file, idea: idea) }
+
+    it 'removes the file reference from the idea custom field values' do
+      idea.update!(
+        custom_field_values: {
+          'some_survey_question': 'option2',
+          'deleted_file_upload' => { 'id' => idea_file.id, 'name' => idea_file.name },
+          'other_file_upload' => { 'id' => 'fake_id', 'name' => 'fake_filename' }
+        }
+      )
+
+      service.after_destroy(idea_file)
+      expect(idea.reload.custom_field_values).to eq(
+        'some_survey_question' => 'option2',
+        'other_file_upload' => { 'id' => 'fake_id', 'name' => 'fake_filename' }
+      )
+    end
+  end
+end


### PR DESCRIPTION
Introduces new `SideFxFileService#after_destroy` that removes any reference to a destroyed `idea_file` from the related idea's `custom_field_values`.

This means the FE can use the `/ideas/:idea_id}/files/:file_id` for a DELETE request when a user clicks on the 'delete' (remove) file icon on a file upload field on a form (e.g. a survey form).

# Changelog
## Fixed
- [TAN-4895] Enable deletion of file from form file upload fields
