### PR TITLE
[TAN-7666] Allow clearing an idea's location via the edit form

### DIFF
--- a/back/app/controllers/web_api/v1/ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/ideas_controller.rb
@@ -534,7 +534,12 @@ class WebApi::V1::IdeasController < ApplicationController
 
   def idea_simple_attributes(submittable_field_keys)
     simple_attributes = %i[location_description proposed_budget] & submittable_field_keys
-    simple_attributes.push(:publication_status, :project_id, :anonymous, { weglot_data: %i[locale body] })
+    # location_point_geojson is also permitted as a nested hash via
+    # idea_complex_attributes for setting a Point. Permitting it here as a
+    # scalar additionally allows the client to send `null` to clear it —
+    # strong-params silently drops a `null` value against a nested-hash
+    # permit, so without this an explicit clear from the FE has no effect.
+    simple_attributes.push(:publication_status, :project_id, :anonymous, :location_point_geojson, { weglot_data: %i[locale body] })
     if submittable_field_keys.include?(:idea_images_attributes)
       simple_attributes << [idea_images_attributes: [:image]]
     end

--- a/back/spec/acceptance/ideas/ideas_update_spec.rb
+++ b/back/spec/acceptance/ideas/ideas_update_spec.rb
@@ -286,6 +286,27 @@ resource 'Ideas' do
           end
         end
 
+        describe 'clearing location_point_geojson' do
+          let(:input) do
+            create(
+              :idea,
+              project: project,
+              phases: project.phases,
+              location_description: 'Old address',
+              location_point_geojson: { 'type' => 'Point', 'coordinates' => [1.0, 2.0] }
+            )
+          end
+          let(:location_description) { nil }
+          let(:location_point_geojson) { nil }
+
+          example 'admin clears the location by sending null for both attributes', document: false do
+            do_request idea: { location_description: nil, location_point_geojson: nil }
+            assert_status 200
+            expect(input.reload.location_description).to be_nil
+            expect(input.reload.location_point_geojson).to be_nil
+          end
+        end
+
         describe 'phase_ids' do
           let(:phase) { project.phases.first }
 

--- a/front/app/components/CustomFieldsForm/IdeationForm/index.tsx
+++ b/front/app/components/CustomFieldsForm/IdeationForm/index.tsx
@@ -119,12 +119,21 @@ const IdeationForm = ({
         // as they are handled via separate API calls
         const { idea_files_attributes: _, ...formValuesWithoutFiles } =
           translatedFormValues;
+        const requestBody = {
+          ...formValuesWithoutFiles,
+          weglot_data: weglotData,
+        };
+        // Keep location_point_geojson consistent with location_description:
+        // if there is no description, force the geojson to null so a stale
+        // value from the idea's initial state can't ride through unchanged
+        // (e.g. when the location field is disabled in the form config and
+        // the LocationInput never mounts to clear it).
+        if (!requestBody.location_description) {
+          requestBody.location_point_geojson = null;
+        }
         await updateIdea({
           id: idea.id,
-          requestBody: {
-            ...formValuesWithoutFiles,
-            weglot_data: weglotData,
-          },
+          requestBody,
         });
         updateSearchParams({ idea_id: idea.id });
       }


### PR DESCRIPTION
Claude Code assisted.

## The fix

- BE: permit `location_point_geojson` as a scalar in addition to its existing nested-hash permit, so a client-sent `null` is no longer silently dropped by strong-params and actually clears the column.
- FE: at `IdeationForm` submit time, force `location_point_geojson` to null when `location_description` is empty — without this the form would echo the original `Point` back and the BE would just re-save it, even with the permit fix in place.
- Regression spec in `ideas_update_spec.rb`: admin sends `null` for both attributes, both clear on the persisted record.

## Not covered

- Asymmetric field gating. `location_description` is gated on `submittable_field_keys`; `location_point_geojson` is permitted unconditionally on the BE. Maybe worth aligning, or maybe there is a good reason for this, but out of scope in any case.
- Historic records with point-but-no-description. Some are possibly legitimate (e.g. bulk import). Cleanup needs a domain decision rather than a blanket rule. Also, nobody is asking for a cleanup of existing data.

### A note on Rails params, scalars & nested hashes

In Rails strong-params, parameters are permitted in two shapes:

1. Scalar — a single primitive value at a top-level key. You permit it by `name: params.permit(:location_point_geojson)`. Rails accepts strings, numbers, booleans, nil, dates, etc. as scalars. A JSON object is not a scalar in this sense.
2. Nested hash — a structured value under a key. You permit it by passing a hash spec: `params.permit(idea_complex_attributes: [:location_point_geojson, ...]`) or `params.permit(location_point_geojson: [:type, coordinates: []])`.

When you only declare `location_point_geojson` as a nested hash permit (expecting `{ type: "Point", coordinates: [...] }`), strong-params evaluates whether the incoming value matches that hash shape. A `null` doesn't match a hash shape, so it gets silently dropped from the permitted params — the controller never sees the clear intent.

Permitting it additionally as a scalar `(params.permit(:location_point_geojson)`) tells strong-params "a bare primitive value at this key is also acceptable." Now `null` survives the filter and reaches the model, where assigning `nil` actually clears the column. The two permits coexist: a hash payload flows through the nested permit, a null payload flows through the scalar permit.

# Changelog
## Fixed
- [TAN-7666] Allow clearing an idea's location via the edit form
