### PR TITLE
TAN-6079 - Fix submitted at date in idea import and export

### DIFF
--- a/back/app/services/export/xlsx/input_sheet_generator.rb
+++ b/back/app/services/export/xlsx/input_sheet_generator.rb
@@ -91,10 +91,10 @@ module Export
         )
       end
 
-      def created_at_report_field
+      def submitted_at_report_field
         ComputedFieldForReport.new(
-          column_header_for('created_at'),
-          ->(input) { AppConfiguration.timezone.at(input.created_at) }
+          column_header_for('submitted_at'),
+          ->(input) { AppConfiguration.timezone.at(input.submitted_at || input.created_at) }
         )
       end
 
@@ -234,7 +234,7 @@ module Export
 
       def meta_report_fields
         [].tap do |meta_fields|
-          meta_fields << created_at_report_field
+          meta_fields << submitted_at_report_field
           meta_fields << published_at_report_field if participation_method.supports_public_visibility?
           meta_fields << comments_count_report_field if participation_method.supports_commenting?
           meta_fields << likes_count_report_field if participation_method.supports_reacting?('up')

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/importers/idea_importer.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/importers/idea_importer.rb
@@ -111,7 +111,9 @@ module BulkImportIdeas::Importers
         )
       end
 
+      # Set both published_at and submitted_at to the same value
       idea_attributes[:published_at] = published_at
+      idea_attributes[:submitted_at] = published_at
     end
 
     # Add the current time to the date to ensure consistent sorting by published_at date

--- a/back/engines/commercial/bulk_import_ideas/spec/services/importers/idea_importer_spec.rb
+++ b/back/engines/commercial/bulk_import_ideas/spec/services/importers/idea_importer_spec.rb
@@ -187,18 +187,20 @@ describe BulkImportIdeas::Importers::IdeaImporter do
       )
     end
 
-    it 'adds a timestamp to published at so that idea sorting is consistent' do
+    it 'adds a timestamp to published at and submitted at so that idea sorting is consistent' do
       allow(Time).to receive(:now).and_return(Time.new(2024, 12, 25, 11, 22, 33))
       project = create(:project, title_multiloc: { 'en' => 'Project title' })
       idea_rows = [
         {
           title_multiloc: { 'en' => 'My idea title' },
           project_id: project.id,
-          published_at: '01-11-2024'
+          published_at: '01-11-2024',
+          submitted_at: '01-11-2024'
         }
       ]
       service.import idea_rows
       expect(project.ideas.first.published_at.strftime('%F %T')).to eq '2024-11-01 11:22:33'
+      expect(project.ideas.first.submitted_at.strftime('%F %T')).to eq '2024-11-01 11:22:33'
     end
 
     it 'does not import a user if there is a problem with saving a named user' do

--- a/back/spec/services/export/xlsx/input_sheet_generator_spec.rb
+++ b/back/spec/services/export/xlsx/input_sheet_generator_spec.rb
@@ -58,7 +58,7 @@ describe Export::Xlsx::InputSheetGenerator do
       describe 'timezone handling' do
         let(:tenant_timezone) { 'America/Toronto' }
         let(:utc_time) { Time.utc(2019, 9, 9, 18, 30, 0) }
-        let(:idea) { create(:idea, project: phase.project, phases: [phase], created_at: utc_time) }
+        let(:idea) { create(:idea, project: phase.project, phases: [phase], created_at: utc_time, submitted_at: utc_time) }
         let(:inputs) { [idea] }
 
         before do


### PR DESCRIPTION
Looks like at some point the column header in the export changed to 'Submitted at' but the value was still from `created_at`. Separately the importer was not setting `submitted_at` when importing from XLSX.

# Changelog
## Fixed
- Fixed idea importer so that the `submitted_at` date is set to the value in XLSX
- Fixed idea xlsx export so that 'Submitted at' is the `submitted_at` value and not the `created_at` value
