### PR TITLE
[TAN-5685] Allow duplicate columns in xlsx export

### DIFF
--- a/back/app/services/export/xlsx/attendees_generator.rb
+++ b/back/app/services/export/xlsx/attendees_generator.rb
@@ -11,7 +11,8 @@ module Export
         ]
         columns.reject! { |c| %w[email first_name last_name].include?(c[:header]) } unless view_private_attributes
 
-        xlsx_service.generate_xlsx 'Users', columns, users
+        # We allow duplicate columns here because custom fields can have the same title as built in fields (e.g., "Last name")
+        xlsx_service.generate_xlsx 'Users', columns, users, reject_duplicate_columns: false
       end
     end
   end

--- a/back/app/services/xlsx_service.rb
+++ b/back/app/services/xlsx_service.rb
@@ -62,16 +62,16 @@ class XlsxService
     xlsx_from_rows([header, *rows], sheetname: sheetname)
   end
 
-  def generate_xlsx(sheetname, columns, instances)
-    columns = columns.uniq { |c| c[:header] }
+  def generate_xlsx(sheetname, columns, instances, reject_duplicate_columns: true)
+    columns = columns.uniq { |c| c[:header] } if reject_duplicate_columns
     pa = Axlsx::Package.new
-    generate_sheet pa.workbook, sheetname, columns, instances
+    generate_sheet pa.workbook, sheetname, columns, instances, reject_duplicate_columns: reject_duplicate_columns
     pa.to_stream
   end
 
-  def generate_sheet(workbook, sheetname, columns, instances)
+  def generate_sheet(workbook, sheetname, columns, instances, reject_duplicate_columns: true)
     sheetname = utils.sanitize_sheetname sheetname
-    columns = columns.uniq { |c| c[:header] }
+    columns = columns.uniq { |c| c[:header] } if reject_duplicate_columns
     workbook.styles do |s|
       workbook.add_worksheet(name: sheetname) do |sheet|
         header = columns.pluck(:header)

--- a/back/spec/services/export/xlsx/attendees_generator_spec.rb
+++ b/back/spec/services/export/xlsx/attendees_generator_spec.rb
@@ -30,15 +30,18 @@ describe Export::Xlsx::AttendeesGenerator do
       expect([user_row[title_row.find_index 'domicile']]).to eq ['Center']
     end
 
-    it 'allows custom fields with the same name' do
+    it 'allows custom fields with the same name as user attributes' do
       create(:custom_field, title_multiloc: { 'en' => 'Last name' }, key: 'last_name', resource_type: 'User')
+      user_last_name = users.first.last_name
       users.first.update!(custom_field_values: { 'last_name' => 'Doe' })
-
       title_row = worksheet[0].cells.map(&:value)
       user_rows = worksheet.map { |row| row.cells.map(&:value) }
       user_row = user_rows.find { |values| values.include? users.first.email }
+
       expect(title_row.count('Last name')).to eq 2
       expect(user_row.count('Doe')).to eq 1
+      expect(user_row.count(user_last_name)).to eq 1
+      expect(user_last_name).not_to eq 'Doe'
     end
 
     it 'includes hidden custom fields' do

--- a/back/spec/services/export/xlsx/attendees_generator_spec.rb
+++ b/back/spec/services/export/xlsx/attendees_generator_spec.rb
@@ -30,6 +30,17 @@ describe Export::Xlsx::AttendeesGenerator do
       expect([user_row[title_row.find_index 'domicile']]).to eq ['Center']
     end
 
+    it 'allows custom fields with the same name' do
+      create(:custom_field, title_multiloc: { 'en' => 'Last name' }, key: 'last_name', resource_type: 'User')
+      users.first.update!(custom_field_values: { 'last_name' => 'Doe' })
+
+      title_row = worksheet[0].cells.map(&:value)
+      user_rows = worksheet.map { |row| row.cells.map(&:value) }
+      user_row = user_rows.find { |values| values.include? users.first.email }
+      expect(title_row.count('Last name')).to eq 2
+      expect(user_row.count('Doe')).to eq 1
+    end
+
     it 'includes hidden custom fields' do
       create(:custom_field, hidden: true, title_multiloc: { 'en' => 'Hidden field' })
       headers = worksheet[0].cells.map(&:value)

--- a/back/spec/services/export/xlsx/attendees_generator_spec.rb
+++ b/back/spec/services/export/xlsx/attendees_generator_spec.rb
@@ -30,7 +30,7 @@ describe Export::Xlsx::AttendeesGenerator do
       expect([user_row[title_row.find_index 'domicile']]).to eq ['Center']
     end
 
-    it 'allows custom fields with the same name as user attributes' do
+    it 'allows duplicate column headers' do
       create(:custom_field, title_multiloc: { 'en' => 'Last name' }, key: 'last_name', resource_type: 'User')
       user_last_name = users.first.last_name
       users.first.update!(custom_field_values: { 'last_name' => 'Doe' })


### PR DESCRIPTION
# Changelog
## Fixed 
- Allow duplicate column names in events export
