### PR TITLE
TAN-5408 - Fix images in editable areas, allow images in invite messages

### DIFF
--- a/back/app/models/invite.rb
+++ b/back/app/models/invite.rb
@@ -44,9 +44,14 @@ class Invite < ApplicationRecord
   before_destroy :remove_notifications # Must occur before has_many :notifications (see https://github.com/rails/rails/issues/5205)
   has_many :notifications, dependent: :nullify
 
+  has_many :text_images, as: :imageable, dependent: :destroy
+  accepts_nested_attributes_for :text_images
+
   validates :token, presence: true, uniqueness: true
   validates :invitee, presence: true, uniqueness: true
   validates :send_invite_email, inclusion: [true, false]
+
+  after_save :process_invite_text_images, if: :invite_text
 
   after_destroy :destroy_invitee, if: :pending?
 
@@ -68,10 +73,15 @@ class Invite < ApplicationRecord
     service = SanitizationService.new
     self.invite_text = service.sanitize(
       invite_text,
-      %i[decoration link]
+      %i[decoration link image]
     )
     self.invite_text = service.remove_empty_trailing_tags(invite_text)
     self.invite_text = service.linkify(invite_text)
+  end
+
+  def process_invite_text_images
+    processed_invite_text = TextImageService.new.swap_data_images self.invite_text, field: :invite_text, imageable: self
+    update_column :invite_text, processed_invite_text
   end
 
   def remove_notifications

--- a/back/app/models/invite.rb
+++ b/back/app/models/invite.rb
@@ -51,9 +51,8 @@ class Invite < ApplicationRecord
   validates :invitee, presence: true, uniqueness: true
   validates :send_invite_email, inclusion: [true, false]
 
-  after_save :process_invite_text_images, if: :invite_text
-
   after_destroy :destroy_invitee, if: :pending?
+  after_save :process_invite_text_images, if: :invite_text
 
   private
 
@@ -80,7 +79,7 @@ class Invite < ApplicationRecord
   end
 
   def process_invite_text_images
-    processed_invite_text = TextImageService.new.swap_data_images self.invite_text, field: :invite_text, imageable: self
+    processed_invite_text = TextImageService.new.swap_data_images invite_text, field: :invite_text, imageable: self
     update_column :invite_text, processed_invite_text
   end
 

--- a/back/app/services/content_image_service.rb
+++ b/back/app/services/content_image_service.rb
@@ -62,7 +62,7 @@ class ContentImageService
     return multiloc if multiloc.blank?
     return multiloc if multiloc.values.none? { |encoded_content| could_include_images?(encoded_content) }
 
-    precompute_for_rendering_multiloc multiloc, imageable, field
+    precompute_for_rendering imageable
 
     multiloc.transform_values do |encoded_content|
       render_data_images encoded_content, imageable: imageable, field: field
@@ -72,7 +72,7 @@ class ContentImageService
   # Replaces references to image models in the content by actual image data.
   def render_data_images(encoded_content, imageable: nil, field: nil)
     content = decode_content encoded_content
-    precompute_for_rendering content, imageable, field
+    precompute_for_rendering imageable
 
     image_elements(content).each do |img_elt|
       next if !attribute? img_elt, code_attribute_for_element
@@ -161,9 +161,7 @@ class ContentImageService
     true
   end
 
-  def precompute_for_rendering_multiloc(_multiloc, _imageable, _field); end
-
-  def precompute_for_rendering(content, imageable, field); end
+  def precompute_for_rendering(_imageable); end
 
   def fetch_content_image(code)
     content_image_class.find_by code_attribute_for_model => code

--- a/back/app/services/text_image_service.rb
+++ b/back/app/services/text_image_service.rb
@@ -70,7 +70,7 @@ class TextImageService < ContentImageService
     html_string.include? code_attribute_for_element
   end
 
-  def precompute_for_rendering_multiloc(_multiloc, imageable, _field)
+  def precompute_for_rendering(imageable)
     @precomputed_text_images = imageable.text_images.index_by do |ti|
       ti[code_attribute_for_model]
     end

--- a/back/engines/free/email_campaigns/app/mailers/concerns/email_campaigns/editable_with_preview.rb
+++ b/back/engines/free/email_campaigns/app/mailers/concerns/email_campaigns/editable_with_preview.rb
@@ -75,6 +75,9 @@ module EmailCampaigns
         region_text = I18n.t("#{message_group}.#{override_default_key}", locale: locale.to_s).gsub(/%\{(.*?)}/, '{{\1}}')
       end
 
+      # Render any images that are stored as data in the text.
+      region_text = TextImageService.new.render_data_images(region_text, field: region_key, imageable: campaign) if region[:type] == 'html'
+
       render_liquid_template(
         text: region_text,
         values: values.transform_keys(&:to_s),

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaign.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaign.rb
@@ -186,8 +186,8 @@ module EmailCampaigns
       super || {}
     end
 
-    def lock_enabled?
-      false
+    def can_be_disabled?
+      true
     end
 
     protected

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaign.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaign.rb
@@ -186,6 +186,10 @@ module EmailCampaigns
       super || {}
     end
 
+    def lock_enabled?
+      false
+    end
+
     protected
 
     def set_enabled

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/base_manual.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/base_manual.rb
@@ -67,6 +67,10 @@ module EmailCampaigns
       true
     end
 
+    def can_be_disabled?
+      false
+    end
+
     protected
 
     def unique_campaigns_per_context?

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/invite_received.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/invite_received.rb
@@ -66,7 +66,7 @@ module EmailCampaigns
           inviter_last_name: activity.item.inviter&.last_name,
           invitee_first_name: activity.item.invitee.first_name,
           invitee_last_name: activity.item.invitee.last_name,
-          invite_text: activity.item.invite_text,
+          invite_text: format_invite_text(activity.item),
           activate_invite_url: Frontend::UrlService.new.invite_url(activity.item.token, locale: Locale.new(activity.item.invitee.locale))
         }
       }]
@@ -86,6 +86,23 @@ module EmailCampaigns
 
     def self.recipient_segment_multiloc_key
       'email_campaigns.admin_labels.recipient_segment.user_who_was_invited'
+    end
+
+    def format_invite_text(invite)
+      html = TextImageService.new.render_data_images(invite.invite_text, field: :invite_text, imageable: invite)
+      fix_image_widths(html)
+    end
+
+    # NOTE: Copied from EmailCampaigns::EditableWithPreview
+    def fix_image_widths(html)
+      doc = Nokogiri::HTML.fragment(html)
+      doc.css('img').each do |img|
+        # Set the width to 100% if it's not set.
+        # Otherwise, the image will be displayed at its original size.
+        # This can mess up the layout if the original image is e.g. 4000px wide.
+        img['width'] = '100%' if img['width'].blank?
+      end
+      doc.to_s
     end
   end
 end

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/invite_received.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/invite_received.rb
@@ -38,7 +38,7 @@ module EmailCampaigns
     include Trackable
     include LifecycleStageRestrictable
     include ContentConfigurable
-    include Disableable # Not technically disableable, but this ensures that it is locked to enabled.
+    include Disableable # This campaign is not actually disableable, but this concern ensures that we are able to see it in the editable campaigns list in the admin panel
     allow_lifecycle_stages except: ['churned']
 
     filter :check_send_invite_email_toggle
@@ -93,8 +93,8 @@ module EmailCampaigns
       'email_campaigns.admin_labels.trigger.user_is_invited_to_platform'
     end
 
-    def lock_enabled?
-      true
+    def can_be_disabled?
+      false
     end
 
     private

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/invite_received.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/invite_received.rb
@@ -38,6 +38,7 @@ module EmailCampaigns
     include Trackable
     include LifecycleStageRestrictable
     include ContentConfigurable
+    include Disableable # Not technically disableable, but this ensures that it is locked to enabled.
     allow_lifecycle_stages except: ['churned']
 
     filter :check_send_invite_email_toggle
@@ -87,6 +88,16 @@ module EmailCampaigns
     def self.recipient_segment_multiloc_key
       'email_campaigns.admin_labels.recipient_segment.user_who_was_invited'
     end
+
+    def self.trigger_multiloc_key
+      'email_campaigns.admin_labels.trigger.user_is_invited_to_platform'
+    end
+
+    def lock_enabled?
+      true
+    end
+
+    private
 
     def format_invite_text(invite)
       return unless invite.invite_text

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/invite_received.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/invite_received.rb
@@ -89,6 +89,8 @@ module EmailCampaigns
     end
 
     def format_invite_text(invite)
+      return unless invite.invite_text
+
       html = TextImageService.new.render_data_images(invite.invite_text, field: :invite_text, imageable: invite)
       fix_image_widths(html)
     end

--- a/back/engines/free/email_campaigns/app/serializers/email_campaigns/web_api/v1/campaign_serializer.rb
+++ b/back/engines/free/email_campaigns/app/serializers/email_campaigns/web_api/v1/campaign_serializer.rb
@@ -3,7 +3,7 @@
 module EmailCampaigns
   class WebApi::V1::CampaignSerializer < ::WebApi::V1::BaseSerializer
     extend GroupOrderingHelper
-    attributes :created_at, :updated_at
+    attributes :created_at, :updated_at, :enabled
 
     attribute :campaign_name do |object|
       object.class.campaign_name
@@ -53,9 +53,10 @@ module EmailCampaigns
       end
     end
 
-    attribute :enabled, if: proc { |object|
-      disableable? object
-    }
+    attribute :lock_enabled do |object|
+      object.lock_enabled?
+    end
+
     attribute :schedule, if: proc { |object|
       schedulable? object
     }

--- a/back/engines/free/email_campaigns/app/serializers/email_campaigns/web_api/v1/campaign_serializer.rb
+++ b/back/engines/free/email_campaigns/app/serializers/email_campaigns/web_api/v1/campaign_serializer.rb
@@ -53,8 +53,8 @@ module EmailCampaigns
       end
     end
 
-    attribute :lock_enabled do |object|
-      object.lock_enabled?
+    attribute :can_be_disabled do |object|
+      object.can_be_disabled?
     end
 
     attribute :schedule, if: proc { |object|

--- a/back/engines/free/email_campaigns/config/locales/en.yml
+++ b/back/engines/free/email_campaigns/config/locales/en.yml
@@ -642,6 +642,7 @@ en:
         user_is_given_admin_rights: 'User is given admin rights'
         user_is_given_folder_moderator_rights: 'User is given folder moderator rights'
         user_is_given_project_moderator_rights: 'User is given project moderator rights'
+        user_is_invited_to_platform: 'User is invited to platform'
         user_is_invited_to_cosponsor_a_proposal: 'User is invited to co-sponsor a proposal'
         user_is_mentioned: 'User is mentioned'
         user_is_mentioned_in_internal_comment: 'User is mentioned in internal comment'

--- a/back/spec/services/content_image_service_spec.rb
+++ b/back/spec/services/content_image_service_spec.rb
@@ -41,7 +41,7 @@ describe ContentImageService do
         :text_reference
       end
 
-      def precompute_for_rendering(_multiloc, _imageable, _field)
+      def precompute_for_rendering(_imageable)
         @precomputed_content_images = content_image_class.all.index_by do |ti|
           ti[code_attribute_for_model]
         end

--- a/front/app/api/campaigns/__mocks__/useCampaigns.ts
+++ b/front/app/api/campaigns/__mocks__/useCampaigns.ts
@@ -6,6 +6,7 @@ export const campaignsData: ICampaignData[] = [
     type: 'campaign',
     attributes: {
       enabled: true,
+      lock_enabled: false,
       sender: 'author',
       reply_to: 'author',
       subject_multiloc: {
@@ -47,6 +48,7 @@ export const campaignsData: ICampaignData[] = [
     type: 'campaign',
     attributes: {
       enabled: true,
+      lock_enabled: false,
       sender: 'author',
       reply_to: 'author',
       subject_multiloc: {

--- a/front/app/api/campaigns/__mocks__/useCampaigns.ts
+++ b/front/app/api/campaigns/__mocks__/useCampaigns.ts
@@ -6,7 +6,7 @@ export const campaignsData: ICampaignData[] = [
     type: 'campaign',
     attributes: {
       enabled: true,
-      lock_enabled: false,
+      can_be_disabled: true,
       sender: 'author',
       reply_to: 'author',
       subject_multiloc: {
@@ -48,7 +48,7 @@ export const campaignsData: ICampaignData[] = [
     type: 'campaign',
     attributes: {
       enabled: true,
-      lock_enabled: false,
+      can_be_disabled: true,
       sender: 'author',
       reply_to: 'author',
       subject_multiloc: {

--- a/front/app/api/campaigns/types.ts
+++ b/front/app/api/campaigns/types.ts
@@ -19,7 +19,7 @@ export interface ICampaignData {
     campaign_description_multiloc: Multiloc;
     // Only undefined for invite_received?
     enabled: boolean;
-    lock_enabled: boolean;
+    can_be_disabled: boolean;
     subject_multiloc: Multiloc;
     body_multiloc: Multiloc;
     title_multiloc?: Multiloc;

--- a/front/app/api/campaigns/types.ts
+++ b/front/app/api/campaigns/types.ts
@@ -18,7 +18,8 @@ export interface ICampaignData {
     campaign_name: CampaignName;
     campaign_description_multiloc: Multiloc;
     // Only undefined for invite_received?
-    enabled?: boolean;
+    enabled: boolean;
+    lock_enabled: boolean;
     subject_multiloc: Multiloc;
     body_multiloc: Multiloc;
     title_multiloc?: Multiloc;

--- a/front/app/components/admin/FormSync/messages.ts
+++ b/front/app/components/admin/FormSync/messages.ts
@@ -10,8 +10,8 @@ export default defineMessages({
     defaultMessage: 'Download as pdf',
   },
   downloadExcelTemplateTooltip: {
-    id: 'app.components.FormSync.downloadExcelTemplateTooltip2',
+    id: 'app.components.FormSync.downloadExcelTemplateTooltip3',
     defaultMessage:
-      'Excel templates will not include Ranking questions, Matrix questions, File upload questions and any mapping input questions (Drop Pin, Draw Route, Draw Area, ESRI file upload) as these are not supported for bulk importing at this time.',
+      'Excel templates will not include File upload questions and any mapping input questions (Drop Pin, Draw Route, Draw Area, ESRI file upload) as these are not supported for bulk importing at this time.',
   },
 });

--- a/front/app/containers/Admin/invitations/invite/InvitationOptions.tsx
+++ b/front/app/containers/Admin/invitations/invite/InvitationOptions.tsx
@@ -262,7 +262,6 @@ const InvitationOptions = ({
             value={selectedInviteText || ''}
             onChange={handleInviteTextOnChange}
             limitedTextFormatting
-            noImages
             noVideos
             withCTAButton
           />

--- a/front/app/containers/Admin/messaging/AutomatedEmails/CampaignRow.tsx
+++ b/front/app/containers/Admin/messaging/AutomatedEmails/CampaignRow.tsx
@@ -69,7 +69,7 @@ const CampaignRow = ({ campaign, context, onClickViewExample }: Props) => {
   const isOutsidePlan =
     !globalFeatureActivated || (context && !contextFeatureActivated);
   const isEditable = !isComingSoon && !isContextDisabled && !isOutsidePlan;
-  const lockEnabled = campaign.attributes.lock_enabled;
+  const canBeDisabled = campaign.attributes.can_be_disabled;
   const handleEditClick = () => {
     if (unpersistedContextCampaign) {
       addCampaign(
@@ -110,7 +110,7 @@ const CampaignRow = ({ campaign, context, onClickViewExample }: Props) => {
         <Toggle
           checked={!!campaign.attributes.enabled}
           onChange={toggleEnabled}
-          disabled={lockEnabled}
+          disabled={!canBeDisabled}
         />
         <CampaignDescription campaign={campaign} />
         <Box display="flex" justifyContent="flex-end" flexGrow={1}>

--- a/front/app/containers/Admin/messaging/AutomatedEmails/CampaignRow.tsx
+++ b/front/app/containers/Admin/messaging/AutomatedEmails/CampaignRow.tsx
@@ -69,6 +69,7 @@ const CampaignRow = ({ campaign, context, onClickViewExample }: Props) => {
   const isOutsidePlan =
     !globalFeatureActivated || (context && !contextFeatureActivated);
   const isEditable = !isComingSoon && !isContextDisabled && !isOutsidePlan;
+  const lockEnabled = campaign.attributes.lock_enabled;
   const handleEditClick = () => {
     if (unpersistedContextCampaign) {
       addCampaign(
@@ -109,6 +110,7 @@ const CampaignRow = ({ campaign, context, onClickViewExample }: Props) => {
         <Toggle
           checked={!!campaign.attributes.enabled}
           onChange={toggleEnabled}
+          disabled={lockEnabled}
         />
         <CampaignDescription campaign={campaign} />
         <Box display="flex" justifyContent="flex-end" flexGrow={1}>

--- a/front/app/containers/Admin/messaging/AutomatedEmails/index.tsx
+++ b/front/app/containers/Admin/messaging/AutomatedEmails/index.tsx
@@ -29,7 +29,6 @@ const AutomatedEmails = () => {
   const { data: campaigns } = useCampaigns({
     withoutCampaignNames: [
       'manual',
-      'invite_received',
       ...(isInternalCommentingEnabled ? [] : internalCommentNotificationTypes),
     ],
     pageSize: 250,

--- a/front/app/translations/admin/ar-SA.json
+++ b/front/app/translations/admin/ar-SA.json
@@ -73,7 +73,6 @@
   "app.components.CommunityMonitorModal.surveyCompletedUntilNextQuarter": "شكرًا لك على إكمال الاستبيان! نرحب بك للمشاركة فيه مجددًا في الربع القادم.",
   "app.components.FormBuilder.components.FormBuilderTopBar.downloadPDF": "تحميل بصيغة pdf",
   "app.components.FormSync.downloadExcelTemplate": "تنزيل قالب Excel",
-  "app.components.FormSync.downloadExcelTemplateTooltip2": "لن تتضمن قوالب Excel أسئلة التصنيف، وأسئلة المصفوفة، وأسئلة تحميل الملفات وأي أسئلة إدخال تعيين (دبوس الإسقاط، مسار الرسم، منطقة الرسم، تحميل ملف ESRI) حيث لا يتم دعم هذه الأسئلة للاستيراد بالجملة في هذا الوقت.",
   "app.components.ProjectTemplatePreview.close": "إغلاق",
   "app.components.ProjectTemplatePreview.createProject": "أنشئ مشروعًا",
   "app.components.ProjectTemplatePreview.createProjectBasedOn2": "إنشاء مشروع بناءً على القالب ''{templateTitle}''",

--- a/front/app/translations/admin/cy-GB.json
+++ b/front/app/translations/admin/cy-GB.json
@@ -73,7 +73,6 @@
   "app.components.CommunityMonitorModal.surveyCompletedUntilNextQuarter": "Diolch am gwblhau'r arolwg! Mae croeso i chi fynd ag e eto'r chwarter nesaf.",
   "app.components.FormBuilder.components.FormBuilderTopBar.downloadPDF": "Lawrlwytho fel pdf",
   "app.components.FormSync.downloadExcelTemplate": "Lawrlwythwch dempled Excel",
-  "app.components.FormSync.downloadExcelTemplateTooltip2": "Ni fydd templedi Excel yn cynnwys cwestiynau Rhestru, cwestiynau Matrics, cwestiynau uwchlwytho ffeiliau ac unrhyw gwestiynau mewnbwn mapio (Gollwng Pin, Lluniadu Llwybr, Lluniadu Ardal, uwchlwytho ffeiliau ESRI) gan nad yw'r rhain yn cael eu cefnogi ar gyfer mewnforio swmp ar hyn o bryd.",
   "app.components.ProjectTemplatePreview.close": "Cau",
   "app.components.ProjectTemplatePreview.createProject": "Creu prosiect",
   "app.components.ProjectTemplatePreview.createProjectBasedOn2": "Creu prosiect yn seiliedig ar y templed ''{templateTitle}''",

--- a/front/app/translations/admin/da-DK.json
+++ b/front/app/translations/admin/da-DK.json
@@ -73,7 +73,6 @@
   "app.components.CommunityMonitorModal.surveyCompletedUntilNextQuarter": "Tak, fordi du gennemførte undersøgelsen! Du er velkommen til at tage den igen næste kvartal.",
   "app.components.FormBuilder.components.FormBuilderTopBar.downloadPDF": "Download som pdf",
   "app.components.FormSync.downloadExcelTemplate": "Download en Excel-skabelon",
-  "app.components.FormSync.downloadExcelTemplateTooltip2": "Excel-skabeloner vil ikke indeholde rangordningsspørgsmål, matrixspørgsmål, spørgsmål om filupload og spørgsmål om kortlægningsinput (Drop Pin, Draw Route, Draw Area, ESRI-filupload), da disse ikke understøttes til bulkimport på nuværende tidspunkt.",
   "app.components.ProjectTemplatePreview.close": "Luk",
   "app.components.ProjectTemplatePreview.createProject": "Opret projekt",
   "app.components.ProjectTemplatePreview.createProjectBasedOn2": "Opret et projekt baseret på skabelonen ''{templateTitle}''.",

--- a/front/app/translations/admin/de-DE.json
+++ b/front/app/translations/admin/de-DE.json
@@ -73,7 +73,6 @@
   "app.components.CommunityMonitorModal.surveyCompletedUntilNextQuarter": "Vielen Dank für die Teilnahme an der Umfrage! Gerne können Sie im nächsten Quartal erneut teilnehmen.",
   "app.components.FormBuilder.components.FormBuilderTopBar.downloadPDF": "Als PDF herunterladen",
   "app.components.FormSync.downloadExcelTemplate": "Download einer Excel-Vorlage",
-  "app.components.FormSync.downloadExcelTemplateTooltip2": "Die Excel-Vorlagen enthalten keine Ranking-Fragen, Matrix-Fragen, Dateiupload-Fragen und keine Fragen mit Kartierung (Pin setzen, Route zeichnen, Gebiet zeichnen, ESRI Datenupload), da diese derzeit für den Import nicht unterstützt werden.",
   "app.components.ProjectTemplatePreview.close": "Schließen",
   "app.components.ProjectTemplatePreview.createProject": "Projekt erstellen",
   "app.components.ProjectTemplatePreview.createProjectBasedOn2": "Erstellen Sie ein Projekt auf der Grundlage der Vorlage ''{templateTitle}''",

--- a/front/app/translations/admin/en-CA.json
+++ b/front/app/translations/admin/en-CA.json
@@ -73,7 +73,6 @@
   "app.components.CommunityMonitorModal.surveyCompletedUntilNextQuarter": "Thank you for completing the survey! You're welcome to take it again next quarter.",
   "app.components.FormBuilder.components.FormBuilderTopBar.downloadPDF": "Download as pdf",
   "app.components.FormSync.downloadExcelTemplate": "Download an Excel template",
-  "app.components.FormSync.downloadExcelTemplateTooltip2": "Excel templates will not include Ranking questions, Matrix questions, File upload questions and any mapping input questions (Drop Pin, Draw Route, Draw Area, ESRI file upload) as these are not supported for bulk importing at this time.",
   "app.components.ProjectTemplatePreview.close": "Close",
   "app.components.ProjectTemplatePreview.createProject": "Create project",
   "app.components.ProjectTemplatePreview.createProjectBasedOn2": "Create a project based on the template ''{templateTitle}''",

--- a/front/app/translations/admin/en-GB.json
+++ b/front/app/translations/admin/en-GB.json
@@ -73,7 +73,6 @@
   "app.components.CommunityMonitorModal.surveyCompletedUntilNextQuarter": "Thank you for completing the survey! You're welcome to take it again next quarter.",
   "app.components.FormBuilder.components.FormBuilderTopBar.downloadPDF": "Download as pdf",
   "app.components.FormSync.downloadExcelTemplate": "Download an Excel template",
-  "app.components.FormSync.downloadExcelTemplateTooltip2": "Excel templates will not include Ranking questions, Matrix questions, File upload questions and any mapping input questions (Drop Pin, Draw Route, Draw Area, ESRI file upload) as these are not supported for bulk importing at this time.",
   "app.components.ProjectTemplatePreview.close": "Close",
   "app.components.ProjectTemplatePreview.createProject": "Create project",
   "app.components.ProjectTemplatePreview.createProjectBasedOn2": "Create a project based on the template ''{templateTitle}''",

--- a/front/app/translations/admin/en-IE.json
+++ b/front/app/translations/admin/en-IE.json
@@ -73,7 +73,6 @@
   "app.components.CommunityMonitorModal.surveyCompletedUntilNextQuarter": "Thank you for completing the survey! You're welcome to take it again next quarter.",
   "app.components.FormBuilder.components.FormBuilderTopBar.downloadPDF": "Download as pdf",
   "app.components.FormSync.downloadExcelTemplate": "Download an Excel template",
-  "app.components.FormSync.downloadExcelTemplateTooltip2": "Excel templates will not include Ranking questions, Matrix questions, File upload questions and any mapping input questions (Drop Pin, Draw Route, Draw Area, ESRI file upload) as these are not supported for bulk importing at this time.",
   "app.components.ProjectTemplatePreview.close": "Close",
   "app.components.ProjectTemplatePreview.createProject": "Create project",
   "app.components.ProjectTemplatePreview.createProjectBasedOn2": "Create a project based on the template ''{templateTitle}''",

--- a/front/app/translations/admin/en.json
+++ b/front/app/translations/admin/en.json
@@ -73,7 +73,7 @@
   "app.components.CommunityMonitorModal.surveyCompletedUntilNextQuarter": "Thank you for completing the survey! You're welcome to take it again next quarter.",
   "app.components.FormBuilder.components.FormBuilderTopBar.downloadPDF": "Download as pdf",
   "app.components.FormSync.downloadExcelTemplate": "Download an Excel template",
-  "app.components.FormSync.downloadExcelTemplateTooltip2": "Excel templates will not include Ranking questions, Matrix questions, File upload questions and any mapping input questions (Drop Pin, Draw Route, Draw Area, ESRI file upload) as these are not supported for bulk importing at this time.",
+  "app.components.FormSync.downloadExcelTemplateTooltip3": "Excel templates will not include File upload questions and any mapping input questions (Drop Pin, Draw Route, Draw Area, ESRI file upload) as these are not supported for bulk importing at this time.",
   "app.components.ProjectTemplatePreview.close": "Close",
   "app.components.ProjectTemplatePreview.createProject": "Create project",
   "app.components.ProjectTemplatePreview.createProjectBasedOn2": "Create a project based on the template ''{templateTitle}''",

--- a/front/app/translations/admin/es-CL.json
+++ b/front/app/translations/admin/es-CL.json
@@ -73,7 +73,6 @@
   "app.components.CommunityMonitorModal.surveyCompletedUntilNextQuarter": "¡Gracias por completar la encuesta! Te invitamos a volver a hacerla el próximo trimestre.",
   "app.components.FormBuilder.components.FormBuilderTopBar.downloadPDF": "Descargar como pdf",
   "app.components.FormSync.downloadExcelTemplate": "Descargar una plantilla Excel",
-  "app.components.FormSync.downloadExcelTemplateTooltip2": "Las plantillas de Excel no incluirán preguntas de clasificación, preguntas de matriz, preguntas de carga de archivos ni preguntas de introducción de datos cartográficos (punto, pinta ruta, pintar área, carga de archivos ESRI), ya que en este momento no son compatibles con la importación masiva.",
   "app.components.ProjectTemplatePreview.close": "Cerrar",
   "app.components.ProjectTemplatePreview.createProject": "Crear proyecto",
   "app.components.ProjectTemplatePreview.createProjectBasedOn2": "Crea un proyecto basado en la plantilla ''{templateTitle}''",

--- a/front/app/translations/admin/es-ES.json
+++ b/front/app/translations/admin/es-ES.json
@@ -73,7 +73,6 @@
   "app.components.CommunityMonitorModal.surveyCompletedUntilNextQuarter": "¡Gracias por completar la encuesta! Te invitamos a volver a hacerla el próximo trimestre.",
   "app.components.FormBuilder.components.FormBuilderTopBar.downloadPDF": "Descargar como pdf",
   "app.components.FormSync.downloadExcelTemplate": "Descargar una plantilla Excel",
-  "app.components.FormSync.downloadExcelTemplateTooltip2": "Las plantillas de Excel no incluirán preguntas de clasificación, preguntas de matriz, preguntas de carga de archivos ni preguntas de introducción de datos cartográficos (punto, pinta ruta, pintar área, carga de archivos ESRI), ya que en este momento no son compatibles con la importación masiva.",
   "app.components.ProjectTemplatePreview.close": "Cerrar",
   "app.components.ProjectTemplatePreview.createProject": "Crear proyecto",
   "app.components.ProjectTemplatePreview.createProjectBasedOn2": "Crea un proyecto basado en la plantilla ''{templateTitle}''",

--- a/front/app/translations/admin/fi-FI.json
+++ b/front/app/translations/admin/fi-FI.json
@@ -73,7 +73,6 @@
   "app.components.CommunityMonitorModal.surveyCompletedUntilNextQuarter": "Kiitos kyselyn täyttämisestä! Voit ottaa sen uudelleen ensi vuosineljänneksellä.",
   "app.components.FormBuilder.components.FormBuilderTopBar.downloadPDF": "Lataa pdf-tiedostona",
   "app.components.FormSync.downloadExcelTemplate": "Lataa Excel-malli",
-  "app.components.FormSync.downloadExcelTemplateTooltip2": "Excel-malleissa ei ole mukana ranking-kysymyksiä, matriisikysymyksiä, tiedostojen latauskysymyksiä tai kartoituskysymyksiä (pudotusnasta, reitin piirtäminen, alueen piirtäminen, ESRI-tiedostojen lataus), koska niitä ei tällä hetkellä tueta joukkotuonnissa.",
   "app.components.ProjectTemplatePreview.close": "kiinni",
   "app.components.ProjectTemplatePreview.createProject": "Luo projekti",
   "app.components.ProjectTemplatePreview.createProjectBasedOn2": "Luo projekti mallin ''{templateTitle}'' pohjalta",

--- a/front/app/translations/admin/fr-BE.json
+++ b/front/app/translations/admin/fr-BE.json
@@ -73,7 +73,6 @@
   "app.components.CommunityMonitorModal.surveyCompletedUntilNextQuarter": "Merci d'avoir complété l'enquête ! N'hésitez pas à y participer à nouveau au prochain trimestre.",
   "app.components.FormBuilder.components.FormBuilderTopBar.downloadPDF": "Télécharger au format PDF",
   "app.components.FormSync.downloadExcelTemplate": "Télécharger un modèle Excel",
-  "app.components.FormSync.downloadExcelTemplateTooltip2": "Les modèles Excel n’incluent pas les questions de classement, les questions matricielles, les questions de téléchargement de fichiers et les questions cartographiques (placer un repère, dessiner un tracé, délimiter une zone, téléchargement de fichier ESRI), car elles ne sont actuellement pas prises en charge pour l’importation en masse.",
   "app.components.ProjectTemplatePreview.close": "Fermer",
   "app.components.ProjectTemplatePreview.createProject": "Créer un projet",
   "app.components.ProjectTemplatePreview.createProjectBasedOn2": "Créer un projet basé sur le modèle ''{templateTitle}''.",

--- a/front/app/translations/admin/fr-FR.json
+++ b/front/app/translations/admin/fr-FR.json
@@ -73,7 +73,6 @@
   "app.components.CommunityMonitorModal.surveyCompletedUntilNextQuarter": "Merci d'avoir complété l'enquête ! N'hésitez pas à y participer à nouveau au prochain trimestre.",
   "app.components.FormBuilder.components.FormBuilderTopBar.downloadPDF": "Télécharger au format PDF",
   "app.components.FormSync.downloadExcelTemplate": "Télécharger un modèle Excel",
-  "app.components.FormSync.downloadExcelTemplateTooltip2": "Les modèles Excel n’incluent pas les questions de classement, les questions matricielles, les questions de téléchargement de fichiers et les questions cartographiques (placer un repère, dessiner un tracé, délimiter une zone, téléchargement de fichier ESRI), car elles ne sont actuellement pas prises en charge pour l’importation en masse.",
   "app.components.ProjectTemplatePreview.close": "Fermer",
   "app.components.ProjectTemplatePreview.createProject": "Créer un projet",
   "app.components.ProjectTemplatePreview.createProjectBasedOn2": "Créer un projet basé sur le modèle ''{templateTitle}''.",

--- a/front/app/translations/admin/hr-HR.json
+++ b/front/app/translations/admin/hr-HR.json
@@ -73,7 +73,6 @@
   "app.components.CommunityMonitorModal.surveyCompletedUntilNextQuarter": "Hvala što ste ispunili anketu! Slobodno ga ponovite sljedećeg kvartala.",
   "app.components.FormBuilder.components.FormBuilderTopBar.downloadPDF": "Preuzmi kao pdf",
   "app.components.FormSync.downloadExcelTemplate": "Preuzmite Excel predložak",
-  "app.components.FormSync.downloadExcelTemplateTooltip2": "Excel predlošci neće uključivati pitanja o rangiranju, matrična pitanja, pitanja o prijenosu datoteka i bilo koja pitanja o unosu mapiranja (Ispuštanje pribadače, Crtanje rute, Crtanje područja, Prijenos ESRI datoteke) jer trenutno nije podržan skupni uvoz.",
   "app.components.ProjectTemplatePreview.close": "Zatvori",
   "app.components.ProjectTemplatePreview.createProject": "Kreiraj projekt",
   "app.components.ProjectTemplatePreview.createProjectBasedOn2": "Izradite projekt na temelju predloška ''{templateTitle}''",

--- a/front/app/translations/admin/lt-LT.json
+++ b/front/app/translations/admin/lt-LT.json
@@ -73,7 +73,6 @@
   "app.components.CommunityMonitorModal.surveyCompletedUntilNextQuarter": "Dėkojame, kad užpildėte apklausą! Kitą ketvirtį kviečiame ją atlikti dar kartą.",
   "app.components.FormBuilder.components.FormBuilderTopBar.downloadPDF": "Atsisiųsti kaip pdf",
   "app.components.FormSync.downloadExcelTemplate": "Atsisiųsti \"Excel\" šabloną",
-  "app.components.FormSync.downloadExcelTemplateTooltip2": "Į \"Excel\" šablonus nebus įtraukti reitingavimo klausimai, matricos klausimai, failų įkėlimo klausimai ir bet kokie žemėlapių įvesties klausimai (\"Drop Pin\", \"Draw Route\", \"Draw Area\", ESRI failų įkėlimas), nes šiuo metu jie nepalaikomi masiniam importui.",
   "app.components.ProjectTemplatePreview.close": "Uždaryti",
   "app.components.ProjectTemplatePreview.createProject": "Sukurti projektą",
   "app.components.ProjectTemplatePreview.createProjectBasedOn2": "Sukurkite projektą pagal šabloną ''{templateTitle}''",

--- a/front/app/translations/admin/lv-LV.json
+++ b/front/app/translations/admin/lv-LV.json
@@ -73,7 +73,6 @@
   "app.components.CommunityMonitorModal.surveyCompletedUntilNextQuarter": "Paldies, ka aizpildījāt aptauju! Esiet laipni aicināti to darīt arī nākamajā ceturksnī.",
   "app.components.FormBuilder.components.FormBuilderTopBar.downloadPDF": "Lejupielādēt kā pdf",
   "app.components.FormSync.downloadExcelTemplate": "Lejupielādēt Excel veidni",
-  "app.components.FormSync.downloadExcelTemplateTooltip2": "Excel veidnēs netiks iekļauti ranga jautājumi, matricas jautājumi, failu augšupielādes jautājumi un kartēšanas ievades jautājumi (Drop Pin, Draw Route, Draw Area, ESRI failu augšupielāde), jo pašlaik tie netiek atbalstīti masveida importēšanai.",
   "app.components.ProjectTemplatePreview.close": "Aizvērt",
   "app.components.ProjectTemplatePreview.createProject": "Izveidot projektu",
   "app.components.ProjectTemplatePreview.createProjectBasedOn2": "Izveidojiet projektu, pamatojoties uz veidni ''{templateTitle}''",

--- a/front/app/translations/admin/nb-NO.json
+++ b/front/app/translations/admin/nb-NO.json
@@ -73,7 +73,6 @@
   "app.components.CommunityMonitorModal.surveyCompletedUntilNextQuarter": "Takk for at du fullførte undersøkelsen! Du er velkommen til å svare på den igjen neste kvartal.",
   "app.components.FormBuilder.components.FormBuilderTopBar.downloadPDF": "Last ned som pdf",
   "app.components.FormSync.downloadExcelTemplate": "Last ned en Excel-mal",
-  "app.components.FormSync.downloadExcelTemplateTooltip2": "Excel-maler inkluderer ikke rangeringsspørsmål, matrisespørsmål, filopplastingsspørsmål og eventuelle kartleggingsspørsmål (Drop Pin, Draw Route, Draw Area, ESRI-filopplasting), ettersom disse ikke støttes for masseimport på nåværende tidspunkt.",
   "app.components.ProjectTemplatePreview.close": "Lukk",
   "app.components.ProjectTemplatePreview.createProject": "Opprett prosjekt",
   "app.components.ProjectTemplatePreview.createProjectBasedOn2": "Opprett et prosjekt basert på malen ''{templateTitle}''",

--- a/front/app/translations/admin/nl-BE.json
+++ b/front/app/translations/admin/nl-BE.json
@@ -73,7 +73,6 @@
   "app.components.CommunityMonitorModal.surveyCompletedUntilNextQuarter": "Bedankt voor het invullen van de vragenlijst! Je bent van harte welkom om hem volgend kwartaal weer in te vullen.",
   "app.components.FormBuilder.components.FormBuilderTopBar.downloadPDF": "Download als pdf",
   "app.components.FormSync.downloadExcelTemplate": "Download een Excel-sjabloon",
-  "app.components.FormSync.downloadExcelTemplateTooltip2": "Excel-sjablonen bevatten geen rangschikkingsvragen, matrixvragen, bestand uploadvragen en kaart-gerelateerde vragen (pin prikken, route tekenen, gebied tekenen, ESRI-bestandsupload) omdat deze op dit moment nog niet worden ondersteund voor bulkimport.",
   "app.components.ProjectTemplatePreview.close": "Sluiten",
   "app.components.ProjectTemplatePreview.createProject": "Maak een project aan",
   "app.components.ProjectTemplatePreview.createProjectBasedOn2": "Maak een project aan op basis van het sjabloon ''{templateTitle}''.",

--- a/front/app/translations/admin/nl-NL.json
+++ b/front/app/translations/admin/nl-NL.json
@@ -73,7 +73,6 @@
   "app.components.CommunityMonitorModal.surveyCompletedUntilNextQuarter": "Bedankt voor het invullen van de vragenlijst! Je bent van harte welkom om hem volgend kwartaal weer in te vullen.",
   "app.components.FormBuilder.components.FormBuilderTopBar.downloadPDF": "Download als pdf",
   "app.components.FormSync.downloadExcelTemplate": "Download een Excel-sjabloon",
-  "app.components.FormSync.downloadExcelTemplateTooltip2": "Excel-sjablonen bevatten geen rangschikkingsvragen, matrixvragen, bestand uploadvragen en kaart-gerelateerde vragen (pin prikken, route tekenen, gebied tekenen, ESRI-bestandsupload) omdat deze op dit moment nog niet worden ondersteund voor bulkimport.",
   "app.components.ProjectTemplatePreview.close": "Sluiten",
   "app.components.ProjectTemplatePreview.createProject": "Maak een project aan",
   "app.components.ProjectTemplatePreview.createProjectBasedOn2": "Maak een project aan op basis van het sjabloon ''{templateTitle}''.",

--- a/front/app/translations/admin/pa-IN.json
+++ b/front/app/translations/admin/pa-IN.json
@@ -73,7 +73,6 @@
   "app.components.CommunityMonitorModal.surveyCompletedUntilNextQuarter": "ਸਰਵੇਖਣ ਨੂੰ ਪੂਰਾ ਕਰਨ ਲਈ ਤੁਹਾਡਾ ਧੰਨਵਾਦ! ਅਗਲੀ ਤਿਮਾਹੀ ਵਿੱਚ ਇਸਨੂੰ ਦੁਬਾਰਾ ਲੈਣ ਲਈ ਤੁਹਾਡਾ ਸਵਾਗਤ ਹੈ।",
   "app.components.FormBuilder.components.FormBuilderTopBar.downloadPDF": "ਪੀਡੀਐਫ ਦੇ ਤੌਰ ਤੇ ਡਾਊਨਲੋਡ ਕਰੋ",
   "app.components.FormSync.downloadExcelTemplate": "ਇੱਕ ਐਕਸਲ ਟੈਂਪਲੇਟ ਡਾਊਨਲੋਡ ਕਰੋ",
-  "app.components.FormSync.downloadExcelTemplateTooltip2": "ਐਕਸਲ ਟੈਂਪਲੇਟਸ ਵਿੱਚ ਰੈਂਕਿੰਗ ਸਵਾਲ, ਮੈਟ੍ਰਿਕਸ ਸਵਾਲ, ਫਾਈਲ ਅਪਲੋਡ ਸਵਾਲ ਅਤੇ ਕੋਈ ਵੀ ਮੈਪਿੰਗ ਇਨਪੁੱਟ ਸਵਾਲ (ਡ੍ਰੌਪ ਪਿੰਨ, ਡਰਾਅ ਰੂਟ, ਡਰਾਅ ਏਰੀਆ, ESRI ਫਾਈਲ ਅਪਲੋਡ) ਸ਼ਾਮਲ ਨਹੀਂ ਹੋਣਗੇ ਕਿਉਂਕਿ ਇਹ ਇਸ ਸਮੇਂ ਥੋਕ ਆਯਾਤ ਲਈ ਸਮਰਥਿਤ ਨਹੀਂ ਹਨ।",
   "app.components.ProjectTemplatePreview.close": "ਬੰਦ ਕਰੋ",
   "app.components.ProjectTemplatePreview.createProject": "ਪ੍ਰੋਜੈਕਟ ਬਣਾਓ",
   "app.components.ProjectTemplatePreview.createProjectBasedOn2": "''{templateTitle}'' ਟੈਂਪਲੇਟ ਦੇ ਆਧਾਰ 'ਤੇ ਇੱਕ ਪ੍ਰੋਜੈਕਟ ਬਣਾਓ।",

--- a/front/app/translations/admin/pl-PL.json
+++ b/front/app/translations/admin/pl-PL.json
@@ -73,7 +73,6 @@
   "app.components.CommunityMonitorModal.surveyCompletedUntilNextQuarter": "Dziękujemy za wypełnienie ankiety! Możesz wziąć w niej udział ponownie w przyszłym kwartale.",
   "app.components.FormBuilder.components.FormBuilderTopBar.downloadPDF": "Pobierz jako pdf",
   "app.components.FormSync.downloadExcelTemplate": "Pobierz szablon Excel",
-  "app.components.FormSync.downloadExcelTemplateTooltip2": "Szablony Excel nie będą zawierać pytań rankingowych, pytań dotyczących macierzy, pytań dotyczących przesyłania plików ani żadnych pytań dotyczących mapowania (Drop Pin, Draw Route, Draw Area, ESRI file upload), ponieważ nie są one obecnie obsługiwane w przypadku importu zbiorczego.",
   "app.components.ProjectTemplatePreview.close": "Zamknij",
   "app.components.ProjectTemplatePreview.createProject": "Stwórz projekt",
   "app.components.ProjectTemplatePreview.createProjectBasedOn2": "Utwórz projekt na podstawie szablonu ''{templateTitle}''",

--- a/front/app/translations/admin/pt-BR.json
+++ b/front/app/translations/admin/pt-BR.json
@@ -73,7 +73,6 @@
   "app.components.CommunityMonitorModal.surveyCompletedUntilNextQuarter": "Obrigado por você ter concluído a pesquisa! Você está convidado a respondê-la novamente no próximo trimestre.",
   "app.components.FormBuilder.components.FormBuilderTopBar.downloadPDF": "Baixar como pdf",
   "app.components.FormSync.downloadExcelTemplate": "Faça o download de um modelo do Excel",
-  "app.components.FormSync.downloadExcelTemplateTooltip2": "Os modelos do Excel não incluirão perguntas de classificação, perguntas de matriz, perguntas de upload de arquivo e perguntas de entrada de mapeamento (Drop Pin, Draw Route, Draw Area, upload de arquivo ESRI), pois elas não são compatíveis com a importação em massa no momento.",
   "app.components.ProjectTemplatePreview.close": "Fechar",
   "app.components.ProjectTemplatePreview.createProject": "Criar um projeto",
   "app.components.ProjectTemplatePreview.createProjectBasedOn2": "Crie um projeto com base no modelo ''{templateTitle}''",

--- a/front/app/translations/admin/sr-Latn.json
+++ b/front/app/translations/admin/sr-Latn.json
@@ -73,7 +73,6 @@
   "app.components.CommunityMonitorModal.surveyCompletedUntilNextQuarter": "Thank you for completing the survey! You're welcome to take it again next quarter.",
   "app.components.FormBuilder.components.FormBuilderTopBar.downloadPDF": "Download as pdf",
   "app.components.FormSync.downloadExcelTemplate": "Download an Excel template",
-  "app.components.FormSync.downloadExcelTemplateTooltip2": "Excel templates will not include Ranking questions, Matrix questions, File upload questions and any mapping input questions (Drop Pin, Draw Route, Draw Area, ESRI file upload) as these are not supported for bulk importing at this time.",
   "app.components.ProjectTemplatePreview.close": "Zatvori",
   "app.components.ProjectTemplatePreview.createProject": "Kreirajte projekat",
   "app.components.ProjectTemplatePreview.createProjectBasedOn2": "Create a project based on the template ''{templateTitle}''",

--- a/front/app/translations/admin/sr-SP.json
+++ b/front/app/translations/admin/sr-SP.json
@@ -73,7 +73,6 @@
   "app.components.CommunityMonitorModal.surveyCompletedUntilNextQuarter": "Thank you for completing the survey! You're welcome to take it again next quarter.",
   "app.components.FormBuilder.components.FormBuilderTopBar.downloadPDF": "Download as pdf",
   "app.components.FormSync.downloadExcelTemplate": "Download an Excel template",
-  "app.components.FormSync.downloadExcelTemplateTooltip2": "Excel templates will not include Ranking questions, Matrix questions, File upload questions and any mapping input questions (Drop Pin, Draw Route, Draw Area, ESRI file upload) as these are not supported for bulk importing at this time.",
   "app.components.ProjectTemplatePreview.close": "Близу",
   "app.components.ProjectTemplatePreview.createProject": "Креирајте пројекат",
   "app.components.ProjectTemplatePreview.createProjectBasedOn2": "Create a project based on the template ''{templateTitle}''",

--- a/front/app/translations/admin/sv-SE.json
+++ b/front/app/translations/admin/sv-SE.json
@@ -73,7 +73,6 @@
   "app.components.CommunityMonitorModal.surveyCompletedUntilNextQuarter": "Tack för att du besvarade enkäten! Du är välkommen att besvara den igen nästa kvartal.",
   "app.components.FormBuilder.components.FormBuilderTopBar.downloadPDF": "Ladda ner som pdf",
   "app.components.FormSync.downloadExcelTemplate": "Ladda ner en Excel-mall",
-  "app.components.FormSync.downloadExcelTemplateTooltip2": "Excel-mallarna innehåller inte frågor om rangordning, matrisfrågor, frågor om filuppladdning och frågor om kartdata (Drop Pin, Draw Route, Draw Area, ESRI-filuppladdning) eftersom dessa inte stöds för bulkimport i nuläget.",
   "app.components.ProjectTemplatePreview.close": "Stäng",
   "app.components.ProjectTemplatePreview.createProject": "Skapa projekt",
   "app.components.ProjectTemplatePreview.createProjectBasedOn2": "Skapa ett projekt baserat på mallen ''{templateTitle}''",

--- a/front/app/translations/admin/tr-TR.json
+++ b/front/app/translations/admin/tr-TR.json
@@ -73,7 +73,6 @@
   "app.components.CommunityMonitorModal.surveyCompletedUntilNextQuarter": "Anketi tamamladığınız için teşekkür ederiz! Önümüzdeki çeyrekte tekrar katılabilirsiniz.",
   "app.components.FormBuilder.components.FormBuilderTopBar.downloadPDF": "Pdf olarak indir",
   "app.components.FormSync.downloadExcelTemplate": "Bir Excel şablonu indirin",
-  "app.components.FormSync.downloadExcelTemplateTooltip2": "Excel şablonları Sıralama sorularını, Matris sorularını, Dosya yükleme sorularını ve herhangi bir harita giriş sorusunu (Drop Pin, Draw Route, Draw Area, ESRI dosya yükleme) içermeyecektir, çünkü bunlar şu anda toplu içe aktarma için desteklenmemektedir.",
   "app.components.ProjectTemplatePreview.close": "Kapat",
   "app.components.ProjectTemplatePreview.createProject": "Proje oluştur",
   "app.components.ProjectTemplatePreview.createProjectBasedOn2": "''{templateTitle}'' şablonuna dayalı bir proje oluşturun",

--- a/front/app/translations/admin/ur-PK.json
+++ b/front/app/translations/admin/ur-PK.json
@@ -73,7 +73,6 @@
   "app.components.CommunityMonitorModal.surveyCompletedUntilNextQuarter": "سروے مکمل کرنے کے لیے آپ کا شکریہ! اگلی سہ ماہی میں اسے دوبارہ لینے کے لیے آپ کا استقبال ہے۔",
   "app.components.FormBuilder.components.FormBuilderTopBar.downloadPDF": "پی ڈی ایف کے طور پر ڈاؤن لوڈ کریں۔",
   "app.components.FormSync.downloadExcelTemplate": "ایکسل ٹیمپلیٹ ڈاؤن لوڈ کریں۔",
-  "app.components.FormSync.downloadExcelTemplateTooltip2": "ایکسل ٹیمپلیٹس میں درجہ بندی کے سوالات، میٹرکس کے سوالات، فائل اپ لوڈ کے سوالات اور کوئی بھی میپنگ ان پٹ سوالات (ڈراپ پن، ڈرا روٹ، ڈرا ایریا، ESRI فائل اپ لوڈ) شامل نہیں ہوں گے کیونکہ یہ اس وقت بلک امپورٹنگ کے لیے تعاون یافتہ نہیں ہیں۔",
   "app.components.ProjectTemplatePreview.close": "بند",
   "app.components.ProjectTemplatePreview.createProject": "پروجیکٹ بنائیں",
   "app.components.ProjectTemplatePreview.createProjectBasedOn2": "ٹیمپلیٹ ''{templateTitle}'' کی بنیاد پر ایک پروجیکٹ بنائیں",


### PR DESCRIPTION
Allow editing of invitation template - new row in automated emails:
<img width="1102" height="352" alt="image" src="https://github.com/user-attachments/assets/7639a597-e0cd-423a-a24e-65775eb3f046" />

Images in email template and invite text:
<img width="751" height="955" alt="image" src="https://github.com/user-attachments/assets/a16280a4-d466-4ff2-a49a-5723f5cb809d" />


Adding images to the invite text:
<img width="446" height="461" alt="image" src="https://github.com/user-attachments/assets/f52a28b5-8e55-47fe-9204-c930f24f8fd8" />


# Changelog
## Fixed
- Fixed images in editable email templates

## Added
- Allowed editing of invite received email template
- Allow images to be added to platform invite message box
