### PR TITLE
Fix double padding on content builder in project pages on mobile

### DIFF
--- a/front/app/components/DescriptionBuilder/ContentViewer/ProjectContentViewer.tsx
+++ b/front/app/components/DescriptionBuilder/ContentViewer/ProjectContentViewer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Box, Spinner, Title } from '@citizenlab/cl2-component-library';
+import { Box, Spinner, Title, useBreakpoint } from '@citizenlab/cl2-component-library';
 import { isEmpty } from 'lodash-es';
 import { Multiloc } from 'typings';
 
@@ -37,6 +37,7 @@ const ProjectContentViewer = ({
   enabled,
 }: ProjectContentViewerProps) => {
   const localize = useLocalize();
+  const isSmallerThanTablet = useBreakpoint('tablet');
   const featureEnabled = useFeatureFlag({
     name: 'project_description_builder',
   });
@@ -64,7 +65,7 @@ const ProjectContentViewer = ({
           <Title color="tenantText" variant="h1">
             {localize(projectTitle)}
           </Title>
-          <Box id={`project-description-${projectId}`}>
+          <Box id={`project-description-${projectId}`} mx={isSmallerThanTablet ? '-20px' : '0px'}>
             <ContentBuilderLayoutProvider
               layoutId={descriptionBuilderLayout.data.id}
             >


### PR DESCRIPTION
## Summary
- On screens <1200px, `ContentContainer` already applies 20px horizontal padding to everything in `ProjectHeader`
- Content builder widgets add *another* 20px via `useCraftComponentDefaultPadding`, causing double padding
- The WYSIWYG description path was unaffected, making the inconsistency visible
- Fix: cancel the inner 20px on the content builder wrapper in `ProjectContentViewer` using a negative margin, scoped to the tablet breakpoint — no shared code touched, no risk to homepage/folder/report builder

## Test plan
- [ ] Project page with content builder enabled at <1200px wide — padding matches title/image
- [ ] Project page with content builder enabled at >1200px wide — no change
- [ ] Project page using WYSIWYG description — no change
- [ ] Homepage, folder page, report builder at mobile width — no change

🤖 Generated with [Claude Code](https://claude.com/claude-code)