### PR TITLE
TAN-5587- Fix capitalisation of Keycloak users with spaces and hyphens

### DIFF
--- a/back/engines/commercial/id_keycloak/app/lib/id_keycloak/keycloak_omniauth.rb
+++ b/back/engines/commercial/id_keycloak/app/lib/id_keycloak/keycloak_omniauth.rb
@@ -6,8 +6,8 @@ module IdKeycloak
 
     def profile_to_user_attrs(auth)
       {
-        first_name: auth.info.first_name&.downcase&.capitalize,
-        last_name: auth.info.last_name&.downcase&.capitalize,
+        first_name: format_name(auth.info.first_name),
+        last_name: format_name(auth.info.last_name),
         email: auth.info.email,
         locale: AppConfiguration.instance.closest_locale_to('nb-NO') # No need to get the locale from the provider
       }
@@ -61,6 +61,15 @@ module IdKeycloak
 
     def updateable_user_attrs
       super + %i[first_name last_name]
+    end
+
+    private
+
+    # Proper case the returned Captialised name - capitalize first letter of each part, lowercase the rest
+    def format_name(name)
+      return unless name
+
+      name.downcase.split(/[\s-]/).map(&:capitalize).join(name.include?('-') ? '-' : ' ')
     end
   end
 end

--- a/back/engines/commercial/id_keycloak/spec/requests/keycloak_verification_spec.rb
+++ b/back/engines/commercial/id_keycloak/spec/requests/keycloak_verification_spec.rb
@@ -9,12 +9,12 @@ context 'keycloak verification (ID-Porten - Oslo)' do
       'provider' => 'keycloak',
       'uid' => 'b045a9a9-cf7e-4add-acc7-1f606eb1e9e0',
       'info' => {
-        'name' => 'UNØYAKTIG KOST',
+        'name' => 'UNØY-AKTIG KOST NOST',
         'email' => 'test@govocal.com',
         'email_verified' => false,
         'nickname' => '21929974805',
-        'first_name' => 'UNØYAKTIG',
-        'last_name' => 'KOST',
+        'first_name' => 'UNØY-AKTIG',
+        'last_name' => 'KOST NOST',
         'gender' => nil,
         'image' => nil,
         'phone' => '+447780122122',
@@ -40,12 +40,12 @@ context 'keycloak verification (ID-Porten - Oslo)' do
           'amr' => 'TestID',
           'pid' => '21929974805',
           'preferred_username' => '21929974805',
-          'given_name' => 'UNØYAKTIG',
+          'given_name' => 'UNØY-AKTIG',
           'locale' => 'en',
           'acr_security_level' => 'idporten-loa-substantial',
-          'name' => 'UNØYAKTIG KOST',
+          'name' => 'UNØY-AKTIG KOST NOST',
           'phone_number' => '+447780122122',
-          'family_name' => 'KOST',
+          'family_name' => 'KOST NOST',
           'email' => 'test@govocal.com',
           'exp' => 1_728_307_270,
           'iat' => 1_728_306_970,
@@ -91,8 +91,8 @@ context 'keycloak verification (ID-Porten - Oslo)' do
   def expect_user_to_be_verified(user)
     expect(user.reload).to have_attributes({
       verified: true,
-      first_name: 'Unøyaktig',
-      last_name: 'Kost',
+      first_name: 'Unøy-Aktig',
+      last_name: 'Kost Nost',
       custom_field_values: {}
     })
     expect(user.verifications.first).to have_attributes({


### PR DESCRIPTION
# Changelog
## Fixed
- Fixed capitalisation of Keycloak user names with spaces and hyphens
