### PR TITLE
[TAN-5215] Filter our Shoulda::Matcher temporary models in ApplicationPolicy scope

### DIFF
--- a/back/app/policies/application_policy.rb
+++ b/back/app/policies/application_policy.rb
@@ -20,7 +20,11 @@ class ApplicationPolicy
     end
 
     def scope_for(target_scope_or_klass)
-      (filtered_scope = handle_excluded_models(target_scope_or_klass)) and return filtered_scope if Rails.env.test?
+      if Rails.env.test?
+         filtered_scope = handle_excluded_models(target_scope_or_klass)
+
+         return filtered_scope if filtered_scope
+      end
 
       Pundit.policy_scope!(user_context, target_scope_or_klass)
     end

--- a/back/app/policies/application_policy.rb
+++ b/back/app/policies/application_policy.rb
@@ -5,7 +5,7 @@ class ApplicationPolicy
   # Pundit policy lookup when in test environment.
   # This list will specifically target Shoulda::Matchers temporary models.
   EXCLUDED_TEST_POLICY_MODEL_NAME_PATTERNS = [
-    /^Shoulda::Matchers::ActiveRecord::Uniqueness::TestModels::/,
+    /^Shoulda::Matchers::ActiveRecord::Uniqueness::TestModels::/
   ].freeze
 
   module Helpers
@@ -29,7 +29,6 @@ class ApplicationPolicy
       if target_scope_or_klass.is_a?(Class) &&
          EXCLUDED_TEST_POLICY_MODEL_NAME_PATTERNS.any? { |pattern| target_scope_or_klass.name.match?(pattern) }
 
-        Rails.logger.debug "DEBUG: ApplicationPolicy::Helpers#handle_excluded_models: Matched and skipping model: #{target_scope_or_klass.name.inspect}"
         return target_scope_or_klass.none # Return an empty ActiveRecord::Relation
       end
 

--- a/back/app/policies/application_policy.rb
+++ b/back/app/policies/application_policy.rb
@@ -21,9 +21,9 @@ class ApplicationPolicy
 
     def scope_for(target_scope_or_klass)
       if Rails.env.test?
-         filtered_scope = handle_excluded_models(target_scope_or_klass)
+        filtered_scope = handle_excluded_models(target_scope_or_klass)
 
-         return filtered_scope if filtered_scope
+        return filtered_scope if filtered_scope
       end
 
       Pundit.policy_scope!(user_context, target_scope_or_klass)

--- a/back/app/policies/application_policy.rb
+++ b/back/app/policies/application_policy.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class ApplicationPolicy
-  # Define patterns for class names that should be *excluded* from Pundit policy lookup.
+  # Define patterns for class names that should be *excluded* from
+  # Pundit policy lookup when in test environment.
   # This list will specifically target Shoulda::Matchers temporary models.
-  EXCLUDED_POLICY_MODEL_NAME_PATTERNS = [
+  EXCLUDED_TEST_POLICY_MODEL_NAME_PATTERNS = [
     /^Shoulda::Matchers::ActiveRecord::Uniqueness::TestModels::/,
   ].freeze
 
@@ -26,7 +27,7 @@ class ApplicationPolicy
 
     def handle_excluded_models(target_scope_or_klass)
       if target_scope_or_klass.is_a?(Class) &&
-         EXCLUDED_POLICY_MODEL_NAME_PATTERNS.any? { |pattern| target_scope_or_klass.name.match?(pattern) }
+         EXCLUDED_TEST_POLICY_MODEL_NAME_PATTERNS.any? { |pattern| target_scope_or_klass.name.match?(pattern) }
 
         Rails.logger.debug "DEBUG: ApplicationPolicy::Helpers#handle_excluded_models: Matched and skipping model: #{target_scope_or_klass.name.inspect}"
         return target_scope_or_klass.none # Return an empty ActiveRecord::Relation

--- a/back/app/policies/application_policy.rb
+++ b/back/app/policies/application_policy.rb
@@ -3,7 +3,7 @@
 class ApplicationPolicy
   # Define patterns for class names that should be *excluded* from
   # Pundit policy lookup when in test environment.
-  # This list will specifically target Shoulda::Matchers temporary models.
+  # This list specifically targets Shoulda::Matchers temporary models.
   EXCLUDED_TEST_POLICY_MODEL_NAME_PATTERNS = [
     /^Shoulda::Matchers::ActiveRecord::Uniqueness::TestModels::/
   ].freeze

--- a/back/app/policies/application_policy.rb
+++ b/back/app/policies/application_policy.rb
@@ -7,7 +7,7 @@ class ApplicationPolicy
   EXCLUDED_POLICY_MODEL_NAME_PATTERNS = [
     # Pattern for Shoulda::Matchers temporary models (like 'Projecu')
     /^Shoulda::Matchers::ActiveRecord::Uniqueness::TestModels::/,
-    /^AnonymousClass/, # Catches common forms of anonymous classes if their name method behaves this way
+    /^AnonymousClass/ # Catches common forms of anonymous classes if their name method behaves this way
   ].freeze
 
   module Helpers
@@ -30,7 +30,7 @@ class ApplicationPolicy
         # 2. Check against our EXCLUDED_POLICY_MODEL_NAME_PATTERNS.
         # This catches "Projecu" and similar temporary models.
         if EXCLUDED_POLICY_MODEL_NAME_PATTERNS.any? { |pattern| target_scope_or_klass.name.match?(pattern) }
-          Rails.logger.debug "DEBUG: ApplicationPolicy::Helpers#scope_for: Skipping excluded temporary model by pattern: #{target_scope_or_klass.name.inspect}"
+          Rails.logger.debug { "DEBUG: ApplicationPolicy::Helpers#scope_for: Skipping excluded temporary model by pattern: #{target_scope_or_klass.name.inspect}" }
           return target_scope_or_klass.none # Return an empty ActiveRecord::Relation
         end
 
@@ -38,7 +38,7 @@ class ApplicationPolicy
       # (e.g., it's already an ActiveRecord::Relation instance, which is fine)
       # Or if it's a Class but not an ActiveRecord descendant (e.g., a simple Ruby class that doesn't need policy scoping)
       elsif target_scope_or_klass.is_a?(Class) && target_scope_or_klass.name.blank?
-        Rails.logger.debug "DEBUG: ApplicationPolicy::Helpers#scope_for: Skipping anonymous/blank-named class: #{target_scope_or_klass.inspect}"
+        Rails.logger.debug { "DEBUG: ApplicationPolicy::Helpers#scope_for: Skipping anonymous/blank-named class: #{target_scope_or_klass.inspect}" }
         return [] # Return an empty array for anonymous classes
       end
 

--- a/back/app/policies/application_policy.rb
+++ b/back/app/policies/application_policy.rb
@@ -2,12 +2,9 @@
 
 class ApplicationPolicy
   # Define patterns for class names that should be *excluded* from Pundit policy lookup.
-  # This list will contain regex patterns for temporary or non-application models.
-  # Placed at the top-level of ApplicationPolicy, so it's a class constant.
+  # This list will specifically target Shoulda::Matchers temporary models.
   EXCLUDED_POLICY_MODEL_NAME_PATTERNS = [
-    # Pattern for Shoulda::Matchers temporary models (like 'Projecu')
     /^Shoulda::Matchers::ActiveRecord::Uniqueness::TestModels::/,
-    /^AnonymousClass/ # Catches common forms of anonymous classes if their name method behaves this way
   ].freeze
 
   module Helpers
@@ -22,28 +19,20 @@ class ApplicationPolicy
     end
 
     def scope_for(target_scope_or_klass)
-      # 1. Basic check if it's a Class and an ActiveRecord descendant.
-      is_a_potential_ar_model = target_scope_or_klass.is_a?(Class) &&
-                                (target_scope_or_klass < ActiveRecord::Base || target_scope_or_klass < ApplicationRecord)
+      (filtered_scope = handle_excluded_models(target_scope_or_klass)) and return filtered_scope if Rails.env.test?
 
-      if is_a_potential_ar_model
-        # 2. Check against our EXCLUDED_POLICY_MODEL_NAME_PATTERNS.
-        # This catches "Projecu" and similar temporary models.
-        if EXCLUDED_POLICY_MODEL_NAME_PATTERNS.any? { |pattern| target_scope_or_klass.name.match?(pattern) }
-          Rails.logger.debug { "DEBUG: ApplicationPolicy::Helpers#scope_for: Skipping excluded temporary model by pattern: #{target_scope_or_klass.name.inspect}" }
-          return target_scope_or_klass.none # Return an empty ActiveRecord::Relation
-        end
+      Pundit.policy_scope!(user_context, target_scope_or_klass)
+    end
 
-      # Handle cases where `target_scope_or_klass` is not a Class object
-      # (e.g., it's already an ActiveRecord::Relation instance, which is fine)
-      # Or if it's a Class but not an ActiveRecord descendant (e.g., a simple Ruby class that doesn't need policy scoping)
-      elsif target_scope_or_klass.is_a?(Class) && target_scope_or_klass.name.blank?
-        Rails.logger.debug { "DEBUG: ApplicationPolicy::Helpers#scope_for: Skipping anonymous/blank-named class: #{target_scope_or_klass.inspect}" }
-        return [] # Return an empty array for anonymous classes
+    def handle_excluded_models(target_scope_or_klass)
+      if target_scope_or_klass.is_a?(Class) &&
+         EXCLUDED_POLICY_MODEL_NAME_PATTERNS.any? { |pattern| target_scope_or_klass.name.match?(pattern) }
+
+        Rails.logger.debug "DEBUG: ApplicationPolicy::Helpers#handle_excluded_models: Matched and skipping model: #{target_scope_or_klass.name.inspect}"
+        return target_scope_or_klass.none # Return an empty ActiveRecord::Relation
       end
 
-      # If it passes all exclusion filters, assume it's a legitimate target for Pundit.
-      Pundit.policy_scope!(user_context, target_scope_or_klass)
+      nil # If no filter was applied, return nil
     end
 
     def can_moderate?


### PR DESCRIPTION
Not clear why this issue started appearing, but I'm reasonably confident this fix is 'safe', since we only apply it the test environment.

# Changelog
## Technical
- [TAN-5215] Filter out Shoulda::Matcher temporary models in ApplicationPolicy scope (only in test env)
