### PR TITLE
Skip user model when translating missing locales

### DIFF
--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/change_tenant_locale.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/change_tenant_locale.rake
@@ -4,7 +4,7 @@
 # and craftjs_json content.
 #
 # Usage:
-#   rake 'core:change_tenant_locale[hostname.com,en-GB,en]'
+#   rake fix_existing_tenants:change_tenant_locale[hostname.com,en-GB,en]
 #
 # The task will:
 #   1. Add the new locale to AppConfiguration settings (alongside the current locale)

--- a/back/engines/commercial/multi_tenancy/lib/tasks/demos/translate_missing_locales.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/demos/translate_missing_locales.rake
@@ -123,6 +123,8 @@ module TranslateMissingLocales
       data_listing_service = Cl2DataListingService.new
 
       data_listing_service.cl2_schema_models.each do |model|
+        next if model == User # User model bio does not need translation - waste of money!
+
         multiloc_columns = data_listing_service.multiloc_attributes(model)
         next if multiloc_columns.empty?
 

--- a/back/engines/commercial/multi_tenancy/lib/tasks/demos/translate_missing_locales.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/demos/translate_missing_locales.rake
@@ -5,9 +5,11 @@
 # Optionally, it can also translate missing content using Machine Translation (or copy in dev mode).
 #
 # Usage:
-#   rails 'demos:translate_missing_locales[hostname.com,en]'                      - Audit only
-#   rails 'demos:translate_missing_locales[hostname.com,en,true]'                 - Audit and translate
-#   rails 'demos:translate_missing_locales[hostname.com,en,true,nl-NL:fr-BE]'     - With extra locales
+#   rake 'demos:translate_missing_locales[hostname.com,en]'                      - Audit only
+#   rake 'demos:translate_missing_locales[hostname.com,en,true]'                 - Audit and translate
+#   rake 'demos:translate_missing_locales[hostname.com,en,true,nl-NL:fr-BE]'     - With extra locales
+#
+# NOTE: needs to be run on production with rake not rails to ensure it loads the full Rails environment and all models.
 #
 # Parameters:
 #   - host: The demo tenant hostname


### PR DESCRIPTION
# Changelog
## Technical
- Skip User model when translating missing locales on demo platforms
