### PR TITLE
[TAN-5588] Refactor content image extraction

### DIFF
--- a/back/app/controllers/web_api/v1/folders_controller.rb
+++ b/back/app/controllers/web_api/v1/folders_controller.rb
@@ -76,23 +76,10 @@ class WebApi::V1::FoldersController < ApplicationController
   end
 
   def create
-    project_folder_attributes = project_folder_params
-    text_image_service = TextImageService.new
-    extract_output = text_image_service.extract_data_images_multiloc(
-      project_folder_attributes[:description_multiloc]
-    )
-    project_folder_attributes[:description_multiloc] = extract_output[:content_multiloc]
-
-    @project_folder = ProjectFolders::Folder.new(project_folder_attributes)
-
+    @project_folder = ProjectFolders::Folder.new(project_folder_params)
     authorize @project_folder
 
     if @project_folder.save
-      text_image_service.bulk_create_images!(
-        extract_output[:extracted_images],
-        @project_folder,
-        :description_multiloc
-      )
       ProjectFolders::SideFxProjectFolderService.new.after_create(@project_folder, current_user)
 
       render json: WebApi::V1::FolderSerializer.new(
@@ -110,7 +97,6 @@ class WebApi::V1::FoldersController < ApplicationController
     authorize @project_folder
     remove_image_if_requested!(@project_folder, project_folder_params, :header_bg)
 
-    ProjectFolders::SideFxProjectFolderService.new.before_update(@project_folder, current_user)
     if @project_folder.save
       ProjectFolders::SideFxProjectFolderService.new.after_update(@project_folder, current_user)
       render json: WebApi::V1::FolderSerializer.new(

--- a/back/app/controllers/web_api/v1/ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/ideas_controller.rb
@@ -176,12 +176,6 @@ class WebApi::V1::IdeasController < ApplicationController
     params_for_create = idea_params form
     files_params = extract_file_params(params_for_create)
 
-    text_image_service = TextImageService.new
-    extract_output = text_image_service.extract_data_images_multiloc(
-      params_for_create[:body_multiloc]
-    )
-    params_for_create[:body_multiloc] = extract_output[:content_multiloc]
-
     input = Idea.new params_for_create
 
     files_params.each do |file_params|
@@ -240,11 +234,6 @@ class WebApi::V1::IdeasController < ApplicationController
     ActiveRecord::Base.transaction do
       if input.save(**save_options)
         update_file_upload_fields input, form, params_for_create
-        text_image_service.bulk_create_images!(
-          extract_output[:extracted_images],
-          input,
-          :body_multiloc
-        )
         sidefx.after_create(input, current_user)
         write_everyone_tracking_cookie input
         render json: WebApi::V1::IdeaSerializer.new(

--- a/back/app/controllers/web_api/v1/phases_controller.rb
+++ b/back/app/controllers/web_api/v1/phases_controller.rb
@@ -28,23 +28,12 @@ class WebApi::V1::PhasesController < ApplicationController
 
   def create
     phase_attributes = phase_params
-    text_image_service = TextImageService.new
-    extract_output = text_image_service.extract_data_images_multiloc(
-      phase_attributes[:description_multiloc]
-    )
-    phase_attributes[:description_multiloc] = extract_output[:content_multiloc]
-
     @phase = Phase.new(phase_attributes)
     @phase.project_id = params[:project_id]
     sidefx.before_create(@phase, current_user)
     authorize @phase
 
     if @phase.save
-      text_image_service.bulk_create_images!(
-        extract_output[:extracted_images],
-        @phase,
-        :description_multiloc
-      )
       sidefx.after_create(@phase, current_user)
       render json: WebApi::V1::PhaseSerializer.new(@phase, params: jsonapi_serializer_params).serializable_hash, status: :created
     else

--- a/back/app/controllers/web_api/v1/static_pages_controller.rb
+++ b/back/app/controllers/web_api/v1/static_pages_controller.rb
@@ -25,29 +25,8 @@ class WebApi::V1::StaticPagesController < ApplicationController
     assign_attributes
     authorize @page
 
-    text_image_service = TextImageService.new
-    extract_output_top = text_image_service.extract_data_images_multiloc(
-      @page.top_info_section_multiloc
-    )
-    extract_output_bottom = text_image_service.extract_data_images_multiloc(
-      @page.bottom_info_section_multiloc
-    )
-    @page.top_info_section_multiloc = extract_output_top[:content_multiloc]
-    @page.bottom_info_section_multiloc = extract_output_bottom[:content_multiloc]
-
     SideFxStaticPageService.new.before_create @page, current_user
     if @page.save
-      text_image_service.bulk_create_images!(
-        extract_output_top[:extracted_images],
-        @page,
-        :top_info_section_multiloc
-      )
-      text_image_service.bulk_create_images!(
-        extract_output_bottom[:extracted_images],
-        @page,
-        :bottom_info_section_multiloc
-      )
-
       SideFxStaticPageService.new.after_create @page, current_user
       render(
         json: WebApi::V1::StaticPageSerializer.new(@page, params: jsonapi_serializer_params).serializable_hash,
@@ -62,7 +41,6 @@ class WebApi::V1::StaticPagesController < ApplicationController
     assign_attributes
     authorize @page
 
-    SideFxStaticPageService.new.before_update @page, current_user
     if @page.save
       SideFxStaticPageService.new.after_update @page, current_user
       render json: WebApi::V1::StaticPageSerializer.new(@page, params: jsonapi_serializer_params).serializable_hash, status: :ok

--- a/back/app/models/application_record.rb
+++ b/back/app/models/application_record.rb
@@ -2,6 +2,7 @@
 
 class ApplicationRecord < ActiveRecord::Base
   include Sluggable
+  include Imageable
 
   self.abstract_class = true
 

--- a/back/app/models/concerns/imageable.rb
+++ b/back/app/models/concerns/imageable.rb
@@ -1,0 +1,17 @@
+module Imageable
+  extend ActiveSupport::Concern
+
+  class_methods do
+    # rubocop:disable Naming/PredicateName
+    def has_many_text_images_from(attribute, association_name = :text_images)
+      TextImageService
+        .configure_image_extraction(self, attribute, association_name)
+    end
+
+    def has_many_layout_images_from(attribute, association_name = :layout_images)
+      ContentBuilder::LayoutImageService
+        .configure_image_extraction(self, attribute, association_name)
+    end
+    # rubocop:enable Naming/PredicateName
+  end
+end

--- a/back/app/models/concerns/imageable.rb
+++ b/back/app/models/concerns/imageable.rb
@@ -4,13 +4,7 @@ module Imageable
   class_methods do
     # rubocop:disable Naming/PredicateName
     def has_many_text_images_from(attribute, association_name = :text_images)
-      TextImageService
-        .configure_image_extraction(self, attribute, association_name)
-    end
-
-    def has_many_layout_images_from(attribute, association_name = :layout_images)
-      ContentBuilder::LayoutImageService
-        .configure_image_extraction(self, attribute, association_name)
+      TextImageService.setup_image_extraction(self, attribute, association_name)
     end
     # rubocop:enable Naming/PredicateName
   end

--- a/back/app/models/concerns/imageable.rb
+++ b/back/app/models/concerns/imageable.rb
@@ -2,10 +2,8 @@ module Imageable
   extend ActiveSupport::Concern
 
   class_methods do
-    # rubocop:disable Naming/PredicateName
-    def has_many_text_images_from(attribute, association_name = :text_images)
-      TextImageService.setup_image_extraction(self, attribute, association_name)
+    def has_many_text_images(from:, as: :text_images)
+      TextImageService.setup_image_extraction(self, from, as)
     end
-    # rubocop:enable Naming/PredicateName
   end
 end

--- a/back/app/models/custom_field.rb
+++ b/back/app/models/custom_field.rb
@@ -57,7 +57,7 @@
 class CustomField < ApplicationRecord
   acts_as_list column: :ordering, top_of_list: 0, scope: [:resource_id]
 
-  has_many_text_images_from :description_multiloc
+  has_many_text_images from: :description_multiloc
   accepts_nested_attributes_for :text_images
 
   has_many :options, -> { order(:ordering) }, dependent: :destroy, class_name: 'CustomFieldOption', inverse_of: :custom_field

--- a/back/app/models/custom_field.rb
+++ b/back/app/models/custom_field.rb
@@ -57,7 +57,7 @@
 class CustomField < ApplicationRecord
   acts_as_list column: :ordering, top_of_list: 0, scope: [:resource_id]
 
-  has_many_text_images from: :description_multiloc
+  has_many_text_images from: :description_multiloc, as: :text_images
   accepts_nested_attributes_for :text_images
 
   has_many :options, -> { order(:ordering) }, dependent: :destroy, class_name: 'CustomFieldOption', inverse_of: :custom_field

--- a/back/app/models/event.rb
+++ b/back/app/models/event.rb
@@ -36,7 +36,7 @@ class Event < ApplicationRecord
   include Files::FileAttachable
   include GeoJsonHelpers
 
-  has_many_text_images_from :description_multiloc
+  has_many_text_images from: :description_multiloc
 
   belongs_to :project
   has_many :attendances, class_name: 'Events::Attendance', dependent: :destroy

--- a/back/app/models/event.rb
+++ b/back/app/models/event.rb
@@ -36,11 +36,12 @@ class Event < ApplicationRecord
   include Files::FileAttachable
   include GeoJsonHelpers
 
+  has_many_text_images_from :description_multiloc
+
   belongs_to :project
   has_many :attendances, class_name: 'Events::Attendance', dependent: :destroy
   has_many :attendees, through: :attendances
   has_many :event_files, -> { order(:ordering) }, dependent: :destroy
-  has_many :text_images, as: :imageable, dependent: :destroy
   has_many :event_images, -> { order(:ordering) }, dependent: :destroy, inverse_of: :event
   accepts_nested_attributes_for :text_images, :event_images
 

--- a/back/app/models/idea.rb
+++ b/back/app/models/idea.rb
@@ -96,7 +96,7 @@ class Idea < ApplicationRecord
     delta_magnitude: proc { |idea| idea.comments_count }
   )
 
-  has_many_text_images_from :body_multiloc
+  has_many_text_images from: :body_multiloc
 
   # Must appear before before_destroy
   before_save :convert_wkt_geo_custom_field_values_to_geojson

--- a/back/app/models/invite.rb
+++ b/back/app/models/invite.rb
@@ -39,7 +39,7 @@ class Invite < ApplicationRecord
   belongs_to :inviter, class_name: 'User', optional: true
   belongs_to :invitee, class_name: 'User'
 
-  has_many_text_images from: :invite_text
+  has_many_text_images from: :invite_text, as: :text_images
   accepts_nested_attributes_for :text_images
 
   before_validation :generate_token, on: :create

--- a/back/app/models/invite.rb
+++ b/back/app/models/invite.rb
@@ -39,7 +39,7 @@ class Invite < ApplicationRecord
   belongs_to :inviter, class_name: 'User', optional: true
   belongs_to :invitee, class_name: 'User'
 
-  has_many_text_images_from :invite_text
+  has_many_text_images from: :invite_text
   accepts_nested_attributes_for :text_images
 
   before_validation :generate_token, on: :create

--- a/back/app/models/invite.rb
+++ b/back/app/models/invite.rb
@@ -39,20 +39,19 @@ class Invite < ApplicationRecord
   belongs_to :inviter, class_name: 'User', optional: true
   belongs_to :invitee, class_name: 'User'
 
+  has_many_text_images_from :invite_text
+  accepts_nested_attributes_for :text_images
+
   before_validation :generate_token, on: :create
   before_validation :sanitize_invite_text, if: :invite_text
   before_destroy :remove_notifications # Must occur before has_many :notifications (see https://github.com/rails/rails/issues/5205)
   has_many :notifications, dependent: :nullify
-
-  has_many :text_images, as: :imageable, dependent: :destroy
-  accepts_nested_attributes_for :text_images
 
   validates :token, presence: true, uniqueness: true
   validates :invitee, presence: true, uniqueness: true
   validates :send_invite_email, inclusion: [true, false]
 
   after_destroy :destroy_invitee, if: :pending?
-  after_save :process_invite_text_images, if: :invite_text
 
   private
 
@@ -76,11 +75,6 @@ class Invite < ApplicationRecord
     )
     self.invite_text = service.remove_empty_trailing_tags(invite_text)
     self.invite_text = service.linkify(invite_text)
-  end
-
-  def process_invite_text_images
-    processed_invite_text = TextImageService.new.swap_data_images invite_text, field: :invite_text, imageable: self
-    update_column :invite_text, processed_invite_text
   end
 
   def remove_notifications

--- a/back/app/models/phase.rb
+++ b/back/app/models/phase.rb
@@ -78,7 +78,7 @@ class Phase < ApplicationRecord
 
   attribute :reacting_dislike_enabled, :boolean, default: -> { disliking_enabled_default }
 
-  has_many_text_images from: :description_multiloc
+  has_many_text_images from: :description_multiloc, as: :text_images
   accepts_nested_attributes_for :text_images
 
   belongs_to :project

--- a/back/app/models/phase.rb
+++ b/back/app/models/phase.rb
@@ -78,6 +78,9 @@ class Phase < ApplicationRecord
 
   attribute :reacting_dislike_enabled, :boolean, default: -> { disliking_enabled_default }
 
+  has_many_text_images_from :description_multiloc
+  accepts_nested_attributes_for :text_images
+
   belongs_to :project
 
   has_one :custom_form, as: :participation_context, dependent: :destroy # native_survey only
@@ -87,8 +90,6 @@ class Phase < ApplicationRecord
   has_many :ideas_phases, dependent: :destroy
   has_many :ideas, through: :ideas_phases
   has_many :reactions, through: :ideas
-  has_many :text_images, as: :imageable, dependent: :destroy
-  accepts_nested_attributes_for :text_images
   has_many :phase_files, -> { order(:ordering) }, dependent: :destroy
   has_many :jobs_trackers, -> { where(context_type: 'Phase') }, class_name: 'Jobs::Tracker', as: :context, dependent: :destroy
   belongs_to :manual_voters_last_updated_by, class_name: 'User', optional: true

--- a/back/app/models/phase.rb
+++ b/back/app/models/phase.rb
@@ -78,7 +78,7 @@ class Phase < ApplicationRecord
 
   attribute :reacting_dislike_enabled, :boolean, default: -> { disliking_enabled_default }
 
-  has_many_text_images_from :description_multiloc
+  has_many_text_images from: :description_multiloc
   accepts_nested_attributes_for :text_images
 
   belongs_to :project

--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -46,7 +46,7 @@ class Project < ApplicationRecord
 
   mount_base64_uploader :header_bg, ProjectHeaderBgUploader
 
-  has_many_text_images_from :description_multiloc
+  has_many_text_images from: :description_multiloc
   accepts_nested_attributes_for :text_images
 
   has_one :custom_form, as: :participation_context, dependent: :destroy # ideation & voting phases only

--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -46,6 +46,9 @@ class Project < ApplicationRecord
 
   mount_base64_uploader :header_bg, ProjectHeaderBgUploader
 
+  has_many_text_images_from :description_multiloc
+  accepts_nested_attributes_for :text_images
+
   has_one :custom_form, as: :participation_context, dependent: :destroy # ideation & voting phases only
 
   has_many :ideas, dependent: :destroy
@@ -65,8 +68,6 @@ class Project < ApplicationRecord
   # project_images should always store one record, but in practice it's different (maybe because of a bug)
   # https://citizenlabco.slack.com/archives/C015M14HYSF/p1674228018666059
   has_many :project_images, -> { order(:ordering) }, dependent: :destroy
-  has_many :text_images, as: :imageable, dependent: :destroy
-  accepts_nested_attributes_for :text_images
   has_many :project_files, -> { order(:ordering) }, dependent: :destroy
   has_many :followers, as: :followable, dependent: :destroy
   has_many :impact_tracking_pageviews, class_name: 'ImpactTracking::Pageview', dependent: :nullify

--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -46,7 +46,7 @@ class Project < ApplicationRecord
 
   mount_base64_uploader :header_bg, ProjectHeaderBgUploader
 
-  has_many_text_images from: :description_multiloc
+  has_many_text_images from: :description_multiloc, as: :text_images
   accepts_nested_attributes_for :text_images
 
   has_one :custom_form, as: :participation_context, dependent: :destroy # ideation & voting phases only

--- a/back/app/models/project_folders/folder.rb
+++ b/back/app/models/project_folders/folder.rb
@@ -27,7 +27,7 @@ module ProjectFolders
 
     slug from: proc { |folder| folder.title_multiloc&.values&.find(&:present?) }
 
-    has_many_text_images_from :description_multiloc
+    has_many_text_images from: :description_multiloc
 
     has_one :admin_publication, as: :publication, dependent: :destroy
     has_one :nav_bar_item, dependent: :destroy, inverse_of: 'project_folder', foreign_key: 'project_folder_id'

--- a/back/app/models/project_folders/folder.rb
+++ b/back/app/models/project_folders/folder.rb
@@ -27,13 +27,13 @@ module ProjectFolders
 
     slug from: proc { |folder| folder.title_multiloc&.values&.find(&:present?) }
 
+    has_many_text_images_from :description_multiloc
+
     has_one :admin_publication, as: :publication, dependent: :destroy
     has_one :nav_bar_item, dependent: :destroy, inverse_of: 'project_folder', foreign_key: 'project_folder_id'
     accepts_nested_attributes_for :admin_publication, update_only: true
     has_many :images, -> { order(:ordering) }, dependent: :destroy, inverse_of: 'project_folder', foreign_key: 'project_folder_id' # TODO: remove after renaming project_folder association in Image model
     has_many :files, -> { order(:ordering) }, dependent: :destroy, inverse_of: 'project_folder', foreign_key: 'project_folder_id'  # TODO: remove after renaming project_folder association in File model
-    has_many :text_images, as: :imageable, dependent: :destroy
-    accepts_nested_attributes_for :text_images
     has_many :followers, as: :followable, dependent: :destroy
 
     mount_base64_uploader :header_bg, HeaderBgUploader

--- a/back/app/models/static_page.rb
+++ b/back/app/models/static_page.rb
@@ -44,8 +44,8 @@ class StaticPage < ApplicationRecord
 
   enum :projects_filter_type, { no_filter: 'no_filter', areas: 'areas', topics: 'topics' }
 
-  has_many_text_images_from :top_info_section_multiloc, :top_info_section_text_images
-  has_many_text_images_from :bottom_info_section_multiloc, :bottom_info_section_text_images
+  has_many_text_images from: :top_info_section_multiloc, as: :top_info_section_text_images
+  has_many_text_images from: :bottom_info_section_multiloc, as: :bottom_info_section_text_images
   has_many :text_images, as: :imageable, dependent: :destroy
   accepts_nested_attributes_for :text_images
 

--- a/back/app/models/static_page.rb
+++ b/back/app/models/static_page.rb
@@ -44,10 +44,13 @@ class StaticPage < ApplicationRecord
 
   enum :projects_filter_type, { no_filter: 'no_filter', areas: 'areas', topics: 'topics' }
 
+  has_many_text_images_from :top_info_section_multiloc, :top_info_section_text_images
+  has_many_text_images_from :bottom_info_section_multiloc, :bottom_info_section_text_images
+  has_many :text_images, as: :imageable, dependent: :destroy
+  accepts_nested_attributes_for :text_images
+
   has_one :nav_bar_item, dependent: :destroy
   has_many :static_page_files, -> { order(:ordering) }, dependent: :destroy
-  has_many :text_images, as: :imageable, dependent: :destroy
-
   has_many :static_pages_topics, dependent: :destroy
   has_many :topics, -> { order(:ordering) }, through: :static_pages_topics
 
@@ -55,7 +58,6 @@ class StaticPage < ApplicationRecord
   has_many :areas, through: :areas_static_pages
 
   accepts_nested_attributes_for :nav_bar_item
-  accepts_nested_attributes_for :text_images
 
   before_validation :set_code, on: :create
   before_validation :strip_title

--- a/back/app/models/text_image.rb
+++ b/back/app/models/text_image.rb
@@ -14,16 +14,10 @@
 #  text_reference  :string           not null
 #
 class TextImage < ApplicationRecord
+  attribute :text_reference, :string, default: -> { SecureRandom.uuid }
+
   mount_base64_uploader :image, TextImageUploader
   belongs_to :imageable, polymorphic: true
 
   validates :imageable, presence: true
-
-  before_validation :generate_text_reference, on: :create
-
-  private
-
-  def generate_text_reference
-    self.text_reference ||= SecureRandom.uuid
-  end
 end

--- a/back/app/serializers/web_api/v1/invite_serializer.rb
+++ b/back/app/serializers/web_api/v1/invite_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class WebApi::V1::InviteSerializer < WebApi::V1::BaseSerializer
-  attributes :token, :invite_text, :accepted_at, :updated_at, :created_at
+  attributes :token, :accepted_at, :updated_at, :created_at
 
   attribute :activate_invite_url do |object|
     Frontend::UrlService.new.invite_url object.token, locale: Locale.new(object.invitee.locale)

--- a/back/app/services/content_image_service.rb
+++ b/back/app/services/content_image_service.rb
@@ -35,11 +35,7 @@ class ContentImageService
   # Extracts and remove image data from the content, stores it in a separate image model,
   # and updates the original content to reference the image model instead.
   def swap_data_images(encoded_content, imageable: nil, field: nil)
-    content = begin
-      decode_content encoded_content
-    rescue DecodingError => e
-      log_decoding_error e
-    end
+    content = decode_content(encoded_content)
     return encoded_content if !content
 
     image_elements(content).each do |img_elt|
@@ -71,7 +67,7 @@ class ContentImageService
 
   # Replaces references to image models in the content by actual image data.
   def render_data_images(encoded_content, imageable: nil, field: nil)
-    content = decode_content encoded_content
+    content = decode_content! encoded_content
     precompute_for_rendering imageable
 
     image_elements(content).each do |img_elt|
@@ -91,9 +87,18 @@ class ContentImageService
 
   protected
 
-  def decode_content(encoded_content)
+  # @param encoded_content [String]
+  # @raise [DecodingError] if the content could not be decoded.
+  def decode_content!(encoded_content)
     # No encoding by default.
     encoded_content
+  end
+
+  def decode_content(encoded_content)
+    decode_content!(encoded_content)
+  rescue DecodingError => e
+    log_decoding_error(e)
+    nil
   end
 
   def encode_content(decoded_content)

--- a/back/app/services/content_image_service.rb
+++ b/back/app/services/content_image_service.rb
@@ -243,7 +243,7 @@ class ContentImageService
         association_name,
         as: :imageable,
         dependent: :destroy,
-        class_name: 'TextImage'
+        class_name: content_image_class.name
       )
     end
   end

--- a/back/app/services/content_image_service.rb
+++ b/back/app/services/content_image_service.rb
@@ -230,7 +230,7 @@ class ContentImageService
         Module.new do
           define_method(:"#{field}=") do |value|
             super(value)
-            image_service_class.new.swap_data_images!(self, field, association_name)
+            image_service_class.new.swap_data_images!(self, field, association_name) if value.present?
           end
         end
       )

--- a/back/app/services/content_image_service.rb
+++ b/back/app/services/content_image_service.rb
@@ -222,18 +222,15 @@ class ContentImageService
   end
 
   class << self
-    def configure_image_extraction(imageable_class, field, association_name = :text_images)
+    def setup_image_extraction(imageable_class, field, association_name = :text_images)
       define_association(imageable_class, association_name, field)
       image_service_class = self
 
-      imageable_class.prepend(
-        Module.new do
-          define_method(:"#{field}=") do |value|
-            super(value)
-            image_service_class.new.swap_data_images!(self, field, association_name) if value.present?
-          end
-        end
-      )
+      imageable_class.before_validation do
+        next unless will_save_change_to_attribute?(field)
+
+        image_service_class.new.swap_data_images!(self, field, association_name)
+      end
     end
 
     private

--- a/back/app/services/content_image_service.rb
+++ b/back/app/services/content_image_service.rb
@@ -25,13 +25,6 @@ class ContentImageService
     attr_reader :parse_errors
   end
 
-  # Applies {#swap_data_images} to each multiloc value in the given multiloc.
-  def swap_data_images_multiloc(multiloc, imageable: nil, field: nil)
-    multiloc.transform_values do |encoded_content|
-      swap_data_images encoded_content, imageable: imageable, field: field
-    end
-  end
-
   # Extracts and remove image data from the content, stores it in a separate image model,
   # and updates the original content to reference the image model instead.
   def swap_data_images(encoded_content, imageable: nil, field: nil)

--- a/back/app/services/content_image_service.rb
+++ b/back/app/services/content_image_service.rb
@@ -222,7 +222,7 @@ class ContentImageService
   end
 
   class << self
-    def setup_image_extraction(imageable_class, field, association_name = :text_images)
+    def setup_image_extraction(imageable_class, field, association_name)
       define_association(imageable_class, association_name, field)
       image_service_class = self
 

--- a/back/app/services/content_image_service.rb
+++ b/back/app/services/content_image_service.rb
@@ -46,7 +46,7 @@ class ContentImageService
     encode_content content
   end
 
-  # Extracts image data from the content field of the given record, stores them in a
+  # Extracts image data from the content field of the given record, stores it in a
   # separate model and updates the content field to reference the stored image instead.
   #
   # This method doesn't directly save the image models. Instead, it returns the record

--- a/back/app/services/content_image_service.rb
+++ b/back/app/services/content_image_service.rb
@@ -220,4 +220,31 @@ class ContentImageService
       }
     )
   end
+
+  class << self
+    def configure_image_extraction(imageable_class, field, association_name = :text_images)
+      define_association(imageable_class, association_name, field)
+      image_service_class = self
+
+      imageable_class.prepend(
+        Module.new do
+          define_method(:"#{field}=") do |value|
+            super(value)
+            image_service_class.new.swap_data_images!(self, field, association_name)
+          end
+        end
+      )
+    end
+
+    private
+
+    def define_association(imageable_class, association_name, _field)
+      imageable_class.has_many(
+        association_name,
+        as: :imageable,
+        dependent: :destroy,
+        class_name: 'TextImage'
+      )
+    end
+  end
 end

--- a/back/app/services/project_folders/side_fx_project_folder_service.rb
+++ b/back/app/services/project_folders/side_fx_project_folder_service.rb
@@ -15,7 +15,7 @@ module ProjectFolders
     end
 
     def before_update(folder, _user)
-      folder.description_multiloc = TextImageService.new.swap_data_images_multiloc(folder.description_multiloc, field: :description_multiloc, imageable: folder)
+      folder.description_multiloc = TextImageService.new.swap_data_images(folder.description_multiloc, field: :description_multiloc, imageable: folder)
     end
 
     def after_update(folder, user)

--- a/back/app/services/project_folders/side_fx_project_folder_service.rb
+++ b/back/app/services/project_folders/side_fx_project_folder_service.rb
@@ -14,10 +14,6 @@ module ProjectFolders
       )
     end
 
-    def before_update(folder, _user)
-      folder.description_multiloc = TextImageService.new.swap_data_images(folder.description_multiloc, field: :description_multiloc, imageable: folder)
-    end
-
     def after_update(folder, user)
       change = folder.saved_changes
       payload = { project_folder: clean_time_attributes(folder.attributes) }

--- a/back/app/services/side_fx_custom_field_service.rb
+++ b/back/app/services/side_fx_custom_field_service.rb
@@ -10,7 +10,7 @@ class SideFxCustomFieldService
   end
 
   def before_update(custom_field, _current_user)
-    custom_field.description_multiloc = TextImageService.new.swap_data_images_multiloc(custom_field.description_multiloc, field: :description_multiloc, imageable: custom_field)
+    custom_field.description_multiloc = TextImageService.new.swap_data_images(custom_field.description_multiloc, field: :description_multiloc, imageable: custom_field)
   end
 
   def after_update(custom_field, current_user)

--- a/back/app/services/side_fx_custom_field_service.rb
+++ b/back/app/services/side_fx_custom_field_service.rb
@@ -9,10 +9,6 @@ class SideFxCustomFieldService
     LogActivityJob.perform_later(custom_field, 'created', current_user, custom_field.created_at.to_i)
   end
 
-  def before_update(custom_field, _current_user)
-    custom_field.description_multiloc = TextImageService.new.swap_data_images(custom_field.description_multiloc, field: :description_multiloc, imageable: custom_field)
-  end
-
   def after_update(custom_field, current_user)
     LogActivityJob.perform_later(custom_field, 'changed', current_user, custom_field.updated_at.to_i)
   end

--- a/back/app/services/side_fx_event_service.rb
+++ b/back/app/services/side_fx_event_service.rb
@@ -9,10 +9,6 @@ class SideFxEventService
     LogActivityJob.perform_later(event, 'created', current_user, event.created_at.to_i)
   end
 
-  def before_update(event, _current_user)
-    event.description_multiloc = TextImageService.new.swap_data_images(event.description_multiloc, field: :description_multiloc, imageable: event)
-  end
-
   def after_update(event, current_user)
     LogActivityJob.perform_later(event, 'changed', current_user, event.updated_at.to_i)
   end

--- a/back/app/services/side_fx_event_service.rb
+++ b/back/app/services/side_fx_event_service.rb
@@ -10,7 +10,7 @@ class SideFxEventService
   end
 
   def before_update(event, _current_user)
-    event.description_multiloc = TextImageService.new.swap_data_images_multiloc(event.description_multiloc, field: :description_multiloc, imageable: event)
+    event.description_multiloc = TextImageService.new.swap_data_images(event.description_multiloc, field: :description_multiloc, imageable: event)
   end
 
   def after_update(event, current_user)

--- a/back/app/services/side_fx_idea_service.rb
+++ b/back/app/services/side_fx_idea_service.rb
@@ -34,7 +34,7 @@ class SideFxIdeaService
   def before_update(idea, user)
     @old_cosponsor_ids = idea.cosponsor_ids
     @old_phase_ids = idea.phase_ids
-    idea.body_multiloc = TextImageService.new.swap_data_images_multiloc(idea.body_multiloc, field: :body_multiloc, imageable: idea)
+    idea.body_multiloc = TextImageService.new.swap_data_images(idea.body_multiloc, field: :body_multiloc, imageable: idea)
     idea.publication_status = 'published' if idea.submitted_or_published? && idea.idea_status&.public_post?
     before_publish_or_submit idea, user if idea.will_be_submitted? || idea.will_be_published?
   end

--- a/back/app/services/side_fx_idea_service.rb
+++ b/back/app/services/side_fx_idea_service.rb
@@ -34,7 +34,6 @@ class SideFxIdeaService
   def before_update(idea, user)
     @old_cosponsor_ids = idea.cosponsor_ids
     @old_phase_ids = idea.phase_ids
-    idea.body_multiloc = TextImageService.new.swap_data_images(idea.body_multiloc, field: :body_multiloc, imageable: idea)
     idea.publication_status = 'published' if idea.submitted_or_published? && idea.idea_status&.public_post?
     before_publish_or_submit idea, user if idea.will_be_submitted? || idea.will_be_published?
   end

--- a/back/app/services/side_fx_phase_service.rb
+++ b/back/app/services/side_fx_phase_service.rb
@@ -28,7 +28,7 @@ class SideFxPhaseService
   end
 
   def before_update(phase, _user)
-    phase.description_multiloc = TextImageService.new.swap_data_images_multiloc(phase.description_multiloc, field: :description_multiloc, imageable: phase)
+    phase.description_multiloc = TextImageService.new.swap_data_images(phase.description_multiloc, field: :description_multiloc, imageable: phase)
 
     if phase.pmethod.allowed_ideas_orders.exclude? phase.ideas_order
       phase.ideas_order = phase.pmethod.allowed_ideas_orders.first

--- a/back/app/services/side_fx_phase_service.rb
+++ b/back/app/services/side_fx_phase_service.rb
@@ -28,8 +28,6 @@ class SideFxPhaseService
   end
 
   def before_update(phase, _user)
-    phase.description_multiloc = TextImageService.new.swap_data_images(phase.description_multiloc, field: :description_multiloc, imageable: phase)
-
     if phase.pmethod.allowed_ideas_orders.exclude? phase.ideas_order
       phase.ideas_order = phase.pmethod.allowed_ideas_orders.first
     end

--- a/back/app/services/side_fx_project_service.rb
+++ b/back/app/services/side_fx_project_service.rb
@@ -49,7 +49,7 @@ class SideFxProjectService
   def before_update(project, _user)
     @publication_status_was = project.admin_publication.publication_status_was
     @folder_id_was = project.admin_publication.parent_id_was
-    project.description_multiloc = TextImageService.new.swap_data_images_multiloc(project.description_multiloc, field: :description_multiloc, imageable: project)
+    project.description_multiloc = TextImageService.new.swap_data_images(project.description_multiloc, field: :description_multiloc, imageable: project)
   end
 
   def after_update(project, user)

--- a/back/app/services/side_fx_project_service.rb
+++ b/back/app/services/side_fx_project_service.rb
@@ -49,7 +49,6 @@ class SideFxProjectService
   def before_update(project, _user)
     @publication_status_was = project.admin_publication.publication_status_was
     @folder_id_was = project.admin_publication.parent_id_was
-    project.description_multiloc = TextImageService.new.swap_data_images(project.description_multiloc, field: :description_multiloc, imageable: project)
   end
 
   def after_update(project, user)

--- a/back/app/services/side_fx_static_page_service.rb
+++ b/back/app/services/side_fx_static_page_service.rb
@@ -9,16 +9,6 @@ class SideFxStaticPageService
     LogActivityJob.perform_later(page, 'created', user, page.created_at.to_i)
   end
 
-  def before_update(page, _)
-    if page.top_info_section_multiloc.present?
-      page.top_info_section_multiloc = TextImageService.new.swap_data_images page.top_info_section_multiloc, field: :top_info_section_multiloc, imageable: page
-    end
-
-    return if page.bottom_info_section_multiloc.blank?
-
-    page.bottom_info_section_multiloc = TextImageService.new.swap_data_images page.bottom_info_section_multiloc, field: :bottom_info_section_multiloc, imageable: page
-  end
-
   def after_update(page, user)
     LogActivityJob.perform_later(page, 'changed', user, page.updated_at.to_i)
   end

--- a/back/app/services/side_fx_static_page_service.rb
+++ b/back/app/services/side_fx_static_page_service.rb
@@ -11,12 +11,12 @@ class SideFxStaticPageService
 
   def before_update(page, _)
     if page.top_info_section_multiloc.present?
-      page.top_info_section_multiloc = TextImageService.new.swap_data_images_multiloc page.top_info_section_multiloc, field: :top_info_section_multiloc, imageable: page
+      page.top_info_section_multiloc = TextImageService.new.swap_data_images page.top_info_section_multiloc, field: :top_info_section_multiloc, imageable: page
     end
 
     return if page.bottom_info_section_multiloc.blank?
 
-    page.bottom_info_section_multiloc = TextImageService.new.swap_data_images_multiloc page.bottom_info_section_multiloc, field: :bottom_info_section_multiloc, imageable: page
+    page.bottom_info_section_multiloc = TextImageService.new.swap_data_images page.bottom_info_section_multiloc, field: :bottom_info_section_multiloc, imageable: page
   end
 
   def after_update(page, user)

--- a/back/app/services/text_image_service.rb
+++ b/back/app/services/text_image_service.rb
@@ -3,63 +3,6 @@
 class TextImageService < ContentImageService
   BASE64_REGEX = %r{^data:image/([a-zA-Z]*);base64,.*$}
 
-  # Applies {#extract_data_images} to each multiloc value in the given multiloc.
-  def extract_data_images_multiloc(multiloc)
-    content_multiloc = {}
-    extracted_images = []
-
-    (multiloc || {}).each do |language_key, encoded_content|
-      output = extract_data_images(encoded_content)
-
-      content_multiloc[language_key] = output[:content]
-      extracted_images += output[:extracted_images]
-    end
-
-    {
-      content_multiloc: content_multiloc,
-      extracted_images: extracted_images
-    }
-  end
-
-  # Extracts and remove image data from the content, and stores it in an array
-  # to be processed later.
-  # Already updates the original content to reference the future image model instead.
-  def extract_data_images(encoded_content)
-    content = decode_content(encoded_content)
-
-    extracted_images = []
-
-    if !content
-      return { content: encoded_content, extracted_images: extracted_images }
-    end
-
-    image_elements(content).each do |img_elt|
-      next if image_attributes_for_element.none? { |elt_atr| attribute? img_elt, elt_atr }
-
-      if !attribute?(img_elt, code_attribute_for_element)
-        text_reference = SecureRandom.uuid
-        set_attribute! img_elt, code_attribute_for_element, text_reference
-
-        img_src = get_attribute img_elt, image_attribute_for_element
-        img_key = img_src.match?(BASE64_REGEX) ? :image : :remote_image_url
-
-        extracted_images << {
-          text_reference: text_reference,
-          img_key: img_key,
-          img_src: img_src
-        }
-      end
-      image_attributes_for_element.each do |elt_atr|
-        remove_attribute! img_elt, elt_atr
-      end
-    end
-
-    {
-      content: encode_content(content),
-      extracted_images: extracted_images
-    }
-  end
-
   protected
 
   def decode_content!(content)

--- a/back/app/services/text_image_service.rb
+++ b/back/app/services/text_image_service.rb
@@ -79,29 +79,43 @@ class TextImageService < ContentImageService
 
   protected
 
+  def decode_content!(content)
+    case content
+    when Hash then content.transform_values { |v| decode_content!(v) }
+    when String, nil then decode_string!(content)
+    else raise ArgumentError, "Invalid content type: #{content.class}"
+    end
+  end
+
+  def encode_content(content)
+    case content
+    when Nokogiri::HTML::DocumentFragment then content.to_s
+    when Hash then content.transform_values(&:to_s)
+    else raise ArgumentError, "Invalid content type: #{content.class}"
+    end
+  end
+
   # Decodes the given HTML string into a Nokogiri document.
   # @raise [DecodingError] if the HTML string is not valid.
-  # @param html_string [String] the HTML string to decode.
+  # @param html_string [String, nil] the HTML string to decode. `nil` values are treated
+  #   as empty strings.
   # @return [Nokogiri::HTML::DocumentFragment] the decoded HTML document.
-  def decode_content!(html_string)
+  def decode_string!(html_string)
     html_doc = Nokogiri::HTML.fragment html_string
     raise ContentImageService::DecodingError.new parse_errors: html_doc.errors if html_doc.errors.any?
 
     html_doc
   end
 
-  # Encodes the given HTML document into a string.
-  # @param [Nokogiri::HTML::DocumentFragment] html_doc the HTML document to encode.
-  # @return [String] the encoded HTML string.
-  def encode_content(html_doc)
-    html_doc.to_s
-  end
-
   # Returns the image elements in the given HTML document.
   # @param html_doc [Nokogiri::HTML::DocumentFragment] the HTML document to search.
   # @return [Nokogiri::XML::NodeSet] the image elements.
-  def image_elements(html_doc)
-    html_doc.css 'img'
+  def image_elements(content)
+    case content
+    when Nokogiri::HTML::DocumentFragment then content.css('img')
+    when Hash then content.values.flat_map { |v| image_elements(v) }
+    else raise ArgumentError, "Invalid content type: #{content.class}"
+    end
   end
 
   def content_image_class
@@ -140,12 +154,16 @@ class TextImageService < ContentImageService
     'text_reference'
   end
 
-  def could_include_images?(html_string)
-    html_string.include? code_attribute_for_element
+  def could_include_images?(encoded_content)
+    case encoded_content
+    when String then encoded_content.include?(code_attribute_for_element)
+    when Hash then encoded_content.values.any? { |v| could_include_images?(v) }
+    else raise ArgumentError, "Invalid content type: #{encoded_content.class}"
+    end
   end
 
   def precompute_for_rendering(imageable)
-    @precomputed_text_images = imageable.text_images.index_by do |ti|
+    @precomputed_text_images = TextImage.where(imageable: imageable).index_by do |ti|
       ti[code_attribute_for_model]
     end
   end

--- a/back/app/services/text_image_service.rb
+++ b/back/app/services/text_image_service.rb
@@ -60,23 +60,6 @@ class TextImageService < ContentImageService
     }
   end
 
-  def bulk_create_images!(
-    extracted_images,
-    imageable,
-    field
-  )
-    extracted_images.map do |extracted_image|
-      img_attrs = {
-        imageable: imageable,
-        imageable_field: field,
-        text_reference: extracted_image[:text_reference]
-      }
-      img_attrs[extracted_image[:img_key]] = extracted_image[:img_src]
-
-      TextImage.create!(img_attrs)
-    end
-  end
-
   protected
 
   def decode_content!(content)

--- a/back/app/services/text_image_service.rb
+++ b/back/app/services/text_image_service.rb
@@ -171,4 +171,18 @@ class TextImageService < ContentImageService
   def fetch_content_image(code)
     @precomputed_text_images[code] || content_image_class.find_by(code_attribute_for_model => code)
   end
+
+  class << self
+    private
+
+    def define_association(imageable_class, association_name, field)
+      imageable_class.has_many(
+        association_name,
+        -> { where(imageable_field: field) },
+        as: :imageable,
+        dependent: :destroy,
+        class_name: 'TextImage'
+      )
+    end
+  end
 end

--- a/back/app/services/text_image_service.rb
+++ b/back/app/services/text_image_service.rb
@@ -25,11 +25,7 @@ class TextImageService < ContentImageService
   # to be processed later.
   # Already updates the original content to reference the future image model instead.
   def extract_data_images(encoded_content)
-    content = begin
-      decode_content encoded_content
-    rescue DecodingError => e
-      log_decoding_error e
-    end
+    content = decode_content(encoded_content)
 
     extracted_images = []
 
@@ -87,7 +83,7 @@ class TextImageService < ContentImageService
   # @raise [DecodingError] if the HTML string is not valid.
   # @param html_string [String] the HTML string to decode.
   # @return [Nokogiri::HTML::DocumentFragment] the decoded HTML document.
-  def decode_content(html_string)
+  def decode_content!(html_string)
     html_doc = Nokogiri::HTML.fragment html_string
     raise ContentImageService::DecodingError.new parse_errors: html_doc.errors if html_doc.errors.any?
 

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/importers/project_importer.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/importers/project_importer.rb
@@ -246,23 +246,7 @@ module BulkImportIdeas::Importers
 
         # Create a new project only visible to admins
         project_attributes = project_data.except(:phases, :thumbnail_url)
-
-        # Any images in the description need to be uploaded to our system and refs replaced
-        text_image_service = TextImageService.new
-        extract_output = text_image_service.extract_data_images_multiloc(
-          project_attributes[:description_multiloc]
-        )
-        project_attributes[:description_multiloc] = extract_output[:content_multiloc]
-
-        # Create project
         project = Project.create!(project_attributes)
-
-        # Generate description TextImages
-        text_image_service.bulk_create_images!(
-          extract_output[:extracted_images],
-          project,
-          :description_multiloc
-        )
 
         # Create the project thumbnail image if it exists
         create_project_thumbnail_image(project, project_data)
@@ -306,24 +290,7 @@ module BulkImportIdeas::Importers
         log "Importing phase: '#{phase_attributes[:title_multiloc][@locale]}'"
         begin
           phase_attributes = phase_attributes.merge(project: project)
-
-          # Any images in the description need to be uploaded to our system and refs replaced
-          text_image_service = TextImageService.new
-          extract_output = text_image_service.extract_data_images_multiloc(
-            phase_attributes[:description_multiloc]
-          )
-          phase_attributes[:description_multiloc] = extract_output[:content_multiloc]
-
-          # Create project
           phase = Phase.create!(phase_attributes)
-
-          # Generate description TextImages
-          text_image_service.bulk_create_images!(
-            extract_output[:extracted_images],
-            phase,
-            :description_multiloc
-          )
-
           Permissions::PermissionsUpdateService.new.update_permissions_for_scope(phase)
           log "Created '#{phase.participation_method}' phase"
           phase

--- a/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/idea_custom_fields_controller.rb
+++ b/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/idea_custom_fields_controller.rb
@@ -182,24 +182,11 @@ module IdeaCustomFields
         create_params['key'] = default_field.key
       end
 
-      text_image_service = TextImageService.new
-      extract_output = text_image_service.extract_data_images_multiloc(
-        create_params['description_multiloc']
-      )
-      create_params['description_multiloc'] = extract_output[:content_multiloc]
-
       field = CustomField.new create_params.merge(resource: @custom_form)
 
       SideFxCustomFieldService.new.before_create field, current_user
       if field.save
         page_temp_ids_to_ids_mapping[field_params[:temp_id]] = field.id if field_params[:temp_id]
-
-        text_image_service.bulk_create_images!(
-          extract_output[:extracted_images],
-          field,
-          :description_multiloc
-        )
-
         SideFxCustomFieldService.new.after_create field, current_user
         field
       else

--- a/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/idea_custom_fields_controller.rb
+++ b/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/idea_custom_fields_controller.rb
@@ -202,7 +202,6 @@ module IdeaCustomFields
       field.assign_attributes field_params
       return true unless field.changed?
 
-      SideFxCustomFieldService.new.before_update field, current_user
       if field.save
         SideFxCustomFieldService.new.after_update field, current_user
         field

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/fix_html_multiloc.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/fix_html_multiloc.rake
@@ -77,7 +77,7 @@ namespace :fix_existing_tenants do
     if errors.blank?
       puts 'Success!'
     else
-      puts 'Some issues occured.'
+      puts 'Some issues occurred.'
       errors.each { |err| puts err }
     end
   end
@@ -218,7 +218,7 @@ namespace :fix_existing_tenants do
     if errors.blank?
       puts 'Success!'
     else
-      puts 'Some issues occured.'
+      puts 'Some issues occurred.'
       errors.each { |err| puts err }
     end
   end

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/fix_html_multiloc.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/fix_html_multiloc.rake
@@ -65,7 +65,7 @@ namespace :fix_existing_tenants do
             attributes.each do |attribute|
               instance.send attribute
               begin
-                multiloc = TextImageService.new.swap_data_images_multiloc instance[attribute], field: attribute, imageable: instance
+                multiloc = TextImageService.new.swap_data_images instance[attribute], field: attribute, imageable: instance
                 instance.send :"#{attribute}=", multiloc
                 instance.save!
               rescue StandardError => e
@@ -107,7 +107,7 @@ namespace :fix_existing_tenants do
                 end
                 multiloc[k] = doc.to_s
               end
-              multiloc = TextImageService.new.swap_data_images_multiloc object[attribute], field: attribute, imageable: object
+              multiloc = TextImageService.new.swap_data_images object[attribute], field: attribute, imageable: object
               object.send :"#{attribute}=", multiloc
               object.save!
             end
@@ -204,7 +204,7 @@ namespace :fix_existing_tenants do
 
               instance.update_column(attribute, multiloc)
               begin
-                multiloc = TextImageService.new.swap_data_images_multiloc instance[attribute], field: attribute, imageable: instance
+                multiloc = TextImageService.new.swap_data_images instance[attribute], field: attribute, imageable: instance
                 instance.send :"#{attribute}=", multiloc
                 instance.save!
               rescue StandardError => e

--- a/back/engines/commercial/multi_tenancy/spec/services/multi_tenancy/templates/tenant_serializer_spec.rb
+++ b/back/engines/commercial/multi_tenancy/spec/services/multi_tenancy/templates/tenant_serializer_spec.rb
@@ -171,11 +171,8 @@ describe MultiTenancy::Templates::TenantSerializer do
     end
 
     it 'successfully exports custom field' do
-      description_multiloc = {
-        'en' => '<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" />'
-      }
+      description_multiloc = { 'en' => '<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" />' }
       field = create(:custom_field_page, :for_custom_form, description_multiloc: description_multiloc)
-      field.update! description_multiloc: TextImageService.new.swap_data_images(field.description_multiloc, field: :description_multiloc, imageable: field)
 
       template = tenant_serializer.run(deserializer_format: true)
 

--- a/back/engines/commercial/multi_tenancy/spec/services/multi_tenancy/templates/tenant_serializer_spec.rb
+++ b/back/engines/commercial/multi_tenancy/spec/services/multi_tenancy/templates/tenant_serializer_spec.rb
@@ -175,7 +175,7 @@ describe MultiTenancy::Templates::TenantSerializer do
         'en' => '<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" />'
       }
       field = create(:custom_field_page, :for_custom_form, description_multiloc: description_multiloc)
-      field.update! description_multiloc: TextImageService.new.swap_data_images_multiloc(field.description_multiloc, field: :description_multiloc, imageable: field)
+      field.update! description_multiloc: TextImageService.new.swap_data_images(field.description_multiloc, field: :description_multiloc, imageable: field)
 
       template = tenant_serializer.run(deserializer_format: true)
 

--- a/back/engines/commercial/user_custom_fields/app/controllers/user_custom_fields/web_api/v1/user_custom_fields_controller.rb
+++ b/back/engines/commercial/user_custom_fields/app/controllers/user_custom_fields/web_api/v1/user_custom_fields_controller.rb
@@ -23,25 +23,12 @@ module UserCustomFields
         end
 
         def create
-          params = custom_field_params(CustomField)
-          text_image_service = TextImageService.new
-          extract_output = text_image_service.extract_data_images_multiloc(
-            params[:description_multiloc]
-          )
-          params['description_multiloc'] = extract_output[:content_multiloc]
-
-          @custom_field = CustomField.new params
+          @custom_field = CustomField.new custom_field_params(CustomField)
           @custom_field.resource_type = 'User'
           authorize @custom_field, policy_class: UserCustomFieldPolicy
 
           SideFxCustomFieldService.new.before_create(@custom_field, current_user)
-
           if @custom_field.save
-            text_image_service.bulk_create_images!(
-              extract_output[:extracted_images],
-              @custom_field,
-              :description_multiloc
-            )
             SideFxCustomFieldService.new.after_create(@custom_field, current_user)
             render json: serialize_custom_fields(@custom_field, params: jsonapi_serializer_params_with_locked_fields), status: :created
           else
@@ -52,7 +39,7 @@ module UserCustomFields
         def update
           @custom_field.assign_attributes custom_field_params(@custom_field)
           authorize @custom_field, policy_class: UserCustomFieldPolicy
-          SideFxCustomFieldService.new.before_update @custom_field, current_user
+
           if @custom_field.save
             SideFxCustomFieldService.new.after_update(@custom_field, current_user)
             render json: serialize_custom_fields(@custom_field.reload, params: jsonapi_serializer_params_with_locked_fields), status: :ok

--- a/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/content_configurable.rb
+++ b/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/content_configurable.rb
@@ -73,7 +73,7 @@ module EmailCampaigns
     end
 
     def process_images(multiloc)
-      processed_multiloc = TextImageService.new.swap_data_images_multiloc self[multiloc], field: multiloc, imageable: self
+      processed_multiloc = TextImageService.new.swap_data_images self[multiloc], field: multiloc, imageable: self
       update_column multiloc, processed_multiloc
     end
 

--- a/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/content_configurable.rb
+++ b/back/engines/free/email_campaigns/app/models/concerns/email_campaigns/content_configurable.rb
@@ -10,7 +10,6 @@ module EmailCampaigns
       with_options if: :manual? do
         validates :body_multiloc, presence: true, multiloc: { presence: true, html: true }
         before_validation :sanitize_body_multiloc
-        after_save :process_body_images
       end
 
       # Automated campaigns only.
@@ -20,7 +19,6 @@ module EmailCampaigns
         validates :button_text_multiloc, multiloc: { presence: true }, if: :editable_button_text?
         before_validation :sanitize_intro_multiloc
         before_validation :reject_default_region_values
-        after_save :process_intro_images
       end
     end
 
@@ -72,27 +70,14 @@ module EmailCampaigns
       self[multiloc] = value
     end
 
-    def process_images(multiloc)
-      processed_multiloc = TextImageService.new.swap_data_images self[multiloc], field: multiloc, imageable: self
-      update_column multiloc, processed_multiloc
-    end
-
     # Methods for manual campaigns
     def sanitize_body_multiloc
       sanitize_multiloc(:body_multiloc, %i[title alignment list decoration link image video])
     end
 
-    def process_body_images
-      process_images(:body_multiloc)
-    end
-
     # Methods for automated campaigns
     def sanitize_intro_multiloc
       sanitize_multiloc(:intro_multiloc, %i[alignment list decoration link image video])
-    end
-
-    def process_intro_images
-      process_images(:intro_multiloc)
     end
 
     def merge_default_region_values(region_key)

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaign.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaign.rb
@@ -34,6 +34,8 @@
 #
 module EmailCampaigns
   class Campaign < ApplicationRecord
+    include Imageable
+
     belongs_to :author, class_name: 'User', optional: true
     belongs_to :context, polymorphic: true, optional: true
     has_many :examples, class_name: 'EmailCampaigns::Example', dependent: :destroy
@@ -45,6 +47,8 @@ module EmailCampaigns
     # ContentConfigurable concern.
     has_many :text_images, as: :imageable, dependent: :destroy
     accepts_nested_attributes_for :text_images
+    has_many_text_images from: :body_multiloc, as: :body_text_images
+    has_many_text_images from: :intro_multiloc, as: :intro_text_images
 
     before_validation :set_enabled, on: :create
 

--- a/back/engines/free/email_campaigns/spec/acceptance/campaigns_spec.rb
+++ b/back/engines/free/email_campaigns/spec/acceptance/campaigns_spec.rb
@@ -248,6 +248,33 @@ resource 'Campaigns' do
           expect(json_response.dig(:data, :relationships, :author, :data, :id)).to eq @user.id
           expect(json_response.dig(:data, :relationships, :groups, :data).pluck(:id)).to eq group_ids
         end
+
+        context 'when body contains images' do
+          let(:body_multiloc) { { 'en' => html_with_base64_image } }
+
+          example 'Create a manual campaign with body containing images', document: false do
+            expect { do_request }.to change(TextImage, :count).by(1)
+
+            assert_status 201
+
+            campaign = EmailCampaigns::Campaign.find(json_response_body.dig(:data, :id))
+
+            text_image = TextImage.find_sole_by(
+              imageable: campaign,
+              imageable_type: 'EmailCampaigns::Campaign',
+              imageable_field: 'body_multiloc'
+            )
+
+            expect(campaign.body_multiloc['en']).not_to include('data:image/png;base64')
+            expect(campaign.body_multiloc['en']).to include(%(data-cl2-text-image-text-reference="#{text_image.text_reference}"))
+            expect(campaign.body_multiloc['en']).not_to include(' src="')
+
+            body = response_data.dig(:attributes, :body_multiloc, :en)
+            expect(body).not_to include('data:image/png;base64')
+            expect(body).to include(%(data-cl2-text-image-text-reference="#{text_image.text_reference}"))
+            expect(body).to include(' src="')
+          end
+        end
       end
     end
 
@@ -407,6 +434,33 @@ resource 'Campaigns' do
             example_request 'Disable the campaign' do
               assert_status 200
               expect(campaign.reload.enabled).to be false
+            end
+          end
+
+          context 'when intro contains images' do
+            let(:intro_multiloc) { { 'en' => html_with_base64_image } }
+
+            example 'Update automated campaign intro with images', document: false do
+              expect { do_request }.to change(TextImage, :count).by(1)
+
+              assert_status 200
+
+              campaign = EmailCampaigns::Campaign.find(json_response_body.dig(:data, :id))
+
+              text_image = TextImage.find_sole_by(
+                imageable: campaign,
+                imageable_type: 'EmailCampaigns::Campaign',
+                imageable_field: 'intro_multiloc'
+              )
+
+              expect(campaign.intro_multiloc['en']).not_to include('data:image/png;base64')
+              expect(campaign.intro_multiloc['en']).to include(%(data-cl2-text-image-text-reference="#{text_image.text_reference}"))
+              expect(campaign.intro_multiloc['en']).not_to include(' src="')
+
+              intro = response_data.dig(:attributes, :intro_multiloc, :en)
+              expect(intro).not_to include('data:image/png;base64')
+              expect(intro).to include(%(data-cl2-text-image-text-reference="#{text_image.text_reference}"))
+              expect(intro).to include(' src="')
             end
           end
         end

--- a/back/engines/free/email_campaigns/spec/acceptance/campaigns_spec.rb
+++ b/back/engines/free/email_campaigns/spec/acceptance/campaigns_spec.rb
@@ -252,28 +252,9 @@ resource 'Campaigns' do
         context 'when body contains images' do
           let(:body_multiloc) { { 'en' => html_with_base64_image } }
 
-          example 'Create a manual campaign with body containing images', document: false do
-            expect { do_request }.to change(TextImage, :count).by(1)
-
-            assert_status 201
-
-            campaign = EmailCampaigns::Campaign.find(json_response_body.dig(:data, :id))
-
-            text_image = TextImage.find_sole_by(
-              imageable: campaign,
-              imageable_type: 'EmailCampaigns::Campaign',
-              imageable_field: 'body_multiloc'
-            )
-
-            expect(campaign.body_multiloc['en']).not_to include('data:image/png;base64')
-            expect(campaign.body_multiloc['en']).to include(%(data-cl2-text-image-text-reference="#{text_image.text_reference}"))
-            expect(campaign.body_multiloc['en']).not_to include(' src="')
-
-            body = response_data.dig(:attributes, :body_multiloc, :en)
-            expect(body).not_to include('data:image/png;base64')
-            expect(body).to include(%(data-cl2-text-image-text-reference="#{text_image.text_reference}"))
-            expect(body).to include(' src="')
-          end
+          it_behaves_like 'creates record with text images',
+            model_class: EmailCampaigns::Campaign,
+            field: :body_multiloc
         end
       end
     end
@@ -390,6 +371,14 @@ resource 'Campaigns' do
           expect(json_response.dig(:data, :relationships, :author, :data, :id)).to eq campaign.author_id
           expect(json_response.dig(:data, :relationships, :groups, :data).pluck(:id)).to eq group_ids
         end
+
+        context 'when body contains images' do
+          let(:body_multiloc) { { 'en' => html_with_base64_image } }
+
+          it_behaves_like 'updates record with text images',
+            model_class: EmailCampaigns::Campaign,
+            field: :body_multiloc
+        end
       end
 
       context 'global campaigns' do
@@ -440,28 +429,10 @@ resource 'Campaigns' do
           context 'when intro contains images' do
             let(:intro_multiloc) { { 'en' => html_with_base64_image } }
 
-            example 'Update automated campaign intro with images', document: false do
-              expect { do_request }.to change(TextImage, :count).by(1)
-
-              assert_status 200
-
-              campaign = EmailCampaigns::Campaign.find(json_response_body.dig(:data, :id))
-
-              text_image = TextImage.find_sole_by(
-                imageable: campaign,
-                imageable_type: 'EmailCampaigns::Campaign',
-                imageable_field: 'intro_multiloc'
-              )
-
-              expect(campaign.intro_multiloc['en']).not_to include('data:image/png;base64')
-              expect(campaign.intro_multiloc['en']).to include(%(data-cl2-text-image-text-reference="#{text_image.text_reference}"))
-              expect(campaign.intro_multiloc['en']).not_to include(' src="')
-
-              intro = response_data.dig(:attributes, :intro_multiloc, :en)
-              expect(intro).not_to include('data:image/png;base64')
-              expect(intro).to include(%(data-cl2-text-image-text-reference="#{text_image.text_reference}"))
-              expect(intro).to include(' src="')
-            end
+            it_behaves_like 'updates record with text images',
+              model_class: EmailCampaigns::Campaign,
+              field: :intro_multiloc,
+              locale: :en
           end
         end
       end

--- a/back/spec/acceptance/events_spec.rb
+++ b/back/spec/acceptance/events_spec.rb
@@ -416,25 +416,17 @@ resource 'Events' do
         end
       end
 
-      describe 'when event description contains images' do
+      context 'when event description contains images' do
         let(:project_id) { @project.id }
         let(:title_multiloc) { event.title_multiloc }
-        let(:description_multiloc) do
-          {
-            'en' => html_with_base64_image
-          }
-        end
+        let(:description_multiloc) { { 'en' => html_with_base64_image } }
         let(:start_at) { event.start_at }
         let(:end_at) { event.end_at }
         let(:online_link) { event.online_link }
 
-        example_request 'Create an event with description containing images', document: false do
-          assert_status 201
-          json_parse(response_body)
-          expect(response_data.dig(:attributes, :description_multiloc, :en)).to include('<p>Some text</p><img alt="Red dot"')
-          text_image = TextImage.find_by(imageable_id: response_data[:id], imageable_type: 'Event', imageable_field: 'description_multiloc')
-          expect(response_data.dig(:attributes, :description_multiloc, :en)).to include("data-cl2-text-image-text-reference=\"#{text_image.text_reference}\"")
-        end
+        it_behaves_like 'creates record with text images',
+          model_class: Event,
+          field: :description_multiloc
       end
 
       example 'Create an event with a location using location_multiloc parameter', document: false do
@@ -542,6 +534,14 @@ resource 'Events' do
         attributes = response_data[:attributes].with_indifferent_access
         expect(attributes[:address_1]).to eq(address_1)
         expect(attributes[:address_2_multiloc]).to eq(address_2_multiloc)
+      end
+
+      context 'when description_multiloc contains images' do
+        let(:description_multiloc) { { 'en' => html_with_base64_image } }
+
+        it_behaves_like 'updates record with text images',
+          model_class: Event,
+          field: :description_multiloc
       end
 
       example 'Update event location using location_multiloc parameter', document: false do

--- a/back/spec/acceptance/ideas/ideas_create_spec.rb
+++ b/back/spec/acceptance/ideas/ideas_create_spec.rb
@@ -91,26 +91,12 @@ resource 'Ideas' do
           expect(response_data[:attributes][:likes_count]).to eq 1
         end
 
-        describe 'when idea has images in body_multiloc', document: false do
-          let(:body_multiloc) do
-            {
-              'en' => html_with_base64_image
-            }
-          end
-          let(:idea) { build(:idea, body_multiloc: body_multiloc) }
+        context 'when idea has images in body_multiloc' do
+          let(:body_multiloc) { { 'en' => html_with_base64_image } }
 
-          example 'Removes images from body_multiloc and creates idea_images', document: false do
-            do_request
-            assert_status 201
-            expect(response_data.dig(:attributes, :body_multiloc, :en)).to include('<p>Some text</p><img alt="Red dot"')
-            text_image = TextImage.find_by(imageable_id: response_data[:id], imageable_type: 'Idea', imageable_field: 'body_multiloc')
-            expect(response_data.dig(:attributes, :body_multiloc, :en)).to include("data-cl2-text-image-text-reference=\"#{text_image.text_reference}\"")
-            expect(TextImage.count).to eq 1
-            image = TextImage.last
-            expect(image.imageable_id).to eq response_data[:id]
-            expect(image.imageable_type).to eq 'Idea'
-            expect(image.imageable_field).to eq 'body_multiloc'
-          end
+          it_behaves_like 'creates record with text images',
+            model_class: Idea,
+            field: :body_multiloc
         end
 
         describe 'Values for disabled fields are ignored' do

--- a/back/spec/acceptance/ideas/ideas_update_spec.rb
+++ b/back/spec/acceptance/ideas/ideas_update_spec.rb
@@ -71,6 +71,14 @@ resource 'Ideas' do
           end
         end
 
+        context 'when body_multiloc contains images' do
+          let(:body_multiloc) { { 'en' => html_with_base64_image } }
+
+          it_behaves_like 'updates record with text images',
+            model_class: Idea,
+            field: :body_multiloc
+        end
+
         describe do
           let(:idea_status_id) { create(:idea_status).id }
 

--- a/back/spec/acceptance/phases_spec.rb
+++ b/back/spec/acceptance/phases_spec.rb
@@ -615,6 +615,14 @@ resource 'Phases' do
         expect(json_response.dig(:data, :attributes, :similarity_threshold_body)).to eq similarity_threshold_body
       end
 
+      context 'when description_multiloc contains images' do
+        let(:description_multiloc) { { 'en' => html_with_base64_image } }
+
+        it_behaves_like 'updates record with text images',
+          model_class: Phase,
+          field: :description_multiloc
+      end
+
       describe do
         with_options scope: :phase do
           parameter :expire_days_limit, 'Default value for how many days a proposal has to meet the voting threshold and move to the next stage.'

--- a/back/spec/acceptance/project_folders_spec.rb
+++ b/back/spec/acceptance/project_folders_spec.rb
@@ -179,20 +179,12 @@ resource 'ProjectFolder' do
         expect(json_response[:included].find { |inc| inc[:type] == 'admin_publication' }.dig(:attributes, :ordering)).to eq 0
       end
 
-      describe 'when the folder description contains images' do
-        let(:description_multiloc) do
-          {
-            'en' => html_with_base64_image
-          }
-        end
+      context 'when the folder description contains images' do
+        let(:description_multiloc) { { 'en' => html_with_base64_image } }
 
-        example_request 'Create a folder with images in the description', document: false do
-          assert_status 201
-          json_parse(response_body)
-          expect(response_data.dig(:attributes, :description_multiloc, :en)).to include('<p>Some text</p><img alt="Red dot"')
-          text_image = TextImage.find_by(imageable_id: response_data[:id], imageable_type: 'ProjectFolders::Folder', imageable_field: 'description_multiloc')
-          expect(response_data.dig(:attributes, :description_multiloc, :en)).to include("data-cl2-text-image-text-reference=\"#{text_image.text_reference}\"")
-        end
+        it_behaves_like 'creates record with text images',
+          model_class: ProjectFolders::Folder,
+          field: :description_multiloc
       end
     end
 
@@ -225,6 +217,14 @@ resource 'ProjectFolder' do
         expect(json_response.dig(:data, :attributes, :title_multiloc).stringify_keys).to match title_multiloc
         expect(json_response.dig(:data, :attributes, :description_multiloc).stringify_keys).to match description_multiloc
         expect(json_response[:included].find { |inc| inc[:type] == 'admin_publication' }.dig(:attributes, :publication_status)).to eq 'archived'
+      end
+
+      context 'when description_multiloc contains images' do
+        let(:description_multiloc) { { 'en' => html_with_base64_image } }
+
+        it_behaves_like 'updates record with text images',
+          model_class: ProjectFolders::Folder,
+          field: :description_multiloc
       end
 
       describe do

--- a/back/spec/acceptance/projects_spec.rb
+++ b/back/spec/acceptance/projects_spec.rb
@@ -340,20 +340,12 @@ resource 'Projects' do
                  end.dig(:attributes, :ordering)).to eq 0
         end
 
-        describe 'when project description contains text images' do
-          let(:description_multiloc) do
-            {
-              'en' => html_with_base64_image
-            }
-          end
+        context 'when project description contains text images' do
+          let(:description_multiloc) { { 'en' => html_with_base64_image } }
 
-          example_request 'Create a project with description containing images', document: false do
-            assert_status 201
-            json_parse(response_body)
-            expect(response_data.dig(:attributes, :description_multiloc, :en)).to include('<p>Some text</p><img alt="Red dot"')
-            text_image = TextImage.find_by(imageable_id: response_data[:id], imageable_type: 'Project', imageable_field: 'description_multiloc')
-            expect(response_data.dig(:attributes, :description_multiloc, :en)).to include("data-cl2-text-image-text-reference=\"#{text_image.text_reference}\"")
-          end
+          it_behaves_like 'creates record with text images',
+            model_class: Project,
+            field: :description_multiloc
         end
       end
     end
@@ -456,6 +448,14 @@ resource 'Projects' do
         @project.update!(default_assignee: create(:admin))
         do_request(project: { default_assignee_id: nil })
         expect(json_response.dig(:data, :relationships, :default_assignee, :data, :id)).to be_nil
+      end
+
+      context 'when description_multiloc contains images' do
+        let(:description_multiloc) { { 'en' => html_with_base64_image } }
+
+        it_behaves_like 'updates record with text images',
+          model_class: Project,
+          field: :description_multiloc
       end
 
       describe do

--- a/back/spec/acceptance/static_pages_spec.rb
+++ b/back/spec/acceptance/static_pages_spec.rb
@@ -254,20 +254,12 @@ resource 'StaticPages' do
         end
       end
 
-      describe 'when bottom section contains images', document: false do
-        let(:bottom_info_section_multiloc) do
-          {
-            'en' => html_with_base64_image
-          }
-        end
+      context 'when bottom section contains images' do
+        let(:bottom_info_section_multiloc) { { 'en' => html_with_base64_image } }
 
-        example_request 'Create a static page with bottom section containing images', document: false do
-          assert_status 201
-          json_parse(response_body)
-          expect(response_data.dig(:attributes, :bottom_info_section_multiloc, :en)).to include('<p>Some text</p><img alt="Red dot"')
-          text_image = TextImage.find_by(imageable_id: response_data[:id], imageable_type: 'StaticPage', imageable_field: 'bottom_info_section_multiloc')
-          expect(response_data.dig(:attributes, :bottom_info_section_multiloc, :en)).to include("data-cl2-text-image-text-reference=\"#{text_image.text_reference}\"")
-        end
+        it_behaves_like 'creates record with text images',
+          model_class: StaticPage,
+          field: :bottom_info_section_multiloc
       end
     end
 

--- a/back/spec/models/idea_spec.rb
+++ b/back/spec/models/idea_spec.rb
@@ -632,10 +632,11 @@ RSpec.describe Idea do
     end
 
     it 'sanitizes img tags in the body' do
-      idea = create(:idea, body_multiloc: {
-        'en' => 'Something <img src=x onerror=alert(1)>'
-      })
-      expect(idea.body_multiloc).to eq({ 'en' => 'Something <img src="x">' })
+      ti_service = instance_double(TextImageService).as_null_object
+      allow(TextImageService).to receive(:new).and_return(ti_service)
+
+      idea = create(:idea, body_multiloc: { 'en' => '... <img src=x onerror=alert(1)>' })
+      expect(idea.body_multiloc).to match('en' => '... <img src="x">')
     end
 
     it "allows embedded youtube video's in the body" do

--- a/back/spec/services/content_image_service_spec.rb
+++ b/back/spec/services/content_image_service_spec.rb
@@ -70,19 +70,19 @@ describe ContentImageService do
   let(:service) { subclass.new }
   let(:text_images) { create_list(:text_image, 2) }
 
-  describe 'swap_data_images_multiloc' do
+  describe 'swap_data_images' do
     before { allow(TextImage).to receive(:create!).and_return(text_images[0], text_images[1]) }
 
     it 'returns exactly the same input locales' do
       imageable = build(:user, bio_multiloc: { 'en' => '[]', 'fr-BE' => '[]', 'nl-BE' => '[]', 'de' => '[]' })
-      output = service.swap_data_images_multiloc imageable.bio_multiloc, field: :bio_multiloc
+      output = service.swap_data_images imageable.bio_multiloc, field: :bio_multiloc
       expect(output.keys).to match_array %w[en fr-BE nl-BE de]
     end
 
     it 'returns the same multiloc when no images are included' do
       json_str = '[{"type":"furniture"},{"type":"text","value":"My awesome text"}]'
       imageable = build(:user, bio_multiloc: { 'fr-BE' => json_str })
-      output = service.swap_data_images_multiloc imageable.bio_multiloc, field: :bio_multiloc
+      output = service.swap_data_images imageable.bio_multiloc, field: :bio_multiloc
       expect(output).to eq({ 'fr-BE' => json_str })
     end
 
@@ -97,7 +97,7 @@ describe ContentImageService do
       ].to_json
 
       imageable = build(:user, bio_multiloc: { 'nl-BE' => json_str })
-      output = service.swap_data_images_multiloc imageable.bio_multiloc, field: :bio_multiloc
+      output = service.swap_data_images imageable.bio_multiloc, field: :bio_multiloc
       expect(output).to eq({ 'nl-BE' => expected_json })
       expect(TextImage).to have_received(:create!).twice
     end
@@ -112,7 +112,7 @@ describe ContentImageService do
 
       imageable = build(:user, bio_multiloc: { 'en' => json_str })
       output = nil
-      expect { output = service.swap_data_images_multiloc imageable.bio_multiloc, field: :bio_multiloc }.not_to(change(TextImage, :count))
+      expect { output = service.swap_data_images imageable.bio_multiloc, field: :bio_multiloc }.not_to(change(TextImage, :count))
       expect(output).to eq({ 'en' => expected_json })
     end
 
@@ -120,7 +120,7 @@ describe ContentImageService do
       json_str = '[{"type":"image"}]'
       imageable = build(:user, bio_multiloc: { 'de' => json_str })
       output = nil
-      expect { output = service.swap_data_images_multiloc imageable.bio_multiloc, field: :bio_multiloc }.not_to(change(TextImage, :count))
+      expect { output = service.swap_data_images imageable.bio_multiloc, field: :bio_multiloc }.not_to(change(TextImage, :count))
       expect(output).to eq({ 'de' => json_str })
     end
   end

--- a/back/spec/services/project_copy_service_spec.rb
+++ b/back/spec/services/project_copy_service_spec.rb
@@ -86,7 +86,7 @@ describe ProjectCopyService do
         'en' => '<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" />'
       }
       field = create(:custom_field, :for_custom_form, description_multiloc: description_multiloc)
-      field.update! description_multiloc: TextImageService.new.swap_data_images_multiloc(field.description_multiloc, field: :description_multiloc, imageable: field)
+      field.update! description_multiloc: TextImageService.new.swap_data_images(field.description_multiloc, field: :description_multiloc, imageable: field)
 
       template = service.export field.resource.participation_context
 

--- a/back/spec/services/project_copy_service_spec.rb
+++ b/back/spec/services/project_copy_service_spec.rb
@@ -82,11 +82,8 @@ describe ProjectCopyService do
     end
 
     it 'successfully exports custom field text images' do
-      description_multiloc = {
-        'en' => '<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" />'
-      }
+      description_multiloc = { 'en' => '<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" />' }
       field = create(:custom_field, :for_custom_form, description_multiloc: description_multiloc)
-      field.update! description_multiloc: TextImageService.new.swap_data_images(field.description_multiloc, field: :description_multiloc, imageable: field)
 
       template = service.export field.resource.participation_context
 

--- a/back/spec/services/project_folders/side_fx_project_folder_service_spec.rb
+++ b/back/spec/services/project_folders/side_fx_project_folder_service_spec.rb
@@ -23,16 +23,6 @@ describe ProjectFolders::SideFxProjectFolderService do
     end
   end
 
-  describe 'before_update' do
-    it 'runs the description through the text image service' do
-      expect_any_instance_of(TextImageService)
-        .to receive(:swap_data_images)
-        .with(project_folder.description_multiloc, field: :description_multiloc, imageable: project_folder)
-        .and_return(project_folder.description_multiloc)
-      service.before_update(project_folder, user)
-    end
-  end
-
   describe 'after_update' do
     it "logs a 'changed' action job when the folder has changed" do
       old_title_multiloc = project_folder.title_multiloc

--- a/back/spec/services/project_folders/side_fx_project_folder_service_spec.rb
+++ b/back/spec/services/project_folders/side_fx_project_folder_service_spec.rb
@@ -26,7 +26,7 @@ describe ProjectFolders::SideFxProjectFolderService do
   describe 'before_update' do
     it 'runs the description through the text image service' do
       expect_any_instance_of(TextImageService)
-        .to receive(:swap_data_images_multiloc)
+        .to receive(:swap_data_images)
         .with(project_folder.description_multiloc, field: :description_multiloc, imageable: project_folder)
         .and_return(project_folder.description_multiloc)
       service.before_update(project_folder, user)

--- a/back/spec/services/side_fx_custom_field_service_spec.rb
+++ b/back/spec/services/side_fx_custom_field_service_spec.rb
@@ -7,15 +7,6 @@ describe SideFxCustomFieldService do
   let(:user) { create(:user) }
   let(:field) { create(:custom_field) }
 
-  describe 'before_update' do
-    it 'swaps the text images' do
-      expect_any_instance_of(TextImageService).to(
-        receive(:swap_data_images).with(field.description_multiloc, field: :description_multiloc, imageable: field).and_return(field.description_multiloc)
-      )
-      service.before_update field, user
-    end
-  end
-
   describe 'before_delete' do
     let(:custom_field) { create(:custom_field, :for_custom_form, input_type: 'select') }
     let!(:user1) { create(:user, custom_field_values: { custom_field.key => 'option_1' }) }

--- a/back/spec/services/side_fx_custom_field_service_spec.rb
+++ b/back/spec/services/side_fx_custom_field_service_spec.rb
@@ -10,7 +10,7 @@ describe SideFxCustomFieldService do
   describe 'before_update' do
     it 'swaps the text images' do
       expect_any_instance_of(TextImageService).to(
-        receive(:swap_data_images_multiloc).with(field.description_multiloc, field: :description_multiloc, imageable: field).and_return(field.description_multiloc)
+        receive(:swap_data_images).with(field.description_multiloc, field: :description_multiloc, imageable: field).and_return(field.description_multiloc)
       )
       service.before_update field, user
     end

--- a/back/spec/services/side_fx_event_spec.rb
+++ b/back/spec/services/side_fx_event_spec.rb
@@ -17,7 +17,7 @@ describe SideFxEventService do
 
   describe 'before_update' do
     it 'runs the description through the text image service' do
-      expect_any_instance_of(TextImageService).to receive(:swap_data_images_multiloc).with(event.description_multiloc, field: :description_multiloc, imageable: event).and_return(event.description_multiloc)
+      expect_any_instance_of(TextImageService).to receive(:swap_data_images).with(event.description_multiloc, field: :description_multiloc, imageable: event).and_return(event.description_multiloc)
       service.before_update(event, user)
     end
   end

--- a/back/spec/services/side_fx_event_spec.rb
+++ b/back/spec/services/side_fx_event_spec.rb
@@ -15,13 +15,6 @@ describe SideFxEventService do
     end
   end
 
-  describe 'before_update' do
-    it 'runs the description through the text image service' do
-      expect_any_instance_of(TextImageService).to receive(:swap_data_images).with(event.description_multiloc, field: :description_multiloc, imageable: event).and_return(event.description_multiloc)
-      service.before_update(event, user)
-    end
-  end
-
   describe 'after_update' do
     it "logs a 'changed' action job when the event has changed" do
       event.update(title_multiloc: { en: 'changed' })

--- a/back/spec/services/side_fx_phase_spec.rb
+++ b/back/spec/services/side_fx_phase_spec.rb
@@ -28,7 +28,7 @@ describe SideFxPhaseService do
 
   describe 'before_update' do
     it 'runs the description through the text image service' do
-      expect_any_instance_of(TextImageService).to receive(:swap_data_images_multiloc).with(phase.description_multiloc, field: :description_multiloc, imageable: phase).and_return(phase.description_multiloc)
+      expect_any_instance_of(TextImageService).to receive(:swap_data_images).with(phase.description_multiloc, field: :description_multiloc, imageable: phase).and_return(phase.description_multiloc)
       service.before_update(phase, user)
     end
   end

--- a/back/spec/services/side_fx_phase_spec.rb
+++ b/back/spec/services/side_fx_phase_spec.rb
@@ -26,13 +26,6 @@ describe SideFxPhaseService do
     it { expect { service.after_create(phase, user) }.to have_enqueued_job(Surveys::WebhookManagerJob) }
   end
 
-  describe 'before_update' do
-    it 'runs the description through the text image service' do
-      expect_any_instance_of(TextImageService).to receive(:swap_data_images).with(phase.description_multiloc, field: :description_multiloc, imageable: phase).and_return(phase.description_multiloc)
-      service.before_update(phase, user)
-    end
-  end
-
   describe 'after_update' do
     it "logs a 'changed' action job when the phase has changed" do
       phase.update(title_multiloc: { en: 'changed' })

--- a/back/spec/services/side_fx_project_service_spec.rb
+++ b/back/spec/services/side_fx_project_service_spec.rb
@@ -38,13 +38,6 @@ describe SideFxProjectService do
     end
   end
 
-  describe 'before_update' do
-    it 'runs the description through the text image service' do
-      expect_any_instance_of(TextImageService).to receive(:swap_data_images).with(project.description_multiloc, field: :description_multiloc, imageable: project).and_return(project.description_multiloc)
-      service.before_update(project, user)
-    end
-  end
-
   describe 'after_update' do
     it "logs a 'changed' action job when the project has changed" do
       service.before_update(project, user)

--- a/back/spec/services/side_fx_project_service_spec.rb
+++ b/back/spec/services/side_fx_project_service_spec.rb
@@ -40,7 +40,7 @@ describe SideFxProjectService do
 
   describe 'before_update' do
     it 'runs the description through the text image service' do
-      expect_any_instance_of(TextImageService).to receive(:swap_data_images_multiloc).with(project.description_multiloc, field: :description_multiloc, imageable: project).and_return(project.description_multiloc)
+      expect_any_instance_of(TextImageService).to receive(:swap_data_images).with(project.description_multiloc, field: :description_multiloc, imageable: project).and_return(project.description_multiloc)
       service.before_update(project, user)
     end
   end

--- a/back/spec/services/side_fx_static_page_spec.rb
+++ b/back/spec/services/side_fx_static_page_spec.rb
@@ -14,16 +14,6 @@ describe SideFxStaticPageService do
     end
   end
 
-  describe 'before_update' do
-    it 'runs runs both info sections through the text image service' do
-      obj = instance_double(TextImageService)
-      allow(TextImageService).to receive(:new).and_return(obj)
-      expect(obj).to receive(:swap_data_images).with(page.top_info_section_multiloc, field: :top_info_section_multiloc, imageable: page).and_return(page.top_info_section_multiloc)
-      expect(obj).to receive(:swap_data_images).with(page.bottom_info_section_multiloc, field: :bottom_info_section_multiloc, imageable: page).and_return(page.bottom_info_section_multiloc)
-      service.before_update(page, user)
-    end
-  end
-
   describe 'after_update' do
     it "logs a 'changed' action job when the page has changed" do
       page.update!(title_multiloc: { 'en' => 'changed' })

--- a/back/spec/services/side_fx_static_page_spec.rb
+++ b/back/spec/services/side_fx_static_page_spec.rb
@@ -18,8 +18,8 @@ describe SideFxStaticPageService do
     it 'runs runs both info sections through the text image service' do
       obj = instance_double(TextImageService)
       allow(TextImageService).to receive(:new).and_return(obj)
-      expect(obj).to receive(:swap_data_images_multiloc).with(page.top_info_section_multiloc, field: :top_info_section_multiloc, imageable: page).and_return(page.top_info_section_multiloc)
-      expect(obj).to receive(:swap_data_images_multiloc).with(page.bottom_info_section_multiloc, field: :bottom_info_section_multiloc, imageable: page).and_return(page.bottom_info_section_multiloc)
+      expect(obj).to receive(:swap_data_images).with(page.top_info_section_multiloc, field: :top_info_section_multiloc, imageable: page).and_return(page.top_info_section_multiloc)
+      expect(obj).to receive(:swap_data_images).with(page.bottom_info_section_multiloc, field: :bottom_info_section_multiloc, imageable: page).and_return(page.bottom_info_section_multiloc)
       service.before_update(page, user)
     end
   end

--- a/back/spec/services/text_image_service_spec.rb
+++ b/back/spec/services/text_image_service_spec.rb
@@ -34,6 +34,23 @@ describe TextImageService do
       imageable = build(:project, description_multiloc: { 'en' => input })
       expect(service.swap_data_images_multiloc(imageable.description_multiloc, field: :description_multiloc, imageable: imageable)).to eq({ 'en' => input })
     end
+
+    # It's more of a side effect; what really matters is that it doesn't fail when some
+    # values are nil.
+    it 'converts nil values in multiloc to empty strings' do
+      imageable = build(:project, description_multiloc: {
+        'nl-BE' => nil,
+        'en' => '<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7">'
+      })
+
+      output = service.swap_data_images imageable.description_multiloc, field: :description_multiloc, imageable: imageable
+      text_image = imageable.text_images.order(:created_at).first
+
+      expect(output).to match(
+        'en' => %(<img data-cl2-text-image-text-reference="#{text_image.text_reference}">),
+        'nl-BE' => ''
+      )
+    end
   end
 
   describe 'extract_data_images_multiloc' do

--- a/back/spec/services/text_image_service_spec.rb
+++ b/back/spec/services/text_image_service_spec.rb
@@ -93,36 +93,6 @@ describe TextImageService do
     end
   end
 
-  describe 'bulk_create_images!' do
-    before do
-      stub_request(:any, 'res.cloudinary.com').to_return(
-        body: png_image_as_base64('image10.jpg')
-      )
-    end
-
-    it 'processes both base64 and URL as src' do
-      input = <<~HTML
-        <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7">
-        <img src="data:image/jpeg;base64,/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=" />
-        <img src="https://cl2-seed-and-template-assets.s3.eu-central-1.amazonaws.com/images/people_with_speech_bubbles.jpeg" />
-      HTML
-      imageable = build(:idea, body_multiloc: { 'fr-BE' => input })
-      extracted_images = service.extract_data_images_multiloc(imageable.body_multiloc)[:extracted_images]
-
-      images = service.bulk_create_images!(
-        extracted_images,
-        imageable,
-        :body_multiloc
-      )
-
-      expect(TextImage.count).to eq(3)
-      expect(images.count).to eq(3)
-      expect(TextImage.all.map(&:text_reference).sort).to eq(
-        images.map { |img| img[:text_reference] }.sort
-      )
-    end
-  end
-
   describe 'render_data_images_multiloc' do
     it 'adds src attributes to the img tags' do
       text_image1, text_image2 = create_list(:text_image, 2)

--- a/back/spec/services/text_image_service_spec.rb
+++ b/back/spec/services/text_image_service_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe TextImageService do
   let(:service) { described_class.new }
 
-  describe 'swap_data_images_multiloc' do
+  describe 'swap_data_images' do
     before do
       stub_request(:any, 'res.cloudinary.com').to_return(
         body: png_image_as_base64('image10.jpg')
@@ -19,7 +19,7 @@ describe TextImageService do
         <img src="https://cl2-seed-and-template-assets.s3.eu-central-1.amazonaws.com/images/people_with_speech_bubbles.jpeg" />
       HTML
       imageable = build(:project, description_multiloc: { 'fr-BE' => input })
-      output = service.swap_data_images_multiloc imageable.description_multiloc, field: :description_multiloc, imageable: imageable
+      output = service.swap_data_images imageable.description_multiloc, field: :description_multiloc, imageable: imageable
       codes = imageable.reload.text_images.order(:created_at).pluck :text_reference
       expected_html = <<~HTML
         <img data-cl2-text-image-text-reference="#{codes[0]}">
@@ -32,7 +32,7 @@ describe TextImageService do
     it 'does not modify the empty string' do
       input = ''
       imageable = build(:project, description_multiloc: { 'en' => input })
-      expect(service.swap_data_images_multiloc(imageable.description_multiloc, field: :description_multiloc, imageable: imageable)).to eq({ 'en' => input })
+      expect(service.swap_data_images(imageable.description_multiloc, field: :description_multiloc, imageable: imageable)).to eq({ 'en' => input })
     end
 
     # It's more of a side effect; what really matters is that it doesn't fail when some

--- a/back/spec/services/text_image_service_spec.rb
+++ b/back/spec/services/text_image_service_spec.rb
@@ -18,7 +18,7 @@ describe TextImageService do
         <img src="data:image/jpeg;base64,/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=" />
         <img src="https://cl2-seed-and-template-assets.s3.eu-central-1.amazonaws.com/images/people_with_speech_bubbles.jpeg" />
       HTML
-      imageable = build(:project, description_multiloc: { 'fr-BE' => input })
+      imageable = create(:project, description_multiloc: { 'fr-BE' => input })
       output = service.swap_data_images imageable.description_multiloc, field: :description_multiloc, imageable: imageable
       codes = imageable.reload.text_images.order(:created_at).pluck :text_reference
       expected_html = <<~HTML
@@ -31,20 +31,20 @@ describe TextImageService do
 
     it 'does not modify the empty string' do
       input = ''
-      imageable = build(:project, description_multiloc: { 'en' => input })
+      imageable = create(:project, description_multiloc: { 'en' => input })
       expect(service.swap_data_images(imageable.description_multiloc, field: :description_multiloc, imageable: imageable)).to eq({ 'en' => input })
     end
 
     # It's more of a side effect; what really matters is that it doesn't fail when some
     # values are nil.
     it 'converts nil values in multiloc to empty strings' do
-      imageable = build(:project, description_multiloc: {
+      imageable = create(:project, description_multiloc: {
         'nl-BE' => nil,
         'en' => '<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7">'
       })
 
       output = service.swap_data_images imageable.description_multiloc, field: :description_multiloc, imageable: imageable
-      text_image = imageable.text_images.order(:created_at).first
+      text_image = imageable.text_images.reload.order(:created_at).first
 
       expect(output).to match(
         'en' => %(<img data-cl2-text-image-text-reference="#{text_image.text_reference}">),

--- a/back/spec/services/text_image_service_spec.rb
+++ b/back/spec/services/text_image_service_spec.rb
@@ -53,46 +53,6 @@ describe TextImageService do
     end
   end
 
-  describe 'extract_data_images_multiloc' do
-    before do
-      stub_request(:any, 'res.cloudinary.com').to_return(
-        body: png_image_as_base64('image10.jpg')
-      )
-    end
-
-    it 'processes both base64 and URL as src' do
-      input = <<~HTML
-        <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7">
-        <img src="data:image/jpeg;base64,/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=" />
-        <img src="https://cl2-seed-and-template-assets.s3.eu-central-1.amazonaws.com/images/people_with_speech_bubbles.jpeg" />
-      HTML
-      output = service.extract_data_images_multiloc({ 'fr-BE' => input })
-
-      content = output[:content_multiloc]['fr-BE']
-      extracted_images = output[:extracted_images]
-
-      codes = extracted_images.pluck(:text_reference)
-      expected_html = <<~HTML
-        <img data-cl2-text-image-text-reference="#{codes[0]}">
-        <img data-cl2-text-image-text-reference="#{codes[1]}">
-        <img data-cl2-text-image-text-reference="#{codes[2]}">
-      HTML
-
-      expect(content).to eq(expected_html)
-    end
-
-    it 'does not modify the empty string' do
-      input = ''
-      output = service.extract_data_images_multiloc({ 'en' => input })
-      expect(output).to eq({
-        content_multiloc: {
-          'en' => input
-        },
-        extracted_images: []
-      })
-    end
-  end
-
   describe 'render_data_images_multiloc' do
     it 'adds src attributes to the img tags' do
       text_image1, text_image2 = create_list(:text_image, 2)

--- a/back/spec/support/api_helper.rb
+++ b/back/spec/support/api_helper.rb
@@ -6,7 +6,7 @@ module ApiHelper
   end
 
   def assert_status(code)
-    expect(status).to eq code
+    expect(status).to eq Rack::Utils.status_code(code)
   end
 
   def json_parse(body)

--- a/back/spec/support/shared_examples/text_image_extraction.rb
+++ b/back/spec/support/shared_examples/text_image_extraction.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# Shared examples for testing text image extraction via the Imageable concern.
+# Usage in acceptance tests:
+#
+#   # For POST
+#   context 'when body contains images' do
+#     let(:body_multiloc) { { 'en' => html_with_base64_image } }
+#
+#     it_behaves_like 'handles record with text images',
+#       model_class: Idea,
+#       field: :body_multiloc,
+#       expected_status: :created
+#   end
+RSpec.shared_examples 'handles record with text images' do |model_class:, field:, expected_status:|
+  action = expected_status == :created ? 'Create' : 'Handle'
+
+  example "#{action} record with images in field", document: false do
+    expect { do_request }.to change(TextImage, :count).by(1)
+
+    assert_status expected_status
+
+    record = model_class.find(json_response_body.dig(:data, :id))
+
+    text_image = TextImage.find_sole_by(
+      imageable: record,
+      imageable_type: model_class.name,
+      imageable_field: field.to_s
+    )
+
+    expect(text_image.imageable).to eq(record)
+    expect(text_image.imageable_field).to eq(field.to_s)
+
+    # Content can be a String or a multiloc (Hash)
+    field_content = record.public_send(field)
+    field_content = field_content.values.sole if field_content.is_a?(Hash)
+
+    expect(field_content).not_to include('data:image/png;base64')
+    expect(field_content).to include(%(data-cl2-text-image-text-reference="#{text_image.text_reference}"))
+    expect(field_content).not_to include(' src="')
+
+    response_field = response_data.dig(:attributes, field)
+    response_field = response_field.values.sole if response_field.is_a?(Hash)
+
+    expect(response_field).not_to include('data:image/png;base64')
+    expect(response_field).to include(%(data-cl2-text-image-text-reference="#{text_image.text_reference}"))
+    expect(response_field).to include(' src="')
+  end
+end
+
+# Convenience aliases
+RSpec.shared_examples 'creates record with text images' do |model_class:, field:|
+  it_behaves_like 'handles record with text images',
+    model_class: model_class,
+    field: field,
+    expected_status: :created
+end
+
+RSpec.shared_examples 'updates record with text images' do |model_class:, field:|
+  it_behaves_like 'handles record with text images',
+    model_class: model_class,
+    field: field,
+    expected_status: :ok
+end

--- a/back/spec/support/shared_examples/text_image_extraction.rb
+++ b/back/spec/support/shared_examples/text_image_extraction.rb
@@ -10,9 +10,16 @@
 #     it_behaves_like 'handles record with text images',
 #       model_class: Idea,
 #       field: :body_multiloc,
-#       expected_status: :created
+#       expected_status: :created,
+#       locale: :en
 #   end
-RSpec.shared_examples 'handles record with text images' do |model_class:, field:, expected_status:|
+#
+# @param model_class [Class]
+# @param field [Symbol] The field that contains one base64 encoded image.
+# @param expected_status [Symbol, Integer] The expected status of the request.
+# @param locale [String] If the field is a multiloc and has multiple locales, the locale
+#   to test (the locale that contains the base64 image).
+RSpec.shared_examples 'handles record with text images' do |model_class:, field:, expected_status:, locale: nil|
   action = expected_status == :created ? 'Create' : 'Handle'
 
   example "#{action} record with images in field", document: false do
@@ -33,14 +40,18 @@ RSpec.shared_examples 'handles record with text images' do |model_class:, field:
 
     # Content can be a String or a multiloc (Hash)
     field_content = record.public_send(field)
-    field_content = field_content.values.sole if field_content.is_a?(Hash)
+    if field_content.is_a?(Hash)
+      field_content = locale ? field_content[locale.to_s] : field_content.values.sole
+    end
 
     expect(field_content).not_to include('data:image/png;base64')
     expect(field_content).to include(%(data-cl2-text-image-text-reference="#{text_image.text_reference}"))
     expect(field_content).not_to include(' src="')
 
     response_field = response_data.dig(:attributes, field)
-    response_field = response_field.values.sole if response_field.is_a?(Hash)
+    if response_field.is_a?(Hash)
+      response_field = locale ? response_field[locale.to_sym] : response_field.values.sole
+    end
 
     expect(response_field).not_to include('data:image/png;base64')
     expect(response_field).to include(%(data-cl2-text-image-text-reference="#{text_image.text_reference}"))
@@ -49,16 +60,10 @@ RSpec.shared_examples 'handles record with text images' do |model_class:, field:
 end
 
 # Convenience aliases
-RSpec.shared_examples 'creates record with text images' do |model_class:, field:|
-  it_behaves_like 'handles record with text images',
-    model_class: model_class,
-    field: field,
-    expected_status: :created
+RSpec.shared_examples 'creates record with text images' do |model_class:, field:, locale: nil|
+  it_behaves_like 'handles record with text images', model_class:, field:, locale:, expected_status: :created
 end
 
-RSpec.shared_examples 'updates record with text images' do |model_class:, field:|
-  it_behaves_like 'handles record with text images',
-    model_class: model_class,
-    field: field,
-    expected_status: :ok
+RSpec.shared_examples 'updates record with text images' do |model_class:, field:, locale: nil|
+  it_behaves_like('handles record with text images', model_class:, field:, locale:, expected_status: :ok)
 end

--- a/front/app/api/invites/__mocks__/useInvites.ts
+++ b/front/app/api/invites/__mocks__/useInvites.ts
@@ -6,7 +6,6 @@ export const invitesData: IInviteData[] = [
     type: 'invite',
     attributes: {
       token: '4nce3671h',
-      invite_text: null,
       accepted_at: null,
       updated_at: '2023-06-01T14:06:25.686Z',
       created_at: '2023-06-01T14:06:25.686Z',
@@ -26,7 +25,6 @@ export const invitesData: IInviteData[] = [
     type: 'invite',
     attributes: {
       token: '0q9h8po6v',
-      invite_text: null,
       accepted_at: null,
       updated_at: '2023-06-01T12:41:47.471Z',
       created_at: '2023-06-01T12:41:47.471Z',
@@ -44,7 +42,6 @@ export const invitesData: IInviteData[] = [
     type: 'invite',
     attributes: {
       token: '0qyim13pb',
-      invite_text: null,
       accepted_at: null,
       updated_at: '2023-06-01T12:41:47.425Z',
       created_at: '2023-06-01T12:41:47.425Z',
@@ -62,7 +59,6 @@ export const invitesData: IInviteData[] = [
     type: 'invite',
     attributes: {
       token: 'bmnugo2dy',
-      invite_text: null,
       accepted_at: null,
       updated_at: '2023-06-01T12:41:47.370Z',
       created_at: '2023-06-01T12:41:47.370Z',
@@ -80,7 +76,6 @@ export const invitesData: IInviteData[] = [
     type: 'invite',
     attributes: {
       token: 'yae6tfbrc',
-      invite_text: null,
       accepted_at: null,
       updated_at: '2023-06-01T12:41:47.325Z',
       created_at: '2023-06-01T12:41:47.325Z',
@@ -98,7 +93,6 @@ export const invitesData: IInviteData[] = [
     type: 'invite',
     attributes: {
       token: 'ze5gdqc9v',
-      invite_text: null,
       accepted_at: null,
       updated_at: '2023-06-01T12:41:47.278Z',
       created_at: '2023-06-01T12:41:47.278Z',

--- a/front/app/api/invites/types.ts
+++ b/front/app/api/invites/types.ts
@@ -38,7 +38,6 @@ export interface IInviteData {
   attributes: {
     token: string;
     accepted_at: string | null;
-    invite_text: string | null;
     updated_at: string;
     created_at: string;
     activate_invite_url: string;


### PR DESCRIPTION
The goal was to completely get rid of `ContentImageService#swap_data_images` and only use `ContentImageService#swap_data_images!`, but I won't get there this time. 

The problem is that `ContentImageService#swap_data_images!` requires the imageable model to have a `has_many` association to the image model (so it can use `association.build` to set foreign keys correctly), but `ContentBuilder::Layout` and `ContentBuilder::LayoutImage` don't have this association set up, which I didn't anticipate.

I still need to test it live on epics because I can't make images in text fields work locally.

# Changelog
## Technical
- [TAN-5588] Refactored text image extraction by replacing manual image extraction calls in controllers and services with automatic `before_validation` callbacks.

