### PR TITLE
TAN-6458: Add key to explain common ground colors in results

### DIFF
--- a/front/app/containers/ProjectsShowPage/timeline/CommonGround/CommonGroundResults/ColorKey.tsx
+++ b/front/app/containers/ProjectsShowPage/timeline/CommonGround/CommonGroundResults/ColorKey.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+import { Box, colors } from '@citizenlab/cl2-component-library';
+import Text from 'component-library/components/Text';
+
+import { useIntl } from 'utils/cl-intl';
+
+import messages from '../messages';
+
+const ColorKey = () => {
+  const { formatMessage } = useIntl();
+
+  return (
+    <Box display="flex" alignItems="center" gap="16px" mb="16px">
+      <Box display="flex" alignItems="center" gap="4px">
+        <Box
+          width="12px"
+          height="12px"
+          borderRadius="2px"
+          bg={colors.green500}
+        />
+        <Text fontSize="s" color="grey700" my="0px">
+          {formatMessage(messages.agreeLabel)}
+        </Text>
+      </Box>
+      <Box display="flex" alignItems="center" gap="4px">
+        <Box
+          width="12px"
+          height="12px"
+          borderRadius="2px"
+          bg={colors.coolGrey500}
+        />
+        <Text fontSize="s" color="grey700" my="0px">
+          {formatMessage(messages.unsureLabel)}
+        </Text>
+      </Box>
+      <Box display="flex" alignItems="center" gap="4px">
+        <Box width="12px" height="12px" borderRadius="2px" bg={colors.red500} />
+        <Text fontSize="s" color="grey700" my="0px">
+          {formatMessage(messages.disagreeLabel)}
+        </Text>
+      </Box>
+    </Box>
+  );
+};
+
+export default ColorKey;

--- a/front/app/containers/ProjectsShowPage/timeline/CommonGround/CommonGroundResults/index.tsx
+++ b/front/app/containers/ProjectsShowPage/timeline/CommonGround/CommonGroundResults/index.tsx
@@ -9,6 +9,7 @@ import { useIntl } from 'utils/cl-intl';
 
 import messages from '../messages';
 
+import ColorKey from './ColorKey';
 import ResultList from './ResultList';
 import Statistics from './Statistics';
 
@@ -50,6 +51,7 @@ const CommonGroundResults = ({ phaseId }: Props) => {
         numOfIdeas={num_ideas}
         totalVotes={totalVotes}
       />
+      <ColorKey />
       <ResultList
         title={formatMessage(messages.highestConsensusTitle)}
         description={formatMessage(messages.highestConsensusDescription)}

--- a/front/app/containers/ProjectsShowPage/timeline/CommonGround/OutcomeBreakdownBar.tsx
+++ b/front/app/containers/ProjectsShowPage/timeline/CommonGround/OutcomeBreakdownBar.tsx
@@ -36,21 +36,21 @@ const OutcomeBreakdownBar = ({
           as="span"
           fontWeight="bold"
           fontSize="s"
-          color="red500"
-          mr="8px"
-          my="0px"
-        >
-          {disagreePercent}%
-        </Text>
-        <Text
-          as="span"
-          fontWeight="bold"
-          fontSize="s"
           color="coolGrey500"
           mr="8px"
           my="0px"
         >
           {unsurePercent}%
+        </Text>
+        <Text
+          as="span"
+          fontWeight="bold"
+          fontSize="s"
+          color="red500"
+          mr="8px"
+          my="0px"
+        >
+          {disagreePercent}%
         </Text>
         {typeof totalCount === 'number' && (
           <Text as="span" color="grey800" my="0px">
@@ -68,8 +68,8 @@ const OutcomeBreakdownBar = ({
         bg={colors.background}
       >
         <Box width={`${agreedPercent}%`} bg={colors.green500} />
-        <Box width={`${disagreePercent}%`} bg={colors.red500} />
         <Box width={`${unsurePercent}%`} bg={colors.coolGrey500} />
+        <Box width={`${disagreePercent}%`} bg={colors.red500} />
         {emptyPercent > 0 && (
           <Box width={`${emptyPercent}%`} bg={colors.white} />
         )}


### PR DESCRIPTION
# Changelog

## Added
Color Key: Introduced a legend to define the meaning of each color within the common ground results.

## Changed
Result Ordering: Updated the common ground bar sequence to Agree, Unsure, Disagree (previously Agree, Disagree, Unsure).

<img width="624" height="604" alt="image" src="https://github.com/user-attachments/assets/ff42bbb1-c3e6-44d3-a860-f865223bbff9" />

