### PR TITLE
[TAN-7653] Notify admins when a proposal expires

### DIFF
--- a/back/app/models/notifications/proposal_expired_for_admin.rb
+++ b/back/app/models/notifications/proposal_expired_for_admin.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: notifications
+#
+#  id                            :uuid             not null, primary key
+#  type                          :string
+#  read_at                       :datetime
+#  recipient_id                  :uuid
+#  idea_id                       :uuid
+#  comment_id                    :uuid
+#  project_id                    :uuid
+#  created_at                    :datetime         not null
+#  updated_at                    :datetime         not null
+#  initiating_user_id            :uuid
+#  spam_report_id                :uuid
+#  invite_id                     :uuid
+#  reason_code                   :string
+#  other_reason                  :string
+#  idea_status_id                :uuid
+#  official_feedback_id          :uuid
+#  phase_id                      :uuid
+#  project_folder_id             :uuid
+#  inappropriate_content_flag_id :uuid
+#  internal_comment_id           :uuid
+#  basket_id                     :uuid
+#  cosponsorship_id              :uuid
+#  project_review_id             :uuid
+#  space_id                      :uuid
+#
+# Indexes
+#
+#  index_notifications_on_basket_id                      (basket_id)
+#  index_notifications_on_cosponsorship_id               (cosponsorship_id)
+#  index_notifications_on_created_at                     (created_at)
+#  index_notifications_on_idea_status_id                 (idea_status_id)
+#  index_notifications_on_inappropriate_content_flag_id  (inappropriate_content_flag_id)
+#  index_notifications_on_initiating_user_id             (initiating_user_id)
+#  index_notifications_on_internal_comment_id            (internal_comment_id)
+#  index_notifications_on_invite_id                      (invite_id)
+#  index_notifications_on_official_feedback_id           (official_feedback_id)
+#  index_notifications_on_phase_id                       (phase_id)
+#  index_notifications_on_project_review_id              (project_review_id)
+#  index_notifications_on_recipient_id                   (recipient_id)
+#  index_notifications_on_recipient_id_and_read_at       (recipient_id,read_at)
+#  index_notifications_on_space_id                       (space_id)
+#  index_notifications_on_spam_report_id                 (spam_report_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (basket_id => baskets.id)
+#  fk_rails_...  (comment_id => comments.id)
+#  fk_rails_...  (cosponsorship_id => cosponsorships.id)
+#  fk_rails_...  (idea_id => ideas.id)
+#  fk_rails_...  (idea_status_id => idea_statuses.id)
+#  fk_rails_...  (inappropriate_content_flag_id => flag_inappropriate_content_inappropriate_content_flags.id)
+#  fk_rails_...  (initiating_user_id => users.id)
+#  fk_rails_...  (internal_comment_id => internal_comments.id)
+#  fk_rails_...  (invite_id => invites.id)
+#  fk_rails_...  (official_feedback_id => official_feedbacks.id)
+#  fk_rails_...  (phase_id => phases.id)
+#  fk_rails_...  (project_id => projects.id)
+#  fk_rails_...  (project_review_id => project_reviews.id)
+#  fk_rails_...  (recipient_id => users.id)
+#  fk_rails_...  (space_id => spaces.id)
+#  fk_rails_...  (spam_report_id => spam_reports.id)
+#
+module Notifications
+  class ProposalExpiredForAdmin < Notification
+    validates :idea, presence: true
+
+    ACTIVITY_TRIGGERS = { 'Idea' => { 'changed_status' => true } }
+    EVENT_NAME = 'Proposal expired for admin'
+
+    def self.make_notifications_on(activity)
+      status = IdeaStatus.find(activity.payload['change'].last)
+      return [] unless status&.code == 'expired'
+
+      input = activity.item
+      initiator_id = activity.user_id
+
+      UserRoleService.new.moderators_for_project(input.project).map do |recipient|
+        new(
+          recipient: recipient,
+          initiating_user_id: initiator_id,
+          idea: input,
+          idea_status: status
+        )
+      end
+    end
+  end
+end

--- a/back/app/serializers/web_api/v1/notifications/proposal_expired_for_admin_serializer.rb
+++ b/back/app/serializers/web_api/v1/notifications/proposal_expired_for_admin_serializer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class WebApi::V1::Notifications::ProposalExpiredForAdminSerializer < WebApi::V1::Notifications::NotificationSerializer
+  attribute :post_title_multiloc do |object|
+    object.idea&.title_multiloc
+  end
+
+  attribute :post_slug do |object|
+    object.idea&.slug
+  end
+end

--- a/back/app/services/notification_service.rb
+++ b/back/app/services/notification_service.rb
@@ -28,6 +28,7 @@ class NotificationService
     Notifications::ProjectPublished,
     Notifications::ProjectReviewRequest,
     Notifications::ProjectReviewStateChange,
+    Notifications::ProposalExpiredForAdmin,
     Notifications::SpaceModerationRightsReceived,
     Notifications::StatusChangeOnIdeaYouFollow,
     Notifications::ThresholdReachedForAdmin,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/proposal_expired_for_admin_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/proposal_expired_for_admin_mailer.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module EmailCampaigns
+  class ProposalExpiredForAdminMailer < ApplicationMailer
+    include EditableWithPreview
+
+    def editable
+      %i[subject_multiloc title_multiloc button_text_multiloc]
+    end
+
+    def substitution_variables
+      {
+        input_title: localize_for_recipient(event&.idea_title_multiloc),
+        organizationName: organization_name
+      }
+    end
+
+    def preview_command(recipient, _context)
+      data = preview_service.preview_data(recipient)
+      {
+        recipient: recipient,
+        event_payload: {
+          idea_title_multiloc: data.idea.title_multiloc,
+          idea_author_name: data.author.display_name,
+          idea_url: data.idea.url,
+          assignee_first_name: recipient.first_name,
+          assignee_last_name: recipient.last_name
+        }
+      }
+    end
+  end
+end

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/proposal_expired_for_admin.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/proposal_expired_for_admin.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: email_campaigns_campaigns
+#
+#  id                   :uuid             not null, primary key
+#  type                 :string           not null
+#  author_id            :uuid
+#  enabled              :boolean
+#  sender               :string
+#  reply_to             :string
+#  schedule             :jsonb
+#  subject_multiloc     :jsonb
+#  body_multiloc        :jsonb
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  deliveries_count     :integer          default(0), not null
+#  context_id           :uuid
+#  title_multiloc       :jsonb
+#  intro_multiloc       :jsonb
+#  button_text_multiloc :jsonb
+#  context_type         :string
+#
+# Indexes
+#
+#  index_email_campaigns_campaigns_on_author_id   (author_id)
+#  index_email_campaigns_campaigns_on_context_id  (context_id)
+#  index_email_campaigns_campaigns_on_type        (type)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (author_id => users.id)
+#
+module EmailCampaigns
+  class Campaigns::ProposalExpiredForAdmin < Campaign
+    include Consentable
+    include ActivityTriggerable
+    include RecipientConfigurable
+    include Disableable
+    include Trackable
+    include ContentConfigurable
+    include LifecycleStageRestrictable
+    allow_lifecycle_stages only: %w[trial active]
+
+    recipient_filter :filter_notification_recipient
+
+    def mailer_class
+      ProposalExpiredForAdminMailer
+    end
+
+    def self.consentable_roles
+      %w[admin project_moderator project_folder_moderator]
+    end
+
+    def activity_triggers
+      { 'Notifications::ProposalExpiredForAdmin' => { 'created' => true } }
+    end
+
+    def filter_notification_recipient(users_scope, activity:, time: nil)
+      users_scope.where(id: activity.item.recipient.id)
+    end
+
+    def self.recipient_role_multiloc_key
+      'email_campaigns.admin_labels.recipient_role.admins_and_managers'
+    end
+
+    def self.recipient_segment_multiloc_key
+      'email_campaigns.admin_labels.recipient_segment.admins_and_managers_managing_the_project'
+    end
+
+    def self.content_type_multiloc_key
+      'email_campaigns.admin_labels.content_type.proposals'
+    end
+
+    def self.trigger_multiloc_key
+      'email_campaigns.admin_labels.trigger.proposal_expired'
+    end
+
+    def generate_commands(recipient:, activity:, time: nil)
+      notification = activity.item
+      assignee_attributes = {}
+      if notification.idea.assignee_id
+        assignee_attributes[:assignee_first_name] = notification.idea.assignee.first_name
+        assignee_attributes[:assignee_last_name] = notification.idea.assignee.last_name
+      end
+      [{
+        event_payload: {
+          idea_title_multiloc: notification.idea.title_multiloc,
+          idea_author_name: notification.idea.author_name,
+          idea_url: Frontend::UrlService.new.model_to_url(notification.idea, locale: Locale.new(recipient.locale)),
+          **assignee_attributes
+        }
+      }]
+    end
+
+    protected
+
+    def set_enabled
+      self.enabled = true if enabled.nil?
+    end
+  end
+end

--- a/back/engines/free/email_campaigns/app/services/email_campaigns/delivery_service.rb
+++ b/back/engines/free/email_campaigns/app/services/email_campaigns/delivery_service.rb
@@ -40,6 +40,7 @@ module EmailCampaigns
       Campaigns::ProjectPublished,
       Campaigns::ProjectReviewRequest,
       Campaigns::ProjectReviewStateChange,
+      Campaigns::ProposalExpiredForAdmin,
       Campaigns::StatusChangeOnIdeaYouFollow,
       Campaigns::SurveySubmitted,
       Campaigns::ThresholdReachedForAdmin,

--- a/back/engines/free/email_campaigns/app/views/email_campaigns/proposal_expired_for_admin_mailer/campaign_mail.mjml
+++ b/back/engines/free/email_campaigns/app/views/email_campaigns/proposal_expired_for_admin_mailer/campaign_mail.mjml
@@ -1,0 +1,21 @@
+<!-- Proposal description box -->
+<mj-section padding="0 25px 25px">
+  <mj-column>
+    <mj-table>
+      <tr>
+        <td style="border:1px solid #eaeaea; padding:20px 25px; background-color:#fff; border-radius:5px;">
+          <h2 style="font-size: 18px; margin-top: 10px; margin-bottom: 10px;">
+            <%= localize_for_recipient(event.idea_title_multiloc) %>
+          </h2>
+          <p style="margin-top: 10px; color: #84939E;">
+            <%= format_message('by_author', component: 'general', values: { authorName: event.idea_author_name }) %>
+          </p>
+        </td>
+      </tr>
+    </mj-table>
+  </mj-column>
+</mj-section>
+
+
+<!-- CTA button -->
+<%= render 'application/cta_button', href: event.idea_url, message: cta_button_text %>

--- a/back/engines/free/email_campaigns/config/locales/.polyglit.da-DK.yml.json
+++ b/back/engines/free/email_campaigns/config/locales/.polyglit.da-DK.yml.json
@@ -439,6 +439,11 @@
     "verified_at": "2026-03-18T12:49:36.766851Z",
     "verified_by": "Admin"
   },
+  "email_campaigns.admin_labels.trigger.proposal_expired": {
+    "state": "verified",
+    "verified_at": "2026-05-07T08:09:26.471781Z",
+    "verified_by": "kielgast@govocal.com"
+  },
   "email_campaigns.admin_labels.trigger.proposal_gets_reported_as_spam": {
     "state": "verified",
     "verified_at": "2026-03-18T12:49:36.766851Z",
@@ -893,6 +898,11 @@
     "state": "verified",
     "verified_at": "2026-03-18T12:49:36.766851Z",
     "verified_by": "Admin"
+  },
+  "email_campaigns.campaign_type_description.proposal_expired_for_admin": {
+    "state": "verified",
+    "verified_at": "2026-05-07T08:09:26.471781Z",
+    "verified_by": "kielgast@govocal.com"
   },
   "email_campaigns.campaign_type_description.screening_digest": {
     "state": "verified",
@@ -2683,6 +2693,26 @@
     "state": "verified",
     "verified_at": "2026-03-18T12:49:36.766851Z",
     "verified_by": "Admin"
+  },
+  "email_campaigns.proposal_expired_for_admin.cta_button": {
+    "state": "verified",
+    "verified_at": "2026-05-07T08:09:26.471781Z",
+    "verified_by": "kielgast@govocal.com"
+  },
+  "email_campaigns.proposal_expired_for_admin.preheader": {
+    "state": "verified",
+    "verified_at": "2026-05-07T08:09:26.471781Z",
+    "verified_by": "kielgast@govocal.com"
+  },
+  "email_campaigns.proposal_expired_for_admin.subject": {
+    "state": "verified",
+    "verified_at": "2026-05-07T08:09:26.471781Z",
+    "verified_by": "kielgast@govocal.com"
+  },
+  "email_campaigns.proposal_expired_for_admin.title": {
+    "state": "verified",
+    "verified_at": "2026-05-07T08:09:26.471781Z",
+    "verified_by": "kielgast@govocal.com"
   },
   "email_campaigns.schedules.quarterly": {
     "state": "verified",

--- a/back/engines/free/email_campaigns/config/locales/.polyglit.de-AT.yml.json
+++ b/back/engines/free/email_campaigns/config/locales/.polyglit.de-AT.yml.json
@@ -439,6 +439,11 @@
     "verified_at": "2026-03-30T12:57:38.560424Z",
     "verified_by": "Edwin Kato"
   },
+  "email_campaigns.admin_labels.trigger.proposal_expired": {
+    "state": "verified",
+    "verified_at": "2026-05-06T13:53:36.430031Z",
+    "verified_by": "Jelena"
+  },
   "email_campaigns.admin_labels.trigger.proposal_gets_reported_as_spam": {
     "state": "verified",
     "verified_at": "2026-03-30T12:57:38.560424Z",
@@ -893,6 +898,11 @@
     "state": "verified",
     "verified_at": "2026-03-30T12:57:38.560424Z",
     "verified_by": "Edwin Kato"
+  },
+  "email_campaigns.campaign_type_description.proposal_expired_for_admin": {
+    "state": "verified",
+    "verified_at": "2026-05-06T13:53:36.430031Z",
+    "verified_by": "Jelena"
   },
   "email_campaigns.campaign_type_description.screening_digest": {
     "state": "verified",
@@ -2683,6 +2693,26 @@
     "state": "verified",
     "verified_at": "2026-03-30T12:57:38.560424Z",
     "verified_by": "Edwin Kato"
+  },
+  "email_campaigns.proposal_expired_for_admin.cta_button": {
+    "state": "verified",
+    "verified_at": "2026-05-06T13:53:36.430031Z",
+    "verified_by": "Jelena"
+  },
+  "email_campaigns.proposal_expired_for_admin.preheader": {
+    "state": "verified",
+    "verified_at": "2026-05-06T13:53:36.430031Z",
+    "verified_by": "Jelena"
+  },
+  "email_campaigns.proposal_expired_for_admin.subject": {
+    "state": "verified",
+    "verified_at": "2026-05-06T13:53:36.430031Z",
+    "verified_by": "Jelena"
+  },
+  "email_campaigns.proposal_expired_for_admin.title": {
+    "state": "verified",
+    "verified_at": "2026-05-06T13:53:36.430031Z",
+    "verified_by": "Jelena"
   },
   "email_campaigns.schedules.quarterly": {
     "state": "verified",

--- a/back/engines/free/email_campaigns/config/locales/.polyglit.de-DE.yml.json
+++ b/back/engines/free/email_campaigns/config/locales/.polyglit.de-DE.yml.json
@@ -439,6 +439,11 @@
     "verified_at": "2026-03-18T15:41:17.450605Z",
     "verified_by": "Admin"
   },
+  "email_campaigns.admin_labels.trigger.proposal_expired": {
+    "state": "verified",
+    "verified_at": "2026-05-06T13:53:36.291481Z",
+    "verified_by": "Jelena"
+  },
   "email_campaigns.admin_labels.trigger.proposal_gets_reported_as_spam": {
     "state": "verified",
     "verified_at": "2026-03-18T15:41:17.450605Z",
@@ -893,6 +898,11 @@
     "state": "verified",
     "verified_at": "2026-03-18T15:41:17.450605Z",
     "verified_by": "Admin"
+  },
+  "email_campaigns.campaign_type_description.proposal_expired_for_admin": {
+    "state": "verified",
+    "verified_at": "2026-05-06T13:53:36.291481Z",
+    "verified_by": "Jelena"
   },
   "email_campaigns.campaign_type_description.screening_digest": {
     "state": "verified",
@@ -2683,6 +2693,26 @@
     "state": "verified",
     "verified_at": "2026-03-18T15:41:17.450605Z",
     "verified_by": "Admin"
+  },
+  "email_campaigns.proposal_expired_for_admin.cta_button": {
+    "state": "verified",
+    "verified_at": "2026-05-06T13:53:36.291481Z",
+    "verified_by": "Jelena"
+  },
+  "email_campaigns.proposal_expired_for_admin.preheader": {
+    "state": "verified",
+    "verified_at": "2026-05-06T13:53:36.291481Z",
+    "verified_by": "Jelena"
+  },
+  "email_campaigns.proposal_expired_for_admin.subject": {
+    "state": "verified",
+    "verified_at": "2026-05-06T13:53:36.291481Z",
+    "verified_by": "Jelena"
+  },
+  "email_campaigns.proposal_expired_for_admin.title": {
+    "state": "verified",
+    "verified_at": "2026-05-06T13:53:36.291481Z",
+    "verified_by": "Jelena"
   },
   "email_campaigns.schedules.quarterly": {
     "state": "verified",

--- a/back/engines/free/email_campaigns/config/locales/.polyglit.fr-BE.yml.json
+++ b/back/engines/free/email_campaigns/config/locales/.polyglit.fr-BE.yml.json
@@ -439,6 +439,11 @@
     "verified_at": "2026-03-18T11:50:36.802938Z",
     "verified_by": "Admin"
   },
+  "email_campaigns.admin_labels.trigger.proposal_expired": {
+    "state": "verified",
+    "verified_at": "2026-05-07T17:56:46.381858Z",
+    "verified_by": "Cindy EB"
+  },
   "email_campaigns.admin_labels.trigger.proposal_gets_reported_as_spam": {
     "state": "verified",
     "verified_at": "2026-03-18T11:50:36.802938Z",
@@ -893,6 +898,11 @@
     "state": "verified",
     "verified_at": "2026-03-18T11:50:36.802938Z",
     "verified_by": "Admin"
+  },
+  "email_campaigns.campaign_type_description.proposal_expired_for_admin": {
+    "state": "verified",
+    "verified_at": "2026-05-07T17:56:46.381858Z",
+    "verified_by": "Cindy EB"
   },
   "email_campaigns.campaign_type_description.screening_digest": {
     "state": "verified",
@@ -2673,6 +2683,26 @@
     "state": "verified",
     "verified_at": "2026-03-18T11:50:36.802938Z",
     "verified_by": "Admin"
+  },
+  "email_campaigns.proposal_expired_for_admin.cta_button": {
+    "state": "verified",
+    "verified_at": "2026-05-07T17:56:46.381858Z",
+    "verified_by": "Cindy EB"
+  },
+  "email_campaigns.proposal_expired_for_admin.preheader": {
+    "state": "verified",
+    "verified_at": "2026-05-07T17:56:46.381858Z",
+    "verified_by": "Cindy EB"
+  },
+  "email_campaigns.proposal_expired_for_admin.subject": {
+    "state": "verified",
+    "verified_at": "2026-05-07T17:56:46.381858Z",
+    "verified_by": "Cindy EB"
+  },
+  "email_campaigns.proposal_expired_for_admin.title": {
+    "state": "verified",
+    "verified_at": "2026-05-07T17:56:46.381858Z",
+    "verified_by": "Cindy EB"
   },
   "email_campaigns.schedules.quarterly": {
     "state": "verified",

--- a/back/engines/free/email_campaigns/config/locales/.polyglit.fr-FR.yml.json
+++ b/back/engines/free/email_campaigns/config/locales/.polyglit.fr-FR.yml.json
@@ -439,6 +439,11 @@
     "verified_at": "2026-03-18T11:50:36.629201Z",
     "verified_by": "Admin"
   },
+  "email_campaigns.admin_labels.trigger.proposal_expired": {
+    "state": "verified",
+    "verified_at": "2026-05-07T17:56:46.272287Z",
+    "verified_by": "Cindy EB"
+  },
   "email_campaigns.admin_labels.trigger.proposal_gets_reported_as_spam": {
     "state": "verified",
     "verified_at": "2026-03-18T11:50:36.629201Z",
@@ -893,6 +898,11 @@
     "state": "verified",
     "verified_at": "2026-03-18T11:50:36.629201Z",
     "verified_by": "Admin"
+  },
+  "email_campaigns.campaign_type_description.proposal_expired_for_admin": {
+    "state": "verified",
+    "verified_at": "2026-05-07T17:56:46.272287Z",
+    "verified_by": "Cindy EB"
   },
   "email_campaigns.campaign_type_description.screening_digest": {
     "state": "verified",
@@ -2673,6 +2683,26 @@
     "state": "verified",
     "verified_at": "2026-03-18T11:50:36.629201Z",
     "verified_by": "Admin"
+  },
+  "email_campaigns.proposal_expired_for_admin.cta_button": {
+    "state": "verified",
+    "verified_at": "2026-05-07T17:56:46.272287Z",
+    "verified_by": "Cindy EB"
+  },
+  "email_campaigns.proposal_expired_for_admin.preheader": {
+    "state": "verified",
+    "verified_at": "2026-05-07T17:56:46.272287Z",
+    "verified_by": "Cindy EB"
+  },
+  "email_campaigns.proposal_expired_for_admin.subject": {
+    "state": "verified",
+    "verified_at": "2026-05-07T17:56:46.272287Z",
+    "verified_by": "Cindy EB"
+  },
+  "email_campaigns.proposal_expired_for_admin.title": {
+    "state": "verified",
+    "verified_at": "2026-05-07T17:56:46.272287Z",
+    "verified_by": "Cindy EB"
   },
   "email_campaigns.schedules.quarterly": {
     "state": "verified",

--- a/back/engines/free/email_campaigns/config/locales/.polyglit.nl-BE.yml.json
+++ b/back/engines/free/email_campaigns/config/locales/.polyglit.nl-BE.yml.json
@@ -439,6 +439,11 @@
     "verified_at": "2026-03-18T11:49:32.624820Z",
     "verified_by": "Admin"
   },
+  "email_campaigns.admin_labels.trigger.proposal_expired": {
+    "state": "verified",
+    "verified_at": "2026-05-06T19:26:45.565417Z",
+    "verified_by": "Luuc"
+  },
   "email_campaigns.admin_labels.trigger.proposal_gets_reported_as_spam": {
     "state": "verified",
     "verified_at": "2026-03-18T11:49:32.624820Z",
@@ -893,6 +898,11 @@
     "state": "verified",
     "verified_at": "2026-03-18T11:49:32.624820Z",
     "verified_by": "Admin"
+  },
+  "email_campaigns.campaign_type_description.proposal_expired_for_admin": {
+    "state": "verified",
+    "verified_at": "2026-05-06T19:26:45.565417Z",
+    "verified_by": "Luuc"
   },
   "email_campaigns.campaign_type_description.screening_digest": {
     "state": "verified",
@@ -2683,6 +2693,26 @@
     "state": "verified",
     "verified_at": "2026-03-18T11:49:32.624820Z",
     "verified_by": "Admin"
+  },
+  "email_campaigns.proposal_expired_for_admin.cta_button": {
+    "state": "verified",
+    "verified_at": "2026-05-06T19:26:45.565417Z",
+    "verified_by": "Luuc"
+  },
+  "email_campaigns.proposal_expired_for_admin.preheader": {
+    "state": "verified",
+    "verified_at": "2026-05-06T19:26:45.565417Z",
+    "verified_by": "Luuc"
+  },
+  "email_campaigns.proposal_expired_for_admin.subject": {
+    "state": "verified",
+    "verified_at": "2026-05-06T19:26:45.565417Z",
+    "verified_by": "Luuc"
+  },
+  "email_campaigns.proposal_expired_for_admin.title": {
+    "state": "verified",
+    "verified_at": "2026-05-06T19:26:45.565417Z",
+    "verified_by": "Luuc"
   },
   "email_campaigns.schedules.quarterly": {
     "state": "verified",

--- a/back/engines/free/email_campaigns/config/locales/.polyglit.nl-NL.yml.json
+++ b/back/engines/free/email_campaigns/config/locales/.polyglit.nl-NL.yml.json
@@ -439,6 +439,11 @@
     "verified_at": "2026-03-18T11:49:32.458214Z",
     "verified_by": "Admin"
   },
+  "email_campaigns.admin_labels.trigger.proposal_expired": {
+    "state": "verified",
+    "verified_at": "2026-05-06T19:26:45.459389Z",
+    "verified_by": "Luuc"
+  },
   "email_campaigns.admin_labels.trigger.proposal_gets_reported_as_spam": {
     "state": "verified",
     "verified_at": "2026-03-18T11:49:32.458214Z",
@@ -893,6 +898,11 @@
     "state": "verified",
     "verified_at": "2026-03-18T11:49:32.458214Z",
     "verified_by": "Admin"
+  },
+  "email_campaigns.campaign_type_description.proposal_expired_for_admin": {
+    "state": "verified",
+    "verified_at": "2026-05-06T19:26:45.459389Z",
+    "verified_by": "Luuc"
   },
   "email_campaigns.campaign_type_description.screening_digest": {
     "state": "verified",
@@ -2683,6 +2693,26 @@
     "state": "verified",
     "verified_at": "2026-03-18T11:49:32.458214Z",
     "verified_by": "Admin"
+  },
+  "email_campaigns.proposal_expired_for_admin.cta_button": {
+    "state": "verified",
+    "verified_at": "2026-05-06T19:26:45.459389Z",
+    "verified_by": "Luuc"
+  },
+  "email_campaigns.proposal_expired_for_admin.preheader": {
+    "state": "verified",
+    "verified_at": "2026-05-06T19:26:45.459389Z",
+    "verified_by": "Luuc"
+  },
+  "email_campaigns.proposal_expired_for_admin.subject": {
+    "state": "verified",
+    "verified_at": "2026-05-06T19:26:45.459389Z",
+    "verified_by": "Luuc"
+  },
+  "email_campaigns.proposal_expired_for_admin.title": {
+    "state": "verified",
+    "verified_at": "2026-05-06T19:26:45.459389Z",
+    "verified_by": "Luuc"
   },
   "email_campaigns.schedules.quarterly": {
     "state": "verified",

--- a/back/engines/free/email_campaigns/config/locales/ar-MA.yml
+++ b/back/engines/free/email_campaigns/config/locales/ar-MA.yml
@@ -94,6 +94,7 @@ ar-MA:
         project_published: تم نشر المشروع
         project_review_request: طلب المنسق مراجعة المشروع
         project_review_state_change: وافق المراجع على المشروع
+        proposal_expired: تنتهي صلاحية مقترح دون الوصول إلى العتبة
         proposal_gets_reported_as_spam: تم الإبلاغ عن الاقتراح باعتباره بريدًا عشوائيًا
         proposal_is_assigned_to_admin: يتم تعيين الاقتراح إلى المسؤول
         proposal_is_published: تم نشر الاقتراح
@@ -188,6 +189,7 @@ ar-MA:
       project_published: تم نشر المشروع
       project_review_request: طلب مراجعة المشروع
       project_review_state_change: تمت الموافقة على المشروع
+      proposal_expired_for_admin: انتهت صلاحية المقترح دون الوصول إلى عتبة التصويت
       screening_digest: تذكير بالفحص الأسبوعي
       space_moderation_rights_received: تم استلام صلاحيات مسير فضاء
       status_change_on_idea_you_follow: تغيير حالة الفكرة التي تتابعها
@@ -591,6 +593,11 @@ ar-MA:
       preheader: '%{reviewerName} وافق على المشروع "%{projectTitle}"'
       subject: تمت الموافقة على "%{projectTitle}"
       title: '%{reviewerName} وافق على المشروع "%{projectTitle}"'
+    proposal_expired_for_admin:
+      cta_button: مراجعة المساهمة التي انتهت صلاحيتها
+      preheader: انتهت صلاحية مساهمة دون الوصول إلى العتبة
+      subject: انتهت صلاحية "%{input_title}" دون الوصول إلى العتبة
+      title: انتهت صلاحية مساهمة دون الوصول إلى عتبة التصويت
     schedules:
       quarterly: ربع سنوي، في اليوم الأول من الربع
       weekly:

--- a/back/engines/free/email_campaigns/config/locales/ar-SA.yml
+++ b/back/engines/free/email_campaigns/config/locales/ar-SA.yml
@@ -94,6 +94,7 @@ ar-SA:
         project_published: تم نشر المشروع
         project_review_request: طلب المنسق مراجعة المشروع
         project_review_state_change: وافق المراجع على المشروع
+        proposal_expired: تنتهي صلاحية المقترح دون الوصول إلى الحد الأدنى
         proposal_gets_reported_as_spam: تم الإبلاغ عن الاقتراح باعتباره بريدًا عشوائيًا
         proposal_is_assigned_to_admin: يتم تعيين الاقتراح إلى المسؤول
         proposal_is_published: تم نشر الاقتراح
@@ -188,6 +189,7 @@ ar-SA:
       project_published: تم نشر المشروع
       project_review_request: طلب مراجعة المشروع
       project_review_state_change: تمت الموافقة على المشروع
+      proposal_expired_for_admin: انتهت صلاحية المقترح دون الوصول إلى الحد الأدنى للأصوات
       screening_digest: تذكير بالفحص الأسبوعي
       space_moderation_rights_received: تم استلام صلاحيات مدير المساحة
       status_change_on_idea_you_follow: تغيير حالة الفكرة التي تتابعها
@@ -591,6 +593,11 @@ ar-SA:
       preheader: '%{reviewerName} وافق على المشروع "%{projectTitle}"'
       subject: تمت الموافقة على "%{projectTitle}"
       title: '%{reviewerName} وافق على المشروع "%{projectTitle}"'
+    proposal_expired_for_admin:
+      cta_button: مراجعة المشاركة التي انتهت صلاحيتها
+      preheader: انتهت صلاحية مشاركة دون الوصول إلى الحد الأدنى
+      subject: انتهت صلاحية "%{input_title}" دون الوصول إلى الحد الأدنى
+      title: انتهت صلاحية مشاركة دون الوصول إلى الحد الأدنى للأصوات
     schedules:
       quarterly: ربع سنوي، في اليوم الأول من الربع
       weekly:

--- a/back/engines/free/email_campaigns/config/locales/ca-ES.yml
+++ b/back/engines/free/email_campaigns/config/locales/ca-ES.yml
@@ -94,6 +94,7 @@ ca-ES:
         project_published: Projecte publicat
         project_review_request: El moderador ha sol·licitat una revisió del projecte
         project_review_state_change: El revisor va aprovar el projecte
+        proposal_expired: Una proposta caduca sense assolir el llindar
         proposal_gets_reported_as_spam: La proposta s'informa com a correu brossa
         proposal_is_assigned_to_admin: "La proposta s'assigna a l'administrador"
         proposal_is_published: Es publica la proposta
@@ -188,6 +189,7 @@ ca-ES:
       project_published: Projecte publicat
       project_review_request: Sol·licitud de revisió del projecte
       project_review_state_change: Projecte aprovat
+      proposal_expired_for_admin: La proposta ha caducat sense assolir el llindar de votació
       screening_digest: Recordatori de cribratge setmanal
       space_moderation_rights_received: Drets de gestor d'espai rebuts
       status_change_on_idea_you_follow: "Canvi d'estat d'una idea que segueixes"
@@ -591,6 +593,11 @@ ca-ES:
       preheader: '%{reviewerName} ha aprovat el projecte "%{projectTitle}"'
       subject: "\"%{projectTitle}\" s'ha aprovat"
       title: '%{reviewerName} va aprovar el projecte "%{projectTitle}"'
+    proposal_expired_for_admin:
+      cta_button: Revisa l'aportació caducada
+      preheader: Una aportació ha caducat sense assolir el llindar
+      subject: '"%{input_title}" ha caducat sense assolir el llindar'
+      title: Una aportació ha caducat sense assolir el llindar de votació
     schedules:
       quarterly: Trimestral, el primer dia del trimestre
       weekly:

--- a/back/engines/free/email_campaigns/config/locales/cy-GB.yml
+++ b/back/engines/free/email_campaigns/config/locales/cy-GB.yml
@@ -94,6 +94,7 @@ cy-GB:
         project_published: Cyhoeddi'r prosiect
         project_review_request: Gofynnodd y safonwr am adolygiad o'r prosiect
         project_review_state_change: Cymeradwyodd yr adolygydd y prosiect
+        proposal_expired: Mae cynnig yn dod i ben heb gyrraedd y trothwy
         proposal_gets_reported_as_spam: Mae'r cynnig yn cael ei adrodd fel sbam
         proposal_is_assigned_to_admin: Cynnig yn cael ei neilltuo i weinyddol
         proposal_is_published: Cynnig yn cael ei gyhoeddi
@@ -188,6 +189,7 @@ cy-GB:
       project_published: Cyhoeddi'r prosiect
       project_review_request: Cais am adolygiad prosiect
       project_review_state_change: Prosiect wedi'i gymeradwyo
+      proposal_expired_for_admin: Cynnig wedi dod i ben heb gyrraedd y trothwy pleidleisio
       screening_digest: Nodyn atgoffa sgrinio wythnosol
       space_moderation_rights_received: Hawliau rheolwr gofod wedi'u derbyn
       status_change_on_idea_you_follow: Newid statws syniad rydych chi'n ei ddilyn
@@ -591,6 +593,11 @@ cy-GB:
       preheader: "%{reviewerName} wedi cymeradwyo'r prosiect \"%{projectTitle}\""
       subject: '"%{projectTitle}" wedi ei gymeradwyo'
       title: '%{reviewerName} cymeradwyodd y prosiect "%{projectTitle}"'
+    proposal_expired_for_admin:
+      cta_button: Adolygu'r mewnbwn sydd wedi dod i ben
+      preheader: Daeth mewnbwn i ben heb gyrraedd y trothwy
+      subject: Daeth "%{input_title}" i ben heb gyrraedd y trothwy
+      title: Daeth mewnbwn i ben heb gyrraedd y trothwy pleidleisio
     schedules:
       quarterly: Chwarterol, ar y dydd cyntaf o'r chwarter
       weekly:

--- a/back/engines/free/email_campaigns/config/locales/da-DK.yml
+++ b/back/engines/free/email_campaigns/config/locales/da-DK.yml
@@ -94,7 +94,7 @@ da-DK:
         project_published: Projekt offentliggjort
         project_review_request: Moderator anmodede om en projektgennemgang
         project_review_state_change: Projektgodkender godkendte projektet
-        proposal_expired: Et forslag udløber uden at have nået tærsklen
+        proposal_expired: Et forslag udløber uden at have nået tærsklen for antal stemmer
         proposal_gets_reported_as_spam: Forslaget bliver rapporteret som spam
         proposal_is_assigned_to_admin: Forslaget er tildelt administrator
         proposal_is_published: Forslaget er offentliggjort

--- a/back/engines/free/email_campaigns/config/locales/da-DK.yml
+++ b/back/engines/free/email_campaigns/config/locales/da-DK.yml
@@ -94,6 +94,7 @@ da-DK:
         project_published: Projekt offentliggjort
         project_review_request: Moderator anmodede om en projektgennemgang
         project_review_state_change: Projektgodkender godkendte projektet
+        proposal_expired: Et forslag udløber uden at have nået tærsklen
         proposal_gets_reported_as_spam: Forslaget bliver rapporteret som spam
         proposal_is_assigned_to_admin: Forslaget er tildelt administrator
         proposal_is_published: Forslaget er offentliggjort
@@ -188,6 +189,7 @@ da-DK:
       project_published: Projekt offentliggjort
       project_review_request: Anmodning om projektgennemgang
       project_review_state_change: Projekt godkendt
+      proposal_expired_for_admin: Forslag udløbet uden at have nået stemmetærsklen
       screening_digest: Ugentlig påmindelse om screening
       space_moderation_rights_received: Rettigheder som områdeprojektleder modtaget
       status_change_on_idea_you_follow: Statusændring af en idé, som du følger
@@ -591,6 +593,11 @@ da-DK:
       preheader: '%{reviewerName} godkendte projektet "%{projectTitle}"'
       subject: '"%{projectTitle}" er blevet godkendt'
       title: '%{reviewerName} godkendte projektet "%{projectTitle}"'
+    proposal_expired_for_admin:
+      cta_button: Gennemse det udløbne input
+      preheader: Et input er udløbet uden at have nået tærsklen
+      subject: '"%{input_title}" er udløbet uden at have nået tærsklen'
+      title: Et input er udløbet uden at have nået stemmetærsklen
     schedules:
       quarterly: Kvartalsvis på den første dag i kvartalet
       weekly:

--- a/back/engines/free/email_campaigns/config/locales/de-AT.yml
+++ b/back/engines/free/email_campaigns/config/locales/de-AT.yml
@@ -94,6 +94,7 @@ de-AT:
         project_published: Projekt veröffentlicht
         project_review_request: Projektmanager*in hat eine Projektfreigabe beantragt
         project_review_state_change: Prüfer*in genehmigt das Projekt
+        proposal_expired: Ein Vorschlag läuft ab, ohne die Schwelle zu erreichen
         proposal_gets_reported_as_spam: Vorschlag wird als Spam markiert
         proposal_is_assigned_to_admin: Vorschlag wird Admin zugewiesen
         proposal_is_published: Vorschlag wird veröffentlicht
@@ -188,6 +189,7 @@ de-AT:
       project_published: Projekt veröffentlicht
       project_review_request: Antrag auf Projektfreigabe
       project_review_state_change: Projekt freigegeben
+      proposal_expired_for_admin: Vorschlag abgelaufen, ohne die Abstimmungsschwelle zu erreichen
       screening_digest: Wöchentliche Überprüfungs-Erinnerung
       space_moderation_rights_received: Space-Manager*innen-Rechte erhalten
       status_change_on_idea_you_follow: Statusänderung einer Idee, der Sie folgen
@@ -591,6 +593,11 @@ de-AT:
       preheader: '%{reviewerName} hat das Projekt "%{projectTitle}" freigegeben'
       subject: '"%{projectTitle}" wurde freigegeben'
       title: '%{reviewerName} hat das Projekt "%{projectTitle}" freigegeben'
+    proposal_expired_for_admin:
+      cta_button: Den abgelaufenen Beitrag überprüfen
+      preheader: Ein Beitrag ist abgelaufen, ohne die Schwelle zu erreichen
+      subject: '"%{input_title}" ist abgelaufen, ohne die Schwelle zu erreichen'
+      title: Ein Beitrag ist abgelaufen, ohne die Abstimmungsschwelle zu erreichen
     schedules:
       quarterly: Vierteljährlich, am ersten Tag des Quartals
       weekly:

--- a/back/engines/free/email_campaigns/config/locales/de-DE.yml
+++ b/back/engines/free/email_campaigns/config/locales/de-DE.yml
@@ -94,6 +94,7 @@ de-DE:
         project_published: Projekt veröffentlicht
         project_review_request: Projektmanager*in hat eine Projektfreigabe beantragt
         project_review_state_change: Prüfer*in genehmigt das Projekt
+        proposal_expired: Ein Vorschlag läuft ab, ohne die Schwelle zu erreichen
         proposal_gets_reported_as_spam: Vorschlag wird als Spam markiert
         proposal_is_assigned_to_admin: Vorschlag wird Admin zugewiesen
         proposal_is_published: Vorschlag wird veröffentlicht
@@ -188,6 +189,7 @@ de-DE:
       project_published: Projekt veröffentlicht
       project_review_request: Antrag auf Projektfreigabe
       project_review_state_change: Projekt freigegeben
+      proposal_expired_for_admin: Vorschlag abgelaufen, ohne die Abstimmungsschwelle zu erreichen
       screening_digest: Wöchentliche Überprüfungs-Erinnerung
       space_moderation_rights_received: Space-Manager*innen-Rechte erhalten
       status_change_on_idea_you_follow: Statusänderung einer Idee, der Sie folgen
@@ -591,6 +593,11 @@ de-DE:
       preheader: '%{reviewerName} hat das Projekt "%{projectTitle}" freigegeben'
       subject: '"%{projectTitle}" wurde freigegeben'
       title: '%{reviewerName} hat das Projekt "%{projectTitle}" freigegeben'
+    proposal_expired_for_admin:
+      cta_button: Den abgelaufenen Beitrag überprüfen
+      preheader: Ein Beitrag ist abgelaufen, ohne die Schwelle zu erreichen
+      subject: '"%{input_title}" ist abgelaufen, ohne die Schwelle zu erreichen'
+      title: Ein Beitrag ist abgelaufen, ohne die Abstimmungsschwelle zu erreichen
     schedules:
       quarterly: Vierteljährlich, am ersten Tag des Quartals
       weekly:

--- a/back/engines/free/email_campaigns/config/locales/el-GR.yml
+++ b/back/engines/free/email_campaigns/config/locales/el-GR.yml
@@ -94,6 +94,7 @@ el-GR:
         project_published: Δημοσιευμένο έργο
         project_review_request: Ο συντονιστής ζήτησε επανεξέταση του έργου
         project_review_state_change: Ο κριτής ενέκρινε το έργο
+        proposal_expired: Μια πρόταση λήγει χωρίς να συμπληρώσει το όριο
         proposal_gets_reported_as_spam: Η πρόταση αναφέρεται ως spam
         proposal_is_assigned_to_admin: Η πρόταση ανατίθεται στον admin
         proposal_is_published: Η πρόταση δημοσιεύεται
@@ -188,6 +189,7 @@ el-GR:
       project_published: Δημοσιευμένο έργο
       project_review_request: Αίτημα αξιολόγησης του έργου
       project_review_state_change: Το έργο εγκρίθηκε
+      proposal_expired_for_admin: Η πρόταση έληξε χωρίς να συμπληρώσει το όριο ψήφων
       screening_digest: Εβδομαδιαία υπενθύμιση ελέγχου
       space_moderation_rights_received: Λήφθηκαν δικαιώματα διαχειριστή χώρου
       status_change_on_idea_you_follow: Αλλαγή κατάστασης μιας ιδέας που ακολουθείτε
@@ -591,6 +593,11 @@ el-GR:
       preheader: '%{reviewerName} ενέκρινε το σχέδιο "%{projectTitle}"'
       subject: '"%{projectTitle}" έχει εγκριθεί'
       title: '%{reviewerName} ενέκρινε το σχέδιο "%{projectTitle}"'
+    proposal_expired_for_admin:
+      cta_button: Ελέγξτε τη συμμετοχή που έληξε
+      preheader: Μια συμμετοχή έληξε χωρίς να συμπληρώσει το όριο
+      subject: Το "%{input_title}" έληξε χωρίς να συμπληρώσει το όριο
+      title: Μια συμμετοχή έληξε χωρίς να συμπληρώσει το όριο ψήφων
     schedules:
       quarterly: Τριμηνιαία, την πρώτη ημέρα του τριμήνου
       weekly:

--- a/back/engines/free/email_campaigns/config/locales/en-CA.yml
+++ b/back/engines/free/email_campaigns/config/locales/en-CA.yml
@@ -94,6 +94,7 @@ en-CA:
         project_published: Project published
         project_review_request: Moderator requested a project review
         project_review_state_change: Reviewer approved the project
+        proposal_expired: A proposal expires without reaching the threshold
         proposal_gets_reported_as_spam: Proposal gets reported as spam
         proposal_is_assigned_to_admin: Proposal is assigned to admin
         proposal_is_published: Proposal is published
@@ -188,6 +189,7 @@ en-CA:
       project_published: Project published
       project_review_request: Project review request
       project_review_state_change: Project approved
+      proposal_expired_for_admin: Proposal expired without reaching the voting threshold
       screening_digest: Weekly screening reminder
       space_moderation_rights_received: Space manager rights received
       status_change_on_idea_you_follow: Status change of an input that you follow
@@ -591,6 +593,11 @@ en-CA:
       preheader: '%{reviewerName} approved the project "%{projectTitle}"'
       subject: '"%{projectTitle}" has been approved'
       title: '%{reviewerName} approved the project "%{projectTitle}"'
+    proposal_expired_for_admin:
+      cta_button: Review the expired input
+      preheader: An input expired without reaching the threshold
+      subject: '"%{input_title}" expired without reaching the threshold'
+      title: An input expired without reaching the voting threshold
     schedules:
       quarterly: Quarterly, on the first day of the quarter
       weekly:

--- a/back/engines/free/email_campaigns/config/locales/en-GB.yml
+++ b/back/engines/free/email_campaigns/config/locales/en-GB.yml
@@ -94,6 +94,7 @@ en-GB:
         project_published: Project published
         project_review_request: Moderator requested a project review
         project_review_state_change: Reviewer approved the project
+        proposal_expired: A proposal expires without reaching the threshold
         proposal_gets_reported_as_spam: Proposal gets reported as spam
         proposal_is_assigned_to_admin: Proposal is assigned to admin
         proposal_is_published: Proposal is published
@@ -188,6 +189,7 @@ en-GB:
       project_published: Project published
       project_review_request: Project review request
       project_review_state_change: Project approved
+      proposal_expired_for_admin: Proposal expired without reaching the voting threshold
       screening_digest: Weekly screening reminder
       space_moderation_rights_received: Space manager rights received
       status_change_on_idea_you_follow: Status change of an input that you follow
@@ -591,6 +593,11 @@ en-GB:
       preheader: '%{reviewerName} approved the project "%{projectTitle}"'
       subject: '"%{projectTitle}" has been approved'
       title: '%{reviewerName} approved the project "%{projectTitle}"'
+    proposal_expired_for_admin:
+      cta_button: Review the expired input
+      preheader: An input expired without reaching the threshold
+      subject: '"%{input_title}" expired without reaching the threshold'
+      title: An input expired without reaching the voting threshold
     schedules:
       quarterly: Quarterly, on the first day of the quarter
       weekly:

--- a/back/engines/free/email_campaigns/config/locales/en-IE.yml
+++ b/back/engines/free/email_campaigns/config/locales/en-IE.yml
@@ -94,6 +94,7 @@ en-IE:
         project_published: Project published
         project_review_request: Moderator requested a project review
         project_review_state_change: Reviewer approved the project
+        proposal_expired: A proposal expires without reaching the threshold
         proposal_gets_reported_as_spam: Proposal gets reported as spam
         proposal_is_assigned_to_admin: Proposal is assigned to admin
         proposal_is_published: Proposal is published
@@ -188,6 +189,7 @@ en-IE:
       project_published: Project published
       project_review_request: Project review request
       project_review_state_change: Project approved
+      proposal_expired_for_admin: Proposal expired without reaching the voting threshold
       screening_digest: Weekly screening reminder
       space_moderation_rights_received: Space manager rights received
       status_change_on_idea_you_follow: Status change of an input that you follow
@@ -591,6 +593,11 @@ en-IE:
       preheader: '%{reviewerName} approved the project "%{projectTitle}"'
       subject: '"%{projectTitle}" has been approved'
       title: '%{reviewerName} approved the project "%{projectTitle}"'
+    proposal_expired_for_admin:
+      cta_button: Review the expired input
+      preheader: An input expired without reaching the threshold
+      subject: '"%{input_title}" expired without reaching the threshold'
+      title: An input expired without reaching the voting threshold
     schedules:
       quarterly: Quarterly, on the first day of the quarter
       weekly:

--- a/back/engines/free/email_campaigns/config/locales/en.yml
+++ b/back/engines/free/email_campaigns/config/locales/en.yml
@@ -588,10 +588,10 @@ en:
       subject: '"%{projectTitle}" has been approved'
       title: '%{reviewerName} approved the project "%{projectTitle}"'
     proposal_expired_for_admin:
-      cta_button: Review the expired proposal
-      preheader: A proposal closed without reaching the threshold
+      cta_button: Review the expired input
+      preheader: An input expired without reaching the threshold
       subject: '"%{input_title}" expired without reaching the threshold'
-      title: A proposal expired without reaching the voting threshold
+      title: An input expired without reaching the voting threshold
     schedules:
       quarterly: Quarterly, on the first day of the quarter
       weekly:

--- a/back/engines/free/email_campaigns/config/locales/en.yml
+++ b/back/engines/free/email_campaigns/config/locales/en.yml
@@ -92,6 +92,7 @@ en:
         project_published: Project published
         project_review_request: Moderator requested a project review
         project_review_state_change: Reviewer approved the project
+        proposal_expired: A proposal expires without reaching the threshold
         proposal_gets_reported_as_spam: Proposal gets reported as spam
         proposal_is_assigned_to_admin: Proposal is assigned to admin
         proposal_is_published: Proposal is published
@@ -183,6 +184,7 @@ en:
       project_published: Project published
       project_review_request: Project review request
       project_review_state_change: Project approved
+      proposal_expired_for_admin: Proposal expired without reaching the voting threshold
       screening_digest: Weekly screening reminder
       space_moderation_rights_received: Space manager rights received
       status_change_on_idea_you_follow: Status change of an input that you follow
@@ -585,6 +587,11 @@ en:
       preheader: '%{reviewerName} approved the project "%{projectTitle}"'
       subject: '"%{projectTitle}" has been approved'
       title: '%{reviewerName} approved the project "%{projectTitle}"'
+    proposal_expired_for_admin:
+      cta_button: Review the expired proposal
+      preheader: A proposal closed without reaching the threshold
+      subject: '"%{input_title}" expired without reaching the threshold'
+      title: A proposal expired without reaching the voting threshold
     schedules:
       quarterly: Quarterly, on the first day of the quarter
       weekly:

--- a/back/engines/free/email_campaigns/config/locales/es-CL.yml
+++ b/back/engines/free/email_campaigns/config/locales/es-CL.yml
@@ -94,6 +94,7 @@ es-CL:
         project_published: Proyecto publicado
         project_review_request: El moderador solicitó la revisión del proyecto
         project_review_state_change: El revisor aprobó el proyecto
+        proposal_expired: Una propuesta caduca sin alcanzar el umbral
         proposal_gets_reported_as_spam: La propuesta es denunciada como spam
         proposal_is_assigned_to_admin: La propuesta está asignada al administrador
         proposal_is_published: Se publica la propuesta
@@ -188,6 +189,7 @@ es-CL:
       project_published: Proyecto publicado
       project_review_request: Solicitud de revisión del proyecto
       project_review_state_change: Proyecto aprobado
+      proposal_expired_for_admin: La propuesta ha caducado sin alcanzar el umbral de votación
       screening_digest: Recordatorio de evaluación semanal
       space_moderation_rights_received: Permisos de gestor de espacio recibidos
       status_change_on_idea_you_follow: Cambio de estado de una idea que sigues
@@ -591,6 +593,11 @@ es-CL:
       preheader: '%{reviewerName} aprobó el proyecto "%{projectTitle}"'
       subject: '"%{projectTitle}" ha sido aprobado'
       title: '%{reviewerName} aprobó el proyecto "%{projectTitle}"'
+    proposal_expired_for_admin:
+      cta_button: Revisar la aportación caducada
+      preheader: Una aportación ha caducado sin alcanzar el umbral
+      subject: '"%{input_title}" ha caducado sin alcanzar el umbral'
+      title: Una aportación ha caducado sin alcanzar el umbral de votación
     schedules:
       quarterly: Trimestralmente, el primer día del trimestre
       weekly:

--- a/back/engines/free/email_campaigns/config/locales/es-ES.yml
+++ b/back/engines/free/email_campaigns/config/locales/es-ES.yml
@@ -94,6 +94,7 @@ es-ES:
         project_published: Proyecto publicado
         project_review_request: El moderador solicitó la revisión del proyecto
         project_review_state_change: El revisor aprobó el proyecto
+        proposal_expired: Una propuesta caduca sin alcanzar el umbral
         proposal_gets_reported_as_spam: La propuesta es denunciada como spam
         proposal_is_assigned_to_admin: La propuesta está asignada al administrador
         proposal_is_published: Se publica la propuesta
@@ -188,6 +189,7 @@ es-ES:
       project_published: Proyecto publicado
       project_review_request: Solicitud de revisión del proyecto
       project_review_state_change: Proyecto aprobado
+      proposal_expired_for_admin: La propuesta ha caducado sin alcanzar el umbral de votación
       screening_digest: Recordatorio semanal de cribado
       space_moderation_rights_received: Permisos de gestor de espacio recibidos
       status_change_on_idea_you_follow: Cambio de estado de una idea que sigues
@@ -591,6 +593,11 @@ es-ES:
       preheader: '%{reviewerName} aprobó el proyecto "%{projectTitle}"'
       subject: '"%{projectTitle}" ha sido aprobado'
       title: '%{reviewerName} aprobó el proyecto "%{projectTitle}"'
+    proposal_expired_for_admin:
+      cta_button: Revisar la aportación caducada
+      preheader: Una aportación ha caducado sin alcanzar el umbral
+      subject: '"%{input_title}" ha caducado sin alcanzar el umbral'
+      title: Una aportación ha caducado sin alcanzar el umbral de votación
     schedules:
       quarterly: Trimestralmente, el primer día del trimestre
       weekly:

--- a/back/engines/free/email_campaigns/config/locales/fi-FI.yml
+++ b/back/engines/free/email_campaigns/config/locales/fi-FI.yml
@@ -94,6 +94,7 @@ fi-FI:
         project_published: Projekti julkaistu
         project_review_request: Moderaattori pyysi projektin tarkistusta
         project_review_state_change: Arvioija hyväksyi hankkeen
+        proposal_expired: Ehdotus vanhentuu saavuttamatta kynnystä
         proposal_gets_reported_as_spam: Ehdotus ilmoitetaan roskapostiksi
         proposal_is_assigned_to_admin: Ehdotus on annettu järjestelmänvalvojalle
         proposal_is_published: Ehdotus on julkaistu
@@ -188,6 +189,7 @@ fi-FI:
       project_published: Projekti julkaistu
       project_review_request: Hankearviointipyyntö
       project_review_state_change: Projekti hyväksytty
+      proposal_expired_for_admin: Ehdotus vanhentui saavuttamatta äänestyskynnystä
       screening_digest: Viikoittainen seulontamuistutus
       space_moderation_rights_received: Tilan hallinnointioikeudet vastaanotettu
       status_change_on_idea_you_follow: Seuraamasi idean tilanmuutos
@@ -591,6 +593,11 @@ fi-FI:
       preheader: '%{reviewerName} hyväksyi projektin "%{projectTitle}"'
       subject: '"%{projectTitle}" on hyväksytty'
       title: '%{reviewerName} hyväksyi projektin "%{projectTitle}"'
+    proposal_expired_for_admin:
+      cta_button: Tarkista vanhentunut ehdotus
+      preheader: Ehdotus vanhentui saavuttamatta kynnystä
+      subject: '"%{input_title}" vanhentui saavuttamatta kynnystä'
+      title: Ehdotus vanhentui saavuttamatta äänestyskynnystä
     schedules:
       quarterly: Neljännesvuosittain, neljänneksen ensimmäisenä päivänä
       weekly:

--- a/back/engines/free/email_campaigns/config/locales/fr-BE.yml
+++ b/back/engines/free/email_campaigns/config/locales/fr-BE.yml
@@ -94,6 +94,7 @@ fr-BE:
         project_published: Publication d'un projet
         project_review_request: Demande d'approbation pour publier un projet
         project_review_state_change: Le projet a été approuvé
+        proposal_expired: Une proposition expire sans atteindre le seuil
         proposal_gets_reported_as_spam: Proposition marquée comme spam
         proposal_is_assigned_to_admin: Une proposition est assignée à un administrateur
         proposal_is_published: Une proposition est publiée
@@ -190,6 +191,7 @@ fr-BE:
       project_published: Projet publié
       project_review_request: Demande de révision d'un projet
       project_review_state_change: Projet approuvé
+      proposal_expired_for_admin: Proposition expirée sans atteindre le seuil de vote
       screening_digest: Rappel hebdomadaire de modération
       space_moderation_rights_received: Droits de gestionnaire d'espace reçus
       status_change_on_idea_you_follow: Changement de statut d'une idée que vous suivez
@@ -593,6 +595,11 @@ fr-BE:
       preheader: '%{reviewerName} a approuvé le projet « %{projectTitle} »'
       subject: '"%{projectTitle}" a été approuvé'
       title: '%{reviewerName} a approuvé le projet « %{projectTitle} »'
+    proposal_expired_for_admin:
+      cta_button: Consulter la contribution expirée
+      preheader: Une contribution a expiré sans atteindre le seuil
+      subject: '"%{input_title}" a expiré sans atteindre le seuil'
+      title: Une contribution a expiré sans atteindre le seuil de vote
     schedules:
       quarterly: Le premier jour de chaque trimestre
       weekly:

--- a/back/engines/free/email_campaigns/config/locales/fr-FR.yml
+++ b/back/engines/free/email_campaigns/config/locales/fr-FR.yml
@@ -94,6 +94,7 @@ fr-FR:
         project_published: Publication d'un projet
         project_review_request: Demande d'approbation pour publier un projet
         project_review_state_change: Le projet a été approuvé
+        proposal_expired: Une proposition expire sans atteindre le seuil
         proposal_gets_reported_as_spam: Proposition marquée comme spam
         proposal_is_assigned_to_admin: Une proposition est assignée à un administrateur
         proposal_is_published: Une proposition est publiée
@@ -191,6 +192,7 @@ fr-FR:
       project_published: Projet publié
       project_review_request: Demande de révision d'un projet
       project_review_state_change: Projet approuvé
+      proposal_expired_for_admin: Proposition expirée sans atteindre le seuil de vote
       screening_digest: Rappel hebdomadaire de modération
       space_moderation_rights_received: Droits de gestionnaire d'espace reçus
       status_change_on_idea_you_follow: Changement de statut d'une idée que vous suivez
@@ -594,6 +596,11 @@ fr-FR:
       preheader: '%{reviewerName} a approuvé le projet « %{projectTitle} »'
       subject: '"%{projectTitle}" a été approuvé'
       title: '%{reviewerName} a approuvé le projet « %{projectTitle} »'
+    proposal_expired_for_admin:
+      cta_button: Consulter la contribution expirée
+      preheader: Une contribution a expiré sans atteindre le seuil
+      subject: '"%{input_title}" a expiré sans atteindre le seuil'
+      title: Une contribution a expiré sans atteindre le seuil de vote
     schedules:
       quarterly: Le premier jour de chaque trimestre
       weekly:

--- a/back/engines/free/email_campaigns/config/locales/ga-IE.yml
+++ b/back/engines/free/email_campaigns/config/locales/ga-IE.yml
@@ -94,6 +94,7 @@ ga-IE:
         project_published: Tionscadal foilsithe
         project_review_request: D'iarr an modhnóir athbhreithniú tionscadail
         project_review_state_change: D'fhormheas an t-athbhreithneoir an tionscadal
+        proposal_expired: Téann moladh in éag gan an tairseach a bhaint amach
         proposal_gets_reported_as_spam: Tuairiscítear an togra mar thurscar
         proposal_is_assigned_to_admin: Tá an togra sannta don riarthóir
         proposal_is_published: Tá an togra foilsithe
@@ -188,6 +189,7 @@ ga-IE:
       project_published: Tionscadal foilsithe
       project_review_request: Iarratas ar athbhreithniú tionscadail
       project_review_state_change: Tionscadal ceadaithe
+      proposal_expired_for_admin: Chuaigh moladh in éag gan an tairseach vótála a bhaint amach
       screening_digest: Meabhrúchán scagthástála seachtainiúil
       space_moderation_rights_received: Cearta bainisteora spáis faighte
       status_change_on_idea_you_follow: Athrú stádais ionchuir a leanann tú
@@ -591,6 +593,11 @@ ga-IE:
       preheader: '%{reviewerName} a cheadaigh an tionscadal "%{projectTitle}"'
       subject: Tá "%{projectTitle}" ceadaithe
       title: '%{reviewerName} a cheadaigh an tionscadal "%{projectTitle}"'
+    proposal_expired_for_admin:
+      cta_button: Déan athbhreithniú ar an ionchur atá in éag
+      preheader: Chuaigh ionchur in éag gan an tairseach a bhaint amach
+      subject: Chuaigh "%{input_title}" in éag gan an tairseach a bhaint amach
+      title: Chuaigh ionchur in éag gan an tairseach vótála a bhaint amach
     schedules:
       quarterly: Ráithiúil, ar an gcéad lá den ráithe
       weekly:

--- a/back/engines/free/email_campaigns/config/locales/hr-HR.yml
+++ b/back/engines/free/email_campaigns/config/locales/hr-HR.yml
@@ -94,6 +94,7 @@ hr-HR:
         project_published: Projekt objavljen
         project_review_request: Moderator je zatražio pregled projekta
         project_review_state_change: Recenzent je odobrio projekt
+        proposal_expired: Prijedlog istječe bez dostizanja praga
         proposal_gets_reported_as_spam: Prijedlog se prijavljuje kao neželjena pošta
         proposal_is_assigned_to_admin: Prijedlog je dodijeljen adminu
         proposal_is_published: Prijedlog je objavljen
@@ -188,6 +189,7 @@ hr-HR:
       project_published: Projekt objavljen
       project_review_request: Zahtjev za pregled projekta
       project_review_state_change: Projekt odobren
+      proposal_expired_for_admin: Prijedlog je istekao bez dostizanja praga za glasovanje
       screening_digest: Podsjetnik na tjedni pregled
       space_moderation_rights_received: Primljena prava voditelja prostora
       status_change_on_idea_you_follow: Promjena statusa ideje koju slijedite
@@ -591,6 +593,11 @@ hr-HR:
       preheader: '%{reviewerName} je odobrio/la projekt "%{projectTitle}"'
       subject: '"%{projectTitle}" je odobren'
       title: '%{reviewerName} odobrio/la je projekt "%{projectTitle}"'
+    proposal_expired_for_admin:
+      cta_button: Pregledajte istekli unos
+      preheader: Unos je istekao bez dostizanja praga
+      subject: '"%{input_title}" je istekao bez dostizanja praga'
+      title: Unos je istekao bez dostizanja praga za glasovanje
     schedules:
       quarterly: Tromjesečno, prvog dana tromjesečja
       weekly:

--- a/back/engines/free/email_campaigns/config/locales/hu-HU.yml
+++ b/back/engines/free/email_campaigns/config/locales/hu-HU.yml
@@ -94,6 +94,7 @@ hu-HU:
         project_published: A projekt megjelent
         project_review_request: A moderátor a projekt felülvizsgálatát kérte
         project_review_state_change: A bíráló jóváhagyta a projektet
+        proposal_expired: Egy javaslat lejár a küszöbérték elérése nélkül
         proposal_gets_reported_as_spam: Az ajánlatot spamként jelentik be
         proposal_is_assigned_to_admin: Az ajánlat adminisztrátorhoz van rendelve
         proposal_is_published: A javaslat közzétételre került
@@ -188,6 +189,7 @@ hu-HU:
       project_published: A projekt megjelent
       project_review_request: Projekt felülvizsgálati kérelem
       project_review_state_change: Projekt jóváhagyva
+      proposal_expired_for_admin: A javaslat lejárt a szavazati küszöb elérése nélkül
       screening_digest: Heti szűrővizsgálati emlékeztető
       space_moderation_rights_received: Térkezelői jogosultságok megadva
       status_change_on_idea_you_follow: A követett bemenet állapotának változása
@@ -591,6 +593,11 @@ hu-HU:
       preheader: '%{reviewerName} jóváhagyta a(z) "%{projectTitle}" projektet'
       subject: '"%{projectTitle}" jóváhagyva'
       title: '%{reviewerName} jóváhagyta a(z) "%{projectTitle}" projektet'
+    proposal_expired_for_admin:
+      cta_button: A lejárt javaslat áttekintése
+      preheader: Egy javaslat lejárt a küszöbérték elérése nélkül
+      subject: '"%{input_title}" lejárt a küszöbérték elérése nélkül'
+      title: Egy javaslat lejárt a szavazati küszöb elérése nélkül
     schedules:
       quarterly: Negyedévenként, a negyedév első napján
       weekly:

--- a/back/engines/free/email_campaigns/config/locales/it-IT.yml
+++ b/back/engines/free/email_campaigns/config/locales/it-IT.yml
@@ -94,6 +94,7 @@ it-IT:
         project_published: Progetto pubblicato
         project_review_request: Il moderatore ha richiesto una revisione del progetto
         project_review_state_change: Il revisore ha approvato il progetto
+        proposal_expired: Una proposta scade senza raggiungere la soglia
         proposal_gets_reported_as_spam: La proposta viene segnalata come spam
         proposal_is_assigned_to_admin: La proposta è assegnata all'amministratore
         proposal_is_published: La proposta viene pubblicata
@@ -188,6 +189,7 @@ it-IT:
       project_published: Progetto pubblicato
       project_review_request: Richiesta di revisione del progetto
       project_review_state_change: Progetto approvato
+      proposal_expired_for_admin: Proposta scaduta senza raggiungere la soglia di voto
       screening_digest: Promemoria settimanale per lo screening
       space_moderation_rights_received: Permessi di manager d'area ricevuti
       status_change_on_idea_you_follow: Cambiamento di status di un contributo che seguo
@@ -591,6 +593,11 @@ it-IT:
       preheader: '%{reviewerName} ha approvato il progetto "%{projectTitle}"'
       subject: '"%{projectTitle}" è stato approvato'
       title: '%{reviewerName} ha approvato il progetto "%{projectTitle}"'
+    proposal_expired_for_admin:
+      cta_button: Esamina il contributo scaduto
+      preheader: Un contributo è scaduto senza raggiungere la soglia
+      subject: '"%{input_title}" è scaduto senza raggiungere la soglia'
+      title: Un contributo è scaduto senza raggiungere la soglia di voto
     schedules:
       quarterly: Trimestralmente, il primo giorno del trimestre
       weekly:

--- a/back/engines/free/email_campaigns/config/locales/kl-GL.yml
+++ b/back/engines/free/email_campaigns/config/locales/kl-GL.yml
@@ -149,6 +149,7 @@ kl-GL:
         project_published: Suliniut saqqummiunneqarpoq
         project_review_request: Akunnermuliuttup suliassap misissorneqarnissaa piumasaraa
         project_review_state_change: Misissuisup suliassaq akueraa
+        proposal_expired: Siunnersuut piffissaa qaangiuppoq amerlassusissaq angunngitsoorlugu
         proposal_gets_reported_as_spam: Siunnersuut spamitut nalunaarutigineqarpoq
         proposal_is_assigned_to_admin: Siunnersuut aqutsisumut suliassanngortinneqarpoq
         proposal_is_published: Siunnersuut saqqummiunneqarpoq
@@ -271,6 +272,7 @@ kl-GL:
       project_published: Suliniut saqqummiunneqarpoq
       project_review_request: Suliniutip misissorneqarnissaanik kissaat
       project_review_state_change: Suliniut akuerineqarpoq
+      proposal_expired_for_admin: Siunnersuut piffissaa qaangiuppoq taasinerit amerlassusissaat angunngitsoorlugu
       screening_digest: Sapaatip-akunneranut misissugassat pillugit eqqaasitsissut
       space_moderation_rights_received: Immikkoortortami aqutsisutut pisinnaatitaaffiit tiguneqarput
       status_change_of_commented_idea: Isumasssarsiap oqaaseqarfigisimasama killiffiani allanngorneq
@@ -886,6 +888,11 @@ kl-GL:
       preheader: '%{reviewerName}-p suliniut "%{projectTitle}" akueraa'
       subject: '"%{projectTitle}" akuerineqarpoq'
       title: '%{reviewerName}-ip suliniut "%{projectTitle}" akueraa'
+    proposal_expired_for_admin:
+      cta_button: Siunnersuut piffissaa qaangiuttoq misissoruk
+      preheader: Siunnersuut piffissaa qaangiuppoq amerlassusissaq angunngitsoorlugu
+      subject: '"%{input_title}" piffissaa qaangiuppoq amerlassusissaq angunngitsoorlugu'
+      title: Siunnersuut piffissaa qaangiuppoq taasinerit amerlassusissaat angunngitsoorlugu
     schedules:
       quarterly: Ukiup sisamararterutikkaarlugu, sisamararterutip ulluani siullermi
       weekly:

--- a/back/engines/free/email_campaigns/config/locales/lb-LU.yml
+++ b/back/engines/free/email_campaigns/config/locales/lb-LU.yml
@@ -94,6 +94,7 @@ lb-LU:
         project_published: Projet publizéiert
         project_review_request: Moderator gefrot e Projet review
         project_review_state_change: Rezensor huet de Projet guttgeheescht
+        proposal_expired: Eng Propositioun leeft of, ouni de Seuil ze erreechen
         proposal_gets_reported_as_spam: Propositioun gëtt als Spam gemellt
         proposal_is_assigned_to_admin: Propositioun ass dem Administrateur zougewisen
         proposal_is_published: Propositioun ass publizéiert
@@ -190,6 +191,7 @@ lb-LU:
       project_published: Projet publizéiert
       project_review_request: Projet review Ufro
       project_review_state_change: Projet guttgeheescht
+      proposal_expired_for_admin: Propositioun ofgelaf, ouni d'Mindestzuel u Stëmmen ze erreechen
       screening_digest: Wëchentlech Screening-Erënnerung
       space_moderation_rights_received: Space-Manager-Rechter kritt
       status_change_on_idea_you_follow: Status Ännerung vun enger Iddi déi Dir verfollegt
@@ -595,6 +597,11 @@ lb-LU:
       preheader: '%{reviewerName} huet de Projet "%{projectTitle}" guttgeheescht'
       subject: '"%{projectTitle}" gouf guttgeheescht'
       title: '%{reviewerName} huet de Projet "%{projectTitle}" guttgeheescht'
+    proposal_expired_for_admin:
+      cta_button: Iwwerpréift den ofgelafene Bäitrag
+      preheader: E Bäitrag ass ofgelaf, ouni de Seuil ze erreechen
+      subject: '"%{input_title}" ass ofgelaf, ouni de Seuil ze erreechen'
+      title: E Bäitrag ass ofgelaf, ouni d'Mindestzuel u Stëmmen ze erreechen
     schedules:
       quarterly: Trimester, um éischten Dag vum Véierel
       weekly:

--- a/back/engines/free/email_campaigns/config/locales/lt-LT.yml
+++ b/back/engines/free/email_campaigns/config/locales/lt-LT.yml
@@ -94,6 +94,7 @@ lt-LT:
         project_published: Paskelbtas projektas
         project_review_request: Moderatorius paprašė peržiūrėti projektą
         project_review_state_change: Recenzentas patvirtino projektą
+        proposal_expired: Pasiūlymo galiojimo laikas pasibaigia nepasiekus slenksčio
         proposal_gets_reported_as_spam: Apie pasiūlymą pranešama kaip apie šlamštą
         proposal_is_assigned_to_admin: Pasiūlymas priskirtas admin
         proposal_is_published: Pasiūlymas skelbiamas
@@ -188,6 +189,7 @@ lt-LT:
       project_published: Paskelbtas projektas
       project_review_request: Projekto peržiūros prašymas
       project_review_state_change: Patvirtintas projektas
+      proposal_expired_for_admin: Pasiūlymo galiojimo laikas pasibaigė nepasiekus balsavimo slenksčio
       screening_digest: Savaitinis priminimas apie patikrą
       space_moderation_rights_received: Suteiktos erdvės valdytojo teisės
       status_change_on_idea_you_follow: Įvesties, kurią sekate, būsenos pasikeitimas
@@ -591,6 +593,11 @@ lt-LT:
       preheader: '%{reviewerName} patvirtino projektą "%{projectTitle}"'
       subject: '"%{projectTitle}" buvo patvirtintas'
       title: '%{reviewerName} patvirtino projektą "%{projectTitle}"'
+    proposal_expired_for_admin:
+      cta_button: Peržiūrėti pasibaigusio galiojimo pasiūlymą
+      preheader: Pasiūlymo galiojimo laikas pasibaigė nepasiekus slenksčio
+      subject: „%{input_title}“ galiojimo laikas pasibaigė nepasiekus slenksčio
+      title: Pasiūlymo galiojimo laikas pasibaigė nepasiekus balsavimo slenksčio
     schedules:
       quarterly: Kas ketvirtį, pirmąją ketvirčio dieną
       weekly:

--- a/back/engines/free/email_campaigns/config/locales/lv-LV.yml
+++ b/back/engines/free/email_campaigns/config/locales/lv-LV.yml
@@ -94,6 +94,7 @@ lv-LV:
         project_published: Publicēts projekts
         project_review_request: Moderators pieprasīja projekta pārskatīšanu
         project_review_state_change: Recenzents apstiprināja projektu
+        proposal_expired: Priekšlikuma termiņš beidzas, nesasniedzot slieksni
         proposal_gets_reported_as_spam: Par priekšlikumu tiek ziņots kā par surogātpastu
         proposal_is_assigned_to_admin: Priekšlikums ir piešķirts admin
         proposal_is_published: Priekšlikums ir publicēts
@@ -188,6 +189,7 @@ lv-LV:
       project_published: Publicēts projekts
       project_review_request: Projekta pārskatīšanas pieprasījums
       project_review_state_change: Projekts apstiprināts
+      proposal_expired_for_admin: Priekšlikuma termiņš ir beidzies, nesasniedzot balsošanas slieksni
       screening_digest: Iknedēļas skrīninga atgādinājums
       space_moderation_rights_received: Saņemtas telpas pārvaldnieka tiesības
       status_change_on_idea_you_follow: Idejas statusa maiņa, kurai jūs sekojat
@@ -591,6 +593,11 @@ lv-LV:
       preheader: '%{reviewerName} apstiprināja projektu "%{projectTitle}"'
       subject: '"%{projectTitle}" ir apstiprināts'
       title: '%{reviewerName} apstiprināja projektu "%{projectTitle}"'
+    proposal_expired_for_admin:
+      cta_button: Pārskatīt iesniegumu, kura termiņš ir beidzies
+      preheader: Iesnieguma termiņš ir beidzies, nesasniedzot slieksni
+      subject: '"%{input_title}" termiņš ir beidzies, nesasniedzot slieksni'
+      title: Iesnieguma termiņš ir beidzies, nesasniedzot balsošanas slieksni
     schedules:
       quarterly: Ceturkšņa ceturksnis, ceturkšņa pirmajā dienā
       weekly:

--- a/back/engines/free/email_campaigns/config/locales/nb-NO.yml
+++ b/back/engines/free/email_campaigns/config/locales/nb-NO.yml
@@ -94,6 +94,7 @@ nb-NO:
         project_published: Prosjekt publisert
         project_review_request: Moderator ba om en prosjektgjennomgang
         project_review_state_change: Kritikeren godkjente prosjektet
+        proposal_expired: Et forslag utløper uten å nå terskelen
         proposal_gets_reported_as_spam: Forslaget blir rapportert som søppelpost
         proposal_is_assigned_to_admin: Forslaget er tildelt administrator
         proposal_is_published: Forslaget er publisert
@@ -188,6 +189,7 @@ nb-NO:
       project_published: Prosjekt publisert
       project_review_request: Forespørsel om prosjektgjennomgang
       project_review_state_change: Prosjektet er godkjent
+      proposal_expired_for_admin: Forslag utløpt uten å nå stemmeterskelen
       screening_digest: Ukentlig påminnelse om screening
       space_moderation_rights_received: Rettigheter som områdeansvarlig mottatt
       status_change_on_idea_you_follow: Statusendring for en inngang som du følger
@@ -591,6 +593,11 @@ nb-NO:
       preheader: '%{reviewerName} godkjente prosjektet "%{projectTitle}"'
       subject: '"%{projectTitle}" har blitt godkjent'
       title: '%{reviewerName} godkjente prosjektet "%{projectTitle}"'
+    proposal_expired_for_admin:
+      cta_button: Se over det utløpte innspillet
+      preheader: Et innspill utløp uten å nå terskelen
+      subject: '"%{input_title}" utløp uten å nå terskelen'
+      title: Et innspill utløp uten å nå stemmeterskelen
     schedules:
       quarterly: Kvartalsvis, på den første dagen i kvartalet
       weekly:

--- a/back/engines/free/email_campaigns/config/locales/nl-BE.yml
+++ b/back/engines/free/email_campaigns/config/locales/nl-BE.yml
@@ -94,6 +94,7 @@ nl-BE:
         project_published: Project gepubliceerd
         project_review_request: Moderator heeft een projectbeoordeling aangevraagd
         project_review_state_change: Reviewer heeft het project goedgekeurd
+        proposal_expired: Een voorstel verloopt zonder de drempel te bereiken
         proposal_gets_reported_as_spam: Voorstel wordt gerapporteerd als spam
         proposal_is_assigned_to_admin: Voorstel is toegewezen aan platformbeheerder
         proposal_is_published: Voorstel is gepubliceerd
@@ -188,6 +189,7 @@ nl-BE:
       project_published: Project gepubliceerd
       project_review_request: Projectbeoordelingsverzoek
       project_review_state_change: Project goedgekeurd
+      proposal_expired_for_admin: Voorstel verlopen zonder de stemdrempel te bereiken
       screening_digest: Wekelijkse screeningherinnering
       space_moderation_rights_received: Ruimtebeheerdersrechten ontvangen
       status_change_on_idea_you_follow: Statuswijziging van een idee dat je volgt
@@ -592,6 +594,11 @@ nl-BE:
       preheader: '%{reviewerName} heeft het project "%{projectTitle}" goedgekeurd'
       subject: '"%{projectTitle}" is goedgekeurd'
       title: '%{reviewerName} heeft het project "%{projectTitle}" goedgekeurd'
+    proposal_expired_for_admin:
+      cta_button: Bekijk de verlopen bijdrage
+      preheader: Een bijdrage is verlopen zonder de drempel te bereiken
+      subject: '"%{input_title}" is verlopen zonder de drempel te bereiken'
+      title: Een bijdrage is verlopen zonder de stemdrempel te bereiken
     schedules:
       quarterly: Per kwartaal, op de eerste dag van het kwartaal
       weekly:

--- a/back/engines/free/email_campaigns/config/locales/nl-NL.yml
+++ b/back/engines/free/email_campaigns/config/locales/nl-NL.yml
@@ -94,6 +94,7 @@ nl-NL:
         project_published: Project gepubliceerd
         project_review_request: Moderator heeft een projectbeoordeling aangevraagd
         project_review_state_change: Reviewer heeft het project goedgekeurd
+        proposal_expired: Een voorstel verloopt zonder de drempel te bereiken
         proposal_gets_reported_as_spam: Voorstel wordt gerapporteerd als spam
         proposal_is_assigned_to_admin: Voorstel is toegewezen aan platformbeheerder
         proposal_is_published: Voorstel is gepubliceerd
@@ -188,6 +189,7 @@ nl-NL:
       project_published: Project gepubliceerd
       project_review_request: Projectbeoordelingsverzoek
       project_review_state_change: Project goedgekeurd
+      proposal_expired_for_admin: Voorstel verlopen zonder de stemdrempel te bereiken
       screening_digest: Wekelijkse screeningherinnering
       space_moderation_rights_received: Ruimtebeheerdersrechten ontvangen
       status_change_on_idea_you_follow: Statuswijziging van een idee dat je volgt
@@ -593,6 +595,11 @@ nl-NL:
       preheader: '%{reviewerName} heeft het project "%{projectTitle}" goedgekeurd'
       subject: '"%{projectTitle}" is goedgekeurd'
       title: '%{reviewerName} heeft het project "%{projectTitle}" goedgekeurd'
+    proposal_expired_for_admin:
+      cta_button: Bekijk de verlopen bijdrage
+      preheader: Een bijdrage is verlopen zonder de drempel te bereiken
+      subject: '"%{input_title}" is verlopen zonder de drempel te bereiken'
+      title: Een bijdrage is verlopen zonder de stemdrempel te bereiken
     schedules:
       quarterly: Per kwartaal, op de eerste dag van het kwartaal
       weekly:

--- a/back/engines/free/email_campaigns/config/locales/pa-IN.yml
+++ b/back/engines/free/email_campaigns/config/locales/pa-IN.yml
@@ -94,6 +94,7 @@ pa-IN:
         project_published: ਪ੍ਰੋਜੈਕਟ ਪ੍ਰਕਾਸ਼ਿਤ ਕੀਤਾ ਗਿਆ ਹੈ
         project_review_request: ਸੰਚਾਲਕ ਨੇ ਇੱਕ ਪ੍ਰੋਜੈਕਟ ਸਮੀਖਿਆ ਦੀ ਬੇਨਤੀ ਕੀਤੀ
         project_review_state_change: ਸਮੀਖਿਅਕ ਨੇ ਪ੍ਰੋਜੈਕਟ ਨੂੰ ਮਨਜ਼ੂਰੀ ਦਿੱਤੀ
+        proposal_expired: ਇੱਕ ਪ੍ਰਸਤਾਵ ਥ੍ਰੈਸ਼ਹੋਲਡ ਤੱਕ ਪਹੁੰਚੇ ਬਿਨਾਂ ਐਕਸਪਾਇਰ ਹੋ ਜਾਂਦਾ ਹੈ
         proposal_gets_reported_as_spam: ਪ੍ਰਸਤਾਵ ਨੂੰ ਸਪੈਮ ਵਜੋਂ ਰਿਪੋਰਟ ਕੀਤਾ ਜਾਂਦਾ ਹੈ
         proposal_is_assigned_to_admin: ਪ੍ਰਸਤਾਵ ਐਡਮਿਨ ਨੂੰ ਸੌਂਪਿਆ ਗਿਆ ਹੈ
         proposal_is_published: ਪ੍ਰਸਤਾਵ ਪ੍ਰਕਾਸ਼ਿਤ ਕੀਤਾ ਗਿਆ ਹੈ
@@ -188,6 +189,7 @@ pa-IN:
       project_published: ਪ੍ਰੋਜੈਕਟ ਪ੍ਰਕਾਸ਼ਿਤ ਕੀਤਾ ਗਿਆ ਹੈ
       project_review_request: ਪ੍ਰੋਜੈਕਟ ਸਮੀਖਿਆ ਬੇਨਤੀ
       project_review_state_change: ਪ੍ਰੋਜੈਕਟ ਨੂੰ ਮਨਜ਼ੂਰੀ ਦਿੱਤੀ ਗਈ
+      proposal_expired_for_admin: ਪ੍ਰਸਤਾਵ ਵੋਟਿੰਗ ਥ੍ਰੈਸ਼ਹੋਲਡ ਤੱਕ ਪਹੁੰਚੇ ਬਿਨਾਂ ਐਕਸਪਾਇਰ ਹੋ ਗਿਆ
       screening_digest: ਹਫ਼ਤਾਵਾਰੀ ਸਕ੍ਰੀਨਿੰਗ ਰੀਮਾਈਂਡਰ
       space_moderation_rights_received: ਸਪੇਸ ਮੈਨੇਜਰ ਦੇ ਅਧਿਕਾਰ ਪ੍ਰਾਪਤ ਹੋਏ
       status_change_on_idea_you_follow: ਕਿਸੇ ਵਿਚਾਰ ਦੀ ਸਥਿਤੀ ਤਬਦੀਲੀ ਜਿਸਦਾ ਤੁਸੀਂ ਅਨੁਸਰਣ ਕਰਦੇ ਹੋ
@@ -591,6 +593,11 @@ pa-IN:
       preheader: '%{reviewerName} ਨੇ ਪ੍ਰੋਜੈਕਟ ਨੂੰ ਪ੍ਰਵਾਨਗੀ ਦਿੱਤੀ "%{projectTitle}"'
       subject: '"%{projectTitle}" ਨੂੰ ਮਨਜ਼ੂਰੀ ਦਿੱਤੀ ਗਈ ਹੈ'
       title: '%{reviewerName} ਨੇ "%{projectTitle}" ਪ੍ਰੋਜੈਕਟ ਨੂੰ ਪ੍ਰਵਾਨਗੀ ਦਿੱਤੀ'
+    proposal_expired_for_admin:
+      cta_button: ਐਕਸਪਾਇਰ ਹੋਏ ਇਨਪੁਟ ਦੀ ਸਮੀਖਿਆ ਕਰੋ
+      preheader: ਇੱਕ ਇਨਪੁਟ ਥ੍ਰੈਸ਼ਹੋਲਡ ਤੱਕ ਪਹੁੰਚੇ ਬਿਨਾਂ ਐਕਸਪਾਇਰ ਹੋ ਗਿਆ
+      subject: '"%{input_title}" ਥ੍ਰੈਸ਼ਹੋਲਡ ਤੱਕ ਪਹੁੰਚੇ ਬਿਨਾਂ ਐਕਸਪਾਇਰ ਹੋ ਗਿਆ'
+      title: ਇੱਕ ਇਨਪੁਟ ਵੋਟਿੰਗ ਥ੍ਰੈਸ਼ਹੋਲਡ ਤੱਕ ਪਹੁੰਚੇ ਬਿਨਾਂ ਐਕਸਪਾਇਰ ਹੋ ਗਿਆ
     schedules:
       quarterly: ਤਿਮਾਹੀ, ਤਿਮਾਹੀ ਦੇ ਪਹਿਲੇ ਦਿਨ
       weekly:

--- a/back/engines/free/email_campaigns/config/locales/pl-PL.yml
+++ b/back/engines/free/email_campaigns/config/locales/pl-PL.yml
@@ -94,6 +94,7 @@ pl-PL:
         project_published: Projekt opublikowany
         project_review_request: Moderator zażądał przeglądu projektu
         project_review_state_change: Recenzent zatwierdził projekt
+        proposal_expired: Propozycja wygasa bez osiągnięcia progu
         proposal_gets_reported_as_spam: Propozycja zostaje zgłoszona jako spam
         proposal_is_assigned_to_admin: Propozycja jest przypisana do administratora
         proposal_is_published: Wniosek został opublikowany
@@ -188,6 +189,7 @@ pl-PL:
       project_published: Projekt opublikowany
       project_review_request: Żądanie przeglądu projektu
       project_review_state_change: Projekt zatwierdzony
+      proposal_expired_for_admin: Propozycja wygasła bez osiągnięcia progu głosowania
       screening_digest: Cotygodniowe przypomnienie o badaniu przesiewowym
       space_moderation_rights_received: Otrzymano uprawnienia menedżera obszaru
       status_change_on_idea_you_follow: Zmiana statusu pomysłu, za którym podążasz
@@ -591,6 +593,11 @@ pl-PL:
       preheader: '%{reviewerName} zatwierdził projekt "%{projectTitle}"'
       subject: '"%{projectTitle}" został zatwierdzony'
       title: '%{reviewerName} zatwierdził projekt "%{projectTitle}"'
+    proposal_expired_for_admin:
+      cta_button: Przejrzyj wygasłe zgłoszenie
+      preheader: Zgłoszenie wygasło bez osiągnięcia progu
+      subject: '%{input_title} wygasło bez osiągnięcia progu'
+      title: Zgłoszenie wygasło bez osiągnięcia progu głosowania
     schedules:
       quarterly: Kwartalnie, pierwszego dnia kwartału
       weekly:

--- a/back/engines/free/email_campaigns/config/locales/pt-BR.yml
+++ b/back/engines/free/email_campaigns/config/locales/pt-BR.yml
@@ -94,6 +94,7 @@ pt-BR:
         project_published: Projeto publicado
         project_review_request: O moderador solicitou uma revisão do projeto
         project_review_state_change: O revisor aprovou o projeto
+        proposal_expired: Uma proposta expira sem atingir o limiar
         proposal_gets_reported_as_spam: A proposta foi denunciada como spam
         proposal_is_assigned_to_admin: A proposta está atribuída ao administrador
         proposal_is_published: A proposta foi publicada
@@ -188,6 +189,7 @@ pt-BR:
       project_published: Projeto publicado
       project_review_request: Solicitação de revisão do projeto
       project_review_state_change: Projeto aprovado
+      proposal_expired_for_admin: Proposta expirou sem atingir o limiar de votação
       screening_digest: Lembrete semanal de triagem
       space_moderation_rights_received: Direitos de gerente de espaço recebidos
       status_change_on_idea_you_follow: Mudança de status de uma ideia que você segue
@@ -591,6 +593,11 @@ pt-BR:
       preheader: '%{reviewerName} aprovou o projeto "%{projectTitle}"'
       subject: '"%{projectTitle}" " foi aprovado'
       title: '%{reviewerName} aprovou o projeto "%{projectTitle}"'
+    proposal_expired_for_admin:
+      cta_button: Revisar a contribuição expirada
+      preheader: Uma contribuição expirou sem atingir o limiar
+      subject: '"%{input_title}" expirou sem atingir o limiar'
+      title: Uma contribuição expirou sem atingir o limiar de votação
     schedules:
       quarterly: Trimestralmente, no primeiro dia do trimestre
       weekly:

--- a/back/engines/free/email_campaigns/config/locales/sv-SE.yml
+++ b/back/engines/free/email_campaigns/config/locales/sv-SE.yml
@@ -94,6 +94,7 @@ sv-SE:
         project_published: Projekt publicerat
         project_review_request: Moderator begärde en projektgenomgång
         project_review_state_change: Granskaren godkände projektet
+        proposal_expired: Ett förslag löper ut utan att nå tröskeln
         proposal_gets_reported_as_spam: Förslaget rapporteras som skräppost
         proposal_is_assigned_to_admin: Förslaget har tilldelats admin
         proposal_is_published: Förslaget har offentliggjorts
@@ -188,6 +189,7 @@ sv-SE:
       project_published: Projekt publicerat
       project_review_request: Begäran om projektgranskning
       project_review_state_change: Projekt godkänt
+      proposal_expired_for_admin: Förslaget har löpt ut utan att nå rösttröskeln
       screening_digest: Påminnelse om screening varje vecka
       space_moderation_rights_received: Rättigheter som space-ansvarig mottagna
       status_change_on_idea_you_follow: Statusförändring av en idé som du följer
@@ -591,6 +593,11 @@ sv-SE:
       preheader: '%{reviewerName} godkänt projektet "%{projectTitle}"'
       subject: '"%{projectTitle}" har godkänts'
       title: '%{reviewerName} godkänt projektet "%{projectTitle}"'
+    proposal_expired_for_admin:
+      cta_button: Granska det utgångna bidraget
+      preheader: Ett bidrag har löpt ut utan att nå tröskeln
+      subject: '"%{input_title}" har löpt ut utan att nå tröskeln'
+      title: Ett bidrag har löpt ut utan att nå rösttröskeln
     schedules:
       quarterly: Kvartalsvis, den första dagen i kvartalet
       weekly:

--- a/back/engines/free/email_campaigns/config/locales/tr-TR.yml
+++ b/back/engines/free/email_campaigns/config/locales/tr-TR.yml
@@ -94,6 +94,7 @@ tr-TR:
         project_published: Proje yayınlandı
         project_review_request: Moderatör proje incelemesi talep etti
         project_review_state_change: Gözden geçiren projeyi onayladı
+        proposal_expired: Bir öneri eşiğe ulaşamadan süresi doluyor
         proposal_gets_reported_as_spam: Teklif spam olarak bildiriliyor
         proposal_is_assigned_to_admin: Teklif yöneticiye atanır
         proposal_is_published: Teklif yayınlandı
@@ -188,6 +189,7 @@ tr-TR:
       project_published: Proje yayınlandı
       project_review_request: Proje inceleme talebi
       project_review_state_change: Proje onaylandı
+      proposal_expired_for_admin: Öneri oylama eşiğine ulaşamadan süresi doldu
       screening_digest: Haftalık tarama hatırlatması
       space_moderation_rights_received: Alan yöneticisi yetkileri alındı
       status_change_on_idea_you_follow: Takip ettiğiniz bir fikrin durum değişikliği
@@ -591,6 +593,11 @@ tr-TR:
       preheader: '%{reviewerName} "%{projectTitle}" projesini onayladı.'
       subject: '"%{projectTitle}" onaylanmıştır'
       title: '%{reviewerName} "%{projectTitle}" projesini onayladı.'
+    proposal_expired_for_admin:
+      cta_button: Süresi dolan girdiyi inceleyin
+      preheader: Bir girdi eşiğe ulaşamadan süresi doldu
+      subject: '"%{input_title}" eşiğe ulaşamadan süresi doldu'
+      title: Bir girdi oylama eşiğine ulaşamadan süresi doldu
     schedules:
       quarterly: Üç ayda bir, üç aylık dönemin ilk gününde
       weekly:

--- a/back/engines/free/email_campaigns/config/locales/ur-PK.yml
+++ b/back/engines/free/email_campaigns/config/locales/ur-PK.yml
@@ -94,6 +94,7 @@ ur-PK:
         project_published: پروجیکٹ شائع ہوا۔
         project_review_request: ماڈریٹر نے پروجیکٹ کے جائزے کی درخواست کی۔
         project_review_state_change: جائزہ لینے والے نے منصوبے کی منظوری دے دی۔
+        proposal_expired: حد تک پہنچے بغیر ایک تجویز کی میعاد ختم ہو جاتی ہے
         proposal_gets_reported_as_spam: تجویز کو اسپام کے طور پر رپورٹ کیا جاتا ہے۔
         proposal_is_assigned_to_admin: تجویز ایڈمن کو سونپی گئی ہے۔
         proposal_is_published: تجویز شائع کی گئی ہے۔
@@ -188,6 +189,7 @@ ur-PK:
       project_published: پروجیکٹ شائع ہوا۔
       project_review_request: پروجیکٹ کا جائزہ لینے کی درخواست
       project_review_state_change: پروجیکٹ کی منظوری دی گئی۔
+      proposal_expired_for_admin: ووٹنگ کی حد تک پہنچے بغیر تجویز کی میعاد ختم ہو گئی
       screening_digest: ہفتہ وار اسکریننگ کی یاد دہانی
       space_moderation_rights_received: اسپیس مینیجر کے اختیارات موصول ہو گئے
       status_change_on_idea_you_follow: کسی خیال کی حیثیت کی تبدیلی جس کی آپ پیروی کرتے ہیں۔
@@ -591,6 +593,11 @@ ur-PK:
       preheader: '%{reviewerName} نے پروجیکٹ کی منظوری دے دی "%{projectTitle}"'
       subject: '"%{projectTitle}" کو منظور کر لیا گیا ہے۔'
       title: '%{reviewerName} نے پروجیکٹ کی منظوری دی "%{projectTitle}"'
+    proposal_expired_for_admin:
+      cta_button: میعاد ختم ہونے والے ان پٹ کا جائزہ لیں
+      preheader: حد تک پہنچے بغیر ایک ان پٹ کی میعاد ختم ہو گئی
+      subject: '"%{input_title}" حد تک پہنچے بغیر ایکسپائر ہو گیا'
+      title: ووٹنگ کی حد تک پہنچے بغیر ایک ان پٹ کی میعاد ختم ہو گئی
     schedules:
       quarterly: سہ ماہی، سہ ماہی کے پہلے دن
       weekly:

--- a/back/engines/free/email_campaigns/spec/acceptance/campaigns_spec.rb
+++ b/back/engines/free/email_campaigns/spec/acceptance/campaigns_spec.rb
@@ -73,7 +73,7 @@ resource 'Campaigns' do
         end
 
         do_request(manual: false)
-        expect(response_data.size).to eq 50
+        expect(response_data.size).to eq 51
       end
 
       example 'List all manual campaigns when one has been sent' do

--- a/back/engines/free/email_campaigns/spec/factories/campaigns.rb
+++ b/back/engines/free/email_campaigns/spec/factories/campaigns.rb
@@ -162,6 +162,10 @@ FactoryBot.define do
     enabled { true }
   end
 
+  factory :proposal_expired_for_admin_campaign, class: 'EmailCampaigns::Campaigns::ProposalExpiredForAdmin' do
+    enabled { true }
+  end
+
   factory :welcome_campaign, class: 'EmailCampaigns::Campaigns::Welcome' do
     enabled { true }
   end

--- a/back/engines/free/email_campaigns/spec/fixtures/locales/mailers.en.yml
+++ b/back/engines/free/email_campaigns/spec/fixtures/locales/mailers.en.yml
@@ -429,6 +429,11 @@ en:
       title: 'A proposal reached the voting threshold!'
       subject: '"%{input_title}" reached the voting threshold'
       preheader: 'Make sure to take the next steps'
+    proposal_expired_for_admin:
+      cta_button: 'Review the expired proposal'
+      title: 'A proposal expired without reaching the voting threshold'
+      subject: '"%{input_title}" expired without reaching the threshold'
+      preheader: 'A proposal closed without reaching the threshold'
     welcome:
       cta_button: 'Discover the platform'
       subject: 'Welcome to the platform of %{organizationName}'

--- a/back/engines/free/email_campaigns/spec/fixtures/locales/mailers.fr-FR.yml
+++ b/back/engines/free/email_campaigns/spec/fixtures/locales/mailers.fr-FR.yml
@@ -430,6 +430,11 @@ fr-FR:
       title: 'Une proposition a atteint le nombre de voix requis!'
       subject: '"%{input_title}" a atteint le nombre de voix requis sur votre plateforme'
       preheader: 'Assurez-vous de passer aux étapes suivantes'
+    proposal_expired_for_admin:
+      cta_button: 'Consulter la proposition expirée'
+      title: 'Une proposition a expiré sans atteindre le seuil de vote'
+      subject: '"%{input_title}" a expiré sans atteindre le seuil'
+      preheader: 'Une proposition s''est terminée sans atteindre le seuil'
     welcome:
       cta_button: 'Découvrir la plateforme'
       subject: 'Bienvenue sur la plateforme de %{organizationName}'

--- a/back/engines/free/email_campaigns/spec/fixtures/locales/mailers.nl-NL.yml
+++ b/back/engines/free/email_campaigns/spec/fixtures/locales/mailers.nl-NL.yml
@@ -429,6 +429,11 @@ nl:
       title: 'Een voorstel heeft het benodigd aantal stemmen bereikt!'
       subject: '"%{input_title}" heeft het benodigd aantal stemmen op je platform bereikt'
       preheader: 'Tijd om de volgende stappen te nemen'
+    proposal_expired_for_admin:
+      cta_button: 'Bekijk het verlopen voorstel'
+      title: 'Een voorstel is verlopen zonder het benodigd aantal stemmen te bereiken'
+      subject: '"%{input_title}" is verlopen zonder het benodigd aantal stemmen te bereiken'
+      preheader: 'Een voorstel is afgesloten zonder de drempel te bereiken'
     welcome:
       cta_button: 'Ontdek het platform'
       subject: 'Welkom op het platform van %{organizationName}'

--- a/back/engines/free/email_campaigns/spec/mailers/previews/email_campaigns/proposal_expired_for_admin_mailer_preview.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/previews/email_campaigns/proposal_expired_for_admin_mailer_preview.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module EmailCampaigns
+  class ProposalExpiredForAdminMailerPreview < ActionMailer::Preview
+    include EmailCampaigns::MailerPreview
+
+    def campaign_mail
+      preview_campaign_mail(EmailCampaigns::Campaigns::ProposalExpiredForAdmin)
+    end
+  end
+end

--- a/back/engines/free/email_campaigns/spec/mailers/proposal_expired_for_admin_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/proposal_expired_for_admin_mailer_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EmailCampaigns::ProposalExpiredForAdminMailer do
+  describe 'campaign_mail' do
+    let_it_be(:recipient) { create(:user, locale: 'en') }
+    let_it_be(:command) do
+      {
+        recipient: recipient,
+        event_payload: {
+          idea_title_multiloc: { 'en' => 'Example idea title' },
+          idea_author_name: 'Hodor',
+          idea_url: 'https://example.com/ideas/1',
+          assignee_first_name: 'Hans',
+          assignee_last_name: 'Annee'
+        }
+      }
+    end
+
+    let(:campaign) { create(:proposal_expired_for_admin_campaign) }
+    let(:mailer) { described_class.with(command: command, campaign: campaign) }
+    let(:mail) { mailer.campaign_mail.deliver_now }
+    let(:body) { mail_body(mail) }
+
+    before_all { EmailCampaigns::UnsubscriptionToken.create!(user_id: recipient.id) }
+
+    include_examples 'campaign delivery tracking'
+
+    it 'renders the subject' do
+      expect(mail.subject).to eq('"Example idea title" expired without reaching the threshold')
+    end
+
+    it 'renders the receiver email' do
+      expect(mail.to).to eq([recipient.email])
+    end
+
+    it 'renders the sender email' do
+      expect(mail.from).to all(end_with('@citizenlab.co'))
+    end
+
+    it 'includes the header' do
+      expect(body).to have_tag('div') do
+        with_tag 'h1' do
+          with_text(/A proposal expired without reaching the voting threshold/)
+        end
+      end
+    end
+
+    it 'includes the idea box' do
+      expect(body).to have_tag('table') do
+        with_tag 'h2' do
+          with_text(/Example idea title/)
+        end
+        with_tag 'p' do
+          with_text(/by Hodor/)
+        end
+      end
+    end
+
+    it 'includes the CTA' do
+      expect(body).to have_tag('a', with: { href: 'https://example.com/ideas/1' }) do
+        with_text(/Review the expired proposal/)
+      end
+    end
+
+    context 'with custom text' do
+      let!(:global_campaign) do
+        create(
+          :proposal_expired_for_admin_campaign,
+          subject_multiloc: { 'en' => 'Custom Global Subject - {{ organizationName }}' },
+          title_multiloc: { 'en' => 'NEW TITLE FOR {{ input_title }}' },
+          button_text_multiloc: { 'en' => 'CLICK THE GLOBAL BUTTON' }
+        )
+      end
+
+      context 'on a global campaign' do
+        let(:campaign) { global_campaign }
+
+        it 'can customise the subject' do
+          expect(mail.subject).to eq 'Custom Global Subject - Liege'
+        end
+
+        it 'renders the reply to email' do
+          expect(mail.reply_to).to eq [ENV.fetch('DEFAULT_FROM_EMAIL', 'hello@citizenlab.co')]
+        end
+
+        it 'can customize the header' do
+          expect(body).to have_tag('div') do
+            with_tag 'h1' do
+              with_text(/NEW TITLE FOR Example idea title/)
+            end
+          end
+        end
+
+        it 'includes the CTA' do
+          expect(body).to have_tag('a', with: { href: 'https://example.com/ideas/1' }) do
+            with_text(/CLICK THE GLOBAL BUTTON/)
+          end
+        end
+      end
+    end
+  end
+end

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/proposal_expired_for_admin_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/proposal_expired_for_admin_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EmailCampaigns::Campaigns::ProposalExpiredForAdmin do
+  describe 'ProposalExpiredForAdmin campaign default factory' do
+    it 'is valid' do
+      expect(build(:proposal_expired_for_admin_campaign)).to be_valid
+    end
+  end
+
+  describe '#generate_commands' do
+    let(:campaign) { create(:proposal_expired_for_admin_campaign) }
+    let(:notification) { create(:proposal_expired_for_admin) }
+    let(:notification_activity) { create(:activity, item: notification, action: 'created') }
+
+    it 'generates a command with the desired payload and tracked content' do
+      command = campaign.generate_commands(
+        recipient: notification_activity.item.recipient,
+        activity: notification_activity
+      ).first
+
+      expect(command).to match({
+        event_payload: hash_including(
+          idea_title_multiloc: notification.idea.title_multiloc,
+          idea_author_name: an_instance_of(String),
+          idea_url: an_instance_of(String)
+        )
+      })
+    end
+  end
+end

--- a/back/spec/factories/idea_statuses.rb
+++ b/back/spec/factories/idea_statuses.rb
@@ -40,6 +40,11 @@ FactoryBot.define do
       title_multiloc { { 'en' => 'Threshold reached' } }
     end
 
+    factory :proposal_status_expired, traits: [:proposals] do
+      code { 'expired' }
+      title_multiloc { { 'en' => 'Expired' } }
+    end
+
     factory :proposals_status, traits: [:proposals]
     factory :idea_status_proposed, traits: %i[ideation proposed]
     factory :idea_status_prescreening, traits: %i[ideation prescreening]

--- a/back/spec/factories/notifications.rb
+++ b/back/spec/factories/notifications.rb
@@ -182,6 +182,11 @@ FactoryBot.define do
     idea_status
   end
 
+  factory :proposal_expired_for_admin, parent: :notification, class: 'Notifications::ProposalExpiredForAdmin' do
+    idea
+    idea_status
+  end
+
   factory :native_survey_not_submitted, parent: :notification, class: 'Notifications::NativeSurveyNotSubmitted' do
     idea
     project

--- a/back/spec/models/notifications/proposal_expired_for_admin_spec.rb
+++ b/back/spec/models/notifications/proposal_expired_for_admin_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Notifications::ProposalExpiredForAdmin do
+  describe 'make_notifications_on' do
+    it 'makes a notification on an idea reaching the expired status for admins and moderators' do
+      status = create(:proposal_status_expired)
+      proposal = create(:proposal, idea_status: status)
+      activity = create(:idea_changed_status_activity, item: proposal, payload: { change: [nil, status.id] }, user: nil)
+
+      recipient = create(:admin)
+      recipient2 = create(:project_moderator, projects: [proposal.project])
+      _non_recipient = create(:user)
+      _non_recipient2 = create(:project_moderator)
+
+      notifications = described_class.make_notifications_on(activity)
+      expect(notifications.size).to eq(2)
+      expect(notifications).to include(have_attributes(
+        recipient_id: recipient.id,
+        idea_id: proposal.id,
+        idea_status_id: status.id,
+        initiating_user: nil
+      ))
+      expect(notifications).to include(have_attributes(
+        recipient_id: recipient2.id
+      ))
+    end
+
+    it 'does not make a notification on an idea not reaching the expired status' do
+      status = create(:proposals_status, code: 'proposed')
+      proposal = create(:proposal, idea_status: status)
+      activity = create(:idea_changed_status_activity, item: proposal, payload: { change: [nil, status.id] }, user: nil)
+
+      expect(described_class.make_notifications_on(activity)).to be_empty
+    end
+  end
+end

--- a/front/app/api/campaigns/types.ts
+++ b/front/app/api/campaigns/types.ts
@@ -151,6 +151,7 @@ type AdminModeratorCampaignName =
   | 'project_moderation_rights_received'
   | 'space_moderation_rights_received'
   | 'threshold_reached_for_admin'
+  | 'proposal_expired_for_admin'
   | InternalCommentType;
 
 export type CampaignName =

--- a/front/app/api/notifications/types.ts
+++ b/front/app/api/notifications/types.ts
@@ -311,6 +311,17 @@ export interface IThresholdReachedForAdminNotificationData
   };
 }
 
+export interface IProposalExpiredForAdminNotificationData
+  extends IBaseNotificationData {
+  attributes: {
+    type: 'proposal_expired_for_admin';
+    read_at: string | null;
+    created_at: string;
+    post_title_multiloc: Multiloc;
+    post_slug: string;
+  };
+}
+
 export interface ISpaceModerationRightsReceivedNotificationData
   extends IBaseNotificationData {
   attributes: {
@@ -412,6 +423,7 @@ export interface INotificationDataMap {
   IProjectReviewStateChangeNotificationData: IProjectReviewStateChangeNotificationData;
   IStatusChangeOnIdeaYouFollowNotificationData: IStatusChangeOnIdeaYouFollowNotificationData;
   IThresholdReachedForAdminNotificationData: IThresholdReachedForAdminNotificationData;
+  IProposalExpiredForAdminNotificationData: IProposalExpiredForAdminNotificationData;
   ISpaceModerationRightsReceivedNotificationData: ISpaceModerationRightsReceivedNotificationData;
   IProjectFolderModerationRightsReceivedNotificationData: IProjectFolderModerationRightsReceivedNotificationData;
   IVotingBasketSubmittedNotificationData: IVotingBasketSubmittedNotificationData;


### PR DESCRIPTION
Adds an admin/moderator-facing in-app notification and email when a proposal automatically transitions to `expired` (its phase's `expire_days_limit` elapsed without the reacting threshold being met). Mirrors the existing `ThresholdReachedForAdmin` notification + campaign, which fires on the inverse outcome.

# Changelog
## Added
- Admins and project moderators now receive an in-app notification and email when a proposal expires without reaching the voting threshold.

# For translators

<img width="1031" height="1455" alt="image" src="https://github.com/user-attachments/assets/78400fa3-994b-4a8e-9684-e360b2d98f8a" />
