### PR TITLE
[TAN-7617] Scope idea-feed topic modeling and classification to project

### DIFF
--- a/back/app/jobs/idea_feed/batch_topic_classification_job.rb
+++ b/back/app/jobs/idea_feed/batch_topic_classification_job.rb
@@ -5,9 +5,9 @@ module IdeaFeed
     queue_as :default
     self.priority = 70 # low priority
 
-    def perform(phase, idea_ids)
+    def perform(project, idea_ids)
       ideas = Idea.where(id: idea_ids)
-      service = IdeaFeed::TopicClassificationService.new(phase)
+      service = IdeaFeed::TopicClassificationService.new(project)
       service.classify_parallel_batch(ideas)
     end
   end

--- a/back/app/jobs/idea_feed/topic_modeling_job.rb
+++ b/back/app/jobs/idea_feed/topic_modeling_job.rb
@@ -3,9 +3,9 @@ module IdeaFeed
     queue_as :default
     self.priority = 70 # low priority
 
-    def perform(phase)
-      IdeaFeed::TopicModelingService.new(phase).rebalance_topics!
-      IdeaFeed::TopicClassificationService.new(phase).classify_all_inputs_in_background!
+    def perform(project)
+      IdeaFeed::TopicModelingService.new(project).rebalance_topics!
+      IdeaFeed::TopicClassificationService.new(project).classify_all_inputs_in_background!
     end
   end
 end

--- a/back/app/jobs/idea_feed/topic_modeling_scheduler_job.rb
+++ b/back/app/jobs/idea_feed/topic_modeling_scheduler_job.rb
@@ -1,23 +1,24 @@
+# frozen_string_literal: true
+
 module IdeaFeed
-  # Applies the topic modeling scheduler for all relevant phases in the current
-  # tenant
+  # Applies the topic modeling scheduler for all relevant projects in the
+  # current tenant
   class TopicModelingSchedulerJob < ApplicationJob
     queue_as :default
     self.priority = 70 # low priority
 
     def perform
-      phases_with_topic_modeling_enabled.each do |phase|
-        TopicModelingScheduler.new(phase).on_every_hour
+      projects_with_topic_modeling_enabled.each do |project|
+        TopicModelingScheduler.new(project).on_every_hour
       end
     end
 
-    # Returns all phases for which topic modeling could be scheduled
-    def phases_with_topic_modeling_enabled
-      Phase
-        .joins(:project)
-        .where(projects: { live_auto_input_topics_enabled: true })
-        .current
-        .filter { |phase| phase.pmethod.supports_input_topics? }
+    # Returns all projects for which topic modeling could be scheduled
+    def projects_with_topic_modeling_enabled
+      Project
+        .joins(:admin_publication)
+        .where(live_auto_input_topics_enabled: true)
+        .merge(AdminPublication.published)
     end
   end
 end

--- a/back/app/services/idea_feed/topic_classification_service.rb
+++ b/back/app/services/idea_feed/topic_classification_service.rb
@@ -8,8 +8,8 @@ module IdeaFeed
     class InvalidLLMResponse < StandardError; end
     RETRIES_INVALID_RESPONSE = 3
 
-    def initialize(phase)
-      @phase = phase
+    def initialize(project)
+      @project = project
     end
 
     # Given an idea, classifies it into one or more topics, overwriting any
@@ -55,17 +55,21 @@ module IdeaFeed
     BATCH_SIZE = 24
 
     def classify_all_inputs_in_background!
-      idea_ids = @phase.ideas.published.pluck(:id)
+      idea_ids = classifiable_inputs.pluck(:id)
       classification_jobs = idea_ids.each_slice(BATCH_SIZE).map do |batch_ids|
-        BatchTopicClassificationJob.new(@phase, batch_ids)
+        BatchTopicClassificationJob.new(@project, batch_ids)
       end
       ActiveJob.perform_all_later(classification_jobs)
     end
 
     private
 
+    def classifiable_inputs
+      @project.ideas.where(creation_phase: nil).published
+    end
+
     def load_topics
-      @phase.project.input_topics.where(depth: 0).order(:lft).includes(:children)
+      @project.input_topics.where(depth: 0).order(:lft).includes(:children)
     end
 
     def create_llm
@@ -102,9 +106,12 @@ module IdeaFeed
       @multiloc_service ||= MultilocService.new
     end
 
+    def custom_form
+      @project.custom_form || CustomForm.new(participation_context: @project)
+    end
+
     def classification_prompt(idea, topics)
-      form = @phase.pmethod.custom_form
-      input_text = Analysis::InputToText.new(custom_fields_without_topics(form)).formatted(idea)
+      input_text = Analysis::InputToText.new(custom_fields_without_topics(custom_form)).formatted(idea)
       ::Analysis::LLM::Prompt.new.fetch('idea_feed_live_classification',
         multiloc_service:,
         project: idea.project,

--- a/back/app/services/idea_feed/topic_modeling_scheduler.rb
+++ b/back/app/services/idea_feed/topic_modeling_scheduler.rb
@@ -14,10 +14,10 @@ module IdeaFeed
     MINIMUM_INPUTS = 10
     MINIMUM_INTERVAL_BETWEEN_RUNS = 20.minutes
 
-    attr_reader :phase
+    attr_reader :project
 
-    def initialize(phase)
-      @phase = phase
+    def initialize(project)
+      @project = project
     end
 
     def on_every_hour
@@ -40,15 +40,19 @@ module IdeaFeed
     private
 
     def shared_conditions_for_scheduling_met?
-      return false if phase.ideas.published.count < MINIMUM_INPUTS
+      return false if classifiable_inputs.count < MINIMUM_INPUTS
       return false if !first_run? && time_since_last_run < MINIMUM_INTERVAL_BETWEEN_RUNS
 
       true
     end
 
+    def classifiable_inputs
+      project.ideas.where(creation_phase: nil).published
+    end
+
     def last_run_activity
       @last_run_activity ||= Activity.where(
-        item: phase,
+        item: project,
         action: 'topics_rebalanced'
       ).order(acted_at: :desc).first
     end
@@ -59,7 +63,7 @@ module IdeaFeed
       inputs_at_last_run = last_run_activity.payload['input_count']
       return Float::INFINITY if inputs_at_last_run == 0
 
-      inputs_now = phase.ideas.published.count
+      inputs_now = classifiable_inputs.count
 
       (inputs_now - inputs_at_last_run) / inputs_at_last_run.to_f
     end
@@ -75,7 +79,7 @@ module IdeaFeed
     end
 
     def schedule_job!
-      TopicModelingJob.perform_later(phase)
+      TopicModelingJob.perform_later(project)
     end
   end
 end

--- a/back/app/services/idea_feed/topic_modeling_service.rb
+++ b/back/app/services/idea_feed/topic_modeling_service.rb
@@ -4,8 +4,8 @@ module IdeaFeed
   # to keep the topics up to date with the latest ideas. It tries to strike a
   # balance between accuracy and stability of the clusters.
   class TopicModelingService
-    def initialize(phase)
-      @phase = phase
+    def initialize(project)
+      @project = project
       @llm = LLMSelector.new.llm_class_for_use_case('idea_feed_live_topic_model').new
     end
 
@@ -14,7 +14,7 @@ module IdeaFeed
     # extent, but also reshuffles them if needed.
     def rebalance_topics!
       # Only root topics participate in mapping - subtopics are always recreated
-      old_root_topics = @phase.project.input_topics.roots.to_a
+      old_root_topics = @project.input_topics.roots.to_a
 
       # Run the topic model from scratch on the current set of inputs
       new_topics = run_topic_model
@@ -55,10 +55,16 @@ module IdeaFeed
       form.custom_fields.reject { |f| f.key == 'topic_ids' }
     end
 
-    def run_topic_model
-      inputs = @phase.ideas.published
+    def topic_modeling_inputs
+      @project.ideas.where(creation_phase: nil).published
+    end
 
-      prompt = topic_model_prompt(inputs)
+    def custom_form
+      @project.custom_form || CustomForm.new(participation_context: @project)
+    end
+
+    def run_topic_model
+      prompt = topic_model_prompt(topic_modeling_inputs)
 
       @llm.chat(prompt, response_schema: topic_model_response_schema)
     end
@@ -133,16 +139,15 @@ module IdeaFeed
     end
 
     def topic_model_prompt(inputs)
-      form = @phase.pmethod.custom_form
-      input_texts = Analysis::InputToText.new(custom_fields_without_topics(form)).format_all(
+      input_texts = Analysis::InputToText.new(custom_fields_without_topics(custom_form)).format_all(
         inputs.order(Arel.sql('RANDOM()')).limit(500),
         truncate_values: 256
       )
       ::Analysis::LLM::Prompt.new.fetch('idea_feed_live_topic_modeling',
         multiloc_service: MultilocService.new,
         project_description:,
-        project: @phase.project,
-        custom_fields: custom_fields_without_topics(form),
+        project: @project,
+        custom_fields: custom_fields_without_topics(custom_form),
         inputs_text: input_texts)
     end
 
@@ -150,7 +155,7 @@ module IdeaFeed
       ::Analysis::LLM::Prompt.new.fetch('idea_feed_live_topic_mapping',
         multiloc_service: MultilocService.new,
         project_description:,
-        project: @phase.project,
+        project: @project,
         old_topics:,
         new_topics:)
     end
@@ -223,7 +228,7 @@ module IdeaFeed
 
           (new_topic['problems'] || []).each do |subtopic|
             subtopic_record = InputTopic.create!(
-              project: @phase.project,
+              project: @project,
               parent: old_topic,
               title_multiloc: subtopic['title_multiloc'],
               description_multiloc: subtopic['description_multiloc']
@@ -242,7 +247,7 @@ module IdeaFeed
         .each_value do |new_topic|
           InputTopic.transaction do
             topic = InputTopic.create!(
-              project: @phase.project,
+              project: @project,
               title_multiloc: new_topic['title_multiloc'],
               description_multiloc: new_topic['description_multiloc'],
               icon: new_topic['icon']
@@ -258,7 +263,7 @@ module IdeaFeed
 
             (new_topic['problems'] || []).each do |subtopic|
               subtopic_record = InputTopic.create!(
-                project: @phase.project,
+                project: @project,
                 parent: topic,
                 title_multiloc: subtopic['title_multiloc'],
                 description_multiloc: subtopic['description_multiloc']
@@ -295,22 +300,22 @@ module IdeaFeed
     end
 
     def project_description
-      description_multiloc = if (layout = ContentBuilder::Layout.find_by(content_buildable: @phase.project, code: 'project_description', enabled: true))
+      description_multiloc = if (layout = ContentBuilder::Layout.find_by(content_buildable: @project, code: 'project_description', enabled: true))
         ContentBuilder::Craftjs::VisibleTextualMultilocs.new(layout.craftjs_json).extract_and_join
       else
-        @phase.project.description_multiloc
+        @project.description_multiloc
       end
       multiloc_service.t(description_multiloc)
     end
 
     def log_topics_rebalanced_activity(update_log: [], creation_log: [], removal_log: [])
       LogActivityJob.perform_later(
-        @phase,
+        @project,
         'topics_rebalanced',
         nil,
         Time.now.to_i,
         payload: {
-          input_count: @phase.ideas.published.count,
+          input_count: topic_modeling_inputs.count,
           update_log:,
           creation_log:,
           removal_log:

--- a/back/app/services/side_fx_idea_service.rb
+++ b/back/app/services/side_fx_idea_service.rb
@@ -251,21 +251,17 @@ class SideFxIdeaService
 
   def notify_topic_modeling_scheduler(idea)
     return unless idea.project.live_auto_input_topics_enabled
+    return unless idea.creation_phase.nil?
 
-    current_phase = TimelineService.new.current_phase(idea.project)
-    return unless current_phase.pmethod.supports_input_topics?
-
-    IdeaFeed::TopicModelingScheduler.new(current_phase).on_new_input
+    IdeaFeed::TopicModelingScheduler.new(idea.project).on_new_input
   end
 
   def enqueue_topic_classification_job(idea)
     return unless idea.project.live_auto_input_topics_enabled
     return if idea.input_topics.any?
+    return unless idea.creation_phase.nil?
 
-    current_phase = TimelineService.new.current_phase(idea.project)
-    return unless current_phase.pmethod.supports_input_topics?
-
-    IdeaFeed::BatchTopicClassificationJob.set(priority: 10).perform_later(current_phase, [idea.id])
+    IdeaFeed::BatchTopicClassificationJob.set(priority: 10).perform_later(idea.project, [idea.id])
   end
 end
 

--- a/back/spec/jobs/idea_feed/topic_modeling_scheduler_job_spec.rb
+++ b/back/spec/jobs/idea_feed/topic_modeling_scheduler_job_spec.rb
@@ -4,39 +4,50 @@ require 'rails_helper'
 
 describe IdeaFeed::TopicModelingSchedulerJob do
   describe '#perform' do
-    it 'calls the scheduler for current ideation phases with topic modeling enabled' do
-      phase = create(:phase, participation_method: 'ideation', start_at: 1.day.ago, end_at: 1.day.from_now)
-      phase.project.update!(live_auto_input_topics_enabled: true)
+    it 'calls the scheduler for projects with topic modeling enabled' do
+      project = create(:project)
+      project.update!(live_auto_input_topics_enabled: true)
 
       scheduler = instance_double(IdeaFeed::TopicModelingScheduler)
-      allow(IdeaFeed::TopicModelingScheduler).to receive(:new).with(phase).and_return(scheduler)
+      allow(IdeaFeed::TopicModelingScheduler).to receive(:new).with(project).and_return(scheduler)
       expect(scheduler).to receive(:on_every_hour)
 
       described_class.perform_now
     end
 
-    it 'skips phases where the participation method does not support input topics' do
-      phase = create(:phase, participation_method: 'common_ground', start_at: 1.day.ago, end_at: 1.day.from_now)
-      phase.project.update!(live_auto_input_topics_enabled: true)
+    it 'skips projects where topic modeling is not enabled' do
+      create(:project, live_auto_input_topics_enabled: false)
 
       expect(IdeaFeed::TopicModelingScheduler).not_to receive(:new)
 
       described_class.perform_now
     end
 
-    it 'skips phases where topic modeling is not enabled on the project' do
-      create(:phase, participation_method: 'ideation', start_at: 1.day.ago, end_at: 1.day.from_now)
+    it 'skips archived projects' do
+      project = create(:project, live_auto_input_topics_enabled: true)
+      project.admin_publication.update!(publication_status: 'archived')
 
       expect(IdeaFeed::TopicModelingScheduler).not_to receive(:new)
 
       described_class.perform_now
     end
 
-    it 'skips phases that are not current' do
-      phase = create(:phase, participation_method: 'ideation', start_at: 1.year.ago, end_at: 6.months.ago)
-      phase.project.update!(live_auto_input_topics_enabled: true)
+    it 'skips draft projects' do
+      project = create(:project, live_auto_input_topics_enabled: true)
+      project.admin_publication.update!(publication_status: 'draft')
 
       expect(IdeaFeed::TopicModelingScheduler).not_to receive(:new)
+
+      described_class.perform_now
+    end
+
+    it 'still runs after the only feed phase has ended' do
+      project = create(:project, live_auto_input_topics_enabled: true)
+      create(:idea_feed_phase, project:, start_at: 1.year.ago, end_at: 6.months.ago)
+
+      scheduler = instance_double(IdeaFeed::TopicModelingScheduler)
+      allow(IdeaFeed::TopicModelingScheduler).to receive(:new).with(project).and_return(scheduler)
+      expect(scheduler).to receive(:on_every_hour)
 
       described_class.perform_now
     end

--- a/back/spec/services/idea_feed/topic_classification_service_spec.rb
+++ b/back/spec/services/idea_feed/topic_classification_service_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe IdeaFeed::TopicClassificationService do
-  let(:service) { described_class.new(phase) }
+  let(:service) { described_class.new(project) }
 
   describe '#classify_topics!' do
     let_it_be(:project) { create(:project) }

--- a/back/spec/services/idea_feed/topic_modeling_scheduler_spec.rb
+++ b/back/spec/services/idea_feed/topic_modeling_scheduler_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe IdeaFeed::TopicModelingScheduler do
   let(:project) { create(:project) }
   let(:phase) { create(:idea_feed_phase, project:) }
-  let(:scheduler) { described_class.new(phase) }
+  let(:scheduler) { described_class.new(project) }
   let(:timezone) { AppConfiguration.timezone }
 
   before do
@@ -34,7 +34,7 @@ describe IdeaFeed::TopicModelingScheduler do
       it 'returns nil' do
         create_list(:idea, 5, project:, phases: [phase])
         travel_to time_at_hour(4) do
-          create(:activity, item: phase, action: 'topics_rebalanced', acted_at: 10.minutes.ago, payload: { 'input_count' => 3 })
+          create(:activity, item: project, action: 'topics_rebalanced', acted_at: 10.minutes.ago, payload: { 'input_count' => 3 })
           expect(scheduler.on_every_hour).to be_nil
         end
       end
@@ -62,7 +62,7 @@ describe IdeaFeed::TopicModelingScheduler do
       it 'returns nil' do
         create_list(:idea, 10, project:, phases: [phase])
         travel_to time_at_hour(4) do
-          create(:activity, item: phase, action: 'topics_rebalanced', acted_at: 1.day.ago, payload: { 'input_count' => 10 })
+          create(:activity, item: project, action: 'topics_rebalanced', acted_at: 1.day.ago, payload: { 'input_count' => 10 })
           expect(scheduler.on_every_hour).to be_nil
         end
       end
@@ -72,8 +72,8 @@ describe IdeaFeed::TopicModelingScheduler do
       it 'enqueues TopicModelingJob when input increase is >= 10%' do
         create_list(:idea, 6, project:, phases: [phase])
         travel_to time_at_hour(4) do
-          create(:activity, item: phase, action: 'topics_rebalanced', acted_at: 1.day.ago, payload: { 'input_count' => 5 })
-          expect { scheduler.on_every_hour }.to have_enqueued_job(IdeaFeed::TopicModelingJob).with(phase)
+          create(:activity, item: project, action: 'topics_rebalanced', acted_at: 1.day.ago, payload: { 'input_count' => 5 })
+          expect { scheduler.on_every_hour }.to have_enqueued_job(IdeaFeed::TopicModelingJob).with(project)
         end
       end
     end
@@ -85,7 +85,7 @@ describe IdeaFeed::TopicModelingScheduler do
 
       it 'enqueues TopicModelingJob' do
         travel_to time_at_hour(4) do
-          expect { scheduler.on_every_hour }.to have_enqueued_job(IdeaFeed::TopicModelingJob).with(phase)
+          expect { scheduler.on_every_hour }.to have_enqueued_job(IdeaFeed::TopicModelingJob).with(project)
         end
       end
     end
@@ -94,8 +94,8 @@ describe IdeaFeed::TopicModelingScheduler do
       it 'enqueues TopicModelingJob' do
         create_list(:idea, 3, project:, phases: [phase])
         travel_to time_at_hour(4) do
-          create(:activity, item: phase, action: 'topics_rebalanced', acted_at: 1.day.ago, payload: { 'input_count' => 0 })
-          expect { scheduler.on_every_hour }.to have_enqueued_job(IdeaFeed::TopicModelingJob).with(phase)
+          create(:activity, item: project, action: 'topics_rebalanced', acted_at: 1.day.ago, payload: { 'input_count' => 0 })
+          expect { scheduler.on_every_hour }.to have_enqueued_job(IdeaFeed::TopicModelingJob).with(project)
         end
       end
     end
@@ -115,7 +115,7 @@ describe IdeaFeed::TopicModelingScheduler do
     context 'when a recent run happened less than MINIMUM_INTERVAL_BETWEEN_RUNS ago' do
       before do
         create_list(:idea, 7, project:, phases: [phase])
-        create(:activity, item: phase, action: 'topics_rebalanced', acted_at: 10.minutes.ago, payload: { 'input_count' => 5 })
+        create(:activity, item: project, action: 'topics_rebalanced', acted_at: 10.minutes.ago, payload: { 'input_count' => 5 })
       end
 
       it 'returns nil' do
@@ -126,7 +126,7 @@ describe IdeaFeed::TopicModelingScheduler do
     context 'when input increase since last run is less than INSTANT_INPUT_INCREASE (30%)' do
       before do
         create_list(:idea, 6, project:, phases: [phase])
-        create(:activity, item: phase, action: 'topics_rebalanced', acted_at: 1.day.ago, payload: { 'input_count' => 5 })
+        create(:activity, item: project, action: 'topics_rebalanced', acted_at: 1.day.ago, payload: { 'input_count' => 5 })
       end
 
       it 'returns nil when increase is 20%' do
@@ -137,11 +137,11 @@ describe IdeaFeed::TopicModelingScheduler do
     context 'when all conditions are met' do
       before do
         create_list(:idea, 7, project:, phases: [phase])
-        create(:activity, item: phase, action: 'topics_rebalanced', acted_at: 1.day.ago, payload: { 'input_count' => 5 })
+        create(:activity, item: project, action: 'topics_rebalanced', acted_at: 1.day.ago, payload: { 'input_count' => 5 })
       end
 
       it 'enqueues TopicModelingJob when input increase is >= 30%' do
-        expect { scheduler.on_new_input }.to have_enqueued_job(IdeaFeed::TopicModelingJob).with(phase)
+        expect { scheduler.on_new_input }.to have_enqueued_job(IdeaFeed::TopicModelingJob).with(project)
       end
     end
 
@@ -151,18 +151,18 @@ describe IdeaFeed::TopicModelingScheduler do
       end
 
       it 'enqueues TopicModelingJob' do
-        expect { scheduler.on_new_input }.to have_enqueued_job(IdeaFeed::TopicModelingJob).with(phase)
+        expect { scheduler.on_new_input }.to have_enqueued_job(IdeaFeed::TopicModelingJob).with(project)
       end
     end
 
     context 'when previous run had 0 inputs' do
       before do
         create_list(:idea, 3, project:, phases: [phase])
-        create(:activity, item: phase, action: 'topics_rebalanced', acted_at: 1.day.ago, payload: { 'input_count' => 0 })
+        create(:activity, item: project, action: 'topics_rebalanced', acted_at: 1.day.ago, payload: { 'input_count' => 0 })
       end
 
       it 'enqueues TopicModelingJob' do
-        expect { scheduler.on_new_input }.to have_enqueued_job(IdeaFeed::TopicModelingJob).with(phase)
+        expect { scheduler.on_new_input }.to have_enqueued_job(IdeaFeed::TopicModelingJob).with(project)
       end
     end
   end
@@ -173,7 +173,7 @@ describe IdeaFeed::TopicModelingScheduler do
         create_list(:idea, 10, project:, phases: [phase])
         travel_to time_at_hour(4) do
           # 10 ideas now, 9 at last run = 11.1% increase (just over 10%)
-          create(:activity, item: phase, action: 'topics_rebalanced', acted_at: 1.day.ago, payload: { 'input_count' => 9 })
+          create(:activity, item: project, action: 'topics_rebalanced', acted_at: 1.day.ago, payload: { 'input_count' => 9 })
           expect { scheduler.on_every_hour }.to have_enqueued_job(IdeaFeed::TopicModelingJob)
         end
       end
@@ -181,7 +181,7 @@ describe IdeaFeed::TopicModelingScheduler do
       it 'does not enqueue job via on_new_input (needs 30%)' do
         create_list(:idea, 10, project:, phases: [phase])
         # 10 ideas now, 9 at last run = 11.1% increase (under 30%)
-        create(:activity, item: phase, action: 'topics_rebalanced', acted_at: 1.day.ago, payload: { 'input_count' => 9 })
+        create(:activity, item: project, action: 'topics_rebalanced', acted_at: 1.day.ago, payload: { 'input_count' => 9 })
         expect(scheduler.on_new_input).to be_nil
       end
     end
@@ -190,7 +190,7 @@ describe IdeaFeed::TopicModelingScheduler do
       before do
         create_list(:idea, 10, project:, phases: [phase])
         # 10 ideas now, 7 at last run = 42.8% increase (over 30%)
-        create(:activity, item: phase, action: 'topics_rebalanced', acted_at: 1.day.ago, payload: { 'input_count' => 7 })
+        create(:activity, item: project, action: 'topics_rebalanced', acted_at: 1.day.ago, payload: { 'input_count' => 7 })
       end
 
       it 'enqueues job via on_new_input' do
@@ -204,12 +204,12 @@ describe IdeaFeed::TopicModelingScheduler do
       end
 
       it 'allows job when exactly 20 minutes have passed' do
-        create(:activity, item: phase, action: 'topics_rebalanced', acted_at: 20.minutes.ago, payload: { 'input_count' => 3 })
+        create(:activity, item: project, action: 'topics_rebalanced', acted_at: 20.minutes.ago, payload: { 'input_count' => 3 })
         expect { scheduler.on_new_input }.to have_enqueued_job(IdeaFeed::TopicModelingJob)
       end
 
       it 'blocks job when just under 20 minutes have passed' do
-        create(:activity, item: phase, action: 'topics_rebalanced', acted_at: 19.minutes.ago, payload: { 'input_count' => 3 })
+        create(:activity, item: project, action: 'topics_rebalanced', acted_at: 19.minutes.ago, payload: { 'input_count' => 3 })
         expect(scheduler.on_new_input).to be_nil
       end
     end
@@ -217,8 +217,8 @@ describe IdeaFeed::TopicModelingScheduler do
     context 'when multiple previous run activities exist' do
       before do
         create_list(:idea, 8, project:, phases: [phase])
-        create(:activity, item: phase, action: 'topics_rebalanced', acted_at: 2.days.ago, payload: { 'input_count' => 3 })
-        create(:activity, item: phase, action: 'topics_rebalanced', acted_at: 1.day.ago, payload: { 'input_count' => 5 })
+        create(:activity, item: project, action: 'topics_rebalanced', acted_at: 2.days.ago, payload: { 'input_count' => 3 })
+        create(:activity, item: project, action: 'topics_rebalanced', acted_at: 1.day.ago, payload: { 'input_count' => 5 })
       end
 
       it 'uses the most recent activity for calculations' do

--- a/back/spec/services/idea_feed/topic_modeling_service_spec.rb
+++ b/back/spec/services/idea_feed/topic_modeling_service_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe IdeaFeed::TopicModelingService do
-  let(:service) { described_class.new(phase) }
+  let(:service) { described_class.new(project) }
 
   describe '#rebalance_topics!' do
     let!(:project) { create(:project) }
@@ -145,7 +145,7 @@ describe IdeaFeed::TopicModelingService do
           .and change { old_topics[0].reload.title_multiloc['en'] }.from('Parking areas').to('Parking')
           .and change { old_topics[0].reload.description_multiloc['fr-FR'] }.from(nil).to('Contributions relatives à la disponibilité du stationnement, à la réglementation et aux infrastructures pour les véhicules.')
           .and have_enqueued_job(LogActivityJob).at_least(:once).with(kind_of(InputTopic), 'created', nil, anything, project_id: kind_of(String))
-          .and have_enqueued_job(LogActivityJob).at_least(:once).with(phase, 'topics_rebalanced', nil, anything, project_id: kind_of(String), payload: hash_including(
+          .and have_enqueued_job(LogActivityJob).at_least(:once).with(project, 'topics_rebalanced', nil, anything, project_id: kind_of(String), payload: hash_including(
             update_log: [{ topic_id: old_topics[0].id, title_multiloc: { old: { 'en' => 'Parking areas' }, new: { 'en' => 'Parking', 'fr-FR' => 'Stationnement', 'nl-NL' => 'Parkeren' } }, description_multiloc: { old: { 'en' => 'Ideas about depositing your car' }, new: { 'en' => 'Contributions related to parking availability, regulations, and infrastructure for vehicles.', 'fr-FR' => 'Contributions relatives à la disponibilité du stationnement, à la réglementation et aux infrastructures pour les véhicules.', 'nl-NL' => 'Bijdragen met betrekking tot de beschikbaarheid van parkeerplaatsen, regelgeving en infrastructuur voor voertuigen.' } } }],
             input_count: 1,
             creation_log: [{ topic_id: kind_of(String), title_multiloc: { 'en' => 'Public Transportation' }, description_multiloc: { 'en' => 'Ideas about public transportation systems and services' }, icon: nil }],
@@ -169,7 +169,7 @@ describe IdeaFeed::TopicModelingService do
 
         expect { service.rebalance_topics! }.to change(InputTopic, :count).from(3).to(2)
           .and have_enqueued_job(LogActivityJob).twice.with(kind_of(InputTopic), 'created', nil, anything, project_id: kind_of(String))
-          .and have_enqueued_job(LogActivityJob).at_least(:once).with(phase, 'topics_rebalanced', nil, anything, project_id: kind_of(String), payload: hash_including(
+          .and have_enqueued_job(LogActivityJob).at_least(:once).with(project, 'topics_rebalanced', nil, anything, project_id: kind_of(String), payload: hash_including(
             update_log: [],
             input_count: 1,
             creation_log: [

--- a/back/spec/services/side_fx_idea_service_spec.rb
+++ b/back/spec/services/side_fx_idea_service_spec.rb
@@ -183,7 +183,7 @@ describe SideFxIdeaService do
       idea.project.update!(live_auto_input_topics_enabled: true)
       expect { service.after_create(idea, user, phase) }
         .to enqueue_job(IdeaFeed::BatchTopicClassificationJob)
-        .with(idea.phases.first, [idea.id])
+        .with(idea.project, [idea.id])
         .exactly(1).times
     end
 
@@ -485,7 +485,7 @@ describe SideFxIdeaService do
       idea.update!(title_multiloc: { en: 'changed' })
       expect { service.after_update(idea, user) }
         .to enqueue_job(IdeaFeed::BatchTopicClassificationJob)
-        .with(idea.phases.first, [idea.id])
+        .with(idea.project, [idea.id])
         .exactly(1).times
     end
 


### PR DESCRIPTION
## Summary

Topic modeling and classification scheduling used to depend on the current phase, so once a feed phase ended (and the next phase took over), scheduling either stopped or,  when the next phase had a different idea set, wiped most ideas' classifications via cascading topic deletes without re-classifying them.

Topics, the `live_auto_input_topics_enabled` toggle, the project-level `custom_form`, and idea ownership are all already project-scoped. This PR moves the modeling/classification pipeline from the project to the scope.

Most changes are a simple swap, the important tradeoff is that we now only classify transitive ideas (ideation-based).

# Changelog

## Changed 
- [TAN-7617] Auto-tagging is no longer influenced by any phase configuration. All ideas in the project will remain classified, even if the phase expires.