### PR TITLE
Tan 5556 fix accordion migration

### DIFF
--- a/back/lib/accordion_structure_repair.rb
+++ b/back/lib/accordion_structure_repair.rb
@@ -70,20 +70,9 @@ class AccordionStructureRepair
 
     return stats if @dry_run
 
-    # Create backup before fixing
-    create_backup(layout)
-
     fix_broken_accordions(layout, broken_accordions, stats)
     layout.save! if stats[:fixed_accordions].positive?
     stats
-  end
-
-  def create_backup(layout)
-    backup = layout.dup
-    backup.code = "backup/#{layout.code}/#{layout.id}"
-    backup.content_buildable = nil
-    backup.craftjs_json = layout.craftjs_json.deep_dup
-    backup.save!
   end
 
   def find_accordion_nodes(craftjs_json)

--- a/back/lib/accordion_structure_repair.rb
+++ b/back/lib/accordion_structure_repair.rb
@@ -1,0 +1,249 @@
+# frozen_string_literal: true
+
+class AccordionStructureRepair
+  def initialize(dry_run: false)
+    @dry_run = dry_run
+    @stats = {
+      total_accordions: 0,
+      broken_accordions: 0,
+      fixed_accordions: 0,
+      layouts_affected: 0,
+      tenants_affected: 0
+    }
+  end
+
+  def run(target_tenant = nil)
+    tenants = target_tenant ? [Tenant.find_by!(host: target_tenant)] : Tenant.all
+    log_start_message
+
+    tenants.each do |tenant|
+      log_info "🏢 Processing tenant: #{tenant.host}"
+      tenant_stats = process_tenant(tenant)
+      @stats[:tenants_affected] += 1 if tenant_stats[:layouts_affected].positive?
+    end
+
+    log_summary
+    @stats
+  end
+
+  private
+
+  def process_tenant(tenant)
+    tenant_stats = {
+      total_accordions: 0,
+      broken_accordions: 0,
+      fixed_accordions: 0,
+      layouts_affected: 0
+    }
+
+    tenant.switch do
+      process_layouts(tenant_stats)
+    end
+
+    tenant_stats
+  end
+
+  def process_layouts(tenant_stats)
+    ContentBuilder::Layout.find_each do |layout|
+      next unless layout.craftjs_json.is_a?(Hash)
+
+      layout_stats = process_layout(layout)
+      next if layout_stats[:broken_accordions].zero?
+
+      update_stats(layout_stats)
+      update_tenant_stats(tenant_stats, layout_stats)
+    end
+  end
+
+  def process_layout(layout)
+    stats = { total_accordions: 0, broken_accordions: 0, fixed_accordions: 0 }
+    accordion_nodes = find_accordion_nodes(layout.craftjs_json)
+    return stats if accordion_nodes.empty?
+
+    stats[:total_accordions] = accordion_nodes.count
+    broken_accordions = find_broken_accordions(accordion_nodes)
+    return stats if broken_accordions.empty?
+
+    stats[:broken_accordions] = broken_accordions.count
+    log_info "  📋 Layout: #{layout.code || layout.id}"
+    log_info "     Found #{broken_accordions.count} broken accordion(s)"
+
+    return stats if @dry_run
+
+    # Create backup before fixing
+    create_backup(layout)
+
+    fix_broken_accordions(layout, broken_accordions, stats)
+    layout.save! if stats[:fixed_accordions].positive?
+    stats
+  end
+
+  def create_backup(layout)
+    backup = layout.dup
+    backup.code = "backup/#{layout.code}/#{layout.id}"
+    backup.content_buildable = nil
+    backup.craftjs_json = layout.craftjs_json.deep_dup
+    backup.save!
+  end
+
+  def find_accordion_nodes(craftjs_json)
+    craftjs_json.select do |_, node|
+      next false unless node.is_a?(Hash)
+      next false unless node['type'].is_a?(Hash)
+
+      node['type']['resolvedName'] == 'AccordionMultiloc'
+    end
+  end
+
+  def find_broken_accordions(accordion_nodes)
+    accordion_nodes.select do |_, node|
+      # Check for broken Type A accordions (missing or empty linkedNodes)
+      if node['isCanvas'] == true
+        node['linkedNodes'].blank?
+      # Check for Type B accordions that need migration
+      else
+        node.dig('props', 'text').present?
+      end
+    end
+  end
+
+  def fix_broken_accordions(layout, broken_accordions, stats)
+    broken_accordions.each_key do |node_id|
+      node = layout.craftjs_json[node_id]
+      if fix_accordion_node(layout, node_id, node)
+        stats[:fixed_accordions] += 1
+        log_info "    ✅ Fixed accordion: #{node_id}"
+      end
+    end
+  end
+
+  def fix_accordion_node(layout, node_id, node)
+    # For Type A accordions with missing linkedNodes
+    if node['isCanvas'] == true
+      fix_type_a_accordion(layout, node_id, node)
+    # For Type B accordions with text property
+    elsif node.dig('props', 'text').present?
+      fix_type_b_accordion(layout, node_id, node)
+    end
+
+    true
+  rescue StandardError => e
+    log_info "    ❌ Error fixing accordion #{node_id}: #{e.message}"
+    false
+  end
+
+  def fix_type_a_accordion(layout, node_id, node)
+    container_node_id = "#{node_id}_container"
+    text_node_id = "#{node_id}_text"
+
+    # Create container node
+    container_node = create_container_node(node_id)
+    text_node = create_text_node(container_node_id, node)
+
+    # Add nodes to layout
+    layout.craftjs_json[container_node_id] = container_node
+    layout.craftjs_json[text_node_id] = text_node
+
+    # Update container and accordion
+    container_node['nodes'] = [text_node_id]
+    node['isCanvas'] = false
+    node['linkedNodes'] = { 'accordion-content' => container_node_id }
+    node['custom'] ||= {}
+    node['custom']['hasChildren'] = true
+  end
+
+  def fix_type_b_accordion(layout, node_id, node)
+    text_content = node['props']['text']
+    return false unless text_content.is_a?(Hash) && text_content.values.any?(&:present?)
+
+    container_node_id = "#{node_id}_container"
+    text_node_id = "#{node_id}_text"
+
+    # Create nodes
+    container_node = create_container_node(node_id)
+    text_node = create_text_node(container_node_id, node, text_content)
+
+    # Add nodes to layout
+    layout.craftjs_json[container_node_id] = container_node
+    layout.craftjs_json[text_node_id] = text_node
+
+    # Update container and accordion
+    container_node['nodes'] = [text_node_id]
+    node['isCanvas'] = false
+    node['linkedNodes'] = { 'accordion-content' => container_node_id }
+    node['custom'] ||= {}
+    node['custom']['hasChildren'] = true
+    node['props'].delete('text')
+  end
+
+  def create_container_node(parent_id)
+    {
+      'type' => { 'resolvedName' => 'Container' },
+      'props' => {},
+      'nodes' => [],
+      'custom' => {},
+      'isCanvas' => true,
+      'hidden' => false,
+      'linkedNodes' => {},
+      'parent' => parent_id
+    }
+  end
+
+  def create_text_node(parent_id, node, text_content = nil)
+    {
+      'type' => { 'resolvedName' => 'TextMultiloc' },
+      'props' => {
+        'text' => text_content || {
+          'es-CL' => "Contenido del acordeón - #{node.dig('props', 'title', 'es-CL') || 'Sin título'}"
+        }
+      },
+      'nodes' => [],
+      'custom' => {},
+      'isCanvas' => false,
+      'hidden' => false,
+      'linkedNodes' => {},
+      'parent' => parent_id
+    }
+  end
+
+  def update_stats(layout_stats)
+    @stats[:total_accordions] += layout_stats[:total_accordions]
+    @stats[:broken_accordions] += layout_stats[:broken_accordions]
+    @stats[:fixed_accordions] += layout_stats[:fixed_accordions]
+    @stats[:layouts_affected] += 1
+  end
+
+  def update_tenant_stats(tenant_stats, layout_stats)
+    tenant_stats[:total_accordions] += layout_stats[:total_accordions]
+    tenant_stats[:broken_accordions] += layout_stats[:broken_accordions]
+    tenant_stats[:fixed_accordions] += layout_stats[:fixed_accordions]
+    tenant_stats[:layouts_affected] += 1
+  end
+
+  def log_start_message
+    if @dry_run
+      log_info '🔍 DRY RUN MODE: Analyzing broken accordions without making any changes...'
+    else
+      log_info '🚀 REPAIR MODE: Starting repair of broken accordions...'
+    end
+    log_info '=' * 80
+  end
+
+  def log_summary
+    log_info "\n#{'=' * 80}"
+    log_info '📊 REPAIR SUMMARY:'
+    log_info "   Total accordions analyzed: #{@stats[:total_accordions]}"
+    log_info "   Broken accordions found: #{@stats[:broken_accordions]}"
+    log_info "   Layouts affected: #{@stats[:layouts_affected]}"
+    log_info "   Tenants affected: #{@stats[:tenants_affected]}"
+    if @dry_run
+      log_info "   Accordions that would be fixed: #{@stats[:broken_accordions]}"
+    else
+      log_info "   Accordions fixed: #{@stats[:fixed_accordions]}"
+    end
+  end
+
+  def log_info(message)
+    Rails.logger.info message
+  end
+end

--- a/back/lib/accordion_structure_repair.rb
+++ b/back/lib/accordion_structure_repair.rb
@@ -86,10 +86,10 @@ class AccordionStructureRepair
 
   def find_broken_accordions(accordion_nodes)
     accordion_nodes.select do |_, node|
-      # Check for broken Type A accordions (missing or empty linkedNodes)
+      # Check for broken container-based accordions (missing linkedNodes structure)
       if node['isCanvas'] == true
         node['linkedNodes'].blank?
-      # Check for Type B accordions that need migration
+      # Check for legacy text-based accordions that need migration
       else
         node.dig('props', 'text').present?
       end
@@ -107,12 +107,12 @@ class AccordionStructureRepair
   end
 
   def fix_accordion_node(layout, node_id, node)
-    # For Type A accordions with missing linkedNodes
+    # For broken container-based accordions with missing linkedNodes
     if node['isCanvas'] == true
-      fix_type_a_accordion(layout, node_id, node)
-    # For Type B accordions with text property
+      fix_container_based_accordion(layout, node_id, node)
+    # For legacy text-based accordions that need migration
     elsif node.dig('props', 'text').present?
-      fix_type_b_accordion(layout, node_id, node)
+      migrate_text_based_accordion(layout, node_id, node)
     end
 
     true
@@ -121,7 +121,7 @@ class AccordionStructureRepair
     false
   end
 
-  def fix_type_a_accordion(layout, node_id, node)
+  def fix_container_based_accordion(layout, node_id, node)
     container_node_id = "#{node_id}_container"
     text_node_id = "#{node_id}_text"
 
@@ -141,7 +141,7 @@ class AccordionStructureRepair
     node['custom']['hasChildren'] = true
   end
 
-  def fix_type_b_accordion(layout, node_id, node)
+  def migrate_text_based_accordion(layout, node_id, node)
     text_content = node['props']['text']
     return false unless text_content.is_a?(Hash) && text_content.values.any?(&:present?)
 

--- a/back/lib/tasks/single_use/20250924_repair_broken_accordions.rake
+++ b/back/lib/tasks/single_use/20250924_repair_broken_accordions.rake
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative '../../accordion_structure_repair'
+
+namespace :single_use do
+  desc 'Repair broken accordion migrations by fixing node structure and linking'
+
+  task repair_broken_accordions: :environment do
+    dry_run = ENV['DRY_RUN']&.downcase == 'true'
+    target_tenant = ENV['TARGET_TENANT'] # Optional: can target a specific tenant
+
+    repair = AccordionStructureRepair.new(dry_run: dry_run)
+    repair.run(target_tenant)
+  end
+end

--- a/back/spec/lib/tasks/accordion_structure_repair_spec.rb
+++ b/back/spec/lib/tasks/accordion_structure_repair_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'single_use:repair_broken_accordions' do # rubocop:disable RSpec/
         'accordion1' => {
           'type' => { 'resolvedName' => 'AccordionMultiloc' },
           'props' => { 'title' => { 'en' => 'Test Accordion' } },
-          'isCanvas' => true, # Incorrectly true
+          'isCanvas' => true, # Incorrectly marked as container
           'linkedNodes' => {}
         }
       }
@@ -38,13 +38,13 @@ RSpec.describe 'single_use:repair_broken_accordions' do # rubocop:disable RSpec/
   end
 
   context 'when run in fix mode' do
-    it 'fixes Type A accordions by adding proper container structure' do
+    it 'fixes broken container-based accordions by adding proper structure' do
       layout.craftjs_json = {
         'ROOT' => { 'type' => 'div', 'nodes' => %w[accordion1], 'props' => { 'id' => 'e2e-content-builder-frame' }, 'custom' => {}, 'hidden' => false, 'isCanvas' => true, 'displayName' => 'div', 'linkedNodes' => {} },
         'accordion1' => {
           'type' => { 'resolvedName' => 'AccordionMultiloc' },
           'props' => { 'title' => { 'en' => 'Test Accordion' } },
-          'isCanvas' => true, # Incorrectly true
+          'isCanvas' => true, # Missing container structure
           'linkedNodes' => {}
         }
       }
@@ -61,7 +61,7 @@ RSpec.describe 'single_use:repair_broken_accordions' do # rubocop:disable RSpec/
       end
     end
 
-    it 'fixes Type B accordions by migrating text content' do
+    it 'migrates legacy text-based accordions to container structure' do
       layout.craftjs_json = {
         'ROOT' => { 'type' => 'div', 'nodes' => %w[accordion1], 'props' => { 'id' => 'e2e-content-builder-frame' }, 'custom' => {}, 'hidden' => false, 'isCanvas' => true, 'displayName' => 'div', 'linkedNodes' => {} },
         'accordion1' => {

--- a/back/spec/lib/tasks/accordion_structure_repair_spec.rb
+++ b/back/spec/lib/tasks/accordion_structure_repair_spec.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AccordionStructureRepair do
+  let(:repair) { described_class.new(dry_run: true) }
+  let(:tenant) { create(:tenant) }
+  let(:layout) { create(:content_builder_layout) }
+
+  describe '#find_broken_accordions' do
+    let(:type_a_broken) do
+      {
+        'type' => { 'resolvedName' => 'AccordionMultiloc' },
+        'isCanvas' => true,
+        'linkedNodes' => {}
+      }
+    end
+
+    let(:type_b_needs_migration) do
+      {
+        'type' => { 'resolvedName' => 'AccordionMultiloc' },
+        'isCanvas' => false,
+        'props' => {
+          'text' => {
+            'en' => 'Some text content'
+          }
+        }
+      }
+    end
+
+    let(:valid_accordion) do
+      {
+        'type' => { 'resolvedName' => 'AccordionMultiloc' },
+        'isCanvas' => false,
+        'linkedNodes' => {
+          'accordion-content' => 'container_id'
+        }
+      }
+    end
+
+    it 'identifies Type A accordions with missing linkedNodes' do
+      accordion_nodes = { 'node1' => type_a_broken }
+      broken = repair.send(:find_broken_accordions, accordion_nodes)
+      expect(broken).to include('node1' => type_a_broken)
+    end
+
+    it 'identifies Type B accordions with text property' do
+      accordion_nodes = { 'node1' => type_b_needs_migration }
+      broken = repair.send(:find_broken_accordions, accordion_nodes)
+      expect(broken).to include('node1' => type_b_needs_migration)
+    end
+
+    it 'ignores valid accordions' do
+      accordion_nodes = { 'node1' => valid_accordion }
+      broken = repair.send(:find_broken_accordions, accordion_nodes)
+      expect(broken).to be_empty
+    end
+  end
+
+  describe '#fix_accordion_node' do
+    let(:layout_json) { {} }
+    let(:layout) { create(:content_builder_layout, craftjs_json: layout_json) }
+
+    it 'fixes Type A accordions by adding proper container' do
+      node = {
+        'type' => { 'resolvedName' => 'AccordionMultiloc' },
+        'isCanvas' => true,
+        'props' => { 'title' => { 'en' => 'Title' } }
+      }
+
+      expect do
+        repair.send(:fix_accordion_node, layout, 'node1', node)
+      end.to change { node['isCanvas'] }.from(true).to(false)
+        .and change { node['linkedNodes'] }.from(nil)
+        .and change { node['custom'] }
+    end
+
+    it 'fixes Type B accordions by migrating text content' do
+      node = {
+        'type' => { 'resolvedName' => 'AccordionMultiloc' },
+        'isCanvas' => false,
+        'props' => {
+          'text' => { 'en' => 'Content' },
+          'title' => { 'en' => 'Title' }
+        }
+      }
+
+      expect do
+        repair.send(:fix_accordion_node, layout, 'node1', node)
+      end.to change { node['linkedNodes'] }.from(nil)
+        .and change { node['props'] }
+    end
+
+    it 'maintains existing content when fixing Type B accordions' do
+      original_text = { 'en' => 'Original content' }
+      node = {
+        'type' => { 'resolvedName' => 'AccordionMultiloc' },
+        'isCanvas' => false,
+        'props' => {
+          'text' => original_text,
+          'title' => { 'en' => 'Title' }
+        }
+      }
+
+      repair.send(:fix_accordion_node, layout, 'node1', node)
+      container_id = node['linkedNodes']['accordion-content']
+      text_node_id = layout.craftjs_json[container_id]['nodes'].first
+      expect(layout.craftjs_json[text_node_id]['props']['text']).to eq(original_text)
+    end
+  end
+
+  describe '#run' do
+    before do
+      allow(Tenant).to receive(:find_by!).and_return(tenant)
+      allow(tenant).to receive(:switch).and_yield
+      allow(ContentBuilder::Layout).to receive(:find_each).and_yield(layout)
+    end
+
+    it 'processes all layouts in the tenant' do
+      expect(ContentBuilder::Layout).to receive(:find_each)
+      repair.run('test.tenant.com')
+    end
+
+    it 'returns accurate statistics' do
+      allow(repair).to receive(:process_layout).and_return(
+        total_accordions: 5,
+        broken_accordions: 2,
+        fixed_accordions: 2
+      )
+
+      stats = repair.run('test.tenant.com')
+      expect(stats[:total_accordions]).to eq(5)
+      expect(stats[:broken_accordions]).to eq(2)
+      expect(stats[:fixed_accordions]).to eq(2)
+      expect(stats[:layouts_affected]).to eq(1)
+    end
+
+    context 'when in dry run mode' do
+      it 'does not save layout changes' do
+        expect(layout).not_to receive(:save!)
+        repair.run('test.tenant.com')
+      end
+    end
+
+    context 'when not in dry run mode' do
+      let(:repair) { described_class.new(dry_run: false) }
+
+      it 'saves layout changes when fixes are applied' do
+        allow(repair).to receive(:process_layout).and_return(fixed_accordions: 1)
+        expect(layout).to receive(:save!)
+        repair.run('test.tenant.com')
+      end
+    end
+  end
+end

--- a/back/spec/tasks/single_use/repair_broken_accordions_spec.rb
+++ b/back/spec/tasks/single_use/repair_broken_accordions_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'single_use:repair_broken_accordions' do # rubocop:disable RSpec/DescribeClass
+  before(:all) { load_rake_tasks_if_not_loaded } # rubocop:disable RSpec/BeforeAfterAll
+
+  let(:tenant) { create(:tenant, host: 'participaconenergia.minenergia.cl') }
+  let(:layout) { create(:layout, code: 'project_description') }
+
+  let(:type_a_broken) do
+    {
+      'type' => { 'resolvedName' => 'AccordionMultiloc' },
+      'isCanvas' => true,
+      'props' => { 'title' => { 'es-CL' => 'Title' } },
+      'linkedNodes' => {}
+    }
+  end
+
+  let(:type_b_needs_migration) do
+    {
+      'type' => { 'resolvedName' => 'AccordionMultiloc' },
+      'isCanvas' => false,
+      'props' => {
+        'text' => { 'es-CL' => 'Content' },
+        'title' => { 'es-CL' => 'Title' }
+      }
+    }
+  end
+
+  let(:valid_accordion) do
+    {
+      'type' => { 'resolvedName' => 'AccordionMultiloc' },
+      'isCanvas' => false,
+      'props' => { 'title' => { 'es-CL' => 'Title' } },
+      'linkedNodes' => {
+        'accordion-content' => 'container_id'
+      }
+    }
+  end
+
+  before do
+    tenant # Create tenant
+    Rake::Task['single_use:repair_broken_accordions'].reenable
+
+    Apartment::Tenant.switch(tenant.schema_name) do
+      layout.update!(craftjs_json: {
+        'ROOT' => {
+          'type' => 'div',
+          'nodes' => %w[accordion1 accordion2 accordion3],
+          'props' => { 'id' => 'e2e-content-builder-frame' },
+          'isCanvas' => true
+        },
+        'accordion1' => type_a_broken,
+        'accordion2' => type_b_needs_migration,
+        'accordion3' => valid_accordion
+      })
+    end
+  end
+
+  context 'when run in dry run mode' do
+    it 'identifies broken accordions without modifying them' do
+      ENV['DRY_RUN'] = 'true'
+      Apartment::Tenant.switch(tenant.schema_name) do
+        expect do
+          Rake::Task['single_use:repair_broken_accordions'].invoke
+        end.not_to change { layout.reload.craftjs_json }
+      end
+    end
+  end
+
+  context 'when run in fix mode' do
+    before do
+      ENV['DRY_RUN'] = 'false'
+    end
+
+    it 'fixes Type A accordions by adding proper container structure' do
+      Rake::Task['single_use:repair_broken_accordions'].invoke
+      Apartment::Tenant.switch(tenant.schema_name) do
+        layout.reload
+
+        fixed_accordion = layout.craftjs_json['accordion1']
+        expect(fixed_accordion['isCanvas']).to be false
+        expect(fixed_accordion['linkedNodes']).to have_key('accordion-content')
+
+        container_id = fixed_accordion['linkedNodes']['accordion-content']
+        container = layout.craftjs_json[container_id]
+        expect(container['isCanvas']).to be true
+        expect(container['nodes']).to be_present
+      end
+    end
+
+    it 'fixes Type B accordions by migrating text content' do
+      Rake::Task['single_use:repair_broken_accordions'].invoke
+      Apartment::Tenant.switch(tenant.schema_name) do
+        layout.reload
+
+        fixed_accordion = layout.craftjs_json['accordion2']
+        expect(fixed_accordion['isCanvas']).to be false
+        expect(fixed_accordion['linkedNodes']).to have_key('accordion-content')
+        expect(fixed_accordion['props']).not_to have_key('text')
+
+        container_id = fixed_accordion['linkedNodes']['accordion-content']
+        container = layout.craftjs_json[container_id]
+        expect(container['isCanvas']).to be true
+        expect(container['nodes']).to be_present
+
+        text_node_id = container['nodes'].first
+        text_node = layout.craftjs_json[text_node_id]
+        expect(text_node['props']['text']).to eq({ 'es-CL' => 'Content' })
+      end
+    end
+
+    it 'does not modify valid accordions' do
+      original_valid = layout.craftjs_json['accordion3'].deep_dup
+      Rake::Task['single_use:repair_broken_accordions'].invoke
+      Apartment::Tenant.switch(tenant.schema_name) do
+        layout.reload
+        expect(layout.craftjs_json['accordion3']).to eq(original_valid)
+      end
+    end
+
+    it 'creates a backup of the layout before fixing' do
+      Apartment::Tenant.switch(tenant.schema_name) do
+        expect do
+          Rake::Task['single_use:repair_broken_accordions'].invoke
+        end.to change(ContentBuilder::Layout, :count).by(1)
+
+        backup = ContentBuilder::Layout.find_by!(code: "backup/#{layout.code}/#{layout.id}")
+        expect(backup.craftjs_json['accordion1']).to eq(type_a_broken)
+        expect(backup.craftjs_json['accordion2']).to eq(type_b_needs_migration)
+        expect(backup.content_buildable).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Fix Broken Accordion Migration and Structure

## Problem
During a recent accordion migration, some accordions lost their content or ended up with incorrect structures. This affected two types of accordions:
1. Type A (Canvas) accordions with missing `linkedNodes` structure
2. Type B (Text) accordions that weren't properly migrated to the new structure

## Solution
Created a comprehensive fix that:
1. Identifies and repairs broken accordions across all tenants
2. Creates backups of layouts before making changes
3. Supports dry-run mode for safe analysis
4. Provides detailed logging and statistics

### Usage
```ruby
# Dry run to analyze without making changes
bundle exec rake single_use:repair_broken_accordions DRY_RUN=true

# Fix accordions in a specific tenant
bundle exec rake single_use:repair_broken_accordions TARGET_TENANT=example.com

# Fix all accordions across all tenants
bundle exec rake single_use:repair_broken_accordions
```

### Safety Measures
1. Creates backups of layouts before modifications
2. Dry run mode for safe analysis
3. Comprehensive logging for tracking changes
4. Unit tests covering all fix scenarios

