### PR TITLE
TAN-4824 Accessible PDFs

### DIFF
--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/gotenberg_client.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/gotenberg_client.rb
@@ -14,7 +14,7 @@ module BulkImportIdeas::Exporters
         'preferCssPageSize' => true,
         'generateDocumentOutline' => true,
         'generateTaggedPdf' => true,
-        'index.html': Faraday::Multipart::FilePart.new(
+        'index.html' => Faraday::Multipart::FilePart.new(
           StringIO.new(html),
           'text/html',
           'index.html'

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/gotenberg_client.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/gotenberg_client.rb
@@ -11,12 +11,14 @@ module BulkImportIdeas::Exporters
       return false unless up?
 
       payload = {
+        'preferCssPageSize' => true,
+        'generateDocumentOutline' => true,
+        'generateTaggedPdf' => true,
         'index.html': Faraday::Multipart::FilePart.new(
           StringIO.new(html),
           'text/html',
           'index.html'
-        ),
-        preferCssPageSize: true
+        )
       }
       url = "#{@api_url}/forms/chromium/convert/html"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,7 +96,7 @@ services:
   # For generating PDFs
   gotenberg:
     container_name: cl-gotenberg
-    image: gotenberg/gotenberg:8
+    image: gotenberg/gotenberg:8.21
     restart: always
 
 volumes:


### PR DESCRIPTION
# Changelog
## Fixed
- The survey PDF export now generates a 'tagged PDF', which improves on its accessibility. It's not yet passing all accessibility audit checks, but a serious step forward.
