### PR TITLE
[TAN-5482] Display event attachment filename not URL, if possible

### DIFF
--- a/front/app/containers/Admin/projects/project/events/edit.tsx
+++ b/front/app/containers/Admin/projects/project/events/edit.tsx
@@ -194,12 +194,29 @@ const AdminProjectEventEdit = () => {
     if (!isNilOrError(remoteEventFiles)) {
       (async () => {
         const files = await Promise.all(
-          remoteEventFiles.data.map(
-            async (file) =>
-              await convertUrlToUploadFile(file.attributes.file.url, file.id)
-          )
+          remoteEventFiles.data.map(async (file) => {
+            // Get the original filename from the API
+            const originalFilename = file.attributes.name;
+
+            // Create the uploadFile
+            const uploadFile = await convertUrlToUploadFile(
+              file.attributes.file.url,
+              file.id
+            );
+
+            if (uploadFile && originalFilename) {
+              // Create a new object with all properties from uploadFile,
+              // but override the name property
+              return {
+                ...uploadFile,
+                name: originalFilename,
+              };
+            }
+
+            return uploadFile;
+          })
         );
-        setEventFiles(files as UploadFile[]);
+        setEventFiles(files.filter(Boolean) as UploadFile[]);
       })();
     }
   }, [remoteEventFiles]);


### PR DESCRIPTION
This seems to fix it. Really not sure if this is the 'correct' approach, nor if this issue exists elsewhere (but seems not to exist for phase and project attachments, at least).

Was probably not an issue before we recently introduced file signing, as seems like for event attachments we were displaying last part of URL, which would have matched the filename (or have been close).

# Changelog
## Fixed
- [TAN-5482] Display event attachment filename not URL, if possible
