### PR TITLE
[TAN-7623] Flatten .claude/private/ into .claude/

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,7 +9,8 @@ set -e
 STAGED="$(git diff --cached --name-only --diff-filter=ACMR)"
 
 # 1. Block private overlay paths from being staged.
-PRIVATE_PATHS="$(echo "$STAGED" | grep -E '^\.claude/(private(/|$)|skills/|commands/|README\.md$)' || true)"
+#    Everything under .claude/ is private (mirrored from citizenlab-claude) except settings.json.
+PRIVATE_PATHS="$(echo "$STAGED" | grep -E '^\.claude/' | grep -vE '^\.claude/settings\.json$' || true)"
 if [ -n "$PRIVATE_PATHS" ]; then
   echo "ERROR: refusing to commit private Claude overlay paths:" >&2
   echo "$PRIVATE_PATHS" | sed 's/^/  /' >&2

--- a/.gitignore
+++ b/.gitignore
@@ -21,11 +21,8 @@ node_modules
 
 # Claude Code local files
 CLAUDE.local.md
-.claude/settings.local.json
-.claude/private
-.claude/skills
-.claude/commands
-.claude/README.md
+.claude/*
+!.claude/settings.json
 
 # MCP local files
 .serena/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,3 @@
 <!-- Stub. Active Claude config lives in the private overlay (run make claude-setup). -->
 
-@./.claude/private/CLAUDE.md
+@./.claude/CLAUDE.md

--- a/back/CLAUDE.md
+++ b/back/CLAUDE.md
@@ -1,3 +1,3 @@
 <!-- Stub. Active Claude config lives in the private overlay (run make claude-setup). -->
 
-@../.claude/private/back/CLAUDE.md
+@../.claude/back/CLAUDE.md

--- a/bin/check-claude-privacy
+++ b/bin/check-claude-privacy
@@ -8,8 +8,8 @@ set -euo pipefail
 
 errors=0
 
-# 1. No tracked files under the private overlay paths.
-LEAKED="$(git ls-files .claude/private .claude/skills .claude/commands .claude/README.md 2>/dev/null || true)"
+# 1. No tracked files under .claude/ other than settings.json.
+LEAKED="$(git ls-files .claude/ -- ':!.claude/settings.json' 2>/dev/null || true)"
 if [ -n "$LEAKED" ]; then
   echo "ERROR: tracked files under private overlay paths:" >&2
   echo "$LEAKED" | sed 's/^/  /' >&2
@@ -20,8 +20,8 @@ fi
 #    so that accidental stripping of the import line is caught.
 while IFS= read -r f; do
   [ -z "$f" ] && continue
-  if ! grep -qE '^@\.{0,2}/?\.claude/private/' "$f"; then
-    echo "ERROR: $f is missing the expected '@.../.claude/private/...' import line." >&2
+  if ! grep -qE '^@\.{0,2}/?\.claude/' "$f"; then
+    echo "ERROR: $f is missing the expected '@.../.claude/...' import line." >&2
     errors=$((errors + 1))
   fi
 done < <(git ls-files '*/CLAUDE.md' 'CLAUDE.md')

--- a/bin/setup-claude
+++ b/bin/setup-claude
@@ -69,9 +69,13 @@ mkdir -p .claude
 # committed) or any non-symlink entry.
 find .claude -type l -delete 2>/dev/null || true
 
-# Remove obsolete artifacts from the previous nested-`private/` layout.
-[ -d .claude/private ] && rm -rf .claude/private
-[ -L .claude/skills/private ] && rm .claude/skills/private
+# One-shot migration cleanup for devs upgrading from earlier .claude/
+# layouts that this script no longer produces. Each line is idempotent
+# (the test guards make it a no-op on fresh clones), so it's safe to
+# leave indefinitely — and safe to delete once every active dev has
+# run setup-claude at least once after the relevant layout change.
+[ -d .claude/private ] && rm -rf .claude/private             # pre-flatten nested-private/ namespace
+[ -L .claude/skills/private ] && rm .claude/skills/private   # original single-dir-symlink design (predates per-file symlinks)
 
 # Mirror every tracked file from the private repo as a per-file symlink at
 # .claude/<same-relative-path>. Per-file (not directory) symlinks because

--- a/bin/setup-claude
+++ b/bin/setup-claude
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # bin/setup-claude — clone or update the citizenlab-claude private overlay
-# and create per-file symlinks under .claude/private/ in the public repo.
+# and create per-file symlinks under .claude/ in the public repo. Everything
+# under .claude/ is private (mirrored here) except .claude/settings.json,
+# which is committed publicly.
 #
 # Requires CITIZENLAB_CLAUDE_GIT_REMOTE (the git remote spec for the private
 # overlay repo — SSH `git@host:...`, HTTPS, or `ssh://...`). It can be set in
@@ -60,64 +62,34 @@ else
   git -C "$PRIVATE_DIR" pull --ff-only
 fi
 
-mkdir -p .claude/private .claude/skills .claude/commands
+mkdir -p .claude
 
-# Clean stale file symlinks so files removed from the private repo disappear here too
-find .claude/private -type l -delete 2>/dev/null || true
+# Clean stale file symlinks under .claude/ so files removed from the private
+# repo disappear here too. Doesn't touch .claude/settings.json (regular file,
+# committed) or any non-symlink entry.
+find .claude -type l -delete 2>/dev/null || true
 
-# Mirror everything from the private repo (CLAUDE.md files, hook scripts, etc.)
-# as per-file symlinks under a real .claude/private/ directory. Skills and the
-# settings.local.json are handled separately below.
+# Remove obsolete artifacts from the previous nested-`private/` layout.
+[ -d .claude/private ] && rm -rf .claude/private
+[ -L .claude/skills/private ] && rm .claude/skills/private
+
+# Mirror every tracked file from the private repo as a per-file symlink at
+# .claude/<same-relative-path>. Per-file (not directory) symlinks because
+# Claude Code's `@import` and skill/command discovery don't follow directory
+# symlinks. Skipped: the private repo's own README/.gitignore, the per-folder
+# README docs, and the two files that have special destinations below.
 while IFS= read -r -d '' src; do
   rel="${src#$PRIVATE_DIR/}"
-  dst=".claude/private/$rel"
+  dst=".claude/$rel"
   mkdir -p "$(dirname "$dst")"
   ln -sfn "$(relpath "$src" "$REPO_ROOT/$(dirname "$dst")")" "$dst"
 done < <(find "$PRIVATE_DIR" -type f \
   -not -path '*/.git/*' \
-  -not -path "$PRIVATE_DIR/skills/*" \
-  -not -path "$PRIVATE_DIR/commands/*" \
   -not -name 'README.md' \
   -not -name '.gitignore' \
   -not -name 'settings.local.json' \
   -not -name '.claude-readme.md' \
   -print0)
-
-# Skills: per-file symlinks under real per-skill directories.
-# Claude Code's skill discovery only walks top-level .claude/skills/<name>/ and
-# doesn't follow dir symlinks (verified empirically), so we mirror each skill
-# as a real directory with file symlinks for SKILL.md and any other contents.
-mkdir -p .claude/skills
-
-# Remove obsolete top-level dir symlink from the earlier design, if present
-[ -L .claude/skills/private ] && rm .claude/skills/private
-
-# Clean stale per-skill file symlinks (depth >= 2, type symlink) so files
-# removed from the private repo disappear here too
-find .claude/skills -mindepth 2 -type l -delete 2>/dev/null || true
-
-# Mirror each skill's contents as file symlinks under a real per-skill directory
-while IFS= read -r -d '' src; do
-  rel="${src#$PRIVATE_DIR/skills/}"
-  dst=".claude/skills/$rel"
-  mkdir -p "$(dirname "$dst")"
-  ln -sfn "$(relpath "$src" "$REPO_ROOT/$(dirname "$dst")")" "$dst"
-done < <(find "$PRIVATE_DIR/skills" -mindepth 2 -type f -not -path '*/.git/*' -print0)
-
-# Slash commands: per-file symlinks at .claude/commands/<name>.md (and nested
-# subdirs for namespaced commands). Same constraint as skills — Claude Code
-# discovers commands at the exact path .claude/commands/, so they can't live
-# under .claude/private/. Skip the commands/ README, which exists only to
-# document the folder in the private repo.
-if [ -d "$PRIVATE_DIR/commands" ]; then
-  find .claude/commands -type l -delete 2>/dev/null || true
-  while IFS= read -r -d '' src; do
-    rel="${src#$PRIVATE_DIR/commands/}"
-    dst=".claude/commands/$rel"
-    mkdir -p "$(dirname "$dst")"
-    ln -sfn "$(relpath "$src" "$REPO_ROOT/$(dirname "$dst")")" "$dst"
-  done < <(find "$PRIVATE_DIR/commands" -type f -not -path '*/.git/*' -not -name 'README.md' -print0)
-fi
 
 # Private hook config / settings (only if present in the private repo)
 if [ -f "$PRIVATE_DIR/settings.local.json" ]; then

--- a/front/CLAUDE.md
+++ b/front/CLAUDE.md
@@ -1,3 +1,3 @@
 <!-- Stub. Active Claude config lives in the private overlay (run make claude-setup). -->
 
-@../.claude/private/front/CLAUDE.md
+@../.claude/front/CLAUDE.md


### PR DESCRIPTION
# Changelog

## Technical
- Flatten the private Claude Code overlay's mirror layout

---

# Why

The `private/` namespace was justified when it was the only mirror location, on the grounds of "consolidate things mirrored from the private overlay under one namespace." That rationale fell apart once `skills/`, `commands/`, and `settings.local.json` were also mirrored from the overlay but living at top level (because Claude Code's discovery for those is hardcoded). The current split implies that things outside `private/` are less private — they're not. Confusing for new readers, and load-bearing on a distinction that no longer exists.

New mental model: **everything under `.claude/` is private**, with one allowlisted exception — `settings.json`. That's Claude Code's convention for committed/shared project settings. We don't currently have a `settings.json` (nothing satisfies the public side of the rule today), but the privacy guards leave the slot open in case non-sensitive shared config is ever needed. So the rule is forward-looking: it describes the *contract* for what may be committed, not a description of files currently on disk. One rule covers all the privacy guards. No namespace, no special-cased loops.

# What's in this PR

- `bin/setup-claude` — collapse three mirror loops into one. Every tracked file in `citizenlab-claude` lands at `.claude/<same-relative-path>`. Cleans up any pre-existing `.claude/private/` directory on first run for in-place migration.
- `.gitignore` — replace per-path entries with `.claude/*` + `!.claude/settings.json` (the allowlist for the reserved-but-unused public slot).
- `.githooks/pre-commit` — privacy regex simplified to "anything under `.claude/` other than `settings.json`."
- `bin/check-claude-privacy` — same simplification, plus updated `@import` regex (now matches `@.../.claude/...` instead of `@.../.claude/private/...`).
- `CLAUDE.md`, `back/CLAUDE.md`, `front/CLAUDE.md` — `@import` paths updated. Committed with `--no-verify` (the pre-commit hook's stub-edit block calls out `@import` path maintenance as the legitimate bypass case).

# Paired PR

Private side (settings.local.json hook paths + doc updates): https://github.com/CitizenLabDotCo/citizenlab-claude/pull/5

# Migration

Both PRs need to land in quick succession. Between the merges, devs running `make claude-setup` will end up with hooks at the new paths but settings.local.json (or the other way around) referencing the old, breaking hook resolution for ~minutes. Mitigation: coordinate the two merges and post a brief Slack heads-up before triggering them. The team is small enough that this is fine.

# Test plan

- [x] `make claude-setup` produces the new flat layout
- [x] `.claude/CLAUDE.md`, `.claude/back/CLAUDE.md`, etc. resolve via @import in fresh Claude Code sessions
- [x] Hook scripts at `.claude/hooks/<name>.sh` resolve and fire
- [x] `/changelog-pr` and other commands at `.claude/commands/` still discoverable
- [x] `.claude/skills/test-private-skill/` still discoverable
- [x] `bin/check-claude-privacy` passes locally; CI `claude-privacy-check` should pass too

🤖 Generated with [Claude Code](https://claude.com/claude-code)