### PR TITLE
TAN-7125 Resolve topic modeling issues

### DIFF
--- a/back/app/services/idea_feed/topic_modeling_service.rb
+++ b/back/app/services/idea_feed/topic_modeling_service.rb
@@ -31,7 +31,7 @@ module IdeaFeed
         creation_log = create_new_topics!(mapping, new_topics_by_id)
         removal_log = remove_obsolete_topics!(mapping, old_topics_by_id)
       else
-        creation_log = create_new_topics!({}, new_topics_by_id)
+        creation_log = create_new_topics!([], new_topics_by_id)
       end
 
       log_topics_rebalanced_activity(update_log:, creation_log:, removal_log:)
@@ -65,12 +65,12 @@ module IdeaFeed
 
     def run_map_old_to_new_topics(old_topics, new_topics)
       prompt = topic_mapping_prompt(old_topics, new_topics)
-      @llm.chat(prompt, response_schema: topic_mapping_response_schema(old_topics))
+      @llm.chat(prompt, response_schema: topic_mapping_response_schema)
     end
 
-    # Given the mapping, counts how many old topics map to the same new topic as the given old_topic_id
+    # Given the mapping, counts how many old topics map to the same new topic
     def in_count(mapping, new_topic_id)
-      mapping.values.count { |v| v['new_topic_id'] == new_topic_id }
+      mapping.count { |item| item['new_topic_id'] == new_topic_id }
     end
 
     def topic_model_response_schema
@@ -79,19 +79,21 @@ module IdeaFeed
         type: 'array',
         items: {
           type: 'object',
+          additionalProperties: false,
+          required: %w[title_multiloc description_multiloc icon problems],
           properties: {
             title_multiloc: {
               type: 'object',
+              additionalProperties: false,
               description:
               "The title of the topic in #{locales.join(', ')}",
-              properties: locales.index_with { |locale| { type: 'string', description: "The title in #{locale}" } },
-              additionalProperties: false
+              properties: locales.index_with { |locale| { type: 'string', description: "The title in #{locale}" } }
             },
             description_multiloc: {
               type: 'object',
+              additionalProperties: false,
               description: "A short description of the topic in #{locales.join(', ')}",
-              properties: locales.index_with { |locale| { type: 'string', description: "The description in #{locale}" } },
-              additionalProperties: false
+              properties: locales.index_with { |locale| { type: 'string', description: "The description in #{locale}" } }
             },
             icon: {
               type: 'string',
@@ -102,34 +104,33 @@ module IdeaFeed
               description: 'A list of mined problems or challenges that fall under this main topic.',
               items: {
                 type: 'object',
+                additionalProperties: false,
+                required: %w[title_multiloc description_multiloc],
                 properties: {
                   title_multiloc: {
                     type: 'object',
+                    additionalProperties: false,
                     description:
                     "The title of the problem in #{locales.join(', ')}. A very short problem statement.",
-                    properties: locales.index_with { |locale| { type: 'string', description: "The title in #{locale}" } },
-                    additionalProperties: false
+                    properties: locales.index_with { |locale| { type: 'string', description: "The title in #{locale}" } }
                   },
                   description_multiloc: {
                     type: 'object',
+                    additionalProperties: false,
                     description: "A short description of the problem in #{locales.join(', ')}. An open question that invites further exploration, without leading the respondent.",
-                    properties: locales.index_with { |locale| { type: 'string', description: "The description in #{locale}" } },
-                    additionalProperties: false
+                    properties: locales.index_with { |locale| { type: 'string', description: "The description in #{locale}" } }
                   }
-                },
-                required: %w[title_multiloc description_multiloc]
+                }
               }
             }
-          },
-          required: %w[title_multiloc description_multiloc icon],
-          additionalProperties: false
+          }
         }
       }
     end
 
     def topic_model_prompt(inputs)
       form = @phase.pmethod.custom_form
-      input_texts = Analysis::InputToText.new(custom_fields_without_topics(form)).format_all(inputs)
+      input_texts = Analysis::InputToText.new(custom_fields_without_topics(form)).format_all(inputs.order(Arel.sql('RANDOM()')).limit(250), truncate_values: 256)
       ::Analysis::LLM::Prompt.new.fetch('idea_feed_live_topic_modeling',
         multiloc_service: MultilocService.new,
         project_description:,
@@ -147,51 +148,51 @@ module IdeaFeed
         new_topics:)
     end
 
-    def topic_mapping_response_schema(old_topics)
+    def topic_mapping_response_schema
       locales = AppConfiguration.instance.settings('core', 'locales') || ['en']
 
       {
-        type: 'object',
-        description: 'A mapping from old topic IDs to new topic IDs',
-        additionalProperties: false,
-        properties: old_topics.each_with_object({}).with_index do |(_old_topic, hash), i|
-          hash["OLD-#{i + 1}"] = {
-            type: 'object',
-            additionalProperties: false,
-            properties: {
-              new_topic_id: { type: %w[string null], description: 'The ID of the corresponding new topic (e.g. NEW-5), or null if there is no match' },
-              adjusted_topic_title_multiloc: {
-                type: 'object',
-                description: "An adjusted title of the old topic, incorporating any new nuance from the new topic, if anything. Only make a change if it is really necessary. In languages #{locales.join(', ')}",
-                properties: locales.index_with { |locale| { type: 'string', description: "The title in #{locale}" } },
-                additionalProperties: false
-              },
-              adjusted_topic_description_multiloc: {
-                type: 'object',
-                description: "An adjusted description of the old topic, incorporating any new nuance from the new topic. Only make a change if it is really necessary. In languages #{locales.join(', ')}",
-                properties: locales.index_with { |locale| { type: 'string', description: "The description in #{locale}" } },
-                additionalProperties: false
-              }
+        type: 'array',
+        description: 'A list of mappings from old topic IDs to new topic IDs. Only include items where a good match exists.',
+        items: {
+          type: 'object',
+          additionalProperties: false,
+          required: %w[old_topic_id new_topic_id],
+          properties: {
+            old_topic_id: { type: 'string', description: 'The ID of the old topic (e.g. OLD-1)' },
+            new_topic_id: { type: 'string', description: 'The ID of the corresponding new topic (e.g. NEW-5)' },
+            adjusted_topic_title_multiloc: {
+              type: 'object',
+              additionalProperties: false,
+              required: locales,
+              description: "An adjusted title of the old topic, incorporating any new nuance from the new topic, if anything. Only make a change if it is really necessary. In languages #{locales.join(', ')}",
+              properties: locales.index_with { { type: 'string' } }
             },
-            required: %w[new_topic_id]
+            adjusted_topic_description_multiloc: {
+              type: 'object',
+              additionalProperties: false,
+              required: locales,
+              description: "An adjusted description of the old topic, incorporating any new nuance from the new topic. Only make a change if it is really necessary. In languages #{locales.join(', ')}",
+              properties: locales.index_with { { type: 'string' } }
+            }
           }
-        end
+        }
       }
     end
 
     def update_changed_topics!(mapping, old_topics_by_id, new_topics_by_id)
       update_log = []
-      mapping.each do |old_topic_id, v|
-        next if v['new_topic_id'].blank?
+      mapping.each do |item|
         # If multiple old topics map to the same new topic, we don't update them
         # (but we'll remove them later)
-        next if in_count(mapping, v['new_topic_id']) != 1
+        next if in_count(mapping, item['new_topic_id']) != 1
 
-        old_topic = old_topics_by_id[old_topic_id]
-        new_topic = new_topics_by_id[v['new_topic_id']]
+        old_topic = old_topics_by_id[item['old_topic_id']]
+        new_topic = new_topics_by_id[item['new_topic_id']]
+        next unless old_topic && new_topic # LLM might return mappings to non-existing topics, in which case we skip the update
 
-        new_title_multiloc = v['adjusted_topic_title_multiloc'] || new_topic['title_multiloc']
-        new_description_multiloc = v['adjusted_topic_description_multiloc'] || new_topic['description_multiloc']
+        new_title_multiloc = item['adjusted_topic_title_multiloc'] || new_topic['title_multiloc']
+        new_description_multiloc = item['adjusted_topic_description_multiloc'] || new_topic['description_multiloc']
 
         InputTopic.transaction do
           if old_topic.title_multiloc != new_title_multiloc || old_topic.description_multiloc != new_description_multiloc
@@ -271,16 +272,17 @@ module IdeaFeed
     def remove_obsolete_topics!(mapping, old_topics_by_id)
       removal_log = []
 
-      obsolete_old_topic_ids = mapping
-        .filter { |_, v| v['new_topic_id'].blank? || in_count(mapping, v['new_topic_id']) != 1 }
-        .keys
-      obsolete_old_topic_ids.uniq.each do |old_topic_id|
-        old_topic = old_topics_by_id[old_topic_id]
+      # Old topics with a unique 1:1 mapping are kept; all others are obsolete
+      kept_old_topic_ids = mapping
+        .select { |item| in_count(mapping, item['new_topic_id']) == 1 }
+        .pluck('old_topic_id')
+
+      old_topics_by_id.each do |old_topic_id, old_topic|
+        next if kept_old_topic_ids.include?(old_topic_id)
+
         # Destroying a root topic also destroys its children via dependent: :destroy
         old_topic.destroy!
-        removal_log << {
-          topic_id: old_topic.id
-        }
+        removal_log << { topic_id: old_topic.id }
       end
       removal_log
     end

--- a/back/app/services/idea_feed/topic_modeling_service.rb
+++ b/back/app/services/idea_feed/topic_modeling_service.rb
@@ -130,7 +130,10 @@ module IdeaFeed
 
     def topic_model_prompt(inputs)
       form = @phase.pmethod.custom_form
-      input_texts = Analysis::InputToText.new(custom_fields_without_topics(form)).format_all(inputs.order(Arel.sql('RANDOM()')).limit(250), truncate_values: 256)
+      input_texts = Analysis::InputToText.new(custom_fields_without_topics(form)).format_all(
+        inputs.order(Arel.sql('RANDOM()')).limit(500),
+        truncate_values: 256
+      )
       ::Analysis::LLM::Prompt.new.fetch('idea_feed_live_topic_modeling',
         multiloc_service: MultilocService.new,
         project_description:,

--- a/back/app/services/llm_selector.rb
+++ b/back/app/services/llm_selector.rb
@@ -31,8 +31,8 @@ class LLMSelector
     ::Analysis::LLM::GPT4o,
     ::Analysis::LLM::GPT41,
     ::Analysis::LLM::ClaudeHaiku45,
-    ::Analysis::LLM::ClaudeSonnet45,
-    ::Analysis::LLM::ClaudeOpus45,
+    ::Analysis::LLM::ClaudeSonnet46,
+    ::Analysis::LLM::ClaudeOpus46,
     ::Analysis::LLM::Gemini3Pro,
     ::Analysis::LLM::Gemini3Flash
   ]
@@ -47,7 +47,7 @@ class LLMSelector
     LLMUseCase.new(
       key: 'sensemaking_summarization',
       description: 'Summarization of content in sensemaking',
-      supported_models: [::Analysis::LLM::GPT41, ::Analysis::LLM::Gemini3Pro, ::Analysis::LLM::ClaudeOpus45],
+      supported_models: [::Analysis::LLM::GPT41, ::Analysis::LLM::Gemini3Pro, ::Analysis::LLM::ClaudeOpus46],
       default_model: ::Analysis::LLM::GPT41
     ),
     LLMUseCase.new(
@@ -59,20 +59,20 @@ class LLMSelector
     LLMUseCase.new(
       key: '360_input_file_description',
       description: 'Generating descriptions for 360 input files',
-      supported_models: [::Analysis::LLM::GPT4o, ::Analysis::LLM::ClaudeSonnet45, ::Analysis::LLM::Gemini3Pro],
+      supported_models: [::Analysis::LLM::GPT4o, ::Analysis::LLM::ClaudeSonnet46, ::Analysis::LLM::Gemini3Pro],
       default_model: ::Analysis::LLM::GPT4o
     ),
     LLMUseCase.new(
       key: 'idea_feed_live_topic_model',
       description: 'Automatically manage the tags in the Idea Feed constantly.',
-      supported_models: [::Analysis::LLM::ClaudeOpus45, ::Analysis::LLM::Gemini3Pro],
-      default_model: ::Analysis::LLM::Gemini3Pro
+      supported_models: [::Analysis::LLM::ClaudeOpus46, ::Analysis::LLM::Gemini3Pro],
+      default_model: ::Analysis::LLM::ClaudeOpus46
     ),
     LLMUseCase.new(
       key: 'idea_feed_live_classification',
       description: 'Classify ideas into existing topics in the Idea Feed constantly.',
       supported_models: [::Analysis::LLM::ClaudeHaiku45, ::Analysis::LLM::Gemini3Flash],
-      default_model: ::Analysis::LLM::Gemini3Flash
+      default_model: ::Analysis::LLM::ClaudeHaiku45
     )
   ]
 

--- a/back/engines/commercial/analysis/app/lib/analysis/LLM/claude_opus_46.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/LLM/claude_opus_46.rb
@@ -1,9 +1,9 @@
 module Analysis
   module LLM
-    class ClaudeOpus45 < RubyLLM
+    class ClaudeOpus46 < RubyLLM
       # The model ID as returned by RubyLLM.models.chat_models
       def model
-        'eu.anthropic.claude-opus-4-5-20251101-v1:0'
+        'eu.anthropic.claude-opus-4-6-v1'
       end
 
       def self.family

--- a/back/engines/commercial/analysis/app/lib/analysis/LLM/claude_sonnet_46.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/LLM/claude_sonnet_46.rb
@@ -1,9 +1,9 @@
 module Analysis
   module LLM
-    class ClaudeSonnet45 < RubyLLM
+    class ClaudeSonnet46 < RubyLLM
       # The model ID as returned by RubyLLM.models.chat_models
       def model
-        'eu.anthropic.claude-sonnet-4-5-20250929-v1:0'
+        'eu.anthropic.claude-sonnet-4-6'
       end
 
       def self.family

--- a/back/engines/commercial/analysis/app/lib/analysis/LLM/gemini_3_pro.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/LLM/gemini_3_pro.rb
@@ -3,7 +3,7 @@ module Analysis
     class Gemini3Pro < RubyLLM
       # The model ID as returned by RubyLLM.models.chat_models
       def model
-        'gemini-3-pro-preview'
+        'gemini-3.1-pro-preview'
       end
 
       def self.family

--- a/back/spec/services/idea_feed/topic_classification_service_spec.rb
+++ b/back/spec/services/idea_feed/topic_classification_service_spec.rb
@@ -25,7 +25,7 @@ describe IdeaFeed::TopicClassificationService do
     it 'classifies an unclassified idea into the correct subtopic' do
       idea = create(:idea, phases: [phase], title_multiloc: { 'en' => 'Free bike sharing!' }, body_multiloc: { 'en' => 'I love biking around the city.' }, input_topics: [])
 
-      expect_any_instance_of(Analysis::LLM::Gemini3Flash).to receive(:chat).and_return(['1.1'])
+      expect_any_instance_of(Analysis::LLM::ClaudeHaiku45).to receive(:chat).and_return(['1.1'])
       service.classify_topics!(idea)
 
       expect(idea.input_topics).to contain_exactly(subtopics[0])
@@ -34,7 +34,7 @@ describe IdeaFeed::TopicClassificationService do
     it 'classifies an unclassified idea into the correct topic' do
       idea = create(:idea, phases: [phase], title_multiloc: { 'en' => 'Free bike sharing!' }, body_multiloc: { 'en' => 'I love biking around the city.' }, input_topics: [])
 
-      expect_any_instance_of(Analysis::LLM::Gemini3Flash).to receive(:chat).and_return(['2'])
+      expect_any_instance_of(Analysis::LLM::ClaudeHaiku45).to receive(:chat).and_return(['2'])
       service.classify_topics!(idea)
 
       expect(idea.input_topics).to contain_exactly(topics[1])
@@ -43,7 +43,7 @@ describe IdeaFeed::TopicClassificationService do
     it 'erases previous topic associations when classifying' do
       idea = create(:idea, phases: [phase], title_multiloc: { 'en' => 'Affordable housing for all' }, body_multiloc: { 'en' => 'We need more affordable housing.' }, input_topics: [topics[0]])
 
-      expect_any_instance_of(Analysis::LLM::Gemini3Flash).to receive(:chat).and_return(['2'])
+      expect_any_instance_of(Analysis::LLM::ClaudeHaiku45).to receive(:chat).and_return(['2'])
       service.classify_topics!(idea)
 
       expect(idea.input_topics).to contain_exactly(topics[1])
@@ -52,7 +52,7 @@ describe IdeaFeed::TopicClassificationService do
     it 'assigns multiple topics if applicable' do
       idea = create(:idea, phases: [phase], title_multiloc: { 'en' => 'Better schools and public transport' }, body_multiloc: { 'en' => 'We need to improve both education and transportation.' }, input_topics: [])
 
-      expect_any_instance_of(Analysis::LLM::Gemini3Flash).to receive(:chat).and_return(['1.2', '3'])
+      expect_any_instance_of(Analysis::LLM::ClaudeHaiku45).to receive(:chat).and_return(['1.2', '3'])
       service.classify_topics!(idea)
 
       expect(idea.input_topics).to contain_exactly(subtopics[1], topics[2])
@@ -61,7 +61,7 @@ describe IdeaFeed::TopicClassificationService do
     it 'removes all topics if no topic is relevant' do
       idea = create(:idea, phases: [phase], title_multiloc: { 'en' => 'More parks and green spaces' }, body_multiloc: { 'en' => 'We need more parks in the city.' }, input_topics: [topics[0]])
 
-      expect_any_instance_of(Analysis::LLM::Gemini3Flash).to receive(:chat).and_return([])
+      expect_any_instance_of(Analysis::LLM::ClaudeHaiku45).to receive(:chat).and_return([])
       service.classify_topics!(idea)
 
       expect(idea.input_topics).to be_empty
@@ -70,8 +70,8 @@ describe IdeaFeed::TopicClassificationService do
     it 'retries when the LLM response contains invalid topic IDs' do
       idea = create(:idea, phases: [phase], title_multiloc: { 'en' => 'Improve public transport' }, body_multiloc: { 'en' => 'Public transport needs to be more efficient.' }, input_topics: [])
 
-      llm_instance = instance_double(Analysis::LLM::Gemini3Flash)
-      expect(Analysis::LLM::Gemini3Flash).to receive(:new).and_return(llm_instance)
+      llm_instance = instance_double(Analysis::LLM::ClaudeHaiku45)
+      expect(Analysis::LLM::ClaudeHaiku45).to receive(:new).and_return(llm_instance)
       expect(llm_instance).to receive(:chat).and_return(['99'], ['1'])
 
       service.classify_topics!(idea)
@@ -82,8 +82,8 @@ describe IdeaFeed::TopicClassificationService do
     it 'retries when the LLM response is not an in-bounds integer array' do
       idea = create(:idea, phases: [phase], title_multiloc: { 'en' => 'Improve public transport' }, body_multiloc: { 'en' => 'Public transport needs to be more efficient.' }, input_topics: [])
 
-      llm_instance = instance_double(Analysis::LLM::Gemini3Flash)
-      expect(Analysis::LLM::Gemini3Flash).to receive(:new).and_return(llm_instance)
+      llm_instance = instance_double(Analysis::LLM::ClaudeHaiku45)
+      expect(Analysis::LLM::ClaudeHaiku45).to receive(:new).and_return(llm_instance)
       expect(llm_instance).to receive(:chat).and_return(%w[a b], ['1'])
 
       service.classify_topics!(idea)
@@ -138,8 +138,8 @@ describe IdeaFeed::TopicClassificationService do
       idea2 = create(:idea, phases: [phase], title_multiloc: { 'en' => 'Affordable housing' }, body_multiloc: { 'en' => 'Housing is too expensive.' }, input_topics: [])
       idea3 = create(:idea, phases: [phase], title_multiloc: { 'en' => 'Better schools' }, body_multiloc: { 'en' => 'Schools need more funding.' }, input_topics: [])
 
-      llm_instance = instance_double(Analysis::LLM::Gemini3Flash)
-      expect(Analysis::LLM::Gemini3Flash).to receive(:new).and_return(llm_instance)
+      llm_instance = instance_double(Analysis::LLM::ClaudeHaiku45)
+      expect(Analysis::LLM::ClaudeHaiku45).to receive(:new).and_return(llm_instance)
       expect(llm_instance).to receive(:chat).and_return(['1.1'], ['2'], ['3'])
 
       result = service.classify_parallel_batch([idea1, idea2, idea3], n_threads: 2)
@@ -160,8 +160,8 @@ describe IdeaFeed::TopicClassificationService do
     it 'handles ActiveRecord::Relation input' do
       idea = create(:idea, phases: [phase], title_multiloc: { 'en' => 'Bike lanes' }, body_multiloc: { 'en' => 'We need more bike lanes.' }, input_topics: [])
 
-      llm_instance = instance_double(Analysis::LLM::Gemini3Flash)
-      expect(Analysis::LLM::Gemini3Flash).to receive(:new).and_return(llm_instance)
+      llm_instance = instance_double(Analysis::LLM::ClaudeHaiku45)
+      expect(Analysis::LLM::ClaudeHaiku45).to receive(:new).and_return(llm_instance)
       expect(llm_instance).to receive(:chat).and_return(['1'])
 
       result = service.classify_parallel_batch(Idea.where(id: idea.id))
@@ -173,8 +173,8 @@ describe IdeaFeed::TopicClassificationService do
     it 'retries on invalid LLM responses' do
       idea = create(:idea, phases: [phase], title_multiloc: { 'en' => 'Bike lanes' }, body_multiloc: { 'en' => 'We need more bike lanes.' }, input_topics: [])
 
-      llm_instance = instance_double(Analysis::LLM::Gemini3Flash)
-      expect(Analysis::LLM::Gemini3Flash).to receive(:new).and_return(llm_instance)
+      llm_instance = instance_double(Analysis::LLM::ClaudeHaiku45)
+      expect(Analysis::LLM::ClaudeHaiku45).to receive(:new).and_return(llm_instance)
       expect(llm_instance).to receive(:chat).and_return(%w[invalid response], ['1'])
 
       service.classify_parallel_batch([idea])
@@ -185,8 +185,8 @@ describe IdeaFeed::TopicClassificationService do
     it 'assigns empty topics if all retries fail' do
       idea = create(:idea, phases: [phase], title_multiloc: { 'en' => 'Bike lanes' }, body_multiloc: { 'en' => 'We need more bike lanes.' }, input_topics: [topics[0]])
 
-      llm_instance = instance_double(Analysis::LLM::Gemini3Flash)
-      expect(Analysis::LLM::Gemini3Flash).to receive(:new).and_return(llm_instance)
+      llm_instance = instance_double(Analysis::LLM::ClaudeHaiku45)
+      expect(Analysis::LLM::ClaudeHaiku45).to receive(:new).and_return(llm_instance)
       expect(llm_instance).to receive(:chat).and_return(%w[invalid response]).exactly(3).times
 
       service.classify_parallel_batch([idea])

--- a/back/spec/services/idea_feed/topic_modeling_service_spec.rb
+++ b/back/spec/services/idea_feed/topic_modeling_service_spec.rb
@@ -13,7 +13,7 @@ describe IdeaFeed::TopicModelingService do
     context 'when no topics exist yet' do
       it 'contains the project description in the prompt when not using the ContentBuilder' do
         project.update!(description_multiloc: { 'en' => 'This is a test project about urban development.' })
-        expect_any_instance_of(Analysis::LLM::Gemini3Pro).to receive(:chat) do |_, prompt|
+        expect_any_instance_of(Analysis::LLM::ClaudeOpus46).to receive(:chat) do |_, prompt|
           expect(prompt).to include('This is a test project about urban development.')
           []
         end
@@ -55,7 +55,7 @@ describe IdeaFeed::TopicModelingService do
             'linkedNodes' => {}
           }
         })
-        expect_any_instance_of(Analysis::LLM::Gemini3Pro).to receive(:chat) do |_, prompt|
+        expect_any_instance_of(Analysis::LLM::ClaudeOpus46).to receive(:chat) do |_, prompt|
           expect(prompt).to include('This is a ContentBuilder project description.')
           []
         end
@@ -65,7 +65,7 @@ describe IdeaFeed::TopicModelingService do
       it 'creates the returned topics and subtopics' do
         create(:idea, project:, phases: [phase], title_multiloc: { 'en' => 'Finding parking is impossible' }, body_multiloc: { 'en' => "I'm getting tired of the impossible parking situation in the city center. Sometimes I have to drive around for half an hour to find a parking space near my house." })
 
-        expect_any_instance_of(Analysis::LLM::Gemini3Pro).to receive(:chat).and_return([
+        expect_any_instance_of(Analysis::LLM::ClaudeOpus46).to receive(:chat).and_return([
           {
             'title_multiloc' => { 'en' => 'Parking', 'fr-FR' => 'Stationnement', 'nl-NL' => 'Parkeren' },
             'description_multiloc' => { 'en' => 'Contributions related to parking availability, regulations, and infrastructure for vehicles.', 'fr-FR' => 'Contributions relatives à la disponibilité du stationnement, à la réglementation et aux infrastructures pour les véhicules.', 'nl-NL' => 'Bijdragen met betrekking tot de beschikbaarheid van parkeerplaatsen, regelgeving en infrastructuur voor voertuigen.' },
@@ -96,7 +96,7 @@ describe IdeaFeed::TopicModelingService do
       it 'maps matching old topics to new topics and recreates subtopics' do
         create(:idea, project:, phases: [phase], title_multiloc: { 'en' => 'Finding parking is impossible' }, body_multiloc: { 'en' => "I'm getting tired of the impossible parking situation in the city center. Sometimes I have to drive around for half an hour to find a parking space near my house." })
 
-        allow_any_instance_of(Analysis::LLM::Gemini3Pro).to receive(:chat).and_return(
+        allow_any_instance_of(Analysis::LLM::ClaudeOpus46).to receive(:chat).and_return(
           # First call: topic model returns new topics
           [
             {
@@ -130,7 +130,7 @@ describe IdeaFeed::TopicModelingService do
       it 'updates changed topics, creates new topics, and removes obsolete topics' do
         create(:idea, project:, phases: [phase], title_multiloc: { 'en' => 'Finding parking is impossible' }, body_multiloc: { 'en' => "I'm getting tired of the impossible parking situation in the city center. Sometimes I have to drive around for half an hour to find a parking space near my house." })
 
-        allow_any_instance_of(Analysis::LLM::Gemini3Pro).to receive(:chat).and_return(
+        allow_any_instance_of(Analysis::LLM::ClaudeOpus46).to receive(:chat).and_return(
           [
             { 'title_multiloc' => { 'en' => 'Public Transportation' }, 'description_multiloc' => { 'en' => 'Ideas about public transportation systems and services' }, 'problems' => [] },
             { 'title_multiloc' => { 'en' => 'Parking' }, 'description_multiloc' => { 'en' => 'Contributions related to parking availability, regulations, and infrastructure for vehicles.' }, 'problems' => [] }
@@ -156,7 +156,7 @@ describe IdeaFeed::TopicModelingService do
       it 'when the mapping maps multiple old topics to the same new topic, removes them both and creates the new topic' do
         create(:idea, project:, phases: [phase], title_multiloc: { 'en' => 'Finding parking is impossible' }, body_multiloc: { 'en' => "I'm getting tired of the impossible parking situation in the city center. Sometimes I have to drive around for half an hour to find a parking space near my house." })
 
-        allow_any_instance_of(Analysis::LLM::Gemini3Pro).to receive(:chat).and_return(
+        allow_any_instance_of(Analysis::LLM::ClaudeOpus46).to receive(:chat).and_return(
           [
             { 'title_multiloc' => { 'en' => 'Public Transportation' }, 'description_multiloc' => { 'en' => 'Ideas about public transportation systems and services' }, 'problems' => [] },
             { 'title_multiloc' => { 'en' => 'Parking' }, 'description_multiloc' => { 'en' => 'Contributions related to parking availability, regulations, and infrastructure for vehicles.' }, 'problems' => [] }

--- a/back/spec/services/idea_feed/topic_modeling_service_spec.rb
+++ b/back/spec/services/idea_feed/topic_modeling_service_spec.rb
@@ -112,11 +112,9 @@ describe IdeaFeed::TopicModelingService do
             }
           ],
           # Second call: mapping - OLD-1 (Parking areas) maps to NEW-1 (Parking), others are removed
-          {
-            'OLD-1' => { 'new_topic_id' => 'NEW-1', 'adjusted_topic_title_multiloc' => { 'en' => 'Parking', 'fr-FR' => 'Stationnement', 'nl-NL' => 'Parkeren' }, 'adjusted_topic_description_multiloc' => { 'en' => 'Contributions related to parking availability, regulations, and infrastructure for vehicles.', 'fr-FR' => 'Contributions relatives à la disponibilité du stationnement, à la réglementation et aux infrastructures pour les véhicules.', 'nl-NL' => 'Bijdragen met betrekking tot de beschikbaarheid van parkeerplaatsen, regelgeving en infrastructuur voor voertuigen.' } },
-            'OLD-2' => { 'new_topic_id' => nil },
-            'OLD-3' => { 'new_topic_id' => nil }
-          }
+          [
+            { 'old_topic_id' => 'OLD-1', 'new_topic_id' => 'NEW-1', 'adjusted_topic_title_multiloc' => { 'en' => 'Parking', 'fr-FR' => 'Stationnement', 'nl-NL' => 'Parkeren' }, 'adjusted_topic_description_multiloc' => { 'en' => 'Contributions related to parking availability, regulations, and infrastructure for vehicles.', 'fr-FR' => 'Contributions relatives à la disponibilité du stationnement, à la réglementation et aux infrastructures pour les véhicules.', 'nl-NL' => 'Bijdragen met betrekking tot de beschikbaarheid van parkeerplaatsen, regelgeving en infrastructuur voor voertuigen.' } }
+          ]
         )
 
         expect { service.rebalance_topics! }.to change(InputTopic, :count).from(3).to(2)
@@ -137,11 +135,9 @@ describe IdeaFeed::TopicModelingService do
             { 'title_multiloc' => { 'en' => 'Public Transportation' }, 'description_multiloc' => { 'en' => 'Ideas about public transportation systems and services' }, 'problems' => [] },
             { 'title_multiloc' => { 'en' => 'Parking' }, 'description_multiloc' => { 'en' => 'Contributions related to parking availability, regulations, and infrastructure for vehicles.' }, 'problems' => [] }
           ],
-          {
-            'OLD-1' => { 'new_topic_id' => 'NEW-2', 'adjusted_topic_description_multiloc' => { 'en' => 'Contributions related to parking availability, regulations, and infrastructure for vehicles.', 'fr-FR' => 'Contributions relatives à la disponibilité du stationnement, à la réglementation et aux infrastructures pour les véhicules.', 'nl-NL' => 'Bijdragen met betrekking tot de beschikbaarheid van parkeerplaatsen, regelgeving en infrastructuur voor voertuigen.' }, 'adjusted_topic_title_multiloc' => { 'en' => 'Parking', 'fr-FR' => 'Stationnement', 'nl-NL' => 'Parkeren' } },
-            'OLD-2' => { 'new_topic_id' => nil },
-            'OLD-3' => { 'new_topic_id' => nil }
-          }
+          [
+            { 'old_topic_id' => 'OLD-1', 'new_topic_id' => 'NEW-2', 'adjusted_topic_description_multiloc' => { 'en' => 'Contributions related to parking availability, regulations, and infrastructure for vehicles.', 'fr-FR' => 'Contributions relatives à la disponibilité du stationnement, à la réglementation et aux infrastructures pour les véhicules.', 'nl-NL' => 'Bijdragen met betrekking tot de beschikbaarheid van parkeerplaatsen, regelgeving en infrastructuur voor voertuigen.' }, 'adjusted_topic_title_multiloc' => { 'en' => 'Parking', 'fr-FR' => 'Stationnement', 'nl-NL' => 'Parkeren' } }
+          ]
         )
 
         expect { service.rebalance_topics! }.to change(InputTopic, :count).from(3).to(2)
@@ -165,11 +161,10 @@ describe IdeaFeed::TopicModelingService do
             { 'title_multiloc' => { 'en' => 'Public Transportation' }, 'description_multiloc' => { 'en' => 'Ideas about public transportation systems and services' }, 'problems' => [] },
             { 'title_multiloc' => { 'en' => 'Parking' }, 'description_multiloc' => { 'en' => 'Contributions related to parking availability, regulations, and infrastructure for vehicles.' }, 'problems' => [] }
           ],
-          {
-            'OLD-1' => { 'new_topic_id' => 'NEW-2', 'adjusted_topic_description_multiloc' => { 'en' => 'Contributions related to parking availability, regulations, and infrastructure for vehicles.', 'fr-FR' => 'Contributions relatives à la disponibilité du stationnement, à la réglementation et aux infrastructures pour les véhicules.', 'nl-NL' => 'Bijdragen met betrekking tot de beschikbaarheid van parkeerplaatsen, regelgeving en infrastructuur voor voertuigen.' }, 'adjusted_topic_title_multiloc' => { 'en' => 'Parking', 'fr-FR' => 'Stationnement', 'nl-NL' => 'Parkeren' } },
-            'OLD-2' => { 'new_topic_id' => 'NEW-2' },
-            'OLD-3' => { 'new_topic_id' => nil }
-          }
+          [
+            { 'old_topic_id' => 'OLD-1', 'new_topic_id' => 'NEW-2', 'adjusted_topic_description_multiloc' => { 'en' => 'Contributions related to parking availability, regulations, and infrastructure for vehicles.', 'fr-FR' => 'Contributions relatives à la disponibilité du stationnement, à la réglementation et aux infrastructures pour les véhicules.', 'nl-NL' => 'Bijdragen met betrekking tot de beschikbaarheid van parkeerplaatsen, regelgeving en infrastructuur voor voertuigen.' }, 'adjusted_topic_title_multiloc' => { 'en' => 'Parking', 'fr-FR' => 'Stationnement', 'nl-NL' => 'Parkeren' } },
+            { 'old_topic_id' => 'OLD-2', 'new_topic_id' => 'NEW-2' }
+          ]
         )
 
         expect { service.rebalance_topics! }.to change(InputTopic, :count).from(3).to(2)


### PR DESCRIPTION
# Changelog
## Changed
- Auto input tagging (used in Perspectives aka Idea Feed) now uses AWS Bedrock Claude instead of Gemini by default
## Fixed
- Live auto tagging works again when there are a lot of topics present
