### PR TITLE
TAN-4918 Participation state filter (BE)

### DIFF
--- a/back/app/services/projects_finder_admin_service.rb
+++ b/back/app/services/projects_finder_admin_service.rb
@@ -143,6 +143,8 @@ class ProjectsFinderAdminService
     if participation_states.include?('not_started')
       phases_not_in_the_future = Phase.where("start_at < ?", DateTime.current)
       scope = scope.where.not(id: phases_not_in_the_future.select(:project_id))
+
+      use_or = true
     end
 
     if participation_states.include?('collecting_data')
@@ -151,10 +153,11 @@ class ProjectsFinderAdminService
           participation_method != 'information'
       ", Date.today, Date.today)
 
-      scope = scope.or if use_or
-
-      scope = scope
-        .where(id: phase_scope.select(:project_id))
+      if use_or
+        scope = scope.or(Phase.where(id: phase_scope.select(:project_id)))
+      else
+        scope = scope.where(id: phase_scope.select(:project_id))
+      end
 
       use_or = true
     end
@@ -165,10 +168,11 @@ class ProjectsFinderAdminService
         participation_method = 'information'
       ", Date.today, Date.today)
 
-      scope = scope.or if use_or
-
-      scope = scope
-        .where(id: phase_scope.select(:project_id))
+      if use_or
+        scope = scope.or(Phase.where(id: phase_scope.select(:project_id)))
+      else
+        scope = scope.where(id: phase_scope.select(:project_id))
+      end
 
       use_or = true
     end
@@ -176,10 +180,11 @@ class ProjectsFinderAdminService
     if participation_states.include?('finished')
       phases_not_in_the_past = Phase.where("coalesce(end_at, 'infinity'::DATE) >= ?", DateTime.current)
 
-      scope = scope.or if use_or
-
-      scope = scope
-        .where.not(id: phases_not_in_the_past.select(:project_id))
+      if use_or
+        scope = scope.or(Phase.where.not(id: phases_not_in_the_past.select(:project_id)))
+      else
+        scope = scope.where.not(id: phases_not_in_the_past.select(:project_id))
+      end
     end
 
     scope

--- a/back/app/services/projects_finder_admin_service.rb
+++ b/back/app/services/projects_finder_admin_service.rb
@@ -138,11 +138,13 @@ class ProjectsFinderAdminService
     participation_states = params[:participation_states] || []
     return scope if participation_states.blank?
 
+    today = Time.zone.today
+
     conditions = []
 
     if participation_states.include?('not_started')
       # Projects with no phases that have started yet
-      conditions << "projects.id NOT IN (SELECT project_id FROM phases WHERE start_at < '#{DateTime.current.iso8601}')"
+      conditions << "projects.id NOT IN (SELECT project_id FROM phases WHERE start_at < '#{today}')"
     end
 
     if participation_states.include?('collecting_data')
@@ -150,7 +152,7 @@ class ProjectsFinderAdminService
       conditions << <<-SQL.squish
         projects.id IN (
           SELECT project_id FROM phases
-          WHERE (start_at, coalesce(end_at, 'infinity'::DATE)) OVERLAPS ('#{Time.zone.today}', '#{Time.zone.today}')
+          WHERE (start_at, coalesce(end_at, 'infinity'::DATE)) OVERLAPS ('#{today}', '#{today}')
           AND participation_method != 'information'
         )
       SQL
@@ -161,7 +163,7 @@ class ProjectsFinderAdminService
       conditions << <<-SQL.squish
         projects.id IN (
           SELECT project_id FROM phases
-          WHERE (start_at, coalesce(end_at, 'infinity'::DATE)) OVERLAPS ('#{Time.zone.today}', '#{Time.zone.today}')
+          WHERE (start_at, coalesce(end_at, 'infinity'::DATE)) OVERLAPS ('#{today}', '#{today}')
           AND participation_method = 'information'
         )
       SQL
@@ -169,7 +171,7 @@ class ProjectsFinderAdminService
 
     if participation_states.include?('past')
       # Projects with no phases that end in the future
-      conditions << "projects.id NOT IN (SELECT project_id FROM phases WHERE coalesce(end_at, 'infinity'::DATE) >= '#{DateTime.current.iso8601}')"
+      conditions << "projects.id NOT IN (SELECT project_id FROM phases WHERE coalesce(end_at, 'infinity'::DATE) >= '#{today}')"
     end
 
     scope.where(conditions.map { |c| "(#{c})" }.join(' OR '))

--- a/back/app/services/projects_finder_admin_service.rb
+++ b/back/app/services/projects_finder_admin_service.rb
@@ -157,6 +157,21 @@ class ProjectsFinderAdminService
         )
     end
 
+    if participation_states.include?('informing')
+      phase_scope = phase_scope
+        .or(
+          "
+            ((start_at, coalesce(end_at, 'infinity'::DATE)) OVERLAPS (?, ?)) AND
+            participation_method = 'information'
+          ",
+          start_at, end_at
+        )
+    end
+
+    if participation_states.include?('finished')
+      # TODO
+    end
+
     scope.where(id: phase_scope.select(:project_id))
   end
 end

--- a/back/app/services/projects_finder_admin_service.rb
+++ b/back/app/services/projects_finder_admin_service.rb
@@ -143,7 +143,7 @@ class ProjectsFinderAdminService
 
     if participation_states.include?('not_started')
       phase_scope = phase_scope
-        .or('start_at > ?', DateTime.current)
+        .or.not("start_at <= ?", DateTime.current)
     end
 
     if participation_states.include?('collecting_data')
@@ -169,10 +169,8 @@ class ProjectsFinderAdminService
     end
 
     if participation_states.include?('finished')
-      phases_not_ended = Phase.where("coalesce(end_at, 'infinity'::DATE) >= ?", DateTime.current)
-
       phase_scope = phase_scope
-        .or("id NOT IN (?)", phases_not_ended.select(:id))
+        .or.not("coalesce(end_at, 'infinity'::DATE) >= ?", DateTime.current)
     end
 
     scope.where(id: phase_scope.select(:project_id))

--- a/back/app/services/projects_finder_admin_service.rb
+++ b/back/app/services/projects_finder_admin_service.rb
@@ -139,7 +139,6 @@ class ProjectsFinderAdminService
     return scope if participation_states.blank?
 
     today = Time.zone.today
-
     conditions = []
 
     if participation_states.include?('not_started')

--- a/back/app/services/projects_finder_admin_service.rb
+++ b/back/app/services/projects_finder_admin_service.rb
@@ -169,7 +169,10 @@ class ProjectsFinderAdminService
     end
 
     if participation_states.include?('finished')
-      # TODO
+      phases_not_ended = Phase.where("coalesce(end_at, 'infinity'::DATE) >= ?", DateTime.current)
+
+      phase_scope = phase_scope
+        .or("id NOT IN (?)", phases_not_ended.select(:id))
     end
 
     scope.where(id: phase_scope.select(:project_id))

--- a/back/app/services/projects_finder_admin_service.rb
+++ b/back/app/services/projects_finder_admin_service.rb
@@ -157,8 +157,6 @@ class ProjectsFinderAdminService
         )
     end
 
-
-    # TODO
-    scope
+    scope.where(id: phase_scope.select(:project_id))
   end
 end

--- a/back/app/services/projects_finder_admin_service.rb
+++ b/back/app/services/projects_finder_admin_service.rb
@@ -138,12 +138,9 @@ class ProjectsFinderAdminService
     participation_states = params[:participation_states] || []
     return scope if participation_states.blank?
 
-    # Add some nonsense where clause that is always false so we can just use "or" afterwards
-    phase_scope = Phase.where("id IS NULL")
-
     if participation_states.include?('not_started')
-      phase_scope = phase_scope
-        .or.not.where("start_at <= ?", DateTime.current)
+      phases_not_in_the_future = Phase.where("start_at < ?", DateTime.current)
+      scope = scope.where.not(id: phases_not_in_the_future.select(:project_id))
     end
 
     if participation_states.include?('collecting_data')
@@ -167,6 +164,6 @@ class ProjectsFinderAdminService
         .or.not.where("coalesce(end_at, 'infinity'::DATE) >= ?", DateTime.current)
     end
 
-    scope.where(id: phase_scope.select(:project_id))
+    scope
   end
 end

--- a/back/app/services/projects_finder_admin_service.rb
+++ b/back/app/services/projects_finder_admin_service.rb
@@ -8,6 +8,7 @@ class ProjectsFinderAdminService
     projects = filter_project_manager(projects, params)
     projects = search(projects, params)
     projects = filter_date(projects, params)
+    projects = filter_participation_states(projects, params)
 
     # Apply sorting
     if params[:sort] == 'recently_viewed'
@@ -131,5 +132,13 @@ class ProjectsFinderAdminService
       )
 
     scope.where(id: overlapping_project_ids)
+  end
+
+  def self.filter_participation_states(scope, params = {})
+    participation_states = params[:participation_states] || []
+    return scope if participation_state.blank?
+
+    # TODO
+    scope
   end
 end

--- a/back/app/services/projects_finder_admin_service.rb
+++ b/back/app/services/projects_finder_admin_service.rb
@@ -167,7 +167,7 @@ class ProjectsFinderAdminService
       SQL
     end
 
-    if participation_states.include?('finished')
+    if participation_states.include?('past')
       # Projects with no phases that end in the future
       conditions << "projects.id NOT IN (SELECT project_id FROM phases WHERE coalesce(end_at, 'infinity'::DATE) >= '#{DateTime.current.iso8601}')"
     end

--- a/back/app/services/projects_finder_admin_service.rb
+++ b/back/app/services/projects_finder_admin_service.rb
@@ -137,7 +137,7 @@ class ProjectsFinderAdminService
   def self.filter_participation_states(scope, params = {})
     participation_states = params[:participation_states] || []
     return scope if participation_states.blank?
-    
+
     conditions = []
 
     if participation_states.include?('not_started')
@@ -150,7 +150,7 @@ class ProjectsFinderAdminService
       conditions << <<-SQL.squish
         projects.id IN (
           SELECT project_id FROM phases
-          WHERE (start_at, coalesce(end_at, 'infinity'::DATE)) OVERLAPS ('#{Date.today}', '#{Date.today}')
+          WHERE (start_at, coalesce(end_at, 'infinity'::DATE)) OVERLAPS ('#{Time.zone.today}', '#{Time.zone.today}')
           AND participation_method != 'information'
         )
       SQL
@@ -161,7 +161,7 @@ class ProjectsFinderAdminService
       conditions << <<-SQL.squish
         projects.id IN (
           SELECT project_id FROM phases
-          WHERE (start_at, coalesce(end_at, 'infinity'::DATE)) OVERLAPS ('#{Date.today}', '#{Date.today}')
+          WHERE (start_at, coalesce(end_at, 'infinity'::DATE)) OVERLAPS ('#{Time.zone.today}', '#{Time.zone.today}')
           AND participation_method = 'information'
         )
       SQL

--- a/back/spec/services/projects_finder_admin_service_spec.rb
+++ b/back/spec/services/projects_finder_admin_service_spec.rb
@@ -139,7 +139,46 @@ describe ProjectsFinderAdminService do
       project
     end
 
-    # TODO
+    it 'returns all projects when no participation states specified' do
+      result = described_class.filter_participation_states(Project.all, {})
+      expect(result.pluck(:id).sort).to match_array([
+        not_started_project.id,
+        collecting_data_project.id,
+        information_phase_project.id,
+        past_project.id,
+        gap_project.id
+      ].sort)
+    end
+
+    it 'returns not_started projects' do
+      result = described_class.filter_participation_states(Project.all, { participation_states: ['not_started'] })
+      expect(result.pluck(:id)).to eq([not_started_project.id])
+    end
+
+    it 'returns collecting_data projects' do
+      result = described_class.filter_participation_states(Project.all, { participation_states: ['collecting_data'] })
+      expect(result.pluck(:id)).to eq([collecting_data_project.id])
+    end
+
+    it 'returns informing projects' do
+      result = described_class.filter_participation_states(Project.all, { participation_states: ['informing'] })
+      expect(result.pluck(:id)).to eq([information_phase_project.id])
+    end
+
+    it 'returns finished projects' do
+      result = described_class.filter_participation_states(Project.all, { participation_states: ['finished'] })
+      expect(result.pluck(:id)).to eq([past_project.id])
+    end
+
+    it 'returns collecting_data and finished projects' do
+      result = described_class.filter_participation_states(Project.all, { participation_states: ['collecting_data', 'finished'] })
+      expect(result.pluck(:id).sort).to match_array([collecting_data_project.id, past_project.id].sort)
+    end
+
+    it 'returns not_started, collecting_data, informing and finished projects' do
+      result = described_class.filter_participation_states(Project.all, { participation_states: ['not_started', 'collecting_data', 'informing', 'finished'] })
+      expect(result.pluck(:id).sort).to match_array([not_started_project.id, collecting_data_project.id, information_phase_project.id, past_project.id].sort)
+    end
   end
 
   describe 'self.execute' do

--- a/back/spec/services/projects_finder_admin_service_spec.rb
+++ b/back/spec/services/projects_finder_admin_service_spec.rb
@@ -171,12 +171,12 @@ describe ProjectsFinderAdminService do
     end
 
     it 'returns collecting_data and past projects' do
-      result = described_class.filter_participation_states(Project.all, { participation_states: ['collecting_data', 'past'] })
+      result = described_class.filter_participation_states(Project.all, { participation_states: %w[collecting_data past] })
       expect(result.pluck(:id).sort).to match_array([collecting_data_project.id, past_project.id].sort)
     end
 
     it 'returns not_started, collecting_data, informing and past projects' do
-      result = described_class.filter_participation_states(Project.all, { participation_states: ['not_started', 'collecting_data', 'informing', 'past'] })
+      result = described_class.filter_participation_states(Project.all, { participation_states: %w[not_started collecting_data informing past] })
       expect(result.pluck(:id).sort).to match_array([not_started_project.id, collecting_data_project.id, information_phase_project.id, past_project.id].sort)
     end
   end

--- a/back/spec/services/projects_finder_admin_service_spec.rb
+++ b/back/spec/services/projects_finder_admin_service_spec.rb
@@ -165,18 +165,18 @@ describe ProjectsFinderAdminService do
       expect(result.pluck(:id)).to eq([information_phase_project.id])
     end
 
-    it 'returns finished projects' do
-      result = described_class.filter_participation_states(Project.all, { participation_states: ['finished'] })
+    it 'returns past projects' do
+      result = described_class.filter_participation_states(Project.all, { participation_states: ['past'] })
       expect(result.pluck(:id)).to eq([past_project.id])
     end
 
-    it 'returns collecting_data and finished projects' do
-      result = described_class.filter_participation_states(Project.all, { participation_states: ['collecting_data', 'finished'] })
+    it 'returns collecting_data and past projects' do
+      result = described_class.filter_participation_states(Project.all, { participation_states: ['collecting_data', 'past'] })
       expect(result.pluck(:id).sort).to match_array([collecting_data_project.id, past_project.id].sort)
     end
 
-    it 'returns not_started, collecting_data, informing and finished projects' do
-      result = described_class.filter_participation_states(Project.all, { participation_states: ['not_started', 'collecting_data', 'informing', 'finished'] })
+    it 'returns not_started, collecting_data, informing and past projects' do
+      result = described_class.filter_participation_states(Project.all, { participation_states: ['not_started', 'collecting_data', 'informing', 'past'] })
       expect(result.pluck(:id).sort).to match_array([not_started_project.id, collecting_data_project.id, information_phase_project.id, past_project.id].sort)
     end
   end

--- a/back/spec/services/projects_finder_admin_service_spec.rb
+++ b/back/spec/services/projects_finder_admin_service_spec.rb
@@ -101,18 +101,44 @@ describe ProjectsFinderAdminService do
 
   describe 'self.filter_participation_states' do
     # Project that has not started yet
-    # TODO
+    let!(:not_started_project) do
+      project = create(:project)
+      create(:phase, start_at: Time.zone.today + 10.days, project: project)
+      project
+    end
 
     # Project with current data collection phase
-    # TODO
+    let!(:collecting_data_project) do
+      project = create(:project)
+      create(:phase, start_at: Time.zone.today - 20.days, end_at: Time.zone.today - 11.days, project: project, participation_method: 'information')
+      create(:phase, start_at: Time.zone.today - 10.days, end_at: Time.zone.today + 10.days, project: project, participation_method: 'ideation')
+      project
+    end
 
     # Project with current information phase
-    # TODO
+    let!(:information_phase_project) do
+      project = create(:project)
+      create(:phase, start_at: Time.zone.today - 20.days, end_at: Time.zone.today - 11.days, project: project, participation_method: 'ideation')
+      create(:phase, start_at: Time.zone.today - 10.days, end_at: Time.zone.today + 10.days, project: project, participation_method: 'information')
+      create(:phase, start_at: Time.zone.today + 11.days, end_at: nil, project: project, participation_method: 'ideation')
+      project
+    end
 
     # Project that is completely in the past
-    # TODO
+    let!(:past_project) do
+      project = create(:project)
+      create(:phase, start_at: Time.zone.today - 30.days, end_at: Time.zone.today - 20.days, project: project)
+      project
+    end
 
     # Project that has a gap between phases, and right now we're in the gap
+    let!(:gap_project) do
+      project = create(:project)
+      create(:phase, start_at: Time.zone.today - 30.days, end_at: Time.zone.today - 20.days, project: project)
+      create(:phase, start_at: Time.zone.today + 10.days, end_at: Time.zone.today + 20.days, project: project)
+      project
+    end
+
     # TODO
   end
 

--- a/back/spec/services/projects_finder_admin_service_spec.rb
+++ b/back/spec/services/projects_finder_admin_service_spec.rb
@@ -99,6 +99,23 @@ describe ProjectsFinderAdminService do
     end
   end
 
+  describe 'self.filter_participation_states' do
+    # Project that has not started yet
+    # TODO
+
+    # Project with current data collection phase
+    # TODO
+
+    # Project with current information phase
+    # TODO
+
+    # Project that is completely in the past
+    # TODO
+
+    # Project that has a gap between phases, and right now we're in the gap
+    # TODO
+  end
+
   describe 'self.execute' do
     describe 'sort: recently_viewed' do
       let!(:user) { create(:user) }


### PR DESCRIPTION
BE logic for the following filter states (see image below). For now, I will implement it as a separate filter dropdown, so you will have to select "Published" in one filter dropdown and "Participation state" in a second one. We can decide later to combine this in the FE as a single dropdown.

I have changed 'finished' to 'past' because 'finished' has a different meaning in the 'Finished and archived' widget: here, it only includes projects that are in the past, while in that widget it also includes projects that are in their last phase but the last phase is a reporting information phase.

<img width="442" alt="Captura de Tela 2025-06-30 às 09 49 23" src="https://github.com/user-attachments/assets/9f279336-03da-4c59-af30-b4eec73dd75b" />

# Changelog
## Technical
- Add BE logic for filtering projects by 'participation state' (not started, collecting data, informing, finished)
