### PR TITLE
TAN-5977 - Fix survey copy when logic has 'no_answer' or 'any_other_answer'

### DIFF
--- a/back/app/services/idea_custom_fields_service.rb
+++ b/back/app/services/idea_custom_fields_service.rb
@@ -120,6 +120,7 @@ class IdeaCustomFieldsService
   def duplicate_all_fields
     fields = all_fields
     logic_id_map = {}
+    logic_catch_all_values = %w[any_other_answer no_answer]
     copied_fields = fields.map do |field|
       # Duplicate fields to return with a new id
       copied_field = field.dup
@@ -165,7 +166,7 @@ class IdeaCustomFieldsService
     copied_fields.map do |field|
       if field.logic['rules']
         field.logic['rules'].map! do |rule|
-          rule['if'] = logic_id_map[rule['if']] unless %w[any_other_answer no_answer].include?(rule['if'])
+          rule['if'] = logic_id_map[rule['if']] unless logic_catch_all_values.include?(rule['if'])
           rule['goto_page_id'] = logic_id_map[rule['goto_page_id']]
           rule
         end

--- a/back/app/services/idea_custom_fields_service.rb
+++ b/back/app/services/idea_custom_fields_service.rb
@@ -165,7 +165,7 @@ class IdeaCustomFieldsService
     copied_fields.map do |field|
       if field.logic['rules']
         field.logic['rules'].map! do |rule|
-          rule['if'] = logic_id_map[rule['if']]
+          rule['if'] = logic_id_map[rule['if']] unless %w[any_other_answer no_answer].include?(rule['if'])
           rule['goto_page_id'] = logic_id_map[rule['goto_page_id']]
           rule
         end

--- a/back/spec/services/idea_custom_fields_service_spec.rb
+++ b/back/spec/services/idea_custom_fields_service_spec.rb
@@ -284,7 +284,12 @@ describe IdeaCustomFieldsService do
         _multi_select_option = create(:custom_field_option, custom_field: multi_select_field)
         map_field = create(:custom_field_point, resource: custom_form, map_config: create(:map_config))
         map_field_no_config = create(:custom_field_point, resource: custom_form)
-        select_field.update!(logic: { rules: [{ if: select_option.id, goto_page_id: page3.id }] })
+        select_field.update!(logic: {
+          rules: [
+            { if: select_option.id, goto_page_id: page3.id },
+            { if: 'no_answer', goto_page_id: page3.id }
+          ]
+        })
         page2.update!(logic: { next_page_id: page3.id })
 
         expect(CustomField.count).to eq 9
@@ -303,7 +308,8 @@ describe IdeaCustomFieldsService do
         expect(fields[1].id).not_to eq select_field.id
         expect(fields[1].logic).to match({
           'rules' => [
-            { 'if' => fields[1].options[0].temp_id, 'goto_page_id' => fields[5].id }
+            { 'if' => fields[1].options[0].temp_id, 'goto_page_id' => fields[5].id },
+            { 'if' => 'no_answer', 'goto_page_id' => fields[5].id }
           ]
         })
         expect(fields[1].options[0].temp_id).to match 'TEMP-ID-'


### PR DESCRIPTION
# Changelog
## Fixed 
- Fixed duplicate existing survey functionality when logic has 'no_answer' or 'any_other_answer'
