### PR TITLE
[TAN-7687] Remove redundant tabIndex on voting CTA submit button wrapper

### DIFF
--- a/front/app/components/ParticipationCTABars/VotingCTABar/CTAButton.tsx
+++ b/front/app/components/ParticipationCTABars/VotingCTABar/CTAButton.tsx
@@ -155,9 +155,7 @@ const CTAButton = ({ phase, project }: Props) => {
         placement="bottom"
         content={disabledExplanation}
       >
-        {/* We need to add a tabIndex of 0 to
-        make sure this is keyboard-focusable so screen reader software can read the explanation */}
-        <Box width="100%" tabIndex={disabledExplanation ? 0 : -1}>
+        <Box width="100%">
           <StyledButton
             icon="vote-ballot"
             buttonStyle="primary-inverse"


### PR DESCRIPTION
# Changelog
## Fixed
- [TAN-7687] Remove redundant tabIndex on voting CTA submit button wrapper

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
