### PR TITLE
Restore lost da-DK approvals

### DIFF
--- a/front/app/translations/.polyglit.da-DK.json.json
+++ b/front/app/translations/.polyglit.da-DK.json.json
@@ -1,13 +1,13193 @@
 {
-  "app.components.form.controls.rankingDragHandleLabel": {
+  "EmailSettingsPage.emailSettings": {
     "state": "verified",
-    "verified_at": "2026-04-22T16:13:29.827729Z",
-    "verified_by": "Edwin Kato"
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "EmailSettingsPage.initialUnsubscribeError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "EmailSettingsPage.initialUnsubscribeLoading": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "EmailSettingsPage.initialUnsubscribeSuccess": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "UI.FormComponents.optional": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.closeIconButton.a11y_buttonActionMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Areas.areaUpdateError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Areas.followedArea": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Areas.followedTopic": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Areas.topicUpdateError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Areas.unfollowedArea": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Areas.unfollowedTopic": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AssignBudgetControl.a11y_price": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AssignBudgetControl.add": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AssignBudgetControl.added": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AssignMultipleVotesControl.addVote": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AssignMultipleVotesControl.maxCreditsInTotalReached": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AssignMultipleVotesControl.maxCreditsPerInputReached": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AssignMultipleVotesControl.maxPercentsInTotalReached2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AssignMultipleVotesControl.maxPercentsPerInputReached2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AssignMultipleVotesControl.maxPointsInTotalReached": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AssignMultipleVotesControl.maxPointsPerInputReached": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AssignMultipleVotesControl.maxTokensInTotalReached": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AssignMultipleVotesControl.maxTokensPerInputReached": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AssignMultipleVotesControl.maxVotesInTotalReached": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AssignMultipleVotesControl.maxVotesPerInputReached1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AssignMultipleVotesControl.numberManualVotes2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AssignMultipleVotesControl.phaseNotActive": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AssignMultipleVotesControl.removeVote": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AssignMultipleVotesControl.select": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AssignMultipleVotesControl.votesSubmitted1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AssignMultipleVotesControl.votesSubmittedIdeaPage1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AssignMultipleVotesControl.xCredits1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AssignMultipleVotesControl.xPercents2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AssignMultipleVotesControl.xPoints1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AssignMultipleVotesControl.xTokens1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AssignMultipleVotesControl.xVotes3": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AssignVoteControl.maxVotesReached1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AssignVoteControl.phaseNotActive": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AssignVoteControl.select": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AssignVoteControl.selected2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AssignVoteControl.voteForAtLeastOne": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AssignVoteControl.votesSubmitted1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AssignVoteControl.votesSubmittedIdeaPage1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AuthProviders.continue": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AuthProviders.continueWithAzure": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AuthProviders.continueWithFacebook": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AuthProviders.continueWithFakeSSO": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AuthProviders.continueWithFedera": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AuthProviders.continueWithGoogle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AuthProviders.continueWithHoplr": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AuthProviders.continueWithIdAustria": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AuthProviders.continueWithLoginMechanism": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AuthProviders.continueWithNemlogIn": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AuthProviders.franceConnectMergingFailed": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AuthProviders.livesOutsideAreaAuthFailed": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AuthProviders.livesOutsideAreaVerificationFailed": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AuthProviders.nemlogInUnderMinimumAgeVerificationFailed": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AuthProviders.noMatchAuthFailed": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AuthProviders.noMatchVerificationFailed": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AuthProviders.serviceErrorAuthFailed": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AuthProviders.serviceErrorVerificationFailed": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AuthProviders.signUpButtonAltText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AuthProviders.underMinimumAgeAuthFailed": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AuthProviders.verificationRequired": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Author.a11yPostedBy": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AvatarBubbles.numberOfParticipants1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AvatarBubbles.numberOfUsers": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AvatarBubbles.participant": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.AvatarBubbles.participants1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CityLogoSection.logoLinkAriaLabelExternal": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CityLogoSection.logoLinkAriaLabelInternal": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Comments.cancel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Comments.commentingDisabledInCurrentPhase": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Comments.commentingDisabledInactiveProject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Comments.commentingDisabledProject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Comments.commentingDisabledUnverified": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Comments.commentingMaybeNotPermitted": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Comments.inputsAssociatedWithProfile": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Comments.invisibleTitleComments": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Comments.leastRecent": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Comments.likeComment": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Comments.mostLiked": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Comments.mostRecent": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Comments.official": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Comments.postAnonymously": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Comments.replyToComment": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Comments.reportAsSpam": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Comments.seeOriginal": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Comments.seeTranslation": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Comments.yourComment": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CommonGroundResults.closeCallsDescription": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CommonGroundResults.closeCallsTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CommonGroundResults.highestConsensusDescription": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CommonGroundResults.highestConsensusTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CommonGroundResults.participantLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CommonGroundResults.participantsLabel1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CommonGroundResults.statementLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CommonGroundResults.statementsLabel1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CommonGroundResults.votesLabe": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CommonGroundResults.votesLabel1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CommonGroundStatements.agreeLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CommonGroundStatements.disagreeLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CommonGroundStatements.noMoreStatements": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CommonGroundStatements.noResults": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CommonGroundStatements.unsureLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CommonGroundTabs.resultsTabLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CommonGroundTabs.statementsTabLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CommunityMonitorModal.formError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CommunityMonitorModal.surveyDescription2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CommunityMonitorModal.xMinutesToComplete": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ConfirmationModal.anExampleCodeHasBeenSent": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ConfirmationModal.changeYourEmail": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ConfirmationModal.codeInput": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ConfirmationModal.confirmationCodeSent": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ConfirmationModal.didntGetAnEmail": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ConfirmationModal.sendNewCode": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ConfirmationModal.verifyAndContinue": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ConfirmationModal.wrongEmail": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ConsentManager.Banner.accept": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ConsentManager.Banner.ariaButtonClose2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ConsentManager.Banner.close": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ConsentManager.Banner.cookieModalInitialScreenDescription1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ConsentManager.Banner.cookieModalTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ConsentManager.Banner.linkToCookiePolicyText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ConsentManager.Banner.manage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ConsentManager.Banner.reject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ConsentManager.Modal.PreferencesDialog.advertising": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ConsentManager.Modal.PreferencesDialog.advertisingPurpose": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ConsentManager.Modal.PreferencesDialog.allow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ConsentManager.Modal.PreferencesDialog.analytics": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ConsentManager.Modal.PreferencesDialog.analyticsPurpose": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ConsentManager.Modal.PreferencesDialog.back": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ConsentManager.Modal.PreferencesDialog.cancel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ConsentManager.Modal.PreferencesDialog.disallow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ConsentManager.Modal.PreferencesDialog.functional": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ConsentManager.Modal.PreferencesDialog.functionalPurpose": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ConsentManager.Modal.PreferencesDialog.google_tag_manager": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ConsentManager.Modal.PreferencesDialog.required": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ConsentManager.Modal.PreferencesDialog.requiredPurpose": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ConsentManager.Modal.PreferencesDialog.save": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ConsentManager.Modal.PreferencesDialog.tools": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ContentUploadDisclaimer.contentDisclaimerModalHeader": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ContentUploadDisclaimer.contentUploadDisclaimerFull2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ContentUploadDisclaimer.onAccept": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ContentUploadDisclaimer.onCancel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.Fields.SentimentScaleField.tellUsWhy": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.PageControlButtons.SubmissionReference.preferToStayAnonymous": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.PageControlButtons.SubmissionReference.saveThisCode": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.PageControlButtons.SubmissionReference.sendThisCode": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.PageControlButtons.SubmissionReference.submissionIdentifier": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.PostParticipationBox.createAnAccountOrLogIn": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.PostParticipationBox.createOrLinkAnAccountToFollow2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.PostParticipationBox.getUpdates": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.PostParticipationBox.joinDiscussions3": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.PostParticipationBox.participateInOtherProjects": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.PostParticipationBox.stayConnected": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.addressInputAriaLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.addressInputPlaceholder6": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.adminFieldTooltip": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.atLeastThreePointsRequired": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.atLeastTwoPointsRequired": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.attachmentRequired": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.authorFieldLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.authorFieldPlaceholder": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.back": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.blockedVerified": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.budgetFieldLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.clickOnMapMultipleToAdd3": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.clickOnMapToAddOrType": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.confirm": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.continueEditing": {
+    "state": "verified",
+    "verified_at": "2026-03-27T11:35:57.044515Z",
+    "verified_by": "kielgast@govocal.com"
+  },
+  "app.components.CustomFieldsForm.descriptionMaxLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.descriptionMinLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.descriptionRequired": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.fieldMaxLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.fieldMaximumItems": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.fieldMinLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.fieldMinimumItems": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.fieldRequired": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.fileSizeLimit": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.imageRequired": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.minimumCoordinates2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.notPublic1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.otherArea": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.progressBarLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.removeAnswer": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.selectAsManyAsYouLike": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.selectBetween": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.selectExactly2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.selectMany": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.submitConfirmation": {
+    "state": "verified",
+    "verified_at": "2026-03-27T11:35:57.044515Z",
+    "verified_by": "kielgast@govocal.com"
+  },
+  "app.components.CustomFieldsForm.tagsRequired": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.tapOnFullscreenMapToAdd4": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.tapOnFullscreenMapToAddPoint": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.tapOnMapMultipleToAdd3": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.tapOnMapToAddOrType": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.tapToAddALine": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.tapToAddAPoint": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.tapToAddAnArea": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.titleMaxLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.titleMinLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.titleRequired": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.topicMaximumItems": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.topicMinimumItems": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.typeYourAnswer": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.typeYourAnswerRequired": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.uploadShapefileInstructions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.validCordinatesTooltip2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.CustomFieldsForm.yesSubmit": {
+    "state": "verified",
+    "verified_at": "2026-03-27T11:35:57.044515Z",
+    "verified_by": "kielgast@govocal.com"
+  },
+  "app.components.ErrorBoundary.errorFormErrorFormEntry": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ErrorBoundary.errorFormErrorGeneric": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ErrorBoundary.errorFormLabelClose": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ErrorBoundary.errorFormLabelComments": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ErrorBoundary.errorFormLabelEmail": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ErrorBoundary.errorFormLabelName": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ErrorBoundary.errorFormLabelSubmit": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ErrorBoundary.errorFormSubtitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ErrorBoundary.errorFormSubtitle2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ErrorBoundary.errorFormSuccessMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ErrorBoundary.errorFormTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ErrorBoundary.genericErrorWithForm": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ErrorBoundary.openFormText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ErrorToast.budgetExceededError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ErrorToast.votesExceededError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.EsriMap.mapLayerListAriaLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.EsriMap.mapLegendAriaLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.EventAttendanceButton.forwardToFriend": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.EventAttendanceButton.maxRegistrationsReached": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.EventAttendanceButton.register": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.EventAttendanceButton.registered": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.EventAttendanceButton.seeYouThere": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.EventAttendanceButton.seeYouThereName": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.EventCard.a11y_lessContentVisible": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.EventCard.a11y_moreContentVisible": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.EventCard.a11y_readMore": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.EventCard.endsAt": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.EventCard.readMore": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.EventCard.showLess": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.EventCard.showMore": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.EventCard.startsAt": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.EventPreviews.eventPreviewContinuousTitle2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.EventPreviews.eventPreviewTimelineTitle3": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FileRepositorySelectAndUpload.addFile2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FileRepositorySelectAndUpload.or": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FileRepositorySelectAndUpload.selectExistingFile": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FileRepositorySelectAndUpload.selectFile": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FileUploader.a11y_file": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FileUploader.a11y_filesToBeUploaded": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FileUploader.a11y_noFiles": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FileUploader.a11y_removeFile": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FileUploader.fileInputDescription": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FileUploader.fileUploadLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FileUploader.file_too_large2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FileUploader.incorrect_extension": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FilterBoxes.a11y_allFilterSelected": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FilterBoxes.a11y_numberOfInputs": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FilterBoxes.a11y_removeFilter": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FilterBoxes.a11y_selectedFilter": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FilterBoxes.a11y_selectedTopicFilters": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FilterBoxes.all": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FilterBoxes.areas": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FilterBoxes.inputs": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FilterBoxes.noValuesFound": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FilterBoxes.showLess": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FilterBoxes.showTagsWithNumber": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FilterBoxes.statusTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FilterBoxes.topicsTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FiltersModal.filters": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FolderFolderCard.a11y_folderDescription": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FolderFolderCard.a11y_folderTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FolderFolderCard.archived": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FolderFolderCard.numberOfProjectsInFolder": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FormBuilder.components.FieldTypeSwitcher.formHasSubmissionsWarning2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FormBuilder.components.FieldTypeSwitcher.type": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FormBuilder.components.FormBuilderTopBar.autosave": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FormBuilder.components.FormBuilderTopBar.autosaveTooltip4": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FormBuilder.components.FormBuilderTopBar.superAdmin.schemaCancelEdit": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FormBuilder.components.FormBuilderTopBar.superAdmin.schemaCopied": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FormBuilder.components.FormBuilderTopBar.superAdmin.schemaCopy": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FormBuilder.components.FormBuilderTopBar.superAdmin.schemaCopyTooltip": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FormBuilder.components.FormBuilderTopBar.superAdmin.schemaEdit": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FormBuilder.components.FormBuilderTopBar.superAdmin.schemaParseError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FormBuilder.components.FormBuilderTopBar.superAdmin.schemaSave": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.FormBuilder.components.FormBuilderTopBar.superAdmin.schemaSaveDisabled": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.GanttChart.timeRange.month": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.GanttChart.timeRange.quarter": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.GanttChart.timeRange.timeRangeMultiyear": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.GanttChart.timeRange.year": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.GanttChart.today": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.GoBackButton.group.edit.goBack": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.GoBackButton.group.edit.goBackToPreviousPage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.HookForm.EmojiPicker.clearEmoji": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.HookForm.Feedback.errorTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.HookForm.Feedback.submissionError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.HookForm.Feedback.submissionErrorTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.HookForm.Feedback.successMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.HookForm.PasswordInput.passwordLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.HorizontalScroll.scrollLeftLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.HorizontalScroll.scrollRightLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeaCards.a11y_ideasHaveBeenSorted": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeaCards.filters": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeaCards.filters.mostDiscussed": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeaCards.filters.newest": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeaCards.filters.oldest": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeaCards.filters.popular": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeaCards.filters.random": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeaCards.filters.sortBy": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeaCards.filters.sortChangedScreenreaderMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeaCards.filters.trending": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeaCards.showMore": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeasMap.a11y_hideIdeaCard": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeasMap.a11y_mapTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeasMap.clickOnMapToAdd": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeasMap.clickOnMapToAddAdmin2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeasMap.filters": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeasMap.multipleInputsAtLocation": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeasMap.noFilteredResults": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeasMap.noResults": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeasMap.or": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeasMap.screenReaderDislikesText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeasMap.screenReaderLikesText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeasMap.signInLinkText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeasMap.signUpLinkText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeasMap.submitIdea2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeasMap.tapOnMapToAdd": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeasMap.tapOnMapToAddAdmin2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeasMap.userInputs2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeasMap.xComments": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeasShow.bodyTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeasShow.deletePost": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeasShow.editPost": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeasShow.goBack": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeasShow.moreOptions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeasShow.or": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeasShow.proposedBudgetTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeasShow.reportAsSpam": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeasShow.send": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeasShow.skipSharing": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeasShowPage.signIn2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.IdeasShowPage.sorryNoAccess": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.LocationInput.noOptions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Modal.closeWindow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.MultiSelect.clearButtonAction": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.MultiSelect.clearSearchButtonAction": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PageNotFound.goBackToHomePage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PageNotFound.notFoundTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PageNotFound.pageNotFoundDescription": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PagesForm.descriptionMissingOneLanguageError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PagesForm.editContent": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PagesForm.fileUploadLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PagesForm.fileUploadLabelTooltip": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PagesForm.navbarItemTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PagesForm.pageTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PagesForm.savePage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PagesForm.saveSuccess": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PagesForm.titleMissingOneLanguageError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Pagination.back": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Pagination.next": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.VotingCTABar.budgetExceedsLimit": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.VotingCTABar.currencyLeft1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.VotingCTABar.minBudgetNotReached1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.VotingCTABar.noVotesCast4": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.VotingCTABar.nothingInBasket": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.VotingCTABar.numberOfCreditsLeft": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.VotingCTABar.numberOfPercentsLeft4": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.VotingCTABar.numberOfPointsLeft": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.VotingCTABar.numberOfTokensLeft": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.VotingCTABar.numberOfVotesLeft": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.VotingCTABar.selectMinXOptions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.VotingCTABar.selectMinXOptionsToVote": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.VotingCTABar.votesCast": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.VotingCTABar.votesExceedLimit": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.addInput": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.allocateBudget": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.budgetSubmitSuccess": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.mobileProjectOpenForSubmission": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.poll": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.reviewDocument": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.seeComments": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.seeContributions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.seeEvents3": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.seeIdeas": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.seeInitiatives": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.seeIssues": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.seeOptions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.seePetitions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.seePosts": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.seeProjects": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.seeProposals": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.seeQuestions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.seeResponses": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.seeStories": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.seeSuggestions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.seeTopics": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.submit": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.takeTheSurvey": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.userHasParticipated": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.viewInputs": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.volunteer": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.votesCounter.vote": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ParticipationCTABars.votesCounter.votes": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PasswordInput.a11y_passwordHidden": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PasswordInput.a11y_passwordVisible": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PasswordInput.a11y_strength1Password": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PasswordInput.a11y_strength2Password": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PasswordInput.a11y_strength3Password": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PasswordInput.a11y_strength4Password": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PasswordInput.a11y_strength5Password": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PasswordInput.hidePassword": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PasswordInput.initialPasswordStrengthCheckerMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PasswordInput.minimumPasswordLengthError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PasswordInput.passwordEmptyError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PasswordInput.passwordStrengthTooltip1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PasswordInput.passwordStrengthTooltip2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PasswordInput.passwordStrengthTooltip3": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PasswordInput.passwordStrengthTooltip4": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PasswordInput.showPassword": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PasswordInput.strength1Password": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PasswordInput.strength2Password": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PasswordInput.strength3Password": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PasswordInput.strength4Password": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PasswordInput.strength5Password": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostCardsComponents.list": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostCardsComponents.map": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.OfficialFeedback.addOfficalUpdate": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.OfficialFeedback.cancel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.OfficialFeedback.deleteOfficialFeedbackPost": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.OfficialFeedback.deletionConfirmation": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.OfficialFeedback.editOfficialFeedbackPost": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.OfficialFeedback.lastEdition": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.OfficialFeedback.lastUpdate": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.OfficialFeedback.official": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.OfficialFeedback.officialNamePlaceholder": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.OfficialFeedback.officialUpdateAuthor": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.OfficialFeedback.officialUpdateBody": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.OfficialFeedback.officialUpdates": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.OfficialFeedback.postedOn": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.OfficialFeedback.publishButtonText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.OfficialFeedback.showPreviousUpdates": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.OfficialFeedback.textAreaPlaceholder": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.OfficialFeedback.updateButtonError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.OfficialFeedback.updateButtonSaveEditForm": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.OfficialFeedback.updateMessageSuccess": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.commentEmailSharingBody": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.commentEmailSharingSubject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.commentWhatsAppMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.contributionEmailSharingBody": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.contributionEmailSharingSubject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.contributionWhatsAppMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.ideaEmailSharingBody": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.ideaEmailSharingSubjectText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.ideaWhatsAppMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.initiativeEmailSharingBody": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.initiativeEmailSharingSubject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.initiativeWhatsAppMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.issueEmailSharingBody1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.issueEmailSharingSubject1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.issueWhatsAppMessage1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.optionEmailSharingBody": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.optionEmailSharingSubject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.optionWhatsAppMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.petitionEmailSharingBody": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.petitionEmailSharingSubject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.petitionWhatsAppMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.postEmailSharingBody": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.postEmailSharingSubject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.postWhatsAppMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.projectEmailSharingBody": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.projectEmailSharingSubject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.projectWhatsAppMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.proposalEmailSharingBody": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.proposalEmailSharingSubject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.proposalWhatsAppMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.questionEmailSharingModalContentBody": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.questionEmailSharingSubject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.questionWhatsAppMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.responseEmailSharingBody": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.responseEmailSharingSubject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.responseWhatsAppMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.storyEmailSharingBody": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.storyEmailSharingSubject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.storyWhatsAppMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.suggestionEmailSharingBody": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.suggestionEmailSharingSubject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.suggestionWhatsAppMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.topicEmailSharingBody": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.topicEmailSharingSubject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.topicWhatsAppMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.SharingModalContent.twitterMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.linkToHomePage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.readMore": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.PostComponents.topics": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectArchivedIndicator.archivedProject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectArchivedIndicator.previewProject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectArchivedIndicator.previewProjectExplanation": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.a11y_projectDescription": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.a11y_projectTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.addYourOption": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.allocateYourBudget": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.archived": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.comment": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.contributeYourInput": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.finished": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.joinDiscussion": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.learnMore": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.reaction": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.readTheReport": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.reviewDocument": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.submitAnIssue": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.submitYourComment": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.submitYourIdea": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.submitYourInitiative": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.submitYourPetition": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.submitYourPost": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.submitYourProject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.submitYourProposal": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.submitYourResponse": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.submitYourStory": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.submitYourSuggestion": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.submitYourTopic": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.takeThePoll": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.takeTheSurvey": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.viewTheComments": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.viewTheContributions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.viewTheIdeas": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.viewTheInitiatives": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.viewTheIssues1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.viewTheOptions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.viewThePetitions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.viewThePosts": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.viewTheProjects": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.viewTheProposals": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.viewTheQuestions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.viewTheResponses": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.viewTheStories": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.viewTheSuggestions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.viewTheTopics": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.vote": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.xComments": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.xCommentsTerm": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.xContributions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.xIdeas": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.xInitiatives": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.xIssues1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.xOptions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.xPetitions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.xPosts": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.xProjects": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.xProposals": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.xQuestions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.xResponses": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.xStories": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.xSuggestions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectCard.xTopics": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectFolderCard.xComments": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectFolderCard.xInputs": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectFolderCards.components.Topbar.a11y_projectFilterTabInfo": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectFolderCards.components.Topbar.all": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectFolderCards.components.Topbar.archived": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectFolderCards.components.Topbar.draft": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectFolderCards.components.Topbar.filterBy": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectFolderCards.components.Topbar.published2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectFolderCards.components.Topbar.topicTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectFolderCards.noProjectYet": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectFolderCards.noProjectsAvailable": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectFolderCards.showMore": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectFolderCards.stayTuned": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectFolderCards.tryChangingFilters": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectTemplatePreview.alsoUsedIn": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectTemplatePreview.copied": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ProjectTemplatePreview.copyLink": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.QuillEditor.alignCenter": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.QuillEditor.alignLeft": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.QuillEditor.alignRight": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.QuillEditor.altTextLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.QuillEditor.bold": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.QuillEditor.clean": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.QuillEditor.customLink": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.QuillEditor.customLinkPrompt": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.QuillEditor.edit": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.QuillEditor.image": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.QuillEditor.imageTitleLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.QuillEditor.italic": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.QuillEditor.link": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.QuillEditor.linkPrompt": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.QuillEditor.normalText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.QuillEditor.orderedList": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.QuillEditor.remove": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.QuillEditor.save": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.QuillEditor.subtitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.QuillEditor.title": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.QuillEditor.unorderedList": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.QuillEditor.video": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.QuillEditor.videoPrompt": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.QuillEditor.visitPrompt": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ReactionControl.completeProfileToReact": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ReactionControl.dislike": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ReactionControl.dislikingDisabledMaxReached": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ReactionControl.like": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ReactionControl.likingDisabledMaxReached": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ReactionControl.reactingDisabledFutureEnabled": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ReactionControl.reactingDisabledPhaseOver": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ReactionControl.reactingDisabledProjectInactive": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ReactionControl.reactingNotEnabled": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ReactionControl.reactingNotPermitted": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ReactionControl.reactingNotSignedIn": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ReactionControl.reactingPossibleLater": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ReactionControl.reactingVerifyToReact": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ScreenReadableEventDate..multiDayScreenReaderDate": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ScreenReadableEventDate..singleDayScreenReaderDate": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Sharing.linkCopied": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Sharing.or": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Sharing.share": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Sharing.shareByEmail": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Sharing.shareByLink": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Sharing.shareOnFacebook": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Sharing.shareOnTwitter": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Sharing.shareThisEvent": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Sharing.shareThisFolder": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Sharing.shareThisProject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Sharing.shareViaMessenger": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Sharing.shareViaWhatsApp": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.SideModal.closeButtonAria": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.StatusModule.futurePhase": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.StatusModule.modifyYourSubmission1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.StatusModule.submittedUntil3": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.TopicsPicker.numberOfSelectedTopics": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.TypedConfirmationModal.cancel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.TypedConfirmationModal.confirmationWordDelete": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.TypedConfirmationModal.typeToConfirm1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.TypedConfirmationModal.warning": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.UI.FullscreenImage.expandImage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.UI.MoreActionsMenu.moreOptions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.UI.MoreActionsMenu.showMoreActions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.UI.NewLabel.new": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.UI.PhaseFilter.noAppropriatePhases": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.UI.RemoveImageButton.a11y_removeImage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.UI.TranslateButton.original": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.UI.TranslateButton.translate": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Unauthorized.additionalInformationRequired": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Unauthorized.completeProfile": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Unauthorized.completeProfileTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Unauthorized.noPermission": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Unauthorized.notAuthorized": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Upload.errorImageMaxSizeExceeded": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Upload.errorImagesMaxSizeExceeded": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Upload.onlyOneImage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Upload.onlyXImages": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Upload.remaining": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Upload.uploadImageLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.Upload.uploadMultipleImagesLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.UpsellTooltip.tooltipContent": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.UserName.anonymous": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.UserName.anonymousTooltip2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.UserName.authorWithNoNameTooltip": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.UserName.deletedUser": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.UserName.verified": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.VerificationModal.verifyAcm": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.VerificationModal.verifyAuth0": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.VerificationModal.verifyBOSA": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.VerificationModal.verifyBosaFas": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.VerificationModal.verifyClaveUnica": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.VerificationModal.verifyFakeSSO": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.VerificationModal.verifyFedera": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.VerificationModal.verifyIdAustria": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.VerificationModal.verifyKeycloak": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.VerificationModal.verifyNemLogIn": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.VerificationModal.verifyTwoday2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.VerificationModal.verifyYourIdentity": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.VoteControl.budgetingFutureEnabled": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.VoteControl.budgetingNotPermitted": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.VoteControl.budgetingNotPossible": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.VoteControl.budgetingNotVerified": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.VoteInputs._shared.currencyLeft1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.VoteInputs._shared.numberOfCreditsLeft": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.VoteInputs._shared.numberOfPercentsLeft6": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.VoteInputs._shared.numberOfPointsLeft": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.VoteInputs._shared.numberOfTokensLeft": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.VoteInputs._shared.numberOfVotesLeft": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.VoteInputs.budgeting.AddToBasketButton.basketAlreadySubmitted1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.VoteInputs.budgeting.AddToBasketButton.basketAlreadySubmittedIdeaPage1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.VoteInputs.budgeting.AddToBasketButton.phaseNotActive": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.VoteInputs.single.youHaveVotedForX2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.PostManager.components.ActionBar.deleteInputExplanation": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.PostManager.components.ActionBar.deleteInputTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.PostManager.components.PostTable.Row.cancel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.PostManager.components.PostTable.Row.confirm": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.SlugInput.resultingURL": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.SlugInput.slugTooltip": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.SlugInput.urlSlugBrokenLinkWarning": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.SlugInput.urlSlugLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.addCondition": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.field_email": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.field_event_attendance": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.field_follow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.field_lives_in": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.field_participated_in_community_monitor": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.field_participated_in_input_status": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.field_participated_in_project": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.field_participated_in_topic": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.field_registration_completed_at": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.field_role": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.field_verified": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.ideaStatusMethodIdeation": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.ideaStatusMethodProposals": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_attends_none_of": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_attends_nothing": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_attends_some_of": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_attends_something": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_begins_with": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_commented_in": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_contains": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_ends_on": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_has_value": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_in": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_is": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_is_admin": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_is_after": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_is_before": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_is_checked": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_is_empty": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_is_equal": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_is_exactly": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_is_larger_than": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_is_larger_than_or_equal": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_is_moderator": {
+    "state": "verified",
+    "verified_at": "2026-03-23T10:30:39.834804Z",
+    "verified_by": "kielgast@govocal.com"
+  },
+  "app.components.admin.UserFilterConditions.predicate_is_normal_user": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_is_not_area": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_is_not_folder": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_is_not_input": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_is_not_project": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_is_not_topic": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_is_one_of": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_is_one_of_areas": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_is_one_of_folders": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_is_one_of_inputs": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_is_one_of_projects": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_is_one_of_topics": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_is_project_folder_moderator": {
+    "state": "verified",
+    "verified_at": "2026-03-23T10:30:39.834804Z",
+    "verified_by": "kielgast@govocal.com"
+  },
+  "app.components.admin.UserFilterConditions.predicate_is_project_moderator": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_is_smaller_than": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_is_smaller_than_or_equal": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_is_space_moderator": {
+    "state": "verified",
+    "verified_at": "2026-03-30T15:31:21.570131Z",
+    "verified_by": "kielgast@govocal.com"
+  },
+  "app.components.admin.UserFilterConditions.predicate_is_verified": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_not_begins_with": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_not_commented_in": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_not_contains": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_not_ends_on": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_not_has_value": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_not_in": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_not_is": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_not_is_admin": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_not_is_checked": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_not_is_empty": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_not_is_equal": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_not_is_moderator": {
+    "state": "verified",
+    "verified_at": "2026-03-23T10:30:39.834804Z",
+    "verified_by": "kielgast@govocal.com"
+  },
+  "app.components.admin.UserFilterConditions.predicate_not_is_normal_user": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_not_is_one_of": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_not_is_project_folder_moderator": {
+    "state": "verified",
+    "verified_at": "2026-03-23T10:30:39.834804Z",
+    "verified_by": "kielgast@govocal.com"
+  },
+  "app.components.admin.UserFilterConditions.predicate_not_is_project_moderator": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_not_is_space_moderator": {
+    "state": "verified",
+    "verified_at": "2026-03-30T15:31:21.570131Z",
+    "verified_by": "kielgast@govocal.com"
+  },
+  "app.components.admin.UserFilterConditions.predicate_not_is_verified": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_not_posted_input": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_not_reacted_comment_in": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_not_reacted_input_in": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_not_registered_to_an_event": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_not_taken_survey": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_not_volunteered_in": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_not_voted_in3": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_nothing": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_posted_input": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_reacted_comment_in": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_reacted_input_in": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_registered_to_an_event": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_something": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_taken_survey": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_volunteered_in": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.predicate_voted_in3": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.rulesFormLabelField": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.rulesFormLabelPredicate": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.admin.UserFilterConditions.rulesFormLabelValue": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.anonymousParticipationModal.anonymousParticipationWarning": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.anonymousParticipationModal.cancel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.anonymousParticipationModal.continue": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.anonymousParticipationModal.participateAnonymously": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.anonymousParticipationModal.participateAnonymouslyModalText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.anonymousParticipationModal.participateAnonymouslyModalTextSection2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.avatar.titleForAccessibility": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.customFields.mapInput.removeAnswer": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.customFields.mapInput.undo": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.customFields.mapInput.undoLastPoint": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.followUnfollow.follow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.followUnfollow.followADiscussion": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.followUnfollow.followTooltipInputPage2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.followUnfollow.followTooltipProjects2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.followUnfollow.unFollow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.followUnfollow.unsubscribe": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.followUnfollow.unsubscribeUrl": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.form.ErrorDisplay.guidelinesLinkText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.form.ErrorDisplay.next": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.form.ErrorDisplay.previous": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.form.ErrorDisplay.save": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.form.ErrorDisplay.userPickerPlaceholder": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.form.backToInputManager": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.form.backToProject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.form.controls.allStatementsError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.form.controls.birthyearTooHigh": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.form.controls.birthyearTooLow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.form.controls.clearAll": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.form.controls.clearAllScreenreader": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.form.controls.cosponsorsPlaceholder": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.form.controls.currentRank": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.form.controls.matrixStatementHeader": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.form.controls.noRankSelected": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.form.controls.optionalParentheses": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.form.controls.rankingInstructions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.form.controls.valueOutOfTotal": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.form.controls.valueOutOfTotalWithLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.form.controls.valueOutOfTotalWithMaxExplanation": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.form.error": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.form.locationGoogleUnavailable": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.form.submit": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.form.submitApiError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.form.verifiedBlocked": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.Page": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.accessibilityStatement": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.addAnswer": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.addStatement": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.agree": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.ai1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.aiUpsellText1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.askFollowUpToggleLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.bad": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.bodyMultiloc": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.buttonLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.buttonLink": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.cancelLeaveBuilderButtonText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.category": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.chooseMany": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.chooseOne": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.close": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.closed": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.configureMap": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.confirmLeaveBuilderButtonText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.content": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.continuePageLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.cosponsors": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.default": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.defaultContent": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.delete": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.deleteButtonLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.description": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.disabledBuiltInFieldTooltip": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.disabledCustomFieldsTooltip1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.disagree": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.displayAsDropdown": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.displayAsDropdownTooltip": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.done": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.dragAndDrop": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.drawArea": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.drawRoute": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.dropPin": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.editButtonLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.emptyImageOptionError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.emptyOptionError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.emptyStatementError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.emptyTitleError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.emptyTitleMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.emptyTitleStatementMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.enable": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.errorMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.fieldGroup.description": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.fieldGroup.title": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.fieldIsNotVisibleTooltip": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.fieldLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.fieldLabelStatement": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.fileUpload": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.formBuilderSettings.pageLayoutSettings.mapBasedPage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.formBuilderSettings.pageLayoutSettings.mapOptionDescription": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.formBuilderSettings.pageLayoutSettings.noMapInputQuestions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.formBuilderSettings.pageLayoutSettings.normalPage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.formBuilderSettings.pageLayoutSettings.notInCurrentLicense": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.formBuilderSettings.pageLayoutSettings.pageType": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.formEnd": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.formField.cancelDeleteButtonText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.formField.components.cancel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.formField.components.confirmDeletion": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.formField.components.delete": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.formField.components.deleteLocationFieldExplanation1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.formField.components.deleteLocationFieldExplanation2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.formField.confirmDeleteFieldWithLogicButtonText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.formField.copyNoun": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.formField.copyVerb": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.formField.delete": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.formField.deleteFieldWithLogicConfirmationQuestion": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.formField.deleteResultsInfo": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.goToPageInputLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.good": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.helmetTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.imageFileUpload": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.inputImages": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.inputTagManager": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.invalidLogicBadgeMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.labels2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.labelsTooltipContent2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.lastPage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.layout": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.leaveBuilderConfirmationQuestion": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.leaveBuilderText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.limitAnswersTooltip": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.limitNumberAnswers": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.limitNumberTags": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.limitNumberTagsTooltip": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.linePolygonMapWarning2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.linearScale": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.locationDescription": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.logic": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.logicAnyOtherAnswer": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.logicConflicts.conflictingLogic": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.logicConflicts.interQuestionConflict": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.logicConflicts.multipleConflictTypes": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.logicConflicts.multipleGotoInMultiSelect": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.logicConflicts.multipleGotoInMultiSelectAndInterQuestionConflict": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.logicConflicts.multipleGotoInMultiSelectAndQuestionVsPageLogic": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.logicConflicts.questionVsPageLogic": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.logicConflicts.questionVsPageLogicAndInterQuestionConflict": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.logicNoAnswer2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.logicPanelAnyOtherAnswer": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.logicPanelNoAnswer": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.logicValidationError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.longAnswer": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.manageTagsExplanation": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.mapConfiguration": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.mapping": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.mappingNotInCurrentLicense": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.matrix": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.matrixSettings.columns": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.matrixSettings.rows": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.maxCharacters": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.minCharacters": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.multipleChoice": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.multipleChoiceHelperText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.multipleChoiceImage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.multiselect.maximum": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.multiselect.minimum": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.neutral": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.newField": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.noLimit": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.number": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.ok": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.open": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.optional": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.other": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.otherOption": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.otherOptionTooltip": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.page": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.pageRuleLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.pagesLogicHelperTextDefault1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.preview": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.printSupportTooltip.cosponsor_ids2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.printSupportTooltip.fileupload": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.printSupportTooltip.mapping": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.printSupportTooltip.matrix": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.printSupportTooltip.page": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.printSupportTooltip.ranking": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.printSupportTooltip.topics2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.proposedBudget": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.question": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.questionCannotBeDeleted": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.questionDescriptionOptional": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.questionTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.randomize": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.randomizeToolTip": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.range": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.ranking": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.rating": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.removeAnswer": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.required": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.requiredToggleLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.ruleForAnswerLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.ruleForAnswerLabelMultiselect": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.save": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.selectRangeTooltip": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.sentiment": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.shapefileUpload": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.shortAnswer": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.showResponseToUsersToggleLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.singleChoice": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.staleDataErrorMessage2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.stronglyAgree": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.stronglyDisagree": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.supportArticleLinkText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.tags": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.title": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.toLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.topics.maximum": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.topics.minimum": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.unsavedChanges": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.useCustomButton2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.veryBad": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.formBuilder.veryGood": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ideas.similarIdeas.closeSidebar": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ideas.similarIdeas.engageHere": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ideas.similarIdeas.ideaAuthorStats": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ideas.similarIdeas.noSimilarSubmissions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ideas.similarIdeas.openToSeeDetails": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ideas.similarIdeas.similarIdeaDetails": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ideas.similarIdeas.similarSubmissionsDescription2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ideas.similarIdeas.similarSubmissionsList": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ideas.similarIdeas.similarSubmissionsPosted": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.ideas.similarIdeas.similarSubmissionsSearch": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.phaseTimeLeft.xDayLeft": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.phaseTimeLeft.xWeeksLeft": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.AED": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.AFN": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.ALL": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.AMD": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.ANG": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.AOA": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.ARS": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.AUD": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.AWG": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.AZN": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.BAM": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.BBD": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.BDT": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.BGN": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.BHD": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.BIF": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.BMD": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.BND": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.BOB": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.BOV": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.BRL": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.BSD": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.BTN": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.BWP": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.BYR": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.BZD": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.CAD": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.CDF": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.CHE": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.CHF": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.CHW": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.CLF": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.CLP": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.CNY": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.COP": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.COU": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.CRC": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.CRE": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.CUC": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.CUP": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.CVE": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.CZK": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.DJF": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.DKK": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.DOP": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.DZD": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.EGP": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.ERN": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.ETB": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.EUR": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.FJD": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.FKP": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.GBP": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.GEL": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.GHS": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.GIP": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.GMD": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.GNF": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.GTQ": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.GYD": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.HKD": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.HNL": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.HRK": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.HTG": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.HUF": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.IDR": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.ILS": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.INR": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.IQD": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.IRR": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.ISK": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.JMD": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.JOD": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.JPY": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.KES": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.KGS": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.KHR": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.KMF": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.KPW": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.KRW": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.KWD": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.KYD": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.KZT": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.LAK": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.LBP": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.LKR": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.LRD": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.LSL": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.LTL": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.LVL": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.LYD": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.MAD": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.MDL": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.MGA": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.MKD": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.MMK": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.MNT": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.MOP": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.MRO": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.MUR": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.MVR": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.MWK": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.MXN": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.MXV": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.MYR": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.MZN": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.NAD": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.NGN": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.NIO": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.NOK": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.NPR": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.NZD": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.OMR": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.PAB": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.PEN": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.PGK": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.PHP": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.PKR": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.PLN": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.PYG": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.QAR": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.RON": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.RSD": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.RUB": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.RWF": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.SAR": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.SBD": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.SCR": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.SDG": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.SEK": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.SGD": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.SHP": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.SLL": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.SOS": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.SRD": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.SSP": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.STD": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.SYP": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.SZL": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.THB": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.TJS": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.TMT": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.TND": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.TOK": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.TOP": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.TRY": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.TTD": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.TWD": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.TZS": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.UAH": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.UGX": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.USD": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.USN": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.USS": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.UYI": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.UYU": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.UZS": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.VEF": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.VND": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.VUV": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.WST": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.XAF": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.XAG": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.XAU": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.XBA": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.XBB": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.XBC": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.XBD": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.XCD": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.XDR": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.XFU": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.XOF": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.XPD": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.XPF": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.XPT": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.XTS": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.XXX": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.YER": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.ZAR": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.ZMW": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.amount": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.screenReaderCurrency.currency": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.trendIndicator.lastQuarter2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AccessibilityStatement.applicability": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AccessibilityStatement.assesmentMethodsTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AccessibilityStatement.assesmentText2022": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AccessibilityStatement.changePreferencesButtonText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AccessibilityStatement.changePreferencesText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AccessibilityStatement.conformanceExceptions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AccessibilityStatement.conformanceStatus": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AccessibilityStatement.contentConformanceExceptions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AccessibilityStatement.demoPlatformLinkText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AccessibilityStatement.email": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AccessibilityStatement.embeddedSurveyTools": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AccessibilityStatement.embeddedSurveyToolsException": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AccessibilityStatement.exception_1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AccessibilityStatement.feedbackProcessIntro": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AccessibilityStatement.feedbackProcessTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AccessibilityStatement.govocalAddress2022": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AccessibilityStatement.headTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AccessibilityStatement.intro2022": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AccessibilityStatement.mapping": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AccessibilityStatement.mapping_1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AccessibilityStatement.mapping_2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AccessibilityStatement.mapping_3": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AccessibilityStatement.mapping_4": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AccessibilityStatement.onlineWorkshopsException": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AccessibilityStatement.pageDescription": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AccessibilityStatement.postalAddress": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AccessibilityStatement.publicationDate": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AccessibilityStatement.publicationDate2024": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AccessibilityStatement.responsiveness": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AccessibilityStatement.statusPageText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AccessibilityStatement.technologiesIntro": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AccessibilityStatement.technologiesTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AccessibilityStatement.title": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AccessibilityStatement.userGeneratedContent": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AccessibilityStatement.workshops": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AdminPage.DashboardPage.typeToSearchProjects": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AdminPage.ProjectDescription.folderLayoutBuilderWarning": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AdminPage.ProjectDescription.layoutBuilderWarning": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AdminPage.ProjectDescription.linkText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AdminPage.ProjectDescription.saveError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AdminPage.ProjectDescription.toggleLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AdminPage.ProjectDescription.toggleTooltip": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AdminPage.ProjectDescription.viewPublicProject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AdminPage.ProjectEdit.formBuilder.surveyEnd": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AdminPage.Users.GroupCreation.modalHeaderRules": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AdminPage.Users.GroupCreation.rulesExplanation": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AdminPage.Users.UsersGroup.atLeastOneRuleError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AdminPage.Users.UsersGroup.rulesError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AdminPage.Users.UsersGroup.saveGroup": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AdminPage.Users.UsersGroup.smartGroupsAvailability1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AdminPage.Users.UsersGroup.titleFieldEmptyError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AdminPage.Users.UsersGroup.verificationDisabled": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.App.appMetaDescription": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.App.loading": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.App.metaTitle1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.App.skipLinkText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AreaTerms.areaTerm": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AreaTerms.areasTerm": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.AuthProviders.emailTakenAndUserCanBeVerified": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Authentication.authenticationDialog": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Authentication.signUpOrLogIn": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Authentication.steps.AccessDenied.close": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Authentication.steps.AccessDenied.youDoNotMeetTheRequirements": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Authentication.steps.EmailFlowStart.clickHereToLoginAsAdminOrPM": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Authentication.steps.Invitation.pleaseEnterAToken": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Authentication.steps.Invitation.token": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Authentication.steps.InvitationResent.emailAlreadyTaken2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Authentication.steps.InvitationResent.invitationResent2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Authentication.steps.InvitationResent.resendInvite2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Authentication.steps.SSOVerification.alreadyHaveAnAccount": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Authentication.steps.SSOVerification.logIn": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.CampaignsConsentForm.ally_categoryLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.CampaignsConsentForm.messageError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.CampaignsConsentForm.messageSuccess": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.CampaignsConsentForm.notificationsSubTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.CampaignsConsentForm.notificationsTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.CampaignsConsentForm.submit": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ChangeEmail.adminEmailChangeWarning2": {
+    "state": "verified",
+    "verified_at": "2026-03-27T11:19:43.862093Z",
+    "verified_by": "kielgast@govocal.com"
+  },
+  "app.containers.ChangeEmail.backToProfile": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ChangeEmail.confirmationModalTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ChangeEmail.emailEmptyError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ChangeEmail.emailInvalidError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ChangeEmail.emailRequired": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ChangeEmail.emailTaken": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ChangeEmail.emailUpdateCancelled": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ChangeEmail.emailUpdateCancelledDescription": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ChangeEmail.helmetDescription": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ChangeEmail.helmetTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ChangeEmail.newEmailLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ChangeEmail.submitButton": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ChangeEmail.titleAddEmail": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ChangeEmail.titleChangeEmail": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ChangeEmail.updateSuccessful": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ChangePassword.adminPasswordChangeWarning2": {
+    "state": "verified",
+    "verified_at": "2026-03-27T11:19:43.862093Z",
+    "verified_by": "kielgast@govocal.com"
+  },
+  "app.containers.ChangePassword.currentPasswordLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ChangePassword.currentPasswordRequired": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ChangePassword.goHome": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ChangePassword.helmetDescription": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ChangePassword.helmetTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ChangePassword.newPasswordLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ChangePassword.newPasswordRequired": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ChangePassword.password.minimumPasswordLengthError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ChangePassword.passwordChangeSuccessMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ChangePassword.passwordEmptyError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ChangePassword.passwordsDontMatch": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ChangePassword.titleAddPassword": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ChangePassword.titleChangePassword": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.a11y_commentDeleted": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.a11y_commentPosted": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.a11y_likeCount": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.a11y_undoLike": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.addCommentError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.adminCommentDeletionCancelButton": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.adminCommentDeletionConfirmButton": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.cancelCommentEdit": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.childCommentBodyPlaceholder": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.commentCancelUpvote": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.commentDeletedPlaceholder": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.commentDeletionCancelButton": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.commentDeletionConfirmButton": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.commentLike": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.commentReplyButton": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.commentsSortTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.completeProfileLinkText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.completeProfileToComment": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.confirmCommentDeletion": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.deleteComment": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.deleteReasonDescriptionError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.deleteReasonError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.deleteReason_inappropriate": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.deleteReason_irrelevant": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.deleteReason_other": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.editComment": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.guidelinesLinkText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.ideaCommentBodyPlaceholder": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.internalCommentingNudgeMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.internalConversation": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.loadMoreComments": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.loadingComments": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.loadingMoreComments": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.notVisibleToUsersPlaceholder": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.postInternalComment": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.postPublicComment": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.profanityError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.publicDiscussion": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.publishComment": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.reportAsSpamModalTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.saveComment": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.signInLinkText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.signInToComment": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.signUpLinkText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.verifyIdentityLinkText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.visibleToUsersPlaceholder": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Comments.visibleToUsersWarning": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ContentBuilder.PageTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ContentBuilder.PageTitleFolder": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.CookiePolicy.advertisingContent": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.CookiePolicy.advertisingTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.CookiePolicy.analyticsContents": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.CookiePolicy.analyticsTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.CookiePolicy.cookiePolicyDescription": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.CookiePolicy.cookiePolicyTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.CookiePolicy.essentialContent": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.CookiePolicy.essentialTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.CookiePolicy.externalContent": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.CookiePolicy.externalTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.CookiePolicy.functionalContents": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.CookiePolicy.functionalTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.CookiePolicy.headCookiePolicyTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.CookiePolicy.intro": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.CookiePolicy.manageCookiesDescription": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.CookiePolicy.manageCookiesPreferences": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.CookiePolicy.manageCookiesPreferencesButtonText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.CookiePolicy.manageCookiesTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.CookiePolicy.viewPreferencesButtonText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.CookiePolicy.viewPreferencesText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.CookiePolicy.whatDoWeUseCookiesFor": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.CustomPageShow.editPage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.CustomPageShow.goBack": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.CustomPageShow.notFound": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.DisabledAccount.bottomText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.DisabledAccount.termsAndConditions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.DisabledAccount.text2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.DisabledAccount.title": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.EventsShow.addToCalendar": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.EventsShow.editEvent": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.EventsShow.emailSharingBody2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.EventsShow.eventDateTimeIcon": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.EventsShow.eventFrom2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.EventsShow.goBack": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.EventsShow.goToProject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.EventsShow.haveRegistered": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.EventsShow.icsError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.EventsShow.linkToOnlineEvent": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.EventsShow.locationIconAltText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.EventsShow.metaTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.EventsShow.online2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.EventsShow.onlineLinkIconAltText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.EventsShow.registered": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.EventsShow.registrantCount": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.EventsShow.registrantCountWithMaximum": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.EventsShow.registrantsIconAltText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.EventsShow.socialMediaSharingMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.EventsShow.xParticipants": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.EventsViewer.allTime": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.EventsViewer.date": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.EventsViewer.thisMonth2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.EventsViewer.thisWeek2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.EventsViewer.today": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaButton.addAComment": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaButton.addAContribution": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaButton.addAPetition": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaButton.addAPost": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaButton.addAProject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaButton.addAProposal": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaButton.addAQuestion": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaButton.addAResponse": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaButton.addAStory": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaButton.addASuggestion": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaButton.addATopic": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaButton.addAnInitiative": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaButton.addAnOption": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaButton.postingDisabled": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaButton.postingInNonActivePhases": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaButton.postingInactive": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaButton.postingLimitedMaxReached": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaButton.postingNoPermission": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaButton.postingNotYetPossible": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaButton.signInLinkText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaButton.signUpLinkText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaButton.submitAnIssue1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaButton.submitYourIdea": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaButton.takeTheSurvey": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaButton.verificationLinkText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCard.readMore": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCard.xComments": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCard.xVotesOfY": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.a11y_closeFilterPanel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.a11y_totalItems": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.all": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.allStatuses": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.commentTerm": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.contributions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.ideaTerm": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.initiatives": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.issueTerm": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.list": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.map": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.mostDiscussed": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.newest": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.noFilteredResults": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.numberResults": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.oldest": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.optionTerm": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.petitions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.popular": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.postTerm": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.projectFilterTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.projectTerm": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.proposals": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.questionTerm": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.random": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.resetFilters": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.responseTerm": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.showXResults": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.sortTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.statusTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.statusesTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.storyTerm": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.suggestionTerm": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.topicTerm": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.topics": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.topicsTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.trending": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.tryDifferentFilters": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.xComments3": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.xCommentsTerm": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.xContributions2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.xIdeas2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.xInitiatives2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.xIssues": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.xOptions2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.xPetitions2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.xPosts": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.xProjects3": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.xProposals2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.xQuestion2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.xResponses": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.xResults": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.xStories": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.xSuggestions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeaCards.xTopics": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasEditPage.commentFormTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasEditPage.contributionFormTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasEditPage.editedPostSave": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasEditPage.fileUploadError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasEditPage.formTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasEditPage.ideasEditMetaDescription": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasEditPage.ideasEditMetaTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasEditPage.initiativeFormTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasEditPage.issueFormTitle1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasEditPage.optionFormTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasEditPage.petitionFormTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasEditPage.postFormTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasEditPage.projectFormTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasEditPage.proposalFormTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasEditPage.questionFormTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasEditPage.responseFormTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasEditPage.save": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasEditPage.storyFormTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasEditPage.submitApiError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasEditPage.suggestionFormTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasEditPage.topicFormTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.addAComment": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.addAContribution": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.addAPetition": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.addAPost": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.addAProject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.addAProposal": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.addAQuestion": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.addAResponse": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.addAStory": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.addASuggestion": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.addATopic": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.addAnIdea": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.addAnInitiative": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.addAnIssue": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.addAnOption": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.allTopics": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.back": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.collapsePanel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.endOfFeed": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.expandPanel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.exploreTags": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.noIdeasForTag": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.nothingToShowYet": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.seeAllComments": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.seeAllContributions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.seeAllIdeas2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.seeAllInitiatives": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.seeAllIssues": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.seeAllOptions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.seeAllPetitions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.seeAllPosts": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.seeAllProjects": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.seeAllProposals": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.seeAllQuestions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.seeAllResponses": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.seeAllStories": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.seeAllSuggestions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.seeAllTopicsTerm": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.showAllComments": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.showAllContributions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.showAllIdeas": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.showAllInitiatives": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.showAllIssues": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.showAllOptions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.showAllPetitions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.showAllPosts": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.showAllProjects": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.showAllProposals": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.showAllQuestions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.showAllResponses": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.showAllStories": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.showAllSuggestions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.showAllTopics": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasFeedPage.topicsPanel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasIndexPage.a11y_IdeasListTitle1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasIndexPage.inputsIndexMetaDescription": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasIndexPage.inputsIndexMetaTitle1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasIndexPage.inputsPageTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasIndexPage.loadMore": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasIndexPage.loading": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.IdeasNewForm.inputsAssociatedWithProfile1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.IdeasNewForm.postAnonymously": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.IdeasNewForm.profileVisibility": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.SurveyNotActiveNotice.surveyNotActiveDescription": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.SurveyNotActiveNotice.surveyNotActiveTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.SurveySubmittedNotice.returnToProject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.SurveySubmittedNotice.surveySubmittedDescription": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.SurveySubmittedNotice.surveySubmittedTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.SurveySubmittedNotice.thanksForResponse": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_comment_body_multiloc_maxLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_comment_body_multiloc_minLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_comment_title_multiloc_maxLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_comment_title_multiloc_minLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_contribution_body_multiloc_maxLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_contribution_body_multiloc_minLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_contribution_title_multiloc_maxLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_contribution_title_multiloc_minLength1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_cosponsor_ids_required": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_idea_body_multiloc_maxLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_idea_body_multiloc_minLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_idea_body_multiloc_required": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_idea_title_multiloc_maxLength1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_idea_title_multiloc_minLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_initiative_body_multiloc_maxLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_initiative_body_multiloc_minLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_initiative_title_multiloc_maxLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_initiative_title_multiloc_minLength1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_issue_body_multiloc_maxLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_issue_body_multiloc_minLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_issue_title_multiloc_maxLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_issue_title_multiloc_minLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_number_required": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_option_body_multiloc_maxLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_option_body_multiloc_minLength1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_option_title_multiloc_maxLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_option_title_multiloc_minLength1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_option_topic_ids_minItems": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_petition_body_multiloc_maxLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_petition_body_multiloc_minLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_petition_title_multiloc_maxLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_petition_title_multiloc_minLength1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_post_body_multiloc_maxLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_post_body_multiloc_minLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_post_title_multiloc_maxLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_post_title_multiloc_minLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_project_body_multiloc_maxLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_project_body_multiloc_minLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_project_title_multiloc_maxLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_project_title_multiloc_minLength1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_proposal_body_multiloc_maxLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_proposal_body_multiloc_minLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_proposal_title_multiloc_maxLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_proposal_title_multiloc_minLength1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_proposed_budget_required": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_proposed_bugdet_type": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_question_body_multiloc_maxLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_question_body_multiloc_minLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_question_title_multiloc_maxLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_question_title_multiloc_minLength1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_response_body_multiloc_maxLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_response_body_multiloc_minLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_response_title_multiloc_maxLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_response_title_multiloc_minLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_story_body_multiloc_maxLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_story_body_multiloc_minLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_story_title_multiloc_maxLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_story_title_multiloc_minLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_suggestion_body_multiloc_maxLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_suggestion_body_multiloc_minLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_suggestion_title_multiloc_maxLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_suggestion_title_multiloc_minLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_title_multiloc_required": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_topic_body_multiloc_maxLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_topic_body_multiloc_minLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_topic_title_multiloc_maxLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ajv_error_topic_title_multiloc_minLength": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_comment_description_multiloc_too_long": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_comment_description_multiloc_too_short": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_comment_title_multiloc_too_long": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_comment_title_multiloc_too_short": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_contribution_description_multiloc_too_long": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_contribution_description_multiloc_too_short": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_contribution_title_multiloc_too_long": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_contribution_title_multiloc_too_short": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_idea_description_multiloc_too_long": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_idea_description_multiloc_too_short": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_idea_title_multiloc_blank": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_idea_title_multiloc_too_long": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_idea_title_multiloc_too_short": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_includes_banned_words": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_initiative_description_multiloc_too_long": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_initiative_description_multiloc_too_short": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_initiative_title_multiloc_too_long": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_initiative_title_multiloc_too_short": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_issue_description_multiloc_too_long": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_issue_description_multiloc_too_short": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_issue_title_multiloc_too_long": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_issue_title_multiloc_too_short": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_option_description_multiloc_too_long": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_option_description_multiloc_too_short": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_option_title_multiloc_too_long": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_option_title_multiloc_too_short": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_petition_description_multiloc_too_long": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_petition_description_multiloc_too_short": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_petition_title_multiloc_too_long": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_petition_title_multiloc_too_short": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_post_description_multiloc_too_long": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_post_description_multiloc_too_short": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_post_title_multiloc_too_long": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_post_title_multiloc_too_short": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_project_description_multiloc_too_long": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_project_description_multiloc_too_short": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_project_title_multiloc_too_long": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_project_title_multiloc_too_short": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_proposal_description_multiloc_too_long": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_proposal_description_multiloc_too_short": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_proposal_title_multiloc_too_long": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_proposal_title_multiloc_too_short": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_question_description_multiloc_blank": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_question_description_multiloc_too_long": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_question_description_multiloc_too_short": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_question_title_multiloc_too_long": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_question_title_multiloc_too_short": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_response_description_multiloc_too_long": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_response_description_multiloc_too_short": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_response_title_multiloc_too_long": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_response_title_multiloc_too_short": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_story_description_multiloc_too_long": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_story_description_multiloc_too_short": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_story_title_multiloc_too_long": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_story_title_multiloc_too_short": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_suggestion_description_multiloc_too_long": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_suggestion_description_multiloc_too_short": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_suggestion_title_multiloc_too_long": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_suggestion_title_multiloc_too_short": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_topic_description_multiloc_too_long": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_topic_description_multiloc_too_short": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_topic_title_multiloc_too_long": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.api_error_topic_title_multiloc_too_short": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.cancelLeaveSurveyButtonText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.commentMetaTitle1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.confirmLeaveFormButtonText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.contributionMetaTitle1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.editSurvey": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ideaNewMetaDescription": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.ideaNewMetaTitle1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.initiativeMetaTitle1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.issueMetaTitle1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.leaveFormConfirmationQuestion": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.leaveFormTextLoggedIn": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.leaveSurvey": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.leaveSurveyText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.optionMetaTitle1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.petitionMetaTitle1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.postMetaTitle1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.projectMetaTitle1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.proposalMetaTitle1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.questionMetaTitle1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.responseMetaTitle1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.storyMetaTitle1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.suggestionMetaTitle1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.surveyNewMetaTitle2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasNewPage.topicMetaTitle1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.Cosponsorship.co-sponsorAcceptInvitation": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.Cosponsorship.co-sponsorInvitation": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.Cosponsorship.co-sponsors": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.Cosponsorship.cosponsorDescription": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.Cosponsorship.cosponsorInvitationAccepted": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.Cosponsorship.pending": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.MetaInformation.attachments": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.MetaInformation.byUserOnDate": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.MetaInformation.currentStatus": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.MetaInformation.location": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.MetaInformation.postedBy": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.MetaInformation.similar": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.MetaInformation.topics": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.commentCTA": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.commentEmailSharingBody": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.commentEmailSharingSubject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.commentSharingModalTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.commentTwitterMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.commentWhatsAppMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.contributionEmailSharingBody": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.contributionEmailSharingSubject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.contributionSharingModalTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.contributionTwitterMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.contributionWhatsAppMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.currentStatus": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.deletedUser": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.ideaEmailSharingBody": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.ideaEmailSharingSubject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.ideaTwitterMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.ideaWhatsAppMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.imported": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.importedTooltip": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.initiativeEmailSharingBody": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.initiativeEmailSharingSubject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.initiativeSharingModalTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.initiativeTwitterMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.initiativeWhatsAppMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.issueEmailSharingBody1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.issueEmailSharingSubject1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.issueSharingModalTitle1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.issueTwitterMessage1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.issueWhatsAppMessage1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.metaTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.optionEmailSharingBody": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.optionEmailSharingSubject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.optionSharingModalTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.optionTwitterMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.optionWhatsAppMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.petitionEmailSharingBody": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.petitionEmailSharingSubject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.petitionSharingModalTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.petitionTwitterMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.petitionWhatsAppMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.postEmailSharingBody": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.postEmailSharingSubject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.postSharingModalTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.postTwitterMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.postWhatsAppMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.projectEmailSharingBody": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.projectEmailSharingSubject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.projectSharingModalTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.projectTwitterMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.projectWhatsAppMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.proposalEmailSharingBody": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.proposalEmailSharingSubject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.proposalSharingModalTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.proposalTwitterMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.proposalWhatsAppMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.proposals.VoteControl.a11y_timeLeft": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.proposals.VoteControl.a11y_xVotesOfRequiredY": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.proposals.VoteControl.cancelVote": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.proposals.VoteControl.days": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.proposals.VoteControl.guidelinesLinkText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.proposals.VoteControl.hours": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.proposals.VoteControl.invisibleTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.proposals.VoteControl.minutes": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.proposals.VoteControl.moreInfo": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.proposals.VoteControl.thresholdReachedStillOpen1": {
+    "state": "verified",
+    "verified_at": "2026-04-17T13:33:20.942288Z",
+    "verified_by": "kielgast@govocal.com"
+  },
+  "app.containers.IdeasShow.proposals.VoteControl.vote": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.proposals.VoteControl.voted": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.proposals.VoteControl.votedText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.proposals.VoteControl.votedTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.proposals.VoteControl.votingNotPermitted1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.proposals.VoteControl.xDays": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.proposals.VoteControl.xVotes": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.questionEmailSharingBody": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.questionEmailSharingSubject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.questionSharingModalTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.questionTwitterMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.questionWhatsAppMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.reportAsSpamModalTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.responseEmailSharingBody": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.responseEmailSharingSubject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.responseSharingModalTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.responseTwitterMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.responseWhatsAppMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.share": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.sharingModalSubtitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.sharingModalTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.storyEmailSharingBody": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.storyEmailSharingSubject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.storySharingModalTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.storyTwitterMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.storyWhatsAppMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.suggestionEmailSharingBody": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.suggestionEmailSharingSubject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.suggestionSharingModalTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.suggestionTwitterMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.suggestionWhatsAppMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.topicEmailSharingBody": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.topicEmailSharingSubject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.topicSharingModalTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.topicTwitterMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.IdeasShow.topicWhatsAppMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Navbar.completeOnboarding": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Navbar.completeProfile": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Navbar.confirmEmail2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Navbar.unverified": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Navbar.verified": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NewAuthModal.beforeYouFollow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NewAuthModal.beforeYouParticipate": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NewAuthModal.completeYourProfile": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NewAuthModal.confirmYourEmail": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NewAuthModal.logIn": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NewAuthModal.steps.AcceptPolicies.reviewTheTerms": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NewAuthModal.steps.BuiltInFields.pleaseCompleteYourProfile": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NewAuthModal.steps.EmailConfirmation.codeMustHaveFourDigits": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NewAuthModal.steps.EmailSignUp.SSOButtons.noAuthenticationMethodsEnabled": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NewAuthModal.steps.EmailSignUp.byContinuing": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NewAuthModal.steps.EmailSignUp.email": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NewAuthModal.steps.EmailSignUp.emailFormatError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NewAuthModal.steps.EmailSignUp.emailMissingError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NewAuthModal.steps.EmailSignUp.enterYourEmailAddress": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NewAuthModal.steps.Password.forgotPassword": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NewAuthModal.steps.Password.logInToYourAccount": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NewAuthModal.steps.Password.noPasswordError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NewAuthModal.steps.Password.password": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NewAuthModal.steps.Password.rememberMe": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NewAuthModal.steps.Password.rememberMeTooltip": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NewAuthModal.steps.Policies.change1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NewAuthModal.steps.Policies.createANewAccountWith": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
   },
   "app.containers.NewAuthModal.steps.Success.allDone": {
     "state": "verified",
     "verified_at": "2026-04-24T10:50:26.324675Z",
     "verified_by": "kielgast@govocal.com"
+  },
+  "app.containers.NewAuthModal.steps.Success.nowContinueYourParticipation": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NewAuthModal.steps.VerificationSuccess.userVerifiedSubtitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NewAuthModal.steps.VerificationSuccess.userVerifiedTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NewAuthModal.steps.close": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NewAuthModal.steps.continue": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NewAuthModal.whatAreYouInterestedIn": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NewAuthModal.youCantParticipate": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.a11y_notificationsLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.adminRightsReceived": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.commentDeletedByAdminFor1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.cosponsorOfYourIdea": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.deletedUser": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.error": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.internalCommentOnIdeaAssignedToYou": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.internalCommentOnIdeaYouCommentedInternallyOn": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.internalCommentOnIdeaYouModerate": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.internalCommentOnUnassignedUnmoderatedIdea": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.internalCommentOnYourInternalComment": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.invitationToCosponsorComment": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.invitationToCosponsorContribution": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.invitationToCosponsorIdea": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.invitationToCosponsorInitiative": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.invitationToCosponsorIssue": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.invitationToCosponsorOption": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.invitationToCosponsorPetition": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.invitationToCosponsorPost": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.invitationToCosponsorProject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.invitationToCosponsorProposal": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.invitationToCosponsorQuestion": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.invitationToCosponsorResponse": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.invitationToCosponsorStory": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.invitationToCosponsorSuggestion": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.invitationToCosponsorTopic": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.loadMore": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.loading": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.mentionInComment": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.mentionInInternalComment": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.mentionInOfficialFeedback": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.nativeSurveyNotSubmitted": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.noNotifications": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.notificationsLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.officialFeedbackOnCommentYouFollow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.officialFeedbackOnContributionYouFollow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.officialFeedbackOnIdeaYouFollow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.officialFeedbackOnInitiativeYouFollow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.officialFeedbackOnIssueYouFollow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.officialFeedbackOnOptionYouFollow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.officialFeedbackOnPetitionYouFollow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.officialFeedbackOnPostYouFollow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.officialFeedbackOnProjectYouFollow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.officialFeedbackOnProposalYouFollow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.officialFeedbackOnQuestionYouFollow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.officialFeedbackOnResponseYouFollow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.officialFeedbackOnStoryYouFollow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.officialFeedbackOnSuggestionYouFollow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.officialFeedbackOnTopicYouFollow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.postAssignedToYou": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.projectModerationRightsReceived": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.projectPhaseStarted": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.projectPhaseUpcoming": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.projectPublished": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.projectReviewRequest": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.projectReviewStateChange": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.statusChangedOnIdeaYouFollow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.thresholdReachedForAdmin": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.userAcceptedYourInvitation": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.userCommentedOnCommentYouFollow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.userCommentedOnContributionYouFollow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.userCommentedOnIdeaYouFollow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.userCommentedOnInitiativeYouFollow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.userCommentedOnIssueYouFollow1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.userCommentedOnOptionYouFollow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.userCommentedOnPetitionYouFollow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.userCommentedOnPostYouFollow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.userCommentedOnProjectYouFollow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.userCommentedOnProposalYouFollow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.userCommentedOnQuestionYouFollow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.userCommentedOnResponseYouFollow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.userCommentedOnStoryYouFollow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.userCommentedOnSuggestionYouFollow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.userCommentedOnTopicYouFollow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.userMarkedPostAsSpam1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.userReactedToYourComment": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.userReportedCommentAsSpam1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.votingBasketNotSubmitted": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.votingBasketSubmitted": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.votingLastChance": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.votingResults": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.NotificationMenu.xAssignedPostToYou": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.PasswordRecovery.emailError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.PasswordRecovery.emailLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.PasswordRecovery.emailPlaceholder": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.PasswordRecovery.helmetDescription": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.PasswordRecovery.helmetTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.PasswordRecovery.passwordResetSuccessMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.PasswordRecovery.resetPassword": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.PasswordRecovery.submitError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.PasswordRecovery.subtitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.PasswordRecovery.title": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.PasswordReset.helmetDescription": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.PasswordReset.helmetTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.PasswordReset.login": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.PasswordReset.passwordError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.PasswordReset.passwordLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.PasswordReset.passwordPlaceholder": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.PasswordReset.passwordUpdatedSuccessMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.PasswordReset.pleaseLogInMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.PasswordReset.requestNewPasswordReset": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.PasswordReset.submitError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.PasswordReset.title": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.PasswordReset.updatePassword": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectFolderCards.allProjects": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectFolderCards.currentlyWorkingOn": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectFolderShowPage.editFolder": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectFolderShowPage.invisibleTitleMainContent": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectFolderShowPage.metaTitle1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectFolderShowPage.projectFolderTwitterMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectFolderShowPage.projectFolderWhatsAppMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectFolderShowPage.readMore": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectFolderShowPage.seeLess": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectFolderShowPage.share": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.PollForm.document": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.PollForm.formCompleted": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.PollForm.maxOptions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.PollForm.pollDisabledAlreadyResponded": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.PollForm.pollDisabledNotActivePhase1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.PollForm.pollDisabledNotPermitted": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.PollForm.pollDisabledNotPossible": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.PollForm.pollDisabledProjectInactive": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.PollForm.sendAnswer": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.a11y_phase": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.a11y_phasesOverview": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.a11y_titleInputs": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.a11y_titleInputsPhase": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.accessRights": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.addedToBasket": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.allocateBudget": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.archived": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.basketSubmitted": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.commentsTerm": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.contributions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.createANewPhase": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.currentPhase": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.document": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.editProject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.emailSharingBody": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.emailSharingSubject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.endedOn": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.events": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.header": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.ideas": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.information": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.initiatives": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.invisbleTitleDocumentAnnotation1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.invisibleTitlePhaseAbout": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.invisibleTitlePoll": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.invisibleTitleSurvey": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.issues1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.liveDataMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.location": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.manageBasket": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.meetMinBudgetRequirement": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.meetMinSelectionRequirement": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.metaTitle1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.minBudgetRequired": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.myBasket": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.navPoll": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.navSurvey": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.newPhase": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.nextPhase": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.noEndDate": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.noItems": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.noPastEvents": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.noPhaseSelected": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.noUpcomingOrOngoingEvents": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.offlineVotersTooltip": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.options": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.participants": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.participantsTooltip4": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.pastEvents": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.petitions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.phases": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.postsTerm": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.previousPhase": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.project": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.projectTwitterMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.projects": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.proposals": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.questions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.readLess": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.readMore": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.removeItem": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.requiredSelection": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.responsesTerm": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.reviewDocument": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.seeTheComments": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.seeTheContributions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.seeTheIdeas": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.seeTheInitiatives": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.seeTheIssues1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.seeTheOptions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.seeThePetitions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.seeThePosts": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.seeTheProjects": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.seeTheProposals": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.seeTheQuestions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.seeTheResponses": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.seeTheStories": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.seeTheSuggestions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.seeTheTopics": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.seeUpcomingEvents": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.share": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.shareThisProject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.storiesTerm": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.submitMyBasket": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.suggestionsTerm": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.survey": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.takeThePoll": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.takeTheSurvey": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.timeline": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.topicsTerm": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.upcomingAndOngoingEvents": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.upcomingEvents": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.whatsAppMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.Projects.yourBudget": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectsIndexPage.metaDescription": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectsIndexPage.metaTitle1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectsIndexPage.pageTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectsShowPage.VolunteeringSection.becomeVolunteerButton": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectsShowPage.VolunteeringSection.notLoggedIn": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectsShowPage.VolunteeringSection.notOpenParticipation": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectsShowPage.VolunteeringSection.signInLinkText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectsShowPage.VolunteeringSection.signUpLinkText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectsShowPage.VolunteeringSection.withdrawVolunteerButton": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectsShowPage.VolunteeringSection.xVolunteers": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectsShowPage.process.survey.embeddedSurveyScreenReaderWarning1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectsShowPage.process.survey.survey": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectsShowPage.process.survey.surveyDisabledMaybeNotPermitted": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectsShowPage.process.survey.surveyDisabledNotActivePhase": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectsShowPage.process.survey.surveyDisabledNotActiveUser": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectsShowPage.process.survey.surveyDisabledNotPermitted": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectsShowPage.process.survey.surveyDisabledNotVerified": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectsShowPage.process.survey.surveyDisabledProjectInactive2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectsShowPage.shared.ParticipationPermission.completeRegistrationLinkText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectsShowPage.shared.ParticipationPermission.logInLinkText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectsShowPage.shared.ParticipationPermission.signUpLinkText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectsShowPage.shared.ParticipationPermission.verificationLinkText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectsShowPage.shared.document_annotation.documentAnnotationDisabledMaybeNotPermitted": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectsShowPage.shared.document_annotation.documentAnnotationDisabledNotActivePhase1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectsShowPage.shared.document_annotation.documentAnnotationDisabledNotActiveUser": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectsShowPage.shared.document_annotation.documentAnnotationDisabledNotPermitted": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectsShowPage.shared.document_annotation.documentAnnotationDisabledNotVerified": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectsShowPage.shared.document_annotation.documentAnnotationDisabledProjectInactive": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectsShowPage.timeline.VotingResults.ProgressBar.numberManualVoters2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectsShowPage.timeline.VotingResults.ProgressBar.numberOfPicks": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectsShowPage.timeline.VotingResults.ProgressBars.budgetingTooltip1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectsShowPage.timeline.VotingResults.ProgressBars.votingTooltip": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectsShowPage.timeline.VotingResults.cost": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ProjectsShowPage.timeline.VotingResults.showMore": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ReactionControl.a11y_likesDislikes": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ReactionControl.cancelDislikeSuccess": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ReactionControl.cancelLikeSuccess": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ReactionControl.dislikeSuccess": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ReactionControl.likeSuccess": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ReactionControl.reactionErrorSubTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ReactionControl.reactionSuccessTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ReactionControl.vote": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ReactionControl.voted": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SearchInput.a11y_cancelledPostingComment": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SearchInput.a11y_commentsHaveChanged": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SearchInput.a11y_eventsHaveChanged1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SearchInput.a11y_filtersAppliedCount": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SearchInput.a11y_projectsAvailable": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SearchInput.a11y_projectsHaveChanged1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SearchInput.a11y_searchQuery": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SearchInput.a11y_searchResultsHaveChanged1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SearchInput.removeSearchTerm": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SearchInput.searchAriaLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SearchInput.searchLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SearchInput.searchPlaceholder": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SearchInput.searchTerm": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SignIn.createAnAccountLink": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SignIn.franceConnectIsTheSolutionProposedByTheGovernment": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SignIn.or": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SignIn.signInError2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SignIn.useFranceConnectToLoginCreateOrVerifyYourAccount": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SignIn.whatIsFranceConnect": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SignUp.adminOptions2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SignUp.continue": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SignUp.emailConsent": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SignUp.emptyFirstNameError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SignUp.emptyLastNameError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SignUp.firstNamesLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SignUp.iHaveReadAndAgreeToPrivacy": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SignUp.iHaveReadAndAgreeToTerms": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SignUp.iHaveReadAndAgreeToVienna": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SignUp.invitationErrorText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SignUp.lastNameLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SignUp.onboarding.topicsAndAreas.followAreasOfFocus": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SignUp.onboarding.topicsAndAreas.followYourFavoriteTopics": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SignUp.onboarding.topicsAndAreas.savePreferences": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SignUp.onboarding.topicsAndAreas.skipForNow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SignUp.privacyPolicyNotAcceptedError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SignUp.signUp2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SignUp.skip": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SignUp.tacError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SignUp.thePrivacyPolicy": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SignUp.theTermsAndConditions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SignUp.unknownError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SignUp.viennaConsentEmail": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SignUp.viennaConsentFirstName": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SignUp.viennaConsentFooter": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SignUp.viennaConsentHeader": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SignUp.viennaConsentLastName": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SignUp.viennaConsentUserName": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SignUp.viennaDataProtection": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SiteMap.contributions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SiteMap.cookiePolicyLinkTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SiteMap.issues1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SiteMap.options": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SiteMap.projects": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SiteMap.questions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SpamReport.buttonSave": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SpamReport.buttonSuccess": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SpamReport.inappropriate": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SpamReport.messageError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SpamReport.messageSuccess": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SpamReport.other": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SpamReport.otherReasonPlaceholder": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.SpamReport.wrong_content": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.a11y_imageDropzoneRemoveIconAriaTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.activeProposalVotesWillBeDeleted": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.addPassword": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.becomeVerifiedSubtitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.becomeVerifiedTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.bio": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.bio_placeholder": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.blockedVerified": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.buttonSuccessLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.cancel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.changeEmail": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.changePassword2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.clickHereToUpdateVerification": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.conditionsLinkText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.contactUs": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.deleteAccountSubtext": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.deleteMyAccount": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.deleteYourAccount": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.deletionSection": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.deletionSubtitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.email": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.emailEmptyError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.emailInvalidError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.feedbackLinkText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.feedbackLinkUrl": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.firstNames": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.firstNamesEmptyError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.h1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.h1sub": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.image": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.imageDropzonePlaceholder": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.invisibleTitleUserSettings": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.language": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.lastName": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.lastNameEmptyError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.loading": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.loginCredentialsSubtitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.loginCredentialsTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.messageError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.messageSuccess": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.metaDescription": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.metaTitle1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.noGoingBack": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.noNameWarning2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.notificationsSubTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.notificationsTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.password": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.password.minimumPasswordLengthError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.passwordAddSection": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.passwordAddSubtitle2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.passwordChangeSection": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.passwordChangeSubtitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.privacyReasons": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.processing": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.provideFirstNameIfLastName": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.reasonsToStayListTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.submit": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.tooManyEmails": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.updateverification": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.user": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.verifiedIdentitySubtitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.verifiedIdentityTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersEditPage.verifyNow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersShowPage.Surveys.SurveySubmissionCard.downloadYourResponses2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersShowPage.a11y_likesCount": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersShowPage.a11y_postCommentPostedIn": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersShowPage.areas": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersShowPage.commentsWithCount": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersShowPage.editProfile": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersShowPage.emptyInfoText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersShowPage.eventsWithCount": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersShowPage.followingWithCount": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersShowPage.inputs": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersShowPage.invisibleTitlePostsList": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersShowPage.invisibleTitleUserComments": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersShowPage.loadMore": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersShowPage.loadMoreComments": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersShowPage.loadingComments": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersShowPage.loadingEvents": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersShowPage.memberSince": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersShowPage.metaTitle1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersShowPage.noCommentsForUser": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersShowPage.noCommentsForYou": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersShowPage.noEventsForUser": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersShowPage.postsWithCount": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersShowPage.projectFolders": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersShowPage.projects": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersShowPage.proposals": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersShowPage.seePost": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersShowPage.surveyResponses": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersShowPage.topics": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersShowPage.tryAgain": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.UsersShowPage.userShowPageMetaDescription": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.VoteControl.close": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.VoteControl.voteErrorTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.admin.ContentBuilder.default": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.admin.ContentBuilder.folderFiles": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.admin.ContentBuilder.folderTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.admin.ContentBuilder.imageTextCards": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.admin.ContentBuilder.infoWithAccordions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.admin.ContentBuilder.oneColumnLayout": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.admin.ContentBuilder.projectDescription": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.admin.ContentBuilder.publishedProjects": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.admin.ContentBuilder.selectedProjects": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.app.navbar.admin": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.app.navbar.allProjects": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.app.navbar.ariaLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.app.navbar.closeMobileNavMenu": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.app.navbar.editProfile": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.app.navbar.fullMobileNavigation": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.app.navbar.logIn": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.app.navbar.logoImgAltText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.app.navbar.more": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.app.navbar.myProfile": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.app.navbar.search": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.app.navbar.showFullMenu": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.app.navbar.signOut": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.eventspage.errorWhenFetchingEvents": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.eventspage.events": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.eventspage.eventsPageDescription": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.eventspage.eventsPageTitle1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.eventspage.filterDropdownTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.eventspage.noPastEvents": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.eventspage.noUpcomingOrOngoingEvents": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.eventspage.pastEvents": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.eventspage.upcomingAndOngoingEvents": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.footer.accessibility-statement": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.footer.ariaLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.footer.cookie-policy": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.footer.cookieSettings": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.footer.feedbackEmptyError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.footer.poweredBy": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.footer.privacy-policy": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.footer.siteMap": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.footer.terms-and-conditions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ideaHeading.cancelLeaveIdeaButtonText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ideaHeading.confirmLeaveFormButtonText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ideaHeading.editForm": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ideaHeading.leaveFormConfirmationQuestion": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ideaHeading.leaveIdeaForm": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.ideaHeading.leaveIdeaText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.landing.cityProjects": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.landing.completeProfile": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.landing.completeYourProfile": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.landing.createAccount": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.landing.defaultSignedInMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.landing.doItLater": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.landing.new": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.landing.subtitleCity": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.landing.titleCity": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.landing.twitterMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.landing.upcomingEventsWidgetTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.landing.userDeletedSubtitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.landing.userDeletedSubtitleLinkText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.landing.userDeletedSubtitleLinkUrl": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.landing.userDeletedTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.landing.userDeletionFailed": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.landing.verifyNow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.landing.verifyYourIdentity": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.landing.viewAllEventsText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.containers.projectsShowPage.folderGoBackButton.backToFolder": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.after_end_at": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.avatar_carrierwave_download_error": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.avatar_carrierwave_integrity_error": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.avatar_carrierwave_processing_error": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.avatar_extension_blacklist_error": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.avatar_extension_whitelist_error": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.banner_cta_button_multiloc_blank": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.banner_cta_button_url_blank": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.banner_cta_button_url_url": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.banner_cta_signed_in_text_multiloc_blank": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.banner_cta_signed_in_url_blank": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.banner_cta_signed_in_url_url": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.banner_cta_signed_out_text_multiloc_blank": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.banner_cta_signed_out_url_blank": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.banner_cta_signed_out_url_url": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.base_includes_banned_words": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.body_multiloc_includes_banned_words": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.bulk_import_idea_not_valid": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.bulk_import_image_url_not_valid": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.bulk_import_location_point_blank_coordinate": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.bulk_import_location_point_non_numeric_coordinate": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.bulk_import_malformed_pdf": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.bulk_import_maximum_ideas_exceeded": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.bulk_import_maximum_pdf_pages_exceeded": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.bulk_import_not_enough_pdf_pages": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.bulk_import_pdf_pages_not_divisible": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.bulk_import_publication_date_invalid_format": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.cannot_contain_ideas": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.cant_change_after_first_response": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.category_name_taken": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.confirmation_code_expired": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.confirmation_code_invalid": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.confirmation_code_too_many_resets": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.confirmation_code_too_many_retries": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.email_already_active": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.email_already_invited": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.email_banned": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.email_blank": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.email_domain_blacklisted": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.email_invalid": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.email_sso_enforced_for_domain": {
+    "state": "verified",
+    "verified_at": "2026-03-27T11:37:54.117817Z",
+    "verified_by": "kielgast@govocal.com"
+  },
+  "app.errors.email_taken": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.email_taken_by_invite": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.emails_duplicate": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.extension_whitelist_error": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.file_extension_whitelist_error": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.first_name_blank": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.generics.blank": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.generics.invalid": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.generics.taken": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.generics.unsupported_locales": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.group_ids_unauthorized_choice_moderator": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.has_inputs": {
+    "state": "verified",
+    "verified_at": "2026-03-18T16:34:05.090946Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.has_other_overlapping_phases": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.invalid_email": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.invalid_row": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.is_not_timeline_project": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.key_invalid": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.last_name_blank": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.locale_blank": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.locale_inclusion": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.malformed_admin_value": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.malformed_groups_value": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.max_invites_limit_exceeded1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.maximum_attendees_greater_than1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.maximum_attendees_greater_than_attendees_count1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.no_invites_specified": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.no_recipients": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.number_invalid": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.password_blank": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.password_invalid": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.password_too_short": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.resending_code_failed": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.slug_taken": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.something_went_wrong": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.tag_name_taken": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.title_multiloc_blank": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.title_multiloc_includes_banned_words": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.token_invalid": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.too_common": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.too_long": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.too_short": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.uncaught_error": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.unknown_group": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.unknown_locale": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.unparseable_excel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.url": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.verification_taken": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.errors.view_name_taken": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.commercial.flag_inappropriate_content.citizen.components.inappropriateContentAutoDetected": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.commercial.id_vienna_saml.components.signInWithStandardPortal": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_cow.cancel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_cow.emptyFieldError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_cow.helpAltText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_cow.invalidIdSerialError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_cow.invalidRunError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_cow.noMatchFormError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_cow.notEntitledFormError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_cow.showCOWHelp": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_cow.somethingWentWrongError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_cow.submit": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_cow.takenFormError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_cow.verifyCow": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_franceconnect.verificationButtonAltText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_gent_rrn.cancel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_gent_rrn.emptyFieldError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_gent_rrn.gentRrnHelp": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_gent_rrn.invalidRrnError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_gent_rrn.noMatchFormError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_gent_rrn.notEntitledLivesOutsideFormError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_gent_rrn.notEntitledTooYoungFormError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_gent_rrn.rrnLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_gent_rrn.rrnTooltip": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_gent_rrn.showGentRrnHelp": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_gent_rrn.somethingWentWrongError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_gent_rrn.submit": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_gent_rrn.takenFormError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_gent_rrn.verifyGentRrn": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_id_card_lookup.cancel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_id_card_lookup.emptyFieldError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_id_card_lookup.helpAltText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_id_card_lookup.invalidCardIdError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_id_card_lookup.noMatchFormError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_id_card_lookup.showHelp": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_id_card_lookup.somethingWentWrongError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_id_card_lookup.submit": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_id_card_lookup.takenFormError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_oostende_rrn.cancel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_oostende_rrn.emptyFieldError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_oostende_rrn.invalidRrnError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_oostende_rrn.noMatchFormError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_oostende_rrn.notEntitledLivesOutsideFormError1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_oostende_rrn.notEntitledTooYoungFormError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_oostende_rrn.oostendeRrnHelp": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_oostende_rrn.rrnLabel": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_oostende_rrn.rrnTooltip": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_oostende_rrn.showOostendeRrnHelp": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_oostende_rrn.somethingWentWrongError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_oostende_rrn.submit": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_oostende_rrn.takenFormError": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.id_oostende_rrn.verifyOostendeRrn": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.project_folder.citizen.components.Notification.youveReceivedFolderAdminRights": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.project_folder.citizen.components.ProjectFolderShareButton.share": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.project_folder.citizen.components.ProjectFolderSharingModal.emailSharingBody": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.project_folder.citizen.components.ProjectFolderSharingModal.emailSharingSubject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.project_folder.citizen.components.ProjectFolderSharingModal.twitterMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.modules.project_folder.citizen.components.ProjectFolderSharingModal.whatsAppMessage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.sessionRecording.accept": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.sessionRecording.modalDescription1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.sessionRecording.modalDescription2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.sessionRecording.modalDescription3": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.sessionRecording.modalDescriptionFaq": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.sessionRecording.modalTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.sessionRecording.reject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.AdminPage.ProjectEdit.conductParticipatoryBudgetingText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.AdminPage.ProjectEdit.createDocumentAnnotation": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.AdminPage.ProjectEdit.createNativeSurvey": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.AdminPage.ProjectEdit.createPoll": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.AdminPage.ProjectEdit.createSurveyText": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.AdminPage.ProjectEdit.findVolunteers": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.AdminPage.ProjectEdit.inputAndFeedback": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.AdminPage.ProjectEdit.shareInformation": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.FormattedCurrency.credits": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.FormattedCurrency.tokens": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.FormattedCurrency.xCredits": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.FormattedCurrency.xTokens": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeaCards.mostDiscussed": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeaCards.mostReacted": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeaCards.newest": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeaCards.oldest": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeaCards.random": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeaCards.trending": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeasNewPage.commentFormTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeasNewPage.contributionFormTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeasNewPage.ideaFormTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeasNewPage.initiativeFormTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeasNewPage.issueFormTitle2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeasNewPage.optionFormTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeasNewPage.petitionFormTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeasNewPage.postFormTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeasNewPage.projectFormTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeasNewPage.proposalFormTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeasNewPage.questionFormTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeasNewPage.responseFormTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeasNewPage.storyFormTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeasNewPage.suggestionFormTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeasNewPage.surveyTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeasNewPage.topicFormTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeasNewPage.viewYourComment": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeasNewPage.viewYourContribution": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeasNewPage.viewYourIdea": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeasNewPage.viewYourInitiative": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeasNewPage.viewYourInput": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeasNewPage.viewYourIssue": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeasNewPage.viewYourOption": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeasNewPage.viewYourPetition": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeasNewPage.viewYourPost": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeasNewPage.viewYourProject": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeasNewPage.viewYourProposal": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeasNewPage.viewYourQuestion": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeasNewPage.viewYourResponse": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeasNewPage.viewYourStory": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeasNewPage.viewYourSuggestion": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.IdeasNewPage.viewYourTopic": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.Projects.surveySubmission": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.Projects.yourResponseHasTheFollowingId": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.actionDescriptors.attendingEventMissingRequirements": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.actionDescriptors.attendingEventNotInGroup": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.actionDescriptors.attendingEventNotPermitted": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.actionDescriptors.attendingEventNotSignedIn": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.actionDescriptors.attendingEventNotVerified": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.actionDescriptors.volunteeringMissingRequirements": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.actionDescriptors.volunteeringNotInGroup": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.actionDescriptors.volunteeringNotPermitted": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.actionDescriptors.volunteeringNotSignedIn": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.actionDescriptors.volunteeringNotVerified": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.actionDescriptors.volunteeringdNotActiveUser": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.errors.api_error_default.in": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.errors.default.ajv_error_date_any": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.errors.default.ajv_error_invalid": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.errors.default.ajv_error_maxItems": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.errors.default.ajv_error_minItems": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.errors.default.ajv_error_number_any": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.errors.default.ajv_error_required3": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.errors.default.ajv_error_type": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.errors.default.api_error_accepted": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.errors.default.api_error_blank": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.errors.default.api_error_confirmation": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.errors.default.api_error_empty": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.errors.default.api_error_equal_to": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.errors.default.api_error_even": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.errors.default.api_error_exclusion": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.errors.default.api_error_greater_than": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.errors.default.api_error_greater_than_or_equal_to": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.errors.default.api_error_inclusion": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.errors.default.api_error_invalid": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.errors.default.api_error_less_than": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.errors.default.api_error_less_than_or_equal_to": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.errors.default.api_error_not_a_number": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.errors.default.api_error_not_an_integer": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.errors.default.api_error_other_than": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.errors.default.api_error_present": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.errors.default.api_error_too_long": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.errors.default.api_error_too_short": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.errors.default.api_error_wrong_length": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.errors.defaultapi_error_.odd": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.notInGroup": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.participationMethod.onSurveySubmission": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.participationMethodConfig.voting.votingDisabledProjectInactive": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.participationMethodConfig.voting.votingNotInGroup": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.participationMethodConfig.voting.votingNotPermitted": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.participationMethodConfig.voting.votingNotSignedIn2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.participationMethodConfig.voting.votingNotVerified": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.budgetParticipationEnded1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.budgetSubmitted": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.budgetSubmittedWithIcon": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.budgetingNotInGroup": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.budgetingNotPermitted": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.budgetingNotSignedIn2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.budgetingNotVerified": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.budgetingPreSubmissionWarning": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.budgetingSubmissionInstructionsMinBudget1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.budgetingSubmissionInstructionsOnceYouAreDone": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.budgetingSubmissionInstructionsPreferredOptions": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.budgetingSubmissionInstructionsTotalBudget2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.budgetingSubmittedInstructions2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.budgetingSubmittedInstructionsNoEndDate": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.castYourVote": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.cumulativeVotingInstructionsMaxCreditsPerIdea1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.cumulativeVotingInstructionsMaxPercentsPerIdea2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.cumulativeVotingInstructionsMaxPointsPerIdea1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.cumulativeVotingInstructionsMaxTokensPerIdea1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
   },
   "app.utils.votingMethodUtils.cumulativeVotingInstructionsMaxVotesPerIdea4": {
     "state": "verified",
@@ -19,19 +13199,339 @@
     "verified_at": "2026-04-24T09:57:09.001319Z",
     "verified_by": "KenVM"
   },
+  "app.utils.votingMethodUtils.cumulativeVotingInstructionsPreferredOptions2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.cumulativeVotingInstructionsTotalCredits2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.cumulativeVotingInstructionsTotalPercents2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.cumulativeVotingInstructionsTotalPoints2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.cumulativeVotingInstructionsTotalTokens2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.cumulativeVotingInstructionsTotalVotes3": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.finalResults": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.finalTally": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.howToParticipate": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.howToVote": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
   "app.utils.votingMethodUtils.minSelectedOptionsMessage": {
     "state": "verified",
     "verified_at": "2026-04-24T09:57:09.001319Z",
     "verified_by": "KenVM"
+  },
+  "app.utils.votingMethodUtils.multipleVotingEnded1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.numberOfCredits": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.numberOfPercents2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.numberOfPoints": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.numberOfTokens": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.numberOfVotes1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.results": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.singleVotingEnded": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
   },
   "app.utils.votingMethodUtils.singleVotingMultipleVotesPreferredOptions": {
     "state": "verified",
     "verified_at": "2026-04-24T09:58:18.836927Z",
     "verified_by": "KenVM"
   },
+  "app.utils.votingMethodUtils.singleVotingMultipleVotesYouCanVote2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
   "app.utils.votingMethodUtils.singleVotingOnceYouAreDone": {
     "state": "verified",
     "verified_at": "2026-04-24T09:57:09.001319Z",
     "verified_by": "KenVM"
+  },
+  "app.utils.votingMethodUtils.singleVotingOneVoteEnded": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.singleVotingOneVotePreferredOption": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.singleVotingOneVoteYouCanVote2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.singleVotingUnlimitedEnded": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.singleVotingUnlimitedVotesYouCanVote": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.submitYourBudget": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.submittedBudgetCountText2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.submittedBudgetsCountText2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.submittedVoteCountText2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.submittedVotesCountText2": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.voteSubmittedWithIcon": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.votesCast": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.votingClosed": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.votingPreSubmissionWarning1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.votingSubmittedInstructions1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.utils.votingMethodUtils.votingSubmittedInstructionsNoEndDate1": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "components.UI.IdeaSelect.noIdeaAvailable": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "components.UI.IdeaSelect.selectIdea": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "containers.SiteMap.allProjects": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "containers.SiteMap.customPageSection": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "containers.SiteMap.folderInfo": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "containers.SiteMap.headSiteMapTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "containers.SiteMap.homeSection": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "containers.SiteMap.pageContents": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "containers.SiteMap.profilePage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "containers.SiteMap.profileSettings": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "containers.SiteMap.projectEvents": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "containers.SiteMap.projectIdeas": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "containers.SiteMap.projectInfo": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "containers.SiteMap.projectPoll": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "containers.SiteMap.projectSurvey": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "containers.SiteMap.projectsArchived": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "containers.SiteMap.projectsCurrent": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "containers.SiteMap.projectsDraft": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "containers.SiteMap.projectsSection": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "containers.SiteMap.signInPage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "containers.SiteMap.signUpPage": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "containers.SiteMap.siteMapDescription": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "containers.SiteMap.siteMapTitle": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "containers.SiteMap.successStories": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "containers.SiteMap.timeline": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "containers.SiteMap.userSpaceSection": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "containers.SubscriptionEndedPage.accessDenied": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "containers.SubscriptionEndedPage.subscriptionEnded": {
+    "state": "verified",
+    "verified_at": "2026-03-18T12:49:36.657470Z",
+    "verified_by": "Admin"
+  },
+  "app.components.form.controls.rankingDragHandleLabel": {
+    "state": "verified",
+    "verified_at": "2026-04-22T16:13:29.827729Z",
+    "verified_by": "Edwin Kato"
   }
 }


### PR DESCRIPTION
Noticed the many da-DK translation approvals got lost in a faulty merge. This restores them.