### PR TITLE
TAN-7438 - Explicitly define which participation methods should destroy ideas on phase destroy

### DIFF
--- a/back/app/controllers/web_api/v1/phases_controller.rb
+++ b/back/app/controllers/web_api/v1/phases_controller.rb
@@ -58,7 +58,7 @@ class WebApi::V1::PhasesController < ApplicationController
   def destroy
     sidefx.before_destroy(@phase, current_user)
     phase = ActiveRecord::Base.transaction do
-      @phase.ideas.each(&:destroy!) unless @phase.pmethod.transitive?
+      @phase.ideas.each(&:destroy!) if @phase.pmethod.destroy_ideas_on_phase_destroy?
 
       @phase.destroy
     end

--- a/back/lib/participation_method/base.rb
+++ b/back/lib/participation_method/base.rb
@@ -200,6 +200,10 @@ module ParticipationMethod
       false
     end
 
+    def destroy_ideas_on_phase_destroy?
+      false
+    end
+
     def use_reactions_as_votes?
       false
     end

--- a/back/lib/participation_method/common_ground.rb
+++ b/back/lib/participation_method/common_ground.rb
@@ -50,6 +50,10 @@ module ParticipationMethod
       true
     end
 
+    def destroy_ideas_on_phase_destroy?
+      true
+    end
+
     def supports_edits_after_publication?
       true
     end

--- a/back/lib/participation_method/community_monitor_survey.rb
+++ b/back/lib/participation_method/community_monitor_survey.rb
@@ -82,6 +82,10 @@ module ParticipationMethod
       true
     end
 
+    def destroy_ideas_on_phase_destroy?
+      true
+    end
+
     private
 
     def page_field(custom_form, key)

--- a/back/lib/participation_method/native_survey.rb
+++ b/back/lib/participation_method/native_survey.rb
@@ -116,6 +116,10 @@ module ParticipationMethod
       %i[native_survey_title_multiloc native_survey_button_multiloc].include?(attribute)
     end
 
+    def destroy_ideas_on_phase_destroy?
+      true
+    end
+
     def supports_submission?
       true
     end

--- a/back/lib/participation_method/proposals.rb
+++ b/back/lib/participation_method/proposals.rb
@@ -48,6 +48,10 @@ module ParticipationMethod
       false
     end
 
+    def destroy_ideas_on_phase_destroy?
+      true
+    end
+
     def use_reactions_as_votes?
       true
     end

--- a/back/spec/acceptance/phases_spec.rb
+++ b/back/spec/acceptance/phases_spec.rb
@@ -248,7 +248,7 @@ resource 'Phases' do
 
     post 'web_api/v1/projects/:project_id/phases' do
       with_options scope: :phase do
-        parameter :title_multiloc, 'The title of the phase in nultiple locales', required: true
+        parameter :title_multiloc, 'The title of the phase in multiple locales', required: true
         parameter :description_multiloc, 'The description of the phase in multiple languages. Supports basic HTML.', required: false
         parameter :participation_method, "The participation method of the project, either #{Phase::PARTICIPATION_METHODS.join(',')}. Defaults to ideation.", required: false
         parameter :submission_enabled, 'Can citizens submit inputs in this phase? Defaults to true', required: false
@@ -742,6 +742,19 @@ resource 'Phases' do
 
       context 'on an ideation phase' do
         let(:phase) { create(:phase, participation_method: 'ideation', project: @project) }
+
+        example 'Deleting a phase does not delete the ideas', document: false do
+          idea = create(:idea, project: @project, phases: [phase])
+
+          do_request
+
+          expect { idea.reload }.not_to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+
+      # Edge case: Historic code means a phase with ideas could be changed to an information phase
+      context 'on an information phase' do
+        let(:phase) { create(:phase, participation_method: 'information', project: @project) }
 
         example 'Deleting a phase does not delete the ideas', document: false do
           idea = create(:idea, project: @project, phases: [phase])

--- a/back/spec/lib/participation_method/common_ground_spec.rb
+++ b/back/spec/lib/participation_method/common_ground_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe ParticipationMethod::CommonGround do
 
   its(:use_reactions_as_votes?) { is_expected.to be(true) }
   its(:transitive?) { is_expected.to be(false) }
+  its(:destroy_ideas_on_phase_destroy?) { is_expected.to be(true) }
   its(:supports_status?) { is_expected.to be(false) }
   its(:supports_inputs_without_author?) { is_expected.to be(false) }
   its(:supports_submission?) { is_expected.to be(true) }

--- a/back/spec/lib/participation_method/community_monitor_survey_spec.rb
+++ b/back/spec/lib/participation_method/community_monitor_survey_spec.rb
@@ -206,6 +206,7 @@ RSpec.describe ParticipationMethod::CommunityMonitorSurvey do
   its(:supports_toxicity_detection?) { is_expected.to be false }
   its(:use_reactions_as_votes?) { is_expected.to be false }
   its(:transitive?) { is_expected.to be false }
+  its(:destroy_ideas_on_phase_destroy?) { is_expected.to be true }
   its(:form_logic_enabled?) { is_expected.to be false }
   its(:follow_idea_on_idea_submission?) { is_expected.to be false }
   its(:supports_custom_field_categories?) { is_expected.to be true }

--- a/back/spec/lib/participation_method/ideation_spec.rb
+++ b/back/spec/lib/participation_method/ideation_spec.rb
@@ -266,6 +266,7 @@ RSpec.describe ParticipationMethod::Ideation do
   its(:supports_toxicity_detection?) { is_expected.to be true }
   its(:use_reactions_as_votes?) { is_expected.to be false }
   its(:transitive?) { is_expected.to be true }
+  its(:destroy_ideas_on_phase_destroy?) { is_expected.to be false }
   its(:supports_private_attributes_in_export?) { is_expected.to be true }
   its(:form_logic_enabled?) { is_expected.to be false }
   its(:follow_idea_on_idea_submission?) { is_expected.to be true }

--- a/back/spec/lib/participation_method/information_spec.rb
+++ b/back/spec/lib/participation_method/information_spec.rb
@@ -115,6 +115,7 @@ RSpec.describe ParticipationMethod::Information do
   its(:supports_submission?) { is_expected.to be false }
   its(:supports_toxicity_detection?) { is_expected.to be true }
   its(:transitive?) { is_expected.to be false }
+  its(:destroy_ideas_on_phase_destroy?) { is_expected.to be false }
   its(:use_reactions_as_votes?) { is_expected.to be false }
   its(:supports_private_attributes_in_export?) { is_expected.to be false }
   its(:form_logic_enabled?) { is_expected.to be false }

--- a/back/spec/lib/participation_method/native_survey_spec.rb
+++ b/back/spec/lib/participation_method/native_survey_spec.rb
@@ -191,6 +191,7 @@ RSpec.describe ParticipationMethod::NativeSurvey do
   its(:supports_toxicity_detection?) { is_expected.to be false }
   its(:use_reactions_as_votes?) { is_expected.to be false }
   its(:transitive?) { is_expected.to be false }
+  its(:destroy_ideas_on_phase_destroy?) { is_expected.to be true }
   its(:form_logic_enabled?) { is_expected.to be true }
   its(:follow_idea_on_idea_submission?) { is_expected.to be false }
   its(:supports_custom_field_categories?) { is_expected.to be false }

--- a/back/spec/lib/participation_method/none_spec.rb
+++ b/back/spec/lib/participation_method/none_spec.rb
@@ -99,6 +99,7 @@ RSpec.describe ParticipationMethod::None do
   its(:supports_toxicity_detection?) { is_expected.to be true }
   its(:use_reactions_as_votes?) { is_expected.to be false }
   its(:transitive?) { is_expected.to be false }
+  its(:destroy_ideas_on_phase_destroy?) { is_expected.to be false }
   its(:supports_private_attributes_in_export?) { is_expected.to be false }
   its(:form_logic_enabled?) { is_expected.to be false }
   its(:follow_idea_on_idea_submission?) { is_expected.to be false }

--- a/back/spec/lib/participation_method/poll_spec.rb
+++ b/back/spec/lib/participation_method/poll_spec.rb
@@ -115,6 +115,7 @@ RSpec.describe ParticipationMethod::Poll do
   its(:supports_toxicity_detection?) { is_expected.to be true }
   its(:use_reactions_as_votes?) { is_expected.to be false }
   its(:transitive?) { is_expected.to be false }
+  its(:destroy_ideas_on_phase_destroy?) { is_expected.to be false }
   its(:supports_private_attributes_in_export?) { is_expected.to be false }
   its(:form_logic_enabled?) { is_expected.to be false }
   its(:follow_idea_on_idea_submission?) { is_expected.to be false }

--- a/back/spec/lib/participation_method/proposals_spec.rb
+++ b/back/spec/lib/participation_method/proposals_spec.rb
@@ -259,6 +259,7 @@ RSpec.describe ParticipationMethod::Proposals do
   its(:supports_toxicity_detection?) { is_expected.to be true }
   its(:use_reactions_as_votes?) { is_expected.to be true }
   its(:transitive?) { is_expected.to be false }
+  its(:destroy_ideas_on_phase_destroy?) { is_expected.to be true }
   its(:supports_private_attributes_in_export?) { is_expected.to be true }
   its(:form_logic_enabled?) { is_expected.to be false }
   its(:follow_idea_on_idea_submission?) { is_expected.to be true }

--- a/back/spec/lib/participation_method/survey_spec.rb
+++ b/back/spec/lib/participation_method/survey_spec.rb
@@ -116,6 +116,7 @@ RSpec.describe ParticipationMethod::Survey do
   its(:supports_toxicity_detection?) { is_expected.to be true }
   its(:use_reactions_as_votes?) { is_expected.to be false }
   its(:transitive?) { is_expected.to be false }
+  its(:destroy_ideas_on_phase_destroy?) { is_expected.to be false }
   its(:supports_private_attributes_in_export?) { is_expected.to be false }
   its(:form_logic_enabled?) { is_expected.to be false }
   its(:follow_idea_on_idea_submission?) { is_expected.to be false }

--- a/back/spec/lib/participation_method/volunteering_spec.rb
+++ b/back/spec/lib/participation_method/volunteering_spec.rb
@@ -115,6 +115,7 @@ RSpec.describe ParticipationMethod::Volunteering do
   its(:supports_toxicity_detection?) { is_expected.to be true }
   its(:use_reactions_as_votes?) { is_expected.to be false }
   its(:transitive?) { is_expected.to be false }
+  its(:destroy_ideas_on_phase_destroy?) { is_expected.to be false }
   its(:supports_private_attributes_in_export?) { is_expected.to be false }
   its(:form_logic_enabled?) { is_expected.to be false }
   its(:follow_idea_on_idea_submission?) { is_expected.to be false }

--- a/back/spec/lib/participation_method/voting_spec.rb
+++ b/back/spec/lib/participation_method/voting_spec.rb
@@ -205,6 +205,7 @@ RSpec.describe ParticipationMethod::Voting do
   its(:supports_submission?) { is_expected.to be false }
   its(:use_reactions_as_votes?) { is_expected.to be false }
   its(:transitive?) { is_expected.to be true }
+  its(:destroy_ideas_on_phase_destroy?) { is_expected.to be false }
   its(:supports_private_attributes_in_export?) { is_expected.to be true }
   its(:form_logic_enabled?) { is_expected.to be false }
   its(:follow_idea_on_idea_submission?) { is_expected.to be true }


### PR DESCRIPTION
# Changelog
## Fixed
- Ensured only phases that should destroy ideas on deletion actually do