### PR TITLE
TAN-7522 - Allow rich text in xlsx idea imports

### DIFF
--- a/back/app/services/xlsx_service.rb
+++ b/back/app/services/xlsx_service.rb
@@ -39,8 +39,8 @@ class XlsxService
       xlsx_utils = Export::Xlsx::Utils.new
       (row&.cells || []).compact.filter_map do |cell|
         if cell.value || include_empty_cells
-          column_header = xlsx_utils.add_duplicate_column_name_suffix(worksheet[0][cell.column]&.value)
-          raw_column_header = xlsx_utils.remove_duplicate_column_name_suffix(column_header)
+          raw_column_header = worksheet[0][cell.column]&.value
+          column_header = xlsx_utils.add_duplicate_column_name_suffix(raw_column_header)
           value = if rich_text_column_set.include?(raw_column_header)
             rich_text_cell_html(cell, workbook) || cell.value
           else
@@ -312,23 +312,23 @@ class XlsxService
   end
 
   # Returns an HTML string if the cell is backed by a shared string with
-  # formatting runs (bold/italic/underline/strike). Returns nil for plain cells
-  # so the caller can fall back to the plain `cell.value`.
+  # formatting runs (bold/italic/underline/strike). Returns nil for plain text cells.
+  # NOTE: A run is the standard xlsx terminology for a formatted text segment inside a cell - containing <r> elements
   def rich_text_cell_html(cell, workbook)
-    entry =
-      case cell.datatype
-      when RubyXL::DataType::SHARED_STRING
-        workbook.shared_strings_container&.[](cell.raw_value.to_i)
-      when 'inlineStr'
-        cell.respond_to?(:is) ? cell.is : nil
-      end
+    entry = case cell.datatype
+    when RubyXL::DataType::SHARED_STRING
+      workbook.shared_strings_container&.[](cell.raw_value.to_i)
+    when 'inlineStr'
+      cell.respond_to?(:is) ? cell.is : nil
+    end
+
     return nil unless entry
 
     runs = entry.respond_to?(:r) ? entry.r : nil
     return nil if runs.blank?
 
-    # If the author has already written HTML into the cell, skip rich-text
-    # conversion so we don't double-encode their tags — fall back to plain text.
+    # If there are HTML tags in the cell, skip rich-text conversion
+    # so we don't double-encode their tags — fall back to plain text.
     return nil if contains_html_tags?(entry.to_s)
 
     runs.map { |run| rich_text_run_to_html(run) }.join.presence
@@ -338,7 +338,6 @@ class XlsxService
     text.to_s.match?(%r{</?[a-zA-Z][^>]*>})
   end
 
-  # NOTE: run is the standard xlsx terminology for a formatted text segment inside a cell - containing <r> elements
   def rich_text_run_to_html(run)
     text_node = run.respond_to?(:t) ? run.t : nil
     raw_text = text_node.respond_to?(:value) ? text_node.value.to_s : text_node.to_s

--- a/back/app/services/xlsx_service.rb
+++ b/back/app/services/xlsx_service.rb
@@ -31,15 +31,22 @@ class XlsxService
   # | John  |      | 35  |
   # into this hash array:
   #   [{'name' => 'Ron', 'size' => 'xl'), {'name' => 'John', 'age' => 35}]
-  def xlsx_to_hash_array(xlsx, include_empty_cells: false)
+  def xlsx_to_hash_array(xlsx, include_empty_cells: false, rich_text_columns: [])
     workbook = RubyXL::Parser.parse_buffer(xlsx)
     worksheet = workbook.worksheets[0]
+    rich_text_column_set = rich_text_columns.to_set
     worksheet.drop(1).map do |row|
       xlsx_utils = Export::Xlsx::Utils.new
       (row&.cells || []).compact.filter_map do |cell|
         if cell.value || include_empty_cells
           column_header = xlsx_utils.add_duplicate_column_name_suffix(worksheet[0][cell.column]&.value)
-          [column_header, cell.value]
+          raw_column_header = xlsx_utils.remove_duplicate_column_name_suffix(column_header)
+          value = if rich_text_column_set.include?(raw_column_header)
+            rich_text_cell_html(cell, workbook) || cell.value
+          else
+            cell.value
+          end
+          [column_header, value]
         end
       end.to_h
     end
@@ -302,6 +309,59 @@ class XlsxService
 
   def utils
     @utils ||= Export::Xlsx::Utils.new
+  end
+
+  # Returns an HTML string if the cell is backed by a shared string with
+  # formatting runs (bold/italic/underline/strike). Returns nil for plain cells
+  # so the caller can fall back to the plain `cell.value`.
+  def rich_text_cell_html(cell, workbook)
+    entry =
+      case cell.datatype
+      when RubyXL::DataType::SHARED_STRING
+        workbook.shared_strings_container&.[](cell.raw_value.to_i)
+      when 'inlineStr'
+        cell.respond_to?(:is) ? cell.is : nil
+      end
+    return nil unless entry
+
+    runs = entry.respond_to?(:r) ? entry.r : nil
+    return nil if runs.blank?
+
+    # If the author has already written HTML into the cell, skip rich-text
+    # conversion so we don't double-encode their tags — fall back to plain text.
+    return nil if contains_html_tags?(entry.to_s)
+
+    runs.map { |run| rich_text_run_to_html(run) }.join.presence
+  end
+
+  def contains_html_tags?(text)
+    text.to_s.match?(%r{</?[a-zA-Z][^>]*>})
+  end
+
+  # NOTE: run is the standard xlsx terminology for a formatted text segment inside a cell - containing <r> elements
+  def rich_text_run_to_html(run)
+    text_node = run.respond_to?(:t) ? run.t : nil
+    raw_text = text_node.respond_to?(:value) ? text_node.value.to_s : text_node.to_s
+    html = CGI.escapeHTML(raw_text).gsub("\n", '<br>')
+
+    rpr = %i[r_pr rpr run_properties].filter_map { |m| run.send(m) if run.respond_to?(m) }.first
+    return html unless rpr
+
+    html = "<s>#{html}</s>" if rich_text_flag?(rpr, :strike)
+    html = "<u>#{html}</u>" if rich_text_flag?(rpr, :u)
+    html = "<em>#{html}</em>" if rich_text_flag?(rpr, :i)
+    html = "<strong>#{html}</strong>" if rich_text_flag?(rpr, :b)
+    html
+  end
+
+  def rich_text_flag?(rpr, name)
+    return false unless rpr.respond_to?(name)
+
+    value = rpr.public_send(name)
+    return false if value.nil?
+    return value.val != false if value.respond_to?(:val)
+
+    !!value
   end
 end
 

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/parsers/idea_xlsx_file_parser.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/parsers/idea_xlsx_file_parser.rb
@@ -128,7 +128,18 @@ module BulkImportIdeas::Parsers
 
     def parse_xlsx_ideas(file)
       # Empty cells are included so we get all form fields per idea - this is important for 'other' fields that have the same header
-      XlsxService.new.xlsx_to_hash_array(file.file.read, include_empty_cells: true)
+      XlsxService.new.xlsx_to_hash_array(
+        file.file.read,
+        include_empty_cells: true,
+        rich_text_columns: rich_text_column_headers
+      )
+    end
+
+    # The description cell can contain formatting (bold/italic/etc) that we want
+    # to preserve as HTML — body_multiloc stores HTML downstream.
+    def rich_text_column_headers
+      description_field = template_data[:fields].find { |f| f[:code] == 'body_multiloc' }
+      description_field ? [description_field[:name]] : []
     end
 
     def template_data

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/parsers/idea_xlsx_file_parser.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/parsers/idea_xlsx_file_parser.rb
@@ -135,11 +135,13 @@ module BulkImportIdeas::Parsers
       )
     end
 
-    # The description cell can contain formatting (bold/italic/etc) that we want
-    # to preserve as HTML — body_multiloc stores HTML downstream.
+    # Cells for fields whose input_type stores HTML (e.g. body_multiloc) can
+    # contain formatting (bold/italic/etc) that we want to preserve.
     def rich_text_column_headers
-      description_field = template_data[:fields].find { |f| f[:code] == 'body_multiloc' }
-      description_field ? [description_field[:name]] : []
+      html_input_types = %w[html html_multiloc]
+      template_data[:fields]
+        .select { |f| html_input_types.include?(f[:input_type]) }
+        .pluck(:name)
     end
 
     def template_data

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/patches/xlsx_service.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/patches/xlsx_service.rb
@@ -16,10 +16,14 @@ module BulkImportIdeas
         # StringIO (e.g. from Axlsx#to_stream), and RubyXL::Parser.parse_buffer
         # consumes its input, so we dup per parse.
         xlsx_bytes = xlsx.respond_to?(:string) ? xlsx.string : xlsx.to_s
-        data_row_count = [RubyXL::Parser.parse_buffer(xlsx_bytes.dup)[0].sheet_data.rows.size - 1, 0].max
+
+        source_workbook = RubyXL::Parser.parse_buffer(xlsx_bytes.dup)
+        trim_trailing_empty_rows!(source_workbook[0])
+        data_row_count = [source_workbook[0].sheet_data.rows.size - 1, 0].max
 
         (0...data_row_count).each_slice(max_rows).map do |chunk_indices|
           chunk_workbook = RubyXL::Parser.parse_buffer(xlsx_bytes.dup)
+          trim_trailing_empty_rows!(chunk_workbook[0])
           rows = chunk_workbook[0].sheet_data.rows
           first = chunk_indices.first + 1
           last = chunk_indices.last + 1
@@ -27,6 +31,19 @@ module BulkImportIdeas
           rows.slice!(1...first) if first > 1
           chunk_workbook.stream
         end
+      end
+
+      private
+
+      def trim_trailing_empty_rows!(worksheet)
+        rows = worksheet.sheet_data.rows
+        rows.pop while rows.size > 1 && row_empty?(rows.last)
+      end
+
+      def row_empty?(row)
+        return true if row.nil?
+
+        (row.cells || []).all? { |c| c.nil? || c.value.nil? || c.value.to_s.strip.empty? }
       end
     end
   end

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/patches/xlsx_service.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/patches/xlsx_service.rb
@@ -7,27 +7,22 @@ module BulkImportIdeas
         super + [{ header: 'imported', f: ->(i) { i.idea_import ? true : false } }]
       end
 
-      # Splits a single sheet XLSX into multiple XLSXs, each containing at most `max_rows` rows.
+      # Splits a single sheet XLSX into multiple XLSXs, each containing at most
+      # `max_rows` rows. Rows are not rewritten — we re-parse the original xlsx
+      # per chunk and delete the rows outside it, so all cell fidelity
+      # (rich text, styles, hyperlinks, formulas) is preserved.
       def split_xlsx(xlsx, max_rows)
-        workbook = RubyXL::Parser.parse_buffer(xlsx)
-        worksheet = workbook[0]
-        header = worksheet[0]
-        data_rows = worksheet.drop(1)
+        # RubyXL::Parser.parse_buffer consumes its input, so dup per parse.
+        data_row_count = [RubyXL::Parser.parse_buffer(xlsx.dup)[0].sheet_data.rows.size - 1, 0].max
 
-        data_rows.each_slice(max_rows).map do |rows|
-          new_package = Axlsx::Package.new
-          new_workbook = new_package.workbook
-          new_workbook.add_worksheet(name: worksheet.sheet_name) do |new_sheet|
-            new_sheet.add_row(header.cells.map { |c| c&.value })
-
-            rows.each do |row|
-              next unless row&.cells
-
-              new_sheet.add_row(row.cells.map { |c| c&.value })
-            end
-          end
-
-          new_package.to_stream
+        (0...data_row_count).each_slice(max_rows).map do |chunk_indices|
+          chunk_workbook = RubyXL::Parser.parse_buffer(xlsx.dup)
+          rows = chunk_workbook[0].sheet_data.rows
+          first = chunk_indices.first + 1
+          last = chunk_indices.last + 1
+          rows.slice!((last + 1)..) if last + 1 < rows.size
+          rows.slice!(1...first) if first > 1
+          chunk_workbook.stream
         end
       end
     end

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/patches/xlsx_service.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/patches/xlsx_service.rb
@@ -12,11 +12,14 @@ module BulkImportIdeas
       # per chunk and delete the rows outside it, so all cell fidelity
       # (rich text, styles, hyperlinks, formulas) is preserved.
       def split_xlsx(xlsx, max_rows)
-        # RubyXL::Parser.parse_buffer consumes its input, so dup per parse.
-        data_row_count = [RubyXL::Parser.parse_buffer(xlsx.dup)[0].sheet_data.rows.size - 1, 0].max
+        # Normalize to a byte string — callers pass either a String or a
+        # StringIO (e.g. from Axlsx#to_stream), and RubyXL::Parser.parse_buffer
+        # consumes its input, so we dup per parse.
+        xlsx_bytes = xlsx.respond_to?(:string) ? xlsx.string : xlsx.to_s
+        data_row_count = [RubyXL::Parser.parse_buffer(xlsx_bytes.dup)[0].sheet_data.rows.size - 1, 0].max
 
         (0...data_row_count).each_slice(max_rows).map do |chunk_indices|
-          chunk_workbook = RubyXL::Parser.parse_buffer(xlsx.dup)
+          chunk_workbook = RubyXL::Parser.parse_buffer(xlsx_bytes.dup)
           rows = chunk_workbook[0].sheet_data.rows
           first = chunk_indices.first + 1
           last = chunk_indices.last + 1

--- a/back/engines/commercial/bulk_import_ideas/spec/services/parsers/idea_xlsx_file_parser_spec.rb
+++ b/back/engines/commercial/bulk_import_ideas/spec/services/parsers/idea_xlsx_file_parser_spec.rb
@@ -338,6 +338,18 @@ describe BulkImportIdeas::Parsers::IdeaXlsxFileParser do
     end
   end
 
+  describe 'rich_text_column_headers' do
+    it 'returns the localized title of the body_multiloc field' do
+      expect(service.send(:rich_text_column_headers)).to eq ['Description']
+    end
+
+    it 'returns an empty array when the form has no html or html_multiloc fields' do
+      survey_phase = create(:native_survey_phase)
+      survey_service = described_class.new(create(:admin), 'en', survey_phase.id, false)
+      expect(survey_service.send(:rich_text_column_headers)).to eq []
+    end
+  end
+
   describe 'format_date' do
     it 'formats date strings in dd-mm-yyyy format' do
       date_string = '15-08-2023'

--- a/back/engines/commercial/bulk_import_ideas/spec/services/patches/xlsx_service_spec.rb
+++ b/back/engines/commercial/bulk_import_ideas/spec/services/patches/xlsx_service_spec.rb
@@ -59,6 +59,30 @@ describe XlsxService do
       expect(document3[0].map { |r| r.cells.map(&:value) }).to eq [%w[col1 col2], ['g', 7]]
     end
 
+    it 'trims trailing empty rows before splitting' do
+      rows = [
+        %w[col1 col2],
+        ['a', 1],
+        ['b', 2],
+        ['c', 3],
+        ['', ''],
+        ['', ''],
+        ['', ''],
+        ['', ''],
+        ['', '']
+      ]
+      xlsx = service.xlsx_from_rows(rows)
+      multiple_xlsx = service.split_xlsx(xlsx, 2)
+
+      expect(multiple_xlsx.count).to eq 2
+
+      document1 = RubyXL::Parser.parse_buffer(multiple_xlsx[0])
+      expect(document1[0].map { |r| r.cells.map(&:value) }).to eq [%w[col1 col2], ['a', 1], ['b', 2]]
+
+      document2 = RubyXL::Parser.parse_buffer(multiple_xlsx[1])
+      expect(document2[0].map { |r| r.cells.map(&:value) }).to eq [%w[col1 col2], ['c', 3]]
+    end
+
     it 'writes dates correctly in split xlsx files' do
       sheet_rows = [
         %w[col1 col2],

--- a/back/spec/services/xlsx_service_spec.rb
+++ b/back/spec/services/xlsx_service_spec.rb
@@ -309,7 +309,7 @@ describe XlsxService do
           sheet.add_row %w[Description Other]
           description_rich = Axlsx::RichText.new
           description_rich.add_run 'hello ', b: true
-          description_rich.add_run 'world', i: true
+          description_rich.add_run 'world & people', i: true
           other_rich = Axlsx::RichText.new
           other_rich.add_run 'stay ', b: true
           other_rich.add_run 'plain'
@@ -320,7 +320,7 @@ describe XlsxService do
 
       it 'returns HTML for cells in rich_text_columns when runs are present' do
         result = service.xlsx_to_hash_array(rich_xlsx, rich_text_columns: ['Description'])
-        expect(result.first['Description']).to eq '<strong>hello </strong><em>world</em>'
+        expect(result.first['Description']).to eq '<strong>hello </strong><em>world &amp; people</em>'
       end
 
       it 'leaves columns outside rich_text_columns as plain text even if formatted' do
@@ -328,9 +328,9 @@ describe XlsxService do
         expect(result.first['Other']).to eq 'stay plain'
       end
 
-      it 'returns plain text when rich_text_columns is not passed (backwards compatible)' do
+      it 'returns plain text when rich_text_columns is not passed' do
         result = service.xlsx_to_hash_array(rich_xlsx)
-        expect(result.first['Description']).to eq 'hello world'
+        expect(result.first['Description']).to eq 'hello world & people'
         expect(result.first['Other']).to eq 'stay plain'
       end
 
@@ -346,19 +346,6 @@ describe XlsxService do
         xlsx = package.to_stream.string
         result = service.xlsx_to_hash_array(xlsx, rich_text_columns: ['Description'])
         expect(result.first['Description']).to eq '<p>already html</p>'
-      end
-
-      it 'escapes HTML entities in the rich-text source' do
-        package = Axlsx::Package.new
-        package.workbook.add_worksheet do |sheet|
-          sheet.add_row ['Description']
-          rich = Axlsx::RichText.new
-          rich.add_run 'A & B', b: true
-          sheet.add_row [rich]
-        end
-        xlsx = package.to_stream.string
-        result = service.xlsx_to_hash_array(xlsx, rich_text_columns: ['Description'])
-        expect(result.first['Description']).to eq '<strong>A &amp; B</strong>'
       end
     end
   end

--- a/back/spec/services/xlsx_service_spec.rb
+++ b/back/spec/services/xlsx_service_spec.rb
@@ -301,6 +301,66 @@ describe XlsxService do
       expect(xlsx_hash_array[0]['Duplicate field']).to eq 'Duplicate field value 1'
       expect(xlsx_hash_array[0]['Duplicate field__2']).to eq 'Duplicate field value 2'
     end
+
+    context 'with rich_text_columns' do
+      let(:rich_xlsx) do
+        package = Axlsx::Package.new
+        package.workbook.add_worksheet do |sheet|
+          sheet.add_row %w[Description Other]
+          description_rich = Axlsx::RichText.new
+          description_rich.add_run 'hello ', b: true
+          description_rich.add_run 'world', i: true
+          other_rich = Axlsx::RichText.new
+          other_rich.add_run 'stay ', b: true
+          other_rich.add_run 'plain'
+          sheet.add_row [description_rich, other_rich]
+        end
+        package.to_stream.string
+      end
+
+      it 'returns HTML for cells in rich_text_columns when runs are present' do
+        result = service.xlsx_to_hash_array(rich_xlsx, rich_text_columns: ['Description'])
+        expect(result.first['Description']).to eq '<strong>hello </strong><em>world</em>'
+      end
+
+      it 'leaves columns outside rich_text_columns as plain text even if formatted' do
+        result = service.xlsx_to_hash_array(rich_xlsx, rich_text_columns: ['Description'])
+        expect(result.first['Other']).to eq 'stay plain'
+      end
+
+      it 'returns plain text when rich_text_columns is not passed (backwards compatible)' do
+        result = service.xlsx_to_hash_array(rich_xlsx)
+        expect(result.first['Description']).to eq 'hello world'
+        expect(result.first['Other']).to eq 'stay plain'
+      end
+
+      it 'falls back to plain text when the cell already contains HTML tags' do
+        package = Axlsx::Package.new
+        package.workbook.add_worksheet do |sheet|
+          sheet.add_row ['Description']
+          rich = Axlsx::RichText.new
+          rich.add_run '<p>already ', b: true
+          rich.add_run 'html</p>', i: true
+          sheet.add_row [rich]
+        end
+        xlsx = package.to_stream.string
+        result = service.xlsx_to_hash_array(xlsx, rich_text_columns: ['Description'])
+        expect(result.first['Description']).to eq '<p>already html</p>'
+      end
+
+      it 'escapes HTML entities in the rich-text source' do
+        package = Axlsx::Package.new
+        package.workbook.add_worksheet do |sheet|
+          sheet.add_row ['Description']
+          rich = Axlsx::RichText.new
+          rich.add_run 'A & B', b: true
+          sheet.add_row [rich]
+        end
+        xlsx = package.to_stream.string
+        result = service.xlsx_to_hash_array(xlsx, rich_text_columns: ['Description'])
+        expect(result.first['Description']).to eq '<strong>A &amp; B</strong>'
+      end
+    end
   end
 
   describe '#xlsx_from_rows' do


### PR DESCRIPTION
NOTE: Claude used heavily here

# Changelog
## Changed
- Updated XLSX idea import to allow rich text imports to HTML fields
- Updated XLSX idea import to reject any empty rows before splitting the XLSX