### PR TITLE
TAN-4946 - Checkbox and Date user fields added to PDF form

### DIFF
--- a/back/app/models/custom_field.rb
+++ b/back/app/models/custom_field.rb
@@ -274,7 +274,8 @@ class CustomField < ApplicationRecord
     build_in_types = %w[text_multiloc html_multiloc image_files files topic_ids]
     ideation_types = ParticipationMethod::Ideation::ALLOWED_EXTRA_FIELD_TYPES
     native_survey_types = ParticipationMethod::NativeSurvey::ALLOWED_EXTRA_FIELD_TYPES
-    all_input_types = build_in_types + ideation_types + native_survey_types
+    user_field_types = %w[checkbox date] # Only when 'user_fields_in_form' is enabled
+    all_input_types = build_in_types + ideation_types + native_survey_types + user_field_types
 
     all_input_types.include? input_type
   end
@@ -288,7 +289,7 @@ class CustomField < ApplicationRecord
   end
 
   def pdf_importable?
-    ignore_field_types = %w[page date files topic_ids image_files file_upload shapefile_upload point line polygon cosponsor_ids ranking matrix_linear_scale]
+    ignore_field_types = %w[page checkbox files topic_ids image_files file_upload shapefile_upload point line polygon cosponsor_ids ranking matrix_linear_scale]
     printable? && ignore_field_types.exclude?(input_type)
   end
 

--- a/back/config/locales/en.yml
+++ b/back/config/locales/en.yml
@@ -341,7 +341,7 @@ en:
       line_print_description: 'Please draw a route on the map below.'
       polygon_print_description: 'Please draw a shape on the map below.'
       select_print_description: 'Only choose one option.'
-      date_print_description: 'Please write the date in the format YYYY-DD-MM'
+      date_print_description: 'Please write a date in the format YYYY-DD-MM.'
   project_copy:
     title_suffix: 'Copy'
   confirmations_mailer:

--- a/back/config/locales/en.yml
+++ b/back/config/locales/en.yml
@@ -341,7 +341,7 @@ en:
       line_print_description: 'Please draw a route on the map below.'
       polygon_print_description: 'Please draw a shape on the map below.'
       select_print_description: 'Only choose one option.'
-      date_print_description: 'Please write a date in the format YYYY-DD-MM.'
+      date_print_description: 'Please write a date in the format YYYY-MM-DD.'
   project_copy:
     title_suffix: 'Copy'
   confirmations_mailer:

--- a/back/config/locales/en.yml
+++ b/back/config/locales/en.yml
@@ -341,6 +341,7 @@ en:
       line_print_description: 'Please draw a route on the map below.'
       polygon_print_description: 'Please draw a shape on the map below.'
       select_print_description: 'Only choose one option.'
+      date_print_description: 'Please write the date in the format YYYY-DD-MM'
   project_copy:
     title_suffix: 'Copy'
   confirmations_mailer:

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_html_form_exporter.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/idea_html_form_exporter.rb
@@ -177,12 +177,14 @@ module BulkImportIdeas::Exporters
         :multi_select_image
       when 'multiline_text', 'html_multiloc'
         :multi_line_text
-      when 'text', 'text_multiloc', 'number', 'linear_scale', 'rating', 'sentiment_linear_scale'
+      when 'text', 'text_multiloc', 'number', 'linear_scale', 'rating', 'sentiment_linear_scale', 'date'
         :single_line_text
       when 'ranking'
         :ranking
       when 'matrix_linear_scale'
         :matrix_linear_scale
+      when 'checkbox'
+        :checkbox
       when 'point', 'line', 'polygon'
         field_map_url(field) ? :mapping : :unsupported
       else
@@ -213,6 +215,7 @@ module BulkImportIdeas::Exporters
       html += ranking_print_instructions(field)
       html += matrix_print_instructions(field)
       html += map_print_instructions(field)
+      html += date_print_instructions(field)
       html
     end
 
@@ -390,6 +393,12 @@ module BulkImportIdeas::Exporters
       end
 
       format_instructions(description)
+    end
+
+    def date_print_instructions(field)
+      return '' unless field.input_type == 'date'
+
+      format_instructions(I18n.with_locale(@locale) { I18n.t('form_builder.pdf_export.date_print_description') })
     end
 
     def format_instructions(instructions)

--- a/back/engines/commercial/bulk_import_ideas/app/views/bulk_import_ideas/web_api/v1/export_form.html.erb
+++ b/back/engines/commercial/bulk_import_ideas/app/views/bulk_import_ideas/web_api/v1/export_form.html.erb
@@ -285,6 +285,13 @@
               <img alt="" src="<%= field[:map_url] %>">
             </div>
 
+          <% elsif field[:format] == :checkbox %>
+            <div class="options">
+                <div class="select">
+                  <div><input type="checkbox" class="checkbox"></div>
+                </div>
+            </div>
+
           <% else %>
             <div class="unsupported">
               <p><%= unsupported_field_text %></p>

--- a/back/engines/commercial/bulk_import_ideas/spec/services/exporters/idea_html_form_exporter_spec.rb
+++ b/back/engines/commercial/bulk_import_ideas/spec/services/exporters/idea_html_form_exporter_spec.rb
@@ -68,6 +68,10 @@ describe BulkImportIdeas::Exporters::IdeaHtmlFormExporter do
   let!(:polygon_field) { create(:custom_field_polygon, resource: custom_form, title_multiloc: { 'en' => 'Polygon field' }) }
   let!(:end_page_field) { create(:custom_field_form_end_page, resource: custom_form) }
 
+  # User fields
+  let_it_be(:checkbox_field) { create(:custom_field_checkbox, resource_type: 'User', title_multiloc: { 'en' => 'Checkbox field' })}
+  let_it_be(:date_field) { create(:custom_field_date, resource_type: 'User', title_multiloc: { 'en' => 'Date field' })}
+
   before do
     settings = AppConfiguration.instance.settings
     settings['maps'] = {
@@ -249,30 +253,23 @@ describe BulkImportIdeas::Exporters::IdeaHtmlFormExporter do
         expect(line.text).not_to include 'Please draw a route on the map below.'
         expect(line.text).to include 'This field cannot be completed on paper.'
       end
+    end
 
-      context 'user_fields_in_form is enabled' do
-        # let!(:parsed_html) do
-        #   create(:custom_field_checkbox, key: 'checkbox', resource_type: 'User', title_multiloc: { 'en' => 'Checkbox field' })
-        #   phase.update!(user_fields_in_form: true)
-        #   Nokogiri::HTML(service.export)
-        # end
+    context 'user_fields_in_form is enabled' do
+      let!(:parsed_html) do
+        phase.update!(user_fields_in_form: true)
+        Nokogiri::HTML(service.export)
+      end
 
-        it 'shows checkbox question' do
-          checkbox_field = create(:custom_field_checkbox, key: 'checkbox', resource_type: 'User', title_multiloc: { 'en' => 'Checkbox field' })
-          phase.update!(user_fields_in_form: true)
-          parsed_html = Nokogiri::HTML(service.export)
-          binding.pry
-          checkbox = parsed_html.css("div##{checkbox_field.id}")
-          # expect(ranking.text).to include 'Please write a number from 1 (most preferred) and 2 (least preferred) in each box. Use each number exactly once.'
-          # expect(ranking.text).to include 'Ranking one'
-          # expect(ranking.text).to include 'Ranking two'
-        end
+      it 'shows checkbox question' do
+        checkbox = parsed_html.css("div##{checkbox_field.id}")
+        expect(checkbox.text).to include 'Checkbox field'
+      end
 
-        it 'shows date question' do
-          date_field = create(:custom_field_date, resource: custom_form, key: 'date_field', title_multiloc: { 'en' => 'Date field' })
-          date_html = parsed_html.css("div##{date_field.id}")
-          expect(date_html.text).to include 'Please write a date in the format dd-mm-yyyy.'
-        end
+      it 'shows date question' do
+        date_html = parsed_html.css("div##{date_field.id}")
+        expect(date_html.text).to include 'Date field'
+        expect(date_html.text).to include 'Please write a date in the format dd-mm-yyyy.'
       end
     end
   end

--- a/back/engines/commercial/bulk_import_ideas/spec/services/exporters/idea_html_form_exporter_spec.rb
+++ b/back/engines/commercial/bulk_import_ideas/spec/services/exporters/idea_html_form_exporter_spec.rb
@@ -69,8 +69,8 @@ describe BulkImportIdeas::Exporters::IdeaHtmlFormExporter do
   let!(:end_page_field) { create(:custom_field_form_end_page, resource: custom_form) }
 
   # User fields
-  let_it_be(:checkbox_field) { create(:custom_field_checkbox, resource_type: 'User', title_multiloc: { 'en' => 'Checkbox field' })}
-  let_it_be(:date_field) { create(:custom_field_date, resource_type: 'User', title_multiloc: { 'en' => 'Date field' })}
+  let_it_be(:checkbox_field) { create(:custom_field_checkbox, resource_type: 'User', title_multiloc: { 'en' => 'Checkbox field' }) }
+  let_it_be(:date_field) { create(:custom_field_date, resource_type: 'User', title_multiloc: { 'en' => 'Date field' }) }
 
   before do
     settings = AppConfiguration.instance.settings

--- a/back/engines/commercial/bulk_import_ideas/spec/services/exporters/idea_html_form_exporter_spec.rb
+++ b/back/engines/commercial/bulk_import_ideas/spec/services/exporters/idea_html_form_exporter_spec.rb
@@ -269,7 +269,7 @@ describe BulkImportIdeas::Exporters::IdeaHtmlFormExporter do
       it 'shows date question' do
         date_html = parsed_html.css("div##{date_field.id}")
         expect(date_html.text).to include 'Date field'
-        expect(date_html.text).to include 'Please write a date in the format dd-mm-yyyy.'
+        expect(date_html.text).to include 'Please write a date in the format YYYY-MM-DD.'
       end
     end
   end

--- a/back/spec/fixtures/locales/en.yml
+++ b/back/spec/fixtures/locales/en.yml
@@ -43,7 +43,7 @@ en:
       line_print_description: 'Please draw a route on the map below.'
       polygon_print_description: 'Please draw a shape on the map below.'
       select_print_description: 'Only choose one option.'
-      date_print_description: 'Please write the date in the format YYYY-DD-MM'
+      date_print_description: 'Please write a date in the format YYYY-DD-MM.'
   custom_fields:
     ideas:
       title:

--- a/back/spec/fixtures/locales/en.yml
+++ b/back/spec/fixtures/locales/en.yml
@@ -43,7 +43,7 @@ en:
       line_print_description: 'Please draw a route on the map below.'
       polygon_print_description: 'Please draw a shape on the map below.'
       select_print_description: 'Only choose one option.'
-      date_print_description: 'Please write a date in the format YYYY-DD-MM.'
+      date_print_description: 'Please write a date in the format YYYY-MM-DD.'
   custom_fields:
     ideas:
       title:

--- a/back/spec/fixtures/locales/en.yml
+++ b/back/spec/fixtures/locales/en.yml
@@ -43,6 +43,7 @@ en:
       line_print_description: 'Please draw a route on the map below.'
       polygon_print_description: 'Please draw a shape on the map below.'
       select_print_description: 'Only choose one option.'
+      date_print_description: 'Please write the date in the format YYYY-DD-MM'
   custom_fields:
     ideas:
       title:


### PR DESCRIPTION
Fields look like this (checkbox is the same as how it appears on the web form - not ideal, but it's there) 
<img width="420" height="202" alt="image" src="https://github.com/user-attachments/assets/23249fe4-f655-4b21-bb1f-38a76e3402f2" />

# Changelog
## Changed
- Added checkbox and date fields to the PDF form download
