### PR TITLE
TAN-6072 Shift timestamps issue

### DIFF
--- a/back/.rubocop.yml
+++ b/back/.rubocop.yml
@@ -161,9 +161,7 @@ RSpec/DescribeClass:
     - 'engines/commercial/id_vienna_saml/spec/requests/employee_authentication_spec.rb'
     - 'spec/requests/google_authentication_spec.rb'
     - 'engines/commercial/multi_tenancy/spec/db/seedfile_spec.rb'
-    - 'engines/commercial/multi_tenancy/spec/tasks/email_campaigns_task_spec.rb'
-    - 'engines/commercial/multi_tenancy/spec/tasks/fix_notifications_task_spec.rb'
-    - 'engines/commercial/multi_tenancy/spec/tasks/invalid_data_checker_task_spec.rb'
+    - 'engines/commercial/multi_tenancy/spec/tasks/*_task_spec.rb'
     - 'spec/tasks/single_use/*.ignore.rb'
 
 RSpec/EmptyExampleGroup:

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/tenant_service.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/tenant_service.rb
@@ -103,7 +103,6 @@ module MultiTenancy
       data_listing = Cl2DataListingService.new
 
       data_listing.cl2_schema_leaf_models.each do |claz|
-        puts claz.name
         next if claz == QueJob
 
         timestamp_attrs = data_listing.timestamp_attributes claz
@@ -121,7 +120,6 @@ module MultiTenancy
         # timestamps to remain in the future (e.g. future timeline phases, expiration
         # date etc.)
         timestamp_attrs.each do |atr|
-          puts atr
           instances = claz.where("#{atr} > NOW()")
             .where("(#{atr} - (:num_days * INTERVAL '1 day')) < NOW()", num_days: num_days)
           query = "#{atr} = (#{atr} - (:num_days * INTERVAL '1 day'))"

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/tenant_service.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/tenant_service.rb
@@ -103,6 +103,7 @@ module MultiTenancy
       data_listing = Cl2DataListingService.new
 
       data_listing.cl2_schema_leaf_models.each do |claz|
+        puts claz.name
         next if claz == QueJob
 
         timestamp_attrs = data_listing.timestamp_attributes claz
@@ -112,7 +113,7 @@ module MultiTenancy
         next if timestamp_attrs.blank?
 
         query = timestamp_attrs.map do |timestamp_attr|
-          "#{timestamp_attr} = (#{timestamp_attr} + ':num_days DAY'::INTERVAL)"
+          "#{timestamp_attr} = (#{timestamp_attr} + (:num_days * INTERVAL '1 day'))"
         end.join(', ')
         claz.update_all [query, { num_days: num_days }]
 
@@ -120,9 +121,10 @@ module MultiTenancy
         # timestamps to remain in the future (e.g. future timeline phases, expiration
         # date etc.)
         timestamp_attrs.each do |atr|
+          puts atr
           instances = claz.where("#{atr} > NOW()")
-            .where("(#{atr} - ':num_days DAY'::INTERVAL) < NOW()", num_days: num_days)
-          query = "#{atr} = (#{atr} - ':num_days DAY'::INTERVAL)"
+            .where("(#{atr} - (:num_days * INTERVAL '1 day')) < NOW()", num_days: num_days)
+          query = "#{atr} = (#{atr} - (:num_days * INTERVAL '1 day'))"
           instances.update_all [query, { num_days: num_days }]
         end
       end

--- a/back/engines/commercial/multi_tenancy/spec/tasks/fix_assignees_task_spec.rb
+++ b/back/engines/commercial/multi_tenancy/spec/tasks/fix_assignees_task_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'rake fix_existing_tenants' do # rubocop:disable RSpec/DescribeClass
+describe 'rake fix_existing_tenants' do
   before { load_rake_tasks_if_not_loaded }
 
   let(:task) { Rake::Task[task_name] }

--- a/back/engines/commercial/multi_tenancy/spec/tasks/shift_tenant_timestamps_task_spec.rb
+++ b/back/engines/commercial/multi_tenancy/spec/tasks/shift_tenant_timestamps_task_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe 'fix orderings tasks' do
+  describe 'cl2back:shift_tenant_timestamps rake task' do
+    before { load_rake_tasks_if_not_loaded }
+
+    it 'Fixes the orderings of custom fields' do
+      tenant = create(:tenant, settings: SettingsService.new.minimal_required_settings(locales: %w[en], lifecycle_stage: 'demo', country_code: 'BE'), creation_finalized_at: Time.now)
+      tenant.switch do
+        travel_to Time.zone.local(2026, 2, 7, 12, 0, 0) do
+          user = create(:user, registration_completed_at: 2.days.ago)
+
+          Rake::Task['cl2back:shift_tenant_timestamps'].invoke
+
+          expect(user.reload.registration_completed_at.to_date).to eq((1.day.ago).to_date)
+        end
+      end
+    end
+  end
+end

--- a/back/engines/commercial/multi_tenancy/spec/tasks/shift_tenant_timestamps_task_spec.rb
+++ b/back/engines/commercial/multi_tenancy/spec/tasks/shift_tenant_timestamps_task_spec.rb
@@ -1,19 +1,17 @@
 require 'rails_helper'
 
-describe 'fix orderings tasks' do
-  describe 'cl2back:shift_tenant_timestamps rake task' do
-    before { load_rake_tasks_if_not_loaded }
+describe 'cl2back:shift_tenant_timestamps rake task' do
+  before { load_rake_tasks_if_not_loaded }
 
-    it 'Fixes the orderings of custom fields' do
-      tenant = create(:tenant, settings: SettingsService.new.minimal_required_settings(locales: %w[en], lifecycle_stage: 'demo', country_code: 'BE'), creation_finalized_at: Time.now)
-      tenant.switch do
-        travel_to Time.zone.local(2026, 2, 7, 12, 0, 0) do
-          user = create(:user, registration_completed_at: 2.days.ago)
+  it 'Shifts timestamps by 1 day' do
+    tenant = create(:tenant, settings: SettingsService.new.minimal_required_settings(locales: %w[en], lifecycle_stage: 'demo', country_code: 'BE'), creation_finalized_at: Time.now)
+    tenant.switch do
+      travel_to Time.zone.local(2026, 2, 7, 12, 0, 0) do
+        user = create(:user, registration_completed_at: 2.days.ago)
 
-          Rake::Task['cl2back:shift_tenant_timestamps'].invoke
+        Rake::Task['cl2back:shift_tenant_timestamps'].invoke
 
-          expect(user.reload.registration_completed_at.to_date).to eq((1.day.ago).to_date)
-        end
+        expect(user.reload.registration_completed_at.to_date).to eq 1.day.ago.to_date
       end
     end
   end


### PR DESCRIPTION
Apparently Rails is now stricter with parameters binding and Postgres could no longer infer the type of `num_days` (something like that). The corresponding query parts were rewritten differently as a fix, where the integer type can now be inferred from the multiplication context (with help of Copilot).

# Changelog
### Technical
- [TAN-6072] Fixed timestamps shifting issue (keep nice-looking dashboards nice on demo platforms).
