### PR TITLE
TAN-5383 - Stop ranking questions in random order reshuffling on re-render

### DIFF
--- a/front/app/components/CustomFieldsForm/Fields/RankingField/Ranking.tsx
+++ b/front/app/components/CustomFieldsForm/Fields/RankingField/Ranking.tsx
@@ -59,10 +59,9 @@ const Ranking = ({ value: data, question, onChange }: Props) => {
 
   if (!question.options) return null;
 
-  const questionOptions = questionOptionsRef.current!;
-
   // If form data present, get options in that ranking order.
   // Otherwise, get option order from the question.
+  const questionOptions = questionOptionsRef.current!;
   const options = data
     ? getOptionsFromData(data, questionOptions)
     : questionOptions;

--- a/front/app/components/CustomFieldsForm/Fields/RankingField/Ranking.tsx
+++ b/front/app/components/CustomFieldsForm/Fields/RankingField/Ranking.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 
 import { Box, Button, IOption, Text } from '@citizenlab/cl2-component-library';
 import styled, { useTheme } from 'styled-components';
@@ -46,16 +46,23 @@ const Ranking = ({ value: data, question, onChange }: Props) => {
   const localize = useLocalize();
   const theme = useTheme();
 
+  // Compute randomized options just once and cache in a ref so that
+  // re-renders (e.g. typing in another field) don't re-shuffle.
+  const questionOptionsRef = useRef<IOption[] | null>(null);
+  if (questionOptionsRef.current === null && question.options) {
+    questionOptionsRef.current = extractOptions(
+      question,
+      localize,
+      question.random_option_ordering
+    );
+  }
+
   if (!question.options) return null;
+
+  const questionOptions = questionOptionsRef.current!;
 
   // If form data present, get options in that ranking order.
   // Otherwise, get option order from the question.
-  const questionOptions: IOption[] = extractOptions(
-    question,
-    localize,
-    question.random_option_ordering
-  );
-
   const options = data
     ? getOptionsFromData(data, questionOptions)
     : questionOptions;


### PR DESCRIPTION
# Changelog
## Fixed
- Fixed random order ranking questions reordering when you type in another field
