### PR TITLE
TAN-7433: Associate Continue button with email consent message on sign up

### DIFF
--- a/front/app/containers/Authentication/steps/Policies/PoliciesForm.tsx
+++ b/front/app/containers/Authentication/steps/Policies/PoliciesForm.tsx
@@ -65,6 +65,11 @@ const PoliciesForm = ({ loading, showByContinuingText, onSubmit }: Props) => {
           width="100%"
           disabled={loading}
           processing={loading}
+          ariaDescribedby={
+            showByContinuingText !== false
+              ? 'email-consent-description'
+              : undefined
+          }
         >
           {formatMessage(sharedMessages.continue)}
         </ButtonWithLink>

--- a/front/app/containers/Authentication/steps/Policies/PoliciesMarkup.tsx
+++ b/front/app/containers/Authentication/steps/Policies/PoliciesMarkup.tsx
@@ -91,7 +91,13 @@ const PoliciesMarkup = ({ showByContinuingText = true }: Props) => {
         />
       </Box>
       {showByContinuingText && (
-        <Text mt="24px" mb="0px" fontSize="s" color="tenantText">
+        <Text
+          id="email-consent-description"
+          mt="24px"
+          mb="0px"
+          fontSize="s"
+          color="tenantText"
+        >
           {formatMessage(messages.byContinuing)}
         </Text>
       )}


### PR DESCRIPTION
# Changelog

## Fixed
- a11y: Added `aria-describedby` to the Continue button on the sign-up policies step, associating it with the email consent message so screen readers announce the consent text when the button is focused.
