### PR TITLE
TAN-5262: filter out projects without phases when filtering past projects

### DIFF
--- a/back/app/services/projects_finder_admin_service.rb
+++ b/back/app/services/projects_finder_admin_service.rb
@@ -206,15 +206,8 @@ class ProjectsFinderAdminService
     conditions = []
 
     if participation_states.include?('not_started')
-      # Projects that have at least one phase and no phases have started yet
-      conditions << <<-SQL.squish
-        projects.id IN (
-          SELECT project_id FROM phases 
-          GROUP BY project_id 
-          HAVING COUNT(*) > 0 
-          AND MIN(start_at) >= '#{today}'
-        )
-      SQL
+      # Projects with no phases that have started yet
+      conditions << "projects.id NOT IN (SELECT project_id FROM phases WHERE start_at < '#{today}')"
     end
 
     if participation_states.include?('collecting_data')

--- a/back/spec/services/projects_finder_admin_service_spec.rb
+++ b/back/spec/services/projects_finder_admin_service_spec.rb
@@ -245,12 +245,12 @@ describe ProjectsFinderAdminService do
 
     it 'returns not_started projects' do
       result = described_class.filter_participation_states(Project.all, { participation_states: ['not_started'] })
-      expect(result.pluck(:id)).to eq([not_started_project.id])
+      expect(result.pluck(:id).sort).to match_array([not_started_project.id, project_without_phases.id].sort)
     end
 
-    it 'excludes projects without phases when filtering for not_started projects' do
+    it 'includes projects without phases when filtering for not_started projects' do
       result = described_class.filter_participation_states(Project.all, { participation_states: ['not_started'] })
-      expect(result.pluck(:id)).not_to include(project_without_phases.id)
+      expect(result.pluck(:id)).to include(project_without_phases.id)
     end
 
     it 'returns collecting_data projects' do
@@ -280,7 +280,7 @@ describe ProjectsFinderAdminService do
 
     it 'returns not_started, collecting_data, informing and past projects' do
       result = described_class.filter_participation_states(Project.all, { participation_states: %w[not_started collecting_data informing past] })
-      expect(result.pluck(:id).sort).to match_array([not_started_project.id, collecting_data_project.id, information_phase_project.id, past_project.id].sort)
+      expect(result.pluck(:id).sort).to match_array([not_started_project.id, project_without_phases.id, collecting_data_project.id, information_phase_project.id, past_project.id].sort)
     end
   end
 

--- a/back/spec/services/projects_finder_admin_service_spec.rb
+++ b/back/spec/services/projects_finder_admin_service_spec.rb
@@ -226,6 +226,11 @@ describe ProjectsFinderAdminService do
       project
     end
 
+    # Project without any phases
+    let!(:project_without_phases) do
+      create(:project)
+    end
+
     it 'returns all projects when no participation states specified' do
       result = described_class.filter_participation_states(Project.all, {})
       expect(result.pluck(:id).sort).to match_array([
@@ -233,13 +238,19 @@ describe ProjectsFinderAdminService do
         collecting_data_project.id,
         information_phase_project.id,
         past_project.id,
-        gap_project.id
+        gap_project.id,
+        project_without_phases.id
       ].sort)
     end
 
     it 'returns not_started projects' do
       result = described_class.filter_participation_states(Project.all, { participation_states: ['not_started'] })
       expect(result.pluck(:id)).to eq([not_started_project.id])
+    end
+
+    it 'excludes projects without phases when filtering for not_started projects' do
+      result = described_class.filter_participation_states(Project.all, { participation_states: ['not_started'] })
+      expect(result.pluck(:id)).not_to include(project_without_phases.id)
     end
 
     it 'returns collecting_data projects' do
@@ -255,6 +266,11 @@ describe ProjectsFinderAdminService do
     it 'returns past projects' do
       result = described_class.filter_participation_states(Project.all, { participation_states: ['past'] })
       expect(result.pluck(:id)).to eq([past_project.id])
+    end
+
+    it 'excludes projects without phases when filtering for past projects' do
+      result = described_class.filter_participation_states(Project.all, { participation_states: ['past'] })
+      expect(result.pluck(:id)).not_to include(project_without_phases.id)
     end
 
     it 'returns collecting_data and past projects' do


### PR DESCRIPTION
# Changelog

## Fixed
- Projects without phases are now excluded when filtering for past projects
