### PR TITLE
[TAN-7738] Use current path in og:url, not homepage

### DIFF
--- a/front/app/containers/App/Meta.tsx
+++ b/front/app/containers/App/Meta.tsx
@@ -128,7 +128,7 @@ const Meta = () => {
           property="og:image:height"
           content={`${imageSizes.headerBg.large[1]}`}
         />
-        <meta property="og:url" content={`${url}/${locale}`} />
+        <meta property="og:url" content={`${url}${pathname}`} />
         <meta name="twitter:card" content="summary_large_image" />
         <meta property="fb:app_id" content={fbAppId} />
         <meta property="og:site_name" content={organizationName} />

--- a/front/app/containers/App/Meta.tsx
+++ b/front/app/containers/App/Meta.tsx
@@ -128,6 +128,8 @@ const Meta = () => {
           property="og:image:height"
           content={`${imageSizes.headerBg.large[1]}`}
         />
+        {/* og:url must reflect the current page, not the homepage — otherwise FB
+            follows it back to the homepage when scraping non-home shares. */}
         <meta property="og:url" content={`${url}${pathname}`} />
         <meta name="twitter:card" content="summary_large_image" />
         <meta property="fb:app_id" content={fbAppId} />


### PR DESCRIPTION
## Summary

Fix `og:url` so it reflects the current page rather than always pointing at the homepage.

## Why

Custom pages routed through CustomPageShow (privacy policy, cookie policy, accessibility statement, tenant-created info pages) had their `og:url` set to the homepage by `App/Meta.tsx`'s default.

When Facebook scraped a non-home URL — concretely, the FB Login app's privacy-policy URL for `participa.tudsid.org` — FB followed `og:url` back to the homepage and tried to scrape that instead.

tudsid's homepage embeds a Vimeo iframe that hangs the prerender (~21s, with intermittent 502/503), pushing FB past its scraper timeout. FB recorded "Curl Timeout" / 418 and flagged the privacy-policy URL as invalid, blocking the FB SSO app.

The fix derives `og:url` from `useLocation().pathname` instead of `${url}/${locale}.` Pages that already have their own `*Meta.tsx with og:url={location.href}` are unaffected (Helmet's last-write-wins still applies). The homepage is byte-identical (its pathname is /<locale>).

## Customer impact

Minimal. The pages whose `og:url` actually changes are privacy/cookie/accessibility/auth pages (not normally shared on Facebook) and tenant-created custom info pages. The only realistic regression scenario is a tenant who actively promoted a custom info page on Facebook: accumulated FB like/share counts previously aggregated incorrectly to their homepage will stay on the homepage, and the actual page URL will start fresh. I expect this to be rare in our customer base and don't think a proactive notice is warranted.

# Changelog
##  Technical
- [TAN-7738] Use current path in `og:url`, not homepage. This fixes some FB SSO app checks of privacy policy URLs that were timing out due to i-frames on homepage embedding slow 3rd party content. e.g. Vimeo video.

