### PR TITLE
TAN-7216: Ensure we have accessible names to all modals

### DIFF
--- a/front/app/components/AnonymousParticipationConfirmationModal/OldAnonymousParticipationConfirmationModal.tsx
+++ b/front/app/components/AnonymousParticipationConfirmationModal/OldAnonymousParticipationConfirmationModal.tsx
@@ -30,7 +30,12 @@ const OldAnonymousParticipationConfirmationModal = ({
   const { formatMessage } = useIntl();
 
   return (
-    <Modal width="460px" opened close={onCloseModal}>
+    <Modal
+      width="460px"
+      opened
+      close={onCloseModal}
+      ariaLabelledBy="anonymous-participation-modal-title"
+    >
       <Box
         display="flex"
         height="64px"
@@ -48,7 +53,11 @@ const OldAnonymousParticipationConfirmationModal = ({
       </Box>
       <Box display="flex" flexDirection="column" width="100%">
         <Box mb="40px">
-          <Title variant="h4" color="tenantText">
+          <Title
+            id="anonymous-participation-modal-title"
+            variant="h4"
+            color="tenantText"
+          >
             {formatMessage(messages.participateAnonymously)}
           </Title>
           <Text color="tenantText" fontSize="s">

--- a/front/app/components/AnonymousParticipationConfirmationModal/index.tsx
+++ b/front/app/components/AnonymousParticipationConfirmationModal/index.tsx
@@ -24,7 +24,12 @@ const AnonymousParticipationConfirmationModal = ({ onCloseModal }: Props) => {
   const { formatMessage } = useIntl();
 
   return (
-    <Modal width="460px" opened close={onCloseModal}>
+    <Modal
+      width="460px"
+      opened
+      close={onCloseModal}
+      ariaLabelledBy="anonymous-participation-modal-title"
+    >
       <Box
         display="flex"
         height="64px"
@@ -42,7 +47,11 @@ const AnonymousParticipationConfirmationModal = ({ onCloseModal }: Props) => {
       </Box>
       <Box display="flex" flexDirection="column" width="100%">
         <Box mb="40px">
-          <Title variant="h4" color="tenantText">
+          <Title
+            id="anonymous-participation-modal-title"
+            variant="h4"
+            color="tenantText"
+          >
             {formatMessage(messages.participateAnonymously)}
           </Title>
           <Text color="tenantText" fontSize="s">

--- a/front/app/components/ConsentManager/BaseMainContent.tsx
+++ b/front/app/components/ConsentManager/BaseMainContent.tsx
@@ -12,6 +12,8 @@ import { FormattedMessage } from 'utils/cl-intl';
 import CookieModalContentContainer from './CookieModalContentContainer';
 import messages from './messages';
 
+export const COOKIE_MODAL_TITLE_ID = 'cookie-modal-title';
+
 interface Props {
   id?: string;
   children?: ReactNode;
@@ -28,7 +30,11 @@ const BaseMainContent = ({ id, children }: Props) => {
   return (
     <CookieModalContentContainer id={id}>
       <Icon name="cookie" fill={theme.colors.tenantPrimary} />
-      <Title as="h1" variant={isSmallerThanPhone ? 'h4' : 'h3'}>
+      <Title
+        as="h1"
+        id={COOKIE_MODAL_TITLE_ID}
+        variant={isSmallerThanPhone ? 'h4' : 'h3'}
+      >
         <FormattedMessage {...messages.cookieModalTitle} />
         {siteName && <> - {localize(siteName)}</>}
       </Title>

--- a/front/app/components/ConsentManager/ConsentManagerModal/index.tsx
+++ b/front/app/components/ConsentManager/ConsentManagerModal/index.tsx
@@ -10,6 +10,7 @@ import Modal from 'components/UI/Modal';
 import eventEmitter from 'utils/eventEmitter';
 import { isNilOrError } from 'utils/helperUtils';
 
+import { COOKIE_MODAL_TITLE_ID } from '../BaseMainContent';
 import { getConsent, ISavedDestinations, setConsent } from '../consent';
 import { allCategories, TCategory } from '../destinations';
 import InitialScreenFooter from '../InitialScreen/Footer';
@@ -160,6 +161,7 @@ const ConsentManagerModal = () => {
       closeOnClickOutside={false}
       hideCloseButton
       close={reject}
+      ariaLabelledBy={COOKIE_MODAL_TITLE_ID}
       footer={
         <>
           {screen === 'initial' && (

--- a/front/app/components/FormBuilder/components/FormBuilderTopBar/SuperAdmin/EditSchemaButtonWithModal.tsx
+++ b/front/app/components/FormBuilder/components/FormBuilderTopBar/SuperAdmin/EditSchemaButtonWithModal.tsx
@@ -144,9 +144,14 @@ const EditSchemaButtonWithModal = ({
       >
         <FormattedMessage {...messages.schemaEdit} />
       </Button>
-      <Modal opened={showModal} close={() => setShowModal(false)} width="800px">
+      <Modal
+        opened={showModal}
+        close={() => setShowModal(false)}
+        width="800px"
+        ariaLabelledBy="edit-schema-modal-title"
+      >
         <Box p="24px">
-          <Title variant="h3" mb="16px">
+          <Title id="edit-schema-modal-title" variant="h3" mb="16px">
             <FormattedMessage {...messages.schemaEdit} />
           </Title>
 

--- a/front/app/components/FormBuilder/components/FormBuilderTopBar/index.tsx
+++ b/front/app/components/FormBuilder/components/FormBuilderTopBar/index.tsx
@@ -209,10 +209,14 @@ const FormBuilderTopBar = ({
           <FormattedMessage {...messages.save} />
         </ButtonWithLink>
       </Box>
-      <Modal opened={showLeaveModal} close={closeModal}>
+      <Modal
+        opened={showLeaveModal}
+        close={closeModal}
+        ariaLabelledBy="leave-builder-modal-title"
+      >
         <Box display="flex" flexDirection="column" width="100%" p="20px">
           <Box mb="40px">
-            <Title variant="h3" color="primary">
+            <Title id="leave-builder-modal-title" variant="h3" color="primary">
               <FormattedMessage
                 {...messages.leaveBuilderConfirmationQuestion}
               />

--- a/front/app/components/FormBuilder/components/FormFields/FormField/index.tsx
+++ b/front/app/components/FormBuilder/components/FormFields/FormField/index.tsx
@@ -407,10 +407,11 @@ export const FormField = ({
         opened={showDeleteModal}
         close={closeModal}
         returnFocusRef={moreActionsButtonRef}
+        ariaLabelledBy="delete-field-modal-title"
       >
         <Box display="flex" flexDirection="column" width="100%" p="20px">
           <Box mb="40px">
-            <Title variant="h3" color="primary">
+            <Title id="delete-field-modal-title" variant="h3" color="primary">
               {formatMessage(messages.deleteFieldWithLogicConfirmationQuestion)}
             </Title>
             <Text color="primary" fontSize="l">

--- a/front/app/components/PostShowComponents/SharingModalContent/index.tsx
+++ b/front/app/components/PostShowComponents/SharingModalContent/index.tsx
@@ -140,6 +140,7 @@ const SharingModalContent = ({ postId, className, title, subtitle }: Props) => {
       >
         <Image width="80px" height="80px" src={rocket} alt="" />
         <Title
+          id="success-modal-title"
           variant="h2"
           textAlign="center"
           className={`e2e-idea-social-sharing-modal-title`}

--- a/front/app/components/UI/Modal/index.tsx
+++ b/front/app/components/UI/Modal/index.tsx
@@ -317,14 +317,13 @@ const ModalContentContainerSwitch = ({
   return <StyledFocusOn width={width}>{children}</StyledFocusOn>;
 };
 
-interface Props {
+interface BaseProps {
   'data-testid'?: string;
   opened: boolean;
   fixedHeight?: boolean;
   width?: number | string;
   close: () => void;
   className?: string;
-  header?: JSX.Element | string;
   niceHeader?: boolean;
   footer?: JSX.Element;
   hasSkipButton?: boolean;
@@ -334,7 +333,6 @@ interface Props {
   children: React.ReactNode;
   zIndex?: number;
   hideCloseButton?: boolean;
-  ariaLabelledBy?: string;
   /**
    * Optional ref to return focus on close.
    * By default, focus returns to the control that opened the modal.
@@ -342,6 +340,10 @@ interface Props {
    */
   returnFocusRef?: React.RefObject<HTMLElement>;
 }
+
+type Props =
+  | (BaseProps & { header: JSX.Element | string; ariaLabelledBy?: string })
+  | (BaseProps & { header?: JSX.Element | string; ariaLabelledBy: string });
 
 const Modal: React.FC<Props> = ({
   'data-testid': dataTestId,

--- a/front/app/components/UI/Modal/index.tsx
+++ b/front/app/components/UI/Modal/index.tsx
@@ -334,6 +334,7 @@ interface Props {
   children: React.ReactNode;
   zIndex?: number;
   hideCloseButton?: boolean;
+  ariaLabelledBy?: string;
   /**
    * Optional ref to return focus on close.
    * By default, focus returns to the control that opened the modal.
@@ -359,6 +360,7 @@ const Modal: React.FC<Props> = ({
   children,
   zIndex,
   hideCloseButton,
+  ariaLabelledBy,
   returnFocusRef,
 }) => {
   const nodeRef = useRef(null); // Needed to fix React StrictMode warning
@@ -490,7 +492,7 @@ const Modal: React.FC<Props> = ({
             className={`modalcontent ${fixedHeight ? 'fixedHeight' : ''}`}
             onClickOutside={clickOutsideModal}
             windowHeight={windowHeight}
-            ariaLabelledBy={header ? 'modal-header' : undefined}
+            ariaLabelledBy={header ? 'modal-header' : ariaLabelledBy}
             aria-modal="true"
             role="dialog"
           >

--- a/front/app/components/UI/TypedDeleteConfirmationModal/index.tsx
+++ b/front/app/components/UI/TypedDeleteConfirmationModal/index.tsx
@@ -75,8 +75,9 @@ const TypedDeleteConfirmationModal = ({
       close={onClose}
       width={500}
       closeOnClickOutside={!isDeleting}
+      ariaLabelledBy="typed-delete-modal-title"
     >
-      <Title variant="h3" color="primary">
+      <Title id="typed-delete-modal-title" variant="h3" color="primary">
         {formatMessage(title)}
       </Title>
 

--- a/front/app/components/WarningModal/index.tsx
+++ b/front/app/components/WarningModal/index.tsx
@@ -45,6 +45,7 @@ const WarningModal = ({
       opened={open}
       close={onClose}
       returnFocusRef={returnFocusRef}
+      ariaLabelledBy="warning-modal-title"
     >
       <Box
         display="flex"
@@ -63,7 +64,7 @@ const WarningModal = ({
       </Box>
       <Box display="flex" flexDirection="column" width="100%">
         <Box mb="24px">
-          <Title variant="h4" color="tenantText">
+          <Title id="warning-modal-title" variant="h4" color="tenantText">
             {title}
           </Title>
           <Text color="tenantText" fontSize="s">

--- a/front/app/components/admin/SeatBasedBilling/AddModeratorsModal/index.tsx
+++ b/front/app/components/admin/SeatBasedBilling/AddModeratorsModal/index.tsx
@@ -36,7 +36,14 @@ const AddModeratorsModal = ({
     : formatMessage(messages.confirmButtonText);
 
   const header = !showSuccess ? (
-    <Text color="primary" my="8px" fontSize="l" fontWeight="bold" px="2px">
+    <Text
+      id="add-moderators-modal-title"
+      color="primary"
+      my="8px"
+      fontSize="l"
+      fontWeight="bold"
+      px="2px"
+    >
       {formatMessage(messages.giveManagerRights)}
     </Text>
   ) : undefined;
@@ -47,7 +54,12 @@ const AddModeratorsModal = ({
   };
 
   return (
-    <Modal opened={showModal} close={resetModal} header={header}>
+    <Modal
+      opened={showModal}
+      close={resetModal}
+      header={header}
+      ariaLabelledBy="add-moderators-modal-title"
+    >
       {showSuccess ? (
         <SeatSetSuccess
           closeModal={resetModal}

--- a/front/app/components/admin/SeatBasedBilling/ChangeSeatModal/index.tsx
+++ b/front/app/components/admin/SeatBasedBilling/ChangeSeatModal/index.tsx
@@ -100,7 +100,13 @@ const ChangeSeatModal = ({
 
   const header = !showSuccess ? (
     <Box px="2px">
-      <Text color="primary" my="8px" fontSize="l" fontWeight="bold">
+      <Text
+        id="change-seat-modal-title"
+        color="primary"
+        my="8px"
+        fontSize="l"
+        fontWeight="bold"
+      >
         {formatMessage(messages.changeUserRights)}
       </Text>
     </Box>
@@ -118,6 +124,7 @@ const ChangeSeatModal = ({
       close={resetModal}
       header={header}
       returnFocusRef={returnFocusRef}
+      ariaLabelledBy="change-seat-modal-title"
     >
       {showSuccess ? (
         <SeatSetSuccess

--- a/front/app/components/admin/SeatBasedBilling/InviteUsersWithSeatsModal/index.tsx
+++ b/front/app/components/admin/SeatBasedBilling/InviteUsersWithSeatsModal/index.tsx
@@ -56,7 +56,14 @@ const InviteUsersWithSeatsModal = ({
   };
 
   const header = !showSuccess ? (
-    <Text color="primary" my="8px" fontSize="l" fontWeight="bold" px="2px">
+    <Text
+      id="invite-users-modal-title"
+      color="primary"
+      my="8px"
+      fontSize="l"
+      fontWeight="bold"
+      px="2px"
+    >
       {formatMessage(messages.confirmSeatUsageChange)}
     </Text>
   ) : undefined;
@@ -87,7 +94,12 @@ const InviteUsersWithSeatsModal = ({
   };
 
   return (
-    <Modal opened={showModal} close={resetModal} header={header}>
+    <Modal
+      opened={showModal}
+      close={resetModal}
+      header={header}
+      ariaLabelledBy="invite-users-modal-title"
+    >
       {showSuccess ? (
         <SeatSetSuccess
           closeModal={resetModal}

--- a/front/app/components/admin/SurveyDeleteModal/SurveyDeleteModal.tsx
+++ b/front/app/components/admin/SurveyDeleteModal/SurveyDeleteModal.tsx
@@ -20,10 +20,14 @@ const DeleteModal = ({
 }: Props) => {
   const { formatMessage } = useIntl();
   return (
-    <Modal opened={showDeleteModal} close={closeDeleteModal}>
+    <Modal
+      opened={showDeleteModal}
+      close={closeDeleteModal}
+      ariaLabelledBy="delete-survey-modal-title"
+    >
       <Box display="flex" flexDirection="column" width="100%" p="20px">
         <Box mb="40px">
-          <Title variant="h3" color="primary">
+          <Title id="delete-survey-modal-title" variant="h3" color="primary">
             {formatMessage(messages.deleteResultsConfirmationQuestion)}
           </Title>
           <Text color="primary" fontSize="l">

--- a/front/app/components/admin/UserBlockModals/SuccessfulUserBlock.tsx
+++ b/front/app/components/admin/UserBlockModals/SuccessfulUserBlock.tsx
@@ -33,7 +33,12 @@ export default ({ opened, resetSuccess, setClose, date, name }: Props) => {
   };
 
   return (
-    <Modal width={400} opened={localOpened} close={onClose}>
+    <Modal
+      width={400}
+      opened={localOpened}
+      close={onClose}
+      ariaLabelledBy="user-block-success-title"
+    >
       <Box p="30px">
         <Box display="flex" justifyContent="center">
           <Icon
@@ -43,7 +48,7 @@ export default ({ opened, resetSuccess, setClose, date, name }: Props) => {
             height="60px"
           />
         </Box>
-        <Title variant="h2" textAlign="center">
+        <Title id="user-block-success-title" variant="h2" textAlign="center">
           {formatMessage(messages.allDone)}
         </Title>
         <Text textAlign="center">

--- a/front/app/components/admin/UserBlockModals/UnblockUser.tsx
+++ b/front/app/components/admin/UserBlockModals/UnblockUser.tsx
@@ -40,8 +40,9 @@ const UnblockUserModal = ({ setClose, user, returnFocusRef }: Props) => {
       close={setClose}
       opened={true}
       returnFocusRef={returnFocusRef}
+      ariaLabelledBy="unblock-user-modal-title"
     >
-      <Title variant="h3" m="35px 0 30px">
+      <Title id="unblock-user-modal-title" variant="h3" m="35px 0 30px">
         {formatMessage(messages.confirmUnblock, {
           name: getFullName(user),
         })}

--- a/front/app/containers/Admin/dashboard/ManagementFeed/ChangesTables.tsx
+++ b/front/app/containers/Admin/dashboard/ManagementFeed/ChangesTables.tsx
@@ -37,7 +37,7 @@ const ChangesTablesBeforeAndAfter = ({
     <div>
       <Box display="flex" gap="8px">
         <Box flex="1">
-          <Title color="primary" variant="h2">
+          <Title id="changes-modal-title" color="primary" variant="h2">
             {formatMessage(messages.before)}
           </Title>
           <ChangesTable changes={beforeChanges} />

--- a/front/app/containers/Admin/dashboard/ManagementFeed/ManagementFeedRow.tsx
+++ b/front/app/containers/Admin/dashboard/ManagementFeed/ManagementFeedRow.tsx
@@ -153,6 +153,7 @@ const ManagementFeedRow = ({ item }: { item: ManagementFeedData }) => {
         opened={isChangedModalOpened}
         close={() => setIsChangedModalOpened(false)}
         width="1000px"
+        ariaLabelledBy="changes-modal-title"
       >
         <ChangesTables changes={item.attributes.change} />
       </Modal>

--- a/front/app/containers/Admin/projects/project/analysis/LaunchModal/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/LaunchModal/index.tsx
@@ -29,7 +29,7 @@ const LaunchModal = ({ onClose }: LaunchModalProps) => {
     >
       <Box display="flex" gap="16px" alignItems="center">
         <Icon name="stars" fill={colors.orange500} width="40px" height="40px" />
-        <Title>{formatMessage(messages.title)}</Title>
+        <Title id="launch-modal-title">{formatMessage(messages.title)}</Title>
       </Box>
       <Box>
         <Text>{formatMessage(messages.subtitle)}</Text>

--- a/front/app/containers/Admin/projects/project/analysis/Tags/AutoTaggingModal/Step1.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Tags/AutoTaggingModal/Step1.tsx
@@ -90,7 +90,7 @@ const Step1 = ({
 
   return (
     <>
-      <Title mb="32px">
+      <Title id="auto-tagging-modal-title" mb="32px">
         <Icon name="stars" height="32px" width="32px" mr="4px" />
         {formatMessage(messages.autoTagTitle)}
       </Title>

--- a/front/app/containers/Admin/projects/project/analysis/Tags/RenameTagModal.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Tags/RenameTagModal.tsx
@@ -57,7 +57,9 @@ const RenameTag = ({
 
   return (
     <Box>
-      <Title>{formatMessage(messages.renameTagModalTitle)}</Title>
+      <Title id="rename-tag-modal-title">
+        {formatMessage(messages.renameTagModalTitle)}
+      </Title>
       <FormProvider {...methods}>
         <Box as="form" mt="40px" onSubmit={methods.handleSubmit(onFormSubmit)}>
           <Input

--- a/front/app/containers/Admin/projects/project/analysis/Tags/TagActions.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Tags/TagActions.tsx
@@ -174,6 +174,7 @@ const TagActions = ({ tag }: { tag: ITagData }) => {
       <Modal
         opened={renameModalOpenedTagId === tag.id}
         close={closeTagRenameModal}
+        ariaLabelledBy="rename-tag-modal-title"
       >
         <RenameTagModal
           closeRenameModal={closeTagRenameModal}

--- a/front/app/containers/Admin/projects/project/analysis/Tags/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Tags/index.tsx
@@ -178,6 +178,7 @@ const Tags = () => {
         opened={autotaggingModalIsOpened}
         close={() => setAutotaggingModalIsOpened(false)}
         width="1000px"
+        ariaLabelledBy="auto-tagging-modal-title"
       >
         <AutotaggingModal
           onCloseModal={() => setAutotaggingModalIsOpened(false)}

--- a/front/app/containers/Admin/projects/project/analysis/TopBar/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/TopBar/index.tsx
@@ -183,7 +183,11 @@ const TopBar = () => {
           iconColor={colors.grey800}
         />
         {isFiltersOpen && <Filters onClose={() => setIsFiltersOpen(false)} />}
-        <Modal opened={showLaunchModal} close={closeLaunchModal}>
+        <Modal
+          opened={showLaunchModal}
+          close={closeLaunchModal}
+          ariaLabelledBy="launch-modal-title"
+        >
           <LaunchModal onClose={closeLaunchModal} />
         </Modal>
       </Box>

--- a/front/app/containers/Admin/projects/project/data/ResetParticipationData.tsx
+++ b/front/app/containers/Admin/projects/project/data/ResetParticipationData.tsx
@@ -27,8 +27,14 @@ const ResetParticipationData = () => {
       >
         {formatMessage(messages.resetParticipationData)}
       </Button>
-      <Modal opened={modalOpened} close={() => setModalOpened(false)}>
-        <Title variant="h3">{formatMessage(messages.confirmationTitle)}</Title>
+      <Modal
+        opened={modalOpened}
+        close={() => setModalOpened(false)}
+        ariaLabelledBy="reset-data-modal-title"
+      >
+        <Title id="reset-data-modal-title" variant="h3">
+          {formatMessage(messages.confirmationTitle)}
+        </Title>
         <Text>{formatMessage(messages.confirmationDescription)}</Text>
         <Box display="flex" justifyContent="flex-end" gap="12px">
           <Button

--- a/front/app/containers/Admin/projects/project/files/components/FilesList/components/FilesListItem.tsx
+++ b/front/app/containers/Admin/projects/project/files/components/FilesList/components/FilesListItem.tsx
@@ -131,6 +131,7 @@ const FilesListItem = ({
         opened={isDeleteModalOpen}
         close={() => setIsDeleteModalOpen(false)}
         width="540px"
+        ariaLabelledBy="delete-file-modal-title"
       >
         <Box display="flex" flexDirection="column" mt="20px">
           {isBeingUsedAsAttachment && (
@@ -138,7 +139,7 @@ const FilesListItem = ({
               <FormattedMessage {...messages.fileBeingUsed} />
             </Text>
           )}
-          <Text textAlign="center" m="0px">
+          <Text id="delete-file-modal-title" textAlign="center" m="0px">
             <FormattedMessage {...messages.confirmDelete} />{' '}
           </Text>
           {isBeingUsedAsAttachment && (

--- a/front/app/containers/Admin/projects/project/files/components/UploadFileButtonWithModal.tsx
+++ b/front/app/containers/Admin/projects/project/files/components/UploadFileButtonWithModal.tsx
@@ -4,6 +4,7 @@ import { Button } from '@citizenlab/cl2-component-library';
 
 import Modal from 'components/UI/Modal';
 
+import { ScreenReaderOnly } from 'utils/a11y';
 import { useIntl } from 'utils/cl-intl';
 
 import FilesUpload from './FilesUpload';
@@ -26,7 +27,11 @@ const UploadFileButtonWithModal = () => {
         opened={modalOpen}
         close={() => setModalOpen(false)}
         padding={'40px'}
+        ariaLabelledBy="upload-files-modal-title"
       >
+        <ScreenReaderOnly id="upload-files-modal-title">
+          {formatMessage(messages.addFiles)}
+        </ScreenReaderOnly>
         <FilesUpload setModalOpen={setModalOpen} />
       </Modal>
     </>

--- a/front/app/containers/Admin/projects/project/information/ReportTab/CreateReportModal/index.tsx
+++ b/front/app/containers/Admin/projects/project/information/ReportTab/CreateReportModal/index.tsx
@@ -104,9 +104,19 @@ const CreateReportModal = ({
   };
 
   return (
-    <Modal opened={open} close={onClose} width="640px">
+    <Modal
+      opened={open}
+      close={onClose}
+      width="640px"
+      ariaLabelledBy="create-report-modal-title"
+    >
       <Box display="flex" flexDirection="column" alignItems="center" px="100px">
-        <Title variant="h2" color="primary" mt="40px">
+        <Title
+          id="create-report-modal-title"
+          variant="h2"
+          color="primary"
+          mt="40px"
+        >
           {formatMessage(otherModalMessages.createReportModalTitle)}
         </Title>
         <Text

--- a/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/ParticipationMethodPicker.tsx
+++ b/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/ParticipationMethodPicker.tsx
@@ -391,10 +391,14 @@ const ParticipationMethodPicker = ({
           <Error apiErrors={apiErrors && apiErrors.participation_method} />
         </>
       </SectionField>
-      <Modal opened={showChangeMethodModal} close={closeModal}>
+      <Modal
+        opened={showChangeMethodModal}
+        close={closeModal}
+        ariaLabelledBy="change-method-modal-title"
+      >
         <Box display="flex" flexDirection="column" width="100%" p="20px">
           <Box mb="40px">
-            <Title variant="h3" color="primary">
+            <Title id="change-method-modal-title" variant="h3" color="primary">
               <FormattedMessage {...messages2.changingMethod} />
             </Title>
             <Text color="primary" fontSize="l">

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/TopBar/QuitModal.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/TopBar/QuitModal.tsx
@@ -19,10 +19,14 @@ interface Props {
 
 const QuitModal = ({ open, onCloseModal, onGoBack }: Props) => {
   return (
-    <Modal opened={open} close={onCloseModal}>
+    <Modal
+      opened={open}
+      close={onCloseModal}
+      ariaLabelledBy="quit-report-modal-title"
+    >
       <Box display="flex" flexDirection="column" width="100%" p="20px">
         <Box mb="40px">
-          <Title variant="h3" color="primary">
+          <Title id="quit-report-modal-title" variant="h3" color="primary">
             <FormattedMessage {...messages.quitReportConfirmationQuestion} />
           </Title>
           <Text color="primary" fontSize="l">

--- a/front/app/containers/Admin/reporting/components/ReportBuilderPage/CreateReportModal/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilderPage/CreateReportModal/index.tsx
@@ -96,9 +96,19 @@ const CreateReportModal = ({ open, onClose }: Props) => {
   };
 
   return (
-    <Modal opened={open} close={onClose} width="640px">
+    <Modal
+      opened={open}
+      close={onClose}
+      width="640px"
+      ariaLabelledBy="create-report-modal-title"
+    >
       <Box display="flex" flexDirection="column" alignItems="center" px="100px">
-        <Title variant="h2" color="primary" mt="40px">
+        <Title
+          id="create-report-modal-title"
+          variant="h2"
+          color="primary"
+          mt="40px"
+        >
           {formatMessage(messages.createReportModalTitle)}
         </Title>
         <Text

--- a/front/app/containers/Admin/tools/PublicAPI/PublicAPITokens/CreateTokenModal/index.tsx
+++ b/front/app/containers/Admin/tools/PublicAPI/PublicAPITokens/CreateTokenModal/index.tsx
@@ -68,7 +68,9 @@ const CreateTokenModal = ({ onClose }: CreateTokenModalProps) => {
     <Box w="100%" m="24px auto" pr="24px">
       {!success ? (
         <>
-          <Title variant="h2">{formatMessage(messages.createTokenTitle)}</Title>
+          <Title id="create-token-modal-title" variant="h2">
+            {formatMessage(messages.createTokenTitle)}
+          </Title>
           <Text>{formatMessage(messages.createTokenDescription)}</Text>
           <FormProvider {...methods}>
             <form onSubmit={methods.handleSubmit(onFormSubmit)}>

--- a/front/app/containers/Admin/tools/PublicAPI/PublicAPITokens/index.tsx
+++ b/front/app/containers/Admin/tools/PublicAPI/PublicAPITokens/index.tsx
@@ -119,7 +119,11 @@ const PublicAPITokens = () => {
           <Title variant="h3">{formatMessage(messages.noTokens)}</Title>
         </Box>
       )}
-      <Modal opened={isModalOpen} close={closeTokenModal}>
+      <Modal
+        opened={isModalOpen}
+        close={closeTokenModal}
+        ariaLabelledBy="create-token-modal-title"
+      >
         <CreateTokenModal onClose={closeTokenModal} />
       </Modal>
     </>

--- a/front/app/containers/Admin/tools/Webhooks/WebhookSubscriptions/CreateSubscriptionModal/index.tsx
+++ b/front/app/containers/Admin/tools/Webhooks/WebhookSubscriptions/CreateSubscriptionModal/index.tsx
@@ -115,7 +115,7 @@ const CreateSubscriptionModal = ({ onClose }: CreateSubscriptionModalProps) => {
     <Box w="100%" m="24px auto" pr="24px">
       {!methods.formState.isSubmitSuccessful ? (
         <>
-          <Title variant="h2">
+          <Title id="create-webhook-modal-title" variant="h2">
             {formatMessage(messages.createWebhookTitle)}
           </Title>
           <Text>

--- a/front/app/containers/Admin/tools/Webhooks/WebhookSubscriptions/DeliveriesModal/index.tsx
+++ b/front/app/containers/Admin/tools/Webhooks/WebhookSubscriptions/DeliveriesModal/index.tsx
@@ -78,7 +78,7 @@ const DeliveriesModal = ({ subscriptionId }: DeliveriesModalProps) => {
 
   return (
     <Box w="100%" m="24px auto" pr="24px" maxHeight="80vh" overflowY="auto">
-      <Title variant="h2">
+      <Title id="deliveries-modal-title" variant="h2">
         <FormattedMessage
           {...messages.deliveriesTitle}
           values={{

--- a/front/app/containers/Admin/tools/Webhooks/WebhookSubscriptions/EditSubscriptionModal/index.tsx
+++ b/front/app/containers/Admin/tools/Webhooks/WebhookSubscriptions/EditSubscriptionModal/index.tsx
@@ -153,7 +153,9 @@ const EditSubscriptionModal = ({
 
   return (
     <Box w="100%" m="24px auto" pr="24px">
-      <Title variant="h2">{formatMessage(messages.editWebhookTitle)}</Title>
+      <Title id="edit-webhook-modal-title" variant="h2">
+        {formatMessage(messages.editWebhookTitle)}
+      </Title>
       <Text>{formatMessage(messages.editWebhookDescription)}</Text>
       <FormProvider {...methods}>
         <form onSubmit={methods.handleSubmit(onFormSubmit)}>

--- a/front/app/containers/Admin/tools/Webhooks/WebhookSubscriptions/index.tsx
+++ b/front/app/containers/Admin/tools/Webhooks/WebhookSubscriptions/index.tsx
@@ -269,11 +269,19 @@ const WebhookSubscriptions = () => {
           <Title variant="h3">{formatMessage(messages.noWebhooks)}</Title>
         </Box>
       )}
-      <Modal opened={modal.view === 'create'} close={closeModal}>
+      <Modal
+        opened={modal.view === 'create'}
+        close={closeModal}
+        ariaLabelledBy="create-webhook-modal-title"
+      >
         <CreateSubscriptionModal onClose={closeModal} />
       </Modal>
       {modal.view === 'edit' && (
-        <Modal opened={true} close={closeModal}>
+        <Modal
+          opened={true}
+          close={closeModal}
+          ariaLabelledBy="edit-webhook-modal-title"
+        >
           <EditSubscriptionModal
             subscriptionId={modal.subscriptionId}
             onClose={closeModal}
@@ -281,7 +289,12 @@ const WebhookSubscriptions = () => {
         </Modal>
       )}
       {modal.view === 'deliveries' && (
-        <Modal opened={true} close={closeModal} width="800px">
+        <Modal
+          opened={true}
+          close={closeModal}
+          width="800px"
+          ariaLabelledBy="deliveries-modal-title"
+        >
           <DeliveriesModal
             subscriptionId={modal.subscriptionId}
             onClose={closeModal}
@@ -289,9 +302,15 @@ const WebhookSubscriptions = () => {
         </Modal>
       )}
       {modal.view === 'new_secret' && (
-        <Modal opened={true} close={closeModal}>
+        <Modal
+          opened={true}
+          close={closeModal}
+          ariaLabelledBy="new-secret-modal-title"
+        >
           <Box data-testid="webhookNewSecret">
-            <Title variant="h2">{formatMessage(messages.newSecretTitle)}</Title>
+            <Title id="new-secret-modal-title" variant="h2">
+              {formatMessage(messages.newSecretTitle)}
+            </Title>
             <SecretTokenDisplay
               secret={modal.new_secret_token}
               onClose={closeModal}

--- a/front/app/containers/Admin/users/SetAsProjectModerator.tsx
+++ b/front/app/containers/Admin/users/SetAsProjectModerator.tsx
@@ -88,7 +88,7 @@ const SetAsProjectModerator = ({
 
   return (
     <div>
-      <Title mb="40px">
+      <Title id="set-moderator-modal-title" mb="40px">
         <FormattedMessage
           {...messages.setUserAsProjectModerator}
           values={{ name: getFullName(user) }}

--- a/front/app/containers/Admin/users/UserAssignedItems.tsx
+++ b/front/app/containers/Admin/users/UserAssignedItems.tsx
@@ -144,7 +144,7 @@ const UserAssignedItems = ({ user }: { user: IUserData }) => {
 
   return (
     <div>
-      <Title mb="0px">
+      <Title id="assigned-items-modal-title" mb="0px">
         <FormattedMessage
           {...messages.assignedItemsFor}
           values={{ name: getFullName(user) }}

--- a/front/app/containers/Admin/users/UserTableRow.tsx
+++ b/front/app/containers/Admin/users/UserTableRow.tsx
@@ -364,6 +364,7 @@ const UserTableRow = ({
           close={() => setIsAssignedItemsOpened(false)}
           // Return focus to the More Actions button on close
           returnFocusRef={moreActionsButtonRef}
+          ariaLabelledBy="assigned-items-modal-title"
         >
           <UserAssignedItems user={userInRow} />
         </Modal>
@@ -372,6 +373,7 @@ const UserTableRow = ({
           close={() => setIsSetSetAsProjectModeratorOpened(false)}
           // Return focus to the More Actions button on close
           returnFocusRef={moreActionsButtonRef}
+          ariaLabelledBy="set-moderator-modal-title"
         >
           <SetSetAsProjectModerator
             user={userInRow}

--- a/front/app/containers/App/ModalQueue/modals/CommunityMonitor/Modal.tsx
+++ b/front/app/containers/App/ModalQueue/modals/CommunityMonitor/Modal.tsx
@@ -40,7 +40,12 @@ const CommunityMonitorModal = () => {
   }
 
   return (
-    <Modal opened close={onClose} width="460px">
+    <Modal
+      opened
+      close={onClose}
+      width="460px"
+      ariaLabelledBy="community-monitor-modal-title"
+    >
       <Box mt="40px">
         <QuestionPreview
           projectSlug={project.data.attributes.slug}

--- a/front/app/containers/App/ModalQueue/modals/CommunityMonitor/components/QuestionPreview.tsx
+++ b/front/app/containers/App/ModalQueue/modals/CommunityMonitor/components/QuestionPreview.tsx
@@ -81,7 +81,12 @@ const QuestionPreview = ({
           participationMethod={'native_survey'}
         />
       </Suspense>
-      <Text textAlign="center" color="textSecondary" fontSize="s">
+      <Text
+        id="community-monitor-modal-title"
+        textAlign="center"
+        color="textSecondary"
+        fontSize="s"
+      >
         {formatMessage(messages.surveyDescription)}
       </Text>
     </FormProvider>

--- a/front/app/containers/App/ModalQueue/modals/UserSessionRecording/Modal.tsx
+++ b/front/app/containers/App/ModalQueue/modals/UserSessionRecording/Modal.tsx
@@ -36,7 +36,11 @@ const UserSessionRecordingModal = () => {
   };
 
   return (
-    <Modal opened close={onClose}>
+    <Modal
+      opened
+      close={onClose}
+      ariaLabelledBy="session-recording-modal-title"
+    >
       <Box p="24px">
         <Box display="flex" gap="16px" alignItems="center">
           <Icon
@@ -45,7 +49,9 @@ const UserSessionRecordingModal = () => {
             width="40px"
             height="40px"
           />
-          <Title>{formatMessage(messages.modalTitle)}</Title>
+          <Title id="session-recording-modal-title">
+            {formatMessage(messages.modalTitle)}
+          </Title>
         </Box>
 
         <Text fontSize="l">{formatMessage(messages.modalDescription1)}</Text>

--- a/front/app/containers/App/UserDeletedModal/index.tsx
+++ b/front/app/containers/App/UserDeletedModal/index.tsx
@@ -77,11 +77,18 @@ const UserDeletedModal = ({
   intl: { formatMessage },
 }: Props & WrappedComponentProps) => {
   return (
-    <Modal opened={modalOpened} close={closeUserDeletedModal}>
+    <Modal
+      opened={modalOpened}
+      close={closeUserDeletedModal}
+      ariaLabelledBy="user-deleted-modal-title"
+    >
       {userSuccessfullyDeleted ? (
         <Container>
           <img src={illustration} alt="illu" />
-          <Title data-cy="e2e-user-deleted-success-modal-content">
+          <Title
+            id="user-deleted-modal-title"
+            data-cy="e2e-user-deleted-success-modal-content"
+          >
             <FormattedMessage {...messages.userDeletedTitle} />
           </Title>
           <Subtitle>

--- a/front/app/containers/Authentication/Modal/index.tsx
+++ b/front/app/containers/Authentication/Modal/index.tsx
@@ -12,6 +12,7 @@ import Error from 'components/UI/Error';
 import Modal from 'components/UI/Modal';
 import QuillEditedContent from 'components/UI/QuillEditedContent';
 
+import { ScreenReaderOnly } from 'utils/a11y';
 import { useIntl, FormattedMessage } from 'utils/cl-intl';
 
 import messages from '../messages';
@@ -83,8 +84,12 @@ const AuthModal = () => {
         ) : undefined
       }
       niceHeader
+      ariaLabelledBy="auth-modal-title"
     >
       <Box id="e2e-authentication-modal" px={marginX} py="32px" w="100%">
+        <ScreenReaderOnly id="auth-modal-title">
+          {formatMessage(messages.authenticationDialog)}
+        </ScreenReaderOnly>
         {error && (
           <Box mb="16px">
             <Error

--- a/front/app/containers/Authentication/messages.ts
+++ b/front/app/containers/Authentication/messages.ts
@@ -111,4 +111,8 @@ export default defineMessages({
     id: 'app.containers.Authentication.signUpOrLogIn',
     defaultMessage: 'Sign up or log in',
   },
+  authenticationDialog: {
+    id: 'app.containers.Authentication.authenticationDialog',
+    defaultMessage: 'Authentication',
+  },
 });

--- a/front/app/containers/IdeaHeading/EditIdeaHeading/index.tsx
+++ b/front/app/containers/IdeaHeading/EditIdeaHeading/index.tsx
@@ -110,10 +110,19 @@ const EditIdeaHeading = ({ titleText, idea, projectId }: Props) => {
           />
         </Box>
       </Box>
-      <Modal opened={showLeaveModal} close={closeModal}>
+      <Modal
+        opened={showLeaveModal}
+        close={closeModal}
+        ariaLabelledBy="leave-edit-idea-modal-title"
+      >
         <Box display="flex" flexDirection="column" width="100%" p="20px">
           <Box mb="40px">
-            <Title variant="h1" as="h3" color="primary">
+            <Title
+              id="leave-edit-idea-modal-title"
+              variant="h1"
+              as="h3"
+              color="primary"
+            >
               <FormattedMessage {...messages.leaveFormConfirmationQuestion} />
             </Title>
             <Text color="primary" fontSize="l">

--- a/front/app/containers/IdeaHeading/NewIdeaHeading/index.tsx
+++ b/front/app/containers/IdeaHeading/NewIdeaHeading/index.tsx
@@ -137,10 +137,19 @@ const NewIdeaHeading = ({ phase, titleText }: Props) => {
           />
         </Box>
       </Box>
-      <Modal opened={showLeaveModal} close={closeModal}>
+      <Modal
+        opened={showLeaveModal}
+        close={closeModal}
+        ariaLabelledBy="leave-new-idea-modal-title"
+      >
         <Box display="flex" flexDirection="column" width="100%" p="20px">
           <Box mb="40px">
-            <Title variant="h1" as="h3" color="primary">
+            <Title
+              id="leave-new-idea-modal-title"
+              variant="h1"
+              as="h3"
+              color="primary"
+            >
               <FormattedMessage {...messages.leaveFormConfirmationQuestion} />
             </Title>
             <Text color="primary" fontSize="l">

--- a/front/app/containers/IdeasNewSurveyPage/IdeasNewSurveyForm/SurveyHeading/index.tsx
+++ b/front/app/containers/IdeasNewSurveyPage/IdeasNewSurveyForm/SurveyHeading/index.tsx
@@ -160,10 +160,19 @@ const SurveyHeading = ({ titleText, phaseId }: Props) => {
           />
         </Box>
       </Box>
-      <Modal opened={showLeaveModal} close={closeModal}>
+      <Modal
+        opened={showLeaveModal}
+        close={closeModal}
+        ariaLabelledBy="leave-survey-modal-title"
+      >
         <Box display="flex" flexDirection="column" width="100%" p="20px">
           <Box mb="40px">
-            <Title variant="h1" as="h3" color="primary">
+            <Title
+              id="leave-survey-modal-title"
+              variant="h1"
+              as="h3"
+              color="primary"
+            >
               <FormattedMessage {...messages.leaveFormConfirmationQuestion} />
             </Title>
             <Text color="primary" fontSize="l">

--- a/front/app/containers/IdeasShow/components/IdeaSharingModal/index.tsx
+++ b/front/app/containers/IdeasShow/components/IdeaSharingModal/index.tsx
@@ -31,6 +31,7 @@ const IdeaSharingModal = ({
       close={closeIdeaSocialSharingModal}
       hasSkipButton={true}
       skipText={<>{formatMessage(messages.skipSharing)}</>}
+      ariaLabelledBy="success-modal-title"
     >
       <SharingModalContent
         postId={newIdeaId}

--- a/front/app/containers/ProjectsShowPage/SucessModal.tsx
+++ b/front/app/containers/ProjectsShowPage/SucessModal.tsx
@@ -66,7 +66,12 @@ const SuccessModal = ({ projectId }: Props) => {
   const handleClose = () => setShowModal(false);
 
   return (
-    <Modal opened={showModal} close={handleClose} hasSkipButton={false}>
+    <Modal
+      opened={showModal}
+      close={handleClose}
+      hasSkipButton={false}
+      ariaLabelledBy="success-modal-title"
+    >
       <Box
         width="100%"
         display="flex"

--- a/front/app/containers/UsersEditPage/DeletionDialog.tsx
+++ b/front/app/containers/UsersEditPage/DeletionDialog.tsx
@@ -79,7 +79,7 @@ const DeletionDialog = ({
     return (
       <Container>
         {logo && <Logo src={logo} alt={localizedOrgName} />}
-        <Styledh1>
+        <Styledh1 id="delete-account-modal-title">
           <FormattedMessage {...messages.deleteYourAccount} />
         </Styledh1>
         <p>

--- a/front/app/containers/UsersEditPage/ProfileDeletion.tsx
+++ b/front/app/containers/UsersEditPage/ProfileDeletion.tsx
@@ -69,7 +69,11 @@ class ProfileDeletion extends PureComponent<
             </ButtonWithLink>
           </Row>
         </FormSection>
-        <Modal opened={dialogOpened} close={this.onCloseDialog}>
+        <Modal
+          opened={dialogOpened}
+          close={this.onCloseDialog}
+          ariaLabelledBy="delete-account-modal-title"
+        >
           <DeletionDialog closeDialog={this.onCloseDialog} />
         </Modal>
       </>

--- a/front/app/modules/commercial/admin_project_templates/admin/components/ProjectTemplateCard.tsx
+++ b/front/app/modules/commercial/admin_project_templates/admin/components/ProjectTemplateCard.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 import ButtonWithLink from 'components/UI/ButtonWithLink';
 import Modal from 'components/UI/Modal';
 
+import { ScreenReaderOnly } from 'utils/a11y';
 import { trackEventByName } from 'utils/analytics';
 import { FormattedMessage } from 'utils/cl-intl';
 
@@ -180,7 +181,11 @@ const ProjectTemplateCard = memo<Props>(
             setPreviewModalOpened(false);
           }}
           width={'95%'}
+          ariaLabelledBy="template-preview-modal-title"
         >
+          <ScreenReaderOnly id="template-preview-modal-title">
+            {title}
+          </ScreenReaderOnly>
           <Box width="100%" display="flex" justifyContent="center">
             <ProjectTemplatePreviewAdmin
               projectTemplateId={projectTemplateId}

--- a/front/app/modules/commercial/widgets/admin/containers/IdeasWidget/index.tsx
+++ b/front/app/modules/commercial/widgets/admin/containers/IdeasWidget/index.tsx
@@ -10,6 +10,7 @@ import { string, object, number, boolean, array } from 'yup';
 import ButtonWithLink from 'components/UI/ButtonWithLink';
 import Modal from 'components/UI/Modal';
 
+import { ScreenReaderOnly } from 'utils/a11y';
 import { trackEventByName } from 'utils/analytics';
 import { FormattedMessage, useIntl } from 'utils/cl-intl';
 
@@ -152,7 +153,11 @@ const IdeasWidget = () => {
         opened={codeModalOpened}
         close={handleCloseCodeModal}
         fixedHeight={true}
+        ariaLabelledBy="widget-code-modal-title"
       >
+        <ScreenReaderOnly id="widget-code-modal-title">
+          <FormattedMessage {...messages.htmlCodeTitle} />
+        </ScreenReaderOnly>
         <WidgetCode
           path={`/ideas?${widgetParams}`}
           width={methods.getValues('width') || 300}

--- a/front/app/translations/en.json
+++ b/front/app/translations/en.json
@@ -1201,6 +1201,7 @@
   "app.containers.AreaTerms.areaTerm": "area",
   "app.containers.AreaTerms.areasTerm": "areas",
   "app.containers.AuthProviders.emailTakenAndUserCanBeVerified": "An account with this email already exists. You can sign out, log in with this email address and verify your account on the settings page.",
+  "app.containers.Authentication.authenticationDialog": "Authentication",
   "app.containers.Authentication.signUpOrLogIn": "Sign up or log in",
   "app.containers.Authentication.steps.AccessDenied.close": "Close",
   "app.containers.Authentication.steps.AccessDenied.youDoNotMeetTheRequirements": "You do not meet the requirements to participate in this process.",


### PR DESCRIPTION
# Changelog

## Fixed
- a11y: Cookie consent dialog missing accessible name (WCAG 4.1.2) — screen readers now announce the dialog title
- a11y: Enforced accessible names on all Modal components via TypeScript union type (header or ariaLabelledBy required)
- a11y: Added ariaLabelledBy to 40+ modals across the codebase that were missing accessible names
