### PR TITLE
[TAN-7623] Merge claude-tests and claude-privacy-check into one CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,7 @@ jobs:
       - shallow-clone
       - run: danger ci
 
-  claude-privacy-check:
+  claude-tests-and-privacy-check:
     resource_class: small
     docker:
       - image: cimg/base:stable
@@ -157,22 +157,12 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Verify no Claude private overlay content has leaked into the public repo
-          command: bin/check-claude-privacy
-
-  claude-tests:
-    resource_class: small
-    docker:
-      - image: cimg/base:stable
-    working_directory: ~/citizenlab
-    steps:
-      - checkout
-      - run:
-          name: Run Claude private overlay test scripts (setup-claude, privacy check, pre-commit hook)
+          name: Run Claude private overlay test scripts and verify no overlay content has leaked into the public repo
           command: |
             bin/setup-claude.test.sh
             bin/check-claude-privacy.test.sh
             .githooks/pre-commit.test.sh
+            bin/check-claude-privacy
 
   changelogger:
     resource_class: small
@@ -900,13 +890,7 @@ workflows:
                 - /l10n_.*/
                 - master
                 - production
-      - claude-privacy-check:
-          filters:
-            branches:
-              ignore:
-                - crowdin_master
-                - /l10n_.*/
-      - claude-tests:
+      - claude-tests-and-privacy-check:
           filters:
             branches:
               ignore:


### PR DESCRIPTION
## Summary

Both jobs were identical except for the run step (same `cimg/base:stable`, same `small` resource class, same working directory, same branch filters), and each was paying a ~30s container spin-up to run <1s of work.

Folded them into a single `claude-tests-and-privacy-check` job that runs the three test scripts followed by `bin/check-claude-privacy`.

## Test plan

- [x] CI: confirm the new `claude-tests-and-privacy-check` job runs and passes on this PR
- [x] CI: confirm the old `claude-tests` and `claude-privacy-check` jobs no longer appear in the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)