### PR TITLE
TAN-7320: Fix null focus when reordering ranking questions using a dropdown

### DIFF
--- a/front/app/components/CustomFieldsForm/Fields/RankingField/RankingOption.tsx
+++ b/front/app/components/CustomFieldsForm/Fields/RankingField/RankingOption.tsx
@@ -108,12 +108,13 @@ const RankingOption = ({
                 onChange={(selectedOption) => {
                   moveOptionInArray(index, selectedOption.value - 1);
 
-                  // For a11y, focus the list item again after reordering.
-                  (
-                    document.querySelector(
-                      `[data-rbd-drag-handle-draggable-id="ranking-item-${option.value}"]`
-                    ) as HTMLElement
-                  ).focus();
+                  // For a11y, focus the select dropdown of the reordered item.
+                  requestAnimationFrame(() => {
+                    document
+                      .getElementById(`ranking-item-${option.value}`)
+                      ?.querySelector<HTMLSelectElement>('select')
+                      ?.focus();
+                  });
                 }}
               />
               <Text


### PR DESCRIPTION
# Changelog

## Technical
- Fixed a crash that occurred when reordering survey ranking questions using the dropdown. (Not affecting users directly but sending errors to sentry)
