### PR TITLE
Fix the `BlockUser` modal closing before the success view is shown

### DIFF
--- a/front/app/components/admin/UserBlockModals/BlockUser.tsx
+++ b/front/app/components/admin/UserBlockModals/BlockUser.tsx
@@ -75,7 +75,6 @@ const BlockUserModal = ({ open, setClose, user, returnFocusRef }: Props) => {
         },
       }
     );
-    setClose();
   };
 
   const blockingDuration =
@@ -91,6 +90,7 @@ const BlockUserModal = ({ open, setClose, user, returnFocusRef }: Props) => {
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         date={moment(updatedUser?.attributes.block_end_at).format('LL')}
         resetSuccess={() => setSuccess(false)}
+        setClose={setClose}
         opened={true}
       />
     );

--- a/front/app/components/admin/UserBlockModals/SuccessfulUserBlock.tsx
+++ b/front/app/components/admin/UserBlockModals/SuccessfulUserBlock.tsx
@@ -17,17 +17,19 @@ import messages from './messages';
 type Props = {
   opened: boolean;
   resetSuccess: () => void;
+  setClose: () => void;
   date: string;
   name: string;
 };
 
-export default ({ opened, resetSuccess, date, name }: Props) => {
+export default ({ opened, resetSuccess, setClose, date, name }: Props) => {
   const [localOpened, setLocaloOpened] = useState(opened);
   const { formatMessage } = useIntl();
 
   const onClose = () => {
     resetSuccess();
     setLocaloOpened(false);
+    setClose();
   };
 
   return (


### PR DESCRIPTION
The bug was introduced by this commit: [`19f2de5` (#12565)](https://github.com/CitizenLabDotCo/citizenlab/pull/12565/commits/19f2de53ecd22688f0af952ee359d96420a963a6)

# Changelog
## Fixed
- Fix the `BlockUser` modal closing before the success view is shown. The modal was unmounted as soon as the block request was sent, which prevented the success confirmation from being displayed.
