### PR TITLE
[TAN-7428] Add FM and SM to Intercom attributes

### DIFF
--- a/back/app/services/track_intercom_service.rb
+++ b/back/app/services/track_intercom_service.rb
@@ -32,7 +32,7 @@ class TrackIntercomService
   def track_user?(user)
     return false if user.super_admin?
 
-    user.admin? || user.project_moderator?
+    UserRoleService.new.moderates_something?(user)
   end
 
   def identify_tenant(tenant)
@@ -80,6 +80,8 @@ class TrackIntercomService
       isAdmin: user.admin?,
       isSuperAdmin: user.super_admin?,
       isProjectModerator: user.project_moderator?,
+      isProjectFolderModerator: user.project_folder_moderator?,
+      isSpaceModerator: user.space_moderator?,
       highestRole: user.highest_role.to_s
     }
   end

--- a/back/lib/tasks/single_use/20260428_backfill_intercom_user_attributes.rake
+++ b/back/lib/tasks/single_use/20260428_backfill_intercom_user_attributes.rake
@@ -1,0 +1,125 @@
+# Backfills Intercom contact custom attributes (isAdmin, highestRole, etc.)
+# for trackable users after the US -> EU Intercom workspace migration, which
+# left many existing contacts with empty CDA values.
+#
+# Reuses TrackIntercomService#identify_user so the production code path runs
+# (including the MultiTenancy patch that links the contact to its company).
+#
+# Usage:
+#   # Dry run across all active tenants:
+#   rake single_use:backfill_intercom_user_attributes
+#
+#   # Execute for real:
+#   rake single_use:backfill_intercom_user_attributes[execute]
+#
+#   # Limit to a single tenant (host) for staged rollout:
+#   rake single_use:backfill_intercom_user_attributes[execute,my-tenant.govocal.com]
+
+namespace :single_use do
+  desc 'Backfill Intercom contact custom attributes after US->EU migration'
+  task :backfill_intercom_user_attributes, %i[execute tenant_host] => [:environment] do |_t, args|
+    execute = args[:execute] == 'execute'
+    tenant_host_filter = args[:tenant_host].presence
+
+    puts "---------- STARTING TASK: Backfill Intercom user attributes ----------\n"
+    puts "Mode: #{execute ? 'EXECUTE - Intercom API calls WILL be made' : 'Dry run - no API calls'}"
+    puts "Tenant filter: #{tenant_host_filter || '(all active tenants with intercom feature on)'}\n\n"
+
+    unless INTERCOM_CLIENT
+      puts 'INTERCOM_CLIENT is not configured (no INTERCOM_TOKEN env var). Aborting.'
+      next
+    end
+
+    reporter = ScriptReporter.new
+    # Tune if you hit 429s. Intercom contact-search is more restrictive than
+    # the global limit; ~6-10 req/sec is a safe starting point.
+    sleep_between_users = 0.15
+
+    # Returns true when the contact already has every CDA we'd write set to
+    # the same value — in which case the update is a no-op and we can skip
+    # the API call. Stringifies keys on both sides so symbol/string mismatch
+    # in Intercom's response shape doesn't trip us up.
+    contact_already_populated = lambda do |contact, desired_attrs|
+      current = (contact.custom_attributes || {}).transform_keys(&:to_s)
+      desired_attrs.all? { |k, v| current[k.to_s] == v }
+    end
+
+    Tenant.safe_switch_each do |tenant|
+      next if tenant_host_filter && tenant.host != tenant_host_filter
+
+      app_config = AppConfiguration.instance
+      next unless app_config.settings['core']['lifecycle_stage'] == 'active'
+      next unless app_config.feature_activated?('intercom')
+
+      puts "Processing tenant: #{tenant.host}"
+      reporter.add_processed_tenant(tenant)
+
+      service = TrackIntercomService.new
+      updated = 0
+      created = 0
+      already_populated = 0
+      skipped = 0
+      errored = 0
+
+      User.active.find_each do |user|
+        unless service.track_user?(user)
+          skipped += 1
+          next
+        end
+
+        begin
+          # Pre-search so we can log update vs create distinctly and skip
+          # contacts whose CDAs are already correct. Costs an extra API call
+          # per user in execute mode (identify_user re-searches internally),
+          # but for a one-off backfill that's fine — and surfaces external_id
+          # mismatches that would otherwise silently create duplicates.
+          existing_contact = service.send(:search_contact, user)
+          sleep sleep_between_users
+          desired_attrs = service.user_attributes(user)
+
+          if existing_contact.nil?
+            puts "  #{execute ? 'CREATING' : 'Would CREATE'} user #{user.id} (#{user.email}) — no Intercom contact found by external_id"
+            if execute
+              service.identify_user(user)
+              reporter.add_create(
+                'Intercom::Contact',
+                { user_id: user.id, attributes: desired_attrs },
+                context: { tenant: tenant.host, action: 'create' }
+              )
+              sleep sleep_between_users
+            end
+            created += 1
+          elsif contact_already_populated.call(existing_contact, desired_attrs)
+            already_populated += 1
+          else
+            puts "  #{execute ? 'Updating' : 'Would update'} user #{user.id} (#{user.email}) — highest_role=#{user.highest_role}"
+            if execute
+              service.identify_user(user)
+              reporter.add_change(
+                { user_id: user.id, status: 'pre-backfill' },
+                { user_id: user.id, attributes: desired_attrs },
+                context: { tenant: tenant.host, action: 'update' }
+              )
+              sleep sleep_between_users
+            end
+            updated += 1
+          end
+        rescue StandardError => e
+          errored += 1
+          puts "  ERROR for user #{user.id}: #{e.class}: #{e.message}"
+          reporter.add_error(
+            "#{e.class}: #{e.message}",
+            context: { tenant: tenant.host, user_id: user.id }
+          )
+        end
+      end
+
+      verb = execute ? '' : 'Would '
+      puts "  #{verb}update #{updated}, #{verb}create #{created}, already populated #{already_populated}, skipped #{skipped}, errored #{errored}"
+    end
+
+    reporter.report!('backfill_intercom_user_attributes.json', verbose: true)
+
+    puts "\n---------- FINISHED TASK ----------\n"
+  end
+end

--- a/back/lib/tasks/single_use/20260428_backfill_intercom_user_attributes.rake
+++ b/back/lib/tasks/single_use/20260428_backfill_intercom_user_attributes.rake
@@ -33,7 +33,7 @@ namespace :single_use do
     reporter = ScriptReporter.new
     # Tune if you hit 429s. Intercom contact-search is more restrictive than
     # the global limit; ~6-10 req/sec is a safe starting point.
-    sleep_between_users = 0.15
+    sleep_between_users = 0.25
 
     # Returns true when the contact already has every CDA we'd write set to
     # the same value — in which case the update is a no-op and we can skip

--- a/back/lib/tasks/single_use/20260428_backfill_intercom_user_attributes.rake
+++ b/back/lib/tasks/single_use/20260428_backfill_intercom_user_attributes.rake
@@ -61,8 +61,11 @@ namespace :single_use do
       skipped = 0
       errored = 0
 
-      User.active.find_each do |user|
-        unless service.track_user?(user)
+      # Pre-filter at SQL level: only users with a non-empty roles array can
+      # possibly be tracked. The remaining super_admin? check is email-regex
+      # based and can't be expressed in SQL.
+      User.active.not_normal_user.find_each do |user|
+        if user.super_admin?
           skipped += 1
           next
         end

--- a/back/spec/services/track_intercom_service_spec.rb
+++ b/back/spec/services/track_intercom_service_spec.rb
@@ -6,6 +6,32 @@ describe TrackIntercomService do
   let(:intercom) { double(INTERCOM_CLIENT).as_null_object }
   let(:service) { described_class.new(intercom) }
 
+  describe 'track_user?' do
+    it 'returns true for admins' do
+      expect(service.track_user?(create(:admin))).to be true
+    end
+
+    it 'returns true for project moderators' do
+      expect(service.track_user?(create(:project_moderator))).to be true
+    end
+
+    it 'returns true for project folder moderators' do
+      expect(service.track_user?(create(:project_folder_moderator))).to be true
+    end
+
+    it 'returns true for space moderators' do
+      expect(service.track_user?(create(:space_moderator))).to be true
+    end
+
+    it 'returns false for regular users' do
+      expect(service.track_user?(create(:user))).to be false
+    end
+
+    it 'returns false for super admins, even though they are admins' do
+      expect(service.track_user?(create(:super_admin))).to be false
+    end
+  end
+
   describe 'identify_user' do
     it "doesn't interact with Intercom when the given user is not an admin or moderator" do
       user = create(:user)
@@ -37,6 +63,8 @@ describe TrackIntercomService do
           isAdmin: true,
           isSuperAdmin: false,
           isProjectModerator: false,
+          isProjectFolderModerator: false,
+          isSpaceModerator: false,
           highestRole: 'admin',
           firstName: user.first_name,
           lastName: user.last_name,
@@ -67,6 +95,8 @@ describe TrackIntercomService do
           isAdmin: true,
           isSuperAdmin: false,
           isProjectModerator: false,
+          isProjectFolderModerator: false,
+          isSpaceModerator: false,
           highestRole: 'admin',
           firstName: user.first_name,
           lastName: user.last_name,
@@ -75,6 +105,50 @@ describe TrackIntercomService do
       )
 
       expect(contacts_api).to receive(:save).with(contact).and_return(contact)
+
+      service.identify_user(user)
+    end
+
+    it 'creates an Intercom contact for a project folder moderator with the correct role flags' do
+      user = create(:project_folder_moderator)
+
+      contacts_api = double
+      expect(intercom).to receive(:contacts).twice.and_return(contacts_api)
+      expect(contacts_api).to receive(:search).and_return(OpenStruct.new({ count: 0 }))
+
+      expect(contacts_api).to receive(:create).with(
+        hash_including(
+          custom_attributes: hash_including(
+            isAdmin: false,
+            isProjectModerator: false,
+            isProjectFolderModerator: true,
+            isSpaceModerator: false,
+            highestRole: 'project_folder_moderator'
+          )
+        )
+      ).and_return(double.as_null_object)
+
+      service.identify_user(user)
+    end
+
+    it 'creates an Intercom contact for a space moderator with the correct role flags' do
+      user = create(:space_moderator)
+
+      contacts_api = double
+      expect(intercom).to receive(:contacts).twice.and_return(contacts_api)
+      expect(contacts_api).to receive(:search).and_return(OpenStruct.new({ count: 0 }))
+
+      expect(contacts_api).to receive(:create).with(
+        hash_including(
+          custom_attributes: hash_including(
+            isAdmin: false,
+            isProjectModerator: false,
+            isProjectFolderModerator: false,
+            isSpaceModerator: true,
+            highestRole: 'space_moderator'
+          )
+        )
+      ).and_return(double.as_null_object)
 
       service.identify_user(user)
     end
@@ -107,6 +181,28 @@ describe TrackIntercomService do
           action: 'published'
         )
       })
+
+      service.track_activity(activity)
+    end
+
+    it 'sends the activity to Intercom for a project folder moderator' do
+      user = create(:project_folder_moderator)
+      activity = build(:activity, user: user)
+
+      events_api = double
+      expect(intercom).to receive(:events).and_return(events_api)
+      expect(events_api).to receive(:create)
+
+      service.track_activity(activity)
+    end
+
+    it 'sends the activity to Intercom for a space moderator' do
+      user = create(:space_moderator)
+      activity = build(:activity, user: user)
+
+      events_api = double
+      expect(intercom).to receive(:events).and_return(events_api)
+      expect(events_api).to receive(:create)
 
       service.track_activity(activity)
     end

--- a/back/spec/tasks/single_use/backfill_intercom_user_attributes_spec.ignore.rb
+++ b/back/spec/tasks/single_use/backfill_intercom_user_attributes_spec.ignore.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-# rubocop:disable RSpec/DescribeClass, RSpec/AnyInstance
+# rubocop:disable RSpec/DescribeClass, RSpec/VerifiedDoubles, Style/OpenStructUse
 describe 'single_use:backfill_intercom_user_attributes rake task' do
   let(:contacts_api) { double('contacts_api') }
   let(:intercom_client) { double('intercom_client', contacts: contacts_api).as_null_object }
@@ -27,7 +27,7 @@ describe 'single_use:backfill_intercom_user_attributes rake task' do
 
   describe 'dry run' do
     it 'searches existing contacts but makes no writes' do
-      user = create(:admin)
+      create(:admin)
       contact = double('contact', custom_attributes: {}).as_null_object
 
       expect(contacts_api).to receive(:search).once.and_return(double(count: 1, :[] => contact))
@@ -183,4 +183,4 @@ describe 'single_use:backfill_intercom_user_attributes rake task' do
     end
   end
 end
-# rubocop:enable RSpec/DescribeClass, RSpec/AnyInstance
+# rubocop:enable RSpec/DescribeClass, RSpec/VerifiedDoubles, Style/OpenStructUse

--- a/back/spec/tasks/single_use/backfill_intercom_user_attributes_spec.ignore.rb
+++ b/back/spec/tasks/single_use/backfill_intercom_user_attributes_spec.ignore.rb
@@ -1,0 +1,186 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# rubocop:disable RSpec/DescribeClass, RSpec/AnyInstance
+describe 'single_use:backfill_intercom_user_attributes rake task' do
+  let(:contacts_api) { double('contacts_api') }
+  let(:intercom_client) { double('intercom_client', contacts: contacts_api).as_null_object }
+  let(:task) { Rake::Task['single_use:backfill_intercom_user_attributes'] }
+
+  before do
+    load_rake_tasks_if_not_loaded
+    stub_const('INTERCOM_CLIENT', intercom_client)
+    SettingsService.new.activate_feature!('intercom')
+    # The task sleeps between users for rate limiting; suppress in tests.
+    allow_any_instance_of(Object).to receive(:sleep)
+  end
+
+  after { task.reenable }
+
+  # Build a contact's current custom_attributes hash from what the service
+  # would write — keeps the test in sync with TrackIntercomService and the
+  # MultiTenancy patch (which adds tenantId, tenantHost, etc.).
+  def populated_attrs_for(user)
+    TrackIntercomService.new.user_attributes(user).transform_keys(&:to_s)
+  end
+
+  describe 'dry run' do
+    it 'searches existing contacts but makes no writes' do
+      user = create(:admin)
+      contact = double('contact', custom_attributes: {}).as_null_object
+
+      expect(contacts_api).to receive(:search).once.and_return(double(count: 1, :[] => contact))
+      expect(contacts_api).not_to receive(:save)
+      expect(contacts_api).not_to receive(:create)
+
+      task.invoke
+    end
+
+    it 'reports a would-create when no Intercom contact exists' do
+      create(:admin)
+
+      expect(contacts_api).to receive(:search).once.and_return(OpenStruct.new(count: 0))
+      expect(contacts_api).not_to receive(:create)
+
+      task.invoke
+    end
+  end
+
+  describe 'execute mode' do
+    it 'updates an existing Intercom contact whose CDAs are missing' do
+      user = create(:admin)
+      contact = double('contact', custom_attributes: {}).as_null_object
+
+      # search runs twice: once for the pre-check, once inside identify_user.
+      expect(contacts_api).to receive(:search).twice.and_return(double(count: 1, :[] => contact))
+      expect(contact).to receive(:custom_attributes=).with(hash_including(
+        isAdmin: true,
+        isSuperAdmin: false,
+        isProjectModerator: false,
+        isProjectFolderModerator: false,
+        isSpaceModerator: false,
+        highestRole: 'admin',
+        firstName: user.first_name,
+        lastName: user.last_name,
+        locale: user.locale
+      ))
+      expect(contacts_api).to receive(:save).with(contact).and_return(contact)
+
+      task.invoke('execute')
+    end
+
+    it 'skips contacts whose CDAs are already fully populated (no save, no second search)' do
+      user = create(:admin)
+      contact = double('contact', custom_attributes: populated_attrs_for(user))
+
+      # Only the pre-check search runs; we skip identify_user entirely.
+      expect(contacts_api).to receive(:search).once.and_return(double(count: 1, :[] => contact))
+      expect(contacts_api).not_to receive(:save)
+      expect(contacts_api).not_to receive(:create)
+
+      task.invoke('execute')
+    end
+
+    it 'still updates when CDAs are partially populated (e.g. missing a new role flag)' do
+      user = create(:admin)
+      stale = populated_attrs_for(user)
+      stale.delete('isProjectFolderModerator') # newly added CDA never set on this contact
+      contact = double('contact', custom_attributes: stale).as_null_object
+
+      expect(contacts_api).to receive(:search).twice.and_return(double(count: 1, :[] => contact))
+      expect(contact).to receive(:custom_attributes=).with(hash_including(isProjectFolderModerator: false))
+      expect(contacts_api).to receive(:save).with(contact).and_return(contact)
+
+      task.invoke('execute')
+    end
+
+    it 'creates a new contact when none exists' do
+      user = create(:admin)
+
+      expect(contacts_api).to receive(:search).twice.and_return(OpenStruct.new(count: 0))
+      expect(contacts_api).to receive(:create).with(hash_including(
+        external_id: user.id,
+        email: user.email,
+        custom_attributes: hash_including(isAdmin: true, highestRole: 'admin')
+      )).and_return(double.as_null_object)
+
+      task.invoke('execute')
+    end
+
+    it 'skips super admins and regular users without searching Intercom' do
+      create(:super_admin)
+      create(:user)
+
+      expect(contacts_api).not_to receive(:search)
+      expect(contacts_api).not_to receive(:save)
+      expect(contacts_api).not_to receive(:create)
+
+      task.invoke('execute')
+    end
+
+    it 'processes folder moderators with the right role flags' do
+      create(:project_folder_moderator)
+
+      expect(contacts_api).to receive(:search).twice.and_return(OpenStruct.new(count: 0))
+      expect(contacts_api).to receive(:create).with(hash_including(
+        custom_attributes: hash_including(
+          isAdmin: false,
+          isProjectFolderModerator: true,
+          isSpaceModerator: false,
+          highestRole: 'project_folder_moderator'
+        )
+      )).and_return(double.as_null_object)
+
+      task.invoke('execute')
+    end
+
+    it 'processes space moderators with the right role flags' do
+      create(:space_moderator)
+
+      expect(contacts_api).to receive(:search).twice.and_return(OpenStruct.new(count: 0))
+      expect(contacts_api).to receive(:create).with(hash_including(
+        custom_attributes: hash_including(
+          isAdmin: false,
+          isProjectFolderModerator: false,
+          isSpaceModerator: true,
+          highestRole: 'space_moderator'
+        )
+      )).and_return(double.as_null_object)
+
+      task.invoke('execute')
+    end
+
+    it 'continues processing remaining users when one user errors' do
+      failing_user = create(:admin)
+      ok_contact = double('ok_contact', custom_attributes: {}).as_null_object
+
+      allow(contacts_api).to receive(:search) do |query:|
+        query_value = query[:value] || query['value']
+        if query_value == failing_user.id
+          raise StandardError, 'simulated Intercom failure'
+        else
+          double(count: 1, :[] => ok_contact)
+        end
+      end
+      expect(contacts_api).to receive(:save).with(ok_contact).and_return(ok_contact)
+
+      create(:admin) # ok user
+      expect { task.invoke('execute') }.not_to raise_error
+    end
+  end
+
+  describe 'tenant scoping' do
+    it 'does nothing when intercom feature is not activated on the tenant' do
+      SettingsService.new.deactivate_feature!('intercom')
+      create(:admin)
+
+      expect(contacts_api).not_to receive(:search)
+      expect(contacts_api).not_to receive(:create)
+      expect(contacts_api).not_to receive(:save)
+
+      task.invoke('execute')
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass, RSpec/AnyInstance


### PR DESCRIPTION
I think these changes are needed, but I won't release until I meet with Nola (Tues 28/4/26), get access to Intercom, and have an understanding of what these changes might cause on Intercom (e.g. will we spam users with welcome emails if we detect a new role for them? etc)

# Changelog
## Fixed
- [TAN-7428] Fix updates of intercom contacts attributes + backfill the missing intercom contact attributes
