### PR TITLE
TAN-5218 Cache participant counts client-side

### DIFF
--- a/front/app/api/participant_counts/useParticipantCounts.ts
+++ b/front/app/api/participant_counts/useParticipantCounts.ts
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import { useQuery } from '@tanstack/react-query';
 import { CLErrors } from 'typings';
 
@@ -16,17 +18,41 @@ const fetchParticipantCounts = async (projectIds: string[]) => {
   });
 };
 
+// Client-side caching to avoid sending super long lists
+// of project IDs in the query
+const PARTICIPANTS_PER_PROJECT_CACHE: Record<string, number> = {};
+
 const useParticipantCounts = (projectIds: string[]) => {
-  return useQuery<
+  // Only fetch project ids that are not already cached
+  const projectIdsToFetch = projectIds.filter(
+    (projectId) => !(projectId in PARTICIPANTS_PER_PROJECT_CACHE)
+  );
+
+  const { data } = useQuery<
     ParticipantCounts,
     CLErrors,
     ParticipantCounts,
     ParticipantCountsKeys
   >({
-    queryKey: participantCountKeys.list({ project_ids: projectIds }),
-    queryFn: () => fetchParticipantCounts(projectIds),
-    enabled: projectIds.length > 0,
+    queryKey: participantCountKeys.list({ project_ids: projectIdsToFetch }),
+    queryFn: () => fetchParticipantCounts(projectIdsToFetch),
+    enabled: projectIdsToFetch.length > 0,
   });
+
+  const participantCountsResponse = data?.data.attributes.participant_counts;
+
+  // Add the fetched counts to the cache
+  useEffect(() => {
+    if (participantCountsResponse) {
+      Object.entries(participantCountsResponse).forEach(
+        ([projectId, count]) => {
+          PARTICIPANTS_PER_PROJECT_CACHE[projectId] = count;
+        }
+      );
+    }
+  }, [participantCountsResponse]);
+
+  return PARTICIPANTS_PER_PROJECT_CACHE;
 };
 
 export default useParticipantCounts;

--- a/front/app/containers/Admin/projects/all/new/Projects/Table/index.tsx
+++ b/front/app/containers/Admin/projects/all/new/Projects/Table/index.tsx
@@ -55,7 +55,7 @@ const Table = () => {
   );
 
   const projectIds = projects.map((project) => project.id);
-  const { data: participantsCounts } = useParticipantCounts(projectIds);
+  const participantsCounts = useParticipantCounts(projectIds);
 
   const { loadMoreRef } = useInfiniteScroll({
     isLoading: isFetchingNextPage,
@@ -108,11 +108,7 @@ const Table = () => {
             <Row
               key={project.id}
               project={project}
-              participantsCount={
-                participantsCounts?.data.attributes.participant_counts[
-                  project.id
-                ]
-              }
+              participantsCount={participantsCounts[project.id]}
             />
           ))}
         </Tbody>


### PR DESCRIPTION
# Changelog
## Technical
- Cache participation counts client-side to avoid requests with potentially hundreds of project ids (behind FF)