### PR TITLE
[TAN-5569] Only validate emails against blocked domains when changing email value

### DIFF
--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -193,7 +193,7 @@ class User < ApplicationRecord
   validate :validate_not_duplicate_email
   validate :validate_not_duplicate_new_email
   validate :validate_can_update_email, on: :form_submission # only called if `save` is called w/ `context: :form_submission`
-  validate :validate_email_domains_blacklist
+  validate :validate_email_domains_blacklist, if: :email_or_new_email_changed?
 
   before_destroy :remove_initiated_notifications # Must occur before has_many :notifications (see https://github.com/rails/rails/issues/5205)
   has_many :notifications, foreign_key: :recipient_id, dependent: :destroy
@@ -349,6 +349,10 @@ class User < ApplicationRecord
     )
     self.bio_multiloc = service.remove_multiloc_empty_trailing_tags(bio_multiloc)
     self.bio_multiloc = service.linkify_multiloc(bio_multiloc)
+  end
+
+  def email_or_new_email_changed?
+    new_record? || email_changed? || new_email_changed?
   end
 
   def validate_email_domains_blacklist

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -363,10 +363,12 @@ class User < ApplicationRecord
     return unless domain
 
     if EMAIL_DOMAIN_BLACKLIST.include?(domain.strip.downcase)
+      field = (email_field == new_email ? :new_email : :email)
+
       # Mild obfuscation of error message to make a spammers life a little more difficult,
       # especially avoiding leaking info about which domains are blacklisted.
       # Error is a string, not a symbol, as it is translated on FE, not BE.
-      errors.add(:email, 'something_went_wrong', code: 'zrb-42')
+      errors.add(field, 'something_went_wrong', code: 'zrb-42')
       Rails.logger.info "Validation error! Email domain blacklisted: #{domain}" # Clearer message in the logs
     end
   end

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -227,11 +227,10 @@ RSpec.describe User do
     it 'is invalid if the domain is on our blacklist' do
       user = build(:user, new_email: 'xwrknecgyq_1542135485@039b1ee.netsolhost.com')
       expect(user).to be_invalid
-      expect(user.errors.details[:new_email]).not_to be_present
 
       # We mildly obfuscate the error message to make a spammers life a little more difficult,
       # especially avoiding leaking info about which domains are blacklisted.
-      expect(user.errors.details[:email]).to eq [{ error: 'something_went_wrong', code: 'zrb-42' }]
+      expect(user.errors.details[:new_email]).to eq [{ error: 'something_went_wrong', code: 'zrb-42' }]
     end
 
     it 'is invalid email if the new email is not a valid email' do


### PR DESCRIPTION
Being 'safe' by assuming users who already existed and are using an email domain on our [recently implemented](https://github.com/CitizenLabDotCo/citizenlab/pull/12214) blacklisting of common_spam_domains, may be 'real' users, and not spam usres.

In other words, we only prevent usage of these email domains when creating a new user with such a domain in the `email` or `new_email` field, or when updating either field to use a blocked domain.

# Changelog
## Technical
- [TAN-5569] Only validate emails against blocked domains when changing email value
