### PR TITLE
Fix Chrome GPG key verification failure in CI Docker build

### DIFF
--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -7,7 +7,7 @@ FROM cypress/factory:4.1.0
 WORKDIR /
 
 # Install jq for version parsing
-RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg \
+RUN rm -f /etc/apt/sources.list.d/google-chrome.list \
     && apt-get update && apt-get install -y jq curl
 
 # Change the working directory to /front

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -7,7 +7,8 @@ FROM cypress/factory:4.1.0
 WORKDIR /
 
 # Install jq for version parsing
-RUN apt-get update && apt-get install -y jq curl
+RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg \
+    && apt-get update && apt-get install -y jq curl
 
 # Change the working directory to /front
 WORKDIR /front


### PR DESCRIPTION
# Changelog

## Technical
- Fix Google Chrome APT repository GPG key verification failure in the E2E Docker build. Google rotated their signing key (`FD533C07C264648F`), which is not present in the `cypress/factory:4.1.0` base image's keyring. Import the current Google signing key before running `apt-get update` in `front/Dockerfile`

