### PR TITLE
[TAN-7350] Show any validation errors for FormSync imported ideas in UI from start

### DIFF
--- a/front/app/components/CustomFieldsForm/CustomFields.tsx
+++ b/front/app/components/CustomFieldsForm/CustomFields.tsx
@@ -42,10 +42,12 @@ const renderField = ({
   question,
   projectId,
   ideaId,
+  scrollErrorIntoView = true,
 }: {
   question: IFlatCustomField;
   projectId?: string;
   ideaId?: string;
+  scrollErrorIntoView?: boolean;
 }) => {
   // Only user fields can be locked (disabled) for now due to a verification method!
   // Possible user fields are: text, number, multiline_text, select, multiselect, checkbox, date
@@ -58,7 +60,7 @@ const renderField = ({
           name={question.key}
           hideLocaleSwitcher
           maxCharCount={question.max_characters}
-          scrollErrorIntoView={true}
+          scrollErrorIntoView={scrollErrorIntoView}
           disabled={disabled}
         />
       );
@@ -67,7 +69,7 @@ const renderField = ({
         <QuillMultilocWithLocaleSwitcher
           name={question.key}
           hideLocaleSwitcher
-          scrollErrorIntoView={true}
+          scrollErrorIntoView={scrollErrorIntoView}
           id={question.key}
           maxCharCount={question.max_characters}
           minCharCount={question.min_characters}
@@ -78,7 +80,7 @@ const renderField = ({
       return question.key === 'location_description' ? (
         <LocationInput
           name={question.key}
-          scrollErrorIntoView={true}
+          scrollErrorIntoView={scrollErrorIntoView}
           isDisabled={disabled}
         />
       ) : (
@@ -86,7 +88,7 @@ const renderField = ({
           type={question.input_type === 'number' ? 'number' : 'text'}
           name={question.key}
           maxCharCount={question.max_characters}
-          scrollErrorIntoView={true}
+          scrollErrorIntoView={scrollErrorIntoView}
           disabled={disabled}
         />
       );
@@ -95,7 +97,7 @@ const renderField = ({
         <TextArea
           name={question.key}
           maxCharCount={question.max_characters}
-          scrollErrorIntoView={true}
+          scrollErrorIntoView={scrollErrorIntoView}
           minRows={2}
           disabled={disabled}
         />
@@ -104,7 +106,7 @@ const renderField = ({
       return (
         <SingleSelectField
           question={question}
-          scrollErrorIntoView={true}
+          scrollErrorIntoView={scrollErrorIntoView}
           disabled={disabled}
         />
       );
@@ -112,7 +114,7 @@ const renderField = ({
       return (
         <MultiSelectField
           question={question}
-          scrollErrorIntoView={true}
+          scrollErrorIntoView={scrollErrorIntoView}
           disabled={disabled}
         />
       );
@@ -125,7 +127,7 @@ const renderField = ({
             'image/*': ['.jpg', '.jpeg', '.png'],
           }}
           ideaId={ideaId}
-          scrollErrorIntoView={true}
+          scrollErrorIntoView={scrollErrorIntoView}
         />
       );
     case 'files':
@@ -133,7 +135,7 @@ const renderField = ({
         <MultiFileUploadField
           name={question.key}
           ideaId={ideaId}
-          scrollErrorIntoView={true}
+          scrollErrorIntoView={scrollErrorIntoView}
         />
       );
     case 'topic_ids':
@@ -141,28 +143,57 @@ const renderField = ({
         <Topics
           name={question.key}
           projectId={projectId}
-          scrollErrorIntoView={true}
+          scrollErrorIntoView={scrollErrorIntoView}
         />
       );
     case 'linear_scale':
       return (
-        <LinearScaleField question={question} scrollErrorIntoView={true} />
+        <LinearScaleField
+          question={question}
+          scrollErrorIntoView={scrollErrorIntoView}
+        />
       );
     case 'ranking':
-      return <RankingField question={question} scrollErrorIntoView={true} />;
+      return (
+        <RankingField
+          question={question}
+          scrollErrorIntoView={scrollErrorIntoView}
+        />
+      );
     case 'rating':
-      return <RatingField question={question} scrollErrorIntoView={true} />;
+      return (
+        <RatingField
+          question={question}
+          scrollErrorIntoView={scrollErrorIntoView}
+        />
+      );
     case 'matrix_linear_scale':
-      return <MatrixField question={question} scrollErrorIntoView={true} />;
+      return (
+        <MatrixField
+          question={question}
+          scrollErrorIntoView={scrollErrorIntoView}
+        />
+      );
     case 'sentiment_linear_scale':
       return (
-        <SentimentScaleField question={question} scrollErrorIntoView={true} />
+        <SentimentScaleField
+          question={question}
+          scrollErrorIntoView={scrollErrorIntoView}
+        />
       );
     case 'cosponsor_ids':
-      return <CosponsorsField question={question} scrollErrorIntoView={true} />;
+      return (
+        <CosponsorsField
+          question={question}
+          scrollErrorIntoView={scrollErrorIntoView}
+        />
+      );
     case 'multiselect_image':
       return (
-        <ImageMultichoiceField question={question} scrollErrorIntoView={true} />
+        <ImageMultichoiceField
+          question={question}
+          scrollErrorIntoView={scrollErrorIntoView}
+        />
       );
     case 'file_upload':
     case 'shapefile_upload':
@@ -170,7 +201,7 @@ const renderField = ({
         <SingleFileUploadField
           name={question.key}
           ideaId={ideaId}
-          scrollErrorIntoView={true}
+          scrollErrorIntoView={scrollErrorIntoView}
         />
       );
     case 'point':
@@ -184,14 +215,14 @@ const renderField = ({
             }
           }
           projectId={projectId}
-          scrollErrorIntoView={true}
+          scrollErrorIntoView={scrollErrorIntoView}
         />
       );
     case 'checkbox':
       return (
         <CheckboxField
           name={question.key}
-          scrollErrorIntoView={true}
+          scrollErrorIntoView={scrollErrorIntoView}
           disabled={disabled}
         />
       );
@@ -199,7 +230,7 @@ const renderField = ({
       return (
         <DateField
           name={question.key}
-          scrollErrorIntoView={true}
+          scrollErrorIntoView={scrollErrorIntoView}
           disabled={disabled}
         />
       );
@@ -214,12 +245,14 @@ const CustomFields = ({
   ideaId,
   phase,
   participationMethod,
+  scrollErrorIntoView = true,
 }: {
   questions: IFlatCustomField[];
   projectId?: string;
   ideaId?: string;
   phase?: IPhaseData;
   participationMethod?: ParticipationMethod;
+  scrollErrorIntoView?: boolean;
 }) => {
   const localize = useLocalize();
   const { formatMessage } = useIntl();
@@ -290,7 +323,12 @@ const CustomFields = ({
               )}
               <Box display="flex" alignItems="center" gap="8px">
                 <Box w="100%">
-                  {renderField({ question, projectId, ideaId })}
+                  {renderField({
+                    question,
+                    projectId,
+                    ideaId,
+                    scrollErrorIntoView,
+                  })}
                 </Box>
                 {question.constraints?.locked && (
                   <IconTooltip

--- a/front/app/containers/Admin/projects/project/inputImporter/ReviewSection/IdeaEditor/IdeaForm.tsx
+++ b/front/app/containers/Admin/projects/project/inputImporter/ReviewSection/IdeaEditor/IdeaForm.tsx
@@ -56,6 +56,11 @@ const IdeaForm = ({
     defaultValues: formData,
   });
 
+  // Trigger validation on mount so errors show immediately
+  useEffect(() => {
+    methods.trigger();
+  }, [methods]);
+
   // Ensure initial form validation state is correct
   useEffect(() => {
     setIdeaFormDataValid(methods.formState.isValid);

--- a/front/app/containers/Admin/projects/project/inputImporter/ReviewSection/IdeaEditor/IdeaForm.tsx
+++ b/front/app/containers/Admin/projects/project/inputImporter/ReviewSection/IdeaEditor/IdeaForm.tsx
@@ -92,6 +92,7 @@ const IdeaForm = ({
                 participationMethod={
                   phase?.data.attributes.participation_method
                 }
+                scrollErrorIntoView={false}
               />
             </Suspense>
           )}


### PR DESCRIPTION
# Description
- Show any validation errors for FormSync imported ideas in the review UI from start (E.g. Missing required fields), rather than only showing them once the user clicks the "Approve" button. Makes the review experience better.

