### PR TITLE
[TAN-5670] - fix long link in visitors table

### DIFF
--- a/front/app/components/admin/GraphCards/VisitorsTrafficSourcesCard/Table.tsx
+++ b/front/app/components/admin/GraphCards/VisitorsTrafficSourcesCard/Table.tsx
@@ -61,7 +61,7 @@ const TableComponent = ({ tableData, onOpenModal }: Props) => {
         <Tbody>
           {paginatedData.map((row, i) => (
             <Tr key={i}>
-              <Td background={colors.grey50} display="flex">
+              <Td background={colors.grey50}>
                 <Text color="primary" fontSize="s" wordBreak="break-word">
                   ({row.referrer_type}) {row.referrer}
                 </Text>

--- a/front/app/components/admin/GraphCards/VisitorsTrafficSourcesCard/Table.tsx
+++ b/front/app/components/admin/GraphCards/VisitorsTrafficSourcesCard/Table.tsx
@@ -10,6 +10,7 @@ import {
   Td,
   colors,
   stylingConsts,
+  Text,
 } from '@citizenlab/cl2-component-library';
 
 import Pagination from 'components/Pagination';
@@ -60,8 +61,10 @@ const TableComponent = ({ tableData, onOpenModal }: Props) => {
         <Tbody>
           {paginatedData.map((row, i) => (
             <Tr key={i}>
-              <Td background={colors.grey50}>
-                ({row.referrer_type}) {row.referrer}
+              <Td background={colors.grey50} display="flex">
+                <Text color="primary" fontSize="s" wordBreak="break-word">
+                  ({row.referrer_type}) {row.referrer}
+                </Text>
               </Td>
               <Td>{row.visits}</Td>
               <Td>{row.visitors}</Td>

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/VisitorsTrafficSourcesWidget/Table.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/VisitorsTrafficSourcesWidget/Table.tsx
@@ -48,7 +48,7 @@ const TableView = ({ tableData }: Props) => {
         <Tbody>
           {tableData.slice(0, 5).map((row, i) => (
             <Tr key={i}>
-              <Td background={colors.grey50} display="flex">
+              <Td background={colors.grey50}>
                 <Text color="primary" fontSize="s" wordBreak="break-word">
                   ({row.referrer_type}) {row.referrer}
                 </Text>

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/VisitorsTrafficSourcesWidget/Table.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/VisitorsTrafficSourcesWidget/Table.tsx
@@ -10,6 +10,7 @@ import {
   Td,
   colors,
   stylingConsts,
+  Text,
 } from '@citizenlab/cl2-component-library';
 
 import messages from 'components/admin/GraphCards/VisitorsTrafficSourcesCard/messages';
@@ -47,8 +48,10 @@ const TableView = ({ tableData }: Props) => {
         <Tbody>
           {tableData.slice(0, 5).map((row, i) => (
             <Tr key={i}>
-              <Td background={colors.grey50}>
-                ({row.referrer_type}) {row.referrer}
+              <Td background={colors.grey50} display="flex">
+                <Text color="primary" fontSize="s" wordBreak="break-word">
+                  ({row.referrer_type}) {row.referrer}
+                </Text>
               </Td>
               <Td>{row.visits}</Td>
               <Td>{row.visitors}</Td>


### PR DESCRIPTION
# Changelog
## Fixed
- [TAN-5670] Break long "Traffic sources" links in Visitors table (Widget & Dashboard)
