### PR TITLE
[TAN-6329] Rename some phase insight vars & make percentage floats consistent

### DIFF
--- a/back/app/services/insights/base_phase_insights_service.rb
+++ b/back/app/services/insights/base_phase_insights_service.rb
@@ -51,7 +51,7 @@ module Insights
 
       {
         visitors: visitors_count,
-        visitors_7_day_change: base_7_day_changes[:visitors_7_day_change],
+        visitors_7_day_percent_change: base_7_day_changes[:visitors_7_day_percent_change],
         participants: participants_count,
         participants_7_day_change: base_7_day_changes[:participants_7_day_change],
         participation_rate: visitors_count > 0 ? (participants_count.to_f / visitors_count).round(3) : 0,
@@ -82,7 +82,7 @@ module Insights
       participation_rate_previous_7_days = visitors_previous_7_days_count > 0 ? (participants_previous_7_days_count.to_f / visitors_previous_7_days_count).round(3) : 0
 
       {
-        visitors_7_day_change: percentage_change(visitors_previous_7_days_count, visitors_last_7_days_count),
+        visitors_7_day_percent_change: percentage_change(visitors_previous_7_days_count, visitors_last_7_days_count),
         participants_7_day_change: percentage_change(participants_previous_7_days_count, participants_last_7_days_count),
         participation_rate_7_day_change: percentage_change(participation_rate_previous_7_days, participation_rate_last_7_days)
       }

--- a/back/app/services/insights/base_phase_insights_service.rb
+++ b/back/app/services/insights/base_phase_insights_service.rb
@@ -55,7 +55,7 @@ module Insights
         participants: participants_count,
         participants_7_day_change: base_7_day_changes[:participants_7_day_change],
         participation_rate: visitors_count > 0 ? (participants_count.to_f / visitors_count).round(3) : 0,
-        participation_rate_7_day_change: base_7_day_changes[:participation_rate_7_day_change]
+        participation_rate_7_day_percent_change: base_7_day_changes[:participation_rate_7_day_percent_change]
       }
     end
 
@@ -84,7 +84,7 @@ module Insights
       {
         visitors_7_day_percent_change: percentage_change(visitors_previous_7_days_count, visitors_last_7_days_count),
         participants_7_day_change: percentage_change(participants_previous_7_days_count, participants_last_7_days_count),
-        participation_rate_7_day_change: percentage_change(participation_rate_previous_7_days, participation_rate_last_7_days)
+        participation_rate_7_day_percent_change: percentage_change(participation_rate_previous_7_days, participation_rate_last_7_days)
       }
     end
 

--- a/back/app/services/insights/base_phase_insights_service.rb
+++ b/back/app/services/insights/base_phase_insights_service.rb
@@ -60,7 +60,6 @@ module Insights
     end
 
     def base_7_day_changes(participations, visits)
-      puts "participations: #{participations.inspect}"
       flattened_participations = participations.values.flatten
 
       participants_last_7_days_count = flattened_participations.select do |p|
@@ -70,9 +69,6 @@ module Insights
       participants_previous_7_days_count = flattened_participations.select do |p|
         p[:acted_at] < 7.days.ago && p[:acted_at] >= 14.days.ago
       end.pluck(:participant_id).uniq.count
-
-      puts "participants_last_7_days_count: #{participants_last_7_days_count}"
-      puts "participants_previous_7_days_count: #{participants_previous_7_days_count}"
 
       visitors_last_7_days_count = visits.select do |v|
         v[:acted_at] >= 7.days.ago

--- a/back/app/services/insights/base_phase_insights_service.rb
+++ b/back/app/services/insights/base_phase_insights_service.rb
@@ -54,7 +54,7 @@ module Insights
         visitors_7_day_percent_change: base_7_day_changes[:visitors_7_day_percent_change],
         participants: participants_count,
         participants_7_day_percent_change: base_7_day_changes[:participants_7_day_percent_change],
-        participation_rate: visitors_count > 0 ? (participants_count.to_f / visitors_count).round(3) : 0,
+        participation_rate_as_percent: visitors_count > 0 ? ((participants_count.to_f / visitors_count) * 100).round(1) : 0,
         participation_rate_7_day_percent_change: base_7_day_changes[:participation_rate_7_day_percent_change]
       }
     end

--- a/back/app/services/insights/base_phase_insights_service.rb
+++ b/back/app/services/insights/base_phase_insights_service.rb
@@ -53,13 +53,14 @@ module Insights
         visitors: visitors_count,
         visitors_7_day_percent_change: base_7_day_changes[:visitors_7_day_percent_change],
         participants: participants_count,
-        participants_7_day_change: base_7_day_changes[:participants_7_day_change],
+        participants_7_day_percent_change: base_7_day_changes[:participants_7_day_percent_change],
         participation_rate: visitors_count > 0 ? (participants_count.to_f / visitors_count).round(3) : 0,
         participation_rate_7_day_percent_change: base_7_day_changes[:participation_rate_7_day_percent_change]
       }
     end
 
     def base_7_day_changes(participations, visits)
+      puts "participations: #{participations.inspect}"
       flattened_participations = participations.values.flatten
 
       participants_last_7_days_count = flattened_participations.select do |p|
@@ -69,6 +70,9 @@ module Insights
       participants_previous_7_days_count = flattened_participations.select do |p|
         p[:acted_at] < 7.days.ago && p[:acted_at] >= 14.days.ago
       end.pluck(:participant_id).uniq.count
+
+      puts "participants_last_7_days_count: #{participants_last_7_days_count}"
+      puts "participants_previous_7_days_count: #{participants_previous_7_days_count}"
 
       visitors_last_7_days_count = visits.select do |v|
         v[:acted_at] >= 7.days.ago
@@ -83,7 +87,7 @@ module Insights
 
       {
         visitors_7_day_percent_change: percentage_change(visitors_previous_7_days_count, visitors_last_7_days_count),
-        participants_7_day_change: percentage_change(participants_previous_7_days_count, participants_last_7_days_count),
+        participants_7_day_percent_change: percentage_change(participants_previous_7_days_count, participants_last_7_days_count),
         participation_rate_7_day_percent_change: percentage_change(participation_rate_previous_7_days, participation_rate_last_7_days)
       }
     end

--- a/back/app/services/insights/base_phase_insights_service.rb
+++ b/back/app/services/insights/base_phase_insights_service.rb
@@ -107,6 +107,7 @@ module Insights
     end
 
     def percentage_change(old_value, new_value)
+      return nil unless phase_has_run_more_than_14_days?
       return 0.0 if old_value == new_value # Includes case where both are zero
       return 'last_7_days_compared_with_zero' if old_value.zero? # Infinite percentage change (avoid division by zero)
 

--- a/back/app/services/insights/common_ground_phase_insights_service.rb
+++ b/back/app/services/insights/common_ground_phase_insights_service.rb
@@ -37,9 +37,9 @@ module Insights
       {
         associated_ideas: associated_published_ideas_count,
         ideas_posted: participations[:posting_idea].count,
-        ideas_posted_7_day_change: participations_7_day_change(participations[:posting_idea]),
+        ideas_posted_7_day_percent_change: participations_7_day_change(participations[:posting_idea]),
         reactions: participations[:reacting_idea].count,
-        reactions_7_day_change: participations_7_day_change(participations[:reacting_idea])
+        reactions_7_day_percent_change: participations_7_day_change(participations[:reacting_idea])
       }
     end
   end

--- a/back/app/services/insights/ideation_phase_insights_service.rb
+++ b/back/app/services/insights/ideation_phase_insights_service.rb
@@ -79,11 +79,11 @@ module Insights
     def phase_participation_method_metrics(participations)
       {
         ideas_posted: participations[:posting_idea].count,
-        ideas_posted_7_day_change: participations_7_day_change(participations[:posting_idea]),
+        ideas_posted_7_day_percent_change: participations_7_day_change(participations[:posting_idea]),
         comments_posted: participations[:commenting_idea].count,
-        comments_posted_7_day_change: participations_7_day_change(participations[:commenting_idea]),
+        comments_posted_7_day_percent_change: participations_7_day_change(participations[:commenting_idea]),
         reactions: participations[:reacting_idea].count,
-        reactions_7_day_change: participations_7_day_change(participations[:reacting_idea])
+        reactions_7_day_percent_change: participations_7_day_change(participations[:reacting_idea])
       }
     end
   end

--- a/back/app/services/insights/native_survey_phase_insights_service.rb
+++ b/back/app/services/insights/native_survey_phase_insights_service.rb
@@ -27,21 +27,21 @@ module Insights
     def phase_participation_method_metrics(participations)
       posted_ideas_count = phase_ideas.count
       total_submitted_surveys = participations[:submitting_idea].count
-      completion_rate = completion_rate(posted_ideas_count, total_submitted_surveys)
+      completion_rate_as_percent = completion_rate_as_percent(posted_ideas_count, total_submitted_surveys)
       rolling_7_day_changes = rolling_7_day_changes(participations)
 
       {
         surveys_submitted: total_submitted_surveys,
         surveys_submitted_7_day_change: rolling_7_day_changes[:surveys_submitted_7_day_change],
-        completion_rate: completion_rate,
+        completion_rate_as_percent: completion_rate_as_percent,
         completion_rate_7_day_change: rolling_7_day_changes[:completion_rate_7_day_change]
       }
     end
 
-    def completion_rate(all, submitted)
+    def completion_rate_as_percent(all, submitted)
       return 0 if all == 0
 
-      (submitted.to_f / all).round(3)
+      ((submitted.to_f / all) * 100).round(1)
     end
 
     def rolling_7_day_changes(participations)
@@ -60,8 +60,8 @@ module Insights
         p[:acted_at] < 7.days.ago && p[:acted_at] >= 14.days.ago
       end
 
-      completion_rate_last_7_days = completion_rate(ideas_last_7_days_count, submitted_last_7_days_count)
-      completion_rate_previous_7_days = completion_rate(ideas_previous_7_days_count, submitted_previous_7_days_count)
+      completion_rate_last_7_days = completion_rate_as_percent(ideas_last_7_days_count, submitted_last_7_days_count)
+      completion_rate_previous_7_days = completion_rate_as_percent(ideas_previous_7_days_count, submitted_previous_7_days_count)
 
       result[:surveys_submitted_7_day_change] = percentage_change(submitted_previous_7_days_count, submitted_last_7_days_count)
       result[:completion_rate_7_day_change] = percentage_change(completion_rate_previous_7_days, completion_rate_last_7_days)

--- a/back/app/services/insights/native_survey_phase_insights_service.rb
+++ b/back/app/services/insights/native_survey_phase_insights_service.rb
@@ -32,9 +32,9 @@ module Insights
 
       {
         surveys_submitted: total_submitted_surveys,
-        surveys_submitted_7_day_change: rolling_7_day_changes[:surveys_submitted_7_day_change],
+        surveys_submitted_7_day_percent_change: rolling_7_day_changes[:surveys_submitted_7_day_percent_change],
         completion_rate_as_percent: completion_rate_as_percent,
-        completion_rate_7_day_change: rolling_7_day_changes[:completion_rate_7_day_change]
+        completion_rate_7_day_percent_change: rolling_7_day_changes[:completion_rate_7_day_percent_change]
       }
     end
 
@@ -46,8 +46,8 @@ module Insights
 
     def rolling_7_day_changes(participations)
       result = {
-        surveys_submitted_7_day_change: nil,
-        completion_rate_7_day_change: nil
+        surveys_submitted_7_day_percent_change: nil,
+        completion_rate_7_day_percent_change: nil
       }
 
       return result unless phase_has_run_more_than_14_days?
@@ -63,8 +63,8 @@ module Insights
       completion_rate_last_7_days = completion_rate_as_percent(ideas_last_7_days_count, submitted_last_7_days_count)
       completion_rate_previous_7_days = completion_rate_as_percent(ideas_previous_7_days_count, submitted_previous_7_days_count)
 
-      result[:surveys_submitted_7_day_change] = percentage_change(submitted_previous_7_days_count, submitted_last_7_days_count)
-      result[:completion_rate_7_day_change] = percentage_change(completion_rate_previous_7_days, completion_rate_last_7_days)
+      result[:surveys_submitted_7_day_percent_change] = percentage_change(submitted_previous_7_days_count, submitted_last_7_days_count)
+      result[:completion_rate_7_day_percent_change] = percentage_change(completion_rate_previous_7_days, completion_rate_last_7_days)
 
       result
     end

--- a/back/app/services/insights/poll_phase_insights_service.rb
+++ b/back/app/services/insights/poll_phase_insights_service.rb
@@ -25,7 +25,7 @@ module Insights
     def phase_participation_method_metrics(participations)
       {
         responses: participations[:taking_poll].count,
-        responses_7_day_change: participations_7_day_change(participations[:taking_poll])
+        responses_7_day_percent_change: participations_7_day_change(participations[:taking_poll])
       }
     end
   end

--- a/back/app/services/insights/proposals_phase_insights_service.rb
+++ b/back/app/services/insights/proposals_phase_insights_service.rb
@@ -41,7 +41,7 @@ module Insights
         ideas_posted: participations[:posting_idea].count,
         ideas_posted_7_day_percent_change: participations_7_day_change(participations[:posting_idea]),
         reached_threshold: proposals_reached_threshold.count,
-        reached_threshold_7_day_change: participations_7_day_change(proposals_reached_threshold),
+        reached_threshold_7_day_percent_change: participations_7_day_change(proposals_reached_threshold),
         comments_posted: participations[:commenting_idea].count,
         comments_posted_7_day_percent_change: participations_7_day_change(participations[:commenting_idea]),
         reactions: participations[:reacting_idea].count,

--- a/back/app/services/insights/proposals_phase_insights_service.rb
+++ b/back/app/services/insights/proposals_phase_insights_service.rb
@@ -39,13 +39,13 @@ module Insights
 
       {
         ideas_posted: participations[:posting_idea].count,
-        ideas_posted_7_day_change: participations_7_day_change(participations[:posting_idea]),
+        ideas_posted_7_day_percent_change: participations_7_day_change(participations[:posting_idea]),
         reached_threshold: proposals_reached_threshold.count,
         reached_threshold_7_day_change: participations_7_day_change(proposals_reached_threshold),
         comments_posted: participations[:commenting_idea].count,
-        comments_posted_7_day_change: participations_7_day_change(participations[:commenting_idea]),
+        comments_posted_7_day_percent_change: participations_7_day_change(participations[:commenting_idea]),
         reactions: participations[:reacting_idea].count,
-        reactions_7_day_change: participations_7_day_change(participations[:reacting_idea])
+        reactions_7_day_percent_change: participations_7_day_change(participations[:reacting_idea])
       }
     end
 

--- a/back/app/services/insights/volunteering_phase_insights_service.rb
+++ b/back/app/services/insights/volunteering_phase_insights_service.rb
@@ -26,7 +26,7 @@ module Insights
     def phase_participation_method_metrics(participations)
       {
         volunteerings: participations[:volunteering].count,
-        volunteerings_7_day_change: participations_7_day_change(participations[:volunteering])
+        volunteerings_7_day_percent_change: participations_7_day_change(participations[:volunteering])
       }
     end
   end

--- a/back/app/services/insights/voting_phase_insights_service.rb
+++ b/back/app/services/insights/voting_phase_insights_service.rb
@@ -167,7 +167,7 @@ module Insights
           voters: participations[:voting].pluck(:participant_id).uniq.count,
           voters_7_day_change: common_7_day_changes[:voters_7_day_change],
           comments_posted: participations[:commenting_idea].count,
-          comments_posted_7_day_change: common_7_day_changes[:comments_posted_7_day_change]
+          comments_posted_7_day_percent_change: common_7_day_changes[:comments_posted_7_day_percent_change]
         }
       else
         {
@@ -179,7 +179,7 @@ module Insights
           voters: participations[:voting].pluck(:participant_id).uniq.count,
           voters_7_day_change: common_7_day_changes[:voters_7_day_change],
           comments_posted: participations[:commenting_idea].count,
-          comments_posted_7_day_change: common_7_day_changes[:comments_posted_7_day_change]
+          comments_posted_7_day_percent_change: common_7_day_changes[:comments_posted_7_day_percent_change]
         }
       end
     end
@@ -187,7 +187,7 @@ module Insights
     def common_7_day_changes(participations)
       result = {
         voters_7_day_change: nil,
-        comments_posted_7_day_change: nil
+        comments_posted_7_day_percent_change: nil
       }
 
       return result unless phase_has_run_more_than_14_days?
@@ -205,7 +205,7 @@ module Insights
       end
 
       result[:voters_7_day_change] = percentage_change(voters_previous_7_days, voters_last_7_days)
-      result[:comments_posted_7_day_change] = percentage_change(comments_previous_7_days, comments_last_7_days)
+      result[:comments_posted_7_day_percent_change] = percentage_change(comments_previous_7_days, comments_last_7_days)
 
       result
     end

--- a/back/app/services/insights/voting_phase_insights_service.rb
+++ b/back/app/services/insights/voting_phase_insights_service.rb
@@ -174,7 +174,7 @@ module Insights
           voting_method: @phase.voting_method,
           associated_ideas: associated_published_ideas_count,
           online_votes: participations[:voting].sum { |p| p[:total_votes] },
-          online_votes_7_day_change: online_votes_7_day_change(participations),
+          online_votes_7_day_percent_change: online_votes_7_day_percent_change(participations),
           offline_votes: @phase.manual_votes_count,
           voters: participations[:voting].pluck(:participant_id).uniq.count,
           voters_7_day_percent_change: common_7_day_changes[:voters_7_day_percent_change],
@@ -225,7 +225,7 @@ module Insights
       percentage_change(online_picks_previous_7_days, online_picks_last_7_days)
     end
 
-    def online_votes_7_day_change(participations)
+    def online_votes_7_day_percent_change(participations)
       return nil unless phase_has_run_more_than_14_days?
 
       voting_participations = participations[:voting]

--- a/back/app/services/insights/voting_phase_insights_service.rb
+++ b/back/app/services/insights/voting_phase_insights_service.rb
@@ -162,10 +162,10 @@ module Insights
           voting_method: 'budgeting',
           associated_ideas: associated_published_ideas_count,
           online_picks: participations[:voting].sum { |p| p[:ideas_count] },
-          online_picks_7_day_change: online_picks_7_day_change(participations),
+          online_picks_7_day_percent_change: online_picks_7_day_percent_change(participations),
           offline_picks: @phase.manual_votes_count,
           voters: participations[:voting].pluck(:participant_id).uniq.count,
-          voters_7_day_change: common_7_day_changes[:voters_7_day_change],
+          voters_7_day_percent_change: common_7_day_changes[:voters_7_day_percent_change],
           comments_posted: participations[:commenting_idea].count,
           comments_posted_7_day_percent_change: common_7_day_changes[:comments_posted_7_day_percent_change]
         }
@@ -177,7 +177,7 @@ module Insights
           online_votes_7_day_change: online_votes_7_day_change(participations),
           offline_votes: @phase.manual_votes_count,
           voters: participations[:voting].pluck(:participant_id).uniq.count,
-          voters_7_day_change: common_7_day_changes[:voters_7_day_change],
+          voters_7_day_percent_change: common_7_day_changes[:voters_7_day_percent_change],
           comments_posted: participations[:commenting_idea].count,
           comments_posted_7_day_percent_change: common_7_day_changes[:comments_posted_7_day_percent_change]
         }
@@ -186,7 +186,7 @@ module Insights
 
     def common_7_day_changes(participations)
       result = {
-        voters_7_day_change: nil,
+        voters_7_day_percent_change: nil,
         comments_posted_7_day_percent_change: nil
       }
 
@@ -204,13 +204,13 @@ module Insights
         p[:acted_at] >= 14.days.ago && p[:acted_at] < 7.days.ago
       end
 
-      result[:voters_7_day_change] = percentage_change(voters_previous_7_days, voters_last_7_days)
+      result[:voters_7_day_percent_change] = percentage_change(voters_previous_7_days, voters_last_7_days)
       result[:comments_posted_7_day_percent_change] = percentage_change(comments_previous_7_days, comments_last_7_days)
 
       result
     end
 
-    def online_picks_7_day_change(participations)
+    def online_picks_7_day_percent_change(participations)
       return nil unless phase_has_run_more_than_14_days?
 
       voting_participations = participations[:voting]

--- a/back/engines/commercial/report_builder/app/services/report_builder/queries/participants.rb
+++ b/back/engines/commercial/report_builder/app/services/report_builder/queries/participants.rb
@@ -49,7 +49,7 @@ module ReportBuilder
       response = {
         participants_timeseries: participants_timeseries,
         participants_whole_period: participants_whole_period,
-        participation_rate_whole_period: participation_rate(
+        participation_rate_whole_period: participation_rate_as_percent(
           participants_whole_period,
           start_date,
           end_date,
@@ -68,7 +68,7 @@ module ReportBuilder
           .count('distinct participant_id')
 
         response[:participants_compared_period] = participants_compared_period
-        response[:participation_rate_compared_period] = participation_rate(
+        response[:participation_rate_compared_period] = participation_rate_as_percent(
           participants_compared_period,
           compare_start_at,
           compare_end_at,
@@ -105,7 +105,7 @@ module ReportBuilder
       participations
     end
 
-    def participation_rate(
+    def participation_rate_as_percent(
       participants,
       start_date,
       end_date,

--- a/back/spec/acceptance/phase_insights/common_ground_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/common_ground_phase_insights_spec.rb
@@ -88,7 +88,7 @@ resource 'Phase insights' do
         visitors: 3,
         visitors_7_day_percent_change: 0.0, # from 2 (in week before last) to 2 unique visitors (in last 7 days) = 0% change
         participants: 2,
-        participants_7_day_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
+        participants_7_day_percent_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
         participation_rate: 0.667,
         participation_rate_7_day_percent_change: 100.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1)
         common_ground: {

--- a/back/spec/acceptance/phase_insights/common_ground_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/common_ground_phase_insights_spec.rb
@@ -89,7 +89,7 @@ resource 'Phase insights' do
         visitors_7_day_percent_change: 0.0, # from 2 (in week before last) to 2 unique visitors (in last 7 days) = 0% change
         participants: 2,
         participants_7_day_percent_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
-        participation_rate: 0.667,
+        participation_rate_as_percent: 0.667,
         participation_rate_7_day_percent_change: 100.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1)
         common_ground: {
           associated_ideas: 4,

--- a/back/spec/acceptance/phase_insights/common_ground_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/common_ground_phase_insights_spec.rb
@@ -90,7 +90,7 @@ resource 'Phase insights' do
         participants: 2,
         participants_7_day_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
         participation_rate: 0.667,
-        participation_rate_7_day_change: 100.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1)
+        participation_rate_7_day_percent_change: 100.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1)
         common_ground: {
           associated_ideas: 4,
           ideas_posted: 2,

--- a/back/spec/acceptance/phase_insights/common_ground_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/common_ground_phase_insights_spec.rb
@@ -89,7 +89,7 @@ resource 'Phase insights' do
         visitors_7_day_percent_change: 0.0, # from 2 (in week before last) to 2 unique visitors (in last 7 days) = 0% change
         participants: 2,
         participants_7_day_percent_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
-        participation_rate_as_percent: 0.667,
+        participation_rate_as_percent: 66.7,
         participation_rate_7_day_percent_change: 100.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1)
         common_ground: {
           associated_ideas: 4,

--- a/back/spec/acceptance/phase_insights/common_ground_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/common_ground_phase_insights_spec.rb
@@ -94,9 +94,9 @@ resource 'Phase insights' do
         common_ground: {
           associated_ideas: 4,
           ideas_posted: 2,
-          ideas_posted_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) = 0% change
+          ideas_posted_7_day_percent_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) = 0% change
           reactions: 1,
-          reactions_7_day_change: 'last_7_days_compared_with_zero' # from 0 (in week before last) to 1 (in last 7 days) => avoid division by zero
+          reactions_7_day_percent_change: 'last_7_days_compared_with_zero' # from 0 (in week before last) to 1 (in last 7 days) => avoid division by zero
         }
       })
 

--- a/back/spec/acceptance/phase_insights/common_ground_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/common_ground_phase_insights_spec.rb
@@ -86,7 +86,7 @@ resource 'Phase insights' do
       metrics = json_response_body.dig(:data, :attributes, :metrics)
       expect(metrics).to eq({
         visitors: 3,
-        visitors_7_day_change: 0.0, # from 2 (in week before last) to 2 unique visitors (in last 7 days) = 0% change
+        visitors_7_day_percent_change: 0.0, # from 2 (in week before last) to 2 unique visitors (in last 7 days) = 0% change
         participants: 2,
         participants_7_day_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
         participation_rate: 0.667,

--- a/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
@@ -100,11 +100,11 @@ resource 'Phase insights' do
         participation_rate_7_day_percent_change: 0.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
         ideation: {
           ideas_posted: 2,
-          ideas_posted_7_day_change: 'last_7_days_compared_with_zero', # from 0 (in week before last) to 1 (in last 7 days) => avoid division by zero
+          ideas_posted_7_day_percent_change: 'last_7_days_compared_with_zero', # from 0 (in week before last) to 1 (in last 7 days) => avoid division by zero
           comments_posted: 1,
-          comments_posted_7_day_change: -100.0, # from 1 (in week before last) to 0 (in last 7 days) = -100% decrease
+          comments_posted_7_day_percent_change: -100.0, # from 1 (in week before last) to 0 (in last 7 days) = -100% decrease
           reactions: 1,
-          reactions_7_day_change: 'last_7_days_compared_with_zero' # from 0 (in week before last) to 1 (in last 7 days) => avoid division by zero
+          reactions_7_day_percent_change: 'last_7_days_compared_with_zero' # from 0 (in week before last) to 1 (in last 7 days) => avoid division by zero
         }
       })
 

--- a/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
@@ -97,7 +97,7 @@ resource 'Phase insights' do
         participants: 3,
         participants_7_day_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
         participation_rate: 0.75,
-        participation_rate_7_day_change: 0.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
+        participation_rate_7_day_percent_change: 0.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
         ideation: {
           ideas_posted: 2,
           ideas_posted_7_day_change: 'last_7_days_compared_with_zero', # from 0 (in week before last) to 1 (in last 7 days) => avoid division by zero

--- a/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
@@ -96,7 +96,7 @@ resource 'Phase insights' do
         visitors_7_day_percent_change: 100.0, # from 1 (in week before last) to 2 unique visitors (in last 7 days) = 100% increase
         participants: 3,
         participants_7_day_percent_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
-        participation_rate: 0.75,
+        participation_rate_as_percent: 0.75,
         participation_rate_7_day_percent_change: 0.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
         ideation: {
           ideas_posted: 2,

--- a/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
@@ -96,7 +96,7 @@ resource 'Phase insights' do
         visitors_7_day_percent_change: 100.0, # from 1 (in week before last) to 2 unique visitors (in last 7 days) = 100% increase
         participants: 3,
         participants_7_day_percent_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
-        participation_rate_as_percent: 0.75,
+        participation_rate_as_percent: 75.0,
         participation_rate_7_day_percent_change: 0.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
         ideation: {
           ideas_posted: 2,

--- a/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
@@ -95,7 +95,7 @@ resource 'Phase insights' do
         visitors: 4,
         visitors_7_day_percent_change: 100.0, # from 1 (in week before last) to 2 unique visitors (in last 7 days) = 100% increase
         participants: 3,
-        participants_7_day_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
+        participants_7_day_percent_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
         participation_rate: 0.75,
         participation_rate_7_day_percent_change: 0.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
         ideation: {

--- a/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
@@ -93,7 +93,7 @@ resource 'Phase insights' do
       metrics = json_response_body.dig(:data, :attributes, :metrics)
       expect(metrics).to eq({
         visitors: 4,
-        visitors_7_day_change: 100.0, # from 1 (in week before last) to 2 unique visitors (in last 7 days) = 100% increase
+        visitors_7_day_percent_change: 100.0, # from 1 (in week before last) to 2 unique visitors (in last 7 days) = 100% increase
         participants: 3,
         participants_7_day_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
         participation_rate: 0.75,

--- a/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
@@ -114,7 +114,7 @@ resource 'Phase insights' do
         native_survey: {
           surveys_submitted: 4,
           surveys_submitted_7_day_change: 100.0, # from 1 (in week before last) to 2 (in last 7 days) = +100% change
-          completion_rate: 0.8, # 4 submitted surveys out of 5 ideas
+          completion_rate_as_percent: 0.8, # 4 submitted surveys out of 5 ideas
           completion_rate_7_day_change: 100.0 # completion_rate_last_7_days: 1.0, completion_rate_previous_7_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1) = +100% change
         }
       })

--- a/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
@@ -106,7 +106,7 @@ resource 'Phase insights' do
       metrics = json_response_body.dig(:data, :attributes, :metrics)
       expect(metrics).to eq({
         visitors: 3,
-        visitors_7_day_change: -50.0, # from 2 (in week before last) to 1 unique visitor (in last 7 days) = -50% decrease
+        visitors_7_day_percent_change: -50.0, # from 2 (in week before last) to 1 unique visitor (in last 7 days) = -50% decrease
         participants: 3,
         participants_7_day_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
         participation_rate: 1.0,

--- a/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
@@ -114,7 +114,7 @@ resource 'Phase insights' do
         native_survey: {
           surveys_submitted: 4,
           surveys_submitted_7_day_change: 100.0, # from 1 (in week before last) to 2 (in last 7 days) = +100% change
-          completion_rate_as_percent: 0.8, # 4 submitted surveys out of 5 ideas
+          completion_rate_as_percent: 80.0, # 4 submitted surveys out of 5 ideas
           completion_rate_7_day_change: 100.0 # completion_rate_last_7_days: 1.0, completion_rate_previous_7_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1) = +100% change
         }
       })

--- a/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
@@ -109,7 +109,7 @@ resource 'Phase insights' do
         visitors_7_day_percent_change: -50.0, # from 2 (in week before last) to 1 unique visitor (in last 7 days) = -50% decrease
         participants: 3,
         participants_7_day_percent_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
-        participation_rate: 1.0,
+        participation_rate_as_percent: 1.0,
         participation_rate_7_day_percent_change: 300.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
         native_survey: {
           surveys_submitted: 4,

--- a/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
@@ -108,7 +108,7 @@ resource 'Phase insights' do
         visitors: 3,
         visitors_7_day_percent_change: -50.0, # from 2 (in week before last) to 1 unique visitor (in last 7 days) = -50% decrease
         participants: 3,
-        participants_7_day_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
+        participants_7_day_percent_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
         participation_rate: 1.0,
         participation_rate_7_day_percent_change: 300.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
         native_survey: {

--- a/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
@@ -109,7 +109,7 @@ resource 'Phase insights' do
         visitors_7_day_percent_change: -50.0, # from 2 (in week before last) to 1 unique visitor (in last 7 days) = -50% decrease
         participants: 3,
         participants_7_day_percent_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
-        participation_rate_as_percent: 1.0,
+        participation_rate_as_percent: 100.0,
         participation_rate_7_day_percent_change: 300.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
         native_survey: {
           surveys_submitted: 4,

--- a/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
@@ -113,9 +113,9 @@ resource 'Phase insights' do
         participation_rate_7_day_percent_change: 300.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
         native_survey: {
           surveys_submitted: 4,
-          surveys_submitted_7_day_change: 100.0, # from 1 (in week before last) to 2 (in last 7 days) = +100% change
+          surveys_submitted_7_day_percent_change: 100.0, # from 1 (in week before last) to 2 (in last 7 days) = +100% change
           completion_rate_as_percent: 80.0, # 4 submitted surveys out of 5 ideas
-          completion_rate_7_day_change: 100.0 # completion_rate_last_7_days: 1.0, completion_rate_previous_7_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1) = +100% change
+          completion_rate_7_day_percent_change: 100.0 # completion_rate_last_7_days: 1.0, completion_rate_previous_7_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1) = +100% change
         }
       })
 

--- a/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
@@ -110,7 +110,7 @@ resource 'Phase insights' do
         participants: 3,
         participants_7_day_change: 100.0, # from 1 (in week before last) to 2 unique participants (in last 7 days) = 100% increase
         participation_rate: 1.0,
-        participation_rate_7_day_change: 300.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
+        participation_rate_7_day_percent_change: 300.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
         native_survey: {
           surveys_submitted: 4,
           surveys_submitted_7_day_change: 100.0, # from 1 (in week before last) to 2 (in last 7 days) = +100% change

--- a/back/spec/acceptance/phase_insights/poll_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/poll_phase_insights_spec.rb
@@ -71,7 +71,7 @@ resource 'Phase insights' do
         visitors_7_day_percent_change: -50.0, # from 2 (in week before last) to 1 unique visitor (in last 7 days) = -50% decrease
         participants: 2,
         participants_7_day_percent_change: 0.0, # from 1 (in week before last) to 1 unique participant (in last 7 days) = 0% change
-        participation_rate: 1.0,
+        participation_rate_as_percent: 1.0,
         participation_rate_7_day_percent_change: 100.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1)
         poll: {
           responses: 2,

--- a/back/spec/acceptance/phase_insights/poll_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/poll_phase_insights_spec.rb
@@ -71,7 +71,7 @@ resource 'Phase insights' do
         visitors_7_day_percent_change: -50.0, # from 2 (in week before last) to 1 unique visitor (in last 7 days) = -50% decrease
         participants: 2,
         participants_7_day_percent_change: 0.0, # from 1 (in week before last) to 1 unique participant (in last 7 days) = 0% change
-        participation_rate_as_percent: 1.0,
+        participation_rate_as_percent: 100.0,
         participation_rate_7_day_percent_change: 100.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1)
         poll: {
           responses: 2,

--- a/back/spec/acceptance/phase_insights/poll_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/poll_phase_insights_spec.rb
@@ -75,7 +75,7 @@ resource 'Phase insights' do
         participation_rate_7_day_percent_change: 100.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1)
         poll: {
           responses: 2,
-          responses_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change
+          responses_7_day_percent_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change
         }
       })
 

--- a/back/spec/acceptance/phase_insights/poll_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/poll_phase_insights_spec.rb
@@ -70,7 +70,7 @@ resource 'Phase insights' do
         visitors: 2,
         visitors_7_day_percent_change: -50.0, # from 2 (in week before last) to 1 unique visitor (in last 7 days) = -50% decrease
         participants: 2,
-        participants_7_day_change: 0.0, # from 1 (in week before last) to 1 unique participant (in last 7 days) = 0% change
+        participants_7_day_percent_change: 0.0, # from 1 (in week before last) to 1 unique participant (in last 7 days) = 0% change
         participation_rate: 1.0,
         participation_rate_7_day_percent_change: 100.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1)
         poll: {

--- a/back/spec/acceptance/phase_insights/poll_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/poll_phase_insights_spec.rb
@@ -72,7 +72,7 @@ resource 'Phase insights' do
         participants: 2,
         participants_7_day_change: 0.0, # from 1 (in week before last) to 1 unique participant (in last 7 days) = 0% change
         participation_rate: 1.0,
-        participation_rate_7_day_change: 100.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1)
+        participation_rate_7_day_percent_change: 100.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 0.5 = (((1.0 - 0.5).to_f / 0.5) * 100.0).round(1)
         poll: {
           responses: 2,
           responses_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change

--- a/back/spec/acceptance/phase_insights/poll_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/poll_phase_insights_spec.rb
@@ -68,7 +68,7 @@ resource 'Phase insights' do
       metrics = json_response_body.dig(:data, :attributes, :metrics)
       expect(metrics).to eq({
         visitors: 2,
-        visitors_7_day_change: -50.0, # from 2 (in week before last) to 1 unique visitor (in last 7 days) = -50% decrease
+        visitors_7_day_percent_change: -50.0, # from 2 (in week before last) to 1 unique visitor (in last 7 days) = -50% decrease
         participants: 2,
         participants_7_day_change: 0.0, # from 1 (in week before last) to 1 unique participant (in last 7 days) = 0% change
         participation_rate: 1.0,

--- a/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
@@ -119,7 +119,7 @@ resource 'Phase insights' do
         visitors_7_day_percent_change: 0.0, # from 2 (in week before last) to 2 unique visitors (in last 7 days) = 0% change
         participants: 3,
         participants_7_day_percent_change: 0.0, # from 2 (in week before last) to 2 unique participants (in last 7 days) = 0% change
-        participation_rate: 0.75,
+        participation_rate_as_percent: 0.75,
         participation_rate_7_day_percent_change: 0.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
         proposals: {
           ideas_posted: 2,

--- a/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
@@ -123,13 +123,13 @@ resource 'Phase insights' do
         participation_rate_7_day_percent_change: 0.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
         proposals: {
           ideas_posted: 2,
-          ideas_posted_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) => 0% change
+          ideas_posted_7_day_percent_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) => 0% change
           reached_threshold: 2,
           reached_threshold_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) => 0% change
           comments_posted: 1,
-          comments_posted_7_day_change: -100.0, # from 1 (in week before last) to 0 (in last 7 days) = -100% decrease
+          comments_posted_7_day_percent_change: -100.0, # from 1 (in week before last) to 0 (in last 7 days) = -100% decrease
           reactions: 1,
-          reactions_7_day_change: 'last_7_days_compared_with_zero' # from 0 (in week before last) to 1 (in last 7 days) => avoid division by zero
+          reactions_7_day_percent_change: 'last_7_days_compared_with_zero' # from 0 (in week before last) to 1 (in last 7 days) => avoid division by zero
         }
       })
 

--- a/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
@@ -116,7 +116,7 @@ resource 'Phase insights' do
       metrics = json_response_body.dig(:data, :attributes, :metrics)
       expect(metrics).to eq({
         visitors: 4,
-        visitors_7_day_change: 0.0, # from 2 (in week before last) to 2 unique visitors (in last 7 days) = 0% change
+        visitors_7_day_percent_change: 0.0, # from 2 (in week before last) to 2 unique visitors (in last 7 days) = 0% change
         participants: 3,
         participants_7_day_change: 0.0, # from 2 (in week before last) to 2 unique participants (in last 7 days) = 0% change
         participation_rate: 0.75,

--- a/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
@@ -125,7 +125,7 @@ resource 'Phase insights' do
           ideas_posted: 2,
           ideas_posted_7_day_percent_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) => 0% change
           reached_threshold: 2,
-          reached_threshold_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) => 0% change
+          reached_threshold_7_day_percent_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) => 0% change
           comments_posted: 1,
           comments_posted_7_day_percent_change: -100.0, # from 1 (in week before last) to 0 (in last 7 days) = -100% decrease
           reactions: 1,

--- a/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
@@ -120,7 +120,7 @@ resource 'Phase insights' do
         participants: 3,
         participants_7_day_change: 0.0, # from 2 (in week before last) to 2 unique participants (in last 7 days) = 0% change
         participation_rate: 0.75,
-        participation_rate_7_day_change: 0.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
+        participation_rate_7_day_percent_change: 0.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
         proposals: {
           ideas_posted: 2,
           ideas_posted_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) => 0% change

--- a/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
@@ -118,7 +118,7 @@ resource 'Phase insights' do
         visitors: 4,
         visitors_7_day_percent_change: 0.0, # from 2 (in week before last) to 2 unique visitors (in last 7 days) = 0% change
         participants: 3,
-        participants_7_day_change: 0.0, # from 2 (in week before last) to 2 unique participants (in last 7 days) = 0% change
+        participants_7_day_percent_change: 0.0, # from 2 (in week before last) to 2 unique participants (in last 7 days) = 0% change
         participation_rate: 0.75,
         participation_rate_7_day_percent_change: 0.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
         proposals: {

--- a/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
@@ -119,7 +119,7 @@ resource 'Phase insights' do
         visitors_7_day_percent_change: 0.0, # from 2 (in week before last) to 2 unique visitors (in last 7 days) = 0% change
         participants: 3,
         participants_7_day_percent_change: 0.0, # from 2 (in week before last) to 2 unique participants (in last 7 days) = 0% change
-        participation_rate_as_percent: 0.75,
+        participation_rate_as_percent: 75.0,
         participation_rate_7_day_percent_change: 0.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
         proposals: {
           ideas_posted: 2,

--- a/back/spec/acceptance/phase_insights/volunteering_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/volunteering_phase_insights_spec.rb
@@ -76,7 +76,7 @@ resource 'Phase insights' do
         visitors_7_day_percent_change: 0.0, # from 1 (in week before last) to 1 unique visitor (in last 7 days) = 0% change
         participants: 2,
         participants_7_day_percent_change: 0.0, # from 1 (in week before last) to 1 unique participant (in last 7 days) = 0% change
-        participation_rate: 1.0,
+        participation_rate_as_percent: 1.0,
         participation_rate_7_day_percent_change: 0.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
         volunteering: {
           volunteerings: 3,

--- a/back/spec/acceptance/phase_insights/volunteering_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/volunteering_phase_insights_spec.rb
@@ -76,7 +76,7 @@ resource 'Phase insights' do
         visitors_7_day_percent_change: 0.0, # from 1 (in week before last) to 1 unique visitor (in last 7 days) = 0% change
         participants: 2,
         participants_7_day_percent_change: 0.0, # from 1 (in week before last) to 1 unique participant (in last 7 days) = 0% change
-        participation_rate_as_percent: 1.0,
+        participation_rate_as_percent: 100.0,
         participation_rate_7_day_percent_change: 0.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
         volunteering: {
           volunteerings: 3,

--- a/back/spec/acceptance/phase_insights/volunteering_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/volunteering_phase_insights_spec.rb
@@ -77,7 +77,7 @@ resource 'Phase insights' do
         participants: 2,
         participants_7_day_change: 0.0, # from 1 (in week before last) to 1 unique participant (in last 7 days) = 0% change
         participation_rate: 1.0,
-        participation_rate_7_day_change: 0.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
+        participation_rate_7_day_percent_change: 0.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
         volunteering: {
           volunteerings: 3,
           volunteerings_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change

--- a/back/spec/acceptance/phase_insights/volunteering_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/volunteering_phase_insights_spec.rb
@@ -80,7 +80,7 @@ resource 'Phase insights' do
         participation_rate_7_day_percent_change: 0.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
         volunteering: {
           volunteerings: 3,
-          volunteerings_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change
+          volunteerings_7_day_percent_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change
         }
       })
 

--- a/back/spec/acceptance/phase_insights/volunteering_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/volunteering_phase_insights_spec.rb
@@ -75,7 +75,7 @@ resource 'Phase insights' do
         visitors: 2,
         visitors_7_day_percent_change: 0.0, # from 1 (in week before last) to 1 unique visitor (in last 7 days) = 0% change
         participants: 2,
-        participants_7_day_change: 0.0, # from 1 (in week before last) to 1 unique participant (in last 7 days) = 0% change
+        participants_7_day_percent_change: 0.0, # from 1 (in week before last) to 1 unique participant (in last 7 days) = 0% change
         participation_rate: 1.0,
         participation_rate_7_day_percent_change: 0.0, # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 1.0 = 0% change
         volunteering: {

--- a/back/spec/acceptance/phase_insights/volunteering_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/volunteering_phase_insights_spec.rb
@@ -73,7 +73,7 @@ resource 'Phase insights' do
       metrics = json_response_body.dig(:data, :attributes, :metrics)
       expect(metrics).to eq({
         visitors: 2,
-        visitors_7_day_change: 0.0, # from 1 (in week before last) to 1 unique visitor (in last 7 days) = 0% change
+        visitors_7_day_percent_change: 0.0, # from 1 (in week before last) to 1 unique visitor (in last 7 days) = 0% change
         participants: 2,
         participants_7_day_change: 0.0, # from 1 (in week before last) to 1 unique participant (in last 7 days) = 0% change
         participation_rate: 1.0,

--- a/back/spec/acceptance/phase_insights/voting_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/voting_phase_insights_spec.rb
@@ -138,7 +138,7 @@ resource 'Phase insights' do
           online_votes_7_day_change: 0.0, # from 3 (in week before last) to 3 (in last 7 days) = 0% change
           offline_votes: 3,
           voters: 3,
-          voters_7_day_change: 0.0, # from 2 (in week before last) to 2 unique voters (in last 7 days) = 0% change
+          voters_7_day_percent_change: 0.0, # from 2 (in week before last) to 2 unique voters (in last 7 days) = 0% change
           comments_posted: 3,
           comments_posted_7_day_percent_change: 100.0 # from 1 (in week before last) to 2 (in last 7 days) = 100% increase
         }
@@ -170,10 +170,10 @@ resource 'Phase insights' do
             voting_method: 'budgeting',
             associated_ideas: 3,
             online_picks: 4,
-            online_picks_7_day_change: 0.0, # from 2 (in week before last) to 2 (in last 7 days) = 0% change
+            online_picks_7_day_percent_change: 0.0, # from 2 (in week before last) to 2 (in last 7 days) = 0% change
             offline_picks: 3,
             voters: 3,
-            voters_7_day_change: 0.0, # from 2 (in week before last) to 2 unique voters (in last 7 days) = 0% change
+            voters_7_day_percent_change: 0.0, # from 2 (in week before last) to 2 unique voters (in last 7 days) = 0% change
             comments_posted: 3,
             comments_posted_7_day_percent_change: 100.0 # from 1 (in week before last) to 2 (in last 7 days) = 100% increase
           }

--- a/back/spec/acceptance/phase_insights/voting_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/voting_phase_insights_spec.rb
@@ -129,7 +129,7 @@ resource 'Phase insights' do
         visitors_7_day_percent_change: 25.0, # from 4 (in week before last) to 5 unique visitors (in last 7 days) = 25% increase
         participants: 5,
         participants_7_day_percent_change: 50.0, # from 3 (in week before last) to 5 unique participants (in last 7 days) = 50% increase
-        participation_rate: 0.833,
+        participation_rate_as_percent: 0.833,
         participation_rate_7_day_percent_change: 20.0, # participation_rate_last_7_days: 0.6, participation_rate_previous_7_days: 0.5 = (((0.6 - 0.5).to_f / 0.5) * 100.0).round(1)
         voting: {
           voting_method: 'multiple_voting',
@@ -164,7 +164,7 @@ resource 'Phase insights' do
           visitors_7_day_percent_change: 25.0, # from 4 (in week before last) to 5 unique visitors (in last 7 days) = 25% increase
           participants: 5,
           participants_7_day_percent_change: 50.0, # from 3 (in week before last) to 5 unique participants (in last 7 days) = 50% increase
-          participation_rate: 0.833,
+          participation_rate_as_percent: 0.833,
           participation_rate_7_day_percent_change: 20.0, # participation_rate_last_7_days: 0.6, participation_rate_previous_7_days: 0.5 = (((0.6 - 0.5).to_f / 0.5) * 100.0).round(1)
           voting: {
             voting_method: 'budgeting',

--- a/back/spec/acceptance/phase_insights/voting_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/voting_phase_insights_spec.rb
@@ -129,7 +129,7 @@ resource 'Phase insights' do
         visitors_7_day_percent_change: 25.0, # from 4 (in week before last) to 5 unique visitors (in last 7 days) = 25% increase
         participants: 5,
         participants_7_day_percent_change: 50.0, # from 3 (in week before last) to 5 unique participants (in last 7 days) = 50% increase
-        participation_rate_as_percent: 0.833,
+        participation_rate_as_percent: 83.3,
         participation_rate_7_day_percent_change: 20.0, # participation_rate_last_7_days: 0.6, participation_rate_previous_7_days: 0.5 = (((0.6 - 0.5).to_f / 0.5) * 100.0).round(1)
         voting: {
           voting_method: 'multiple_voting',
@@ -164,7 +164,7 @@ resource 'Phase insights' do
           visitors_7_day_percent_change: 25.0, # from 4 (in week before last) to 5 unique visitors (in last 7 days) = 25% increase
           participants: 5,
           participants_7_day_percent_change: 50.0, # from 3 (in week before last) to 5 unique participants (in last 7 days) = 50% increase
-          participation_rate_as_percent: 0.833,
+          participation_rate_as_percent: 83.3,
           participation_rate_7_day_percent_change: 20.0, # participation_rate_last_7_days: 0.6, participation_rate_previous_7_days: 0.5 = (((0.6 - 0.5).to_f / 0.5) * 100.0).round(1)
           voting: {
             voting_method: 'budgeting',

--- a/back/spec/acceptance/phase_insights/voting_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/voting_phase_insights_spec.rb
@@ -135,7 +135,7 @@ resource 'Phase insights' do
           voting_method: 'multiple_voting',
           associated_ideas: 3,
           online_votes: 6,
-          online_votes_7_day_change: 0.0, # from 3 (in week before last) to 3 (in last 7 days) = 0% change
+          online_votes_7_day_percent_change: 0.0, # from 3 (in week before last) to 3 (in last 7 days) = 0% change
           offline_votes: 3,
           voters: 3,
           voters_7_day_percent_change: 0.0, # from 2 (in week before last) to 2 unique voters (in last 7 days) = 0% change

--- a/back/spec/acceptance/phase_insights/voting_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/voting_phase_insights_spec.rb
@@ -128,7 +128,7 @@ resource 'Phase insights' do
         visitors: 6,
         visitors_7_day_percent_change: 25.0, # from 4 (in week before last) to 5 unique visitors (in last 7 days) = 25% increase
         participants: 5,
-        participants_7_day_change: 50.0, # from 3 (in week before last) to 5 unique participants (in last 7 days) = 50% increase
+        participants_7_day_percent_change: 50.0, # from 3 (in week before last) to 5 unique participants (in last 7 days) = 50% increase
         participation_rate: 0.833,
         participation_rate_7_day_percent_change: 20.0, # participation_rate_last_7_days: 0.6, participation_rate_previous_7_days: 0.5 = (((0.6 - 0.5).to_f / 0.5) * 100.0).round(1)
         voting: {
@@ -163,7 +163,7 @@ resource 'Phase insights' do
           visitors: 6,
           visitors_7_day_percent_change: 25.0, # from 4 (in week before last) to 5 unique visitors (in last 7 days) = 25% increase
           participants: 5,
-          participants_7_day_change: 50.0, # from 3 (in week before last) to 5 unique participants (in last 7 days) = 50% increase
+          participants_7_day_percent_change: 50.0, # from 3 (in week before last) to 5 unique participants (in last 7 days) = 50% increase
           participation_rate: 0.833,
           participation_rate_7_day_percent_change: 20.0, # participation_rate_last_7_days: 0.6, participation_rate_previous_7_days: 0.5 = (((0.6 - 0.5).to_f / 0.5) * 100.0).round(1)
           voting: {

--- a/back/spec/acceptance/phase_insights/voting_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/voting_phase_insights_spec.rb
@@ -126,7 +126,7 @@ resource 'Phase insights' do
       metrics = json_response_body.dig(:data, :attributes, :metrics)
       expect(metrics).to eq({
         visitors: 6,
-        visitors_7_day_change: 25.0, # from 4 (in week before last) to 5 unique visitors (in last 7 days) = 25% increase
+        visitors_7_day_percent_change: 25.0, # from 4 (in week before last) to 5 unique visitors (in last 7 days) = 25% increase
         participants: 5,
         participants_7_day_change: 50.0, # from 3 (in week before last) to 5 unique participants (in last 7 days) = 50% increase
         participation_rate: 0.833,
@@ -161,7 +161,7 @@ resource 'Phase insights' do
         metrics = json_response_body.dig(:data, :attributes, :metrics)
         expect(metrics).to eq({
           visitors: 6,
-          visitors_7_day_change: 25.0, # from 4 (in week before last) to 5 unique visitors (in last 7 days) = 25% increase
+          visitors_7_day_percent_change: 25.0, # from 4 (in week before last) to 5 unique visitors (in last 7 days) = 25% increase
           participants: 5,
           participants_7_day_change: 50.0, # from 3 (in week before last) to 5 unique participants (in last 7 days) = 50% increase
           participation_rate: 0.833,

--- a/back/spec/acceptance/phase_insights/voting_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/voting_phase_insights_spec.rb
@@ -130,7 +130,7 @@ resource 'Phase insights' do
         participants: 5,
         participants_7_day_change: 50.0, # from 3 (in week before last) to 5 unique participants (in last 7 days) = 50% increase
         participation_rate: 0.833,
-        participation_rate_7_day_change: 20.0, # participation_rate_last_7_days: 0.6, participation_rate_previous_7_days: 0.5 = (((0.6 - 0.5).to_f / 0.5) * 100.0).round(1)
+        participation_rate_7_day_percent_change: 20.0, # participation_rate_last_7_days: 0.6, participation_rate_previous_7_days: 0.5 = (((0.6 - 0.5).to_f / 0.5) * 100.0).round(1)
         voting: {
           voting_method: 'multiple_voting',
           associated_ideas: 3,
@@ -165,7 +165,7 @@ resource 'Phase insights' do
           participants: 5,
           participants_7_day_change: 50.0, # from 3 (in week before last) to 5 unique participants (in last 7 days) = 50% increase
           participation_rate: 0.833,
-          participation_rate_7_day_change: 20.0, # participation_rate_last_7_days: 0.6, participation_rate_previous_7_days: 0.5 = (((0.6 - 0.5).to_f / 0.5) * 100.0).round(1)
+          participation_rate_7_day_percent_change: 20.0, # participation_rate_last_7_days: 0.6, participation_rate_previous_7_days: 0.5 = (((0.6 - 0.5).to_f / 0.5) * 100.0).round(1)
           voting: {
             voting_method: 'budgeting',
             associated_ideas: 3,

--- a/back/spec/acceptance/phase_insights/voting_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/voting_phase_insights_spec.rb
@@ -140,7 +140,7 @@ resource 'Phase insights' do
           voters: 3,
           voters_7_day_change: 0.0, # from 2 (in week before last) to 2 unique voters (in last 7 days) = 0% change
           comments_posted: 3,
-          comments_posted_7_day_change: 100.0 # from 1 (in week before last) to 2 (in last 7 days) = 100% increase
+          comments_posted_7_day_percent_change: 100.0 # from 1 (in week before last) to 2 (in last 7 days) = 100% increase
         }
       })
     end
@@ -175,7 +175,7 @@ resource 'Phase insights' do
             voters: 3,
             voters_7_day_change: 0.0, # from 2 (in week before last) to 2 unique voters (in last 7 days) = 0% change
             comments_posted: 3,
-            comments_posted_7_day_change: 100.0 # from 1 (in week before last) to 2 (in last 7 days) = 100% increase
+            comments_posted_7_day_percent_change: 100.0 # from 1 (in week before last) to 2 (in last 7 days) = 100% increase
           }
         })
 

--- a/back/spec/services/insights/base_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/base_phase_insights_service_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Insights::BasePhaseInsightsService do
           visitors_7_day_percent_change: 0.0, # From 3 (7 to 14 days ago) to 3 (last 7-day period) unique visitors = 0% change
           participants: 3,
           participants_7_day_percent_change: 50.0, # From 2 (7 to 14 days ago) to 3 (last 7-day period) unique participants = 50% increase
-          participation_rate_as_percent: 0.75,
+          participation_rate_as_percent: 75.0,
           participation_rate_7_day_percent_change: 49.9 # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 0.667 = (((1 - 0.667).to_f / 0.667) * 100.0).round(1)
         }
       )

--- a/back/spec/services/insights/base_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/base_phase_insights_service_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Insights::BasePhaseInsightsService do
       expect(result).to eq(
         {
           visitors: 4,
-          visitors_7_day_change: 0.0, # From 3 (7 to 14 days ago) to 3 (last 7-day period) unique visitors = 0% change
+          visitors_7_day_percent_change: 0.0, # From 3 (7 to 14 days ago) to 3 (last 7-day period) unique visitors = 0% change
           participants: 3,
           participants_7_day_change: 50.0, # From 2 (7 to 14 days ago) to 3 (last 7-day period) unique participants = 50% increase
           participation_rate: 0.75,

--- a/back/spec/services/insights/base_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/base_phase_insights_service_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Insights::BasePhaseInsightsService do
           visitors: 4,
           visitors_7_day_percent_change: 0.0, # From 3 (7 to 14 days ago) to 3 (last 7-day period) unique visitors = 0% change
           participants: 3,
-          participants_7_day_change: 50.0, # From 2 (7 to 14 days ago) to 3 (last 7-day period) unique participants = 50% increase
+          participants_7_day_percent_change: 50.0, # From 2 (7 to 14 days ago) to 3 (last 7-day period) unique participants = 50% increase
           participation_rate: 0.75,
           participation_rate_7_day_percent_change: 49.9 # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 0.667 = (((1 - 0.667).to_f / 0.667) * 100.0).round(1)
         }

--- a/back/spec/services/insights/base_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/base_phase_insights_service_spec.rb
@@ -680,6 +680,12 @@ RSpec.describe Insights::BasePhaseInsightsService do
       expect(service.send(:percentage_change, 100, 0)).to eq(-100.0)
     end
 
+    it 'returns null when phase less than 14 days old' do
+      phase.update(start_at: 10.days.ago)
+
+      expect(service.send(:percentage_change, 100, 150)).to be_nil
+    end
+
     it 'rounds percentage change to one decimal place' do
       expect(service.send(:percentage_change, 3, 4)).to eq(33.3)
       expect(service.send(:percentage_change, 7, 5)).to eq(-28.6)

--- a/back/spec/services/insights/base_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/base_phase_insights_service_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Insights::BasePhaseInsightsService do
           participants: 3,
           participants_7_day_change: 50.0, # From 2 (7 to 14 days ago) to 3 (last 7-day period) unique participants = 50% increase
           participation_rate: 0.75,
-          participation_rate_7_day_change: 49.9 # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 0.667 = (((1 - 0.667).to_f / 0.667) * 100.0).round(1)
+          participation_rate_7_day_percent_change: 49.9 # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 0.667 = (((1 - 0.667).to_f / 0.667) * 100.0).round(1)
         }
       )
     end

--- a/back/spec/services/insights/base_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/base_phase_insights_service_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Insights::BasePhaseInsightsService do
           visitors_7_day_percent_change: 0.0, # From 3 (7 to 14 days ago) to 3 (last 7-day period) unique visitors = 0% change
           participants: 3,
           participants_7_day_percent_change: 50.0, # From 2 (7 to 14 days ago) to 3 (last 7-day period) unique participants = 50% increase
-          participation_rate: 0.75,
+          participation_rate_as_percent: 0.75,
           participation_rate_7_day_percent_change: 49.9 # participation_rate_last_7_days: 1.0, participation_rate_previous_7_days: 0.667 = (((1 - 0.667).to_f / 0.667) * 100.0).round(1)
         }
       )

--- a/back/spec/services/insights/common_ground_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/common_ground_phase_insights_service_spec.rb
@@ -117,9 +117,9 @@ RSpec.describe Insights::CommonGroundPhaseInsightsService do
       expect(metrics).to eq({
         associated_ideas: 6,
         ideas_posted: 2,
-        ideas_posted_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) = 0% change
+        ideas_posted_7_day_percent_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) = 0% change
         reactions: 2,
-        reactions_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change
+        reactions_7_day_percent_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change
       })
     end
   end

--- a/back/spec/services/insights/ideation_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/ideation_phase_insights_service_spec.rb
@@ -217,11 +217,11 @@ RSpec.describe Insights::IdeationPhaseInsightsService do
 
       expect(metrics).to eq({
         ideas_posted: 2,
-        ideas_posted_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) => 0% change
+        ideas_posted_7_day_percent_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) => 0% change
         comments_posted: 2,
-        comments_posted_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) => 0% change
+        comments_posted_7_day_percent_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) => 0% change
         reactions: 2,
-        reactions_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) => 0% change
+        reactions_7_day_percent_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) => 0% change
       })
     end
   end

--- a/back/spec/services/insights/native_survey_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/native_survey_phase_insights_service_spec.rb
@@ -123,9 +123,9 @@ RSpec.describe Insights::NativeSurveyPhaseInsightsService do
 
       expect(metrics).to eq({
         surveys_submitted: 6,
-        surveys_submitted_7_day_change: -33.3, # from 3 (in week before last) to 2 (in last 7 days) = -33.3% change
+        surveys_submitted_7_day_percent_change: -33.3, # from 3 (in week before last) to 2 (in last 7 days) = -33.3% change
         completion_rate_as_percent: 85.7, # 6 submitted surveys out of 7 ideas created during phase
-        completion_rate_7_day_change: 33.3 # completion_rate_last_7_days: 1.0, completion_rate_previous_7_days: 0.75 = 33.3% change
+        completion_rate_7_day_percent_change: 33.3 # completion_rate_last_7_days: 1.0, completion_rate_previous_7_days: 0.75 = 33.3% change
       })
     end
   end

--- a/back/spec/services/insights/native_survey_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/native_survey_phase_insights_service_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe Insights::NativeSurveyPhaseInsightsService do
       expect(metrics).to eq({
         surveys_submitted: 6,
         surveys_submitted_7_day_change: -33.3, # from 3 (in week before last) to 2 (in last 7 days) = -33.3% change
-        completion_rate: 0.857, # 6 submitted surveys out of 7 ideas created during phase
+        completion_rate_as_percent: 85.7, # 6 submitted surveys out of 7 ideas created during phase
         completion_rate_7_day_change: 33.3 # completion_rate_last_7_days: 1.0, completion_rate_previous_7_days: 0.75 = 33.3% change
       })
     end

--- a/back/spec/services/insights/poll_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/poll_phase_insights_service_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Insights::PollPhaseInsightsService do
 
       expect(metrics).to eq({
         responses: 2,
-        responses_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change
+        responses_7_day_percent_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change
       })
     end
   end

--- a/back/spec/services/insights/proposals_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/proposals_phase_insights_service_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe Insights::ProposalsPhaseInsightsService do
         ideas_posted: 2,
         ideas_posted_7_day_percent_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) => 0% change
         reached_threshold: 1,
-        reached_threshold_7_day_change: -100.0, # from 1 (in week before last) to 0 (in last 7 days) => -100% change
+        reached_threshold_7_day_percent_change: -100.0, # from 1 (in week before last) to 0 (in last 7 days) => -100% change
         comments_posted: 2,
         comments_posted_7_day_percent_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) => 0% change
         reactions: 2,

--- a/back/spec/services/insights/proposals_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/proposals_phase_insights_service_spec.rb
@@ -213,13 +213,13 @@ RSpec.describe Insights::ProposalsPhaseInsightsService do
 
       expect(metrics).to eq({
         ideas_posted: 2,
-        ideas_posted_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) => 0% change
+        ideas_posted_7_day_percent_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) => 0% change
         reached_threshold: 1,
         reached_threshold_7_day_change: -100.0, # from 1 (in week before last) to 0 (in last 7 days) => -100% change
         comments_posted: 2,
-        comments_posted_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) => 0% change
+        comments_posted_7_day_percent_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) => 0% change
         reactions: 2,
-        reactions_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) => 0% change
+        reactions_7_day_percent_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) => 0% change
       })
     end
   end

--- a/back/spec/services/insights/volunteering_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/volunteering_phase_insights_service_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Insights::VolunteeringPhaseInsightsService do
 
       expect(metrics).to eq({
         volunteerings: 2,
-        volunteerings_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change
+        volunteerings_7_day_percent_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change
       })
     end
   end

--- a/back/spec/services/insights/voting_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/voting_phase_insights_service_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Insights::VotingPhaseInsightsService do
         voting_method: phase.voting_method,
         associated_ideas: 2,
         online_votes: 5,
-        online_votes_7_day_change: 50.0, # from 2 (in week before last) to 3 (in last 7 days) = 50% increase
+        online_votes_7_day_percent_change: 50.0, # from 2 (in week before last) to 3 (in last 7 days) = 50% increase
         offline_votes: phase.manual_votes_count,
         voters: 1,
         voters_7_day_percent_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) = 0% change

--- a/back/spec/services/insights/voting_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/voting_phase_insights_service_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe Insights::VotingPhaseInsightsService do
         voters: 1,
         voters_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) = 0% change
         comments_posted: 2,
-        comments_posted_7_day_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change
+        comments_posted_7_day_percent_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change
       })
     end
   end

--- a/back/spec/services/insights/voting_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/voting_phase_insights_service_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Insights::VotingPhaseInsightsService do
         online_votes_7_day_change: 50.0, # from 2 (in week before last) to 3 (in last 7 days) = 50% increase
         offline_votes: phase.manual_votes_count,
         voters: 1,
-        voters_7_day_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) = 0% change
+        voters_7_day_percent_change: 0.0, # from 1 (in week before last) to 1 (in last 7 days) = 0% change
         comments_posted: 2,
         comments_posted_7_day_percent_change: 0.0 # from 1 (in week before last) to 1 (in last 7 days) = 0% change
       })

--- a/front/app/api/phase_insights/types.ts
+++ b/front/app/api/phase_insights/types.ts
@@ -23,13 +23,13 @@ export interface IdeationMetrics {
 
 export interface ProposalsMetrics extends IdeationMetrics {
   reached_threshold: number;
-  reached_threshold_7_day_change?: SevenDayChange;
+  reached_threshold_7_day_percent_change?: SevenDayChange;
 }
 
 interface BaseVotingMetrics {
   voting_method: string;
   voters: number;
-  voters_7_day_change?: SevenDayChange;
+  voters_7_day_percent_change?: SevenDayChange;
   associated_ideas: number;
   comments_posted: number;
   comments_posted_7_day_percent_change?: SevenDayChange;
@@ -44,7 +44,7 @@ export interface VotingMetrics extends BaseVotingMetrics {
 export interface BudgetingMetrics extends BaseVotingMetrics {
   voting_method: 'budgeting';
   online_picks: number;
-  online_picks_7_day_change?: SevenDayChange;
+  online_picks_7_day_percent_change?: SevenDayChange;
   offline_picks: number;
 }
 
@@ -57,7 +57,7 @@ export interface SurveyMetrics {
 
 export interface PollMetrics {
   responses: number;
-  responses_7_day_change?: SevenDayChange;
+  responses_7_day_percent_change?: SevenDayChange;
 }
 
 export interface CommonGroundMetrics
@@ -70,7 +70,7 @@ export interface CommonGroundMetrics
 
 export interface VolunteeringMetrics {
   volunteerings: number;
-  volunteerings_7_day_change?: SevenDayChange;
+  volunteerings_7_day_percent_change?: SevenDayChange;
 }
 
 export interface PhaseInsightsParticipationMetrics {

--- a/front/app/api/phase_insights/types.ts
+++ b/front/app/api/phase_insights/types.ts
@@ -37,7 +37,7 @@ interface BaseVotingMetrics {
 
 export interface VotingMetrics extends BaseVotingMetrics {
   online_votes: number;
-  online_votes_7_day_change?: SevenDayChange;
+  online_votes_7_day_percent_change?: SevenDayChange;
   offline_votes: number;
 }
 

--- a/front/app/api/phase_insights/types.ts
+++ b/front/app/api/phase_insights/types.ts
@@ -75,7 +75,7 @@ export interface VolunteeringMetrics {
 
 export interface PhaseInsightsParticipationMetrics {
   visitors: number;
-  visitors_7_day_change?: SevenDayChange;
+  visitors_7_day_percent_change?: SevenDayChange;
   participants: number;
   participants_7_day_change?: SevenDayChange;
   participation_rate: number;

--- a/front/app/api/phase_insights/types.ts
+++ b/front/app/api/phase_insights/types.ts
@@ -51,7 +51,7 @@ export interface BudgetingMetrics extends BaseVotingMetrics {
 export interface SurveyMetrics {
   surveys_submitted: number;
   surveys_submitted_7_day_change?: SevenDayChange;
-  completion_rate: number;
+  completion_rate_as_percent: number;
   completion_rate_7_day_change?: SevenDayChange;
 }
 

--- a/front/app/api/phase_insights/types.ts
+++ b/front/app/api/phase_insights/types.ts
@@ -50,9 +50,9 @@ export interface BudgetingMetrics extends BaseVotingMetrics {
 
 export interface SurveyMetrics {
   surveys_submitted: number;
-  surveys_submitted_7_day_change?: SevenDayChange;
+  surveys_submitted_7_day_percent_change?: SevenDayChange;
   completion_rate_as_percent: number;
-  completion_rate_7_day_change?: SevenDayChange;
+  completion_rate_7_day_percent_change?: SevenDayChange;
 }
 
 export interface PollMetrics {

--- a/front/app/api/phase_insights/types.ts
+++ b/front/app/api/phase_insights/types.ts
@@ -77,7 +77,7 @@ export interface PhaseInsightsParticipationMetrics {
   visitors: number;
   visitors_7_day_percent_change?: SevenDayChange;
   participants: number;
-  participants_7_day_change?: SevenDayChange;
+  participants_7_day_percent_change?: SevenDayChange;
   participation_rate: number;
   participation_rate_7_day_percent_change?: SevenDayChange;
   ideation?: IdeationMetrics;

--- a/front/app/api/phase_insights/types.ts
+++ b/front/app/api/phase_insights/types.ts
@@ -79,7 +79,7 @@ export interface PhaseInsightsParticipationMetrics {
   participants: number;
   participants_7_day_change?: SevenDayChange;
   participation_rate: number;
-  participation_rate_7_day_change?: SevenDayChange;
+  participation_rate_7_day_percent_change?: SevenDayChange;
   ideation?: IdeationMetrics;
   proposals?: ProposalsMetrics;
   voting?: VotingMetrics;

--- a/front/app/api/phase_insights/types.ts
+++ b/front/app/api/phase_insights/types.ts
@@ -14,11 +14,11 @@ export type SevenDayChange = number | null | 'last_7_days_compared_with_zero';
  */
 export interface IdeationMetrics {
   ideas_posted: number;
-  ideas_posted_7_day_change?: SevenDayChange;
+  ideas_posted_7_day_percent_change?: SevenDayChange;
   comments_posted: number;
-  comments_posted_7_day_change?: SevenDayChange;
+  comments_posted_7_day_percent_change?: SevenDayChange;
   reactions: number;
-  reactions_7_day_change?: SevenDayChange;
+  reactions_7_day_percent_change?: SevenDayChange;
 }
 
 export interface ProposalsMetrics extends IdeationMetrics {
@@ -32,7 +32,7 @@ interface BaseVotingMetrics {
   voters_7_day_change?: SevenDayChange;
   associated_ideas: number;
   comments_posted: number;
-  comments_posted_7_day_change?: SevenDayChange;
+  comments_posted_7_day_percent_change?: SevenDayChange;
 }
 
 export interface VotingMetrics extends BaseVotingMetrics {
@@ -63,7 +63,7 @@ export interface PollMetrics {
 export interface CommonGroundMetrics
   extends Omit<
     IdeationMetrics,
-    'comments_posted' | 'comments_posted_7_day_change'
+    'comments_posted' | 'comments_posted_7_day_percent_change'
   > {
   associated_ideas: number;
 }

--- a/front/app/api/phase_insights/types.ts
+++ b/front/app/api/phase_insights/types.ts
@@ -78,7 +78,7 @@ export interface PhaseInsightsParticipationMetrics {
   visitors_7_day_percent_change?: SevenDayChange;
   participants: number;
   participants_7_day_percent_change?: SevenDayChange;
-  participation_rate: number;
+  participation_rate_as_percent: number;
   participation_rate_7_day_percent_change?: SevenDayChange;
   ideation?: IdeationMetrics;
   proposals?: ProposalsMetrics;

--- a/front/app/containers/Admin/projects/project/insights/participationMetrics/ParticipationMetrics.tsx
+++ b/front/app/containers/Admin/projects/project/insights/participationMetrics/ParticipationMetrics.tsx
@@ -74,7 +74,9 @@ const ParticipationMetrics = ({ phase }: Props) => {
         label={formatMessage(messages.participants)}
         value={metrics.participants}
         icon="sidebar-users"
-        change={isCurrentPhase ? metrics.participants_7_day_change : undefined}
+        change={
+          isCurrentPhase ? metrics.participants_7_day_percent_change : undefined
+        }
       />
 
       <MethodMetrics

--- a/front/app/containers/Admin/projects/project/insights/participationMetrics/ParticipationMetrics.tsx
+++ b/front/app/containers/Admin/projects/project/insights/participationMetrics/ParticipationMetrics.tsx
@@ -66,7 +66,9 @@ const ParticipationMetrics = ({ phase }: Props) => {
         label={formatMessage(messages.visitors)}
         value={metrics.visitors}
         icon="user-circle"
-        change={isCurrentPhase ? metrics.visitors_7_day_change : undefined}
+        change={
+          isCurrentPhase ? metrics.visitors_7_day_percent_change : undefined
+        }
       />
       <MetricCard
         label={formatMessage(messages.participants)}

--- a/front/app/containers/Admin/projects/project/insights/participationMetrics/ParticipationMetrics.tsx
+++ b/front/app/containers/Admin/projects/project/insights/participationMetrics/ParticipationMetrics.tsx
@@ -87,7 +87,7 @@ const ParticipationMetrics = ({ phase }: Props) => {
 
       <MetricCard
         label={formatMessage(messages.participationRate)}
-        value={`${(metrics.participation_rate * 100).toFixed(1)}%`}
+        value={`${metrics.participation_rate_as_percent.toFixed(1)}%`}
         icon="chart-bar"
         change={
           isCurrentPhase

--- a/front/app/containers/Admin/projects/project/insights/participationMetrics/ParticipationMetrics.tsx
+++ b/front/app/containers/Admin/projects/project/insights/participationMetrics/ParticipationMetrics.tsx
@@ -88,7 +88,9 @@ const ParticipationMetrics = ({ phase }: Props) => {
         value={`${(metrics.participation_rate * 100).toFixed(1)}%`}
         icon="chart-bar"
         change={
-          isCurrentPhase ? metrics.participation_rate_7_day_change : undefined
+          isCurrentPhase
+            ? metrics.participation_rate_7_day_percent_change
+            : undefined
         }
       />
     </Box>

--- a/front/app/containers/Admin/projects/project/insights/participationMetrics/methodMetrics/CommonGroundMetrics.tsx
+++ b/front/app/containers/Admin/projects/project/insights/participationMetrics/methodMetrics/CommonGroundMetrics.tsx
@@ -21,7 +21,9 @@ const CommonGroundMetrics = ({ metrics, showChange }: Props) => {
         label={formatMessage(messages.ideasPosted)}
         value={metrics.ideas_posted}
         icon="blank-paper"
-        change={showChange ? metrics.ideas_posted_7_day_change : undefined}
+        change={
+          showChange ? metrics.ideas_posted_7_day_percent_change : undefined
+        }
       />
       <MetricCard
         label={formatMessage(messages.associatedIdeas)}
@@ -32,7 +34,7 @@ const CommonGroundMetrics = ({ metrics, showChange }: Props) => {
         label={formatMessage(messages.reactions)}
         value={metrics.reactions}
         icon="thumb-up"
-        change={showChange ? metrics.reactions_7_day_change : undefined}
+        change={showChange ? metrics.reactions_7_day_percent_change : undefined}
       />
     </>
   );

--- a/front/app/containers/Admin/projects/project/insights/participationMetrics/methodMetrics/IdeationMetrics.tsx
+++ b/front/app/containers/Admin/projects/project/insights/participationMetrics/methodMetrics/IdeationMetrics.tsx
@@ -21,19 +21,23 @@ const IdeationMetrics = ({ metrics, showChange }: Props) => {
         label={formatMessage(messages.inputs)}
         value={metrics.ideas_posted}
         icon="blank-paper"
-        change={showChange ? metrics.ideas_posted_7_day_change : undefined}
+        change={
+          showChange ? metrics.ideas_posted_7_day_percent_change : undefined
+        }
       />
       <MetricCard
         label={formatMessage(messages.comments)}
         value={metrics.comments_posted}
         icon="chat-bubble"
-        change={showChange ? metrics.comments_posted_7_day_change : undefined}
+        change={
+          showChange ? metrics.comments_posted_7_day_percent_change : undefined
+        }
       />
       <MetricCard
         label={formatMessage(messages.reactions)}
         value={metrics.reactions}
         icon="thumb-up"
-        change={showChange ? metrics.reactions_7_day_change : undefined}
+        change={showChange ? metrics.reactions_7_day_percent_change : undefined}
       />
     </>
   );

--- a/front/app/containers/Admin/projects/project/insights/participationMetrics/methodMetrics/PollMetrics.tsx
+++ b/front/app/containers/Admin/projects/project/insights/participationMetrics/methodMetrics/PollMetrics.tsx
@@ -20,7 +20,7 @@ const PollMetrics = ({ metrics, showChange }: Props) => {
       label={formatMessage(messages.responses)}
       value={metrics.responses}
       icon="vote-ballot"
-      change={showChange ? metrics.responses_7_day_change : undefined}
+      change={showChange ? metrics.responses_7_day_percent_change : undefined}
     />
   );
 };

--- a/front/app/containers/Admin/projects/project/insights/participationMetrics/methodMetrics/ProposalsMetrics.tsx
+++ b/front/app/containers/Admin/projects/project/insights/participationMetrics/methodMetrics/ProposalsMetrics.tsx
@@ -21,19 +21,23 @@ const ProposalsMetrics = ({ metrics, showChange }: Props) => {
         label={formatMessage(messages.inputs)}
         value={metrics.ideas_posted}
         icon="sidebar-proposals"
-        change={showChange ? metrics.ideas_posted_7_day_change : undefined}
+        change={
+          showChange ? metrics.ideas_posted_7_day_percent_change : undefined
+        }
       />
       <MetricCard
         label={formatMessage(messages.comments)}
         value={metrics.comments_posted}
         icon="chat-bubble"
-        change={showChange ? metrics.comments_posted_7_day_change : undefined}
+        change={
+          showChange ? metrics.comments_posted_7_day_percent_change : undefined
+        }
       />
       <MetricCard
         label={formatMessage(messages.reactions)}
         value={metrics.reactions}
         icon="thumb-up"
-        change={showChange ? metrics.reactions_7_day_change : undefined}
+        change={showChange ? metrics.reactions_7_day_percent_change : undefined}
       />
     </>
   );

--- a/front/app/containers/Admin/projects/project/insights/participationMetrics/methodMetrics/SurveyMetrics.tsx
+++ b/front/app/containers/Admin/projects/project/insights/participationMetrics/methodMetrics/SurveyMetrics.tsx
@@ -21,13 +21,19 @@ const SurveyMetrics = ({ metrics, showChange }: Props) => {
         label={formatMessage(messages.submissions)}
         value={metrics.surveys_submitted}
         icon="check-circle"
-        change={showChange ? metrics.surveys_submitted_7_day_change : undefined}
+        change={
+          showChange
+            ? metrics.surveys_submitted_7_day_percent_change
+            : undefined
+        }
       />
       <MetricCard
         label={formatMessage(messages.completionRate)}
         value={`${metrics.completion_rate_as_percent.toFixed(1)}%`}
         icon="chart-bar"
-        change={showChange ? metrics.completion_rate_7_day_change : undefined}
+        change={
+          showChange ? metrics.completion_rate_7_day_percent_change : undefined
+        }
       />
     </>
   );

--- a/front/app/containers/Admin/projects/project/insights/participationMetrics/methodMetrics/SurveyMetrics.tsx
+++ b/front/app/containers/Admin/projects/project/insights/participationMetrics/methodMetrics/SurveyMetrics.tsx
@@ -25,7 +25,7 @@ const SurveyMetrics = ({ metrics, showChange }: Props) => {
       />
       <MetricCard
         label={formatMessage(messages.completionRate)}
-        value={`${(metrics.completion_rate * 100).toFixed(1)}%`}
+        value={`${metrics.completion_rate_as_percent.toFixed(1)}%`}
         icon="chart-bar"
         change={showChange ? metrics.completion_rate_7_day_change : undefined}
       />

--- a/front/app/containers/Admin/projects/project/insights/participationMetrics/methodMetrics/VolunteeringMetrics.tsx
+++ b/front/app/containers/Admin/projects/project/insights/participationMetrics/methodMetrics/VolunteeringMetrics.tsx
@@ -20,7 +20,9 @@ const VolunteeringMetrics = ({ metrics, showChange }: Props) => {
       label={formatMessage(messages.volunteerings)}
       value={metrics.volunteerings}
       icon="user-check"
-      change={showChange ? metrics.volunteerings_7_day_change : undefined}
+      change={
+        showChange ? metrics.volunteerings_7_day_percent_change : undefined
+      }
     />
   );
 };


### PR DESCRIPTION
Also ensure we consistently return `null` for all 7_day_change metrics when phase less than 14 days of age.

# Changelog
## Technical
- [TAN-6329] Rename some phase insight vars & make percentage floats consistent. Also consistently return `null` for all 7_day_change metrics when phase less than 14 days of age. (Behind FF - in development)
