### PR TITLE
[TAN-6300] Do not include not submitted surveys in phase insights participations

### DIFF
--- a/back/app/services/insights/native_survey_phase_insights_service.rb
+++ b/back/app/services/insights/native_survey_phase_insights_service.rb
@@ -4,7 +4,7 @@ module Insights
 
     def phase_participations
       # Events are not associated with phase, so attending_event not included at phase-level.
-      { posting_idea: participations_posting_idea }
+      { posting_idea: participations_submitting_idea }
     end
 
     def ideas_in_phase
@@ -16,7 +16,7 @@ module Insights
       end
     end
 
-    def participations_posting_idea
+    def participations_submitting_idea
       ideas_in_phase.map do |idea|
         {
           item_id: idea.id,

--- a/back/app/services/insights/native_survey_phase_insights_service.rb
+++ b/back/app/services/insights/native_survey_phase_insights_service.rb
@@ -16,9 +16,8 @@ module Insights
         {
           item_id: idea.id,
           action: 'submitting_idea',
-          acted_at: idea.created_at,
+          acted_at: idea.submitted_at,
           classname: 'Idea',
-          survey_submitted_at: idea&.submitted_at,
           participant_id: participant_id(idea.id, idea.author_id, idea.author_hash),
           user_custom_field_values: idea&.custom_field_values || {}
         }
@@ -56,9 +55,9 @@ module Insights
       ideas_last_7_days_count = phase_ideas.where(created_at: 7.days.ago..).count
       ideas_previous_7_days_count = phase_ideas.where(created_at: 14.days.ago...7.days.ago).count
 
-      submitted_last_7_days_count = participations[:submitting_idea].count { |p| p[:survey_submitted_at] >= 7.days.ago }
+      submitted_last_7_days_count = participations[:submitting_idea].count { |p| p[:acted_at] >= 7.days.ago }
       submitted_previous_7_days_count = participations[:submitting_idea].count do |p|
-        p[:survey_submitted_at] < 7.days.ago && p[:survey_submitted_at] >= 14.days.ago
+        p[:acted_at] < 7.days.ago && p[:acted_at] >= 14.days.ago
       end
 
       completion_rate_last_7_days = completion_rate(ideas_last_7_days_count, submitted_last_7_days_count)

--- a/back/app/services/insights/native_survey_phase_insights_service.rb
+++ b/back/app/services/insights/native_survey_phase_insights_service.rb
@@ -12,7 +12,7 @@ module Insights
         end_time = @phase.end_at ? @phase.end_at.end_of_day : Time.current.end_of_day
         @phase.ideas
           .transitive(false)
-          .where('ideas.created_at >= ? AND ideas.created_at <= ?', @phase.start_at.beginning_of_day, end_time)
+          .where(created_at: @phase.start_at.beginning_of_day..end_time)
       end
     end
 
@@ -59,8 +59,8 @@ module Insights
 
       return result unless phase_has_run_more_than_14_days?
 
-      ideas_last_7_days_count = ideas_in_phase.where('ideas.created_at >= ?', 7.days.ago).count
-      ideas_previous_7_days_count = ideas_in_phase.where('ideas.created_at < ? AND ideas.created_at >= ?', 7.days.ago, 14.days.ago).count
+      ideas_last_7_days_count = ideas_in_phase.where(created_at: 7.days.ago..).count
+      ideas_previous_7_days_count = ideas_in_phase.where(created_at: 14.days.ago...7.days.ago).count
 
       submitted_survey_participations = participations[:posting_idea].select { |p| p[:survey_submitted_at].present? }
 

--- a/back/app/services/insights/native_survey_phase_insights_service.rb
+++ b/back/app/services/insights/native_survey_phase_insights_service.rb
@@ -63,9 +63,6 @@ module Insights
       completion_rate_last_7_days = completion_rate(ideas_last_7_days_count, submitted_last_7_days_count)
       completion_rate_previous_7_days = completion_rate(ideas_previous_7_days_count, submitted_previous_7_days_count)
 
-      # puts "Last 7 days - Ideas: #{ideas_last_7_days_count}, Submitted: #{submitted_last_7_days_count}, Completion Rate: #{completion_rate_last_7_days}"
-      # puts "Previous 7 days - Ideas: #{ideas_previous_7_days_count}, Submitted: #{submitted_previous_7_days_count}, Completion Rate: #{completion_rate_previous_7_days}"
-
       result[:surveys_submitted_7_day_change] = percentage_change(submitted_previous_7_days_count, submitted_last_7_days_count)
       result[:completion_rate_7_day_change] = percentage_change(completion_rate_previous_7_days, completion_rate_last_7_days)
 

--- a/back/app/services/insights/native_survey_phase_insights_service.rb
+++ b/back/app/services/insights/native_survey_phase_insights_service.rb
@@ -4,7 +4,7 @@ module Insights
 
     def phase_participations
       # Events are not associated with phase, so attending_event not included at phase-level.
-      { posting_idea: participations_submitting_idea }
+      { submitting_idea: participations_submitting_idea }
     end
 
     def phase_ideas
@@ -15,7 +15,7 @@ module Insights
       phase_ideas.published.map do |idea|
         {
           item_id: idea.id,
-          action: 'posting_idea',
+          action: 'submitting_idea',
           acted_at: idea.created_at,
           classname: 'Idea',
           survey_submitted_at: idea&.submitted_at,
@@ -27,7 +27,7 @@ module Insights
 
     def phase_participation_method_metrics(participations)
       posted_ideas_count = phase_ideas.count
-      submitted_survey_participations = participations[:posting_idea].select { |p| p[:survey_submitted_at].present? }
+      submitted_survey_participations = participations[:submitting_idea].select { |p| p[:survey_submitted_at].present? }
       total_submitted_surveys = submitted_survey_participations.count
       completion_rate = completion_rate(posted_ideas_count, total_submitted_surveys)
       rolling_7_day_changes = rolling_7_day_changes(participations)
@@ -57,7 +57,7 @@ module Insights
       ideas_last_7_days_count = phase_ideas.where(created_at: 7.days.ago..).count
       ideas_previous_7_days_count = phase_ideas.where(created_at: 14.days.ago...7.days.ago).count
 
-      submitted_survey_participations = participations[:posting_idea].select { |p| p[:survey_submitted_at].present? }
+      submitted_survey_participations = participations[:submitting_idea].select { |p| p[:survey_submitted_at].present? }
 
       submitted_last_7_days_count = submitted_survey_participations.count { |p| p[:survey_submitted_at] >= 7.days.ago }
       submitted_previous_7_days_count = submitted_survey_participations.count do |p|

--- a/back/app/services/insights/native_survey_phase_insights_service.rb
+++ b/back/app/services/insights/native_survey_phase_insights_service.rb
@@ -27,8 +27,7 @@ module Insights
 
     def phase_participation_method_metrics(participations)
       posted_ideas_count = phase_ideas.count
-      submitted_survey_participations = participations[:submitting_idea].select { |p| p[:survey_submitted_at].present? }
-      total_submitted_surveys = submitted_survey_participations.count
+      total_submitted_surveys = participations[:submitting_idea].count
       completion_rate = completion_rate(posted_ideas_count, total_submitted_surveys)
       rolling_7_day_changes = rolling_7_day_changes(participations)
 
@@ -57,10 +56,8 @@ module Insights
       ideas_last_7_days_count = phase_ideas.where(created_at: 7.days.ago..).count
       ideas_previous_7_days_count = phase_ideas.where(created_at: 14.days.ago...7.days.ago).count
 
-      submitted_survey_participations = participations[:submitting_idea].select { |p| p[:survey_submitted_at].present? }
-
-      submitted_last_7_days_count = submitted_survey_participations.count { |p| p[:survey_submitted_at] >= 7.days.ago }
-      submitted_previous_7_days_count = submitted_survey_participations.count do |p|
+      submitted_last_7_days_count = participations[:submitting_idea].count { |p| p[:survey_submitted_at] >= 7.days.ago }
+      submitted_previous_7_days_count = participations[:submitting_idea].count do |p|
         p[:survey_submitted_at] < 7.days.ago && p[:survey_submitted_at] >= 14.days.ago
       end
 

--- a/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
@@ -47,7 +47,7 @@ resource 'Phase insights' do
       ns_user5 = create(:user)
 
       # Ideas
-      create(:idea, phases: [phase], created_at: 25.days.ago, author: ns_user1, creation_phase_id: phase.id) # created & published before phase (not counted)
+      create(:idea, phases: [phase], created_at: 25.days.ago, submitted_at: 25.days.ago, author: ns_user1, creation_phase_id: phase.id) # created & published before phase (still counted)
 
       # created and submitted during native survey phase (in week before last)
       create(
@@ -61,7 +61,7 @@ resource 'Phase insights' do
       )
 
       create(:idea, phases: [phase], created_at: 5.days.ago, submitted_at: 5.days.ago, author: ns_user2, creation_phase_id: phase.id) # created during phase, and in last 7 days
-      create(:idea, phases: [phase], created_at: 2.days.ago, submitted_at: 2.days.ago, author: ns_user3, creation_phase_id: phase.id) # created & published after phase (not counted)
+      create(:idea, phases: [phase], created_at: 2.days.ago, submitted_at: 2.days.ago, author: ns_user3, creation_phase_id: phase.id, custom_field_values: { gender: 'male', birthyear: 1990 }) # created & published after phase (still counted), and in last 7 days
 
       # created during native survey phase (in week before last), not submitted (considered incomplete, affecting completion rate)
       create(
@@ -107,15 +107,15 @@ resource 'Phase insights' do
       expect(metrics).to eq({
         visitors: 3,
         visitors_7_day_change: -50.0, # from 2 (in week before last) to 1 unique visitor (in last 7 days) = -50% decrease
-        participants: 2,
-        participants_7_day_change: -50.0, # from 2 (in week before last) to 1 unique participant (in last 7 days) = -50% decrease
-        participation_rate: 0.667,
-        participation_rate_7_day_change: 0.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
+        participants: 3,
+        participants_7_day_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
+        participation_rate: 1.0,
+        participation_rate_7_day_change: 300.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
         native_survey: {
-          surveys_submitted: 2,
-          surveys_submitted_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) = 0% change
-          completion_rate: 0.667,
-          completion_rate_7_day_change: 100.0 # completion_rate_last_7_days: 1.0, completion_rate_previous_7_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1)
+          surveys_submitted: 4,
+          surveys_submitted_7_day_change: 100.0, # from 1 (in week before last) to 2 (in last 7 days) = +100% change
+          completion_rate: 0.8, # 4 submitted surveys out of 5 ideas
+          completion_rate_7_day_change: 100.0 # completion_rate_last_7_days: 1.0, completion_rate_previous_7_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1) = +100% change
         }
       })
 
@@ -123,15 +123,17 @@ resource 'Phase insights' do
       expect(participants_and_visitors_chart_data).to eq({
         resolution: 'day',
         timeseries: [
+          { participants: 1, visitors: 0, date_group: '2025-11-07' },
           { participants: 0, visitors: 1, date_group: '2025-11-17' },
-          { participants: 2, visitors: 2, date_group: '2025-11-20' },
-          { participants: 1, visitors: 1, date_group: '2025-11-27' }
+          { participants: 1, visitors: 2, date_group: '2025-11-20' },
+          { participants: 1, visitors: 1, date_group: '2025-11-27' },
+          { participants: 1, visitors: 0, date_group: '2025-11-30' },
         ]
       })
     end
 
     include_examples 'phase insights demographics',
-      gender_blank: 0,
-      birthyear_blank: 0
+      gender_blank: 1,
+      birthyear_blank: 1
   end
 end

--- a/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
@@ -127,7 +127,7 @@ resource 'Phase insights' do
           { participants: 0, visitors: 1, date_group: '2025-11-17' },
           { participants: 1, visitors: 2, date_group: '2025-11-20' },
           { participants: 1, visitors: 1, date_group: '2025-11-27' },
-          { participants: 1, visitors: 0, date_group: '2025-11-30' },
+          { participants: 1, visitors: 0, date_group: '2025-11-30' }
         ]
       })
     end

--- a/back/spec/services/insights/native_survey_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/native_survey_phase_insights_service_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe Insights::NativeSurveyPhaseInsightsService do
         action: 'submitting_idea',
         acted_at: a_kind_of(Time),
         classname: 'Idea',
-        survey_submitted_at: idea1.submitted_at,
         participant_id: user1.id,
         user_custom_field_values: {}
       }, {
@@ -43,7 +42,6 @@ RSpec.describe Insights::NativeSurveyPhaseInsightsService do
         action: 'submitting_idea',
         acted_at: a_kind_of(Time),
         classname: 'Idea',
-        survey_submitted_at: idea2.submitted_at,
         participant_id: user1.id,
         user_custom_field_values: {}
       }, {
@@ -51,7 +49,6 @@ RSpec.describe Insights::NativeSurveyPhaseInsightsService do
         action: 'submitting_idea',
         acted_at: a_kind_of(Time),
         classname: 'Idea',
-        survey_submitted_at: idea3.submitted_at,
         participant_id: user1.id,
         user_custom_field_values: {}
       }, {
@@ -59,7 +56,6 @@ RSpec.describe Insights::NativeSurveyPhaseInsightsService do
         action: 'submitting_idea',
         acted_at: a_kind_of(Time),
         classname: 'Idea',
-        survey_submitted_at: idea4.submitted_at,
         participant_id: user2.id,
         user_custom_field_values: {}
       }, {
@@ -67,7 +63,6 @@ RSpec.describe Insights::NativeSurveyPhaseInsightsService do
         action: 'submitting_idea',
         acted_at: a_kind_of(Time),
         classname: 'Idea',
-        survey_submitted_at: idea6.submitted_at,
         participant_id: 'some_author_hash',
         user_custom_field_values: {}
       }, {
@@ -75,7 +70,6 @@ RSpec.describe Insights::NativeSurveyPhaseInsightsService do
         action: 'submitting_idea',
         acted_at: a_kind_of(Time),
         classname: 'Idea',
-        survey_submitted_at: idea7.submitted_at,
         participant_id: idea7.id,
         user_custom_field_values: {}
       })

--- a/back/spec/services/insights/native_survey_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/native_survey_phase_insights_service_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe Insights::NativeSurveyPhaseInsightsService do
   let(:phase) { create(:native_survey_phase, start_at: 17.days.ago, end_at: 2.days.ago) }
 
   let(:user1) { create(:user) }
-  let!(:idea1) { create(:idea, phases: [phase], created_at: 20.days.ago, submitted_at: 20.days.ago, author: user1, creation_phase_id: phase.id) } # before phase start
+  let!(:idea1) { create(:idea, phases: [phase], created_at: 20.days.ago, submitted_at: 20.days.ago, author: user1, creation_phase_id: phase.id) } # before phase start (should still be included)
   let!(:idea2) { create(:idea, phases: [phase], created_at: 10.days.ago, submitted_at: 10.days.ago, author: user1, creation_phase_id: phase.id) } # during phase, in week before last
-  let!(:idea3) { create(:idea, phases: [phase], created_at: 1.day.ago, submitted_at: 1.day.ago, author: user1, creation_phase_id: phase.id) } # after phase end
+  let!(:idea3) { create(:idea, phases: [phase], created_at: 1.day.ago, submitted_at: 1.day.ago, author: user1, creation_phase_id: phase.id) } # after phase end (should still be included)
 
   let(:user2) { create(:user) }
   let!(:idea4) { create(:idea, phases: [phase], created_at: 5.days.ago, submitted_at: 5.days.ago, author: user2, creation_phase_id: phase.id) } # during phase, in last 7 days
@@ -30,12 +30,30 @@ RSpec.describe Insights::NativeSurveyPhaseInsightsService do
     it 'returns the participation ideas posted data for non-transitive ideas created during phase' do
       participations_submitting_idea = service.send(:participations_submitting_idea)
 
+      pp idea1
+
       expect(participations_submitting_idea).to contain_exactly({
+        item_id: idea1.id,
+        action: 'posting_idea',
+        acted_at: a_kind_of(Time),
+        classname: 'Idea',
+        survey_submitted_at: idea1.submitted_at,
+        participant_id: user1.id,
+        user_custom_field_values: {}
+      }, {
         item_id: idea2.id,
         action: 'posting_idea',
         acted_at: a_kind_of(Time),
         classname: 'Idea',
         survey_submitted_at: idea2.submitted_at,
+        participant_id: user1.id,
+        user_custom_field_values: {}
+      } , {
+        item_id: idea3.id,
+        action: 'posting_idea',
+        acted_at: a_kind_of(Time),
+        classname: 'Idea',
+        survey_submitted_at: idea3.submitted_at,
         participant_id: user1.id,
         user_custom_field_values: {}
       }, {
@@ -44,14 +62,6 @@ RSpec.describe Insights::NativeSurveyPhaseInsightsService do
         acted_at: a_kind_of(Time),
         classname: 'Idea',
         survey_submitted_at: idea4.submitted_at,
-        participant_id: user2.id,
-        user_custom_field_values: {}
-      }, {
-        item_id: idea5.id,
-        action: 'posting_idea',
-        acted_at: a_kind_of(Time),
-        classname: 'Idea',
-        survey_submitted_at: nil,
         participant_id: user2.id,
         user_custom_field_values: {}
       }, {
@@ -81,14 +91,14 @@ RSpec.describe Insights::NativeSurveyPhaseInsightsService do
       phase.update!(end_at: nil)
       participations_submitting_idea = service.send(:participations_submitting_idea)
 
-      expect(participations_submitting_idea.pluck(:item_id)).to contain_exactly(idea2.id, idea3.id, idea4.id, idea5.id, idea6.id, idea7.id)
+      expect(participations_submitting_idea.pluck(:item_id)).to contain_exactly(idea1.id, idea2.id, idea3.id, idea4.id, idea6.id, idea7.id)
     end
 
-    it 'includes draft ideas' do
+    it 'does not include draft ideas' do
       participations_submitting_idea = service.send(:participations_submitting_idea)
 
       idea_ids = participations_submitting_idea.map { |p| p[:item_id] }
-      expect(idea_ids).to include(idea5.id)
+      expect(idea_ids).not_to include(idea5.id)
     end
 
     it 'does not include transitive ideas' do
@@ -109,7 +119,7 @@ RSpec.describe Insights::NativeSurveyPhaseInsightsService do
         posting_idea: service.send(:participations_submitting_idea)
       })
 
-      expect(participations[:posting_idea].map { |p| p[:item_id] }).to contain_exactly(idea2.id, idea4.id, idea5.id, idea6.id, idea7.id)
+      expect(participations[:posting_idea].map { |p| p[:item_id] }).to contain_exactly(idea1.id, idea2.id, idea3.id, idea4.id, idea6.id, idea7.id)
     end
   end
 
@@ -120,9 +130,9 @@ RSpec.describe Insights::NativeSurveyPhaseInsightsService do
       metrics = service.send(:phase_participation_method_metrics, participations)
 
       expect(metrics).to eq({
-        surveys_submitted: 4,
-        surveys_submitted_7_day_change: -66.7, # from 3 (in week before last) to 1 (in last 7 days) = -66.7% change
-        completion_rate: 0.8, # 4 submitted surveys out of 5 ideas created during phase
+        surveys_submitted: 6,
+        surveys_submitted_7_day_change: -33.3, # from 3 (in week before last) to 2 (in last 7 days) = -33.3% change
+        completion_rate: 0.857, # 6 submitted surveys out of 7 ideas created during phase
         completion_rate_7_day_change: 33.3 # completion_rate_last_7_days: 1.0, completion_rate_previous_7_days: 0.75 = 33.3% change
       })
     end

--- a/back/spec/services/insights/native_survey_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/native_survey_phase_insights_service_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Insights::NativeSurveyPhaseInsightsService do
 
       expect(participations_submitting_idea).to contain_exactly({
         item_id: idea1.id,
-        action: 'posting_idea',
+        action: 'submitting_idea',
         acted_at: a_kind_of(Time),
         classname: 'Idea',
         survey_submitted_at: idea1.submitted_at,
@@ -42,7 +42,7 @@ RSpec.describe Insights::NativeSurveyPhaseInsightsService do
         user_custom_field_values: {}
       }, {
         item_id: idea2.id,
-        action: 'posting_idea',
+        action: 'submitting_idea',
         acted_at: a_kind_of(Time),
         classname: 'Idea',
         survey_submitted_at: idea2.submitted_at,
@@ -50,7 +50,7 @@ RSpec.describe Insights::NativeSurveyPhaseInsightsService do
         user_custom_field_values: {}
       }, {
         item_id: idea3.id,
-        action: 'posting_idea',
+        action: 'submitting_idea',
         acted_at: a_kind_of(Time),
         classname: 'Idea',
         survey_submitted_at: idea3.submitted_at,
@@ -58,7 +58,7 @@ RSpec.describe Insights::NativeSurveyPhaseInsightsService do
         user_custom_field_values: {}
       }, {
         item_id: idea4.id,
-        action: 'posting_idea',
+        action: 'submitting_idea',
         acted_at: a_kind_of(Time),
         classname: 'Idea',
         survey_submitted_at: idea4.submitted_at,
@@ -66,7 +66,7 @@ RSpec.describe Insights::NativeSurveyPhaseInsightsService do
         user_custom_field_values: {}
       }, {
         item_id: idea6.id,
-        action: 'posting_idea',
+        action: 'submitting_idea',
         acted_at: a_kind_of(Time),
         classname: 'Idea',
         survey_submitted_at: idea6.submitted_at,
@@ -74,7 +74,7 @@ RSpec.describe Insights::NativeSurveyPhaseInsightsService do
         user_custom_field_values: {}
       }, {
         item_id: idea7.id,
-        action: 'posting_idea',
+        action: 'submitting_idea',
         acted_at: a_kind_of(Time),
         classname: 'Idea',
         survey_submitted_at: idea7.submitted_at,
@@ -116,10 +116,10 @@ RSpec.describe Insights::NativeSurveyPhaseInsightsService do
       participations = service.send(:phase_participations)
 
       expect(participations).to eq({
-        posting_idea: service.send(:participations_submitting_idea)
+        submitting_idea: service.send(:participations_submitting_idea)
       })
 
-      expect(participations[:posting_idea].map { |p| p[:item_id] }).to contain_exactly(idea1.id, idea2.id, idea3.id, idea4.id, idea6.id, idea7.id)
+      expect(participations[:submitting_idea].map { |p| p[:item_id] }).to contain_exactly(idea1.id, idea2.id, idea3.id, idea4.id, idea6.id, idea7.id)
     end
   end
 

--- a/back/spec/services/insights/native_survey_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/native_survey_phase_insights_service_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Insights::NativeSurveyPhaseInsightsService do
         survey_submitted_at: idea2.submitted_at,
         participant_id: user1.id,
         user_custom_field_values: {}
-      } , {
+      }, {
         item_id: idea3.id,
         action: 'posting_idea',
         acted_at: a_kind_of(Time),

--- a/back/spec/services/insights/native_survey_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/native_survey_phase_insights_service_spec.rb
@@ -30,8 +30,6 @@ RSpec.describe Insights::NativeSurveyPhaseInsightsService do
     it 'returns the participation ideas posted data for non-transitive ideas created during phase' do
       participations_submitting_idea = service.send(:participations_submitting_idea)
 
-      pp idea1
-
       expect(participations_submitting_idea).to contain_exactly({
         item_id: idea1.id,
         action: 'submitting_idea',


### PR DESCRIPTION
Aligns definition of survey participation with that used elsewhere, (e.g. [here in analytics_fact_participations](https://github.com/CitizenLabDotCo/citizenlab/blob/00296ba965bf30b7a4ad452607a71d88672eead2/back/engines/commercial/analytics/db/views/analytics_fact_participations_v08.sql#L22)), so that only submission of a survey counts as a participation. This is achieved by only including published ideas in `participations_submitting_idea`, since publication is synonymous with survey submission, and `publication_status: 'published'` is what is used by `analytics_fact_participation`. 

Also removes filtering of ideas to include only those with `created_at` date between phase start and end. This simplifies the code considerably. It is also probably a relatively safe approach, since, unlike ideation phases, we would not expect ideas which are survey responses from other phases or projects to be copied to / associated with the survey phase.

# Changelog
## Fixed
- [TAN-6300] Do not include not submitted surveys in phase insights participations (Behind FF - in development)
