### PR TITLE
[TAN-6460] Correctly interpret phase end_at in phase insights

### DIFF
--- a/back/app/services/insights/base_phase_insights_service.rb
+++ b/back/app/services/insights/base_phase_insights_service.rb
@@ -89,19 +89,17 @@ module Insights
     end
 
     def phase_has_run_more_than_14_days?
-      time_now = Time.current
-      phase_start_at = @phase.start_at.to_time
-      phase_end_at = (@phase.end_at || time_now).to_time
+      time_now = Time.current.to_date
+      phase_end_date = @phase.end_at || time_now
 
-      # Check if the phase duration (start to end or current time) is more than 14 days
-      phase_duration_seconds = phase_end_at - phase_start_at
-      phase_duration_days = (phase_duration_seconds / 86_400).to_i
+      # Check if the phase duration (start to end or current date) is more than 14 days
+      # Add 1 to include both start and end dates (inclusive counting)
+      phase_duration_days = (phase_end_date - @phase.start_at).to_i + 1
 
       return false if phase_duration_days < 14
 
       # Check if the elapsed time from phase start to now is more than 14 days
-      elapsed_seconds = time_now - phase_start_at
-      elapsed_days = (elapsed_seconds / 86_400).to_i
+      elapsed_days = (time_now - @phase.start_at).to_i
 
       elapsed_days >= 14
     end

--- a/back/app/services/insights/base_phase_insights_service.rb
+++ b/back/app/services/insights/base_phase_insights_service.rb
@@ -92,7 +92,7 @@ module Insights
       time_now = Time.current.to_date
       phase_end_date = @phase.end_at || time_now
 
-      # Check if the phase duration (start to end or current date) is more than 14 days
+      # Check if the phase duration (start to end or current date) is less than 14 days
       # Add 1 to include both start and end dates (inclusive counting)
       phase_duration_days = (phase_end_date - @phase.start_at).to_i + 1
 

--- a/back/app/services/insights/visits_service.rb
+++ b/back/app/services/insights/visits_service.rb
@@ -4,9 +4,9 @@ module Insights
       constraints = { project_id: phase.project.id }
 
       constraints[:created_at] = if phase.end_at.present?
-        phase.start_at..phase.end_at
+        phase.start_at.beginning_of_day..phase.end_at.end_of_day
       else
-        phase.start_at..
+        phase.start_at.beginning_of_day..
       end
 
       visits = ImpactTracking::Session

--- a/back/spec/services/insights/base_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/base_phase_insights_service_spec.rb
@@ -604,27 +604,35 @@ RSpec.describe Insights::BasePhaseInsightsService do
 
   describe '#phase_has_run_more_than_14_days?' do
     it 'returns false when phase duration is less than 14 days' do
-      phase = create(:single_voting_phase, start_at: 15.days.ago, end_at: 2.days.ago)
-      service = described_class.new(phase)
-      expect(service.send(:phase_has_run_more_than_14_days?)).to be false
+      travel_to(Time.zone.parse('2026-01-15 12:00:00')) do
+        phase = create(:single_voting_phase, start_at: Date.new(2026, 1, 1), end_at: Date.new(2026, 1, 13)) # 13 days, including both start and end dates
+        service = described_class.new(phase)
+        expect(service.send(:phase_has_run_more_than_14_days?)).to be false
+      end
     end
 
-    it 'returns false when phase duration is more than 14 days but elapsed time is less than 14 days' do
-      phase = create(:single_voting_phase, start_at: 13.days.ago, end_at: 2.days.from_now)
-      service = described_class.new(phase)
-      expect(service.send(:phase_has_run_more_than_14_days?)).to be false
+    it 'returns false when phase duration is 14 days but elapsed time is less than 14 days' do
+      travel_to(Time.zone.parse('2026-01-13 12:00:00')) do
+        phase = create(:single_voting_phase, start_at: Date.new(2026, 1, 1), end_at: Date.new(2026, 1, 14)) # 14 days, including both start and end dates
+        service = described_class.new(phase)
+        expect(service.send(:phase_has_run_more_than_14_days?)).to be false
+      end
     end
 
-    it 'returns true when phase duration is more than 14 days and elapsed time is at least 14 days' do
-      phase = create(:single_voting_phase, start_at: 20.days.ago, end_at: 1.day.ago)
-      service = described_class.new(phase)
-      expect(service.send(:phase_has_run_more_than_14_days?)).to be true
+    it 'returns true when phase duration is 14 days and elapsed time is at least 14 days' do
+      travel_to(Time.zone.parse('2026-01-15 12:00:00')) do
+        phase = create(:single_voting_phase, start_at: Date.new(2026, 1, 1), end_at: Date.new(2026, 1, 14)) # 14 days, including both start and end dates
+        service = described_class.new(phase)
+        expect(service.send(:phase_has_run_more_than_14_days?)).to be true
+      end
     end
 
     it 'returns false when phase is long enough but started less than 14 days ago' do
-      phase = create(:single_voting_phase, start_at: 10.days.ago, end_at: 30.days.from_now)
-      service = described_class.new(phase)
-      expect(service.send(:phase_has_run_more_than_14_days?)).to be false
+      travel_to(Time.zone.parse('2026-01-14 12:00:00')) do
+        phase = create(:single_voting_phase, start_at: Date.new(2026, 1, 1), end_at: Date.new(2026, 1, 14)) # 14 days, including both start and end dates
+        service = described_class.new(phase)
+        expect(service.send(:phase_has_run_more_than_14_days?)).to be false
+      end
     end
 
     it 'returns true for ongoing phases without end_at when started more than 14 days ago' do

--- a/back/spec/services/insights/visits_service_spec.rb
+++ b/back/spec/services/insights/visits_service_spec.rb
@@ -45,7 +45,7 @@ describe Insights::VisitsService do
     describe 'edge cases for phase date boundaries' do
       let(:phase2) { create(:single_voting_phase, start_at: Date.new(2026, 1, 15), end_at: Date.new(2026, 2, 2)) }
       let(:session) { create(:session, user_id: user1.id) }
-      
+
       it 'excludes a visit before the phase start date' do
         create(:pageview, session: session, created_at: Time.zone.parse('2026-01-14 23:59:59'), project_id: phase2.project.id) # before phase start
         visits = service.phase_visits(phase2)


### PR DESCRIPTION
# Changelog
## Fixed
- [TAN-6460] Correctly interpret phase end_at in phase insights (Behind FF)
