### PR TITLE
TAN-7429 Allow accepting cookies through URL parameter

### DIFF
--- a/front/app/components/ConsentManager/index.tsx
+++ b/front/app/components/ConsentManager/index.tsx
@@ -11,7 +11,12 @@ import { useModalQueue } from 'containers/App/ModalQueue';
 
 import eventEmitter from 'utils/eventEmitter';
 
-import { getConsent, ISavedDestinations } from './consent';
+import {
+  getConsent,
+  IConsentCookie,
+  ISavedDestinations,
+  setConsent,
+} from './consent';
 import { useConsentRequired, getCurrentPreferences } from './utils';
 
 const ConsentManager = () => {
@@ -21,8 +26,27 @@ const ConsentManager = () => {
 
   const [searchParams] = useSearchParams();
   const from = searchParams.get('from');
+  const bypassCookieConsent =
+    searchParams.get('yes-I-accept-cookies') === 'true';
 
   const isConsentRequired = useConsentRequired();
+
+  // Allow bypassing cookie consent via URL parameter,
+  // e.g. for web scrapers/archiving purposes.
+  useEffect(() => {
+    if (!bypassCookieConsent) return;
+
+    const consent = getConsent();
+    if (consent) return;
+
+    const allAccepted: IConsentCookie = {
+      functional: true,
+      analytics: true,
+      advertising: true,
+      savedChoices: {},
+    };
+    setConsent(allAccepted);
+  }, [bypassCookieConsent]);
 
   // Code that should run every time the app is first loaded.
   // Initialize everything that needs to be initialized,
@@ -51,17 +75,17 @@ const ConsentManager = () => {
 
   useEffect(() => {
     /*
-      When we click the link to the cookie policy in the modal, 
-      we wouldn't be able to read the cookie policy without this, 
+      When we click the link to the cookie policy in the modal,
+      we wouldn't be able to read the cookie policy without this,
       because the modal is on top of the page.
       Search the codebase for 'from=cookie-modal' to see where this is used.
     */
-    if (from === 'cookie-modal') {
+    if (from === 'cookie-modal' || bypassCookieConsent) {
       removeModal('consent-modal');
     } else if (isConsentRequired) {
       queueModal('consent-modal');
     }
-  }, [from, isConsentRequired, queueModal, removeModal]);
+  }, [from, bypassCookieConsent, isConsentRequired, queueModal, removeModal]);
 
   useObserveEvent('openConsentManager', () => {
     queueModal('consent-modal');

--- a/front/cypress/e2e/auth/cookie_consent.cy.ts
+++ b/front/cypress/e2e/auth/cookie_consent.cy.ts
@@ -31,6 +31,14 @@ describe('Cookie consent form for signed-in users', () => {
   });
 });
 
+describe('Cookie consent bypass via URL parameter', () => {
+  it('Does not show the cookie consent modal when yes-I-accept-cookies=true is in the URL', () => {
+    cy.clearCookies();
+    cy.visit('/?yes-I-accept-cookies=true');
+    cy.dataCy('e2e-manage-preferences-btn').should('not.exist');
+  });
+});
+
 describe('Cookie consent form for signed-in admins', () => {
   beforeEach(() => {
     cy.clearCookies();


### PR DESCRIPTION
# Changelog
## Added
- When adding `?yes-i-accept-cookies=true` to the URL parameters, the cookie consent is skipped and automatically accepted. We'll automatically set this when prerendering, to not include the cookie consent in the output of archiving scraping tools, which are common in The Netherlands.