### PR TITLE
TAN-7709-a11y/fix-confusing-spacing-css-disabled

### DIFF
--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/SingleIdeaWidget/IdeaCard/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/SingleIdeaWidget/IdeaCard/index.tsx
@@ -139,15 +139,16 @@ const IdeaCard = ({
               }
               overflow={hideTextOverflow ? 'hidden' : undefined}
             >
-              <Box
-                display={hideTextOverflow ? 'block' : 'none'}
-                position="absolute"
-                mt={`${MEDIUM_LINE_HEIGHT * 6}px`}
-                height={`${MEDIUM_LINE_HEIGHT * 2}px`}
-                width={`${textContainerRef.current?.clientWidth ?? 0}px`}
-              >
-                <Image src={GradientSrc} alt="" width="100%" height="100%" />
-              </Box>
+              {hideTextOverflow && (
+                <Box
+                  position="absolute"
+                  mt={`${MEDIUM_LINE_HEIGHT * 6}px`}
+                  height={`${MEDIUM_LINE_HEIGHT * 2}px`}
+                  width={`${textContainerRef.current?.clientWidth ?? 0}px`}
+                >
+                  <Image src={GradientSrc} alt="" width="100%" height="100%" />
+                </Box>
+              )}
               <Box mt="12px">
                 <QuillEditedContent textColor={colors.textPrimary} fontSize="m">
                   <IdeaText


### PR DESCRIPTION
**conditionally render gradient overlay to prevent empty space when CSS disabled**
Previously, the gradient overlay used` display="none" `which still rendered the image element in the DOM. When CSS was disabled, this created unwanted empty space
Now the gradient only renders when hideTextOverflow is true and completely removing it from the DOM when not needed.


# Changelog
- conditionally render gradient overlay to prevent empty space when CSS disabled


# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
