### PR TITLE
[TAN-5569] Log remote_ip when user creation blocked due to blocked email domain

### DIFF
--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -149,7 +149,7 @@ class WebApi::V1::UsersController < ApplicationController
         params: jsonapi_serializer_params
       ).serializable_hash, status: :ok
     else
-      SideFxUserService.new.after_error(@user)
+      SideFxUserService.new.after_error(@user, request&.remote_ip)
 
       render json: { errors: @user.errors.details }, status: :unprocessable_entity
     end

--- a/back/app/services/side_fx_user_service.rb
+++ b/back/app/services/side_fx_user_service.rb
@@ -66,7 +66,7 @@ class SideFxUserService
     LogActivityJob.perform_later(user, 'unblocked', current_user, user.updated_at.to_i)
   end
 
-  def after_error(user)
+  def after_error(user, remote_ip)
     return unless user.errors.details[:email].any? { |e| e[:code] == 'zrb-42' }
 
     # We pass AppConfiguration.instance as item (required)
@@ -76,7 +76,7 @@ class SideFxUserService
       'blacklisted_email_domain_used',
       nil,
       Time.current,
-      payload: { email: user.email }
+      payload: { email: user.email, remote_ip: remote_ip }
     )
   end
 

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -259,7 +259,7 @@ resource 'Users' do
               'blacklisted_email_domain_used',
               nil,
               anything,
-              payload: { email: email }
+              payload: { email: email, remote_ip: anything }
             )
           end
         end


### PR DESCRIPTION
# Changelog
## Technical
- [TAN-5569] Log remote_ip when user creation blocked due to blocked email domain
