### PR TITLE
TAN-7394: Fix tooltip keyboard accessibility

### DIFF
--- a/front/app/component-library/components/Tooltip/index.tsx
+++ b/front/app/component-library/components/Tooltip/index.tsx
@@ -42,29 +42,7 @@ const useActiveElement = () => {
   return active;
 };
 
-const PLUGINS = [
-  {
-    name: 'hideOnEsc',
-    defaultValue: true,
-    fn({ hide }) {
-      function onKeyDown(event: KeyboardEvent) {
-        if (event.key === 'Escape') {
-          hide();
-        }
-      }
-
-      return {
-        onShow() {
-          document.addEventListener('keydown', onKeyDown);
-        },
-        onHide() {
-          document.removeEventListener('keydown', onKeyDown);
-        },
-      };
-    },
-  },
-  followCursor,
-];
+const PLUGINS = [followCursor];
 
 const Tooltip = ({
   children,
@@ -80,21 +58,63 @@ const Tooltip = ({
   const [isFocused, setIsFocused] = useState<boolean | undefined>(undefined);
   const [key, setKey] = useState<number>(0);
   const activeElement = useActiveElement();
+  // Ref-based flag to track when the user explicitly hid the tooltip via
+  // click/Space/Escape. Using a ref (not state) avoids re-render timing
+  // issues with the document-level click/focusin handlers in useActiveElement.
+  const manuallyHiddenRef = useRef(false);
 
   // Check if the active element is inside the tooltip
   useEffect(() => {
     const tooltip = document.getElementById(tooltipId.current);
     const tooltipContent = document.querySelector('.tippy-content');
     if (tooltip && tooltip.contains(activeElement)) {
-      setIsFocused(true);
+      if (!manuallyHiddenRef.current) {
+        setIsFocused(true);
+      }
     } else if (
       isFocused &&
       tooltipContent &&
       !tooltipContent.contains(activeElement)
     ) {
       setIsFocused(false);
+      manuallyHiddenRef.current = false;
     }
   }, [activeElement, isFocused]);
+
+  // Handle click (Space/Enter on button) to toggle tooltip visibility, and
+  // Escape to close. Uses native listeners so they fire before document-level
+  // handlers in useActiveElement, and stopPropagation prevents Escape from
+  // closing parent dialogs.
+  useEffect(() => {
+    const tooltip = document.getElementById(tooltipId.current);
+    if (!tooltip) return;
+
+    const handleClick = (event: MouseEvent) => {
+      event.stopPropagation();
+      if (manuallyHiddenRef.current) {
+        manuallyHiddenRef.current = false;
+        setIsFocused(true);
+      } else {
+        manuallyHiddenRef.current = true;
+        setIsFocused(false);
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && !manuallyHiddenRef.current) {
+        event.stopPropagation();
+        manuallyHiddenRef.current = true;
+        setIsFocused(false);
+      }
+    };
+
+    tooltip.addEventListener('click', handleClick);
+    tooltip.addEventListener('keydown', handleKeyDown);
+    return () => {
+      tooltip.removeEventListener('click', handleClick);
+      tooltip.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [key]);
 
   // This component sometimes crashes because of re-renders.
   // This useCallback slightly improves the situation (i.e. it makes it
@@ -103,8 +123,13 @@ const Tooltip = ({
   // to fix the issue properly.
   // https://www.notion.so/govocal/Fix-Tooltip-component-16f9663b7b2680a48aebdf2ace15d1f8
   const handleOnHidden = useCallback(() => {
-    setIsFocused(undefined);
-    setKey((prev) => prev + 1);
+    // When manually hidden (click/Space/Escape toggle), skip the key
+    // increment and isFocused reset. This preserves the Tippy instance so
+    // the user can re-open it with another click/Space.
+    if (!manuallyHiddenRef.current) {
+      setIsFocused(undefined);
+      setKey((prev) => prev + 1);
+    }
   }, [setIsFocused, setKey]);
 
   if (useContentWrapper) {

--- a/front/app/component-library/components/Tooltip/index.tsx
+++ b/front/app/component-library/components/Tooltip/index.tsx
@@ -63,7 +63,9 @@ const Tooltip = ({
   // issues with the document-level click/focusin handlers in useActiveElement.
   const manuallyHiddenRef = useRef(false);
 
-  // Check if the active element is inside the tooltip
+  // Check if the active element is inside the tooltip.
+  // Ignores activeElement === null (transient state from the document-level
+  // handleOutsideClick) to avoid interfering with click-based toggling.
   useEffect(() => {
     const tooltip = document.getElementById(tooltipId.current);
     const tooltipContent = document.querySelector('.tippy-content');
@@ -71,26 +73,30 @@ const Tooltip = ({
       if (!manuallyHiddenRef.current) {
         setIsFocused(true);
       }
-    } else if (
-      isFocused &&
-      tooltipContent &&
-      !tooltipContent.contains(activeElement)
-    ) {
-      setIsFocused(false);
+    } else if (activeElement !== null) {
+      // Focus has genuinely moved to another element outside the tooltip
+      if (
+        isFocused &&
+        tooltipContent &&
+        !tooltipContent.contains(activeElement)
+      ) {
+        setIsFocused(false);
+      }
       manuallyHiddenRef.current = false;
     }
   }, [activeElement, isFocused]);
 
   // Handle click (Space/Enter on button) to toggle tooltip visibility, and
-  // Escape to close. Uses native listeners so they fire before document-level
-  // handlers in useActiveElement, and stopPropagation prevents Escape from
-  // closing parent dialogs.
+  // Escape to close. Uses native listeners on the wrapper element.
+  // Click does NOT use stopPropagation, so clicks on interactive children
+  // (buttons, inputs) inside the tooltip wrapper propagate normally.
+  // Escape uses stopPropagation only when the tooltip is visible, preventing
+  // it from closing parent dialogs.
   useEffect(() => {
     const tooltip = document.getElementById(tooltipId.current);
     if (!tooltip) return;
 
-    const handleClick = (event: MouseEvent) => {
-      event.stopPropagation();
+    const handleClick = () => {
       if (manuallyHiddenRef.current) {
         manuallyHiddenRef.current = false;
         setIsFocused(true);


### PR DESCRIPTION
# Changelog

## Fixed
- a11y (Tooltip): Pressing Space/Enter on the tooltip info button now properly toggles the tooltip open and closed, instead of immediately re-expanding
- a11y (Tooltip): Pressing Escape closes the tooltip without propagating to parent components (e.g. dialogs)
- a11y (Tooltip): A second Escape press behaves as expected, propagating normally to parent components
