### PR TITLE
[TAN-6740] Allowlist facebookexternalhit in robots.txt

### DIFF
--- a/back/engines/free/seo/app/views/seo/application/robots.text.erb
+++ b/back/engines/free/seo/app/views/seo/application/robots.text.erb
@@ -1,3 +1,6 @@
+User-agent: facebookexternalhit
+Allow: /
+
 User-agent: *
 Disallow: /admin/
 


### PR DESCRIPTION
Not sure why we might get this issue with one (or maybe two?) FB apps, but maybe we should follow the advice given in the FB URL debugger tool:

<img width="875" height="1348" alt="Screenshot 2026-02-15 at 13 41 50" src="https://github.com/user-attachments/assets/5c084334-7a5a-4073-9324-630c4079fc85" />

# Changelog
## Technical
- [TAN-6740] Allowlist facebookexternalhit in robots.txt
