### PR TITLE
Screening email bug

### DIFF
--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/your_input_in_screening.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/your_input_in_screening.rb
@@ -64,7 +64,7 @@ module EmailCampaigns
     def activity_context(activity)
       return nil unless activity.item.is_a?(::Idea)
 
-      activity.item.idea && TimelineService.new.current_phase(activity.item.idea.project)
+      TimelineService.new.current_phase(activity.item.project)
     end
 
     def self.supported_context_class

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/your_idea_in_screening_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/your_idea_in_screening_spec.rb
@@ -46,17 +46,37 @@ RSpec.describe EmailCampaigns::Campaigns::YourInputInScreening do
   end
 
   describe 'send_on_activity' do
-    it 'delivers context campaigns' do
-      phase = create(:proposals_phase)
-      campaign = create(:your_input_in_screening_campaign, context: phase)
+    let(:context) { create(:proposals_phase) }
+    let(:phase) { context }
+    let!(:global_campaign) { create(:your_input_in_screening_campaign) }
+    let!(:context_campaign) { create(:your_input_in_screening_campaign, context:) }
+    let(:activity) do
       proposal = create(:proposal, idea_status: create(:proposal_status_prescreening), publication_status: 'submitted', project: phase.project, creation_phase: phase, phases: [phase])
-      activity = create(:activity, item: proposal, action: 'submitted')
+      create(:activity, item: proposal, action: 'submitted')
+    end
 
+    describe do
+      let(:context) { create(:proposals_phase) }
+
+      it 'delivers global campaigns' do
+        expect do
+          EmailCampaigns::DeliveryService.new.send_on_activity(activity)
+        end.to have_enqueued_job(ActionMailer::MailDeliveryJob)
+          .with(
+            global_campaign.mailer_class.to_s,
+            'campaign_mail',
+            'deliver_now',
+            anything
+          )
+      end
+    end
+
+    it 'delivers context campaigns' do
       expect do
         EmailCampaigns::DeliveryService.new.send_on_activity(activity)
       end.to have_enqueued_job(ActionMailer::MailDeliveryJob)
         .with(
-          campaign.mailer_class.to_s,
+          context_campaign.mailer_class.to_s,
           'campaign_mail',
           'deliver_now',
           anything

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/your_idea_in_screening_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/your_idea_in_screening_spec.rb
@@ -44,4 +44,23 @@ RSpec.describe EmailCampaigns::Campaigns::YourInputInScreening do
       expect(campaign.run_filter_hooks(activity: activity)).to be_falsy
     end
   end
+
+  describe 'send_on_activity' do
+    it 'delivers context campaigns' do
+      phase = create(:proposals_phase)
+      campaign = create(:your_input_in_screening_campaign, context: phase)
+      proposal = create(:proposal, idea_status: create(:proposal_status_prescreening), publication_status: 'submitted', project: phase.project, creation_phase: phase, phases: [phase])
+      activity = create(:activity, item: proposal, action: 'submitted')
+
+      expect do
+        EmailCampaigns::DeliveryService.new.send_on_activity(activity)
+      end.to have_enqueued_job(ActionMailer::MailDeliveryJob)
+        .with(
+          campaign.mailer_class.to_s,
+          'campaign_mail',
+          'deliver_now',
+          anything
+        )
+    end
+  end
 end

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/your_idea_in_screening_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/your_idea_in_screening_spec.rb
@@ -61,7 +61,8 @@ RSpec.describe EmailCampaigns::Campaigns::YourInputInScreening do
       it 'delivers global campaigns' do
         expect do
           EmailCampaigns::DeliveryService.new.send_on_activity(activity)
-        end.to have_enqueued_job(ActionMailer::MailDeliveryJob)
+        end.to have_enqueued_job(ActionMailer::MailDeliveryJob).exactly(:once)
+          .and have_enqueued_job(ActionMailer::MailDeliveryJob)
           .with(
             global_campaign.mailer_class.to_s,
             'campaign_mail',
@@ -74,7 +75,8 @@ RSpec.describe EmailCampaigns::Campaigns::YourInputInScreening do
     it 'delivers context campaigns' do
       expect do
         EmailCampaigns::DeliveryService.new.send_on_activity(activity)
-      end.to have_enqueued_job(ActionMailer::MailDeliveryJob)
+      end.to have_enqueued_job(ActionMailer::MailDeliveryJob).exactly(:once)
+        .and have_enqueued_job(ActionMailer::MailDeliveryJob)
         .with(
           context_campaign.mailer_class.to_s,
           'campaign_mail',


### PR DESCRIPTION
I would say we are lacking some test coverage around the email delivery pipeline (for example, the filters), which allowed this bug to slip through. We do have the "doesn't raise errors while processing all types of campaigns" in the delivery service spec, but it doesn't really test all filters as most campaigns won't match the activity or get stopped by the first filters.

So I would propose to add 2 extra tests to the campaign model specs, that should deliver the email and thereby go through all the filters: one for global campaigns and one for contextual campaigns.

https://sentry.hq.citizenlab.co/share/issue/79de6f64ea84481092f4c72626b2606a/

# Changelog
### Fixed
- Bug with your proposal in screening campaign emails for customized phase contexts not arriving.
