### PR TITLE
TAN-7270: Remove language attribute from HTML tag in index.html

### DIFF
--- a/front/app/index.html
+++ b/front/app/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html>
   <head>
     <title>Citizen engagement platform</title>
     <meta charset="utf-8" />


### PR DESCRIPTION
# Changelog

## Fixed
- Temporarily removed hardcoded lang="en" from index.html to prevent browsers from incorrectly auto-translating non-English pages.