### PR TITLE
[TAN-6010] Fix IdeasCountService bug

### DIFF
--- a/back/app/services/ideas_count_service.rb
+++ b/back/app/services/ideas_count_service.rb
@@ -4,7 +4,7 @@ module IdeasCountService
   }
 
   def self.counts(ideas_scope, attributes = %w[idea_status_id topic_id])
-    result = attributes.index_with({})
+    result = attributes.index_with { {} }  # Use a block to create separate hash objects
 
     attributes.each do |attribute|
       join_table = ATTRIBUTE_JOIN_TABLES[attribute]
@@ -15,11 +15,11 @@ module IdeasCountService
 
     ideas_scope
       .select("#{column_names(attributes).join(', ')}, COUNT(DISTINCT(ideas.id)) as count")
-      .reorder(nil) # Avoids SQL error on GROUP BY when a search string was used
+      .reorder(nil)
       .group("GROUPING SETS (#{column_names(attributes).join(', ')})")
       .each do |record|
         attributes.each do |attribute|
-          id = record.send attribute
+          id = record.send(attribute)
           result[attribute][id] = record.count if id
         end
       end

--- a/back/app/services/ideas_count_service.rb
+++ b/back/app/services/ideas_count_service.rb
@@ -15,7 +15,7 @@ module IdeasCountService
 
     ideas_scope
       .select("#{column_names(attributes).join(', ')}, COUNT(DISTINCT(ideas.id)) as count")
-      .reorder(nil)
+      .reorder(nil) # Avoids SQL error on GROUP BY when a search string was used
       .group("GROUPING SETS (#{column_names(attributes).join(', ')})")
       .each do |record|
         attributes.each do |attribute|

--- a/back/app/services/ideas_count_service.rb
+++ b/back/app/services/ideas_count_service.rb
@@ -4,7 +4,7 @@ module IdeasCountService
   }
 
   def self.counts(ideas_scope, attributes = %w[idea_status_id topic_id])
-    result = attributes.index_with { {} } # Use a block to create separate hash objects
+    result = attributes.index_with { {} }
 
     attributes.each do |attribute|
       join_table = ATTRIBUTE_JOIN_TABLES[attribute]

--- a/back/app/services/ideas_count_service.rb
+++ b/back/app/services/ideas_count_service.rb
@@ -4,7 +4,7 @@ module IdeasCountService
   }
 
   def self.counts(ideas_scope, attributes = %w[idea_status_id topic_id])
-    result = attributes.index_with { {} }  # Use a block to create separate hash objects
+    result = attributes.index_with { {} } # Use a block to create separate hash objects
 
     attributes.each do |attribute|
       join_table = ATTRIBUTE_JOIN_TABLES[attribute]

--- a/back/spec/services/idea_count_service_spec.rb
+++ b/back/spec/services/idea_count_service_spec.rb
@@ -9,8 +9,8 @@ describe IdeasCountService do
     let!(:idea2) { create(:idea, topics: [topic1, topic2]) }
 
     it 'returns the expected result' do
-      result = IdeasCountService.counts(Idea.all)
-      
+      result = described_class.counts(Idea.all)
+
       expect(result).to eq({
         'idea_status_id' => {
           idea1.idea_status_id => 1,

--- a/back/spec/services/idea_count_service_spec.rb
+++ b/back/spec/services/idea_count_service_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+describe IdeasCountService do
+  describe '#counts' do
+    let(:topic1) { create(:topic) }
+    let(:topic2) { create(:topic) }
+
+    let!(:idea1) { create(:idea, topics: [topic1]) }
+    let!(:idea2) { create(:idea, topics: [topic1, topic2]) }
+
+    it 'returns the expected result' do
+      result = IdeasCountService.counts(Idea.all)
+      
+      expect(result).to eq({
+        'idea_status_id' => {
+          idea1.idea_status_id => 1,
+          idea2.idea_status_id => 1
+        },
+        'topic_id' => {
+          topic1.id => 2,
+          topic2.id => 1
+        }
+      })
+    end
+  end
+end


### PR DESCRIPTION
We were creating a `result` which contained both the topic IDs and idea_status IDs in both the `result['topic_id']` and `result['idea_status_id']` sets. In other words both sets were duplicates, and contained IDs of both types of records.

Now the correct IDs are separated into the correct sets in the `result` hash.

See ticket description for an example bugged response.

# Changelog
## Technical
- [TAN-6010] Fix IdeasCountService bug
