### PR TITLE
[TAN-6284] Bugfix: Do not include not submitted vote baskets in voting phase insights participations

### DIFF
--- a/back/app/services/insights/voting_phase_insights_service.rb
+++ b/back/app/services/insights/voting_phase_insights_service.rb
@@ -126,7 +126,7 @@ module Insights
 
     def participations_voting
       @phase.baskets
-        .where.not(submitted_at: nil)
+        .submitted
         .includes(:user, :baskets_ideas, :ideas)
         .map do |basket|
           basket_ideas = basket.baskets_ideas

--- a/back/app/services/insights/voting_phase_insights_service.rb
+++ b/back/app/services/insights/voting_phase_insights_service.rb
@@ -125,27 +125,30 @@ module Insights
     end
 
     def participations_voting
-      @phase.baskets.includes(:user, :baskets_ideas).map do |basket|
-        basket_ideas = basket.baskets_ideas
-        total_votes = basket_ideas.to_a.sum(&:votes)
-        votes_per_idea = if @phase.voting_method == 'budgeting'
-          basket_ideas.to_h { |bi| [bi.idea_id, 1] }
-        else
-          basket_ideas.to_h { |bi| [bi.idea_id, bi.votes] }
-        end
+      @phase.baskets
+        .where.not(submitted_at: nil)
+        .includes(:user, :baskets_ideas)
+        .map do |basket|
+          basket_ideas = basket.baskets_ideas
+          total_votes = basket_ideas.to_a.sum(&:votes)
+          votes_per_idea = if @phase.voting_method == 'budgeting'
+            basket_ideas.to_h { |bi| [bi.idea_id, 1] }
+          else
+            basket_ideas.to_h { |bi| [bi.idea_id, bi.votes] }
+          end
 
-        {
-          item_id: basket.id,
-          action: 'voting',
-          acted_at: basket.submitted_at,
-          classname: 'Basket',
-          participant_id: participant_id(basket.id, basket.user_id),
-          user_custom_field_values: basket&.user&.custom_field_values || {},
-          total_votes: total_votes,
-          ideas_count: basket.ideas.count,
-          votes_per_idea: votes_per_idea
-        }
-      end
+          {
+            item_id: basket.id,
+            action: 'voting',
+            acted_at: basket.submitted_at,
+            classname: 'Basket',
+            participant_id: participant_id(basket.id, basket.user_id),
+            user_custom_field_values: basket&.user&.custom_field_values || {},
+            total_votes: total_votes,
+            ideas_count: basket.ideas.count,
+            votes_per_idea: votes_per_idea
+          }
+        end
     end
 
     def phase_participation_method_metrics(participations)

--- a/back/app/services/insights/voting_phase_insights_service.rb
+++ b/back/app/services/insights/voting_phase_insights_service.rb
@@ -127,7 +127,7 @@ module Insights
     def participations_voting
       @phase.baskets
         .where.not(submitted_at: nil)
-        .includes(:user, :baskets_ideas)
+        .includes(:user, :baskets_ideas, :ideas)
         .map do |basket|
           basket_ideas = basket.baskets_ideas
           total_votes = basket_ideas.to_a.sum(&:votes)

--- a/back/spec/services/insights/voting_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/voting_phase_insights_service_spec.rb
@@ -15,14 +15,17 @@ RSpec.describe Insights::VotingPhaseInsightsService do
   let!(:basket2) { create(:basket, phase: phase, user: nil, submitted_at: phase.start_at + 1.day) }
   let!(:baskets_idea3) { create(:baskets_idea, basket: basket2, idea: idea2, votes: 42) }
 
+  let!(:basket3) { create(:basket, phase: phase, user: nil, submitted_at: nil) }
+  let!(:baskets_idea4) { create(:baskets_idea, basket: basket3, idea: idea2, votes: 999) }
+
   let!(:comment1) { create(:comment, idea: idea1, created_at: 20.days.ago, author: user) } # before phase start
   let!(:comment2) { create(:comment, idea: idea1, created_at: 10.days.ago, author: user) } # during phase
   let!(:comment3) { create(:comment, idea: idea1, created_at: 1.day.ago, author: user) } # after phase end
 
   # Update votes_count after creating baskets_ideas
   before do
-    idea1.update_column(:votes_count, idea1.baskets_ideas.sum(:votes))
-    idea2.update_column(:votes_count, idea2.baskets_ideas.sum(:votes))
+    idea1.update_column(:votes_count, idea1.baskets_ideas.joins(:basket).where.not(baskets: { submitted_at: nil }).sum(:votes))
+    idea2.update_column(:votes_count, idea2.baskets_ideas.joins(:basket).where.not(baskets: { submitted_at: nil }).sum(:votes))
   end
 
   describe '#participations_voting' do

--- a/back/spec/services/insights/voting_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/voting_phase_insights_service_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Insights::VotingPhaseInsightsService do
   let!(:comment2) { create(:comment, idea: idea1, created_at: 10.days.ago, author: user) } # during phase
   let!(:comment3) { create(:comment, idea: idea1, created_at: 1.day.ago, author: user) } # after phase end
 
-  # Update votes_count after creating baskets_ideas
+  # Manually update votes_count for each idea to reflect only votes from submitted baskets, mimicking production behavior
   before do
     idea1.update_column(:votes_count, idea1.baskets_ideas.joins(:basket).where.not(baskets: { submitted_at: nil }).sum(:votes))
     idea2.update_column(:votes_count, idea2.baskets_ideas.joins(:basket).where.not(baskets: { submitted_at: nil }).sum(:votes))


### PR DESCRIPTION
I was including all baskets as voting 'participations' for a voting phase, even if their `submitted_at` was nil (not submitted). Since each voting participation object has an `acted_at` value set to the `basket.submitted_at` value, and I later compare this value with other dates (e.g. to get counts over 7 day periods), the request would crash with a 500 server error, if any not submitted baskets existed.

Now, I simply do include any baskets with `submitted_at: nil` as voting participations. I think this should be fine, as we were not asked to give insights into such not submitted baskets (unlike native surveys, where we do give some insights into 'completion rate' == n submitted survey response ideas / n created survey response ideas)

I don't think this will be an issue in any other participation objects, as in all other cases `acted_at` is set to a record's `created_at` value.

# Changelog
## Fixed
- [TAN-6284] Do not include not submitted vote baskets in voting phase insights participations (behind FF - in development)
