### PR TITLE
[TAN-7162] Fix phase start_at/end_at timezone offset after date-to-datetime conversion

### DIFF
--- a/back/db/migrate/20260421105121_fix_phase_dates_timezone.rb
+++ b/back/db/migrate/20260421105121_fix_phase_dates_timezone.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Corrects phase start_at/end_at values that were converted from date to datetime
+# in UTC midnight instead of the tenant's local midnight.
+# See 20260309120000_change_phases_dates_to_timestamps.rb for the original migration.
+class FixPhaseDatesTimezone < ActiveRecord::Migration[7.2]
+  class Phase < ActiveRecord::Base
+    self.table_name = 'phases'
+  end
+
+  def up
+    tz = Time.zone.tzinfo.identifier
+
+    # Reinterpret UTC midnight as local midnight.
+    Phase
+      .where.not(start_at: nil)
+      .update_all("start_at = start_at AT TIME ZONE '#{tz}' AT TIME ZONE 'UTC'")
+
+    Phase
+      .where.not(end_at: nil)
+      .update_all("end_at = end_at AT TIME ZONE '#{tz}' AT TIME ZONE 'UTC'")
+  end
+
+  def down
+    tz = Time.zone.tzinfo.identifier
+
+    Phase
+      .where.not(start_at: nil)
+      .update_all("start_at = start_at AT TIME ZONE 'UTC' AT TIME ZONE '#{tz}'")
+
+    Phase
+      .where.not(end_at: nil)
+      .update_all("end_at = end_at AT TIME ZONE 'UTC' AT TIME ZONE '#{tz}'")
+  end
+end

--- a/back/db/structure.sql
+++ b/back/db/structure.sql
@@ -8510,6 +8510,7 @@ ALTER TABLE ONLY public.project_reviews
 SET search_path TO public,shared_extensions;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260421105121'),
 ('20260323120000'),
 ('20260313160000'),
 ('20260313120000'),

--- a/back/spec/db/migrate/fix_phase_dates_timezone_spec.rb
+++ b/back/spec/db/migrate/fix_phase_dates_timezone_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../../../db/migrate/20260421105121_fix_phase_dates_timezone'
+
+RSpec.describe FixPhaseDatesTimezone do
+  let(:migration) { described_class.new }
+
+  describe '#up' do
+    context 'with a positive UTC offset (Europe/Brussels, UTC+1/+2)' do
+      before do
+        settings = AppConfiguration.instance.settings
+        settings['core']['timezone'] = 'Europe/Brussels'
+        AppConfiguration.instance.update!(settings: settings)
+      end
+
+      it 'shifts start_at and end_at from UTC midnight to local midnight' do
+        # Simulate the state left by the original migration: UTC midnight values
+        phase = create(:phase, start_at: '2026-03-15T00:00:00Z', end_at: '2026-04-15T00:00:00Z')
+
+        migration.up
+
+        phase.reload
+
+        expect(phase.start_at).to eq(Time.utc(2026, 3, 14, 23, 0, 0)) # UTC+1 in March (CET)
+        expect(phase.end_at).to eq(Time.utc(2026, 4, 14, 22, 0, 0)) # UTC+2 in April (CEST)
+
+        # Verify the user-facing dates are correct
+        expect(phase.start_date).to eq(Date.new(2026, 3, 15))
+        expect(phase.end_date).to eq(Date.new(2026, 4, 14))
+      end
+    end
+
+    context 'with a negative UTC offset (America/New_York, EDT=UTC-4)' do
+      before do
+        settings = AppConfiguration.instance.settings
+        settings['core']['timezone'] = 'America/New_York'
+        AppConfiguration.instance.update!(settings: settings)
+      end
+
+      it 'shifts start_at and end_at from UTC midnight to local midnight' do
+        phase = create(:phase, start_at: '2026-03-15T00:00:00Z', end_at: '2026-04-15T00:00:00Z')
+
+        migration.up
+
+        phase.reload
+        # New York is EDT (UTC-4) during this time period
+        expect(phase.start_at).to eq(Time.utc(2026, 3, 15, 4, 0, 0))
+        expect(phase.end_at).to eq(Time.utc(2026, 4, 15, 4, 0, 0))
+
+        expect(phase.start_date).to eq(Date.new(2026, 3, 15))
+        expect(phase.end_date).to eq(Date.new(2026, 4, 14))
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Changelog
## Technical
- [TAN-7162] Fix phase start_at/end_at timezone offset after date-to-datetime conversion. Migration 20260309120000 converted phase dates to datetimes using UTC midnight, ignoring tenant timezones. Add a corrective migration that uses PostgreSQL's AT TIME ZONE to reinterpret the naive values as local midnight for each tenant.


