### PR TITLE
[TAN-4966] Fix PDF export of special characters in custom fonts

### DIFF
--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/gotenberg_client.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/gotenberg_client.rb
@@ -10,17 +10,12 @@ module BulkImportIdeas::Exporters
     def render_to_pdf(html)
       return false unless up?
 
-      # Create a file with explicit UTF-8 encoding
-      html_file = Tempfile.new(['input', '.html'])
-      html_file.write("<!DOCTYPE html><html><head><meta charset=\"UTF-8\"></head><body>#{html}</body></html>")
-      html_file.rewind
-
       payload = {
         'preferCssPageSize' => true,
         'generateDocumentOutline' => true, 
         'generateTaggedPdf' => true,
         'index.html' => Faraday::Multipart::FilePart.new(
-          html_file.path,
+          StringIO.new(html),
           'text/html; charset=utf-8',
           'index.html'
         )
@@ -32,13 +27,13 @@ module BulkImportIdeas::Exporters
         f.adapter :net_http
       end
       response = conn.post(url, payload)
-      html_file.close
-      html_file.unlink
 
       output_pdf = Tempfile.new(['gotenberg', '.pdf'])
       output_pdf.binmode
       output_pdf.write(response.body)
       output_pdf.rewind
+      
+      output_pdf
     end
 
     private

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/gotenberg_client.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/gotenberg_client.rb
@@ -12,7 +12,7 @@ module BulkImportIdeas::Exporters
 
       payload = {
         'preferCssPageSize' => true,
-        'generateDocumentOutline' => true, 
+        'generateDocumentOutline' => true,
         'generateTaggedPdf' => true,
         'index.html' => Faraday::Multipart::FilePart.new(
           StringIO.new(html),

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/gotenberg_client.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/exporters/gotenberg_client.rb
@@ -32,7 +32,7 @@ module BulkImportIdeas::Exporters
       output_pdf.binmode
       output_pdf.write(response.body)
       output_pdf.rewind
-      
+
       output_pdf
     end
 

--- a/back/engines/commercial/bulk_import_ideas/app/views/bulk_import_ideas/web_api/v1/export_form.html.erb
+++ b/back/engines/commercial/bulk_import_ideas/app/views/bulk_import_ideas/web_api/v1/export_form.html.erb
@@ -1,5 +1,6 @@
 <html>
 <head>
+  <meta charset="UTF-8">
   <title><%= form_title %></title>
 
   <% if font_config %>


### PR DESCRIPTION
No regression test added, as we do not have Gotenberg available in CI test environment, so very hard or impossible to replicate the conditions that would cause the issue (without this fix).

Testing functionally, locally, with Vienna's custom font:

Before:
<img width="788" height="408" alt="Screenshot 2025-07-14 at 10 52 55" src="https://github.com/user-attachments/assets/b42786f5-eb83-4396-89f6-178230b3f9dd" />

After:
<img width="788" height="408" alt="Screenshot 2025-07-14 at 10 51 44" src="https://github.com/user-attachments/assets/e3922666-4a3e-4384-943a-ca533ea29509" />

# Changelog
## Fixed
- [TAN-4966] Fix PDF export of special characters in custom fonts
