### PR TITLE
[TAN-6415] Fix foreign key violation when deleting users with idea exposures

### DIFF
--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -138,6 +138,7 @@ class User < ApplicationRecord
   end)
 
   has_many :ideas, -> { order(:project_id) }, foreign_key: :author_id, dependent: :nullify
+  has_many :idea_exposures, dependent: :destroy
   has_many :idea_imports, class_name: 'BulkImportIdeas::IdeaImport', foreign_key: :import_user_id, dependent: :nullify
   has_many :manual_votes_last_updated_ideas, class_name: 'Idea', foreign_key: :manual_votes_last_updated_by_id, dependent: :nullify
   has_many :manual_voters_last_updated_phases, class_name: 'Phase', foreign_key: :manual_voters_last_updated_by_id, dependent: :nullify

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe User do
     it { is_expected.to have_many(:jobs_trackers).class_name('Jobs::Tracker').with_foreign_key('owner_id').dependent(:nullify) }
     it { is_expected.to have_many(:files).class_name('Files::File').with_foreign_key('uploader_id').dependent(:nullify) }
     it { is_expected.to have_many(:claim_tokens).with_foreign_key('pending_claimer_id').dependent(:destroy) }
+    it { is_expected.to have_many(:idea_exposures).dependent(:destroy) }
 
     it 'nullifies idea import association' do
       idea_import = create(:idea_import, import_user: user)
@@ -42,6 +43,15 @@ RSpec.describe User do
       phase = create(:phase, manual_voters_last_updated_by: user)
       expect { user.destroy }.not_to raise_error
       expect(phase.reload.manual_voters_last_updated_by).to be_nil
+    end
+
+    it 'destroys idea_exposures when user is deleted' do
+      user.save!
+      phase = create(:phase)
+      idea = create(:idea, phases: [phase])
+      idea_exposure = create(:idea_exposure, user: user, idea: idea, phase: phase)
+      expect { user.destroy }.not_to raise_error
+      expect { idea_exposure.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 


### PR DESCRIPTION
## Summary
- Add `has_many :idea_exposures, dependent: :destroy` association to User model
- This fixes the `PG::ForeignKeyViolation` error that occurred when deleting users who have idea_exposure records
- Mirrors the existing pattern in the Idea model

## Test plan
- [x] Added unit tests for the new association
- [x] Added behavioral test verifying users with idea_exposures can be deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Changelog
## Fixed
- Deleting a user account of a user that has used the new Feed presentation mode no longer results in an error