### PR TITLE
Fix missing remove_all_unlisted filtering on admin publication status counts

### DIFF
--- a/back/app/controllers/web_api/v1/admin_publications_controller.rb
+++ b/back/app/controllers/web_api/v1/admin_publications_controller.rb
@@ -97,6 +97,7 @@ class WebApi::V1::AdminPublicationsController < ApplicationController
 
     admin_publication_filterer = AdminPublicationsFilteringService.new
     admin_publications = policy_scope(AdminPublication.includes(:parent))
+    admin_publications = apply_projects_listed_scope(admin_publications)
     admin_publications = admin_publication_filterer.filter(admin_publications, params)
 
     counts = admin_publications.group(:publication_status).count


### PR DESCRIPTION
# Description
When getting the `status_counts` for admin publications, we have a query parameter called `remove_all_unlisted`, but we didn't seem to actually be filtering for that on the BE. I've added a line which solves this and makes sure we respect/check for the `remove_all_unlisted`.