### PR TITLE
TAN-5403 Allow phases to start in 1900

### DIFF
--- a/front/app/containers/Admin/projects/project/phaseSetup/components/DateSetup.tsx
+++ b/front/app/containers/Admin/projects/project/phaseSetup/components/DateSetup.tsx
@@ -93,6 +93,7 @@ const DateSetup = ({
         selectedRange={selectedRange}
         disabledRanges={disabledRanges}
         defaultMonth={defaultMonth ?? undefined}
+        startMonth={new Date(1900, 1, 1)}
         onUpdateRange={({ from, to }) => {
           setSubmitState('enabled');
           setValidationErrors((prevState) => ({


### PR DESCRIPTION
# Changelog
Mini change, requested by a customer who wants to present historical projects around real estate.

## Changed
- The phase start and end dates can now be set all the way back to 1900
