### PR TITLE
TAN-5006: Remove the idea the user is editing from the list of similar ideas returned when editing

### DIFF
--- a/back/app/controllers/web_api/v1/ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/ideas_controller.rb
@@ -291,7 +291,7 @@ class WebApi::V1::IdeasController < ApplicationController
 
     title_threshold = phase_for_input.similarity_threshold_title
     body_threshold = phase_for_input.similarity_threshold_body
-    cache_key = "similar_ideas/#{{ title_multiloc: idea.title_multiloc, body_multiloc: idea.body_multiloc, project_id: idea.project_id, title_threshold:, body_threshold: }}"
+    cache_key = "similar_ideas/#{{ id: idea.id, title_multiloc: idea.title_multiloc, body_multiloc: idea.body_multiloc, project_id: idea.project_id, title_threshold:, body_threshold: }}"
 
     json_result = Rails.cache.fetch(cache_key, expires_in: 10.minutes) do
       scope = policy_scope(Idea)
@@ -465,7 +465,7 @@ class WebApi::V1::IdeasController < ApplicationController
   end
 
   def idea_params_for_similarities
-    params.require(:idea).permit([:project_id, { title_multiloc: CL2_SUPPORTED_LOCALES, body_multiloc: CL2_SUPPORTED_LOCALES }])
+    params.require(:idea).permit([:id, :project_id, { title_multiloc: CL2_SUPPORTED_LOCALES, body_multiloc: CL2_SUPPORTED_LOCALES }])
   end
 
   def submittable_custom_fields(custom_form)

--- a/back/app/controllers/web_api/v1/ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/ideas_controller.rb
@@ -291,7 +291,7 @@ class WebApi::V1::IdeasController < ApplicationController
 
     title_threshold = phase_for_input.similarity_threshold_title
     body_threshold = phase_for_input.similarity_threshold_body
-    cache_key = "similar_ideas/#{{ title_multiloc: idea.title_multiloc, body_multiloc: idea.body_multiloc, project_id: idea.project_id, title_threshold:, body_threshold: }}"
+    cache_key = "similar_ideas/#{{ id: idea.id, title_multiloc: idea.title_multiloc, body_multiloc: idea.body_multiloc, project_id: idea.project_id, title_threshold:, body_threshold: }}"
 
     json_result = Rails.cache.fetch(cache_key, expires_in: 10.minutes) do
       scope = policy_scope(Idea)

--- a/back/app/controllers/web_api/v1/ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/ideas_controller.rb
@@ -291,7 +291,7 @@ class WebApi::V1::IdeasController < ApplicationController
 
     title_threshold = phase_for_input.similarity_threshold_title
     body_threshold = phase_for_input.similarity_threshold_body
-    cache_key = "similar_ideas/#{{ id: idea.id, title_multiloc: idea.title_multiloc, body_multiloc: idea.body_multiloc, project_id: idea.project_id, title_threshold:, body_threshold: }}"
+    cache_key = "similar_ideas/#{{ title_multiloc: idea.title_multiloc, body_multiloc: idea.body_multiloc, project_id: idea.project_id, title_threshold:, body_threshold: }}"
 
     json_result = Rails.cache.fetch(cache_key, expires_in: 10.minutes) do
       scope = policy_scope(Idea)

--- a/back/spec/acceptance/ideas/ideas_spec.rb
+++ b/back/spec/acceptance/ideas/ideas_spec.rb
@@ -542,7 +542,7 @@ resource 'Ideas' do
 
           # When editing current_idea, it should be excluded from results
           # but other similar ideas should still be included
-          do_request(idea: { 
+          do_request(idea: {
             id: current_idea.id,
             title_multiloc: { 'en' => 'My similar idea' },
             body_multiloc: { 'en' => 'This is the body of my similar idea' }

--- a/back/spec/acceptance/ideas/ideas_spec.rb
+++ b/back/spec/acceptance/ideas/ideas_spec.rb
@@ -542,7 +542,11 @@ resource 'Ideas' do
 
           # When editing current_idea, it should be excluded from results
           # but other similar ideas should still be included
-          do_request(idea: { id: current_idea.id })
+          do_request(idea: { 
+            id: current_idea.id,
+            title_multiloc: { 'en' => 'My similar idea' },
+            body_multiloc: { 'en' => 'This is the body of my similar idea' }
+          })
           assert_status 200
           expect(json_parse(response_body)[:data].pluck(:id)).to include(idea_pizza.id, another_similar_idea.id)
           expect(json_parse(response_body)[:data].pluck(:id)).not_to include(current_idea.id)

--- a/back/spec/services/similar_ideas_service_spec.rb
+++ b/back/spec/services/similar_ideas_service_spec.rb
@@ -37,6 +37,11 @@ describe SimilarIdeasService do
         expect(result.ids).not_to include(idea_burger.id)
       end
 
+      it 'excludes the current idea from results' do
+        result = service.similar_ideas(title_threshold: 1.0, body_threshold: 1.0)
+        expect(result.ids).not_to include(idea.id)
+      end
+
       it 'applies the limit' do
         result = service.similar_ideas(limit: 2, title_threshold: 1.0, body_threshold: 1.0)
         expect(result.ids.size).to eq 2

--- a/front/app/api/similar_ideas/types.ts
+++ b/front/app/api/similar_ideas/types.ts
@@ -2,6 +2,7 @@ import { Multiloc } from 'typings';
 
 export interface ISimilarityRequestPayload {
   idea: {
+    id?: string;
     title_multiloc?: Multiloc;
     body_multiloc?: Multiloc;
     project_id?: string;

--- a/front/app/containers/IdeasNewPage/SimilarInputs/SimilarInputsList.tsx
+++ b/front/app/containers/IdeasNewPage/SimilarInputs/SimilarInputsList.tsx
@@ -54,6 +54,7 @@ const SimilarIdeasList = ({
   const { data: ideas, isLoading } = useSimilarIdeas(
     {
       idea: {
+        id: ideaId,
         project_id: project?.data.id,
         ...((title || '').trim() && {
           title_multiloc: { [currentLocale]: title },


### PR DESCRIPTION
# Changelog

## Fixed
- Remove the idea the user is editing from the list of similar ideas returned when editing
