### PR TITLE
TAN-6236 - Fix user fields for ideation to get the correct phase

### DIFF
--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -251,8 +251,6 @@ class Project < ApplicationRecord
     )
   end
 
-  def
-
   def refresh_preview_token
     self.preview_token = self.class.generate_preview_token
   end

--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -247,7 +247,7 @@ class Project < ApplicationRecord
     # The following mimics the same behaviour now that participation method is not available on the project
     # This defaults to Ideation as pmethod is only needed when dealing with custom forms for Ideation phases
     @pmethod ||= ParticipationMethod::Ideation.new(
-      TimelineService.new.current_or_backup_transitive_phase(self)
+      TimelineService.new.current_or_backup_transitive_phase(self) || phases.first
     )
   end
 

--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -245,9 +245,13 @@ class Project < ApplicationRecord
     # NOTE: if a project is passed to this method, timeline projects used to always return 'Ideation'
     # as it was never set and defaulted to this when the participation_method was available on the project
     # The following mimics the same behaviour now that participation method is not available on the project
-    # TODO: Maybe change to find phase with ideation or voting where created date between start and end date?
-    @pmethod ||= ParticipationMethod::Ideation.new(phases.first)
+    # This defaults to Ideation as pmethod is only needed when dealing with custom forms for Ideation phases
+    @pmethod ||= ParticipationMethod::Ideation.new(
+      TimelineService.new.current_or_backup_transitive_phase(self)
+    )
   end
+
+  def
 
   def refresh_preview_token
     self.preview_token = self.class.generate_preview_token

--- a/back/spec/acceptance/ideas/user_fields_in_form_ideation_spec.rb
+++ b/back/spec/acceptance/ideas/user_fields_in_form_ideation_spec.rb
@@ -23,7 +23,7 @@ resource 'Ideas' do
       )
 
       @permission = @phase.permissions.find_by(action: 'posting_idea')
-      @custom_form = create(:custom_form, :with_default_fields, participation_context: @phase)
+      @custom_form = create(:custom_form, :with_default_fields, participation_context: @project)
 
       # Create registration (demographic) question and
       # add to permission


### PR DESCRIPTION
Turns out it was nothing to do with your code. It's the slightly fudgey `pmethod` method on project which was using the first phase of the project instead of the current ideation phase
