### PR TITLE
[TAN-7623] Add automated tests for Claude private overlay scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,7 @@ jobs:
           name: Verify no Claude private overlay content has leaked into the public repo
           command: bin/check-claude-privacy
 
-  claude-setup-test:
+  claude-tests:
     resource_class: small
     docker:
       - image: cimg/base:stable
@@ -168,8 +168,11 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Run bin/setup-claude tests (unit + integration via tmpdir fixtures)
-          command: bin/setup-claude.test.sh
+          name: Run Claude private overlay test scripts (setup-claude, privacy check, pre-commit hook)
+          command: |
+            bin/setup-claude.test.sh
+            bin/check-claude-privacy.test.sh
+            .githooks/pre-commit.test.sh
 
   changelogger:
     resource_class: small
@@ -903,7 +906,7 @@ workflows:
               ignore:
                 - crowdin_master
                 - /l10n_.*/
-      - claude-setup-test:
+      - claude-tests:
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,6 +160,17 @@ jobs:
           name: Verify no Claude private overlay content has leaked into the public repo
           command: bin/check-claude-privacy
 
+  claude-setup-test:
+    resource_class: small
+    docker:
+      - image: cimg/base:stable
+    working_directory: ~/citizenlab
+    steps:
+      - checkout
+      - run:
+          name: Run bin/setup-claude tests (unit + integration via tmpdir fixtures)
+          command: bin/setup-claude.test.sh
+
   changelogger:
     resource_class: small
     docker:
@@ -887,6 +898,12 @@ workflows:
                 - master
                 - production
       - claude-privacy-check:
+          filters:
+            branches:
+              ignore:
+                - crowdin_master
+                - /l10n_.*/
+      - claude-setup-test:
           filters:
             branches:
               ignore:

--- a/.githooks/pre-commit.test.sh
+++ b/.githooks/pre-commit.test.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# .githooks/pre-commit.test.sh — tests for .githooks/pre-commit.
+#
+# Run from anywhere inside the citizenlab repo:
+#   ./.githooks/pre-commit.test.sh
+#
+# Exits 0 if all tests pass, non-zero otherwise. Plain bash, no framework.
+#
+# `.githooks/pre-commit` is the active layer of the privacy guard system:
+# when a dev runs `git commit`, the hook fires before the commit is
+# created and refuses to proceed if any private overlay path or any
+# CLAUDE.md is staged. This catches `git add -f` bypasses (where someone
+# force-stages a path past .gitignore) at commit time, before the leak
+# reaches a remote. (The CI privacy check is the final backstop, but
+# catching it locally is faster and clearer for the dev.)
+#
+# These tests construct fake repo states that mimic the situations the
+# hook is designed to block (and not block), attempt commits, and assert
+# that each is allowed or rejected as expected.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK_TO_TEST="$SCRIPT_DIR/pre-commit"
+
+
+# ============================================================================
+# Test framework
+# ============================================================================
+
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+pass() { PASS=$((PASS + 1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL + 1)); FAILED_TESTS+=("$1"); echo "  ✗ $1" >&2; }
+
+assert_exit_code() {
+  local actual="$1" expected="$2" label="$3"
+  if [ "$actual" = "$expected" ]; then
+    pass "$label"
+  else
+    fail "$label"
+    echo "    expected exit code: $expected" >&2
+    echo "    actual exit code:   $actual" >&2
+  fi
+}
+
+
+# ============================================================================
+# Test fixtures
+# ============================================================================
+
+TEST_TMP=""
+trap '[ -n "${TEST_TMP:-}" ] && rm -rf "$TEST_TMP"' EXIT
+
+# Build a fresh git repo with the hook installed at .githooks/pre-commit
+# and `core.hooksPath` pointing there. Each test starts from this clean
+# state, then stages something and tries to commit.
+setup_test_repo() {
+  TEST_TMP="$(cd "$(mktemp -d)" && pwd -P)"
+  REPO="$TEST_TMP/repo"
+  mkdir -p "$REPO/.githooks"
+  cp "$HOOK_TO_TEST" "$REPO/.githooks/pre-commit"
+  chmod +x "$REPO/.githooks/pre-commit"
+  (
+    cd "$REPO"
+    git init -q
+    # Tell git to invoke hooks from .githooks/ (matching how
+    # bin/setup-claude wires hooks up in the real repo).
+    git config core.hooksPath .githooks
+    git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+  )
+}
+
+# Attempt a commit in $REPO and echo its exit code. `extra_flags` lets
+# tests pass `--no-verify` to verify the bypass case.
+attempt_commit() {
+  local extra_flags="${1:-}"
+  local exit_code=0
+  (
+    cd "$REPO"
+    # Stderr captured to stdout and discarded — the hook prints error
+    # messages there for the dev's benefit, but they're noise during
+    # the test. We only care about the exit code.
+    git -c user.email=t@t -c user.name=t commit $extra_flags -q -m "test commit" >/dev/null 2>&1
+  ) || exit_code=$?
+  echo "$exit_code"
+}
+
+
+# ============================================================================
+# Tests
+# ============================================================================
+
+echo "Tests: .githooks/pre-commit"
+
+
+# ----------------------------------------------------------------------------
+# Test: a normal file commits without obstruction. This is the common
+# case — every commit that doesn't touch privacy-sensitive paths should
+# pass through the hook silently.
+# ----------------------------------------------------------------------------
+setup_test_repo
+echo "ok" > "$REPO/normal.txt"
+( cd "$REPO" && git add normal.txt )
+assert_exit_code "$(attempt_commit)" "0" "allows commit of a normal file"
+
+
+# ----------------------------------------------------------------------------
+# Test: blocks commit when a CLAUDE.md is force-staged. This is the
+# leak shape the hook exists to catch — someone has bypassed .gitignore
+# with `git add -f`, and we need to refuse the commit before it lands.
+# ----------------------------------------------------------------------------
+setup_test_repo
+echo "leaked content" > "$REPO/CLAUDE.md"
+( cd "$REPO" && git add -f CLAUDE.md )
+assert_exit_code "$(attempt_commit)" "1" "blocks commit when a CLAUDE.md is staged"
+
+
+# ----------------------------------------------------------------------------
+# Test: blocks commit when a nested CLAUDE.md (e.g. back/CLAUDE.md) is
+# staged. Same rule: any CLAUDE.md anywhere is a privacy violation.
+# ----------------------------------------------------------------------------
+setup_test_repo
+mkdir -p "$REPO/sub"
+echo "leaked content" > "$REPO/sub/CLAUDE.md"
+( cd "$REPO" && git add -f sub/CLAUDE.md )
+assert_exit_code "$(attempt_commit)" "1" "blocks commit when a nested CLAUDE.md is staged"
+
+
+# ----------------------------------------------------------------------------
+# Test: blocks commit when a file under .claude/ is staged. Hooks,
+# skills, commands, and settings.local.json all live under .claude/
+# and should never be committed.
+# ----------------------------------------------------------------------------
+setup_test_repo
+mkdir -p "$REPO/.claude/hooks"
+echo "secret hook" > "$REPO/.claude/hooks/leak.sh"
+( cd "$REPO" && git add -f .claude/hooks/leak.sh )
+assert_exit_code "$(attempt_commit)" "1" "blocks commit when a file under .claude/ is staged"
+
+
+# ----------------------------------------------------------------------------
+# Test: `git commit --no-verify` bypasses the hook. We test this not
+# because we want to encourage it but because it's a documented escape
+# valve for genuine emergencies and we want to confirm it still works
+# (a hook that refused even --no-verify would be a bug — the dev would
+# have to delete the hook file to commit, which is worse). The CI
+# privacy check is the backstop that catches `--no-verify` bypasses.
+# ----------------------------------------------------------------------------
+setup_test_repo
+echo "leaked content" > "$REPO/CLAUDE.md"
+( cd "$REPO" && git add -f CLAUDE.md )
+assert_exit_code "$(attempt_commit --no-verify)" "0" "--no-verify bypasses the hook"
+
+
+# ============================================================================
+# Summary
+# ============================================================================
+
+echo ""
+echo "Total: $((PASS + FAIL)) tests, $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed tests:" >&2
+  printf '  - %s\n' "${FAILED_TESTS[@]}" >&2
+  exit 1
+fi
+exit 0

--- a/bin/check-claude-privacy.test.sh
+++ b/bin/check-claude-privacy.test.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# bin/check-claude-privacy.test.sh — tests for bin/check-claude-privacy.
+#
+# Run from anywhere inside the citizenlab repo:
+#   ./bin/check-claude-privacy.test.sh
+#
+# Exits 0 if all tests pass, non-zero otherwise. Plain bash, no framework.
+#
+# `bin/check-claude-privacy` is the CI safety net: it runs in a CircleCI
+# job on every PR, and refuses the PR if anything tracked under .claude/
+# (other than the never-actually-existed settings.json carve-out we
+# removed) or any tracked CLAUDE.md anywhere in the repo would leak
+# private overlay content into the public repo.
+#
+# A regression in this script's logic could let a leak through silently —
+# the "passes when it shouldn't" failure mode is the dangerous one,
+# because it never produces a failing build for someone to investigate.
+# These tests construct fake repo states (clean and various leak shapes),
+# run the script against each, and assert it correctly passes or fails.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_TO_TEST="$SCRIPT_DIR/check-claude-privacy"
+
+
+# ============================================================================
+# Test framework
+# ============================================================================
+
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+pass() { PASS=$((PASS + 1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL + 1)); FAILED_TESTS+=("$1"); echo "  ✗ $1" >&2; }
+
+assert_exit_code() {
+  local actual="$1" expected="$2" label="$3"
+  if [ "$actual" = "$expected" ]; then
+    pass "$label"
+  else
+    fail "$label"
+    echo "    expected exit code: $expected" >&2
+    echo "    actual exit code:   $actual" >&2
+  fi
+}
+
+# Run the script-under-test inside the given repo and echo its exit code.
+# We capture rather than letting the exit propagate because the test
+# framework's strict mode (`set -e`) would otherwise abort on any
+# non-zero exit — which is exactly what some test cases expect.
+run_check_in() {
+  local repo="$1"
+  local exit_code=0
+  ( cd "$repo" && bash "$SCRIPT_TO_TEST" >/dev/null 2>&1 ) || exit_code=$?
+  echo "$exit_code"
+}
+
+
+# ============================================================================
+# Test fixtures
+# ============================================================================
+
+TEST_TMP=""
+trap '[ -n "${TEST_TMP:-}" ] && rm -rf "$TEST_TMP"' EXIT
+
+# Build a fresh, empty git repo with one initial commit. Each test calls
+# this to start from a known-clean state, then mutates from there.
+setup_test_repo() {
+  TEST_TMP="$(cd "$(mktemp -d)" && pwd -P)"
+  REPO="$TEST_TMP/repo"
+  mkdir -p "$REPO"
+  (
+    cd "$REPO"
+    git init -q
+    # Empty initial commit so `git ls-files` works deterministically.
+    git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+  )
+}
+
+
+# ============================================================================
+# Tests
+# ============================================================================
+
+echo "Tests: bin/check-claude-privacy"
+
+
+# ----------------------------------------------------------------------------
+# Test: passes on a fully clean repo (nothing tracked that shouldn't be).
+# This is the common case — every PR that doesn't touch private paths
+# should pass through this check silently.
+# ----------------------------------------------------------------------------
+setup_test_repo
+assert_exit_code "$(run_check_in "$REPO")" "0" "passes on clean repo"
+
+
+# ----------------------------------------------------------------------------
+# Test: fails when a CLAUDE.md is tracked at the repo root.
+# This is the leak we'd see if someone force-added the file past the
+# pre-commit hook (`git commit --no-verify`) or committed before the
+# hook was installed. The CI check is what catches it.
+# ----------------------------------------------------------------------------
+setup_test_repo
+echo "leaked content" > "$REPO/CLAUDE.md"
+(
+  cd "$REPO"
+  # `git add -f` bypasses .gitignore. (Even though this fixture repo
+  # has no .gitignore, this matches how a real leak would happen in
+  # citizenlab where `**/CLAUDE.md` is gitignored.)
+  git add -f CLAUDE.md
+  git -c user.email=t@t -c user.name=t commit -q -m "leak"
+)
+assert_exit_code "$(run_check_in "$REPO")" "1" "fails when a tracked CLAUDE.md exists at root"
+
+
+# ----------------------------------------------------------------------------
+# Test: fails when a CLAUDE.md is tracked anywhere nested. The privacy
+# rule covers `**/CLAUDE.md` (any depth), so a `back/CLAUDE.md` or
+# `e2e/integration/CLAUDE.md` is just as much a leak as the root one.
+# ----------------------------------------------------------------------------
+setup_test_repo
+mkdir -p "$REPO/sub/deeper"
+echo "leaked content" > "$REPO/sub/deeper/CLAUDE.md"
+(
+  cd "$REPO"
+  git add -f sub/deeper/CLAUDE.md
+  git -c user.email=t@t -c user.name=t commit -q -m "nested leak"
+)
+assert_exit_code "$(run_check_in "$REPO")" "1" "fails when a nested tracked CLAUDE.md exists"
+
+
+# ----------------------------------------------------------------------------
+# Test: fails when something under `.claude/` is tracked. Same threat
+# model as the CLAUDE.md cases — `.claude/` content (hooks, skills,
+# commands, settings.local.json) should always be gitignored symlinks
+# materialized at runtime, never committed.
+# ----------------------------------------------------------------------------
+setup_test_repo
+mkdir -p "$REPO/.claude/hooks"
+echo "secret hook script" > "$REPO/.claude/hooks/leak.sh"
+(
+  cd "$REPO"
+  git add -f .claude/hooks/leak.sh
+  git -c user.email=t@t -c user.name=t commit -q -m "leaky claude file"
+)
+assert_exit_code "$(run_check_in "$REPO")" "1" "fails when a file under .claude/ is tracked"
+
+
+# ----------------------------------------------------------------------------
+# Test: passes when a CLAUDE.md exists on disk but is NOT tracked by git.
+# This is the normal post-`make claude-setup` state in citizenlab —
+# CLAUDE.md files exist as gitignored symlinks. The check has to look
+# at git's index, not the filesystem, otherwise it'd fail on every
+# correctly-configured dev machine.
+# ----------------------------------------------------------------------------
+setup_test_repo
+# Set up gitignore that mirrors citizenlab's, so git treats the file
+# as ignored just like in production.
+echo '**/CLAUDE.md' > "$REPO/.gitignore"
+(
+  cd "$REPO"
+  git add .gitignore
+  git -c user.email=t@t -c user.name=t commit -q -m "gitignore"
+)
+echo "this file exists but isn't tracked" > "$REPO/CLAUDE.md"
+assert_exit_code "$(run_check_in "$REPO")" "0" "passes when CLAUDE.md exists on disk but is gitignored / untracked"
+
+
+# ============================================================================
+# Summary
+# ============================================================================
+
+echo ""
+echo "Total: $((PASS + FAIL)) tests, $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed tests:" >&2
+  printf '  - %s\n' "${FAILED_TESTS[@]}" >&2
+  exit 1
+fi
+exit 0

--- a/bin/setup-claude
+++ b/bin/setup-claude
@@ -19,6 +19,37 @@
 
 set -euo pipefail
 
+# Compute a relative path from anchor dir (arg 2, absolute) to target (arg 1, absolute).
+# Used so committed symlinks (if ever force-staged) don't reveal a dev's home dir layout.
+relpath() {
+  local target="$1"
+  local anchor="$2"
+  local up=""
+  while [ "${target#$anchor/}" = "$target" ] && [ "$target" != "$anchor" ]; do
+    local new_anchor; new_anchor="$(dirname "$anchor")"
+    if [ "$new_anchor" = "$anchor" ]; then
+      # Reached filesystem root with no common ancestor — paths share no
+      # prefix string-wise (e.g. /var/X vs /private/var/X on macOS where
+      # one was canonicalized but the other wasn't). Fall back to the
+      # absolute target rather than infinite-loop.
+      echo "$target"
+      return
+    fi
+    anchor="$new_anchor"
+    up="../$up"
+  done
+  if [ "$target" = "$anchor" ]; then
+    echo "${up%/}"
+  else
+    echo "${up}${target#$anchor/}"
+  fi
+}
+
+# Library mode: when sourced for testing (BIN_SETUP_CLAUDE_LIBRARY=1), stop
+# here. Tests get access to the helpers above without running the main
+# script. See bin/setup-claude.test.sh.
+[ "${BIN_SETUP_CLAUDE_LIBRARY:-}" = "1" ] && return 0
+
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 
@@ -42,23 +73,6 @@ fi
 
 PARENT="$(dirname "$REPO_ROOT")"
 PRIVATE_DIR="${CITIZENLAB_CLAUDE_DIR:-$PARENT/citizenlab-claude}"
-
-# Compute a relative path from anchor dir (arg 2, absolute) to target (arg 1, absolute).
-# Used so committed symlinks (if ever force-staged) don't reveal a dev's home dir layout.
-relpath() {
-  local target="$1"
-  local anchor="$2"
-  local up=""
-  while [ "${target#$anchor/}" = "$target" ] && [ "$target" != "$anchor" ]; do
-    anchor="$(dirname "$anchor")"
-    up="../$up"
-  done
-  if [ "$target" = "$anchor" ]; then
-    echo "${up%/}"
-  else
-    echo "${up}${target#$anchor/}"
-  fi
-}
 
 if [ ! -d "$PRIVATE_DIR" ]; then
   echo "Cloning private overlay into $PRIVATE_DIR ..."

--- a/bin/setup-claude.test.sh
+++ b/bin/setup-claude.test.sh
@@ -4,27 +4,64 @@
 # Run from anywhere inside the citizenlab repo:
 #   ./bin/setup-claude.test.sh
 #
-# Plain bash, no framework. Exits non-zero if any test fails.
-# Constructs a fake "private overlay" + "public repo" pair in a tmpdir
-# and exercises bin/setup-claude end-to-end without touching real state.
+# Exits 0 if all tests pass, non-zero otherwise. Plain bash, no framework.
+#
+# Two flavours of test:
+#
+#   1. UNIT TESTS for the `relpath` helper inside bin/setup-claude. We can
+#      call it directly because we source the script in "library mode" (see
+#      below) — that lets us use the function without running the rest of
+#      the script.
+#
+#   2. INTEGRATION TESTS that build a fake "private overlay" + "public repo"
+#      pair inside a temp directory, run bin/setup-claude against them with
+#      env vars overriding the real paths, then assert that the resulting
+#      filesystem state (symlinks, cleanups, etc.) is correct.
 
+# `set -euo pipefail` is bash's strict mode:
+#   -e: exit immediately on any failed command (so a broken setup step
+#       aborts the test run instead of producing misleading downstream
+#       failures);
+#   -u: error on unset variables (catches typos like `$TEST_TMP` vs
+#       `$TEST_TEMP`);
+#   -o pipefail: a pipeline's exit status is the rightmost non-zero one,
+#       so a failing command in the middle of a pipe doesn't get masked.
 set -euo pipefail
 
+# Resolve the absolute directory this test script lives in, so paths work
+# regardless of where the dev runs the script from. `BASH_SOURCE[0]` is
+# the path of the current script; `cd ... && pwd` canonicalises it.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_TO_TEST="$SCRIPT_DIR/setup-claude"
 
-# Source in library mode to access helpers (relpath)
+# Source bin/setup-claude in "library mode": the BIN_SETUP_CLAUDE_LIBRARY=1
+# env var tells the script to define its helpers (like `relpath`) and then
+# `return` early before running the main mirror logic. After this line,
+# the `relpath` function is available in this shell to call directly in
+# unit tests.
 BIN_SETUP_CLAUDE_LIBRARY=1 source "$SCRIPT_TO_TEST"
 
-# --- Test framework ---
+
+# ============================================================================
+# Test framework
+# ============================================================================
+# A handful of helpers in lieu of a real framework. The test script tracks
+# a passing and failing count, prints a checkmark or cross per assertion,
+# and at the end exits non-zero if anything failed.
 
 PASS=0
 FAIL=0
-FAILED_TESTS=()
+FAILED_TESTS=()  # bash array; we append failed-test labels to it for the summary
 
+# Print a green-ish checkmark and bump the pass count.
 pass() { PASS=$((PASS + 1)); echo "  ✓ $1"; }
+
+# Print a red-ish cross, bump the fail count, and remember the label so we
+# can repeat the list at the end. `FAILED_TESTS+=("$1")` appends to the array.
 fail() { FAIL=$((FAIL + 1)); FAILED_TESTS+=("$1"); echo "  ✗ $1" >&2; }
 
+# Assert two strings match. If they don't, print expected vs actual to stderr
+# so the test output makes the discrepancy obvious without re-running.
 assert_eq() {
   local actual="$1" expected="$2" label="$3"
   if [ "$actual" = "$expected" ]; then
@@ -36,16 +73,24 @@ assert_eq() {
   fi
 }
 
+# Assert that `link` is a symlink whose target string matches `expected`.
+# Note this checks the symlink TARGET STRING (e.g. "../private/CLAUDE.md"),
+# not whether the target file exists or what it contains.
 assert_symlink_to() {
   local link="$1" expected="$2" label="$3"
   if [ ! -L "$link" ]; then
     fail "$label (not a symlink: $link)"
     return
   fi
+  # `readlink` prints the symlink's target string without resolving it.
   local actual; actual="$(readlink "$link")"
   assert_eq "$actual" "$expected" "$label"
 }
 
+# Assert that nothing exists at `path` — neither a regular file/dir (`-e`)
+# nor a symlink (`-L`, even a broken one). Used to verify that cleanup
+# steps removed what they were supposed to remove, or that we didn't
+# create something we shouldn't have.
 assert_path_missing() {
   if [ ! -e "$1" ] && [ ! -L "$1" ]; then
     pass "$2"
@@ -54,7 +99,15 @@ assert_path_missing() {
   fi
 }
 
-# --- Unit tests: relpath ---
+
+# ============================================================================
+# Unit tests: `relpath`
+# ============================================================================
+# `relpath TARGET ANCHOR` returns a relative path from ANCHOR to TARGET.
+# Both inputs are absolute paths; the output is what you'd put in `ln -s`
+# at ANCHOR to make a symlink resolve to TARGET. Used throughout
+# bin/setup-claude to keep symlink targets relative (so a force-staged
+# symlink wouldn't reveal a dev's home dir layout).
 
 echo "Unit tests: relpath"
 assert_eq "$(relpath /a/b/c     /a/b)"        "c"             "target one level deeper"
@@ -64,35 +117,85 @@ assert_eq "$(relpath /a/b       /a/b/c/d)"    "../.."         "anchor two levels
 assert_eq "$(relpath /a/b/c     /a/b/c)"      ""              "target equals anchor"
 assert_eq "$(relpath /a/sib/x   /a/cl)"       "../sib/x"      "sibling tree (real-world case)"
 assert_eq "$(relpath /a/sib/x/y /a/cl/z)"     "../../sib/x/y" "sibling tree at different depths"
+
+# Edge case: target and anchor have NO common prefix at the string level
+# (which can happen on macOS when one path has been canonicalised through
+# the /var → /private/var symlink and the other hasn't). Without the
+# safeguard added in bin/setup-claude, the function would infinite-loop.
+# The safeguard makes it fall back to returning the absolute target.
 assert_eq "$(relpath /var/x     /private/var/x)" "/var/x"      "no common ancestor: falls back to absolute (no infinite loop)"
 
-# --- Integration test fixtures ---
+
+# ============================================================================
+# Integration test fixtures
+# ============================================================================
+# The integration tests construct a self-contained "fake universe" inside a
+# temp directory, then run bin/setup-claude against it with env vars
+# pointing at the fake paths. This way we exercise the real script
+# end-to-end without touching the actual citizenlab / citizenlab-claude
+# clones or any other state on the dev's machine.
+#
+# Layout per test run:
+#
+#   $TEST_TMP/
+#     ├── remote.git/      a bare git repo standing in for the
+#     │                    citizenlab-claude GitHub remote
+#     ├── fixture-wt/      a working tree we use to seed `remote.git`
+#     │                    with an initial commit of fixture content
+#     ├── public/          stand-in for the citizenlab repo (where
+#     │                    bin/setup-claude creates symlinks)
+#     └── private/         stand-in for the local citizenlab-claude clone;
+#                          created by bin/setup-claude on its first run
+#                          when it clones from `remote.git`
 
 TEST_TMP=""
+
+# `trap ... EXIT` runs the given command when the script exits, for any
+# reason — normal completion, error, or signal. We use it to clean up the
+# tmpdir even if a test fails partway through.
 trap '[ -n "${TEST_TMP:-}" ] && rm -rf "$TEST_TMP"' EXIT
 
+# Build the fake universe described above. After this returns, REMOTE has
+# fixture content, PUBLIC is a fresh git repo with the area dirs that
+# host CLAUDE.md content, and PRIVATE doesn't exist yet (setup-claude
+# clones it on first run).
 setup_fake_env() {
-  # Canonicalize the tmpdir path so it matches what `git rev-parse
-  # --show-toplevel` returns. On macOS, mktemp -d returns /var/folders/...
-  # while git canonicalizes through the /var → /private/var symlink. If we
-  # don't normalize here, relpath hits no-common-ancestor and falls back
-  # to absolute paths — tests then assert against unstable absolute paths.
+  # Canonicalise the tmpdir path so it matches what `git rev-parse
+  # --show-toplevel` returns inside the public repo. On macOS, `mktemp -d`
+  # returns /var/folders/... while git canonicalises through the
+  # /var → /private/var symlink. If we don't normalise here, `relpath`
+  # inside setup-claude hits the no-common-ancestor edge case and falls
+  # back to absolute paths, so the test assertions (which expect
+  # relative paths like "../private/CLAUDE.md") would all fail.
   TEST_TMP="$(cd "$(mktemp -d)" && pwd -P)"
   REMOTE="$TEST_TMP/remote.git"
   PUBLIC="$TEST_TMP/public"
   PRIVATE="$TEST_TMP/private"
   FIXTURE_WT="$TEST_TMP/fixture-wt"
 
+  # `git init --bare` creates a repo with no working tree (just the
+  # `.git` internals). It's the standard format for a "remote" that
+  # other clones push to / pull from.
   git init --bare -q "$REMOTE"
 
-  # Populate the remote via a separate working tree
+  # We can't add commits directly to a bare repo, so clone it into a
+  # working tree, populate the fixture content there, commit, and push.
+  # After this block, REMOTE has a single commit with the fixture content,
+  # and FIXTURE_WT is a normal working tree we can use later in the
+  # tests if we want to push more commits.
   git clone -q "$REMOTE" "$FIXTURE_WT"
+  # Parens `( ... )` create a SUBSHELL: any `cd` inside doesn't affect
+  # the parent shell's working directory. We use this pattern throughout
+  # so we can safely `cd` into a temp dir without having to cd back.
   (
     cd "$FIXTURE_WT"
     mkdir -p back front hooks skills/test-skill commands
     echo '# root context'  > CLAUDE.md
     echo '# back context'  > back/CLAUDE.md
     echo '# front context' > front/CLAUDE.md
+    # `<<'HOOK' ... HOOK` is a heredoc — multi-line literal string. The
+    # quotes around 'HOOK' mean no shell interpolation happens inside,
+    # which we want so the script content lands verbatim.
     cat > hooks/test-hook.sh <<'HOOK'
 #!/usr/bin/env bash
 exit 0
@@ -108,21 +211,43 @@ SKILL
     echo '{}' > settings.local.json
     echo '# private overlay README' > .claude-readme.md
     echo 'private repo own README' > README.md
+    # `-c user.email=...` sets the value just for this one git command,
+    # avoiding any reliance on whatever `git config` is set to on the
+    # dev's machine or the CI runner.
     git -c user.email=t@t -c user.name=t add -A
     git -c user.email=t@t -c user.name=t commit -q -m fixtures
+    # Push to whatever default branch the local clone landed on (could be
+    # `main` or `master` depending on the user's git defaults).
     git push -q origin "$(git rev-parse --abbrev-ref HEAD)"
   )
 
-  # Public repo: needs to exist as a git repo with the area dirs that have CLAUDE.md content
+  # Public repo: needs to be a git repo (setup-claude calls
+  # `git rev-parse --show-toplevel`) and needs the `back/` and `front/`
+  # area directories to exist (otherwise setup-claude skips the
+  # corresponding top-level CLAUDE.md symlinks). `.githooks/` is
+  # required for the `git config core.hooksPath .githooks` step.
   mkdir -p "$PUBLIC/back" "$PUBLIC/front" "$PUBLIC/.githooks"
   (
     cd "$PUBLIC"
     git init -q
+    # An initial commit gives `git rev-parse --show-toplevel` a stable
+    # answer (works fine without it on most git versions, but explicit
+    # is safer).
     git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
   )
-  # PRIVATE is created by setup-claude on first run (via clone from REMOTE)
+  # NB: PRIVATE itself is NOT created here. Setup-claude clones it from
+  # REMOTE on its first run. That way we exercise the
+  # "PRIVATE_DIR doesn't exist → clone" path; the second invocation in
+  # the same test then exercises the "PRIVATE_DIR exists → pull" path.
 }
 
+# Run bin/setup-claude against the fake universe. Env var overrides:
+#   CITIZENLAB_CLAUDE_GIT_REMOTE — where to clone the private overlay
+#                                 from (our fake bare REMOTE);
+#   CITIZENLAB_CLAUDE_DIR        — where to put the local clone of it
+#                                 (our fake PRIVATE path).
+# Output is silenced with `>/dev/null 2>&1` because we only care about
+# the resulting filesystem state in assertions, not the script's chatter.
 run_setup() {
   (
     cd "$PUBLIC"
@@ -132,57 +257,124 @@ run_setup() {
   )
 }
 
-# --- Integration tests ---
+
+# ============================================================================
+# Integration tests
+# ============================================================================
 
 echo ""
 echo "Integration tests"
 
-# Test: fresh setup creates the expected symlinks (top-level CLAUDE.md + .claude/<rel>)
+
+# ----------------------------------------------------------------------------
+# Test: a fresh setup creates the symlinks we expect, in both their
+# locations (top-level for CLAUDE.md, .claude/<rel> for everything else),
+# with the correct relative paths back to the private overlay clone.
+# ----------------------------------------------------------------------------
 setup_fake_env
 run_setup
+
+# Top-level CLAUDE.md symlinks: <area>/CLAUDE.md → ../citizenlab-claude/...
+# Claude Code's discovery walks up from CWD looking for these at fixed paths.
 assert_symlink_to "$PUBLIC/CLAUDE.md"                          "../private/CLAUDE.md"                            "root CLAUDE.md → private"
 assert_symlink_to "$PUBLIC/back/CLAUDE.md"                     "../../private/back/CLAUDE.md"                    "back/CLAUDE.md → private"
 assert_symlink_to "$PUBLIC/front/CLAUDE.md"                    "../../private/front/CLAUDE.md"                   "front/CLAUDE.md → private"
+
+# Everything else lands under .claude/<same-relative-path>. Symlink target
+# `../`-counts depend on nesting depth (each level deeper adds one `../`).
 assert_symlink_to "$PUBLIC/.claude/hooks/test-hook.sh"         "../../../private/hooks/test-hook.sh"             "hook script → private"
 assert_symlink_to "$PUBLIC/.claude/skills/test-skill/SKILL.md" "../../../../private/skills/test-skill/SKILL.md"  "skill SKILL.md → private"
 assert_symlink_to "$PUBLIC/.claude/commands/test.md"           "../../../private/commands/test.md"               "command → private"
 assert_symlink_to "$PUBLIC/.claude/settings.local.json"        "../../private/settings.local.json"               "settings.local.json → private"
+
+# Special case: the file named `.claude-readme.md` in the private overlay
+# is renamed to `README.md` when it lands under .claude/. This makes the
+# README appear at the conventional location in the public repo's view.
 assert_symlink_to "$PUBLIC/.claude/README.md"                  "../../private/.claude-readme.md"                 ".claude/README.md → private .claude-readme.md"
 
-# .claude/ should not redundantly mirror CLAUDE.md content; empty area dirs cleaned up
+
+# ----------------------------------------------------------------------------
+# Test: setup-claude does NOT also mirror CLAUDE.md content under .claude/.
+# CLAUDE.md content lives at the top-level paths only; mirroring it under
+# .claude/ too would be redundant. Empty `.claude/<area>/` directories
+# left over from the previous design (which DID mirror CLAUDE.md there)
+# should be cleaned up.
+# ----------------------------------------------------------------------------
 assert_path_missing "$PUBLIC/.claude/CLAUDE.md"  ".claude/CLAUDE.md not created (lives at top-level instead)"
 assert_path_missing "$PUBLIC/.claude/back"       ".claude/back/ empty dir cleaned up"
 assert_path_missing "$PUBLIC/.claude/front"      ".claude/front/ empty dir cleaned up"
 
-# Test: idempotent — second run produces the same state
+
+# ----------------------------------------------------------------------------
+# Test: re-running setup-claude is safe and idempotent. Important because
+# `make claude-setup` and `make reset-dev-env` may be run multiple times
+# per dev session, and we don't want the second run to break the first
+# run's state.
+# ----------------------------------------------------------------------------
 run_setup
 assert_symlink_to "$PUBLIC/CLAUDE.md" "../private/CLAUDE.md" "second run: root symlink unchanged"
 
-# Test: top-level CLAUDE.md is skipped when the area dir doesn't exist in citizenlab
-rm -rf "$PUBLIC/front"
+
+# ----------------------------------------------------------------------------
+# Test: top-level CLAUDE.md is skipped when the corresponding area
+# directory doesn't exist in the public repo. This avoids creating
+# "phantom" directories: if `citizenlab-claude/foo/CLAUDE.md` exists
+# but `citizenlab/foo/` doesn't, we should NOT auto-create `citizenlab/foo/`.
+# ----------------------------------------------------------------------------
+rm -rf "$PUBLIC/front"   # remove the area dir
 run_setup
 assert_path_missing "$PUBLIC/front" "front/ not auto-created when area dir missing (no phantom dir)"
 
-# Test: pre-existing regular file at a CLAUDE.md path is replaced by a symlink (migration case)
-rm -f "$PUBLIC/CLAUDE.md"
-echo "old stub" > "$PUBLIC/CLAUDE.md"
+
+# ----------------------------------------------------------------------------
+# Test: a pre-existing regular file at a CLAUDE.md path gets overwritten
+# with a symlink. Real-world scenario: a dev pulled master after the
+# stub-deletion PR merged but hasn't run `make claude-setup` yet, so the
+# old committed `CLAUDE.md` file might still be on their disk if they
+# had local changes when pulling. Setup-claude should replace it with
+# the symlink without making them clean up by hand.
+# ----------------------------------------------------------------------------
+rm -f "$PUBLIC/CLAUDE.md"               # remove the symlink from the previous test runs
+echo "old stub" > "$PUBLIC/CLAUDE.md"   # plant a regular file in its place
 run_setup
 assert_symlink_to "$PUBLIC/CLAUDE.md" "../private/CLAUDE.md" "regular CLAUDE.md replaced by symlink"
 
-# Test: migration cleanup — pre-existing .claude/private/ directory is removed
+
+# ----------------------------------------------------------------------------
+# Test: migration cleanup of `.claude/private/`, the directory used by an
+# earlier layout to hold private overlay content. After the flatten
+# refactor, this directory should never exist; setup-claude removes it
+# on every run as a one-shot migration cleanup. (Idempotent — no-op when
+# the directory isn't present.)
+# ----------------------------------------------------------------------------
 mkdir -p "$PUBLIC/.claude/private/back"
 echo "x" > "$PUBLIC/.claude/private/CLAUDE.md"
 echo "x" > "$PUBLIC/.claude/private/back/CLAUDE.md"
 run_setup
 assert_path_missing "$PUBLIC/.claude/private" "obsolete .claude/private/ directory removed"
 
-# Test: migration cleanup — obsolete .claude/skills/private dir-symlink is removed
+
+# ----------------------------------------------------------------------------
+# Test: migration cleanup of an even older artifact — a directory symlink
+# at `.claude/skills/private` that was the original (pre-per-file-symlink)
+# design. Setup-claude removes it on every run.
+# ----------------------------------------------------------------------------
 ln -sfn "../../$PRIVATE/skills" "$PUBLIC/.claude/skills/private"
 run_setup
 assert_path_missing "$PUBLIC/.claude/skills/private" "obsolete .claude/skills/private symlink removed"
 
-# Test: stale CLAUDE.md symlink cleaned up after private content drops
-mkdir -p "$PUBLIC/front"  # restore the area dir
+
+# ----------------------------------------------------------------------------
+# Test: stale `<area>/CLAUDE.md` symlinks are cleaned up when their
+# private content is removed. Scenario: a dev removes
+# `citizenlab-claude/front/CLAUDE.md`, pushes, and the next
+# `make claude-setup` should make `citizenlab/front/CLAUDE.md` disappear
+# too — not leave a dangling symlink to a now-nonexistent file.
+# ----------------------------------------------------------------------------
+mkdir -p "$PUBLIC/front"   # restore the area dir we removed in an earlier test
+# Modify the fixture: drop front/CLAUDE.md from the private overlay and
+# push the change to REMOTE, so the next `git pull` inside setup-claude
+# picks it up.
 (
   cd "$FIXTURE_WT"
   git pull -q --ff-only
@@ -194,12 +386,18 @@ mkdir -p "$PUBLIC/front"  # restore the area dir
 run_setup
 assert_path_missing "$PUBLIC/front/CLAUDE.md" "stale front/CLAUDE.md symlink cleaned up after private content removal"
 
-# --- Summary ---
+
+# ============================================================================
+# Summary
+# ============================================================================
 
 echo ""
 echo "Total: $((PASS + FAIL)) tests, $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then
   echo "Failed tests:" >&2
+  # `printf '  - %s\n' "${FAILED_TESTS[@]}"` prints one line per array
+  # element. Useful when there's more than one failure — repeats the list
+  # at the end so it's easy to scan.
   printf '  - %s\n' "${FAILED_TESTS[@]}" >&2
   exit 1
 fi

--- a/bin/setup-claude.test.sh
+++ b/bin/setup-claude.test.sh
@@ -183,7 +183,13 @@ setup_fake_env() {
   # After this block, REMOTE has a single commit with the fixture content,
   # and FIXTURE_WT is a normal working tree we can use later in the
   # tests if we want to push more commits.
-  git clone -q "$REMOTE" "$FIXTURE_WT"
+  #
+  # `2>/dev/null` silences git's "warning: You appear to have cloned an
+  # empty repository" — REMOTE is genuinely empty at this moment, by
+  # design (we're about to populate it). The warning is harmless noise.
+  # If the clone really fails, `cd "$FIXTURE_WT"` below will error and
+  # the strict-mode `set -e` aborts the test run.
+  git clone -q "$REMOTE" "$FIXTURE_WT" 2>/dev/null
   # Parens `( ... )` create a SUBSHELL: any `cd` inside doesn't affect
   # the parent shell's working directory. We use this pattern throughout
   # so we can safely `cd` into a temp dir without having to cd back.

--- a/bin/setup-claude.test.sh
+++ b/bin/setup-claude.test.sh
@@ -108,6 +108,19 @@ assert_path_missing() {
 # at ANCHOR to make a symlink resolve to TARGET. Used throughout
 # bin/setup-claude to keep symlink targets relative (so a force-staged
 # symlink wouldn't reveal a dev's home dir layout).
+#
+# The cases below exercise every shape of input the helper needs to handle:
+#
+#   - target nested below anchor → no `..`s in the output
+#   - anchor nested below target → enough `..`s to escape up to a shared
+#     parent, then descend
+#   - target equals anchor → empty path
+#   - sibling trees → single `..` to step across (this is the real-world
+#     case bin/setup-claude relies on, since citizenlab/ and
+#     citizenlab-claude/ are sibling clones under the same parent dir)
+#   - no common ancestor at all → defensive fallback that returns the
+#     absolute target (see the comment on that test case below for why
+#     this matters)
 
 echo "Unit tests: relpath"
 assert_eq "$(relpath /a/b/c     /a/b)"        "c"             "target one level deeper"

--- a/bin/setup-claude.test.sh
+++ b/bin/setup-claude.test.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# bin/setup-claude.test.sh — tests for bin/setup-claude.
+#
+# Run from anywhere inside the citizenlab repo:
+#   ./bin/setup-claude.test.sh
+#
+# Plain bash, no framework. Exits non-zero if any test fails.
+# Constructs a fake "private overlay" + "public repo" pair in a tmpdir
+# and exercises bin/setup-claude end-to-end without touching real state.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_TO_TEST="$SCRIPT_DIR/setup-claude"
+
+# Source in library mode to access helpers (relpath)
+BIN_SETUP_CLAUDE_LIBRARY=1 source "$SCRIPT_TO_TEST"
+
+# --- Test framework ---
+
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+pass() { PASS=$((PASS + 1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL + 1)); FAILED_TESTS+=("$1"); echo "  ✗ $1" >&2; }
+
+assert_eq() {
+  local actual="$1" expected="$2" label="$3"
+  if [ "$actual" = "$expected" ]; then
+    pass "$label"
+  else
+    fail "$label"
+    echo "    expected: '$expected'" >&2
+    echo "    actual:   '$actual'" >&2
+  fi
+}
+
+assert_symlink_to() {
+  local link="$1" expected="$2" label="$3"
+  if [ ! -L "$link" ]; then
+    fail "$label (not a symlink: $link)"
+    return
+  fi
+  local actual; actual="$(readlink "$link")"
+  assert_eq "$actual" "$expected" "$label"
+}
+
+assert_path_missing() {
+  if [ ! -e "$1" ] && [ ! -L "$1" ]; then
+    pass "$2"
+  else
+    fail "$2 ($1 should not exist)"
+  fi
+}
+
+# --- Unit tests: relpath ---
+
+echo "Unit tests: relpath"
+assert_eq "$(relpath /a/b/c     /a/b)"        "c"             "target one level deeper"
+assert_eq "$(relpath /a/b/c/d   /a/b)"        "c/d"           "target nested deeper"
+assert_eq "$(relpath /a/b       /a/b/c)"      ".."            "anchor one level deeper"
+assert_eq "$(relpath /a/b       /a/b/c/d)"    "../.."         "anchor two levels deeper"
+assert_eq "$(relpath /a/b/c     /a/b/c)"      ""              "target equals anchor"
+assert_eq "$(relpath /a/sib/x   /a/cl)"       "../sib/x"      "sibling tree (real-world case)"
+assert_eq "$(relpath /a/sib/x/y /a/cl/z)"     "../../sib/x/y" "sibling tree at different depths"
+assert_eq "$(relpath /var/x     /private/var/x)" "/var/x"      "no common ancestor: falls back to absolute (no infinite loop)"
+
+# --- Integration test fixtures ---
+
+TEST_TMP=""
+trap '[ -n "${TEST_TMP:-}" ] && rm -rf "$TEST_TMP"' EXIT
+
+setup_fake_env() {
+  # Canonicalize the tmpdir path so it matches what `git rev-parse
+  # --show-toplevel` returns. On macOS, mktemp -d returns /var/folders/...
+  # while git canonicalizes through the /var → /private/var symlink. If we
+  # don't normalize here, relpath hits no-common-ancestor and falls back
+  # to absolute paths — tests then assert against unstable absolute paths.
+  TEST_TMP="$(cd "$(mktemp -d)" && pwd -P)"
+  REMOTE="$TEST_TMP/remote.git"
+  PUBLIC="$TEST_TMP/public"
+  PRIVATE="$TEST_TMP/private"
+  FIXTURE_WT="$TEST_TMP/fixture-wt"
+
+  git init --bare -q "$REMOTE"
+
+  # Populate the remote via a separate working tree
+  git clone -q "$REMOTE" "$FIXTURE_WT"
+  (
+    cd "$FIXTURE_WT"
+    mkdir -p back front hooks skills/test-skill commands
+    echo '# root context'  > CLAUDE.md
+    echo '# back context'  > back/CLAUDE.md
+    echo '# front context' > front/CLAUDE.md
+    cat > hooks/test-hook.sh <<'HOOK'
+#!/usr/bin/env bash
+exit 0
+HOOK
+    chmod +x hooks/test-hook.sh
+    cat > skills/test-skill/SKILL.md <<'SKILL'
+---
+name: test-skill
+description: test
+---
+SKILL
+    echo '# test command' > commands/test.md
+    echo '{}' > settings.local.json
+    echo '# private overlay README' > .claude-readme.md
+    echo 'private repo own README' > README.md
+    git -c user.email=t@t -c user.name=t add -A
+    git -c user.email=t@t -c user.name=t commit -q -m fixtures
+    git push -q origin "$(git rev-parse --abbrev-ref HEAD)"
+  )
+
+  # Public repo: needs to exist as a git repo with the area dirs that have CLAUDE.md content
+  mkdir -p "$PUBLIC/back" "$PUBLIC/front" "$PUBLIC/.githooks"
+  (
+    cd "$PUBLIC"
+    git init -q
+    git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+  )
+  # PRIVATE is created by setup-claude on first run (via clone from REMOTE)
+}
+
+run_setup() {
+  (
+    cd "$PUBLIC"
+    CITIZENLAB_CLAUDE_GIT_REMOTE="$REMOTE" \
+    CITIZENLAB_CLAUDE_DIR="$PRIVATE" \
+      bash "$SCRIPT_TO_TEST" >/dev/null 2>&1
+  )
+}
+
+# --- Integration tests ---
+
+echo ""
+echo "Integration tests"
+
+# Test: fresh setup creates the expected symlinks (top-level CLAUDE.md + .claude/<rel>)
+setup_fake_env
+run_setup
+assert_symlink_to "$PUBLIC/CLAUDE.md"                          "../private/CLAUDE.md"                            "root CLAUDE.md → private"
+assert_symlink_to "$PUBLIC/back/CLAUDE.md"                     "../../private/back/CLAUDE.md"                    "back/CLAUDE.md → private"
+assert_symlink_to "$PUBLIC/front/CLAUDE.md"                    "../../private/front/CLAUDE.md"                   "front/CLAUDE.md → private"
+assert_symlink_to "$PUBLIC/.claude/hooks/test-hook.sh"         "../../../private/hooks/test-hook.sh"             "hook script → private"
+assert_symlink_to "$PUBLIC/.claude/skills/test-skill/SKILL.md" "../../../../private/skills/test-skill/SKILL.md"  "skill SKILL.md → private"
+assert_symlink_to "$PUBLIC/.claude/commands/test.md"           "../../../private/commands/test.md"               "command → private"
+assert_symlink_to "$PUBLIC/.claude/settings.local.json"        "../../private/settings.local.json"               "settings.local.json → private"
+assert_symlink_to "$PUBLIC/.claude/README.md"                  "../../private/.claude-readme.md"                 ".claude/README.md → private .claude-readme.md"
+
+# .claude/ should not redundantly mirror CLAUDE.md content; empty area dirs cleaned up
+assert_path_missing "$PUBLIC/.claude/CLAUDE.md"  ".claude/CLAUDE.md not created (lives at top-level instead)"
+assert_path_missing "$PUBLIC/.claude/back"       ".claude/back/ empty dir cleaned up"
+assert_path_missing "$PUBLIC/.claude/front"      ".claude/front/ empty dir cleaned up"
+
+# Test: idempotent — second run produces the same state
+run_setup
+assert_symlink_to "$PUBLIC/CLAUDE.md" "../private/CLAUDE.md" "second run: root symlink unchanged"
+
+# Test: top-level CLAUDE.md is skipped when the area dir doesn't exist in citizenlab
+rm -rf "$PUBLIC/front"
+run_setup
+assert_path_missing "$PUBLIC/front" "front/ not auto-created when area dir missing (no phantom dir)"
+
+# Test: pre-existing regular file at a CLAUDE.md path is replaced by a symlink (migration case)
+rm -f "$PUBLIC/CLAUDE.md"
+echo "old stub" > "$PUBLIC/CLAUDE.md"
+run_setup
+assert_symlink_to "$PUBLIC/CLAUDE.md" "../private/CLAUDE.md" "regular CLAUDE.md replaced by symlink"
+
+# Test: migration cleanup — pre-existing .claude/private/ directory is removed
+mkdir -p "$PUBLIC/.claude/private/back"
+echo "x" > "$PUBLIC/.claude/private/CLAUDE.md"
+echo "x" > "$PUBLIC/.claude/private/back/CLAUDE.md"
+run_setup
+assert_path_missing "$PUBLIC/.claude/private" "obsolete .claude/private/ directory removed"
+
+# Test: migration cleanup — obsolete .claude/skills/private dir-symlink is removed
+ln -sfn "../../$PRIVATE/skills" "$PUBLIC/.claude/skills/private"
+run_setup
+assert_path_missing "$PUBLIC/.claude/skills/private" "obsolete .claude/skills/private symlink removed"
+
+# Test: stale CLAUDE.md symlink cleaned up after private content drops
+mkdir -p "$PUBLIC/front"  # restore the area dir
+(
+  cd "$FIXTURE_WT"
+  git pull -q --ff-only
+  rm front/CLAUDE.md
+  git -c user.email=t@t -c user.name=t add -A
+  git -c user.email=t@t -c user.name=t commit -q -m "drop front"
+  git push -q
+)
+run_setup
+assert_path_missing "$PUBLIC/front/CLAUDE.md" "stale front/CLAUDE.md symlink cleaned up after private content removal"
+
+# --- Summary ---
+
+echo ""
+echo "Total: $((PASS + FAIL)) tests, $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed tests:" >&2
+  printf '  - %s\n' "${FAILED_TESTS[@]}" >&2
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
# Changelog

## Technical
- Add automated tests for `bin/setup-claude`, `bin/check-claude-privacy`, and `.githooks/pre-commit`. New `claude-tests` CircleCI job runs them on every PR. See each test file's header comment for what it covers.