### PR TITLE
TAN-5966 Mass feedback update

### DIFF
--- a/back/.rubocop_todo.yml
+++ b/back/.rubocop_todo.yml
@@ -96,7 +96,7 @@ Metrics/AbcSize:
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns, inherit_mode.
 # AllowedMethods: refine
 Metrics/BlockLength:
-  Max: 354
+  Max: 384
 
 # Offense count: 12
 # Configuration parameters: CountBlocks, CountModifierForms.


### PR DESCRIPTION
Fixes the outdated mass feedback SLS task, and uses the script reporter to report issues (like missing ideas) instead of crashing.
