### PR TITLE
TAN-6480 Only sync permissions custom fields

### DIFF
--- a/back/app/services/user_fields_in_form_service.rb
+++ b/back/app/services/user_fields_in_form_service.rb
@@ -50,8 +50,17 @@ class UserFieldsInFormService
     return idea_custom_field_values unless current_user
     return idea_custom_field_values if phase.blank?
 
+    permission = phase.permissions.find_by(action: 'posting_idea')
+
+    # Use PermissionsCustomFieldsService to get fields, which handles both persisted and non-persisted (global) fields
+    permissions_custom_fields_service = Permissions::PermissionsCustomFieldsService.new
+    permissions_custom_fields = permissions_custom_fields_service.fields_for_permission(permission)
+
+    allowed_keys = permissions_custom_fields.map { |pcf| pcf.custom_field.key }.uniq
+
     user_values = current_user
       .custom_field_values
+      .select { |key, _value| allowed_keys.include?(key) }
       .transform_keys do |key|
         prefix_key(key)
       end

--- a/back/spec/acceptance/ideas/user_fields_in_form_survey_spec.rb
+++ b/back/spec/acceptance/ideas/user_fields_in_form_survey_spec.rb
@@ -29,6 +29,9 @@ resource 'Ideas' do
       enabled: true
     )
     create(:permissions_custom_field, custom_field: @user_select_field, permission: @permission)
+
+    # Create another user field (but that is not added as permissions_custom_field)
+    create(:custom_field_select, :for_registration, :with_options, key: 'favorite_color', enabled: true)
   end
 
   # This endpoint is used in the context of surveys in 3 situations:
@@ -58,7 +61,8 @@ resource 'Ideas' do
             project_id: @project.id,
             @custom_field.key => 'option2',
             u_user_select_field: 'option1',
-            u_nonexistent_field: 'whatever'
+            u_nonexistent_field: 'whatever', # key has no custom field so should be filtered out
+            u_favorite_color: 'green' # custom field is not a permissions_custom_field so should be filtered out
           }
         })
 

--- a/back/spec/services/user_fields_in_form_service_spec.rb
+++ b/back/spec/services/user_fields_in_form_service_spec.rb
@@ -86,10 +86,28 @@ describe UserFieldsInFormService do
       permission.update!(global_custom_fields: false)
       create(:permissions_custom_field, permission: permission, custom_field: create(:custom_field, key: 'age'))
       create(:permissions_custom_field, permission: permission, custom_field: create(:custom_field, key: 'city'))
+      create(:custom_field, key: 'favorite_color')
     end
 
     it 'merges user custom fields into idea custom fields with prefixed keys' do
       user = build(:user, custom_field_values: { 'age' => 30, 'city' => 'New York' })
+      idea = build(:idea, custom_field_values: { 'satisfaction' => 'high' })
+
+      merged_values = described_class.merge_user_fields_into_idea(
+        user,
+        @phase,
+        idea.custom_field_values
+      )
+
+      expect(merged_values).to eq({
+        'u_age' => 30,
+        'u_city' => 'New York',
+        'satisfaction' => 'high'
+      })
+    end
+
+    it 'does not include user fields that are not explicitly asked in permissions_custom_fields' do
+      user = build(:user, custom_field_values: { 'age' => 30, 'city' => 'New York', 'gender' => 'female', 'favorite_color' => 'green' })
       idea = build(:idea, custom_field_values: { 'satisfaction' => 'high' })
 
       merged_values = described_class.merge_user_fields_into_idea(

--- a/back/spec/services/user_fields_in_form_service_spec.rb
+++ b/back/spec/services/user_fields_in_form_service_spec.rb
@@ -86,7 +86,7 @@ describe UserFieldsInFormService do
       permission.update!(global_custom_fields: false)
       create(:permissions_custom_field, permission: permission, custom_field: create(:custom_field, key: 'age'))
       create(:permissions_custom_field, permission: permission, custom_field: create(:custom_field, key: 'city'))
-      create(:custom_field, key: 'favorite_color')
+      create(:custom_field, key: 'favorite_color', enabled: true)
     end
 
     it 'merges user custom fields into idea custom fields with prefixed keys' do


### PR DESCRIPTION
# Changelog
## Technical
- Revert previous change- make sure that we always only sync the custom field values that are set as permissions_custom_fields and filter out any others