### PR TITLE
TAN-5463 - Improve translation during project copy

### DIFF
--- a/back/app/services/project_copy_service.rb
+++ b/back/app/services/project_copy_service.rb
@@ -2,7 +2,8 @@
 
 class ProjectCopyService < TemplateService # rubocop:disable Metrics/ClassLength
   def import(template, folder: nil, local_copy: false)
-    same_template = MultiTenancy::Templates::Utils.translate_and_fix_locales(template)
+    # No translation required if it's a local copy
+    same_template = local_copy ? template : MultiTenancy::Templates::Utils.translate_and_fix_locales(template)
 
     created_objects_ids = ActiveRecord::Base.transaction do
       tenant_deserializer.deserialize(same_template, validate: false, local_copy: local_copy)


### PR DESCRIPTION
# Changelog
## Changed
- Improved translation during admin HQ project copy so that ALL unpopulated locales in the destination platform are translated - previously translation would only occur if one locale in destination platform
