### PR TITLE
Ensure button is visually evenly spread across container

### DIFF
--- a/front/app/components/VoteInputs/multiple/AssignMultipleVotesBox.tsx
+++ b/front/app/components/VoteInputs/multiple/AssignMultipleVotesBox.tsx
@@ -14,7 +14,7 @@ import { isNil } from 'utils/helperUtils';
 import messages from '../_shared/messages';
 import WhiteBox from '../_shared/WhiteBox';
 
-import AssignMultipleVotesControl from './AssignMultipleVotesInput';
+import AssignMultipleVotesInput from './AssignMultipleVotesInput';
 
 interface Props {
   ideaId: string;
@@ -48,7 +48,7 @@ const AssignMultipleVotesBox = memo(({ ideaId, phase }: Props) => {
 
   return (
     <WhiteBox>
-      <AssignMultipleVotesControl ideaId={ideaId} phase={phase} onIdeaPage />
+      <AssignMultipleVotesInput ideaId={ideaId} phase={phase} onIdeaPage />
       <Box
         color={colors.grey700}
         mt="8px"

--- a/front/app/components/VoteInputs/multiple/AssignMultipleVotesInput/index.tsx
+++ b/front/app/components/VoteInputs/multiple/AssignMultipleVotesInput/index.tsx
@@ -268,28 +268,30 @@ const AssignMultipleVotesInput = ({
   }
 
   return (
-    <Tooltip
-      disabled={!plusButtonDisabledExplanation}
-      placement="bottom"
-      content={plusButtonDisabledExplanation}
-    >
-      <div>
-        <Button
-          buttonStyle="primary-outlined"
-          disabled={!!plusButtonDisabledExplanation}
-          processing={isProcessing}
-          className="e2e-multiple-votes-button"
-          icon="vote-ballot"
-          width="100%"
-          onClick={onAdd}
-          opacityDisabled="0.8"
-          textDisabledColor={colors.coolGrey700}
-          borderDisabledColor={colors.coolGrey700}
-        >
-          {formatMessage(messages.select)}
-        </Button>
-      </div>
-    </Tooltip>
+    <Box w="100%">
+      <Tooltip
+        disabled={!plusButtonDisabledExplanation}
+        placement="bottom"
+        content={plusButtonDisabledExplanation}
+      >
+        <div>
+          <Button
+            buttonStyle="primary-outlined"
+            disabled={!!plusButtonDisabledExplanation}
+            processing={isProcessing}
+            className="e2e-multiple-votes-button"
+            icon="vote-ballot"
+            width="100%"
+            onClick={onAdd}
+            opacityDisabled="0.8"
+            textDisabledColor={colors.coolGrey700}
+            borderDisabledColor={colors.coolGrey700}
+          >
+            {formatMessage(messages.select)}
+          </Button>
+        </div>
+      </Tooltip>
+    </Box>
   );
 };
 


### PR DESCRIPTION
Before
<img width="397" height="358" alt="Screenshot 2025-07-14 at 10 07 47" src="https://github.com/user-attachments/assets/b59c7e8a-71aa-48ab-b632-afcc8cfa26a9" />

After
<img width="378" height="340" alt="Screenshot 2025-07-14 at 10 07 39" src="https://github.com/user-attachments/assets/867bd7f7-2ed6-4c79-b19f-e84e24222a44" />


# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Input page of multi-vote phases: width of "Select" button ([before/after](https://github.com/CitizenLabDotCo/citizenlab/pull/11581))