### PR TITLE
[TAN-3503] Fix links in tooltips

### DIFF
--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/HomepageBanner/LayoutSettingField/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/HomepageBanner/LayoutSettingField/index.tsx
@@ -45,10 +45,6 @@ export interface Props {
 
 const LayoutSettingField = ({ bannerLayout, onChange }: Props) => {
   const { formatMessage } = useIntl();
-  console.log(
-    'imageSupportPageURL value:',
-    formatMessage(messages.imageSupportPageURL)
-  );
   const customHomepageBannerAllowed = useFeatureFlag({
     name: 'customisable_homepage_banner',
     onlyCheckAllowed: true,

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/HomepageBanner/LayoutSettingField/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/HomepageBanner/LayoutSettingField/index.tsx
@@ -45,6 +45,10 @@ export interface Props {
 
 const LayoutSettingField = ({ bannerLayout, onChange }: Props) => {
   const { formatMessage } = useIntl();
+  console.log(
+    'imageSupportPageURL value:',
+    formatMessage(messages.imageSupportPageURL)
+  );
   const customHomepageBannerAllowed = useFeatureFlag({
     name: 'customisable_homepage_banner',
     onlyCheckAllowed: true,
@@ -79,6 +83,7 @@ const LayoutSettingField = ({ bannerLayout, onChange }: Props) => {
                               href={formatMessage(messages.imageSupportPageURL)}
                               target="_blank"
                               rel="noreferrer"
+                              onClick={(e) => e.stopPropagation()}
                             >
                               <FormattedMessage
                                 {...messages.fullWidthBannerTooltipLink}
@@ -149,6 +154,7 @@ const LayoutSettingField = ({ bannerLayout, onChange }: Props) => {
                               href={formatMessage(messages.imageSupportPageURL)}
                               target="_blank"
                               rel="noreferrer"
+                              onClick={(e) => e.stopPropagation()}
                             >
                               <FormattedMessage
                                 {...messages.twoRowBannerTooltipLink}
@@ -194,6 +200,7 @@ const LayoutSettingField = ({ bannerLayout, onChange }: Props) => {
                               href={formatMessage(messages.imageSupportPageURL)}
                               target="_blank"
                               rel="noreferrer"
+                              onClick={(e) => e.stopPropagation()}
                             >
                               <FormattedMessage
                                 {...messages.fixedRatioBannerTooltipLink}

--- a/front/app/containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/LayoutSettingField/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/LayoutSettingField/index.tsx
@@ -70,6 +70,7 @@ const LayoutSettingField = ({ bannerLayout, onChange }: Props) => {
                 <Box display="flex" gap="8px">
                   {formatMessage(messages.fullWidthBannerLayout)}
                   <IconTooltip
+                    placement="bottom-start"
                     content={
                       <FormattedMessage
                         {...messages.fullWidthBannerTooltip}
@@ -79,6 +80,7 @@ const LayoutSettingField = ({ bannerLayout, onChange }: Props) => {
                               href={formatMessage(messages.imageSupportPageURL)}
                               target="_blank"
                               rel="noreferrer"
+                              onClick={(e) => e.stopPropagation()}
                             >
                               <FormattedMessage
                                 {...messages.fullWidthBannerTooltipLink}
@@ -137,6 +139,7 @@ const LayoutSettingField = ({ bannerLayout, onChange }: Props) => {
                 <Box display="flex" gap="8px">
                   {formatMessage(messages.twoRowLayout)}
                   <IconTooltip
+                    placement="bottom-start"
                     content={
                       <FormattedMessage
                         {...messages.twoRowBannerTooltip}
@@ -146,6 +149,7 @@ const LayoutSettingField = ({ bannerLayout, onChange }: Props) => {
                               href={formatMessage(messages.imageSupportPageURL)}
                               target="_blank"
                               rel="noreferrer"
+                              onClick={(e) => e.stopPropagation()}
                             >
                               <FormattedMessage
                                 {...messages.twoRowBannerTooltipLink}
@@ -180,6 +184,7 @@ const LayoutSettingField = ({ bannerLayout, onChange }: Props) => {
                 <Box display="flex" gap="8px">
                   {formatMessage(messages.fixedRatioLayout)}
                   <IconTooltip
+                    placement="bottom-start"
                     content={
                       <FormattedMessage
                         {...messages.fixedRatioBannerTooltip}
@@ -189,6 +194,7 @@ const LayoutSettingField = ({ bannerLayout, onChange }: Props) => {
                               href={formatMessage(messages.imageSupportPageURL)}
                               target="_blank"
                               rel="noreferrer"
+                              onClick={(e) => e.stopPropagation()}
                             >
                               <FormattedMessage
                                 {...messages.fixedRatioBannerTooltipLink}


### PR DESCRIPTION
Behaviour, at least locally, is somewhat weirdly varied.

On generic banner layout page:
- the 'Banner image' tooltip link already worked, but tooltip does not close automatically after link clicked.
- the 3 banner type tooltip links did not work, but now do, _and_ tooltips close automatically after link clicked.

On homepage widget banner tooltips:
- the 3 banner type tooltip links did not work, but now do, and tooltips DO NOT close automatically after link clicked.

Not closing automatically, after link is clicked, is what we would expect after adding `stopPropagation`, so I have no idea why the automatic closing still works for the 3 banner type tooltips on the generic banner settings.

In any case, Rob is cool with the tooltips staying open after clicking link (just need to click elsewhere on page to close, in this case), so I don' think it's worth the time trying to 'fix' the automatic tooltip closing in these cases.

# Changelog
## Fixed
- [TAN-3503] Fix links in tooltips. Links to knowledge base in tooltips now open page when clicked.
