### PR TITLE
[TAN-5321] Pin postgis-pgvector in e2e docker-compose file

### DIFF
--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   postgres:
     container_name: e2e-postgres
-    image: "citizenlabdotco/postgis-pgvector:latest"
+    image: "citizenlabdotco/postgis-pgvector:16-3.5"
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
# Changelog
## Technical
- [TAN-5321] Pin postgis-pgvector in e2e docker-compose file - fix for failing e2e-db-setup CI step
