### PR TITLE
Fix unit test by updating project mock

### DIFF
--- a/front/app/api/projects/__mocks__/_mockServer.ts
+++ b/front/app/api/projects/__mocks__/_mockServer.ts
@@ -90,7 +90,7 @@ export const project1: IProjectData = {
     },
     avatars_count: 8,
     participants_count: 8,
-    uses_content_builder: false,
+    uses_content_builder: true,
     preview_token: 'fake-token-0123456789',
     baskets_count: 0,
     votes_count: 0,

--- a/front/app/components/DescriptionBuilder/ContentViewer/ProjectContentViewer.tsx
+++ b/front/app/components/DescriptionBuilder/ContentViewer/ProjectContentViewer.tsx
@@ -6,7 +6,6 @@ import { Multiloc } from 'typings';
 
 import useContentBuilderLayout from 'api/content_builder/useContentBuilderLayout';
 import useProjectFiles from 'api/project_files/useProjectFiles';
-import useProjectById from 'api/projects/useProjectById';
 
 import useFeatureFlag from 'hooks/useFeatureFlag';
 import useLocalize from 'hooks/useLocalize';
@@ -41,14 +40,13 @@ const ProjectContentViewer = ({
     name: 'project_description_builder',
   });
   const { data: projectFiles } = useProjectFiles(projectId);
-  const { data: project } = useProjectById(projectId);
   const { data: descriptionBuilderLayout, isInitialLoading } =
     useContentBuilderLayout('project', projectId, featureEnabled && enabled);
 
   if (!featureEnabled) return null;
 
   const descriptionBuilderContent =
-    project?.data.attributes.uses_content_builder &&
+    enabled &&
     descriptionBuilderLayout &&
     descriptionBuilderLayout.data.attributes.enabled &&
     !isEmpty(descriptionBuilderLayout.data.attributes.craftjs_json);


### PR DESCRIPTION
# Description
After tweaking the logic for showing the content builder project description, we need to update the Project mock as well (setting `uses_content_builder` to true).