### PR TITLE
TAN-5364 Fixing crashing reports depending on old phase payload, without vote_term

### DIFF
--- a/back/lib/tasks/single_use/20250805_fix_missing_vote_term_in_graph_data_units.rake
+++ b/back/lib/tasks/single_use/20250805_fix_missing_vote_term_in_graph_data_units.rake
@@ -1,8 +1,6 @@
 namespace :single_use do
   desc 'Fix missing vote_term in graph data units, which was forgotton to be updated when introducing the vote term'
-  task :fix_missing_vote_term_in_graph_data_units, %i[execute] => [:environment] do |_t, args|
-    execute = args[:execute] == 'execute'
-
+  task :fix_missing_vote_term_in_graph_data_units, %i[execute] => [:environment] do |_t, _args|
     Tenant.safe_switch_each do |tenant|
       puts "\nProcessing tenant #{tenant.host} \n\n"
 

--- a/back/lib/tasks/single_use/20250805_fix_missing_vote_term_in_graph_data_units.rake
+++ b/back/lib/tasks/single_use/20250805_fix_missing_vote_term_in_graph_data_units.rake
@@ -1,13 +1,13 @@
 namespace :single_use do
   desc 'Fix missing vote_term in graph data units, which was forgotton to be updated when introducing the vote term'
-  task :fix_missing_vote_term_in_graph_data_units, %i[execute] => [:environment] do |_t, _args|
+  task :fix_missing_vote_term_in_graph_data_units => :environment do |_t, _args|
     Tenant.safe_switch_each do |tenant|
       puts "\nProcessing tenant #{tenant.host} \n\n"
 
       data_units = ReportBuilder::PublishedGraphDataUnit.where("data->'phase' IS NOT NULL AND data->'phase'->'vote_term' IS NULL")
 
       data_units.each do |data_unit|
-        builder = ReportBuilder::ReportPublisher.new(data_unit.report)
+        builder = ReportBuilder::ReportPublisher.new(data_unit.report, data_unit.report.owner)
         builder.publish
       end
     end

--- a/back/lib/tasks/single_use/20250805_fix_missing_vote_term_in_graph_data_units.rake
+++ b/back/lib/tasks/single_use/20250805_fix_missing_vote_term_in_graph_data_units.rake
@@ -1,0 +1,17 @@
+namespace :single_use do
+  desc 'Fix missing vote_term in graph data units, which was forgotton to be updated when introducing the vote term'
+  task :fix_missing_vote_term_in_graph_data_units, %i[execute] => [:environment] do |_t, args|
+    execute = args[:execute] == 'execute'
+
+    Tenant.safe_switch_each do |tenant|
+      puts "\nProcessing tenant #{tenant.host} \n\n"
+
+      data_units = ReportBuilder::PublishedGraphDataUnit.where("data->'phase' IS NOT NULL AND data->'phase'->'vote_term' IS NULL")
+
+      data_units.each do |data_unit|
+        builder = ReportBuilder::ReportPublisher.new(data_unit.report)
+        builder.publish
+      end
+    end
+  end
+end

--- a/back/lib/tasks/single_use/20250805_fix_missing_vote_term_in_graph_data_units.rake
+++ b/back/lib/tasks/single_use/20250805_fix_missing_vote_term_in_graph_data_units.rake
@@ -1,6 +1,6 @@
 namespace :single_use do
   desc 'Fix missing vote_term in graph data units, which was forgotton to be updated when introducing the vote term'
-  task :fix_missing_vote_term_in_graph_data_units => :environment do |_t, _args|
+  task fix_missing_vote_term_in_graph_data_units: :environment do |_t, _args|
     Tenant.safe_switch_each do |tenant|
       puts "\nProcessing tenant #{tenant.host} \n\n"
 


### PR DESCRIPTION
# Changelog

When we introduced the new `vote_term` in phases, we didn't account for the fact that published reports still depend on the old Phase payload, saved in PublishedGraphDataUnit records. At least one component in the report depends on the vote_term and assumes it's present, leading to a hard crash.

This solves it at the source, by republishing the data units that have a `phase` without `vote_term`.

## Fixed
- Phases that show reports that date from before we introduced to Vote term no longer crash