### PR TITLE
[TAN-7670] Bugfix: Can edit project after project added to folder via folder form

### DIFF
--- a/front/app/api/projects/useUpdateProjectFolderMembership.ts
+++ b/front/app/api/projects/useUpdateProjectFolderMembership.ts
@@ -1,14 +1,10 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { CLErrors } from 'typings';
-
-import adminPublicationsKeys from 'api/admin_publications/keys';
-import adminPublicationsStatusCountsKeys from 'api/admin_publications_status_counts/keys';
-import projectFoldersKeys from 'api/project_folders/keys';
 
 import fetcher from 'utils/cl-react-query/fetcher';
 
-import projectsKeys from './keys';
 import { IProject } from './types';
+import { invalidateOnCRUD } from './utils';
 
 interface Params {
   projectId: string;
@@ -27,29 +23,10 @@ const updateProjectFolderMembership = async ({
   });
 
 const useUpdateProjectFolderMembership = () => {
-  const queryClient = useQueryClient();
   return useMutation<IProject, CLErrors, Params>({
     mutationFn: updateProjectFolderMembership,
-    onSuccess: async (_data, { newProjectFolderId, oldProjectFolderId }) => {
-      queryClient.invalidateQueries({ queryKey: projectsKeys.lists() });
-
-      if (newProjectFolderId) {
-        queryClient.invalidateQueries({
-          queryKey: projectFoldersKeys.item({ id: newProjectFolderId }),
-        });
-      }
-
-      if (oldProjectFolderId) {
-        queryClient.invalidateQueries({
-          queryKey: projectFoldersKeys.item({ id: oldProjectFolderId }),
-        });
-      }
-      queryClient.invalidateQueries({
-        queryKey: adminPublicationsKeys.lists(),
-      });
-      queryClient.invalidateQueries({
-        queryKey: adminPublicationsStatusCountsKeys.items(),
-      });
+    onSuccess: () => {
+      invalidateOnCRUD();
     },
   });
 };

--- a/front/app/containers/Admin/projects/project/general/setUp/index.tsx
+++ b/front/app/containers/Admin/projects/project/general/setUp/index.tsx
@@ -7,7 +7,6 @@ import { Multiloc, UploadFile, CLErrors } from 'typings';
 
 import { IFileAttachmentData } from 'api/file_attachments/types';
 import useFileAttachments from 'api/file_attachments/useFileAttachments';
-import useAuthUser from 'api/me/useAuthUser';
 import useProjectImages, {
   CARD_IMAGE_ASPECT_RATIO_HEIGHT,
   CARD_IMAGE_ASPECT_RATIO_WIDTH,
@@ -17,7 +16,6 @@ import projectsKeys from 'api/projects/keys';
 import { IUpdatedProjectProperties, IProject } from 'api/projects/types';
 import useProjectById from 'api/projects/useProjectById';
 import useUpdateProject from 'api/projects/useUpdateProject';
-import { IUser } from 'api/users/types';
 
 import { useSyncFiles } from 'hooks/files/useSyncFiles';
 import useAppConfigurationLocales from 'hooks/useAppConfigurationLocales';
@@ -74,10 +72,9 @@ import validateTitle from '../utils/validateTitle';
 
 interface Props {
   project: IProject;
-  authUser: IUser;
 }
 
-const AdminProjectsProjectGeneral = ({ project, authUser }: Props) => {
+const AdminProjectsProjectGeneral = ({ project }: Props) => {
   const { formatMessage } = useIntl();
   const projectId = project.data.id;
 
@@ -144,20 +141,9 @@ const AdminProjectsProjectGeneral = ({ project, authUser }: Props) => {
       project.data.attributes.description_preview_multiloc
     );
 
-  const { highest_role } = authUser.data.attributes;
-
   const [projectContext, setProjectContext] = useState<ProjectContext>(() => {
-    if (highest_role === 'space_moderator') {
-      if (project.data.attributes.space_id) return 'space';
-      if (project.data.attributes.folder_id) return 'folder';
-      return 'root';
-    }
-
-    if (highest_role === 'project_folder_moderator') {
-      if (project.data.attributes.folder_id) return 'folder';
-      return 'root';
-    }
-
+    if (project.data.attributes.space_id) return 'space';
+    if (project.data.attributes.folder_id) return 'folder';
     return 'root';
   });
 
@@ -650,10 +636,9 @@ const AdminProjectsProjectGeneral = ({ project, authUser }: Props) => {
 const AdminProjectsProjectGeneralWrapper = () => {
   const { projectId } = useParams();
   const { data: project } = useProjectById(projectId);
-  const { data: authUser } = useAuthUser();
-  if (!project || !authUser) return null;
+  if (!project) return null;
 
-  return <AdminProjectsProjectGeneral project={project} authUser={authUser} />;
+  return <AdminProjectsProjectGeneral project={project} />;
 };
 
 export default AdminProjectsProjectGeneralWrapper;


### PR DESCRIPTION
Claude:

### The bug

The project's general settings form had two paths for adding a project to a folder:

- Path A (project's settings form): user clicks the "Folder" radio in-session, which sets local state `projectContext = 'folder'`. Save works because validation sees `projectContext === 'folder'` matching the new `folder_id`.
- Path B (folder's projects form): user adds the project via the folder side. Then opens the project's general settings form for the first time. The form's `projectContext` initializer fell through to 'root' for admins, ignoring the actual `folder_id`. On save, `validateProjectContext('root', { folder_id: 'X' })` returns false, so `validateForm` aborts and shows the error — the API was never even called.

### The fix

`general/setUp/index.tsx` — replaced the role-branching `projectContext` initializer with three lines that derive context from the project's actual attributes:
```
  if (project.data.attributes.space_id) return 'space';
  if (project.data.attributes.folder_id) return 'folder';
  return 'root';
```
That made highest_role → authUser prop → useAuthUser → IUser import a chain of dead code, all removed. Authorization is unaffected: the admin route shell (containers/Admin/index.tsx) gates access upstream, and the backend (`ProjectPolicy`) enforces the real rules.

`useUpdateProjectFolderMembership.ts` — switched to `invalidateOnCRUD()` to match the convention used by `useAddProject` / `useUpdateProject` / `useDeleteProject`. Not strictly needed for the bug, but the bespoke invalidation list was missing keys (notably the project's item key).

### Notes

The removed code wasn't doing permission checks. Let me walk through what each piece actually was.

`if (!authUser) return null` in the wrapper — this is a render-readiness gate. It only checks that the auth data has loaded; it doesn't check what role the user has. Removing it is safe because:

  1. The admin shell at `containers/Admin/index.tsx:85-113` already uses `useAuthUser` and redirects unauthenticated/unauthorized users before this form ever mounts.
  2. The backend `ProjectsController` runs `before_action :authorize_project` plus a second `authorize @project` after `assign_attributes`. That's the real check.

`highest_role` in the initializer — this wasn't permission enforcement either. It was UX branching: deciding which radio to pre-select. The fallthrough returning 'root' for admins is exactly the bug we just fixed. The role check was masking the bug, not enforcing anything.

Where role-based UI still happens — I did not touch `ProjectContextSection/Inner.tsx`. It still calls `useAuthUser()` itself and branches on `highest_role` to render different radio sets (e.g. a `project_folder_moderator` sees just the folder dropdown, no radios). That logic is intact.

# Changelog
## Fixed
- [TAN-7670] Bugfix: Can edit project after project added to folder via folder form
