### PR TITLE
TAN-7432: Fix sign-up form password autocomplete attribute

### DIFF
--- a/front/app/containers/Authentication/steps/BuiltInFields/index.tsx
+++ b/front/app/containers/Authentication/steps/BuiltInFields/index.tsx
@@ -155,7 +155,7 @@ const BuiltInFields = ({
                 name="password"
                 id="password"
                 label={formatMessage(sharedMessages.password)}
-                autocomplete="current-password"
+                autocomplete="new-password"
                 required
               />
             </Box>

--- a/front/app/containers/Authentication/steps/InviteSignUp/index.tsx
+++ b/front/app/containers/Authentication/steps/InviteSignUp/index.tsx
@@ -166,7 +166,7 @@ const InviteSignUp = ({ state, loading, setError, onSubmit }: Props) => {
             <PasswordInput
               name="password"
               id="password"
-              autocomplete="current-password"
+              autocomplete="new-password"
               required
             />
           </Box>


### PR DESCRIPTION
# Changelog

## Fixed
- Changed `autocomplete="current-password"` to `autocomplete="new-password"` on the password field in the sign-up and invite sign-up forms. The incorrect attribute caused browsers to autofill existing passwords instead of prompting users to create a new one.
