### PR TITLE
TAN-4933 Remove logic from multiselect fields in form builder

### DIFF
--- a/front/app/components/FormBuilder/components/FormBuilderSettings/index.tsx
+++ b/front/app/components/FormBuilder/components/FormBuilderSettings/index.tsx
@@ -91,19 +91,23 @@ const FormBuilderSettings = ({
   const tabActiveBorder = `4px solid ${colors.primary}`;
   const fieldType = watch(`customFields.${field.index}.input_type`);
 
+  const fieldHasLogic = field.logic.rules && field.logic.rules.length > 0;
+
   const getShowTabbedSettings = () => {
     const isFieldWithLogicTab = [
-      'multiselect',
-      'multiselect_image',
       'linear_scale',
       'select',
       'rating',
       'page',
     ].includes(fieldType);
 
+    // Only show logic tab for multiselect/multiselect_image if they already have logic
+    const isMultiselectWithLogic =
+      ['multiselect', 'multiselect_image'].includes(fieldType) && fieldHasLogic;
+
     const isFormEndPage = fieldType === 'page' && field.key === 'form_end';
 
-    return isFieldWithLogicTab && !isFormEndPage;
+    return (isFieldWithLogicTab || isMultiselectWithLogic) && !isFormEndPage;
   };
 
   const showTabbedSettings = getShowTabbedSettings();

--- a/front/app/components/FormBuilder/components/FormBuilderSettings/index.tsx
+++ b/front/app/components/FormBuilder/components/FormBuilderSettings/index.tsx
@@ -91,8 +91,6 @@ const FormBuilderSettings = ({
   const tabActiveBorder = `4px solid ${colors.primary}`;
   const fieldType = watch(`customFields.${field.index}.input_type`);
 
-  const fieldHasLogic = field.logic.rules && field.logic.rules.length > 0;
-
   const getShowTabbedSettings = () => {
     const isFieldWithLogicTab = [
       'linear_scale',
@@ -101,7 +99,8 @@ const FormBuilderSettings = ({
       'page',
     ].includes(fieldType);
 
-    // Only show logic tab for multiselect/multiselect_image if they already have logic
+    // For backwards compatibility, we only show the logic tab for multiselect/multiselect_image if they already have logic.
+    const fieldHasLogic = field.logic.rules && field.logic.rules.length > 0;
     const isMultiselectWithLogic =
       ['multiselect', 'multiselect_image'].includes(fieldType) && fieldHasLogic;
 


### PR DESCRIPTION
# Changelog
## Changed
- Logic is removed for multi select and image multi select fields in form builder. Fields that already had logic rules added to them still display the logic tab in order to ensure backwards compatibility. For new fields added to forms the logic tab will no longer be accessible.
