### PR TITLE
TAN-5361: Fix spacing issue in Visitors timeline widget settings

### DIFF
--- a/front/app/components/admin/ResolutionControl/index.tsx
+++ b/front/app/components/admin/ResolutionControl/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import styled from 'styled-components';
+import { Box } from '@citizenlab/cl2-component-library';
 
 import Tabs from 'components/UI/Tabs';
 
@@ -9,8 +9,6 @@ import { FormattedMessage } from 'utils/cl-intl';
 import messages from './messages';
 
 export type IResolution = 'day' | 'week' | 'month';
-
-const Container = styled.div``;
 
 interface Props {
   value: IResolution;
@@ -35,7 +33,12 @@ const ResolutionControl = ({ value, onChange, className }: Props) => {
   ];
 
   return (
-    <Container className={className}>
+    <Box
+      className={className}
+      pl="1px" // Compensates for Tabs component's margin-left: -1px on first tab to prevent left border cutoff.
+      // We can't remove the -1px margin from Tabs component as it creates seamless borders between tabs
+      // and removing it would cause double borders (2px thick) in all other Tabs usages across the app.
+    >
       <Tabs
         items={resOptions}
         selectedValue={
@@ -43,7 +46,7 @@ const ResolutionControl = ({ value, onChange, className }: Props) => {
         }
         onClick={onChange}
       />
-    </Container>
+    </Box>
   );
 };
 

--- a/front/app/components/admin/ResolutionControl/index.tsx
+++ b/front/app/components/admin/ResolutionControl/index.tsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React from 'react';
 
 import styled from 'styled-components';
 
@@ -18,38 +18,33 @@ interface Props {
   className?: string;
 }
 
-export default class ResolutionControl extends PureComponent<Props> {
-  handleOnResolutionChange = (resolution: IResolution) => {
-    this.props.onChange(resolution);
-  };
+const ResolutionControl = ({ value, onChange, className }: Props) => {
+  const resOptions = [
+    {
+      name: 'day',
+      label: <FormattedMessage {...messages.resolutionday} />,
+    },
+    {
+      name: 'week',
+      label: <FormattedMessage {...messages.resolutionweek} />,
+    },
+    {
+      name: 'month',
+      label: <FormattedMessage {...messages.resolutionmonth} />,
+    },
+  ];
 
-  render() {
-    const { value, className } = this.props;
-    const resOptions = [
-      {
-        name: 'day',
-        label: <FormattedMessage {...messages.resolutionday} />,
-      },
-      {
-        name: 'week',
-        label: <FormattedMessage {...messages.resolutionweek} />,
-      },
-      {
-        name: 'month',
-        label: <FormattedMessage {...messages.resolutionmonth} />,
-      },
-    ];
+  return (
+    <Container className={className}>
+      <Tabs
+        items={resOptions}
+        selectedValue={
+          resOptions.find((item) => item.name === value)?.name as string
+        }
+        onClick={onChange}
+      />
+    </Container>
+  );
+};
 
-    return (
-      <Container className={className}>
-        <Tabs
-          items={resOptions}
-          selectedValue={
-            resOptions.find((item) => item.name === value)?.name as string
-          }
-          onClick={this.handleOnResolutionChange}
-        />
-      </Container>
-    );
-  }
-}
+export default ResolutionControl;


### PR DESCRIPTION
# Changelog

## Fixed
- The "in Days" button in the ResolutionControl component was appearing cut off on the left side when used in the ChartFilters layout. This was particularly visible in the admin dashboard where the ResolutionControl is positioned at the right edge of a flex container. This has been fixed now

Before
<img width="1434" height="893" alt="image" src="https://github.com/user-attachments/assets/89ca8090-7e97-4f50-a4bc-54edc3df2f60" />
After
<img width="1917" height="955" alt="image" src="https://github.com/user-attachments/assets/bbd4f4eb-5c0a-48bf-a9ab-dea9e7a2c2be" />

