### PR TITLE
TAN-5587 - Ensure keycloak (Oslo) user names are not stored as capita…

### DIFF
--- a/back/engines/commercial/id_keycloak/app/lib/id_keycloak/keycloak_omniauth.rb
+++ b/back/engines/commercial/id_keycloak/app/lib/id_keycloak/keycloak_omniauth.rb
@@ -6,8 +6,8 @@ module IdKeycloak
 
     def profile_to_user_attrs(auth)
       {
-        first_name: auth.info.first_name,
-        last_name: auth.info.last_name,
+        first_name: auth.info.first_name&.downcase&.capitalize,
+        last_name: auth.info.last_name&.downcase&.capitalize,
         email: auth.info.email,
         locale: AppConfiguration.instance.closest_locale_to('nb-NO') # No need to get the locale from the provider
       }

--- a/back/engines/commercial/id_keycloak/spec/requests/keycloak_verification_spec.rb
+++ b/back/engines/commercial/id_keycloak/spec/requests/keycloak_verification_spec.rb
@@ -91,8 +91,8 @@ context 'keycloak verification (ID-Porten - Oslo)' do
   def expect_user_to_be_verified(user)
     expect(user.reload).to have_attributes({
       verified: true,
-      first_name: 'UNØYAKTIG',
-      last_name: 'KOST',
+      first_name: 'Unøyaktig',
+      last_name: 'Kost',
       custom_field_values: {}
     })
     expect(user.verifications.first).to have_attributes({


### PR DESCRIPTION
When deployed the following code will also need to be run:

```
Tenant.find_by(host: 'medvirkning.oslo.kommune.no').switch!
User.find_each { |user| user.update!(first_name: user.first_name.downcase.capitalize, last_name: user.last_name.downcase.capitalize) }
```

# Changelog
## Fixed
- Decapitalise first_name and last_name returned from ID-Porten (keycloak) SSO
