### PR TITLE
[TAN-7773] (a11y) Show "Powered by" text in footer at 400% zoom

### DIFF
--- a/front/app/containers/PlatformFooter/index.tsx
+++ b/front/app/containers/PlatformFooter/index.tsx
@@ -176,8 +176,8 @@ const PoweredByText = styled.span`
   line-height: normal;
   margin-right: 8px;
   ${media.tablet`
-    display: none;
-    margin-bottom: 10px;
+    margin-right: 0;
+    margin-bottom: 4px;
   `}
 `;
 

--- a/front/app/containers/PlatformFooter/index.tsx
+++ b/front/app/containers/PlatformFooter/index.tsx
@@ -177,7 +177,7 @@ const PoweredByText = styled.span`
   margin-right: 8px;
   ${media.tablet`
     margin-right: 0;
-    margin-bottom: 4px;
+    margin-bottom: 10px;
   `}
 `;
 
@@ -237,7 +237,7 @@ const PlatformFooter = ({ className }: Props) => {
     eventEmitter.emit('openConsentManager');
   };
 
-  /* 
+  /*
     Likely not the most reliable way to determine if the bar is present.
     Context would probably be better, but this is a quick fix.
   */


### PR DESCRIPTION
The `PoweredByText` styled span was set to `display: none` at the tablet breakpoint, which also hides it at 400% zoom (since high zoom collapses the CSS viewport into the tablet breakpoint range). This violated WCAG 1.4.10 (Reflow, Level AA), which requires content to remain available at 400% zoom / 320 CSS px without loss of information.

The fix removes the `display: none` rule from the tablet media query so the text renders at narrow viewports, and zeroes out its `margin-right` so it stays centred above the logo in the column layout.

The parent `PoweredBy` container already switches to `flex-direction: column` at the tablet breakpoint, so the text stacks above the Go Vocal logo.

Screenshots at 400%:
<img width="2560" height="833" alt="Screenshot 2026-05-13 at 12 31 48" src="https://github.com/user-attachments/assets/1b012159-d4bf-4651-8abd-984dd42ac5ee" />
<img width="402" height="859" alt="Screenshot 2026-05-13 at 12 32 09" src="https://github.com/user-attachments/assets/337b236c-440f-4c9c-aa91-7a05e7873406" />


# Changelog
## Fixed
- [TAN-7773] (a11y) Show "Powered by" text in footer at 400% zoom
