### PR TITLE
[TAN-5434] Fix issue where unlisted projects counted in status counts on homepage

### DIFF
--- a/front/app/components/ProjectAndFolderCards/index.tsx
+++ b/front/app/components/ProjectAndFolderCards/index.tsx
@@ -138,6 +138,7 @@ const ProjectAndFolderCardsWrapper = (props: Props) => {
       publicationStatusFilter: PUBLICATION_STATUSES,
       rootLevelOnly: true,
       removeNotAllowedParents: true,
+      discoverability: ['listed'],
     }
   );
 


### PR DESCRIPTION
# Changelog
## Fixed
- [TAN-5434] Remove unlisted projects from "Published" project count in legacy homepage project/folder cards.
