### PR TITLE
Only allow importing scanned forms if FF is both Enabled & Allowed

### DIFF
--- a/front/app/containers/Admin/projects/project/inputImporter/TopBar/ImportButtons.tsx
+++ b/front/app/containers/Admin/projects/project/inputImporter/TopBar/ImportButtons.tsx
@@ -24,7 +24,6 @@ const ImportButtons = ({ onClickPDFImport, onClickExcelImport }: Props) => {
   const [dropdownOpened, setDropdownOpened] = useState(false);
   const printedFormsAllowed = useFeatureFlag({
     name: 'import_printed_forms',
-    onlyCheckAllowed: true,
   });
   const inputImporterAllowed = useFeatureFlag({
     name: 'input_importer',


### PR DESCRIPTION
# Changelog
## Fixed
- [TAN-6342] Only allow importing scanned PDF forms if Feature Flag is both Enabled & Allowed (previously we only required it to be "Allowed").