### PR TITLE
Remove incorrect type in useRelevantToHeatmapInputCustomFields

### DIFF
--- a/front/app/containers/Admin/projects/project/analysis/hooks/useRelevantToHeatmapInputCustomFields.ts
+++ b/front/app/containers/Admin/projects/project/analysis/hooks/useRelevantToHeatmapInputCustomFields.ts
@@ -13,7 +13,6 @@ const useRelevantToHeatmapInputCustomFields = ({
     'multiselect',
     'number',
     'linear_scale',
-    'ranking',
     'rating',
     'multiselect_image',
     'sentiment_linear_scale',


### PR DESCRIPTION
Koen highlighted that ranking is actually not a supported type here ([thread](https://go-vocal.slack.com/archives/C06CJ4D3B0R/p1760711898301539?thread_ts=1760702277.563579&cid=C06CJ4D3B0R)).

So just removing it, but @IvaKop I wanted to double-check that removing it shouldn't have an impact anywhere else?
