### PR TITLE
TAN-7130 Fix votes_count overflow for PB

### DIFF
--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -19,7 +19,7 @@
 #  default_assignee_id            :uuid
 #  include_all_areas              :boolean          default(FALSE), not null
 #  baskets_count                  :integer          default(0), not null
-#  votes_count                    :integer          default(0), not null
+#  votes_count                    :bigint           default(0), not null
 #  followers_count                :integer          default(0), not null
 #  header_bg_alt_text_multiloc    :jsonb
 #  preview_token                  :string           not null

--- a/back/db/migrate/20260227120000_change_votes_count_to_bigint.rb
+++ b/back/db/migrate/20260227120000_change_votes_count_to_bigint.rb
@@ -1,0 +1,19 @@
+  # frozen_string_literal: true
+
+class ChangeVotesCountToBigint < ActiveRecord::Migration[7.1]
+  # Since these vote counts are potentially storing the sum of budgets, they can
+  # exceed the limit of a 4-byte integer, so we need to change them to bigint.
+  def up
+    safety_assured do
+      change_column :projects, :votes_count, :bigint, default: 0, null: false
+      change_column :phases, :votes_count, :bigint, default: 0, null: false
+    end
+  end
+
+  def down
+    safety_assured do
+      change_column :projects, :votes_count, :integer, default: 0, null: false
+      change_column :phases, :votes_count, :integer, default: 0, null: false
+    end
+  end
+end

--- a/back/db/migrate/20260227120000_change_votes_count_to_bigint.rb
+++ b/back/db/migrate/20260227120000_change_votes_count_to_bigint.rb
@@ -1,4 +1,4 @@
-  # frozen_string_literal: true
+# frozen_string_literal: true
 
 class ChangeVotesCountToBigint < ActiveRecord::Migration[7.1]
   # Since these vote counts are potentially storing the sum of budgets, they can

--- a/back/db/structure.sql
+++ b/back/db/structure.sql
@@ -1381,7 +1381,7 @@ CREATE TABLE public.projects (
     default_assignee_id uuid,
     include_all_areas boolean DEFAULT false NOT NULL,
     baskets_count integer DEFAULT 0 NOT NULL,
-    votes_count integer DEFAULT 0 NOT NULL,
+    votes_count bigint DEFAULT 0 NOT NULL,
     followers_count integer DEFAULT 0 NOT NULL,
     header_bg_alt_text_multiloc jsonb DEFAULT '{}'::jsonb,
     preview_token character varying NOT NULL,
@@ -1764,7 +1764,7 @@ CREATE TABLE public.phases (
     voting_term_singular_multiloc jsonb DEFAULT '{}'::jsonb,
     voting_term_plural_multiloc jsonb DEFAULT '{}'::jsonb,
     baskets_count integer DEFAULT 0 NOT NULL,
-    votes_count integer DEFAULT 0 NOT NULL,
+    votes_count bigint DEFAULT 0 NOT NULL,
     native_survey_title_multiloc jsonb DEFAULT '{}'::jsonb,
     native_survey_button_multiloc jsonb DEFAULT '{}'::jsonb,
     expire_days_limit integer,
@@ -8386,6 +8386,7 @@ ALTER TABLE ONLY public.project_reviews
 SET search_path TO public,shared_extensions;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260227120000'),
 ('20260205124240'),
 ('20260127094257'),
 ('20260127092840'),

--- a/back/spec/models/basket_spec.rb
+++ b/back/spec/models/basket_spec.rb
@@ -276,6 +276,16 @@ RSpec.describe Basket do
           expect(project.reload.votes_count).to eq 0
         end
       end
+
+      context 'when votes_count exceeds 4-byte integer limit' do
+        it 'stores the votes_count without overflow on the phase and project' do
+          basket = create(:basket, phase: project.phases.first, ideas: ideas, submitted_at: Time.zone.now)
+          basket.baskets_ideas.update_all(votes: 1_500_000_000)
+          basket.update_counts!
+          expect(current_phase.reload.votes_count).to eq 3_000_000_000
+          expect(project.reload.votes_count).to eq 3_000_000_000
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
# Changelog
## Fixed
- When using PB with all user votes combined exceeding a ~ 2.1 billion budget (4 byte integer), voting was not possible
