### PR TITLE
TAN-6272: Fix layout issues in pdf export of the insights page

### DIFF
--- a/front/app/containers/Admin/projects/project/insights/methodSpecific/MethodSpecificInsights.tsx
+++ b/front/app/containers/Admin/projects/project/insights/methodSpecific/MethodSpecificInsights.tsx
@@ -27,7 +27,7 @@ const MethodSpecificInsights = ({
         <NativeSurveyInsights phaseId={phaseId} isPdfExport={isPdfExport} />
       );
     case 'ideation':
-      return <IdeationInsights phaseId={phaseId} />;
+      return <IdeationInsights phaseId={phaseId} isPdfExport={isPdfExport} />;
     case 'proposals':
       return <ProposalsInsights phaseId={phaseId} />;
     case 'voting':

--- a/front/app/containers/Admin/projects/project/insights/methodSpecific/ideation/AiSummary.tsx
+++ b/front/app/containers/Admin/projects/project/insights/methodSpecific/ideation/AiSummary.tsx
@@ -33,9 +33,10 @@ const MIN_INPUTS_FOR_SUMMARY = 10;
 
 interface Props {
   phaseId: string;
+  isPdfExport?: boolean;
 }
 
-const AiSummary = ({ phaseId }: Props) => {
+const AiSummary = ({ phaseId, isPdfExport = false }: Props) => {
   const { formatMessage } = useIntl();
   const { projectId } = useParams() as { projectId: string };
   const [automaticSummaryCreated, setAutomaticSummaryCreated] = useState(false);
@@ -203,7 +204,7 @@ const AiSummary = ({ phaseId }: Props) => {
         borderLeft={`3px solid ${colors.primary}`}
         display="flex"
         flexDirection="column"
-        h="400px"
+        h={isPdfExport ? 'auto' : '400px'}
       >
         <Box
           display="flex"
@@ -213,15 +214,17 @@ const AiSummary = ({ phaseId }: Props) => {
           flexShrink={0}
         >
           <SummaryHeader showAiWarning={false} />
-          <Button
-            buttonStyle="text"
-            icon="refresh"
-            onClick={handleRefresh}
-            processing={isRegenerating}
-            padding="0"
-          >
-            {formatMessage(messages.refresh)}
-          </Button>
+          {!isPdfExport && (
+            <Button
+              buttonStyle="text"
+              icon="refresh"
+              onClick={handleRefresh}
+              processing={isRegenerating}
+              padding="0"
+            >
+              {formatMessage(messages.refresh)}
+            </Button>
+          )}
         </Box>
 
         <Box
@@ -229,9 +232,9 @@ const AiSummary = ({ phaseId }: Props) => {
           flexDirection="column"
           gap="8px"
           flex="1"
-          overflow="hidden"
+          overflow={isPdfExport ? 'visible' : 'hidden'}
         >
-          <Box flex="1" overflow="auto">
+          <Box flex="1" overflow={isPdfExport ? 'visible' : 'auto'}>
             <InsightBody
               text={summary}
               filters={filters}
@@ -242,40 +245,42 @@ const AiSummary = ({ phaseId }: Props) => {
             />
           </Box>
 
-          <Box
-            display="flex"
-            justifyContent="space-between"
-            alignItems="center"
-            flexShrink={0}
-          >
-            <Box display="flex" flexDirection="column" gap="4px">
-              <Text m="0" fontSize="s" color="textSecondary">
-                {missingInputsCount} / {inputCount}
-              </Text>
-              <Box display="flex" alignItems="center" gap="4px">
-                <Box
-                  w="8px"
-                  h="8px"
-                  borderRadius="50%"
-                  bgColor={colors.primary}
-                />
-                <Text m="0" fontSize="s" color="textSecondary">
-                  {formatMessage(messages.newResponses, {
-                    count: missingInputsCount,
-                  })}
-                </Text>
-              </Box>
-            </Box>
-
-            <Button
-              buttonStyle="secondary-outlined"
-              icon="eye"
-              onClick={handleExplore}
-              size="s"
+          {!isPdfExport && (
+            <Box
+              display="flex"
+              justifyContent="space-between"
+              alignItems="center"
+              flexShrink={0}
             >
-              {formatMessage(messages.explore)}
-            </Button>
-          </Box>
+              <Box display="flex" flexDirection="column" gap="4px">
+                <Text m="0" fontSize="s" color="textSecondary">
+                  {missingInputsCount} / {inputCount}
+                </Text>
+                <Box display="flex" alignItems="center" gap="4px">
+                  <Box
+                    w="8px"
+                    h="8px"
+                    borderRadius="50%"
+                    bgColor={colors.primary}
+                  />
+                  <Text m="0" fontSize="s" color="textSecondary">
+                    {formatMessage(messages.newResponses, {
+                      count: missingInputsCount,
+                    })}
+                  </Text>
+                </Box>
+              </Box>
+
+              <Button
+                buttonStyle="secondary-outlined"
+                icon="eye"
+                onClick={handleExplore}
+                size="s"
+              >
+                {formatMessage(messages.explore)}
+              </Button>
+            </Box>
+          )}
         </Box>
       </Box>
     </Box>

--- a/front/app/containers/Admin/projects/project/insights/methodSpecific/ideation/IdeationInsights.tsx
+++ b/front/app/containers/Admin/projects/project/insights/methodSpecific/ideation/IdeationInsights.tsx
@@ -9,7 +9,22 @@ import { MethodSpecificInsightProps } from '../types';
 import AiSummary from './AiSummary';
 import MostLikedIdeas from './MostLikedIdeas';
 
-const IdeationInsights = ({ phaseId }: MethodSpecificInsightProps) => {
+const IdeationInsights = ({
+  phaseId,
+  isPdfExport = false,
+}: MethodSpecificInsightProps) => {
+  // For PDF export, use single-column layout so content spans full width
+  if (isPdfExport) {
+    return (
+      <Box mt="16px" display="flex" flexDirection="column" gap="24px">
+        <AiSummary phaseId={phaseId} />
+        <InputsByTopic phaseId={phaseId} />
+        <MostLikedIdeas phaseId={phaseId} />
+        <StatusBreakdown phaseId={phaseId} participationMethod="ideation" />
+      </Box>
+    );
+  }
+
   return (
     <Box mt="16px" gap="24px">
       <Box display="flex" gap="16px" w="100%">

--- a/front/app/containers/Admin/projects/project/insights/methodSpecific/ideation/IdeationInsights.tsx
+++ b/front/app/containers/Admin/projects/project/insights/methodSpecific/ideation/IdeationInsights.tsx
@@ -17,7 +17,7 @@ const IdeationInsights = ({
   if (isPdfExport) {
     return (
       <Box mt="16px" display="flex" flexDirection="column" gap="24px">
-        <AiSummary phaseId={phaseId} />
+        <AiSummary phaseId={phaseId} isPdfExport />
         <InputsByTopic phaseId={phaseId} />
         <MostLikedIdeas phaseId={phaseId} />
         <StatusBreakdown phaseId={phaseId} participationMethod="ideation" />

--- a/front/app/containers/Admin/projects/project/insights/methodSpecific/types.ts
+++ b/front/app/containers/Admin/projects/project/insights/methodSpecific/types.ts
@@ -3,4 +3,5 @@
  */
 export interface MethodSpecificInsightProps {
   phaseId: string;
+  isPdfExport?: boolean;
 }


### PR DESCRIPTION
# Changelog

## Fixed
- **Insights Page PDF:** Exports now render in a single-column layout to prevent content from appearing squeezed.
- **PDF AI Summaries:** The AI summary now expands to show the full text, eliminating vertical scrollbars within the PDF.