### PR TITLE
Fix participants count check to handle undefined values

### DIFF
--- a/front/app/containers/Admin/projects/all/new/Projects/Table/Row.tsx
+++ b/front/app/containers/Admin/projects/all/new/Projects/Table/Row.tsx
@@ -119,7 +119,7 @@ const Row = ({ project, participantsCount }: Props) => {
       </StyledTd>
       {COLUMN_VISIBILITY.participants && (
         <Td background={colors.grey50} width="1px">
-          {participantsCount ? (
+          {participantsCount !== undefined ? (
             <Text
               m="0"
               fontSize="s"


### PR DESCRIPTION
# Changelog

## Fixed
- Fixed an issue where a loading spinner was incorrectly displayed when the participant count was 0. (This is behind the `project_planning` feature flag.)