### PR TITLE
TAN-7681 Add embedded video title to Quill video

### DIFF
--- a/front/app/components/UI/QuillEditor/configureQuill.ts
+++ b/front/app/components/UI/QuillEditor/configureQuill.ts
@@ -9,6 +9,12 @@ import { isYouTubeEmbedLink } from 'utils/urlUtils';
 
 import { attributes, ImageBlot, KeepHTML } from './altTextToImagesModule';
 
+let embeddedVideoTitle = 'Embedded video';
+
+export const setEmbeddedVideoTitle = (title: string) => {
+  embeddedVideoTitle = title;
+};
+
 export const configureQuill = () => {
   // Pre-register imageAlign and iframeAlign formats so they exist in the
   // registry when Quill validates the "formats" whitelist during construction.
@@ -46,6 +52,8 @@ export const configureQuill = () => {
   class VideoFormat extends Video {
     static create(url: string) {
       const node = super.create(url);
+
+      node.setAttribute('title', embeddedVideoTitle);
 
       // Add referrer policy to YouTube video embeds
       if (isYouTubeEmbedLink(url)) {

--- a/front/app/components/UI/QuillEditor/configureQuill.ts
+++ b/front/app/components/UI/QuillEditor/configureQuill.ts
@@ -66,6 +66,9 @@ export const configureQuill = () => {
     static formats(domNode: Element) {
       return attributes.reduce(
         (formats: Record<string, string | null>, attribute) => {
+          // `title` is set dynamically from the current locale in `create`;
+          // skip it here so a stale title in saved HTML doesn't override it.
+          if (attribute === 'title') return formats;
           if (domNode.hasAttribute(attribute)) {
             formats[attribute] = domNode.getAttribute(attribute);
           }
@@ -75,6 +78,7 @@ export const configureQuill = () => {
       );
     }
     format(name: string, value: string) {
+      if (name === 'title') return;
       if (attributes.indexOf(name) > -1) {
         if (value) {
           this.domNode.setAttribute(name, value);

--- a/front/app/components/UI/QuillEditor/index.tsx
+++ b/front/app/components/UI/QuillEditor/index.tsx
@@ -15,7 +15,7 @@ import { useIntl } from 'utils/cl-intl';
 import 'quill/dist/quill.snow.css';
 import '@enzedonline/quill-blot-formatter2/dist/css/quill-blot-formatter2.css';
 
-import { configureQuill } from './configureQuill';
+import { configureQuill, setEmbeddedVideoTitle } from './configureQuill';
 import { createQuill } from './createQuill';
 import messages from './messages';
 import StyleContainer from './StyleContainer';
@@ -94,6 +94,8 @@ const QuillEditor = ({
     const editorContainer = container.appendChild(
       container.ownerDocument.createElement('div')
     );
+
+    setEmbeddedVideoTitle(formatMessage(messages.embeddedVideo));
 
     const quill = createQuill(editorContainer, {
       id,

--- a/front/app/components/UI/QuillEditor/messages.ts
+++ b/front/app/components/UI/QuillEditor/messages.ts
@@ -49,6 +49,10 @@ export default defineMessages({
     id: 'app.components.QuillEditor.video',
     defaultMessage: 'Add video',
   },
+  embeddedVideo: {
+    id: 'app.components.QuillEditor.embeddedVideo',
+    defaultMessage: 'Embedded video',
+  },
   link: {
     id: 'app.components.QuillEditor.link',
     defaultMessage: 'Add link',

--- a/front/app/translations/.polyglit.da-DK.json.json
+++ b/front/app/translations/.polyglit.da-DK.json.json
@@ -2909,6 +2909,11 @@
     "verified_at": "2026-03-18T12:49:36.657470Z",
     "verified_by": "Admin"
   },
+  "app.components.QuillEditor.embeddedVideo": {
+    "state": "verified",
+    "verified_at": "2026-05-05T17:03:31.214757Z",
+    "verified_by": "kielgast@govocal.com"
+  },
   "app.components.QuillEditor.image": {
     "state": "verified",
     "verified_at": "2026-03-18T12:49:36.657470Z",

--- a/front/app/translations/.polyglit.de-AT.json.json
+++ b/front/app/translations/.polyglit.de-AT.json.json
@@ -2909,6 +2909,11 @@
     "verified_at": "2026-03-30T12:57:38.368694Z",
     "verified_by": "Edwin Kato"
   },
+  "app.components.QuillEditor.embeddedVideo": {
+    "state": "verified",
+    "verified_at": "2026-05-05T11:41:00.809248Z",
+    "verified_by": "Jelena"
+  },
   "app.components.QuillEditor.image": {
     "state": "verified",
     "verified_at": "2026-03-30T12:57:38.368694Z",

--- a/front/app/translations/.polyglit.de-DE.json.json
+++ b/front/app/translations/.polyglit.de-DE.json.json
@@ -2909,6 +2909,11 @@
     "verified_at": "2026-03-18T15:41:17.347666Z",
     "verified_by": "Admin"
   },
+  "app.components.QuillEditor.embeddedVideo": {
+    "state": "verified",
+    "verified_at": "2026-05-05T11:41:00.688981Z",
+    "verified_by": "Jelena"
+  },
   "app.components.QuillEditor.image": {
     "state": "verified",
     "verified_at": "2026-03-18T15:41:17.347666Z",
@@ -9699,7 +9704,6 @@
     "verified_at": "2026-03-18T15:41:17.347666Z",
     "verified_by": "Admin"
   },
-
   "app.containers.NotificationMenu.spaceModerationRightsReceived": {
     "state": "verified",
     "verified_at": "2026-04-15T14:46:55.319599Z",
@@ -12555,7 +12559,6 @@
     "verified_at": "2026-03-18T15:41:17.347666Z",
     "verified_by": "Admin"
   },
-
   "app.modules.project_folder.citizen.components.Notification.youveReceivedFolderManagerRights": {
     "state": "verified",
     "verified_at": "2026-04-15T14:46:55.319599Z",

--- a/front/app/translations/.polyglit.fr-BE.json.json
+++ b/front/app/translations/.polyglit.fr-BE.json.json
@@ -2909,6 +2909,11 @@
     "verified_at": "2026-03-18T11:50:36.653533Z",
     "verified_by": "Admin"
   },
+  "app.components.QuillEditor.embeddedVideo": {
+    "state": "verified",
+    "verified_at": "2026-05-05T13:00:15.266485Z",
+    "verified_by": "Cindy EB"
+  },
   "app.components.QuillEditor.image": {
     "state": "verified",
     "verified_at": "2026-03-18T11:50:36.653533Z",

--- a/front/app/translations/.polyglit.fr-FR.json.json
+++ b/front/app/translations/.polyglit.fr-FR.json.json
@@ -2909,6 +2909,11 @@
     "verified_at": "2026-03-18T11:50:36.510849Z",
     "verified_by": "Admin"
   },
+  "app.components.QuillEditor.embeddedVideo": {
+    "state": "verified",
+    "verified_at": "2026-05-05T13:00:15.150761Z",
+    "verified_by": "Cindy EB"
+  },
   "app.components.QuillEditor.image": {
     "state": "verified",
     "verified_at": "2026-03-18T11:50:36.510849Z",

--- a/front/app/translations/.polyglit.nl-BE.json.json
+++ b/front/app/translations/.polyglit.nl-BE.json.json
@@ -2909,6 +2909,11 @@
     "verified_at": "2026-03-18T11:49:32.481338Z",
     "verified_by": "Admin"
   },
+  "app.components.QuillEditor.embeddedVideo": {
+    "state": "verified",
+    "verified_at": "2026-05-05T14:19:17.959545Z",
+    "verified_by": "Luuc"
+  },
   "app.components.QuillEditor.image": {
     "state": "verified",
     "verified_at": "2026-03-18T11:49:32.481338Z",

--- a/front/app/translations/.polyglit.nl-NL.json.json
+++ b/front/app/translations/.polyglit.nl-NL.json.json
@@ -2909,6 +2909,11 @@
     "verified_at": "2026-03-18T11:49:32.340815Z",
     "verified_by": "Admin"
   },
+  "app.components.QuillEditor.embeddedVideo": {
+    "state": "verified",
+    "verified_at": "2026-05-05T14:19:17.805484Z",
+    "verified_by": "Luuc"
+  },
   "app.components.QuillEditor.image": {
     "state": "verified",
     "verified_at": "2026-03-18T11:49:32.340815Z",

--- a/front/app/translations/ar-MA.json
+++ b/front/app/translations/ar-MA.json
@@ -581,7 +581,7 @@
   "app.components.QuillEditor.customLink": "أضِف زرًا",
   "app.components.QuillEditor.customLinkPrompt": "أدخل الرابط:",
   "app.components.QuillEditor.edit": "تعديل",
-  "app.components.QuillEditor.embeddedVideo": "فيديو مُضمن",
+  "app.components.QuillEditor.embeddedVideo": "فيديو مضمن",
   "app.components.QuillEditor.image": "تحميل صورة",
   "app.components.QuillEditor.imageTitleLabel": "عنوان الصورة",
   "app.components.QuillEditor.italic": "مائل",

--- a/front/app/translations/ar-MA.json
+++ b/front/app/translations/ar-MA.json
@@ -581,6 +581,7 @@
   "app.components.QuillEditor.customLink": "أضِف زرًا",
   "app.components.QuillEditor.customLinkPrompt": "أدخل الرابط:",
   "app.components.QuillEditor.edit": "تعديل",
+  "app.components.QuillEditor.embeddedVideo": "فيديو مُضمن",
   "app.components.QuillEditor.image": "تحميل صورة",
   "app.components.QuillEditor.imageTitleLabel": "عنوان الصورة",
   "app.components.QuillEditor.italic": "مائل",

--- a/front/app/translations/ar-SA.json
+++ b/front/app/translations/ar-SA.json
@@ -581,6 +581,7 @@
   "app.components.QuillEditor.customLink": "أضِف زرًا",
   "app.components.QuillEditor.customLinkPrompt": "أدخل الرابط:",
   "app.components.QuillEditor.edit": "تعديل",
+  "app.components.QuillEditor.embeddedVideo": "فيديو مضمن",
   "app.components.QuillEditor.image": "تحميل صورة",
   "app.components.QuillEditor.imageTitleLabel": "عنوان الصورة",
   "app.components.QuillEditor.italic": "مائل",

--- a/front/app/translations/ar-SA.json
+++ b/front/app/translations/ar-SA.json
@@ -581,7 +581,7 @@
   "app.components.QuillEditor.customLink": "أضِف زرًا",
   "app.components.QuillEditor.customLinkPrompt": "أدخل الرابط:",
   "app.components.QuillEditor.edit": "تعديل",
-  "app.components.QuillEditor.embeddedVideo": "فيديو مضمن",
+  "app.components.QuillEditor.embeddedVideo": "فيديو مُضمّن",
   "app.components.QuillEditor.image": "تحميل صورة",
   "app.components.QuillEditor.imageTitleLabel": "عنوان الصورة",
   "app.components.QuillEditor.italic": "مائل",

--- a/front/app/translations/ca-ES.json
+++ b/front/app/translations/ca-ES.json
@@ -581,6 +581,7 @@
   "app.components.QuillEditor.customLink": "Botó Afegir",
   "app.components.QuillEditor.customLinkPrompt": "Introduïu l'enllaç:",
   "app.components.QuillEditor.edit": "Editar",
+  "app.components.QuillEditor.embeddedVideo": "Vídeo incrustat",
   "app.components.QuillEditor.image": "Carregar la imatge",
   "app.components.QuillEditor.imageTitleLabel": "Títol de la imatge",
   "app.components.QuillEditor.italic": "Cursiva",

--- a/front/app/translations/cy-GB.json
+++ b/front/app/translations/cy-GB.json
@@ -581,6 +581,7 @@
   "app.components.QuillEditor.customLink": "Ychwanegu botwm",
   "app.components.QuillEditor.customLinkPrompt": "Rhowch ddolen:",
   "app.components.QuillEditor.edit": "Golygu",
+  "app.components.QuillEditor.embeddedVideo": "Fideo wedi'i fewnosod",
   "app.components.QuillEditor.image": "Uwchlwytho delwedd",
   "app.components.QuillEditor.imageTitleLabel": "Teitl y Delwedd",
   "app.components.QuillEditor.italic": "Italaidd",

--- a/front/app/translations/da-DK.json
+++ b/front/app/translations/da-DK.json
@@ -581,6 +581,7 @@
   "app.components.QuillEditor.customLink": "Tilføj knap",
   "app.components.QuillEditor.customLinkPrompt": "Indtast link:",
   "app.components.QuillEditor.edit": "Rediger",
+  "app.components.QuillEditor.embeddedVideo": "Indlejret video",
   "app.components.QuillEditor.image": "Overfør billede",
   "app.components.QuillEditor.imageTitleLabel": "Billedets titel",
   "app.components.QuillEditor.italic": "Kursiv",

--- a/front/app/translations/de-AT.json
+++ b/front/app/translations/de-AT.json
@@ -581,6 +581,7 @@
   "app.components.QuillEditor.customLink": "Button hinzufügen",
   "app.components.QuillEditor.customLinkPrompt": "Link eingeben:",
   "app.components.QuillEditor.edit": "Bearbeiten",
+  "app.components.QuillEditor.embeddedVideo": "Eingebettetes Video",
   "app.components.QuillEditor.image": "Bild hochladen",
   "app.components.QuillEditor.imageTitleLabel": "Bildtitel",
   "app.components.QuillEditor.italic": "Kursiv",

--- a/front/app/translations/de-DE.json
+++ b/front/app/translations/de-DE.json
@@ -581,6 +581,7 @@
   "app.components.QuillEditor.customLink": "Button hinzufügen",
   "app.components.QuillEditor.customLinkPrompt": "Link eingeben:",
   "app.components.QuillEditor.edit": "Bearbeiten",
+  "app.components.QuillEditor.embeddedVideo": "Eingebettetes Video",
   "app.components.QuillEditor.image": "Bild hochladen",
   "app.components.QuillEditor.imageTitleLabel": "Bildtitel",
   "app.components.QuillEditor.italic": "Kursiv",

--- a/front/app/translations/el-GR.json
+++ b/front/app/translations/el-GR.json
@@ -581,6 +581,7 @@
   "app.components.QuillEditor.customLink": "Προσθήκη κουμπιού",
   "app.components.QuillEditor.customLinkPrompt": "Εισαγωγή συνδέσμου:",
   "app.components.QuillEditor.edit": "Επεξεργασία",
+  "app.components.QuillEditor.embeddedVideo": "Ενσωματωμένο βίντεο",
   "app.components.QuillEditor.image": "Αποστολή εικόνας",
   "app.components.QuillEditor.imageTitleLabel": "Τίτλος εικόνας",
   "app.components.QuillEditor.italic": "Πλάγια γραφή",

--- a/front/app/translations/en-CA.json
+++ b/front/app/translations/en-CA.json
@@ -581,6 +581,7 @@
   "app.components.QuillEditor.customLink": "Add button",
   "app.components.QuillEditor.customLinkPrompt": "Enter link:",
   "app.components.QuillEditor.edit": "Edit",
+  "app.components.QuillEditor.embeddedVideo": "Embedded video",
   "app.components.QuillEditor.image": "Upload image",
   "app.components.QuillEditor.imageTitleLabel": "Image Title",
   "app.components.QuillEditor.italic": "Italic",

--- a/front/app/translations/en-GB.json
+++ b/front/app/translations/en-GB.json
@@ -581,6 +581,7 @@
   "app.components.QuillEditor.customLink": "Add button",
   "app.components.QuillEditor.customLinkPrompt": "Enter link:",
   "app.components.QuillEditor.edit": "Edit",
+  "app.components.QuillEditor.embeddedVideo": "Embedded video",
   "app.components.QuillEditor.image": "Upload image",
   "app.components.QuillEditor.imageTitleLabel": "Image Title",
   "app.components.QuillEditor.italic": "Italic",

--- a/front/app/translations/en-IE.json
+++ b/front/app/translations/en-IE.json
@@ -581,6 +581,7 @@
   "app.components.QuillEditor.customLink": "Add button",
   "app.components.QuillEditor.customLinkPrompt": "Enter link:",
   "app.components.QuillEditor.edit": "Edit",
+  "app.components.QuillEditor.embeddedVideo": "Embedded video",
   "app.components.QuillEditor.image": "Upload image",
   "app.components.QuillEditor.imageTitleLabel": "Image Title",
   "app.components.QuillEditor.italic": "Italic",

--- a/front/app/translations/en.json
+++ b/front/app/translations/en.json
@@ -581,6 +581,7 @@
   "app.components.QuillEditor.customLink": "Add button",
   "app.components.QuillEditor.customLinkPrompt": "Enter link:",
   "app.components.QuillEditor.edit": "Edit",
+  "app.components.QuillEditor.embeddedVideo": "Embedded video",
   "app.components.QuillEditor.image": "Upload image",
   "app.components.QuillEditor.imageTitleLabel": "Image Title",
   "app.components.QuillEditor.italic": "Italic",

--- a/front/app/translations/es-CL.json
+++ b/front/app/translations/es-CL.json
@@ -581,6 +581,7 @@
   "app.components.QuillEditor.customLink": "Añade un botón",
   "app.components.QuillEditor.customLinkPrompt": "Entrar al enlace:",
   "app.components.QuillEditor.edit": "Editar",
+  "app.components.QuillEditor.embeddedVideo": "Vídeo incrustado",
   "app.components.QuillEditor.image": "Subir imagen",
   "app.components.QuillEditor.imageTitleLabel": "Título de la imagen",
   "app.components.QuillEditor.italic": "Cursiva",

--- a/front/app/translations/es-ES.json
+++ b/front/app/translations/es-ES.json
@@ -581,6 +581,7 @@
   "app.components.QuillEditor.customLink": "Añade un botón",
   "app.components.QuillEditor.customLinkPrompt": "Entrar al enlace:",
   "app.components.QuillEditor.edit": "Editar",
+  "app.components.QuillEditor.embeddedVideo": "Vídeo incrustado",
   "app.components.QuillEditor.image": "Subir imagen",
   "app.components.QuillEditor.imageTitleLabel": "Título de la imagen",
   "app.components.QuillEditor.italic": "Cursiva",

--- a/front/app/translations/fi-FI.json
+++ b/front/app/translations/fi-FI.json
@@ -581,6 +581,7 @@
   "app.components.QuillEditor.customLink": "Lisää-painike",
   "app.components.QuillEditor.customLinkPrompt": "Anna linkki:",
   "app.components.QuillEditor.edit": "Muokkaa",
+  "app.components.QuillEditor.embeddedVideo": "Upotettu video",
   "app.components.QuillEditor.image": "Lataa kuva",
   "app.components.QuillEditor.imageTitleLabel": "Kuvan otsikko",
   "app.components.QuillEditor.italic": "Kursiivi",

--- a/front/app/translations/fr-BE.json
+++ b/front/app/translations/fr-BE.json
@@ -581,6 +581,7 @@
   "app.components.QuillEditor.customLink": "Ajouter un bouton",
   "app.components.QuillEditor.customLinkPrompt": "Entrer le lien :",
   "app.components.QuillEditor.edit": "Editer",
+  "app.components.QuillEditor.embeddedVideo": "Vidéo intégrée",
   "app.components.QuillEditor.image": "Charger une image",
   "app.components.QuillEditor.imageTitleLabel": "Titre de l'image",
   "app.components.QuillEditor.italic": "Italique",

--- a/front/app/translations/fr-FR.json
+++ b/front/app/translations/fr-FR.json
@@ -581,6 +581,7 @@
   "app.components.QuillEditor.customLink": "Ajouter un bouton",
   "app.components.QuillEditor.customLinkPrompt": "Entrer le lien :",
   "app.components.QuillEditor.edit": "Editer",
+  "app.components.QuillEditor.embeddedVideo": "Vidéo intégrée",
   "app.components.QuillEditor.image": "Charger une image",
   "app.components.QuillEditor.imageTitleLabel": "Titre de l'image",
   "app.components.QuillEditor.italic": "Italique",

--- a/front/app/translations/ga-IE.json
+++ b/front/app/translations/ga-IE.json
@@ -581,6 +581,7 @@
   "app.components.QuillEditor.customLink": "Cuir cnaipe leis",
   "app.components.QuillEditor.customLinkPrompt": "Cuir isteach nasc:",
   "app.components.QuillEditor.edit": "Cuir in Eagar",
+  "app.components.QuillEditor.embeddedVideo": "Físeán leabaithe",
   "app.components.QuillEditor.image": "Uaslódáil íomhá",
   "app.components.QuillEditor.imageTitleLabel": "Teideal na hÍomhá",
   "app.components.QuillEditor.italic": "Iodálach",

--- a/front/app/translations/hr-HR.json
+++ b/front/app/translations/hr-HR.json
@@ -581,6 +581,7 @@
   "app.components.QuillEditor.customLink": "Dodajte gumb",
   "app.components.QuillEditor.customLinkPrompt": "Unesite vezu:",
   "app.components.QuillEditor.edit": "Uredi",
+  "app.components.QuillEditor.embeddedVideo": "Ugrađeni videozapis",
   "app.components.QuillEditor.image": "Prenesite sliku",
   "app.components.QuillEditor.imageTitleLabel": "Naslov slike",
   "app.components.QuillEditor.italic": "Kurziv",

--- a/front/app/translations/hu-HU.json
+++ b/front/app/translations/hu-HU.json
@@ -581,6 +581,7 @@
   "app.components.QuillEditor.customLink": "Hozzáadás gomb",
   "app.components.QuillEditor.customLinkPrompt": "Írja be a linket:",
   "app.components.QuillEditor.edit": "Szerkesztés",
+  "app.components.QuillEditor.embeddedVideo": "Beágyazott videó",
   "app.components.QuillEditor.image": "Kép feltöltése",
   "app.components.QuillEditor.imageTitleLabel": "Kép címe",
   "app.components.QuillEditor.italic": "Dőlt",

--- a/front/app/translations/it-IT.json
+++ b/front/app/translations/it-IT.json
@@ -581,6 +581,7 @@
   "app.components.QuillEditor.customLink": "Aggiungi pulsante",
   "app.components.QuillEditor.customLinkPrompt": "Inserisci il link:",
   "app.components.QuillEditor.edit": "Modifica",
+  "app.components.QuillEditor.embeddedVideo": "Video incorporato",
   "app.components.QuillEditor.image": "Carica immagine",
   "app.components.QuillEditor.imageTitleLabel": "Titolo dell'immagine",
   "app.components.QuillEditor.italic": "Corsivo",

--- a/front/app/translations/kl-GL.json
+++ b/front/app/translations/kl-GL.json
@@ -581,6 +581,7 @@
   "app.components.QuillEditor.customLink": "Toortaammik ilanngussigit",
   "app.components.QuillEditor.customLinkPrompt": "Link allaguk:",
   "app.components.QuillEditor.edit": "Aaqqissuuguk",
+  "app.components.QuillEditor.embeddedVideo": "Video ikunneqartoq",
   "app.components.QuillEditor.image": "Assimik nuussigit",
   "app.components.QuillEditor.imageTitleLabel": "Image Title",
   "app.components.QuillEditor.italic": "Uingasoq",

--- a/front/app/translations/kl-GL.json
+++ b/front/app/translations/kl-GL.json
@@ -581,7 +581,7 @@
   "app.components.QuillEditor.customLink": "Toortaammik ilanngussigit",
   "app.components.QuillEditor.customLinkPrompt": "Link allaguk:",
   "app.components.QuillEditor.edit": "Aaqqissuuguk",
-  "app.components.QuillEditor.embeddedVideo": "Video ikunneqartoq",
+  "app.components.QuillEditor.embeddedVideo": "Video iigunneqartoq",
   "app.components.QuillEditor.image": "Assimik nuussigit",
   "app.components.QuillEditor.imageTitleLabel": "Image Title",
   "app.components.QuillEditor.italic": "Uingasoq",

--- a/front/app/translations/lb-LU.json
+++ b/front/app/translations/lb-LU.json
@@ -581,6 +581,7 @@
   "app.components.QuillEditor.customLink": "Knäppche bäifügen",
   "app.components.QuillEditor.customLinkPrompt": "Link aginn:",
   "app.components.QuillEditor.edit": "Beaarbechten",
+  "app.components.QuillEditor.embeddedVideo": "Agebettene Video",
   "app.components.QuillEditor.image": "Bild eroplueden",
   "app.components.QuillEditor.imageTitleLabel": "Bildtitel",
   "app.components.QuillEditor.italic": "Kursiv",

--- a/front/app/translations/lt-LT.json
+++ b/front/app/translations/lt-LT.json
@@ -581,6 +581,7 @@
   "app.components.QuillEditor.customLink": "Pridėti mygtuką",
   "app.components.QuillEditor.customLinkPrompt": "Įveskite nuorodą:",
   "app.components.QuillEditor.edit": "Redaguoti",
+  "app.components.QuillEditor.embeddedVideo": "Įterptas vaizdo įrašas",
   "app.components.QuillEditor.image": "Įkelti paveikslėlį",
   "app.components.QuillEditor.imageTitleLabel": "Vaizdo pavadinimas",
   "app.components.QuillEditor.italic": "Kursyvu",

--- a/front/app/translations/lv-LV.json
+++ b/front/app/translations/lv-LV.json
@@ -581,6 +581,7 @@
   "app.components.QuillEditor.customLink": "Pievienot pogu",
   "app.components.QuillEditor.customLinkPrompt": "Ievadīt saiti:",
   "app.components.QuillEditor.edit": "Rediģēt",
+  "app.components.QuillEditor.embeddedVideo": "Iegults video",
   "app.components.QuillEditor.image": "Augšupielādēt attēlu",
   "app.components.QuillEditor.imageTitleLabel": "Attēla nosaukums",
   "app.components.QuillEditor.italic": "Kursīvs",

--- a/front/app/translations/nb-NO.json
+++ b/front/app/translations/nb-NO.json
@@ -581,6 +581,7 @@
   "app.components.QuillEditor.customLink": "Legg til knapp",
   "app.components.QuillEditor.customLinkPrompt": "Skriv inn lenke:",
   "app.components.QuillEditor.edit": "Rediger",
+  "app.components.QuillEditor.embeddedVideo": "Innebygd video",
   "app.components.QuillEditor.image": "Last opp bilde",
   "app.components.QuillEditor.imageTitleLabel": "Bildetittel",
   "app.components.QuillEditor.italic": "Kursiv",

--- a/front/app/translations/nl-BE.json
+++ b/front/app/translations/nl-BE.json
@@ -581,6 +581,7 @@
   "app.components.QuillEditor.customLink": "Knop toevoegen",
   "app.components.QuillEditor.customLinkPrompt": "Geef de link in:",
   "app.components.QuillEditor.edit": "Bewerk",
+  "app.components.QuillEditor.embeddedVideo": "Ingebedde video",
   "app.components.QuillEditor.image": "Upload afbeelding",
   "app.components.QuillEditor.imageTitleLabel": "Titel afbeelding",
   "app.components.QuillEditor.italic": "Cursief",

--- a/front/app/translations/nl-BE.json
+++ b/front/app/translations/nl-BE.json
@@ -581,7 +581,7 @@
   "app.components.QuillEditor.customLink": "Knop toevoegen",
   "app.components.QuillEditor.customLinkPrompt": "Geef de link in:",
   "app.components.QuillEditor.edit": "Bewerk",
-  "app.components.QuillEditor.embeddedVideo": "Ingebedde video",
+  "app.components.QuillEditor.embeddedVideo": "Ingesloten video",
   "app.components.QuillEditor.image": "Upload afbeelding",
   "app.components.QuillEditor.imageTitleLabel": "Titel afbeelding",
   "app.components.QuillEditor.italic": "Cursief",

--- a/front/app/translations/nl-NL.json
+++ b/front/app/translations/nl-NL.json
@@ -581,6 +581,7 @@
   "app.components.QuillEditor.customLink": "Knop toevoegen",
   "app.components.QuillEditor.customLinkPrompt": "Geef de link in:",
   "app.components.QuillEditor.edit": "Bewerk",
+  "app.components.QuillEditor.embeddedVideo": "Ingebedde video",
   "app.components.QuillEditor.image": "Upload afbeelding",
   "app.components.QuillEditor.imageTitleLabel": "Titel afbeelding",
   "app.components.QuillEditor.italic": "Cursief",

--- a/front/app/translations/nl-NL.json
+++ b/front/app/translations/nl-NL.json
@@ -581,7 +581,7 @@
   "app.components.QuillEditor.customLink": "Knop toevoegen",
   "app.components.QuillEditor.customLinkPrompt": "Geef de link in:",
   "app.components.QuillEditor.edit": "Bewerk",
-  "app.components.QuillEditor.embeddedVideo": "Ingebedde video",
+  "app.components.QuillEditor.embeddedVideo": "Ingesloten video",
   "app.components.QuillEditor.image": "Upload afbeelding",
   "app.components.QuillEditor.imageTitleLabel": "Titel afbeelding",
   "app.components.QuillEditor.italic": "Cursief",

--- a/front/app/translations/pa-IN.json
+++ b/front/app/translations/pa-IN.json
@@ -581,6 +581,7 @@
   "app.components.QuillEditor.customLink": "ਬਟਨ ਸ਼ਾਮਲ ਕਰੋ",
   "app.components.QuillEditor.customLinkPrompt": "ਲਿੰਕ ਦਰਜ ਕਰੋ:",
   "app.components.QuillEditor.edit": "ਸੰਪਾਦਿਤ ਕਰੋ",
+  "app.components.QuillEditor.embeddedVideo": "ਐਮਬੈਡ ਕੀਤਾ ਵੀਡੀਓ",
   "app.components.QuillEditor.image": "ਚਿੱਤਰ ਅੱਪਲੋਡ ਕਰੋ",
   "app.components.QuillEditor.imageTitleLabel": "ਚਿੱਤਰ ਸਿਰਲੇਖ",
   "app.components.QuillEditor.italic": "ਇਟਾਲਿਕ",

--- a/front/app/translations/pa-IN.json
+++ b/front/app/translations/pa-IN.json
@@ -581,7 +581,7 @@
   "app.components.QuillEditor.customLink": "ਬਟਨ ਸ਼ਾਮਲ ਕਰੋ",
   "app.components.QuillEditor.customLinkPrompt": "ਲਿੰਕ ਦਰਜ ਕਰੋ:",
   "app.components.QuillEditor.edit": "ਸੰਪਾਦਿਤ ਕਰੋ",
-  "app.components.QuillEditor.embeddedVideo": "ਐਮਬੈਡ ਕੀਤਾ ਵੀਡੀਓ",
+  "app.components.QuillEditor.embeddedVideo": "ਐਮਬੇਡ ਕੀਤੀ ਵੀਡੀਓ",
   "app.components.QuillEditor.image": "ਚਿੱਤਰ ਅੱਪਲੋਡ ਕਰੋ",
   "app.components.QuillEditor.imageTitleLabel": "ਚਿੱਤਰ ਸਿਰਲੇਖ",
   "app.components.QuillEditor.italic": "ਇਟਾਲਿਕ",

--- a/front/app/translations/pl-PL.json
+++ b/front/app/translations/pl-PL.json
@@ -581,6 +581,7 @@
   "app.components.QuillEditor.customLink": "Dodaj przycisk",
   "app.components.QuillEditor.customLinkPrompt": "Podaj link:",
   "app.components.QuillEditor.edit": "Edycja",
+  "app.components.QuillEditor.embeddedVideo": "Osadzone wideo",
   "app.components.QuillEditor.image": "Prześlij obrazek",
   "app.components.QuillEditor.imageTitleLabel": "Tytuł obrazu",
   "app.components.QuillEditor.italic": "Kursywa",

--- a/front/app/translations/pt-BR.json
+++ b/front/app/translations/pt-BR.json
@@ -581,6 +581,7 @@
   "app.components.QuillEditor.customLink": "Adicionar botão",
   "app.components.QuillEditor.customLinkPrompt": "Entrar link:",
   "app.components.QuillEditor.edit": "Editar",
+  "app.components.QuillEditor.embeddedVideo": "Vídeo incorporado",
   "app.components.QuillEditor.image": "Carregar imagem",
   "app.components.QuillEditor.imageTitleLabel": "Título da imagem",
   "app.components.QuillEditor.italic": "Itálico",

--- a/front/app/translations/sv-SE.json
+++ b/front/app/translations/sv-SE.json
@@ -581,6 +581,7 @@
   "app.components.QuillEditor.customLink": "Lägg till knapp",
   "app.components.QuillEditor.customLinkPrompt": "Ange länk:",
   "app.components.QuillEditor.edit": "Redigera",
+  "app.components.QuillEditor.embeddedVideo": "Inbäddad video",
   "app.components.QuillEditor.image": "Ladda upp bild",
   "app.components.QuillEditor.imageTitleLabel": "Bildtitel",
   "app.components.QuillEditor.italic": "Kursiv",

--- a/front/app/translations/tr-TR.json
+++ b/front/app/translations/tr-TR.json
@@ -581,6 +581,7 @@
   "app.components.QuillEditor.customLink": "Düğme ekle",
   "app.components.QuillEditor.customLinkPrompt": "Bağlantıyı girin:",
   "app.components.QuillEditor.edit": "Düzenle",
+  "app.components.QuillEditor.embeddedVideo": "Gömülü video",
   "app.components.QuillEditor.image": "Görsel yükleyin",
   "app.components.QuillEditor.imageTitleLabel": "Resim Başlığı",
   "app.components.QuillEditor.italic": "İtalik",

--- a/front/app/translations/ur-PK.json
+++ b/front/app/translations/ur-PK.json
@@ -581,6 +581,7 @@
   "app.components.QuillEditor.customLink": "بٹن شامل کریں۔",
   "app.components.QuillEditor.customLinkPrompt": "لنک درج کریں:",
   "app.components.QuillEditor.edit": "ترمیم کریں۔",
+  "app.components.QuillEditor.embeddedVideo": "شامل کردہ ویڈیو",
   "app.components.QuillEditor.image": "تصویر اپ لوڈ کریں۔",
   "app.components.QuillEditor.imageTitleLabel": "تصویر کا عنوان",
   "app.components.QuillEditor.italic": "ترچھا",


### PR DESCRIPTION
# Changelog
## Fixed
- a11y - videos added through Quill now have accessible title

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
