### PR TITLE
[No-ticket] disable rubocop Metrics/AbcSize for method

### DIFF
--- a/back/app/services/project_copy_service.rb
+++ b/back/app/services/project_copy_service.rb
@@ -26,6 +26,7 @@ class ProjectCopyService < TemplateService # rubocop:disable Metrics/ClassLength
     project
   end
 
+  # rubocop:disable Metrics/AbcSize
   def export(
     project,
     local_copy: false,
@@ -95,6 +96,7 @@ class ProjectCopyService < TemplateService # rubocop:disable Metrics/ClassLength
     end
     @template
   end
+  # rubocop:enable Metrics/AbcSize
 
   private
 


### PR DESCRIPTION
# Changelog
## Technical
- [No-ticket] disable rubocop Metrics/AbcSize for method
