### PR TITLE
TAN-6517 Migrate ButtonWithLink callsites and centralize Link locale handling

### DIFF
--- a/front/app/api/projects/utils.ts
+++ b/front/app/api/projects/utils.ts
@@ -13,7 +13,7 @@ import projectsKeys from './keys';
 
 export function getProjectLinkProps(slug: string) {
   return {
-    to: '/$locale/projects/$slug',
+    to: '/projects/$slug',
     params: { slug },
   } as const;
 }

--- a/front/app/components/Avatar/index.tsx
+++ b/front/app/components/Avatar/index.tsx
@@ -139,11 +139,7 @@ const Avatar = memo(
 
     if (isLinkToProfile && hasValidProfileLink) {
       return (
-        <Link
-          to="/$locale/profile/$userSlug"
-          params={{ userSlug: slug }}
-          scrollToTop
-        >
+        <Link to="/profile/$userSlug" params={{ userSlug: slug }} scrollToTop>
           <ScreenReaderOnly>
             <FormattedMessage
               {...messages.titleForAccessibility}

--- a/front/app/components/ConsentManager/ConsentManager.test.tsx
+++ b/front/app/components/ConsentManager/ConsentManager.test.tsx
@@ -14,9 +14,16 @@ import ConsentManager from '.';
 
 // mocks
 
-jest.mock('utils/cl-router/Link', () => ({ children }) => (
-  <button>{children}</button>
-));
+jest.mock('utils/cl-router/Link', () => {
+  const Link = ({ children }: { children?: React.ReactNode }) => (
+    <button>{children}</button>
+  );
+  return {
+    __esModule: true,
+    default: Link,
+    typedStyled: () => () => Link,
+  };
+});
 
 let mockAuthUser: IUserData | null = null;
 jest.mock('api/me/useAuthUser', () => () => ({ data: { data: mockAuthUser } }));

--- a/front/app/components/ConsentManager/InitialScreen/MainContent.tsx
+++ b/front/app/components/ConsentManager/InitialScreen/MainContent.tsx
@@ -29,7 +29,7 @@ const MainContent = () => {
             linkToCookiePolicy: (
               <TextLink
                 target="_blank"
-                to="/$locale/pages/cookie-policy"
+                to="/pages/cookie-policy"
                 search={{ from: 'cookie-modal' }}
               >
                 <FormattedMessage {...messages.linkToCookiePolicyText} />

--- a/front/app/components/DescriptionBuilder/DescriptionBuilderToggle/index.tsx
+++ b/front/app/components/DescriptionBuilder/DescriptionBuilderToggle/index.tsx
@@ -103,11 +103,11 @@ const DescriptionBuilderToggle = ({
   const linkProps =
     contentBuildableType === 'project'
       ? ({
-          to: '/$locale/admin/description-builder/projects/$projectId/description',
+          to: '/admin/description-builder/projects/$projectId/description',
           params: { projectId: contentBuildableId },
         } as const)
       : ({
-          to: '/$locale/admin/description-builder/folders/$folderId/description',
+          to: '/admin/description-builder/folders/$folderId/description',
           params: { folderId: contentBuildableId },
         } as const);
 

--- a/front/app/components/DescriptionBuilder/DescriptionBuilderTopBar/DescriptionBuilderTopBar.test.tsx
+++ b/front/app/components/DescriptionBuilder/DescriptionBuilderTopBar/DescriptionBuilderTopBar.test.tsx
@@ -108,7 +108,7 @@ describe('ProjectDescriptionBuilderTopBar', () => {
           contentBuildableType="project"
           backPath="/projects"
           titleMultiloc={{ en: 'Test Project' }}
-          previewPath="/projects/preview"
+          previewLink={{ to: '/projects/preview' } as any}
         />
       </Editor>
     );
@@ -127,7 +127,7 @@ describe('ProjectDescriptionBuilderTopBar', () => {
           contentBuildableType="project"
           backPath="/projects"
           titleMultiloc={{ en: 'Test Project' }}
-          previewPath="/projects/preview"
+          previewLink={{ to: '/projects/preview' } as any}
         />
       </Editor>
     );
@@ -147,7 +147,7 @@ describe('ProjectDescriptionBuilderTopBar', () => {
           contentBuildableType="project"
           backPath="/projects"
           titleMultiloc={{ en: 'Test Project' }}
-          previewPath="/projects/preview"
+          previewLink={{ to: '/projects/preview' } as any}
         />
       </Editor>
     );
@@ -175,7 +175,7 @@ describe('ProjectDescriptionBuilderTopBar', () => {
           contentBuildableType="project"
           backPath="/projects"
           titleMultiloc={{ en: 'Test Project' }}
-          previewPath="/projects/preview"
+          previewLink={{ to: '/projects/preview' } as any}
         />
       </Editor>
     );
@@ -197,7 +197,7 @@ describe('ProjectDescriptionBuilderTopBar', () => {
           contentBuildableType="project"
           backPath="/projects"
           titleMultiloc={{ en: 'Test Project' }}
-          previewPath="/projects/preview"
+          previewLink={{ to: '/projects/preview' } as any}
         />
       </Editor>
     );
@@ -219,7 +219,7 @@ describe('ProjectDescriptionBuilderTopBar', () => {
           contentBuildableType="project"
           backPath="/projects"
           titleMultiloc={{ en: 'Test Project' }}
-          previewPath="/projects/preview"
+          previewLink={{ to: '/projects/preview' } as any}
         />
       </Editor>
     );
@@ -244,7 +244,7 @@ describe('ProjectDescriptionBuilderTopBar', () => {
           contentBuildableType="project"
           backPath="/projects"
           titleMultiloc={{ en: 'Test Project' }}
-          previewPath="/projects/preview"
+          previewLink={{ to: '/projects/preview' } as any}
         />
       </Editor>
     );
@@ -268,7 +268,7 @@ describe('ProjectDescriptionBuilderTopBar', () => {
           contentBuildableType="project"
           backPath="/projects"
           titleMultiloc={{ en: 'Test Project' }}
-          previewPath="/projects/preview"
+          previewLink={{ to: '/projects/preview' } as any}
         />
       </Editor>
     );
@@ -289,7 +289,7 @@ describe('ProjectDescriptionBuilderTopBar', () => {
           contentBuildableType="project"
           backPath="/projects"
           titleMultiloc={{ en: 'Test Project' }}
-          previewPath="/projects/preview"
+          previewLink={{ to: '/projects/preview' } as any}
         />
       </Editor>
     );
@@ -311,7 +311,7 @@ describe('ProjectDescriptionBuilderTopBar', () => {
           contentBuildableType="project"
           backPath="/projects"
           titleMultiloc={{ en: 'Test Project' }}
-          previewPath="/projects/preview"
+          previewLink={{ to: '/projects/preview' } as any}
         />
       </Editor>
     );
@@ -342,7 +342,7 @@ describe('ProjectDescriptionBuilderTopBar', () => {
           contentBuildableType="project"
           backPath="/projects"
           titleMultiloc={{ en: 'Test Project' }}
-          previewPath="/projects/preview"
+          previewLink={{ to: '/projects/preview' } as any}
         />
       </Editor>
     );

--- a/front/app/components/DescriptionBuilder/DescriptionBuilderTopBar/index.tsx
+++ b/front/app/components/DescriptionBuilder/DescriptionBuilderTopBar/index.tsx
@@ -18,6 +18,7 @@ import ButtonWithLink from 'components/UI/ButtonWithLink';
 
 import { FormattedMessage } from 'utils/cl-intl';
 import clHistory from 'utils/cl-router/history';
+import { type TypedLinkProps } from 'utils/cl-router/Link';
 
 import messages from './messages';
 
@@ -34,7 +35,7 @@ type DescriptionBuilderTopBarProps = {
   contentBuildableId: string;
   contentBuildableType: ContentBuildableType;
   backPath: string;
-  previewPath: string;
+  previewLink: TypedLinkProps;
   titleMultiloc: Multiloc;
 };
 
@@ -48,7 +49,7 @@ const DescriptionBuilderTopBar = ({
   contentBuildableId,
   contentBuildableType,
   backPath,
-  previewPath,
+  previewLink,
   titleMultiloc,
 }: DescriptionBuilderTopBarProps) => {
   const { query } = useEditor();
@@ -115,7 +116,7 @@ const DescriptionBuilderTopBar = ({
           ml="32px"
           disabled={!titleMultiloc}
           openLinkInNewTab
-          linkTo={previewPath}
+          {...previewLink}
         />
         <SaveButton
           isDisabled={disableSave}

--- a/front/app/components/EventCards/EventInformation/index.tsx
+++ b/front/app/components/EventCards/EventInformation/index.tsx
@@ -81,10 +81,7 @@ const EventInformation = ({ event }: Props) => {
           justifyContent="space-between"
           flexDirection={theme.isRtl ? 'row-reverse' : 'row'}
         >
-          <PrimaryLink
-            to="/$locale/events/$eventId"
-            params={{ eventId: event.id }}
-          >
+          <PrimaryLink to="/events/$eventId" params={{ eventId: event.id }}>
             <Title
               variant="h3"
               fontSize="l"
@@ -227,7 +224,7 @@ const EventInformation = ({ event }: Props) => {
             ml="auto"
             width={'100%'}
             bgColor={theme.colors.tenantPrimary}
-            to="/$locale/events/$eventId"
+            to="/events/$eventId"
             params={{ eventId: event.id }}
             scrollToTop
             // For accessibility, we need to add an aria-label to the button

--- a/front/app/components/EventCards/EventInformation/index.tsx
+++ b/front/app/components/EventCards/EventInformation/index.tsx
@@ -227,7 +227,8 @@ const EventInformation = ({ event }: Props) => {
             ml="auto"
             width={'100%'}
             bgColor={theme.colors.tenantPrimary}
-            linkTo={`/events/${event.id}`}
+            to="/$locale/events/$eventId"
+            params={{ eventId: event.id }}
             scrollToTop
             // For accessibility, we need to add an aria-label to the button
             // to provide context for screen readers. Using the same "Read more" text

--- a/front/app/components/FormBuilder/components/FormBuilderSettings/ContentSettings/index.tsx
+++ b/front/app/components/FormBuilder/components/FormBuilderSettings/ContentSettings/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import { Box, Text } from '@citizenlab/cl2-component-library';
 import { useFormContext } from 'react-hook-form';
-import { useParams } from 'utils/router';
 
 import { IFlatCustomFieldWithIndex } from 'api/custom_fields/types';
 
@@ -17,6 +16,7 @@ import Toggle from 'components/HookForm/Toggle';
 
 import { FormattedMessage } from 'utils/cl-intl';
 import Link from 'utils/cl-router/Link';
+import { useParams } from 'utils/router';
 
 import messages from '../../messages';
 import FieldTypeSwitcher from '../FieldTypeSwitcher';
@@ -70,7 +70,7 @@ const ContentSettings = ({ field }: ContentSettingsProps) => {
                 values={{
                   inputTagsLink: (
                     <Link
-                      to="/$locale/admin/projects/$projectId/general/input-tags"
+                      to="/admin/projects/$projectId/general/input-tags"
                       params={{ projectId: projectId ?? '' }}
                       target="_blank"
                     >

--- a/front/app/components/FormBuilder/components/FormBuilderTopBar/index.tsx
+++ b/front/app/components/FormBuilder/components/FormBuilderTopBar/index.tsx
@@ -11,7 +11,6 @@ import {
   IconTooltip,
 } from '@citizenlab/cl2-component-library';
 import { useFormContext } from 'react-hook-form';
-import { useParams } from 'utils/router';
 import styled from 'styled-components';
 
 import { IFlatCustomField } from 'api/custom_fields/types';
@@ -33,6 +32,8 @@ import Modal from 'components/UI/Modal';
 import { trackEventByName } from 'utils/analytics';
 import { FormattedMessage, useIntl } from 'utils/cl-intl';
 import clHistory from 'utils/cl-router/history';
+import { type TypedLinkProps } from 'utils/cl-router/Link';
+import { useParams } from 'utils/router';
 
 import messages from '../messages';
 import tracks from '../tracks';
@@ -48,7 +49,7 @@ const StyledStatusLabel = styled(StatusLabel)`
 type FormBuilderTopBarProps = {
   isSubmitting: boolean;
   builderConfig: FormBuilderConfig;
-  viewFormLink: string;
+  viewFormLink: TypedLinkProps;
   autosaveEnabled: boolean;
   setAutosaveEnabled: Dispatch<SetStateAction<boolean>>;
   phaseId: string;
@@ -193,7 +194,7 @@ const FormBuilderTopBar = ({
           icon="eye"
           mr="20px"
           disabled={!project}
-          linkTo={viewFormLink}
+          {...viewFormLink}
           openLinkInNewTab
           data-cy="e2e-preview-form-button"
         >

--- a/front/app/components/FormBuilder/edit/index.tsx
+++ b/front/app/components/FormBuilder/edit/index.tsx
@@ -10,7 +10,6 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { createPortal } from 'react-dom';
 import { FocusOn } from 'react-focus-on';
 import { useForm, useFieldArray, FormProvider } from 'react-hook-form';
-import { useParams, useSearch } from 'utils/router';
 
 import {
   IFlatCreateCustomField,
@@ -35,8 +34,10 @@ import FormFields from 'components/FormBuilder/components/FormFields';
 import HelmetIntl from 'components/HelmetIntl';
 
 import { useIntl } from 'utils/cl-intl';
+import { type TypedLinkProps } from 'utils/cl-router/Link';
 import { handleHookFormSubmissionError } from 'utils/errorUtils';
 import { isNilOrError } from 'utils/helperUtils';
+import { useParams, useSearch } from 'utils/router';
 
 import { DragAndDrop, Drop } from '../components/DragAndDrop';
 import { pageDNDType } from '../components/FormFields/constants';
@@ -65,7 +66,7 @@ type FormEditProps = {
   };
   builderConfig: FormBuilderConfig;
   totalSubmissions: number;
-  viewFormLink: string;
+  viewFormLink: TypedLinkProps;
   phase: IPhaseData;
 };
 
@@ -393,7 +394,7 @@ const FormEdit = ({
 
 type FormBuilderPageProps = {
   builderConfig: FormBuilderConfig;
-  viewFormLink: string;
+  viewFormLink: TypedLinkProps;
 };
 
 const FormBuilderPage = ({

--- a/front/app/components/IdeaCard/index.tsx
+++ b/front/app/components/IdeaCard/index.tsx
@@ -146,7 +146,7 @@ const IdeaCard = ({
           }
         >
           <Link
-            to="/$locale/ideas/$slug"
+            to="/ideas/$slug"
             params={{ slug }}
             search={{ go_back: 'true' }}
             onClick={handleClick}

--- a/front/app/components/LandingPages/citizen/BannerButton.tsx
+++ b/front/app/components/LandingPages/citizen/BannerButton.tsx
@@ -2,12 +2,17 @@ import React, { MouseEvent, KeyboardEvent } from 'react';
 
 import ButtonWithLink from 'components/UI/ButtonWithLink';
 
+import type { LinkProps } from '@tanstack/react-router';
+
 export type BannerButtonStyle = 'primary-inverse' | 'primary';
 
 type Props = {
   className?: string;
   buttonStyle: BannerButtonStyle;
   text: string;
+  to?: LinkProps['to'];
+  params?: Record<string, string>;
+  search?: Record<string, unknown>;
   linkTo?: string | null;
   onClick?: (event: MouseEvent | KeyboardEvent) => void;
   openLinkInNewTab?: boolean;

--- a/front/app/components/LandingPages/citizen/BannerButton.tsx
+++ b/front/app/components/LandingPages/citizen/BannerButton.tsx
@@ -2,7 +2,7 @@ import React, { MouseEvent, KeyboardEvent } from 'react';
 
 import ButtonWithLink from 'components/UI/ButtonWithLink';
 
-import type { LinkProps } from '@tanstack/react-router';
+import { type TypedLinkProps } from 'utils/cl-router/Link';
 
 export type BannerButtonStyle = 'primary-inverse' | 'primary';
 
@@ -10,13 +10,10 @@ type Props = {
   className?: string;
   buttonStyle: BannerButtonStyle;
   text: string;
-  to?: LinkProps['to'];
-  params?: Record<string, string>;
-  search?: Record<string, unknown>;
   linkTo?: string | null;
   onClick?: (event: MouseEvent | KeyboardEvent) => void;
   openLinkInNewTab?: boolean;
-};
+} & TypedLinkProps;
 
 const BannerButton = ({ buttonStyle, ...props }: Props) => (
   <ButtonWithLink

--- a/front/app/components/LandingPages/citizen/EventsWidget.tsx
+++ b/front/app/components/LandingPages/citizen/EventsWidget.tsx
@@ -112,7 +112,7 @@ const EventsWidget = ({ staticPageId }: Props) => {
           </Box>
 
           <Box alignSelf="center">
-            <EventPageLink to="/$locale/events">
+            <EventPageLink to="/events">
               {formatMessage(messages.viewAllEventsText)}
             </EventPageLink>
           </Box>

--- a/front/app/components/PageNotFound/index.tsx
+++ b/front/app/components/PageNotFound/index.tsx
@@ -54,7 +54,7 @@ const PageNotFound = () => {
           {formatMessage(messages.pageNotFoundDescription)}
         </Text>
         <ButtonWithLink
-          linkTo="/"
+          to="/$locale/"
           text={formatMessage(messages.goBackToHomePage)}
           icon="arrow-left"
         />

--- a/front/app/components/PageNotFound/index.tsx
+++ b/front/app/components/PageNotFound/index.tsx
@@ -54,7 +54,7 @@ const PageNotFound = () => {
           {formatMessage(messages.pageNotFoundDescription)}
         </Text>
         <ButtonWithLink
-          to="/$locale/"
+          to="/"
           text={formatMessage(messages.goBackToHomePage)}
           icon="arrow-left"
         />

--- a/front/app/components/ParticipationCTABars/CommonGroundCTABar/index.tsx
+++ b/front/app/components/ParticipationCTABars/CommonGroundCTABar/index.tsx
@@ -95,7 +95,7 @@ const CommonGroundCTABar = ({ phases, project }: CTABarProps) => {
                 textHoverColor={theme.colors.black}
                 padding="6px 12px"
                 fontSize="14px"
-                to="/$locale/projects/$slug/ideas/new"
+                to="/projects/$slug/ideas/new"
                 params={{ slug: project.attributes.slug }}
                 search={{ phase_id: currentPhase.id }}
               >

--- a/front/app/components/ParticipationCTABars/CommonGroundCTABar/index.tsx
+++ b/front/app/components/ParticipationCTABars/CommonGroundCTABar/index.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
 import { Box } from '@citizenlab/cl2-component-library';
-import { useLocation } from 'utils/router';
 import { useTheme } from 'styled-components';
 
 import { IPhaseData } from 'api/phases/types';
@@ -20,6 +19,7 @@ import Button from 'components/UI/ButtonWithLink';
 
 import { isFixableByAuthentication } from 'utils/actionDescriptors';
 import { FormattedMessage } from 'utils/cl-intl';
+import { useLocation } from 'utils/router';
 
 import messages from '../messages';
 
@@ -95,7 +95,9 @@ const CommonGroundCTABar = ({ phases, project }: CTABarProps) => {
                 textHoverColor={theme.colors.black}
                 padding="6px 12px"
                 fontSize="14px"
-                linkTo={`/projects/${project.attributes.slug}/ideas/new?phase_id=${currentPhase.id}`}
+                to="/$locale/projects/$slug/ideas/new"
+                params={{ slug: project.attributes.slug }}
+                search={{ phase_id: currentPhase.id }}
               >
                 <FormattedMessage {...messages.addInput} />
               </Button>

--- a/front/app/components/PostShowComponents/Comments/CommentForm/ErrorMessage.tsx
+++ b/front/app/components/PostShowComponents/Comments/CommentForm/ErrorMessage.tsx
@@ -21,7 +21,7 @@ const ErrorMessage = ({ profanityApiError }: Props) => {
         {...messages.profanityError}
         values={{
           guidelinesLink: (
-            <Link to="/$locale/pages/$slug" params={{ slug: "faq" }} target="_blank">
+            <Link to="/pages/$slug" params={{ slug: 'faq' }} target="_blank">
               {formatMessage(messages.guidelinesLinkText)}
             </Link>
           ),

--- a/front/app/components/ProjectAndFolderCards/components/ProjectFolderCard/index.tsx
+++ b/front/app/components/ProjectAndFolderCards/components/ProjectFolderCard/index.tsx
@@ -33,12 +33,12 @@ import Image from 'components/UI/Image';
 import { ScreenReaderOnly } from 'utils/a11y';
 import { trackEventByName } from 'utils/analytics';
 import { FormattedMessage } from 'utils/cl-intl';
-import Link from 'utils/cl-router/Link';
+import Link, { typedStyled } from 'utils/cl-router/Link';
 
 import messages from './messages';
 import tracks from './tracks';
 
-const Container = styled(Link)`
+const Container = typedStyled(Link)`
   width: calc(33% - 12px);
   display: flex;
   flex-direction: column;

--- a/front/app/components/UI/Breadcrumbs/index.tsx
+++ b/front/app/components/UI/Breadcrumbs/index.tsx
@@ -2,9 +2,7 @@ import React from 'react';
 
 import { Box, Text, colors } from '@citizenlab/cl2-component-library';
 
-import Link, { typedStyled } from 'utils/cl-router/Link';
-
-import type { LinkProps } from '@tanstack/react-router';
+import Link, { typedStyled, type WrapperTo } from 'utils/cl-router/Link';
 
 const StyledLink = typedStyled(Link)`
   color: ${colors.textSecondary};
@@ -16,7 +14,7 @@ const StyledLink = typedStyled(Link)`
 `;
 
 type TBreadcrumbLink = {
-  to: LinkProps['to'];
+  to: WrapperTo;
   params?: Record<string, string>;
   search?: Record<string, unknown>;
 };
@@ -52,7 +50,11 @@ const Breadcrumbs = ({ breadcrumbs }: Props) => {
           >
             {link && (
               <Text fontSize="m" as="span">
-                <StyledLink {...(link as Parameters<typeof StyledLink>[0])}>
+                <StyledLink
+                  to={link.to}
+                  params={link.params}
+                  search={link.search}
+                >
                   {label}
                 </StyledLink>
               </Text>

--- a/front/app/components/UI/ButtonWithLink/index.tsx
+++ b/front/app/components/UI/ButtonWithLink/index.tsx
@@ -6,15 +6,11 @@ import {
   ButtonStyles,
 } from '@citizenlab/cl2-component-library';
 
-import Link from 'utils/cl-router/Link';
+import Link, { type TypedLinkProps } from 'utils/cl-router/Link';
 
 import type { LinkProps } from '@tanstack/react-router';
 
-interface Props extends ButtonProps {
-  // Preferred: typed-route props mirroring cl-router/Link's shape.
-  to?: LinkProps['to'];
-  params?: Record<string, string>;
-  search?: Record<string, unknown>;
+interface Props extends ButtonProps, TypedLinkProps {
   // Legacy/external/admin-supplied URL escape hatch. Prefer `to` for known
   // internal routes — this stays for arbitrary admin-configured URLs.
   linkTo?: string | null;

--- a/front/app/components/UI/ButtonWithLink/index.tsx
+++ b/front/app/components/UI/ButtonWithLink/index.tsx
@@ -11,6 +11,12 @@ import Link from 'utils/cl-router/Link';
 import type { LinkProps } from '@tanstack/react-router';
 
 interface Props extends ButtonProps {
+  // Preferred: typed-route props mirroring cl-router/Link's shape.
+  to?: LinkProps['to'];
+  params?: Record<string, string>;
+  search?: Record<string, unknown>;
+  // Legacy/external/admin-supplied URL escape hatch. Prefer `to` for known
+  // internal routes — this stays for arbitrary admin-configured URLs.
   linkTo?: string | null;
   openLinkInNewTab?: boolean;
   scrollToTop?: boolean;
@@ -19,45 +25,76 @@ interface Props extends ButtonProps {
 type Ref = HTMLButtonElement;
 
 const ButtonWithLink = forwardRef<Ref, Props>(
-  ({ linkTo, openLinkInNewTab, disabled, scrollToTop, ...rest }, ref) => {
+  (
+    {
+      to,
+      params,
+      search,
+      linkTo,
+      openLinkInNewTab,
+      disabled,
+      scrollToTop,
+      ...rest
+    },
+    ref
+  ) => {
     const isExternalLink =
       linkTo &&
       (linkTo.startsWith('http') ||
         linkTo.startsWith('www') ||
         linkTo.startsWith('mailto'));
 
-    const link =
-      linkTo && !disabled
-        ? isExternalLink
-          ? ({
-              children,
-              ...rest
-            }: ButtonProps & React.HTMLAttributes<HTMLAnchorElement>) => (
-              <a
-                href={linkTo}
-                target={openLinkInNewTab ? '_blank' : undefined}
-                rel="noreferrer"
-                {...rest}
-              >
-                {children}
-              </a>
-            )
-          : ({
-              children,
-              ...rest
-            }: Omit<ButtonProps, 'as' | 'size'> &
-              React.HTMLAttributes<HTMLAnchorElement>) => (
-              <Link
-                to={linkTo as LinkProps['to']}
-                target={openLinkInNewTab ? '_blank' : undefined}
-                rel="noreferrer"
-                scrollToTop={scrollToTop}
-                {...rest}
-              >
-                {children}
-              </Link>
-            )
-        : undefined;
+    const link = disabled
+      ? undefined
+      : to
+      ? ({
+          children,
+          ...rest
+        }: Omit<ButtonProps, 'as' | 'size'> &
+          React.HTMLAttributes<HTMLAnchorElement>) => (
+          <Link
+            to={to}
+            params={params as Parameters<typeof Link>[0]['params']}
+            search={search as Parameters<typeof Link>[0]['search']}
+            target={openLinkInNewTab ? '_blank' : undefined}
+            rel="noreferrer"
+            scrollToTop={scrollToTop}
+            {...rest}
+          >
+            {children}
+          </Link>
+        )
+      : linkTo
+      ? isExternalLink
+        ? ({
+            children,
+            ...rest
+          }: ButtonProps & React.HTMLAttributes<HTMLAnchorElement>) => (
+            <a
+              href={linkTo}
+              target={openLinkInNewTab ? '_blank' : undefined}
+              rel="noreferrer"
+              {...rest}
+            >
+              {children}
+            </a>
+          )
+        : ({
+            children,
+            ...rest
+          }: Omit<ButtonProps, 'as' | 'size'> &
+            React.HTMLAttributes<HTMLAnchorElement>) => (
+            <Link
+              to={linkTo as LinkProps['to']}
+              target={openLinkInNewTab ? '_blank' : undefined}
+              rel="noreferrer"
+              scrollToTop={scrollToTop}
+              {...rest}
+            >
+              {children}
+            </Link>
+          )
+      : undefined;
 
     return <Button as={link} disabled={disabled} {...rest} ref={ref} />;
   }

--- a/front/app/components/UI/FeatureCallout/index.tsx
+++ b/front/app/components/UI/FeatureCallout/index.tsx
@@ -12,16 +12,13 @@ import {
 
 import ButtonWithLink from 'components/UI/ButtonWithLink';
 
-import type { LinkProps } from '@tanstack/react-router';
+import { type TypedLinkProps } from 'utils/cl-router/Link';
 
-interface Props {
+interface Props extends TypedLinkProps {
   icon: IconNames;
   title: ReactNode;
   description: ReactNode;
   linkText?: ReactNode;
-  to?: LinkProps['to'];
-  params?: Record<string, string>;
-  search?: Record<string, unknown>;
   linkTo?: string;
   disabledTooltipContent?: ReactNode;
   tooltipDisabled?: boolean;

--- a/front/app/components/UI/FeatureCallout/index.tsx
+++ b/front/app/components/UI/FeatureCallout/index.tsx
@@ -12,11 +12,16 @@ import {
 
 import ButtonWithLink from 'components/UI/ButtonWithLink';
 
+import type { LinkProps } from '@tanstack/react-router';
+
 interface Props {
   icon: IconNames;
   title: ReactNode;
   description: ReactNode;
   linkText?: ReactNode;
+  to?: LinkProps['to'];
+  params?: Record<string, string>;
+  search?: Record<string, unknown>;
   linkTo?: string;
   disabledTooltipContent?: ReactNode;
   tooltipDisabled?: boolean;
@@ -27,6 +32,9 @@ const FeatureCallout = ({
   title,
   description,
   linkText,
+  to,
+  params,
+  search,
   linkTo,
   disabledTooltipContent,
   tooltipDisabled,
@@ -34,6 +42,7 @@ const FeatureCallout = ({
   const iconElement = (
     <Icon name={icon} fill={colors.teal700} height="20px" mt="2px" />
   );
+  const hasLink = !!(to || linkTo);
 
   return (
     <Box
@@ -65,8 +74,11 @@ const FeatureCallout = ({
         </Text>
       </Box>
 
-      {linkTo && linkText && (
+      {hasLink && linkText && (
         <ButtonWithLink
+          to={to}
+          params={params}
+          search={search}
           linkTo={linkTo}
           openLinkInNewTab
           buttonStyle="text"

--- a/front/app/components/UI/GoBackButton/GoBackButtonSolid.tsx
+++ b/front/app/components/UI/GoBackButton/GoBackButtonSolid.tsx
@@ -9,10 +9,15 @@ import { useIntl } from 'utils/cl-intl';
 
 import messages from './messages';
 
+import type { LinkProps } from '@tanstack/react-router';
+
 interface Props {
   text?: string;
   iconSize?: string;
   onClick?: (event: React.MouseEvent) => void;
+  to?: LinkProps['to'];
+  params?: Record<string, string>;
+  search?: Record<string, unknown>;
   linkTo?: string;
 }
 
@@ -20,6 +25,9 @@ const GoBackButtonSolid = ({
   text,
   iconSize = '28px',
   onClick,
+  to,
+  params,
+  search,
   linkTo,
 }: Props) => {
   const isSmallerThanPhone = useBreakpoint('phone');
@@ -43,6 +51,9 @@ const GoBackButtonSolid = ({
       textDecorationHover="underline"
       whiteSpace="normal"
       onClick={handleClick}
+      to={to}
+      params={params}
+      search={search}
       linkTo={linkTo}
       text={text}
     >

--- a/front/app/components/UI/GoBackButton/GoBackButtonSolid.tsx
+++ b/front/app/components/UI/GoBackButton/GoBackButtonSolid.tsx
@@ -6,18 +6,14 @@ import ButtonWithLink from 'components/UI/ButtonWithLink';
 
 import { ScreenReaderOnly } from 'utils/a11y';
 import { useIntl } from 'utils/cl-intl';
+import { type TypedLinkProps } from 'utils/cl-router/Link';
 
 import messages from './messages';
 
-import type { LinkProps } from '@tanstack/react-router';
-
-interface Props {
+interface Props extends TypedLinkProps {
   text?: string;
   iconSize?: string;
   onClick?: (event: React.MouseEvent) => void;
-  to?: LinkProps['to'];
-  params?: Record<string, string>;
-  search?: Record<string, unknown>;
   linkTo?: string;
 }
 

--- a/front/app/components/UI/GoBackButton/index.tsx
+++ b/front/app/components/UI/GoBackButton/index.tsx
@@ -5,10 +5,9 @@ import styled from 'styled-components';
 import ButtonWithLink, { ButtonProps } from 'components/UI/ButtonWithLink';
 
 import { FormattedMessage, MessageDescriptor } from 'utils/cl-intl';
+import { type TypedLinkProps } from 'utils/cl-router/Link';
 
 import messages from './messages';
-
-import type { LinkProps } from '@tanstack/react-router';
 
 const Container = styled.div`
   display: inline-block;
@@ -18,12 +17,10 @@ type Props = {
   onClick?: (arg: FormEvent) => void;
   className?: string;
   customMessage?: MessageDescriptor;
-  to?: LinkProps['to'];
-  params?: Record<string, string>;
-  search?: Record<string, unknown>;
   linkTo?: string;
   showGoBackText?: boolean;
-} & ButtonProps;
+} & ButtonProps &
+  TypedLinkProps;
 
 const GoBackButton = ({
   onClick,

--- a/front/app/components/UI/GoBackButton/index.tsx
+++ b/front/app/components/UI/GoBackButton/index.tsx
@@ -8,6 +8,8 @@ import { FormattedMessage, MessageDescriptor } from 'utils/cl-intl';
 
 import messages from './messages';
 
+import type { LinkProps } from '@tanstack/react-router';
+
 const Container = styled.div`
   display: inline-block;
 `;
@@ -16,6 +18,9 @@ type Props = {
   onClick?: (arg: FormEvent) => void;
   className?: string;
   customMessage?: MessageDescriptor;
+  to?: LinkProps['to'];
+  params?: Record<string, string>;
+  search?: Record<string, unknown>;
   linkTo?: string;
   showGoBackText?: boolean;
 } & ButtonProps;
@@ -24,6 +29,9 @@ const GoBackButton = ({
   onClick,
   className,
   customMessage,
+  to,
+  params,
+  search,
   linkTo,
   showGoBackText = true,
   buttonStyle = 'text',
@@ -42,6 +50,9 @@ const GoBackButton = ({
           ) : undefined
         }
         data-testid="goBackButton"
+        to={to}
+        params={params}
+        search={search}
         linkTo={linkTo}
         buttonStyle={buttonStyle}
         {...buttonProps}

--- a/front/app/components/UI/UserName/index.tsx
+++ b/front/app/components/UI/UserName/index.tsx
@@ -191,7 +191,7 @@ const UserName = ({
 
     const linkedNamelement = (
       <Link
-        to="/$locale/profile/$userSlug"
+        to="/profile/$userSlug"
         params={{ userSlug }}
         className={`e2e-author-link ${className || ''}`}
         scrollToTop

--- a/front/app/components/Unauthorized/index.tsx
+++ b/front/app/components/Unauthorized/index.tsx
@@ -76,7 +76,7 @@ const Unauthorized = ({
                 {formatMessage(messages.notAuthorized)}
               </Text>
               <ButtonWithLink
-                to="/$locale/"
+                to="/"
                 text={formatMessage(pageNotFoundMessages.goBackToHomePage)}
                 icon="arrow-left"
               />

--- a/front/app/components/Unauthorized/index.tsx
+++ b/front/app/components/Unauthorized/index.tsx
@@ -76,7 +76,7 @@ const Unauthorized = ({
                 {formatMessage(messages.notAuthorized)}
               </Text>
               <ButtonWithLink
-                linkTo="/"
+                to="/$locale/"
                 text={formatMessage(pageNotFoundMessages.goBackToHomePage)}
                 icon="arrow-left"
               />

--- a/front/app/components/admin/ActionForm/Fields/CustomField/index.tsx
+++ b/front/app/components/admin/ActionForm/Fields/CustomField/index.tsx
@@ -93,7 +93,7 @@ const CustomField = ({ field, phaseId, action }: Props) => {
                     {...messages.globalRegFlowTooltip}
                     values={{
                       globalRegFlowLink: (
-                        <Link to="/$locale/admin/settings/registration" target="_blank">
+                        <Link to="/admin/settings/registration" target="_blank">
                           <FormattedMessage {...messages.globalRegFlowLink} />
                         </Link>
                       ),

--- a/front/app/components/admin/ContentBuilder/Widgets/FileAttachment/index.tsx
+++ b/front/app/components/admin/ContentBuilder/Widgets/FileAttachment/index.tsx
@@ -8,7 +8,6 @@ import {
   Text,
 } from '@citizenlab/cl2-component-library';
 import { useNode, useEditor } from '@craftjs/core';
-import { useParams } from 'utils/router';
 
 import useFileAttachments from 'api/file_attachments/useFileAttachments';
 import useFileById from 'api/files/useFileById';
@@ -19,6 +18,7 @@ import ButtonWithLink from 'components/UI/ButtonWithLink';
 import FileDisplay from 'components/UI/FileAttachments/FileDisplay';
 
 import { FormattedMessage, useIntl } from 'utils/cl-intl';
+import { useParams } from 'utils/router';
 
 import FilePlaceholder from './FilePlaceholder';
 import messages from './messages';
@@ -196,7 +196,8 @@ const FileAttachmentSettings = () => {
       )}
 
       <ButtonWithLink
-        linkTo={`/admin/projects/${projectId}/files`}
+        to="/$locale/admin/projects/$projectId/files"
+        params={{ projectId: projectId ?? '' }}
         buttonStyle="text"
         icon="upload-file"
         openLinkInNewTab={true}

--- a/front/app/components/admin/ContentBuilder/Widgets/FileAttachment/index.tsx
+++ b/front/app/components/admin/ContentBuilder/Widgets/FileAttachment/index.tsx
@@ -196,7 +196,7 @@ const FileAttachmentSettings = () => {
       )}
 
       <ButtonWithLink
-        to="/$locale/admin/projects/$projectId/files"
+        to="/admin/projects/$projectId/files"
         params={{ projectId: projectId ?? '' }}
         buttonStyle="text"
         icon="upload-file"

--- a/front/app/components/admin/Email/DraftCampaignRow.tsx
+++ b/front/app/components/admin/Email/DraftCampaignRow.tsx
@@ -36,10 +36,24 @@ const DraftCampaignRow = ({ campaign, context }: Props) => {
   );
   const localize = useLocalize();
 
-  const editLink =
+  const editLink: {
+    to:
+      | '/$locale/admin/messaging/emails/custom/$campaignId'
+      | '/$locale/admin/projects/$projectId/messaging/$campaignId';
+    params: Record<string, string>;
+  } =
     context === 'global'
-      ? `/admin/messaging/emails/custom/${campaign.id}`
-      : `/admin/projects/${campaign.relationships.context?.data?.id}/messaging/${campaign.id}`;
+      ? {
+          to: '/$locale/admin/messaging/emails/custom/$campaignId',
+          params: { campaignId: campaign.id },
+        }
+      : {
+          to: '/$locale/admin/projects/$projectId/messaging/$campaignId',
+          params: {
+            projectId: campaign.relationships.context?.data?.id ?? '',
+            campaignId: campaign.id,
+          },
+        };
   const { data: tenant } = useAppConfiguration();
   const timeZone = tenant?.data.attributes.settings.core.timezone || 'UTC';
   return (
@@ -83,7 +97,7 @@ const DraftCampaignRow = ({ campaign, context }: Props) => {
 
       <Box minWidth="220px" display="flex" justifyContent="flex-end">
         <ButtonWithLink
-          linkTo={editLink}
+          {...editLink}
           buttonStyle="secondary-outlined"
           icon="edit"
         >

--- a/front/app/components/admin/Email/DraftCampaignRow.tsx
+++ b/front/app/components/admin/Email/DraftCampaignRow.tsx
@@ -38,17 +38,17 @@ const DraftCampaignRow = ({ campaign, context }: Props) => {
 
   const editLink: {
     to:
-      | '/$locale/admin/messaging/emails/custom/$campaignId'
-      | '/$locale/admin/projects/$projectId/messaging/$campaignId';
+      | '/admin/messaging/emails/custom/$campaignId'
+      | '/admin/projects/$projectId/messaging/$campaignId';
     params: Record<string, string>;
   } =
     context === 'global'
       ? {
-          to: '/$locale/admin/messaging/emails/custom/$campaignId',
+          to: '/admin/messaging/emails/custom/$campaignId',
           params: { campaignId: campaign.id },
         }
       : {
-          to: '/$locale/admin/projects/$projectId/messaging/$campaignId',
+          to: '/admin/projects/$projectId/messaging/$campaignId',
           params: {
             projectId: campaign.relationships.context?.data?.id ?? '',
             campaignId: campaign.id,

--- a/front/app/components/admin/Email/SentCampaignRow.tsx
+++ b/front/app/components/admin/Email/SentCampaignRow.tsx
@@ -37,10 +37,24 @@ const SentCampaignRow = ({ campaign, context }: Props) => {
   const { formatMessage } = useIntl();
   const isCustomSmtp = useFeatureFlag({ name: 'custom_smtp' });
 
-  const statsLink =
+  const statsLink: {
+    to:
+      | '/$locale/admin/messaging/emails/custom/$campaignId'
+      | '/$locale/admin/projects/$projectId/messaging/$campaignId';
+    params: Record<string, string>;
+  } =
     context === 'global'
-      ? `/admin/messaging/emails/custom/${campaign.id}`
-      : `/admin/projects/${campaign.relationships.context?.data?.id}/messaging/${campaign.id}`;
+      ? {
+          to: '/$locale/admin/messaging/emails/custom/$campaignId',
+          params: { campaignId: campaign.id },
+        }
+      : {
+          to: '/$locale/admin/projects/$projectId/messaging/$campaignId',
+          params: {
+            projectId: campaign.relationships.context?.data?.id ?? '',
+            campaignId: campaign.id,
+          },
+        };
   const { data: tenant } = useAppConfiguration();
   const timeZone = tenant?.data.attributes.settings.core.timezone || 'UTC';
 
@@ -118,7 +132,7 @@ const SentCampaignRow = ({ campaign, context }: Props) => {
             <FormattedMessage {...messages.clicked} />
           </Text>
         </Box>
-        <ButtonWithLink linkTo={statsLink} icon="chart-bar" buttonStyle="text">
+        <ButtonWithLink {...statsLink} icon="chart-bar" buttonStyle="text">
           <FormattedMessage {...messages.statsButton} />
         </ButtonWithLink>
       </Box>

--- a/front/app/components/admin/Email/SentCampaignRow.tsx
+++ b/front/app/components/admin/Email/SentCampaignRow.tsx
@@ -39,17 +39,17 @@ const SentCampaignRow = ({ campaign, context }: Props) => {
 
   const statsLink: {
     to:
-      | '/$locale/admin/messaging/emails/custom/$campaignId'
-      | '/$locale/admin/projects/$projectId/messaging/$campaignId';
+      | '/admin/messaging/emails/custom/$campaignId'
+      | '/admin/projects/$projectId/messaging/$campaignId';
     params: Record<string, string>;
   } =
     context === 'global'
       ? {
-          to: '/$locale/admin/messaging/emails/custom/$campaignId',
+          to: '/admin/messaging/emails/custom/$campaignId',
           params: { campaignId: campaign.id },
         }
       : {
-          to: '/$locale/admin/projects/$projectId/messaging/$campaignId',
+          to: '/admin/projects/$projectId/messaging/$campaignId',
           params: {
             projectId: campaign.relationships.context?.data?.id ?? '',
             campaignId: campaign.id,

--- a/front/app/components/admin/FormResults/FormResultsQuestion/TextQuestion/Analysis/Question.tsx
+++ b/front/app/components/admin/FormResults/FormResultsQuestion/TextQuestion/Analysis/Question.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 
 import { Box, Spinner } from '@citizenlab/cl2-component-library';
-import { stringify } from 'qs';
-import { useParams } from 'utils/router';
 
 import useInfiniteAnalysisInputs from 'api/analysis_inputs/useInfiniteAnalysisInputs';
 import useAnalysisQuestion from 'api/analysis_questions/useAnalysisQuestion';
@@ -17,6 +15,7 @@ import QuestionHeader from 'containers/Admin/projects/project/analysis/Insights/
 import ButtonWithLink from 'components/UI/ButtonWithLink';
 
 import { FormattedMessage, useIntl } from 'utils/cl-intl';
+import { useParams } from 'utils/router';
 
 import messages from '../../../messages';
 
@@ -121,9 +120,12 @@ const Question = ({
           <ButtonWithLink
             buttonStyle="secondary-outlined"
             icon="eye"
-            linkTo={`/admin/projects/${projectId}/analysis/${analysisId}?${stringify(
-              { ...convertFilterValuesToString(filters), phase_id: phaseId }
-            )}`}
+            to="/$locale/admin/projects/$projectId/analysis/$analysisId"
+            params={{ projectId, analysisId }}
+            search={{
+              ...convertFilterValuesToString(filters),
+              phase_id: phaseId,
+            }}
           >
             {formatMessage(messages.explore)}
           </ButtonWithLink>

--- a/front/app/components/admin/FormResults/FormResultsQuestion/TextQuestion/Analysis/Question.tsx
+++ b/front/app/components/admin/FormResults/FormResultsQuestion/TextQuestion/Analysis/Question.tsx
@@ -120,7 +120,7 @@ const Question = ({
           <ButtonWithLink
             buttonStyle="secondary-outlined"
             icon="eye"
-            to="/$locale/admin/projects/$projectId/analysis/$analysisId"
+            to="/admin/projects/$projectId/analysis/$analysisId"
             params={{ projectId, analysisId }}
             search={{
               ...convertFilterValuesToString(filters),

--- a/front/app/components/admin/FormResults/FormResultsQuestion/TextQuestion/Analysis/Summary.tsx
+++ b/front/app/components/admin/FormResults/FormResultsQuestion/TextQuestion/Analysis/Summary.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 
 import { Box, Spinner } from '@citizenlab/cl2-component-library';
-import { stringify } from 'qs';
-import { useParams } from 'utils/router';
 
 import useAnalysisBackgroundTask from 'api/analysis_background_tasks/useAnalysisBackgroundTask';
 import useInfiniteAnalysisInputs from 'api/analysis_inputs/useInfiniteAnalysisInputs';
@@ -21,6 +19,7 @@ import Error from 'components/UI/Error';
 
 import { trackEventByName } from 'utils/analytics';
 import { FormattedMessage, useIntl } from 'utils/cl-intl';
+import { useParams } from 'utils/router';
 
 import messages from '../../../messages';
 
@@ -139,9 +138,12 @@ const Summary = ({
             id="e2e-explore-summary"
             buttonStyle="secondary-outlined"
             icon="eye"
-            linkTo={`/admin/projects/${projectId}/analysis/${analysisId}?${stringify(
-              { ...convertFilterValuesToString(filters), phase_id: phaseId }
-            )}`}
+            to="/$locale/admin/projects/$projectId/analysis/$analysisId"
+            params={{ projectId, analysisId }}
+            search={{
+              ...convertFilterValuesToString(filters),
+              phase_id: phaseId,
+            }}
           >
             {formatMessage(messages.explore)}
           </ButtonWithLink>

--- a/front/app/components/admin/FormResults/FormResultsQuestion/TextQuestion/Analysis/Summary.tsx
+++ b/front/app/components/admin/FormResults/FormResultsQuestion/TextQuestion/Analysis/Summary.tsx
@@ -138,7 +138,7 @@ const Summary = ({
             id="e2e-explore-summary"
             buttonStyle="secondary-outlined"
             icon="eye"
-            to="/$locale/admin/projects/$projectId/analysis/$analysisId"
+            to="/admin/projects/$projectId/analysis/$analysisId"
             params={{ projectId, analysisId }}
             search={{
               ...convertFilterValuesToString(filters),

--- a/front/app/components/admin/FormSync/ImportResponsesSection.tsx
+++ b/front/app/components/admin/FormSync/ImportResponsesSection.tsx
@@ -48,7 +48,10 @@ const ImportResponsesSection = ({ formType }: Props) => {
     saveAs(blob, 'example.xlsx');
   };
 
-  const importerPath = `/admin/projects/${projectId}/phases/${phaseId}/input-importer`;
+  const importerLink = {
+    to: '/$locale/admin/projects/$projectId/phases/$phaseId/input-importer',
+    params: { projectId: projectId ?? '', phaseId: phaseId ?? '' },
+  } as const;
 
   return (
     <Box mt="28px">
@@ -94,7 +97,7 @@ const ImportResponsesSection = ({ formType }: Props) => {
               <ButtonWithLink
                 buttonStyle="admin-dark"
                 icon="form-sync"
-                linkTo={importerPath}
+                {...importerLink}
               >
                 <FormattedMessage {...messages.importScans} />
               </ButtonWithLink>
@@ -153,7 +156,7 @@ const ImportResponsesSection = ({ formType }: Props) => {
             <ButtonWithLink
               buttonStyle="text"
               icon="upload-file"
-              linkTo={importerPath}
+              {...importerLink}
             >
               <FormattedMessage {...messages.importFile} />
             </ButtonWithLink>

--- a/front/app/components/admin/FormSync/ImportResponsesSection.tsx
+++ b/front/app/components/admin/FormSync/ImportResponsesSection.tsx
@@ -49,7 +49,7 @@ const ImportResponsesSection = ({ formType }: Props) => {
   };
 
   const importerLink = {
-    to: '/$locale/admin/projects/$projectId/phases/$phaseId/input-importer',
+    to: '/admin/projects/$projectId/phases/$phaseId/input-importer',
     params: { projectId: projectId ?? '', phaseId: phaseId ?? '' },
   } as const;
 

--- a/front/app/components/admin/PostManager/CommonGroundInputManager/NoInputsDisplay.tsx
+++ b/front/app/components/admin/PostManager/CommonGroundInputManager/NoInputsDisplay.tsx
@@ -52,7 +52,7 @@ const NoInputsDisplay = ({
         <Button
           buttonStyle="secondary-outlined"
           width="auto"
-          to="/$locale/projects/$slug/ideas/new"
+          to="/projects/$slug/ideas/new"
           params={{ slug: project?.attributes.slug ?? '' }}
           search={{ phase_id: phaseId }}
         >

--- a/front/app/components/admin/PostManager/CommonGroundInputManager/NoInputsDisplay.tsx
+++ b/front/app/components/admin/PostManager/CommonGroundInputManager/NoInputsDisplay.tsx
@@ -52,7 +52,9 @@ const NoInputsDisplay = ({
         <Button
           buttonStyle="secondary-outlined"
           width="auto"
-          linkTo={`/projects/${project?.attributes.slug}/ideas/new?phase_id=${phaseId}`}
+          to="/$locale/projects/$slug/ideas/new"
+          params={{ slug: project?.attributes.slug ?? '' }}
+          search={{ phase_id: phaseId }}
         >
           <FormattedMessage {...messages.createInput} />
         </Button>

--- a/front/app/components/admin/PostManager/components/FilterSidebar/index.tsx
+++ b/front/app/components/admin/PostManager/components/FilterSidebar/index.tsx
@@ -82,12 +82,12 @@ const FilterSidebar = ({
       typeof projectId === 'string'
     ) {
       return {
-        to: '/$locale/admin/projects/$projectId/general/input-tags',
+        to: '/admin/projects/$projectId/general/input-tags',
         params: { projectId },
       } as const;
     } else if (isAdmin(authUser)) {
       // For admins we show the link to the platform-wide tag manager
-      return { to: '/$locale/admin/settings/topics' } as const;
+      return { to: '/admin/settings/topics' } as const;
     } else {
       // Don't show the link to the platform-wide tag manager if the user is not an admin.
       // (i.e. project/folder managers that have access to the general input manager at /admin/ideas,

--- a/front/app/components/admin/PostManager/components/FilterSidebar/index.tsx
+++ b/front/app/components/admin/PostManager/components/FilterSidebar/index.tsx
@@ -7,7 +7,6 @@ import {
   stylingConsts,
 } from '@citizenlab/cl2-component-library';
 import { isEmpty } from 'lodash-es';
-import { useParams } from 'utils/router';
 
 import { IIdeaStatusData } from 'api/idea_statuses/types';
 import { IInputTopicData } from 'api/input_topics/types';
@@ -19,6 +18,7 @@ import { ManagerType, TFilterMenu } from 'components/admin/PostManager';
 
 import { useIntl } from 'utils/cl-intl';
 import { isAdmin } from 'utils/permissions/roles';
+import { useParams } from 'utils/router';
 
 import messages from '../../messages';
 
@@ -75,16 +75,19 @@ const FilterSidebar = ({
 
   if (!authUser) return null;
 
-  const getLinkToTagManager = (): string | null => {
+  const getLinkToTagManager = () => {
     // https://www.notion.so/citizenlab/Customised-tags-don-t-show-up-as-options-to-add-to-input-9c7c39f6af194c8385088878037cd498?pvs=4
     if (
       (type === 'ProjectIdeas' || type === 'ProjectProposals') &&
       typeof projectId === 'string'
     ) {
-      return `/admin/projects/${projectId}/general/input-tags`;
+      return {
+        to: '/$locale/admin/projects/$projectId/general/input-tags',
+        params: { projectId },
+      } as const;
     } else if (isAdmin(authUser)) {
       // For admins we show the link to the platform-wide tag manager
-      return '/admin/settings/topics';
+      return { to: '/$locale/admin/settings/topics' } as const;
     } else {
       // Don't show the link to the platform-wide tag manager if the user is not an admin.
       // (i.e. project/folder managers that have access to the general input manager at /admin/ideas,

--- a/front/app/components/admin/PostManager/components/FilterSidebar/projects/FilterSidebarProjects.tsx
+++ b/front/app/components/admin/PostManager/components/FilterSidebar/projects/FilterSidebarProjects.tsx
@@ -59,7 +59,7 @@ const FilterSidebarProjects = ({
           buttonStyle="text"
           icon="edit"
           pl="12px"
-          linkTo="/admin/projects"
+          to="/$locale/admin/projects"
           iconPos="right"
           iconSize="14px"
         >

--- a/front/app/components/admin/PostManager/components/FilterSidebar/projects/FilterSidebarProjects.tsx
+++ b/front/app/components/admin/PostManager/components/FilterSidebar/projects/FilterSidebarProjects.tsx
@@ -59,7 +59,7 @@ const FilterSidebarProjects = ({
           buttonStyle="text"
           icon="edit"
           pl="12px"
-          to="/$locale/admin/projects"
+          to="/admin/projects"
           iconPos="right"
           iconSize="14px"
         >

--- a/front/app/components/admin/PostManager/components/FilterSidebar/statuses/StatusFilters.tsx
+++ b/front/app/components/admin/PostManager/components/FilterSidebar/statuses/StatusFilters.tsx
@@ -46,8 +46,8 @@ const StatusFilters = ({
 
   const linkToStatusSettings =
     type === 'AllIdeas' || type === 'ProjectIdeas'
-      ? '/admin/settings/statuses/ideation'
-      : '/admin/settings/statuses/proposals';
+      ? ('/$locale/admin/settings/statuses/ideation' as const)
+      : ('/$locale/admin/settings/statuses/proposals' as const);
 
   return (
     <Box display="flex" flexDirection="column">
@@ -62,7 +62,7 @@ const StatusFilters = ({
             buttonStyle="text"
             icon="edit"
             pl="12px"
-            linkTo={linkToStatusSettings}
+            to={linkToStatusSettings}
             iconPos="right"
             iconSize="14px"
           >

--- a/front/app/components/admin/PostManager/components/FilterSidebar/statuses/StatusFilters.tsx
+++ b/front/app/components/admin/PostManager/components/FilterSidebar/statuses/StatusFilters.tsx
@@ -46,8 +46,8 @@ const StatusFilters = ({
 
   const linkToStatusSettings =
     type === 'AllIdeas' || type === 'ProjectIdeas'
-      ? ('/$locale/admin/settings/statuses/ideation' as const)
-      : ('/$locale/admin/settings/statuses/proposals' as const);
+      ? ('/admin/settings/statuses/ideation' as const)
+      : ('/admin/settings/statuses/proposals' as const);
 
   return (
     <Box display="flex" flexDirection="column">

--- a/front/app/components/admin/PostManager/components/FilterSidebar/topics/FilterSidebarTopics.tsx
+++ b/front/app/components/admin/PostManager/components/FilterSidebar/topics/FilterSidebarTopics.tsx
@@ -18,7 +18,12 @@ interface Props {
   selectableTopics: IInputTopicData[];
   selectedTopics?: string[] | null;
   onChangeTopicsFilter?: (topics: string[]) => void;
-  linkToTagManager: string | null;
+  linkToTagManager: {
+    to:
+      | '/$locale/admin/projects/$projectId/general/input-tags'
+      | '/$locale/admin/settings/topics';
+    params?: Record<string, string>;
+  } | null;
 }
 
 const FilterSidebarTopics = ({
@@ -61,14 +66,14 @@ const FilterSidebarTopics = ({
         labelContent={<FormattedMessage {...messages.allTopics} />}
       />
       <Divider />
-      {typeof linkToTagManager === 'string' && (
+      {linkToTagManager && (
         <Box display="inline-flex">
           <ButtonWithLink
             data-cy="e2e-post-manager-topic-filters-edit-tags"
             buttonStyle="text"
             icon="edit"
             pl="12px"
-            linkTo={linkToTagManager}
+            {...linkToTagManager}
             iconPos="right"
             iconSize="14px"
           >

--- a/front/app/components/admin/PostManager/components/FilterSidebar/topics/FilterSidebarTopics.tsx
+++ b/front/app/components/admin/PostManager/components/FilterSidebar/topics/FilterSidebarTopics.tsx
@@ -20,8 +20,8 @@ interface Props {
   onChangeTopicsFilter?: (topics: string[]) => void;
   linkToTagManager: {
     to:
-      | '/$locale/admin/projects/$projectId/general/input-tags'
-      | '/$locale/admin/settings/topics';
+      | '/admin/projects/$projectId/general/input-tags'
+      | '/admin/settings/topics';
     params?: Record<string, string>;
   } | null;
 }

--- a/front/app/components/admin/PostManager/components/PostPreview/Idea/AdminIdeaContent.tsx
+++ b/front/app/components/admin/PostManager/components/PostPreview/Idea/AdminIdeaContent.tsx
@@ -222,7 +222,8 @@ const AdminIdeaContent = ({
         </ButtonWithLink>
         {!isCommonGround && (
           <ButtonWithLink
-            linkTo={`/ideas/${idea.data.attributes.slug}`}
+            to="/$locale/ideas/$slug"
+            params={{ slug: idea.data.attributes.slug }}
             // We open in a new tab not lose state of the input manager
             openLinkInNewTab
             icon="eye"

--- a/front/app/components/admin/PostManager/components/PostPreview/Idea/AdminIdeaContent.tsx
+++ b/front/app/components/admin/PostManager/components/PostPreview/Idea/AdminIdeaContent.tsx
@@ -222,7 +222,7 @@ const AdminIdeaContent = ({
         </ButtonWithLink>
         {!isCommonGround && (
           <ButtonWithLink
-            to="/$locale/ideas/$slug"
+            to="/ideas/$slug"
             params={{ slug: idea.data.attributes.slug }}
             // We open in a new tab not lose state of the input manager
             openLinkInNewTab
@@ -250,7 +250,7 @@ const AdminIdeaContent = ({
                 projectLink: (
                   <ProjectLink
                     className="e2e-project-link"
-                    to="/$locale/projects/$slug"
+                    to="/projects/$slug"
                     params={{ slug: project.data.attributes.slug }}
                   >
                     <T value={project.data.attributes.title_multiloc} />

--- a/front/app/components/admin/Representativeness/ChartCard/EmptyCard.tsx
+++ b/front/app/components/admin/Representativeness/ChartCard/EmptyCard.tsx
@@ -87,7 +87,7 @@ const EmptyCard = ({ titleMultiloc, isComingSoon }: Props) => {
             <ButtonWithLink
               width="164px"
               bgColor={colors.primary}
-              to="/$locale/admin/dashboard/representation/edit-base-data"
+              to="/admin/dashboard/representation/edit-base-data"
             >
               <FormattedMessage {...messages.submitBaseDataButton} />
             </ButtonWithLink>

--- a/front/app/components/admin/Representativeness/ChartCard/EmptyCard.tsx
+++ b/front/app/components/admin/Representativeness/ChartCard/EmptyCard.tsx
@@ -87,7 +87,7 @@ const EmptyCard = ({ titleMultiloc, isComingSoon }: Props) => {
             <ButtonWithLink
               width="164px"
               bgColor={colors.primary}
-              linkTo="/admin/dashboard/representation/edit-base-data"
+              to="/$locale/admin/dashboard/representation/edit-base-data"
             >
               <FormattedMessage {...messages.submitBaseDataButton} />
             </ButtonWithLink>

--- a/front/app/components/admin/Representativeness/ChartFilters/index.tsx
+++ b/front/app/components/admin/Representativeness/ChartFilters/index.tsx
@@ -27,7 +27,7 @@ const ChartFilters = ({ projectId, onProjectFilter, noData }: Props) => (
     <ProjectFilter projectId={projectId} onProjectFilter={onProjectFilter} />
     {!noData && (
       <ButtonWithLink
-        linkTo="/admin/dashboard/representation/edit-base-data"
+        to="/$locale/admin/dashboard/representation/edit-base-data"
         text={<FormattedMessage {...messages.editBaseData} />}
         bgColor={colors.teal}
       />

--- a/front/app/components/admin/Representativeness/ChartFilters/index.tsx
+++ b/front/app/components/admin/Representativeness/ChartFilters/index.tsx
@@ -27,7 +27,7 @@ const ChartFilters = ({ projectId, onProjectFilter, noData }: Props) => (
     <ProjectFilter projectId={projectId} onProjectFilter={onProjectFilter} />
     {!noData && (
       <ButtonWithLink
-        to="/$locale/admin/dashboard/representation/edit-base-data"
+        to="/admin/dashboard/representation/edit-base-data"
         text={<FormattedMessage {...messages.editBaseData} />}
         bgColor={colors.teal}
       />

--- a/front/app/components/admin/SeatBasedBilling/SeatInfo/index.tsx
+++ b/front/app/components/admin/SeatBasedBilling/SeatInfo/index.tsx
@@ -127,7 +127,7 @@ const SeatInfo = ({ seatType, mb }: Props) => {
       </Box>
       {showLink && (
         <Box mt="12px">
-          <StyledLink target="_blank" to="/$locale/admin/users/seats">
+          <StyledLink target="_blank" to="/admin/users/seats">
             <Text variant="bodyXs" my="0px" color="coolGrey600">
               {formatMessage(messages.goToSeatsOverview)}
             </Text>

--- a/front/app/components/admin/Section/index.tsx
+++ b/front/app/components/admin/Section/index.tsx
@@ -7,7 +7,7 @@ import {
 } from '@citizenlab/cl2-component-library';
 import styled from 'styled-components';
 
-import Link from 'utils/cl-router/Link';
+import Link, { typedStyled } from 'utils/cl-router/Link';
 
 export const Section = styled.div`
   margin-bottom: 0;
@@ -99,6 +99,6 @@ export const SectionDescription = styled.p`
   `}
 `;
 
-export const StyledLink = styled(Link)`
+export const StyledLink = typedStyled(Link)`
   text-decoration: underline;
 `;

--- a/front/app/components/admin/TreeView/Folder.tsx
+++ b/front/app/components/admin/TreeView/Folder.tsx
@@ -58,7 +58,7 @@ const Folder = ({
             fill={lockedFolderTooltip ? colors.grey600 : colors.black}
           />
           <Link
-            to="/$locale/admin/projects/folders/$projectFolderId"
+            to="/admin/projects/folders/$projectFolderId"
             params={{ projectFolderId: node.id }}
             color={lockedFolderTooltip ? colors.grey600 : colors.black}
           >

--- a/front/app/components/admin/TreeView/Project.tsx
+++ b/front/app/components/admin/TreeView/Project.tsx
@@ -47,7 +47,7 @@ const Project = ({
           fill={lockedProjectTooltip ? colors.grey600 : colors.black}
         />
         <Link
-          to="/$locale/admin/projects/$projectId"
+          to="/admin/projects/$projectId"
           params={{ projectId: node.id }}
           color={lockedProjectTooltip ? colors.grey600 : colors.black}
         >

--- a/front/app/components/admin/TreeView/Space.tsx
+++ b/front/app/components/admin/TreeView/Space.tsx
@@ -58,7 +58,7 @@ const Space = ({
             fill={colors.black}
           />
           <Link
-            to="/$locale/admin/projects/spaces/$spaceId"
+            to="/admin/projects/spaces/$spaceId"
             params={{ spaceId: node.id }}
             color={colors.black}
           >

--- a/front/app/components/admin/TreeView/_shared/Link.tsx
+++ b/front/app/components/admin/TreeView/_shared/Link.tsx
@@ -5,8 +5,6 @@ import styled from 'styled-components';
 
 import OriginalLink from 'utils/cl-router/Link';
 
-type LinkProps = Parameters<typeof OriginalLink>[0] & { color?: string };
-
 const StyledLink = styled(OriginalLink)<{
   color: string;
 }>`
@@ -19,9 +17,20 @@ const StyledLink = styled(OriginalLink)<{
   }
 ` as typeof OriginalLink;
 
-const Link: typeof OriginalLink = ((props: LinkProps) => {
-  const { color = colors.black, ...rest } = props;
-  return <StyledLink {...rest} color={color} />;
+// Internal props are intentionally loose: the public signature comes from
+// `: typeof OriginalLink` on the export, which preserves typed-route checking
+// at the call site.
+const Link: typeof OriginalLink = ((
+  props: { color?: string } & Record<string, unknown>
+) => {
+  const { color = colors.black, ...rest } = props as {
+    color?: string;
+  } & Record<string, unknown>;
+  const StyledLinkAny = StyledLink as unknown as React.ComponentType<{
+    color: string;
+    [key: string]: unknown;
+  }>;
+  return <StyledLinkAny {...rest} color={color} />;
 }) as typeof OriginalLink;
 
 export default Link;

--- a/front/app/components/admin/UsersTable/NameAvatarEmail.tsx
+++ b/front/app/components/admin/UsersTable/NameAvatarEmail.tsx
@@ -37,7 +37,7 @@ const NameAvatarEmail = ({ user }: Props) => {
       <Avatar userId={user.id} size={30} />
       <Box>
         <StyledLink
-          to="/$locale/profile/$userSlug"
+          to="/profile/$userSlug"
           params={{ userSlug: user.attributes.slug }}
         >
           {user.attributes.first_name && user.attributes.last_name ? (

--- a/front/app/containers/Admin/Representativeness/Dashboard/EmptyState.tsx
+++ b/front/app/containers/Admin/Representativeness/Dashboard/EmptyState.tsx
@@ -45,7 +45,7 @@ const EmptyState = () => (
             width="auto"
             mb="16px"
             bgColor={colors.primary}
-            linkTo="/admin/dashboard/representation/edit-base-data"
+            to="/$locale/admin/dashboard/representation/edit-base-data"
           >
             <FormattedMessage {...messages.submitBaseDataButton} />
           </ButtonWithLink>

--- a/front/app/containers/Admin/Representativeness/Dashboard/EmptyState.tsx
+++ b/front/app/containers/Admin/Representativeness/Dashboard/EmptyState.tsx
@@ -45,7 +45,7 @@ const EmptyState = () => (
             width="auto"
             mb="16px"
             bgColor={colors.primary}
-            to="/$locale/admin/dashboard/representation/edit-base-data"
+            to="/admin/dashboard/representation/edit-base-data"
           >
             <FormattedMessage {...messages.submitBaseDataButton} />
           </ButtonWithLink>

--- a/front/app/containers/Admin/Representativeness/ReferenceDataInterface/Header.tsx
+++ b/front/app/containers/Admin/Representativeness/ReferenceDataInterface/Header.tsx
@@ -17,7 +17,7 @@ const Header = () => (
         {...messages.pageDescription}
         values={{
           userRegistrationLink: (
-            <Link to="/$locale/admin/settings/registration">
+            <Link to="/admin/settings/registration">
               <FormattedMessage {...messages.userRegistrationLink} />
             </Link>
           ),

--- a/front/app/containers/Admin/Representativeness/ReferenceDataInterface/index.tsx
+++ b/front/app/containers/Admin/Representativeness/ReferenceDataInterface/index.tsx
@@ -24,7 +24,7 @@ const ReferenceDataInterface = () => {
     <>
       <Box display="flex" justifyContent="flex-start" mb="32px">
         <ButtonWithLink
-          linkTo="/admin/dashboard/representation"
+          to="/$locale/admin/dashboard/representation"
           buttonStyle="text"
           icon="arrow-left"
           size="m"

--- a/front/app/containers/Admin/Representativeness/ReferenceDataInterface/index.tsx
+++ b/front/app/containers/Admin/Representativeness/ReferenceDataInterface/index.tsx
@@ -24,7 +24,7 @@ const ReferenceDataInterface = () => {
     <>
       <Box display="flex" justifyContent="flex-start" mb="32px">
         <ButtonWithLink
-          to="/$locale/admin/dashboard/representation"
+          to="/admin/dashboard/representation"
           buttonStyle="text"
           icon="arrow-left"
           size="m"

--- a/front/app/containers/Admin/communityMonitor/CommunityMonitorFormBuilder/index.tsx
+++ b/front/app/containers/Admin/communityMonitor/CommunityMonitorFormBuilder/index.tsx
@@ -34,7 +34,11 @@ const CommunityMonitorSurveyFormBuilder = () => {
         formCustomFields,
         goBackUrl: `/admin/community-monitor/settings`,
       }}
-      viewFormLink={`/projects/${project.data.attributes.slug}/surveys/new?phase_id=${phase.data.id}`}
+      viewFormLink={{
+        to: '/projects/$slug/surveys/new',
+        params: { slug: project.data.attributes.slug },
+        search: { phase_id: phase.data.id },
+      }}
     />
   );
 };

--- a/front/app/containers/Admin/communityMonitor/components/Settings/components/SurveySettings/index.tsx
+++ b/front/app/containers/Admin/communityMonitor/components/Settings/components/SurveySettings/index.tsx
@@ -123,7 +123,7 @@ const SurveySettings = () => {
               />
             </Box>
             <ButtonWithLink
-              linkTo={inputImporterLink}
+              {...inputImporterLink}
               icon="page"
               iconSize="20px"
               buttonStyle="secondary-outlined"

--- a/front/app/containers/Admin/communityMonitor/components/ViewSurveyButton/index.tsx
+++ b/front/app/containers/Admin/communityMonitor/components/ViewSurveyButton/index.tsx
@@ -19,7 +19,7 @@ const ViewSurveyButton = ({ ...props }: ButtonProps) => {
 
   return (
     <ButtonWithLink
-      to="/$locale/projects/$slug/surveys/new"
+      to="/projects/$slug/surveys/new"
       params={{ slug: project.data.attributes.slug }}
       search={{ phase_id: phaseId }}
       icon="eye"

--- a/front/app/containers/Admin/communityMonitor/components/ViewSurveyButton/index.tsx
+++ b/front/app/containers/Admin/communityMonitor/components/ViewSurveyButton/index.tsx
@@ -19,7 +19,9 @@ const ViewSurveyButton = ({ ...props }: ButtonProps) => {
 
   return (
     <ButtonWithLink
-      linkTo={`/projects/${project.data.attributes.slug}/surveys/new?phase_id=${phaseId}`}
+      to="/$locale/projects/$slug/surveys/new"
+      params={{ slug: project.data.attributes.slug }}
+      search={{ phase_id: phaseId }}
       icon="eye"
       iconSize="20px"
       buttonStyle="secondary-outlined"

--- a/front/app/containers/Admin/dashboard/ManagementFeed/ManagementFeedRow.tsx
+++ b/front/app/containers/Admin/dashboard/ManagementFeed/ManagementFeedRow.tsx
@@ -118,7 +118,7 @@ const ManagementFeedRow = ({ item }: { item: ManagementFeedData }) => {
                     values={{
                       project: (
                         <Link
-                          to="/$locale/admin/projects/$projectId"
+                          to="/admin/projects/$projectId"
                           params={{ projectId: project.data.id }}
                           target="_blank"
                         >

--- a/front/app/containers/Admin/dashboard/overview/charts/InputStatusCard/index.tsx
+++ b/front/app/containers/Admin/dashboard/overview/charts/InputStatusCard/index.tsx
@@ -126,7 +126,7 @@ const InputStatusCard = ({
         marginTop="20px"
         textDecorationHover="underline"
         text={formatMessage(messages.goToInputManager)}
-        to="/$locale/admin/ideas"
+        to="/admin/ideas"
       />
     </GraphCard>
   );

--- a/front/app/containers/Admin/dashboard/overview/charts/InputStatusCard/index.tsx
+++ b/front/app/containers/Admin/dashboard/overview/charts/InputStatusCard/index.tsx
@@ -126,7 +126,7 @@ const InputStatusCard = ({
         marginTop="20px"
         textDecorationHover="underline"
         text={formatMessage(messages.goToInputManager)}
-        linkTo="/admin/ideas"
+        to="/$locale/admin/ideas"
       />
     </GraphCard>
   );

--- a/front/app/containers/Admin/messaging/CustomEmails/All/NewCampaignButton.tsx
+++ b/front/app/containers/Admin/messaging/CustomEmails/All/NewCampaignButton.tsx
@@ -11,7 +11,7 @@ const NewCampaignButton = () => {
     <ButtonWithLink
       buttonStyle="admin-dark"
       icon="plus-circle"
-      to="/$locale/admin/messaging/emails/custom/new"
+      to="/admin/messaging/emails/custom/new"
     >
       <FormattedMessage {...messages.addCampaignButton} />
     </ButtonWithLink>

--- a/front/app/containers/Admin/messaging/CustomEmails/All/NewCampaignButton.tsx
+++ b/front/app/containers/Admin/messaging/CustomEmails/All/NewCampaignButton.tsx
@@ -11,7 +11,7 @@ const NewCampaignButton = () => {
     <ButtonWithLink
       buttonStyle="admin-dark"
       icon="plus-circle"
-      linkTo="/admin/messaging/emails/custom/new"
+      to="/$locale/admin/messaging/emails/custom/new"
     >
       <FormattedMessage {...messages.addCampaignButton} />
     </ButtonWithLink>

--- a/front/app/containers/Admin/messaging/CustomEmails/CampaignForm/index.tsx
+++ b/front/app/containers/Admin/messaging/CustomEmails/CampaignForm/index.tsx
@@ -174,7 +174,7 @@ const CampaignForm = ({
               <Text fontSize="l">
                 <FormattedMessage {...messages.allParticipantsInProject} />{' '}
                 <Link
-                  to="/$locale/admin/projects/$projectId"
+                  to="/admin/projects/$projectId"
                   params={{ projectId: project.data.id }}
                   target="_blank"
                 >

--- a/front/app/containers/Admin/messaging/CustomEmails/Show/index.tsx
+++ b/front/app/containers/Admin/messaging/CustomEmails/Show/index.tsx
@@ -254,7 +254,7 @@ const Show = () => {
             campaign.data.attributes.scheduled_at) && (
             <Buttons>
               <ButtonWithLink
-                to="/$locale/admin/messaging/emails/custom/$campaignId/edit"
+                to="/admin/messaging/emails/custom/$campaignId/edit"
                 params={{ campaignId: campaign.data.id }}
                 buttonStyle="secondary-outlined"
               >
@@ -329,7 +329,7 @@ const Show = () => {
                   <span>
                     <FormattedMessage {...messages.allParticipantsInProject} />{' '}
                     <Link
-                      to="/$locale/admin/projects/$projectId"
+                      to="/admin/projects/$projectId"
                       params={{ projectId: project.data.id }}
                       target="_blank"
                     >
@@ -407,7 +407,7 @@ const Show = () => {
             <ButtonsWrapper>
               <ButtonWithLink
                 buttonStyle="secondary-outlined"
-                to="/$locale/admin/messaging/emails/custom/$campaignId/edit"
+                to="/admin/messaging/emails/custom/$campaignId/edit"
                 params={{ campaignId: campaign.data.id }}
               >
                 <FormattedMessage {...messages.changeRecipientsButton} />

--- a/front/app/containers/Admin/messaging/CustomEmails/Show/index.tsx
+++ b/front/app/containers/Admin/messaging/CustomEmails/Show/index.tsx
@@ -254,7 +254,8 @@ const Show = () => {
             campaign.data.attributes.scheduled_at) && (
             <Buttons>
               <ButtonWithLink
-                linkTo={`/admin/messaging/emails/custom/${campaign.data.id}/edit`}
+                to="/$locale/admin/messaging/emails/custom/$campaignId/edit"
+                params={{ campaignId: campaign.data.id }}
                 buttonStyle="secondary-outlined"
               >
                 <FormattedMessage {...messages.editButtonLabel} />
@@ -406,7 +407,8 @@ const Show = () => {
             <ButtonsWrapper>
               <ButtonWithLink
                 buttonStyle="secondary-outlined"
-                linkTo={`/admin/messaging/emails/custom/${campaign.data.id}/edit`}
+                to="/$locale/admin/messaging/emails/custom/$campaignId/edit"
+                params={{ campaignId: campaign.data.id }}
               >
                 <FormattedMessage {...messages.changeRecipientsButton} />
               </ButtonWithLink>

--- a/front/app/containers/Admin/pagesAndMenu/breadcrumbs.ts
+++ b/front/app/containers/Admin/pagesAndMenu/breadcrumbs.ts
@@ -5,5 +5,5 @@ export const pagesAndMenuBreadcrumb = {
 };
 
 export const pagesAndMenuBreadcrumbLink = {
-  to: '/$locale/admin/pages-menu',
+  to: '/admin/pages-menu',
 } as const;

--- a/front/app/containers/Admin/pagesAndMenu/containers/Attachments/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/Attachments/index.tsx
@@ -174,7 +174,8 @@ const AttachmentsForm = ({
             ]}
             rightSideCTA={
               <ViewCustomPageButton
-                linkTo={`/pages/${customPage.data.attributes.slug}`}
+                to="/$locale/pages/$slug"
+                params={{ slug: customPage.data.attributes.slug }}
               />
             }
           >

--- a/front/app/containers/Admin/pagesAndMenu/containers/Attachments/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/Attachments/index.tsx
@@ -174,7 +174,7 @@ const AttachmentsForm = ({
             ]}
             rightSideCTA={
               <ViewCustomPageButton
-                to="/$locale/pages/$slug"
+                to="/pages/$slug"
                 params={{ slug: customPage.data.attributes.slug }}
               />
             }

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/TopBar/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/TopBar/index.tsx
@@ -92,7 +92,7 @@ const BuilderTopBar = ({
           px="11px"
           py="6px"
           ml="32px"
-          to="/$locale/"
+          to="/"
           openLinkInNewTab
         />
         <SaveButton

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/TopBar/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/TopBar/index.tsx
@@ -92,7 +92,7 @@ const BuilderTopBar = ({
           px="11px"
           py="6px"
           ml="32px"
-          linkTo="/"
+          to="/$locale/"
           openLinkInNewTab
         />
         <SaveButton

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/ProjectsAndFoldersLegacy/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/ProjectsAndFoldersLegacy/index.tsx
@@ -68,7 +68,7 @@ const ProjectsSettings = () => {
           {...messages.projectsDescription}
           values={{
             link: (
-              <Link to="/$locale/admin/projects" target="_blank">
+              <Link to="/admin/projects" target="_blank">
                 <FormattedMessage {...messages.projectsDescriptionLink} />
               </Link>
             ),

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/AdminPublicationsCarrousel/AdminPublicationCard/utils.ts
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/AdminPublicationsCarrousel/AdminPublicationCard/utils.ts
@@ -6,12 +6,12 @@ export const getPublicationLinkProps = (publication: IAdminPublicationData) => {
 
   if (publicationType === 'folder') {
     return {
-      to: '/$locale/folders/$slug',
+      to: '/folders/$slug',
       params: { slug: publication_slug },
     } as const;
   }
   return {
-    to: '/$locale/projects/$slug',
+    to: '/projects/$slug',
     params: { slug: publication_slug },
   } as const;
 };

--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/Content/BottomInfoSection/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/Content/BottomInfoSection/index.tsx
@@ -49,7 +49,10 @@ const BottomInfoSection = () => {
           link: adminCustomPageContentLink(customPageId),
         },
       ]}
-      linkToViewPage={`/pages/${customPage.data.attributes.slug}`}
+      viewPageLink={{
+        to: '/pages/$slug',
+        params: { slug: customPage.data.attributes.slug },
+      }}
     />
   );
 };

--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/Content/TopInfoSection/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/Content/TopInfoSection/index.tsx
@@ -47,7 +47,10 @@ const TopInfoSection = () => {
           link: adminCustomPageContentLink(customPageId),
         },
       ]}
-      linkToViewPage={`/pages/${customPage.data.attributes.slug}`}
+      viewPageLink={{
+        to: '/pages/$slug',
+        params: { slug: customPage.data.attributes.slug },
+      }}
     />
   );
 };

--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/HeroBanner/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/HeroBanner/index.tsx
@@ -220,7 +220,10 @@ const EditCustomPageHeroBannerForm = ({
           }
           formStatus={formStatus}
           isLoading={isLoading}
-          linkToViewPage={`/pages/${customPage.data.attributes.slug}`}
+          viewPageLink={{
+            to: '/pages/$slug',
+            params: { slug: customPage.data.attributes.slug },
+          }}
           breadcrumbs={[
             {
               label: formatMessage(pagesAndMenuBreadcrumb.label),

--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/ViewCustomPageButton.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/ViewCustomPageButton.tsx
@@ -5,15 +5,11 @@ import { WrappedComponentProps } from 'react-intl';
 import ButtonWithLink from 'components/UI/ButtonWithLink';
 
 import { injectIntl } from 'utils/cl-intl';
+import { type TypedLinkProps } from 'utils/cl-router/Link';
 
 import messages from '../messages';
 
-import type { LinkProps } from '@tanstack/react-router';
-
-interface Props {
-  to?: LinkProps['to'];
-  params?: Record<string, string>;
-  search?: Record<string, unknown>;
+interface Props extends TypedLinkProps {
   linkTo?: string;
 }
 

--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/ViewCustomPageButton.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/ViewCustomPageButton.tsx
@@ -8,11 +8,19 @@ import { injectIntl } from 'utils/cl-intl';
 
 import messages from '../messages';
 
+import type { LinkProps } from '@tanstack/react-router';
+
 interface Props {
-  linkTo: string;
+  to?: LinkProps['to'];
+  params?: Record<string, string>;
+  search?: Record<string, unknown>;
+  linkTo?: string;
 }
 
 const ViewCustomPageButton = ({
+  to,
+  params,
+  search,
   linkTo,
   intl: { formatMessage },
 }: Props & WrappedComponentProps) => {
@@ -22,6 +30,9 @@ const ViewCustomPageButton = ({
       icon="eye"
       id="to-custom-page"
       openLinkInNewTab
+      to={to}
+      params={params}
+      search={search}
       linkTo={linkTo}
     >
       {formatMessage(messages.viewCustomPage)}

--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/index.tsx
@@ -68,7 +68,8 @@ const CustomPagesEditSettings = () => {
             title: localize(pageTitleMultiloc),
             rightSideCTA: (
               <ViewCustomPageButton
-                linkTo={`/pages/${customPage.data.attributes.slug}`}
+                to="/$locale/pages/$slug"
+                params={{ slug: customPage.data.attributes.slug }}
               />
             ),
           }}

--- a/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/CustomPages/Edit/index.tsx
@@ -68,7 +68,7 @@ const CustomPagesEditSettings = () => {
             title: localize(pageTitleMultiloc),
             rightSideCTA: (
               <ViewCustomPageButton
-                to="/$locale/pages/$slug"
+                to="/pages/$slug"
                 params={{ slug: customPage.data.attributes.slug }}
               />
             ),

--- a/front/app/containers/Admin/pagesAndMenu/containers/GenericBottomInfoSection/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/GenericBottomInfoSection/index.tsx
@@ -16,6 +16,7 @@ import { TBreadcrumbs } from 'components/UI/Breadcrumbs';
 import ButtonWithLink from 'components/UI/ButtonWithLink';
 
 import { injectIntl } from 'utils/cl-intl';
+import { type TypedLinkProps } from 'utils/cl-router/Link';
 import { handleHookFormSubmissionError } from 'utils/errorUtils';
 import validateAtLeastOneLocale from 'utils/yup/validateAtLeastOneLocale';
 
@@ -38,7 +39,7 @@ interface Props {
     bottom_info_section_multiloc: Multiloc;
   }) => Promise<any>;
   breadcrumbs: TBreadcrumbs;
-  linkToViewPage?: string;
+  viewPageLink?: TypedLinkProps;
 }
 
 interface FormValues {
@@ -51,7 +52,7 @@ const GenericBottomInfoSection = ({
   updatePageAndEnableSection,
   breadcrumbs,
   intl: { formatMessage },
-  linkToViewPage,
+  viewPageLink,
 }: WrappedComponentProps & Props) => {
   const theme = useTheme();
 
@@ -108,9 +109,7 @@ const GenericBottomInfoSection = ({
             />
           }
           rightSideCTA={
-            linkToViewPage ? (
-              <ViewCustomPageButton linkTo={linkToViewPage} />
-            ) : null
+            viewPageLink ? <ViewCustomPageButton {...viewPageLink} /> : null
           }
         >
           <Feedback successMessage={formatMessage(messages.messageSuccess)} />

--- a/front/app/containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/GenericHeroBannerForm/index.tsx
@@ -7,6 +7,7 @@ import { TBreadcrumbs } from 'components/UI/Breadcrumbs';
 import Warning from 'components/UI/Warning';
 
 import { FormattedMessage } from 'utils/cl-intl';
+import { type TypedLinkProps } from 'utils/cl-router/Link';
 
 import SectionFormWrapper from '../../components/SectionFormWrapper';
 import ViewCustomPageButton from '../CustomPages/Edit/ViewCustomPageButton';
@@ -27,7 +28,7 @@ interface Props {
   bannerHeaderFieldsComponent: ReactElement;
   ctaButtonFieldsComponent: ReactElement;
   badge: JSX.Element;
-  linkToViewPage: string;
+  viewPageLink: TypedLinkProps;
 }
 
 const GenericHeroBannerForm = ({
@@ -42,7 +43,7 @@ const GenericHeroBannerForm = ({
   layoutSettingFieldComponent,
   ctaButtonFieldsComponent,
   badge,
-  linkToViewPage,
+  viewPageLink,
 }: Props) => {
   return (
     <>
@@ -67,11 +68,7 @@ const GenericHeroBannerForm = ({
             secondaryButtonSaveMessage={messages.saveAndEnable}
           />
         }
-        rightSideCTA={
-          linkToViewPage ? (
-            <ViewCustomPageButton linkTo={linkToViewPage} />
-          ) : null
-        }
+        rightSideCTA={<ViewCustomPageButton {...viewPageLink} />}
       >
         <Section key={'header'}>
           {/*

--- a/front/app/containers/Admin/pagesAndMenu/containers/GenericTopInfoSection/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/GenericTopInfoSection/index.tsx
@@ -16,6 +16,7 @@ import { TBreadcrumbs } from 'components/UI/Breadcrumbs';
 import ButtonWithLink from 'components/UI/ButtonWithLink';
 
 import { useIntl } from 'utils/cl-intl';
+import { type TypedLinkProps } from 'utils/cl-router/Link';
 import { handleHookFormSubmissionError } from 'utils/errorUtils';
 import validateAtLeastOneLocale from 'utils/yup/validateAtLeastOneLocale';
 
@@ -36,7 +37,7 @@ interface Props {
     top_info_section_multiloc: Multiloc;
   }) => Promise<any>;
   breadcrumbs: TBreadcrumbs;
-  linkToViewPage?: string;
+  viewPageLink?: TypedLinkProps;
 }
 
 interface FormValues {
@@ -48,7 +49,7 @@ const GenericTopInfoSection = ({
   updatePage,
   updatePageAndEnableSection,
   breadcrumbs,
-  linkToViewPage,
+  viewPageLink,
 }: Props) => {
   const theme = useTheme();
   const { formatMessage } = useIntl();
@@ -108,9 +109,7 @@ const GenericTopInfoSection = ({
             ]}
             title={formatMessage(messages.topInfoPageTitle)}
             rightSideCTA={
-              linkToViewPage ? (
-                <ViewCustomPageButton linkTo={linkToViewPage} />
-              ) : null
+              viewPageLink ? <ViewCustomPageButton {...viewPageLink} /> : null
             }
           >
             <Feedback

--- a/front/app/containers/Admin/pagesAndMenu/containers/PagesMenu/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/PagesMenu/index.tsx
@@ -76,7 +76,7 @@ const PagesMenu = () => {
                 buttonStyle="admin-dark"
                 icon="plus-circle"
                 id="create-custom-page"
-                to="/$locale/admin/pages-menu/pages/new"
+                to="/admin/pages-menu/pages/new"
                 className="intercom-admin-pages-menu-add-page"
                 disabled={!canCreateCustomPages}
               >

--- a/front/app/containers/Admin/pagesAndMenu/containers/PagesMenu/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/PagesMenu/index.tsx
@@ -76,7 +76,7 @@ const PagesMenu = () => {
                 buttonStyle="admin-dark"
                 icon="plus-circle"
                 id="create-custom-page"
-                linkTo={'/admin/pages-menu/pages/new'}
+                to="/$locale/admin/pages-menu/pages/new"
                 className="intercom-admin-pages-menu-add-page"
                 disabled={!canCreateCustomPages}
               >

--- a/front/app/containers/Admin/pagesAndMenu/containers/ProjectsList/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ProjectsList/index.tsx
@@ -60,7 +60,7 @@ const ProjectList = () => {
         ]}
         rightSideCTA={
           <ViewCustomPageButton
-            to="/$locale/pages/$slug"
+            to="/pages/$slug"
             params={{ slug: customPage.data.attributes.slug }}
           />
         }

--- a/front/app/containers/Admin/pagesAndMenu/containers/ProjectsList/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ProjectsList/index.tsx
@@ -60,7 +60,8 @@ const ProjectList = () => {
         ]}
         rightSideCTA={
           <ViewCustomPageButton
-            linkTo={`/pages/${customPage.data.attributes.slug}`}
+            to="/$locale/pages/$slug"
+            params={{ slug: customPage.data.attributes.slug }}
           />
         }
       >

--- a/front/app/containers/Admin/pagesAndMenu/routes.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/routes.tsx
@@ -45,10 +45,6 @@ const CustomPageHeroBannerForm = lazy(
 // path utils
 export const ADMIN_PAGES_MENU_PATH = `/admin/pages-menu`;
 
-export const adminCustomPageContentPath = (pageId: string) => {
-  return `/admin/pages-menu/pages/${pageId}/content`;
-};
-
 export const adminCustomPageContentLink = (customPageId: string) =>
   ({
     to: '/admin/pages-menu/pages/$customPageId/content',

--- a/front/app/containers/Admin/pagesAndMenu/routes.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/routes.tsx
@@ -51,7 +51,7 @@ export const adminCustomPageContentPath = (pageId: string) => {
 
 export const adminCustomPageContentLink = (customPageId: string) =>
   ({
-    to: '/$locale/admin/pages-menu/pages/$customPageId/content',
+    to: '/admin/pages-menu/pages/$customPageId/content',
     params: { customPageId },
   } as const);
 

--- a/front/app/containers/Admin/projectFolders/containers/index.tsx
+++ b/front/app/containers/Admin/projectFolders/containers/index.tsx
@@ -73,7 +73,7 @@ const AdminProjectFolderEdition = () => {
           buttonStyle="admin-dark"
           icon="eye"
           id="to-projectFolder"
-          to="/$locale/folders/$slug"
+          to="/folders/$slug"
           params={{ slug: projectFolder.data.attributes.slug }}
         >
           <FormattedMessage {...messages.viewPublicProjectFolder} />

--- a/front/app/containers/Admin/projectFolders/containers/index.tsx
+++ b/front/app/containers/Admin/projectFolders/containers/index.tsx
@@ -73,7 +73,8 @@ const AdminProjectFolderEdition = () => {
           buttonStyle="admin-dark"
           icon="eye"
           id="to-projectFolder"
-          linkTo={`/folders/${projectFolder.data.attributes.slug}`}
+          to="/$locale/folders/$slug"
+          params={{ slug: projectFolder.data.attributes.slug }}
         >
           <FormattedMessage {...messages.viewPublicProjectFolder} />
         </ButtonWithLink>

--- a/front/app/containers/Admin/projects/_shared/components/NewIdeaButton/index.tsx
+++ b/front/app/containers/Admin/projects/_shared/components/NewIdeaButton/index.tsx
@@ -12,13 +12,25 @@ import { useLocation } from 'utils/router';
 import messages from './messages';
 import tracks from './tracks';
 
+import type { LinkProps } from '@tanstack/react-router';
+
 interface Props {
-  linkTo: string;
+  to?: LinkProps['to'];
+  params?: Record<string, string>;
+  search?: Record<string, unknown>;
+  linkTo?: string;
   inputTerm: InputTerm;
   participationMethod: ParticipationMethod;
 }
 
-const NewIdeaButton = ({ linkTo, inputTerm, participationMethod }: Props) => {
+const NewIdeaButton = ({
+  to,
+  params,
+  search,
+  linkTo,
+  inputTerm,
+  participationMethod,
+}: Props) => {
   const { formatMessage } = useIntl();
   const { pathname } = useLocation();
   const buttonText =
@@ -49,6 +61,9 @@ const NewIdeaButton = ({ linkTo, inputTerm, participationMethod }: Props) => {
       id="e2e-new-idea"
       buttonStyle="admin-dark"
       icon="plus"
+      to={to}
+      params={params}
+      search={search}
       linkTo={linkTo}
       onClick={() => {
         trackEventByName(tracks.clickNewIdea.name, {

--- a/front/app/containers/Admin/projects/_shared/components/NewIdeaButton/index.tsx
+++ b/front/app/containers/Admin/projects/_shared/components/NewIdeaButton/index.tsx
@@ -6,18 +6,14 @@ import ButtonWithLink from 'components/UI/ButtonWithLink';
 
 import { trackEventByName } from 'utils/analytics';
 import { useIntl } from 'utils/cl-intl';
+import { type TypedLinkProps } from 'utils/cl-router/Link';
 import { getInputTermMessage } from 'utils/i18n';
 import { useLocation } from 'utils/router';
 
 import messages from './messages';
 import tracks from './tracks';
 
-import type { LinkProps } from '@tanstack/react-router';
-
-interface Props {
-  to?: LinkProps['to'];
-  params?: Record<string, string>;
-  search?: Record<string, unknown>;
+interface Props extends TypedLinkProps {
   linkTo?: string;
   inputTerm: InputTerm;
   participationMethod: ParticipationMethod;

--- a/front/app/containers/Admin/projects/_shared/components/ProjectRow/AdminTag.tsx
+++ b/front/app/containers/Admin/projects/_shared/components/ProjectRow/AdminTag.tsx
@@ -27,7 +27,7 @@ const AdminTag = ({ userCanModerateProject, projectId }: Props) => {
     return (
       <Link
         data-cy="e2e-admins-only-permissions-tag"
-        to="/$locale/admin/projects/$projectId/general/access-rights"
+        to="/admin/projects/$projectId/general/access-rights"
         params={{ projectId }}
       >
         <StatusLabel />

--- a/front/app/containers/Admin/projects/_shared/components/ProjectRow/GroupsTag.tsx
+++ b/front/app/containers/Admin/projects/_shared/components/ProjectRow/GroupsTag.tsx
@@ -48,7 +48,7 @@ const GroupsTag = ({ projectId, userCanModerateProject }: Props) => {
     return (
       <Link
         data-cy="e2e-groups-permissions-tag"
-        to="/$locale/admin/projects/$projectId/general/access-rights"
+        to="/admin/projects/$projectId/general/access-rights"
         params={{ projectId }}
       >
         <StatusLabel groupCount={groupCount} />

--- a/front/app/containers/Admin/projects/_shared/components/ProjectRow/ManageButton.tsx
+++ b/front/app/containers/Admin/projects/_shared/components/ProjectRow/ManageButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { adminProjectsProjectPath } from 'containers/Admin/projects/routes';
+import { adminProjectsProjectLink } from 'containers/Admin/projects/routes';
 
 import { FormattedMessage } from 'utils/cl-intl';
 
@@ -18,7 +18,7 @@ const ManageButton = ({ isDisabled, publicationId }: Props) => {
       className={`
       e2e-admin-edit-publication intercom-admin-project-edit-button
     `}
-      linkTo={adminProjectsProjectPath(publicationId)}
+      {...adminProjectsProjectLink(publicationId)}
       buttonStyle="secondary-outlined"
       icon="edit"
       type="button"

--- a/front/app/containers/Admin/projects/_shared/components/ProjectSetupForm/GeographicAreaInputs.tsx
+++ b/front/app/containers/Admin/projects/_shared/components/ProjectSetupForm/GeographicAreaInputs.tsx
@@ -128,7 +128,7 @@ const GeographicAreaInputs = ({
                 {...messages.areasLabelTooltipHint}
                 values={{
                   areasLabelTooltipLink: (
-                    <Link to="/$locale/admin/settings/areas">
+                    <Link to="/admin/settings/areas">
                       <FormattedMessage
                         {...messages.areasLabelTooltipLinkText}
                       />

--- a/front/app/containers/Admin/projects/_shared/components/ProjectSetupForm/TopicInputsTooltipExtraCopy.tsx
+++ b/front/app/containers/Admin/projects/_shared/components/ProjectSetupForm/TopicInputsTooltipExtraCopy.tsx
@@ -13,7 +13,7 @@ const TopicInputsCopyProvider = () => {
         {...messages.topicInputsTooltipExtraCopy}
         values={{
           topicManagerLink: (
-            <Link to="/$locale/admin/settings/topics">
+            <Link to="/admin/settings/topics">
               <FormattedMessage {...messages.topicInputsTooltipLink} />
             </Link>
           ),

--- a/front/app/containers/Admin/projects/all/Header.tsx
+++ b/front/app/containers/Admin/projects/all/Header.tsx
@@ -47,7 +47,7 @@ const Header = () => {
               <Button
                 data-cy="e2e-new-space-button"
                 className="intercom-admin-projects-new-space-button"
-                to="/$locale/admin/projects/spaces/new"
+                to="/admin/projects/spaces/new"
                 buttonStyle="secondary-outlined"
                 icon="spaces"
                 iconSize="20px"
@@ -71,7 +71,7 @@ const Header = () => {
           <Box>
             <Button
               data-cy="e2e-new-project-folder-button"
-              to="/$locale/admin/projects/folders/new"
+              to="/admin/projects/folders/new"
               buttonStyle="secondary-outlined"
               icon="folder-add"
               disabled={!userCanAddFolders}
@@ -84,7 +84,7 @@ const Header = () => {
           <Button
             data-cy="e2e-new-project-button"
             className="intercom-admin-projects-new-project-button"
-            to="/$locale/admin/projects/new"
+            to="/admin/projects/new"
             icon="plus-circle"
             buttonStyle="admin-dark"
           >

--- a/front/app/containers/Admin/projects/all/Header.tsx
+++ b/front/app/containers/Admin/projects/all/Header.tsx
@@ -47,7 +47,7 @@ const Header = () => {
               <Button
                 data-cy="e2e-new-space-button"
                 className="intercom-admin-projects-new-space-button"
-                linkTo={'/admin/projects/spaces/new'}
+                to="/$locale/admin/projects/spaces/new"
                 buttonStyle="secondary-outlined"
                 icon="spaces"
                 iconSize="20px"
@@ -71,7 +71,7 @@ const Header = () => {
           <Box>
             <Button
               data-cy="e2e-new-project-folder-button"
-              linkTo={'/admin/projects/folders/new'}
+              to="/$locale/admin/projects/folders/new"
               buttonStyle="secondary-outlined"
               icon="folder-add"
               disabled={!userCanAddFolders}
@@ -84,7 +84,7 @@ const Header = () => {
           <Button
             data-cy="e2e-new-project-button"
             className="intercom-admin-projects-new-project-button"
-            linkTo={'/admin/projects/new'}
+            to="/$locale/admin/projects/new"
             icon="plus-circle"
             buttonStyle="admin-dark"
           >

--- a/front/app/containers/Admin/projects/all/Projects/Table/Row.tsx
+++ b/front/app/containers/Admin/projects/all/Projects/Table/Row.tsx
@@ -96,10 +96,21 @@ const Row = ({
     }
   };
 
-  const link =
+  const link: {
+    to:
+      | '/admin/projects/folders/$projectFolderId'
+      | '/admin/projects/$projectId';
+    params: Record<string, string>;
+  } =
     hover === 'folder' && canModerateThisFolder
-      ? (`/admin/projects/folders/${folderId}` as const)
-      : (`/admin/projects/${project.id}` as const);
+      ? {
+          to: '/admin/projects/folders/$projectFolderId',
+          params: { projectFolderId: folderId },
+        }
+      : {
+          to: '/admin/projects/$projectId',
+          params: { projectId: project.id },
+        };
 
   return (
     <Tr dataCy="projects-overview-table-row">
@@ -116,53 +127,53 @@ const Row = ({
             : undefined
         }
       >
-        <Box
-          display="flex"
-          alignItems="center"
-          w="100%"
-          h="100%"
-          as={Link}
-          to={link}
+        <Link
+          to={link.to}
+          params={link.params as Parameters<typeof Link>[0]['params']}
         >
-          <RowImage
-            imageUrl={imageUrl ?? undefined}
-            alt={localize(title_multiloc)}
-          />
-          <Box ml="8px">
-            <Text
-              m="0"
-              fontSize="s"
-              textDecoration={hover === 'project' ? 'underline' : 'none'}
-            >
-              {localize(title_multiloc)}
-            </Text>
-            {folder_title_multiloc && (
+          <Box display="flex" alignItems="center" w="100%" h="100%">
+            <RowImage
+              imageUrl={imageUrl ?? undefined}
+              alt={localize(title_multiloc)}
+            />
+            <Box ml="8px">
               <Text
                 m="0"
-                fontSize="xs"
-                color="textSecondary"
-                textDecoration={
-                  hover === 'folder' && canModerateThisFolder
-                    ? 'underline'
-                    : 'none'
-                }
-                onMouseEnter={
-                  canModerateThisFolder ? () => setHover('folder') : undefined
-                }
-                onMouseLeave={
-                  canModerateThisFolder ? () => setHover('project') : undefined
-                }
+                fontSize="s"
+                textDecoration={hover === 'project' ? 'underline' : 'none'}
               >
-                {localize(folder_title_multiloc)}
+                {localize(title_multiloc)}
               </Text>
+              {folder_title_multiloc && (
+                <Text
+                  m="0"
+                  fontSize="xs"
+                  color="textSecondary"
+                  textDecoration={
+                    hover === 'folder' && canModerateThisFolder
+                      ? 'underline'
+                      : 'none'
+                  }
+                  onMouseEnter={
+                    canModerateThisFolder ? () => setHover('folder') : undefined
+                  }
+                  onMouseLeave={
+                    canModerateThisFolder
+                      ? () => setHover('project')
+                      : undefined
+                  }
+                >
+                  {localize(folder_title_multiloc)}
+                </Text>
+              )}
+            </Box>
+            {(isBeingCopyied || isBeingDeleted) && (
+              <Box ml="12px">
+                <Spinner size="20px" color={colors.grey400} />
+              </Box>
             )}
           </Box>
-          {(isBeingCopyied || isBeingDeleted) && (
-            <Box ml="12px">
-              <Spinner size="20px" color={colors.grey400} />
-            </Box>
-          )}
-        </Box>
+        </Link>
         {error && (
           <Box mt="8px">
             <Error text={error} />

--- a/front/app/containers/Admin/projects/new/ProjectSetupForm.tsx
+++ b/front/app/containers/Admin/projects/new/ProjectSetupForm.tsx
@@ -311,7 +311,7 @@ const ProjectSetupForm = () => {
                   {...messages.needInspiration}
                   values={{
                     inspirationHubLink: (
-                      <Link to="/$locale/admin/inspiration-hub" target="_blank">
+                      <Link to="/admin/inspiration-hub" target="_blank">
                         <FormattedMessage {...messages.inspirationHub} />
                       </Link>
                     ),

--- a/front/app/containers/Admin/projects/new/index.tsx
+++ b/front/app/containers/Admin/projects/new/index.tsx
@@ -56,7 +56,7 @@ const CreateProject = () => {
 
   return (
     <Box>
-      <GoBackButton linkTo="/admin/projects" />
+      <GoBackButton to="/$locale/admin/projects" />
       <Title color="primary" mb="32px">
         {formatMessage(messages.createAProject)}
       </Title>

--- a/front/app/containers/Admin/projects/new/index.tsx
+++ b/front/app/containers/Admin/projects/new/index.tsx
@@ -56,7 +56,7 @@ const CreateProject = () => {
 
   return (
     <Box>
-      <GoBackButton to="/$locale/admin/projects" />
+      <GoBackButton to="/admin/projects" />
       <Title color="primary" mb="32px">
         {formatMessage(messages.createAProject)}
       </Title>

--- a/front/app/containers/Admin/projects/project/analysis/InputPreview/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/InputPreview/index.tsx
@@ -63,7 +63,9 @@ const InputListItem = () => {
       {showManageInputButton && (
         <Box display="flex" justifyContent="flex-end">
           <ButtonWithLink
-            linkTo={`/admin/projects/${projectId}/phases/${phaseId}/ideas?selected_idea_id=${selectedInputId}`}
+            to="/$locale/admin/projects/$projectId/phases/$phaseId/ideas"
+            params={{ projectId, phaseId }}
+            search={{ selected_idea_id: selectedInputId }}
             openLinkInNewTab
             buttonStyle="secondary-outlined"
             icon="settings"

--- a/front/app/containers/Admin/projects/project/analysis/InputPreview/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/InputPreview/index.tsx
@@ -63,7 +63,7 @@ const InputListItem = () => {
       {showManageInputButton && (
         <Box display="flex" justifyContent="flex-end">
           <ButtonWithLink
-            to="/$locale/admin/projects/$projectId/phases/$phaseId/ideas"
+            to="/admin/projects/$projectId/phases/$phaseId/ideas"
             params={{ projectId, phaseId }}
             search={{ selected_idea_id: selectedInputId }}
             openLinkInNewTab

--- a/front/app/containers/Admin/projects/project/analysis/Insights/Files/FileSelectionView/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Insights/Files/FileSelectionView/index.tsx
@@ -133,7 +133,7 @@ const FileSelectionView = ({ setIsFileSelectionOpen, analysisId }: Props) => {
 
           <Box mt="24px">
             <ButtonWithLink
-              to="/$locale/admin/projects/$projectId/files"
+              to="/admin/projects/$projectId/files"
               params={{ projectId }}
               buttonStyle="text"
               icon="open-in-new"

--- a/front/app/containers/Admin/projects/project/analysis/Insights/Files/FileSelectionView/index.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Insights/Files/FileSelectionView/index.tsx
@@ -133,7 +133,8 @@ const FileSelectionView = ({ setIsFileSelectionOpen, analysisId }: Props) => {
 
           <Box mt="24px">
             <ButtonWithLink
-              linkTo={`/admin/projects/${projectId}/files`}
+              to="/$locale/admin/projects/$projectId/files"
+              params={{ projectId }}
               buttonStyle="text"
               icon="open-in-new"
               iconPos="right"

--- a/front/app/containers/Admin/projects/project/analysis/Insights/ReferenceLink.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/Insights/ReferenceLink.tsx
@@ -106,7 +106,7 @@ const ReferenceLink = ({
     >
       <Box display="inline">
         <StyledLink
-          to="/$locale/admin/projects/$projectId/analysis/$analysisId"
+          to="/admin/projects/$projectId/analysis/$analysisId"
           params={{ projectId, analysisId }}
           search={{ phase_id: phaseId, selected_input_id: match }}
           className={selectedInputId === match ? 'active' : undefined}

--- a/front/app/containers/Admin/projects/project/events/edit.tsx
+++ b/front/app/containers/Admin/projects/project/events/edit.tsx
@@ -624,7 +624,10 @@ const AdminProjectEventEdit = () => {
   return (
     <Box mt="44px" mx="44px">
       <Box bg={colors.white} borderRadius={stylingConsts.borderRadius} p="44px">
-        <GoBackButton linkTo={`/admin/projects/${projectId}/events`} />
+        <GoBackButton
+          to="/$locale/admin/projects/$projectId/events"
+          params={{ projectId: projectId ?? '' }}
+        />
         <Box ref={containerRef}>
           <SectionTitle>
             {event && <FormattedMessage {...messages.editEventTitle} />}

--- a/front/app/containers/Admin/projects/project/events/edit.tsx
+++ b/front/app/containers/Admin/projects/project/events/edit.tsx
@@ -625,7 +625,7 @@ const AdminProjectEventEdit = () => {
     <Box mt="44px" mx="44px">
       <Box bg={colors.white} borderRadius={stylingConsts.borderRadius} p="44px">
         <GoBackButton
-          to="/$locale/admin/projects/$projectId/events"
+          to="/admin/projects/$projectId/events"
           params={{ projectId: projectId ?? '' }}
         />
         <Box ref={containerRef}>

--- a/front/app/containers/Admin/projects/project/events/index.tsx
+++ b/front/app/containers/Admin/projects/project/events/index.tsx
@@ -94,7 +94,7 @@ const AdminProjectEventsIndex = () => {
           <AddButton
             buttonStyle="admin-dark"
             icon="plus-circle"
-            to="/$locale/admin/projects/$projectId/events/new"
+            to="/admin/projects/$projectId/events/new"
             params={{ projectId }}
           >
             <FormattedMessage {...messages.addEventButton} />
@@ -193,7 +193,7 @@ const AdminProjectEventsIndex = () => {
                       <ButtonWithLink
                         buttonStyle="secondary-outlined"
                         icon="edit"
-                        to="/$locale/admin/projects/$projectId/events/$id"
+                        to="/admin/projects/$projectId/events/$id"
                         params={{ projectId, id: event.id }}
                       >
                         <FormattedMessage {...messages.editButtonLabel} />

--- a/front/app/containers/Admin/projects/project/events/index.tsx
+++ b/front/app/containers/Admin/projects/project/events/index.tsx
@@ -94,7 +94,8 @@ const AdminProjectEventsIndex = () => {
           <AddButton
             buttonStyle="admin-dark"
             icon="plus-circle"
-            linkTo={`/admin/projects/${projectId}/events/new`}
+            to="/$locale/admin/projects/$projectId/events/new"
+            params={{ projectId }}
           >
             <FormattedMessage {...messages.addEventButton} />
           </AddButton>
@@ -192,7 +193,8 @@ const AdminProjectEventsIndex = () => {
                       <ButtonWithLink
                         buttonStyle="secondary-outlined"
                         icon="edit"
-                        linkTo={`/admin/projects/${projectId}/events/${event.id}`}
+                        to="/$locale/admin/projects/$projectId/events/$id"
+                        params={{ projectId, id: event.id }}
                       >
                         <FormattedMessage {...messages.editButtonLabel} />
                       </ButtonWithLink>

--- a/front/app/containers/Admin/projects/project/general/setUp/index.tsx
+++ b/front/app/containers/Admin/projects/project/general/setUp/index.tsx
@@ -468,7 +468,7 @@ const AdminProjectsProjectGeneral = ({ project }: Props) => {
                   {...messages.needInspiration}
                   values={{
                     inspirationHubLink: (
-                      <Link to="/$locale/admin/inspiration-hub" target="_blank">
+                      <Link to="/admin/inspiration-hub" target="_blank">
                         <FormattedMessage {...messages.inspirationHub} />
                       </Link>
                     ),

--- a/front/app/containers/Admin/projects/project/ideas/index.tsx
+++ b/front/app/containers/Admin/projects/project/ideas/index.tsx
@@ -62,7 +62,8 @@ const AdminProjectIdeas = () => {
             {!isCommonGround && (
               <ButtonWithLink
                 width="auto"
-                linkTo={`/admin/projects/${projectId}/phases/${phaseId}/input-importer`}
+                to="/$locale/admin/projects/$projectId/phases/$phaseId/input-importer"
+                params={{ projectId, phaseId }}
                 icon="page"
                 buttonStyle="secondary-outlined"
               >
@@ -81,7 +82,9 @@ const AdminProjectIdeas = () => {
               <NewIdeaButton
                 participationMethod={phase.data.attributes.participation_method}
                 inputTerm={phase.data.attributes.input_term}
-                linkTo={`/projects/${project.data.attributes.slug}/ideas/new?phase_id=${phaseId}`}
+                to="/$locale/projects/$slug/ideas/new"
+                params={{ slug: project.data.attributes.slug }}
+                search={{ phase_id: phaseId }}
               />
             )}
           </Box>

--- a/front/app/containers/Admin/projects/project/ideas/index.tsx
+++ b/front/app/containers/Admin/projects/project/ideas/index.tsx
@@ -62,7 +62,7 @@ const AdminProjectIdeas = () => {
             {!isCommonGround && (
               <ButtonWithLink
                 width="auto"
-                to="/$locale/admin/projects/$projectId/phases/$phaseId/input-importer"
+                to="/admin/projects/$projectId/phases/$phaseId/input-importer"
                 params={{ projectId, phaseId }}
                 icon="page"
                 buttonStyle="secondary-outlined"
@@ -82,7 +82,7 @@ const AdminProjectIdeas = () => {
               <NewIdeaButton
                 participationMethod={phase.data.attributes.participation_method}
                 inputTerm={phase.data.attributes.input_term}
-                to="/$locale/projects/$slug/ideas/new"
+                to="/projects/$slug/ideas/new"
                 params={{ slug: project.data.attributes.slug }}
                 search={{ phase_id: phaseId }}
               />

--- a/front/app/containers/Admin/projects/project/inputForm/IdeaFormBuilder/index.tsx
+++ b/front/app/containers/Admin/projects/project/inputForm/IdeaFormBuilder/index.tsx
@@ -48,7 +48,11 @@ const IdeaFormBuilder = ({
         formCustomFields,
         goBackUrl,
       }}
-      viewFormLink={`/projects/${projectSlug}/ideas/new?phase_id=${phaseId}`}
+      viewFormLink={{
+        to: '/projects/$slug/ideas/new',
+        params: { slug: projectSlug },
+        search: { phase_id: phaseId },
+      }}
     />
   );
 };

--- a/front/app/containers/Admin/projects/project/inputForm/index.tsx
+++ b/front/app/containers/Admin/projects/project/inputForm/index.tsx
@@ -27,7 +27,7 @@ export const InputForm = () => {
       <Box display="flex" flexDirection="row">
         <ButtonWithLink
           mr="8px"
-          to="/$locale/admin/projects/$projectId/phases/$phaseId/form/edit"
+          to="/admin/projects/$projectId/phases/$phaseId/form/edit"
           params={{ projectId, phaseId }}
           width="auto"
           icon="edit"

--- a/front/app/containers/Admin/projects/project/inputForm/index.tsx
+++ b/front/app/containers/Admin/projects/project/inputForm/index.tsx
@@ -27,7 +27,8 @@ export const InputForm = () => {
       <Box display="flex" flexDirection="row">
         <ButtonWithLink
           mr="8px"
-          linkTo={`/admin/projects/${projectId}/phases/${phaseId}/form/edit`}
+          to="/$locale/admin/projects/$projectId/phases/$phaseId/form/edit"
+          params={{ projectId, phaseId }}
           width="auto"
           icon="edit"
           data-cy="e2e-edit-input-form"

--- a/front/app/containers/Admin/projects/project/inputImporter/ImportModal/ImportExcelModal.tsx
+++ b/front/app/containers/Admin/projects/project/inputImporter/ImportModal/ImportExcelModal.tsx
@@ -52,11 +52,11 @@ const ImportExcelModal = ({ open, onClose }: Props) => {
   const downloadFormLink =
     phase?.data.attributes.participation_method === 'native_survey'
       ? ({
-          to: '/$locale/admin/projects/$projectId/phases/$phaseId/survey-form',
+          to: '/admin/projects/$projectId/phases/$phaseId/survey-form',
           params: { projectId, phaseId },
         } as const)
       : ({
-          to: '/$locale/admin/projects/$projectId/phases/$phaseId/form',
+          to: '/admin/projects/$projectId/phases/$phaseId/form',
           params: { projectId, phaseId },
         } as const);
 

--- a/front/app/containers/Admin/projects/project/inputImporter/ImportModal/ImportPdfModal.tsx
+++ b/front/app/containers/Admin/projects/project/inputImporter/ImportModal/ImportPdfModal.tsx
@@ -61,11 +61,11 @@ const ImportPdfModal = ({ open, onClose }: Props) => {
   const downloadFormLink =
     phase?.data.attributes.participation_method === 'native_survey'
       ? ({
-          to: '/$locale/admin/projects/$projectId/phases/$phaseId/survey-form',
+          to: '/admin/projects/$projectId/phases/$phaseId/survey-form',
           params: downloadFormParams,
         } as const)
       : ({
-          to: '/$locale/admin/projects/$projectId/phases/$phaseId/form',
+          to: '/admin/projects/$projectId/phases/$phaseId/form',
           params: downloadFormParams,
         } as const);
 

--- a/front/app/containers/Admin/projects/project/inputImporter/TopBar/index.tsx
+++ b/front/app/containers/Admin/projects/project/inputImporter/TopBar/index.tsx
@@ -21,7 +21,7 @@ import { useParams } from 'utils/router';
 import messages from '../messages';
 
 import ImportButtons from './ImportButtons';
-import { getBackPath } from './utils';
+import { getBackLink } from './utils';
 
 interface Props {
   onClickPDFImport: () => void;
@@ -44,10 +44,10 @@ const TopBar = ({ onClickPDFImport, onClickExcelImport }: Props) => {
 
   const participationMethod = phase?.data.attributes.participation_method;
 
-  const backPath =
-    projectId &&
-    phaseId &&
-    getBackPath(projectId, phaseId, participationMethod);
+  const backLink =
+    projectId && phaseId
+      ? getBackLink(projectId, phaseId, participationMethod)
+      : undefined;
 
   return (
     <Box
@@ -63,7 +63,7 @@ const TopBar = ({ onClickPDFImport, onClickExcelImport }: Props) => {
       px="24px"
     >
       <Box display="flex" alignItems="center">
-        <GoBackButton linkTo={backPath} />
+        <GoBackButton {...backLink} />
         <Box ml="24px">
           <Box display="flex" gap="8px" alignItems="center">
             <Text m="0px" color="textSecondary">

--- a/front/app/containers/Admin/projects/project/inputImporter/TopBar/utils.ts
+++ b/front/app/containers/Admin/projects/project/inputImporter/TopBar/utils.ts
@@ -1,16 +1,24 @@
 import { ParticipationMethod } from 'api/phases/types';
 
-export const getBackPath = (
+import { type TypedLinkProps } from 'utils/cl-router/Link';
+
+export const getBackLink = (
   projectId: string,
   phaseId: string,
   participationMethod?: ParticipationMethod
-): string => {
+): TypedLinkProps => {
   switch (participationMethod) {
     case 'native_survey':
-      return `/admin/projects/${projectId}/phases/${phaseId}/insights`;
+      return {
+        to: '/admin/projects/$projectId/phases/$phaseId/insights',
+        params: { projectId, phaseId },
+      };
     case 'community_monitor_survey':
-      return `/admin/community-monitor/settings`;
+      return { to: '/admin/community-monitor/settings' };
     default:
-      return `/admin/projects/${projectId}/phases/${phaseId}/ideas`;
+      return {
+        to: '/admin/projects/$projectId/phases/$phaseId/ideas',
+        params: { projectId, phaseId },
+      };
   }
 };

--- a/front/app/containers/Admin/projects/project/insights/methodSpecific/nativeSurvey/SurveyActions.tsx
+++ b/front/app/containers/Admin/projects/project/insights/methodSpecific/nativeSurvey/SurveyActions.tsx
@@ -272,7 +272,7 @@ const SurveyActions = ({ phase }: Props) => {
           />
         </Box>
         <ButtonWithLink
-          to="/$locale/projects/$slug/surveys/new"
+          to="/projects/$slug/surveys/new"
           params={{ slug: project.data.attributes.slug }}
           search={{ phase_id: phaseId }}
           buttonStyle="text"

--- a/front/app/containers/Admin/projects/project/insights/methodSpecific/nativeSurvey/SurveyActions.tsx
+++ b/front/app/containers/Admin/projects/project/insights/methodSpecific/nativeSurvey/SurveyActions.tsx
@@ -272,7 +272,9 @@ const SurveyActions = ({ phase }: Props) => {
           />
         </Box>
         <ButtonWithLink
-          linkTo={`/projects/${project.data.attributes.slug}/surveys/new?phase_id=${phaseId}`}
+          to="/$locale/projects/$slug/surveys/new"
+          params={{ slug: project.data.attributes.slug }}
+          search={{ phase_id: phaseId }}
           buttonStyle="text"
           width="auto"
           openLinkInNewTab

--- a/front/app/containers/Admin/projects/project/insights/methodSpecific/nativeSurvey/SurveyActions.tsx
+++ b/front/app/containers/Admin/projects/project/insights/methodSpecific/nativeSurvey/SurveyActions.tsx
@@ -282,7 +282,7 @@ const SurveyActions = ({ phase }: Props) => {
           {formatMessage(messages.newSubmission)}
         </ButtonWithLink>
         <ButtonWithLink
-          linkTo={inputImporterLink}
+          {...inputImporterLink}
           icon="page"
           iconSize="20px"
           buttonStyle="secondary-outlined"

--- a/front/app/containers/Admin/projects/project/messaging/All/NewCampaignButton.tsx
+++ b/front/app/containers/Admin/projects/project/messaging/All/NewCampaignButton.tsx
@@ -13,7 +13,8 @@ const NewCampaignButton = () => {
     <ButtonWithLink
       buttonStyle="admin-dark"
       icon="plus-circle"
-      linkTo={`/admin/projects/${projectId}/messaging/new`}
+      to="/$locale/admin/projects/$projectId/messaging/new"
+      params={{ projectId: projectId ?? '' }}
     >
       <FormattedMessage {...messages.addCampaignButton} />
     </ButtonWithLink>

--- a/front/app/containers/Admin/projects/project/messaging/All/NewCampaignButton.tsx
+++ b/front/app/containers/Admin/projects/project/messaging/All/NewCampaignButton.tsx
@@ -13,7 +13,7 @@ const NewCampaignButton = () => {
     <ButtonWithLink
       buttonStyle="admin-dark"
       icon="plus-circle"
-      to="/$locale/admin/projects/$projectId/messaging/new"
+      to="/admin/projects/$projectId/messaging/new"
       params={{ projectId: projectId ?? '' }}
     >
       <FormattedMessage {...messages.addCampaignButton} />

--- a/front/app/containers/Admin/projects/project/messaging/CampaignForm/index.tsx
+++ b/front/app/containers/Admin/projects/project/messaging/CampaignForm/index.tsx
@@ -196,7 +196,7 @@ const CampaignForm = ({
                   {...messages.infoboxAdmin}
                   values={{
                     link: (
-                      <Link to="/$locale/admin/messaging/emails/custom">
+                      <Link to="/admin/messaging/emails/custom">
                         <FormattedMessage {...messages.infoboxLink} />
                       </Link>
                     ),

--- a/front/app/containers/Admin/projects/project/messaging/Show/index.tsx
+++ b/front/app/containers/Admin/projects/project/messaging/Show/index.tsx
@@ -162,7 +162,7 @@ const Show = () => {
       <Box p="44px">
         <Box background={colors.white} p="40px" id="e2e-custom-email-container">
           <GoBackButton
-            to="/$locale/admin/projects/$projectId/messaging"
+            to="/admin/projects/$projectId/messaging"
             params={{ projectId }}
           />
           <Box display="flex" mb="20px">
@@ -201,7 +201,7 @@ const Show = () => {
               campaign.data.attributes.scheduled_at) && (
               <Buttons>
                 <ButtonWithLink
-                  to="/$locale/admin/projects/$projectId/messaging/$campaignId/edit"
+                  to="/admin/projects/$projectId/messaging/$campaignId/edit"
                   params={{ projectId, campaignId: campaign.data.id }}
                   buttonStyle="secondary-outlined"
                 >

--- a/front/app/containers/Admin/projects/project/messaging/Show/index.tsx
+++ b/front/app/containers/Admin/projects/project/messaging/Show/index.tsx
@@ -161,7 +161,10 @@ const Show = () => {
     return (
       <Box p="44px">
         <Box background={colors.white} p="40px" id="e2e-custom-email-container">
-          <GoBackButton linkTo={`/admin/projects/${projectId}/messaging`} />
+          <GoBackButton
+            to="/$locale/admin/projects/$projectId/messaging"
+            params={{ projectId }}
+          />
           <Box display="flex" mb="20px">
             <Box display="flex" alignItems="center" mr="auto" gap="12px">
               <Title mr="12px">
@@ -198,7 +201,8 @@ const Show = () => {
               campaign.data.attributes.scheduled_at) && (
               <Buttons>
                 <ButtonWithLink
-                  linkTo={`/admin/projects/${projectId}/messaging/${campaign.data.id}/edit`}
+                  to="/$locale/admin/projects/$projectId/messaging/$campaignId/edit"
+                  params={{ projectId, campaignId: campaign.data.id }}
                   buttonStyle="secondary-outlined"
                 >
                   <FormattedMessage {...messages.editButtonLabel} />

--- a/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/VotingInputs/index.tsx
+++ b/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/VotingInputs/index.tsx
@@ -174,7 +174,7 @@ const VotingInputs = ({
               values={{
                 optionsPageLink: (
                   <Link
-                    to="/$locale/admin/projects/$projectId/phases/$phaseId/ideas"
+                    to="/admin/projects/$projectId/phases/$phaseId/ideas"
                     params={{ projectId, phaseId }}
                     rel="noreferrer"
                   >

--- a/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/index.tsx
+++ b/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/index.tsx
@@ -504,7 +504,7 @@ const PhaseParticipationConfig = ({
                   {...projectMessages.needInspirationDescription}
                   values={{
                     inspirationHubLink: (
-                      <Link to="/$locale/admin/inspiration-hub" target="_blank">
+                      <Link to="/admin/inspiration-hub" target="_blank">
                         <FormattedMessage {...projectMessages.inspirationHub} />
                       </Link>
                     ),

--- a/front/app/containers/Admin/projects/project/projectHeader/FolderProjectDropdown.tsx
+++ b/front/app/containers/Admin/projects/project/projectHeader/FolderProjectDropdown.tsx
@@ -76,7 +76,11 @@ const FolderProjectDropdown = ({ folderId }: Props) => {
                   page.data.map((adminPublication) => (
                     <ButtonWithLink
                       key={adminPublication.id}
-                      linkTo={`/admin/projects/${adminPublication.relationships.publication.data.id}`}
+                      to="/$locale/admin/projects/$projectId"
+                      params={{
+                        projectId:
+                          adminPublication.relationships.publication.data.id,
+                      }}
                       openLinkInNewTab={true}
                       buttonStyle="text"
                       p="4px"

--- a/front/app/containers/Admin/projects/project/projectHeader/FolderProjectDropdown.tsx
+++ b/front/app/containers/Admin/projects/project/projectHeader/FolderProjectDropdown.tsx
@@ -76,7 +76,7 @@ const FolderProjectDropdown = ({ folderId }: Props) => {
                   page.data.map((adminPublication) => (
                     <ButtonWithLink
                       key={adminPublication.id}
-                      to="/$locale/admin/projects/$projectId"
+                      to="/admin/projects/$projectId"
                       params={{
                         projectId:
                           adminPublication.relationships.publication.data.id,

--- a/front/app/containers/Admin/projects/project/projectHeader/PublicationButtons/ScheduleLaunchModal/EmailNotificationsSection.tsx
+++ b/front/app/containers/Admin/projects/project/projectHeader/PublicationButtons/ScheduleLaunchModal/EmailNotificationsSection.tsx
@@ -86,7 +86,8 @@ const EmailNotificationsSection = ({
             </Text>
             <ButtonWithLink
               buttonStyle="text"
-              linkTo={`/admin/projects/${projectId}/general`}
+              to="/$locale/admin/projects/$projectId/general"
+              params={{ projectId }}
               onClick={onCloseModal}
               padding="0"
               fontSize="14px"

--- a/front/app/containers/Admin/projects/project/projectHeader/PublicationButtons/ScheduleLaunchModal/EmailNotificationsSection.tsx
+++ b/front/app/containers/Admin/projects/project/projectHeader/PublicationButtons/ScheduleLaunchModal/EmailNotificationsSection.tsx
@@ -86,7 +86,7 @@ const EmailNotificationsSection = ({
             </Text>
             <ButtonWithLink
               buttonStyle="text"
-              to="/$locale/admin/projects/$projectId/general"
+              to="/admin/projects/$projectId/general"
               params={{ projectId }}
               onClick={onCloseModal}
               padding="0"

--- a/front/app/containers/Admin/projects/project/projectHeader/PublicationButtons/ScheduleLaunchModal/VisibilitySection.tsx
+++ b/front/app/containers/Admin/projects/project/projectHeader/PublicationButtons/ScheduleLaunchModal/VisibilitySection.tsx
@@ -64,7 +64,8 @@ const VisibilitySection = ({ project, onClose }: Props) => {
         </Text>
         <ButtonWithLink
           buttonStyle="text"
-          linkTo={`/admin/projects/${projectId}/general/access-rights`}
+          to="/$locale/admin/projects/$projectId/general/access-rights"
+          params={{ projectId }}
           onClick={() => onClose()}
           padding="0"
           fontSize="14px"

--- a/front/app/containers/Admin/projects/project/projectHeader/PublicationButtons/ScheduleLaunchModal/VisibilitySection.tsx
+++ b/front/app/containers/Admin/projects/project/projectHeader/PublicationButtons/ScheduleLaunchModal/VisibilitySection.tsx
@@ -64,7 +64,7 @@ const VisibilitySection = ({ project, onClose }: Props) => {
         </Text>
         <ButtonWithLink
           buttonStyle="text"
-          to="/$locale/admin/projects/$projectId/general/access-rights"
+          to="/admin/projects/$projectId/general/access-rights"
           params={{ projectId }}
           onClick={() => onClose()}
           padding="0"

--- a/front/app/containers/Admin/projects/project/projectHeader/index.tsx
+++ b/front/app/containers/Admin/projects/project/projectHeader/index.tsx
@@ -112,7 +112,7 @@ const ProjectHeader = ({ projectId }: Props) => {
             className="intercom-projects-project-header-buttons"
           >
             <ButtonWithLink
-              to="/$locale/projects/$slug"
+              to="/projects/$slug"
               params={{ slug: project.data.attributes.slug }}
               buttonStyle="secondary-outlined"
               icon="eye"
@@ -136,7 +136,7 @@ const ProjectHeader = ({ projectId }: Props) => {
         </Box>
         <Box display="flex" gap="8px">
           <ButtonWithLink
-            to="/$locale/admin/projects/$projectId/general/access-rights"
+            to="/admin/projects/$projectId/general/access-rights"
             params={{ projectId: project.data.id }}
             buttonStyle="text"
             size="s"
@@ -157,7 +157,7 @@ const ProjectHeader = ({ projectId }: Props) => {
             ·
           </Text>
           <ButtonWithLink
-            to="/$locale/admin/projects/$projectId/general/access-rights"
+            to="/admin/projects/$projectId/general/access-rights"
             params={{ projectId: project.data.id }}
             buttonStyle="text"
             size="s"

--- a/front/app/containers/Admin/projects/project/projectHeader/index.tsx
+++ b/front/app/containers/Admin/projects/project/projectHeader/index.tsx
@@ -112,7 +112,8 @@ const ProjectHeader = ({ projectId }: Props) => {
             className="intercom-projects-project-header-buttons"
           >
             <ButtonWithLink
-              linkTo={`/projects/${project.data.attributes.slug}`}
+              to="/$locale/projects/$slug"
+              params={{ slug: project.data.attributes.slug }}
               buttonStyle="secondary-outlined"
               icon="eye"
               size="s"
@@ -135,7 +136,8 @@ const ProjectHeader = ({ projectId }: Props) => {
         </Box>
         <Box display="flex" gap="8px">
           <ButtonWithLink
-            linkTo={`/admin/projects/${project.data.id}/general/access-rights`}
+            to="/$locale/admin/projects/$projectId/general/access-rights"
+            params={{ projectId: project.data.id }}
             buttonStyle="text"
             size="s"
             padding="0px"
@@ -155,7 +157,8 @@ const ProjectHeader = ({ projectId }: Props) => {
             ·
           </Text>
           <ButtonWithLink
-            linkTo={`/admin/projects/${project.data.id}/general/access-rights`}
+            to="/$locale/admin/projects/$projectId/general/access-rights"
+            params={{ projectId: project.data.id }}
             buttonStyle="text"
             size="s"
             padding="0px"

--- a/front/app/containers/Admin/projects/project/proposals/index.tsx
+++ b/front/app/containers/Admin/projects/project/proposals/index.tsx
@@ -48,7 +48,7 @@ const AdminProjectProposals = () => {
           <Box display="flex" gap="8px">
             <ButtonWithLink
               width="auto"
-              to="/$locale/admin/projects/$projectId/phases/$phaseId/input-importer"
+              to="/admin/projects/$projectId/phases/$phaseId/input-importer"
               params={{ projectId, phaseId }}
               icon="page"
               buttonStyle="secondary-outlined"
@@ -59,7 +59,7 @@ const AdminProjectProposals = () => {
               <NewIdeaButton
                 participationMethod={phase.data.attributes.participation_method}
                 inputTerm={phase.data.attributes.input_term}
-                to="/$locale/projects/$slug/ideas/new"
+                to="/projects/$slug/ideas/new"
                 params={{ slug: project.data.attributes.slug }}
                 search={{ phase_id: phaseId }}
               />

--- a/front/app/containers/Admin/projects/project/proposals/index.tsx
+++ b/front/app/containers/Admin/projects/project/proposals/index.tsx
@@ -48,7 +48,8 @@ const AdminProjectProposals = () => {
           <Box display="flex" gap="8px">
             <ButtonWithLink
               width="auto"
-              linkTo={`/admin/projects/${projectId}/phases/${phaseId}/input-importer`}
+              to="/$locale/admin/projects/$projectId/phases/$phaseId/input-importer"
+              params={{ projectId, phaseId }}
               icon="page"
               buttonStyle="secondary-outlined"
             >
@@ -58,7 +59,9 @@ const AdminProjectProposals = () => {
               <NewIdeaButton
                 participationMethod={phase.data.attributes.participation_method}
                 inputTerm={phase.data.attributes.input_term}
-                linkTo={`/projects/${project.data.attributes.slug}/ideas/new?phase_id=${phaseId}`}
+                to="/$locale/projects/$slug/ideas/new"
+                params={{ slug: project.data.attributes.slug }}
+                search={{ phase_id: phaseId }}
               />
             )}
           </Box>

--- a/front/app/containers/Admin/projects/project/surveyFormAssets/AccessRightsNotice/index.tsx
+++ b/front/app/containers/Admin/projects/project/surveyFormAssets/AccessRightsNotice/index.tsx
@@ -30,7 +30,7 @@ const AccessRightsNotice = ({
 
   const accessRightsSettingsLink = (
     <Link
-      to="/$locale/admin/projects/$projectId/phases/$phaseId/access-rights"
+      to="/admin/projects/$projectId/phases/$phaseId/access-rights"
       params={{ projectId, phaseId }}
     >
       {formatMessage(messages.accessRightsSettings)}

--- a/front/app/containers/Admin/projects/project/surveyFormAssets/SurveyFormBuilder/index.tsx
+++ b/front/app/containers/Admin/projects/project/surveyFormAssets/SurveyFormBuilder/index.tsx
@@ -46,7 +46,11 @@ const SurveyFormBuilder = ({
         formCustomFields: newCustomFields,
         goBackUrl: `/admin/projects/${projectId}/phases/${phaseId}/survey-form`,
       }}
-      viewFormLink={`/projects/${project.data.attributes.slug}/surveys/new?phase_id=${phase.data.id}`}
+      viewFormLink={{
+        to: '/projects/$slug/surveys/new',
+        params: { slug: project.data.attributes.slug },
+        search: { phase_id: phase.data.id },
+      }}
     />
   );
 };

--- a/front/app/containers/Admin/projects/project/volunteering/AllCauses.tsx
+++ b/front/app/containers/Admin/projects/project/volunteering/AllCauses.tsx
@@ -144,7 +144,7 @@ const AllCauses = ({ phaseId, projectId }: Props) => {
                   <FormattedMessage {...messages.deleteButtonLabel} />
                 </ButtonWithLink>
                 <ButtonWithLink
-                  to="/$locale/admin/projects/$projectId/phases/$phaseId/volunteering/causes/$causeId"
+                  to="/admin/projects/$projectId/phases/$phaseId/volunteering/causes/$causeId"
                   params={{ projectId, phaseId, causeId: cause.id }}
                   icon="edit"
                   buttonStyle="secondary-outlined"

--- a/front/app/containers/Admin/projects/project/volunteering/AllCauses.tsx
+++ b/front/app/containers/Admin/projects/project/volunteering/AllCauses.tsx
@@ -100,8 +100,6 @@ const AllCauses = ({ phaseId, projectId }: Props) => {
     }
   };
 
-  const newCauseLink = `/admin/projects/${projectId}/phases/${phaseId}/volunteering/causes/new`;
-
   if (isNilOrError(causes)) return null;
 
   return (
@@ -110,7 +108,8 @@ const AllCauses = ({ phaseId, projectId }: Props) => {
         <ButtonWithLink
           buttonStyle="admin-dark"
           icon="plus-circle"
-          linkTo={newCauseLink}
+          to="/admin/projects/$projectId/phases/$phaseId/volunteering/causes/new"
+          params={{ projectId, phaseId }}
         >
           <FormattedMessage {...messages.addCauseButton} />
         </ButtonWithLink>

--- a/front/app/containers/Admin/projects/project/volunteering/AllCauses.tsx
+++ b/front/app/containers/Admin/projects/project/volunteering/AllCauses.tsx
@@ -144,7 +144,8 @@ const AllCauses = ({ phaseId, projectId }: Props) => {
                   <FormattedMessage {...messages.deleteButtonLabel} />
                 </ButtonWithLink>
                 <ButtonWithLink
-                  linkTo={`/admin/projects/${projectId}/phases/${phaseId}/volunteering/causes/${cause.id}`}
+                  to="/$locale/admin/projects/$projectId/phases/$phaseId/volunteering/causes/$causeId"
+                  params={{ projectId, phaseId, causeId: cause.id }}
                   icon="edit"
                   buttonStyle="secondary-outlined"
                 >

--- a/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/index.tsx
+++ b/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/index.tsx
@@ -137,7 +137,11 @@ const ProjectFolderRow = memo<Props>(
                       'en-GB'
                     ] || ''
                   }`}
-                  linkTo={`/admin/projects/folders/${publication.relationships.publication.data.id}`}
+                  to="/$locale/admin/projects/folders/$projectFolderId"
+                  params={{
+                    projectFolderId:
+                      publication.relationships.publication.data.id,
+                  }}
                   buttonStyle="secondary-outlined"
                   icon="edit"
                   disabled={

--- a/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/index.tsx
+++ b/front/app/containers/Admin/projects/projectFolders/components/ProjectFolderRow/index.tsx
@@ -137,7 +137,7 @@ const ProjectFolderRow = memo<Props>(
                       'en-GB'
                     ] || ''
                   }`}
-                  to="/$locale/admin/projects/folders/$projectFolderId"
+                  to="/admin/projects/folders/$projectFolderId"
                   params={{
                     projectFolderId:
                       publication.relationships.publication.data.id,

--- a/front/app/containers/Admin/projects/routes.tsx
+++ b/front/app/containers/Admin/projects/routes.tsx
@@ -85,7 +85,7 @@ export function adminProjectsProjectPath(projectId: string) {
 
 export const adminProjectsProjectLink = (projectId: string) =>
   ({
-    to: '/$locale/admin/projects/$projectId',
+    to: '/admin/projects/$projectId',
     params: { projectId },
   } as const);
 

--- a/front/app/containers/Admin/projects/routes.tsx
+++ b/front/app/containers/Admin/projects/routes.tsx
@@ -83,6 +83,12 @@ export function adminProjectsProjectPath(projectId: string) {
   return `/admin/projects/${projectId}`;
 }
 
+export const adminProjectsProjectLink = (projectId: string) =>
+  ({
+    to: '/$locale/admin/projects/$projectId',
+    params: { projectId },
+  } as const);
+
 // --- Search parameter schemas ---
 
 // Survey form builder search schema

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Analysis/Analyses.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Analysis/Analyses.tsx
@@ -30,10 +30,21 @@ const Analyses = ({
     phaseId: participationMethod === 'native_survey' ? phaseId : undefined,
   });
 
-  const projectLink =
+  const projectLink: {
+    to:
+      | '/admin/projects/$projectId/phases/$phaseId/ideas'
+      | '/admin/projects/$projectId/phases/$phaseId/insights';
+    params: Record<string, string>;
+  } =
     participationMethod === 'ideation'
-      ? `/admin/projects/${projectId}/phases/${phaseId}/ideas`
-      : `/admin/projects/${projectId}/phases/${phaseId}/insights`;
+      ? {
+          to: '/admin/projects/$projectId/phases/$phaseId/ideas',
+          params: { projectId: projectId ?? '', phaseId: phaseId ?? '' },
+        }
+      : {
+          to: '/admin/projects/$projectId/phases/$phaseId/insights',
+          params: { projectId: projectId ?? '', phaseId: phaseId ?? '' },
+        };
 
   // Analyses related to specific survey questions are now handled in the Survey Question Widget
   const analysesWithoutMainCustomField = analyses?.data.filter(
@@ -47,7 +58,12 @@ const Analyses = ({
         <Text>{formatMessage(messages.noInsights)}</Text>
         <Box display="flex">
           <ButtonWithLink
-            linkTo={projectLink}
+            to={projectLink.to}
+            params={
+              projectLink.params as Parameters<
+                typeof ButtonWithLink
+              >[0]['params']
+            }
             buttonStyle="secondary-outlined"
             openLinkInNewTab
           >

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/SurveyQuestionResultWidget/Settings/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/SurveyQuestionResultWidget/Settings/index.tsx
@@ -243,7 +243,7 @@ const Settings = () => {
             mb="16px"
           >
             <ButtonWithLink
-              to="/$locale/admin/projects/$projectId/analysis/$analysisId"
+              to="/admin/projects/$projectId/analysis/$analysisId"
               params={{ projectId, analysisId: analysis.id }}
               search={{ phase_id: phaseId }}
             >

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/SurveyQuestionResultWidget/Settings/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/SurveyQuestionResultWidget/Settings/index.tsx
@@ -243,7 +243,9 @@ const Settings = () => {
             mb="16px"
           >
             <ButtonWithLink
-              linkTo={`/admin/projects/${projectId}/analysis/${analysis.id}?phase_id=${phaseId}`}
+              to="/$locale/admin/projects/$projectId/analysis/$analysisId"
+              params={{ projectId, analysisId: analysis.id }}
+              search={{ phase_id: phaseId }}
             >
               {formatMessage(messages.openAIAnalysis)}
             </ButtonWithLink>

--- a/front/app/containers/Admin/reporting/components/ReportBuilderPage/ReportRow/Buttons/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilderPage/ReportRow/Buttons/index.tsx
@@ -88,7 +88,8 @@ const Buttons = ({ reportId, showDuplicate = true }: Props) => {
           icon="edit"
           buttonStyle="secondary-outlined"
           disabled={isLoading || !canEdit}
-          linkTo={`/admin/reporting/report-builder/${reportId}/editor`}
+          to="/$locale/admin/reporting/report-builder/$reportId/editor"
+          params={{ reportId }}
         >
           {formatMessage(messages.edit)}
         </BaseButton>

--- a/front/app/containers/Admin/reporting/components/ReportBuilderPage/ReportRow/Buttons/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilderPage/ReportRow/Buttons/index.tsx
@@ -88,7 +88,7 @@ const Buttons = ({ reportId, showDuplicate = true }: Props) => {
           icon="edit"
           buttonStyle="secondary-outlined"
           disabled={isLoading || !canEdit}
-          to="/$locale/admin/reporting/report-builder/$reportId/editor"
+          to="/admin/reporting/report-builder/$reportId/editor"
           params={{ reportId }}
         >
           {formatMessage(messages.edit)}

--- a/front/app/containers/Admin/settings/areas/all/index.tsx
+++ b/front/app/containers/Admin/settings/areas/all/index.tsx
@@ -76,7 +76,7 @@ const AreaList = () => {
         <ButtonWithLink
           buttonStyle="admin-dark"
           icon="plus-circle"
-          linkTo="/admin/settings/areas/new"
+          to="/$locale/admin/settings/areas/new"
         >
           <FormattedMessage {...messages.addAreaButton} />
         </ButtonWithLink>
@@ -185,7 +185,8 @@ const AreaListRow = ({
         <FormattedMessage {...messages.deleteButtonLabel} />
       </ButtonWithLink>
       <ButtonWithLink
-        linkTo={`/admin/settings/areas/${item.id}`}
+        to="/$locale/admin/settings/areas/$areaId"
+        params={{ areaId: item.id }}
         buttonStyle="secondary-outlined"
         icon="edit"
       >

--- a/front/app/containers/Admin/settings/areas/all/index.tsx
+++ b/front/app/containers/Admin/settings/areas/all/index.tsx
@@ -76,7 +76,7 @@ const AreaList = () => {
         <ButtonWithLink
           buttonStyle="admin-dark"
           icon="plus-circle"
-          to="/$locale/admin/settings/areas/new"
+          to="/admin/settings/areas/new"
         >
           <FormattedMessage {...messages.addAreaButton} />
         </ButtonWithLink>
@@ -162,7 +162,7 @@ const AreaListRow = ({
                     return (
                       <li key={staticPage.id}>
                         <StyledLink
-                          to="/$locale/admin/pages-menu/pages/$customPageId/settings"
+                          to="/admin/pages-menu/pages/$customPageId/settings"
                           params={{ customPageId: staticPage.id }}
                         >
                           {localize(staticPage.attributes.title_multiloc)}
@@ -185,7 +185,7 @@ const AreaListRow = ({
         <FormattedMessage {...messages.deleteButtonLabel} />
       </ButtonWithLink>
       <ButtonWithLink
-        to="/$locale/admin/settings/areas/$areaId"
+        to="/admin/settings/areas/$areaId"
         params={{ areaId: item.id }}
         buttonStyle="secondary-outlined"
         icon="edit"

--- a/front/app/containers/Admin/settings/policies/index.tsx
+++ b/front/app/containers/Admin/settings/policies/index.tsx
@@ -34,7 +34,7 @@ const PoliciesTab = () => {
           {...messages.policiesSubtitle}
           values={{
             navigationLink: (
-              <StyledLink to="/$locale/admin/pages-menu">
+              <StyledLink to="/admin/pages-menu">
                 <FormattedMessage {...pagesAndMenuMessages.pagesAndMenuTitle} />
               </StyledLink>
             ),

--- a/front/app/containers/Admin/settings/registration/CustomFieldRoutes/RegistrationCustomFieldEdit/RegistrationCustomFieldOptions.tsx
+++ b/front/app/containers/Admin/settings/registration/CustomFieldRoutes/RegistrationCustomFieldEdit/RegistrationCustomFieldOptions.tsx
@@ -65,7 +65,8 @@ const RegistrationCustomFieldOptions = memo(
             <ButtonWithLink
               buttonStyle="admin-dark"
               icon="plus-circle"
-              linkTo={`/admin/settings/registration/custom-fields/${userCustomFieldId}/options/new`}
+              to="/$locale/admin/settings/registration/custom-fields/$userCustomFieldId/options/new"
+              params={{ userCustomFieldId }}
             >
               {formatMessage(messages.addOption)}
             </ButtonWithLink>
@@ -102,7 +103,11 @@ const RegistrationCustomFieldOptions = memo(
                           )}
                         </TextCell>
                         <ButtonWithLink
-                          linkTo={`/admin/settings/registration/custom-fields/${userCustomFieldId}/options/${userCustomFieldOptionId}`}
+                          to="/$locale/admin/settings/registration/custom-fields/$userCustomFieldId/options/$userCustomFieldOptionId"
+                          params={{
+                            userCustomFieldId,
+                            userCustomFieldOptionId,
+                          }}
                           buttonStyle="secondary-outlined"
                           icon="edit"
                         >

--- a/front/app/containers/Admin/settings/registration/CustomFieldRoutes/RegistrationCustomFieldEdit/RegistrationCustomFieldOptions.tsx
+++ b/front/app/containers/Admin/settings/registration/CustomFieldRoutes/RegistrationCustomFieldEdit/RegistrationCustomFieldOptions.tsx
@@ -65,7 +65,7 @@ const RegistrationCustomFieldOptions = memo(
             <ButtonWithLink
               buttonStyle="admin-dark"
               icon="plus-circle"
-              to="/$locale/admin/settings/registration/custom-fields/$userCustomFieldId/options/new"
+              to="/admin/settings/registration/custom-fields/$userCustomFieldId/options/new"
               params={{ userCustomFieldId }}
             >
               {formatMessage(messages.addOption)}
@@ -103,7 +103,7 @@ const RegistrationCustomFieldOptions = memo(
                           )}
                         </TextCell>
                         <ButtonWithLink
-                          to="/$locale/admin/settings/registration/custom-fields/$userCustomFieldId/options/$userCustomFieldOptionId"
+                          to="/admin/settings/registration/custom-fields/$userCustomFieldId/options/$userCustomFieldOptionId"
                           params={{
                             userCustomFieldId,
                             userCustomFieldOptionId,

--- a/front/app/containers/Admin/settings/registration/CustomFieldRoutes/RegistrationCustomFieldEdit/RegistrationCustomFieldOptionsForm.tsx
+++ b/front/app/containers/Admin/settings/registration/CustomFieldRoutes/RegistrationCustomFieldEdit/RegistrationCustomFieldOptionsForm.tsx
@@ -81,7 +81,7 @@ const RegistrationCustomFieldOptionsForm = ({
 
           <ButtonWithLink
             buttonStyle="text"
-            to="/$locale/admin/settings/registration/custom-fields/$userCustomFieldId/options"
+            to="/admin/settings/registration/custom-fields/$userCustomFieldId/options"
             params={{ userCustomFieldId }}
           >
             {formatMessage(messages.optionCancelButton)}

--- a/front/app/containers/Admin/settings/registration/CustomFieldRoutes/RegistrationCustomFieldEdit/RegistrationCustomFieldOptionsForm.tsx
+++ b/front/app/containers/Admin/settings/registration/CustomFieldRoutes/RegistrationCustomFieldEdit/RegistrationCustomFieldOptionsForm.tsx
@@ -81,7 +81,8 @@ const RegistrationCustomFieldOptionsForm = ({
 
           <ButtonWithLink
             buttonStyle="text"
-            linkTo={`/admin/settings/registration/custom-fields/${userCustomFieldId}/options/`}
+            to="/$locale/admin/settings/registration/custom-fields/$userCustomFieldId/options"
+            params={{ userCustomFieldId }}
           >
             {formatMessage(messages.optionCancelButton)}
           </ButtonWithLink>

--- a/front/app/containers/Admin/settings/registration/CustomFieldSettings/index.tsx
+++ b/front/app/containers/Admin/settings/registration/CustomFieldSettings/index.tsx
@@ -238,7 +238,8 @@ const CustomFieldSettings = () => {
                       {!isHiddenField(field) && (
                         <ButtonWithLink
                           className={`e2e-custom-field-edit-btn e2e-${field.attributes.title_multiloc['en-GB']} intercom-settings-tab-registration-fields-edit`}
-                          linkTo={`/admin/settings/registration/custom-fields/${field.id}/field-settings`}
+                          to="/$locale/admin/settings/registration/custom-fields/$userCustomFieldId/field-settings"
+                          params={{ userCustomFieldId: field.id }}
                           buttonStyle="secondary-outlined"
                           icon="edit"
                         >
@@ -258,7 +259,7 @@ const CustomFieldSettings = () => {
       <ButtonWithLink
         buttonStyle="admin-dark"
         icon="plus-circle"
-        linkTo="/admin/settings/registration/custom-fields/new"
+        to="/$locale/admin/settings/registration/custom-fields/new"
         className="intercom-settings-tab-registration-fields-new"
       >
         <FormattedMessage {...messages.addAQuestionButton} />

--- a/front/app/containers/Admin/settings/registration/CustomFieldSettings/index.tsx
+++ b/front/app/containers/Admin/settings/registration/CustomFieldSettings/index.tsx
@@ -190,7 +190,7 @@ const CustomFieldSettings = () => {
                                 {...messages.domicileManagementInfo}
                                 values={{
                                   geographicAreasTabLink: (
-                                    <Link to="/$locale/admin/settings/areas">
+                                    <Link to="/admin/settings/areas">
                                       {formatMessage(
                                         messages.geographicAreasTabLinkText
                                       )}
@@ -238,7 +238,7 @@ const CustomFieldSettings = () => {
                       {!isHiddenField(field) && (
                         <ButtonWithLink
                           className={`e2e-custom-field-edit-btn e2e-${field.attributes.title_multiloc['en-GB']} intercom-settings-tab-registration-fields-edit`}
-                          to="/$locale/admin/settings/registration/custom-fields/$userCustomFieldId/field-settings"
+                          to="/admin/settings/registration/custom-fields/$userCustomFieldId/field-settings"
                           params={{ userCustomFieldId: field.id }}
                           buttonStyle="secondary-outlined"
                           icon="edit"
@@ -259,7 +259,7 @@ const CustomFieldSettings = () => {
       <ButtonWithLink
         buttonStyle="admin-dark"
         icon="plus-circle"
-        to="/$locale/admin/settings/registration/custom-fields/new"
+        to="/admin/settings/registration/custom-fields/new"
         className="intercom-settings-tab-registration-fields-new"
       >
         <FormattedMessage {...messages.addAQuestionButton} />

--- a/front/app/containers/Admin/settings/statuses/components/EditStatusButton.tsx
+++ b/front/app/containers/Admin/settings/statuses/components/EditStatusButton.tsx
@@ -5,17 +5,13 @@ import { Tooltip, Box, TooltipProps } from '@citizenlab/cl2-component-library';
 import ButtonWithLink from 'components/UI/ButtonWithLink';
 
 import { FormattedMessage } from 'utils/cl-intl';
+import { type TypedLinkProps } from 'utils/cl-router/Link';
 
 import messages from './messages';
 
-import type { LinkProps } from '@tanstack/react-router';
-
-interface Props {
+interface Props extends TypedLinkProps {
   buttonDisabled: boolean;
   tooltipContent: TooltipProps['content'];
-  to?: LinkProps['to'];
-  params?: Record<string, string>;
-  search?: Record<string, unknown>;
   linkTo?: string;
 }
 

--- a/front/app/containers/Admin/settings/statuses/components/EditStatusButton.tsx
+++ b/front/app/containers/Admin/settings/statuses/components/EditStatusButton.tsx
@@ -8,15 +8,23 @@ import { FormattedMessage } from 'utils/cl-intl';
 
 import messages from './messages';
 
+import type { LinkProps } from '@tanstack/react-router';
+
 interface Props {
   buttonDisabled: boolean;
   tooltipContent: TooltipProps['content'];
-  linkTo: string;
+  to?: LinkProps['to'];
+  params?: Record<string, string>;
+  search?: Record<string, unknown>;
+  linkTo?: string;
 }
 
 const EditStatusButton = ({
   buttonDisabled,
   tooltipContent,
+  to,
+  params,
+  search,
   linkTo,
 }: Props) => {
   const tooltipDisabled = !buttonDisabled;
@@ -31,6 +39,9 @@ const EditStatusButton = ({
     >
       <Box>
         <ButtonWithLink
+          to={to}
+          params={params}
+          search={search}
           linkTo={linkTo}
           buttonStyle="secondary-outlined"
           icon="edit"

--- a/front/app/containers/Admin/settings/statuses/containers/index.tsx
+++ b/front/app/containers/Admin/settings/statuses/containers/index.tsx
@@ -135,7 +135,9 @@ const IdeaStatuses = ({
                 data-testid="e2e-add-status-button"
                 buttonStyle="admin-dark"
                 icon="plus-circle"
-                linkTo={`/admin/settings/statuses/${variant}/new`}
+                {...(variant === 'ideation'
+                  ? { to: '/admin/settings/statuses/ideation/new' as const }
+                  : { to: '/admin/settings/statuses/proposals/new' as const })}
                 disabled={!customIdeaStatusesAllowed}
               >
                 <FormattedMessage {...messages.addIdeaStatus} />
@@ -181,7 +183,15 @@ const IdeaStatuses = ({
                       tooltipContent={
                         <FormattedMessage {...messages.pricingPlanUpgrade} />
                       }
-                      linkTo={`/admin/settings/statuses/${variant}/${defaultStatus.id}`}
+                      {...(variant === 'ideation'
+                        ? {
+                            to: '/admin/settings/statuses/ideation/$statusId' as const,
+                            params: { statusId: defaultStatus.id },
+                          }
+                        : {
+                            to: '/admin/settings/statuses/proposals/$statusId' as const,
+                            params: { statusId: defaultStatus.id },
+                          })}
                     />
                   </Buttons>
                 </LockedRow>
@@ -231,7 +241,15 @@ const IdeaStatuses = ({
                       tooltipContent={
                         <FormattedMessage {...messages.pricingPlanUpgrade} />
                       }
-                      linkTo={`/admin/settings/statuses/${variant}/${ideaStatus.id}`}
+                      {...(variant === 'ideation'
+                        ? {
+                            to: '/admin/settings/statuses/ideation/$statusId' as const,
+                            params: { statusId: ideaStatus.id },
+                          }
+                        : {
+                            to: '/admin/settings/statuses/proposals/$statusId' as const,
+                            params: { statusId: ideaStatus.id },
+                          })}
                     />
                   </Buttons>
                 </SortableRow>

--- a/front/app/containers/Admin/settings/topics/default_input_topics/index.tsx
+++ b/front/app/containers/Admin/settings/topics/default_input_topics/index.tsx
@@ -143,7 +143,7 @@ const DefaultInputTopics = () => {
         <ButtonWithLink
           buttonStyle="admin-dark"
           icon="plus-circle"
-          linkTo="/admin/settings/topics/input/new"
+          to="/$locale/admin/settings/topics/input/new"
           id="e2e-add-default-input-topic-button"
         >
           <FormattedMessage {...messages.addDefaultInputTopicButton} />
@@ -173,7 +173,8 @@ const DefaultInputTopics = () => {
                   <Box display="flex" alignItems="center" gap="16px">
                     {nestedInputTopicsActive && isRootTopic && (
                       <ButtonWithLink
-                        linkTo={`/admin/settings/topics/input/new?parent_id=${topic.id}`}
+                        to="/$locale/admin/settings/topics/input/new"
+                        search={{ parent_id: topic.id }}
                         buttonStyle="secondary-outlined"
                         icon="plus-circle"
                         m="0px"
@@ -183,7 +184,8 @@ const DefaultInputTopics = () => {
                       </ButtonWithLink>
                     )}
                     <ButtonWithLink
-                      linkTo={`/admin/settings/topics/input/${topic.id}/edit`}
+                      to="/$locale/admin/settings/topics/input/$defaultInputTopicId/edit"
+                      params={{ defaultInputTopicId: topic.id }}
                       buttonStyle="secondary-outlined"
                       icon="edit"
                       m="0px"

--- a/front/app/containers/Admin/settings/topics/default_input_topics/index.tsx
+++ b/front/app/containers/Admin/settings/topics/default_input_topics/index.tsx
@@ -143,7 +143,7 @@ const DefaultInputTopics = () => {
         <ButtonWithLink
           buttonStyle="admin-dark"
           icon="plus-circle"
-          to="/$locale/admin/settings/topics/input/new"
+          to="/admin/settings/topics/input/new"
           id="e2e-add-default-input-topic-button"
         >
           <FormattedMessage {...messages.addDefaultInputTopicButton} />
@@ -173,7 +173,7 @@ const DefaultInputTopics = () => {
                   <Box display="flex" alignItems="center" gap="16px">
                     {nestedInputTopicsActive && isRootTopic && (
                       <ButtonWithLink
-                        to="/$locale/admin/settings/topics/input/new"
+                        to="/admin/settings/topics/input/new"
                         search={{ parent_id: topic.id }}
                         buttonStyle="secondary-outlined"
                         icon="plus-circle"
@@ -184,7 +184,7 @@ const DefaultInputTopics = () => {
                       </ButtonWithLink>
                     )}
                     <ButtonWithLink
-                      to="/$locale/admin/settings/topics/input/$defaultInputTopicId/edit"
+                      to="/admin/settings/topics/input/$defaultInputTopicId/edit"
                       params={{ defaultInputTopicId: topic.id }}
                       buttonStyle="secondary-outlined"
                       icon="edit"

--- a/front/app/containers/Admin/settings/topics/global_topics/TopicRow.tsx
+++ b/front/app/containers/Admin/settings/topics/global_topics/TopicRow.tsx
@@ -62,7 +62,7 @@ const DeleteButton = ({ topic, handleDeleteClick }: DeleteButtonProps) => {
         {staticPages.map((staticPage) => (
           <li key={staticPage.id}>
             <StyledLink
-              to="/$locale/admin/pages-menu/pages/$customPageId/settings"
+              to="/admin/pages-menu/pages/$customPageId/settings"
               params={{ customPageId: staticPage.id }}
             >
               {localize(staticPage.attributes.title_multiloc)}
@@ -128,7 +128,7 @@ const TopicRow = (props: Props) => {
       </Box>
       <Box display="flex" alignItems="center" gap="16px">
         <ButtonWithLink
-          to="/$locale/admin/settings/topics/platform/$topicId/edit"
+          to="/admin/settings/topics/platform/$topicId/edit"
           params={{ topicId: topic.id }}
           buttonStyle="secondary-outlined"
           icon="edit"

--- a/front/app/containers/Admin/settings/topics/global_topics/TopicRow.tsx
+++ b/front/app/containers/Admin/settings/topics/global_topics/TopicRow.tsx
@@ -128,7 +128,8 @@ const TopicRow = (props: Props) => {
       </Box>
       <Box display="flex" alignItems="center" gap="16px">
         <ButtonWithLink
-          linkTo={`/admin/settings/topics/platform/${topic.id}/edit`}
+          to="/$locale/admin/settings/topics/platform/$topicId/edit"
+          params={{ topicId: topic.id }}
           buttonStyle="secondary-outlined"
           icon="edit"
           m="0px"

--- a/front/app/containers/Admin/settings/topics/global_topics/index.tsx
+++ b/front/app/containers/Admin/settings/topics/global_topics/index.tsx
@@ -77,7 +77,7 @@ const AllTopics = () => {
         <ButtonWithLink
           buttonStyle="admin-dark"
           icon="plus-circle"
-          linkTo="/admin/settings/topics/platform/new"
+          to="/$locale/admin/settings/topics/platform/new"
           id="e2e-add-custom-topic-button"
         >
           <FormattedMessage {...messages.addTopicButton} />

--- a/front/app/containers/Admin/settings/topics/global_topics/index.tsx
+++ b/front/app/containers/Admin/settings/topics/global_topics/index.tsx
@@ -77,7 +77,7 @@ const AllTopics = () => {
         <ButtonWithLink
           buttonStyle="admin-dark"
           icon="plus-circle"
-          to="/$locale/admin/settings/topics/platform/new"
+          to="/admin/settings/topics/platform/new"
           id="e2e-add-custom-topic-button"
         >
           <FormattedMessage {...messages.addTopicButton} />

--- a/front/app/containers/Admin/sideBar/MenuItem.tsx
+++ b/front/app/containers/Admin/sideBar/MenuItem.tsx
@@ -10,7 +10,7 @@ import useFeatureFlags from 'hooks/useFeatureFlags';
 import CountBadge from 'components/UI/CountBadge';
 
 import { FormattedMessage } from 'utils/cl-intl';
-import Link from 'utils/cl-router/Link';
+import Link, { typedStyled } from 'utils/cl-router/Link';
 import { usePermission } from 'utils/permissions';
 import { isSuperAdmin } from 'utils/permissions/roles';
 import { useLocation } from 'utils/router';
@@ -33,7 +33,7 @@ const Text = styled.div`
   `}
 `;
 
-const MenuItemLink = styled(Link)<{ active: boolean }>`
+const MenuItemLink = typedStyled(Link)`
   flex: 0 0 auto;
   width: 224px;
   display: flex;
@@ -76,21 +76,6 @@ const MenuItemLink = styled(Link)<{ active: boolean }>`
     }
   }
 
-  ${({ active }) =>
-    active
-      ? `
-    background: rgba(0, 0, 0, 0.7);
-    .cl-icon {
-      .cl-icon-primary {
-        fill: ${colors.teal400};
-      }
-      .cl-icon-accent {
-        fill: ${colors.blue400};
-      }
-    }
-  `
-      : ''}
-
   ${media.tablet`
     width: 56px;
     padding-right: 5px;
@@ -132,8 +117,9 @@ const MenuItem = ({ navItem }: Props) => {
   return (
     <MenuItemLink
       to={navItem.link}
-      className={`intercom-admin-menu-item-${navItem.name}`}
-      active={inspirationHubActive}
+      className={`intercom-admin-menu-item-${navItem.name}${
+        inspirationHubActive ? ' active' : ''
+      }`}
     >
       <>
         <Box

--- a/front/app/containers/Admin/sideBar/UserMenu.tsx
+++ b/front/app/containers/Admin/sideBar/UserMenu.tsx
@@ -160,7 +160,8 @@ export const UserMenu = () => {
               </ItemMenu>
             )}
             <ItemMenu
-              linkTo={`/profile/${authUser.data.attributes.slug}`}
+              to="/$locale/profile/$userSlug"
+              params={{ userSlug: authUser.data.attributes.slug }}
               buttonStyle="text"
             >
               <Box display="flex" justifyContent="space-between" w="100%">

--- a/front/app/containers/Admin/sideBar/UserMenu.tsx
+++ b/front/app/containers/Admin/sideBar/UserMenu.tsx
@@ -160,7 +160,7 @@ export const UserMenu = () => {
               </ItemMenu>
             )}
             <ItemMenu
-              to="/$locale/profile/$userSlug"
+              to="/profile/$userSlug"
               params={{ userSlug: authUser.data.attributes.slug }}
               buttonStyle="text"
             >

--- a/front/app/containers/Admin/sideBar/index.tsx
+++ b/front/app/containers/Admin/sideBar/index.tsx
@@ -149,7 +149,7 @@ const Sidebar = ({ authUser }: Props) => {
            * making it unclear for screen readers what the link point to.
            * https://stackoverflow.com/a/53765144/7237112
            */}
-          <Link to="/$locale/" aria-label={formatMessage(messages.toPlatform)}>
+          <Link to="/" aria-label={formatMessage(messages.toPlatform)}>
             <Box
               height={
                 isPagesAndMenuPage ? `${stylingConsts.menuHeight}px` : '60px'

--- a/front/app/containers/Admin/spaces/EditSpace/index.tsx
+++ b/front/app/containers/Admin/spaces/EditSpace/index.tsx
@@ -53,7 +53,7 @@ const EditSpace = () => {
 
   return (
     <Box>
-      <GoBackButton linkTo={'/admin/projects?tab=spaces' as any} />
+      <GoBackButton to="/$locale/admin/projects" search={{ tab: 'spaces' }} />
       <TabbedResource {...tabbedProps}>
         <RouterOutlet />
       </TabbedResource>

--- a/front/app/containers/Admin/spaces/EditSpace/index.tsx
+++ b/front/app/containers/Admin/spaces/EditSpace/index.tsx
@@ -53,7 +53,7 @@ const EditSpace = () => {
 
   return (
     <Box>
-      <GoBackButton to="/$locale/admin/projects" search={{ tab: 'spaces' }} />
+      <GoBackButton to="/admin/projects" search={{ tab: 'spaces' }} />
       <TabbedResource {...tabbedProps}>
         <RouterOutlet />
       </TabbedResource>

--- a/front/app/containers/Admin/tools/Esri/index.tsx
+++ b/front/app/containers/Admin/tools/Esri/index.tsx
@@ -63,7 +63,7 @@ const Esri = () => {
               icon={isEsriEnabled ? 'arrow-right' : 'lock'}
               iconPos="right"
               width="fit-content"
-              to="/$locale/admin/tools/esri-integration"
+              to="/admin/tools/esri-integration"
             >
               {formatMessage(messages.esriIntegrationButton)}
             </ButtonWithLink>

--- a/front/app/containers/Admin/tools/Esri/index.tsx
+++ b/front/app/containers/Admin/tools/Esri/index.tsx
@@ -63,7 +63,7 @@ const Esri = () => {
               icon={isEsriEnabled ? 'arrow-right' : 'lock'}
               iconPos="right"
               width="fit-content"
-              linkTo="/admin/tools/esri-integration"
+              to="/$locale/admin/tools/esri-integration"
             >
               {formatMessage(messages.esriIntegrationButton)}
             </ButtonWithLink>

--- a/front/app/containers/Admin/tools/PowerBI/PowerBITemplates/index.tsx
+++ b/front/app/containers/Admin/tools/PowerBI/PowerBITemplates/index.tsx
@@ -58,7 +58,7 @@ const PowerBITemplates = () => {
           {...messages.intro}
           values={{
             link: (
-              <Link to="/$locale/admin/tools/public-api-tokens">
+              <Link to="/admin/tools/public-api-tokens">
                 {formatMessage(messages.publicApiLinkText)}
               </Link>
             ),

--- a/front/app/containers/Admin/tools/PowerBI/index.tsx
+++ b/front/app/containers/Admin/tools/PowerBI/index.tsx
@@ -63,7 +63,7 @@ const PowerBI = () => {
               iconColor={colors.white}
               iconPos="right"
               width="fit-content"
-              linkTo="/admin/tools/power-bi"
+              to="/$locale/admin/tools/power-bi"
               textColor="white"
               bgColor={colors.primary}
             >

--- a/front/app/containers/Admin/tools/PowerBI/index.tsx
+++ b/front/app/containers/Admin/tools/PowerBI/index.tsx
@@ -63,7 +63,7 @@ const PowerBI = () => {
               iconColor={colors.white}
               iconPos="right"
               width="fit-content"
-              to="/$locale/admin/tools/power-bi"
+              to="/admin/tools/power-bi"
               textColor="white"
               bgColor={colors.primary}
             >

--- a/front/app/containers/Admin/tools/PublicAPI/index.tsx
+++ b/front/app/containers/Admin/tools/PublicAPI/index.tsx
@@ -47,7 +47,7 @@ export const PublicAPI = () => {
               iconColor={colors.white}
               iconPos="right"
               width="fit-content"
-              linkTo="/admin/tools/public-api-tokens"
+              to="/$locale/admin/tools/public-api-tokens"
               textColor="white"
               bgColor={colors.primary}
             >

--- a/front/app/containers/Admin/tools/PublicAPI/index.tsx
+++ b/front/app/containers/Admin/tools/PublicAPI/index.tsx
@@ -47,7 +47,7 @@ export const PublicAPI = () => {
               iconColor={colors.white}
               iconPos="right"
               width="fit-content"
-              to="/$locale/admin/tools/public-api-tokens"
+              to="/admin/tools/public-api-tokens"
               textColor="white"
               bgColor={colors.primary}
             >

--- a/front/app/containers/Admin/tools/Webhooks/index.tsx
+++ b/front/app/containers/Admin/tools/Webhooks/index.tsx
@@ -47,7 +47,7 @@ export const Webhooks = () => {
               iconColor={colors.white}
               iconPos="right"
               width="fit-content"
-              linkTo="/admin/tools/webhooks"
+              to="/$locale/admin/tools/webhooks"
               textColor="white"
               bgColor={colors.primary}
             >

--- a/front/app/containers/Admin/tools/Webhooks/index.tsx
+++ b/front/app/containers/Admin/tools/Webhooks/index.tsx
@@ -47,7 +47,7 @@ export const Webhooks = () => {
               iconColor={colors.white}
               iconPos="right"
               width="fit-content"
-              to="/$locale/admin/tools/webhooks"
+              to="/admin/tools/webhooks"
               textColor="white"
               bgColor={colors.primary}
             >

--- a/front/app/containers/Admin/users/GroupsListPanel.tsx
+++ b/front/app/containers/Admin/users/GroupsListPanel.tsx
@@ -346,7 +346,7 @@ export const GroupsListPanel = ({ onCreateGroup, className }: Props) => {
       </GroupsList>
       <Box display="flex" flexGrow={1} />
       <ButtonWithLink
-        linkTo="/admin/users/invitations"
+        to="/$locale/admin/users/invitations"
         icon="email"
         className="intercom-users-invite-users-button"
       >

--- a/front/app/containers/Admin/users/GroupsListPanel.tsx
+++ b/front/app/containers/Admin/users/GroupsListPanel.tsx
@@ -207,13 +207,13 @@ export const GroupsListPanel = ({ onCreateGroup, className }: Props) => {
 
   return (
     <Container className={className}>
-      <MenuLink to="/$locale/admin/users" onlyActiveOnIndex>
+      <MenuLink to="/admin/users" onlyActiveOnIndex>
         <GroupName>
           <FormattedMessage {...messages.allUsers} />
         </GroupName>
         <MembersCount>{usersCount?.data.attributes.count}</MembersCount>
       </MenuLink>
-      <MenuLink to="/$locale/admin/users/admins">
+      <MenuLink to="/admin/users/admins">
         <GroupName>
           <FormattedMessage {...messages.admins} />
         </GroupName>
@@ -224,7 +224,7 @@ export const GroupsListPanel = ({ onCreateGroup, className }: Props) => {
         )}
       </MenuLink>
       {spacesEnabled && (
-        <MenuLink to="/$locale/admin/users/space-moderators">
+        <MenuLink to="/admin/users/space-moderators">
           <GroupName>
             <FormattedMessage {...messages.spaceManagers} />
           </GroupName>
@@ -235,7 +235,7 @@ export const GroupsListPanel = ({ onCreateGroup, className }: Props) => {
           )}
         </MenuLink>
       )}
-      <MenuLink to="/$locale/admin/users/folder-moderators">
+      <MenuLink to="/admin/users/folder-moderators">
         <GroupName>
           <FormattedMessage {...messages.folderManagers} />
         </GroupName>
@@ -245,7 +245,7 @@ export const GroupsListPanel = ({ onCreateGroup, className }: Props) => {
           </MembersCount>
         )}
       </MenuLink>
-      <MenuLink to="/$locale/admin/users/project-moderators">
+      <MenuLink to="/admin/users/project-moderators">
         <GroupName>
           <FormattedMessage {...messages.projectManagers} />
         </GroupName>
@@ -257,7 +257,7 @@ export const GroupsListPanel = ({ onCreateGroup, className }: Props) => {
       </MenuLink>
       {isUserBlockingEnabled && (
         <MenuLink
-          to="/$locale/admin/users/blocked"
+          to="/admin/users/blocked"
           data-testid="blocked-users-link"
           onlyActiveOnIndex
         >
@@ -272,7 +272,7 @@ export const GroupsListPanel = ({ onCreateGroup, className }: Props) => {
         </MenuLink>
       )}
       <MenuLink
-        to="/$locale/admin/users/banned-emails"
+        to="/admin/users/banned-emails"
         data-testid="banned-emails-link"
       >
         <GroupName>
@@ -324,7 +324,7 @@ export const GroupsListPanel = ({ onCreateGroup, className }: Props) => {
             >
               <MenuLink
                 key={group.id}
-                to="/$locale/admin/users/groups/$groupId"
+                to="/admin/users/groups/$groupId"
                 params={{ groupId: group.id }}
                 className={`${
                   highlightedGroups.has(group.id) ? 'highlight' : ''
@@ -346,7 +346,7 @@ export const GroupsListPanel = ({ onCreateGroup, className }: Props) => {
       </GroupsList>
       <Box display="flex" flexGrow={1} />
       <ButtonWithLink
-        to="/$locale/admin/users/invitations"
+        to="/admin/users/invitations"
         icon="email"
         className="intercom-users-invite-users-button"
       >

--- a/front/app/containers/Admin/users/SeatsOverview/index.tsx
+++ b/front/app/containers/Admin/users/SeatsOverview/index.tsx
@@ -57,7 +57,7 @@ const SeatsOverview = () => {
       alignItems="center"
     >
       <Box px="51px" maxWidth="1400px" w="100%">
-        <GoBackButton to="/$locale/admin/users" />
+        <GoBackButton to="/admin/users" />
         <Title>
           <FormattedMessage {...messages.seatsOverview} />
         </Title>

--- a/front/app/containers/Admin/users/SeatsOverview/index.tsx
+++ b/front/app/containers/Admin/users/SeatsOverview/index.tsx
@@ -57,7 +57,7 @@ const SeatsOverview = () => {
       alignItems="center"
     >
       <Box px="51px" maxWidth="1400px" w="100%">
-        <GoBackButton linkTo="/admin/users" />
+        <GoBackButton to="/$locale/admin/users" />
         <Title>
           <FormattedMessage {...messages.seatsOverview} />
         </Title>

--- a/front/app/containers/Admin/users/_shared/UserManager/NoUsers.tsx
+++ b/front/app/containers/Admin/users/_shared/UserManager/NoUsers.tsx
@@ -67,7 +67,7 @@ const NoUsers = memo(({ groupType, noSuchSearchResult }: Props) => {
             {...messages.goToAllUsers}
             values={{
               allUsersLink: (
-                <Link to="/$locale/admin/users/">
+                <Link to="/admin/users/">
                   <FormattedMessage {...messages.allUsers} />
                 </Link>
               ),

--- a/front/app/containers/Admin/users/_shared/UsersHeader.tsx
+++ b/front/app/containers/Admin/users/_shared/UsersHeader.tsx
@@ -65,14 +65,14 @@ const UsersHeader = memo(({ title, subtitle }: Props) => {
         {authUserIsAdmin && (
           <Box display="flex" flexDirection="row" alignItems="flex-start">
             <ButtonWithLink
-              to="/$locale/admin/users/seats"
+              to="/admin/users/seats"
               icon="shield-checkered"
               mr="12px"
             >
               <FormattedMessage {...messages.seatsOverview} />
             </ButtonWithLink>
             <ButtonWithLink
-              to="/$locale/admin/dashboard/users"
+              to="/admin/dashboard/users"
               text={<FormattedMessage {...messages.userInsights} />}
               icon="chart-bar"
               buttonStyle="secondary-outlined"

--- a/front/app/containers/Admin/users/_shared/UsersHeader.tsx
+++ b/front/app/containers/Admin/users/_shared/UsersHeader.tsx
@@ -65,14 +65,14 @@ const UsersHeader = memo(({ title, subtitle }: Props) => {
         {authUserIsAdmin && (
           <Box display="flex" flexDirection="row" alignItems="flex-start">
             <ButtonWithLink
-              linkTo="/admin/users/seats"
+              to="/$locale/admin/users/seats"
               icon="shield-checkered"
               mr="12px"
             >
               <FormattedMessage {...messages.seatsOverview} />
             </ButtonWithLink>
             <ButtonWithLink
-              linkTo="/admin/dashboard/users"
+              to="/$locale/admin/dashboard/users"
               text={<FormattedMessage {...messages.userInsights} />}
               icon="chart-bar"
               buttonStyle="secondary-outlined"

--- a/front/app/containers/Authentication/steps/InviteSignUp/index.tsx
+++ b/front/app/containers/Authentication/steps/InviteSignUp/index.tsx
@@ -112,7 +112,11 @@ const InviteSignUp = ({ state, loading, setError, onSubmit }: Props) => {
                     {...commentsMessages.profanityError}
                     values={{
                       guidelinesLink: (
-                        <Link to="/$locale/pages/$slug" params={{ slug: "faq" }} target="_blank">
+                        <Link
+                          to="/pages/$slug"
+                          params={{ slug: 'faq' }}
+                          target="_blank"
+                        >
                           {formatMessage(commentsMessages.guidelinesLinkText)}
                         </Link>
                       ),

--- a/front/app/containers/Authentication/steps/Password/index.tsx
+++ b/front/app/containers/Authentication/steps/Password/index.tsx
@@ -150,7 +150,7 @@ const Password = ({ state, loading, setError, onSubmit, onClose }: Props) => {
         </Box>
       </form>
       <Box mt="32px">
-        <TextLink to="/$locale/password-recovery" onClick={onClose}>
+        <TextLink to="/password-recovery" onClick={onClose}>
           {formatMessage(sharedMessages.forgotPassword)}
         </TextLink>
       </Box>

--- a/front/app/containers/Authentication/steps/Policies/PoliciesMarkup.tsx
+++ b/front/app/containers/Authentication/steps/Policies/PoliciesMarkup.tsx
@@ -55,7 +55,11 @@ const PoliciesMarkup = ({ showByContinuingText = true }: Props) => {
                 {...authProvidersMessages.iHaveReadAndAgreeToTerms}
                 values={{
                   link: (
-                    <Link target="_blank" to="/$locale/pages/$slug" params={{ slug: "terms-and-conditions" }}>
+                    <Link
+                      target="_blank"
+                      to="/pages/$slug"
+                      params={{ slug: 'terms-and-conditions' }}
+                    >
                       <FormattedMessage
                         {...authProvidersMessages.theTermsAndConditions}
                       />
@@ -78,7 +82,11 @@ const PoliciesMarkup = ({ showByContinuingText = true }: Props) => {
                 {...authProvidersMessages.iHaveReadAndAgreeToPrivacy}
                 values={{
                   link: (
-                    <Link target="_blank" to="/$locale/pages/$slug" params={{ slug: "privacy-policy" }}>
+                    <Link
+                      target="_blank"
+                      to="/pages/$slug"
+                      params={{ slug: 'privacy-policy' }}
+                    >
                       <FormattedMessage
                         {...authProvidersMessages.thePrivacyPolicy}
                       />

--- a/front/app/containers/Authentication/steps/_components/AuthProviderButton/Consent.tsx
+++ b/front/app/containers/Authentication/steps/_components/AuthProviderButton/Consent.tsx
@@ -99,7 +99,11 @@ const Consent = memo(
               {...messages.iHaveReadAndAgreeToVienna}
               values={{
                 link: (
-                  <Link target="_blank" to="/$locale/pages/$slug" params={{ slug: "privacy-policy" }}>
+                  <Link
+                    target="_blank"
+                    to="/pages/$slug"
+                    params={{ slug: 'privacy-policy' }}
+                  >
                     <FormattedMessage {...messages.viennaDataProtection} />
                   </Link>
                 ),
@@ -123,7 +127,11 @@ const Consent = memo(
                     {...messages.iHaveReadAndAgreeToTerms}
                     values={{
                       link: (
-                        <Link target="_blank" to="/$locale/pages/$slug" params={{ slug: "terms-and-conditions" }}>
+                        <Link
+                          target="_blank"
+                          to="/pages/$slug"
+                          params={{ slug: 'terms-and-conditions' }}
+                        >
                           <FormattedMessage
                             {...messages.theTermsAndConditions}
                           />
@@ -155,7 +163,11 @@ const Consent = memo(
                     {...messages.iHaveReadAndAgreeToPrivacy}
                     values={{
                       link: (
-                        <Link target="_blank" to="/$locale/pages/$slug" params={{ slug: "privacy-policy" }}>
+                        <Link
+                          target="_blank"
+                          to="/pages/$slug"
+                          params={{ slug: 'privacy-policy' }}
+                        >
                           <FormattedMessage {...messages.thePrivacyPolicy} />
                         </Link>
                       ),

--- a/front/app/containers/CustomPageShow/CustomPageHeader/AdminCustomPageEditButton.tsx
+++ b/front/app/containers/CustomPageShow/CustomPageHeader/AdminCustomPageEditButton.tsx
@@ -4,7 +4,7 @@ import { WrappedComponentProps } from 'react-intl';
 
 import useAuthUser from 'api/me/useAuthUser';
 
-import { adminCustomPageContentPath } from 'containers/Admin/pagesAndMenu/routes';
+import { adminCustomPageContentLink } from 'containers/Admin/pagesAndMenu/routes';
 
 import ButtonWithLink from 'components/UI/ButtonWithLink';
 
@@ -29,7 +29,7 @@ const AdminCustomPageEditButton = ({
   return userCanEditPage ? (
     <ButtonWithLink
       icon="edit"
-      linkTo={adminCustomPageContentPath(pageId)}
+      {...adminCustomPageContentLink(pageId)}
       buttonStyle="secondary-outlined"
       padding="5px 8px"
       position="absolute"

--- a/front/app/containers/DescriptionBuilder/FolderDescriptionBuilder/index.tsx
+++ b/front/app/containers/DescriptionBuilder/FolderDescriptionBuilder/index.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
-import { useParams } from 'utils/router';
-
 import useProjectFolderById from 'api/project_folders/useProjectFolderById';
 
 import DescriptionBuilderPage from 'containers/DescriptionBuilder/index';
+
+import { useParams } from 'utils/router';
 
 const FolderDescriptionBuilderPage = () => {
   const { folderId } = useParams({ strict: false }) as { folderId: string };
@@ -18,7 +18,10 @@ const FolderDescriptionBuilderPage = () => {
       contentBuildableId={folderId}
       contentBuildableType="folder"
       backPath={`/admin/projects/folders/${folderId}/settings`}
-      previewPath={`/folders/${folder.data.attributes.slug}`}
+      previewLink={{
+        to: '/folders/$slug',
+        params: { slug: folder.data.attributes.slug },
+      }}
       titleMultiloc={folder.data.attributes.title_multiloc}
     />
   );

--- a/front/app/containers/DescriptionBuilder/ProjectDescriptionBuilder/index.tsx
+++ b/front/app/containers/DescriptionBuilder/ProjectDescriptionBuilder/index.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
-import { useParams } from 'utils/router';
-
 import useProjectById from 'api/projects/useProjectById';
 
 import DescriptionBuilderPage from 'containers/DescriptionBuilder/index';
+
+import { useParams } from 'utils/router';
 
 const ProjectDescriptionBuilderPage = () => {
   const { projectId } = useParams({ strict: false }) as { projectId: string };
@@ -18,7 +18,10 @@ const ProjectDescriptionBuilderPage = () => {
       contentBuildableId={projectId}
       contentBuildableType="project"
       backPath={`/admin/projects/${projectId}/general`}
-      previewPath={`/projects/${project.data.attributes.slug}`}
+      previewLink={{
+        to: '/projects/$slug',
+        params: { slug: project.data.attributes.slug },
+      }}
       titleMultiloc={project.data.attributes.title_multiloc}
     />
   );

--- a/front/app/containers/DescriptionBuilder/index.tsx
+++ b/front/app/containers/DescriptionBuilder/index.tsx
@@ -3,7 +3,6 @@ import React, { useState, useRef, useCallback } from 'react';
 import { Box, stylingConsts } from '@citizenlab/cl2-component-library';
 import { SerializedNodes } from '@craftjs/core';
 import { isEmpty } from 'lodash-es';
-import { useLocation } from 'utils/router';
 import { Multiloc, SupportedLocale } from 'typings';
 
 import { ContentBuildableType } from 'api/content_builder/types';
@@ -25,13 +24,15 @@ import DescriptionBuilderTopBar from 'components/DescriptionBuilder/DescriptionB
 import Editor from 'components/DescriptionBuilder/Editor';
 import ContentBuilderSettings from 'components/DescriptionBuilder/Settings';
 
+import { type TypedLinkProps } from 'utils/cl-router/Link';
 import { isNilOrError } from 'utils/helperUtils';
+import { useLocation } from 'utils/router';
 
 type Props = {
   contentBuildableId: string;
   contentBuildableType: ContentBuildableType;
   backPath: string;
-  previewPath: string;
+  previewLink: TypedLinkProps;
   titleMultiloc: Multiloc;
 };
 
@@ -39,7 +40,7 @@ const DescriptionBuilderPage = ({
   contentBuildableId,
   contentBuildableType,
   backPath,
-  previewPath,
+  previewLink,
   titleMultiloc,
 }: Props) => {
   const locale = useLocale();
@@ -149,7 +150,7 @@ const DescriptionBuilderPage = ({
             contentBuildableId={contentBuildableId}
             contentBuildableType={contentBuildableType}
             backPath={backPath}
-            previewPath={previewPath}
+            previewLink={previewLink}
             titleMultiloc={titleMultiloc}
           />
           <Box

--- a/front/app/containers/DisabledAccount/index.tsx
+++ b/front/app/containers/DisabledAccount/index.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 
 import { Box, Text } from '@citizenlab/cl2-component-library';
 import moment from 'moment';
-import { useSearch } from 'utils/router';
 
 import ContentContainer from 'components/ContentContainer';
 import { Title } from 'components/smallForm';
 
 import { FormattedMessage } from 'utils/cl-intl';
 import Link from 'utils/cl-router/Link';
+import { useSearch } from 'utils/router';
 
 import messages from './messages';
 
@@ -33,7 +33,10 @@ const DisabledAccount = () => {
               {...messages.text}
               values={{
                 TermsAndConditions: (
-                  <Link to="/$locale/pages/$slug" params={{ slug: "terms-and-conditions" }}>
+                  <Link
+                    to="/pages/$slug"
+                    params={{ slug: 'terms-and-conditions' }}
+                  >
                     <FormattedMessage {...messages.termsAndConditions} />
                   </Link>
                 ),

--- a/front/app/containers/EventsShowPage/components/ProjectLink.tsx
+++ b/front/app/containers/EventsShowPage/components/ProjectLink.tsx
@@ -53,7 +53,7 @@ const ProjectLink = ({ project }: ProjectLinkProps) => {
             projectTitle: projectTitleLocalized,
           })}
         </Text>
-        <Link to="/$locale/projects/$slug" params={{ slug: projectSlug }}>
+        <Link to="/projects/$slug" params={{ slug: projectSlug }}>
           <Text
             fontSize={isMobileOrSmaller ? 'xs' : 's'}
             p="0px"

--- a/front/app/containers/HomePage/SignedInHeader/AcceptButton.tsx
+++ b/front/app/containers/HomePage/SignedInHeader/AcceptButton.tsx
@@ -5,6 +5,8 @@ import styled, { useTheme } from 'styled-components';
 
 import ButtonWithLink from 'components/UI/ButtonWithLink';
 
+import type { LinkProps } from '@tanstack/react-router';
+
 const StyledButton = styled(ButtonWithLink)`
   ${media.tablet`
   order: 1;
@@ -19,12 +21,23 @@ const StyledButton = styled(ButtonWithLink)`
 
 interface Props {
   onClick?: () => void;
+  to?: LinkProps['to'];
+  params?: Record<string, string>;
+  search?: Record<string, unknown>;
   linkTo?: string;
   className?: string;
   text: string;
 }
 
-const AcceptButton = ({ onClick, linkTo, className, text }: Props) => {
+const AcceptButton = ({
+  onClick,
+  to,
+  params,
+  search,
+  linkTo,
+  className,
+  text,
+}: Props) => {
   const theme = useTheme();
 
   return (
@@ -32,6 +45,9 @@ const AcceptButton = ({ onClick, linkTo, className, text }: Props) => {
       text={text}
       buttonStyle="primary-inverse"
       onClick={onClick}
+      to={to}
+      params={params}
+      search={search}
       linkTo={linkTo}
       textColor={theme.colors.tenantPrimary}
       textHoverColor={theme.colors.tenantPrimary}

--- a/front/app/containers/HomePage/SignedInHeader/AcceptButton.tsx
+++ b/front/app/containers/HomePage/SignedInHeader/AcceptButton.tsx
@@ -5,7 +5,7 @@ import styled, { useTheme } from 'styled-components';
 
 import ButtonWithLink from 'components/UI/ButtonWithLink';
 
-import type { LinkProps } from '@tanstack/react-router';
+import { type TypedLinkProps } from 'utils/cl-router/Link';
 
 const StyledButton = styled(ButtonWithLink)`
   ${media.tablet`
@@ -19,11 +19,8 @@ const StyledButton = styled(ButtonWithLink)`
 `}
 `;
 
-interface Props {
+interface Props extends TypedLinkProps {
   onClick?: () => void;
-  to?: LinkProps['to'];
-  params?: Record<string, string>;
-  search?: Record<string, unknown>;
   linkTo?: string;
   className?: string;
   text: string;

--- a/front/app/containers/HomePage/SignedInHeader/CompleteProfileStep.tsx
+++ b/front/app/containers/HomePage/SignedInHeader/CompleteProfileStep.tsx
@@ -69,7 +69,7 @@ const CompleteProfileStep = ({
               className="e2e-signed-in-header-complete-skip-btn"
             />
             <AcceptButton
-              linkTo="/profile/edit"
+              to="/$locale/profile/edit"
               className="e2e-signed-in-header-accept-btn"
               text={formatMessage(messages.completeProfile)}
             />

--- a/front/app/containers/HomePage/SignedInHeader/CompleteProfileStep.tsx
+++ b/front/app/containers/HomePage/SignedInHeader/CompleteProfileStep.tsx
@@ -69,7 +69,7 @@ const CompleteProfileStep = ({
               className="e2e-signed-in-header-complete-skip-btn"
             />
             <AcceptButton
-              to="/$locale/profile/edit"
+              to="/profile/edit"
               className="e2e-signed-in-header-accept-btn"
               text={formatMessage(messages.completeProfile)}
             />

--- a/front/app/containers/IdeaHeading/NewIdeaHeading/index.tsx
+++ b/front/app/containers/IdeaHeading/NewIdeaHeading/index.tsx
@@ -9,7 +9,6 @@ import {
   stylingConsts,
   Title,
 } from '@citizenlab/cl2-component-library';
-import { useParams, useSearch } from 'utils/router';
 import styled from 'styled-components';
 
 import useAuthUser from 'api/me/useAuthUser';
@@ -22,6 +21,7 @@ import Modal from 'components/UI/Modal';
 import { FormattedMessage, useIntl } from 'utils/cl-intl';
 import clHistory from 'utils/cl-router/history';
 import { canModerateProject } from 'utils/permissions/rules/projectPermissions';
+import { useParams, useSearch } from 'utils/router';
 
 import messages from '../messages';
 
@@ -67,7 +67,10 @@ const NewIdeaHeading = ({ phase, titleText }: Props) => {
     !isSmallerThanPhone &&
     canModerateProject(project.data, authUser) &&
     !isCommonGround;
-  const linkToFormBuilder = `/admin/projects/${project.data.id}/phases/${phaseId}/form/edit`;
+  const linkToFormBuilder = {
+    to: '/admin/projects/$projectId/phases/$phaseId/form/edit',
+    params: { projectId: project.data.id, phaseId },
+  } as const;
 
   const onClickClose = () => {
     const pathname = isCommonGround
@@ -112,7 +115,7 @@ const NewIdeaHeading = ({ phase, titleText }: Props) => {
           {showEditFormButton && (
             <ButtonWithLink
               icon="edit"
-              linkTo={linkToFormBuilder}
+              {...linkToFormBuilder}
               buttonStyle="primary-inverse"
               textDecorationHover="underline"
               mr="12px"

--- a/front/app/containers/IdeasFeedPage/Sidebar/TopicsContent.tsx
+++ b/front/app/containers/IdeasFeedPage/Sidebar/TopicsContent.tsx
@@ -65,7 +65,8 @@ const TopicsContent = ({
     <>
       <Box px="16px" mb="16px">
         <GoBackButton
-          linkTo={`/projects/${slug}`}
+          to="/$locale/projects/$slug"
+          params={{ slug }}
           size="s"
           customMessage={messages.back}
           iconSize="20px"

--- a/front/app/containers/IdeasFeedPage/Sidebar/TopicsContent.tsx
+++ b/front/app/containers/IdeasFeedPage/Sidebar/TopicsContent.tsx
@@ -65,7 +65,7 @@ const TopicsContent = ({
     <>
       <Box px="16px" mb="16px">
         <GoBackButton
-          to="/$locale/projects/$slug"
+          to="/projects/$slug"
           params={{ slug }}
           size="s"
           customMessage={messages.back}

--- a/front/app/containers/IdeasFeedPage/index.tsx
+++ b/front/app/containers/IdeasFeedPage/index.tsx
@@ -7,6 +7,7 @@ import useProjectBySlug from 'api/projects/useProjectBySlug';
 
 import GoBackButton from 'components/UI/GoBackButton';
 
+import { type TypedLinkProps } from 'utils/cl-router/Link';
 import { removeSearchParams } from 'utils/cl-router/removeSearchParams';
 import { updateSearchParams } from 'utils/cl-router/updateSearchParams';
 import { useParams, useSearch } from 'utils/router';
@@ -61,10 +62,10 @@ const IdeasFeedPage = () => {
     // If sheet is open without subtopic -> handled by linkTo (exit to project)
   };
 
-  const getMobileBackLinkTo = (): string | undefined => {
+  const getMobileBackLink = (): TypedLinkProps | undefined => {
     // Only exit to project when sheet is open and no subtopic selected
     if (sheetOpen && !selectedSubtopicId) {
-      return `/projects/${slug}`;
+      return { to: '/projects/$slug', params: { slug } };
     }
     return undefined;
   };
@@ -80,10 +81,8 @@ const IdeasFeedPage = () => {
         {isMobileOrSmaller && (
           <Box position="absolute" top="16px" left="16px" zIndex="1">
             <GoBackButton
-              linkTo={getMobileBackLinkTo()}
-              onClick={
-                getMobileBackLinkTo() ? undefined : handleMobileBackClick
-              }
+              {...getMobileBackLink()}
+              onClick={getMobileBackLink() ? undefined : handleMobileBackClick}
               showGoBackText={false}
               buttonStyle="white"
             />

--- a/front/app/containers/IdeasNewPage/SimilarInputs/InputDetailView.tsx
+++ b/front/app/containers/IdeasNewPage/SimilarInputs/InputDetailView.tsx
@@ -151,7 +151,7 @@ const IdeaDetailView = ({ ideaId, onClose }: IdeaDetailViewProps) => {
         <ButtonWithLink
           width="100%"
           buttonStyle="primary"
-          to="/$locale/ideas/$slug"
+          to="/ideas/$slug"
           params={{ slug: idea.data.attributes.slug }}
           bgColor={colors.primary}
           onClick={() => {

--- a/front/app/containers/IdeasNewPage/SimilarInputs/InputDetailView.tsx
+++ b/front/app/containers/IdeasNewPage/SimilarInputs/InputDetailView.tsx
@@ -151,7 +151,8 @@ const IdeaDetailView = ({ ideaId, onClose }: IdeaDetailViewProps) => {
         <ButtonWithLink
           width="100%"
           buttonStyle="primary"
-          linkTo={`/ideas/${idea.data.attributes.slug}`}
+          to="/$locale/ideas/$slug"
+          params={{ slug: idea.data.attributes.slug }}
           bgColor={colors.primary}
           onClick={() => {
             trackEventByName(tracks.clickedSimilarInputFromSuggestions);

--- a/front/app/containers/IdeasNewSurveyPage/IdeasNewSurveyForm/SurveyHeading/index.tsx
+++ b/front/app/containers/IdeasNewSurveyPage/IdeasNewSurveyForm/SurveyHeading/index.tsx
@@ -9,7 +9,6 @@ import {
   stylingConsts,
   Title,
 } from '@citizenlab/cl2-component-library';
-import { useParams, useSearch } from 'utils/router';
 import styled from 'styled-components';
 
 import ideasKeys from 'api/ideas/keys';
@@ -24,6 +23,7 @@ import { FormattedMessage, useIntl } from 'utils/cl-intl';
 import { queryClient } from 'utils/cl-react-query/queryClient';
 import clHistory from 'utils/cl-router/history';
 import { canModerateProject } from 'utils/permissions/rules/projectPermissions';
+import { useParams, useSearch } from 'utils/router';
 
 import { getLeaveFormDestination } from '../utils';
 
@@ -71,10 +71,21 @@ const SurveyHeading = ({ titleText, phaseId }: Props) => {
 
   const showEditSurveyButton =
     !isSmallerThanPhone && canModerateProject(project.data, authUser);
-  const linkToSurveyBuilder: string =
+  const linkToSurveyBuilder: {
+    to:
+      | '/admin/community-monitor/projects/$projectId/phases/$phaseId/survey/edit'
+      | '/admin/projects/$projectId/phases/$phaseId/survey-form/edit';
+    params: Record<string, string>;
+  } =
     phaseParticipationMethod === 'community_monitor_survey'
-      ? `/admin/community-monitor/projects/${project.data.id}/phases/${phaseId}/survey/edit`
-      : `/admin/projects/${project.data.id}/phases/${phaseId}/survey-form/edit`;
+      ? {
+          to: '/admin/community-monitor/projects/$projectId/phases/$phaseId/survey/edit',
+          params: { projectId: project.data.id, phaseId },
+        }
+      : {
+          to: '/admin/projects/$projectId/phases/$phaseId/survey-form/edit',
+          params: { projectId: project.data.id, phaseId },
+        };
 
   const leaveForm = () => {
     const leaveFormDestination = getLeaveFormDestination(
@@ -135,7 +146,12 @@ const SurveyHeading = ({ titleText, phaseId }: Props) => {
             <ButtonWithLink
               data-cy="e2e-edit-survey-link"
               icon="edit"
-              linkTo={linkToSurveyBuilder}
+              to={linkToSurveyBuilder.to}
+              params={
+                linkToSurveyBuilder.params as Parameters<
+                  typeof ButtonWithLink
+                >[0]['params']
+              }
               buttonStyle="primary-inverse"
               textDecorationHover="underline"
               mr="12px"

--- a/front/app/containers/MainHeader/Components/DesktopNavItems/AdminPublicationsNavbarItem.tsx
+++ b/front/app/containers/MainHeader/Components/DesktopNavItems/AdminPublicationsNavbarItem.tsx
@@ -220,7 +220,7 @@ const AdminPublicationsNavbarItem = ({
                   <React.Fragment key={item.id}>
                     {item.relationships.publication.data.type === 'project' && (
                       <ProjectsListItem
-                        to="/$locale/projects/$slug"
+                        to="/projects/$slug"
                         params={{ slug: item.attributes.publication_slug }}
                         scrollToTop
                       >
@@ -229,7 +229,7 @@ const AdminPublicationsNavbarItem = ({
                     )}
                     {item.relationships.publication.data.type === 'folder' && (
                       <ProjectsListItem
-                        to="/$locale/folders/$slug"
+                        to="/folders/$slug"
                         params={{ slug: item.attributes.publication_slug }}
                         scrollToTop
                       >
@@ -248,7 +248,7 @@ const AdminPublicationsNavbarItem = ({
           <>
             {totalProjectsListLength > 9 && (
               <ProjectsListFooter
-                to="/$locale/projects"
+                to="/projects"
                 id="e2e-all-projects-link"
                 scrollToTop
               >

--- a/front/app/containers/MainHeader/Components/DesktopNavItems/DesktopNavbarItem.tsx
+++ b/front/app/containers/MainHeader/Components/DesktopNavItems/DesktopNavbarItem.tsx
@@ -9,6 +9,8 @@ import T from 'components/T';
 
 import Link, { typedStyled } from 'utils/cl-router/Link';
 
+import type { LinkProps } from '@tanstack/react-router';
+
 const NavigationItemBorder = styled.div`
   height: 6px;
   position: absolute;
@@ -67,18 +69,30 @@ const StyledLink = typedStyled(Link)`
 
 interface Props {
   className?: string;
-  linkTo: string;
+  to?: LinkProps['to'];
+  params?: Record<string, string>;
+  search?: Record<string, unknown>;
+  linkTo?: string;
   navigationItemTitle: Multiloc;
   onlyActiveOnIndex?: boolean;
 }
 
 const DesktopNavbarItem = ({
+  to,
+  params,
+  search,
   linkTo,
   navigationItemTitle,
   onlyActiveOnIndex,
 }: Props) => (
   <NavigationItem data-testid="desktop-navbar-item">
-    <StyledLink to={linkTo} onlyActiveOnIndex={onlyActiveOnIndex} scrollToTop>
+    <StyledLink
+      to={(to ?? linkTo) as Parameters<typeof StyledLink>[0]['to']}
+      params={params as Parameters<typeof StyledLink>[0]['params']}
+      search={search as Parameters<typeof StyledLink>[0]['search']}
+      onlyActiveOnIndex={onlyActiveOnIndex}
+      scrollToTop
+    >
       <NavigationItemBorder />
       <T value={navigationItemTitle} />
     </StyledLink>

--- a/front/app/containers/MainHeader/Components/DesktopNavItems/DesktopNavbarItem.tsx
+++ b/front/app/containers/MainHeader/Components/DesktopNavItems/DesktopNavbarItem.tsx
@@ -7,9 +7,7 @@ import { Multiloc } from 'typings';
 
 import T from 'components/T';
 
-import Link, { typedStyled } from 'utils/cl-router/Link';
-
-import type { LinkProps } from '@tanstack/react-router';
+import Link, { typedStyled, type TypedLinkProps } from 'utils/cl-router/Link';
 
 const NavigationItemBorder = styled.div`
   height: 6px;
@@ -67,11 +65,8 @@ const StyledLink = typedStyled(Link)`
   }
 `;
 
-interface Props {
+interface Props extends TypedLinkProps {
   className?: string;
-  to?: LinkProps['to'];
-  params?: Record<string, string>;
-  search?: Record<string, unknown>;
   linkTo?: string;
   navigationItemTitle: Multiloc;
   onlyActiveOnIndex?: boolean;

--- a/front/app/containers/MainHeader/Components/DesktopNavItems/MoreNavbarItem.tsx
+++ b/front/app/containers/MainHeader/Components/DesktopNavItems/MoreNavbarItem.tsx
@@ -16,6 +16,8 @@ import Link, { typedStyled } from 'utils/cl-router/Link';
 
 import messages from '../../messages';
 
+import type { LinkProps } from '@tanstack/react-router';
+
 const DropdownListItem = typedStyled(Link)`
   display: flex;
   align-items: center;
@@ -69,7 +71,10 @@ const StyledButton = styled.button`
 `;
 
 interface NavbarItemProps {
-  linkTo: string;
+  to?: LinkProps['to'];
+  params?: Record<string, string>;
+  search?: Record<string, unknown>;
+  linkTo?: string;
   navigationItemTitle: Multiloc;
   onlyActiveOnIndex?: boolean;
 }
@@ -112,7 +117,21 @@ const MoreNavbarItem = ({ overflowItems }: Props) => {
             {overflowItems.map((item, index) => (
               <DropdownListItem
                 key={index}
-                to={item.linkTo}
+                to={
+                  (item.to ?? item.linkTo) as Parameters<
+                    typeof DropdownListItem
+                  >[0]['to']
+                }
+                params={
+                  item.params as Parameters<
+                    typeof DropdownListItem
+                  >[0]['params']
+                }
+                search={
+                  item.search as Parameters<
+                    typeof DropdownListItem
+                  >[0]['search']
+                }
                 onlyActiveOnIndex={item.onlyActiveOnIndex}
                 onClick={closeDropdown}
                 scrollToTop

--- a/front/app/containers/MainHeader/Components/DesktopNavItems/MoreNavbarItem.tsx
+++ b/front/app/containers/MainHeader/Components/DesktopNavItems/MoreNavbarItem.tsx
@@ -12,11 +12,9 @@ import { Multiloc } from 'typings';
 import T from 'components/T';
 
 import { useIntl } from 'utils/cl-intl';
-import Link, { typedStyled } from 'utils/cl-router/Link';
+import Link, { typedStyled, type TypedLinkProps } from 'utils/cl-router/Link';
 
 import messages from '../../messages';
-
-import type { LinkProps } from '@tanstack/react-router';
 
 const DropdownListItem = typedStyled(Link)`
   display: flex;
@@ -70,10 +68,7 @@ const StyledButton = styled.button`
   }
 `;
 
-interface NavbarItemProps {
-  to?: LinkProps['to'];
-  params?: Record<string, string>;
-  search?: Record<string, unknown>;
+interface NavbarItemProps extends TypedLinkProps {
   linkTo?: string;
   navigationItemTitle: Multiloc;
   onlyActiveOnIndex?: boolean;

--- a/front/app/containers/MainHeader/Components/NavbarContent/MobileNavbarContent/FullMobileNavMenu.tsx
+++ b/front/app/containers/MainHeader/Components/NavbarContent/MobileNavbarContent/FullMobileNavMenu.tsx
@@ -127,7 +127,8 @@ const FullMobileNavMenu = ({ onClose, isFullMenuOpened }: Props) => {
             return null;
           })}
           <FullMobileNavMenuItem
-            linkTo={'/projects?focusSearch=true'}
+            to="/$locale/projects"
+            search={{ focusSearch: true }}
             navigationItemTitle={formatMessage(messages.search)}
             onClick={handleOnMenuItemClick('/projects?focusSearch=true')}
             iconName="search"

--- a/front/app/containers/MainHeader/Components/NavbarContent/MobileNavbarContent/FullMobileNavMenu.tsx
+++ b/front/app/containers/MainHeader/Components/NavbarContent/MobileNavbarContent/FullMobileNavMenu.tsx
@@ -127,7 +127,7 @@ const FullMobileNavMenu = ({ onClose, isFullMenuOpened }: Props) => {
             return null;
           })}
           <FullMobileNavMenuItem
-            to="/$locale/projects"
+            to="/projects"
             search={{ focusSearch: true }}
             navigationItemTitle={formatMessage(messages.search)}
             onClick={handleOnMenuItemClick('/projects?focusSearch=true')}

--- a/front/app/containers/MainHeader/Components/NavbarContent/MobileNavbarContent/FullMobileNavMenuItem.tsx
+++ b/front/app/containers/MainHeader/Components/NavbarContent/MobileNavbarContent/FullMobileNavMenuItem.tsx
@@ -11,6 +11,8 @@ import styled from 'styled-components';
 
 import Link, { typedStyled } from 'utils/cl-router/Link';
 
+import type { LinkProps } from '@tanstack/react-router';
+
 const MenuItem = styled.li`
   font-size: ${fontSizes.base}px;
   display: flex;
@@ -34,7 +36,10 @@ const StyledLink = typedStyled(Link)`
 `;
 
 interface Props {
-  linkTo: string;
+  to?: LinkProps['to'];
+  params?: Record<string, string>;
+  search?: Record<string, unknown>;
+  linkTo?: string;
   navigationItemTitle: string;
   onlyActiveOnIndex?: boolean;
   onClick: () => void;
@@ -43,6 +48,9 @@ interface Props {
 }
 
 const FullMobileNavMenuItem = ({
+  to,
+  params,
+  search,
   linkTo,
   navigationItemTitle,
   onClick,
@@ -56,7 +64,9 @@ const FullMobileNavMenuItem = ({
     {iconName && <Icon name={iconName} height="20px" />}
     <StyledLink
       onClick={onClick}
-      to={linkTo}
+      to={(to ?? linkTo) as Parameters<typeof StyledLink>[0]['to']}
+      params={params as Parameters<typeof StyledLink>[0]['params']}
+      search={search as Parameters<typeof StyledLink>[0]['search']}
       onlyActiveOnIndex={onlyActiveOnIndex}
       scrollToTop={scrollToTop}
     >

--- a/front/app/containers/MainHeader/Components/NavbarContent/MobileNavbarContent/FullMobileNavMenuItem.tsx
+++ b/front/app/containers/MainHeader/Components/NavbarContent/MobileNavbarContent/FullMobileNavMenuItem.tsx
@@ -9,9 +9,7 @@ import {
 import { darken } from 'polished';
 import styled from 'styled-components';
 
-import Link, { typedStyled } from 'utils/cl-router/Link';
-
-import type { LinkProps } from '@tanstack/react-router';
+import Link, { typedStyled, type TypedLinkProps } from 'utils/cl-router/Link';
 
 const MenuItem = styled.li`
   font-size: ${fontSizes.base}px;
@@ -35,10 +33,7 @@ const StyledLink = typedStyled(Link)`
   }
 `;
 
-interface Props {
-  to?: LinkProps['to'];
-  params?: Record<string, string>;
-  search?: Record<string, unknown>;
+interface Props extends TypedLinkProps {
   linkTo?: string;
   navigationItemTitle: string;
   onlyActiveOnIndex?: boolean;

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/AdminRightsReceivedNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/AdminRightsReceivedNotification/index.tsx
@@ -14,7 +14,7 @@ interface Props {
 const AdminRightsReceivedNotification = ({ notification }: Props) => {
   return (
     <NotificationWrapper
-      linkTo={'/admin'}
+      to="/$locale/admin"
       timing={notification.attributes.created_at}
       icon="shield-checkered"
       isRead={!!notification.attributes.read_at}

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/AdminRightsReceivedNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/AdminRightsReceivedNotification/index.tsx
@@ -14,7 +14,7 @@ interface Props {
 const AdminRightsReceivedNotification = ({ notification }: Props) => {
   return (
     <NotificationWrapper
-      to="/$locale/admin"
+      to="/admin"
       timing={notification.attributes.created_at}
       icon="shield-checkered"
       isRead={!!notification.attributes.read_at}

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/CommentDeletedByAdminNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/CommentDeletedByAdminNotification/index.tsx
@@ -16,7 +16,8 @@ interface Props {
 const CommentDeletedByAdminNotification = ({ notification }: Props) => {
   return (
     <NotificationWrapper
-      linkTo={`/ideas/${notification.attributes.post_slug}`}
+      to="/$locale/ideas/$slug"
+      params={{ slug: notification.attributes.post_slug ?? '' }}
       timing={notification.attributes.created_at}
       icon="comments"
       isRead={!!notification.attributes.read_at}

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/CommentDeletedByAdminNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/CommentDeletedByAdminNotification/index.tsx
@@ -16,7 +16,7 @@ interface Props {
 const CommentDeletedByAdminNotification = ({ notification }: Props) => {
   return (
     <NotificationWrapper
-      to="/$locale/ideas/$slug"
+      to="/ideas/$slug"
       params={{ slug: notification.attributes.post_slug ?? '' }}
       timing={notification.attributes.created_at}
       icon="comments"

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/CommentMarkedAsSpamNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/CommentMarkedAsSpamNotification/index.tsx
@@ -21,7 +21,7 @@ const CommentMarkedAsSpamNotification = memo<Props>((props) => {
 
   return (
     <NotificationWrapper
-      to="/$locale/ideas/$slug"
+      to="/ideas/$slug"
       params={{ slug: notification.attributes.post_slug ?? '' }}
       timing={notification.attributes.created_at}
       icon="comments"

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/CommentMarkedAsSpamNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/CommentMarkedAsSpamNotification/index.tsx
@@ -21,7 +21,8 @@ const CommentMarkedAsSpamNotification = memo<Props>((props) => {
 
   return (
     <NotificationWrapper
-      linkTo={`/ideas/${notification.attributes.post_slug}`}
+      to="/$locale/ideas/$slug"
+      params={{ slug: notification.attributes.post_slug ?? '' }}
       timing={notification.attributes.created_at}
       icon="comments"
       isRead={!!notification.attributes.read_at}

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/CommentOnIdeaYouFollowNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/CommentOnIdeaYouFollowNotification/index.tsx
@@ -34,7 +34,7 @@ const CommentOnIdeaYouFollowNotification = memo<Props>((props) => {
 
     return (
       <NotificationWrapper
-        to="/$locale/ideas/$slug"
+        to="/ideas/$slug"
         params={{ slug: notification.attributes.post_slug ?? '' }}
         timing={notification.attributes.created_at}
         icon="comments"

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/CommentOnIdeaYouFollowNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/CommentOnIdeaYouFollowNotification/index.tsx
@@ -34,7 +34,8 @@ const CommentOnIdeaYouFollowNotification = memo<Props>((props) => {
 
     return (
       <NotificationWrapper
-        linkTo={`/ideas/${notification.attributes.post_slug}`}
+        to="/$locale/ideas/$slug"
+        params={{ slug: notification.attributes.post_slug ?? '' }}
         timing={notification.attributes.created_at}
         icon="comments"
         isRead={!!notification.attributes.read_at}

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/CommentOnYourCommentNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/CommentOnYourCommentNotification/index.tsx
@@ -19,7 +19,7 @@ const CommentOnYourCommentNotification = memo<Props>((props) => {
 
   return (
     <NotificationWrapper
-      to="/$locale/ideas/$slug"
+      to="/ideas/$slug"
       params={{ slug: notification.attributes.post_slug ?? '' }}
       timing={notification.attributes.created_at}
       icon="comments"

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/CommentOnYourCommentNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/CommentOnYourCommentNotification/index.tsx
@@ -19,7 +19,8 @@ const CommentOnYourCommentNotification = memo<Props>((props) => {
 
   return (
     <NotificationWrapper
-      linkTo={`/ideas/${notification.attributes.post_slug}`}
+      to="/$locale/ideas/$slug"
+      params={{ slug: notification.attributes.post_slug ?? '' }}
       timing={notification.attributes.created_at}
       icon="comments"
       isRead={!!notification.attributes.read_at}

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/CosponsorOfYourIdeaNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/CosponsorOfYourIdeaNotification/index.tsx
@@ -17,7 +17,8 @@ const CosponsorOfYourIdeaNotification = memo<Props>((props) => {
 
   return (
     <NotificationWrapper
-      linkTo={`/ideas/${notification.attributes.post_slug}`}
+      to="/$locale/ideas/$slug"
+      params={{ slug: notification.attributes.post_slug ?? '' }}
       timing={notification.attributes.created_at}
       icon="label"
       isRead={!!notification.attributes.read_at}

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/CosponsorOfYourIdeaNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/CosponsorOfYourIdeaNotification/index.tsx
@@ -17,7 +17,7 @@ const CosponsorOfYourIdeaNotification = memo<Props>((props) => {
 
   return (
     <NotificationWrapper
-      to="/$locale/ideas/$slug"
+      to="/ideas/$slug"
       params={{ slug: notification.attributes.post_slug ?? '' }}
       timing={notification.attributes.created_at}
       icon="label"

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/IdeaAssignedToYouNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/IdeaAssignedToYouNotification/index.tsx
@@ -47,7 +47,7 @@ const IdeaAssignedToYouNotification = ({ notification }: Props) => {
             ...sharedValues,
             name: (
               <Link
-                to="/$locale/profile/$userSlug"
+                to="/profile/$userSlug"
                 params={{
                   userSlug: notification.attributes.initiating_user_slug,
                 }}
@@ -67,7 +67,7 @@ const IdeaAssignedToYouNotification = ({ notification }: Props) => {
 
   return (
     <NotificationWrapper
-      to="/$locale/admin/projects/$projectId/ideas/$ideaId"
+      to="/admin/projects/$projectId/ideas/$ideaId"
       params={{ projectId, ideaId }}
       timing={notification.attributes.created_at}
       icon="idea"

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/IdeaAssignedToYouNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/IdeaAssignedToYouNotification/index.tsx
@@ -67,7 +67,8 @@ const IdeaAssignedToYouNotification = ({ notification }: Props) => {
 
   return (
     <NotificationWrapper
-      linkTo={`/admin/projects/${projectId}/ideas/${ideaId}`}
+      to="/$locale/admin/projects/$projectId/ideas/$ideaId"
+      params={{ projectId, ideaId }}
       timing={notification.attributes.created_at}
       icon="idea"
       isRead={!!notification.attributes.read_at}

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/IdeaMarkedAsSpamNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/IdeaMarkedAsSpamNotification/index.tsx
@@ -19,7 +19,7 @@ const IdeaMarkedAsSpamNotification = memo<Props>((props) => {
 
   return (
     <NotificationWrapper
-      to="/$locale/ideas/$slug"
+      to="/ideas/$slug"
       params={{ slug: notification.attributes.post_slug }}
       timing={notification.attributes.created_at}
       icon="idea"

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/IdeaMarkedAsSpamNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/IdeaMarkedAsSpamNotification/index.tsx
@@ -19,7 +19,8 @@ const IdeaMarkedAsSpamNotification = memo<Props>((props) => {
 
   return (
     <NotificationWrapper
-      linkTo={`/ideas/${notification.attributes.post_slug}`}
+      to="/$locale/ideas/$slug"
+      params={{ slug: notification.attributes.post_slug }}
       timing={notification.attributes.created_at}
       icon="idea"
       isRead={!!notification.attributes.read_at}

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/InvitationToCosponsorIdeaNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/InvitationToCosponsorIdeaNotification/index.tsx
@@ -33,7 +33,8 @@ const InvitationToCosponsorIdeaNotification = memo<Props>((props) => {
 
     return (
       <NotificationWrapper
-        linkTo={`/ideas/${notification.attributes.post_slug}`}
+        to="/$locale/ideas/$slug"
+        params={{ slug: notification.attributes.post_slug ?? '' }}
         timing={notification.attributes.created_at}
         icon="label"
         isRead={!!notification.attributes.read_at}

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/InvitationToCosponsorIdeaNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/InvitationToCosponsorIdeaNotification/index.tsx
@@ -33,7 +33,7 @@ const InvitationToCosponsorIdeaNotification = memo<Props>((props) => {
 
     return (
       <NotificationWrapper
-        to="/$locale/ideas/$slug"
+        to="/ideas/$slug"
         params={{ slug: notification.attributes.post_slug ?? '' }}
         timing={notification.attributes.created_at}
         icon="label"

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/InviteAcceptedNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/InviteAcceptedNotification/index.tsx
@@ -17,7 +17,7 @@ const InviteAcceptedNotification = memo<Props>((props) => {
 
   return (
     <NotificationWrapper
-      linkTo={'/admin/users/invitations'}
+      to="/$locale/admin/users/invitations"
       timing={notification.attributes.created_at}
       icon="user-check"
       isRead={!!notification.attributes.read_at}

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/InviteAcceptedNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/InviteAcceptedNotification/index.tsx
@@ -17,7 +17,7 @@ const InviteAcceptedNotification = memo<Props>((props) => {
 
   return (
     <NotificationWrapper
-      to="/$locale/admin/users/invitations"
+      to="/admin/users/invitations"
       timing={notification.attributes.created_at}
       icon="user-check"
       isRead={!!notification.attributes.read_at}

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/MentionInCommentNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/MentionInCommentNotification/index.tsx
@@ -17,7 +17,7 @@ const MentionInCommentNotification = memo<Props>((props) => {
 
   return (
     <NotificationWrapper
-      to="/$locale/ideas/$slug"
+      to="/ideas/$slug"
       params={{ slug: notification.attributes.post_slug ?? '' }}
       timing={notification.attributes.created_at}
       icon="mention"

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/MentionInCommentNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/MentionInCommentNotification/index.tsx
@@ -17,7 +17,8 @@ const MentionInCommentNotification = memo<Props>((props) => {
 
   return (
     <NotificationWrapper
-      linkTo={`/ideas/${notification.attributes.post_slug}`}
+      to="/$locale/ideas/$slug"
+      params={{ slug: notification.attributes.post_slug ?? '' }}
       timing={notification.attributes.created_at}
       icon="mention"
       isRead={!!notification.attributes.read_at}

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/MentionInOfficialFeedbackNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/MentionInOfficialFeedbackNotification/index.tsx
@@ -25,7 +25,7 @@ const MentionInCommentNotification = memo<Props>((props) => {
 
   return (
     <NotificationWrapper
-      to="/$locale/ideas/$slug"
+      to="/ideas/$slug"
       params={{ slug: notification.attributes.post_slug ?? '' }}
       timing={notification.attributes.created_at}
       icon="mention"
@@ -38,7 +38,7 @@ const MentionInCommentNotification = memo<Props>((props) => {
             <DeletedUser />
           ) : (
             <Link
-              to="/$locale/profile/$userSlug"
+              to="/profile/$userSlug"
               params={{ userSlug }}
               onClick={stopPropagation}
             >

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/MentionInOfficialFeedbackNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/MentionInOfficialFeedbackNotification/index.tsx
@@ -25,7 +25,8 @@ const MentionInCommentNotification = memo<Props>((props) => {
 
   return (
     <NotificationWrapper
-      linkTo={`/ideas/${notification.attributes.post_slug}`}
+      to="/$locale/ideas/$slug"
+      params={{ slug: notification.attributes.post_slug ?? '' }}
       timing={notification.attributes.created_at}
       icon="mention"
       isRead={!!notification.attributes.read_at}

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/NativeSurveyNotSubmittedNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/NativeSurveyNotSubmittedNotification/index.tsx
@@ -16,7 +16,7 @@ const NativeSurveyNotSubmittedNotification = memo<Props>((props) => {
 
   return (
     <NotificationWrapper
-      to="/$locale/projects/$slug"
+      to="/projects/$slug"
       params={{ slug: notification.attributes.project_slug }}
       timing={notification.attributes.created_at}
       icon="vote-ballot"

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/NativeSurveyNotSubmittedNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/NativeSurveyNotSubmittedNotification/index.tsx
@@ -16,7 +16,8 @@ const NativeSurveyNotSubmittedNotification = memo<Props>((props) => {
 
   return (
     <NotificationWrapper
-      linkTo={`/projects/${notification.attributes.project_slug}`}
+      to="/$locale/projects/$slug"
+      params={{ slug: notification.attributes.project_slug }}
       timing={notification.attributes.created_at}
       icon="vote-ballot"
       isRead={!!notification.attributes.read_at}

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/NotificationWrapper/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/NotificationWrapper/index.tsx
@@ -13,13 +13,15 @@ import styled from 'styled-components';
 import useLocale from 'hooks/useLocale';
 
 import { trackEventByName } from 'utils/analytics';
-import Link from 'utils/cl-router/Link';
+import Link, { typedStyled } from 'utils/cl-router/Link';
 import { timeAgo } from 'utils/dateUtils';
 import { isNilOrError } from 'utils/helperUtils';
 
 import tracks from '../../tracks';
 
-const Container = styled(Link)`
+import type { LinkProps } from '@tanstack/react-router';
+
+const Container = typedStyled(Link)`
   display: flex;
   text-align: left;
   cursor: pointer;
@@ -97,7 +99,10 @@ type Props = {
   icon?: IconNames;
   timing?: string;
   children: React.ReactNode;
-  linkTo: string;
+  to?: LinkProps['to'];
+  params?: Record<string, string>;
+  search?: Record<string, unknown>;
+  linkTo?: string;
   isRead: boolean;
 };
 
@@ -106,16 +111,24 @@ const NotificationWrapper = ({
   children,
   timing,
   isRead,
+  to,
+  params,
+  search,
   linkTo,
 }: Props) => {
   const locale = useLocale();
   const track = () => {
-    trackEventByName(tracks.clickNotification, { linkTo });
+    trackEventByName(tracks.clickNotification, { linkTo: to ?? linkTo });
   };
 
   if (!isNilOrError(locale)) {
     return (
-      <Container to={linkTo} onClick={track}>
+      <Container
+        to={(to ?? linkTo) as Parameters<typeof Container>[0]['to']}
+        params={params as Parameters<typeof Container>[0]['params']}
+        search={search as Parameters<typeof Container>[0]['search']}
+        onClick={track}
+      >
         <IconContainer>
           {icon && <StyledIcon name={icon} isRead={isRead} />}
         </IconContainer>

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/NotificationWrapper/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/NotificationWrapper/index.tsx
@@ -13,13 +13,11 @@ import styled from 'styled-components';
 import useLocale from 'hooks/useLocale';
 
 import { trackEventByName } from 'utils/analytics';
-import Link, { typedStyled } from 'utils/cl-router/Link';
+import Link, { typedStyled, type TypedLinkProps } from 'utils/cl-router/Link';
 import { timeAgo } from 'utils/dateUtils';
 import { isNilOrError } from 'utils/helperUtils';
 
 import tracks from '../../tracks';
-
-import type { LinkProps } from '@tanstack/react-router';
 
 const Container = typedStyled(Link)`
   display: flex;
@@ -99,12 +97,9 @@ type Props = {
   icon?: IconNames;
   timing?: string;
   children: React.ReactNode;
-  to?: LinkProps['to'];
-  params?: Record<string, string>;
-  search?: Record<string, unknown>;
   linkTo?: string;
   isRead: boolean;
-};
+} & TypedLinkProps;
 
 const NotificationWrapper = ({
   icon,

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/OfficialFeedbackOnIdeaYouFollowNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/OfficialFeedbackOnIdeaYouFollowNotification/index.tsx
@@ -35,7 +35,8 @@ const OfficialFeedbackOnIdeaYouFollowNotification = memo<Props>((props) => {
 
     return (
       <NotificationWrapper
-        linkTo={`/ideas/${slug}`}
+        to="/$locale/ideas/$slug"
+        params={{ slug }}
         timing={notification.attributes.created_at}
         icon="comments"
         isRead={!!notification.attributes.read_at}

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/OfficialFeedbackOnIdeaYouFollowNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/OfficialFeedbackOnIdeaYouFollowNotification/index.tsx
@@ -35,7 +35,7 @@ const OfficialFeedbackOnIdeaYouFollowNotification = memo<Props>((props) => {
 
     return (
       <NotificationWrapper
-        to="/$locale/ideas/$slug"
+        to="/ideas/$slug"
         params={{ slug }}
         timing={notification.attributes.created_at}
         icon="comments"
@@ -64,7 +64,7 @@ const OfficialFeedbackOnIdeaYouFollowNotification = memo<Props>((props) => {
               <T value={notification.attributes.official_feedback_author} />
             ),
             idea: (
-              <Link to="/$locale/ideas/$slug" params={{ slug }}>
+              <Link to="/ideas/$slug" params={{ slug }}>
                 <T value={notification.attributes.post_title_multiloc} />
               </Link>
             ),

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/ProjectFolderModerationRightsReceivedNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/ProjectFolderModerationRightsReceivedNotification/index.tsx
@@ -23,7 +23,8 @@ const ProjectFolderModerationRightsReceivedNotification = ({
 
   return (
     <NotificationWrapper
-      linkTo={`/admin/projects/folders/${projectFolderId}`}
+      to="/$locale/admin/projects/folders/$projectFolderId"
+      params={{ projectFolderId }}
       timing={notification.attributes.created_at}
       icon="folder-solid"
       isRead={!!notification.attributes.read_at}

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/ProjectFolderModerationRightsReceivedNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/ProjectFolderModerationRightsReceivedNotification/index.tsx
@@ -23,7 +23,7 @@ const ProjectFolderModerationRightsReceivedNotification = ({
 
   return (
     <NotificationWrapper
-      to="/$locale/admin/projects/folders/$projectFolderId"
+      to="/admin/projects/folders/$projectFolderId"
       params={{ projectFolderId }}
       timing={notification.attributes.created_at}
       icon="folder-solid"
@@ -34,7 +34,7 @@ const ProjectFolderModerationRightsReceivedNotification = ({
         values={{
           folderLink: (
             <Link
-              to="/$locale/admin/projects/folders/$projectFolderId"
+              to="/admin/projects/folders/$projectFolderId"
               params={{ projectFolderId }}
               onClick={stopPropagation}
             >

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/ProjectModerationRightsReceivedNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/ProjectModerationRightsReceivedNotification/index.tsx
@@ -2,7 +2,7 @@ import React, { memo } from 'react';
 
 import { IProjectModerationRightsReceivedNotificationData } from 'api/notifications/types';
 
-import { adminProjectsProjectPath } from 'containers/Admin/projects/routes';
+import { adminProjectsProjectLink } from 'containers/Admin/projects/routes';
 
 import T from 'components/T';
 
@@ -22,7 +22,7 @@ const ProjectModerationRightsReceivedNotification = memo<Props>((props) => {
 
   return (
     <NotificationWrapper
-      linkTo={adminProjectsProjectPath(notification.attributes.project_id)}
+      {...adminProjectsProjectLink(notification.attributes.project_id)}
       timing={notification.attributes.created_at}
       icon="shield-checkered"
       isRead={!!notification.attributes.read_at}
@@ -32,7 +32,7 @@ const ProjectModerationRightsReceivedNotification = memo<Props>((props) => {
         values={{
           projectLink: (
             <Link
-              to={adminProjectsProjectPath(notification.attributes.project_id)}
+              {...adminProjectsProjectLink(notification.attributes.project_id)}
               onClick={stopPropagation}
             >
               <T value={notification.attributes.project_title_multiloc} />

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/ProjectPhaseStartedNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/ProjectPhaseStartedNotification/index.tsx
@@ -18,7 +18,7 @@ const ProjectPhaseStartedNotification = memo<Props>((props) => {
 
   return (
     <NotificationWrapper
-      to="/$locale/projects/$slug"
+      to="/projects/$slug"
       params={{ slug: notification.attributes.project_slug }}
       timing={notification.attributes.created_at}
       icon="timeline"

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/ProjectPhaseStartedNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/ProjectPhaseStartedNotification/index.tsx
@@ -18,7 +18,8 @@ const ProjectPhaseStartedNotification = memo<Props>((props) => {
 
   return (
     <NotificationWrapper
-      linkTo={`/projects/${notification.attributes.project_slug}`}
+      to="/$locale/projects/$slug"
+      params={{ slug: notification.attributes.project_slug }}
       timing={notification.attributes.created_at}
       icon="timeline"
       isRead={!!notification.attributes.read_at}

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/ProjectPhaseUpcomingNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/ProjectPhaseUpcomingNotification/index.tsx
@@ -20,7 +20,8 @@ const ProjectPhaseUpcomingNotification = memo<Props>((props) => {
 
   return (
     <NotificationWrapper
-      linkTo={`/projects/${notification.attributes.project_slug}`}
+      to="/$locale/projects/$slug"
+      params={{ slug: notification.attributes.project_slug }}
       timing={notification.attributes.created_at}
       icon="timeline"
       isRead={!!notification.attributes.read_at}

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/ProjectPhaseUpcomingNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/ProjectPhaseUpcomingNotification/index.tsx
@@ -20,7 +20,7 @@ const ProjectPhaseUpcomingNotification = memo<Props>((props) => {
 
   return (
     <NotificationWrapper
-      to="/$locale/projects/$slug"
+      to="/projects/$slug"
       params={{ slug: notification.attributes.project_slug }}
       timing={notification.attributes.created_at}
       icon="timeline"

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/ProjectPublishedNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/ProjectPublishedNotification/index.tsx
@@ -18,7 +18,7 @@ const ProjectPublishedNotification = memo<Props>((props) => {
 
   return (
     <NotificationWrapper
-      to="/$locale/projects/$slug"
+      to="/projects/$slug"
       params={{ slug: notification.attributes.project_slug }}
       timing={notification.attributes.created_at}
       icon="timeline"

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/ProjectPublishedNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/ProjectPublishedNotification/index.tsx
@@ -18,7 +18,8 @@ const ProjectPublishedNotification = memo<Props>((props) => {
 
   return (
     <NotificationWrapper
-      linkTo={`/projects/${notification.attributes.project_slug}`}
+      to="/$locale/projects/$slug"
+      params={{ slug: notification.attributes.project_slug }}
       timing={notification.attributes.created_at}
       icon="timeline"
       isRead={!!notification.attributes.read_at}

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/ProjectReviewRequestNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/ProjectReviewRequestNotification/index.tsx
@@ -2,7 +2,7 @@ import React, { memo } from 'react';
 
 import { IProjectReviewRequestNotificationData } from 'api/notifications/types';
 
-import { adminProjectsProjectPath } from 'containers/Admin/projects/routes';
+import { adminProjectsProjectLink } from 'containers/Admin/projects/routes';
 
 import T from 'components/T';
 
@@ -19,7 +19,7 @@ type Props = {
 const ProjectReviewRequestNotification = memo<Props>(
   ({ notification }: Props) => (
     <NotificationWrapper
-      linkTo={adminProjectsProjectPath(notification.attributes.project_id)}
+      {...adminProjectsProjectLink(notification.attributes.project_id)}
       icon="shield-checkered"
       timing={notification.attributes.created_at}
       isRead={!!notification.attributes.read_at}

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/ProjectReviewStateChangeNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/ProjectReviewStateChangeNotification/index.tsx
@@ -2,7 +2,7 @@ import React, { memo } from 'react';
 
 import { IProjectReviewStateChangeNotificationData } from 'api/notifications/types';
 
-import { adminProjectsProjectPath } from 'containers/Admin/projects/routes';
+import { adminProjectsProjectLink } from 'containers/Admin/projects/routes';
 
 import T from 'components/T';
 
@@ -19,7 +19,7 @@ type Props = {
 const ProjectReviewStateChangeNotification = memo<Props>(
   ({ notification }: Props) => (
     <NotificationWrapper
-      linkTo={adminProjectsProjectPath(notification.attributes.project_id)}
+      {...adminProjectsProjectLink(notification.attributes.project_id)}
       icon="shield-checkered"
       timing={notification.attributes.created_at}
       isRead={!!notification.attributes.read_at}

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/SpaceModerationRightsReceivedNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/SpaceModerationRightsReceivedNotification/index.tsx
@@ -21,7 +21,8 @@ const SpaceModerationRightsReceivedNotification = memo<Props>((props) => {
 
   return (
     <NotificationWrapper
-      linkTo={`/admin/projects/spaces/${spaceId}`}
+      to="/$locale/admin/projects/spaces/$spaceId"
+      params={{ spaceId }}
       timing={notification.attributes.created_at}
       icon="shield-checkered"
       isRead={!!notification.attributes.read_at}

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/SpaceModerationRightsReceivedNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/SpaceModerationRightsReceivedNotification/index.tsx
@@ -21,7 +21,7 @@ const SpaceModerationRightsReceivedNotification = memo<Props>((props) => {
 
   return (
     <NotificationWrapper
-      to="/$locale/admin/projects/spaces/$spaceId"
+      to="/admin/projects/spaces/$spaceId"
       params={{ spaceId }}
       timing={notification.attributes.created_at}
       icon="shield-checkered"
@@ -32,7 +32,7 @@ const SpaceModerationRightsReceivedNotification = memo<Props>((props) => {
         values={{
           spaceLink: (
             <Link
-              to="/$locale/admin/projects/spaces/$spaceId"
+              to="/admin/projects/spaces/$spaceId"
               params={{ spaceId }}
               onClick={stopPropagation}
             >

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/StatusChangeOnIdeaYouFollowNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/StatusChangeOnIdeaYouFollowNotification/index.tsx
@@ -18,7 +18,8 @@ const StatusChangeOnIdeaYouFollowNotification = memo<Props>((props) => {
 
   return (
     <NotificationWrapper
-      linkTo={`/ideas/${notification.attributes.post_slug}`}
+      to="/$locale/ideas/$slug"
+      params={{ slug: notification.attributes.post_slug }}
       timing={notification.attributes.created_at}
       icon="label"
       isRead={!!notification.attributes.read_at}

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/StatusChangeOnIdeaYouFollowNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/StatusChangeOnIdeaYouFollowNotification/index.tsx
@@ -18,7 +18,7 @@ const StatusChangeOnIdeaYouFollowNotification = memo<Props>((props) => {
 
   return (
     <NotificationWrapper
-      to="/$locale/ideas/$slug"
+      to="/ideas/$slug"
       params={{ slug: notification.attributes.post_slug }}
       timing={notification.attributes.created_at}
       icon="label"

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/UserLink.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/UserLink.tsx
@@ -25,7 +25,7 @@ const UserLink = ({ userName, userSlug }) => {
     <DeletedUser />
   ) : (
     <Link
-      to="/$locale/profile/$userSlug"
+      to="/profile/$userSlug"
       params={{ userSlug }}
       onClick={stopPropagation}
     >

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/VotingBasketNotSubmittedNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/VotingBasketNotSubmittedNotification/index.tsx
@@ -16,7 +16,8 @@ const VotingBasketNotSubmittedNotification = memo<Props>((props) => {
 
   return (
     <NotificationWrapper
-      linkTo={`/projects/${notification.attributes.project_slug}`}
+      to="/$locale/projects/$slug"
+      params={{ slug: notification.attributes.project_slug }}
       timing={notification.attributes.created_at}
       icon="vote-ballot"
       isRead={!!notification.attributes.read_at}

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/VotingBasketNotSubmittedNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/VotingBasketNotSubmittedNotification/index.tsx
@@ -16,7 +16,7 @@ const VotingBasketNotSubmittedNotification = memo<Props>((props) => {
 
   return (
     <NotificationWrapper
-      to="/$locale/projects/$slug"
+      to="/projects/$slug"
       params={{ slug: notification.attributes.project_slug }}
       timing={notification.attributes.created_at}
       icon="vote-ballot"

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/VotingBasketSubmittedNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/VotingBasketSubmittedNotification/index.tsx
@@ -16,7 +16,8 @@ const VotingBasketSubmittedNotification = memo<Props>((props) => {
 
   return (
     <NotificationWrapper
-      linkTo={`/projects/${notification.attributes.project_slug}`}
+      to="/$locale/projects/$slug"
+      params={{ slug: notification.attributes.project_slug }}
       timing={notification.attributes.created_at}
       icon="vote-ballot"
       isRead={!!notification.attributes.read_at}

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/VotingBasketSubmittedNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/VotingBasketSubmittedNotification/index.tsx
@@ -16,7 +16,7 @@ const VotingBasketSubmittedNotification = memo<Props>((props) => {
 
   return (
     <NotificationWrapper
-      to="/$locale/projects/$slug"
+      to="/projects/$slug"
       params={{ slug: notification.attributes.project_slug }}
       timing={notification.attributes.created_at}
       icon="vote-ballot"

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/VotingLastChanceNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/VotingLastChanceNotification/index.tsx
@@ -18,7 +18,8 @@ const VotingLastChanceNotification = memo<Props>((props) => {
 
   return (
     <NotificationWrapper
-      linkTo={`/projects/${notification.attributes.project_slug}`}
+      to="/$locale/projects/$slug"
+      params={{ slug: notification.attributes.project_slug }}
       timing={notification.attributes.created_at}
       icon="vote-ballot"
       isRead={!!notification.attributes.read_at}

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/VotingLastChanceNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/VotingLastChanceNotification/index.tsx
@@ -18,7 +18,7 @@ const VotingLastChanceNotification = memo<Props>((props) => {
 
   return (
     <NotificationWrapper
-      to="/$locale/projects/$slug"
+      to="/projects/$slug"
       params={{ slug: notification.attributes.project_slug }}
       timing={notification.attributes.created_at}
       icon="vote-ballot"

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/VotingResultsNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/VotingResultsNotification/index.tsx
@@ -18,7 +18,7 @@ const VotingResultsNotification = memo<Props>((props) => {
 
   return (
     <NotificationWrapper
-      to="/$locale/projects/$slug"
+      to="/projects/$slug"
       params={{ slug: notification.attributes.project_slug }}
       timing={notification.attributes.created_at}
       icon="vote-ballot"

--- a/front/app/containers/MainHeader/Components/NotificationMenu/components/VotingResultsNotification/index.tsx
+++ b/front/app/containers/MainHeader/Components/NotificationMenu/components/VotingResultsNotification/index.tsx
@@ -18,7 +18,8 @@ const VotingResultsNotification = memo<Props>((props) => {
 
   return (
     <NotificationWrapper
-      linkTo={`/projects/${notification.attributes.project_slug}`}
+      to="/$locale/projects/$slug"
+      params={{ slug: notification.attributes.project_slug }}
       timing={notification.attributes.created_at}
       icon="vote-ballot"
       isRead={!!notification.attributes.read_at}

--- a/front/app/containers/MainHeader/Components/TenantLogo/index.tsx
+++ b/front/app/containers/MainHeader/Components/TenantLogo/index.tsx
@@ -29,7 +29,7 @@ const TenantLogo = () => {
     if (tenantLogo) {
       return (
         <Link
-          to="/$locale/"
+          to="/"
           onlyActiveOnIndex={true}
           /* The aria-label here is used when there is no clear
            * 'text-like' element as a child of the Link component,

--- a/front/app/containers/MainHeader/Components/UserMenu/UserMenuDropdown.tsx
+++ b/front/app/containers/MainHeader/Components/UserMenu/UserMenuDropdown.tsx
@@ -75,7 +75,7 @@ const UserMenuDropdown = ({ toggleDropdown, closeDropdown, opened }: Props) => {
           {canAccessAdmin && (
             <DropdownListItem
               id="admin-link"
-              to="/$locale/admin"
+              to="/admin"
               onClick={handleCloseDropdown}
               buttonStyle="text"
               bgHoverColor={colors.grey300}
@@ -92,7 +92,7 @@ const UserMenuDropdown = ({ toggleDropdown, closeDropdown, opened }: Props) => {
           {isConfirmedUser && (
             <DropdownListItem
               id="e2e-my-ideas-page-link"
-              to="/$locale/profile/$userSlug"
+              to="/profile/$userSlug"
               params={{ userSlug: authUser.data.attributes.slug }}
               onClick={handleCloseDropdown}
               buttonStyle="text"
@@ -110,7 +110,7 @@ const UserMenuDropdown = ({ toggleDropdown, closeDropdown, opened }: Props) => {
           {isConfirmedUser && (
             <DropdownListItem
               id="e2e-profile-edit-link"
-              to="/$locale/profile/edit"
+              to="/profile/edit"
               onClick={handleCloseDropdown}
               buttonStyle="text"
               bgHoverColor={colors.grey300}

--- a/front/app/containers/MainHeader/Components/UserMenu/UserMenuDropdown.tsx
+++ b/front/app/containers/MainHeader/Components/UserMenu/UserMenuDropdown.tsx
@@ -75,7 +75,7 @@ const UserMenuDropdown = ({ toggleDropdown, closeDropdown, opened }: Props) => {
           {canAccessAdmin && (
             <DropdownListItem
               id="admin-link"
-              linkTo={'/admin'}
+              to="/$locale/admin"
               onClick={handleCloseDropdown}
               buttonStyle="text"
               bgHoverColor={colors.grey300}
@@ -92,7 +92,8 @@ const UserMenuDropdown = ({ toggleDropdown, closeDropdown, opened }: Props) => {
           {isConfirmedUser && (
             <DropdownListItem
               id="e2e-my-ideas-page-link"
-              linkTo={`/profile/${authUser.data.attributes.slug}`}
+              to="/$locale/profile/$userSlug"
+              params={{ userSlug: authUser.data.attributes.slug }}
               onClick={handleCloseDropdown}
               buttonStyle="text"
               bgHoverColor={colors.grey300}
@@ -109,7 +110,7 @@ const UserMenuDropdown = ({ toggleDropdown, closeDropdown, opened }: Props) => {
           {isConfirmedUser && (
             <DropdownListItem
               id="e2e-profile-edit-link"
-              linkTo={'/profile/edit'}
+              to="/$locale/profile/edit"
               onClick={handleCloseDropdown}
               buttonStyle="text"
               bgHoverColor={colors.grey300}

--- a/front/app/containers/PasswordChange/ChangePasswordSuccess.tsx
+++ b/front/app/containers/PasswordChange/ChangePasswordSuccess.tsx
@@ -31,7 +31,7 @@ export default () => (
     <Title style={{ paddingTop: '26px' }}>
       <FormattedMessage {...messages.passwordChangeSuccessMessage} />
     </Title>
-    <ButtonWithLink linkTo={'/'} scrollToTop>
+    <ButtonWithLink to="/$locale/" scrollToTop>
       <FormattedMessage {...messages.goHome} />
     </ButtonWithLink>
   </Box>

--- a/front/app/containers/PasswordChange/ChangePasswordSuccess.tsx
+++ b/front/app/containers/PasswordChange/ChangePasswordSuccess.tsx
@@ -31,7 +31,7 @@ export default () => (
     <Title style={{ paddingTop: '26px' }}>
       <FormattedMessage {...messages.passwordChangeSuccessMessage} />
     </Title>
-    <ButtonWithLink to="/$locale/" scrollToTop>
+    <ButtonWithLink to="/" scrollToTop>
       <FormattedMessage {...messages.goHome} />
     </ButtonWithLink>
   </Box>

--- a/front/app/containers/PasswordReset/index.tsx
+++ b/front/app/containers/PasswordReset/index.tsx
@@ -148,7 +148,7 @@ class PasswordReset extends React.PureComponent<Props, State> {
 
             invalidTokenError.payload = {
               passwordResetLink: (
-                <Link to="/$locale/password-recovery">
+                <Link to="/password-recovery">
                   <FormattedMessage {...messages.requestNewPasswordReset} />
                 </Link>
               ),

--- a/front/app/containers/PlatformFooter/index.tsx
+++ b/front/app/containers/PlatformFooter/index.tsx
@@ -321,7 +321,7 @@ const PlatformFooter = ({ className }: Props) => {
                       </StyledA>
                     ) : (
                       <StyledLink
-                        to="/$locale/pages/$slug"
+                        to="/pages/$slug"
                         params={{ slug }}
                         className={index === 0 ? 'first' : ''}
                         scrollToTop={true}
@@ -339,7 +339,7 @@ const PlatformFooter = ({ className }: Props) => {
               </StyledButton>
             </PagesNavListItem>
             <PagesNavListItem>
-              <StyledLink to="/$locale/site-map" id="site-map-link">
+              <StyledLink to="/site-map" id="site-map-link">
                 <FormattedMessage {...messages.siteMap} />
               </StyledLink>
             </PagesNavListItem>

--- a/front/app/containers/ProjectFolderShowPage/index.tsx
+++ b/front/app/containers/ProjectFolderShowPage/index.tsx
@@ -123,7 +123,7 @@ const ProjectFolderShowPage = ({ projectFolder }: Props) => {
               >
                 <ButtonWithLink
                   icon="edit"
-                  to="/$locale/admin/projects/folders/$projectFolderId/settings"
+                  to="/admin/projects/folders/$projectFolderId/settings"
                   params={{ projectFolderId: projectFolder.id }}
                   buttonStyle="secondary-outlined"
                   padding="6px 12px"

--- a/front/app/containers/ProjectFolderShowPage/index.tsx
+++ b/front/app/containers/ProjectFolderShowPage/index.tsx
@@ -7,7 +7,6 @@ import {
   colors,
   useBreakpoint,
 } from '@citizenlab/cl2-component-library';
-import { useParams } from 'utils/router';
 import styled from 'styled-components';
 
 import useAuthUser from 'api/me/useAuthUser';
@@ -27,6 +26,7 @@ import VerticalCenterer from 'components/VerticalCenterer';
 import { FormattedMessage } from 'utils/cl-intl';
 import { isUnauthorizedRQ } from 'utils/errorUtils';
 import { userModeratesFolder } from 'utils/permissions/rules/projectFolderPermissions';
+import { useParams } from 'utils/router';
 
 import messages from './messages';
 import ProjectFolderDescription from './ProjectFolderDescription';
@@ -123,7 +123,8 @@ const ProjectFolderShowPage = ({ projectFolder }: Props) => {
               >
                 <ButtonWithLink
                   icon="edit"
-                  linkTo={`/admin/projects/folders/${projectFolder.id}/settings`}
+                  to="/$locale/admin/projects/folders/$projectFolderId/settings"
+                  params={{ projectFolderId: projectFolder.id }}
                   buttonStyle="secondary-outlined"
                   padding="6px 12px"
                 >

--- a/front/app/containers/ProjectsShowPage/shared/header/ProjectHeader.tsx
+++ b/front/app/containers/ProjectsShowPage/shared/header/ProjectHeader.tsx
@@ -14,7 +14,7 @@ import useProjectById from 'api/projects/useProjectById';
 import useFeatureFlag from 'hooks/useFeatureFlag';
 import useLocalize from 'hooks/useLocalize';
 
-import { adminProjectsProjectPath } from 'containers/Admin/projects/routes';
+import { adminProjectsProjectLink } from 'containers/Admin/projects/routes';
 import messages from 'containers/ProjectsShowPage/messages';
 import { maxPageWidth } from 'containers/ProjectsShowPage/styles';
 
@@ -106,7 +106,7 @@ const ProjectHeader = memo<Props>(({ projectId, className }) => {
                   {userCanEditProject && (
                     <EditButton
                       icon="edit"
-                      linkTo={adminProjectsProjectPath(project.data.id)}
+                      {...adminProjectsProjectLink(project.data.id)}
                       buttonStyle="secondary-outlined"
                       padding="6px 12px"
                     >

--- a/front/app/containers/ProjectsShowPage/shared/header/ProjectInfoSideBar/index.tsx
+++ b/front/app/containers/ProjectsShowPage/shared/header/ProjectInfoSideBar/index.tsx
@@ -125,7 +125,7 @@ const ProjectInfoSideBar = memo<Props>(
                             values={{
                               accessRightsLink: (
                                 <Link
-                                  to="/$locale/admin/projects/$projectId/general/access-rights"
+                                  to="/admin/projects/$projectId/general/access-rights"
                                   params={{ projectId }}
                                 >
                                   <FormattedMessage

--- a/front/app/containers/ProjectsShowPage/timeline/VotingResults/VotingResultCard.tsx
+++ b/front/app/containers/ProjectsShowPage/timeline/VotingResults/VotingResultCard.tsx
@@ -22,7 +22,7 @@ import Image from 'components/UI/Image';
 
 import { useIntl } from 'utils/cl-intl';
 import clHistory from 'utils/cl-router/history';
-import Link from 'utils/cl-router/Link';
+import Link, { typedStyled } from 'utils/cl-router/Link';
 import { updateSearchParams } from 'utils/cl-router/updateSearchParams';
 import FormattedBudget from 'utils/currency/FormattedBudget';
 
@@ -35,7 +35,7 @@ const cardPadding = '17px';
 const cardInnerHeight = '162px';
 const cardInnerHeightExtended = '180px';
 
-const Container = styled(Link)`
+const Container = typedStyled(Link)`
   width: 100%;
   min-height: calc(${cardInnerHeight} + ${cardPadding} + ${cardPadding});
   display: flex;

--- a/front/app/containers/SiteMap/Project.tsx
+++ b/front/app/containers/SiteMap/Project.tsx
@@ -36,7 +36,7 @@ const Project = ({ projectId, hightestTitle }: Props) => {
         <ul>
           <li>
             <Link
-              to="/$locale/projects/$slug"
+              to="/projects/$slug"
               params={{ slug: project.data.attributes.slug }}
             >
               <FormattedMessage {...messages.projectInfo} />
@@ -47,7 +47,7 @@ const Project = ({ projectId, hightestTitle }: Props) => {
           {!isNilOrError(events) && events.data.length > 0 && (
             <li>
               <Link
-                to="/$locale/projects/$slug"
+                to="/projects/$slug"
                 params={{ slug: project.data.attributes.slug }}
                 hash="e2e-events-section-project-page"
               >

--- a/front/app/containers/SiteMap/ProjectFolderSiteMapItem/index.tsx
+++ b/front/app/containers/SiteMap/ProjectFolderSiteMapItem/index.tsx
@@ -48,7 +48,7 @@ const ProjectFolderSitemap = ({ projectFolderId, hightestTitle }: Props) => {
         <ul>
           <li>
             <Link
-              to="/$locale/folders/$slug"
+              to="/folders/$slug"
               params={{ slug: folder.data.attributes.slug }}
             >
               <FormattedMessage {...messages.folderInfo} />

--- a/front/app/containers/SiteMap/ProjectsAndFoldersSection.tsx
+++ b/front/app/containers/SiteMap/ProjectsAndFoldersSection.tsx
@@ -37,7 +37,7 @@ const ProjectsAndFoldersSection = ({ projectsSectionRef }: Props) => {
         <H2 ref={projectsSectionRef} tabIndex={-1}>
           <FormattedMessage {...messages.projectsSection} />
         </H2>
-        <AllProjectsLink to="/$locale/projects" id="projects-section">
+        <AllProjectsLink to="/projects" id="projects-section">
           <FormattedMessage {...messages.allProjects} />
         </AllProjectsLink>
         {adminPublications.map((adminPublication) => (

--- a/front/app/containers/SiteMap/TimelineProject.tsx
+++ b/front/app/containers/SiteMap/TimelineProject.tsx
@@ -25,7 +25,7 @@ const TimelineProject = ({ project }: Props) => {
     return (
       <li key={phases.data[0].id}>
         <Link
-          to="/$locale/projects/$slug/$phaseNumber"
+          to="/projects/$slug/$phaseNumber"
           params={{ slug: project.attributes.slug, phaseNumber: '1' }}
         >
           <T value={phases.data[0].attributes.title_multiloc} />
@@ -41,7 +41,7 @@ const TimelineProject = ({ project }: Props) => {
         {phases.data.map((phase, i) => (
           <li key={phase.id}>
             <Link
-              to="/$locale/projects/$slug/$phaseNumber"
+              to="/projects/$slug/$phaseNumber"
               params={{
                 slug: project.attributes.slug,
                 phaseNumber: String(i + 1),

--- a/front/app/containers/SiteMap/index.tsx
+++ b/front/app/containers/SiteMap/index.tsx
@@ -267,7 +267,7 @@ const SiteMap = () => {
                       return (
                         <li key={page.id}>
                           <Link
-                            to="/$locale/pages/$slug"
+                            to="/pages/$slug"
                             params={{ slug: page.attributes.slug }}
                           >
                             {localize(page.attributes.title_multiloc)}
@@ -278,7 +278,7 @@ const SiteMap = () => {
                     {/* Default cookie policy link if no custom one exists */}
                     {!hasStaticPageWithCode('cookie-policy') && (
                       <li key="default-cookie-policy">
-                        <Link to="/$locale/pages/cookie-policy">
+                        <Link to="/pages/cookie-policy">
                           <FormattedMessage
                             {...messages.cookiePolicyLinkTitle}
                           />
@@ -296,7 +296,7 @@ const SiteMap = () => {
                           <>
                             <li>
                               <Link
-                                to="/$locale/profile/$userSlug"
+                                to="/profile/$userSlug"
                                 params={{
                                   userSlug: authUser.data.attributes.slug,
                                 }}
@@ -305,7 +305,7 @@ const SiteMap = () => {
                               </Link>
                             </li>
                             <li>
-                              <Link to="/$locale/profile/edit">
+                              <Link to="/profile/edit">
                                 <FormattedMessage
                                   {...messages.profileSettings}
                                 />
@@ -331,7 +331,7 @@ const SiteMap = () => {
                           {customStaticPages.map((item) => (
                             <li key={item.id}>
                               <Link
-                                to="/$locale/pages/$slug"
+                                to="/pages/$slug"
                                 params={{ slug: item.attributes.slug }}
                               >
                                 {localize(item.attributes.title_multiloc)}

--- a/front/app/containers/UsersEditPage/DeletionDialog.tsx
+++ b/front/app/containers/UsersEditPage/DeletionDialog.tsx
@@ -100,7 +100,11 @@ const DeletionDialog = ({
               {...messages.privacyReasons}
               values={{
                 conditionsLink: (
-                  <Link to="/$locale/pages/$slug" params={{ slug: "terms-and-conditions" }} target="_blank">
+                  <Link
+                    to="/pages/$slug"
+                    params={{ slug: 'terms-and-conditions' }}
+                    target="_blank"
+                  >
                     <FormattedMessage {...messages.conditionsLinkText} />
                   </Link>
                 ),

--- a/front/app/containers/UsersEditPage/LoginCredentials.tsx
+++ b/front/app/containers/UsersEditPage/LoginCredentials.tsx
@@ -54,7 +54,7 @@ const LoginCredentials = ({ user }: PasswordChangeProps) => {
       />
       <Box display="flex" flexWrap="wrap" gap="16px">
         <ButtonWithLink
-          linkTo="/profile/change-email"
+          to="/$locale/profile/change-email"
           scrollToTop
           width="auto"
           justifyWrapper="left"
@@ -65,7 +65,7 @@ const LoginCredentials = ({ user }: PasswordChangeProps) => {
         </ButtonWithLink>
         {showChangePassword && (
           <ButtonWithLink
-            linkTo="/profile/change-password"
+            to="/$locale/profile/change-password"
             scrollToTop
             width="auto"
             justifyWrapper="left"

--- a/front/app/containers/UsersEditPage/LoginCredentials.tsx
+++ b/front/app/containers/UsersEditPage/LoginCredentials.tsx
@@ -54,7 +54,7 @@ const LoginCredentials = ({ user }: PasswordChangeProps) => {
       />
       <Box display="flex" flexWrap="wrap" gap="16px">
         <ButtonWithLink
-          to="/$locale/profile/change-email"
+          to="/profile/change-email"
           scrollToTop
           width="auto"
           justifyWrapper="left"
@@ -65,7 +65,7 @@ const LoginCredentials = ({ user }: PasswordChangeProps) => {
         </ButtonWithLink>
         {showChangePassword && (
           <ButtonWithLink
-            to="/$locale/profile/change-password"
+            to="/profile/change-password"
             scrollToTop
             width="auto"
             justifyWrapper="left"

--- a/front/app/containers/UsersEditPage/ProfileForm.tsx
+++ b/front/app/containers/UsersEditPage/ProfileForm.tsx
@@ -226,7 +226,11 @@ const ProfileForm = () => {
                     {...commentsMessages.profanityError}
                     values={{
                       guidelinesLink: (
-                        <Link to="/$locale/pages/$slug" params={{ slug: "faq" }} target="_blank">
+                        <Link
+                          to="/pages/$slug"
+                          params={{ slug: 'faq' }}
+                          target="_blank"
+                        >
                           {formatMessage(commentsMessages.guidelinesLinkText)}
                         </Link>
                       ),

--- a/front/app/containers/UsersShowPage/PostCommentGroup.tsx
+++ b/front/app/containers/UsersShowPage/PostCommentGroup.tsx
@@ -145,7 +145,7 @@ const PostCommentGroup = ({ comments, userId, postId }: Props) => {
         <FormattedMessage {...messages.a11y_postCommentPostedIn} />
       </ScreenReaderOnly>
       <PostLink
-        to="/$locale/ideas/$slug"
+        to="/ideas/$slug"
         params={{ slug }}
         search={{ go_back: 'true' }}
       >

--- a/front/app/containers/UsersShowPage/UserHeader.tsx
+++ b/front/app/containers/UsersShowPage/UserHeader.tsx
@@ -167,7 +167,7 @@ const UserHeader = ({ userSlug }: Props) => {
           )}
         {!isNilOrError(authUser) && authUser.data.id === user.data.id && (
           <ButtonWithLink
-            linkTo="/profile/edit"
+            to="/$locale/profile/edit"
             buttonStyle="text"
             icon="edit"
             className="e2e-edit-profile"

--- a/front/app/containers/UsersShowPage/UserHeader.tsx
+++ b/front/app/containers/UsersShowPage/UserHeader.tsx
@@ -167,7 +167,7 @@ const UserHeader = ({ userSlug }: Props) => {
           )}
         {!isNilOrError(authUser) && authUser.data.id === user.data.id && (
           <ButtonWithLink
-            to="/$locale/profile/edit"
+            to="/profile/edit"
             buttonStyle="text"
             icon="edit"
             className="e2e-edit-profile"

--- a/front/app/modules/commercial/admin_project_templates/admin/components/UseTemplateModal.tsx
+++ b/front/app/modules/commercial/admin_project_templates/admin/components/UseTemplateModal.tsx
@@ -30,7 +30,6 @@ import Modal from 'components/UI/Modal';
 import { trackEventByName } from 'utils/analytics';
 import { injectIntl, FormattedMessage } from 'utils/cl-intl';
 import Link from 'utils/cl-router/Link';
-import { useParams } from 'utils/router';
 import eventEmitter from 'utils/eventEmitter';
 import { convertToGraphqlLocale, isNilOrError } from 'utils/helperUtils';
 import { isAdmin } from 'utils/permissions/roles';
@@ -38,6 +37,7 @@ import {
   userModeratesFolder,
   isProjectFolderModerator,
 } from 'utils/permissions/rules/projectFolderPermissions';
+import { useParams } from 'utils/router';
 
 import tracks from '../../tracks';
 import useApplyProjectTemplate from '../api/useApplyProjectTemplate';
@@ -382,7 +382,7 @@ const UseTemplateModal = memo<Props & WrappedComponentProps>(
                     {...messages.goBackTo}
                     values={{
                       goBackLink: (
-                        <Link to="/$locale/admin/projects/">
+                        <Link to="/admin/projects/">
                           <FormattedMessage
                             {...messages.projectsOverviewPage}
                           />

--- a/front/app/modules/commercial/flag_inappropriate_content/admin/containers/Setting/index.tsx
+++ b/front/app/modules/commercial/flag_inappropriate_content/admin/containers/Setting/index.tsx
@@ -95,7 +95,7 @@ const FlagInnapropriateContentSetting = ({
                     {...messages.inappropriateContentDetectionToggleTooltip}
                     values={{
                       linkToActivityPage: (
-                        <Link to="/$locale/admin/dashboard/moderation">
+                        <Link to="/admin/dashboard/moderation">
                           {formatMessage(messages.linkToActivityPageText)}
                         </Link>
                       ),

--- a/front/app/modules/commercial/idea_assignment/admin/containers/index.tsx
+++ b/front/app/modules/commercial/idea_assignment/admin/containers/index.tsx
@@ -37,7 +37,7 @@ const InputAssignment = ({ projectId }: Props) => {
               {...messages.inputAssignmentTooltipText}
               values={{
                 globalInputManagerLink: (
-                  <StyledLink to="/$locale/admin/ideas">
+                  <StyledLink to="/admin/ideas">
                     <FormattedMessage
                       {...messages.globalInputManagerLinkText}
                     />

--- a/front/app/utils/cl-router/Link.tsx
+++ b/front/app/utils/cl-router/Link.tsx
@@ -16,12 +16,39 @@ import useLocale from 'hooks/useLocale';
 
 import { scrollToTop as scrollTop } from 'utils/scroll';
 
+// Strip the leading `/$locale` segment from a typed-route literal so callsites
+// can pass raw paths like `/admin/users` or `/projects/$slug`. The Link wrapper
+// auto-prepends `/$locale` at runtime, so consumers shouldn't have to write it.
+type StripLocale<T> = T extends '/$locale'
+  ? '/'
+  : T extends `/$locale/${infer Rest}`
+  ? `/${Rest}`
+  : T;
+
+// The set of `to` values the wrapper accepts. Includes both the stripped form
+// (preferred) and the original prefixed form (for transitional callsites and
+// any code that passes typed routes through unchanged).
+export type WrapperTo =
+  | StripLocale<NonNullable<LinkProps['to']>>
+  | LinkProps['to'];
+
+// Inverse of StripLocale — adds `/$locale` back so we feed TanStack the real
+// registered route literal for params/search type correlation when callsites
+// pass the stripped form.
+type AddLocale<T> = T extends `/$locale${string}`
+  ? T
+  : T extends '/'
+  ? '/$locale'
+  : T extends `/${infer Rest}`
+  ? `/$locale/${Rest}`
+  : T;
+
 // Shared shape for components that forward a typed-link target to Link or
 // ButtonWithLink. `to` is the typed-route literal (compile-checked against the
 // route tree); `params` and `search` are loose at this boundary because the
 // strict typing kicks in at the consuming Link callsite.
 export type TypedLinkProps = {
-  to?: LinkProps['to'];
+  to?: WrapperTo;
   params?: Record<string, string>;
   search?: Record<string, unknown>;
 };
@@ -99,10 +126,13 @@ type WithLocaleAwareParams<P> = P extends { params: infer TP }
   ? Omit<P, 'params'> & { params?: WithOptionalLocale<TP> }
   : P;
 
-// Wrapper-specific Link signature: `to`, `params`, and `search` keep full
-// TanStack type-safety against the route tree. The only relaxation is that
-// `locale` is optional within `params` — the wrapper auto-injects it from
-// `useLocale()`. Other route params (e.g. `projectId`) remain required.
+// Wrapper-specific Link signature: `to` accepts the stripped form (preferred,
+// e.g. `/admin/users`) or the prefixed form (e.g. `/$locale/admin/users`).
+// `params` and `search` keep TanStack type-safety against the route tree —
+// internally we feed TanStack `AddLocale<TTo>` so the strict route literal
+// drives params/search shape resolution. The locale is optional within
+// `params` — the wrapper auto-injects it from `useLocale()`. Other route
+// params (e.g. `projectId`) remain required.
 type LocaleAwareLink<TComp> = <
   TRouter extends AnyRouter = RegisteredRouter,
   const TFrom extends string = string,
@@ -110,9 +140,19 @@ type LocaleAwareLink<TComp> = <
   const TMaskFrom extends string = TFrom,
   const TMaskTo extends string = ''
 >(
-  props: WithLocaleAwareParams<
-    LinkComponentProps<TComp, TRouter, TFrom, TTo, TMaskFrom, TMaskTo>
-  >
+  props: Omit<
+    WithLocaleAwareParams<
+      LinkComponentProps<
+        TComp,
+        TRouter,
+        TFrom,
+        TTo extends string ? AddLocale<TTo> : TTo,
+        TMaskFrom,
+        TMaskTo
+      >
+    >,
+    'to'
+  > & { to?: TTo }
 ) => React.ReactElement;
 
 // Implementation-side props: the public `LocaleAwareLink<>` signature is the
@@ -133,7 +173,14 @@ type LinkImplProps = ExtraProps &
 
 const Link = (props: LinkImplProps) => {
   const locale = useLocale();
-  const { params, onlyActiveOnIndex, activeOptions, ...rest } = props;
+  const { to, params, onlyActiveOnIndex, activeOptions, ...rest } = props;
+
+  // Auto-prepend `/$locale` to absolute internal paths that don't already have
+  // it. Mirrors __mocks__/Link.tsx so test href assertions match runtime.
+  const resolvedTo =
+    typeof to === 'string' && to.startsWith('/') && !to.startsWith('/$locale')
+      ? `/$locale${to}`
+      : to;
 
   const mergedParams =
     typeof params === 'function'
@@ -152,6 +199,7 @@ const Link = (props: LinkImplProps) => {
   // erased to keep the wrapper non-generic.
   const linkProps = {
     ...rest,
+    to: resolvedTo,
     params: mergedParams,
     activeOptions: resolvedActiveOptions,
   } as React.ComponentProps<typeof TypedLink>;

--- a/front/app/utils/cl-router/Link.tsx
+++ b/front/app/utils/cl-router/Link.tsx
@@ -7,6 +7,7 @@ import {
   type CreateLinkProps,
   type LinkComponent,
   type LinkComponentProps,
+  type LinkProps,
   type RegisteredRouter,
 } from '@tanstack/react-router';
 import styled from 'styled-components';
@@ -14,6 +15,16 @@ import styled from 'styled-components';
 import useLocale from 'hooks/useLocale';
 
 import { scrollToTop as scrollTop } from 'utils/scroll';
+
+// Shared shape for components that forward a typed-link target to Link or
+// ButtonWithLink. `to` is the typed-route literal (compile-checked against the
+// route tree); `params` and `search` are loose at this boundary because the
+// strict typing kicks in at the consuming Link callsite.
+export type TypedLinkProps = {
+  to?: LinkProps['to'];
+  params?: Record<string, string>;
+  search?: Record<string, unknown>;
+};
 
 // styled-components erases the generic-function shape of typed router
 // components like cl-router/Link, so `styled(Link)` drops route-aware typing.

--- a/front/app/utils/cl-router/__mocks__/Link.tsx
+++ b/front/app/utils/cl-router/__mocks__/Link.tsx
@@ -24,4 +24,9 @@ const Link = ({
   return <a {...rest} href={href} />;
 };
 
+// Mirror the runtime helper so styled(Link) wrappers in tests don't crash.
+// Passes the component through unchanged — styling isn't asserted in unit
+// tests, so this is enough.
+export const typedStyled = (component: any) => () => component;
+
 export default Link;

--- a/front/app/utils/configs/formActionsConfig/utils.tsx
+++ b/front/app/utils/configs/formActionsConfig/utils.tsx
@@ -3,9 +3,11 @@ import { Multiloc } from 'typings';
 import { UpdatePhaseObject, IPhaseData } from 'api/phases/types';
 import { IProjectData } from 'api/projects/types';
 
+import { type TypedLinkProps } from 'utils/cl-router/Link';
+
 type FormActionsConfig = {
   phaseId?: string;
-  inputImporterLink: string;
+  inputImporterLink: TypedLinkProps;
   heading?: Multiloc;
   postingEnabled: boolean;
   togglePostingEnabled: () => void;
@@ -18,7 +20,10 @@ export const getFormActionsConfig = (
 ): FormActionsConfig => {
   return {
     phaseId: phase.id,
-    inputImporterLink: `/admin/projects/${project.id}/phases/${phase.id}/input-importer`,
+    inputImporterLink: {
+      to: '/admin/projects/$projectId/phases/$phaseId/input-importer',
+      params: { projectId: project.id, phaseId: phase.id },
+    },
     heading: phase.attributes.title_multiloc,
     postingEnabled: phase.attributes.submission_enabled,
     togglePostingEnabled: () => {


### PR DESCRIPTION
## Summary

Builds on #13732. Three threads:

1. **`ButtonWithLink` + 12 forwarder components extended** to accept typed `to` / `params` / `search` alongside legacy `linkTo: string | null`. Migrated ~150 ButtonWithLink callsites to the typed shape.

2. **Centralized `TypedLinkProps`** in `cl-router/Link`. The 13 typed-link forwarders (GoBackButton, FeatureCallout, ViewCustomPageButton, NotificationWrapper, navbar items, etc.) now share a single source of truth for the `to` / `params` / `search` trio.

3. **Runtime auto-prepend of `/$locale`** in the `Link` wrapper, mirroring the existing test mock. Fixes a real runtime bug — clicking the admin sidebar from `/en/admin/dashboard/overview` was navigating to `/admin/users` (locale stripped) and rendering "Not Found". Same bug affected dashboard sub-tabs, navbar items, and any other place that passed a runtime path string. With auto-prepend in place, every callsite now uses raw paths (`/admin/users`, `/projects/$slug`) — no `/$locale` prefix anywhere outside the wrapper itself.

## What changed

### Foundation — `cl-router/Link.tsx`

- Added mapped types `StripLocale<T>` and `AddLocale<T>` (inverse). Exported `WrapperTo` — the union of stripped + prefixed route literals.
- `LocaleAwareLink<TComp>` accepts `TTo` in stripped form and feeds `AddLocale<TTo>` to TanStack internally, so strict params/search type correlation against the route tree is preserved.
- Runtime wrapper auto-prepends `/$locale` to absolute internal paths that don't already have it. Already-prefixed callsites pass through unchanged.
- Exported `TypedLinkProps` as the single source of truth for the typed-link prop trio.

### Mock — `__mocks__/Link.tsx`

- Added `typedStyled` export so `styled(Link)` wrappers don't crash in tests.

### `ButtonWithLink` + forwarder components

- `ButtonWithLink` accepts typed `to` / `params` / `search` (via `TypedLinkProps`) plus legacy `linkTo: string | null` for arbitrary admin-supplied URLs and external links.
- 13 forwarders extended to accept the typed shape: `GoBackButton`, `GoBackButtonSolid`, `FeatureCallout`, `BannerButton`, `ViewCustomPageButton`, `AcceptButton`, `NewIdeaButton`, `EditStatusButton`, `NotificationWrapper`, `FullMobileNavMenuItem`, `DesktopNavbarItem`, `MoreNavbarItem`.
- New typed helper `adminProjectsProjectLink(projectId)` (mirrors `adminCustomPageContentLink` from #13732).
- Sidebar `MenuItem` migrated `styled(Link)<{ active }>` → `typedStyled(Link)` with className-based active state.
- Adjacent type-driven fixups: `Section`, `ProjectFolderCard`, `VotingResultCard` migrated `styled(Link)` → `typedStyled(Link)`. `TreeView/_shared/Link` loosened internal props. `Breadcrumbs` switched from spread to explicit prop forwarding. `Row.tsx` (admin/projects/all/Projects/Table) converted `<Box as={Link}>` → `<Link><Box>`.

### Callsite migrations

- ~150 ButtonWithLink callsites migrated from `linkTo` (string) to typed `to` / `params` / `search`.
- ~150 typed callsites had `/$locale/` dropped from the literal (now `to=\"/admin/users\"`, `to=\"/projects/$slug\" params={{ slug }}`).
- Helpers' return literals updated: `adminProjectsProjectLink`, `adminCustomPageContentLink`, `pagesAndMenuBreadcrumbLink`, `getProjectLinkProps`, `getPublicationLinkProps`.
- Discriminated-union types (`editLink` / `statsLink` in Email rows, `linkToTagManager` in FilterSidebar) stripped `/$locale`.
- 75 `useParams({ from: '/$locale/...' })` call sites preserved — those are TanStack route discriminators, not URL targets.

### Deep prop chain migrations

Migrated several string-typed prop chains to `TypedLinkProps`, removing intermediate `linkTo` plumbing:

- **`ViewCustomPageButton` chain** — `linkToViewPage: string` → `viewPageLink: TypedLinkProps` across `GenericTopInfoSection`, `GenericBottomInfoSection`, `GenericHeroBannerForm` and their callers (CustomPages Edit Top/Bottom/HeroBanner).
- **Survey/idea form-builder chain** — `viewFormLink: string` → `viewFormLink: TypedLinkProps` through `FormBuilderTopBar` → `FormBuilder/edit` → `SurveyFormBuilder` / `IdeaFormBuilder` / `CommunityMonitorFormBuilder`. `inputImporterLink` in `getFormActionsConfig` returns `TypedLinkProps`. `linkToSurveyBuilder` (SurveyHeading) and `linkToFormBuilder` (NewIdeaHeading) typed.
- **DescriptionBuilder chain** — `previewPath: string` → `previewLink: TypedLinkProps` through `DescriptionBuilderTopBar` → `DescriptionBuilder/index` → `Project`/`Folder`DescriptionBuilder pages. Test fixtures updated.
- **Volunteering AllCauses** — inline-typed `to`/`params` instead of constructed string.
- **ReportBuilder Analyses** — `projectLink: string` discriminated union → typed-link discriminated union.
- **InputImporter TopBar** — `getBackPath` → `getBackLink` returning `TypedLinkProps` based on `participationMethod`.
- **IdeasFeedPage mobile back** — `getMobileBackLinkTo` → `getMobileBackLink` returning `TypedLinkProps`.
- **Settings statuses** — dynamic `${variant}` URLs migrated to runtime branch on `'ideation' | 'proposals'` typed routes.

## Audit: legacy `linkTo` — what remains and why

22 `linkTo` callsites legitimately remain. They fall into categories where a string-typed prop is genuinely required and typed routes can't apply:

| Category | Count | Why it stays |
|---|---|---|
| Admin-supplied URLs | ~12 | `customButtonUrl`, `banner_cta_button_url`, content-builder admin inputs (`ButtonMultiloc`, `Spotlight`, `CallToAction`), form-builder page-button URLs (`PageButtonSettings`, `PageControlButtons`), event `using_url`, `customerPortalUrl` — admins enter arbitrary strings into a form, runtime URL of unknown shape |
| External URLs | ~10 | Support articles via `formatMessage(messages.linkToSupport)`, Google Maps, mailto via `getMailLink({...})`, Intercom, `${window.location.origin}/workshops` — these render `<a href>`, not `<Link>` |
| Module-registered route | 1 | `/admin/tools/widgets` — registered via `ModuleConfiguration` in the commercial engine, not statically known to TanStack at compile time. Making it typed would require crossing the free/commercial boundary; out of scope here. |
| API-derived runtime path | 1 | `notification.attributes.flaggable_path` (`NLPFlagNotification`) — backend supplies the path; can't be statically typed |
| Forwarder pass-throughs | 11 | `linkTo={linkTo}` inside the forwarder components themselves. Stay so the legacy string path keeps working for the categories above and any external callers. |
| `goBackUrl` fallback in `FormBuilderTopBar` | 1 | Used for both `clHistory.push(...)` (which takes a string) and a Link target. Migrating would split it; left as `linkTo` for now. |
| `editLink` in `createHighlighterLink` (`InternalCommentNotification`) | 1 | Builds a hash-anchor URL via `createHighlighterLink`. `Link` doesn't natively accept hash segments via the typed `to` shape; left as `linkTo`. |

The contained `as LinkProps['to']` cast inside `ButtonWithLink` only fires on the legacy `linkTo` path. Future cleanup options if we want to tighten further: rename `linkTo` → `externalUrl` to clarify intent, or split into `externalUrl` + `dynamicUrl` to discriminate genuinely-external vs admin-supplied-may-be-internal.

## Test plan

- [x] `cd front && npm run typecheck` — clean
- [x] `cd front && npm run lint` — clean
- [x] `cd front && npm test` — 545 suites, 1928 tests passing
- [x] Manual smoke:
  - Sidebar items (Users, Projects, Ideas, Messaging, etc.) keep `/en/` prefix
  - Dashboard sub-tabs (Overview / Users / Visitors / Representativeness / Participation feed / Management feed) keep `/en/`
  - Admin TabbedResource sub-tabs
  - Notifications dropdown links
  - GoBackButton flows (e.g. `/en/admin/projects/new` → back, `/en/admin/projects/<id>/phases/<id>/input-importer` → back)
  - Breadcrumbs in admin pages-menu
  - Survey/form-builder edit + preview flows (`viewFormLink`)
  - Description builder preview link
  - Volunteering "Add cause" button
  - ReportBuilder "Open project" CTA
  - IdeasFeedPage mobile back button
  - Settings → Statuses → Add status / Edit status (both `ideation` and `proposals` variants)
  - Module-registered route `/en/admin/tools/widgets`
- [ ] Verify a typed callsite still gets IntelliSense and that a typo'd route fails compile