### PR TITLE
[TAN-5321] Patch ros-apartment gem PSQL_DUMP_BLACKLISTED_STATEMENTS

### DIFF
--- a/back/config/initializers/ros_apartment_patch.rb
+++ b/back/config/initializers/ros_apartment_patch.rb
@@ -1,0 +1,26 @@
+require 'apartment/adapters/postgresql_adapter'
+
+# This patch is necessary to ensure that the `PSQL_DUMP_BLACKLISTED_STATEMENTS`
+# includes \unrestrict and \restrict
+
+module Apartment
+  module Adapters
+    class PostgresqlSchemaFromSqlAdapter
+      # Use class_eval to redefine the constant within the class.
+      class_eval do
+        remove_const(:PSQL_DUMP_BLACKLISTED_STATEMENTS)
+        const_set(:PSQL_DUMP_BLACKLISTED_STATEMENTS, [
+          /SET search_path/i,
+          /SET lock_timeout/i,
+          /SET row_security/i,
+          /SET idle_in_transaction_session_timeout/i,
+          /SET default_table_access_method/i,
+          /CREATE SCHEMA public/i,
+          /COMMENT ON SCHEMA public/i,
+          /\\unrestrict/i,
+          /\\restrict/i
+        ].freeze)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Patching the`PSQL_DUMP_BLACKLISTED_STATEMENTS` constant in:

```Ruby
root@e9d50ab94900:/bundle/ruby/3.3.0/gems/ros-apartment-3.1.0/lib/apartment/adapters# cat postgresql_adapter.rb
# frozen_string_literal: true

require 'apartment/adapters/abstract_adapter'
require 'apartment/active_record/postgresql_adapter'

module Apartment

  ...

  module Adapters

    ...

    # Another Adapter for Postgresql when using schemas and SQL
    class PostgresqlSchemaFromSqlAdapter < PostgresqlSchemaAdapter
      PSQL_DUMP_BLACKLISTED_STATEMENTS = [
        /SET search_path/i,                           # overridden later
        /SET lock_timeout/i,                          # new in postgresql 9.3
        /SET row_security/i,                          # new in postgresql 9.5
        /SET idle_in_transaction_session_timeout/i,   # new in postgresql 9.6
        /SET default_table_access_method/i,           # new in postgresql 12
        /CREATE SCHEMA public/i,
        /COMMENT ON SCHEMA public/i

      ].freeze

      def import_database_schema
        preserving_search_path do
          clone_pg_schema
          copy_schema_migrations
        end
      end

      private

      ...

      #   Remove "SET search_path ..." line from SQL dump and prepend search_path set to current tenant
      #
      #   @return {String} patched raw SQL dump
      #
      def patch_search_path(sql)
        search_path = "SET search_path = \"#{current}\", #{default_tenant};"

        swap_schema_qualifier(sql)
          .split("\n")
          .select { |line| check_input_against_regexps(line, PSQL_DUMP_BLACKLISTED_STATEMENTS).empty? }
          .prepend(search_path)
          .join("\n")
      end

      ...

    end
  end
end
```


# Changelog
## Technical
- [TAN-5321] Patch ros-apartment gem PSQL_DUMP_BLACKLISTED_STATEMENTS. Should fix invalid SQL when resetting db (seen in e2e-db-setup on CI, and any db reset after a pull of new postgis-pgvector image)