### PR TITLE
[TAN-5021] Fix survey results which attempt to average string values

### DIFF
--- a/back/app/services/surveys/average_generator.rb
+++ b/back/app/services/surveys/average_generator.rb
@@ -120,7 +120,7 @@ module Surveys
 
     def calculate_average(values)
       values = values.compact # Remove any nils
-      total = values.sum { |a| a || 0 }
+      total = values.sum { |a| a.to_i || 0 }
       count = values.count
       count > 0 ? (total.to_f / values.count).round(1) : 0.0
     end

--- a/back/spec/services/surveys/average_generator_spec.rb
+++ b/back/spec/services/surveys/average_generator_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Surveys::AverageGenerator do
       end
 
       it 'handles string values' do
-        values = ['1', '2', '3', '4', '5']
+        values = %w[1 2 3 4 5]
         expect(generator.send(:calculate_average, values)).to eq(3.0)
       end
     end

--- a/back/spec/services/surveys/average_generator_spec.rb
+++ b/back/spec/services/surveys/average_generator_spec.rb
@@ -72,6 +72,19 @@ RSpec.describe Surveys::AverageGenerator do
         expect(averages).to eq({})
       end
     end
+
+    describe 'calculate_average' do
+      let(:values) { [1, 2, 3, 4, 5] }
+
+      it 'returns the average of the values' do
+        expect(generator.send(:calculate_average, values)).to eq(3.0)
+      end
+
+      it 'handles string values' do
+        values = ['1', '2', '3', '4', '5']
+        expect(generator.send(:calculate_average, values)).to eq(3.0)
+      end
+    end
   end
 
   context 'community monitor survey' do


### PR DESCRIPTION
The issue was that we had some values for answers to a survey number question that were strings when passed to `Surveys::AverageGenerator`. The quick fix is simply to cast these values to integers when summing as part of averaging.

E.g. For one platform that had reported the issue, the values in response to a number survey question, that are passed to `Surveys::AverageGenerator` are:
```
[9, 16, \"1\", 7, 33, \"1\", \"1\", \"48\", \"1\", 11, \"25\", \"1\", 31, \"7\", \"1\", \"1\", 7, 1, \"10\", \"1\", 35, \"1\", \"1\", 5, \"1\", 16, 1, 7, 18, \"18\", \"7\", \"19\", \"1\", \"28\", \"15\", 15, 7, 37, \"1\", \"1\", 2, 42, 6, 23, 48, 39, 78, 14, 26, 12, 26, 38, 62, 25, 48, 27, 7, 31, 63, 18, 1, 27, 151]
```

The elephant in the room is _'but how did we get strings for numbers?'_ **TL;DR:** I don't know at this point.

I thought maybe this could happen when importing number answers from Excel, but so far I have not managed to reproduce strings for numbers via this method.

In any case, I think we should release this quick fix, understanding that it will not detect weird string values like 'XX', but will just silently convert them to zero. This seems better, at least, than having BO survey results crashing and failing to display at all on production platforms.


# Changelog
## Fixed
- [TAN-5021] Some BO survey results not displaying due to error when averaging responses to number questions.
