### PR TITLE
Ensure vote button is full width on mobile

### DIFF
--- a/front/app/components/ParticipationCTABars/VotingCTABar/CTAButton.tsx
+++ b/front/app/components/ParticipationCTABars/VotingCTABar/CTAButton.tsx
@@ -146,7 +146,7 @@ const CTAButton = ({ phase, project }: Props) => {
   );
 
   return (
-    <>
+    <Box width="100%">
       <Tooltip
         disabled={!disabledExplanation}
         placement="bottom"
@@ -183,7 +183,7 @@ const CTAButton = ({ phase, project }: Props) => {
           <FormattedMessage {...messages.budgetSubmitSuccess} />
         )}
       </ScreenReaderOnly>
-    </>
+    </Box>
   );
 };
 


### PR DESCRIPTION
Before
<img width="382" height="674" alt="image" src="https://github.com/user-attachments/assets/73cd1224-6012-47cb-baf4-d1cc3604761e" />

After
<img width="384" height="680" alt="Screenshot 2025-07-14 at 10 17 10" src="https://github.com/user-attachments/assets/49c61cc2-5896-4ca2-8059-15b785452362" />


# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

## Fixed
- Ensure vote button is full width on mobile (before/after)