### PR TITLE
[TAN-5277] Add `migrated_file_id` to mark legacy files that have been…

### DIFF
--- a/back/app/controllers/web_api/v1/ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/ideas_controller.rb
@@ -66,7 +66,7 @@ class WebApi::V1::IdeasController < ApplicationController
       current_user: current_user
     ).find_records
     ideas = paginate SortByParamsService.new.sort_ideas(ideas, params, current_user)
-    ideas = ideas.includes(:author, :topics, :project, :idea_status, :idea_files)
+    ideas = ideas.includes(:author, :topics, :project, :idea_status)
 
     render json: linked_json(ideas, WebApi::V1::PostMarkerSerializer, params: jsonapi_serializer_params)
   end
@@ -78,7 +78,7 @@ class WebApi::V1::IdeasController < ApplicationController
       current_user: current_user
     ).find_records
     ideas = SortByParamsService.new.sort_ideas(ideas, params, current_user)
-    ideas = ideas.includes(:author, :topics, :project, :idea_status, :idea_files)
+    ideas = ideas.includes(:author, :topics, :project, :idea_status, :idea_files, :attached_files)
 
     with_cosponsors = AppConfiguration.instance.feature_activated?('input_cosponsorship')
     ideas = ideas.includes(:cosponsors) if with_cosponsors

--- a/back/app/controllers/web_api/v1/ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/ideas_controller.rb
@@ -167,7 +167,14 @@ class WebApi::V1::IdeasController < ApplicationController
     form = phase_for_input.pmethod.custom_form
     extract_custom_field_values_from_params!(form)
     params_for_create = idea_params form
+    files_params = extract_file_params(params_for_create)
+
     input = Idea.new params_for_create
+
+    files_params.each do |file_params|
+      build_idea_file_attachment(input, file_params)
+    end
+
     input.creation_phase = (phase_for_input if !phase_for_input.pmethod.transitive?)
     input.phase_ids = [phase_for_input.id] if params.dig(:idea, :phase_ids).blank?
 
@@ -229,6 +236,15 @@ class WebApi::V1::IdeasController < ApplicationController
     params_service.mark_custom_field_values_to_clear!(input.custom_field_values, params[:idea][:custom_field_values])
 
     update_params = idea_params(input.custom_form).to_h
+
+    legacy_files = FileUpload.where(idea: input)
+
+    unless legacy_files.exists?
+      extract_file_params(update_params).each do |file_params|
+        build_idea_file_attachment(input, file_params)
+      end
+    end
+
     phase_ids = update_params.delete(:phase_ids) if update_params[:phase_ids]
     update_params[:custom_field_values] = params_service.updated_custom_field_values(input.custom_field_values, update_params[:custom_field_values])
     CustomFieldService.new.compact_custom_field_values! update_params[:custom_field_values]
@@ -376,26 +392,53 @@ class WebApi::V1::IdeasController < ApplicationController
   def update_file_upload_fields(input, custom_form, params)
     file_uploads_exist = false
     params_for_file_upload_fields = extract_params_for_file_upload_fields custom_form, params
+
+    legacy_files = FileUpload.where(idea: input)
+
     params_for_file_upload_fields.each do |key, params_for_files_field|
-      if params_for_files_field['id']
-        idea_file = FileUpload.find(params_for_files_field['id'])
-        if idea_file
-          input.custom_field_values[key] = { id: idea_file.id, name: idea_file.name }
-          file_uploads_exist = true
-        end
+      if (file_id = params_for_files_field['id'])
+        idea_file = Files::FileAttachment.find_by(id: file_id) || FileUpload.find(file_id)
+        filename = idea_file.is_a?(FileUpload) ? idea_file.name : idea_file.file.name
+        input.custom_field_values[key] = { id: idea_file.id, name: filename }
+        file_uploads_exist = true
+
       elsif params_for_files_field['content']
-        idea_file = FileUpload.create!(
-          idea: input,
-          file_by_content: {
+        idea_file = if legacy_files.exists?
+          FileUpload.create!(idea: input, file_by_content: {
             name: params_for_files_field['name'],
             content: params_for_files_field['content']
-          }
-        )
-        input.custom_field_values[key] = { id: idea_file.id, name: idea_file.name }
+          })
+        else
+          build_idea_file_attachment(input, params_for_files_field).tap(&:save!)
+        end
+
+        filename = idea_file.is_a?(FileUpload) ? idea_file.name : idea_file.file.name
+        input.custom_field_values[key] = { id: idea_file.id, name: filename }
         file_uploads_exist = true
       end
     end
+
     input.save! if file_uploads_exist
+  end
+
+  def extract_file_params(idea_params)
+    idea_params
+      .delete(:idea_files_attributes).to_a
+      .map { |file_params| file_params.fetch(:file_by_content) }
+  end
+
+  def build_idea_file_attachment(idea, file_params)
+    files_file = Files::File.new(
+      content_by_content: {
+        content: file_params['content'],
+        name: file_params['name']
+      },
+      uploader: current_user
+    )
+
+    project = idea.project
+    files_file.files_projects.build(project: project)
+    idea.file_attachments.build(file: files_file)
   end
 
   def sidefx

--- a/back/app/models/concerns/file_migratable.rb
+++ b/back/app/models/concerns/file_migratable.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Temporary concern to help with migrating legacy files. This concern removes from the
+# default scope any legacy files that have already been migrated to the new Files::File
+# model. This allows for a non-destructive migration of legacy files to the new model and
+# makes it possible to revert the migration if needed.
+module FileMigratable
+  extend ActiveSupport::Concern
+
+  included do
+    default_scope { where(migrated_file_id: nil) }
+
+    belongs_to :migrated_file, class_name: 'Files::File', optional: true
+  end
+
+  # @return [Boolean] true if the file has been migrated
+  def migrated?
+    migrated_file_id.present?
+  end
+end

--- a/back/app/models/concerns/file_migratable.rb
+++ b/back/app/models/concerns/file_migratable.rb
@@ -8,7 +8,10 @@ module FileMigratable
   extend ActiveSupport::Concern
 
   included do
-    default_scope { where(migrated_file_id: nil) }
+    default_scope { where(migrated_file_id: nil, migration_skipped_reason: nil) }
+
+    scope :migrated, -> { unscope(:where).where.not(migrated_file_id: nil) }
+    scope :migration_skipped, -> { unscope(:where).where.not(migration_skipped_reason: nil) }
 
     belongs_to :migrated_file, class_name: 'Files::File', optional: true
   end
@@ -16,5 +19,9 @@ module FileMigratable
   # @return [Boolean] true if the file has been migrated
   def migrated?
     migrated_file_id.present?
+  end
+
+  def migration_skipped?
+    migration_skipped_reason.present?
   end
 end

--- a/back/app/models/event_file.rb
+++ b/back/app/models/event_file.rb
@@ -12,6 +12,7 @@
 #  updated_at                                                                             :datetime         not null
 #  name                                                                                   :string
 #  migrated_file_id(References the Files::File record after migration to new file system) :uuid
+#  migration_skipped_reason                                                               :string
 #
 # Indexes
 #

--- a/back/app/models/event_file.rb
+++ b/back/app/models/event_file.rb
@@ -4,23 +4,28 @@
 #
 # Table name: event_files
 #
-#  id         :uuid             not null, primary key
-#  event_id   :uuid
-#  file       :string
-#  ordering   :integer
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  name       :string
+#  id                                                                                     :uuid             not null, primary key
+#  event_id                                                                               :uuid
+#  file                                                                                   :string
+#  ordering                                                                               :integer
+#  created_at                                                                             :datetime         not null
+#  updated_at                                                                             :datetime         not null
+#  name                                                                                   :string
+#  migrated_file_id(References the Files::File record after migration to new file system) :uuid
 #
 # Indexes
 #
-#  index_event_files_on_event_id  (event_id)
+#  index_event_files_on_event_id          (event_id)
+#  index_event_files_on_migrated_file_id  (migrated_file_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (event_id => events.id)
+#  fk_rails_...  (migrated_file_id => files.id)
 #
 class EventFile < ApplicationRecord
+  include FileMigratable
+
   mount_base64_file_uploader :file, EventFileUploader
   belongs_to :event
 

--- a/back/app/models/file_upload.rb
+++ b/back/app/models/file_upload.rb
@@ -4,21 +4,24 @@
 #
 # Table name: idea_files
 #
-#  id         :uuid             not null, primary key
-#  idea_id    :uuid
-#  file       :string
-#  ordering   :integer
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  name       :string
+#  id                                                                                     :uuid             not null, primary key
+#  idea_id                                                                                :uuid
+#  file                                                                                   :string
+#  ordering                                                                               :integer
+#  created_at                                                                             :datetime         not null
+#  updated_at                                                                             :datetime         not null
+#  name                                                                                   :string
+#  migrated_file_id(References the Files::File record after migration to new file system) :uuid
 #
 # Indexes
 #
-#  index_idea_files_on_idea_id  (idea_id)
+#  index_idea_files_on_idea_id           (idea_id)
+#  index_idea_files_on_migrated_file_id  (migrated_file_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (idea_id => ideas.id)
+#  fk_rails_...  (migrated_file_id => files.id)
 #
 class FileUpload < IdeaFile
   mount_base64_file_uploader :file, FileUploadUploader

--- a/back/app/models/file_upload.rb
+++ b/back/app/models/file_upload.rb
@@ -12,6 +12,7 @@
 #  updated_at                                                                             :datetime         not null
 #  name                                                                                   :string
 #  migrated_file_id(References the Files::File record after migration to new file system) :uuid
+#  migration_skipped_reason                                                               :string
 #
 # Indexes
 #

--- a/back/app/models/idea_file.rb
+++ b/back/app/models/idea_file.rb
@@ -4,23 +4,28 @@
 #
 # Table name: idea_files
 #
-#  id         :uuid             not null, primary key
-#  idea_id    :uuid
-#  file       :string
-#  ordering   :integer
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  name       :string
+#  id                                                                                     :uuid             not null, primary key
+#  idea_id                                                                                :uuid
+#  file                                                                                   :string
+#  ordering                                                                               :integer
+#  created_at                                                                             :datetime         not null
+#  updated_at                                                                             :datetime         not null
+#  name                                                                                   :string
+#  migrated_file_id(References the Files::File record after migration to new file system) :uuid
 #
 # Indexes
 #
-#  index_idea_files_on_idea_id  (idea_id)
+#  index_idea_files_on_idea_id           (idea_id)
+#  index_idea_files_on_migrated_file_id  (migrated_file_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (idea_id => ideas.id)
+#  fk_rails_...  (migrated_file_id => files.id)
 #
 class IdeaFile < ApplicationRecord
+  include FileMigratable
+
   mount_base64_file_uploader :file, IdeaFileUploader
   belongs_to :idea, inverse_of: :idea_files
 

--- a/back/app/models/idea_file.rb
+++ b/back/app/models/idea_file.rb
@@ -12,6 +12,7 @@
 #  updated_at                                                                             :datetime         not null
 #  name                                                                                   :string
 #  migrated_file_id(References the Files::File record after migration to new file system) :uuid
+#  migration_skipped_reason                                                               :string
 #
 # Indexes
 #

--- a/back/app/models/phase_file.rb
+++ b/back/app/models/phase_file.rb
@@ -12,6 +12,7 @@
 #  updated_at                                                                             :datetime         not null
 #  name                                                                                   :string
 #  migrated_file_id(References the Files::File record after migration to new file system) :uuid
+#  migration_skipped_reason                                                               :string
 #
 # Indexes
 #

--- a/back/app/models/phase_file.rb
+++ b/back/app/models/phase_file.rb
@@ -4,23 +4,28 @@
 #
 # Table name: phase_files
 #
-#  id         :uuid             not null, primary key
-#  phase_id   :uuid
-#  file       :string
-#  ordering   :integer
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  name       :string
+#  id                                                                                     :uuid             not null, primary key
+#  phase_id                                                                               :uuid
+#  file                                                                                   :string
+#  ordering                                                                               :integer
+#  created_at                                                                             :datetime         not null
+#  updated_at                                                                             :datetime         not null
+#  name                                                                                   :string
+#  migrated_file_id(References the Files::File record after migration to new file system) :uuid
 #
 # Indexes
 #
-#  index_phase_files_on_phase_id  (phase_id)
+#  index_phase_files_on_migrated_file_id  (migrated_file_id)
+#  index_phase_files_on_phase_id          (phase_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (migrated_file_id => files.id)
 #  fk_rails_...  (phase_id => phases.id)
 #
 class PhaseFile < ApplicationRecord
+  include FileMigratable
+
   mount_base64_file_uploader :file, PhaseFileUploader
   belongs_to :phase
 

--- a/back/app/models/project_file.rb
+++ b/back/app/models/project_file.rb
@@ -4,23 +4,28 @@
 #
 # Table name: project_files
 #
-#  id         :uuid             not null, primary key
-#  project_id :uuid
-#  file       :string
-#  ordering   :integer
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  name       :string
+#  id                                                                                     :uuid             not null, primary key
+#  project_id                                                                             :uuid
+#  file                                                                                   :string
+#  ordering                                                                               :integer
+#  created_at                                                                             :datetime         not null
+#  updated_at                                                                             :datetime         not null
+#  name                                                                                   :string
+#  migrated_file_id(References the Files::File record after migration to new file system) :uuid
 #
 # Indexes
 #
-#  index_project_files_on_project_id  (project_id)
+#  index_project_files_on_migrated_file_id  (migrated_file_id)
+#  index_project_files_on_project_id        (project_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (migrated_file_id => files.id)
 #  fk_rails_...  (project_id => projects.id)
 #
 class ProjectFile < ApplicationRecord
+  include FileMigratable
+
   attr_accessor :filename
 
   mount_base64_file_uploader :file, ProjectFileUploader

--- a/back/app/models/project_file.rb
+++ b/back/app/models/project_file.rb
@@ -12,6 +12,7 @@
 #  updated_at                                                                             :datetime         not null
 #  name                                                                                   :string
 #  migrated_file_id(References the Files::File record after migration to new file system) :uuid
+#  migration_skipped_reason                                                               :string
 #
 # Indexes
 #

--- a/back/app/models/project_folders/file.rb
+++ b/back/app/models/project_folders/file.rb
@@ -12,6 +12,7 @@
 #  created_at                                                                             :datetime         not null
 #  updated_at                                                                             :datetime         not null
 #  migrated_file_id(References the Files::File record after migration to new file system) :uuid
+#  migration_skipped_reason                                                               :string
 #
 # Indexes
 #

--- a/back/app/models/project_folders/file.rb
+++ b/back/app/models/project_folders/file.rb
@@ -4,24 +4,29 @@
 #
 # Table name: project_folders_files
 #
-#  id                :uuid             not null, primary key
-#  project_folder_id :uuid
-#  file              :string
-#  name              :string
-#  ordering          :integer
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
+#  id                                                                                     :uuid             not null, primary key
+#  project_folder_id                                                                      :uuid
+#  file                                                                                   :string
+#  name                                                                                   :string
+#  ordering                                                                               :integer
+#  created_at                                                                             :datetime         not null
+#  updated_at                                                                             :datetime         not null
+#  migrated_file_id(References the Files::File record after migration to new file system) :uuid
 #
 # Indexes
 #
+#  index_project_folders_files_on_migrated_file_id   (migrated_file_id)
 #  index_project_folders_files_on_project_folder_id  (project_folder_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (migrated_file_id => files.id)
 #  fk_rails_...  (project_folder_id => project_folders_folders.id)
 #
 module ProjectFolders
   class File < ::ApplicationRecord
+    include FileMigratable
+
     self.table_name = 'project_folders_files'
 
     attr_accessor :filename

--- a/back/app/models/static_page_file.rb
+++ b/back/app/models/static_page_file.rb
@@ -12,6 +12,7 @@
 #  created_at                                                                             :datetime         not null
 #  updated_at                                                                             :datetime         not null
 #  migrated_file_id(References the Files::File record after migration to new file system) :uuid
+#  migration_skipped_reason                                                               :string
 #
 # Indexes
 #

--- a/back/app/models/static_page_file.rb
+++ b/back/app/models/static_page_file.rb
@@ -4,23 +4,28 @@
 #
 # Table name: static_page_files
 #
-#  id             :uuid             not null, primary key
-#  static_page_id :uuid
-#  file           :string
-#  ordering       :integer
-#  name           :string
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
+#  id                                                                                     :uuid             not null, primary key
+#  static_page_id                                                                         :uuid
+#  file                                                                                   :string
+#  ordering                                                                               :integer
+#  name                                                                                   :string
+#  created_at                                                                             :datetime         not null
+#  updated_at                                                                             :datetime         not null
+#  migrated_file_id(References the Files::File record after migration to new file system) :uuid
 #
 # Indexes
 #
-#  index_static_page_files_on_static_page_id  (static_page_id)
+#  index_static_page_files_on_migrated_file_id  (migrated_file_id)
+#  index_static_page_files_on_static_page_id    (static_page_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (migrated_file_id => files.id)
 #  fk_rails_...  (static_page_id => static_pages.id)
 #
 class StaticPageFile < ApplicationRecord
+  include FileMigratable
+
   attr_accessor :filename
 
   mount_base64_file_uploader :file, StaticPageFileUploader

--- a/back/app/services/export/geojson/value_visitor.rb
+++ b/back/app/services/export/geojson/value_visitor.rb
@@ -43,13 +43,15 @@ module Export
       end
 
       def visit_file_upload(field)
-        file = value_for(field)
+        file_id = value_for(field)['id']
+        return nil if file_id.blank?
 
-        return nil if file.nil? || file['id'].blank?
-
-        file_id = file['id']
-        idea_file = model.idea_files.detect { |f| f.id == file_id }
-        idea_file.file.url
+        if (file = model.idea_files.find { |f| f.id == file_id })
+          file.file.url
+        else
+          file_attachment = model.file_attachments.find { |f| f.id == file_id }
+          file_attachment.file.content.url
+        end
       end
 
       def visit_shapefile_upload(field)

--- a/back/app/services/export/xlsx/inputs_generator.rb
+++ b/back/app/services/export/xlsx/inputs_generator.rb
@@ -43,7 +43,17 @@ module Export
       end
 
       def eager_load_inputs(inputs)
-        inputs.includes(:project, :author, :ideas_topics, :topics, :idea_files, :idea_status, :assignee).order(:created_at)
+        inputs.includes(
+          :project,
+          :author,
+          :ideas_topics,
+          :topics,
+          :idea_files,
+          :file_attachments,
+          :attached_files,
+          :idea_status,
+          :assignee
+        ).order(:created_at)
       end
 
       def generate_for_timeline_project(workbook, project)

--- a/back/app/services/export/xlsx/project_ideas_votes_generator.rb
+++ b/back/app/services/export/xlsx/project_ideas_votes_generator.rb
@@ -19,7 +19,7 @@ module Export
 
       def generate_phase_ideas_votes_sheet(workbook, sheet_name, phase)
         url_service = Frontend::UrlService.new
-        ideas = phase.ideas.includes(:author, :idea_status, :topics, :idea_files, :project, :ideas_phases, [baskets_ideas: :basket])
+        ideas = phase.ideas.includes(:author, :idea_status, :topics, :idea_files, :attached_files, :project, :ideas_phases, [baskets_ideas: :basket])
         t_scope = 'xlsx_export.column_headers'
 
         columns = [
@@ -32,9 +32,13 @@ module Export
           columns << send(:"#{column}_column", t_scope, phase)
         end
 
+        get_attachments_urls = lambda do |i|
+          i.attached_files.map { |f| f.content.url } + i.idea_files.map { |f| f.file.url }
+        end
+
         columns += [
           { header: I18n.t('input_url', scope: t_scope),       f: ->(i) { url_service.model_to_url(i) }, skip_sanitization: true },
-          { header: I18n.t('attachments', scope: t_scope),     f: ->(i) { i.idea_files.map { |f| f.file.url }.join("\n") }, skip_sanitization: true, width: 2 },
+          { header: I18n.t('attachments', scope: t_scope),     f: ->(i) { get_attachments_urls.call(i).join("\n") }, skip_sanitization: true, width: 2 },
           { header: I18n.t('tags', scope: t_scope),            f: ->(i) { i.topics.map { |t| multiloc_service.t(t.title_multiloc) }.join(',') }, skip_sanitization: true },
           { header: I18n.t('latitude', scope: t_scope),        f: ->(i) { i.location_point&.coordinates&.last }, skip_sanitization: true },
           { header: I18n.t('longitude', scope: t_scope),       f: ->(i) { i.location_point&.coordinates&.first }, skip_sanitization: true },

--- a/back/app/services/files/legacy_file_migration_service.rb
+++ b/back/app/services/files/legacy_file_migration_service.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+module Files
+  # Service to migrate legacy file records to the new Files::File system
+  #
+  # This service handles the migration of legacy file models (IdeaFile, ProjectFile,
+  # EventFile, PhaseFile, StaticPageFile, ProjectFolders::File) to the new unified
+  # Files::File and Files::FileAttachment system.
+  #
+  # Usage:
+  #   # Migrate all legacy files
+  #   Files::LegacyFileMigrationService.new.migrate_all
+  #
+  #   # Migrate files for a specific container
+  #   Files::LegacyFileMigrationService.new.migrate_container(project)
+  #
+  class LegacyFileMigrationService
+    LEGACY_FILE_ASSOCIATIONS = {
+      Idea => :idea_files,
+      Project => :project_files,
+      Event => :event_files,
+      Phase => :phase_files,
+      ProjectFolders::Folder => :files,
+      StaticPage => :static_page_files
+    }.freeze
+
+    def migrate_all
+      LEGACY_FILE_ASSOCIATIONS.keys.each do |container_class|
+        migrate_container_class(container_class)
+      end
+    end
+
+    def migrate_container_class(container_class)
+      legacy_file_association = LEGACY_FILE_ASSOCIATIONS.fetch(container_class)
+
+      container_class.where.associated(legacy_file_association).find_each do |container|
+        migrate_container(container)
+      end
+    end
+
+    def migrate_container(container)
+      legacy_file_association = LEGACY_FILE_ASSOCIATIONS.fetch(container.class)
+
+      Files::File.transaction do
+        container.send(legacy_file_association).find_each do |legacy_file|
+          migrate_legacy_file(container, legacy_file)
+        end
+
+        Rails.logger.info 'Migrated legacy file', legacy_file: legacy_file.id, file: file.id, container: container.id, container_class: container.class
+      rescue RemoteFileMissingError
+        Rails.logger.error 'Skipping file with missing content', legacy_file: legacy_file.id, container: container.id, container_class: container.class
+      end
+    end
+
+    private
+
+    # Migrate a single legacy file. It is private because we want to migrate all the files for a container at once, transactionally.
+    # So, this method is not intended to be called directly.
+    def migrate_legacy_file(container, legacy_file)
+      file = Files::File.new(
+        name: legacy_file.name,
+        content: legacy_file.file,
+        uploader: (container.author if container.is_a?(Idea)),
+        created_at: legacy_file.created_at
+      )
+
+      raise RemoteFileMissingError if file.content.blank?
+
+      attachment = file.attachments.build(
+        position: legacy_file.ordering,
+        attachable: container
+      )
+
+      if (project = container.try(:project))
+        file.files_projects.build(project: project)
+      end
+
+      file.save!
+
+      update_idea_cf_values!(container, legacy_file.id, attachment.id) if container.is_a?(Idea)
+      legacy_file.update!(migrated_file: file)
+    end
+
+    def update_idea_cf_values!(idea, legacy_file_id, attachment_id)
+      idea.custom_field_values.transform_values! do |value|
+        value.merge('id' => attachment_id) if value['id'] == legacy_file_id
+      end
+
+      idea.save!
+    end
+
+    class RemoteFileMissingError < StandardError; end
+  end
+end

--- a/back/app/services/files/legacy_file_migration_service.rb
+++ b/back/app/services/files/legacy_file_migration_service.rb
@@ -63,7 +63,7 @@ module Files
     def migrate_container_class(container_class, stats: Statistics.new)
       legacy_file_association = LEGACY_FILE_ASSOCIATIONS.fetch(container_class)
 
-      container_class.where.associated(legacy_file_association).find_each do |container|
+      container_class.where.associated(legacy_file_association).distinct.find_each do |container|
         migrate_container(container, stats: stats)
       end
 
@@ -81,10 +81,10 @@ module Files
           migrate_legacy_file(container, legacy_file)
         rescue RemoteFileMissingError
           logger.error('Skipping file with missing content', log_payload(container, legacy_file))
-          legacy_file.update!(migration_skipped_reason: 'File content missing')
+          legacy_file.update_column(:migration_skipped_reason, 'File content missing')
           files_skipped += 1
         rescue StandardError => e
-          error_details = log_payload(container, legacy_file, error: e.message)
+          error_details = log_payload(container, legacy_file, error_class: e.class.name, error_msg: e.message)
           stats.errors << error_details
           logger.error('Failed to migrate legacy file', error_details, e)
           raise ActiveRecord::Rollback

--- a/back/app/services/surveys/results_generator.rb
+++ b/back/app/services/surveys/results_generator.rb
@@ -106,14 +106,16 @@ module Surveys
         .select("custom_field_values->'#{field.key}'->'id' as value")
         .where("custom_field_values->'#{field.key}' IS NOT NULL")
         .map(&:value)
-      files = IdeaFile.where(id: file_ids).map do |file|
-        { name: file.name, url: file.file.url }
-      end
-      response_count = files.size
 
-      core_field_attributes(field, response_count:).merge({
-        files: files
-      })
+      files = ::Files::FileAttachment.where(id: file_ids).map do |attachment|
+        { name: attachment.file.name, url: attachment.file.content.url }
+      end
+
+      files.concat(IdeaFile.where(id: file_ids).map do |file|
+        { name: file.name, url: file.file.url }
+      end)
+
+      core_field_attributes(field, response_count: files.size).merge(files: files)
     end
 
     def visit_shapefile_upload(field)

--- a/back/app/services/xlsx_service.rb
+++ b/back/app/services/xlsx_service.rb
@@ -135,6 +135,10 @@ class XlsxService
   end
 
   def generate_idea_xlsx_columns(_ideas, view_private_attributes: false, with_tags: false, with_cosponsors: false)
+    get_attachments_urls = lambda do |i|
+      i.attached_files.map { |f| f.content.url } + i.idea_files.map { |f| f.file.url }
+    end
+
     columns = [
       { header: 'id',                   f: ->(i) { i.id }, skip_sanitization: true },
       { header: 'title',                f: ->(i) { multiloc_service.t(i.title_multiloc) } },
@@ -158,7 +162,7 @@ class XlsxService
       { header: 'latitude',             f: ->(i) { i.location_point&.coordinates&.last },                                  skip_sanitization: true },
       { header: 'longitude',            f: ->(i) { i.location_point&.coordinates&.first },                                 skip_sanitization: true },
       { header: 'location_description', f: ->(i) { i.location_description } },
-      { header: 'attachments',          f: ->(i) { i.idea_files.map { |f| f.file.url }.join("\n") }, skip_sanitization: true, width: 2 }
+      { header: 'attachments',          f: ->(i) { get_attachments_urls.call(i).join("\n") }, skip_sanitization: true, width: 2 }
     ]
 
     if with_cosponsors

--- a/back/db/migrate/20250807000000_add_migrated_file_id_to_container_files.rb
+++ b/back/db/migrate/20250807000000_add_migrated_file_id_to_container_files.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class AddMigratedFileIdToContainerFiles < ActiveRecord::Migration[7.1]
+  def change
+    # Adding a column to mark migrated files across all legacy file tables. This allows
+    # migrated files to be treated as deleted while still retaining them in the database,
+    # making it possible to revert the migration if needed.
+    container_file_tables = %i[
+      event_files
+      phase_files
+      project_files
+      idea_files
+      project_folders_files
+      static_page_files
+    ]
+
+    container_file_tables.each do |table|
+      add_reference table, :migrated_file,
+        foreign_key: { to_table: :files },
+        type: :uuid, null: true, index: true,
+        comment: 'References the Files::File record after migration to new file system'
+    end
+  end
+end

--- a/back/db/migrate/20250807000000_add_migration_columns_id_to_container_files.rb
+++ b/back/db/migrate/20250807000000_add_migration_columns_id_to_container_files.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
-class AddMigratedFileIdToContainerFiles < ActiveRecord::Migration[7.1]
+class AddMigrationColumnsIdToContainerFiles < ActiveRecord::Migration[7.1]
   def change
-    # Adding a column to mark migrated files across all legacy file tables. This allows
+    # Adding columns to mark migrated files across all legacy file tables. This allows
     # migrated files to be treated as deleted while still retaining them in the database,
     # making it possible to revert the migration if needed.
+    #
+    # A file is considered migrated if the `migrated_file_id` or `migration_skipped_reason`
+    # column is set.
     container_file_tables = %i[
       event_files
       phase_files
@@ -19,6 +22,8 @@ class AddMigratedFileIdToContainerFiles < ActiveRecord::Migration[7.1]
         foreign_key: { to_table: :files },
         type: :uuid, null: true, index: true,
         comment: 'References the Files::File record after migration to new file system'
+
+      add_column table, :migration_skipped_reason, :string, null: true
     end
   end
 end

--- a/back/engines/commercial/analysis/app/controllers/analysis/web_api/v1/inputs_controller.rb
+++ b/back/engines/commercial/analysis/app/controllers/analysis/web_api/v1/inputs_controller.rb
@@ -13,7 +13,7 @@ module Analysis
           @inputs = InputsFinder.new(@analysis, filters).execute
           filtered_count = @inputs.count
           @inputs = @inputs.order(published_at: :asc)
-          @inputs = @inputs.includes(:author, :idea_files)
+          @inputs = @inputs.includes(:author)
           @inputs = paginate @inputs
 
           render json: linked_json(
@@ -24,7 +24,7 @@ module Analysis
               view_private_attributes: view_private_attributes?,
               **jsonapi_serializer_params
             },
-            include: %i[author idea_files],
+            include: %i[author],
             meta: {
               filtered_count: filtered_count
             }

--- a/back/engines/commercial/analysis/app/serializers/analysis/web_api/v1/input_serializer.rb
+++ b/back/engines/commercial/analysis/app/serializers/analysis/web_api/v1/input_serializer.rb
@@ -8,7 +8,6 @@ module Analysis
 
         attributes :title_multiloc, :body_multiloc, :custom_field_values, :published_at, :updated_at, :likes_count, :dislikes_count, :comments_count, :votes_count, :location_description
 
-        has_many :idea_files, serializer: ::WebApi::V1::FileSerializer
         belongs_to :author, serializer: ::Analysis::WebApi::V1::AnalysisUserSerializer
         belongs_to :idea, serializer: ::WebApi::V1::IdeaSerializer do |input|
           input

--- a/back/spec/acceptance/ideas/ideas_create_spec.rb
+++ b/back/spec/acceptance/ideas/ideas_create_spec.rb
@@ -219,12 +219,24 @@ resource 'Ideas' do
           end
 
           describe do
-            let(:idea_files_attributes) { [{ name: 'afvalkalender.pdf', file: encode_file_as_base64('afvalkalender.pdf') }] }
+            let(:idea_files_attributes) do
+              [{
+                name: 'afvalkalender.pdf',
+                file_by_content: {
+                  name: 'afvalkalender.pdf',
+                  content: encode_file_as_base64('afvalkalender.pdf')
+                }
+              }]
+            end
 
             example_request 'Create an idea with a file' do
               assert_status 201
-              json_response = json_parse(response_body)
-              expect(Idea.find(json_response.dig(:data, :id)).idea_files.size).to eq 1
+
+              idea = Idea.find(response_data[:id])
+
+              # We are no longer using idea_files for new ideas.
+              expect(idea.idea_files.size).to eq(0)
+              expect(idea.attached_files.size).to eq(1)
             end
           end
 

--- a/back/spec/models/concerns/file_migratable_spec.rb
+++ b/back/spec/models/concerns/file_migratable_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FileMigratable do
+  describe 'default scope' do
+    let(:event_files) { create_list(:event_file, 2) }
+
+    it 'only returns non-migrated files' do
+      expect(EventFile.all).to match_array(event_files)
+
+      e1, e2 = event_files
+      e1.update!(migrated_file: create(:file))
+
+      expect(EventFile.all).to contain_exactly(e2)
+    end
+  end
+
+  describe 'migrated_file association' do
+    let(:file_record) { create(:event_file) }
+
+    it 'is optional' do
+      expect(file_record.migrated_file).to be_nil
+      expect(file_record).to be_valid
+    end
+  end
+end

--- a/back/spec/services/legacy_file_migration_service_spec.rb
+++ b/back/spec/services/legacy_file_migration_service_spec.rb
@@ -1,0 +1,172 @@
+require 'rails_helper'
+
+describe Files::LegacyFileMigrationService do
+  subject(:service) { described_class.new }
+
+  describe '#migrate_all' do
+    context 'when migrating survey responses with file upload custom fields' do
+      let(:survey_response) { @survey_response }
+      let(:file_upload_field) { @file_upload_field }
+      let(:filename) { 'the-filename.pdf' }
+
+      before do
+        create(:idea_status_proposed)
+        project = create(:single_phase_native_survey_project)
+        custom_form = create(:custom_form, participation_context: project.phases.first)
+
+        @file_upload_field = create(:custom_field_file_upload, resource: custom_form)
+
+        @survey_response = create(
+          :native_survey_response,
+          project: project,
+          creation_phase: project.phases.sole
+        )
+
+        idea_file = create(:idea_file, idea: @survey_response, name: filename)
+
+        @survey_response.update!(custom_field_values: {
+          @file_upload_field.key => { 'id' => idea_file.id, 'name' => filename }
+        })
+      end
+
+      it 'migrates all legacy files' do
+        stats = service.migrate_all
+        expect(stats.containers_migrated).to eq(1)
+        expect(stats.files_migrated).to eq(1)
+
+        attachment = survey_response.file_attachments.sole
+        custom_field_values = survey_response.reload.custom_field_values
+        expect(custom_field_values).to match(
+          file_upload_field.key => { 'id' => attachment.id, 'name' => attachment.file.name }
+        )
+      end
+    end
+
+    context 'when migrating mixed legacy file types across multiple containers' do
+      before_all do
+        project = create(:project)
+        create_list(:project_file, 2, project: project)
+          .each_with_index { |file, index| file.update!(ordering: index) }
+
+        event = create(:event)
+        create_list(:event_file, 2, event: event)
+
+        create_list(:phase_file, 2)
+        create_list(:static_page_file, 2)
+        create_list(:project_folder_file, 2)
+        create_list(:idea_file, 2)
+      end
+
+      it 'migrates all legacy files' do
+        stats = nil
+        expect { stats = service.migrate_all }
+          .to change(Files::File, :count).by(12)
+          .and change(Files::FileAttachment, :count).by(12)
+
+        expect(stats.containers_migrated).to eq(10)
+        expect(stats.files_migrated).to eq(12)
+        expect(stats.files_skipped).to eq(0)
+        expect(stats.errors).to be_empty
+
+        ProjectFile.migrated.each do |project_file|
+          attachment = project_file.migrated_file.attachments.sole
+          expect(attachment.position).to eq project_file.ordering
+        end
+      end
+    end
+
+    context 'when migrating multiple project files from a single project' do
+      before_all do
+        project = create(:project)
+        create_list(:project_file, 3, project: project)
+      end
+
+      it 'migrates all legacy files' do
+        stats = service.migrate_all
+        expect(stats.containers_migrated).to eq(1)
+        expect(stats.files_migrated).to eq(3)
+      end
+    end
+
+    context 'when migrating files with missing remote files' do
+      let!(:project_file) do
+        create(:project_file).tap do |file|
+          file.update_column(:file, 'incorrect-name.pdf')
+        end
+      end
+
+      it 'skips the file' do
+        stats = service.migrate_all
+        expect(stats.containers_migrated).to eq(1)
+        expect(stats.files_migrated).to eq(0)
+        expect(stats.files_skipped).to eq(1)
+        expect(stats.errors).to be_empty
+
+        expect(project_file.reload.migration_skipped_reason).to eq('File content missing')
+      end
+    end
+
+    context 'when migrating files with errors' do
+      let!(:project_file) { create(:project_file) }
+
+      it 'rolls back the transaction and logs the error' do
+        error_msg = 'no address for test.s3.eu-central-1.amazonaws.com'
+        allow(service).to receive(:migrate_legacy_file) # rubocop:disable RSpec/SubjectStub
+          .and_raise(StandardError, error_msg)
+
+        stats = service.migrate_all
+
+        expect(stats.containers_migrated).to eq(0)
+        expect(stats.files_migrated).to eq(0)
+        expect(stats.files_skipped).to eq(0)
+        expect(stats.errors.first).to match(
+          tenant_id: Tenant.current.id,
+          tenant_host: Tenant.current.host,
+          container_type: 'Project',
+          container_id: project_file.project.id,
+          legacy_file_type: 'ProjectFile',
+          legacy_file_id: project_file.id,
+          error_class: 'StandardError',
+          error_msg: error_msg
+        )
+      end
+    end
+  end
+
+  describe '#migrate_container' do
+    it 'migrates legacy files for an event' do
+      event = create(:event)
+      legacy_files = create_list(:event_file, 2, event: event).each_with_index do |file, index|
+        file.update!(ordering: index)
+      end
+
+      stats = nil
+      expect { stats = service.migrate_container(event) }
+        .to change(Files::File, :count).by(2)
+        .and change(Files::FileAttachment, :count).by(2)
+
+      expect(stats.files_migrated).to eq(2)
+      expect(stats.files_skipped).to eq(0)
+      expect(stats.containers_migrated).to eq(1)
+      expect(stats.errors).to be_empty
+
+      legacy_files.each(&:reload)
+      expect(legacy_files).to all(be_migrated)
+
+      legacy_files.each do |legacy_file|
+        migrated_file = legacy_file.migrated_file
+        attachment = migrated_file.attachments.sole
+
+        expect(migrated_file.name).to eq legacy_file.name
+        expect(migrated_file.created_at).to eq legacy_file.created_at
+        expect(migrated_file.projects).to contain_exactly(event.project)
+        expect(migrated_file.ai_processing_allowed).to eq false
+        expect(migrated_file.category).to eq 'other'
+        expect(migrated_file.uploader).to be_nil
+
+        expect(attachment.position).to eq legacy_file.ordering
+        expect(attachment.attachable).to eq event
+      end
+    end
+  end
+end


### PR DESCRIPTION
… migrated

The default_scope of the legacy file model is adapted to exclude the files marked as migrated.# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->
