### PR TITLE
Fix for hidden fields in user forms

### DIFF
--- a/back/app/services/permissions/user_requirements_service.rb
+++ b/back/app/services/permissions/user_requirements_service.rb
@@ -36,8 +36,7 @@ class Permissions::UserRequirementsService
         field.required = permissions_custom_field.required
       end
     end
-    fields = fields.reject { |field| field.hidden } # Should not return hidden fields
-    fields
+    fields.reject(&:hidden?) # Should not return hidden fields
   end
 
   # Verification requirement can now come from either a group or the "verified" permitted_by value

--- a/back/app/services/permissions/user_requirements_service.rb
+++ b/back/app/services/permissions/user_requirements_service.rb
@@ -30,12 +30,14 @@ class Permissions::UserRequirementsService
   end
 
   def requirements_custom_fields(permission)
-    permissions_custom_fields_service.fields_for_permission(permission).map do |permissions_custom_field|
+    fields = permissions_custom_fields_service.fields_for_permission(permission).map do |permissions_custom_field|
       permissions_custom_field.custom_field.tap do |field|
         field.enabled = true # Need to override this to ensure it gets displayed when not enabled at platform level
         field.required = permissions_custom_field.required
       end
     end
+    fields = fields.reject { |field| field.hidden } # Should not return hidden fields
+    fields
   end
 
   # Verification requirement can now come from either a group or the "verified" permitted_by value

--- a/back/spec/services/permissions/user_requirements_service_spec.rb
+++ b/back/spec/services/permissions/user_requirements_service_spec.rb
@@ -758,5 +758,14 @@ describe Permissions::UserRequirementsService do
         expect(requirements_custom_fields.map(&:required)).to eq [false, true]
       end
     end
+
+    context 'when user fields are hidden' do
+      it 'does not return hidden fields' do
+        permission.update!(global_custom_fields: false)
+        hidden_field = custom_fields.first
+        hidden_field.update!(hidden: true)
+        expect(requirements_custom_fields.map(&:id)).to eq [custom_fields.second.id]
+      end
+    end
   end
 end

--- a/front/app/components/UserCustomFields/index.tsx
+++ b/front/app/components/UserCustomFields/index.tsx
@@ -59,8 +59,6 @@ const UserCustomFieldsForm = ({
     return () => subscription.unsubscribe();
   }, [methods, onChange, customFields]);
 
-  console.log(customFields);
-
   if (!customFields) return null;
 
   return (

--- a/front/app/components/UserCustomFields/index.tsx
+++ b/front/app/components/UserCustomFields/index.tsx
@@ -59,6 +59,8 @@ const UserCustomFieldsForm = ({
     return () => subscription.unsubscribe();
   }, [methods, onChange, customFields]);
 
+  console.log(customFields);
+
   if (!customFields) return null;
 
   return (


### PR DESCRIPTION
Previously the JSON schema endpoint took care of removing hidden fields. This was left out when we moved to raw custom fields and it causes an issue for some SSO customers using smart groups based on hidden custom fields populated from the SSO method. 

The `requirements_custom_fields` method is only used by the application in user forms only, so this is safe to add to the service.

# Changelog
## Fixed
- Removed hidden demographic fields from user fields in registration flow
