### PR TITLE
[TAN-7605] Don't link to folder settings in BO projects list unless can moderate folder

### DIFF
--- a/back/app/serializers/web_api/v1/project_mini_admin_serializer.rb
+++ b/back/app/serializers/web_api/v1/project_mini_admin_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class WebApi::V1::ProjectMiniAdminSerializer < WebApi::V1::BaseSerializer
-  attributes(:title_multiloc, :visible_to, :listed, :space_id)
+  attributes(:title_multiloc, :visible_to, :listed)
 
   attribute :publication_status do |object|
     object.admin_publication.publication_status

--- a/back/app/serializers/web_api/v1/project_mini_admin_serializer.rb
+++ b/back/app/serializers/web_api/v1/project_mini_admin_serializer.rb
@@ -37,6 +37,8 @@ class WebApi::V1::ProjectMiniAdminSerializer < WebApi::V1::BaseSerializer
 
   has_one :folder
 
+  has_one :space
+
   has_many :project_images, serializer: WebApi::V1::ImageSerializer
 
   has_many :phases, serializer: WebApi::V1::PhaseSerializer

--- a/back/spec/serializers/project_mini_admin_serializer_spec.rb
+++ b/back/spec/serializers/project_mini_admin_serializer_spec.rb
@@ -38,4 +38,21 @@ describe WebApi::V1::ProjectMiniAdminSerializer do
     phase_ids = serialized_project2.dig(:data, :relationships, :phases, :data).pluck(:id)
     expect(phase_ids).to eq(project2.phases.pluck(:id).map(&:to_s))
   end
+
+  it 'exposes the folder relationship' do
+    expect(serialized_project.dig(:data, :relationships, :folder, :data, :id)).to eq(folder.id)
+  end
+
+  it 'exposes the space relationship when the project belongs to a space' do
+    space = create(:space)
+    folder.update!(space: space)
+    project.reload.update!(space: space)
+
+    serialized = described_class.new(project, params: { current_user: user }).serializable_hash
+    expect(serialized.dig(:data, :relationships, :space, :data, :id)).to eq(space.id)
+  end
+
+  it 'exposes a nil space relationship when the project has no space' do
+    expect(serialized_project.dig(:data, :relationships, :space, :data)).to be_nil
+  end
 end

--- a/front/app/api/projects_mini_admin/types.ts
+++ b/front/app/api/projects_mini_admin/types.ts
@@ -78,6 +78,9 @@ export type ProjectMiniAdminData = {
     folder?: {
       data: IRelationship | null;
     };
+    space?: {
+      data: IRelationship | null;
+    };
     phases?: {
       data: IRelationship[];
     };

--- a/front/app/containers/Admin/projects/all/Projects/Table/Row.test.tsx
+++ b/front/app/containers/Admin/projects/all/Projects/Table/Row.test.tsx
@@ -1,0 +1,154 @@
+import React from 'react';
+
+import {
+  Table as TableComponent,
+  Tbody,
+} from '@citizenlab/cl2-component-library';
+
+import { ProjectMiniAdminData } from 'api/projects_mini_admin/types';
+
+import { TRole } from 'utils/permissions/roles';
+import { render, screen, userEvent } from 'utils/testUtils/rtl';
+
+import Row from './Row';
+
+let mockAuthUserRoles: TRole[] = [];
+
+jest.mock('api/me/useAuthUser', () => () => ({
+  data: {
+    data: {
+      id: 'me',
+      type: 'user',
+      attributes: {
+        first_name: 'Test',
+        last_name: 'User',
+        roles: mockAuthUserRoles,
+        highest_role: 'user',
+      },
+    },
+  },
+}));
+
+jest.mock('api/project_images/useProjectImage', () => () => ({
+  data: undefined,
+}));
+
+const project: ProjectMiniAdminData = {
+  id: 'project-1',
+  type: 'project_mini_admin',
+  attributes: {
+    current_phase_start_date: null,
+    current_phase_end_date: null,
+    first_phase_start_date: null,
+    first_published_at: null,
+    folder_title_multiloc: { en: 'Test folder' },
+    last_phase_end_date: null,
+    listed: true,
+    publication_status: 'published',
+    title_multiloc: { en: 'Test project' },
+    visible_to: 'public',
+  },
+  relationships: {
+    folder: { data: { id: 'folder-1', type: 'project_folder' } },
+    space: { data: { id: 'space-1', type: 'space' } },
+    phases: { data: [] },
+    project_images: { data: [] },
+    groups: { data: [] },
+    moderators: { data: [] },
+  },
+};
+
+const renderRow = () =>
+  render(
+    <TableComponent>
+      <Tbody>
+        <Row project={project} firstRow />
+      </Tbody>
+    </TableComponent>
+  );
+
+const findRowLink = () =>
+  screen.getByText('Test project').closest('a') as HTMLAnchorElement;
+
+describe('Projects table Row — folder link', () => {
+  beforeEach(() => {
+    mockAuthUserRoles = [];
+  });
+
+  it('does not link to the folder when the user cannot moderate it', async () => {
+    mockAuthUserRoles = [];
+    renderRow();
+
+    await userEvent.hover(screen.getByText('Test folder'));
+
+    expect(findRowLink()).toHaveAttribute(
+      'href',
+      expect.stringContaining(`/admin/projects/${project.id}`)
+    );
+    expect(findRowLink().getAttribute('href')).not.toContain(
+      'folders/folder-1'
+    );
+  });
+
+  it('does not link to the folder for a moderator of a different folder', async () => {
+    mockAuthUserRoles = [
+      { type: 'project_folder_moderator', project_folder_id: 'other-folder' },
+    ];
+    renderRow();
+
+    await userEvent.hover(screen.getByText('Test folder'));
+
+    expect(findRowLink().getAttribute('href')).not.toContain(
+      'folders/folder-1'
+    );
+  });
+
+  it('links to the folder when the user is a moderator of that folder', async () => {
+    mockAuthUserRoles = [
+      { type: 'project_folder_moderator', project_folder_id: 'folder-1' },
+    ];
+    renderRow();
+
+    await userEvent.hover(screen.getByText('Test folder'));
+
+    expect(findRowLink()).toHaveAttribute(
+      'href',
+      expect.stringContaining('/admin/projects/folders/folder-1')
+    );
+  });
+
+  it('links to the folder when the user is an admin', async () => {
+    mockAuthUserRoles = [{ type: 'admin' }];
+    renderRow();
+
+    await userEvent.hover(screen.getByText('Test folder'));
+
+    expect(findRowLink()).toHaveAttribute(
+      'href',
+      expect.stringContaining('/admin/projects/folders/folder-1')
+    );
+  });
+
+  it("links to the folder when the user is a space moderator of the folder's space", async () => {
+    mockAuthUserRoles = [{ type: 'space_moderator', space_id: 'space-1' }];
+    renderRow();
+
+    await userEvent.hover(screen.getByText('Test folder'));
+
+    expect(findRowLink()).toHaveAttribute(
+      'href',
+      expect.stringContaining('/admin/projects/folders/folder-1')
+    );
+  });
+
+  it('does not link to the folder for a space moderator of a different space', async () => {
+    mockAuthUserRoles = [{ type: 'space_moderator', space_id: 'other-space' }];
+    renderRow();
+
+    await userEvent.hover(screen.getByText('Test folder'));
+
+    expect(findRowLink().getAttribute('href')).not.toContain(
+      'folders/folder-1'
+    );
+  });
+});

--- a/front/app/containers/Admin/projects/all/Projects/Table/Row.tsx
+++ b/front/app/containers/Admin/projects/all/Projects/Table/Row.tsx
@@ -24,7 +24,7 @@ import Error from 'components/UI/Error';
 
 import Link from 'utils/cl-router/Link';
 import { parseBackendDateString } from 'utils/dateUtils';
-import { canModerateFolder } from 'utils/permissions/rules/projectFolderPermissions';
+import { userModeratesFolder } from 'utils/permissions/rules/projectFolderPermissions';
 
 import ManagerBubbles from '../../_shared/ManagerBubbles';
 import RowImage from '../../_shared/RowImage';
@@ -86,7 +86,7 @@ const Row = ({
   const folderId = project.relationships.folder?.data?.id;
   const folderSpaceId = project.relationships.space?.data?.id;
   const canModerateThisFolder =
-    !!folderId && canModerateFolder(authUser, folderId, folderSpaceId);
+    !!folderId && userModeratesFolder(authUser, folderId, folderSpaceId);
 
   const handleActionLoading = (actionType: ActionType, isRunning: boolean) => {
     if (actionType === 'copying') {

--- a/front/app/containers/Admin/projects/all/Projects/Table/Row.tsx
+++ b/front/app/containers/Admin/projects/all/Projects/Table/Row.tsx
@@ -9,6 +9,7 @@ import {
   colors,
 } from '@citizenlab/cl2-component-library';
 
+import useAuthUser from 'api/me/useAuthUser';
 import useProjectImage from 'api/project_images/useProjectImage';
 import { ProjectMiniAdminData } from 'api/projects_mini_admin/types';
 import { IUserData } from 'api/users/types';
@@ -23,6 +24,7 @@ import Error from 'components/UI/Error';
 
 import Link from 'utils/cl-router/Link';
 import { parseBackendDateString } from 'utils/dateUtils';
+import { canModerateFolder } from 'utils/permissions/rules/projectFolderPermissions';
 
 import ManagerBubbles from '../../_shared/ManagerBubbles';
 import RowImage from '../../_shared/RowImage';
@@ -44,6 +46,7 @@ const Row = ({
   moderatorsById,
 }: Props) => {
   const localize = useLocalize();
+  const { data: authUser } = useAuthUser();
 
   const imageId = project.relationships.project_images.data[0]?.id;
   const { data: image } = useProjectImage({
@@ -81,6 +84,9 @@ const Row = ({
   };
 
   const folderId = project.relationships.folder?.data?.id;
+  const folderSpaceId = project.relationships.space?.data?.id;
+  const canModerateThisFolder =
+    !!folderId && canModerateFolder(authUser, folderId, folderSpaceId);
 
   const handleActionLoading = (actionType: ActionType, isRunning: boolean) => {
     if (actionType === 'copying') {
@@ -91,7 +97,7 @@ const Row = ({
   };
 
   const link =
-    hover === 'folder'
+    hover === 'folder' && canModerateThisFolder
       ? (`/admin/projects/folders/${folderId}` as const)
       : (`/admin/projects/${project.id}` as const);
 
@@ -135,9 +141,17 @@ const Row = ({
                 m="0"
                 fontSize="xs"
                 color="textSecondary"
-                textDecoration={hover === 'folder' ? 'underline' : 'none'}
-                onMouseEnter={() => setHover('folder')}
-                onMouseLeave={() => setHover('project')}
+                textDecoration={
+                  hover === 'folder' && canModerateThisFolder
+                    ? 'underline'
+                    : 'none'
+                }
+                onMouseEnter={
+                  canModerateThisFolder ? () => setHover('folder') : undefined
+                }
+                onMouseLeave={
+                  canModerateThisFolder ? () => setHover('project') : undefined
+                }
               >
                 {localize(folder_title_multiloc)}
               </Text>

--- a/front/app/utils/permissions/rules/projectFolderPermissions.ts
+++ b/front/app/utils/permissions/rules/projectFolderPermissions.ts
@@ -21,6 +21,21 @@ export function userModeratesFolder(
   return isAdmin(user) || isProjectFolderModerator(user, projectFolderId);
 }
 
+// Mirrors the backend's UserRoleService#can_moderate?(folder, user): direct or
+// indirect moderation rights, including space moderators of the folder's space.
+export function canModerateFolder(
+  user: IUser | undefined,
+  folderId: string,
+  folderSpaceId?: string | null
+) {
+  if (!user) return false;
+
+  return (
+    userModeratesFolder(user, folderId) ||
+    (typeof folderSpaceId === 'string' && isSpaceModerator(user, folderSpaceId))
+  );
+}
+
 export const userModeratesSpace = (
   user: IUser | undefined,
   spaceId: string

--- a/front/app/utils/permissions/rules/projectFolderPermissions.ts
+++ b/front/app/utils/permissions/rules/projectFolderPermissions.ts
@@ -14,24 +14,14 @@ import {
 
 export function userModeratesFolder(
   user: IUser | undefined,
-  projectFolderId: string
-) {
-  if (!user) return false;
-
-  return isAdmin(user) || isProjectFolderModerator(user, projectFolderId);
-}
-
-// Mirrors the backend's UserRoleService#can_moderate?(folder, user): direct or
-// indirect moderation rights, including space moderators of the folder's space.
-export function canModerateFolder(
-  user: IUser | undefined,
-  folderId: string,
+  projectFolderId: string,
   folderSpaceId?: string | null
 ) {
   if (!user) return false;
 
   return (
-    userModeratesFolder(user, folderId) ||
+    isAdmin(user) ||
+    isProjectFolderModerator(user, projectFolderId) ||
     (typeof folderSpaceId === 'string' && isSpaceModerator(user, folderSpaceId))
   );
 }


### PR DESCRIPTION
- extends `userModeratesFolder` to include space_moderator who moderates folder
- adds space relationship to `ProjectMiniAdminSerializer` to facilitate the new FE method
- removes unused `space_id` from `ProjectMiniAdminSerializer`
- adds FE tests of the new functionality (Claude wrote them)

Note: This is probably the lowest effort way to solve this issue, but maybe this is best given my lack of sophistication with the FE and its permissions related code. Please tell me if this is not an adequate solution.

# Changelog
## Fixed
- [TAN-7605] Don't link to folder settings in back office projects list unless can manage folder.

