### PR TITLE
Fix inconsistent activerecord version

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -81,7 +81,6 @@ gem 'active_model_serializers', '~> 0.10.15'
 gem 'jwt', '~> 2.8.1'
 gem 'que', '~> 2.3.0'
 
-gem 'activerecord', '~> 7.1.5.2'
 gem 'activerecord-import', '~> 1.7'
 gem 'json-schema', '~> 4.3'
 gem 'activerecord-postgis-adapter', '~> 9.0.2'

--- a/back/Gemfile
+++ b/back/Gemfile
@@ -8,7 +8,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
-gem 'rails', '~> 7.1.5.1'
+gem 'rails', '~> 7.1.5.2'
 gem 'pg', '~> 1.5.6'
 gem 'puma', '~> 6.4.3'
 gem 'bcrypt', '~> 3.1.20' # Use ActiveModel has_secure_password

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -1336,7 +1336,6 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers (~> 0.10.15)
-  activerecord (~> 7.1.5.2)
   activerecord-import (~> 1.7)
   activerecord-postgis-adapter (~> 9.0.2)
   acts_as_list (~> 1.2)

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -1457,7 +1457,7 @@ DEPENDENCIES
   rack-attack (~> 6)
   rack-cors (= 2.0.0)
   rack-mini-profiler
-  rails (~> 7.1.5.1)
+  rails (~> 7.1.5.2)
   rails-i18n (~> 7.0.9)
   rails_semantic_logger
   redcarpet


### PR DESCRIPTION
The version of Activerecord was set as 7.1.5.2. while the Rails version currently is 7.1.5.1.

The reason I made this change is that I ran into some errors with Solargraph/Rubocop integrations with VSCode. In my case Rubocop autocorrect does not seem to work without this fix.

But Rails already comes with Activerecord, so it seems best to not have it explicitly mentioned in the Gemfile (this is what Copilot suggested).
