### PR TITLE
TAN-6409: Use correct scope for AI analysis for participation methods

### DIFF
--- a/front/app/containers/Admin/projects/project/insights/methodSpecific/ideation/IdeationInsights.tsx
+++ b/front/app/containers/Admin/projects/project/insights/methodSpecific/ideation/IdeationInsights.tsx
@@ -17,8 +17,8 @@ const IdeationInsights = ({ phaseId }: MethodSpecificInsightProps) => {
   if (isPdfRenderMode) {
     return (
       <Box mt="16px" display="flex" flexDirection="column" gap="24px">
-        <AiSummary phaseId={phaseId} />
-        <TopicBreakdown phaseId={phaseId} />
+        <AiSummary phaseId={phaseId} participationMethod="ideation" />
+        <TopicBreakdown phaseId={phaseId} participationMethod="ideation" />
         <MostLikedIdeas phaseId={phaseId} />
         <StatusBreakdown phaseId={phaseId} participationMethod="ideation" />
       </Box>
@@ -29,10 +29,10 @@ const IdeationInsights = ({ phaseId }: MethodSpecificInsightProps) => {
     <Box mt="16px" gap="24px">
       <Box display="flex" gap="16px" w="100%">
         <Box w="100%">
-          <AiSummary phaseId={phaseId} />
+          <AiSummary phaseId={phaseId} participationMethod="ideation" />
         </Box>
         <Box w="100%">
-          <TopicBreakdown phaseId={phaseId} />
+          <TopicBreakdown phaseId={phaseId} participationMethod="ideation" />
         </Box>
       </Box>
       <Box display="flex" gap="16px" w="100%" flexDirection="row">

--- a/front/app/containers/Admin/projects/project/insights/methodSpecific/proposals/ProposalsInsights.tsx
+++ b/front/app/containers/Admin/projects/project/insights/methodSpecific/proposals/ProposalsInsights.tsx
@@ -16,8 +16,8 @@ const ProposalsInsights = ({ phaseId }: MethodSpecificInsightProps) => {
   if (isPdfRenderMode) {
     return (
       <Box mt="16px" display="flex" flexDirection="column" gap="24px">
-        <AiSummary phaseId={phaseId} />
-        <TopicBreakdown phaseId={phaseId} />
+        <AiSummary phaseId={phaseId} participationMethod="proposals" />
+        <TopicBreakdown phaseId={phaseId} participationMethod="proposals" />
         <MostLikedProposals phaseId={phaseId} />
         <StatusBreakdown phaseId={phaseId} participationMethod="proposals" />
       </Box>
@@ -28,10 +28,10 @@ const ProposalsInsights = ({ phaseId }: MethodSpecificInsightProps) => {
     <Box mt="16px" gap="24px">
       <Box display="flex" gap="16px" w="100%">
         <Box w="100%">
-          <AiSummary phaseId={phaseId} />
+          <AiSummary phaseId={phaseId} participationMethod="proposals" />
         </Box>
         <Box w="100%">
-          <TopicBreakdown phaseId={phaseId} />
+          <TopicBreakdown phaseId={phaseId} participationMethod="proposals" />
         </Box>
       </Box>
       <Box display="flex" gap="16px" w="100%" flexDirection="row">

--- a/front/app/containers/Admin/projects/project/insights/methodSpecific/shared/TopicBreakdown/index.tsx
+++ b/front/app/containers/Admin/projects/project/insights/methodSpecific/shared/TopicBreakdown/index.tsx
@@ -8,6 +8,8 @@ import {
   colors,
 } from '@citizenlab/cl2-component-library';
 
+import { ParticipationMethod } from 'api/phases/types';
+
 import { useIntl } from 'utils/cl-intl';
 
 import messages from '../messages';
@@ -19,9 +21,10 @@ import useTopicBreakdownData from './useTopicBreakdownData';
 
 interface Props {
   phaseId: string;
+  participationMethod?: ParticipationMethod;
 }
 
-const TopicBreakdown = ({ phaseId }: Props) => {
+const TopicBreakdown = ({ phaseId, participationMethod }: Props) => {
   const { formatMessage } = useIntl();
 
   const {
@@ -32,7 +35,7 @@ const TopicBreakdown = ({ phaseId }: Props) => {
     maxAiTopicCount,
     maxManualTopicCount,
     isLoading,
-  } = useTopicBreakdownData({ phaseId });
+  } = useTopicBreakdownData({ phaseId, participationMethod });
 
   if (isLoading) {
     return (

--- a/front/app/containers/Admin/projects/project/insights/methodSpecific/shared/TopicBreakdown/useTopicBreakdownData.ts
+++ b/front/app/containers/Admin/projects/project/insights/methodSpecific/shared/TopicBreakdown/useTopicBreakdownData.ts
@@ -6,9 +6,12 @@ import useAnalyses from 'api/analyses/useAnalyses';
 import useAnalysisTags from 'api/analysis_tags/useAnalysisTags';
 import useIdeasFilterCounts from 'api/ideas_filter_counts/useIdeasFilterCounts';
 import useInputTopics from 'api/input_topics/useInputTopics';
+import { ParticipationMethod } from 'api/phases/types';
 
 import useFeatureFlag from 'hooks/useFeatureFlag';
 import useLocalize from 'hooks/useLocalize';
+
+import { getAnalysisScope } from 'containers/Admin/projects/components/AnalysisBanner/utils';
 
 export interface TopicData {
   id: string;
@@ -19,9 +22,13 @@ export interface TopicData {
 
 interface UseTopicBreakdownDataProps {
   phaseId: string;
+  participationMethod?: ParticipationMethod;
 }
 
-const useTopicBreakdownData = ({ phaseId }: UseTopicBreakdownDataProps) => {
+const useTopicBreakdownData = ({
+  phaseId,
+  participationMethod,
+}: UseTopicBreakdownDataProps) => {
   const localize = useLocalize();
   const { projectId } = useParams() as { projectId: string };
 
@@ -30,15 +37,15 @@ const useTopicBreakdownData = ({ phaseId }: UseTopicBreakdownDataProps) => {
     onlyCheckAllowed: true,
   });
 
-  // 1. Fetch Analysis (to get analysisId)
+  // Determine the correct scope based on participation method
+  const scope = getAnalysisScope(participationMethod);
+
+  // 1. Fetch Analysis with correct scope (projectId for ideation/voting, phaseId for others)
   const {
     data: analyses,
     isLoading: isLoadingAnalyses,
     error: errorAnalyses,
-  } = useAnalyses({
-    projectId,
-    phaseId,
-  });
+  } = useAnalyses(scope === 'project' ? { projectId } : { phaseId });
 
   const analysisId = analyses?.data[0]?.id;
 


### PR DESCRIPTION
# Changelog

## Fixed
- Fixed indefinite spinner shown on some proposals when an analysis has never been created (This is on the insights page that is currently hidden behind a spinner)
