### PR TITLE
[TAN-5537] Do not include admins with email: nil in not_citizenlab_member scope

### DIFF
--- a/back/app/models/concerns/user_roles.rb
+++ b/back/app/models/concerns/user_roles.rb
@@ -81,7 +81,12 @@ module UserRoles # rubocop:disable Metrics/ModuleLength
 
     # https://www.postgresql.org/docs/12/functions-matching.html#FUNCTIONS-POSIX-REGEXP
     scope :citizenlab_member, -> { where('email ~* ?', CITIZENLAB_MEMBER_REGEX_CONTENT).or(where('email ~* ?', GOVOCAL_MEMBER_REGEX_CONTENT)) }
-    scope :not_citizenlab_member, -> { where.not('email ~* ?', CITIZENLAB_MEMBER_REGEX_CONTENT).and(where.not('email ~* ?', GOVOCAL_MEMBER_REGEX_CONTENT)) }
+    scope :not_citizenlab_member, -> {
+      where.not('email ~* ?', CITIZENLAB_MEMBER_REGEX_CONTENT)
+        .and(where.not('email ~* ?', GOVOCAL_MEMBER_REGEX_CONTENT))
+        .where.not(email: nil)
+    }
+
     scope :billed_admins, -> { admin.not_citizenlab_member }
     scope :billed_moderators, lambda {
       # use any conditions before `or` very carefully (inspect the generated SQL)

--- a/back/app/models/concerns/user_roles.rb
+++ b/back/app/models/concerns/user_roles.rb
@@ -81,11 +81,11 @@ module UserRoles # rubocop:disable Metrics/ModuleLength
 
     # https://www.postgresql.org/docs/12/functions-matching.html#FUNCTIONS-POSIX-REGEXP
     scope :citizenlab_member, -> { where('email ~* ?', CITIZENLAB_MEMBER_REGEX_CONTENT).or(where('email ~* ?', GOVOCAL_MEMBER_REGEX_CONTENT)) }
-    scope :not_citizenlab_member, lambda do
+    scope :not_citizenlab_member, lambda {
       where.not('email ~* ?', CITIZENLAB_MEMBER_REGEX_CONTENT)
         .and(where.not('email ~* ?', GOVOCAL_MEMBER_REGEX_CONTENT))
         .where.not(email: nil)
-    end
+    }
 
     scope :billed_admins, -> { admin.not_citizenlab_member }
     scope :billed_moderators, lambda {

--- a/back/app/models/concerns/user_roles.rb
+++ b/back/app/models/concerns/user_roles.rb
@@ -81,11 +81,11 @@ module UserRoles # rubocop:disable Metrics/ModuleLength
 
     # https://www.postgresql.org/docs/12/functions-matching.html#FUNCTIONS-POSIX-REGEXP
     scope :citizenlab_member, -> { where('email ~* ?', CITIZENLAB_MEMBER_REGEX_CONTENT).or(where('email ~* ?', GOVOCAL_MEMBER_REGEX_CONTENT)) }
-    scope :not_citizenlab_member, -> {
+    scope :not_citizenlab_member, lambda do
       where.not('email ~* ?', CITIZENLAB_MEMBER_REGEX_CONTENT)
         .and(where.not('email ~* ?', GOVOCAL_MEMBER_REGEX_CONTENT))
         .where.not(email: nil)
-    }
+    end
 
     scope :billed_admins, -> { admin.not_citizenlab_member }
     scope :billed_moderators, lambda {

--- a/back/app/models/concerns/user_roles.rb
+++ b/back/app/models/concerns/user_roles.rb
@@ -82,9 +82,11 @@ module UserRoles # rubocop:disable Metrics/ModuleLength
     # https://www.postgresql.org/docs/12/functions-matching.html#FUNCTIONS-POSIX-REGEXP
     scope :citizenlab_member, -> { where('email ~* ?', CITIZENLAB_MEMBER_REGEX_CONTENT).or(where('email ~* ?', GOVOCAL_MEMBER_REGEX_CONTENT)) }
     scope :not_citizenlab_member, lambda {
-      where.not('email ~* ?', CITIZENLAB_MEMBER_REGEX_CONTENT)
-        .and(where.not('email ~* ?', GOVOCAL_MEMBER_REGEX_CONTENT))
-        .where.not(email: nil)
+      where(
+        'email IS NULL OR (email IS NOT NULL AND email !~* ? AND email !~* ?)',
+        CITIZENLAB_MEMBER_REGEX_CONTENT,
+        GOVOCAL_MEMBER_REGEX_CONTENT
+      )
     }
 
     scope :billed_admins, -> { admin.not_citizenlab_member }

--- a/back/spec/acceptance/invites_spec.rb
+++ b/back/spec/acceptance/invites_spec.rb
@@ -131,7 +131,8 @@ resource 'Invites' do
           assert_status 200
 
           expect(response_data[:attributes]).to eq(
-            newly_added_admins_number: 4,
+            # 6 invited (including one with email: nil), 1 is already an admin
+            newly_added_admins_number: 5,
             # When a moderator is promoted to admin, moderator count is decreased
             newly_added_moderators_number: -1
           )

--- a/back/spec/services/user_role_service_spec.rb
+++ b/back/spec/services/user_role_service_spec.rb
@@ -271,4 +271,19 @@ describe UserRoleService do
       expect(service.moderators_per_folder([f1.id])).to eq({})
     end
   end
+
+  describe 'not_citizenlab_member scope' do
+    it 'includes only users that do not have CitizenLab or Govocal emails' do
+      scope_member_count = User.citizenlab_member.count
+
+      create(:user, email: 'someone@citizenlab.co')
+      create(:user, email: 'someone@govocal.com')
+      create(:user, email: 'someone@should-not-be-excluded.com')
+      nil_email_user = create(:user)
+      nil_email_user.update_column(:email, nil)
+
+      expect(User.not_citizenlab_member.count).to eq(scope_member_count + 1)
+      expect(User.not_citizenlab_member.pluck(:email)).to include('someone@should-not-be-excluded.com')
+    end
+  end
 end

--- a/back/spec/services/user_role_service_spec.rb
+++ b/back/spec/services/user_role_service_spec.rb
@@ -283,7 +283,7 @@ describe UserRoleService do
       nil_email_user = create(:user)
       nil_email_user.update_column(:email, nil)
 
-      expect(User.not_citizenlab_member.count).to eq(scope_member_count + 1)
+      expect(User.not_citizenlab_member.count).to eq(scope_member_count + 2)
       expect(User.not_citizenlab_member.pluck(:email)).to include('someone@should-not-be-excluded.com')
     end
   end

--- a/back/spec/services/user_role_service_spec.rb
+++ b/back/spec/services/user_role_service_spec.rb
@@ -274,8 +274,6 @@ describe UserRoleService do
 
   describe 'not_citizenlab_member scope' do
     it 'includes only users that do not have Citizenlab or Govocal emails' do
-      scope_member_count = User.citizenlab_member.count
-
       create(:user, email: 'someone@citizenlab.co')
       create(:user, email: 'someone@govocal.com')
       create(:user, email: 'someone@should-not-be-excluded.com')
@@ -283,8 +281,10 @@ describe UserRoleService do
       nil_email_user = create(:user)
       nil_email_user.update_column(:email, nil)
 
-      expect(User.not_citizenlab_member.count).to eq(scope_member_count + 2)
-      expect(User.not_citizenlab_member.pluck(:email)).to include('someone@should-not-be-excluded.com')
+      expect(User.not_citizenlab_member.pluck(:email))
+        .to include('someone@should-not-be-excluded.com', nil)
+      expect(User.not_citizenlab_member.pluck(:email))
+        .not_to include('someone@citizenlab.co', 'someone@govocal.com')
     end
   end
 end

--- a/back/spec/services/user_role_service_spec.rb
+++ b/back/spec/services/user_role_service_spec.rb
@@ -273,12 +273,13 @@ describe UserRoleService do
   end
 
   describe 'not_citizenlab_member scope' do
-    it 'includes only users that do not have CitizenLab or Govocal emails' do
+    it 'includes only users that do not have Citizenlab or Govocal emails' do
       scope_member_count = User.citizenlab_member.count
 
       create(:user, email: 'someone@citizenlab.co')
       create(:user, email: 'someone@govocal.com')
       create(:user, email: 'someone@should-not-be-excluded.com')
+      # Users with email: nil can be created via bulk invite import
       nil_email_user = create(:user)
       nil_email_user.update_column(:email, nil)
 


### PR DESCRIPTION
# Changelog
## Fixed
- Ensure admins with `email: nil` are included in `billed_admins` scope (none exist on production currently, but fixes a bug where they can exist but would not be included in the scope)
