### PR TITLE
[TAN-6005] Add automatic clearing of skipped survey page values

### DIFF
--- a/front/app/components/CustomFieldsForm/SurveyForm/SurveyPage.tsx
+++ b/front/app/components/CustomFieldsForm/SurveyForm/SurveyPage.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useRef, useEffect } from 'react';
 
 import { Box, useBreakpoint } from '@citizenlab/cl2-component-library';
 import { FormProvider } from 'react-hook-form';
@@ -30,7 +30,11 @@ import { FormValues } from '../Page/types';
 import usePageForm from '../Page/usePageForm';
 import { getFormCompletionPercentage, Pages } from '../util';
 
-import { determineNextPageNumber, determinePreviousPageNumber } from './logic';
+import {
+  determineNextPageNumber,
+  determinePreviousPageNumber,
+  getSkippedPageIndices,
+} from './logic';
 
 const StyledForm = styled.form`
   height: 100%;
@@ -115,6 +119,35 @@ const SurveyPage = ({
     currentPage: page,
     formData: methods.watch(),
   });
+
+  // Clear values from skipped pages when form data changes
+  // This ensures that if a user changes an answer that affects conditional logic,
+  // any previously filled values from now-skipped pages are removed
+  useEffect(() => {
+    const subscription = methods.watch((formData) => {
+      const skippedPageIndices = getSkippedPageIndices({
+        pages,
+        formData,
+      });
+
+      // Clear all field values from skipped pages
+      skippedPageIndices.forEach((skippedPageIndex) => {
+        const skippedPage = pages[skippedPageIndex];
+        skippedPage.pageQuestions.forEach((question) => {
+          const currentValue = methods.getValues(question.key);
+          // Only clear if there's actually a value to clear
+          if (currentValue !== undefined && currentValue !== null) {
+            methods.setValue(question.key, undefined, {
+              shouldValidate: false,
+              shouldDirty: false,
+            });
+          }
+        });
+      });
+    });
+
+    return () => subscription.unsubscribe();
+  }, [methods, pages]);
 
   const onFormSubmit = async (formValues: FormValues) => {
     // Go to the project page if this is the last page

--- a/front/app/components/CustomFieldsForm/SurveyForm/logic.test.ts
+++ b/front/app/components/CustomFieldsForm/SurveyForm/logic.test.ts
@@ -557,7 +557,7 @@ describe('Survey form logic', () => {
         },
       ];
 
-      pages[2].page.logic = { next_page_id: 'page4' };
+      pages[2].page.logic = { next_page_id: 'page5' };
       pages[2].pageQuestions = [
         {
           type: 'custom_field',
@@ -590,7 +590,7 @@ describe('Survey form logic', () => {
         pages,
         formData: { answer_q1: 'no' },
       });
-      expect(validPathWhenNo).toEqual([0, 2, 3, 4]);
+      expect(validPathWhenNo).toEqual([0, 2, 4]);
     });
 
     it('should identify which pages are skipped based on current form data', () => {
@@ -604,7 +604,7 @@ describe('Survey form logic', () => {
         pages,
         formData: { answer_q1: 'no' },
       });
-      expect(skippedWhenNo).toEqual([1]);
+      expect(skippedWhenNo).toEqual([1, 3]);
     });
   });
 });


### PR DESCRIPTION
# Changelog
## Fixed
- Fixed survey data integrity issue where previously entered values from conditionally skipped pages were being included in submissions.
