### PR TITLE
TAN-7560 Performance improvements for Admin HQ

### DIFF
--- a/back/config/initializers/ros_apartment_patch.rb
+++ b/back/config/initializers/ros_apartment_patch.rb
@@ -24,3 +24,35 @@ module Apartment
     end
   end
 end
+
+# Memoize pg_dump output so we only pay for it once per worker process.
+# Apartment clones the public schema into each new tenant by shelling out to
+# pg_dump to capture the DDL (CREATE TABLE/INDEX/FUNCTION/...) as a SQL string,
+# which it then rewrites and executes against the new schema. The shell-out
+# takes ~10 s per call and is the dominant cost of tenant creation. The dump
+# only changes when migrations run, so we key the cache on the schema version
+# to invalidate automatically if someone runs db:migrate against a long-lived
+# process.
+module Apartment
+  module Adapters
+    module MemoizedPgDumpSchema
+      @cache = {}
+
+      def self.cache
+        @cache
+      end
+
+      private
+
+      def pg_dump_schema
+        version = ActiveRecord::Migrator.current_version
+        MemoizedPgDumpSchema.cache[version] ||= begin
+          MemoizedPgDumpSchema.cache.clear
+          super
+        end
+      end
+    end
+
+    PostgresqlSchemaFromSqlAdapter.prepend(MemoizedPgDumpSchema)
+  end
+end

--- a/back/engines/commercial/multi_tenancy/app/uploaders/multi_tenancy/patches/base_uploader.rb
+++ b/back/engines/commercial/multi_tenancy/app/uploaders/multi_tenancy/patches/base_uploader.rb
@@ -10,7 +10,10 @@ module MultiTenancy
 
       unless Rails.env.test?
         def asset_host
-          AppConfiguration.instance.base_asset_host_uri
+          # Read the host from `model` when possible to avoid an N+1 on tenant
+          # listing (AdminApi::TenantsController#index).
+          config = model.is_a?(AppConfiguration) ? model : AppConfiguration.instance
+          config.base_asset_host_uri
         rescue ActiveRecord::RecordNotFound
           # If there is no AppConfiguration, fall back on the default carrierwave
           # behavior (S3 in production).


### PR DESCRIPTION
This PR includes two improvements:
- Faster tenant creation. By caching the SQL dump that Apartment generates using `pg_dump`, we have faster tenant creation starting from the second created tenant after each release. The profiler output indicates this solution makes the tenant POST endpoint, which does not include template application that happens in the background, more than twice as fast.
- Faster listing of tenants. By using the model instead of `AppConfiguration.instance` in the base uploader, we avoid one case of N+1 queries. There's still more tenant queries happening that we should look into at some point. The profiler output indicates this solution makes listing of the tenants 12% faster.

Added a CDM point to discuss if we should consider using structure.sql.

With help from Claude.

# Changelog
### Fixed
- [TAN-7560] Tenant creation and listing tenants in Admin HQ should be somewhat faster now.
