### PR TITLE
TAN-6017 Return custom field options by ordering in permissions endpoint

### DIFF
--- a/back/app/controllers/web_api/v1/permissions_controller.rb
+++ b/back/app/controllers/web_api/v1/permissions_controller.rb
@@ -66,7 +66,10 @@ class WebApi::V1::PermissionsController < ApplicationController
   def custom_field_options
     authorize @permission
     fields = user_requirements_service.requirements_custom_fields @permission
-    options = CustomFieldOption.where(custom_field_id: fields.map(&:id))
+    options = CustomFieldOption
+      .joins(:custom_field)
+      .where(custom_field_id: fields.map(&:id))
+      .order('custom_fields.ordering ASC, custom_field_options.ordering ASC')
 
     render json: WebApi::V1::CustomFieldOptionSerializer.new(
       options,

--- a/back/spec/acceptance/permissions_spec.rb
+++ b/back/spec/acceptance/permissions_spec.rb
@@ -466,6 +466,7 @@ resource 'Permissions' do
           create_list(:custom_field_option, 3, custom_field: @field1)
           create_list(:custom_field_option, 2, custom_field: @field2)
 
+          # Reorder one option to test ordering
           @reordered_option = @field1.reload.options.last
           @reordered_option.insert_at(1)
         end
@@ -476,6 +477,7 @@ resource 'Permissions' do
           expect(json_response[:data]).to be_an(Array)
           expect(json_response[:data].size).to eq 5
 
+          # Test ordering
           expect(json_response[:data][1][:id]).to eq @reordered_option.id
         end
       end

--- a/back/spec/acceptance/permissions_spec.rb
+++ b/back/spec/acceptance/permissions_spec.rb
@@ -465,6 +465,9 @@ resource 'Permissions' do
           @field2 = create(:custom_field_select, required: false)
           create_list(:custom_field_option, 3, custom_field: @field1)
           create_list(:custom_field_option, 2, custom_field: @field2)
+
+          @reordered_option = @field1.reload.options.last
+          @reordered_option.insert_at(1)
         end
 
         example_request 'Get the custom fields for a global permission' do
@@ -472,6 +475,8 @@ resource 'Permissions' do
           json_response = json_parse response_body
           expect(json_response[:data]).to be_an(Array)
           expect(json_response[:data].size).to eq 5
+
+          expect(json_response[:data][1][:id]).to eq @reordered_option.id
         end
       end
     end


### PR DESCRIPTION
# Changelog
### Fixed
- [TAN-6017] Custom field options in the front office don't follow the ordering set through the back office.
