### PR TITLE
Replacing GraphQL

### DIFF
--- a/back/engines/commercial/admin_api/app/controllers/admin_api/ideas_controller.rb
+++ b/back/engines/commercial/admin_api/app/controllers/admin_api/ideas_controller.rb
@@ -2,9 +2,34 @@
 
 module AdminApi
   class IdeasController < AdminApiController
+    def index
+      ideas = ::IdeaPolicy::Scope.new(nil, Idea)
+        .resolve
+        .includes(:idea_images)
+        .published
+
+      ideas = sort_ideas(ideas)
+      ideas = ideas.with_some_input_topics(InputTopic.where(id: params[:topics])) if params[:topics].present?
+      ideas = ideas.where(project_id: params[:projects]) if params[:projects].present?
+      ideas = ideas.limit(params[:limit]&.to_i || 5)
+
+      render json: ideas, each_serializer: AdminApi::IdeaSerializer, adapter: :json, include: [:idea_images]
+    end
+
     def show
       @idea = Idea.find(params[:id])
       render json: @idea, adapter: :json
+    end
+
+    private
+
+    def sort_ideas(ideas)
+      case params[:sort]
+      when 'trending' then TrendingIdeaService.new.sort_trending(ideas)
+      when 'popular' then ideas.order_popular
+      when 'new' then ideas.order_new
+      else ideas
+      end
     end
   end
 end

--- a/back/engines/commercial/admin_api/app/controllers/admin_api/tenants_controller.rb
+++ b/back/engines/commercial/admin_api/app/controllers/admin_api/tenants_controller.rb
@@ -15,6 +15,11 @@ module AdminApi
       render json: tenants_json
     end
 
+    def by_host
+      tenant = Tenant.find_by!(host: params[:host])
+      render json: AdminApi::TenantSerializer.new(tenant).to_json
+    end
+
     def show
       # Call #to_json explicitly, otherwise 'data' is added as root.
       render json: AdminApi::TenantSerializer.new(@tenant).to_json

--- a/back/engines/commercial/admin_api/app/serializers/admin_api/idea_serializer.rb
+++ b/back/engines/commercial/admin_api/app/serializers/admin_api/idea_serializer.rb
@@ -6,6 +6,7 @@ module AdminApi
       :title_multiloc,
       :body_multiloc,
       :slug,
+      :href,
       :published_at,
       :submitted_at,
       :project_id,
@@ -14,6 +15,10 @@ module AdminApi
       :comments_count,
       :created_at,
       :updated_at
+
+    def href
+      Frontend::UrlService.new.model_to_url(object)
+    end
 
     has_many :input_topics
     has_many :idea_images

--- a/back/engines/commercial/admin_api/app/serializers/admin_api/idea_serializer.rb
+++ b/back/engines/commercial/admin_api/app/serializers/admin_api/idea_serializer.rb
@@ -5,13 +5,18 @@ module AdminApi
     attributes :id,
       :title_multiloc,
       :body_multiloc,
+      :slug,
       :published_at,
       :submitted_at,
       :project_id,
+      :likes_count,
+      :dislikes_count,
+      :comments_count,
       :created_at,
       :updated_at
 
     has_many :input_topics
+    has_many :idea_images
     belongs_to :author
 
     class InputTopicSerializer < ActiveModel::Serializer
@@ -20,6 +25,14 @@ module AdminApi
 
     class UserSerializer < ActiveModel::Serializer
       attributes :id
+    end
+
+    class IdeaImageSerializer < ActiveModel::Serializer
+      attributes :id, :versions
+
+      def versions
+        object.image.versions.to_h { |k, v| [k.to_s, v.url] }
+      end
     end
   end
 end

--- a/back/engines/commercial/admin_api/config/routes.rb
+++ b/back/engines/commercial/admin_api/config/routes.rb
@@ -29,7 +29,7 @@ AdminApi::Engine.routes.draw do
 
   resources :invites, only: [:create]
 
-  resources :ideas, only: [:show]
+  resources :ideas, only: %i[index show]
 
   post '/graphql', to: 'graphql#execute'
 end

--- a/back/engines/commercial/admin_api/config/routes.rb
+++ b/back/engines/commercial/admin_api/config/routes.rb
@@ -2,6 +2,7 @@
 
 AdminApi::Engine.routes.draw do
   resources :tenants do
+    get :by_host, on: :collection
     get :settings_schema, on: :collection
     get :style_schema, on: :collection
     get :templates, on: :collection

--- a/back/engines/commercial/admin_api/spec/acceptance/ideas_spec.rb
+++ b/back/engines/commercial/admin_api/spec/acceptance/ideas_spec.rb
@@ -12,6 +12,65 @@ resource 'Idea', admin_api: true do
   let(:idea) { create(:idea_with_topics) }
   let(:idea_id) { idea.id }
 
+  get 'admin_api/ideas' do
+    parameter :sort, 'Sort order: trending, popular, or new', required: false
+    parameter :projects, 'Filter by project IDs', required: false
+    parameter :topics, 'Filter by topic IDs', required: false
+    parameter :limit, 'Maximum number of ideas to return', required: false
+
+    before do
+      header 'tenant', Tenant.current.id
+
+      @project = create(:project)
+      @idea_old = create(:idea, project: @project, publication_status: 'published', published_at: 3.days.ago)
+      @idea_mid = create(:idea, project: @project, publication_status: 'published', published_at: 2.days.ago)
+      @idea_new = create(:idea, project: @project, publication_status: 'published', published_at: 1.day.ago)
+      create(:idea_image, idea: @idea_new)
+      create(:idea, publication_status: 'draft') # should not appear
+    end
+
+    example_request 'List public ideas' do
+      expect(status).to eq 200
+      json_response = json_parse(response_body)
+      expect(json_response[:ideas].size).to eq 3
+    end
+
+    example 'List ideas sorted by newest' do
+      do_request(sort: 'new')
+      expect(status).to eq 200
+      json_response = json_parse(response_body)
+      ids = json_response[:ideas].pluck(:id)
+      expect(ids).to eq [@idea_new.id, @idea_mid.id, @idea_old.id]
+    end
+
+    example 'Filter ideas by project' do
+      other_project = create(:project)
+      create(:idea, project: other_project, publication_status: 'published')
+
+      do_request(projects: [@project.id])
+      expect(status).to eq 200
+      json_response = json_parse(response_body)
+      expect(json_response[:ideas].size).to eq 3
+      expect(json_response[:ideas].pluck(:project_id)).to all(eq(@project.id))
+    end
+
+    example 'Limit the number of ideas' do
+      do_request(limit: 2)
+      expect(status).to eq 200
+      json_response = json_parse(response_body)
+      expect(json_response[:ideas].size).to eq 2
+    end
+
+    example 'Ideas include images' do
+      do_request
+      expect(status).to eq 200
+      json_response = json_parse(response_body)
+      idea_with_image = json_response[:ideas].find { |i| i[:id] == @idea_new.id }
+      expect(idea_with_image[:idea_images]).to be_present
+      expect(idea_with_image[:idea_images].first[:versions]).to be_a(Hash)
+    end
+  end
+
   get 'admin_api/ideas/:idea_id' do
     example_request 'Find an idea by id' do
       expect(status).to eq 200

--- a/back/engines/commercial/admin_api/spec/acceptance/tenants_spec.rb
+++ b/back/engines/commercial/admin_api/spec/acceptance/tenants_spec.rb
@@ -35,6 +35,23 @@ resource 'Tenants', admin_api: true do
     end
   end
 
+  get 'admin_api/tenants/by_host' do
+    parameter :host, 'The hostname to look up', required: true
+
+    let(:host) { tenant.host }
+
+    example_request 'Get a tenant by hostname' do
+      assert_status 200
+      expect(json_response_body[:id]).to eq(tenant.id)
+      expect(json_response_body[:host]).to eq(tenant.host)
+    end
+
+    example 'Returns 404 for unknown host' do
+      do_request(host: 'nonexistent.example.com')
+      assert_status 404
+    end
+  end
+
   patch 'admin_api/tenants/:tenant_id' do
     with_options scope: :tenant do
       parameter :name, 'The name of the tenant'


### PR DESCRIPTION
On the backend side, we need to provide the REST Admin API endpoints that are now used by cl2-widgets. Koen and I agreed that it's better to separate responsibilities of Web API vs. Admin API, and so Web API should only be used by the frontend (and not by cl2-widgets).

With help from Claude.
