### PR TITLE
TAN-5874 Include email campaigns context in templates

### DIFF
--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/email_campaigns/campaign.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/email_campaigns/campaign.rb
@@ -5,7 +5,7 @@ module MultiTenancy
     module Serializers
       module EmailCampaigns
         class Campaign < Base
-          ref_attribute :author
+          ref_attributes %i[author context]
 
           attributes %i[
             type

--- a/back/engines/commercial/multi_tenancy/spec/services/multi_tenancy/templates/tenant_serializer_spec.rb
+++ b/back/engines/commercial/multi_tenancy/spec/services/multi_tenancy/templates/tenant_serializer_spec.rb
@@ -337,7 +337,7 @@ describe MultiTenancy::Templates::TenantSerializer do
           'sender' => global_manual_campaign.sender,
           'subject_multiloc' => global_manual_campaign.subject_multiloc,
           'body_multiloc' => global_manual_campaign.body_multiloc,
-          'context_ref' => nil
+          # 'context_ref' => nil
         ),
         hash_including(
           'type' => 'EmailCampaigns::Campaigns::ManualProjectParticipants',
@@ -354,7 +354,7 @@ describe MultiTenancy::Templates::TenantSerializer do
       tenant = create(:tenant, locales: AppConfiguration.instance.settings('core', 'locales'))
       tenant.switch do
         MultiTenancy::Templates::TenantDeserializer.new.deserialize(template)
-        expect(EmailCampaigns::Campaigns.count).to eq 2
+        expect(EmailCampaigns::Campaign.count).to eq 2
       end
     end
   end

--- a/back/engines/commercial/multi_tenancy/spec/services/multi_tenancy/templates/tenant_serializer_spec.rb
+++ b/back/engines/commercial/multi_tenancy/spec/services/multi_tenancy/templates/tenant_serializer_spec.rb
@@ -336,8 +336,7 @@ describe MultiTenancy::Templates::TenantSerializer do
           'enabled' => global_manual_campaign.enabled,
           'sender' => global_manual_campaign.sender,
           'subject_multiloc' => global_manual_campaign.subject_multiloc,
-          'body_multiloc' => global_manual_campaign.body_multiloc,
-          # 'context_ref' => nil
+          'body_multiloc' => global_manual_campaign.body_multiloc
         ),
         hash_including(
           'type' => 'EmailCampaigns::Campaigns::ManualProjectParticipants',


### PR DESCRIPTION
There are two issues that need to be solved to get the blank demo template working:
1. Support contexts in campaigns: https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/303317/workflows/cd0438f1-73e3-4d7a-8cde-23ac91af8a07/jobs/662517
2. Fix invalid data in the platform (doing that now).

# Changelog
### Fixed
- [TAN-5874] Tenant templates for platforms with manual project campaigns.
