### PR TITLE
TAN-7134: fix open ended date issue

### DIFF
--- a/front/app/containers/Admin/projects/project/phaseSetup/index.tsx
+++ b/front/app/containers/Admin/projects/project/phaseSetup/index.tsx
@@ -260,7 +260,12 @@ const AdminPhaseEdit = ({ projectId, phase }: Props) => {
     event.preventDefault();
     if (!formData) return;
 
-    const { isValidated, errors } = validate(formData, phases, formatMessage);
+    const { isValidated, errors } = validate(
+      formData,
+      phases,
+      formatMessage,
+      phase?.data.id
+    );
 
     setValidationErrors(errors);
 

--- a/front/app/containers/Admin/projects/project/phaseSetup/validate.test.ts
+++ b/front/app/containers/Admin/projects/project/phaseSetup/validate.test.ts
@@ -1,56 +1,102 @@
-import { IUpdatedPhaseProperties } from 'api/phases/types';
+import { IPhaseData, IUpdatedPhaseProperties } from 'api/phases/types';
 
 import validate from './validate';
 
+const formatMessage = () => 'some message';
+
+const makePhase = (
+  id: string,
+  start_at: string,
+  end_at: string | null
+): IPhaseData => ({
+  id,
+  type: 'phase',
+  attributes: { start_at, end_at } as IPhaseData['attributes'],
+  relationships: {} as IPhaseData['relationships'],
+});
+
+const baseFormData: IUpdatedPhaseProperties = {
+  poll_anonymous: false,
+  survey_embed_url: null,
+  survey_service: null,
+  document_annotation_embed_url: null,
+  title_multiloc: { 'nl-BE': 'Title' },
+  start_at: '2024-01-01',
+  end_at: null,
+  participation_method: 'voting',
+  submission_enabled: true,
+  commenting_enabled: true,
+  reacting_enabled: true,
+  reacting_like_method: 'limited',
+  reacting_like_limited_max: null,
+  reacting_dislike_enabled: true,
+  reacting_dislike_method: 'unlimited',
+  reacting_dislike_limited_max: null,
+  allow_anonymous_participation: false,
+  presentation_mode: 'card',
+  ideas_order: 'random',
+  input_term: 'idea',
+  prescreening_mode: null,
+  voting_method: 'single_voting',
+  voting_max_total: 1,
+  voting_min_total: 0,
+  voting_max_votes_per_idea: 1,
+  vote_term: 'vote',
+  description_multiloc: { 'nl-BE': '<p>Desc</p>' },
+};
+
 describe('validate', () => {
-  it('should work', () => {
-    const formData: IUpdatedPhaseProperties = {
-      poll_anonymous: false,
-      survey_embed_url: null,
-      survey_service: null,
-      document_annotation_embed_url: null,
-      title_multiloc: {
-        'nl-BE': 'Iedereen kan stemmen op de mooiste foto of locatie',
-      },
+  it('validates successfully with valid data and no existing phases', () => {
+    const formData = {
+      ...baseFormData,
       start_at: '2024-11-01',
       end_at: '2024-12-20',
-      // created_at: "2024-08-29T14:22:12.260Z",
-      // updated_at: "2024-09-03T11:57:23.901Z",
-      // ideas_count: 0,
-      participation_method: 'voting',
-      submission_enabled: true,
-      commenting_enabled: true,
-      reacting_enabled: true,
-      reacting_like_method: 'limited',
-      reacting_like_limited_max: null,
-      reacting_dislike_enabled: true,
-      reacting_dislike_method: 'unlimited',
-      reacting_dislike_limited_max: null,
-      allow_anonymous_participation: false,
-      presentation_mode: 'card',
-      ideas_order: 'random',
-      input_term: 'idea',
-      prescreening_mode: null,
-      voting_method: 'single_voting',
-      voting_max_total: 1,
-      voting_min_total: 0,
-      voting_max_votes_per_idea: 1,
-      // baskets_count: 0,
-      // votes_count: 0,
-      vote_term: 'vote',
-      description_multiloc: {
-        'nl-BE':
-          '<p>Alle ingediende foto\'s van "verborgen parels" in Boom worden hier getoond.</p><p>Je kan nu 3 stemmen uitbrengen op jouw favoriete foto.</p><p>De 10 foto\'s met de meeste stemmen worden tentoongesteld in de bibliotheek.</p><p>jgerwogj</p>',
-      },
-      // previous_phase_end_at_updated: false,
-      // report_public: null,
-      // custom_form_persisted: false
     };
-
-    const formatMessage = () => 'some message';
 
     const result = validate(formData, { data: [] }, formatMessage);
 
     expect(result.isValidated).toBe(true);
+  });
+
+  it('allows changing start date to earlier when editing last phase with no end date', () => {
+    const lastPhaseId = 'last-phase-id';
+    const phases = {
+      data: [
+        makePhase('first-phase-id', '2024-01-15', '2024-02-01'),
+        makePhase(lastPhaseId, '2024-06-01', null),
+      ],
+    };
+
+    const result = validate(baseFormData, phases, formatMessage, lastPhaseId);
+
+    expect(result.isValidated).toBe(true);
+    expect(result.errors.phaseDateError).toBeUndefined();
+  });
+
+  it('requires end date when editing non-last phase with start before another phase and no end date', () => {
+    const firstPhaseId = 'first-phase-id';
+    const phases = {
+      data: [
+        makePhase(firstPhaseId, '2024-01-15', '2024-02-01'),
+        makePhase('last-phase-id', '2024-06-01', null),
+      ],
+    };
+
+    const result = validate(baseFormData, phases, formatMessage, firstPhaseId);
+
+    expect(result.isValidated).toBe(false);
+    expect(result.errors.phaseDateError).toBeDefined();
+  });
+
+  it('allows changing start date to earlier when editing the only phase with no end date', () => {
+    const onlyPhaseId = 'only-phase-id';
+    const phases = {
+      data: [makePhase(onlyPhaseId, '2024-06-01', null)],
+    };
+
+    const result = validate(baseFormData, phases, formatMessage, onlyPhaseId);
+
+    expect(result.isValidated).toBe(true);
+    expect(result.errors.phaseDateError).toBeUndefined();
   });
 });

--- a/front/app/containers/Admin/projects/project/phaseSetup/validate.tsx
+++ b/front/app/containers/Admin/projects/project/phaseSetup/validate.tsx
@@ -8,7 +8,8 @@ import messages from '../messages';
 const validate = (
   state: IUpdatedPhaseProperties,
   phases: IPhases | undefined,
-  formatMessage: FormatMessage
+  formatMessage: FormatMessage,
+  phaseId?: string
 ) => {
   const {
     start_at,
@@ -53,9 +54,20 @@ const validate = (
           new Date(phase.attributes.start_at).getTime()
         );
         const maxStartAt = Math.max(...startAtDates);
-        if (new Date(start_at).getTime() < maxStartAt) {
-          phaseDateError = formatMessage(messages.missingEndDateError);
-          isValidated = false;
+        const formStartAt = new Date(start_at).getTime();
+        if (formStartAt < maxStartAt) {
+          // Allow open end when editing the last phase (phase with latest start_at).
+          const phaseBeingEdited = phaseId
+            ? phases.data.find((p) => p.id === phaseId)
+            : undefined;
+          const isEditingLastPhase =
+            phaseBeingEdited &&
+            new Date(phaseBeingEdited.attributes.start_at).getTime() ===
+              maxStartAt;
+          if (!isEditingLastPhase) {
+            phaseDateError = formatMessage(messages.missingEndDateError);
+            isValidated = false;
+          }
         }
       }
     }


### PR DESCRIPTION
# Changelog

## Fixed
- Fixed a validation error that incorrectly blocked saving when editing the last (or only) open-ended phase's start date to an earlier date