### PR TITLE
[TAN-5821] Fix issue with slow loading for reports

### DIFF
--- a/front/app/api/analyses/useAnalyses.test.ts
+++ b/front/app/api/analyses/useAnalyses.test.ts
@@ -13,6 +13,7 @@ const apiPath = '*analyses';
 const params: IAnalysesQueryParams = {
   pageNumber: 1,
   pageSize: 5000,
+  phaseId: 'phaseId123',
 };
 
 const server = setupServer(

--- a/front/app/api/analyses/useAnalyses.ts
+++ b/front/app/api/analyses/useAnalyses.ts
@@ -28,6 +28,8 @@ const useAnalyses = (params: IAnalysesQueryParams) => {
   return useQuery<IAnalyses, CLErrors, IAnalyses, AnalysesKeys>({
     queryKey: analysesKeys.list(params),
     queryFn: () => fetchAnalyses(params),
+    // If there is no projectId or phaseId, don't fetch analyses
+    enabled: !!params.projectId || !!params.phaseId,
   });
 };
 

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Analysis/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Analysis/index.tsx
@@ -50,11 +50,7 @@ const Analysis = ({ selectedLocale }: { selectedLocale: string }) => {
     setPhaseId(value);
   }, []);
 
-  const showAnalyses =
-    projectId &&
-    phaseId &&
-    // We only show analyses for non-information phases
-    phase?.data.attributes.participation_method !== 'information';
+  const showAnalyses = projectId && phaseId;
 
   return (
     <>

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Analysis/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Analysis/index.tsx
@@ -50,7 +50,11 @@ const Analysis = ({ selectedLocale }: { selectedLocale: string }) => {
     setPhaseId(value);
   }, []);
 
-  const showAnalyses = projectId && phaseId;
+  const showAnalyses =
+    projectId &&
+    phaseId &&
+    // We only show analyses for non-information phases
+    phase?.data.attributes.participation_method !== 'information';
 
   return (
     <>


### PR DESCRIPTION
# Description
Essentially, for reports in phases (information phases) we hit the `GET analyses` endpoint without any project/phase ID filtering because of this in the `Analysis/Analyses.tsx` :

```
  const { data: analyses, isLoading } = useAnalyses({
    projectId: participationMethod === 'ideation' ? projectId : undefined,
    phaseId: participationMethod === 'native_survey' ? phaseId : undefined,
  });
```
This resulted in a huge response on some platforms, since we requested all analyses across the platform.

In reality though, we don't want to `GET analyses` unless we've specified a Project or Phase Id.

# Changelog
## Fixed
- [TAN-5821] Fix issue with slow loading for reports.
