### PR TITLE
 TAN-7262: Translate Weglot UGC comments to main locale at submission

### DIFF
--- a/back/app/controllers/web_api/v1/comments_controller.rb
+++ b/back/app/controllers/web_api/v1/comments_controller.rb
@@ -210,14 +210,15 @@ class WebApi::V1::CommentsController < ApplicationController
     params.require(:comment).permit(
       :parent_id,
       :anonymous,
-      body_multiloc: CL2_SUPPORTED_LOCALES
+      body_multiloc: CL2_SUPPORTED_LOCALES,
+      weglot_data: %i[locale body]
     )
   end
 
   def comment_update_params
     attrs = []
     if @comment.author_id == current_user&.id
-      attrs += [:anonymous, { body_multiloc: CL2_SUPPORTED_LOCALES }]
+      attrs += [:anonymous, { body_multiloc: CL2_SUPPORTED_LOCALES, weglot_data: %i[locale body] }]
     end
     params.require(:comment).permit(attrs)
   end

--- a/back/app/models/comment.rb
+++ b/back/app/models/comment.rb
@@ -20,6 +20,7 @@
 #  children_count     :integer          default(0), not null
 #  author_hash        :string
 #  anonymous          :boolean          default(FALSE), not null
+#  weglot_data        :jsonb            not null
 #
 # Indexes
 #

--- a/back/app/serializers/web_api/v1/comment_serializer.rb
+++ b/back/app/serializers/web_api/v1/comment_serializer.rb
@@ -9,6 +9,12 @@ class WebApi::V1::CommentSerializer < WebApi::V1::BaseSerializer
     end
   end
 
+  attribute :weglot_data do |object|
+    if object.publication_status != 'deleted'
+      object.weglot_data
+    end
+  end
+
   attribute :is_admin_comment do |object|
     object.author&.admin?
   end

--- a/back/db/migrate/20260313120000_add_weglot_data_to_comments.rb
+++ b/back/db/migrate/20260313120000_add_weglot_data_to_comments.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddWeglotDataToComments < ActiveRecord::Migration[7.2]
+  def change
+    add_column :comments, :weglot_data, :jsonb, default: {}, null: false
+  end
+end

--- a/back/db/structure.sql
+++ b/back/db/structure.sql
@@ -1674,7 +1674,8 @@ CREATE TABLE public.comments (
     body_updated_at timestamp without time zone,
     children_count integer DEFAULT 0 NOT NULL,
     author_hash character varying,
-    anonymous boolean DEFAULT false NOT NULL
+    anonymous boolean DEFAULT false NOT NULL,
+    weglot_data jsonb DEFAULT '{}'::jsonb NOT NULL
 );
 
 
@@ -8446,6 +8447,7 @@ ALTER TABLE ONLY public.project_reviews
 SET search_path TO public,shared_extensions;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260313120000'),
 ('20260302101045'),
 ('20260302100745'),
 ('20260302100636'),

--- a/front/app/api/comments/__mocks__/useComments.ts
+++ b/front/app/api/comments/__mocks__/useComments.ts
@@ -11,6 +11,7 @@ export const links = {
 
 export const mockCommentDataAttributes1: IPresentComment = {
   body_multiloc: { en: 'body_multiloc' },
+  weglot_data: {},
   created_at: 'created_at',
   publication_status: 'published',
   likes_count: 0,
@@ -52,6 +53,7 @@ export const commentsData: ICommentData[] = [
     type: 'comment',
     attributes: {
       body_multiloc: { en: 'body_multiloc' },
+      weglot_data: {},
       created_at: 'created_at',
       publication_status: 'published',
       likes_count: 0,

--- a/front/app/api/comments/types.ts
+++ b/front/app/api/comments/types.ts
@@ -1,6 +1,7 @@
 import { IRelationship, Multiloc, ILinks } from 'typings';
 
 import { Keys } from 'utils/cl-react-query/types';
+import { WeglotData } from 'utils/weglot';
 
 import commentsKeys from './keys';
 
@@ -22,6 +23,7 @@ interface CommentAttributes {
 
 export interface IPresentComment extends CommentAttributes {
   body_multiloc: Multiloc;
+  weglot_data: WeglotData | Record<string, never>;
   publication_status: 'published';
   anonymous?: boolean;
   author_hash?: string;
@@ -66,6 +68,7 @@ export interface INewComment {
   author_id: string;
   parent_id?: string;
   body_multiloc: Multiloc;
+  weglot_data?: WeglotData | Record<string, never>;
   anonymous?: boolean;
 }
 
@@ -74,6 +77,7 @@ export interface IUpdatedComment {
   author_id?: string;
   parent_id?: string;
   body_multiloc: Multiloc;
+  weglot_data?: WeglotData | Record<string, never>;
 }
 
 export const DeleteReasonCode = {

--- a/front/app/components/PostShowComponents/Comments/Comment/CommentBody.tsx
+++ b/front/app/components/PostShowComponents/Comments/Comment/CommentBody.tsx
@@ -5,6 +5,7 @@ import { filter } from 'rxjs/operators';
 import styled, { useTheme } from 'styled-components';
 import { CLErrors } from 'typings';
 
+import useAppConfiguration from 'api/app_configuration/useAppConfiguration';
 import { IUpdatedComment } from 'api/comments/types';
 import useComment from 'api/comments/useComment';
 import useUpdateComment from 'api/comments/useUpdateComment';
@@ -23,6 +24,12 @@ import QuillEditedContent from 'components/UI/QuillEditedContent';
 
 import { FormattedMessage } from 'utils/cl-intl';
 import { isNilOrError } from 'utils/helperUtils';
+import {
+  isWeglotTranslatedPage,
+  getWeglotCurrentLang,
+  weglotTranslate,
+  WeglotData,
+} from 'utils/weglot';
 
 import { commentTranslateButtonClicked$ } from '../events';
 import messages from '../messages';
@@ -71,6 +78,7 @@ const CommentBody = ({
   ideaId,
 }: Props) => {
   const theme = useTheme();
+  const { data: appConfiguration } = useAppConfiguration();
   const { data: comment } = useComment(commentId);
   const { mutate: updateComment, isLoading: processing } = useUpdateComment({
     ideaId,
@@ -154,13 +162,33 @@ const CommentBody = ({
     event.preventDefault();
 
     if (!isNilOrError(locale)) {
+      const processedValue = editableCommentContent.replace(
+        /@\[(.*?)\]\((.*?)\)/gi,
+        '@$2'
+      );
+
+      let bodyMultiloc: Record<string, string> = {
+        [locale]: processedValue,
+      };
+      let weglotData: WeglotData | Record<string, never> = {};
+
+      const weglotApiKey =
+        appConfiguration?.data.attributes.settings.core.weglot_api_key;
+      if (weglotApiKey && isWeglotTranslatedPage(locale)) {
+        const weglotLang = getWeglotCurrentLang()!;
+        const translatedValue = await weglotTranslate(
+          processedValue,
+          weglotLang,
+          locale,
+          weglotApiKey
+        );
+        bodyMultiloc = { [locale]: translatedValue };
+        weglotData = { locale: weglotLang, body: processedValue };
+      }
+
       const updatedComment: Omit<IUpdatedComment, 'commentId'> = {
-        body_multiloc: {
-          [locale]: editableCommentContent.replace(
-            /@\[(.*?)\]\((.*?)\)/gi,
-            '@$2'
-          ),
-        },
+        body_multiloc: bodyMultiloc,
+        weglot_data: weglotData,
       };
 
       setApiErrors(null);

--- a/front/app/components/PostShowComponents/Comments/CommentsSection/PublicComments/Comments/ChildCommentForm.tsx
+++ b/front/app/components/PostShowComponents/Comments/CommentsSection/PublicComments/Comments/ChildCommentForm.tsx
@@ -23,6 +23,12 @@ import { trackEventByName } from 'utils/analytics';
 import { FormattedMessage, useIntl } from 'utils/cl-intl';
 import { isNilOrError } from 'utils/helperUtils';
 import { canModerateProject } from 'utils/permissions/rules/projectPermissions';
+import {
+  isWeglotTranslatedPage,
+  getWeglotCurrentLang,
+  weglotTranslate,
+  WeglotData,
+} from 'utils/weglot';
 
 import { commentReplyButtonClicked$, commentAdded } from '../../../events';
 import messages from '../../../messages';
@@ -171,9 +177,26 @@ const ChildCommentForm = ({
 
   const continueSubmission = async () => {
     if (canSubmit) {
-      const commentBodyMultiloc = {
-        [locale]: inputValue.replace(/@\[(.*?)\]\((.*?)\)/gi, '@$2'),
+      const processedValue = inputValue.replace(/@\[(.*?)\]\((.*?)\)/gi, '@$2');
+
+      let commentBodyMultiloc: Record<string, string> = {
+        [locale]: processedValue,
       };
+      let weglotData: WeglotData | Record<string, never> = {};
+
+      const weglotApiKey =
+        appConfiguration?.data.attributes.settings.core.weglot_api_key;
+      if (weglotApiKey && isWeglotTranslatedPage(locale)) {
+        const weglotLang = getWeglotCurrentLang()!;
+        const translatedValue = await weglotTranslate(
+          processedValue,
+          weglotLang,
+          locale,
+          weglotApiKey
+        );
+        commentBodyMultiloc = { [locale]: translatedValue };
+        weglotData = { locale: weglotLang, body: processedValue };
+      }
 
       setCanSubmit(false);
 
@@ -191,6 +214,7 @@ const ChildCommentForm = ({
             author_id: authUser.data.id,
             parent_id: parentId,
             body_multiloc: commentBodyMultiloc,
+            weglot_data: weglotData,
             anonymous: postAnonymously,
           },
           {

--- a/front/app/components/PostShowComponents/Comments/CommentsSection/PublicComments/ParentCommentForm.tsx
+++ b/front/app/components/PostShowComponents/Comments/CommentsSection/PublicComments/ParentCommentForm.tsx
@@ -24,6 +24,12 @@ import { trackEventByName } from 'utils/analytics';
 import { FormattedMessage, MessageDescriptor, useIntl } from 'utils/cl-intl';
 import { isNilOrError, isPage } from 'utils/helperUtils';
 import { canModerateProject } from 'utils/permissions/rules/projectPermissions';
+import {
+  isWeglotTranslatedPage,
+  getWeglotCurrentLang,
+  weglotTranslate,
+  WeglotData,
+} from 'utils/weglot';
 
 import Actions from '../../CommentForm/Actions';
 import { commentAdded } from '../../events';
@@ -151,9 +157,26 @@ const ParentCommentForm = ({
     setFocused(false);
 
     if (isString(inputValue) && trim(inputValue) !== '') {
-      const commentBodyMultiloc = {
-        [locale]: inputValue.replace(/@\[(.*?)\]\((.*?)\)/gi, '@$2'),
+      const processedValue = inputValue.replace(/@\[(.*?)\]\((.*?)\)/gi, '@$2');
+
+      let commentBodyMultiloc: Record<string, string> = {
+        [locale]: processedValue,
       };
+      let weglotData: WeglotData | Record<string, never> = {};
+
+      const weglotApiKey =
+        appConfiguration?.data.attributes.settings.core.weglot_api_key;
+      if (weglotApiKey && isWeglotTranslatedPage(locale)) {
+        const weglotLang = getWeglotCurrentLang()!;
+        const translatedValue = await weglotTranslate(
+          processedValue,
+          weglotLang,
+          locale,
+          weglotApiKey
+        );
+        commentBodyMultiloc = { [locale]: translatedValue };
+        weglotData = { locale: weglotLang, body: processedValue };
+      }
 
       trackEventByName(tracks.clickParentCommentPublish, {
         postId: ideaId,
@@ -167,6 +190,7 @@ const ParentCommentForm = ({
             ideaId,
             author_id: authUser.data.id,
             body_multiloc: commentBodyMultiloc,
+            weglot_data: weglotData,
             anonymous: postAnonymously,
           },
           {

--- a/front/app/containers/App/index.tsx
+++ b/front/app/containers/App/index.tsx
@@ -179,10 +179,11 @@ const App = ({ children }: Props) => {
         document.head.appendChild(script);
 
         script.onload = function () {
-          window.Weglot.initialize({
-            api_key:
-              appConfiguration.data.attributes.settings.core.weglot_api_key,
-          });
+          const apiKey =
+            appConfiguration.data.attributes.settings.core.weglot_api_key;
+          if (window.Weglot && apiKey) {
+            window.Weglot.initialize({ api_key: apiKey });
+          }
         };
 
         script.src = 'https://cdn.weglot.com/weglot.min.js';

--- a/front/app/typings.ts
+++ b/front/app/typings.ts
@@ -20,7 +20,20 @@ declare global {
   }
   interface Window {
     Intercom?: any;
-    Weglot?: any;
+    Weglot?: {
+      initialize: (options: { api_key: string }) => void;
+      getCurrentLang: () => string;
+      switchTo: (lang: string) => void;
+      on: (event: string, callback: (...args: any[]) => void) => void;
+      off: (event: string, callback: (...args: any[]) => void) => void;
+      translate: (
+        payload: {
+          words: { t: number; w: string }[];
+          languageTo: string;
+        },
+        callback: (data: any) => void
+      ) => void;
+    };
     _paq: any;
     attachEvent?: any;
     dataLayer?: any[];

--- a/front/app/utils/weglot.ts
+++ b/front/app/utils/weglot.ts
@@ -46,6 +46,7 @@ export async function weglotTranslate(
         body: JSON.stringify({
           l_from: fromLang,
           l_to: toLang.split('-')[0], // Weglot expects 2-letter ISO codes
+          request_url: window.location.href,
           words: [{ w: text, t: 3 }], // t:3 for HTML content
         }),
         signal: AbortSignal.timeout(5000), // 5s timeout

--- a/front/app/utils/weglot.ts
+++ b/front/app/utils/weglot.ts
@@ -1,0 +1,62 @@
+import { SupportedLocale } from 'typings';
+
+export interface WeglotData {
+  locale: string;
+  body: string;
+}
+
+/**
+ * Returns the current Weglot language if Weglot is active,
+ * or null if Weglot is not loaded.
+ */
+export function getWeglotCurrentLang(): string | null {
+  return window.Weglot?.getCurrentLang?.() ?? null;
+}
+
+/**
+ * Checks if Weglot is active and the user is on a translated page
+ * (i.e., the current Weglot language differs from the platform's main locale).
+ */
+export function isWeglotTranslatedPage(mainLocale: SupportedLocale): boolean {
+  const weglotLang = getWeglotCurrentLang();
+  if (!weglotLang) return false;
+
+  // Compare 2-letter Weglot code against the main locale
+  // e.g., "fr" !== "en", or "en" === "en"
+  const mainLangCode = mainLocale.split('-')[0];
+  return weglotLang !== mainLangCode;
+}
+
+/**
+ * Calls the Weglot REST API to translate text from one language to another.
+ * Returns the translated text, or the original text on failure (graceful degradation).
+ */
+export async function weglotTranslate(
+  text: string,
+  fromLang: string,
+  toLang: string,
+  apiKey: string
+): Promise<string> {
+  try {
+    const response = await fetch(
+      `https://api.weglot.com/translate?api_key=${apiKey}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          l_from: fromLang,
+          l_to: toLang.split('-')[0], // Weglot expects 2-letter ISO codes
+          words: [{ w: text, t: 3 }], // t:3 for HTML content
+        }),
+        signal: AbortSignal.timeout(5000), // 5s timeout
+      }
+    );
+
+    if (!response.ok) return text;
+
+    const data = await response.json();
+    return data.to_words?.[0] ?? text;
+  } catch {
+    return text; // Graceful degradation
+  }
+}

--- a/front/app/utils/weglot.ts
+++ b/front/app/utils/weglot.ts
@@ -10,7 +10,7 @@ export interface WeglotData {
  * or null if Weglot is not loaded.
  */
 export function getWeglotCurrentLang(): string | null {
-  return window.Weglot?.getCurrentLang?.() ?? null;
+  return window.Weglot?.getCurrentLang() ?? null;
 }
 
 /**


### PR DESCRIPTION
# Changelog

## Fixed
- Comments written via Weglot-translated pages now display correctly in the platform's main language. Previously, a comment written in French (via Weglot) was stored under the English locale key untranslated, causing it to appear in French on the English page.
