### PR TITLE
TAN-5463 - Reduce translation costs in project copy

### DIFF
--- a/back/app/services/project_copy_service.rb
+++ b/back/app/services/project_copy_service.rb
@@ -21,6 +21,7 @@ class ProjectCopyService < TemplateService # rubocop:disable Metrics/ClassLength
       import_log = ["Copied project: #{project.title_multiloc.values.first}"]
       import_log << "Translated strings: #{translate_logs[:strings]}"
       import_log << "Translated chars: #{translate_logs[:chars]}"
+      import_log << "Models translated - #{translate_logs[:models].map { |k, v| "#{k}: #{v}" }.join(', ')}"
       BulkImportIdeas::ProjectImport.create!(project: project, log: import_log, import_type: 'project_copy')
     end
 
@@ -79,7 +80,7 @@ class ProjectCopyService < TemplateService # rubocop:disable Metrics/ClassLength
       limit_num_ideas = max_ideas && @project.ideas.published.count > max_ideas
       exported_ideas = limit_num_ideas ? @project.ideas.published.sample(max_ideas) : @project.ideas.published
 
-      @template['models']['user']                   = yml_users anonymize_users, exported_ideas, shift_timestamps: shift_timestamps
+      @template['models']['user']                   = yml_users anonymize_users, exported_ideas, limit_num_ideas, shift_timestamps: shift_timestamps
       @template['models']['idea']                   = yml_ideas exported_ideas, shift_timestamps: shift_timestamps
       @template['models']['basket']                 = yml_baskets shift_timestamps: shift_timestamps
       @template['models']['baskets_idea']           = yml_baskets_ideas exported_ideas
@@ -472,7 +473,7 @@ class ProjectCopyService < TemplateService # rubocop:disable Metrics/ClassLength
     end
   end
 
-  def yml_users(anonymize_users, exported_ideas, shift_timestamps: 0)
+  def yml_users(anonymize_users, exported_ideas, limit_num_ideas, shift_timestamps: 0)
     service = AnonymizeUserService.new
     user_ids = []
     idea_ids = exported_ideas.pluck(:id)
@@ -481,13 +482,14 @@ class ProjectCopyService < TemplateService # rubocop:disable Metrics/ClassLength
     user_ids += Comment.where(id: comment_ids).pluck(:author_id)
     reaction_ids = Reaction.where(reactable_id: [idea_ids + comment_ids]).ids
     user_ids += Reaction.where(id: reaction_ids).pluck(:user_id)
-    user_ids += Basket.where(phase: Phase.where(project: @project)).pluck(:user_id)
+    user_ids += Basket.joins(:baskets_ideas).where(baskets_ideas: { idea_id: idea_ids }).pluck(:user_id)
     user_ids += OfficialFeedback.where(idea_id: idea_ids).pluck(:user_id)
-    user_ids += Follower.where(followable_id: ([@project.id] + idea_ids)).pluck(:user_id)
+    user_ids += Follower.where(followable_id: ([@project.id] + idea_ids)).pluck(:user_id) unless limit_num_ideas
     user_ids += Volunteering::Volunteer.where(cause: Volunteering::Cause.where(phase: Phase.where(project: @project))).pluck :user_id
     user_ids += Events::Attendance.where(event: @project.events).pluck :attendee_id
 
-    User.where(id: user_ids.uniq).map do |user|
+    @user_ids = user_ids.uniq # set globally so we can restrict follower export later
+    User.where(id: @user_ids).map do |user|
       yml_user = if anonymize_users
         service.anonymized_attributes AppConfiguration.instance.settings('core', 'locales'), user: user
       else
@@ -752,8 +754,8 @@ class ProjectCopyService < TemplateService # rubocop:disable Metrics/ClassLength
   end
 
   def yml_followers(exported_ideas, shift_timestamps: 0)
-    followers = Follower.where(followable: @project)
-      .or(Follower.where(followable: exported_ideas))
+    followers = Follower.where(followable: @project, user_id: @user_ids)
+      .or(Follower.where(followable: exported_ideas, user_id: @user_ids))
 
     followers.map do |follower|
       {

--- a/back/engines/commercial/admin_api/app/serializers/admin_api/project_serializer.rb
+++ b/back/engines/commercial/admin_api/app/serializers/admin_api/project_serializer.rb
@@ -9,6 +9,7 @@ module AdminApi
       :map_config_id,
       :image_path, # Used by project library
       :visible_to,
+      :ideas_count,
       :created_at,
       :updated_at
 

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/utils.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/utils.rb
@@ -206,7 +206,7 @@ module MultiTenancy
           return [serialized_models, translate_logs] if Set.new(locales_to) == Set.new(template_locales(serialized_models))
 
           # Change unsupported user locales to first target tenant locale.
-          # Only keep the bio if the locale is supported
+          # Only keep the bio if the locale is supported by the target - to reduce translation costs.
           unless Set.new(locales_to) == Set.new(user_locales(serialized_models))
             serialized_models['models']['user']&.each do |attributes|
               unless locales_to.include? attributes['locale']
@@ -218,7 +218,7 @@ module MultiTenancy
 
           # Translate any missing locales from the first locale found.
           serialized_models['models'].each do |model_name, model|
-            next if model_name == 'user' # Users have been handled above and do not translations
+            next if model_name == 'user' # Users have been handled above and do not have translations
 
             model.each do |attributes|
               model_has_been_logged = false


### PR DESCRIPTION
Issue was that all followers were being copied across (not just those relating to the ideas being copied) and their bios translated - which really there is no need to do. I also added some more logging.

related AdminHQ PR: https://github.com/CitizenLabDotCo/cl2-admin/pull/163

# Changelog
## Changed
- Reduced translation costs and increased speed in AdminHQ project copy
