### PR TITLE
TAN-6013: Enable multi-locale input for common ground statements

### DIFF
--- a/front/app/components/CustomFieldsForm/CustomFields.tsx
+++ b/front/app/components/CustomFieldsForm/CustomFields.tsx
@@ -42,23 +42,26 @@ const renderField = ({
   question,
   projectId,
   ideaId,
+  participationMethod,
   scrollErrorIntoView = true,
 }: {
   question: IFlatCustomField;
   projectId?: string;
   ideaId?: string;
+  participationMethod?: ParticipationMethod;
   scrollErrorIntoView?: boolean;
 }) => {
   // Only user fields can be locked (disabled) for now due to a verification method!
   // Possible user fields are: text, number, multiline_text, select, multiselect, checkbox, date
   const disabled = question.constraints?.locked;
+  const hideLocaleSwitcher = participationMethod !== 'common_ground';
 
   switch (question.input_type) {
     case 'text_multiloc':
       return (
         <InputMultilocWithLocaleSwitcher
           name={question.key}
-          hideLocaleSwitcher
+          hideLocaleSwitcher={hideLocaleSwitcher}
           maxCharCount={question.max_characters}
           scrollErrorIntoView={scrollErrorIntoView}
           disabled={disabled}
@@ -69,7 +72,7 @@ const renderField = ({
       return (
         <QuillMultilocWithLocaleSwitcher
           name={question.key}
-          hideLocaleSwitcher
+          hideLocaleSwitcher={hideLocaleSwitcher}
           scrollErrorIntoView={scrollErrorIntoView}
           id={question.key}
           maxCharCount={question.max_characters}
@@ -334,6 +337,7 @@ const CustomFields = ({
                     question,
                     projectId,
                     ideaId,
+                    participationMethod,
                     scrollErrorIntoView,
                   })}
                 </Box>

--- a/front/app/components/CustomFieldsForm/IdeationForm/index.tsx
+++ b/front/app/components/CustomFieldsForm/IdeationForm/index.tsx
@@ -72,13 +72,21 @@ const IdeationForm = ({
 
   const onSubmit = async (formValues: FormValues) => {
     if (currentPageIndex === nestedPagesData.length - 2) {
-      const { translatedTitle, translatedBody, weglotData } =
-        await weglotTranslateIdeaSubmission(
-          formValues.title_multiloc?.[locale],
-          formValues.body_multiloc?.[locale],
-          locale,
-          appConfiguration?.data.attributes.settings.core.weglot_api_key
-        );
+      // Common ground lets admins enter the statement in every platform locale,
+      // so the full multiloc hash must be preserved and auto-translation is skipped.
+      const isCommonGround = participationMethod === 'common_ground';
+      const { translatedTitle, translatedBody, weglotData } = isCommonGround
+        ? {
+            translatedTitle: undefined,
+            translatedBody: undefined,
+            weglotData: {},
+          }
+        : await weglotTranslateIdeaSubmission(
+            formValues.title_multiloc?.[locale],
+            formValues.body_multiloc?.[locale],
+            locale,
+            appConfiguration?.data.attributes.settings.core.weglot_api_key
+          );
       const translatedFormValues = {
         ...formValues,
         ...(translatedTitle !== undefined && {


### PR DESCRIPTION
# Changelog

## Changed
- When creating a common ground statement, the title field now shows a language switcher so you can enter the statement in every platform language.
