### PR TITLE
Add fix for YouTube embeds in FE & BE on form save

### DIFF
--- a/back/app/services/sanitization_service.rb
+++ b/back/app/services/sanitization_service.rb
@@ -135,7 +135,7 @@ class SanitizationService
       },
       video: {
         tags: %w[iframe],
-        attributes: %w[class frameborder allowfullscreen src data-blot-formatter-unclickable-bound width height data-align style]
+        attributes: %w[class frameborder allowfullscreen referrerpolicy src data-blot-formatter-unclickable-bound width height data-align style]
       },
       mention: {
         tags: %w[span],

--- a/back/spec/services/sanitization_service_spec.rb
+++ b/back/spec/services/sanitization_service_spec.rb
@@ -125,7 +125,7 @@ describe SanitizationService do
 
     it 'allows youtube video to pass through when video feature is enabled' do
       input = <<~HTML
-        "<iframe class="ql-video" frameborder="0" allowfullscreen="true" src="https://www.youtube.com/embed/Y1mtif1B8k0?showinfo=0" data-blot-formatter-unclickable-bound="true" width="497" height="248.5" style="display:block;margin:auto;cursor:nwse-resize;" data-align="center"></iframe>"
+        "<iframe class="ql-video" frameborder="0" allowfullscreen="true" src="https://www.youtube.com/embed/Y1mtif1B8k0?showinfo=0" referrerpolicy="strict-origin-when-cross-origin" data-blot-formatter-unclickable-bound="true" width="497" height="248.5" style="display:block;margin:auto;cursor:nwse-resize;" data-align="center"></iframe>"
       HTML
       features = [:video]
       expect(service.sanitize(input, features)).to eq input

--- a/front/app/components/UI/QuillEditedContent/index.tsx
+++ b/front/app/components/UI/QuillEditedContent/index.tsx
@@ -3,8 +3,6 @@ import React, { useRef, useEffect } from 'react';
 import { quillEditedContent } from '@citizenlab/cl2-component-library';
 import styled, { useTheme } from 'styled-components';
 
-import { isYouTubeEmbedLink } from 'utils/urlUtils';
-
 const Container = styled.div<{
   textColor: Props['textColor'];
   mentionColor: Props['mentionColor'];
@@ -46,24 +44,6 @@ const QuillEditedContent = ({
   const tabbableElements = containerRef.current?.querySelectorAll(
     'a, iframe, button, input, select, textarea'
   );
-
-  useEffect(() => {
-    const setSecureReferrerPolicy = (iframe: HTMLIFrameElement) => {
-      if (!isYouTubeEmbedLink(iframe.src)) return;
-
-      // Set both referrer policy attribute and property
-      iframe.setAttribute('referrerpolicy', 'strict-origin-when-cross-origin');
-      iframe.referrerPolicy = 'strict-origin-when-cross-origin';
-    };
-
-    // Process all iframes in container
-    containerRef.current?.querySelectorAll('iframe').forEach((iframe) => {
-      const src = iframe.src;
-      setSecureReferrerPolicy(iframe);
-      // Re-assign src to force reload with new referrer policy
-      iframe.src = src;
-    });
-  }, []);
 
   useEffect(() => {
     if (tabbableElements) {

--- a/front/app/components/UI/QuillEditor/configureQuill.ts
+++ b/front/app/components/UI/QuillEditor/configureQuill.ts
@@ -1,6 +1,8 @@
 import Quill from 'quill';
 import BlotFormatter from 'quill-blot-formatter/dist/BlotFormatter';
 
+import { isYouTubeEmbedLink } from 'utils/urlUtils';
+
 import {
   attributes,
   ImageBlot,
@@ -14,6 +16,17 @@ export const configureQuill = () => {
   // BEGIN allow video resizing styles
   const BaseVideoFormat = Quill.import('formats/video');
   class VideoFormat extends BaseVideoFormat {
+    static create(url: string) {
+      const node = super.create(url);
+
+      // Add referrer policy to YouTube video embeds
+      if (isYouTubeEmbedLink(url)) {
+        node.setAttribute('referrerpolicy', 'strict-origin-when-cross-origin');
+      }
+
+      return node;
+    }
+
     static formats(domNode) {
       return attributes.reduce((formats, attribute) => {
         if (domNode.hasAttribute(attribute)) {


### PR DESCRIPTION
Removed the previous attempt to fix YouTube embeds on render in the FE as it won't work for places like the phase description.

Instead, added a fix for YouTube embeds in FE & BE on form save. This does mean that admins/users will have to re-upload the YouTubbe videos in any Idea/Phase/Event descriptions, but I don't think this is too bad :thinking: