### PR TITLE
TAN-6102 Auto send code if user has not requested any codes since last confirming email

### DIFF
--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -148,7 +148,7 @@ class WebApi::V1::UsersController < ApplicationController
           # to automatically send the confirmation code.
           # If they would already have a email_confirmation_code_reset_count > 0,
           # they tried to log in previously and failed. In this case, we don't
-          # automatically resend the code, because otherwise we 
+          # automatically resend the code, because otherwise we
           # might too easily reach the retry limit. So they will
           # have to request it themselves
           RequestConfirmationCodeJob.perform_now(@user)

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -135,6 +135,8 @@ resource 'Users' do
             before do
               @user = create(:user_no_password, email: 'test@test.com')
               @user.confirm
+              @user.save!
+
               RequestConfirmationCodeJob.perform_now @user
 
               allow(RequestConfirmationCodeJob).to receive(:perform_now)

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -116,6 +116,7 @@ resource 'Users' do
             before do
               @user = create(:user_no_password, email: 'test@test.com')
               @user.confirm
+              @user.save!
 
               allow(RequestConfirmationCodeJob).to receive(:perform_now)
             end
@@ -124,7 +125,6 @@ resource 'Users' do
 
             example_request 'Returns "confirm"' do
               expect(@user.password_digest).to be_nil
-              expect(@user.confirmation_required?).to be true
               assert_status 200
               expect(json_response_body[:data][:attributes][:action]).to eq('confirm')
               expect(RequestConfirmationCodeJob).to have_received(:perform_now).with(@user)
@@ -144,7 +144,6 @@ resource 'Users' do
 
             example_request 'Returns "confirm"' do
               expect(@user.password_digest).to be_nil
-              expect(@user.confirmation_required?).to be true
               assert_status 200
               expect(json_response_body[:data][:attributes][:action]).to eq('confirm')
               expect(RequestConfirmationCodeJob).not_to have_received(:perform_now).with(@user)


### PR DESCRIPTION
You can test on https://6102.epic.govocal.com/en/ with mailcatcher

# Changelog
## Changed
- If you are an existing user without password, logging in with an email confirmation code: now, the code will be sent automatically, as long as this is the first time you are requesting it since last confirming your email. Previously, you had to request it manually.
