### PR TITLE
[TAN-7466] Always show phase insights 7-day change in grey when rounds to zero

### DIFF
--- a/front/app/containers/Admin/projects/project/insights/participationMetrics/MetricTrend.tsx
+++ b/front/app/containers/Admin/projects/project/insights/participationMetrics/MetricTrend.tsx
@@ -68,14 +68,15 @@ const MetricTrend = ({ change }: Props) => {
     );
   }
 
-  const isPositive = change > 0;
-  const isNeutral = change === 0;
+  const roundedChange = Math.round(change);
+  const isPositive = roundedChange > 0;
+  const isNeutral = roundedChange === 0;
   const trendIcon = isPositive
     ? 'arrow-up'
     : isNeutral
     ? undefined
     : 'arrow-down';
-  const formattedPercentage = formatNumber(Math.round(change) / 100, {
+  const formattedPercentage = formatNumber(roundedChange / 100, {
     style: 'percent',
     minimumFractionDigits: 0,
     maximumFractionDigits: 0,


### PR DESCRIPTION
# Changelog
## Fixed
- [TAN-7466] Always show phase insights 7-day change in grey when rounds to zero
