### PR TITLE
TAN-6436 Populate dem fields in FE

### DIFF
--- a/back/app/controllers/web_api/v1/ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/ideas_controller.rb
@@ -142,17 +142,6 @@ class WebApi::V1::IdeasController < ApplicationController
       (current_user && Idea.find_by(creation_phase_id: params[:phase_id], author: current_user, publication_status: 'draft')) ||
       Idea.new(project: phase.project, author: current_user, publication_status: 'draft')
 
-    # Merge custom field values from the user's profile
-    # if user fields are presented in the idea form
-    # AND the user_data_collection setting allows it
-    if phase.pmethod.user_fields_in_form_enabled?
-      draft_idea.custom_field_values = UserFieldsInFormService.merge_user_fields_into_idea(
-        current_user,
-        phase,
-        draft_idea.custom_field_values
-      )
-    end
-
     render_show draft_idea, check_auth: false
   end
 

--- a/back/app/serializers/web_api/v1/phase_serializer.rb
+++ b/back/app/serializers/web_api/v1/phase_serializer.rb
@@ -69,6 +69,10 @@ class WebApi::V1::PhaseSerializer < WebApi::V1::BaseSerializer
     phase.pmethod.user_data_collection
   end
 
+  attribute :user_fields_in_form_enabled do |phase|
+    phase.pmethod.user_fields_in_form_enabled?
+  end
+
   attribute :allow_anonymous_participation do |phase|
     posting_permission = phase.permissions.find_by(action: 'posting_idea')
     posting_permission&.permitted_by == 'everyone' || phase.allow_anonymous_participation

--- a/back/app/services/user_fields_in_form_service.rb
+++ b/back/app/services/user_fields_in_form_service.rb
@@ -50,17 +50,8 @@ class UserFieldsInFormService
     return idea_custom_field_values unless current_user
     return idea_custom_field_values if phase.blank?
 
-    permission = phase.permissions.find_by(action: 'posting_idea')
-
-    # Use PermissionsCustomFieldsService to get fields, which handles both persisted and non-persisted (global) fields
-    permissions_custom_fields_service = Permissions::PermissionsCustomFieldsService.new
-    permissions_custom_fields = permissions_custom_fields_service.fields_for_permission(permission)
-
-    allowed_keys = permissions_custom_fields.map { |pcf| pcf.custom_field.key }.uniq
-
     user_values = current_user
       .custom_field_values
-      .select { |key, _value| allowed_keys.include?(key) }
       .transform_keys do |key|
         prefix_key(key)
       end

--- a/back/spec/services/user_fields_in_form_service_spec.rb
+++ b/back/spec/services/user_fields_in_form_service_spec.rb
@@ -105,23 +105,6 @@ describe UserFieldsInFormService do
       })
     end
 
-    it 'does not include user fields that are not explicitly asked' do
-      user = build(:user, custom_field_values: { 'age' => 30, 'city' => 'New York', 'gender' => 'female' })
-      idea = build(:idea, custom_field_values: { 'satisfaction' => 'high' })
-
-      merged_values = described_class.merge_user_fields_into_idea(
-        user,
-        @phase,
-        idea.custom_field_values
-      )
-
-      expect(merged_values).to eq({
-        'u_age' => 30,
-        'u_city' => 'New York',
-        'satisfaction' => 'high'
-      })
-    end
-
     it 'pre-populates user fields when using global_custom_fields being the default' do
       user = build(:user, custom_field_values: { 'age' => 30, 'city' => 'New York' })
       idea = build(:idea, custom_field_values: {})

--- a/front/app/api/phases/__mocks__/_mockServer.ts
+++ b/front/app/api/phases/__mocks__/_mockServer.ts
@@ -34,6 +34,7 @@ export const phasesData: IPhaseData[] = [
       total_votes_amount: 0,
       user_data_collection: 'all_data',
       voting_filtering_enabled: false,
+      user_fields_in_form_enabled: false,
     },
     relationships: {
       permissions: {
@@ -81,6 +82,7 @@ export const phasesData: IPhaseData[] = [
       total_votes_amount: 0,
       user_data_collection: 'all_data',
       voting_filtering_enabled: false,
+      user_fields_in_form_enabled: false,
     },
     relationships: {
       permissions: {
@@ -124,6 +126,7 @@ export const phasesData: IPhaseData[] = [
       total_votes_amount: 0,
       user_data_collection: 'all_data',
       voting_filtering_enabled: false,
+      user_fields_in_form_enabled: false,
     },
     relationships: {
       permissions: {
@@ -172,6 +175,7 @@ export const mockPhaseInformationData: IPhaseData = {
     total_votes_amount: 0,
     user_data_collection: 'all_data',
     voting_filtering_enabled: false,
+    user_fields_in_form_enabled: false,
   },
   relationships: {
     permissions: {
@@ -219,6 +223,7 @@ export const mockPhaseIdeationData: IPhaseData = {
     total_votes_amount: 0,
     user_data_collection: 'all_data',
     voting_filtering_enabled: false,
+    user_fields_in_form_enabled: false,
   },
   relationships: {
     permissions: {
@@ -268,6 +273,7 @@ export const mockPhaseSurveyTypeformData: IPhaseData = {
     total_votes_amount: 0,
     user_data_collection: 'all_data',
     voting_filtering_enabled: false,
+    user_fields_in_form_enabled: false,
   },
   relationships: {
     permissions: {
@@ -317,6 +323,7 @@ export const mockPhaseSurveyGoogleFormData: IPhaseData = {
     total_votes_amount: 0,
     user_data_collection: 'all_data',
     voting_filtering_enabled: false,
+    user_fields_in_form_enabled: false,
   },
   relationships: {
     permissions: {
@@ -385,6 +392,7 @@ const votingPhase: IPhaseData = {
     report_public: false,
     user_data_collection: 'all_data',
     voting_filtering_enabled: true,
+    user_fields_in_form_enabled: false,
   },
   relationships: {
     permissions: {

--- a/front/app/api/phases/types.ts
+++ b/front/app/api/phases/types.ts
@@ -82,6 +82,7 @@ export interface IPhaseAttributes {
   similarity_threshold_title?: number | null;
   similarity_threshold_body?: number | null;
   user_data_collection: UserDataCollection;
+  user_fields_in_form_enabled: boolean;
 }
 
 export interface IPhases {

--- a/front/app/components/CustomFieldsForm/IdeationForm/index.tsx
+++ b/front/app/components/CustomFieldsForm/IdeationForm/index.tsx
@@ -20,6 +20,7 @@ import tracks from '../tracks';
 import { convertCustomFieldsToNestedPages } from '../util';
 
 import IdeationPage from './IdeationPage';
+import { getInitialData } from './utils';
 
 const IdeationForm = ({
   projectId,
@@ -52,11 +53,13 @@ const IdeationForm = ({
     publicFields: true,
   });
 
+  if (!phase) return null;
+
   const nestedPagesData = convertCustomFieldsToNestedPages(customFields || []);
 
   const showTogglePostAnonymously =
     !!authUser &&
-    phase?.data.attributes.allow_anonymous_participation &&
+    phase.data.attributes.allow_anonymous_participation &&
     participationMethod !== 'native_survey';
 
   const lastPageIndex = nestedPagesData.length - 1;
@@ -100,18 +103,7 @@ const IdeationForm = ({
       setCurrentPageIndex((pageNumber: number) => pageNumber + 1);
     }
   };
-  const initialFormData = idea
-    ? {
-        ...idea.attributes,
-        author_id: idea.relationships.author?.data?.id,
-        cosponsor_ids: idea.relationships.cosponsors?.data?.map(
-          (cosponsor) => cosponsor.id
-        ),
-        topic_ids: idea.relationships.input_topics?.data.map(
-          (topic) => topic.id
-        ),
-      }
-    : undefined;
+  const initialFormData = getInitialData(idea, authUser, phase);
 
   return (
     <Box w="100%">
@@ -127,7 +119,7 @@ const IdeationForm = ({
           ideaId={idea?.id}
           projectId={projectId}
           onSubmit={onSubmit}
-          phase={phase?.data}
+          phase={phase.data}
           defaultValues={initialFormData}
           pages={nestedPagesData}
         />

--- a/front/app/components/CustomFieldsForm/IdeationForm/utils.ts
+++ b/front/app/components/CustomFieldsForm/IdeationForm/utils.ts
@@ -1,15 +1,27 @@
-import { IIdea } from 'api/ideas/types';
+import { IIdeaData } from 'api/ideas/types';
 import { IPhase } from 'api/phases/types';
 import { IUser } from 'api/users/types';
 
 import { addPrefix } from '../util';
 
 export const getInitialData = (
-  draftIdea: IIdea | undefined,
+  idea: IIdeaData | undefined,
   authUser: IUser | undefined,
   phase: IPhase
 ) => {
-  const initialFormData = draftIdea?.data.attributes ?? {};
+  const initialFormData = idea
+    ? {
+        ...idea.attributes,
+        author_id: idea.relationships.author?.data?.id,
+        cosponsor_ids: idea.relationships.cosponsors?.data?.map(
+          (cosponsor) => cosponsor.id
+        ),
+        topic_ids: idea.relationships.input_topics?.data.map(
+          (topic) => topic.id
+        ),
+      }
+    : {};
+
   const customFieldValues = authUser?.data.attributes.custom_field_values;
 
   if (phase.data.attributes.user_fields_in_form_enabled && customFieldValues) {

--- a/front/app/components/CustomFieldsForm/SurveyForm/index.tsx
+++ b/front/app/components/CustomFieldsForm/SurveyForm/index.tsx
@@ -22,6 +22,7 @@ import tracks from '../tracks';
 import { convertCustomFieldsToNestedPages } from '../util';
 
 import SurveyPage from './SurveyPage';
+import { getInitialData } from './utils';
 
 const SurveyForm = ({
   projectId,
@@ -109,7 +110,7 @@ const SurveyForm = ({
     }
   };
 
-  const initialFormData = draftIdea?.data.attributes;
+  const initialFormData = getInitialData(draftIdea, authUser, phase);
 
   if (isLoading) {
     return <Spinner />;

--- a/front/app/components/CustomFieldsForm/SurveyForm/utils.ts
+++ b/front/app/components/CustomFieldsForm/SurveyForm/utils.ts
@@ -8,13 +8,26 @@ export const getInitialData = (
   phase: IPhase
 ) => {
   const initialFormData = draftIdea?.data.attributes ?? {};
+  const customFieldValues = authUser?.data.attributes.custom_field_values;
 
-  if (phase.data.attributes.user_fields_in_form_enabled && authUser) {
+  if (phase.data.attributes.user_fields_in_form_enabled && customFieldValues) {
     return {
       ...initialFormData,
-      ...authUser.data.attributes.custom_field_values,
+      ...addPrefix(customFieldValues),
     };
   }
 
   return initialFormData;
+};
+
+const PREFIX = 'u_';
+
+const addPrefix = (customFieldValues: Record<string, any>) => {
+  const newValues = {};
+
+  for (const key in customFieldValues) {
+    newValues[`${PREFIX}${key}`] = customFieldValues[key];
+  }
+
+  return newValues;
 };

--- a/front/app/components/CustomFieldsForm/SurveyForm/utils.ts
+++ b/front/app/components/CustomFieldsForm/SurveyForm/utils.ts
@@ -1,0 +1,20 @@
+import { IIdea } from 'api/ideas/types';
+import { IPhase } from 'api/phases/types';
+import { IUser } from 'api/users/types';
+
+export const getInitialData = (
+  draftIdea: IIdea | undefined,
+  authUser: IUser | undefined,
+  phase: IPhase
+) => {
+  const initialFormData = draftIdea?.data.attributes ?? {};
+
+  if (phase.data.attributes.user_fields_in_form_enabled && authUser) {
+    return {
+      ...initialFormData,
+      ...authUser.data.attributes.custom_field_values,
+    };
+  }
+
+  return initialFormData;
+};

--- a/front/app/components/CustomFieldsForm/util.ts
+++ b/front/app/components/CustomFieldsForm/util.ts
@@ -167,3 +167,15 @@ export const getInstructionMessage = ({
   }
   return null;
 };
+
+const PREFIX = 'u_';
+
+export const addPrefix = (customFieldValues: Record<string, any>) => {
+  const newValues = {};
+
+  for (const key in customFieldValues) {
+    newValues[`${PREFIX}${key}`] = customFieldValues[key];
+  }
+
+  return newValues;
+};


### PR DESCRIPTION
# Changelog
## Added
- When user fields in form for ideation/proposals: pre-populate if user is logged in
## Technical
- Make user fields in idea behavior consistent: always merge all user fields into idea, regardless of which ones are actually asked