### PR TITLE
Update file policy to fix issue with file attachment visibility

### DIFF
--- a/back/app/policies/files/file_attachment_policy.rb
+++ b/back/app/policies/files/file_attachment_policy.rb
@@ -8,9 +8,17 @@ module Files
         # an invalid query.
         attachable_types = scope.distinct.reorder(nil).pluck(:attachable_type)
 
-        attachable_types.map do |attachable_type|
+        # Filter attachable types and handle authorization errors for each type.
+        # Some attachable types may raise NotAuthorizedError (e.g., when their policy scope
+        # doesn't exist or the user doesn't have access), so we filter those out.
+        scoped_attachments = attachable_types.filter_map do |attachable_type|
           scope.where(attachable_type: attachable_type, attachable_id: scope_for(attachable_type.constantize))
+        rescue Pundit::NotAuthorizedError
+          # Skip attachments for resources the user cannot access
+          nil
         end.reduce(scope.none, :or)
+
+        scoped_attachments
       end
     end
 


### PR DESCRIPTION
Fixes an issue we were seeing regarding file attachment visibility in front office.
Slack thread: https://go-vocal.slack.com/archives/C01J9DHRJTE/p1770643076303949?thread_ts=1770631997.654969&cid=C01J9DHRJTE


Explanation for BE developer (aided by Claude):

Problem: FileAttachmentPolicy::Scope iterates over all distinct [attachable_type](vscode-file://vscode-app/snap/code/220/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) values in the database and calls [scope_for()](vscode-file://vscode-app/snap/code/220/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for each, which fails when an attachable type has no policy scope (e.g., Analysis::Question) or raises NotAuthorizedError, causing 500 errors for all file attachment requests.

Fix: Added rescue block to filter out unauthorized attachable types instead of crashing the entire query, allowing the request to succeed by returning only attachments the user can access.