### PR TITLE
[TAN-5431] Improve form field colour accessibility

### DIFF
--- a/front/app/component-library/components/Checkbox/utils.test.tsx
+++ b/front/app/component-library/components/Checkbox/utils.test.tsx
@@ -30,7 +30,7 @@ describe('getColor', () => {
       checkedOrIndeterminate: false,
       element: 'hoverBackground',
     });
-    expect(borderColor).toEqual('#999999');
+    expect(borderColor).toEqual('#767676');
     expect(hoverBorderColor).toEqual('#000000');
     expect(backgroundColor).toEqual('#ffffff');
     expect(hoverBackgroundColor).toEqual('#ffffff');

--- a/front/app/component-library/components/Checkbox/utils.tsx
+++ b/front/app/component-library/components/Checkbox/utils.tsx
@@ -24,7 +24,7 @@ export const getColor = ({
   if (!checkedOrIndeterminate && !usePrimaryBorder) {
     switch (element) {
       case 'border':
-        return colors.grey600;
+        return colors.borderDark;
       case 'background':
         return colors.white;
       case 'hoverBorder':

--- a/front/app/component-library/components/Radio/index.tsx
+++ b/front/app/component-library/components/Radio/index.tsx
@@ -32,7 +32,9 @@ const CustomRadio = styled.div<{ borderColor: string | undefined }>`
   background: #fff;
   border-radius: 50%;
   border: ${({ borderColor }) =>
-    borderColor ? `solid 1px ${borderColor}` : `solid 1px ${colors.grey500}`};
+    borderColor
+      ? `solid 1px ${borderColor}`
+      : `solid 1px ${colors.borderDark}`};
   transition: all 120ms ease-out;
 
   ${isRtl`

--- a/front/app/components/CustomFieldsForm/Fields/ImageMultichoiceField/index.tsx
+++ b/front/app/components/CustomFieldsForm/Fields/ImageMultichoiceField/index.tsx
@@ -6,6 +6,7 @@ import {
   useBreakpoint,
   Text,
   Image,
+  colors,
 } from '@citizenlab/cl2-component-library';
 import { Controller, useFormContext } from 'react-hook-form';
 import styled, { useTheme } from 'styled-components';
@@ -27,10 +28,11 @@ import { extractOptions } from '../../util';
 
 import imageFile from './emptyImage.png';
 
-const HoverBox = styled(Box)<{ hoverColor: string }>`
+const HoverBox = styled(Box)<{ selected: boolean }>`
   cursor: pointer;
   &:hover {
-    background-color: ${({ hoverColor }) => hoverColor};
+    box-shadow: 0 0 0 1px
+      ${({ selected }) => (selected ? 'undefined' : colors.borderDark)};
   }
 `;
 
@@ -138,13 +140,12 @@ const ImageMultichoiceField = ({
                   <HoverBox
                     key={option.value}
                     borderRadius="3px"
-                    bgColor={theme.colors.tenantPrimaryLighten95}
                     border={
                       value?.includes(option.value)
                         ? `2px solid ${theme.colors.tenantPrimary}`
-                        : `1px solid ${theme.colors.tenantPrimary}`
+                        : `1px solid ${theme.colors.borderDark}`
                     }
-                    hoverColor={theme.colors.tenantPrimaryLighten75}
+                    selected={value?.includes(option.value)}
                   >
                     <Box
                       as="label"
@@ -171,14 +172,13 @@ const ImageMultichoiceField = ({
                       <Box display="flex" alignItems="flex-start" p="16px">
                         <Checkbox
                           checkedColor="tenantPrimary"
-                          usePrimaryBorder={true}
                           id={`${name}-checkbox-${index}`}
                           data-cy="e2e-image-multichoice-control-checkbox"
                           onChange={() => onChange(option)}
                           checked={value?.includes(option.value)}
                           mr="8px"
                         />
-                        <Text color="tenantPrimary" m="0">
+                        <Text color="textPrimary" m="0">
                           {option.label}
                         </Text>
                       </Box>

--- a/front/app/components/CustomFieldsForm/Fields/LinearScale/LinearScale.tsx
+++ b/front/app/components/CustomFieldsForm/Fields/LinearScale/LinearScale.tsx
@@ -18,7 +18,7 @@ import { getLinearScaleLabel } from './utils';
 interface Props {
   value?: number;
   question: IFlatCustomField;
-  onChange: (value: number) => void;
+  onChange: (value: number | undefined) => void;
 }
 
 const LinearScale = ({ value: data, question, onChange }: Props) => {

--- a/front/app/components/CustomFieldsForm/Fields/LinearScale/LinearScaleButton.tsx
+++ b/front/app/components/CustomFieldsForm/Fields/LinearScale/LinearScaleButton.tsx
@@ -81,13 +81,7 @@ const LinearScaleButton = ({
           data === visualIndex ? colors.white : theme.colors.textPrimary
         }
         width="100%"
-        onClick={() => {
-          if (data === visualIndex) {
-            onSelect(undefined); // Deselect if the same button is clicked
-          } else {
-            onSelect(visualIndex);
-          }
-        }}
+        onClick={() => onSelect(data === visualIndex ? undefined : visualIndex)}
       >
         {visualIndex}
       </StyledButton>

--- a/front/app/components/CustomFieldsForm/Fields/LinearScale/LinearScaleButton.tsx
+++ b/front/app/components/CustomFieldsForm/Fields/LinearScale/LinearScaleButton.tsx
@@ -6,7 +6,7 @@ import {
   colors,
   useBreakpoint,
 } from '@citizenlab/cl2-component-library';
-import { useTheme } from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 
 import { IFlatCustomField } from 'api/custom_fields/types';
 
@@ -15,8 +15,15 @@ interface Props {
   visualIndex: number;
   data?: number;
   maximum: number;
-  onSelect: (value: number) => void;
+  onSelect: (value: number | undefined) => void;
 }
+
+const StyledButton = styled(Button)<{ selected: boolean }>`
+  &:hover {
+    box-shadow: 0 0 0 1px
+      ${({ selected }) => (selected ? 'undefined' : colors.borderDark)};
+  }
+`;
 
 const LinearScaleButton = ({
   question,
@@ -44,34 +51,46 @@ const LinearScaleButton = ({
       minWidth={getButtonWidth()}
       padding="16px, 20px, 16px, 20px"
     >
-      <Button
+      <StyledButton
         py="12px"
         id={`linear-scale-option-${visualIndex}`}
+        selected={data === visualIndex}
         tabIndex={-1}
         aria-pressed={data === visualIndex}
-        borderColor={theme.colors.tenantPrimary}
-        borderHoverColor={theme.colors.tenantPrimary}
-        bgColor={
+        borderRadius="3px"
+        borderColor={
           data === visualIndex
             ? theme.colors.tenantPrimary
-            : theme.colors.tenantPrimaryLighten95
+            : theme.colors.borderDark
+        }
+        borderHoverColor={
+          data === visualIndex
+            ? theme.colors.tenantPrimary
+            : theme.colors.borderDark
+        }
+        bgColor={
+          data === visualIndex ? theme.colors.tenantPrimary : theme.colors.white
         }
         bgHoverColor={
-          data === visualIndex
-            ? theme.colors.tenantPrimary
-            : theme.colors.tenantPrimaryLighten75
+          data === visualIndex ? theme.colors.tenantPrimary : theme.colors.white
         }
         textHoverColor={
-          data === visualIndex ? colors.white : theme.colors.tenantPrimary
+          data === visualIndex ? colors.white : theme.colors.textPrimary
         }
         textColor={
-          data === visualIndex ? colors.white : theme.colors.tenantPrimary
+          data === visualIndex ? colors.white : theme.colors.textPrimary
         }
         width="100%"
-        onClick={() => onSelect(visualIndex)}
+        onClick={() => {
+          if (data === visualIndex) {
+            onSelect(undefined); // Deselect if the same button is clicked
+          } else {
+            onSelect(visualIndex);
+          }
+        }}
       >
         {visualIndex}
-      </Button>
+      </StyledButton>
     </Box>
   );
 };

--- a/front/app/components/CustomFieldsForm/Fields/MatrixField/Matrix.tsx
+++ b/front/app/components/CustomFieldsForm/Fields/MatrixField/Matrix.tsx
@@ -12,7 +12,7 @@ import {
   Thead,
   Tr,
 } from '@citizenlab/cl2-component-library';
-import { media, RGBAtoRGB } from 'component-library/utils/styleUtils';
+import { media } from 'component-library/utils/styleUtils';
 import styled, { useTheme } from 'styled-components';
 
 import { IFlatCustomField } from 'api/custom_fields/types';
@@ -27,8 +27,6 @@ import { useIntl } from 'utils/cl-intl';
 import { getLinearScaleLabel } from '../LinearScale/utils';
 
 const StickyTh = styled(Th)<{ hasLongContent: boolean }>`
-  background: ${(props) =>
-    RGBAtoRGB(props.theme.colors.tenantPrimaryLighten95, 0.05)};
   position: sticky;
   inset-inline-start: 0px;
   z-index: 1;
@@ -48,15 +46,20 @@ const StickyTh = styled(Th)<{ hasLongContent: boolean }>`
 `;
 
 const StyledTd = styled(Td)`
-  background: ${(props) =>
-    RGBAtoRGB(props.theme.colors.tenantPrimaryLighten95, 0.05)};
   // This min-width also ensures that the th elements have the same min-width.
   min-width: 84px;
 
   .circle {
     margin-right: 0px;
-    border: 1px solid ${(props) => props.theme.colors.tenantPrimary};
+    border: 1px solid ${(props) => props.theme.colors.borderDark};
   }
+  .circle :hover {
+    border-color: ${(props) => props.theme.colors.grey800};
+  }
+`;
+
+const StyledTr = styled(Tr)`
+  border-bottom: 1px solid ${(props) => props.theme.colors.borderDark};
 `;
 
 const LONG_LABEL_THRESHOLD = 10; // Threshold for long labels, used to apply specific styling
@@ -150,21 +153,29 @@ const Matrix = ({ value: data, question, onChange }: Props) => {
       <Box overflowX="auto" ref={tableDivRef} id="e2e-matrix-control">
         <Table
           width={'100%'}
-          style={{ borderCollapse: 'separate', borderSpacing: '0px 8px' }}
+          style={{ borderCollapse: 'collapse', borderSpacing: '0px 8px' }}
           aria-labelledby={`matrix-question-label-${id}`}
         >
           <Thead>
             <Tr>
-              <Th pt="0px" />
+              <Th
+                pt="0px"
+                borderBottom={`1px solid ${theme.colors.borderDark} !important`}
+              />
               {columnsFromSchema.map((column, index) => {
                 return (
-                  <Th key={index} scope="col" pt="0px">
+                  <Th
+                    key={index}
+                    scope="col"
+                    pt="0px"
+                    borderBottom={`1px solid ${theme.colors.borderDark} !important`}
+                  >
                     <Text
                       textAlign="center"
                       m="0px"
                       p="0px"
                       mx="auto"
-                      color="tenantPrimary"
+                      color="textPrimary"
                     >
                       {column}
                     </Text>
@@ -177,14 +188,14 @@ const Matrix = ({ value: data, question, onChange }: Props) => {
             {statements.map((statement, index) => {
               const statementLabel = localize(statement.title_multiloc);
               return (
-                <Tr key={index}>
+                <StyledTr key={index}>
                   <StickyTh
                     scope="row"
                     hasLongContent={
                       statementLabel.length > LONG_LABEL_THRESHOLD
                     }
                   >
-                    <Text m="4px" color="tenantPrimary">
+                    <Text m="4px" color="textPrimary">
                       {statementLabel}
                     </Text>
                   </StickyTh>
@@ -219,6 +230,7 @@ const Matrix = ({ value: data, question, onChange }: Props) => {
                             }
                             name={`radio-group-${statement.key}-${id}`}
                             id={`${id}-${index}-${columnIndex}-radio`}
+                            buttonColor={theme.colors.tenantPrimary}
                             onChange={(value) => {
                               onChange({
                                 ...data,
@@ -230,7 +242,7 @@ const Matrix = ({ value: data, question, onChange }: Props) => {
                       </StyledTd>
                     );
                   })}
-                </Tr>
+                </StyledTr>
               );
             })}
           </Tbody>
@@ -241,8 +253,9 @@ const Matrix = ({ value: data, question, onChange }: Props) => {
           <Button
             p="0px"
             buttonStyle="text"
-            textColor={theme.colors.tenantPrimary}
+            textColor={theme.colors.textPrimary}
             textDecoration="underline"
+            mt="4px"
             text={
               <>
                 <ScreenReaderOnly>

--- a/front/app/components/CustomFieldsForm/Fields/RankingField/Ranking.tsx
+++ b/front/app/components/CustomFieldsForm/Fields/RankingField/Ranking.tsx
@@ -96,7 +96,7 @@ const Ranking = ({ value: data, question, onChange }: Props) => {
           }}
         >
           <Drop id="droppable" type="rankOptions">
-            <Text m="0px" aria-hidden color="tenantPrimary">
+            <Text m="0px" aria-hidden color="textPrimary">
               {formatMessage(messages.rankingInstructions)}
             </Text>
             <Ul aria-labelledby={`ranking-question-label-${question.key}`}>
@@ -118,7 +118,7 @@ const Ranking = ({ value: data, question, onChange }: Props) => {
             <Button
               p="0px"
               buttonStyle="text"
-              textColor={theme.colors.tenantPrimary}
+              textColor={theme.colors.textPrimary}
               textDecoration="underline"
               text={formatMessage(messages.clearAll)}
               onClick={() => {

--- a/front/app/components/CustomFieldsForm/Fields/RankingField/RankingOption.tsx
+++ b/front/app/components/CustomFieldsForm/Fields/RankingField/RankingOption.tsx
@@ -24,13 +24,19 @@ const StyledSelect = styled(Select)`
 
   select {
     padding: 4px;
-    border: solid 1px ${(props) => props.theme.colors.tenantPrimary};
-    color: ${(props) => props.theme.colors.tenantPrimary};
+    border: solid 1px ${(props) => props.theme.colors.textPrimary};
+    color: ${(props) => props.theme.colors.textPrimary};
   }
 
   svg {
-    fill: ${(props) => props.theme.colors.tenantPrimary} !important;
+    fill: ${(props) => props.theme.colors.textPrimary} !important;
     width: 16px;
+  }
+`;
+
+const StyledBox = styled(Box)`
+  :hover {
+    box-shadow: 0 0 0 1px ${(props) => props.theme.colors.textPrimary};
   }
 `;
 
@@ -72,14 +78,13 @@ const RankingOption = ({
   return (
     <li aria-roledescription="sortable">
       <Drag index={index} useBorder={false} id={`ranking-item-${option.value}`}>
-        <Box
+        <StyledBox
           style={{ cursor: 'grab' }}
           mb="12px"
-          background={theme.colors.tenantPrimaryLighten95}
           borderRadius={theme.borderRadius}
-          border={`1px solid ${theme.colors.tenantPrimary}`}
+          border={`1px solid ${theme.colors.borderDark}`}
         >
-          <Box
+          <StyledBox
             padding="18px 20px 18px 20px"
             display="flex"
             justifyContent="space-between"
@@ -112,7 +117,7 @@ const RankingOption = ({
               <Text
                 maxWidth="80%"
                 my="auto"
-                color="tenantPrimary"
+                color="textPrimary"
                 p="0px"
                 m="0px"
                 aria-hidden
@@ -125,11 +130,11 @@ const RankingOption = ({
               <Icon
                 height="18px"
                 name="drag-handle"
-                fill={theme.colors.tenantPrimary}
+                fill={theme.colors.textPrimary}
               />
             </Box>
-          </Box>
-        </Box>
+          </StyledBox>
+        </StyledBox>
       </Drag>
     </li>
   );

--- a/front/app/components/CustomFieldsForm/Fields/RankingField/RankingOption.tsx
+++ b/front/app/components/CustomFieldsForm/Fields/RankingField/RankingOption.tsx
@@ -24,19 +24,19 @@ const StyledSelect = styled(Select)`
 
   select {
     padding: 4px;
-    border: solid 1px ${(props) => props.theme.colors.textPrimary};
+    border: solid 1px ${(props) => props.theme.colors.borderDark};
     color: ${(props) => props.theme.colors.textPrimary};
   }
 
   svg {
-    fill: ${(props) => props.theme.colors.textPrimary} !important;
+    fill: ${(props) => props.theme.colors.borderDark} !important;
     width: 16px;
   }
 `;
 
 const StyledBox = styled(Box)`
   :hover {
-    box-shadow: 0 0 0 1px ${(props) => props.theme.colors.textPrimary};
+    box-shadow: 0 0 0 1px ${(props) => props.theme.colors.borderDark};
   }
 `;
 

--- a/front/app/components/CustomFieldsForm/Fields/RatingField/Rating.tsx
+++ b/front/app/components/CustomFieldsForm/Fields/RatingField/Rating.tsx
@@ -6,7 +6,7 @@ import {
   Button,
   Icon,
 } from '@citizenlab/cl2-component-library';
-import { useTheme } from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 
 import { IFlatCustomField } from 'api/custom_fields/types';
 
@@ -17,6 +17,12 @@ interface Props {
   question: IFlatCustomField;
   onChange: (value: number) => void;
 }
+
+const StyledIcon = styled(Icon)`
+  :hover {
+    fill: ${(props) => props.theme.colors.grey800};
+  }
+`;
 
 const Rating = ({ value: data, question, onChange }: Props) => {
   const isSmallerThanPhone = useBreakpoint('phone');
@@ -115,14 +121,14 @@ const Rating = ({ value: data, question, onChange }: Props) => {
                     alignItems="center"
                     gap="4px"
                   >
-                    <Icon
+                    <StyledIcon
                       name={selectedIndex ? 'ratingFilled' : 'rating'}
                       height="40px"
                       width="40px"
                       fill={
                         selectedIndex
                           ? theme.colors.tenantPrimary
-                          : theme.colors.tenantPrimaryLighten75
+                          : theme.colors.borderDark
                       }
                     />
                     {visualIndex}

--- a/front/app/components/CustomFieldsForm/Fields/SentimentScaleField/TableHead.tsx
+++ b/front/app/components/CustomFieldsForm/Fields/SentimentScaleField/TableHead.tsx
@@ -17,18 +17,18 @@ import { getSentimentEmoji } from './utils';
 
 export const StyledImg = styled.img`
   padding: 8px;
-  border: 1px solid white;
+  border: 2px solid white;
   border-radius: 8px;
   width: 48px;
 
   &.isSelected {
-    border: 1px solid ${({ theme }) => theme.colors.tenantPrimary};
+    border: 2px solid ${({ theme }) => theme.colors.tenantPrimary};
     background-color: ${({ theme }) => theme.colors.tenantPrimaryLighten90};
   }
 
   &:not(.isSelected):hover {
     background-color: ${({ theme }) => theme.colors.grey100};
-    border: 1px solid ${({ theme }) => theme.colors.grey500};
+    border: 2px solid ${({ theme }) => theme.colors.borderDark};
   }
 `;
 

--- a/front/app/components/CustomFieldsForm/Fields/SingleSelectField.tsx
+++ b/front/app/components/CustomFieldsForm/Fields/SingleSelectField.tsx
@@ -20,11 +20,11 @@ import { useIntl } from 'utils/cl-intl';
 import messages from '../messages';
 import { extractOptions } from '../util';
 
-const StyledBox = styled(Box)`
+const StyledBox = styled(Box)<{ selected: boolean }>`
   cursor: pointer;
-  background-color: ${colors.grey100};
   &:hover {
-    background-color: ${colors.grey200};
+    box-shadow: 0 0 0 1px
+      ${({ selected }) => (selected ? 'undefined' : colors.borderDark)};
   }
 `;
 
@@ -75,13 +75,13 @@ const SingleSelectField = ({
               mb="12px"
               padding="20px 20px 8px 20px"
               border={
-                options.includes(option.value)
+                option.value === value
                   ? `2px solid ${theme.colors.tenantPrimary}`
-                  : `1px solid ${theme.colors.tenantPrimary}`
+                  : `1px solid ${theme.colors.borderDark}`
               }
-              background={theme.colors.tenantPrimaryLighten95}
               key={option.value}
               borderRadius="3px"
+              selected={option.value === value}
             >
               <Radio
                 name={question.key}
@@ -89,6 +89,7 @@ const SingleSelectField = ({
                 key={option.value}
                 value={option.value}
                 label={option.label}
+                buttonColor={theme.colors.tenantPrimary}
                 canDeselect
               />
             </StyledBox>

--- a/front/app/components/HookForm/CheckboxMultiSelect/index.tsx
+++ b/front/app/components/HookForm/CheckboxMultiSelect/index.tsx
@@ -22,11 +22,11 @@ interface Props extends Omit<SelectProps, 'onChange'> {
   title: string;
 }
 
-const StyledBox = styled(Box)`
+const StyledBox = styled(Box)<{ selected: boolean }>`
   cursor: pointer;
-  background-color: ${colors.grey100};
   &:hover {
-    background-color: ${colors.grey200};
+    box-shadow: 0 0 0 1px
+      ${({ selected }) => (selected ? 'undefined' : colors.borderDark)};
   }
 `;
 
@@ -69,11 +69,11 @@ const CheckboxMultiSelect = ({
                   border={
                     checkedOptions.includes(option.value)
                       ? `2px solid ${theme.colors.tenantPrimary}`
-                      : `1px solid ${theme.colors.tenantPrimary}`
+                      : `1px solid ${theme.colors.borderDark}`
                   }
-                  background={theme.colors.tenantPrimaryLighten95}
                   key={option.value}
                   borderRadius="3px"
+                  selected={checkedOptions.includes(option.value)}
                 >
                   <CheckboxWithLabel
                     size="20px"
@@ -85,7 +85,7 @@ const CheckboxMultiSelect = ({
                       </Text>
                     }
                     checked={checkedOptions.includes(option.value)}
-                    usePrimaryBorder={true}
+                    usePrimaryBorder={false}
                     onChange={() => {
                       if (checkedOptions.includes(option.value)) {
                         setValue(


### PR DESCRIPTION
# Changelog
## Changed
- [TAN-5431] Improve form field colour accessibility, specifically for platforms that are using very light branding colours ([before-1](https://github.com/user-attachments/assets/f1ea1fc1-7117-4d2c-99be-963735c93f2d)/[after-1](
https://github.com/user-attachments/assets/6551c50e-2d10-47aa-9348-b3e77763f05c) and [before-2](https://github.com/user-attachments/assets/5f01ded2-ed72-41af-a1d5-d9cd273790d6)/[after-2](https://github.com/user-attachments/assets/fe770cef-69d1-48b4-a003-f86e590cccbd)).
