### PR TITLE
TAN-7140 - Fixed field descriptions & titles persisting after a field has been deleted

### DIFF
--- a/front/app/components/FormBuilder/components/FormFields/FormField/index.tsx
+++ b/front/app/components/FormBuilder/components/FormFields/FormField/index.tsx
@@ -10,7 +10,7 @@ import {
   Tooltip,
 } from '@citizenlab/cl2-component-library';
 import { rgba } from 'polished';
-import { useFormContext, useFieldArray } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
 import styled from 'styled-components';
 
 import {
@@ -31,6 +31,7 @@ import { useIntl } from 'utils/cl-intl';
 import { generateTempId } from 'utils/helperUtils';
 
 import { FlexibleRow } from '../../FlexibleRow';
+import { FieldArrayOperations } from '../types';
 import { getFieldBackgroundColor } from '../utils';
 
 import LocationDeletionModal from './components/LocationDeletionModal';
@@ -55,6 +56,7 @@ type Props = {
   fieldNumbers: Record<string, number>;
   closeSettings: (triggerAutosave?: boolean) => void;
   conflicts?: Conflict[];
+  fieldArrayOperations: FieldArrayOperations;
 };
 
 export const FormField = ({
@@ -65,6 +67,7 @@ export const FormField = ({
   fieldNumbers,
   closeSettings,
   conflicts,
+  fieldArrayOperations,
 }: Props) => {
   const {
     watch,
@@ -78,9 +81,7 @@ export const FormField = ({
   const [showLocationDeleteModal, setShowLocationDeleteModal] = useState(false);
   const formCustomFields: IFlatCustomField[] = watch('customFields');
   const index = formCustomFields.findIndex((f) => f.id === field.id);
-  const { insert, move, remove } = useFieldArray({
-    name: 'customFields',
-  });
+  const { insert, move, remove } = fieldArrayOperations;
   const { formEndPageLogicOption, displayBuiltInFields } = builderConfig;
   const { mutateAsync: duplicateMapConfig } = useDuplicateMapConfig();
 

--- a/front/app/components/FormBuilder/components/FormFields/index.tsx
+++ b/front/app/components/FormBuilder/components/FormFields/index.tsx
@@ -21,6 +21,7 @@ import { getFieldNumbers } from '../utils';
 
 import { fieldAreaDNDType } from './constants';
 import { FormField } from './FormField';
+import { FieldArrayOperations } from './types';
 
 interface FormFieldsProps {
   onEditField: (field: IFlatCustomFieldWithIndex) => void;
@@ -31,6 +32,7 @@ interface FormFieldsProps {
   selectedFieldId?: string;
   builderConfig: FormBuilderConfig;
   closeSettings: (triggerAutosave?: boolean) => void;
+  fieldArrayOperations: FieldArrayOperations;
 }
 
 const FormFields = ({
@@ -38,6 +40,7 @@ const FormFields = ({
   selectedFieldId,
   builderConfig,
   closeSettings,
+  fieldArrayOperations,
 }: FormFieldsProps) => {
   const { watch } = useFormContext();
   const formCustomFields: IFlatCustomField[] = watch('customFields');
@@ -85,6 +88,7 @@ const FormFields = ({
                   fieldNumbers={fieldNumbers}
                   closeSettings={closeSettings}
                   conflicts={conflictsByPage[grouping.groupElement.id]}
+                  fieldArrayOperations={fieldArrayOperations}
                 />
                 <Drop
                   key={grouping.id}
@@ -111,6 +115,7 @@ const FormFields = ({
                                 builderConfig={builderConfig}
                                 fieldNumbers={fieldNumbers}
                                 closeSettings={closeSettings}
+                                fieldArrayOperations={fieldArrayOperations}
                               />
                             </Drag>
                           ) : (
@@ -139,6 +144,7 @@ const FormFields = ({
                 builderConfig={builderConfig}
                 fieldNumbers={fieldNumbers}
                 closeSettings={closeSettings}
+                fieldArrayOperations={fieldArrayOperations}
               />
             </Box>
           </>

--- a/front/app/components/FormBuilder/components/FormFields/types.ts
+++ b/front/app/components/FormBuilder/components/FormFields/types.ts
@@ -1,0 +1,6 @@
+export interface FieldArrayOperations {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  insert: (index: number, value: any) => void;
+  move: (indexA: number, indexB: number) => void;
+  remove: (index?: number | number[]) => void;
+}

--- a/front/app/components/FormBuilder/edit/index.tsx
+++ b/front/app/components/FormBuilder/edit/index.tsx
@@ -129,7 +129,7 @@ const FormEdit = ({
     setValue,
   } = methods;
 
-  const { move, replace, insert } = useFieldArray({
+  const { move, replace, insert, remove } = useFieldArray({
     name: 'customFields',
     control,
   });
@@ -366,6 +366,7 @@ const FormEdit = ({
                         handleDragEnd={reorderFields}
                         builderConfig={builderConfig}
                         closeSettings={closeSettings}
+                        fieldArrayOperations={{ insert, move, remove }}
                       />
                     </Box>
                   </Box>


### PR DESCRIPTION
Claude helped me:

Root Cause: FormField component created its own useFieldArray({ name: 'customFields' }) hook, while the parent FormEdit also had one for the same name. React Hook Form https://react-hook-form.com/docs/usefieldarray against having multiple useFieldArray instances with the same name, as it can cause state synchronization issues.                                                                                                                                                              
                                                                                                                                                                                                                                                         
When remove() was called from FormField's separate useFieldArray instance, the form values didn't properly shift - the remaining fields retained stale values from the deleted field's position. This caused Q2 (now at Q1's position) to display Q1's old title and description.

# Changelog
## Fixed
- Fixed issue in form editor where titles and descriptions of deleted fields would persist in the form after a field has been deleted
