### PR TITLE
TAN-6547 Replace Bedrock model infering with ENV var

### DIFF
--- a/back/app/services/files/description_generator.rb
+++ b/back/app/services/files/description_generator.rb
@@ -40,7 +40,8 @@ module Files
     # @param locales [Array<String>] Array of locale codes
     # @return [Hash] Hash with locale keys and description values
     def generate_descriptions(file, locales)
-      chat = RubyLLM.chat(model: infer_best_model, provider: :bedrock, assume_model_exists: true)
+      model_id = ENV.fetch('BEDROCK_SONNET_MODEL', 'eu.anthropic.claude-sonnet-4-5-20250929-v1:0')
+      chat = RubyLLM.chat(model: model_id, provider: :bedrock, assume_model_exists: true)
       prompt = build_prompt(file.name, locales)
       prefill_msg = '{' # Prefill the response to encourage the LLM to respond with a JSON object
 
@@ -57,40 +58,6 @@ module Files
 
     def file_preprocessor
       @file_preprocessor ||= LLMFilePreprocessor.new
-    end
-
-    # Selects the best available Claude model for the Bedrock provider.
-    # Uses Sonnet 4 if available, otherwise falls back to Sonnet 3.7.
-    #
-    # @return [String] The model ID to use
-    def infer_best_model
-      # RubyLLM does not yet support all Bedrock regions due to differences in available
-      # models and inference profiles. In the following regions, it returns non-existent
-      # inference profiles. For now, we hardcode the id of the inference profile and set
-      # +assume_model_exists+ to +true+ when initializing the RubyLLM client.
-      # (We are considering moving away from RubyLLM, so we don't want to spend too much
-      # time on a full fix.)
-      if RubyLLM.config.bedrock_region.in? %w[ca-central-1 sa-east-1]
-        return 'global.anthropic.claude-sonnet-4-5-20250929-v1:0'
-      end
-
-      available_models = RubyLLM.models
-        .select { |model| model.provider == 'bedrock' }
-        .map(&:id)
-
-      # These are not full model IDs, but substrings used to find the corresponding model
-      # ID, since model IDs can vary depending on the Bedrock region.
-      preferred_models = %w[
-        .anthropic.claude-sonnet-4
-        .anthropic.claude-3-7-sonnet
-      ]
-
-      preferred_models.each do |substring|
-        matching_model = available_models.find { |id| id.include?(substring) }
-        return matching_model if matching_model
-      end
-
-      raise DescriptionGeneratorError, 'No suitable model found for description generation.'
     end
 
     def build_prompt(file_name, locales)

--- a/back/app/services/files/description_generator.rb
+++ b/back/app/services/files/description_generator.rb
@@ -6,6 +6,8 @@ module Files
   # @example Basic usage
   #   Files::DescriptionGenerator.new.generate_descriptions!(file)
   class DescriptionGenerator
+    SONNET_MODEL_ID = ENV.fetch('BEDROCK_SONNET_MODEL', 'eu.anthropic.claude-sonnet-4-5-20250929-v1:0')
+
     delegate :generate_descriptions?, to: :class
 
     # Generate and update the descriptions for the given file
@@ -40,8 +42,7 @@ module Files
     # @param locales [Array<String>] Array of locale codes
     # @return [Hash] Hash with locale keys and description values
     def generate_descriptions(file, locales)
-      model_id = ENV.fetch('BEDROCK_SONNET_MODEL', 'eu.anthropic.claude-sonnet-4-5-20250929-v1:0')
-      chat = RubyLLM.chat(model: model_id, provider: :bedrock, assume_model_exists: true)
+      chat = RubyLLM.chat(model: SONNET_MODEL_ID, provider: :bedrock, assume_model_exists: true)
       prompt = build_prompt(file.name, locales)
       prefill_msg = '{' # Prefill the response to encourage the LLM to respond with a JSON object
 

--- a/back/spec/fixtures/vcr_cassettes/Files_DescriptionGenerator/_generate_descriptions_/generates_and_updates_the_file_descriptions_for_a_supported_file_format.yml
+++ b/back/spec/fixtures/vcr_cassettes/Files_DescriptionGenerator/_generate_descriptions_/generates_and_updates_the_file_descriptions_for_a_supported_file_format.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://bedrock-runtime.eu-central-1.amazonaws.com/model/eu.anthropic.claude-sonnet-4-20250514-v1:0/invoke
+    uri: https://bedrock-runtime.eu-central-1.amazonaws.com/model/eu.anthropic.claude-sonnet-4-5-20250929-v1:0/invoke
     body:
       encoding: UTF-8
       string: '{"anthropic_version":"bedrock-2023-05-31","messages":[{"role":"user","content":[{"type":"text","text":"Analyze

--- a/back/spec/fixtures/vcr_cassettes/Files_DescriptionGenerator/_generate_descriptions_/raises_RubyLLM_BadRequestError_for_unsupported_file.yml
+++ b/back/spec/fixtures/vcr_cassettes/Files_DescriptionGenerator/_generate_descriptions_/raises_RubyLLM_BadRequestError_for_unsupported_file.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://bedrock-runtime.eu-central-1.amazonaws.com/model/eu.anthropic.claude-sonnet-4-20250514-v1:0/invoke
+    uri: https://bedrock-runtime.eu-central-1.amazonaws.com/model/eu.anthropic.claude-sonnet-4-5-20250929-v1:0/invoke
     body:
       encoding: UTF-8
       string: '{"anthropic_version":"bedrock-2023-05-31","messages":[{"role":"user","content":[{"type":"text","text":"Analyze

--- a/back/spec/fixtures/vcr_cassettes/Files_DescriptionGenerator/_generate_descriptions_/the_file_is_an_image/when_the_image_is_large/is_resized_and_generates_descriptions.yml
+++ b/back/spec/fixtures/vcr_cassettes/Files_DescriptionGenerator/_generate_descriptions_/the_file_is_an_image/when_the_image_is_large/is_resized_and_generates_descriptions.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://bedrock-runtime.eu-central-1.amazonaws.com/model/eu.anthropic.claude-sonnet-4-20250514-v1:0/invoke
+    uri: https://bedrock-runtime.eu-central-1.amazonaws.com/model/eu.anthropic.claude-sonnet-4-5-20250929-v1:0/invoke
     body:
       encoding: UTF-8
       string: '{"anthropic_version":"bedrock-2023-05-31","messages":[{"role":"user","content":[{"type":"text","text":"Analyze

--- a/back/spec/fixtures/vcr_cassettes/Files_DescriptionGenerator/_generate_descriptions_/the_file_is_an_image/when_the_image_is_small/generates_descriptions_without_resizing.yml
+++ b/back/spec/fixtures/vcr_cassettes/Files_DescriptionGenerator/_generate_descriptions_/the_file_is_an_image/when_the_image_is_small/generates_descriptions_without_resizing.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://bedrock-runtime.eu-central-1.amazonaws.com/model/eu.anthropic.claude-sonnet-4-20250514-v1:0/invoke
+    uri: https://bedrock-runtime.eu-central-1.amazonaws.com/model/eu.anthropic.claude-sonnet-4-5-20250929-v1:0/invoke
     body:
       encoding: UTF-8
       string: '{"anthropic_version":"bedrock-2023-05-31","messages":[{"role":"user","content":[{"type":"text","text":"Analyze

--- a/back/spec/fixtures/vcr_cassettes/Files_DescriptionGenerator/_generate_descriptions_/when_the_file_type_is_not_supported_by_the_LLM_but_is_previewable_as_PDF/when_the_preview_generation_failed/converts_docx_to_HTML_and_generates_descriptions.yml
+++ b/back/spec/fixtures/vcr_cassettes/Files_DescriptionGenerator/_generate_descriptions_/when_the_file_type_is_not_supported_by_the_LLM_but_is_previewable_as_PDF/when_the_preview_generation_failed/converts_docx_to_HTML_and_generates_descriptions.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://bedrock-runtime.eu-central-1.amazonaws.com/model/eu.anthropic.claude-sonnet-4-20250514-v1:0/invoke
+    uri: https://bedrock-runtime.eu-central-1.amazonaws.com/model/eu.anthropic.claude-sonnet-4-5-20250929-v1:0/invoke
     body:
       encoding: UTF-8
       string: '{"anthropic_version":"bedrock-2023-05-31","messages":[{"role":"user","content":[{"type":"text","text":"Analyze

--- a/back/spec/fixtures/vcr_cassettes/Files_DescriptionGenerator/_generate_descriptions_/when_the_file_type_is_not_supported_by_the_LLM_but_is_previewable_as_PDF/when_the_preview_is_present/generates_and_updates_the_file_descriptions.yml
+++ b/back/spec/fixtures/vcr_cassettes/Files_DescriptionGenerator/_generate_descriptions_/when_the_file_type_is_not_supported_by_the_LLM_but_is_previewable_as_PDF/when_the_preview_is_present/generates_and_updates_the_file_descriptions.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://bedrock-runtime.eu-central-1.amazonaws.com/model/eu.anthropic.claude-sonnet-4-20250514-v1:0/invoke
+    uri: https://bedrock-runtime.eu-central-1.amazonaws.com/model/eu.anthropic.claude-sonnet-4-5-20250929-v1:0/invoke
     body:
       encoding: UTF-8
       string: '{"anthropic_version":"bedrock-2023-05-31","messages":[{"role":"user","content":[{"type":"text","text":"Analyze


### PR DESCRIPTION
Also ran a script to run `available_models` on all clusters, processed the output with AI and came up with this table, and checked to make sure they're not hallucinated. Adding it as env vars.
```

Region	Model String
aws-aus-3 (Australia)	ap.anthropic.claude-sonnet-4-5-20250929-v1:0
aws-bnl-3 (Benelux)	eu.anthropic.claude-sonnet-4-5-20250929-v1:0
aws-can-3 (Canada)	ca.anthropic.claude-sonnet-4-5-20250929-v1:0
aws-paris-3 (Paris)	eu.anthropic.claude-sonnet-4-5-20250929-v1:0
aws-stockholm-3 (Stockholm)	eu.anthropic.claude-sonnet-4-5-20250929-v1:0
aws-uk-3 (UK)	eu.anthropic.claude-sonnet-4-5-20250929-v1:0
aws-usw-3 (US West)	us.anthropic.claude-sonnet-4-5-20250929-v1:0
aws-sam-3 (South America)	sa.anthropic.claude-sonnet-4-5-20250929-v1:0
```

# Changelog
## Fixed
- Generating file descriptions works again in all regions.
