### PR TITLE
[TAN-5983] Add rolling last 7 days change to phase insights metrics

### DIFF
--- a/back/app/services/insights/base_phase_insights_service.rb
+++ b/back/app/services/insights/base_phase_insights_service.rb
@@ -47,19 +47,19 @@ module Insights
     def base_metrics(participations, participant_ids, visits)
       visitors_count = visits.pluck(:visitor_id).uniq.count
       participants_count = participant_ids.count
-      base_rolling_7_day_changes = base_rolling_7_day_changes(participations, visits)
+      base_7_day_changes = base_7_day_changes(participations, visits)
 
       {
         visitors: visitors_count,
-        visitors_rolling_7_day_change: base_rolling_7_day_changes[:visitors_rolling_7_day_change],
+        visitors_7_day_change: base_7_day_changes[:visitors_7_day_change],
         participants: participants_count,
-        participants_rolling_7_day_change: base_rolling_7_day_changes[:participants_rolling_7_day_change],
+        participants_7_day_change: base_7_day_changes[:participants_7_day_change],
         participation_rate: visitors_count > 0 ? (participants_count.to_f / visitors_count).round(3) : 0,
-        participation_rate_rolling_7_day_change: base_rolling_7_day_changes[:participation_rate_rolling_7_day_change]
+        participation_rate_7_day_change: base_7_day_changes[:participation_rate_7_day_change]
       }
     end
 
-    def base_rolling_7_day_changes(participations, visits)
+    def base_7_day_changes(participations, visits)
       flattened_participations = participations.values.flatten
 
       participants_last_7_days_count = flattened_participations.select do |p|
@@ -82,9 +82,9 @@ module Insights
       participation_rate_previous_7_days = visitors_previous_7_days_count > 0 ? (participants_previous_7_days_count.to_f / visitors_previous_7_days_count).round(3) : 0
 
       {
-        visitors_rolling_7_day_change: percentage_change(visitors_previous_7_days_count, visitors_last_7_days_count),
-        participants_rolling_7_day_change: percentage_change(participants_previous_7_days_count, participants_last_7_days_count),
-        participation_rate_rolling_7_day_change: percentage_change(participation_rate_previous_7_days, participation_rate_last_7_days)
+        visitors_7_day_change: percentage_change(visitors_previous_7_days_count, visitors_last_7_days_count),
+        participants_7_day_change: percentage_change(participants_previous_7_days_count, participants_last_7_days_count),
+        participation_rate_7_day_change: percentage_change(participation_rate_previous_7_days, participation_rate_last_7_days)
       }
     end
 
@@ -114,7 +114,7 @@ module Insights
       (((new_value - old_value).to_f / old_value) * 100.0).round(1)
     end
 
-    def participations_rolling_7_day_change(participations)
+    def participations_7_day_change(participations)
       return nil unless phase_has_run_more_than_14_days?
       return 0.0 if participations.empty?
 

--- a/back/app/services/insights/base_phase_insights_service.rb
+++ b/back/app/services/insights/base_phase_insights_service.rb
@@ -23,19 +23,19 @@ module Insights
 
     # TODO: Implement caching? (may not be needed if performance good enough)
     def cached_insights_data(participations)
-      visits_data = VisitsService.new.phase_visits_data(@phase)
+      visits = VisitsService.new.phase_visits(@phase)
       flattened_participations = participations.values.flatten
       participant_ids = flattened_participations.pluck(:participant_id).uniq
       participation_method_metrics = phase_participation_method_metrics(participations)
-      metrics = metrics_data(participations, participant_ids, visits_data, participation_method_metrics)
+      metrics = metrics_data(participations, participant_ids, visits, participation_method_metrics)
       demographics = demographics_data(flattened_participations, participant_ids)
-      participants_and_visitors_chart_data = participants_and_visitors_chart_data(flattened_participations, visits_data)
+      participants_and_visitors_chart_data = participants_and_visitors_chart_data(flattened_participations, visits)
 
       metrics.merge(demographics: { fields: demographics }, participants_and_visitors_chart_data: participants_and_visitors_chart_data)
     end
 
-    def metrics_data(participations, participant_ids, visits_data, participation_method_metrics)
-      base_metrics = base_metrics(participations, participant_ids, visits_data)
+    def metrics_data(participations, participant_ids, visits, participation_method_metrics)
+      base_metrics = base_metrics(participations, participant_ids, visits)
 
       phase_participation_method_metrics = {
         @phase.participation_method => participation_method_metrics
@@ -44,7 +44,7 @@ module Insights
       { metrics: base_metrics.merge(phase_participation_method_metrics) }
     end
 
-    def base_metrics(participations, participant_ids, visits_data)
+    def base_metrics(participations, participant_ids, visits)
       total_participant_count = participant_ids.count
       flattened_participations = participations.values.flatten
 
@@ -52,12 +52,15 @@ module Insights
 
       participants_rolling_7_day_change = phase_run_14_days ? participants_rolling_7_day_change(flattened_participations) : nil
 
+      unique_visitors = visits.pluck(:visitor_id).compact.uniq.count
+      unique_visitors_last_7_days = visits.select { |v| v[:acted_at] >= 7.days.ago }.pluck(:visitor_id).compact.uniq.count
+
       {
-        visitors: visits_data[:visitors_total],
-        visitors_last_7_days: visits_data[:visitors_last_7_days],
+        visitors: unique_visitors,
+        visitors_last_7_days: unique_visitors_last_7_days,
         participants: total_participant_count,
         participants_rolling_7_day_change: participants_rolling_7_day_change,
-        engagement_rate: visits_data[:visitors_total] > 0 ? (total_participant_count.to_f / visits_data[:visitors_total]).round(3) : 0
+        engagement_rate: unique_visitors > 0 ? (total_participant_count.to_f / unique_visitors).round(3) : 0
       }
     end
 
@@ -275,9 +278,9 @@ module Insights
       UserCustomFields::Representativeness::RScore.compute_scores(counts, reference_distribution)[:min_max_p_ratio]
     end
 
-    def participants_and_visitors_chart_data(flattened_participations, visits_data)
+    def participants_and_visitors_chart_data(flattened_participations, visits)
       resolution = chart_resolution
-      grouped_visits = visits_data[:visits].group_by { |v| date_truncate(v[:date], resolution) }
+      grouped_visits = visits.group_by { |v| date_truncate(v[:acted_at], resolution) }
       grouped_participations = flattened_participations.group_by { |p| date_truncate(p[:acted_at], resolution) }
 
       # Get all unique date groups from both participations and visits

--- a/back/app/services/insights/base_phase_insights_service.rb
+++ b/back/app/services/insights/base_phase_insights_service.rb
@@ -66,12 +66,18 @@ module Insights
           v[:acted_at] < 7.days.ago && v[:acted_at] >= 14.days.ago
         end.pluck(:visitor_id).uniq.count
 
+        engagement_rate_last_7_days = visitors_last_7_days_count > 0 ? (participants_last_7_days_count.to_f / visitors_last_7_days_count).round(3) : 0
+        engagement_rate_last_14_to_8_days = visitors_last_14_to_8_days_count > 0 ? (participants_last_14_to_8_days_count.to_f / visitors_last_14_to_8_days_count).round(3) : 0
+
+        puts "engagement_rate_last_7_days: #{engagement_rate_last_7_days}, engagement_rate_last_14_to_8_days: #{engagement_rate_last_14_to_8_days}"
+
         {
           visitors: unique_visitors,
           visitors_rolling_7_day_change: percentage_change(visitors_last_14_to_8_days_count, visitors_last_7_days_count),
           participants: total_participant_count,
           participants_rolling_7_day_change: percentage_change(participants_last_14_to_8_days_count, participants_last_7_days_count),
-          engagement_rate: unique_visitors > 0 ? (total_participant_count.to_f / unique_visitors).round(3) : 0
+          engagement_rate: unique_visitors > 0 ? (total_participant_count.to_f / unique_visitors).round(3) : 0,
+          engagement_rate_rolling_7_day_change: percentage_change(engagement_rate_last_14_to_8_days, engagement_rate_last_7_days)
         }
       else
         {
@@ -79,7 +85,8 @@ module Insights
           visitors_rolling_7_day_change: nil,
           participants: total_participant_count,
           participants_rolling_7_day_change: nil,
-          engagement_rate: unique_visitors > 0 ? (total_participant_count.to_f / unique_visitors).round(3) : 0
+          engagement_rate: unique_visitors > 0 ? (total_participant_count.to_f / unique_visitors).round(3) : 0,
+          engagement_rate_rolling_7_day_change: nil
         }
       end
     end
@@ -106,7 +113,7 @@ module Insights
       return nil if old_value.zero?
 
       # Round to one decimal place
-      (((new_value - old_value).to_f / old_value) * 100).round(1)
+      (((new_value - old_value).to_f / old_value) * 100.0).round(1)
     end
 
     def participant_id(item_id, user_id, user_hash = nil)

--- a/back/app/services/insights/base_phase_insights_service.rb
+++ b/back/app/services/insights/base_phase_insights_service.rb
@@ -124,8 +124,6 @@ module Insights
         p[:acted_at] < 7.days.ago && p[:acted_at] >= 14.days.ago
       end
 
-      # puts "participations_last_7_days_count: #{participations_last_7_days_count.count}, participations_last_14_to_8_days_count: #{participations_last_14_to_8_days_count.count}"
-
       percentage_change(
         participations_last_14_to_8_days_count.count,
         participations_last_7_days_count.count

--- a/back/app/services/insights/base_phase_insights_service.rb
+++ b/back/app/services/insights/base_phase_insights_service.rb
@@ -109,7 +109,7 @@ module Insights
 
     def percentage_change(old_value, new_value)
       return 0.0 if old_value == new_value # Includes case where both are zero
-      return nil if old_value.zero? # Infinite percentage change (avoid division by zero)
+      return 'last_7_days_compared_with_zero' if old_value.zero? # Infinite percentage change (avoid division by zero)
 
       # Round to one decimal place
       (((new_value - old_value).to_f / old_value) * 100.0).round(1)

--- a/back/app/services/insights/base_phase_insights_service.rb
+++ b/back/app/services/insights/base_phase_insights_service.rb
@@ -50,7 +50,7 @@ module Insights
       phase_run_14_days = phase_has_run_more_than_14_days?
 
       participants_rolling_7_day_change = phase_run_14_days ? participants_rolling_7_day_change(flattened_participations) : nil
-      unique_visitors = visits.pluck(:visitor_id).compact.uniq.count
+      unique_visitors = visits.pluck(:visitor_id).uniq.count
       visitors_rolling_7_day_change = phase_run_14_days ? visitors_rolling_7_day_change(visits) : nil
 
       {
@@ -302,7 +302,7 @@ module Insights
 
         {
           participants: participations_in_group.pluck(:participant_id).uniq.count,
-          visitors: visits_in_group.pluck(:visitor_id).compact.uniq.count,
+          visitors: visits_in_group.pluck(:visitor_id).uniq.count,
           date_group: date_group
         }
       end

--- a/back/app/services/insights/base_phase_insights_service.rb
+++ b/back/app/services/insights/base_phase_insights_service.rb
@@ -45,17 +45,17 @@ module Insights
     end
 
     def base_metrics(participations, participant_ids, visits)
-      unique_visitors = visits.pluck(:visitor_id).uniq.count
-      unique_participants = participant_ids.count
+      visitors_count = visits.pluck(:visitor_id).uniq.count
+      participants_count = participant_ids.count
       base_rolling_7_day_changes = base_rolling_7_day_changes(participations, visits)
 
       {
-        visitors: unique_visitors,
+        visitors: visitors_count,
         visitors_rolling_7_day_change: base_rolling_7_day_changes[:visitors_rolling_7_day_change],
-        participants: unique_participants,
+        participants: participants_count,
         participants_rolling_7_day_change: base_rolling_7_day_changes[:participants_rolling_7_day_change],
-        engagement_rate: unique_visitors > 0 ? (unique_participants.to_f / unique_visitors).round(3) : 0,
-        engagement_rate_rolling_7_day_change: base_rolling_7_day_changes[:engagement_rate_rolling_7_day_change]
+        participation_rate: visitors_count > 0 ? (participants_count.to_f / visitors_count).round(3) : 0,
+        participation_rate_rolling_7_day_change: base_rolling_7_day_changes[:participation_rate_rolling_7_day_change]
       }
     end
 
@@ -78,13 +78,13 @@ module Insights
         v[:acted_at] < 7.days.ago && v[:acted_at] >= 14.days.ago
       end.pluck(:visitor_id).uniq.count
 
-      engagement_rate_last_7_days = visitors_last_7_days_count > 0 ? (participants_last_7_days_count.to_f / visitors_last_7_days_count).round(3) : 0
-      engagement_rate_previous_7_days = visitors_previous_7_days_count > 0 ? (participants_previous_7_days_count.to_f / visitors_previous_7_days_count).round(3) : 0
+      participation_rate_last_7_days = visitors_last_7_days_count > 0 ? (participants_last_7_days_count.to_f / visitors_last_7_days_count).round(3) : 0
+      participation_rate_previous_7_days = visitors_previous_7_days_count > 0 ? (participants_previous_7_days_count.to_f / visitors_previous_7_days_count).round(3) : 0
 
       {
         visitors_rolling_7_day_change: percentage_change(visitors_previous_7_days_count, visitors_last_7_days_count),
         participants_rolling_7_day_change: percentage_change(participants_previous_7_days_count, participants_last_7_days_count),
-        engagement_rate_rolling_7_day_change: percentage_change(engagement_rate_previous_7_days, engagement_rate_last_7_days)
+        participation_rate_rolling_7_day_change: percentage_change(participation_rate_previous_7_days, participation_rate_last_7_days)
       }
     end
 

--- a/back/app/services/insights/base_phase_insights_service.rb
+++ b/back/app/services/insights/base_phase_insights_service.rb
@@ -58,6 +58,24 @@ module Insights
       }
     end
 
+    def phase_has_run_more_than_14_days?
+      time_now = Time.current
+      phase_start_at = @phase.start_at.to_time
+      phase_end_at = (@phase.end_at || time_now).to_time
+
+      # Check if the phase duration (start to end or current time) is more than 14 days
+      phase_duration_seconds = phase_end_at - phase_start_at
+      phase_duration_days = (phase_duration_seconds / 86_400).to_i
+
+      return false if phase_duration_days < 14
+
+      # Check if the elapsed time from phase start to now is more than 14 days
+      elapsed_seconds = time_now - phase_start_at
+      elapsed_days = (elapsed_seconds / 86_400).to_i
+
+      elapsed_days >= 14
+    end
+
     def participant_id(item_id, user_id, user_hash = nil)
       user_id.presence || user_hash.presence || item_id
     end

--- a/back/app/services/insights/base_phase_insights_service.rb
+++ b/back/app/services/insights/base_phase_insights_service.rb
@@ -76,6 +76,13 @@ module Insights
       elapsed_days >= 14
     end
 
+    def percentage_change(old_value, new_value)
+      return nil if old_value.zero?
+
+      # Round to one decimal place
+      (((new_value - old_value).to_f / old_value) * 100).round(1)
+    end
+
     def participant_id(item_id, user_id, user_hash = nil)
       user_id.presence || user_hash.presence || item_id
     end

--- a/back/app/services/insights/base_phase_insights_service.rb
+++ b/back/app/services/insights/base_phase_insights_service.rb
@@ -110,6 +110,7 @@ module Insights
     end
 
     def percentage_change(old_value, new_value)
+      return 0.0 if old_value == new_value # Includes case where both are zero
       return nil if old_value.zero?
 
       # Round to one decimal place

--- a/back/app/services/insights/base_phase_insights_service.rb
+++ b/back/app/services/insights/base_phase_insights_service.rb
@@ -47,43 +47,41 @@ module Insights
     def base_metrics(participations, participant_ids, visits)
       total_participant_count = participant_ids.count
       flattened_participations = participations.values.flatten
-      phase_run_14_days = phase_has_run_more_than_14_days?
-
-      participants_rolling_7_day_change = phase_run_14_days ? participants_rolling_7_day_change(flattened_participations) : nil
       unique_visitors = visits.pluck(:visitor_id).uniq.count
-      visitors_rolling_7_day_change = phase_run_14_days ? visitors_rolling_7_day_change(visits) : nil
 
-      {
-        visitors: unique_visitors,
-        visitors_rolling_7_day_change: visitors_rolling_7_day_change,
-        participants: total_participant_count,
-        participants_rolling_7_day_change: participants_rolling_7_day_change,
-        engagement_rate: unique_visitors > 0 ? (total_participant_count.to_f / unique_visitors).round(3) : 0
-      }
-    end
+      if phase_has_run_more_than_14_days?
+        participants_last_7_days_count = flattened_participations.select do |p|
+          p[:acted_at] >= 7.days.ago
+        end.pluck(:participant_id).uniq.count
 
-    def participants_rolling_7_day_change(flattened_participations)
-      participants_last_7_days_count = flattened_participations.select do |p|
-        p[:acted_at] >= 7.days.ago
-      end.pluck(:participant_id).uniq.count
+        participants_last_14_to_8_days_count = flattened_participations.select do |p|
+          p[:acted_at] < 7.days.ago && p[:acted_at] >= 14.days.ago
+        end.pluck(:participant_id).uniq.count
 
-      participants_last_14_to_8_days_count = flattened_participations.select do |p|
-        p[:acted_at] < 7.days.ago && p[:acted_at] >= 14.days.ago
-      end.pluck(:participant_id).uniq.count
+        visitors_last_7_days_count = visits.select do |v|
+          v[:acted_at] >= 7.days.ago
+        end.pluck(:visitor_id).uniq.count
 
-      percentage_change(participants_last_14_to_8_days_count, participants_last_7_days_count)
-    end
+        visitors_last_14_to_8_days_count = visits.select do |v|
+          v[:acted_at] < 7.days.ago && v[:acted_at] >= 14.days.ago
+        end.pluck(:visitor_id).uniq.count
 
-    def visitors_rolling_7_day_change(visits)
-      visitors_last_7_days_count = visits.select do |v|
-        v[:acted_at] >= 7.days.ago
-      end.pluck(:visitor_id).uniq.count
-
-      visitors_last_14_to_8_days_count = visits.select do |v|
-        v[:acted_at] < 7.days.ago && v[:acted_at] >= 14.days.ago
-      end.pluck(:visitor_id).uniq.count
-
-      percentage_change(visitors_last_14_to_8_days_count, visitors_last_7_days_count)
+        {
+          visitors: unique_visitors,
+          visitors_rolling_7_day_change: percentage_change(visitors_last_14_to_8_days_count, visitors_last_7_days_count),
+          participants: total_participant_count,
+          participants_rolling_7_day_change: percentage_change(participants_last_14_to_8_days_count, participants_last_7_days_count),
+          engagement_rate: unique_visitors > 0 ? (total_participant_count.to_f / unique_visitors).round(3) : 0
+        }
+      else
+        {
+          visitors: unique_visitors,
+          visitors_rolling_7_day_change: nil,
+          participants: total_participant_count,
+          participants_rolling_7_day_change: nil,
+          engagement_rate: unique_visitors > 0 ? (total_participant_count.to_f / unique_visitors).round(3) : 0
+        }
+      end
     end
 
     def phase_has_run_more_than_14_days?

--- a/back/app/services/insights/base_phase_insights_service.rb
+++ b/back/app/services/insights/base_phase_insights_service.rb
@@ -137,39 +137,6 @@ module Insights
       @phase.ideas.where(publication_status: 'published').count
     end
 
-    def phase_ideas_counts(participations)
-      total_ideas = participations.count
-      ideas_last_7_days = participations.count { |p| p[:acted_at] >= 7.days.ago }
-
-      {
-        total: total_ideas,
-        last_7_days: ideas_last_7_days
-      }
-    end
-
-    # idea comments posted during the phase
-    def phase_comments_counts(participations)
-      commenting_participations = participations[:commenting_idea] || []
-      total_comments = commenting_participations.count
-      comments_last_7_days = commenting_participations.count { |p| p[:acted_at] >= 7.days.ago }
-
-      {
-        total: total_comments,
-        last_7_days: comments_last_7_days
-      }
-    end
-
-    def phase_reactions_counts(participations)
-      reacting_participations = participations[:reacting_idea] || []
-      total_reactions = reacting_participations.count
-      reactions_last_7_days = reacting_participations.count { |p| p[:acted_at] >= 7.days.ago }
-
-      {
-        total: total_reactions,
-        last_7_days: reactions_last_7_days
-      }
-    end
-
     def demographics_data(participations, participant_ids)
       return [] if participant_ids.empty?
 

--- a/back/app/services/insights/base_phase_insights_service.rb
+++ b/back/app/services/insights/base_phase_insights_service.rb
@@ -124,7 +124,7 @@ module Insights
         p[:acted_at] < 7.days.ago && p[:acted_at] >= 14.days.ago
       end
 
-      puts "participations_last_7_days_count: #{participations_last_7_days_count.count}, participations_last_14_to_8_days_count: #{participations_last_14_to_8_days_count.count}"
+      # puts "participations_last_7_days_count: #{participations_last_7_days_count.count}, participations_last_14_to_8_days_count: #{participations_last_14_to_8_days_count.count}"
 
       percentage_change(
         participations_last_14_to_8_days_count.count,

--- a/back/app/services/insights/base_phase_insights_service.rb
+++ b/back/app/services/insights/base_phase_insights_service.rb
@@ -54,7 +54,7 @@ module Insights
           p[:acted_at] >= 7.days.ago
         end.pluck(:participant_id).uniq.count
 
-        participants_last_14_to_8_days_count = flattened_participations.select do |p|
+        participants_previous_7_days_count = flattened_participations.select do |p|
           p[:acted_at] < 7.days.ago && p[:acted_at] >= 14.days.ago
         end.pluck(:participant_id).uniq.count
 
@@ -62,20 +62,20 @@ module Insights
           v[:acted_at] >= 7.days.ago
         end.pluck(:visitor_id).uniq.count
 
-        visitors_last_14_to_8_days_count = visits.select do |v|
+        visitors_previous_7_days_count = visits.select do |v|
           v[:acted_at] < 7.days.ago && v[:acted_at] >= 14.days.ago
         end.pluck(:visitor_id).uniq.count
 
         engagement_rate_last_7_days = visitors_last_7_days_count > 0 ? (participants_last_7_days_count.to_f / visitors_last_7_days_count).round(3) : 0
-        engagement_rate_last_14_to_8_days = visitors_last_14_to_8_days_count > 0 ? (participants_last_14_to_8_days_count.to_f / visitors_last_14_to_8_days_count).round(3) : 0
+        engagement_rate_previous_7_days = visitors_previous_7_days_count > 0 ? (participants_previous_7_days_count.to_f / visitors_previous_7_days_count).round(3) : 0
 
         {
           visitors: unique_visitors,
-          visitors_rolling_7_day_change: percentage_change(visitors_last_14_to_8_days_count, visitors_last_7_days_count),
+          visitors_rolling_7_day_change: percentage_change(visitors_previous_7_days_count, visitors_last_7_days_count),
           participants: total_participant_count,
-          participants_rolling_7_day_change: percentage_change(participants_last_14_to_8_days_count, participants_last_7_days_count),
+          participants_rolling_7_day_change: percentage_change(participants_previous_7_days_count, participants_last_7_days_count),
           engagement_rate: unique_visitors > 0 ? (total_participant_count.to_f / unique_visitors).round(3) : 0,
-          engagement_rate_rolling_7_day_change: percentage_change(engagement_rate_last_14_to_8_days, engagement_rate_last_7_days)
+          engagement_rate_rolling_7_day_change: percentage_change(engagement_rate_previous_7_days, engagement_rate_last_7_days)
         }
       else
         {
@@ -120,12 +120,12 @@ module Insights
       return 0.0 if participations.empty?
 
       participations_last_7_days_count = participations.select { |p| p[:acted_at] >= 7.days.ago }
-      participations_last_14_to_8_days_count = participations.select do |p|
+      participations_previous_7_days_count = participations.select do |p|
         p[:acted_at] < 7.days.ago && p[:acted_at] >= 14.days.ago
       end
 
       percentage_change(
-        participations_last_14_to_8_days_count.count,
+        participations_previous_7_days_count.count,
         participations_last_7_days_count.count
       )
     end

--- a/back/app/services/insights/base_phase_insights_service.rb
+++ b/back/app/services/insights/base_phase_insights_service.rb
@@ -47,7 +47,7 @@ module Insights
     def base_metrics(participations, participant_ids, visits_data)
       total_participant_count = participant_ids.count
       flattened_participations = participations.values.flatten
-      
+
       phase_run_14_days = phase_has_run_more_than_14_days?
 
       participants_rolling_7_day_change = phase_run_14_days ? participants_rolling_7_day_change(flattened_participations) : nil

--- a/back/app/services/insights/common_ground_phase_insights_service.rb
+++ b/back/app/services/insights/common_ground_phase_insights_service.rb
@@ -37,9 +37,9 @@ module Insights
       {
         associated_ideas: associated_published_ideas_count,
         ideas_posted: participations[:posting_idea].count,
-        ideas_posted_rolling_7_day_change: participations_rolling_7_day_change(participations[:posting_idea]),
+        ideas_posted_7_day_change: participations_7_day_change(participations[:posting_idea]),
         reactions: participations[:reacting_idea].count,
-        reactions_rolling_7_day_change: participations_rolling_7_day_change(participations[:reacting_idea])
+        reactions_7_day_change: participations_7_day_change(participations[:reacting_idea])
       }
     end
   end

--- a/back/app/services/insights/common_ground_phase_insights_service.rb
+++ b/back/app/services/insights/common_ground_phase_insights_service.rb
@@ -34,15 +34,12 @@ module Insights
     end
 
     def phase_participation_method_metrics(participations)
-      ideas_counts = phase_ideas_counts(participations[:posting_idea] || [])
-      reactions_counts = phase_reactions_counts(participations)
-
       {
         associated_ideas: associated_published_ideas_count,
-        ideas_posted: ideas_counts[:total],
-        ideas_posted_last_7_days: ideas_counts[:last_7_days],
-        reactions: reactions_counts[:total],
-        reactions_last_7_days: reactions_counts[:last_7_days]
+        ideas_posted: participations[:posting_idea].count,
+        ideas_posted_rolling_7_day_change: participations_rolling_7_day_change(participations[:posting_idea]),
+        reactions: participations[:reacting_idea].count,
+        reactions_rolling_7_day_change: participations_rolling_7_day_change(participations[:reacting_idea])
       }
     end
   end

--- a/back/app/services/insights/ideation_phase_insights_service.rb
+++ b/back/app/services/insights/ideation_phase_insights_service.rb
@@ -78,11 +78,11 @@ module Insights
 
     def phase_participation_method_metrics(participations)
       {
-        ideas_posted: (participations[:posting_idea] || []).count,
+        ideas_posted: participations[:posting_idea].count,
         ideas_posted_7_day_change: participations_7_day_change(participations[:posting_idea]),
-        comments_posted: (participations[:commenting_idea] || []).count,
+        comments_posted: participations[:commenting_idea].count,
         comments_posted_7_day_change: participations_7_day_change(participations[:commenting_idea]),
-        reactions: (participations[:reacting_idea] || []).count,
+        reactions: participations[:reacting_idea].count,
         reactions_7_day_change: participations_7_day_change(participations[:reacting_idea])
       }
     end

--- a/back/app/services/insights/ideation_phase_insights_service.rb
+++ b/back/app/services/insights/ideation_phase_insights_service.rb
@@ -79,11 +79,11 @@ module Insights
     def phase_participation_method_metrics(participations)
       {
         ideas_posted: (participations[:posting_idea] || []).count,
-        ideas_posted_rolling_7_day_change: participations_rolling_7_day_change(participations[:posting_idea]),
+        ideas_posted_7_day_change: participations_7_day_change(participations[:posting_idea]),
         comments_posted: (participations[:commenting_idea] || []).count,
-        comments_posted_rolling_7_day_change: participations_rolling_7_day_change(participations[:commenting_idea]),
+        comments_posted_7_day_change: participations_7_day_change(participations[:commenting_idea]),
         reactions: (participations[:reacting_idea] || []).count,
-        reactions_rolling_7_day_change: participations_rolling_7_day_change(participations[:reacting_idea])
+        reactions_7_day_change: participations_7_day_change(participations[:reacting_idea])
       }
     end
   end

--- a/back/app/services/insights/ideation_phase_insights_service.rb
+++ b/back/app/services/insights/ideation_phase_insights_service.rb
@@ -77,17 +77,13 @@ module Insights
     end
 
     def phase_participation_method_metrics(participations)
-      ideas_counts = phase_ideas_counts(participations[:posting_idea] || [])
-      comments_counts = phase_comments_counts(participations)
-      reactions_counts = phase_reactions_counts(participations)
-
       {
-        ideas_posted: ideas_counts[:total],
-        ideas_posted_last_7_days: ideas_counts[:last_7_days],
-        comments_posted: comments_counts[:total],
-        comments_posted_last_7_days: comments_counts[:last_7_days],
-        reactions: reactions_counts[:total],
-        reactions_last_7_days: reactions_counts[:last_7_days]
+        ideas_posted: (participations[:posting_idea] || []).count,
+        ideas_posted_rolling_7_day_change: participations_rolling_7_day_change(participations[:posting_idea]),
+        comments_posted: (participations[:commenting_idea] || []).count,
+        comments_posted_rolling_7_day_change: participations_rolling_7_day_change(participations[:commenting_idea]),
+        reactions: (participations[:reacting_idea] || []).count,
+        reactions_rolling_7_day_change: participations_rolling_7_day_change(participations[:reacting_idea])
       }
     end
   end

--- a/back/app/services/insights/native_survey_phase_insights_service.rb
+++ b/back/app/services/insights/native_survey_phase_insights_service.rb
@@ -36,23 +36,23 @@ module Insights
 
       if phase_has_run_more_than_14_days?
         ideas_last_7_days_count = participations[:posting_idea].count { |p| p[:acted_at] >= 7.days.ago }
-        ideas_last_14_to_8_days_count = participations[:posting_idea].count do |p|
+        ideas_previous_7_days_count = participations[:posting_idea].count do |p|
           p[:acted_at] < 7.days.ago && p[:acted_at] >= 14.days.ago
         end
 
         submitted_last_7_days_count = submitted_survey_participations.count { |p| p[:survey_submitted_at] >= 7.days.ago }
-        submitted_last_14_to_8_days_count = submitted_survey_participations.count do |p|
+        submitted_previous_7_days_count = submitted_survey_participations.count do |p|
           p[:survey_submitted_at] < 7.days.ago && p[:survey_submitted_at] >= 14.days.ago
         end
 
         completion_rate_last_7_days = completion_rate(ideas_last_7_days_count, submitted_last_7_days_count)
-        completion_rate_last_14_to_8_days = completion_rate(ideas_last_14_to_8_days_count, submitted_last_14_to_8_days_count)
+        completion_rate_previous_7_days = completion_rate(ideas_previous_7_days_count, submitted_previous_7_days_count)
 
         {
           submitted_surveys: total_submitted_surveys,
-          submitted_surveys_rolling_7_day_change: percentage_change(submitted_last_14_to_8_days_count, submitted_last_7_days_count),
+          submitted_surveys_rolling_7_day_change: percentage_change(submitted_previous_7_days_count, submitted_last_7_days_count),
           completion_rate: completion_rate,
-          completion_rate_rolling_7_day_change: percentage_change(completion_rate_last_14_to_8_days, completion_rate_last_7_days)
+          completion_rate_rolling_7_day_change: percentage_change(completion_rate_previous_7_days, completion_rate_last_7_days)
         }
       else
         {
@@ -75,12 +75,12 @@ module Insights
       return 0.0 if participations.empty?
 
       participations_last_7_days_count = participations.select { |p| p[:survey_submitted_at] >= 7.days.ago }
-      participations_last_14_to_8_days_count = participations.select do |p|
+      participations_previous_7_days_count = participations.select do |p|
         p[:survey_submitted_at] < 7.days.ago && p[:survey_submitted_at] >= 14.days.ago
       end
 
       percentage_change(
-        participations_last_14_to_8_days_count.count,
+        participations_previous_7_days_count.count,
         participations_last_7_days_count.count
       )
     end

--- a/back/app/services/insights/native_survey_phase_insights_service.rb
+++ b/back/app/services/insights/native_survey_phase_insights_service.rb
@@ -30,7 +30,7 @@ module Insights
 
     def phase_participation_method_metrics(participations)
       posted_ideas_count = participations[:posting_idea].count
-      submitted_survey_participations = participations[:posting_idea]&.select { |p| p[:survey_submitted_at].present? } || []
+      submitted_survey_participations = participations[:posting_idea].select { |p| p[:survey_submitted_at].present? }
       total_submitted_surveys = submitted_survey_participations.count
       completion_rate = completion_rate(posted_ideas_count, total_submitted_surveys)
       rolling_7_day_changes = rolling_7_day_changes(participations)
@@ -62,7 +62,7 @@ module Insights
         p[:acted_at] < 7.days.ago && p[:acted_at] >= 14.days.ago
       end
 
-      submitted_survey_participations = participations[:posting_idea]&.select { |p| p[:survey_submitted_at].present? } || []
+      submitted_survey_participations = participations[:posting_idea].select { |p| p[:survey_submitted_at].present? }
 
       submitted_last_7_days_count = submitted_survey_participations.count { |p| p[:survey_submitted_at] >= 7.days.ago }
       submitted_previous_7_days_count = submitted_survey_participations.count do |p|

--- a/back/app/services/insights/native_survey_phase_insights_service.rb
+++ b/back/app/services/insights/native_survey_phase_insights_service.rb
@@ -35,15 +35,15 @@ module Insights
       completion_rate = completion_rate(posted_ideas_count, total_submitted_surveys)
 
       if phase_has_run_more_than_14_days?
-        ideas_last_7_days_count = participations[:posting_idea].select { |p| p[:acted_at] >= 7.days.ago }.count
-        ideas_last_14_to_8_days_count = participations[:posting_idea].select do |p|
+        ideas_last_7_days_count = participations[:posting_idea].count { |p| p[:acted_at] >= 7.days.ago }
+        ideas_last_14_to_8_days_count = participations[:posting_idea].count do |p|
           p[:acted_at] < 7.days.ago && p[:acted_at] >= 14.days.ago
-        end.count
+        end
 
-        submitted_last_7_days_count = submitted_survey_participations.select { |p| p[:survey_submitted_at] >= 7.days.ago }.count
-        submitted_last_14_to_8_days_count = submitted_survey_participations.select do |p|
+        submitted_last_7_days_count = submitted_survey_participations.count { |p| p[:survey_submitted_at] >= 7.days.ago }
+        submitted_last_14_to_8_days_count = submitted_survey_participations.count do |p|
           p[:survey_submitted_at] < 7.days.ago && p[:survey_submitted_at] >= 14.days.ago
-        end.count
+        end
 
         completion_rate_last_7_days = completion_rate(ideas_last_7_days_count, submitted_last_7_days_count)
         completion_rate_last_14_to_8_days = completion_rate(ideas_last_14_to_8_days_count, submitted_last_14_to_8_days_count)
@@ -78,8 +78,6 @@ module Insights
       participations_last_14_to_8_days_count = participations.select do |p|
         p[:survey_submitted_at] < 7.days.ago && p[:survey_submitted_at] >= 14.days.ago
       end
-
-      puts "participations_last_7_days_count: #{participations_last_7_days_count.count}, participations_last_14_to_8_days_count: #{participations_last_14_to_8_days_count.count}"
 
       percentage_change(
         participations_last_14_to_8_days_count.count,

--- a/back/app/services/insights/native_survey_phase_insights_service.rb
+++ b/back/app/services/insights/native_survey_phase_insights_service.rb
@@ -29,18 +29,62 @@ module Insights
     end
 
     def phase_participation_method_metrics(participations)
-      ideas_counts = phase_ideas_counts(participations[:posting_idea] || [])
+      posted_ideas_count = participations[:posting_idea].count
       submitted_survey_participations = participations[:posting_idea]&.select { |p| p[:survey_submitted_at].present? } || []
       total_submitted_surveys = submitted_survey_participations.count
-      submitted_surveys_last_7_days = submitted_survey_participations.count { |p| p[:survey_submitted_at] >= 7.days.ago }
+      completion_rate = completion_rate(posted_ideas_count, total_submitted_surveys)
 
-      completion_rate = ideas_counts[:total] > 0 ? (total_submitted_surveys.to_f / ideas_counts[:total]).round(3) : 0
+      if phase_has_run_more_than_14_days?
+        ideas_last_7_days_count = participations[:posting_idea].select { |p| p[:acted_at] >= 7.days.ago }.count
+        ideas_last_14_to_8_days_count = participations[:posting_idea].select do |p|
+          p[:acted_at] < 7.days.ago && p[:acted_at] >= 14.days.ago
+        end.count
 
-      {
-        submitted_surveys: total_submitted_surveys,
-        submitted_surveys_last_7_days: submitted_surveys_last_7_days,
-        completion_rate: completion_rate
-      }
+        submitted_last_7_days_count = submitted_survey_participations.select { |p| p[:survey_submitted_at] >= 7.days.ago }.count
+        submitted_last_14_to_8_days_count = submitted_survey_participations.select do |p|
+          p[:survey_submitted_at] < 7.days.ago && p[:survey_submitted_at] >= 14.days.ago
+        end.count
+
+        completion_rate_last_7_days = completion_rate(ideas_last_7_days_count, submitted_last_7_days_count)
+        completion_rate_last_14_to_8_days = completion_rate(ideas_last_14_to_8_days_count, submitted_last_14_to_8_days_count)
+
+        {
+          submitted_surveys: total_submitted_surveys,
+          submitted_surveys_rolling_7_day_change: percentage_change(submitted_last_14_to_8_days_count, submitted_last_7_days_count),
+          completion_rate: completion_rate,
+          completion_rate_rolling_7_day_change: percentage_change(completion_rate_last_14_to_8_days, completion_rate_last_7_days)
+        }
+      else
+        {
+          submitted_surveys: total_submitted_surveys,
+          submitted_surveys_rolling_7_day_change: nil,
+          completion_rate: completion_rate,
+          completion_rate_rolling_7_day_change: nil
+        }
+      end
+    end
+
+    def completion_rate(all, submitted)
+      return 0 if all == 0
+
+      (submitted.to_f / all).round(3)
+    end
+
+    def submitted_surveys_rolling_7_day_change(participations)
+      return nil unless phase_has_run_more_than_14_days?
+      return 0.0 if participations.empty?
+
+      participations_last_7_days_count = participations.select { |p| p[:survey_submitted_at] >= 7.days.ago }
+      participations_last_14_to_8_days_count = participations.select do |p|
+        p[:survey_submitted_at] < 7.days.ago && p[:survey_submitted_at] >= 14.days.ago
+      end
+
+      puts "participations_last_7_days_count: #{participations_last_7_days_count.count}, participations_last_14_to_8_days_count: #{participations_last_14_to_8_days_count.count}"
+
+      percentage_change(
+        participations_last_14_to_8_days_count.count,
+        participations_last_7_days_count.count
+      )
     end
   end
 end

--- a/back/app/services/insights/native_survey_phase_insights_service.rb
+++ b/back/app/services/insights/native_survey_phase_insights_service.rb
@@ -37,9 +37,9 @@ module Insights
 
       {
         submitted_surveys: total_submitted_surveys,
-        submitted_surveys_rolling_7_day_change: rolling_7_day_changes[:submitted_surveys_rolling_7_day_change],
+        submitted_surveys_7_day_change: rolling_7_day_changes[:submitted_surveys_7_day_change],
         completion_rate: completion_rate,
-        completion_rate_rolling_7_day_change: rolling_7_day_changes[:completion_rate_rolling_7_day_change]
+        completion_rate_7_day_change: rolling_7_day_changes[:completion_rate_7_day_change]
       }
     end
 
@@ -51,8 +51,8 @@ module Insights
 
     def rolling_7_day_changes(participations)
       result = {
-        submitted_surveys_rolling_7_day_change: nil,
-        completion_rate_rolling_7_day_change: nil
+        submitted_surveys_7_day_change: nil,
+        completion_rate_7_day_change: nil
       }
 
       return result unless phase_has_run_more_than_14_days?
@@ -72,8 +72,8 @@ module Insights
       completion_rate_last_7_days = completion_rate(ideas_last_7_days_count, submitted_last_7_days_count)
       completion_rate_previous_7_days = completion_rate(ideas_previous_7_days_count, submitted_previous_7_days_count)
 
-      result[:submitted_surveys_rolling_7_day_change] = percentage_change(submitted_previous_7_days_count, submitted_last_7_days_count)
-      result[:completion_rate_rolling_7_day_change] = percentage_change(completion_rate_previous_7_days, completion_rate_last_7_days)
+      result[:submitted_surveys_7_day_change] = percentage_change(submitted_previous_7_days_count, submitted_last_7_days_count)
+      result[:completion_rate_7_day_change] = percentage_change(completion_rate_previous_7_days, completion_rate_last_7_days)
 
       result
     end

--- a/back/app/services/insights/poll_phase_insights_service.rb
+++ b/back/app/services/insights/poll_phase_insights_service.rb
@@ -25,7 +25,7 @@ module Insights
     def phase_participation_method_metrics(participations)
       {
         responses: participations[:taking_poll].count,
-        responses_rolling_7_day_change: participations_rolling_7_day_change(participations[:taking_poll])
+        responses_7_day_change: participations_7_day_change(participations[:taking_poll])
       }
     end
   end

--- a/back/app/services/insights/poll_phase_insights_service.rb
+++ b/back/app/services/insights/poll_phase_insights_service.rb
@@ -23,13 +23,9 @@ module Insights
     end
 
     def phase_participation_method_metrics(participations)
-      responses = participations[:taking_poll] || []
-      responses_total = responses.count
-      responses_last_7_days = responses.count { |p| p[:acted_at] >= 7.days.ago }
-
       {
-        responses: responses_total,
-        responses_last_7_days: responses_last_7_days
+        responses: participations[:taking_poll].count,
+        responses_rolling_7_day_change: participations_rolling_7_day_change(participations[:taking_poll])
       }
     end
   end

--- a/back/app/services/insights/proposals_phase_insights_service.rb
+++ b/back/app/services/insights/proposals_phase_insights_service.rb
@@ -35,7 +35,7 @@ module Insights
     end
 
     def phase_participation_method_metrics(participations)
-      proposals_reached_threshold = participations[:posting_idea].select { |p| p[:threshold_reached_at].present? } 
+      proposals_reached_threshold = participations[:posting_idea].select { |p| p[:threshold_reached_at].present? }
 
       {
         ideas_posted: participations[:posting_idea].count,

--- a/back/app/services/insights/proposals_phase_insights_service.rb
+++ b/back/app/services/insights/proposals_phase_insights_service.rb
@@ -35,31 +35,18 @@ module Insights
     end
 
     def phase_participation_method_metrics(participations)
-      ideas_counts = phase_ideas_counts(participations[:posting_idea] || [])
-      comments_counts = phase_comments_counts(participations)
-      reactions_counts = phase_reactions_counts(participations)
-      reached_threshold_counts = threshold_reached_counts(participations[:posting_idea] || [])
+      proposals_reached_threshold = participations[:posting_idea].select { |p| p[:threshold_reached_at].present? } 
 
       {
-        ideas_posted: ideas_counts[:total],
-        ideas_posted_last_7_days: ideas_counts[:last_7_days],
-        reached_threshold: reached_threshold_counts[:total],
-        reached_threshold_last_7_days: reached_threshold_counts[:last_7_days],
-        comments_posted: comments_counts[:total],
-        comments_posted_last_7_days: comments_counts[:last_7_days],
-        reactions: reactions_counts[:total],
-        reactions_last_7_days: reactions_counts[:last_7_days]
+        ideas_posted: participations[:posting_idea].count,
+        ideas_posted_rolling_7_day_change: participations_rolling_7_day_change(participations[:posting_idea]),
+        reached_threshold: proposals_reached_threshold.count,
+        reached_threshold_rolling_7_day_change: participations_rolling_7_day_change(proposals_reached_threshold),
+        comments_posted: participations[:commenting_idea].count,
+        comments_posted_rolling_7_day_change: participations_rolling_7_day_change(participations[:commenting_idea]),
+        reactions: participations[:reacting_idea].count,
+        reactions_rolling_7_day_change: participations_rolling_7_day_change(participations[:reacting_idea])
       }
-    end
-
-    def threshold_reached_counts(posting_idea_participations)
-      total = posting_idea_participations.count { |p| p[:threshold_reached_at].present? }
-      last_7_days = posting_idea_participations.count do |p|
-        p[:threshold_reached_at].present? &&
-          p[:threshold_reached_at] >= 7.days.ago.beginning_of_day
-      end
-
-      { total: total, last_7_days: last_7_days }
     end
 
     # Because a proposal can be moved from a threshold_reached status to another status,

--- a/back/app/services/insights/proposals_phase_insights_service.rb
+++ b/back/app/services/insights/proposals_phase_insights_service.rb
@@ -39,13 +39,13 @@ module Insights
 
       {
         ideas_posted: participations[:posting_idea].count,
-        ideas_posted_rolling_7_day_change: participations_rolling_7_day_change(participations[:posting_idea]),
+        ideas_posted_7_day_change: participations_7_day_change(participations[:posting_idea]),
         reached_threshold: proposals_reached_threshold.count,
-        reached_threshold_rolling_7_day_change: participations_rolling_7_day_change(proposals_reached_threshold),
+        reached_threshold_7_day_change: participations_7_day_change(proposals_reached_threshold),
         comments_posted: participations[:commenting_idea].count,
-        comments_posted_rolling_7_day_change: participations_rolling_7_day_change(participations[:commenting_idea]),
+        comments_posted_7_day_change: participations_7_day_change(participations[:commenting_idea]),
         reactions: participations[:reacting_idea].count,
-        reactions_rolling_7_day_change: participations_rolling_7_day_change(participations[:reacting_idea])
+        reactions_7_day_change: participations_7_day_change(participations[:reacting_idea])
       }
     end
 

--- a/back/app/services/insights/visits_service.rb
+++ b/back/app/services/insights/visits_service.rb
@@ -1,6 +1,6 @@
 module Insights
   class VisitsService
-    def phase_visits_data(phase)
+    def phase_visits(phase)
       constraints = { project_id: phase.project.id }
 
       constraints[:created_at] = if phase.end_at.present?
@@ -13,33 +13,16 @@ module Insights
         .joins(:pageviews)
         .where(impact_tracking_pageviews: constraints)
 
-      visits_list = visits.select(
+      visits.select(
         "impact_tracking_pageviews.created_at AS date,
         impact_tracking_sessions.user_id AS user_id,
         impact_tracking_sessions.monthly_user_hash AS monthly_user_hash"
       ).map do |row|
         {
-          date: row.date,
+          acted_at: row.date,
           visitor_id: row.user_id.present? ? row.user_id.to_s : row.monthly_user_hash
         }
       end
-
-      visitors_total = visits_list.pluck(:visitor_id).compact.uniq.count
-      last_7_days_start = 7.days.ago
-      last_7_days_end = phase.end_at.present? ? [Time.current, phase.end_at].min : Time.current
-
-      visitors_last_7_days = visits_list
-        .select { |v| v[:date] >= last_7_days_start && v[:date] <= last_7_days_end }
-        .pluck(:visitor_id)
-        .compact
-        .uniq
-        .count
-
-      {
-        visitors_total: visitors_total || 0,
-        visitors_last_7_days: visitors_last_7_days || 0,
-        visits: visits_list
-      }
     end
   end
 end

--- a/back/app/services/insights/volunteering_phase_insights_service.rb
+++ b/back/app/services/insights/volunteering_phase_insights_service.rb
@@ -26,7 +26,7 @@ module Insights
     def phase_participation_method_metrics(participations)
       {
         volunteerings: participations[:volunteering].count,
-        volunteerings_rolling_7_day_change: participations_rolling_7_day_change(participations[:volunteering])
+        volunteerings_7_day_change: participations_7_day_change(participations[:volunteering])
       }
     end
   end

--- a/back/app/services/insights/volunteering_phase_insights_service.rb
+++ b/back/app/services/insights/volunteering_phase_insights_service.rb
@@ -24,13 +24,9 @@ module Insights
     end
 
     def phase_participation_method_metrics(participations)
-      volunteerings = participations[:volunteering] || []
-      volunteerings_total = volunteerings.count
-      volunteerings_last_7_days = volunteerings.count { |p| p[:acted_at] >= 7.days.ago }
-
       {
-        volunteerings: volunteerings_total,
-        volunteerings_last_7_days: volunteerings_last_7_days
+        volunteerings: participations[:volunteering].count,
+        volunteerings_rolling_7_day_change: participations_rolling_7_day_change(participations[:volunteering])
       }
     end
   end

--- a/back/app/services/insights/voting_phase_insights_service.rb
+++ b/back/app/services/insights/voting_phase_insights_service.rb
@@ -28,36 +28,36 @@ module Insights
     end
 
     def phase_participation_method_metrics(participations)
-      common_rolling_7_day_changes = common_rolling_7_day_changes(participations)
+      common_7_day_changes = common_7_day_changes(participations)
 
       if @phase.voting_method == 'budgeting'
         {
           voting_method: 'budgeting',
           associated_ideas: associated_published_ideas_count,
           online_picks: participations[:voting].sum { |p| p[:ideas_count] },
-          online_picks_rolling_7_day_change: online_picks_rolling_7_day_change(participations),
+          online_picks_7_day_change: online_picks_7_day_change(participations),
           offline_picks: @phase.manual_votes_count,
           voters: participations[:voting].pluck(:participant_id).uniq.count,
-          voters_rolling_7_day_change: common_rolling_7_day_changes[:voters_rolling_7_day_change],
+          voters_7_day_change: common_7_day_changes[:voters_7_day_change],
           comments_posted: participations[:commenting_idea].count,
-          comments_posted_rolling_7_day_change: common_rolling_7_day_changes[:comments_posted_rolling_7_day_change]
+          comments_posted_7_day_change: common_7_day_changes[:comments_posted_7_day_change]
         }
       else
         {
           voting_method: @phase.voting_method,
           associated_ideas: associated_published_ideas_count,
           online_votes: participations[:voting].sum { |p| p[:votes] },
-          online_votes_rolling_7_day_change: online_votes_rolling_7_day_change(participations),
+          online_votes_7_day_change: online_votes_7_day_change(participations),
           offline_votes: @phase.manual_votes_count,
           voters: participations[:voting].pluck(:participant_id).uniq.count,
-          voters_rolling_7_day_change: common_rolling_7_day_changes[:voters_rolling_7_day_change],
+          voters_7_day_change: common_7_day_changes[:voters_7_day_change],
           comments_posted: participations[:commenting_idea].count,
-          comments_posted_rolling_7_day_change: common_rolling_7_day_changes[:comments_posted_rolling_7_day_change]
+          comments_posted_7_day_change: common_7_day_changes[:comments_posted_7_day_change]
         }
       end
     end
 
-    def common_rolling_7_day_changes(participations)
+    def common_7_day_changes(participations)
       return nil unless phase_has_run_more_than_14_days?
 
       voting_participations = participations[:voting] || []
@@ -73,12 +73,12 @@ module Insights
       end
 
       {
-        voters_rolling_7_day_change: percentage_change(voters_previous_7_days, voters_last_7_days),
-        comments_posted_rolling_7_day_change: percentage_change(comments_previous_7_days, comments_last_7_days)
+        voters_7_day_change: percentage_change(voters_previous_7_days, voters_last_7_days),
+        comments_posted_7_day_change: percentage_change(comments_previous_7_days, comments_last_7_days)
       }
     end
 
-    def online_picks_rolling_7_day_change(participations)
+    def online_picks_7_day_change(participations)
       return nil unless phase_has_run_more_than_14_days?
 
       voting_participations = participations[:voting] || []
@@ -93,7 +93,7 @@ module Insights
       percentage_change(online_picks_previous_7_days, online_picks_last_7_days)
     end
 
-    def online_votes_rolling_7_day_change(participations)
+    def online_votes_7_day_change(participations)
       return nil unless phase_has_run_more_than_14_days?
 
       voting_participations = participations[:voting] || []

--- a/back/app/services/insights/voting_phase_insights_service.rb
+++ b/back/app/services/insights/voting_phase_insights_service.rb
@@ -60,13 +60,13 @@ module Insights
     def common_7_day_changes(participations)
       return nil unless phase_has_run_more_than_14_days?
 
-      voting_participations = participations[:voting] || []
+      voting_participations = participations[:voting]
       voters_last_7_days = voting_participations.select { |p| p[:acted_at] >= 7.days.ago }.pluck(:participant_id).uniq.count
       voters_previous_7_days = voting_participations.select do |p|
         p[:acted_at] >= 14.days.ago && p[:acted_at] < 7.days.ago
       end.pluck(:participant_id).uniq.count
 
-      commenting_ideas_participations = participations[:commenting_idea] || []
+      commenting_ideas_participations = participations[:commenting_idea]
       comments_last_7_days = commenting_ideas_participations.count { |p| p[:acted_at] >= 7.days.ago }
       comments_previous_7_days = commenting_ideas_participations.count do |p|
         p[:acted_at] >= 14.days.ago && p[:acted_at] < 7.days.ago
@@ -81,7 +81,7 @@ module Insights
     def online_picks_7_day_change(participations)
       return nil unless phase_has_run_more_than_14_days?
 
-      voting_participations = participations[:voting] || []
+      voting_participations = participations[:voting]
       return 0.0 if voting_participations.empty?
 
       online_picks_last_7_days = voting_participations.select { |p| p[:acted_at] >= 7.days.ago }.sum { |p| p[:ideas_count] }
@@ -96,7 +96,7 @@ module Insights
     def online_votes_7_day_change(participations)
       return nil unless phase_has_run_more_than_14_days?
 
-      voting_participations = participations[:voting] || []
+      voting_participations = participations[:voting]
       return 0.0 if voting_participations.empty?
 
       online_votes_last_7_days = voting_participations.select { |p| p[:acted_at] >= 7.days.ago }.sum { |p| p[:votes] }

--- a/back/app/services/insights/voting_phase_insights_service.rb
+++ b/back/app/services/insights/voting_phase_insights_service.rb
@@ -28,43 +28,82 @@ module Insights
     end
 
     def phase_participation_method_metrics(participations)
-      voting_participations = participations[:voting] || []
-      voters = voting_participations.pluck(:participant_id).uniq.count
-      voters_last_7_days = voting_participations.select { |p| p[:acted_at] >= 7.days.ago }.pluck(:participant_id).uniq.count
-      comments_counts = phase_comments_counts(participations)
-      offline_votes = @phase.manual_votes_count
+      common_rolling_7_day_changes = common_rolling_7_day_changes(participations)
 
       if @phase.voting_method == 'budgeting'
-        online_picks = voting_participations.sum { |p| p[:ideas_count] }
-        online_picks_last_7_days = voting_participations.select { |p| p[:acted_at] >= 7.days.ago }.sum { |p| p[:ideas_count] }
-
         {
           voting_method: 'budgeting',
-          online_picks: online_picks,
-          online_picks_last_7_days: online_picks_last_7_days,
-          offline_picks: offline_votes,
-          voters: voters,
-          voters_last_7_days: voters_last_7_days,
+          online_picks: participations[:voting].sum { |p| p[:ideas_count] },
+          online_picks_rolling_7_day_change: online_picks_rolling_7_day_change(participations),
+          offline_picks: @phase.manual_votes_count,
+          voters: participations[:voting].pluck(:participant_id).uniq.count,
+          voters_rolling_7_day_change: common_rolling_7_day_changes[:voters_rolling_7_day_change],
           associated_ideas: associated_published_ideas_count,
-          comments_posted: comments_counts[:total],
-          comments_posted_last_7_days: comments_counts[:last_7_days]
+          comments_posted: participations[:commenting_idea].count,
+          comments_posted_rolling_7_day_change: common_rolling_7_day_changes[:comments_posted_rolling_7_day_change]
         }
       else
-        online_votes = voting_participations.sum { |p| p[:votes] }
-        online_votes_last_7_days = voting_participations.select { |p| p[:acted_at] >= 7.days.ago }.sum { |p| p[:votes] }
-
         {
           voting_method: @phase.voting_method,
-          online_votes: online_votes,
-          online_votes_last_7_days: online_votes_last_7_days,
-          offline_votes: offline_votes,
-          voters: voters,
-          voters_last_7_days: voters_last_7_days,
+          online_votes: participations[:voting].sum { |p| p[:votes] },
+          online_votes_rolling_7_day_change: online_votes_rolling_7_day_change(participations),
+          offline_votes: @phase.manual_votes_count,
+          voters: participations[:voting].pluck(:participant_id).uniq.count,
+          voters_rolling_7_day_change: common_rolling_7_day_changes[:voters_rolling_7_day_change],
           associated_ideas: associated_published_ideas_count,
-          comments_posted: comments_counts[:total],
-          comments_posted_last_7_days: comments_counts[:last_7_days]
+          comments_posted: participations[:commenting_idea].count,
+          comments_posted_rolling_7_day_change: common_rolling_7_day_changes[:comments_posted_rolling_7_day_change]
         }
       end
+    end
+
+    def common_rolling_7_day_changes(participations)
+      return nil unless phase_has_run_more_than_14_days?
+
+      voting_participations = participations[:voting] || []
+      voters_last_7_days = voting_participations.select { |p| p[:acted_at] >= 7.days.ago }.pluck(:participant_id).uniq.count
+      voters_previous_7_days = voting_participations.select do |p|
+        p[:acted_at] >= 14.days.ago && p[:acted_at] < 7.days.ago
+      end.pluck(:participant_id).uniq.count
+
+      commenting_ideas_participations = participations[:commenting_idea] || []
+      comments_last_7_days = commenting_ideas_participations.count { |p| p[:acted_at] >= 7.days.ago }
+      comments_previous_7_days = commenting_ideas_participations.count do |p|
+        p[:acted_at] >= 14.days.ago && p[:acted_at] < 7.days.ago
+      end
+
+      {
+        voters_rolling_7_day_change: percentage_change(voters_previous_7_days, voters_last_7_days),
+        comments_posted_rolling_7_day_change: percentage_change(comments_previous_7_days, comments_last_7_days)
+      }
+    end
+
+    def online_picks_rolling_7_day_change(participations)
+      return nil unless phase_has_run_more_than_14_days?
+
+      voting_participations = participations[:voting] || []
+      return 0.0 if voting_participations.empty?
+
+      online_picks_last_7_days = voting_participations.select { |p| p[:acted_at] >= 7.days.ago }.sum { |p| p[:ideas_count] }
+      online_picks_previous_7_days = voting_participations.select do |p|
+        p[:acted_at] >= 14.days.ago && p[:acted_at] < 7.days.ago
+      end.sum { |p| p[:ideas_count] }
+
+      percentage_change(online_picks_previous_7_days, online_picks_last_7_days)
+    end
+
+    def online_votes_rolling_7_day_change(participations)
+      return nil unless phase_has_run_more_than_14_days?
+
+      voting_participations = participations[:voting] || []
+      return 0.0 if voting_participations.empty?
+
+      online_votes_last_7_days = voting_participations.select { |p| p[:acted_at] >= 7.days.ago }.sum { |p| p[:votes] }
+      online_votes_previous_7_days = voting_participations.select do |p|
+        p[:acted_at] >= 14.days.ago && p[:acted_at] < 7.days.ago
+      end.sum { |p| p[:votes] }
+
+      percentage_change(online_votes_previous_7_days, online_votes_last_7_days)
     end
   end
 end

--- a/back/app/services/insights/voting_phase_insights_service.rb
+++ b/back/app/services/insights/voting_phase_insights_service.rb
@@ -33,24 +33,24 @@ module Insights
       if @phase.voting_method == 'budgeting'
         {
           voting_method: 'budgeting',
+          associated_ideas: associated_published_ideas_count,
           online_picks: participations[:voting].sum { |p| p[:ideas_count] },
           online_picks_rolling_7_day_change: online_picks_rolling_7_day_change(participations),
           offline_picks: @phase.manual_votes_count,
           voters: participations[:voting].pluck(:participant_id).uniq.count,
           voters_rolling_7_day_change: common_rolling_7_day_changes[:voters_rolling_7_day_change],
-          associated_ideas: associated_published_ideas_count,
           comments_posted: participations[:commenting_idea].count,
           comments_posted_rolling_7_day_change: common_rolling_7_day_changes[:comments_posted_rolling_7_day_change]
         }
       else
         {
           voting_method: @phase.voting_method,
+          associated_ideas: associated_published_ideas_count,
           online_votes: participations[:voting].sum { |p| p[:votes] },
           online_votes_rolling_7_day_change: online_votes_rolling_7_day_change(participations),
           offline_votes: @phase.manual_votes_count,
           voters: participations[:voting].pluck(:participant_id).uniq.count,
           voters_rolling_7_day_change: common_rolling_7_day_changes[:voters_rolling_7_day_change],
-          associated_ideas: associated_published_ideas_count,
           comments_posted: participations[:commenting_idea].count,
           comments_posted_rolling_7_day_change: common_rolling_7_day_changes[:comments_posted_rolling_7_day_change]
         }

--- a/back/app/services/insights/voting_phase_insights_service.rb
+++ b/back/app/services/insights/voting_phase_insights_service.rb
@@ -85,9 +85,10 @@ module Insights
       return 0.0 if voting_participations.empty?
 
       online_picks_last_7_days = voting_participations.select { |p| p[:acted_at] >= 7.days.ago }.sum { |p| p[:ideas_count] }
-      online_picks_previous_7_days = voting_participations.select do |p|
+      picks_in_previous_7_days = voting_participations.select do |p|
         p[:acted_at] >= 14.days.ago && p[:acted_at] < 7.days.ago
-      end.sum { |p| p[:ideas_count] }
+      end
+      online_picks_previous_7_days = picks_in_previous_7_days.sum { |p| p[:ideas_count] }
 
       percentage_change(online_picks_previous_7_days, online_picks_last_7_days)
     end
@@ -99,9 +100,10 @@ module Insights
       return 0.0 if voting_participations.empty?
 
       online_votes_last_7_days = voting_participations.select { |p| p[:acted_at] >= 7.days.ago }.sum { |p| p[:votes] }
-      online_votes_previous_7_days = voting_participations.select do |p|
+      votes_in_previous_7_days = voting_participations.select do |p|
         p[:acted_at] >= 14.days.ago && p[:acted_at] < 7.days.ago
-      end.sum { |p| p[:votes] }
+      end
+      online_votes_previous_7_days = votes_in_previous_7_days.sum { |p| p[:votes] }
 
       percentage_change(online_votes_previous_7_days, online_votes_last_7_days)
     end

--- a/back/spec/acceptance/phase_insights/common_ground_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/common_ground_phase_insights_spec.rb
@@ -90,7 +90,7 @@ resource 'Phase insights' do
         participants: 2,
         participants_rolling_7_day_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
         engagement_rate: 0.667,
-        engagement_rate_rolling_7_day_change: 100.0, # engagement_rate_last_7_days: 1.0, engagement_rate_last_14_to_8_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1)
+        engagement_rate_rolling_7_day_change: 100.0, # engagement_rate_last_7_days: 1.0, engagement_rate_previous_7_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1)
         common_ground: {
           associated_ideas: 4,
           ideas_posted: 2,

--- a/back/spec/acceptance/phase_insights/common_ground_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/common_ground_phase_insights_spec.rb
@@ -90,6 +90,7 @@ resource 'Phase insights' do
         participants: 2,
         participants_rolling_7_day_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
         engagement_rate: 0.667,
+        engagement_rate_rolling_7_day_change: 100.0, # engagement_rate_last_7_days: 1.0, engagement_rate_last_14_to_8_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1)
         common_ground: {
           associated_ideas: 4,
           ideas_posted: 2,

--- a/back/spec/acceptance/phase_insights/common_ground_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/common_ground_phase_insights_spec.rb
@@ -77,7 +77,7 @@ resource 'Phase insights' do
   let(:id) { common_ground_phase.id }
 
   get 'web_api/v1/phases/:id/insights' do
-    example_request 'returns insights for common_ground phase' do
+    example_request 'returns insights data for common_ground phase' do
       assert_status 200
 
       expect(json_response_body[:data][:id]).to eq(common_ground_phase.id.to_s)

--- a/back/spec/acceptance/phase_insights/common_ground_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/common_ground_phase_insights_spec.rb
@@ -89,8 +89,8 @@ resource 'Phase insights' do
         visitors_rolling_7_day_change: 0.0, # from 2 (in week before last) to 2 unique visitors (in last 7 days) = 0% change
         participants: 2,
         participants_rolling_7_day_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
-        engagement_rate: 0.667,
-        engagement_rate_rolling_7_day_change: 100.0, # engagement_rate_last_7_days: 1.0, engagement_rate_previous_7_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1)
+        participation_rate: 0.667,
+        participation_rate_rolling_7_day_change: 100.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1)
         common_ground: {
           associated_ideas: 4,
           ideas_posted: 2,

--- a/back/spec/acceptance/phase_insights/common_ground_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/common_ground_phase_insights_spec.rb
@@ -53,24 +53,24 @@ resource 'Phase insights' do
       create(:idea, phases: [phase], author: user3, created_at: 2.days.ago, published_at: 2.days.ago, creation_phase_id: phase.id) # published after phase (not counted)
 
       # Reactions
-      create(:reaction, reactable: idea1, user: user4, created_at: 5.days.ago) # in phase, and in last 7 days
+      create(:reaction, reactable: idea1, user: user4, created_at: 5.days.ago) # during phase, and in last 7 days
 
       # Pageviews and sessions
       session1 = create(:session, user_id: user1.id)
       create(:pageview, session: session1, created_at: 25.days.ago, project_id: phase.project.id) # before phase
 
       session2 = create(:session, user_id: user2.id)
-      create(:pageview, session: session2, created_at: 13.days.ago, project_id: phase.project.id) # in phase
-      create(:pageview, session: session2, created_at: 5.days.ago, project_id: phase.project.id) # in phase & last 7 days, same session
+      create(:pageview, session: session2, created_at: 13.days.ago, project_id: phase.project.id) # during phase (in week before last)
+      create(:pageview, session: session2, created_at: 5.days.ago, project_id: phase.project.id) # during phase & last 7 days, same session
 
       session3 = create(:session, user_id: user3.id)
       create(:pageview, session: session3, created_at: 2.days.ago, project_id: phase.project.id) # after phase
 
       session4 = create(:session)
-      create(:pageview, session: session4, created_at: 13.days.ago, project_id: phase.project.id) # in phase, did not participate
+      create(:pageview, session: session4, created_at: 13.days.ago, project_id: phase.project.id) # during phase (in week before last), did not participate
 
       session5 = create(:session, user_id: user4.id)
-      create(:pageview, session: session5, created_at: 5.days.ago, project_id: phase.project.id) # in phase, and in last 7 days
+      create(:pageview, session: session5, created_at: 5.days.ago, project_id: phase.project.id) # during phase, and in last 7 days
     end
   end
 
@@ -86,7 +86,7 @@ resource 'Phase insights' do
       metrics = json_response_body.dig(:data, :attributes, :metrics)
       expect(metrics).to eq({
         visitors: 3,
-        visitors_last_7_days: 2,
+        visitors_rolling_7_day_change: 0.0, # from 2 (in week before last) to 2 unique visitors (in last 7 days) = 0% change
         participants: 2,
         participants_rolling_7_day_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
         engagement_rate: 0.667,

--- a/back/spec/acceptance/phase_insights/common_ground_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/common_ground_phase_insights_spec.rb
@@ -86,17 +86,17 @@ resource 'Phase insights' do
       metrics = json_response_body.dig(:data, :attributes, :metrics)
       expect(metrics).to eq({
         visitors: 3,
-        visitors_rolling_7_day_change: 0.0, # from 2 (in week before last) to 2 unique visitors (in last 7 days) = 0% change
+        visitors_7_day_change: 0.0, # from 2 (in week before last) to 2 unique visitors (in last 7 days) = 0% change
         participants: 2,
-        participants_rolling_7_day_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
+        participants_7_day_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
         participation_rate: 0.667,
-        participation_rate_rolling_7_day_change: 100.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1)
+        participation_rate_7_day_change: 100.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1)
         common_ground: {
           associated_ideas: 4,
           ideas_posted: 2,
-          ideas_posted_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) = 0% change
+          ideas_posted_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) = 0% change
           reactions: 1,
-          reactions_rolling_7_day_change: 'last_7_days_compared_with_zero' # from 0 (in week before last) to 1 (in last 7 days) => avoid division by zero
+          reactions_7_day_change: 'last_7_days_compared_with_zero' # from 0 (in week before last) to 1 (in last 7 days) => avoid division by zero
         }
       })
 

--- a/back/spec/acceptance/phase_insights/common_ground_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/common_ground_phase_insights_spec.rb
@@ -94,9 +94,9 @@ resource 'Phase insights' do
         common_ground: {
           associated_ideas: 4,
           ideas_posted: 2,
-          ideas_posted_last_7_days: 1,
+          ideas_posted_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) = 0% change
           reactions: 1,
-          reactions_last_7_days: 1
+          reactions_rolling_7_day_change: 'last_7_days_compared_with_zero' # from 0 (in week before last) to 1 (in last 7 days) => avoid division by zero
         }
       })
 

--- a/back/spec/acceptance/phase_insights/common_ground_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/common_ground_phase_insights_spec.rb
@@ -48,7 +48,7 @@ resource 'Phase insights' do
 
       # Ideas
       idea1 = create(:idea, phases: [phase], author: user1, created_at: 25.days.ago, published_at: 25.days.ago, creation_phase_id: phase.id) # published before phase (not counted)
-      create(:idea, phases: [phase], author: user2, created_at: 15.days.ago, published_at: 15.days.ago, creation_phase_id: phase.id) # published during phase
+      create(:idea, phases: [phase], author: user2, created_at: 13.days.ago, published_at: 13.days.ago, creation_phase_id: phase.id) # published during phase
       create(:idea, phases: [phase], author: user2, created_at: 5.days.ago, published_at: 5.days.ago, creation_phase_id: phase.id) # published during phase, and in last 7 days
       create(:idea, phases: [phase], author: user3, created_at: 2.days.ago, published_at: 2.days.ago, creation_phase_id: phase.id) # published after phase (not counted)
 
@@ -60,14 +60,14 @@ resource 'Phase insights' do
       create(:pageview, session: session1, created_at: 25.days.ago, project_id: phase.project.id) # before phase
 
       session2 = create(:session, user_id: user2.id)
-      create(:pageview, session: session2, created_at: 15.days.ago, project_id: phase.project.id) # in phase
+      create(:pageview, session: session2, created_at: 13.days.ago, project_id: phase.project.id) # in phase
       create(:pageview, session: session2, created_at: 5.days.ago, project_id: phase.project.id) # in phase & last 7 days, same session
 
       session3 = create(:session, user_id: user3.id)
       create(:pageview, session: session3, created_at: 2.days.ago, project_id: phase.project.id) # after phase
 
       session4 = create(:session)
-      create(:pageview, session: session4, created_at: 15.days.ago, project_id: phase.project.id) # in phase, did not participate
+      create(:pageview, session: session4, created_at: 13.days.ago, project_id: phase.project.id) # in phase, did not participate
 
       session5 = create(:session, user_id: user4.id)
       create(:pageview, session: session5, created_at: 5.days.ago, project_id: phase.project.id) # in phase, and in last 7 days
@@ -88,7 +88,7 @@ resource 'Phase insights' do
         visitors: 3,
         visitors_last_7_days: 2,
         participants: 2,
-        participants_last_7_days: 2,
+        participants_rolling_7_day_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
         engagement_rate: 0.667,
         common_ground: {
           associated_ideas: 4,
@@ -103,7 +103,7 @@ resource 'Phase insights' do
       expect(participants_and_visitors_chart_data).to eq({
         resolution: 'day',
         timeseries: [
-          { participants: 1, visitors: 2, date_group: '2025-11-17' },
+          { participants: 1, visitors: 2, date_group: '2025-11-19' },
           { participants: 2, visitors: 2, date_group: '2025-11-27' }
         ]
       })

--- a/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
@@ -97,7 +97,7 @@ resource 'Phase insights' do
         participants: 3,
         participants_rolling_7_day_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
         engagement_rate: 0.75,
-        engagement_rate_rolling_7_day_change: 0.0, # engagement_rate_last_7_days: 1.0, engagement_rate_last_14_to_8_days: 1.0 = 0% change
+        engagement_rate_rolling_7_day_change: 0.0, # engagement_rate_last_7_days: 1.0, engagement_rate_previous_7_days: 1.0 = 0% change
         ideation: {
           ideas_posted: 2,
           ideas_posted_rolling_7_day_change: 'last_7_days_compared_with_zero', # from 0 (in week before last) to 1 (in last 7 days) => avoid division by zero

--- a/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
@@ -96,8 +96,8 @@ resource 'Phase insights' do
         visitors_rolling_7_day_change: 100.0, # from 1 (in week before last) to 2 unique visitors (in last 7 days) = 100% increase
         participants: 3,
         participants_rolling_7_day_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
-        engagement_rate: 0.75,
-        engagement_rate_rolling_7_day_change: 0.0, # engagement_rate_last_7_days: 1.0, engagement_rate_previous_7_days: 1.0 = 0% change
+        participation_rate: 0.75,
+        participation_rate_rolling_7_day_change: 0.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
         ideation: {
           ideas_posted: 2,
           ideas_posted_rolling_7_day_change: 'last_7_days_compared_with_zero', # from 0 (in week before last) to 1 (in last 7 days) => avoid division by zero

--- a/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
@@ -100,11 +100,11 @@ resource 'Phase insights' do
         engagement_rate_rolling_7_day_change: 0.0, # engagement_rate_last_7_days: 1.0, engagement_rate_last_14_to_8_days: 1.0 = 0% change
         ideation: {
           ideas_posted: 2,
-          ideas_posted_last_7_days: 1,
+          ideas_posted_rolling_7_day_change: nil, # from 0 (in week before last) to 1 (in last 7 days) => nil (avoiding division by zero),
           comments_posted: 1,
-          comments_posted_last_7_days: 0,
+          comments_posted_rolling_7_day_change: -100.0, # from 1 (in week before last) to 0 (in last 7 days) = -100% decrease
           reactions: 1,
-          reactions_last_7_days: 1
+          reactions_rolling_7_day_change: nil # from 0 (in week before last) to 1 (in last 7 days) => nil (avoiding division by zero)
         }
       })
 

--- a/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
@@ -54,7 +54,7 @@ resource 'Phase insights' do
       create(:idea, phases: [phase], author: user3, created_at: 2.days.ago, published_at: 2.days.ago) # published after ideation phase (not counted)
 
       # Comments
-      create(:comment, idea: idea2, author: user4, created_at: 10.days.ago) # in ideation phase
+      create(:comment, idea: idea2, author: user4, created_at: 10.days.ago) # in ideation phase (in week before last)
 
       # Reactions
       create(:reaction, reactable: idea2, user: user5, created_at: 5.days.ago) # in ideation phase, and in last 7 days
@@ -74,7 +74,7 @@ resource 'Phase insights' do
       create(:pageview, session: session4, created_at: 15.days.ago, project_id: phase.project.id) # in ideation phase, did not participate
 
       session5 = create(:session, user_id: user4.id)
-      create(:pageview, session: session5, created_at: 10.days.ago, project_id: phase.project.id) # in ideation phase
+      create(:pageview, session: session5, created_at: 10.days.ago, project_id: phase.project.id) # in ideation phase (in week before last)
 
       session6 = create(:session, user_id: user5.id)
       create(:pageview, session: session6, created_at: 5.days.ago, project_id: phase.project.id) # in ideation phase, and in last 7 days
@@ -95,7 +95,7 @@ resource 'Phase insights' do
         visitors: 4,
         visitors_last_7_days: 2,
         participants: 3,
-        participants_last_7_days: 2,
+        participants_rolling_7_day_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
         engagement_rate: 0.75,
         ideation: {
           ideas_posted: 2,

--- a/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
@@ -100,11 +100,11 @@ resource 'Phase insights' do
         engagement_rate_rolling_7_day_change: 0.0, # engagement_rate_last_7_days: 1.0, engagement_rate_last_14_to_8_days: 1.0 = 0% change
         ideation: {
           ideas_posted: 2,
-          ideas_posted_rolling_7_day_change: nil, # from 0 (in week before last) to 1 (in last 7 days) => nil (avoiding division by zero),
+          ideas_posted_rolling_7_day_change: 'last_7_days_compared_with_zero', # from 0 (in week before last) to 1 (in last 7 days) => nil (avoiding division by zero),
           comments_posted: 1,
           comments_posted_rolling_7_day_change: -100.0, # from 1 (in week before last) to 0 (in last 7 days) = -100% decrease
           reactions: 1,
-          reactions_rolling_7_day_change: nil # from 0 (in week before last) to 1 (in last 7 days) => nil (avoiding division by zero)
+          reactions_rolling_7_day_change: 'last_7_days_compared_with_zero' # from 0 (in week before last) to 1 (in last 7 days) => nil (avoiding division by zero)
         }
       })
 

--- a/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
@@ -93,18 +93,18 @@ resource 'Phase insights' do
       metrics = json_response_body.dig(:data, :attributes, :metrics)
       expect(metrics).to eq({
         visitors: 4,
-        visitors_rolling_7_day_change: 100.0, # from 1 (in week before last) to 2 unique visitors (in last 7 days) = 100% increase
+        visitors_7_day_change: 100.0, # from 1 (in week before last) to 2 unique visitors (in last 7 days) = 100% increase
         participants: 3,
-        participants_rolling_7_day_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
+        participants_7_day_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
         participation_rate: 0.75,
-        participation_rate_rolling_7_day_change: 0.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
+        participation_rate_7_day_change: 0.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
         ideation: {
           ideas_posted: 2,
-          ideas_posted_rolling_7_day_change: 'last_7_days_compared_with_zero', # from 0 (in week before last) to 1 (in last 7 days) => avoid division by zero
+          ideas_posted_7_day_change: 'last_7_days_compared_with_zero', # from 0 (in week before last) to 1 (in last 7 days) => avoid division by zero
           comments_posted: 1,
-          comments_posted_rolling_7_day_change: -100.0, # from 1 (in week before last) to 0 (in last 7 days) = -100% decrease
+          comments_posted_7_day_change: -100.0, # from 1 (in week before last) to 0 (in last 7 days) = -100% decrease
           reactions: 1,
-          reactions_rolling_7_day_change: 'last_7_days_compared_with_zero' # from 0 (in week before last) to 1 (in last 7 days) => avoid division by zero
+          reactions_7_day_change: 'last_7_days_compared_with_zero' # from 0 (in week before last) to 1 (in last 7 days) => avoid division by zero
         }
       })
 

--- a/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
@@ -84,7 +84,7 @@ resource 'Phase insights' do
   let(:id) { ideation_phase.id }
 
   get 'web_api/v1/phases/:id/insights' do
-    example_request 'creates insights for ideation phase' do
+    example_request 'returns insights data for ideation phase' do
       assert_status 200
 
       expect(json_response_body[:data][:id]).to eq(ideation_phase.id.to_s)
@@ -93,7 +93,7 @@ resource 'Phase insights' do
       metrics = json_response_body.dig(:data, :attributes, :metrics)
       expect(metrics).to eq({
         visitors: 4,
-        visitors_last_7_days: 2,
+        visitors_rolling_7_day_change: 100.0, # from 1 (in week before last) to 2 unique visitors (in last 7 days) = 100% increase
         participants: 3,
         participants_rolling_7_day_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
         engagement_rate: 0.75,

--- a/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
@@ -100,11 +100,11 @@ resource 'Phase insights' do
         engagement_rate_rolling_7_day_change: 0.0, # engagement_rate_last_7_days: 1.0, engagement_rate_last_14_to_8_days: 1.0 = 0% change
         ideation: {
           ideas_posted: 2,
-          ideas_posted_rolling_7_day_change: 'last_7_days_compared_with_zero', # from 0 (in week before last) to 1 (in last 7 days) => nil (avoiding division by zero),
+          ideas_posted_rolling_7_day_change: 'last_7_days_compared_with_zero', # from 0 (in week before last) to 1 (in last 7 days) => avoid division by zero
           comments_posted: 1,
           comments_posted_rolling_7_day_change: -100.0, # from 1 (in week before last) to 0 (in last 7 days) = -100% decrease
           reactions: 1,
-          reactions_rolling_7_day_change: 'last_7_days_compared_with_zero' # from 0 (in week before last) to 1 (in last 7 days) => nil (avoiding division by zero)
+          reactions_rolling_7_day_change: 'last_7_days_compared_with_zero' # from 0 (in week before last) to 1 (in last 7 days) => avoid division by zero
         }
       })
 

--- a/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
@@ -97,6 +97,7 @@ resource 'Phase insights' do
         participants: 3,
         participants_rolling_7_day_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
         engagement_rate: 0.75,
+        engagement_rate_rolling_7_day_change: 0.0, # engagement_rate_last_7_days: 1.0, engagement_rate_last_14_to_8_days: 1.0 = 0% change
         ideation: {
           ideas_posted: 2,
           ideas_posted_last_7_days: 1,

--- a/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
@@ -109,8 +109,8 @@ resource 'Phase insights' do
         visitors_rolling_7_day_change: -50.0, # from 2 (in week before last) to 1 unique visitor (in last 7 days) = -50% decrease
         participants: 2,
         participants_rolling_7_day_change: -50.0, # from 2 (in week before last) to 1 unique participant (in last 7 days) = -50% decrease
-        engagement_rate: 0.667,
-        engagement_rate_rolling_7_day_change: 0.0, # engagement_rate_last_7_days: 1.0, engagement_rate_previous_7_days: 1.0 = 0% change
+        participation_rate: 0.667,
+        participation_rate_rolling_7_day_change: 0.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
         native_survey: {
           submitted_surveys: 2,
           submitted_surveys_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) = 0% change

--- a/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
@@ -110,6 +110,7 @@ resource 'Phase insights' do
         participants: 2,
         participants_rolling_7_day_change: -50.0, # from 2 (in week before last) to 1 unique participant (in last 7 days) = -50% decrease
         engagement_rate: 0.667,
+        engagement_rate_rolling_7_day_change: 0.0, # engagement_rate_last_7_days: 1.0, engagement_rate_last_14_to_8_days: 1.0 = 0% change
         native_survey: {
           submitted_surveys: 2,
           submitted_surveys_last_7_days: 1,

--- a/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
@@ -80,24 +80,24 @@ resource 'Phase insights' do
       create(:pageview, session: session1, created_at: 25.days.ago, project_id: phase.project.id) # before phase
 
       session2 = create(:session, user_id: ns_user2.id)
-      create(:pageview, session: session2, created_at: 15.days.ago, project_id: phase.project.id) # in phase
-      create(:pageview, session: session2, created_at: 5.days.ago, project_id: phase.project.id) # in phase & last 7 days, same session
+      create(:pageview, session: session2, created_at: 15.days.ago, project_id: phase.project.id) # during phase
+      create(:pageview, session: session2, created_at: 5.days.ago, project_id: phase.project.id) # during phase & last 7 days, same session
 
       session3 = create(:session, user_id: ns_user3.id)
       create(:pageview, session: session3, created_at: 2.days.ago, project_id: phase.project.id) # after phase
 
       session4 = create(:session, user_id: ns_user4.id)
-      create(:pageview, session: session4, created_at: 12.days.ago, project_id: phase.project.id) # in phase
+      create(:pageview, session: session4, created_at: 12.days.ago, project_id: phase.project.id) # during phase (in week before last)
 
       session5 = create(:session, user_id: ns_user5.id)
-      create(:pageview, session: session5, created_at: 12.days.ago, project_id: phase.project.id) # in phase, did not participate
+      create(:pageview, session: session5, created_at: 12.days.ago, project_id: phase.project.id) # during phase (in week before last), did not participate
     end
   end
 
   let(:id) { native_survey_phase.id }
 
   get 'web_api/v1/phases/:id/insights' do
-    example_request 'creates insights for native survey phase' do
+    example_request 'returns insights data for native survey phase' do
       assert_status 200
 
       expect(json_response_body[:data][:id]).to eq(native_survey_phase.id.to_s)
@@ -106,7 +106,7 @@ resource 'Phase insights' do
       metrics = json_response_body.dig(:data, :attributes, :metrics)
       expect(metrics).to eq({
         visitors: 3,
-        visitors_last_7_days: 1,
+        visitors_rolling_7_day_change: -50.0, # from 2 (in week before last) to 1 unique visitor (in last 7 days) = -50% decrease
         participants: 2,
         participants_rolling_7_day_change: -50.0, # from 2 (in week before last) to 1 unique participant (in last 7 days) = -50% decrease
         engagement_rate: 0.667,

--- a/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
@@ -106,16 +106,16 @@ resource 'Phase insights' do
       metrics = json_response_body.dig(:data, :attributes, :metrics)
       expect(metrics).to eq({
         visitors: 3,
-        visitors_rolling_7_day_change: -50.0, # from 2 (in week before last) to 1 unique visitor (in last 7 days) = -50% decrease
+        visitors_7_day_change: -50.0, # from 2 (in week before last) to 1 unique visitor (in last 7 days) = -50% decrease
         participants: 2,
-        participants_rolling_7_day_change: -50.0, # from 2 (in week before last) to 1 unique participant (in last 7 days) = -50% decrease
+        participants_7_day_change: -50.0, # from 2 (in week before last) to 1 unique participant (in last 7 days) = -50% decrease
         participation_rate: 0.667,
-        participation_rate_rolling_7_day_change: 0.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
+        participation_rate_7_day_change: 0.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
         native_survey: {
           submitted_surveys: 2,
-          submitted_surveys_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) = 0% change
+          submitted_surveys_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) = 0% change
           completion_rate: 0.667,
-          completion_rate_rolling_7_day_change: 100.0 # completion_rate_last_7_days: 1.0, completion_rate_previous_7_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1)
+          completion_rate_7_day_change: 100.0 # completion_rate_last_7_days: 1.0, completion_rate_previous_7_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1)
         }
       })
 

--- a/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
@@ -63,7 +63,7 @@ resource 'Phase insights' do
       create(:idea, phases: [phase], created_at: 5.days.ago, submitted_at: 5.days.ago, author: ns_user2, creation_phase_id: phase.id) # created during phase, and in last 7 days
       create(:idea, phases: [phase], created_at: 2.days.ago, submitted_at: 2.days.ago, author: ns_user3, creation_phase_id: phase.id) # created & published after phase (not counted)
 
-      # created during native survey phase (in week before last), not submitted
+      # created during native survey phase (in week before last), not submitted (considered incomplete, affecting completion rate)
       create(
         :idea,
         phases: [phase],
@@ -73,7 +73,7 @@ resource 'Phase insights' do
         author: ns_user4,
         creation_phase_id: phase.id,
         custom_field_values: { gender: 'male', birthyear: 1990 }
-      ) # created during phase, but not submitted (considered incomplete, affecting completion rate)
+      )
 
       # Pageviews and sessions
       session1 = create(:session, user_id: ns_user1.id)
@@ -113,8 +113,9 @@ resource 'Phase insights' do
         engagement_rate_rolling_7_day_change: 0.0, # engagement_rate_last_7_days: 1.0, engagement_rate_last_14_to_8_days: 1.0 = 0% change
         native_survey: {
           submitted_surveys: 2,
-          submitted_surveys_last_7_days: 1,
-          completion_rate: 0.667
+          submitted_surveys_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) = 0% change
+          completion_rate: 0.667,
+          completion_rate_rolling_7_day_change: 100.0 # completion_rate_last_7_days: 1.0, completion_rate_last_14_to_8_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1)
         }
       })
 

--- a/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
@@ -110,12 +110,12 @@ resource 'Phase insights' do
         participants: 2,
         participants_rolling_7_day_change: -50.0, # from 2 (in week before last) to 1 unique participant (in last 7 days) = -50% decrease
         engagement_rate: 0.667,
-        engagement_rate_rolling_7_day_change: 0.0, # engagement_rate_last_7_days: 1.0, engagement_rate_last_14_to_8_days: 1.0 = 0% change
+        engagement_rate_rolling_7_day_change: 0.0, # engagement_rate_last_7_days: 1.0, engagement_rate_previous_7_days: 1.0 = 0% change
         native_survey: {
           submitted_surveys: 2,
           submitted_surveys_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) = 0% change
           completion_rate: 0.667,
-          completion_rate_rolling_7_day_change: 100.0 # completion_rate_last_7_days: 1.0, completion_rate_last_14_to_8_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1)
+          completion_rate_rolling_7_day_change: 100.0 # completion_rate_last_7_days: 1.0, completion_rate_previous_7_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1)
         }
       })
 

--- a/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
@@ -49,12 +49,12 @@ resource 'Phase insights' do
       # Ideas
       create(:idea, phases: [phase], created_at: 25.days.ago, author: ns_user1, creation_phase_id: phase.id) # created & published before phase (not counted)
 
-      # created and submitted during native survey phase
+      # created and submitted during native survey phase (in week before last)
       create(
         :idea,
         phases: [phase],
-        created_at: 15.days.ago,
-        submitted_at: 15.days.ago,
+        created_at: 12.days.ago,
+        submitted_at: 12.days.ago,
         author: ns_user2,
         creation_phase_id: phase.id,
         custom_field_values: { gender: 'female', birthyear: 1980 }
@@ -63,11 +63,11 @@ resource 'Phase insights' do
       create(:idea, phases: [phase], created_at: 5.days.ago, submitted_at: 5.days.ago, author: ns_user2, creation_phase_id: phase.id) # created during phase, and in last 7 days
       create(:idea, phases: [phase], created_at: 2.days.ago, submitted_at: 2.days.ago, author: ns_user3, creation_phase_id: phase.id) # created & published after phase (not counted)
 
-      # created during native survey phase, not submitted
+      # created during native survey phase (in week before last), not submitted
       create(
         :idea,
         phases: [phase],
-        created_at: 15.days.ago,
+        created_at: 12.days.ago,
         publication_status: 'draft', # Avoid automatic setting of submitted_at
         submitted_at: nil,
         author: ns_user4,
@@ -87,10 +87,10 @@ resource 'Phase insights' do
       create(:pageview, session: session3, created_at: 2.days.ago, project_id: phase.project.id) # after phase
 
       session4 = create(:session, user_id: ns_user4.id)
-      create(:pageview, session: session4, created_at: 15.days.ago, project_id: phase.project.id) # in phase
+      create(:pageview, session: session4, created_at: 12.days.ago, project_id: phase.project.id) # in phase
 
       session5 = create(:session, user_id: ns_user5.id)
-      create(:pageview, session: session5, created_at: 15.days.ago, project_id: phase.project.id) # in phase, did not participate
+      create(:pageview, session: session5, created_at: 12.days.ago, project_id: phase.project.id) # in phase, did not participate
     end
   end
 
@@ -108,7 +108,7 @@ resource 'Phase insights' do
         visitors: 3,
         visitors_last_7_days: 1,
         participants: 2,
-        participants_last_7_days: 1,
+        participants_rolling_7_day_change: -50.0, # from 2 (in week before last) to 1 unique participant (in last 7 days) = -50% decrease
         engagement_rate: 0.667,
         native_survey: {
           submitted_surveys: 2,
@@ -121,7 +121,8 @@ resource 'Phase insights' do
       expect(participants_and_visitors_chart_data).to eq({
         resolution: 'day',
         timeseries: [
-          { participants: 2, visitors: 3, date_group: '2025-11-17' },
+          { participants: 0, visitors: 1, date_group: '2025-11-17' },
+          { participants: 2, visitors: 2, date_group: '2025-11-20' },
           { participants: 1, visitors: 1, date_group: '2025-11-27' }
         ]
       })

--- a/back/spec/acceptance/phase_insights/poll_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/poll_phase_insights_spec.rb
@@ -40,15 +40,15 @@ resource 'Phase insights' do
       user3 = create(:user)
 
       # Poll responses
-      create(:poll_response, phase: phase, user: user1, created_at: 15.days.ago)
-      create(:poll_response, phase: phase, user: user2, created_at: 5.days.ago)
+      create(:poll_response, phase: phase, user: user1, created_at: 12.days.ago) # during phase (in week before last)
+      create(:poll_response, phase: phase, user: user2, created_at: 5.days.ago) # during phase & last 7 days
 
       # Pageviews and sessions
       session1 = create(:session, user_id: user1.id)
-      create(:pageview, session: session1, created_at: 15.days.ago, project_id: phase.project.id) # during phase
+      create(:pageview, session: session1, created_at: 12.days.ago, project_id: phase.project.id) # during phase (in week before last)
 
       session2 = create(:session, user_id: user2.id)
-      create(:pageview, session: session2, created_at: 15.days.ago, project_id: phase.project.id) # during phase
+      create(:pageview, session: session2, created_at: 12.days.ago, project_id: phase.project.id) # during phase (in week before last)
       create(:pageview, session: session2, created_at: 5.days.ago, project_id: phase.project.id) # during phase & last 7 days, same session
 
       session3 = create(:session, user_id: user3.id)
@@ -70,7 +70,7 @@ resource 'Phase insights' do
         visitors: 2,
         visitors_last_7_days: 1,
         participants: 2,
-        participants_last_7_days: 1,
+        participants_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 unique participant (in last 7 days) = 0% change
         engagement_rate: 1.0,
         poll: {
           responses: 2,
@@ -82,7 +82,7 @@ resource 'Phase insights' do
       expect(participants_and_visitors_chart_data).to eq({
         resolution: 'day',
         timeseries: [
-          { participants: 1, visitors: 2, date_group: '2025-11-17' },
+          { participants: 1, visitors: 2, date_group: '2025-11-20' },
           { participants: 1, visitors: 1, date_group: '2025-11-27' }
         ]
       })

--- a/back/spec/acceptance/phase_insights/poll_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/poll_phase_insights_spec.rb
@@ -59,7 +59,7 @@ resource 'Phase insights' do
   let(:id) { poll_phase.id }
 
   get 'web_api/v1/phases/:id/insights' do
-    example_request 'creates insights for poll phase' do
+    example_request 'returns insights data for poll phase' do
       assert_status 200
 
       expect(json_response_body[:data][:id]).to eq(poll_phase.id.to_s)
@@ -68,7 +68,7 @@ resource 'Phase insights' do
       metrics = json_response_body.dig(:data, :attributes, :metrics)
       expect(metrics).to eq({
         visitors: 2,
-        visitors_last_7_days: 1,
+        visitors_rolling_7_day_change: -50.0, # from 2 (in week before last) to 1 unique visitor (in last 7 days) = -50% decrease
         participants: 2,
         participants_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 unique participant (in last 7 days) = 0% change
         engagement_rate: 1.0,

--- a/back/spec/acceptance/phase_insights/poll_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/poll_phase_insights_spec.rb
@@ -72,6 +72,7 @@ resource 'Phase insights' do
         participants: 2,
         participants_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 unique participant (in last 7 days) = 0% change
         engagement_rate: 1.0,
+        engagement_rate_rolling_7_day_change: 100.0, # engagement_rate_last_7_days: 1.0, engagement_rate_last_14_to_8_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1)
         poll: {
           responses: 2,
           responses_last_7_days: 1

--- a/back/spec/acceptance/phase_insights/poll_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/poll_phase_insights_spec.rb
@@ -68,14 +68,14 @@ resource 'Phase insights' do
       metrics = json_response_body.dig(:data, :attributes, :metrics)
       expect(metrics).to eq({
         visitors: 2,
-        visitors_rolling_7_day_change: -50.0, # from 2 (in week before last) to 1 unique visitor (in last 7 days) = -50% decrease
+        visitors_7_day_change: -50.0, # from 2 (in week before last) to 1 unique visitor (in last 7 days) = -50% decrease
         participants: 2,
-        participants_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 unique participant (in last 7 days) = 0% change
+        participants_7_day_change: 0.0, # from 1 (in week before last) to 1 unique participant (in last 7 days) = 0% change
         participation_rate: 1.0,
-        participation_rate_rolling_7_day_change: 100.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1)
+        participation_rate_7_day_change: 100.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1)
         poll: {
           responses: 2,
-          responses_rolling_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change
+          responses_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change
         }
       })
 

--- a/back/spec/acceptance/phase_insights/poll_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/poll_phase_insights_spec.rb
@@ -75,7 +75,7 @@ resource 'Phase insights' do
         engagement_rate_rolling_7_day_change: 100.0, # engagement_rate_last_7_days: 1.0, engagement_rate_last_14_to_8_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1)
         poll: {
           responses: 2,
-          responses_last_7_days: 1
+          responses_rolling_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change
         }
       })
 

--- a/back/spec/acceptance/phase_insights/poll_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/poll_phase_insights_spec.rb
@@ -72,7 +72,7 @@ resource 'Phase insights' do
         participants: 2,
         participants_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 unique participant (in last 7 days) = 0% change
         engagement_rate: 1.0,
-        engagement_rate_rolling_7_day_change: 100.0, # engagement_rate_last_7_days: 1.0, engagement_rate_last_14_to_8_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1)
+        engagement_rate_rolling_7_day_change: 100.0, # engagement_rate_last_7_days: 1.0, engagement_rate_previous_7_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1)
         poll: {
           responses: 2,
           responses_rolling_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change

--- a/back/spec/acceptance/phase_insights/poll_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/poll_phase_insights_spec.rb
@@ -71,8 +71,8 @@ resource 'Phase insights' do
         visitors_rolling_7_day_change: -50.0, # from 2 (in week before last) to 1 unique visitor (in last 7 days) = -50% decrease
         participants: 2,
         participants_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 unique participant (in last 7 days) = 0% change
-        engagement_rate: 1.0,
-        engagement_rate_rolling_7_day_change: 100.0, # engagement_rate_last_7_days: 1.0, engagement_rate_previous_7_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1)
+        participation_rate: 1.0,
+        participation_rate_rolling_7_day_change: 100.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1)
         poll: {
           responses: 2,
           responses_rolling_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change

--- a/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
@@ -77,37 +77,37 @@ resource 'Phase insights' do
       )
 
       # Comments
-      create(:comment, idea: idea2, author: user4, created_at: 10.days.ago) # in phase (in week before last)
+      create(:comment, idea: idea2, author: user4, created_at: 10.days.ago) # during phase (in week before last)
 
       # Reactions
-      create(:reaction, reactable: idea1, user: user5, created_at: 5.days.ago) # in phase, and in last 7 days
+      create(:reaction, reactable: idea1, user: user5, created_at: 5.days.ago) # during phase & last 7 days
 
       # Pageviews and sessions
       session1 = create(:session, user_id: user1.id)
       create(:pageview, session: session1, created_at: 25.days.ago, project_id: phase.project.id) # before phase
 
       session2 = create(:session, user_id: user2.id)
-      create(:pageview, session: session2, created_at: 15.days.ago, project_id: phase.project.id) # in phase
-      create(:pageview, session: session2, created_at: 5.days.ago, project_id: phase.project.id) # in phase & last 7 days, same session
+      create(:pageview, session: session2, created_at: 15.days.ago, project_id: phase.project.id) # during phase
+      create(:pageview, session: session2, created_at: 5.days.ago, project_id: phase.project.id) # during phase & last 7 days, same session
 
       session3 = create(:session, user_id: user3.id)
       create(:pageview, session: session3, created_at: 2.days.ago, project_id: phase.project.id) # after phase
 
       session4 = create(:session)
-      create(:pageview, session: session4, created_at: 15.days.ago, project_id: phase.project.id) # in phase, did not participate
+      create(:pageview, session: session4, created_at: 15.days.ago, project_id: phase.project.id) # during phase, did not participate
 
       session5 = create(:session, user_id: user4.id)
-      create(:pageview, session: session5, created_at: 10.days.ago, project_id: phase.project.id) # in phase
+      create(:pageview, session: session5, created_at: 10.days.ago, project_id: phase.project.id) # during phase (in week before last)
 
       session6 = create(:session, user_id: user5.id)
-      create(:pageview, session: session6, created_at: 5.days.ago, project_id: phase.project.id) # in phase, and in last 7 days
+      create(:pageview, session: session6, created_at: 5.days.ago, project_id: phase.project.id) # during phase & last 7 days
     end
   end
 
   let(:id) { proposals_phase.id }
 
   get 'web_api/v1/phases/:id/insights' do
-    example_request 'creates insights for proposals phase' do
+    example_request 'returns insights data for proposals phase' do
       assert_status 200
 
       expect(json_response_body[:data][:id]).to eq(proposals_phase.id.to_s)
@@ -116,7 +116,7 @@ resource 'Phase insights' do
       metrics = json_response_body.dig(:data, :attributes, :metrics)
       expect(metrics).to eq({
         visitors: 4,
-        visitors_last_7_days: 2,
+        visitors_rolling_7_day_change: 100.0, # from 1 (in week before last) to 2 unique visitors (in last 7 days) = 100% increase
         participants: 3,
         participants_rolling_7_day_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
         engagement_rate: 0.75,

--- a/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
@@ -129,7 +129,7 @@ resource 'Phase insights' do
           comments_posted: 1,
           comments_posted_rolling_7_day_change: -100.0, # from 1 (in week before last) to 0 (in last 7 days) = -100% decrease
           reactions: 1,
-          reactions_rolling_7_day_change: 'last_7_days_compared_with_zero' # from 0 (in week before last) to 1 (in last 7 days) => nil (avoiding division by zero)
+          reactions_rolling_7_day_change: 'last_7_days_compared_with_zero' # from 0 (in week before last) to 1 (in last 7 days) => avoid division by zero
         }
       })
 

--- a/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
@@ -116,20 +116,20 @@ resource 'Phase insights' do
       metrics = json_response_body.dig(:data, :attributes, :metrics)
       expect(metrics).to eq({
         visitors: 4,
-        visitors_rolling_7_day_change: 0.0, # from 2 (in week before last) to 2 unique visitors (in last 7 days) = 0% change
+        visitors_7_day_change: 0.0, # from 2 (in week before last) to 2 unique visitors (in last 7 days) = 0% change
         participants: 3,
-        participants_rolling_7_day_change: 0.0, # from 2 (in week before last) to 2 unique participants (in last 7 days) = 0% change
+        participants_7_day_change: 0.0, # from 2 (in week before last) to 2 unique participants (in last 7 days) = 0% change
         participation_rate: 0.75,
-        participation_rate_rolling_7_day_change: 0.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
+        participation_rate_7_day_change: 0.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
         proposals: {
           ideas_posted: 2,
-          ideas_posted_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) => 0% change
+          ideas_posted_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) => 0% change
           reached_threshold: 2,
-          reached_threshold_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) => 0% change
+          reached_threshold_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) => 0% change
           comments_posted: 1,
-          comments_posted_rolling_7_day_change: -100.0, # from 1 (in week before last) to 0 (in last 7 days) = -100% decrease
+          comments_posted_7_day_change: -100.0, # from 1 (in week before last) to 0 (in last 7 days) = -100% decrease
           reactions: 1,
-          reactions_rolling_7_day_change: 'last_7_days_compared_with_zero' # from 0 (in week before last) to 1 (in last 7 days) => avoid division by zero
+          reactions_7_day_change: 'last_7_days_compared_with_zero' # from 0 (in week before last) to 1 (in last 7 days) => avoid division by zero
         }
       })
 

--- a/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
@@ -129,7 +129,7 @@ resource 'Phase insights' do
           comments_posted: 1,
           comments_posted_rolling_7_day_change: -100.0, # from 1 (in week before last) to 0 (in last 7 days) = -100% decrease
           reactions: 1,
-          reactions_rolling_7_day_change: nil # from 0 (in week before last) to 1 (in last 7 days) => nil (avoiding division by zero)
+          reactions_rolling_7_day_change: 'last_7_days_compared_with_zero' # from 0 (in week before last) to 1 (in last 7 days) => nil (avoiding division by zero)
         }
       })
 

--- a/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
@@ -119,8 +119,8 @@ resource 'Phase insights' do
         visitors_rolling_7_day_change: 0.0, # from 2 (in week before last) to 2 unique visitors (in last 7 days) = 0% change
         participants: 3,
         participants_rolling_7_day_change: 0.0, # from 2 (in week before last) to 2 unique participants (in last 7 days) = 0% change
-        engagement_rate: 0.75,
-        engagement_rate_rolling_7_day_change: 0.0, # engagement_rate_last_7_days: 1.0, engagement_rate_previous_7_days: 1.0 = 0% change
+        participation_rate: 0.75,
+        participation_rate_rolling_7_day_change: 0.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
         proposals: {
           ideas_posted: 2,
           ideas_posted_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) => 0% change

--- a/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
@@ -77,7 +77,7 @@ resource 'Phase insights' do
       )
 
       # Comments
-      create(:comment, idea: idea2, author: user4, created_at: 10.days.ago) # in phase
+      create(:comment, idea: idea2, author: user4, created_at: 10.days.ago) # in phase (in week before last)
 
       # Reactions
       create(:reaction, reactable: idea1, user: user5, created_at: 5.days.ago) # in phase, and in last 7 days
@@ -118,7 +118,7 @@ resource 'Phase insights' do
         visitors: 4,
         visitors_last_7_days: 2,
         participants: 3,
-        participants_last_7_days: 2,
+        participants_rolling_7_day_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
         engagement_rate: 0.75,
         proposals: {
           ideas_posted: 2,

--- a/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
@@ -120,6 +120,7 @@ resource 'Phase insights' do
         participants: 3,
         participants_rolling_7_day_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
         engagement_rate: 0.75,
+        engagement_rate_rolling_7_day_change: 0.0, # engagement_rate_last_7_days: 1.0, engagement_rate_last_14_to_8_days: 1.0 = 0% change
         proposals: {
           ideas_posted: 2,
           ideas_posted_last_7_days: 1,

--- a/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
@@ -120,7 +120,7 @@ resource 'Phase insights' do
         participants: 3,
         participants_rolling_7_day_change: 0.0, # from 2 (in week before last) to 2 unique participants (in last 7 days) = 0% change
         engagement_rate: 0.75,
-        engagement_rate_rolling_7_day_change: 0.0, # engagement_rate_last_7_days: 1.0, engagement_rate_last_14_to_8_days: 1.0 = 0% change
+        engagement_rate_rolling_7_day_change: 0.0, # engagement_rate_last_7_days: 1.0, engagement_rate_previous_7_days: 1.0 = 0% change
         proposals: {
           ideas_posted: 2,
           ideas_posted_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) => 0% change

--- a/back/spec/acceptance/phase_insights/volunteering_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/volunteering_phase_insights_spec.rb
@@ -44,9 +44,9 @@ resource 'Phase insights' do
       user3 = create(:user)
 
       # Volunteerings
-      create(:volunteer, cause: cause1, user: user1, created_at: 15.days.ago)
-      create(:volunteer, cause: cause2, user: user1, created_at: 5.days.ago)
-      create(:volunteer, cause: cause1, user: user2, created_at: 10.days.ago)
+      create(:volunteer, cause: cause1, user: user1, created_at: 15.days.ago) # during phase
+      create(:volunteer, cause: cause2, user: user1, created_at: 5.days.ago) # during phase & last 7 days
+      create(:volunteer, cause: cause1, user: user2, created_at: 10.days.ago) # during phase (in week before last)
 
       # Pageviews and sessions
       session1 = create(:session, user_id: user1.id)
@@ -75,7 +75,7 @@ resource 'Phase insights' do
         visitors: 2,
         visitors_last_7_days: 1,
         participants: 2,
-        participants_last_7_days: 1,
+        participants_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 unique participant (in last 7 days) = 0% change
         engagement_rate: 1.0,
         volunteering: {
           volunteerings: 3,

--- a/back/spec/acceptance/phase_insights/volunteering_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/volunteering_phase_insights_spec.rb
@@ -76,8 +76,8 @@ resource 'Phase insights' do
         visitors_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 unique visitor (in last 7 days) = 0% change
         participants: 2,
         participants_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 unique participant (in last 7 days) = 0% change
-        engagement_rate: 1.0,
-        engagement_rate_rolling_7_day_change: 0.0, # engagement_rate_last_7_days: 1.0, engagement_rate_previous_7_days: 1.0 = 0% change
+        participation_rate: 1.0,
+        participation_rate_rolling_7_day_change: 0.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
         volunteering: {
           volunteerings: 3,
           volunteerings_rolling_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change

--- a/back/spec/acceptance/phase_insights/volunteering_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/volunteering_phase_insights_spec.rb
@@ -77,6 +77,7 @@ resource 'Phase insights' do
         participants: 2,
         participants_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 unique participant (in last 7 days) = 0% change
         engagement_rate: 1.0,
+        engagement_rate_rolling_7_day_change: 0.0, # engagement_rate_last_7_days: 1.0, engagement_rate_last_14_to_8_days: 1.0 = 0% change
         volunteering: {
           volunteerings: 3,
           volunteerings_last_7_days: 1

--- a/back/spec/acceptance/phase_insights/volunteering_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/volunteering_phase_insights_spec.rb
@@ -80,7 +80,7 @@ resource 'Phase insights' do
         engagement_rate_rolling_7_day_change: 0.0, # engagement_rate_last_7_days: 1.0, engagement_rate_last_14_to_8_days: 1.0 = 0% change
         volunteering: {
           volunteerings: 3,
-          volunteerings_last_7_days: 1
+          volunteerings_rolling_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change
         }
       })
 

--- a/back/spec/acceptance/phase_insights/volunteering_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/volunteering_phase_insights_spec.rb
@@ -77,7 +77,7 @@ resource 'Phase insights' do
         participants: 2,
         participants_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 unique participant (in last 7 days) = 0% change
         engagement_rate: 1.0,
-        engagement_rate_rolling_7_day_change: 0.0, # engagement_rate_last_7_days: 1.0, engagement_rate_last_14_to_8_days: 1.0 = 0% change
+        engagement_rate_rolling_7_day_change: 0.0, # engagement_rate_last_7_days: 1.0, engagement_rate_previous_7_days: 1.0 = 0% change
         volunteering: {
           volunteerings: 3,
           volunteerings_rolling_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change

--- a/back/spec/acceptance/phase_insights/volunteering_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/volunteering_phase_insights_spec.rb
@@ -51,10 +51,10 @@ resource 'Phase insights' do
       # Pageviews and sessions
       session1 = create(:session, user_id: user1.id)
       create(:pageview, session: session1, created_at: 15.days.ago, project_id: phase.project.id) # during phase
+      create(:pageview, session: session1, created_at: 5.days.ago, project_id: phase.project.id) # during phase & last 7 days
 
       session2 = create(:session, user_id: user2.id)
-      create(:pageview, session: session2, created_at: 15.days.ago, project_id: phase.project.id) # during phase
-      create(:pageview, session: session2, created_at: 5.days.ago, project_id: phase.project.id) # during phase & last 7 days, same session
+      create(:pageview, session: session2, created_at: 10.days.ago, project_id: phase.project.id) # during phase (in week before last)
 
       session3 = create(:session, user_id: user3.id)
       create(:pageview, session: session3, created_at: 2.days.ago, project_id: phase.project.id) # after phase
@@ -64,7 +64,7 @@ resource 'Phase insights' do
   let(:id) { volunteering_phase.id }
 
   get 'web_api/v1/phases/:id/insights' do
-    example_request 'creates insights for volunteering phase' do
+    example_request 'returns insights data for volunteering phase' do
       assert_status 200
 
       expect(json_response_body[:data][:id]).to eq(volunteering_phase.id.to_s)
@@ -73,7 +73,7 @@ resource 'Phase insights' do
       metrics = json_response_body.dig(:data, :attributes, :metrics)
       expect(metrics).to eq({
         visitors: 2,
-        visitors_last_7_days: 1,
+        visitors_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 unique visitor (in last 7 days) = 0% change
         participants: 2,
         participants_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 unique participant (in last 7 days) = 0% change
         engagement_rate: 1.0,
@@ -87,8 +87,8 @@ resource 'Phase insights' do
       expect(participants_and_visitors_chart_data).to eq({
         resolution: 'day',
         timeseries: [
-          { participants: 1, visitors: 2, date_group: '2025-11-17' },
-          { participants: 1, visitors: 0, date_group: '2025-11-22' },
+          { participants: 1, visitors: 1, date_group: '2025-11-17' },
+          { participants: 1, visitors: 1, date_group: '2025-11-22' },
           { participants: 1, visitors: 1, date_group: '2025-11-27' }
         ]
       })

--- a/back/spec/acceptance/phase_insights/volunteering_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/volunteering_phase_insights_spec.rb
@@ -73,14 +73,14 @@ resource 'Phase insights' do
       metrics = json_response_body.dig(:data, :attributes, :metrics)
       expect(metrics).to eq({
         visitors: 2,
-        visitors_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 unique visitor (in last 7 days) = 0% change
+        visitors_7_day_change: 0.0, # from 1 (in week before last) to 1 unique visitor (in last 7 days) = 0% change
         participants: 2,
-        participants_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 unique participant (in last 7 days) = 0% change
+        participants_7_day_change: 0.0, # from 1 (in week before last) to 1 unique participant (in last 7 days) = 0% change
         participation_rate: 1.0,
-        participation_rate_rolling_7_day_change: 0.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
+        participation_rate_7_day_change: 0.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
         volunteering: {
           volunteerings: 3,
-          volunteerings_rolling_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change
+          volunteerings_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change
         }
       })
 

--- a/back/spec/acceptance/phase_insights/voting_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/voting_phase_insights_spec.rb
@@ -125,17 +125,17 @@ resource 'Phase insights' do
         participants: 5,
         participants_rolling_7_day_change: 50.0, # from 3 (in week before last) to 5 unique participants (in last 7 days) = 50% increase
         engagement_rate: 0.833,
-        engagement_rate_rolling_7_day_change: 20.0, # engagement_rate_last_7_days: 0.6, engagement_rate_last_14_to_8_days: 0.5 = (((0.6 - 0.5).to_f / 0.5) * 100.0).round(1)
+        engagement_rate_rolling_7_day_change: 20.0, # engagement_rate_last_7_days: 0.6, engagement_rate_previous_7_days: 0.5 = (((0.6 - 0.5).to_f / 0.5) * 100.0).round(1)
         voting: {
           voting_method: 'multiple_voting',
           online_votes: 6,
-          online_votes_last_7_days: 1,
+          online_votes_rolling_7_day_change: 0.0, # from 3 (in week before last) to 3 (in last 7 days) = 0% change
           offline_votes: 3,
           voters: 3,
-          voters_last_7_days: 1,
+          voters_rolling_7_day_change: 0.0, # from 2 (in week before last) to 2 unique voters (in last 7 days) = 0% change
           associated_ideas: 3,
           comments_posted: 3,
-          comments_posted_last_7_days: 2
+          comments_posted_rolling_7_day_change: 100.0 # from 1 (in week before last) to 2 (in last 7 days) = 100% increase
         }
       })
     end
@@ -160,17 +160,17 @@ resource 'Phase insights' do
           participants: 5,
           participants_rolling_7_day_change: 50.0, # from 3 (in week before last) to 5 unique participants (in last 7 days) = 50% increase
           engagement_rate: 0.833,
-          engagement_rate_rolling_7_day_change: 20.0, # engagement_rate_last_7_days: 0.6, engagement_rate_last_14_to_8_days: 0.5 = (((0.6 - 0.5).to_f / 0.5) * 100.0).round(1)
+          engagement_rate_rolling_7_day_change: 20.0, # engagement_rate_last_7_days: 0.6, engagement_rate_previous_7_days: 0.5 = (((0.6 - 0.5).to_f / 0.5) * 100.0).round(1)
           voting: {
             voting_method: 'budgeting',
             online_picks: 4,
-            online_picks_last_7_days: 1,
+            online_picks_rolling_7_day_change: 0.0, # from 2 (in week before last) to 2 (in last 7 days) = 0% change
             offline_picks: 3,
             voters: 3,
-            voters_last_7_days: 1,
+            voters_rolling_7_day_change: 0.0, # from 2 (in week before last) to 2 unique voters (in last 7 days) = 0% change
             associated_ideas: 3,
             comments_posted: 3,
-            comments_posted_last_7_days: 2
+            comments_posted_rolling_7_day_change: 100.0 # from 1 (in week before last) to 2 (in last 7 days) = 100% increase
           }
         })
 

--- a/back/spec/acceptance/phase_insights/voting_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/voting_phase_insights_spec.rb
@@ -128,12 +128,12 @@ resource 'Phase insights' do
         participation_rate_rolling_7_day_change: 20.0, # participation_rate_last_7_days: 0.6, participation_rate_previous_7_days: 0.5 = (((0.6 - 0.5).to_f / 0.5) * 100.0).round(1)
         voting: {
           voting_method: 'multiple_voting',
+          associated_ideas: 3,
           online_votes: 6,
           online_votes_rolling_7_day_change: 0.0, # from 3 (in week before last) to 3 (in last 7 days) = 0% change
           offline_votes: 3,
           voters: 3,
           voters_rolling_7_day_change: 0.0, # from 2 (in week before last) to 2 unique voters (in last 7 days) = 0% change
-          associated_ideas: 3,
           comments_posted: 3,
           comments_posted_rolling_7_day_change: 100.0 # from 1 (in week before last) to 2 (in last 7 days) = 100% increase
         }
@@ -163,12 +163,12 @@ resource 'Phase insights' do
           participation_rate_rolling_7_day_change: 20.0, # participation_rate_last_7_days: 0.6, participation_rate_previous_7_days: 0.5 = (((0.6 - 0.5).to_f / 0.5) * 100.0).round(1)
           voting: {
             voting_method: 'budgeting',
+            associated_ideas: 3,
             online_picks: 4,
             online_picks_rolling_7_day_change: 0.0, # from 2 (in week before last) to 2 (in last 7 days) = 0% change
             offline_picks: 3,
             voters: 3,
             voters_rolling_7_day_change: 0.0, # from 2 (in week before last) to 2 unique voters (in last 7 days) = 0% change
-            associated_ideas: 3,
             comments_posted: 3,
             comments_posted_rolling_7_day_change: 100.0 # from 1 (in week before last) to 2 (in last 7 days) = 100% increase
           }

--- a/back/spec/acceptance/phase_insights/voting_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/voting_phase_insights_spec.rb
@@ -121,21 +121,21 @@ resource 'Phase insights' do
       metrics = json_response_body.dig(:data, :attributes, :metrics)
       expect(metrics).to eq({
         visitors: 6,
-        visitors_rolling_7_day_change: 25.0, # from 4 (in week before last) to 5 unique visitors (in last 7 days) = 25% increase
+        visitors_7_day_change: 25.0, # from 4 (in week before last) to 5 unique visitors (in last 7 days) = 25% increase
         participants: 5,
-        participants_rolling_7_day_change: 50.0, # from 3 (in week before last) to 5 unique participants (in last 7 days) = 50% increase
+        participants_7_day_change: 50.0, # from 3 (in week before last) to 5 unique participants (in last 7 days) = 50% increase
         participation_rate: 0.833,
-        participation_rate_rolling_7_day_change: 20.0, # participation_rate_last_7_days: 0.6, participation_rate_previous_7_days: 0.5 = (((0.6 - 0.5).to_f / 0.5) * 100.0).round(1)
+        participation_rate_7_day_change: 20.0, # participation_rate_last_7_days: 0.6, participation_rate_previous_7_days: 0.5 = (((0.6 - 0.5).to_f / 0.5) * 100.0).round(1)
         voting: {
           voting_method: 'multiple_voting',
           associated_ideas: 3,
           online_votes: 6,
-          online_votes_rolling_7_day_change: 0.0, # from 3 (in week before last) to 3 (in last 7 days) = 0% change
+          online_votes_7_day_change: 0.0, # from 3 (in week before last) to 3 (in last 7 days) = 0% change
           offline_votes: 3,
           voters: 3,
-          voters_rolling_7_day_change: 0.0, # from 2 (in week before last) to 2 unique voters (in last 7 days) = 0% change
+          voters_7_day_change: 0.0, # from 2 (in week before last) to 2 unique voters (in last 7 days) = 0% change
           comments_posted: 3,
-          comments_posted_rolling_7_day_change: 100.0 # from 1 (in week before last) to 2 (in last 7 days) = 100% increase
+          comments_posted_7_day_change: 100.0 # from 1 (in week before last) to 2 (in last 7 days) = 100% increase
         }
       })
     end
@@ -156,21 +156,21 @@ resource 'Phase insights' do
         metrics = json_response_body.dig(:data, :attributes, :metrics)
         expect(metrics).to eq({
           visitors: 6,
-          visitors_rolling_7_day_change: 25.0, # from 4 (in week before last) to 5 unique visitors (in last 7 days) = 25% increase
+          visitors_7_day_change: 25.0, # from 4 (in week before last) to 5 unique visitors (in last 7 days) = 25% increase
           participants: 5,
-          participants_rolling_7_day_change: 50.0, # from 3 (in week before last) to 5 unique participants (in last 7 days) = 50% increase
+          participants_7_day_change: 50.0, # from 3 (in week before last) to 5 unique participants (in last 7 days) = 50% increase
           participation_rate: 0.833,
-          participation_rate_rolling_7_day_change: 20.0, # participation_rate_last_7_days: 0.6, participation_rate_previous_7_days: 0.5 = (((0.6 - 0.5).to_f / 0.5) * 100.0).round(1)
+          participation_rate_7_day_change: 20.0, # participation_rate_last_7_days: 0.6, participation_rate_previous_7_days: 0.5 = (((0.6 - 0.5).to_f / 0.5) * 100.0).round(1)
           voting: {
             voting_method: 'budgeting',
             associated_ideas: 3,
             online_picks: 4,
-            online_picks_rolling_7_day_change: 0.0, # from 2 (in week before last) to 2 (in last 7 days) = 0% change
+            online_picks_7_day_change: 0.0, # from 2 (in week before last) to 2 (in last 7 days) = 0% change
             offline_picks: 3,
             voters: 3,
-            voters_rolling_7_day_change: 0.0, # from 2 (in week before last) to 2 unique voters (in last 7 days) = 0% change
+            voters_7_day_change: 0.0, # from 2 (in week before last) to 2 unique voters (in last 7 days) = 0% change
             comments_posted: 3,
-            comments_posted_rolling_7_day_change: 100.0 # from 1 (in week before last) to 2 (in last 7 days) = 100% increase
+            comments_posted_7_day_change: 100.0 # from 1 (in week before last) to 2 (in last 7 days) = 100% increase
           }
         })
 

--- a/back/spec/acceptance/phase_insights/voting_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/voting_phase_insights_spec.rb
@@ -125,6 +125,7 @@ resource 'Phase insights' do
         participants: 5,
         participants_rolling_7_day_change: 50.0, # from 3 (in week before last) to 5 unique participants (in last 7 days) = 50% increase
         engagement_rate: 0.833,
+        engagement_rate_rolling_7_day_change: 20.0, # engagement_rate_last_7_days: 0.6, engagement_rate_last_14_to_8_days: 0.5 = (((0.6 - 0.5).to_f / 0.5) * 100.0).round(1)
         voting: {
           voting_method: 'multiple_voting',
           online_votes: 6,
@@ -159,6 +160,7 @@ resource 'Phase insights' do
           participants: 5,
           participants_rolling_7_day_change: 50.0, # from 3 (in week before last) to 5 unique participants (in last 7 days) = 50% increase
           engagement_rate: 0.833,
+          engagement_rate_rolling_7_day_change: 20.0, # engagement_rate_last_7_days: 0.6, engagement_rate_last_14_to_8_days: 0.5 = (((0.6 - 0.5).to_f / 0.5) * 100.0).round(1)
           voting: {
             voting_method: 'budgeting',
             online_picks: 4,

--- a/back/spec/acceptance/phase_insights/voting_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/voting_phase_insights_spec.rb
@@ -124,8 +124,8 @@ resource 'Phase insights' do
         visitors_rolling_7_day_change: 25.0, # from 4 (in week before last) to 5 unique visitors (in last 7 days) = 25% increase
         participants: 5,
         participants_rolling_7_day_change: 50.0, # from 3 (in week before last) to 5 unique participants (in last 7 days) = 50% increase
-        engagement_rate: 0.833,
-        engagement_rate_rolling_7_day_change: 20.0, # engagement_rate_last_7_days: 0.6, engagement_rate_previous_7_days: 0.5 = (((0.6 - 0.5).to_f / 0.5) * 100.0).round(1)
+        participation_rate: 0.833,
+        participation_rate_rolling_7_day_change: 20.0, # participation_rate_last_7_days: 0.6, participation_rate_previous_7_days: 0.5 = (((0.6 - 0.5).to_f / 0.5) * 100.0).round(1)
         voting: {
           voting_method: 'multiple_voting',
           online_votes: 6,
@@ -159,8 +159,8 @@ resource 'Phase insights' do
           visitors_rolling_7_day_change: 25.0, # from 4 (in week before last) to 5 unique visitors (in last 7 days) = 25% increase
           participants: 5,
           participants_rolling_7_day_change: 50.0, # from 3 (in week before last) to 5 unique participants (in last 7 days) = 50% increase
-          engagement_rate: 0.833,
-          engagement_rate_rolling_7_day_change: 20.0, # engagement_rate_last_7_days: 0.6, engagement_rate_previous_7_days: 0.5 = (((0.6 - 0.5).to_f / 0.5) * 100.0).round(1)
+          participation_rate: 0.833,
+          participation_rate_rolling_7_day_change: 20.0, # participation_rate_last_7_days: 0.6, participation_rate_previous_7_days: 0.5 = (((0.6 - 0.5).to_f / 0.5) * 100.0).round(1)
           voting: {
             voting_method: 'budgeting',
             online_picks: 4,

--- a/back/spec/acceptance/phase_insights/voting_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/voting_phase_insights_spec.rb
@@ -37,7 +37,7 @@ resource 'Phase insights' do
       :phase,
       participation_method: 'ideation',
       start_at: 30.days.ago,
-      end_at: 15.days.ago
+      end_at: 16.days.ago
     )
   end
 
@@ -46,7 +46,7 @@ resource 'Phase insights' do
       :phase,
       participation_method: 'voting',
       voting_method: 'multiple_voting',
-      start_at: 14.days.ago,
+      start_at: 15.days.ago,
       end_at: 1.day.ago,
       project: ideation_phase.project,
       manual_votes_count: 3,
@@ -67,7 +67,7 @@ resource 'Phase insights' do
 
       # Comments
       create(:comment, idea: idea1, author: user1, created_at: 25.days.ago) # before voting phase (not counted)
-      create(:comment, idea: idea2, author: user2, created_at: 13.days.ago) # in voting phase
+      create(:comment, idea: idea2, author: user2, created_at: 13.days.ago) # in voting phase (in week before last)
       create(:comment, idea: idea3, author: user2, created_at: 5.days.ago) # in voting phase & last 7 days
       create(:comment, idea: idea3, author: user3, created_at: 5.days.ago) # in voting phase & last 7 days
 
@@ -76,7 +76,7 @@ resource 'Phase insights' do
       create(:baskets_idea, basket: basket1, idea: idea1, votes: 1)
       create(:baskets_idea, basket: basket1, idea: idea2, votes: 3)
 
-      basket2 = create(:basket, phase: phase, user: user5, submitted_at: 10.days.ago) # in voting phase
+      basket2 = create(:basket, phase: phase, user: user5, submitted_at: 10.days.ago) # in voting phase (in week before last)
       create(:baskets_idea, basket: basket2, idea: idea2, votes: 1)
 
       basket3 = create(:basket, phase: phase, user: user6, submitted_at: 5.days.ago) # in voting phase & last 7 days
@@ -124,7 +124,7 @@ resource 'Phase insights' do
         visitors: 6,
         visitors_last_7_days: 5,
         participants: 5,
-        participants_last_7_days: 3,
+        participants_rolling_7_day_change: 50.0, # from 3 (in week before last) to 5 unique participants (in last 7 days) = 50% increase
         engagement_rate: 0.833,
         voting: {
           voting_method: 'multiple_voting',
@@ -158,7 +158,7 @@ resource 'Phase insights' do
           visitors: 6,
           visitors_last_7_days: 5,
           participants: 5,
-          participants_last_7_days: 3,
+          participants_rolling_7_day_change: 50.0, # from 3 (in week before last) to 5 unique participants (in last 7 days) = 50% increase
           engagement_rate: 0.833,
           voting: {
             voting_method: 'budgeting',

--- a/back/spec/factories/participations.rb
+++ b/back/spec/factories/participations.rb
@@ -130,6 +130,25 @@ FactoryBot.define do
     end
   end
 
+  factory :taking_poll_participation, parent: :participation do
+    initialize_with do
+      participation_user = user || create(:user)
+      response = create(:poll_response, user: participation_user)
+      acted_at_time = acted_at || response.created_at
+      participant_id ||= response.user_id
+      custom_field_values = user_custom_field_values.presence || response.user.custom_field_values || {}
+
+      {
+        item_id: response.id,
+        action: 'taking_poll',
+        acted_at: acted_at_time,
+        classname: 'Response',
+        participant_id: participant_id,
+        user_custom_field_values: custom_field_values
+      }
+    end
+  end
+
   # Alias basket_participation as the default participation
   factory :participation_default, parent: :basket_participation
 end

--- a/back/spec/factories/participations.rb
+++ b/back/spec/factories/participations.rb
@@ -149,6 +149,25 @@ FactoryBot.define do
     end
   end
 
+  factory :volunteering_participation, parent: :participation do
+    initialize_with do
+      participation_user = user || create(:user)
+      volunteer = create(:volunteer, user: participation_user)
+      acted_at_time = acted_at || volunteer.created_at
+      participant_id ||= volunteer.user_id
+      custom_field_values = user_custom_field_values.presence || volunteer.user.custom_field_values || {}
+
+      {
+        item_id: volunteer.id,
+        action: 'volunteering',
+        acted_at: acted_at_time,
+        classname: 'Volunteer',
+        participant_id: participant_id,
+        user_custom_field_values: custom_field_values
+      }
+    end
+  end
+
   # Alias basket_participation as the default participation
   factory :participation_default, parent: :basket_participation
 end

--- a/back/spec/services/insights/base_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/base_phase_insights_service_spec.rb
@@ -483,4 +483,42 @@ RSpec.describe Insights::BasePhaseInsightsService do
       expect(service.send(:date_truncate, datetime, 'month')).to eq(Date.new(2024, 6, 1))
     end
   end
+
+  describe '#phase_has_run_more_than_14_days?' do
+    it 'returns false when phase duration is less than 14 days' do
+      phase = create(:single_voting_phase, start_at: 15.days.ago, end_at: 2.days.ago)
+      service = described_class.new(phase)
+      expect(service.send(:phase_has_run_more_than_14_days?)).to be false
+    end
+
+    it 'returns false when phase duration is more than 14 days but elapsed time is less than 14 days' do
+      phase = create(:single_voting_phase, start_at: 13.days.ago, end_at: 2.days.from_now)
+      service = described_class.new(phase)
+      expect(service.send(:phase_has_run_more_than_14_days?)).to be false
+    end
+
+    it 'returns true when phase duration is more than 14 days and elapsed time is at least 14 days' do
+      phase = create(:single_voting_phase, start_at: 20.days.ago, end_at: 1.day.ago)
+      service = described_class.new(phase)
+      expect(service.send(:phase_has_run_more_than_14_days?)).to be true
+    end
+
+    it 'returns false when phase is long enough but started less than 14 days ago' do
+      phase = create(:single_voting_phase, start_at: 10.days.ago, end_at: 30.days.from_now)
+      service = described_class.new(phase)
+      expect(service.send(:phase_has_run_more_than_14_days?)).to be false
+    end
+
+    it 'returns true for ongoing phases without end_at when started more than 14 days ago' do
+      phase = create(:single_voting_phase, start_at: 20.days.ago, end_at: nil)
+      service = described_class.new(phase)
+      expect(service.send(:phase_has_run_more_than_14_days?)).to be true
+    end
+
+    it 'returns false for ongoing phases without end_at when started less than 14 days ago' do
+      phase = create(:single_voting_phase, start_at: 10.days.ago, end_at: nil)
+      service = described_class.new(phase)
+      expect(service.send(:phase_has_run_more_than_14_days?)).to be false
+    end
+  end
 end

--- a/back/spec/services/insights/base_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/base_phase_insights_service_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe Insights::BasePhaseInsightsService do
           visitors_rolling_7_day_change: 0.0, # From 3 (7 to 14 days ago) to 3 (last 7-day period) unique visitors = 0% change
           participants: 3,
           participants_rolling_7_day_change: 50.0, # From 2 (7 to 14 days ago) to 3 (last 7-day period) unique participants = 50% increase
-          engagement_rate: 0.75,
-          engagement_rate_rolling_7_day_change: 49.9 # engagement_rate_last_7_days: 1.0, engagement_rate_previous_7_days: 0.667 = (((1 - 0.667).to_f / 0.667) * 100.0).round(1)
+          participation_rate: 0.75,
+          participation_rate_rolling_7_day_change: 49.9 # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 0.667 = (((1 - 0.667).to_f / 0.667) * 100.0).round(1)
         }
       )
     end

--- a/back/spec/services/insights/base_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/base_phase_insights_service_spec.rb
@@ -54,11 +54,11 @@ RSpec.describe Insights::BasePhaseInsightsService do
       expect(result).to eq(
         {
           visitors: 4,
-          visitors_rolling_7_day_change: 0.0, # From 3 (7 to 14 days ago) to 3 (last 7-day period) unique visitors = 0% change
+          visitors_7_day_change: 0.0, # From 3 (7 to 14 days ago) to 3 (last 7-day period) unique visitors = 0% change
           participants: 3,
-          participants_rolling_7_day_change: 50.0, # From 2 (7 to 14 days ago) to 3 (last 7-day period) unique participants = 50% increase
+          participants_7_day_change: 50.0, # From 2 (7 to 14 days ago) to 3 (last 7-day period) unique participants = 50% increase
           participation_rate: 0.75,
-          participation_rate_rolling_7_day_change: 49.9 # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 0.667 = (((1 - 0.667).to_f / 0.667) * 100.0).round(1)
+          participation_rate_7_day_change: 49.9 # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 0.667 = (((1 - 0.667).to_f / 0.667) * 100.0).round(1)
         }
       )
     end
@@ -561,20 +561,20 @@ RSpec.describe Insights::BasePhaseInsightsService do
     end
   end
 
-  describe '#participations_rolling_7_day_change' do
+  describe '#participations_7_day_change' do
     it 'returns nil when phase has not run more than 14 days' do
       phase = create(:single_voting_phase, start_at: 10.days.ago, end_at: 5.days.ago)
       service = described_class.new(phase)
       participations = [create(:basket_participation, acted_at: 9.days.ago)]
 
-      expect(service.send(:participations_rolling_7_day_change, participations)).to be_nil
+      expect(service.send(:participations_7_day_change, participations)).to be_nil
     end
 
     it 'returns 0.0 when participations is empty' do
-      expect(service.send(:participations_rolling_7_day_change, [])).to eq(0.0)
+      expect(service.send(:participations_7_day_change, [])).to eq(0.0)
     end
 
-    it 'calculates rolling 7-day change correctly' do
+    it 'calculates 7-day change correctly' do
       participations = [
         create(:basket_participation, acted_at: 10.days.ago, participant_id: 'user_1'),
         create(:basket_participation, acted_at: 9.days.ago, participant_id: 'user_2'),
@@ -584,13 +584,13 @@ RSpec.describe Insights::BasePhaseInsightsService do
 
       # Unique participants in 7-14 days ago: user_1, user_2 => 2
       # Unique participants in last 7 days: user_1, user_3 => 2
-      expect(service.send(:participations_rolling_7_day_change, participations)).to eq(0.0)
+      expect(service.send(:participations_7_day_change, participations)).to eq(0.0)
 
       # Adding one more participation in the last 7 days
       participations << create(:basket_participation, acted_at: 3.days.ago, participant_id: 'user_4')
 
       # Unique participants in last 7 days: user_1, user_3, user_4 => 3
-      expect(service.send(:participations_rolling_7_day_change, participations)).to eq(50.0)
+      expect(service.send(:participations_7_day_change, participations)).to eq(50.0)
     end
   end
 end

--- a/back/spec/services/insights/base_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/base_phase_insights_service_spec.rb
@@ -484,11 +484,6 @@ RSpec.describe Insights::BasePhaseInsightsService do
     end
   end
 
-  describe 'participants_rolling_7_day_change' do
-    it 'calculates rolling 7-day change correctly' do
-    end
-  end
-
   describe '#phase_has_run_more_than_14_days?' do
     it 'returns false when phase duration is less than 14 days' do
       phase = create(:single_voting_phase, start_at: 15.days.ago, end_at: 2.days.ago)

--- a/back/spec/services/insights/base_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/base_phase_insights_service_spec.rb
@@ -521,4 +521,30 @@ RSpec.describe Insights::BasePhaseInsightsService do
       expect(service.send(:phase_has_run_more_than_14_days?)).to be false
     end
   end
+
+  describe '#percentage_change' do
+    it 'calculates percentage change correctly' do
+      expect(service.send(:percentage_change, 100, 150)).to eq(50.0)
+      expect(service.send(:percentage_change, 200, 100)).to eq(-50.0)
+      expect(service.send(:percentage_change, 50, 75)).to eq(50.0)
+      expect(service.send(:percentage_change, 80, 60)).to eq(-25.0)
+    end
+
+    it 'returns nil when old value is zero' do
+      expect(service.send(:percentage_change, 0, 100)).to be_nil
+    end
+
+    it 'returns zero when there is no change' do
+      expect(service.send(:percentage_change, 100, 100)).to eq(0.0)
+    end
+
+    it 'returns -100.0 when new value is zero' do
+      expect(service.send(:percentage_change, 100, 0)).to eq(-100.0)
+    end
+
+    it 'rounds percentage change to one decimal place' do
+      expect(service.send(:percentage_change, 3, 4)).to eq(33.3)
+      expect(service.send(:percentage_change, 7, 5)).to eq(-28.6)
+    end
+  end
 end

--- a/back/spec/services/insights/base_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/base_phase_insights_service_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Insights::BasePhaseInsightsService do
   let(:service) { described_class.new(phase) }
 
-  let(:phase) { create(:single_voting_phase, start_at: 15.days.ago, end_at: 2.days.ago) }
+  let(:phase) { create(:single_voting_phase, start_at: 17.days.ago, end_at: 2.days.ago) }
   let!(:permission1) { create(:permission, action: 'voting', permission_scope: phase) }
 
   describe '#participant_id' do
@@ -26,13 +26,13 @@ RSpec.describe Insights::BasePhaseInsightsService do
     let(:user1) { create(:user) }
 
     let(:participation1) { create(:basket_participation, acted_at: 20.days.ago, user: user1) } # before phase start
-    let(:participation2) { create(:basket_participation, acted_at: 10.days.ago, user: user1) } # after phase start & before phase end
-    let(:participation3) { create(:basket_participation, acted_at: 5.days.ago, user: user1) } # in last 7 days & before phase end
+    let(:participation2) { create(:basket_participation, acted_at: 10.days.ago, user: user1) } # during phase & before last 7 days
+    let(:participation3) { create(:basket_participation, acted_at: 5.days.ago, user: user1) } # during phase & in last 7 days
     let(:participation4) { create(:basket_participation, acted_at: 1.day.ago, user: user1) } # after phase end
 
     let(:user2) { create(:user) }
-    let(:participation5) { create(:basket_participation, acted_at: 10.days.ago, user: user2) } # after phase start & before phase end
-    let(:participation6) { create(:basket_participation, acted_at: 4.days.ago, user: user2) } # in last 7 days & before phase end
+    let(:participation5) { create(:basket_participation, acted_at: 10.days.ago, user: user2) } # during phase & before last 7 days
+    let(:participation6) { create(:basket_participation, acted_at: 4.days.ago, user: user2) } # during phase & in last 7 days
 
     let(:participation7) { create(:basket_participation, acted_at: 4.days.ago, user: nil, participant_id: SecureRandom.uuid) } # Anonymous or no user, in last 7 days & before phase end
 
@@ -47,7 +47,7 @@ RSpec.describe Insights::BasePhaseInsightsService do
           visitors: 100,
           visitors_last_7_days: 20,
           participants: 3,
-          participants_last_7_days: 3,
+          participants_rolling_7_day_change: 50.0, # From 2 (7 to 14 days ago) to 3 (last 7-day period) participants = 50% increase
           engagement_rate: 0.03
         }
       )
@@ -481,6 +481,11 @@ RSpec.describe Insights::BasePhaseInsightsService do
     it 'returns the first day of month for month resolution' do
       datetime = Time.new(2024, 6, 15, 14, 30, 0)
       expect(service.send(:date_truncate, datetime, 'month')).to eq(Date.new(2024, 6, 1))
+    end
+  end
+
+  describe 'participants_rolling_7_day_change' do
+    it 'calculates rolling 7-day change correctly' do
     end
   end
 

--- a/back/spec/services/insights/base_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/base_phase_insights_service_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Insights::BasePhaseInsightsService do
           participants: 3,
           participants_rolling_7_day_change: 50.0, # From 2 (7 to 14 days ago) to 3 (last 7-day period) unique participants = 50% increase
           engagement_rate: 0.75,
-          engagement_rate_rolling_7_day_change: 49.9 # engagement_rate_last_7_days: 1.0, engagement_rate_last_14_to_8_days: 0.667 = (((1 - 0.667).to_f / 0.667) * 100.0).round(1)
+          engagement_rate_rolling_7_day_change: 49.9 # engagement_rate_last_7_days: 1.0, engagement_rate_previous_7_days: 0.667 = (((1 - 0.667).to_f / 0.667) * 100.0).round(1)
         }
       )
     end

--- a/back/spec/services/insights/base_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/base_phase_insights_service_spec.rb
@@ -539,12 +539,16 @@ RSpec.describe Insights::BasePhaseInsightsService do
       expect(service.send(:percentage_change, 80, 60)).to eq(-25.0)
     end
 
-    it 'returns nil when old value is zero' do
+    it 'returns nil when old value is zero and new value is not zero' do
       expect(service.send(:percentage_change, 0, 100)).to be_nil
     end
 
     it 'returns zero when there is no change' do
       expect(service.send(:percentage_change, 100, 100)).to eq(0.0)
+    end
+
+    it 'returns zero when both old and new values are zero' do
+      expect(service.send(:percentage_change, 0, 0)).to eq(0.0)
     end
 
     it 'returns -100.0 when new value is zero' do

--- a/back/spec/services/insights/base_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/base_phase_insights_service_spec.rb
@@ -39,12 +39,12 @@ RSpec.describe Insights::BasePhaseInsightsService do
 
     let(:visits) do
       [
-        { acted_at: 10.days.ago, visitor_id: user1.id.to_s }, # after phase start & before phase end
-        { acted_at: 5.days.ago, visitor_id: user1.id.to_s },  # in last 7 days & before phase end
-        { acted_at: 10.days.ago, visitor_id: user2.id.to_s }, # after phase start & before phase end
-        { acted_at: 4.days.ago, visitor_id: user2.id.to_s },  # in last 7 days & before phase end
-        { acted_at: 4.days.ago, visitor_id: 'anonymous_1' },  # in last 7 days & before phase end
-        { acted_at: 10.days.ago, visitor_id: SecureRandom.uuid } # in phase, but no participation
+        { acted_at: 10.days.ago, visitor_id: user1.id.to_s }, # during phase (in week before last)
+        { acted_at: 5.days.ago, visitor_id: user1.id.to_s },  # during phase & in last 7 days
+        { acted_at: 10.days.ago, visitor_id: user2.id.to_s }, # during phase (in week before last)
+        { acted_at: 4.days.ago, visitor_id: user2.id.to_s },  # during phase & in last 7 days
+        { acted_at: 4.days.ago, visitor_id: 'anonymous_1' },  # during phase & in last 7 days
+        { acted_at: 10.days.ago, visitor_id: SecureRandom.uuid } # # during phase (in week before last)
       ]
     end
 
@@ -54,9 +54,9 @@ RSpec.describe Insights::BasePhaseInsightsService do
       expect(result).to eq(
         {
           visitors: 4,
-          visitors_last_7_days: 3,
+          visitors_rolling_7_day_change: 0.0, # From 3 (7 to 14 days ago) to 3 (last 7-day period) unique visitors = 0% change
           participants: 3,
-          participants_rolling_7_day_change: 50.0, # From 2 (7 to 14 days ago) to 3 (last 7-day period) participants = 50% increase
+          participants_rolling_7_day_change: 50.0, # From 2 (7 to 14 days ago) to 3 (last 7-day period) unique participants = 50% increase
           engagement_rate: 0.75
         }
       )

--- a/back/spec/services/insights/base_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/base_phase_insights_service_spec.rb
@@ -57,7 +57,8 @@ RSpec.describe Insights::BasePhaseInsightsService do
           visitors_rolling_7_day_change: 0.0, # From 3 (7 to 14 days ago) to 3 (last 7-day period) unique visitors = 0% change
           participants: 3,
           participants_rolling_7_day_change: 50.0, # From 2 (7 to 14 days ago) to 3 (last 7-day period) unique participants = 50% increase
-          engagement_rate: 0.75
+          engagement_rate: 0.75,
+          engagement_rate_rolling_7_day_change: 49.9 # engagement_rate_last_7_days: 1.0, engagement_rate_last_14_to_8_days: 0.667 = (((1 - 0.667).to_f / 0.667) * 100.0).round(1)
         }
       )
     end

--- a/back/spec/services/insights/base_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/base_phase_insights_service_spec.rb
@@ -539,8 +539,8 @@ RSpec.describe Insights::BasePhaseInsightsService do
       expect(service.send(:percentage_change, 80, 60)).to eq(-25.0)
     end
 
-    it 'returns nil when old value is zero and new value is not zero' do
-      expect(service.send(:percentage_change, 0, 100)).to be_nil
+    it "returns 'last_7_days_compared_with_zero' when old value is zero and new value is not zero" do
+      expect(service.send(:percentage_change, 0, 100)).to eq('last_7_days_compared_with_zero')
     end
 
     it 'returns zero when there is no change' do

--- a/back/spec/services/insights/common_ground_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/common_ground_phase_insights_service_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Insights::CommonGroundPhaseInsightsService do
   let(:service) { described_class.new(phase) }
-  let(:phase) { create(:common_ground_phase, start_at: 15.days.ago, end_at: 2.days.ago) }
+  let(:phase) { create(:common_ground_phase, start_at: 17.days.ago, end_at: 2.days.ago) }
 
   let(:user1) { create(:user) }
   let!(:idea1) { create(:idea, phases: [phase], created_at: 20.days.ago, published_at: 20.days.ago, author: user1, creation_phase_id: phase.id) } # before phase start
@@ -112,6 +112,33 @@ RSpec.describe Insights::CommonGroundPhaseInsightsService do
       expect(participations[:reacting_idea].map { |p| p[:item_id] }).to match_array([
         reaction1.id
       ])
+    end
+  end
+
+  describe 'phase_participation_method_metrics' do
+    let(:user1) { create(:user) }
+    let(:participation1) { create(:posting_idea_participation, acted_at: 10.days.ago, user: user1) }
+    let(:participation2) { create(:posting_idea_participation, acted_at: 5.days.ago, user: user1) }
+    let(:participation3) { create(:reacting_idea_participation, acted_at: 10.days.ago, user: user1) }
+    let(:participation4) { create(:reacting_idea_participation, acted_at: 5.days.ago, user: user1) }
+
+    let(:participations) do
+      {
+        posting_idea: [participation1, participation2],
+        reacting_idea: [participation3, participation4]
+      }
+    end
+
+    it 'calculates the correct metrics' do
+      metrics = service.send(:phase_participation_method_metrics, participations)
+
+      expect(metrics).to eq({
+        associated_ideas: 6,
+        ideas_posted: 2,
+        ideas_posted_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) = 0% change
+        reactions: 2,
+        reactions_rolling_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change
+      })
     end
   end
 end

--- a/back/spec/services/insights/common_ground_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/common_ground_phase_insights_service_spec.rb
@@ -135,9 +135,9 @@ RSpec.describe Insights::CommonGroundPhaseInsightsService do
       expect(metrics).to eq({
         associated_ideas: 6,
         ideas_posted: 2,
-        ideas_posted_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) = 0% change
+        ideas_posted_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) = 0% change
         reactions: 2,
-        reactions_rolling_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change
+        reactions_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change
       })
     end
   end

--- a/back/spec/services/insights/ideation_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/ideation_phase_insights_service_spec.rb
@@ -248,11 +248,11 @@ RSpec.describe Insights::IdeationPhaseInsightsService do
 
       expect(metrics).to eq({
         ideas_posted: 2,
-        ideas_posted_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) => 0% change
+        ideas_posted_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) => 0% change
         comments_posted: 2,
-        comments_posted_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) => 0% change
+        comments_posted_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) => 0% change
         reactions: 2,
-        reactions_rolling_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) => 0% change
+        reactions_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) => 0% change
       })
     end
   end

--- a/back/spec/services/insights/ideation_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/ideation_phase_insights_service_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Insights::IdeationPhaseInsightsService do
-  let(:phase) { create(:ideation_phase, start_at: 15.days.ago, end_at: 2.days.ago) }
+  let(:phase) { create(:ideation_phase, start_at: 17.days.ago, end_at: 2.days.ago) }
   let(:service) { described_class.new(phase) }
 
   let(:user1) { create(:user) }
@@ -248,11 +248,11 @@ RSpec.describe Insights::IdeationPhaseInsightsService do
 
       expect(metrics).to eq({
         ideas_posted: 2,
-        ideas_posted_last_7_days: 1,
+        ideas_posted_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) => 0% change
         comments_posted: 2,
-        comments_posted_last_7_days: 1,
+        comments_posted_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) => 0% change
         reactions: 2,
-        reactions_last_7_days: 1
+        reactions_rolling_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) => 0% change
       })
     end
   end

--- a/back/spec/services/insights/native_survey_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/native_survey_phase_insights_service_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Insights::NativeSurveyPhaseInsightsService do
   let(:service) { described_class.new(phase) }
-  let(:phase) { create(:native_survey_phase, start_at: 15.days.ago, end_at: 2.days.ago) }
+  let(:phase) { create(:native_survey_phase, start_at: 17.days.ago, end_at: 2.days.ago) }
 
   let(:user1) { create(:user) }
   let!(:idea1) { create(:idea, phases: [phase], created_at: 20.days.ago, submitted_at: 20.days.ago, author: user1, creation_phase_id: phase.id) } # before phase start
@@ -129,6 +129,27 @@ RSpec.describe Insights::NativeSurveyPhaseInsightsService do
         idea6.id,
         idea7.id
       ])
+    end
+  end
+
+  describe 'phase_participation_method_metrics' do
+    let(:user1) { create(:user) }
+    let(:participation1) { create(:posting_idea_participation, acted_at: 10.days.ago, user: user1) }
+    let(:participation2) { create(:posting_idea_participation, acted_at: 5.days.ago, user: user1) }
+
+    it 'calculates the correct metrics' do
+      participation1[:survey_submitted_at] = 10.days.ago
+      participation2[:survey_submitted_at] = 5.days.ago
+      participations = { posting_idea: [participation1, participation2] }
+
+      metrics = service.send(:phase_participation_method_metrics, participations)
+
+      expect(metrics).to eq({
+        submitted_surveys: 2,
+        submitted_surveys_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) = 0% change
+        completion_rate: 1.0,
+        completion_rate_rolling_7_day_change: 0.0 # completion_rate_last_7_days: 1.0, completion_rate_last_14_to_8_days: 1.0 = 0% change
+      })
     end
   end
 end

--- a/back/spec/services/insights/native_survey_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/native_survey_phase_insights_service_spec.rb
@@ -146,9 +146,9 @@ RSpec.describe Insights::NativeSurveyPhaseInsightsService do
 
       expect(metrics).to eq({
         submitted_surveys: 2,
-        submitted_surveys_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) = 0% change
+        submitted_surveys_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) = 0% change
         completion_rate: 1.0,
-        completion_rate_rolling_7_day_change: 0.0 # completion_rate_last_7_days: 1.0, completion_rate_previous_7_days: 1.0 = 0% change
+        completion_rate_7_day_change: 0.0 # completion_rate_last_7_days: 1.0, completion_rate_previous_7_days: 1.0 = 0% change
       })
     end
   end

--- a/back/spec/services/insights/native_survey_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/native_survey_phase_insights_service_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe Insights::NativeSurveyPhaseInsightsService do
         submitted_surveys: 2,
         submitted_surveys_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) = 0% change
         completion_rate: 1.0,
-        completion_rate_rolling_7_day_change: 0.0 # completion_rate_last_7_days: 1.0, completion_rate_last_14_to_8_days: 1.0 = 0% change
+        completion_rate_rolling_7_day_change: 0.0 # completion_rate_last_7_days: 1.0, completion_rate_previous_7_days: 1.0 = 0% change
       })
     end
   end

--- a/back/spec/services/insights/poll_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/poll_phase_insights_service_spec.rb
@@ -53,4 +53,23 @@ RSpec.describe Insights::PollPhaseInsightsService do
       ])
     end
   end
+
+  describe 'phase_participation_method_metrics' do
+    let(:user1) { create(:user) }
+    let(:participation1) { create(:taking_poll_participation, acted_at: 10.days.ago, user: user1) }
+    let(:participation2) { create(:taking_poll_participation, acted_at: 5.days.ago, user: user1) }
+
+    let(:participations) do
+      { taking_poll: [participation1, participation2] }
+    end
+
+    it 'calculates the correct metrics' do
+      metrics = service.send(:phase_participation_method_metrics, participations)
+
+      expect(metrics).to eq({
+        responses: 2,
+        responses_rolling_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change
+      })
+    end
+  end
 end

--- a/back/spec/services/insights/poll_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/poll_phase_insights_service_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Insights::PollPhaseInsightsService do
 
       expect(metrics).to eq({
         responses: 2,
-        responses_rolling_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change
+        responses_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change
       })
     end
   end

--- a/back/spec/services/insights/proposals_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/proposals_phase_insights_service_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Insights::ProposalsPhaseInsightsService do
-  let(:phase) { create(:proposals_phase, start_at: 15.days.ago, end_at: 2.days.ago) }
+  let(:phase) { create(:proposals_phase, start_at: 17.days.ago, end_at: 2.days.ago) }
   let(:service) { described_class.new(phase) }
 
   let(:user1) { create(:user) }
@@ -215,57 +215,37 @@ RSpec.describe Insights::ProposalsPhaseInsightsService do
     end
   end
 
-  describe '#threshold_reached_counts' do
-    it 'returns zero counts when no ideas reached threshold' do
-      mock_participations = [
-        { threshold_reached_at: nil },
-        { threshold_reached_at: nil }
-      ]
+  describe 'phase_participation_method_metrics' do
+    let(:user1) { create(:user) }
+    let(:participation1) { create(:posting_idea_participation, acted_at: 10.days.ago, user: user1) }
+    let(:participation2) { create(:posting_idea_participation, acted_at: 5.days.ago, user: user1) }
+    let(:participation3) { create(:commenting_idea_participation, acted_at: 10.days.ago, user: user1) }
+    let(:participation4) { create(:commenting_idea_participation, acted_at: 5.days.ago, user: user1) }
+    let(:participation5) { create(:reacting_idea_participation, acted_at: 10.days.ago, user: user1) }
+    let(:participation6) { create(:reacting_idea_participation, acted_at: 5.days.ago, user: user1) }
 
-      counts = service.send(:threshold_reached_counts, mock_participations)
-
-      expect(counts).to eq({ total: 0, last_7_days: 0 })
+    let(:participations) do
+      {
+        posting_idea: [participation1, participation2],
+        commenting_idea: [participation3, participation4],
+        reacting_idea: [participation5, participation6]
+      }
     end
 
-    it 'counts ideas that reached threshold' do
-      mock_participations = [
-        { threshold_reached_at: 10.days.ago },
-        { threshold_reached_at: 5.days.ago },
-        { threshold_reached_at: nil }
-      ]
+    it 'calculates the correct metrics' do
+      participation1[:threshold_reached_at] = 8.days.ago
+      metrics = service.send(:phase_participation_method_metrics, participations)
 
-      counts = service.send(:threshold_reached_counts, mock_participations)
-
-      expect(counts).to eq({ total: 2, last_7_days: 1 })
-    end
-
-    it 'only counts ideas reaching threshold in last 7 days for last_7_days metric' do
-      mock_participations = [
-        { threshold_reached_at: 10.days.ago },
-        { threshold_reached_at: 8.days.ago },
-        { threshold_reached_at: 6.days.ago },
-        { threshold_reached_at: 2.days.ago }
-      ]
-
-      counts = service.send(:threshold_reached_counts, mock_participations)
-
-      expect(counts).to eq({ total: 4, last_7_days: 2 })
-    end
-
-    it 'returns zero counts for empty participations array' do
-      counts = service.send(:threshold_reached_counts, [])
-
-      expect(counts).to eq({ total: 0, last_7_days: 0 })
-    end
-
-    it 'counts ideas that reached threshold exactly 7 days ago' do
-      mock_participations = [
-        { threshold_reached_at: 7.days.ago.beginning_of_day }
-      ]
-
-      counts = service.send(:threshold_reached_counts, mock_participations)
-
-      expect(counts).to eq({ total: 1, last_7_days: 1 })
+      expect(metrics).to eq({
+        ideas_posted: 2,
+        ideas_posted_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) => 0% change
+        reached_threshold: 1,
+        reached_threshold_rolling_7_day_change: -100.0, # from 1 (in week before last) to 0 (in last 7 days) => -100% change
+        comments_posted: 2,
+        comments_posted_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) => 0% change
+        reactions: 2,
+        reactions_rolling_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) => 0% change
+      })
     end
   end
 end

--- a/back/spec/services/insights/proposals_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/proposals_phase_insights_service_spec.rb
@@ -238,13 +238,13 @@ RSpec.describe Insights::ProposalsPhaseInsightsService do
 
       expect(metrics).to eq({
         ideas_posted: 2,
-        ideas_posted_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) => 0% change
+        ideas_posted_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) => 0% change
         reached_threshold: 1,
-        reached_threshold_rolling_7_day_change: -100.0, # from 1 (in week before last) to 0 (in last 7 days) => -100% change
+        reached_threshold_7_day_change: -100.0, # from 1 (in week before last) to 0 (in last 7 days) => -100% change
         comments_posted: 2,
-        comments_posted_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) => 0% change
+        comments_posted_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) => 0% change
         reactions: 2,
-        reactions_rolling_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) => 0% change
+        reactions_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) => 0% change
       })
     end
   end

--- a/back/spec/services/insights/visits_service_spec.rb
+++ b/back/spec/services/insights/visits_service_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Insights::VisitsService do
   let(:service) { described_class.new }
 
-  describe '#phase_visitors_data' do
+  describe '#phase_visits' do
     # rubocop:disable RSpec/ScatteredLet
     let(:phase) { create(:single_voting_phase, start_at: 20.days.ago, end_at: 2.days.ago) }
 
@@ -14,11 +14,11 @@ describe Insights::VisitsService do
     let!(:session1) { create(:session, user_id: user1.id) }
     let!(:pageview1) { create(:pageview, session: session1, created_at: 22.days.ago, project_id: phase.project.id) } # before phase start
     let!(:pageview2) { create(:pageview, session: session1, created_at: 13.days.ago, project_id: phase.project.id) } # in phase
-    let!(:pageview3) { create(:pageview, session: session1, created_at: 13.days.ago, project_id: phase.project.id) } # in phase, but repeat visitor
+    let!(:pageview3) { create(:pageview, session: session1, created_at: 13.days.ago, project_id: phase.project.id) } # in phase, and repeat visitor
 
     let!(:session2) { create(:session, user_id: user2.id, monthly_user_hash: 'user2_user_hash') }
     let!(:pageview4) { create(:pageview, session: session2, created_at: 5.days.ago, project_id: phase.project.id) } # in phase & last 7 days
-    let!(:pageview5) { create(:pageview, session: session2, created_at: 4.days.ago, project_id: phase.project.id) } # in last 7 days, but repeat visitor
+    let!(:pageview5) { create(:pageview, session: session2, created_at: 4.days.ago, project_id: phase.project.id) } # in last 7 days, and repeat visitor
 
     let!(:session3) { create(:session, user_id: nil, monthly_user_hash: 'anonymous_user_hash') }
     let!(:pageview6) { create(:pageview, session: session3, created_at: 13.days.ago, project_id: phase.project.id) } # in phase
@@ -31,16 +31,14 @@ describe Insights::VisitsService do
     # rubocop:enable RSpec/ScatteredLet
 
     it 'returns correct visits data for the phase' do
-      visits_data = service.phase_visits_data(phase)
+      visits = service.phase_visits(phase)
 
-      expect(visits_data[:visitors_total]).to eq(3)
-      expect(visits_data[:visitors_last_7_days]).to eq(1)
-      expect(visits_data[:visits]).to match_array([
-        { date: pageview2.created_at, visitor_id: user1.id.to_s },
-        { date: pageview3.created_at, visitor_id: user1.id.to_s },
-        { date: pageview4.created_at, visitor_id: user2.id.to_s },
-        { date: pageview5.created_at, visitor_id: user2.id.to_s },
-        { date: pageview6.created_at, visitor_id: 'anonymous_user_hash' }
+      expect(visits).to match_array([
+        { acted_at: pageview2.created_at, visitor_id: user1.id },
+        { acted_at: pageview3.created_at, visitor_id: user1.id },
+        { acted_at: pageview4.created_at, visitor_id: user2.id },
+        { acted_at: pageview5.created_at, visitor_id: user2.id },
+        { acted_at: pageview6.created_at, visitor_id: 'anonymous_user_hash' }
       ])
     end
   end

--- a/back/spec/services/insights/volunteering_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/volunteering_phase_insights_service_spec.rb
@@ -66,4 +66,23 @@ RSpec.describe Insights::VolunteeringPhaseInsightsService do
       ])
     end
   end
+
+  describe 'phase_participation_method_metrics' do
+    let(:user1) { create(:user) }
+    let(:participation1) { create(:volunteering_participation, acted_at: 10.days.ago, user: user1) }
+    let(:participation2) { create(:volunteering_participation, acted_at: 5.days.ago, user: user1) }
+
+    let(:participations) do
+      { volunteering: [participation1, participation2] }
+    end
+
+    it 'calculates the correct metrics' do
+      metrics = service.send(:phase_participation_method_metrics, participations)
+
+      expect(metrics).to eq({
+        volunteerings: 2,
+        volunteerings_rolling_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change
+      })
+    end
+  end
 end

--- a/back/spec/services/insights/volunteering_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/volunteering_phase_insights_service_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Insights::VolunteeringPhaseInsightsService do
 
       expect(metrics).to eq({
         volunteerings: 2,
-        volunteerings_rolling_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change
+        volunteerings_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change
       })
     end
   end

--- a/back/spec/services/insights/voting_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/voting_phase_insights_service_spec.rb
@@ -91,12 +91,12 @@ RSpec.describe Insights::VotingPhaseInsightsService do
 
       expect(metrics).to eq({
         voting_method: phase.voting_method,
+        associated_ideas: 2,
         online_votes: 5,
         online_votes_rolling_7_day_change: 50.0, # from 2 (in week before last) to 3 (in last 7 days) = 50% increase
         offline_votes: phase.manual_votes_count,
         voters: 1,
         voters_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) = 0% change
-        associated_ideas: 2,
         comments_posted: 2,
         comments_posted_rolling_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change
       })

--- a/back/spec/services/insights/voting_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/voting_phase_insights_service_spec.rb
@@ -93,12 +93,12 @@ RSpec.describe Insights::VotingPhaseInsightsService do
         voting_method: phase.voting_method,
         associated_ideas: 2,
         online_votes: 5,
-        online_votes_rolling_7_day_change: 50.0, # from 2 (in week before last) to 3 (in last 7 days) = 50% increase
+        online_votes_7_day_change: 50.0, # from 2 (in week before last) to 3 (in last 7 days) = 50% increase
         offline_votes: phase.manual_votes_count,
         voters: 1,
-        voters_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) = 0% change
+        voters_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) = 0% change
         comments_posted: 2,
-        comments_posted_rolling_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change
+        comments_posted_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change
       })
     end
   end

--- a/back/spec/services/insights/voting_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/voting_phase_insights_service_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Insights::VotingPhaseInsightsService do
   let(:service) { described_class.new(phase) }
 
-  let!(:phase) { create(:multiple_voting_phase, start_at: 15.days.ago, end_at: 2.days.ago) }
+  let!(:phase) { create(:multiple_voting_phase, start_at: 17.days.ago, end_at: 2.days.ago) }
   let!(:idea1) { create(:idea, phases: [phase]) }
   let!(:idea2) { create(:idea, phases: [phase]) }
 
@@ -69,6 +69,37 @@ RSpec.describe Insights::VotingPhaseInsightsService do
       expect(participations[:commenting_idea].map { |p| p[:item_id] }).to match_array([
         comment2.id
       ])
+    end
+  end
+
+  describe 'phase_participation_method_metrics' do
+    let(:user1) { create(:user) }
+    let(:participation1) { create(:basket_participation, :with_votes, vote_count: 2, acted_at: 10.days.ago, user: user1) }
+    let(:participation2) { create(:basket_participation, :with_votes, vote_count: 3, acted_at: 5.days.ago, user: user1) }
+    let(:participation3) { create(:commenting_idea_participation, acted_at: 10.days.ago, user: user1) }
+    let(:participation4) { create(:commenting_idea_participation, acted_at: 5.days.ago, user: user1) }
+
+    let(:participations) do
+      {
+        voting: [participation1, participation2],
+        commenting_idea: [participation3, participation4]
+      }
+    end
+
+    it 'calculates the correct metrics' do
+      metrics = service.send(:phase_participation_method_metrics, participations)
+
+      expect(metrics).to eq({
+        voting_method: phase.voting_method,
+        online_votes: 5,
+        online_votes_rolling_7_day_change: 50.0, # from 2 (in week before last) to 3 (in last 7 days) = 50% increase
+        offline_votes: phase.manual_votes_count,
+        voters: 1,
+        voters_rolling_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) = 0% change
+        associated_ideas: 2,
+        comments_posted: 2,
+        comments_posted_rolling_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change
+      })
     end
   end
 end


### PR DESCRIPTION
See related [Slack thread](https://go-vocal.slack.com/archives/C09MWU5FFPB/p1764779259192579)
See ticket description for resultant changed response shapes && values.

Also changes `engagement_rate` to `participation_rate` to match existing naming convention.

# Changelog
## Technical
- [TAN-5983] Add rolling last 7 days change to phase insights metrics [phase insights not enabled yet]
