### PR TITLE
[TAN-7779] Improve error message for survey number answer that is not a number

### DIFF
--- a/front/app/components/CustomFieldsForm/Page/usePageForm.ts
+++ b/front/app/components/CustomFieldsForm/Page/usePageForm.ts
@@ -10,6 +10,7 @@ import useLocalize from 'hooks/useLocalize';
 import { useIntl } from 'utils/cl-intl';
 
 import generateYupValidationSchema from '../generateYupSchema';
+import messages from '../messages';
 
 import { FormValues } from './types';
 
@@ -28,10 +29,29 @@ const usePageForm = ({
     formatMessage,
     localize,
   });
+  const baseResolver = yupResolver(schema);
 
   const methods = useForm({
     mode: 'onBlur',
-    resolver: yupResolver(schema),
+    // Yup can't see "bad input" in <input type="number"> (browser reports value="" while validity.badInput=true, and React's value-tracker suppresses the change event for the empty→invalid transition). Sweep the DOM after Yup runs and override the error for any number field whose input is in that state.
+    resolver: (async (values, context, options) => {
+      const result = await baseResolver(values, context, options);
+      pageQuestions.forEach((question) => {
+        if (question.input_type !== 'number') return;
+        const el = document.querySelector<HTMLInputElement>(
+          `input[name="${CSS.escape(question.key)}"]`
+        );
+        if (el?.validity.badInput) {
+          (result.errors as Record<string, unknown>)[question.key] = {
+            type: 'badInput',
+            message: formatMessage(messages.mustBeNumber, {
+              fieldName: localize(question.title_multiloc),
+            }),
+          };
+        }
+      });
+      return result;
+    }) as typeof baseResolver,
     defaultValues,
   });
 

--- a/front/app/components/CustomFieldsForm/generateYupSchema.test.ts
+++ b/front/app/components/CustomFieldsForm/generateYupSchema.test.ts
@@ -65,4 +65,44 @@ describe('generateYupSchema', () => {
       ).toBe(true);
     });
   });
+
+  describe('number field', () => {
+    const buildSchema = (required: boolean, key = 'number_q') =>
+      generateYupSchema({
+        pageQuestions: [
+          { input_type: 'number', required, key, enabled: true },
+        ] as any,
+        formatMessage,
+        localize,
+      });
+
+    it('accepts a valid number when required', () => {
+      expect(buildSchema(true).isValidSync({ number_q: 42 })).toBe(true);
+    });
+
+    it('rejects an empty value when required', () => {
+      expect(buildSchema(true).isValidSync({ number_q: '' })).toBe(false);
+    });
+
+    it('accepts an empty value when optional', () => {
+      expect(buildSchema(false).isValidSync({ number_q: '' })).toBe(true);
+      expect(buildSchema(false).isValidSync({})).toBe(true);
+    });
+
+    it('rejects NaN (bad input) whether required or optional', () => {
+      expect(buildSchema(true).isValidSync({ number_q: NaN })).toBe(false);
+      expect(buildSchema(false).isValidSync({ number_q: NaN })).toBe(false);
+    });
+
+    it('rejects NaN for birthyear and proposed_budget too', () => {
+      expect(
+        buildSchema(true, 'birthyear').isValidSync({ birthyear: NaN })
+      ).toBe(false);
+      expect(
+        buildSchema(true, 'proposed_budget').isValidSync({
+          proposed_budget: NaN,
+        })
+      ).toBe(false);
+    });
+  });
 });

--- a/front/app/components/CustomFieldsForm/generateYupSchema.ts
+++ b/front/app/components/CustomFieldsForm/generateYupSchema.ts
@@ -189,6 +189,9 @@ const generateYupSchema = ({
       }
 
       case 'number': {
+        const mustBeNumber = formatMessage(messages.mustBeNumber, {
+          fieldName: title,
+        });
         if (key === 'proposed_budget') {
           schema[key] =
             required && enabled
@@ -196,11 +199,13 @@ const generateYupSchema = ({
                   .transform((value, originalValue) =>
                     originalValue === '' ? null : value
                   )
+                  .typeError(mustBeNumber)
                   .required(fieldRequired)
               : number()
                   .transform((value, originalValue) =>
                     originalValue === '' ? null : value
                   )
+                  .typeError(mustBeNumber)
                   .nullable();
         } else if (key === 'birthyear') {
           schema[key] = required
@@ -208,6 +213,7 @@ const generateYupSchema = ({
                 .transform((value, originalValue) =>
                   originalValue === '' ? null : value
                 )
+                .typeError(mustBeNumber)
                 .min(1900, formatMessage(messages.birthyearTooLow))
                 .max(
                   new Date().getFullYear(),
@@ -218,6 +224,7 @@ const generateYupSchema = ({
                 .transform((value, originalValue) =>
                   originalValue === '' ? null : value
                 )
+                .typeError(mustBeNumber)
                 .min(1900, formatMessage(messages.birthyearTooLow))
                 .max(
                   new Date().getFullYear(),
@@ -230,11 +237,13 @@ const generateYupSchema = ({
                 .transform((value, originalValue) =>
                   originalValue === '' ? null : value
                 )
+                .typeError(mustBeNumber)
                 .required(fieldRequired)
             : number()
                 .transform((value, originalValue) =>
                   originalValue === '' ? null : value
                 )
+                .typeError(mustBeNumber)
                 .nullable();
         }
         break;

--- a/front/app/components/CustomFieldsForm/messages.ts
+++ b/front/app/components/CustomFieldsForm/messages.ts
@@ -61,6 +61,10 @@ export default defineMessages({
     id: 'app.components.CustomFieldsForm.fieldRequired',
     defaultMessage: 'The field "{fieldName}" is required',
   },
+  mustBeNumber: {
+    id: 'app.components.CustomFieldsForm.mustBeNumber',
+    defaultMessage: 'The field "{fieldName}" must be a number',
+  },
   fieldMaximum: {
     id: 'app.components.CustomFieldsForm.fieldMaximumItems',
     defaultMessage:

--- a/front/app/components/HookForm/Input/index.tsx
+++ b/front/app/components/HookForm/Input/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 
 import {
   Input as InputComponent,
@@ -28,6 +28,7 @@ const Input = ({
     formState: { errors: formContextErrors },
     control,
   } = useFormContext();
+  const inputRef = useRef<HTMLInputElement | null>(null);
 
   const errors = get(formContextErrors, name) as RHFErrors;
   const validationError = errors?.message;
@@ -44,7 +45,7 @@ const Input = ({
       <Controller
         name={name}
         control={control}
-        render={({ field: { ref: _ref, ...field } }) => (
+        render={({ field: { ref: _ref, onChange, ...field } }) => (
           <InputComponent
             id={name}
             type={type}
@@ -52,6 +53,16 @@ const Input = ({
             ariaDescribedBy={ariaDescribedBy}
             {...field}
             {...rest}
+            setRef={(el) => {
+              inputRef.current = el;
+            }}
+            onChange={(value, locale) => {
+              // Skip when `<input type="number">` reports validity.badInput — writing back to RHF causes React to resync input.value and wipe the visible bad-input text. The form's resolver scans the DOM and surfaces the error.
+              if (type === 'number' && inputRef.current?.validity.badInput) {
+                return;
+              }
+              onChange(value, locale);
+            }}
           />
         )}
       />

--- a/front/app/translations/en.json
+++ b/front/app/translations/en.json
@@ -182,6 +182,7 @@
   "app.components.CustomFieldsForm.fileSizeLimit": "The file size limit is {maxFileSize} MB.",
   "app.components.CustomFieldsForm.imageRequired": "The image is required",
   "app.components.CustomFieldsForm.minimumCoordinates2": "A minimum of {numPoints} map points is required.",
+  "app.components.CustomFieldsForm.mustBeNumber": "The field \"{fieldName}\" must be a number",
   "app.components.CustomFieldsForm.notPublic1": "*This answer will only be shared with project managers, and not to the public.",
   "app.components.CustomFieldsForm.otherArea": "Somewhere else",
   "app.components.CustomFieldsForm.progressBarLabel": "Progress",


### PR DESCRIPTION
# DO NOT MERGE! Needs translations if approved.

Used Claude Code assistance heavily. Sorry for verbose description, but thought it wise, given my reliance on Claude choosing a 'good' solution.

## Summary
Fixes the misleading validation error shown by survey number questions when the user types a non-numeric character (e.g. 'e').

### Before:
- Required field + invalid char → "The field 'X' is required" (misleading; the user did type something).
- Optional field + invalid char → form submits silently with no value stored.

### After:
- Both cases show: "The field 'X' must be a number". Submission is blocked until the input is cleared or a valid number is entered.

## Why the obvious fix isn't enough

`<input type="number">` is the trap here. When the user types an invalid char like 'e' in an empty field:
- The browser shows 'e' in the field but reports `input.value === ""` and `validity.badInput === true`.
- React's `controlled-component` value tracker compares old `""` to new `""`, sees no change, and suppresses the synthetic `onChange`. So nothing reaches React Hook Form, and Yup just sees an empty value.
- Writing anything back to RHF state (e.g. `NaN`) would force React to resync `input.value` and wipe the visible 'e' the user typed.

So we can't fix this purely in the schema, and we can't fix it purely by reflecting `badInput` into RHF state.

## What changed
- `components/HookForm/Input/index.tsx` — capture a ref to the underlying `<input>`. When `type="number"` and `validity.badInput is true`, the wrapper's `onChange` returns early instead of writing to RHF. Belt-and-braces: relevant for any future browser/case where React does fire `onChange` on a `badInput` transition; without it, the resync would clobber the visible text.
- `components/CustomFieldsForm/Page/usePageForm.ts` — the form's resolver now wraps `yupResolver`. After Yup runs, it sweeps `pageQuestions` for every `input_type === 'number'`, looks up `input[name="..."]` in the DOM, and if `validity.badInput` is `true`, overrides that field's error with `mustBeNumber`. This is what actually surfaces the error in the empty → invalid case Yup can't see.
- `components/CustomFieldsForm/generateYupSchema.ts` — adds `.typeError(mustBeNumber)` to all three number branches (generic, `birthyear`, `proposed_budget`). Defense-in-depth: catches `NaN` if it ever reaches RHF state programmatically.
- `components/CustomFieldsForm/messages.ts` + `translations/en.json` — new `mustBeNumber` message: 'The field "{fieldName}" must be a number'.
- `components/CustomFieldsForm/generateYupSchema.test.ts` — adds 5 cases covering `empty/valid/NaN × required/optional`, plus `birthyear` and `proposed_budget`.

Covers all custom number questions (generic, birthyear, proposed_budget). The admin-only `BudgetField` (name="budget", ideation page) uses the same `Input` wrapper, so it benefits from the visible-text preservation, but it isn't a `pageQuestion`, so the resolver's DOM sweep doesn't override its error — out of scope here. If this type of fix is acceptable, I can create a new ticket for the admin-only `BudgetField`.

## Test plan
In the in-platform survey form (any page with a number question):
 - Required number field, type 'e', click submit → error reads "must be a number" (not "is required"). The 'e' stays visible in the field.
 - Optional number field, type 'e', click submit → same error; submission blocked.
 - Type 'e', then backspace to clear it → error clears. Submit: required field shows "is required"; optional field submits as empty.
 - Type a valid number 5 → no error, submits with 5.
 - `birthyear` field (registration / user profile): same behavior.
 - `proposed_budget` field (idea form, where enabled): same behavior.

All functional tests listed above seem to pass.

Note: browser behavior with `<input type="number">` and non-numeric chars varies (Chrome/Firefox/Safari each handle 'e' and decimal separators slightly differently). The fix is browser-agnostic because the resolver reads `validity.badInput` directly from the DOM, which is the canonical signal across browsers.

<img width="716" height="509" alt="Screenshot 2026-05-13 at 16 04 19" src="https://github.com/user-attachments/assets/df54e42b-2a29-4491-974a-298c47292bb0" />
<img width="586" height="181" alt="Screenshot 2026-05-13 at 16 35 59" src="https://github.com/user-attachments/assets/bc26270e-64a2-498e-aef9-2fe2d66890fe" />
<img width="680" height="181" alt="Screenshot 2026-05-13 at 16 37 27" src="https://github.com/user-attachments/assets/d45a068f-3738-4b7d-b128-e03cd188b045" />


# Changelog
## Fixed
- [TAN-7779] Improve error message for survey number answer that is not a number

# For translators
Do not translate '_fieldName_'. It should appear on Polyglit as `« {fieldName} »`, as for example is seen in the translation of the existing `app.components.CustomFieldsForm.fieldRequired` copy.
