### PR TITLE
[TAN-5355] Do not prevent back office editing of anonymous ideas

### DIFF
--- a/back/app/controllers/web_api/v1/ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/ideas_controller.rb
@@ -579,7 +579,7 @@ class WebApi::V1::IdeasController < ApplicationController
   def not_allowed_update_errors(input)
     can_moderate = UserRoleService.new.can_moderate?(input.project, current_user)
 
-    if can_moderate == false && anonymous_not_allowed?(TimelineService.new.current_phase_not_archived(input.project))
+    if !can_moderate && anonymous_not_allowed?(TimelineService.new.current_phase_not_archived(input.project))
       return { errors: { base: [{ error: :anonymous_participation_not_allowed }] } }
     end
 

--- a/back/app/controllers/web_api/v1/ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/ideas_controller.rb
@@ -577,12 +577,16 @@ class WebApi::V1::IdeasController < ApplicationController
   end
 
   def not_allowed_update_errors(input)
-    if anonymous_not_allowed?(TimelineService.new.current_phase_not_archived(input.project))
+    is_moderator = UserRoleService.new.can_moderate?(input.project, current_user)
+
+    if is_moderator == false && anonymous_not_allowed?(TimelineService.new.current_phase_not_archived(input.project))
       return { errors: { base: [{ error: :anonymous_participation_not_allowed }] } }
     end
+
     if idea_status_not_allowed?(input)
       return { errors: { idea_status_id: [{ error: 'Cannot manually assign inputs to this status', value: input.idea_status_id }] } }
     end
+
     if !input.participation_method_on_creation.transitive? && input.project_id_changed?
       return { errors: { project_id: [{ error: 'Cannot change the project of non-transitive inputs', value: input.project_id }] } }
     end

--- a/back/app/controllers/web_api/v1/ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/ideas_controller.rb
@@ -577,7 +577,6 @@ class WebApi::V1::IdeasController < ApplicationController
   end
 
   def not_allowed_update_errors(input)
-    puts "idea: #{input.inspect}"
     can_moderate = UserRoleService.new.can_moderate?(input.project, current_user)
 
     if can_moderate == false && anonymous_not_allowed?(TimelineService.new.current_phase_not_archived(input.project))

--- a/back/app/controllers/web_api/v1/ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/ideas_controller.rb
@@ -577,9 +577,10 @@ class WebApi::V1::IdeasController < ApplicationController
   end
 
   def not_allowed_update_errors(input)
-    is_moderator = UserRoleService.new.can_moderate?(input.project, current_user)
+    puts "idea: #{input.inspect}"
+    can_moderate = UserRoleService.new.can_moderate?(input.project, current_user)
 
-    if is_moderator == false && anonymous_not_allowed?(TimelineService.new.current_phase_not_archived(input.project))
+    if can_moderate == false && anonymous_not_allowed?(TimelineService.new.current_phase_not_archived(input.project))
       return { errors: { base: [{ error: :anonymous_participation_not_allowed }] } }
     end
 

--- a/back/spec/acceptance/ideas/ideas_update_spec.rb
+++ b/back/spec/acceptance/ideas/ideas_update_spec.rb
@@ -321,10 +321,23 @@ resource 'Ideas' do
 
             example 'Does not reject the anonymous parameter' do
               do_request idea: { anonymous: true }
+
               assert_status 200
-              json_response = json_parse response_body
               expect(response_data.dig(:relationships, :author, :data, :id)).to be_nil
               expect(response_data.dig(:attributes, :anonymous)).to be true
+            end
+          end
+
+          describe 'when anonymous posting is allowed and phase is not current' do
+            let(:allow_anonymous_participation) { true }
+
+            example 'updates without error' do
+              project.phases.first.update! start_at: 2.weeks.ago, end_at: 1.week.ago
+
+              do_request idea: { body_multiloc: { 'en' => 'Updated body' } }
+
+              assert_status 200
+              expect(response_data.dig(:attributes, :body_multiloc)).to eq({ en: 'Updated body' })
             end
           end
 

--- a/back/spec/acceptance/ideas/ideas_update_spec.rb
+++ b/back/spec/acceptance/ideas/ideas_update_spec.rb
@@ -319,11 +319,12 @@ resource 'Ideas' do
           describe 'when anonymous posting is not allowed' do
             let(:allow_anonymous_participation) { false }
 
-            example 'Rejects the anonymous parameter' do
+            example 'Does not reject the anonymous parameter' do
               do_request idea: { anonymous: true }
-              assert_status 422
+              assert_status 200
               json_response = json_parse response_body
-              expect(json_response).to include_response_error(:base, 'anonymous_participation_not_allowed')
+              expect(response_data.dig(:relationships, :author, :data, :id)).to be_nil
+              expect(response_data.dig(:attributes, :anonymous)).to be true
             end
           end
 


### PR DESCRIPTION
Quick fix to permit BO editing of anonymous ideas created in phase that has not yet started.

# Changelog
## Fixed
- [TAN-5355] Do not prevent back office editing of anonymous ideas
