### PR TITLE
TAN-7215: clarify brand link destinations

### DIFF
--- a/front/app/components/CityLogoSection/index.tsx
+++ b/front/app/components/CityLogoSection/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { Image } from '@citizenlab/cl2-component-library';
 import styled from 'styled-components';
@@ -7,7 +7,10 @@ import useAppConfiguration from 'api/app_configuration/useAppConfiguration';
 
 import useLocalize from 'hooks/useLocalize';
 
+import { useIntl } from 'utils/cl-intl';
 import { isNilOrError } from 'utils/helperUtils';
+
+import messages from './messages';
 
 const Container = styled.div`
   display: flex;
@@ -28,44 +31,60 @@ const LogoLink = styled.a`
 
 const CityLogoSection = () => {
   const { data: appConfiguration } = useAppConfiguration();
+  const { formatMessage } = useIntl();
   const localize = useLocalize();
 
-  if (!isNilOrError(appConfiguration)) {
-    const currentTenantLogo =
-      appConfiguration.data.attributes.logo?.large || null;
-    const tenantSite =
-      appConfiguration.data.attributes.settings.core.organization_site;
-    const localizedOrgName = localize(
-      appConfiguration.data.attributes.settings.core.organization_name
-    );
+  const tenantSite =
+    appConfiguration?.data.attributes.settings.core.organization_site;
+  const platformHost = appConfiguration?.data.attributes.host;
+  const currentTenantLogo =
+    appConfiguration?.data.attributes.logo?.large || null;
+  const localizedOrgName = localize(
+    appConfiguration?.data.attributes.settings.core.organization_name
+  );
 
-    if (currentTenantLogo) {
-      const tenantImage = (
-        <Image
-          src={currentTenantLogo}
-          alt={localizedOrgName}
-          height="100px"
-          marginBottom="20px"
-          width="100%"
-          objectFit="contain"
-        />
-      );
-
-      return (
-        <Container id="hook-footer-logo">
-          {tenantSite ? (
-            <LogoLink href={tenantSite} target="_blank">
-              {tenantImage}
-            </LogoLink>
-          ) : (
-            <>{tenantImage}</>
-          )}
-        </Container>
-      );
+  const isExternalSite = useMemo(() => {
+    if (!tenantSite) return false;
+    try {
+      return new URL(tenantSite).hostname !== platformHost;
+    } catch {
+      return true;
     }
-  }
+  }, [tenantSite, platformHost]);
 
-  return null;
+  if (isNilOrError(appConfiguration) || !currentTenantLogo) return null;
+
+  const tenantImage = (
+    <Image
+      src={currentTenantLogo}
+      alt={localizedOrgName}
+      height="100px"
+      marginBottom="20px"
+      width="100%"
+      objectFit="contain"
+    />
+  );
+
+  return (
+    <Container id="hook-footer-logo">
+      {tenantSite ? (
+        <LogoLink
+          href={tenantSite}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={formatMessage(
+            isExternalSite
+              ? messages.logoLinkAriaLabelExternal
+              : messages.logoLinkAriaLabelInternal
+          )}
+        >
+          {tenantImage}
+        </LogoLink>
+      ) : (
+        tenantImage
+      )}
+    </Container>
+  );
 };
 
 export default CityLogoSection;

--- a/front/app/components/CityLogoSection/messages.ts
+++ b/front/app/components/CityLogoSection/messages.ts
@@ -1,0 +1,12 @@
+import { defineMessages } from 'react-intl';
+
+export default defineMessages({
+  logoLinkAriaLabelExternal: {
+    id: 'app.components.CityLogoSection.logoLinkAriaLabelExternal',
+    defaultMessage: 'Visit {orgName} website (opens in new tab)',
+  },
+  logoLinkAriaLabelInternal: {
+    id: 'app.components.CityLogoSection.logoLinkAriaLabelInternal',
+    defaultMessage: '{orgName} Home',
+  },
+});

--- a/front/app/translations/en.json
+++ b/front/app/translations/en.json
@@ -68,6 +68,8 @@
   "app.components.AvatarBubbles.numberOfUsers": "{numberOfUsers} users",
   "app.components.AvatarBubbles.participant": "participant",
   "app.components.AvatarBubbles.participants1": "participants",
+  "app.components.CityLogoSection.logoLinkAriaLabelExternal": "Visit {orgName} website (opens in new tab)",
+  "app.components.CityLogoSection.logoLinkAriaLabelInternal": "{orgName} Home",
   "app.components.Comments.cancel": "Cancel",
   "app.components.Comments.commentingDisabledInCurrentPhase": "Commenting is not possible in the current phase.",
   "app.components.Comments.commentingDisabledInactiveProject": "Commenting is not possible because this project is currently not active.",


### PR DESCRIPTION
# Changelog

## Fixed
- a11y: Disambiguate header and footer logo links for screen readers (WCAG 2.4.4). The footer logo link now has a distinct aria-label ("Visit {orgName} website") when it points to an external site, so it's clearly distinguishable from the header logo ("{orgName} Home").
