### PR TITLE
TAN-6395: Fix insights page crashing when there is no analysis id

### DIFF
--- a/front/app/api/analysis_inputs/useInfiniteAnalysisInputs.ts
+++ b/front/app/api/analysis_inputs/useInfiniteAnalysisInputs.ts
@@ -43,6 +43,7 @@ const useInfiniteAnalysisInputs = ({
       const pageNumber = getPageNumberFromUrl(lastPage.links.self);
       return hasNextPage && pageNumber ? pageNumber + 1 : null;
     },
+    enabled: !!analysisId,
     keepPreviousData: true,
   });
 };

--- a/front/app/api/analysis_tags/useAnalysisTags.ts
+++ b/front/app/api/analysis_tags/useAnalysisTags.ts
@@ -18,6 +18,7 @@ const useAnalysisTags = (queryParams: ITagParams) => {
   return useQuery<ITags, CLErrors, ITags, TagsKeys>({
     queryKey: tagsKeys.list(queryParams),
     queryFn: () => fetchTags(queryParams),
+    enabled: !!queryParams.analysisId,
   });
 };
 


### PR DESCRIPTION
# Changelog

## Fixed
- Fix insights page crashing on proposals when there is no existing analysis id
