### PR TITLE
[TAN-7623] Update setup-claude header to reflect new symlink targets

### DIFF
--- a/bin/setup-claude
+++ b/bin/setup-claude
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # bin/setup-claude — clone or update the citizenlab-claude private overlay
-# and create per-file symlinks under .claude/private/ in the public repo.
+# and create per-file symlinks under .claude/private/, .claude/skills/, and
+# .claude/commands/ in the public repo.
 #
 # Requires CITIZENLAB_CLAUDE_GIT_REMOTE (the git remote spec for the private
 # overlay repo — SSH `git@host:...`, HTTPS, or `ssh://...`). It can be set in


### PR DESCRIPTION
# Changelog

## Technical
- Update the header comment in `bin/setup-claude` so it reflects that the script now also creates per-file symlinks under `.claude/skills/` and `.claude/commands/`, not just `.claude/private/`.