### PR TITLE
[TAN-6100] Fix project templates showing English-only content

### DIFF
--- a/front/app/modules/commercial/admin_project_templates/admin/api/useDepartments.tsx
+++ b/front/app/modules/commercial/admin_project_templates/admin/api/useDepartments.tsx
@@ -20,8 +20,9 @@ const useDepartments = () => {
   `;
 
   return useQuery({
-    queryKey: ['departments'],
+    queryKey: ['departments', graphqlTenantLocales],
     queryFn: () => graphqlFetcher({ query: DEPARTMENTS_QUERY }),
+    enabled: graphqlTenantLocales !== null,
     select: (data) => data.departments.nodes, // Transform to return just the nodes array
   });
 };

--- a/front/app/modules/commercial/admin_project_templates/admin/api/useGraphqlTenantLocales.ts
+++ b/front/app/modules/commercial/admin_project_templates/admin/api/useGraphqlTenantLocales.ts
@@ -1,33 +1,23 @@
-import { useState, useEffect } from 'react';
-
-import { includes } from 'lodash-es';
-import { GraphqlLocale } from 'typings';
+import { useMemo } from 'react';
 
 import useAppConfiguration from 'api/app_configuration/useAppConfiguration';
 
-import { isNilOrError, convertToGraphqlLocale } from 'utils/helperUtils';
+import { convertToGraphqlLocale } from 'utils/helperUtils';
 
 export default function useGraphqlTenantLocales() {
-  const [graphqlTenantLocales, setGraphqlTenantLocales] = useState<
-    GraphqlLocale[]
-  >(['en']);
   const { data: appConfig } = useAppConfiguration();
 
-  useEffect(() => {
-    if (isNilOrError(appConfig)) return;
+  return useMemo(() => {
+    if (!appConfig) return null;
 
     const graphqlLocales = appConfig.data.attributes.settings.core.locales.map(
       (locale) => convertToGraphqlLocale(locale)
     );
 
-    if (!includes(graphqlLocales, 'en')) {
+    if (!graphqlLocales.includes('en')) {
       graphqlLocales.push('en');
     }
 
-    setGraphqlTenantLocales(graphqlLocales);
-
-    return () => setGraphqlTenantLocales(['en']);
+    return graphqlLocales;
   }, [appConfig]);
-
-  return graphqlTenantLocales;
 }

--- a/front/app/modules/commercial/admin_project_templates/admin/api/useParticipationLevels.tsx
+++ b/front/app/modules/commercial/admin_project_templates/admin/api/useParticipationLevels.tsx
@@ -20,11 +20,12 @@ const useParticipationLevels = () => {
   `;
 
   return useQuery({
-    queryKey: ['participationLevels'],
+    queryKey: ['participationLevels', graphqlTenantLocales],
     queryFn: () =>
       graphqlFetcher({
         query: PARTICIPATION_LEVELS_QUERY,
       }),
+    enabled: graphqlTenantLocales !== null,
     select: (data) => data.participationLevels.nodes, // Transform to return just the nodes array
   });
 };

--- a/front/app/modules/commercial/admin_project_templates/admin/api/useProjectTemplatePreview.tsx
+++ b/front/app/modules/commercial/admin_project_templates/admin/api/useProjectTemplatePreview.tsx
@@ -4,7 +4,7 @@ import { graphqlFetcher } from '../../utils/graphqlFetcher';
 
 type ProjectTemplatePreviewArgs = {
   projectTemplateId: string | null | undefined;
-  graphqlTenantLocales: string[];
+  graphqlTenantLocales: string[] | null;
 };
 
 const useProjectTemplatePreview = ({
@@ -57,13 +57,13 @@ const useProjectTemplatePreview = ({
 `;
 
   return useQuery({
-    queryKey: ['projectTemplate', projectTemplateId],
+    queryKey: ['projectTemplate', projectTemplateId, graphqlTenantLocales],
     queryFn: () =>
       graphqlFetcher({
         query: PROJECT_TEMPLATE_QUERY,
         variables: { id: projectTemplateId },
       }),
-    enabled: !!projectTemplateId,
+    enabled: !!projectTemplateId && graphqlTenantLocales !== null,
   });
 };
 

--- a/front/app/modules/commercial/admin_project_templates/admin/api/usePublishedProjectTemplates.tsx
+++ b/front/app/modules/commercial/admin_project_templates/admin/api/usePublishedProjectTemplates.tsx
@@ -14,7 +14,7 @@ interface PublishedProjectTemplatesArgs {
     | 'large_city'
     | 'generic'
     | null;
-  graphqlTenantLocales: string[];
+  graphqlTenantLocales: string[] | null;
 }
 
 type PublishedProjectTemplatesResponse = {
@@ -119,6 +119,7 @@ const usePublishedProjectTemplates = ({
         search,
         locales,
         organizationTypes,
+        graphqlTenantLocales,
       },
     ],
     queryFn: ({ pageParam = null }) =>
@@ -134,6 +135,7 @@ const usePublishedProjectTemplates = ({
           organizationTypes,
         },
       }),
+    enabled: graphqlTenantLocales !== null,
     getNextPageParam: (lastPage) =>
       lastPage.publishedProjectTemplates.pageInfo.hasNextPage
         ? lastPage.publishedProjectTemplates.pageInfo.endCursor

--- a/front/app/modules/commercial/admin_project_templates/admin/api/usePurposes.tsx
+++ b/front/app/modules/commercial/admin_project_templates/admin/api/usePurposes.tsx
@@ -20,8 +20,9 @@ const usePurposes = () => {
   `;
 
   return useQuery({
-    queryKey: ['purposes'],
+    queryKey: ['purposes', graphqlTenantLocales],
     queryFn: () => graphqlFetcher({ query: PURPOSES_QUERY }),
+    enabled: graphqlTenantLocales !== null,
     select: (data) => data.purposes.nodes, // Transform to return just the nodes array
   });
 };

--- a/front/app/modules/commercial/admin_project_templates/admin/api/useTemplateTitle.tsx
+++ b/front/app/modules/commercial/admin_project_templates/admin/api/useTemplateTitle.tsx
@@ -17,13 +17,13 @@ const useTemplateTitle = (projectTemplateId?: string | null) => {
   `;
 
   return useQuery({
-    queryKey: ['projectTemplateTitle', projectTemplateId],
+    queryKey: ['projectTemplateTitle', projectTemplateId, graphqlTenantLocales],
     queryFn: () =>
       graphqlFetcher({
         query: TEMPLATE_TITLE_QUERY,
         variables: { id: projectTemplateId },
       }),
-    enabled: !!projectTemplateId,
+    enabled: !!projectTemplateId && graphqlTenantLocales !== null,
   });
 };
 


### PR DESCRIPTION
useGraphqlTenantLocales initialized to ['en'] and updated via useEffect after appConfig loaded, causing a race: queries fired with just 'en' before the real locales were available, and their queryKey didn't include the locales so they never refetched with the correct values.

Replace useState+useEffect with useMemo to derive locales synchronously, return null while loading, and gate all template GraphQL queries on locales being available. Include locales in queryKeys so queries refetch if the locale set changes.


# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
