### PR TITLE
[TAN-5081] Rake task to re-upload Vienna user images

### DIFF
--- a/back/lib/tasks/single_use/20250721_count_images_by_type_for_tenant.rake
+++ b/back/lib/tasks/single_use/20250721_count_images_by_type_for_tenant.rake
@@ -12,7 +12,7 @@ namespace :single_use do
 
     cutoff_date = args[:date] ? Date.parse(args[:date]) : Time.zone.today
 
-    image_extensions = %w[jpg jpeg png gif tiff]
+    image_extensions = %w[jpg jpeg gif png webp]
 
     total_images = 0
     total_possibly_user_images = 0

--- a/back/lib/tasks/single_use/20250721_download_vienna_image_files_and_related_record_attributes.rake
+++ b/back/lib/tasks/single_use/20250721_download_vienna_image_files_and_related_record_attributes.rake
@@ -13,7 +13,7 @@ namespace :single_use do
     # ActiveRecord::Base.logger = dev_null
 
     cutoff_date = args[:date] ? Date.parse(args[:date]) : Time.zone.today
-    image_extensions = %w[jpg jpeg png gif tiff]
+    image_extensions = %w[jpg jpeg gif png webp]
     total_images = 0
 
     tenant_host = 'mitgestalten.wien.gv.at'

--- a/back/lib/tasks/single_use/20250722_reupload_user_images.rake
+++ b/back/lib/tasks/single_use/20250722_reupload_user_images.rake
@@ -5,9 +5,9 @@ namespace :single_use do
   desc 'Re-uploads user images to ensure metadata stripping is applied.'
   task :reupload_user_images, %i[host date] => [:environment] do |_t, args|
     # Reduce logging when developing (to more closely match the production environment)
-    dev_null = Logger.new('/dev/null')
-    Rails.logger = dev_null
-    ActiveRecord::Base.logger = dev_null
+    # dev_null = Logger.new('/dev/null')
+    # Rails.logger = dev_null
+    # ActiveRecord::Base.logger = dev_null
 
     cutoff_date = args[:date] ? Date.parse(args[:date]) : Time.zone.today + 1.day
     total_images = 0

--- a/back/lib/tasks/single_use/20250722_reupload_user_images.rake
+++ b/back/lib/tasks/single_use/20250722_reupload_user_images.rake
@@ -1,0 +1,56 @@
+# Re-uploads citizen images, to ensure the relatively new metadata stripping is
+# applied. Primarily for use with the Vienna tenant, but tenant is selectable
+# to enable testing on a demo.
+namespace :single_use do
+  desc 'Re-uploads user images to ensure metadata stripping is applied.'
+  task :reupload_user_images, %i[host date] => [:environment] do |_t, args|
+    # Reduce logging when developing (to more closely match the production environment)
+    dev_null = Logger.new('/dev/null')
+    Rails.logger = dev_null
+    ActiveRecord::Base.logger = dev_null
+
+    cutoff_date = args[:date] ? Date.parse(args[:date]) : Time.zone.today + 1.day
+    total_images = 0
+    successful = 0
+    failed = 0
+
+    Apartment::Tenant.switch(args[:host].tr('.', '_')) do
+      users_with_avatars = User.where(updated_at: ...cutoff_date).where.not(avatar: nil)
+      puts "Found #{users_with_avatars.count} users with avatar images updated before #{cutoff_date}"
+      total_images += users_with_avatars.count
+
+      users_with_avatars.each do |user|
+        if user.avatar.present?
+          file_path = user.avatar.url
+          file_name = user.avatar.identifier
+
+          begin
+            File.binwrite("tmp/#{file_name}", URI.open(file_path).read)
+          rescue StandardError => e
+            puts "ERROR downloading or saving #{file_name} from #{file_path}: #{e.class} - #{e.message}"
+          end
+
+          begin
+            image_path = Rails.root.join("tmp/#{file_name}")
+            image_file = File.open(image_path)
+            user.avatar = image_file
+            if user.save
+              puts "Successfully re-uploaded avatar for user #{user.id} (#{user.email})"
+              successful += 1
+            else
+              puts "Failed to save user #{user.id} (#{user.email}) after re-uploading avatar: #{user.errors.full_messages.join(', ')}"
+              failed += 1
+            end
+          rescue StandardError => e
+            puts "ERROR re-uploading avatar for user #{user.id} (#{user.email}): #{e.class} - #{e.message}"
+            failed += 1
+          end
+        end
+      end
+
+      puts "Total image uploads attempted: #{total_images}"
+      puts "Total successful uploads: #{successful}"
+      puts "Total failed uploads: #{failed}"
+    end
+  end
+end

--- a/back/lib/tasks/single_use/20250722_reupload_user_images.rake
+++ b/back/lib/tasks/single_use/20250722_reupload_user_images.rake
@@ -3,13 +3,14 @@ require 'fileutils'
 # Re-uploads citizen images, to ensure the relatively new metadata stripping is
 # applied. Primarily for use with the Vienna tenant, but tenant is selectable
 # to enable testing on a demo.
+# Re-uploads user avatars, idea_images, and Idea text_images.
 namespace :single_use do
   desc 'Re-uploads user images to ensure metadata stripping is applied.'
   task :reupload_user_images, %i[host date] => [:environment] do |_t, args|
     # Reduce logging when developing (to more closely match the production environment)
-    dev_null = Logger.new('/dev/null')
-    Rails.logger = dev_null
-    ActiveRecord::Base.logger = dev_null
+    # dev_null = Logger.new('/dev/null')
+    # Rails.logger = dev_null
+    # ActiveRecord::Base.logger = dev_null
 
     cutoff_date = args[:date] ? Date.parse(args[:date]) : Time.zone.today + 1.day
     total_images = 0

--- a/front/app/root.tsx
+++ b/front/app/root.tsx
@@ -90,7 +90,13 @@ const mountApplication = () => {
   } finally {
     // We don't want to use StrictMode during E2E tests, since it causes test failures due to
     // some issues with the re-rendering & re-running of effects in the JSONForms and react-select libraries.
-    window.Cypress ? root.render(<Root />) : root.render(<Root />);
+    window.Cypress
+      ? root.render(<Root />)
+      : root.render(
+          <StrictMode>
+            <Root />
+          </StrictMode>
+        );
   }
 };
 

--- a/front/app/root.tsx
+++ b/front/app/root.tsx
@@ -90,13 +90,7 @@ const mountApplication = () => {
   } finally {
     // We don't want to use StrictMode during E2E tests, since it causes test failures due to
     // some issues with the re-rendering & re-running of effects in the JSONForms and react-select libraries.
-    window.Cypress
-      ? root.render(<Root />)
-      : root.render(
-          <StrictMode>
-            <Root />
-          </StrictMode>
-        );
+    window.Cypress ? root.render(<Root />) : root.render(<Root />);
   }
 };
 


### PR DESCRIPTION
Download and re-upload user `avatars`, `idea_images`, and Idea `text_images`.

A few (approx 100) `idea_files` are also images, but currently we do not filter such files and process them as images when uploading (i.e. stripping metadata), so re-uploading them would not achieve anything. 

# Changelog
## Technical
- [TAN-5081] Rake task to re-upload Vienna user images (to strip image metadata)
