### PR TITLE
Remove X-Mailgun-Track from the Mailgun headers

### DIFF
--- a/back/app/mailers/application_mailer.rb
+++ b/back/app/mailers/application_mailer.rb
@@ -112,13 +112,9 @@ class ApplicationMailer < ActionMailer::Base
   end
 
   def mailgun_headers
-    headers = {
+    {
       'X-Mailgun-Variables' => mailgun_variables.to_json
     }
-    return headers if mailgun_variables['cl_delivery_id'].present?
-
-    # Do not use the hook API for tracking if the delivery ID is not set.
-    headers.merge('X-Mailgun-Track' => 'no')
   end
 
   def mailgun_variables

--- a/back/engines/free/email_campaigns/app/controllers/email_campaigns/hooks/mailgun_events_controller.rb
+++ b/back/engines/free/email_campaigns/app/controllers/email_campaigns/hooks/mailgun_events_controller.rb
@@ -38,12 +38,6 @@ module EmailCampaigns
           head :not_acceptable
         end
       else
-        # If this error is never reported to Sentry, we can remove this in August 2025, together
-        # with the ErrorReporter call in extra_mailgun_variables in the Trackable concern.
-        ErrorReporter.report_msg(
-          'No delivery found for delivery ID passed in Mailgun hook!',
-          extra: { user_variables: params[:'event-data'][:'user-variables'] }
-        )
         # We haven't sent out this mail
         head :not_acceptable
       end

--- a/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/trackable.rb
+++ b/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/trackable.rb
@@ -25,15 +25,6 @@ module EmailCampaigns
     end
 
     def extra_mailgun_variables(command)
-      if !command[:delivery_id]
-        # This can be removed in August 2025. It seems like the delivery_id is always included now,
-        # but somehow the Mailgun header is also called when the delivery_id is not set yet. But if
-        # the error in MailgunEventsController is not raised, then all should be fine.
-        ErrorReporter.report_msg(
-          'No delivery ID in Mailgun variables!',
-          extra: { command: command, campaign: self }
-        )
-      end
       { 'cl_delivery_id' => command[:delivery_id] }
     end
 

--- a/back/spec/mailers/confirmations_mailer_spec.rb
+++ b/back/spec/mailers/confirmations_mailer_spec.rb
@@ -25,11 +25,10 @@ RSpec.describe ConfirmationsMailer do
 
         mailer.send_confirmation_code.deliver_now
 
-        expect(mailer_instance.mailgun_headers.keys).to match_array %w[X-Mailgun-Variables X-Mailgun-Track]
+        expect(mailer_instance.mailgun_headers.keys).to match_array %w[X-Mailgun-Variables]
         expect(JSON.parse(mailer_instance.mailgun_headers['X-Mailgun-Variables'])).to match(
           hash_including('cl_tenant_id' => instance_of(String))
         )
-        expect(mailer_instance.mailgun_headers['X-Mailgun-Track']).to eq 'no'
       end
     end
 

--- a/back/spec/mailers/reset_password_mailer_spec.rb
+++ b/back/spec/mailers/reset_password_mailer_spec.rb
@@ -21,11 +21,10 @@ RSpec.describe ResetPasswordMailer do
 
       mailer.send_reset_password.deliver_now
 
-      expect(mailer_instance.mailgun_headers.keys).to match_array %w[X-Mailgun-Variables X-Mailgun-Track]
+      expect(mailer_instance.mailgun_headers.keys).to match_array %w[X-Mailgun-Variables]
       expect(JSON.parse(mailer_instance.mailgun_headers['X-Mailgun-Variables'])).to match(
         hash_including('cl_tenant_id' => instance_of(String))
       )
-      expect(mailer_instance.mailgun_headers['X-Mailgun-Track']).to eq 'no'
     end
   end
 

--- a/back/spec/mailers/user_blocked_mailer_spec.rb
+++ b/back/spec/mailers/user_blocked_mailer_spec.rb
@@ -21,11 +21,10 @@ RSpec.describe UserBlockedMailer do
 
         mailer.send_user_blocked_email.deliver_now
 
-        expect(mailer_instance.mailgun_headers.keys).to match_array %w[X-Mailgun-Variables X-Mailgun-Track]
+        expect(mailer_instance.mailgun_headers.keys).to match_array %w[X-Mailgun-Variables]
         expect(JSON.parse(mailer_instance.mailgun_headers['X-Mailgun-Variables'])).to match(
           hash_including('cl_tenant_id' => instance_of(String))
         )
-        expect(mailer_instance.mailgun_headers['X-Mailgun-Track']).to eq 'no'
       end
     end
 


### PR DESCRIPTION
During this tandem, we introduced `cl_delivery_id` to be able to have stats on automated emails in the future. We wanted to make sure they are always set when they should be set.

That's why we also included `X-Mailgun-Track` and set the value to "no", to tell Mailgun not to use the hook for built-in emails like the password reset and confirmation email. However, it turns out that Mailgun is not taking `X-Mailgun-Track` into account and calls the hook API anyway.

We also added Sentry error reports when the delivery ID is missing. The idea is that the API hook would only be called for email campaigns that are trackable and include a delivery ID. But as Mailgun just always calls the API hook, we got many false positives in Sentry.

We tested everything manually and can confirm that the delivery ID was always set when it should be and that the Sentry issue gets triggered by the built-in emails, like the password reset. We can therefore quite confidently remove this code.

If we want stronger guarantees on the presence of the Delivery ID in the future however, I would propose to migrate the password reset and other built-in emails to become proper email campaigns that are also trackable. We would then have statistics for all email campaigns and could raise an error in Sentry when there is no delivery ID in the Mailgun headers. This is a fair amount of effort, so we won't do this anymore in this tandem.