### PR TITLE
TAN-5270 - Preview project import in browser

### DIFF
--- a/back/engines/commercial/bulk_import_ideas/app/controllers/bulk_import_ideas/web_api/v1/project_import_controller.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/controllers/bulk_import_ideas/web_api/v1/project_import_controller.rb
@@ -32,7 +32,7 @@ module BulkImportIdeas
           id: import_id,
           attributes: {
             projects_to_import: num_projects,
-            preview: preview,
+            preview: preview
           }
         }
       }

--- a/back/engines/commercial/bulk_import_ideas/app/controllers/bulk_import_ideas/web_api/v1/project_import_controller.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/controllers/bulk_import_ideas/web_api/v1/project_import_controller.rb
@@ -5,6 +5,8 @@ module BulkImportIdeas
     def bulk_create_projects
       base64_zip = project_import_params[:file]
       locale = project_import_params[:locale]
+      preview = project_import_params[:preview]
+
       upload_path = 'tmp/import_files'
       import_path = "#{upload_path}/#{Tenant.current.schema_name}"
 
@@ -21,9 +23,7 @@ module BulkImportIdeas
       projects = project_extractor.projects
       importer = BulkImportIdeas::Importers::ProjectImporter.new(current_user, locale)
       num_projects = projects.count
-      import_id = importer.import_async(projects)
-
-      # TODO: No preview for projects do by creating new objects with the logs from importer.preview(projects)
+      import_id = preview ? importer.preview_async(projects) : importer.import_async(projects)
 
       authorize Project.first # TODO: Fix this authorization
       render json: {
@@ -31,7 +31,8 @@ module BulkImportIdeas
           type: 'bulk_import_projects',
           id: import_id,
           attributes: {
-            projects_to_import: num_projects
+            projects_to_import: num_projects,
+            preview: preview,
           }
         }
       }
@@ -53,7 +54,7 @@ module BulkImportIdeas
     def project_import_params
       params
         .require(:import)
-        .permit(%i[file locale])
+        .permit(%i[file locale preview])
     end
 
     def unzip_base64_encoded_zip(base64_zip, destination)

--- a/back/engines/commercial/bulk_import_ideas/app/jobs/bulk_import_ideas/project_import_preview_job.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/jobs/bulk_import_ideas/project_import_preview_job.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module BulkImportIdeas
+  class ProjectImportPreviewJob < ApplicationJob
+    self.priority = 60
+    perform_retries false
+
+    def run(preview_log, import_id, import_user, locale)
+      BulkImportIdeas::ProjectImport.create!(
+        project: nil,
+        import_user: import_user,
+        import_id: import_id,
+        log: preview_log,
+        locale: locale
+      )
+    end
+  end
+end

--- a/back/engines/commercial/bulk_import_ideas/app/models/bulk_import_ideas/project_import.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/models/bulk_import_ideas/project_import.rb
@@ -28,7 +28,7 @@ module BulkImportIdeas
   class ProjectImport < ApplicationRecord
     self.table_name = 'project_imports'
 
-    belongs_to :project
+    belongs_to :project, optional: true
     belongs_to :import_user, class_name: 'User', optional: true
   end
 end

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/importers/project_importer.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/importers/project_importer.rb
@@ -17,6 +17,7 @@ module BulkImportIdeas::Importers
     # Preview the data that will be imported
     # rubocop:disable Metrics/PerceivedComplexity
     # rubocop:disable Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/MethodLength
     def preview(projects)
       num_projects_to_import = 0
       projects.each do |project|
@@ -92,6 +93,7 @@ module BulkImportIdeas::Importers
 
       log "Will import data for #{num_projects_to_import} projects"
     end
+    # rubocop:enable Metrics/MethodLength
     # rubocop:enable Metrics/CyclomaticComplexity
     # rubocop:enable Metrics/PerceivedComplexity
 

--- a/front/app/api/project_imports/useAddProjectImportAsync.ts
+++ b/front/app/api/project_imports/useAddProjectImportAsync.ts
@@ -10,6 +10,7 @@ import projectImportKeys from './keys';
 interface RequestParams {
   file: string;
   locale: SupportedLocale;
+  preview?: boolean;
 }
 
 interface JobIdResponse {
@@ -20,11 +21,12 @@ interface JobIdResponse {
 const addProjectImport = async ({
   file,
   locale,
+  preview = false,
 }: RequestParams): Promise<JobIdResponse> =>
   fetcher<JobIdResponse>({
     path: `/importer/bulk_create_async/projects/`,
     action: 'post',
-    body: { import: { file, locale } },
+    body: { import: { file, locale, preview } },
   });
 
 const useAddProjectImportAsync = () => {

--- a/front/app/containers/Admin/ProjectImporter/ImportZipModal.tsx
+++ b/front/app/containers/Admin/ProjectImporter/ImportZipModal.tsx
@@ -20,13 +20,13 @@ import useLocale from 'hooks/useLocale';
 import LocalePicker from 'containers/Admin/projects/project/inputImporter/ImportModal/LocalePicker';
 import messages from 'containers/Admin/projects/project/inputImporter/ImportModal/messages';
 
+import CheckboxWithLabel from 'components/HookForm/CheckboxWithLabel';
 import Feedback from 'components/HookForm/Feedback';
 import SingleFileUploader from 'components/HookForm/SingleFileUploader';
 import Modal from 'components/UI/Modal';
 
 import { FormattedMessage, useIntl } from 'utils/cl-intl';
 import { handleHookFormSubmissionError } from 'utils/errorUtils';
-import CheckboxWithLabel from 'components/HookForm/CheckboxWithLabel';
 
 interface FormValues {
   locale: SupportedLocale;

--- a/front/app/containers/Admin/ProjectImporter/ImportZipModal.tsx
+++ b/front/app/containers/Admin/ProjectImporter/ImportZipModal.tsx
@@ -26,12 +26,12 @@ import Modal from 'components/UI/Modal';
 
 import { FormattedMessage, useIntl } from 'utils/cl-intl';
 import { handleHookFormSubmissionError } from 'utils/errorUtils';
-
-// TODO: Remove these references
+import CheckboxWithLabel from 'components/HookForm/CheckboxWithLabel';
 
 interface FormValues {
   locale: SupportedLocale;
   file?: UploadFile;
+  preview: boolean;
 }
 
 interface Props {
@@ -49,6 +49,7 @@ const ImportZipModal = ({ open, onClose, onImport }: Props) => {
   const defaultValues: FormValues = {
     locale,
     file: undefined,
+    preview: false,
   };
 
   const schema = object({
@@ -103,6 +104,10 @@ const ImportZipModal = ({ open, onClose, onImport }: Props) => {
 
             <Box>
               <SingleFileUploader name="file" accept=".zip" />
+            </Box>
+
+            <Box mt="24px">
+              <CheckboxWithLabel name="preview" label="Preview the import?" />
             </Box>
 
             <Box w="100%" display="flex" mt="32px">

--- a/front/app/containers/Admin/ProjectImporter/index.tsx
+++ b/front/app/containers/Admin/ProjectImporter/index.tsx
@@ -6,6 +6,7 @@ import { useSearchParams } from 'react-router-dom';
 import useAuthUser from 'api/me/useAuthUser';
 import useProjectImports from 'api/project_imports/useProjectImports';
 
+import useFeatureFlag from 'hooks/useFeatureFlag';
 import useLocalize from 'hooks/useLocalize';
 
 import clHistory from 'utils/cl-router/history';
@@ -13,7 +14,6 @@ import Link from 'utils/cl-router/Link';
 import { isSuperAdmin } from 'utils/permissions/roles';
 
 import ImportZipModal from './ImportZipModal';
-import useFeatureFlag from 'hooks/useFeatureFlag';
 
 const ProjectImporter = () => {
   const { data: authUser } = useAuthUser();
@@ -45,7 +45,7 @@ const ProjectImporter = () => {
     } else {
       setIsImporting(false);
     }
-  }, [projectImports, numProjects]);
+  }, [projectImports, numProjects, isPreview]);
 
   const setImportData = (data) => {
     clHistory.push(
@@ -54,8 +54,9 @@ const ProjectImporter = () => {
   };
 
   // This feature is only for super admins when the feature flag is enabled
-  if (!(isFeatureEnabled && isSuperAdmin(authUser)))
+  if (!(isFeatureEnabled && isSuperAdmin(authUser))) {
     return <h1>Not allowed</h1>;
+  }
 
   return (
     <Box>

--- a/front/app/containers/Admin/ProjectImporter/index.tsx
+++ b/front/app/containers/Admin/ProjectImporter/index.tsx
@@ -90,9 +90,7 @@ const ProjectImporter = () => {
       {projectImports?.data?.map((importedProject) => {
         const projectTitle =
           localize(importedProject.attributes.project_title_multiloc) ||
-          isPreview
-            ? 'IMPORT PREVIEW'
-            : 'DELETED PROJECT';
+          (isPreview ? 'IMPORT PREVIEW' : 'DELETED PROJECT');
         const projectPath = importedProject.attributes.project_id
           ? (`/admin/projects/${importedProject.attributes.project_id}` as any) // TODO: Sort out types
           : undefined;
@@ -101,9 +99,9 @@ const ProjectImporter = () => {
             <h3>
               {projectPath ? (
                 <Link to={projectPath} target="_blank">
-                  {projectTitle} -
+                  {projectTitle}
                   <Text display="inline" fontSize="xs">
-                    {importedProject.attributes.created_at}
+                    - {importedProject.attributes.created_at}
                   </Text>
                 </Link>
               ) : (

--- a/front/app/containers/Admin/ProjectImporter/index.tsx
+++ b/front/app/containers/Admin/ProjectImporter/index.tsx
@@ -25,6 +25,7 @@ const ProjectImporter = () => {
   const [searchParams] = useSearchParams();
   const importId = searchParams.get('id') || undefined;
   const numProjects = searchParams.get('num_projects') || undefined;
+  const isPreview = searchParams.get('preview') === 'true';
 
   const [importZipModalOpen, setImportZipModalOpen] = useState(false);
   const openImportZipModal = () => setImportZipModalOpen(true);
@@ -38,10 +39,8 @@ const ProjectImporter = () => {
   const localize = useLocalize();
 
   useEffect(() => {
-    if (
-      numProjects &&
-      projectImports?.data?.length < parseInt(numProjects, 10)
-    ) {
+    const numImportJobs = isPreview ? 1 : parseInt(numProjects || '0', 10);
+    if (projectImports?.data?.length < numImportJobs) {
       setIsImporting(true);
     } else {
       setIsImporting(false);
@@ -50,7 +49,7 @@ const ProjectImporter = () => {
 
   const setImportData = (data) => {
     clHistory.push(
-      `/admin/project-importer?id=${data.id}&num_projects=${data.attributes.projects_to_import}` as any
+      `/admin/project-importer?id=${data.id}&num_projects=${data.attributes.projects_to_import}&preview=${data.attributes.preview}` as any
     ); // TODO: Sort out types
   };
 
@@ -77,16 +76,22 @@ const ProjectImporter = () => {
 
       {isImporting ? (
         <p>
-          Importing: {projectImports?.data?.length + 1} / {numProjects}
+          {isPreview ? 'Previewing' : 'Importing'}:{' '}
+          {projectImports?.data?.length + 1} / {numProjects}
         </p>
       ) : (
-        <p>Imported: {projectImports?.data?.length} projects</p>
+        <p>
+          {isPreview ? 'Previewed' : 'Imported'}: {projectImports?.data?.length}{' '}
+          projects
+        </p>
       )}
 
       {projectImports?.data?.map((importedProject) => {
         const projectTitle =
           localize(importedProject.attributes.project_title_multiloc) ||
-          'DELETED PROJECT';
+          isPreview
+            ? 'IMPORT PREVIEW'
+            : 'DELETED PROJECT';
         const projectPath = importedProject.attributes.project_id
           ? (`/admin/projects/${importedProject.attributes.project_id}` as any) // TODO: Sort out types
           : undefined;


### PR DESCRIPTION
New checkbox to merely preview and not actually import:
<img width="758" height="449" alt="image" src="https://github.com/user-attachments/assets/7e1d3763-5c47-40b1-8b61-b4c06a29f31e" />
<img width="945" height="650" alt="image" src="https://github.com/user-attachments/assets/231e651e-0496-4cbc-9f48-dbac14887905" />

# Changelog
## Added
- Added preview of project import in super user project importer
