### PR TITLE
TAN-6122 - Do not allow logic to be saved for unsupported fields

### DIFF
--- a/back/app/models/custom_field.rb
+++ b/back/app/models/custom_field.rb
@@ -115,7 +115,7 @@ class CustomField < ApplicationRecord
   before_validation :set_default_enabled
   before_validation :generate_key, on: :create
   before_validation :sanitize_description_multiloc
-  before_save :clear_logic_unless_supported
+  before_validation :clear_logic_unless_supported
   after_create(if: :domicile?) { Area.recreate_custom_field_options }
 
   scope :registration, -> { where(resource_type: 'User') }

--- a/back/spec/models/custom_field_spec.rb
+++ b/back/spec/models/custom_field_spec.rb
@@ -149,6 +149,24 @@ RSpec.describe CustomField do
     end
   end
 
+  describe '#clear_logic_unless_supported' do
+    let(:field) { create(:custom_field, resource: create(:custom_form)) }
+
+    it 'saves logic when the field supports logic' do
+      field.input_type = 'select'
+      field.logic = { 'rules' => [{ 'if' => 2, 'goto_page_id' => 'some_page_id' }] }
+      field.save!
+      expect(field.logic).to eq({ 'rules' => [{ 'if' => 2, 'goto_page_id' => 'some_page_id' }] })
+    end
+
+    it 'does not save logic when the field does not support logic' do
+      field.input_type = 'multiselect'
+      field.logic = { 'rules' => [{ 'if' => 2, 'goto_page_id' => 'some_page_id' }] }
+      field.save!
+      expect(field.logic).to eq({})
+    end
+  end
+
   describe '#file_upload?' do
     it 'returns true when the input_type is "file_upload"' do
       files_field = described_class.new input_type: 'file_upload'

--- a/front/app/components/FormBuilder/components/FormBuilderSettings/index.tsx
+++ b/front/app/components/FormBuilder/components/FormBuilderSettings/index.tsx
@@ -62,10 +62,12 @@ const FormBuilderSettings = ({
       'page',
     ].includes(fieldType);
 
-    // For backwards compatibility, we only show the logic tab for multiselect/multiselect_image if they already have logic.
+    // For backwards compatibility (pre-2026), we only show the logic tab for multiselect/multiselect_image if they already have logic.
     const fieldHasLogic = field.logic.rules && field.logic.rules.length > 0;
     const isMultiselectWithLogic =
-      ['multiselect', 'multiselect_image'].includes(fieldType) && fieldHasLogic;
+      ['multiselect', 'multiselect_image'].includes(fieldType) &&
+      fieldHasLogic &&
+      field.created_at < '2026-01-10';
 
     const isFormEndPage = fieldType === 'page' && field.key === 'form_end';
 

--- a/front/app/components/FormBuilder/components/FormBuilderSettings/index.tsx
+++ b/front/app/components/FormBuilder/components/FormBuilderSettings/index.tsx
@@ -67,7 +67,7 @@ const FormBuilderSettings = ({
     const isMultiselectWithLogic =
       ['multiselect', 'multiselect_image'].includes(fieldType) &&
       fieldHasLogic &&
-      field.created_at < '2026-01-10';
+      field.created_at < '2026-01-18';
 
     const isFormEndPage = fieldType === 'page' && field.key === 'form_end';
 


### PR DESCRIPTION
Checked in metabase and there are no phases that are not yet started that use logic in multiselect fields (and only about 12 that are live) so nobody should need to edit the forms that currently use logic on multiselects.

# Changelog
## Fixed
- Do not allow fields to save logic to multiselect/multiselect_image fields - currently if you add logic to a single select and switch to multiselect you can still use logic. Logic on multiselect fields was removed last summer.
