### PR TITLE
Make quill use <b> tag by default instead of <strong>

### DIFF
--- a/front/app/components/UI/QuillEditor/configureQuill.ts
+++ b/front/app/components/UI/QuillEditor/configureQuill.ts
@@ -39,7 +39,7 @@ export const configureQuill = () => {
   Quill.register('modules/blotFormatter', BlotFormatter);
 
   class CustomBold extends Bold {}
-  CustomBold.tagName = 'B';
+  CustomBold.tagName = ['B'];
   Quill.register('formats/bold', CustomBold, true);
 
   // BEGIN allow video resizing styles

--- a/front/app/components/UI/QuillEditor/configureQuill.ts
+++ b/front/app/components/UI/QuillEditor/configureQuill.ts
@@ -1,6 +1,7 @@
 import BlotFormatter from '@enzedonline/quill-blot-formatter2';
 import Quill from 'quill';
 import QuillInline from 'quill/blots/inline';
+import Bold from 'quill/formats/bold';
 import QuillLink from 'quill/formats/link';
 import Video from 'quill/formats/video';
 
@@ -36,6 +37,10 @@ export const configureQuill = () => {
   );
 
   Quill.register('modules/blotFormatter', BlotFormatter);
+
+  class CustomBold extends Bold {}
+  CustomBold.tagName = 'B';
+  Quill.register('formats/bold', CustomBold, true);
 
   // BEGIN allow video resizing styles
   class VideoFormat extends Video {


### PR DESCRIPTION
# Changelog
## Fixed
- a11y - Quill editor now uses < b > tag for bold content rather than < strong >

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
