### PR TITLE
TAN-7441 - Override native copy when copying form schemas as super user

### DIFF
--- a/front/app/components/FormBuilder/components/FormBuilderTopBar/SuperAdmin/EditSchemaButtonWithModal.tsx
+++ b/front/app/components/FormBuilder/components/FormBuilderTopBar/SuperAdmin/EditSchemaButtonWithModal.tsx
@@ -26,7 +26,7 @@ import TextArea from 'components/UI/TextArea';
 import { FormattedMessage, useIntl } from 'utils/cl-intl';
 
 import messages from './messages';
-import { replaceIdsWithNewUuids } from './utils';
+import { replaceIdsWithNewUuids, replaceUuidsInText } from './utils';
 
 const CodeTextArea = styled(TextArea)`
   .TextArea textarea {
@@ -88,6 +88,22 @@ const EditSchemaButtonWithModal = ({
     } catch (e) {
       setError(formatMessage(messages.schemaParseError));
     }
+  };
+
+  // Native copy also needs to be handed to ensure that we can never directly
+  // copy & paste the same IDs to different platforms - causes metabase issues
+  const handleNativeCopy = (e: React.ClipboardEvent) => {
+    const selection = window.getSelection()?.toString();
+    if (!selection) return;
+    e.preventDefault();
+    let rewritten: string;
+    try {
+      const parsed = JSON.parse(selection) as IFlatCustomField[];
+      rewritten = JSON.stringify(replaceIdsWithNewUuids(parsed), null, 2);
+    } catch {
+      rewritten = replaceUuidsInText(selection);
+    }
+    e.clipboardData.setData('text/plain', rewritten);
   };
 
   const handleSave = async () => {
@@ -155,11 +171,13 @@ const EditSchemaButtonWithModal = ({
             <FormattedMessage {...messages.schemaEdit} />
           </Title>
 
-          <CodeTextArea
-            value={jsonText}
-            onChange={(value) => setJsonText(value)}
-            maxRows={20}
-          />
+          <Box onCopy={handleNativeCopy}>
+            <CodeTextArea
+              value={jsonText}
+              onChange={(value) => setJsonText(value)}
+              maxRows={20}
+            />
+          </Box>
 
           {error && <Error text={error} marginTop="8px" marginBottom="0" />}
 

--- a/front/app/components/FormBuilder/components/FormBuilderTopBar/SuperAdmin/utils.ts
+++ b/front/app/components/FormBuilder/components/FormBuilderTopBar/SuperAdmin/utils.ts
@@ -83,3 +83,19 @@ export const replaceIdsWithNewUuids = (
 
   return fields.map(replaceIds);
 };
+
+// Sometimes we need to replace UUIDs in partially copied JSON snippets
+// that are not parsable as JSON.
+const UUID_REGEX =
+  /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi;
+
+export const replaceUuidsInText = (text: string): string => {
+  const mapping: Record<string, string> = {};
+  return text.replace(UUID_REGEX, (match) => {
+    const key = match.toLowerCase();
+    if (!mapping[key]) {
+      mapping[key] = uuidv4();
+    }
+    return mapping[key];
+  });
+};


### PR DESCRIPTION
Mainly written with Claude's help (as was the original feature)

# Changelog
## Technical
- Ensure native copy replaces UUIDs when using the super user form schema editor - to avoid issues with duplicate IDs in Metabase