### PR TITLE
TAN-7554 Email bug: Sending manual campaigns twice

### DIFF
--- a/back/engines/free/email_campaigns/app/controllers/email_campaigns/web_api/v1/campaigns_controller.rb
+++ b/back/engines/free/email_campaigns/app/controllers/email_campaigns/web_api/v1/campaigns_controller.rb
@@ -98,9 +98,7 @@ module EmailCampaigns
     end
 
     def do_send
-      if !@campaign.valid?(:send)
-        render json: { errors: @campaign.errors.details }, status: :unprocessable_entity
-      elsif SendManualCampaignService.new.call(@campaign, current_user)
+      if @campaign.valid?(:send) && SendManualCampaignService.new.call(@campaign, current_user)
         render json: WebApi::V1::CampaignSerializer.new(
           @campaign.reload,
           params: jsonapi_serializer_params

--- a/back/engines/free/email_campaigns/app/controllers/email_campaigns/web_api/v1/campaigns_controller.rb
+++ b/back/engines/free/email_campaigns/app/controllers/email_campaigns/web_api/v1/campaigns_controller.rb
@@ -98,13 +98,9 @@ module EmailCampaigns
     end
 
     def do_send
-      if @campaign.valid?(:send)
-        SideFxCampaignService.new.before_send(@campaign, current_user)
-        @campaign.with_lock do
-          @campaign.clear_scheduled_at!
-          EmailCampaigns::DeliveryService.new.send_now(@campaign)
-        end
-        SideFxCampaignService.new.after_send(@campaign, current_user)
+      if !@campaign.valid?(:send)
+        render json: { errors: @campaign.errors.details }, status: :unprocessable_entity
+      elsif SendManualCampaignService.new.call(@campaign, current_user)
         render json: WebApi::V1::CampaignSerializer.new(
           @campaign.reload,
           params: jsonapi_serializer_params

--- a/back/engines/free/email_campaigns/app/jobs/email_campaigns/send_scheduled_campaign_job.rb
+++ b/back/engines/free/email_campaigns/app/jobs/email_campaigns/send_scheduled_campaign_job.rb
@@ -13,11 +13,7 @@ module EmailCampaigns
                 campaign.scheduled_at.blank? ||
                 campaign.scheduled_at != expected_scheduled_at
 
-      campaign.with_lock do
-        campaign.clear_scheduled_at!
-        DeliveryService.new.send_now(campaign)
-      end
-      SideFxCampaignService.new.after_send(campaign, campaign.author)
+      SendManualCampaignService.new.call(campaign, campaign.author)
     end
   end
 end

--- a/back/engines/free/email_campaigns/app/policies/email_campaigns/campaign_policy.rb
+++ b/back/engines/free/email_campaigns/app/policies/email_campaigns/campaign_policy.rb
@@ -35,7 +35,7 @@ module EmailCampaigns
     end
 
     def do_send?
-      update?
+      can_access_and_modify?
     end
 
     def send_preview?

--- a/back/engines/free/email_campaigns/app/services/email_campaigns/send_manual_campaign_service.rb
+++ b/back/engines/free/email_campaigns/app/services/email_campaigns/send_manual_campaign_service.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module EmailCampaigns
+  class SendManualCampaignService
+    def call(campaign, user)
+      # The sent? check must happen inside with_lock to prevent race conditions.
+      # CampaignPolicy#update? also checks sent?, but that runs before the lock
+      # is acquired, so concurrent requests can both pass the policy check while
+      # deliveries from the first request are still uncommitted.
+      campaign.with_lock do
+        if campaign.sent?
+          campaign.errors.add(:base, :already_sent, message: 'This campaign has already been sent')
+          false
+        else
+          campaign.clear_scheduled_at!
+          DeliveryService.new.send_now(campaign)
+          SideFxCampaignService.new.after_send(campaign, user)
+          true
+        end
+      end
+    end
+  end
+end

--- a/back/engines/free/email_campaigns/spec/acceptance/campaigns_spec.rb
+++ b/back/engines/free/email_campaigns/spec/acceptance/campaigns_spec.rb
@@ -551,6 +551,13 @@ resource 'Campaigns' do
         assert_status 422
         expect(json_response_body).to include_response_error(:base, 'no_recipients')
       end
+
+      example '[error] Send a campaign that has already been sent' do
+        create(:delivery, campaign: campaign)
+        do_request
+        assert_status 422
+        expect(json_response_body).to include_response_error(:base, 'already_sent')
+      end
     end
 
     get 'web_api/v1/campaigns/:id/deliveries' do

--- a/back/engines/free/email_campaigns/spec/services/email_campaigns/send_manual_campaign_service_spec.rb
+++ b/back/engines/free/email_campaigns/spec/services/email_campaigns/send_manual_campaign_service_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe EmailCampaigns::SendManualCampaignService do
+  subject(:service) { described_class.new }
+
+  let(:user) { create(:admin) }
+
+  describe '#call' do
+    let(:campaign) { create(:manual_campaign) }
+    let!(:users) { create_list(:user, 3) }
+
+    it 'sends to all recipients and returns true' do
+      result = service.call(campaign, user)
+      expect(result).to be true
+      expect(campaign.deliveries.count).to eq User.count
+    end
+
+    it 'clears scheduled_at' do
+      campaign.scheduled_at = 2.hours.from_now
+      campaign.save!
+      service.call(campaign, user)
+      expect(campaign.reload.scheduled_at).to be_nil
+    end
+
+    context 'when the campaign has already been sent' do
+      before { create(:delivery, campaign: campaign) }
+
+      it 'returns false with an already_sent error' do
+        result = service.call(campaign, user)
+        expect(result).to be false
+        expect(campaign.errors.details[:base]).to include(error: :already_sent)
+      end
+
+      it 'does not create additional deliveries' do
+        expect { service.call(campaign, user) }.not_to change(campaign.deliveries, :count)
+      end
+    end
+  end
+end


### PR DESCRIPTION
When sending to large recipient lists, the HTTP request can time out (504) while the backend continues processing. The frontend shows an error and still displays the Send button, allowing users to trigger a second send and resulting in duplicate emails to all recipients.

There are at least 5 issues:
- The do_send endpoint can time out because emails are sent out synchronously.
- The frontend cannot handle the timeout error well and crashes (front/app/containers/Admin/messaging/CustomEmails/Show/index.tsx#L302-L305).
- The frontend allows sending the email campaign twice in this situation because the data is not refreshed in this situation.
- The backend allows sending the email campaign twice because of a race condition. The policy check runs before the lock is acquired (which creates a transaction and that's why the second send does not see that the first send has happened). This is fixed in this PR.
- The draft status is implicitly modelled as not having deliveries. Explicit modelling would have avoided this.


# Changelog
### Fixed
[TAN-7554] Initial fix to prevent sending manual campaigns twice.
