### PR TITLE
[TAN-4896] Remove underline from Clave Unica button text

### DIFF
--- a/front/app/components/UI/ClaveUnicaButton/ClaveUnicaButton.tsx
+++ b/front/app/components/UI/ClaveUnicaButton/ClaveUnicaButton.tsx
@@ -39,7 +39,6 @@ const ButtonWrapper = styled(ClaveUnicaButtonContainer)`
 
 const ClaveUnicaButtonLabel = styled.span`
   padding-left: 3px;
-  text-decoration: underline;
   box-sizing: border-box;
 `;
 


### PR DESCRIPTION
Apparently, underlined button text does not comply with their [current style guide](https://drive.google.com/file/d/1XvPV-jfJKLg-1Gx1Qo26oAvkQ_tSmtZj/view).

Before:
<img width="538" height="85" alt="Screenshot 2025-08-11 at 14 43 59" src="https://github.com/user-attachments/assets/b5a961bb-4536-4359-a9ff-4c1d2fed6363" />

After:
<img width="538" height="85" alt="Screenshot 2025-08-11 at 14 44 14" src="https://github.com/user-attachments/assets/68894329-fb7f-41b4-a9ae-201ff429d10d" />

# Changelog
## Technical
- [TAN-4896] Remove underline from Clave Unica button text
