### PR TITLE
Fix liquid error with the basket not submitted campaign.

### DIFF
--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/voting_basket_not_submitted_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/voting_basket_not_submitted_mailer.rb
@@ -11,7 +11,7 @@ module EmailCampaigns
     def substitution_variables
       {
         organizationName: organization_name,
-        contextTitle: event&.context_title_multiloc
+        contextTitle: localize_for_recipient(event&.context_title_multiloc)
       }
     end
 

--- a/back/engines/free/email_campaigns/spec/mailers/voting_basket_not_submitted_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/voting_basket_not_submitted_mailer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe EmailCampaigns::VotingBasketNotSubmittedMailer do
         recipient: recipient,
         event_payload: {
           project_url: Frontend::UrlService.new.model_to_url(project, locale: Locale.new(recipient.locale)),
-          context_title_multiloc: 'Example phase title'
+          context_title_multiloc: { 'en' => 'Example phase title' }
         }
       }
     end


### PR DESCRIPTION
I made the same mistake twice: In the mailer (should have taken a value out of the multiloc) and in the spec (should have been a multiloc instead of a string). This is why the issue could slip through. This then results in substitution errors with Liquid.

Sentry error: https://sentry.hq.citizenlab.co/share/issue/d3d61f2b18a4499ab5200b259be057f7/