### PR TITLE
Add Docker Compose debug setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build reset-dev-env migrate be-up fe-up up c rails-console rails-console-exec e2e-setup e2e-setup-and-up e2e-run-test e2e-ci-env-setup e2e-ci-env-setup-and-up e2e-ci-env-run-test ci-regenerate-templates ci-trigger-build ci-run-e2e release_pr
+.PHONY: build reset-dev-env migrate be-up be-up-debug fe-up up c rails-console rails-console-exec e2e-setup e2e-setup-and-up e2e-run-test e2e-ci-env-setup e2e-ci-env-setup-and-up e2e-ci-env-run-test ci-regenerate-templates ci-trigger-build ci-run-e2e release_pr
 
 # You can run this file with `make` command:
 # make reset-dev-env
@@ -32,6 +32,9 @@ migrate:
 
 be-up:
 	docker compose up
+
+be-up-debug:
+	docker compose -f docker-compose.yml -f docker-compose.debug.yml up
 
 fe-up:
 	cd front && npm start

--- a/back/Gemfile
+++ b/back/Gemfile
@@ -22,6 +22,7 @@ group :development, :test do
   gem 'ricecream', '~> 0.2.1'
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
+  gem 'debug', require: false
   gem 'pry'
   gem 'pry-byebug'
   gem 'pry-rails'

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -621,6 +621,9 @@ GEM
       database_cleaner-core (~> 2.0)
     database_cleaner-core (2.0.1)
     date (3.4.1)
+    debug (1.11.1)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     debug_inspector (1.1.0)
     declarative (0.0.20)
     diff-lcs (1.5.1)
@@ -1361,6 +1364,7 @@ DEPENDENCIES
   custom_maps!
   dalli (~> 3.2.8)
   database_cleaner (~> 2.1.0)
+  debug
   document_annotation!
   docx (~> 0.3.0)
   drb

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -1,0 +1,12 @@
+services:
+  web:
+    command: bundle exec rdbg -O -n --host 0.0.0.0 --port 12345 -c -- bundle exec puma -C config/puma.rb
+    environment:
+      - WEB_CONCURRENCY=0
+    ports:
+      - "12345:12345"
+      - "12347:12347"
+  que:
+    command: bundle exec rdbg -O -n --host 0.0.0.0 --port 12346 -c -- bundle exec que
+    ports:
+      - "12346:12346"


### PR DESCRIPTION
## Summary
- Add `docker-compose.debug.yml` overlay to run the backend with Ruby's `rdbg` debugger attached to `web` and `que`
- Add `make be-up-debug` target to easily start the backend in debug mode
- Add `debug` gem with `require: false` to prevent it from auto-loading during Rails boot (which causes port conflicts with `rdbg`)

See the [Notion document](https://www.notion.so/govocal/Debugging-the-Backend-in-VS-Code-3299663b7b268098a496e5966c1e5125?source=copy_link) for full setup instructions.