### PR TITLE
New comment for admin emails not arriving when the author is anonymous

### DIFF
--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/new_comment_for_admin_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/new_comment_for_admin_mailer.rb
@@ -12,7 +12,7 @@ module EmailCampaigns
       {
         organizationName: organization_name,
         firstName: recipient&.first_name,
-        authorName: event&.comment_author_name || format_message('anonymous_user'),
+        authorName: event&.comment_author_name || format_message('anonymous_user', component: 'new_comment_for_admin'),
         authorFirstName: event&.initiating_user_first_name
       }
     end

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/new_comment_for_admin_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/new_comment_for_admin_mailer.rb
@@ -12,7 +12,7 @@ module EmailCampaigns
       {
         organizationName: organization_name,
         firstName: recipient&.first_name,
-        authorName: event&.comment_author_name,
+        authorName: event&.comment_author_name || format_message('anonymous_user'),
         authorFirstName: event&.initiating_user_first_name
       }
     end

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/new_comment_for_admin.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/new_comment_for_admin.rb
@@ -90,7 +90,6 @@ module EmailCampaigns
       [{
         event_payload: {
           initiating_user_first_name: comment.author&.first_name,
-          initiating_user_last_name: comment.author&.last_name,
           comment_author_name: comment.author_name,
           comment_body_multiloc: comment.body_multiloc,
           comment_url: Frontend::UrlService.new.model_to_url(comment, locale: Locale.new(recipient.locale)),

--- a/back/engines/free/email_campaigns/app/views/email_campaigns/new_comment_for_admin_mailer/campaign_mail.mjml
+++ b/back/engines/free/email_campaigns/app/views/email_campaigns/new_comment_for_admin_mailer/campaign_mail.mjml
@@ -25,7 +25,7 @@
   <mj-column border-radius="5px" background-color="#F2F6F8" padding="25px">
     <mj-text font-size="14px">
       <%= format_message('commented', values: {
-        authorFirstName: "<span style=\"font-weight:bold; color: #000;\">#{event.initiating_user_first_name.capitalize}</span>"
+        authorFirstName: "<span style=\"font-weight:bold; color: #000;\">#{event.initiating_user_first_name&.capitalize || format_message('anonymous_user')}</span>"
       }).html_safe %>
       <p style="margin: 15px 0 0;">
         <%= strip_tags(localize_for_recipient_and_truncate(event.comment_body_multiloc, 140)) %>

--- a/back/engines/free/email_campaigns/config/locales/en.yml
+++ b/back/engines/free/email_campaigns/config/locales/en.yml
@@ -259,6 +259,7 @@ en:
       x_days_ago_by_author: '%{x} days ago by %{author}'
     new_comment_for_admin:
       commented: '%{authorFirstName} commented:'
+      anonymous_user: Anonymous user
       cta_button: 'View %{authorFirstName}''s comment'
       days_ago: '%{numberOfDays} days ago'
       event_description: '%{authorName} added a new comment on your platform.'

--- a/back/engines/free/email_campaigns/spec/fixtures/locales/mailers.en.yml
+++ b/back/engines/free/email_campaigns/spec/fixtures/locales/mailers.en.yml
@@ -218,6 +218,7 @@ en:
       x_days_ago_by_author: '%{x} days ago by %{author}'
     new_comment_for_admin:
       commented: '%{authorFirstName} commented:'
+      anonymous_user: Anonymous user
       cta_button: 'View %{authorFirstName}''s comment'
       days_ago: '%{numberOfDays} days ago'
       event_description: '%{authorName} added a new comment on your platform.'

--- a/back/engines/free/email_campaigns/spec/mailers/new_comment_for_admin_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/new_comment_for_admin_mailer_spec.rb
@@ -147,4 +147,3 @@ RSpec.describe EmailCampaigns::NewCommentForAdminMailer do
     end
   end
 end
-

--- a/back/engines/free/email_campaigns/spec/mailers/new_comment_for_admin_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/new_comment_for_admin_mailer_spec.rb
@@ -21,20 +21,21 @@ RSpec.describe EmailCampaigns::NewCommentForAdminMailer do
           idea_title_multiloc: {
             en: 'Wiki Roulette'
           },
-          idea_author_name: "K\u00c3\u00bcn Gremmelpret"
+          idea_author_name: 'Bob'
         }
       }
     end
 
     let_it_be(:mailer) { described_class.with(command: command, campaign: campaign) }
     let_it_be(:mail) { mailer.campaign_mail.deliver_now }
+    let_it_be(:body) { mail_body(mail) }
 
     before_all { EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id) }
 
     include_examples 'campaign delivery tracking'
 
     it 'renders the subject' do
-      expect(mail.subject).to be_present
+      expect(mail.subject).to eq('A new comment has been posted on Liege\'s platform')
     end
 
     it 'renders the receiver email' do
@@ -45,21 +46,45 @@ RSpec.describe EmailCampaigns::NewCommentForAdminMailer do
       expect(mail.from).to all(end_with('@citizenlab.co'))
     end
 
-    it 'assigns organisation name' do
-      expect(mail.body.encoded).to match(AppConfiguration.instance.settings('core', 'organization_name')['en'])
+    it 'includes the header' do
+      expect(body).to have_tag('div') do
+        with_tag 'h1' do
+          with_text(/Homer, a new comment has been posted on your platform/)
+        end
+        with_tag 'p' do
+          with_text(/Chewbacca added a new comment on your platform./)
+        end
+      end
     end
 
-    it 'includes the comment author name' do
-      expect(mail.body.encoded).to include('Chewbacca')
+    it 'includes the input box' do
+      expect(body).to have_tag('table') do
+        with_tag 'h2' do
+          with_text(/Wiki Roulette/)
+        end
+        with_tag 'p' do
+          with_text(/14 days ago/)
+          with_text(/by Bob/)
+        end
+      end
     end
 
-    it 'includes the comment body' do
-      expect(mail.body.encoded).to include('roooarrgh')
+    it 'includes the comment box' do
+      expect(body).to have_tag('table') do
+        with_text(/Chewbacca commented:/)
+        with_tag 'p' do
+          with_text(/Ruh roooarrgh yrroonn wyaaaaaa ahuma hnn-rowr ma/)
+        end
+      end
     end
 
-    it 'includes the time when it was posted' do
-      expect(mail.body.encoded).to include('14')
+    it 'includes the CTA' do
+      expect(body).to have_tag('a', with: { href: 'http://localhost:3000/en/ideas/wiki-roulette' }) do
+        with_text(/View Chewbacca's comment/)
+      end
     end
+
+    # TODO: Anonymous author
 
     context 'with custom text' do
       let(:mail) { described_class.with(command: command, campaign: campaign).campaign_mail.deliver_now }
@@ -69,7 +94,8 @@ RSpec.describe EmailCampaigns::NewCommentForAdminMailer do
           subject_multiloc: { 'en' => 'Custom Subject - {{ organizationName }}' },
           title_multiloc: { 'en' => 'NEW TITLE - {{ firstName }}' },
           intro_multiloc: { 'en' => '<b>NEW BODY TEXT - {{ authorName }}</b>' },
-          button_text_multiloc: { 'en' => 'CLICK THE BUTTON' }
+          button_text_multiloc: { 'en' => 'CLICK THE BUTTON' },
+          reply_to: 'noreply@govocal.com'
         )
       end
 
@@ -77,17 +103,27 @@ RSpec.describe EmailCampaigns::NewCommentForAdminMailer do
         expect(mail.subject).to eq 'Custom Subject - Liege'
       end
 
-      it 'can customise the title' do
-        expect(mail_body(mail)).to include('NEW TITLE - Homer')
+      it 'can customize the reply to email' do
+        expect(mail.reply_to).to eq ['noreply@govocal.com']
       end
 
-      it 'can customise the body including HTML' do
-        expect(mail_body(mail)).to include('<b>NEW BODY TEXT - Chewbacca</b>')
+      it 'can customize the header and fall back to global customzations' do
+        expect(mail_body(mail)).to have_tag('div') do
+          with_tag 'h1' do
+            with_text(/NEW TITLE - Homer/)
+          end
+          with_tag 'p' do
+            with_text(/NEW BODY TEXT - Chewbacca/)
+          end
+        end
       end
 
-      it 'can customise the cta button' do
-        expect(mail_body(mail)).to include('CLICK THE BUTTON')
+      it 'can customise the CTA' do
+        expect(mail_body(mail)).to have_tag('a', with: { href: 'http://localhost:3000/en/ideas/wiki-roulette' }) do
+          with_text(/CLICK THE BUTTON/)
+        end
       end
     end
   end
 end
+

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/new_comment_for_admin_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/new_comment_for_admin_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe EmailCampaigns::Campaigns::NewCommentForAdmin do
       expect(command).to match(
         event_payload: a_hash_including(
           initiating_user_first_name: 'Rea',
-          initiating_user_last_name: 'Xion',
           comment_author_name: 'Rea Xion',
           comment_body_multiloc: { 'en' => 'Example comment.' },
           comment_url: "http://example.org/en/ideas/#{comment.idea.slug}",


### PR DESCRIPTION
Not sure if this is the cleanest way to deal with this. I wonder if we shouldn't invest time to have a reusable mechanism to let the different mailers deal with this. Also, it doesn't look like we can use the "coloured animals" name generator here, as the author is not present on these comments at this point? If this is correct, then it would be nice if we could find a way to retrieve the coloured animal of the anonymous author of a given post. But seems out of scope.

# Changelog
### Fixed
- [TAN-6026] New comment for admin emails not arriving when the author is anonymous
