### PR TITLE
TAN-7610 - Add helper text to demographic questions when they appear inline in the form

### DIFF
--- a/front/app/components/CustomFieldsForm/CustomFieldsSignupHelperText/index.tsx
+++ b/front/app/components/CustomFieldsForm/CustomFieldsSignupHelperText/index.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import { Box } from '@citizenlab/cl2-component-library';
+
+import useAppConfiguration from 'api/app_configuration/useAppConfiguration';
+
+import useLocalize from 'hooks/useLocalize';
+
+import T from 'components/T';
+import QuillEditedContent from 'components/UI/QuillEditedContent';
+
+const CustomFieldsSignupHelperText = () => {
+  const { data: appConfiguration } = useAppConfiguration();
+  const localize = useLocalize();
+
+  const helperText =
+    appConfiguration?.data.attributes.settings.core
+      .custom_fields_signup_helper_text;
+  const localizedHelperText = localize(helperText);
+
+  if (!helperText || !localizedHelperText || localizedHelperText.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box mb="20px">
+      <QuillEditedContent fontSize="base">
+        <T value={helperText} supportHtml />
+      </QuillEditedContent>
+    </Box>
+  );
+};
+
+export default CustomFieldsSignupHelperText;

--- a/front/app/components/CustomFieldsForm/IdeationForm/IdeationPage.tsx
+++ b/front/app/components/CustomFieldsForm/IdeationForm/IdeationPage.tsx
@@ -19,6 +19,7 @@ import ProfileVisiblity from 'containers/IdeasNewPage/IdeasNewIdeationForm/Profi
 
 import AnonymousParticipationConfirmationModal from 'components/AnonymousParticipationConfirmationModal';
 import ContentUploadDisclaimer from 'components/ContentUploadDisclaimer';
+import CustomFieldsSignupHelperText from 'components/CustomFieldsForm/CustomFieldsSignupHelperText';
 import SubmissionReference from 'components/CustomFieldsForm/SubmissionReference';
 import Feedback from 'components/HookForm/Feedback';
 
@@ -274,6 +275,10 @@ const IdeationPage = ({
                 <Box p="24px" w="100%">
                   <Box display="flex" flexDirection="column">
                     <PageTitle page={page} />
+
+                    {page.key === 'user_page' && (
+                      <CustomFieldsSignupHelperText />
+                    )}
 
                     {currentPageIndex === 0 && isAdmin(authUser) && (
                       <Box mb="24px">

--- a/front/app/components/CustomFieldsForm/SurveyForm/SurveyPage.tsx
+++ b/front/app/components/CustomFieldsForm/SurveyForm/SurveyPage.tsx
@@ -16,6 +16,7 @@ import useLocalize from 'hooks/useLocalize';
 
 import { triggerPostParticipationFlow } from 'containers/Authentication/events';
 
+import CustomFieldsSignupHelperText from 'components/CustomFieldsForm/CustomFieldsSignupHelperText';
 import SubmissionReference from 'components/CustomFieldsForm/SubmissionReference';
 import Feedback from 'components/HookForm/Feedback';
 
@@ -342,6 +343,10 @@ const SurveyPage = ({
                   <Box p="24px" w="100%">
                     <Box display="flex" flexDirection="column">
                       <PageTitle page={page} />
+
+                      {page.key === 'user_page' && (
+                        <CustomFieldsSignupHelperText />
+                      )}
 
                       <CustomFields
                         questions={pageQuestions}


### PR DESCRIPTION
Makes the text from here:
<img width="595" height="591" alt="image" src="https://github.com/user-attachments/assets/0c9654df-6c01-4542-b955-5d81348bc058" />

Appear here (as well as in the normal registration modal where it already appears):
<img width="725" height="738" alt="image" src="https://github.com/user-attachments/assets/0527a606-5d88-4dd0-ba0b-567dac95e4fc" />

# Changelog
## Changed
- Added helper text to demographic questions when they appear inline in the form
