### PR TITLE
TAN-7171 - Reduce number of calls to location APIs

### DIFF
--- a/front/app/components/HookForm/LocationInput/index.tsx
+++ b/front/app/components/HookForm/LocationInput/index.tsx
@@ -86,28 +86,22 @@ const LocationInput = ({
 
       fetchLocationDescription();
     }
-  }, [
-    latitude,
-    longitude,
-    locale,
-    name,
-    setValue,
-    locationDescription,
-    getLocationDescription,
-    touchedFields,
-  ]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [latitude, longitude, locale, name, setValue, getLocationDescription]);
 
   useEffect(() => {
     // If the location input is changed but no lat/lng have been provided in the URL params,
     // we geocode the location description to get the geojson.
-    if (locationDescription && !latitude && !longitude) {
+    // Only geocode when the user has actually changed the field (touchedFields)
+    // to avoid unnecessary calls when loading an existing idea for editing.
+    if (locationDescription && !latitude && !longitude && touchedFields[name]) {
       getLocationGeojson(locationDescription).then((location_point_geojson) => {
         setValue('location_point_geojson', {
           ...location_point_geojson,
         });
       });
     }
-  }, [latitude, locationDescription, longitude, setValue]);
+  }, [latitude, locationDescription, longitude, name, setValue, touchedFields]);
 
   const value = locationDescription
     ? {

--- a/front/app/components/HookForm/LocationInput/index.tsx
+++ b/front/app/components/HookForm/LocationInput/index.tsx
@@ -40,6 +40,7 @@ const LocationInput = ({
   const [searchParams] = useSearchParams();
   const latitude = searchParams.get('lat');
   const longitude = searchParams.get('lng');
+  const isTouched = !!touchedFields[name];
 
   const errors = get(formContextErrors, name) as RHFErrors;
   const validationError = errors?.message;
@@ -71,7 +72,7 @@ const LocationInput = ({
   const locationDescription = watch(name);
 
   useEffect(() => {
-    if (latitude && longitude && !touchedFields[name]) {
+    if (latitude && longitude && !isTouched) {
       const fetchLocationDescription = async () => {
         const location_description = await getLocationDescription();
         if (location_description) {
@@ -86,22 +87,29 @@ const LocationInput = ({
 
       fetchLocationDescription();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [latitude, longitude, locale, name, setValue, getLocationDescription]);
+  }, [
+    latitude,
+    longitude,
+    locale,
+    name,
+    setValue,
+    getLocationDescription,
+    isTouched,
+  ]);
 
   useEffect(() => {
     // If the location input is changed but no lat/lng have been provided in the URL params,
     // we geocode the location description to get the geojson.
     // Only geocode when the user has actually changed the field (touchedFields)
     // to avoid unnecessary calls when loading an existing idea for editing.
-    if (locationDescription && !latitude && !longitude && touchedFields[name]) {
+    if (locationDescription && !latitude && !longitude && isTouched) {
       getLocationGeojson(locationDescription).then((location_point_geojson) => {
         setValue('location_point_geojson', {
           ...location_point_geojson,
         });
       });
     }
-  }, [latitude, locationDescription, longitude, name, setValue, touchedFields]);
+  }, [latitude, locationDescription, longitude, name, setValue, isTouched]);
 
   const value = locationDescription
     ? {

--- a/front/app/components/HookForm/LocationInput/index.tsx
+++ b/front/app/components/HookForm/LocationInput/index.tsx
@@ -100,8 +100,7 @@ const LocationInput = ({
   useEffect(() => {
     // If the location input is changed but no lat/lng have been provided in the URL params,
     // we geocode the location description to get the geojson.
-    // Only geocode when the user has actually changed the field (touchedFields)
-    // to avoid unnecessary calls when loading an existing idea for editing.
+    // To avoid unnecessary calls, only geocode when the user has actually changed the field.
     if (locationDescription && !latitude && !longitude && isTouched) {
       getLocationGeojson(locationDescription).then((location_point_geojson) => {
         setValue('location_point_geojson', {

--- a/front/app/components/UI/LocationInput/index.tsx
+++ b/front/app/components/UI/LocationInput/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 import { Text } from '@citizenlab/cl2-component-library';
 import { debounce } from 'lodash-es';
@@ -36,36 +36,11 @@ export type LocationInputProps = React.ComponentProps<typeof AsyncSelect> & {
 const LocationInput = (props: LocationInputProps) => {
   const { formatMessage } = useIntl();
   const locale = useLocale();
-  const [defaultOptions, setDefaultOptions] = useState<Option[]>([]);
   const theme = useTheme();
 
-  useEffect(() => {
-    const fetchDefaultOptions = async () => {
-      try {
-        const response = await fetcher<TextSearchResponse>({
-          path: '/location/autocomplete',
-          action: 'get',
-          queryParams: {
-            input: props.value?.value,
-            language: locale,
-          },
-        });
-
-        return setDefaultOptions(
-          response.data.attributes.results?.map((item) => ({
-            label: item,
-            value: item,
-          })) || []
-        );
-      } catch (error) {
-        return setDefaultOptions([]);
-      }
-    };
-
-    if (props.value?.value) {
-      fetchDefaultOptions();
-    }
-  }, [locale, props.value?.value]);
+  const defaultOptions = props.value
+    ? [{ label: props.value.value, value: props.value.value }]
+    : [];
 
   const fetchOptions = useCallback(
     async (inputValue: string) => {

--- a/front/app/components/UI/LocationInput/index.tsx
+++ b/front/app/components/UI/LocationInput/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 
 import { Text } from '@citizenlab/cl2-component-library';
 import { debounce } from 'lodash-es';
@@ -98,32 +98,20 @@ const LocationInput = (props: LocationInputProps) => {
     [locale]
   );
 
-  // Using debounce limit the number of calls to the location API
-  // by waiting X seconds after the last key press
-  const debouncedFetchRef = useRef(
-    debounce(
-      (inputValue: string, resolve: (options: Option[]) => void) => {
+  const loadOptions = useMemo(
+    () =>
+      debounce((inputValue: string, resolve: (options: Option[]) => void) => {
         fetchOptions(inputValue).then(resolve);
-      },
-      500 // 0.5 seconds
-    )
+      }, 500),
+    [fetchOptions]
   );
-
-  useEffect(() => {
-    debouncedFetchRef.current = debounce(
-      (inputValue: string, resolve: (options: Option[]) => void) => {
-        fetchOptions(inputValue).then(resolve);
-      },
-      500
-    );
-  }, [fetchOptions]);
 
   const promiseOptions = useCallback(
     (inputValue: string) =>
       new Promise<Option[]>((resolve) => {
-        debouncedFetchRef.current(inputValue, resolve);
+        loadOptions(inputValue, resolve);
       }),
-    []
+    [loadOptions]
   );
 
   return (

--- a/front/app/components/UI/LocationInput/index.tsx
+++ b/front/app/components/UI/LocationInput/index.tsx
@@ -1,6 +1,7 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 
 import { Text } from '@citizenlab/cl2-component-library';
+import { debounce } from 'lodash-es';
 import AsyncSelect from 'react-select/async';
 import { useTheme } from 'styled-components';
 
@@ -66,33 +67,64 @@ const LocationInput = (props: LocationInputProps) => {
     }
   }, [locale, props.value?.value]);
 
-  const promiseOptions = async (inputValue: string) => {
-    try {
-      const response = await fetcher<TextSearchResponse>({
-        path: '/location/autocomplete',
-        action: 'get',
-        queryParams: {
-          input: inputValue,
-          language: locale,
-        },
-      });
+  const fetchOptions = useCallback(
+    async (inputValue: string) => {
+      try {
+        const response = await fetcher<TextSearchResponse>({
+          path: '/location/autocomplete',
+          action: 'get',
+          queryParams: {
+            input: inputValue,
+            language: locale,
+          },
+        });
 
-      const options =
-        response.data.attributes.results?.map((item) => ({
-          label: item,
-          value: item,
-        })) || [];
+        const options =
+          response.data.attributes.results?.map((item) => ({
+            label: item,
+            value: item,
+          })) || [];
 
-      // Add the inputValue as an option if it is a valid coordinate
-      if (isValidCoordinate(inputValue)) {
-        options.push({ label: inputValue, value: inputValue });
+        // Add the inputValue as an option if it is a valid coordinate
+        if (isValidCoordinate(inputValue)) {
+          options.push({ label: inputValue, value: inputValue });
+        }
+
+        return options;
+      } catch (error) {
+        return [];
       }
+    },
+    [locale]
+  );
 
-      return options;
-    } catch (error) {
-      return [];
-    }
-  };
+  // Using debounce limit the number of calls to the location API
+  // by waiting X seconds after the last key press
+  const debouncedFetchRef = useRef(
+    debounce(
+      (inputValue: string, resolve: (options: Option[]) => void) => {
+        fetchOptions(inputValue).then(resolve);
+      },
+      500 // 0.5 seconds
+    )
+  );
+
+  useEffect(() => {
+    debouncedFetchRef.current = debounce(
+      (inputValue: string, resolve: (options: Option[]) => void) => {
+        fetchOptions(inputValue).then(resolve);
+      },
+      500
+    );
+  }, [fetchOptions]);
+
+  const promiseOptions = useCallback(
+    (inputValue: string) =>
+      new Promise<Option[]>((resolve) => {
+        debouncedFetchRef.current(inputValue, resolve);
+      }),
+    []
+  );
 
   return (
     <AsyncSelect


### PR DESCRIPTION
The FE was quite chatty in a few places with the location APIs so to reduce costs I've tried to reduce the number of calls with the help of Claude:

front/app/components/UI/LocationInput/index.tsx                                                                                                                                                                                      
                                                                                                                                                                                                                                       
- Debounce on autocomplete requests: The autocomplete API (/location/autocomplete) was called on every keystroke. Added a 500ms debounce, so the API is only called after the user stops typing. 
- Removed autocomplete on mount: Previously, a useEffect called the autocomplete API whenever the component received a value (e.g. when editing an existing idea), storing results in defaultOptions state. This was replaced with a synchronous derivation — defaultOptions is now just the current value itself, avoiding the API call entirely. The loadOptions callback handles real autocomplete when the user types.                                                                                                                                            
                                                                                                                                                                                                                                     
front/app/components/HookForm/LocationInput/index.tsx

- Prevented unnecessary geocoding on edit: The geocode effect (/location/geocode) previously ran whenever locationDescription was set and no URL lat/lng params existed — including on initial load when editing an existing idea that already has a stored location_point_geojson. Added an isTouched guard so it only geocodes after the user has actually changed the field. 
- Fixed self-triggering effect: The URL-params effect had locationDescription in its dependency array despite not using it in the body. Since the effect itself calls setValue(name, ...) which updates locationDescription, it was re-triggering itself. Removed the unused dependency.
                                                                                                                                                                                                                                    
# Changelog
## Technical
- Added debounce to Geocoding autocompletes to limit requests
- Stop geocoding and autocomplete API calls when loading an idea for editing
