### PR TITLE
TAN-7452 Skip diversity service once all ideas have been exposed

### DIFF
--- a/back/app/services/idea_feed/feed_service.rb
+++ b/back/app/services/idea_feed/feed_service.rb
@@ -13,16 +13,20 @@ module IdeaFeed
     def top_n(n = 5, scope = Idea.all)
       eligible_ideas = fetch_eligible_ideas(scope)
 
-      candidates = if eligible_ideas.none?
-        fetch_least_exposed_candidates(fetch_all_ideas(scope), n * 4)
+      if eligible_ideas.none?
+        # When recycling (all ideas seen), respect the exposure-count ordering
+        # directly. Diversity sampling would override this ordering by selecting
+        # based on embedding distance, causing the same ideas to be returned
+        # every time regardless of their exposure counts.
+        fetch_least_exposed_candidates(fetch_all_ideas(scope), n).to_a
       else
-        fetch_scored_candidates(eligible_ideas, n * 4)
-      end
+        candidates = fetch_scored_candidates(eligible_ideas, n * 4)
 
-      if skip_diversity_sampling?
-        candidates.limit(n).to_a
-      else
-        DiversityService.new.generate_list(candidates, exposures_scope, n)
+        if skip_diversity_sampling?
+          candidates.limit(n).to_a
+        else
+          DiversityService.new.generate_list(candidates, exposures_scope, n)
+        end
       end
     end
 

--- a/back/spec/services/idea_feed/feed_service_spec.rb
+++ b/back/spec/services/idea_feed/feed_service_spec.rb
@@ -111,6 +111,48 @@ describe IdeaFeed::FeedService do
         expect(top_ideas).to contain_exactly(exposed_idea)
         expect(top_ideas).not_to include(other_idea)
       end
+
+      it 'does not use diversity sampling' do
+        expect(IdeaFeed::DiversityService).not_to receive(:new)
+        service.top_n(5)
+      end
+    end
+
+    context 'when all ideas have been exposed and requesting fewer than total' do
+      let!(:ideas) { [] }
+      let!(:idea_a) { create(:idea, project: phase.project, phases: [phase]) }
+      let!(:idea_b) { create(:idea, project: phase.project, phases: [phase]) }
+      let!(:idea_c) { create(:idea, project: phase.project, phases: [phase]) }
+
+      it 'returns least exposed ideas first' do
+        create(:idea_exposure, idea: idea_a, user:, phase:)
+        create(:idea_exposure, idea: idea_b, user:, phase:)
+        create(:idea_exposure, idea: idea_c, user:, phase:)
+        # Expose idea_a a second time so it has the highest count
+        create(:idea_exposure, idea: idea_a, user:, phase:)
+
+        top_ideas = service.top_n(2)
+        expect(top_ideas).to contain_exactly(idea_b, idea_c)
+        expect(top_ideas).not_to include(idea_a)
+      end
+
+      it 'returns different ideas across consecutive calls as exposures accumulate' do
+        # First cycle: all ideas exposed once
+        create(:idea_exposure, idea: idea_a, user:, phase:)
+        create(:idea_exposure, idea: idea_b, user:, phase:)
+        create(:idea_exposure, idea: idea_c, user:, phase:)
+
+        first_batch = service.top_n(2)
+        expect(first_batch.size).to eq(2)
+
+        # Simulate exposures for the returned ideas (second exposure)
+        first_batch.each { |idea| create(:idea_exposure, idea:, user:, phase:) }
+
+        second_batch = service.top_n(2)
+        # The idea not in first_batch (exposure_count=1) should now appear
+        remaining_idea = [idea_a, idea_b, idea_c] - first_batch
+        expect(second_batch).to include(*remaining_idea)
+      end
     end
   end
 end

--- a/back/spec/services/idea_feed/feed_service_spec.rb
+++ b/back/spec/services/idea_feed/feed_service_spec.rb
@@ -120,6 +120,9 @@ describe IdeaFeed::FeedService do
 
     context 'when all ideas have been exposed and requesting fewer than total' do
       let!(:ideas) { [] }
+      let!(:other_idea) { create(:idea) }
+      let!(:exposed_idea) { nil }
+      let!(:idea_exposure) { nil }
       let!(:idea_a) { create(:idea, project: phase.project, phases: [phase]) }
       let!(:idea_b) { create(:idea, project: phase.project, phases: [phase]) }
       let!(:idea_c) { create(:idea, project: phase.project, phases: [phase]) }


### PR DESCRIPTION
# Changelog

## Fixed
- Ideas feed - list should now be repopulated correctly once a user is exposed to all ideas once

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
