### PR TITLE
[TAN-5196] Refactor OpenAI clients to use the new Responses API

### DIFF
--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -25,7 +25,7 @@ PATH
       matrix (~> 0.4.2)
       prime (~> 0.1.3)
       rails (~> 7.0)
-      ruby-openai (>= 6.3, < 8.0)
+      ruby-openai (~> 8.3.0)
       tiktoken_ruby (~> 0.0.12)
 
 PATH
@@ -1186,7 +1186,7 @@ GEM
       rubocop-rspec_rails (~> 2.28)
     rubocop-rspec_rails (2.28.3)
       rubocop (~> 1.40)
-    ruby-openai (7.4.0)
+    ruby-openai (8.3.0)
       event_stream_parser (>= 0.3.0, < 2.0.0)
       faraday (>= 1)
       faraday-multipart (>= 1)

--- a/back/engines/commercial/analysis/analysis.gemspec
+++ b/back/engines/commercial/analysis/analysis.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib}/**/*', 'Rakefile', 'README.md']
 
   s.add_dependency 'rails', '~> 7.0'
-  s.add_dependency 'ruby-openai', '>= 6.3', '< 8.0'
+  s.add_dependency 'ruby-openai', '~> 8.3.0'
   s.add_dependency 'tiktoken_ruby', '~> 0.0.12'
   s.add_dependency 'concurrent-ruby', '~> 1.2.3'
   s.add_dependency 'distribution', '~> 0.8.0'

--- a/back/engines/commercial/analysis/app/jobs/analysis/q_and_a_job.rb
+++ b/back/engines/commercial/analysis/app/jobs/analysis/q_and_a_job.rb
@@ -10,6 +10,7 @@ module Analysis
       # changed between enqueueing and executing this job
       plan = QAndAMethod::Base.plan(question)
 
+      # @type [Analysis::QAndAMethod::Base]
       q_and_a_method = plan.q_and_a_method_class.new(question)
       q_and_a_method.execute(plan)
     end

--- a/back/engines/commercial/analysis/app/lib/analysis/LLM/azure_open_ai.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/LLM/azure_open_ai.rb
@@ -23,7 +23,7 @@ module Analysis
         # model name, stripping out any characters that are not allowed in Azure
         # deployment names.
         def azure_deployment_name
-          gpt_model.gsub(/[^a-zA-Z0-9.-]/, '')
+          gpt_model.gsub(/[^\w.-]/, '')
         end
       end
 

--- a/back/engines/commercial/analysis/app/lib/analysis/LLM/azure_open_ai.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/LLM/azure_open_ai.rb
@@ -13,10 +13,6 @@ module Analysis
           raise NotImplementedError
         end
 
-        def headroom_ratio
-          0.85
-        end
-
         # On Azure, each model needs to be deployed separately and given its own
         # name. To avoid having to introduce an extra deployment_name parameter
         # per model in our configuration, we derive the deployment name from the
@@ -24,6 +20,10 @@ module Analysis
         # deployment names.
         def azure_deployment_name
           gpt_model.gsub(/[^\w.-]/, '')
+        end
+
+        def headroom_ratio
+          0.85
         end
       end
 

--- a/back/engines/commercial/analysis/app/lib/analysis/LLM/message.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/LLM/message.rb
@@ -1,0 +1,21 @@
+module Analysis
+  module LLM
+    class Message
+      attr_reader :role, :inputs
+      alias content inputs
+
+      def initialize(*inputs, role: 'user')
+        @role = role
+        @inputs = inputs
+      end
+
+      def self.wrap(message)
+        case message
+        when self then message
+        when String then new(message)
+        else raise ArgumentError, "Unsupported message type: #{message.class}"
+        end
+      end
+    end
+  end
+end

--- a/back/engines/commercial/analysis/app/lib/analysis/q_and_a_method/base.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/q_and_a_method/base.rb
@@ -60,6 +60,10 @@ module Analysis
 
     protected
 
+    def run(plan)
+      raise NotImplementedError
+    end
+
     def filtered_inputs
       @filtered_inputs ||= InputsFinder.new(analysis, question.filters.symbolize_keys).execute
     end

--- a/back/engines/commercial/analysis/app/lib/analysis/q_and_a_method/one_pass_llm.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/q_and_a_method/one_pass_llm.rb
@@ -27,10 +27,10 @@ module Analysis
         inputs_text = input_to_text.format_all(filtered_inputs.includes(:comments), **input_to_text_options)
         prompt = prompt(@analysis.source_project, inputs_text, input_to_text_options[:include_comments])
 
-        # As a rule of thumb, 1 token corresponds to ~4 charachters in English.
+        # As a rule of thumb, 1 token corresponds to ~4 characters in English.
         # Since calculating the token_count is slow, as an optimization, we
         # don't even bother calculating the token count for a safe worst case of
-        # 6 charachters/token
+        # 6 characters/token
         next if prompt.size > (max_context_window * 6)
 
         # Is there an LLM that can handle the prompt size?

--- a/back/engines/commercial/analysis/app/lib/analysis/q_and_a_method/one_pass_llm.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/q_and_a_method/one_pass_llm.rb
@@ -56,6 +56,7 @@ module Analysis
     protected
 
     # Use `execute` on the parent class to actually use the method
+    # @param plan [Analysis::QAndAPlan]
     def run(plan)
       inputs_text = input_to_text.format_all(
         filtered_inputs,

--- a/back/engines/commercial/analysis/app/lib/analysis/summarization_method/one_pass_llm.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/summarization_method/one_pass_llm.rb
@@ -27,10 +27,10 @@ module Analysis
         inputs_text = input_to_text.format_all(filtered_inputs.includes(:comments), **input_to_text_options)
         prompt = prompt(@analysis.source_project, inputs_text, input_to_text_options[:include_comments])
 
-        # As a rule of thumb, 1 token corresponds to ~4 charachters in English.
+        # As a rule of thumb, 1 token corresponds to ~4 characters in English.
         # Since calculating the token_count is slow, as an optimization, we
         # don't even bother calculating the token count for a safe worst case of
-        # 6 charachters/token
+        # 6 characters/token
         next if prompt.size > (max_context_window * 6)
 
         # Which LLM can handle the prompt size?

--- a/back/engines/commercial/analysis/spec/lib/llm/azure_open_ai_spec.rb
+++ b/back/engines/commercial/analysis/spec/lib/llm/azure_open_ai_spec.rb
@@ -17,40 +17,79 @@ RSpec.describe Analysis::LLM::AzureOpenAI do
   describe 'chat' do
     before { allow(service).to receive(:sleep) } # Don't sleep while testing
 
-    it 'reports error when response is 429 and retries is 0' do
-      allow(service.instance_variable_get(:@client)).to(
-        receive(:chat).and_raise(Faraday::TooManyRequestsError.new(status: 429))
-      )
-      expect { service.chat('fake prompt', retries: 0) }.to raise_error(Faraday::TooManyRequestsError)
-      expect(ErrorReporter).to have_received :report_msg
+    # A simplified version of a successful response from Azure OpenAI Responses API.
+    # A better approach would be to use VCR to record and replay actual API responses.
+    let(:simplified_response) do
+      {
+        'id' => 'resp_0f89cbd1c06a0ef90168e3eccd09988197929b3f176d8fd7a6',
+        'status' => 'completed',
+        'output' => [{
+          'id' => 'msg_0f89cbd1c06a0ef90168e3eccd72f8819796810f939adc81ef',
+          'type' => 'message',
+          'status' => 'completed',
+          'content' => [{ 'type' => 'output_text', 'text' => 'The weather today is...' }],
+          'role' => 'assistant'
+        }]
+      }
     end
 
-    it 'retries when response is 429 and retries > 0' do
-      allow(service).to receive(:chat_with_retry).with(retries: 3, parameters: anything).and_call_original
-      allow(service.instance_variable_get(:@client)).to(
-        receive(:chat).and_raise(Faraday::TooManyRequestsError.new(status: 429))
-      )
-      fake_response = { 'choices' => [{ 'message' => { 'content' => 'fake response' } }] }
-      allow(service).to receive(:chat_with_retry).with(retries: 2, parameters: anything).and_return(fake_response)
-      expect(service.chat('fake prompt', retries: 3)).to eq 'fake response'
-      expect(service).to have_received(:chat_with_retry).twice
-      expect(ErrorReporter).not_to have_received :report_msg
+    context 'when the OpenAI API returns "Too Many Requests" errors' do
+      let(:too_many_requests_error) { Faraday::TooManyRequestsError.new(status: 429) }
+
+      it "doesn't retry when retries is set to 0" do
+        expect(service.response_client)
+          .to receive(:create).once.and_raise(too_many_requests_error)
+
+        expect(ErrorReporter).to receive(:report_msg).once
+
+        expect { service.chat('Hello, how are you?', retries: 0) }
+          .to raise_error(Faraday::TooManyRequestsError)
+      end
+
+      it 'retries the specified number of times before raising the error' do
+        max_retries = 2
+
+        expect(service.response_client)
+          .to receive(:create).exactly(max_retries + 1).times
+          .and_raise(too_many_requests_error)
+
+        expect(ErrorReporter).to receive(:report_msg).once
+
+        expect { service.chat('Hello, how are you?', retries: max_retries) }
+          .to raise_error(Faraday::TooManyRequestsError)
+      end
+
+      it 'retries MAX_RETRIES times by default' do
+        expect(service.response_client)
+          .to receive(:create).exactly(described_class::MAX_RETRIES + 1).times
+          .and_raise(too_many_requests_error)
+
+        expect(ErrorReporter).to receive(:report_msg).once
+
+        expect { service.chat('Hello, how are you?') }
+          .to raise_error(Faraday::TooManyRequestsError)
+      end
+
+      it 'succeeds if a retry succeeds within the allowed attempts' do
+        call_count = 0
+        success_on_attempt = 3
+
+        allow(service.response_client).to receive(:create) do
+          call_count += 1
+          call_count < success_on_attempt ? (raise too_many_requests_error) : simplified_response
+        end
+
+        expect(service.chat('Hello?', retries: 5)).to eq('The weather today is...')
+        expect(service.response_client).to have_received(:create).exactly(success_on_attempt).times
+        expect(ErrorReporter).not_to have_received :report_msg
+      end
     end
 
-    it 'reports error when response is not 429 and retries > 0' do
-      allow(service.instance_variable_get(:@client)).to(
-        receive(:chat).and_raise(Faraday::TooManyRequestsError.new(status: 400))
-      )
-      expect { service.chat('fake prompt', retries: 3) }.to raise_error(Faraday::TooManyRequestsError)
-      expect(ErrorReporter).to have_received :report_msg
-    end
+    it 'returns the response text when the API call is successful' do
+      allow(service.response_client)
+        .to receive(:create).once.and_return(simplified_response)
 
-    it 'returns when response is ok' do
-      fake_response = { 'choices' => [{ 'message' => { 'content' => 'fake response' } }] }
-      allow(service.instance_variable_get(:@client)).to(
-        receive(:chat).and_return(fake_response)
-      )
-      expect(service.chat('fake prompt')).to eq 'fake response'
+      expect(service.chat('Hello?')).to eq('The weather today is...')
       expect(ErrorReporter).not_to have_received :report_msg
     end
 


### PR DESCRIPTION
# Changelog
## Technical
- [TAN-5196] Refactor OpenAI clients to use the new Responses API and prep work to support files in Sensemaking

