### PR TITLE
TAN-5953: Fix size of image in image description

### DIFF
--- a/front/app/components/admin/FormResults/FormResultsQuestion/index.tsx
+++ b/front/app/components/admin/FormResults/FormResultsQuestion/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { Box, Title, Text, Tooltip } from '@citizenlab/cl2-component-library';
 import { snakeCase } from 'lodash-es';
+import styled from 'styled-components';
 
 import { LogicConfig, ResultUngrouped } from 'api/survey_results/types';
 
@@ -16,6 +17,16 @@ import messages from '../messages';
 
 import FormResultQuestionValue from './components/FormResultsQuestionValue';
 import InputType from './InputType';
+
+const DescriptionContainer = styled.div`
+  img {
+    max-width: 400px;
+    max-height: 300px;
+    width: auto;
+    height: auto;
+    object-fit: contain;
+  }
+`;
 
 type FormResultsQuestionProps = {
   result: ResultUngrouped;
@@ -79,9 +90,11 @@ const FormResultsQuestion = ({
             totalResponses={questionResponseCount}
           />
         </Tooltip>
-        <Text variant="bodyS" color="textSecondary" mt="12px" mb="12px">
-          <T value={description} supportHtml={true} />
-        </Text>
+        <DescriptionContainer>
+          <Text variant="bodyS" color="textSecondary" mt="12px" mb="12px">
+            <T value={description} supportHtml={true} />
+          </Text>
+        </DescriptionContainer>
 
         <FormResultQuestionValue result={result} logicConfig={logicConfig} />
 


### PR DESCRIPTION
# Changelog

## Fixed
- Fix size of image in the description of a survey question when displaying survey results. Images added to survey question descriptions now display at a reasonable size instead of stretching beyond the size of the screen

### Before
<img width="1916" height="960" alt="image" src="https://github.com/user-attachments/assets/6901331b-e72c-4044-abe4-2e6eee4fed59" />

### After
<img width="1641" height="882" alt="image" src="https://github.com/user-attachments/assets/0b1bc74e-43a0-496f-9155-3c542ee79a46" />

