### PR TITLE
[TAN-7137] Fix email campaigns test fixture locale root key

### DIFF
--- a/back/engines/free/email_campaigns/spec/fixtures/locales/mailers.fr-FR.yml
+++ b/back/engines/free/email_campaigns/spec/fixtures/locales/mailers.fr-FR.yml
@@ -1,4 +1,4 @@
-fr:
+fr-FR:
   email_campaigns:
     campaign_type_description:
       "manual": Messages officiels


### PR DESCRIPTION
The production fr-FR.yml had its root key changed by Polyglit from `fr:` to `fr-FR:`, which meant it loaded directly under `fr-FR` and took priority over the test fixture (still under `fr:`). Update the fixture root key to match.

