### PR TITLE
[TAN-6073] Require project selection for moderators in report builder

### DIFF
--- a/front/app/components/UI/ProjectFilter/index.tsx
+++ b/front/app/components/UI/ProjectFilter/index.tsx
@@ -45,6 +45,7 @@ interface Props {
   hideLabel?: boolean;
   onProjectFilter: (filter: Option) => void;
   includeHiddenProjects?: boolean;
+  isClearable?: boolean;
 }
 
 const generateProjectOptions = (
@@ -73,6 +74,7 @@ const ProjectFilter = ({
   hideLabel = false,
   onProjectFilter,
   includeHiddenProjects = false,
+  isClearable = true,
   id,
   ...boxProps
 }: Props & Omit<BoxProps, 'children'>) => {
@@ -209,7 +211,7 @@ const ProjectFilter = ({
         }}
         menuPosition="fixed"
         menuPlacement="auto"
-        isClearable
+        isClearable={isClearable}
       />
     </Box>
   );

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Toolbox/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Toolbox/index.tsx
@@ -309,18 +309,20 @@ const ReportBuilderToolbox = ({
               icon="chart-bar"
               label={formatMessage(WIDGET_TITLES.ParticipantsWidget)}
             />
-            <DraggableElement
-              id="e2e-draggable-registrations-widget"
-              component={
-                <RegistrationsWidget
-                  title={toMultiloc(WIDGET_TITLES.RegistrationsWidget)}
-                  startAt={undefined}
-                  endAt={chartEndDate}
-                />
-              }
-              icon="chart-bar"
-              label={formatMessage(WIDGET_TITLES.RegistrationsWidget)}
-            />
+            {isUserAdmin && (
+              <DraggableElement
+                id="e2e-draggable-registrations-widget"
+                component={
+                  <RegistrationsWidget
+                    title={toMultiloc(WIDGET_TITLES.RegistrationsWidget)}
+                    startAt={undefined}
+                    endAt={chartEndDate}
+                  />
+                }
+                icon="chart-bar"
+                label={formatMessage(WIDGET_TITLES.RegistrationsWidget)}
+              />
+            )}
             <DraggableElement
               id="e2e-draggable-visitors-traffic-sources-widget"
               component={
@@ -366,18 +368,20 @@ const ReportBuilderToolbox = ({
               icon="chart-bar"
               label={formatMessage(WIDGET_TITLES.ParticipationWidget)}
             />
-            <DraggableElement
-              id="e2e-draggable-methods-used-widget"
-              component={
-                <MethodsUsedWidget
-                  title={toMultiloc(WIDGET_TITLES.MethodsUsedWidget)}
-                  startAt={undefined}
-                  endAt={chartEndDate}
-                />
-              }
-              icon="chart-bar"
-              label={formatMessage(WIDGET_TITLES.MethodsUsedWidget)}
-            />
+            {isUserAdmin && (
+              <DraggableElement
+                id="e2e-draggable-methods-used-widget"
+                component={
+                  <MethodsUsedWidget
+                    title={toMultiloc(WIDGET_TITLES.MethodsUsedWidget)}
+                    startAt={undefined}
+                    endAt={chartEndDate}
+                  />
+                }
+                icon="chart-bar"
+                label={formatMessage(WIDGET_TITLES.MethodsUsedWidget)}
+              />
+            )}
             {/* Only show Projects Widget for admins, not for project moderators */}
             {isUserAdmin && (
               <DraggableElement

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Toolbox/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Toolbox/index.tsx
@@ -289,6 +289,7 @@ const ReportBuilderToolbox = ({
                 <VisitorsWidget
                   title={toMultiloc(WIDGET_TITLES.VisitorsWidget)}
                   startAt={undefined}
+                  projectId={selectedProjectId}
                   endAt={chartEndDate}
                 />
               }

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/_shared/ProjectFilter.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/_shared/ProjectFilter.tsx
@@ -61,6 +61,7 @@ const ProjectFilter = ({
       emptyOptionMessage={getEmptyOptionMessage()}
       onProjectFilter={handleProjectFilter}
       includeHiddenProjects
+      isClearable={isAdmin(authUser)}
     />
   );
 };


### PR DESCRIPTION
# Changelog
## Fixed 
- Fixed project managers getting locked out of their own report by adding a 'forbidden' widget.
