### PR TITLE
Update Async bulk delete to not invoke update_member_counts

### DIFF
--- a/back/app/jobs/delete_user_job.rb
+++ b/back/app/jobs/delete_user_job.rb
@@ -14,7 +14,8 @@ class DeleteUserJob < ApplicationJob
     current_user = nil,
     delete_participation_data: false,
     ban_email: false,
-    ban_reason: nil
+    ban_reason: nil,
+    update_member_counts: true
   )
     user = User.find(user) unless user.respond_to?(:id)
     email_to_ban = user.email if ban_email
@@ -27,7 +28,8 @@ class DeleteUserJob < ApplicationJob
 
     SideFxUserService.new.after_destroy(
       user, current_user,
-      participation_data_deleted: delete_participation_data
+      participation_data_deleted: delete_participation_data,
+      update_member_counts:
     )
   end
 end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -72,7 +72,8 @@ class User < ApplicationRecord
     def destroy_all_async(scope = User)
       scope.pluck(:id).each.with_index do |id, idx|
         # Spread out the deletion of users to avoid throttling.
-        DeleteUserJob.set(wait: (idx / 5.0).seconds).perform_later(id)
+        # Note: No need to update member counts if we're deleting all users, as the count will never be seen.
+        DeleteUserJob.set(wait: (idx / 5.0).seconds).perform_later(id, update_member_counts: false)
       end
     end
 

--- a/back/app/services/side_fx_user_service.rb
+++ b/back/app/services/side_fx_user_service.rb
@@ -37,7 +37,7 @@ class SideFxUserService
     UpdateMemberCountJob.perform_later
   end
 
-  def after_destroy(frozen_user, current_user, participation_data_deleted: false)
+  def after_destroy(frozen_user, current_user, participation_data_deleted: false, update_member_counts: true)
     activity_user = current_user&.id == frozen_user&.id ? nil : current_user
 
     LogActivityJob.perform_later(
@@ -48,7 +48,7 @@ class SideFxUserService
       payload: { participation_data_deleted: }
     )
 
-    UpdateMemberCountJob.perform_later
+    UpdateMemberCountJob.perform_later if update_member_counts
     RemoveUserFromIntercomJob.perform_later(frozen_user.id)
     RemoveUsersFromSegmentJob.perform_later([frozen_user.id])
   end

--- a/back/spec/jobs/delete_user_job_spec.rb
+++ b/back/spec/jobs/delete_user_job_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe DeleteUserJob do
       described_class.perform_now(user.id, current_user)
 
       expect(sidefx_service).to have_received(:after_destroy)
-        .with(user, current_user, participation_data_deleted: false)
+        .with(user, current_user, participation_data_deleted: false, update_member_counts: true)
     end
 
     context 'with delete_participation_data: true' do
@@ -46,7 +46,22 @@ RSpec.describe DeleteUserJob do
 
         described_class.perform_now(user.id, current_user, delete_participation_data: true)
 
-        expect(sidefx_service).to have_received(:after_destroy).with(user, current_user, participation_data_deleted: true)
+        expect(sidefx_service).to have_received(:after_destroy).with(user, current_user, participation_data_deleted: true, update_member_counts: true)
+      end
+    end
+
+    context 'with update_member_counts: false' do
+      let(:current_user) { create(:admin) }
+
+      it 'triggers after_destroy side effects' do
+        sidefx_service = instance_spy(SideFxUserService, 'sidefx_service')
+        allow(SideFxUserService).to receive(:new).and_return(sidefx_service)
+
+        current_user = build_stubbed(:user)
+        described_class.perform_now(user.id, current_user, update_member_counts: false)
+
+        expect(sidefx_service).to have_received(:after_destroy)
+          .with(user, current_user, participation_data_deleted: false, update_member_counts: false)
       end
     end
 

--- a/back/spec/services/side_fx_user_service_spec.rb
+++ b/back/spec/services/side_fx_user_service_spec.rb
@@ -143,8 +143,12 @@ describe SideFxUserService do
       end
     end
 
-    it 'logs a UpdateMemberCountJob' do
+    it 'enqueues a UpdateMemberCountJob by default' do
       expect { service.after_destroy(user, current_user) }.to have_enqueued_job(UpdateMemberCountJob)
+    end
+
+    it 'does not enqueue a UpdateMemberCountJob when update_member_counts is false' do
+      expect { service.after_destroy(user, current_user, update_member_counts: false) }.not_to have_enqueued_job(UpdateMemberCountJob)
     end
 
     it 'successfully enqueues PII data deletion job for Intercom' do


### PR DESCRIPTION
# Changelog
## Technical
- Changed Async bulk delete to not invoke UpdateMemberCount as this can cause performance issues on large platforms with many users and many smart groups
