### PR TITLE
TAN-5956 Script to fix first pages

### DIFF
--- a/back/.rubocop.yml
+++ b/back/.rubocop.yml
@@ -152,6 +152,18 @@ Layout/MultilineMethodCallIndentation:
 RSpec/DescribeClass:
   IgnoredMetadata:
     type: ["request"]
+  Exclude:
+    - 'engines/commercial/id_bosa_fas/spec/requests/bosa_fas_verification_spec.rb'
+    - 'engines/commercial/id_clave_unica/spec/requests/clave_unica_verification_spec.rb'
+    - 'engines/commercial/id_franceconnect/spec/requests/franceconnect_verification_spec.rb'
+    - 'engines/commercial/id_vienna_saml/spec/requests/citizen_authentication_spec.rb'
+    - 'engines/commercial/id_vienna_saml/spec/requests/employee_authentication_spec.rb'
+    - 'spec/requests/google_authentication_spec.rb'
+    - 'engines/commercial/multi_tenancy/spec/db/seedfile_spec.rb'
+    - 'engines/commercial/multi_tenancy/spec/tasks/email_campaigns_task_spec.rb'
+    - 'engines/commercial/multi_tenancy/spec/tasks/fix_notifications_task_spec.rb'
+    - 'engines/commercial/multi_tenancy/spec/tasks/invalid_data_checker_task_spec.rb'
+    - 'spec/tasks/single_use/*.ignore.rb'
 
 RSpec/EmptyExampleGroup:
   # `context` and `describe` are found as empty example groups when
@@ -161,6 +173,11 @@ RSpec/EmptyExampleGroup:
 
 RSpec/ExampleLength:
   Enabled: false
+
+RSpec/SpecFilePathSuffix:
+  Exclude:
+    - 'spec/migrations/20241127093339_add_first_published_at_to_admin_publications_spec.ignore.rb'
+    - 'spec/tasks/single_use/*.ignore.rb'
 
 Metrics/MethodLength:
   CountAsOne: ["array", "hash", "heredoc"]

--- a/back/.rubocop_todo.yml
+++ b/back/.rubocop_todo.yml
@@ -178,31 +178,6 @@ RSpec/BeforeAfterAll:
 RSpec/ContextWording:
   Enabled: false
 
-# Offense count: 19
-# Configuration parameters: IgnoredMetadata.
-RSpec/DescribeClass:
-  Exclude:
-    - 'engines/commercial/id_bosa_fas/spec/requests/bosa_fas_verification_spec.rb'
-    - 'engines/commercial/id_clave_unica/spec/requests/clave_unica_verification_spec.rb'
-    - 'engines/commercial/id_franceconnect/spec/requests/franceconnect_verification_spec.rb'
-    - 'engines/commercial/id_vienna_saml/spec/requests/citizen_authentication_spec.rb'
-    - 'engines/commercial/id_vienna_saml/spec/requests/employee_authentication_spec.rb'
-    - 'spec/requests/google_authentication_spec.rb'
-    - 'engines/commercial/multi_tenancy/spec/db/seedfile_spec.rb'
-    - 'engines/commercial/multi_tenancy/spec/tasks/email_campaigns_task_spec.rb'
-    - 'engines/commercial/multi_tenancy/spec/tasks/fix_notifications_task_spec.rb'
-    - 'engines/commercial/multi_tenancy/spec/tasks/invalid_data_checker_task_spec.rb'
-    - 'spec/tasks/single_use/delete_initiative_dimension_types_spec.ignore.rb'
-    - 'spec/tasks/single_use/fix_map_configs_zoom_level_spec.ignore.rb'
-    - 'spec/tasks/single_use/migrate_contextual_campaigns_spec.ignore.rb'
-    - 'spec/tasks/single_use/migrate_engagementhq_demographics_spec.ignore.rb'
-    - 'spec/tasks/single_use/migrate_forms_sections_to_pages_spec.ignore.rb'
-    - 'spec/tasks/single_use/migrate_forms_separate_title_description_pages_spec.ignore.rb'
-    - 'spec/tasks/single_use/migrate_homepage_craftjson_task_spec.ignore.rb'
-    - 'spec/tasks/single_use/rename_gv_profile_spec.ignore.rb'
-    - 'spec/tasks/single_use/substitute_cl_gv_task_spec.ignore.rb'
-    - 'spec/tasks/single_use/custom_field_orderings_spec.ignore.rb'
-
 # Offense count: 149
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: CustomTransform, IgnoredWords, DisallowedExamples.
@@ -319,26 +294,6 @@ RSpec/ScatteredSetup:
 # Include: **/*_spec.rb
 RSpec/SpecFilePathFormat:
   Enabled: false
-
-# Offense count: 13
-# Configuration parameters: Include.
-# Include: **/*_spec*rb*, **/spec/**/*
-RSpec/SpecFilePathSuffix:
-  Exclude:
-    - 'spec/migrations/20241127093339_add_first_published_at_to_admin_publications_spec.ignore.rb'
-    - 'spec/tasks/single_use/add_missing_locales_task_spec.ignore.rb'
-    - 'spec/tasks/single_use/continuous_project_migration_service_spec.ignore.rb'
-    - 'spec/tasks/single_use/delete_initiative_dimension_types_spec.ignore.rb'
-    - 'spec/tasks/single_use/fix_map_configs_zoom_level_spec.ignore.rb'
-    - 'spec/tasks/single_use/migrate_contextual_campaigns_spec.ignore.rb'
-    - 'spec/tasks/single_use/migrate_engagementhq_demographics_spec.ignore.rb'
-    - 'spec/tasks/single_use/migrate_forms_sections_to_pages_spec.ignore.rb'
-    - 'spec/tasks/single_use/migrate_forms_separate_title_description_pages_spec.ignore.rb'
-    - 'spec/tasks/single_use/migrate_homepage_craftjson_task_spec.ignore.rb'
-    - 'spec/tasks/single_use/move_ideation_custom_forms_to_project_spec.ignore.rb'
-    - 'spec/tasks/single_use/rename_gv_profile_spec.ignore.rb'
-    - 'spec/tasks/single_use/substitute_cl_gv_task_spec.ignore.rb'
-    - 'spec/tasks/single_use/custom_field_orderings_spec.ignore.rb'
 
 # Offense count: 77
 RSpec/StubbedMock:

--- a/back/lib/tasks/single_use/20251202_custom_fields_first_page.rake
+++ b/back/lib/tasks/single_use/20251202_custom_fields_first_page.rake
@@ -1,0 +1,33 @@
+namespace :fix_existing_tenants do
+  desc 'Fix custom fields by making sure the first field is a page.'
+  task :custom_fields_first_page, [] => [:environment] do
+    reporter = ScriptReporter.new
+    Tenant.all.each do |tenant|
+      tenant.switch do
+        CustomForm.all.each do |form|
+          first_field = CustomField.find_by(ordering: 0, resource_id: form.id)
+          next if first_field&.page?
+
+          first_page = CustomField.where(resource_id: form.id).order(:ordering).find(&:page?)
+          if !first_page
+            reporter.add_error(
+              'Form has no pages!',
+              context: { tenant: tenant.host, form: form.id }
+            )
+            next
+          end
+
+          prev_ordering = first_page.ordering
+          first_page.move_to_top
+
+          reporter.add_change(
+            prev_ordering,
+            first_page.ordering,
+            context: { tenant: tenant.host, form: form.id, field: first_page.id }
+          )
+        end
+      end
+    end
+    reporter.report!('fix_custom_fields_first_page_report.json', verbose: true)
+  end
+end

--- a/back/spec/tasks/single_use/custom_fields_first_page_spec.ignore.rb
+++ b/back/spec/tasks/single_use/custom_fields_first_page_spec.ignore.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+describe 'fix_existing_tenants:custom_fields_first_page rake task' do
+  before { load_rake_tasks_if_not_loaded }
+
+  it 'Fixes the orderings' do
+    form1 = create(:custom_form)
+    create(:custom_field, resource: form1, input_type: 'number', key: 'field2')
+    create(:custom_field_page, resource: form1, key: 'field1')
+    create(:custom_field, resource: form1, input_type: 'number', key: 'field3')
+    create(:custom_field, resource: form1, input_type: 'text', key: 'field4')
+    create(:custom_field_page, resource: form1, key: 'field5')
+
+    form2 = create(:custom_form)
+    create(:custom_field_page, resource: form2, key: 'field1')
+    create(:custom_field, resource: form2, input_type: 'number', key: 'field2')
+    create(:custom_field, resource: form2, input_type: 'text', key: 'field3')
+    create(:custom_field_page, resource: form2, key: 'field4')
+
+    create(:custom_field, resource_id: nil, resource_type: 'User', input_type: 'text', key: 'field1')
+    create(:custom_field, resource_id: nil, resource_type: 'User', input_type: 'number', key: 'field2')
+
+    Rake::Task['fix_existing_tenants:custom_fields_first_page'].invoke
+
+    expect(form1.reload.custom_fields.pluck(:key, :ordering)).to eq([
+      ['field1', 0],
+      ['field2', 1],
+      ['field3', 2],
+      ['field4', 3],
+      ['field5', 4]
+    ])
+
+    expect(form2.reload.custom_fields.pluck(:key, :ordering)).to eq([
+      ['field1', 0],
+      ['field2', 1],
+      ['field3', 2],
+      ['field4', 3]
+    ])
+
+    expect(CustomField.where(resource_id: nil).order(:ordering).pluck(:key, :ordering)).to eq([
+      ['field1', 0],
+      ['field2', 1]
+    ])
+  end
+end


### PR DESCRIPTION
It's not clear how this issue can occur, and hopefully fixing the data will be enough.

Here is an overview of first fields that are not pages: https://metabase.hq.citizenlab.co/question/2847-fields-that-are-not-the-first-page. I don't see a clear pattern, but most fields were created a while ago. The 3rd of september is when a rake task was ran (but probably unrelated to this issue).

If the issue comes back, I would suggest to remodel pages as a separate model instead of as custom fields. This would guarantee that fields are always part of a page. But it would be a high-effort restructuring.

However, this doesn't fix input forms with zero fields.

# Changelog
### Fixed
- [TAN-5956] Some input forms were crashing because the first field is not a page.
