### PR TITLE
TAN-5393 Separate similar ideas for title and description fields

### DIFF
--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -1301,7 +1301,7 @@ GEM
     unparser (0.6.7)
       diff-lcs (~> 1.3)
       parser (>= 3.2.0)
-    uri (1.0.3)
+    uri (1.0.4)
     validate_email (0.1.6)
       activemodel (>= 3.0)
       mail (>= 2.2.5)

--- a/front/app/components/CustomFieldsForm/CustomFields.tsx
+++ b/front/app/components/CustomFieldsForm/CustomFields.tsx
@@ -238,7 +238,7 @@ const CustomFields = ({
               )}
               {renderField({ question, projectId, ideaId })}
               {question?.code && inputIqFields.includes(question.code) && (
-                <InputIQ phase={phase} />
+                <InputIQ phase={phase} field={question} />
               )}
             </Box>
           );

--- a/front/app/components/CustomFieldsForm/InputIQ/index.tsx
+++ b/front/app/components/CustomFieldsForm/InputIQ/index.tsx
@@ -7,8 +7,15 @@ import { IPhaseData } from 'api/phases/types';
 import useFeatureFlag from 'hooks/useFeatureFlag';
 
 import SimilarIdeasList from 'containers/IdeasNewPage/SimilarInputs/SimilarInputsList';
+import { IFlatCustomField } from 'api/custom_fields/types';
 
-const InputIQ = ({ phase }: { phase: IPhaseData | undefined }) => {
+const InputIQ = ({
+  phase,
+  field,
+}: {
+  phase: IPhaseData | undefined;
+  field: IFlatCustomField;
+}) => {
   const { watch } = useFormContext();
   const isInputIQEnabled = useFeatureFlag({
     name: 'input_iq',
@@ -17,8 +24,9 @@ const InputIQ = ({ phase }: { phase: IPhaseData | undefined }) => {
     phase?.attributes.similarity_enabled && isInputIQEnabled
   );
 
-  const titleMultiloc = watch('title_multiloc');
-  const bodyMultiloc = watch('body_multiloc');
+  const titleMultiloc =
+    field.code === 'title_multiloc' && watch('title_multiloc');
+  const bodyMultiloc = field.code === 'body_multiloc' && watch('body_multiloc');
 
   // Debounced values for similar ideas lookup
   const [debouncedTitleMultiloc, setDebouncedTitleMultiloc] =

--- a/front/app/components/CustomFieldsForm/InputIQ/index.tsx
+++ b/front/app/components/CustomFieldsForm/InputIQ/index.tsx
@@ -24,9 +24,8 @@ const InputIQ = ({
     phase?.attributes.similarity_enabled && isInputIQEnabled
   );
 
-  const titleMultiloc =
-    field.code === 'title_multiloc' && watch('title_multiloc');
-  const bodyMultiloc = field.code === 'body_multiloc' && watch('body_multiloc');
+  const titleMultiloc = watch('title_multiloc');
+  const bodyMultiloc = watch('body_multiloc');
 
   // Debounced values for similar ideas lookup
   const [debouncedTitleMultiloc, setDebouncedTitleMultiloc] =
@@ -50,8 +49,12 @@ const InputIQ = ({
   return (
     <div>
       <SimilarIdeasList
-        titleMultiloc={debouncedTitleMultiloc}
-        bodyMultiloc={debouncedBodyMultiloc}
+        titleMultiloc={
+          field.code === 'title_multiloc' ? debouncedTitleMultiloc : undefined
+        }
+        bodyMultiloc={
+          field.code === 'body_multiloc' ? debouncedBodyMultiloc : undefined
+        }
         phase={phase}
       />
     </div>


### PR DESCRIPTION
It was agreed with Rob that the similar ideas for title and body should now only take only the text of their own field into account, not title+body together. When title and body are on the same page, the results can be different, which makes more sense.

<img width="543" height="840" alt="Screenshot 2025-10-08 at 11 15 07" src="https://github.com/user-attachments/assets/51d08766-422d-4bc4-9c72-dee0889339d6" />
