### PR TITLE
Make dependabot wait a week before upgrading a dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,15 +24,3 @@ updates:
       - "adessy"
     reviewers:
       - "adessy"
-  - package-ecosystem: npm
-    directory: '/cl2-component-library'
-    schedule:
-      interval: monthly
-      time: '04:00'
-    open-pull-requests-limit: 10
-    cooldown:
-      default-days: 7
-    assignees:
-      - 'IvaKop'
-    reviewers:
-      - 'IvaKop'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       time: "04:00"
     rebase-strategy: "disabled"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
     assignees:
       - "IvaKop"
     reviewers:
@@ -16,6 +18,8 @@ updates:
     open-pull-requests-limit: 10
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     assignees:
       - "adessy"
     reviewers:
@@ -26,6 +30,8 @@ updates:
       interval: monthly
       time: '04:00'
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
     assignees:
       - 'IvaKop'
     reviewers:


### PR DESCRIPTION
# Changelog
## Technical
- Dependabot, the system that helps us upgrading software libraries, now waits a week before upgrading to new libraries to protect against supply chain attacks. CVEs are excluded from this rule.
