### PR TITLE
Added hosts param to first page rake task

### DIFF
--- a/back/lib/tasks/single_use/20251202_custom_fields_first_page.rake
+++ b/back/lib/tasks/single_use/20251202_custom_fields_first_page.rake
@@ -1,8 +1,13 @@
 namespace :fix_existing_tenants do
   desc 'Fix custom fields by making sure the first field is a page.'
-  task :custom_fields_first_page, [] => [:environment] do
+  task :custom_fields_first_page, %i[hosts] => [:environment] do |_, args|
     reporter = ScriptReporter.new
-    Tenant.all.each do |tenant|
+    tenants = if args[:hosts].present?
+      Tenant.where(host: args[:hosts].split(';').map(&:strip))
+    else
+      Tenant.all
+    end
+    tenants.each do |tenant|
       tenant.switch do
         CustomForm.all.each do |form|
           first_field = CustomField.find_by(ordering: 0, resource_id: form.id)


### PR DESCRIPTION
As discussed during the weekly QQ meeting, I added a tenants parameter to the rake task to fix crashing input forms (when the first field is not a page) so that we can execute it for only that specific platform whenever this issue would happen again (until we work out a more permanent solution). 

I added instructions on how to run the rake task in the ticket: https://www.notion.so/govocal/Survey-Form-crashes-backoffice-frontoffice-2b89663b7b2680cf8789eca425fe82a7
