### PR TITLE
TAN-7784: Make filter-tab focus ring visible across browsers

### DIFF
--- a/front/app/components/UI/FilterTabs/index.tsx
+++ b/front/app/components/UI/FilterTabs/index.tsx
@@ -39,6 +39,12 @@ const Tab = styled.button<{ active: boolean; fullWidth: boolean }>`
       cursor: pointer;
     `}
 
+  &.focus-visible,
+  &:focus-visible {
+    outline: 2px solid ${({ theme }) => theme.colors.tenantPrimary};
+    outline-offset: -2px;
+  }
+
   ${media.phone`
     font-size: ${fontSizes.base}px;
     padding: 14px 9px 14px;


### PR DESCRIPTION
# Changelog

## Fixed
- The focus indicator around the project-list filter tabs (Published, Archived, Draft, All) on the homepage is now clearly visible when navigating with the keyboard. Previously the ring was not visible in Safari and Firefox, making it hard for keyboard users to tell which tab they were on. Resolves an issue flagged by the Frameless accessibility audit.