### PR TITLE
[TAN-7348] Fix "approve all" button approves invalid FormSync imports

### DIFF
--- a/back/app/services/idea_custom_fields_service.rb
+++ b/back/app/services/idea_custom_fields_service.rb
@@ -56,6 +56,8 @@ class IdeaCustomFieldsService
   end
 
   def fields_to_validate_on_import
+    # Currently we do not handle forms with logic, since we cannot validate required
+    # fields as the logic may hide required fields based on previous answers.
     return [] if form_has_logic?
 
     enabled_fields.select { |f| f.required? && !f.built_in? && f.supports_submission? }

--- a/back/app/services/idea_custom_fields_service.rb
+++ b/back/app/services/idea_custom_fields_service.rb
@@ -55,6 +55,10 @@ class IdeaCustomFieldsService
     enabled_fields_with_other_options.select(&:supports_xlsx_import?)
   end
 
+  def fields_to_validate_on_import
+    enabled_fields.select { |f| f.required? && !f.built_in? && f.supports_submission? }
+  end
+
   def enabled_fields
     fields = all_fields.select(&:enabled?)
     UserFieldsInFormService.add_user_fields_to_form(fields, participation_method, custom_form)

--- a/back/app/services/idea_custom_fields_service.rb
+++ b/back/app/services/idea_custom_fields_service.rb
@@ -56,6 +56,8 @@ class IdeaCustomFieldsService
   end
 
   def fields_to_validate_on_import
+    return [] if form_has_logic?
+
     enabled_fields.select { |f| f.required? && !f.built_in? && f.supports_submission? }
   end
 
@@ -173,6 +175,10 @@ class IdeaCustomFieldsService
   end
 
   private
+
+  def form_has_logic?
+    all_fields.any? { |field| field.logic.present? && field.logic != { 'rules' => [] } }
+  end
 
   # @param fields [Enumerable<CustomField>]
   # @return [Array<CustomField>]

--- a/back/engines/commercial/bulk_import_ideas/app/controllers/bulk_import_ideas/web_api/v1/bulk_import_controller.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/controllers/bulk_import_ideas/web_api/v1/bulk_import_controller.rb
@@ -64,7 +64,17 @@ module BulkImportIdeas
       approved = 0
       not_approved = 0
       side_fx_idea_service = SideFxIdeaService.new
+      participation_context = @phase.pmethod.transitive? ? @project : @phase
+      custom_form = participation_context.custom_form || CustomForm.new(participation_context: participation_context)
+      required_custom_fields = custom_form.custom_fields
+        .select { |f| f.enabled? && f.required? && !f.built_in? && f.supports_submission? }
+
       records.each do |record|
+        # Validate required custom fields have values before approving
+        missing = required_custom_fields.any? { |f| record.custom_field_values[f.key].blank? }
+        next if missing
+
+        # Built-in field validation is handled by model validations (which run when not draft)
         if record.update(publication_status: 'published')
           approved += 1
           side_fx_idea_service.after_import(record, current_user)

--- a/back/engines/commercial/bulk_import_ideas/app/controllers/bulk_import_ideas/web_api/v1/bulk_import_controller.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/controllers/bulk_import_ideas/web_api/v1/bulk_import_controller.rb
@@ -72,7 +72,10 @@ module BulkImportIdeas
       records.each do |record|
         # Validate required custom fields have values before approving
         missing = required_custom_fields.any? { |f| record.custom_field_values[f.key].blank? }
-        next if missing
+        if missing
+          not_approved += 1
+          next
+        end
 
         # Built-in field validation is handled by model validations (which run when not draft)
         if record.update(publication_status: 'published')

--- a/back/engines/commercial/bulk_import_ideas/app/controllers/bulk_import_ideas/web_api/v1/bulk_import_controller.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/controllers/bulk_import_ideas/web_api/v1/bulk_import_controller.rb
@@ -65,7 +65,7 @@ module BulkImportIdeas
       not_approved = 0
       side_fx_idea_service = SideFxIdeaService.new
       participation_context = @phase.pmethod.transitive? ? @project : @phase
-      custom_form = participation_context.custom_form || CustomForm.new(participation_context: participation_context)
+      custom_form = participation_context.custom_form
       required_custom_fields = custom_form.custom_fields
         .select { |f| f.enabled? && f.required? && !f.built_in? && f.supports_submission? }
 

--- a/back/engines/commercial/bulk_import_ideas/app/controllers/bulk_import_ideas/web_api/v1/bulk_import_controller.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/controllers/bulk_import_ideas/web_api/v1/bulk_import_controller.rb
@@ -64,10 +64,8 @@ module BulkImportIdeas
       approved = 0
       not_approved = 0
       side_fx_idea_service = SideFxIdeaService.new
-      participation_context = @phase.pmethod.transitive? ? @project : @phase
-      custom_form = participation_context.custom_form || CustomForm.new(participation_context: participation_context)
-      required_custom_fields = custom_form.custom_fields
-        .select { |f| f.enabled? && f.required? && !f.built_in? && f.supports_submission? }
+      custom_form = @phase.pmethod.custom_form
+      required_custom_fields = IdeaCustomFieldsService.new(custom_form).fields_to_validate_on_import
 
       records.each do |record|
         # Validate required custom fields have values before approving

--- a/back/engines/commercial/bulk_import_ideas/app/controllers/bulk_import_ideas/web_api/v1/bulk_import_controller.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/controllers/bulk_import_ideas/web_api/v1/bulk_import_controller.rb
@@ -65,7 +65,7 @@ module BulkImportIdeas
       not_approved = 0
       side_fx_idea_service = SideFxIdeaService.new
       participation_context = @phase.pmethod.transitive? ? @project : @phase
-      custom_form = participation_context.custom_form
+      custom_form = participation_context.custom_form || CustomForm.new(participation_context: participation_context)
       required_custom_fields = custom_form.custom_fields
         .select { |f| f.enabled? && f.required? && !f.built_in? && f.supports_submission? }
 

--- a/front/app/containers/Admin/projects/project/inputForm/index.tsx
+++ b/front/app/containers/Admin/projects/project/inputForm/index.tsx
@@ -36,6 +36,7 @@ export const InputForm = () => {
             width="auto"
             icon="edit"
             data-cy="e2e-edit-input-form"
+            buttonStyle="admin-dark"
           >
             <FormattedMessage {...messages.editInputForm} />
           </ButtonWithLink>

--- a/front/app/containers/Admin/projects/project/inputImporter/ReviewSection/IdeaEditor/IdeaForm.tsx
+++ b/front/app/containers/Admin/projects/project/inputImporter/ReviewSection/IdeaEditor/IdeaForm.tsx
@@ -58,7 +58,10 @@ const IdeaForm = ({
 
   // Trigger validation on mount so errors show immediately
   useEffect(() => {
-    methods.trigger();
+    const timeout = setTimeout(() => {
+      methods.trigger();
+    }, 1000);
+    return () => clearTimeout(timeout);
   }, [methods]);
 
   // Ensure initial form validation state is correct

--- a/front/app/containers/Admin/projects/project/inputImporter/ReviewSection/IdeaEditor/index.tsx
+++ b/front/app/containers/Admin/projects/project/inputImporter/ReviewSection/IdeaEditor/index.tsx
@@ -133,7 +133,7 @@ const IdeaEditor = ({ ideaId, setIdeaId }: Props) => {
 
     const timeout = setTimeout(() => {
       autoSave(ideaId, ideaFormStatePerIdea[ideaId]);
-    }, 1000);
+    }, 500);
 
     return () => clearTimeout(timeout);
   }, [ideaId, ideaFormStatePerIdea, autoSave]);

--- a/front/app/containers/Admin/projects/project/inputImporter/ReviewSection/IdeaEditor/index.tsx
+++ b/front/app/containers/Admin/projects/project/inputImporter/ReviewSection/IdeaEditor/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import {
   Box,
@@ -119,6 +119,24 @@ const IdeaEditor = ({ ideaId, setIdeaId }: Props) => {
       [ideaId]: ideaFormData,
     }));
   };
+
+  // Auto-save form edits to the backend so that "Approve All" picks up changes
+  const autoSave = useCallback(
+    (id: string, formData: FormValues) => {
+      updateIdea({ id, requestBody: formData, skipRefetchCounts: true });
+    },
+    [updateIdea]
+  );
+
+  useEffect(() => {
+    if (!ideaId || !(ideaId in ideaFormStatePerIdea)) return;
+
+    const timeout = setTimeout(() => {
+      autoSave(ideaId, ideaFormStatePerIdea[ideaId]);
+    }, 1000);
+
+    return () => clearTimeout(timeout);
+  }, [ideaId, ideaFormStatePerIdea, autoSave]);
 
   const userFormDataValid = isUserFormDataValid(userFormData);
 

--- a/front/app/containers/Admin/projects/project/inputImporter/ReviewSection/PDFViewer.tsx
+++ b/front/app/containers/Admin/projects/project/inputImporter/ReviewSection/PDFViewer.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import { Box, colors } from '@citizenlab/cl2-component-library';
 import { pdfjs, Document, Page } from 'react-pdf';
@@ -43,10 +43,13 @@ const PDFViewer = ({ file, ideaId }: Props) => {
   };
 
   const jwt = getJwt();
-  const fileWithHeaders = {
-    url: file,
-    httpHeaders: { Authorization: jwt },
-  };
+  const fileWithHeaders = useMemo(
+    () => ({
+      url: file,
+      httpHeaders: { Authorization: jwt },
+    }),
+    [file, jwt]
+  );
 
   return (
     <>

--- a/front/app/containers/Admin/projects/project/inputImporter/ReviewSection/PDFViewer.tsx
+++ b/front/app/containers/Admin/projects/project/inputImporter/ReviewSection/PDFViewer.tsx
@@ -61,7 +61,11 @@ const PDFViewer = ({ file, ideaId }: Props) => {
         background={colors.grey100}
         p="12px"
       >
-        <Document file={fileWithHeaders} onLoadSuccess={handleLoadSuccess}>
+        <Document
+          key={ideaId}
+          file={fileWithHeaders}
+          onLoadSuccess={handleLoadSuccess}
+        >
           {pagesInDocument &&
             [...Array(pagesInDocument)].map((_, pageIndex) => (
               <FullWidthPage key={pageIndex}>

--- a/front/app/containers/Admin/projects/project/inputImporter/ReviewSection/index.tsx
+++ b/front/app/containers/Admin/projects/project/inputImporter/ReviewSection/index.tsx
@@ -5,7 +5,6 @@ import {
   Title,
   Text,
   colors,
-  stylingConsts,
   Spinner,
 } from '@citizenlab/cl2-component-library';
 import { useParams } from 'react-router-dom';
@@ -160,7 +159,8 @@ const ReviewSection = ({
       </Box>
 
       <Box
-        h={`calc(100vh - ${stylingConsts.mobileMenuHeight}px - 100px)`}
+        flex="1"
+        minHeight="0"
         display="flex"
         px="40px"
         justifyContent="space-between"

--- a/front/app/containers/Admin/projects/project/inputImporter/ReviewSection/index.tsx
+++ b/front/app/containers/Admin/projects/project/inputImporter/ReviewSection/index.tsx
@@ -123,45 +123,40 @@ const ReviewSection = ({
         </Title>
       </Box>
 
-      <Box
-        px="25px"
-        borderBottom={`5px ${colors.grey200} solid`}
-        display="flex"
-      >
-        <Box w="100%" display="flex" alignItems="center">
-          {approvals.not_approved === 0 ? (
-            <>
-              <Box px="15px" py="10px">
-                <ButtonWithLink
-                  bgColor={colors.primary}
-                  icon="check"
-                  processing={isApproving}
-                  disabled={isApproving || importing}
-                  onClick={handleApproveAll}
-                >
-                  <FormattedMessage {...messages.approveAllInputs} />
-                </ButtonWithLink>
-              </Box>
-              <Box>
-                <Text>
-                  <FormattedMessage
-                    {...messages.inputsImported}
-                    values={{ numIdeas }}
-                  />
-                </Text>
-              </Box>
-            </>
-          ) : (
-            <Error
-              text={formatMessage(messages.inputsNotApproved, {
-                numNotApproved: approvals.not_approved,
-              })}
-              marginTop="0px"
-              showBackground={false}
-              showIcon={true}
-            />
-          )}
+      <Box px="25px" borderBottom={`5px ${colors.grey200} solid`}>
+        <Box display="flex">
+          <Box w="100%" display="flex" alignItems="center">
+            <Box px="15px" py="10px">
+              <ButtonWithLink
+                bgColor={colors.primary}
+                icon="check"
+                processing={isApproving}
+                disabled={isApproving || importing}
+                onClick={handleApproveAll}
+              >
+                <FormattedMessage {...messages.approveAllInputs} />
+              </ButtonWithLink>
+            </Box>
+            <Box>
+              <Text>
+                <FormattedMessage
+                  {...messages.inputsImported}
+                  values={{ numIdeas }}
+                />
+              </Text>
+            </Box>
+          </Box>
         </Box>
+        {approvals.not_approved > 0 && (
+          <Error
+            text={formatMessage(messages.inputsNotApproved, {
+              numNotApproved: approvals.not_approved,
+            })}
+            marginTop="0px"
+            showBackground={false}
+            showIcon={true}
+          />
+        )}
       </Box>
 
       <Box


### PR DESCRIPTION
# Changelog
## Fixed
- [TAN-7348] Fix "approve all" button approves invalid FormSync imports (now it skips any invalid inputs + shows error to user). Note: This does not work for surveys with logic though yet.
