### PR TITLE
[TAN-5706] Always save email in lowercase, so we don't have case-sensitive email issues.

### DIFF
--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -154,6 +154,7 @@ class User < ApplicationRecord
 
   before_validation :sanitize_bio_multiloc, if: :bio_multiloc
   before_validation :complete_registration
+  before_validation :downcase_email, if: :email_or_new_email_changed?
 
   has_many :identities, dependent: :destroy
   has_many :spam_reports, dependent: :nullify
@@ -348,6 +349,11 @@ class User < ApplicationRecord
     )
     self.bio_multiloc = service.remove_multiloc_empty_trailing_tags(bio_multiloc)
     self.bio_multiloc = service.linkify_multiloc(bio_multiloc)
+  end
+
+  def downcase_email
+    self.email = email.downcase if email_changed? && email.present?
+    self.new_email = new_email.downcase if new_email_changed? && new_email.present?
   end
 
   def email_or_new_email_changed?

--- a/back/engines/commercial/admin_api/spec/acceptance/invites_spec.rb
+++ b/back/engines/commercial/admin_api/spec/acceptance/invites_spec.rb
@@ -48,7 +48,7 @@ resource 'Invite', admin_api: true do
         expect(json_response[:send_invite_email]).to eq send_invite_email
         expect(invite.invitee.first_name).to eq first_name
         expect(invite.invitee.last_name).to eq last_name
-        expect(invite.invitee.email).to eq email
+        expect(invite.invitee.email).to eq email.downcase
         expect(invite.invitee.locale).to eq locale
       end
     end

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -309,7 +309,7 @@ resource 'Users' do
           example 'Different cases of same email are treated as same user' do
             original_email = 'TeStUsEr@ExAmPlE.com'
             lowercased_email = 'testuser@example.com'
-            
+
             create(:user, email: original_email)
             expect(User.find_by_cimail(lowercased_email)).to be_present
             expect(User.find_by_cimail(original_email)).to be_present

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -294,7 +294,7 @@ resource 'Users' do
 
           example 'Accepts registration with different case and converts to lowercase' do
             User.delete_all # Clean state
-            
+
             user_params = {
               first_name: Faker::Name.first_name,
               last_name: Faker::Name.last_name,
@@ -310,7 +310,7 @@ resource 'Users' do
 
           example 'Different cases of same email are treated as same user' do
             User.delete_all # Clean state
-            
+
             original_email = 'TeStUsEr@ExAmPlE.com'
             lowercased_email = 'testuser@example.com'
 

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -280,16 +280,29 @@ resource 'Users' do
           end
         end
 
-        describe 'case insensitive email error' do
-          before do
-            create(:user, email: 'JeZuS@citizenlab.co')
+        describe 'case insensitive email handling' do
+          example 'Accepts registration with different case and converts to lowercase' do
+            user_params = {
+              first_name: Faker::Name.first_name,
+              last_name: Faker::Name.last_name,
+              email: 'TeStUsEr@ExAmPlE.com',
+              password: 'password8',
+              locale: 'en'
+            }
+
+            do_request(user: user_params)
+            assert_status 201
+            expect(User.last.email).to eq 'testuser@example.com'
           end
 
-          let(:email) { 'jEzUs@citizenlab.co' }
-
-          example '[error] Registering a user with case insensitive email duplicate', document: false do
-            do_request
-            assert_status 422
+          example 'Different cases of same email are treated as same user' do
+            original_email = 'TeStUsEr@ExAmPlE.com'
+            lowercased_email = 'testuser@example.com'
+            
+            create(:user, email: original_email)
+            expect(User.find_by_cimail(lowercased_email)).to be_present
+            expect(User.find_by_cimail(original_email)).to be_present
+            expect(User.last.email).to eq lowercased_email
           end
         end
 

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -293,6 +293,8 @@ resource 'Users' do
           end
 
           example 'Accepts registration with different case and converts to lowercase' do
+            User.delete_all # Clean state
+            
             user_params = {
               first_name: Faker::Name.first_name,
               last_name: Faker::Name.last_name,
@@ -307,6 +309,8 @@ resource 'Users' do
           end
 
           example 'Different cases of same email are treated as same user' do
+            User.delete_all # Clean state
+            
             original_email = 'TeStUsEr@ExAmPlE.com'
             lowercased_email = 'testuser@example.com'
 

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -281,6 +281,17 @@ resource 'Users' do
         end
 
         describe 'case insensitive email handling' do
+          before do
+            create(:user, email: 'JeZuS@citizenlab.co')
+          end
+
+          let(:email) { 'jEzUs@citizenlab.co' }
+
+          example '[error] Registering a user with case insensitive email duplicate', document: false do
+            do_request
+            assert_status 422
+          end
+
           example 'Accepts registration with different case and converts to lowercase' do
             user_params = {
               first_name: Faker::Name.first_name,

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -297,7 +297,7 @@ RSpec.describe User do
       user = build(:user, new_email: 'kOeN@citizenlab.co')
       expect(user).to be_invalid
       expect(user.errors.details[:new_email]).not_to be_present
-      expect(user.errors.details[:email]).to eq [{ error: :taken, value: 'kOeN@citizenlab.co' }]
+      expect(user.errors.details[:email]).to eq [{ error: :taken, value: 'koen@citizenlab.co' }]
     end
   end
 


### PR DESCRIPTION
# Description
- In this PR I added a `before_validation` function to change any updated email or new email to lowercase. For any emails in the DB that are already using capital letters, they will still work though today as whenever we do checks against the email we use `find_by_cimail`, which converts it to lowercase anyways.

```
def self.find_by_cimail(email)
  where('lower(email) = lower(?)', email).first
end
```

If I've misunderstood something though, just let me know! :)

# Changelog
## Fixed
- [TAN-5706] Always save emails in lowercase, so we don't have case-sensitive email issues.
