### PR TITLE
Fix issue with null referrer in visitor table

### DIFF
--- a/front/app/components/admin/GraphCards/VisitorsTrafficSourcesCard/Table.tsx
+++ b/front/app/components/admin/GraphCards/VisitorsTrafficSourcesCard/Table.tsx
@@ -77,9 +77,9 @@ const TableComponent = ({ tableData, onOpenModal }: Props) => {
                   wordBreak="break-word"
                 >
                   ({row.referrer_type}){' '}
-                  {truncate(row.referrer, MAX_REFERRER_LENGTH)}
+                  {row.referrer && truncate(row.referrer, MAX_REFERRER_LENGTH)}
                 </Text>
-                {row.referrer.length > MAX_REFERRER_LENGTH && (
+                {row.referrer && row.referrer.length > MAX_REFERRER_LENGTH && (
                   <IconTooltip
                     content={
                       <Text wordBreak="break-word" color="white" fontSize="s">

--- a/front/app/components/admin/GraphCards/VisitorsTrafficSourcesCard/useVisitorReferrerTypes/parse.ts
+++ b/front/app/components/admin/GraphCards/VisitorsTrafficSourcesCard/useVisitorReferrerTypes/parse.ts
@@ -30,7 +30,7 @@ export const parsePieData = (
 
 export type TranslatedReferrers = {
   referrer_type: string;
-  referrer: string;
+  referrer: string | null; // If the referrer is direct, this might be null
   visits: number;
   visitors: number;
 }[];


### PR DESCRIPTION
# Description
Looks like our existing type on the FE was incorrect - referrers can actually sometimes be `null` :shrug: , e.g.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/28b59a52-1a86-4392-88a0-f7d3f836c0e6" />


So we just needed to update our type + add a special type check to fix the issue! :]

# Changelog
## Fixed
- Fix crash in visitor table when there is a null referrer.
