### PR TITLE
TAN-7658 Fire status-change notifications on automatic proposal transitions

### DIFF
--- a/back/app/services/input_status_service.rb
+++ b/back/app/services/input_status_service.rb
@@ -45,16 +45,11 @@ class InputStatusService
   private
 
   private_class_method def self.apply_transition!(input, code_to)
-    code_from = input.idea_status.code
     status_to = IdeaStatus.find_by(code: code_to, participation_method: input.participation_method_on_creation.class.method_str)
+    sfx = SideFxIdeaService.new
+    sfx.before_update(input, nil)
     input.update!(idea_status: status_to)
-    LogActivityJob.perform_later(
-      input,
-      'changed_input_status',
-      nil,
-      Time.zone.now.to_i,
-      payload: { input_status_from_code: code_from, input_status_to_code: code_to }
-    )
+    sfx.after_update(input, nil)
   end
 
   private_class_method def self.threshold_reached_condition?(input)

--- a/back/app/services/insights/proposals_phase_insights_service.rb
+++ b/back/app/services/insights/proposals_phase_insights_service.rb
@@ -17,7 +17,7 @@ module Insights
         .transitive(false)
         .where.not(submitted_at: nil)
         .where(created_at: @phase.start_at...end_time, publication_status: %w[published submitted])
-        .includes(:author, :activities)
+        .includes(:author)
 
       ideas.map do |idea|
         {
@@ -52,12 +52,39 @@ module Insights
     # i.e. we include ideas with statuses of accepted, ineligible, etc,
     # if they ever had a status of threshold_reached.
     def threshold_reached_at(idea)
-      activity = idea.activities.find do |act|
-        act.action == 'changed_input_status' &&
-          act.payload['input_status_to_code'] == 'threshold_reached'
-      end
+      threshold_reached_at_by_idea_id[idea.id]
+    end
 
-      activity&.acted_at
+    # The legacy 'changed_input_status' branch covers activity rows logged before
+    # TAN-7658, when automatic transitions emitted their own activity action.
+    # Manual and (post-TAN-7658) automatic transitions both emit 'changed_status'.
+    def threshold_reached_at_by_idea_id
+      @threshold_reached_at_by_idea_id ||= begin
+        idea_ids = @phase.ideas.pluck(:id)
+
+        legacy = Activity
+          .where(item_type: 'Idea', item_id: idea_ids, action: 'changed_input_status')
+          .where("payload->>'input_status_to_code' = 'threshold_reached'")
+
+        current = if threshold_reached_status_id
+          Activity
+            .where(item_type: 'Idea', item_id: idea_ids, action: 'changed_status')
+            .where("payload->'change'->>1 = ?", threshold_reached_status_id)
+        else
+          Activity.none
+        end
+
+        (legacy.to_a + current.to_a)
+          .group_by(&:item_id)
+          .transform_values { |acts| acts.min_by(&:acted_at).acted_at }
+      end
+    end
+
+    def threshold_reached_status_id
+      @threshold_reached_status_id ||= IdeaStatus.find_by(
+        code: 'threshold_reached',
+        participation_method: 'proposals'
+      )&.id
     end
   end
 end

--- a/back/engines/commercial/webhooks/app/models/webhooks/subscription.rb
+++ b/back/engines/commercial/webhooks/app/models/webhooks/subscription.rb
@@ -40,6 +40,7 @@ module Webhooks
       'idea.created',
       'idea.published',
       'idea.changed',
+      'idea.changed_status',
       'idea.deleted',
       'user.created',
       'user.changed',

--- a/back/engines/commercial/webhooks/spec/models/webhooks/subscription_spec.rb
+++ b/back/engines/commercial/webhooks/spec/models/webhooks/subscription_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Webhooks::Subscription do
 
     it 'accepts all supported events' do
       subscription = build(:webhook_subscription,
-        events: ['idea.created', 'idea.published', 'idea.changed', 'user.created'])
+        events: ['idea.created', 'idea.published', 'idea.changed', 'idea.changed_status', 'user.created'])
       expect(subscription).to be_valid
     end
   end

--- a/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
@@ -54,7 +54,12 @@ resource 'Phase insights' do
       idea3 = create(:idea, phases: [phase], author: user2, created_at: 5.days.ago, submitted_at: 5.days.ago, creation_phase_id: phase.id) # published during phase, and in last 7 days
       create(:idea, phases: [phase], author: user3, created_at: 2.days.ago, submitted_at: 2.days.ago, creation_phase_id: phase.id) # published after phase (not counted)
 
-      # Activities
+      # Statuses (needed for the current 'changed_status' activity format below)
+      proposed_status = create(:proposals_status, code: 'proposed')
+      threshold_status = create(:proposal_status_threshold_reached)
+
+      # Activities — idea2 uses the legacy 'changed_input_status' format to assert
+      # the service still interprets activity rows logged before TAN-7658.
       create(
         :activity,
         item: idea2,
@@ -66,15 +71,14 @@ resource 'Phase insights' do
         }
       )
 
+      # idea3 uses the current 'changed_status' format emitted by both manual
+      # changes and (post-TAN-7658) automatic transitions.
       create(
         :activity,
         item: idea3,
-        action: 'changed_input_status',
+        action: 'changed_status',
         acted_at: 3.days.ago,
-        payload: {
-          input_status_from_code: 'proposed',
-          input_status_to_code: 'threshold_reached'
-        }
+        payload: { change: [proposed_status.id, threshold_status.id] }
       )
 
       # Comments

--- a/back/spec/services/input_status_service_spec.rb
+++ b/back/spec/services/input_status_service_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 describe InputStatusService do
+  include ActiveJob::TestHelper
+
   describe 'automated transitions' do
     before do
       %w[proposed threshold_reached expired].each do |status_code|
@@ -22,6 +24,33 @@ describe InputStatusService do
         expect(proposal.reload.idea_status.code).to eq 'threshold_reached'
       end
 
+      it "logs a 'changed_status' activity when transitioning" do
+        proposed_status = IdeaStatus.find_by(code: 'proposed')
+        threshold_status = IdeaStatus.find_by(code: 'threshold_reached')
+        create_list(:reaction, 3, reactable: proposal, mode: 'up')
+
+        expect { described_class.auto_transition_input!(proposal.reload) }
+          .to enqueue_job(LogActivityJob).with(
+            proposal,
+            'changed_status',
+            nil,
+            anything,
+            payload: { change: [proposed_status.id, threshold_status.id] },
+            project_id: proposal.project_id
+          )
+      end
+
+      it 'creates ThresholdReachedForAdmin notifications for project moderators on threshold transition' do
+        moderator = create(:project_moderator, projects: [phase.project])
+        create_list(:reaction, 3, reactable: proposal, mode: 'up')
+
+        expect do
+          perform_enqueued_jobs do
+            described_class.auto_transition_input!(proposal.reload)
+          end
+        end.to change { Notifications::ThresholdReachedForAdmin.where(recipient: moderator).count }.by(1)
+      end
+
       it 'remains proposed if not expired nor threshold reached' do
         create(:reaction, reactable: proposal, mode: 'up')
 
@@ -38,6 +67,23 @@ describe InputStatusService do
         travel_to(Time.now + 22.days) do
           described_class.auto_transition_hourly!
           expect(proposal.reload.idea_status.code).to eq 'expired'
+        end
+      end
+
+      it "logs a 'changed_status' activity when transitioning to expired" do
+        proposed_status = IdeaStatus.find_by(code: 'proposed')
+        expired_status = IdeaStatus.find_by(code: 'expired')
+
+        travel_to(Time.now + 22.days) do
+          expect { described_class.auto_transition_hourly! }
+            .to enqueue_job(LogActivityJob).with(
+              proposal,
+              'changed_status',
+              nil,
+              anything,
+              payload: { change: [proposed_status.id, expired_status.id] },
+              project_id: proposal.project_id
+            )
         end
       end
 

--- a/back/spec/services/input_status_service_spec.rb
+++ b/back/spec/services/input_status_service_spec.rb
@@ -44,8 +44,13 @@ describe InputStatusService do
         moderator = create(:project_moderator, projects: [phase.project])
         create_list(:reaction, 3, reactable: proposal, mode: 'up')
 
+        # Restrict job execution to LogActivityJob (creates the Activity and
+        # enqueues notification jobs) and MakeNotificationsForClassJob (creates
+        # the Notification records). Other jobs that LogActivityJob enqueues
+        # (Rabbit publish, Segment tracking) require external services that
+        # aren't available in CI.
         expect do
-          perform_enqueued_jobs do
+          perform_enqueued_jobs(only: [LogActivityJob, MakeNotificationsForClassJob]) do
             described_class.auto_transition_input!(proposal.reload)
           end
         end.to change { Notifications::ThresholdReachedForAdmin.where(recipient: moderator).count }.by(1)

--- a/back/spec/services/insights/proposals_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/proposals_phase_insights_service_spec.rb
@@ -137,74 +137,141 @@ RSpec.describe Insights::ProposalsPhaseInsightsService do
   end
 
   describe '#threshold_reached_at' do
+    let!(:threshold_status) { create(:proposal_status_threshold_reached) }
+
     it 'returns nil when idea has no threshold_reached status change' do
       threshold_reached_at = service.send(:threshold_reached_at, idea2)
 
       expect(threshold_reached_at).to be_nil
     end
 
-    it 'returns the acted_at time when idea reached threshold' do
-      activity_time = 8.days.ago
-      create(
-        :activity,
-        item: idea2,
-        action: 'changed_input_status',
-        acted_at: activity_time,
-        payload: {
-          input_status_from_code: 'proposed',
-          input_status_to_code: 'threshold_reached'
-        }
-      )
+    # The 'changed_status' activity is the format emitted by both manual status
+    # changes and (post-TAN-7658) automatic transitions.
+    context "with current 'changed_status' activity format" do
+      it 'returns the acted_at time when idea reached threshold' do
+        proposed_status = create(:proposals_status, code: 'proposed')
+        activity_time = 8.days.ago
+        create(
+          :activity,
+          item: idea2,
+          action: 'changed_status',
+          acted_at: activity_time,
+          payload: { change: [proposed_status.id, threshold_status.id] }
+        )
 
-      threshold_reached_at = service.send(:threshold_reached_at, idea2)
+        threshold_reached_at = service.send(:threshold_reached_at, idea2)
 
-      expect(threshold_reached_at).to be_within(1.second).of(activity_time)
+        expect(threshold_reached_at).to be_within(1.second).of(activity_time)
+      end
+
+      it 'returns the threshold_reached time even when status changed again after' do
+        proposed_status = create(:proposals_status, code: 'proposed')
+        accepted_status = create(:proposals_status, code: 'accepted')
+        threshold_time = 8.days.ago
+        create(
+          :activity,
+          item: idea2,
+          action: 'changed_status',
+          acted_at: threshold_time,
+          payload: { change: [proposed_status.id, threshold_status.id] }
+        )
+        create(
+          :activity,
+          item: idea2,
+          action: 'changed_status',
+          acted_at: 5.days.ago,
+          payload: { change: [threshold_status.id, accepted_status.id] }
+        )
+
+        threshold_reached_at = service.send(:threshold_reached_at, idea2)
+
+        expect(threshold_reached_at).to be_within(1.second).of(threshold_time)
+      end
+
+      it 'returns nil when idea has other status changes but not threshold_reached' do
+        proposed_status = create(:proposals_status, code: 'proposed')
+        accepted_status = create(:proposals_status, code: 'accepted')
+        create(
+          :activity,
+          item: idea2,
+          action: 'changed_status',
+          acted_at: 8.days.ago,
+          payload: { change: [proposed_status.id, accepted_status.id] }
+        )
+
+        threshold_reached_at = service.send(:threshold_reached_at, idea2)
+
+        expect(threshold_reached_at).to be_nil
+      end
     end
 
-    it 'returns the threshold_reached time even when status changed again after' do
-      threshold_time = 8.days.ago
-      create(
-        :activity,
-        item: idea2,
-        action: 'changed_input_status',
-        acted_at: threshold_time,
-        payload: {
-          input_status_from_code: 'proposed',
-          input_status_to_code: 'threshold_reached'
-        }
-      )
+    # Pre-TAN-7658, automatic transitions emitted a separate 'changed_input_status'
+    # activity. Old activity rows still need to be interpreted by this service so
+    # historical insights remain accurate after the deploy.
+    context "with legacy 'changed_input_status' activity format (backwards compatibility)" do
+      it 'returns the acted_at time when idea reached threshold' do
+        activity_time = 8.days.ago
+        create(
+          :activity,
+          item: idea2,
+          action: 'changed_input_status',
+          acted_at: activity_time,
+          payload: {
+            input_status_from_code: 'proposed',
+            input_status_to_code: 'threshold_reached'
+          }
+        )
 
-      create(
-        :activity,
-        item: idea2,
-        action: 'changed_input_status',
-        acted_at: 5.days.ago,
-        payload: {
-          input_status_from_code: 'threshold_reached',
-          input_status_to_code: 'accepted'
-        }
-      )
+        threshold_reached_at = service.send(:threshold_reached_at, idea2)
 
-      threshold_reached_at = service.send(:threshold_reached_at, idea2)
+        expect(threshold_reached_at).to be_within(1.second).of(activity_time)
+      end
 
-      expect(threshold_reached_at).to be_within(1.second).of(threshold_time)
-    end
+      it 'returns the threshold_reached time even when status changed again after' do
+        threshold_time = 8.days.ago
+        create(
+          :activity,
+          item: idea2,
+          action: 'changed_input_status',
+          acted_at: threshold_time,
+          payload: {
+            input_status_from_code: 'proposed',
+            input_status_to_code: 'threshold_reached'
+          }
+        )
 
-    it 'returns nil when idea has other status changes but not threshold_reached' do
-      create(
-        :activity,
-        item: idea2,
-        action: 'changed_input_status',
-        acted_at: 8.days.ago,
-        payload: {
-          input_status_from_code: 'proposed',
-          input_status_to_code: 'accepted'
-        }
-      )
+        create(
+          :activity,
+          item: idea2,
+          action: 'changed_input_status',
+          acted_at: 5.days.ago,
+          payload: {
+            input_status_from_code: 'threshold_reached',
+            input_status_to_code: 'accepted'
+          }
+        )
 
-      threshold_reached_at = service.send(:threshold_reached_at, idea2)
+        threshold_reached_at = service.send(:threshold_reached_at, idea2)
 
-      expect(threshold_reached_at).to be_nil
+        expect(threshold_reached_at).to be_within(1.second).of(threshold_time)
+      end
+
+      it 'returns nil when idea has other status changes but not threshold_reached' do
+        create(
+          :activity,
+          item: idea2,
+          action: 'changed_input_status',
+          acted_at: 8.days.ago,
+          payload: {
+            input_status_from_code: 'proposed',
+            input_status_to_code: 'accepted'
+          }
+        )
+
+        threshold_reached_at = service.send(:threshold_reached_at, idea2)
+
+        expect(threshold_reached_at).to be_nil
+      end
     end
   end
 

--- a/front/app/api/webhook_subscriptions/types.ts
+++ b/front/app/api/webhook_subscriptions/types.ts
@@ -73,6 +73,7 @@ export const WEBHOOK_EVENTS = [
   'idea.created',
   'idea.published',
   'idea.changed',
+  'idea.changed_status',
   'idea.deleted',
   'user.created',
   'user.changed',


### PR DESCRIPTION
`InputStatusService.apply_transition!` previously called `idea.update!` directly and logged a one-off `'changed_input_status'` activity that nothing subscribed to. It now routes through `SideFxIdeaService.new.before_update` / `update!` / `after_update` — the same path manual status changes use — which emits the standard `'changed_status'` activity. The two notifications listed above subscribe to that activity, so they (and their corresponding email campaigns) start firing for auto transitions without any change to the notification or campaign classes themselves.

The legacy `'changed_input_status'` activity is no longer logged. Its only consumer was `Insights::ProposalsPhaseInsightsService#threshold_reached_at`, which has been reworked to read both formats from the DB via two indexed, payload-filtered Postgres queries (replacing the previous in-Ruby scan over an eager-loaded `idea.activities` association — which scaled with idea age across a very large table). No data backfill required; historical insights remain accurate.

Side effects of routing through the full SideFx chain that are kept by design:
- An additional `'changed'` activity is logged alongside `'changed_status'` so auto transitions show up in the Management Feed the same way manual ones do.
- `Seo::ScrapeFacebookJob` is enqueued so the Open Graph cache reflects the new status when the public idea URL is shared.


# Changelog
## Fixed
- The notifications and emails for ThresholdReachedForAdmin and StatusChangeOnIdeaYouFollow now fire when a proposal automatically reaches the voting threshold (and when it expires for followers). They were silently broken for more than a year.

## Added
- New `idea.changed_status` webhook event, fired on both manual status changes and automatic threshold/expiry transitions. Selectable from the admin webhook subscription modal.