### PR TITLE
[TAN-5471] Edit file_attachment_policy to check PM can moderate

### DIFF
--- a/back/app/policies/files/file_attachment_policy.rb
+++ b/back/app/policies/files/file_attachment_policy.rb
@@ -46,7 +46,7 @@ module Files
     private
 
     def active_moderator?(project)
-      return unless active?
+      return false unless active?
 
       UserRoleService.new.can_moderate_project? project, user
     end

--- a/back/app/policies/files/file_attachment_policy.rb
+++ b/back/app/policies/files/file_attachment_policy.rb
@@ -22,7 +22,6 @@ module Files
       return false unless policy_for(record.attachable).update?
 
       # For idea files, the attachment should be created at the same time as the file.
-      # Attaching the file to other resources is not allowed.
       case record.attachable_type
       when 'Idea'
         record.file.new_record?

--- a/back/app/policies/files/file_attachment_policy.rb
+++ b/back/app/policies/files/file_attachment_policy.rb
@@ -23,8 +23,13 @@ module Files
 
       # For idea files, the attachment should be created at the same time as the file.
       # Attaching the file to other resources is not allowed.
-      if record.attachable_type == 'Idea'
+      case record.attachable_type
+      when 'Idea'
         record.file.new_record?
+      when 'Project'
+        active_moderator?(record.attachable)
+      when 'Phase', 'Event'
+        active_moderator?(record.attachable.project)
       else
         policy_for(record.file).update?
       end
@@ -36,6 +41,14 @@ module Files
 
     def destroy?
       policy_for(record.attachable).update?
+    end
+
+    private
+
+    def active_moderator?(project)
+      return unless active?
+
+      UserRoleService.new.can_moderate_project? project, user
     end
   end
 end


### PR DESCRIPTION
Quick fix - tests added in #12089

# Changelog
## Fixed
[TAN-5471] Project moderators can again add file attachments to project, phase or event (in project they manage)
