### PR TITLE
CDM: Added strong migrations gem

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -63,6 +63,7 @@ group :development do
   gem 'spring-commands-rspec'
   gem 'spring-watcher-listen', '~> 2.1'
   gem 'annotate'
+  gem 'strong_migrations', '~> 2.5'
 end
 
 group :test do

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -1266,6 +1266,8 @@ GEM
     ssrf_filter (1.2.0)
     stackprof (0.2.26)
     stringio (3.1.2)
+    strong_migrations (2.5.0)
+      activerecord (>= 7.1)
     swd (2.0.2)
       activesupport (>= 3)
       attr_required (>= 0.0.5)
@@ -1498,6 +1500,7 @@ DEPENDENCIES
   spring-commands-rspec
   spring-watcher-listen (~> 2.1)
   stackprof (~> 0.2.26)
+  strong_migrations (~> 2.5)
   surveys!
   test-prof (~> 1.3)
   user_custom_fields!

--- a/back/config/initializers/strong_migrations.rb
+++ b/back/config/initializers/strong_migrations.rb
@@ -1,3 +1,6 @@
+# Exit unless the gem is loaded (i.e. not in development)
+return unless defined?(StrongMigrations)
+
 # Mark existing migrations as safe
 StrongMigrations.start_after = 20250912152550 # rubocop:disable Style/NumericLiterals
 

--- a/back/config/initializers/strong_migrations.rb
+++ b/back/config/initializers/strong_migrations.rb
@@ -1,0 +1,29 @@
+# Mark existing migrations as safe
+StrongMigrations.start_after = 20250912152550 # rubocop:disable Style/NumericLiterals
+
+# Set timeouts for migrations
+# If you use PgBouncer in transaction mode, delete these lines and set timeouts on the database user
+StrongMigrations.lock_timeout = 10.seconds
+StrongMigrations.statement_timeout = 1.hour
+
+# Analyze tables after indexes are added
+# Outdated statistics can sometimes hurt performance
+StrongMigrations.auto_analyze = true
+
+# Set the version of the production database
+# so the right checks are run in development
+# StrongMigrations.target_version = 10
+
+# Add custom checks
+# StrongMigrations.add_check do |method, args|
+#   if method == :add_index && args[0].to_s == "users"
+#     stop! "No more indexes on the users table"
+#   end
+# end
+
+# Remove invalid indexes when rerunning migrations
+# StrongMigrations.remove_invalid_indexes = true
+
+# Make some operations safe by default
+# See https://github.com/ankane/strong_migrations#safe-by-default
+# StrongMigrations.safe_by_default = true


### PR DESCRIPTION
The strong migrations helps identify migrations that could cause deployment issues or block writes on production. This was agreed on during the [CDM](https://www.notion.so/govocal/Back-end-Code-Discussion-Meeting-BE-CDM-a94ef3cfdd9849e4bde22d2b10dcffeb?source=copy_link#22d9663b7b2680aabe0ae8f861025b7f).

I only added the gem to the dev environment, because I don't think it's desired to let it block migrations on production.

Tested locally:
<img width="485" height="130" alt="Screenshot 2025-09-12 at 17 34 38" src="https://github.com/user-attachments/assets/c0fa5be4-bbb7-4233-a5b7-7a3884a47b0e" />
<img width="748" height="463" alt="Screenshot 2025-09-12 at 17 34 57" src="https://github.com/user-attachments/assets/da958509-8795-472d-b7e3-7a8b0c964b23" />

Or you can just ignore the gem error with a `safety_assured` block:
<img width="511" height="109" alt="Screenshot 2025-09-12 at 17 36 05" src="https://github.com/user-attachments/assets/4666f66f-01ea-4258-a212-037c82e6646f" />
