### PR TITLE
Pick other arbitrary date for shift_tenant_timestamps_task_spec

### DIFF
--- a/back/engines/commercial/multi_tenancy/spec/tasks/shift_tenant_timestamps_task_spec.rb
+++ b/back/engines/commercial/multi_tenancy/spec/tasks/shift_tenant_timestamps_task_spec.rb
@@ -6,7 +6,7 @@ describe 'cl2back:shift_tenant_timestamps rake task' do
   it 'Shifts timestamps by 1 day' do
     tenant = create(:tenant, settings: SettingsService.new.minimal_required_settings(locales: %w[en], lifecycle_stage: 'demo', country_code: 'BE'), creation_finalized_at: Time.now)
     tenant.switch do
-      travel_to Time.zone.local(2026, 2, 7, 12, 0, 0) do
+      travel_to Time.zone.local(2200, 2, 8, 12, 0, 0) do
         user = create(:user, registration_completed_at: 2.days.ago)
 
         Rake::Task['cl2back:shift_tenant_timestamps'].invoke


### PR DESCRIPTION
# Changelog
## Technical
- Fix BE test failing because of arbitrary hard-coded date by picking another arbitrary hard-coded date
