### PR TITLE
[TAN-7431] Do not show exceed seats modal if null maximum_moderators_number or number or maximum_admins_number

### DIFF
--- a/front/app/hooks/useExceedsSeats.ts
+++ b/front/app/hooks/useExceedsSeats.ts
@@ -56,8 +56,10 @@ const useExceedsSeats = () => {
           return false;
         }
 
+        const totalAdminSeats = totalSeats.totalAdminSeats;
+        if (totalAdminSeats === null) return false;
+
         const currentAdminSeats = seats.data.attributes.admins_number;
-        const totalAdminSeats = totalSeats.totalAdminSeats ?? 0;
         return currentAdminSeats + 1 > totalAdminSeats;
       }
 
@@ -68,8 +70,10 @@ const useExceedsSeats = () => {
         return false;
       }
 
+      const totalModeratorSeats = totalSeats.totalModeratorSeats;
+      if (totalModeratorSeats === null) return false;
+
       const currentModeratorSeats = seats.data.attributes.moderators_number;
-      const totalModeratorSeats = totalSeats.totalModeratorSeats ?? 0;
       return currentModeratorSeats + 1 > totalModeratorSeats;
     };
   }, [totalSeats, seats]);


### PR DESCRIPTION
For context. `null` == no limit

<img width="1052" height="247" alt="Screenshot 2026-03-23 at 15 19 28" src="https://github.com/user-attachments/assets/a0a1acb2-f059-45d7-942e-b6f11a06a238" />

Seems this was an issue when adding a roles to a regular user, but not when adding manager roles to managers (probably as an earlier check caught such cases)


# Changelog
## Fixed
- [TAN-7431] Customers with unlimited admin or manager seats can add new roles accordingly without being blocked by new seats modal.
