### PR TITLE
TAN-5326 Fix for tooltip of substitution variables

### DIFF
--- a/front/app/api/campaigns/types.ts
+++ b/front/app/api/campaigns/types.ts
@@ -27,7 +27,7 @@ export interface ICampaignData {
     sender: 'author' | 'organization';
     reply_to: 'author' | 'organization';
     editable_regions?: EditableRegion[];
-    editable_region_variable_keys?: string[];
+    substitution_variable_keys?: string[];
     created_at: string;
     updated_at: string;
     deliveries_count: number;

--- a/front/app/containers/Admin/messaging/AutomatedEmails/CampaignForm/index.tsx
+++ b/front/app/containers/Admin/messaging/AutomatedEmails/CampaignForm/index.tsx
@@ -47,7 +47,7 @@ const EditCampaignForm = ({
   // Schema and default values are derived from which editable regions are present
   const editableRegions = campaign.data.attributes.editable_regions || [];
   const editableRegionVariableKeys =
-    campaign.data.attributes.editable_region_variable_keys || [];
+    campaign.data.attributes.substitution_variable_keys || [];
 
   const schema = object({
     ...editableRegions.reduce((fieldSchema, region) => {


### PR DESCRIPTION
Not clear what happened exactly, I suspect `editable_region_variable_keys` was renamed to `substitution_variable_keys` in the backend at some point.

<img width="980" height="869" alt="Screenshot 2025-08-20 at 10 09 58" src="https://github.com/user-attachments/assets/480c6a2d-9000-463d-9219-b50acab1bda4" />
