### PR TITLE
Adjust comments color from 02 to 05

### DIFF
--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/ParticipationWidget/ParticipationCard/Chart.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/ParticipationWidget/ParticipationCard/Chart.tsx
@@ -34,7 +34,7 @@ const LEGEND_ITEMS = {
     message: messages.inputs,
   },
   comments: {
-    color: colors.categorical02,
+    color: colors.categorical05,
     message: messages.comments,
   },
   votes: {


### PR DESCRIPTION
# Changelog

[TAN-5395] - Adjust comment color in participation widget for better clarity 
<img width="762" height="374" alt="Screenshot 2025-10-29 at 14 00 49" src="https://github.com/user-attachments/assets/8740818d-09c1-4106-9905-60b596eada90" />
