### PR TITLE
[TAN-4983] Bugfix: Use pundit_user in idea_custom_fields controller index action

### DIFF
--- a/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/idea_custom_fields_controller.rb
+++ b/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/idea_custom_fields_controller.rb
@@ -40,7 +40,7 @@ module IdeaCustomFields
       fields = if params[:copy] == 'true'
         service.duplicate_all_fields
       elsif params[:public_fields] == 'true'
-        service.enabled_fields.select { |field| IdeaCustomFieldPolicy.new(current_user, field).show? }
+        service.enabled_fields.select { |field| IdeaCustomFieldPolicy.new(ApplicationPolicy::UserContext.new(current_user, policy_context), field).show? }
       elsif @custom_form.custom_field_ids.present?
         authorized_ids = IdeaCustomFieldPolicy::Scope.new(pundit_user, @custom_form.custom_fields, @custom_form).resolve.ids
         service.all_fields.select { |field| authorized_ids.include? field.id }

--- a/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/idea_custom_fields_controller.rb
+++ b/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/idea_custom_fields_controller.rb
@@ -45,7 +45,7 @@ module IdeaCustomFields
         authorized_ids = IdeaCustomFieldPolicy::Scope.new(pundit_user, @custom_form.custom_fields, @custom_form).resolve.ids
         service.all_fields.select { |field| authorized_ids.include? field.id }
       else
-        service.all_fields.select { |field| IdeaCustomFieldPolicy.new(current_user, field).show? }
+        service.all_fields.select { |field| IdeaCustomFieldPolicy.new(pundit_user, field).show? }
       end
       fields = fields.filter(&:support_free_text_value?) if params[:support_free_text_value].present?
       fields = fields.filter { |field| params[:input_types].include?(field.input_type) } if params[:input_types].present?

--- a/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/idea_custom_fields_controller.rb
+++ b/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/idea_custom_fields_controller.rb
@@ -40,7 +40,7 @@ module IdeaCustomFields
       fields = if params[:copy] == 'true'
         service.duplicate_all_fields
       elsif params[:public_fields] == 'true'
-        service.enabled_fields.select { |field| IdeaCustomFieldPolicy.new(ApplicationPolicy::UserContext.new(current_user, policy_context), field).show? }
+        service.enabled_fields.select { |field| IdeaCustomFieldPolicy.new(pundit_user, field).show? }
       elsif @custom_form.custom_field_ids.present?
         authorized_ids = IdeaCustomFieldPolicy::Scope.new(pundit_user, @custom_form.custom_fields, @custom_form).resolve.ids
         service.all_fields.select { |field| authorized_ids.include? field.id }

--- a/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/index_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/index_spec.rb
@@ -122,7 +122,7 @@ resource 'Idea Custom Fields' do
             include_examples 'Unauthorized (401)'
           end
         end
-      
+
         context 'and the project_preview_link feature flag is disabled and a valid preview_token is provided in cookies' do
           before { header('Cookie', "preview_token=#{survey_phase.project.preview_token}") }
 
@@ -158,7 +158,7 @@ resource 'Idea Custom Fields' do
             include_examples 'Unauthorized (401)'
           end
         end
-      
+
         context 'and the project_preview_link feature flag is disabled and a valid preview_token is provided in cookies' do
           before { header('Cookie', "preview_token=#{survey_phase.project.preview_token}") }
 

--- a/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/index_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/index_spec.rb
@@ -16,7 +16,7 @@ resource 'Idea Custom Fields' do
   shared_examples 'draft project preview tests' do |options = {}|
     phase_var = options[:phase_var] || 'survey_phase'
     custom_field_var = options[:custom_field_var] || 'custom_field1'
-    
+
     before do
       phase = instance_eval(phase_var)
       phase.project.update!(admin_publication_attributes: { publication_status: 'draft' })
@@ -38,7 +38,7 @@ resource 'Idea Custom Fields' do
         example 'List all public custom fields for a phase' do
           do_request(public_fields: true)
           assert_status 200
-          
+
           field = instance_eval(custom_field_var)
           expect(response_data.size).to be >= 1
           expect(response_data.map { |d| d.dig(:attributes, :key) }).to include(field.key)
@@ -130,10 +130,10 @@ resource 'Idea Custom Fields' do
     end
 
     context 'when regular user' do
-
       let(:user) { create(:user) }
+
       before { header_token_for(user) }
-      
+
       context 'when the project is in draft' do
         include_examples 'draft project preview tests', {
           phase_var: 'survey_phase',

--- a/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/index_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/index_spec.rb
@@ -13,20 +13,56 @@ resource 'Idea Custom Fields' do
     end
   end
 
-  shared_examples 'List all public custom fields for a phase' do
-    example 'List all public custom fields for a phase' do
-      do_request(public_fields: true)
-      assert_status 200
-      expect(response_data.size).to eq 1
-      expect(response_data.map { |d| d.dig(:attributes, :key) }).to eq [custom_field1.key]
-    end
-  end
-
-  shared_context 'with project preview feature enabled' do
+  shared_examples 'draft project preview tests' do |options = {}|
+    phase_var = options[:phase_var] || 'survey_phase'
+    custom_field_var = options[:custom_field_var] || 'custom_field1'
+    
     before do
-      settings = AppConfiguration.instance.settings
-      settings['project_preview_link'] = { 'enabled' => true, 'allowed' => true }
-      AppConfiguration.instance.update!(settings: settings)
+      phase = instance_eval(phase_var)
+      phase.project.update!(admin_publication_attributes: { publication_status: 'draft' })
+    end
+
+    context 'and the project_preview_link feature flag is enabled' do
+      before do
+        settings = AppConfiguration.instance.settings
+        settings['project_preview_link'] = { 'enabled' => true, 'allowed' => true }
+        AppConfiguration.instance.update!(settings: settings)
+      end
+
+      context 'and a valid preview_token is provided in cookies' do
+        before do
+          phase = instance_eval(phase_var)
+          header('Cookie', "preview_token=#{phase.project.preview_token}")
+        end
+
+        example 'List all public custom fields for a phase' do
+          do_request(public_fields: true)
+          assert_status 200
+          
+          field = instance_eval(custom_field_var)
+          expect(response_data.size).to be >= 1
+          expect(response_data.map { |d| d.dig(:attributes, :key) }).to include(field.key)
+        end
+      end
+
+      context 'and an invalid preview_token is provided in cookies' do
+        before { header('Cookie', 'preview_token=invalid') }
+
+        include_examples 'Unauthorized (401)'
+      end
+
+      context 'and no preview_token is provided in cookies' do
+        include_examples 'Unauthorized (401)'
+      end
+    end
+
+    context 'and the project_preview_link feature flag is disabled and a valid preview_token is provided in cookies' do
+      before do
+        phase = instance_eval(phase_var)
+        header('Cookie', "preview_token=#{phase.project.preview_token}")
+      end
+
+      include_examples 'Unauthorized (401)'
     end
   end
 
@@ -94,76 +130,24 @@ resource 'Idea Custom Fields' do
     end
 
     context 'when regular user' do
+
       let(:user) { create(:user) }
-
       before { header_token_for(user) }
-
+      
       context 'when the project is in draft' do
-        before do
-          survey_phase.project.update!(admin_publication_attributes: { publication_status: 'draft' })
-        end
-
-        context 'and the project_preview_link feature flag is enabled' do
-          include_context 'with project preview feature enabled'
-
-          context 'and a valid preview_token is provided in cookies' do
-            before { header('Cookie', "preview_token=#{survey_phase.project.preview_token}") }
-
-            include_examples 'List all public custom fields for a phase'
-          end
-
-          context 'and an invalid preview_token is provided in cookies' do
-            before { header('Cookie', 'preview_token=invalid') }
-
-            include_examples 'Unauthorized (401)'
-          end
-
-          context 'and no preview_token is provided in cookies' do
-            include_examples 'Unauthorized (401)'
-          end
-        end
-
-        context 'and the project_preview_link feature flag is disabled and a valid preview_token is provided in cookies' do
-          before { header('Cookie', "preview_token=#{survey_phase.project.preview_token}") }
-
-          include_examples 'Unauthorized (401)'
-        end
+        include_examples 'draft project preview tests', {
+          phase_var: 'survey_phase',
+          custom_field_var: 'custom_field1'
+        }
       end
     end
 
     context 'when a visitor' do
-      let(:user) { create(:user) }
-
       context 'when the project is in draft' do
-        before do
-          survey_phase.project.update!(admin_publication_attributes: { publication_status: 'draft' })
-        end
-
-        context 'and the project_preview_link feature flag is enabled' do
-          include_context 'with project preview feature enabled'
-
-          context 'and a valid preview_token is provided in cookies' do
-            before { header('Cookie', "preview_token=#{survey_phase.project.preview_token}") }
-
-            include_examples 'List all public custom fields for a phase'
-          end
-
-          context 'and an invalid preview_token is provided in cookies' do
-            before { header('Cookie', 'preview_token=invalid') }
-
-            include_examples 'Unauthorized (401)'
-          end
-
-          context 'and no preview_token is provided in cookies' do
-            include_examples 'Unauthorized (401)'
-          end
-        end
-
-        context 'and the project_preview_link feature flag is disabled and a valid preview_token is provided in cookies' do
-          before { header('Cookie', "preview_token=#{survey_phase.project.preview_token}") }
-
-          include_examples 'Unauthorized (401)'
-        end
+        include_examples 'draft project preview tests', {
+          phase_var: 'survey_phase',
+          custom_field_var: 'custom_field1'
+        }
       end
     end
   end


### PR DESCRIPTION
Ensure user using preview links can access custom fields index used in idea forms (to complete an idea, survey, etc.)

# Changelog
## Fixed
- [TAN-4983] Can complete & submit idea, survey, etc when using preview link. (idea form custom_fields can be indexed).
