### PR TITLE
 WIP Creating a two-color focus indicator 

### DIFF
--- a/front/app/components/UI/FilterTabs/index.tsx
+++ b/front/app/components/UI/FilterTabs/index.tsx
@@ -29,6 +29,15 @@ const Tab = styled.button<{ active: boolean; fullWidth: boolean }>`
   color: ${({ active, theme }) =>
     active ? theme.colors.tenantPrimary : colors.textSecondary};
 
+  /* Custom focus styles for tabs */
+  &:focus {
+    outline: none !important;
+    box-shadow: inset 0 0 0 1px #ffffff, 0 0 0 3px #000000 !important;
+    margin: 3px 1px !important;
+    position: relative;
+    z-index: 1000;
+  }
+
   ${({ active, theme }) =>
     active
       ? ''

--- a/front/app/global-styles.ts
+++ b/front/app/global-styles.ts
@@ -22,6 +22,11 @@ const GlobalStyle = createGlobalStyle`
     &:not(.focus-visible) {
       outline: none;
     }
+
+  *:focus {
+    outline: 4px solid #000000  ;
+    outline-offset: 2px ;
+    box-shadow: 0 0 0 4px #F9F9F9 ;
   }
 
   html,


### PR DESCRIPTION
Creating a two-color focus indicator to ensure sufficient contrast with all components

WIP: The current solution uses **WCAG 2.2 CSS technique C40** to replace the default browser focus
This improves visibility, but it is not consistent on all components and sometimes shows only part of the focus outline!! 
