### PR TITLE
[TAN-6098] - only render DescriptionText when localized description exists

### DIFF
--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/_shared/DescriptionText.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ChartWidgets/_shared/DescriptionText.tsx
@@ -24,8 +24,12 @@ export const DescriptionText = ({
   const localizedDescription = localize(description);
 
   return (
-    <Text color="grey700" fontSize="s" id={descriptionId}>
-      {formatMessage(messages.description)} {localizedDescription}
-    </Text>
+    <>
+      {localizedDescription && (
+        <Text color="grey700" fontSize="s" id={descriptionId}>
+          {formatMessage(messages.description)} {localizedDescription}
+        </Text>
+      )}
+    </>
   );
 };


### PR DESCRIPTION
# Changelog
## Fixed 
- DescriptionText renders only when description exists
