### PR TITLE
[OLD] - [TAN-5322]  File widget + link to files tab in sense-making

### DIFF
--- a/front/app/api/file_attachments/types.ts
+++ b/front/app/api/file_attachments/types.ts
@@ -1,6 +1,6 @@
 import { IRelationship } from 'typings';
 
-type AttachableType = 'Phase' | 'Project' | 'Event';
+type AttachableType = 'Phase' | 'Project' | 'Event' | 'Layout';
 
 export type QueryParameters = {
   attachable_type?: AttachableType;

--- a/front/app/api/file_attachments/useDeleteFileAttachment.ts
+++ b/front/app/api/file_attachments/useDeleteFileAttachment.ts
@@ -1,0 +1,26 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import fetcher from 'utils/cl-react-query/fetcher';
+
+import fileAttachmentsKeys from './keys';
+
+const deleteFileAttachment = (id: string) =>
+  fetcher({
+    path: `/file_attachments/${id}`,
+    action: 'delete',
+  });
+
+const useDeleteFileAttachment = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: deleteFileAttachment,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: fileAttachmentsKeys.lists(),
+      });
+    },
+  });
+};
+
+export default useDeleteFileAttachment;

--- a/front/app/containers/Admin/projects/project/analysis/Insights/Files/FileSelectionView/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Insights/Files/FileSelectionView/index.tsx
@@ -10,6 +10,7 @@ import useUpdateAnalysis from 'api/analyses/useUpdateAnalysis';
 import useFiles from 'api/files/useFiles';
 
 import MultipleSelect from 'components/HookForm/MultipleSelect';
+import ButtonWithLink from 'components/UI/ButtonWithLink';
 import GoBackButton from 'components/UI/GoBackButton';
 
 import { useIntl } from 'utils/cl-intl';
@@ -107,6 +108,17 @@ const FileSelectionView = ({ setIsFileSelectionOpen, analysisId }: Props) => {
             options={fileOptions}
             placeholder={formatMessage(messages.attachFilesFromProject)}
           />
+
+          <Box mt="24px">
+            <ButtonWithLink
+              linkTo={`/admin/projects/${projectId}/files`}
+              buttonStyle="text"
+              icon="upload-file"
+              openLinkInNewTab={true}
+            >
+              {formatMessage(messages.uploadFiles)}
+            </ButtonWithLink>
+          </Box>
         </Box>
       </form>
     </FormProvider>

--- a/front/app/containers/Admin/projects/project/analysis/Insights/Files/messages.ts
+++ b/front/app/containers/Admin/projects/project/analysis/Insights/Files/messages.ts
@@ -26,4 +26,8 @@ export default defineMessages({
     id: 'app.containers.AdminPage.projects.project.analysis.files.save',
     defaultMessage: 'Save',
   },
+  uploadFiles: {
+    id: 'app.containers.AdminPage.projects.project.analysis.files.uploadFiles',
+    defaultMessage: 'Upload files to project',
+  },
 });

--- a/front/app/translations/admin/en.json
+++ b/front/app/translations/admin/en.json
@@ -2884,6 +2884,7 @@
   "app.containers.AdminPage.projects.project.analysis.files.attachFilesTooltip": "Attach files to provide additional context to the AI to support analysis.",
   "app.containers.AdminPage.projects.project.analysis.files.attachFilesWithCurrentCount": "Attach files ({numberAttachedFiles})",
   "app.containers.AdminPage.projects.project.analysis.files.save": "Save",
+  "app.containers.AdminPage.projects.project.analysis.files.uploadFiles": "Upload files to project",
   "app.containers.AdminPage.projects.project.analysis.filter": "Only show inputs with this value",
   "app.containers.AdminPage.projects.project.analysis.filterEmptyCustomFields": "Hide responses with no answer",
   "app.containers.AdminPage.projects.project.analysis.heatmap.autoInsights": "Auto-insights",


### PR DESCRIPTION
Covered 2 things in this PR:

1. In the File Attachment Widget, I used a file attachment with a "Layout" resource as you recommended. I couldn't test it though, since this "Layout" resource isn't supported in the BE.

2. A small tweak in sense-making - just added a button link to the Files Tab so admins can easily upload files.

For #1 though - I delete existing file attachments whenever the selected file changes, but if the widget is deleted altogether, there is currently no cleanup function to remove the "orphaned" file attachment. It would have introduced really awkward code in the FE, so I hope this is acceptable for now.
