### PR TITLE
TAN-6517: Make Navigate type-safe against the route tree

### DIFF
--- a/front/app/components/admin/FormSync/ImportInputsSection.tsx
+++ b/front/app/components/admin/FormSync/ImportInputsSection.tsx
@@ -10,7 +10,6 @@ import {
   colors,
   stylingConsts,
 } from '@citizenlab/cl2-component-library';
-import { useParams } from 'utils/router';
 
 import useFeatureFlag from 'hooks/useFeatureFlag';
 
@@ -18,6 +17,7 @@ import { FormType } from 'components/FormBuilder/utils';
 import UpsellTooltip from 'components/UpsellTooltip';
 
 import { FormattedMessage, useIntl } from 'utils/cl-intl';
+import { useParams } from 'utils/router';
 
 import ExcelImportButton from './components/ExcelImportButton';
 import PDFImportButton from './components/PDFImportButton';

--- a/front/app/containers/Admin/communityMonitor/routes.tsx
+++ b/front/app/containers/Admin/communityMonitor/routes.tsx
@@ -2,7 +2,8 @@ import React, { lazy } from 'react';
 
 import PageLoading from 'components/UI/PageLoading';
 
-import { createRoute, Navigate } from 'utils/router';
+import Navigate from 'utils/cl-router/Navigate';
+import { createRoute } from 'utils/router';
 
 import { adminRoute } from '../routes';
 
@@ -46,7 +47,9 @@ const communityMonitorRoute = createRoute({
 const communityMonitorIndexRoute = createRoute({
   getParentRoute: () => communityMonitorRoute,
   path: '/',
-  component: () => <Navigate to="live-monitor" replace />,
+  component: () => (
+    <Navigate to="/admin/community-monitor/live-monitor" replace />
+  ),
 });
 
 const liveMonitorRoute = createRoute({
@@ -83,7 +86,9 @@ const settingsRoute = createRoute({
 const settingsIndexRoute = createRoute({
   getParentRoute: () => settingsRoute,
   path: '/',
-  component: () => <Navigate to="survey" replace />,
+  component: () => (
+    <Navigate to="/admin/community-monitor/settings/survey" replace />
+  ),
 });
 
 const settingsSurveyRoute = createRoute({

--- a/front/app/containers/Admin/messaging/routes.tsx
+++ b/front/app/containers/Admin/messaging/routes.tsx
@@ -4,7 +4,8 @@ import * as yup from 'yup';
 
 import PageLoading from 'components/UI/PageLoading';
 
-import { createRoute, Navigate } from 'utils/router';
+import Navigate from 'utils/cl-router/Navigate';
+import { createRoute } from 'utils/router';
 
 import { adminRoute } from '../routes';
 
@@ -37,7 +38,7 @@ const messagingRoute = createRoute({
 const messagingIndexRoute = createRoute({
   getParentRoute: () => messagingRoute,
   path: '/',
-  component: () => <Navigate to="emails/custom" />,
+  component: () => <Navigate to="/admin/messaging/emails/custom" />,
 });
 
 const customEmailsRoute = createRoute({

--- a/front/app/containers/Admin/pagesAndMenu/routes.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/routes.tsx
@@ -2,7 +2,8 @@ import React, { lazy } from 'react';
 
 import PageLoading from 'components/UI/PageLoading';
 
-import { createRoute, Navigate } from 'utils/router';
+import Navigate from 'utils/cl-router/Navigate';
+import { createRoute, useParams } from 'utils/router';
 
 import { adminRoute } from '../routes';
 
@@ -122,10 +123,22 @@ const customPageRoute = createRoute({
   component: () => <EditCustomPageIndex />,
 });
 
+const CustomPageIndexRedirect = () => {
+  const { customPageId } = useParams({
+    from: '/$locale/admin/pages-menu/pages/$customPageId',
+  });
+  return (
+    <Navigate
+      to="/admin/pages-menu/pages/$customPageId/settings"
+      params={{ customPageId }}
+    />
+  );
+};
+
 const customPageIndexRoute = createRoute({
   getParentRoute: () => customPageRoute,
   path: '/',
-  component: () => <Navigate to="settings" />,
+  component: CustomPageIndexRedirect,
 });
 
 const customPageSettingsRoute = createRoute({

--- a/front/app/containers/Admin/projectFolders/routes.tsx
+++ b/front/app/containers/Admin/projectFolders/routes.tsx
@@ -2,7 +2,8 @@ import React, { lazy } from 'react';
 
 import PageLoading from 'components/UI/PageLoading';
 
-import { createRoute, Navigate, Outlet as RouterOutlet } from 'utils/router';
+import Navigate from 'utils/cl-router/Navigate';
+import { createRoute, Outlet as RouterOutlet, useParams } from 'utils/router';
 
 import { adminRoute } from '../routes';
 
@@ -41,10 +42,22 @@ const projectFoldersIdRoute = createRoute({
   ),
 });
 
+const ProjectFoldersIdDefaultRedirect = () => {
+  const { projectFolderId } = useParams({
+    from: '/$locale/admin/projects/folders/$projectFolderId',
+  });
+  return (
+    <Navigate
+      to="/admin/projects/folders/$projectFolderId/projects"
+      params={{ projectFolderId }}
+    />
+  );
+};
+
 const projectFoldersIdDefaultRoute = createRoute({
   getParentRoute: () => projectFoldersIdRoute,
   path: '/',
-  component: () => <Navigate to="projects" />,
+  component: ProjectFoldersIdDefaultRedirect,
 });
 
 const projectFoldersIdProjectsRoute = createRoute({

--- a/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/VotingInputs/votingMethodInputs/BudgetingInputs.tsx
+++ b/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/VotingInputs/votingMethodInputs/BudgetingInputs.tsx
@@ -6,8 +6,8 @@ import { SectionField, SubSectionTitle } from 'components/admin/Section';
 
 import { FormattedMessage } from 'utils/cl-intl';
 
-import messages from '../../../../../../../messages';
 import { LabelBudgetingInput } from '../../../../../../../../_shared/components/labels';
+import messages from '../../../../../../../messages';
 import {
   BudgetingAmountInput,
   VotingAmountInputError,

--- a/front/app/containers/Admin/projects/routes.tsx
+++ b/front/app/containers/Admin/projects/routes.tsx
@@ -4,8 +4,9 @@ import * as yup from 'yup';
 
 import PageLoading from 'components/UI/PageLoading';
 
+import Navigate from 'utils/cl-router/Navigate';
 import { parseModuleRoutes, RouteConfiguration } from 'utils/moduleUtils';
-import { createRoute, Navigate } from 'utils/router';
+import { createRoute, useParams } from 'utils/router';
 
 import { adminRoute } from '../routes';
 
@@ -175,10 +176,23 @@ const projectRoute = createRoute({
 });
 
 // Project index redirect
+const ProjectIndexRedirect = () => {
+  const { projectId } = useParams({
+    from: '/$locale/admin/projects/$projectId',
+  });
+  return (
+    <Navigate
+      to="/admin/projects/$projectId/phases/setup"
+      params={{ projectId }}
+      replace
+    />
+  );
+};
+
 const projectIndexRoute = createRoute({
   getParentRoute: () => projectRoute,
   path: '/',
-  component: () => <Navigate to="phases/setup" replace />,
+  component: ProjectIndexRedirect,
 });
 
 // --- General settings layout ---

--- a/front/app/containers/Admin/reporting/routes.tsx
+++ b/front/app/containers/Admin/reporting/routes.tsx
@@ -4,7 +4,8 @@ import * as yup from 'yup';
 
 import PageLoading from 'components/UI/PageLoading';
 
-import { createRoute, Navigate } from 'utils/router';
+import Navigate from 'utils/cl-router/Navigate';
+import { createRoute } from 'utils/router';
 
 import { adminRoute } from '../routes';
 
@@ -68,7 +69,7 @@ const reportEditorRoute = createRoute({
 const reportingRedirectRoute = createRoute({
   getParentRoute: () => adminRoute,
   path: 'reporting',
-  component: () => <Navigate to="report-builder" />,
+  component: () => <Navigate to="/admin/reporting/report-builder" />,
 });
 
 const createAdminReportingRoutes = () => {

--- a/front/app/containers/Admin/routes.tsx
+++ b/front/app/containers/Admin/routes.tsx
@@ -9,11 +9,13 @@ import useAppConfiguration from 'api/app_configuration/useAppConfiguration';
 import PageLoading from 'components/UI/PageLoading';
 import Unauthorized from 'components/Unauthorized';
 
+import clHistory from 'utils/cl-router/history';
+import Navigate from 'utils/cl-router/Navigate';
 import { removeLocale } from 'utils/cl-router/updateLocationDescriptor';
 import { isUUID } from 'utils/helperUtils';
 import type { Routes } from 'utils/moduleUtils';
 import { usePermission } from 'utils/permissions';
-import { createRoute, Navigate, useLocation } from 'utils/router';
+import { createRoute, useLocation } from 'utils/router';
 
 import createAdminCommunityMonitorRoutes from './communityMonitor/routes';
 import createAdminDashboardRoutes from './dashboard/routes';
@@ -62,15 +64,16 @@ const isTemplatePreviewPage = (urlSegments: string[]) =>
   urlSegments[2] === 'templates' &&
   isUUID(urlSegments[3]);
 
-const getRedirectURL = (
-  appConfiguration: IAppConfigurationData,
-  pathname: string | undefined,
-  urlLocale: string | null
-) => {
-  const localeSegment = urlLocale ? `/${urlLocale}` : '';
+type UnauthorizedRedirect =
+  | { kind: 'subscriptionEnded' }
+  | { kind: 'templatePreview'; templateId: string };
 
+const getUnauthorizedRedirect = (
+  appConfiguration: IAppConfigurationData,
+  pathname: string | undefined
+): UnauthorizedRedirect | null => {
   if (appConfiguration.attributes.settings.core.lifecycle_stage === 'churned') {
-    return `${localeSegment}/subscription-ended`;
+    return { kind: 'subscriptionEnded' };
   }
 
   // get array with url segments (e.g. 'admin/projects/all' becomes ['admin', 'projects', 'all'])
@@ -80,9 +83,7 @@ const getRedirectURL = (
 
   // check if the unauthorized user is trying to access a template preview page (url pattern: /admin/projects/templates/[id])
   if (urlSegments && isTemplatePreviewPage(urlSegments)) {
-    const templateId = urlSegments[3];
-    // if so, redirect them to the citizen-facing version of the template preview page (url pattern: /templates/[id])
-    return `${localeSegment}/templates/${templateId}`;
+    return { kind: 'templatePreview', templateId: urlSegments[3] };
   }
 
   return null;
@@ -90,7 +91,7 @@ const getRedirectURL = (
 
 const AdminLayoutElement = () => {
   const location = useLocation();
-  const { pathname, urlLocale } = removeLocale(location.pathname);
+  const { pathname } = removeLocale(location.pathname);
 
   const accessAuthorized = usePermission({
     item: { type: 'route', path: pathname },
@@ -101,14 +102,20 @@ const AdminLayoutElement = () => {
 
   if (!appConfiguration) return null;
 
-  const redirectURL = accessAuthorized
+  const redirect = accessAuthorized
     ? null
-    : getRedirectURL(appConfiguration.data, pathname, urlLocale);
+    : getUnauthorizedRedirect(appConfiguration.data, pathname);
 
-  if (!redirectURL && !accessAuthorized) {
+  if (!redirect && !accessAuthorized) {
     return <Unauthorized />;
-  } else if (redirectURL) {
-    return <Navigate to={redirectURL} />;
+  }
+
+  if (redirect?.kind === 'subscriptionEnded') {
+    return <Navigate to="/subscription-ended" />;
+  }
+
+  if (redirect?.kind === 'templatePreview') {
+    return <TemplatePreviewRedirect templateId={redirect.templateId} />;
   }
 
   return (
@@ -116,6 +123,18 @@ const AdminLayoutElement = () => {
       <AdminContainer />
     </PageLoading>
   );
+};
+
+// The citizen template-preview route (`/templates/:projectTemplateId`) is
+// registered by the `admin_project_templates` commercial module and isn't part
+// of the static typed route tree, so we can't pass it through the typed
+// `Navigate` wrapper. Push through `clHistory` (which auto-prepends the
+// locale) instead.
+const TemplatePreviewRedirect = ({ templateId }: { templateId: string }) => {
+  React.useEffect(() => {
+    clHistory.push(`/templates/${templateId}`);
+  }, [templateId]);
+  return null;
 };
 
 // Admin layout route - parent for all admin routes
@@ -131,7 +150,7 @@ const adminIndexRoute = createRoute({
   // Careful: moderators currently have access to the admin index route
   // Adjust isModerator in routePermissions.ts if needed.
   path: '/',
-  component: () => <Navigate to="dashboard/overview" />,
+  component: () => <Navigate to="/admin/dashboard/overview" />,
 });
 
 // Favicon route

--- a/front/app/containers/Admin/settings/routes.tsx
+++ b/front/app/containers/Admin/settings/routes.tsx
@@ -4,7 +4,8 @@ import * as yup from 'yup';
 
 import PageLoading from 'components/UI/PageLoading';
 
-import { createRoute, Navigate } from 'utils/router';
+import Navigate from 'utils/cl-router/Navigate';
+import { createRoute } from 'utils/router';
 
 import { adminRoute } from '../routes';
 
@@ -72,7 +73,7 @@ export const settingsRoute = createRoute({
 const settingsIndexRoute = createRoute({
   getParentRoute: () => settingsRoute,
   path: '/',
-  component: () => <Navigate to="general" replace />,
+  component: () => <Navigate to="/admin/settings/general" replace />,
 });
 
 const generalRoute = createRoute({
@@ -216,7 +217,7 @@ const topicsRoute = createRoute({
 const topicsIndexRoute = createRoute({
   getParentRoute: () => topicsRoute,
   path: '/',
-  component: () => <Navigate to="platform" replace />,
+  component: () => <Navigate to="/admin/settings/topics/platform" replace />,
 });
 
 const platformRoute = createRoute({

--- a/front/app/containers/IdeasNewPage/index.tsx
+++ b/front/app/containers/IdeasNewPage/index.tsx
@@ -112,7 +112,9 @@ const IdeasNewPage = () => {
   if (participationMethod === 'native_survey' && typeof phaseId === 'string') {
     return (
       <Navigate
-        to={`/projects/${slug}/surveys/new?phase_id=${phaseId}`}
+        to="/projects/$slug/surveys/new"
+        params={{ slug }}
+        search={{ phase_id: phaseId }}
         replace
       />
     );

--- a/front/app/containers/UsersShowPage/routes.tsx
+++ b/front/app/containers/UsersShowPage/routes.tsx
@@ -4,7 +4,8 @@ import { localeRoute } from 'routes';
 
 import PageLoading from 'components/UI/PageLoading';
 
-import { createRoute, Navigate } from 'utils/router';
+import Navigate from 'utils/cl-router/Navigate';
+import { createRoute, useParams } from 'utils/router';
 
 const UsersShowPage = lazy(() => import('./'));
 const Following = lazy(() => import('./Following'));
@@ -34,10 +35,23 @@ export const createUserShowPageRoutes = () => {
     ),
   });
 
+  const ProfileIndexRedirect = () => {
+    const { userSlug } = useParams({
+      from: '/$locale/profile/$userSlug',
+    });
+    return (
+      <Navigate
+        to="/profile/$userSlug/submissions"
+        params={{ userSlug }}
+        replace
+      />
+    );
+  };
+
   const profileIndexRoute = createRoute({
     getParentRoute: () => profileRoute,
     path: '/',
-    component: () => <Navigate to="submissions" replace />,
+    component: ProfileIndexRedirect,
   });
 
   const submissionsRoute = createRoute({

--- a/front/app/routes.tsx
+++ b/front/app/routes.tsx
@@ -262,9 +262,22 @@ const projectIdeaNewRoute = createRoute({
   ),
 });
 
+const projectSurveyNewSearchSchema = yup.object({
+  phase_id: yup.string().optional(),
+  idea_id: yup.string().optional(),
+});
+
+type ProjectSurveyNewSearchParams = yup.InferType<
+  typeof projectSurveyNewSearchSchema
+>;
+
 const projectSurveyNewRoute = createRoute({
   getParentRoute: () => localeRoute,
   path: 'projects/$slug/surveys/new',
+  validateSearch: (
+    search: Record<string, unknown>
+  ): ProjectSurveyNewSearchParams =>
+    projectSurveyNewSearchSchema.validateSync(search, { stripUnknown: true }),
   component: () => (
     <PageLoading>
       <IdeasNewSurveyPage />

--- a/front/app/utils/cl-router/Link.tsx
+++ b/front/app/utils/cl-router/Link.tsx
@@ -109,9 +109,13 @@ const Link = (props: LinkImplProps) => {
 
   // Auto-prepend `/$locale` to absolute internal paths that don't already have
   // it. Mirrors __mocks__/Link.tsx so test href assertions match runtime.
+  // `'/'` is special-cased to `'/$locale'` (no trailing slash) so the runtime
+  // string lines up with the type-level `AddLocale<'/'>`.
   const resolvedTo =
     typeof to === 'string' && to.startsWith('/') && !to.startsWith('/$locale')
-      ? `/$locale${to}`
+      ? to === '/'
+        ? '/$locale'
+        : `/$locale${to}`
       : to;
 
   const mergedParams =

--- a/front/app/utils/cl-router/Link.tsx
+++ b/front/app/utils/cl-router/Link.tsx
@@ -7,7 +7,6 @@ import {
   type CreateLinkProps,
   type LinkComponent,
   type LinkComponentProps,
-  type LinkProps,
   type RegisteredRouter,
 } from '@tanstack/react-router';
 import styled from 'styled-components';
@@ -16,42 +15,9 @@ import useLocale from 'hooks/useLocale';
 
 import { scrollToTop as scrollTop } from 'utils/scroll';
 
-// Strip the leading `/$locale` segment from a typed-route literal so callsites
-// can pass raw paths like `/admin/users` or `/projects/$slug`. The Link wrapper
-// auto-prepends `/$locale` at runtime, so consumers shouldn't have to write it.
-type StripLocale<T> = T extends '/$locale'
-  ? '/'
-  : T extends `/$locale/${infer Rest}`
-  ? `/${Rest}`
-  : T;
+import type { AddLocale, WithLocaleAwareParams } from './localeAware';
 
-// The set of `to` values the wrapper accepts. Includes both the stripped form
-// (preferred) and the original prefixed form (for transitional callsites and
-// any code that passes typed routes through unchanged).
-export type WrapperTo =
-  | StripLocale<NonNullable<LinkProps['to']>>
-  | LinkProps['to'];
-
-// Inverse of StripLocale — adds `/$locale` back so we feed TanStack the real
-// registered route literal for params/search type correlation when callsites
-// pass the stripped form.
-type AddLocale<T> = T extends `/$locale${string}`
-  ? T
-  : T extends '/'
-  ? '/$locale'
-  : T extends `/${infer Rest}`
-  ? `/$locale/${Rest}`
-  : T;
-
-// Shared shape for components that forward a typed-link target to Link or
-// ButtonWithLink. `to` is the typed-route literal (compile-checked against the
-// route tree); `params` and `search` are loose at this boundary because the
-// strict typing kicks in at the consuming Link callsite.
-export type TypedLinkProps = {
-  to?: WrapperTo;
-  params?: Record<string, string>;
-  search?: Record<string, unknown>;
-};
+export type { WrapperTo, TypedLinkProps } from './localeAware';
 
 // styled-components erases the generic-function shape of typed router
 // components like cl-router/Link, so `styled(Link)` drops route-aware typing.
@@ -91,40 +57,6 @@ const Inner = React.forwardRef<HTMLAnchorElement, InnerProps>(
 Inner.displayName = 'ClRouterLinkInner';
 
 const TypedLink: LinkComponent<typeof Inner> = createLink(Inner);
-
-// Make `locale` optional inside a resolved params object/reducer while keeping
-// every other key strictly typed against the route tree. Distributes over the
-// `true | object | (prev) => object` union that TanStack emits for `params`.
-type WithOptionalLocale<TP> = TP extends true
-  ? TP
-  : TP extends (...args: infer A) => infer R
-  ? (...args: A) => WithOptionalLocale<R>
-  : TP extends Record<string, unknown>
-  ? Omit<TP, 'locale'> & {
-      locale?: TP extends { locale: infer L } ? L : string;
-    }
-  : TP;
-
-// `never` if every key of T is optional, else the union of required keys.
-// Used to decide whether `params` itself can be demoted from required to
-// optional after `locale` is made optional within it.
-type RequiredKeysOf<T> = {
-  [K in keyof T]-?: {} extends Pick<T, K> ? never : K;
-}[keyof T];
-
-// Replace the resolved `params` shape on `LinkComponentProps` with a
-// locale-optional version. If `locale` was the only required param on the
-// route (so making it optional leaves no required keys), `params` itself is
-// also demoted to optional — otherwise required-ness is preserved.
-type WithLocaleAwareParams<P> = P extends { params: infer TP }
-  ? [
-      RequiredKeysOf<Extract<WithOptionalLocale<TP>, Record<string, unknown>>>
-    ] extends [never]
-    ? Omit<P, 'params'> & { params?: WithOptionalLocale<TP> }
-    : Omit<P, 'params'> & { params: WithOptionalLocale<TP> }
-  : P extends { params?: infer TP }
-  ? Omit<P, 'params'> & { params?: WithOptionalLocale<TP> }
-  : P;
 
 // Wrapper-specific Link signature: `to` accepts the stripped form (preferred,
 // e.g. `/admin/users`) or the prefixed form (e.g. `/$locale/admin/users`).

--- a/front/app/utils/cl-router/Navigate.tsx
+++ b/front/app/utils/cl-router/Navigate.tsx
@@ -1,18 +1,85 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 
-import clHistory from 'utils/cl-router/history';
+import {
+  type AnyRouter,
+  Navigate as TanstackNavigate,
+  type NavigateOptions,
+  type RegisteredRouter,
+} from '@tanstack/react-router';
 
-interface Props {
-  to: string;
-  replace?: boolean;
-}
+import useLocale from 'hooks/useLocale';
 
-const Navigate = ({ to, replace = false }: Props) => {
-  useEffect(() => {
-    replace ? clHistory.replace(to) : clHistory.push(to);
-  }, [to, replace]);
+import type { AddLocale, WithLocaleAwareParams } from './localeAware';
 
-  return <></>;
+// Wrapper-specific Navigate signature: same locale-aware typing as
+// `cl-router/Link`. `to` accepts the stripped form (preferred, e.g.
+// `/admin/users`) or the prefixed form (e.g. `/$locale/admin/users`).
+// Internally we feed TanStack `AddLocale<TTo>` so the strict registered route
+// literal drives params/search shape resolution; the wrapper auto-injects
+// `locale` from `useLocale()` at runtime.
+type LocaleAwareNavigate = <
+  TRouter extends AnyRouter = RegisteredRouter,
+  const TFrom extends string = string,
+  const TTo extends string | undefined = undefined,
+  const TMaskFrom extends string = TFrom,
+  const TMaskTo extends string = ''
+>(
+  props: Omit<
+    WithLocaleAwareParams<
+      NavigateOptions<
+        TRouter,
+        TFrom,
+        TTo extends string ? AddLocale<TTo> : TTo,
+        TMaskFrom,
+        TMaskTo
+      >
+    >,
+    'to'
+  > & { to?: TTo }
+) => React.ReactElement | null;
+
+// Implementation-side props: the public `LocaleAwareNavigate` signature is the
+// source of truth (applied via the cast on `export default` below). Internally
+// we widen `params` to the loose union TanStack emits so the body can
+// destructure and remap without per-call generic resolution.
+type ParamsValue =
+  | true
+  | Record<string, unknown>
+  | ((prev: unknown) => Record<string, unknown>);
+
+type NavigateImplProps = Omit<NavigateOptions, 'params'> & {
+  params?: ParamsValue;
 };
 
-export default Navigate;
+const Navigate = (props: NavigateImplProps) => {
+  const locale = useLocale();
+  const { to, params, ...rest } = props;
+
+  // Auto-prepend `/$locale` to absolute internal paths that don't already have
+  // it. Mirrors the behavior of `cl-router/Link`.
+  const resolvedTo =
+    typeof to === 'string' && to.startsWith('/') && !to.startsWith('/$locale')
+      ? `/$locale${to}`
+      : to;
+
+  const mergedParams =
+    typeof params === 'function'
+      ? (prev: unknown) => ({ locale, ...params(prev) })
+      : params && params !== true
+      ? { locale, ...params }
+      : { locale };
+
+  // Single contained cast: the public `LocaleAwareNavigate` type already
+  // enforces the route-aware shape on callers; here we hand the resolved
+  // (locale-merged) props to TanStack's Navigate, whose generic param/search
+  // types we've intentionally erased to keep the wrapper non-generic.
+  const navigateProps = {
+    ...rest,
+    to: resolvedTo,
+    params: mergedParams,
+  } as React.ComponentProps<typeof TanstackNavigate>;
+
+  return <TanstackNavigate {...navigateProps} />;
+};
+
+export default Navigate as LocaleAwareNavigate;

--- a/front/app/utils/cl-router/Navigate.tsx
+++ b/front/app/utils/cl-router/Navigate.tsx
@@ -56,10 +56,14 @@ const Navigate = (props: NavigateImplProps) => {
   const { to, params, ...rest } = props;
 
   // Auto-prepend `/$locale` to absolute internal paths that don't already have
-  // it. Mirrors the behavior of `cl-router/Link`.
+  // it. Mirrors the behavior of `cl-router/Link`. `'/'` is special-cased to
+  // `'/$locale'` (no trailing slash) so the runtime string lines up with the
+  // type-level `AddLocale<'/'>`.
   const resolvedTo =
     typeof to === 'string' && to.startsWith('/') && !to.startsWith('/$locale')
-      ? `/$locale${to}`
+      ? to === '/'
+        ? '/$locale'
+        : `/$locale${to}`
       : to;
 
   const mergedParams =

--- a/front/app/utils/cl-router/__mocks__/Link.tsx
+++ b/front/app/utils/cl-router/__mocks__/Link.tsx
@@ -5,7 +5,11 @@ const buildHref = (
   params: Record<string, unknown> = {}
 ): string => {
   if (typeof to !== 'string') return '#';
-  const withLocale = to.startsWith('/$locale') ? to : `/$locale${to}`;
+  const withLocale = to.startsWith('/$locale')
+    ? to
+    : to === '/'
+    ? '/$locale'
+    : `/$locale${to}`;
   return withLocale.replace(/\$([a-zA-Z_][a-zA-Z0-9_]*)/g, (_match, key) => {
     const v = params[key];
     return v == null ? `$${key}` : String(v);

--- a/front/app/utils/cl-router/__mocks__/Navigate.tsx
+++ b/front/app/utils/cl-router/__mocks__/Navigate.tsx
@@ -1,0 +1,5 @@
+// Tests don't assert on Navigate behavior (it renders nothing and triggers a
+// route change), so the mock is a no-op.
+const Navigate = (_props: any) => null;
+
+export default Navigate;

--- a/front/app/utils/cl-router/localeAware.ts
+++ b/front/app/utils/cl-router/localeAware.ts
@@ -1,0 +1,73 @@
+import type { LinkProps } from '@tanstack/react-router';
+
+// Strip the leading `/$locale` segment from a typed-route literal so callsites
+// can pass raw paths like `/admin/users` or `/projects/$slug`. The Link/Navigate
+// wrappers auto-prepend `/$locale` at runtime, so consumers shouldn't have to
+// write it.
+export type StripLocale<T> = T extends '/$locale'
+  ? '/'
+  : T extends `/$locale/${infer Rest}`
+  ? `/${Rest}`
+  : T;
+
+// The set of `to` values the wrappers accept. Includes both the stripped form
+// (preferred) and the original prefixed form (for transitional callsites and
+// any code that passes typed routes through unchanged).
+export type WrapperTo =
+  | StripLocale<NonNullable<LinkProps['to']>>
+  | LinkProps['to'];
+
+// Inverse of StripLocale — adds `/$locale` back so we feed TanStack the real
+// registered route literal for params/search type correlation when callsites
+// pass the stripped form.
+export type AddLocale<T> = T extends `/$locale${string}`
+  ? T
+  : T extends '/'
+  ? '/$locale'
+  : T extends `/${infer Rest}`
+  ? `/$locale/${Rest}`
+  : T;
+
+// Shared shape for components that forward a typed-link target to Link or
+// ButtonWithLink. `to` is the typed-route literal (compile-checked against the
+// route tree); `params` and `search` are loose at this boundary because the
+// strict typing kicks in at the consuming Link callsite.
+export type TypedLinkProps = {
+  to?: WrapperTo;
+  params?: Record<string, string>;
+  search?: Record<string, unknown>;
+};
+
+// Make `locale` optional inside a resolved params object/reducer while keeping
+// every other key strictly typed against the route tree. Distributes over the
+// `true | object | (prev) => object` union that TanStack emits for `params`.
+export type WithOptionalLocale<TP> = TP extends true
+  ? TP
+  : TP extends (...args: infer A) => infer R
+  ? (...args: A) => WithOptionalLocale<R>
+  : TP extends Record<string, unknown>
+  ? Omit<TP, 'locale'> & {
+      locale?: TP extends { locale: infer L } ? L : string;
+    }
+  : TP;
+
+// `never` if every key of T is optional, else the union of required keys.
+// Used to decide whether `params` itself can be demoted from required to
+// optional after `locale` is made optional within it.
+export type RequiredKeysOf<T> = {
+  [K in keyof T]-?: {} extends Pick<T, K> ? never : K;
+}[keyof T];
+
+// Replace the resolved `params` shape on a TanStack props type with a
+// locale-optional version. If `locale` was the only required param on the
+// route (so making it optional leaves no required keys), `params` itself is
+// also demoted to optional — otherwise required-ness is preserved.
+export type WithLocaleAwareParams<P> = P extends { params: infer TP }
+  ? [
+      RequiredKeysOf<Extract<WithOptionalLocale<TP>, Record<string, unknown>>>
+    ] extends [never]
+    ? Omit<P, 'params'> & { params?: WithOptionalLocale<TP> }
+    : Omit<P, 'params'> & { params: WithOptionalLocale<TP> }
+  : P extends { params?: infer TP }
+  ? Omit<P, 'params'> & { params?: WithOptionalLocale<TP> }
+  : P;

--- a/front/app/utils/router.tsx
+++ b/front/app/utils/router.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 
 /* eslint-disable no-restricted-imports */
 import {
@@ -6,7 +6,6 @@ import {
   type LinkComponent,
   type LinkProps,
   type RegisteredRouter,
-  Navigate as TanstackNavigate,
   Link,
   Outlet,
   RouterProvider,
@@ -31,8 +30,4 @@ export const useSearch = (_options: any) => {
       ],
     [searchStr]
   );
-};
-
-export const Navigate = (props: any) => {
-  return <TanstackNavigate {...props} />;
 };


### PR DESCRIPTION
## Approach

- Bring `Navigate` to the same standard as the typed `Link` from #13732: route literals validated against the route tree, `params`/`search` per-route-typed, `locale` auto-injected from `useLocale()`.
- Extract the locale-aware type machinery (`StripLocale`, `AddLocale`, `WithLocaleAwareParams`, `WithOptionalLocale`, `RequiredKeysOf`, `WrapperTo`, `TypedLinkProps`) out of `Link.tsx` into a shared `front/app/utils/cl-router/localeAware.ts` module so both the typed Link and Navigate wrappers reuse it. `Link.tsx` re-exports `WrapperTo`/`TypedLinkProps` for backward compat — no callsite changes.
- Replace the imperative `cl-router/Navigate.tsx` (which used `clHistory.push` in a `useEffect`) with a typed wrapper around TanStack Router's `<Navigate>`. Same `LocaleAwareNavigate<>` signature pattern as `LocaleAwareLink<>`, minus the anchor/scroll plumbing.
- Drop the `(props: any) => <TanstackNavigate {...props} />` escape-hatch export from `utils/router.tsx`. There is now one canonical typed Navigate; routes files import from `utils/cl-router/Navigate`.
- Migrate all 15 callsites:
  - 10 `routes.tsx` redirects converted from relative (`<Navigate to="dashboard/overview" />`) to typed absolute (`<Navigate to="/admin/dashboard/overview" />`).
  - 4 redirects under dynamic parents (`$projectId`, `$projectFolderId`, `$customPageId`, `$userSlug`) wrap the redirect in a small component that reads `useParams({ from: '/$locale/...' })` and passes the param through `params={{ ... }}`.
  - The `IdeasNewPage` survey redirect goes from `to={`/projects/${slug}/surveys/new?phase_id=${phaseId}`}` to typed `to="/projects/$slug/surveys/new" params={{ slug }} search={{ phase_id }}`.
- Refactor the unauthorized-redirect logic in `Admin/routes.tsx`:
  - `/subscription-ended` (lifecycle-ended tenants) goes through the typed `Navigate`.
  - `/templates/$templateId` (registered by the `admin_project_templates` commercial module, not in the static typed route tree) falls through to `clHistory.push` in a small `<TemplatePreviewRedirect>` effect — same semantics as the previous behavior.
  - `urlLocale` parameter dropped from `getRedirectURL`/`getUnauthorizedRedirect`; the typed wrapper handles locale.
- Add a `validateSearch` yup schema (`phase_id`, `idea_id`) to `projectSurveyNewRoute` so the redirect can pass typed search params; the receiving `IdeasNewSurveyPage` already reads both via `URLSearchParams`.
- Stacked on `TAN-6517-typed-link-component` (#13732) — review can land Link first.