### PR TITLE
[TAN-4374] Add highest_role to JWT payload

### DIFF
--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -216,6 +216,7 @@ class User < ApplicationRecord
     token_lifetime = AppConfiguration.instance.settings('core', 'authentication_token_lifetime_in_days').days
     {
       sub: id,
+      highest_role: highest_role,
       roles: compress_roles,
       exp: token_lifetime.from_now.to_i,
       cluster: CL2_CLUSTER,


### PR DESCRIPTION
See related [cl2-admin-templates PR](https://github.com/CitizenLabDotCo/cl2-admin-templates/pull/40)

# Changelog
## Technical
- [TAN-4374] Add highest_role to JWT payload. First step in fixing oversize JWT issue.
