### PR TITLE
TAN-7174 - Fix option text jumps and logic reset

### DIFF
--- a/front/app/components/CustomFieldsForm/SurveyForm/SurveyPage.tsx
+++ b/front/app/components/CustomFieldsForm/SurveyForm/SurveyPage.tsx
@@ -40,13 +40,12 @@ import {
   trackFormPageView,
 } from '../util';
 
-import SubmitConfirmation from './SubmitConfirmation';
-
 import {
   determineNextPageNumber,
   determinePreviousPageNumber,
   getSkippedPageIndices,
 } from './logic';
+import SubmitConfirmation from './SubmitConfirmation';
 
 const StyledForm = styled.form`
   height: 100%;

--- a/front/app/components/FormBuilder/components/FormBuilderSettings/ConfigOptionsWithLocaleSwitcher/SelectFieldOption.tsx
+++ b/front/app/components/FormBuilder/components/FormBuilderSettings/ConfigOptionsWithLocaleSwitcher/SelectFieldOption.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useState } from 'react';
+import React, { memo, useState, useEffect } from 'react';
 
 import {
   Box,
@@ -30,6 +30,11 @@ interface Props {
   locale: SupportedLocale;
   removeOption: (index: number) => void;
   onChoiceUpdate: (choice: IOptionsType, index: number) => void;
+  onTitleChange: (
+    value: string,
+    index: number,
+    locale: SupportedLocale
+  ) => void;
   onMultilinePaste?: (lines: string[], index: number) => void;
   optionImages: OptionImageType | undefined;
 }
@@ -43,11 +48,20 @@ const SelectFieldOption = memo(
     locale,
     removeOption,
     onChoiceUpdate,
+    onTitleChange,
     onMultilinePaste,
     optionImages,
   }: Props) => {
     const [isUploading, setIsUploading] = useState(false);
+    const [localTitle, setLocalTitle] = useState(
+      choice.title_multiloc[locale] || ''
+    );
     const { formatMessage } = useIntl();
+
+    // Sync from external changes (locale switch, drag reorder, etc.)
+    useEffect(() => {
+      setLocalTitle(choice.title_multiloc[locale] || '');
+    }, [choice.title_multiloc, locale]);
     const showImageSettings =
       inputType === 'multiselect_image' && !choice.other;
     const { mutateAsync: addCustomFieldOptionImage } =
@@ -115,11 +129,11 @@ const SelectFieldOption = memo(
             id={`e2e-option-input-${index}`}
             size="small"
             type="text"
-            value={choice.title_multiloc[locale]}
+            value={localTitle}
             onKeyDown={handleKeyDown}
             onChange={(value) => {
-              choice.title_multiloc[locale] = value;
-              onChoiceUpdate(choice, index);
+              setLocalTitle(value);
+              onTitleChange(value, index, locale);
             }}
             autoFocus={false}
             onMultilinePaste={

--- a/front/app/components/FormBuilder/components/FormBuilderSettings/ConfigOptionsWithLocaleSwitcher/index.tsx
+++ b/front/app/components/FormBuilder/components/FormBuilderSettings/ConfigOptionsWithLocaleSwitcher/index.tsx
@@ -64,6 +64,7 @@ const ConfigSelectWithLocaleSwitcher = ({
     control,
     formState: { errors: formContextErrors },
     trigger,
+    setValue,
   } = useFormContext();
 
   // Handles drag and drop
@@ -187,6 +188,13 @@ const ConfigSelectWithLocaleSwitcher = ({
     });
   };
 
+  const updateChoiceTitle = useCallback(
+    (value: string, index: number, locale: SupportedLocale) => {
+      setValue(`${name}.${index}.title_multiloc.${locale}`, value);
+    },
+    [setValue, name]
+  );
+
   const handleMultilinePaste = useCallback(
     (lines, index) => {
       if (!selectedLocale) return;
@@ -307,6 +315,7 @@ const ConfigSelectWithLocaleSwitcher = ({
                                   canDeleteLastOption={canDeleteLastOption}
                                   removeOption={removeOption}
                                   onChoiceUpdate={updateChoice}
+                                  onTitleChange={updateChoiceTitle}
                                   optionImages={optionImages}
                                 />
                               </Row>
@@ -330,6 +339,7 @@ const ConfigSelectWithLocaleSwitcher = ({
                                   optionImages={optionImages}
                                   removeOption={removeOption}
                                   onChoiceUpdate={updateChoice}
+                                  onTitleChange={updateChoiceTitle}
                                   onMultilinePaste={
                                     multilinePasteAllowed
                                       ? handleMultilinePaste

--- a/front/app/components/FormBuilder/components/FormBuilderSettings/LogicSettings/QuestionRuleInput.tsx
+++ b/front/app/components/FormBuilder/components/FormBuilderSettings/LogicSettings/QuestionRuleInput.tsx
@@ -80,7 +80,7 @@ export const QuestionRuleInput = ({
       } else {
         logic.rules = [newRule];
       }
-      setValue(name, { ...field, logic }, { shouldDirty: true });
+      setValue(`${name}.logic`, logic, { shouldDirty: true });
       trigger();
     }
   };
@@ -91,7 +91,7 @@ export const QuestionRuleInput = ({
       logic.rules = logic.rules.filter((rule) => rule.if !== answer.key);
     }
     // Update rule variable
-    setValue(name, { ...field, logic }, { shouldDirty: true });
+    setValue(`${name}.logic`, logic, { shouldDirty: true });
     trigger();
   };
 


### PR DESCRIPTION
Claude helped me (of course):

  1. Cursor jumping — useFieldArray.update() replaces the entire array item on every keystroke, causing react-hook-form to trigger intermediate re-renders that reset cursor position. Fixed with local state + targeted setValue.                                       
  2. Logic tab overwriting options — Both onSelectionChange and removeRuleForAnswer were spreading the stale field prop ({ ...field, logic }), which reset options to their original values. Fixed by narrowing the setValue to just the logic path.

# Changelog
## Fixed
- Stopped cursor jumping to end of text when editing option values in Form Editor
- Stopped logic resetting on select questions

