### PR TITLE
TAN-5024: Make sure tooltip always appears on top of gantt chart

### DIFF
--- a/front/app/components/UI/GanttChart/components/GanttItem.tsx
+++ b/front/app/components/UI/GanttChart/components/GanttItem.tsx
@@ -90,6 +90,8 @@ const GanttItem = ({
       disabled={!renderItemTooltip}
       theme="dark"
       followCursor="initial"
+      zIndex={9999}
+      appendTo={typeof window !== 'undefined' ? () => document.body : undefined}
     >
       <Box
         position="absolute"


### PR DESCRIPTION
# Changelog

## Fixed
- Make sure tooltip always appears on top of gantt chart (Feature flagged with the project planning work)
