### PR TITLE
TAN-7400 - Stop confirmation code email being sent when invites are created

### DIFF
--- a/back/app/services/side_fx_user_service.rb
+++ b/back/app/services/side_fx_user_service.rb
@@ -138,7 +138,7 @@ class SideFxUserService
   end
 
   def should_send_confirmation_email?(user)
-    user.confirmation_required? && user.email_confirmation_code_sent_at.nil? &&
+    !user.invite_pending? && user.confirmation_required? && user.email_confirmation_code_sent_at.nil? &&
       (user.email.present? || user.new_email.present?) # some SSO methods don't provide email
   end
 

--- a/back/spec/services/side_fx_user_service_spec.rb
+++ b/back/spec/services/side_fx_user_service_spec.rb
@@ -63,6 +63,17 @@ describe SideFxUserService do
       expect(user.follows.pluck(:followable_id)).to contain_exactly area.id
     end
 
+    context 'when user is an invitee' do
+      before { SettingsService.new.activate_feature!('user_confirmation') }
+
+      let(:invitee) { create(:user_with_confirmation, invite_status: 'pending') }
+
+      it 'does not send a confirmation code email' do
+        expect(RequestConfirmationCodeJob).not_to receive(:perform_now)
+        service.after_create(invitee, current_user)
+      end
+    end
+
     describe 'claim_tokens' do
       let!(:claim_token) { create(:claim_token) }
       let(:idea) { claim_token.item }


### PR DESCRIPTION
# Changelog
## Fixed
- Stopped confirmation code email being sent when invites are created
