### PR TITLE
620: show common ground results when phase ended

### DIFF
--- a/front/app/containers/ProjectsShowPage/shared/ParticipationPermission/index.tsx
+++ b/front/app/containers/ProjectsShowPage/shared/ParticipationPermission/index.tsx
@@ -28,6 +28,7 @@ interface Props {
   disabledMessage: MessageDescriptor | null;
   enabled: boolean;
   className?: string;
+  projectName?: string;
 }
 
 const ParticipationPermission = ({
@@ -38,6 +39,7 @@ const ParticipationPermission = ({
   action,
   disabledMessage,
   enabled,
+  projectName,
 }: Props) => {
   const signUpIn = (flow: 'signin' | 'signup') => {
     if (!phaseId) return;
@@ -75,6 +77,7 @@ const ParticipationPermission = ({
             <FormattedMessage
               {...disabledMessage}
               values={{
+                projectName,
                 verificationLink: (
                   <button onClick={signUp}>
                     <FormattedMessage {...messages.verificationLinkText} />

--- a/front/app/containers/ProjectsShowPage/timeline/CommonGround/CommonGroundTabs.tsx
+++ b/front/app/containers/ProjectsShowPage/timeline/CommonGround/CommonGroundTabs.tsx
@@ -1,16 +1,19 @@
 import React from 'react';
 
-import { Box } from '@citizenlab/cl2-component-library';
+import { Box, Title } from '@citizenlab/cl2-component-library';
 import { useSearchParams } from 'react-router-dom';
 
 import useCommonGroundProgress from 'api/common_ground/useCommonGroundProgress';
 import { IProjectData } from 'api/projects/types';
+
+import useLocalize from 'hooks/useLocalize';
 
 import ParticipationPermission from 'containers/ProjectsShowPage/shared/ParticipationPermission';
 
 import Tabs, { TabData } from 'components/UI/FilterTabs';
 
 import { getPermissionsDisabledMessage } from 'utils/actionDescriptors';
+import { FormattedMessage } from 'utils/cl-intl';
 
 import CommonGroundResults from './CommonGroundResults';
 import CommonGroundStatements from './CommonGroundStatements';
@@ -22,14 +25,17 @@ type TabKey = (typeof tabs)[number];
 interface Props {
   phaseId: string;
   project: IProjectData;
+  isPastPhase: boolean;
 }
 
-const CommonGroundTabs = ({ phaseId, project }: Props) => {
+const CommonGroundTabs = ({ phaseId, project, isPastPhase }: Props) => {
   const [searchParams, setSearchParams] = useSearchParams();
+  const localize = useLocalize();
   const currentTabParam = searchParams.get('tab') as TabKey;
+  const defaultTab = isPastPhase ? 'results' : 'statements';
   const currentTab = tabs.includes(currentTabParam)
     ? currentTabParam
-    : 'statements';
+    : defaultTab;
   const { enabled, disabled_reason } =
     project.attributes.action_descriptors.reacting_idea;
   const disabledMessage =
@@ -39,6 +45,7 @@ const CommonGroundTabs = ({ phaseId, project }: Props) => {
     ? progressData.data.attributes.num_ideas -
       progressData.data.attributes.num_reacted_ideas
     : undefined;
+  const projectName = localize(project.attributes.title_multiloc);
 
   const tabData: TabData = {
     statements: {
@@ -55,12 +62,45 @@ const CommonGroundTabs = ({ phaseId, project }: Props) => {
     setSearchParams({ tab });
   };
 
+  // When the phase has ended, show the warning message and results only.
+  // We pass enabled={true} so ParticipationPermission renders the children
+  // (results) while still displaying the disabled warning message.
+  if (isPastPhase) {
+    return (
+      <ParticipationPermission
+        action="reacting_idea"
+        enabled={true}
+        phaseId={phaseId}
+        disabledMessage={disabledMessage}
+        projectName={projectName}
+        id="common-ground-tabs"
+      >
+        <Box
+          display="flex"
+          flexDirection="column"
+          width="100%"
+          maxWidth="600px"
+          margin="0 auto"
+          padding="8px"
+        >
+          <Box p="30px 30px 48px 30px" bg="white">
+            <Title variant="h3" mt="0">
+              <FormattedMessage {...messages.resultsTabLabel} />
+            </Title>
+            <CommonGroundResults phaseId={phaseId} />
+          </Box>
+        </Box>
+      </ParticipationPermission>
+    );
+  }
+
   return (
     <ParticipationPermission
       action="reacting_idea"
       enabled={enabled}
       phaseId={phaseId}
       disabledMessage={disabledMessage}
+      projectName={projectName}
       id="common-ground-tabs"
     >
       <Box

--- a/front/app/containers/ProjectsShowPage/timeline/index.tsx
+++ b/front/app/containers/ProjectsShowPage/timeline/index.tsx
@@ -169,6 +169,7 @@ const ProjectTimelineContainer = ({ projectId, className }: Props) => {
             <CommonGroundTabs
               phaseId={selectedPhase.id}
               project={project.data}
+              isPastPhase={isPastPhase}
             />
           )}
         </ContentContainer>


### PR DESCRIPTION
# Changelog

## Fixed
- Show common ground results even when the phase ended
<img width="1232" height="857" alt="image" src="https://github.com/user-attachments/assets/ff06f29d-4846-45ce-8fef-908bd965a11d" />

