### PR TITLE
TAN-5186 Folder managers cannot see own folder in folders tab

### DIFF
--- a/back/app/controllers/web_api/v1/folders_controller.rb
+++ b/back/app/controllers/web_api/v1/folders_controller.rb
@@ -31,11 +31,20 @@ class WebApi::V1::FoldersController < ApplicationController
 
   def index_for_admin
     project_folders = policy_scope(ProjectFolders::Folder)
+
+    authorize project_folders
+
+    # The authorize statement above ensures that we only allow
+    # admins or folder managers.
+    # If the current user is not an admin, but only a folder manager,
+    # we filter the folders to only those that the user moderates.
+    if !current_user.admin?
+      params[:managers] = [current_user.id]
+    end
+
     project_folders = FoldersFinderAdminService.execute(project_folders, params)
     project_folders = paginate project_folders
     project_folders = project_folders.includes(:admin_publication, :images)
-
-    authorize project_folders
 
     moderators_per_folder = User
       .where("roles @> '[{\"type\":\"project_folder_moderator\"}]'")

--- a/back/app/policies/project_folders/folder_policy.rb
+++ b/back/app/policies/project_folders/folder_policy.rb
@@ -17,7 +17,7 @@ module ProjectFolders
     end
 
     def index_for_admin?
-      user&.admin? || user&.project_folder_moderator? || user&.project_moderator?
+      user&.admin? || user&.project_folder_moderator?
     end
 
     def show?

--- a/back/app/policies/project_folders/folder_policy.rb
+++ b/back/app/policies/project_folders/folder_policy.rb
@@ -17,7 +17,7 @@ module ProjectFolders
     end
 
     def index_for_admin?
-      user && UserRoleService.new.can_moderate?(record, user)
+      user&.admin? || user&.project_folder_moderator? || user&.project_moderator?
     end
 
     def show?

--- a/back/spec/acceptance/project_folders_spec.rb
+++ b/back/spec/acceptance/project_folders_spec.rb
@@ -472,5 +472,16 @@ resource 'ProjectFolder' do
         expect(response_status).to eq 401
       end
     end
+
+    get 'web_api/v1/project_folders/for_admin' do
+      example 'it only returns folders the user moderates' do
+        do_request
+        assert_status 200
+        json_response = json_parse response_body
+        expect(json_response[:data].size).to eq 1
+        expect(json_response[:data].first[:id]).to eq moderated_folder.id
+        expect(json_response[:data].first.dig(:relationships, :moderators, :data).pluck(:id)).to eq [user.id]
+      end
+    end
   end
 end


### PR DESCRIPTION
# Changelog
## Fixed
- New projects page: folder managers could not see own folder in folders tab. Now they can see all folders they can moderate. (behind FF / secret route)
