### PR TITLE
TAN-6289 Fix lastpass CLI installation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -718,7 +718,7 @@ jobs:
   # E2E TESTS
   e2e-setup-db:
     docker:
-      - image: cimg/base:2024.08
+      - image: cimg/base:2026.01
     working_directory: ~/citizenlab
     resource_class: medium
     parameters:
@@ -751,7 +751,7 @@ jobs:
 
   e2e-setup-front:
     docker:
-      - image: cimg/base:2024.08
+      - image: cimg/base:2026.01
     resource_class: large
     parameters:
       docker_layer_caching:
@@ -778,7 +778,7 @@ jobs:
             - build
   e2e-tests:
     docker:
-      - image: cimg/base:2024.08
+      - image: cimg/base:2026.01
     parameters:
       parallelism:
         type: integer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ commands:
       # version available in the source repositories is 1.3.3, which has been broken by
       # a change of SSL certificate. For more information, see:
       # https://github.com/lastpass/lastpass-cli/issues/653
-      - run: sudo .circleci/install_lpass.sh v1.5.0
+      - run: sudo .circleci/install_lpass.sh master
       - run: echo $LASTPASS_PASSWORD | LPASS_DISABLE_PINENTRY=1 lpass login ${LASTPASS_EMAIL}
       - run: lpass show --notes 'citizenlab back-secret.env' > env_files/back-secret.env
       - run: lpass show --notes 'citizenlab front-secret.env' > env_files/front-secret.env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,7 @@ commands:
       # version available in the source repositories is 1.3.3, which has been broken by
       # a change of SSL certificate. For more information, see:
       # https://github.com/lastpass/lastpass-cli/issues/653
+      - run: sudo apt-get update && sudo apt-get install -y libxml2-dev
       - run: sudo .circleci/install_lpass.sh master
       - run: echo $LASTPASS_PASSWORD | LPASS_DISABLE_PINENTRY=1 lpass login ${LASTPASS_EMAIL}
       - run: lpass show --notes 'citizenlab back-secret.env' > env_files/back-secret.env

--- a/.circleci/install_lpass.sh
+++ b/.circleci/install_lpass.sh
@@ -6,7 +6,10 @@ if [ $# -ne 1 ]; then
 fi
 
 version="$1"
-repository="https://github.com/lastpass/lastpass-cli.git"
+
+# Temporary fix until https://github.com/lastpass/lastpass-cli/pull/729 is merged
+repository="https://github.com/aukecb/lastpass-cli.git"
+# repository="https://github.com/lastpass/lastpass-cli.git"
 
 # Clone the LastPass CLI repository with a shallow clone
 if ! git clone --depth 1 --branch "$version" "$repository" lastpass-cli; then


### PR DESCRIPTION
# Changelog
## Technical
- Fixes e2e tests in CI by upgrading the lastpass CLI to a patched, currently unmerged version. The LastPass API became more strict on the ciphers it accepts, and the CLI has not yet been updated