### PR TITLE
TAN-2608 - Update sso auth hash every time we login

### DIFF
--- a/back/app/controllers/omniauth_callback_controller.rb
+++ b/back/app/controllers/omniauth_callback_controller.rb
@@ -93,7 +93,7 @@ class OmniauthCallbackController < ApplicationController
       else # !@user.invite_pending?
         begin
           update_user!(auth, @user, authver_method)
-          @identity.update_auth_hash!(auth, authver_method)
+          update_identity!(auth, @identity, authver_method)
           SideFxUserService.new.after_update(@user, nil)
         rescue ActiveRecord::RecordInvalid => e
           ErrorReporter.report(e)
@@ -223,6 +223,13 @@ class OmniauthCallbackController < ApplicationController
 
     UserService.update_in_sso!(user, user_params, confirm_user)
   end
+
+  # Updates the auth_hash in a users identity to ensure tokens are up to date for logout (mainly for FranceConnect)
+  def update_identity!(auth, identity, authver_method)
+    identity.update_auth_hash!(auth, authver_method)
+  end
+
+  # Determines the locale to set for a user upon signup via SSO.
 
   # Return locale if a locale can be parsed from pathname which matches an app locale
   # and is not the default locale.

--- a/back/app/controllers/omniauth_callback_controller.rb
+++ b/back/app/controllers/omniauth_callback_controller.rb
@@ -93,6 +93,7 @@ class OmniauthCallbackController < ApplicationController
       else # !@user.invite_pending?
         begin
           update_user!(auth, @user, authver_method)
+          @identity.update_auth_hash!(auth, authver_method)
           SideFxUserService.new.after_update(@user, nil)
         rescue ActiveRecord::RecordInvalid => e
           ErrorReporter.report(e)

--- a/back/app/controllers/omniauth_callback_controller.rb
+++ b/back/app/controllers/omniauth_callback_controller.rb
@@ -229,8 +229,6 @@ class OmniauthCallbackController < ApplicationController
     identity.update_auth_hash!(auth, authver_method)
   end
 
-  # Determines the locale to set for a user upon signup via SSO.
-
   # Return locale if a locale can be parsed from pathname which matches an app locale
   # and is not the default locale.
   # If that fails, return the locale returned by the SSO provider.

--- a/back/app/models/identity.rb
+++ b/back/app/models/identity.rb
@@ -43,6 +43,11 @@ class Identity < ApplicationRecord
     end
   end
 
+  def update_auth_hash!(auth, authver_method)
+    auth_to_persist = authver_method.filter_auth_to_persist(auth)
+    update!(auth_hash: auth_to_persist)
+  end
+
   def email_always_present?
     AuthenticationService.all_methods.fetch(provider).email_always_present?
   end

--- a/back/engines/commercial/id_franceconnect/spec/requests/franceconnect_verification_spec.rb
+++ b/back/engines/commercial/id_franceconnect/spec/requests/franceconnect_verification_spec.rb
@@ -4,12 +4,10 @@ require 'rails_helper'
 require 'rspec_api_documentation/dsl'
 
 describe 'franceconnect verification' do
-  before do
-    OmniAuth.config.test_mode = true
-    OmniAuth.config.mock_auth[:franceconnect] = OmniAuth::AuthHash.new(
-      { 'provider' => 'franceconnect',
-        'uid' => 'cfdbc2447d7a579dd48bc67e43ef44a03c208cb8c218450168cfc3ba89f502f6v1',
-        'info' =>
+  let(:auth_hash) do
+    { 'provider' => 'franceconnect',
+      'uid' => 'cfdbc2447d7a579dd48bc67e43ef44a03c208cb8c218450168cfc3ba89f502f6v1',
+      'info' =>
         { 'name' => nil,
           'email' => 'wossewodda-3728@yopmail.com',
           'nickname' => '',
@@ -19,30 +17,34 @@ describe 'franceconnect verification' do
           'image' => nil,
           'phone' => nil,
           'urls' => { 'website' => nil } },
-        'credentials' =>
+      'credentials' =>
         { 'id_token' =>
-          'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2ZjcC5pbnRlZzAxLmRldi1mcmFuY2Vjb25uZWN0LmZyIiwic3ViIjoiY2ZkYmMyNDQ3ZDdhNTc5ZGQ0OGJjNjdlNDNlZjQ0YTAzYzIwOGNiOGMyMTg0NTAxNjhjZmMzYmE4OWY1MDJmNnYxIiwiYXVkIjoiMGI4YmEwZjlhMjNmMTZiY2JkODZjNzgzYjJhNDFmZDBjZWYwZWE5NjhlMjUzNzM0ZGU3MWY2NDFlMGU2NjA1NyIsImV4cCI6MTU3MzczMTMxOSwiaWF0IjoxNTczNzMxMjU5LCJub25jZSI6ImE1ZjgwOWM1MTQ0MTVkMDEyMGRjNmJkZGRiZTgxMWYwIiwiaWRwIjoiRkMiLCJhY3IiOiJlaWRhczEiLCJhbXIiOm51bGx9.sa9WM_VBsMb0Rku6KTg6Pk90UBmP46bnOABojcw0cYM',
+            'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2ZjcC5pbnRlZzAxLmRldi1mcmFuY2Vjb25uZWN0LmZyIiwic3ViIjoiY2ZkYmMyNDQ3ZDdhNTc5ZGQ0OGJjNjdlNDNlZjQ0YTAzYzIwOGNiOGMyMTg0NTAxNjhjZmMzYmE4OWY1MDJmNnYxIiwiYXVkIjoiMGI4YmEwZjlhMjNmMTZiY2JkODZjNzgzYjJhNDFmZDBjZWYwZWE5NjhlMjUzNzM0ZGU3MWY2NDFlMGU2NjA1NyIsImV4cCI6MTU3MzczMTMxOSwiaWF0IjoxNTczNzMxMjU5LCJub25jZSI6ImE1ZjgwOWM1MTQ0MTVkMDEyMGRjNmJkZGRiZTgxMWYwIiwiaWRwIjoiRkMiLCJhY3IiOiJlaWRhczEiLCJhbXIiOm51bGx9.sa9WM_VBsMb0Rku6KTg6Pk90UBmP46bnOABojcw0cYM',
           'token' => '535a2da9-98a9-4888-8c0a-fea052b51f04',
           'refresh_token' => nil,
           'expires_in' => 60,
           'scope' => nil },
-        'extra' =>
+      'extra' =>
         { 'raw_info' =>
-          { 'sub' =>
-            'cfdbc2447d7a579dd48bc67e43ef44a03c208cb8c218450168cfc3ba89f502f6v1',
-            'given_name' => 'Angela Claire Louise',
-            'family_name' => 'DUBOIS',
-            'gender' => 'female',
-            'birthdate' => '1962-08-24',
-            'preferred_username' => '',
-            'email' => 'wossewodda-3728@yopmail.com',
-            'address' =>
-            { 'country' => 'France',
-              'formatted' => 'France Paris 75107 20 avenue de Ségur',
-              'locality' => 'Paris',
-              'postal_code' => '75107',
-              'street_address' => '20 avenue de Ségur' } } } }
-    )
+            { 'sub' =>
+                'cfdbc2447d7a579dd48bc67e43ef44a03c208cb8c218450168cfc3ba89f502f6v1',
+              'given_name' => 'Angela Claire Louise',
+              'family_name' => 'DUBOIS',
+              'gender' => 'female',
+              'birthdate' => '1962-08-24',
+              'preferred_username' => '',
+              'email' => 'wossewodda-3728@yopmail.com',
+              'address' =>
+                { 'country' => 'France',
+                  'formatted' => 'France Paris 75107 20 avenue de Ségur',
+                  'locality' => 'Paris',
+                  'postal_code' => '75107',
+                  'street_address' => '20 avenue de Ségur' } } } }
+  end
+
+  before do
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:franceconnect] = OmniAuth::AuthHash.new(auth_hash)
 
     configuration = AppConfiguration.instance
     settings = configuration.settings
@@ -111,5 +113,24 @@ describe 'franceconnect verification' do
       user_id: user.id,
       active: true
     })
+  end
+
+  it 'successfully authenticates a user that was previously authenticated and updates the auth_hash' do
+    get '/auth/franceconnect'
+    follow_redirect!
+    user = User.order(created_at: :asc).last
+    expect(user.identities.first).to have_attributes({
+      provider: 'franceconnect',
+      user_id: user.id
+    })
+    expect(user.identities.first.auth_hash['info']['gender']).to eq 'female'
+
+    # Change the auth hash so we can check that is is updated
+    auth_hash['info']['gender'] = 'male'
+    OmniAuth.config.mock_auth[:franceconnect] = OmniAuth::AuthHash.new(auth_hash)
+
+    get '/auth/franceconnect'
+    follow_redirect!
+    expect(user.identities.first.auth_hash['info']['gender']).to eq 'male'
   end
 end

--- a/back/spec/acceptance/omniauth_callback_spec.rb
+++ b/back/spec/acceptance/omniauth_callback_spec.rb
@@ -47,6 +47,7 @@ def mock_omniauth_callback_controller(auth_service_mock)
   # Mock other methods
   allow_any_instance_of(OmniauthCallbackController).to receive(:authentication_service).and_return(auth_service_mock)
   allow_any_instance_of(OmniauthCallbackController).to receive(:update_user!).and_return(true)
+  allow_any_instance_of(OmniauthCallbackController).to receive(:update_identity!).and_return(true)
   allow_any_instance_of(OmniauthCallbackController).to receive(:verified_for_sso?).and_return(true)
   allow_any_instance_of(OmniauthCallbackController).to receive(:signin_success_redirect)
 end


### PR DESCRIPTION
`auth_hash` in `Identity` was not being updated each time the user logged in and therefore old access tokens were being sent to FranceConnect on logout, causing an error.

# Changelog
## Fixed
- Update SSO auth hash every time SSO logs in. Solves a logout issue on FranceConnect
