### PR TITLE
Remove Folder link E2E test

### DIFF
--- a/front/cypress/e2e/admin/projects/project_settings.cy.ts
+++ b/front/cypress/e2e/admin/projects/project_settings.cy.ts
@@ -30,14 +30,6 @@ describe('Project settings', () => {
     });
   });
 
-  describe('Folder', () => {
-    it('The folder preview links to the folder selector', () => {
-      cy.visit(`admin/projects/${globalProjectId}`);
-      cy.dataCy('e2e-folder-preview-link-to-settings').click();
-      cy.dataCy('e2e-project-folder-setting-field').should('exist');
-    });
-  });
-
   describe('Project title', () => {
     it('The title preview links to project title settings', () => {
       cy.visit(`admin/projects/${globalProjectId}`);


### PR DESCRIPTION
Description: Removes Folder link E2E test which isn't required anymore after we've replaced this with a project dropdown.