### PR TITLE
Remove "confirmation screen" after canceling cookie preference management

### DIFF
--- a/front/app/components/ConsentManager/Container.tsx
+++ b/front/app/components/ConsentManager/Container.tsx
@@ -1,4 +1,4 @@
-import React, { FormEvent, useState, useCallback } from 'react';
+import React, { FormEvent, useState } from 'react';
 
 import useObserveEvent from 'hooks/useObserveEvent';
 
@@ -19,6 +19,8 @@ interface Props {
   saveConsent: () => void;
 }
 
+export type FormMode = 'preferenceForm' | 'noDestinations';
+
 const Container = ({
   preferences,
   categorizedDestinations,
@@ -31,65 +33,36 @@ const Container = ({
   saveConsent,
 }: Props) => {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const [isCancelling, setIsCancelling] = useState(false);
 
-  const openDialog = useCallback(() => {
+  const openDialog = () => {
     onToggleModal(false);
     setIsDialogOpen(true);
-  }, [onToggleModal]);
+  };
 
-  const closeDialog = useCallback(() => {
+  const closeDialog = () => {
     onToggleModal(true);
     setIsDialogOpen(false);
-  }, [onToggleModal]);
+  };
 
   useObserveEvent('openConsentManager', openDialog);
 
-  const handleSave = useCallback(
-    (e: FormEvent) => {
-      e.preventDefault();
+  const handleSave = (e: FormEvent) => {
+    e.preventDefault();
 
-      setIsDialogOpen(false);
-      saveConsent();
-    },
-    [saveConsent]
-  );
-
-  const handleCancel = useCallback(() => {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    const isEmpty = Object.values(preferences).every((e) => e === undefined);
-
-    // Only show the cancel confirmation if there's unconsented destinations...
-    // or if the user made a choice and we want to confirm aborting it
-    if (isConsentRequired && !isEmpty) {
-      setIsCancelling(true);
-    } else {
-      setIsDialogOpen(false);
-      resetPreferences();
-    }
-  }, [preferences, isConsentRequired, resetPreferences]);
-
-  const handleCancelBack = useCallback(() => {
-    setIsCancelling(false);
-  }, []);
-
-  const handleCancelConfirm = useCallback(() => {
-    setIsCancelling(false);
     setIsDialogOpen(false);
+    saveConsent();
+  };
 
+  const handleCancel = () => {
     resetPreferences();
-  }, [resetPreferences]);
+    setIsDialogOpen(false);
+  };
 
   const noDestinations = Object.values(categorizedDestinations).every(
     (array) => array.length === 0
   );
 
-  const mode = noDestinations
-    ? 'noDestinations'
-    : !isCancelling
-    ? 'preferenceForm'
-    : 'cancelling';
+  const mode: FormMode = noDestinations ? 'noDestinations' : 'preferenceForm';
 
   return (
     <>
@@ -98,9 +71,6 @@ const Container = ({
         mode={mode}
         categorizedDestinations={categorizedDestinations}
         preferences={preferences}
-        isCancelling={isCancelling}
-        handleCancelBack={handleCancelBack}
-        handleCancelConfirm={handleCancelConfirm}
         handleCancel={handleCancel}
         handleSave={handleSave}
         onClose={closeDialog}

--- a/front/app/components/ConsentManager/PreferencesModal/Footer.tsx
+++ b/front/app/components/ConsentManager/PreferencesModal/Footer.tsx
@@ -8,6 +8,7 @@ import ButtonWithLink from 'components/UI/ButtonWithLink';
 
 import { FormattedMessage } from 'utils/cl-intl';
 
+import { FormMode } from '../Container';
 import messages from '../messages';
 
 const ButtonContainer = ({ children }: { children: React.ReactNode }) => (
@@ -26,40 +27,13 @@ const CancelButton = styled(ButtonWithLink)`
 `;
 
 interface Props {
-  handleCancelBack: () => void;
-  handleCancelConfirm: () => void;
   handleCancel: () => void;
   handleSave: (e: FormEvent<any>) => void;
-  mode: 'preferenceForm' | 'noDestinations' | 'cancelling';
+  mode: FormMode;
 }
 
-const Footer = ({
-  mode,
-  handleCancelBack,
-  handleCancelConfirm,
-  handleCancel,
-  handleSave,
-}: Props) => {
-  return mode === 'cancelling' ? (
-    <ButtonContainer>
-      <CancelButton
-        onClick={handleCancelBack}
-        buttonStyle="primary-inverse"
-        textColor={colors.primary}
-        textHoverColor={colors.primary}
-      >
-        <FormattedMessage {...messages.back} />
-      </CancelButton>
-      <ButtonWithLink
-        onClick={handleCancelConfirm}
-        buttonStyle="primary"
-        bgColor={colors.primary}
-        bgHoverColor={darken(0.1, colors.primary)}
-      >
-        <FormattedMessage {...messages.confirm} />
-      </ButtonWithLink>
-    </ButtonContainer>
-  ) : mode === 'preferenceForm' ? (
+const Footer = ({ mode, handleCancel, handleSave }: Props) => {
+  return mode === 'preferenceForm' ? (
     <ButtonContainer>
       <CancelButton
         onClick={handleCancel}

--- a/front/app/components/ConsentManager/PreferencesModal/index.tsx
+++ b/front/app/components/ConsentManager/PreferencesModal/index.tsx
@@ -1,28 +1,23 @@
 import React, { FormEvent } from 'react';
 
-import { Title } from '@citizenlab/cl2-component-library';
-
 import Modal from 'components/UI/Modal';
 
 import { FormattedMessage } from 'utils/cl-intl';
 
+import { FormMode } from '../Container';
 import { TCategory } from '../destinations';
 import messages from '../messages';
 import { CategorizedDestinations, IPreferences } from '../typings';
 
-import ContentContainer from './ContentContainer';
 import Footer from './Footer';
 import Preferences from './Preferences';
 
 interface Props {
   opened: boolean;
-  mode: 'preferenceForm' | 'noDestinations' | 'cancelling';
-  isCancelling: boolean;
+  mode: FormMode;
   categorizedDestinations: CategorizedDestinations;
   preferences: IPreferences;
   onClose: () => void;
-  handleCancelBack: () => void;
-  handleCancelConfirm: () => void;
   handleCancel: () => void;
   handleSave: (e: FormEvent) => void;
   updatePreference: (category: TCategory, value: boolean) => void;
@@ -31,13 +26,10 @@ interface Props {
 const PreferencesModal = ({
   opened,
   mode,
-  isCancelling,
   categorizedDestinations,
   preferences,
   onClose,
-  handleCancelBack,
   handleCancel,
-  handleCancelConfirm,
   handleSave,
   updatePreference,
 }: Props) => {
@@ -49,33 +41,16 @@ const PreferencesModal = ({
       footer={
         <Footer
           mode={mode}
-          handleCancelBack={handleCancelBack}
-          handleCancelConfirm={handleCancelConfirm}
           handleCancel={handleCancel}
           handleSave={handleSave}
         />
       }
     >
-      {!isCancelling ? (
-        <Preferences
-          onChange={updatePreference}
-          categoryDestinations={categorizedDestinations}
-          preferences={preferences}
-        />
-      ) : (
-        <ContentContainer
-          role="dialog"
-          aria-modal
-          // aria-labelledby helps screen readers find
-          // the title of the dialog
-          // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role
-          aria-labelledby="consent-manager-preferences-title"
-        >
-          <Title variant="h5" as="h1" id="consent-manager-preferences-title">
-            <FormattedMessage {...messages.confirmation} />
-          </Title>
-        </ContentContainer>
-      )}
+      <Preferences
+        onChange={updatePreference}
+        categoryDestinations={categorizedDestinations}
+        preferences={preferences}
+      />
     </Modal>
   );
 };

--- a/front/app/components/ConsentManager/messages.ts
+++ b/front/app/components/ConsentManager/messages.ts
@@ -93,12 +93,4 @@ export default defineMessages({
     id: 'app.components.ConsentManager.Modal.PreferencesDialog.cancel',
     defaultMessage: 'Cancel',
   },
-  confirmation: {
-    id: 'app.components.ConsentManager.Modal.CancelDialog.confirmation',
-    defaultMessage: 'If you cancel, your preferences will be lost.',
-  },
-  confirm: {
-    id: 'app.components.ConsentManager.Modal.CancelDialog.confirm',
-    defaultMessage: 'Confirm',
-  },
 });

--- a/front/app/translations/ar-MA.json
+++ b/front/app/translations/ar-MA.json
@@ -114,8 +114,6 @@
   "app.components.ConsentManager.Banner.manage": "إدارة",
   "app.components.ConsentManager.Banner.policyLink": "سياسة ملفات تعريف الارتباط ",
   "app.components.ConsentManager.Banner.reject": "يرفض",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "تأكيد",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "إذا قمت بالإلغاء، فستفقد تفضيلاتك.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "الإعلانات",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "نستخدم هذا لتخصيص وقياس فعالية الحملات الإعلانية على موقعنا الإلكتروني. لن نقوم بإظهار أي إعلانات على هذه المنصة، ولكن الخدمات التالية قد تقوم بإظهار إعلانات مخصصة لك بناءً على الصفحات التي قمت بزيارتها على موقعنا الإلكتروني.",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "سماح",

--- a/front/app/translations/ar-SA.json
+++ b/front/app/translations/ar-SA.json
@@ -114,8 +114,6 @@
   "app.components.ConsentManager.Banner.manage": "إدارة",
   "app.components.ConsentManager.Banner.policyLink": "سياسة ملفات تعريف الارتباط",
   "app.components.ConsentManager.Banner.reject": "يرفض",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "تأكيد",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "إذا قمت بالإلغاء، فستفقد تفضيلاتك.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "الإعلانات",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "نستخدم هذا لتخصيص وقياس فعالية الحملات الإعلانية على موقعنا الإلكتروني. لن نقوم بإظهار أي إعلانات على هذه المنصة، ولكن الخدمات التالية قد تقوم بإظهار إعلانات مخصصة لك بناءً على الصفحات التي قمت بزيارتها على موقعنا الإلكتروني.",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "سماح",

--- a/front/app/translations/ca-ES.json
+++ b/front/app/translations/ca-ES.json
@@ -114,8 +114,6 @@
   "app.components.ConsentManager.Banner.manage": "Gestionar",
   "app.components.ConsentManager.Banner.policyLink": "Política de galetes",
   "app.components.ConsentManager.Banner.reject": "Rebutjar",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "Confirmeu",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Si cancel·leu, es perdran les vostres preferències.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Publicitat",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "Utilitzem això per personalitzar i mesurar l'eficàcia de les campanyes publicitàries del nostre lloc web. No mostrarem cap publicitat en aquesta plataforma, però els serveis següents poden oferir-vos un anunci personalitzat en funció de les pàgines que visiteu al nostre lloc.",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "Permetre",

--- a/front/app/translations/cy-GB.json
+++ b/front/app/translations/cy-GB.json
@@ -114,8 +114,6 @@
   "app.components.ConsentManager.Banner.manage": "Rheoli",
   "app.components.ConsentManager.Banner.policyLink": "Polisi cwcis",
   "app.components.ConsentManager.Banner.reject": "Gwrthod",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "Cadarnhau",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Os byddwch yn canslo, bydd eich dewisiadau yn cael eu colli.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Hysbysebu",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "Rydym yn defnyddio hwn i bersonoli a mesur effeithiolrwydd ymgyrchoedd hysbysebu ein gwefan. Ni fyddwn yn dangos unrhyw hysbysebion ar y platfform hwn, ond efallai y bydd y gwasanaethau canlynol yn cynnig hysbyseb wedi'i bersonoli i chi yn seiliedig ar y tudalennau rydych chi'n ymweld â nhw ar ein gwefan.",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "Caniatáu",

--- a/front/app/translations/da-DK.json
+++ b/front/app/translations/da-DK.json
@@ -114,8 +114,6 @@
   "app.components.ConsentManager.Banner.manage": "Administrer",
   "app.components.ConsentManager.Banner.policyLink": "Cookiepolitik",
   "app.components.ConsentManager.Banner.reject": "Afvis",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "Bekræft",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Hvis du annullerer, vil dine præferencer gå tabt.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Reklamer og annoncering",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "{tenantName, select, Horsholm {For at personliggøre og måle reklamekampagnernes effektivitet på vores webside. Vi viser ikke nogen reklamer på denne platform, men følgende tjenester kan give dig en personlig reklame baseret på de sider du besøger på vores side. Denne platform sender data fra Google Analytics videre til Siteimprove, som er den applikation, der bruges af Hørsholm Kommune.} other {For at personliggøre og måle reklamekampagnernes effektivitet på vores webside. Vi viser ikke nogen reklamer på denne platform, men følgende tjenester kan give dig en personlig reklame baseret på de sider du besøger på vores side.}}",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "Tillade",

--- a/front/app/translations/de-DE.json
+++ b/front/app/translations/de-DE.json
@@ -114,8 +114,6 @@
   "app.components.ConsentManager.Banner.manage": "Bearbeiten",
   "app.components.ConsentManager.Banner.policyLink": "Cookie-Richtlinie",
   "app.components.ConsentManager.Banner.reject": "Ablehnen",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "Bestätigen",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Solltest du jetzt abbrechen, gehen die Einstellungen verloren.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Werbung",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "Wir verwenden dies, um Werbekampagnen auf unserer Webseite zu personalisieren und ihre Wirksamkeit zu messen. Wir zeigen keine Werbung auf dieser Plattform, aber die folgenden Dienste können Ihnen eine personalisierte Werbung auf der Grundlage der Seiten, die Sie auf unserer Webseite besuchen, anbieten.",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "Zulassen",

--- a/front/app/translations/el-GR.json
+++ b/front/app/translations/el-GR.json
@@ -114,8 +114,6 @@
   "app.components.ConsentManager.Banner.manage": "Διαχείριση",
   "app.components.ConsentManager.Banner.policyLink": "Πολιτική cookie",
   "app.components.ConsentManager.Banner.reject": "Απόρριψη",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "Επιβεβαίωση",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Εάν ακυρώσετε, οι προτιμήσεις σας θα χαθούν.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Διαφήμιση",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "Το χρησιμοποιούμε για την εξατομίκευση και τη μέτρηση της αποτελεσματικότητας των διαφημιστικών εκστρατειών του ιστότοπού μας. Δεν θα προβάλλουμε καμία διαφήμιση σε αυτή την πλατφόρμα, αλλά οι ακόλουθες υπηρεσίες ενδέχεται να σας προσφέρουν μια εξατομικευμένη διαφήμιση με βάση τις σελίδες που επισκέπτεστε στον ιστότοπό μας.",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "Να επιτρέπεται",

--- a/front/app/translations/en-CA.json
+++ b/front/app/translations/en-CA.json
@@ -114,8 +114,6 @@
   "app.components.ConsentManager.Banner.manage": "Manage",
   "app.components.ConsentManager.Banner.policyLink": "Cookie policy",
   "app.components.ConsentManager.Banner.reject": "Reject",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "Confirm",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "If you cancel, your preferences will be lost.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Advertising",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "We use this to personalize and measure the effectiveness of advertising campaigns of our website. We will not show any advertising on this platform, but the following services might offer you a personalized ad based on the pages you visit on our site.",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "Allow",

--- a/front/app/translations/en-GB.json
+++ b/front/app/translations/en-GB.json
@@ -114,8 +114,6 @@
   "app.components.ConsentManager.Banner.manage": "Manage",
   "app.components.ConsentManager.Banner.policyLink": "Cookie policy",
   "app.components.ConsentManager.Banner.reject": "Reject",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "Confirm",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "If you cancel, your preferences will be lost.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Advertising",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "We use this to personalise and measure the effectiveness of advertising campaigns of our website. We will not show any advertising on this platform, but the following services might offer you a personalised ad based on the pages you visit on our site.",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "Allow",

--- a/front/app/translations/en-IE.json
+++ b/front/app/translations/en-IE.json
@@ -114,8 +114,6 @@
   "app.components.ConsentManager.Banner.manage": "Manage",
   "app.components.ConsentManager.Banner.policyLink": "Cookie policy",
   "app.components.ConsentManager.Banner.reject": "Reject",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "Confirm",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "If you cancel, your preferences will be lost.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Advertising",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "We use this to personalize and measure the effectiveness of advertising campaigns of our website. We will not show any advertising on this platform, but the following services might offer you a personalized ad based on the pages you visit on our site.",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "Allow",

--- a/front/app/translations/en.json
+++ b/front/app/translations/en.json
@@ -114,8 +114,6 @@
   "app.components.ConsentManager.Banner.manage": "Manage",
   "app.components.ConsentManager.Banner.policyLink": "Cookie policy",
   "app.components.ConsentManager.Banner.reject": "Reject",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "Confirm",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "If you cancel, your preferences will be lost.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Advertising",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "We use this to personalize and measure the effectiveness of advertising campaigns of our website. We will not show any advertising on this platform, but the following services might offer you a personalized ad based on the pages you visit on our site.",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "Allow",

--- a/front/app/translations/es-CL.json
+++ b/front/app/translations/es-CL.json
@@ -114,8 +114,6 @@
   "app.components.ConsentManager.Banner.manage": "Administrar",
   "app.components.ConsentManager.Banner.policyLink": "Política de cookies",
   "app.components.ConsentManager.Banner.reject": "Rechaza",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "Confirmar",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Si cancelas, se perderán tus preferencias.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Publicidad",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "Usamos esto para personalizar y medir la efectividad de campañas de nuestro sitio Web. No mostramos ningún tipo de publicidad en esta plataforma, pero los siguientes servicios pueden ofrecer un anuncio personalizado basado en las páginas que visitas en nuestro sitio.",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "Permitir",

--- a/front/app/translations/es-ES.json
+++ b/front/app/translations/es-ES.json
@@ -114,8 +114,6 @@
   "app.components.ConsentManager.Banner.manage": "Administrar",
   "app.components.ConsentManager.Banner.policyLink": "Política de cookies",
   "app.components.ConsentManager.Banner.reject": "Rechaza",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "Confirmar",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Si cancelas, se perderán tus preferencias.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Publicidad",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "Usamos esto para personalizar y medir la efectividad de campañas de nuestro sitio Web. No mostramos ningún tipo de publicidad en esta plataforma, pero los siguientes servicios pueden ofrecer un anuncio personalizado basado en las páginas que visitas en nuestro sitio.",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "Permitir",

--- a/front/app/translations/fi-FI.json
+++ b/front/app/translations/fi-FI.json
@@ -114,8 +114,6 @@
   "app.components.ConsentManager.Banner.manage": "Muokkaa",
   "app.components.ConsentManager.Banner.policyLink": "Evästekäytäntö",
   "app.components.ConsentManager.Banner.reject": "Hylkää",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "Vahvistaa",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Jos peruutat, asetuksesi menetetään.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Mainonta",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "Käytämme tätä mukauttaaksemme ja mitataksemme verkkosivustomme mainoskampanjoiden tehokkuutta. Emme näytä mainoksia tällä alustalla, mutta seuraavat palvelut voivat tarjota sinulle räätälöidyn mainoksen sivustollamme vierailemiesi sivujen perusteella.",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "Sallia",

--- a/front/app/translations/fr-BE.json
+++ b/front/app/translations/fr-BE.json
@@ -114,8 +114,6 @@
   "app.components.ConsentManager.Banner.manage": "Gérer",
   "app.components.ConsentManager.Banner.policyLink": "Politique de cookie",
   "app.components.ConsentManager.Banner.reject": "Refuser",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "Confirmer",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Si vous annulez, vos préférences seront perdues.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Publicité",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "Nous utilisons ce suivi afin de personnaliser et mesurer l’efficacité de la publicité des campagnes de notre site Web. Nous ne montrerons aucune publicité sur cette plate-forme, mais les services suivants pourraient vous afficher des annonces personnalisées basées sur les pages que vous visitez sur notre site.",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "Permettre",

--- a/front/app/translations/fr-FR.json
+++ b/front/app/translations/fr-FR.json
@@ -114,8 +114,6 @@
   "app.components.ConsentManager.Banner.manage": "Gérer",
   "app.components.ConsentManager.Banner.policyLink": "Politique de cookie",
   "app.components.ConsentManager.Banner.reject": "Refuser",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "Confirmer",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Si vous annulez, vos préférences seront perdues.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Publicité",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "Nous utilisons ce suivi afin de personnaliser et mesurer l’efficacité de la publicité des campagnes de notre site Web. Nous ne montrerons aucune publicité sur cette plate-forme, mais les services suivants pourraient vous afficher des annonces personnalisées basées sur les pages que vous visitez sur notre site.",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "Permettre",

--- a/front/app/translations/hr-HR.json
+++ b/front/app/translations/hr-HR.json
@@ -114,8 +114,6 @@
   "app.components.ConsentManager.Banner.manage": "Upravljanje",
   "app.components.ConsentManager.Banner.policyLink": "Pravila o kolačićima",
   "app.components.ConsentManager.Banner.reject": "Odbiti",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "Potvrdi",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Ukoliko odustanete, vaše postavke neće biti spremljene.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Oglašavanje",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "Ovo koristimo kako bismo personalizovali oglašavanje na našem sajtu i merili njegovu efikasnost. Mi ne prikazujemo oglase, ali to na osnovu stranica koje na našem sajtu posećujete mogu učiniti sledeći servisi. ",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "Dopusti",

--- a/front/app/translations/hu-HU.json
+++ b/front/app/translations/hu-HU.json
@@ -114,8 +114,6 @@
   "app.components.ConsentManager.Banner.manage": "Kezelése",
   "app.components.ConsentManager.Banner.policyLink": "Cookie-szabályzat",
   "app.components.ConsentManager.Banner.reject": "Elutasít",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "Erősítse meg",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Ha lemond, a beállítások elvesznek.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Hirdető",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "Ezt arra használjuk, hogy személyre szabjuk és mérjük weboldalunk reklámkampányainak hatékonyságát. Ezen a platformon nem jelenítünk meg hirdetéseket, de a következő szolgáltatások személyre szabott hirdetést kínálhatnak Önnek az oldalunkon meglátogatott oldalak alapján.",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "Engedélyezze",

--- a/front/app/translations/it-IT.json
+++ b/front/app/translations/it-IT.json
@@ -114,8 +114,6 @@
   "app.components.ConsentManager.Banner.manage": "Gestire",
   "app.components.ConsentManager.Banner.policyLink": "Politica dei cookie",
   "app.components.ConsentManager.Banner.reject": "Rifiuta",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "Confermare",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Se ti cancelli, le tue preferenze andranno perse.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Pubblicità",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "Lo utilizziamo per personalizzare e misurare l'efficacia delle campagne pubblicitarie del nostro sito. Non mostreremo alcuna pubblicità su questa piattaforma, ma i seguenti servizi potrebbero offrirti un annuncio personalizzato in base alle pagine che visiti sul nostro sito.",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "Permettere",

--- a/front/app/translations/kl-GL.json
+++ b/front/app/translations/kl-GL.json
@@ -114,8 +114,6 @@
   "app.components.ConsentManager.Banner.manage": "Aqutsinerit",
   "app.components.ConsentManager.Banner.policyLink": "Cookiet pillugit politik",
   "app.components.ConsentManager.Banner.reject": "Reject",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "Uppernarsaruk",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Taamaatikkukku salliusussaanerit asuliinnassaaq.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Ussassaarutit saqqummiussinerlu",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "Nittartakkatsinni inunnut tulluussaaniarluta ussassaarinermillu pisariillisaaneq nalilerniarlugu Uani platformimi ussassaarutinik takutitsissanngilagut, kisianni kiffartuussinerit ilai nittartakkatsinni iserfigisatit malillugit inummut tulluussakkamik ussassaarsinnaavaatit.",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "Akuersineq",

--- a/front/app/translations/lb-LU.json
+++ b/front/app/translations/lb-LU.json
@@ -114,8 +114,6 @@
   "app.components.ConsentManager.Banner.manage": "Beaarbechten",
   "app.components.ConsentManager.Banner.policyLink": "Cookie-Richtlinnen",
   "app.components.ConsentManager.Banner.reject": "Refuséieren",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "Bestätegen",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Wann Dir ofbriecht, ginn Är Preferenze verluer.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Cookië fir Publicitéit",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "Mir benotzen dëst fir d'Effektivitéit vu Reklammekampagne vun eiser Websäit ze moossen an ze personaliséieren. Mir weise keng Reklamm op dëser Plattform. Allerdéngs kennen, baséierend op de Säiten déi Dir op eisem Site besicht, Ennerkontrakter (sous-traitant)  Iech personaliséiert Reklammen ubidden.",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "Erlaben",

--- a/front/app/translations/lt-LT.json
+++ b/front/app/translations/lt-LT.json
@@ -114,8 +114,6 @@
   "app.components.ConsentManager.Banner.manage": "Tvarkykite",
   "app.components.ConsentManager.Banner.policyLink": "Slapukų politika",
   "app.components.ConsentManager.Banner.reject": "Atmesti",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "Patvirtinkite",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Jei atšauksite užsakymą, jūsų parinktys bus prarastos.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Reklama",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "Naudojame tai, kad galėtume suasmeninti ir įvertinti mūsų svetainės reklamos kampanijų veiksmingumą. Šioje platformoje nerodysime jokios reklamos, tačiau toliau nurodytos paslaugos gali pasiūlyti jums asmeninę reklamą pagal jūsų aplankytus mūsų svetainės puslapius.",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "Leisti",

--- a/front/app/translations/lv-LV.json
+++ b/front/app/translations/lv-LV.json
@@ -114,8 +114,6 @@
   "app.components.ConsentManager.Banner.manage": "Pārvaldīt",
   "app.components.ConsentManager.Banner.policyLink": "Sīkdatņu politika",
   "app.components.ConsentManager.Banner.reject": "Noraidīt",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "Apstiprināt",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Ja atcelsiet reģistrāciju, jūsu preferences tiks zaudētas.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Reklāma",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "Mēs to izmantojam, lai personalizētu un mērītu mūsu vietnes reklāmas kampaņu efektivitāti. Šajā platformā mēs nerādīsim nekādas reklāmas, taču turpmāk minētie pakalpojumi var jums piedāvāt personalizētu reklāmu, pamatojoties uz jūsu apmeklētajām mūsu vietnes lapām.",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "Atļaut",

--- a/front/app/translations/mi.json
+++ b/front/app/translations/mi.json
@@ -34,8 +34,6 @@
   "app.components.ConsentManager.Banner.mainText": "This platform uses cookies in accordance with our {policyLink}.",
   "app.components.ConsentManager.Banner.manage": "Manage",
   "app.components.ConsentManager.Banner.policyLink": "Kaupapahere pihikete",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "Confirm",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "If you cancel, your preferences will be lost.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Advertising",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "We use this to personalise and measure the effectiveness of advertising campaigns of our website. We will not show any advertising on this platform, but the following services might offer you a personalised ad based on the pages you visit on our site.",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "Allow",

--- a/front/app/translations/nb-NO.json
+++ b/front/app/translations/nb-NO.json
@@ -114,8 +114,6 @@
   "app.components.ConsentManager.Banner.manage": "Administrer",
   "app.components.ConsentManager.Banner.policyLink": "Retningslinjer for informasjonskapsler",
   "app.components.ConsentManager.Banner.reject": "Avvis",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "Bekreft",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Hvis du avbryter, vil preferansene dine gå tapt.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Reklame",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "Vi bruker dette til å tilpasse og måle effektiviteten av reklamekampanjer på nettstedet vårt. Vi viser ingen reklame på denne plattformen, men følgende tjenester kan tilby deg en personlig tilpasset annonse basert på sidene du besøker på nettstedet vårt.",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "Tillat",

--- a/front/app/translations/nl-BE.json
+++ b/front/app/translations/nl-BE.json
@@ -114,8 +114,6 @@
   "app.components.ConsentManager.Banner.manage": "Beheren",
   "app.components.ConsentManager.Banner.policyLink": "Cookiebeleid",
   "app.components.ConsentManager.Banner.reject": "Weiger",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "Bevestigen",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Als je annuleert, gaan je voorkeuren verloren.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Advertenties",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "{tenantName, select, Noordwijk {We gebruiken dit om marketing campagnes op onze website te personaliseren en hun effectiviteit te meten. We tonen geen advertenties op het platform, maar de volgende diensten kunnen mogelijks gepersonaliseerde advertenties maken gebaseerd op de pagina's die je bezoekt op onze website. Dit platform stuurt de gegevens van Google Analytics door naar Siteimprove, de applicatie die door de gemeente Noordwijk wordt gebruikt.} other {We gebruiken dit om marketing campagnes op onze website te personaliseren en hun effectiviteit te meten. We tonen geen advertenties op het platform, maar de volgende diensten kunnen mogelijks gepersonaliseerde advertenties maken gebaseerd op de pagina's die je bezoekt op onze website.}}",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "Toestaan",

--- a/front/app/translations/nl-NL.json
+++ b/front/app/translations/nl-NL.json
@@ -114,8 +114,6 @@
   "app.components.ConsentManager.Banner.manage": "Beheren",
   "app.components.ConsentManager.Banner.policyLink": "Cookiebeleid",
   "app.components.ConsentManager.Banner.reject": "Weiger",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "Bevestigen",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Als je annuleert, gaan je voorkeuren verloren.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Advertenties",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "{tenantName, select, Noordwijk {We gebruiken dit om marketing campagnes op onze website te personaliseren en hun effectiviteit te meten. We tonen geen advertenties op het platform, maar de volgende diensten kunnen mogelijks gepersonaliseerde advertenties maken gebaseerd op de pagina's die je bezoekt op onze website. Dit platform stuurt de gegevens van Google Analytics door naar Siteimprove, de applicatie die door de gemeente Noordwijk wordt gebruikt.} other {We gebruiken dit om marketing campagnes op onze website te personaliseren en hun effectiviteit te meten. We tonen geen advertenties op het platform, maar de volgende diensten kunnen mogelijks gepersonaliseerde advertenties maken gebaseerd op de pagina's die je bezoekt op onze website.}}",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "Toestaan",

--- a/front/app/translations/pa-IN.json
+++ b/front/app/translations/pa-IN.json
@@ -114,8 +114,6 @@
   "app.components.ConsentManager.Banner.manage": "ਪ੍ਰਬੰਧਿਤ ਕਰੋ",
   "app.components.ConsentManager.Banner.policyLink": "ਕੂਕੀ ਨੀਤੀ",
   "app.components.ConsentManager.Banner.reject": "ਅਸਵੀਕਾਰ ਕਰੋ",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "ਪੁਸ਼ਟੀ ਕਰੋ",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "ਜੇਕਰ ਤੁਸੀਂ ਰੱਦ ਕਰਦੇ ਹੋ, ਤਾਂ ਤੁਹਾਡੀਆਂ ਤਰਜੀਹਾਂ ਖਤਮ ਹੋ ਜਾਣਗੀਆਂ।",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "ਇਸ਼ਤਿਹਾਰਬਾਜ਼ੀ",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "ਅਸੀਂ ਇਸਦੀ ਵਰਤੋਂ ਸਾਡੀ ਵੈਬਸਾਈਟ ਦੇ ਵਿਗਿਆਪਨ ਮੁਹਿੰਮਾਂ ਦੀ ਪ੍ਰਭਾਵਸ਼ੀਲਤਾ ਨੂੰ ਵਿਅਕਤੀਗਤ ਬਣਾਉਣ ਅਤੇ ਮਾਪਣ ਲਈ ਕਰਦੇ ਹਾਂ। ਅਸੀਂ ਇਸ ਪਲੇਟਫਾਰਮ 'ਤੇ ਕੋਈ ਵਿਗਿਆਪਨ ਨਹੀਂ ਦਿਖਾਵਾਂਗੇ, ਪਰ ਹੇਠਾਂ ਦਿੱਤੀਆਂ ਸੇਵਾਵਾਂ ਤੁਹਾਨੂੰ ਸਾਡੀ ਸਾਈਟ 'ਤੇ ਵਿਜ਼ਿਟ ਕੀਤੇ ਪੰਨਿਆਂ ਦੇ ਆਧਾਰ 'ਤੇ ਵਿਅਕਤੀਗਤ ਵਿਗਿਆਪਨ ਦੀ ਪੇਸ਼ਕਸ਼ ਕਰ ਸਕਦੀਆਂ ਹਨ।",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "ਇਜਾਜ਼ਤ ਦਿਓ",

--- a/front/app/translations/pl-PL.json
+++ b/front/app/translations/pl-PL.json
@@ -114,8 +114,6 @@
   "app.components.ConsentManager.Banner.manage": "Zarządzaj",
   "app.components.ConsentManager.Banner.policyLink": "Polityka ciasteczek",
   "app.components.ConsentManager.Banner.reject": "Odrzuć",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "Potwierdź",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Jeśli anulujesz, Twoje preferencje zostaną utracone.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Reklama",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "Wykorzystujemy to do personalizacji i pomiaru skuteczności kampanii reklamowych naszej strony internetowej. Nie pokażemy żadnej reklamy na tej platformie, ale poniższe usługi mogą zaoferować Ci spersonalizowaną reklamę w oparciu o strony, które odwiedzasz na naszej stronie.",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "Zezwól",

--- a/front/app/translations/pt-BR.json
+++ b/front/app/translations/pt-BR.json
@@ -114,8 +114,6 @@
   "app.components.ConsentManager.Banner.manage": "Gerenciar   ",
   "app.components.ConsentManager.Banner.policyLink": "Política de Cookies",
   "app.components.ConsentManager.Banner.reject": "Recusar",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "Confirmar",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Se você cancelar, perderá as suas preferências.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Publicidade",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "Usamos isto para personalizar e medir a eficácia das campanhas publicitárias do nosso site. Não mostraremos qualquer publicidade nesta plataforma, mas os seguintes serviços podem oferecer-lhe um anúncio personalizado com base nas páginas que visitar no nosso site.",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "Permitido",

--- a/front/app/translations/ro-RO.json
+++ b/front/app/translations/ro-RO.json
@@ -47,8 +47,6 @@
   "app.components.ConsentManager.Banner.mainText": "Prin navigare, sunteți de acord cu {policyLink}.",
   "app.components.ConsentManager.Banner.manage": "Administrează",
   "app.components.ConsentManager.Banner.policyLink": "Politica Cookie",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "Confirmă",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Dacă anulați, preferințele vor fi pierdute.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Reclamă",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "Folosim acest lucru pentru a personaliza și a măsura eficiența campaniilor publicitare de pe site-ului nostru. Nu vom afișa orice formă de publicitate pe această platformă, dar următoarele servicii ar putea oferi un anunț personalizat bazat pe paginile pe care le vizitați pe site-ul nostru.\n",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "Permite",

--- a/front/app/translations/sr-Latn.json
+++ b/front/app/translations/sr-Latn.json
@@ -114,8 +114,6 @@
   "app.components.ConsentManager.Banner.manage": "Upravljajte",
   "app.components.ConsentManager.Banner.policyLink": "Deklaracija o kolačićima",
   "app.components.ConsentManager.Banner.reject": "Odbij",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "Potvrdi",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Ukoliko prekinete, vaše preferencije neće biti sačuvane.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Oglašavanje",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "Ovo koristimo kako bismo personalizovali oglašavanje na našem sajtu i merili njegovu efikasnost. Mi ne prikazujemo oglase, ali to na osnovu stranica koje na našem sajtu posećujete mogu učiniti sledeći servisi. ",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "Dozvoli",

--- a/front/app/translations/sr-SP.json
+++ b/front/app/translations/sr-SP.json
@@ -114,8 +114,6 @@
   "app.components.ConsentManager.Banner.manage": "Управљајте",
   "app.components.ConsentManager.Banner.policyLink": "Декларација о колачићима",
   "app.components.ConsentManager.Banner.reject": "Одбиј",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "Потврди",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Ако откажете, ваше поставке ће бити изгубљене.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Оглашавање",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "Користимо ово да персонализујемо и меримо ефикасност рекламних кампања наше веб странице. Нећемо приказивати никакво оглашавање на овој платформи, али следеће услуге вам могу понудити персонализовани оглас на основу страница које посећујете на нашем сајту.",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "Дозволи",

--- a/front/app/translations/sv-SE.json
+++ b/front/app/translations/sv-SE.json
@@ -114,8 +114,6 @@
   "app.components.ConsentManager.Banner.manage": "Hantera",
   "app.components.ConsentManager.Banner.policyLink": "Policy webbkakor",
   "app.components.ConsentManager.Banner.reject": "Avvisa",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "Bekräfta",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "Om du avbryter, kommer dina inställningar att gå förlorade.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Reklam",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "Vi använder detta för att anpassa och mäta effektiviteten av reklamkampanjer på vår webbplats. Vi kommer inte att visa någon reklam på denna plattform, men följande tjänster kan erbjuda dig en personlig annons baserat på de sidor du besöker på vår plats.",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "Tillåta",

--- a/front/app/translations/tr-TR.json
+++ b/front/app/translations/tr-TR.json
@@ -114,8 +114,6 @@
   "app.components.ConsentManager.Banner.manage": "Yönet",
   "app.components.ConsentManager.Banner.policyLink": "Çerez politikası",
   "app.components.ConsentManager.Banner.reject": "Reddet",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "Onayla",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "İptal ederseniz tercihleriniz kaydedilmez.",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "Reklam",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "Bunu web sitemizin reklam kampanyalarını kişiselleştirmek ve bu kampanyaların etki düzeyini ölçmek için kullanırız. Bu platformda reklam göstermeyiz ancak ilgili hizmetler sitemizde ziyaret ettiğiniz sayfaları temel alarak size kişiselleştirilmiş reklamlar sunabilir.",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "İzin ver",

--- a/front/app/translations/ur-PK.json
+++ b/front/app/translations/ur-PK.json
@@ -114,8 +114,6 @@
   "app.components.ConsentManager.Banner.manage": "انتظام کریں۔",
   "app.components.ConsentManager.Banner.policyLink": "کوکی پالیسی",
   "app.components.ConsentManager.Banner.reject": "رد کرنا",
-  "app.components.ConsentManager.Modal.CancelDialog.confirm": "تصدیق کریں۔",
-  "app.components.ConsentManager.Modal.CancelDialog.confirmation": "اگر آپ منسوخ کرتے ہیں تو آپ کی ترجیحات ضائع ہو جائیں گی۔",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertising": "ایڈورٹائزنگ",
   "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": "ہم اس کا استعمال اپنی ویب سائٹ کی اشتہاری مہموں کی تاثیر کو ذاتی بنانے اور پیمائش کرنے کے لیے کرتے ہیں۔ ہم اس پلیٹ فارم پر کوئی اشتہار نہیں دکھائیں گے، لیکن درج ذیل سروسز آپ کو ہماری سائٹ پر جو صفحات ملاحظہ کرتی ہیں ان کی بنیاد پر آپ کو ذاتی نوعیت کا اشتہار پیش کر سکتی ہیں۔",
   "app.components.ConsentManager.Modal.PreferencesDialog.allow": "اجازت دیں۔",


### PR DESCRIPTION
Simplifying the modal while/before we're [changing it](https://www.notion.so/govocal/Users-don-t-dismiss-cookie-banners-hiding-main-CTAs-1f19663b7b26802091d9c3cc43bb1ae0?source=copy_link). E2E tests pass.

Before
<img width="1286" height="792" alt="Screenshot 2025-07-15 at 11 32 58" src="https://github.com/user-attachments/assets/c440f283-eb68-47fe-89ff-a744c36b32f9" />
=> Cancel =>
<img width="1282" height="789" alt="Screenshot 2025-07-15 at 11 34 18" src="https://github.com/user-attachments/assets/5c520569-cbdc-4d2d-9a5e-c5f078e665ac" />

After
<img width="1286" height="792" alt="Screenshot 2025-07-15 at 11 32 58" src="https://github.com/user-attachments/assets/8f1daf37-2ced-44df-85b5-d970e656575d" />
=> Cancel just closes the modal immediately =>
<img width="1279" height="785" alt="Screenshot 2025-07-15 at 11 33 04" src="https://github.com/user-attachments/assets/fc14a2c3-22b5-48a8-a5b0-d684be58eaef" />

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->
