### PR TITLE
[TAN-7632] Reorganize content of CLAUDE.md files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,42 +2,17 @@
 
 ## Project Overview
 
-Go Vocal is a **digital democracy platform** that facilitates community participation and co-creation, aimed at (mostly local) governments. It enables communities to post ideas, contribute to discussions, vote, and prioritize community projects through various participation methods including polls, participatory budgets, idea collection, and surveys. It allows admins to manage and process the results of these processes.
+Go Vocal is a **digital democracy platform** that facilitates community participation and co-creation, aimed at (mostly local) governments. It enables communities to post ideas, contribute to discussions, vote, and prioritize community projects through various participation methods including polls, participatory budgets, idea collection, and surveys. Admins and moderators (called "managers" in UI copy) manage and process the results.
 
 ## Repository Structure
 
-This is a monorepo containing:
+Monorepo:
 
-- **`front/`** - React/TypeScript frontend application (Vite-based)
-- **`back/`** - Ruby on Rails backend API (Rails 7.1+)
-- **`e2e/`** - End-to-end tests
-- **`.circleci/`** - CI/CD configuration
-
-## Key Technologies
-
-### Frontend (`front/`)
-
-The front-end is a Single Page Application handling both the front-office (citizen-facing) as the back-office (government-facing) side of the platform.
-
-- React 18.3 with TypeScript 5.3
-- Vite for build tooling
-- Styled Components for styling
-- React Query for data fetching
-- React Router for navigation
-- Component library in `front/app/component-library/`
-
-### Backend (`back/`)
-
-The back-end is purely an API layer, and in general not rendering HTML.
-
-- Ruby 3.3+ with Rails 7.1.5
-- PostgreSQL with PostGIS (spatial data)
-- Multi-tenant architecture (using ros-apartment gem)
-- Engine-based architecture (`engines/free/` and `engines/commercial/`)
-- Background jobs with Que
-- RabbitMQ for event messaging
-- Carrierwave + Fog for file uploads (S3)
-- Pundit for policies
+- **`front/`** — React/TypeScript SPA (citizen-facing front-office + admin back-office). See [`front/CLAUDE.md`](./front/CLAUDE.md) for FE-specific guidance.
+- **`back/`** — Rails REST API (multi-tenant, engine-based). See [`back/CLAUDE.md`](./back/CLAUDE.md) for BE-specific guidance.
+- **`e2e/`** — Cypress end-to-end tests.
+- **`.circleci/`** — CI/CD configuration.
+- **`env_files/`** — per-area environment files for local development.
 
 ## Getting Started
 
@@ -48,74 +23,41 @@ The back-end is purely an API layer, and in general not rendering HTML.
 
 ### Quick Start
 
-1. **Clone the repository**:
+1. Clone the repository:
 
    ```bash
    git clone <repository-url>
    cd citizenlab
    ```
 
-2. **Build and start the backend in docker compose**:
+2. From the repo root, build and seed the backend:
 
    ```bash
    make reset-dev-env
    ```
 
-   This builds Docker images and populates the database with seed data.
+3. In another terminal, install and start the frontend:
 
-3. **Install and start the frontend**:
    ```bash
    cd front
    npm install
    npm start
    ```
-   The frontend will be available at the default Vite dev server port.
 
-### Environment Configuration
+## Make Commands
 
-- Backend and frontend environment files are in `env_files/`
-- Use `docker-compose.yml` for local development orchestration
+The root `Makefile` defines convenience targets. Most are backend-oriented but **all `make` commands must be run from the repo root**, even when the underlying command operates inside `back/`.
 
-## Development Workflow
+Notable targets:
 
-### Backend Development
-
-**Run all rails commands in docker compose, no local execution**:
-
-```bash
-docker compose run --rm web <command>
-```
-
-## Make commands
-
-The root of the repository defines a Makefile with a bunch of useful make commands. Most apply to the back-end, so despite the code of the back-end living in `back/`, executing any make commands should be done through the root folder.
-
-### Frontend Development
-
-- **Start dev server**: `npm start` (in `front/`)
-- **Run tests**: `npm test`
-- **Build for production**: `npm run build`
-- **Lint code**: `npm run lint`
-
-### Testing
-
-- **Backend tests**: `docker compose run --rm web bin/rspec`
-- **Frontend unit tests**: `cd front && npm test`
-- **E2E tests**:
-  ```bash
-  make e2e-setup  # Backend setup
-  cd front && npm run cypress:open  # Run Cypress
-  ```
-
-## Additional Resources
-
-- Main README: [README.md](./README.md)
-- Frontend README: [front/README.md](./front/README.md)
-- Backend README: [back/README.md](./back/README.md)
-- Official Website: https://www.govocal.com
+- `make reset-dev-env` — rebuild backend images + reseed the database.
+- `make e2e-setup` — prepare the backend for a Cypress run; then `npm run cypress:open` from `front/`.
 
 ## CI/CD
 
-- CircleCI runs tests on all PRs and master branch commits
-- Config: `.circleci/config.yml`
-- Tests include: backend specs, frontend unit tests, E2E tests, linting
+CircleCI runs on every PR and on master. Config: `.circleci/config.yml`. Pipeline includes backend specs, frontend unit tests, E2E tests, and linting.
+
+## Additional Resources
+
+- [README.md](./README.md)
+- https://www.govocal.com

--- a/back/CLAUDE.md
+++ b/back/CLAUDE.md
@@ -54,38 +54,18 @@ back/
 
 ```
 
-## Getting Started
+## Running
 
-### Prerequisites
+For initial bootstrap, see the [root `CLAUDE.md`](../CLAUDE.md).
 
-- Docker and Docker Compose (latest versions)
-
-### Setup
-
-**Build and initialize database**:
-Run in the root repository folder (parent of back/)
-
-```bash
-make reset-dev-env
-```
-
-This will:
-1. Build Docker images
-2. Create and migrate database
-3. Load seed data
-
-### Running
-
-**Start all services**:
+**Start all services** (from repo root):
 ```bash
 docker compose up
 ```
 
 API available at: http://localhost:4000
 
-### Executing Commands
-
-All commands MUST be run through docker compose. The docker compose configuration lives at the root of the repository (parent of `back` folder), so any docker compose commands must be launched from there.
+**Executing backend commands**: all backend commands MUST be run through docker compose, from the **repo root** (where `docker-compose.yml` lives), never from `back/`.
 
 ```bash
 docker compose run --rm web <command>
@@ -93,24 +73,15 @@ docker compose run --rm web <command>
 
 ## Development
 
-### Commands
-
-The development environment is always run through docker compose. Never run the tests locally, but always run all commands through `docker compose run`.
-
 ### Handling Updates
 
-After `git pull`, if there are schema or seed changes:
+After `git pull`, if there are schema or seed changes, either rerun `make reset-dev-env` (root), or:
 
 ```bash
 docker compose down
 docker compose build web
 docker compose run --rm web bundle exec rake db:reset
 docker compose up
-```
-
-Or use the convenience script in the parent folder:
-```bash
-make reset-dev-env
 ```
 
 ### Environment Configuration
@@ -377,6 +348,7 @@ docker compose run --rm web rails my_namespace:my_task
 
 ## Resources
 
+- [`back/README.md`](./README.md) — backend README
 - Rails Guides: https://guides.rubyonrails.org
 - Ruby Docs: https://ruby-doc.org
 - RSpec: https://rspec.info

--- a/front/CLAUDE.md
+++ b/front/CLAUDE.md
@@ -361,14 +361,20 @@ Key features:
 - Type checking (`vite-plugin-checker`)
 - Bundle analysis
 
-### Environment Variables
+### Environment Configuration
 
-- Development: Set in shell or `.env` files
-- Production: Injected during build
-- Key variables:
-  - `API_HOST`: Backend hostname
-  - `API_PORT`: Backend port
-  - `HTTPS_HOST`: HTTPS hostname for SSO
+Environment variables are in `../env_files/`:
+
+- `front-safe.env` - Safe to commit
+- `front-secret.env` - Secrets (gitignored)
+
+In production, variables are injected during build.
+
+Key variables:
+
+- `API_HOST`: Backend hostname
+- `API_PORT`: Backend port
+- `HTTPS_HOST`: HTTPS hostname for SSO
 
 ## Key Features & Modules
 

--- a/front/CLAUDE.md
+++ b/front/CLAUDE.md
@@ -38,23 +38,11 @@ front/
 └── vite.config.ts             # Vite configuration
 ```
 
-## Getting Started
+## Running
 
-### Prerequisites
+For initial bootstrap, see the [root `CLAUDE.md`](../CLAUDE.md). The backend must be running (default: `localhost:4000`) before the frontend will work.
 
-- Node.js
-- Backend must be running (default: localhost:4000)
-
-### Installation
-
-```bash
-cd front
-npm install
-```
-
-### Running the Development Server
-
-**Standard development**:
+**Standard development** (from `front/`):
 
 ```bash
 npm start
@@ -494,6 +482,7 @@ const Component = lazy(() => import('./Component'));
 
 ## Resources
 
+- [`front/README.md`](./README.md) — frontend README
 - React docs: https://react.dev
 - TypeScript docs: https://www.typescriptlang.org
 - Vite docs: https://vitejs.dev


### PR DESCRIPTION
Trims and reorganizes the three `CLAUDE.md` files (root, `back/`, `front/`) so each owns content appropriate to its scope.                                                                                                                                
                                                                                                                                                                                                                                                            
- Root: keeps only cross-cutting info (project overview, monorepo layout, prerequisites, quick-start, root `Makefile`, CI). Drops duplicated tech-stack lists and per-area workflow commands.
  - Project Overview improved to mention admins **and** moderators, with the `manager` (UI copy) ↔ `moderator` (code/API) glossary note.                                                        
- `back/CLAUDE.md`: replaces the duplicated setup section with a one-line reference to root; merges the duplicated "Development → Commands" rule into the new `## Running` section.
- `front/CLAUDE.md`: same shape — one-line reference to root for setup, then a `## Running` section with the FE-specific note that the backend must be on `:4000`.
- Both sub-files now surface their sibling `README.md` in their existing `## Resources` section.                                                                                                                                                          


# Changelog
## Technical
- [TAN-7632] Reorganize content of CLAUDE.md files - keep cross-cutting info in root, move area-specific guidance to back/ and front/, remove duplication.
