### PR TITLE
TAN-5503 Prompts can get too large

### DIFF
--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -26,7 +26,7 @@ PATH
       prime (~> 0.1.3)
       rails (~> 7.0)
       ruby-openai (>= 6.3, < 8.0)
-      tiktoken_ruby (~> 0.0.7)
+      tiktoken_ruby (~> 0.0.12)
 
 PATH
   remote: engines/commercial/analytics
@@ -1277,10 +1277,10 @@ GEM
     thor (1.4.0)
     thread (0.2.2)
     thread_safe (0.3.6)
-    tiktoken_ruby (0.0.11.1-aarch64-linux)
-    tiktoken_ruby (0.0.11.1-arm64-darwin)
-    tiktoken_ruby (0.0.11.1-x86_64-darwin)
-    tiktoken_ruby (0.0.11.1-x86_64-linux)
+    tiktoken_ruby (0.0.12-aarch64-linux)
+    tiktoken_ruby (0.0.12-arm64-darwin)
+    tiktoken_ruby (0.0.12-x86_64-darwin)
+    tiktoken_ruby (0.0.12-x86_64-linux)
     timeout (0.4.3)
     tomlrb (2.0.3)
     trailblazer-option (0.1.2)

--- a/back/engines/commercial/analysis/analysis.gemspec
+++ b/back/engines/commercial/analysis/analysis.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rails', '~> 7.0'
   s.add_dependency 'ruby-openai', '>= 6.3', '< 8.0'
-  s.add_dependency 'tiktoken_ruby', '~> 0.0.7'
+  s.add_dependency 'tiktoken_ruby', '~> 0.0.12'
   s.add_dependency 'concurrent-ruby', '~> 1.2.3'
   s.add_dependency 'distribution', '~> 0.8.0'
   s.add_dependency 'prime', '~> 0.1.3'

--- a/back/engines/commercial/analysis/app/lib/analysis/LLM/azure_open_ai.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/LLM/azure_open_ai.rb
@@ -8,6 +8,25 @@ module Analysis
     class AzureOpenAI < Base
       MAX_RETRIES = 20
 
+      class << self
+        def gpt_model
+          raise NotImplementedError
+        end
+
+        def headroom_ratio
+          0.85
+        end
+
+        # On Azure, each model needs to be deployed separately and given its own
+        # name. To avoid having to introduce an extra deployment_name parameter
+        # per model in our configuration, we derive the deployment name from the
+        # model name, stripping out any characters that are not allowed in Azure
+        # deployment names.
+        def azure_deployment_name
+          gpt_model.gsub(/[^a-zA-Z0-9-]/, '')
+        end
+      end
+
       def initialize(**params)
         super
 
@@ -33,23 +52,6 @@ module Analysis
           yield new_text
         end
         chat_with_retry(**params_with_stream.deep_merge(params))
-      end
-
-      def self.gpt_model
-        raise NotImplementedError
-      end
-
-      def self.headroom_ratio
-        0.85
-      end
-
-      # On Azure, each model needs to be deployed separately and given its own
-      # name. To avoid having to introduce an extra deployment_name parameter
-      # per model in our configuration, we derive the deployment name from the
-      # model name, stripping out any characters that are not allowed in Azure
-      # deployment names.
-      def self.azure_deployment_name
-        gpt_model.gsub(/[^a-zA-Z0-9-]\./, '')
       end
 
       def token_count(str)

--- a/back/engines/commercial/analysis/app/lib/analysis/LLM/azure_open_ai.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/LLM/azure_open_ai.rb
@@ -36,7 +36,7 @@ module Analysis
       end
 
       def self.gpt_model
-        'gpt-4' # raise NotImplementedError Temporarily because sometimes AzureOpenAI is used directly
+        raise NotImplementedError
       end
 
       def self.headroom_ratio

--- a/back/engines/commercial/analysis/app/lib/analysis/LLM/azure_open_ai.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/LLM/azure_open_ai.rb
@@ -6,7 +6,7 @@ require 'tiktoken_ruby'
 module Analysis
   module LLM
     class AzureOpenAI < Base
-      MAX_RETRIES = 2 # 20 Temporarily to make debugging faster
+      MAX_RETRIES = 20
 
       def initialize(**params)
         super

--- a/back/engines/commercial/analysis/app/lib/analysis/LLM/azure_open_ai.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/LLM/azure_open_ai.rb
@@ -39,6 +39,10 @@ module Analysis
         'gpt-4' # raise NotImplementedError Temporarily because sometimes AzureOpenAI is used directly
       end
 
+      def self.headroom_ratio
+        0.85
+      end
+
       # On Azure, each model needs to be deployed separately and given its own
       # name. To avoid having to introduce an extra deployment_name parameter
       # per model in our configuration, we derive the deployment name from the
@@ -48,8 +52,8 @@ module Analysis
         gpt_model.gsub(/[^a-zA-Z0-9-]\./, '')
       end
 
-      def self.token_count(str)
-        enc = Tiktoken.encoding_for_model(gpt_model)
+      def token_count(str)
+        enc = Tiktoken.encoding_for_model(self.class.gpt_model)
         enc.encode(str).size
       end
 

--- a/back/engines/commercial/analysis/app/lib/analysis/LLM/base.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/LLM/base.rb
@@ -15,6 +15,9 @@ module Analysis
         raise NotImplementedError
       end
 
+      # Returns the practical context window size after applying a safety margin.
+      # This prevents hitting rate limits and accounts for system overhead, response tokens,
+      # and tokenization variance that aren't captured in our initial token estimates.
       def usable_context_window
         (context_window * self.class.headroom_ratio).to_i
       end

--- a/back/engines/commercial/analysis/app/lib/analysis/LLM/base.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/LLM/base.rb
@@ -3,12 +3,20 @@
 module Analysis
   module LLM
     class Base
+      def self.headroom_ratio
+        0.9
+      end
+
       def name
         self.class.name.demodulize.underscore
       end
 
       def context_window
         raise NotImplementedError
+      end
+
+      def usable_context_window
+        (context_window * self.class.headroom_ratio).to_i
       end
 
       # Float in 0..1 that denotes how relatively accurate the llm is. 1 would

--- a/back/engines/commercial/analysis/app/lib/analysis/LLM/bedrock.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/LLM/bedrock.rb
@@ -13,7 +13,7 @@ module Analysis
         @client = Aws::BedrockRuntime::Client.new(params)
       end
 
-      def self.token_count(str)
+      def token_count(str)
         # From https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-prepare.html:
         # "Use 6 characters per token as an approximation for the number of tokens."
         (str.size / 6.0).ceil

--- a/back/engines/commercial/analysis/app/lib/analysis/LLM/gpt_41.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/LLM/gpt_41.rb
@@ -4,7 +4,7 @@ module Analysis
   module LLM
     class GPT41 < AzureOpenAI
       def context_window
-        1_000_000
+        1_000_000 # TODO: Apply 0.9 ratio to summary, qanda, and tagging
       end
 
       def enabled?
@@ -15,7 +15,7 @@ module Analysis
         0.8
       end
 
-      def gpt_model
+      def self.gpt_model
         'gpt-4.1'
       end
     end

--- a/back/engines/commercial/analysis/app/lib/analysis/LLM/gpt_41.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/LLM/gpt_41.rb
@@ -4,7 +4,7 @@ module Analysis
   module LLM
     class GPT41 < AzureOpenAI
       def context_window
-        1_000_000 # TODO: Apply 0.9 ratio to summary, qanda, and tagging
+        1_000_000
       end
 
       def enabled?

--- a/back/engines/commercial/analysis/app/lib/analysis/LLM/gpt_4o.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/LLM/gpt_4o.rb
@@ -15,7 +15,7 @@ module Analysis
         0.8
       end
 
-      def gpt_model
+      def self.gpt_model
         'gpt-4o'
       end
     end

--- a/back/engines/commercial/analysis/app/lib/analysis/LLM/gpt_4o_mini.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/LLM/gpt_4o_mini.rb
@@ -15,7 +15,7 @@ module Analysis
         0.6
       end
 
-      def gpt_model
+      def self.gpt_model
         'gpt-4o-mini'
       end
     end

--- a/back/engines/commercial/analysis/app/lib/analysis/auto_tagging_method/nlp_topic.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/auto_tagging_method/nlp_topic.rb
@@ -59,11 +59,11 @@ module Analysis
     def fit_inputs_in_context_window(inputs, project_title)
       prompt = inputs_prompt(inputs, project_title)
       tokens_for_response = TOKENS_PER_TOPIC * max_topics(inputs.size)
-      tokens = LLM::AzureOpenAI.token_count(prompt) + tokens_for_response # The context window is an upper limit on the number of tokens in the prompt + response (the returned topics)
-      exceeded_tokens = tokens - gpt4.context_window
+      tokens = gpt4.token_count(prompt) + tokens_for_response # The context window is an upper limit on the number of tokens in the prompt + response (the returned topics)
+      exceeded_tokens = tokens - gpt4.usable_context_window
       return inputs if exceeded_tokens < 0
 
-      tokens_per_input = (LLM::AzureOpenAI.token_count(input_to_text.format_all(inputs)) / inputs.size.to_f).ceil
+      tokens_per_input = (gpt4.token_count(input_to_text.format_all(inputs)) / inputs.size.to_f).ceil
       inputs_excess = (exceeded_tokens / tokens_per_input.to_f).ceil
       inputs_excess = [inputs_excess, 1].max # Avoid infinite loop
       fit_inputs_in_context_window(inputs.shuffle.drop(inputs_excess), project_title)

--- a/back/engines/commercial/analysis/app/lib/analysis/q_and_a_method/base.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/q_and_a_method/base.rb
@@ -78,12 +78,7 @@ module Analysis
 
     # What is the maximum context window any of the LLMs support?
     def max_context_window
-      enabled_llms.map(&:context_window).max
-    end
-
-    # For now, we assume GPT tokenization for all llms
-    def token_count(str)
-      LLM::AzureOpenAI.token_count(str)
+      enabled_llms.map(&:usable_context_window).max
     end
   end
 end

--- a/back/engines/commercial/analysis/app/lib/analysis/q_and_a_method/one_pass_llm.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/q_and_a_method/one_pass_llm.rb
@@ -33,12 +33,10 @@ module Analysis
         # 6 charachters/token
         next if prompt.size > (max_context_window * 6)
 
-        complete_token_count = token_count(prompt) + TOKENS_FOR_RESPONSE
-
         # Is there an LLM that can handle the prompt size?
         selected_llm = enabled_llms
           .sort_by { |llm| -llm.accuracy }
-          .find { |llm| llm.context_window >= complete_token_count }
+          .find { |llm| llm.usable_context_window >= llm.token_count(prompt) + TOKENS_FOR_RESPONSE }
 
         # If yes, let's define the plan
         if selected_llm

--- a/back/engines/commercial/analysis/app/lib/analysis/summarization_method/base.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/summarization_method/base.rb
@@ -78,12 +78,7 @@ module Analysis
 
     # What is the maximum context window any of the LLMs support?
     def max_context_window
-      enabled_llms.map(&:context_window).max
-    end
-
-    # For now, we assume GPT tokenization for all llms
-    def token_count(str)
-      LLM::AzureOpenAI.token_count(str)
+      enabled_llms.map(&:usable_context_window).max
     end
   end
 end

--- a/back/engines/commercial/analysis/app/lib/analysis/summarization_method/one_pass_llm.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/summarization_method/one_pass_llm.rb
@@ -7,7 +7,7 @@ module Analysis
     SUMMARIZATION_METHOD = 'one_pass_llm'
 
     # The number of tokens we reserve for the LLM response containing the summary
-    TOKENS_FOR_RESPONSE = 600
+    TOKENS_FOR_RESPONSE = 3000 # 1926
 
     def generate_plan
       plan = nil

--- a/back/engines/commercial/analysis/app/lib/analysis/summarization_method/one_pass_llm.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/summarization_method/one_pass_llm.rb
@@ -33,12 +33,10 @@ module Analysis
         # 6 charachters/token
         next if prompt.size > (max_context_window * 6)
 
-        complete_token_count = token_count(prompt) + TOKENS_FOR_RESPONSE
-
         # Which LLM can handle the prompt size?
         selected_llm = enabled_llms
           .sort_by { |llm| -llm.accuracy }
-          .find { |llm| llm.context_window >= complete_token_count }
+          .find { |llm| llm.usable_context_window >= llm.token_count(prompt) + TOKENS_FOR_RESPONSE }
 
         # If any, let's define the plan
         if selected_llm

--- a/back/engines/commercial/analysis/app/lib/analysis/summarization_method/one_pass_llm.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/summarization_method/one_pass_llm.rb
@@ -7,7 +7,7 @@ module Analysis
     SUMMARIZATION_METHOD = 'one_pass_llm'
 
     # The number of tokens we reserve for the LLM response containing the summary
-    TOKENS_FOR_RESPONSE = 3000 # 1926
+    TOKENS_FOR_RESPONSE = 3000
 
     def generate_plan
       plan = nil

--- a/back/engines/commercial/analysis/spec/lib/auto_tagging_task_spec.rb
+++ b/back/engines/commercial/analysis/spec/lib/auto_tagging_task_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe Analysis::AutoTaggingTask do
       it 'recudes the inputs to fit in the context window' do
         stubbed_context_window = 1000
         expect_any_instance_of(Analysis::LLM::GPT41)
-          .to receive(:context_window)
+          .to receive(:usable_context_window)
           .at_least(:once)
           .and_return(stubbed_context_window)
 
@@ -167,11 +167,11 @@ RSpec.describe Analysis::AutoTaggingTask do
 
         # Take token size of the prompt with one input + one returned topic
         ideas = [create(:idea, project: project)]
-        min_size = Analysis::LLM::AzureOpenAI.token_count(model.send(:inputs_prompt, ideas, project.title_multiloc.values.first)) + Analysis::AutoTaggingMethod::NLPTopic::TOKENS_PER_TOPIC
+        min_size = Analysis::LLM::GPT41.new.token_count(model.send(:inputs_prompt, ideas, project.title_multiloc.values.first)) + Analysis::AutoTaggingMethod::NLPTopic::TOKENS_PER_TOPIC
 
         # Check how many more inputs can fit and triple that amount
         remaining_tokens = stubbed_context_window - min_size
-        tokens_per_input = Analysis::LLM::AzureOpenAI.token_count(Analysis::InputToText.new(analysis.associated_custom_fields).format_all(ideas))
+        tokens_per_input = Analysis::LLM::GPT41.new.token_count(Analysis::InputToText.new(analysis.associated_custom_fields).format_all(ideas))
         fit_ideas_count = (remaining_tokens / tokens_per_input.to_f).ceil
         ideas += create_list(:idea, (fit_ideas_count * 3), project: project)
 

--- a/back/engines/commercial/analysis/spec/lib/llm/azure_open_ai_spec.rb
+++ b/back/engines/commercial/analysis/spec/lib/llm/azure_open_ai_spec.rb
@@ -54,4 +54,22 @@ RSpec.describe Analysis::LLM::AzureOpenAI do
       expect(ErrorReporter).not_to have_received :report_msg
     end
   end
+
+  describe 'usable_context_window' do
+    it 'applies headroom ratio to the context window for safety margin' do
+      raw_context_window = 1000
+      stubbed_headroom_ratio = 0.5 # 50% safety margin
+      expected_usable_window = 500
+
+      expect(service)
+        .to receive(:context_window)
+        .and_return(raw_context_window)
+
+      expect(subclass)
+        .to receive(:headroom_ratio)
+        .and_return(stubbed_headroom_ratio)
+
+      expect(service.usable_context_window).to eq(expected_usable_window)
+    end
+  end
 end

--- a/back/engines/commercial/analysis/spec/lib/llm/azure_open_ai_spec.rb
+++ b/back/engines/commercial/analysis/spec/lib/llm/azure_open_ai_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Analysis::LLM::AzureOpenAI do
 
   let(:subclass) do
     Class.new(described_class) do
-      def gpt_model
+      def self.gpt_model
         'gpt-vocal'
       end
     end

--- a/back/lib/cohere_multilingual_embeddings.rb
+++ b/back/lib/cohere_multilingual_embeddings.rb
@@ -7,7 +7,7 @@ class CohereMultilingualEmbeddings
     @client = Aws::BedrockRuntime::Client.new(params)
   end
 
-  def self.token_count(str)
+  def token_count(str)
     # From https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-embed.html:
     # "For optimal performance, we recommend reducing the length of each text to less than 512 tokens. 1 token is about 4 characters."
     (str.size / 4.0).ceil


### PR DESCRIPTION
This PR solves the issues we were running into with Sensemaking for this analysis: https://yourvoice.brighton-hove.gov.uk/en-GB/admin/projects/7cf72086-2d78-475c-b1dd-909d4b2a43ed/analysis/567e5a9d-c404-4b89-85e1-a07e120a4f35?phase_id=faecae52-5ce9-4152-b318-ad13a7daa989. We were running into 429 Too many requests: https://sentry.hq.citizenlab.co/share/issue/fd4a36252f7945e0a98017f4a3560ceb/ and https://sentry.hq.citizenlab.co/share/issue/7d820b2c264c4d4eaace0ef16032fa16/.

The number of tokens of the prompt is 985.000 while the context window of GPT4.1 is 1.000.000, so we didn't expect this to happen, but it's probably no coincidence that these numbers are so close to each other. There are two possible explanations:
1. There could have been previous LLM requests that already used up the remaining tokens.
2. The true number of tokens is usually a bit larger, because the actual prompt is more elaborated ("You are a chatbot... User> ... Assistant> ...") and there can be other optimizations.

The proposed solution is to take 85% of the 1M context window and apply that as the limit.

Other changes:
- The number of tokens is actually slightly different between different GPT versions, so we now use different token encoding models.
- The summaries turn out to be larger than was previously estimated (though not large enough to exceed 1M in this example).

<img width="1912" height="794" alt="Screenshot 2025-09-18 at 18 27 12" src="https://github.com/user-attachments/assets/15ab1a77-a74c-4de3-aaeb-354cd6b13b13" />


# Changelog
### Fixed
- [TAN-5503] Sensemaking for projects with a large amount of inputs. 
