### PR TITLE
[TAN-5668] Allow capitalization and special characters in area terminology

### DIFF
--- a/front/app/components/admin/TerminologyConfig/index.tsx
+++ b/front/app/components/admin/TerminologyConfig/index.tsx
@@ -69,11 +69,11 @@ const TerminologyConfig = ({
   const toggleOpened = () => setOpened((opened) => !opened);
 
   const handleSingularChange = (changedTerm: Multiloc) => {
-    setSingular(mapValues(changedTerm, lowerCase));
+    setSingular(mapValues(changedTerm));
   };
 
   const handlePluralChange = (changedTerm: Multiloc) => {
-    setPlural(mapValues(changedTerm, lowerCase));
+    setPlural(mapValues(changedTerm));
   };
 
   const save = async () => {

--- a/front/app/components/admin/TerminologyConfig/index.tsx
+++ b/front/app/components/admin/TerminologyConfig/index.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 
-import { mapValues, lowerCase } from 'lodash-es';
 import { WrappedComponentProps, MessageDescriptor } from 'react-intl';
 import styled from 'styled-components';
 import { Multiloc } from 'typings';
@@ -69,11 +68,11 @@ const TerminologyConfig = ({
   const toggleOpened = () => setOpened((opened) => !opened);
 
   const handleSingularChange = (changedTerm: Multiloc) => {
-    setSingular(mapValues(changedTerm));
+    setSingular(changedTerm);
   };
 
   const handlePluralChange = (changedTerm: Multiloc) => {
-    setPlural(mapValues(changedTerm));
+    setPlural(changedTerm);
   };
 
   const save = async () => {


### PR DESCRIPTION
# Changelog
## Fixed
- We now allow the "terminology" setup for Area to use capital letters or specific letters
