### PR TITLE
TAN-5120 - Split out first names for ID Austria

### DIFF
--- a/back/engines/commercial/id_id_austria/app/lib/id_id_austria/id_austria_omniauth.rb
+++ b/back/engines/commercial/id_id_austria/app/lib/id_id_austria/id_austria_omniauth.rb
@@ -10,7 +10,7 @@ module IdIdAustria
 
     def profile_to_user_attrs(auth)
       {
-        first_name: auth.info.first_name,
+        first_name: split_first_name(auth.info.first_name),
         last_name: auth.info.last_name,
         email: auth.info.email,
         locale: AppConfiguration.instance.closest_locale_to('de-DE')
@@ -67,6 +67,14 @@ module IdIdAustria
 
     def issuer
       "https://#{host}"
+    end
+
+    # If the first name fields contains multiple names (ie middle names too) only return the first
+    def split_first_name(first_name)
+      return nil unless first_name
+
+      parts = first_name.split
+      parts.first
     end
   end
 end

--- a/back/engines/commercial/id_id_austria/app/lib/id_id_austria/id_austria_omniauth.rb
+++ b/back/engines/commercial/id_id_austria/app/lib/id_id_austria/id_austria_omniauth.rb
@@ -73,8 +73,7 @@ module IdIdAustria
     def split_first_name(first_name)
       return nil unless first_name
 
-      parts = first_name.split
-      parts.first
+      first_name.split.first
     end
   end
 end


### PR DESCRIPTION
# Changelog
## Fixed
- Ensure only first name and not middle names are returned from ID Austria SSO
