### PR TITLE
TAN-7337: Fix missing form label accessibility error in ranking field

### DIFF
--- a/front/app/components/CustomFieldsForm/Fields/RankingField/RankingOption.tsx
+++ b/front/app/components/CustomFieldsForm/Fields/RankingField/RankingOption.tsx
@@ -76,6 +76,8 @@ const RankingOption = ({
     })
   );
 
+  const selectId = `ranking-select-${option.value}`;
+
   return (
     <li aria-roledescription="sortable">
       <Drag index={index} useBorder={false} id={`ranking-item-${option.value}`}>
@@ -92,7 +94,7 @@ const RankingOption = ({
           >
             <Box display="flex">
               <ScreenReaderOnly>
-                <Label>
+                <Label htmlFor={selectId}>
                   {`${option.label}. ${
                     getRankOfOption(option)
                       ? formatMessage(messages.currentRank)
@@ -102,6 +104,7 @@ const RankingOption = ({
               </ScreenReaderOnly>
 
               <StyledSelect
+                id={selectId}
                 options={rankDropdownOptions}
                 value={getRankOfOption(option)}
                 height="auto"


### PR DESCRIPTION
This fixes number 9 in this excel sheet https://docs.google.com/spreadsheets/d/13Ml40RMvBrsTr1_AORb_goZYoLYWrDbN/edit?gid=88917892#gid=88917892

# Changelog

## Fixed
- a11y: Associate ranking select dropdowns with their screen-reader-only labels by adding htmlFor and id attributes, resolving the WAVE "Missing form label" error