### PR TITLE
[TAN-5544] Improve clarity around New Phase button

### DIFF
--- a/front/app/containers/Admin/projects/project/phaseSetup/index.tsx
+++ b/front/app/containers/Admin/projects/project/phaseSetup/index.tsx
@@ -330,6 +330,11 @@ const AdminPhaseEdit = ({ projectId, phase }: Props) => {
               id="title"
               type="text"
               valueMultiloc={formData.title_multiloc}
+              placeholder={
+                phaseId
+                  ? undefined
+                  : formatMessage(messages.phaseTitlePlaceholder)
+              }
               onChange={handleTitleMultilocOnChange}
             />
             <Error apiErrors={errors && errors.title_multiloc} />

--- a/front/app/containers/Admin/projects/project/phaseSetup/messages.ts
+++ b/front/app/containers/Admin/projects/project/phaseSetup/messages.ts
@@ -13,6 +13,10 @@ export default defineMessages({
     id: 'app.containers.AdminPage.ProjectTimeline.titleLabel',
     defaultMessage: 'Title',
   },
+  phaseTitlePlaceholder: {
+    id: 'app.containers.AdminPage.ProjectTimeline.phaseTitlePlaceholder',
+    defaultMessage: 'New phase',
+  },
   surveyTitleLabel: {
     id: 'app.containers.AdminPage.ProjectTimeline.surveyTitleLabel',
     defaultMessage: 'Survey title',

--- a/front/app/containers/ProjectsShowPage/timeline/Timeline.tsx
+++ b/front/app/containers/ProjectsShowPage/timeline/Timeline.tsx
@@ -442,7 +442,7 @@ const Timeline = ({
                 );
               })}
               {isBackoffice && (
-                <Box width="44px" ml="8px">
+                <Box minWidth="44px" ml="8px">
                   <PhaseContainer
                     className="first"
                     key="new-phase"
@@ -473,12 +473,13 @@ const Timeline = ({
                         id="new-phase"
                         showArrow={false}
                       >
-                        <span aria-hidden>
+                        <span
+                          aria-hidden
+                          style={{ textWrap: 'nowrap', marginRight: '4px' }}
+                        >
                           <PlusIcon name="plus" height="16px" />
-                        </span>
-                        <ScreenReaderOnly>
                           <FormattedMessage {...messages.newPhase} />
-                        </ScreenReaderOnly>
+                        </span>
                       </PhaseBar>
                     </Tooltip>
                   </PhaseContainer>

--- a/front/app/translations/admin/en.json
+++ b/front/app/translations/admin/en.json
@@ -2380,6 +2380,7 @@
   "app.containers.AdminPage.ProjectTimeline.noEndDateWarningBullet1": "Some methods' results sharing (such as voting results) won't be triggered until an end date is selected.",
   "app.containers.AdminPage.ProjectTimeline.noEndDateWarningBullet2": "As soon as you add a phase after this one, it will add an end date to this phase.",
   "app.containers.AdminPage.ProjectTimeline.noEndDateWarningTitle": "Not selecting an end date for this implies that:",
+  "app.containers.AdminPage.ProjectTimeline.phaseTitlePlaceholder": "New phase",
   "app.containers.AdminPage.ProjectTimeline.previewSurveyCTALabel": "Preview",
   "app.containers.AdminPage.ProjectTimeline.saveChangesLabel": "Save changes",
   "app.containers.AdminPage.ProjectTimeline.saveErrorMessage": "There was an error submitting the form, please try again.",


### PR DESCRIPTION

# Changelog
## Fixed
- [TAN-5544] Improve the clarity around the "New phase" button. We now use the full 'New phase' text in the button, and we also use "New phase" as the placeholder text for the phase title in the form that appears, to better communicate that this form is for the new phase they are creating (Images: [1. New phase button, now with text](https://github.com/user-attachments/assets/e3ff1a6f-6b3e-469d-b9ac-5a02f5ec07c4). [2. New phase as placeholder](https://github.com/user-attachments/assets/c2ada35f-57ec-4115-82db-3ef1634a9bfe)).