### PR TITLE
TAN-5992 - Improve performance of update_all service

### DIFF
--- a/back/engines/commercial/idea_custom_fields/app/services/idea_custom_fields/update_all_service.rb
+++ b/back/engines/commercial/idea_custom_fields/app/services/idea_custom_fields/update_all_service.rb
@@ -87,7 +87,7 @@ module IdeaCustomFields
 
           update_statements!(field, statements_params, index) if statements_params
           relate_map_config_to_field(field, field_params, index)
-          field.move_to_bottom
+          field.insert_at(index) unless field.ordering == index
           count_fields(field)
         end
 
@@ -166,8 +166,8 @@ module IdeaCustomFields
             option = create_option!(option_params, field, option_temp_ids_to_ids_mapping, field_index, option_index)
             next unless option
           end
-          update_option_image!(option, option_params[:image_id])
-          option.move_to_bottom
+          update_option_image!(option, option_params[:image_id]) if option_params.key?(:image_id)
+          option.insert_at(option_index) unless option.ordering == option_index
         end
       end
     end
@@ -245,7 +245,7 @@ module IdeaCustomFields
         else
           statement = create_statement!(statement_params, field, field_index, statement_index)
         end
-        statement&.move_to_bottom
+        statement&.insert_at(statement_index) unless statement&.ordering == statement_index
       end
     end
 


### PR DESCRIPTION
Theory here is that for a form with lots of fields and lots of options, on save we are currently moving each field/option to the bottom which writes updates to all the fields or all the options every time. ie 10 fields = 10 queries per `move_to_bottom` = 100 updates in total, where none need to happen if the field order has not changed.

TODO: Could do with a test or two to prove this

# Changelog
## Fixed
- Attempt to make save work quicker when editing forms
