### PR TITLE
TAN-5659 Add user page navigation history to survey

### DIFF
--- a/front/app/components/CustomFieldsForm/SurveyForm/SurveyPage.tsx
+++ b/front/app/components/CustomFieldsForm/SurveyForm/SurveyPage.tsx
@@ -30,7 +30,7 @@ import { FormValues } from '../Page/types';
 import usePageForm from '../Page/usePageForm';
 import { getFormCompletionPercentage, Pages } from '../util';
 
-import { determineNextPageNumber, determinePreviousPage } from './logic';
+import { determineNextPageNumber, determinePreviousPageNumber } from './logic';
 
 const StyledForm = styled.form`
   height: 100%;
@@ -105,7 +105,7 @@ const SurveyPage = ({
       localize,
     });
 
-  const previousPageNumber = determinePreviousPage({
+  const previousPageNumber = determinePreviousPageNumber({
     userNavigationHistory,
     currentPageIndex,
   });

--- a/front/app/components/CustomFieldsForm/SurveyForm/SurveyPage.tsx
+++ b/front/app/components/CustomFieldsForm/SurveyForm/SurveyPage.tsx
@@ -30,10 +30,7 @@ import { FormValues } from '../Page/types';
 import usePageForm from '../Page/usePageForm';
 import { getFormCompletionPercentage, Pages } from '../util';
 
-import {
-  determineNextPageNumber,
-  determinePreviousPageNumberWithHistory,
-} from './logic';
+import { determineNextPageNumber, determinePreviousPage } from './logic';
 
 const StyledForm = styled.form`
   height: 100%;
@@ -108,12 +105,9 @@ const SurveyPage = ({
       localize,
     });
 
-  const previousPageNumber = determinePreviousPageNumberWithHistory({
+  const previousPageNumber = determinePreviousPage({
     userNavigationHistory,
     currentPageIndex,
-    pages,
-    currentPage: page,
-    formData: methods.watch(),
   });
 
   const nextPageNumber = determineNextPageNumber({

--- a/front/app/components/CustomFieldsForm/SurveyForm/SurveyPage.tsx
+++ b/front/app/components/CustomFieldsForm/SurveyForm/SurveyPage.tsx
@@ -30,7 +30,10 @@ import { FormValues } from '../Page/types';
 import usePageForm from '../Page/usePageForm';
 import { getFormCompletionPercentage, Pages } from '../util';
 
-import { determineNextPageNumber, determinePreviousPageNumber } from './logic';
+import {
+  determineNextPageNumber,
+  determinePreviousPageNumberWithHistory,
+} from './logic';
 
 const StyledForm = styled.form`
   height: 100%;
@@ -42,6 +45,8 @@ type SurveyPage = {
   pageQuestions: IFlatCustomField[];
   currentPageIndex: number;
   setCurrentPageIndex: React.Dispatch<React.SetStateAction<number>>;
+  userNavigationHistory: number[];
+  setUserNavigationHistory: React.Dispatch<React.SetStateAction<number[]>>;
   lastPageIndex: number;
   participationMethod?: ParticipationMethod;
   ideaId?: string;
@@ -68,6 +73,8 @@ const SurveyPage = ({
   onSubmit,
   currentPageIndex,
   setCurrentPageIndex,
+  userNavigationHistory,
+  setUserNavigationHistory,
   phase,
   defaultValues,
 }: SurveyPage) => {
@@ -101,7 +108,9 @@ const SurveyPage = ({
       localize,
     });
 
-  const previousPageNumber = determinePreviousPageNumber({
+  const previousPageNumber = determinePreviousPageNumberWithHistory({
+    userNavigationHistory,
+    currentPageIndex,
     pages,
     currentPage: page,
     formData: methods.watch(),
@@ -130,6 +139,8 @@ const SurveyPage = ({
       });
       // Go to the next page
       if (currentPageIndex < lastPageIndex) {
+        // Add the next page to navigation history
+        setUserNavigationHistory((history) => [...history, nextPageNumber]);
         setCurrentPageIndex(nextPageNumber);
       }
     } catch (error) {
@@ -161,6 +172,8 @@ const SurveyPage = ({
 
   const handlePrevious = () => {
     pageRef.current?.scrollTo(0, 0);
+    // Remove the current page from navigation history when going back
+    setUserNavigationHistory((history) => history.slice(0, -1));
     setCurrentPageIndex(previousPageNumber);
   };
 

--- a/front/app/components/CustomFieldsForm/SurveyForm/index.tsx
+++ b/front/app/components/CustomFieldsForm/SurveyForm/index.tsx
@@ -33,6 +33,11 @@ const SurveyForm = ({
   participationMethod?: ParticipationMethod;
 }) => {
   const [currentPageIndex, setCurrentPageIndex] = useState(0);
+  // Track the actual path the user has taken through the survey
+  // This helps with proper go-back navigation when users can reach the same page through multiple paths
+  const [userNavigationHistory, setUserNavigationHistory] = useState<number[]>([
+    0,
+  ]);
 
   const { data: authUser } = useAuthUser();
   const { data: project } = useProjectById(projectId);
@@ -122,6 +127,8 @@ const SurveyForm = ({
           currentPageIndex={currentPageIndex}
           lastPageIndex={lastPageIndex}
           setCurrentPageIndex={setCurrentPageIndex}
+          userNavigationHistory={userNavigationHistory}
+          setUserNavigationHistory={setUserNavigationHistory}
           participationMethod={participationMethod}
           projectId={projectId}
           onSubmit={onSubmit}

--- a/front/app/components/CustomFieldsForm/SurveyForm/logic.test.ts
+++ b/front/app/components/CustomFieldsForm/SurveyForm/logic.test.ts
@@ -1,10 +1,6 @@
 import { Pages } from '../util';
 
-import {
-  determineNextPageNumber,
-  determinePreviousPageNumber,
-  determinePreviousPageNumberWithHistory,
-} from './logic';
+import { determineNextPageNumber, determinePreviousPage } from './logic';
 
 const pages: Pages = [
   {
@@ -135,12 +131,6 @@ describe('Survey form logic', () => {
       currentPage: pages[0].page,
     });
     expect(nextPageIndex).toBe(2);
-
-    const previousPageIndex = determinePreviousPageNumber({
-      pages,
-      currentPage: pages[2].page,
-    });
-    expect(previousPageIndex).toBe(0);
   });
 
   it('should determine previous and next page number based on select question logic', () => {
@@ -200,13 +190,6 @@ describe('Survey form logic', () => {
     });
     expect(nextPageIndex).toBe(1);
 
-    const previousPageIndex = determinePreviousPageNumber({
-      pages,
-      currentPage: pages[1].page,
-    });
-
-    expect(previousPageIndex).toBe(0);
-
     const nextPageIndex2 = determineNextPageNumber({
       pages,
       currentPage: pages[0].page,
@@ -215,12 +198,6 @@ describe('Survey form logic', () => {
       },
     });
     expect(nextPageIndex2).toBe(2);
-
-    const previousPageIndex2 = determinePreviousPageNumber({
-      pages,
-      currentPage: pages[2].page,
-    });
-    expect(previousPageIndex2).toBe(0);
 
     const nextPageIndex3 = determineNextPageNumber({
       pages,
@@ -231,23 +208,12 @@ describe('Survey form logic', () => {
     });
     expect(nextPageIndex3).toBe(3);
 
-    const previousPageIndex3 = determinePreviousPageNumber({
-      pages,
-      currentPage: pages[3].page,
-    });
-    expect(previousPageIndex3).toBe(0);
     const nextPageIndex4 = determineNextPageNumber({
       pages,
       currentPage: pages[0].page,
       formData: {},
     });
     expect(nextPageIndex4).toBe(4);
-
-    const previousPageIndex4 = determinePreviousPageNumber({
-      pages,
-      currentPage: pages[4].page,
-    });
-    expect(previousPageIndex4).toBe(0);
   });
 
   it('should determine previous and next page number based on multiselect question logic', () => {
@@ -306,11 +272,7 @@ describe('Survey form logic', () => {
       },
     });
     expect(nextPageIndex).toBe(1);
-    const previousPageIndex = determinePreviousPageNumber({
-      pages,
-      currentPage: pages[1].page,
-    });
-    expect(previousPageIndex).toBe(0);
+
     const nextPageIndex2 = determineNextPageNumber({
       pages,
       currentPage: pages[0].page,
@@ -319,11 +281,7 @@ describe('Survey form logic', () => {
       },
     });
     expect(nextPageIndex2).toBe(2);
-    const previousPageIndex2 = determinePreviousPageNumber({
-      pages,
-      currentPage: pages[2].page,
-    });
-    expect(previousPageIndex2).toBe(0);
+
     const nextPageIndex3 = determineNextPageNumber({
       pages,
       currentPage: pages[0].page,
@@ -332,22 +290,13 @@ describe('Survey form logic', () => {
       },
     });
     expect(nextPageIndex3).toBe(3);
-    const previousPageIndex3 = determinePreviousPageNumber({
-      pages,
-      currentPage: pages[3].page,
-    });
-    expect(previousPageIndex3).toBe(0);
+
     const nextPageIndex4 = determineNextPageNumber({
       pages,
       currentPage: pages[0].page,
       formData: {},
     });
     expect(nextPageIndex4).toBe(4);
-    const previousPageIndex4 = determinePreviousPageNumber({
-      pages,
-      currentPage: pages[4].page,
-    });
-    expect(previousPageIndex4).toBe(0);
   });
 
   it('determies previous and next page number based on linear scale question logic', () => {
@@ -390,11 +339,7 @@ describe('Survey form logic', () => {
       },
     });
     expect(nextPageIndex).toBe(1);
-    const previousPageIndex = determinePreviousPageNumber({
-      pages,
-      currentPage: pages[1].page,
-    });
-    expect(previousPageIndex).toBe(0);
+
     const nextPageIndex2 = determineNextPageNumber({
       pages,
       currentPage: pages[0].page,
@@ -403,11 +348,7 @@ describe('Survey form logic', () => {
       },
     });
     expect(nextPageIndex2).toBe(2);
-    const previousPageIndex2 = determinePreviousPageNumber({
-      pages,
-      currentPage: pages[2].page,
-    });
-    expect(previousPageIndex2).toBe(0);
+
     const nextPageIndex3 = determineNextPageNumber({
       pages,
       currentPage: pages[0].page,
@@ -417,22 +358,13 @@ describe('Survey form logic', () => {
     });
 
     expect(nextPageIndex3).toBe(3);
-    const previousPageIndex3 = determinePreviousPageNumber({
-      pages,
-      currentPage: pages[3].page,
-    });
-    expect(previousPageIndex3).toBe(0);
+
     const nextPageIndex4 = determineNextPageNumber({
       pages,
       currentPage: pages[0].page,
       formData: {},
     });
     expect(nextPageIndex4).toBe(4);
-    const previousPageIndex4 = determinePreviousPageNumber({
-      pages,
-      currentPage: pages[4].page,
-    });
-    expect(previousPageIndex4).toBe(0);
   });
 
   it('determies previous and next page number based on rating question logic', () => {
@@ -475,11 +407,7 @@ describe('Survey form logic', () => {
       },
     });
     expect(nextPageIndex).toBe(1);
-    const previousPageIndex = determinePreviousPageNumber({
-      pages,
-      currentPage: pages[1].page,
-    });
-    expect(previousPageIndex).toBe(0);
+
     const nextPageIndex2 = determineNextPageNumber({
       pages,
       currentPage: pages[0].page,
@@ -488,11 +416,7 @@ describe('Survey form logic', () => {
       },
     });
     expect(nextPageIndex2).toBe(2);
-    const previousPageIndex2 = determinePreviousPageNumber({
-      pages,
-      currentPage: pages[2].page,
-    });
-    expect(previousPageIndex2).toBe(0);
+
     const nextPageIndex3 = determineNextPageNumber({
       pages,
       currentPage: pages[0].page,
@@ -502,22 +426,13 @@ describe('Survey form logic', () => {
     });
 
     expect(nextPageIndex3).toBe(3);
-    const previousPageIndex3 = determinePreviousPageNumber({
-      pages,
-      currentPage: pages[3].page,
-    });
-    expect(previousPageIndex3).toBe(0);
+
     const nextPageIndex4 = determineNextPageNumber({
       pages,
       currentPage: pages[0].page,
       formData: {},
     });
     expect(nextPageIndex4).toBe(4);
-    const previousPageIndex4 = determinePreviousPageNumber({
-      pages,
-      currentPage: pages[4].page,
-    });
-    expect(previousPageIndex4).toBe(0);
   });
 
   describe('Navigation history-based previous page determination', () => {
@@ -526,11 +441,9 @@ describe('Survey form logic', () => {
       const userNavigationHistory = [0, 2, 1];
       const currentPageIndex = 1; // Currently on page 1
 
-      const previousPageIndex = determinePreviousPageNumberWithHistory({
+      const previousPageIndex = determinePreviousPage({
         userNavigationHistory,
         currentPageIndex,
-        pages,
-        currentPage: pages[1].page,
       });
 
       // Should return page 2 (the previous page in history), not page 0 (sequential previous)
@@ -541,11 +454,9 @@ describe('Survey form logic', () => {
       const userNavigationHistory = [0, 2]; // History doesn't include current page
       const currentPageIndex = 1;
 
-      const previousPageIndex = determinePreviousPageNumberWithHistory({
+      const previousPageIndex = determinePreviousPage({
         userNavigationHistory,
         currentPageIndex,
-        pages,
-        currentPage: pages[1].page,
       });
 
       // Should fallback to original logic
@@ -556,11 +467,9 @@ describe('Survey form logic', () => {
       const userNavigationHistory = [1]; // Only current page in history
       const currentPageIndex = 1;
 
-      const previousPageIndex = determinePreviousPageNumberWithHistory({
+      const previousPageIndex = determinePreviousPage({
         userNavigationHistory,
         currentPageIndex,
-        pages,
-        currentPage: pages[1].page,
       });
 
       // Should fallback to original logic
@@ -572,11 +481,9 @@ describe('Survey form logic', () => {
       const userNavigationHistory = [0, 3, 1, 2, 4];
       const currentPageIndex = 4;
 
-      const previousPageIndex = determinePreviousPageNumberWithHistory({
+      const previousPageIndex = determinePreviousPage({
         userNavigationHistory,
         currentPageIndex,
-        pages,
-        currentPage: pages[4].page,
       });
 
       // Should return page 2 (the actual previous page in user's path)
@@ -588,11 +495,9 @@ describe('Survey form logic', () => {
       const userNavigationHistory = [0, 1, 2, 1];
       const currentPageIndex = 1;
 
-      const previousPageIndex = determinePreviousPageNumberWithHistory({
+      const previousPageIndex = determinePreviousPage({
         userNavigationHistory,
         currentPageIndex,
-        pages,
-        currentPage: pages[1].page,
       });
 
       // Should return page 2 (the most recent previous page in history)

--- a/front/app/components/CustomFieldsForm/SurveyForm/logic.test.ts
+++ b/front/app/components/CustomFieldsForm/SurveyForm/logic.test.ts
@@ -1,6 +1,6 @@
 import { Pages } from '../util';
 
-import { determineNextPageNumber, determinePreviousPage } from './logic';
+import { determineNextPageNumber, determinePreviousPageNumber } from './logic';
 
 const pages: Pages = [
   {
@@ -441,7 +441,7 @@ describe('Survey form logic', () => {
       const userNavigationHistory = [0, 2, 1];
       const currentPageIndex = 1; // Currently on page 1
 
-      const previousPageIndex = determinePreviousPage({
+      const previousPageIndex = determinePreviousPageNumber({
         userNavigationHistory,
         currentPageIndex,
       });
@@ -454,7 +454,7 @@ describe('Survey form logic', () => {
       const userNavigationHistory = [0, 2]; // History doesn't include current page
       const currentPageIndex = 1;
 
-      const previousPageIndex = determinePreviousPage({
+      const previousPageIndex = determinePreviousPageNumber({
         userNavigationHistory,
         currentPageIndex,
       });
@@ -467,7 +467,7 @@ describe('Survey form logic', () => {
       const userNavigationHistory = [1]; // Only current page in history
       const currentPageIndex = 1;
 
-      const previousPageIndex = determinePreviousPage({
+      const previousPageIndex = determinePreviousPageNumber({
         userNavigationHistory,
         currentPageIndex,
       });
@@ -481,7 +481,7 @@ describe('Survey form logic', () => {
       const userNavigationHistory = [0, 3, 1, 2, 4];
       const currentPageIndex = 4;
 
-      const previousPageIndex = determinePreviousPage({
+      const previousPageIndex = determinePreviousPageNumber({
         userNavigationHistory,
         currentPageIndex,
       });
@@ -495,7 +495,7 @@ describe('Survey form logic', () => {
       const userNavigationHistory = [0, 1, 2, 1];
       const currentPageIndex = 1;
 
-      const previousPageIndex = determinePreviousPage({
+      const previousPageIndex = determinePreviousPageNumber({
         userNavigationHistory,
         currentPageIndex,
       });

--- a/front/app/components/CustomFieldsForm/SurveyForm/logic.ts
+++ b/front/app/components/CustomFieldsForm/SurveyForm/logic.ts
@@ -146,75 +146,14 @@ export const determineNextPageNumber = ({
   return nextPageIndex;
 };
 
-export const determinePreviousPageNumber = ({
-  pages,
-  currentPage,
-  formData,
-}: {
-  pages: Pages;
-  currentPage: IFlatCustomField;
-  formData?: Record<string, any>;
-}) => {
-  const currentPageIndex = findPageIndex(pages, currentPage.id);
-  let previousPageIndex = currentPageIndex - 1;
-
-  const questionsWithLogic = pages.map((page) =>
-    page.pageQuestions.filter((question) => question.logic.rules?.length)
-  );
-
-  const questionsWithLogicReferringToCurrentPage = questionsWithLogic
-    .flat()
-    .filter((question) =>
-      question.logic.rules?.some((rule) => rule.goto_page_id === currentPage.id)
-    );
-
-  if (questionsWithLogicReferringToCurrentPage.length > 0) {
-    questionsWithLogicReferringToCurrentPage.forEach((question) => {
-      const rules = question.logic.rules;
-      if (rules && rules.length > 0) {
-        const rule = rules.find((rule) =>
-          isRuleConditionMet(question, rule, formData)
-        );
-
-        if (rule) {
-          const previousPage = pages.find((page) =>
-            page.pageQuestions.some(
-              (pageQuestion) => pageQuestion.id === question.id
-            )
-          );
-
-          if (previousPage) {
-            previousPageIndex = findPageIndex(pages, previousPage.page.id);
-          }
-        }
-      }
-    });
-  } else {
-    const previousPage = pages.find(
-      (page) => currentPage.id === page.page.logic.next_page_id
-    );
-    if (previousPage) {
-      previousPageIndex = findPageIndex(pages, previousPage.page.id);
-    }
-  }
-
-  return previousPageIndex;
-};
-
-export const determinePreviousPageNumberWithHistory = ({
+export const determinePreviousPage = ({
   userNavigationHistory,
   currentPageIndex,
-  pages,
-  currentPage,
-  formData,
 }: {
   userNavigationHistory: number[];
   currentPageIndex: number;
-  pages: Pages;
-  currentPage: IFlatCustomField;
-  formData?: Record<string, any>;
 }) => {
-  // If we have navigation history and can go back in history, use that
+  // Rely solely on navigation history
   if (userNavigationHistory.length > 1) {
     // Find the current page in the history
     const currentHistoryIndex =
@@ -226,10 +165,6 @@ export const determinePreviousPageNumberWithHistory = ({
     }
   }
 
-  // Fallback to the existing logic-based approach
-  return determinePreviousPageNumber({
-    pages,
-    currentPage,
-    formData,
-  });
+  // If no history is available, return the sequential previous page
+  return Math.max(0, currentPageIndex - 1);
 };

--- a/front/app/components/CustomFieldsForm/SurveyForm/logic.ts
+++ b/front/app/components/CustomFieldsForm/SurveyForm/logic.ts
@@ -146,7 +146,7 @@ export const determineNextPageNumber = ({
   return nextPageIndex;
 };
 
-export const determinePreviousPage = ({
+export const determinePreviousPageNumber = ({
   userNavigationHistory,
   currentPageIndex,
 }: {

--- a/front/app/components/CustomFieldsForm/SurveyForm/logic.ts
+++ b/front/app/components/CustomFieldsForm/SurveyForm/logic.ts
@@ -200,3 +200,36 @@ export const determinePreviousPageNumber = ({
 
   return previousPageIndex;
 };
+
+export const determinePreviousPageNumberWithHistory = ({
+  userNavigationHistory,
+  currentPageIndex,
+  pages,
+  currentPage,
+  formData,
+}: {
+  userNavigationHistory: number[];
+  currentPageIndex: number;
+  pages: Pages;
+  currentPage: IFlatCustomField;
+  formData?: Record<string, any>;
+}) => {
+  // If we have navigation history and can go back in history, use that
+  if (userNavigationHistory.length > 1) {
+    // Find the current page in the history
+    const currentHistoryIndex =
+      userNavigationHistory.lastIndexOf(currentPageIndex);
+
+    // If we found the current page and there's a previous page in history
+    if (currentHistoryIndex > 0) {
+      return userNavigationHistory[currentHistoryIndex - 1];
+    }
+  }
+
+  // Fallback to the existing logic-based approach
+  return determinePreviousPageNumber({
+    pages,
+    currentPage,
+    formData,
+  });
+};


### PR DESCRIPTION
# Changelog
## Fixed
- Clicking "Go back" is a survey with logic now takes the user back to the correct page in all cases