### PR TITLE
[TAN-6120] Align format of custom field options in voting phase insights response with format in base phase insights response

### DIFF
--- a/back/app/services/insights/voting_phase_insights_service.rb
+++ b/back/app/services/insights/voting_phase_insights_service.rb
@@ -13,11 +13,14 @@ module Insights
       total_votes = online_votes + offline_votes
 
       options = if custom_field&.options&.any?
-        custom_field.options.map do |opt|
-          { "#{opt.key}": { id: opt.id, title_multiloc: opt.title_multiloc }, ordering: opt.ordering }
+        custom_field.options.index_by(&:key).transform_values do |opt|
+          {
+            title_multiloc: opt.title_multiloc,
+            ordering: opt.ordering
+          }
         end
       else
-        []
+        {}
       end
 
       {

--- a/back/spec/acceptance/phase_insights/voting_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/voting_phase_insights_spec.rb
@@ -253,7 +253,7 @@ resource 'Phase insights' do
         expect(attributes[:group_by]).to be_nil
         expect(attributes[:custom_field_id]).to be_nil
         expect(attributes[:input_type]).to be_nil
-        expect(attributes[:options]).to eq([])
+        expect(attributes[:options]).to eq({})
         expect(attributes[:ideas]).to contain_exactly(
           {
             id: voting_phase.project.ideas.find_by(title_multiloc: { en: 'Idea 1' }).id,
@@ -308,12 +308,11 @@ resource 'Phase insights' do
         expect(attributes[:group_by]).to eq('gender')
         expect(attributes[:custom_field_id]).to eq(custom_field_gender.id)
         expect(attributes[:input_type]).to eq('select')
-        expect(attributes[:options]).to contain_exactly(
-          { male: { id: custom_field_option_male.id, title_multiloc: { en: 'Male' } }, ordering: custom_field_option_male.ordering },
-          { female: { id: custom_field_option_female.id, title_multiloc: { en: 'Female' } }, ordering: custom_field_option_female.ordering },
-          { unspecified: { id: custom_field_option_other.id, title_multiloc: { en: 'Unspecified' } }, ordering: custom_field_option_other.ordering }
-        )
-
+        expect(attributes[:options]).to eq({
+          male: { title_multiloc: { en: 'Male' }, ordering: custom_field_option_male.ordering },
+          female: { title_multiloc: { en: 'Female' }, ordering: custom_field_option_female.ordering },
+          unspecified: { title_multiloc: { en: 'Unspecified' }, ordering: custom_field_option_other.ordering }
+        })
         expect(attributes[:ideas]).to contain_exactly(
           {
             id: voting_phase.project.ideas.find_by(title_multiloc: { en: 'Idea 1' }).id,
@@ -413,11 +412,11 @@ resource 'Phase insights' do
           expect(attributes[:group_by]).to eq('gender')
           expect(attributes[:custom_field_id]).to eq(custom_field_gender.id)
           expect(attributes[:input_type]).to eq('select')
-          expect(attributes[:options]).to contain_exactly(
-            { male: { id: custom_field_option_male.id, title_multiloc: { en: 'Male' } }, ordering: custom_field_option_male.ordering },
-            { female: { id: custom_field_option_female.id, title_multiloc: { en: 'Female' } }, ordering: custom_field_option_female.ordering },
-            { unspecified: { id: custom_field_option_other.id, title_multiloc: { en: 'Unspecified' } }, ordering: custom_field_option_other.ordering }
-          )
+          expect(attributes[:options]).to eq({
+            male: { title_multiloc: { en: 'Male' }, ordering: custom_field_option_male.ordering },
+            female: { title_multiloc: { en: 'Female' }, ordering: custom_field_option_female.ordering },
+            unspecified: { title_multiloc: { en: 'Unspecified' }, ordering: custom_field_option_other.ordering }
+          })
 
           expect(attributes[:ideas]).to contain_exactly(
             {

--- a/back/spec/services/insights/voting_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/voting_phase_insights_service_spec.rb
@@ -238,7 +238,7 @@ RSpec.describe Insights::VotingPhaseInsightsService do
       expect(result[:group_by]).to be_nil
       expect(result[:custom_field_id]).to be_nil
       expect(result[:input_type]).to be_nil
-      expect(result[:options]).to eq([])
+      expect(result[:options]).to eq({})
 
       expect(result[:ideas]).to contain_exactly(
         {
@@ -276,11 +276,11 @@ RSpec.describe Insights::VotingPhaseInsightsService do
       expect(result[:group_by]).to eq('gender')
       expect(result[:custom_field_id]).to eq(custom_field.id)
       expect(result[:input_type]).to eq('select')
-      expect(result[:options]).to eq([
-        { male: { id: custom_field.options.find_by(key: 'male').id, title_multiloc: { 'en' => 'Male' } }, ordering: 0 },
-        { female: { id: custom_field.options.find_by(key: 'female').id, title_multiloc: { 'en' => 'Female' } }, ordering: 1 },
-        { unspecified: { id: custom_field.options.find_by(key: 'unspecified').id, title_multiloc: { 'en' => 'Unspecified' } }, ordering: 2 }
-      ])
+      expect(result[:options]).to eq({
+        'male' => { title_multiloc: { 'en' => 'Male' }, ordering: 0 },
+        'female' => { title_multiloc: { 'en' => 'Female' }, ordering: 1 },
+        'unspecified' => { title_multiloc: { 'en' => 'Unspecified' }, ordering: 2 }
+      })
 
       expect(result[:ideas]).to contain_exactly(
         {
@@ -329,10 +329,10 @@ RSpec.describe Insights::VotingPhaseInsightsService do
       expect(result[:group_by]).to eq('multiselect')
       expect(result[:custom_field_id]).to eq(custom_field.id)
       expect(result[:input_type]).to eq('multiselect')
-      expect(result[:options]).to eq([
-        { option_a: { id: custom_field.options.find_by(key: 'option_a').id, title_multiloc: { 'en' => 'Option A' } }, ordering: 0 },
-        { option_b: { id: custom_field.options.find_by(key: 'option_b').id, title_multiloc: { 'en' => 'Option B' } }, ordering: 1 }
-      ])
+      expect(result[:options]).to eq({
+        'option_a' => { title_multiloc: { 'en' => 'Option A' }, ordering: 0 },
+        'option_b' => { title_multiloc: { 'en' => 'Option B' }, ordering: 1 }
+      })
 
       expect(result[:ideas]).to contain_exactly(
         {
@@ -376,7 +376,7 @@ RSpec.describe Insights::VotingPhaseInsightsService do
       expect(result[:group_by]).to eq('checkbox')
       expect(result[:custom_field_id]).to eq(custom_field.id)
       expect(result[:input_type]).to eq('checkbox')
-      expect(result[:options]).to eq([])
+      expect(result[:options]).to eq({})
 
       expect(result[:ideas]).to contain_exactly(
         {
@@ -430,7 +430,7 @@ RSpec.describe Insights::VotingPhaseInsightsService do
         expect(result[:group_by]).to eq('birthyear')
         expect(result[:custom_field_id]).to eq(custom_field.id)
         expect(result[:input_type]).to eq('number')
-        expect(result[:options]).to eq([])
+        expect(result[:options]).to eq({})
 
         expect(result[:ideas]).to contain_exactly(
           {

--- a/front/app/api/phase_insights/voting_insights/types.ts
+++ b/front/app/api/phase_insights/voting_insights/types.ts
@@ -1,5 +1,3 @@
-import { DemographicOption } from '../types';
-
 export interface VotingDemographicBreakdown {
   count: number;
   percentage: number;
@@ -7,18 +5,12 @@ export interface VotingDemographicBreakdown {
 
 /**
  * Backend format for demographic options.
- * Each option is a record with:
- * - An optional 'ordering' key with a number value
- * - One other key-value pair where:
- *   - The key is the demographic field key (e.g., 'gender', 'birthyear')
- *   - The value is an object with id and title_multiloc (for select/multiselect/checkbox fields)
+ * Each option contains title_multiloc and ordering.
+ * The options are returned as an object keyed by option key (e.g., 'male', 'female').
  */
 export type BackendDemographicOption = {
-  ordering?: number;
-  [demographicKey: string]:
-    | { id: string; title_multiloc: Record<string, string> }
-    | number
-    | undefined;
+  title_multiloc: Record<string, string>;
+  ordering: number;
 };
 
 export interface VotingIdeaResult {
@@ -39,13 +31,8 @@ export interface VotingPhaseVotesAttributes {
   group_by?: string;
   custom_field_id?: string;
   input_type?: string;
-  options?: BackendDemographicOption[];
+  options?: Record<string, BackendDemographicOption>;
   ideas: VotingIdeaResult[];
-}
-
-export interface TransformedVotingPhaseVotesAttributes
-  extends Omit<VotingPhaseVotesAttributes, 'options'> {
-  options?: Record<string, DemographicOption>;
 }
 
 export interface VotingPhaseVotesData {
@@ -56,16 +43,6 @@ export interface VotingPhaseVotesData {
 
 export interface VotingPhaseVotes {
   data: VotingPhaseVotesData;
-}
-
-export interface TransformedVotingPhaseVotesData {
-  type: 'voting_phase_votes';
-  id: string;
-  attributes: TransformedVotingPhaseVotesAttributes;
-}
-
-export interface TransformedVotingPhaseVotes {
-  data: TransformedVotingPhaseVotesData;
 }
 
 export type DemographicFieldKey = 'gender' | 'birthyear' | 'domicile' | string;


### PR DESCRIPTION
# Changelog
## Technical
- [TAN-6120] Align format of custom field options in voting phase insights response with format in base phase insights response (Behind FF - in development)
