### PR TITLE
[TAN-6142] Use alphabetical sorting to ensure consistent colors across different timeframes

### DIFF
--- a/front/app/components/admin/GraphCards/DeviceTypesCard/useDeviceTypes.ts
+++ b/front/app/components/admin/GraphCards/DeviceTypesCard/useDeviceTypes.ts
@@ -29,7 +29,10 @@ const useDeviceTypes = ({
 
   const { counts_per_device_type } = data.data.attributes;
 
-  const deviceTypes = keys(counts_per_device_type);
+  // Sort device types alphabetically for consistent colors across timeframes
+  const deviceTypes = keys(counts_per_device_type).toSorted((a, b) =>
+    translations[a].localeCompare(translations[b])
+  );
   const counts = deviceTypes.map(
     (deviceType) => counts_per_device_type[deviceType]
   );

--- a/front/app/components/admin/GraphCards/VisitorsLanguageCard/useVisitorLanguages/parse.ts
+++ b/front/app/components/admin/GraphCards/VisitorsLanguageCard/useVisitorLanguages/parse.ts
@@ -12,10 +12,13 @@ import { PieRow } from './typings';
 export const parsePieData = ({
   sessions_per_locale,
 }: VisitorsLanguagesResponse['data']['attributes']): PieRow[] | null => {
-  const asArray = keys(sessions_per_locale).map((key) => ({
-    locale: key,
-    count: sessions_per_locale[key],
-  }));
+  // Sort by locale name alphabetically for consistent colors across timeframes
+  const asArray = keys(sessions_per_locale)
+    .toSorted((a, b) => a.localeCompare(b))
+    .map((key) => ({
+      locale: key,
+      count: sessions_per_locale[key],
+    }));
 
   const percentages = roundPercentages(asArray.map(({ count }) => count));
 

--- a/front/app/components/admin/GraphCards/VisitorsTrafficSourcesCard/useVisitorReferrerTypes/parse.ts
+++ b/front/app/components/admin/GraphCards/VisitorsTrafficSourcesCard/useVisitorReferrerTypes/parse.ts
@@ -14,7 +14,10 @@ export const parsePieData = (
   }: VisitorsTrafficSourcesResponse['data']['attributes'],
   translations: Translations
 ): PieRow[] | undefined => {
-  const referrerTypes = keys(sessions_per_referrer_type);
+  // Sort by translated name alphabetically for consistent colors across timeframes
+  const referrerTypes = keys(sessions_per_referrer_type).toSorted((a, b) =>
+    translations[a].localeCompare(translations[b])
+  );
   if (referrerTypes.length === 0) return undefined;
 
   const counts = referrerTypes.map((key) => sessions_per_referrer_type[key]);


### PR DESCRIPTION
I used alphabetical sorting to fix this issue. I considered using a const array approach for `useDeviceTypes` and `useVisitorReferrerTypes` to ensure absolute color consistency, but opted against it since new device/referrer types could be added in the future and would be silently ignored if not also added to the frontend.

# Changelog
## Fixed
- Fix pie chart colors changing when date range is modified