### PR TITLE
TAN-7142 - Fixed buttons in forms so the correct submit button is called on 'Enter'

### DIFF
--- a/front/app/components/CustomFieldsForm/Fields/MapField/components/RemoveAnswerButton.tsx
+++ b/front/app/components/CustomFieldsForm/Fields/MapField/components/RemoveAnswerButton.tsx
@@ -19,6 +19,7 @@ const RemoveAnswerButton = ({ mapView, handleMultiPointChange }: Props) => {
   return (
     <Box display="flex" justifyContent="center" mt="12px">
       <Button
+        type="button"
         icon="close"
         buttonStyle="secondary"
         p="4px"

--- a/front/app/components/CustomFieldsForm/Fields/MatrixField/Matrix.tsx
+++ b/front/app/components/CustomFieldsForm/Fields/MatrixField/Matrix.tsx
@@ -257,6 +257,7 @@ const Matrix = ({ value: data, question, onChange }: Props) => {
       {data !== undefined && (
         <Box display="flex">
           <Button
+            type="button"
             p="0px"
             buttonStyle="text"
             textColor={theme.colors.textPrimary}

--- a/front/app/components/CustomFieldsForm/Fields/RankingField/Ranking.tsx
+++ b/front/app/components/CustomFieldsForm/Fields/RankingField/Ranking.tsx
@@ -118,6 +118,7 @@ const Ranking = ({ value: data, question, onChange }: Props) => {
         {data !== undefined && (
           <Box display="flex">
             <Button
+              type="button"
               p="0px"
               buttonStyle="text"
               textColor={theme.colors.textPrimary}

--- a/front/app/components/CustomFieldsForm/Fields/RatingField/Rating.tsx
+++ b/front/app/components/CustomFieldsForm/Fields/RatingField/Rating.tsx
@@ -106,6 +106,7 @@ const Rating = ({ value: data, question, onChange }: Props) => {
                 minWidth={getButtonWidth()}
               >
                 <Button
+                  type="button"
                   py="12px"
                   id={`${inputId}-option-${visualIndex}`}
                   tabIndex={-1}

--- a/front/app/components/CustomFieldsForm/Fields/SentimentScaleField/TableHead.tsx
+++ b/front/app/components/CustomFieldsForm/Fields/SentimentScaleField/TableHead.tsx
@@ -62,6 +62,7 @@ const TableHead = ({
             <Td py="4px" key={`${id}-radio-${visualIndex}`}>
               <Box display="flex" flexDirection="column" alignItems="center">
                 <Button
+                  type="button"
                   p="0px"
                   m="0px"
                   id={`${id}-linear-scale-option-${visualIndex}`}

--- a/front/app/components/CustomFieldsForm/PageControlButtons/index.tsx
+++ b/front/app/components/CustomFieldsForm/PageControlButtons/index.tsx
@@ -213,6 +213,7 @@ const PageControlButtons = ({
       <Box display="flex" justifyContent="center" alignItems="center">
         {hasPreviousPage && pageVariant !== 'after-submission' && (
           <Button
+            type="button"
             onClick={handlePrevious}
             data-cy="e2e-previous-page"
             icon="chevron-left"

--- a/front/app/components/CustomFieldsForm/PostParticipationBox/index.tsx
+++ b/front/app/components/CustomFieldsForm/PostParticipationBox/index.tsx
@@ -50,6 +50,7 @@ const PostParticipationBox = ({
         />
       </Box>
       <Button
+        type="button"
         onClick={onCreateAccount}
         mt="16px"
         dataCy="post-participation-signup"

--- a/front/app/containers/MainHeader/Components/LanguageSelector/index.tsx
+++ b/front/app/containers/MainHeader/Components/LanguageSelector/index.tsx
@@ -166,6 +166,7 @@ const LanguageSelector = ({
         style={{ marginLeft: isPhoneOrSmaller || isRtl ? '16px' : undefined }}
       >
         <DropdownButton
+          type="button"
           className="e2e-language-dropdown-toggle"
           aria-expanded={dropdownOpened}
         >
@@ -193,6 +194,7 @@ const LanguageSelector = ({
 
                 return (
                   <ListItem
+                    type="button"
                     key={tenantLocale}
                     onClick={handleLanguageSelect(tenantLocale)}
                     className={`e2e-langage-${tenantLocale} ${


### PR DESCRIPTION
Root cause: HTML `<button>` by default is of type `submit` and there are several buttons in form components - eg sentiment scale, rating questions, reset matrix questions. Now the only submit button should be the actual form submit button

# Changelog
- Stopped sentiment scale, rating questions from changing when pressing 'Enter' in text questions - now does the accessible browser default of submitting the form 