### PR TITLE
Add missing preview copy

### DIFF
--- a/front/app/containers/Admin/messaging/Edit/index.tsx
+++ b/front/app/containers/Admin/messaging/Edit/index.tsx
@@ -137,7 +137,9 @@ const Edit = ({ campaignType }: EditProps) => {
         <Box width="50%">
           <Box display="inline-flex" width="100%" mb="12px">
             <Box width="70%">
-              <h2>Preview</h2>
+              <h2>
+                <FormattedMessage {...messages.preview} />
+              </h2>
             </Box>
             <Box>
               <Button

--- a/front/app/containers/Admin/messaging/messages.ts
+++ b/front/app/containers/Admin/messaging/messages.ts
@@ -132,6 +132,10 @@ export default defineMessages({
     defaultMessage:
       'When you click this link, a test email will be sent to your email address only. This allows you to check what the email looks like in ‘real life’.',
   },
+  preview: {
+    id: 'app.containers.Admin.emails.preview',
+    defaultMessage: 'Preview',
+  },
   previewSentConfirmation: {
     id: 'app.containers.Admin.emails.previewSentConfirmation',
     defaultMessage: 'A preview email has been sent to your email address',

--- a/front/app/translations/admin/en.json
+++ b/front/app/translations/admin/en.json
@@ -889,6 +889,7 @@
   "app.containers.Admin.emails.groups": "Groups",
   "app.containers.Admin.emails.helmetDescription": "Send out manual emails to user groups and activate automated campaigns",
   "app.containers.Admin.emails.nameVariablesInfo2": "You can speak directly to citizens using the variables {firstName} {lastName}. E.g. \"Dear {firstName} {lastName}, ...\"",
+  "app.containers.Admin.emails.preview": "Preview",
   "app.containers.Admin.emails.previewSentConfirmation": "A preview email has been sent to your email address",
   "app.containers.Admin.emails.previewTitle": "Preview",
   "app.containers.Admin.emails.regionMultilocError": "Please provide a value for all languages",


### PR DESCRIPTION
This copy in the emails was not using translations.
<img width="2880" height="1800" alt="Screenshot 2025-08-27 at 12 49 13 (2)" src="https://github.com/user-attachments/assets/3c195127-1f48-4763-89fd-dfab08198d31" />
