### PR TITLE
assign only if nil as id seems to change

### DIFF
--- a/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/trackable.rb
+++ b/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/trackable.rb
@@ -31,7 +31,6 @@ module EmailCampaigns
       end
       if !@command[:delivery_id]
         ErrorReporter.report_msg('No delivery ID in extra_mailgun_variables!')
-        @command[:delivery_id] = SecureRandom.uuid
       end
       { 'cl_delivery_id' => @command[:delivery_id] }
     end

--- a/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/trackable.rb
+++ b/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/trackable.rb
@@ -34,9 +34,11 @@ module EmailCampaigns
 
     private
 
+    # rubocop:disable Naming/MemoizedInstanceVariableName
     def generate_delivery_id(_command)
-      @delivery_id = SecureRandom.uuid
+      @delivery_id ||= SecureRandom.uuid
     end
+    # rubocop:enable Naming/MemoizedInstanceVariableName
 
     def save_delivery(command)
       ErrorReporter.report_msg('No delivery ID in save_delivery!') if !@delivery_id

--- a/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/trackable.rb
+++ b/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/trackable.rb
@@ -25,25 +25,28 @@ module EmailCampaigns
     end
 
     def extra_mailgun_variables
-      if !@delivery_id
-        ErrorReporter.report_msg('No delivery ID in extra_mailgun_variables!')
-        @delivery_id = SecureRandom.uuid
+      if !@command
+        ErrorReporter.report_msg('No command in extra_mailgun_variables!')
+        @command = {}
       end
-      { 'cl_delivery_id' => @delivery_id }
+      if !@command[:delivery_id]
+        ErrorReporter.report_msg('No delivery ID in extra_mailgun_variables!')
+        @command[:delivery_id] = SecureRandom.uuid
+      end
+      { 'cl_delivery_id' => @command[:delivery_id] }
     end
 
     private
 
-    # rubocop:disable Naming/MemoizedInstanceVariableName
-    def generate_delivery_id(_command)
-      @delivery_id ||= SecureRandom.uuid
+    def generate_delivery_id(command)
+      @command = command
+      command[:delivery_id] ||= SecureRandom.uuid
     end
-    # rubocop:enable Naming/MemoizedInstanceVariableName
 
     def save_delivery(command)
-      ErrorReporter.report_msg('No delivery ID in save_delivery!') if !@delivery_id
+      ErrorReporter.report_msg('No delivery ID in save_delivery!') if !command[:delivery_id]
       deliveries.create(
-        id: @delivery_id,
+        id: command[:delivery_id],
         delivery_status: 'sent',
         user: command[:recipient],
         tracked_content: command[:tracked_content]

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaign.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaign.rb
@@ -140,19 +140,16 @@ module EmailCampaigns
       result
     end
 
-    def run_before_send_hooks(campaign)
-      result = true
+    def run_before_send_hooks(command)
       current_class = self.class
 
       while current_class <= ::EmailCampaigns::Campaign
-        result &&= current_class.before_send_hooks.all? do |action_symbol|
-          send(action_symbol, campaign)
+        current_class.before_send_hooks.each do |action_symbol|
+          send(action_symbol, command)
         end
 
         current_class = current_class.superclass
       end
-
-      result
     end
 
     def run_after_send_hooks(command)

--- a/back/engines/free/email_campaigns/spec/mailers/shared_examples_for_campaign_delivery_tracking.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/shared_examples_for_campaign_delivery_tracking.rb
@@ -10,7 +10,7 @@ RSpec.shared_examples 'campaign delivery tracking' do
         mailer_instance
       end
 
-      campaign.run_before_send_hooks({})
+      campaign.run_before_send_hooks(command)
       mailer.campaign_mail.deliver_now
       campaign.run_after_send_hooks(command)
 

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/concerns/trackable_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/concerns/trackable_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe EmailCampaigns::Trackable do
       recipient: user,
       tracked_content: {}
     }
-    # expect(campaign.extra_mailgun_variables['cl_delivery_id']).to be_nil
+    expect(campaign.extra_mailgun_variables['cl_delivery_id']).to be_nil
 
     campaign.run_before_send_hooks(command)
     delivery_id = campaign.extra_mailgun_variables['cl_delivery_id']


### PR DESCRIPTION
I think I'm getting close. The ID is now included in the Mailgunheaders, but is different from the delivery, so I now think that generate_delivery_id is somehow being called after the email is sent.