### PR TITLE
[TAN-5957] Fix bug around file attachments widget

### DIFF
--- a/back/app/controllers/web_api/v1/files/file_attachments_controller.rb
+++ b/back/app/controllers/web_api/v1/files/file_attachments_controller.rb
@@ -147,6 +147,7 @@ class WebApi::V1::Files::FileAttachmentsController < ApplicationController
   def cleanup_existing_content_builder_attachments(file_attachment)
     # Remove any existing attachments for the same file and layout
     # This enforces the business rule: only one file attachment widget per file per layout
+    # Essentially, the last one added will work. Any existing ones are removed.
     existing_attachments = Files::FileAttachment.where(
       file_id: file_attachment.file_id,
       attachable_type: 'ContentBuilder::Layout',

--- a/front/app/components/admin/ContentBuilder/FullscreenContentBuilder/index.tsx
+++ b/front/app/components/admin/ContentBuilder/FullscreenContentBuilder/index.tsx
@@ -50,23 +50,10 @@ export const ContentBuilder = ({
   useEffect(() => {
     if (!onDeleteElement) return;
 
-    const cleanUpElementAfterDeletion = (deletedElement: SelectedNode) => {
-      // Add additional cleanup logic below for other element types as needed.
-
-      // File Attachment
-      if (deletedElement.custom?.title.defaultMessage === 'File Attachment') {
-        const fileAttachmentId = deletedElement.props.fileAttachmentId;
-        deleteFileAttachment(fileAttachmentId);
-      }
-    };
-
     const subscription = eventEmitter
       .observeEvent(CONTENT_BUILDER_DELETE_ELEMENT_EVENT)
       .subscribe(({ eventValue }) => {
         const deletedElement = eventValue as SelectedNode;
-
-        cleanUpElementAfterDeletion(deletedElement);
-
         const deletedElementId = deletedElement.id;
         onDeleteElement(deletedElementId);
       });


### PR DESCRIPTION
# Description
The issue here is that the FE cleanup code wasn't being run if the user had added a new file attachment widget and then reloaded the page/closed the page without saving.

Although we wanted a FE solution here, there isn't a completely reliable way to ensure this cleanup happens in every case, and it's causing bugs for clients.

Instead, I looked into a BE solution which runs each time we try to create a File Attachment for a Content Builder Layout and we encounter the "Taken" error.

# Changelog
## Fixed
- [TAN-5957] Fix bug around some files not working in file attachments widget.