### PR TITLE
[No-ticket] Fix flaky test by removing tie for count of input_topics

### DIFF
--- a/back/spec/models/input_topic_spec.rb
+++ b/back/spec/models/input_topic_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe InputTopic do
     let_it_be(:idea3) { create(:idea, project:, input_topics: [input_topics[0], input_topics[5]]) }
     let_it_be(:idea4) { create(:idea, project:, input_topics: [input_topics[2], input_topics[4], input_topics[5]]) }
     let_it_be(:idea5) { create(:idea, project:, input_topics: [input_topics[2], input_topics[4], input_topics[5]]) }
-    let_it_be(:idea6) { create(:idea, project:, input_topics: [input_topics[0], input_topics[3]]) }
+    let_it_be(:idea6) { create(:idea, project:, input_topics: [input_topics[0]]) }
 
     it 'sorts from fewest ideas to most ideas when asking asc' do
       sorted_topics = described_class.order_ideas_count(Idea.where(id: [idea2.id, idea3.id, idea4.id, idea5.id, idea6.id]), direction: :asc)


### PR DESCRIPTION
In the test, for the given 3 ideas, both `input_topics[2]` and `input_topics[3]` were associated with 2 of those ideas. This meant the order was somewhat arbitrary, but for some reason this arbitrariness only showed up on CI ([example failure](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/316776/workflows/2e7ef8e6-4f4c-4dca-b13f-5995dbabea97/jobs/688474)).

# Changelog
## Technical
- [No-ticket] Fix flaky test by removing tie for count of ideas per input_topic
