### PR TITLE
[TAN-7738] Revert the revert of change to og:url

### DIFF
--- a/front/app/containers/App/Meta.tsx
+++ b/front/app/containers/App/Meta.tsx
@@ -128,7 +128,9 @@ const Meta = () => {
           property="og:image:height"
           content={`${imageSizes.headerBg.large[1]}`}
         />
-        <meta property="og:url" content={`${url}/${locale}`} />
+        {/* og:url must reflect the current page, not the homepage — otherwise FB
+            follows it back to the homepage when scraping non-home shares. */}
+        <meta property="og:url" content={`${url}${pathname}`} />
         <meta name="twitter:card" content="summary_large_image" />
         <meta property="fb:app_id" content={fbAppId} />
         <meta property="og:site_name" content={organizationName} />


### PR DESCRIPTION
# Changelog
## Technical
- [TAN-7738](https://notion.so/TAN-7738)] Use current path in og:url, not homepage. This fixes some FB SSO app checks of privacy policy URLs that were timing out due to i-frames on homepage embedding slow 3rd party content. e.g. Vimeo video. Reverting the revert.
