### PR TITLE
TAN-5579 - Added link to AzureAD login when the only other login method is email and password

### DIFF
--- a/front/app/containers/Authentication/steps/AuthProviders/index.tsx
+++ b/front/app/containers/Authentication/steps/AuthProviders/index.tsx
@@ -24,6 +24,7 @@ import SSOButtonsExceptFCAndCU from '../_components/SSOButtonsExceptFCAndCU';
 import TextButton from '../_components/TextButton';
 
 import messages from './messages';
+import authMessages from '../messages';
 
 const Container = styled.div`
   display: flex;
@@ -162,7 +163,7 @@ const AuthProviders = memo<Props>(
               textDecoration="underline"
               color="textSecondary"
             >
-              <FormattedMessage {...messages.adminOptions} />
+              <FormattedMessage {...authMessages.adminOptions} />
             </Text>
           </Link>
         )}

--- a/front/app/containers/Authentication/steps/AuthProviders/index.tsx
+++ b/front/app/containers/Authentication/steps/AuthProviders/index.tsx
@@ -22,9 +22,9 @@ import AuthProviderButton, {
 import ClaveUnicaExpandedAuthProviderButton from '../_components/ClaveUnicaExpandedAuthProviderButton';
 import SSOButtonsExceptFCAndCU from '../_components/SSOButtonsExceptFCAndCU';
 import TextButton from '../_components/TextButton';
+import authMessages from '../messages';
 
 import messages from './messages';
-import authMessages from '../messages';
 
 const Container = styled.div`
   display: flex;
@@ -59,7 +59,6 @@ const AuthProviders = memo<Props>(
 
     // Show link to the above hidden path
     const showAdminLoginLink =
-      (flow === 'signin' || flow === 'signup') &&
       tenantSettings?.azure_ad_login?.visibility === 'link';
 
     const handleOnFranceConnectSelected = useCallback(

--- a/front/app/containers/Authentication/steps/AuthProviders/index.tsx
+++ b/front/app/containers/Authentication/steps/AuthProviders/index.tsx
@@ -58,7 +58,7 @@ const AuthProviders = memo<Props>(
 
     // Show link to the above hidden path
     const showAdminLoginLink =
-      flow === 'signin' &&
+      (flow === 'signin' || flow === 'signup') &&
       tenantSettings?.azure_ad_login?.visibility === 'link';
 
     const handleOnFranceConnectSelected = useCallback(

--- a/front/app/containers/Authentication/steps/AuthProviders/messages.ts
+++ b/front/app/containers/Authentication/steps/AuthProviders/messages.ts
@@ -96,8 +96,4 @@ export default defineMessages({
     defaultMessage:
       'By signing up, you agree to receive emails from this platform. You can select which emails you wish to receive from your user settings.',
   },
-  adminOptions: {
-    id: 'app.containers.SignUp.adminOptions2',
-    defaultMessage: 'For admins and project managers',
-  },
 });

--- a/front/app/containers/Authentication/steps/EmailAndPassword/index.tsx
+++ b/front/app/containers/Authentication/steps/EmailAndPassword/index.tsx
@@ -11,6 +11,8 @@ import TextButton from '../_components/TextButton';
 
 import Form from './Form';
 import messages from './messages';
+import authMessages from '../messages';
+import useAppConfiguration from 'api/app_configuration/useAppConfiguration';
 
 interface Props {
   loading: boolean;
@@ -36,6 +38,12 @@ const EmailAndPassword = ({
 }: Props) => {
   const { anySSOProviderEnabled } = useAuthConfig();
   const { formatMessage } = useIntl();
+  const { data: tenant } = useAppConfiguration();
+  const tenantSettings = tenant?.data.attributes.settings;
+
+  // Show link to the Azure AD button?
+  const showAdminLoginLink =
+    tenantSettings?.azure_ad_login?.visibility === 'link';
 
   return (
     <Box id="e2e-sign-in-email-password-container">
@@ -71,6 +79,13 @@ const EmailAndPassword = ({
           />
         )}
       </Text>
+      {showAdminLoginLink && (
+        <a href="/sign-in/admin">
+          <Text fontSize="xs" textDecoration="underline" color="textSecondary">
+            <FormattedMessage {...authMessages.adminOptions} />
+          </Text>
+        </a>
+      )}
     </Box>
   );
 };

--- a/front/app/containers/Authentication/steps/EmailAndPassword/index.tsx
+++ b/front/app/containers/Authentication/steps/EmailAndPassword/index.tsx
@@ -2,17 +2,18 @@ import React from 'react';
 
 import { Box, Text } from '@citizenlab/cl2-component-library';
 
+import useAppConfiguration from 'api/app_configuration/useAppConfiguration';
+
 import { SetError } from 'containers/Authentication/typings';
 import useAuthConfig from 'containers/Authentication/useAuthConfig';
 
 import { useIntl, FormattedMessage } from 'utils/cl-intl';
 
 import TextButton from '../_components/TextButton';
+import authMessages from '../messages';
 
 import Form from './Form';
 import messages from './messages';
-import authMessages from '../messages';
-import useAppConfiguration from 'api/app_configuration/useAppConfiguration';
 
 interface Props {
   loading: boolean;

--- a/front/app/containers/Authentication/steps/messages.ts
+++ b/front/app/containers/Authentication/steps/messages.ts
@@ -58,4 +58,8 @@ export default defineMessages({
     id: 'app.containers.SignUp.emptyLastNameError',
     defaultMessage: 'Enter your last name',
   },
+  adminOptions: {
+    id: 'app.containers.SignUp.adminOptions2',
+    defaultMessage: 'For admins and project managers',
+  },
 });


### PR DESCRIPTION
Note sure, but don't think this link was ever there for email and password login.

This is basically what I have developed:
<img width="537" height="505" alt="image" src="https://github.com/user-attachments/assets/5592b107-acd8-4a1b-bc49-733cf5711293" />

But in order to get it to link to here (which it would do if there were already 2 login methods:
<img width="474" height="308" alt="image" src="https://github.com/user-attachments/assets/ea624006-6c63-44a2-9f4c-52be7dae0d62" />

I have to use `<a href` to reload the page instead of using `<Link` as I cannot get that to refresh the modal until I subsequently click back.

# Changelog
## Fixed
- Added link to AzureAD login when the only other login method is email and password
