### PR TITLE
Disable NPM pre- and post install scripts

### DIFF
--- a/front/.npmrc
+++ b/front/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+ignore-scripts=true

--- a/front/.npmrc
+++ b/front/.npmrc
@@ -1,2 +1,7 @@
 engine-strict=true
+
+# Disabled for security reasons.
+# Pre and post install scripts are often exploited
+# in supply chain attacks, and can steal credentials
+# or run arbitrary code on a developer's machine.
 ignore-scripts=true

--- a/front/__mocks__/canvas.js
+++ b/front/__mocks__/canvas.js
@@ -1,0 +1,62 @@
+class CanvasRenderingContext2D {
+  constructor(width, height) {
+    this.canvas = { width, height };
+    this.font = '10px sans-serif';
+    this.textAlign = 'left';
+    this.textBaseline = 'alphabetic';
+  }
+  measureText(text) { return { width: (text || '').length * 7 }; }
+  getImageData() { return { data: new Uint8ClampedArray(this.canvas.width * this.canvas.height * 4) }; }
+  createImageData(w, h) { return { data: new Uint8ClampedArray(w * h * 4) }; }
+  putImageData() { }
+  fillRect() { }
+  clearRect() { }
+  drawImage() { }
+  beginPath() { }
+  closePath() { }
+  moveTo() { }
+  lineTo() { }
+  stroke() { }
+  fill() { }
+  rect() { }
+  fillText() { }
+  strokeText() { }
+  save() { }
+  restore() { }
+  rotate() { }
+  scale() { }
+  translate() { }
+  createLinearGradient() { return { addColorStop() { } }; }
+  createRadialGradient() { return { addColorStop() { } }; }
+}
+
+class Canvas {
+  constructor(width = 300, height = 150) {
+    this.width = width;
+    this.height = height;
+  }
+  getContext(type) {
+    return type === '2d' ? new CanvasRenderingContext2D(this.width, this.height) : null;
+  }
+  toBuffer() { return Buffer.alloc(0); }
+  toDataURL() { return 'data:image/png;base64,'; }
+}
+
+class Image {
+  constructor() {
+    this.width = 0;
+    this.height = 0;
+    this.onload = null;
+    this.onerror = null;
+    this.src = '';
+  }
+}
+
+module.exports = {
+  Canvas,
+  Image,
+  CanvasRenderingContext2D,
+  createCanvas: (width = 300, height = 150) => new Canvas(width, height),
+  loadImage: async (_src) => new Image(),
+  registerFont: (_path, _options) => { },
+};

--- a/front/internals/jest/jsdom-no-canvas.js
+++ b/front/internals/jest/jsdom-no-canvas.js
@@ -1,0 +1,24 @@
+const JSDOMEnvironment = require('jest-environment-jsdom').default;
+const Module = require('module');
+
+// Store the original require
+const originalRequire = Module.prototype.require;
+
+// Override Module.prototype.require globally before JSDOM loads
+Module.prototype.require = function (id) {
+  if (id === 'canvas' || (typeof id === 'string' && id.startsWith('canvas/'))) {
+    // Return the mock instead of trying to load the real canvas
+    const path = require('path');
+    const mockPath = path.join(process.cwd(), '__mocks__', 'canvas.js');
+    return originalRequire.call(this, mockPath);
+  }
+  return originalRequire.apply(this, arguments);
+};
+
+class JSDOMNoCanvasEnvironment extends JSDOMEnvironment {
+  constructor(config, context) {
+    super(config, context);
+  }
+}
+
+module.exports = JSDOMNoCanvasEnvironment;

--- a/front/internals/jest/resolver.js
+++ b/front/internals/jest/resolver.js
@@ -1,4 +1,11 @@
+const nodePath = require('path');
+
 module.exports = (path, options) => {
+  // Intercept canvas and all subpaths
+  if (path === 'canvas' || (typeof path === 'string' && path.startsWith('canvas/'))) {
+    return nodePath.join(options.rootDir || process.cwd(), '__mocks__', 'canvas.js');
+  }
+
   // Call the defaultResolver, so we leverage its cache, error handling, etc.
   return options.defaultResolver(path, {
     ...options,

--- a/front/internals/jest/resolver.js
+++ b/front/internals/jest/resolver.js
@@ -1,11 +1,4 @@
-const nodePath = require('path');
-
 module.exports = (path, options) => {
-  // Intercept canvas and all subpaths
-  if (path === 'canvas' || (typeof path === 'string' && path.startsWith('canvas/'))) {
-    return nodePath.join(options.rootDir || process.cwd(), '__mocks__', 'canvas.js');
-  }
-
   // Call the defaultResolver, so we leverage its cache, error handling, etc.
   return options.defaultResolver(path, {
     ...options,

--- a/front/jest.config.js
+++ b/front/jest.config.js
@@ -26,7 +26,6 @@ module.exports = {
   reporters: ['default', 'jest-junit'],
   coverageReporters: ['json', 'lcov', 'text-summary', 'clover'],
   moduleNameMapper: {
-    '^canvas$': '<rootDir>/__mocks__/canvas.js',
     '\\.(css)$': 'identity-obj-proxy',
     '\\.(jpg|jpeg|png|gif|svg)$': '<rootDir>/app/utils/testUtils/fileMock.js',
     '^react-scroll-to-component$': 'identity-obj-proxy',
@@ -37,11 +36,6 @@ module.exports = {
   testEnvironmentOptions: {
     url: 'https://demo.stg.govocal.com/en/',
     customExportConditions: [''],
-    // Tell jsdom to NOT try to load canvas
-    features: {
-      FetchExternalResources: false,
-      ProcessExternalResources: false,
-    },
   },
   resolver: `${__dirname}/internals/jest/resolver.js`,
 };

--- a/front/jest.config.js
+++ b/front/jest.config.js
@@ -3,7 +3,6 @@ module.exports = {
   clearMocks: true,
   coverageDirectory: 'coverage',
   preset: undefined,
-  testEnvironment: 'jest-environment-jsdom',
   transform: {
     '^.+\\.(js|jsx|ts|tsx)$': 'babel-jest',
   },
@@ -27,15 +26,21 @@ module.exports = {
   reporters: ['default', 'jest-junit'],
   coverageReporters: ['json', 'lcov', 'text-summary', 'clover'],
   moduleNameMapper: {
+    '^canvas$': '<rootDir>/__mocks__/canvas.js',
     '\\.(css)$': 'identity-obj-proxy',
     '\\.(jpg|jpeg|png|gif|svg)$': '<rootDir>/app/utils/testUtils/fileMock.js',
     '^react-scroll-to-component$': 'identity-obj-proxy',
     '@citizenlab/cl2-component-library': '<rootDir>/app/component-library',
   },
-  modulePathIgnorePatterns: ['.*__mocks__.*'],
+  testEnvironment: '<rootDir>/internals/jest/jsdom-no-canvas.js',
   testEnvironmentOptions: {
     url: 'https://demo.stg.govocal.com/en/',
     customExportConditions: [''],
+    // Tell jsdom to NOT try to load canvas
+    features: {
+      FetchExternalResources: false,
+      ProcessExternalResources: false,
+    },
   },
   resolver: `${__dirname}/internals/jest/resolver.js`,
 };

--- a/front/jest.config.js
+++ b/front/jest.config.js
@@ -32,6 +32,7 @@ module.exports = {
     '^react-scroll-to-component$': 'identity-obj-proxy',
     '@citizenlab/cl2-component-library': '<rootDir>/app/component-library',
   },
+  modulePathIgnorePatterns: ['.*__mocks__.*'],
   testEnvironment: '<rootDir>/internals/jest/jsdom-no-canvas.js',
   testEnvironmentOptions: {
     url: 'https://demo.stg.govocal.com/en/',


### PR DESCRIPTION
AI disclaimer: I vibe-coded the solution to this canvas mock with help from Claude Sonnet

PR that disables NPM pre- and post install scripts by default. These are often exploited in supply chain attacks, like [this recent really bad one](https://snyk.io/pt-BR/blog/sha1-hulud-npm-supply-chain-incident/). None of our dependencies require pre- or post install scripts, except JSDom which relies by default on a canvas mock binary. I replaced that binary by a more stupid mock in JS. This should be fine, as long as our tests don't require actual canvas functionality (which they don't).

# Changelog
## Technical
- Disable NPM pre- and post install scripts
