### PR TITLE
TAN-6068 Fix restricted file paths

### DIFF
--- a/back/app/uploaders/files/restricted_file_uploader.rb
+++ b/back/app/uploaders/files/restricted_file_uploader.rb
@@ -6,5 +6,11 @@ module Files
     def extension_denylist
       %w[svg]
     end
+
+    def store_dir
+      # Keep the same directory structure as Files::File:
+      # ".../uploads/<tenant_id>/files/file/<mounted_as>/<model.id>"
+      super.sub('/files/restricted_file/', '/files/file/')
+    end
   end
 end

--- a/back/lib/tasks/single_use/20251230_move_restricted_files.rake
+++ b/back/lib/tasks/single_use/20251230_move_restricted_files.rake
@@ -1,0 +1,43 @@
+namespace :fix_existing_tenants do
+  desc 'Move/copy RestrictedFile objects from files/restricted_file to files/file. DRY_RUN=true (default), DELETE_OLD=false'
+  task :move_restricted_files, %i[dry_run] => [:environment] do |_, args|
+    dry_run = args[:dry_run].to_s.downcase != 'false'
+
+    reporter = ScriptReporter.new
+
+    s3 = Aws::S3::Client.new(region: ENV.fetch('AWS_REGION'))
+    s3_utils = Aws::S3::Utils.new
+    bucket = ENV.fetch('AWS_S3_BUCKET')
+
+    Tenant.creation_finalized.each do |tenant|
+      tenant.switch do
+        s3_prefix = "uploads/#{tenant.id}/files/restricted_file/"
+        restricted_files = s3_utils.objects(s3, bucket: bucket, prefix: s3_prefix)
+        next if restricted_files.none?
+
+        mapping = if dry_run
+          restricted_files.map.to_h do |restricted_file|
+            [restricted_file.key, restricted_file.key.sub('/files/restricted_file/', '/files/file/')]
+          end
+        else
+          s3_utils.copy_objects(
+            bucket,
+            s3,
+            bucket,
+            dest_s3_client: s3,
+            prefix: s3_prefix,
+            copy_args: { acl: 'public-read' }
+          ) do |key|
+            key.sub('/files/restricted_file/', '/files/file/')
+          end
+        end
+
+        mapping.each do |old_key, new_key|
+          reporter.add_change(old_key, new_key, context: { tenant: tenant.host })
+        end
+        reporter.add_processed_tenant(tenant.host)
+      end
+    end
+    reporter.report!('move_restricted_files_report.json', verbose: true)
+  end
+end


### PR DESCRIPTION
After introducing the blacklisting of SVG through a `RestrictedFile` class (temporary fix for the security issue reported by Vienna), file uploads in survey responses could no longer be accessed/downloaded by admins. The problem is that the S3 key would now contain `.../restricted_file/...` instead of `.../file/...`. This PR should fix that and includes a script to fix existing keys.

Testing the script was a bit challenging. A dry run was executed on a copy of the staging cluster, but there was nothing to be fixed. The part of the script that checks if there are any tenants with restricted file keys was ran on Canada (no matches), SAM (no matches), Paris (no matches) and eventually found matches on Benelux. The part that copies over the restricted files was executed only for the lafabriquecitoyenne.charenton.fr, which is the tenant for which the issue was reported. This fixed the issue for the corresponding survey.

# Changelog
### Fixed
- [TAN-6068] Finding back recently uploaded files in survey responses.
