### PR TITLE
[TAN-5500] Add flex wrap to avoid the ui being cutoff for languages with long words

### DIFF
--- a/front/app/containers/Admin/projects/project/analysis/Tags/TagAssistance.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Tags/TagAssistance.tsx
@@ -27,7 +27,7 @@ const Step1 = ({ onSetStep }) => {
         <FormattedMessage {...messages.autoAssignQuestion} />
       </Title>
 
-      <Box display="flex" gap="24px" mt="24px">
+      <Box display="flex" gap="24px" mt="24px" flexWrap="wrap">
         <Button
           buttonStyle="primary-outlined"
           onClick={() => onSetStep('step2-auto')}


### PR DESCRIPTION
# Changelog
## Fixed
- Fixed the UI cutting off in the AI analysis interface for languages with long word (the auto-tagging pop-up)
