### PR TITLE
TAN-7679 Remove inaccurate combobox role from filter selector

### DIFF
--- a/front/app/component-library/components/Button/index.tsx
+++ b/front/app/component-library/components/Button/index.tsx
@@ -530,6 +530,7 @@ export interface Props extends ButtonContainerProps {
   as?: React.ElementType;
   tabIndex?: number;
   dataCy?: string;
+  ariaHasPopup?: string;
 }
 export type Ref = HTMLButtonElement;
 
@@ -606,6 +607,7 @@ const Button = forwardRef<Ref, Props>((props, ref) => {
     tabIndex,
     as,
     dataCy,
+    ariaHasPopup,
     ...rest
   } = props;
 
@@ -714,6 +716,7 @@ const Button = forwardRef<Ref, Props>((props, ref) => {
         tabIndex={tabIndex}
         ref={ref}
         data-cy={dataCy}
+        aria-haspopup={ariaHasPopup}
       >
         {childContent}
       </StyledButton>

--- a/front/app/components/FilterSelector/SingleSelectDropdown.tsx
+++ b/front/app/components/FilterSelector/SingleSelectDropdown.tsx
@@ -48,7 +48,7 @@ interface Props extends SelectorProps {
   options: IFilterSelectorValue[];
 }
 
-const Combobox = ({
+const SingleSelectDropdown = ({
   options,
   width,
   opened,
@@ -166,8 +166,7 @@ const Combobox = ({
             ariaControls={baseID}
             // Needed to track aria-labelledby
             id={`${baseID}-label`}
-            role="combobox"
-            aria-haspopup="listbox"
+            ariaHasPopup="listbox"
             ariaLabel={
               typeof currentTitle === 'string' ? currentTitle : undefined
             }
@@ -240,4 +239,4 @@ const Combobox = ({
   );
 };
 
-export default Combobox;
+export default SingleSelectDropdown;

--- a/front/app/components/FilterSelector/index.tsx
+++ b/front/app/components/FilterSelector/index.tsx
@@ -12,8 +12,8 @@ import {
 } from 'lodash-es';
 import styled from 'styled-components';
 
-import Combobox from './Combobox';
 import MultiSelectDropdown from './MultiSelectDropdown';
+import SingleSelectDropdown from './SingleSelectDropdown';
 
 const Container = styled(Box)<{ mr?: string; ml?: string }>`
   display: inline-block;
@@ -267,7 +267,7 @@ const FilterSelector = ({
           {...sharedProps}
         />
       ) : (
-        <Combobox
+        <SingleSelectDropdown
           options={values}
           onChange={selectionChange}
           {...sharedProps}


### PR DESCRIPTION
# Changelog
## Fixed
- a11y - Remove inacurate "combobox" role from the filter selector in the events page

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
