### PR TITLE
TAN-7692 - Add setting to hide submission ID after survey submission

### DIFF
--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -1711,6 +1711,18 @@
             "private": true
           }
         }
+      },
+
+      "hide_submission_removal_text": {
+        "type": "object",
+        "title": "Hide submission removal text",
+        "description": "Do not give users the option to remove survey submissions (post survey & in email confirmation). WARNING: Should only be used where GPDR does not apply.",
+        "additionalProperties": false,
+        "required": ["allowed", "enabled"],
+        "properties": {
+          "allowed": { "type": "boolean", "default": false },
+          "enabled": { "type": "boolean", "default": false }
+        }
       }
     },
   "dependencies": {

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/survey_submitted_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/survey_submitted_mailer.rb
@@ -23,7 +23,8 @@ module EmailCampaigns
           idea_id: data.idea.id,
           project_title_multiloc: data.project.title_multiloc,
           profile_url: "#{Frontend::UrlService.new.home_url}/profile/#{recipient.slug}/surveys",
-          has_password: true
+          has_password: true,
+          hide_submission_removal_text: AppConfiguration.instance.feature_activated?('hide_submission_removal_text')
         }
       }
     end

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/survey_submitted.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/survey_submitted.rb
@@ -97,7 +97,8 @@ module EmailCampaigns
           idea_id: idea.id,
           project_title_multiloc: project.title_multiloc,
           profile_url: Frontend::UrlService.new.profile_surveys_url(recipient.slug),
-          has_password: !recipient.no_password?
+          has_password: !recipient.no_password?,
+          hide_submission_removal_text: AppConfiguration.instance.feature_activated?('hide_submission_removal_text')
         }
       }]
     end

--- a/back/engines/free/email_campaigns/app/views/email_campaigns/survey_submitted_mailer/campaign_mail.mjml
+++ b/back/engines/free/email_campaigns/app/views/email_campaigns/survey_submitted_mailer/campaign_mail.mjml
@@ -1,13 +1,15 @@
 <!-- Action list -->
-<mj-section padding="0 25px 10px">
-  <mj-column>
-    <mj-text>
-      <p><%= format_message('your_submission_has_id') %></p>
-      <p style="font-weight: bold;"><%= event.idea_id %></p>
-      <p><%= format_message('you_can_use_this_id') %></p>
-    </mj-text>
-  </mj-column>
-</mj-section>
+<% unless event.hide_submission_removal_text %>
+  <mj-section padding="0 25px 10px">
+    <mj-column>
+      <mj-text>
+        <p><%= format_message('your_submission_has_id') %></p>
+        <p style="font-weight: bold;"><%= event.idea_id %></p>
+        <p><%= format_message('you_can_use_this_id') %></p>
+      </mj-text>
+    </mj-column>
+  </mj-section>
+<% end %>
 <% if event.has_password %>
   <%= render partial: 'application/cta_button', locals: { href: event.profile_url, message: cta_button_text } %>
 <% end %>

--- a/back/engines/free/email_campaigns/spec/mailers/survey_submitted_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/survey_submitted_mailer_spec.rb
@@ -58,15 +58,12 @@ RSpec.describe EmailCampaigns::SurveySubmittedMailer do
       end
     end
 
-    it 'it does not include the idea id when "hide_submission_removal_text" is turned on' do
+    it 'does not include the idea id when "hide_submission_removal_text" is turned on' do
       configuration = AppConfiguration.instance
       configuration.settings['hide_submission_removal_text'] = { 'enabled' => true, 'allowed' => true }
       configuration.save!
-      expect(body).not_to have_tag('p') do
-        with_text(input.id)
-      end
+      expect(body).not_to include(input.id)
     end
-
 
     it 'includes the download button' do
       expect(body).to have_tag('a') do

--- a/back/engines/free/email_campaigns/spec/mailers/survey_submitted_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/survey_submitted_mailer_spec.rb
@@ -58,6 +58,16 @@ RSpec.describe EmailCampaigns::SurveySubmittedMailer do
       end
     end
 
+    it 'it does not include the idea id when "hide_submission_removal_text" is turned on' do
+      configuration = AppConfiguration.instance
+      configuration.settings['hide_submission_removal_text'] = { 'enabled' => true, 'allowed' => true }
+      configuration.save!
+      expect(body).not_to have_tag('p') do
+        with_text(input.id)
+      end
+    end
+
+
     it 'includes the download button' do
       expect(body).to have_tag('a') do
         with_text(/Download your responses/)

--- a/back/engines/free/email_campaigns/spec/mailers/survey_submitted_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/survey_submitted_mailer_spec.rb
@@ -59,9 +59,7 @@ RSpec.describe EmailCampaigns::SurveySubmittedMailer do
     end
 
     it 'does not include the idea id when "hide_submission_removal_text" is turned on' do
-      configuration = AppConfiguration.instance
-      configuration.settings['hide_submission_removal_text'] = { 'enabled' => true, 'allowed' => true }
-      configuration.save!
+      SettingsService.new.activate_feature! 'hide_submission_removal_text'
       expect(body).not_to include(input.id)
     end
 

--- a/front/app/api/app_configuration/types.ts
+++ b/front/app/api/app_configuration/types.ts
@@ -281,6 +281,7 @@ export interface IAppConfigurationSettings {
   email_scheduling?: AppConfigurationFeature;
   phase_datetime_setup?: AppConfigurationFeature;
   custom_smtp?: AppConfigurationFeature;
+  hide_submission_removal_text?: AppConfigurationFeature;
 }
 
 export type TAppConfigurationSettingCore = keyof IAppConfigurationSettingsCore;

--- a/front/app/components/CustomFieldsForm/SubmissionReference/index.tsx
+++ b/front/app/components/CustomFieldsForm/SubmissionReference/index.tsx
@@ -18,6 +18,7 @@ import { FormattedMessage, useIntl } from 'utils/cl-intl';
 import messages from './messages';
 import SubmissionIdContainer from './SubmissionIdContainer';
 import { getMailLink } from './utils';
+import useFeatureFlag from 'hooks/useFeatureFlag';
 
 interface Props {
   inputId: string;
@@ -30,6 +31,11 @@ const SubmissionReference = ({
 }: Props) => {
   const { formatMessage } = useIntl();
   const { data: authUser } = useAuthUser();
+
+  const hideSubmissionRemovalText = useFeatureFlag({
+    name: 'hide_submission_removal_text',
+  });
+  if (hideSubmissionRemovalText) return null;
 
   return (
     <Box


### PR DESCRIPTION
California wanted to hide the ability for users to request removal of their content:

<img width="713" height="760" alt="image" src="https://github.com/user-attachments/assets/a84ceabc-9f01-4775-a23d-7293201994f3" />

# Changelog
## Added
- Added new setting to hide submission ID after survey submission (only enable if GDPR does not apply)