### PR TITLE
Make Spanish an L2 locale

### DIFF
--- a/polyglit.jsonc
+++ b/polyglit.jsonc
@@ -10,10 +10,10 @@
       "da-DK",
       { "nl-NL": ["nl-BE"] },
       { "fr-FR": ["fr-BE"] },
-      { "de-DE": ["de-AT"] },
-      { "es-ES": ["es-CL"] }
+      { "de-DE": ["de-AT"] }
     ],
     "l2": [
+      { "es-ES": ["es-CL"] },
       "ar-SA",
       "hr-HR",
       "en-CA",


### PR DESCRIPTION
# Changelog
## Changed
- We are treating Spanish as an "L2" language, which means that proofreading is no longer required before release, but can happen afterwards.