### PR TITLE
TAN-7690 Incorrect aria attribute on date picker

### DIFF
--- a/front/app/component-library/components/Tooltip/index.tsx
+++ b/front/app/component-library/components/Tooltip/index.tsx
@@ -145,7 +145,6 @@ const Tooltip = ({
         plugins={PLUGINS}
         interactive={true}
         role="tooltip"
-        aria={{ expanded: false }}
         visible={isFocused}
         // Ensures tippy works with both keyboard and mouse
         onHidden={handleOnHidden}
@@ -166,7 +165,6 @@ const Tooltip = ({
           plugins={PLUGINS}
           interactive={true}
           role="tooltip"
-          aria={{ expanded: false }}
           visible={isFocused}
           // Ensures tippy works with both keyboard and mouse
           onHidden={handleOnHidden}

--- a/front/app/component-library/utils/containers/InputContainer.tsx
+++ b/front/app/component-library/utils/containers/InputContainer.tsx
@@ -51,6 +51,7 @@ interface Props {
   disabled?: boolean;
   children: React.ReactNode;
   className?: string;
+  ariaExpanded?: boolean;
   onClick?: () => void;
   onMouseEnter?: () => void;
   onMouseLeave?: () => void;
@@ -63,6 +64,7 @@ const InputContainer = ({
   disabled = false,
   children,
   className,
+  ariaExpanded,
   onClick,
   onMouseEnter,
   onMouseLeave,
@@ -76,6 +78,7 @@ const InputContainer = ({
       disabled={disabled}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
+      aria-expanded={ariaExpanded}
       onClick={(e) => {
         if (disabled) return;
         e.preventDefault();

--- a/front/app/components/admin/DatePickers/DateSinglePicker/Input.tsx
+++ b/front/app/components/admin/DatePickers/DateSinglePicker/Input.tsx
@@ -10,10 +10,17 @@ interface Props {
   id?: string;
   disabled?: boolean;
   selectedDate?: Date;
+  ariaExpanded?: boolean;
   onClick: () => void;
 }
 
-const Input = ({ id, disabled, selectedDate, onClick }: Props) => {
+const Input = ({
+  id,
+  disabled,
+  selectedDate,
+  ariaExpanded,
+  onClick,
+}: Props) => {
   const { formatMessage } = useIntl();
   const selectDate = formatMessage(sharedMessages.selectDate);
 
@@ -23,6 +30,7 @@ const Input = ({ id, disabled, selectedDate, onClick }: Props) => {
       id={id}
       disabled={disabled}
       className="e2e-date-single-picker-input"
+      ariaExpanded={ariaExpanded}
     >
       <Box mr="8px">
         {selectedDate ? selectedDate.toLocaleDateString() : selectDate}

--- a/front/app/components/admin/DatePickers/DateSinglePicker/index.tsx
+++ b/front/app/components/admin/DatePickers/DateSinglePicker/index.tsx
@@ -55,6 +55,7 @@ const DateSinglePicker = ({
           id={id}
           disabled={disabled}
           selectedDate={selectedDate}
+          ariaExpanded={calendarOpen}
           onClick={() => setCalendarOpen(true)}
         />
       </Tooltip>


### PR DESCRIPTION
@EdwinKato see here for a description: https://www.notion.so/govocal/Incorrect-ARIA-use-in-date-picker-span-2929663b7b2680b29a3df2c2f76d289a

I removed the `aria-expanded` attribute from all Tippy tooltips. I did this for 2 reasons:

1. Tippy wraps a `span` around the trigger (the thing that you click for the tooltip to appear, in this example a `button`) and puts the aria attribute on the `span` wrapper. But according to the reviewers, this is wrong and the attribute should always be on the trigger (`button`). 
2. The value never changes- i.e. `aria-expanded` should become `true` when the thing is expanded I assume? But it never does.

So I figured we should probably remove it? But not fully sure so wanted to check with you first.

# Changelog
## Changed
- Removed aria attribute from tippy tooltip, and move it to trigger (button) instead
