### PR TITLE
TAN-6058 Project copy issues

### DIFF
--- a/back/app/services/project_copy_service.rb
+++ b/back/app/services/project_copy_service.rb
@@ -2,6 +2,7 @@
 
 class ProjectCopyService < TemplateService # rubocop:disable Metrics/ClassLength
   def import(template, folder: nil, local_copy: false)
+    fix_project_slugs_in_template!(template)
     # No translation required if it's a local copy
     template, translate_logs = MultiTenancy::Templates::Utils.translate_and_fix_locales(template) unless local_copy
 
@@ -10,10 +11,7 @@ class ProjectCopyService < TemplateService # rubocop:disable Metrics/ClassLength
     end
 
     project = Project.find(created_objects_ids['Project'].first)
-    unless local_copy
-      project.update!(slug: SlugService.new.generate_slug(project, project.slug))
-      project.set_default_input_topics!
-    end
+    project.set_default_input_topics! if !local_copy
     project.update! folder: folder if folder
 
     # Log to a project import if this is a copy from another platform
@@ -814,5 +812,12 @@ class ProjectCopyService < TemplateService # rubocop:disable Metrics/ClassLength
           mappable: CustomField.where(resource: CustomForm.where(participation_context: [@project, *@project.phases]))
         )
       )
+  end
+
+  def fix_project_slugs_in_template!(template)
+    projects = template.dig('models', 'project')
+    projects.each do |project|
+      project['slug'] = SlugService.new.generate_slug(Project.new, project['slug'])
+    end
   end
 end

--- a/back/app/services/project_copy_service.rb
+++ b/back/app/services/project_copy_service.rb
@@ -41,7 +41,7 @@ class ProjectCopyService < TemplateService # rubocop:disable Metrics/ClassLength
     new_publication_status: nil
   )
     include_ideas = false if local_copy
-    max_ideas = max_ideas&.to_i
+    max_ideas = max_ideas.presence&.to_i
     @include_ideas = include_ideas
     @local_copy = local_copy
     @project = project

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/utils.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/utils.rb
@@ -194,7 +194,6 @@ module MultiTenancy
           serialized_models
         end
 
-        # rubocop:disable Metrics/CyclomaticComplexity
         def translate_and_fix_locales(serialized_models)
           translator = MachineTranslations::MachineTranslationService.new
           locales_to = AppConfiguration.instance.settings('core', 'locales')
@@ -236,16 +235,16 @@ module MultiTenancy
                   locales_to.each do |locale|
                     next if field_value.key?(locale) && field_value[locale].present?
 
-                    field_value[locale] = if source_text.blank?
-                      source_text
-                    else
-                      translate_logs[:strings] += 1
-                      translate_logs[:chars] += source_text.length
-                      begin
-                        translator.translate source_text, source_locale, locale, retries: 10
-                      rescue StandardError => e
-                        ErrorReporter.report(e, extra: { model: model_name, field: field_name, from: source_locale, to: locale, text: source_text })
+                    begin
+                      field_value[locale] = if source_text.blank?
+                        source_text
+                      else
+                        translate_logs[:strings] += 1
+                        translate_logs[:chars] += source_text.length
+                        translator.translate source_text, source_locale, locale, retries: 10 
                       end
+                    rescue StandardError => e
+                      ErrorReporter.report(e, extra: { model: model_name, field: field_name, from: source_locale, to: locale, text: source_text })
                     end
                   end
 
@@ -260,7 +259,6 @@ module MultiTenancy
 
           [serialized_models, translate_logs]
         end
-        # rubocop:enable Metrics/CyclomaticComplexity
 
         def user_locales(serialized_models)
           serialized_models = serialized_models.with_indifferent_access

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/utils.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/utils.rb
@@ -241,7 +241,7 @@ module MultiTenancy
                       else
                         translate_logs[:strings] += 1
                         translate_logs[:chars] += source_text.length
-                        translator.translate source_text, source_locale, locale, retries: 10 
+                        translator.translate source_text, source_locale, locale, retries: 10
                       end
                     rescue StandardError => e
                       ErrorReporter.report(e, extra: { model: model_name, field: field_name, from: source_locale, to: locale, text: source_text })

--- a/back/spec/services/project_copy_service_spec.rb
+++ b/back/spec/services/project_copy_service_spec.rb
@@ -32,6 +32,27 @@ describe ProjectCopyService do
       end
     end
 
+    describe 'new_slug' do
+      let(:new_slug) { 'custom-project-slug' }
+
+      it 'preserves the slug if possible' do
+        template = create(:tenant).switch do
+          service.export create(:project), new_slug:
+        end
+        service.import template
+        expect(Project.find_by(slug: 'custom-project-slug')).to be_present
+      end
+
+      it 'generates a unique variation of the slug if a project with the slug already exists' do
+        template = create(:tenant).switch do
+          service.export create(:project), new_slug:
+        end
+        create(:project, slug: 'custom-project-slug')
+        service.import template
+        expect(Project.find_by(slug: 'custom-project-slug')).to be_present
+      end
+    end
+
     it 'successfully copies over native surveys and responses' do
       create(:idea_status_proposed)
 


### PR DESCRIPTION
- Import all ideas when leaving max ideas field empty.
- Prevent crashing during translations (catch and report error, but continue applying the template).
- Don't cut off translations.
- Preserve project slug when possible.

# Changelog
### Fixed
- [TAN-6058] Project copy fixes: Including ideas, preserve chosen slug, don't cut off titles, and don't crash on Google translate issues.
