### PR TITLE
TAN-5463 - Limit inputs in project copy

### DIFF
--- a/back/app/services/project_copy_service.rb
+++ b/back/app/services/project_copy_service.rb
@@ -71,7 +71,7 @@ class ProjectCopyService < TemplateService # rubocop:disable Metrics/ClassLength
     end
 
     if include_ideas
-      limit_num_ideas = max_ideas.is_a?(Integer) && @project.ideas.published.count > max_ideas
+      limit_num_ideas = max_ideas && @project.ideas.published.count > max_ideas
       exported_ideas = limit_num_ideas ? @project.ideas.published.sample(max_ideas) : @project.ideas.published
 
       @template['models']['user']                   = yml_users anonymize_users, exported_ideas, shift_timestamps: shift_timestamps

--- a/back/app/services/project_copy_service.rb
+++ b/back/app/services/project_copy_service.rb
@@ -35,7 +35,7 @@ class ProjectCopyService < TemplateService # rubocop:disable Metrics/ClassLength
     new_publication_status: nil
   )
     include_ideas = false if local_copy
-    max_ideas = max_ideas&.match?(/\A\d+\z/) && max_ideas.to_i.positive? ? max_ideas.to_i : nil
+    max_ideas = max_ideas&.to_i
     @include_ideas = include_ideas
     @local_copy = local_copy
     @project = project

--- a/back/app/services/project_copy_service.rb
+++ b/back/app/services/project_copy_service.rb
@@ -19,7 +19,6 @@ class ProjectCopyService < TemplateService # rubocop:disable Metrics/ClassLength
     project
   end
 
-  # rubocop:disable Metrics/AbcSize
   def export(
     project,
     local_copy: false,
@@ -89,7 +88,6 @@ class ProjectCopyService < TemplateService # rubocop:disable Metrics/ClassLength
 
     @template
   end
-  # rubocop:enable Metrics/AbcSize
 
   private
 

--- a/back/app/services/project_copy_service.rb
+++ b/back/app/services/project_copy_service.rb
@@ -9,8 +9,6 @@ class ProjectCopyService < TemplateService # rubocop:disable Metrics/ClassLength
       tenant_deserializer.deserialize(same_template, validate: false, local_copy: local_copy)
     end
 
-    # TODO: Update basket counts etc?
-
     project = Project.find(created_objects_ids['Project'].first)
     unless local_copy
       project.update!(slug: SlugService.new.generate_slug(project, project.slug))

--- a/back/engines/commercial/admin_api/app/controllers/admin_api/projects_controller.rb
+++ b/back/engines/commercial/admin_api/app/controllers/admin_api/projects_controller.rb
@@ -36,6 +36,7 @@ module AdminApi
     def template_export_params
       params.require(:project).permit(
         :include_ideas,
+        :max_ideas,
         :anonymize_users,
         :translate_content,
         :shift_timestamps,

--- a/back/engines/commercial/admin_api/spec/acceptance/projects_spec.rb
+++ b/back/engines/commercial/admin_api/spec/acceptance/projects_spec.rb
@@ -34,6 +34,7 @@ resource 'Project', admin_api: true do
     parameter :tenant_id, 'The tenant id from which to export the project', required: true
     with_options scope: :project do
       parameter :include_ideas, "Whether to also include the project's ideas, comments, reactions and participants", required: false
+      parameter :max_ideas, 'Maximum number of inputs to export from the project - if used will take a random sample up to the limit', required: false
       parameter :anonymize_users, 'Generate new first and last name, email etc.', required: false
       parameter :translate_content, 'Translate the content to other languages', required: false
       parameter :shift_timestamps, 'Change the timestamps by the specified number of days', required: false

--- a/back/spec/services/project_copy_service_spec.rb
+++ b/back/spec/services/project_copy_service_spec.rb
@@ -355,6 +355,22 @@ describe ProjectCopyService do
       end
     end
 
+    it 'can limit the number of ideas copied' do
+      project = create(:project_with_active_ideation_phase, title_multiloc: { en: 'ENGLISH PROJECT', 'fr-FR': 'FRENCH PROJECT' }, description_multiloc: {})
+      create_list(:idea, 5, project: project, phases: project.phases)
+
+      template = service.export project, anonymize_users: false, include_ideas: true, max_ideas: 2
+
+      # Switch to another platform with different multiple locales
+      tenant = create(:tenant)
+      tenant.switch do
+        create(:idea_status_proposed)
+
+        copied_project = service.import template
+        expect(copied_project.ideas.count).to eq 2
+      end
+    end
+
     context 'with machine translations' do
       before { create(:idea_status, code: 'proposed') }
 


### PR DESCRIPTION
# Changelog
## Changed
- Allow admins to limit the number of inputs copied during project copy in AdminHQ
