### PR TITLE
TAN-7408: fix all phases filter

### DIFF
--- a/front/app/components/admin/PostManager/InputManager.tsx
+++ b/front/app/components/admin/PostManager/InputManager.tsx
@@ -168,8 +168,8 @@ const InputManager = ({
     setParams({ 'page[number]': 1, feedback_needed: feedbackNeeded });
   };
 
-  const onChangePhase = (phase: string) => {
-    setParams({ 'page[number]': 1, phase });
+  const onChangePhase = (phase: string | null) => {
+    setParams({ 'page[number]': 1, phase: phase ?? undefined });
   };
 
   const onChangeProjects = (projects: string[]) => {

--- a/front/app/components/admin/PostManager/components/FilterSidebar/FilterRadioButton/index.tsx
+++ b/front/app/components/admin/PostManager/components/FilterSidebar/FilterRadioButton/index.tsx
@@ -51,7 +51,7 @@ const FilterRadioButton = ({
         checked={isSelected}
         onChange={onChange}
       />
-      <Label htmlFor={id} onClick={onChange} selected={isSelected}>
+      <Label htmlFor={id} selected={isSelected}>
         {labelContent}
       </Label>
     </>

--- a/front/app/components/admin/PostManager/useInputManagerSearchParams.ts
+++ b/front/app/components/admin/PostManager/useInputManagerSearchParams.ts
@@ -41,11 +41,13 @@ const useInputManagerSearchParams = (context: {
       ? Math.max(1, parseInt(pageRaw, 10)) || undefined // avoid NaNs
       : undefined;
 
+    const phaseParam = getParam('phase');
+
     return {
       projects,
       input_topics: inputTopics,
       feedback_needed: boolean(getParam('feedback_needed')),
-      phase: getParam('phase') || context.phaseId,
+      phase: phaseParam === 'all' ? undefined : phaseParam || context.phaseId,
       sort: (getParam('sort') || 'new') as Sort,
       tab: getParam('tab') as TFilterMenu | undefined,
       search: getParam('search'),
@@ -118,8 +120,12 @@ const useInputManagerSearchParams = (context: {
       }
 
       if ('phase' in newParams) {
-        if (newParams.phase && newParams.phase !== context.phaseId) {
-          toUpdate.phase = newParams.phase;
+        const phase = newParams.phase;
+        if (!phase) {
+          // "All phases" selected
+          toUpdate.phase = 'all';
+        } else if (phase !== context.phaseId) {
+          toUpdate.phase = phase;
         } else {
           toRemove.push('phase');
         }


### PR DESCRIPTION
# Changelog

## Fixed
- "All Phases" filter in admin ideation view was unresponsive — clicking it had no effect because the phase URL param always fell back to the current phase context, preventing the filter from clearing
