### PR TITLE
[TAN-5124] Do not include empty text answers in survey results

### DIFF
--- a/back/app/services/surveys/results_generator.rb
+++ b/back/app/services/surveys/results_generator.rb
@@ -311,6 +311,9 @@ module Surveys
       inputs
         .select("custom_field_values->'#{field_key}' as value")
         .where("custom_field_values->'#{field_key}' IS NOT NULL")
+        # Remove all sequences of one or more whitespace characters (including spaces, newlines, tabs),
+        # then check the result is not empty. TRIM would not handle newlines correctly.
+        .where("regexp_replace(custom_field_values->>'#{field_key}', '[[:space:]]+', '', 'g') != ''")
         .map { |answer| { answer: answer.value.to_s } }
         .sort_by { |a| a[:answer] }
     end

--- a/back/engines/commercial/analysis/app/services/analysis/inputs_finder.rb
+++ b/back/engines/commercial/analysis/app/services/analysis/inputs_finder.rb
@@ -50,6 +50,7 @@ module Analysis
       scope = inputs
       if params[:input_custom_field_no_empty_values] && analysis.main_custom_field_id
         scope = scope.where.not("ideas.custom_field_values->>'#{analysis.main_custom_field.key}' IS NULL")
+          .where("regexp_replace(custom_field_values->>'#{analysis.main_custom_field.key}', '[[:space:]]+', '', 'g') != ''")
       end
       scope
     end

--- a/back/engines/commercial/analysis/app/services/analysis/inputs_finder.rb
+++ b/back/engines/commercial/analysis/app/services/analysis/inputs_finder.rb
@@ -50,6 +50,8 @@ module Analysis
       scope = inputs
       if params[:input_custom_field_no_empty_values] && analysis.main_custom_field_id
         scope = scope.where.not("ideas.custom_field_values->>'#{analysis.main_custom_field.key}' IS NULL")
+          # Remove all sequences of one or more whitespace characters (including spaces, newlines, tabs),
+          # then check the result is not empty. TRIM would not handle newlines correctly.
           .where("regexp_replace(custom_field_values->>'#{analysis.main_custom_field.key}', '[[:space:]]+', '', 'g') != ''")
       end
       scope

--- a/back/engines/commercial/analysis/spec/services/inputs_finder_spec.rb
+++ b/back/engines/commercial/analysis/spec/services/inputs_finder_spec.rb
@@ -368,6 +368,24 @@ describe Analysis::InputsFinder do
       })
     end
 
+    let_it_be(:input3) do
+      create(:idea, project: analysis.source_project, custom_field_values: {
+        custom_field_text.key => ''
+      })
+    end
+
+    let_it_be(:input4) do
+      create(:idea, project: analysis.source_project, custom_field_values: {
+        custom_field_text.key => '  '
+      })
+    end
+
+    let_it_be(:input5) do
+      create(:idea, project: analysis.source_project, custom_field_values: {
+        custom_field_text.key => "   \n"
+      })
+    end
+
     it 'filters out custom_field with no empty values correctly' do
       @params = { input_custom_field_no_empty_values: true }
       expect(output).to contain_exactly(input1, input2)

--- a/back/spec/services/surveys/results_generator_spec.rb
+++ b/back/spec/services/surveys/results_generator_spec.rb
@@ -110,8 +110,8 @@ RSpec.describe Surveys::ResultsGenerator do
       # Documenting the behavior for 'empty' text fields explicitly.
       it 'does not return count empty text responses' do
         text_answers = project.phases.first.ideas
-                       .where(Arel.sql("custom_field_values ? '#{text_field.key}'"))
-                       .pluck(Arel.sql("custom_field_values->>'#{text_field.key}'"))
+          .where(Arel.sql("custom_field_values ? '#{text_field.key}'"))
+          .pluck(Arel.sql("custom_field_values->>'#{text_field.key}'"))
 
         expect(text_answers).to include('', "   \n")
         expect(generated_results[:results][1][:textResponses].pluck(:answer)).not_to include('', "   \n")

--- a/back/spec/services/surveys/results_generator_spec.rb
+++ b/back/spec/services/surveys/results_generator_spec.rb
@@ -106,6 +106,16 @@ RSpec.describe Surveys::ResultsGenerator do
           }
         )
       end
+
+      # Documenting the behavior for 'empty' text fields explicitly.
+      it 'does not return count empty text responses' do
+        text_answers = project.phases.first.ideas
+                       .where(Arel.sql("custom_field_values ? '#{text_field.key}'"))
+                       .pluck(Arel.sql("custom_field_values->>'#{text_field.key}'"))
+
+        expect(text_answers).to include('', "   \n")
+        expect(generated_results[:results][1][:textResponses].pluck(:answer)).not_to include('', "   \n")
+      end
     end
 
     describe 'multiline text fields' do

--- a/back/spec/services/surveys/shared/survey_setup.rb
+++ b/back/spec/services/surveys/shared/survey_setup.rb
@@ -397,6 +397,7 @@ RSpec.shared_context 'survey_setup' do
       project: project,
       phases: phases_of_inputs,
       custom_field_values: {
+        text_field.key => '', # Empty text field - can be saved from visitor survey with multiple pages
         select_field.key => 'la',
         multiselect_image_field.key => ['school'],
         ranking_field.key => %w[by_bike by_train by_foot],
@@ -410,6 +411,7 @@ RSpec.shared_context 'survey_setup' do
       project: project,
       phases: phases_of_inputs,
       custom_field_values: {
+        text_field.key => "   \n", # Empty text field - can be saved from visitor survey with multiple pages
         select_field.key => 'other',
         "#{select_field.key}_other" => 'Seattle',
         matrix_linear_scale_field.key => {

--- a/front/app/components/CustomFieldsForm/generateYupSchema.ts
+++ b/front/app/components/CustomFieldsForm/generateYupSchema.ts
@@ -91,13 +91,21 @@ const generateYupValidationSchema = ({
       case 'text':
       case 'multiline_text':
       case 'date': {
+        let fieldSchema = string();
+
+        if (required) {
+          fieldSchema = fieldSchema
+            .required(fieldRequired)
+            .trim() // Removes leading/trailing whitespace before validation
+            .min(1, fieldRequired); // Ensures at least one character after trimming
+        }
+
         if (key === 'location_description') {
-          schema[key] =
-            required && enabled
-              ? string().required(fieldRequired).nullable()
-              : string().nullable();
+          schema[key] = enabled
+            ? fieldSchema.nullable()
+            : fieldSchema.nullable();
         } else {
-          schema[key] = required ? string().required(fieldRequired) : string();
+          schema[key] = fieldSchema;
         }
         break;
       }


### PR DESCRIPTION
Because these 2 things are true...
1. This PR removes empty/blank strings from survey results (after they have been saved to an idea.custom_field_values)
2. Saving an empty string is technically possible using a survey open to visitors, when a visitor first inserts text tin answer, navigates to next page and back again, then removes text from answer (due to different idea saving procedure to when non-visitor). 

... I have also tried to tighten the FE validation of 'blank' text fields.

This is because if we don't count blank answers (that exist) in the BE, we need to do our best to prevent them, to avoid inconsistent results (eg 4/5 participants answered) when field is required.

This PR, therefore, also changes the FE validation of a required text input, to check not only that it is not empty (i.e. ""), but also that it is not full of only blank content (e.g "   ", or "    \n").

# Changelog
## Fixed
- [TAN-5124] Do not include empty text answers in survey results or analyses
