### PR TITLE
[TAN-4143] Fix representativeness participant data to not include users with only draft surveys

### DIFF
--- a/back/app/services/participants_service.rb
+++ b/back/app/services/participants_service.rb
@@ -119,14 +119,10 @@ class ParticipantsService
   end
 
   def projects_participants(projects, options = {})
-    puts "options_found: #{options.inspect}"
     since = options[:since]
     actions = options[:actions] || PROJECT_PARTICIPANT_ACTIONS
     ideas = Idea.where(project: projects).where(publication_status: 'published')
     participants = ideas_participants(ideas, options)
-
-    puts "projects_participants_ideas: #{ideas.inspect}"
-    puts "projects_participants_participants: #{participants.inspect}"
 
     # Voting
     if actions.include? :voting

--- a/back/app/services/participants_service.rb
+++ b/back/app/services/participants_service.rb
@@ -119,10 +119,14 @@ class ParticipantsService
   end
 
   def projects_participants(projects, options = {})
+    puts "options_found: #{options.inspect}"
     since = options[:since]
     actions = options[:actions] || PROJECT_PARTICIPANT_ACTIONS
-    ideas = Idea.where(project: projects)
+    ideas = Idea.where(project: projects).where(publication_status: 'published')
     participants = ideas_participants(ideas, options)
+
+    puts "projects_participants_ideas: #{ideas.inspect}"
+    puts "projects_participants_participants: #{participants.inspect}"
 
     # Voting
     if actions.include? :voting

--- a/back/spec/services/participants_service_spec.rb
+++ b/back/spec/services/participants_service_spec.rb
@@ -367,6 +367,15 @@ describe ParticipantsService do
 
       expect(service.projects_participants([project]).map(&:id)).to match_array [author.id]
     end
+
+    # Regression test: mainly to avoid counting unsubmitted survey responses as project participation
+    it 'does not return users who have only an un-published idea in the project' do
+      project = create(:project)
+      author = create(:user)
+      create(:idea, project: project, author: author, publication_status: 'draft')
+
+      expect(service.projects_participants([project]).map(&:id)).to be_empty
+    end
   end
 
   describe 'topics_participants' do


### PR DESCRIPTION
# Changelog
## Fixed
- [TAN-4143]-Fix representativeness participant data to not include users with only draft surveys. Also, similarly fixes the data in the project participant timeline. We are aware of other similar issues with participant data.
