### PR TITLE
[TAN-5605] Use X icon instead of Twitter for idea published mailer

### DIFF
--- a/back/engines/free/email_campaigns/app/views/email_campaigns/first_idea_published_mailer/campaign_mail.mjml
+++ b/back/engines/free/email_campaigns/app/views/email_campaigns/first_idea_published_mailer/campaign_mail.mjml
@@ -76,9 +76,9 @@
         </td>
         <td style="padding-left: 3px; padding-bottom:15px;">
           <img
-            alt="Twitter icon"
-            style="vertical-align: middle; width: 16px; height: 14px;"
-            src="https://cl2-seed-and-template-assets.s3.eu-central-1.amazonaws.com/images/icons/icon_twitter_logo_small.png">
+            alt="X icon"
+            style="vertical-align: middle; height: 14px;"
+            src="https://cl2-seed-and-template-assets.s3.eu-central-1.amazonaws.com/images/icons/icon_x_logo.png">
         </td>
       </tr>
 

--- a/back/engines/free/email_campaigns/app/views/email_campaigns/idea_published_mailer/campaign_mail.mjml
+++ b/back/engines/free/email_campaigns/app/views/email_campaigns/idea_published_mailer/campaign_mail.mjml
@@ -80,9 +80,9 @@
         </td>
         <td style="padding-left: 3px; padding-bottom:15px;">
           <img
-            alt="Twitter icon"
-            style="vertical-align: middle; width: 16px; height: 14px;"
-            src="https://cl2-seed-and-template-assets.s3.eu-central-1.amazonaws.com/images/icons/icon_twitter_logo_small.png">
+            alt="X icon"
+            style="vertical-align: middle; height: 14px;"
+            src="https://cl2-seed-and-template-assets.s3.eu-central-1.amazonaws.com/images/icons/icon_x_logo.png">
         </td>
       </tr>
 


### PR DESCRIPTION
# Changelog
## Fixed
- [TAN-5605] Use X icon instead of Twitter for idea published automatic email.