### PR TITLE
[TAN-5710] Add new fields to public api survey responses

### DIFF
--- a/back/engines/commercial/public_api/app/controllers/public_api/v2/ideas_controller.rb
+++ b/back/engines/commercial/public_api/app/controllers/public_api/v2/ideas_controller.rb
@@ -10,11 +10,12 @@ module PublicApi
         **finder_params
       ).execute
 
-      list_items(ideas, V2::IdeaSerializer, includes: %i[idea_images project idea_status])
+      list_items(ideas, V2::IdeaSerializer, includes: %i[idea_images project idea_status creation_phase idea_files])
     end
 
     def show
-      show_item Idea.find(params[:id]), V2::IdeaSerializer
+      idea = Idea.includes(:idea_images, :project, :idea_status, :creation_phase, :idea_files).find(params[:id])
+      show_item idea, V2::IdeaSerializer
     end
 
     private

--- a/back/engines/commercial/public_api/app/serializers/public_api/v2/idea_serializer.rb
+++ b/back/engines/commercial/public_api/app/serializers/public_api/v2/idea_serializer.rb
@@ -73,8 +73,8 @@ class PublicApi::V2::IdeaSerializer < PublicApi::V2::BaseSerializer
   def file_attachments
     object.idea_files.map do |idea_file|
       {
-        name: idea_file.name,
-        url: idea_file.file.url
+        'name' => idea_file.name,
+        'url' => idea_file.file.url
       }
     end
   end

--- a/back/engines/commercial/public_api/app/serializers/public_api/v2/idea_serializer.rb
+++ b/back/engines/commercial/public_api/app/serializers/public_api/v2/idea_serializer.rb
@@ -30,7 +30,9 @@ class PublicApi::V2::IdeaSerializer < PublicApi::V2::BaseSerializer
     :href, # Not in spec
     :status, # idea_status in spec
     :custom_field_values, # Not nested in spec
-    :type
+    :type,
+    :survey_title,
+    :file_attachments
 
   def title
     multiloc_service.t(object.title_multiloc)
@@ -60,6 +62,21 @@ class PublicApi::V2::IdeaSerializer < PublicApi::V2::BaseSerializer
 
   def href
     Frontend::UrlService.new.model_to_url object
+  end
+
+  def survey_title
+    return nil unless object.creation_phase_id.present?
+    
+    multiloc_service.t(object.creation_phase&.native_survey_title_multiloc)
+  end
+
+  def file_attachments
+    object.idea_files.map do |idea_file|
+      {
+        name: idea_file.name,
+        url: idea_file.file.url
+      }
+    end
   end
 
   private


### PR DESCRIPTION
# Changelog
## Changed
- [TAN-5710] Add new fields to public api survey responses (file attachments, survey title).
