### PR TITLE
TAN-6656 Add screen reader only table header to matrix question

### DIFF
--- a/front/app/components/CustomFieldsForm/Fields/MatrixField/Matrix.tsx
+++ b/front/app/components/CustomFieldsForm/Fields/MatrixField/Matrix.tsx
@@ -160,6 +160,7 @@ const Matrix = ({ value: data, question, onChange }: Props) => {
           <Thead>
             <Tr>
               <Th
+                scope="col"
                 pt="0px"
                 borderBottom={`1px solid ${theme.colors.borderDark} !important`}
               >

--- a/front/app/components/CustomFieldsForm/Fields/MatrixField/Matrix.tsx
+++ b/front/app/components/CustomFieldsForm/Fields/MatrixField/Matrix.tsx
@@ -161,7 +161,11 @@ const Matrix = ({ value: data, question, onChange }: Props) => {
               <Th
                 pt="0px"
                 borderBottom={`1px solid ${theme.colors.borderDark} !important`}
-              />
+              >
+                <ScreenReaderOnly>
+                  {formatMessage(messages.matrixStatementHeader)}
+                </ScreenReaderOnly>
+              </Th>
               {columnsFromSchema.map((column, index) => {
                 return (
                   <Th

--- a/front/app/components/CustomFieldsForm/messages.ts
+++ b/front/app/components/CustomFieldsForm/messages.ts
@@ -337,6 +337,10 @@ export default defineMessages({
     id: 'app.components.form.controls.clearAllScreenreader',
     defaultMessage: 'Clear all answers from above matrix question',
   },
+  matrixStatementHeader: {
+    id: 'app.components.form.controls.matrixStatementHeader',
+    defaultMessage: 'Statement',
+  },
   noRankSelected: {
     id: 'app.components.form.controls.noRankSelected',
     defaultMessage: 'No rank selected',

--- a/front/app/translations/en.json
+++ b/front/app/translations/en.json
@@ -753,6 +753,7 @@
   "app.components.form.controls.clearAllScreenreader": "Clear all answers from above matrix question",
   "app.components.form.controls.cosponsorsPlaceholder": "Start typing a name to search",
   "app.components.form.controls.currentRank": "Current rank:",
+  "app.components.form.controls.matrixStatementHeader": "Statement",
   "app.components.form.controls.noRankSelected": "No rank selected",
   "app.components.form.controls.optionalParentheses": "(optional)",
   "app.components.form.controls.rankingInstructions": "Drag and drop to rank options.",


### PR DESCRIPTION
# Changelog
## a11y
- Fix empty table header in matrix survey question
