### PR TITLE
TAN-5485 Fix bug with event confirmation emails not arriving

### DIFF
--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/event_registration_confirmation_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/event_registration_confirmation_mailer.rb
@@ -78,14 +78,12 @@ module EmailCampaigns
     end
 
     def event_location
-      location = event_details&.address_1&.to_s
-
+      location = event_details&.address_1
       address_details = localize_for_recipient(event_details&.address_2_multiloc)
-      if address_details.present?
-        location += location.present? ? "\n(#{address_details})" : address_details
-      end
+      return address_details if !location
+      return location if !address_details
 
-      location.presence
+      "#{location}\n(#{address_details})"
     end
 
     def project_title

--- a/back/engines/free/email_campaigns/spec/mailers/event_registration_confirmation_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/event_registration_confirmation_mailer_spec.rb
@@ -156,6 +156,20 @@ RSpec.describe EmailCampaigns::EventRegistrationConfirmationMailer do
         end
       end
 
+      context 'when the event has no first address but has a second address' do
+        before do
+          event_attributes['address_1'] = nil
+          event_attributes['address_2_multiloc'] = { 'en' => 'Democracy centre' }
+        end
+
+        it 'contains location details' do
+          label_div = page.find('div', exact_text: /\s*Location\s*/)
+          location_div = label_div.find('+ div')
+
+          expect(location_div).to have_text('Democracy centre')
+        end
+      end
+
       context 'when the event has no description' do
         before do
           event_attributes['description_multiloc'] = {}


### PR DESCRIPTION
A sneaky bug slipped in when `location = event.event_attributes.address_1.to_s` was changed to `location = event_details&.address_1&.to_s`. This is because `nil&.to_s` results in `nil` instead of the empty string, which can't be added to other strings. I don't think this is a very robust way to deal with missing addresses, so I refactored the `event_location` method while fixing the bug.

Sentry: https://sentry.hq.citizenlab.co/share/issue/35f6b295bf11406eb61e04298d342771/

# Changelog
### Fixed
- [TAN-5485] Event confirmation emails not arriving when the first address is empty and the second address is filled in.
