### PR TITLE
TAN-7165 Claude: Bulk import official feedback imprvements (SLS)

### DIFF
--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/setup_and_support.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/setup_and_support.rake
@@ -4,77 +4,73 @@ namespace :setup_and_support do
   desc 'Mass official feedback'
   task :mass_official_feedback, %i[url host locale] => [:environment] do |_t, args|
     # ID, Feedback, Feedback Author Name, Feedback Email, New Status
-    data = CSV.parse(open(args[:url]).read, headers: true, col_sep: ',', converters: [])
+    data = CSV.parse(URI.open(args[:url]).read, headers: true, col_sep: ',', converters: [])
     reporter = ScriptReporter.new
+
     Apartment::Tenant.switch(args[:host].tr('.', '_')) do
-      data.each do |row|
-        idea = Idea.find_by id: row['ID']
-        if !idea
-          reporter.add_error(
-            "Couldn't find idea",
-            context: { idea_id: row['ID'] }
-          )
-          next
-        end
+      statuses = IdeaStatus.all.to_a
+
+      validated_rows = data.map do |row|
+        idea = Idea.find_by(id: row['ID'])
+        raise "Couldn't find idea with ID '#{row['ID']}'" if !idea
+
+        user = User.find_by(email: row['Feedback Email'])
+        raise "Couldn't find feedback author with email '#{row['Feedback Email']}'" if !user
 
         status = if row['New Status'].present?
-          IdeaStatus.all.find do |some_idea|
-            some_idea.title_multiloc[args[:locale]].downcase.strip == row['New Status'].downcase.strip
-          end
+          statuses.find { |s| s.title_multiloc[args[:locale]]&.downcase&.strip == row['New Status'].downcase.strip }
         end
-        if !status
-          reporter.add_error(
-            "Couldn't find status",
-            context: { idea_id: idea.id, new_status: row['New Status'] }
-          )
-        end
+        raise "Couldn't find status '#{row['New Status']}'" if row['New Status'].present? && !status
 
-        name = row['Feedback Author Name']
-        text = row['Feedback']
-        first_name = idea.author&.first_name || row['First name'] || ''
-        text = text.gsub '{{first_name}}', first_name
-
-        user = User.find_by email: row['Feedback Email']
-        if !user
-          reporter.add_error(
-            "Couldn't find feedback author",
-            context: { idea_id: idea.id, email: row['Feedback Email'] }
-          )
-          next
-        end
-
-        if status && idea.idea_status != status
-          status_id_was = idea.idea_status_id
-          idea.update!(idea_status: status)
-          LogActivityJob.perform_later(
-            idea,
-            'changed_status',
-            user,
-            idea.updated_at.to_i,
-            payload: { change: idea.idea_status_id_previous_change }
-          )
-          reporter.add_change(
-            status_id_was,
-            status.id,
-            context: { idea_id: idea.id }
-          )
-        end
-
-        feedback_attributes = {
-          idea_id: idea.id,
-          body_multiloc: { args[:locale] => text },
-          author_multiloc: { args[:locale] => name },
-          user_id: user.id
-        }
-        feedback = OfficialFeedback.create!(feedback_attributes)
-        LogActivityJob.perform_later(feedback, 'created', user, feedback.created_at.to_i)
-        reporter.add_create(
-          'OfficialFeedback',
-          feedback_attributes,
-          context: { idea_id: idea.id }
-        )
+        { idea: idea, user: user, status: status, row: row }
       end
+
+      jobs_to_enqueue = []
+
+      ApplicationRecord.transaction do
+        validated_rows.each do |r|
+          idea = r[:idea]
+          user = r[:user]
+          status = r[:status]
+          row = r[:row]
+
+          name = row['Feedback Author Name']
+          text = row['Feedback']
+          first_name = idea.author&.first_name || row['First name'] || ''
+          text = text.gsub('{{first_name}}', first_name)
+
+          if status && idea.idea_status != status
+            status_id_was = idea.idea_status_id
+            idea.update!(idea_status: status)
+            jobs_to_enqueue << lambda {
+              LogActivityJob.perform_later(
+                idea,
+                'changed_status',
+                user,
+                idea.updated_at.to_i,
+                payload: { change: idea.idea_status_id_previous_change }
+              )
+            }
+            reporter.add_change(status_id_was, status.id, context: { idea_id: idea.id })
+          end
+
+          feedback_attributes = {
+            idea_id: idea.id,
+            body_multiloc: { args[:locale] => text },
+            author_multiloc: { args[:locale] => name },
+            user_id: user.id
+          }
+          feedback = OfficialFeedback.create!(feedback_attributes)
+          jobs_to_enqueue << lambda { LogActivityJob.perform_later(feedback, 'created', user, feedback.created_at.to_i) }
+          reporter.add_create('OfficialFeedback', feedback_attributes, context: { idea_id: idea.id })
+        end
+      end
+
+      jobs_to_enqueue.each(&:call)
+    rescue StandardError => e
+      reporter.add_error(e.message)
     end
+
     reporter.report!('mass_official_feedback_report.json', verbose: true)
   end
 

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/setup_and_support.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/setup_and_support.rake
@@ -61,7 +61,7 @@ namespace :setup_and_support do
             user_id: user.id
           }
           feedback = OfficialFeedback.create!(feedback_attributes)
-          jobs_to_enqueue << lambda { LogActivityJob.perform_later(feedback, 'created', user, feedback.created_at.to_i) }
+          jobs_to_enqueue << -> { LogActivityJob.perform_later(feedback, 'created', user, feedback.created_at.to_i) }
           reporter.add_create('OfficialFeedback', feedback_attributes, context: { idea_id: idea.id })
         end
       end

--- a/back/engines/commercial/multi_tenancy/spec/tasks/mass_official_feedback_spec.rb
+++ b/back/engines/commercial/multi_tenancy/spec/tasks/mass_official_feedback_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'rake setup_and_support:mass_official_feedback' do # rubocop:disable RSpec/DescribeClass
+  before { load_rake_tasks_if_not_loaded }
+
+  after { Rake::Task['setup_and_support:mass_official_feedback'].reenable }
+
+  let(:locale) { 'en' }
+  let(:host) { Tenant.current.host }
+  let!(:author) { create(:admin) }
+  let!(:status_under_review) { create(:idea_status, title_multiloc: { locale => 'Under review' }) }
+  let!(:status_proposed) { create(:idea_status, title_multiloc: { locale => 'Proposed' }) }
+  let!(:idea1) { create(:idea, idea_status: status_proposed) }
+  let!(:idea2) { create(:idea, idea_status: status_proposed) }
+
+  let(:csv_file) do
+    Tempfile.new(['mass_official_feedback', '.csv']).tap do |f|
+      f.write(csv_content)
+      f.close
+    end
+  end
+
+  before { allow(LogActivityJob).to receive(:perform_later) }
+  after { csv_file.unlink }
+
+  def invoke
+    Rake::Task['setup_and_support:mass_official_feedback'].invoke(csv_file.path, host, locale)
+  end
+
+  context 'when all rows are valid' do
+    let(:csv_content) do
+      <<~CSV
+        ID,Feedback,Feedback Author Name,Feedback Email,New Status
+        #{idea1.id},Thank you {{first_name}}.,City Team,#{author.email},Under review
+        #{idea2.id},We reviewed your submission.,City Team,#{author.email},
+      CSV
+    end
+
+    it 'creates feedback, updates statuses, and enqueues activity jobs' do
+      invoke
+
+      expect(OfficialFeedback.count).to eq(2)
+      expect(idea1.reload.idea_status).to eq(status_under_review)
+      expect(idea2.reload.idea_status).to eq(status_proposed)
+      expect(OfficialFeedback.find_by(idea: idea1).body_multiloc[locale]).to include(idea1.author.first_name)
+      expect(LogActivityJob).to have_received(:perform_later).at_least(:twice)
+    end
+  end
+
+  context 'when an idea is not found' do
+    let(:csv_content) do
+      <<~CSV
+        ID,Feedback,Feedback Author Name,Feedback Email,New Status
+        #{idea1.id},Thank you.,City Team,#{author.email},
+        00000000-0000-0000-0000-000000000000,Feedback.,City Team,#{author.email},
+      CSV
+    end
+
+    it 'creates no feedback and leaves statuses unchanged' do
+      invoke
+
+      expect(OfficialFeedback.count).to eq(0)
+      expect(idea1.reload.idea_status).to eq(status_proposed)
+    end
+  end
+
+  context 'when a feedback author is not found' do
+    let(:csv_content) do
+      <<~CSV
+        ID,Feedback,Feedback Author Name,Feedback Email,New Status
+        #{idea1.id},Thank you.,City Team,unknown@example.org,
+        #{idea2.id},Feedback.,City Team,#{author.email},
+      CSV
+    end
+
+    it 'creates no feedback' do
+      invoke
+
+      expect(OfficialFeedback.count).to eq(0)
+    end
+  end
+
+  context 'when a status title is not found' do
+    let(:csv_content) do
+      <<~CSV
+        ID,Feedback,Feedback Author Name,Feedback Email,New Status
+        #{idea1.id},Thank you.,City Team,#{author.email},Nonexistent Status
+        #{idea2.id},Feedback.,City Team,#{author.email},
+      CSV
+    end
+
+    it 'creates no feedback and leaves statuses unchanged' do
+      invoke
+
+      expect(OfficialFeedback.count).to eq(0)
+      expect(idea1.reload.idea_status).to eq(status_proposed)
+    end
+  end
+
+  context 'when a write fails mid-transaction' do
+    let(:csv_content) do
+      <<~CSV
+        ID,Feedback,Feedback Author Name,Feedback Email,New Status
+        #{idea1.id},Thank you.,City Team,#{author.email},Under review
+        #{idea2.id},Feedback.,City Team,#{author.email},
+      CSV
+    end
+
+    before { allow(OfficialFeedback).to receive(:create!).and_raise(ActiveRecord::RecordInvalid) }
+
+    it 'rolls back all writes and enqueues no jobs' do
+      invoke
+
+      expect(OfficialFeedback.count).to eq(0)
+      expect(idea1.reload.idea_status).to eq(status_proposed)
+      expect(LogActivityJob).not_to have_received(:perform_later)
+    end
+  end
+end

--- a/back/engines/commercial/multi_tenancy/spec/tasks/mass_official_feedback_spec.rb
+++ b/back/engines/commercial/multi_tenancy/spec/tasks/mass_official_feedback_spec.rb
@@ -3,10 +3,6 @@
 require 'rails_helper'
 
 describe 'rake setup_and_support:mass_official_feedback' do # rubocop:disable RSpec/DescribeClass
-  before { load_rake_tasks_if_not_loaded }
-
-  after { Rake::Task['setup_and_support:mass_official_feedback'].reenable }
-
   let(:locale) { 'en' }
   let(:host) { Tenant.current.host }
   let!(:author) { create(:admin) }
@@ -22,8 +18,15 @@ describe 'rake setup_and_support:mass_official_feedback' do # rubocop:disable RS
     end
   end
 
-  before { allow(LogActivityJob).to receive(:perform_later) }
-  after { csv_file.unlink }
+  before do
+    load_rake_tasks_if_not_loaded
+    allow(LogActivityJob).to receive(:perform_later)
+  end
+
+  after do
+    Rake::Task['setup_and_support:mass_official_feedback'].reenable
+    csv_file.unlink
+  end
 
   def invoke
     Rake::Task['setup_and_support:mass_official_feedback'].invoke(csv_file.path, host, locale)


### PR DESCRIPTION
This should allow us to try importing the official feedbacks directly on the production servers, instead of trying on a database backup before.
- By prechecking and running the changes in a transaction, a rollback is performed if there are any issues. Jobs are only enqueued at the very end.
- A spec was included. The script was also tested manually.
