### PR TITLE
[TAN-7623] Mirror private slash commands into .claude/commands/

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,7 +9,7 @@ set -e
 STAGED="$(git diff --cached --name-only --diff-filter=ACMR)"
 
 # 1. Block private overlay paths from being staged.
-PRIVATE_PATHS="$(echo "$STAGED" | grep -E '^\.claude/(private(/|$)|skills/|README\.md$)' || true)"
+PRIVATE_PATHS="$(echo "$STAGED" | grep -E '^\.claude/(private(/|$)|skills/|commands/|README\.md$)' || true)"
 if [ -n "$PRIVATE_PATHS" ]; then
   echo "ERROR: refusing to commit private Claude overlay paths:" >&2
   echo "$PRIVATE_PATHS" | sed 's/^/  /' >&2

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ CLAUDE.local.md
 .claude/settings.local.json
 .claude/private
 .claude/skills
+.claude/commands
 .claude/README.md
 
 # MCP local files

--- a/bin/check-claude-privacy
+++ b/bin/check-claude-privacy
@@ -9,7 +9,7 @@ set -euo pipefail
 errors=0
 
 # 1. No tracked files under the private overlay paths.
-LEAKED="$(git ls-files .claude/private .claude/skills .claude/README.md 2>/dev/null || true)"
+LEAKED="$(git ls-files .claude/private .claude/skills .claude/commands .claude/README.md 2>/dev/null || true)"
 if [ -n "$LEAKED" ]; then
   echo "ERROR: tracked files under private overlay paths:" >&2
   echo "$LEAKED" | sed 's/^/  /' >&2

--- a/bin/setup-claude
+++ b/bin/setup-claude
@@ -60,7 +60,7 @@ else
   git -C "$PRIVATE_DIR" pull --ff-only
 fi
 
-mkdir -p .claude/private .claude/skills
+mkdir -p .claude/private .claude/skills .claude/commands
 
 # Clean stale file symlinks so files removed from the private repo disappear here too
 find .claude/private -type l -delete 2>/dev/null || true
@@ -76,6 +76,7 @@ while IFS= read -r -d '' src; do
 done < <(find "$PRIVATE_DIR" -type f \
   -not -path '*/.git/*' \
   -not -path "$PRIVATE_DIR/skills/*" \
+  -not -path "$PRIVATE_DIR/commands/*" \
   -not -name 'README.md' \
   -not -name '.gitignore' \
   -not -name 'settings.local.json' \
@@ -102,6 +103,21 @@ while IFS= read -r -d '' src; do
   mkdir -p "$(dirname "$dst")"
   ln -sfn "$(relpath "$src" "$REPO_ROOT/$(dirname "$dst")")" "$dst"
 done < <(find "$PRIVATE_DIR/skills" -mindepth 2 -type f -not -path '*/.git/*' -print0)
+
+# Slash commands: per-file symlinks at .claude/commands/<name>.md (and nested
+# subdirs for namespaced commands). Same constraint as skills — Claude Code
+# discovers commands at the exact path .claude/commands/, so they can't live
+# under .claude/private/. Skip the commands/ README, which exists only to
+# document the folder in the private repo.
+if [ -d "$PRIVATE_DIR/commands" ]; then
+  find .claude/commands -type l -delete 2>/dev/null || true
+  while IFS= read -r -d '' src; do
+    rel="${src#$PRIVATE_DIR/commands/}"
+    dst=".claude/commands/$rel"
+    mkdir -p "$(dirname "$dst")"
+    ln -sfn "$(relpath "$src" "$REPO_ROOT/$(dirname "$dst")")" "$dst"
+  done < <(find "$PRIVATE_DIR/commands" -type f -not -path '*/.git/*' -not -name 'README.md' -print0)
+fi
 
 # Private hook config / settings (only if present in the private repo)
 if [ -f "$PRIVATE_DIR/settings.local.json" ]; then


### PR DESCRIPTION
# Changelog

- (No user-facing change — internal Claude Code config wiring.)

---

Adds a per-file symlink loop in `bin/setup-claude` that materializes `citizenlab-claude/commands/<name>.md` at `.claude/commands/<name>.md`, mirroring the skills approach. Slash-command discovery is hardcoded to that exact path, so it can't live nested under `.claude/private/` like CLAUDE.md content or hook scripts.

Extends all three privacy layers to cover the new path:
- `.gitignore` adds `.claude/commands`
- `.githooks/pre-commit` blocks staging under `.claude/commands/`
- `bin/check-claude-privacy` (CI `claude-privacy-check`) fails if anything is tracked there

# Paired PR

`citizenlab-claude` side (source of truth + a smoke-test command): https://github.com/CitizenLabDotCo/citizenlab-claude/pull/3

Forward/backward compatible — either can merge first. The `commands/` source-of-truth lives in the private repo; this PR adds the wiring to mirror it locally.

# Test plan

- [x] `make claude-setup` runs without error and produces `.claude/commands/<name>.md` symlinks
- [x] `/test-private-command` discoverable in a fresh Claude Code session in this repo
- [x] `bin/check-claude-privacy` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)