### PR TITLE
TAN-7513 Support navbar item to folder association in tenant templates

### DIFF
--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/nav_bar_item.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/serializers/nav_bar_item.rb
@@ -4,7 +4,7 @@ module MultiTenancy
   module Templates
     module Serializers
       class NavBarItem < Base
-        ref_attributes %i[static_page project]
+        ref_attributes %i[static_page project project_folder]
         attributes %i[code ordering title_multiloc]
       end
     end

--- a/back/engines/commercial/multi_tenancy/spec/services/multi_tenancy/templates/tenant_serializer_spec.rb
+++ b/back/engines/commercial/multi_tenancy/spec/services/multi_tenancy/templates/tenant_serializer_spec.rb
@@ -51,6 +51,20 @@ describe MultiTenancy::Templates::TenantSerializer do
       expect(home_attributes['title_multiloc']).to be_blank
     end
 
+    it 'preserves nav bar item references to project folders' do
+      folder = create(:project_folder, title_multiloc: { 'en' => 'My folder' })
+      create(:nav_bar_item, project_folder: folder, static_page: nil, title_multiloc: { 'en' => 'Folder link' })
+
+      template = tenant_serializer.run(deserializer_format: true)
+
+      tenant = create(:tenant, locales: AppConfiguration.instance.settings('core', 'locales'))
+      tenant.switch do
+        MultiTenancy::Templates::TenantDeserializer.new.deserialize(template)
+        nav_bar_item = NavBarItem.find_by(title_multiloc: { 'en' => 'Folder link' })
+        expect(nav_bar_item.project_folder.title_multiloc).to eq({ 'en' => 'My folder' })
+      end
+    end
+
     it 'can deal with nested admin publications in projects' do
       create(:project, title_multiloc: { 'en' => 'top-project' })
       create(


### PR DESCRIPTION
The NavBarItem serializer was missing project_folder from ref_attributes, causing folder references to be silently dropped during template serialization.


# Changelog
### Fixed
- [TAN-7513] Support navbar item to folder association in tenant templates
