### PR TITLE
[TAN-7774] (a11y) Reflow Edit page button at 400% zoom

### DIFF
--- a/front/app/containers/CustomPageShow/CustomPageHeader/AdminCustomPageEditButton.tsx
+++ b/front/app/containers/CustomPageShow/CustomPageHeader/AdminCustomPageEditButton.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 
+import { media } from '@citizenlab/cl2-component-library';
 import { WrappedComponentProps } from 'react-intl';
+import styled from 'styled-components';
 
 import useAuthUser from 'api/me/useAuthUser';
 
@@ -13,6 +15,21 @@ import { isNilOrError } from 'utils/helperUtils';
 import { isAdmin } from 'utils/permissions/roles';
 
 import messages from '../messages';
+
+// Absolutely positioned at top-right on wider viewports, but switches to
+// in-flow on narrow viewports / 400% zoom so the button doesn't overlap
+// the page heading (WCAG 1.4.10 Reflow).
+const PositionWrapper = styled.div`
+  position: absolute;
+  top: 50px;
+  right: 30px;
+
+  ${media.tablet`
+    position: static;
+    width: fit-content;
+    margin-top: 16px;
+  `}
+`;
 
 interface Props {
   pageId: string;
@@ -27,17 +44,16 @@ const AdminCustomPageEditButton = ({
   const userCanEditPage = !isNilOrError(authUser) && isAdmin(authUser);
 
   return userCanEditPage ? (
-    <ButtonWithLink
-      icon="edit"
-      linkTo={adminCustomPageContentPath(pageId)}
-      buttonStyle="secondary-outlined"
-      padding="5px 8px"
-      position="absolute"
-      top="30px"
-      right="30px"
-    >
-      {formatMessage(messages.editPage)}
-    </ButtonWithLink>
+    <PositionWrapper>
+      <ButtonWithLink
+        icon="edit"
+        linkTo={adminCustomPageContentPath(pageId)}
+        buttonStyle="secondary-outlined"
+        padding="5px 8px"
+      >
+        {formatMessage(messages.editPage)}
+      </ButtonWithLink>
+    </PositionWrapper>
   ) : null;
 };
 

--- a/front/app/containers/CustomPageShow/CustomPageHeader/AdminCustomPageEditButton.tsx
+++ b/front/app/containers/CustomPageShow/CustomPageHeader/AdminCustomPageEditButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { media } from '@citizenlab/cl2-component-library';
+import { colors, media } from '@citizenlab/cl2-component-library';
 import { WrappedComponentProps } from 'react-intl';
 import styled from 'styled-components';
 
@@ -49,6 +49,7 @@ const AdminCustomPageEditButton = ({
         icon="edit"
         linkTo={adminCustomPageContentPath(pageId)}
         buttonStyle="secondary-outlined"
+        bgColor={colors.white}
         padding="5px 8px"
       >
         {formatMessage(messages.editPage)}


### PR DESCRIPTION
- Solves reflow issue
- Also aligns button vertically with page title, when not reflowed.
- Also sets button background color to white, as I noticed it was tranparent and could get lost when the page has a banner with an image.

Before:
<img width="1603" height="889" alt="Screenshot 2026-05-13 at 13 07 28" src="https://github.com/user-attachments/assets/4447b0b5-c7a6-430d-b182-7ae7b9330e1b" />

After:
<img width="1599" height="1105" alt="Screenshot 2026-05-13 at 13 28 28" src="https://github.com/user-attachments/assets/4e125d52-2f8c-4973-9838-90ee12bbd431" />

Before:
<img width="1603" height="247" alt="Screenshot 2026-05-13 at 13 12 53" src="https://github.com/user-attachments/assets/12acb5d6-dfe8-4701-b047-686fbf242e11" />

After:
<img width="1603" height="247" alt="Screenshot 2026-05-13 at 13 13 37" src="https://github.com/user-attachments/assets/db6a974b-e7be-49ef-9902-07258022efa0" />

Before:
<img width="458" height="310" alt="Screenshot 2026-05-13 at 13 26 25" src="https://github.com/user-attachments/assets/05914a87-f738-4b17-a772-d051c948205f" />

After:
<img width="458" height="310" alt="Screenshot 2026-05-13 at 13 26 55" src="https://github.com/user-attachments/assets/82153c39-fa46-4ccc-ae26-5c8465d2b1fc" />

# Changelog
## Fixed
- [TAN-7774] (a11y) Reflow Edit page button at 400% zoom
