### PR TITLE
TAN-5763 Support setting created_at in admin HQ

### DIFF
--- a/back/engines/commercial/admin_api/app/controllers/admin_api/tenants_controller.rb
+++ b/back/engines/commercial/admin_api/app/controllers/admin_api/tenants_controller.rb
@@ -96,7 +96,7 @@ module AdminApi
     end
 
     def config_params
-      @config_params ||= params.require(:tenant).permit(:host, :name, :logo, settings: {}, style: {})
+      @config_params ||= params.require(:tenant).permit(:host, :name, :created_at, :logo, settings: {}, style: {})
     end
     alias legacy_tenant_params config_params
 

--- a/back/engines/commercial/admin_api/app/serializers/admin_api/tenant_serializer.rb
+++ b/back/engines/commercial/admin_api/app/serializers/admin_api/tenant_serializer.rb
@@ -9,7 +9,7 @@ module AdminApi
   # one DB query using:
   #   AdminApi::TenantSerializer.new(tenant, app_configuration: config)
   class TenantSerializer < ActiveModel::Serializer
-    attributes :id, :name, :host, :settings, :style, :logo, :favicon
+    attributes :id, :name, :host, :settings, :style, :logo, :favicon, :created_at
     delegate :host, :settings, :style, to: :configuration
 
     def logo


### PR DESCRIPTION
I have regularly received the request to fix demo dashboards, which happens by changing the created_at of the tenant to an earlier date. The reason this happens is that sometimes demo data is added that is older than the tenant itself, but the dashboards need to have a start date and use the tenant's creation date for that. The field can only be changed for demo platforms.

# Changelog

### Changed
- [TAN-5763] Setting created_at in Admin HQ to have nicer demo dashboards
