### PR TITLE
[TAN-5442] Files::File policy for pms

### DIFF
--- a/back/app/controllers/web_api/v1/files/file_attachments_controller.rb
+++ b/back/app/controllers/web_api/v1/files/file_attachments_controller.rb
@@ -36,7 +36,7 @@ class WebApi::V1::Files::FileAttachmentsController < ApplicationController
     # So we create the association here, by creating a files_projects record, if it doesn't already exist.
     if file_attachment.attachable_type == 'Project' && file_attachment.attachable_id.present?
       Files::FilesProject.find_or_create_by!(
-        file: file_attachment.file, 
+        file: file_attachment.file,
         project_id: file_attachment.attachable_id
       )
 

--- a/back/app/controllers/web_api/v1/files/files_controller.rb
+++ b/back/app/controllers/web_api/v1/files/files_controller.rb
@@ -31,7 +31,9 @@ class WebApi::V1::Files::FilesController < ApplicationController
 
   def create
     file = Files::File.new(create_params)
-    file.files_projects.build(project_id: params[:file][:project])
+    project_id = params.dig(:file, :project)
+
+    file.files_projects.build(project_id: project_id) if project_id.present?
     authorize(file)
 
     side_fx.before_create(file, current_user)

--- a/back/app/policies/files/file_policy.rb
+++ b/back/app/policies/files/file_policy.rb
@@ -26,9 +26,10 @@ module Files
       return true if admin?
 
       # A files_project record is built in the controller #create action, but not yet persisted.
-      project_ids = record.files_projects.filter_map(&:project_id)
-      projects = Project.where(id: project_ids)
-      moderates_all_projects?(projects)
+      # project_ids = record.files_projects.filter_map(&:project_id)
+      # projects = Project.where(id: project_ids)
+      # moderates_all_projects?(projects)
+      true
     end
 
     def update?

--- a/back/app/policies/files/file_policy.rb
+++ b/back/app/policies/files/file_policy.rb
@@ -45,6 +45,8 @@ module Files
 
     def moderates_all_projects?(projects = nil)
       projects ||= record.projects
+
+      puts "Moderates all projects check for user #{user&.id} on projects #{projects.pluck(:id)}"
       return false if projects.blank?
 
       (projects - UserRoleService.new.moderatable_projects(user)).empty?

--- a/back/app/policies/files/file_policy.rb
+++ b/back/app/policies/files/file_policy.rb
@@ -23,13 +23,8 @@ module Files
     def create?
       return false unless active?
       return false unless record.uploader_id == user.id # cannot upload file on behalf of another user
-      return true if admin?
 
-      # A files_project record is built in the controller #create action, but not yet persisted.
-      # project_ids = record.files_projects.filter_map(&:project_id)
-      # projects = Project.where(id: project_ids)
-      # moderates_all_projects?(projects)
-      true
+      !user.normal_user? # Any elevated role can create
     end
 
     def update?

--- a/back/app/policies/files/file_policy.rb
+++ b/back/app/policies/files/file_policy.rb
@@ -38,11 +38,8 @@ module Files
       update?
     end
 
-    def moderates_all_projects?(projects = nil)
-      projects ||= record.projects
-
-      puts "Moderates all projects check for user #{user&.id} on projects #{projects.pluck(:id)}"
-      return false if projects.blank?
+    def moderates_all_projects?
+      return false if record.projects.blank?
 
       (projects - UserRoleService.new.moderatable_projects(user)).empty?
     end

--- a/back/app/policies/files/file_policy.rb
+++ b/back/app/policies/files/file_policy.rb
@@ -29,8 +29,9 @@ module Files
 
     def update?
       return false unless active?
+      return true if admin?
 
-      admin_or_moderator?
+      moderates_all_projects?
     end
 
     def destroy?
@@ -39,6 +40,12 @@ module Files
 
     def admin_or_moderator?
       user.highest_role != 'user'
+    end
+
+    def moderates_all_projects?
+      return false if record.projects.empty?
+
+      (record.projects - UserRoleService.new.moderatable_projects(user)).empty?
     end
   end
 end

--- a/back/app/policies/files/file_policy.rb
+++ b/back/app/policies/files/file_policy.rb
@@ -26,7 +26,7 @@ module Files
       return true if admin?
 
       # A files_project record is built in the controller #create action, but not yet persisted.
-      project_ids = record.files_projects.map(&:project_id).compact
+      project_ids = record.files_projects.filter_map(&:project_id)
       projects = Project.where(id: project_ids)
       moderates_all_projects?(projects)
     end

--- a/back/app/policies/files/file_policy.rb
+++ b/back/app/policies/files/file_policy.rb
@@ -44,7 +44,7 @@ module Files
 
     def moderates_all_projects?(projects = nil)
       projects ||= record.projects
-      return false if projects.empty?
+      return false if projects.blank?
 
       (projects - UserRoleService.new.moderatable_projects(user)).empty?
     end

--- a/back/app/policies/files/file_policy.rb
+++ b/back/app/policies/files/file_policy.rb
@@ -38,8 +38,11 @@ module Files
       update?
     end
 
+    private
+
     def moderates_all_projects?
-      return false if record.projects.blank?
+      project_ids = record.files_projects.filter_map(&:project_id)
+      projects = Project.where(id: project_ids)
 
       (projects - UserRoleService.new.moderatable_projects(user)).empty?
     end

--- a/back/app/policies/files/file_policy.rb
+++ b/back/app/policies/files/file_policy.rb
@@ -24,7 +24,7 @@ module Files
       return false unless active?
       return false unless record.uploader_id == user.id # cannot upload file on behalf of another user
 
-      !user.normal_user? # Any elevated role can create
+      admin? || user.project_or_folder_moderator? # Any elevated role can create
     end
 
     def update?

--- a/back/app/policies/files/file_policy.rb
+++ b/back/app/policies/files/file_policy.rb
@@ -41,9 +41,7 @@ module Files
     private
 
     def moderates_all_projects?
-      project_ids = record.files_projects.filter_map(&:project_id)
-      projects = Project.where(id: project_ids)
-
+      projects = Project.where(id: record.project_ids)
       (projects - UserRoleService.new.moderatable_projects(user)).empty?
     end
   end

--- a/back/app/policies/files/file_policy.rb
+++ b/back/app/policies/files/file_policy.rb
@@ -46,7 +46,7 @@ module Files
       projects ||= record.projects
       return false if projects.empty?
 
-      (record.projects - UserRoleService.new.moderatable_projects(user)).empty?
+      (projects - UserRoleService.new.moderatable_projects(user)).empty?
     end
   end
 end

--- a/back/app/services/files/side_fx_file_attachment_service.rb
+++ b/back/app/services/files/side_fx_file_attachment_service.rb
@@ -2,6 +2,8 @@
 
 module Files
   class SideFxFileAttachmentService < BaseSideFxService
+    private
+
     def resource_name
       :'files/file_attachment'
     end

--- a/back/app/services/files/side_fx_file_attachment_service.rb
+++ b/back/app/services/files/side_fx_file_attachment_service.rb
@@ -2,20 +2,6 @@
 
 module Files
   class SideFxFileAttachmentService < BaseSideFxService
-    def before_create(file_attachment, _current_user)
-      # We permit creation of files_files records before creation of an associated project (i.e. in project create/edit form).
-      # So we create the association here, by creating a files_projects record, if it doesn't already exist.
-      return if file_attachment.attachable_type != 'Project' || file_attachment.attachable_id.nil?
-
-      files_project = Files::FilesProject.find_by(file: file_attachment.file, project_id: file_attachment.attachable_id)
-
-      unless files_project
-        Files::FilesProject.create!(file: file_attachment.file, project_id: file_attachment.attachable_id)
-      end
-    end
-
-    private
-
     def resource_name
       :'files/file_attachment'
     end

--- a/back/app/services/files/side_fx_file_attachment_service.rb
+++ b/back/app/services/files/side_fx_file_attachment_service.rb
@@ -2,10 +2,10 @@
 
 module Files
   class SideFxFileAttachmentService < BaseSideFxService
-    def before_create(file_attachment, current_user)
+    def before_create(file_attachment, _current_user)
       # We permit creation of files_files records before creation of an associated project (i.e. in project create/edit form).
-      # So we create the association here if needed, by creating a files_projects record if it doesn't already exist.
-      return if file_attachment.attachable_type != 'Project' || file_attachment.attachable_id.nil
+      # So we create the association here, by creating a files_projects record, if it doesn't already exist.
+      return if file_attachment.attachable_type != 'Project' || file_attachment.attachable_id.nil?
 
       files_project = Files::FilesProject.find_by(file: file_attachment.file, project_id: file_attachment.attachable_id)
 

--- a/back/app/services/files/side_fx_file_attachment_service.rb
+++ b/back/app/services/files/side_fx_file_attachment_service.rb
@@ -2,6 +2,18 @@
 
 module Files
   class SideFxFileAttachmentService < BaseSideFxService
+    def before_create(file_attachment, current_user)
+      # We permit creation of files_files records before creation of an associated project (i.e. in project create/edit form).
+      # So we create the association here if needed, by creating a files_projects record if it doesn't already exist.
+      return if file_attachment.attachable_type != 'Project' || file_attachment.attachable_id.nil
+
+      files_project = Files::FilesProject.find_by(file: file_attachment.file, project_id: file_attachment.attachable_id)
+
+      unless files_project
+        Files::FilesProject.create!(file: file_attachment.file, project_id: file_attachment.attachable_id)
+      end
+    end
+
     private
 
     def resource_name

--- a/back/spec/policies/files/file_policy_spec.rb
+++ b/back/spec/policies/files/file_policy_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Files::FilePolicy do
 
           it { is_expected.to permit(:show) }
           it { is_expected.to permit(:update) }
-          it { is_expected.not_to permit(:destroy) }
+          it { is_expected.to permit(:destroy) }
         end
       end
 
@@ -71,7 +71,7 @@ RSpec.describe Files::FilePolicy do
           before { file.save! }
 
           it { is_expected.to permit(:show) }
-          it { is_expected.to permit(:update) }
+          it { is_expected.not_to permit(:update) }
           it { is_expected.not_to permit(:destroy) }
         end
       end

--- a/back/spec/policies/files/file_policy_spec.rb
+++ b/back/spec/policies/files/file_policy_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Files::FilePolicy do
         let(:user) { create(:project_moderator, projects: projects) }
         let(:file) { build(:file, uploader: user) }
 
-        it { is_expected.not_to permit(:create) }
+        it { is_expected.to permit(:create) }
 
         context do
           before { file.save! }
@@ -65,7 +65,7 @@ RSpec.describe Files::FilePolicy do
         let(:user) { create(:project_moderator, projects: [projects.first]) }
         let(:file) { build(:file, uploader: user, projects: projects) }
 
-        it { is_expected.not_to permit(:create) }
+        it { is_expected.to permit(:create) }
 
         context do
           before { file.save! }
@@ -80,7 +80,7 @@ RSpec.describe Files::FilePolicy do
         let(:user) { create(:project_moderator, projects: [create(:project)]) }
         let(:file) { build(:file, uploader: user, projects: projects) }
 
-        it { is_expected.not_to permit(:create) }
+        it { is_expected.to permit(:create) }
 
         context do
           before { file.save! }

--- a/front/app/api/files/types.ts
+++ b/front/app/api/files/types.ts
@@ -62,7 +62,6 @@ export interface GetFilesParameters {
   sort?: FileSortOptions;
   search?: string;
   deleted?: boolean;
-  enabled?: boolean;
 }
 
 export interface IFiles {

--- a/front/app/api/files/useDeleteFile.ts
+++ b/front/app/api/files/useDeleteFile.ts
@@ -1,5 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
+import fileAttachmentsKeys from 'api/file_attachments/keys';
+
 import fetcher from 'utils/cl-react-query/fetcher';
 
 import filesKeys from './keys';
@@ -18,6 +20,9 @@ const useDeleteFile = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: filesKeys.lists(),
+      });
+      queryClient.invalidateQueries({
+        queryKey: fileAttachmentsKeys.lists(),
       });
     },
   });

--- a/front/app/api/files/useFiles.ts
+++ b/front/app/api/files/useFiles.ts
@@ -26,7 +26,6 @@ const useFiles = ({
   sort,
   search,
   deleted,
-  enabled = true,
 }: GetFilesParameters) => {
   const queryParameters: QueryParameters = {
     'page[number]': pageNumber ?? 1,
@@ -41,7 +40,7 @@ const useFiles = ({
   return useQuery<IFiles, CLErrors, IFiles, FilesKeys>({
     queryKey: filesKeys.list(queryParameters),
     queryFn: () => fetchFiles(queryParameters),
-    enabled,
+    enabled: project?.length !== 0, // only run if project array is non-empty
   });
 };
 

--- a/front/app/components/UI/FileRepositorySelectAndUpload/components/FileSelectOrUploadModal.tsx
+++ b/front/app/components/UI/FileRepositorySelectAndUpload/components/FileSelectOrUploadModal.tsx
@@ -47,7 +47,6 @@ const FileSelectOrUploadModal = ({
 
   const { data: files } = useFiles({
     project: projectId ? [projectId] : [],
-    enabled: !!projectId,
   });
 
   // Generate options for the file select dropdown

--- a/front/app/components/UI/FileRepositorySelectAndUpload/components/FileSelectOrUploadModal.tsx
+++ b/front/app/components/UI/FileRepositorySelectAndUpload/components/FileSelectOrUploadModal.tsx
@@ -19,7 +19,6 @@ import FileInput from '../../FileUploader/FileInput';
 import messages from './messages';
 
 type Props = {
-  id: string;
   onFileAdd: (fileToAdd: UploadFile) => void;
   onFileAttach?: (fileToAttach: IFileData) => void;
   fileAttachments?: IFileAttachmentData[];
@@ -29,7 +28,6 @@ type Props = {
 };
 
 const FileSelectOrUploadModal = ({
-  id,
   onFileAdd,
   onFileAttach,
   maxSizeMb,
@@ -77,6 +75,7 @@ const FileSelectOrUploadModal = ({
     <>
       <Button
         onClick={() => setModalOpen(true)}
+        id={'e2e-open-file-upload-modal-button'}
         buttonStyle="secondary"
         icon="file-add"
         disabled={isDisabled}
@@ -121,7 +120,7 @@ const FileSelectOrUploadModal = ({
 
           <FileInput
             onAdd={handleFileOnAdd}
-            id={id}
+            id={'e2e-file-upload-input'}
             multiple={false}
             maxSizeMb={maxSizeMb}
             dataCy={dataCy}

--- a/front/app/components/UI/FileRepositorySelectAndUpload/index.tsx
+++ b/front/app/components/UI/FileRepositorySelectAndUpload/index.tsx
@@ -103,7 +103,11 @@ const FileRepositorySelectAndUpload = ({
             : fileAttachment
       );
 
-      onFileReorder?.(fileAttachmentsUpdatedPositions);
+      // Delay the parent callback to break the circular update
+      setTimeout(() => {
+        onFileReorder?.(fileAttachmentsUpdatedPositions);
+      }, 0);
+
       return fileAttachmentsUpdatedPositions;
     });
   };

--- a/front/app/components/UI/FileRepositorySelectAndUpload/index.tsx
+++ b/front/app/components/UI/FileRepositorySelectAndUpload/index.tsx
@@ -122,7 +122,6 @@ const FileRepositorySelectAndUpload = ({
     >
       <FileSelectOrUploadModal
         fileAttachments={fileAttachments}
-        id={id}
         onFileAdd={handleFileOnAdd}
         onFileAttach={handleFileOnAttach}
         maxSizeMb={maxSizeMb}

--- a/front/app/containers/Admin/projects/project/analysis/Insights/Files/FileSelectionView/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Insights/Files/FileSelectionView/index.tsx
@@ -27,7 +27,6 @@ const FileSelectionView = ({ setIsFileSelectionOpen, analysisId }: Props) => {
 
   const { data: files } = useFiles({
     project: projectId ? [projectId] : [],
-    enabled: !!projectId,
   }); // TODO: Add a whitelisting mechanism to only fetch files that can be added to an analysis.
 
   const { formatMessage } = useIntl();

--- a/front/cypress/e2e/admin/projects/project_settings_attachments.cy.ts
+++ b/front/cypress/e2e/admin/projects/project_settings_attachments.cy.ts
@@ -72,19 +72,11 @@ describe('Project attachments settings', () => {
       // Drag "example.txt" (index 1) above "example.pdf" (index 0)
       const dataTransfer = new DataTransfer();
 
-      cy.get('[data-cy="e2e-file-uploader-container"] .files-list')
-        .children()
-        .children()
-        .eq(0)
-        .scrollIntoView()
-        .trigger('dragstart', { dataTransfer });
+      cy.contains('example.txt').trigger('dragstart', { dataTransfer });
 
       cy.wait(2000);
 
-      cy.get('[data-cy="e2e-file-uploader-container"] .files-list')
-        .children()
-        .children()
-        .eq(1)
+      cy.contains('example.pdf')
         .trigger('dragenter', { dataTransfer })
         .trigger('dragover', { dataTransfer })
         .trigger('drop', { dataTransfer });
@@ -108,9 +100,8 @@ describe('Project attachments settings', () => {
         });
 
       // Attach another new file, reorder to top of list and save
-      cy.get('#e2e-project-file-uploader').selectFile(
-        'cypress/fixtures/icon.png'
-      );
+      cy.get('#e2e-open-file-upload-modal-button').click();
+      cy.get('#e2e-file-upload-input').selectFile('cypress/fixtures/icon.png');
       // Wait for the file to be visible
       cy.contains('icon.png').should('be.visible');
 

--- a/front/cypress/e2e/admin/projects/project_settings_attachments.cy.ts
+++ b/front/cypress/e2e/admin/projects/project_settings_attachments.cy.ts
@@ -24,7 +24,7 @@ describe('Project attachments settings', () => {
     it('File attachments can be added, reordered, and saved correctly', () => {
       cy.setConsentAndAdminLoginCookies();
 
-      cy.intercept(`**/projects/${projectId}/files`).as('saveProjectFiles');
+      cy.intercept(`**/files`).as('saveProjectFiles');
 
       // Visit the project settings page
       cy.visit(`admin/projects/${projectId}/settings`);
@@ -34,15 +34,20 @@ describe('Project attachments settings', () => {
       cy.wait(4000);
       cy.scrollTo('bottom');
 
+      // Open the file upload modal
+      cy.get('#e2e-open-file-upload-modal-button').click();
+      cy.get('#e2e-file-upload-input').should('exist');
       // Attach a project file
-      cy.get('#e2e-project-file-uploader').selectFile(
+      cy.get('#e2e-file-upload-input').selectFile(
         'cypress/fixtures/example.pdf'
       );
       // Wait for the file to be visible
       cy.contains('example.pdf').should('be.visible');
 
       // Attach another project file
-      cy.get('#e2e-project-file-uploader').selectFile(
+      cy.get('#e2e-open-file-upload-modal-button').click();
+      cy.get('#e2e-file-upload-input').should('exist');
+      cy.get('#e2e-file-upload-input').selectFile(
         'cypress/fixtures/example.txt'
       );
       // Wait for the file to be visible

--- a/front/cypress/e2e/profile_page.cy.ts
+++ b/front/cypress/e2e/profile_page.cy.ts
@@ -111,6 +111,7 @@ describe('Profile Page', () => {
     // RSVP to event
     cy.get('.e2e-event-attendance-button').should('exist');
     cy.get('.e2e-event-attendance-button').click();
+    cy.wait(1000);
 
     // Go to profile
     cy.visit(`/profile/${newUserName}-${newUserSurname}`);

--- a/front/cypress/e2e/project_description_builder/project_description_builder_toggle.cy.ts
+++ b/front/cypress/e2e/project_description_builder/project_description_builder_toggle.cy.ts
@@ -57,7 +57,7 @@ describe('Project description builder toggle', () => {
 
   it('shows original description by default along with any attachments if project description builder is not used', () => {
     cy.intercept(`**/projects/${projectId}`).as('saveProject');
-    cy.intercept(`**/projects/${projectId}/files`).as('saveProjectFiles');
+    cy.intercept(`**/files`).as('saveProjectFiles');
 
     // Attach a project file
     cy.visit(`admin/projects/${projectId}/settings`);
@@ -98,7 +98,7 @@ describe('Project description builder toggle', () => {
 
   it('shows attachments added to the project after description added using project description builder', () => {
     cy.intercept(`**/projects/${projectId}`).as('saveProject');
-    cy.intercept(`**/projects/${projectId}/files`).as('saveProjectFiles');
+    cy.intercept(`**/files`).as('saveProjectFiles');
     cy.intercept('**/content_builder_layouts/project_description/upsert').as(
       'saveProjectDescriptionBuilder'
     );
@@ -109,12 +109,11 @@ describe('Project description builder toggle', () => {
     cy.scrollTo('bottom');
 
     // Open the file upload modal
+    cy.get('#e2e-open-file-upload-modal-button').should('exist');
     cy.get('#e2e-open-file-upload-modal-button').click();
     cy.get('#e2e-file-upload-input').should('exist');
 
-    cy.dataCy('e2e-file-upload-input').selectFile(
-      'cypress/fixtures/example.pdf'
-    );
+    cy.get('#e2e-file-upload-input').selectFile('cypress/fixtures/example.pdf');
     cy.contains('example.pdf').should('exist');
     cy.wait(2000);
 

--- a/front/cypress/e2e/project_description_builder/project_description_builder_toggle.cy.ts
+++ b/front/cypress/e2e/project_description_builder/project_description_builder_toggle.cy.ts
@@ -64,9 +64,11 @@ describe('Project description builder toggle', () => {
     cy.wait(2000);
     cy.scrollTo('bottom');
 
-    cy.get('#e2e-project-file-uploader').selectFile(
-      'cypress/fixtures/example.pdf'
-    );
+    // Open the file upload modal
+    cy.get('#e2e-open-file-upload-modal-button').click();
+    cy.get('#e2e-file-upload-input').should('exist');
+
+    cy.get('#e2e-file-upload-input').selectFile('cypress/fixtures/example.pdf');
     cy.wait(2000);
 
     // Submit project
@@ -106,8 +108,11 @@ describe('Project description builder toggle', () => {
     cy.wait(2000);
     cy.scrollTo('bottom');
 
-    cy.dataCy('e2e-project-file-uploader').should('exist');
-    cy.dataCy('e2e-project-file-uploader').selectFile(
+    // Open the file upload modal
+    cy.get('#e2e-open-file-upload-modal-button').click();
+    cy.get('#e2e-file-upload-input').should('exist');
+
+    cy.dataCy('e2e-file-upload-input').selectFile(
       'cypress/fixtures/example.pdf'
     );
     cy.contains('example.pdf').should('exist');


### PR DESCRIPTION
## Notes

1. Relaxes `FilePolicy#create?`, so that now any elevated role can create.
2. Removes precondition that `files_file` should be associated with a project when created. This enables creation via the new project form, before the new project has been created (before 'save' is clicked). Obviously this can and will lead to orphaned `files_files` (not associated with anything).
3. Creates appropriate `files_project` record when `file_attachment` created, if no such record exists. This is now needed due to point (2).

I've gone for the more restrictive approach of only allowing Update or Destroy of `Files::File` by a PM if they moderate _all_ projects associated with the file in question. This should be fine for the current implementation, as it seems any file can only be associated with one project atm. (The assumption this approach is best could be wrong: best to check with Adrien when he's back).

Attaching files to events does not work. I haven't worked out exactly why yet, however I note that a `Files::File` is created (if not attaching an existing one), but there is no POST request to `http://localhost:3000/web_api/v1/file_attachments` made (as there is when attaching at a phase or project level).

The changes I recently made ([PR](https://github.com/CitizenLabDotCo/citizenlab/pull/12086/files)) to the `FileAttachmentPolicy` (now on master & production) can probably be reverted, as the changes here should work without them. I think master has not been merged into the branch this PR is pointed at, to pick up those changes, so I couldn't test this yet.

Context: We are now using the new `WebApi::V1::Files::FilesController` for these operations, not `WebApi::V1::FilesController`

## Important

My best guess is this will work fine with legacy files (i.e. files that were attached prior to this change & other recent file related changes), but I cannot be sure.

Because of this, I strongly advise blocking releases and testing thoroughly on staging, including with such legacy file attachments. Especially testing the functionalities for PMs, but also Idea attachments for regular users.

@adessy Probably best if you look over these changes (if they are used), as you may well have had a different variation or approach in mind.