### PR TITLE
 delay pageNotFound content

### DIFF
--- a/front/app/components/PageNotFound/index.tsx
+++ b/front/app/components/PageNotFound/index.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 
-import { Title, Text, media } from '@citizenlab/cl2-component-library';
+import { Title, Text, media, Spinner } from '@citizenlab/cl2-component-library';
 import styled from 'styled-components';
 
 import ButtonWithLink from 'components/UI/ButtonWithLink';
+import Centerer from 'components/UI/Centerer';
 
 import { useIntl } from 'utils/cl-intl';
 
@@ -25,6 +26,25 @@ const PageNotFoundWrapper = styled.div`
 
 const PageNotFound = () => {
   const { formatMessage } = useIntl();
+  const [showContent, setShowContent] = useState(false);
+  // show spinner for 3 seconds before showing content to avoid redirect 404 page flash
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setShowContent(true);
+    }, 3000);
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  if (!showContent) {
+    return (
+      <main>
+        <Centerer h="500px">
+          <Spinner />
+        </Centerer>
+      </main>
+    );
+  }
 
   return (
     <main>

--- a/front/app/containers/CustomPageShow/index.tsx
+++ b/front/app/containers/CustomPageShow/index.tsx
@@ -85,7 +85,7 @@ const CustomPageShow = () => {
 
   // when neither have loaded
   if (!appConfiguration || !page) {
-    return null;
+    return <PageNotFound />;
   }
 
   if (

--- a/front/app/containers/IdeasShowPage/index.tsx
+++ b/front/app/containers/IdeasShowPage/index.tsx
@@ -70,7 +70,7 @@ const IdeasShowPage = () => {
   const [searchParams] = useSearchParams();
   const phaseContext = searchParams.get('phase_context');
 
-  if (!project) return null;
+  if (!project) return <PageNotFound />;
 
   if (status === 'loading') {
     return (

--- a/front/app/routes.tsx
+++ b/front/app/routes.tsx
@@ -415,15 +415,15 @@ export default function createRoutes() {
           ),
         },
         ...moduleConfiguration.routes.citizen,
+        {
+          path: '*',
+          element: (
+            <PageLoading>
+              <PageNotFound />
+            </PageLoading>
+          ),
+        },
       ],
-    },
-    {
-      path: '*',
-      element: (
-        <PageLoading>
-          <PageNotFound />
-        </PageLoading>
-      ),
     },
   ];
 }


### PR DESCRIPTION
# Description
- Replaced all null returns (Idea, projects and pages) with `PageNotFound` to prevent empty pages!
- Delayed `PageNotFound` rendering with a 3 sec spinner to prevent redirect flashing issue!

# Changelog
-  Delay pageNotFound content with a 3 sec spinner to prevent redirect flashing issue.
