### PR TITLE
[TAN-5145] Fix templateTitle interpolation on project template modal

### DIFF
--- a/front/app/modules/commercial/admin_project_templates/admin/components/messages.ts
+++ b/front/app/modules/commercial/admin_project_templates/admin/components/messages.ts
@@ -96,7 +96,8 @@ export default defineMessages({
   },
   createProjectBasedOn: {
     id: 'app.components.ProjectTemplatePreview.createProjectBasedOn',
-    defaultMessage: "Create a project based on the template '{templateTitle}'",
+    defaultMessage:
+      "Create a project based on the template ''{templateTitle}''",
   },
   participationLevels: {
     id: 'app.containers.AdminPage.ProjectEdit.participationLevels',


### PR DESCRIPTION
Problem was we were using single quotes around interpolated value in message/translations. Should be double single-quotes if intention is to display single-quotes.

Reverted, as I want to do this the regular way... by changing the translation key, etc.

# Changelog
# Fixed
- [TAN-5145] Fix templateTitle interpolation on project template modal (will need manual fixes of translations - in progress)
