### PR TITLE
TAN-5131 Updated email delivery stats tooltips

### DIFF
--- a/front/app/components/admin/Email/CampaignStats.tsx
+++ b/front/app/components/admin/Email/CampaignStats.tsx
@@ -106,6 +106,15 @@ const CampaignStats = ({ campaignId, className }: Props) => {
           </GraphCardCount>
           <GraphCardTitle>
             <FormattedMessage {...messages[`deliveryStatus_${status}`]} />
+            {status === 'opened' && (
+              <IconTooltip
+                content={
+                  <FormattedMessage
+                    {...messages.deliveryStatus_openedTooltip}
+                  />
+                }
+              />
+            )}
             {status === 'clicked' && (
               <IconTooltip
                 content={

--- a/front/app/components/admin/Email/messages.ts
+++ b/front/app/components/admin/Email/messages.ts
@@ -35,9 +35,9 @@ export default defineMessages({
       'This shows how many recipients opened the email. Please note that some security systems (like Microsoft Defender) may pre-load content for scanning, which can result in false opens.',
   },
   deliveryStatus_clickedTooltip: {
-    id: 'app.components.Admin.Campaigns.deliveryStatus_clickedTooltip',
+    id: 'app.components.Admin.Campaigns.deliveryStatus_clickedTooltip2',
     defaultMessage:
-      'When you added one or more links to your email, the number of users who clicked a link will be shown here.',
+      'This shows how many recipients clicked a link in the email. Please note that some security systems may follow links automatically to scan them, which can result in false clicks.',
   },
   recipientsTitle: {
     id: 'app.components.Admin.Campaigns.recipientsTitle',

--- a/front/app/components/admin/Email/messages.ts
+++ b/front/app/components/admin/Email/messages.ts
@@ -29,6 +29,11 @@ export default defineMessages({
     id: 'app.components.Admin.Campaigns.deliveryStatus_bounced',
     defaultMessage: 'Bounced',
   },
+  deliveryStatus_openedTooltip: {
+    id: 'app.components.Admin.Campaigns.deliveryStatus_openedTooltip',
+    defaultMessage:
+      'This shows how many recipients opened the email. Please note that some security systems (like Microsoft Defender) may pre-load content for scanning, which can result in false opens.',
+  },
   deliveryStatus_clickedTooltip: {
     id: 'app.components.Admin.Campaigns.deliveryStatus_clickedTooltip',
     defaultMessage:

--- a/front/app/translations/admin/ar-SA.json
+++ b/front/app/translations/admin/ar-SA.json
@@ -32,7 +32,6 @@
   "app.components.Admin.Campaigns.deliveryStatus_accepted": "قبلت",
   "app.components.Admin.Campaigns.deliveryStatus_bounced": "ارتد",
   "app.components.Admin.Campaigns.deliveryStatus_clicked": "تم النقر عليه",
-  "app.components.Admin.Campaigns.deliveryStatus_clickedTooltip": "عند إضافة رابط واحد أو أكثر إلى بريدك الإلكتروني، سيظهر هنا عدد المستخدمين الذين نقروا على الرابط.",
   "app.components.Admin.Campaigns.deliveryStatus_delivered": "تم التوصيل",
   "app.components.Admin.Campaigns.deliveryStatus_failed": "فشل",
   "app.components.Admin.Campaigns.deliveryStatus_opened": "افتتح",

--- a/front/app/translations/admin/cy-GB.json
+++ b/front/app/translations/admin/cy-GB.json
@@ -32,7 +32,6 @@
   "app.components.Admin.Campaigns.deliveryStatus_accepted": "Derbyniwyd",
   "app.components.Admin.Campaigns.deliveryStatus_bounced": "Bownsio",
   "app.components.Admin.Campaigns.deliveryStatus_clicked": "Wedi clicio",
-  "app.components.Admin.Campaigns.deliveryStatus_clickedTooltip": "Pan ychwanegoch un neu fwy o ddolenni at eich e-bost, bydd nifer y defnyddwyr a gliciodd ddolen yn cael eu dangos yma.",
   "app.components.Admin.Campaigns.deliveryStatus_delivered": "Wedi'i gyflwyno",
   "app.components.Admin.Campaigns.deliveryStatus_failed": "Wedi methu",
   "app.components.Admin.Campaigns.deliveryStatus_opened": "Agorwyd",

--- a/front/app/translations/admin/da-DK.json
+++ b/front/app/translations/admin/da-DK.json
@@ -32,7 +32,6 @@
   "app.components.Admin.Campaigns.deliveryStatus_accepted": "Accepteret",
   "app.components.Admin.Campaigns.deliveryStatus_bounced": "Afvist",
   "app.components.Admin.Campaigns.deliveryStatus_clicked": "Klikede på",
-  "app.components.Admin.Campaigns.deliveryStatus_clickedTooltip": "Når du har tilføjet et eller flere links til din e-mail, vil antallet af brugere, der har klikket på et link, blive vist her.",
   "app.components.Admin.Campaigns.deliveryStatus_delivered": "Leveret",
   "app.components.Admin.Campaigns.deliveryStatus_failed": "Mislykkedes",
   "app.components.Admin.Campaigns.deliveryStatus_opened": "Åbnet",

--- a/front/app/translations/admin/de-DE.json
+++ b/front/app/translations/admin/de-DE.json
@@ -32,7 +32,6 @@
   "app.components.Admin.Campaigns.deliveryStatus_accepted": "Akzeptiert",
   "app.components.Admin.Campaigns.deliveryStatus_bounced": "Nicht zugestellt",
   "app.components.Admin.Campaigns.deliveryStatus_clicked": "Angeklickt",
-  "app.components.Admin.Campaigns.deliveryStatus_clickedTooltip": "Wenn Sie einen oder mehrere Links zu Ihrer E-Mail hinzugefügt haben, wird hier die Anzahl der Nutzer*innen angezeigt, die auf einen Link geklickt haben.",
   "app.components.Admin.Campaigns.deliveryStatus_delivered": "Angekommen",
   "app.components.Admin.Campaigns.deliveryStatus_failed": "Fehlgeschlagen",
   "app.components.Admin.Campaigns.deliveryStatus_opened": "Geöffnet",

--- a/front/app/translations/admin/en-CA.json
+++ b/front/app/translations/admin/en-CA.json
@@ -32,7 +32,6 @@
   "app.components.Admin.Campaigns.deliveryStatus_accepted": "Accepted",
   "app.components.Admin.Campaigns.deliveryStatus_bounced": "Bounced",
   "app.components.Admin.Campaigns.deliveryStatus_clicked": "Clicked",
-  "app.components.Admin.Campaigns.deliveryStatus_clickedTooltip": "When you added one or more links to your email, the number of users who clicked a link will be shown here.",
   "app.components.Admin.Campaigns.deliveryStatus_delivered": "Delivered",
   "app.components.Admin.Campaigns.deliveryStatus_failed": "Failed",
   "app.components.Admin.Campaigns.deliveryStatus_opened": "Opened",

--- a/front/app/translations/admin/en-GB.json
+++ b/front/app/translations/admin/en-GB.json
@@ -32,7 +32,6 @@
   "app.components.Admin.Campaigns.deliveryStatus_accepted": "Accepted",
   "app.components.Admin.Campaigns.deliveryStatus_bounced": "Bounced",
   "app.components.Admin.Campaigns.deliveryStatus_clicked": "Clicked",
-  "app.components.Admin.Campaigns.deliveryStatus_clickedTooltip": "When you added one or more links to your email, the number of users who clicked a link will be shown here.",
   "app.components.Admin.Campaigns.deliveryStatus_delivered": "Delivered",
   "app.components.Admin.Campaigns.deliveryStatus_failed": "Failed",
   "app.components.Admin.Campaigns.deliveryStatus_opened": "Opened",

--- a/front/app/translations/admin/en-IE.json
+++ b/front/app/translations/admin/en-IE.json
@@ -32,7 +32,6 @@
   "app.components.Admin.Campaigns.deliveryStatus_accepted": "Accepted",
   "app.components.Admin.Campaigns.deliveryStatus_bounced": "Bounced",
   "app.components.Admin.Campaigns.deliveryStatus_clicked": "Clicked",
-  "app.components.Admin.Campaigns.deliveryStatus_clickedTooltip": "When you added one or more links to your email, the number of users who clicked a link will be shown here.",
   "app.components.Admin.Campaigns.deliveryStatus_delivered": "Delivered",
   "app.components.Admin.Campaigns.deliveryStatus_failed": "Failed",
   "app.components.Admin.Campaigns.deliveryStatus_opened": "Opened",

--- a/front/app/translations/admin/en.json
+++ b/front/app/translations/admin/en.json
@@ -32,7 +32,7 @@
   "app.components.Admin.Campaigns.deliveryStatus_accepted": "Accepted",
   "app.components.Admin.Campaigns.deliveryStatus_bounced": "Bounced",
   "app.components.Admin.Campaigns.deliveryStatus_clicked": "Clicked",
-  "app.components.Admin.Campaigns.deliveryStatus_clickedTooltip": "This shows how many recipients clicked a link in the email. Please note that some security systems may follow links automatically to scan them, which can result in false clicks.",
+  "app.components.Admin.Campaigns.deliveryStatus_clickedTooltip2": "This shows how many recipients clicked a link in the email. Please note that some security systems may follow links automatically to scan them, which can result in false clicks.",
   "app.components.Admin.Campaigns.deliveryStatus_delivered": "Delivered",
   "app.components.Admin.Campaigns.deliveryStatus_failed": "Failed",
   "app.components.Admin.Campaigns.deliveryStatus_opened": "Opened",

--- a/front/app/translations/admin/en.json
+++ b/front/app/translations/admin/en.json
@@ -36,6 +36,7 @@
   "app.components.Admin.Campaigns.deliveryStatus_delivered": "Delivered",
   "app.components.Admin.Campaigns.deliveryStatus_failed": "Failed",
   "app.components.Admin.Campaigns.deliveryStatus_opened": "Opened",
+  "app.components.Admin.Campaigns.deliveryStatus_openedTooltip": "This shows how many recipients opened the email. Please note that some security systems (like Microsoft Defender) may pre-load content for scanning, which can result in false opens.",
   "app.components.Admin.Campaigns.deliveryStatus_sent": "Sent",
   "app.components.Admin.Campaigns.draft": "Draft",
   "app.components.Admin.Campaigns.manageButtonLabel": "Manage",

--- a/front/app/translations/admin/en.json
+++ b/front/app/translations/admin/en.json
@@ -32,7 +32,7 @@
   "app.components.Admin.Campaigns.deliveryStatus_accepted": "Accepted",
   "app.components.Admin.Campaigns.deliveryStatus_bounced": "Bounced",
   "app.components.Admin.Campaigns.deliveryStatus_clicked": "Clicked",
-  "app.components.Admin.Campaigns.deliveryStatus_clickedTooltip": "When you added one or more links to your email, the number of users who clicked a link will be shown here.",
+  "app.components.Admin.Campaigns.deliveryStatus_clickedTooltip": "This shows how many recipients clicked a link in the email. Please note that some security systems may follow links automatically to scan them, which can result in false clicks.",
   "app.components.Admin.Campaigns.deliveryStatus_delivered": "Delivered",
   "app.components.Admin.Campaigns.deliveryStatus_failed": "Failed",
   "app.components.Admin.Campaigns.deliveryStatus_opened": "Opened",

--- a/front/app/translations/admin/es-CL.json
+++ b/front/app/translations/admin/es-CL.json
@@ -32,7 +32,6 @@
   "app.components.Admin.Campaigns.deliveryStatus_accepted": "Aceptado",
   "app.components.Admin.Campaigns.deliveryStatus_bounced": "Rebotado",
   "app.components.Admin.Campaigns.deliveryStatus_clicked": "Cliqueado",
-  "app.components.Admin.Campaigns.deliveryStatus_clickedTooltip": "Cuando tu agregas uno o más vínculos a tu correo, el número de usuarios que revisaron el vínculo será mostrado aquí.",
   "app.components.Admin.Campaigns.deliveryStatus_delivered": "Entregado",
   "app.components.Admin.Campaigns.deliveryStatus_failed": "Fallido",
   "app.components.Admin.Campaigns.deliveryStatus_opened": "Abierto",

--- a/front/app/translations/admin/es-ES.json
+++ b/front/app/translations/admin/es-ES.json
@@ -32,7 +32,6 @@
   "app.components.Admin.Campaigns.deliveryStatus_accepted": "Aceptado",
   "app.components.Admin.Campaigns.deliveryStatus_bounced": "Rebotado",
   "app.components.Admin.Campaigns.deliveryStatus_clicked": "Cliqueado",
-  "app.components.Admin.Campaigns.deliveryStatus_clickedTooltip": "Cuando tu agregas uno o más vínculos a tu correo, el número de usuarios que revisaron el vínculo será mostrado aquí.",
   "app.components.Admin.Campaigns.deliveryStatus_delivered": "Entregado",
   "app.components.Admin.Campaigns.deliveryStatus_failed": "Fallido",
   "app.components.Admin.Campaigns.deliveryStatus_opened": "Abierto",

--- a/front/app/translations/admin/fi-FI.json
+++ b/front/app/translations/admin/fi-FI.json
@@ -32,7 +32,6 @@
   "app.components.Admin.Campaigns.deliveryStatus_accepted": "Hyväksytty",
   "app.components.Admin.Campaigns.deliveryStatus_bounced": "Pomppii",
   "app.components.Admin.Campaigns.deliveryStatus_clicked": "Napsautettu",
-  "app.components.Admin.Campaigns.deliveryStatus_clickedTooltip": "Kun lisäsit yhden tai useamman linkin sähköpostiisi, linkkiä napsauttaneiden käyttäjien määrä näkyy tässä.",
   "app.components.Admin.Campaigns.deliveryStatus_delivered": "Toimitettu",
   "app.components.Admin.Campaigns.deliveryStatus_failed": "Epäonnistui",
   "app.components.Admin.Campaigns.deliveryStatus_opened": "Avattu",

--- a/front/app/translations/admin/fr-BE.json
+++ b/front/app/translations/admin/fr-BE.json
@@ -32,7 +32,6 @@
   "app.components.Admin.Campaigns.deliveryStatus_accepted": "Accepté",
   "app.components.Admin.Campaigns.deliveryStatus_bounced": "Rejeté",
   "app.components.Admin.Campaigns.deliveryStatus_clicked": "Cliqué",
-  "app.components.Admin.Campaigns.deliveryStatus_clickedTooltip": "Si votre e-mail contient un ou plusieurs liens, le nombre d'utilisateurs ayant cliqué sur un lien s'affichera ici.",
   "app.components.Admin.Campaigns.deliveryStatus_delivered": "Distribué ",
   "app.components.Admin.Campaigns.deliveryStatus_failed": "Échoué",
   "app.components.Admin.Campaigns.deliveryStatus_opened": "Ouvert",

--- a/front/app/translations/admin/fr-FR.json
+++ b/front/app/translations/admin/fr-FR.json
@@ -32,7 +32,6 @@
   "app.components.Admin.Campaigns.deliveryStatus_accepted": "Accepté",
   "app.components.Admin.Campaigns.deliveryStatus_bounced": "Rejeté",
   "app.components.Admin.Campaigns.deliveryStatus_clicked": "Cliqué",
-  "app.components.Admin.Campaigns.deliveryStatus_clickedTooltip": "Si votre e-mail contient un ou plusieurs liens, le nombre d'utilisateurs ayant cliqué sur un lien s'affichera ici.",
   "app.components.Admin.Campaigns.deliveryStatus_delivered": "Distribué ",
   "app.components.Admin.Campaigns.deliveryStatus_failed": "Échoué",
   "app.components.Admin.Campaigns.deliveryStatus_opened": "Ouvert",

--- a/front/app/translations/admin/hr-HR.json
+++ b/front/app/translations/admin/hr-HR.json
@@ -32,7 +32,6 @@
   "app.components.Admin.Campaigns.deliveryStatus_accepted": "Prihvaćeno",
   "app.components.Admin.Campaigns.deliveryStatus_bounced": "Odskočio",
   "app.components.Admin.Campaigns.deliveryStatus_clicked": "Kliknuo",
-  "app.components.Admin.Campaigns.deliveryStatus_clickedTooltip": "Kada dodate jednu ili više poveznica u svoju e-poštu, ovdje će se prikazati broj korisnika koji su kliknuli vezu.",
   "app.components.Admin.Campaigns.deliveryStatus_delivered": "Isporučeno",
   "app.components.Admin.Campaigns.deliveryStatus_failed": "Neuspjeh",
   "app.components.Admin.Campaigns.deliveryStatus_opened": "Otvoreno",

--- a/front/app/translations/admin/lt-LT.json
+++ b/front/app/translations/admin/lt-LT.json
@@ -32,7 +32,6 @@
   "app.components.Admin.Campaigns.deliveryStatus_accepted": "Priimtas",
   "app.components.Admin.Campaigns.deliveryStatus_bounced": "Atšokęs",
   "app.components.Admin.Campaigns.deliveryStatus_clicked": "Paspaudė",
-  "app.components.Admin.Campaigns.deliveryStatus_clickedTooltip": "Kai į el. laišką pridėjote vieną ar daugiau nuorodų, čia bus rodomas naudotojų, kurie spustelėjo nuorodą, skaičius.",
   "app.components.Admin.Campaigns.deliveryStatus_delivered": "Pristatytas",
   "app.components.Admin.Campaigns.deliveryStatus_failed": "Nepavyko",
   "app.components.Admin.Campaigns.deliveryStatus_opened": "Atidaryta",

--- a/front/app/translations/admin/lv-LV.json
+++ b/front/app/translations/admin/lv-LV.json
@@ -32,7 +32,6 @@
   "app.components.Admin.Campaigns.deliveryStatus_accepted": "Pieņemts",
   "app.components.Admin.Campaigns.deliveryStatus_bounced": "Atbalsots",
   "app.components.Admin.Campaigns.deliveryStatus_clicked": "Noklikšķiniet uz",
-  "app.components.Admin.Campaigns.deliveryStatus_clickedTooltip": "Ja e-pastam pievienojāt vienu vai vairākas saites, šeit tiks parādīts to lietotāju skaits, kuri noklikšķināja uz saites.",
   "app.components.Admin.Campaigns.deliveryStatus_delivered": "Piegādāts",
   "app.components.Admin.Campaigns.deliveryStatus_failed": "Neveiksmīgs",
   "app.components.Admin.Campaigns.deliveryStatus_opened": "Atvērts",

--- a/front/app/translations/admin/nb-NO.json
+++ b/front/app/translations/admin/nb-NO.json
@@ -32,7 +32,6 @@
   "app.components.Admin.Campaigns.deliveryStatus_accepted": "Godkjent",
   "app.components.Admin.Campaigns.deliveryStatus_bounced": "Avvist",
   "app.components.Admin.Campaigns.deliveryStatus_clicked": "Klikket",
-  "app.components.Admin.Campaigns.deliveryStatus_clickedTooltip": "Når du har lagt til en eller flere lenker i e-posten din, vil antall brukere som har klikket på en lenke, vises her.",
   "app.components.Admin.Campaigns.deliveryStatus_delivered": "Leveres",
   "app.components.Admin.Campaigns.deliveryStatus_failed": "Mislyktes",
   "app.components.Admin.Campaigns.deliveryStatus_opened": "Åpnet",

--- a/front/app/translations/admin/nl-BE.json
+++ b/front/app/translations/admin/nl-BE.json
@@ -32,7 +32,6 @@
   "app.components.Admin.Campaigns.deliveryStatus_accepted": "Geaccepteerd",
   "app.components.Admin.Campaigns.deliveryStatus_bounced": "Bounced",
   "app.components.Admin.Campaigns.deliveryStatus_clicked": "Geklikt",
-  "app.components.Admin.Campaigns.deliveryStatus_clickedTooltip": "Als je één of meer hyperlinks hebt toegevoegd aan je e-mail, kan je hier zien hoeveel gebruikers erop hebben geklikt.",
   "app.components.Admin.Campaigns.deliveryStatus_delivered": "Afgeleverd",
   "app.components.Admin.Campaigns.deliveryStatus_failed": "Mislukt",
   "app.components.Admin.Campaigns.deliveryStatus_opened": "Geopend",

--- a/front/app/translations/admin/nl-NL.json
+++ b/front/app/translations/admin/nl-NL.json
@@ -32,7 +32,6 @@
   "app.components.Admin.Campaigns.deliveryStatus_accepted": "Geaccepteerd",
   "app.components.Admin.Campaigns.deliveryStatus_bounced": "Bounced",
   "app.components.Admin.Campaigns.deliveryStatus_clicked": "Geklikt",
-  "app.components.Admin.Campaigns.deliveryStatus_clickedTooltip": "Als je één of meer hyperlinks hebt toegevoegd aan je e-mail, kan je hier zien hoeveel gebruikers erop hebben geklikt.",
   "app.components.Admin.Campaigns.deliveryStatus_delivered": "Afgeleverd",
   "app.components.Admin.Campaigns.deliveryStatus_failed": "Mislukt",
   "app.components.Admin.Campaigns.deliveryStatus_opened": "Geopend",

--- a/front/app/translations/admin/pa-IN.json
+++ b/front/app/translations/admin/pa-IN.json
@@ -32,7 +32,6 @@
   "app.components.Admin.Campaigns.deliveryStatus_accepted": "ਸਵੀਕਾਰ ਕੀਤਾ",
   "app.components.Admin.Campaigns.deliveryStatus_bounced": "ਉਛਾਲਿਆ",
   "app.components.Admin.Campaigns.deliveryStatus_clicked": "ਕਲਿਕ ਕੀਤਾ",
-  "app.components.Admin.Campaigns.deliveryStatus_clickedTooltip": "ਜਦੋਂ ਤੁਸੀਂ ਆਪਣੀ ਈਮੇਲ ਵਿੱਚ ਇੱਕ ਜਾਂ ਵੱਧ ਲਿੰਕ ਜੋੜਦੇ ਹੋ, ਤਾਂ ਲਿੰਕ 'ਤੇ ਕਲਿੱਕ ਕਰਨ ਵਾਲੇ ਉਪਭੋਗਤਾਵਾਂ ਦੀ ਗਿਣਤੀ ਇੱਥੇ ਦਿਖਾਈ ਜਾਵੇਗੀ।",
   "app.components.Admin.Campaigns.deliveryStatus_delivered": "ਡਿਲੀਵਰ ਕੀਤਾ",
   "app.components.Admin.Campaigns.deliveryStatus_failed": "ਅਸਫਲ ਰਿਹਾ",
   "app.components.Admin.Campaigns.deliveryStatus_opened": "ਖੋਲ੍ਹਿਆ",

--- a/front/app/translations/admin/pl-PL.json
+++ b/front/app/translations/admin/pl-PL.json
@@ -32,7 +32,6 @@
   "app.components.Admin.Campaigns.deliveryStatus_accepted": "Zaakceptowany",
   "app.components.Admin.Campaigns.deliveryStatus_bounced": "Odbity",
   "app.components.Admin.Campaigns.deliveryStatus_clicked": "Kliknij",
-  "app.components.Admin.Campaigns.deliveryStatus_clickedTooltip": "Jeśli dodałeś jeden lub więcej linków do wiadomości e-mail, liczba użytkowników, którzy kliknęli link, zostanie wyświetlona tutaj.",
   "app.components.Admin.Campaigns.deliveryStatus_delivered": "Dostarczone",
   "app.components.Admin.Campaigns.deliveryStatus_failed": "Nie powiodło się",
   "app.components.Admin.Campaigns.deliveryStatus_opened": "Otwarte",

--- a/front/app/translations/admin/pt-BR.json
+++ b/front/app/translations/admin/pt-BR.json
@@ -32,7 +32,6 @@
   "app.components.Admin.Campaigns.deliveryStatus_accepted": "Aceito",
   "app.components.Admin.Campaigns.deliveryStatus_bounced": "Rejeitado",
   "app.components.Admin.Campaigns.deliveryStatus_clicked": "Clicado",
-  "app.components.Admin.Campaigns.deliveryStatus_clickedTooltip": "Quando você adicionou um ou mais links ao seu e-mail, o número de usuários que clicaram em um link será mostrado aqui.",
   "app.components.Admin.Campaigns.deliveryStatus_delivered": "Entregue",
   "app.components.Admin.Campaigns.deliveryStatus_failed": "Falha",
   "app.components.Admin.Campaigns.deliveryStatus_opened": "Aberto",

--- a/front/app/translations/admin/sr-Latn.json
+++ b/front/app/translations/admin/sr-Latn.json
@@ -32,7 +32,6 @@
   "app.components.Admin.Campaigns.deliveryStatus_accepted": "Accepted",
   "app.components.Admin.Campaigns.deliveryStatus_bounced": "Bounced",
   "app.components.Admin.Campaigns.deliveryStatus_clicked": "Clicked",
-  "app.components.Admin.Campaigns.deliveryStatus_clickedTooltip": "When you added one or more links to your email, the number of users who clicked a link will be shown here.",
   "app.components.Admin.Campaigns.deliveryStatus_delivered": "Delivered",
   "app.components.Admin.Campaigns.deliveryStatus_failed": "Failed",
   "app.components.Admin.Campaigns.deliveryStatus_opened": "Opened",

--- a/front/app/translations/admin/sr-SP.json
+++ b/front/app/translations/admin/sr-SP.json
@@ -32,7 +32,6 @@
   "app.components.Admin.Campaigns.deliveryStatus_accepted": "Accepted",
   "app.components.Admin.Campaigns.deliveryStatus_bounced": "Bounced",
   "app.components.Admin.Campaigns.deliveryStatus_clicked": "Clicked",
-  "app.components.Admin.Campaigns.deliveryStatus_clickedTooltip": "When you added one or more links to your email, the number of users who clicked a link will be shown here.",
   "app.components.Admin.Campaigns.deliveryStatus_delivered": "Delivered",
   "app.components.Admin.Campaigns.deliveryStatus_failed": "Failed",
   "app.components.Admin.Campaigns.deliveryStatus_opened": "Opened",

--- a/front/app/translations/admin/sv-SE.json
+++ b/front/app/translations/admin/sv-SE.json
@@ -32,7 +32,6 @@
   "app.components.Admin.Campaigns.deliveryStatus_accepted": "Accepterad",
   "app.components.Admin.Campaigns.deliveryStatus_bounced": "Studsade",
   "app.components.Admin.Campaigns.deliveryStatus_clicked": "Klickade",
-  "app.components.Admin.Campaigns.deliveryStatus_clickedTooltip": "När du har lagt till en eller flera länkar i ditt e-postmeddelande visas antalet användare som har klickat på en länk här.",
   "app.components.Admin.Campaigns.deliveryStatus_delivered": "Levereras",
   "app.components.Admin.Campaigns.deliveryStatus_failed": "Misslyckades",
   "app.components.Admin.Campaigns.deliveryStatus_opened": "Öppnad",

--- a/front/app/translations/admin/tr-TR.json
+++ b/front/app/translations/admin/tr-TR.json
@@ -32,7 +32,6 @@
   "app.components.Admin.Campaigns.deliveryStatus_accepted": "Kabul Edildi",
   "app.components.Admin.Campaigns.deliveryStatus_bounced": "Zıpladı",
   "app.components.Admin.Campaigns.deliveryStatus_clicked": "Tıklandı",
-  "app.components.Admin.Campaigns.deliveryStatus_clickedTooltip": "E-postanıza bir veya daha fazla bağlantı eklediğinizde, bir bağlantıya tıklayan kullanıcı sayısı burada gösterilecektir.",
   "app.components.Admin.Campaigns.deliveryStatus_delivered": "Teslim edildi",
   "app.components.Admin.Campaigns.deliveryStatus_failed": "Başarısız",
   "app.components.Admin.Campaigns.deliveryStatus_opened": "Açıldı",

--- a/front/app/translations/admin/ur-PK.json
+++ b/front/app/translations/admin/ur-PK.json
@@ -32,7 +32,6 @@
   "app.components.Admin.Campaigns.deliveryStatus_accepted": "قبول کر لیا",
   "app.components.Admin.Campaigns.deliveryStatus_bounced": "اچھال دیا",
   "app.components.Admin.Campaigns.deliveryStatus_clicked": "کلک کیا۔",
-  "app.components.Admin.Campaigns.deliveryStatus_clickedTooltip": "جب آپ اپنے ای میل میں ایک یا زیادہ لنکس شامل کرتے ہیں، تو لنک پر کلک کرنے والے صارفین کی تعداد یہاں دکھائی جائے گی۔",
   "app.components.Admin.Campaigns.deliveryStatus_delivered": "پہنچایا",
   "app.components.Admin.Campaigns.deliveryStatus_failed": "ناکام",
   "app.components.Admin.Campaigns.deliveryStatus_opened": "کھول دیا",


### PR DESCRIPTION
<img width="1122" height="511" alt="Screenshot 2025-07-30 at 16 09 24" src="https://github.com/user-attachments/assets/df693551-5a65-44db-a31f-7825d3a79996" />

# Changelog
### Added
- [TAN-5131] Tooltips in the email delivery stats explain that there can be false positives for "opened" and "clicked" due to scanning by, for example, Windows Defender.
