### PR TITLE
TAN-5796: Add missing legends to chart export

### DIFF
--- a/front/app/components/admin/Representativeness/ChartCard/Chart.tsx
+++ b/front/app/components/admin/Representativeness/ChartCard/Chart.tsx
@@ -5,6 +5,7 @@ import {
   colors,
   DEFAULT_BAR_CHART_MARGIN,
 } from 'components/admin/Graphs/styling';
+import { Legend } from 'components/admin/Graphs/typings';
 
 import { RepresentativenessData } from '../../../../hooks/parseReferenceData';
 
@@ -23,6 +24,14 @@ const BAR_FILLS = [colors.blue, colors.lightBlue];
 const Chart = ({ currentChartRef, data, barNames, hideTicks }: Props) => {
   const hideLabels = data.length > 10;
   const slicedData = data.slice(0, 24);
+
+  const legend: Legend = {
+    items: [
+      { icon: 'rect', color: BAR_FILLS[0], label: barNames[0] },
+      { icon: 'rect', color: BAR_FILLS[1], label: barNames[1] },
+    ],
+    position: 'bottom-center',
+  };
 
   return (
     <MultiBarChart
@@ -45,6 +54,7 @@ const Chart = ({ currentChartRef, data, barNames, hideTicks }: Props) => {
       yaxis={{ tickFormatter: formatPercentage }}
       labels={hideLabels ? undefined : { formatter: formatPercentage }}
       tooltip={renderTooltip}
+      legend={legend}
     />
   );
 };

--- a/front/app/components/admin/Representativeness/ChartCard/ChartCard.test.tsx
+++ b/front/app/components/admin/Representativeness/ChartCard/ChartCard.test.tsx
@@ -75,12 +75,6 @@ describe('<ChartCard />', () => {
 });
 
 describe('<ChartCard /> (chart view)', () => {
-  it('renders legend', () => {
-    render(<ChartCard userCustomField={userCustomField} />);
-
-    expect(screen.getByTestId('graph-legend')).toBeInTheDocument();
-  });
-
   describe('N <= 10', () => {
     beforeEach(() => {
       mockData = generateData(6);
@@ -337,19 +331,6 @@ describe('<ChartCard /> (chart view)', () => {
 describe('<ChartCard /> (table view)', () => {
   beforeEach(() => {
     mockData = generateData(6);
-  });
-
-  it('does not render legend in table view', () => {
-    const { container } = render(
-      <ChartCard userCustomField={userCustomField} />
-    );
-
-    expect(screen.getByTestId('graph-legend')).toBeInTheDocument();
-
-    const tableTabButton = container.querySelector('button#table');
-    fireEvent.click(tableTabButton);
-
-    expect(screen.queryByTestId('graph-legend')).not.toBeInTheDocument();
   });
 
   describe('N <= 12', () => {

--- a/front/app/components/admin/Representativeness/ChartCard/index.tsx
+++ b/front/app/components/admin/Representativeness/ChartCard/index.tsx
@@ -97,7 +97,6 @@ const ChartCard = injectIntl(
     const hideTicks = referenceData.length > 12;
     const dataIsTooLong = referenceData.length > 24;
     const numberOfHiddenItems = referenceData.length - 24;
-    const hideLegend = view === 'table';
 
     const barNames = [
       formatMessage(messages.users),
@@ -162,7 +161,7 @@ const ChartCard = injectIntl(
           numberOfHiddenItems={numberOfHiddenItems}
           view={view}
           legendLabels={legendLabels}
-          hideLegend={hideLegend}
+          hideLegend
           onClickSwitchToTableView={handleClickSwitchToTableView}
         />
       </Box>


### PR DESCRIPTION
# Changelog

## Fixed
- Add missing legends to the export of the representativeness graphs
<img width="1470" height="389" alt="image" src="https://github.com/user-attachments/assets/b53d85b4-4dae-43d7-94ba-3069c3699694" />

