### PR TITLE
TAN-5509 Validate invalid inputs for voting as well

### DIFF
--- a/back/app/models/phase.rb
+++ b/back/app/models/phase.rb
@@ -97,7 +97,6 @@ class Phase < ApplicationRecord
   before_validation :strip_title
   before_validation :set_participation_method_defaults, on: :create
   before_validation :set_presentation_mode, on: :create
-  before_save :reload_participation_method, if: :will_save_change_to_participation_method?
 
   before_destroy :remove_notifications # Must occur before has_many :notifications (see https://github.com/rails/rails/issues/5205)
   has_many :notifications, dependent: :nullify
@@ -254,10 +253,33 @@ class Phase < ApplicationRecord
     participation_method == 'voting'
   end
 
-  # @return [ParticipationMethod::Base]
   def pmethod
-    reload_participation_method if !@pmethod
-    @pmethod
+    @pmethod = case participation_method
+    when 'information'
+      ParticipationMethod::Information.new(self)
+    when 'ideation'
+      ParticipationMethod::Ideation.new(self)
+    when 'proposals'
+      ParticipationMethod::Proposals.new(self)
+    when 'native_survey'
+      ParticipationMethod::NativeSurvey.new(self)
+    when 'community_monitor_survey'
+      ParticipationMethod::CommunityMonitorSurvey.new(self)
+    when 'document_annotation'
+      ParticipationMethod::DocumentAnnotation.new(self)
+    when 'survey'
+      ParticipationMethod::Survey.new(self)
+    when 'voting'
+      ParticipationMethod::Voting.new(self)
+    when 'poll'
+      ParticipationMethod::Poll.new(self)
+    when 'volunteering'
+      ParticipationMethod::Volunteering.new(self)
+    when 'common_ground'
+      ParticipationMethod::CommonGround.new(self)
+    else
+      ParticipationMethod::None.new
+    end
   end
 
   def set_manual_voters(amount, user)
@@ -344,35 +366,6 @@ class Phase < ApplicationRecord
 
   def set_participation_method_defaults
     pmethod.assign_defaults_for_phase
-  end
-
-  def reload_participation_method
-    @pmethod = case participation_method
-    when 'information'
-      ParticipationMethod::Information.new(self)
-    when 'ideation'
-      ParticipationMethod::Ideation.new(self)
-    when 'proposals'
-      ParticipationMethod::Proposals.new(self)
-    when 'native_survey'
-      ParticipationMethod::NativeSurvey.new(self)
-    when 'community_monitor_survey'
-      ParticipationMethod::CommunityMonitorSurvey.new(self)
-    when 'document_annotation'
-      ParticipationMethod::DocumentAnnotation.new(self)
-    when 'survey'
-      ParticipationMethod::Survey.new(self)
-    when 'voting'
-      ParticipationMethod::Voting.new(self)
-    when 'poll'
-      ParticipationMethod::Poll.new(self)
-    when 'volunteering'
-      ParticipationMethod::Volunteering.new(self)
-    when 'common_ground'
-      ParticipationMethod::CommonGround.new(self)
-    else
-      ParticipationMethod::None.new
-    end
   end
 
   def set_presentation_mode

--- a/back/lib/participation_method/voting.rb
+++ b/back/lib/participation_method/voting.rb
@@ -3,7 +3,7 @@
 module ParticipationMethod
   class Voting < Ideation
     SUPPORTED_REACTION_MODES = [].freeze
-    delegate :additional_export_columns, :supports_serializing?, :validate_phase, to: :voting_method
+    delegate :additional_export_columns, :supports_serializing?, to: :voting_method
 
     def self.method_str
       'voting'
@@ -23,6 +23,11 @@ module ParticipationMethod
     # Remove after unified status implementation
     def idea_status_method
       'ideation'
+    end
+
+    def validate_phase
+      super
+      voting_method.validate_phase
     end
 
     def supported_email_campaigns

--- a/back/lib/tasks/single_use/20250926_delete_invalid_method_inputs.rake
+++ b/back/lib/tasks/single_use/20250926_delete_invalid_method_inputs.rake
@@ -3,7 +3,7 @@ namespace :inconsistant_data do
   task :delete_proposals_in_ideation, [] => [:environment] do
     reporter = ScriptReporter.new
     Tenant.safe_switch_each do |tenant|
-      Idea.where(creation_phase: Phase.where(participation_method: 'ideation')).find_each do |input|
+      Idea.where(creation_phase: Phase.where(participation_method: %w[ideation voting])).find_each do |input|
         next if input.valid?
 
         if input.destroy

--- a/back/spec/acceptance/phases_spec.rb
+++ b/back/spec/acceptance/phases_spec.rb
@@ -158,15 +158,6 @@ resource 'Phases' do
         expect(response_data[:attributes]).to eq({ totalSubmissions: 2 })
       end
     end
-
-    context 'ideation' do
-      example 'Get count for ideation phase (ignores native survey responses)' do
-        phase.update!(participation_method: 'ideation')
-        do_request
-        assert_status 200
-        expect(response_data[:attributes]).to eq({ totalSubmissions: 3 })
-      end
-    end
   end
 
   get 'web_api/v1/phases/:id/as_xlsx' do

--- a/back/spec/acceptance/projects_spec.rb
+++ b/back/spec/acceptance/projects_spec.rb
@@ -917,24 +917,6 @@ resource 'Projects' do
           }
         ])
       end
-
-      example 'Downloaded inputs do not include ideas with no content' do
-        # Simulating a survey response with no content, which already
-        # existed before the phase participation_method was changed.
-        survey_response.title_multiloc = {}
-        survey_response.body_multiloc = {}
-        survey_response.save!(validate: false)
-
-        native_survey_phase.update!(participation_method: 'ideation', input_term: 'idea')
-
-        do_request
-        assert_status 200
-        xlsx = xlsx_contents response_body
-        expect(xlsx.size).to eq 3
-
-        all_values = xlsx.flat_map { |sheet| sheet[:rows].flatten }
-        expect(all_values).not_to include(survey_response.id)
-      end
     end
   end
 

--- a/back/spec/acceptance/projects_spec.rb
+++ b/back/spec/acceptance/projects_spec.rb
@@ -925,7 +925,7 @@ resource 'Projects' do
         survey_response.body_multiloc = {}
         survey_response.save!(validate: false)
 
-        native_survey_phase.update!(participation_method: 'ideation')
+        native_survey_phase.update!(participation_method: 'ideation', input_term: 'idea')
 
         do_request
         assert_status 200

--- a/back/spec/lib/participation_method/ideation_spec.rb
+++ b/back/spec/lib/participation_method/ideation_spec.rb
@@ -213,6 +213,21 @@ RSpec.describe ParticipationMethod::Ideation do
     end
   end
 
+  describe '#validate_phase' do
+    it 'does not add an error with transitive inputs' do
+      create(:idea, phases: [phase], project: phase.project)
+      expect(phase).to be_valid
+    end
+
+    it 'adds an error with non-transitive inputs' do
+      phase.update!(participation_method: 'proposals', reacting_threshold: 50, expire_days_limit: 10)
+      create(:proposal, creation_phase: phase, project: phase.project)
+      phase.participation_method = 'ideation'
+      expect(phase).not_to be_valid
+      expect(phase.errors.details).to eq({ participation_method: [{ error: :non_complying_inputs }] })
+    end
+  end
+
   its(:additional_export_columns) { is_expected.to eq %w[manual_votes] }
   its(:allowed_ideas_orders) { is_expected.to eq %w[trending random popular -new new comments_count] }
   its(:return_disabled_actions?) { is_expected.to be false }
@@ -235,7 +250,6 @@ RSpec.describe ParticipationMethod::Ideation do
   its(:supports_private_attributes_in_export?) { is_expected.to be true }
   its(:form_logic_enabled?) { is_expected.to be false }
   its(:follow_idea_on_idea_submission?) { is_expected.to be true }
-  its(:validate_phase) { is_expected.to be_nil }
   its(:supports_custom_field_categories?) { is_expected.to be false }
   its(:user_fields_in_form?) { is_expected.to be false }
   its(:supports_multiple_phase_reports?) { is_expected.to be false }

--- a/back/spec/lib/participation_method/information_spec.rb
+++ b/back/spec/lib/participation_method/information_spec.rb
@@ -114,7 +114,6 @@ RSpec.describe ParticipationMethod::Information do
   its(:supports_private_attributes_in_export?) { is_expected.to be false }
   its(:form_logic_enabled?) { is_expected.to be false }
   its(:follow_idea_on_idea_submission?) { is_expected.to be false }
-  its(:validate_phase) { is_expected.to be_nil }
   its(:supports_custom_field_categories?) { is_expected.to be false }
   its(:user_fields_in_form?) { is_expected.to be false }
   its(:supports_multiple_phase_reports?) { is_expected.to be false }

--- a/back/spec/lib/participation_method/native_survey_spec.rb
+++ b/back/spec/lib/participation_method/native_survey_spec.rb
@@ -281,7 +281,6 @@ RSpec.describe ParticipationMethod::NativeSurvey do
   its(:transitive?) { is_expected.to be false }
   its(:form_logic_enabled?) { is_expected.to be true }
   its(:follow_idea_on_idea_submission?) { is_expected.to be false }
-  its(:validate_phase) { is_expected.to be_nil }
   its(:supports_custom_field_categories?) { is_expected.to be false }
   its(:supports_multiple_phase_reports?) { is_expected.to be false }
   its(:add_autoreaction_to_inputs?) { is_expected.to be(false) }

--- a/back/spec/lib/participation_method/none_spec.rb
+++ b/back/spec/lib/participation_method/none_spec.rb
@@ -97,7 +97,6 @@ RSpec.describe ParticipationMethod::None do
   its(:supports_private_attributes_in_export?) { is_expected.to be false }
   its(:form_logic_enabled?) { is_expected.to be false }
   its(:follow_idea_on_idea_submission?) { is_expected.to be false }
-  its(:validate_phase) { is_expected.to be_nil }
   its(:supports_custom_field_categories?) { is_expected.to be false }
   its(:user_fields_in_form?) { is_expected.to be false }
   its(:supports_multiple_phase_reports?) { is_expected.to be false }

--- a/back/spec/lib/participation_method/poll_spec.rb
+++ b/back/spec/lib/participation_method/poll_spec.rb
@@ -113,7 +113,6 @@ RSpec.describe ParticipationMethod::Poll do
   its(:supports_private_attributes_in_export?) { is_expected.to be false }
   its(:form_logic_enabled?) { is_expected.to be false }
   its(:follow_idea_on_idea_submission?) { is_expected.to be false }
-  its(:validate_phase) { is_expected.to be_nil }
   its(:supports_custom_field_categories?) { is_expected.to be false }
   its(:user_fields_in_form?) { is_expected.to be false }
   its(:supports_multiple_phase_reports?) { is_expected.to be false }

--- a/back/spec/lib/participation_method/proposals_spec.rb
+++ b/back/spec/lib/participation_method/proposals_spec.rb
@@ -204,6 +204,13 @@ RSpec.describe ParticipationMethod::Proposals do
     end
   end
 
+  describe '#validate_phase' do
+    it 'does not add an error with non-transitive inputs' do
+      create(:proposal, creation_phase: phase, project: phase.project)
+      expect(phase).to be_valid
+    end
+  end
+
   describe '#supported_email_campaigns' do
     it 'returns campaigns supported for proposals' do
       expect(participation_method.supported_email_campaigns).to match_array %w[comment_deleted_by_admin comment_on_idea_you_follow comment_on_your_comment cosponsor_of_your_idea idea_published invitation_to_cosponsor_idea mention_in_official_feedback official_feedback_on_idea_you_follow project_phase_started status_change_on_idea_you_follow your_input_in_screening]
@@ -243,7 +250,6 @@ RSpec.describe ParticipationMethod::Proposals do
   its(:supports_private_attributes_in_export?) { is_expected.to be true }
   its(:form_logic_enabled?) { is_expected.to be false }
   its(:follow_idea_on_idea_submission?) { is_expected.to be true }
-  its(:validate_phase) { is_expected.to be_nil }
   its(:supports_custom_field_categories?) { is_expected.to be false }
   its(:user_fields_in_form?) { is_expected.to be false }
   its(:supports_multiple_phase_reports?) { is_expected.to be false }

--- a/back/spec/lib/participation_method/survey_spec.rb
+++ b/back/spec/lib/participation_method/survey_spec.rb
@@ -114,7 +114,6 @@ RSpec.describe ParticipationMethod::Survey do
   its(:supports_private_attributes_in_export?) { is_expected.to be false }
   its(:form_logic_enabled?) { is_expected.to be false }
   its(:follow_idea_on_idea_submission?) { is_expected.to be false }
-  its(:validate_phase) { is_expected.to be_nil }
   its(:supports_custom_field_categories?) { is_expected.to be false }
   its(:user_fields_in_form?) { is_expected.to be false }
   its(:supports_multiple_phase_reports?) { is_expected.to be false }

--- a/back/spec/lib/participation_method/volunteering_spec.rb
+++ b/back/spec/lib/participation_method/volunteering_spec.rb
@@ -113,7 +113,6 @@ RSpec.describe ParticipationMethod::Volunteering do
   its(:supports_private_attributes_in_export?) { is_expected.to be false }
   its(:form_logic_enabled?) { is_expected.to be false }
   its(:follow_idea_on_idea_submission?) { is_expected.to be false }
-  its(:validate_phase) { is_expected.to be_nil }
   its(:supports_custom_field_categories?) { is_expected.to be false }
   its(:user_fields_in_form?) { is_expected.to be false }
   its(:supports_multiple_phase_reports?) { is_expected.to be false }

--- a/back/spec/lib/participation_method/voting_spec.rb
+++ b/back/spec/lib/participation_method/voting_spec.rb
@@ -172,6 +172,21 @@ RSpec.describe ParticipationMethod::Voting do
     end
   end
 
+  describe '#validate_phase' do
+    it 'does not add an error with transitive inputs' do
+      create(:idea, phases: [phase], project: phase.project)
+      expect(phase).to be_valid
+    end
+
+    it 'adds an error with non-transitive inputs' do
+      phase.update!(participation_method: 'proposals', reacting_threshold: 50, expire_days_limit: 10)
+      create(:proposal, creation_phase: phase, project: phase.project)
+      phase.participation_method = 'voting'
+      expect(phase).not_to be_valid
+      expect(phase.errors.details).to eq({ participation_method: [{ error: :non_complying_inputs }] })
+    end
+  end
+
   its(:allowed_ideas_orders) { is_expected.to eq ['random'] }
   its(:return_disabled_actions?) { is_expected.to be false }
   its(:supports_assignment?) { is_expected.to be true }

--- a/back/spec/models/phase_spec.rb
+++ b/back/spec/models/phase_spec.rb
@@ -94,6 +94,7 @@ RSpec.describe Phase do
       phase.participation_method = 'voting'
       phase.voting_method = 'budgeting'
       phase.voting_max_total = 200
+      phase.input_term = 'idea'
       expect(phase.save).to be true
     end
   end

--- a/back/spec/services/permissions/permissions_update_service_spec.rb
+++ b/back/spec/services/permissions/permissions_update_service_spec.rb
@@ -41,7 +41,7 @@ describe Permissions::PermissionsUpdateService do
       expect(phase.permissions.pluck(:action)).to match_array %w[posting_idea attending_event]
       expect(phase.permissions.pluck(:permitted_by)).to match_array %w[everyone users]
 
-      phase.update!(participation_method: 'ideation')
+      phase.update!(participation_method: 'ideation', input_term: 'idea')
       service.update_permissions_for_scope(phase)
       expect(phase.permissions.pluck(:action)).to match_array %w[posting_idea commenting_idea reacting_idea attending_event]
       expect(phase.permissions.pluck(:permitted_by)).to match_array %w[users users users users]
@@ -62,7 +62,7 @@ describe Permissions::PermissionsUpdateService do
       expect(phase.permissions.pluck(:action)).to match_array %w[posting_idea attending_event]
       expect(phase.permissions.pluck(:permitted_by)).to match_array %w[users users]
 
-      phase.update!(participation_method: 'ideation')
+      phase.update!(participation_method: 'ideation', input_term: 'idea')
       service.update_permissions_for_scope(phase)
       expect(phase.permissions.pluck(:action)).to match_array %w[posting_idea commenting_idea reacting_idea attending_event]
       expect(phase.permissions.pluck(:permitted_by)).to match_array %w[users users users users]


### PR DESCRIPTION
The previous solution is now also applied for voting phases.

But while adding tests I ran into another issue: the phase was being validating using the previous participation method rather than the new one when updating the participation method. I decided to get rid of the "memoizing" of the participation method, as instantiating a simple class is very fast compared to running SQL queries. I think it's much more preferable to have robust code, that doesn't cause unexpected bugs. This is why other specs had to be updated, as the ideation method requires the input term to be present.

I ran the script on a benelux sandbox and the only input that will be deleted there is the input that is currently causing the remaining Sentry issue.