### PR TITLE
 [TAN-6055] delete position from label in piechart

### DIFF
--- a/front/app/components/admin/Graphs/PieChart/index.tsx
+++ b/front/app/components/admin/Graphs/PieChart/index.tsx
@@ -117,7 +117,7 @@ const PieChart = <Row,>({
             <Cell key={`cell-${cellIndex}`} {...cell} />
           ))}
 
-          {centerLabel && <Label content={centerLabel} position="center" />}
+          {centerLabel && <Label content={centerLabel} />}
         </Pie>
       </RechartsPieChart>
     </Container>


### PR DESCRIPTION
# Changelog
## Fixed 
- Fix pie chart center label positioning to prevent overlap
