### PR TITLE
Hide Insights tab for external surveys in getTabs function

### DIFF
--- a/front/app/containers/Admin/projects/project/tabs.ts
+++ b/front/app/containers/Admin/projects/project/tabs.ts
@@ -102,8 +102,9 @@ export const getTabs = (
         ? undefined
         : formatMessage(messages.lockedTooltip),
     },
-    // Show Insights tab when phase_insights is enabled (for all methods except information)
+    // Show Insights tab when phase_insights is enabled (for all methods except information and external surveys)
     phase.attributes.participation_method !== 'information' &&
+      phase.attributes.participation_method !== 'survey' &&
       phase_insights_enabled && {
         label: formatMessage(messages.insightsTab),
         url: 'insights',


### PR DESCRIPTION
# Changelog

## Fixed
- Hide the Insights tab for external survey phases. External surveys (e.g. Typeform, Google Forms) don't capture participation metrics, timeline, or demographics data in our application. These phases already have a dedicated "Survey Results" tab for downloading responses.
