### PR TITLE
TAN-7705-a11y/fix-all-projects-list-css-disabled

### DIFF
--- a/front/app/containers/MainHeader/Components/DesktopNavItems/AdminPublicationsNavbarItem.tsx
+++ b/front/app/containers/MainHeader/Components/DesktopNavItems/AdminPublicationsNavbarItem.tsx
@@ -103,13 +103,19 @@ const NavigationDropdownItemIcon = styled(Icon)`
   `}
 `;
 
-const ProjectsList = styled.div`
+const ProjectsList = styled.ul`
   display: flex;
   flex-direction: column;
   align-items: stretch;
   ${isRtl`
     text-align: right;
   `}
+  list-style: none;
+  margin: 0;
+  padding: 0;
+`;
+const ListItemWrapper = styled.li`
+  list-style: none;
 `;
 
 const ProjectsListFooter = styled(Link)`
@@ -219,7 +225,7 @@ const AdminPublicationsNavbarItem = ({
             {adminPublications ? (
               <>
                 {adminPublications.map((item) => (
-                  <React.Fragment key={item.id}>
+                  <ListItemWrapper key={item.id}>
                     {item.relationships.publication.data.type === 'project' && (
                       <ProjectsListItem
                         to={
@@ -238,7 +244,7 @@ const AdminPublicationsNavbarItem = ({
                         {localize(item.attributes.publication_title_multiloc)}
                       </ProjectsListItem>
                     )}
-                  </React.Fragment>
+                  </ListItemWrapper>
                 ))}
               </>
             ) : (

--- a/front/app/containers/MainHeader/Components/ProjectsListItem/index.tsx
+++ b/front/app/containers/MainHeader/Components/ProjectsListItem/index.tsx
@@ -10,6 +10,7 @@ const ProjectsListItem = styled(Link)`
   line-height: 21px;
   text-decoration: none;
   padding: 10px;
+  margin-bottom: 4px;
   display: block;
   background: transparent;
   border-radius: ${(props) => props.theme.borderRadius};

--- a/front/app/containers/MainHeader/Components/ProjectsListItem/index.tsx
+++ b/front/app/containers/MainHeader/Components/ProjectsListItem/index.tsx
@@ -10,7 +10,7 @@ const ProjectsListItem = styled(Link)`
   line-height: 21px;
   text-decoration: none;
   padding: 10px;
-  margin-bottom: 4px;
+  display: block;
   background: transparent;
   border-radius: ${(props) => props.theme.borderRadius};
 


### PR DESCRIPTION
Wraps ProjectsListItem links in `<li> `elements within the projects dropdown
to improve semantic HTML structure and ensure proper spacing when CSS is
disabled. This change enhances accessibility without affecting visual design.

# Changelog
-  wrap project links in list items for a11y

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
