### PR TITLE
[TAN-7662] Quickfix: show existing translation in confirm seat modal

### DIFF
--- a/front/app/components/admin/SeatBasedBilling/SeatLimitReachedModal/index.tsx
+++ b/front/app/components/admin/SeatBasedBilling/SeatLimitReachedModal/index.tsx
@@ -75,7 +75,10 @@ const SeatLimitReachedModal = ({
           data-cy="seat-limit-reached-body"
         >
           <Text color="textPrimary" fontSize="m" mt="0" mb="24px">
-            <FormattedMessage {...messages.hasReachedOrIsOverLimit} />
+            <FormattedMessage
+              {...messages.hasReachedOrIsOverLimit}
+              values={{ noOfSeats: 1 }}
+            />
           </Text>
           <Box mb="24px">
             <SeatInfo seatType={seatType} />

--- a/front/app/components/admin/SeatBasedBilling/SeatLimitReachedModal/messages.ts
+++ b/front/app/components/admin/SeatBasedBilling/SeatLimitReachedModal/messages.ts
@@ -12,7 +12,7 @@ export default defineMessages({
   hasReachedOrIsOverLimit: {
     id: 'app.containers.admin.addCollaboratorsModal.hasReachedOrIsOverLimit',
     defaultMessage:
-      'You have reached the limit of included seats within your plan, 1 additional seat will be added.',
+      'You have reached the limit of included seats within your plan, {noOfSeats} additional {noOfSeats, plural, one {seat} other {seats}} will be added.',
   },
   buyAdditionalSeats: {
     id: 'app.containers.admin.addCollaboratorsModal.buyAdditionalSeats1',


### PR DESCRIPTION
Lowest effort fix to get the translation working again.

If we really want to, we can also follow up with a new translation key + simplified translations string (no interpolated vars in string) - but will need to wait for translation approvals, etc.

# Changelog
## Fixed
- [TAN-7662] Quick fix: show existing translations in confirm seat modal
