### PR TITLE
TAN-5388 Bump expiry time of signed images

### DIFF
--- a/back/lib/citizen_lab/cloudfront_url_signer.rb
+++ b/back/lib/citizen_lab/cloudfront_url_signer.rb
@@ -17,7 +17,7 @@ module CitizenLab
       raise MissingConfigurationError
     end
 
-    def sign_url(url, expires_in: 1.day)
+    def sign_url(url, expires_in: 1.month)
       expires_at = Time.now + expires_in
       @signer.signed_url(url, expires: expires_at)
     end


### PR DESCRIPTION
Bumps the expiry time from 24 hours to 30 days, which buys us some time to fix the external systems that store image URLs. (cl2-workshops and cl2-library)