### PR TITLE
Test flat output schema & reasoning keys

### DIFF
--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/parsers/pdf/form_sync_schema_builder.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/parsers/pdf/form_sync_schema_builder.rb
@@ -176,40 +176,25 @@ module BulkImportIdeas::Parsers::Pdf
         field[attr_name][@locale.to_s]
       end.compact_blank
 
-      sub_properties = {}
-      sub_required = []
-      statement_mapping = {}
-
       field.matrix_statements.each_with_index do |statement, index|
         sub_key = "#{question_key}.#{index + 1}"
         statement_title = statement.title_multiloc[@locale.to_s]
 
-        sub_properties[sub_key] = {
+        properties[sub_key] = {
           type: 'string',
           description: 'The answer represented by the checkbox the respondent checked corresponding to the statement ' \
                        "'#{statement_title}'. Return an empty string if the statement was left unanswered. " \
                        "Return `#{NOT_FOUND}` if the question was not in the document.",
           enum: labels + ['', NOT_FOUND]
         }
-        sub_required << sub_key
-        statement_mapping[sub_key] = statement.key
+        required << sub_key
+        @key_mapping[sub_key] = {
+          type: :matrix_statement,
+          field_key: field.key,
+          statement_key: statement.key,
+          label_to_index: labels.each_with_index.to_h { |label, i| [label, i + 1] }
+        }
       end
-
-      properties[question_key] = {
-        type: 'object',
-        description: "The answers represented by the table of matrix questions under question #{question_num}: " \
-                     "'#{title}'.",
-        additionalProperties: false,
-        required: sub_required,
-        properties: sub_properties
-      }
-      required << question_key
-      @key_mapping[question_key] = {
-        type: :matrix,
-        field_key: field.key,
-        statements: statement_mapping,
-        label_to_index: labels.each_with_index.to_h { |label, i| [label, i + 1] }
-      }
     end
 
     def add_checkbox_property(field, question_key, question_num, properties, required)

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/parsers/pdf/form_sync_schema_builder.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/parsers/pdf/form_sync_schema_builder.rb
@@ -177,8 +177,15 @@ module BulkImportIdeas::Parsers::Pdf
       end.compact_blank
 
       field.matrix_statements.each_with_index do |statement, index|
-        sub_key = "#{question_key}.#{index + 1}"
+        sub_key = "#{question_key}_#{index + 1}"
+        reasoning_key = "#{sub_key}_reasoning"
         statement_title = statement.title_multiloc[@locale.to_s]
+
+        properties[reasoning_key] = {
+          type: 'string',
+          description: "For the row '#{statement_title}', describe which column (counting from left) the mark is in."
+        }
+        required << reasoning_key
 
         properties[sub_key] = {
           type: 'string',

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/parsers/pdf/llm_form_parser.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/parsers/pdf/llm_form_parser.rb
@@ -30,7 +30,7 @@ module BulkImportIdeas::Parsers::Pdf
       message = Analysis::LLM::Message.new(prompt, pdf_file)
 
       begin
-        response = llm.chat(message)
+        response = llm.chat(message, response_schema: schema_builder.output_schema)
       rescue RubyLLM::BadRequestError => e
         raise unless e.message.include?('grammar is too large')
 
@@ -66,9 +66,11 @@ module BulkImportIdeas::Parsers::Pdf
           next if not_found?(answer)
 
           result[field_info[:field_key]] = normalize_answer(answer)
-        when :matrix
-          matrix_answer = build_matrix_answer(answer, field_info)
-          result[field_info[:field_key]] = matrix_answer if matrix_answer.present?
+        when :matrix_statement
+          next if not_found?(answer) || answer.blank?
+
+          result[field_info[:field_key]] ||= {}
+          result[field_info[:field_key]][field_info[:statement_key]] = answer
         end
       end
 
@@ -85,6 +87,7 @@ module BulkImportIdeas::Parsers::Pdf
 
         result[statement_key] = sub_answer
       end
+      Rails.logger.info("[FormSync] Mapped fields: #{result.inspect}")
       result
     end
 

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/parsers/pdf/llm_form_parser.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/parsers/pdf/llm_form_parser.rb
@@ -87,7 +87,6 @@ module BulkImportIdeas::Parsers::Pdf
 
         result[statement_key] = sub_answer
       end
-      Rails.logger.info("[FormSync] Mapped fields: #{result.inspect}")
       result
     end
 


### PR DESCRIPTION
# Description
Testing out some changes in order to get structured output working for matrix fields.

# Changes include
- De-nesting matrix sub questions, so just a flat schema
- Adding a new "_reasoning" key as well to provide more context to the LLM