### PR TITLE
TAN-7125 Make Haiku model regional

### DIFF
--- a/back/engines/commercial/analysis/app/lib/analysis/LLM/claude_haiku_45.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/LLM/claude_haiku_45.rb
@@ -3,7 +3,7 @@ module Analysis
     class ClaudeHaiku45 < RubyLLM
       # The model ID as returned by RubyLLM.models.chat_models
       def model
-        'eu.anthropic.claude-haiku-4-5-20251001-v1:0'
+        ENV.fetch('BEDROCK_HAIKU_MODEL', 'eu.anthropic.claude-haiku-4-5-20251001-v1:0')
       end
 
       def self.family


### PR DESCRIPTION
This was an oversight which is currently breaking idea classification (as part of the idea feed) in the US

# Changelog
## Fixed
- Idea classification as part of automated live clustering (Perspectives) now works out of the box in non-EU regions