### PR TITLE
[TAN-4791] Permit listing (index) idea custom_fields for visitor

### DIFF
--- a/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
+++ b/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/admin/idea_custom_fields_controller.rb
@@ -23,6 +23,7 @@ module IdeaCustomFields
       }
     }
 
+    skip_before_action :authenticate_user, only: %i[index]
     before_action :set_custom_field, only: %i[show as_geojson]
     before_action :set_custom_form, only: %i[index update_all]
     skip_after_action :verify_policy_scoped

--- a/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/index_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/index_spec.rb
@@ -59,4 +59,165 @@ resource 'Idea Custom Fields' do
       end
     end
   end
+
+  context 'When there are 2 survey phases in same project' do
+    get 'web_api/v1/admin/phases/:phase_id/custom_fields' do
+      let(:phase_id) { current_phase.id }
+
+      let(:project) { create(:project) }
+
+      let(:past_phase) { create(:native_survey_phase, start_at: 2.weeks.ago, end_at: 1.week.ago, project: project) }
+      let(:form) { create(:custom_form, participation_context: past_phase) }
+      let!(:custom_field1) { create(:custom_field_text, resource: form, key: 'survey1_field') }
+
+      let(:current_phase) { create(:native_survey_phase, start_at: 1.day.ago, end_at: 1.week.from_now, project: project) }
+
+      context 'when survey form not persisted' do
+        shared_examples 'returns default survey custom fields' do
+          example_request 'List default survey custom fields' do
+            assert_status 200
+            expect(response_data.size).to eq 3
+
+            keys = response_data.map { |d| d.dig(:attributes, :key) }
+
+            expect(keys).to include('page1', 'form_end')
+            expect(keys.any? { |key| key.include?('default_question') }).to be true
+          end
+        end
+
+        context 'when admin' do
+          before { admin_header_token }
+
+          include_examples 'returns default survey custom fields'
+
+          example 'List survey fields in project for groups not including user' do
+            project.update!(visible_to: 'groups')
+            do_request
+            assert_status 200
+            expect(response_data.size).to eq 3
+          end
+        end
+
+        context 'when regular user' do
+          before { header_token_for(user) }
+
+          let(:user) { create(:user) }
+
+          include_examples 'returns default survey custom fields'
+
+          example '[Unauthorized] List survey fields in admin only project' do
+            project.update!(visible_to: 'admins')
+            do_request
+            assert_status 401
+          end
+
+          example '[Unauthorized] List survey fields in project for groups not including user' do
+            project.update!(visible_to: 'groups')
+            do_request
+            assert_status 401
+          end
+
+          example 'List survey fields in project for groups including user' do
+            project.update!(visible_to: 'groups')
+            group = create(:group)
+            create(:membership, group: group, user: user)
+            create(:groups_project, group: group, project: project)
+            do_request
+            assert_status 200
+            expect(response_data.size).to eq 3
+          end
+        end
+
+        context 'when visitor' do
+          include_examples 'returns default survey custom fields'
+
+          example '[Unauthorized] List survey fields in admin only project' do
+            project.update!(visible_to: 'admins')
+            do_request
+            assert_status 401
+          end
+
+          example '[Unauthorized] List survey fields in project for groups' do
+            project.update!(visible_to: 'groups')
+            do_request
+            assert_status 401
+          end
+        end
+      end
+
+      context 'when survey form persisted' do
+        let(:form2) { create(:custom_form, participation_context: current_phase) }
+        let!(:custom_field2) { create(:custom_field_text, resource: form2, key: 'survey2_field') }
+
+        shared_examples 'returns non-default survey custom fields' do
+          example_request 'List all custom fields for a survey' do
+            assert_status 200
+            expect(response_data.size).to eq 1
+            expect(response_data.map { |d| d.dig(:attributes, :key) }).to eq [
+              custom_field2.key
+            ]
+          end
+        end
+
+        context 'when admin' do
+          before { admin_header_token }
+
+          include_examples 'returns non-default survey custom fields'
+
+          example 'List survey fields in project for groups not including user' do
+            project.update!(visible_to: 'groups')
+            do_request
+            assert_status 200
+            expect(response_data.size).to eq 1
+          end
+        end
+
+        context 'when regular user' do
+          let(:user) { create(:user) }
+
+          before { header_token_for(user) }
+
+          include_examples 'returns non-default survey custom fields'
+
+          example '[Unauthorized] List survey fields in admin only project' do
+            project.update!(visible_to: 'admins')
+            do_request
+            assert_status 401
+          end
+
+          example '[Unauthorized] List survey fields in project for groups not including user' do
+            project.update!(visible_to: 'groups')
+            do_request
+            assert_status 401
+          end
+
+          example 'List survey fields in project for groups including user' do
+            project.update!(visible_to: 'groups')
+            group = create(:group)
+            create(:membership, group: group, user: user)
+            create(:groups_project, group: group, project: project)
+            do_request
+            assert_status 200
+            expect(response_data.size).to eq 1
+          end
+        end
+
+        context 'when visitor' do
+          include_examples 'returns non-default survey custom fields'
+
+          example '[Unauthorized] List survey fields in admin only project' do
+            project.update!(visible_to: 'admins')
+            do_request
+            assert_status 401
+          end
+
+          example '[Unauthorized] List survey fields in project for groups' do
+            project.update!(visible_to: 'groups')
+            do_request
+            assert_status 401
+          end
+        end
+      end
+    end
+  end
 end

--- a/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/project_context/index_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/project_context/index_spec.rb
@@ -71,13 +71,22 @@ resource 'Idea Custom Fields' do
           'proposed_budget'
         ]
       end
+
+      example 'List input fields in project for groups not including user' do
+        context.update!(visible_to: 'groups')
+        do_request
+        assert_status 200
+        expect(response_data.size).to eq 13
+      end
     end
 
     context 'when resident' do
       let!(:hidden_field) { create(:custom_field_text, resource: form, key: 'extra_field2', hidden: true) }
       let!(:disabled_field) { create(:custom_field_text, resource: form, key: 'extra_field3', enabled: false) }
 
-      before { resident_header_token }
+      let(:user) { create(:user) }
+
+      before { header_token_for(user) }
 
       example_request 'List all allowed custom fields for a project' do
         assert_status 200
@@ -90,6 +99,28 @@ resource 'Idea Custom Fields' do
           nil, 'topic_ids', 'location_description',
           'extra_field1', 'form_end'
         ]
+      end
+
+      example '[Unauthorized] List input fields in admin only project' do
+        context.update!(visible_to: 'admins')
+        do_request
+        assert_status 401
+      end
+
+      example '[Unauthorized] List input fields in project for groups not including user' do
+        context.update!(visible_to: 'groups')
+        do_request
+        assert_status 401
+      end
+
+      example 'List survey fields in project for groups including user' do
+        context.update!(visible_to: 'groups')
+        group = create(:group)
+        create(:membership, group: group, user: user)
+        create(:groups_project, group: group, project: context)
+        do_request
+        assert_status 200
+        expect(response_data.size).to eq 12
       end
     end
   end

--- a/back/engines/commercial/idea_custom_fields/spec/policies/idea_custom_field_policy_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/policies/idea_custom_field_policy_spec.rb
@@ -9,6 +9,14 @@ describe IdeaCustomFields::IdeaCustomFieldPolicy do
   let!(:project) { create(:project, custom_form: custom_form) }
   let!(:idea_custom_field) { create(:custom_field, resource: custom_form) }
 
+  context 'for a visitor' do
+    let(:user) { nil }
+
+    it { is_expected.to permit(:index) }
+    it { is_expected.to permit(:show) }
+    it { is_expected.not_to permit(:update_all) }
+  end
+
   context 'for a normal user who can access the project' do
     let(:user) { create(:user) }
 


### PR DESCRIPTION
Combining #11359 && #11378 into one PR to merge into `master`, since they should be unproblematic, and to remove their diff(s) from #11347

# Changelog
## Technical
- [TAN-4791] Permit listing (index) idea custom_fields for visitor
