### PR TITLE
TAN-6106 Preserve query parameters in redirects

### DIFF
--- a/front/app/containers/App/index.tsx
+++ b/front/app/containers/App/index.tsx
@@ -224,7 +224,12 @@ const App = ({ children }: Props) => {
             locales.includes(localeInUrl) &&
             pathnameWithoutLocale === rule.path
           ) {
-            window.location.href = rule.target;
+            const queryString = location.search;
+            const separator = rule.target.includes('?') ? '&' : '?';
+            const targetUrl = queryString
+              ? `${rule.target}${separator}${queryString.slice(1)}`
+              : rule.target;
+            window.location.href = targetUrl;
           }
         });
       }


### PR DESCRIPTION
# Changelog
## Changed
- Redirects now preserve any query parameters added to the original url