### PR TITLE
Rename "sort" to "options_sort_order" for clarity in SurveyResults

### DIFF
--- a/back/app/services/surveys/results_generator.rb
+++ b/back/app/services/surveys/results_generator.rb
@@ -7,11 +7,11 @@
 
 module Surveys
   class ResultsGenerator < FieldVisitorService
-    # sort: 'count' (default) sorts options by count descending, 'original' preserves option order
-    def initialize(phase, structure_by_category: false, sort: 'count')
+    # options_sort_order: 'count' (default) sorts options by count descending, 'original' preserves option order
+    def initialize(phase, structure_by_category: false, options_sort_order: 'count')
       super()
       @phase = phase
-      @sort = sort
+      @options_sort_order = options_sort_order
       form = phase.custom_form || CustomForm.new(participation_context: phase)
       @fields = IdeaCustomFieldsService.new(form).survey_results_fields(structure_by_category:)
       @locales = AppConfiguration.instance.settings('core', 'locales')
@@ -301,7 +301,7 @@ module Surveys
       end
 
       # Sort answers correctly
-      if @sort == 'count' && !field.supports_linear_scale?
+      if @options_sort_order == 'count' && !field.supports_linear_scale?
         answers = answers.sort_by { |a| -a[:count] }
       end
       answers = answers.sort_by { |a| a[:answer] == 'other' ? 1 : 0 } # other should always be last

--- a/back/app/services/surveys/results_with_date_generator.rb
+++ b/back/app/services/surveys/results_with_date_generator.rb
@@ -2,8 +2,8 @@
 
 module Surveys
   class ResultsWithDateGenerator < ResultsGenerator
-    def initialize(phase, structure_by_category: false, year: nil, quarter: nil, sort: 'count')
-      super(phase, structure_by_category: structure_by_category, sort: sort)
+    def initialize(phase, structure_by_category: false, year: nil, quarter: nil, options_sort_order: 'count')
+      super(phase, structure_by_category: structure_by_category, options_sort_order: options_sort_order)
       @year = year&.to_i
       @quarter = quarter&.to_i
       filter_inputs_by_quarter

--- a/back/app/services/surveys/results_with_group_generator.rb
+++ b/back/app/services/surveys/results_with_group_generator.rb
@@ -2,8 +2,8 @@
 
 module Surveys
   class ResultsWithGroupGenerator < ResultsWithDateGenerator
-    def initialize(phase, group_mode: nil, group_field_id: nil, year: nil, quarter: nil, sort: 'count')
-      super(phase, year:, quarter:, sort:)
+    def initialize(phase, group_mode: nil, group_field_id: nil, year: nil, quarter: nil, options_sort_order: 'count')
+      super(phase, year:, quarter:, options_sort_order:)
       @group_mode = group_mode
       @group_field_id = group_field_id
     end

--- a/back/engines/commercial/report_builder/app/services/report_builder/queries/survey_question_result.rb
+++ b/back/engines/commercial/report_builder/app/services/report_builder/queries/survey_question_result.rb
@@ -7,7 +7,7 @@ module ReportBuilder
       group_field_id: nil,
       year: nil,
       quarter: nil,
-      sort: 'count',
+      options_sort_order: 'count',
       **_other_props
     )
       return {} if phase_id.blank? || question_id.blank?
@@ -21,17 +21,17 @@ module ReportBuilder
           group_field_id:,
           year:,
           quarter:,
-          sort: sort
+          options_sort_order:
         )
       elsif year && quarter
         Surveys::ResultsWithDateGenerator.new(
           phase,
           year:,
           quarter:,
-          sort: sort
+          options_sort_order:
         )
       else
-        Surveys::ResultsGenerator.new(phase, sort: sort)
+        Surveys::ResultsGenerator.new(phase, options_sort_order:)
       end
 
       service.generate_result_for_field(question_id)

--- a/back/spec/services/surveys/results_generator_spec.rb
+++ b/back/spec/services/surveys/results_generator_spec.rb
@@ -530,7 +530,7 @@ RSpec.describe Surveys::ResultsGenerator do
       end
 
       context "when sort is 'original'" do
-        subject(:generator) { described_class.new(survey_phase, sort: 'original') }
+        subject(:generator) { described_class.new(survey_phase, options_sort_order: 'original') }
 
         it 'returns select answers in original field option order, with other always last' do
           results = generator.generate_results

--- a/front/app/api/graph_data_units/requestTypes.ts
+++ b/front/app/api/graph_data_units/requestTypes.ts
@@ -48,7 +48,7 @@ export type ParametersLive =
 
 export type GroupMode = 'user_field' | 'survey_question';
 type ExcludeRoles = 'exclude_admins_and_moderators';
-export type Sort = 'count' | 'original';
+export type OptionsSortOrder = 'count' | 'original';
 
 export interface SurveyQuestionResultProps {
   phase_id: string;
@@ -57,7 +57,7 @@ export interface SurveyQuestionResultProps {
   group_field_id?: string;
   year?: string;
   quarter?: string;
-  sort?: Sort;
+  options_sort_order?: OptionsSortOrder;
 }
 
 export interface SurveyQuestionResultParams extends BaseParams {

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/SurveyQuestionResultWidget/Question/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/SurveyQuestionResultWidget/Question/index.tsx
@@ -3,7 +3,7 @@ import React, { useCallback } from 'react';
 import { Title, Box } from '@citizenlab/cl2-component-library';
 
 import { useSurveyQuestionResult } from 'api/graph_data_units';
-import { GroupMode, Sort } from 'api/graph_data_units/requestTypes';
+import { GroupMode, OptionsSortOrder } from 'api/graph_data_units/requestTypes';
 
 import useLocalize from 'hooks/useLocalize';
 
@@ -32,7 +32,7 @@ interface Props {
   year?: number;
   quarter?: number;
   heatmap?: boolean;
-  sort?: Sort;
+  optionsSortOrder?: OptionsSortOrder;
 }
 
 const SurveyQuestionResult = ({
@@ -44,7 +44,7 @@ const SurveyQuestionResult = ({
   heatmap,
   year,
   quarter,
-  sort,
+  optionsSortOrder,
 }: Props) => {
   const { data, error } = useSurveyQuestionResult({
     phase_id: phaseId,
@@ -53,7 +53,7 @@ const SurveyQuestionResult = ({
     group_field_id: groupFieldId,
     year: year?.toString(),
     quarter: quarter?.toString(),
-    sort,
+    options_sort_order: optionsSortOrder,
   });
 
   const localize = useLocalize();

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/SurveyQuestionResultWidget/Settings/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/SurveyQuestionResultWidget/Settings/index.tsx
@@ -50,7 +50,7 @@ const Settings = () => {
     groupMode,
     groupFieldId,
     heatmap,
-    sort,
+    optionsSortOrder,
   } = useNode<Props>((node) => ({
     title: node.data.props.title,
     projectId: node.data.props.projectId,
@@ -59,7 +59,7 @@ const Settings = () => {
     groupMode: node.data.props.groupMode,
     groupFieldId: node.data.props.groupFieldId,
     heatmap: node.data.props.heatmap,
-    sort: node.data.props.sort,
+    optionsSortOrder: node.data.props.optionsSortOrder,
   }));
 
   const { data: questions } = useRawCustomFields({ phaseId });
@@ -164,7 +164,7 @@ const Settings = () => {
   const handleSort = useCallback(
     ({ value }: IOption) => {
       setProp((props: Props) => {
-        props.sort = value;
+        props.optionsSortOrder = value;
       });
     },
     [setProp]
@@ -263,7 +263,7 @@ const Settings = () => {
           <Select
             label={formatMessage(messages.sort)}
             options={sortOptions}
-            value={sort || 'count'}
+            value={optionsSortOrder || 'count'}
             onChange={handleSort}
             dataCy="sort-select"
           />

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/SurveyQuestionResultWidget/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/SurveyQuestionResultWidget/index.tsx
@@ -24,7 +24,7 @@ const SurveyQuestionResultWidget = ({
   quarter,
   ariaLabel,
   description,
-  sort,
+  optionsSortOrder,
 }: Props) => {
   const localize = useLocalize();
   const hasEverything = projectId && phaseId && questionId;
@@ -51,7 +51,7 @@ const SurveyQuestionResultWidget = ({
             heatmap={heatmap}
             year={year}
             quarter={quarter}
-            sort={sort}
+            optionsSortOrder={optionsSortOrder}
           />
           <DescriptionText
             description={description}
@@ -75,7 +75,7 @@ SurveyQuestionResultWidget.craft = {
     heatmap: undefined,
     ariaLabel: undefined,
     description: undefined,
-    sort: undefined,
+    optionsSortOrder: undefined,
   },
   related: {
     settings: Settings,

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/SurveyQuestionResultWidget/typings.ts
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/SurveyQuestionResultWidget/typings.ts
@@ -1,6 +1,6 @@
 import { Multiloc } from 'component-library/utils/typings';
 
-import { GroupMode, Sort } from 'api/graph_data_units/requestTypes';
+import { GroupMode, OptionsSortOrder } from 'api/graph_data_units/requestTypes';
 
 export interface Props {
   projectId?: string;
@@ -13,5 +13,5 @@ export interface Props {
   heatmap?: boolean;
   ariaLabel?: Multiloc;
   description?: Multiloc;
-  sort?: Sort;
+  optionsSortOrder?: OptionsSortOrder;
 }


### PR DESCRIPTION
# Changelog
## Technical
- Rename "sort" to "options_sort_order" for clarity in SurveyResults