### PR TITLE
TAN-7269: fix download dropdown issues

### DIFF
--- a/front/app/components/admin/ContentBuilder/TopBar/Container.tsx
+++ b/front/app/components/admin/ContentBuilder/TopBar/Container.tsx
@@ -5,13 +5,14 @@ import { Box, colors, stylingConsts } from '@citizenlab/cl2-component-library';
 interface Props {
   id?: string;
   children: React.ReactNode;
+  zIndex?: string;
 }
 
-const Container = ({ id, children }: Props) => (
+const Container = ({ id, children, zIndex = '3' }: Props) => (
   <Box
     id={id}
     position="fixed"
-    zIndex="3"
+    zIndex={zIndex}
     alignItems="center"
     w="100%"
     h={`${stylingConsts.menuHeight}px`}

--- a/front/app/containers/Admin/projects/project/insights/index.tsx
+++ b/front/app/containers/Admin/projects/project/insights/index.tsx
@@ -6,12 +6,11 @@ import {
   Button,
   Text,
   Dropdown,
+  DropdownListItem,
   Badge,
   colors,
-  fontSizes,
 } from '@citizenlab/cl2-component-library';
 import { useParams } from 'react-router-dom';
-import styled from 'styled-components';
 
 import useAddAnalysis from 'api/analyses/useAddAnalysis';
 import useAnalyses from 'api/analyses/useAnalyses';
@@ -20,7 +19,6 @@ import usePhase from 'api/phases/usePhase';
 import projectFilesMessages from 'containers/Admin/projects/project/files/components/messages';
 
 import PageBreakBox from 'components/admin/ContentBuilder/Widgets/PageBreakBox';
-import ButtonWithLink from 'components/UI/ButtonWithLink';
 
 import { FormattedMessage, useIntl } from 'utils/cl-intl';
 import clHistory from 'utils/cl-router/history';
@@ -41,13 +39,6 @@ import {
   WordExportProvider,
   useWordExportContext,
 } from './word/WordExportContext';
-
-const DropdownButton = styled(ButtonWithLink)`
-  button {
-    display: flex !important;
-    justify-content: flex-start !important;
-  }
-`;
 
 const AI_ANALYSIS_SUPPORTED_METHODS = [
   'ideation',
@@ -227,37 +218,28 @@ const InsightsContent = () => {
                       <FormattedMessage {...messages.download} />
                     </Button>
                     <Dropdown
-                      width="220px"
+                      width="max-content"
                       top="42px"
-                      right="0px"
+                      right="12px"
                       opened={dropdownOpened}
                       onClickOutside={toggleDropdown(false)}
+                      zIndex="10000"
                       content={
                         <Box
                           p="8px"
                           display="flex"
                           flexDirection="column"
                           gap="4px"
+                          style={{ whiteSpace: 'nowrap' }}
                         >
-                          <DropdownButton
-                            onClick={handleDownloadPdf}
-                            buttonStyle="text"
-                            padding="8px"
-                            fontSize={`${fontSizes.s}px`}
-                          >
+                          <DropdownListItem onClick={handleDownloadPdf}>
                             <FormattedMessage {...messages.downloadPdf} />
-                          </DropdownButton>
-                          <DropdownButton
-                            onClick={handleDownloadWord}
-                            buttonStyle="text"
-                            padding="8px"
-                            fontSize={`${fontSizes.s}px`}
-                          >
+                          </DropdownListItem>
+                          <DropdownListItem onClick={handleDownloadWord}>
                             <Box
                               display="inline-flex"
                               alignItems="center"
                               gap="6px"
-                              style={{ whiteSpace: 'nowrap' }}
                             >
                               <FormattedMessage {...messages.downloadWord} />
                               <Badge
@@ -267,7 +249,7 @@ const InsightsContent = () => {
                                 {formatMessage(projectFilesMessages.beta)}
                               </Badge>
                             </Box>
-                          </DropdownButton>
+                          </DropdownListItem>
                         </Box>
                       }
                     />

--- a/front/app/containers/Admin/projects/project/insights/methodSpecific/nativeSurvey/SurveyActions.tsx
+++ b/front/app/containers/Admin/projects/project/insights/methodSpecific/nativeSurvey/SurveyActions.tsx
@@ -204,10 +204,12 @@ const SurveyActions = ({ phase }: Props) => {
             opened={isDropdownOpened}
             onClickOutside={closeDropdown}
             className="dropdown"
-            right="0px"
+            width="max-content"
+            right="12px"
             top="45px"
+            zIndex="10000"
             content={
-              <Box minWidth="300px">
+              <Box style={{ whiteSpace: 'nowrap' }}>
                 <DropdownListItem
                   onClick={() => {
                     setDropdownOpened(false);

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/TopBar/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/TopBar/index.tsx
@@ -7,12 +7,11 @@ import {
   TooltipContentWrapper,
   Tooltip,
   Dropdown,
-  fontSizes,
+  DropdownListItem,
   Badge,
 } from '@citizenlab/cl2-component-library';
 import { useEditor, SerializedNodes } from '@craftjs/core';
 import { RouteType } from 'routes';
-import styled from 'styled-components';
 import { SupportedLocale } from 'typings';
 
 import useAppConfiguration from 'api/app_configuration/useAppConfiguration';
@@ -47,13 +46,6 @@ import messages from './messages';
 import QuitModal from './QuitModal';
 import ReportTitle from './ReportTitle';
 import tracks from './tracks';
-
-const DownloadButton = styled(ButtonWithLink)`
-  button {
-    display: flex !important;
-    justify-content: flex-start !important;
-  }
-`;
 
 type ContentBuilderTopBarProps = {
   hasPendingState: boolean;
@@ -280,7 +272,7 @@ const ContentBuilderTopBar = ({
   ]);
 
   return (
-    <Container id="e2e-report-builder-topbar">
+    <Container id="e2e-report-builder-topbar" zIndex="100000">
       <QuitModal
         open={showQuitModal}
         onCloseModal={closeModal}
@@ -335,43 +327,32 @@ const ContentBuilderTopBar = ({
             </div>
           </Tooltip>
           <Dropdown
-            width="220px"
+            width="max-content"
             top="35px"
-            right="0"
+            right="12px"
             zIndex="1000002"
             opened={downloadMenuOpened}
             onClickOutside={toggleDownloadMenu(false)}
             content={
-              <>
-                <DownloadButton
+              <Box style={{ whiteSpace: 'nowrap' }}>
+                <DropdownListItem
                   onClick={handleDownloadPdf}
-                  buttonStyle="text"
-                  padding="0"
-                  fontSize={`${fontSizes.s}px`}
                   disabled={disablePrint}
                 >
                   {formatMessage(messages.downloadAsPdf)}
-                </DownloadButton>
-                <DownloadButton
+                </DropdownListItem>
+                <DropdownListItem
                   onClick={handleDownloadWord}
-                  buttonStyle="text"
-                  padding="0"
-                  fontSize={`${fontSizes.s}px`}
                   disabled={disableWordExport}
                 >
-                  <Box
-                    display="inline-flex"
-                    alignItems="center"
-                    gap="6px"
-                    style={{ whiteSpace: 'nowrap' }}
-                  >
+                  <Box display="inline-flex" alignItems="center" gap="6px">
                     {formatMessage(messages.downloadAsWord)}
                     <Badge color={colors.coolGrey600} className="inverse">
                       {formatMessage(projectFilesMessages.beta)}
                     </Badge>
                   </Box>
-                </DownloadButton>
-              </>
+                </DropdownListItem>
+              </Box>
             }
           />
         </Box>


### PR DESCRIPTION
# Changelog

## Fixed
- Download dropdown now expands to fit label text (no horizontal scroll) on Phase Insights, native survey insights, and Report Builder and no longer sits under the Settings panel on Report Builder