### PR TITLE
[No-ticket] Whitelist yopmail.com as FC use for test user creds

### DIFF
--- a/back/lib/email_domain_blacklist.rb
+++ b/back/lib/email_domain_blacklist.rb
@@ -7,10 +7,15 @@
 # https://github.com/disposable-email-domains/disposable-email-domains/blob/main/disposable_email_blocklist.conf
 
 module EmailDomainBlacklist
+  # yopmail.com is allowed, because FC uses it for test users, despite being a common spam domain.
+  WHITELISTED_DOMAINS = %w[yopmail.com].freeze
+
+
   def self.load
     domains = []
     domains += Rails.root.join('config/our_domain_blacklist.txt').readlines.map { |x| x.strip.downcase }
     domains += Rails.root.join('config/common_spam_domains.txt').readlines.map { |x| x.strip.downcase }
+    domains -= WHITELISTED_DOMAINS
     domains.uniq.freeze
   end
 end

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -229,6 +229,15 @@ RSpec.describe User do
       expect(user).to be_valid
     end
 
+    it 'is valid if domain is on our blacklist but also on our whitelist' do
+      common_spam_domains = Rails.root.join('config/common_spam_domains.txt').readlines.map { |x| x.strip.downcase }
+      expect(common_spam_domains).to include('yopmail.com')
+      expect(EmailDomainBlacklist::WHITELISTED_DOMAINS).to include('yopmail.com')
+
+      user = build(:user, email: 'someone@yopmail.com')
+      expect(user).to be_valid
+    end
+
     it 'is required when a unique code is not present' do
       u1 = build(:user, email: nil)
       expect(u1).to be_invalid
@@ -264,6 +273,15 @@ RSpec.describe User do
       user.update_column(:new_email, 'blocked@039b1ee.netsolhost.com') # bypasses validations
 
       user.first_name = 'UpdatedName'
+      expect(user).to be_valid
+    end
+
+    it 'is valid if domain is on our blacklist but also on our whitelist' do
+      common_spam_domains = Rails.root.join('config/common_spam_domains.txt').readlines.map { |x| x.strip.downcase }
+      expect(common_spam_domains).to include('yopmail.com')
+      expect(EmailDomainBlacklist::WHITELISTED_DOMAINS).to include('yopmail.com')
+
+      user = build(:user, new_email: 'someone@yopmail.com')
       expect(user).to be_valid
     end
 


### PR DESCRIPTION
# Changelog
## Technical
- [No-ticket] Whitelist yopmail.com, as FranceConnect use it for test user creds
