### PR TITLE
[TAN-7623] Replace committed CLAUDE.md stubs with gitignored symlinks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -8,9 +8,10 @@ set -e
 
 STAGED="$(git diff --cached --name-only --diff-filter=ACMR)"
 
-# 1. Block private overlay paths from being staged.
-#    Everything under .claude/ is private (mirrored from citizenlab-claude) except settings.json.
-PRIVATE_PATHS="$(echo "$STAGED" | grep -E '^\.claude/' | grep -vE '^\.claude/settings\.json$' || true)"
+# 1. Block any path under .claude/ from being staged. Everything there is
+#    private (mirrored from citizenlab-claude) and materialized at runtime
+#    by bin/setup-claude.
+PRIVATE_PATHS="$(echo "$STAGED" | grep -E '^\.claude/' || true)"
 if [ -n "$PRIVATE_PATHS" ]; then
   echo "ERROR: refusing to commit private Claude overlay paths:" >&2
   echo "$PRIVATE_PATHS" | sed 's/^/  /' >&2
@@ -31,13 +32,7 @@ if [ -n "$CLAUDE_CHANGES" ]; then
   exit 1
 fi
 
-# 3. Soft warning on .claude/settings.json — legitimately editable, but flag for intent.
-if echo "$STAGED" | grep -qE '^\.claude/settings\.json$'; then
-  echo "NOTE: .claude/settings.json is being modified."
-  echo "If you're adding a hook, consider whether it belongs in settings.local.json (private) instead."
-fi
-
-# 4. Chain to existing .git/hooks/pre-commit (e.g. husky's prettier check) so we don't disable it.
+# 3. Chain to existing .git/hooks/pre-commit (e.g. husky's prettier check) so we don't disable it.
 if [ -x .git/hooks/pre-commit ]; then
   exec .git/hooks/pre-commit "$@"
 fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -18,12 +18,16 @@ if [ -n "$PRIVATE_PATHS" ]; then
   exit 1
 fi
 
-# 2. Block edits to public CLAUDE.md stubs. Once stubbed, all edits belong in the private overlay.
+# 2. Block any CLAUDE.md from being staged. They're all gitignored file
+#    symlinks materialized by bin/setup-claude — no CLAUDE.md should ever
+#    be committed. Edits to CLAUDE.md content belong in citizenlab-claude.
 CLAUDE_CHANGES="$(echo "$STAGED" | grep -E '(^|/)CLAUDE\.md$' || true)"
 if [ -n "$CLAUDE_CHANGES" ]; then
-  echo "ERROR: public CLAUDE.md stubs are frozen. Edit the private overlay instead:" >&2
+  echo "ERROR: refusing to commit a CLAUDE.md file:" >&2
   echo "$CLAUDE_CHANGES" | sed 's/^/  /' >&2
-  echo "Bypass with --no-verify only for genuine stub maintenance (e.g. fixing the @import path)." >&2
+  echo "All CLAUDE.md files are gitignored symlinks managed by bin/setup-claude;" >&2
+  echo "edit content in the citizenlab-claude private overlay instead." >&2
+  echo "Bypass with --no-verify only if you really mean it." >&2
   exit 1
 fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ node_modules
 CLAUDE.local.md
 .claude/*
 !.claude/settings.json
+# CLAUDE.md files are gitignored at any path: the citizenlab-claude private
+# overlay materializes them as file symlinks via bin/setup-claude.
+**/CLAUDE.md
 
 # MCP local files
 .serena/

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@ node_modules
 # Claude Code local files
 CLAUDE.local.md
 .claude/*
-!.claude/settings.json
 # CLAUDE.md files are gitignored at any path: the citizenlab-claude private
 # overlay materializes them as file symlinks via bin/setup-claude.
 **/CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,0 @@
-<!-- Stub. Active Claude config lives in the private overlay (run make claude-setup). -->
-
-@./.claude/CLAUDE.md

--- a/back/CLAUDE.md
+++ b/back/CLAUDE.md
@@ -1,3 +1,0 @@
-<!-- Stub. Active Claude config lives in the private overlay (run make claude-setup). -->
-
-@../.claude/back/CLAUDE.md

--- a/bin/check-claude-privacy
+++ b/bin/check-claude-privacy
@@ -16,15 +16,14 @@ if [ -n "$LEAKED" ]; then
   errors=$((errors + 1))
 fi
 
-# 2. Every public CLAUDE.md must reference a private overlay via @import,
-#    so that accidental stripping of the import line is caught.
-while IFS= read -r f; do
-  [ -z "$f" ] && continue
-  if ! grep -qE '^@\.{0,2}/?\.claude/' "$f"; then
-    echo "ERROR: $f is missing the expected '@.../.claude/...' import line." >&2
-    errors=$((errors + 1))
-  fi
-done < <(git ls-files '*/CLAUDE.md' 'CLAUDE.md')
+# 2. No CLAUDE.md should be tracked at any path. They're all gitignored
+#    file symlinks materialized by bin/setup-claude.
+TRACKED_CLAUDE_MD="$(git ls-files '*/CLAUDE.md' 'CLAUDE.md' 2>/dev/null || true)"
+if [ -n "$TRACKED_CLAUDE_MD" ]; then
+  echo "ERROR: tracked CLAUDE.md files (should be gitignored symlinks instead):" >&2
+  echo "$TRACKED_CLAUDE_MD" | sed 's/^/  /' >&2
+  errors=$((errors + 1))
+fi
 
 if [ "$errors" -gt 0 ]; then
   echo "" >&2

--- a/bin/check-claude-privacy
+++ b/bin/check-claude-privacy
@@ -8,8 +8,9 @@ set -euo pipefail
 
 errors=0
 
-# 1. No tracked files under .claude/ other than settings.json.
-LEAKED="$(git ls-files .claude/ -- ':!.claude/settings.json' 2>/dev/null || true)"
+# 1. No tracked files under .claude/. Everything there is private and
+#    materialized at runtime by bin/setup-claude.
+LEAKED="$(git ls-files .claude/ 2>/dev/null || true)"
 if [ -n "$LEAKED" ]; then
   echo "ERROR: tracked files under private overlay paths:" >&2
   echo "$LEAKED" | sed 's/^/  /' >&2

--- a/bin/setup-claude
+++ b/bin/setup-claude
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
 # bin/setup-claude — clone or update the citizenlab-claude private overlay
-# and create per-file symlinks under .claude/ in the public repo. Everything
-# under .claude/ is private (mirrored here) except .claude/settings.json,
-# which is committed publicly.
+# and create per-file symlinks in the public repo so Claude Code can find
+# its config:
+#   - .claude/<rel>: hooks, skills, commands, settings.local.json, and
+#     anything else the private overlay tracks. Everything under .claude/
+#     is private (mirrored here) except .claude/settings.json, which is
+#     committed publicly.
+#   - <area>/CLAUDE.md (root + per-area): file symlinks pointing directly
+#     at the private content. Gitignored at any path via .gitignore.
+#     Claude Code's CLAUDE.md discovery follows file symlinks, so no
+#     committed stub or @import indirection is needed.
 #
 # Requires CITIZENLAB_CLAUDE_GIT_REMOTE (the git remote spec for the private
 # overlay repo — SSH `git@host:...`, HTTPS, or `ssh://...`). It can be set in
@@ -81,7 +88,8 @@ find .claude -type l -delete 2>/dev/null || true
 # .claude/<same-relative-path>. Per-file (not directory) symlinks because
 # Claude Code's `@import` and skill/command discovery don't follow directory
 # symlinks. Skipped: the private repo's own README/.gitignore, the per-folder
-# README docs, and the two files that have special destinations below.
+# README docs, the files with special destinations handled below, and any
+# CLAUDE.md (those are materialized as top-level symlinks, see further down).
 while IFS= read -r -d '' src; do
   rel="${src#$PRIVATE_DIR/}"
   dst=".claude/$rel"
@@ -93,7 +101,12 @@ done < <(find "$PRIVATE_DIR" -type f \
   -not -name '.gitignore' \
   -not -name 'settings.local.json' \
   -not -name '.claude-readme.md' \
+  -not -name 'CLAUDE.md' \
   -print0)
+
+# Remove any empty directories under .claude/ left behind after the CLAUDE.md
+# exclusion (e.g. .claude/back/ / .claude/front/ from the previous design).
+find .claude -mindepth 1 -type d -empty -delete 2>/dev/null || true
 
 # Private hook config / settings (only if present in the private repo)
 if [ -f "$PRIVATE_DIR/settings.local.json" ]; then
@@ -104,6 +117,42 @@ fi
 if [ -f "$PRIVATE_DIR/.claude-readme.md" ]; then
   ln -sfn "$(relpath "$PRIVATE_DIR/.claude-readme.md" "$REPO_ROOT/.claude")" .claude/README.md
 fi
+
+# Top-level CLAUDE.md symlinks: Claude Code's CLAUDE.md discovery walks up
+# from the CWD looking for files at fixed paths. We put a file symlink at
+# each <area>/CLAUDE.md (and root) pointing directly at the private content,
+# so Claude Code reads the private content without any committed stub or
+# @import indirection.
+
+# Clean up stale top-level CLAUDE.md symlinks before recreating from the
+# current private state. We own all CLAUDE.md anywhere in the public repo
+# (gitignored everywhere via .gitignore), so it's safe to wipe and recreate.
+# Skip vendor / vcs dirs and .claude/ (handled by its own cleanup above).
+find . -type l -name 'CLAUDE.md' \
+  -not -path '*/.git/*' \
+  -not -path '*/.claude/*' \
+  -not -path '*/node_modules/*' \
+  -delete 2>/dev/null || true
+
+# Create a top-level CLAUDE.md symlink for every CLAUDE.md in the private
+# repo. Skip paths whose parent directory doesn't exist in the public repo —
+# this avoids materializing phantom area directories from a stale private
+# entry. ln -sfn overwrites any leftover regular file (e.g. a committed stub
+# from the previous layout that hasn't been removed by `git pull` yet).
+while IFS= read -r -d '' src; do
+  rel="${src#$PRIVATE_DIR/}"
+  parent="$(dirname "$rel")"
+  if [ "$parent" = "." ] || [ -d "$parent" ]; then
+    # Avoid passing "$REPO_ROOT/." to relpath (trailing /. throws off the
+    # prefix-strip loop and produces an extra ../).
+    if [ "$parent" = "." ]; then
+      anchor="$REPO_ROOT"
+    else
+      anchor="$REPO_ROOT/$parent"
+    fi
+    ln -sfn "$(relpath "$src" "$anchor")" "$rel"
+  fi
+done < <(find "$PRIVATE_DIR" -name 'CLAUDE.md' -not -path '*/.git/*' -print0)
 
 # Install the privacy guard hooks (versioned at .githooks/)
 if [ -d .githooks ]; then

--- a/bin/setup-claude
+++ b/bin/setup-claude
@@ -4,8 +4,7 @@
 # its config:
 #   - .claude/<rel>: hooks, skills, commands, settings.local.json, and
 #     anything else the private overlay tracks. Everything under .claude/
-#     is private (mirrored here) except .claude/settings.json, which is
-#     committed publicly.
+#     is private (mirrored here, gitignored).
 #   - <area>/CLAUDE.md (root + per-area): file symlinks pointing directly
 #     at the private content. Gitignored at any path via .gitignore.
 #     Claude Code's CLAUDE.md discovery follows file symlinks, so no

--- a/front/CLAUDE.md
+++ b/front/CLAUDE.md
@@ -1,3 +1,0 @@
-<!-- Stub. Active Claude config lives in the private overlay (run make claude-setup). -->
-
-@../.claude/front/CLAUDE.md


### PR DESCRIPTION
# Changelog

## Technical
- Replace committed `CLAUDE.md` stubs with gitignored file symlinks created by `bin/setup-claude`.