### PR TITLE
[TAN-5080] Show BE generated file previews in FE

### DIFF
--- a/front/app/api/files/filePreviews/keys.ts
+++ b/front/app/api/files/filePreviews/keys.ts
@@ -1,18 +1,11 @@
 import { QueryKeys } from 'utils/cl-react-query/types';
 
-import { QueryParameters } from './types';
-
 const baseKey = {
-  type: 'file',
+  type: 'file_preview',
 };
 
 const filePreviewsKeys = {
   all: () => [baseKey],
-  lists: () => [{ ...baseKey, operation: 'list' }],
-  list: (parameters: QueryParameters) => [
-    { ...baseKey, operation: 'list', parameters },
-  ],
-  items: () => [{ ...baseKey, operation: 'item' }],
   item: ({ id }: { id?: string | null }) => [
     {
       ...baseKey,

--- a/front/app/api/files/filePreviews/types.ts
+++ b/front/app/api/files/filePreviews/types.ts
@@ -1,0 +1,32 @@
+import { IRelationship } from 'typings';
+
+import { Keys } from 'utils/cl-react-query/types';
+
+import filePreviewsKeys from './keys';
+
+export type FilePreviewKeys = Keys<typeof filePreviewsKeys>;
+
+export type FilePreviewStatus = 'pending' | 'completed' | 'failed';
+
+export interface IFilePreviewAttributes {
+  content: {
+    url: string;
+  };
+  status: FilePreviewStatus;
+  created_at: string;
+  updated_at: string;
+}
+export interface IFilePreviewData {
+  id: string;
+  type: string;
+  attributes: IFilePreviewAttributes;
+  relationships: {
+    file: {
+      data: IRelationship;
+    };
+  };
+}
+
+export interface IFilePreview {
+  data: IFilePreviewData;
+}

--- a/front/app/api/files/filePreviews/useFilePreview.ts
+++ b/front/app/api/files/filePreviews/useFilePreview.ts
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query';
+import { CLErrors } from 'typings';
+
+import fetcher from 'utils/cl-react-query/fetcher';
+
+import filePreviewsKeys from './keys';
+import { IFilePreview, FilePreviewKeys } from './types';
+
+const fetchPreviewByFileId = (id?: string | null) =>
+  fetcher<IFilePreview>({
+    path: `/files/${id}/preview`,
+    action: 'get',
+  });
+
+const useFilePreview = (id?: string | null) => {
+  return useQuery<IFilePreview, CLErrors, IFilePreview, FilePreviewKeys>({
+    queryKey: filePreviewsKeys.item({ id }),
+    queryFn: () => fetchPreviewByFileId(id),
+    enabled: !!id,
+    refetchInterval: (data) => {
+      // Poll every 2 seconds if status is pending, otherwise stop polling
+      return data?.data.attributes.status === 'pending' ? 2000 : false;
+    },
+  });
+};
+
+export default useFilePreview;

--- a/front/app/api/files/filePreviews/useFilePreview.ts
+++ b/front/app/api/files/filePreviews/useFilePreview.ts
@@ -12,7 +12,7 @@ const fetchPreviewByFileId = (id?: string | null) =>
     action: 'get',
   });
 
-const useFilePreview = (id?: string | null) => {
+const useFilePreview = (id?: string) => {
   return useQuery<IFilePreview, CLErrors, IFilePreview, FilePreviewKeys>({
     queryKey: filePreviewsKeys.item({ id }),
     queryFn: () => fetchPreviewByFileId(id),

--- a/front/app/api/files/keys.ts
+++ b/front/app/api/files/keys.ts
@@ -6,7 +6,7 @@ const baseKey = {
   type: 'file',
 };
 
-const filePreviewsKeys = {
+const filesKeys = {
   all: () => [baseKey],
   lists: () => [{ ...baseKey, operation: 'list' }],
   list: (parameters: QueryParameters) => [
@@ -22,4 +22,4 @@ const filePreviewsKeys = {
   ],
 } satisfies QueryKeys;
 
-export default filePreviewsKeys;
+export default filesKeys;

--- a/front/app/containers/Admin/projects/project/files/components/FilePreview/messages.ts
+++ b/front/app/containers/Admin/projects/project/files/components/FilePreview/messages.ts
@@ -17,6 +17,10 @@ export default defineMessages({
     id: 'app.containers.AdminPage.ProjectFiles.couldNotLoadMarkdown',
     defaultMessage: 'Could not load markdown file.',
   },
+  generatingPreview: {
+    id: 'app.containers.AdminPage.ProjectFiles.generatingPreview',
+    defaultMessage: 'Generating preview...',
+  },
   csvPreviewError: {
     id: 'app.containers.AdminPage.ProjectFiles.csvPreviewError',
     defaultMessage: 'Could not load CSV preview.',

--- a/front/app/translations/admin/en.json
+++ b/front/app/translations/admin/en.json
@@ -2270,6 +2270,7 @@
   "app.containers.AdminPage.ProjectFiles.filePreviewLabel": "File Preview",
   "app.containers.AdminPage.ProjectFiles.fileSizeError2": "This file will not be uploaded, as it exceeds the maximum limit of 50 MB.",
   "app.containers.AdminPage.ProjectFiles.filesUploadedSuccessfully": "All files uploaded successfully",
+  "app.containers.AdminPage.ProjectFiles.generatingPreview": "Generating preview...",
   "app.containers.AdminPage.ProjectFiles.info_sheet": "Information",
   "app.containers.AdminPage.ProjectFiles.informationPoint1Description": "E.g. WAV, MP3",
   "app.containers.AdminPage.ProjectFiles.informationPoint1Title": "Audio interviews, Town Hall recordings",


### PR DESCRIPTION
Connects FE to BE work around pdf file previews generated by Gotenberg.