### PR TITLE
TAN-7148 - Fixed campaigns so that moderators can edit emails on a phase

### DIFF
--- a/back/engines/free/email_campaigns/app/controllers/email_campaigns/web_api/v1/campaigns_controller.rb
+++ b/back/engines/free/email_campaigns/app/controllers/email_campaigns/web_api/v1/campaigns_controller.rb
@@ -19,7 +19,6 @@ module EmailCampaigns
       end
 
       if campaign_context
-        # binding.pry
         @campaigns = @campaigns.where(context: campaign_context)
         supported_ids = @campaigns.filter { |campaign| campaign.class.supports_context?(campaign_context) }.map(&:id)
         @campaigns = @campaigns.where(id: supported_ids)

--- a/back/engines/free/email_campaigns/app/controllers/email_campaigns/web_api/v1/campaigns_controller.rb
+++ b/back/engines/free/email_campaigns/app/controllers/email_campaigns/web_api/v1/campaigns_controller.rb
@@ -19,6 +19,7 @@ module EmailCampaigns
       end
 
       if campaign_context
+        # binding.pry
         @campaigns = @campaigns.where(context: campaign_context)
         supported_ids = @campaigns.filter { |campaign| campaign.class.supports_context?(campaign_context) }.map(&:id)
         @campaigns = @campaigns.where(id: supported_ids)

--- a/back/engines/free/email_campaigns/app/policies/email_campaigns/campaign_policy.rb
+++ b/back/engines/free/email_campaigns/app/policies/email_campaigns/campaign_policy.rb
@@ -11,7 +11,8 @@ module EmailCampaigns
       end
 
       def resolve
-        if user&.active? && UserRoleService.new.can_moderate?(campaign_context, user)
+        # Only moderators of the phase can see the campaigns on the phase, but ANY moderator can see (but not edit) the default campaigns.
+        if user&.active? && (campaign_context ? UserRoleService.new.can_moderate?(campaign_context, user) : active_admin_or_moderator?)
           scope.where(context: campaign_context)
         else
           scope.none
@@ -19,11 +20,11 @@ module EmailCampaigns
       end
     end
 
-    def create?
-      can_access_and_modify?
+    def show?
+      record.context ? can_access_and_modify? : active_admin_or_moderator?
     end
 
-    def show?
+    def create?
       can_access_and_modify?
     end
 

--- a/back/engines/free/email_campaigns/spec/acceptance/campaigns_spec.rb
+++ b/back/engines/free/email_campaigns/spec/acceptance/campaigns_spec.rb
@@ -586,8 +586,9 @@ resource 'Campaigns' do
     get '/web_api/v1/campaigns/:id' do
       let(:id) { @automated_campaigns.first.id }
 
-      example_request '[Unauthorized] Get campaign of type not manageable by project moderators', document: false do
-        assert_status 401
+      example_request 'Get global campaign', document: false do
+        assert_status 200
+        expect(response_data[:id]).to eq id
       end
     end
 
@@ -706,9 +707,9 @@ resource 'Campaigns' do
         assert_status 401
       end
 
-      example '[Unauthorized] Get the delivery statistics of a sent campaign not manageable by project moderator', document: false do
+      example 'Get the delivery statistics of a sent global campaign', document: false do
         do_request(id: @automated_campaigns.second.id)
-        assert_status 401
+        assert_status 200
       end
     end
   end

--- a/back/engines/free/email_campaigns/spec/policies/campaign_policy_spec.rb
+++ b/back/engines/free/email_campaigns/spec/policies/campaign_policy_spec.rb
@@ -11,7 +11,7 @@ describe EmailCampaigns::CampaignPolicy do
   let!(:global_campaign) { create(:comment_on_your_comment_campaign, context: nil) }
   let!(:context_campaign) { create(:comment_on_your_comment_campaign, context: phase) }
 
-  context 'for a global campaigns' do
+  context 'for global campaigns' do
     let(:campaign) { global_campaign }
 
     context 'for a visitor' do

--- a/back/engines/free/email_campaigns/spec/policies/campaign_policy_spec.rb
+++ b/back/engines/free/email_campaigns/spec/policies/campaign_policy_spec.rb
@@ -3,62 +3,49 @@
 require 'rails_helper'
 
 describe EmailCampaigns::CampaignPolicy do
-  subject { described_class.new(user, context_campaign) }
+  subject { described_class.new(user, campaign) }
 
-  let(:scope) { EmailCampaigns::CampaignPolicy::Scope.new(user, context_campaign.class, context_campaign.context) }
-  let(:context) { create(:phase) }
+  let(:scope) { EmailCampaigns::CampaignPolicy::Scope.new(user, campaign.class, campaign.context) }
+  let(:phase) { create(:phase) }
+
   let!(:global_campaign) { create(:comment_on_your_comment_campaign, context: nil) }
-  let!(:context_campaign) { create(:comment_on_your_comment_campaign, context: context) }
+  let!(:context_campaign) { create(:comment_on_your_comment_campaign, context: phase) }
 
-  context 'for a visitor' do
-    let(:user) { nil }
+  context 'for a global campaigns' do
+    let(:campaign) { global_campaign }
 
-    it { is_expected.not_to permit(:show)    }
-    it { is_expected.not_to permit(:create)  }
-    it { is_expected.not_to permit(:update)  }
-    it { is_expected.not_to permit(:destroy) }
+    context 'for a visitor' do
+      let(:user) { nil }
 
-    it 'does not index the campaign' do
-      expect(scope.resolve.size).to eq 0
+      it { is_expected.not_to permit(:show)    }
+      it { is_expected.not_to permit(:create)  }
+      it { is_expected.not_to permit(:update)  }
+      it { is_expected.not_to permit(:destroy) }
+
+      it 'does not index the campaign' do
+        expect(scope.resolve.size).to eq 0
+      end
     end
-  end
 
-  context 'for a resident' do
-    let(:user) { create(:user) }
+    context 'for a resident' do
+      let(:user) { create(:user) }
 
-    it { is_expected.not_to permit(:show)    }
-    it { is_expected.not_to permit(:create)  }
-    it { is_expected.not_to permit(:update)  }
-    it { is_expected.not_to permit(:destroy) }
+      it { is_expected.not_to permit(:show)    }
+      it { is_expected.not_to permit(:create)  }
+      it { is_expected.not_to permit(:update)  }
+      it { is_expected.not_to permit(:destroy) }
 
-    it 'does not index the campaign' do
-      expect(scope.resolve.size).to eq 0
+      it 'does not index the campaign' do
+        expect(scope.resolve.size).to eq 0
+      end
     end
-  end
 
-  context 'for an admin' do
-    let(:user) { create(:admin) }
-
-    it { is_expected.to permit(:show) }
-    it { is_expected.to permit(:create) }
-    it { is_expected.to permit(:update)  }
-    it { is_expected.to permit(:destroy) }
-
-    it 'indexes the campaign' do
-      expect(scope.resolve.size).to eq 1
-    end
-  end
-
-  context 'for a project moderator' do
-    let(:phase) { create(:phase) }
-    let(:user) { create(:project_moderator, projects: [phase.project]) }
-
-    context 'of a project they moderate' do
-      let(:context) { phase }
+    context 'for an admin' do
+      let(:user) { create(:admin) }
 
       it { is_expected.to permit(:show) }
       it { is_expected.to permit(:create) }
-      it { is_expected.to permit(:update) }
+      it { is_expected.to permit(:update)  }
       it { is_expected.to permit(:destroy) }
 
       it 'indexes the campaign' do
@@ -66,16 +53,87 @@ describe EmailCampaigns::CampaignPolicy do
       end
     end
 
-    context 'of a project they don\'t moderate' do
-      let(:phase) { create(:phase) }
+    context 'for a project moderator' do
+      let(:user) { create(:project_moderator) }
 
-      it { is_expected.not_to permit(:show) }
+      it { is_expected.to permit(:show) }
       it { is_expected.not_to permit(:create) }
       it { is_expected.not_to permit(:update) }
       it { is_expected.not_to permit(:destroy) }
 
+      it 'indexes the campaign' do
+        expect(scope.resolve.size).to eq 1
+      end
+    end
+  end
+
+  context 'for campaigns with a phase context' do
+    let(:campaign) { context_campaign }
+
+    context 'for a visitor' do
+      let(:user) { nil }
+
+      it { is_expected.not_to permit(:show)    }
+      it { is_expected.not_to permit(:create)  }
+      it { is_expected.not_to permit(:update)  }
+      it { is_expected.not_to permit(:destroy) }
+
       it 'does not index the campaign' do
         expect(scope.resolve.size).to eq 0
+      end
+    end
+
+    context 'for a resident' do
+      let(:user) { create(:user) }
+
+      it { is_expected.not_to permit(:show)    }
+      it { is_expected.not_to permit(:create)  }
+      it { is_expected.not_to permit(:update)  }
+      it { is_expected.not_to permit(:destroy) }
+
+      it 'does not index the campaign' do
+        expect(scope.resolve.size).to eq 0
+      end
+    end
+
+    context 'for an admin' do
+      let(:user) { create(:admin) }
+
+      it { is_expected.to permit(:show) }
+      it { is_expected.to permit(:create) }
+      it { is_expected.to permit(:update)  }
+      it { is_expected.to permit(:destroy) }
+
+      it 'indexes the campaign' do
+        expect(scope.resolve.size).to eq 1
+      end
+    end
+
+    context 'for a project moderator' do
+      context 'of a project they moderate' do
+        let(:user) { create(:project_moderator, projects: [phase.project]) }
+
+        it { is_expected.to permit(:show) }
+        it { is_expected.to permit(:create) }
+        it { is_expected.to permit(:update) }
+        it { is_expected.to permit(:destroy) }
+
+        it 'indexes the campaign' do
+          expect(scope.resolve.size).to eq 1
+        end
+      end
+
+      context 'of a project they don\'t moderate' do
+        let(:user) { create(:project_moderator, projects: [create(:project)]) }
+
+        it { is_expected.not_to permit(:show) }
+        it { is_expected.not_to permit(:create) }
+        it { is_expected.not_to permit(:update) }
+        it { is_expected.not_to permit(:destroy) }
+
+        it 'does not index the campaign' do
+          expect(scope.resolve.size).to eq 0
+        end
       end
     end
   end


### PR DESCRIPTION
To fix this, I've had to change it so that moderators can read global campaigns (but not create, update or delete them)

# Changelog
## Fixed
- Fixed project moderator access to see and edit emails on a phase
