### PR TITLE
[TAN-6249] Add participation location tracking

### DIFF
--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -16,6 +16,7 @@ class ApplicationController < ActionController::API
 
   before_action :authenticate_user
   before_action :set_policy_context
+  before_action :set_current_location_headers
 
   after_action :verify_authorized, except: :index
   after_action :verify_policy_scoped, only: :index
@@ -199,6 +200,10 @@ class ApplicationController < ActionController::API
     if project_preview_token && AppConfiguration.instance.feature_activated?('project_preview_link')
       policy_context[:project_preview_token] = project_preview_token
     end
+  end
+
+  def set_current_location_headers
+    Current.location_headers = ParticipationLocationService.extract_location_headers(request.headers)
   end
 end
 

--- a/back/app/controllers/web_api/v1/phases_controller.rb
+++ b/back/app/controllers/web_api/v1/phases_controller.rb
@@ -191,9 +191,11 @@ class WebApi::V1::PhasesController < ApplicationController
         native_survey_button_multiloc: CL2_SUPPORTED_LOCALES
       }
     ]
+
     if AppConfiguration.instance.feature_activated? 'disable_disliking'
       permitted += %i[reacting_dislike_enabled reacting_dislike_method reacting_dislike_limited_max]
     end
+
     params.require(:phase).permit(permitted)
   end
 

--- a/back/app/models/basket.rb
+++ b/back/app/models/basket.rb
@@ -22,6 +22,7 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class Basket < ApplicationRecord
+  include LocationTrackableParticipation
   belongs_to :phase
 
   belongs_to :user, optional: true
@@ -36,7 +37,7 @@ class Basket < ApplicationRecord
   scope :submitted, -> { where.not(submitted_at: nil) }
   scope :not_submitted, -> { where(submitted_at: nil) }
 
-  delegate :project_id, to: :phase
+  delegate :project_id, :project, to: :phase
 
   def submitted?
     !!submitted_at

--- a/back/app/models/comment.rb
+++ b/back/app/models/comment.rb
@@ -37,11 +37,14 @@
 #
 class Comment < ApplicationRecord
   include AnonymousParticipation
+  include LocationTrackableParticipation
 
   acts_as_nested_set dependent: :destroy, counter_cache: :children_count
 
-  belongs_to :author, class_name: 'User', optional: true
   belongs_to :idea
+  delegate :project_id, :project, to: :idea
+
+  belongs_to :author, class_name: 'User', optional: true
   has_many :reactions, as: :reactable, dependent: :destroy
   has_many :likes, -> { where(mode: 'up') }, as: :reactable, class_name: 'Reaction'
   has_many :dislikes, -> { where(mode: 'down') }, as: :reactable, class_name: 'Reaction'
@@ -78,9 +81,6 @@ class Comment < ApplicationRecord
   validates :publication_status, presence: true, inclusion: { in: PUBLICATION_STATUSES }
 
   scope :published, -> { where publication_status: 'published' }
-
-  delegate :project_id, to: :idea
-  delegate :project, to: :idea
 
   def published?
     publication_status == 'published'

--- a/back/app/models/concerns/location_trackable_participation.rb
+++ b/back/app/models/concerns/location_trackable_participation.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module LocationTrackableParticipation
+  extend ActiveSupport::Concern
+
+  included do
+    has_one :participation_location, as: :trackable, dependent: :destroy, inverse_of: :trackable
+    after_create :track_participation_location
+  end
+
+  private
+
+  def track_participation_location
+    ParticipationLocationService.track(self, Current.location_headers)
+  rescue StandardError => e
+    # A tracking error should not prevent the creation of the participation.
+    Rails.logger.error("Failed to track participation location: #{e.message}")
+    ErrorReporter.report(e)
+  end
+end

--- a/back/app/models/current.rb
+++ b/back/app/models/current.rb
@@ -2,6 +2,7 @@
 
 class Current < ActiveSupport::CurrentAttributes
   attribute :tenant, :app_configuration
+  attribute :location_headers
   private :tenant=, :app_configuration=
 
   def app_configuration

--- a/back/app/models/idea.rb
+++ b/back/app/models/idea.rb
@@ -67,6 +67,7 @@ class Idea < ApplicationRecord
   include AnonymousParticipation
   include Files::FileAttachable
   include ClaimableParticipation
+  include LocationTrackableParticipation
   extend OrderAsSpecified
 
   PUBLICATION_STATUSES = %w[draft submitted published].freeze

--- a/back/app/models/participation_location.rb
+++ b/back/app/models/participation_location.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: participation_locations
+#
+#  id             :uuid             not null, primary key
+#  trackable_type :string           not null
+#  trackable_id   :uuid             not null
+#  country_code   :string(2)
+#  country_name   :string
+#  city           :string
+#  region         :string
+#  latitude       :decimal(9, 6)
+#  longitude      :decimal(9, 6)
+#  asn            :integer
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
+# Indexes
+#
+#  index_participation_locations_on_trackable  (trackable_type,trackable_id) UNIQUE
+#
+class ParticipationLocation < ApplicationRecord
+  TRACKABLE_TYPES = %w[Idea Comment Reaction Basket].freeze
+
+  belongs_to :trackable, polymorphic: true
+
+  validates :trackable, presence: true
+  validates :trackable_type, inclusion: { in: TRACKABLE_TYPES }
+  validates :trackable_id, uniqueness: { scope: :trackable_type }
+  validates :country_code, length: { is: 2 }, allow_nil: true
+end

--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -25,6 +25,7 @@
 #  header_bg_alt_text_multiloc  :jsonb
 #  hidden                       :boolean          default(FALSE), not null
 #  listed                       :boolean          default(TRUE), not null
+#  track_participation_location :boolean          default(FALSE), not null
 #
 # Indexes
 #

--- a/back/app/models/reaction.rb
+++ b/back/app/models/reaction.rb
@@ -23,6 +23,7 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class Reaction < ApplicationRecord
+  include LocationTrackableParticipation
   # Neutral mode is only valid for ideas. Also, currently, it only makes sense the context
   # of "Common Ground" participation. However, we don't make it a hard constraint, since
   # the participation method can be changed and this could result to invalid reactions.
@@ -68,9 +69,7 @@ class Reaction < ApplicationRecord
     mode == 'neutral'
   end
 
-  def project_id
-    reactable.try(:project_id)
-  end
+  delegate :project_id, :project, to: :reactable, allow_nil: true
 
   private
 

--- a/back/app/policies/project_policy.rb
+++ b/back/app/policies/project_policy.rb
@@ -163,6 +163,11 @@ class ProjectPolicy < ApplicationPolicy
     if AppConfiguration.instance.feature_activated? 'disable_disliking'
       shared += %i[reacting_dislike_enabled reacting_dislike_method reacting_dislike_limited_max]
     end
+
+    if AppConfiguration.instance.feature_activated? 'participation_location_tracking'
+      shared += %i[track_participation_location]
+    end
+
     shared
   end
 

--- a/back/app/serializers/web_api/v1/project_serializer.rb
+++ b/back/app/serializers/web_api/v1/project_serializer.rb
@@ -14,7 +14,8 @@ class WebApi::V1::ProjectSerializer < WebApi::V1::BaseSerializer
     :created_at,
     :updated_at,
     :header_bg_alt_text_multiloc,
-    :listed
+    :listed,
+    :track_participation_location
   )
 
   attribute :folder_id do |project|

--- a/back/app/services/participation_location_service.rb
+++ b/back/app/services/participation_location_service.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class ParticipationLocationService
+  class << self
+    def extract_location_headers(headers)
+      {
+        country_code: headers['CloudFront-Viewer-Country'],
+        country_name: headers['CloudFront-Viewer-Country-Name'],
+        region: headers['CloudFront-Viewer-Country-Region-Name'],
+        city: headers['CloudFront-Viewer-City'],
+        latitude: parse_decimal(headers['CloudFront-Viewer-Latitude']),
+        longitude: parse_decimal(headers['CloudFront-Viewer-Longitude']),
+        asn: parse_integer(headers['CloudFront-Viewer-ASN'])
+      }
+    end
+
+    def track(trackable, location_attrs)
+      return unless should_track?(trackable)
+
+      attrs = location_attrs&.compact_blank
+      if attrs.blank?
+        ErrorReporter.report_msg(
+          'Location tracking enabled but no location data available',
+          extra: { trackable_type: trackable.class.name, trackable_id: trackable.id }
+        )
+        return
+      end
+
+      ParticipationLocation.create!(trackable: trackable, **attrs)
+    end
+
+    private
+
+    def should_track?(trackable)
+      AppConfiguration.instance.feature_activated?('participation_location_tracking') &&
+        trackable.project&.track_participation_location
+    end
+
+    def parse_decimal(value)
+      BigDecimal(value.to_s, exception: false)
+    end
+
+    def parse_integer(value)
+      Integer(value.to_s, exception: false)
+    end
+  end
+end

--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -1117,6 +1117,18 @@
         }
       },
 
+      "participation_location_tracking": {
+        "type": "object",
+        "title": "Participation location tracking",
+        "description": "Tracks the geographic location of participants when they submit ideas, comments, reactions, or votes. Only the city, country, and coordinates are stored. IP addresses are not collected.",
+        "additionalProperties": false,
+        "required": ["allowed", "enabled"],
+        "properties": {
+          "allowed": { "type": "boolean", "default": false },
+          "enabled": { "type": "boolean", "default": false }
+        }
+      },
+
       "anonymous_participation": {
         "type": "object",
         "title": "Anonymous participation",

--- a/back/db/migrate/20251222000001_create_participation_locations.rb
+++ b/back/db/migrate/20251222000001_create_participation_locations.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class CreateParticipationLocations < ActiveRecord::Migration[7.1]
+  def change
+    create_table :participation_locations, id: :uuid do |t|
+      t.references :trackable, polymorphic: true, type: :uuid, null: false, index: false
+
+      # Location data
+      t.string :country_code, limit: 2 # ISO 3166-1 alpha-2
+      t.string :country_name
+      t.string :city
+      t.string :region
+      t.decimal :latitude, precision: 9, scale: 6
+      t.decimal :longitude, precision: 9, scale: 6
+
+      # Autonomous System Number for future VPN/proxy detection
+      t.integer :asn
+
+      t.timestamps
+    end
+
+    add_index :participation_locations, %i[trackable_type trackable_id], unique: true, name: 'index_participation_locations_on_trackable'
+  end
+end

--- a/back/db/migrate/20251222000002_add_track_participation_location_to_projects.rb
+++ b/back/db/migrate/20251222000002_add_track_participation_location_to_projects.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddTrackParticipationLocationToProjects < ActiveRecord::Migration[7.1]
+  def change
+    add_column :projects, :track_participation_location, :boolean, default: false, null: false
+  end
+end

--- a/back/db/structure.sql
+++ b/back/db/structure.sql
@@ -247,6 +247,7 @@ DROP INDEX IF EXISTS public.index_permissions_on_action;
 DROP INDEX IF EXISTS public.index_permissions_custom_fields_on_permission_id;
 DROP INDEX IF EXISTS public.index_permissions_custom_fields_on_custom_field_id;
 DROP INDEX IF EXISTS public.index_permission_field;
+DROP INDEX IF EXISTS public.index_participation_locations_on_trackable;
 DROP INDEX IF EXISTS public.index_onboarding_campaign_dismissals_on_user_id;
 DROP INDEX IF EXISTS public.index_official_feedbacks_on_user_id;
 DROP INDEX IF EXISTS public.index_official_feedbacks_on_idea_id;
@@ -519,6 +520,7 @@ ALTER TABLE IF EXISTS ONLY public.phases DROP CONSTRAINT IF EXISTS phases_pkey;
 ALTER TABLE IF EXISTS ONLY public.phase_files DROP CONSTRAINT IF EXISTS phase_files_pkey;
 ALTER TABLE IF EXISTS ONLY public.permissions DROP CONSTRAINT IF EXISTS permissions_pkey;
 ALTER TABLE IF EXISTS ONLY public.permissions_custom_fields DROP CONSTRAINT IF EXISTS permissions_custom_fields_pkey;
+ALTER TABLE IF EXISTS ONLY public.participation_locations DROP CONSTRAINT IF EXISTS participation_locations_pkey;
 ALTER TABLE IF EXISTS ONLY public.static_pages DROP CONSTRAINT IF EXISTS pages_pkey;
 ALTER TABLE IF EXISTS ONLY public.static_page_files DROP CONSTRAINT IF EXISTS page_files_pkey;
 ALTER TABLE IF EXISTS ONLY public.onboarding_campaign_dismissals DROP CONSTRAINT IF EXISTS onboarding_campaign_dismissals_pkey;
@@ -647,6 +649,7 @@ DROP TABLE IF EXISTS public.polls_options;
 DROP TABLE IF EXISTS public.phase_files;
 DROP TABLE IF EXISTS public.permissions_custom_fields;
 DROP TABLE IF EXISTS public.permissions;
+DROP TABLE IF EXISTS public.participation_locations;
 DROP TABLE IF EXISTS public.onboarding_campaign_dismissals;
 DROP TABLE IF EXISTS public.notifications;
 DROP TABLE IF EXISTS public.nav_bar_items;
@@ -1378,7 +1381,8 @@ CREATE TABLE public.projects (
     preview_token character varying NOT NULL,
     header_bg_alt_text_multiloc jsonb DEFAULT '{}'::jsonb,
     hidden boolean DEFAULT false NOT NULL,
-    listed boolean DEFAULT true NOT NULL
+    listed boolean DEFAULT true NOT NULL,
+    track_participation_location boolean DEFAULT false NOT NULL
 );
 
 
@@ -3169,6 +3173,26 @@ CREATE TABLE public.onboarding_campaign_dismissals (
 
 
 --
+-- Name: participation_locations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.participation_locations (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    trackable_type character varying NOT NULL,
+    trackable_id uuid NOT NULL,
+    country_code character varying(2),
+    country_name character varying,
+    city character varying,
+    region character varying,
+    latitude numeric(9,6),
+    longitude numeric(9,6),
+    asn integer,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
 -- Name: permissions; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -4512,6 +4536,14 @@ ALTER TABLE ONLY public.static_page_files
 
 ALTER TABLE ONLY public.static_pages
     ADD CONSTRAINT pages_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: participation_locations participation_locations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.participation_locations
+    ADD CONSTRAINT participation_locations_pkey PRIMARY KEY (id);
 
 
 --
@@ -6461,6 +6493,13 @@ CREATE INDEX index_onboarding_campaign_dismissals_on_user_id ON public.onboardin
 
 
 --
+-- Name: index_participation_locations_on_trackable; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_participation_locations_on_trackable ON public.participation_locations USING btree (trackable_type, trackable_id);
+
+
+--
 -- Name: index_permission_field; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -8287,6 +8326,8 @@ SET search_path TO public,shared_extensions;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20251224101437'),
+('20251222000002'),
+('20251222000001'),
 ('20251217110845'),
 ('20251212135514'),
 ('20251209135529'),

--- a/back/engines/commercial/multi_tenancy/db/seeds/tenants.rb
+++ b/back/engines/commercial/multi_tenancy/db/seeds/tenants.rb
@@ -586,6 +586,10 @@ module MultiTenancy
               enabled: true,
               allowed: true
             },
+            participation_location_tracking: {
+              enabled: false,
+              allowed: false
+            },
             post_participation_signup: {
               enabled: true,
               allowed: true

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/create_tenant.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/create_tenant.rake
@@ -359,6 +359,10 @@ namespace :cl2_back do
           enabled: true,
           allowed: true
         },
+        participation_location_tracking: {
+          enabled: false,
+          allowed: false
+        },
         post_participation_signup: {
           enabled: true,
           allowed: true

--- a/back/spec/factories/participation_locations.rb
+++ b/back/spec/factories/participation_locations.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  # This factory fails when:
+  # - the `participation_location_tracking` feature is enabled, and
+  # - Current.location_headers is set.
+  #
+  # In that case, a participation location is automatically created
+  # alongside the trackable, which prevents the factory from creating
+  # a second one.
+  factory :participation_location do
+    association :trackable, factory: :idea
+  end
+end

--- a/back/spec/models/basket_spec.rb
+++ b/back/spec/models/basket_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Basket do
+  it_behaves_like 'location_trackable_participation'
+
   context 'Default factory' do
     it 'is valid' do
       expect(build(:basket)).to be_valid

--- a/back/spec/models/comment_spec.rb
+++ b/back/spec/models/comment_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Comment do
+  it_behaves_like 'location_trackable_participation'
+
   describe 'Default factory' do
     it 'is valid' do
       expect(build(:comment)).to be_valid

--- a/back/spec/models/idea_spec.rb
+++ b/back/spec/models/idea_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Idea do
   end
 
   it_behaves_like 'claimable_participation'
+  it_behaves_like 'location_trackable_participation'
 
   describe 'title validation' do
     it 'requires title_multiloc when title_multiloc_required? is true' do

--- a/back/spec/models/participation_location_spec.rb
+++ b/back/spec/models/participation_location_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ParticipationLocation do
+  subject(:location) { build(:participation_location) }
+
+  it { is_expected.to be_valid }
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:trackable) }
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:trackable) }
+    it { is_expected.to validate_inclusion_of(:trackable_type).in_array(described_class::TRACKABLE_TYPES) }
+    it { is_expected.to validate_length_of(:country_code).is_equal_to(2).allow_nil }
+    it { is_expected.to validate_uniqueness_of(:trackable_id).scoped_to(:trackable_type).case_insensitive }
+  end
+end

--- a/back/spec/models/reaction_spec.rb
+++ b/back/spec/models/reaction_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe Reaction do
     it { is_expected.to belong_to(:reactable) }
   end
 
+  it_behaves_like 'location_trackable_participation'
+
   context 'Default factory' do
     it 'is valid' do
       expect(build(:reaction)).to be_valid

--- a/back/spec/services/participation_location_service_spec.rb
+++ b/back/spec/services/participation_location_service_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ParticipationLocationService do
+  describe '.extract_location_headers' do
+    it 'extracts and casts location headers from request headers' do
+      headers = {
+        'CloudFront-Viewer-Country' => 'BE',
+        'CloudFront-Viewer-Country-Name' => 'Belgium',
+        'CloudFront-Viewer-Country-Region-Name' => 'Brussels-Capital Region',
+        'CloudFront-Viewer-City' => 'Brussels',
+        'CloudFront-Viewer-Latitude' => '50.8503',
+        'CloudFront-Viewer-Longitude' => '4.3517',
+        'CloudFront-Viewer-ASN' => '12345'
+      }
+
+      result = described_class.extract_location_headers(headers)
+
+      expect(result).to eq(
+        country_code: 'BE',
+        country_name: 'Belgium',
+        region: 'Brussels-Capital Region',
+        city: 'Brussels',
+        latitude: BigDecimal('50.8503'),
+        longitude: BigDecimal('4.3517'),
+        asn: 12_345
+      )
+    end
+
+    it 'returns nil for missing headers' do
+      expect(described_class.extract_location_headers({})).to eq(
+        country_code: nil,
+        country_name: nil,
+        region: nil,
+        city: nil,
+        latitude: nil,
+        longitude: nil,
+        asn: nil
+      )
+    end
+
+    it 'handles invalid numeric values gracefully' do
+      headers = {
+        'CloudFront-Viewer-Country' => 'BE',
+        'CloudFront-Viewer-Latitude' => 'invalid',
+        'CloudFront-Viewer-ASN' => '1.1' # ASN should be an integer
+      }
+
+      result = described_class.extract_location_headers(headers)
+
+      expect(result).to include(country_code: 'BE', latitude: nil, asn: nil)
+    end
+  end
+
+  describe '.track' do
+    let(:project) { create(:project, track_participation_location: true) }
+    let(:idea) { create(:idea, project: project) }
+    let(:location_attrs) do
+      {
+        country_code: 'BE',
+        country_name: 'Belgium',
+        region: 'Brussels-Capital Region',
+        city: 'Brussels',
+        latitude: BigDecimal('50.8503'),
+        longitude: BigDecimal('4.3517'),
+        asn: 12_345
+      }
+    end
+
+    context 'when tracking is enabled' do
+      before { SettingsService.new.activate_feature!('participation_location_tracking') }
+
+      it 'creates a record with correct data' do
+        expect { described_class.track(idea, location_attrs) }
+          .to change(ParticipationLocation, :count).by(1)
+
+        expect(idea.reload.participation_location).to have_attributes(location_attrs)
+      end
+
+      it 'creates a record with partial data' do
+        described_class.track(idea, { country_code: 'US', country_name: 'United States' })
+
+        expect(idea.reload.participation_location).to have_attributes(
+          country_code: 'US',
+          country_name: 'United States'
+        )
+      end
+
+      it 'does not create a record for nil attrs' do
+        expect { described_class.track(idea, nil) }.not_to change(ParticipationLocation, :count)
+      end
+
+      it 'does not create a record for empty attrs' do
+        expect { described_class.track(idea, {}) }.not_to change(ParticipationLocation, :count)
+      end
+
+      it 'does not create a record when all values are nil' do
+        nil_attrs = { country_code: nil, city: nil, latitude: nil, longitude: nil, asn: nil }
+        expect { described_class.track(idea, nil_attrs) }.not_to change(ParticipationLocation, :count)
+      end
+    end
+
+    context 'when feature is disabled' do
+      before { SettingsService.new.deactivate_feature!('participation_location_tracking') }
+
+      it 'does not create a record' do
+        expect { described_class.track(idea, location_attrs) }
+          .not_to change(ParticipationLocation, :count)
+      end
+    end
+
+    context 'when project tracking is disabled' do
+      before do
+        SettingsService.new.activate_feature!('participation_location_tracking')
+        project.update!(track_participation_location: false)
+      end
+
+      it 'does not create a record' do
+        expect { described_class.track(idea, location_attrs) }
+          .not_to change(ParticipationLocation, :count)
+      end
+    end
+  end
+end

--- a/back/spec/support/shared_examples/location_trackable_participation.rb
+++ b/back/spec/support/shared_examples/location_trackable_participation.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Shared examples for testing the LocationTrackableParticipation concern.
+# Usage: it_behaves_like 'location_trackable_participation'
+RSpec.shared_examples 'location_trackable_participation' do |factory_name: nil|
+  let(:trackable) do
+    factory_name ||= described_class.model_name.singular.to_sym
+    instance = build(factory_name)
+    instance.project.update!(track_participation_location: true)
+    instance
+  end
+
+  describe 'participation_location association' do
+    it { is_expected.to have_one(:participation_location).dependent(:destroy) }
+  end
+
+  describe 'location tracking' do
+    it 'creates a ParticipationLocation when tracking is enabled' do
+      raise '`trackable` must not be persisted' if trackable.persisted?
+
+      SettingsService.new.activate_feature!('participation_location_tracking')
+      Current.location_headers = { country_code: 'BE', city: 'Brussels' }
+
+      trackable.save!
+
+      expect(trackable.reload.participation_location).to have_attributes(
+        country_code: 'BE',
+        city: 'Brussels'
+      )
+    end
+
+    it 'does not prevent creation when tracking fails' do
+      allow(ParticipationLocationService).to receive(:track).and_raise(StandardError.new('test error'))
+      allow(ErrorReporter).to receive(:report)
+
+      expect { create(factory_name) }.to change(described_class, :count).by(1)
+    end
+  end
+end

--- a/front/app/api/app_configuration/types.ts
+++ b/front/app/api/app_configuration/types.ts
@@ -273,6 +273,7 @@ export interface IAppConfigurationSettings {
   project_importer?: AppConfigurationFeature;
   idea_feed?: AppConfigurationFeature;
   ideation_accountless_posting?: AppConfigurationFeature;
+  participation_location_tracking?: AppConfigurationFeature;
   post_participation_signup?: AppConfigurationFeature;
   phase_insights?: AppConfigurationFeature;
 }


### PR DESCRIPTION
# Changelog
## Added
  - [TAN-6249] Added (optional) participation location tracking: Optionally capture approximate geographic location (country, city, region) when users submit ideas, comments, reactions, or votes. This feature is not yet accessible in the UI; it can be enabled on demand (at the project level) and data can be exported upon request.