### PR TITLE
TAN-6061 Fix foreign key bug when deleting user

### DIFF
--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -169,6 +169,7 @@ class User < ApplicationRecord
   has_many :requested_project_reviews, class_name: 'ProjectReview', foreign_key: :requester_id, dependent: :nullify
   has_many :assigned_project_reviews, class_name: 'ProjectReview', foreign_key: :reviewer_id, dependent: :nullify
   has_many :jobs_trackers, class_name: 'Jobs::Tracker', foreign_key: :owner_id, dependent: :nullify
+  has_many :invites_imports, foreign_key: :importer_id, dependent: :destroy
 
   store_accessor :custom_field_values, :gender, :birthyear, :domicile
   store_accessor :onboarding, :topics_and_areas

--- a/back/spec/models/invites_import_spec.rb
+++ b/back/spec/models/invites_import_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe InvitesImport do
       user = create(:user)
       create(:invites_import, importer: user)
 
-      expect { user.destroy }.to change { InvitesImport.where(importer_id: user.id).count }.from(1).to(0)
+      expect { user.destroy }.to change { described_class.where(importer_id: user.id).count }.from(1).to(0)
     end
   end
 end

--- a/back/spec/models/invites_import_spec.rb
+++ b/back/spec/models/invites_import_spec.rb
@@ -9,4 +9,13 @@ RSpec.describe InvitesImport do
 
   it { is_expected.to validate_inclusion_of(:job_type).in_array(described_class::JOB_TYPES) }
   it { is_expected.to belong_to(:importer).class_name('User').optional }
+
+  describe 'User deletion' do
+    it 'cleans up InviteImport references' do
+      user = create(:user)
+      create(:invites_import, importer: user)
+
+      expect { user.destroy }.to change { InvitesImport.where(importer_id: user.id).count }.from(1).to(0)
+    end
+  end
 end


### PR DESCRIPTION
When deleting the user mentioned in the ticket, you will see that this exception is caught in Sentry: https://sentry.hq.citizenlab.co/organizations/citizenlab/issues/112818/?project=2&query=is%3Aunresolved&statsPeriod=14d

This is a very common issue in Rails data models. The invites_import table has a foreign key reference to the users table, with the constraint that the value of its importer_id column should be an existing ID from the users table. When this user is getting deleted, Postgres raises an error because the importer_id constrain would otherwise get violated. The solution for this type of issue is to add `dependent: :destroy` (or alternatively `dependent: :nullify`) to the has_many relationship. By specifying this, the InvitesImport instance will get also get deleted when deleting the user.

# Changelog
### Fixed
- [TAN-6061] Deleting imported users
