### PR TITLE
Security: Hardcoded Salt Values for Author Hash

### DIFF
--- a/back/app/models/concerns/anonymous_participation.rb
+++ b/back/app/models/concerns/anonymous_participation.rb
@@ -7,8 +7,8 @@ module AnonymousParticipation
   included do
     class << self
       def create_author_hash(author_id, project_id, anonymous)
-        salt_normal = ENV.fetch('AUTHOR_HASH_SALT', '84c168c4-a240-4f0a-8468-9e2cf714d4e1')
-        salt_anon = ENV.fetch('AUTHOR_HASH_SALT_ANON', '335b6eb2-9e7c-405c-9221-9b8919b64b8b')
+        salt_normal = ENV.fetch('AUTHOR_HASH_SALT')
+        salt_anon = ENV.fetch('AUTHOR_HASH_SALT_ANON')
         salt = anonymous ? "#{project_id}#{salt_anon}" : salt_normal
         digest = Digest::MD5.hexdigest(author_id + salt)
 


### PR DESCRIPTION
## Summary

Security: Hardcoded Salt Values for Author Hash

## Problem

**Severity**: `Medium` | **File**: `back/app/models/concerns/anonymous_participation.rb:L14`

The anonymous_participation.rb uses hardcoded default salt values ('84c168c4-a240-4f0a-8468-9e2cf714d4e1' and '335b6eb2-9e7c-405c-9221-9b8919b64b8b') as fallbacks when ENV variables are not set. This weakens security if the environment variables are not properly configured.

## Solution

Remove the fallback hardcoded salts and require the environment variables to be properly set, or raise an error if they're missing.

## Changes

- `back/app/models/concerns/anonymous_participation.rb` (modified)