### PR TITLE
TAN-7268 - Enable email change for SSO methods

### DIFF
--- a/front/app/containers/UsersEditPage/LoginCredentials.tsx
+++ b/front/app/containers/UsersEditPage/LoginCredentials.tsx
@@ -4,13 +4,14 @@ import { Box } from '@citizenlab/cl2-component-library';
 
 import { IUserData } from 'api/users/types';
 
+import useFeatureFlag from 'hooks/useFeatureFlag';
+
 import ButtonWithLink from 'components/UI/ButtonWithLink';
 import { FormSection, FormSectionTitle } from 'components/UI/FormComponents';
 
 import { FormattedMessage } from 'utils/cl-intl';
 
 import messages from './messages';
-import useFeatureFlag from 'hooks/useFeatureFlag';
 
 type PasswordChangeProps = {
   user: IUserData;

--- a/front/app/containers/UsersEditPage/LoginCredentials.tsx
+++ b/front/app/containers/UsersEditPage/LoginCredentials.tsx
@@ -10,12 +10,35 @@ import { FormSection, FormSectionTitle } from 'components/UI/FormComponents';
 import { FormattedMessage } from 'utils/cl-intl';
 
 import messages from './messages';
+import useFeatureFlag from 'hooks/useFeatureFlag';
 
 type PasswordChangeProps = {
   user: IUserData;
 };
 
 const LoginCredentials = ({ user }: PasswordChangeProps) => {
+  const passwordLoginEnabled = useFeatureFlag({ name: 'password_login' });
+
+  // Also need to show the change email button for SSO methods that don't return an email by default (email_always_present? == false)
+  const claveUnicaEnabled = useFeatureFlag({ name: 'clave_unica_login' });
+  const idAustriaEnabled = useFeatureFlag({ name: 'id_austria_login' });
+  const nemloginEnabled = useFeatureFlag({ name: 'nemlog_in_login' });
+  const acmEnabled = useFeatureFlag({ name: 'acm_login' });
+  const criiptoEnabled = useFeatureFlag({ name: 'criipto_login' });
+  const twodayEnabled = useFeatureFlag({ name: 'twoday_login' });
+
+  const showChangePassword = passwordLoginEnabled;
+  const showChangeEmail =
+    passwordLoginEnabled ||
+    claveUnicaEnabled ||
+    idAustriaEnabled ||
+    nemloginEnabled ||
+    acmEnabled ||
+    criiptoEnabled ||
+    twodayEnabled;
+
+  if (!showChangeEmail && !showChangePassword) return null;
+
   const userHasPreviousPassword = !user.attributes.no_password;
 
   const passwordChangeButtonText = !userHasPreviousPassword
@@ -39,16 +62,18 @@ const LoginCredentials = ({ user }: PasswordChangeProps) => {
         >
           <FormattedMessage {...messages.changeEmail} />
         </ButtonWithLink>
-        <ButtonWithLink
-          linkTo="/profile/change-password"
-          scrollToTop
-          width="auto"
-          justifyWrapper="left"
-          buttonStyle="secondary-outlined"
-          icon="lock"
-        >
-          <FormattedMessage {...passwordChangeButtonText} />
-        </ButtonWithLink>
+        {showChangePassword && (
+          <ButtonWithLink
+            linkTo="/profile/change-password"
+            scrollToTop
+            width="auto"
+            justifyWrapper="left"
+            buttonStyle="secondary-outlined"
+            icon="lock"
+          >
+            <FormattedMessage {...passwordChangeButtonText} />
+          </ButtonWithLink>
+        )}
       </Box>
     </FormSection>
   );

--- a/front/app/containers/UsersEditPage/index.tsx
+++ b/front/app/containers/UsersEditPage/index.tsx
@@ -5,8 +5,6 @@ import styled from 'styled-components';
 
 import useAuthUser from 'api/me/useAuthUser';
 
-import useFeatureFlag from 'hooks/useFeatureFlag';
-
 import CampaignsConsentForm from 'components/CampaignConsentForm';
 import Unauthorized from 'components/Unauthorized';
 
@@ -33,7 +31,6 @@ const Container = styled.div`
 `;
 
 const UsersEditPage = () => {
-  const passwordLoginActive = useFeatureFlag({ name: 'password_login' });
   const { data: authUser } = useAuthUser();
 
   if (!authUser?.data.attributes.registration_completed_at) {
@@ -59,7 +56,7 @@ const UsersEditPage = () => {
           <div>
             <VerificationStatus />
             <ProfileForm />
-            {passwordLoginActive && <LoginCredentials user={authUser.data} />}
+            <LoginCredentials user={authUser.data} />
             <ProfileDeletion />
             <CampaignsConsentForm
               trackEventName={tracks.defaultSettingsChanged}


### PR DESCRIPTION
# Changelog
## Fixed
- Enabled 'change email' button for platforms that only have SSO methods enabled that do not always return an email (eg ClaveUnica. ID Austria)
