### PR TITLE
Extra check to make sure Delivery ID is included in Mailgun headers

### DIFF
--- a/back/engines/free/email_campaigns/app/controllers/email_campaigns/hooks/mailgun_events_controller.rb
+++ b/back/engines/free/email_campaigns/app/controllers/email_campaigns/hooks/mailgun_events_controller.rb
@@ -38,6 +38,12 @@ module EmailCampaigns
           head :not_acceptable
         end
       else
+        # If this error is never reported to Sentry, we can remove this after a month or so,
+        # together with the ErrorReporter call in extra_mailgun_variables in the Trackable concern.
+        ErrorReporter.report_msg(
+          'No delivery found for delivery ID passed in Mailgun hook!',
+          extra: { user_variables: params[:'event-data'][:'user-variables'] }
+        )
         # We haven't sent out this mail
         head :not_acceptable
       end

--- a/back/engines/free/email_campaigns/app/controllers/email_campaigns/hooks/mailgun_events_controller.rb
+++ b/back/engines/free/email_campaigns/app/controllers/email_campaigns/hooks/mailgun_events_controller.rb
@@ -38,8 +38,8 @@ module EmailCampaigns
           head :not_acceptable
         end
       else
-        # If this error is never reported to Sentry, we can remove this after a month or so,
-        # together with the ErrorReporter call in extra_mailgun_variables in the Trackable concern.
+        # If this error is never reported to Sentry, we can remove this in August 2025, together
+        # with the ErrorReporter call in extra_mailgun_variables in the Trackable concern.
         ErrorReporter.report_msg(
           'No delivery found for delivery ID passed in Mailgun hook!',
           extra: { user_variables: params[:'event-data'][:'user-variables'] }

--- a/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/trackable.rb
+++ b/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/trackable.rb
@@ -25,7 +25,10 @@ module EmailCampaigns
     end
 
     def extra_mailgun_variables(command)
-      if !command[:delivery_id] # This can be removed after a month or so.
+      if !command[:delivery_id]
+        # This can be removed after a month or so. It seems like the delivery_id is always included now,
+        # but somehow the Mailgun header is also called when the delivery_id is not set yet. But if the
+        # error in MailgunEventsController is not raised, then all should be fine.
         ErrorReporter.report_msg(
           'No delivery ID in Mailgun variables!',
           extra: { command: command, campaign: self }

--- a/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/trackable.rb
+++ b/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/trackable.rb
@@ -26,9 +26,9 @@ module EmailCampaigns
 
     def extra_mailgun_variables(command)
       if !command[:delivery_id]
-        # This can be removed after a month or so. It seems like the delivery_id is always included now,
-        # but somehow the Mailgun header is also called when the delivery_id is not set yet. But if the
-        # error in MailgunEventsController is not raised, then all should be fine.
+        # This can be removed in August 2025. It seems like the delivery_id is always included now,
+        # but somehow the Mailgun header is also called when the delivery_id is not set yet. But if
+        # the error in MailgunEventsController is not raised, then all should be fine.
         ErrorReporter.report_msg(
           'No delivery ID in Mailgun variables!',
           extra: { command: command, campaign: self }


### PR DESCRIPTION
I have not been able to reproduce this locally, even with:
```
activity = Activity.find_by(item: User.find_by(email: 'sebastien.h@govocal.com'), action: 'completed_registration')
10.times do
  EmailCampaigns::TriggerOnActivityJob.perform_later(activity)
end
```

Then, I looked up a delivery that corresponded with the time and type of email for an exception that was raised in Sentry. The delivery was successfully updated to "clicked", and in Mailgun, I could see that the delivery ID was included in the headers (see included screenshots).

<img width="428" height="190" alt="Screenshot 2025-07-14 at 12 37 00" src="https://github.com/user-attachments/assets/7ee22b88-8950-497a-951e-6de270bbd021" />
<img width="1312" height="763" alt="Screenshot 2025-07-14 at 12 37 13" src="https://github.com/user-attachments/assets/ce9734f2-cff1-4115-a357-74ba1e404f0d" />
<img width="567" height="155" alt="Screenshot 2025-07-14 at 12 48 40" src="https://github.com/user-attachments/assets/26a82aa7-bb70-4f7c-a102-7e638adc758e" />

I therefore now believe that the issues is that `mailgun_headers` is actually being called multiple times when sending the emails, and that one of those times is before the Delivery ID was added to the command. I added an extra `ErrorReporter` call to verify that this reasoning is true.
