### PR TITLE
TAN-6565 - Ensure all dashboard visit stats all use the same logic

### DIFF
--- a/back/app/services/insights/base_phase_insights_service.rb
+++ b/back/app/services/insights/base_phase_insights_service.rb
@@ -23,19 +23,19 @@ module Insights
 
     # TODO: Implement caching? (may not be needed if performance good enough)
     def cached_insights_data(participations)
-      sessions = visits_service.sessions(@phase.project_id, start_at: @phase.start_at, end_at: @phase.end_at)
+      visits_service = VisitsService.new(@phase.project_id, start_at: @phase.start_at, end_at: @phase.end_at)
       flattened_participations = participations.values.flatten
       participant_ids = flattened_participations.pluck(:participant_id).uniq
       participation_method_metrics = phase_participation_method_metrics(participations)
-      metrics = metrics_data(participations, participant_ids, sessions, participation_method_metrics)
+      metrics = metrics_data(participations, participant_ids, visits_service, participation_method_metrics)
       demographics = demographics_data(flattened_participations, participant_ids)
-      participants_and_visitors_chart_data = participants_and_visitors_chart_data(flattened_participations, sessions)
+      participants_and_visitors_chart_data = participants_and_visitors_chart_data(flattened_participations, visits_service)
 
       metrics.merge(demographics: { fields: demographics }, participants_and_visitors_chart_data: participants_and_visitors_chart_data)
     end
 
-    def metrics_data(participations, participant_ids, sessions, participation_method_metrics)
-      base_metrics = base_metrics(participations, participant_ids, sessions)
+    def metrics_data(participations, participant_ids, visits_service, participation_method_metrics)
+      base_metrics = base_metrics(participations, participant_ids, visits_service)
 
       phase_participation_method_metrics = {
         @phase.participation_method => participation_method_metrics
@@ -44,11 +44,8 @@ module Insights
       { metrics: base_metrics.merge(phase_participation_method_metrics) }
     end
 
-    def base_metrics(participations, participant_ids, sessions)
-      # TODO: 1
-      # visitors_count = visits.pluck(:visitor_id).uniq.count
-      visitors_count = visits_service.totals(sessions)[:visitors]
-
+    def base_metrics(participations, participant_ids, visits_service)
+      visitors_count = visits_service.total_visits[:visitors]
       participants_count = participant_ids.count
       base_7_day_changes = base_7_day_changes(participations, visitors_count, participants_count)
 
@@ -77,34 +74,8 @@ module Insights
         p[:acted_at] < 7.days.ago
       end.pluck(:participant_id).uniq.count
 
-      # OLD LOGIC
-      # constraints = { project_id: @phase.project.id }
-      # constraints[:created_at] = if @phase.end_at.present?
-      #                              @phase.start_at.beginning_of_day..phase.end_at.end_of_day
-      #                            else
-      #                              @phase.start_at.beginning_of_day..
-      #                                end
-      # visits = ImpactTracking::Session
-      #            .joins(:pageviews)
-      #            .where(impact_tracking_pageviews: constraints)
-      #
-      # old = visits.select(
-      #   "impact_tracking_pageviews.created_at AS date,
-      #   impact_tracking_sessions.user_id AS user_id,
-      #   impact_tracking_sessions.monthly_user_hash AS monthly_user_hash"
-      # ).map do |row|
-      #   {
-      #     acted_at: row.date,
-      #     visitor_id: row.user_id.present? ? row.user_id.to_s : row.monthly_user_hash
-      #   }
-      # end
-
-      # TODO: 2
-      # old_visitors_count_7_days_ago = old.select do |v|
-      #   v[:acted_at] < 7.days.ago
-      # end.pluck(:visitor_id).uniq.count
-      sessions_7_days_ago = visits_service.sessions(@phase.project_id, start_at: @phase.start_at, end_at: 7.days.ago)
-      visitors_count_7_days_ago = visits_service.totals(sessions_7_days_ago)[:visitors]
+      visits_service_7_days_ago = VisitsService.new(@phase.project_id, start_at: @phase.start_at, end_at: 7.days.ago)
+      visitors_count_7_days_ago = visits_service_7_days_ago.total_visits[:visitors]
 
       participation_rate_7_day_percent_change = if visitors_count > 0 && visitors_count_7_days_ago > 0
         participation_rate_7_days_ago = participants_count_7_days_ago.to_f / visitors_count_7_days_ago
@@ -305,12 +276,10 @@ module Insights
       ref_distribution.distribution_by_option_key
     end
 
-    def participants_and_visitors_chart_data(flattened_participations, sessions)
+    def participants_and_visitors_chart_data(flattened_participations, visits_service)
       resolution = chart_resolution
-      # TODO: 3
-      # grouped_visits = visits.group_by { |v| date_truncate(v[:acted_at], resolution) }
-      grouped_visits = visits_service.group_by_date(sessions, resolution).each_with_object({}) do |row, hash|
-        hash[row.date_group.to_date] = { visits: row.visits, visitors: row.visitors }
+      grouped_visits = visits_service.visits_by_date(resolution).each_with_object({}) do |row, hash|
+        hash[row[:date_group]] = { visits: row[:visits], visitors: row[:visitors] }
       end
       grouped_participations = flattened_participations.group_by { |p| date_truncate(p[:acted_at], resolution) }
 
@@ -319,12 +288,10 @@ module Insights
 
       grouped_timeseries = all_date_groups.map do |date_group|
         participations_in_group = grouped_participations[date_group] || []
-        visits_in_group = grouped_visits[date_group] || []
-
-        binding.pry
+        visits_in_group = grouped_visits[date_group] || {}
         {
           participants: participations_in_group.pluck(:participant_id).uniq.count,
-          visitors: visits_in_group[:visitors],
+          visitors: visits_in_group[:visitors] || 0,
           date_group: date_group
         }
       end
@@ -362,10 +329,6 @@ module Insights
       else # 'month'
         Date.new(date.year, date.month, 1)
       end
-    end
-
-    def visits_service
-      @visits_service ||= Insights::VisitsService.new
     end
   end
 end

--- a/back/app/services/insights/base_phase_insights_service.rb
+++ b/back/app/services/insights/base_phase_insights_service.rb
@@ -23,19 +23,19 @@ module Insights
 
     # TODO: Implement caching? (may not be needed if performance good enough)
     def cached_insights_data(participations)
-      visits = VisitsService.new.phase_visits(@phase)
+      sessions = visits_service.sessions(@phase.project_id, start_at: @phase.start_at, end_at: @phase.end_at)
       flattened_participations = participations.values.flatten
       participant_ids = flattened_participations.pluck(:participant_id).uniq
       participation_method_metrics = phase_participation_method_metrics(participations)
-      metrics = metrics_data(participations, participant_ids, visits, participation_method_metrics)
+      metrics = metrics_data(participations, participant_ids, sessions, participation_method_metrics)
       demographics = demographics_data(flattened_participations, participant_ids)
-      participants_and_visitors_chart_data = participants_and_visitors_chart_data(flattened_participations, visits)
+      participants_and_visitors_chart_data = participants_and_visitors_chart_data(flattened_participations, sessions)
 
       metrics.merge(demographics: { fields: demographics }, participants_and_visitors_chart_data: participants_and_visitors_chart_data)
     end
 
-    def metrics_data(participations, participant_ids, visits, participation_method_metrics)
-      base_metrics = base_metrics(participations, participant_ids, visits)
+    def metrics_data(participations, participant_ids, sessions, participation_method_metrics)
+      base_metrics = base_metrics(participations, participant_ids, sessions)
 
       phase_participation_method_metrics = {
         @phase.participation_method => participation_method_metrics
@@ -44,10 +44,13 @@ module Insights
       { metrics: base_metrics.merge(phase_participation_method_metrics) }
     end
 
-    def base_metrics(participations, participant_ids, visits)
-      visitors_count = visits.pluck(:visitor_id).uniq.count
+    def base_metrics(participations, participant_ids, sessions)
+      # TODO: 1
+      # visitors_count = visits.pluck(:visitor_id).uniq.count
+      visitors_count = visits_service.totals(sessions)[:visitors]
+
       participants_count = participant_ids.count
-      base_7_day_changes = base_7_day_changes(participations, visits, visitors_count, participants_count)
+      base_7_day_changes = base_7_day_changes(participations, visitors_count, participants_count)
 
       {
         visitors: visitors_count,
@@ -59,7 +62,7 @@ module Insights
       }
     end
 
-    def base_7_day_changes(participations, visits, visitors_count, participants_count)
+    def base_7_day_changes(participations, visitors_count, participants_count)
       unless phase_has_run_more_than_7_days?
         return {
           visitors_7_day_percent_change: nil,
@@ -74,9 +77,34 @@ module Insights
         p[:acted_at] < 7.days.ago
       end.pluck(:participant_id).uniq.count
 
-      visitors_count_7_days_ago = visits.select do |v|
-        v[:acted_at] < 7.days.ago
-      end.pluck(:visitor_id).uniq.count
+      # OLD LOGIC
+      # constraints = { project_id: @phase.project.id }
+      # constraints[:created_at] = if @phase.end_at.present?
+      #                              @phase.start_at.beginning_of_day..phase.end_at.end_of_day
+      #                            else
+      #                              @phase.start_at.beginning_of_day..
+      #                                end
+      # visits = ImpactTracking::Session
+      #            .joins(:pageviews)
+      #            .where(impact_tracking_pageviews: constraints)
+      #
+      # old = visits.select(
+      #   "impact_tracking_pageviews.created_at AS date,
+      #   impact_tracking_sessions.user_id AS user_id,
+      #   impact_tracking_sessions.monthly_user_hash AS monthly_user_hash"
+      # ).map do |row|
+      #   {
+      #     acted_at: row.date,
+      #     visitor_id: row.user_id.present? ? row.user_id.to_s : row.monthly_user_hash
+      #   }
+      # end
+
+      # TODO: 2
+      # old_visitors_count_7_days_ago = old.select do |v|
+      #   v[:acted_at] < 7.days.ago
+      # end.pluck(:visitor_id).uniq.count
+      sessions_7_days_ago = visits_service.sessions(@phase.project_id, start_at: @phase.start_at, end_at: 7.days.ago)
+      visitors_count_7_days_ago = visits_service.totals(sessions_7_days_ago)[:visitors]
 
       participation_rate_7_day_percent_change = if visitors_count > 0 && visitors_count_7_days_ago > 0
         participation_rate_7_days_ago = participants_count_7_days_ago.to_f / visitors_count_7_days_ago
@@ -277,9 +305,13 @@ module Insights
       ref_distribution.distribution_by_option_key
     end
 
-    def participants_and_visitors_chart_data(flattened_participations, visits)
+    def participants_and_visitors_chart_data(flattened_participations, sessions)
       resolution = chart_resolution
-      grouped_visits = visits.group_by { |v| date_truncate(v[:acted_at], resolution) }
+      # TODO: 3
+      # grouped_visits = visits.group_by { |v| date_truncate(v[:acted_at], resolution) }
+      grouped_visits = visits_service.group_by_date(sessions, resolution).each_with_object({}) do |row, hash|
+        hash[row.date_group.to_date] = { visits: row.visits, visitors: row.visitors }
+      end
       grouped_participations = flattened_participations.group_by { |p| date_truncate(p[:acted_at], resolution) }
 
       # Get all unique date groups from both participations and visits
@@ -289,9 +321,10 @@ module Insights
         participations_in_group = grouped_participations[date_group] || []
         visits_in_group = grouped_visits[date_group] || []
 
+        binding.pry
         {
           participants: participations_in_group.pluck(:participant_id).uniq.count,
-          visitors: visits_in_group.pluck(:visitor_id).uniq.count,
+          visitors: visits_in_group[:visitors],
           date_group: date_group
         }
       end
@@ -329,6 +362,10 @@ module Insights
       else # 'month'
         Date.new(date.year, date.month, 1)
       end
+    end
+
+    def visits_service
+      @visits_service ||= Insights::VisitsService.new
     end
   end
 end

--- a/back/app/services/insights/visits_service.rb
+++ b/back/app/services/insights/visits_service.rb
@@ -31,7 +31,7 @@ date_trunc('#{resolution}', impact_tracking_pageviews.created_at) as date_group"
         {
           visits: row.visits,
           visitors: row.visitors,
-          date_group: row.date_group.to_date
+          date_group: resolution == 'hour' ? row.date_group.to_datetime : row.date_group.to_date
         }
       end
     end

--- a/back/app/services/insights/visits_service.rb
+++ b/back/app/services/insights/visits_service.rb
@@ -24,8 +24,7 @@ module Insights
     # Grouping needs to join page views to session to be able to group by the date of each page view
     # @param [String] resolution - hour|day|month|year
     def visits_by_date(resolution)
-      result = filtered_page_views_query.joins(:session)
-      result = exclude_session_roles(result)
+      result = filtered_page_views_query
       result = result.select("
         COUNT(DISTINCT session_id) as visits,
         COUNT(DISTINCT COALESCE(CAST(user_id AS TEXT), monthly_user_hash)) as visitors,
@@ -52,25 +51,22 @@ module Insights
       exclude_session_roles(ImpactTracking::Session.where(id: session_ids))
     end
 
-    def filtered_page_views
-      result = filtered_page_views_query
-      if @exclude_roles
-        result = result.joins(:session)
-        result = exclude_session_roles(result)
-      end
+    def filtered_page_views_query
+      result = filtered_page_views_root_query.joins(:session)
+      result = exclude_session_roles(result) if @exclude_roles
       result
     end
 
     private
 
-    def filtered_page_views_query
+    def filtered_page_views_root_query
       page_views = ImpactTracking::Pageview.where(created_at: @start_date..@end_date)
       page_views = page_views.where(project_id: @project_id) if @project_id
       page_views
     end
 
     def session_ids
-      @session_ids ||= filtered_page_views_query.pluck(:session_id).uniq
+      @session_ids ||= filtered_page_views_root_query.pluck(:session_id).uniq
     end
 
     # NOTE: An extra query is needed when excluding roles

--- a/back/app/services/insights/visits_service.rb
+++ b/back/app/services/insights/visits_service.rb
@@ -44,8 +44,21 @@ module Insights
 
     # Because we want to calculate timings based on all page views of sessions that had a page view in the period,
     # we need to get all page views of for the sessions, even the ones outside the period.
-    def all_page_views_for_sessions
+    def all_page_views_query
       ImpactTracking::Pageview.where(session_id: session_ids_excluding_roles)
+    end
+
+    def filtered_sessions_query
+      exclude_session_roles(ImpactTracking::Session.where(id: session_ids))
+    end
+
+    def filtered_page_views
+      result = filtered_page_views_query
+      if @exclude_roles
+        result = result.joins(:session)
+        result = exclude_session_roles(result)
+      end
+      result
     end
 
     private
@@ -54,10 +67,6 @@ module Insights
       page_views = ImpactTracking::Pageview.where(created_at: @start_date..@end_date)
       page_views = page_views.where(project_id: @project_id) if @project_id
       page_views
-    end
-
-    def filtered_sessions_query
-      exclude_session_roles(ImpactTracking::Session.where(id: session_ids))
     end
 
     def session_ids

--- a/back/app/services/insights/visits_service.rb
+++ b/back/app/services/insights/visits_service.rb
@@ -1,30 +1,29 @@
 module Insights
   class VisitsService
-    # Single, simple definition of visit - filter sessions where a pageview happened in the period
+    # Definition of a visit - a session where a pageview happened
+    # When filtered by date - a session where a pageview has a date in the period
     def initialize(project_id, start_at: nil, end_at: nil, exclude_roles: nil)
       start_date, end_date = TimeBoundariesParser.new(start_at, end_at).parse
-
-      constraints = { created_at: start_date..end_date }
-      constraints[:project_id] = project_id if project_id.present?
-
-      @filtered_page_views = ImpactTracking::Pageview
-        .joins(:session)
-        .where(constraints)
-      if exclude_roles == 'exclude_admins_and_moderators'
-        @filtered_page_views = @filtered_page_views.where("highest_role IS NULL OR highest_role = 'user'")
-      end
+      @project_id = project_id
+      @start_date = start_date
+      @end_date = end_date
+      @exclude_roles = exclude_roles
     end
 
     def total_visits
-      result = @filtered_page_views.select("count(DISTINCT session_id) as visits,
-    count(DISTINCT COALESCE(CAST(user_id AS TEXT), monthly_user_hash)) as visitors")[0]
+      result = filtered_page_views.select("
+        count(DISTINCT session_id) as visits,
+        count(DISTINCT COALESCE(CAST(user_id AS TEXT), monthly_user_hash)) as visitors
+      ")[0]
       { visits: result.visits, visitors: result.visitors }
     end
 
     def visits_by_date(resolution)
-      result = @filtered_page_views.select("count(DISTINCT session_id) as visits,
-count(DISTINCT COALESCE(CAST(user_id AS TEXT), monthly_user_hash)) as visitors,
-date_trunc('#{resolution}', impact_tracking_pageviews.created_at) as date_group")
+      result = filtered_page_views.select("
+        count(DISTINCT session_id) as visits,
+        count(DISTINCT COALESCE(CAST(user_id AS TEXT), monthly_user_hash)) as visitors,
+        date_trunc('#{resolution}', impact_tracking_pageviews.created_at) as date_group
+      ")
         .group('date_group')
         .order('date_group')
       result.map do |row|
@@ -36,10 +35,22 @@ date_trunc('#{resolution}', impact_tracking_pageviews.created_at) as date_group"
       end
     end
 
-    # All page views for the sessions in the period, used for calculating timings and pages per session
-    # @filtered_page_views only includes those relevant to the filters
-    def all_session_page_views
-      ImpactTracking::Pageview.where(session_id: @filtered_page_views.pluck(:session_id).uniq)
+    # Because we want to calculate timings based on all page views of sessions that had a page view in the period,
+    # we need to get all page views of for the sessions, even the ones outside the period.
+    def all_page_views_for_sessions
+      ImpactTracking::Pageview.where(session_id: filtered_page_views.pluck(:session_id).uniq)
+    end
+
+    private
+
+    # Sessions with page views in the period
+    def filtered_page_views
+      page_views = ImpactTracking::Pageview
+                     .joins(:session)
+                     .where(created_at: @start_date..@end_date)
+      page_views = page_views.where(project_id: @project_id) if @project_id
+      page_views = page_views.where("highest_role IS NULL OR highest_role = 'user'") if @exclude_roles == 'exclude_admins_and_moderators'
+      page_views
     end
   end
 end

--- a/back/app/services/insights/visits_service.rb
+++ b/back/app/services/insights/visits_service.rb
@@ -10,19 +10,26 @@ module Insights
       @exclude_roles = exclude_roles
     end
 
+    # Totals only needs the sessions
     def total_visits
-      result = filtered_page_views.select("
-        count(DISTINCT session_id) as visits,
-        count(DISTINCT COALESCE(CAST(user_id AS TEXT), monthly_user_hash)) as visitors
-      ")[0]
-      { visits: result.visits, visitors: result.visitors }
+      result = filtered_sessions_query
+      result = result.select("
+        COUNT(*) as visits,
+        COUNT(DISTINCT COALESCE(CAST(user_id AS TEXT), monthly_user_hash)) as visitors
+      ")
+      row = result[0]
+      { visits: row&.visits || 0, visitors: row&.visitors || 0 }
     end
 
+    # Grouping needs to join page views to session to be able to group by the date of each page view
+    # @param [String] resolution - hour|day|month|year
     def visits_by_date(resolution)
-      result = filtered_page_views.select("
-        count(DISTINCT session_id) as visits,
-        count(DISTINCT COALESCE(CAST(user_id AS TEXT), monthly_user_hash)) as visitors,
-        date_trunc('#{resolution}', impact_tracking_pageviews.created_at) as date_group
+      result = filtered_page_views_query.joins(:session)
+      result = exclude_session_roles(result)
+      result = result.select("
+        COUNT(DISTINCT session_id) as visits,
+        COUNT(DISTINCT COALESCE(CAST(user_id AS TEXT), monthly_user_hash)) as visitors,
+        DATE_TRUNC('#{resolution}', impact_tracking_pageviews.created_at) as date_group
       ")
         .group('date_group')
         .order('date_group')
@@ -38,19 +45,34 @@ module Insights
     # Because we want to calculate timings based on all page views of sessions that had a page view in the period,
     # we need to get all page views of for the sessions, even the ones outside the period.
     def all_page_views_for_sessions
-      ImpactTracking::Pageview.where(session_id: filtered_page_views.pluck(:session_id).uniq)
+      ImpactTracking::Pageview.where(session_id: session_ids_excluding_roles)
     end
 
     private
 
-    # Sessions with page views in the period
-    def filtered_page_views
-      page_views = ImpactTracking::Pageview
-                     .joins(:session)
-                     .where(created_at: @start_date..@end_date)
+    def filtered_page_views_query
+      page_views = ImpactTracking::Pageview.where(created_at: @start_date..@end_date)
       page_views = page_views.where(project_id: @project_id) if @project_id
-      page_views = page_views.where("highest_role IS NULL OR highest_role = 'user'") if @exclude_roles == 'exclude_admins_and_moderators'
       page_views
+    end
+
+    def filtered_sessions_query
+      exclude_session_roles(ImpactTracking::Session.where(id: session_ids))
+    end
+
+    def session_ids
+      @session_ids ||= filtered_page_views_query.pluck(:session_id).uniq
+    end
+
+    # NOTE: An extra query is needed when excluding roles
+    def session_ids_excluding_roles
+      @session_ids_excluding_roles ||= @exclude_roles ? filtered_sessions_query.pluck(:id).uniq : session_ids
+    end
+
+    def exclude_session_roles(query)
+      return query unless @exclude_roles == 'exclude_admins_and_moderators'
+
+      query.where("highest_role IS NULL OR highest_role = 'user'")
     end
   end
 end

--- a/back/app/services/insights/visits_service.rb
+++ b/back/app/services/insights/visits_service.rb
@@ -1,58 +1,45 @@
 module Insights
   class VisitsService
-    def sessions(project_id, start_at: nil, end_at: nil, exclude_roles: nil)
+    # Single, simple definition of visit - filter sessions where a pageview happened in the period
+    def initialize(project_id, start_at: nil, end_at: nil, exclude_roles: nil)
       start_date, end_date = TimeBoundariesParser.new(start_at, end_at).parse
-      if project_id
-        project_visits(project_id, start_date, end_date, exclude_roles)
-      else
-        platform_visits(start_date, end_date, exclude_roles)
+
+      constraints = { created_at: start_date..end_date }
+      constraints[:project_id] = project_id if project_id.present?
+
+      @filtered_page_views = ImpactTracking::Pageview
+        .joins(:session)
+        .where(constraints)
+      if exclude_roles == 'exclude_admins_and_moderators'
+        @filtered_page_views = @filtered_page_views.where("highest_role IS NULL OR highest_role = 'user'")
       end
     end
 
-    def totals(sessions)
-      result = sessions.select("count(*) as visits,
+    def total_visits
+      result = @filtered_page_views.select("count(DISTINCT session_id) as visits,
     count(DISTINCT COALESCE(CAST(user_id AS TEXT), monthly_user_hash)) as visitors")[0]
       { visits: result.visits, visitors: result.visitors }
     end
 
-    def group_by_date(sessions, resolution)
-      sessions.select("count(*) as visits,
+    def visits_by_date(resolution)
+      result = @filtered_page_views.select("count(DISTINCT session_id) as visits,
 count(DISTINCT COALESCE(CAST(user_id AS TEXT), monthly_user_hash)) as visitors,
-date_trunc('#{resolution}', created_at) as date_group")
-            .group('date_group')
-            .order('date_group')
+date_trunc('#{resolution}', impact_tracking_pageviews.created_at) as date_group")
+        .group('date_group')
+        .order('date_group')
+      result.map do |row|
+        {
+          visits: row.visits,
+          visitors: row.visitors,
+          date_group: row.date_group.to_date
+        }
+      end
     end
 
-    def page_views(sessions)
-      ImpactTracking::Pageview.where(session_id: sessions.select(:id))
-    end
-
-    # def phase_visits(phase)
-    #   visits = visits(phase.project_id, start_at: phase.start_at, end_at: phase.end_at)
-    #   visits.select("impact_tracking_pageviews.created_at AS acted_at,
-    #     impact_tracking_sessions.id AS session_id,
-    #     COALESCE(CAST(impact_tracking_sessions.user_id AS TEXT), impact_tracking_sessions.monthly_user_hash) AS visitor_id")
-    # end
-
-    private
-
-    def platform_visits(start_date, end_date, exclude_roles)
-      # TODO: Actually we should count the number of sessions that had pageviews in the period
-      visits = ImpactTracking::Session.where(created_at: start_date..end_date)
-      exclude_roles(visits, exclude_roles)
-    end
-
-    # For project visits we want to count the date that they visited the project, not the date they started the session.
-    def project_visits(project_id, start_date, end_date, exclude_roles)
-      sessions_with_project = ImpactTracking::Pageview.where(project_id: project_id, created_at: start_date..end_date).select(:session_id)
-      visits = ImpactTracking::Session.where(id: sessions_with_project)
-      exclude_roles(visits, exclude_roles)
-    end
-
-    def exclude_roles(visits, exclude_roles)
-      return visits unless exclude_roles == 'exclude_admins_and_moderators'
-
-      visits.where("highest_role IS NULL OR highest_role = 'user'")
+    # All page views for the sessions in the period, used for calculating timings and pages per session
+    # @filtered_page_views only includes those relevant to the filters
+    def all_session_page_views
+      ImpactTracking::Pageview.where(session_id: @filtered_page_views.pluck(:session_id).uniq)
     end
   end
 end

--- a/back/app/services/insights/visits_service.rb
+++ b/back/app/services/insights/visits_service.rb
@@ -1,28 +1,50 @@
 module Insights
   class VisitsService
-    def phase_visits(phase)
-      constraints = { project_id: phase.project.id }
-
-      constraints[:created_at] = if phase.end_at.present?
-        phase.start_at.beginning_of_day..phase.end_at.end_of_day
+    def visits(project_id, start_at: nil, end_at: nil, exclude_roles: nil)
+      start_date, end_date = TimeBoundariesParser.new(start_at, end_at).parse
+      if project_id
+        project_visits(project_id, start_date, end_date, exclude_roles)
       else
-        phase.start_at.beginning_of_day..
+        platform_visits(start_date, end_date, exclude_roles)
       end
+    end
 
+    def phase_visits(phase)
+      visits(phase.project.id, start_at: phase.start_at, end_at: phase.end_at)
+    end
+
+    private
+
+    def platform_visits(start_date, end_date, exclude_roles)
+      visits = ImpactTracking::Session.where(created_at: start_date..end_date)
+      visits = exclude_roles(visits, exclude_roles)
+      visits.select(
+        "created_at AS acted_at,
+          id AS session_id,
+          COALESCE(CAST(user_id AS TEXT), monthly_user_hash) AS visitor_id"
+      )
+    end
+
+    # For project visits we want to count the date that they visited the project, not the date they started the session.
+    def project_visits(project_id, start_date, end_date, exclude_roles)
       visits = ImpactTracking::Session
         .joins(:pageviews)
-        .where(impact_tracking_pageviews: constraints)
-
+        .where(impact_tracking_pageviews: {
+          project_id: project_id,
+          created_at: start_date..end_date
+        })
+      visits = exclude_roles(visits, exclude_roles)
       visits.select(
-        "impact_tracking_pageviews.created_at AS date,
-        impact_tracking_sessions.user_id AS user_id,
-        impact_tracking_sessions.monthly_user_hash AS monthly_user_hash"
-      ).map do |row|
-        {
-          acted_at: row.date,
-          visitor_id: row.user_id.present? ? row.user_id.to_s : row.monthly_user_hash
-        }
-      end
+        "impact_tracking_pageviews.created_at AS acted_at,
+          impact_tracking_sessions.id AS session_id,
+          COALESCE(CAST(impact_tracking_sessions.user_id AS TEXT), impact_tracking_sessions.monthly_user_hash) AS visitor_id"
+      )
+    end
+
+    def exclude_roles(visits, exclude_roles)
+      return visits unless exclude_roles == 'exclude_admins_and_moderators'
+
+      visits.where("highest_role IS NULL OR highest_role = 'user'")
     end
   end
 end

--- a/back/app/services/insights/visits_service.rb
+++ b/back/app/services/insights/visits_service.rb
@@ -1,6 +1,6 @@
 module Insights
   class VisitsService
-    def visits(project_id, start_at: nil, end_at: nil, exclude_roles: nil)
+    def sessions(project_id, start_at: nil, end_at: nil, exclude_roles: nil)
       start_date, end_date = TimeBoundariesParser.new(start_at, end_at).parse
       if project_id
         project_visits(project_id, start_date, end_date, exclude_roles)
@@ -9,36 +9,44 @@ module Insights
       end
     end
 
-    def phase_visits(phase)
-      visits(phase.project.id, start_at: phase.start_at, end_at: phase.end_at)
+    def totals(sessions)
+      result = sessions.select("count(*) as visits,
+    count(DISTINCT COALESCE(CAST(user_id AS TEXT), monthly_user_hash)) as visitors")[0]
+      { visits: result.visits, visitors: result.visitors }
     end
+
+    def group_by_date(sessions, resolution)
+      sessions.select("count(*) as visits,
+count(DISTINCT COALESCE(CAST(user_id AS TEXT), monthly_user_hash)) as visitors,
+date_trunc('#{resolution}', created_at) as date_group")
+            .group('date_group')
+            .order('date_group')
+    end
+
+    def page_views(sessions)
+      ImpactTracking::Pageview.where(session_id: sessions.select(:id))
+    end
+
+    # def phase_visits(phase)
+    #   visits = visits(phase.project_id, start_at: phase.start_at, end_at: phase.end_at)
+    #   visits.select("impact_tracking_pageviews.created_at AS acted_at,
+    #     impact_tracking_sessions.id AS session_id,
+    #     COALESCE(CAST(impact_tracking_sessions.user_id AS TEXT), impact_tracking_sessions.monthly_user_hash) AS visitor_id")
+    # end
 
     private
 
     def platform_visits(start_date, end_date, exclude_roles)
+      # TODO: Actually we should count the number of sessions that had pageviews in the period
       visits = ImpactTracking::Session.where(created_at: start_date..end_date)
-      visits = exclude_roles(visits, exclude_roles)
-      visits.select(
-        "created_at AS acted_at,
-          id AS session_id,
-          COALESCE(CAST(user_id AS TEXT), monthly_user_hash) AS visitor_id"
-      )
+      exclude_roles(visits, exclude_roles)
     end
 
     # For project visits we want to count the date that they visited the project, not the date they started the session.
     def project_visits(project_id, start_date, end_date, exclude_roles)
-      visits = ImpactTracking::Session
-        .joins(:pageviews)
-        .where(impact_tracking_pageviews: {
-          project_id: project_id,
-          created_at: start_date..end_date
-        })
-      visits = exclude_roles(visits, exclude_roles)
-      visits.select(
-        "impact_tracking_pageviews.created_at AS acted_at,
-          impact_tracking_sessions.id AS session_id,
-          COALESCE(CAST(impact_tracking_sessions.user_id AS TEXT), impact_tracking_sessions.monthly_user_hash) AS visitor_id"
-      )
+      sessions_with_project = ImpactTracking::Pageview.where(project_id: project_id, created_at: start_date..end_date).select(:session_id)
+      visits = ImpactTracking::Session.where(id: sessions_with_project)
+      exclude_roles(visits, exclude_roles)
     end
 
     def exclude_roles(visits, exclude_roles)

--- a/back/db/migrate/20260312142054_add_indexes_to_pageviews_and_sessions.impact_tracking.rb
+++ b/back/db/migrate/20260312142054_add_indexes_to_pageviews_and_sessions.impact_tracking.rb
@@ -7,5 +7,6 @@ class AddIndexesToPageviewsAndSessions < ActiveRecord::Migration[7.1]
     add_index :impact_tracking_pageviews, :project_id, algorithm: :concurrently
     add_index :impact_tracking_pageviews, :created_at, algorithm: :concurrently
     add_index :impact_tracking_sessions, :highest_role, algorithm: :concurrently
+    add_index :impact_tracking_sessions, :user_id, algorithm: :concurrently
   end
 end

--- a/back/db/migrate/20260312142054_add_indexes_to_pageviews_and_sessions.impact_tracking.rb
+++ b/back/db/migrate/20260312142054_add_indexes_to_pageviews_and_sessions.impact_tracking.rb
@@ -1,0 +1,11 @@
+# This migration comes from impact_tracking (originally 20260312100000)
+class AddIndexesToPageviewsAndSessions < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :impact_tracking_pageviews, :session_id, algorithm: :concurrently
+    add_index :impact_tracking_pageviews, :project_id, algorithm: :concurrently
+    add_index :impact_tracking_pageviews, :created_at, algorithm: :concurrently
+    add_index :impact_tracking_sessions, :highest_role, algorithm: :concurrently
+  end
+end

--- a/back/db/structure.sql
+++ b/back/db/structure.sql
@@ -295,6 +295,7 @@ DROP INDEX IF EXISTS public.index_internal_comments_on_author_id;
 DROP INDEX IF EXISTS public.index_input_topics_on_rgt;
 DROP INDEX IF EXISTS public.index_input_topics_on_project_id;
 DROP INDEX IF EXISTS public.index_input_topics_on_parent_id;
+DROP INDEX IF EXISTS public.index_impact_tracking_sessions_on_user_id;
 DROP INDEX IF EXISTS public.index_impact_tracking_sessions_on_monthly_user_hash;
 DROP INDEX IF EXISTS public.index_impact_tracking_sessions_on_highest_role;
 DROP INDEX IF EXISTS public.index_impact_tracking_pageviews_on_session_id;
@@ -6313,6 +6314,13 @@ CREATE INDEX index_impact_tracking_sessions_on_highest_role ON public.impact_tra
 --
 
 CREATE INDEX index_impact_tracking_sessions_on_monthly_user_hash ON public.impact_tracking_sessions USING btree (monthly_user_hash);
+
+
+--
+-- Name: index_impact_tracking_sessions_on_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_impact_tracking_sessions_on_user_id ON public.impact_tracking_sessions USING btree (user_id);
 
 
 --

--- a/back/db/structure.sql
+++ b/back/db/structure.sql
@@ -296,6 +296,10 @@ DROP INDEX IF EXISTS public.index_input_topics_on_rgt;
 DROP INDEX IF EXISTS public.index_input_topics_on_project_id;
 DROP INDEX IF EXISTS public.index_input_topics_on_parent_id;
 DROP INDEX IF EXISTS public.index_impact_tracking_sessions_on_monthly_user_hash;
+DROP INDEX IF EXISTS public.index_impact_tracking_sessions_on_highest_role;
+DROP INDEX IF EXISTS public.index_impact_tracking_pageviews_on_session_id;
+DROP INDEX IF EXISTS public.index_impact_tracking_pageviews_on_project_id;
+DROP INDEX IF EXISTS public.index_impact_tracking_pageviews_on_created_at;
 DROP INDEX IF EXISTS public.index_identities_on_user_id;
 DROP INDEX IF EXISTS public.index_ideas_search;
 DROP INDEX IF EXISTS public.index_ideas_phases_on_phase_id;
@@ -6277,6 +6281,34 @@ CREATE INDEX index_identities_on_user_id ON public.identities USING btree (user_
 
 
 --
+-- Name: index_impact_tracking_pageviews_on_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_impact_tracking_pageviews_on_created_at ON public.impact_tracking_pageviews USING btree (created_at);
+
+
+--
+-- Name: index_impact_tracking_pageviews_on_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_impact_tracking_pageviews_on_project_id ON public.impact_tracking_pageviews USING btree (project_id);
+
+
+--
+-- Name: index_impact_tracking_pageviews_on_session_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_impact_tracking_pageviews_on_session_id ON public.impact_tracking_pageviews USING btree (session_id);
+
+
+--
+-- Name: index_impact_tracking_sessions_on_highest_role; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_impact_tracking_sessions_on_highest_role ON public.impact_tracking_sessions USING btree (highest_role);
+
+
+--
 -- Name: index_impact_tracking_sessions_on_monthly_user_hash; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -8446,6 +8478,7 @@ ALTER TABLE ONLY public.project_reviews
 SET search_path TO public,shared_extensions;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260312142054'),
 ('20260302101045'),
 ('20260302100745'),
 ('20260302100636'),

--- a/back/engines/commercial/impact_tracking/app/models/impact_tracking/pageview.rb
+++ b/back/engines/commercial/impact_tracking/app/models/impact_tracking/pageview.rb
@@ -9,6 +9,12 @@
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #
+# Indexes
+#
+#  index_impact_tracking_pageviews_on_created_at  (created_at)
+#  index_impact_tracking_pageviews_on_project_id  (project_id)
+#  index_impact_tracking_pageviews_on_session_id  (session_id)
+#
 # Foreign Keys
 #
 #  fk_rails_...  (project_id => projects.id)

--- a/back/engines/commercial/impact_tracking/app/models/impact_tracking/session.rb
+++ b/back/engines/commercial/impact_tracking/app/models/impact_tracking/session.rb
@@ -19,6 +19,7 @@
 #
 #  index_impact_tracking_sessions_on_highest_role       (highest_role)
 #  index_impact_tracking_sessions_on_monthly_user_hash  (monthly_user_hash)
+#  index_impact_tracking_sessions_on_user_id            (user_id)
 #
 class ImpactTracking::Session < ApplicationRecord
   validates :monthly_user_hash, presence: true

--- a/back/engines/commercial/impact_tracking/app/models/impact_tracking/session.rb
+++ b/back/engines/commercial/impact_tracking/app/models/impact_tracking/session.rb
@@ -17,6 +17,7 @@
 #
 # Indexes
 #
+#  index_impact_tracking_sessions_on_highest_role       (highest_role)
 #  index_impact_tracking_sessions_on_monthly_user_hash  (monthly_user_hash)
 #
 class ImpactTracking::Session < ApplicationRecord

--- a/back/engines/commercial/impact_tracking/db/migrate/20260312100000_add_indexes_to_pageviews_and_sessions.rb
+++ b/back/engines/commercial/impact_tracking/db/migrate/20260312100000_add_indexes_to_pageviews_and_sessions.rb
@@ -1,0 +1,10 @@
+class AddIndexesToPageviewsAndSessions < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :impact_tracking_pageviews, :session_id, algorithm: :concurrently
+    add_index :impact_tracking_pageviews, :project_id, algorithm: :concurrently
+    add_index :impact_tracking_pageviews, :created_at, algorithm: :concurrently
+    add_index :impact_tracking_sessions, :highest_role, algorithm: :concurrently
+  end
+end

--- a/back/engines/commercial/impact_tracking/db/migrate/20260312100000_add_indexes_to_pageviews_and_sessions.rb
+++ b/back/engines/commercial/impact_tracking/db/migrate/20260312100000_add_indexes_to_pageviews_and_sessions.rb
@@ -6,5 +6,6 @@ class AddIndexesToPageviewsAndSessions < ActiveRecord::Migration[7.1]
     add_index :impact_tracking_pageviews, :project_id, algorithm: :concurrently
     add_index :impact_tracking_pageviews, :created_at, algorithm: :concurrently
     add_index :impact_tracking_sessions, :highest_role, algorithm: :concurrently
+    add_index :impact_tracking_sessions, :user_id, algorithm: :concurrently
   end
 end

--- a/back/engines/commercial/impact_tracking/spec/factories/sessions.rb
+++ b/back/engines/commercial/impact_tracking/spec/factories/sessions.rb
@@ -3,5 +3,16 @@
 FactoryBot.define do
   factory :session, class: 'ImpactTracking::Session' do
     monthly_user_hash { 'aasdf12a1s3f12ds231as21hfg2h1df2g1h1' }
+
+    trait :with_pageview do
+      transient do
+        project { nil }
+        pageview_created_at { Time.zone.now }
+      end
+
+      after(:create) do |session, evaluator|
+        create(:pageview, session: session, project_id: evaluator.project&.id, created_at: evaluator.pageview_created_at)
+      end
+    end
   end
 end

--- a/back/engines/commercial/public_api/app/controllers/public_api/v2/insights/visits_controller.rb
+++ b/back/engines/commercial/public_api/app/controllers/public_api/v2/insights/visits_controller.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module PublicApi
+  class V2::Insights::VisitsController < PublicApiController
+    VALID_RESOLUTIONS = %w[all year month day hour].freeze
+
+    def index
+      resolution = params[:resolution] || 'month'
+
+      unless VALID_RESOLUTIONS.include?(resolution)
+        raise InvalidEnumParameterValueError.new('resolution', resolution, VALID_RESOLUTIONS)
+      end
+
+      project_id = params[:project_id]
+      start_at = params[:start_at] || default_start_at(resolution)
+      end_at = params[:end_at]
+
+      service = ::Insights::VisitsService.new(project_id, start_at:, end_at:)
+
+      visits = if resolution == 'all'
+        [service.total_visits]
+      else
+        format_visits(service.visits_by_date(resolution), resolution)
+      end
+
+      render json: { visits: visits }
+    end
+
+    private
+
+    def format_visits(visits, resolution)
+      visits.map do |visit|
+        {
+          visits: visit[:visits],
+          visitors: visit[:visitors],
+          date_group: resolution == 'hour' ? visit[:date_group].strftime('%Y-%m-%d %H:%M') : visit[:date_group]
+        }
+      end
+    end
+
+    def default_start_at(resolution)
+      case resolution
+      when 'day' then 1.year.ago.to_date.to_s
+      when 'hour' then 1.week.ago.to_date.to_s
+      end
+    end
+  end
+end

--- a/back/engines/commercial/public_api/config/routes.rb
+++ b/back/engines/commercial/public_api/config/routes.rb
@@ -56,6 +56,10 @@ PublicApi::Engine.routes.draw do
     resources :ideas_input_topics, only: %i[index]
     resources :project_topics, only: %i[index]
     resources :project_global_topics, only: %i[index]
+
+    namespace :insights do
+      resources :visits, only: [:index]
+    end
   end
 end
 

--- a/back/engines/commercial/public_api/spec/acceptance/v2/insights/visits_spec.rb
+++ b/back/engines/commercial/public_api/spec/acceptance/v2/insights/visits_spec.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rspec_api_documentation/dsl'
+require './engines/commercial/public_api/spec/acceptance/v2/support/shared'
+
+resource 'Insights Visits' do
+  explanation 'Platform visit statistics aggregated over time, including visits and unique visitors.'
+
+  include_context 'common_auth'
+
+  before do
+    AppConfiguration.instance.update!(platform_start_at: '2025-01-01')
+  end
+
+  let(:project) { create(:project) }
+  let(:other_project) { create(:project) }
+
+  let(:session1) { create(:session, monthly_user_hash: 'user_hash_1') }
+  let(:session2) { create(:session, monthly_user_hash: 'user_hash_2') }
+  let(:session3) { create(:session, monthly_user_hash: 'user_hash_3') }
+
+  before do
+    # January 2025 pageviews for project
+    create(:pageview, session: session1, project_id: project.id, created_at: '2025-01-15')
+    create(:pageview, session: session2, project_id: project.id, created_at: '2025-01-20')
+
+    # February 2025 pageviews for project
+    create(:pageview, session: session1, project_id: project.id, created_at: '2025-02-10')
+    create(:pageview, session: session3, project_id: project.id, created_at: '2025-02-15')
+
+    # January 2025 pageview for other_project
+    create(:pageview, session: session2, project_id: other_project.id, created_at: '2025-01-25')
+  end
+
+  get '/api/v2/insights/visits' do
+    route_summary 'List visit statistics'
+    route_description 'Retrieve visit and visitor counts aggregated by time period.'
+
+    parameter :project_id, 'Filter visits to a specific project', in: :query, required: false, type: 'string'
+    parameter :start_at, 'Start date for the time range (YYYY-MM-DD)', in: :query, required: false, type: 'string'
+    parameter :end_at, 'End date for the time range (YYYY-MM-DD)', in: :query, required: false, type: 'string'
+    parameter :resolution, 'Time grouping resolution: all, year, month, day, hour. Defaults to month.', in: :query, required: false, type: 'string'
+
+    example_request 'Returns visits grouped by month (default)' do
+      assert_status 200
+      expect(json_response_body[:visits].size).to be >= 2
+      expect(json_response_body[:visits].first).to have_key(:visits)
+      expect(json_response_body[:visits].first).to have_key(:visitors)
+      expect(json_response_body[:visits].first).to have_key(:date_group)
+    end
+
+    context 'with project_id filter' do
+      let(:project_id) { project.id }
+
+      example_request 'Returns visits for a specific project' do
+        assert_status 200
+        total_visits = json_response_body[:visits].sum { |v| v[:visits] }
+        # Visits are distinct sessions per time bucket: Jan=2 (session1,2), Feb=2 (session1,3)
+        expect(total_visits).to eq(4)
+      end
+    end
+
+    context 'with start_at and end_at date range' do
+      let(:start_at) { '2025-02-01' }
+      let(:end_at) { '2025-02-28' }
+
+      example_request 'Returns visits within the date range' do
+        assert_status 200
+        expect(json_response_body[:visits].size).to eq(1)
+        expect(json_response_body[:visits].first[:visits]).to eq(2)
+      end
+    end
+
+    context 'with resolution=day' do
+      let(:resolution) { 'day' }
+      let(:start_at) { '2025-01-01' }
+      let(:end_at) { '2025-01-31' }
+
+      example_request 'Returns visits grouped by day' do
+        assert_status 200
+        dates = json_response_body[:visits].map { |v| v[:date_group] }
+        expect(dates.size).to be >= 2
+      end
+    end
+
+    context 'with resolution=day and no start_at' do
+      let(:resolution) { 'day' }
+
+      example_request 'Defaults start_at to 1 year ago', document: false do
+        assert_status 200
+        # All test data is from Jan/Feb 2025, which is more than 1 year ago,
+        # so no visits should be returned with the default start_at
+        expect(json_response_body[:visits]).to be_empty
+      end
+    end
+
+    context 'with resolution=day and has start_at' do
+      let(:resolution) { 'day' }
+      let(:start_at) { '2025-01-01' }
+      let(:end_at) { '2025-01-31' }
+
+      example_request 'Returns visits grouped by day with explicit start_at', document: false do
+        assert_status 200
+        expect(json_response_body[:visits].size).to be >= 2
+        # Day resolution date_group should be date-only format
+        expect(json_response_body[:visits].first[:date_group]).to match(/\A\d{4}-\d{2}-\d{2}\z/)
+      end
+    end
+
+    context 'with resolution=hour and no start_at' do
+      let(:resolution) { 'hour' }
+
+      example_request 'Defaults start_at to 1 week ago', document: false do
+        assert_status 200
+        # All test data is from Jan/Feb 2025, well outside 1 week, so empty
+        expect(json_response_body[:visits]).to be_empty
+      end
+    end
+
+    context 'with resolution=hour and has start_at' do
+      let(:resolution) { 'hour' }
+      let(:start_at) { '2025-01-01' }
+      let(:end_at) { '2025-01-31' }
+
+      example_request 'Returns visits grouped by hour with time in date_group', document: false do
+        assert_status 200
+        expect(json_response_body[:visits].size).to be >= 1
+        # Hour resolution date_group should include time
+        expect(json_response_body[:visits].first[:date_group]).to match(/\A\d{4}-\d{2}-\d{2} \d{2}:\d{2}\z/)
+      end
+    end
+
+    context 'with resolution=all' do
+      let(:resolution) { 'all' }
+
+      example_request 'Returns a single total row' do
+        assert_status 200
+        expect(json_response_body[:visits].size).to eq(1)
+        expect(json_response_body[:visits].first).to have_key(:visits)
+        expect(json_response_body[:visits].first).to have_key(:visitors)
+        expect(json_response_body[:visits].first).not_to have_key(:date_group)
+      end
+    end
+
+    context 'with invalid resolution' do
+      let(:resolution) { 'invalid' }
+
+      example_request 'Returns 400 error', document: false do
+        assert_status 400
+        expect(json_response_body[:parameter_name]).to eq('resolution')
+      end
+    end
+  end
+end

--- a/back/engines/commercial/report_builder/app/services/report_builder/queries/device_types.rb
+++ b/back/engines/commercial/report_builder/app/services/report_builder/queries/device_types.rb
@@ -7,11 +7,8 @@ module ReportBuilder
       exclude_roles: nil,
       **_other_props
     )
-      start_date, end_date = TimeBoundariesParser.new(start_at, end_at).parse
-
-      sessions = ImpactTracking::Session.where(created_at: start_date..end_date)
-      sessions = apply_project_filter_if_needed(sessions, project_id)
-      sessions = exclude_roles_if_needed(sessions, exclude_roles)
+      visits_service = Insights::VisitsService.new(project_id, start_at:, end_at:, exclude_roles:)
+      sessions = visits_service.filtered_sessions_query
 
       counts_per_device_type = sessions
         .where.not(device_type: nil)
@@ -21,24 +18,6 @@ module ReportBuilder
       {
         counts_per_device_type: counts_per_device_type
       }
-    end
-
-    def apply_project_filter_if_needed(sessions, project_id)
-      if project_id.present?
-        sessions_with_project = ImpactTracking::Pageview.where(project_id: project_id).select(:session_id)
-        sessions = sessions.where(id: sessions_with_project)
-      end
-
-      sessions
-    end
-
-    def exclude_roles_if_needed(sessions, exclude_roles)
-      if exclude_roles == 'exclude_admins_and_moderators'
-        sessions = sessions
-          .where("highest_role IS NULL OR highest_role = 'user'")
-      end
-
-      sessions
     end
   end
 end

--- a/back/engines/commercial/report_builder/app/services/report_builder/queries/participants.rb
+++ b/back/engines/commercial/report_builder/app/services/report_builder/queries/participants.rb
@@ -105,29 +105,9 @@ module ReportBuilder
       participations
     end
 
-    def participation_rate_as_percent(
-      participants,
-      start_date,
-      end_date,
-      project_id: nil,
-      exclude_roles: nil
-    )
-      query = ImpactTracking::Session
-        .where(created_at: start_date..end_date)
-
-      if project_id.present?
-        query = query
-          .joins('INNER JOIN impact_tracking_pageviews ON impact_tracking_pageviews.session_id = impact_tracking_sessions.id')
-          .where(impact_tracking_pageviews: { project_id: project_id })
-      end
-
-      if exclude_roles == 'exclude_admins_and_moderators'
-        query = query
-          .where("highest_role IS NULL OR highest_role = 'user'")
-      end
-
-      visitors = query.distinct.count(:monthly_user_hash)
-
+    def participation_rate_as_percent(participants, start_date, end_date, project_id: nil, exclude_roles: nil)
+      visits_service = Insights::VisitsService.new(project_id, start_at: start_date, end_at: end_date, exclude_roles: exclude_roles)
+      visitors = visits_service.total_visits[:visitors]
       visitors.zero? ? 0 : (participants / visitors.to_f)
     end
   end

--- a/back/engines/commercial/report_builder/app/services/report_builder/queries/registrations.rb
+++ b/back/engines/commercial/report_builder/app/services/report_builder/queries/registrations.rb
@@ -57,12 +57,8 @@ module ReportBuilder
     end
 
     def registration_rate(registrations, start_date, end_date)
-      visitors = ImpactTracking::Session
-        .where(created_at: start_date..end_date)
-        .distinct
-        .pluck(:monthly_user_hash)
-        .count
-
+      visits_service = Insights::VisitsService.new(nil, start_at: start_date, end_at: end_date)
+      visitors = visits_service.total_visits[:visitors]
       visitors.zero? ? 0 : (registrations / visitors.to_f)
     end
   end

--- a/back/engines/commercial/report_builder/app/services/report_builder/queries/traffic_sources.rb
+++ b/back/engines/commercial/report_builder/app/services/report_builder/queries/traffic_sources.rb
@@ -34,11 +34,8 @@ module ReportBuilder
       exclude_roles: nil,
       **_other_props
     )
-      start_date, end_date = TimeBoundariesParser.new(start_at, end_at).parse
-
-      sessions = ImpactTracking::Session.where(created_at: start_date..end_date)
-      sessions = apply_project_filter_if_needed(sessions, project_id)
-      sessions = exclude_roles_if_needed(sessions, exclude_roles)
+      visits_service = Insights::VisitsService.new(project_id, start_at:, end_at:, exclude_roles:)
+      sessions = visits_service.filtered_sessions_query
 
       cases = DIRECT_ENTRY_CASES
       cases += generate_cases(SEARCH_ENGINE_REFERRERS, SEARCH_ENGINE_DOMAINS, 'search_engine')
@@ -94,24 +91,6 @@ module ReportBuilder
         sessions_per_referrer_type: sessions_per_referrer_type,
         top_50_referrers: top_50_referrers
       }
-    end
-
-    def apply_project_filter_if_needed(sessions, project_id)
-      if project_id.present?
-        sessions_with_project = ImpactTracking::Pageview.where(project_id: project_id).select(:session_id)
-        sessions = sessions.where(id: sessions_with_project)
-      end
-
-      sessions
-    end
-
-    def exclude_roles_if_needed(sessions, exclude_roles)
-      if exclude_roles == 'exclude_admins_and_moderators'
-        sessions = sessions
-          .where("highest_role IS NULL OR highest_role = 'user'")
-      end
-
-      sessions
     end
 
     def generate_cases(referrers, domains, type)

--- a/back/engines/commercial/report_builder/app/services/report_builder/queries/visitors.rb
+++ b/back/engines/commercial/report_builder/app/services/report_builder/queries/visitors.rb
@@ -19,51 +19,40 @@ module ReportBuilder
     )
       validate_resolution(resolution)
 
-      sessions = visits_service.sessions(project_id, start_at:, end_at:, exclude_roles:)
-      visitors_timeseries = visits_service.group_by_date(sessions, resolution).map do |row|
-          {
-            visits: row.visits,
-            visitors: row.visitors,
-            date_group: row.date_group.to_date
-          }
-      end
-
-      page_views = visits_service.page_views(sessions)
-      totals = visits_service.totals(sessions)
-      stats = calculate_stats(totals, page_views)
+      visits_service = Insights::VisitsService.new(project_id, start_at:, end_at:, exclude_roles:)
+      visitors_timeseries = visits_service.visits_by_date(resolution)
+      totals = visits_service.total_visits
+      page_views = visits_service.all_session_page_views
+      timings = calculate_timings(page_views)
 
       response = {
         visitors_timeseries: visitors_timeseries,
-        visits_whole_period: stats[:visits],
-        visitors_whole_period: stats[:visitors],
-        avg_seconds_per_session_whole_period: stats[:avg_seconds_per_session],
-        avg_pages_visited_whole_period: stats[:avg_pages_visited]
+        visits_whole_period: totals[:visits],
+        visitors_whole_period: totals[:visitors],
+        avg_seconds_per_session_whole_period: timings[:avg_seconds_per_session],
+        avg_pages_visited_whole_period: timings[:avg_pages_visited]
       }
 
       # If compare_start_at and compare_end_at are present:
       if compare_start_at.present? && compare_end_at.present?
-        compare_sessions = visits_service.sessions(project_id, start_at: compare_start_at, end_at: compare_end_at, exclude_roles: exclude_roles)
-        compare_page_views = visits_service.page_views(compare_sessions)
-        compare_totals = visits_service.totals(compare_sessions)
-        compare_stats = calculate_stats(compare_totals, compare_page_views)
+        compare_visits_service = Insights::VisitsService.new(project_id, start_at: compare_start_at, end_at: compare_end_at, exclude_roles: exclude_roles)
+        compare_totals = compare_visits_service.total_visits
+        compare_page_views = compare_visits_service.all_session_page_views
+        compare_timings = calculate_timings(compare_page_views)
 
         response = {
           **response,
-          visits_compared_period: compare_stats[:visits],
-          visitors_compared_period: compare_stats[:visitors],
-          avg_seconds_per_session_compared_period: compare_stats[:avg_seconds_per_session],
-          avg_pages_visited_compared_period: compare_stats[:avg_pages_visited]
+          visits_compared_period: compare_totals[:visits],
+          visitors_compared_period: compare_totals[:visitors],
+          avg_seconds_per_session_compared_period: compare_timings[:avg_seconds_per_session],
+          avg_pages_visited_compared_period: compare_timings[:avg_pages_visited]
         }
       end
 
       response
     end
 
-    def calculate_stats(totals, pageviews)
-      # Total number of visits and visitors
-      visits = totals[:visits]
-      visitors = totals[:visitors]
-
+    def calculate_timings(pageviews)
       # avg seconds per session and avg pages per session from pageview data
       # Calculate avg pages visited per session
       # Or, if project filter is applied:
@@ -89,7 +78,7 @@ module ReportBuilder
         .select(
           <<-SQL.squish
             extract(epoch from
-              (lead(created_at,1) over (partition by session_id order by created_at)) - created_at
+              (lead(impact_tracking_pageviews.created_at,1) over (partition by session_id order by impact_tracking_pageviews.created_at)) - impact_tracking_pageviews.created_at
             ) as seconds_on_page
           SQL
         )
@@ -114,15 +103,9 @@ module ReportBuilder
       avg_seconds_per_session = avg_seconds_on_page * avg_pages_visited
 
       {
-        visits: visits,
-        visitors: visitors,
         avg_seconds_per_session: avg_seconds_per_session,
         avg_pages_visited: avg_pages_visited
       }
-    end
-
-    def visits_service
-      @visits_service ||= Insights::VisitsService.new
     end
   end
 end

--- a/back/engines/commercial/report_builder/app/services/report_builder/queries/visitors.rb
+++ b/back/engines/commercial/report_builder/app/services/report_builder/queries/visitors.rb
@@ -22,7 +22,7 @@ module ReportBuilder
       visits_service = Insights::VisitsService.new(project_id, start_at:, end_at:, exclude_roles:)
       visitors_timeseries = visits_service.visits_by_date(resolution)
       totals = visits_service.total_visits
-      page_views = visits_service.all_page_views_for_sessions
+      page_views = visits_service.all_page_views_query
       timings = calculate_timings(page_views, totals[:visits])
 
       response = {
@@ -37,7 +37,7 @@ module ReportBuilder
       if compare_start_at.present? && compare_end_at.present?
         compare_visits_service = Insights::VisitsService.new(project_id, start_at: compare_start_at, end_at: compare_end_at, exclude_roles: exclude_roles)
         compare_totals = compare_visits_service.total_visits
-        compare_page_views = compare_visits_service.all_page_views_for_sessions
+        compare_page_views = compare_visits_service.all_page_views_query
         compare_timings = calculate_timings(compare_page_views, compare_totals[:visits])
 
         response = {

--- a/back/engines/commercial/report_builder/app/services/report_builder/queries/visitors.rb
+++ b/back/engines/commercial/report_builder/app/services/report_builder/queries/visitors.rb
@@ -22,8 +22,8 @@ module ReportBuilder
       visits_service = Insights::VisitsService.new(project_id, start_at:, end_at:, exclude_roles:)
       visitors_timeseries = visits_service.visits_by_date(resolution)
       totals = visits_service.total_visits
-      page_views = visits_service.all_session_page_views
-      timings = calculate_timings(page_views)
+      page_views = visits_service.all_page_views_for_sessions
+      timings = calculate_timings(page_views, totals[:visits])
 
       response = {
         visitors_timeseries: visitors_timeseries,
@@ -37,8 +37,8 @@ module ReportBuilder
       if compare_start_at.present? && compare_end_at.present?
         compare_visits_service = Insights::VisitsService.new(project_id, start_at: compare_start_at, end_at: compare_end_at, exclude_roles: exclude_roles)
         compare_totals = compare_visits_service.total_visits
-        compare_page_views = compare_visits_service.all_session_page_views
-        compare_timings = calculate_timings(compare_page_views)
+        compare_page_views = compare_visits_service.all_page_views_for_sessions
+        compare_timings = calculate_timings(compare_page_views, compare_totals[:visits])
 
         response = {
           **response,
@@ -52,15 +52,12 @@ module ReportBuilder
       response
     end
 
-    def calculate_timings(pageviews)
+    def calculate_timings(pageviews, visits)
       # avg seconds per session and avg pages per session from pageview data
       # Calculate avg pages visited per session
       # Or, if project filter is applied:
       # Avg pages visited per session where someone visited the project during the session
-      # ALSO: here we only sessions that have pageviews, otherwise we might
-      # also count sessions without pageviews (from before we collected pageview data)
-      visits_with_pageviews = pageviews.select(:session_id).distinct.count
-      avg_pages_visited = visits_with_pageviews == 0 ? 0 : pageviews.count / visits_with_pageviews.to_f
+      avg_pages_visited = visits == 0 ? 0 : pageviews.count / visits.to_f
 
       # Avg seconds per session
       # Because we can only know the time spent on a page if there is

--- a/back/engines/commercial/report_builder/app/services/report_builder/queries/visitors.rb
+++ b/back/engines/commercial/report_builder/app/services/report_builder/queries/visitors.rb
@@ -19,24 +19,18 @@ module ReportBuilder
     )
       validate_resolution(resolution)
 
-      visits_service = Insights::VisitsService.new
-      sessions = visits_service.visits(project_id, start_at:, end_at:, exclude_roles:)
-
-      visitors_timeseries = sessions
-        .select(
-          "count(distinct(session_id) as visits, count(distinct(visitor_id)) as visitors, date_trunc('#{resolution}', acted_at) as date_group"
-        )
-        .group('date_group')
-        .order('date_group')
-        .map do |row|
+      sessions = visits_service.sessions(project_id, start_at:, end_at:, exclude_roles:)
+      visitors_timeseries = visits_service.group_by_date(sessions, resolution).map do |row|
           {
             visits: row.visits,
             visitors: row.visitors,
             date_group: row.date_group.to_date
           }
-        end
+      end
 
-      stats = calculate_stats(sessions)
+      page_views = visits_service.page_views(sessions)
+      totals = visits_service.totals(sessions)
+      stats = calculate_stats(totals, page_views)
 
       response = {
         visitors_timeseries: visitors_timeseries,
@@ -48,8 +42,10 @@ module ReportBuilder
 
       # If compare_start_at and compare_end_at are present:
       if compare_start_at.present? && compare_end_at.present?
-        compare_sessions = visits_service.visits(project_id, start_at: compare_start_at, end_at: compare_end_at, exclude_roles: exclude_roles)
-        compare_stats = calculate_stats(compare_sessions)
+        compare_sessions = visits_service.sessions(project_id, start_at: compare_start_at, end_at: compare_end_at, exclude_roles: exclude_roles)
+        compare_page_views = visits_service.page_views(compare_sessions)
+        compare_totals = visits_service.totals(compare_sessions)
+        compare_stats = calculate_stats(compare_totals, compare_page_views)
 
         response = {
           **response,
@@ -63,14 +59,12 @@ module ReportBuilder
       response
     end
 
-    def calculate_stats(sessions)
+    def calculate_stats(totals, pageviews)
       # Total number of visits and visitors
-      visits = sessions.count # TODO: this is not going to work with this new way
-      visitors = sessions.distinct.pluck(:monthly_user_hash).count
+      visits = totals[:visits]
+      visitors = totals[:visitors]
 
-      # Create new pageviews query for avg seconds per session and avg pages per session
-      pageviews = ImpactTracking::Pageview.where(session_id: sessions.select(:id))
-
+      # avg seconds per session and avg pages per session from pageview data
       # Calculate avg pages visited per session
       # Or, if project filter is applied:
       # Avg pages visited per session where someone visited the project during the session
@@ -125,6 +119,10 @@ module ReportBuilder
         avg_seconds_per_session: avg_seconds_per_session,
         avg_pages_visited: avg_pages_visited
       }
+    end
+
+    def visits_service
+      @visits_service ||= Insights::VisitsService.new
     end
   end
 end

--- a/back/engines/commercial/report_builder/app/services/report_builder/queries/visitors.rb
+++ b/back/engines/commercial/report_builder/app/services/report_builder/queries/visitors.rb
@@ -19,15 +19,12 @@ module ReportBuilder
     )
       validate_resolution(resolution)
 
-      start_date, end_date = TimeBoundariesParser.new(start_at, end_at).parse
-
-      sessions = ImpactTracking::Session.where(created_at: start_date..end_date)
-      sessions = apply_project_filter_if_needed(sessions, project_id)
-      sessions = exclude_roles_if_needed(sessions, exclude_roles)
+      visits_service = Insights::VisitsService.new
+      sessions = visits_service.visits(project_id, start_at:, end_at:, exclude_roles:)
 
       visitors_timeseries = sessions
         .select(
-          "count(*) as visits, count(distinct(monthly_user_hash)) as visitors, date_trunc('#{resolution}', created_at) as date_group"
+          "count(distinct(session_id) as visits, count(distinct(visitor_id)) as visitors, date_trunc('#{resolution}', acted_at) as date_group"
         )
         .group('date_group')
         .order('date_group')
@@ -51,10 +48,7 @@ module ReportBuilder
 
       # If compare_start_at and compare_end_at are present:
       if compare_start_at.present? && compare_end_at.present?
-        compare_sessions = ImpactTracking::Session.where(created_at: compare_start_at..compare_end_at)
-        compare_sessions = apply_project_filter_if_needed(compare_sessions, project_id)
-        compare_sessions = exclude_roles_if_needed(compare_sessions, exclude_roles)
-
+        compare_sessions = visits_service.visits(project_id, start_at: compare_start_at, end_at: compare_end_at, exclude_roles: exclude_roles)
         compare_stats = calculate_stats(compare_sessions)
 
         response = {
@@ -69,27 +63,9 @@ module ReportBuilder
       response
     end
 
-    def apply_project_filter_if_needed(sessions, project_id)
-      if project_id.present?
-        sessions_with_project = ImpactTracking::Pageview.where(project_id: project_id).select(:session_id)
-        sessions = sessions.where(id: sessions_with_project)
-      end
-
-      sessions
-    end
-
-    def exclude_roles_if_needed(sessions, exclude_roles)
-      if exclude_roles == 'exclude_admins_and_moderators'
-        sessions = sessions
-          .where("highest_role IS NULL OR highest_role = 'user'")
-      end
-
-      sessions
-    end
-
     def calculate_stats(sessions)
       # Total number of visits and visitors
-      visits = sessions.count
+      visits = sessions.count # TODO: this is not going to work with this new way
       visitors = sessions.distinct.pluck(:monthly_user_hash).count
 
       # Create new pageviews query for avg seconds per session and avg pages per session

--- a/back/engines/commercial/report_builder/app/services/report_builder/queries/visitors_languages.rb
+++ b/back/engines/commercial/report_builder/app/services/report_builder/queries/visitors_languages.rb
@@ -8,7 +8,7 @@ module ReportBuilder
       **_other_props
     )
       visits_service = Insights::VisitsService.new(project_id, start_at:, end_at:, exclude_roles:)
-      pageviews = visits_service.filtered_page_views
+      pageviews = visits_service.filtered_page_views_query
 
       locale_sql = Arel.sql("split_part(path, '/', 2)")
 

--- a/back/engines/commercial/report_builder/app/services/report_builder/queries/visitors_languages.rb
+++ b/back/engines/commercial/report_builder/app/services/report_builder/queries/visitors_languages.rb
@@ -7,18 +7,8 @@ module ReportBuilder
       exclude_roles: nil,
       **_other_props
     )
-      start_date, end_date = TimeBoundariesParser.new(start_at, end_at).parse
-
-      pageviews = ImpactTracking::Pageview
-        .where(created_at: start_date..end_date)
-
-      if project_id.present?
-        pageviews = pageviews.where(project_id: project_id)
-      end
-
-      if exclude_roles == 'exclude_admins_and_moderators'
-        pageviews = pageviews.joins(:session).where(impact_tracking_sessions: { highest_role: ['user', nil] })
-      end
+      visits_service = Insights::VisitsService.new(project_id, start_at:, end_at:, exclude_roles:)
+      pageviews = visits_service.filtered_page_views
 
       locale_sql = Arel.sql("split_part(path, '/', 2)")
 

--- a/back/engines/commercial/report_builder/spec/services/report_builder/queries/device_types_spec.rb
+++ b/back/engines/commercial/report_builder/spec/services/report_builder/queries/device_types_spec.rb
@@ -16,11 +16,11 @@ RSpec.describe ReportBuilder::Queries::DeviceTypes do
 
     it 'returns device type analytics data for given time period' do
       2.times do
-        create(:session, created_at: Date.new(2023, 2, 1), device_type: 'desktop_or_other')
+        create(:session, :with_pageview, device_type: 'desktop_or_other', pageview_created_at: Date.new(2023, 2, 1))
       end
 
       3.times do
-        create(:session, created_at: Date.new(2023, 2, 1), device_type: 'mobile')
+        create(:session, :with_pageview, device_type: 'mobile', pageview_created_at: Date.new(2023, 2, 1))
       end
 
       params = {
@@ -38,11 +38,11 @@ RSpec.describe ReportBuilder::Queries::DeviceTypes do
 
     it 'filters out nil device types' do
       2.times do
-        create(:session, created_at: Date.new(2023, 2, 1), device_type: nil)
+        create(:session, :with_pageview, device_type: nil, pageview_created_at: Date.new(2023, 2, 1))
       end
 
       3.times do
-        create(:session, created_at: Date.new(2023, 2, 1), device_type: 'mobile')
+        create(:session, :with_pageview, device_type: 'mobile', pageview_created_at: Date.new(2023, 2, 1))
       end
 
       params = {
@@ -59,23 +59,19 @@ RSpec.describe ReportBuilder::Queries::DeviceTypes do
 
     it 'filters by project' do
       project = create(:project_with_active_ideation_phase)
-      project_path = "/en/projects/#{project.slug}"
-      project_id = project.id
 
       2.times do
-        session1 = create(:session, created_at: Date.new(2023, 2, 1), device_type: 'desktop_or_other')
-        create(:pageview, session_id: session1.id, path: '/en/')
+        create(:session, :with_pageview, device_type: 'desktop_or_other', pageview_created_at: Date.new(2023, 2, 1))
       end
 
       3.times do
-        session2 = create(:session, created_at: Date.new(2023, 2, 1), device_type: 'mobile')
-        create(:pageview, session_id: session2.id, path: project_path, project_id: project_id)
+        create(:session, :with_pageview, device_type: 'mobile', project: project, pageview_created_at: Date.new(2023, 2, 1))
       end
 
       params = {
         start_at: Date.new(2023, 1, 1),
         end_at: Date.new(2023, 3, 1),
-        project_id: project_id
+        project_id: project.id
       }
 
       expect(query.run_query(**params)).to eq({
@@ -87,11 +83,11 @@ RSpec.describe ReportBuilder::Queries::DeviceTypes do
 
     it 'applies exclude_roles filter' do
       2.times do
-        create(:session, created_at: Date.new(2023, 2, 1), device_type: 'desktop_or_other', highest_role: 'admin')
+        create(:session, :with_pageview, device_type: 'desktop_or_other', highest_role: 'admin', pageview_created_at: Date.new(2023, 2, 1))
       end
 
       3.times do
-        create(:session, created_at: Date.new(2023, 2, 1), device_type: 'mobile')
+        create(:session, :with_pageview, device_type: 'mobile', pageview_created_at: Date.new(2023, 2, 1))
       end
 
       params = {

--- a/back/engines/commercial/report_builder/spec/services/report_builder/queries/participants_spec.rb
+++ b/back/engines/commercial/report_builder/spec/services/report_builder/queries/participants_spec.rb
@@ -89,8 +89,8 @@ RSpec.describe ReportBuilder::Queries::Participants do
     it 'returns participation rate' do
       user = create(:user)
 
-      create(:session, created_at: @date_september, monthly_user_hash: 'hash_1')
-      create(:session, created_at: @date_september, monthly_user_hash: 'hash_2')
+      create(:session, :with_pageview, created_at: @date_september, monthly_user_hash: 'hash_1', pageview_created_at: @date_september)
+      create(:session, :with_pageview, created_at: @date_september, monthly_user_hash: 'hash_2', pageview_created_at: @date_september)
 
       project = create(:single_phase_ideation_project)
       create(:idea, created_at: @date_september, project: project, author: user)
@@ -116,8 +116,8 @@ RSpec.describe ReportBuilder::Queries::Participants do
 
       # Setup september data: 1 participant, 2 unique visitors
       create(:idea, created_at: @date_september, project: project, author: pp1)
-      create(:session, created_at: @date_september, monthly_user_hash: 'september_visitor_1')
-      create(:session, created_at: @date_september, monthly_user_hash: 'september_visitor_2')
+      create(:session, :with_pageview, created_at: @date_september, monthly_user_hash: 'september_visitor_1', pageview_created_at: @date_september)
+      create(:session, :with_pageview, created_at: @date_september, monthly_user_hash: 'september_visitor_2', pageview_created_at: @date_september)
 
       # Setup october data: 3 participants, 4 unique visitors
       create(:idea, created_at: @date_october, project: project, author: pp1)
@@ -125,7 +125,7 @@ RSpec.describe ReportBuilder::Queries::Participants do
       create(:idea, created_at: @date_october, project: project, author: pp3)
 
       4.times do |i|
-        create(:session, created_at: @date_october, monthly_user_hash: "october_visitor_#{i}")
+        create(:session, :with_pageview, created_at: @date_october, monthly_user_hash: "october_visitor_#{i}", pageview_created_at: @date_october)
       end
 
       params = {
@@ -157,8 +157,7 @@ RSpec.describe ReportBuilder::Queries::Participants do
       end
 
       8.times do |i|
-        session = create(:session, created_at: @date_september, monthly_user_hash: "visitor_#{i}")
-        create(:pageview, created_at: @date_september, session_id: session.id, project_id: project.id)
+        create(:session, :with_pageview, created_at: @date_september, monthly_user_hash: "visitor_#{i}", pageview_created_at: @date_september, project: project)
       end
 
       # Create 3 participants and 4 visitors for other project
@@ -167,8 +166,7 @@ RSpec.describe ReportBuilder::Queries::Participants do
       end
 
       4.times do |i|
-        session = create(:session, created_at: @date_september, monthly_user_hash: "another_visitor_#{i}")
-        create(:pageview, created_at: @date_september, session_id: session.id, project_id: another_project.id)
+        create(:session, :with_pageview, created_at: @date_september, monthly_user_hash: "another_visitor_#{i}", pageview_created_at: @date_september, project: another_project)
       end
 
       params = {
@@ -196,12 +194,7 @@ RSpec.describe ReportBuilder::Queries::Participants do
       end
 
       8.times do |i|
-        session = create(
-          :session,
-          created_at:
-          @date_september, monthly_user_hash: "visitor_#{i}"
-        )
-        create(:pageview, created_at: @date_september, session_id: session.id, project_id: project.id)
+        create(:session, :with_pageview, created_at: @date_september, monthly_user_hash: "visitor_#{i}", pageview_created_at: @date_september, project: project)
       end
 
       # Create 3 participants and 4 visitors with admin role
@@ -210,14 +203,14 @@ RSpec.describe ReportBuilder::Queries::Participants do
       end
 
       4.times do |i|
-        session = create(
-          :session,
-          created_at:
-          @date_september,
+        create(
+          :session, :with_pageview,
+          created_at: @date_september,
           monthly_user_hash: "another_visitor_#{i}",
-          highest_role: 'admin'
+          highest_role: 'admin',
+          pageview_created_at: @date_september,
+          project: project
         )
-        create(:pageview, created_at: @date_september, session_id: session.id, project_id: project.id)
       end
 
       params = {

--- a/back/engines/commercial/report_builder/spec/services/report_builder/queries/registrations_spec.rb
+++ b/back/engines/commercial/report_builder/spec/services/report_builder/queries/registrations_spec.rb
@@ -16,21 +16,13 @@ RSpec.describe ReportBuilder::Queries::Registrations do
       # Setup September data: 3 registrations, 6 unique visitors
       create_list(:user, 3, registration_completed_at: Date.new(2022, 9, 10))
       6.times do |i|
-        create(
-          :session,
-          created_at: Date.new(2022, 9, 10),
-          monthly_user_hash: "september_visitor_#{i}"
-        )
+        create(:session, :with_pageview, monthly_user_hash: "september_visitor_#{i}", pageview_created_at: Date.new(2022, 9, 10))
       end
 
       # Setup October data: 7 registrations, 14 unique visitors
       create_list(:user, 7, registration_completed_at: Date.new(2022, 10, 10))
       14.times do |i|
-        create(
-          :session,
-          created_at: Date.new(2022, 10, 10),
-          monthly_user_hash: "october_visitor_#{i}"
-        )
+        create(:session, :with_pageview, monthly_user_hash: "october_visitor_#{i}", pageview_created_at: Date.new(2022, 10, 10))
       end
     end
 

--- a/back/engines/commercial/report_builder/spec/services/report_builder/queries/traffic_sources_spec.rb
+++ b/back/engines/commercial/report_builder/spec/services/report_builder/queries/traffic_sources_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe ReportBuilder::Queries::TrafficSources do
     end
 
     it 'identifies direct traffic (referrer is empty string or nil)' do
-      create(:session, referrer: '')
-      create(:session, referrer: nil)
-      create(:session, referrer: nil)
+      create(:session, :with_pageview, referrer: '')
+      create(:session, :with_pageview, referrer: nil)
+      create(:session, :with_pageview, referrer: nil)
 
       expect(query.run_query[:sessions_per_referrer_type]).to eq({
         'direct_entry' => 3
@@ -25,21 +25,21 @@ RSpec.describe ReportBuilder::Queries::TrafficSources do
     end
 
     it 'identifies search engines' do
-      create(:session, referrer: 'https://www.google.com/')
-      create(:session, referrer: 'https://www.bing.com/')
-      create(:session, referrer: 'https://bing.com/')
-      create(:session, referrer: 'https://www.google.nl/')
-      create(:session, referrer: 'https://www.google.co.uk/')
-      create(:session, referrer: 'android-app://com.google.android.googlequicksearchbox/')
-      create(:session, referrer: 'https://duckduckgo.com/')
-      create(:session, referrer: 'https://www.ecosia.org/')
-      create(:session, referrer: 'https://search.yahoo.com/')
-      create(:session, referrer: 'https://cl.search.yahoo.com/')
-      create(:session, referrer: 'https://yandex.ru/')
-      create(:session, referrer: 'https://www.msn.com/')
-      create(:session, referrer: 'https://www.qwant.com/')
-      create(:session, referrer: 'https://www.startpage.com/')
-      create(:session, referrer: 'https://search.brave.com/')
+      create(:session, :with_pageview, referrer: 'https://www.google.com/')
+      create(:session, :with_pageview, referrer: 'https://www.bing.com/')
+      create(:session, :with_pageview, referrer: 'https://bing.com/')
+      create(:session, :with_pageview, referrer: 'https://www.google.nl/')
+      create(:session, :with_pageview, referrer: 'https://www.google.co.uk/')
+      create(:session, :with_pageview, referrer: 'android-app://com.google.android.googlequicksearchbox/')
+      create(:session, :with_pageview, referrer: 'https://duckduckgo.com/')
+      create(:session, :with_pageview, referrer: 'https://www.ecosia.org/')
+      create(:session, :with_pageview, referrer: 'https://search.yahoo.com/')
+      create(:session, :with_pageview, referrer: 'https://cl.search.yahoo.com/')
+      create(:session, :with_pageview, referrer: 'https://yandex.ru/')
+      create(:session, :with_pageview, referrer: 'https://www.msn.com/')
+      create(:session, :with_pageview, referrer: 'https://www.qwant.com/')
+      create(:session, :with_pageview, referrer: 'https://www.startpage.com/')
+      create(:session, :with_pageview, referrer: 'https://search.brave.com/')
 
       expect(query.run_query[:sessions_per_referrer_type]).to eq({
         'search_engine' => 15
@@ -47,24 +47,24 @@ RSpec.describe ReportBuilder::Queries::TrafficSources do
     end
 
     it 'identifies social networks' do
-      create(:session, referrer: 'https://www.facebook.com/')
-      create(:session, referrer: 'https://m.facebook.com/')
-      create(:session, referrer: 'https://lm.facebook.com/')
-      create(:session, referrer: 'https://l.facebook.com/')
-      create(:session, referrer: 'https://www.instagram.com/')
-      create(:session, referrer: 'https://l.instagram.com/')
-      create(:session, referrer: 'http://instagram.com/')
-      create(:session, referrer: 'https://www.linkedin.com/')
-      create(:session, referrer: 'https://www.snapchat.com/')
-      create(:session, referrer: 'android-app://com.linkedin.android/')
-      create(:session, referrer: 'https://www.reddit.com/')
-      create(:session, referrer: 'https://out.reddit.com/')
-      create(:session, referrer: 'https://www.hoplr.com/')
-      create(:session, referrer: 'https://www.tiktok.com/')
-      create(:session, referrer: 'https://www.twitter.com/')
-      create(:session, referrer: 'https://x.com')
-      create(:session, referrer: 'https://lnkd.in/')
-      create(:session, referrer: 'https://bsky.app/')
+      create(:session, :with_pageview, referrer: 'https://www.facebook.com/')
+      create(:session, :with_pageview, referrer: 'https://m.facebook.com/')
+      create(:session, :with_pageview, referrer: 'https://lm.facebook.com/')
+      create(:session, :with_pageview, referrer: 'https://l.facebook.com/')
+      create(:session, :with_pageview, referrer: 'https://www.instagram.com/')
+      create(:session, :with_pageview, referrer: 'https://l.instagram.com/')
+      create(:session, :with_pageview, referrer: 'http://instagram.com/')
+      create(:session, :with_pageview, referrer: 'https://www.linkedin.com/')
+      create(:session, :with_pageview, referrer: 'https://www.snapchat.com/')
+      create(:session, :with_pageview, referrer: 'android-app://com.linkedin.android/')
+      create(:session, :with_pageview, referrer: 'https://www.reddit.com/')
+      create(:session, :with_pageview, referrer: 'https://out.reddit.com/')
+      create(:session, :with_pageview, referrer: 'https://www.hoplr.com/')
+      create(:session, :with_pageview, referrer: 'https://www.tiktok.com/')
+      create(:session, :with_pageview, referrer: 'https://www.twitter.com/')
+      create(:session, :with_pageview, referrer: 'https://x.com')
+      create(:session, :with_pageview, referrer: 'https://lnkd.in/')
+      create(:session, :with_pageview, referrer: 'https://bsky.app/')
 
       expect(query.run_query[:sessions_per_referrer_type]).to eq({
         'social_network' => 18
@@ -72,14 +72,14 @@ RSpec.describe ReportBuilder::Queries::TrafficSources do
     end
 
     it 'identifies SSO redirects' do
-      create(:session, referrer: 'https://accounts.claveunica.gob.cl/')
-      create(:session, referrer: 'https://accounts.google.com/')
-      create(:session, referrer: 'https://login.microsoftonline.com/')
-      create(:session, referrer: 'https://my.esr.nhs.uk/')
-      create(:session, referrer: 'https://nemlog-in.mitid.dk/')
-      create(:session, referrer: 'https://frederikssund.criipto.id/')
-      create(:session, referrer: 'https://pvp.wien.gv.at/')
-      create(:session, referrer: 'https://app.franceconnect.gouv.fr/')
+      create(:session, :with_pageview, referrer: 'https://accounts.claveunica.gob.cl/')
+      create(:session, :with_pageview, referrer: 'https://accounts.google.com/')
+      create(:session, :with_pageview, referrer: 'https://login.microsoftonline.com/')
+      create(:session, :with_pageview, referrer: 'https://my.esr.nhs.uk/')
+      create(:session, :with_pageview, referrer: 'https://nemlog-in.mitid.dk/')
+      create(:session, :with_pageview, referrer: 'https://frederikssund.criipto.id/')
+      create(:session, :with_pageview, referrer: 'https://pvp.wien.gv.at/')
+      create(:session, :with_pageview, referrer: 'https://app.franceconnect.gouv.fr/')
 
       expect(query.run_query[:sessions_per_referrer_type]).to eq({
         'sso_redirect' => 8
@@ -87,8 +87,8 @@ RSpec.describe ReportBuilder::Queries::TrafficSources do
     end
 
     it 'identifies other traffic' do
-      create(:session, referrer: 'https://www.example.com/')
-      create(:session, referrer: 'https://www.gov.uk/')
+      create(:session, :with_pageview, referrer: 'https://www.example.com/')
+      create(:session, :with_pageview, referrer: 'https://www.gov.uk/')
 
       expect(query.run_query[:sessions_per_referrer_type]).to eq({
         'other' => 2
@@ -96,10 +96,10 @@ RSpec.describe ReportBuilder::Queries::TrafficSources do
     end
 
     it 'includes top 50 referrers, sorted desc by visits' do
-      create_list(:session, 3, referrer: 'https://www.google.com/')
-      create_list(:session, 5, referrer: 'https://www.facebook.com/')
-      create_list(:session, 2, referrer: 'https://www.example.com/', monthly_user_hash: '123')
-      create_list(:session, 2, referrer: 'https://www.example.com/', monthly_user_hash: '456')
+      create_list(:session, 3, :with_pageview, referrer: 'https://www.google.com/')
+      create_list(:session, 5, :with_pageview, referrer: 'https://www.facebook.com/')
+      create_list(:session, 2, :with_pageview, referrer: 'https://www.example.com/', monthly_user_hash: '123')
+      create_list(:session, 2, :with_pageview, referrer: 'https://www.example.com/', monthly_user_hash: '456')
 
       expect(query.run_query[:top_50_referrers]).to eq([
         {
@@ -124,13 +124,13 @@ RSpec.describe ReportBuilder::Queries::TrafficSources do
     end
 
     it 'does not include sso redirects in top 50 referrers' do
-      create_list(:session, 3, referrer: 'https://www.google.com/')
-      create_list(:session, 5, referrer: 'https://www.facebook.com/')
-      create_list(:session, 2, referrer: 'https://www.example.com/', monthly_user_hash: '123')
-      create_list(:session, 2, referrer: 'https://www.example.com/', monthly_user_hash: '456')
+      create_list(:session, 3, :with_pageview, referrer: 'https://www.google.com/')
+      create_list(:session, 5, :with_pageview, referrer: 'https://www.facebook.com/')
+      create_list(:session, 2, :with_pageview, referrer: 'https://www.example.com/', monthly_user_hash: '123')
+      create_list(:session, 2, :with_pageview, referrer: 'https://www.example.com/', monthly_user_hash: '456')
 
       # SSO referrers
-      create_list(:session, 3, referrer: 'https://accounts.claveunica.gob.cl/')
+      create_list(:session, 3, :with_pageview, referrer: 'https://accounts.claveunica.gob.cl/')
 
       expect(query.run_query[:top_50_referrers]).to eq([
         {

--- a/back/engines/commercial/report_builder/spec/services/report_builder/queries/visitors_spec.rb
+++ b/back/engines/commercial/report_builder/spec/services/report_builder/queries/visitors_spec.rb
@@ -289,8 +289,7 @@ RSpec.describe ReportBuilder::Queries::Visitors do
 
       result = query.run_query(**params)
 
-      expect(result[:visits_whole_period]).to eq(18) # should increase
-      expect(result[:visitors_whole_period]).to eq(5) # should increase
+      expect(result[:visits_whole_period]).to eq(8) # should not increase
       expect(result[:avg_seconds_per_session_whole_period]).to eq(135) # should not be affected
       expect(result[:avg_pages_visited_whole_period]).to eq(1.5) # should not be affected
     end

--- a/back/engines/commercial/report_builder/spec/services/report_builder/queries/visitors_spec.rb
+++ b/back/engines/commercial/report_builder/spec/services/report_builder/queries/visitors_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe ReportBuilder::Queries::Visitors do
       })
     end
 
-    it 'applies exclude_roles filter' do
+    it 'excludes roles' do
       # Create session december (admin)
       session = create(:session, created_at: Date.new(2022, 12, 2), highest_role: 'admin')
       create(:pageview, session_id: session.id, path: '/en/', created_at: DateTime.new(2022, 12, 2, 10, 0, 0))

--- a/back/spec/acceptance/phase_insights/common_ground_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/common_ground_phase_insights_spec.rb
@@ -4,7 +4,6 @@ require 'rspec_api_documentation/dsl'
 resource 'Phase insights' do
   before do
     admin_header_token
-
     # This reference time means we can expect exact dates in the chart data
     AppConfiguration.instance.update!(platform_start_at: '2025-09-01')
     travel_to(Time.zone.parse('2025-12-02 12:00:00'))

--- a/back/spec/acceptance/phase_insights/common_ground_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/common_ground_phase_insights_spec.rb
@@ -4,7 +4,9 @@ require 'rspec_api_documentation/dsl'
 resource 'Phase insights' do
   before do
     admin_header_token
+
     # This reference time means we can expect exact dates in the chart data
+    AppConfiguration.instance.update!(platform_start_at: '2025-09-01')
     travel_to(Time.zone.parse('2025-12-02 12:00:00'))
   end
 

--- a/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
@@ -5,6 +5,7 @@ resource 'Phase insights' do
   before do
     admin_header_token
     # This reference time means we can expect exact dates in the chart data
+    AppConfiguration.instance.update!(platform_start_at: '2025-09-01')
     travel_to(Time.zone.parse('2025-12-02 12:00:00'))
   end
 

--- a/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
@@ -11,6 +11,7 @@ resource 'Phase insights' do
   before do
     admin_header_token
     # This reference time means we can expect exact dates in the chart data
+    AppConfiguration.instance.update!(platform_start_at: '2025-09-01')
     travel_to(Time.zone.parse('2025-12-02 12:00:00'))
   end
 

--- a/back/spec/acceptance/phase_insights/poll_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/poll_phase_insights_spec.rb
@@ -5,6 +5,7 @@ resource 'Phase insights' do
   before do
     admin_header_token
     # This reference time means we can expect exact dates in the chart data
+    AppConfiguration.instance.update!(platform_start_at: '2025-09-01')
     travel_to(Time.zone.parse('2025-12-02 12:00:00'))
   end
 

--- a/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
@@ -5,6 +5,7 @@ resource 'Phase insights' do
   before do
     admin_header_token
     # This reference time means we can expect exact dates in the chart data
+    AppConfiguration.instance.update!(platform_start_at: '2025-09-01')
     travel_to(Time.zone.parse('2025-12-02 12:00:00'))
   end
 

--- a/back/spec/acceptance/phase_insights/volunteering_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/volunteering_phase_insights_spec.rb
@@ -5,6 +5,7 @@ resource 'Phase insights' do
   before do
     admin_header_token
     # This reference time means we can expect exact dates in the chart data
+    AppConfiguration.instance.update!(platform_start_at: '2025-09-01')
     travel_to(Time.zone.parse('2025-12-02 12:00:00'))
   end
 

--- a/back/spec/acceptance/phase_insights/voting_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/voting_phase_insights_spec.rb
@@ -5,6 +5,7 @@ resource 'Phase insights' do
   before do
     admin_header_token
     # This reference time means we can expect exact dates in the chart data
+    AppConfiguration.instance.update!(platform_start_at: '2025-09-01')
     travel_to(Time.zone.parse('2025-12-02 12:00:00'))
   end
 

--- a/back/spec/services/insights/base_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/base_phase_insights_service_spec.rb
@@ -5,6 +5,9 @@ RSpec.describe Insights::BasePhaseInsightsService do
 
   let(:phase) { create(:single_voting_phase, start_at: 17.days.ago, end_at: 2.days.ago) }
   let!(:permission1) { create(:permission, action: 'voting', permission_scope: phase) }
+  let(:visits_service) { Insights::VisitsService.new(phase.project_id, start_at: phase.start_at, end_at: phase.end_at) }
+
+  before { AppConfiguration.instance.update!(platform_start_at: 1.year.ago.beginning_of_day) }
 
   describe '#participant_id' do
     it 'returns the user_id when present' do
@@ -37,19 +40,23 @@ RSpec.describe Insights::BasePhaseInsightsService do
     let(:participations) { { voting: [participation1, participation2, participation3, participation4, participation5, participation6, participation7] } }
     let(:participant_ids) { participations[:voting].pluck(:participant_id).uniq }
 
-    let(:visits) do
-      [
-        { acted_at: 10.days.ago, visitor_id: user1.id.to_s }, # during phase (in week before last)
-        { acted_at: 5.days.ago, visitor_id: user1.id.to_s },  # during phase & in last 7 days
-        { acted_at: 10.days.ago, visitor_id: user2.id.to_s }, # during phase (in week before last)
-        { acted_at: 4.days.ago, visitor_id: user2.id.to_s },  # during phase & in last 7 days
-        { acted_at: 4.days.ago, visitor_id: 'anonymous_1' },  # during phase & in last 7 days
-        { acted_at: 10.days.ago, visitor_id: SecureRandom.uuid } # # during phase (in week before last)
-      ]
-    end
-
     it 'calculates base metrics correctly' do
-      result = service.send(:base_metrics, participations, participant_ids, visits)
+      # Setup some visits
+      session1 = create(:session, user_id: user1.id)
+      create(:pageview, session: session1, created_at: 10.days.ago, project_id: phase.project.id) # during phase (in week before last)
+      create(:pageview, session: session1, created_at: 5.days.ago, project_id: phase.project.id) # during phase & in last 7 days
+
+      session2 = create(:session, user_id: user2.id)
+      create(:pageview, session: session2, created_at: 10.days.ago, project_id: phase.project.id) # during phase (in week before last)
+      create(:pageview, session: session2, created_at: 4.days.ago, project_id: phase.project.id) # during phase & in last 7 days
+
+      session3 = create(:session, user_id: nil) # anonymous visitor
+      create(:pageview, session: session3, created_at: 4.days.ago, project_id: phase.project.id) # during phase & in last 7 days
+
+      session4 = create(:session, user_id: create(:user).id) # visitor who did not participate
+      create(:pageview, session: session4, created_at: 10.days.ago, project_id: phase.project.id) # during phase (in week before last)
+
+      result = service.send(:base_metrics, participations, participant_ids, visits_service)
 
       expect(result).to eq(
         {
@@ -64,8 +71,7 @@ RSpec.describe Insights::BasePhaseInsightsService do
     end
 
     it 'handles zero visitors as expected' do
-      visits = []
-      result = service.send(:base_metrics, participations, participant_ids, visits)
+      result = service.send(:base_metrics, participations, participant_ids, visits_service)
 
       expect(result).to eq(
         {
@@ -90,13 +96,12 @@ RSpec.describe Insights::BasePhaseInsightsService do
         ]
       }
 
-      visits = [
-        { acted_at: 10.days.ago, visitor_id: SecureRandom.uuid },
-        { acted_at: 5.days.ago, visitor_id: SecureRandom.uuid },
-        { acted_at: 4.days.ago, visitor_id: SecureRandom.uuid }
-      ]
+      # Setup 3 visits (only 1 is > 7 days ago)
+      create(:pageview, session: create(:session, monthly_user_hash: 'hash1'), created_at: 10.days.ago, project_id: phase.project.id)
+      create(:pageview, session: create(:session, monthly_user_hash: 'hash2'), created_at: 5.days.ago, project_id: phase.project.id)
+      create(:pageview, session: create(:session, monthly_user_hash: 'hash3'), created_at: 4.days.ago, project_id: phase.project.id)
 
-      result = service.send(:base_7_day_changes, participations, visits, 3, 3)
+      result = service.send(:base_7_day_changes, participations, 3, 3)
 
       expect(result).to eq(
         {
@@ -116,8 +121,10 @@ RSpec.describe Insights::BasePhaseInsightsService do
         ]
       }
 
-      visits = [{ acted_at: 5.days.ago, visitor_id: SecureRandom.uuid }] # No visits before 7-days ago
-      result = service.send(:base_7_day_changes, participations, visits, 1, 3)
+      # No visits before 7-days ago
+      page_view = create(:pageview, session: create(:session), created_at: 5.days.ago, project_id: phase.project.id)
+
+      result = service.send(:base_7_day_changes, participations, 1, 3)
 
       expect(result).to eq(
         {
@@ -127,8 +134,10 @@ RSpec.describe Insights::BasePhaseInsightsService do
         }
       )
 
-      visits = [{ acted_at: 10.days.ago, visitor_id: SecureRandom.uuid }] # No visits in last 7 days
-      result = service.send(:base_7_day_changes, participations, visits, 1, 3)
+      # No visits in last 7 days
+      page_view.update!(created_at: 10.days.ago)
+
+      result = service.send(:base_7_day_changes, participations, 1, 3)
 
       expect(result).to eq(
         {
@@ -138,8 +147,10 @@ RSpec.describe Insights::BasePhaseInsightsService do
         }
       )
 
-      visits = [] # No visits in either period
-      result = service.send(:base_7_day_changes, participations, visits, 0, 3)
+      # No visits in either period
+      page_view.destroy!
+
+      result = service.send(:base_7_day_changes, participations, 0, 3)
 
       expect(result).to eq(
         {
@@ -598,21 +609,20 @@ RSpec.describe Insights::BasePhaseInsightsService do
   describe '#participants_and_visitors_chart_data' do
     it 'handles empty participations and visits data' do
       flattened_participations = []
-      visits = []
-      result = service.send(:participants_and_visitors_chart_data, flattened_participations, visits)
+      result = service.send(:participants_and_visitors_chart_data, flattened_participations, visits_service)
 
       expect(result).to eq({ resolution: 'day', timeseries: [] })
     end
 
     it 'handles empty participations with non-empty visits data' do
       flattened_participations = []
-      visits = [
-        { acted_at: 10.days.ago.beginning_of_day, visitor_id: 'visitor_1' },
-        { acted_at: 9.days.ago.beginning_of_day, visitor_id: 'visitor_2' },
-        { acted_at: 9.days.ago.beginning_of_day, visitor_id: 'visitor_3' }
-      ]
 
-      result = service.send(:participants_and_visitors_chart_data, flattened_participations, visits)
+      # Setup 3 visits / 3 visitors
+      create(:pageview, session: create(:session, monthly_user_hash: 'hash1'), created_at: 10.days.ago, project_id: phase.project.id)
+      create(:pageview, session: create(:session, monthly_user_hash: 'hash2'), created_at: 9.days.ago, project_id: phase.project.id)
+      create(:pageview, session: create(:session, monthly_user_hash: 'hash3'), created_at: 9.days.ago, project_id: phase.project.id)
+
+      result = service.send(:participants_and_visitors_chart_data, flattened_participations, visits_service)
 
       expect(result).to eq({
         resolution: 'day',
@@ -629,8 +639,8 @@ RSpec.describe Insights::BasePhaseInsightsService do
       participation2 = create(:basket_participation, acted_at: 7.days.ago, user: user)
 
       flattened_participations = [participation1, participation2]
-      visits = []
-      result = service.send(:participants_and_visitors_chart_data, flattened_participations, visits)
+
+      result = service.send(:participants_and_visitors_chart_data, flattened_participations, visits_service)
 
       expect(result).to eq({
         resolution: 'day',

--- a/back/spec/services/insights/visits_service_spec.rb
+++ b/back/spec/services/insights/visits_service_spec.rb
@@ -1,11 +1,12 @@
 require 'rails_helper'
 
 describe Insights::VisitsService do
-  let(:service) { described_class.new }
+  before do
+    AppConfiguration.instance.update!(platform_start_at: '2025-09-01')
+    travel_to(Time.zone.parse('2025-12-12'))
+  end
 
-  before { AppConfiguration.instance.update!(platform_start_at: 1.year.ago) }
-
-  describe '#phase_visits' do
+  context 'Phase visits' do
     # rubocop:disable RSpec/ScatteredLet
     let(:phase) { create(:single_voting_phase, start_at: 20.days.ago, end_at: 2.days.ago) }
 
@@ -33,44 +34,47 @@ describe Insights::VisitsService do
     # rubocop:enable RSpec/ScatteredLet
 
     it 'returns correct visits data for the phase' do
-      visits = service.phase_visits(phase).map { |row| { acted_at: row.acted_at, visitor_id: row.visitor_id } }
-
-      expect(visits).to contain_exactly(
-        { acted_at: pageview2.created_at, visitor_id: user1.id.to_s },
-        { acted_at: pageview3.created_at, visitor_id: user1.id.to_s },
-        { acted_at: pageview4.created_at, visitor_id: user2.id.to_s },
-        { acted_at: pageview5.created_at, visitor_id: user2.id.to_s },
-        { acted_at: pageview6.created_at, visitor_id: 'anonymous_user_hash' }
-      )
+      service = described_class.new(phase.project_id, start_at: phase.start_at, end_at: phase.end_at)
+      expect(service.total_visits).to eq({ visits: 3, visitors: 3 })
+      expect(service.visits_by_date('month')).to eq [
+        { visits: 2, visitors: 2, date_group: Date.new(2025, 11) },
+        { visits: 1, visitors: 1, date_group: Date.new(2025, 12) }
+      ]
     end
 
     describe 'edge cases for phase date boundaries' do
-      let(:phase2) { create(:single_voting_phase, start_at: Date.new(2026, 1, 15), end_at: Date.new(2026, 2, 2)) }
+      let(:phase2) { create(:single_voting_phase, start_at: Date.new(2025, 10, 15), end_at: Date.new(2025, 11, 2)) }
       let(:session) { create(:session, user_id: user1.id) }
       let(:tz) { AppConfiguration.timezone }
 
+      let(:service) { described_class.new(phase2.project_id, start_at: phase2.start_at, end_at: phase2.end_at) }
+
       it 'excludes a visit before the phase start date' do
-        create(:pageview, session: session, created_at: tz.parse('2026-01-14 23:59:59'), project_id: phase2.project.id) # before phase start
-        visits = service.phase_visits(phase2)
-        expect(visits).to be_empty
+        create(:pageview, session: session, created_at: tz.parse('2025-10-14 23:59:59'), project_id: phase2.project.id) # before phase start
+        expect(service.total_visits).to eq({ visits: 0, visitors: 0 })
+        expect(service.visits_by_date('month')).to eq []
       end
 
       it 'includes a visit on the phase start date' do
-        pageview = create(:pageview, session: session, created_at: tz.parse('2026-01-15 00:00:00'), project_id: phase2.project.id) # on phase start
-        visits = service.phase_visits(phase2).map { |row| { acted_at: row.acted_at, visitor_id: row.visitor_id } }
-        expect(visits).to contain_exactly({ acted_at: pageview.created_at, visitor_id: user1.id.to_s })
+        create(:pageview, session: session, created_at: tz.parse('2025-10-15 00:00:00'), project_id: phase2.project.id) # on phase start
+        expect(service.total_visits).to eq({ visits: 1, visitors: 1 })
+        expect(service.visits_by_date('month')).to eq [
+          { visits: 1, visitors: 1, date_group: Date.new(2025, 10) }
+        ]
       end
 
       it 'includes a visit on the phase end date' do
-        pageview = create(:pageview, session: session, created_at: tz.parse('2026-02-02 23:59:59'), project_id: phase2.project.id) # on phase end
-        visits = service.phase_visits(phase2).map { |row| { acted_at: row.acted_at, visitor_id: row.visitor_id } }
-        expect(visits).to contain_exactly({ acted_at: pageview.created_at, visitor_id: user1.id.to_s })
+        create(:pageview, session: session, created_at: tz.parse('2025-11-02 23:59:59'), project_id: phase2.project.id) # on phase end
+        expect(service.total_visits).to eq({ visits: 1, visitors: 1 })
+        expect(service.visits_by_date('month')).to eq [
+          { visits: 1, visitors: 1, date_group: Date.new(2025, 11) }
+        ]
       end
 
       it 'excludes a visit after the phase end date' do
-        create(:pageview, session: session, created_at: tz.parse('2026-02-03 00:00:00'), project_id: phase2.project.id) # after phase end
-        visits = service.phase_visits(phase2)
-        expect(visits).to be_empty
+        create(:pageview, session: session, created_at: tz.parse('2025-11-03 00:00:00'), project_id: phase2.project.id) # after phase end
+        expect(service.total_visits).to eq({ visits: 0, visitors: 0 })
+        expect(service.visits_by_date('month')).to eq []
       end
     end
   end

--- a/back/spec/services/insights/visits_service_spec.rb
+++ b/back/spec/services/insights/visits_service_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 describe Insights::VisitsService do
   let(:service) { described_class.new }
 
+  before { AppConfiguration.instance.update!(platform_start_at: 1.year.ago) }
+
   describe '#phase_visits' do
     # rubocop:disable RSpec/ScatteredLet
     let(:phase) { create(:single_voting_phase, start_at: 20.days.ago, end_at: 2.days.ago) }
@@ -31,13 +33,13 @@ describe Insights::VisitsService do
     # rubocop:enable RSpec/ScatteredLet
 
     it 'returns correct visits data for the phase' do
-      visits = service.phase_visits(phase)
+      visits = service.phase_visits(phase).map { |row| { acted_at: row.acted_at, visitor_id: row.visitor_id } }
 
       expect(visits).to contain_exactly(
-        { acted_at: pageview2.created_at, visitor_id: user1.id },
-        { acted_at: pageview3.created_at, visitor_id: user1.id },
-        { acted_at: pageview4.created_at, visitor_id: user2.id },
-        { acted_at: pageview5.created_at, visitor_id: user2.id },
+        { acted_at: pageview2.created_at, visitor_id: user1.id.to_s },
+        { acted_at: pageview3.created_at, visitor_id: user1.id.to_s },
+        { acted_at: pageview4.created_at, visitor_id: user2.id.to_s },
+        { acted_at: pageview5.created_at, visitor_id: user2.id.to_s },
         { acted_at: pageview6.created_at, visitor_id: 'anonymous_user_hash' }
       )
     end
@@ -45,27 +47,28 @@ describe Insights::VisitsService do
     describe 'edge cases for phase date boundaries' do
       let(:phase2) { create(:single_voting_phase, start_at: Date.new(2026, 1, 15), end_at: Date.new(2026, 2, 2)) }
       let(:session) { create(:session, user_id: user1.id) }
+      let(:tz) { AppConfiguration.timezone }
 
       it 'excludes a visit before the phase start date' do
-        create(:pageview, session: session, created_at: Time.zone.parse('2026-01-14 23:59:59'), project_id: phase2.project.id) # before phase start
+        create(:pageview, session: session, created_at: tz.parse('2026-01-14 23:59:59'), project_id: phase2.project.id) # before phase start
         visits = service.phase_visits(phase2)
         expect(visits).to be_empty
       end
 
       it 'includes a visit on the phase start date' do
-        pageview = create(:pageview, session: session, created_at: Time.zone.parse('2026-01-15 00:00:00'), project_id: phase2.project.id) # on phase start
-        visits = service.phase_visits(phase2)
-        expect(visits).to contain_exactly({ acted_at: pageview.created_at, visitor_id: user1.id })
+        pageview = create(:pageview, session: session, created_at: tz.parse('2026-01-15 00:00:00'), project_id: phase2.project.id) # on phase start
+        visits = service.phase_visits(phase2).map { |row| { acted_at: row.acted_at, visitor_id: row.visitor_id } }
+        expect(visits).to contain_exactly({ acted_at: pageview.created_at, visitor_id: user1.id.to_s })
       end
 
       it 'includes a visit on the phase end date' do
-        pageview = create(:pageview, session: session, created_at: Time.zone.parse('2026-02-02 23:59:59'), project_id: phase2.project.id) # on phase end
-        visits = service.phase_visits(phase2)
-        expect(visits).to contain_exactly({ acted_at: pageview.created_at, visitor_id: user1.id })
+        pageview = create(:pageview, session: session, created_at: tz.parse('2026-02-02 23:59:59'), project_id: phase2.project.id) # on phase end
+        visits = service.phase_visits(phase2).map { |row| { acted_at: row.acted_at, visitor_id: row.visitor_id } }
+        expect(visits).to contain_exactly({ acted_at: pageview.created_at, visitor_id: user1.id.to_s })
       end
 
       it 'excludes a visit after the phase end date' do
-        create(:pageview, session: session, created_at: Time.zone.parse('2026-02-03 00:00:00'), project_id: phase2.project.id) # after phase end
+        create(:pageview, session: session, created_at: tz.parse('2026-02-03 00:00:00'), project_id: phase2.project.id) # after phase end
         visits = service.phase_visits(phase2)
         expect(visits).to be_empty
       end

--- a/front/app/containers/Admin/dashboard/visitors/VisitorsOverview.tsx
+++ b/front/app/containers/Admin/dashboard/visitors/VisitorsOverview.tsx
@@ -15,6 +15,7 @@ import { START_DATE_SESSION_DATA_COLLECTION } from '../constants';
 
 import Charts from './Charts';
 import messages from './messages';
+import useAppConfiguration from 'api/app_configuration/useAppConfiguration';
 
 interface Props {
   defaultStartDate: Moment;
@@ -28,6 +29,10 @@ const VisitorsOverview = ({ defaultStartDate }: Props) => {
   const [projectId, setProjectId] = useState<string | undefined>();
   const [resolution, setResolution] = useState<IResolution>('month');
   const { formatMessage } = useIntl();
+
+  const { data: appConfig } = useAppConfiguration();
+  const showVisitorDataBanner =
+    appConfig && appConfig.data.attributes.created_at < '2024-12-01T00:00:00Z';
 
   const handleChangeTimeRange = (
     startAtMoment: Moment | null,
@@ -58,7 +63,11 @@ const VisitorsOverview = ({ defaultStartDate }: Props) => {
           minDate={moment(START_DATE_SESSION_DATA_COLLECTION)}
           // Filtering visitor data by project is not allowed because the data is not available. For more details, refer to: https://www.notion.so/govocal/Gent-is-struggling-to-access-the-data-on-their-visitor-dashboard-cecae17322a24ccdb4bd938a511159cc?d=78857b76019144ee97b6bd8de960ead1
           showProjectFilter={false}
-          timeControlTooltip={formatMessage(messages.visitorDataBanner)}
+          timeControlTooltip={
+            showVisitorDataBanner
+              ? formatMessage(messages.visitorDataBanner)
+              : undefined
+          }
         />
       </Box>
       <Charts

--- a/front/app/containers/Admin/projects/project/traffic/TrafficDatesRange.tsx
+++ b/front/app/containers/Admin/projects/project/traffic/TrafficDatesRange.tsx
@@ -14,6 +14,7 @@ import { toBackendDateString, parseBackendDateString } from 'utils/dateUtils';
 
 import Charts from './Charts';
 import messages from './messages';
+import useAppConfiguration from 'api/app_configuration/useAppConfiguration';
 
 const TrafficDatesRange = ({
   defaultStartDate,
@@ -23,6 +24,9 @@ const TrafficDatesRange = ({
   defaultEndDate: string | undefined;
 }) => {
   const { projectId } = useParams() as { projectId: string };
+  const { data: appConfig } = useAppConfiguration();
+  const showVisitorDataBanner =
+    appConfig && appConfig.data.attributes.created_at < '2024-12-01T00:00:00Z';
 
   const { formatMessage } = useIntl();
 
@@ -48,10 +52,12 @@ const TrafficDatesRange = ({
                 setEndAt(toBackendDateString(to));
               }}
             />
-            <IconTooltip
-              ml="12px"
-              content={formatMessage(messages.visitorDataBanner)}
-            />
+            {showVisitorDataBanner && (
+              <IconTooltip
+                ml="12px"
+                content={formatMessage(messages.visitorDataBanner)}
+              />
+            )}
           </Box>
           <ResolutionControl value={resolution} onChange={setResolution} />
         </Box>


### PR DESCRIPTION
Basically a rewrite of `VisitsService` (most of the change is here) so the core logic of which records are checked is consistent and can be shared. The definition of a when a visit happens is now defined as:

- The date/time when a pageview happens
- NOT when the session was created

This is so that if sessions stretch over more than one day, a visit will be counted in both days when grouped by date. This was the definition being used in the more recent phase dashboard work.

It also now calculates the visits stats for phase as ActiveRecord/SQL instead of getting a large object in memory which I thought could easily become a problem with the number of page view records there might be.

There were also indexes missing on the impact tracking tables which I think will be making things slow at the moment, given that the page views table in particular can get quite big.

When tested locally connecting to a large dataset (america1) it seems faster than master (maybe 15% faster), but hard to be definitive as it's so slow connecting to a US database locally.

# Changelog
## Fixed
- Project and phase visits/visitor stats now use the same logic so the numbers should be consistent. Note: This may mean visitor charts look slightly different as we're now using a more accurate measure for a visit on a particular day

## Added
- Added an API endpoint for visit stats
