### PR TITLE
TAN-5303 Survey results broken

### DIFF
--- a/back/app/services/surveys/results_generator.rb
+++ b/back/app/services/surveys/results_generator.rb
@@ -189,8 +189,10 @@ module Surveys
       elsif field.supports_multiple_selection?
         %{
           jsonb_array_elements(
-            CASE WHEN jsonb_path_exists(#{table}.custom_field_values, '$ ? (exists (@."#{field.key}"))')
-              THEN #{table}.custom_field_values->'#{field.key}'
+            CASE WHEN (
+              jsonb_path_exists(#{table}.custom_field_values, '$ ? (exists (@."#{field.key}"))') AND
+              jsonb_typeof(#{table}.custom_field_values->'#{field.key}') = 'array'
+            ) THEN #{table}.custom_field_values->'#{field.key}'
               ELSE '[null]'::jsonb END
           ) as #{as}
       }

--- a/back/spec/services/surveys/results_generator_spec.rb
+++ b/back/spec/services/surveys/results_generator_spec.rb
@@ -22,6 +22,31 @@ RSpec.describe Surveys::ResultsGenerator do
       generator = described_class.new(survey_phase)
       expect { generator.generate_result_for_field('missing_field') }.to raise_error('Question not found')
     end
+
+    it 'works if multiselect question has single select answer' do
+      create(
+        :native_survey_response,
+        project: project,
+        phases: phases_of_inputs,
+        custom_field_values: {
+          text_field.key => 'Green',
+          multiselect_field.key => 'some_single_select_value',
+          select_field.key => 'other',
+          "#{select_field.key}_other" => 'Austin',
+          multiselect_image_field.key => ['house'],
+          matrix_linear_scale_field.key => {
+            'ride_bicycles_more_often' => 3
+          },
+          sentiment_linear_scale_field.key => 5,
+          "#{sentiment_linear_scale_field.key}_follow_up" => 'Great thanks very much'
+        },
+        author: create(:user, custom_field_values: { gender: 'female', domicile: domicile_user_custom_field.options[1].area.id }),
+        created_at: '2025-04-05'
+      )
+
+      generator = described_class.new(survey_phase)
+      expect { generator.generate_result_for_field(multiselect_field.id) }.not_to raise_error
+    end
   end
 
   describe 'generate_results' do


### PR DESCRIPTION
# Changelog
## Fixed
- Survey results crashing because tenants keep editing live surveys