### PR TITLE
TAN-6405: internationalize numbers

### DIFF
--- a/front/app/components/admin/Graphs/ComparisonBarChart/index.tsx
+++ b/front/app/components/admin/Graphs/ComparisonBarChart/index.tsx
@@ -3,6 +3,8 @@ import React, { useMemo } from 'react';
 import { Box, colors, Text } from '@citizenlab/cl2-component-library';
 import styled from 'styled-components';
 
+import { useIntl } from 'utils/cl-intl';
+
 import EmptyState from '../_components/EmptyState';
 import { hasNoData } from '../utils';
 
@@ -45,6 +47,13 @@ const BarFill = styled(Box)<{
   }
 `;
 
+const PercentageLabel = styled.span<{ color: string }>`
+  font-size: 14px;
+  line-height: 1.5;
+  color: ${({ color }) => color};
+  margin: 0;
+`;
+
 const ComparisonBarChart = <Row,>({
   data,
   mapping,
@@ -61,7 +70,16 @@ const ComparisonBarChart = <Row,>({
   ariaLabel,
   ariaDescribedBy,
 }: Props<Row>) => {
+  const { formatNumber } = useIntl();
   const noData = hasNoData(data);
+
+  const formatPercentageValue = (value: number) => {
+    return formatNumber(value / 100, {
+      style: 'percent',
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 1,
+    });
+  };
 
   const chartData = useMemo(() => {
     if (noData) return [];
@@ -108,16 +126,16 @@ const ComparisonBarChart = <Row,>({
               </Text>
               <Box display="flex" gap="12px" alignItems="center">
                 {payload.primaryValue > 0 && (
-                  <Text fontSize="s" color="coolGrey700" m="0px">
-                    {payload.primaryValue}%
-                  </Text>
+                  <PercentageLabel color={fill}>
+                    {formatPercentageValue(payload.primaryValue)}
+                  </PercentageLabel>
                 )}
                 {showComparison &&
                   payload.comparisonValue !== undefined &&
                   payload.comparisonValue > 0 && (
-                    <Text fontSize="s" color="coolGrey700" m="0px">
-                      {payload.comparisonValue}%
-                    </Text>
+                    <PercentageLabel color={comparisonColor}>
+                      {formatPercentageValue(payload.comparisonValue)}
+                    </PercentageLabel>
                   )}
               </Box>
             </Box>

--- a/front/app/components/admin/Graphs/ComparisonBarChart/index.tsx
+++ b/front/app/components/admin/Graphs/ComparisonBarChart/index.tsx
@@ -20,26 +20,19 @@ const BarContainer = styled(Box)`
   position: relative;
 `;
 
-const BarRow = styled(Box)<{ isFullHeight?: boolean }>`
-  height: ${({ isFullHeight }) => (isFullHeight ? '100%' : '50%')};
-  width: 100%;
-  overflow: hidden;
-  position: relative;
-`;
-
 const BarFill = styled(Box)<{
   percentage: number;
   color: string;
   opacity: number;
-  isFullHeight?: boolean;
 }>`
   position: absolute;
-  left: 1px;
-  top: 1px;
-  height: ${({ isFullHeight }) => (isFullHeight ? '14px' : '7px')};
-  width: calc(${({ percentage }) => percentage}% - 2px);
+  left: 0;
+  top: 0;
+  height: 100%;
+  width: ${({ percentage }) => percentage}%;
   background: ${({ color }) => color};
   opacity: ${({ opacity }) => opacity};
+  border-radius: 3px;
 
   @media print {
     -webkit-print-color-adjust: exact;
@@ -95,7 +88,7 @@ const ComparisonBarChart = <Row,>({
       ref={innerRef}
       display="flex"
       flexDirection="column"
-      gap="8px"
+      gap="16px"
       width={typeof width === 'number' ? `${width}px` : width}
       height={typeof height === 'number' ? `${height}px` : height}
       role="img"
@@ -142,24 +135,27 @@ const ComparisonBarChart = <Row,>({
 
             <BarContainer style={{ height: `${barHeight}px` }}>
               <Box display="flex" flexDirection="column" h="100%">
-                <BarRow isFullHeight={!showComparison}>
+                <Box
+                  h={showComparison ? '50%' : '100%'}
+                  w="100%"
+                  position="relative"
+                >
                   <BarFill
                     percentage={payload.primaryValue}
                     color={fill}
                     opacity={opacity}
-                    isFullHeight={!showComparison}
                   />
-                </BarRow>
+                </Box>
                 {showComparison &&
                   payload.comparisonValue !== undefined &&
                   payload.comparisonValue > 0 && (
-                    <BarRow>
+                    <Box h="50%" w="100%" position="relative">
                       <BarFill
                         percentage={payload.comparisonValue}
                         color={comparisonColor}
                         opacity={1}
                       />
-                    </BarRow>
+                    </Box>
                   )}
               </Box>
             </BarContainer>

--- a/front/app/containers/Admin/projects/project/insights/participationMetrics/MetricCard.tsx
+++ b/front/app/containers/Admin/projects/project/insights/participationMetrics/MetricCard.tsx
@@ -10,6 +10,8 @@ import {
 
 import { SevenDayChange } from 'api/phase_insights/types';
 
+import { useIntl } from 'utils/cl-intl';
+
 import MetricTrend from './MetricTrend';
 
 interface Props {
@@ -20,8 +22,9 @@ interface Props {
 }
 
 const MetricCard = ({ label, value, icon, change }: Props) => {
+  const { formatNumber } = useIntl();
   const formattedValue =
-    typeof value === 'number' ? value.toLocaleString() : value;
+    typeof value === 'number' ? formatNumber(value) : value;
 
   return (
     <Box

--- a/front/app/containers/Admin/projects/project/insights/participationMetrics/MetricTrend.tsx
+++ b/front/app/containers/Admin/projects/project/insights/participationMetrics/MetricTrend.tsx
@@ -20,7 +20,7 @@ interface Props {
 }
 
 const MetricTrend = ({ change }: Props) => {
-  const { formatMessage } = useIntl();
+  const { formatMessage, formatNumber } = useIntl();
 
   if (change === null || change === 'last_7_days_compared_with_zero') {
     const tooltipMessage =
@@ -58,7 +58,14 @@ const MetricTrend = ({ change }: Props) => {
     : isNeutral
     ? undefined
     : 'arrow-down';
-  const trendLabel = `${isPositive ? '+' : ''}${Math.round(change)}%`;
+  const formattedPercentage = formatNumber(Math.round(change) / 100, {
+    style: 'percent',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  });
+  const trendLabel = isPositive
+    ? `+${formattedPercentage}`
+    : formattedPercentage;
   const trendColor: Color = isNeutral
     ? 'textSecondary'
     : isPositive

--- a/front/app/containers/Admin/projects/project/insights/participationMetrics/ParticipationMetrics.tsx
+++ b/front/app/containers/Admin/projects/project/insights/participationMetrics/ParticipationMetrics.tsx
@@ -18,7 +18,7 @@ interface Props {
 }
 
 const ParticipationMetrics = ({ phase }: Props) => {
-  const { formatMessage } = useIntl();
+  const { formatMessage, formatNumber } = useIntl();
   const { start_at, end_at, participation_method } = phase.attributes;
   const {
     data: response,
@@ -87,7 +87,11 @@ const ParticipationMetrics = ({ phase }: Props) => {
 
       <MetricCard
         label={formatMessage(messages.participationRate)}
-        value={`${metrics.participation_rate_as_percent.toFixed(1)}%`}
+        value={formatNumber(metrics.participation_rate_as_percent / 100, {
+          style: 'percent',
+          minimumFractionDigits: 1,
+          maximumFractionDigits: 1,
+        })}
         icon="chart-bar"
         change={
           isCurrentPhase


### PR DESCRIPTION
# Changelog

## Fixed
- Use internationalised numbers on the insights page (Hidden behind a feature flag)
- Minor design upgrades on the demographics widget (Hidden behind a feature flag)
