### PR TITLE
TAN-5418 Undo temp disabling of email campaign

### DIFF
--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/community_monitor_report.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/community_monitor_report.rb
@@ -101,15 +101,12 @@ module EmailCampaigns
     end
 
     def content_worth_sending?(_)
-      # Temporarily disabling this email campaign until issues
-      # around community monitor report generation are resolved
-      false
-      # return false unless community_monitor_service.phase
+      return false unless community_monitor_service.phase
 
-      # report = community_monitor_service.find_or_create_previous_quarter_report
-      # return false unless report
+      report = community_monitor_service.find_or_create_previous_quarter_report
+      return false unless report
 
-      # true
+      true
     end
 
     def community_monitor_service

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/community_monitor_report_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/community_monitor_report_spec.rb
@@ -76,26 +76,26 @@ RSpec.describe EmailCampaigns::Campaigns::CommunityMonitorReport do
         expect(campaign.send(:content_worth_sending?, {})).to be false
       end
 
-      # it 'returns true and creates a new report when there are responses in the previous quarter' do
-      #   travel_to(Date.parse('2025-04-01')) do
-      #     create(:native_survey_response, project: phase.project, creation_phase: phase, published_at: 2.months.ago)
-      #     expect(ReportBuilder::Report.count).to eq 0
-      #     expect(campaign.send(:content_worth_sending?, {})).to be true
-      #     expect(ReportBuilder::Report.count).to eq 1
-      #     expect(ReportBuilder::Report.first.year).to eq 2025
-      #     expect(ReportBuilder::Report.first.quarter).to eq 1
-      #   end
-      # end
+      it 'returns true and creates a new report when there are responses in the previous quarter' do
+        travel_to(Date.parse('2025-04-01')) do
+          create(:native_survey_response, project: phase.project, creation_phase: phase, published_at: 2.months.ago)
+          expect(ReportBuilder::Report.count).to eq 0
+          expect(campaign.send(:content_worth_sending?, {})).to be true
+          expect(ReportBuilder::Report.count).to eq 1
+          expect(ReportBuilder::Report.first.year).to eq 2025
+          expect(ReportBuilder::Report.first.quarter).to eq 1
+        end
+      end
 
-      # it 'returns true and does not create a new report if one exists for the previous quarter' do
-      #   travel_to(Date.parse('2025-04-01')) do
-      #     create(:native_survey_response, project: phase.project, creation_phase: phase, published_at: 2.months.ago)
-      #     create(:report, name: 'Existing Community Monitor Report', phase: phase, year: 2025, quarter: 1)
-      #     expect(ReportBuilder::Report.count).to eq 1
-      #     expect(campaign.send(:content_worth_sending?, {})).to be true
-      #     expect(ReportBuilder::Report.count).to eq 1
-      #   end
-      # end
+      it 'returns true and does not create a new report if one exists for the previous quarter' do
+        travel_to(Date.parse('2025-04-01')) do
+          create(:native_survey_response, project: phase.project, creation_phase: phase, published_at: 2.months.ago)
+          create(:report, name: 'Existing Community Monitor Report', phase: phase, year: 2025, quarter: 1)
+          expect(ReportBuilder::Report.count).to eq 1
+          expect(campaign.send(:content_worth_sending?, {})).to be true
+          expect(ReportBuilder::Report.count).to eq 1
+        end
+      end
 
       it 'returns false when there are only responses in other quarters' do
         travel_to(Date.parse('2025-04-01')) do


### PR DESCRIPTION
# Changelog
## Changed
- Re-enable email campaign auto-generated community monitor reports
