### PR TITLE
TAN-5329 Only include draft projects pending approval

### DIFF
--- a/back/app/services/projects_finder_admin_service.rb
+++ b/back/app/services/projects_finder_admin_service.rb
@@ -148,7 +148,10 @@ class ProjectsFinderAdminService
 
     case review_state
     when 'pending'
-      scope.where(project_reviews: { approved_at: nil })
+      filter_status(
+        scope.where(project_reviews: { approved_at: nil }),
+        { status: ['draft'] }
+      )
     when 'approved'
       scope.where.not(project_reviews: { approved_at: nil })
     else

--- a/front/app/containers/Admin/projects/all/_shared/FilterBar/Filters/PendingApproval.tsx
+++ b/front/app/containers/Admin/projects/all/_shared/FilterBar/Filters/PendingApproval.tsx
@@ -31,11 +31,7 @@ const PendingApproval = () => {
   const { formatMessage } = useIntl();
 
   const pendingReviewParams = {
-    publicationStatusFilter: [
-      'draft' as const,
-      'published' as const,
-      'archived' as const,
-    ],
+    publicationStatusFilter: ['draft' as const],
     review_state: 'pending' as const,
     onlyProjects: true,
     rootLevelOnly: false,
@@ -45,9 +41,7 @@ const PendingApproval = () => {
     useAdminPublicationsStatusCounts(pendingReviewParams);
 
   const totalPendingCount =
-    (pendingReviewStatusCounts?.data.attributes.status_counts.draft ?? 0) +
-    (pendingReviewStatusCounts?.data.attributes.status_counts.published ?? 0) +
-    (pendingReviewStatusCounts?.data.attributes.status_counts.archived ?? 0);
+    pendingReviewStatusCounts?.data.attributes.status_counts.draft ?? 0;
 
   return (
     <StyledInputContainer


### PR DESCRIPTION
# Changelog
## Fixed
- Projects list: projects pending approval included published and archived projects. People found this counterintuitive, so now the list only includes draft projects pending approval.