### PR TITLE
Test for smart groups  'users who have not voted in any project'

### DIFF
--- a/back/engines/commercial/smart_groups/spec/services/rules_service_spec.rb
+++ b/back/engines/commercial/smart_groups/spec/services/rules_service_spec.rb
@@ -81,6 +81,33 @@ describe SmartGroups::RulesService do
       result = service.filter User, rules
       expect(result.count).to eq 1
     end
+
+    context 'voting' do
+      let(:project1) { create(:single_voting_phase, :ongoing).project }
+      let(:project2) { create(:single_voting_phase, :ongoing).project }
+
+      let(:rules) do
+        [
+          { 'ruleType' => 'participated_in_project', 'predicate' => 'not_voted_in', 'value' => project1.id },
+          { 'ruleType' => 'participated_in_project', 'predicate' => 'not_voted_in', 'value' => project2.id }
+        ]
+      end
+
+      it 'includes all users who have not voted in any of the projects' do
+        result = service.filter User, rules
+        expect(result.count).to eq 4
+      end
+
+      it 'filters out users who have voted in at least one of the projects' do
+        # 3 baskets, 2 users have voted in at least one project
+        create(:basket, phase: project1.phases.first, user: User.first)
+        create(:basket, phase: project2.phases.first, user: User.last)
+        create(:basket, phase: project2.phases.first, user: User.last)
+
+        result = service.filter User, rules
+        expect(result.count).to eq 2
+      end
+    end
   end
 
   describe 'groups_for_user' do


### PR DESCRIPTION
# Changelog
## Technical
- Added test to confirm tha we can create a smart group for 'users who have not voted in any of these projects'