### PR TITLE
Replace query param to remove unlisted projects from legacy widget

### DIFF
--- a/front/app/components/ProjectAndFolderCards/index.tsx
+++ b/front/app/components/ProjectAndFolderCards/index.tsx
@@ -139,7 +139,7 @@ const ProjectAndFolderCardsWrapper = (props: Props) => {
       publicationStatusFilter: PUBLICATION_STATUSES,
       rootLevelOnly: true,
       removeNotAllowedParents: true,
-      discoverability: ['listed'],
+      remove_all_unlisted: true,
     }
   );
 


### PR DESCRIPTION
Replace query param to remove unlisted projects from legacy widget.