### PR TITLE
Add `ca-certificates` to Dockerfiles

### DIFF
--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -22,6 +22,8 @@ RUN apt-get update                                        \
    build-essential                                        \
    curl                                                   \
    lsb-release                                            \
+   # Ensure a recent and comprehensive set of CA certificates is installed
+   ca-certificates                                        \
    # Required to install git dependencies in Gemfile and by bundle-audit
    git                                                    \
    libgeos-dev                                            \

--- a/back/Dockerfile.development
+++ b/back/Dockerfile.development
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -qq -y --no-install-recommends \
       libpq-dev            \
       file                 \
       imagemagick          \
+      ca-certificates      \
       curl                 \
       git                  \
       optipng              \


### PR DESCRIPTION
Update CA certificates to fix SSL errors caused by Carrierwave with certificates signed by Sectigo, who recently migrated their CAs: https://www.sectigo.com/knowledge-base/detail/Sectigo-Public-Root-CAs-Migration/kA0Uj0000003RoT

See the Slack thread for more context: https://go-vocal.slack.com/archives/C06CJ4D3B0R/p1753364621064219

# Changelog
## Technical
- Adds the `ca-certificates` package to Docker images to ensure containers are using a more recent and complete set of trusted CA certificates. This will provide a better protection against changes from certificate authorities.
