### PR TITLE
[TAN-5964]  Fix mobile nav bar & cta bar covering focused elements on very small viewports

### DIFF
--- a/front/app/containers/MainHeader/index.tsx
+++ b/front/app/containers/MainHeader/index.tsx
@@ -3,6 +3,8 @@ import React, { useRef, useEffect, useState } from 'react';
 import { media, isRtl, useBreakpoint } from '@citizenlab/cl2-component-library';
 import styled from 'styled-components';
 
+import { MIN_VIEWPORT_HEIGHT_FOR_STICKY_ELEMENTS } from 'utils/styleConstants';
+
 import DesktopNavItems from './Components/DesktopNavItems';
 import DesktopNavbarContent from './Components/NavbarContent/DesktopNavbarContent';
 import MobileNavbarContent from './Components/NavbarContent/MobileNavbarContent';
@@ -91,6 +93,13 @@ const MainHeader = () => {
     function onScroll() {
       // Positive value means we've scrolled down
       const currentPosition = document.documentElement.scrollTop;
+
+      // If the viewport is shorter than 400px, don't show the sticky nav
+      // This helps prevent a11y issues on very small viewports
+      if (window.innerHeight < MIN_VIEWPORT_HEIGHT_FOR_STICKY_ELEMENTS) {
+        setShowMobileStickyNav(false);
+        return;
+      }
 
       // not scrolled yet/still at the top or downscroll
       if (currentPosition <= 0 || currentPosition > lastScrollTop) {

--- a/front/app/containers/MainHeader/index.tsx
+++ b/front/app/containers/MainHeader/index.tsx
@@ -3,6 +3,8 @@ import React, { useRef, useEffect, useState } from 'react';
 import { media, isRtl, useBreakpoint } from '@citizenlab/cl2-component-library';
 import styled from 'styled-components';
 
+import { MIN_VIEWPORT_HEIGHT_FOR_STICKY_ELEMENTS } from 'utils/styleConstants';
+
 import DesktopNavItems from './Components/DesktopNavItems';
 import DesktopNavbarContent from './Components/NavbarContent/DesktopNavbarContent';
 import MobileNavbarContent from './Components/NavbarContent/MobileNavbarContent';
@@ -94,7 +96,7 @@ const MainHeader = () => {
 
       // If the viewport is shorter than 400px, don't show the sticky nav
       // This helps prevent a11y issues on very small viewports
-      if (window.innerHeight <= 400) {
+      if (window.innerHeight < MIN_VIEWPORT_HEIGHT_FOR_STICKY_ELEMENTS) {
         setShowMobileStickyNav(false);
         return;
       }

--- a/front/app/containers/MainHeader/index.tsx
+++ b/front/app/containers/MainHeader/index.tsx
@@ -3,8 +3,6 @@ import React, { useRef, useEffect, useState } from 'react';
 import { media, isRtl, useBreakpoint } from '@citizenlab/cl2-component-library';
 import styled from 'styled-components';
 
-import { MIN_VIEWPORT_HEIGHT_FOR_STICKY_ELEMENTS } from 'utils/styleConstants';
-
 import DesktopNavItems from './Components/DesktopNavItems';
 import DesktopNavbarContent from './Components/NavbarContent/DesktopNavbarContent';
 import MobileNavbarContent from './Components/NavbarContent/MobileNavbarContent';
@@ -96,7 +94,7 @@ const MainHeader = () => {
 
       // If the viewport is shorter than 400px, don't show the sticky nav
       // This helps prevent a11y issues on very small viewports
-      if (window.innerHeight < MIN_VIEWPORT_HEIGHT_FOR_STICKY_ELEMENTS) {
+      if (window.innerHeight <= 400) {
         setShowMobileStickyNav(false);
         return;
       }

--- a/front/app/containers/ProjectsShowPage/ProjectCTABar/index.tsx
+++ b/front/app/containers/ProjectsShowPage/ProjectCTABar/index.tsx
@@ -15,6 +15,7 @@ import {
   getMethodConfig,
   getParticipationMethod,
 } from 'utils/configs/participationMethodConfig';
+import { MIN_VIEWPORT_HEIGHT_FOR_STICKY_ELEMENTS } from 'utils/styleConstants';
 
 type ProjectCTABarProps = {
   projectId: string;
@@ -22,7 +23,11 @@ type ProjectCTABarProps = {
 
 const ProjectCTABar = ({ projectId }: ProjectCTABarProps) => {
   const isSmallerThanTablet = useBreakpoint('tablet');
-  const sticksToBottom = isSmallerThanTablet;
+  const viewportHeight = window.innerHeight;
+  // Only stick on height over 400, to prevent a11y issues on very small viewports
+  const sticksToBottom =
+    isSmallerThanTablet &&
+    viewportHeight > MIN_VIEWPORT_HEIGHT_FOR_STICKY_ELEMENTS;
   const { data: phases } = usePhases(projectId);
   const { data: project } = useProjectById(projectId);
 

--- a/front/app/utils/styleConstants.ts
+++ b/front/app/utils/styleConstants.ts
@@ -1,1 +1,3 @@
 export const defaultAdminCardPadding = 40;
+
+export const MIN_VIEWPORT_HEIGHT_FOR_STICKY_ELEMENTS = 400;


### PR DESCRIPTION
# Changelog
## Fixed
- [TAN-5964]  A11y: Fix mobile nav bar & cta bar covering focused elements on very small viewports
