### PR TITLE
[TAN-6339] Add nav bar to event and idea show pages

### DIFF
--- a/front/app/containers/App/index.tsx
+++ b/front/app/containers/App/index.tsx
@@ -43,11 +43,7 @@ import clHistory from 'utils/cl-router/history';
 import Navigate from 'utils/cl-router/Navigate';
 import { removeLocale } from 'utils/cl-router/updateLocationDescriptor';
 import eventEmitter from 'utils/eventEmitter';
-import {
-  initiativeShowPageSlug,
-  isIdeaShowPage,
-  isPage,
-} from 'utils/helperUtils';
+import { initiativeShowPageSlug, isPage } from 'utils/helperUtils';
 import { usePermission } from 'utils/permissions';
 import { isAdmin, isModerator } from 'utils/permissions/roles';
 
@@ -322,7 +318,6 @@ const App = ({ children }: Props) => {
   );
   const isIdeaFormPage = isPage('idea_form', location.pathname);
   const isIdeaEditPage = isPage('idea_edit', location.pathname);
-  const isEventPage = isPage('event_page', location.pathname);
   const isNativeSurveyPage = isPage('native_survey', location.pathname);
   const isIdeasFeedPage = isPage('ideas_feed', location.pathname);
   const theme = getTheme(appConfiguration);
@@ -355,12 +350,6 @@ const App = ({ children }: Props) => {
       isIdeasFeedPage
     ) {
       return false;
-    }
-
-    if (isSmallerThanTablet) {
-      if (isEventPage || isIdeaShowPage(urlSegments)) {
-        return false;
-      }
     }
 
     return true;

--- a/front/app/containers/EventsShowPage/components/MobileTopBar.tsx
+++ b/front/app/containers/EventsShowPage/components/MobileTopBar.tsx
@@ -22,10 +22,6 @@ const Container = styled.div`
   flex: 0 0 ${(props) => props.theme.mobileTopBarHeight}px;
   height: ${(props) => props.theme.mobileTopBarHeight}px;
   background-color: #fff;
-  border-bottom: solid 1px ${colors.coolGrey300};
-  position: sticky;
-  top: 0;
-  z-index: 2000;
 `;
 
 const TopBarInner = styled.div`

--- a/front/app/containers/EventsShowPage/components/MobileTopBar.tsx
+++ b/front/app/containers/EventsShowPage/components/MobileTopBar.tsx
@@ -1,11 +1,6 @@
 import React from 'react';
 
-import {
-  useBreakpoint,
-  Box,
-  media,
-  colors,
-} from '@citizenlab/cl2-component-library';
+import { useBreakpoint, Box, media } from '@citizenlab/cl2-component-library';
 import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 

--- a/front/app/containers/IdeasShowPage/IdeaShowPageTopBar.tsx
+++ b/front/app/containers/IdeasShowPage/IdeaShowPageTopBar.tsx
@@ -1,12 +1,6 @@
 import React, { useState, useCallback, useEffect } from 'react';
 
-import {
-  Box,
-  useBreakpoint,
-  media,
-  colors,
-} from '@citizenlab/cl2-component-library';
-import { lighten } from 'polished';
+import { Box, useBreakpoint, media } from '@citizenlab/cl2-component-library';
 import { useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -36,7 +30,6 @@ const Container = styled.div`
   flex: 0 0 ${(props) => props.theme.mobileTopBarHeight}px;
   height: ${(props) => props.theme.mobileTopBarHeight}px;
   background-color: #fff;
-  border-bottom: solid 1px ${lighten(0.3, colors.textSecondary)};
 `;
 
 const TopBarInner = styled.div`

--- a/front/app/containers/IdeasShowPage/index.tsx
+++ b/front/app/containers/IdeasShowPage/index.tsx
@@ -8,7 +8,7 @@ import {
   colors,
 } from '@citizenlab/cl2-component-library';
 import { useParams, useSearchParams } from 'react-router-dom';
-import styled, { useTheme } from 'styled-components';
+import styled from 'styled-components';
 
 import { VotingContext } from 'api/baskets_ideas/useVoting';
 import useIdeaBySlug from 'api/ideas/useIdeaBySlug';
@@ -50,7 +50,6 @@ const StyledIdeasShow = styled(IdeasShow)`
 `;
 
 const IdeasShowPage = () => {
-  const theme = useTheme();
   const { slug } = useParams() as { slug: string };
   const { data: idea, status, error } = useIdeaBySlug(slug);
   const isSmallerThanTablet = useBreakpoint('tablet');

--- a/front/app/containers/IdeasShowPage/index.tsx
+++ b/front/app/containers/IdeasShowPage/index.tsx
@@ -29,14 +29,6 @@ import { isUnauthorizedRQ } from 'utils/errorUtils';
 import DesktopTopBar from './DesktopTopBar';
 import IdeaShowPageTopBar from './IdeaShowPageTopBar';
 
-const StyledIdeaShowPageTopBar = styled(IdeaShowPageTopBar)`
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  z-index: 1000;
-`;
-
 // note: StyledIdeasShow styles defined here should match that in PostPageFullscreenModal!
 const StyledIdeasShow = styled(IdeasShow)`
   min-height: calc(
@@ -105,20 +97,14 @@ const IdeasShowPage = () => {
       >
         <Box background={colors.white}>
           {isSmallerThanTablet ? (
-            <StyledIdeaShowPageTopBar idea={idea.data} phase={phase} />
+            <IdeaShowPageTopBar idea={idea.data} phase={phase} />
           ) : (
             // 64px is the height of the CTA bar (see ParticipationCTAContent)
             <Box mt={showCTABar ? '64px' : undefined}>
               <DesktopTopBar project={project.data} />
             </Box>
           )}
-          <Box
-            mt={
-              // If we show IdeaShowPageTopBar on mobile, we need to push down main
-              isSmallerThanTablet ? `${theme.mobileTopBarHeight}px` : undefined
-            }
-            mb="8px"
-          >
+          <Box mb="8px">
             <main id="e2e-idea-show">
               <StyledIdeasShow
                 ideaId={idea.data.id}

--- a/front/app/utils/helperUtils.ts
+++ b/front/app/utils/helperUtils.ts
@@ -87,19 +87,6 @@ export function isPage(pageKey: pageKeys, pathName: string) {
   }
 }
 
-export const isIdeaShowPage = (urlSegments: string[]) => {
-  const firstUrlSegment = urlSegments[0];
-  const secondUrlSegment = urlSegments[1];
-  const lastUrlSegment = urlSegments[urlSegments.length - 1];
-
-  return (
-    urlSegments.length === 3 &&
-    locales.includes(firstUrlSegment) &&
-    secondUrlSegment === 'ideas' &&
-    lastUrlSegment !== 'new'
-  );
-};
-
 export const initiativeShowPageSlug = (urlSegments: string[]) => {
   const firstUrlSegment = urlSegments[0];
   const secondUrlSegment = urlSegments[1];


### PR DESCRIPTION
# Description

**_(This is the last a11y ticket for this cycle. I had planned to have this done by Friday EOD, but I didn't end up having time.)_**

From the a11y audit, it was decided ([Slack link](https://go-vocal.slack.com/archives/C09E46T93EX/p1768578430377779?thread_ts=1765276312.527399&cid=C09E46T93EX)) to add in the full nav bar to Event and Idea show pages for better consistency across the platform. As such, the nav bar has been added, and the previous action bar (with go back buttons) has been integrated into the page at the top instead (and is not sticky).

E.g. Before & After:

<img width="401" height="570" alt="image" src="https://github.com/user-attachments/assets/5c66389b-02ac-4b5d-8556-8f6ce7e25446" />

<img width="401" height="570" alt="image" src="https://github.com/user-attachments/assets/973b244a-0b7c-4e16-80de-3a4c30225ba1" />