### PR TITLE
[TAN-5939] Publish inputs immediately in flagged-only mode

### DIFF
--- a/back/lib/participation_method/ideation.rb
+++ b/back/lib/participation_method/ideation.rb
@@ -29,7 +29,10 @@ module ParticipationMethod
     end
 
     def assign_defaults(input)
-      input_status_code = phase&.prescreening_enabled? ? 'prescreening' : 'proposed'
+      # Only the `all` prescreening mode starts inputs in prescreening. The `flagged_only`
+      # mode starts inputs as published, and oxicity detection will asynchronously move
+      # flagged inputs to prescreening.
+      input_status_code = phase&.prescreening_all? ? 'prescreening' : 'proposed'
       input.idea_status ||= IdeaStatus.find_by!(code: input_status_code, participation_method: idea_status_method)
       input.publication_status ||= input.idea_status.public_post? ? 'published' : 'submitted'
     end

--- a/back/spec/lib/participation_method/ideation_spec.rb
+++ b/back/spec/lib/participation_method/ideation_spec.rb
@@ -72,11 +72,11 @@ RSpec.describe ParticipationMethod::Ideation do
       context 'when prescreening_mode is flagged_only' do
         let(:prescreening_mode) { 'flagged_only' }
 
-        it 'sets idea_status to prescreening and publication_status to submitted' do
+        it 'sets idea_status to proposed and publication_status to published' do
           input = build(:idea, idea_status: nil, publication_status: nil)
           participation_method.assign_defaults input
-          expect(input.idea_status).to eq(prescreening_status)
-          expect(input.publication_status).to eq('submitted')
+          expect(input.idea_status).to eq(proposed_status)
+          expect(input.publication_status).to eq('published')
         end
       end
 

--- a/back/spec/lib/participation_method/proposals_spec.rb
+++ b/back/spec/lib/participation_method/proposals_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe ParticipationMethod::Proposals do
       context 'when prescreening_mode is flagged_only' do
         let(:phase) { create(:proposals_phase, prescreening_mode: 'flagged_only') }
 
-        it 'assigns the default "prescreening" status and submitted publication_status' do
+        it 'assigns the default "proposed" status and published publication_status' do
           proposal = build(
             :proposal, creation_phase: phase, project: phase.project,
             idea_status: nil, publication_status: nil
@@ -53,8 +53,8 @@ RSpec.describe ParticipationMethod::Proposals do
 
           participation_method.assign_defaults(proposal)
 
-          expect(proposal.idea_status).to eq prescreening_status
-          expect(proposal.publication_status).to eq('submitted')
+          expect(proposal.idea_status).to eq proposed_status
+          expect(proposal.publication_status).to eq('published')
         end
       end
 


### PR DESCRIPTION
# Changelog
## Changed
- [TAN-5939] In flagged-only prescreening mode, inputs are now published right away and only sent to prescreening if they are flagged for toxicity. Previously, inputs started in prescreening and were only published after passing toxicity checks. We decided to flip this approach: we prefer that inappropriate content be briefly visible rather than keeping safe contributions in quarantine unnecessarily.
