### PR TITLE
TAN-5003 - Stop survey reminder emails going out when a user has already submitted

### DIFF
--- a/back/app/services/activities_service.rb
+++ b/back/app/services/activities_service.rb
@@ -90,6 +90,9 @@ class ActivitiesService
       next if idea.updated_at > now - 1.day
       next if idea.creation_phase.ends_before?(now)
 
+      # Is there survey already submitted by the same author in the same phase?
+      next if Idea.find_by(author_id: idea.author_id, creation_phase: idea.creation_phase, publication_status: 'published')
+
       LogActivityJob.perform_later(idea, 'survey_not_submitted', nil, now)
     end
   end


### PR DESCRIPTION
Fixing the root cause would be much bigger - It would involve changing the idea policy to use the permissions service for drafts (currently it looks really loose on drafts) and then triggering the 'survey already submitted' screen on the FE when a draft tries to be created/updated when a user already has submitted a survey. This change should be good enough for now.

# Changelog
## Fixed
- Stopped survey reminders being sent when a user has already submitted a survey but has a draft open in another tab
