### PR TITLE
TAN-5362: Restrict Projects Widget visibility to admins only

### DIFF
--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Toolbox/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Toolbox/index.tsx
@@ -368,19 +368,23 @@ const ReportBuilderToolbox = ({
               icon="chart-bar"
               label={formatMessage(WIDGET_TITLES.MethodsUsedWidget)}
             />
-            <DraggableElement
-              id="e2e-draggable-projects-widget"
-              component={
-                <ProjectsWidget
-                  title={toMultiloc(WIDGET_TITLES.ProjectsWidget)}
-                  startAt={undefined}
-                  endAt={chartEndDate}
-                />
-              }
-              icon="projects"
-              label={formatMessage(WIDGET_TITLES.ProjectsWidget)}
-            />
-            {projectPlanningCalendarEnabled && (
+            {/* Only show Projects Widget for admins, not for project moderators */}
+            {!userIsModerator && (
+              <DraggableElement
+                id="e2e-draggable-projects-widget"
+                component={
+                  <ProjectsWidget
+                    title={toMultiloc(WIDGET_TITLES.ProjectsWidget)}
+                    startAt={undefined}
+                    endAt={chartEndDate}
+                  />
+                }
+                icon="projects"
+                label={formatMessage(WIDGET_TITLES.ProjectsWidget)}
+              />
+            )}
+            {/* Only show Projects Timeline Widget for admins, not for project moderators */}
+            {projectPlanningCalendarEnabled && !userIsModerator && (
               <DraggableElement
                 id="e2e-draggable-projects-timeline-widget"
                 component={

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Toolbox/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Toolbox/index.tsx
@@ -39,6 +39,7 @@ import {
   isModerator,
   isProjectModerator,
   isSuperAdmin,
+  isAdmin,
 } from 'utils/permissions/roles';
 
 import Analysis from '../Analysis';
@@ -79,6 +80,7 @@ const ReportBuilderToolbox = ({
 
   const { data: authUser } = useAuthUser();
   const userIsModerator = !!authUser && isModerator(authUser);
+  const isUserAdmin = isAdmin(authUser);
 
   const { data: projects } = useProjects(
     {
@@ -369,7 +371,7 @@ const ReportBuilderToolbox = ({
               label={formatMessage(WIDGET_TITLES.MethodsUsedWidget)}
             />
             {/* Only show Projects Widget for admins, not for project moderators */}
-            {!userIsModerator && (
+            {isUserAdmin && (
               <DraggableElement
                 id="e2e-draggable-projects-widget"
                 component={
@@ -384,7 +386,7 @@ const ReportBuilderToolbox = ({
               />
             )}
             {/* Only show Projects Timeline Widget for admins, not for project moderators */}
-            {projectPlanningCalendarEnabled && !userIsModerator && (
+            {projectPlanningCalendarEnabled && isUserAdmin && (
               <DraggableElement
                 id="e2e-draggable-projects-timeline-widget"
                 component={


### PR DESCRIPTION
# Changelog

## Changed
- This change temporarily restricts the visibility and use of the projects widget and the projects timeline widget to only admins in the report builder. There are some permissions concerns that we need to align on before enabling these. These were already not working well so it shouldn't affect them a lot
