### PR TITLE
[TAN-7607] Remove unnecessary personal data checkbox for FormSync imports

### DIFF
--- a/back/engines/commercial/bulk_import_ideas/app/controllers/bulk_import_ideas/web_api/v1/bulk_import_controller.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/controllers/bulk_import_ideas/web_api/v1/bulk_import_controller.rb
@@ -131,7 +131,7 @@ module BulkImportIdeas
     def bulk_create_params
       params
         .require(:import)
-        .permit(%i[file locale personal_data pages_per_form])
+        .permit(%i[file locale pages_per_form])
     end
 
     def authorize_bulk_import_ideas
@@ -150,7 +150,7 @@ module BulkImportIdeas
 
     def file_parser_service
       locale = params[:import] ? bulk_create_params[:locale] : current_user.locale
-      personal_data_enabled = params[:import] ? bulk_create_params[:personal_data] || false : false
+      personal_data_enabled = @phase.custom_form&.print_personal_data_fields || false
       pages_per_form = params[:import] ? bulk_create_params[:pages_per_form]&.to_i : nil
       pages_per_form = nil if pages_per_form&.zero?
       phase_id = params[:id]

--- a/front/app/api/import_ideas/useAddImportedIdeasAsync.ts
+++ b/front/app/api/import_ideas/useAddImportedIdeasAsync.ts
@@ -12,7 +12,6 @@ interface RequestParams {
   file: string;
   format: string;
   locale: SupportedLocale;
-  personal_data: boolean;
   pages_per_form?: number;
 }
 
@@ -26,13 +25,12 @@ const addOfflineIdeas = async ({
   file,
   format,
   locale,
-  personal_data,
   pages_per_form,
 }: RequestParams): Promise<JobIdResponse> =>
   fetcher<JobIdResponse>({
     path: `/phases/${phase_id}/importer/bulk_create_async/idea/${format}`,
     action: 'post',
-    body: { import: { file, locale, personal_data, pages_per_form } },
+    body: { import: { file, locale, pages_per_form } },
   });
 
 const useAddOfflineIdeasAsync = () => {

--- a/front/app/containers/Admin/projects/project/inputImporter/ImportModal/ImportExcelModal.tsx
+++ b/front/app/containers/Admin/projects/project/inputImporter/ImportModal/ImportExcelModal.tsx
@@ -81,7 +81,6 @@ const ImportExcelModal = ({ open, onClose, onImport }: Props) => {
         phase_id: phaseId,
         file: file.base64,
         format: 'xlsx',
-        personal_data: false,
         locale,
       });
 

--- a/front/app/containers/Admin/projects/project/inputImporter/ImportModal/ImportPdfModal.tsx
+++ b/front/app/containers/Admin/projects/project/inputImporter/ImportModal/ImportPdfModal.tsx
@@ -36,7 +36,6 @@ import messages from './messages';
 interface FormValues {
   locale: SupportedLocale;
   file?: Record<string, any>;
-  personal_data: boolean;
   multiple_forms: boolean;
   pages_per_form: number | undefined;
 }
@@ -65,7 +64,6 @@ const ImportPdfModal = ({ open, onClose, onImport }: Props) => {
   const defaultValues = {
     locale,
     file: undefined,
-    personal_data: false,
     multiple_forms: false,
     pages_per_form: undefined,
   };
@@ -73,7 +71,6 @@ const ImportPdfModal = ({ open, onClose, onImport }: Props) => {
   const schema = object({
     locale: validateLocale().required(),
     file: mixed().required(formatMessage(messages.pleaseUploadFile)),
-    personal_data: boolean().required(),
     multiple_forms: boolean().required(),
     pages_per_form: number()
       .transform((value, originalValue) =>
@@ -105,7 +102,6 @@ const ImportPdfModal = ({ open, onClose, onImport }: Props) => {
   const submitFile = async ({
     file,
     locale,
-    personal_data,
     multiple_forms,
     pages_per_form,
   }: FormValues) => {
@@ -117,7 +113,6 @@ const ImportPdfModal = ({ open, onClose, onImport }: Props) => {
         file: file?.base64,
         format: 'pdf',
         locale,
-        personal_data,
         pages_per_form: multiple_forms ? pages_per_form : undefined,
       });
 
@@ -195,12 +190,6 @@ const ImportPdfModal = ({ open, onClose, onImport }: Props) => {
               </Box>
             )}
 
-            <Box mt="24px">
-              <CheckboxWithLabel
-                name="personal_data"
-                label={<FormattedMessage {...messages.formHasPersonalData} />}
-              />
-            </Box>
             <Box w="100%" display="flex" mt="32px">
               <Button
                 bgColor={colors.primary}


### PR DESCRIPTION
# Changelog
## Changed
- [TAN-7607] Remove unnecessary personal data checkbox for FormSync imports (we can use the saved print_personal_data_fields value in BE instead).
