### PR TITLE
TAN-5503 Fix issue with sentiment linear scale without follow up in sensemaking

### DIFF
--- a/back/engines/commercial/analysis/app/services/analysis/input_to_text.rb
+++ b/back/engines/commercial/analysis/app/services/analysis/input_to_text.rb
@@ -19,7 +19,7 @@ module Analysis
         if field.other_option_text_field
           add_field(field.other_option_text_field, input, obj, truncate_values: truncate_values, override_field_labels: override_field_labels)
         end
-        if field.input_type == 'sentiment_linear_scale'
+        if field.input_type == 'sentiment_linear_scale' && field.follow_up_text_field
           add_field(field.follow_up_text_field, input, obj, truncate_values: truncate_values, override_field_labels: override_field_labels)
         end
       end

--- a/back/engines/commercial/analysis/spec/services/input_to_text_spec.rb
+++ b/back/engines/commercial/analysis/spec/services/input_to_text_spec.rb
@@ -104,6 +104,22 @@ describe Analysis::InputToText do
         'Type your answer' => 'Because none of the above'
       })
     end
+
+    it 'works with a sentiment linear scale field that has no follow-up field' do
+      custom_fields = [
+        build(:custom_field_sentiment_linear_scale, title_multiloc: { en: 'How do you feel about our service?' })
+      ]
+      service = described_class.new(custom_fields)
+      input = build(
+        :idea,
+        custom_field_values: {
+          custom_fields[0].key => 3
+        }
+      )
+      expect(service.execute(input)).to eq({
+        'How do you feel about our service?' => 3
+      })
+    end
   end
 
   describe '#formatted' do


### PR DESCRIPTION
# Changelog
### Fixed
- [TAN-5503] Fix errors in sensemaking when one of the fields of the form is a sentiment linear scale without a follow-up field.
