### PR TITLE
TAN-5499 Only disable search engine index if not listed

### DIFF
--- a/front/app/containers/ProjectsShowPage/shared/header/ProjectShowPageMeta.tsx
+++ b/front/app/containers/ProjectsShowPage/shared/header/ProjectShowPageMeta.tsx
@@ -69,7 +69,7 @@ const ProjectShowPageMeta = ({ project }: Props) => {
       />
       <meta property="og:url" content={location.href} />
       <meta name="twitter:card" content="summary_large_image" />
-      {project.attributes.listed && <meta name="robots" content="noindex" />}
+      {!project.attributes.listed && <meta name="robots" content="noindex" />}
     </Helmet>
   );
 };


### PR DESCRIPTION
# Changelog
## Fixed
- Unlisted projects where indexed by search engines, while listed projects were not. So exactly the opposite behavior of what is desired. Now it works as expected (unlisted = not indexed, listed = indexed)