### PR TITLE
TAN-5534 Log publication changes on project update

### DIFF
--- a/back/app/services/side_fx_project_service.rb
+++ b/back/app/services/side_fx_project_service.rb
@@ -55,6 +55,9 @@ class SideFxProjectService
 
   def after_update(project, user)
     change = project.saved_changes
+    if project.admin_publication.publication_status != @publication_status_was
+      change['publication_status'] = [@publication_status_was, project.admin_publication.publication_status]
+    end
     payload = { project: clean_time_attributes(project.attributes) }
     payload[:change] = sanitize_change(change) if change.present?
 


### PR DESCRIPTION
We received reports from a customer that the project published email was sent out multiple times, even though they say they didn't change the publication status. After investigating, I couldn't reproduce this and strongly suspect that they might have changed the publication status after all (the changed activity includes an empty change hash).

We agreed to add logging for the publication status changes so we can be certain that the publication status was changed next time this issue is being reported.