### PR TITLE
TAN-7314: fix alt text in survey qn descriptions

### DIFF
--- a/front/app/components/UI/QuillEditor/createQuill.ts
+++ b/front/app/components/UI/QuillEditor/createQuill.ts
@@ -54,6 +54,14 @@ export const createQuill = (
                     alt: altTextLabel || 'Alt Text',
                     title: imageTitleLabel || 'Image Title',
                   },
+                  // Our Modal component (UI/Modal) uses z-index 1000001.
+                  // Override the library default (9999) so the alt text
+                  // modal renders above it.
+                  styles: {
+                    modalBackground: {
+                      zIndex: 1000002,
+                    },
+                  },
                 },
               },
             }

--- a/front/app/components/UI/QuillEditor/index.tsx
+++ b/front/app/components/UI/QuillEditor/index.tsx
@@ -110,7 +110,25 @@ const QuillEditor = ({
     setHTML(quill, value);
     setEditor(quill);
 
+    // When the blot-formatter alt text modal is appended to document.body,
+    // it falls outside react-focus-on's focus trap (used by our Modal component).
+    // Adding data-no-focus-lock lets react-focus-lock allow interaction with it.
+    const observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        for (const node of mutation.addedNodes) {
+          if (
+            node instanceof HTMLElement &&
+            node.hasAttribute('data-blot-formatter-modal')
+          ) {
+            node.setAttribute('data-no-focus-lock', 'true');
+          }
+        }
+      }
+    });
+    observer.observe(document.body, { childList: true });
+
     return () => {
+      observer.disconnect();
       container.innerHTML = '';
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
# Changelog

## Fixed
- Fixed alt text modal in Quill editor not appearing above the full-screen survey modal 

