### PR TITLE
Hide project context stuff from PMs

### DIFF
--- a/front/app/containers/Admin/projects/_shared/components/ProjectSetupForm/ProjectContextSection/index.tsx
+++ b/front/app/containers/Admin/projects/_shared/components/ProjectSetupForm/ProjectContextSection/index.tsx
@@ -2,9 +2,12 @@ import React from 'react';
 
 import { Box } from '@citizenlab/cl2-component-library';
 
+import useAuthUser from 'api/me/useAuthUser';
+
 import { SubSectionTitle } from 'components/admin/Section';
 
 import { FormattedMessage } from 'utils/cl-intl';
+import { isProjectModerator } from 'utils/permissions/roles';
 
 import Inner from './Inner';
 import messages from './messages';
@@ -15,6 +18,11 @@ const ProjectContextSection = (
     formSituation: FormSituation;
   }
 ) => {
+  const { data: authUser } = useAuthUser();
+
+  if (!authUser) return null;
+  if (isProjectModerator(authUser)) return null;
+
   return (
     <Box mb="40px">
       <SubSectionTitle>


### PR DESCRIPTION
# Changelog
## Fixed
- PMs were able to see project context interface