### PR TITLE
TAN-6570: fix missing reference ids

### DIFF
--- a/front/app/components/CustomFieldsForm/CustomFields.tsx
+++ b/front/app/components/CustomFieldsForm/CustomFields.tsx
@@ -17,6 +17,7 @@ import { FormLabel } from 'components/UI/FormComponents';
 import QuillEditedContent from 'components/UI/QuillEditedContent';
 
 import { FormattedMessage, useIntl } from 'utils/cl-intl';
+import { sanitizeForClassname } from 'utils/JSONFormUtils';
 
 import CheckboxField from './Fields/CheckboxField';
 import CosponsorsField from './Fields/CosponsorsField';
@@ -227,8 +228,22 @@ const CustomFields = ({
       {questions
         .filter((question) => question.enabled)
         .map((question) => {
+          // These question types render non-labelable elements (e.g. div[role="slider"], table, ul)
+          // so htmlFor would create an invalid label reference. They use aria-labelledby instead.
+          const nonLabelableTypes = [
+            'linear_scale',
+            'rating',
+            'matrix_linear_scale',
+            'sentiment_linear_scale',
+            'ranking',
+          ];
+          const htmlFor = nonLabelableTypes.includes(question.input_type)
+            ? undefined
+            : question.key;
+
           const labelProps = {
-            htmlFor: question.key,
+            id: sanitizeForClassname(question.key),
+            htmlFor,
             labelValue: localize(question.title_multiloc),
             optional: !question.required,
             subtextValue: (

--- a/front/app/components/CustomFieldsForm/Fields/MatrixField/Matrix.tsx
+++ b/front/app/components/CustomFieldsForm/Fields/MatrixField/Matrix.tsx
@@ -21,6 +21,7 @@ import useLocalize from 'hooks/useLocalize';
 
 import { ScreenReaderOnly } from 'utils/a11y';
 import { useIntl } from 'utils/cl-intl';
+import { sanitizeForClassname } from 'utils/JSONFormUtils';
 
 import messages from '../../messages';
 import { getLinearScaleLabel } from '../LinearScale/utils';
@@ -154,7 +155,7 @@ const Matrix = ({ value: data, question, onChange }: Props) => {
         <Table
           width={'100%'}
           style={{ borderCollapse: 'collapse', borderSpacing: '0px 8px' }}
-          aria-labelledby={`matrix-question-label-${id}`}
+          aria-labelledby={sanitizeForClassname(id)}
         >
           <Thead>
             <Tr>

--- a/front/app/components/CustomFieldsForm/Fields/RankingField/Ranking.tsx
+++ b/front/app/components/CustomFieldsForm/Fields/RankingField/Ranking.tsx
@@ -15,6 +15,7 @@ import {
 import { DragAndDropResult } from 'components/FormBuilder/edit/utils';
 
 import { useIntl } from 'utils/cl-intl';
+import { sanitizeForClassname } from 'utils/JSONFormUtils';
 
 import messages from '../../messages';
 
@@ -100,7 +101,7 @@ const Ranking = ({ value: data, question, onChange }: Props) => {
             <Text m="0px" aria-hidden color="textPrimary">
               {formatMessage(messages.rankingInstructions)}
             </Text>
-            <Ul aria-labelledby={`ranking-question-label-${question.key}`}>
+            <Ul aria-labelledby={sanitizeForClassname(question.key)}>
               {options.map((option: IOption, index: number) => (
                 <RankingOption
                   key={option.value}

--- a/front/app/components/CustomFieldsForm/Fields/RatingField/Rating.tsx
+++ b/front/app/components/CustomFieldsForm/Fields/RatingField/Rating.tsx
@@ -34,7 +34,7 @@ const Rating = ({ value: data, question, onChange }: Props) => {
 
   const id = question.key;
 
-  const labelId = `${sanitizeForClassname(id)}-label`;
+  const labelId = sanitizeForClassname(id);
   const inputId = `${sanitizeForClassname(id)}-rating-input`;
 
   const getButtonWidth = () => {

--- a/front/app/components/CustomFieldsForm/Fields/SentimentScaleField/SentimentScale.tsx
+++ b/front/app/components/CustomFieldsForm/Fields/SentimentScaleField/SentimentScale.tsx
@@ -7,6 +7,7 @@ import { IFlatCustomField } from 'api/custom_fields/types';
 import useLocalize from 'hooks/useLocalize';
 
 import { useIntl } from 'utils/cl-intl';
+import { sanitizeForClassname } from 'utils/JSONFormUtils';
 
 import { MINIMUM, MAXIMUM } from './constants';
 import TableBody from './TableBody';
@@ -75,7 +76,7 @@ const SentimentScale = ({ value: data, question, onChange }: Props) => {
       ref={sliderRef}
       aria-valuemin={MINIMUM}
       aria-valuemax={MAXIMUM}
-      aria-labelledby={id}
+      aria-labelledby={sanitizeForClassname(id)}
       onKeyDown={(event) => {
         if (event.key !== 'Tab' && !event.metaKey) {
           // Don't override the default tab behaviour or meta key (E.g. Mac command key)

--- a/front/app/components/UI/FormComponents/index.tsx
+++ b/front/app/components/UI/FormComponents/index.tsx
@@ -224,7 +224,7 @@ export const FormLabel = memo<
   return (
     <FormLabelStyled
       id={id}
-      as="label"
+      as={htmlFor ? 'label' : 'span'}
       className={[className, hidden ? 'invisible' : null]
         .filter((item) => item)
         .join(' ')}


### PR DESCRIPTION
# Summary

Several survey question types had broken `aria-labelledby` references — the slider/control elements pointed to label IDs that didn't exist in the DOM. Additionally, `<label for="...">` attributes pointed to elements that aren't native form controls (e.g. `<div role="slider">`), which is invalid HTML.

## Testing instructions if needed

1. Create or open a survey project with at least one **linear scale** question
2. Navigate to the survey as a citizen (front-office)
3. Open **Silktide** accessibility checker on the survey page
4. Under **Accessibility checker > Automated > WCAG 2.0 A 1.3.1**, verify:
   - **"Broken ARIA reference"** no longer appears for the linear scale control
   - **"Valid label IDs"** no longer flags the linear scale label
   - **"Missing ARIA label IDs"** no longer appears
   - **"Valid label IDs for fragments"** no longer appears
5. Repeat for surveys containing **rating**, **sentiment scale**, **matrix**, and **ranking** question types
6. Confirm the questions still function correctly (selecting values, keyboard navigation with arrow keys)


# Changelog

## Fixed
- a11y: Fix broken ARIA references and invalid label associations in survey question types (linear scale, rating, sentiment scale, matrix, ranking)
