### PR TITLE
Test: Upgrade React Router v7

### DIFF
--- a/front/.eslintrc.js
+++ b/front/.eslintrc.js
@@ -145,7 +145,7 @@ module.exports = {
             name: 'react-router-dom',
             importNames: ['Link', 'useNavigate', 'NavLink'],
             message:
-              "Import the Link or useNavigate from utils/cl-router instead of directly from 'react-router-dom'",
+              "Import the Link or useNavigate from utils/cl-router instead of directly from 'react-router'",
           },
           {
             name: 'react-intl',

--- a/front/.storybook-build/preview.tsx
+++ b/front/.storybook-build/preview.tsx
@@ -4,7 +4,7 @@ import contexts from '../.storybook/contexts';
 import { initialize, mswDecorator } from 'msw-storybook-addon';
 import mockServer from '../.storybook/mockServer';
 import { reactIntl } from '../.storybook/reactIntl';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { allModes } from '../.storybook/modes';
 import { MINIMAL_VIEWPORTS } from '@storybook/addon-viewport';
 

--- a/front/.storybook/preview.tsx
+++ b/front/.storybook/preview.tsx
@@ -4,7 +4,7 @@ import contexts from './contexts';
 import { initialize, mswDecorator } from 'msw-storybook-addon';
 import mockServer from './mockServer';
 import { reactIntl } from './reactIntl';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { allModes } from './modes';
 import { MINIMAL_VIEWPORTS } from '@storybook/addon-viewport';
 

--- a/front/app/api/graph_data_units/useGraphDataUnits.ts
+++ b/front/app/api/graph_data_units/useGraphDataUnits.ts
@@ -1,5 +1,5 @@
 import { useNode } from '@craftjs/core';
-import { useLocation, useSearchParams } from 'react-router-dom';
+import { useLocation, useSearchParams } from 'react-router';
 
 import useGraphDataUnitsPublished from 'api/graph_data_units/useGraphDataUnitsPublished';
 

--- a/front/app/components/Areas/FollowArea/BaseUpdateFollowArea.tsx
+++ b/front/app/components/Areas/FollowArea/BaseUpdateFollowArea.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
 import { Badge, colors, Button } from '@citizenlab/cl2-component-library';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useTheme } from 'styled-components';
 
 import { IAreaData } from 'api/areas/types';

--- a/front/app/components/ConfigurationMap/components/MapHelperOptions.tsx
+++ b/front/app/components/ConfigurationMap/components/MapHelperOptions.tsx
@@ -7,7 +7,7 @@ import {
   colors,
   Tooltip,
 } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { IMapConfig } from 'api/map_config/types';
 import useUpdateMapConfig from 'api/map_config/useUpdateMapConfig';

--- a/front/app/components/ConsentManager/index.tsx
+++ b/front/app/components/ConsentManager/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import useAppConfiguration from 'api/app_configuration/useAppConfiguration';
 import useAuthUser from 'api/me/useAuthUser';

--- a/front/app/components/CustomFieldsForm/IdeationForm/IdeationPage.tsx
+++ b/front/app/components/CustomFieldsForm/IdeationForm/IdeationPage.tsx
@@ -2,7 +2,7 @@ import React, { useState, useRef } from 'react';
 
 import { Box, useBreakpoint } from '@citizenlab/cl2-component-library';
 import { FormProvider } from 'react-hook-form';
-import { useLocation, useSearchParams } from 'react-router-dom';
+import { useLocation, useSearchParams } from 'react-router';
 import styled from 'styled-components';
 
 import { IFlatCustomField } from 'api/custom_fields/types';

--- a/front/app/components/CustomFieldsForm/SurveyForm/SurveyPage.tsx
+++ b/front/app/components/CustomFieldsForm/SurveyForm/SurveyPage.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from 'react';
 
 import { Box, useBreakpoint } from '@citizenlab/cl2-component-library';
 import { FormProvider } from 'react-hook-form';
-import { useLocation, useSearchParams } from 'react-router-dom';
+import { useLocation, useSearchParams } from 'react-router';
 import styled from 'styled-components';
 
 import { IFlatCustomField } from 'api/custom_fields/types';

--- a/front/app/components/EventPreviews/index.tsx
+++ b/front/app/components/EventPreviews/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Title, useBreakpoint } from '@citizenlab/cl2-component-library';
 import moment from 'moment';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useEvents from 'api/events/useEvents';
 import usePhases from 'api/phases/usePhases';

--- a/front/app/components/FollowUnfollow/index.tsx
+++ b/front/app/components/FollowUnfollow/index.tsx
@@ -8,7 +8,7 @@ import {
   colors,
   Tooltip,
 } from '@citizenlab/cl2-component-library';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import useABTest from 'api/experiments/useABTest';
 import { FollowableType } from 'api/follow_unfollow/types';

--- a/front/app/components/Form/Components/Controls/MapInput/MapControl.tsx
+++ b/front/app/components/Form/Components/Controls/MapInput/MapControl.tsx
@@ -11,7 +11,7 @@ import {
 } from '@citizenlab/cl2-component-library';
 import { ControlProps } from '@jsonforms/core';
 import { withJsonFormsControlProps } from '@jsonforms/react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useMapConfigById from 'api/map_config/useMapConfigById';
 import useProjectMapConfig from 'api/map_config/useProjectMapConfig';

--- a/front/app/components/Form/Components/Layouts/CLPageLayout.tsx
+++ b/front/app/components/Form/Components/Layouts/CLPageLayout.tsx
@@ -20,7 +20,7 @@ import {
   useJsonForms,
   JsonFormsDispatch,
 } from '@jsonforms/react';
-import { useLocation, useParams, useSearchParams } from 'react-router-dom';
+import { useLocation, useParams, useSearchParams } from 'react-router';
 import { useTheme } from 'styled-components';
 
 import { IIdea } from 'api/ideas/types';

--- a/front/app/components/FormBuilder/components/FormBuilderSettings/ContentSettings/index.tsx
+++ b/front/app/components/FormBuilder/components/FormBuilderSettings/ContentSettings/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Box, Text } from '@citizenlab/cl2-component-library';
 import { useFormContext } from 'react-hook-form';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { IFlatCustomFieldWithIndex } from 'api/custom_fields/types';
 

--- a/front/app/components/FormBuilder/components/FormBuilderSettings/FieldTypeSwitcher/index.tsx
+++ b/front/app/components/FormBuilder/components/FormBuilderSettings/FieldTypeSwitcher/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Box, Select, Tooltip } from '@citizenlab/cl2-component-library';
 import { useFormContext } from 'react-hook-form';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { IFlatCustomFieldWithIndex } from 'api/custom_fields/types';
 import useFormSubmissionsCount from 'api/submission_count/useSubmissionCount';

--- a/front/app/components/FormBuilder/components/FormBuilderSettings/PointSettings/index.tsx
+++ b/front/app/components/FormBuilder/components/FormBuilderSettings/PointSettings/index.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import MapView from '@arcgis/core/views/MapView';
 import { Box, Button, Label, Spinner } from '@citizenlab/cl2-component-library';
 import { useFormContext } from 'react-hook-form';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import styled from 'styled-components';
 
 import useAppConfiguration from 'api/app_configuration/useAppConfiguration';

--- a/front/app/components/FormBuilder/components/FormBuilderTopBar/index.tsx
+++ b/front/app/components/FormBuilder/components/FormBuilderTopBar/index.tsx
@@ -11,7 +11,7 @@ import {
   IconTooltip,
 } from '@citizenlab/cl2-component-library';
 import { useFormContext } from 'react-hook-form';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { RouteType } from 'routes';
 import styled from 'styled-components';
 

--- a/front/app/components/FormBuilder/edit/index.tsx
+++ b/front/app/components/FormBuilder/edit/index.tsx
@@ -10,7 +10,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { createPortal } from 'react-dom';
 import { FocusOn } from 'react-focus-on';
 import { useForm, useFieldArray, FormProvider } from 'react-hook-form';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router';
 import { RouteType } from 'routes';
 
 import {

--- a/front/app/components/Highlighter/index.tsx
+++ b/front/app/components/Highlighter/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
 import { Box, colors, stylingConsts } from '@citizenlab/cl2-component-library';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { RouteType } from 'routes';
 import styled, { keyframes, css } from 'styled-components';
 

--- a/front/app/components/HookForm/LocationInput/index.tsx
+++ b/front/app/components/HookForm/LocationInput/index.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useEffect } from 'react';
 import { Box } from '@citizenlab/cl2-component-library';
 import { get } from 'lodash-es';
 import { Controller, useFormContext } from 'react-hook-form';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { CLError, RHFErrors } from 'typings';
 
 import useLocale from 'hooks/useLocale';

--- a/front/app/components/IdeaCard/index.tsx
+++ b/front/app/components/IdeaCard/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 
 import { useBreakpoint, Box, Title } from '@citizenlab/cl2-component-library';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { RouteType } from 'routes';
 
 import useIdeaImage from 'api/idea_images/useIdeaImage';

--- a/front/app/components/IdeaCards/IdeasWithFiltersSidebar/index.tsx
+++ b/front/app/components/IdeaCards/IdeasWithFiltersSidebar/index.tsx
@@ -9,7 +9,7 @@ import {
   Text,
   useBreakpoint,
 } from '@citizenlab/cl2-component-library';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import styled from 'styled-components';
 
 import useCustomFields from 'api/custom_fields/useCustomFields';

--- a/front/app/components/IdeaCards/IdeasWithoutFiltersSidebar/index.tsx
+++ b/front/app/components/IdeaCards/IdeasWithoutFiltersSidebar/index.tsx
@@ -7,7 +7,7 @@ import {
   isRtl,
   Box,
 } from '@citizenlab/cl2-component-library';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import styled from 'styled-components';
 
 import useCustomFields from 'api/custom_fields/useCustomFields';

--- a/front/app/components/IdeaCards/shared/Filters/SortingBox/index.tsx
+++ b/front/app/components/IdeaCards/shared/Filters/SortingBox/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box } from '@citizenlab/cl2-component-library';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import { IdeaSortMethod } from 'api/phases/types';
 import usePhase from 'api/phases/usePhase';

--- a/front/app/components/IdeasMap/desktop/MapIdeasList.tsx
+++ b/front/app/components/IdeasMap/desktop/MapIdeasList.tsx
@@ -1,7 +1,7 @@
 import React, { memo, useCallback, useState } from 'react';
 
 import { Button, useBreakpoint } from '@citizenlab/cl2-component-library';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import styled from 'styled-components';
 
 import useIdeaMarkers from 'api/idea_markers/useIdeaMarkers';

--- a/front/app/components/IdeasMap/index.tsx
+++ b/front/app/components/IdeasMap/index.tsx
@@ -21,7 +21,7 @@ import {
   useWindowSize,
   viewportWidths,
 } from '@citizenlab/cl2-component-library';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { CSSTransition } from 'react-transition-group';
 import styled, { useTheme } from 'styled-components';
 

--- a/front/app/components/ParticipationCTABars/CommonGroundCTABar/index.tsx
+++ b/front/app/components/ParticipationCTABars/CommonGroundCTABar/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
 import { Box } from '@citizenlab/cl2-component-library';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useTheme } from 'styled-components';
 
 import { IPhaseData } from 'api/phases/types';

--- a/front/app/components/ParticipationCTABars/DocumentAnnotationCTABar/index.tsx
+++ b/front/app/components/ParticipationCTABars/DocumentAnnotationCTABar/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
 import { Button } from '@citizenlab/cl2-component-library';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useTheme } from 'styled-components';
 
 import { IPhaseData } from 'api/phases/types';

--- a/front/app/components/ParticipationCTABars/EmbeddedSurveyCTABar/index.tsx
+++ b/front/app/components/ParticipationCTABars/EmbeddedSurveyCTABar/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
 import { Button } from '@citizenlab/cl2-component-library';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useTheme } from 'styled-components';
 
 import { IPhaseData } from 'api/phases/types';

--- a/front/app/components/PostShowComponents/Comments/CommentForm/Actions.tsx
+++ b/front/app/components/PostShowComponents/Comments/CommentForm/Actions.tsx
@@ -7,7 +7,7 @@ import {
   Box,
   CheckboxWithLabel,
 } from '@citizenlab/cl2-component-library';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import ButtonWithLink from 'components/UI/ButtonWithLink';
 

--- a/front/app/components/PostShowComponents/Comments/CommentsSection/PublicComments/ParentCommentForm.tsx
+++ b/front/app/components/PostShowComponents/Comments/CommentsSection/PublicComments/ParentCommentForm.tsx
@@ -3,7 +3,7 @@ import React, { useState, useRef } from 'react';
 import { Box, colors } from '@citizenlab/cl2-component-library';
 import { isString, trim } from 'lodash-es';
 import { hideVisually } from 'polished';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import styled from 'styled-components';
 
 import useAppConfiguration from 'api/app_configuration/useAppConfiguration';

--- a/front/app/components/PostShowComponents/Comments/CommentsSection/PublicComments/index.tsx
+++ b/front/app/components/PostShowComponents/Comments/CommentsSection/PublicComments/index.tsx
@@ -9,7 +9,7 @@ import {
   Title,
 } from '@citizenlab/cl2-component-library';
 import { useInView } from 'react-intersection-observer';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import styled from 'styled-components';
 
 import { CommentsSort } from 'api/comments/types';

--- a/front/app/components/ProjectAndFolderCards/components/Topbar/index.tsx
+++ b/front/app/components/ProjectAndFolderCards/components/Topbar/index.tsx
@@ -8,7 +8,7 @@ import {
   colors,
   Title,
 } from '@citizenlab/cl2-component-library';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import styled from 'styled-components';
 import { Multiloc } from 'typings';
 

--- a/front/app/components/ProjectDescriptionBuilder/ProjectDescriptionBuilderTopBar/ProjectDescriptionBuilderTopBar.test.tsx
+++ b/front/app/components/ProjectDescriptionBuilder/ProjectDescriptionBuilderTopBar/ProjectDescriptionBuilderTopBar.test.tsx
@@ -63,8 +63,8 @@ jest.mock('utils/cl-router/withRouter', () => {
   };
 });
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useParams: () => mockParams,
 }));
 

--- a/front/app/components/ProjectDescriptionBuilder/ProjectDescriptionBuilderTopBar/index.tsx
+++ b/front/app/components/ProjectDescriptionBuilder/ProjectDescriptionBuilderTopBar/index.tsx
@@ -8,7 +8,7 @@ import {
   colors,
 } from '@citizenlab/cl2-component-library';
 import { useEditor, SerializedNodes } from '@craftjs/core';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { SupportedLocale } from 'typings';
 
 import useAddProjectDescriptionBuilderLayout from 'api/project_description_builder/useAddProjectDescriptionBuilderLayout';

--- a/front/app/components/ProjectFilterDropdown/index.tsx
+++ b/front/app/components/ProjectFilterDropdown/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import useProjects from 'api/projects/useProjects';
 

--- a/front/app/components/Sharing/SharingButtons/index.tsx
+++ b/front/app/components/Sharing/SharingButtons/index.tsx
@@ -6,7 +6,7 @@ import {
   Title,
   useBreakpoint,
 } from '@citizenlab/cl2-component-library';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import useAppConfiguration from 'api/app_configuration/useAppConfiguration';
 

--- a/front/app/components/Topics/UpdateFollowTopic.tsx
+++ b/front/app/components/Topics/UpdateFollowTopic.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
 import { Badge, colors, Button } from '@citizenlab/cl2-component-library';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useTheme } from 'styled-components';
 
 import useAddFollower from 'api/follow_unfollow/useAddFollower';

--- a/front/app/components/UI/FileRepositorySelectAndUpload/components/FileSelectOrUploadModal.tsx
+++ b/front/app/components/UI/FileRepositorySelectAndUpload/components/FileSelectOrUploadModal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box, Button, Select, Text } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { UploadFile } from 'typings';
 
 import { IFileAttachmentData } from 'api/file_attachments/types';

--- a/front/app/components/UI/FileRepositorySelectAndUpload/components/ScreenReaderFilesList.tsx
+++ b/front/app/components/UI/FileRepositorySelectAndUpload/components/ScreenReaderFilesList.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { IFileAttachmentData } from 'api/file_attachments/types';
 import useFiles from 'api/files/useFiles';

--- a/front/app/components/UI/PageLoading/index.tsx
+++ b/front/app/components/UI/PageLoading/index.tsx
@@ -1,6 +1,6 @@
 import React, { Suspense } from 'react';
 
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import { isAdminRoute } from 'utils/permissions/rules/routePermissions';
 

--- a/front/app/components/VoteInputs/budgeting/AddToBasketButton/index.tsx
+++ b/front/app/components/VoteInputs/budgeting/AddToBasketButton/index.tsx
@@ -7,7 +7,7 @@ import {
   Tooltip,
   Box,
 } from '@citizenlab/cl2-component-library';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import useBasket from 'api/baskets/useBasket';
 import useVoting from 'api/baskets_ideas/useVoting';

--- a/front/app/components/VoteInputs/multiple/AssignMultipleVotesInput/index.tsx
+++ b/front/app/components/VoteInputs/multiple/AssignMultipleVotesInput/index.tsx
@@ -8,7 +8,7 @@ import {
   useBreakpoint,
   Tooltip,
 } from '@citizenlab/cl2-component-library';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { useTheme } from 'styled-components';
 
 import useBasket from 'api/baskets/useBasket';

--- a/front/app/components/VoteInputs/single/AssignSingleVoteButton/index.tsx
+++ b/front/app/components/VoteInputs/single/AssignSingleVoteButton/index.tsx
@@ -6,7 +6,7 @@ import {
   Tooltip,
   Box,
 } from '@citizenlab/cl2-component-library';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import useBasket from 'api/baskets/useBasket';
 import useVoting from 'api/baskets_ideas/useVoting';

--- a/front/app/components/admin/ContentBuilder/Widgets/AboutBox/index.tsx
+++ b/front/app/components/admin/ContentBuilder/Widgets/AboutBox/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Box, colors, Toggle } from '@citizenlab/cl2-component-library';
 import { useNode } from '@craftjs/core';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useProjectBySlug from 'api/projects/useProjectBySlug';
 

--- a/front/app/components/admin/ContentBuilder/Widgets/FileAttachment/index.tsx
+++ b/front/app/components/admin/ContentBuilder/Widgets/FileAttachment/index.tsx
@@ -8,7 +8,7 @@ import {
   Text,
 } from '@citizenlab/cl2-component-library';
 import { useNode } from '@craftjs/core';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useAddFileAttachment from 'api/file_attachments/useAddFileAttachment';
 import useDeleteFileAttachment from 'api/file_attachments/useDeleteFileAttachment';

--- a/front/app/components/admin/Email/DraftCampaignDetails.tsx
+++ b/front/app/components/admin/Email/DraftCampaignDetails.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import styled from 'styled-components';
 
 import { ICampaignData } from 'api/campaigns/types';

--- a/front/app/components/admin/FormResults/FormResultsQuestion/MappingQuestions/LineLocationQuestion/index.tsx
+++ b/front/app/components/admin/FormResults/FormResultsQuestion/MappingQuestions/LineLocationQuestion/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 
 import MapView from '@arcgis/core/views/MapView';
 import { Box, Spinner } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useMapConfigById from 'api/map_config/useMapConfigById';
 import useProjectMapConfig from 'api/map_config/useProjectMapConfig';

--- a/front/app/components/admin/FormResults/FormResultsQuestion/MappingQuestions/PointLocationQuestion/index.tsx
+++ b/front/app/components/admin/FormResults/FormResultsQuestion/MappingQuestions/PointLocationQuestion/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 
 import MapView from '@arcgis/core/views/MapView';
 import { Box, Spinner, Toggle } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useMapConfigById from 'api/map_config/useMapConfigById';
 import useProjectMapConfig from 'api/map_config/useProjectMapConfig';

--- a/front/app/components/admin/FormResults/FormResultsQuestion/MappingQuestions/PolygonLocationQuestion/index.tsx
+++ b/front/app/components/admin/FormResults/FormResultsQuestion/MappingQuestions/PolygonLocationQuestion/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 
 import MapView from '@arcgis/core/views/MapView';
 import { Box, Spinner } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useMapConfigById from 'api/map_config/useMapConfigById';
 import useProjectMapConfig from 'api/map_config/useProjectMapConfig';

--- a/front/app/components/admin/FormResults/FormResultsQuestion/SentimentQuestion/components/Comments.tsx
+++ b/front/app/components/admin/FormResults/FormResultsQuestion/SentimentQuestion/components/Comments.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box, useBreakpoint } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useCommunityMonitorProject from 'api/community_monitor/useCommunityMonitorProject';
 

--- a/front/app/components/admin/FormResults/FormResultsQuestion/TextQuestion/Analysis/AnalysisInsights.tsx
+++ b/front/app/components/admin/FormResults/FormResultsQuestion/TextQuestion/Analysis/AnalysisInsights.tsx
@@ -7,7 +7,7 @@ import {
   Text,
   Spinner,
 } from '@citizenlab/cl2-component-library';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import { IAnalysisData } from 'api/analyses/types';
 import useInfiniteAnalysisInputs from 'api/analysis_inputs/useInfiniteAnalysisInputs';

--- a/front/app/components/admin/FormResults/FormResultsQuestion/TextQuestion/Analysis/Question.tsx
+++ b/front/app/components/admin/FormResults/FormResultsQuestion/TextQuestion/Analysis/Question.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Box, Spinner } from '@citizenlab/cl2-component-library';
 import { stringify } from 'qs';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useInfiniteAnalysisInputs from 'api/analysis_inputs/useInfiniteAnalysisInputs';
 import useAnalysisQuestion from 'api/analysis_questions/useAnalysisQuestion';

--- a/front/app/components/admin/FormResults/FormResultsQuestion/TextQuestion/Analysis/Summary.tsx
+++ b/front/app/components/admin/FormResults/FormResultsQuestion/TextQuestion/Analysis/Summary.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Box, Spinner } from '@citizenlab/cl2-component-library';
 import { stringify } from 'qs';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useAnalysisBackgroundTask from 'api/analysis_background_tasks/useAnalysisBackgroundTask';
 import useInfiniteAnalysisInputs from 'api/analysis_inputs/useInfiniteAnalysisInputs';

--- a/front/app/components/admin/FormResults/FormResultsQuestion/TextQuestion/Analysis/index.tsx
+++ b/front/app/components/admin/FormResults/FormResultsQuestion/TextQuestion/Analysis/index.tsx
@@ -9,7 +9,7 @@ import {
   Spinner,
 } from '@citizenlab/cl2-component-library';
 import { stringify } from 'qs';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router';
 import styled from 'styled-components';
 
 import useAddAnalysis from 'api/analyses/useAddAnalysis';

--- a/front/app/components/admin/FormResults/index.tsx
+++ b/front/app/components/admin/FormResults/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import { Box, Text } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useProjectById from 'api/projects/useProjectById';
 import useFormResults from 'api/survey_results/useSurveyResults';

--- a/front/app/components/admin/InternalComments/InternalParentComment.tsx
+++ b/front/app/components/admin/InternalComments/InternalParentComment.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Spinner } from '@citizenlab/cl2-component-library';
 import { darken } from 'polished';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import styled, { useTheme } from 'styled-components';
 
 import useIdeaById from 'api/ideas/useIdeaById';

--- a/front/app/components/admin/PostManager/CommonGroundInputManager/ImportInputsModal.tsx
+++ b/front/app/components/admin/PostManager/CommonGroundInputManager/ImportInputsModal.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
 import { Box, Button, Text } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { IOption } from 'typings';
 
 import { IJob } from 'api/copy_inputs/types';

--- a/front/app/components/admin/PostManager/InputManager.tsx
+++ b/front/app/components/admin/PostManager/InputManager.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import useIdeaStatuses from 'api/idea_statuses/useIdeaStatuses';
 import { IIdeaQueryParameters, Sort } from 'api/ideas/types';

--- a/front/app/components/admin/PostManager/components/ExportMenu/ExportVotesByInput.tsx
+++ b/front/app/components/admin/PostManager/components/ExportMenu/ExportVotesByInput.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 
 import { fontSizes, Button } from '@citizenlab/cl2-component-library';
 import saveAs from 'file-saver';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import usePhases from 'api/phases/usePhases';
 

--- a/front/app/components/admin/PostManager/components/ExportMenu/ExportVotesByUser.tsx
+++ b/front/app/components/admin/PostManager/components/ExportMenu/ExportVotesByUser.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 
 import { fontSizes, Button } from '@citizenlab/cl2-component-library';
 import saveAs from 'file-saver';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import usePhases from 'api/phases/usePhases';
 

--- a/front/app/components/admin/PostManager/components/FilterSidebar/index.tsx
+++ b/front/app/components/admin/PostManager/components/FilterSidebar/index.tsx
@@ -7,7 +7,7 @@ import {
   stylingConsts,
 } from '@citizenlab/cl2-component-library';
 import { isEmpty } from 'lodash-es';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { RouteType } from 'routes';
 
 import { IIdeaStatusData } from 'api/idea_statuses/types';

--- a/front/app/components/admin/PostManager/components/FilterSidebar/statuses/ScreeningStatusFilter.tsx
+++ b/front/app/components/admin/PostManager/components/FilterSidebar/statuses/ScreeningStatusFilter.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { IconTooltip, Box, Tooltip } from '@citizenlab/cl2-component-library';
 import ColorIndicator from 'component-library/components/ColorIndicator';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import styled from 'styled-components';
 
 import { IIdeaStatusData } from 'api/idea_statuses/types';

--- a/front/app/components/admin/PostManager/components/IdeaPreviewIndex.tsx
+++ b/front/app/components/admin/PostManager/components/IdeaPreviewIndex.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import { Box } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { RouteType } from 'routes';
 
 import GoBackButton from 'components/UI/GoBackButton';

--- a/front/app/components/admin/PostManager/components/PostPreview/Idea/AdminIdeaEdit.tsx
+++ b/front/app/components/admin/PostManager/components/PostPreview/Idea/AdminIdeaEdit.tsx
@@ -1,7 +1,7 @@
 import React, { Suspense } from 'react';
 
 import { Box, Button } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { useTheme } from 'styled-components';
 
 import useIdeaById from 'api/ideas/useIdeaById';

--- a/front/app/components/admin/PostManager/components/PostPreview/Idea/Components/FeedbackSettings.tsx
+++ b/front/app/components/admin/PostManager/components/PostPreview/Idea/Components/FeedbackSettings.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Select, Label } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import styled from 'styled-components';
 import { IOption } from 'typings';
 

--- a/front/app/components/admin/SeatBasedBilling/SeatInfo/index.tsx
+++ b/front/app/components/admin/SeatBasedBilling/SeatInfo/index.tsx
@@ -8,7 +8,7 @@ import {
   colors,
 } from '@citizenlab/cl2-component-library';
 import { rgba } from 'polished';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { RouteType } from 'routes';
 import styled from 'styled-components';
 

--- a/front/app/components/admin/TabbedResource/Tab.tsx
+++ b/front/app/components/admin/TabbedResource/Tab.tsx
@@ -6,7 +6,7 @@ import {
   colors,
   fontSizes,
 } from '@citizenlab/cl2-component-library';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import styled from 'styled-components';
 import { ITab } from 'typings';
 

--- a/front/app/components/admin/participation/Demographics.tsx
+++ b/front/app/components/admin/participation/Demographics.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import { Box, Text } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import DateRangePicker from 'components/admin/DatePickers/DateRangePicker';
 

--- a/front/app/components/admin/participation/ParticipationDateRange.tsx
+++ b/front/app/components/admin/participation/ParticipationDateRange.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import { Box, Text } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import DateRangePicker from 'components/admin/DatePickers/DateRangePicker';
 

--- a/front/app/components/admin/participation/Users.tsx
+++ b/front/app/components/admin/participation/Users.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import UserManager from 'containers/Admin/users/UserManager';
 import UsersHeader from 'containers/Admin/users/UsersHeader';

--- a/front/app/components/admin/participation/index.tsx
+++ b/front/app/components/admin/participation/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box, colors } from '@citizenlab/cl2-component-library';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router';
 
 import usePhases from 'api/phases/usePhases';
 

--- a/front/app/containers/Admin/CustomMapConfigPage/DataImportOptions/FeatureLayerUpload.tsx
+++ b/front/app/containers/Admin/CustomMapConfigPage/DataImportOptions/FeatureLayerUpload.tsx
@@ -10,7 +10,7 @@ import {
   Success,
 } from '@citizenlab/cl2-component-library';
 import { request, ErrorTypes, ApiKeyManager } from '@esri/arcgis-rest-request';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useAppConfiguration from 'api/app_configuration/useAppConfiguration';
 import useAddMapLayer from 'api/map_layers/useAddMapLayer';

--- a/front/app/containers/Admin/CustomMapConfigPage/DataImportOptions/GeoJsonImportButton.tsx
+++ b/front/app/containers/Admin/CustomMapConfigPage/DataImportOptions/GeoJsonImportButton.tsx
@@ -2,7 +2,7 @@ import React, { memo, useState } from 'react';
 
 import { Tooltip } from '@citizenlab/cl2-component-library';
 import flatten from 'geojson-flatten';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import styled from 'styled-components';
 
 import { IMapConfig } from 'api/map_config/types';

--- a/front/app/containers/Admin/CustomMapConfigPage/DataImportOptions/WebMapUpload.tsx
+++ b/front/app/containers/Admin/CustomMapConfigPage/DataImportOptions/WebMapUpload.tsx
@@ -10,7 +10,7 @@ import {
   Success,
 } from '@citizenlab/cl2-component-library';
 import { request, ErrorTypes, ApiKeyManager } from '@esri/arcgis-rest-request';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useAppConfiguration from 'api/app_configuration/useAppConfiguration';
 import useUpdateMapConfig from 'api/map_config/useUpdateMapConfig';

--- a/front/app/containers/Admin/CustomMapConfigPage/LayerConfiguration/MapLayerConfig.tsx
+++ b/front/app/containers/Admin/CustomMapConfigPage/LayerConfiguration/MapLayerConfig.tsx
@@ -7,7 +7,7 @@ import {
 } from '@citizenlab/cl2-component-library';
 import { isEmpty, cloneDeep, forOwn } from 'lodash-es';
 import { WrappedComponentProps } from 'react-intl';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import styled from 'styled-components';
 import { Multiloc } from 'typings';
 

--- a/front/app/containers/Admin/CustomMapConfigPage/LayerConfiguration/MapLayersList.tsx
+++ b/front/app/containers/Admin/CustomMapConfigPage/LayerConfiguration/MapLayersList.tsx
@@ -9,7 +9,7 @@ import {
   Tooltip,
 } from '@citizenlab/cl2-component-library';
 import { WrappedComponentProps } from 'react-intl';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import styled from 'styled-components';
 
 import { IMapConfig } from 'api/map_config/types';

--- a/front/app/containers/Admin/CustomMapConfigPage/MapConfiguration/MapCenterAndZoomConfig.tsx
+++ b/front/app/containers/Admin/CustomMapConfigPage/MapConfiguration/MapCenterAndZoomConfig.tsx
@@ -4,7 +4,7 @@ import MapView from '@arcgis/core/views/MapView';
 import { Input, IconTooltip, Icon } from '@citizenlab/cl2-component-library';
 import { isEmpty, inRange } from 'lodash-es';
 import { WrappedComponentProps } from 'react-intl';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import styled from 'styled-components';
 
 import useAppConfiguration from 'api/app_configuration/useAppConfiguration';

--- a/front/app/containers/Admin/CustomMapConfigPage/index.tsx
+++ b/front/app/containers/Admin/CustomMapConfigPage/index.tsx
@@ -2,7 +2,7 @@ import React, { memo, useEffect, useState } from 'react';
 
 import MapView from '@arcgis/core/views/MapView';
 import { Box, Spinner } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import styled from 'styled-components';
 
 import useAppConfiguration from 'api/app_configuration/useAppConfiguration';

--- a/front/app/containers/Admin/ProjectImporter/index.tsx
+++ b/front/app/containers/Admin/ProjectImporter/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
 import { Box, Button, Text } from '@citizenlab/cl2-component-library';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import useAuthUser from 'api/me/useAuthUser';
 import useProjectImports from 'api/project_imports/useProjectImports';

--- a/front/app/containers/Admin/communityMonitor/CommunityMonitorFormBuilder/index.tsx
+++ b/front/app/containers/Admin/communityMonitor/CommunityMonitorFormBuilder/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useFormCustomFields from 'api/custom_fields/useCustomFields';
 import usePhase from 'api/phases/usePhase';

--- a/front/app/containers/Admin/communityMonitor/components/LiveMonitor/components/FormResults.tsx
+++ b/front/app/containers/Admin/communityMonitor/components/LiveMonitor/components/FormResults.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box, Icon, Text } from '@citizenlab/cl2-component-library';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router';
 
 import useProjectById from 'api/projects/useProjectById';
 import useSurveyResults from 'api/survey_results/useSurveyResults';

--- a/front/app/containers/Admin/communityMonitor/components/LiveMonitor/components/HealthScoreWidget/components/CategoryScores.tsx
+++ b/front/app/containers/Admin/communityMonitor/components/LiveMonitor/components/HealthScoreWidget/components/CategoryScores.tsx
@@ -6,7 +6,7 @@ import {
   Text,
   useBreakpoint,
 } from '@citizenlab/cl2-component-library';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import { getPercentageDifference } from 'components/admin/FormResults/FormResultsQuestion/SentimentQuestion/utils';
 import TrendIndicator from 'components/TrendIndicator';

--- a/front/app/containers/Admin/communityMonitor/components/LiveMonitor/components/HealthScoreWidget/components/HealthScoreChart.tsx
+++ b/front/app/containers/Admin/communityMonitor/components/LiveMonitor/components/HealthScoreWidget/components/HealthScoreChart.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box, useBreakpoint } from '@citizenlab/cl2-component-library';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import LineChart from 'components/admin/Graphs/LineChart';
 

--- a/front/app/containers/Admin/communityMonitor/components/LiveMonitor/components/HealthScoreWidget/components/PreviousQuarterComparison.tsx
+++ b/front/app/containers/Admin/communityMonitor/components/LiveMonitor/components/HealthScoreWidget/components/PreviousQuarterComparison.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import { getPercentageDifference } from 'components/admin/FormResults/FormResultsQuestion/SentimentQuestion/utils';
 import TrendIndicator from 'components/TrendIndicator';

--- a/front/app/containers/Admin/communityMonitor/components/LiveMonitor/components/HealthScoreWidget/components/TotalCountsSentimentBar.tsx
+++ b/front/app/containers/Admin/communityMonitor/components/LiveMonitor/components/HealthScoreWidget/components/TotalCountsSentimentBar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Tooltip } from '@citizenlab/cl2-component-library';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import SentimentBar from 'components/admin/FormResults/FormResultsQuestion/SentimentQuestion/components/SentimentScore/SentimentBar';
 import SentimentTooltip from 'components/admin/FormResults/FormResultsQuestion/SentimentQuestion/components/SentimentScore/SentimentTooltip';

--- a/front/app/containers/Admin/communityMonitor/components/LiveMonitor/components/HealthScoreWidget/index.tsx
+++ b/front/app/containers/Admin/communityMonitor/components/LiveMonitor/components/HealthScoreWidget/index.tsx
@@ -10,7 +10,7 @@ import {
   Title,
   useBreakpoint,
 } from '@citizenlab/cl2-component-library';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import useCommunityMonitorSentimentScores from 'api/community_monitor_scores/useCommunityMonitorSentimentScores';
 

--- a/front/app/containers/Admin/communityMonitor/components/LiveMonitor/components/QuarterlyDatePicker.tsx
+++ b/front/app/containers/Admin/communityMonitor/components/LiveMonitor/components/QuarterlyDatePicker.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 
 import { Box, Text, Button, colors } from '@citizenlab/cl2-component-library';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import { useIntl } from 'utils/cl-intl';
 

--- a/front/app/containers/Admin/communityMonitor/components/NavigationBar/index.tsx
+++ b/front/app/containers/Admin/communityMonitor/components/NavigationBar/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box, useBreakpoint } from '@citizenlab/cl2-component-library';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import useCommunityMonitorProject from 'api/community_monitor/useCommunityMonitorProject';
 

--- a/front/app/containers/Admin/communityMonitor/components/Settings/components/SettingsNavigationBar/index.tsx
+++ b/front/app/containers/Admin/communityMonitor/components/Settings/components/SettingsNavigationBar/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box } from '@citizenlab/cl2-component-library';
-import { Outlet as RouterOutlet, useLocation } from 'react-router-dom';
+import { Outlet as RouterOutlet, useLocation } from 'react-router';
 
 import { Tab } from 'components/admin/NavigationTabs';
 

--- a/front/app/containers/Admin/communityMonitor/index.tsx
+++ b/front/app/containers/Admin/communityMonitor/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box, colors } from '@citizenlab/cl2-component-library';
-import { Outlet as RouterOutlet } from 'react-router-dom';
+import { Outlet as RouterOutlet } from 'react-router';
 
 import NavigationBar from './components/NavigationBar';
 

--- a/front/app/containers/Admin/communityMonitor/routes.tsx
+++ b/front/app/containers/Admin/communityMonitor/routes.tsx
@@ -1,6 +1,6 @@
 import React, { lazy } from 'react';
 
-import { Navigate } from 'react-router-dom';
+import { Navigate } from 'react-router';
 
 import PageLoading from 'components/UI/PageLoading';
 

--- a/front/app/containers/Admin/communityMonitor/routes.tsx
+++ b/front/app/containers/Admin/communityMonitor/routes.tsx
@@ -1,13 +1,13 @@
 import React, { lazy } from 'react';
 
-import { Navigate } from 'react-router';
-
 import PageLoading from 'components/UI/PageLoading';
 
 const LiveMonitor = lazy(() => import('./components/LiveMonitor'));
 const Reports = lazy(() => import('./components/Reports'));
 const Settings = lazy(() => import('./components/Settings/index'));
 const Participants = lazy(() => import('./components/Participants'));
+
+import RelativeNavigate from 'utils/cl-router/RelativeNavigate';
 
 import { AdminRoute } from '../routes';
 
@@ -69,7 +69,7 @@ const communityMonitorsRoutes = () => {
     children: [
       {
         path: '',
-        element: <Navigate to="live-monitor" replace />,
+        element: <RelativeNavigate to="live-monitor" replace />,
       },
       {
         path: communityMonitorRoutes.liveMonitor,
@@ -97,7 +97,7 @@ const communityMonitorsRoutes = () => {
         children: [
           {
             path: '',
-            element: <Navigate to="survey" replace />,
+            element: <RelativeNavigate to="survey" replace />,
           },
           {
             path: communityMonitorRoutes.settingsSurvey,

--- a/front/app/containers/Admin/dashboard/components/DashboardTabs.tsx
+++ b/front/app/containers/Admin/dashboard/components/DashboardTabs.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { ITab } from 'typings';
 
 import NavigationTabs, {

--- a/front/app/containers/Admin/dashboard/index.tsx
+++ b/front/app/containers/Admin/dashboard/index.tsx
@@ -1,6 +1,6 @@
 import React, { memo } from 'react';
 
-import { Outlet as RouterOutlet } from 'react-router-dom';
+import { Outlet as RouterOutlet } from 'react-router';
 
 import useFeatureFlag from 'hooks/useFeatureFlag';
 

--- a/front/app/containers/Admin/ideas/index.tsx
+++ b/front/app/containers/Admin/ideas/index.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 
 // module
 
-import { Outlet as RouterOutlet, useLocation } from 'react-router-dom';
+import { Outlet as RouterOutlet, useLocation } from 'react-router';
 import { InsertConfigurationOptions, ITab } from 'typings';
 
 import NavigationTabs, {

--- a/front/app/containers/Admin/index.tsx
+++ b/front/app/containers/Admin/index.tsx
@@ -1,7 +1,7 @@
 import React, { memo, useEffect } from 'react';
 
 import { colors, media } from '@citizenlab/cl2-component-library';
-import { Outlet as RouterOutlet, useLocation } from 'react-router-dom';
+import { Outlet as RouterOutlet, useLocation } from 'react-router';
 import styled from 'styled-components';
 
 import useAuthUser from 'api/me/useAuthUser';

--- a/front/app/containers/Admin/inspirationHub/ProjectDrawer/index.tsx
+++ b/front/app/containers/Admin/inspirationHub/ProjectDrawer/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box, Text } from '@citizenlab/cl2-component-library';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import useAppConfiguration from 'api/app_configuration/useAppConfiguration';
 import useProjectLibraryProject from 'api/project_library_projects/useProjectLibraryProject';

--- a/front/app/containers/Admin/inspirationHub/routes.tsx
+++ b/front/app/containers/Admin/inspirationHub/routes.tsx
@@ -1,6 +1,6 @@
 import React, { lazy } from 'react';
 
-import { Outlet as RouterOutlet } from 'react-router-dom';
+import { Outlet as RouterOutlet } from 'react-router';
 
 import HelmetIntl from 'components/HelmetIntl';
 import PageLoading from 'components/UI/PageLoading';

--- a/front/app/containers/Admin/inspirationHub/utils.ts
+++ b/front/app/containers/Admin/inspirationHub/utils.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { Multiloc, SupportedLocale } from 'typings';
 
 import { Country } from 'api/project_library_countries/types';

--- a/front/app/containers/Admin/invitations/index.tsx
+++ b/front/app/containers/Admin/invitations/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box } from '@citizenlab/cl2-component-library';
-import { useLocation, Outlet as RouterOutlet } from 'react-router-dom';
+import { useLocation, Outlet as RouterOutlet } from 'react-router';
 import { ITab } from 'typings';
 
 import TabbedResource from 'components/admin/TabbedResource';

--- a/front/app/containers/Admin/messaging/AutomatedEmails/CampaignRow.tsx
+++ b/front/app/containers/Admin/messaging/AutomatedEmails/CampaignRow.tsx
@@ -6,7 +6,7 @@ import {
   ListItem,
   Tooltip,
 } from '@citizenlab/cl2-component-library';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { RouteType } from 'routes';
 
 import { CampaignContext } from 'api/campaigns/types';

--- a/front/app/containers/Admin/messaging/CustomEmails/Show/index.tsx
+++ b/front/app/containers/Admin/messaging/CustomEmails/Show/index.tsx
@@ -9,7 +9,7 @@ import {
   Box,
   fontSizes,
 } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import GetGroup from 'resources/GetGroup';
 import styled from 'styled-components';
 

--- a/front/app/containers/Admin/messaging/Edit/index.tsx
+++ b/front/app/containers/Admin/messaging/Edit/index.tsx
@@ -9,7 +9,7 @@ import {
   StatusLabel,
   Title,
 } from '@citizenlab/cl2-component-library';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router';
 
 import { CampaignFormValues } from 'api/campaigns/types';
 import useCampaign from 'api/campaigns/useCampaign';

--- a/front/app/containers/Admin/messaging/index.tsx
+++ b/front/app/containers/Admin/messaging/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box } from '@citizenlab/cl2-component-library';
-import { Outlet as RouterOutlet, useLocation } from 'react-router-dom';
+import { Outlet as RouterOutlet, useLocation } from 'react-router';
 import { ITab } from 'typings';
 
 import NavigationTabs, {

--- a/front/app/containers/Admin/messaging/routes.tsx
+++ b/front/app/containers/Admin/messaging/routes.tsx
@@ -1,6 +1,6 @@
 import React, { lazy } from 'react';
 
-import { Navigate } from 'react-router-dom';
+import { Navigate } from 'react-router';
 
 import PageLoading from 'components/UI/PageLoading';
 

--- a/front/app/containers/Admin/messaging/routes.tsx
+++ b/front/app/containers/Admin/messaging/routes.tsx
@@ -1,8 +1,8 @@
 import React, { lazy } from 'react';
 
-import { Navigate } from 'react-router';
-
 import PageLoading from 'components/UI/PageLoading';
+
+import RelativeNavigate from 'utils/cl-router/RelativeNavigate';
 
 import { AdminRoute } from '../routes';
 
@@ -42,7 +42,7 @@ const createAdminMessagingRoutes = () => ({
   children: [
     {
       path: '',
-      element: <Navigate to={messagingRoutes.emailsCustom} />,
+      element: <RelativeNavigate to={messagingRoutes.emailsCustom} />,
     },
     {
       path: messagingRoutes.emailsCustom,

--- a/front/app/containers/Admin/pagesAndMenu/containers/Attachments/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/Attachments/index.tsx
@@ -9,7 +9,7 @@ import {
 import { yupResolver } from '@hookform/resolvers/yup';
 import { FormProvider, useForm } from 'react-hook-form';
 import { WrappedComponentProps } from 'react-intl';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { UploadFile } from 'typings';
 import { mixed, object } from 'yup';
 

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/EditModePreview/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/EditModePreview/index.tsx
@@ -1,6 +1,6 @@
 import React, { memo } from 'react';
 
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { SupportedLocale } from 'typings';
 
 import useLocale from 'hooks/useLocale';

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/HomepageBanner/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/HomepageBanner/index.tsx
@@ -12,7 +12,7 @@ import {
   useBreakpoint,
 } from '@citizenlab/cl2-component-library';
 import { useNode } from '@craftjs/core';
-import { useLocation, useSearchParams } from 'react-router-dom';
+import { useLocation, useSearchParams } from 'react-router';
 import { RouteType } from 'routes';
 import { ImageSizes, Multiloc, UploadFile } from 'typings';
 

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/EmptyState.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/EmptyState.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box, Title, useBreakpoint } from '@citizenlab/cl2-component-library';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import { DEFAULT_PADDING } from 'components/admin/ContentBuilder/constants';
 import Warning from 'components/UI/Warning';

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/containers/FullscreenPreview/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/containers/FullscreenPreview/index.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 
 import { Box, Spinner } from '@citizenlab/cl2-component-library';
 import { SerializedNodes } from '@craftjs/core';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { SupportedLocale } from 'typings';
 
 import useHomepageLayout from 'api/home_page_layout/useHomepageLayout';

--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/Content/BottomInfoSection/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/Content/BottomInfoSection/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { ICustomPageAttributes } from 'api/custom_pages/types';
 import useCustomPageById from 'api/custom_pages/useCustomPageById';

--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/Content/TopInfoSection/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/Content/TopInfoSection/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { ICustomPageAttributes } from 'api/custom_pages/types';
 import useCustomPageById from 'api/custom_pages/useCustomPageById';

--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/Content/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/Content/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { TCustomPageEnabledSetting } from 'api/custom_pages/types';
 import useCustomPageById from 'api/custom_pages/useCustomPageById';

--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/HeroBanner/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/HeroBanner/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
 import { WrappedComponentProps } from 'react-intl';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { CLErrors } from 'typings';
 
 import { ICustomPageAttributes } from 'api/custom_pages/types';

--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/Settings/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/Settings/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { omit } from 'lodash-es';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { TCustomPageCode } from 'api/custom_pages/types';
 import useCustomPageById from 'api/custom_pages/useCustomPageById';

--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box } from '@citizenlab/cl2-component-library';
-import { Outlet as RouterOutlet, useParams } from 'react-router-dom';
+import { Outlet as RouterOutlet, useParams } from 'react-router';
 
 import useCustomPageById from 'api/custom_pages/useCustomPageById';
 

--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Outlet as RouterOutlet } from 'react-router-dom';
+import { Outlet as RouterOutlet } from 'react-router';
 
 const CustomPages = () => {
   return <RouterOutlet />;

--- a/front/app/containers/Admin/pagesAndMenu/containers/EditNavbarItemForm/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/EditNavbarItemForm/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useNavbarItems from 'api/navbar/useNavbarItems';
 import useUpdateNavbarItem from 'api/navbar/useUpdateNavbarItem';

--- a/front/app/containers/Admin/pagesAndMenu/containers/PagesMenu/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/PagesMenu/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import { Box, Tooltip } from '@citizenlab/cl2-component-library';
-import { Outlet as RouterOutlet } from 'react-router-dom';
+import { Outlet as RouterOutlet } from 'react-router';
 
 import useNavbarItems from 'api/navbar/useNavbarItems';
 import { MAX_NAVBAR_ITEMS } from 'api/navbar/util';

--- a/front/app/containers/Admin/pagesAndMenu/containers/ProjectsList/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ProjectsList/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useCustomPageById from 'api/custom_pages/useCustomPageById';
 

--- a/front/app/containers/Admin/pagesAndMenu/routes.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/routes.tsx
@@ -1,9 +1,10 @@
 import React, { lazy } from 'react';
 
-import { Navigate } from 'react-router';
 import { RouteType } from 'routes';
 
 import PageLoading from 'components/UI/PageLoading';
+
+import RelativeNavigate from 'utils/cl-router/RelativeNavigate';
 
 import { AdminRoute } from '../routes';
 
@@ -134,7 +135,7 @@ export default () => ({
           path: pagesAndMenuRoutes.customPageId,
           element: <EditCustomPageIndex />,
           children: [
-            { path: '', element: <Navigate to="settings" /> }, // to handle manually changing URL
+            { path: '', element: <RelativeNavigate to="settings" /> }, // to handle manually changing URL
             {
               path: pagesAndMenuRoutes.pageSettings,
               element: (

--- a/front/app/containers/Admin/pagesAndMenu/routes.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/routes.tsx
@@ -1,6 +1,6 @@
 import React, { lazy } from 'react';
 
-import { Navigate } from 'react-router-dom';
+import { Navigate } from 'react-router';
 import { RouteType } from 'routes';
 
 import PageLoading from 'components/UI/PageLoading';

--- a/front/app/containers/Admin/projectFolders/containers/index.tsx
+++ b/front/app/containers/Admin/projectFolders/containers/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Outlet as RouterOutlet, useParams } from 'react-router-dom';
+import { Outlet as RouterOutlet, useParams } from 'react-router';
 import styled from 'styled-components';
 import { ITab } from 'typings';
 

--- a/front/app/containers/Admin/projectFolders/containers/permissions/index.tsx
+++ b/front/app/containers/Admin/projectFolders/containers/permissions/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, lazy, Suspense } from 'react';
 
 import { IconTooltip, Box, Text } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import styled from 'styled-components';
 
 import useAddProjectFolderModerator from 'api/project_folder_moderators/useAddProjectFolderModerator';

--- a/front/app/containers/Admin/projectFolders/routes.tsx
+++ b/front/app/containers/Admin/projectFolders/routes.tsx
@@ -1,8 +1,10 @@
 import React, { lazy } from 'react';
 
-import { Navigate, Outlet as RouterOutlet } from 'react-router';
+import { Outlet as RouterOutlet } from 'react-router';
 
 import PageLoading from 'components/UI/PageLoading';
+
+import RelativeNavigate from 'utils/cl-router/RelativeNavigate';
 
 import { AdminRoute } from '../routes';
 
@@ -47,7 +49,7 @@ export default () => ({
       children: [
         {
           path: projectFolderRoutes.projectFolderIdDefault,
-          element: <Navigate to="projects" />,
+          element: <RelativeNavigate to="projects" />,
         },
         {
           path: projectFolderRoutes.projects,

--- a/front/app/containers/Admin/projectFolders/routes.tsx
+++ b/front/app/containers/Admin/projectFolders/routes.tsx
@@ -1,6 +1,6 @@
 import React, { lazy } from 'react';
 
-import { Navigate, Outlet as RouterOutlet } from 'react-router-dom';
+import { Navigate, Outlet as RouterOutlet } from 'react-router';
 
 import PageLoading from 'components/UI/PageLoading';
 

--- a/front/app/containers/Admin/projects/AdminProjectIdeaPreviewIndex.tsx
+++ b/front/app/containers/Admin/projects/AdminProjectIdeaPreviewIndex.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import IdeaPreviewIndex from 'components/admin/PostManager/components/IdeaPreviewIndex';
 

--- a/front/app/containers/Admin/projects/all/Tabs.tsx
+++ b/front/app/containers/Admin/projects/all/Tabs.tsx
@@ -6,7 +6,7 @@ import {
   colors,
   IconNames,
 } from '@citizenlab/cl2-component-library';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import useAuthUser from 'api/me/useAuthUser';
 

--- a/front/app/containers/Admin/projects/all/_shared/params.ts
+++ b/front/app/containers/Admin/projects/all/_shared/params.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import { Parameters } from 'api/projects_mini_admin/types';
 

--- a/front/app/containers/Admin/projects/all/index.tsx
+++ b/front/app/containers/Admin/projects/all/index.tsx
@@ -1,7 +1,7 @@
 import React, { Suspense } from 'react';
 
 import { Box, colors } from '@citizenlab/cl2-component-library';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import useFeatureFlag from 'hooks/useFeatureFlag';
 

--- a/front/app/containers/Admin/projects/components/NewIdeaButton/index.tsx
+++ b/front/app/containers/Admin/projects/components/NewIdeaButton/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { RouteType } from 'routes';
 
 import { InputTerm, ParticipationMethod } from 'api/phases/types';

--- a/front/app/containers/Admin/projects/index.tsx
+++ b/front/app/containers/Admin/projects/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Outlet as RouterOutlet } from 'react-router-dom';
+import { Outlet as RouterOutlet } from 'react-router';
 
 import HelmetIntl from 'components/HelmetIntl';
 

--- a/front/app/containers/Admin/projects/project/admin_phase_email_wrapper/index.tsx
+++ b/front/app/containers/Admin/projects/project/admin_phase_email_wrapper/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box, Text } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useCampaigns from 'api/campaigns/useCampaigns';
 import useSupportedCampaignNames from 'api/campaigns/useSupportedCampaignNames';

--- a/front/app/containers/Admin/projects/project/analysis/Demographics/AuthorsByAge.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Demographics/AuthorsByAge.tsx
@@ -8,7 +8,7 @@ import {
   Text,
   stylingConsts,
 } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import {
   BarChart as RechartsBarChart,
   Bar,

--- a/front/app/containers/Admin/projects/project/analysis/Demographics/AuthorsByDomicile.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Demographics/AuthorsByDomicile.tsx
@@ -9,7 +9,7 @@ import {
   stylingConsts,
 } from '@citizenlab/cl2-component-library';
 import { xor } from 'lodash-es';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import {
   BarChart,
   Bar,

--- a/front/app/containers/Admin/projects/project/analysis/FilterItems/InputFieldFilterItem.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/FilterItems/InputFieldFilterItem.tsx
@@ -6,7 +6,7 @@ import {
   colors,
   stylingConsts,
 } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useAnalysis from 'api/analyses/useAnalysis';
 import useIdeaCustomField from 'api/idea_custom_fields/useIdeaCustomField';

--- a/front/app/containers/Admin/projects/project/analysis/Heatmap/HeatmapDetails/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Heatmap/HeatmapDetails/index.tsx
@@ -10,7 +10,7 @@ import {
   Select,
   Text,
 } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useAnalysis from 'api/analyses/useAnalysis';
 import { Unit } from 'api/analysis_heat_map_cells/types';

--- a/front/app/containers/Admin/projects/project/analysis/Heatmap/HeatmapInsights.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Heatmap/HeatmapInsights.tsx
@@ -7,7 +7,7 @@ import {
   Button,
   IconButton,
 } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { Unit } from 'api/analysis_heat_map_cells/types';
 import useAnalysisHeatmapCells from 'api/analysis_heat_map_cells/useAnalysisHeatmapCells';

--- a/front/app/containers/Admin/projects/project/analysis/Heatmap/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Heatmap/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import { Button } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useAnalysis from 'api/analyses/useAnalysis';
 import { Unit } from 'api/analysis_heat_map_cells/types';

--- a/front/app/containers/Admin/projects/project/analysis/InputPreview/components/Comments/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/InputPreview/components/Comments/index.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useEffect } from 'react';
 
 import { Box, Spinner, Title } from '@citizenlab/cl2-component-library';
 import { useInView } from 'react-intersection-observer';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useAnalysisInput from 'api/analysis_inputs/useAnalysisInput';
 import useComments from 'api/comments/useComments';

--- a/front/app/containers/Admin/projects/project/analysis/InputPreview/components/CustomFields/LongFieldValue/CustomFieldLongFieldValues/MatrixLongField.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/InputPreview/components/CustomFields/LongFieldValue/CustomFieldLongFieldValues/MatrixLongField.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box, Title, Text } from '@citizenlab/cl2-component-library';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router';
 import { useTheme } from 'styled-components';
 
 import useCustomFieldStatements from 'api/custom_field_statements/useCustomFieldStatements';

--- a/front/app/containers/Admin/projects/project/analysis/InputPreview/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/InputPreview/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import { Box, Divider, Text } from '@citizenlab/cl2-component-library';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router';
 
 import useAnalysis from 'api/analyses/useAnalysis';
 import useAnalysisInput from 'api/analysis_inputs/useAnalysisInput';

--- a/front/app/containers/Admin/projects/project/analysis/InputsList/InputListItem.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/InputsList/InputListItem.tsx
@@ -8,7 +8,7 @@ import {
   Divider,
 } from '@citizenlab/cl2-component-library';
 import { isEmpty } from 'lodash-es';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useAnalysis from 'api/analyses/useAnalysis';
 import { IInputsData } from 'api/analysis_inputs/types';

--- a/front/app/containers/Admin/projects/project/analysis/InputsList/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/InputsList/index.tsx
@@ -8,7 +8,7 @@ import {
   Spinner,
 } from '@citizenlab/cl2-component-library';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import styled from 'styled-components';
 
 import useInfiniteAnalysisInputs from 'api/analysis_inputs/useInfiniteAnalysisInputs';

--- a/front/app/containers/Admin/projects/project/analysis/Insights/Files/FileSelectionView/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Insights/Files/FileSelectionView/index.tsx
@@ -3,7 +3,7 @@ import React, { useEffect } from 'react';
 import { Box, Text, Title } from '@citizenlab/cl2-component-library';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { FormProvider, useForm, useWatch } from 'react-hook-form';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { array, object, string } from 'yup';
 
 import useUpdateAnalysis from 'api/analyses/useUpdateAnalysis';

--- a/front/app/containers/Admin/projects/project/analysis/Insights/InsightBody.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Insights/InsightBody.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Box, Text, Spinner } from '@citizenlab/cl2-component-library';
 import { isEmpty } from 'lodash-es';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import styled from 'styled-components';
 
 import useAnalysisBackgroundTask from 'api/analysis_background_tasks/useAnalysisBackgroundTask';

--- a/front/app/containers/Admin/projects/project/analysis/Insights/Question.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Insights/Question.tsx
@@ -7,7 +7,7 @@ import {
   IconTooltip,
   Divider,
 } from '@citizenlab/cl2-component-library';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router';
 
 import { IInsightData } from 'api/analysis_insights/types';
 import useDeleteAnalysisInsight from 'api/analysis_insights/useDeleteAnalysisInsight';

--- a/front/app/containers/Admin/projects/project/analysis/Insights/QuestionButton.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Insights/QuestionButton.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
 import { Box, Button, Tooltip } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { IQuestionPreCheck } from 'api/analysis_question_pre_check/types';
 import useAddAnalysisQuestionPreCheck from 'api/analysis_question_pre_check/useAddAnalysisQuestionPreCheck';

--- a/front/app/containers/Admin/projects/project/analysis/Insights/QuestionInput.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Insights/QuestionInput.tsx
@@ -7,7 +7,7 @@ import {
   stylingConsts,
   Button,
 } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useAddAnalysisQuestion from 'api/analysis_questions/useAddAnalysisQuestion';
 

--- a/front/app/containers/Admin/projects/project/analysis/Insights/Rate.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Insights/Rate.tsx
@@ -7,7 +7,7 @@ import {
   Box,
   Icon,
 } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useRateAnalysisInsight from 'api/analysis_insights/useRateAnalysisInsight';
 

--- a/front/app/containers/Admin/projects/project/analysis/Insights/ReferenceLink.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Insights/ReferenceLink.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box, Icon, colors, Tooltip } from '@citizenlab/cl2-component-library';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import styled from 'styled-components';
 
 import useAnalysis from 'api/analyses/useAnalysis';

--- a/front/app/containers/Admin/projects/project/analysis/Insights/Summary.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Insights/Summary.tsx
@@ -7,7 +7,7 @@ import {
   IconTooltip,
   Divider,
 } from '@citizenlab/cl2-component-library';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router';
 
 import { IInsightData } from 'api/analysis_insights/types';
 import useDeleteAnalysisInsight from 'api/analysis_insights/useDeleteAnalysisInsight';

--- a/front/app/containers/Admin/projects/project/analysis/Insights/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Insights/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import { Box, Icon, Text, colors } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useInfiniteAnalysisInputs from 'api/analysis_inputs/useInfiniteAnalysisInputs';
 import useAnalysisInsights from 'api/analysis_insights/useAnalysisInsights';

--- a/front/app/containers/Admin/projects/project/analysis/SelectedInputContext/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/SelectedInputContext/index.tsx
@@ -6,7 +6,7 @@ import React, {
   useEffect,
 } from 'react';
 
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 const Context = createContext<{
   selectedInputId: string | null;

--- a/front/app/containers/Admin/projects/project/analysis/Taggings/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Taggings/index.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 
 import { Box } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useAddAnalysisTagging from 'api/analysis_taggings/useAddAnalysisTagging';
 import useAnalysisTaggings from 'api/analysis_taggings/useAnalysisTaggings';

--- a/front/app/containers/Admin/projects/project/analysis/Tags/AddTag.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Tags/AddTag.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import { Box, Button, Input } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useAddAnalysisTag from 'api/analysis_tags/useAddAnalysisTag';
 

--- a/front/app/containers/Admin/projects/project/analysis/Tags/AutoTaggingModal/Step1.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Tags/AutoTaggingModal/Step1.tsx
@@ -10,7 +10,7 @@ import {
   Radio,
 } from '@citizenlab/cl2-component-library';
 import { isEmpty } from 'lodash-es';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import styled from 'styled-components';
 
 import useAnalysis from 'api/analyses/useAnalysis';

--- a/front/app/containers/Admin/projects/project/analysis/Tags/AutoTaggingModal/Step2FewShotClassification.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Tags/AutoTaggingModal/Step2FewShotClassification.tsx
@@ -8,7 +8,7 @@ import {
   Title,
 } from '@citizenlab/cl2-component-library';
 import { xor } from 'lodash-es';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { ITagData } from 'api/analysis_tags/types';
 import useAnalysisTags from 'api/analysis_tags/useAnalysisTags';

--- a/front/app/containers/Admin/projects/project/analysis/Tags/AutoTaggingModal/Step2LabelClassification.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Tags/AutoTaggingModal/Step2LabelClassification.tsx
@@ -9,7 +9,7 @@ import {
   Title,
 } from '@citizenlab/cl2-component-library';
 import { xor } from 'lodash-es';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useAnalysisTags from 'api/analysis_tags/useAnalysisTags';
 

--- a/front/app/containers/Admin/projects/project/analysis/Tags/AutoTaggingModal/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Tags/AutoTaggingModal/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import { Box } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { AutoTaggingMethod } from 'api/analysis_background_tasks/types';
 import useLaunchAnalysisAutotagging from 'api/analysis_background_tasks/useLaunchAnalysisAutotagging';

--- a/front/app/containers/Admin/projects/project/analysis/Tags/TagActions.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Tags/TagActions.tsx
@@ -10,7 +10,7 @@ import {
   Box,
   IconButton,
 } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import styled from 'styled-components';
 
 import useAddAnalysisBulkTagging from 'api/analysis_taggings/useAnalysisBulkTaggings';

--- a/front/app/containers/Admin/projects/project/analysis/Tags/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Tags/index.tsx
@@ -13,7 +13,7 @@ import {
 } from '@citizenlab/cl2-component-library';
 import { useQueryClient } from '@tanstack/react-query';
 import { isEqual, omit, uniq } from 'lodash-es';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import styled from 'styled-components';
 
 import inputsKeys from 'api/analysis_inputs/keys';

--- a/front/app/containers/Admin/projects/project/analysis/Tasks/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Tasks/index.tsx
@@ -10,7 +10,7 @@ import {
   Spinner,
   Divider,
 } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import styled from 'styled-components';
 
 import {

--- a/front/app/containers/Admin/projects/project/analysis/TopBar/Filters/AuthorFilters.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/TopBar/Filters/AuthorFilters.tsx
@@ -7,7 +7,7 @@ import {
   Button,
   Text,
 } from '@citizenlab/cl2-component-library';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import useUserCustomFieldsOptions from 'api/custom_field_options/useCustomFieldOptions';
 import useUserCustomFields from 'api/user_custom_fields/useUserCustomFields';

--- a/front/app/containers/Admin/projects/project/analysis/TopBar/Filters/EmptyCustomFieldsFilter.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/TopBar/Filters/EmptyCustomFieldsFilter.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Toggle } from '@citizenlab/cl2-component-library';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import { useIntl } from 'utils/cl-intl';
 import { removeSearchParams } from 'utils/cl-router/removeSearchParams';

--- a/front/app/containers/Admin/projects/project/analysis/TopBar/Filters/EngagementFilter.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/TopBar/Filters/EngagementFilter.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box, Select, Input, Label } from '@citizenlab/cl2-component-library';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import { trackEventByName } from 'utils/analytics';
 import { useIntl } from 'utils/cl-intl';

--- a/front/app/containers/Admin/projects/project/analysis/TopBar/Filters/TimeFilter.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/TopBar/Filters/TimeFilter.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import moment from 'moment';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import TimeControl from 'containers/Admin/dashboard/components/TimeControl';
 

--- a/front/app/containers/Admin/projects/project/analysis/TopBar/Filters/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/TopBar/Filters/index.tsx
@@ -7,7 +7,7 @@ import {
   Text,
   defaultStyles,
 } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useAnalysis from 'api/analyses/useAnalysis';
 

--- a/front/app/containers/Admin/projects/project/analysis/TopBar/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/TopBar/index.tsx
@@ -8,7 +8,7 @@ import {
   Text,
 } from '@citizenlab/cl2-component-library';
 import { get, set } from 'js-cookie';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router';
 import { RouteType } from 'routes';
 import styled from 'styled-components';
 

--- a/front/app/containers/Admin/projects/project/analysis/hooks/useAnalysisFilterParams.test.ts
+++ b/front/app/containers/Admin/projects/project/analysis/hooks/useAnalysisFilterParams.test.ts
@@ -16,7 +16,7 @@ const mockSearchParams = new URLSearchParams({
   reactions_from: '10',
 });
 
-jest.mock('react-router-dom', () => ({
+jest.mock('react-router', () => ({
   useSearchParams: jest.fn(() => [mockSearchParams]),
 }));
 

--- a/front/app/containers/Admin/projects/project/analysis/hooks/useAnalysisFilterParams.ts
+++ b/front/app/containers/Admin/projects/project/analysis/hooks/useAnalysisFilterParams.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import { IInputsFilterParams } from 'api/analysis_inputs/types';
 

--- a/front/app/containers/Admin/projects/project/data/ResetParticipationData.tsx
+++ b/front/app/containers/Admin/projects/project/data/ResetParticipationData.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import { Button, Box, Title, Text } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useResetProject from 'api/projects/useResetProject';
 

--- a/front/app/containers/Admin/projects/project/description/index.tsx
+++ b/front/app/containers/Admin/projects/project/description/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useCallback, useState } from 'react';
 
 import { Success, Box, colors } from '@citizenlab/cl2-component-library';
 import { isEmpty } from 'lodash-es';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { Multiloc, SupportedLocale } from 'typings';
 
 import useProjectById from 'api/projects/useProjectById';

--- a/front/app/containers/Admin/projects/project/events/edit.tsx
+++ b/front/app/containers/Admin/projects/project/events/edit.tsx
@@ -13,7 +13,7 @@ import {
   stylingConsts,
 } from '@citizenlab/cl2-component-library';
 import { isEmpty, get, isError } from 'lodash-es';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { RouteType } from 'routes';
 import { useTheme } from 'styled-components';
 import { Multiloc, UploadFile } from 'typings';

--- a/front/app/containers/Admin/projects/project/events/index.tsx
+++ b/front/app/containers/Admin/projects/project/events/index.tsx
@@ -9,7 +9,7 @@ import {
 } from '@citizenlab/cl2-component-library';
 import saveAs from 'file-saver';
 import moment from 'moment';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import styled from 'styled-components';
 
 import { IEventData } from 'api/events/types';

--- a/front/app/containers/Admin/projects/project/files/components/FilesList/index.tsx
+++ b/front/app/containers/Admin/projects/project/files/components/FilesList/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import { Box, Spinner, Text } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { GetFilesParameters } from 'api/files/types';
 import useFiles from 'api/files/useFiles';

--- a/front/app/containers/Admin/projects/project/files/components/FilesUpload/index.tsx
+++ b/front/app/containers/Admin/projects/project/files/components/FilesUpload/index.tsx
@@ -7,7 +7,7 @@ import {
   Title,
 } from '@citizenlab/cl2-component-library';
 import { useDropzone } from 'react-dropzone';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { useIntl } from 'utils/cl-intl';
 

--- a/front/app/containers/Admin/projects/project/files/index.tsx
+++ b/front/app/containers/Admin/projects/project/files/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import { Box, Spinner } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useFiles from 'api/files/useFiles';
 

--- a/front/app/containers/Admin/projects/project/general/components/GeographicAreaInputs.tsx
+++ b/front/app/containers/Admin/projects/project/general/components/GeographicAreaInputs.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 
 import { IconTooltip, Radio } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import styled from 'styled-components';
 import { IOption, isIOption } from 'typings';
 

--- a/front/app/containers/Admin/projects/project/general/index.tsx
+++ b/front/app/containers/Admin/projects/project/general/index.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 
 import { Box, colors, IconTooltip } from '@citizenlab/cl2-component-library';
 import { isEmpty } from 'lodash-es';
-import { useParams, useLocation } from 'react-router-dom';
+import { useParams, useLocation } from 'react-router';
 import { Multiloc, UploadFile, CLErrors } from 'typings';
 
 import { IFileAttachmentData } from 'api/file_attachments/types';

--- a/front/app/containers/Admin/projects/project/ideas/index.tsx
+++ b/front/app/containers/Admin/projects/project/ideas/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import { Box, Title, Text, Button } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import usePhase from 'api/phases/usePhase';
 import usePhases from 'api/phases/usePhases';

--- a/front/app/containers/Admin/projects/project/index.tsx
+++ b/front/app/containers/Admin/projects/project/index.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
 
 import { Box } from '@citizenlab/cl2-component-library';
-import {
-  Outlet as RouterOutlet,
-  useLocation,
-  useParams,
-} from 'react-router-dom';
+import { Outlet as RouterOutlet, useLocation, useParams } from 'react-router';
 
 import NavigationTabs from 'components/admin/NavigationTabs';
 import Tab from 'components/admin/NavigationTabs/Tab';

--- a/front/app/containers/Admin/projects/project/information/ReportTab/index.tsx
+++ b/front/app/containers/Admin/projects/project/information/ReportTab/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box, Title, Toggle } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import usePhase from 'api/phases/usePhase';
 import useReport from 'api/reports/useReport';

--- a/front/app/containers/Admin/projects/project/inputForm/IdeaFormBuilder/index.tsx
+++ b/front/app/containers/Admin/projects/project/inputForm/IdeaFormBuilder/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { RouteType } from 'routes';
 
 import useFormCustomFields from 'api/custom_fields/useCustomFields';

--- a/front/app/containers/Admin/projects/project/inputForm/index.tsx
+++ b/front/app/containers/Admin/projects/project/inputForm/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import DownloadPDFButtonWithModal from 'components/admin/FormSync/DownloadPDFButtonWithModal';
 import ExcelDownloadButton from 'components/admin/FormSync/ExcelDownloadButton';

--- a/front/app/containers/Admin/projects/project/inputImporter/ImportModal/ImportExcelModal.tsx
+++ b/front/app/containers/Admin/projects/project/inputImporter/ImportModal/ImportExcelModal.tsx
@@ -9,7 +9,7 @@ import {
 } from '@citizenlab/cl2-component-library';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useForm, FormProvider } from 'react-hook-form';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { UploadFile, SupportedLocale } from 'typings';
 import { object, string, mixed } from 'yup';
 

--- a/front/app/containers/Admin/projects/project/inputImporter/ImportModal/ImportPdfModal.tsx
+++ b/front/app/containers/Admin/projects/project/inputImporter/ImportModal/ImportPdfModal.tsx
@@ -9,7 +9,7 @@ import {
 } from '@citizenlab/cl2-component-library';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useForm, FormProvider } from 'react-hook-form';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router';
 import { UploadFile, SupportedLocale } from 'typings';
 import { object, string, mixed, boolean } from 'yup';
 

--- a/front/app/containers/Admin/projects/project/inputImporter/ReviewSection/EmptyState.tsx
+++ b/front/app/containers/Admin/projects/project/inputImporter/ReviewSection/EmptyState.tsx
@@ -7,7 +7,7 @@ import {
   colors,
   stylingConsts,
 } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import usePhase from 'api/phases/usePhase';
 

--- a/front/app/containers/Admin/projects/project/inputImporter/ReviewSection/IdeaEditor/IdeaForm.tsx
+++ b/front/app/containers/Admin/projects/project/inputImporter/ReviewSection/IdeaEditor/IdeaForm.tsx
@@ -2,7 +2,7 @@ import React, { Suspense, useEffect } from 'react';
 
 import { Box } from '@citizenlab/cl2-component-library';
 import { FormProvider, UseFormSetError } from 'react-hook-form';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useCustomFields from 'api/custom_fields/useCustomFields';
 import usePhase from 'api/phases/usePhase';

--- a/front/app/containers/Admin/projects/project/inputImporter/ReviewSection/IdeaEditor/index.tsx
+++ b/front/app/containers/Admin/projects/project/inputImporter/ReviewSection/IdeaEditor/index.tsx
@@ -8,7 +8,7 @@ import {
   Tooltip,
 } from '@citizenlab/cl2-component-library';
 import { UseFormSetError } from 'react-hook-form';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useIdeaById from 'api/ideas/useIdeaById';
 import useUpdateIdea from 'api/ideas/useUpdateIdea';

--- a/front/app/containers/Admin/projects/project/inputImporter/ReviewSection/index.tsx
+++ b/front/app/containers/Admin/projects/project/inputImporter/ReviewSection/index.tsx
@@ -8,7 +8,7 @@ import {
   stylingConsts,
   Spinner,
 } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { IBackgroundJobData } from 'api/background_jobs/types';
 import useTrackBackgroundJobs from 'api/background_jobs/useTrackBackgroundJobs';

--- a/front/app/containers/Admin/projects/project/inputImporter/TopBar/index.tsx
+++ b/front/app/containers/Admin/projects/project/inputImporter/TopBar/index.tsx
@@ -7,7 +7,7 @@ import {
   stylingConsts,
   colors,
 } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { RouteType } from 'routes';
 
 import usePhase from 'api/phases/usePhase';

--- a/front/app/containers/Admin/projects/project/messaging/All/NewCampaignButton.tsx
+++ b/front/app/containers/Admin/projects/project/messaging/All/NewCampaignButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import ButtonWithLink from 'components/UI/ButtonWithLink';
 

--- a/front/app/containers/Admin/projects/project/messaging/All/index.tsx
+++ b/front/app/containers/Admin/projects/project/messaging/All/index.tsx
@@ -7,7 +7,7 @@ import {
   Text,
   colors,
 } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useCampaigns from 'api/campaigns/useCampaigns';
 import { isDraft } from 'api/campaigns/util';

--- a/front/app/containers/Admin/projects/project/messaging/Edit/index.tsx
+++ b/front/app/containers/Admin/projects/project/messaging/Edit/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { Box, colors } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useCampaign from 'api/campaigns/useCampaign';
 import useUpdateCampaign from 'api/campaigns/useUpdateCampaign';

--- a/front/app/containers/Admin/projects/project/messaging/New/index.tsx
+++ b/front/app/containers/Admin/projects/project/messaging/New/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box, colors } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useAddCampaign from 'api/campaigns/useAddCampaign';
 import useAuthUser from 'api/me/useAuthUser';

--- a/front/app/containers/Admin/projects/project/messaging/Show/index.tsx
+++ b/front/app/containers/Admin/projects/project/messaging/Show/index.tsx
@@ -8,7 +8,7 @@ import {
   Box,
   fontSizes,
 } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import styled from 'styled-components';
 
 import useAppConfiguration from 'api/app_configuration/useAppConfiguration';

--- a/front/app/containers/Admin/projects/project/nativeSurvey/AnalysisBanner/index.tsx
+++ b/front/app/containers/Admin/projects/project/nativeSurvey/AnalysisBanner/index.tsx
@@ -9,7 +9,7 @@ import {
   Tooltip,
 } from '@citizenlab/cl2-component-library';
 import { stringify } from 'qs';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useAddAnalysis from 'api/analyses/useAddAnalysis';
 import useAnalyses from 'api/analyses/useAnalyses';

--- a/front/app/containers/Admin/projects/project/nativeSurvey/SurveyFormBuilder/index.tsx
+++ b/front/app/containers/Admin/projects/project/nativeSurvey/SurveyFormBuilder/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router';
 
 import useFormCustomFields from 'api/custom_fields/useCustomFields';
 import usePhase from 'api/phases/usePhase';

--- a/front/app/containers/Admin/projects/project/nativeSurvey/UserFieldsInFormNotice/index.tsx
+++ b/front/app/containers/Admin/projects/project/nativeSurvey/UserFieldsInFormNotice/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box, colors, Icon, Text } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { RouteType } from 'routes';
 
 import usePhasePermissions from 'api/phase_permissions/usePhasePermissions';

--- a/front/app/containers/Admin/projects/project/nativeSurvey/index.tsx
+++ b/front/app/containers/Admin/projects/project/nativeSurvey/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import { Box, Spinner, Title, Toggle } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import usePhase from 'api/phases/usePhase';
 import useUpdatePhase from 'api/phases/useUpdatePhase';

--- a/front/app/containers/Admin/projects/project/permissions/Phase/index.tsx
+++ b/front/app/containers/Admin/projects/project/permissions/Phase/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Title, Text, Box, colors } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { FormattedMessage } from 'utils/cl-intl';
 

--- a/front/app/containers/Admin/projects/project/permissions/Project/index.tsx
+++ b/front/app/containers/Admin/projects/project/permissions/Project/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { SectionDescription, SectionTitle } from 'components/admin/Section';
 import Outlet from 'components/Outlet';

--- a/front/app/containers/Admin/projects/project/phase/PhaseHeader.tsx
+++ b/front/app/containers/Admin/projects/project/phase/PhaseHeader.tsx
@@ -13,7 +13,7 @@ import {
   Tooltip,
 } from '@citizenlab/cl2-component-library';
 import moment from 'moment';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router';
 import styled from 'styled-components';
 
 import usePhasePermissions from 'api/phase_permissions/usePhasePermissions';

--- a/front/app/containers/Admin/projects/project/phase/index.tsx
+++ b/front/app/containers/Admin/projects/project/phase/index.tsx
@@ -1,11 +1,7 @@
 import React, { useState, useEffect } from 'react';
 
 import { Box, colors, Spinner } from '@citizenlab/cl2-component-library';
-import {
-  Outlet as RouterOutlet,
-  useParams,
-  useLocation,
-} from 'react-router-dom';
+import { Outlet as RouterOutlet, useParams, useLocation } from 'react-router';
 
 import { IPhaseData } from 'api/phases/types';
 import usePhases from 'api/phases/usePhases';

--- a/front/app/containers/Admin/projects/project/phaseSetup/components/DateSetup.tsx
+++ b/front/app/containers/Admin/projects/project/phaseSetup/components/DateSetup.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 
 import { Box } from '@citizenlab/cl2-component-library';
 import { format, parseISO, startOfDay } from 'date-fns';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { CLErrors } from 'typings';
 
 import { IUpdatedPhaseProperties } from 'api/phases/types';

--- a/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/VotingInputs/index.tsx
+++ b/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/VotingInputs/index.tsx
@@ -7,7 +7,7 @@ import {
   Box,
   colors,
 } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import styled from 'styled-components';
 import { CLErrors, IOption } from 'typings';
 

--- a/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/shared/DefaultViewPicker.tsx
+++ b/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/shared/DefaultViewPicker.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Radio, IconTooltip } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { CLErrors } from 'typings';
 
 import { SectionField, SubSectionTitle } from 'components/admin/Section';

--- a/front/app/containers/Admin/projects/project/phaseSetup/index.tsx
+++ b/front/app/containers/Admin/projects/project/phaseSetup/index.tsx
@@ -6,7 +6,7 @@ import {
   IconTooltip,
   colors,
 } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { CLErrors, Multiloc, UploadFile } from 'typings';
 
 import { IFileAttachmentData } from 'api/file_attachments/types';

--- a/front/app/containers/Admin/projects/project/poll/index.tsx
+++ b/front/app/containers/Admin/projects/project/poll/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Box, Title } from '@citizenlab/cl2-component-library';
 import { isError } from 'lodash-es';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import GetPollQuestions, {
   GetPollQuestionsChildProps,
 } from 'resources/GetPollQuestions';

--- a/front/app/containers/Admin/projects/project/previewToken/index.tsx
+++ b/front/app/containers/Admin/projects/project/previewToken/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 
 import { Spinner } from '@citizenlab/cl2-component-library';
 import { set } from 'js-cookie';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import clHistory from 'utils/cl-router/history';
 

--- a/front/app/containers/Admin/projects/project/proposals/index.tsx
+++ b/front/app/containers/Admin/projects/project/proposals/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box, Title, Text } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import usePhase from 'api/phases/usePhase';
 import useProjectById from 'api/projects/useProjectById';

--- a/front/app/containers/Admin/projects/project/settings/index.tsx
+++ b/front/app/containers/Admin/projects/project/settings/index.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
 
 import { Box, colors } from '@citizenlab/cl2-component-library';
-import {
-  Outlet as RouterOutlet,
-  useLocation,
-  useParams,
-} from 'react-router-dom';
+import { Outlet as RouterOutlet, useLocation, useParams } from 'react-router';
 import { ITab } from 'typings';
 
 import NavigationTabs, { Tab } from 'components/admin/NavigationTabs';

--- a/front/app/containers/Admin/projects/project/surveyForm/TabPanel.tsx
+++ b/front/app/containers/Admin/projects/project/surveyForm/TabPanel.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { RouteType } from 'routes';
 
 import DownloadPDFButtonWithModal from 'components/admin/FormSync/DownloadPDFButtonWithModal';

--- a/front/app/containers/Admin/projects/project/surveyResults/index.tsx
+++ b/front/app/containers/Admin/projects/project/surveyResults/index.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import styled from 'styled-components';
 
 import usePhases from 'api/phases/usePhases';

--- a/front/app/containers/Admin/projects/project/traffic/TrafficDatesRange.tsx
+++ b/front/app/containers/Admin/projects/project/traffic/TrafficDatesRange.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 
 import { Box, IconTooltip, Text } from '@citizenlab/cl2-component-library';
 import moment from 'moment';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import DateRangePicker from 'components/admin/DatePickers/DateRangePicker';
 import ResolutionControl, {

--- a/front/app/containers/Admin/projects/project/traffic/index.tsx
+++ b/front/app/containers/Admin/projects/project/traffic/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import usePhases from 'api/phases/usePhases';
 

--- a/front/app/containers/Admin/projects/project/volunteering/EditCause.tsx
+++ b/front/app/containers/Admin/projects/project/volunteering/EditCause.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useCause from 'api/causes/useCause';
 import useUpdateCause from 'api/causes/useUpdateCause';

--- a/front/app/containers/Admin/projects/project/volunteering/NewCause.tsx
+++ b/front/app/containers/Admin/projects/project/volunteering/NewCause.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useAddCause from 'api/causes/useAddCause';
 

--- a/front/app/containers/Admin/projects/project/volunteering/index.tsx
+++ b/front/app/containers/Admin/projects/project/volunteering/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box, Title } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import styled from 'styled-components';
 
 import usePhase from 'api/phases/usePhase';

--- a/front/app/containers/Admin/projects/routes.tsx
+++ b/front/app/containers/Admin/projects/routes.tsx
@@ -1,7 +1,7 @@
 import React, { lazy } from 'react';
 
 import moduleConfiguration from 'modules';
-import { Navigate } from 'react-router-dom';
+import { Navigate } from 'react-router';
 import { RouteType } from 'routes';
 
 import PageLoading from 'components/UI/PageLoading';

--- a/front/app/containers/Admin/projects/routes.tsx
+++ b/front/app/containers/Admin/projects/routes.tsx
@@ -1,10 +1,11 @@
 import React, { lazy } from 'react';
 
 import moduleConfiguration from 'modules';
-import { Navigate } from 'react-router';
 import { RouteType } from 'routes';
 
 import PageLoading from 'components/UI/PageLoading';
+
+import RelativeNavigate from 'utils/cl-router/RelativeNavigate';
 
 import { AdminRoute } from '../routes';
 
@@ -260,7 +261,7 @@ const createAdminProjectsRoutes = () => {
         children: [
           {
             path: '',
-            element: <Navigate to="phases/setup" replace />,
+            element: <RelativeNavigate to="phases/setup" replace />,
           },
           {
             path: projectsRoutes.projectTraffic,

--- a/front/app/containers/Admin/reporting/components/ReportBuilderPage/CreateReportModal/RadioButtons.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilderPage/CreateReportModal/RadioButtons.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Radio, Text } from '@citizenlab/cl2-component-library';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import useAuthUser from 'api/me/useAuthUser';
 

--- a/front/app/containers/Admin/reporting/containers/PrintReport/index.tsx
+++ b/front/app/containers/Admin/reporting/containers/PrintReport/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
 import { Text, Spinner, Box } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import styled from 'styled-components';
 
 import useReportBuilderEnabled from 'api/reports/useReportBuilderEnabled';

--- a/front/app/containers/Admin/reporting/containers/ReportBuilder/index.tsx
+++ b/front/app/containers/Admin/reporting/containers/ReportBuilder/index.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 
 import { Box, stylingConsts } from '@citizenlab/cl2-component-library';
 import { isEmpty } from 'lodash-es';
-import { useLocation, useParams, useSearchParams } from 'react-router-dom';
+import { useLocation, useParams, useSearchParams } from 'react-router';
 import { SupportedLocale } from 'typings';
 
 import { ReportLayout } from 'api/report_layout/types';

--- a/front/app/containers/Admin/reporting/containers/ReportBuilderPage/index.tsx
+++ b/front/app/containers/Admin/reporting/containers/ReportBuilderPage/index.tsx
@@ -7,7 +7,7 @@ import {
   Title,
   Tooltip,
 } from '@citizenlab/cl2-component-library';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import useAuthUser from 'api/me/useAuthUser';
 import useReportBuilderEnabled from 'api/reports/useReportBuilderEnabled';

--- a/front/app/containers/Admin/reporting/index.tsx
+++ b/front/app/containers/Admin/reporting/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Outlet as RouterOutlet } from 'react-router-dom';
+import { Outlet as RouterOutlet } from 'react-router';
 
 import HelmetIntl from 'components/HelmetIntl';
 

--- a/front/app/containers/Admin/reporting/routes.tsx
+++ b/front/app/containers/Admin/reporting/routes.tsx
@@ -1,8 +1,8 @@
 import React, { lazy } from 'react';
 
-import { Navigate } from 'react-router';
-
 import PageLoading from 'components/UI/PageLoading';
+
+import RelativeNavigate from 'utils/cl-router/RelativeNavigate';
 
 import { AdminRoute } from '../routes';
 
@@ -53,7 +53,7 @@ const reportingRoutes = () => {
     },
     {
       path: reportingEnumRoutes.reporting,
-      element: <Navigate to={reportingEnumRoutes.reportBuilder} />,
+      element: <RelativeNavigate to={reportingEnumRoutes.reportBuilder} />,
     },
   ];
 };

--- a/front/app/containers/Admin/reporting/routes.tsx
+++ b/front/app/containers/Admin/reporting/routes.tsx
@@ -1,6 +1,6 @@
 import React, { lazy } from 'react';
 
-import { Navigate } from 'react-router-dom';
+import { Navigate } from 'react-router';
 
 import PageLoading from 'components/UI/PageLoading';
 

--- a/front/app/containers/Admin/routes.tsx
+++ b/front/app/containers/Admin/routes.tsx
@@ -1,7 +1,7 @@
 import React, { lazy } from 'react';
 
 import moduleConfiguration from 'modules';
-import { Navigate, useLocation } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router';
 
 import { IAppConfigurationData } from 'api/app_configuration/types';
 import useAppConfiguration from 'api/app_configuration/useAppConfiguration';

--- a/front/app/containers/Admin/routes.tsx
+++ b/front/app/containers/Admin/routes.tsx
@@ -9,6 +9,7 @@ import useAppConfiguration from 'api/app_configuration/useAppConfiguration';
 import PageLoading from 'components/UI/PageLoading';
 import Unauthorized from 'components/Unauthorized';
 
+import RelativeNavigate from 'utils/cl-router/RelativeNavigate';
 import { removeLocale } from 'utils/cl-router/updateLocationDescriptor';
 import { isUUID } from 'utils/helperUtils';
 import { usePermission } from 'utils/permissions';
@@ -149,7 +150,7 @@ const createAdminRoutes = () => {
         // Careful: moderators currently have access to the admin index route
         // Adjust isModerator in routePermissions.ts if needed.
         path: '',
-        element: <Navigate to="dashboard/overview" />,
+        element: <RelativeNavigate to="dashboard/overview" />,
       },
       createDashboardRoutes(),
       createAdminUsersRoutes(),

--- a/front/app/containers/Admin/settings/areas/Edit/index.tsx
+++ b/front/app/containers/Admin/settings/areas/Edit/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useArea from 'api/areas/useArea';
 import useUpdateArea from 'api/areas/useUpdateArea';

--- a/front/app/containers/Admin/settings/index.tsx
+++ b/front/app/containers/Admin/settings/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box, colors } from '@citizenlab/cl2-component-library';
-import { Outlet as RouterOutlet, useLocation } from 'react-router-dom';
+import { Outlet as RouterOutlet, useLocation } from 'react-router';
 import { ITab } from 'typings';
 
 import NavigationTabs, {

--- a/front/app/containers/Admin/settings/registration/CustomFieldRoutes/RegistrationCustomFieldEdit/RegistrationCustomFieldOptionsEdit.tsx
+++ b/front/app/containers/Admin/settings/registration/CustomFieldRoutes/RegistrationCustomFieldEdit/RegistrationCustomFieldOptionsEdit.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useCustomFieldOption from 'api/custom_field_options/useCustomFieldOption';
 import useUpdateCustomFieldOption from 'api/custom_field_options/useUpdateCustomFieldOption';

--- a/front/app/containers/Admin/settings/registration/CustomFieldRoutes/RegistrationCustomFieldEdit/RegistrationCustomFieldOptionsForm.tsx
+++ b/front/app/containers/Admin/settings/registration/CustomFieldRoutes/RegistrationCustomFieldEdit/RegistrationCustomFieldOptionsForm.tsx
@@ -4,7 +4,7 @@ import { Box } from '@citizenlab/cl2-component-library';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { FormProvider, useForm } from 'react-hook-form';
 import { WrappedComponentProps } from 'react-intl';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { Multiloc } from 'typings';
 import { object } from 'yup';
 

--- a/front/app/containers/Admin/settings/registration/CustomFieldRoutes/RegistrationCustomFieldEdit/RegistrationCustomFieldOptionsNew.tsx
+++ b/front/app/containers/Admin/settings/registration/CustomFieldRoutes/RegistrationCustomFieldEdit/RegistrationCustomFieldOptionsNew.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useAddCustomFieldOption from 'api/custom_field_options/useAddCustomFieldOption';
 

--- a/front/app/containers/Admin/settings/registration/CustomFieldRoutes/RegistrationCustomFieldEdit/RegistrationCustomFieldSettings.tsx
+++ b/front/app/containers/Admin/settings/registration/CustomFieldRoutes/RegistrationCustomFieldEdit/RegistrationCustomFieldSettings.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useUpdateUserCustomField from 'api/user_custom_fields/useUpdateUserCustomField';
 import useUserCustomField from 'api/user_custom_fields/useUserCustomField';

--- a/front/app/containers/Admin/settings/registration/CustomFieldRoutes/RegistrationCustomFieldEdit/index.tsx
+++ b/front/app/containers/Admin/settings/registration/CustomFieldRoutes/RegistrationCustomFieldEdit/index.tsx
@@ -1,7 +1,7 @@
 import React, { memo } from 'react';
 
 import { WrappedComponentProps } from 'react-intl';
-import { Outlet as RouterOutlet } from 'react-router-dom';
+import { Outlet as RouterOutlet } from 'react-router';
 import styled from 'styled-components';
 import { ITab } from 'typings';
 

--- a/front/app/containers/Admin/settings/registration/CustomFieldRoutes/index.tsx
+++ b/front/app/containers/Admin/settings/registration/CustomFieldRoutes/index.tsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 
-import { Outlet as RouterOutlet } from 'react-router-dom';
+import { Outlet as RouterOutlet } from 'react-router';
 
 export interface Props {}
 

--- a/front/app/containers/Admin/settings/registration/routes.tsx
+++ b/front/app/containers/Admin/settings/registration/routes.tsx
@@ -1,6 +1,6 @@
 import React, { lazy } from 'react';
 
-import { Outlet } from 'react-router-dom';
+import { Outlet } from 'react-router';
 
 import { AdminRoute } from 'containers/Admin/routes';
 

--- a/front/app/containers/Admin/settings/routes.tsx
+++ b/front/app/containers/Admin/settings/routes.tsx
@@ -1,7 +1,7 @@
 import React, { lazy } from 'react';
 
 import moduleConfiguration from 'modules';
-import { Navigate } from 'react-router-dom';
+import { Navigate } from 'react-router';
 
 import PageLoading from 'components/UI/PageLoading';
 

--- a/front/app/containers/Admin/settings/routes.tsx
+++ b/front/app/containers/Admin/settings/routes.tsx
@@ -1,9 +1,10 @@
 import React, { lazy } from 'react';
 
 import moduleConfiguration from 'modules';
-import { Navigate } from 'react-router';
 
 import PageLoading from 'components/UI/PageLoading';
+
+import RelativeNavigate from 'utils/cl-router/RelativeNavigate';
 
 import { AdminRoute } from '../routes';
 
@@ -90,7 +91,7 @@ export default () => ({
   children: [
     {
       path: settingsRoutes.settingsDefault,
-      element: <Navigate to="general" replace />,
+      element: <RelativeNavigate to="general" replace />,
     },
     {
       path: settingsRoutes.general,

--- a/front/app/containers/Admin/settings/statuses/containers/edit.tsx
+++ b/front/app/containers/Admin/settings/statuses/containers/edit.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import styled from 'styled-components';
 
 import { IdeaStatusParticipationMethod } from 'api/idea_statuses/types';

--- a/front/app/containers/Admin/settings/statuses/containers/statusesMain.tsx
+++ b/front/app/containers/Admin/settings/statuses/containers/statusesMain.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
 import { Box } from '@citizenlab/cl2-component-library';
-import { useLocation, Outlet } from 'react-router-dom';
+import { useLocation, Outlet } from 'react-router';
 
 import { Tab } from 'components/admin/NavigationTabs';
 

--- a/front/app/containers/Admin/settings/topics/Edit/index.tsx
+++ b/front/app/containers/Admin/settings/topics/Edit/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { ITopicUpdate } from 'api/topics/types';
 import useTopic from 'api/topics/useTopic';

--- a/front/app/containers/Admin/sideBar/MenuItem.tsx
+++ b/front/app/containers/Admin/sideBar/MenuItem.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { media, colors, Icon, Box } from '@citizenlab/cl2-component-library';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import styled from 'styled-components';
 
 import useAuthUser from 'api/me/useAuthUser';

--- a/front/app/containers/Admin/sideBar/index.tsx
+++ b/front/app/containers/Admin/sideBar/index.tsx
@@ -9,7 +9,7 @@ import {
   colors,
   stylingConsts,
 } from '@citizenlab/cl2-component-library';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import styled from 'styled-components';
 import { InsertConfigurationOptions } from 'typings';
 

--- a/front/app/containers/Admin/tools/routes.tsx
+++ b/front/app/containers/Admin/tools/routes.tsx
@@ -1,7 +1,7 @@
 import React, { lazy } from 'react';
 
 import moduleConfiguration from 'modules';
-import { Outlet as RouterOutlet } from 'react-router-dom';
+import { Outlet as RouterOutlet } from 'react-router';
 
 import HelmetIntl from 'components/HelmetIntl';
 import PageLoading from 'components/UI/PageLoading';

--- a/front/app/containers/Admin/users/UsersGroup.tsx
+++ b/front/app/containers/Admin/users/UsersGroup.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import { useQueryClient } from '@tanstack/react-query';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useDeleteMembership from 'api/group_memberships/useDeleteMembership';
 import { MembershipType } from 'api/groups/types';

--- a/front/app/containers/Admin/users/index.tsx
+++ b/front/app/containers/Admin/users/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import { media } from '@citizenlab/cl2-component-library';
-import { Outlet as RouterOutlet } from 'react-router-dom';
+import { Outlet as RouterOutlet } from 'react-router';
 import styled from 'styled-components';
 
 import { IGroupData, MembershipType } from 'api/groups/types';

--- a/front/app/containers/App/Meta.tsx
+++ b/front/app/containers/App/Meta.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Helmet } from 'react-helmet-async';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import useAppConfiguration from 'api/app_configuration/useAppConfiguration';
 import useHomepageLayout from 'api/home_page_layout/useHomepageLayout';

--- a/front/app/containers/App/ModalQueue/modals/CommunityMonitor/ModalManager.tsx
+++ b/front/app/containers/App/ModalQueue/modals/CommunityMonitor/ModalManager.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect } from 'react';
 
 import { get } from 'js-cookie';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import useCommunityMonitorProject from 'api/community_monitor/useCommunityMonitorProject';
 import useAuthUser from 'api/me/useAuthUser';

--- a/front/app/containers/App/index.tsx
+++ b/front/app/containers/App/index.tsx
@@ -15,7 +15,7 @@ import 'intersection-observer';
 // moment-timezone extends the regular moment library,
 // so there's no need to import both moment and moment-timezone
 import moment from 'moment-timezone';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import styled, { ThemeProvider } from 'styled-components';
 
 import { IAppConfigurationStyle } from 'api/app_configuration/types';

--- a/front/app/containers/Authentication/steps/EmailAndPassword/Form.tsx
+++ b/front/app/containers/Authentication/steps/EmailAndPassword/Form.tsx
@@ -3,7 +3,7 @@ import React, { useEffect } from 'react';
 import { Box, Text } from '@citizenlab/cl2-component-library';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useForm, FormProvider } from 'react-hook-form';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { string, object, boolean } from 'yup';
 
 import useAppConfiguration from 'api/app_configuration/useAppConfiguration';

--- a/front/app/containers/Authentication/useAuthConfig/index.tsx
+++ b/front/app/containers/Authentication/useAuthConfig/index.tsx
@@ -1,4 +1,4 @@
-import { useLocation, useSearchParams } from 'react-router-dom';
+import { useLocation, useSearchParams } from 'react-router';
 
 import useAppConfiguration from 'api/app_configuration/useAppConfiguration';
 

--- a/front/app/containers/Authentication/useSteps/index.ts
+++ b/front/app/containers/Authentication/useSteps/index.ts
@@ -1,7 +1,7 @@
 import { useState, useRef, useCallback, useMemo, useEffect } from 'react';
 
 import { parse } from 'qs';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { RouteType } from 'routes';
 
 import { GLOBAL_CONTEXT } from 'api/authentication/authentication_requirements/constants';

--- a/front/app/containers/CustomPageShow/index.tsx
+++ b/front/app/containers/CustomPageShow/index.tsx
@@ -7,7 +7,7 @@ import {
   media,
 } from '@citizenlab/cl2-component-library';
 import { Helmet } from 'react-helmet-async';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import styled from 'styled-components';
 
 import useAppConfiguration from 'api/app_configuration/useAppConfiguration';

--- a/front/app/containers/DisabledAccount/index.tsx
+++ b/front/app/containers/DisabledAccount/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Box, Text } from '@citizenlab/cl2-component-library';
 import moment from 'moment';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import ContentContainer from 'components/ContentContainer';
 import { Title } from 'components/smallForm';

--- a/front/app/containers/EmailSettingsPage/index.tsx
+++ b/front/app/containers/EmailSettingsPage/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
 import { Title, colors } from '@citizenlab/cl2-component-library';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import styled from 'styled-components';
 import { Multiloc } from 'typings';
 

--- a/front/app/containers/EventsPage/EventsViewer/DateFilterDropdown.tsx
+++ b/front/app/containers/EventsPage/EventsViewer/DateFilterDropdown.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import { Box } from '@citizenlab/cl2-component-library';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import FilterSelector from 'components/FilterSelector';
 

--- a/front/app/containers/EventsPage/EventsViewer/index.tsx
+++ b/front/app/containers/EventsPage/EventsViewer/index.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { Box } from '@citizenlab/cl2-component-library';
 import moment from 'moment';
 import { MessageDescriptor } from 'react-intl';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import styled from 'styled-components';
 
 import useEvents from 'api/events/useEvents';

--- a/front/app/containers/EventsShowPage/components/DesktopTopBar.tsx
+++ b/front/app/containers/EventsShowPage/components/DesktopTopBar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box, Button, isRtl } from '@citizenlab/cl2-component-library';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import styled from 'styled-components';
 
 import { IEventData } from 'api/events/types';

--- a/front/app/containers/EventsShowPage/components/MobileTopBar.tsx
+++ b/front/app/containers/EventsShowPage/components/MobileTopBar.tsx
@@ -6,7 +6,7 @@ import {
   media,
   colors,
 } from '@citizenlab/cl2-component-library';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import styled from 'styled-components';
 
 import useProjectById from 'api/projects/useProjectById';

--- a/front/app/containers/EventsShowPage/index.tsx
+++ b/front/app/containers/EventsShowPage/index.tsx
@@ -7,7 +7,7 @@ import {
   media,
   useBreakpoint,
 } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import styled from 'styled-components';
 
 import useEventImage from 'api/event_images/useEventImage';

--- a/front/app/containers/IdeaHeading/EditIdeaHeading/index.tsx
+++ b/front/app/containers/IdeaHeading/EditIdeaHeading/index.tsx
@@ -9,7 +9,7 @@ import {
   stylingConsts,
   Title,
 } from '@citizenlab/cl2-component-library';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import styled from 'styled-components';
 
 import { IIdeaData } from 'api/ideas/types';

--- a/front/app/containers/IdeaHeading/NewIdeaHeading/index.tsx
+++ b/front/app/containers/IdeaHeading/NewIdeaHeading/index.tsx
@@ -9,7 +9,7 @@ import {
   stylingConsts,
   Title,
 } from '@citizenlab/cl2-component-library';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router';
 import { RouteType } from 'routes';
 import styled from 'styled-components';
 

--- a/front/app/containers/IdeasEditPage/IdeasEditForm.tsx
+++ b/front/app/containers/IdeasEditPage/IdeasEditForm.tsx
@@ -1,7 +1,7 @@
 import React, { Suspense, useEffect, useState } from 'react';
 
 import { Box, colors, useBreakpoint } from '@citizenlab/cl2-component-library';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import useAppConfiguration from 'api/app_configuration/useAppConfiguration';
 import useIdeaById from 'api/ideas/useIdeaById';

--- a/front/app/containers/IdeasEditPage/index.tsx
+++ b/front/app/containers/IdeasEditPage/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Spinner } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useIdeaById from 'api/ideas/useIdeaById';
 

--- a/front/app/containers/IdeasIndexPage/index.tsx
+++ b/front/app/containers/IdeasIndexPage/index.tsx
@@ -6,7 +6,7 @@ import {
   colors,
   isRtl,
 } from '@citizenlab/cl2-component-library';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import styled from 'styled-components';
 
 import { IdeaQueryParameters } from 'api/ideas/types';

--- a/front/app/containers/IdeasNewPage/IdeasNewIdeationForm/index.tsx
+++ b/front/app/containers/IdeasNewPage/IdeasNewIdeationForm/index.tsx
@@ -1,7 +1,7 @@
 import React, { Suspense, useEffect, useState } from 'react';
 
 import { Box, colors, useBreakpoint } from '@citizenlab/cl2-component-library';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import { IPhases, IPhaseData, ParticipationMethod } from 'api/phases/types';
 import usePhase from 'api/phases/usePhase';

--- a/front/app/containers/IdeasNewPage/IdeasNewMeta.tsx
+++ b/front/app/containers/IdeasNewPage/IdeasNewMeta.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Helmet } from 'react-helmet-async';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import useAuthUser from 'api/me/useAuthUser';
 import usePhases from 'api/phases/usePhases';

--- a/front/app/containers/IdeasNewPage/SimilarInputs/SimilarInputsList.tsx
+++ b/front/app/containers/IdeasNewPage/SimilarInputs/SimilarInputsList.tsx
@@ -7,7 +7,7 @@ import {
   Icon,
   colors,
 } from '@citizenlab/cl2-component-library';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router';
 import { Multiloc } from 'typings';
 
 import { IIdeaData } from 'api/ideas/types';

--- a/front/app/containers/IdeasNewPage/index.tsx
+++ b/front/app/containers/IdeasNewPage/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Spinner } from '@citizenlab/cl2-component-library';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router';
 
 import useAuthUser from 'api/me/useAuthUser';
 import usePhases from 'api/phases/usePhases';

--- a/front/app/containers/IdeasNewSurveyPage/IdeasNewSurveyForm/SurveyHeading/index.tsx
+++ b/front/app/containers/IdeasNewSurveyPage/IdeasNewSurveyForm/SurveyHeading/index.tsx
@@ -9,7 +9,7 @@ import {
   stylingConsts,
   Title,
 } from '@citizenlab/cl2-component-library';
-import { useLocation, useParams, useSearchParams } from 'react-router-dom';
+import { useLocation, useParams, useSearchParams } from 'react-router';
 import { RouteType } from 'routes';
 import styled from 'styled-components';
 

--- a/front/app/containers/IdeasNewSurveyPage/index.tsx
+++ b/front/app/containers/IdeasNewSurveyPage/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Spinner } from '@citizenlab/cl2-component-library';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router';
 
 import useAuthUser from 'api/me/useAuthUser';
 import usePhases from 'api/phases/usePhases';

--- a/front/app/containers/IdeasShow/components/Container.tsx
+++ b/front/app/containers/IdeasShow/components/Container.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import CSSTransition from 'react-transition-group/CSSTransition';
 import styled from 'styled-components';
 

--- a/front/app/containers/IdeasShowPage/DesktopTopBar.tsx
+++ b/front/app/containers/IdeasShowPage/DesktopTopBar.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useEffect } from 'react';
 
 import { Box } from '@citizenlab/cl2-component-library';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import { IProjectData } from 'api/projects/types';
 

--- a/front/app/containers/IdeasShowPage/IdeaShowPageTopBar.tsx
+++ b/front/app/containers/IdeasShowPage/IdeaShowPageTopBar.tsx
@@ -7,7 +7,7 @@ import {
   colors,
 } from '@citizenlab/cl2-component-library';
 import { lighten } from 'polished';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import styled from 'styled-components';
 
 import { IIdeaData } from 'api/ideas/types';

--- a/front/app/containers/IdeasShowPage/index.tsx
+++ b/front/app/containers/IdeasShowPage/index.tsx
@@ -7,7 +7,7 @@ import {
   media,
   colors,
 } from '@citizenlab/cl2-component-library';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router';
 import styled, { useTheme } from 'styled-components';
 
 import { VotingContext } from 'api/baskets_ideas/useVoting';

--- a/front/app/containers/ProjectDescriptionBuilder/FullscreenPreview/FullscreenPreview.test.tsx
+++ b/front/app/containers/ProjectDescriptionBuilder/FullscreenPreview/FullscreenPreview.test.tsx
@@ -39,8 +39,8 @@ jest.mock(
   }
 );
 
-jest.mock('react-router-dom', () => {
-  const originalModule = jest.requireActual('react-router-dom');
+jest.mock('react-router', () => {
+  const originalModule = jest.requireActual('react-router');
   return {
     ...originalModule,
     useParams: () => ({

--- a/front/app/containers/ProjectDescriptionBuilder/FullscreenPreview/index.tsx
+++ b/front/app/containers/ProjectDescriptionBuilder/FullscreenPreview/index.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 
 import { Box, Spinner, Title } from '@citizenlab/cl2-component-library';
 import { SerializedNodes } from '@craftjs/core';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router';
 import { SupportedLocale } from 'typings';
 
 import useProjectDescriptionBuilderLayout from 'api/project_description_builder/useProjectDescriptionBuilderLayout';

--- a/front/app/containers/ProjectDescriptionBuilder/index.tsx
+++ b/front/app/containers/ProjectDescriptionBuilder/index.tsx
@@ -3,7 +3,7 @@ import React, { useState, useRef, useCallback } from 'react';
 import { Box, stylingConsts } from '@citizenlab/cl2-component-library';
 import { SerializedNodes } from '@craftjs/core';
 import { isEmpty } from 'lodash-es';
-import { useParams, useLocation } from 'react-router-dom';
+import { useParams, useLocation } from 'react-router';
 import { SupportedLocale } from 'typings';
 
 import useProjectDescriptionBuilderLayout from 'api/project_description_builder/useProjectDescriptionBuilderLayout';

--- a/front/app/containers/ProjectFolderShowPage/index.tsx
+++ b/front/app/containers/ProjectFolderShowPage/index.tsx
@@ -7,7 +7,7 @@ import {
   colors,
   useBreakpoint,
 } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import styled from 'styled-components';
 
 import useAuthUser from 'api/me/useAuthUser';

--- a/front/app/containers/ProjectsShowPage/SucessModal.tsx
+++ b/front/app/containers/ProjectsShowPage/SucessModal.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 
 import { Box, Image } from '@citizenlab/cl2-component-library';
 import rocket from 'assets/img/rocket.png';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import useIdeaById from 'api/ideas/useIdeaById';
 import usePhases from 'api/phases/usePhases';

--- a/front/app/containers/ProjectsShowPage/index.tsx
+++ b/front/app/containers/ProjectsShowPage/index.tsx
@@ -9,7 +9,7 @@ import {
 } from '@citizenlab/cl2-component-library';
 import JSConfetti from 'js-confetti';
 import { isError } from 'lodash-es';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router';
 import styled from 'styled-components';
 
 import useAppConfiguration from 'api/app_configuration/useAppConfiguration';

--- a/front/app/containers/ProjectsShowPage/shared/header/ProjectActionButtons.tsx
+++ b/front/app/containers/ProjectsShowPage/shared/header/ProjectActionButtons.tsx
@@ -2,7 +2,7 @@ import React, { memo, useEffect, useState } from 'react';
 
 import { useBreakpoint, Box } from '@citizenlab/cl2-component-library';
 import { isNumber } from 'lodash-es';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import useEvents from 'api/events/useEvents';
 import { IPhaseData } from 'api/phases/types';

--- a/front/app/containers/ProjectsShowPage/timeline/CommonGround/CommonGroundTabs.tsx
+++ b/front/app/containers/ProjectsShowPage/timeline/CommonGround/CommonGroundTabs.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box } from '@citizenlab/cl2-component-library';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import useCommonGroundProgress from 'api/common_ground/useCommonGroundProgress';
 import { IProjectData } from 'api/projects/types';

--- a/front/app/containers/ProjectsShowPage/timeline/Ideas.tsx
+++ b/front/app/containers/ProjectsShowPage/timeline/Ideas.tsx
@@ -1,7 +1,7 @@
 import React, { lazy, Suspense, useMemo } from 'react';
 
 import { Box, Spinner } from '@citizenlab/cl2-component-library';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import { IdeaSortMethod, IPhaseData } from 'api/phases/types';
 import usePhase from 'api/phases/usePhase';

--- a/front/app/containers/ProjectsShowPage/timeline/PhaseNavigation.tsx
+++ b/front/app/containers/ProjectsShowPage/timeline/PhaseNavigation.tsx
@@ -7,7 +7,7 @@ import {
   Tooltip,
 } from '@citizenlab/cl2-component-library';
 import { findIndex } from 'lodash-es';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import styled from 'styled-components';
 
 import { IPhaseData } from 'api/phases/types';

--- a/front/app/containers/ProjectsShowPage/timeline/index.tsx
+++ b/front/app/containers/ProjectsShowPage/timeline/index.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 
 import { Box, colors, isRtl, Title } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import styled from 'styled-components';
 
 import { IPhaseData } from 'api/phases/types';

--- a/front/app/containers/UsersShowPage/Following/index.tsx
+++ b/front/app/containers/UsersShowPage/Following/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
 import { Box, Title, useBreakpoint } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { FollowableObject } from 'api/follow_unfollow/types';
 import useAuthUser from 'api/me/useAuthUser';

--- a/front/app/containers/UsersShowPage/Submissions/index.tsx
+++ b/front/app/containers/UsersShowPage/Submissions/index.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 
 import { Box, Title, useBreakpoint } from '@citizenlab/cl2-component-library';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router';
 
 import { IdeaSortMethod } from 'api/phases/types';
 import { IdeaSortMethodFallback } from 'api/phases/utils';

--- a/front/app/containers/UsersShowPage/Surveys/index.tsx
+++ b/front/app/containers/UsersShowPage/Surveys/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { media } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import styled from 'styled-components';
 
 import useAuthUser from 'api/me/useAuthUser';

--- a/front/app/containers/UsersShowPage/UserComments.tsx
+++ b/front/app/containers/UsersShowPage/UserComments.tsx
@@ -9,7 +9,7 @@ import {
 } from '@citizenlab/cl2-component-library';
 import { groupBy } from 'lodash-es';
 import { darken, rgba } from 'polished';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import styled, { useTheme } from 'styled-components';
 
 import useComments from 'api/comments/useComments';

--- a/front/app/containers/UsersShowPage/UserEvents.tsx
+++ b/front/app/containers/UsersShowPage/UserEvents.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Title, useBreakpoint } from '@citizenlab/cl2-component-library';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import styled from 'styled-components';
 
 import useEventsByUserId from 'api/events/useEventsByUserId';

--- a/front/app/containers/UsersShowPage/UserNavbar.tsx
+++ b/front/app/containers/UsersShowPage/UserNavbar.tsx
@@ -8,7 +8,7 @@ import {
   IconNames,
 } from '@citizenlab/cl2-component-library';
 import { rgba } from 'polished';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import styled from 'styled-components';
 import { ITab } from 'typings';
 

--- a/front/app/containers/UsersShowPage/index.tsx
+++ b/front/app/containers/UsersShowPage/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { media, colors } from '@citizenlab/cl2-component-library';
-import { useParams, Outlet as RouterOutlet } from 'react-router-dom';
+import { useParams, Outlet as RouterOutlet } from 'react-router';
 import styled from 'styled-components';
 
 import useUserBySlug from 'api/users/useUserBySlug';

--- a/front/app/containers/UsersShowPage/routes.tsx
+++ b/front/app/containers/UsersShowPage/routes.tsx
@@ -1,8 +1,8 @@
 import React, { lazy } from 'react';
 
-import { Navigate } from 'react-router';
-
 import PageLoading from 'components/UI/PageLoading';
+
+import RelativeNavigate from 'utils/cl-router/RelativeNavigate';
 
 const UsersShowPage = lazy(() => import('./'));
 const Following = lazy(() => import('./Following'));
@@ -41,7 +41,7 @@ export default () => ({
   children: [
     {
       path: userShowPageRoutes.default,
-      element: <Navigate to="submissions" replace />,
+      element: <RelativeNavigate to="submissions" replace />,
     },
     {
       path: userShowPageRoutes.submissions,

--- a/front/app/containers/UsersShowPage/routes.tsx
+++ b/front/app/containers/UsersShowPage/routes.tsx
@@ -1,6 +1,6 @@
 import React, { lazy } from 'react';
 
-import { Navigate } from 'react-router-dom';
+import { Navigate } from 'react-router';
 
 import PageLoading from 'components/UI/PageLoading';
 

--- a/front/app/modules/commercial/widgets/admin/containers/index.tsx
+++ b/front/app/modules/commercial/widgets/admin/containers/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box, colors } from '@citizenlab/cl2-component-library';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import { SectionTitle, SectionDescription } from 'components/admin/Section';
 import GoBackButton from 'components/UI/GoBackButton';

--- a/front/app/root.tsx
+++ b/front/app/root.tsx
@@ -19,14 +19,14 @@ import {
   useNavigationType,
   useRoutes,
   unstable_HistoryRouter as HistoryRouter,
-} from 'react-router-dom';
+} from 'react-router';
 
 import App from 'containers/App';
 import LanguageProvider from 'containers/LanguageProvider';
 import OutletsProvider from 'containers/OutletsProvider';
 
-import history from 'utils/browserHistory';
 import { queryClient } from 'utils/cl-react-query/queryClient';
+import createBrowserHistory from 'utils/cl-router/history';
 
 import prefetchData from './prefetchData';
 import createRoutes from './routes';
@@ -69,7 +69,7 @@ const Root = () => {
       <OutletsProvider>
         <HelmetProvider>
           <LanguageProvider>
-            <HistoryRouter history={history}>
+            <HistoryRouter history={createBrowserHistory}>
               <App>
                 <Routes />
               </App>

--- a/front/app/utils/cl-router/Link.tsx
+++ b/front/app/utils/cl-router/Link.tsx
@@ -6,7 +6,7 @@ import {
   // eslint-disable-next-line no-restricted-imports
   NavLink as RouterLink,
   NavLinkProps,
-} from 'react-router-dom';
+} from 'react-router';
 import { RouteType } from 'routes';
 
 import useLocale from 'hooks/useLocale';
@@ -24,6 +24,25 @@ export type Props = {
   onClick?: (event: React.MouseEvent) => void;
 } & Omit<NavLinkProps, 'onClick'>;
 
+// Helper to properly separate pathname and search params
+const formatToValue = (to: Path | RouteType | { pathname: string }) => {
+  if (typeof to === 'string' && to.includes('?')) {
+    const [pathname, search] = to.split('?');
+    return { pathname, search: `?${search}` };
+  }
+
+  if (typeof to === 'object' && to.pathname && to.pathname.includes('?')) {
+    const [pathname, search] = to.pathname.split('?');
+    return {
+      ...to,
+      pathname,
+      search: `?${search}`,
+    };
+  }
+
+  return to;
+};
+
 /*
  * This link override doesn't support url parameters, because updateLocationDescriptor doesn't parse them
  */
@@ -36,10 +55,18 @@ const Link = ({
   ...otherProps
 }: Props) => {
   const locale = useLocale();
+
+  // Format the 'to' value properly before passing to updateLocationDescriptor
+  const formattedTo = formatToValue(to);
+
   return (
     <RouterLink
       end={onlyActiveOnIndex}
-      to={!isNilOrError(locale) ? updateLocationDescriptor(to, locale) : '#'}
+      to={
+        !isNilOrError(locale)
+          ? updateLocationDescriptor(formattedTo, locale)
+          : '#'
+      }
       onClick={(event) => {
         onClick && onClick(event);
         if (scrollToTop) {

--- a/front/app/utils/cl-router/RelativeNavigate.tsx
+++ b/front/app/utils/cl-router/RelativeNavigate.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import { Navigate, useLocation } from 'react-router';
+
+interface RelativeNavigateProps {
+  to: string;
+  replace?: boolean;
+}
+
+/**
+ * A component that navigates to a path relative to the current location
+ * This is needed for React Router v7 where relative <Navigate/> behavior changed
+ */
+const RelativeNavigate = ({ to, replace = false }: RelativeNavigateProps) => {
+  const location = useLocation();
+
+  // Get the current path without trailing slash
+  const currentPath = location.pathname.replace(/\/$/, '');
+
+  // Remove leading slash or ./ from the target path if present
+  const cleanedTarget = to.replace(/^(\.\/|\/)/, '');
+
+  // Combine the current path with the target path
+  const fullPath = `${currentPath}/${cleanedTarget}`;
+
+  return <Navigate to={fullPath} replace={replace} />;
+};
+
+export default RelativeNavigate;

--- a/front/app/utils/cl-router/history.ts
+++ b/front/app/utils/cl-router/history.ts
@@ -37,4 +37,14 @@ export default {
   replace: (location: Partial<Location> | RouteType, options?: Options): void =>
     historyMethod('replace', location, { scrollToTop: options?.scrollToTop }),
   goBack: () => history.back(),
+  // Add missing methods for React Router v6/v7 compatibility
+  createURL: (location: any) =>
+    new URL(history.createHref(location), window.location.origin),
+  encodeLocation: (location: any) => location,
+  // Wrap listen to add missing delta property
+  listen: (listener: any) => {
+    return history.listen((update: any) => {
+      listener({ ...update, delta: update.action === 'POP' ? -1 : 1 });
+    });
+  },
 };

--- a/front/app/utils/cl-router/withRouter.tsx
+++ b/front/app/utils/cl-router/withRouter.tsx
@@ -6,7 +6,7 @@ import {
   useNavigate,
   useParams,
   useSearchParams,
-} from 'react-router-dom';
+} from 'react-router';
 
 /** @deprecated Use `React Router hooks` instead */
 export interface WithRouterProps {

--- a/front/app/utils/testUtils/rtl.tsx
+++ b/front/app/utils/testUtils/rtl.tsx
@@ -9,7 +9,7 @@ import GlobalStyle from 'global-styles';
 import messages from 'i18n/en';
 import { HelmetProvider } from 'react-helmet-async';
 import { IntlProvider } from 'react-intl';
-import { unstable_HistoryRouter as HistoryRouter } from 'react-router-dom';
+import { unstable_HistoryRouter as HistoryRouter } from 'react-router';
 import { ThemeProvider } from 'styled-components';
 
 import { ModalQueueProvider } from 'containers/App/ModalQueue';

--- a/front/cypress/.eslintrc.js
+++ b/front/cypress/.eslintrc.js
@@ -87,7 +87,7 @@ module.exports = {
             name: 'react-router-dom',
             importNames: ['Link', 'useNavigate', 'NavLink'],
             message:
-              "Please import the Link or useNavigate from utils/cl-router instead of directly from 'react-router-dom'",
+              "Please import the Link or useNavigate from utils/cl-router instead of directly from 'react-router'",
           },
           {
             name: 'react-intl',

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -79,7 +79,7 @@
         "react-pdf": "9.2.1",
         "react-range": "1.8.14",
         "react-resize-detector": "8.0.3",
-        "react-router-dom": "6.3.0",
+        "react-router": "^7.9.4",
         "react-select": "5.9.0",
         "react-share": "5.1.1",
         "react-string-replace": "1.1.1",
@@ -22100,27 +22100,32 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
-      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+      "version": "7.9.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.4.tgz",
+      "integrity": "sha512-SD3G8HKviFHg9xj7dNODUKDFgpG4xqD5nhyd0mYoB5iISepuZAvzSr8ywxgxKJ52yRzf/HWtVHc9AWwoTbljvA==",
       "dependencies": {
-        "history": "^5.2.0"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
-    "node_modules/react-router-dom": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
-      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
-      "dependencies": {
-        "history": "^5.2.0",
-        "react-router": "6.3.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/react-select": {
@@ -23350,6 +23355,11 @@
       "dev": true,
       "optional": true,
       "peer": true
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/front/package.json
+++ b/front/package.json
@@ -125,7 +125,7 @@
     "react-pdf": "9.2.1",
     "react-range": "1.8.14",
     "react-resize-detector": "8.0.3",
-    "react-router-dom": "6.3.0",
+    "react-router": "^7.9.4",
     "react-select": "5.9.0",
     "react-share": "5.1.1",
     "react-string-replace": "1.1.1",


### PR DESCRIPTION
Notes:

- React-router `<Navigate/>` component behaviour changed between v6 and v7. I created a `<RelativeNavigate/>` wrapper component instead to use in route.tsx files to properly handle our intended behaviour.
- `<HistoryRouter history={createBrowserHistory}>` --> Had to use createBrowserHistory instead of utils/browserHistory
- `utils/cl-router/Link.tsx` Added helper to properly separate pathname and search params
- `front/app/utils/cl-router/history.ts` - Added some missing methods for v7.
- Rest of changes are imports changes (react-router-dom to react-router).