### PR TITLE
TAN-5452 - Real survey end date in email preview

### DIFF
--- a/back/app/mailers/project_folders/email_campaigns/project_folder_moderation_rights_received_mailer.rb
+++ b/back/app/mailers/project_folders/email_campaigns/project_folder_moderation_rights_received_mailer.rb
@@ -19,7 +19,7 @@ module ProjectFolders
         }
       end
 
-      def preview_command(recipient)
+      def preview_command(recipient, _context)
         data = preview_service.preview_data(recipient)
         {
           recipient: recipient,

--- a/back/engines/commercial/flag_inappropriate_content/app/mailers/flag_inappropriate_content/email_campaigns/inappropriate_content_flagged_mailer.rb
+++ b/back/engines/commercial/flag_inappropriate_content/app/mailers/flag_inappropriate_content/email_campaigns/inappropriate_content_flagged_mailer.rb
@@ -16,7 +16,7 @@ module FlagInappropriateContent
         }
       end
 
-      def preview_command(recipient)
+      def preview_command(recipient, _context)
         data = preview_service.preview_data(recipient)
         {
           recipient: recipient,

--- a/back/engines/commercial/idea_assignment/app/mailers/idea_assignment/email_campaigns/idea_assigned_to_you_mailer.rb
+++ b/back/engines/commercial/idea_assignment/app/mailers/idea_assignment/email_campaigns/idea_assigned_to_you_mailer.rb
@@ -17,7 +17,7 @@ module IdeaAssignment
         }
       end
 
-      def preview_command(recipient)
+      def preview_command(recipient, _context)
         data = preview_service.preview_data(recipient)
         {
           recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/admin_digest_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/admin_digest_mailer.rb
@@ -16,7 +16,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       data = preview_service.preview_data(recipient)
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/admin_rights_received_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/admin_rights_received_mailer.rb
@@ -14,7 +14,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       data = preview_service.preview_data(recipient)
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/assignee_digest_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/assignee_digest_mailer.rb
@@ -16,7 +16,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       data = preview_service.preview_data(recipient)
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/base_internal_comment_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/base_internal_comment_mailer.rb
@@ -16,7 +16,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       @recipient = recipient
       data = preview_service.preview_data(recipient)
       {

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/comment_deleted_by_admin_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/comment_deleted_by_admin_mailer.rb
@@ -14,7 +14,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       data = preview_service.preview_data(recipient)
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/comment_marked_as_spam_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/comment_marked_as_spam_mailer.rb
@@ -17,7 +17,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       data = preview_service.preview_data(recipient)
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/comment_on_idea_you_follow_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/comment_on_idea_you_follow_mailer.rb
@@ -19,7 +19,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       data = preview_service.preview_data(recipient)
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/comment_on_your_comment_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/comment_on_your_comment_mailer.rb
@@ -17,7 +17,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       data = preview_service.preview_data(recipient)
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/community_monitor_report_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/community_monitor_report_mailer.rb
@@ -8,7 +8,7 @@ module EmailCampaigns
       %i[subject_multiloc title_multiloc intro_multiloc button_text_multiloc]
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       {
         recipient: recipient,
         event_payload: {

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/cosponsor_of_your_idea_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/cosponsor_of_your_idea_mailer.rb
@@ -14,7 +14,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       data = preview_service.preview_data(recipient)
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/event_registration_confirmation_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/event_registration_confirmation_mailer.rb
@@ -34,7 +34,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       data = preview_service.preview_data(recipient)
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/idea_marked_as_spam_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/idea_marked_as_spam_mailer.rb
@@ -16,7 +16,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       data = preview_service.preview_data(recipient)
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/idea_published_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/idea_published_mailer.rb
@@ -17,7 +17,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       data = preview_service.preview_data(recipient)
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/invitation_to_cosponsor_idea_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/invitation_to_cosponsor_idea_mailer.rb
@@ -14,7 +14,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       data = preview_service.preview_data(recipient)
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/invite_received_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/invite_received_mailer.rb
@@ -16,7 +16,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       data = preview_service.preview_data(recipient)
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/invite_reminder_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/invite_reminder_mailer.rb
@@ -16,7 +16,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       data = preview_service.preview_data(recipient)
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/mention_in_official_feedback_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/mention_in_official_feedback_mailer.rb
@@ -15,7 +15,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       data = preview_service.preview_data(recipient)
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/moderator_digest_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/moderator_digest_mailer.rb
@@ -16,7 +16,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       @recipient = recipient
       data = preview_service.preview_data(recipient)
       {

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/native_survey_not_submitted_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/native_survey_not_submitted_mailer.rb
@@ -15,14 +15,16 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    # NOTE: This preview uses the phase context when available to render a more realistic preview.
+    def preview_command(recipient, context)
       data = preview_service.preview_data(recipient)
+      context_project_url = context && Frontend::UrlService.new.model_to_url(context.project, locale: Locale.new(recipient.locale))
       {
         recipient: recipient,
         event_payload: {
-          survey_url: data.phase.url,
-          phase_title_multiloc: data.phase.title_multiloc,
-          phase_end_at: Time.now + 10.days
+          survey_url: context ? "#{context_project_url}/ideas/new?phase_id=#{context.id}" : data.phase.url,
+          phase_title_multiloc: context&.title_multiloc || data.phase.title_multiloc,
+          phase_end_at: context ? context.end_at : Time.now + 10.days
         }
       }
     end

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/new_comment_for_admin_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/new_comment_for_admin_mailer.rb
@@ -17,7 +17,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       data = preview_service.preview_data(recipient)
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/new_idea_for_admin_base_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/new_idea_for_admin_base_mailer.rb
@@ -16,7 +16,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       data = preview_service.preview_data(recipient)
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/official_feedback_on_idea_you_follow_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/official_feedback_on_idea_you_follow_mailer.rb
@@ -16,7 +16,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       data = preview_service.preview_data(recipient)
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/project_moderation_rights_received_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/project_moderation_rights_received_mailer.rb
@@ -16,7 +16,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       data = preview_service.preview_data(recipient)
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/project_phase_started_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/project_phase_started_mailer.rb
@@ -16,7 +16,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       data = preview_service.preview_data(recipient)
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/project_phase_upcoming_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/project_phase_upcoming_mailer.rb
@@ -17,7 +17,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       data = preview_service.preview_data(recipient)
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/project_published_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/project_published_mailer.rb
@@ -15,7 +15,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       data = preview_service.preview_data(recipient)
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/project_review_request_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/project_review_request_mailer.rb
@@ -16,7 +16,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       data = preview_service.preview_data(recipient)
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/project_review_state_change_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/project_review_state_change_mailer.rb
@@ -16,7 +16,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       data = preview_service.preview_data(recipient)
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/status_change_on_idea_you_follow_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/status_change_on_idea_you_follow_mailer.rb
@@ -16,7 +16,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       data = preview_service.preview_data(recipient)
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/survey_submitted_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/survey_submitted_mailer.rb
@@ -15,7 +15,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       data = preview_service.preview_data(recipient)
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/threshold_reached_for_admin_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/threshold_reached_for_admin_mailer.rb
@@ -15,7 +15,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       data = preview_service.preview_data(recipient)
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/user_digest_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/user_digest_mailer.rb
@@ -14,7 +14,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       data = preview_service.preview_data(recipient)
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/voting_basket_not_submitted_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/voting_basket_not_submitted_mailer.rb
@@ -15,7 +15,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       data = preview_service.preview_data(recipient)
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/voting_basket_submitted_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/voting_basket_submitted_mailer.rb
@@ -14,7 +14,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       data = preview_service.preview_data(recipient)
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/voting_last_chance_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/voting_last_chance_mailer.rb
@@ -16,7 +16,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       data = preview_service.preview_data(recipient)
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/voting_phase_started_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/voting_phase_started_mailer.rb
@@ -16,7 +16,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       data = preview_service.preview_data(recipient)
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/voting_results_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/voting_results_mailer.rb
@@ -15,7 +15,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       data = preview_service.preview_data(recipient)
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/welcome_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/welcome_mailer.rb
@@ -14,7 +14,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       { recipient: recipient }
     end
   end

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/your_input_in_screening_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/your_input_in_screening_mailer.rb
@@ -16,7 +16,7 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient)
+    def preview_command(recipient, _context)
       data = preview_service.preview_data(recipient)
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/content_configurable.rb
+++ b/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/content_configurable.rb
@@ -50,8 +50,8 @@ module EmailCampaigns
       @editable_regions ||= empty_mailer.editable_regions
     end
 
-    def preview_command(recipient)
-      @preview_command ||= empty_mailer.preview_command(recipient)
+    def preview_command(recipient, context)
+      @preview_command ||= empty_mailer.preview_command(recipient, context)
     end
 
     def substitution_variables

--- a/back/engines/free/email_campaigns/app/services/email_campaigns/delivery_service.rb
+++ b/back/engines/free/email_campaigns/app/services/email_campaigns/delivery_service.rb
@@ -97,7 +97,7 @@ module EmailCampaigns
       commands = if campaign.manual?
         generate_commands(campaign, recipient)
       else
-        [campaign.preview_command(recipient)].compact
+        [campaign.preview_command(recipient, campaign.context)].compact
       end
       return unless commands.any?
 
@@ -110,7 +110,7 @@ module EmailCampaigns
       command = if campaign.manual?
         generate_commands(campaign, recipient).first
       else
-        campaign.preview_command(recipient)
+        campaign.preview_command(recipient, campaign.context)
       end
       return {} unless command
 

--- a/back/engines/free/email_campaigns/lib/email_campaigns.rb
+++ b/back/engines/free/email_campaigns/lib/email_campaigns.rb
@@ -8,7 +8,7 @@ module EmailCampaigns
 
     def preview_campaign_mail(campaign_class)
       campaign = campaign_class.new
-      command = campaign.preview_command(recipient_user)
+      command = campaign.preview_command(recipient_user, nil)
       campaign.mailer_class.with(campaign: campaign, command: command).campaign_mail
     end
 


### PR DESCRIPTION
Not in context:
<img width="479" height="504" alt="image" src="https://github.com/user-attachments/assets/65788910-daba-4ec0-83db-3615acc59f18" />

Same email in phase context:
<img width="589" height="481" alt="image" src="https://github.com/user-attachments/assets/68a47d22-c08f-4510-ad99-5f15d8ca4edf" />

# Changelog
## Changed
- Added real survey title and end date when email is previewed in context
