### PR TITLE
TAN-7576 - Azure AD SSO with no email

### DIFF
--- a/back/app/models/concerns/user_confirmation.rb
+++ b/back/app/models/concerns/user_confirmation.rb
@@ -21,9 +21,9 @@ module UserConfirmation
     # we only say that the user requires confirmation if they have requested to set their
     # email.
     # If they haven't, we will regard them as not requiring confirmation.
-    is_verified_sso_user_without_email = sso? && verified && email.nil? && new_email.nil?
+    is_sso_user_without_email = sso? && email.nil? && new_email.nil?
 
-    user_confirmation_enabled? && confirmation_required && !is_verified_sso_user_without_email
+    user_confirmation_enabled? && confirmation_required && !is_sso_user_without_email
   end
 
   def confirm

--- a/back/app/models/concerns/user_confirmation.rb
+++ b/back/app/models/concerns/user_confirmation.rb
@@ -21,9 +21,9 @@ module UserConfirmation
     # we only say that the user requires confirmation if they have requested to set their
     # email.
     # If they haven't, we will regard them as not requiring confirmation.
-    is_sso_user_without_email = sso? && email.nil? && new_email.nil?
+    is_verified_sso_user_without_email = sso? && verified && email.nil? && new_email.nil?
 
-    user_confirmation_enabled? && confirmation_required && !is_sso_user_without_email
+    user_confirmation_enabled? && confirmation_required && !is_verified_sso_user_without_email
   end
 
   def confirm

--- a/back/app/services/anonymous_name_service.rb
+++ b/back/app/services/anonymous_name_service.rb
@@ -31,7 +31,7 @@ class AnonymousNameService
   end
 
   def name_key
-    @user.email || @user.unique_code || @user.id
+    @user.email || @user.unique_code || @user.id || SecureRandom.hex(8)
   end
 
   def scheme

--- a/back/lib/omniauth_methods/azure_active_directory.rb
+++ b/back/lib/omniauth_methods/azure_active_directory.rb
@@ -12,9 +12,9 @@ module OmniauthMethods
 
     def profile_to_user_attrs(auth)
       {
-        first_name: auth.info['first_name'],
-        last_name: auth.info['last_name'],
-        email: nil, # auth.info['email'],
+        first_name: auth.info['first_name'] || auth.info['name'],
+        last_name: auth.info['last_name'] || auth.info['name'],
+        email: auth.info['email'],
         remote_avatar_url: remote_avatar_url(auth),
         locale: AppConfiguration.instance.closest_locale_to(auth.extra.raw_info.locale)
       }

--- a/back/lib/omniauth_methods/azure_active_directory.rb
+++ b/back/lib/omniauth_methods/azure_active_directory.rb
@@ -12,9 +12,9 @@ module OmniauthMethods
 
     def profile_to_user_attrs(auth)
       {
-        first_name: auth.info['first_name'] || auth.info['name'],
-        last_name: auth.info['last_name'] || auth.info['name'],
-        email: auth.info['email'],
+        first_name: auth.info['first_name'].presence || auth.info['name'],
+        last_name: auth.info['last_name'].presence || auth.info['name'],
+        email: auth.info['email'].presence,
         remote_avatar_url: remote_avatar_url(auth),
         locale: AppConfiguration.instance.closest_locale_to(auth.extra.raw_info.locale)
       }
@@ -32,10 +32,6 @@ module OmniauthMethods
 
     def email_always_present?
       false
-    end
-
-    def email_confirmed?(auth)
-      auth&.info['email']&.present?
     end
 
     def updateable_user_attrs

--- a/back/lib/omniauth_methods/azure_active_directory.rb
+++ b/back/lib/omniauth_methods/azure_active_directory.rb
@@ -34,8 +34,12 @@ module OmniauthMethods
       false
     end
 
-    def email_confirmed?(_auth)
-      false
+    def email_confirmed?(auth)
+      auth&.info['email']&.present?
+    end
+
+    def updateable_user_attrs
+      super + %i[remote_avatar_url]
     end
 
     private
@@ -45,9 +49,5 @@ module OmniauthMethods
 
       auth.info['image']
     end
-  end
-
-  def updateable_user_attrs
-    super + %i[remote_avatar_url]
   end
 end

--- a/back/lib/omniauth_methods/azure_active_directory.rb
+++ b/back/lib/omniauth_methods/azure_active_directory.rb
@@ -14,7 +14,7 @@ module OmniauthMethods
       {
         first_name: auth.info['first_name'],
         last_name: auth.info['last_name'],
-        email: auth.info['email'],
+        email: nil, # auth.info['email'],
         remote_avatar_url: remote_avatar_url(auth),
         locale: AppConfiguration.instance.closest_locale_to(auth.extra.raw_info.locale)
       }
@@ -28,6 +28,14 @@ module OmniauthMethods
       return [] if domains_str.blank?
 
       domains_str.split(',').map { |d| d.strip.downcase }.compact_blank
+    end
+
+    def email_always_present?
+      false
+    end
+
+    def email_confirmed?(_auth)
+      false
     end
 
     private

--- a/back/spec/lib/omniauth_methods/azure_active_directory_spec.rb
+++ b/back/spec/lib/omniauth_methods/azure_active_directory_spec.rb
@@ -4,10 +4,11 @@ require 'rails_helper'
 
 describe OmniauthMethods::AzureActiveDirectory do
   describe 'profile_to_user_attrs' do
-    it 'correctly interprets gender, locale and image for google' do
-      auth = OpenStruct.new({
+    let(:auth) do
+      OpenStruct.new({
         provider: 'azureactivedirectory',
         info: OpenStruct.new({
+          'name' => 'jos_jossens',
           'first_name' => 'Jos',
           'last_name' => 'Jossens',
           'email' => 'jos@josnet.com',
@@ -19,11 +20,37 @@ describe OmniauthMethods::AzureActiveDirectory do
           })
         })
       })
+    end
 
+    it 'correctly interprets user attributes for Azure AD' do
       expect(subject.profile_to_user_attrs(auth)).to match({
         first_name: 'Jos',
         last_name: 'Jossens',
         email: 'jos@josnet.com',
+        remote_avatar_url: 'http://www.josnet.com/my-picture',
+        locale: 'fr-FR'
+      })
+    end
+
+    it 'correctly interprets user attributes when email is nil' do
+      auth.info['email'] = nil
+      expect(subject.profile_to_user_attrs(auth)).to match({
+        first_name: 'Jos',
+        last_name: 'Jossens',
+        email: nil,
+        remote_avatar_url: 'http://www.josnet.com/my-picture',
+        locale: 'fr-FR'
+      })
+    end
+
+    it 'correctly interprets user attributes when email and names are empty' do
+      auth.info['email'] = ''
+      auth.info['first_name'] = ''
+      auth.info['last_name'] = ''
+      expect(subject.profile_to_user_attrs(auth)).to match({
+        first_name: 'jos_jossens',
+        last_name: 'jos_jossens',
+        email: nil,
         remote_avatar_url: 'http://www.josnet.com/my-picture',
         locale: 'fr-FR'
       })


### PR DESCRIPTION
# Changelog
## Changed
- Allow Azure AD to be used where accounts do not have an email address