### PR TITLE
TAN-6271: Show same data for most liked ideas in front office and back office

### DIFF
--- a/front/app/containers/Admin/projects/project/insights/methodSpecific/ideation/MostLikedIdeas.tsx
+++ b/front/app/containers/Admin/projects/project/insights/methodSpecific/ideation/MostLikedIdeas.tsx
@@ -19,7 +19,7 @@ const MostLikedIdeas = ({ phaseId }: MethodSpecificInsightProps) => {
 
   const { data: ideasData, isLoading } = useInfiniteIdeas({
     phase: phaseId,
-    sort: '-likes_count',
+    sort: 'popular',
     'page[size]': NUMBER_OF_IDEAS,
   });
 


### PR DESCRIPTION
# Changelog

## Fixed
- Show same data for most liked ideas in front office and back office. This relates to the phase insights work that is currently hidden behind a feature flag
