### PR TITLE
Fix z-index issue on project page

### DIFF
--- a/front/app/components/admin/NavigationTabs/index.tsx
+++ b/front/app/components/admin/NavigationTabs/index.tsx
@@ -13,13 +13,14 @@ import { tabBorderSize } from './tabsStyleConstants';
 const NavigationTabs = styled.nav<{
   position?: BoxPositionProps['position'];
   paddingLeft?: BoxPaddingProps['paddingLeft'];
+  zIndex?: number;
 }>`
-  ${({ theme, position, paddingLeft }) => css`
+  ${({ theme, position, paddingLeft, zIndex }) => css`
     position: ${position || 'fixed'};
     width: 100%;
     // TODO : set bg color in component library
     background: #fbfbfb;
-    z-index: 1000;
+    z-index: ${zIndex ?? 1000};
     box-shadow: ${defaultStyles.boxShadow};
     border-radius: ${theme.borderRadius} ${theme.borderRadius} 0 0;
     padding-left: ${paddingLeft || '44px'};

--- a/front/app/containers/Admin/projects/project/projectHeader/index.tsx
+++ b/front/app/containers/Admin/projects/project/projectHeader/index.tsx
@@ -74,7 +74,7 @@ const ProjectHeader = ({ projectId }: Props) => {
   const { listed } = project.data.attributes;
 
   return (
-    <NavigationTabs position="static" paddingLeft="24px">
+    <NavigationTabs position="relative" paddingLeft="24px" zIndex={1001}>
       <Box
         display="flex"
         flexDirection="column"


### PR DESCRIPTION
# Changelog

## Fixed
- This fixes an issue where part of the share link modal was appearing behind the navigation tab on the project
<img width="459" height="450" alt="image" src="https://github.com/user-attachments/assets/566e0057-eec4-4dc1-afba-79c0dcb46115" />

