### PR TITLE
TAN-7657-a11y/fix-buttons-accessible-name

### DIFF
--- a/front/app/components/ReactionControl/ReactionButton.tsx
+++ b/front/app/components/ReactionControl/ReactionButton.tsx
@@ -464,13 +464,6 @@ const ReactionButton = ({
               ) : (
                 <FormattedMessage {...messages.vote} />
               )}
-              <ScreenReaderOnly>
-                <FormattedMessage
-                  {...{ up: messages.like, down: messages.dislike }[
-                    buttonReactionMode
-                  ]}
-                />
-              </ScreenReaderOnly>
             </ButtonComponent>
           )}
           {variant === 'icon' && (

--- a/front/app/components/UI/GoBackButton/GoBackButtonSolid.tsx
+++ b/front/app/components/UI/GoBackButton/GoBackButtonSolid.tsx
@@ -45,12 +45,11 @@ const GoBackButtonSolid = ({
       whiteSpace="normal"
       onClick={handleClick}
       linkTo={linkTo}
-      text={text}
     >
       <Box
         as="span"
         display={isSmallerThanPhone ? 'none' : 'block'}
-        aria-hidden
+        aria-hidden="true"
       >
         {text}
       </Box>

--- a/front/app/components/UI/GoBackButton/GoBackButtonSolid.tsx
+++ b/front/app/components/UI/GoBackButton/GoBackButtonSolid.tsx
@@ -49,7 +49,7 @@ const GoBackButtonSolid = ({
       <Box
         as="span"
         display={isSmallerThanPhone ? 'none' : 'block'}
-        aria-hidden="true"
+        aria-hidden
       >
         {text}
       </Box>


### PR DESCRIPTION
# Description 

1- The text is already passed as children to `GoBackButtonSolid`, so it doesn’t need to be passed again via `ButtonWithLink`. 
The text prop on `ButtonWithLink` was overriding  `<ScreenReaderOnly>` and make the content unreachable. 
Removing it ensures the correct accessible text is used.

2- Remove duplicate screen reader announcement for vote button success

Currently, the vote button triggers the success message twice for screen readers:

Through the `<ScreenReaderOnly>` element inside `ReactionButton.tsx `(`<span>Like</span>`)
Through the ARIA live region set via `setScreenReaderReactionSuccessMessage` (`<span aria-live="polite">You liked this input successfully.</span>`)
Fix
Remove the `<ScreenReaderOnly>` block from the vote button. The existing aria-live="polite" live region already handles announcing the action result, so keeping both causes duplication and inconsistent button labeling for screen readers

# A11y
- fix buttons accessible name 

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
