### PR TITLE
TAN-5265: filter out projects without an admin publication

### DIFF
--- a/back/app/services/projects_finder_admin_service.rb
+++ b/back/app/services/projects_finder_admin_service.rb
@@ -6,6 +6,7 @@ class ProjectsFinderAdminService
     projects = scope
 
     # Apply filters
+    projects = filter_with_admin_publication(projects)
     projects = filter_moderatable(projects, current_user)
     projects = filter_status_and_review_state(projects, params)
     projects = filter_by_folder_ids(projects, params)
@@ -102,6 +103,12 @@ class ProjectsFinderAdminService
   end
 
   # FILTERING METHODS
+  def self.filter_with_admin_publication(scope)
+    # Filter out projects that don't have an admin_publication to prevent crashes
+    # when trying to access publication_status or other admin_publication attributes
+    scope.joins(:admin_publication)
+  end
+
   def self.filter_moderatable(scope, current_user)
     return scope if current_user.admin?
 

--- a/back/spec/services/projects_finder_admin_service_spec.rb
+++ b/back/spec/services/projects_finder_admin_service_spec.rb
@@ -570,4 +570,21 @@ describe ProjectsFinderAdminService do
       end
     end
   end
+
+  describe '.filter_with_admin_publication' do
+    let!(:project_with_admin_pub) { create(:project) }
+    let!(:project_without_admin_pub) do
+      project = create(:project)
+      project.admin_publication.destroy!
+      project.reload
+      project
+    end
+
+    it 'filters out projects without admin_publication' do
+      all_projects = Project.all
+      filtered_projects = described_class.filter_with_admin_publication(all_projects)
+      
+      expect(filtered_projects).to include(project_with_admin_pub)
+      expect(filtered_projects).not_to include(project_without_admin_pub)
+    end
 end

--- a/back/spec/services/projects_finder_admin_service_spec.rb
+++ b/back/spec/services/projects_finder_admin_service_spec.rb
@@ -583,8 +583,9 @@ describe ProjectsFinderAdminService do
     it 'filters out projects without admin_publication' do
       all_projects = Project.all
       filtered_projects = described_class.filter_with_admin_publication(all_projects)
-      
+
       expect(filtered_projects).to include(project_with_admin_pub)
       expect(filtered_projects).not_to include(project_without_admin_pub)
     end
+  end
 end


### PR DESCRIPTION
# Changelog

## Fixed
- Filter out erroneous projects without an admin publication to prevent crashes on some platforms that have them