### PR TITLE
TAN-6474: Show avatars only when feature flag is enabled

### DIFF
--- a/front/app/components/ProjectAndFolderCards/components/ProjectFolderCard/index.tsx
+++ b/front/app/components/ProjectAndFolderCards/components/ProjectFolderCard/index.tsx
@@ -23,6 +23,7 @@ import {
 import useProjectFolderImage from 'api/project_folder_images/useProjectFolderImage';
 import useProjectFolderById from 'api/project_folders/useProjectFolderById';
 
+import useFeatureFlag from 'hooks/useFeatureFlag';
 import useLocalize from 'hooks/useLocalize';
 
 import AvatarBubbles from 'components/AvatarBubbles';
@@ -320,6 +321,7 @@ const ProjectFolderCard = memo<Props>(
     const isSmallerThanPhone = useBreakpoint('phone');
     const { data: projectFolder } = useProjectFolderById(folderId);
     const localize = useLocalize();
+    const userAvatarsEnabled = useFeatureFlag({ name: 'user_avatars' });
 
     // We use this hook instead of useProjectFolderImages
     // because that one doesn't work well with our caching system
@@ -368,6 +370,7 @@ const ProjectFolderCard = memo<Props>(
           )
         : [];
     const showAvatarBubbles =
+      userAvatarsEnabled &&
       projectFolder.data.attributes.participants_count > 0;
     const folderImageAltText = localize(
       projectFolderImage?.data.attributes.alt_text_multiloc

--- a/front/app/components/ProjectCard/index.tsx
+++ b/front/app/components/ProjectCard/index.tsx
@@ -25,6 +25,7 @@ import useProjectById from 'api/projects/useProjectById';
 import { getProjectUrl } from 'api/projects/utils';
 import useReport from 'api/reports/useReport';
 
+import useFeatureFlag from 'hooks/useFeatureFlag';
 import useLocalize from 'hooks/useLocalize';
 
 import AvatarBubbles from 'components/AvatarBubbles';
@@ -385,6 +386,7 @@ const ProjectCard = memo<InputProps>(
 
     const localize = useLocalize();
     const { formatMessage } = useIntl();
+    const userAvatarsEnabled = useFeatureFlag({ name: 'user_avatars' });
 
     const [visible, setVisible] = useState(false);
 
@@ -413,7 +415,8 @@ const ProjectCard = memo<InputProps>(
     const isFinished = project.data.attributes.timeline_active === 'past';
     const isArchived =
       project.data.attributes.publication_status === 'archived';
-    const showAvatarBubbles = project.data.attributes.participants_count > 0;
+    const showAvatarBubbles =
+      userAvatarsEnabled && project.data.attributes.participants_count > 0;
     const avatarIds =
       project.data.relationships.avatars &&
       project.data.relationships.avatars.data

--- a/front/app/containers/ProjectsShowPage/shared/header/ProjectInfoSideBar/index.tsx
+++ b/front/app/containers/ProjectsShowPage/shared/header/ProjectInfoSideBar/index.tsx
@@ -13,6 +13,8 @@ import useAuthUser from 'api/me/useAuthUser';
 import usePhases from 'api/phases/usePhases';
 import useProjectById from 'api/projects/useProjectById';
 
+import useFeatureFlag from 'hooks/useFeatureFlag';
+
 import messages from 'containers/ProjectsShowPage/messages';
 
 import AvatarBubbles from 'components/AvatarBubbles';
@@ -45,6 +47,7 @@ const ProjectInfoSideBar = memo<Props>(
     const { data: project } = useProjectById(projectId, !isAdmin(authUser));
     const { data: phases } = usePhases(projectId);
     const { formatMessage } = useIntl();
+    const userAvatarsEnabled = useFeatureFlag({ name: 'user_avatars' });
 
     if (project) {
       const projectParticipantsCount =
@@ -66,7 +69,7 @@ const ProjectInfoSideBar = memo<Props>(
       return (
         <Box id="e2e-project-sidebar" className={className || ''} w="100%">
           <StyledProjectActionButtons projectId={projectId} />
-          {!hideParticipationAvatars && (
+          {!hideParticipationAvatars && userAvatarsEnabled && (
             <Box
               display="flex"
               alignItems="center"


### PR DESCRIPTION
# Changelog


## Fixed
- Avatar bubbles on project cards, project folder cards, and the project page sidebar now respect the user_avatars feature flag. Previously, avatars would still appear in these locations even when the setting was disabled in adminHQ.