### PR TITLE
Remove unsupported ARIA attributes from Tooltip component

### DIFF
--- a/front/app/component-library/components/Tooltip/index.tsx
+++ b/front/app/component-library/components/Tooltip/index.tsx
@@ -8,7 +8,7 @@ import Box from '../Box';
 
 export type TooltipProps = Omit<
   React.ComponentProps<typeof Tippy>,
-  'interactive' | 'plugins' | 'role'
+  'interactive' | 'plugins' | 'role' | 'aria'
 > & {
   width?: string;
   useContentWrapper?: boolean;
@@ -114,6 +114,7 @@ const Tooltip = ({
         plugins={PLUGINS}
         interactive={true}
         role="tooltip"
+        aria={{ expanded: false }}
         visible={isFocused}
         // Ensures tippy works with both keyboard and mouse
         onHidden={handleOnHidden}
@@ -134,6 +135,7 @@ const Tooltip = ({
           plugins={PLUGINS}
           interactive={true}
           role="tooltip"
+          aria={{ expanded: false }}
           visible={isFocused}
           // Ensures tippy works with both keyboard and mouse
           onHidden={handleOnHidden}


### PR DESCRIPTION
# Changelog

## Fixed
- a11y: fix accessibility violation where aria-expanded="false" was incorrectly applied to <span> tooltip trigger elements