### PR TITLE
Script to migrate demographics from EngagementHQ

### DIFF
--- a/back/lib/tasks/single_use/20250822_migrate_engagementhq_demographics.rake
+++ b/back/lib/tasks/single_use/20250822_migrate_engagementhq_demographics.rake
@@ -6,20 +6,27 @@ namespace :single_use do
       csv = CSV.read(args[:csvpath], headers: true)
       csv.each do |row|
         user = User.find_by(email: row['Email address']&.strip)
+        next if !user
+
         custom_field_values = {}
+
         birthyear = row['Year of Birth']&.strip&.to_i
         custom_field_values['birthyear'] = birthyear if birthyear.present?
+
         custom_field_values['postal_code_s0n'] = row['Postal Code']&.strip if row['Postal Code'].present?
+
         connection_options = rake_20250822_find_option_keys(
           row['Connections to New Westminster (select all that apply)']&.strip,
           CustomField.find_by(key: 'connections_to_new_westminster_select_all_that_apply_320').options
         )
         custom_field_values['connections_to_new_westminster_select_all_that_apply_320'] = connection_options if connection_options.present?
+
         more_info_options = rake_20250822_find_option_keys(
           row['OPTIONAL - More info about you (select any / all that apply):']&.strip,
           CustomField.find_by(key: 'optional_more_info_about_you_select_any_all_that_apply_snh').options
         )
         custom_field_values['optional_more_info_about_you_select_any_all_that_apply_snh'] = more_info_options if more_info_options.present?
+
         custom_field_values_before = user.custom_field_values
         custom_field_values.merge!(custom_field_values_before)
         if user.update(custom_field_values: custom_field_values)
@@ -41,5 +48,7 @@ namespace :single_use do
 end
 
 def rake_20250822_find_option_keys(value, options)
+  return [] if !value
+
   options.select { |option| option.title_multiloc.values.any? { |option_value| value.include?(option_value) } }.map(&:key)
 end

--- a/back/lib/tasks/single_use/20250822_migrate_engagementhq_demographics.rake
+++ b/back/lib/tasks/single_use/20250822_migrate_engagementhq_demographics.rake
@@ -1,0 +1,45 @@
+namespace :single_use do
+  desc 'Migrate EngagementHQ demographics'
+  task :migrate_engagementhq_demographics, %i[host csvpath] => :environment do |_task, args|
+    reporter = ScriptReporter.new
+    Tenant.find_by(host: args[:host]).switch do
+      csv = CSV.read(args[:csvpath], headers: true)
+      csv.each do |row|
+        user = User.find_by(email: row['Email address']&.strip)
+        custom_field_values = {}
+        birthyear = row['Year of Birth']&.strip&.to_i
+        custom_field_values['birthyear'] = birthyear if birthyear.present?
+        custom_field_values['postal_code_s0n'] = row['Postal Code']&.strip if row['Postal Code'].present?
+        connection_options = rake_20250822_find_option_keys(
+          row['Connections to New Westminster (select all that apply)']&.strip,
+          CustomField.find_by(key: 'connections_to_new_westminster_select_all_that_apply_320').options
+        )
+        custom_field_values['connections_to_new_westminster_select_all_that_apply_320'] = connection_options if connection_options.present?
+        more_info_options = rake_20250822_find_option_keys(
+          row['OPTIONAL - More info about you (select any / all that apply):']&.strip,
+          CustomField.find_by(key: 'optional_more_info_about_you_select_any_all_that_apply_snh').options
+        )
+        custom_field_values['optional_more_info_about_you_select_any_all_that_apply_snh'] = more_info_options if more_info_options.present?
+        custom_field_values_before = user.custom_field_values
+        custom_field_values.merge!(custom_field_values_before)
+        if user.update(custom_field_values: custom_field_values)
+          reporter.add_change(
+            { custom_field_values: custom_field_values_before },
+            { custom_field_values: },
+            context: { tenant: Tenant.current.host, user: user.id }
+          )
+        else
+          reporter.add_error(
+            user.errors.details,
+            context: { tenant: Tenant.current.host, user: user.id, custom_field_values: }
+          )
+        end
+      end
+    end
+    reporter.report!('migrate_engagementhq_demographics.json', verbose: true)
+  end
+end
+
+def rake_20250822_find_option_keys(value, options)
+  options.select { |option| option.title_multiloc.values.any? { |option_value| value.include?(option_value) } }.map(&:key)
+end

--- a/back/spec/fixtures/engagementhq_demographics.csv
+++ b/back/spec/fixtures/engagementhq_demographics.csv
@@ -1,0 +1,4 @@
+Email address,First name(s),Last name,DateCreated,LastAccess,Postal Code,Connections to New Westminster (select all that apply),Year of Birth
+user1@test.com,user1,,3/1/2025,3/1/2025,"New Westminster, BC, V3M6K3","Residential property owner (condo, townhouse, house, etc.) in New West",2024
+user2@test.com,user2,,7/2/2025,7/2/2025,"New Westminster, BC, V3M3C7","Residential property owner (condo, townhouse, house, etc.) in New West, Student in New West, Under-housed or unhoused (having inadequate or unstable housing, at risk of experiencing homelessness, experiencing hidden homelessness – i.e. couchsurfing, or unsheltered) in New West",
+user3@test.com,user3,,7/3/2025,7/3/2025,"New Westminster, BC, V3M4B5","Student in New West, Under-housed or unhoused (having inadequate or unstable housing, at risk of experiencing homelessness, experiencing hidden homelessness – i.e. couchsurfing, or unsheltered) in New West",1905

--- a/back/spec/tasks/single_use/migrate_engagementhq_demographics_spec.ignore.rb
+++ b/back/spec/tasks/single_use/migrate_engagementhq_demographics_spec.ignore.rb
@@ -10,7 +10,7 @@ describe 'rake single_use:migrate_engagementhq_demographics' do
     connections.options.create!([
       { key: 'residential_property_owner_condo_townhouse_house_etc_in_new_west_jfd', title_multiloc: { 'en' => 'Residential property owner (condo, townhouse, house, etc.) in New West' } },
       { key: 'student_in_new_west_z75', title_multiloc: { 'en' => 'Student in New West' } },
-      { key: 'under_housed_or_unhoused_having_inadequate_or_unstable_housing_atrisk_of_experiencing_homelessness_experiencing_hidden_homelessness_i_e_couchsurfing_or_unsheltered_in_new_west_jh2', title_multiloc: { 'en' => 'Under-housed or unhoused (having inadequate or unstable housing, at risk of experiencing homelessness, experiencing hidden homelessness – i.e. couchsurfing, or unsheltered) in New West' } },
+      { key: 'under_housed_or_unhoused_having_inadequate_or_unstable_housing_atrisk_of_experiencing_homelessness_experiencing_hidden_homelessness_i_e_couchsurfing_or_unsheltered_in_new_west_jh2', title_multiloc: { 'en' => 'Under-housed or unhoused (having inadequate or unstable housing, at risk of experiencing homelessness, experiencing hidden homelessness – i.e. couchsurfing, or unsheltered) in New West' } }
     ])
     create(:custom_field_multiselect, :for_registration, key: 'optional_more_info_about_you_select_any_all_that_apply_snh')
 

--- a/back/spec/tasks/single_use/migrate_engagementhq_demographics_spec.ignore.rb
+++ b/back/spec/tasks/single_use/migrate_engagementhq_demographics_spec.ignore.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe 'rake single_use:migrate_engagementhq_demographics' do
+  before { load_rake_tasks_if_not_loaded }
+
+  it 'Migrates demographics' do
+    create(:custom_field_birthyear)
+    create(:custom_field, :for_registration, key: 'postal_code_s0n', input_type: 'text')
+    connections = create(:custom_field_multiselect, :for_registration, key: 'connections_to_new_westminster_select_all_that_apply_320')
+    connections.options.create!([
+      { key: 'residential_property_owner_condo_townhouse_house_etc_in_new_west_jfd', title_multiloc: { 'en' => 'Residential property owner (condo, townhouse, house, etc.) in New West' } },
+      { key: 'student_in_new_west_z75', title_multiloc: { 'en' => 'Student in New West' } },
+      { key: 'under_housed_or_unhoused_having_inadequate_or_unstable_housing_atrisk_of_experiencing_homelessness_experiencing_hidden_homelessness_i_e_couchsurfing_or_unsheltered_in_new_west_jh2', title_multiloc: { 'en' => 'Under-housed or unhoused (having inadequate or unstable housing, at risk of experiencing homelessness, experiencing hidden homelessness – i.e. couchsurfing, or unsheltered) in New West' } },
+    ])
+    create(:custom_field_multiselect, :for_registration, key: 'optional_more_info_about_you_select_any_all_that_apply_snh')
+
+    create(:user, email: 'user1@test.com', first_name: 'user1', last_name: '', custom_field_values: {})
+    create(:user, email: 'user2@test.com', first_name: 'user2', last_name: '', custom_field_values: { 'birthyear' => 1990 })
+    create(:user, email: 'user3@test.com', first_name: 'user3', last_name: '', custom_field_values: {})
+
+    Rake::Task['single_use:migrate_engagementhq_demographics'].invoke(Tenant.current.host, Rails.root.join('spec/fixtures/engagementhq_demographics.csv'))
+
+    expect(User.find_by(email: 'user1@test.com').custom_field_values).to eq({ 'postal_code_s0n' => 'New Westminster, BC, V3M6K3', 'birthyear' => 2024, 'connections_to_new_westminster_select_all_that_apply_320' => ['residential_property_owner_condo_townhouse_house_etc_in_new_west_jfd'] })
+    expect(User.find_by(email: 'user2@test.com').custom_field_values).to eq({ 'postal_code_s0n' => 'New Westminster, BC, V3M3C7', 'birthyear' => 1990, 'connections_to_new_westminster_select_all_that_apply_320' => %w[residential_property_owner_condo_townhouse_house_etc_in_new_west_jfd student_in_new_west_z75 under_housed_or_unhoused_having_inadequate_or_unstable_housing_atrisk_of_experiencing_homelessness_experiencing_hidden_homelessness_i_e_couchsurfing_or_unsheltered_in_new_west_jh2] })
+    expect(User.find_by(email: 'user3@test.com').custom_field_values).to eq({ 'postal_code_s0n' => 'New Westminster, BC, V3M4B5', 'birthyear' => 1905, 'connections_to_new_westminster_select_all_that_apply_320' => %w[student_in_new_west_z75 under_housed_or_unhoused_having_inadequate_or_unstable_housing_atrisk_of_experiencing_homelessness_experiencing_hidden_homelessness_i_e_couchsurfing_or_unsheltered_in_new_west_jh2] })
+  end
+end


### PR DESCRIPTION
The current script that migrates data from EngagementHQ does not include demographic data. We decided to develop a separate script to add the missing data after migrating the users.

TODO during migration:
- Set [custom login text](https://github.com/CitizenLabDotCo/citizenlab/pull/11803).
- Go to https://beheardnewwest.govocal.com/en-CA/admin/project-importer to import the users.
- Delete created duplicates of registration fields.
- Run `bin/rake single_use:migrate_engagementhq_demographics['beheardnewwest.govocal.com','users.csv']`
- Execute `AppConfiguration.instance.update_columns(created_at: 10.years.ago)`

<img width="1579" height="860" alt="Screenshot 2025-08-25 at 12 09 08" src="https://github.com/user-attachments/assets/12688c72-20d9-4745-9ed0-42e00ae71fbc" />
