### PR TITLE
[No-ticket] Bugfix: use string not symbol in error

### DIFF
--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -362,9 +362,13 @@ class User < ApplicationRecord
     domain = email_field.split('@')&.last
     return unless domain
 
-    # Mild obfuscation of error message to make a spammers life a little more difficult,
-    # especially avoiding leaking info about which domains are blacklisted
-    errors.add(:email, :something_went_wrong, code: 'zrb-42') if EMAIL_DOMAIN_BLACKLIST.include?(domain.strip.downcase)
+    if EMAIL_DOMAIN_BLACKLIST.include?(domain.strip.downcase)
+      # Mild obfuscation of error message to make a spammers life a little more difficult,
+      # especially avoiding leaking info about which domains are blacklisted.
+      # Error is a string, not a symbol, as it is translated on FE, not BE.
+      errors.add(:email, 'something_went_wrong', code: 'zrb-42')
+      Rails.logger.info "Validation error! Email domain blacklisted: #{domain}" # Clearer message in the logs
+    end
   end
 
   def remove_initiated_notifications

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe User do
 
       # We mildly obfuscate the error message to make a spammers life a little more difficult,
       # especially avoiding leaking info about which domains are blacklisted.
-      expect(u1.errors.details[:email]).to eq [{ error: :something_went_wrong, code: 'zrb-42' }]
+      expect(u1.errors.details[:email]).to eq [{ error: 'something_went_wrong', code: 'zrb-42' }]
     end
 
     it 'is required when a unique code is not present' do
@@ -231,7 +231,7 @@ RSpec.describe User do
 
       # We mildly obfuscate the error message to make a spammers life a little more difficult,
       # especially avoiding leaking info about which domains are blacklisted.
-      expect(user.errors.details[:email]).to eq [{ error: :something_went_wrong, code: 'zrb-42' }]
+      expect(user.errors.details[:email]).to eq [{ error: 'something_went_wrong', code: 'zrb-42' }]
     end
 
     it 'is invalid email if the new email is not a valid email' do


### PR DESCRIPTION
Because the error is translated on the FE, using a symbol for the error raises a translation error in the BE, obfuscating the validation error. Fixed by using a string instead.

Also adds info logging to more clearly explain the error in server logs.
