### PR TITLE
Add rake task to fix youtube referrer policy in rich text

### DIFF
--- a/back/lib/tasks/fix_html_multiloc_videos.rake
+++ b/back/lib/tasks/fix_html_multiloc_videos.rake
@@ -10,7 +10,7 @@ namespace :fix_existing_description_videos do
       Idea => [:body_multiloc],
       Phase => [:description_multiloc],
       Project => [:description_multiloc],
-      StaticPage => [:body_multiloc],
+      StaticPage => [:top_info_section_multiloc, :bottom_info_section_multiloc],
       CustomField => [:description_multiloc],
       ProjectFolders::Folder => [:description_multiloc],
       EmailCampaigns::Campaign => [:body_multiloc]
@@ -36,7 +36,7 @@ namespace :fix_existing_description_videos do
 
     Tenant.safe_switch_each do |tenant|
       puts "Processing tenant #{tenant.host}..."
-      
+
       content_fields.each do |model, fields|
         puts "  Processing #{model}..."
         model.find_each do |record|

--- a/back/lib/tasks/fix_html_multiloc_videos.rake
+++ b/back/lib/tasks/fix_html_multiloc_videos.rake
@@ -11,9 +11,7 @@ namespace :fix_existing_description_videos do
       Phase => %i[description_multiloc],
       Project => %i[description_multiloc],
       StaticPage => %i[top_info_section_multiloc bottom_info_section_multiloc],
-      CustomField => %i[description_multiloc],
-      ProjectFolders::Folder => %i[description_multiloc],
-      EmailCampaigns::Campaign => %i[body_multiloc]
+      ProjectFolders::Folder => %i[description_multiloc]
     }
 
     reporter = ScriptReporter.new

--- a/back/lib/tasks/fix_html_multiloc_videos.rake
+++ b/back/lib/tasks/fix_html_multiloc_videos.rake
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+namespace :fix_existing_description_videos do
+  desc 'Add referrer policy to YouTube videos in HTML content'
+  task youtube_iframes: :environment do
+    # All models that have HTML multiloc fields that might contain iframes
+    content_fields = {
+      Area => [:description_multiloc],
+      Event => [:description_multiloc],
+      Idea => [:body_multiloc],
+      Phase => [:description_multiloc],
+      Project => [:description_multiloc],
+      StaticPage => [:body_multiloc],
+      CustomField => [:description_multiloc],
+      ProjectFolders::Folder => [:description_multiloc],
+      EmailCampaigns::Campaign => [:body_multiloc]
+    }
+
+    reporter = ScriptReporter.new
+
+    def process_html(html)
+      return html unless html
+
+      doc = Nokogiri::HTML.fragment(html)
+      modified = false
+      doc.css('iframe').each do |iframe|
+        src = iframe['src']
+        next unless src&.include?('youtube.com')
+        next if iframe['referrerpolicy'] == 'strict-origin-when-cross-origin'
+
+        iframe['referrerpolicy'] = 'strict-origin-when-cross-origin'
+        modified = true
+      end
+      [doc.to_s, modified]
+    end
+
+    Tenant.safe_switch_each do |tenant|
+      puts "Processing tenant #{tenant.host}..."
+      
+      content_fields.each do |model, fields|
+        puts "  Processing #{model}..."
+        model.find_each do |record|
+          fields.each do |field|
+            multiloc = record.send(field)
+            next unless multiloc
+
+            changed = false
+            processed_multiloc = multiloc.transform_values do |content|
+              processed_content, was_modified = process_html(content)
+              changed = true if was_modified
+              processed_content
+            end
+
+            if changed
+              record.update_column(field, processed_multiloc)
+              reporter.add_change(
+                { field => multiloc },
+                { field => processed_multiloc },
+                context: {
+                  tenant: tenant.host,
+                  model: model.name,
+                  record_id: record.id
+                }
+              )
+            end
+          end
+        end
+      end
+
+      reporter.add_processed_tenant(tenant)
+    end
+
+    reporter.report!('youtube_iframes_referrer_policy_report.json', verbose: true)
+    puts 'YouTube iframe referrer policy update completed!'
+  end
+end

--- a/back/lib/tasks/fix_html_multiloc_videos.rake
+++ b/back/lib/tasks/fix_html_multiloc_videos.rake
@@ -5,15 +5,15 @@ namespace :fix_existing_description_videos do
   task youtube_iframes: :environment do
     # All models that have HTML multiloc fields that might contain iframes
     content_fields = {
-      Area => [:description_multiloc],
-      Event => [:description_multiloc],
-      Idea => [:body_multiloc],
-      Phase => [:description_multiloc],
-      Project => [:description_multiloc],
-      StaticPage => [:top_info_section_multiloc, :bottom_info_section_multiloc],
-      CustomField => [:description_multiloc],
-      ProjectFolders::Folder => [:description_multiloc],
-      EmailCampaigns::Campaign => [:body_multiloc]
+      Area => %i[description_multiloc],
+      Event => %i[description_multiloc],
+      Idea => %i[body_multiloc],
+      Phase => %i[description_multiloc],
+      Project => %i[description_multiloc],
+      StaticPage => %i[top_info_section_multiloc bottom_info_section_multiloc],
+      CustomField => %i[description_multiloc],
+      ProjectFolders::Folder => %i[description_multiloc],
+      EmailCampaigns::Campaign => %i[body_multiloc]
     }
 
     reporter = ScriptReporter.new


### PR DESCRIPTION
Rake task output, on Benelux sandbox db:
[log_rake_task.json](https://github.com/user-attachments/files/23934641/log_rake_task.json)

Checked some platform examples too, and it looks good!
E.g. [Before](https://github.com/user-attachments/assets/d27c4138-56ae-45f6-b7d7-48053a31b4bc) and [after](https://github.com/user-attachments/assets/848ab319-66ad-49f5-8bd2-4a405b5eb6f4)

# Changelog
## Technical
- Add rake task to fix YouTube embed referrer policies in rich text.