### PR TITLE
TAN-6194 Update all failures with ordering

### DIFF
--- a/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/idea_custom_fields_controller.rb
+++ b/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/idea_custom_fields_controller.rb
@@ -314,13 +314,13 @@ module IdeaCustomFields
       deleted_statements = statements.reject { |statement| given_ids.include? statement.id }
       deleted_statements.each { |statement| delete_statement! statement }
       statements_params.each_with_index do |statement_params, statement_index|
-        statement_params[:ordering] = statement_index # Do this instead of ordering gem .move_to_bottom method for performance reasons
         if statement_params[:id] && statements_by_id[statement_params[:id]]
           statement = statements_by_id[statement_params[:id]]
           update_statement! statement, statement_params, errors, field_index, statement_index
         else
-          create_statement! statement_params, field, errors, field_index, statement_index
+          statement = create_statement! statement_params, field, errors, field_index, statement_index
         end
+        statement&.move_to_bottom
       end
     end
 
@@ -331,6 +331,7 @@ module IdeaCustomFields
       else
         add_statements_errors statement.errors.details, errors, field_index, statement_index
       end
+      statement
     end
 
     def update_statement!(statement, statement_params, errors, field_index, statement_index)

--- a/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/idea_custom_fields_controller.rb
+++ b/back/engines/commercial/idea_custom_fields/app/controllers/idea_custom_fields/web_api/v1/idea_custom_fields_controller.rb
@@ -233,7 +233,6 @@ module IdeaCustomFields
         deleted_options = options.reject { |option| given_ids.include? option.id }
         deleted_options.each { |option| delete_option! option }
         options_params.each_with_index do |option_params, option_index|
-          option_params[:ordering] = option_index # Do this instead of ordering gem .move_to_bottom method for performance reasons
           if option_params[:id] && options_by_id[option_params[:id]]
             option = options_by_id[option_params[:id]]
             next unless update_option! option, option_params, errors, field_index, option_index
@@ -242,6 +241,7 @@ module IdeaCustomFields
             next unless option
           end
           update_option_image!(option, option_params[:image_id])
+          option.move_to_bottom
         end
       end
     end

--- a/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/update_all_native_survey_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/acceptance/idea_custom_fields/phase_context/update_all_native_survey_spec.rb
@@ -3237,6 +3237,39 @@ resource 'Idea Custom Fields' do
         })
       end
 
+      example 'Swap the order of existing options' do
+        select_field = create(:custom_field_select, resource: custom_form)
+        option_a = create(:custom_field_option, custom_field: select_field, key: 'option_a', title_multiloc: { 'en' => 'Option A' }, ordering: 0)
+        option_b = create(:custom_field_option, custom_field: select_field, key: 'option_b', title_multiloc: { 'en' => 'Option B' }, ordering: 1)
+
+        # Swap the order: B first, then A
+        request = {
+          custom_fields: [
+            {
+              input_type: 'page',
+              page_layout: 'default'
+            },
+            {
+              id: select_field.id,
+              input_type: 'select',
+              title_multiloc: select_field.title_multiloc,
+              options: [
+                { id: option_b.id, title_multiloc: { 'en' => 'Option B' } },
+                { id: option_a.id, title_multiloc: { 'en' => 'Option A' } }
+              ]
+            },
+            final_page
+          ]
+        }
+        do_request request
+
+        assert_status 200
+
+        # Verify ordering was swapped
+        expect(option_b.reload.ordering).to eq(0)
+        expect(option_a.reload.ordering).to eq(1)
+      end
+
       example 'Updating custom fields when there are responses' do
         create(:custom_field, resource: custom_form) # field to ensure custom form has been created
         create(:idea_status_proposed)


### PR DESCRIPTION
# Changelog
### Fixed
- [TAN-6194] Issues with reordering custom field options in a survey input form.
